### PR TITLE
<feat>: 添加 fnm 路径支持

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -231,6 +231,19 @@ fn scan_cli_version(tool: &str) -> (Option<String>, Option<String>) {
         search_paths.push(std::path::PathBuf::from("C:\\Program Files\\nodejs"));
     }
 
+    // 添加 fnm 路径支持
+    let fnm_base = home.join(".local/state/fnm_multishells");
+    if fnm_base.exists() {
+        if let Ok(entries) = std::fs::read_dir(&fnm_base) {
+            for entry in entries.flatten() {
+                let bin_path = entry.path().join("bin");
+                if bin_path.exists() {
+                    search_paths.push(bin_path);
+                }
+            }
+        }
+    }
+
     // 扫描 nvm 目录下的所有 node 版本
     let nvm_base = home.join(".nvm/versions/node");
     if nvm_base.exists() {


### PR DESCRIPTION
# 功能：为 CLI 工具检测添加 fnm 支持

## 概述

添加对通过 fnm（Fast Node Manager）安装的 CLI 工具（codex、gemini）的检测支持，以修复“未安装或无法执行”错误。

## 问题

通过 fnm 安装 codex 和 gemini 的用户会遇到“未安装或无法执行”错误，因为当前的工具检测仅扫描传统的 npm 全局路径、nvm 目录和系统路径，但不扫描 fnm 的多壳目录。

## 解决方案

在 `scan_cli_version` 函数中添加 fnm 路径扫描，以检测在 `~/.local/state/fnm_multishells/*/bin` 目录中安装的工具。

## 修改内容

### 修改的文件

- `src-tauri/src/commands/misc.rs`

- 在 `scan_cli_version` 函数中添加 fnm 路径支持

- 扫描 `~/.local/state/fnm_multishells/` 目录下的所有会话

- 保持与现有路径扫描逻辑的兼容性

### 代码更改

```rust

// 添加 fnm 路径支持

let fnm_base = home.join(".local/state/fnm_multishells");

if fnm_base.exists() {

if let Ok(entries) = std::fs::read_dir(&fnm_base) {

for entry in entries.flatten() {

let bin_path = entry.path().join("bin");

if bin_path.exists() {

search_paths.push(bin_path);

}

}

}

}

```

## 测试

- ✅ 验证 codex 和 gemini 工具存在于 `~/.local/state/fnm_multishells/78677_1767939954344/bin/`

- ✅ 确认工具可以正确执行：`codex-cli 0.79.0`，`gemini 0.23.0`

- ✅ 修改的代码正确地将 fnm 路径添加到搜索列表

- ✅ 保持与现有路径扫描的向后兼容性

## 兼容性

- ✅ 与现有的 npm 全局、nvm 和系统路径检测向后兼容

- ✅ 对现有功能没有破坏性更改

- ✅ fnm 路径扫描是附加的

## 环境

- OS：macOS

- fnm 版本：1.38.1

- 受影响的工具：codex，gemini

- 安装方法：fnm 多壳

## 备注

此更改有助于使用 fnm 进行 Node.js 版本管理和全局包安装的用户，fnm 是 nvm 的流行替代品，具有更好的性能和更干净的壳集成。