### PR TITLE
feat(env): add Volta package manager path detection

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -324,6 +324,7 @@ fn scan_cli_version(tool: &str) -> (Option<String>, Option<String>) {
         home.join(".local/bin"), // Native install (official recommended)
         home.join(".npm-global/bin"),
         home.join("n/bin"), // n version manager
+        home.join(".volta/bin"), // Volta package manager
     ];
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Add ~/.volta/bin to CLI version scanning paths to support tools installed via Volta (claude, codex, gemini, etc.).