### PR TITLE
feat(codex): 增强模型映射功能并添加请求体字段重写

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -191,6 +191,17 @@ pub struct ProviderProxyConfig {
     pub proxy_password: Option<String>,
 }
 
+/// 请求体重写器配置（用于过滤或覆盖 JSON 字段）
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RequestBodyRewriter {
+    /// 是否启用
+    #[serde(default)]
+    pub enabled: bool,
+    /// 重写规则：key 为字段路径（支持点分隔如 "text.verbosity"），value 为新值（null 表示删除）
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub rules: HashMap<String, Option<Value>>,
+}
+
 /// 供应商元数据
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProviderMeta {
@@ -238,6 +249,9 @@ pub struct ProviderMeta {
     /// Codex 模型映射配置（每个渠道独立配置）
     #[serde(rename = "codexModelMapping", skip_serializing_if = "Option::is_none")]
     pub codex_model_mapping: Option<crate::proxy::codex_model_mapper::CodexModelMappingConfig>,
+    /// 请求体重写器配置（用于过滤或覆盖 JSON 字段）
+    #[serde(rename = "requestBodyRewriter", skip_serializing_if = "Option::is_none")]
+    pub request_body_rewriter: Option<RequestBodyRewriter>,
 }
 
 impl ProviderManager {

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -235,6 +235,9 @@ pub struct ProviderMeta {
     /// - "openai_chat": OpenAI Chat Completions 格式，需要转换
     #[serde(rename = "apiFormat", skip_serializing_if = "Option::is_none")]
     pub api_format: Option<String>,
+    /// Codex 模型映射配置（每个渠道独立配置）
+    #[serde(rename = "codexModelMapping", skip_serializing_if = "Option::is_none")]
+    pub codex_model_mapping: Option<crate::proxy::codex_model_mapper::CodexModelMappingConfig>,
 }
 
 impl ProviderManager {

--- a/src-tauri/src/proxy/codex_model_mapper.rs
+++ b/src-tauri/src/proxy/codex_model_mapper.rs
@@ -1,0 +1,284 @@
+//! Codex 模型映射模块
+//!
+//! 在请求转发前，根据 Provider 配置替换 Codex 请求中的模型名称
+//! 支持简单映射和 effort 组合映射
+
+use crate::provider::Provider;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Codex 模型映射配置
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CodexModelMappingConfig {
+    /// 是否启用模型映射
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// 简单模型映射：请求模型 → 目标模型
+    /// Key: 请求模型ID, Value: 目标模型ID
+    #[serde(default, rename = "modelMap")]
+    pub model_map: HashMap<String, String>,
+
+    /// Effort 组合映射：(模型, effort) → 目标模型
+    /// Key: "模型ID@effort", Value: 目标模型ID
+    /// 例: "gpt-5.2-codex@xhigh" → "gpt-5.2-codex-xhigh"
+    #[serde(default, rename = "effortMap")]
+    pub effort_map: HashMap<String, String>,
+}
+
+impl CodexModelMappingConfig {
+    /// 检查是否有任何映射规则
+    pub fn has_mapping(&self) -> bool {
+        self.enabled && (!self.model_map.is_empty() || !self.effort_map.is_empty())
+    }
+
+    /// 根据模型和effort查找映射
+    ///
+    /// 优先级：
+    /// 1. model_map (简单模型映射) - 匹配模型ID后直接映射，不管有没有 effort
+    /// 2. effort_map (模型+effort 组合) - 更细粒度的覆盖，仅当简单映射未匹配时使用
+    /// 3. 无映射，返回原模型
+    pub fn map_model(&self, original_model: &str, effort: Option<&str>) -> (String, bool) {
+        if !self.enabled {
+            return (original_model.to_string(), false);
+        }
+
+        // 1. 优先尝试简单模型映射
+        if let Some(mapped) = self.model_map.get(original_model) {
+            return (mapped.clone(), true);
+        }
+
+        // 2. 如果简单映射没匹配，尝试 effort 组合映射（更细粒度）
+        if let Some(eff) = effort {
+            let key = format!("{}@{}", original_model, eff);
+            if let Some(mapped) = self.effort_map.get(&key) {
+                return (mapped.clone(), true);
+            }
+        }
+
+        // 3. 无映射
+        (original_model.to_string(), false)
+    }
+}
+
+/// 从 Provider 提取 Codex 模型映射配置
+pub fn extract_mapping_config(provider: &Provider) -> CodexModelMappingConfig {
+    provider
+        .meta
+        .as_ref()
+        .and_then(|m| m.codex_model_mapping.as_ref())
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// 从请求体中提取 effort 值
+pub fn extract_effort(body: &Value) -> Option<String> {
+    body.get("reasoning")
+        .and_then(|r| r.get("effort"))
+        .and_then(|e| e.as_str())
+        .map(String::from)
+}
+
+/// 应用 Codex 模型映射
+///
+/// 返回 (映射后的请求体, 原始模型, 映射后模型)
+pub fn apply_codex_model_mapping(
+    mut body: Value,
+    provider: &Provider,
+) -> (Value, Option<String>, Option<String>) {
+    let mapping = extract_mapping_config(provider);
+
+    // 如果没有配置映射，直接返回
+    if !mapping.has_mapping() {
+        let original = body.get("model").and_then(|m| m.as_str()).map(String::from);
+        return (body, original, None);
+    }
+
+    // 提取原始模型名和 effort
+    let original_model = body.get("model").and_then(|m| m.as_str()).map(String::from);
+    let effort = extract_effort(&body);
+
+    if let Some(ref original) = original_model {
+        let (mapped, did_map) = mapping.map_model(original, effort.as_deref());
+
+        if did_map && mapped != *original {
+            log::debug!("[CodexModelMapper] 模型映射: {original} → {mapped}");
+            body["model"] = serde_json::json!(mapped);
+            return (body, Some(original.clone()), Some(mapped));
+        }
+    }
+
+    (body, original_model, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn create_provider_with_mapping(
+        model_map: HashMap<String, String>,
+        effort_map: HashMap<String, String>,
+    ) -> Provider {
+        use crate::provider::ProviderMeta;
+
+        Provider {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            settings_config: json!({}),
+            website_url: None,
+            category: None,
+            created_at: None,
+            sort_index: None,
+            notes: None,
+            meta: Some(ProviderMeta {
+                codex_model_mapping: Some(CodexModelMappingConfig {
+                    enabled: true,
+                    model_map,
+                    effort_map,
+                }),
+                ..Default::default()
+            }),
+            icon: None,
+            icon_color: None,
+            in_failover_queue: false,
+        }
+    }
+
+    fn create_provider_without_mapping() -> Provider {
+        Provider {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            settings_config: json!({}),
+            website_url: None,
+            category: None,
+            created_at: None,
+            sort_index: None,
+            notes: None,
+            meta: None,
+            icon: None,
+            icon_color: None,
+            in_failover_queue: false,
+        }
+    }
+
+    #[test]
+    fn test_simple_model_mapping() {
+        let mut model_map = HashMap::new();
+        model_map.insert("gpt-5.2-codex".to_string(), "gpt-5.2-custom".to_string());
+
+        let provider = create_provider_with_mapping(model_map, HashMap::new());
+        let body = json!({"model": "gpt-5.2-codex"});
+
+        let (result, original, mapped) = apply_codex_model_mapping(body, &provider);
+
+        assert_eq!(result["model"], "gpt-5.2-custom");
+        assert_eq!(original, Some("gpt-5.2-codex".to_string()));
+        assert_eq!(mapped, Some("gpt-5.2-custom".to_string()));
+    }
+
+    #[test]
+    fn test_effort_mapping() {
+        let mut effort_map = HashMap::new();
+        effort_map.insert(
+            "gpt-5.2-codex@xhigh".to_string(),
+            "gpt-5.2-codex-xhigh".to_string(),
+        );
+
+        let provider = create_provider_with_mapping(HashMap::new(), effort_map);
+        let body = json!({
+            "model": "gpt-5.2-codex",
+            "reasoning": {"effort": "xhigh", "summary": "auto"}
+        });
+
+        let (result, original, mapped) = apply_codex_model_mapping(body, &provider);
+
+        assert_eq!(result["model"], "gpt-5.2-codex-xhigh");
+        assert_eq!(original, Some("gpt-5.2-codex".to_string()));
+        assert_eq!(mapped, Some("gpt-5.2-codex-xhigh".to_string()));
+        // 验证 reasoning.effort 被保留
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+    }
+
+    #[test]
+    fn test_effort_mapping_priority_over_simple() {
+        let mut model_map = HashMap::new();
+        model_map.insert("gpt-5.2-codex".to_string(), "simple-mapped".to_string());
+
+        let mut effort_map = HashMap::new();
+        effort_map.insert("gpt-5.2-codex@xhigh".to_string(), "effort-mapped".to_string());
+
+        let provider = create_provider_with_mapping(model_map, effort_map);
+        let body = json!({
+            "model": "gpt-5.2-codex",
+            "reasoning": {"effort": "xhigh"}
+        });
+
+        let (result, _, mapped) = apply_codex_model_mapping(body, &provider);
+
+        // effort 映射应该优先
+        assert_eq!(result["model"], "effort-mapped");
+        assert_eq!(mapped, Some("effort-mapped".to_string()));
+    }
+
+    #[test]
+    fn test_fallback_to_simple_mapping_when_effort_not_matched() {
+        let mut model_map = HashMap::new();
+        model_map.insert("gpt-5.2-codex".to_string(), "simple-mapped".to_string());
+
+        let mut effort_map = HashMap::new();
+        effort_map.insert("gpt-5.2-codex@xhigh".to_string(), "effort-mapped".to_string());
+
+        let provider = create_provider_with_mapping(model_map, effort_map);
+        let body = json!({
+            "model": "gpt-5.2-codex",
+            "reasoning": {"effort": "high"}  // 不匹配 xhigh
+        });
+
+        let (result, _, mapped) = apply_codex_model_mapping(body, &provider);
+
+        // 应该 fallback 到简单映射
+        assert_eq!(result["model"], "simple-mapped");
+        assert_eq!(mapped, Some("simple-mapped".to_string()));
+    }
+
+    #[test]
+    fn test_no_mapping_configured() {
+        let provider = create_provider_without_mapping();
+        let body = json!({"model": "gpt-5.2-codex"});
+
+        let (result, original, mapped) = apply_codex_model_mapping(body, &provider);
+
+        assert_eq!(result["model"], "gpt-5.2-codex");
+        assert_eq!(original, Some("gpt-5.2-codex".to_string()));
+        assert!(mapped.is_none());
+    }
+
+    #[test]
+    fn test_disabled_mapping() {
+        let mut model_map = HashMap::new();
+        model_map.insert("gpt-5.2-codex".to_string(), "mapped".to_string());
+
+        let config = CodexModelMappingConfig {
+            enabled: false,
+            model_map,
+            effort_map: HashMap::new(),
+        };
+
+        let (mapped, did_map) = config.map_model("gpt-5.2-codex", None);
+        assert_eq!(mapped, "gpt-5.2-codex");
+        assert!(!did_map);
+    }
+
+    #[test]
+    fn test_extract_effort() {
+        let body = json!({
+            "reasoning": {"effort": "xhigh", "summary": "auto"}
+        });
+        assert_eq!(extract_effort(&body), Some("xhigh".to_string()));
+
+        let body_no_effort = json!({"model": "test"});
+        assert_eq!(extract_effort(&body_no_effort), None);
+    }
+}

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -571,9 +571,14 @@ impl RequestForwarder {
         // 使用适配器构建 URL
         let url = adapter.build_url(&base_url, effective_endpoint);
 
-        // 应用模型映射（独立于格式转换）
-        let (mapped_body, _original_model, _mapped_model) =
-            super::model_mapper::apply_model_mapping(body.clone(), provider);
+        // 应用模型映射（根据适配器类型选择不同的映射器）
+        let (mapped_body, _original_model, _mapped_model) = if adapter.name() == "Codex" {
+            // Codex 使用专用映射器，支持 effort 组合映射
+            super::codex_model_mapper::apply_codex_model_mapping(body.clone(), provider)
+        } else {
+            // Claude 和其他使用原有映射器
+            super::model_mapper::apply_model_mapping(body.clone(), provider)
+        };
 
         // 转换请求体（如果需要）
         let request_body = if needs_transform {

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -15,6 +15,7 @@ mod health;
 pub mod http_client;
 pub mod log_codes;
 pub mod model_mapper;
+pub mod codex_model_mapper;
 pub mod provider_router;
 pub mod providers;
 pub mod response_handler;

--- a/src/components/providers/forms/CodexModelMappingConfig.tsx
+++ b/src/components/providers/forms/CodexModelMappingConfig.tsx
@@ -1,0 +1,457 @@
+import { useTranslation } from "react-i18next";
+import { useState, useEffect, useRef } from "react";
+import { ChevronDown, ChevronRight, ArrowRightLeft, Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+/** Codex 模型映射配置 */
+export interface CodexModelMappingConfig {
+  enabled: boolean;
+  /** 简单模型映射：请求模型 → 目标模型 */
+  modelMap: Record<string, string>;
+  /** Effort 组合映射：模型ID@effort → 目标模型 */
+  effortMap: Record<string, string>;
+}
+
+/** 默认配置 */
+export const defaultCodexModelMappingConfig: CodexModelMappingConfig = {
+  enabled: false,
+  modelMap: {},
+  effortMap: {},
+};
+
+interface CodexModelMappingConfigProps {
+  config: CodexModelMappingConfig;
+  onConfigChange: (config: CodexModelMappingConfig) => void;
+}
+
+/** effort 选项 */
+const EFFORT_OPTIONS = ["low", "medium", "high", "xhigh"];
+
+/** 简单映射行类型 */
+interface SimpleMappingRow {
+  id: string;
+  source: string;
+  target: string;
+  isNew: boolean;
+}
+
+/** Effort 映射行类型 */
+interface EffortMappingRow {
+  id: string;
+  model: string;
+  effort: string;
+  target: string;
+  isNew: boolean;
+}
+
+export function CodexModelMappingConfig({
+  config,
+  onConfigChange,
+}: CodexModelMappingConfigProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(config.enabled);
+
+  // 将 config 转换为行数据
+  const [simpleRows, setSimpleRows] = useState<SimpleMappingRow[]>([]);
+  const [effortRows, setEffortRows] = useState<EffortMappingRow[]>([]);
+
+  // Refs for auto-focus
+  const simpleInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+  const effortInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+
+  // 从 config 初始化行数据
+  // 从 config 初始化 Simple 行数据
+  useEffect(() => {
+    const existingSimple: SimpleMappingRow[] = Object.entries(config.modelMap).map(
+      ([source, target]) => ({
+        id: `simple-${source}`,
+        source,
+        target,
+        isNew: false,
+      })
+    );
+    // 只有当本地没有正在编辑的新行时，或者 config 确实发生了变化（这里简单处理，直接覆盖，但移除了自动添加空行的逻辑）
+    // 为了防止正在输入的行被 config 更新覆盖（如果 config 没变），我们理想情况应该做比较。
+    // 但鉴于目前逻辑是：只有 valid 这里才会 update config，所以 config 中永远只有 valid rows。
+    // 如果我们移除了自动添加空行，useEffect 将只显示 valid rows。
+    // 用户点击 Add -> 本地有了新行 -> config 没变 -> useEffect 没触发 -> 新行保留。
+    // 用户填完 -> config 变了 -> useEffect 触发 -> 重置为 config 内容（包含新行）-> 新行状态变非 isNew。正确。
+    // 唯一问题：如果用户填了一半，config 没变，但 modelMap 引用变了？
+    // 通常 parent 会 ensure stable object if deep equal, or we rely on React rendering.
+    setSimpleRows(existingSimple);
+  }, [config.modelMap]);
+
+  // 从 config 初始化 Effort 行数据
+  useEffect(() => {
+    const existingEffort: EffortMappingRow[] = Object.entries(config.effortMap).map(
+      ([key, target]) => {
+        const [model, effort] = key.split("@");
+        return {
+          id: `effort-${key}`,
+          model,
+          effort: effort || "medium",
+          target,
+          isNew: false,
+        };
+      }
+    );
+    setEffortRows(existingEffort);
+  }, [config.effortMap]);
+
+  // 同步 enabled 状态
+  useEffect(() => {
+    setIsOpen(config.enabled);
+  }, [config.enabled]);
+
+  // 更新简单映射行
+  const handleSimpleRowChange = (
+    id: string,
+    field: "source" | "target",
+    value: string
+  ) => {
+    setSimpleRows((prev) => {
+      const updated = prev.map((row) =>
+        row.id === id ? { ...row, [field]: value } : row
+      );
+      // 同步到 config
+      syncSimpleToConfig(updated);
+      return updated;
+    });
+  };
+
+  // 同步简单映射到 config
+  const syncSimpleToConfig = (rows: SimpleMappingRow[]) => {
+    const newModelMap: Record<string, string> = {};
+    rows.forEach((row) => {
+      if (row.source.trim() && row.target.trim()) {
+        newModelMap[row.source.trim()] = row.target.trim();
+      }
+    });
+    if (JSON.stringify(newModelMap) !== JSON.stringify(config.modelMap)) {
+      onConfigChange({ ...config, modelMap: newModelMap });
+    }
+  };
+
+  // 添加简单映射新行
+  const handleAddSimpleRow = () => {
+    const newId = `simple-new-${Date.now()}`;
+    const newRow: SimpleMappingRow = {
+      id: newId,
+      source: "",
+      target: "",
+      isNew: true,
+    };
+    setSimpleRows((prev) => [...prev, newRow]);
+    // Auto-focus
+    setTimeout(() => {
+      simpleInputRefs.current.get(newId)?.focus();
+    }, 50);
+  };
+
+  // 删除简单映射行
+  const handleRemoveSimpleRow = (id: string) => {
+    setSimpleRows((prev) => {
+      const updated = prev.filter((row) => row.id !== id);
+      syncSimpleToConfig(updated);
+      return updated;
+    });
+  };
+
+  // 更新 effort 映射行
+  const handleEffortRowChange = (
+    id: string,
+    field: "model" | "effort" | "target",
+    value: string
+  ) => {
+    setEffortRows((prev) => {
+      const updated = prev.map((row) =>
+        row.id === id ? { ...row, [field]: value } : row
+      );
+      syncEffortToConfig(updated);
+      return updated;
+    });
+  };
+
+  // 同步 effort 映射到 config
+  const syncEffortToConfig = (rows: EffortMappingRow[]) => {
+    const newEffortMap: Record<string, string> = {};
+    rows.forEach((row) => {
+      if (row.model.trim() && row.target.trim()) {
+        const key = `${row.model.trim()}@${row.effort}`;
+        newEffortMap[key] = row.target.trim();
+      }
+    });
+    if (JSON.stringify(newEffortMap) !== JSON.stringify(config.effortMap)) {
+      onConfigChange({ ...config, effortMap: newEffortMap });
+    }
+  };
+
+  // 添加 effort 映射新行
+  const handleAddEffortRow = () => {
+    const newId = `effort-new-${Date.now()}`;
+    const newRow: EffortMappingRow = {
+      id: newId,
+      model: "",
+      effort: "medium",
+      target: "",
+      isNew: true,
+    };
+    setEffortRows((prev) => [...prev, newRow]);
+    setTimeout(() => {
+      effortInputRefs.current.get(newId)?.focus();
+    }, 50);
+  };
+
+  // 删除 effort 映射行
+  const handleRemoveEffortRow = (id: string) => {
+    setEffortRows((prev) => {
+      const updated = prev.filter((row) => row.id !== id);
+      syncEffortToConfig(updated);
+      return updated;
+    });
+  };
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-muted/20">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between p-4 hover:bg-muted/30 transition-colors"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex items-center gap-3">
+          <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium">
+            {t("providerAdvanced.codexModelMapping", {
+              defaultValue: "Codex 模型映射",
+            })}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <div
+            className="flex items-center gap-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Label
+              htmlFor="codex-mapping-enabled"
+              className="text-sm text-muted-foreground"
+            >
+              {t("providerAdvanced.enableMapping", {
+                defaultValue: "启用映射",
+              })}
+            </Label>
+            <Switch
+              id="codex-mapping-enabled"
+              checked={config.enabled}
+              onCheckedChange={(checked) => {
+                onConfigChange({ ...config, enabled: checked });
+                if (checked) setIsOpen(true);
+              }}
+            />
+          </div>
+          {isOpen ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-300 ease-in-out",
+          isOpen ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0"
+        )}
+      >
+        <div className="border-t border-border/50 p-4 space-y-6">
+          <p className="text-sm text-muted-foreground">
+            {t("providerAdvanced.codexModelMappingDesc", {
+              defaultValue:
+                "为 Codex 请求配置模型ID映射，支持简单映射和 effort 组合映射。",
+            })}
+          </p>
+
+          {/* 简单模型映射 */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">
+              {t("providerAdvanced.simpleModelMapping", {
+                defaultValue: "简单模型映射",
+              })}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t("providerAdvanced.simpleModelMappingHint", {
+                defaultValue: "将请求中的模型ID替换为目标模型ID（优先级最高）",
+              })}
+            </p>
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleAddSimpleRow}
+                disabled={!config.enabled}
+                className="h-8"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                {t("common.add", { defaultValue: "添加" })}
+              </Button>
+            </div>
+
+            {/* 映射行列表 */}
+            <div className="space-y-2">
+              {simpleRows.map((row) => (
+                <div
+                  key={row.id}
+                  className="flex items-center gap-2"
+                >
+                  <Input
+                    ref={(el) => {
+                      if (el) simpleInputRefs.current.set(row.id, el);
+                    }}
+                    placeholder={t("providerAdvanced.sourceModel", {
+                      defaultValue: "请求模型",
+                    })}
+                    value={row.source}
+                    onChange={(e) =>
+                      handleSimpleRowChange(row.id, "source", e.target.value)
+                    }
+                    className="flex-1 font-mono text-sm transition-colors duration-200"
+                    disabled={!config.enabled}
+                  />
+                  <span className="text-muted-foreground">→</span>
+                  <Input
+                    placeholder={t("providerAdvanced.targetModel", {
+                      defaultValue: "目标模型",
+                    })}
+                    value={row.target}
+                    onChange={(e) =>
+                      handleSimpleRowChange(row.id, "target", e.target.value)
+                    }
+                    className="flex-1 font-mono text-sm transition-colors duration-200"
+                    disabled={!config.enabled}
+                  />
+                  {/* 删除按钮 - 总是显示，除非只有一个空行（可选，但这里我们允许删除所有行，或者保持至少一行空的逻辑在 handleRemove 处理） */}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemoveSimpleRow(row.id)}
+                    disabled={!config.enabled}
+                    className="transition-opacity duration-200 hover:bg-destructive/10"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Effort 组合映射 */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">
+              {t("providerAdvanced.effortModelMapping", {
+                defaultValue: "Effort 组合映射",
+              })}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t("providerAdvanced.effortModelMappingHint", {
+                defaultValue:
+                  "当请求同时匹配模型ID和 reasoning.effort 时，替换为目标模型ID（仅当简单映射未匹配时生效）",
+              })}
+            </p>
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleAddEffortRow}
+                disabled={!config.enabled}
+                className="h-8"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                {t("common.add", { defaultValue: "添加" })}
+              </Button>
+            </div>
+
+            {/* 映射行列表 */}
+            <div className="space-y-2">
+              {effortRows.map((row) => (
+                <div
+                  key={row.id}
+                  className="flex items-center gap-2"
+                >
+                  <Input
+                    ref={(el) => {
+                      if (el) effortInputRefs.current.set(row.id, el);
+                    }}
+                    placeholder={t("providerAdvanced.sourceModel", {
+                      defaultValue: "请求模型",
+                    })}
+                    value={row.model}
+                    onChange={(e) =>
+                      handleEffortRowChange(row.id, "model", e.target.value)
+                    }
+                    className="flex-1 font-mono text-sm transition-colors duration-200"
+                    disabled={!config.enabled}
+                  />
+                  <span className="text-muted-foreground">@</span>
+                  <Select
+                    value={row.effort}
+                    onValueChange={(value) =>
+                      handleEffortRowChange(row.id, "effort", value)
+                    }
+                    disabled={!config.enabled}
+                  >
+                    <SelectTrigger className="w-24 transition-colors duration-200">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {EFFORT_OPTIONS.map((opt) => (
+                        <SelectItem key={opt} value={opt}>
+                          {opt}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <span className="text-muted-foreground">→</span>
+                  <Input
+                    placeholder={t("providerAdvanced.targetModel", {
+                      defaultValue: "目标模型",
+                    })}
+                    value={row.target}
+                    onChange={(e) =>
+                      handleEffortRowChange(row.id, "target", e.target.value)
+                    }
+                    className="flex-1 font-mono text-sm transition-colors duration-200"
+                    disabled={!config.enabled}
+                  />
+                  {/* 删除按钮 */}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemoveEffortRow(row.id)}
+                    disabled={!config.enabled}
+                    className="transition-opacity duration-200 hover:bg-destructive/10"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -52,6 +52,11 @@ import {
   type PricingModelSourceOption,
 } from "./ProviderAdvancedConfig";
 import {
+  CodexModelMappingConfig,
+  defaultCodexModelMappingConfig,
+  type CodexModelMappingConfig as CodexModelMappingConfigType,
+} from "./CodexModelMappingConfig";
+import {
   useProviderCategory,
   useApiKeyState,
   useBaseUrlState,
@@ -98,10 +103,10 @@ const OPENCODE_DEFAULT_CONFIG = JSON.stringify(
 type PresetEntry = {
   id: string;
   preset:
-    | ProviderPreset
-    | CodexProviderPreset
-    | GeminiProviderPreset
-    | OpenCodeProviderPreset;
+  | ProviderPreset
+  | CodexProviderPreset
+  | GeminiProviderPreset
+  | OpenCodeProviderPreset;
 };
 
 interface ProviderFormProps {
@@ -188,6 +193,13 @@ export function ProviderForm({
       initialData?.meta?.pricingModelSource,
     ),
   }));
+
+  // Codex 模型映射配置状态
+  const [codexModelMapping, setCodexModelMapping] =
+    useState<CodexModelMappingConfigType>(() => {
+      if (appId !== "codex") return defaultCodexModelMappingConfig;
+      return initialData?.meta?.codexModelMapping ?? defaultCodexModelMappingConfig;
+    });
 
   // 使用 category hook
   const { category } = useProviderCategory({
@@ -943,6 +955,11 @@ export function ProviderForm({
         appId === "claude" && category !== "official"
           ? localApiFormat
           : undefined,
+      // Codex 模型映射配置（仅 Codex 供应商使用）
+      codexModelMapping:
+        appId === "codex" && codexModelMapping.enabled
+          ? codexModelMapping
+          : undefined,
     };
 
     onSubmit(payload);
@@ -1214,8 +1231,8 @@ export function ProviderForm({
                   className={
                     (existingOpencodeKeys.includes(opencodeProviderKey) &&
                       !isEditMode) ||
-                    (opencodeProviderKey.trim() !== "" &&
-                      !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(opencodeProviderKey))
+                      (opencodeProviderKey.trim() !== "" &&
+                        !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(opencodeProviderKey))
                       ? "border-destructive"
                       : ""
                   }
@@ -1495,6 +1512,14 @@ export function ProviderForm({
           onProxyConfigChange={setProxyConfig}
           onPricingConfigChange={setPricingConfig}
         />
+
+        {/* Codex 模型映射配置 */}
+        {appId === "codex" && (
+          <CodexModelMappingConfig
+            config={codexModelMapping}
+            onConfigChange={setCodexModelMapping}
+          />
+        )}
 
         {showButtons && (
           <div className="flex justify-end gap-2">

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -57,6 +57,11 @@ import {
   type CodexModelMappingConfig as CodexModelMappingConfigType,
 } from "./CodexModelMappingConfig";
 import {
+  RequestBodyRewriterConfig,
+  defaultRequestBodyRewriterConfig,
+  type RequestBodyRewriterConfig as RequestBodyRewriterConfigType,
+} from "./RequestBodyRewriterConfig";
+import {
   useProviderCategory,
   useApiKeyState,
   useBaseUrlState,
@@ -199,6 +204,13 @@ export function ProviderForm({
     useState<CodexModelMappingConfigType>(() => {
       if (appId !== "codex") return defaultCodexModelMappingConfig;
       return initialData?.meta?.codexModelMapping ?? defaultCodexModelMappingConfig;
+    });
+
+  // 请求体重写器配置状态
+  const [requestBodyRewriter, setRequestBodyRewriter] =
+    useState<RequestBodyRewriterConfigType>(() => {
+      if (appId !== "codex") return defaultRequestBodyRewriterConfig;
+      return initialData?.meta?.requestBodyRewriter ?? defaultRequestBodyRewriterConfig;
     });
 
   // 使用 category hook
@@ -960,6 +972,11 @@ export function ProviderForm({
         appId === "codex" && codexModelMapping.enabled
           ? codexModelMapping
           : undefined,
+      // 请求体重写器配置（仅 Codex 供应商使用）
+      requestBodyRewriter:
+        appId === "codex" && requestBodyRewriter.enabled
+          ? requestBodyRewriter
+          : undefined,
     };
 
     onSubmit(payload);
@@ -1518,6 +1535,14 @@ export function ProviderForm({
           <CodexModelMappingConfig
             config={codexModelMapping}
             onConfigChange={setCodexModelMapping}
+          />
+        )}
+
+        {/* 请求体字段重写器（仅 Codex） */}
+        {appId === "codex" && (
+          <RequestBodyRewriterConfig
+            config={requestBodyRewriter}
+            onConfigChange={setRequestBodyRewriter}
           />
         )}
 

--- a/src/components/providers/forms/RequestBodyRewriterConfig.tsx
+++ b/src/components/providers/forms/RequestBodyRewriterConfig.tsx
@@ -1,0 +1,256 @@
+import { useTranslation } from "react-i18next";
+import { useState, useRef } from "react";
+import { ChevronDown, ChevronRight, Filter, Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+
+/** 请求体重写器配置 */
+export interface RequestBodyRewriterConfig {
+    enabled: boolean;
+    /** 重写规则：key 为字段路径，value 为新值（null = 删除） */
+    rules: Record<string, any>;
+}
+
+/** 默认配置 */
+export const defaultRequestBodyRewriterConfig: RequestBodyRewriterConfig = {
+    enabled: false,
+    rules: {},
+};
+
+interface RequestBodyRewriterConfigProps {
+    config: RequestBodyRewriterConfig;
+    onConfigChange: (config: RequestBodyRewriterConfig) => void;
+}
+
+/** 规则行类型 */
+interface RuleRow {
+    id: string;
+    path: string;
+    value: string; // JSON 字符串，"null" 表示删除
+}
+
+/** 预设规则 */
+const PRESET_RULES = [
+    { label: "text (删除)", path: "text", value: "null" },
+    { label: "instructions (删除)", path: "instructions", value: "null" },
+    { label: "text.verbosity (删除)", path: "text.verbosity", value: "null" },
+];
+
+let rowIdCounter = 0;
+
+export function RequestBodyRewriterConfig({
+    config,
+    onConfigChange,
+}: RequestBodyRewriterConfigProps) {
+    const { t } = useTranslation();
+    const [isOpen, setIsOpen] = useState(config.enabled);
+    const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+
+    // 从 config 初始化行数据（仅在首次渲染时，无默认空行）
+    const [rows, setRows] = useState<RuleRow[]>(() => {
+        return Object.entries(config.rules || {}).map(
+            ([path, value], index) => ({
+                id: `initial-${index}`,
+                path,
+                value: value === null ? "null" : JSON.stringify(value),
+            })
+        );
+    });
+
+    // 同步到 config
+    const syncToConfig = (newRows: RuleRow[]) => {
+        const rules: Record<string, any> = {};
+        for (const row of newRows) {
+            if (row.path.trim()) {
+                try {
+                    rules[row.path.trim()] = JSON.parse(row.value);
+                } catch {
+                    // 无效 JSON，视为字符串
+                    rules[row.path.trim()] = row.value === "null" ? null : row.value;
+                }
+            }
+        }
+        onConfigChange({ ...config, rules });
+    };
+
+    // 更新行
+    const handleRowChange = (
+        id: string,
+        field: "path" | "value",
+        value: string
+    ) => {
+        setRows((prev) => {
+            const newRows = prev.map((row) =>
+                row.id === id ? { ...row, [field]: value } : row
+            );
+            // 延迟同步
+            setTimeout(() => syncToConfig(newRows), 0);
+            return newRows;
+        });
+    };
+
+    // 删除行
+    const handleRemoveRow = (id: string) => {
+        setRows((prev) => {
+            const newRows = prev.filter((row) => row.id !== id);
+            syncToConfig(newRows);
+            return newRows;
+        });
+    };
+
+    // 添加空行
+    const handleAddRow = () => {
+        const newRow: RuleRow = {
+            id: `row-${++rowIdCounter}`,
+            path: "",
+            value: "null",
+        };
+        setRows((prev) => [...prev, newRow]);
+        // 延迟聚焦到新行
+        setTimeout(() => {
+            const input = inputRefs.current.get(`${newRow.id}-path`);
+            input?.focus();
+        }, 50);
+    };
+
+    // 添加预设规则
+    const handleAddPreset = (preset: (typeof PRESET_RULES)[0]) => {
+        // 检查是否已存在
+        if (rows.some((r) => r.path === preset.path)) {
+            return;
+        }
+        const newRow: RuleRow = {
+            id: `row-${++rowIdCounter}`,
+            path: preset.path,
+            value: preset.value,
+        };
+        setRows((prev) => {
+            const newRows = [...prev, newRow];
+            syncToConfig(newRows);
+            return newRows;
+        });
+    };
+
+    return (
+        <div className="space-y-3">
+            {/* 标题栏 */}
+            <div
+                className="flex items-center gap-2 cursor-pointer select-none"
+                onClick={() => setIsOpen(!isOpen)}
+            >
+                {isOpen ? (
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                )}
+                <Filter className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">
+                    {t("provider.requestBodyRewriter", "请求体字段重写")}
+                </span>
+                <div className="ml-auto" onClick={(e) => e.stopPropagation()}>
+                    <Switch
+                        checked={config.enabled}
+                        onCheckedChange={(checked) =>
+                            onConfigChange({ ...config, enabled: checked })
+                        }
+                    />
+                </div>
+            </div>
+
+            {/* 配置内容 */}
+            {isOpen && config.enabled && (
+                <div className="pl-6 space-y-3">
+                    {/* 预设按钮和添加按钮 */}
+                    <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-xs text-muted-foreground">
+                            {t("provider.presets", "预设")}:
+                        </span>
+                        {PRESET_RULES.map((preset) => (
+                            <Button
+                                key={preset.path}
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-6 text-xs"
+                                onClick={() => handleAddPreset(preset)}
+                            >
+                                <Plus className="h-3 w-3 mr-1" />
+                                {preset.label}
+                            </Button>
+                        ))}
+                        <div className="ml-auto">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-6 text-xs"
+                                onClick={handleAddRow}
+                            >
+                                <Plus className="h-3 w-3 mr-1" />
+                                {t("common.add", "添加")}
+                            </Button>
+                        </div>
+                    </div>
+
+                    {/* 规则列表 */}
+                    {rows.length > 0 && (
+                        <div className="space-y-2">
+                            <div className="grid grid-cols-[1fr_1fr_32px] gap-2 text-xs text-muted-foreground">
+                                <span>{t("provider.fieldPath", "字段路径")}</span>
+                                <span>{t("provider.newValue", "新值 (null=删除)")}</span>
+                                <span></span>
+                            </div>
+
+                            {rows.map((row) => (
+                                <div
+                                    key={row.id}
+                                    className="grid grid-cols-[1fr_1fr_32px] gap-2 items-center"
+                                >
+                                    <Input
+                                        ref={(el) => {
+                                            if (el) inputRefs.current.set(`${row.id}-path`, el);
+                                        }}
+                                        placeholder="text.verbosity"
+                                        value={row.path}
+                                        onChange={(e) =>
+                                            handleRowChange(row.id, "path", e.target.value)
+                                        }
+                                        className="h-8 text-sm"
+                                    />
+                                    <Textarea
+                                        placeholder='null 或 {"key": "value"}'
+                                        value={row.value}
+                                        onChange={(e) =>
+                                            handleRowChange(row.id, "value", e.target.value)
+                                        }
+                                        className="min-h-[32px] h-8 text-sm font-mono resize-y"
+                                        rows={1}
+                                    />
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-destructive hover:text-destructive"
+                                        onClick={() => handleRemoveRow(row.id)}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* 说明 */}
+                    <p className="text-xs text-muted-foreground">
+                        {t(
+                            "provider.rewriterHelp",
+                            "使用点分隔路径（如 text.verbosity）访问嵌套字段。设为 null 删除字段，其他 JSON 值覆盖。"
+                        )}
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,11 @@ export interface ProviderMeta {
     modelMap: Record<string, string>;
     effortMap: Record<string, string>;
   };
+  // 请求体重写器配置（用于过滤或覆盖 JSON 字段）
+  requestBodyRewriter?: {
+    enabled: boolean;
+    rules: Record<string, any>; // null = 删除, 其他值 = 覆盖
+  };
 }
 
 // Skill 同步方式

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,12 @@ export interface ProviderMeta {
   // - "anthropic": 原生 Anthropic Messages API 格式，直接透传
   // - "openai_chat": OpenAI Chat Completions 格式，需要格式转换
   apiFormat?: "anthropic" | "openai_chat";
+  // Codex 模型映射配置（仅 Codex 供应商使用）
+  codexModelMapping?: {
+    enabled: boolean;
+    modelMap: Record<string, string>;
+    effortMap: Record<string, string>;
+  };
 }
 
 // Skill 同步方式


### PR DESCRIPTION
## 概述

本 PR 为 Codex 供应商增加两项核心功能：**模型映射**和**请求体字段重写**，提升与不同上游 API 的兼容性。

---

## 功能一：Codex 模型映射

允许将 Codex 请求的模型 ID 映射到实际的上游模型，支持两种映射方式：

### 简单映射
- 直接将源模型映射到目标模型
- 例如：`gpt-5` → `gpt-5-turbo`

### Effort 组合映射
- 结合 `reasoning_effort` 参数进行映射
- 例如：`gpt-5.2` + `xhigh` → `gpt-5.2-codex-xhigh`
- 支持的 effort 级别：`low`、`medium`、`high`、`xhigh`

### UI 改进
- 将"添加"按钮移至区块标题右侧
- 移除自动生成的空行，改为手动添加
- 修复输入时焦点丢失问题

---

## 功能二：请求体字段重写

允许用户按供应商配置过滤或覆盖发送到上游 API 的 JSON 字段。

### 功能特性
- **字段删除**：将值设为 `null` 可删除该字段
- **字段覆盖**：支持用任意 JSON 值覆盖现有字段
- **嵌套路径**：使用点分隔路径（如 `text.verbosity`）
- **预设模板**：内置 `text`、`instructions`、`text.verbosity` 预设

### 使用场景
某些上游供应商不支持特定字段（如 `text` 或 `instructions`），启用此功能可自动过滤这些字段，避免请求失败。

---

## 截图

<img width="2000" height="1300" alt="image" src="https://github.com/user-attachments/assets/3edfe1d1-47b4-4bed-8da6-04801f9c6093" />

<img width="1978" height="1052" alt="image" src="https://github.com/user-attachments/assets/17367873-1f27-4378-95bf-572e2fa1fafd" />


<img width="1874" height="864" alt="image" src="https://github.com/user-attachments/assets/b4085d89-5b6e-4c4a-b715-3ab932aa10a9" />
