### PR TITLE
feat: update GLM provider model configuration

### DIFF
--- a/src/config/providerPresets.ts
+++ b/src/config/providerPresets.ts
@@ -52,8 +52,9 @@ export const providerPresets: ProviderPreset[] = [
       env: {
         ANTHROPIC_BASE_URL: "https://open.bigmodel.cn/api/anthropic",
         ANTHROPIC_AUTH_TOKEN: "",
-        ANTHROPIC_MODEL: "GLM-4.5",
-        ANTHROPIC_SMALL_FAST_MODEL: "GLM-4.5-Air",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "glm-4.5-air",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "glm-4.6",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "glm-4.6",
       },
     },
     category: "cn_official",


### PR DESCRIPTION
- Update GLM-4.5 to GLM-4.6 as default Sonnet and Opus models
- Use new model naming convention (glm-4.5-air, glm-4.6)
- Align with latest GLM API model naming standards

配置根据官方文档内容更新，[官方文档地址](https://docs.bigmodel.cn/cn/coding-plan/tool/claude#%E5%A6%82%E4%BD%95%E5%88%87%E6%8D%A2%E4%BD%BF%E7%94%A8%E6%A8%A1%E5%9E%8B)