### PR TITLE
fix(settings): correct Gemini default visibility to true

### DIFF
--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -31,7 +31,7 @@ export function AppVisibilitySettings({
   const visibleApps: VisibleApps = settings.visibleApps ?? {
     claude: true,
     codex: true,
-    gemini: false,
+    gemini: true,
     opencode: true,
   };
 


### PR DESCRIPTION
## Summary

修复首次安装时 Gemini 默认不显示在主页面的问题。

## Problem

首次安装应用时，主页面的应用显示设置中：
- ✅ Claude - 默认显示
- ✅ Codex - 默认显示  
- ❌ **Gemini - 默认隐藏**（应该显示）
- ✅ OpenCode - 默认显示


## Root Cause

前端组件 `AppVisibilitySettings.tsx` 中的 fallback 默认值与后端 `settings.rs` 不一致：

**前端 (错误):**
```typescript
// src/components/settings/AppVisibilitySettings.tsx:31-36
const visibleApps: VisibleApps = settings.visibleApps ?? {
  claude: true,
  codex: true,
  gemini: false,  // ❌ 错误
  opencode: true,
};
```

**后端 (正确):**
```rust
// src-tauri/src/settings.rs:38-47
impl Default for VisibleApps {
    fn default() -> Self {
        Self {
            claude: true,
            codex: true,
            gemini: true,  // ✅ 正确
            opencode: true,
        }
    }
}
```

首次安装时 `settings.visibleApps` 为 `undefined`（尚未保存过设置），前端组件使用了错误的 fallback 值，导致 Gemini 默认隐藏。

## Changes

- `src/components/settings/AppVisibilitySettings.tsx`: 将 `gemini: false` 改为 `gemini: true`，与后端默认值保持一致

## Test plan

- [x] 清除 `~/.cc-switch/settings.json` 或全新安装
- [x] 启动应用，验证主页面四个应用（Claude、Codex、Gemini、OpenCode）全部显示
- [x] 打开设置页面，验证"主页面显示"中四个应用按钮全部处于选中状态

Fixes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)