### PR TITLE
feat: change the default Qwen BaseUrl

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -125,7 +125,7 @@ export const providerPresets: ProviderPreset[] = [
     settingsConfig: {
       env: {
         ANTHROPIC_BASE_URL:
-          "https://dashscope.aliyuncs.com/api/v2/apps/claude-code-proxy",
+          "https://dashscope.aliyuncs.com/apps/anthropic",
         ANTHROPIC_AUTH_TOKEN: "",
         ANTHROPIC_MODEL: "qwen3-max",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "qwen3-max",


### PR DESCRIPTION
The Qwen Document hai change the default Anthropic BaseUrl

<img width="2920" height="864" alt="image" src="https://github.com/user-attachments/assets/fe53e53a-7785-47af-87fe-3837de18b1a9" />
