### PR TITLE
feat: support kat-coder & template value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ release/
 .npmrc
 CLAUDE.md
 AGENTS.md
+/.claude

--- a/src/config/providerPresets.ts
+++ b/src/config/providerPresets.ts
@@ -3,6 +3,13 @@
  */
 import { ProviderCategory } from "../types";
 
+export interface TemplateValueConfig {
+  label: string;
+  placeholder: string;
+  defaultValue?: string;
+  editorValue: string;
+}
+
 export interface ProviderPreset {
   name: string;
   websiteUrl: string;
@@ -11,6 +18,8 @@ export interface ProviderPreset {
   settingsConfig: object;
   isOfficial?: boolean; // 标识是否为官方预设
   category?: ProviderCategory; // 新增：分类
+  // 新增：模板变量定义，用于动态替换配置中的值
+  templateValues?: Record<string, TemplateValueConfig>; // editorValue 存储编辑器中的实时输入值
 }
 
 export const providerPresets: ProviderPreset[] = [
@@ -100,5 +109,27 @@ export const providerPresets: ProviderPreset[] = [
       },
     },
     category: "third_party",
+  },
+  {
+    name: "KAT-Coder 官方",
+    websiteUrl: "https://console.streamlake.ai/wanqing/",
+    apiKeyUrl: "https://console.streamlake.ai/console/wanqing/api-key",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://vanchin.streamlake.ai/api/gateway/v1/endpoints/${ENDPOINT_ID}/claude-code-proxy",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "KAT-Coder",
+        ANTHROPIC_SMALL_FAST_MODEL: "KAT-Coder",
+      },
+    },
+    category: "cn_official",
+    templateValues: {
+      ENDPOINT_ID: {
+        label: "Vanchin Endpoint ID",
+        placeholder: "ep-xxx-xxx",
+        defaultValue: "",
+        editorValue: "",
+      },
+    },
   },
 ];


### PR DESCRIPTION
## TLDR

This pull request was authored with the assistance of KAT-Coder, a private beta AI model from `vanchin.streamlake.ai`, in preparation for its upcoming public release.

## Copilot Summary

This pull request introduces support for template variables in provider presets, allowing dynamic configuration values to be defined and edited in the provider form. The main enhancements include defining a template variable system, updating the UI to render and validate these variables, and providing utility functions for applying template values to configuration objects.

**Template Variable System and Provider Preset Enhancements:**

- Added a `templateValues` field to the `ProviderPreset` interface, along with a new `TemplateValueConfig` type to describe template variable metadata and state (such as label, placeholder, default value, and editor value). This enables presets to declare variables that can be dynamically filled by users. [[1]](diffhunk://#diff-036bca9f5d129a504f6d12fdc6d19870d135e9cffbdc9b5330a53fc123e7c77aR6-R12) [[2]](diffhunk://#diff-036bca9f5d129a504f6d12fdc6d19870d135e9cffbdc9b5330a53fc123e7c77aR21-R22)
- Added a new example preset ("KAT-Coder 官方") that demonstrates usage of the template variable system by requiring an `ENDPOINT_ID` variable.

**Provider Form UI and State Management:**

- Updated `ProviderForm.tsx` to:
  - Track template variable values in component state (`templateValues`), initialize them when applying a preset, and reset them on custom mode. [[1]](diffhunk://#diff-01d6176d9dc91dca460be336c227368fd4a7c69e531334e91f4a4bc48c77769bR206-R208) [[2]](diffhunk://#diff-01d6176d9dc91dca460be336c227368fd4a7c69e531334e91f4a4bc48c77769bL532-R707) [[3]](diffhunk://#diff-01d6176d9dc91dca460be336c227368fd4a7c69e531334e91f4a4bc48c77769bR755)
  - Render input fields for template variables when a preset with `templateValues` is selected, and update the provider config in real-time as values change.
  - Validate that all required template variables are filled before allowing save.

**Template Variable Utilities:**

- Implemented utility functions in `providerConfigUtils.ts` for applying template variable values to configuration objects, replacing placeholders like `${ENDPOINT_ID}` with user-provided values.
- Added helper functions in `ProviderForm.tsx` to collect template paths, get/set values at nested paths, and update the config string accordingly.

**Integration and Type Improvements:**

- Updated imports and type usage throughout `ProviderForm.tsx` and utility files to support the new template variable system. [[1]](diffhunk://#diff-01d6176d9dc91dca460be336c227368fd4a7c69e531334e91f4a4bc48c77769bR13-R16) [[2]](diffhunk://#diff-5a2c6d52fc5a9baf81d0e5325a7a30e49c58b100aba1d9684bbd3a5b2271ad8eR3-R4)

These changes collectively enable provider presets to define dynamic, user-editable configuration values, improving flexibility and user experience when adding or customizing providers.