### PR TITLE
fix(usage): 用量查询凭证支持从供应商配置回退

### DIFF
--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -400,15 +400,25 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
             {/* 凭证配置 */}
             {shouldShowCredentialsConfig && (
               <div className="space-y-4">
-                <h4 className="text-sm font-medium text-foreground">
-                  {t("usageScript.credentialsConfig")}
-                </h4>
+                <div className="flex items-start justify-between">
+                  <h4 className="text-sm font-medium text-foreground">
+                    {t("usageScript.credentialsConfig")}
+                  </h4>
+                  <p className="text-xs text-muted-foreground">
+                    {t("usageScript.credentialsHint")}
+                  </p>
+                </div>
 
                 <div className="grid gap-4 md:grid-cols-2">
                   {selectedTemplate === TEMPLATE_KEYS.GENERAL && (
                     <>
                       <div className="space-y-2">
-                        <Label htmlFor="usage-api-key">API Key</Label>
+                        <Label htmlFor="usage-api-key">
+                          API Key{" "}
+                          <span className="text-xs text-muted-foreground font-normal">
+                            ({t("usageScript.optional")})
+                          </span>
+                        </Label>
                         <div className="relative">
                           <Input
                             id="usage-api-key"
@@ -417,7 +427,7 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                             onChange={(e) =>
                               setScript({ ...script, apiKey: e.target.value })
                             }
-                            placeholder="sk-xxxxx"
+                            placeholder={t("usageScript.apiKeyPlaceholder")}
                             autoComplete="off"
                             className="border-white/10"
                           />
@@ -444,7 +454,10 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
 
                       <div className="space-y-2">
                         <Label htmlFor="usage-base-url">
-                          {t("usageScript.baseUrl")}
+                          {t("usageScript.baseUrl")}{" "}
+                          <span className="text-xs text-muted-foreground font-normal">
+                            ({t("usageScript.optional")})
+                          </span>
                         </Label>
                         <Input
                           id="usage-base-url"
@@ -453,7 +466,7 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                           onChange={(e) =>
                             setScript({ ...script, baseUrl: e.target.value })
                           }
-                          placeholder="https://api.example.com"
+                          placeholder={t("usageScript.baseUrlPlaceholder")}
                           autoComplete="off"
                           className="border-white/10"
                         />

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -365,7 +365,10 @@
     "justNow": "Just now",
     "minutesAgo": "{{count}} min ago",
     "hoursAgo": "{{count}} hr ago",
-    "daysAgo": "{{count}} day ago"
+    "daysAgo": "{{count}} day ago",
+    "multiplePlans": "{{count}} plans",
+    "expand": "Expand",
+    "collapse": "Collapse"
   },
   "usageScript": {
     "title": "Configure Usage Query",
@@ -378,6 +381,10 @@
     "templateGeneral": "General",
     "templateNewAPI": "NewAPI",
     "credentialsConfig": "Credentials",
+    "credentialsHint": "Leave empty to use provider config",
+    "optional": "optional",
+    "apiKeyPlaceholder": "Leave empty to use provider's API Key",
+    "baseUrlPlaceholder": "Leave empty to use provider's base URL",
     "baseUrl": "Base URL",
     "accessToken": "Access Token",
     "accessTokenPlaceholder": "Generate in 'Security Settings'",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -365,7 +365,10 @@
     "justNow": "たった今",
     "minutesAgo": "{{count}} 分前",
     "hoursAgo": "{{count}} 時間前",
-    "daysAgo": "{{count}} 日前"
+    "daysAgo": "{{count}} 日前",
+    "multiplePlans": "{{count}} プラン",
+    "expand": "展開",
+    "collapse": "折りたたむ"
   },
   "usageScript": {
     "title": "利用状況を設定",
@@ -378,6 +381,10 @@
     "templateGeneral": "General",
     "templateNewAPI": "NewAPI",
     "credentialsConfig": "認証情報",
+    "credentialsHint": "空欄の場合はプロバイダー設定を使用",
+    "optional": "オプション",
+    "apiKeyPlaceholder": "空欄の場合はプロバイダーの API Key を使用",
+    "baseUrlPlaceholder": "空欄の場合はプロバイダーの Base URL を使用",
     "baseUrl": "Base URL",
     "accessToken": "Access Token",
     "accessTokenPlaceholder": "「Security Settings」で生成",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -365,7 +365,10 @@
     "justNow": "刚刚",
     "minutesAgo": "{{count}} 分钟前",
     "hoursAgo": "{{count}} 小时前",
-    "daysAgo": "{{count}} 天前"
+    "daysAgo": "{{count}} 天前",
+    "multiplePlans": "{{count}} 个套餐",
+    "expand": "展开",
+    "collapse": "收起"
   },
   "usageScript": {
     "title": "配置用量查询",
@@ -378,6 +381,10 @@
     "templateGeneral": "通用模板",
     "templateNewAPI": "NewAPI",
     "credentialsConfig": "凭证配置",
+    "credentialsHint": "留空则自动使用供应商配置",
+    "optional": "可选",
+    "apiKeyPlaceholder": "留空则使用供应商的 API Key",
+    "baseUrlPlaceholder": "留空则使用供应商的请求地址",
     "baseUrl": "请求地址",
     "accessToken": "访问令牌（在个人安全设置里获取）",
     "accessTokenPlaceholder": "在'安全设置'里生成",


### PR DESCRIPTION
### 变更摘要
本 PR 优化了用量查询功能的凭证管理机制，使得用量脚本的 API Key 和 Base URL 配置更加灵活。

### 主要改进
1. 凭证字段支持回退机制
  - API Key 和 Base URL 字段改为可选
  - 留空时自动从供应商配置中提取对应值
2. 多套餐展示优化
  - 当检测到多套餐时，卡片默认显示套餐总数
  - 提供展开/折叠按钮查看完整套餐详情
  - 多套餐情况下自动展开以提升用户体验
3. 界面文案优化
  - 在凭证配置区域添加提示："留空则自动使用供应商配置"
  - 字段标签标注"可选"状态
  - 支持中英日三语
  - 修复用量刷新按钮被启动按钮覆盖的问题

 ### 技术细节
  - 新增 extract_api_key_from_provider 和 extract_base_url_from_provider 辅助函数
  - 优化 query_usage 函数的凭证获取逻辑：优先使用用量脚本配置，其次回退到供应商配置
  - ProviderCard 组件增加展开/折叠状态管理

 ### 相关截图
<img width="896" height="700" alt="image" src="https://github.com/user-attachments/assets/9956fdc6-038d-452a-ae07-d79081315611" />


