### PR TITLE
fix(windows): stabilize test environment

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,18 @@
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+
+    #[cfg(target_os = "windows")]
+    {
+        let manifest_path = std::path::PathBuf::from(
+            std::env::var("CARGO_MANIFEST_DIR").expect("missing CARGO_MANIFEST_DIR"),
+        )
+        .join("common-controls.manifest");
+        let manifest_arg = format!("/MANIFESTINPUT:{}", manifest_path.display());
+
+        println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+        println!("cargo:rustc-link-arg={}", manifest_arg);
+        // Avoid duplicate manifest resources in binary builds.
+        println!("cargo:rustc-link-arg-bins=/MANIFEST:NO");
+        println!("cargo:rerun-if-changed={}", manifest_path.display());
+    }
 }

--- a/src-tauri/common-controls.manifest
+++ b/src-tauri/common-controls.manifest
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"/>
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -11,6 +11,13 @@ use std::path::Path;
 
 /// 获取用户主目录，带回退和日志
 fn get_home_dir() -> PathBuf {
+    #[cfg(windows)]
+    if let Ok(home) = std::env::var("HOME") {
+        let trimmed = home.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
     dirs::home_dir().unwrap_or_else(|| {
         log::warn!("无法获取用户主目录，回退到当前目录");
         PathBuf::from(".")

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -7,6 +8,13 @@ use crate::error::AppError;
 
 /// 获取用户主目录，带回退和日志
 fn get_home_dir() -> PathBuf {
+    #[cfg(windows)]
+    if let Ok(home) = env::var("HOME") {
+        let trimmed = home.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
     dirs::home_dir().unwrap_or_else(|| {
         log::warn!("无法获取用户主目录，回退到当前目录");
         PathBuf::from(".")
@@ -71,10 +79,7 @@ pub fn get_app_config_dir() -> PathBuf {
     if let Some(custom) = crate::app_store::get_app_config_dir_override() {
         return custom;
     }
-
-    dirs::home_dir()
-        .expect("无法获取用户主目录")
-        .join(".cc-switch")
+    get_home_dir().join(".cc-switch")
 }
 
 /// 获取应用配置文件路径

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::env;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -9,7 +8,7 @@ use crate::error::AppError;
 /// 获取用户主目录，带回退和日志
 fn get_home_dir() -> PathBuf {
     #[cfg(windows)]
-    if let Ok(home) = env::var("HOME") {
+    if let Ok(home) = std::env::var("HOME") {
         let trimmed = home.trim();
         if !trimmed.is_empty() {
             return PathBuf::from(trimmed);

--- a/src-tauri/src/gemini_config.rs
+++ b/src-tauri/src/gemini_config.rs
@@ -7,6 +7,13 @@ use std::path::PathBuf;
 
 /// 获取用户主目录，带回退和日志
 fn get_home_dir() -> PathBuf {
+    #[cfg(windows)]
+    if let Ok(home) = std::env::var("HOME") {
+        let trimmed = home.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
     dirs::home_dir().unwrap_or_else(|| {
         log::warn!("无法获取用户主目录，回退到当前目录");
         PathBuf::from(".")

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -101,6 +101,17 @@ impl Default for AppSettings {
 impl AppSettings {
     fn settings_path() -> Option<PathBuf> {
         // settings.json 保留用于旧版本迁移和无数据库场景
+        #[cfg(windows)]
+        if let Ok(home) = std::env::var("HOME") {
+            let trimmed = home.trim();
+            if !trimmed.is_empty() {
+                return Some(
+                    PathBuf::from(trimmed)
+                        .join(".cc-switch")
+                        .join("settings.json"),
+                );
+            }
+        }
         dirs::home_dir().map(|h| h.join(".cc-switch").join("settings.json"))
     }
 


### PR DESCRIPTION
﻿This PR addresses Windows-specific development and testing failures, and the impact on typical end users should be minimal.

## Background

On Windows, `cargo test` failed before most tests even ran: the test binaries could not start (e.g., `STATUS_ENTRYPOINT_NOT_FOUND`). After investigation, the root cause was missing manifests in the test binaries. 

Additionally, we observed other Windows-specific issues during testing, including HOME-based test isolation not being honored and invalid-path behavior differences in `export_sql_returns_error_for_invalid_path()` test.

## Problem

- **Windows test binaries miss the manifest**: `tauri::test` mocks produce test executables that do not carry the Common Controls v6 manifest (it is linked into main bins only), so the loader fails with `STATUS_ENTRYPOINT_NOT_FOUND`.
- **HOME-based test isolation is ignored on Windows**: tests set `$HOME` to a temp directory, but `dirs::home_dir()` resolves to `{FOLDERID_Profile}` on Windows, so config paths still point to the real user profile and pollute tests.
- **The invalid-path export test is Unix-centric**: `/nonexistent/directory` is not guaranteed to be invalid on Windows, so the expected error path can succeed and fail the test.

## Solution

1. Embed a Common Controls manifest for Windows test binaries (workaround via `build.rs`).
   - Add `common-controls.manifest` and pass it via `/MANIFEST:EMBED` + `/MANIFESTINPUT`.
   - Disable the default manifest for main bins to avoid duplicate resources.
2. On Windows, prefer `$HOME` when it is explicitly set so test isolation works as intended.
   - Apply this in home-dir helpers and settings path resolution.
   - Fall back to `dirs::home_dir()` when `$HOME` is unset/empty.
3. Use a guaranteed invalid Windows directory name in the invalid-path test.
   - Use illegal characters like `<` or `>` to force an error on Windows.

## Changes

1. Windows test binaries missing manifest
   - `src-tauri/build.rs`
   - `src-tauri/common-controls.manifest`
2. Windows HOME-based test isolation
   - `src-tauri/src/config.rs`
   - `src-tauri/src/codex_config.rs`
   - `src-tauri/src/gemini_config.rs`
   - `src-tauri/src/settings.rs`
   - `src-tauri/tests/support.rs`
3. Windows-specific invalid-path export test
   - `src-tauri/tests/import_export_sync.rs`

## Limitations

- Cross-platform testing on Linux and macOS is still needed.
- If users set `$HOME` on Windows to a path that differs from `{FOLDERID_Profile}`, behavior may diverge and cause unexpected issues.

## References

- https://github.com/tauri-apps/tauri/issues/13419#issuecomment-3398457618
- https://docs.rs/dirs/latest/dirs/fn.home_dir.html


