### PR TITLE
fix wrong skill repo branch

### DIFF
--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -77,7 +77,7 @@ impl Default for SkillStore {
                 SkillRepo {
                     owner: "ComposioHQ".to_string(),
                     name: "awesome-claude-skills".to_string(),
-                    branch: "main".to_string(),
+                    branch: "master".to_string(),
                     enabled: true,
                 },
                 SkillRepo {


### PR DESCRIPTION
Fix default skill repo `ComposioHQ/awesome-claude-skills` branch(`main`) to `master`. It doesn't have `main` branch, it is `master` actually:  [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills)