### PR TITLE
docs: Add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Download `CC-Switch-v{version}-macOS.zip` from the [Releases](../../releases) pa
 
 > **Note**: Since the author doesn't have an Apple Developer account, you may see an "unidentified developer" warning on first launch. Please close it first, then go to "System Settings" → "Privacy & Security" → click "Open Anyway", and you'll be able to open it normally afterwards.
 
+### ArchLinux 用户
+
+**Install via paru (Recommended)**
+
+```bash
+paru -S cc-switch-bin
+```
+
 ### Linux Users
 
 Download the latest `CC-Switch-v{version}-Linux.deb` package or `CC-Switch-v{version}-Linux.AppImage` from the [Releases](../../releases) page.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -103,6 +103,14 @@ brew upgrade --cask cc-switch
 
 > **注意**：由于作者没有苹果开发者账号，首次打开可能出现"未知开发者"警告，请先关闭，然后前往"系统设置" → "隐私与安全性" → 点击"仍要打开"，之后便可以正常打开
 
+### ArchLinux 用户
+
+**通过 paru 安装（推荐）**
+
+```bash
+paru -S cc-switch-bin
+```
+
 ### Linux 用户
 
 从 [Releases](../../releases) 页面下载最新版本的 `CC-Switch-v{版本号}-Linux.deb` 包或者 `CC-Switch-v{版本号}-Linux.AppImage` 安装包。


### PR DESCRIPTION
Add installation instructions for Arch Linux via `paru`