### PR TITLE
fix: 支持 codex /responses/compact 路由

### DIFF
--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -237,6 +237,23 @@ impl ProxyServer {
             .route("/v1/responses", post(handlers::handle_responses))
             .route("/v1/v1/responses", post(handlers::handle_responses))
             .route("/codex/v1/responses", post(handlers::handle_responses))
+            // OpenAI Responses Compact API (Codex CLI 远程压缩，透传)
+            .route(
+                "/responses/compact",
+                post(handlers::handle_responses_compact),
+            )
+            .route(
+                "/v1/responses/compact",
+                post(handlers::handle_responses_compact),
+            )
+            .route(
+                "/v1/v1/responses/compact",
+                post(handlers::handle_responses_compact),
+            )
+            .route(
+                "/codex/v1/responses/compact",
+                post(handlers::handle_responses_compact),
+            )
             // Gemini API (支持带前缀和不带前缀)
             .route("/v1beta/*path", post(handlers::handle_gemini))
             .route("/gemini/v1beta/*path", post(handlers::handle_gemini))


### PR DESCRIPTION
Close #1144 

### 摘要

本地代理在处理 `/v1/responses/compact` 请求时返回 **404 Not Found**错误，原因是该路由未在 Axum 路由器中注册。Codex 的
远程压缩功能（`/compact`）依赖此端点，通过 OpenAI Responses Compact API实现服务端上下文压缩。

本次PR新增了缺失的路由及处理器：

- **`src-tauri/src/proxy/handlers.rs`** — 新增 `handle_responses_compact` 处理器，该处理器会透明地将请求转发至上游的 `/responses/compact` 接口，
遵循与现有 `handle_responses` 处理器相同的设计模式（包括服务商选择、熔断器、故障转移、使用日志记录）。
- **`src-tauri/src/proxy/server.rs`** — 注册了 4 种路由变体（`/responses/compact`、`/v1/responses/compact`、`/v1/v1/responses/compact`、
`/codex/v1/responses/compact`），与其他端点的路由模式保持一致。

### 变更内容

| 文件路径 | 变更说明 |
|----------|----------|
| `src-tauri/src/proxy/handlers.rs` | 新增 41 行代码 — 实现 `handle_responses_compact` 处理器 |
| `src-tauri/src/proxy/server.rs` | 新增 17 行代码 — 在 Axum 路由器中注册压缩相关路由 |

### 测试计划

- [x] Rust 完整测试套件执行通过（222 个单元测试 + 12 个集成测试，0 个失败用例）
- [x] 对两个修改文件执行 `rustfmt --edition 2021 --check` 格式检查并通过