### PR TITLE
feat(tray): Claude 供应商支持 Option+点击 在终端中打开

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,7 +75,7 @@ winreg = "0.52"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"
-objc2-app-kit = { version = "0.2", features = ["NSColor"] }
+objc2-app-kit = { version = "0.2", features = ["NSColor", "NSEvent"] }
 
 # Optimize release binary size to help reduce AppImage footprint
 [profile.release]

--- a/src-tauri/src/commands/failover.rs
+++ b/src-tauri/src/commands/failover.rs
@@ -164,6 +164,8 @@ pub async fn set_auto_failover_enabled(
     if let Ok(new_menu) = crate::tray::create_tray_menu(&app, &state) {
         if let Some(tray) = app.tray_by_id("main") {
             let _ = tray.set_menu(Some(new_menu));
+            #[cfg(target_os = "macos")]
+            crate::tray::apply_alternate_menu_items(&app);
         }
     }
 

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -592,7 +592,7 @@ pub async fn open_provider_terminal(
 }
 
 /// 从提供商配置中提取环境变量
-fn extract_env_vars_from_config(
+pub(crate) fn extract_env_vars_from_config(
     config: &serde_json::Value,
     app_type: &AppType,
 ) -> Vec<(String, String)> {
@@ -643,7 +643,7 @@ fn extract_env_vars_from_config(
 
 /// 创建临时配置文件并启动 claude 终端
 /// 使用 --settings 参数传入提供商特定的 API 配置
-fn launch_terminal_with_env(
+pub(crate) fn launch_terminal_with_env(
     env_vars: Vec<(String, String)>,
     provider_id: &str,
 ) -> Result<(), String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,6 +162,8 @@ async fn update_tray_menu(
             if let Some(tray) = app.tray_by_id("main") {
                 tray.set_menu(Some(new_menu))
                     .map_err(|e| format!("更新托盘菜单失败: {e}"))?;
+                #[cfg(target_os = "macos")]
+                tray::apply_alternate_menu_items(&app);
                 return Ok(true);
             }
             Ok(false)
@@ -686,6 +688,8 @@ pub fn run() {
             }
 
             let _tray = tray_builder.build(app)?;
+            #[cfg(target_os = "macos")]
+            tray::apply_alternate_menu_items(app.handle());
             crate::services::webdav_auto_sync::start_worker(
                 app_state.db.clone(),
                 app.handle().clone(),

--- a/src-tauri/src/proxy/failover_switch.rs
+++ b/src-tauri/src/proxy/failover_switch.rs
@@ -127,6 +127,8 @@ impl FailoverSwitchManager {
                         if let Err(e) = tray.set_menu(Some(new_menu)) {
                             log::error!("[Failover] 更新托盘菜单失败: {e}");
                         }
+                        #[cfg(target_os = "macos")]
+                        crate::tray::apply_alternate_menu_items(app);
                     }
                 }
             }


### PR DESCRIPTION
在系统托盘菜单中，Claude 分区的供应商现在支持按住 Option（Alt）键点击，直接以该供应商的配置打开终端，而不是切换供应商。

类似 Clash Pro 等应用的交互方式 — 按住 Option 时菜单项文案自动变为 `供应商名 (在终端中打开)`，松开恢复原样。使用 macOS 原生 alternate menu item 机制实现，仅 Claude 分区生效。

## 变更

- `tray.rs`：Claude 分区每个供应商后紧跟一个终端 MenuItem，通过 objc2 运行时设置 `isAlternate` + `keyEquivalentModifierMask(Option)` 实现 macOS 原生 alternate 效果
- `tray.rs`：新增 `set_tray_menu()` 统一封装菜单创建 + alternate 设置，替代各处散落的 `create_tray_menu` + `set_menu` 调用
- `tray.rs`：新增 `handle_terminal_click()` 复用已有的终端打开逻辑
- `commands/misc.rs`：`extract_env_vars_from_config` 和 `launch_terminal_with_env` 改为 `pub(crate)` 供 tray 模块复用
- `Cargo.toml`：`objc2-app-kit` 添加 `NSEvent` feature
- 国际化：终端文案支持中/英/日三语

## 平台说明

- macOS：完整支持 alternate menu item 效果（按住 Option 文案切换）
- Windows/Linux：终端菜单项会正常显示在菜单中（作为独立菜单项），alternate 效果不生效