### PR TITLE
feat(ui): add Teammates mode checkbox to Claude config editor

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -58,7 +58,10 @@
     "extractFromCurrent": "Extract from Editor",
     "extractNoCommonConfig": "No common config available to extract from editor",
     "extractFailed": "Extract failed: {{error}}",
-    "saveFailed": "Save failed: {{error}}"
+    "saveFailed": "Save failed: {{error}}",
+    "hideAttribution": "Hide AI Attribution",
+    "alwaysThinking": "Extended Thinking",
+    "enableTeammates": "Teammates Mode"
   },
   "header": {
     "viewOnGithub": "View on GitHub",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -58,7 +58,10 @@
     "extractFromCurrent": "編集内容から抽出",
     "extractNoCommonConfig": "編集内容から抽出できる共通設定がありません",
     "extractFailed": "抽出に失敗しました: {{error}}",
-    "saveFailed": "保存に失敗しました: {{error}}"
+    "saveFailed": "保存に失敗しました: {{error}}",
+    "hideAttribution": "AI署名を非表示",
+    "alwaysThinking": "拡張思考",
+    "enableTeammates": "Teammates モード"
   },
   "header": {
     "viewOnGithub": "GitHub で見る",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -58,7 +58,10 @@
     "extractFromCurrent": "从编辑内容提取",
     "extractNoCommonConfig": "当前编辑内容没有可提取的通用配置",
     "extractFailed": "提取失败: {{error}}",
-    "saveFailed": "保存失败: {{error}}"
+    "saveFailed": "保存失败: {{error}}",
+    "hideAttribution": "隐藏 AI 署名",
+    "alwaysThinking": "扩展思考",
+    "enableTeammates": "Teammates 模式"
   },
   "header": {
     "viewOnGithub": "在 GitHub 上查看",


### PR DESCRIPTION
## Summary
- Add a "Enable Teammates Mode" checkbox before the config JSON editor in Claude provider settings
- When checked, adds `"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"` to the `env` section
- When unchecked, removes the key from `env`
- Includes i18n support for Chinese, English, and Japanese

## Test plan
- [x] Checkbox toggles correctly and updates JSON editor in real-time
- [x] JSON editor reflects the added/removed env variable
- [x] Unchecking removes the key cleanly
- [x] Invalid JSON in editor does not cause errors when toggling
- [x] Vite build passes with no TypeScript errors
- [x] All three locale files (zh/en/ja) updated