### PR TITLE
fix(provider): fix stale data shown when reopening edit dialog after save

### DIFF
--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -117,6 +117,7 @@ export function EditProviderDialog({
       iconColor: provider.iconColor,
     };
   }, [
+    open, // 修复：编辑保存后再次打开显示旧数据，依赖 open 确保每次打开时重新读取最新 provider 数据
     provider?.id, // 只依赖 ID，provider 对象更新不会触发重新计算
     initialSettingsConfig,
     // 注意：不依赖 provider 的其他字段，防止表单重置


### PR DESCRIPTION
## 🐛 问题描述 (Problem Description)

编辑供应商并保存后，再次打开编辑对话框时，显示的是旧数据而非刚保存的最新数据。

When editing a provider and saving changes, reopening the edit dialog shows old data instead of the updated data that was just saved.

**复现步骤 (Steps to Reproduce):**
1. 编辑某个供应商并修改字段（如名称、API Key 等）/ Edit a provider and modify fields (e.g., name, API key)
2. 保存更改 / Save changes
3. 返回主列表，可以看到修改已生效 / Return to main list, changes are visible
4. 再次点击编辑该供应商 / Click edit on the same provider again
5. ❌ 编辑对话框显示的是修改前的旧数据 / Edit dialog shows old data from before modification

---

## ✨ 解决方案 (Solution)

在 `EditProviderDialog.tsx` 的 `initialData` useMemo 依赖数组中添加 `open`，确保每次打开对话框时重新读取最新的 provider 数据。

Added `open` to the `initialData` useMemo dependencies in `EditProviderDialog.tsx` to ensure latest provider data is read each time the dialog opens.

**核心改动 (Core Change):**
```typescript
const initialData = useMemo(() => {
  // ...
}, [
  open, // 修复：编辑保存后再次打开显示旧数据，依赖 open 确保每次打开时重新读取最新 provider 数据
  provider?.id,
  initialSettingsConfig,
]);
```

**工作原理 (How It Works):**
- 当 `open` 从 `false` → `true` 时，`useMemo` 会重新执行 / When `open` changes from `false` to `true`, `useMemo` re-executes
- 此时读取的是最新的 `provider` 对象数据 / At this point, it reads the latest `provider` object data
- 只依赖 `provider?.id` 而非整个对象，避免编辑期间表单意外重置 / Depends only on `provider?.id` instead of the entire object to avoid unintended form resets during editing

---

## 📊 文件变更 (File Changes)

```
src/components/providers/EditProviderDialog.tsx | +1
Total: 1 file changed, 1 insertion(+)
```

---

## ✅ 测试验证 (Testing)

- [x] 编辑供应商并保存 / Edit provider and save
- [x] 返回列表，验证修改已显示 / Return to list, verify changes are shown
- [x] 再次打开编辑对话框 / Reopen edit dialog
- [x] 确认显示最新数据（不是旧数据）/ Confirm latest data is shown (not old data)
- [x] 验证编辑期间不会意外重置表单 / Verify form doesn't reset unexpectedly during editing

---

## 🔗 相关问题 (Related Issues)

修复了编辑供应商时的数据回显问题，这是一个影响用户体验的 bug。

Fixes the data display issue when editing providers, a bug that affects user experience.