### PR TITLE
feat(proxy): update failover timeout and circuit breaker defaults

### DIFF
--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -121,13 +121,13 @@ impl Database {
                     enabled: false,
                     auto_failover_enabled: false,
                     max_retries: 3,
-                    streaming_first_byte_timeout: 30,
-                    streaming_idle_timeout: 60,
-                    non_streaming_timeout: 300,
-                    circuit_failure_threshold: 5,
+                    streaming_first_byte_timeout: 60,
+                    streaming_idle_timeout: 120,
+                    non_streaming_timeout: 600,
+                    circuit_failure_threshold: 4,
                     circuit_success_threshold: 2,
                     circuit_timeout_seconds: 60,
-                    circuit_error_rate_threshold: 0.5,
+                    circuit_error_rate_threshold: 0.6,
                     circuit_min_requests: 10,
                 })
             }
@@ -210,12 +210,12 @@ impl Database {
                         listen_address: row.get(0)?,
                         listen_port: row.get::<_, i32>(1)? as u16,
                         max_retries: row.get::<_, i32>(2)? as u8,
-                        request_timeout: 300, // 废弃字段，返回默认值
+                        request_timeout: 600, // 废弃字段，返回默认值
                         enable_logging: row.get::<_, i32>(3)? != 0,
                         live_takeover_active: false, // 废弃字段
-                        streaming_first_byte_timeout: row.get::<_, i32>(4).unwrap_or(30) as u64,
-                        streaming_idle_timeout: row.get::<_, i32>(5).unwrap_or(60) as u64,
-                        non_streaming_timeout: row.get::<_, i32>(6).unwrap_or(300) as u64,
+                        streaming_first_byte_timeout: row.get::<_, i32>(4).unwrap_or(60) as u64,
+                        streaming_idle_timeout: row.get::<_, i32>(5).unwrap_or(120) as u64,
+                        non_streaming_timeout: row.get::<_, i32>(6).unwrap_or(600) as u64,
                     })
                 },
             )

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -114,10 +114,10 @@ impl Database {
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 5000, enable_logging INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
-            max_retries INTEGER NOT NULL DEFAULT 3, streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 30,
-            streaming_idle_timeout INTEGER NOT NULL DEFAULT 60, non_streaming_timeout INTEGER NOT NULL DEFAULT 300,
-            circuit_failure_threshold INTEGER NOT NULL DEFAULT 5, circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
-            circuit_timeout_seconds INTEGER NOT NULL DEFAULT 60, circuit_error_rate_threshold REAL NOT NULL DEFAULT 0.5,
+            max_retries INTEGER NOT NULL DEFAULT 3, streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60,
+            streaming_idle_timeout INTEGER NOT NULL DEFAULT 120, non_streaming_timeout INTEGER NOT NULL DEFAULT 600,
+            circuit_failure_threshold INTEGER NOT NULL DEFAULT 4, circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
+            circuit_timeout_seconds INTEGER NOT NULL DEFAULT 60, circuit_error_rate_threshold REAL NOT NULL DEFAULT 0.6,
             circuit_min_requests INTEGER NOT NULL DEFAULT 10,
             created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now'))
         )", []).map_err(|e| AppError::Database(e.to_string()))?;
@@ -133,7 +133,7 @@ impl Database {
                 streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
                 circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
                 circuit_error_rate_threshold, circuit_min_requests)
-                VALUES ('claude', 6, 45, 90, 300, 8, 3, 90, 0.6, 15)",
+                VALUES ('claude', 6, 90, 180, 600, 8, 3, 90, 0.7, 15)",
                 [],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -142,7 +142,7 @@ impl Database {
                 streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
                 circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
                 circuit_error_rate_threshold, circuit_min_requests)
-                VALUES ('codex', 3, 30, 60, 300, 5, 2, 60, 0.5, 10)",
+                VALUES ('codex', 3, 60, 120, 600, 4, 2, 60, 0.6, 10)",
                 [],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -151,7 +151,7 @@ impl Database {
                 streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
                 circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
                 circuit_error_rate_threshold, circuit_min_requests)
-                VALUES ('gemini', 5, 30, 60, 300, 5, 2, 60, 0.5, 10)",
+                VALUES ('gemini', 5, 60, 120, 600, 4, 2, 60, 0.6, 10)",
                 [],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -263,15 +263,15 @@ impl Database {
 
         // 尝试添加超时配置列到 proxy_config 表
         let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 30",
+            "ALTER TABLE proxy_config ADD COLUMN streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60",
             [],
         );
         let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN streaming_idle_timeout INTEGER NOT NULL DEFAULT 60",
+            "ALTER TABLE proxy_config ADD COLUMN streaming_idle_timeout INTEGER NOT NULL DEFAULT 120",
             [],
         );
         let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN non_streaming_timeout INTEGER NOT NULL DEFAULT 300",
+            "ALTER TABLE proxy_config ADD COLUMN non_streaming_timeout INTEGER NOT NULL DEFAULT 600",
             [],
         );
 
@@ -482,19 +482,19 @@ impl Database {
                 conn,
                 "proxy_config",
                 "streaming_first_byte_timeout",
-                "INTEGER NOT NULL DEFAULT 30",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_config",
-                "streaming_idle_timeout",
                 "INTEGER NOT NULL DEFAULT 60",
             )?;
             Self::add_column_if_missing(
                 conn,
                 "proxy_config",
+                "streaming_idle_timeout",
+                "INTEGER NOT NULL DEFAULT 120",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_config",
                 "non_streaming_timeout",
-                "INTEGER NOT NULL DEFAULT 300",
+                "INTEGER NOT NULL DEFAULT 600",
             )?;
         }
 
@@ -666,10 +666,10 @@ impl Database {
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 5000, enable_logging INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
-            max_retries INTEGER NOT NULL DEFAULT 3, streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 30,
-            streaming_idle_timeout INTEGER NOT NULL DEFAULT 60, non_streaming_timeout INTEGER NOT NULL DEFAULT 300,
-            circuit_failure_threshold INTEGER NOT NULL DEFAULT 5, circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
-            circuit_timeout_seconds INTEGER NOT NULL DEFAULT 60, circuit_error_rate_threshold REAL NOT NULL DEFAULT 0.5,
+            max_retries INTEGER NOT NULL DEFAULT 3, streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60,
+            streaming_idle_timeout INTEGER NOT NULL DEFAULT 120, non_streaming_timeout INTEGER NOT NULL DEFAULT 600,
+            circuit_failure_threshold INTEGER NOT NULL DEFAULT 4, circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
+            circuit_timeout_seconds INTEGER NOT NULL DEFAULT 60, circuit_error_rate_threshold REAL NOT NULL DEFAULT 0.6,
             circuit_min_requests INTEGER NOT NULL DEFAULT 10,
             created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now'))
         )", [])?;

--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -49,10 +49,10 @@ pub struct CircuitBreakerConfig {
 impl Default for CircuitBreakerConfig {
     fn default() -> Self {
         Self {
-            failure_threshold: 5,
+            failure_threshold: 4,
             success_threshold: 2,
             timeout_seconds: 60,
-            error_rate_threshold: 0.5,
+            error_rate_threshold: 0.6,
             min_requests: 10,
         }
     }

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -28,11 +28,11 @@ pub struct ProxyConfig {
 }
 
 fn default_streaming_first_byte_timeout() -> u64 {
-    30
+    60
 }
 
 fn default_streaming_idle_timeout() -> u64 {
-    60
+    120
 }
 
 fn default_non_streaming_timeout() -> u64 {
@@ -45,11 +45,11 @@ impl Default for ProxyConfig {
             listen_address: "127.0.0.1".to_string(),
             listen_port: 15721, // 使用较少占用的高位端口
             max_retries: 3,
-            request_timeout: 300,
+            request_timeout: 600,
             enable_logging: true,
             live_takeover_active: false,
-            streaming_first_byte_timeout: 30,
-            streaming_idle_timeout: 60,
+            streaming_first_byte_timeout: 60,
+            streaming_idle_timeout: 120,
             non_streaming_timeout: 600,
         }
     }


### PR DESCRIPTION
- Double all timeout values (streaming/non-streaming)
- Codex/Gemini: circuit_failure_threshold 5→4, error_rate 0.5→0.6
- Claude: circuit_error_rate_threshold 0.6→0.7