### PR TITLE
feat: 为成功弹出提示框增加可关闭按钮

### DIFF
--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -35,7 +35,9 @@ export const useAddProviderMutation = (appId: AppId) => {
       toast.success(
         t("notifications.providerAdded", {
           defaultValue: "供应商已添加",
-        }),
+        }), {
+          closeButton: true
+        }
       );
     },
     onError: (error: Error) => {
@@ -63,7 +65,9 @@ export const useUpdateProviderMutation = (appId: AppId) => {
       toast.success(
         t("notifications.updateSuccess", {
           defaultValue: "供应商更新成功",
-        }),
+        }), {
+          closeButton: true
+        }
       );
     },
     onError: (error: Error) => {
@@ -101,7 +105,9 @@ export const useDeleteProviderMutation = (appId: AppId) => {
       toast.success(
         t("notifications.deleteSuccess", {
           defaultValue: "供应商已删除",
-        }),
+        }), {
+          closeButton: true
+        }
       );
     },
     onError: (error: Error) => {
@@ -140,7 +146,9 @@ export const useSwitchProviderMutation = (appId: AppId) => {
         t("notifications.switchSuccess", {
           defaultValue: "切换供应商成功",
           appName: t(`apps.${appId}`, { defaultValue: appId }),
-        }),
+        }), {
+          closeButton: true
+        }
       );
     },
     onError: (error: Error) => {


### PR DESCRIPTION
<img width="576" height="100" alt="image" src="https://github.com/user-attachments/assets/cbbe881c-5942-48f0-b9da-871be2239734" />

这个成功弹出提示无法手动关闭，有时候会被它硬控好几秒，例如我需要连续切换cc和codex的时候（它会遮挡住 cc 和 codex 的切换按钮）。因此为这类代表成功的弹窗增加了关闭按钮，可以手动快速关闭。