### PR TITLE
feat(codex): 支持 Codex 供应商管理与一键切换；迁移前自动备份

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ For users upgrading from v2.x (Electron version):
 - The app will automatically migrate your existing provider configurations
 - Window position and size preferences have been reset to defaults
 
+#### Backup on v1→v2 Migration (cc-switch internal config)
+- When the app detects an old v1 config structure at `~/.cc-switch/config.json`, it now creates a timestamped backup before writing the new v2 structure.
+- Backup location: `~/.cc-switch/config.v1.backup.<timestamp>.json`
+- This only concerns cc-switch's own metadata file; your actual provider files under `~/.claude/` and `~/.codex/` are untouched.
+
 ### 🛠️ Development
 - Added `pnpm typecheck` command for TypeScript validation
 - Added `pnpm format` and `pnpm format:check` for code formatting

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)](https://github.com/jasonyoung/cc-switch/releases)
 [![Built with Tauri](https://img.shields.io/badge/built%20with-Tauri%202.0-orange.svg)](https://tauri.app/)
 
-一个用于管理和切换 Claude Code 不同供应商配置的桌面应用。
+一个用于管理和切换 Claude Code 与 Codex 不同供应商配置的桌面应用。
 
 > **v3.0.0 重大更新**：从 Electron 完全迁移到 Tauri 2.0，应用体积减少 85%（从 ~80MB 降至 ~12MB），启动速度提升 10 倍！
 
@@ -55,9 +55,18 @@
 
 1. 点击"添加供应商"添加你的 API 配置
 2. 选择要使用的供应商，点击单选按钮切换
-3. 配置会自动保存到 Claude Code 的配置文件中
+3. 配置会自动保存到对应应用的配置文件中
 4. 重启或者新打开终端以生效
 5. 如果需要切回 Claude 官方登录，可以添加预设供应商里的“Claude 官方登录”并切换，重启终端后即可进行正常的 /login 登录
+
+### Codex 说明
+
+- 配置目录：`~/.codex/`
+  - 主配置文件：`auth.json`（必需）、`config.toml`（可为空）
+  - 供应商副本：`auth-<name>.json`、`config-<name>.toml`
+- API Key 字段：`auth.json` 中使用 `OPENAI_API_KEY`
+- 切换策略：将选中供应商的副本覆盖到主配置（`auth.json`、`config.toml`）。若供应商没有 `config-*.toml`，会创建空的 `config.toml`。
+- 导入默认：若 `~/.codex/auth.json` 存在，会将当前主配置导入为 `default` 供应商；`config.toml` 不存在时按空处理。
 
 ## 开发
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -562,6 +562,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "toml 0.8.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri = { version = "2.8.2", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2"
 dirs = "5.0"
+toml = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -1,0 +1,113 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::config::{get_app_config_path, write_json_file};
+use crate::provider::ProviderManager;
+
+/// 应用类型
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AppType {
+    Claude,
+    Codex,
+}
+
+impl AppType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            AppType::Claude => "claude",
+            AppType::Codex => "codex",
+        }
+    }
+}
+
+impl From<&str> for AppType {
+    fn from(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "codex" => AppType::Codex,
+            _ => AppType::Claude, // 默认为 Claude
+        }
+    }
+}
+
+/// 多应用配置结构（向后兼容）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultiAppConfig {
+    #[serde(default = "default_version")]
+    pub version: u32,
+    #[serde(flatten)]
+    pub apps: HashMap<String, ProviderManager>,
+}
+
+fn default_version() -> u32 {
+    2
+}
+
+impl Default for MultiAppConfig {
+    fn default() -> Self {
+        let mut apps = HashMap::new();
+        apps.insert("claude".to_string(), ProviderManager::default());
+        apps.insert("codex".to_string(), ProviderManager::default());
+
+        Self { version: 2, apps }
+    }
+}
+
+impl MultiAppConfig {
+    /// 从文件加载配置（处理v1到v2的迁移）
+    pub fn load() -> Result<Self, String> {
+        let config_path = get_app_config_path();
+
+        if !config_path.exists() {
+            log::info!("配置文件不存在，创建新的多应用配置");
+            return Ok(Self::default());
+        }
+
+        // 尝试读取文件
+        let content = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("读取配置文件失败: {}", e))?;
+
+        // 检查是否是旧版本格式（v1）
+        if let Ok(v1_config) = serde_json::from_str::<ProviderManager>(&content) {
+            log::info!("检测到v1配置，自动迁移到v2");
+
+            // 迁移到新格式
+            let mut apps = HashMap::new();
+            apps.insert("claude".to_string(), v1_config);
+            apps.insert("codex".to_string(), ProviderManager::default());
+
+            let config = Self { version: 2, apps };
+
+            // 保存迁移后的配置
+            config.save()?;
+            return Ok(config);
+        }
+
+        // 尝试读取v2格式
+        serde_json::from_str::<Self>(&content).map_err(|e| format!("解析配置文件失败: {}", e))
+    }
+
+    /// 保存配置到文件
+    pub fn save(&self) -> Result<(), String> {
+        let config_path = get_app_config_path();
+        write_json_file(&config_path, self)
+    }
+
+    /// 获取指定应用的管理器
+    pub fn get_manager(&self, app: &AppType) -> Option<&ProviderManager> {
+        self.apps.get(app.as_str())
+    }
+
+    /// 获取指定应用的管理器（可变引用）
+    pub fn get_manager_mut(&mut self, app: &AppType) -> Option<&mut ProviderManager> {
+        self.apps.get_mut(app.as_str())
+    }
+
+    /// 确保应用存在
+    pub fn ensure_app(&mut self, app: &AppType) {
+        if !self.apps.contains_key(app.as_str()) {
+            self.apps
+                .insert(app.as_str().to_string(), ProviderManager::default());
+        }
+    }
+}

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1,0 +1,159 @@
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::config::{
+    copy_file, delete_file, read_json_file, sanitize_provider_name, write_json_file,
+};
+
+/// 获取 Codex 配置目录路径
+pub fn get_codex_config_dir() -> PathBuf {
+    dirs::home_dir().expect("无法获取用户主目录").join(".codex")
+}
+
+/// 获取 Codex auth.json 路径
+pub fn get_codex_auth_path() -> PathBuf {
+    get_codex_config_dir().join("auth.json")
+}
+
+/// 获取 Codex config.toml 路径
+pub fn get_codex_config_path() -> PathBuf {
+    get_codex_config_dir().join("config.toml")
+}
+
+/// 获取 Codex 供应商配置文件路径
+pub fn get_codex_provider_paths(
+    provider_id: &str,
+    provider_name: Option<&str>,
+) -> (PathBuf, PathBuf) {
+    let base_name = provider_name
+        .map(|name| sanitize_provider_name(name))
+        .unwrap_or_else(|| sanitize_provider_name(provider_id));
+
+    let auth_path = get_codex_config_dir().join(format!("auth-{}.json", base_name));
+    let config_path = get_codex_config_dir().join(format!("config-{}.toml", base_name));
+
+    (auth_path, config_path)
+}
+
+/// 备份 Codex 当前配置
+pub fn backup_codex_config(provider_id: &str, provider_name: &str) -> Result<(), String> {
+    let auth_path = get_codex_auth_path();
+    let config_path = get_codex_config_path();
+    let (backup_auth_path, backup_config_path) =
+        get_codex_provider_paths(provider_id, Some(provider_name));
+
+    // 备份 auth.json
+    if auth_path.exists() {
+        copy_file(&auth_path, &backup_auth_path)?;
+        log::info!("已备份 Codex auth.json: {}", backup_auth_path.display());
+    }
+
+    // 备份 config.toml
+    if config_path.exists() {
+        copy_file(&config_path, &backup_config_path)?;
+        log::info!("已备份 Codex config.toml: {}", backup_config_path.display());
+    }
+
+    Ok(())
+}
+
+/// 保存 Codex 供应商配置副本
+pub fn save_codex_provider_config(
+    provider_id: &str,
+    provider_name: &str,
+    settings_config: &Value,
+) -> Result<(), String> {
+    let (auth_path, config_path) = get_codex_provider_paths(provider_id, Some(provider_name));
+
+    // 保存 auth.json
+    if let Some(auth) = settings_config.get("auth") {
+        write_json_file(&auth_path, auth)?;
+    }
+
+    // 保存 config.toml
+    if let Some(config) = settings_config.get("config") {
+        if let Some(config_str) = config.as_str() {
+            fs::write(&config_path, config_str)
+                .map_err(|e| format!("写入供应商 config.toml 失败: {}", e))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// 删除 Codex 供应商配置文件
+pub fn delete_codex_provider_config(provider_id: &str, provider_name: &str) -> Result<(), String> {
+    let (auth_path, config_path) = get_codex_provider_paths(provider_id, Some(provider_name));
+
+    delete_file(&auth_path).ok();
+    delete_file(&config_path).ok();
+
+    Ok(())
+}
+
+/// 从 Codex 供应商配置副本恢复到主配置
+pub fn restore_codex_provider_config(provider_id: &str, provider_name: &str) -> Result<(), String> {
+    let (provider_auth_path, provider_config_path) =
+        get_codex_provider_paths(provider_id, Some(provider_name));
+    let auth_path = get_codex_auth_path();
+    let config_path = get_codex_config_path();
+
+    // 确保目录存在
+    if let Some(parent) = auth_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("创建 Codex 目录失败: {}", e))?;
+    }
+
+    // 复制 auth.json
+    if provider_auth_path.exists() {
+        copy_file(&provider_auth_path, &auth_path)?;
+        log::info!("已恢复 Codex auth.json");
+    } else {
+        return Err(format!(
+            "供应商 auth.json 不存在: {}",
+            provider_auth_path.display()
+        ));
+    }
+
+    // 复制 config.toml
+    if provider_config_path.exists() {
+        copy_file(&provider_config_path, &config_path)?;
+        log::info!("已恢复 Codex config.toml");
+    } else {
+        return Err(format!(
+            "供应商 config.toml 不存在: {}",
+            provider_config_path.display()
+        ));
+    }
+
+    Ok(())
+}
+
+/// 导入当前 Codex 配置为默认供应商
+pub fn import_current_codex_config() -> Result<Value, String> {
+    let auth_path = get_codex_auth_path();
+    let config_path = get_codex_config_path();
+
+    // 参考 Claude Code 行为：主配置缺失时不导入
+    if !auth_path.exists() || !config_path.exists() {
+        return Err("Codex 配置文件不存在".to_string());
+    }
+
+    // 读取 auth.json
+    let auth = read_json_file::<Value>(&auth_path)?;
+
+    // 读取 config.toml
+    let config_str = fs::read_to_string(&config_path)
+        .map_err(|e| format!("读取 config.toml 失败: {}", e))?;
+
+    // 组合成完整配置
+    let settings_config = serde_json::json!({
+        "auth": auth,
+        "config": config_str
+    });
+
+    // 保存为默认供应商副本
+    save_codex_provider_config("default", "default", &settings_config)?;
+
+    Ok(settings_config)
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -455,13 +455,13 @@ pub async fn get_claude_code_config_path() -> Result<String, String> {
 /// 兼容两种参数：`app_type`（推荐）或 `app`（字符串）
 #[tauri::command]
 pub async fn open_config_folder(
-    app: tauri::AppHandle,
+    handle: tauri::AppHandle,
     app_type: Option<AppType>,
-    app_str: Option<String>,
+    app: Option<String>,
     appType: Option<String>,
 ) -> Result<bool, String> {
     let app_type = app_type
-        .or_else(|| app_str.as_deref().map(|s| s.into()))
+        .or_else(|| app.as_deref().map(|s| s.into()))
         .or_else(|| appType.as_deref().map(|s| s.into()))
         .unwrap_or(AppType::Claude);
     
@@ -476,7 +476,7 @@ pub async fn open_config_folder(
     }
 
     // 使用 opener 插件打开文件夹
-    app.opener()
+    handle.opener()
         .open_path(config_dir.to_string_lossy().to_string(), None::<String>)
         .map_err(|e| format!("打开文件夹失败: {}", e))?;
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,9 +12,14 @@ use crate::store::AppState;
 #[tauri::command]
 pub async fn get_providers(
     state: State<'_, AppState>,
+    app_type: Option<AppType>,
     app: Option<String>,
+    appType: Option<String>,
 ) -> Result<HashMap<String, Provider>, String> {
-    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+    let app_type = app_type
+        .or_else(|| app.as_deref().map(|s| s.into()))
+        .or_else(|| appType.as_deref().map(|s| s.into()))
+        .unwrap_or(AppType::Claude);
 
     let config = state
         .config
@@ -32,9 +37,14 @@ pub async fn get_providers(
 #[tauri::command]
 pub async fn get_current_provider(
     state: State<'_, AppState>,
+    app_type: Option<AppType>,
     app: Option<String>,
+    appType: Option<String>,
 ) -> Result<String, String> {
-    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+    let app_type = app_type
+        .or_else(|| app.as_deref().map(|s| s.into()))
+        .or_else(|| appType.as_deref().map(|s| s.into()))
+        .unwrap_or(AppType::Claude);
 
     let config = state
         .config
@@ -52,10 +62,15 @@ pub async fn get_current_provider(
 #[tauri::command]
 pub async fn add_provider(
     state: State<'_, AppState>,
+    app_type: Option<AppType>,
     app: Option<String>,
+    appType: Option<String>,
     provider: Provider,
 ) -> Result<bool, String> {
-    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+    let app_type = app_type
+        .or_else(|| app.as_deref().map(|s| s.into()))
+        .or_else(|| appType.as_deref().map(|s| s.into()))
+        .unwrap_or(AppType::Claude);
 
     let mut config = state
         .config
@@ -97,10 +112,15 @@ pub async fn add_provider(
 #[tauri::command]
 pub async fn update_provider(
     state: State<'_, AppState>,
+    app_type: Option<AppType>,
     app: Option<String>,
+    appType: Option<String>,
     provider: Provider,
 ) -> Result<bool, String> {
-    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+    let app_type = app_type
+        .or_else(|| app.as_deref().map(|s| s.into()))
+        .or_else(|| appType.as_deref().map(|s| s.into()))
+        .unwrap_or(AppType::Claude);
 
     let mut config = state
         .config
@@ -164,10 +184,15 @@ pub async fn update_provider(
 #[tauri::command]
 pub async fn delete_provider(
     state: State<'_, AppState>,
+    app_type: Option<AppType>,
     app: Option<String>,
+    appType: Option<String>,
     id: String,
 ) -> Result<bool, String> {
-    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+    let app_type = app_type
+        .or_else(|| app.as_deref().map(|s| s.into()))
+        .or_else(|| appType.as_deref().map(|s| s.into()))
+        .unwrap_or(AppType::Claude);
 
     let mut config = state
         .config
@@ -216,10 +241,15 @@ pub async fn delete_provider(
 #[tauri::command]
 pub async fn switch_provider(
     state: State<'_, AppState>,
+    app_type: Option<AppType>,
     app: Option<String>,
+    appType: Option<String>,
     id: String,
 ) -> Result<bool, String> {
-    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+    let app_type = app_type
+        .or_else(|| app.as_deref().map(|s| s.into()))
+        .or_else(|| appType.as_deref().map(|s| s.into()))
+        .unwrap_or(AppType::Claude);
 
     let mut config = state
         .config
@@ -304,9 +334,14 @@ pub async fn switch_provider(
 #[tauri::command]
 pub async fn import_default_config(
     state: State<'_, AppState>,
+    app_type: Option<AppType>,
     app: Option<String>,
+    appType: Option<String>,
 ) -> Result<bool, String> {
-    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+    let app_type = app_type
+        .or_else(|| app.as_deref().map(|s| s.into()))
+        .or_else(|| appType.as_deref().map(|s| s.into()))
+        .unwrap_or(AppType::Claude);
 
     // 若已存在 default 供应商，则直接返回，避免重复导入
     {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use tauri::State;
 use tauri_plugin_opener::OpenerExt;
 
+use crate::app_config::AppType;
+use crate::codex_config;
 use crate::config::{ConfigStatus, get_claude_settings_path, import_current_config_as_default};
 use crate::provider::Provider;
 use crate::store::AppState;
@@ -10,38 +12,82 @@ use crate::store::AppState;
 #[tauri::command]
 pub async fn get_providers(
     state: State<'_, AppState>,
+    app: Option<String>,
 ) -> Result<HashMap<String, Provider>, String> {
-    let manager = state
-        .provider_manager
+    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+
+    let config = state
+        .config
         .lock()
         .map_err(|e| format!("获取锁失败: {}", e))?;
+
+    let manager = config
+        .get_manager(&app_type)
+        .ok_or_else(|| format!("应用类型不存在: {:?}", app_type))?;
 
     Ok(manager.get_all_providers().clone())
 }
 
 /// 获取当前供应商ID
 #[tauri::command]
-pub async fn get_current_provider(state: State<'_, AppState>) -> Result<String, String> {
-    let manager = state
-        .provider_manager
+pub async fn get_current_provider(
+    state: State<'_, AppState>,
+    app: Option<String>,
+) -> Result<String, String> {
+    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+
+    let config = state
+        .config
         .lock()
         .map_err(|e| format!("获取锁失败: {}", e))?;
+
+    let manager = config
+        .get_manager(&app_type)
+        .ok_or_else(|| format!("应用类型不存在: {:?}", app_type))?;
 
     Ok(manager.current.clone())
 }
 
 /// 添加供应商
 #[tauri::command]
-pub async fn add_provider(state: State<'_, AppState>, provider: Provider) -> Result<bool, String> {
-    let mut manager = state
-        .provider_manager
+pub async fn add_provider(
+    state: State<'_, AppState>,
+    app: Option<String>,
+    provider: Provider,
+) -> Result<bool, String> {
+    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+
+    let mut config = state
+        .config
         .lock()
         .map_err(|e| format!("获取锁失败: {}", e))?;
 
-    manager.add_provider(provider)?;
+    let manager = config
+        .get_manager_mut(&app_type)
+        .ok_or_else(|| format!("应用类型不存在: {:?}", app_type))?;
+
+    // 根据应用类型保存配置文件
+    match app_type {
+        AppType::Codex => {
+            // Codex: 保存两个文件
+            codex_config::save_codex_provider_config(
+                &provider.id,
+                &provider.name,
+                &provider.settings_config,
+            )?;
+        }
+        AppType::Claude => {
+            // Claude: 使用原有逻辑
+            use crate::config::{get_provider_config_path, write_json_file};
+            let config_path = get_provider_config_path(&provider.id, Some(&provider.name));
+            write_json_file(&config_path, &provider.settings_config)?;
+        }
+    }
+
+    manager.providers.insert(provider.id.clone(), provider);
 
     // 保存配置
-    drop(manager); // 释放锁
+    drop(config); // 释放锁
     state.save()?;
 
     Ok(true)
@@ -51,17 +97,64 @@ pub async fn add_provider(state: State<'_, AppState>, provider: Provider) -> Res
 #[tauri::command]
 pub async fn update_provider(
     state: State<'_, AppState>,
+    app: Option<String>,
     provider: Provider,
 ) -> Result<bool, String> {
-    let mut manager = state
-        .provider_manager
+    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+
+    let mut config = state
+        .config
         .lock()
         .map_err(|e| format!("获取锁失败: {}", e))?;
 
-    manager.update_provider(provider)?;
+    let manager = config
+        .get_manager_mut(&app_type)
+        .ok_or_else(|| format!("应用类型不存在: {:?}", app_type))?;
+
+    // 检查供应商是否存在
+    if !manager.providers.contains_key(&provider.id) {
+        return Err(format!("供应商不存在: {}", provider.id));
+    }
+
+    // 如果名称改变了，需要处理配置文件
+    if let Some(old_provider) = manager.providers.get(&provider.id) {
+        if old_provider.name != provider.name {
+            // 删除旧配置文件
+            match app_type {
+                AppType::Codex => {
+                    codex_config::delete_codex_provider_config(&provider.id, &old_provider.name)
+                        .ok();
+                }
+                AppType::Claude => {
+                    use crate::config::{delete_file, get_provider_config_path};
+                    let old_config_path =
+                        get_provider_config_path(&provider.id, Some(&old_provider.name));
+                    delete_file(&old_config_path).ok();
+                }
+            }
+        }
+    }
+
+    // 保存新配置文件
+    match app_type {
+        AppType::Codex => {
+            codex_config::save_codex_provider_config(
+                &provider.id,
+                &provider.name,
+                &provider.settings_config,
+            )?;
+        }
+        AppType::Claude => {
+            use crate::config::{get_provider_config_path, write_json_file};
+            let config_path = get_provider_config_path(&provider.id, Some(&provider.name));
+            write_json_file(&config_path, &provider.settings_config)?;
+        }
+    }
+
+    manager.providers.insert(provider.id.clone(), provider);
 
     // 保存配置
-    drop(manager); // 释放锁
+    drop(config); // 释放锁
     state.save()?;
 
     Ok(true)
@@ -69,16 +162,51 @@ pub async fn update_provider(
 
 /// 删除供应商
 #[tauri::command]
-pub async fn delete_provider(state: State<'_, AppState>, id: String) -> Result<bool, String> {
-    let mut manager = state
-        .provider_manager
+pub async fn delete_provider(
+    state: State<'_, AppState>,
+    app: Option<String>,
+    id: String,
+) -> Result<bool, String> {
+    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+
+    let mut config = state
+        .config
         .lock()
         .map_err(|e| format!("获取锁失败: {}", e))?;
 
-    manager.delete_provider(&id)?;
+    let manager = config
+        .get_manager_mut(&app_type)
+        .ok_or_else(|| format!("应用类型不存在: {:?}", app_type))?;
+
+    // 检查是否为当前供应商
+    if manager.current == id {
+        return Err("不能删除当前正在使用的供应商".to_string());
+    }
+
+    // 获取供应商信息
+    let provider = manager
+        .providers
+        .get(&id)
+        .ok_or_else(|| format!("供应商不存在: {}", id))?
+        .clone();
+
+    // 删除配置文件
+    match app_type {
+        AppType::Codex => {
+            codex_config::delete_codex_provider_config(&id, &provider.name)?;
+        }
+        AppType::Claude => {
+            use crate::config::{delete_file, get_provider_config_path};
+            let config_path = get_provider_config_path(&id, Some(&provider.name));
+            delete_file(&config_path)?;
+        }
+    }
+
+    // 从管理器删除
+    manager.providers.remove(&id);
 
     // 保存配置
-    drop(manager); // 释放锁
+    drop(config); // 释放锁
     state.save()?;
 
     Ok(true)
@@ -86,16 +214,87 @@ pub async fn delete_provider(state: State<'_, AppState>, id: String) -> Result<b
 
 /// 切换供应商
 #[tauri::command]
-pub async fn switch_provider(state: State<'_, AppState>, id: String) -> Result<bool, String> {
-    let mut manager = state
-        .provider_manager
+pub async fn switch_provider(
+    state: State<'_, AppState>,
+    app: Option<String>,
+    id: String,
+) -> Result<bool, String> {
+    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+
+    let mut config = state
+        .config
         .lock()
         .map_err(|e| format!("获取锁失败: {}", e))?;
 
-    manager.switch_provider(&id)?;
+    let manager = config
+        .get_manager_mut(&app_type)
+        .ok_or_else(|| format!("应用类型不存在: {:?}", app_type))?;
+
+    // 检查供应商是否存在
+    let provider = manager
+        .providers
+        .get(&id)
+        .ok_or_else(|| format!("供应商不存在: {}", id))?
+        .clone();
+
+    // 根据应用类型执行切换
+    match app_type {
+        AppType::Codex => {
+            // 备份当前配置（如果存在）
+            if !manager.current.is_empty() {
+                if let Some(current_provider) = manager.providers.get(&manager.current) {
+                    codex_config::backup_codex_config(&manager.current, &current_provider.name)?;
+                    log::info!("已备份当前 Codex 供应商配置: {}", current_provider.name);
+                }
+            }
+
+            // 恢复目标供应商配置
+            codex_config::restore_codex_provider_config(&id, &provider.name)?;
+        }
+        AppType::Claude => {
+            // 使用原有的 Claude 切换逻辑
+            use crate::config::{
+                backup_config, copy_file, get_claude_settings_path, get_provider_config_path,
+            };
+
+            let settings_path = get_claude_settings_path();
+            let provider_config_path = get_provider_config_path(&id, Some(&provider.name));
+
+            // 检查供应商配置文件是否存在
+            if !provider_config_path.exists() {
+                return Err(format!(
+                    "供应商配置文件不存在: {}",
+                    provider_config_path.display()
+                ));
+            }
+
+            // 如果当前有配置，先备份到当前供应商
+            if settings_path.exists() && !manager.current.is_empty() {
+                if let Some(current_provider) = manager.providers.get(&manager.current) {
+                    let current_provider_path =
+                        get_provider_config_path(&manager.current, Some(&current_provider.name));
+                    backup_config(&settings_path, &current_provider_path)?;
+                    log::info!("已备份当前供应商配置: {}", current_provider.name);
+                }
+            }
+
+            // 确保主配置父目录存在
+            if let Some(parent) = settings_path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| format!("创建目录失败: {}", e))?;
+            }
+
+            // 复制新供应商配置到主配置
+            copy_file(&provider_config_path, &settings_path)?;
+        }
+    }
+
+    // 更新当前供应商
+    manager.current = id;
+
+    log::info!("成功切换到供应商: {}", provider.name);
 
     // 保存配置
-    drop(manager); // 释放锁
+    drop(config); // 释放锁
     state.save()?;
 
     Ok(true)
@@ -103,20 +302,31 @@ pub async fn switch_provider(state: State<'_, AppState>, id: String) -> Result<b
 
 /// 导入当前配置为默认供应商
 #[tauri::command]
-pub async fn import_default_config(state: State<'_, AppState>) -> Result<bool, String> {
+pub async fn import_default_config(
+    state: State<'_, AppState>,
+    app: Option<String>,
+) -> Result<bool, String> {
+    let app_type = app.as_deref().map(|s| s.into()).unwrap_or(AppType::Claude);
+
     // 若已存在 default 供应商，则直接返回，避免重复导入
     {
-        let manager = state
-            .provider_manager
+        let config = state
+            .config
             .lock()
             .map_err(|e| format!("获取锁失败: {}", e))?;
-        if manager.get_all_providers().contains_key("default") {
-            return Ok(true);
+
+        if let Some(manager) = config.get_manager(&app_type) {
+            if manager.get_all_providers().contains_key("default") {
+                return Ok(true);
+            }
         }
     }
 
-    // 导入配置
-    let settings_config = import_current_config_as_default()?;
+    // 根据应用类型导入配置
+    let settings_config = match app_type {
+        AppType::Codex => codex_config::import_current_codex_config()?,
+        AppType::Claude => import_current_config_as_default()?,
+    };
 
     // 创建默认供应商
     let provider = Provider::with_id(
@@ -127,12 +337,32 @@ pub async fn import_default_config(state: State<'_, AppState>) -> Result<bool, S
     );
 
     // 添加到管理器
-    let mut manager = state
-        .provider_manager
+    let mut config = state
+        .config
         .lock()
         .map_err(|e| format!("获取锁失败: {}", e))?;
 
-    manager.add_provider(provider)?;
+    let manager = config
+        .get_manager_mut(&app_type)
+        .ok_or_else(|| format!("应用类型不存在: {:?}", app_type))?;
+
+    // 根据应用类型保存配置文件
+    match app_type {
+        AppType::Codex => {
+            codex_config::save_codex_provider_config(
+                &provider.id,
+                &provider.name,
+                &provider.settings_config,
+            )?;
+        }
+        AppType::Claude => {
+            use crate::config::{get_provider_config_path, write_json_file};
+            let config_path = get_provider_config_path(&provider.id, Some(&provider.name));
+            write_json_file(&config_path, &provider.settings_config)?;
+        }
+    }
+
+    manager.providers.insert(provider.id.clone(), provider);
 
     // 如果没有当前供应商，设置为 default
     if manager.current.is_empty() {
@@ -140,7 +370,7 @@ pub async fn import_default_config(state: State<'_, AppState>) -> Result<bool, S
     }
 
     // 保存配置
-    drop(manager); // 释放锁
+    drop(config); // 释放锁
     state.save()?;
 
     Ok(true)
@@ -152,6 +382,27 @@ pub async fn get_claude_config_status() -> Result<ConfigStatus, String> {
     Ok(crate::config::get_claude_config_status())
 }
 
+/// 获取应用配置状态（通用）
+#[tauri::command]
+pub async fn get_config_status(app_type: Option<AppType>) -> Result<ConfigStatus, String> {
+    let app = app_type.unwrap_or(AppType::Claude);
+    
+    match app {
+        AppType::Claude => Ok(crate::config::get_claude_config_status()),
+        AppType::Codex => {
+            use crate::codex_config::{get_codex_auth_path, get_codex_config_path};
+            let auth_path = get_codex_auth_path();
+            let config_path = get_codex_config_path();
+            
+            // Codex 需要两个文件都存在才算配置存在
+            let exists = auth_path.exists() && config_path.exists();
+            let path = format!("~/.codex/");
+            
+            Ok(ConfigStatus { exists, path })
+        }
+    }
+}
+
 /// 获取 Claude Code 配置文件路径
 #[tauri::command]
 pub async fn get_claude_code_config_path() -> Result<String, String> {
@@ -160,8 +411,13 @@ pub async fn get_claude_code_config_path() -> Result<String, String> {
 
 /// 打开配置文件夹
 #[tauri::command]
-pub async fn open_config_folder(app: tauri::AppHandle) -> Result<bool, String> {
-    let config_dir = crate::config::get_claude_config_dir();
+pub async fn open_config_folder(app: tauri::AppHandle, app_type: Option<AppType>) -> Result<bool, String> {
+    let app_type = app_type.unwrap_or(AppType::Claude);
+    
+    let config_dir = match app_type {
+        AppType::Claude => crate::config::get_claude_config_dir(),
+        AppType::Codex => crate::codex_config::get_codex_config_dir(),
+    };
 
     // 确保目录存在
     if !config_dir.exists() {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use std::collections::HashMap;
 use tauri::State;
 use tauri_plugin_opener::OpenerExt;

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -1,12 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::path::Path;
 
-use crate::config::{
-    backup_config, copy_file, delete_file, get_claude_settings_path, get_provider_config_path,
-    read_json_file, write_json_file,
-};
+use crate::config::{get_provider_config_path, write_json_file};
 
 /// 供应商结构体
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -54,21 +50,6 @@ impl Default for ProviderManager {
 }
 
 impl ProviderManager {
-    /// 加载供应商列表
-    pub fn load_from_file(path: &Path) -> Result<Self, String> {
-        if !path.exists() {
-            log::info!("配置文件不存在，创建新的供应商管理器");
-            return Ok(Self::default());
-        }
-
-        read_json_file(path)
-    }
-
-    /// 保存供应商列表
-    pub fn save_to_file(&self, path: &Path) -> Result<(), String> {
-        write_json_file(path, self)
-    }
-
     /// 添加供应商
     pub fn add_provider(&mut self, provider: Provider) -> Result<(), String> {
         // 保存供应商配置到独立文件
@@ -77,98 +58,6 @@ impl ProviderManager {
 
         // 添加到管理器
         self.providers.insert(provider.id.clone(), provider);
-        Ok(())
-    }
-
-    /// 更新供应商
-    pub fn update_provider(&mut self, provider: Provider) -> Result<(), String> {
-        // 检查供应商是否存在
-        if !self.providers.contains_key(&provider.id) {
-            return Err(format!("供应商不存在: {}", provider.id));
-        }
-
-        // 如果名称改变了，需要处理配置文件
-        if let Some(old_provider) = self.providers.get(&provider.id) {
-            if old_provider.name != provider.name {
-                // 删除旧配置文件
-                let old_config_path =
-                    get_provider_config_path(&provider.id, Some(&old_provider.name));
-                delete_file(&old_config_path).ok(); // 忽略删除错误
-            }
-        }
-
-        // 保存新配置文件
-        let config_path = get_provider_config_path(&provider.id, Some(&provider.name));
-        write_json_file(&config_path, &provider.settings_config)?;
-
-        // 更新管理器
-        self.providers.insert(provider.id.clone(), provider);
-        Ok(())
-    }
-
-    /// 删除供应商
-    pub fn delete_provider(&mut self, provider_id: &str) -> Result<(), String> {
-        // 检查是否为当前供应商
-        if self.current == provider_id {
-            return Err("不能删除当前正在使用的供应商".to_string());
-        }
-
-        // 获取供应商信息
-        let provider = self
-            .providers
-            .get(provider_id)
-            .ok_or_else(|| format!("供应商不存在: {}", provider_id))?;
-
-        // 删除配置文件
-        let config_path = get_provider_config_path(provider_id, Some(&provider.name));
-        delete_file(&config_path)?;
-
-        // 从管理器删除
-        self.providers.remove(provider_id);
-        Ok(())
-    }
-
-    /// 切换供应商
-    pub fn switch_provider(&mut self, provider_id: &str) -> Result<(), String> {
-        // 检查供应商是否存在
-        let provider = self
-            .providers
-            .get(provider_id)
-            .ok_or_else(|| format!("供应商不存在: {}", provider_id))?;
-
-        let settings_path = get_claude_settings_path();
-        let provider_config_path = get_provider_config_path(provider_id, Some(&provider.name));
-
-        // 检查供应商配置文件是否存在
-        if !provider_config_path.exists() {
-            return Err(format!(
-                "供应商配置文件不存在: {}",
-                provider_config_path.display()
-            ));
-        }
-
-        // 如果当前有配置，先备份到当前供应商
-        if settings_path.exists() && !self.current.is_empty() {
-            if let Some(current_provider) = self.providers.get(&self.current) {
-                let current_provider_path =
-                    get_provider_config_path(&self.current, Some(&current_provider.name));
-                backup_config(&settings_path, &current_provider_path)?;
-                log::info!("已备份当前供应商配置: {}", current_provider.name);
-            }
-        }
-
-        // 确保主配置父目录存在
-        if let Some(parent) = settings_path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| format!("创建目录失败: {}", e))?;
-        }
-
-        // 复制新供应商配置到主配置
-        copy_file(&provider_config_path, &settings_path)?;
-
-        // 更新当前供应商
-        self.current = provider_id.to_string();
-
-        log::info!("成功切换到供应商: {}", provider.name);
         Ok(())
     }
 

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -1,36 +1,31 @@
-use crate::config::get_app_config_path;
-use crate::provider::ProviderManager;
+use crate::app_config::MultiAppConfig;
 use std::sync::Mutex;
 
 /// 全局应用状态
 pub struct AppState {
-    pub provider_manager: Mutex<ProviderManager>,
+    pub config: Mutex<MultiAppConfig>,
 }
 
 impl AppState {
     /// 创建新的应用状态
     pub fn new() -> Self {
-        let config_path = get_app_config_path();
-        let provider_manager = ProviderManager::load_from_file(&config_path).unwrap_or_else(|e| {
+        let config = MultiAppConfig::load().unwrap_or_else(|e| {
             log::warn!("加载配置失败: {}, 使用默认配置", e);
-            ProviderManager::default()
+            MultiAppConfig::default()
         });
 
         Self {
-            provider_manager: Mutex::new(provider_manager),
+            config: Mutex::new(config),
         }
     }
 
     /// 保存配置到文件
     pub fn save(&self) -> Result<(), String> {
-        let config_path = get_app_config_path();
-        let manager = self
-            .provider_manager
+        let config = self
+            .config
             .lock()
             .map_err(|e| format!("获取锁失败: {}", e))?;
 
-        manager.save_to_file(&config_path)
+        config.save()
     }
-
-    // 保留按需扩展：若未来需要热加载，可在此实现
 }

--- a/src/App.css
+++ b/src/App.css
@@ -5,67 +5,90 @@
 }
 
 .app-header {
-  background: #3498db;
+  background: linear-gradient(180deg, #3498db 0%, #2d89c7 100%);
   color: white;
-  padding: 0.75rem 2rem;
-  display: flex;
-  justify-content: space-between;
+  padding: 0.35rem 2rem 0.45rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  grid-template-areas:
+    "title actions"
+    "tabs actions";
   align-items: center;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  row-gap: 0.45rem; /* 间隔增大一点，标题与开关分离 */
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   user-select: none;
-  min-height: 3rem;
-  position: relative;
 }
 
 .app-tabs {
-  position: absolute;
-  left: 2rem;
-  top: 0;
-  display: flex;
-  height: 100%;
+  grid-area: tabs;
 }
 
-.app-tab {
-  background: transparent;
-  color: rgba(255, 255, 255, 0.7);
-  border: none;
-  padding: 0 1.5rem;
-  cursor: pointer;
-  font-size: 0.95rem;
-  font-weight: 500;
-  transition: all 0.2s;
+/* Segmented control */
+.segmented {
+  --seg-bg: rgba(255, 255, 255, 0.16);
+  --seg-thumb: #ffffff;
+  --seg-color: rgba(255, 255, 255, 0.85);
+  --seg-active: #2d89c7;
   position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  width: 280px;
+  background: var(--seg-bg);
+  border-radius: 999px;
+  padding: 4px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  backdrop-filter: saturate(140%) blur(2px);
 }
 
-.app-tab:hover {
-  color: white;
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.app-tab.active {
-  color: white;
-  background: rgba(255, 255, 255, 0.15);
-}
-
-.app-tab.active::after {
-  content: "";
+.segmented-thumb {
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: white;
+  top: 4px;
+  left: 4px;
+  width: calc(50% - 4px);
+  height: calc(100% - 8px);
+  background: var(--seg-thumb);
+  border-radius: 999px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  transition: transform 220ms ease, width 220ms ease;
+  will-change: transform;
+}
+
+.segmented-item {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  padding: 6px 16px; /* 更紧凑的高度 */
+  color: var(--seg-color);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  transition: color 200ms ease;
+}
+
+.segmented-item.active {
+  color: var(--seg-active);
+}
+
+.segmented-item:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
 }
 
 .app-header h1 {
   font-size: 1.5rem;
   font-weight: 500;
-  margin: 0 auto;
+  margin: 0;
+  grid-area: title;
 }
 
 .header-actions {
   display: flex;
   gap: 1rem;
+  grid-area: actions;
 }
 
 .refresh-btn,

--- a/src/App.css
+++ b/src/App.css
@@ -14,11 +14,53 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   user-select: none;
   min-height: 3rem;
+  position: relative;
+}
+
+.app-tabs {
+  position: absolute;
+  left: 2rem;
+  top: 0;
+  display: flex;
+  height: 100%;
+}
+
+.app-tab {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 0 1.5rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: all 0.2s;
+  position: relative;
+}
+
+.app-tab:hover {
+  color: white;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.app-tab.active {
+  color: white;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.app-tab.active::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: white;
 }
 
 .app-header h1 {
   font-size: 1.5rem;
   font-weight: 500;
+  margin: 0 auto;
 }
 
 .header-actions {

--- a/src/App.css
+++ b/src/App.css
@@ -50,7 +50,9 @@
   background: var(--seg-thumb);
   border-radius: 999px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
-  transition: transform 220ms ease, width 220ms ease;
+  transition:
+    transform 220ms ease,
+    width 220ms ease;
   will-change: transform;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -10,9 +10,12 @@
   padding: 0.35rem 2rem 0.45rem;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
+  grid-template-rows: auto auto;
   grid-template-areas:
-    "tabs title actions";
+    ". title ."
+    "tabs . actions";
   align-items: center;
+  row-gap: 0.6rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   user-select: none;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -9,13 +9,10 @@
   color: white;
   padding: 0.35rem 2rem 0.45rem;
   display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: auto auto;
+  grid-template-columns: 1fr auto 1fr;
   grid-template-areas:
-    "title actions"
-    "tabs actions";
+    "tabs title actions";
   align-items: center;
-  row-gap: 0.45rem; /* 间隔增大一点，标题与开关分离 */
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   user-select: none;
 }
@@ -85,12 +82,14 @@
   font-weight: 500;
   margin: 0;
   grid-area: title;
+  text-align: center;
 }
 
 .header-actions {
   display: flex;
   gap: 1rem;
   grid-area: actions;
+  justify-self: end;
 }
 
 .refresh-btn,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,16 +182,14 @@ function App() {
       <header className="app-header">
         <h1>{activeApp === "claude" ? "Claude Code" : "Codex"} 供应商切换器</h1>
         <div className="app-tabs">
-          <div
-            className="segmented"
-            role="tablist"
-            aria-label="选择应用"
-          >
+          <div className="segmented" role="tablist" aria-label="选择应用">
             <span
               className="segmented-thumb"
               style={{
                 transform:
-                  activeApp === "claude" ? "translateX(0%)" : "translateX(100%)",
+                  activeApp === "claude"
+                    ? "translateX(0%)"
+                    : "translateX(100%)",
               }}
             />
             <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,21 +180,44 @@ function App() {
   return (
     <div className="app">
       <header className="app-header">
-        <div className="app-tabs">
-          <button
-            className={`app-tab ${activeApp === "claude" ? "active" : ""}`}
-            onClick={() => setActiveApp("claude")}
-          >
-            Claude Code
-          </button>
-          <button
-            className={`app-tab ${activeApp === "codex" ? "active" : ""}`}
-            onClick={() => setActiveApp("codex")}
-          >
-            Codex
-          </button>
-        </div>
         <h1>{activeApp === "claude" ? "Claude Code" : "Codex"} 供应商切换器</h1>
+        <div className="app-tabs">
+          <div
+            className="segmented"
+            role="tablist"
+            aria-label="选择应用"
+          >
+            <span
+              className="segmented-thumb"
+              style={{
+                transform:
+                  activeApp === "claude" ? "translateX(0%)" : "translateX(100%)",
+              }}
+            />
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeApp === "claude"}
+              className={`segmented-item ${
+                activeApp === "claude" ? "active" : ""
+              }`}
+              onClick={() => setActiveApp("claude")}
+            >
+              Claude Code
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeApp === "codex"}
+              className={`segmented-item ${
+                activeApp === "codex" ? "active" : ""
+              }`}
+              onClick={() => setActiveApp("codex")}
+            >
+              Codex
+            </button>
+          </div>
+        </div>
         <div className="header-actions">
           <button className="add-btn" onClick={() => setIsAddModalOpen(true)}>
             添加供应商

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,7 +181,7 @@ function App() {
   return (
     <div className="app">
       <header className="app-header">
-        <h1>{activeApp === "claude" ? "Claude Code" : "Codex"} 供应商切换器</h1>
+        <h1>CC Switch</h1>
         <div className="app-tabs">
           <AppSwitcher
             activeApp={activeApp}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ProviderList from "./components/ProviderList";
 import AddProviderModal from "./components/AddProviderModal";
 import EditProviderModal from "./components/EditProviderModal";
 import { ConfirmDialog } from "./components/ConfirmDialog";
+import { AppSwitcher } from "./components/AppSwitcher";
 import "./App.css";
 
 function App() {
@@ -182,39 +183,10 @@ function App() {
       <header className="app-header">
         <h1>{activeApp === "claude" ? "Claude Code" : "Codex"} 供应商切换器</h1>
         <div className="app-tabs">
-          <div className="segmented" role="tablist" aria-label="选择应用">
-            <span
-              className="segmented-thumb"
-              style={{
-                transform:
-                  activeApp === "claude"
-                    ? "translateX(0%)"
-                    : "translateX(100%)",
-              }}
-            />
-            <button
-              type="button"
-              role="tab"
-              aria-selected={activeApp === "claude"}
-              className={`segmented-item ${
-                activeApp === "claude" ? "active" : ""
-              }`}
-              onClick={() => setActiveApp("claude")}
-            >
-              Claude Code
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={activeApp === "codex"}
-              className={`segmented-item ${
-                activeApp === "codex" ? "active" : ""
-              }`}
-              onClick={() => setActiveApp("codex")}
-            >
-              Codex
-            </button>
-          </div>
+          <AppSwitcher
+            activeApp={activeApp}
+            onSwitch={setActiveApp}
+          />
         </div>
         <div className="header-actions">
           <button className="add-btn" onClick={() => setIsAddModalOpen(true)}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -246,6 +246,7 @@ function App() {
             onSwitch={handleSwitchProvider}
             onDelete={handleDeleteProvider}
             onEdit={setEditingProviderId}
+            appType={activeApp}
           />
         </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -246,7 +246,6 @@ function App() {
             onSwitch={handleSwitchProvider}
             onDelete={handleDeleteProvider}
             onEdit={setEditingProviderId}
-            appType={activeApp}
           />
         </div>
 

--- a/src/components/AddProviderModal.tsx
+++ b/src/components/AddProviderModal.tsx
@@ -1,18 +1,22 @@
 import React from "react";
 import { Provider } from "../types";
+import { AppType } from "../lib/tauri-api";
 import ProviderForm from "./ProviderForm";
 
 interface AddProviderModalProps {
+  appType: AppType;
   onAdd: (provider: Omit<Provider, "id">) => void;
   onClose: () => void;
 }
 
 const AddProviderModal: React.FC<AddProviderModalProps> = ({
+  appType,
   onAdd,
   onClose,
 }) => {
   return (
     <ProviderForm
+      appType={appType}
       title="添加新供应商"
       submitText="添加"
       showPresets={true}

--- a/src/components/AppSwitcher.css
+++ b/src/components/AppSwitcher.css
@@ -1,0 +1,66 @@
+/* 药丸式切换按钮 */
+.switcher-pills {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 6px 8px;
+  border-radius: 50px;
+  backdrop-filter: blur(10px);
+}
+
+.switcher-pill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: transparent;
+  border: none;
+  border-radius: 50px;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 200ms ease;
+  min-width: 120px;
+}
+
+.switcher-pill:hover:not(.active) {
+  color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.switcher-pill.active {
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+  box-shadow: 
+    inset 0 1px 3px rgba(0, 0, 0, 0.1),
+    0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.pill-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.4;
+  transition: all 200ms ease;
+}
+
+.switcher-pill.active .pill-dot {
+  opacity: 1;
+  box-shadow: 0 0 8px currentColor;
+  animation: pulse 2s infinite;
+}
+
+.pills-divider {
+  width: 1px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.2); opacity: 0.8; }
+}

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -1,0 +1,36 @@
+import { AppType } from "../lib/tauri-api";
+import "./AppSwitcher.css";
+
+interface AppSwitcherProps {
+  activeApp: AppType;
+  onSwitch: (app: AppType) => void;
+}
+
+export function AppSwitcher({ activeApp, onSwitch }: AppSwitcherProps) {
+  const handleSwitch = (app: AppType) => {
+    if (app === activeApp) return;
+    onSwitch(app);
+  };
+
+  return (
+    <div className="switcher-pills">
+      <button
+        type="button"
+        className={`switcher-pill ${activeApp === "claude" ? "active" : ""}`}
+        onClick={() => handleSwitch("claude")}
+      >
+        <span className="pill-dot" />
+        <span>Claude Code</span>
+      </button>
+      <div className="pills-divider" />
+      <button
+        type="button"
+        className={`switcher-pill ${activeApp === "codex" ? "active" : ""}`}
+        onClick={() => handleSwitch("codex")}
+      >
+        <span className="pill-dot" />
+        <span>Codex</span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/EditProviderModal.tsx
+++ b/src/components/EditProviderModal.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import { Provider } from "../types";
+import { AppType } from "../lib/tauri-api";
 import ProviderForm from "./ProviderForm";
 
 interface EditProviderModalProps {
+  appType: AppType;
   provider: Provider;
   onSave: (provider: Provider) => void;
   onClose: () => void;
 }
 
 const EditProviderModal: React.FC<EditProviderModalProps> = ({
+  appType,
   provider,
   onSave,
   onClose,
@@ -22,6 +25,7 @@ const EditProviderModal: React.FC<EditProviderModalProps> = ({
 
   return (
     <ProviderForm
+      appType={appType}
       title="编辑供应商"
       submitText="保存"
       initialData={provider}

--- a/src/components/ProviderForm.tsx
+++ b/src/components/ProviderForm.tsx
@@ -48,7 +48,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   const [codexConfig, setCodexConfig] = useState("");
   const [codexApiKey, setCodexApiKey] = useState("");
   const [selectedCodexPreset, setSelectedCodexPreset] = useState<number | null>(
-    null
+    null,
   );
 
   // 初始化 Codex 配置
@@ -151,7 +151,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   };
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { name, value } = e.target;
 
@@ -188,7 +188,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
     // 更新JSON配置
     const updatedConfig = updateCoAuthoredSetting(
       formData.settingsConfig,
-      checked
+      checked,
     );
     setFormData({
       ...formData,
@@ -219,7 +219,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   // Codex: 应用预设
   const applyCodexPreset = (
     preset: (typeof codexProviderPresets)[0],
-    index: number
+    index: number,
   ) => {
     const authString = JSON.stringify(preset.auth || {}, null, 2);
     setCodexAuth(authString);
@@ -244,7 +244,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
     const configString = setApiKeyInConfig(
       formData.settingsConfig,
       key.trim(),
-      { createIfMissing: selectedPreset !== null }
+      { createIfMissing: selectedPreset !== null },
     );
 
     // 更新表单配置
@@ -298,7 +298,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   useEffect(() => {
     if (initialData) {
       const parsedKey = getApiKeyFromConfig(
-        JSON.stringify(initialData.settingsConfig)
+        JSON.stringify(initialData.settingsConfig),
       );
       if (parsedKey) setApiKey(parsedKey);
     }
@@ -447,7 +447,9 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
                       : "只需要填这里，下方 auth.json 会自动填充"
                   }
                   disabled={isCodexOfficialPreset}
-                  required={selectedCodexPreset !== null && !isCodexOfficialPreset}
+                  required={
+                    selectedCodexPreset !== null && !isCodexOfficialPreset
+                  }
                   autoComplete="off"
                   style={
                     isCodexOfficialPreset

--- a/src/components/ProviderForm.tsx
+++ b/src/components/ProviderForm.tsx
@@ -103,6 +103,23 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
 
       try {
         const authJson = JSON.parse(codexAuth);
+
+        // 非官方预设强制要求 OPENAI_API_KEY
+        if (selectedCodexPreset !== null) {
+          const preset = codexProviderPresets[selectedCodexPreset];
+          const isOfficial = Boolean(preset?.isOfficial);
+          if (!isOfficial) {
+            const key =
+              typeof authJson.OPENAI_API_KEY === "string"
+                ? authJson.OPENAI_API_KEY.trim()
+                : "";
+            if (!key) {
+              setError("请填写 OPENAI_API_KEY");
+              return;
+            }
+          }
+        }
+
         settingsConfig = {
           auth: authJson,
           config: codexConfig ?? "",
@@ -430,6 +447,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
                       : "只需要填这里，下方 auth.json 会自动填充"
                   }
                   disabled={isCodexOfficialPreset}
+                  required={selectedCodexPreset !== null && !isCodexOfficialPreset}
                   autoComplete="off"
                   style={
                     isCodexOfficialPreset

--- a/src/components/ProviderForm.tsx
+++ b/src/components/ProviderForm.tsx
@@ -60,8 +60,8 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
         setCodexConfig(config.config || "");
         try {
           const auth = config.auth || {};
-          if (auth && typeof auth.api_key === "string") {
-            setCodexApiKey(auth.api_key);
+          if (auth && typeof auth.OPENAI_API_KEY === "string") {
+            setCodexApiKey(auth.OPENAI_API_KEY);
           }
         } catch {
           // ignore
@@ -95,9 +95,9 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
     let settingsConfig: Record<string, any>;
 
     if (isCodex) {
-      // Codex: 验证两个文件
-      if (!codexAuth.trim() || !codexConfig.trim()) {
-        setError("请填写 auth.json 和 config.toml 配置");
+      // Codex: 仅要求 auth.json 必填；config.toml 可为空
+      if (!codexAuth.trim()) {
+        setError("请填写 auth.json 配置");
         return;
       }
 
@@ -105,7 +105,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
         const authJson = JSON.parse(codexAuth);
         settingsConfig = {
           auth: authJson,
-          config: codexConfig,
+          config: codexConfig ?? "",
         };
       } catch (err) {
         setError("auth.json 格式错误，请检查JSON语法");
@@ -246,7 +246,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
     setCodexApiKey(key);
     try {
       const auth = JSON.parse(codexAuth || "{}");
-      auth.api_key = key.trim();
+      auth.OPENAI_API_KEY = key.trim();
       setCodexAuth(JSON.stringify(auth, null, 2));
     } catch {
       // ignore
@@ -266,7 +266,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   const getCodexAuthApiKey = (authString: string): string => {
     try {
       const auth = JSON.parse(authString || "{}");
-      return typeof auth.api_key === "string" ? auth.api_key : "";
+      return typeof auth.OPENAI_API_KEY === "string" ? auth.OPENAI_API_KEY : "";
     } catch {
       return "";
     }
@@ -472,7 +472,9 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
                       try {
                         const auth = JSON.parse(value || "{}");
                         const key =
-                          typeof auth.api_key === "string" ? auth.api_key : "";
+                          typeof auth.OPENAI_API_KEY === "string"
+                            ? auth.OPENAI_API_KEY
+                            : "";
                         setCodexApiKey(key);
                       } catch {
                         // ignore
@@ -489,7 +491,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
                 </div>
 
                 <div className="form-group">
-                  <label htmlFor="codexConfig">config.toml (TOML) *</label>
+                  <label htmlFor="codexConfig">config.toml (TOML)</label>
                   <textarea
                     id="codexConfig"
                     value={codexConfig}
@@ -497,10 +499,9 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
                     placeholder={``}
                     rows={8}
                     style={{ fontFamily: "monospace", fontSize: "14px" }}
-                    required
                   />
                   <small className="field-hint">
-                    Codex config.toml 配置内容
+                    Codex config.toml 配置内容（可留空）
                   </small>
                 </div>
               </>

--- a/src/components/ProviderForm.tsx
+++ b/src/components/ProviderForm.tsx
@@ -48,7 +48,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   const [codexConfig, setCodexConfig] = useState("");
   const [codexApiKey, setCodexApiKey] = useState("");
   const [selectedCodexPreset, setSelectedCodexPreset] = useState<number | null>(
-    null,
+    null
   );
 
   // 初始化 Codex 配置
@@ -134,7 +134,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   };
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { name, value } = e.target;
 
@@ -171,7 +171,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
     // 更新JSON配置
     const updatedConfig = updateCoAuthoredSetting(
       formData.settingsConfig,
-      checked,
+      checked
     );
     setFormData({
       ...formData,
@@ -202,7 +202,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   // Codex: 应用预设
   const applyCodexPreset = (
     preset: (typeof codexProviderPresets)[0],
-    index: number,
+    index: number
   ) => {
     const authString = JSON.stringify(preset.auth || {}, null, 2);
     setCodexAuth(authString);
@@ -227,7 +227,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
     const configString = setApiKeyInConfig(
       formData.settingsConfig,
       key.trim(),
-      { createIfMissing: selectedPreset !== null },
+      { createIfMissing: selectedPreset !== null }
     );
 
     // 更新表单配置
@@ -281,7 +281,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
   useEffect(() => {
     if (initialData) {
       const parsedKey = getApiKeyFromConfig(
-        JSON.stringify(initialData.settingsConfig),
+        JSON.stringify(initialData.settingsConfig)
       );
       if (parsedKey) setApiKey(parsedKey);
     }
@@ -427,7 +427,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
                   placeholder={
                     isCodexOfficialPreset
                       ? "官方无需填写 API Key，直接保存即可"
-                      : "只需要填这里，上方 auth.json 会自动填充"
+                      : "只需要填这里，下方 auth.json 会自动填充"
                   }
                   disabled={isCodexOfficialPreset}
                   autoComplete="off"
@@ -471,14 +471,15 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
                       setCodexAuth(value);
                       try {
                         const auth = JSON.parse(value || "{}");
-                        const key = typeof auth.api_key === "string" ? auth.api_key : "";
+                        const key =
+                          typeof auth.api_key === "string" ? auth.api_key : "";
                         setCodexApiKey(key);
                       } catch {
                         // ignore
                       }
                     }}
                     placeholder={`{
-  "api_key": "your-codex-api-key"
+  "OPENAI_API_KEY": "sk-your-api-key-here"
 }`}
                     rows={6}
                     style={{ fontFamily: "monospace", fontSize: "14px" }}
@@ -493,9 +494,7 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
                     id="codexConfig"
                     value={codexConfig}
                     onChange={(e) => setCodexConfig(e.target.value)}
-                    placeholder={`# Codex configuration
-model = "codex-model"
-temperature = 0.7`}
+                    placeholder={``}
                     rows={8}
                     style={{ fontFamily: "monospace", fontSize: "14px" }}
                     required

--- a/src/components/ProviderForm.tsx
+++ b/src/components/ProviderForm.tsx
@@ -216,14 +216,8 @@ const ProviderForm: React.FC<ProviderFormProps> = ({
 
     setSelectedCodexPreset(index);
 
-    // 同步 API Key 输入框
-    try {
-      const auth = JSON.parse(authString);
-      const key = typeof auth.api_key === "string" ? auth.api_key : "";
-      setCodexApiKey(key);
-    } catch {
-      setCodexApiKey("");
-    }
+    // 清空 API Key，让用户重新输入
+    setCodexApiKey("");
   };
 
   // 处理 API Key 输入并自动更新配置

--- a/src/components/ProviderList.tsx
+++ b/src/components/ProviderList.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Provider } from "../types";
-import { AppType } from "../lib/tauri-api";
 import "./ProviderList.css";
 
 interface ProviderListProps {
@@ -9,7 +8,6 @@ interface ProviderListProps {
   onSwitch: (id: string) => void;
   onDelete: (id: string) => void;
   onEdit: (id: string) => void;
-  appType?: AppType;
 }
 
 const ProviderList: React.FC<ProviderListProps> = ({
@@ -18,37 +16,14 @@ const ProviderList: React.FC<ProviderListProps> = ({
   onSwitch,
   onDelete,
   onEdit,
-  appType = "claude",
 }) => {
   // 提取API地址
   const getApiUrl = (provider: Provider): string => {
     try {
       const config = provider.settingsConfig;
-      // Claude: 显示 ANTHROPIC_BASE_URL
-      if (appType === "claude") {
-        if (config?.env?.ANTHROPIC_BASE_URL) {
-          return config.env.ANTHROPIC_BASE_URL;
-        }
-        return "未设置";
+      if (config?.env?.ANTHROPIC_BASE_URL) {
+        return config.env.ANTHROPIC_BASE_URL;
       }
-
-      // Codex: 从 TOML 中提取 base_url 或 model_provider
-      const tomlText: string | undefined =
-        typeof config?.config === "string" ? config.config : undefined;
-      if (!tomlText) return "未设置";
-
-      // 简单解析：base_url = "..."
-      const baseUrlMatch = tomlText.match(/base_url\s*=\s*"([^"]+)"/);
-      if (baseUrlMatch && baseUrlMatch[1]) return baseUrlMatch[1];
-
-      // 回退：model_provider = "..."
-      const providerMatch = tomlText.match(/model_provider\s*=\s*"([^"]+)"/);
-      if (providerMatch && providerMatch[1]) return `provider: ${providerMatch[1]}`;
-
-      // 再回退：model = "..."
-      const modelMatch = tomlText.match(/\bmodel\s*=\s*"([^"]+)"/);
-      if (modelMatch && modelMatch[1]) return `model: ${modelMatch[1]}`;
-
       return "未设置";
     } catch {
       return "配置错误";

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -12,20 +12,30 @@ export interface CodexProviderPreset {
 export const codexProviderPresets: CodexProviderPreset[] = [
   {
     name: "Codex官方",
-    websiteUrl: "https://codex",
+    websiteUrl: "https://chatgpt.com/codex",
     isOfficial: true,
-    // 官方一般不需要在 auth.json 里预置 key，由用户根据实际环境填写
-    auth: {},
-    config: `# Codex 默认配置模板\n# 根据你的 Codex 安装或文档进行调整\nmodel = "default"\ntemperature = 0.7`,
+    // 官方的 key 为null
+    auth: {
+      "OPENAI_API_KEY": null,
+    },
+    config: ``,
   },
   {
     name: "PackyCode",
-    websiteUrl: "https://www.packycode.com",
+    websiteUrl: "https://codex.packycode.com/",
     // PackyCode 一般通过 API Key；请将占位符替换为你的实际 key
     auth: {
-      api_key: "sk-your-api-key-here",
+      "OPENAI_API_KEY": "sk-your-api-key-here",
     },
-    config: `# Codex 配置模板 - PackyCode\n# 如有需要可添加 base_url: \n# base_url = "https://api.packycode.com"\nmodel = "default"\ntemperature = 0.7`,
+    config: `model_provider = "packycode"
+model = "gpt-5"
+model_reasoning_effort = "high"
+
+[model_providers.packycode]
+name = "packycode"
+base_url = "https://codex-api.packycode.com/v1"
+wire_api = "responses"
+env_key = "packycode"`,
   },
 ];
 

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -16,7 +16,7 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     isOfficial: true,
     // 官方的 key 为null
     auth: {
-      "OPENAI_API_KEY": null,
+      OPENAI_API_KEY: null,
     },
     config: ``,
   },
@@ -25,7 +25,7 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     websiteUrl: "https://codex.packycode.com/",
     // PackyCode 一般通过 API Key；请将占位符替换为你的实际 key
     auth: {
-      "OPENAI_API_KEY": "sk-your-api-key-here",
+      OPENAI_API_KEY: "sk-your-api-key-here",
     },
     config: `model_provider = "packycode"
 model = "gpt-5"
@@ -38,4 +38,3 @@ wire_api = "responses"
 env_key = "packycode"`,
   },
 ];
-

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1,0 +1,31 @@
+/**
+ * Codex 预设供应商配置模板
+ */
+export interface CodexProviderPreset {
+  name: string;
+  websiteUrl: string;
+  auth: Record<string, any>; // 将写入 ~/.codex/auth.json
+  config: string; // 将写入 ~/.codex/config.toml（TOML 字符串）
+  isOfficial?: boolean; // 标识是否为官方预设
+}
+
+export const codexProviderPresets: CodexProviderPreset[] = [
+  {
+    name: "Codex官方",
+    websiteUrl: "https://codex",
+    isOfficial: true,
+    // 官方一般不需要在 auth.json 里预置 key，由用户根据实际环境填写
+    auth: {},
+    config: `# Codex 默认配置模板\n# 根据你的 Codex 安装或文档进行调整\nmodel = "default"\ntemperature = 0.7`,
+  },
+  {
+    name: "PackyCode",
+    websiteUrl: "https://www.packycode.com",
+    // PackyCode 一般通过 API Key；请将占位符替换为你的实际 key
+    auth: {
+      api_key: "sk-your-api-key-here",
+    },
+    config: `# Codex 配置模板 - PackyCode\n# 如有需要可添加 base_url: \n# base_url = "https://api.packycode.com"\nmodel = "default"\ntemperature = 0.7`,
+  },
+];
+

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -22,7 +22,7 @@ export const tauriAPI = {
   // 获取所有供应商
   getProviders: async (app?: AppType): Promise<Record<string, Provider>> => {
     try {
-      return await invoke("get_providers", { app });
+      return await invoke("get_providers", { app_type: app, app });
     } catch (error) {
       console.error("获取供应商列表失败:", error);
       return {};
@@ -32,7 +32,7 @@ export const tauriAPI = {
   // 获取当前供应商ID
   getCurrentProvider: async (app?: AppType): Promise<string> => {
     try {
-      return await invoke("get_current_provider", { app });
+      return await invoke("get_current_provider", { app_type: app, app });
     } catch (error) {
       console.error("获取当前供应商失败:", error);
       return "";
@@ -42,7 +42,7 @@ export const tauriAPI = {
   // 添加供应商
   addProvider: async (provider: Provider, app?: AppType): Promise<boolean> => {
     try {
-      return await invoke("add_provider", { provider, app });
+      return await invoke("add_provider", { provider, app_type: app, app });
     } catch (error) {
       console.error("添加供应商失败:", error);
       throw error;
@@ -55,7 +55,7 @@ export const tauriAPI = {
     app?: AppType,
   ): Promise<boolean> => {
     try {
-      return await invoke("update_provider", { provider, app });
+      return await invoke("update_provider", { provider, app_type: app, app });
     } catch (error) {
       console.error("更新供应商失败:", error);
       throw error;
@@ -65,7 +65,7 @@ export const tauriAPI = {
   // 删除供应商
   deleteProvider: async (id: string, app?: AppType): Promise<boolean> => {
     try {
-      return await invoke("delete_provider", { id, app });
+      return await invoke("delete_provider", { id, app_type: app, app });
     } catch (error) {
       console.error("删除供应商失败:", error);
       throw error;
@@ -78,7 +78,7 @@ export const tauriAPI = {
     app?: AppType,
   ): Promise<boolean> => {
     try {
-      return await invoke("switch_provider", { id: providerId, app });
+      return await invoke("switch_provider", { id: providerId, app_type: app, app });
     } catch (error) {
       console.error("切换供应商失败:", error);
       return false;
@@ -90,7 +90,7 @@ export const tauriAPI = {
     app?: AppType,
   ): Promise<ImportResult> => {
     try {
-      const success = await invoke<boolean>("import_default_config", { app });
+      const success = await invoke<boolean>("import_default_config", { app_type: app, app });
       return {
         success,
         message: success ? "成功导入默认配置" : "导入失败",

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -1,6 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 import { Provider } from "../types";
 
+// 应用类型
+export type AppType = "claude" | "codex";
+
 // 定义配置状态类型
 interface ConfigStatus {
   exists: boolean;
@@ -17,9 +20,9 @@ interface ImportResult {
 // Tauri API 封装，提供统一的全局 API 接口
 export const tauriAPI = {
   // 获取所有供应商
-  getProviders: async (): Promise<Record<string, Provider>> => {
+  getProviders: async (app?: AppType): Promise<Record<string, Provider>> => {
     try {
-      return await invoke("get_providers");
+      return await invoke("get_providers", { app });
     } catch (error) {
       console.error("获取供应商列表失败:", error);
       return {};
@@ -27,9 +30,9 @@ export const tauriAPI = {
   },
 
   // 获取当前供应商ID
-  getCurrentProvider: async (): Promise<string> => {
+  getCurrentProvider: async (app?: AppType): Promise<string> => {
     try {
-      return await invoke("get_current_provider");
+      return await invoke("get_current_provider", { app });
     } catch (error) {
       console.error("获取当前供应商失败:", error);
       return "";
@@ -37,9 +40,9 @@ export const tauriAPI = {
   },
 
   // 添加供应商
-  addProvider: async (provider: Provider): Promise<boolean> => {
+  addProvider: async (provider: Provider, app?: AppType): Promise<boolean> => {
     try {
-      return await invoke("add_provider", { provider });
+      return await invoke("add_provider", { provider, app });
     } catch (error) {
       console.error("添加供应商失败:", error);
       throw error;
@@ -47,9 +50,12 @@ export const tauriAPI = {
   },
 
   // 更新供应商
-  updateProvider: async (provider: Provider): Promise<boolean> => {
+  updateProvider: async (
+    provider: Provider,
+    app?: AppType,
+  ): Promise<boolean> => {
     try {
-      return await invoke("update_provider", { provider });
+      return await invoke("update_provider", { provider, app });
     } catch (error) {
       console.error("更新供应商失败:", error);
       throw error;
@@ -57,9 +63,9 @@ export const tauriAPI = {
   },
 
   // 删除供应商
-  deleteProvider: async (id: string): Promise<boolean> => {
+  deleteProvider: async (id: string, app?: AppType): Promise<boolean> => {
     try {
-      return await invoke("delete_provider", { id });
+      return await invoke("delete_provider", { id, app });
     } catch (error) {
       console.error("删除供应商失败:", error);
       throw error;
@@ -67,9 +73,12 @@ export const tauriAPI = {
   },
 
   // 切换供应商
-  switchProvider: async (providerId: string): Promise<boolean> => {
+  switchProvider: async (
+    providerId: string,
+    app?: AppType,
+  ): Promise<boolean> => {
     try {
-      return await invoke("switch_provider", { id: providerId });
+      return await invoke("switch_provider", { id: providerId, app });
     } catch (error) {
       console.error("切换供应商失败:", error);
       return false;
@@ -77,9 +86,11 @@ export const tauriAPI = {
   },
 
   // 导入当前配置为默认供应商
-  importCurrentConfigAsDefault: async (): Promise<ImportResult> => {
+  importCurrentConfigAsDefault: async (
+    app?: AppType,
+  ): Promise<ImportResult> => {
     try {
-      const success = await invoke<boolean>("import_default_config");
+      const success = await invoke<boolean>("import_default_config", { app });
       return {
         success,
         message: success ? "成功导入默认配置" : "导入失败",
@@ -117,10 +128,24 @@ export const tauriAPI = {
     }
   },
 
-  // 打开配置文件夹
-  openConfigFolder: async (): Promise<void> => {
+  // 获取应用配置状态（通用）
+  getConfigStatus: async (app?: AppType): Promise<ConfigStatus> => {
     try {
-      await invoke("open_config_folder");
+      return await invoke("get_config_status", { appType: app });
+    } catch (error) {
+      console.error("获取配置状态失败:", error);
+      return {
+        exists: false,
+        path: "",
+        error: String(error),
+      };
+    }
+  },
+
+  // 打开配置文件夹
+  openConfigFolder: async (app?: AppType): Promise<void> => {
+    try {
+      await invoke("open_config_folder", { appType: app });
     } catch (error) {
       console.error("打开配置文件夹失败:", error);
     }

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -131,7 +131,7 @@ export const tauriAPI = {
   // 获取应用配置状态（通用）
   getConfigStatus: async (app?: AppType): Promise<ConfigStatus> => {
     try {
-      return await invoke("get_config_status", { appType: app });
+      return await invoke("get_config_status", { app_type: app, app });
     } catch (error) {
       console.error("获取配置状态失败:", error);
       return {
@@ -145,7 +145,7 @@ export const tauriAPI = {
   // 打开配置文件夹
   openConfigFolder: async (app?: AppType): Promise<void> => {
     try {
-      await invoke("open_config_folder", { appType: app });
+      await invoke("open_config_folder", { app_type: app, app });
     } catch (error) {
       console.error("打开配置文件夹失败:", error);
     }

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -78,7 +78,11 @@ export const tauriAPI = {
     app?: AppType,
   ): Promise<boolean> => {
     try {
-      return await invoke("switch_provider", { id: providerId, app_type: app, app });
+      return await invoke("switch_provider", {
+        id: providerId,
+        app_type: app,
+        app,
+      });
     } catch (error) {
       console.error("切换供应商失败:", error);
       return false;
@@ -90,7 +94,10 @@ export const tauriAPI = {
     app?: AppType,
   ): Promise<ImportResult> => {
     try {
-      const success = await invoke<boolean>("import_default_config", { app_type: app, app });
+      const success = await invoke<boolean>("import_default_config", {
+        app_type: app,
+        app,
+      });
       return {
         success,
         message: success ? "成功导入默认配置" : "导入失败",

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -167,6 +167,8 @@ export const tauriAPI = {
     }
   },
 
+  // （保留空位，取消迁移提示）
+
   // 选择配置文件（Tauri 暂不实现，保留接口兼容性）
   selectConfigFile: async (): Promise<string | null> => {
     console.warn("selectConfigFile 在 Tauri 版本中暂不支持");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export interface Provider {
   id: string;
   name: string;
-  settingsConfig: Record<string, any>; // 完整的 Claude Code settings.json 配置
+  settingsConfig: Record<string, any>; // 应用配置对象：Claude 为 settings.json；Codex 为 { auth, config }
   websiteUrl?: string;
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 import { Provider } from "./types";
+import { AppType } from "./lib/tauri-api";
 
 interface ImportResult {
   success: boolean;
@@ -16,17 +17,18 @@ interface ConfigStatus {
 declare global {
   interface Window {
     api: {
-      getProviders: () => Promise<Record<string, Provider>>;
-      getCurrentProvider: () => Promise<string>;
-      addProvider: (provider: Provider) => Promise<boolean>;
-      deleteProvider: (id: string) => Promise<boolean>;
-      updateProvider: (provider: Provider) => Promise<boolean>;
-      switchProvider: (providerId: string) => Promise<boolean>;
-      importCurrentConfigAsDefault: () => Promise<ImportResult>;
+      getProviders: (app?: AppType) => Promise<Record<string, Provider>>;
+      getCurrentProvider: (app?: AppType) => Promise<string>;
+      addProvider: (provider: Provider, app?: AppType) => Promise<boolean>;
+      deleteProvider: (id: string, app?: AppType) => Promise<boolean>;
+      updateProvider: (provider: Provider, app?: AppType) => Promise<boolean>;
+      switchProvider: (providerId: string, app?: AppType) => Promise<boolean>;
+      importCurrentConfigAsDefault: (app?: AppType) => Promise<ImportResult>;
       getClaudeCodeConfigPath: () => Promise<string>;
       getClaudeConfigStatus: () => Promise<ConfigStatus>;
+      getConfigStatus: (app?: AppType) => Promise<ConfigStatus>;
       selectConfigFile: () => Promise<string | null>;
-      openConfigFolder: () => Promise<void>;
+      openConfigFolder: (app?: AppType) => Promise<void>;
       openExternal: (url: string) => Promise<void>;
     };
     platform: {


### PR DESCRIPTION

- 概览: 引入 Codex 的供应商管理与切换能力，补齐与 Claude Code 的双应用支持；同时在内部配置从 v1→v2 的迁移前增加备份，保证回滚安全。
- 主要变更:
    - Codex: 增加 ~/.codex/ 配置的导入、切换与副本持久化
    - 切换策略: 覆盖 auth.json（必需）与 config.toml（可为空，缺失时创建空文件）
    - 导入默认: 若当前存在 ~/.codex/auth.json，可一键导入为 default 供应商
    - 迁移安全: 在检测到 v1 配置并迁移到 v2 前，备份旧版文件为 ~/.cc-switch/config.v1.backup.<timestamp>.json
    - 文档: CHANGELOG.md 补充迁移备份说明
- 兼容与迁移:
    - 不修改 ~/.claude/ 与 ~/.codex/ 的生效配置，仅在切换时进行文件级复制
    - cc-switch 自身的配置由 v1 自动迁移到 v2，迁移前生成时间戳备份
    - 旧版 cc-switch 无法解析 v2 结构，降级时可使用备份文件或在旧版中重新导入
- 风险与回滚:
    - 风险低：仅文件级读写；对生效配置的覆盖是显式切换时执行
    - 回滚方案：使用 ~/.cc-switch/config.v1.backup.<ts>.json 覆盖回 config.json，或在旧版 cc-switch 中重新导入默认
- 其他:
    - 已通过本地 pnpm typecheck / cargo check
- 界面变更
 
<img width="892" height="677" alt="main" src="https://github.com/user-attachments/assets/1ec99482-6bcf-4912-8eba-07bcd71e56bc" />
