### PR TITLE
fix(opencode): reject save when no models configured

### DIFF
--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -746,7 +746,7 @@ export function ProviderForm({
       return;
     }
 
-    // OpenCode: validate provider key
+    // OpenCode: validate provider key and models
     if (appId === "opencode") {
       const keyPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
       if (!opencodeProviderKey.trim()) {
@@ -759,6 +759,11 @@ export function ProviderForm({
       }
       if (!isEditMode && existingOpencodeKeys.includes(opencodeProviderKey)) {
         toast.error(t("opencode.providerKeyDuplicate"));
+        return;
+      }
+      // Validate that at least one model is configured
+      if (Object.keys(opencodeModels).length === 0) {
+        toast.error(t("opencode.modelsRequired"));
         return;
       }
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -633,6 +633,7 @@
     "modelId": "Model ID",
     "modelName": "Display Name",
     "noModels": "No models configured",
+    "modelsRequired": "Please add at least one model",
     "providerKey": "Provider Key",
     "providerKeyPlaceholder": "my-provider",
     "providerKeyHint": "Unique identifier in config file. Cannot be changed after creation. Use lowercase letters, numbers, and hyphens only.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -633,6 +633,7 @@
     "modelId": "モデル ID",
     "modelName": "表示名",
     "noModels": "モデルが設定されていません",
+    "modelsRequired": "モデルを少なくとも1つ追加してください",
     "providerKey": "プロバイダーキー",
     "providerKeyPlaceholder": "my-provider",
     "providerKeyHint": "設定ファイルの一意の識別子。作成後は変更できません。小文字、数字、ハイフンのみ使用できます。",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -633,6 +633,7 @@
     "modelId": "模型 ID",
     "modelName": "显示名称",
     "noModels": "暂无模型配置",
+    "modelsRequired": "请至少添加一个模型配置",
     "providerKey": "供应商标识",
     "providerKeyPlaceholder": "my-provider",
     "providerKeyHint": "配置文件中的唯一标识符，创建后无法修改，只能使用小写字母、数字和连字符",


### PR DESCRIPTION
Add validation to require at least one model before saving an OpenCode provider. Shows a localized toast error when models are empty.