### PR TITLE
Add API `models/`  enumeration  

### DIFF
--- a/docs/claude-proxy-verification-commands.md
+++ b/docs/claude-proxy-verification-commands.md
@@ -1,0 +1,44 @@
+# Claude Proxy Verification Commands
+
+This note records the exact commands used to verify the Claude proxy fixes.
+
+## Rust tests
+
+Run in `src-tauri/`:
+
+```bash
+cargo test openrouter_tools_request_fallbacks_to_default_model --quiet
+cargo test openrouter_non_tools_request_keeps_type_specific_mapping --quiet
+cargo test test_failover_disabled_uses_current_provider --quiet
+cargo test test_failover_disabled_fallbacks_when_current_provider_unroutable --quiet
+cargo test estimate_count_tokens --quiet
+```
+
+## Build and reinstall app
+
+Run in repo root:
+
+```bash
+pnpm build
+pkill -f "/cc-switch" || true
+cp -R "/Users/jim/work/cc-switch/src-tauri/target/release/bundle/macos/CC Switch.app" "/Applications/CC Switch.app"
+open -a "/Applications/CC Switch.app"
+```
+
+## Claude CLI smoke tests
+
+Run in target workspace (example: `conductor2`):
+
+```bash
+cd /Users/jim/work/conductor2
+claude -p "reply exactly: TEST_OK"
+claude -p --model claude-sonnet-4-5-20250929 "reply exactly: MODEL_OK"
+claude -p --model claude-sonnet-4-5-20250929 "reply exactly: AGAIN_OK"
+```
+
+## Optional diagnostics
+
+```bash
+tail -n 120 ~/.cc-switch/logs/cc-switch.log
+sqlite3 ~/.cc-switch/cc-switch.db "SELECT request_id,provider_id,app_type,model,request_model,status_code,created_at FROM proxy_request_logs ORDER BY created_at DESC LIMIT 12;"
+```

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -583,12 +583,55 @@ pub async fn open_provider_terminal(
 
     // 从提供商配置中提取环境变量
     let config = &provider.settings_config;
-    let env_vars = extract_env_vars_from_config(config, &app_type);
+    let mut env_vars = extract_env_vars_from_config(config, &app_type);
+
+    // Claude provider-terminal 统一走本地代理，避免 CLI 直连上游时的模型校验/格式不兼容
+    if app_type == AppType::Claude {
+        // 切换当前 Provider，确保代理路由到用户选择的目标
+        ProviderService::switch(state.inner(), app_type.clone(), &providerId)
+            .map_err(|e| format!("切换当前 Provider 失败: {e}"))?;
+
+        // 确保代理服务已启动并接管 Claude
+        if !state.proxy_service.is_running().await {
+            state
+                .proxy_service
+                .start_with_takeover()
+                .await
+                .map_err(|e| format!("启动代理失败: {e}"))?;
+        }
+
+        state
+            .proxy_service
+            .set_takeover_for_app("claude", true)
+            .await
+            .map_err(|e| format!("启用 Claude 代理接管失败: {e}"))?;
+
+        let proxy_config = state
+            .db
+            .get_proxy_config()
+            .await
+            .map_err(|e| format!("读取代理配置失败: {e}"))?;
+
+        let connect_host = match proxy_config.listen_address.as_str() {
+            "0.0.0.0" | "::" => "127.0.0.1".to_string(),
+            _ => proxy_config.listen_address,
+        };
+        let proxy_url = format!("http://{}:{}", connect_host, proxy_config.listen_port);
+        upsert_env_var(&mut env_vars, "ANTHROPIC_BASE_URL", &proxy_url);
+    }
 
     // 根据平台启动终端，传入提供商ID用于生成唯一的配置文件名
     launch_terminal_with_env(env_vars, &providerId).map_err(|e| format!("启动终端失败: {e}"))?;
 
     Ok(true)
+}
+
+fn upsert_env_var(env_vars: &mut Vec<(String, String)>, key: &str, value: &str) {
+    if let Some((_, v)) = env_vars.iter_mut().find(|(k, _)| k == key) {
+        *v = value.to_string();
+    } else {
+        env_vars.push((key.to_string(), value.to_string()));
+    }
 }
 
 /// 从提供商配置中提取环境变量
@@ -714,10 +757,10 @@ fn launch_macos_terminal(config_file: &std::path::Path) -> Result<(), String> {
     // Write the shell script to a temp file
     let script_content = format!(
         r#"#!/bin/bash
-trap 'rm -f "{config_path}" "{script_file}"' EXIT
 echo "Using provider-specific claude config:"
 echo "{config_path}"
 claude --settings "{config_path}"
+rm -f "{config_path}" "{script_file}"
 exec bash --norc --noprofile
 "#,
         config_path = config_path,
@@ -882,10 +925,10 @@ fn launch_linux_terminal(config_file: &std::path::Path) -> Result<(), String> {
 
     let script_content = format!(
         r#"#!/bin/bash
-trap 'rm -f "{config_path}" "{script_file}"' EXIT
 echo "Using provider-specific claude config:"
 echo "{config_path}"
 claude --settings "{config_path}"
+rm -f "{config_path}" "{script_file}"
 exec bash --norc --noprofile
 "#,
         config_path = config_path,

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -1,4 +1,7 @@
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tauri::State;
 
 use crate::app_config::AppType;
@@ -6,7 +9,11 @@ use crate::error::AppError;
 use crate::provider::Provider;
 use crate::services::{EndpointLatency, ProviderService, ProviderSortUpdate, SpeedtestService};
 use crate::store::AppState;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[tauri::command]
 pub fn get_providers(
@@ -169,6 +176,403 @@ pub async fn test_api_endpoints(
     SpeedtestService::test_endpoints(urls, timeoutSecs)
         .await
         .map_err(|e| e.to_string())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteModelInfo {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+const REMOTE_MODELS_CACHE_TTL_MS: i64 = 5 * 60 * 1000;
+const REMOTE_MODELS_CACHE_NAMESPACE: &str = "cc-switch/remote-models";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoteModelsCacheEntry {
+    expires_at_epoch_ms: i64,
+    models: Vec<RemoteModelInfo>,
+}
+
+fn now_epoch_ms() -> i64 {
+    let elapsed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    if elapsed > i64::MAX as u128 {
+        i64::MAX
+    } else {
+        elapsed as i64
+    }
+}
+
+fn remote_models_cache_base_dir() -> PathBuf {
+    let tmp_root = Path::new("/tmp");
+    if tmp_root.is_dir() {
+        return tmp_root.join(REMOTE_MODELS_CACHE_NAMESPACE);
+    }
+    std::env::temp_dir().join(REMOTE_MODELS_CACHE_NAMESPACE)
+}
+
+fn remote_models_cache_path(
+    base_url: &str,
+    api_key: &str,
+    api_format: &str,
+    proxy_config: Option<&crate::provider::ProviderProxyConfig>,
+) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(api_format.as_bytes());
+    hasher.update(b"|");
+    hasher.update(base_url.as_bytes());
+    hasher.update(b"|");
+    hasher.update(api_key.as_bytes());
+    hasher.update(b"|");
+
+    if let Some(config) = proxy_config {
+        match serde_json::to_vec(config) {
+            Ok(bytes) => hasher.update(bytes),
+            Err(err) => log::debug!(
+                "[RemoteModels] Failed to serialize proxy config for cache key: {err}"
+            ),
+        }
+    }
+
+    let digest = format!("{:x}", hasher.finalize());
+    remote_models_cache_base_dir().join(format!("{digest}.json"))
+}
+
+fn read_remote_models_cache(path: &Path) -> Option<Vec<RemoteModelInfo>> {
+    let content = fs::read(path).ok()?;
+    let entry: RemoteModelsCacheEntry = serde_json::from_slice(&content).ok()?;
+    if entry.expires_at_epoch_ms <= now_epoch_ms() {
+        let _ = fs::remove_file(path);
+        return None;
+    }
+    if entry.models.is_empty() {
+        return None;
+    }
+    Some(entry.models)
+}
+
+fn write_remote_models_cache(path: &Path, models: &[RemoteModelInfo]) {
+    if models.is_empty() {
+        return;
+    }
+
+    if let Some(parent) = path.parent() {
+        if let Err(err) = fs::create_dir_all(parent) {
+            log::debug!("[RemoteModels] Failed to create cache dir {:?}: {err}", parent);
+            return;
+        }
+    }
+
+    let entry = RemoteModelsCacheEntry {
+        expires_at_epoch_ms: now_epoch_ms().saturating_add(REMOTE_MODELS_CACHE_TTL_MS),
+        models: models.to_vec(),
+    };
+
+    let payload = match serde_json::to_vec(&entry) {
+        Ok(value) => value,
+        Err(err) => {
+            log::debug!("[RemoteModels] Failed to serialize cache payload: {err}");
+            return;
+        }
+    };
+
+    let tmp_path = path.with_extension(format!("{}.{}.tmp", std::process::id(), now_epoch_ms()));
+
+    if let Err(err) = fs::write(&tmp_path, payload) {
+        log::debug!(
+            "[RemoteModels] Failed to write cache file {:?}: {err}",
+            tmp_path
+        );
+        return;
+    }
+
+    if let Err(err) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        log::debug!(
+            "[RemoteModels] Failed to finalize cache file {:?}: {err}",
+            path
+        );
+    }
+}
+
+fn extract_string_from_keys(obj: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| obj.get(*key))
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn is_likely_model_id(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.chars().any(|c| c.is_whitespace()) {
+        return false;
+    }
+    if !trimmed.chars().any(|c| c.is_ascii_alphanumeric()) {
+        return false;
+    }
+
+    let normalized = trimmed.to_ascii_lowercase();
+    !matches!(
+        normalized.as_str(),
+        "data"
+            | "model"
+            | "models"
+            | "object"
+            | "meta"
+            | "metadata"
+            | "status"
+            | "error"
+            | "errors"
+            | "message"
+            | "messages"
+            | "id"
+            | "list"
+            | "items"
+            | "count"
+            | "total"
+    )
+}
+
+fn parse_model_entry(entry: &Value) -> Option<RemoteModelInfo> {
+    let obj = entry.as_object()?;
+    let id = extract_string_from_keys(obj, &["id", "modelId", "model", "name"])?;
+    if !is_likely_model_id(&id) {
+        return None;
+    }
+    let display_name = extract_string_from_keys(obj, &["display_name", "displayName", "label"])
+        .filter(|name| name != &id);
+    let provider = extract_string_from_keys(obj, &["owned_by", "ownedBy", "provider", "owner", "vendor"]);
+
+    Some(RemoteModelInfo {
+        id,
+        provider,
+        display_name,
+    })
+}
+
+fn parse_remote_models(payload: &Value) -> Vec<RemoteModelInfo> {
+    let mut collected: Vec<RemoteModelInfo> = Vec::new();
+
+    if let Some(data) = payload.get("data").and_then(|v| v.as_array()) {
+        for item in data {
+            if let Some(model) = parse_model_entry(item) {
+                collected.push(model);
+            }
+        }
+    } else if let Some(models) = payload.get("models") {
+        if let Some(arr) = models.as_array() {
+            for item in arr {
+                if let Some(model) = parse_model_entry(item) {
+                    collected.push(model);
+                }
+            }
+        } else if let Some(obj) = models.as_object() {
+            for (model_id, model_value) in obj {
+                if let Some(mut parsed) = parse_model_entry(model_value) {
+                    if parsed.id.is_empty() {
+                        parsed.id = model_id.trim().to_string();
+                    }
+                    if !parsed.id.is_empty() {
+                        collected.push(parsed);
+                    }
+                } else if model_value.is_object() && is_likely_model_id(model_id) {
+                    let trimmed = model_id.trim();
+                    if !trimmed.is_empty() {
+                        collected.push(RemoteModelInfo {
+                            id: trimmed.to_string(),
+                            provider: None,
+                            display_name: None,
+                        });
+                    }
+                }
+            }
+        }
+    } else if let Some(arr) = payload.as_array() {
+        for item in arr {
+            if let Some(model) = parse_model_entry(item) {
+                collected.push(model);
+            }
+        }
+    } else if let Some(single) = parse_model_entry(payload) {
+        collected.push(single);
+    }
+
+    let mut seen = HashSet::new();
+    let mut deduped: Vec<RemoteModelInfo> = collected
+        .into_iter()
+        .filter(|m| is_likely_model_id(&m.id) && seen.insert(m.id.clone()))
+        .collect();
+    deduped.sort_by(|a, b| a.id.to_lowercase().cmp(&b.id.to_lowercase()));
+    deduped
+}
+
+#[cfg(test)]
+mod remote_models_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_remote_models_filters_non_model_map_entries() {
+        let payload = json!({
+            "models": {
+                "meta": { "note": "not a model" },
+                "status": { "healthy": true },
+                "gpt-4o": { "id": "gpt-4o", "owned_by": "openai" }
+            }
+        });
+
+        let models = parse_remote_models(&payload);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "gpt-4o");
+    }
+
+    #[test]
+    fn parse_remote_models_keeps_likely_model_ids_from_object_map_keys() {
+        let payload = json!({
+            "models": {
+                "claude-3-5-sonnet": {
+                    "input_cost": "3"
+                }
+            }
+        });
+
+        let models = parse_remote_models(&payload);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "claude-3-5-sonnet");
+    }
+}
+
+fn build_model_urls(base_url: &str) -> Vec<String> {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    let primary = if trimmed.ends_with("/v1") {
+        format!("{trimmed}/models")
+    } else {
+        format!("{trimmed}/v1/models")
+    };
+    let fallback = if trimmed.ends_with("/v1") {
+        format!("{trimmed}/v1/models")
+    } else {
+        format!("{trimmed}/models")
+    };
+
+    let mut seen = HashSet::new();
+    vec![primary, fallback]
+        .into_iter()
+        .filter(|url| seen.insert(url.clone()))
+        .collect()
+}
+
+fn truncate_for_log(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+#[allow(non_snake_case)]
+#[tauri::command]
+pub async fn enumerate_provider_models(
+    #[allow(non_snake_case)] baseUrl: String,
+    #[allow(non_snake_case)] apiKey: String,
+    #[allow(non_snake_case)] apiFormat: Option<String>,
+    #[allow(non_snake_case)] proxyConfig: Option<crate::provider::ProviderProxyConfig>,
+    #[allow(non_snake_case)] forceRefresh: Option<bool>,
+) -> Result<Vec<RemoteModelInfo>, String> {
+    let base_url = baseUrl.trim();
+    let api_key = apiKey.trim();
+    if base_url.is_empty() {
+        return Err("baseUrl is required".to_string());
+    }
+    if api_key.is_empty() {
+        return Err("apiKey is required".to_string());
+    }
+
+    let format = apiFormat
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("openai_chat")
+        .to_lowercase();
+    if format != "openai_chat" && format != "anthropic" {
+        return Err(format!("Unsupported apiFormat: {format}"));
+    }
+
+    let force_refresh = forceRefresh.unwrap_or(false);
+    let cache_path = remote_models_cache_path(base_url, api_key, &format, proxyConfig.as_ref());
+    if !force_refresh {
+        if let Some(cached_models) = read_remote_models_cache(&cache_path) {
+            log::info!(
+                "[RemoteModels] Using cached model list ({}) from {:?}",
+                cached_models.len(),
+                cache_path
+            );
+            return Ok(cached_models);
+        }
+    }
+
+    let urls = build_model_urls(base_url);
+    let client = crate::proxy::http_client::get_for_provider(proxyConfig.as_ref());
+    let mut errors: Vec<String> = Vec::new();
+
+    for url in urls {
+        log::info!("[RemoteModels] Fetching models from: {url}");
+
+        let mut request = client
+            .get(&url)
+            .header("accept", "application/json")
+            .header("authorization", format!("Bearer {api_key}"))
+            .timeout(std::time::Duration::from_secs(20));
+
+        if format == "anthropic" {
+            request = request
+                .header("x-api-key", api_key)
+                .header("anthropic-version", "2023-06-01");
+        }
+
+        let response = match request.send().await {
+            Ok(resp) => resp,
+            Err(err) => {
+                errors.push(format!("{url}: request failed: {err}"));
+                continue;
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            let body_snippet = truncate_for_log(&body, 240);
+            log::warn!("[RemoteModels] API returned {status}: {body_snippet}");
+            errors.push(format!("{url}: API returned {status}: {body_snippet}"));
+            continue;
+        }
+
+        let payload: Value = match response.json().await {
+            Ok(json) => json,
+            Err(err) => {
+                errors.push(format!("{url}: failed to parse response: {err}"));
+                continue;
+            }
+        };
+
+        let models = parse_remote_models(&payload);
+        if !models.is_empty() {
+            log::info!("[RemoteModels] Fetched {} model(s)", models.len());
+            write_remote_models_cache(&cache_path, &models);
+            return Ok(models);
+        }
+
+        errors.push(format!("{url}: API returned an empty model list"));
+    }
+
+    Err(format!("Failed to fetch models: {}", errors.join(" | ")))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -892,6 +892,7 @@ pub fn run() {
             commands::get_current_prompt_file_content,
             // ours: endpoint speed test + custom endpoint management
             commands::test_api_endpoints,
+            commands::enumerate_provider_models,
             commands::get_custom_endpoints,
             commands::add_custom_endpoint,
             commands::remove_custom_endpoint,

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -230,6 +230,12 @@ pub struct ProviderMeta {
     /// 供应商单独的代理配置
     #[serde(rename = "proxyConfig", skip_serializing_if = "Option::is_none")]
     pub proxy_config: Option<ProviderProxyConfig>,
+    /// Harmony API 支持（用于 gpt-oss 模型）
+    /// - None/"auto": 自动检测（根据模型名判断）
+    /// - "enabled": 强制使用 Harmony Responses API（/v1/responses）
+    /// - "disabled": 禁用 Harmony，使用 OpenAI Chat Completions
+    #[serde(rename = "harmonySupport", skip_serializing_if = "Option::is_none")]
+    pub harmony_support: Option<String>,
     /// Claude API 格式（仅 Claude 供应商使用）
     /// - "anthropic": 原生 Anthropic Messages API，直接透传
     /// - "openai_chat": OpenAI Chat Completions 格式，需要转换

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -19,6 +19,10 @@ use reqwest::RequestBuilder;
 /// Claude 适配器
 pub struct ClaudeAdapter;
 
+/// Harmony models that require /v1/responses endpoint
+/// These models use the Harmony response format (gpt-oss series)
+const HARMONY_MODEL_PATTERNS: &[&str] = &["gpt-oss-", "openai/gpt-oss-"];
+
 impl ClaudeAdapter {
     pub fn new() -> Self {
         Self
@@ -82,7 +86,20 @@ impl ClaudeAdapter {
             };
         }
 
-        // 3) Backward compatibility: legacy openrouter_compat_mode (bool/number/string)
+        // 3) Backward compatibility: settings_config.apiFormat (camelCase)
+        if let Some(api_format) = provider
+            .settings_config
+            .get("apiFormat")
+            .and_then(|v| v.as_str())
+        {
+            return if api_format == "openai_chat" {
+                "openai_chat"
+            } else {
+                "anthropic"
+            };
+        }
+
+        // 4) Backward compatibility: legacy openrouter_compat_mode (bool/number/string)
         let raw = provider.settings_config.get("openrouter_compat_mode");
         let enabled = match raw {
             Some(serde_json::Value::Bool(v)) => *v,
@@ -99,6 +116,33 @@ impl ClaudeAdapter {
         } else {
             "anthropic"
         }
+    }
+
+    /// 检查 Harmony API 支持
+    ///
+    /// 返回值：
+    /// - Some(true): 强制启用 Harmony
+    /// - Some(false): 强制禁用 Harmony
+    /// - None: 自动检测（根据模型名判断）
+    /// 检查模型是否为 Harmony 格式模型
+    fn is_harmony_model(model: &str) -> bool {
+        let model_lower = model.to_lowercase();
+        HARMONY_MODEL_PATTERNS
+            .iter()
+            .any(|prefix| model_lower.starts_with(prefix))
+    }
+
+    fn get_harmony_support(&self, provider: &Provider) -> Option<bool> {
+        provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.harmony_support.as_deref())
+            .and_then(|s| match s {
+                "enabled" | "true" | "1" => Some(true),
+                "disabled" | "false" | "0" => Some(false),
+                "auto" => None,
+                _ => None,
+            })
     }
 
     /// 检测是否为仅 Bearer 认证模式
@@ -263,10 +307,13 @@ impl ProviderAdapter for ClaudeAdapter {
             base = base.replace("/v1/v1", "/v1");
         }
 
-        // 为 Claude 相关端点添加 ?beta=true 参数
+        // 为 Claude 原生 /v1/messages 端点添加 ?beta=true 参数
         // 这是某些上游服务（如 DuckCoding）验证请求来源的关键参数
-        // 注：openai_chat 模式下会转发到 /v1/chat/completions，此处也需要保持一致
-        if (endpoint.contains("/v1/messages") || endpoint.contains("/v1/chat/completions"))
+        // 注意：不要为 OpenAI Chat Completions (/v1/chat/completions) 添加此参数
+        //       当 apiFormat="openai_chat" 时，请求会转发到 /v1/chat/completions，
+        //       但该端点是 OpenAI 标准，不支持 ?beta=true 参数
+        if endpoint.contains("/v1/messages")
+            && !endpoint.contains("/v1/chat/completions")
             && !endpoint.contains('?')
         {
             format!("{base}?beta=true")
@@ -305,13 +352,38 @@ impl ProviderAdapter for ClaudeAdapter {
     fn transform_request(
         &self,
         body: serde_json::Value,
-        _provider: &Provider,
+        provider: &Provider,
     ) -> Result<serde_json::Value, ProxyError> {
-        super::transform::anthropic_to_openai(body)
+        // Check if this is a Harmony model and provider supports it
+        let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
+
+        // If apiFormat is explicitly "openai_chat", never use Harmony
+        let api_format = self.get_api_format(provider);
+        if api_format == "openai_chat" {
+            return super::transform::anthropic_to_openai(body);
+        }
+
+        let harmony_override = self.get_harmony_support(provider);
+        let is_harmony = harmony_override.unwrap_or_else(|| Self::is_harmony_model(model));
+
+        if is_harmony {
+            // Direct Anthropic -> Harmony transformation
+            super::transform::anthropic_to_harmony(body)
+        } else {
+            // Standard Anthropic -> OpenAI Chat Completions
+            super::transform::anthropic_to_openai(body)
+        }
     }
 
     fn transform_response(&self, body: serde_json::Value) -> Result<serde_json::Value, ProxyError> {
-        super::transform::openai_to_anthropic(body)
+        // Detect response format: Harmony has "output", OpenAI has "choices"
+        let is_harmony_response = body.get("output").is_some();
+
+        if is_harmony_response {
+            super::transform::harmony_to_anthropic(body)
+        } else {
+            super::transform::openai_to_anthropic(body)
+        }
     }
 }
 
@@ -514,6 +586,15 @@ mod tests {
     }
 
     #[test]
+    fn test_build_url_no_beta_for_openai_chat_completions() {
+        let adapter = ClaudeAdapter::new();
+        // OpenAI Chat Completions 端点不添加 ?beta=true
+        // 这是 Nvidia 等 apiFormat="openai_chat" 供应商使用的端点
+        let url = adapter.build_url("https://integrate.api.nvidia.com", "/v1/chat/completions");
+        assert_eq!(url, "https://integrate.api.nvidia.com/v1/chat/completions");
+    }
+
+    #[test]
     fn test_needs_transform() {
         let adapter = ClaudeAdapter::new();
 
@@ -547,6 +628,15 @@ mod tests {
             "api_format": "openai_chat"
         }));
         assert!(adapter.needs_transform(&legacy_settings_api_format));
+
+        // Backward compatibility: settings_config.apiFormat (camelCase)
+        let settings_api_format_camel_case = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.example.com"
+            },
+            "apiFormat": "openai_chat"
+        }));
+        assert!(adapter.needs_transform(&settings_api_format_camel_case));
 
         // Legacy openrouter_compat_mode: bool/number/string should enable transform
         let legacy_openrouter_bool = create_provider(json!({

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -1,10 +1,11 @@
 //! 格式转换模块
 //!
 //! 实现 Anthropic ↔ OpenAI 格式转换，用于 OpenRouter 支持
+//! 实现 Anthropic → Harmony 格式转换，用于 gpt-oss 模型支持
 //! 参考: anthropic-proxy-rs
 
 use crate::proxy::error::ProxyError;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 /// Anthropic 请求 → OpenAI 请求
 pub fn anthropic_to_openai(body: Value) -> Result<Value, ProxyError> {
@@ -248,8 +249,15 @@ pub fn openai_to_anthropic(body: Value) -> Result<Value, ProxyError> {
 
     let mut content = Vec::new();
 
-    // 文本内容
-    if let Some(text) = message.get("content").and_then(|c| c.as_str()) {
+    // 文本内容 (优先使用 content，其次使用 reasoning/reasoning_content)
+    let text_content = message
+        .get("content")
+        .and_then(|c| c.as_str())
+        .filter(|s| !s.is_empty())
+        .or_else(|| message.get("reasoning").and_then(|r| r.as_str()))
+        .or_else(|| message.get("reasoning_content").and_then(|r| r.as_str()));
+
+    if let Some(text) = text_content {
         if !text.is_empty() {
             content.push(json!({"type": "text", "text": text}));
         }
@@ -296,6 +304,388 @@ pub fn openai_to_anthropic(body: Value) -> Result<Value, ProxyError> {
         .unwrap_or(0) as u32;
     let output_tokens = usage
         .get("completion_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+
+    let result = json!({
+        "id": body.get("id").and_then(|i| i.as_str()).unwrap_or(""),
+        "type": "message",
+        "role": "assistant",
+        "content": content,
+        "model": body.get("model").and_then(|m| m.as_str()).unwrap_or(""),
+        "stop_reason": stop_reason,
+        "stop_sequence": null,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens
+        }
+    });
+
+    Ok(result)
+}
+
+// ============================================================================
+// Harmony Responses API Transformations
+// ============================================================================
+
+/// Anthropic Messages API → Harmony Responses API format
+///
+/// The Responses API is OpenAI's unified API used by gpt-oss models.
+/// Key differences from Chat Completions:
+/// - `input` instead of `messages` (can be string or array)
+/// - `instructions` for system prompt (extracted from system message)
+/// - `max_output_tokens` instead of `max_tokens`
+/// - Response uses `output` array instead of `choices`
+pub fn anthropic_to_harmony(body: Value) -> Result<Value, ProxyError> {
+    let mut new_body = Map::new();
+
+    // Copy model name
+    if let Some(model) = body.get("model").and_then(|m| m.as_str()) {
+        new_body.insert("model".to_string(), json!(model));
+    }
+
+    // Extract instructions from system message and transform messages to input
+    let mut instructions = String::new();
+    let mut input_messages: Vec<Value> = Vec::new();
+
+    // Handle system prompt (Anthropic uses top-level "system" field)
+    if let Some(system) = body.get("system") {
+        if let Some(text) = system.as_str() {
+            instructions = text.to_string();
+        } else if let Some(arr) = system.as_array() {
+            // Multi-part system message
+            let texts: Vec<&str> = arr
+                .iter()
+                .filter_map(|block| block.get("text").and_then(|t| t.as_str()))
+                .collect();
+            if !texts.is_empty() {
+                instructions = texts.join("\n\n");
+            }
+        }
+    }
+
+    // Transform messages to input format
+    if let Some(messages) = body.get("messages").and_then(|m| m.as_array()) {
+        for msg in messages {
+            let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+            let content = msg.get("content").cloned().unwrap_or(json!(""));
+
+            // Skip system messages in input (they go to instructions)
+            if role == "system" {
+                if instructions.is_empty() {
+                    if let Some(text) = content.as_str() {
+                        instructions = text.to_string();
+                    }
+                }
+                continue;
+            }
+
+            // Convert Anthropic content blocks to Harmony format
+            let harmony_content = convert_anthropic_content_to_harmony(&content);
+            input_messages.push(json!({
+                "role": role,
+                "content": harmony_content,
+            }));
+        }
+    }
+
+    // Set instructions if we found a system message
+    if !instructions.is_empty() {
+        new_body.insert("instructions".to_string(), json!(instructions));
+    }
+
+    // Set input (use array format for multi-turn conversations)
+    if !input_messages.is_empty() {
+        new_body.insert("input".to_string(), json!(input_messages));
+    } else {
+        new_body.insert("input".to_string(), json!(""));
+    }
+
+    // Transform parameter names
+    if let Some(v) = body
+        .get("max_tokens")
+        .or_else(|| body.get("max_output_tokens"))
+    {
+        new_body.insert("max_output_tokens".to_string(), v.clone());
+    }
+
+    // Copy other standard parameters
+    for key in ["temperature", "top_p", "stream", "stop"] {
+        if let Some(v) = body.get(key) {
+            new_body.insert(key.to_string(), v.clone());
+        }
+    }
+
+    // Handle tools - Harmony uses similar tool definitions
+    if let Some(tools) = body.get("tools") {
+        let harmony_tools = convert_anthropic_tools_to_harmony(tools);
+        if !harmony_tools.is_null() {
+            new_body.insert("tools".to_string(), harmony_tools);
+        }
+    }
+
+    // Handle tool_choice
+    if let Some(v) = body.get("tool_choice") {
+        new_body.insert(
+            "tool_choice".to_string(),
+            convert_anthropic_tool_choice_to_harmony(v),
+        );
+    }
+
+    Ok(json!(new_body))
+}
+
+/// Convert Anthropic content to Harmony format
+fn convert_anthropic_content_to_harmony(content: &Value) -> Value {
+    // String content passes through
+    if let Some(text) = content.as_str() {
+        return json!(text);
+    }
+
+    // Array of content blocks
+    if let Some(blocks) = content.as_array() {
+        // Nvidia Responses API expects string input for plain text messages.
+        // When Anthropic sends multi-part text blocks (common with injected reminders),
+        // flatten them into one string to avoid `input` schema rejection.
+        let mut all_text = true;
+        let mut flattened = String::new();
+        for block in blocks {
+            match block.get("type").and_then(|t| t.as_str()) {
+                Some("text") => {
+                    if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                        flattened.push_str(text);
+                    }
+                }
+                _ => {
+                    all_text = false;
+                    break;
+                }
+            }
+        }
+
+        if all_text {
+            return json!(flattened);
+        }
+
+        let parts: Vec<Value> = blocks
+            .iter()
+            .filter_map(|block| {
+                let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+                match block_type {
+                    "text" => block
+                        .get("text")
+                        .map(|t| json!({"type": "text", "text": t})),
+                    "image" => {
+                        // Convert Anthropic image format to OpenAI format
+                        if let Some(source) = block.get("source") {
+                            let media_type = source
+                                .get("media_type")
+                                .and_then(|m| m.as_str())
+                                .unwrap_or("image/png");
+                            let data = source.get("data").and_then(|d| d.as_str()).unwrap_or("");
+                            Some(json!({
+                                "type": "image_url",
+                                "image_url": {"url": format!("data:{};base64,{}", media_type, data)}
+                            }))
+                        } else {
+                            None
+                        }
+                    }
+                    "tool_use" => {
+                        // Tool calls in assistant messages
+                        Some(block.clone())
+                    }
+                    "tool_result" => {
+                        // Tool results need special handling - they become separate messages
+                        // For now, pass through as-is
+                        Some(block.clone())
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+
+        if parts.len() == 1 {
+            // Single part - simplify
+            if let Some(text) = parts[0].get("text") {
+                return text.clone();
+            }
+        }
+
+        return json!(parts);
+    }
+
+    // Default: pass through
+    content.clone()
+}
+
+/// Convert Anthropic tools to Harmony format
+fn convert_anthropic_tools_to_harmony(tools: &Value) -> Value {
+    if let Some(tools_arr) = tools.as_array() {
+        let harmony_tools: Vec<Value> = tools_arr
+            .iter()
+            .filter(|t| t.get("type").and_then(|v| v.as_str()) != Some("BatchTool"))
+            .map(|t| {
+                // Anthropic format: {name, description, input_schema}
+                // Harmony format: {type: "function", name, description, parameters}
+                json!({
+                    "type": "function",
+                    "name": t.get("name").and_then(|n| n.as_str()).unwrap_or(""),
+                    "description": t.get("description").cloned().unwrap_or(json!("")),
+                    "parameters": clean_schema(t.get("input_schema").cloned().unwrap_or(json!({})))
+                })
+            })
+            .collect();
+
+        if harmony_tools.is_empty() {
+            return Value::Null;
+        }
+        return json!(harmony_tools);
+    }
+    tools.clone()
+}
+
+/// Convert Anthropic tool_choice to Harmony format
+fn convert_anthropic_tool_choice_to_harmony(tool_choice: &Value) -> Value {
+    if let Some(choice_str) = tool_choice.as_str() {
+        return match choice_str {
+            "auto" | "none" | "required" => json!(choice_str),
+            _ => tool_choice.clone(),
+        };
+    }
+
+    if let Some(obj) = tool_choice.as_object() {
+        match obj.get("type").and_then(|v| v.as_str()) {
+            Some("auto") => return json!("auto"),
+            Some("any") => return json!("required"),
+            Some("tool") => {
+                if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                    return json!({"type": "function", "name": name});
+                }
+            }
+            _ => {}
+        }
+    }
+
+    tool_choice.clone()
+}
+
+/// Harmony Responses API → Anthropic Messages API format
+///
+/// Converts the Harmony response back to Anthropic format for the client.
+pub fn harmony_to_anthropic(body: Value) -> Result<Value, ProxyError> {
+    // Harmony response has `output` array instead of `choices`
+    let output = body
+        .get("output")
+        .and_then(|o| o.as_array())
+        .ok_or_else(|| ProxyError::TransformError("No output in Harmony response".to_string()))?;
+
+    // Find the main message in output
+    let mut content: Vec<Value> = Vec::new();
+    let mut stop_reason: Option<&str> = None;
+
+    for item in output {
+        let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        match item_type {
+            "message" => {
+                // Main assistant message
+                if let Some(msg_content) = item.get("content") {
+                    if let Some(arr) = msg_content.as_array() {
+                        for part in arr {
+                            let part_type = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                            match part_type {
+                                "text" => {
+                                    if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                                        if !text.is_empty() {
+                                            content.push(json!({"type": "text", "text": text}));
+                                        }
+                                    }
+                                }
+                                "tool_call" | "function_call" => {
+                                    // Tool use
+                                    let id = part.get("id").and_then(|i| i.as_str()).unwrap_or("");
+                                    let name = part
+                                        .get("name")
+                                        .or_else(|| {
+                                            part.get("function").and_then(|f| f.get("name"))
+                                        })
+                                        .and_then(|n| n.as_str())
+                                        .unwrap_or("");
+                                    let args = part
+                                        .get("arguments")
+                                        .or_else(|| {
+                                            part.get("function").and_then(|f| f.get("arguments"))
+                                        })
+                                        .cloned()
+                                        .unwrap_or(json!({}));
+                                    let input: Value = if let Some(args_str) = args.as_str() {
+                                        serde_json::from_str(args_str).unwrap_or(json!({}))
+                                    } else {
+                                        args
+                                    };
+                                    content.push(json!({
+                                        "type": "tool_use",
+                                        "id": id,
+                                        "name": name,
+                                        "input": input
+                                    }));
+                                }
+                                _ => {}
+                            }
+                        }
+                    } else if let Some(text) = msg_content.as_str() {
+                        if !text.is_empty() {
+                            content.push(json!({"type": "text", "text": text}));
+                        }
+                    }
+                }
+            }
+            "function_call" => {
+                // Standalone function call
+                let id = item.get("id").and_then(|i| i.as_str()).unwrap_or("");
+                let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                let args = item.get("arguments").cloned().unwrap_or(json!({}));
+                let input: Value = if let Some(args_str) = args.as_str() {
+                    serde_json::from_str(args_str).unwrap_or(json!({}))
+                } else {
+                    args
+                };
+                content.push(json!({
+                    "type": "tool_use",
+                    "id": id,
+                    "name": name,
+                    "input": input
+                }));
+                stop_reason = Some("tool_use");
+            }
+            _ => {}
+        }
+    }
+
+    // Get finish reason from status or content
+    if stop_reason.is_none() {
+        stop_reason = body
+            .get("status")
+            .and_then(|s| s.as_str())
+            .map(|s| match s {
+                "completed" => "end_turn",
+                "incomplete" => "max_tokens",
+                _ => s,
+            });
+    }
+
+    // Usage
+    let usage = body.get("usage").cloned().unwrap_or(json!({}));
+    let input_tokens = usage
+        .get("input_tokens")
+        .or_else(|| usage.get("prompt_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let output_tokens = usage
+        .get("output_tokens")
+        .or_else(|| usage.get("completion_tokens"))
         .and_then(|v| v.as_u64())
         .unwrap_or(0) as u32;
 
@@ -479,5 +869,83 @@ mod tests {
 
         let result = anthropic_to_openai(input).unwrap();
         assert_eq!(result["model"], "gpt-4o");
+    }
+
+    #[test]
+    fn test_anthropic_to_harmony_tools_use_top_level_function_fields() {
+        let input = json!({
+            "model": "openai/gpt-oss-20b",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [{
+                "name": "get_weather",
+                "description": "Get current weather",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string", "format": "uri"}
+                    }
+                }
+            }]
+        });
+
+        let result = anthropic_to_harmony(input).unwrap();
+        let tool = &result["tools"][0];
+
+        assert_eq!(tool["type"], "function");
+        assert_eq!(tool["name"], "get_weather");
+        assert_eq!(tool["description"], "Get current weather");
+        assert_eq!(tool["parameters"]["type"], "object");
+        assert!(tool.get("function").is_none());
+        assert!(tool["parameters"]["properties"]["location"]
+            .get("format")
+            .is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_harmony_tool_choice_mappings() {
+        let mk_input = |tool_choice: Value| {
+            json!({
+                "model": "openai/gpt-oss-20b",
+                "messages": [{"role": "user", "content": "hello"}],
+                "tool_choice": tool_choice
+            })
+        };
+
+        let auto = anthropic_to_harmony(mk_input(json!({"type": "auto"}))).unwrap();
+        assert_eq!(auto["tool_choice"], "auto");
+
+        let any = anthropic_to_harmony(mk_input(json!({"type": "any"}))).unwrap();
+        assert_eq!(any["tool_choice"], "required");
+
+        let specific =
+            anthropic_to_harmony(mk_input(json!({"type": "tool", "name": "lookup"}))).unwrap();
+        assert_eq!(specific["tool_choice"]["type"], "function");
+        assert_eq!(specific["tool_choice"]["name"], "lookup");
+
+        let pass_auto = anthropic_to_harmony(mk_input(json!("auto"))).unwrap();
+        assert_eq!(pass_auto["tool_choice"], "auto");
+
+        let pass_none = anthropic_to_harmony(mk_input(json!("none"))).unwrap();
+        assert_eq!(pass_none["tool_choice"], "none");
+
+        let pass_required = anthropic_to_harmony(mk_input(json!("required"))).unwrap();
+        assert_eq!(pass_required["tool_choice"], "required");
+    }
+
+    #[test]
+    fn test_anthropic_to_harmony_flattens_multi_text_blocks() {
+        let input = json!({
+            "model": "openai/gpt-oss-20b",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello "},
+                    {"type": "text", "text": "world"}
+                ]
+            }]
+        });
+
+        let result = anthropic_to_harmony(input).unwrap();
+        assert_eq!(result["input"][0]["content"], "Hello world");
     }
 }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -212,7 +212,8 @@ impl ProxyServer {
             .allow_headers(Any);
 
         Router::new()
-            // 健康检查
+            // 根路径与健康检查（避免客户端探活 GET / 返回 404）
+            .route("/", get(handlers::health_check))
             .route("/health", get(handlers::health_check))
             .route("/status", get(handlers::get_status))
             // Claude API (支持带前缀和不带前缀两种格式)

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -218,7 +218,15 @@ impl ProxyServer {
             .route("/status", get(handlers::get_status))
             // Claude API (支持带前缀和不带前缀两种格式)
             .route("/v1/messages", post(handlers::handle_messages))
+            .route(
+                "/v1/messages/count_tokens",
+                post(handlers::handle_count_tokens),
+            )
             .route("/claude/v1/messages", post(handlers::handle_messages))
+            .route(
+                "/claude/v1/messages/count_tokens",
+                post(handlers::handle_count_tokens),
+            )
             // OpenAI Chat Completions API (Codex CLI，支持带前缀和不带前缀)
             .route("/chat/completions", post(handlers::handle_chat_completions))
             .route(

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -118,6 +118,74 @@ base_url = "http://localhost:8080"
             "should keep mcp_servers.* base_url"
         );
     }
+
+    #[test]
+    fn merge_backfilled_claude_settings_preserves_existing_env_when_live_missing_env() {
+        let existing = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+                "ANTHROPIC_AUTH_TOKEN": "sk-test"
+            },
+            "featureFlag": true
+        });
+
+        let live = json!({
+            "apiBaseUrl": "https://api.z.ai/api/anthropic",
+            "featureFlag": false
+        });
+
+        let merged = ProviderService::merge_backfilled_settings(&AppType::Claude, &existing, &live);
+
+        assert_eq!(
+            merged
+                .get("env")
+                .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+                .and_then(|v| v.as_str()),
+            Some("https://api.z.ai/api/anthropic")
+        );
+        assert_eq!(
+            merged.get("apiBaseUrl").and_then(|v| v.as_str()),
+            Some("https://api.z.ai/api/anthropic")
+        );
+        assert_eq!(
+            merged.get("featureFlag").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn merge_backfilled_claude_settings_prefers_live_env_values() {
+        let existing = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+                "ANTHROPIC_AUTH_TOKEN": "sk-old"
+            }
+        });
+
+        let live = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://integrate.api.nvidia.com",
+                "ANTHROPIC_AUTH_TOKEN": "sk-new"
+            }
+        });
+
+        let merged = ProviderService::merge_backfilled_settings(&AppType::Claude, &existing, &live);
+
+        assert_eq!(
+            merged
+                .get("env")
+                .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+                .and_then(|v| v.as_str()),
+            Some("https://integrate.api.nvidia.com")
+        );
+        assert_eq!(
+            merged
+                .get("env")
+                .and_then(|env| env.get("ANTHROPIC_AUTH_TOKEN"))
+                .and_then(|v| v.as_str()),
+            Some("sk-new")
+        );
+    }
 }
 
 impl ProviderService {
@@ -167,8 +235,7 @@ impl ProviderService {
         // Additive mode apps (OpenCode, OpenClaw) - always write to live config
         if app_type.is_additive_mode() {
             // OMO providers use exclusive mode and write to dedicated config file.
-            if matches!(app_type, AppType::OpenCode)
-                && provider.category.as_deref() == Some("omo")
+            if matches!(app_type, AppType::OpenCode) && provider.category.as_deref() == Some("omo")
             {
                 // Do not auto-enable newly added OMO providers.
                 // Users must explicitly switch/apply an OMO provider to activate it.
@@ -207,8 +274,7 @@ impl ProviderService {
 
         // Additive mode apps (OpenCode, OpenClaw) - always update in live config
         if app_type.is_additive_mode() {
-            if matches!(app_type, AppType::OpenCode)
-                && provider.category.as_deref() == Some("omo")
+            if matches!(app_type, AppType::OpenCode) && provider.category.as_deref() == Some("omo")
             {
                 let is_omo_current = state
                     .db
@@ -475,7 +541,11 @@ impl ProviderService {
                     // Only backfill when switching to a different provider
                     if let Ok(live_config) = read_live_settings(app_type.clone()) {
                         if let Some(mut current_provider) = providers.get(&current_id).cloned() {
-                            current_provider.settings_config = live_config;
+                            current_provider.settings_config = Self::merge_backfilled_settings(
+                                &app_type,
+                                &current_provider.settings_config,
+                                &live_config,
+                            );
                             // Ignore backfill failure, don't affect switch flow
                             let _ = state.db.save_provider(app_type.as_str(), &current_provider);
                         }
@@ -1324,6 +1394,21 @@ impl ProviderService {
             (base_val, patch_val) => {
                 *base_val = patch_val.clone();
             }
+        }
+    }
+
+    /// 合并切换回填配置，避免 Claude 因 live 文件字段缺失导致关键 env 丢失
+    fn merge_backfilled_settings(
+        app_type: &AppType,
+        existing: &serde_json::Value,
+        live: &serde_json::Value,
+    ) -> serde_json::Value {
+        if matches!(app_type, AppType::Claude) {
+            let mut merged = existing.clone();
+            Self::merge_json(&mut merged, live);
+            merged
+        } else {
+            live.clone()
         }
     }
 }

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -1,4 +1,6 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
@@ -8,9 +10,30 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Check, ChevronDown, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { providersApi, type RemoteModelInfo } from "@/lib/api/providers";
 import EndpointSpeedTest from "./EndpointSpeedTest";
 import { ApiKeySection, EndpointField } from "./shared";
-import type { ProviderCategory, ClaudeApiFormat } from "@/types";
+import type {
+  ProviderCategory,
+  ClaudeApiFormat,
+  ProviderProxyConfig,
+} from "@/types";
 import type { TemplateValueConfig } from "@/config/claudeProviderPresets";
 
 interface EndpointCandidate {
@@ -68,6 +91,238 @@ interface ClaudeFormFieldsProps {
   // API Format (for third-party providers that use OpenAI Chat Completions format)
   apiFormat: ClaudeApiFormat;
   onApiFormatChange: (format: ClaudeApiFormat) => void;
+
+  // Provider-level proxy config for model enumeration
+  proxyConfig?: ProviderProxyConfig;
+}
+
+interface RemoteModelSelectorProps {
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  models: RemoteModelInfo[];
+  isLoading: boolean;
+  onChange: (value: string) => void;
+  onOpen: () => void;
+  onRefresh: () => void;
+}
+
+const REMOTE_MODELS_CACHE_TTL_MS = 5 * 60 * 1000;
+const remoteModelsCache = new Map<
+  string,
+  { expiresAt: number; models: RemoteModelInfo[] }
+>();
+const remoteModelsInflight = new Map<string, Promise<RemoteModelInfo[]>>();
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
+function apiKeyFingerprint(apiKey: string): string {
+  let hash = 0;
+  for (let i = 0; i < apiKey.length; i += 1) {
+    hash = (hash * 31 + apiKey.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16);
+}
+
+function normalizeProviderName(model: RemoteModelInfo): string | undefined {
+  const provider =
+    typeof model.provider === "string" ? model.provider.trim() : "";
+  return provider || undefined;
+}
+
+function normalizeRemoteModels(models: RemoteModelInfo[]): RemoteModelInfo[] {
+  const seen = new Set<string>();
+  const normalized: RemoteModelInfo[] = [];
+
+  for (const model of models) {
+    const id = typeof model.id === "string" ? model.id.trim() : "";
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    normalized.push({
+      id,
+      provider:
+        typeof model.provider === "string" ? model.provider.trim() : undefined,
+      displayName:
+        typeof model.displayName === "string"
+          ? model.displayName.trim()
+          : undefined,
+    });
+  }
+
+  return normalized.sort((a, b) =>
+    a.id.localeCompare(b.id, "en", { numeric: true }),
+  );
+}
+
+function RemoteModelSelector({
+  id,
+  label,
+  value,
+  placeholder,
+  models,
+  isLoading,
+  onChange,
+  onOpen,
+  onRefresh,
+}: RemoteModelSelectorProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const searchText = search.trim();
+  const hasExactModel = models.some(
+    (model) => model.id.toLowerCase() === searchText.toLowerCase(),
+  );
+
+  return (
+    <div className="space-y-2">
+      <FormLabel htmlFor={id}>{label}</FormLabel>
+      <div className="flex items-center gap-2">
+        <Input
+          id={id}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          autoComplete="off"
+        />
+
+        <Popover
+          modal
+          open={open}
+          onOpenChange={(next) => {
+            setOpen(next);
+            if (next) {
+              onOpen();
+            } else {
+              setSearch("");
+            }
+          }}
+        >
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-9 w-9 shrink-0"
+              aria-label={t("providerForm.selectModel", {
+                defaultValue: "Select model",
+              })}
+            >
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            side="bottom"
+            align="end"
+            sideOffset={6}
+            avoidCollisions={true}
+            collisionPadding={8}
+            className="z-[1000] w-[30rem] max-w-[calc(100vw-2rem)] p-0 border-border-default"
+          >
+            <Command>
+              <CommandInput
+                value={search}
+                onValueChange={setSearch}
+                placeholder={t("providerForm.searchModels", {
+                  defaultValue: "Search models...",
+                })}
+              />
+              <CommandList>
+                <CommandEmpty>
+                  {isLoading
+                    ? t("providerForm.loadingModels", {
+                        defaultValue: "Loading models...",
+                      })
+                    : t("providerForm.noModelsFound", {
+                        defaultValue: "No models found",
+                      })}
+                </CommandEmpty>
+
+                {searchText && !hasExactModel && (
+                  <CommandGroup
+                    heading={t("providerForm.customModel", {
+                      defaultValue: "Custom",
+                    })}
+                  >
+                    <CommandItem
+                      value={`custom:${searchText}`}
+                      onSelect={() => {
+                        onChange(searchText);
+                        setOpen(false);
+                        setSearch("");
+                      }}
+                    >
+                      <Check className="mr-2 h-4 w-4 opacity-0" />
+                      <div className="min-w-0 flex flex-col">
+                        <span className="truncate">{searchText}</span>
+                        <span className="truncate text-xs text-muted-foreground">
+                          {t("providerForm.useTypedModel", {
+                            defaultValue: "Use typed model",
+                          })}
+                        </span>
+                      </div>
+                    </CommandItem>
+                  </CommandGroup>
+                )}
+
+                <CommandGroup>
+                  {models.map((model) => {
+                    const provider = normalizeProviderName(model);
+                    return (
+                      <CommandItem
+                        key={model.id}
+                        value={`${model.id} ${provider ?? ""}`}
+                        keywords={[
+                          model.id,
+                          provider ?? "",
+                          model.displayName ?? "",
+                        ]}
+                        onSelect={() => {
+                          onChange(model.id);
+                          setOpen(false);
+                          setSearch("");
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            value === model.id ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <div className="min-w-0 flex flex-col leading-tight">
+                          <span className="truncate">{model.id}</span>
+                          {provider && (
+                            <span className="truncate text-xs text-muted-foreground">
+                              {provider}
+                            </span>
+                          )}
+                        </div>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-9 w-9 shrink-0"
+          onClick={onRefresh}
+          disabled={isLoading}
+        >
+          <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export function ClaudeFormFields({
@@ -102,8 +357,143 @@ export function ClaudeFormFields({
   speedTestEndpoints,
   apiFormat,
   onApiFormatChange,
+  proxyConfig,
 }: ClaudeFormFieldsProps) {
   const { t } = useTranslation();
+
+  const canEnumerateRemoteModels =
+    shouldShowModelSelector &&
+    category !== "official" &&
+    normalizeBaseUrl(baseUrl).length > 0 &&
+    apiKey.trim().length > 0;
+
+  const cacheKey = useMemo(() => {
+    const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+    if (!normalizedBaseUrl) return "";
+
+    const proxyFingerprint = proxyConfig?.enabled
+      ? `${proxyConfig.proxyType ?? "http"}:${proxyConfig.proxyHost ?? ""}:${proxyConfig.proxyPort ?? ""}`
+      : "none";
+
+    return `${apiFormat}|${normalizedBaseUrl}|${apiKeyFingerprint(apiKey.trim())}|${proxyFingerprint}`;
+  }, [
+    baseUrl,
+    apiFormat,
+    apiKey,
+    proxyConfig?.enabled,
+    proxyConfig?.proxyType,
+    proxyConfig?.proxyHost,
+    proxyConfig?.proxyPort,
+  ]);
+
+  const [remoteModels, setRemoteModels] = useState<RemoteModelInfo[]>([]);
+  const [isLoadingRemoteModels, setIsLoadingRemoteModels] = useState(false);
+  const [hasLoadedRemoteModels, setHasLoadedRemoteModels] = useState(false);
+  const [remoteModelsError, setRemoteModelsError] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!canEnumerateRemoteModels || !cacheKey) {
+      setRemoteModels([]);
+      setHasLoadedRemoteModels(false);
+      setRemoteModelsError(null);
+      return;
+    }
+
+    const cached = remoteModelsCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      setRemoteModels(cached.models);
+      setHasLoadedRemoteModels(true);
+      setRemoteModelsError(null);
+      return;
+    }
+
+    setRemoteModels([]);
+    setHasLoadedRemoteModels(false);
+    setRemoteModelsError(null);
+  }, [canEnumerateRemoteModels, cacheKey]);
+
+  const loadRemoteModels = useCallback(
+    async (forceRefresh = false, notifyOnError = false) => {
+      if (!canEnumerateRemoteModels || !cacheKey) return;
+
+      if (!forceRefresh) {
+        const cached = remoteModelsCache.get(cacheKey);
+        if (cached && cached.expiresAt > Date.now()) {
+          setRemoteModels(cached.models);
+          setHasLoadedRemoteModels(true);
+          setRemoteModelsError(null);
+          return;
+        }
+      }
+
+      setIsLoadingRemoteModels(true);
+      setRemoteModelsError(null);
+
+      let request = !forceRefresh
+        ? remoteModelsInflight.get(cacheKey)
+        : undefined;
+      if (!request) {
+        request = providersApi
+          .enumerateModels({
+            baseUrl: normalizeBaseUrl(baseUrl),
+            apiKey: apiKey.trim(),
+            apiFormat,
+            proxyConfig: proxyConfig?.enabled ? proxyConfig : undefined,
+            forceRefresh,
+          })
+          .then((models) => normalizeRemoteModels(models));
+        remoteModelsInflight.set(cacheKey, request);
+      }
+
+      try {
+        const models = await request;
+        remoteModelsCache.set(cacheKey, {
+          expiresAt: Date.now() + REMOTE_MODELS_CACHE_TTL_MS,
+          models,
+        });
+        setRemoteModels(models);
+        setHasLoadedRemoteModels(true);
+        setRemoteModelsError(null);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setRemoteModelsError(message);
+        if (notifyOnError) {
+          toast.error(
+            t("providerForm.fetchModelsFailed", {
+              defaultValue: "Failed to fetch models: {{error}}",
+              error: message,
+            }),
+          );
+        }
+      } finally {
+        if (remoteModelsInflight.get(cacheKey) === request) {
+          remoteModelsInflight.delete(cacheKey);
+        }
+        setIsLoadingRemoteModels(false);
+      }
+    },
+    [
+      canEnumerateRemoteModels,
+      cacheKey,
+      baseUrl,
+      apiKey,
+      apiFormat,
+      proxyConfig,
+      t,
+    ],
+  );
+
+  const handleModelSelectorOpen = useCallback(() => {
+    if (!hasLoadedRemoteModels && !isLoadingRemoteModels) {
+      void loadRemoteModels(false, false);
+    }
+  }, [hasLoadedRemoteModels, isLoadingRemoteModels, loadRemoteModels]);
+
+  const handleRefreshModels = useCallback(() => {
+    void loadRemoteModels(true, true);
+  }, [loadRemoteModels]);
 
   return (
     <>
@@ -223,107 +613,211 @@ export function ClaudeFormFields({
       {shouldShowModelSelector && (
         <div className="space-y-3">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* 主模型 */}
-            <div className="space-y-2">
-              <FormLabel htmlFor="claudeModel">
-                {t("providerForm.anthropicModel", { defaultValue: "主模型" })}
-              </FormLabel>
-              <Input
-                id="claudeModel"
-                type="text"
-                value={claudeModel}
-                onChange={(e) =>
-                  onModelChange("ANTHROPIC_MODEL", e.target.value)
-                }
-                placeholder={t("providerForm.modelPlaceholder", {
-                  defaultValue: "",
-                })}
-                autoComplete="off"
-              />
-            </div>
+            {canEnumerateRemoteModels ? (
+              <>
+                <RemoteModelSelector
+                  id="claudeModel"
+                  label={t("providerForm.anthropicModel", {
+                    defaultValue: "主模型",
+                  })}
+                  value={claudeModel}
+                  placeholder={t("providerForm.modelPlaceholder", {
+                    defaultValue: "",
+                  })}
+                  models={remoteModels}
+                  isLoading={isLoadingRemoteModels}
+                  onOpen={handleModelSelectorOpen}
+                  onRefresh={handleRefreshModels}
+                  onChange={(value) => onModelChange("ANTHROPIC_MODEL", value)}
+                />
 
-            {/* 推理模型 */}
-            <div className="space-y-2">
-              <FormLabel htmlFor="reasoningModel">
-                {t("providerForm.anthropicReasoningModel")}
-              </FormLabel>
-              <Input
-                id="reasoningModel"
-                type="text"
-                value={reasoningModel}
-                onChange={(e) =>
-                  onModelChange("ANTHROPIC_REASONING_MODEL", e.target.value)
-                }
-                autoComplete="off"
-              />
-            </div>
+                <RemoteModelSelector
+                  id="reasoningModel"
+                  label={t("providerForm.anthropicReasoningModel", {
+                    defaultValue: "推理模型",
+                  })}
+                  value={reasoningModel}
+                  models={remoteModels}
+                  isLoading={isLoadingRemoteModels}
+                  onOpen={handleModelSelectorOpen}
+                  onRefresh={handleRefreshModels}
+                  onChange={(value) =>
+                    onModelChange("ANTHROPIC_REASONING_MODEL", value)
+                  }
+                />
 
-            {/* 默认 Haiku */}
-            <div className="space-y-2">
-              <FormLabel htmlFor="claudeDefaultHaikuModel">
-                {t("providerForm.anthropicDefaultHaikuModel", {
-                  defaultValue: "Haiku 默认模型",
-                })}
-              </FormLabel>
-              <Input
-                id="claudeDefaultHaikuModel"
-                type="text"
-                value={defaultHaikuModel}
-                onChange={(e) =>
-                  onModelChange("ANTHROPIC_DEFAULT_HAIKU_MODEL", e.target.value)
-                }
-                placeholder={t("providerForm.haikuModelPlaceholder", {
-                  defaultValue: "",
-                })}
-                autoComplete="off"
-              />
-            </div>
+                <RemoteModelSelector
+                  id="claudeDefaultHaikuModel"
+                  label={t("providerForm.anthropicDefaultHaikuModel", {
+                    defaultValue: "Haiku 默认模型",
+                  })}
+                  value={defaultHaikuModel}
+                  placeholder={t("providerForm.haikuModelPlaceholder", {
+                    defaultValue: "",
+                  })}
+                  models={remoteModels}
+                  isLoading={isLoadingRemoteModels}
+                  onOpen={handleModelSelectorOpen}
+                  onRefresh={handleRefreshModels}
+                  onChange={(value) =>
+                    onModelChange("ANTHROPIC_DEFAULT_HAIKU_MODEL", value)
+                  }
+                />
 
-            {/* 默认 Sonnet */}
-            <div className="space-y-2">
-              <FormLabel htmlFor="claudeDefaultSonnetModel">
-                {t("providerForm.anthropicDefaultSonnetModel", {
-                  defaultValue: "Sonnet 默认模型",
-                })}
-              </FormLabel>
-              <Input
-                id="claudeDefaultSonnetModel"
-                type="text"
-                value={defaultSonnetModel}
-                onChange={(e) =>
-                  onModelChange(
-                    "ANTHROPIC_DEFAULT_SONNET_MODEL",
-                    e.target.value,
-                  )
-                }
-                placeholder={t("providerForm.modelPlaceholder", {
-                  defaultValue: "",
-                })}
-                autoComplete="off"
-              />
-            </div>
+                <RemoteModelSelector
+                  id="claudeDefaultSonnetModel"
+                  label={t("providerForm.anthropicDefaultSonnetModel", {
+                    defaultValue: "Sonnet 默认模型",
+                  })}
+                  value={defaultSonnetModel}
+                  placeholder={t("providerForm.modelPlaceholder", {
+                    defaultValue: "",
+                  })}
+                  models={remoteModels}
+                  isLoading={isLoadingRemoteModels}
+                  onOpen={handleModelSelectorOpen}
+                  onRefresh={handleRefreshModels}
+                  onChange={(value) =>
+                    onModelChange("ANTHROPIC_DEFAULT_SONNET_MODEL", value)
+                  }
+                />
 
-            {/* 默认 Opus */}
-            <div className="space-y-2">
-              <FormLabel htmlFor="claudeDefaultOpusModel">
-                {t("providerForm.anthropicDefaultOpusModel", {
-                  defaultValue: "Opus 默认模型",
-                })}
-              </FormLabel>
-              <Input
-                id="claudeDefaultOpusModel"
-                type="text"
-                value={defaultOpusModel}
-                onChange={(e) =>
-                  onModelChange("ANTHROPIC_DEFAULT_OPUS_MODEL", e.target.value)
-                }
-                placeholder={t("providerForm.modelPlaceholder", {
-                  defaultValue: "",
-                })}
-                autoComplete="off"
-              />
-            </div>
+                <RemoteModelSelector
+                  id="claudeDefaultOpusModel"
+                  label={t("providerForm.anthropicDefaultOpusModel", {
+                    defaultValue: "Opus 默认模型",
+                  })}
+                  value={defaultOpusModel}
+                  placeholder={t("providerForm.modelPlaceholder", {
+                    defaultValue: "",
+                  })}
+                  models={remoteModels}
+                  isLoading={isLoadingRemoteModels}
+                  onOpen={handleModelSelectorOpen}
+                  onRefresh={handleRefreshModels}
+                  onChange={(value) =>
+                    onModelChange("ANTHROPIC_DEFAULT_OPUS_MODEL", value)
+                  }
+                />
+              </>
+            ) : (
+              <>
+                {/* 主模型 */}
+                <div className="space-y-2">
+                  <FormLabel htmlFor="claudeModel">
+                    {t("providerForm.anthropicModel", {
+                      defaultValue: "主模型",
+                    })}
+                  </FormLabel>
+                  <Input
+                    id="claudeModel"
+                    type="text"
+                    value={claudeModel}
+                    onChange={(e) =>
+                      onModelChange("ANTHROPIC_MODEL", e.target.value)
+                    }
+                    placeholder={t("providerForm.modelPlaceholder", {
+                      defaultValue: "",
+                    })}
+                    autoComplete="off"
+                  />
+                </div>
+
+                {/* 推理模型 */}
+                <div className="space-y-2">
+                  <FormLabel htmlFor="reasoningModel">
+                    {t("providerForm.anthropicReasoningModel")}
+                  </FormLabel>
+                  <Input
+                    id="reasoningModel"
+                    type="text"
+                    value={reasoningModel}
+                    onChange={(e) =>
+                      onModelChange("ANTHROPIC_REASONING_MODEL", e.target.value)
+                    }
+                    autoComplete="off"
+                  />
+                </div>
+
+                {/* 默认 Haiku */}
+                <div className="space-y-2">
+                  <FormLabel htmlFor="claudeDefaultHaikuModel">
+                    {t("providerForm.anthropicDefaultHaikuModel", {
+                      defaultValue: "Haiku 默认模型",
+                    })}
+                  </FormLabel>
+                  <Input
+                    id="claudeDefaultHaikuModel"
+                    type="text"
+                    value={defaultHaikuModel}
+                    onChange={(e) =>
+                      onModelChange(
+                        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+                        e.target.value,
+                      )
+                    }
+                    placeholder={t("providerForm.haikuModelPlaceholder", {
+                      defaultValue: "",
+                    })}
+                    autoComplete="off"
+                  />
+                </div>
+
+                {/* 默认 Sonnet */}
+                <div className="space-y-2">
+                  <FormLabel htmlFor="claudeDefaultSonnetModel">
+                    {t("providerForm.anthropicDefaultSonnetModel", {
+                      defaultValue: "Sonnet 默认模型",
+                    })}
+                  </FormLabel>
+                  <Input
+                    id="claudeDefaultSonnetModel"
+                    type="text"
+                    value={defaultSonnetModel}
+                    onChange={(e) =>
+                      onModelChange(
+                        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                        e.target.value,
+                      )
+                    }
+                    placeholder={t("providerForm.modelPlaceholder", {
+                      defaultValue: "",
+                    })}
+                    autoComplete="off"
+                  />
+                </div>
+
+                {/* 默认 Opus */}
+                <div className="space-y-2">
+                  <FormLabel htmlFor="claudeDefaultOpusModel">
+                    {t("providerForm.anthropicDefaultOpusModel", {
+                      defaultValue: "Opus 默认模型",
+                    })}
+                  </FormLabel>
+                  <Input
+                    id="claudeDefaultOpusModel"
+                    type="text"
+                    value={defaultOpusModel}
+                    onChange={(e) =>
+                      onModelChange(
+                        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                        e.target.value,
+                      )
+                    }
+                    placeholder={t("providerForm.modelPlaceholder", {
+                      defaultValue: "",
+                    })}
+                    autoComplete="off"
+                  />
+                </div>
+              </>
+            )}
           </div>
+
+          {canEnumerateRemoteModels && remoteModelsError && (
+            <p className="text-xs text-destructive">{remoteModelsError}</p>
+          )}
+
           <p className="text-xs text-muted-foreground">
             {t("providerForm.modelHelper", {
               defaultValue:

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -1955,6 +1955,7 @@ export function ProviderForm({
             speedTestEndpoints={speedTestEndpoints}
             apiFormat={localApiFormat}
             onApiFormatChange={handleApiFormatChange}
+            proxyConfig={proxyConfig}
           />
         )}
 

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
   Provider,
+  ProviderProxyConfig,
   UniversalProvider,
   UniversalProvidersMap,
 } from "@/types";
@@ -15,6 +16,12 @@ export interface ProviderSortUpdate {
 export interface ProviderSwitchEvent {
   appType: AppId;
   providerId: string;
+}
+
+export interface RemoteModelInfo {
+  id: string;
+  provider?: string | null;
+  displayName?: string | null;
 }
 
 export const providersApi = {
@@ -105,6 +112,25 @@ export const providersApi = {
    */
   async getOpenClawLiveProviderIds(): Promise<string[]> {
     return await invoke("get_openclaw_live_provider_ids");
+  },
+
+  /**
+   * Enumerate available remote models for a provider endpoint.
+   * Uses Rust backend to avoid browser CORS restrictions.
+   */
+  async enumerateModels(params: {
+    baseUrl: string;
+    apiKey: string;
+    apiFormat?: "anthropic" | "openai_chat";
+    proxyConfig?: ProviderProxyConfig;
+    forceRefresh?: boolean;
+  }): Promise<RemoteModelInfo[]> {
+    if (!(window as any).__TAURI_INTERNALS__) {
+      throw new Error(
+        "This feature is only available in the CC Switch desktop app",
+      );
+    }
+    return await invoke("enumerate_provider_models", params);
   },
 };
 


### PR DESCRIPTION
<img width="1002" height="654" alt="image" src="https://github.com/user-attachments/assets/a1ba7484-f0dc-4b23-b548-89e9d0de050a" />

## Summary
- add OpenAI-compatible model API enumeration command with caching support for provider model lists
- keep model inputs fully editable while showing dropdown suggestions/refresh when a model list is available
- preserve model names as raw strings (including `/`) instead of inferring provider from model text
- add DB schema compatibility by supporting migration from version 5 to 6

## Validation
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml schema_migration_upgrades_v5_to_v6_compat -- --nocapture`
