### PR TITLE
feat: add configurable outbound request redaction in proxy pipeline

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -703,6 +703,7 @@ dependencies = [
 name = "cc-switch"
 version = "3.11.0"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "async-stream",
  "auto-launch",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ tower = "0.4"
 tower-http = { version = "0.5", features = ["cors"] }
 hyper = { version = "1.0", features = ["full"] }
 regex = "1.10"
+aho-corasick = "1.1"
 rquickjs = { version = "0.8", features = ["array-buffer", "classes"] }
 thiserror = "2.0"
 anyhow = "1.0"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -145,6 +145,30 @@ pub async fn set_rectifier_config(
     Ok(true)
 }
 
+/// 获取出站脱敏配置
+#[tauri::command]
+pub async fn get_outbound_redaction_config(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<crate::proxy::types::OutboundRedactionConfig, String> {
+    state
+        .db
+        .get_outbound_redaction_config()
+        .map_err(|e| e.to_string())
+}
+
+/// 设置出站脱敏配置
+#[tauri::command]
+pub async fn set_outbound_redaction_config(
+    state: tauri::State<'_, crate::AppState>,
+    config: crate::proxy::types::OutboundRedactionConfig,
+) -> Result<bool, String> {
+    state
+        .db
+        .set_outbound_redaction_config(&config)
+        .map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
 /// 获取日志配置
 #[tauri::command]
 pub async fn get_log_config(

--- a/src-tauri/src/database/dao/settings.rs
+++ b/src-tauri/src/database/dao/settings.rs
@@ -187,6 +187,29 @@ impl Database {
         self.set_setting("rectifier_config", &json)
     }
 
+    // --- 出站脱敏配置 ---
+
+    /// 获取出站脱敏配置
+    pub fn get_outbound_redaction_config(
+        &self,
+    ) -> Result<crate::proxy::types::OutboundRedactionConfig, AppError> {
+        match self.get_setting("outbound_redaction_config")? {
+            Some(json) => serde_json::from_str(&json)
+                .map_err(|e| AppError::Database(format!("解析出站脱敏配置失败: {e}"))),
+            None => Ok(crate::proxy::types::OutboundRedactionConfig::default()),
+        }
+    }
+
+    /// 更新出站脱敏配置
+    pub fn set_outbound_redaction_config(
+        &self,
+        config: &crate::proxy::types::OutboundRedactionConfig,
+    ) -> Result<(), AppError> {
+        let json = serde_json::to_string(config)
+            .map_err(|e| AppError::Database(format!("序列化出站脱敏配置失败: {e}")))?;
+        self.set_setting("outbound_redaction_config", &json)
+    }
+
     // --- 日志配置 ---
 
     /// 获取日志配置

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -833,6 +833,8 @@ pub fn run() {
             commands::save_settings,
             commands::get_rectifier_config,
             commands::set_rectifier_config,
+            commands::get_outbound_redaction_config,
+            commands::set_outbound_redaction_config,
             commands::get_log_config,
             commands::set_log_config,
             commands::restart_app,

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -15,6 +15,7 @@ mod health;
 pub mod http_client;
 pub mod log_codes;
 pub mod model_mapper;
+pub mod outbound_redactor;
 pub mod provider_router;
 pub mod providers;
 pub mod response_handler;

--- a/src-tauri/src/proxy/outbound_redactor.rs
+++ b/src-tauri/src/proxy/outbound_redactor.rs
@@ -1,0 +1,586 @@
+//! 出站请求脱敏模块
+//!
+//! 在请求发送到上游之前对请求体进行本地脱敏，避免敏感信息外发。
+
+use super::types::{OutboundRedactionConfig, RedactionErrorStrategy, RedactionMatchMethod};
+use aho_corasick::AhoCorasick;
+use regex::Regex;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// 脱敏统计信息（仅包含计数，不记录原始内容）
+#[derive(Debug, Clone, Default)]
+pub struct RedactionStats {
+    pub total_replacements: usize,
+    pub rule_replacements: BTreeMap<String, usize>,
+}
+
+impl RedactionStats {
+    /// 返回可用于日志打印的简短统计信息
+    pub fn to_log_summary(&self) -> String {
+        if self.rule_replacements.is_empty() {
+            return "none".to_string();
+        }
+        self.rule_replacements
+            .iter()
+            .map(|(rule, count)| format!("{rule}:{count}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+/// 脱敏处理结果
+#[derive(Debug, Clone)]
+pub struct RedactionResult {
+    pub body: Value,
+    pub stats: RedactionStats,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CompiledCustomRule {
+    rule_index: usize,
+    label: String,
+    matcher: RuleMatcher,
+}
+
+#[derive(Debug, Clone)]
+enum RuleMatcher {
+    Regex(Regex),
+    Literal(String),
+}
+
+#[derive(Debug, Default)]
+struct RedactionState {
+    stats: RedactionStats,
+}
+
+impl RedactionState {
+    fn record_replacement(&mut self, label: &str) {
+        self.stats.total_replacements += 1;
+        *self
+            .stats
+            .rule_replacements
+            .entry(label.to_string())
+            .or_insert(0) += 1;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MatchSpan {
+    start: usize,
+    end: usize,
+    rule_index: usize,
+    rule_label: String,
+}
+
+#[derive(Debug)]
+struct CompiledLiteralMatcher {
+    ac: AhoCorasick,
+    // Aho pattern slot -> custom_rules index
+    rule_slots: Vec<usize>,
+}
+
+/// 对请求体执行出站脱敏。
+///
+/// 注意：
+/// - 仅处理 JSON 字符串值
+/// - 当前仅支持「自定义规则」
+/// - 默认异常策略为 warn_and_bypass，不中断请求
+pub fn redact_outbound_payload(
+    body: Value,
+    config: &OutboundRedactionConfig,
+) -> Result<RedactionResult, String> {
+    if !config.enabled {
+        return Ok(RedactionResult {
+            body,
+            stats: RedactionStats::default(),
+            warnings: Vec::new(),
+        });
+    }
+
+    let mut warnings = Vec::new();
+    let rules = compile_custom_rules(config, &mut warnings)?;
+    let literal_matcher = build_literal_matcher(&rules);
+
+    let mut state = RedactionState::default();
+    let mut redacted_body = body;
+    redact_value(
+        &mut redacted_body,
+        &rules,
+        literal_matcher.as_ref(),
+        &mut state,
+    );
+
+    Ok(RedactionResult {
+        body: redacted_body,
+        stats: state.stats,
+        warnings,
+    })
+}
+
+fn compile_custom_rules(
+    config: &OutboundRedactionConfig,
+    warnings: &mut Vec<String>,
+) -> Result<Vec<CompiledCustomRule>, String> {
+    let mut compiled = Vec::new();
+
+    for (index, rule) in config.custom_rules.iter().enumerate() {
+        if !rule.enabled {
+            continue;
+        }
+
+        let rule_index = index;
+        let label = format!("RULE_{}", index + 1);
+        let matcher = match rule.match_method {
+            RedactionMatchMethod::Regex => match Regex::new(&rule.pattern) {
+                Ok(regex) => RuleMatcher::Regex(regex),
+                Err(err) => {
+                    let msg = format!("自定义脱敏规则 #{}, pattern 非法: {err}", index + 1);
+                    handle_rule_error(config.on_error, warnings, msg)?;
+                    continue;
+                }
+            },
+            RedactionMatchMethod::StringMatch => {
+                if rule.pattern.is_empty() {
+                    let msg = format!(
+                        "自定义脱敏规则 #{} 的 string_match pattern 不能为空",
+                        index + 1
+                    );
+                    handle_rule_error(config.on_error, warnings, msg)?;
+                    continue;
+                }
+                RuleMatcher::Literal(rule.pattern.clone())
+            }
+        };
+
+        compiled.push(CompiledCustomRule {
+            rule_index,
+            label,
+            matcher,
+        });
+    }
+
+    Ok(compiled)
+}
+
+fn handle_rule_error(
+    strategy: RedactionErrorStrategy,
+    warnings: &mut Vec<String>,
+    message: String,
+) -> Result<(), String> {
+    match strategy {
+        RedactionErrorStrategy::WarnAndBypass => {
+            warnings.push(message);
+            Ok(())
+        }
+        RedactionErrorStrategy::BlockRequest => Err(message),
+    }
+}
+
+fn redact_value(
+    value: &mut Value,
+    custom_rules: &[CompiledCustomRule],
+    literal_matcher: Option<&CompiledLiteralMatcher>,
+    state: &mut RedactionState,
+) {
+    match value {
+        Value::Object(map) => {
+            for child in map.values_mut() {
+                redact_value(child, custom_rules, literal_matcher, state);
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                redact_value(item, custom_rules, literal_matcher, state);
+            }
+        }
+        Value::String(text) => {
+            let redacted = redact_text(text, custom_rules, literal_matcher, state);
+            *text = redacted;
+        }
+        _ => {}
+    }
+}
+
+fn redact_text(
+    input: &str,
+    custom_rules: &[CompiledCustomRule],
+    literal_matcher: Option<&CompiledLiteralMatcher>,
+    state: &mut RedactionState,
+) -> String {
+    let mut all_matches = collect_matches(input, custom_rules, literal_matcher);
+    if all_matches.is_empty() {
+        return input.to_string();
+    }
+
+    all_matches.sort_by(|a, b| {
+        a.start
+            .cmp(&b.start)
+            .then_with(|| (b.end - b.start).cmp(&(a.end - a.start)))
+            .then_with(|| a.rule_index.cmp(&b.rule_index))
+    });
+
+    let mut selected = Vec::new();
+    let mut occupied_until = 0usize;
+    for span in all_matches {
+        if span.start < occupied_until || span.start >= span.end {
+            continue;
+        }
+        occupied_until = span.end;
+        selected.push(span);
+    }
+
+    if selected.is_empty() {
+        return input.to_string();
+    }
+
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0usize;
+    for span in selected {
+        output.push_str(&input[cursor..span.start]);
+        output.push_str(&mask_for_span(&input[span.start..span.end]));
+        state.record_replacement(&span.rule_label);
+        cursor = span.end;
+    }
+    output.push_str(&input[cursor..]);
+    output
+}
+
+fn build_literal_matcher(custom_rules: &[CompiledCustomRule]) -> Option<CompiledLiteralMatcher> {
+    let mut patterns = Vec::new();
+    let mut rule_slots = Vec::new();
+
+    for (rule_slot, rule) in custom_rules.iter().enumerate() {
+        if let RuleMatcher::Literal(literal) = &rule.matcher {
+            patterns.push(literal.as_str());
+            rule_slots.push(rule_slot);
+        }
+    }
+
+    if patterns.is_empty() {
+        return None;
+    }
+
+    match AhoCorasick::new(&patterns) {
+        Ok(ac) => Some(CompiledLiteralMatcher { ac, rule_slots }),
+        Err(_) => None,
+    }
+}
+
+fn collect_matches(
+    input: &str,
+    custom_rules: &[CompiledCustomRule],
+    literal_matcher: Option<&CompiledLiteralMatcher>,
+) -> Vec<MatchSpan> {
+    let mut matches = Vec::new();
+    for rule in custom_rules {
+        match &rule.matcher {
+            RuleMatcher::Regex(regex) => {
+                for found in regex.find_iter(input) {
+                    if found.start() == found.end() {
+                        continue;
+                    }
+                    matches.push(MatchSpan {
+                        start: found.start(),
+                        end: found.end(),
+                        rule_index: rule.rule_index,
+                        rule_label: rule.label.clone(),
+                    });
+                }
+            }
+            RuleMatcher::Literal(_) => {}
+        }
+    }
+    if let Some(matcher) = literal_matcher {
+        matches.extend(collect_literal_matches(input, custom_rules, matcher));
+    } else {
+        matches.extend(collect_literal_matches_fallback(input, custom_rules));
+    }
+    matches
+}
+
+fn collect_literal_matches(
+    input: &str,
+    custom_rules: &[CompiledCustomRule],
+    literal_matcher: &CompiledLiteralMatcher,
+) -> Vec<MatchSpan> {
+    if literal_matcher.rule_slots.is_empty() {
+        return Vec::new();
+    }
+
+    let mut last_end_by_rule = vec![0usize; literal_matcher.rule_slots.len()];
+    let mut matches = Vec::new();
+
+    for found in literal_matcher.ac.find_overlapping_iter(input) {
+        if found.start() == found.end() {
+            continue;
+        }
+        let rule_slot = found.pattern().as_usize();
+        if found.start() < last_end_by_rule[rule_slot] {
+            continue;
+        }
+        last_end_by_rule[rule_slot] = found.end();
+        let rule = &custom_rules[literal_matcher.rule_slots[rule_slot]];
+        matches.push(MatchSpan {
+            start: found.start(),
+            end: found.end(),
+            rule_index: rule.rule_index,
+            rule_label: rule.label.clone(),
+        });
+    }
+
+    matches
+}
+
+fn collect_literal_matches_fallback(
+    input: &str,
+    custom_rules: &[CompiledCustomRule],
+) -> Vec<MatchSpan> {
+    let mut matches = Vec::new();
+    for rule in custom_rules {
+        let literal = match &rule.matcher {
+            RuleMatcher::Literal(literal) => literal.as_str(),
+            RuleMatcher::Regex(_) => continue,
+        };
+        for (start, end) in find_literal_matches(input, literal) {
+            matches.push(MatchSpan {
+                start,
+                end,
+                rule_index: rule.rule_index,
+                rule_label: rule.label.clone(),
+            });
+        }
+    }
+    matches
+}
+
+fn find_literal_matches(input: &str, literal: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    if literal.is_empty() {
+        return ranges;
+    }
+
+    let mut cursor = 0usize;
+    while let Some(found) = input[cursor..].find(literal) {
+        let start = cursor + found;
+        let end = start + literal.len();
+        ranges.push((start, end));
+        cursor = end;
+    }
+
+    ranges
+}
+
+fn mask_for_span(input: &str) -> String {
+    "*".repeat(input.chars().count())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proxy::types::{
+        CustomRedactionRule, OutboundRedactionConfig, RedactionErrorStrategy, RedactionMatchMethod,
+    };
+    use serde_json::json;
+
+    fn base_config() -> OutboundRedactionConfig {
+        OutboundRedactionConfig {
+            enabled: true,
+            on_error: RedactionErrorStrategy::WarnAndBypass,
+            custom_rules: vec![],
+        }
+    }
+
+    #[test]
+    fn custom_rule_redacts_email_and_phone() {
+        let mut config = base_config();
+        config.custom_rules = vec![
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"\b(?:\+?86[-\s]?)?1[3-9]\d{9}\b".to_string(),
+            },
+        ];
+
+        let body = json!({
+            "content": "email=alice@example.com phone=13800001234"
+        });
+
+        let result = redact_outbound_payload(body, &config).expect("redaction ok");
+        let content = result.body["content"].as_str().unwrap();
+
+        assert_eq!(content, "email=***************** phone=***********");
+        assert_eq!(result.stats.rule_replacements.get("RULE_1"), Some(&1));
+        assert_eq!(result.stats.rule_replacements.get("RULE_2"), Some(&1));
+    }
+
+    #[test]
+    fn invalid_custom_rule_warns_and_bypasses_when_configured() {
+        let mut config = base_config();
+        config.custom_rules = vec![
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: "(".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b".to_string(),
+            },
+        ];
+
+        let body = json!({
+            "email": "alice@example.com"
+        });
+        let result = redact_outbound_payload(body, &config).expect("should not fail");
+        assert!(!result.warnings.is_empty());
+        assert_eq!(result.body["email"], "*****************");
+    }
+
+    #[test]
+    fn invalid_custom_rule_blocks_request_when_configured() {
+        let mut config = base_config();
+        config.on_error = RedactionErrorStrategy::BlockRequest;
+        config.custom_rules = vec![CustomRedactionRule {
+            enabled: true,
+            match_method: RedactionMatchMethod::Regex,
+            pattern: "(".to_string(),
+        }];
+
+        let body = json!({
+            "email": "alice@example.com"
+        });
+        let err = redact_outbound_payload(body, &config).expect_err("should fail");
+        assert!(err.contains("#1"));
+    }
+
+    #[test]
+    fn disabled_config_returns_original_body() {
+        let mut config = base_config();
+        config.enabled = false;
+        let body = json!({
+            "email": "alice@example.com"
+        });
+
+        let result = redact_outbound_payload(body.clone(), &config).expect("ok");
+        assert_eq!(result.body, body);
+        assert_eq!(result.stats.total_replacements, 0);
+    }
+
+    #[test]
+    fn string_match_replaces_literal_content() {
+        let mut config = base_config();
+        config.custom_rules = vec![CustomRedactionRule {
+            enabled: true,
+            match_method: RedactionMatchMethod::StringMatch,
+            pattern: "top-secret".to_string(),
+        }];
+
+        let body = json!({
+            "content": "token=top-secret, again=top-secret"
+        });
+        let result = redact_outbound_payload(body, &config).expect("redaction ok");
+        let content = result.body["content"].as_str().unwrap();
+        assert_eq!(content, "token=**********, again=**********");
+        assert_eq!(result.stats.rule_replacements.get("RULE_1"), Some(&2));
+    }
+
+    #[test]
+    fn overlapping_string_match_prefers_longest_span() {
+        let mut config = base_config();
+        config.custom_rules = vec![
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::StringMatch,
+                pattern: "abc".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::StringMatch,
+                pattern: "abc123".to_string(),
+            },
+        ];
+
+        let body = json!({
+            "v1": "abc",
+            "v2": "abc123",
+        });
+
+        let result = redact_outbound_payload(body, &config).expect("redaction ok");
+        assert_eq!(result.body["v1"], "***");
+        assert_eq!(result.body["v2"], "******");
+        assert_eq!(result.stats.rule_replacements.get("RULE_1"), Some(&1));
+        assert_eq!(result.stats.rule_replacements.get("RULE_2"), Some(&1));
+    }
+
+    #[test]
+    fn tie_break_uses_rule_order_not_label_lexical_order() {
+        let mut config = base_config();
+        config.custom_rules = vec![
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"$^".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: "abc".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"$^".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"$^".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"$^".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"$^".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"$^".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"$^".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::Regex,
+                pattern: r"$^".to_string(),
+            },
+            CustomRedactionRule {
+                enabled: true,
+                match_method: RedactionMatchMethod::StringMatch,
+                pattern: "abc".to_string(),
+            },
+        ];
+
+        let body = json!({ "v": "abc" });
+        let result = redact_outbound_payload(body, &config).expect("redaction ok");
+
+        assert_eq!(result.body["v"], "***");
+        assert_eq!(result.stats.rule_replacements.get("RULE_2"), Some(&1));
+        assert_eq!(result.stats.rule_replacements.get("RULE_10"), None);
+    }
+}

--- a/src/components/settings/OutboundRedactionConfigPanel.tsx
+++ b/src/components/settings/OutboundRedactionConfigPanel.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Plus, Trash2 } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  settingsApi,
+  type CustomRedactionRule,
+  type OutboundRedactionConfig,
+} from "@/lib/api/settings";
+
+const DEFAULT_CONFIG: OutboundRedactionConfig = {
+  enabled: false,
+  onError: "warn_and_bypass",
+  customRules: [],
+};
+const PATTERN_SAVE_DEBOUNCE_MS = 300;
+
+function normalizeConfig(
+  config: OutboundRedactionConfig,
+): OutboundRedactionConfig {
+  return {
+    ...config,
+    customRules: (config.customRules ?? []).map((rule) => ({
+      ...rule,
+      matchMethod: rule.matchMethod ?? "regex",
+    })),
+  };
+}
+
+export function OutboundRedactionConfigPanel() {
+  const { t } = useTranslation();
+  const [config, setConfig] = useState<OutboundRedactionConfig>(DEFAULT_CONFIG);
+  const [isLoading, setIsLoading] = useState(true);
+  const pendingSaveSeqRef = useRef(0);
+  const committedSaveSeqRef = useRef(0);
+  const lastCommittedConfigRef = useRef<OutboundRedactionConfig>(DEFAULT_CONFIG);
+  const saveDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queuedSaveConfigRef = useRef<OutboundRedactionConfig | null>(null);
+
+  useEffect(() => {
+    settingsApi
+      .getOutboundRedactionConfig()
+      .then((remote) => {
+        const normalized = normalizeConfig(remote);
+        setConfig(normalized);
+        lastCommittedConfigRef.current = normalized;
+      })
+      .catch((e) => {
+        console.error("Failed to load outbound redaction config:", e);
+        toast.error(String(e));
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const persistConfig = async (normalized: OutboundRedactionConfig) => {
+    const seq = ++pendingSaveSeqRef.current;
+    try {
+      await settingsApi.setOutboundRedactionConfig(normalized);
+      if (seq > committedSaveSeqRef.current) {
+        committedSaveSeqRef.current = seq;
+        lastCommittedConfigRef.current = normalized;
+      }
+    } catch (e) {
+      console.error("Failed to save outbound redaction config:", e);
+      toast.error(String(e));
+      // Only rollback when the latest write fails to avoid older request races
+      if (seq === pendingSaveSeqRef.current) {
+        setConfig(lastCommittedConfigRef.current);
+      }
+    }
+  };
+
+  const flushQueuedSave = () => {
+    if (saveDebounceTimerRef.current) {
+      clearTimeout(saveDebounceTimerRef.current);
+      saveDebounceTimerRef.current = null;
+    }
+    const queued = queuedSaveConfigRef.current;
+    if (!queued) return;
+    queuedSaveConfigRef.current = null;
+    void persistConfig(queued);
+  };
+
+  const schedulePersist = (
+    normalized: OutboundRedactionConfig,
+    debounceMs: number,
+  ) => {
+    if (saveDebounceTimerRef.current) {
+      clearTimeout(saveDebounceTimerRef.current);
+      saveDebounceTimerRef.current = null;
+    }
+
+    if (debounceMs <= 0) {
+      queuedSaveConfigRef.current = null;
+      void persistConfig(normalized);
+      return;
+    }
+
+    queuedSaveConfigRef.current = normalized;
+    saveDebounceTimerRef.current = setTimeout(() => {
+      saveDebounceTimerRef.current = null;
+      const queued = queuedSaveConfigRef.current;
+      queuedSaveConfigRef.current = null;
+      if (!queued) return;
+      void persistConfig(queued);
+    }, debounceMs);
+  };
+
+  const applyConfig = (
+    updater: (previous: OutboundRedactionConfig) => OutboundRedactionConfig,
+    options?: { debounceMs?: number },
+  ) => {
+    setConfig((previous) => {
+      const next = normalizeConfig(updater(previous));
+      schedulePersist(next, options?.debounceMs ?? 0);
+      return next;
+    });
+  };
+
+  const updateRule = (
+    index: number,
+    updates: Partial<CustomRedactionRule>,
+    options?: { debounceMs?: number },
+  ) => {
+    applyConfig((previous) => {
+      const nextRules = [...previous.customRules];
+      nextRules[index] = { ...nextRules[index], ...updates };
+      return { ...previous, customRules: nextRules };
+    }, options);
+  };
+
+  const addRule = () => {
+    const newRule: CustomRedactionRule = {
+      enabled: false,
+      matchMethod: "regex",
+      pattern: "",
+    };
+    applyConfig((previous) => ({
+      ...previous,
+      customRules: [...previous.customRules, newRule],
+    }));
+  };
+
+  const removeRule = (index: number) => {
+    applyConfig((previous) => ({
+      ...previous,
+      customRules: previous.customRules.filter((_, i) => i !== index),
+    }));
+  };
+
+  useEffect(() => {
+    return () => {
+      if (saveDebounceTimerRef.current) {
+        clearTimeout(saveDebounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  if (isLoading) return null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label>{t("settings.advanced.outboundRedaction.enabled")}</Label>
+          <p className="text-xs text-muted-foreground">
+            {t("settings.advanced.outboundRedaction.enabledDescription")}
+          </p>
+        </div>
+        <Switch
+          checked={config.enabled}
+          onCheckedChange={(checked) =>
+            applyConfig((previous) => ({ ...previous, enabled: checked }))
+          }
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>
+          {t("settings.advanced.outboundRedaction.errorStrategy")}
+        </Label>
+        <Select
+          value={config.onError}
+          disabled={!config.enabled}
+          onValueChange={(value) =>
+            applyConfig((previous) => ({
+              ...previous,
+              onError: value as OutboundRedactionConfig["onError"],
+            }))
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="warn_and_bypass">
+              {t(
+                "settings.advanced.outboundRedaction.errorStrategies.warn_and_bypass",
+              )}
+            </SelectItem>
+            <SelectItem value="block_request">
+              {t(
+                "settings.advanced.outboundRedaction.errorStrategies.block_request",
+              )}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-medium text-muted-foreground">
+            {t("settings.advanced.outboundRedaction.customRules")}
+          </h4>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!config.enabled}
+            onClick={addRule}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("settings.advanced.outboundRedaction.addRule")}
+          </Button>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          {t("settings.advanced.outboundRedaction.customRulesDescription")}
+        </p>
+
+        <div className="space-y-3">
+          {config.customRules.map((rule, index) => (
+            <div
+              key={`rule-${index}`}
+              className="rounded-lg border border-border/60 p-3 space-y-3"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <Label className="text-xs text-muted-foreground">
+                  #{index + 1}
+                </Label>
+                <div className="flex items-center gap-2">
+                  <Select
+                    value={rule.matchMethod}
+                    disabled={!config.enabled}
+                    onValueChange={(value) =>
+                      updateRule(index, {
+                        matchMethod:
+                          value as CustomRedactionRule["matchMethod"],
+                      })
+                    }
+                  >
+                    <SelectTrigger className="w-[130px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="regex">
+                        {t(
+                          "settings.advanced.outboundRedaction.matchMethods.regex",
+                        )}
+                      </SelectItem>
+                      <SelectItem value="string_match">
+                        {t(
+                          "settings.advanced.outboundRedaction.matchMethods.string_match",
+                        )}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Switch
+                    checked={rule.enabled}
+                    disabled={!config.enabled}
+                    onCheckedChange={(checked) =>
+                      updateRule(index, { enabled: checked })
+                    }
+                  />
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    disabled={!config.enabled}
+                    onClick={() => removeRule(index)}
+                  >
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                  </Button>
+                </div>
+              </div>
+              <Input
+                value={rule.pattern}
+                disabled={!config.enabled}
+                placeholder={t(
+                  "settings.advanced.outboundRedaction.patternPlaceholder",
+                )}
+                onChange={(e) => {
+                  const value = e.currentTarget.value;
+                  updateRule(
+                    index,
+                    { pattern: value },
+                    { debounceMs: PATTERN_SAVE_DEBOUNCE_MS },
+                  );
+                }}
+                onBlur={flushQueuedSave}
+              />
+            </div>
+          ))}
+          {config.customRules.length === 0 && (
+            <div className="rounded-lg border border-dashed border-border/70 p-4 text-xs text-muted-foreground">
+              {t("settings.advanced.outboundRedaction.noCustomRules")}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Server, Activity, Zap, Globe } from "lucide-react";
+import { Server, Activity, Zap, Globe, Shield } from "lucide-react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import {
@@ -14,6 +14,7 @@ import { ProxyPanel } from "@/components/proxy";
 import { AutoFailoverConfigPanel } from "@/components/proxy/AutoFailoverConfigPanel";
 import { FailoverQueueManager } from "@/components/proxy/FailoverQueueManager";
 import { RectifierConfigPanel } from "@/components/settings/RectifierConfigPanel";
+import { OutboundRedactionConfigPanel } from "@/components/settings/OutboundRedactionConfigPanel";
 import { GlobalProxySettings } from "@/components/settings/GlobalProxySettings";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { useProxyStatus } from "@/hooks/useProxyStatus";
@@ -238,6 +239,29 @@ export function ProxyTabContent({
           </AccordionTrigger>
           <AccordionContent className="px-6 pb-6 pt-4 border-t border-border/50">
             <RectifierConfigPanel />
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Outbound Redaction */}
+        <AccordionItem
+          value="outboundRedaction"
+          className="rounded-xl glass-card overflow-hidden"
+        >
+          <AccordionTrigger className="px-6 py-4 hover:no-underline hover:bg-muted/50 data-[state=open]:bg-muted/50">
+            <div className="flex items-center gap-3">
+              <Shield className="h-5 w-5 text-blue-500" />
+              <div className="text-left">
+                <h3 className="text-base font-semibold">
+                  {t("settings.advanced.outboundRedaction.title")}
+                </h3>
+                <p className="text-sm text-muted-foreground font-normal">
+                  {t("settings.advanced.outboundRedaction.description")}
+                </p>
+              </div>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent className="px-6 pb-6 pt-4 border-t border-border/50">
+            <OutboundRedactionConfigPanel />
           </AccordionContent>
         </AccordionItem>
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -252,6 +252,26 @@
         "thinkingBudget": "Thinking Budget Rectification",
         "thinkingBudgetDescription": "When an Anthropic-type provider returns budget_tokens constraint errors (such as at least 1024), automatically normalizes thinking to enabled, sets thinking budget to 32000, and raises max_tokens to 64000 if needed, then retries once"
       },
+      "outboundRedaction": {
+        "title": "Outbound Redaction",
+        "description": "Replace sensitive content locally before requests leave the proxy",
+        "enabled": "Enable Outbound Redaction",
+        "enabledDescription": "When enabled, only custom rules are applied locally before forwarding.",
+        "errorStrategy": "Rule Error Strategy",
+        "errorStrategies": {
+          "warn_and_bypass": "Warn and bypass bad rules (default)",
+          "block_request": "Block request"
+        },
+        "customRules": "Custom Rules",
+        "customRulesDescription": "Only custom rules are supported. All matched text is masked locally with * while keeping the same length.",
+        "matchMethods": {
+          "regex": "Regex",
+          "string_match": "String Match"
+        },
+        "addRule": "Add Rule",
+        "noCustomRules": "No custom rules yet",
+        "patternPlaceholder": "Value match pattern (required)"
+      },
       "logConfig": {
         "title": "Log Management",
         "description": "Control log output level",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -252,6 +252,26 @@
         "thinkingBudget": "Thinking Budget 整流",
         "thinkingBudgetDescription": "Anthropic タイプのプロバイダーが budget_tokens 制約エラー（例: 1024 以上）を返した場合、thinking を enabled に正規化し、thinking 予算を 32000 に設定し、必要に応じて max_tokens を 64000 に引き上げて 1 回リトライします"
       },
+      "outboundRedaction": {
+        "title": "送信前マスキング",
+        "description": "上流へ送信する前に機密情報をローカルで置換",
+        "enabled": "送信前マスキングを有効化",
+        "enabledDescription": "有効化すると、カスタムルールでローカル置換してから転送します。",
+        "errorStrategy": "ルールエラー時の動作",
+        "errorStrategies": {
+          "warn_and_bypass": "警告して問題ルールをスキップ（既定）",
+          "block_request": "リクエストを中断"
+        },
+        "customRules": "カスタムルール",
+        "customRulesDescription": "カスタムルールのみ対応。一致した文字列は同じ長さの * にローカルでマスクされます。",
+        "matchMethods": {
+          "regex": "正規表現",
+          "string_match": "文字列一致"
+        },
+        "addRule": "ルール追加",
+        "noCustomRules": "カスタムルールはありません",
+        "patternPlaceholder": "値の一致パターン（必須）"
+      },
       "logConfig": {
         "title": "ログ管理",
         "description": "ログ出力レベルを制御",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -252,6 +252,26 @@
         "thinkingBudget": "Thinking Budget 整流",
         "thinkingBudgetDescription": "当 Anthropic 类型供应商返回 budget_tokens 约束错误（如至少 1024）时，自动将 thinking 规范为 enabled 并将 budget 设为 32000，同时在需要时将 max_tokens 设为 64000，然后重试一次"
       },
+      "outboundRedaction": {
+        "title": "出站信息脱敏",
+        "description": "请求发送到上游前在本地替换敏感信息",
+        "enabled": "启用出站脱敏",
+        "enabledDescription": "开启后仅按自定义规则在本地拦截并替换匹配内容",
+        "errorStrategy": "规则异常策略",
+        "errorStrategies": {
+          "warn_and_bypass": "告警并跳过异常规则（默认）",
+          "block_request": "中断请求"
+        },
+        "customRules": "自定义规则",
+        "customRulesDescription": "仅支持自定义规则，对请求体中的所有字符串值做匹配替换。命中后会按原始长度替换为 *。",
+        "matchMethods": {
+          "regex": "正则匹配",
+          "string_match": "字符串匹配"
+        },
+        "addRule": "新增规则",
+        "noCustomRules": "暂无自定义规则",
+        "patternPlaceholder": "值匹配模式（必填）"
+      },
       "logConfig": {
         "title": "日志管理",
         "description": "控制日志输出级别",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -196,6 +196,16 @@ export const settingsApi = {
     return await invoke("set_rectifier_config", { config });
   },
 
+  async getOutboundRedactionConfig(): Promise<OutboundRedactionConfig> {
+    return await invoke("get_outbound_redaction_config");
+  },
+
+  async setOutboundRedactionConfig(
+    config: OutboundRedactionConfig,
+  ): Promise<boolean> {
+    return await invoke("set_outbound_redaction_config", { config });
+  },
+
   async getLogConfig(): Promise<LogConfig> {
     return await invoke("get_log_config");
   },
@@ -209,6 +219,21 @@ export interface RectifierConfig {
   enabled: boolean;
   requestThinkingSignature: boolean;
   requestThinkingBudget: boolean;
+}
+
+export type RedactionErrorStrategy = "warn_and_bypass" | "block_request";
+export type RedactionMatchMethod = "regex" | "string_match";
+
+export interface CustomRedactionRule {
+  enabled: boolean;
+  matchMethod: RedactionMatchMethod;
+  pattern: string;
+}
+
+export interface OutboundRedactionConfig {
+  enabled: boolean;
+  onError: RedactionErrorStrategy;
+  customRules: CustomRedactionRule[];
 }
 
 export interface LogConfig {


### PR DESCRIPTION
## Summary

  This PR adds a local outbound redaction layer before proxy requests are sent upstream.

  - Sensitive content is redacted locally in request payload string values
  - Forwarding flow remains unchanged (same path/method/response behavior)
  - Logs show redaction stats only (no raw sensitive values)

  ## Changes

  ### Backend
  - Add outbound redaction config and persistence:
    - `enabled`
    - `onError` (`warn_and_bypass` / `block_request`)
    - `customRules` (`enabled`, `matchMethod`, `pattern`)
  - Add Tauri commands:
    - `get_outbound_redaction_config`
    - `set_outbound_redaction_config`
  - Integrate redaction into request forwarding before upstream send
  - Add redactor module with:
    - recursive JSON string-value traversal
    - overlap-safe span replacement
    - longest-match + rule-order tie-break
    - same-length `*` masking
  - Add `aho-corasick` acceleration for `string_match` rules (regex path unchanged)

  ### Frontend
  - Add `OutboundRedactionConfigPanel` under Proxy settings
  - Support:
    - global switch
    - error strategy
    - add/remove/enable/disable rules
    - `regex` / `string_match` mode
  - Add i18n strings (zh/en/ja)
  - Add settings API bindings/types

  ## Product decisions in this PR

  - No built-in rules (custom rules only)
  - Value-based matching only (no key-based matching)
  - Auto mask placeholder with same-length `*`
  - Supports both regex and plain string matching

  ## Extra improvements
  - Fix typing UX issue in rule input
  - Debounce pattern saves and flush on blur
  - Avoid debug-body serialization when debug logging is off

  ## Validation
  - `cargo test --manifest-path src-tauri/Cargo.toml outbound_redactor`
  - `pnpm -s typecheck`
  - `pnpm tauri build --debug --no-bundle`