### PR TITLE
fix(common): improve window dragging area in FullScreenPanel

### DIFF
--- a/src/components/common/FullScreenPanel.tsx
+++ b/src/components/common/FullScreenPanel.tsx
@@ -50,31 +50,44 @@ export const FullScreenPanel: React.FC<FullScreenPanelProps> = ({
           {/* Drag region - match App.tsx */}
           <div
             data-tauri-drag-region
-            style={{
-              WebkitAppRegion: "drag",
-              height: DRAG_BAR_HEIGHT,
-            } as React.CSSProperties}
+            style={
+              {
+                WebkitAppRegion: "drag",
+                height: DRAG_BAR_HEIGHT,
+              } as React.CSSProperties
+            }
           />
 
           {/* Header - match App.tsx */}
           <div
             className="flex-shrink-0 flex items-center"
-            style={{
-              backgroundColor: "hsl(var(--background))",
-              height: HEADER_HEIGHT,
-            }}
+            data-tauri-drag-region
+            style={
+              {
+                WebkitAppRegion: "drag",
+                backgroundColor: "hsl(var(--background))",
+                height: HEADER_HEIGHT,
+              } as React.CSSProperties
+            }
           >
-            <div className="mx-auto max-w-[56rem] px-6 w-full flex items-center gap-4">
+            <div
+              className="mx-auto max-w-[56rem] px-6 w-full flex items-center gap-4"
+              data-tauri-drag-region
+              style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+            >
               <Button
                 type="button"
                 variant="outline"
                 size="icon"
                 onClick={onClose}
-                className="rounded-lg"
+                className="rounded-lg select-none"
+                style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
               >
                 <ArrowLeft className="h-4 w-4" />
               </Button>
-              <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+              <h2 className="text-lg font-semibold text-foreground select-none">
+                {title}
+              </h2>
             </div>
           </div>
 


### PR DESCRIPTION
Add data-tauri-drag-region and WebkitAppRegion styles to header area to match App.tsx behavior, ensuring proper window dragging on macOS.

**Before:**
The draggable area at the top of the **Edit Provider** page was too small; the title bar could not be used to drag the window.

**After:**
The top draggable area of the **Edit Provider** page is now consistent with the main window, allowing the window to be dragged easily.


https://github.com/user-attachments/assets/4e52a016-be32-47c2-801c-7f2ec095bdbe

