### PR TITLE
  feat: add configurable close button behavior - minimize to tray  or exit app

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:default",
     "opener:default",
     "updater:default",
+    "core:window:allow-set-skip-taskbar",
     "process:allow-restart",
     "dialog:default"
   ]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashMap;
 use tauri::State;
-use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_dialog::DialogExt;
+use tauri_plugin_opener::OpenerExt;
 
 use crate::app_config::AppType;
 use crate::codex_config;
@@ -655,9 +655,8 @@ pub async fn open_app_config_folder(handle: tauri::AppHandle) -> Result<bool, St
 
 /// 获取设置
 #[tauri::command]
-pub async fn get_settings() -> Result<serde_json::Value, String> {
-    serde_json::to_value(crate::settings::get_settings())
-        .map_err(|e| format!("序列化设置失败: {}", e))
+pub async fn get_settings() -> Result<crate::settings::AppSettings, String> {
+    Ok(crate::settings::get_settings())
 }
 
 /// 保存设置
@@ -697,11 +696,17 @@ pub async fn is_portable_mode() -> Result<bool, String> {
 #[tauri::command]
 pub async fn get_vscode_settings_status() -> Result<ConfigStatus, String> {
     if let Some(p) = vscode::find_existing_settings() {
-        Ok(ConfigStatus { exists: true, path: p.to_string_lossy().to_string() })
+        Ok(ConfigStatus {
+            exists: true,
+            path: p.to_string_lossy().to_string(),
+        })
     } else {
         // 默认返回 macOS 稳定版路径（或其他平台首选项的第一个候选），但标记不存在
         let preferred = vscode::candidate_settings_paths().into_iter().next();
-        Ok(ConfigStatus { exists: false, path: preferred.unwrap_or_default().to_string_lossy().to_string() })
+        Ok(ConfigStatus {
+            exists: false,
+            path: preferred.unwrap_or_default().to_string_lossy().to_string(),
+        })
     }
 }
 

--- a/src-tauri/src/vscode.rs
+++ b/src-tauri/src/vscode.rs
@@ -1,12 +1,12 @@
-use std::path::{PathBuf};
+use std::path::PathBuf;
 
 /// 枚举可能的 VS Code 发行版配置目录名称
 fn vscode_product_dirs() -> Vec<&'static str> {
     vec![
-        "Code",           // VS Code Stable
+        "Code",            // VS Code Stable
         "Code - Insiders", // VS Code Insiders
-        "VSCodium",      // VSCodium
-        "Code - OSS",     // OSS 发行版
+        "VSCodium",        // VSCodium
+        "Code - OSS",      // OSS 发行版
     ]
 }
 
@@ -19,7 +19,11 @@ pub fn candidate_settings_paths() -> Vec<PathBuf> {
         if let Some(home) = dirs::home_dir() {
             for prod in vscode_product_dirs() {
                 paths.push(
-                    home.join("Library").join("Application Support").join(prod).join("User").join("settings.json")
+                    home.join("Library")
+                        .join("Application Support")
+                        .join(prod)
+                        .join("User")
+                        .join("settings.json"),
                 );
             }
         }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -25,6 +25,7 @@ interface SettingsModalProps {
 export default function SettingsModal({ onClose }: SettingsModalProps) {
   const [settings, setSettings] = useState<Settings>({
     showInTray: true,
+    minimizeToTrayOnClose: true,
     claudeConfigDir: undefined,
     codexConfigDir: undefined,
   });
@@ -65,8 +66,13 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
         (loadedSettings as any)?.showInTray ??
         (loadedSettings as any)?.showInDock ??
         true;
+      const minimizeToTrayOnClose =
+        (loadedSettings as any)?.minimizeToTrayOnClose ??
+        (loadedSettings as any)?.minimize_to_tray_on_close ??
+        true;
       setSettings({
         showInTray,
+        minimizeToTrayOnClose,
         claudeConfigDir:
           typeof (loadedSettings as any)?.claudeConfigDir === "string"
             ? (loadedSettings as any).claudeConfigDir
@@ -305,26 +311,35 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
 
         {/* 设置内容 */}
         <div className="px-6 py-4 space-y-6">
-          {/* 系统托盘设置（未实现）
-              说明：此开关用于控制是否在系统托盘/菜单栏显示应用图标。 */}
-          {/* <div>
+          {/* 窗口行为设置 */}
+          <div>
             <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">
-              显示设置（系统托盘）
+              窗口行为
             </h3>
-            <label className="flex items-center justify-between">
-              <span className="text-sm text-gray-500">
-                在菜单栏显示图标（系统托盘）
-              </span>
-              <input
-                type="checkbox"
-                checked={settings.showInTray}
-                onChange={(e) =>
-                  setSettings({ ...settings, showInTray: e.target.checked })
-                }
-                className="w-4 h-4 text-blue-500 rounded focus:ring-blue-500/20"
-              />
-            </label>
-          </div> */}
+            <div className="space-y-3">
+              <label className="flex items-center justify-between">
+                <div>
+                  <span className="text-sm text-gray-900 dark:text-gray-100">
+                    关闭时最小化到托盘
+                  </span>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    勾选后点击关闭按钮会隐藏到系统托盘，取消则直接退出应用。
+                  </p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={settings.minimizeToTrayOnClose}
+                  onChange={(e) =>
+                    setSettings((prev) => ({
+                      ...prev,
+                      minimizeToTrayOnClose: e.target.checked,
+                    }))
+                  }
+                  className="w-4 h-4 text-blue-500 rounded focus:ring-blue-500/20"
+                />
+              </label>
+            </div>
+          </div>
 
           {/* VS Code 自动同步设置已移除 */}
 

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -223,7 +223,7 @@ export const tauriAPI = {
       return await invoke("get_settings");
     } catch (error) {
       console.error("获取设置失败:", error);
-      return { showInTray: true };
+      return { showInTray: true, minimizeToTrayOnClose: true };
     }
   },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export interface AppConfig {
 export interface Settings {
   // 是否在系统托盘（macOS 菜单栏）显示图标
   showInTray: boolean;
+  // 点击关闭按钮时是否最小化到托盘而不是关闭应用
+  minimizeToTrayOnClose: boolean;
   // 覆盖 Claude Code 配置目录（可选）
   claudeConfigDir?: string;
   // 覆盖 Codex 配置目录（可选）


### PR DESCRIPTION
## Problem
  On Windows 11, my couldn't close the taskbar window while        
  keeping the app running in system tray - the close button would     
   always exit the entire application.

  ## Solution
  Added a configurable close button behavior setting. Users can       
  now choose between:
  - **Exit app** (default behavior)
  - **Minimize to tray** (new option)

  ## Implementation
  - Added settings toggle for close button behavior
  - Window close events now check user preference before deciding     
   action

  ## Testing
  Tested on Windows 11. Other platforms need verification.

  ## Usage
  Go to Settings → Enable "关闭时最小化到托盘" → Close button now     
   minimizes to tray instead of exiting.