### PR TITLE
feat(settings): 增强设置中的本地环境的探测在Linux环境和fnm  node管理的健壮性

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "hyper",
  "indexmap 2.11.4",
  "json5",
+ "libc",
  "log",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -2598,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libloading"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,7 @@ rust_decimal = "1.33"
 uuid = { version = "1.11", features = ["v4"] }
 sha2 = "0.10"
 json5 = "0.4"
+libc = "0.2.182"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2"


### PR DESCRIPTION
- 在 Unix 上使用登录 shell (`sh -lc`) 加载用户环境变量
- 将 `~/.opencode/bin` 添加到 OpenCode CLI 扫描路径
- 在 `/run/user` 中添加对 Linux 特定 `fnm` 多 shell 路径的支持