### PR TITLE
fix(skills): resolve third-party skills installation failure

### DIFF
--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -62,7 +62,7 @@ pub async fn install_skill(
                 .clone()
                 .unwrap_or_else(|| "main".to_string()),
             enabled: true,
-            skills_path: None, // 安装时使用默认路径
+            skills_path: skill.skills_path.clone(), // 使用技能记录的 skills_path
         };
 
         service

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -10,6 +10,7 @@ export interface Skill {
   repoOwner?: string;
   repoName?: string;
   repoBranch?: string;
+  skillsPath?: string; // 技能所在的子目录路径，如 "skills"
 }
 
 export interface SkillRepo {


### PR DESCRIPTION
- Add skills_path field to Skill struct
- Use skills_path to construct correct source path during installation
- Fix installation for repos with custom skill subdirectories