### PR TITLE
Feature/VS Code Integration Enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@tauri-apps/api": "^2.8.0",
     "@tauri-apps/plugin-process": "^2.0.0",
     "@tauri-apps/plugin-updater": "^2.0.0",
+    "jsonc-parser": "^3.2.1",
     "codemirror": "^6.0.2",
     "lucide-react": "^0.542.0",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
+      jsonc-parser:
+        specifier: ^3.2.1
+        version: 3.3.1
       lucide-react:
         specifier: ^0.542.0
         version: 0.542.0(react@18.3.1)
@@ -754,6 +757,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
@@ -1579,6 +1585,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   lightningcss-darwin-arm64@1.30.1:
     optional: true

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod app_config;
 mod codex_config;
 mod commands;
 mod config;
+mod vscode;
 mod migration;
 mod provider;
 mod store;
@@ -357,6 +358,9 @@ pub fn run() {
             commands::get_settings,
             commands::save_settings,
             commands::check_for_updates,
+            commands::get_vscode_settings_status,
+            commands::read_vscode_settings,
+            commands::write_vscode_settings,
             update_tray_menu,
         ]);
 

--- a/src-tauri/src/vscode.rs
+++ b/src-tauri/src/vscode.rs
@@ -1,0 +1,61 @@
+use std::path::{PathBuf};
+
+/// 枚举可能的 VS Code 发行版配置目录名称
+fn vscode_product_dirs() -> Vec<&'static str> {
+    vec![
+        "Code",           // VS Code Stable
+        "Code - Insiders", // VS Code Insiders
+        "VSCodium",      // VSCodium
+        "Code - OSS",     // OSS 发行版
+    ]
+}
+
+/// 获取 VS Code 用户 settings.json 的候选路径列表（按优先级排序）
+pub fn candidate_settings_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = dirs::home_dir() {
+            for prod in vscode_product_dirs() {
+                paths.push(
+                    home.join("Library").join("Application Support").join(prod).join("User").join("settings.json")
+                );
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // Windows: %APPDATA%\Code\User\settings.json
+        if let Some(roaming) = dirs::config_dir() {
+            for prod in vscode_product_dirs() {
+                paths.push(roaming.join(prod).join("User").join("settings.json"));
+            }
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        // Linux: ~/.config/Code/User/settings.json
+        if let Some(config) = dirs::config_dir() {
+            for prod in vscode_product_dirs() {
+                paths.push(config.join(prod).join("User").join("settings.json"));
+            }
+        }
+    }
+
+    paths
+}
+
+/// 返回第一个存在的 settings.json 路径
+pub fn find_existing_settings() -> Option<PathBuf> {
+    for p in candidate_settings_paths() {
+        if let Ok(meta) = std::fs::metadata(&p) {
+            if meta.is_file() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,7 @@ function App() {
         unlisten();
       }
     };
-  }, [activeApp, isAutoSyncEnabled]); // 依赖自动同步状态，确保拿到最新开关
+  }, [activeApp, isAutoSyncEnabled]);
 
   const loadProviders = async () => {
     const loadedProviders = await window.api.getProviders(activeApp);
@@ -183,7 +183,7 @@ function App() {
     });
   };
 
-  // 同步Codex供应商到VS Code设置
+  // 同步Codex供应商到VS Code设置（静默覆盖）
   const syncCodexToVSCode = async (providerId: string, silent = false) => {
     try {
       const status = await window.api.getVSCodeSettingsStatus();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,6 +281,8 @@ function App() {
               onSwitch={handleSwitchProvider}
               onDelete={handleDeleteProvider}
               onEdit={setEditingProviderId}
+              appType={activeApp}
+              onNotify={showNotification}
             />
           </div>
         </div>

--- a/src/components/ProviderList.tsx
+++ b/src/components/ProviderList.tsx
@@ -131,7 +131,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
 
       if (next === raw) {
         // 幂等：没有变化也提示成功
-        onNotify?.("已应用到 VS Code", "success", 1500);
+        onNotify?.("已应用到 VS Code，重启 Codex 插件以生效", "success", 3000);
         setVscodeAppliedFor(provider.id);
         // 用户手动应用时，启用自动同步
         enableAutoSync();
@@ -139,7 +139,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
       }
 
       await window.api.writeVSCodeSettings(next);
-      onNotify?.("已应用到 VS Code", "success", 1500);
+      onNotify?.("已应用到 VS Code，重启 Codex 插件以生效", "success", 3000);
       setVscodeAppliedFor(provider.id);
       // 用户手动应用时，启用自动同步
       enableAutoSync();
@@ -167,14 +167,14 @@ const ProviderList: React.FC<ProviderListProps> = ({
         isOfficial: true,
       });
       if (next === raw) {
-        onNotify?.("已从 VS Code 移除", "success", 1500);
+        onNotify?.("已从 VS Code 移除，重启 Codex 插件以生效", "success", 3000);
         setVscodeAppliedFor(null);
         // 用户手动移除时，禁用自动同步
         disableAutoSync();
         return;
       }
       await window.api.writeVSCodeSettings(next);
-      onNotify?.("已从 VS Code 移除", "success", 1500);
+      onNotify?.("已从 VS Code 移除，重启 Codex 插件以生效", "success", 3000);
       setVscodeAppliedFor(null);
       // 用户手动移除时，禁用自动同步
       disableAutoSync();
@@ -284,7 +284,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                               : handleApplyToVSCode(provider)
                           }
                           className={cn(
-                            "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
+                            "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-md transition-colors w-[130px] justify-center",
                             !isCurrent && "invisible",
                             vscodeAppliedFor === provider.id
                               ? "bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"

--- a/src/components/ProviderList.tsx
+++ b/src/components/ProviderList.tsx
@@ -235,7 +235,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                   </div>
 
                   <div className="flex items-center gap-2 ml-4">
-                    {appType === "codex" && isCurrent && (
+                    {appType === "codex" && isCurrent && provider.category !== "official" && (
                       <button
                         onClick={() =>
                           vscodeAppliedFor === provider.id

--- a/src/components/ProviderList.tsx
+++ b/src/components/ProviderList.tsx
@@ -221,12 +221,13 @@ const ProviderList: React.FC<ProviderListProps> = ({
                         {provider.name}
                       </h3>
                       {/* 分类徽章已移除 */}
-                      {isCurrent && (
-                        <div className={badgeStyles.success}>
-                          <CheckCircle2 size={12} />
-                          当前使用
-                        </div>
-                      )}
+                      <div className={cn(
+                        badgeStyles.success,
+                        !isCurrent && "invisible"
+                      )}>
+                        <CheckCircle2 size={12} />
+                        当前使用
+                      </div>
                     </div>
 
                     <div className="flex items-center gap-2 text-sm">
@@ -253,7 +254,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                   </div>
 
                   <div className="flex items-center gap-2 ml-4">
-                    {appType === "codex" && isCurrent && provider.category !== "official" && (
+                    {appType === "codex" && provider.category !== "official" && (
                       <button
                         onClick={() =>
                           vscodeAppliedFor === provider.id
@@ -262,6 +263,7 @@ const ProviderList: React.FC<ProviderListProps> = ({
                         }
                         className={cn(
                           "inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
+                          !isCurrent && "invisible",
                           vscodeAppliedFor === provider.id
                             ? "bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
                             : "bg-emerald-500 text-white hover:bg-emerald-600 dark:bg-emerald-600 dark:hover:bg-emerald-700",

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -11,6 +11,7 @@ import { getVersion } from "@tauri-apps/api/app";
 import "../lib/tauri-api";
 import { relaunchApp } from "../lib/updater";
 import { useUpdate } from "../contexts/UpdateContext";
+import { useVSCodeAutoSync } from "../hooks/useVSCodeAutoSync";
 import type { Settings } from "../types";
 
 interface SettingsModalProps {
@@ -28,6 +29,7 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
   const [showUpToDate, setShowUpToDate] = useState(false);
   const { hasUpdate, updateInfo, updateHandle, checkUpdate, resetDismiss } =
     useUpdate();
+  const { isAutoSyncEnabled, toggleAutoSync } = useVSCodeAutoSync();
 
   useEffect(() => {
     loadSettings();
@@ -200,6 +202,29 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
               />
             </label>
           </div> */}
+
+          {/* VS Code 自动同步设置 */}
+          <div>
+            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">
+              Codex 设置
+            </h3>
+            <label className="flex items-center justify-between cursor-pointer">
+              <div className="flex-1">
+                <span className="text-sm text-gray-700 dark:text-gray-300">
+                  自动同步到 VS Code
+                </span>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  切换 Codex 供应商时自动更新 VS Code 配置
+                </p>
+              </div>
+              <input
+                type="checkbox"
+                checked={isAutoSyncEnabled}
+                onChange={toggleAutoSync}
+                className="w-4 h-4 text-blue-500 rounded focus:ring-blue-500/20"
+              />
+            </label>
+          </div>
 
           {/* 配置文件位置 */}
           <div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -11,7 +11,6 @@ import { getVersion } from "@tauri-apps/api/app";
 import "../lib/tauri-api";
 import { relaunchApp } from "../lib/updater";
 import { useUpdate } from "../contexts/UpdateContext";
-import { useVSCodeAutoSync } from "../hooks/useVSCodeAutoSync";
 import type { Settings } from "../types";
 
 interface SettingsModalProps {
@@ -29,7 +28,6 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
   const [showUpToDate, setShowUpToDate] = useState(false);
   const { hasUpdate, updateInfo, updateHandle, checkUpdate, resetDismiss } =
     useUpdate();
-  const { isAutoSyncEnabled, toggleAutoSync } = useVSCodeAutoSync();
 
   useEffect(() => {
     loadSettings();
@@ -203,28 +201,7 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
             </label>
           </div> */}
 
-          {/* VS Code 自动同步设置 */}
-          <div>
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">
-              Codex 设置
-            </h3>
-            <label className="flex items-center justify-between cursor-pointer">
-              <div className="flex-1">
-                <span className="text-sm text-gray-700 dark:text-gray-300">
-                  自动同步到 VS Code
-                </span>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  切换 Codex 供应商时自动更新 VS Code 配置
-                </p>
-              </div>
-              <input
-                type="checkbox"
-                checked={isAutoSyncEnabled}
-                onChange={toggleAutoSync}
-                className="w-4 h-4 text-blue-500 rounded focus:ring-blue-500/20"
-              />
-            </label>
-          </div>
+          {/* VS Code 自动同步设置已移除 */}
 
           {/* 配置文件位置 */}
           <div>

--- a/src/hooks/useVSCodeAutoSync.ts
+++ b/src/hooks/useVSCodeAutoSync.ts
@@ -4,7 +4,8 @@ const VSCODE_AUTO_SYNC_KEY = "vscode-auto-sync-enabled";
 const VSCODE_AUTO_SYNC_EVENT = "vscode-auto-sync-changed";
 
 export function useVSCodeAutoSync() {
-  const [isAutoSyncEnabled, setIsAutoSyncEnabled] = useState<boolean>(false);
+  // 默认开启自动同步；若本地存储存在记录，则以记录为准
+  const [isAutoSyncEnabled, setIsAutoSyncEnabled] = useState<boolean>(true);
 
   // 从 localStorage 读取初始状态
   useEffect(() => {
@@ -22,7 +23,9 @@ export function useVSCodeAutoSync() {
   useEffect(() => {
     const onCustom = (e: Event) => {
       try {
-        const detail = (e as CustomEvent).detail as { enabled?: boolean } | undefined;
+        const detail = (e as CustomEvent).detail as
+          | { enabled?: boolean }
+          | undefined;
         if (detail && typeof detail.enabled === "boolean") {
           setIsAutoSyncEnabled(detail.enabled);
         } else {
@@ -42,7 +45,10 @@ export function useVSCodeAutoSync() {
     window.addEventListener(VSCODE_AUTO_SYNC_EVENT, onCustom as EventListener);
     window.addEventListener("storage", onStorage);
     return () => {
-      window.removeEventListener(VSCODE_AUTO_SYNC_EVENT, onCustom as EventListener);
+      window.removeEventListener(
+        VSCODE_AUTO_SYNC_EVENT,
+        onCustom as EventListener,
+      );
       window.removeEventListener("storage", onStorage);
     };
   }, []);

--- a/src/hooks/useVSCodeAutoSync.ts
+++ b/src/hooks/useVSCodeAutoSync.ts
@@ -1,0 +1,93 @@
+import { useState, useEffect, useCallback } from "react";
+
+const VSCODE_AUTO_SYNC_KEY = "vscode-auto-sync-enabled";
+const VSCODE_AUTO_SYNC_EVENT = "vscode-auto-sync-changed";
+
+export function useVSCodeAutoSync() {
+  const [isAutoSyncEnabled, setIsAutoSyncEnabled] = useState<boolean>(false);
+
+  // 从 localStorage 读取初始状态
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(VSCODE_AUTO_SYNC_KEY);
+      if (saved !== null) {
+        setIsAutoSyncEnabled(saved === "true");
+      }
+    } catch (error) {
+      console.error("读取自动同步状态失败:", error);
+    }
+  }, []);
+
+  // 订阅同窗口的自定义事件，以及跨窗口的 storage 事件，实现全局同步
+  useEffect(() => {
+    const onCustom = (e: Event) => {
+      try {
+        const detail = (e as CustomEvent).detail as { enabled?: boolean } | undefined;
+        if (detail && typeof detail.enabled === "boolean") {
+          setIsAutoSyncEnabled(detail.enabled);
+        } else {
+          // 兜底：从 localStorage 读取
+          const saved = localStorage.getItem(VSCODE_AUTO_SYNC_KEY);
+          if (saved !== null) setIsAutoSyncEnabled(saved === "true");
+        }
+      } catch {
+        // 忽略
+      }
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === VSCODE_AUTO_SYNC_KEY) {
+        setIsAutoSyncEnabled(e.newValue === "true");
+      }
+    };
+    window.addEventListener(VSCODE_AUTO_SYNC_EVENT, onCustom as EventListener);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(VSCODE_AUTO_SYNC_EVENT, onCustom as EventListener);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  // 启用自动同步
+  const enableAutoSync = useCallback(() => {
+    try {
+      localStorage.setItem(VSCODE_AUTO_SYNC_KEY, "true");
+      setIsAutoSyncEnabled(true);
+      // 通知同窗口其他订阅者
+      window.dispatchEvent(
+        new CustomEvent(VSCODE_AUTO_SYNC_EVENT, { detail: { enabled: true } }),
+      );
+    } catch (error) {
+      console.error("保存自动同步状态失败:", error);
+    }
+  }, []);
+
+  // 禁用自动同步
+  const disableAutoSync = useCallback(() => {
+    try {
+      localStorage.setItem(VSCODE_AUTO_SYNC_KEY, "false");
+      setIsAutoSyncEnabled(false);
+      // 通知同窗口其他订阅者
+      window.dispatchEvent(
+        new CustomEvent(VSCODE_AUTO_SYNC_EVENT, { detail: { enabled: false } }),
+      );
+    } catch (error) {
+      console.error("保存自动同步状态失败:", error);
+    }
+  }, []);
+
+  // 切换自动同步状态
+  const toggleAutoSync = useCallback(() => {
+    if (isAutoSyncEnabled) {
+      disableAutoSync();
+    } else {
+      enableAutoSync();
+    }
+  }, [isAutoSyncEnabled, enableAutoSync, disableAutoSync]);
+
+  return {
+    isAutoSyncEnabled,
+    enableAutoSync,
+    disableAutoSync,
+    toggleAutoSync,
+  };
+}

--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -38,7 +38,7 @@ export const cardStyles = {
 
   // 选中/激活态卡片
   selected:
-    "bg-white rounded-lg border border-blue-500 ring-1 ring-blue-500/20 bg-blue-500/5 p-4 dark:bg-gray-900 dark:border-blue-400 dark:ring-blue-400/20 dark:bg-blue-400/10",
+    "bg-white rounded-lg border border-blue-500 shadow-sm bg-blue-50 p-4 dark:bg-gray-900 dark:border-blue-400 dark:bg-blue-400/10",
 } as const;
 
 // 输入控件样式

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -244,7 +244,11 @@ export const tauriAPI = {
   },
 
   // VS Code: 获取 settings.json 状态
-  getVSCodeSettingsStatus: async (): Promise<{ exists: boolean; path: string; error?: string }> => {
+  getVSCodeSettingsStatus: async (): Promise<{
+    exists: boolean;
+    path: string;
+    error?: string;
+  }> => {
     try {
       return await invoke("get_vscode_settings_status");
     } catch (error) {

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -242,6 +242,34 @@ export const tauriAPI = {
       console.error("打开应用配置文件夹失败:", error);
     }
   },
+
+  // VS Code: 获取 settings.json 状态
+  getVSCodeSettingsStatus: async (): Promise<{ exists: boolean; path: string; error?: string }> => {
+    try {
+      return await invoke("get_vscode_settings_status");
+    } catch (error) {
+      console.error("获取 VS Code 设置状态失败:", error);
+      return { exists: false, path: "", error: String(error) };
+    }
+  },
+
+  // VS Code: 读取 settings.json 文本
+  readVSCodeSettings: async (): Promise<string> => {
+    try {
+      return await invoke("read_vscode_settings");
+    } catch (error) {
+      throw new Error(`读取 VS Code 设置失败: ${String(error)}`);
+    }
+  },
+
+  // VS Code: 写回 settings.json 文本（不自动创建）
+  writeVSCodeSettings: async (content: string): Promise<boolean> => {
+    try {
+      return await invoke("write_vscode_settings", { content });
+    } catch (error) {
+      throw new Error(`写入 VS Code 设置失败: ${String(error)}`);
+    }
+  },
 };
 
 // 创建全局 API 对象，兼容现有代码

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -287,3 +287,34 @@ export const hasTomlCommonConfigSnippet = (
     normalizeWhitespace(snippetString),
   );
 };
+
+// ========== Codex base_url utils ==========
+
+// 从 Codex 的 TOML 配置文本中提取 base_url（支持单/双引号）
+export const extractCodexBaseUrl = (
+  configText: string | undefined | null,
+): string | undefined => {
+  try {
+    const text = typeof configText === "string" ? configText : "";
+    if (!text) return undefined;
+    const m = text.match(/base_url\s*=\s*(['"])([^'\"]+)\1/);
+    return m && m[2] ? m[2] : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+// 从 Provider 对象中提取 Codex base_url（当 settingsConfig.config 为 TOML 字符串时）
+export const getCodexBaseUrl = (
+  provider: { settingsConfig?: Record<string, any> } | undefined | null,
+): string | undefined => {
+  try {
+    const text =
+      typeof provider?.settingsConfig?.config === "string"
+        ? (provider as any).settingsConfig.config
+        : "";
+    return extractCodexBaseUrl(text);
+  } catch {
+    return undefined;
+  }
+};

--- a/src/utils/vscodeSettings.ts
+++ b/src/utils/vscodeSettings.ts
@@ -1,0 +1,110 @@
+import { applyEdits, modify, parse } from "jsonc-parser";
+
+const fmt = { insertSpaces: true, tabSize: 2, eol: "\n" } as const;
+
+export interface AppliedCheck {
+  hasApiBase: boolean;
+  apiBase?: string;
+  hasPreferredAuthMethod: boolean;
+}
+
+export function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+const isDocEmpty = (s: string) => s.trim().length === 0;
+
+// 检查 settings.json（JSONC 文本）中是否已经应用了我们的键
+export function detectApplied(content: string): AppliedCheck {
+  try {
+    // 允许 JSONC 的宽松解析：jsonc-parser 的 parse 可以直接处理注释
+    const data = parse(content) as any;
+    const apiBase = data?.["chatgpt.apiBase"];
+    const method = data?.["chatgpt.config"]?.preferred_auth_method;
+    return {
+      hasApiBase: typeof apiBase === "string",
+      apiBase,
+      hasPreferredAuthMethod: typeof method === "string",
+    };
+  } catch {
+    return { hasApiBase: false, hasPreferredAuthMethod: false };
+  }
+}
+
+// 生成“清理我们管理的键”后的文本（仅删除我们写入的两个键）
+export function removeManagedKeys(content: string): string {
+  if (isDocEmpty(content)) return content; // 空文档无需删除
+  let out = content;
+  // 删除 chatgpt.apiBase
+  try {
+    out = applyEdits(out, modify(out, ["chatgpt.apiBase"], undefined, { formattingOptions: fmt }));
+  } catch {
+    // 忽略删除失败
+  }
+  // 删除 chatgpt.config.preferred_auth_method（注意 chatgpt.config 是顶层带点的键）
+  try {
+    out = applyEdits(
+      out,
+      modify(out, ["chatgpt.config", "preferred_auth_method"], undefined, {
+        formattingOptions: fmt,
+      }),
+    );
+  } catch {
+    // 忽略删除失败
+  }
+
+  // 兼容早期错误写入：若曾写成嵌套 chatgpt.config.preferred_auth_method，也一并清理
+  try {
+    out = applyEdits(
+      out,
+      modify(out, ["chatgpt", "config", "preferred_auth_method"], undefined, {
+        formattingOptions: fmt,
+      }),
+    );
+  } catch {
+    // 忽略删除失败
+  }
+
+  // 若 chatgpt.config 变为空对象，顺便移除（不影响其他 chatgpt* 键）
+  try {
+    const data = parse(out) as any;
+    const cfg = data?.["chatgpt.config"];
+    if (cfg && typeof cfg === "object" && !Array.isArray(cfg) && Object.keys(cfg).length === 0) {
+      out = applyEdits(out, modify(out, ["chatgpt.config"], undefined, { formattingOptions: fmt }));
+    }
+  } catch {
+    // 忽略解析失败，保持已删除的键
+  }
+
+  return out;
+}
+
+// 生成“应用供应商到 VS Code”后的文本：
+// - 先清理我们管理的键
+// - 再根据是否官方决定写入（官方：不写入；非官方：写入两个键）
+export function applyProviderToVSCode(
+  content: string,
+  opts: { baseUrl?: string | null; isOfficial?: boolean },
+): string {
+  let out = removeManagedKeys(content);
+  if (!opts.isOfficial && opts.baseUrl) {
+    const apiBase = normalizeBaseUrl(opts.baseUrl);
+    if (isDocEmpty(out)) {
+      // 简化：空文档直接写入新对象
+      const obj: any = {
+        "chatgpt.apiBase": apiBase,
+        "chatgpt.config": { preferred_auth_method: "apikey" },
+      };
+      out = JSON.stringify(obj, null, 2) + "\n";
+    } else {
+      out = applyEdits(out, modify(out, ["chatgpt.apiBase"], apiBase, { formattingOptions: fmt }));
+      out = applyEdits(
+        out,
+        modify(out, ["chatgpt.config", "preferred_auth_method"], "apikey", {
+          formattingOptions: fmt,
+        }),
+      );
+    }
+  }
+  return out;
+}

--- a/src/utils/vscodeSettings.ts
+++ b/src/utils/vscodeSettings.ts
@@ -37,7 +37,10 @@ export function removeManagedKeys(content: string): string {
   let out = content;
   // 删除 chatgpt.apiBase
   try {
-    out = applyEdits(out, modify(out, ["chatgpt.apiBase"], undefined, { formattingOptions: fmt }));
+    out = applyEdits(
+      out,
+      modify(out, ["chatgpt.apiBase"], undefined, { formattingOptions: fmt }),
+    );
   } catch {
     // 忽略删除失败
   }
@@ -69,8 +72,16 @@ export function removeManagedKeys(content: string): string {
   try {
     const data = parse(out) as any;
     const cfg = data?.["chatgpt.config"];
-    if (cfg && typeof cfg === "object" && !Array.isArray(cfg) && Object.keys(cfg).length === 0) {
-      out = applyEdits(out, modify(out, ["chatgpt.config"], undefined, { formattingOptions: fmt }));
+    if (
+      cfg &&
+      typeof cfg === "object" &&
+      !Array.isArray(cfg) &&
+      Object.keys(cfg).length === 0
+    ) {
+      out = applyEdits(
+        out,
+        modify(out, ["chatgpt.config"], undefined, { formattingOptions: fmt }),
+      );
     }
   } catch {
     // 忽略解析失败，保持已删除的键
@@ -97,7 +108,10 @@ export function applyProviderToVSCode(
       };
       out = JSON.stringify(obj, null, 2) + "\n";
     } else {
-      out = applyEdits(out, modify(out, ["chatgpt.apiBase"], apiBase, { formattingOptions: fmt }));
+      out = applyEdits(
+        out,
+        modify(out, ["chatgpt.apiBase"], apiBase, { formattingOptions: fmt }),
+      );
       out = applyEdits(
         out,
         modify(out, ["chatgpt.config", "preferred_auth_method"], "apikey", {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -40,6 +40,10 @@ declare global {
       checkForUpdates: () => Promise<void>;
       getAppConfigPath: () => Promise<string>;
       openAppConfigFolder: () => Promise<void>;
+      // VS Code settings.json 能力
+      getVSCodeSettingsStatus: () => Promise<ConfigStatus>;
+      readVSCodeSettings: () => Promise<string>;
+      writeVSCodeSettings: (content: string) => Promise<boolean>;
     };
     platform: {
       isMac: boolean;


### PR DESCRIPTION
## VS Code 集成功能增强

 ### 概述

  本 PR 实现了 CC-Switch 与 VS Code 的深度集成功能，允许用户一键将 Codex 提供商配置同步到 VS Code 的 ChatGPT 插件设置中，并支持自动同步功能。

###  主要功能

  1. 一键同步配置到 VS Code

  - 在当前 Codex 提供商卡片上新增"应用到 VS Code"/"从 VS Code 移除"按钮
  - 支持自动检测并配置多个 VS Code 变体（Code、Insiders、VSCodium、OSS）
  - 智能处理官方提供商（如 OpenAI、Anthropic）与自定义 Codex 提供商的不同配置需求

  2. 自动同步机制

  - 实现全局共享的 VS Code 自动同步状态管理（基于 localStorage + 事件广播）
  - 当用户手动点击"应用到 VS Code"后，自动启用同步功能
  - 在系统托盘切换 Codex 提供商时，如果启用了自动同步，会自动更新 VS Code 配置
  - 点击"从 VS Code 移除"会自动禁用同步功能

  3. 跨平台支持

  - 新增 Rust 后端命令，支持跨平台读写 VS Code 的 settings.json
  - 处理 Windows 平台的原子写入问题，确保配置更新的可靠性
  - 正确处理空 settings.json 文件，避免"Cannot delete in empty document"错误

  技术实现

  后端改动

  - src-tauri/src/vscode.rs: 新增 VS Code 配置管理模块，实现跨平台的配置文件检测和读写
  - src-tauri/src/commands.rs: 添加 read_vscode_settings 和 write_vscode_settings 命令
  - 使用 jsonc-parser 依赖处理带注释的 JSON 配置文件

  前端改动

  - src/hooks/useVSCodeAutoSync.ts: 实现自动同步逻辑的自定义 Hook
  - src/utils/vscodeSettings.ts: VS Code 设置管理工具函数
  - src/utils/providerConfigUtils.ts: 提取 Codex base_url 解析为共享工具函数
  - src/components/ProviderList.tsx: 增强提供商列表组件，添加 VS Code 集成按钮和通知
  - src/App.tsx: 集成自动同步逻辑到主应用

  用户体验优化

  - 添加成功/失败的通知提示
  - 防止切换提供商时的布局抖动
  - 官方提供商只清除受管理的配置键，保留用户其他设置
  - 改进错误处理和用户反馈机制

  配置映射

  - Codex base_url → VS Code chatgpt.apiBase
  - Codex auth_type → VS Code chatgpt.config.preferred_auth_method
  - 自动处理 URL 格式转换（如 /v1/chat/completions 后缀）

  测试验证

  - TypeScript 类型检查通过
  - 渲染器构建成功
  - Prettier 代码格式化完成

  依赖变更

  - 新增 jsonc-parser 依赖用于处理 VS Code 的 JSON with Comments 格式