### PR TITLE
fix(settings): 修复 SQL 导入导出在暗黑模式下发白

### DIFF
--- a/src/components/settings/ImportExportSection.tsx
+++ b/src/components/settings/ImportExportSection.tsx
@@ -53,7 +53,7 @@ export function ImportExportSection({
         </p>
       </header>
 
-      <div className="space-y-4 rounded-xl glass-card p-6 border border-white/10">
+      <div className="space-y-4 rounded-lg border border-border bg-muted/40 p-6">
         {/* Import and Export Buttons Side by Side */}
         <div className="grid grid-cols-2 gap-4 items-stretch">
           {/* Import Button */}


### PR DESCRIPTION
设置页中SQL导入导出区域在暗黑模式下使用了 `glass-card + border-white/10`，显示偏白，和同页其他配置区块风格不一致。
<img width="948" height="387" alt="before" src="https://github.com/user-attachments/assets/69bd71e3-1bba-44f1-a1dc-52d1f7989e5a" />


## 变更
- 仅调整 `ImportExportSection` 外层容器样式
- 从 `glass-card border-white/10` 改为主题变量风格：`border-border bg-muted/40`
<img width="1000" height="650" alt="after" src="https://github.com/user-attachments/assets/999ea83b-8174-493a-8e88-ddb4601fa727" />


