### PR TITLE
feat: add tray icon left-click toggle for main window

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -630,16 +630,21 @@ pub fn run() {
 
             // 构建托盘
             let mut tray_builder = TrayIconBuilder::with_id("main")
-                .on_tray_icon_event(|_tray, event| match event {
-                    // 左键点击已通过 show_menu_on_left_click(true) 打开菜单，这里不再额外处理
-                    TrayIconEvent::Click { .. } => {}
-                    _ => log::debug!("unhandled event {event:?}"),
+                .on_tray_icon_event(|tray, event| match event {
+                    TrayIconEvent::Click {
+                        button: tauri::tray::MouseButton::Left,
+                        button_state: tauri::tray::MouseButtonState::Up,
+                        ..
+                    } => {
+                        tray::handle_tray_menu_event(tray.app_handle(), "toggle_main");
+                    }
+                    _ => {}
                 })
                 .menu(&menu)
                 .on_menu_event(|app, event| {
                     tray::handle_tray_menu_event(app, &event.id.0);
                 })
-                .show_menu_on_left_click(true);
+                .show_menu_on_left_click(false);
 
             // 使用平台对应的托盘图标（macOS 使用模板图标适配深浅色）
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -417,6 +417,34 @@ pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
     log::info!("处理托盘菜单事件: {event_id}");
 
     match event_id {
+        "toggle_main" => {
+            if let Some(window) = app.get_webview_window("main") {
+                let visible = window.is_visible().unwrap_or(false);
+                if visible {
+                    let _ = window.hide();
+                    #[cfg(target_os = "windows")]
+                    {
+                        let _ = window.set_skip_taskbar(true);
+                    }
+                    #[cfg(target_os = "macos")]
+                    {
+                        apply_tray_policy(app, false);
+                    }
+                } else {
+                    #[cfg(target_os = "windows")]
+                    {
+                        let _ = window.set_skip_taskbar(false);
+                    }
+                    let _ = window.unminimize();
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                    #[cfg(target_os = "macos")]
+                    {
+                        apply_tray_policy(app, true);
+                    }
+                }
+            }
+        }
         "show_main" => {
             if let Some(window) = app.get_webview_window("main") {
                 #[cfg(target_os = "windows")]


### PR DESCRIPTION
# Summary
- Left-click on tray icon now toggles main window visibility
- If window is visible → hide to tray
- If window is hidden → show and focus

## Motivation
#328 
Currently left-clicking the tray icon only shows the window. Users expect clicking the tray icon to toggle visibility (show/hide), which is the standard behavior in most desktop applications.

## Changes
- `src-tauri/src/lib.rs`: Changed left-click event to send `toggle_main` instead of showing menu
- `src-tauri/src/tray.rs`: Added `toggle_main` handler that checks window visibility and toggles state

## Platform Support
- **Windows**: Hides/shows taskbar icon accordingly
- **macOS**: Adjusts dock visibility via `apply_tray_policy`

## Test Plan
- [ ] Left-click tray when window is visible → window hides to tray
- [ ] Left-click tray when window is hidden → window shows and gets focus
- [ ] Right-click tray menu "Show Main Window" still works
- [ ] Tested on Windows / macOS

