### PR TITLE
feat(provider): add Azure OpenAI gpt-5 codex provider preset

### DIFF
--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -71,6 +71,32 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     },
   },
   {
+    name: "Azure OpenAI (gpt-5-codex)",
+    websiteUrl:
+      "https://learn.microsoft.com/azure/ai-services/openai/how-to/overview",
+    category: "third_party",
+    isOfficial: true,
+    auth: generateThirdPartyAuth(""),
+    config: `model_provider = "azure"
+model = "gpt-5-codex"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.azure]
+name = "Azure OpenAI (gpt-5-codex)"
+base_url = "https://YOUR_RESOURCE_NAME.openai.azure.com/openai"
+env_key = "OPENAI_API_KEY"
+query_params = { "api-version" = "2025-04-01-preview" }
+wire_api = "responses"
+requires_openai_auth = true`,
+    endpointCandidates: ["https://YOUR_RESOURCE_NAME.openai.azure.com/openai"],
+    theme: {
+      icon: "codex",
+      backgroundColor: "#0078D4",
+      textColor: "#FFFFFF",
+    },
+  },
+  {
     name: "AiHubMix",
     websiteUrl: "https://aihubmix.com",
     category: "aggregator",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -63,9 +63,9 @@ try {
 async function bootstrap() {
   // 启动早期主动查询后端初始化错误，避免事件竞态
   try {
-    const initError = (await invoke("get_init_error")) as
-      | ConfigLoadErrorPayload
-      | null;
+    const initError = (await invoke(
+      "get_init_error",
+    )) as ConfigLoadErrorPayload | null;
     if (initError && (initError.path || initError.error)) {
       await handleConfigLoadError(initError);
       // 注意：不会执行到这里，因为 exit(1) 会终止进程


### PR DESCRIPTION
## Summary
  - add a Codex preset for Azure OpenAI gpt-5 with default auth/config metadata

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**