### PR TITLE
fix(password input): disable Edge/IE reveal and clear buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -152,3 +152,9 @@ html.dark ::-webkit-scrollbar-thumb:hover {
     border-color: hsl(var(--primary) / 0.6);
   }
 }
+
+/* 禁用 Edge / IE 的密码显示按钮 */
+input[type="password"]::-ms-reveal,
+input[type="password"]::-ms-clear {
+  display: none;
+}


### PR DESCRIPTION
Hide default password reveal and clear controls in Microsoft browsers for improved consistency and security.

<img width="1120" height="145" alt="Clip_20251116_014337" src="https://github.com/user-attachments/assets/f92fdace-de5e-4b97-bc7f-53650dd21dd1" />

避免密码框出现自带的按钮，造成重复而且很丑