### PR TITLE
fix(gemini): correct MCP server config format for Gemini CLI

### DIFF
--- a/src-tauri/src/gemini_mcp.rs
+++ b/src-tauri/src/gemini_mcp.rs
@@ -96,7 +96,20 @@ pub fn set_mcp_servers_map(
             obj = server_obj;
         }
 
-        // 移除 UI 辅助字段
+        // Gemini CLI 格式转换：
+        // - Gemini 不使用 "type" 字段（从字段名推断传输类型）
+        // - HTTP 使用 "httpUrl" 字段，SSE 使用 "url" 字段
+        let transport_type = obj.get("type").and_then(|v| v.as_str());
+        if transport_type == Some("http") {
+            // HTTP streaming: 将 "url" 重命名为 "httpUrl"
+            if let Some(url_value) = obj.remove("url") {
+                obj.insert("httpUrl".to_string(), url_value);
+            }
+        }
+        // SSE 保持 "url" 字段不变
+
+        // 移除 UI 辅助字段和 type 字段（Gemini 不需要）
+        obj.remove("type");
         obj.remove("enabled");
         obj.remove("source");
         obj.remove("id");


### PR DESCRIPTION
## Description

This PR fixes MCP servers not being recognized by Gemini CLI due to incorrect configuration format.

Fixes #274

## Problem

The `set_mcp_servers_map()` function was writing MCP server configurations using Claude Code's format, which includes an explicit `"type"` field and uses a unified `"url"` field for both HTTP and SSE transports. However, Gemini CLI uses a different convention where the transport type is inferred from which field is present.

### Before (Incorrect Format)
```json
{
  "mcpServers": {
    "context7": {
      "type": "http",
      "url": "https://mcp.context7.com/mcp",
      "headers": {
        "CONTEXT7_API_KEY": ""
      }
    }
  }
}
```

### After (Correct Format)
```json
{
  "mcpServers": {
    "context7": {
      "httpUrl": "https://mcp.context7.com/mcp",
      "headers": {
        "CONTEXT7_API_KEY": ""
      }
    }
  }
}
```

## Solution

Modified `src-tauri/src/gemini_mcp.rs` (lines 99-120) to transform MCP server configurations according to Gemini CLI's expected format:

1. **Extract transport type** from the `"type"` field before processing
2. **For HTTP servers** (`type: "http"`): Rename `"url"` field to `"httpUrl"`
3. **For SSE servers** (`type: "sse"`): Keep `"url"` field as-is
4. **Remove `"type"` field**: Gemini CLI infers transport from field presence

## References

- [Gemini CLI MCP Server Documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)