### PR TITLE
fix(ui): sync tray menu order after drag-and-drop sorting

### DIFF
--- a/src/hooks/useDragSort.ts
+++ b/src/hooks/useDragSort.ts
@@ -74,6 +74,8 @@ export function useDragSort(providers: Record<string, Provider>, appId: AppId) {
         await queryClient.invalidateQueries({
           queryKey: ["providers", appId],
         });
+        // 更新托盘菜单以反映新的排序
+        await providersApi.updateTrayMenu();
         toast.success(
           t("provider.sortUpdated", {
             defaultValue: "排序已更新",


### PR DESCRIPTION
The drag-and-drop sorting feature introduced in PR #126 (9eb991d) was updating the provider sort order in the backend and frontend, but failed to update the tray menu to reflect the new order.

Changes:
- Add updateTrayMenu() call after successful sort order update
- Ensures tray menu items are immediately reordered to match the UI

This fixes the issue where dragging providers in the main window would not update their order in the system tray menu.

Fixes: 9eb991d (feat(ui): add drag-and-drop sorting for provider list)