### PR TITLE
fix(linux): 解决白屏 disable WebKitGTK hardware acceleration to prevent white screen

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -746,6 +746,7 @@ dependencies = [
  "tower-http 0.5.2",
  "url",
  "uuid",
+ "webkit2gtk",
  "winreg 0.52.0",
  "zip 2.4.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,9 @@ uuid = { version = "1.11", features = ["v4"] }
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+webkit2gtk = { version = "2.0.1", features = ["v2_16"] }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -745,6 +745,21 @@ pub fn run() {
                 restore_proxy_state_on_startup(&state).await;
             });
 
+            // Linux: 禁用 WebKitGTK 硬件加速，防止 EGL 初始化失败导致白屏
+            #[cfg(target_os = "linux")]
+            {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.with_webview(|webview| {
+                        use webkit2gtk::{WebViewExt, SettingsExt, HardwareAccelerationPolicy};
+                        let wk_webview = webview.inner();
+                        if let Some(settings) = WebViewExt::settings(&wk_webview) {
+                            SettingsExt::set_hardware_acceleration_policy(&settings, HardwareAccelerationPolicy::Never);
+                            log::info!("已禁用 WebKitGTK 硬件加速");
+                        }
+                    });
+                }
+            }
+
             // 静默启动：根据设置决定是否显示主窗口
             let settings = crate::settings::get_settings();
             if let Some(window) = app.get_webview_window("main") {


### PR DESCRIPTION
## Problem

On some Linux systems with AMD GPUs (e.g., AMD Cezanne / Radeon Vega), cc-switch opens with a **white screen**. The WebKitGTK GPU process crashes during EGL initialization:

```
amdgpu_query_info(ACCEL_WORKING) failed (-13)   # EACCES
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

Environment variables like `WEBKIT_DISABLE_DMABUF_RENDERER=1`, `LIBGL_ALWAYS_SOFTWARE=1`, `GDK_BACKEND=x11` etc. do **not** resolve the issue.

## Root Cause

The AMD kernel driver (`amdgpu`) denies the `ACCEL_WORKING` query with `EACCES`, causing Mesa's EGL initialization to fail. WebKitGTK's GPU process then aborts, resulting in a blank white screen.

## Fix

Use WebKitGTK's `set_hardware_acceleration_policy(Never)` API to disable GPU acceleration on Linux at startup, falling back to software rendering. This is applied via Tauri's `with_webview` API.

### Changes

- **`src-tauri/Cargo.toml`**: Added `webkit2gtk` dependency with `v2_16` feature (Linux only)
- **`src-tauri/src/lib.rs`**: Added `#[cfg(target_os = "linux")]` block to disable hardware acceleration on app setup

### Testing

- Tested on CachyOS (Arch-based) with AMD Cezanne GPU, WebKitGTK 2.50.4, Wayland
- EGL error is gone, app renders correctly with software rendering
- No impact on macOS/Windows builds (changes are `cfg`-gated to Linux only)