### PR TITLE
fix: prevent window flicker on silent startup

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,6 +19,7 @@
         "height": 650,
         "minWidth": 900,
         "minHeight": 600,
+        "visible": false,
         "resizable": true,
         "fullscreen": false,
         "center": true

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -6,6 +6,7 @@
         "label": "main",
         "title": "CC Switch",
         "titleBarStyle": "Visible",
+        "visible": false,
         "minWidth": 900,
         "minHeight": 600
       }


### PR DESCRIPTION
修复 tauri 窗口显示时机早于前端渲染完成，
导致短暂的未渲染界面被用户看到而引发的自启动闪屏问题。
