### PR TITLE
fix(mcp): skip cmd /c wrapper for WSL target paths

### DIFF
--- a/src-tauri/src/claude_mcp.rs
+++ b/src-tauri/src/claude_mcp.rs
@@ -65,6 +65,28 @@ fn wrap_command_for_windows(_obj: &mut Map<String, Value>) {
     // 非 Windows 平台不做任何处理
 }
 
+/// 检测路径是否为 WSL 网络路径（如 \\wsl$\Ubuntu\... 或 \\wsl.localhost\Ubuntu\...）
+/// WSL 环境运行的是 Linux，不需要 cmd /c 包装
+#[cfg(windows)]
+fn is_wsl_path(path: &Path) -> bool {
+    use std::path::{Component, Prefix};
+    path.components().any(|c| match c {
+        Component::Prefix(prefix) => match prefix.kind() {
+            Prefix::UNC(server, _) | Prefix::VerbatimUNC(server, _) => {
+                let s = server.to_string_lossy();
+                s.eq_ignore_ascii_case("wsl$") || s.eq_ignore_ascii_case("wsl.localhost")
+            }
+            _ => false,
+        },
+        _ => false,
+    })
+}
+
+#[cfg(not(windows))]
+fn is_wsl_path(_path: &Path) -> bool {
+    false
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpStatus {
@@ -371,6 +393,8 @@ pub fn set_mcp_servers_map(
     };
 
     // 构建 mcpServers 对象：移除 UI 辅助字段（enabled/source），仅保留实际 MCP 规范
+    // 检测目标路径是否为 WSL，若是则跳过 cmd /c 包装
+    let skip_cmd_wrap = is_wsl_path(&path);
     let mut out: Map<String, Value> = Map::new();
     for (id, spec) in servers.iter() {
         let mut obj = if let Some(map) = spec.as_object() {
@@ -397,8 +421,10 @@ pub fn set_mcp_servers_map(
         obj.remove("homepage");
         obj.remove("docs");
 
-        // Windows 平台自动包装 npx/npm 等命令为 cmd /c 格式
-        wrap_command_for_windows(&mut obj);
+        // Windows 平台自动包装 npx/npm 等命令为 cmd /c 格式（WSL 路径除外）
+        if !skip_cmd_wrap {
+            wrap_command_for_windows(&mut obj);
+        }
 
         out.insert(id.clone(), Value::Object(obj));
     }
@@ -543,6 +569,70 @@ mod tests {
         {
             assert_eq!(obj["command"], "cmd");
             assert_eq!(obj["args"], json!(["/c", "NPX", "-y", "foo"]));
+        }
+    }
+
+    /// 测试 WSL 路径检测功能
+    #[test]
+    fn test_is_wsl_path_wsl_dollar() {
+        // wsl$ 格式 - 各种发行版
+        #[cfg(windows)]
+        {
+            assert!(is_wsl_path(Path::new(r"\\wsl$\Ubuntu\home\user\.claude")));
+            assert!(is_wsl_path(Path::new(r"\\wsl$\Debian\home\user\.claude")));
+            assert!(is_wsl_path(Path::new(
+                r"\\wsl$\openSUSE-Leap-15.2\home\user"
+            )));
+            assert!(is_wsl_path(Path::new(r"\\wsl$\kali-linux\home\user")));
+            assert!(is_wsl_path(Path::new(r"\\wsl$\Arch\home\user")));
+            assert!(is_wsl_path(Path::new(r"\\wsl$\Alpine\home\user")));
+            assert!(is_wsl_path(Path::new(r"\\wsl$\Fedora\home\user")));
+        }
+
+        #[cfg(not(windows))]
+        {
+            // 非 Windows 平台始终返回 false
+            assert!(!is_wsl_path(Path::new(r"\\wsl$\Ubuntu\home\user\.claude")));
+        }
+    }
+
+    #[test]
+    fn test_is_wsl_path_wsl_localhost() {
+        // wsl.localhost 格式
+        #[cfg(windows)]
+        {
+            assert!(is_wsl_path(Path::new(
+                r"\\wsl.localhost\Ubuntu\home\user\.claude"
+            )));
+            assert!(is_wsl_path(Path::new(r"\\wsl.localhost\Debian\home\user")));
+            assert!(is_wsl_path(Path::new(
+                r"\\wsl.localhost\openSUSE-Leap-15.2\home\user"
+            )));
+        }
+    }
+
+    #[test]
+    fn test_is_wsl_path_case_insensitive() {
+        // 大小写不敏感
+        #[cfg(windows)]
+        {
+            assert!(is_wsl_path(Path::new(r"\\WSL$\Ubuntu\home\user")));
+            assert!(is_wsl_path(Path::new(r"\\Wsl$\Ubuntu\home\user")));
+            assert!(is_wsl_path(Path::new(r"\\WSL.LOCALHOST\Ubuntu\home\user")));
+            assert!(is_wsl_path(Path::new(r"\\Wsl.Localhost\Ubuntu\home\user")));
+        }
+    }
+
+    #[test]
+    fn test_is_wsl_path_non_wsl() {
+        // 非 WSL 路径
+        assert!(!is_wsl_path(Path::new(r"C:\Users\user\.claude")));
+        assert!(!is_wsl_path(Path::new(r"D:\Workspace\project")));
+        #[cfg(windows)]
+        {
+            assert!(!is_wsl_path(Path::new(r"\\server\share\path")));
+            assert!(!is_wsl_path(Path::new(r"\\localhost\c$\Users")));
+            assert!(!is_wsl_path(Path::new(r"\\192.168.1.1\share")));
         }
     }
 }

--- a/src-tauri/src/claude_mcp.rs
+++ b/src-tauri/src/claude_mcp.rs
@@ -395,6 +395,9 @@ pub fn set_mcp_servers_map(
     // 构建 mcpServers 对象：移除 UI 辅助字段（enabled/source），仅保留实际 MCP 规范
     // 检测目标路径是否为 WSL，若是则跳过 cmd /c 包装
     let skip_cmd_wrap = is_wsl_path(&path);
+    if skip_cmd_wrap {
+        log::info!("检测到 WSL 路径，跳过 cmd /c 包装: {}", path.display());
+    }
     let mut out: Map<String, Value> = Map::new();
     for (id, spec) in servers.iter() {
         let mut obj = if let Some(map) = spec.as_object() {


### PR DESCRIPTION
Fixes unintended behavior introduced in v3.9.0/v3.9.1 from #453 (also reported in #557)

## Background

- #453 reported that Claude Code `/doctor` shows warnings about missing `cmd /c` wrapper for npx/npm commands on Windows
- v3.9.1 added automatic `cmd /c` wrapping for MCP export to fix this warning
- However, when the Claude config directory is set to a WSL network path (e.g., `\wsl$\Ubuntu\home\user\.claude`), the `cmd /c` wrapper breaks MCP server connections because WSL runs Linux

## Problem

```bash
$ claude mcp list
context7-wrap: cmd /c npx -y @upstash/context7-mcp - ✗ Failed to connect
context7-no-wrap: npx -y @upstash/context7-mcp - ✓ Connected
```

## Solution

- Add `is_wsl_path()` to detect WSL network paths (`\wsl$\` and `\wsl.localhost\`)
- Skip `wrap_command_for_windows()` when target config path is a WSL path
- Add debug logging when WSL path is detected

## Changes

- Add `is_wsl_path()` function using `std::path::Component::Prefix` for robust UNC path detection
- Modify `set_mcp_servers_map()` to check target path before wrapping
- Add comprehensive tests for various WSL distributions (Ubuntu, Debian, Arch, Fedora, etc.)

## Limitations

- Only detects direct UNC paths; mapped drive letters (e.g., `Z:` → `\wsl$\...`) cannot be detected