### PR TITLE
feat(ui): 根据 API 格式动态切换端点提示信息

### DIFF
--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -163,7 +163,11 @@ export function ClaudeFormFields({
           value={baseUrl}
           onChange={onBaseUrlChange}
           placeholder={t("providerForm.apiEndpointPlaceholder")}
-          hint={t("providerForm.apiHint")}
+          hint={
+            apiFormat === "openai_chat"
+              ? t("providerForm.apiHintOAI")
+              : t("providerForm.apiHint")
+          }
           onManageClick={() => onEndpointModalToggle(true)}
         />
       )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -458,6 +458,7 @@
     "fastModelPlaceholder": "e.g., GLM-4.5-Air",
     "modelHint": "💡 Leave blank to use provider's default model",
     "apiHint": "💡 Fill in Claude API compatible service endpoint, avoid trailing slash",
+    "apiHintOAI": "💡 Fill in OpenAI Chat Completions compatible service endpoint, avoid trailing slash",
     "codexApiHint": "💡 Fill in service endpoint compatible with OpenAI Response format",
     "fillSupplierName": "Please fill in provider name",
     "fillConfigContent": "Please fill in configuration content",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -458,6 +458,7 @@
     "fastModelPlaceholder": "例: GLM-4.5-Air",
     "modelHint": "💡 空欄ならプロバイダーのデフォルトモデルを使用します",
     "apiHint": "💡 Claude API 互換サービスのエンドポイントを入力してください。末尾にスラッシュを付けないでください",
+    "apiHintOAI": "💡 OpenAI Chat Completions 互換サービスのエンドポイントを入力してください。末尾にスラッシュを付けないでください",
     "codexApiHint": "💡 OpenAI Response 互換のサービスエンドポイントを入力してください",
     "fillSupplierName": "プロバイダー名を入力してください",
     "fillConfigContent": "設定内容を入力してください",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -458,6 +458,7 @@
     "fastModelPlaceholder": "例如: GLM-4.5-Air",
     "modelHint": "💡 留空将使用供应商的默认模型",
     "apiHint": "💡 填写兼容 Claude API 的服务端点地址，不要以斜杠结尾",
+    "apiHintOAI": "💡 填写兼容 OpenAI Chat Completions 的服务端点地址，不要以斜杠结尾",
     "codexApiHint": "💡 填写兼容 OpenAI Response 格式的服务端点地址",
     "fillSupplierName": "请填写供应商名称",
     "fillConfigContent": "请填写配置内容",


### PR DESCRIPTION
## Summary

- 添加 `apiHintOAI` i18n key，用于 OpenAI Chat Completions 格式的端点提示
- 修改 `ClaudeFormFields` 组件，根据 `apiFormat` 动态选择显示的提示信息
- 当 API 格式为 `openai_chat` 时，显示 OAI 格式的端点提示

## Test plan

- [x] 新建自定义供应商，选择 Anthropic Messages 格式，确认端点提示为 Claude API 兼容
- [x] 切换 API 格式为 OpenAI Chat Completions，确认端点提示变为 OAI 兼容
- [x] 切换语言为英文/日文，确认提示信息正确翻译

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)