### PR TITLE
feat(opencode): add NewAPI auto-fetch models via /v1/models endpoint

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod proxy;
 mod session_manager;
 mod settings;
 pub mod skill;
+mod remote_models;
 mod stream_check;
 mod usage;
 
@@ -33,5 +34,6 @@ pub use proxy::*;
 pub use session_manager::*;
 pub use settings::*;
 pub use skill::*;
+pub use remote_models::*;
 pub use stream_check::*;
 pub use usage::*;

--- a/src-tauri/src/commands/remote_models.rs
+++ b/src-tauri/src/commands/remote_models.rs
@@ -1,0 +1,76 @@
+//! 远程模型列表获取命令
+//!
+//! 通过 /v1/models 接口获取 NewAPI 兼容供应商的可用模型列表。
+
+use crate::proxy::http_client;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteModelInfo {
+    pub id: String,
+    pub owned_by: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiModelsResponse {
+    data: Vec<OpenAiModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiModelEntry {
+    id: String,
+    owned_by: Option<String>,
+}
+
+/// 获取远程模型列表
+///
+/// 调用 `{baseUrl}/v1/models`（若 baseUrl 已以 `/v1` 结尾则用 `{baseUrl}/models`），
+/// 携带 `Authorization: Bearer {apiKey}` 头，解析 OpenAI 标准响应格式。
+#[tauri::command]
+pub async fn fetch_remote_models(
+    base_url: String,
+    api_key: String,
+) -> Result<Vec<RemoteModelInfo>, String> {
+    let base = base_url.trim().trim_end_matches('/');
+    let url = if base.ends_with("/v1") {
+        format!("{base}/models")
+    } else {
+        format!("{base}/v1/models")
+    };
+
+    log::info!("[RemoteModels] Fetching models from: {url}");
+
+    let client = http_client::get();
+    let resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        log::warn!("[RemoteModels] API returned {status}: {body}");
+        return Err(format!("API returned {status}: {body}"));
+    }
+
+    let body: OpenAiModelsResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))?;
+
+    let models: Vec<RemoteModelInfo> = body
+        .data
+        .into_iter()
+        .map(|m| RemoteModelInfo {
+            id: m.id,
+            owned_by: m.owned_by,
+        })
+        .collect();
+
+    log::info!("[RemoteModels] Fetched {} model(s)", models.len());
+    Ok(models)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -958,6 +958,8 @@ pub fn run() {
             commands::scan_local_proxies,
             // Window theme control
             commands::set_window_theme,
+            // Remote models (NewAPI)
+            commands::fetch_remote_models,
         ]);
 
     let app = builder

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -42,6 +42,7 @@ import { CommonConfigEditor } from "./CommonConfigEditor";
 import GeminiConfigEditor from "./GeminiConfigEditor";
 import JsonEditor from "@/components/JsonEditor";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { ProviderPresetSelector } from "./ProviderPresetSelector";
 import { BasicFormFields } from "./BasicFormFields";
 import { ClaudeFormFields } from "./ClaudeFormFields";
@@ -521,6 +522,12 @@ export function ProviderForm({
     );
   }, [opencodeProvidersData?.providers, providerId]);
 
+  // OpenCode: NewAPI 开关状态
+  const [opencodeIsNewApi, setOpencodeIsNewApi] = useState<boolean>(() => {
+    if (appId !== "opencode") return false;
+    return initialData?.meta?.isNewApi ?? false;
+  });
+
   // OpenCode Provider Key state
   const [opencodeProviderKey, setOpencodeProviderKey] = useState<string>(() => {
     if (appId !== "opencode") return "";
@@ -948,6 +955,8 @@ export function ProviderForm({
         appId === "claude" && category !== "official"
           ? localApiFormat
           : undefined,
+      // OpenCode: NewAPI 标记
+      isNewApi: appId === "opencode" ? opencodeIsNewApi : undefined,
     };
 
     onSubmit(payload);
@@ -1062,6 +1071,7 @@ export function ProviderForm({
         setOpencodeApiKey("");
         setOpencodeModels({});
         setOpencodeExtraOptions({});
+        setOpencodeIsNewApi(false);
       }
       return;
     }
@@ -1252,6 +1262,24 @@ export function ProviderForm({
           }
         />
 
+        {/* OpenCode: NewAPI 开关 - 放在 Provider Name 后面 */}
+        {appId === "opencode" && (
+          <div className="flex items-center justify-between rounded-lg border p-3">
+            <div className="space-y-0.5">
+              <Label>NewAPI</Label>
+              <p className="text-xs text-muted-foreground">
+                {t("opencode.newApiHint", {
+                  defaultValue: "启用后可通过 /v1/models 接口自动获取模型列表",
+                })}
+              </p>
+            </div>
+            <Switch
+              checked={opencodeIsNewApi}
+              onCheckedChange={setOpencodeIsNewApi}
+            />
+          </div>
+        )}
+
         {/* Claude 专属字段 */}
         {appId === "claude" && (
           <ClaudeFormFields
@@ -1370,6 +1398,7 @@ export function ProviderForm({
             onModelsChange={handleOpencodeModelsChange}
             extraOptions={opencodeExtraOptions}
             onExtraOptionsChange={handleOpencodeExtraOptionsChange}
+            isNewApi={opencodeIsNewApi}
           />
         )}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -650,7 +650,12 @@
     "noExtraOptions": "No extra options configured",
     "noModelOptions": "Model options, click + to add",
     "modelOptionKeyPlaceholder": "provider",
-    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
+    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}",
+    "newApiHint": "Enable to auto-fetch model list via /v1/models endpoint",
+    "fetchModels": "Fetch Models",
+    "noRemoteModels": "Remote API returned no models",
+    "modelsImported": "Imported {{count}} model(s) ({{total}} total, {{skipped}} skipped as existing)",
+    "fetchModelsFailed": "Failed to fetch models: {{error}}"
   },
   "providerPreset": {
     "label": "Provider Preset",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -650,7 +650,12 @@
     "noExtraOptions": "追加オプションはありません",
     "noModelOptions": "モデルオプション、+ をクリックして追加",
     "modelOptionKeyPlaceholder": "provider",
-    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
+    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}",
+    "newApiHint": "有効にすると /v1/models エンドポイントからモデル一覧を自動取得できます",
+    "fetchModels": "モデルを取得",
+    "noRemoteModels": "リモート API からモデルが返されませんでした",
+    "modelsImported": "{{count}} 件のモデルをインポートしました（全 {{total}} 件、既存 {{skipped}} 件はスキップ）",
+    "fetchModelsFailed": "モデルの取得に失敗しました: {{error}}"
   },
   "providerPreset": {
     "label": "プロバイダータイプ",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -650,7 +650,12 @@
     "noExtraOptions": "暂无额外选项",
     "noModelOptions": "模型选项，点击 + 添加",
     "modelOptionKeyPlaceholder": "provider",
-    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
+    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}",
+    "newApiHint": "启用后可通过 /v1/models 接口自动获取模型列表",
+    "fetchModels": "获取模型",
+    "noRemoteModels": "远程 API 未返回任何模型",
+    "modelsImported": "已导入 {{count}} 个模型（共 {{total}} 个，跳过 {{skipped}} 个已存在）",
+    "fetchModelsFailed": "获取模型失败: {{error}}"
   },
   "providerPreset": {
     "label": "预设供应商",

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -98,6 +98,20 @@ export const providersApi = {
   async getOpenCodeLiveProviderIds(): Promise<string[]> {
     return await invoke("get_opencode_live_provider_ids");
   },
+
+  /**
+   * 通过 /v1/models 接口获取远程模型列表（NewAPI 兼容供应商）
+   * 通过 Rust 后端调用以绕过浏览器 CORS 限制
+   */
+  async fetchRemoteModels(
+    baseUrl: string,
+    apiKey: string,
+  ): Promise<{ id: string; ownedBy: string | null }[]> {
+    if (!(window as any).__TAURI_INTERNALS__) {
+      throw new Error("此功能仅在应用内可用，请在 CC Switch 应用窗口中操作");
+    }
+    return await invoke("fetch_remote_models", { baseUrl, apiKey });
+  },
 };
 
 // ============================================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,8 @@ export interface ProviderMeta {
   // - "anthropic": 原生 Anthropic Messages API 格式，直接透传
   // - "openai_chat": OpenAI Chat Completions 格式，需要格式转换
   apiFormat?: "anthropic" | "openai_chat";
+  // OpenCode: 是否为 NewAPI 兼容供应商（支持 /v1/models 获取模型列表）
+  isNewApi?: boolean;
 }
 
 // Skill 同步方式


### PR DESCRIPTION
## What

Add the ability to automatically fetch available models from NewAPI-compatible OpenCode providers using the standard `/v1/models` endpoint.

### Changes

- **Rust backend**: New `fetch_remote_models` Tauri command that calls `{baseUrl}/v1/models` with Bearer auth via the global HTTP client (bypasses CORS)
- **Frontend**: NewAPI toggle switch after Provider Name field; "Fetch Models" button in the Models section (visible when toggle is on)
- **Behavior**: Fetched models are directly appended to the model list, skipping duplicates
- **Persistence**: `isNewApi` flag saved in `ProviderMeta` for edit-mode restoration

### Files Changed

| File | Change |
|------|--------|
| `src-tauri/src/commands/remote_models.rs` | **New** — async command to fetch `/v1/models` |
| `src-tauri/src/commands/mod.rs` | Register module |
| `src-tauri/src/lib.rs` | Register command in invoke_handler |
| `src/types.ts` | Add `isNewApi` to `ProviderMeta` |
| `src/lib/api/providers.ts` | Add `fetchRemoteModels` API method |
| `src/components/providers/forms/ProviderForm.tsx` | Add NewAPI toggle state + UI |
| `src/components/providers/forms/OpenCodeFormFields.tsx` | Add fetch button + import logic |

---

## 概述

为 OpenCode 供应商表单添加 NewAPI 自动获取模型功能，通过标准 `/v1/models` 接口获取可用模型列表并一键导入。

### 改动内容

- **Rust 后端**：新增 `fetch_remote_models` 命令，通过全局 HTTP 客户端调用 `{baseUrl}/v1/models`（绕过 CORS）
- **前端**：Provider Name 后新增 NewAPI 开关；Models 区域新增"获取模型"按钮（开关开启时显示）
- **行为**：获取到的模型直接追加到模型列表，自动跳过已存在的模型
- **持久化**：`isNewApi` 标记保存在 `ProviderMeta` 中，编辑时自动恢复

### 使用方式

1. 新建/编辑 OpenCode 供应商，填写 Base URL 和 API Key
2. 开启 "NewAPI" 开关

<img width="1992" height="1282" alt="图片" src="https://github.com/user-attachments/assets/b37c5189-613b-46c2-81ae-b507d012f868" />

3. 在 Models 区域点击"获取模型"按钮

<img width="1992" height="1282" alt="图片" src="https://github.com/user-attachments/assets/d9abb31e-0a03-40ca-8522-b27ea21fedb9" />

4. 模型自动导入到列表中