### PR TITLE
fix(stream_check): respect auth_mode for Claude health checks

### DIFF
--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -876,7 +876,13 @@ mod tests {
             .await
             .unwrap_err();
         // AppError::localized returns AppError::Localized variant
-        assert!(matches!(err, AppError::Localized { key: "error.invalidMultiplier", .. }));
+        assert!(matches!(
+            err,
+            AppError::Localized {
+                key: "error.invalidMultiplier",
+                ..
+            }
+        ));
 
         Ok(())
     }
@@ -897,7 +903,13 @@ mod tests {
             .await
             .unwrap_err();
         // AppError::localized returns AppError::Localized variant
-        assert!(matches!(err, AppError::Localized { key: "error.invalidPricingMode", .. }));
+        assert!(matches!(
+            err,
+            AppError::Localized {
+                key: "error.invalidPricingMode",
+                ..
+            }
+        ));
 
         Ok(())
     }

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use crate::app_config::AppType;
 use crate::error::AppError;
 use crate::provider::Provider;
-use crate::proxy::providers::{get_adapter, AuthInfo};
+use crate::proxy::providers::{get_adapter, AuthInfo, AuthStrategy};
 
 /// 健康状态枚举
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -303,12 +303,18 @@ impl StreamCheckService {
         let os_name = Self::get_os_name();
         let arch_name = Self::get_arch_name();
 
-        // 严格按照 Claude CLI 请求格式设置 headers
-        let response = client
+        // 根据 auth.strategy 构建认证 headers
+        let mut request_builder = client
             .post(&url)
-            // 认证 headers（双重认证）
-            .header("authorization", format!("Bearer {}", auth.api_key))
-            .header("x-api-key", &auth.api_key)
+            .header("authorization", format!("Bearer {}", auth.api_key));
+
+        // 只有 Anthropic 官方策略才添加 x-api-key
+        if auth.strategy == AuthStrategy::Anthropic {
+            request_builder = request_builder.header("x-api-key", &auth.api_key);
+        }
+
+        // 严格按照 Claude CLI 请求格式设置其他 headers
+        let response = request_builder
             // Anthropic 必需 headers
             .header("anthropic-version", "2023-06-01")
             .header(
@@ -688,5 +694,23 @@ mod tests {
         // 在 x86_64 上应该返回 "x86_64"
         #[cfg(target_arch = "x86_64")]
         assert_eq!(arch_name, "x86_64");
+    }
+
+    #[test]
+    fn test_auth_strategy_imports() {
+        // 验证 AuthStrategy 枚举可以正常使用
+        let anthropic = AuthStrategy::Anthropic;
+        let claude_auth = AuthStrategy::ClaudeAuth;
+        let bearer = AuthStrategy::Bearer;
+
+        // 验证不同的策略是不相等的
+        assert_ne!(anthropic, claude_auth);
+        assert_ne!(anthropic, bearer);
+        assert_ne!(claude_auth, bearer);
+
+        // 验证相同策略是相等的
+        assert_eq!(anthropic, AuthStrategy::Anthropic);
+        assert_eq!(claude_auth, AuthStrategy::ClaudeAuth);
+        assert_eq!(bearer, AuthStrategy::Bearer);
     }
 }


### PR DESCRIPTION
## 概述

修复了 `stream_check` 服务中 Claude 健康检查功能,使其正确遵从 provider 的 `auth_mode` 配置。

## 问题

之前 `check_claude_stream` 函数硬编码了 Anthropic 官方的双重认证方式(`Authorization` + `x-api-key`),即使 provider 配置了 `auth_mode: "bearer_only"`,仍然会发送 `x-api-key` header。这导致某些只支持 Bearer 认证的中转服务健康检查失败。

## 解决方案

修改 `check_claude_stream` 函数,根据 `auth.strategy` 字段决定是否添加 `x-api-key` header:
- `AuthStrategy::Anthropic`: 添加 `Authorization` + `x-api-key`
- `AuthStrategy::ClaudeAuth`: 仅添加 `Authorization`
- `AuthStrategy::Bearer`: 仅添加 `Authorization`

## 修改内容

### 代码修改
- `src-tauri/src/services/stream_check.rs`:
  - 导入 `AuthStrategy` 枚举
  - 使用条件判断:只有 `AuthStrategy::Anthropic` 时才添加 `x-api-key`
  - 添加 `test_auth_strategy_imports` 测试

- `src-tauri/src/database/dao/proxy.rs`:
  - 代码格式化调整

### 行为变化
| Provider 类型 | auth_mode | AuthStrategy | 发送的 Headers |
|--------------|-----------|--------------|----------------|
| Anthropic 官方 | (默认) | Anthropic | Authorization + x-api-key ✅ |
| 中转服务 | bearer_only | ClaudeAuth | Authorization ✅ |
| OpenRouter | - | Bearer | Authorization ✅ |

## 测试

- ✅ 所有 Rust 测试通过 (stream_check: 7/7)
- ✅ Clippy 检查通过
- ✅ 编译成功

## 兼容性

- ✅ 向后兼容: Anthropic 官方 provider 行为不变
- ✅ 修复中转服务: 现在正确遵从 `auth_mode` 配置
