### PR TITLE
fix(flatpak): bundle libayatana-appindicator for tray icon support

### DIFF
--- a/flatpak/com.ccswitch.desktop.yml
+++ b/flatpak/com.ccswitch.desktop.yml
@@ -22,6 +22,50 @@ finish-args:
   - --filesystem=home
 
 modules:
+  # Required for tray icon support
+  - name: libayatana-ido
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_TESTS=NO
+    sources:
+      - type: git
+        url: https://github.com/AyatanaIndicators/ayatana-ido.git
+        tag: 0.10.4
+
+  - name: libdbusmenu-gtk3
+    buildsystem: autotools
+    build-options:
+      cflags: -Wno-error
+    config-opts:
+      - --with-gtk=3
+      - --disable-dumper
+      - --disable-static
+      - --enable-tests=no
+    sources:
+      - type: archive
+        url: https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz
+        sha256: b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a
+
+  - name: libayatana-indicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_TESTS=NO
+      - -DENABLE_IDO=YES
+    sources:
+      - type: git
+        url: https://github.com/AyatanaIndicators/libayatana-indicator.git
+        tag: 0.9.4
+
+  - name: libayatana-appindicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_BINDINGS_MONO=NO
+      - -DENABLE_BINDINGS_VALA=NO
+    sources:
+      - type: git
+        url: https://github.com/AyatanaIndicators/libayatana-appindicator.git
+        tag: 0.5.93
+
   - name: cc-switch
     buildsystem: simple
     sources:


### PR DESCRIPTION
## Summary
- Fixes Flatpak crash on startup due to missing `libayatana-appindicator3` library
- Bundles required appindicator dependencies in the Flatpak manifest

## Problem
The Flatpak was panicking on launch with:
```
Failed to load ayatana-appindicator3 or appindicator3 dynamic library
libayatana-appindicator3.so.1: cannot open shared object file
```

This happens because `org.gnome.Platform` runtime doesn't include the appindicator library.

## Solution
Added the following modules to `flatpak/com.ccswitch.desktop.yml`:
- `libayatana-ido` - Ayatana indicator display objects
- `libdbusmenu-gtk3` - DBus menu library for GTK3
- `libayatana-indicator` - Ayatana indicator library  
- `libayatana-appindicator` - The appindicator library required by Tauri tray-icon

These are built and bundled inside the Flatpak sandbox so the tray icon works correctly.