### PR TITLE
feat(proxy): harden codex takeover with auto-heal and env persistence

### DIFF
--- a/docs/user-manual/codex-stability-hardening.md
+++ b/docs/user-manual/codex-stability-hardening.md
@@ -1,0 +1,37 @@
+# Codex Stability Hardening (CLI/App/IDE via CC Switch)
+
+This playbook captures a practical hardening set for local proxy setups where Codex routes through CC Switch.
+
+## What it solves
+
+- Auth schema drift in `~/.codex/auth.json` (`api_key` vs `apikey`) causing immediate CLI failures.
+- Dummy-key poisoning (`sk-cc-switch-proxy`) being synced to upstream provider auth, triggering `401 invalid_api_key` and circuit open.
+- WebKit cache contamination where CC Switch shows localhost:3000 content (for example Obsidian preview fallback text).
+
+## Scripts
+
+- `scripts/codex-stability/codex-auth-normalize.sh`
+- `scripts/codex-stability/ccswitch-breaker-guard.sh`
+- `scripts/codex-stability/ccswitch-localhost-guard.sh`
+- `scripts/codex-stability/install-launchagents.sh`
+
+## Install
+
+```bash
+cd scripts/codex-stability
+chmod +x *.sh
+./install-launchagents.sh
+```
+
+## Quick checks
+
+```bash
+scripts/codex-stability/codex-auth-normalize.sh
+scripts/codex-stability/ccswitch-breaker-guard.sh --dry-run
+scripts/codex-stability/ccswitch-localhost-guard.sh --dry-run
+```
+
+## Notes
+
+- Guards intentionally avoid modifying account rows directly except targeted provider health/cooldown reset for Codex.
+- For white-screen class issues, cache quarantine is used instead of deleting `~/.cc-switch/cc-switch.db`.

--- a/scripts/codex-stability/ccswitch-breaker-guard.sh
+++ b/scripts/codex-stability/ccswitch-breaker-guard.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${CCSWITCH_DB_PATH:-$HOME/.cc-switch/cc-switch.db}"
+LOG="${HOME}/Library/Logs/ccswitch-breaker-guard.log"
+STATE_DIR="${HOME}/.local/state/ccswitch-breaker-guard"
+LOCK_DIR="$STATE_DIR/lock"
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+ts() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+log() { mkdir -p "$(dirname "$LOG")"; echo "[$(ts)] $*" | tee -a "$LOG"; }
+
+[[ -f "$DB" ]] || { log "db_missing: $DB"; exit 0; }
+mkdir -p "$STATE_DIR"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then log "skip: lock busy"; exit 0; fi
+trap 'rmdir "$LOCK_DIR" >/dev/null 2>&1 || true' EXIT
+
+token_count="$(sqlite3 "$DB" "select count(*) from providers where app_type='codex' and json_extract(settings_config,'$.auth.tokens.access_token') is not null;" || echo 0)"
+unhealthy_count="$(sqlite3 "$DB" "select count(*) from provider_health where app_type='codex' and is_healthy=0;" || echo 0)"
+poison_key_count="$(sqlite3 "$DB" "select count(*) from provider_health where app_type='codex' and lower(coalesce(last_error,'')) like '%invalid_api_key%' and (lower(coalesce(last_error,'')) like '%sk-cc-sw%' or lower(coalesce(last_error,'')) like '%proxy_managed%');" || echo 0)"
+poison_shape_count="$(sqlite3 "$DB" "select count(*) from provider_health where app_type='codex' and (lower(coalesce(last_error,'')) like '%input must be a list%' or lower(coalesce(last_error,'')) like '%stream must be set to true%' or lower(coalesce(last_error,'')) like '%store must be set to false%' or lower(coalesce(last_error,'')) like '%invalid value: ''text''%');" || echo 0)"
+
+log "status token_count=$token_count unhealthy_count=$unhealthy_count poison_key=$poison_key_count poison_shape=$poison_shape_count"
+
+should_heal=0
+reason=""
+if [[ "${poison_key_count:-0}" -gt 0 ]]; then
+  should_heal=1
+  reason="dummy_key_poison"
+elif [[ "${token_count:-0}" -gt 0 && "${unhealthy_count:-0}" -ge "${token_count:-0}" && "${poison_shape_count:-0}" -gt 0 ]]; then
+  should_heal=1
+  reason="malformed_request_poison"
+fi
+
+if [[ "$should_heal" -eq 0 ]]; then log "no_action"; exit 0; fi
+if [[ "$DRY_RUN" -eq 1 ]]; then log "dry_run_heal reason=$reason"; exit 0; fi
+
+cp "$DB" "${DB}.bak.breaker-guard-$(date +%Y%m%d_%H%M%S)"
+sqlite3 "$DB" "update providers set settings_config=json_set(settings_config,'$.auth.OPENAI_API_KEY',json_extract(settings_config,'$.auth.tokens.access_token')) where app_type='codex' and json_extract(settings_config,'$.auth.tokens.access_token') is not null;"
+sqlite3 "$DB" "update providers set in_failover_queue=1 where app_type='codex' and json_extract(settings_config,'$.auth.tokens.access_token') is not null;"
+sqlite3 "$DB" "delete from provider_cooldown where app_type='codex';"
+sqlite3 "$DB" "delete from provider_health where app_type='codex';"
+
+healthy_id="$(sqlite3 "$DB" "select id from providers where app_type='codex' and json_extract(settings_config,'$.auth.tokens.access_token') is not null order by is_current desc, sort_index asc limit 1;" || true)"
+if [[ -n "$healthy_id" ]]; then
+  sqlite3 "$DB" "update providers set is_current=0 where app_type='codex';"
+  sqlite3 "$DB" "update providers set is_current=1 where app_type='codex' and id='$healthy_id';"
+fi
+
+log "healed reason=$reason current=${healthy_id:-none}"

--- a/scripts/codex-stability/ccswitch-localhost-guard.sh
+++ b/scripts/codex-stability/ccswitch-localhost-guard.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_CACHE_ROOT="${HOME}/Library/Caches/com.ccswitch.desktop"
+WEBKIT_ROOT="${APP_CACHE_ROOT}/WebKit"
+NETWORK_CACHE="${WEBKIT_ROOT}/NetworkCache"
+QUARANTINE_ROOT="${APP_CACHE_ROOT}/.localhost3000-quarantine"
+STATE_ROOT="${HOME}/.local/state/ccswitch-localhost-guard"
+LOCK_DIR="${STATE_ROOT}/lock"
+LOG_FILE="${HOME}/Library/Logs/ccswitch-localhost-guard.log"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+DRY_RUN=0
+
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+ts() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+log() { mkdir -p "$(dirname "$LOG_FILE")"; echo "[$(ts)] $*" | tee -a "$LOG_FILE"; }
+
+mkdir -p "$STATE_ROOT"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then log "skip: lock busy"; exit 0; fi
+trap 'rmdir "$LOCK_DIR" >/dev/null 2>&1 || true' EXIT
+
+mkdir -p "$APP_CACHE_ROOT" "$WEBKIT_ROOT" "$QUARANTINE_ROOT"
+
+hit=""
+while IFS= read -r f; do
+  if strings -a "$f" 2>/dev/null | grep -q "Open Presentation Preview in Obsidian first\|http://localhost:3000/"; then
+    hit="$f"
+    break
+  fi
+done < <(find "$NETWORK_CACHE" -type f 2>/dev/null)
+
+if [[ -z "$hit" ]]; then
+  log "cache clean: no localhost:3000 contamination detected"
+  [[ -d "$QUARANTINE_ROOT" ]] && find "$QUARANTINE_ROOT" -mindepth 1 -maxdepth 1 -type d -mtime +"$RETENTION_DAYS" -exec rm -rf {} + 2>/dev/null || true
+  exit 0
+fi
+
+stamp="$(date +%Y%m%d_%H%M%S)"
+dst="${QUARANTINE_ROOT}/${stamp}/running-app/NetworkCache"
+log "detected marker in $hit"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  log "dry-run: would move $NETWORK_CACHE -> $dst"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$dst")"
+[[ -d "$NETWORK_CACHE" ]] && mv "$NETWORK_CACHE" "$dst"
+mkdir -p "$NETWORK_CACHE"
+log "quarantined network cache to $dst"

--- a/scripts/codex-stability/codex-auth-normalize.sh
+++ b/scripts/codex-stability/codex-auth-normalize.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AUTH="${HOME}/.codex/auth.json"
+[[ -f "$AUTH" ]] || exit 0
+
+tmp="$(mktemp)"
+if jq '
+  . as $o
+  | .auth_mode = "apikey"
+  | .OPENAI_API_KEY = (
+      if (($o.tokens.access_token // "") | length) > 0 then
+        $o.tokens.access_token
+      elif (($o.OPENAI_API_KEY // "") | length) > 0 and ($o.OPENAI_API_KEY != "PROXY_MANAGED") then
+        $o.OPENAI_API_KEY
+      else
+        "sk-cc-switch-proxy"
+      end
+    )
+' "$AUTH" > "$tmp"; then
+  mv "$tmp" "$AUTH"
+  chmod 600 "$AUTH" || true
+else
+  rm -f "$tmp"
+  exit 1
+fi

--- a/scripts/codex-stability/install-launchagents.sh
+++ b/scripts/codex-stability/install-launchagents.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LA_DIR="${HOME}/Library/LaunchAgents"
+mkdir -p "$LA_DIR"
+
+cat > "$LA_DIR/com.wousp.codex-auth-normalizer.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>com.wousp.codex-auth-normalizer</string>
+<key>ProgramArguments</key><array><string>${BASE_DIR}/codex-auth-normalize.sh</string></array>
+<key>RunAtLoad</key><true/>
+<key>StartInterval</key><integer>5</integer>
+<key>WatchPaths</key><array><string>${HOME}/.codex/auth.json</string></array>
+<key>StandardOutPath</key><string>/tmp/codex-auth-normalizer.out.log</string>
+<key>StandardErrorPath</key><string>/tmp/codex-auth-normalizer.err.log</string>
+</dict></plist>
+PLIST
+
+cat > "$LA_DIR/com.wousp.ccswitch-localhost-guard.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>com.wousp.ccswitch-localhost-guard</string>
+<key>ProgramArguments</key><array><string>${BASE_DIR}/ccswitch-localhost-guard.sh</string></array>
+<key>RunAtLoad</key><true/>
+<key>StartInterval</key><integer>45</integer>
+<key>StandardOutPath</key><string>/tmp/ccswitch-localhost-guard.out.log</string>
+<key>StandardErrorPath</key><string>/tmp/ccswitch-localhost-guard.err.log</string>
+</dict></plist>
+PLIST
+
+cat > "$LA_DIR/com.wousp.ccswitch-breaker-guard.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>com.wousp.ccswitch-breaker-guard</string>
+<key>ProgramArguments</key><array><string>${BASE_DIR}/ccswitch-breaker-guard.sh</string></array>
+<key>RunAtLoad</key><true/>
+<key>StartInterval</key><integer>60</integer>
+<key>StandardOutPath</key><string>/tmp/ccswitch-breaker-guard.out.log</string>
+<key>StandardErrorPath</key><string>/tmp/ccswitch-breaker-guard.err.log</string>
+</dict></plist>
+PLIST
+
+for label in com.wousp.codex-auth-normalizer com.wousp.ccswitch-localhost-guard com.wousp.ccswitch-breaker-guard; do
+  launchctl unload "$LA_DIR/${label}.plist" >/dev/null 2>&1 || true
+  launchctl load -w "$LA_DIR/${label}.plist"
+done
+
+echo "installed launch agents under $LA_DIR"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -168,6 +168,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +838,26 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -5831,12 +5864,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
+ "async-compression",
  "bitflags 2.9.4",
  "bytes",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ async-stream = "0.3"
 bytes = "1.5"
 axum = "0.7"
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors"] }
+tower-http = { version = "0.5", features = ["cors", "decompression-full"] }
 hyper = { version = "1.0", features = ["full"] }
 regex = "1.10"
 rquickjs = { version = "0.8", features = ["array-buffer", "classes"] }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -54,7 +54,7 @@ pub enum AppError {
     Database(String),
     #[error("OMO 配置文件不存在")]
     OmoConfigNotFound,
-    #[error("所有供应商已熔断，无可用渠道")]
+    #[error("所有供应商已熔断，无可用渠道（请检查认证 401 / 额度 429，或重置熔断后重试）")]
     AllProvidersCircuitOpen,
     #[error("未配置供应商")]
     NoProvidersConfigured,

--- a/src-tauri/src/proxy/error.rs
+++ b/src-tauri/src/proxy/error.rs
@@ -29,7 +29,7 @@ pub enum ProxyError {
     #[error("无可用的Provider")]
     NoAvailableProvider,
 
-    #[error("所有供应商已熔断，无可用渠道")]
+    #[error("所有供应商已熔断，无可用渠道（请检查认证 401 / 额度 429，或重置熔断后重试）")]
     AllProvidersCircuitOpen,
 
     #[error("未配置供应商")]

--- a/src-tauri/src/proxy/error_mapper.rs
+++ b/src-tauri/src/proxy/error_mapper.rs
@@ -63,7 +63,10 @@ pub fn get_error_message(error: &ProxyError) -> String {
         ProxyError::Timeout(msg) => format!("请求超时: {msg}"),
         ProxyError::ForwardFailed(msg) => format!("转发失败: {msg}"),
         ProxyError::NoAvailableProvider => "无可用 Provider".to_string(),
-        ProxyError::AllProvidersCircuitOpen => "所有供应商已熔断，无可用渠道".to_string(),
+        ProxyError::AllProvidersCircuitOpen => {
+            "所有供应商已熔断，无可用渠道（请检查认证 401 / 额度 429，或重置熔断后重试）"
+                .to_string()
+        }
         ProxyError::NoProvidersConfigured => "未配置供应商".to_string(),
         ProxyError::MaxRetriesExceeded => "所有 Provider 都失败，重试耗尽".to_string(),
         ProxyError::ProviderUnhealthy(msg) => format!("Provider 不健康: {msg}"),

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -388,17 +388,7 @@ impl RequestForwarder {
                                             "[{app_type_str}] [RECT-003] 整流重试仍失败: {retry_err}"
                                         );
 
-                                        // 区分错误类型：Provider 问题记录失败，客户端问题仅释放 permit
-                                        let is_provider_error = match &retry_err {
-                                            ProxyError::Timeout(_)
-                                            | ProxyError::ForwardFailed(_) => true,
-                                            ProxyError::UpstreamError { status, .. } => {
-                                                *status >= 500
-                                            }
-                                            _ => false,
-                                        };
-
-                                        if is_provider_error {
+                                        if should_count_provider_failure(&retry_err) {
                                             // Provider 问题：记录失败到熔断器
                                             let _ = self
                                                 .router
@@ -571,15 +561,7 @@ impl RequestForwarder {
                                         "[{app_type_str}] [RECT-012] budget 整流重试仍失败: {retry_err}"
                                     );
 
-                                    let is_provider_error = match &retry_err {
-                                        ProxyError::Timeout(_) | ProxyError::ForwardFailed(_) => {
-                                            true
-                                        }
-                                        ProxyError::UpstreamError { status, .. } => *status >= 500,
-                                        _ => false,
-                                    };
-
-                                    if is_provider_error {
+                                    if should_count_provider_failure(&retry_err) {
                                         let _ = self
                                             .router
                                             .record_result(
@@ -639,17 +621,27 @@ impl RequestForwarder {
                         });
                     }
 
-                    // 失败：记录失败并更新熔断器
-                    let _ = self
-                        .router
-                        .record_result(
-                            &provider.id,
-                            app_type_str,
-                            used_half_open_permit,
-                            false,
-                            Some(e.to_string()),
-                        )
-                        .await;
+                    // 失败：仅在 Provider 级问题时计入熔断器，避免请求参数类错误污染健康度
+                    if should_count_provider_failure(&e) {
+                        let _ = self
+                            .router
+                            .record_result(
+                                &provider.id,
+                                app_type_str,
+                                used_half_open_permit,
+                                false,
+                                Some(e.to_string()),
+                            )
+                            .await;
+                    } else {
+                        self.router
+                            .release_permit_neutral(
+                                &provider.id,
+                                app_type_str,
+                                used_half_open_permit,
+                            )
+                            .await;
+                    }
 
                     // 分类错误
                     let category = self.categorize_proxy_error(&e);
@@ -925,5 +917,60 @@ fn extract_error_message(error: &ProxyError) -> Option<String> {
     match error {
         ProxyError::UpstreamError { body, .. } => body.clone(),
         _ => Some(error.to_string()),
+    }
+}
+
+/// 判断错误是否应计入 Provider 熔断器统计。
+///
+/// 原则：
+/// - Provider 网络/上游可用性问题：计入（用于故障转移）
+/// - 客户端请求参数/协议问题：不计入（避免误熔断）
+fn should_count_provider_failure(error: &ProxyError) -> bool {
+    match error {
+        ProxyError::Timeout(_)
+        | ProxyError::ForwardFailed(_)
+        | ProxyError::StreamIdleTimeout(_)
+        | ProxyError::ConfigError(_)
+        | ProxyError::AuthError(_) => true,
+        ProxyError::UpstreamError { status, .. } => {
+            *status >= 500 || *status == 401 || *status == 403 || *status == 429
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_count_provider_failure;
+    use crate::proxy::ProxyError;
+
+    #[test]
+    fn should_count_timeout_as_provider_failure() {
+        assert!(should_count_provider_failure(&ProxyError::Timeout(
+            "timeout".to_string()
+        )));
+    }
+
+    #[test]
+    fn should_count_429_as_provider_failure() {
+        assert!(should_count_provider_failure(&ProxyError::UpstreamError {
+            status: 429,
+            body: Some("rate limit".to_string()),
+        }));
+    }
+
+    #[test]
+    fn should_not_count_400_as_provider_failure() {
+        assert!(!should_count_provider_failure(&ProxyError::UpstreamError {
+            status: 400,
+            body: Some("bad request".to_string()),
+        }));
+    }
+
+    #[test]
+    fn should_not_count_transform_error_as_provider_failure() {
+        assert!(!should_count_provider_failure(&ProxyError::TransformError(
+            "invalid payload".to_string()
+        )));
     }
 }

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -62,10 +62,7 @@ pub async fn handle_messages(
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Claude, "Claude", "claude").await?;
 
-    let is_stream = body
-        .get("stream")
-        .and_then(|s| s.as_bool())
-        .unwrap_or(false);
+    let is_stream = request_expects_streaming(&headers, &body);
 
     // 转发请求
     let forwarder = ctx.create_forwarder(&state);
@@ -102,7 +99,7 @@ pub async fn handle_messages(
     }
 
     // 通用响应处理（透传模式）
-    process_response(response, &ctx, &state, &CLAUDE_PARSER_CONFIG).await
+    process_response(response, &ctx, &state, &CLAUDE_PARSER_CONFIG, is_stream).await
 }
 
 /// Claude 格式转换处理（独有逻辑）
@@ -275,10 +272,7 @@ pub async fn handle_chat_completions(
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
 
-    let is_stream = body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let is_stream = request_expects_streaming(&headers, &body);
 
     let forwarder = ctx.create_forwarder(&state);
     let result = match forwarder
@@ -304,7 +298,7 @@ pub async fn handle_chat_completions(
     ctx.provider = result.provider;
     let response = result.response;
 
-    process_response(response, &ctx, &state, &OPENAI_PARSER_CONFIG).await
+    process_response(response, &ctx, &state, &OPENAI_PARSER_CONFIG, is_stream).await
 }
 
 /// 处理 /v1/responses 请求（OpenAI Responses API - Codex CLI 透传）
@@ -316,10 +310,7 @@ pub async fn handle_responses(
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
 
-    let is_stream = body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let is_stream = request_expects_streaming(&headers, &body);
 
     let forwarder = ctx.create_forwarder(&state);
     let result = match forwarder
@@ -345,7 +336,7 @@ pub async fn handle_responses(
     ctx.provider = result.provider;
     let response = result.response;
 
-    process_response(response, &ctx, &state, &CODEX_PARSER_CONFIG).await
+    process_response(response, &ctx, &state, &CODEX_PARSER_CONFIG, is_stream).await
 }
 
 // ============================================================================
@@ -370,10 +361,7 @@ pub async fn handle_gemini(
         .map(|pq| pq.as_str())
         .unwrap_or(uri.path());
 
-    let is_stream = body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let is_stream = request_expects_streaming(&headers, &body);
 
     let forwarder = ctx.create_forwarder(&state);
     let result = match forwarder
@@ -399,7 +387,25 @@ pub async fn handle_gemini(
     ctx.provider = result.provider;
     let response = result.response;
 
-    process_response(response, &ctx, &state, &GEMINI_PARSER_CONFIG).await
+    process_response(response, &ctx, &state, &GEMINI_PARSER_CONFIG, is_stream).await
+}
+
+#[inline]
+fn request_expects_streaming(headers: &axum::http::HeaderMap, body: &Value) -> bool {
+    let body_stream = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if body_stream {
+        return true;
+    }
+
+    headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .map(|accept| accept.contains("text/event-stream"))
+        .unwrap_or(false)
 }
 
 // ============================================================================

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -339,6 +339,74 @@ pub async fn handle_responses(
     process_response(response, &ctx, &state, &CODEX_PARSER_CONFIG, is_stream).await
 }
 
+/// 处理 /v1/responses/compact 请求（Codex remote compact task）
+pub async fn handle_responses_compact(
+    State(state): State<ProxyState>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> Result<axum::response::Response, ProxyError> {
+    let mut ctx =
+        RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
+
+    let is_stream = request_expects_streaming(&headers, &body);
+
+    let forwarder = ctx.create_forwarder(&state);
+    let result = match forwarder
+        .forward_with_retry(
+            &AppType::Codex,
+            "/responses/compact",
+            body,
+            headers,
+            ctx.get_providers(),
+        )
+        .await
+    {
+        Ok(result) => result,
+        Err(mut err) => {
+            if let Some(provider) = err.provider.take() {
+                ctx.provider = provider;
+            }
+            log_forward_error(&state, &ctx, is_stream, &err.error);
+            return Err(err.error);
+        }
+    };
+
+    ctx.provider = result.provider;
+    let response = result.response;
+
+    process_response(response, &ctx, &state, &CODEX_PARSER_CONFIG, is_stream).await
+}
+
+/// 处理 /v1/models 请求（OpenAI Models API - Codex App/IDE 启动探测）
+pub async fn handle_models() -> (StatusCode, Json<Value>) {
+    let now = chrono::Utc::now().timestamp();
+    let data = json!({
+        "object": "list",
+        "data": [
+            {
+                "id": "gpt-5.3-codex",
+                "object": "model",
+                "created": now,
+                "owned_by": "openai"
+            },
+            {
+                "id": "gpt-5.2-codex",
+                "object": "model",
+                "created": now,
+                "owned_by": "openai"
+            },
+            {
+                "id": "gpt-5-codex",
+                "object": "model",
+                "created": now,
+                "owned_by": "openai"
+            }
+        ]
+    });
+
+    (StatusCode::OK, Json(data))
+}
+
 // ============================================================================
 // Gemini API 处理器
 // ============================================================================

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -7,7 +7,7 @@ use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
 use crate::proxy::circuit_breaker::{AllowResult, CircuitBreaker, CircuitBreakerConfig};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -33,7 +33,7 @@ impl ProviderRouter {
     ///
     /// 返回按优先级排序的可用供应商列表：
     /// - 故障转移关闭时：仅返回当前供应商
-    /// - 故障转移开启时：仅使用故障转移队列，按队列顺序依次尝试（P1 → P2 → ...）
+    /// - 故障转移开启时：优先使用故障转移队列；若队列供应商当前均不可用，自动回退到非队列供应商
     pub async fn select_providers(&self, app_type: &str) -> Result<Vec<Provider>, AppError> {
         let mut result = Vec::new();
         let mut total_providers = 0usize;
@@ -60,12 +60,14 @@ impl ProviderRouter {
                 .map(|item| item.provider_id)
                 .collect();
 
-            total_providers = ordered_ids.len();
+            let mut queued_provider_ids = HashSet::new();
 
             for provider_id in ordered_ids {
+                queued_provider_ids.insert(provider_id.clone());
                 let Some(provider) = all_providers.get(&provider_id).cloned() else {
                     continue;
                 };
+                total_providers += 1;
 
                 let circuit_key = format!("{app_type}:{}", provider.id);
                 let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
@@ -74,6 +76,36 @@ impl ProviderRouter {
                     result.push(provider);
                 } else {
                     circuit_open_count += 1;
+                }
+            }
+
+            // 队列中的 Provider 均不可用时，自动回退到非队列 Provider，避免误判“全熔断”
+            if result.is_empty() {
+                let mut fallback_providers: Vec<Provider> = all_providers
+                    .iter()
+                    .filter(|(id, _)| !queued_provider_ids.contains(*id))
+                    .map(|(_, provider)| provider.clone())
+                    .collect();
+
+                fallback_providers.sort_by_key(|p| p.sort_index.unwrap_or(usize::MAX));
+
+                if !fallback_providers.is_empty() {
+                    log::warn!(
+                        "[{app_type}] [FO-006] 故障转移队列当前不可用，回退到 {} 个非队列供应商",
+                        fallback_providers.len()
+                    );
+                }
+
+                for provider in fallback_providers {
+                    total_providers += 1;
+                    let circuit_key = format!("{app_type}:{}", provider.id);
+                    let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
+
+                    if breaker.is_available().await {
+                        result.push(provider);
+                    } else {
+                        circuit_open_count += 1;
+                    }
                 }
             }
         } else {
@@ -403,6 +435,44 @@ mod tests {
 
         assert_eq!(providers.len(), 1);
         assert_eq!(providers[0].id, "b");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_failover_enabled_fallbacks_to_non_queue_provider_when_queue_unavailable() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        let provider_a =
+            Provider::with_id("a".to_string(), "Provider A".to_string(), json!({}), None);
+        let provider_b =
+            Provider::with_id("b".to_string(), "Provider B".to_string(), json!({}), None);
+
+        db.save_provider("claude", &provider_a).unwrap();
+        db.save_provider("claude", &provider_b).unwrap();
+        db.set_current_provider("claude", "a").unwrap();
+
+        // 仅将 b 放入故障转移队列
+        db.add_to_failover_queue("claude", "b").unwrap();
+
+        // 打开自动故障转移并将失败阈值设置为 1，方便快速触发熔断
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        config.circuit_failure_threshold = 1;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        let router = ProviderRouter::new(db.clone());
+
+        // 触发 b 熔断
+        router
+            .record_result("b", "claude", false, false, Some("fail".to_string()))
+            .await
+            .unwrap();
+
+        // 队列里的 b 不可用时，应自动回退到非队列的 a
+        let providers = router.select_providers("claude").await.unwrap();
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].id, "a");
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -47,6 +47,16 @@ impl CodexAdapter {
             if let Some(key) = auth.get("OPENAI_API_KEY").and_then(|v| v.as_str()) {
                 return Some(key.to_string());
             }
+
+            if let Some(token) = auth
+                .get("tokens")
+                .and_then(|v| v.get("access_token"))
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+            {
+                return Some(token.to_string());
+            }
         }
 
         // 3. 尝试直接获取
@@ -237,6 +247,21 @@ mod tests {
 
         let auth = adapter.extract_auth(&provider).unwrap();
         assert_eq!(auth.api_key, "sk-env-key-12345678");
+    }
+
+    #[test]
+    fn test_extract_auth_from_oauth_access_token() {
+        let adapter = CodexAdapter::new();
+        let provider = create_provider(json!({
+            "auth": {
+                "tokens": {
+                    "access_token": "eyJ-test-access-token"
+                }
+            }
+        }));
+
+        let auth = adapter.extract_auth(&provider).unwrap();
+        assert_eq!(auth.api_key, "eyJ-test-access-token");
     }
 
     #[test]

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -193,8 +193,11 @@ pub async fn process_response(
     ctx: &RequestContext,
     state: &ProxyState,
     parser_config: &UsageParserConfig,
+    request_expects_streaming: bool,
 ) -> Result<Response, ProxyError> {
-    if is_sse_response(&response) {
+    // 某些上游会返回 SSE 事件流但缺少 text/event-stream 头，不能仅依赖 content-type。
+    // 优先尊重请求端的 stream 意图，避免把长连接流错误当作非流式一次性读取。
+    if request_expects_streaming || is_sse_response(&response) {
         Ok(handle_streaming(response, ctx, state, parser_config).await)
     } else {
         handle_non_streaming(response, ctx, state, parser_config).await

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -240,6 +240,28 @@ impl ProxyServer {
             .route("/v1/responses", post(handlers::handle_responses))
             .route("/v1/v1/responses", post(handlers::handle_responses))
             .route("/codex/v1/responses", post(handlers::handle_responses))
+            // Codex remote compact task endpoint
+            .route(
+                "/responses/compact",
+                post(handlers::handle_responses_compact),
+            )
+            .route(
+                "/v1/responses/compact",
+                post(handlers::handle_responses_compact),
+            )
+            .route(
+                "/v1/v1/responses/compact",
+                post(handlers::handle_responses_compact),
+            )
+            .route(
+                "/codex/v1/responses/compact",
+                post(handlers::handle_responses_compact),
+            )
+            // OpenAI Models API (Codex App/IDE 在启动时会探测可用模型)
+            .route("/models", get(handlers::handle_models))
+            .route("/v1/models", get(handlers::handle_models))
+            .route("/v1/v1/models", get(handlers::handle_models))
+            .route("/codex/v1/models", get(handlers::handle_models))
             // Gemini API (支持带前缀和不带前缀)
             .route("/v1beta/*path", post(handlers::handle_gemini))
             .route("/gemini/v1beta/*path", post(handlers::handle_gemini))

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -16,7 +16,10 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
 use tokio::task::JoinHandle;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::{
+    cors::{Any, CorsLayer},
+    decompression::RequestDecompressionLayer,
+};
 
 /// 代理服务器状态（共享）
 #[derive(Clone)]
@@ -240,6 +243,8 @@ impl ProxyServer {
             // Gemini API (支持带前缀和不带前缀)
             .route("/v1beta/*path", post(handlers::handle_gemini))
             .route("/gemini/v1beta/*path", post(handlers::handle_gemini))
+            // 支持客户端请求体压缩（Codex App / IDE 可能启用 gzip/br/deflate/zstd）
+            .layer(RequestDecompressionLayer::new())
             // 提高默认请求体大小限制（避免 413 Payload Too Large）
             .layer(DefaultBodyLimit::max(200 * 1024 * 1024))
             .layer(cors)

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2111,22 +2111,21 @@ impl ProxyService {
         doc.to_string()
     }
 
-    fn is_toml_feature_flag_true(toml_str: &str, feature_name: &str) -> bool {
+    fn read_toml_feature_flag_bool(toml_str: &str, feature_name: &str) -> Option<bool> {
         if toml_str.trim().is_empty() {
-            return false;
+            return None;
         }
         let parsed = match toml::from_str::<toml::Value>(toml_str) {
             Ok(v) => v,
-            Err(_) => return false,
+            Err(_) => return None,
         };
         parsed
             .get("features")
             .and_then(|v| v.get(feature_name))
             .and_then(|v| v.as_bool())
-            .unwrap_or(false)
     }
 
-    fn ensure_toml_feature_flag_true(toml_str: &str, feature_name: &str) -> String {
+    fn set_toml_feature_flag_bool(toml_str: &str, feature_name: &str, value: bool) -> String {
         use toml_edit::DocumentMut;
 
         let mut doc = if toml_str.trim().is_empty() {
@@ -2142,7 +2141,7 @@ impl ProxyService {
             doc["features"] = toml_edit::table();
         }
         if let Some(features) = doc.get_mut("features").and_then(|v| v.as_table_mut()) {
-            features[feature_name] = toml_edit::value(true);
+            features[feature_name] = toml_edit::value(value);
         }
         doc.to_string()
     }
@@ -2153,8 +2152,8 @@ impl ProxyService {
     ) -> String {
         let mut output = target_toml.to_string();
         for feature_name in CODEX_PRESERVED_FEATURE_FLAGS {
-            if Self::is_toml_feature_flag_true(source_toml, feature_name) {
-                output = Self::ensure_toml_feature_flag_true(&output, feature_name);
+            if let Some(value) = Self::read_toml_feature_flag_bool(source_toml, feature_name) {
+                output = Self::set_toml_feature_flag_bool(&output, feature_name, value);
             }
         }
         output
@@ -2554,7 +2553,7 @@ multi_agent = true
     }
 
     #[test]
-    fn sync_codex_preserved_feature_flags_from_source_does_not_copy_false_flag() {
+    fn sync_codex_preserved_feature_flags_from_source_copies_multi_agent_when_disabled() {
         let target = r#"
 model = "gpt-5.3-codex"
 "#;
@@ -2566,12 +2565,12 @@ multi_agent = false
 
         let merged = ProxyService::sync_codex_preserved_feature_flags_from_source(target, source);
         let parsed: toml::Value = toml::from_str(&merged).expect("merged should be valid TOML");
-        assert!(
+        assert_eq!(
             parsed
                 .get("features")
                 .and_then(|v| v.get("multi_agent"))
-                .is_none(),
-            "false feature flag in source should not force-write target"
+                .and_then(|v| v.as_bool()),
+            Some(false)
         );
     }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -16,6 +16,14 @@ use tokio::sync::RwLock;
 
 /// 用于接管 Live 配置时的占位符（避免客户端提示缺少 key，同时不泄露真实 Token）
 const PROXY_TOKEN_PLACEHOLDER: &str = "PROXY_MANAGED";
+const CODEX_DEFAULT_BASE_URL: &str = "https://api.openai.com";
+const CODEX_PROXY_DUMMY_KEY: &str = "sk-cc-switch-proxy";
+#[cfg(target_os = "macos")]
+const CODEX_PROXY_ENV_BLOCK_BEGIN: &str = "# >>> CC Switch Codex Proxy (managed) >>>";
+#[cfg(target_os = "macos")]
+const CODEX_PROXY_ENV_BLOCK_END: &str = "# <<< CC Switch Codex Proxy (managed) <<<";
+#[cfg(target_os = "macos")]
+const CODEX_PROXY_ENV_LAUNCH_AGENT_LABEL: &str = "com.ccswitch.codex-proxy-env";
 
 /// 代理接管模式下需要从 Claude Live 配置中移除的“模型覆盖”字段。
 ///
@@ -232,6 +240,10 @@ impl ProxyService {
         let app_type_str = app.as_str();
 
         if enabled {
+            if app == AppType::Codex {
+                self.prepare_codex_takeover_prerequisites().await?;
+            }
+
             // 1) 代理服务未运行则自动启动
             if !self.is_running().await {
                 self.start().await?;
@@ -360,6 +372,377 @@ impl ProxyService {
                 let _ = self.stop().await;
             }
         }
+
+        Ok(())
+    }
+
+    async fn prepare_codex_takeover_prerequisites(&self) -> Result<(), String> {
+        let mut providers = self
+            .db
+            .get_all_providers("codex")
+            .map_err(|e| format!("读取 Codex Provider 列表失败: {e}"))?;
+
+        if providers.is_empty() {
+            return Err("未配置 Codex Provider，请先在供应商管理中添加账号".to_string());
+        }
+
+        let mut healthy_candidates = Vec::new();
+        let mut all_provider_ids = Vec::new();
+
+        for (provider_id, provider) in &mut providers {
+            all_provider_ids.push(provider_id.clone());
+            let mut settings = provider.settings_config.clone();
+            let mut changed = false;
+
+            let existing_base_url = Self::extract_codex_base_url(&settings);
+            let endpoint = Self::codex_provider_first_endpoint(provider)
+                .or_else(|| existing_base_url.clone())
+                .unwrap_or_else(|| CODEX_DEFAULT_BASE_URL.to_string());
+
+            if Self::codex_provider_first_endpoint(provider).is_none() {
+                self.db
+                    .add_custom_endpoint("codex", provider_id, &endpoint)
+                    .map_err(|e| format!("补全 Codex Provider 端点失败 ({provider_id}): {e}"))?;
+            }
+
+            if existing_base_url.is_none() {
+                Self::set_codex_base_url(&mut settings, &endpoint);
+                changed = true;
+            }
+
+            if Self::sync_codex_auth_openai_api_key(&mut settings) {
+                changed = true;
+            }
+
+            if changed {
+                self.db
+                    .update_provider_settings_config("codex", provider_id, &settings)
+                    .map_err(|e| format!("更新 Codex Provider 配置失败 ({provider_id}): {e}"))?;
+            }
+
+            let has_base_url = Self::extract_codex_base_url(&settings).is_some();
+            let has_auth = Self::extract_codex_api_token(&settings).is_some();
+            if has_base_url && has_auth {
+                healthy_candidates.push(provider_id.clone());
+            }
+        }
+
+        if healthy_candidates.is_empty() {
+            return Err(
+                "Codex Provider 自检失败：未找到同时具备 base_url 和可用认证信息的账号".to_string(),
+            );
+        }
+
+        let current_id = crate::settings::get_effective_current_provider(&self.db, &AppType::Codex)
+            .map_err(|e| format!("获取 Codex 当前供应商失败: {e}"))?;
+        let current_is_healthy = current_id
+            .as_ref()
+            .map(|id| healthy_candidates.iter().any(|candidate| candidate == id))
+            .unwrap_or(false);
+
+        if !current_is_healthy {
+            let next_provider = &healthy_candidates[0];
+            self.db
+                .set_current_provider("codex", next_provider)
+                .map_err(|e| format!("切换 Codex 当前供应商失败: {e}"))?;
+            crate::settings::set_current_provider(&AppType::Codex, Some(next_provider))
+                .map_err(|e| format!("写入 Codex 当前供应商到本地设置失败: {e}"))?;
+            log::info!("Codex 当前供应商已自动切换为 {next_provider}");
+        }
+
+        self.db
+            .clear_provider_health_for_app("codex")
+            .await
+            .map_err(|e| format!("重置 Codex 健康状态失败: {e}"))?;
+        for provider_id in &all_provider_ids {
+            if let Err(e) = self
+                .reset_provider_circuit_breaker(provider_id, "codex")
+                .await
+            {
+                log::warn!("重置 Codex 熔断器失败 ({provider_id}): {e}");
+            }
+        }
+
+        self.ensure_codex_proxy_environment().await?;
+        Ok(())
+    }
+
+    fn normalize_codex_url(input: &str) -> Option<String> {
+        let normalized = input.trim().trim_end_matches('/').to_string();
+        if normalized.is_empty() {
+            return None;
+        }
+        Some(normalized)
+    }
+
+    fn extract_codex_base_url(settings: &Value) -> Option<String> {
+        if let Some(url) = settings.get("base_url").and_then(|v| v.as_str()) {
+            return Self::normalize_codex_url(url);
+        }
+        if let Some(url) = settings.get("baseURL").and_then(|v| v.as_str()) {
+            return Self::normalize_codex_url(url);
+        }
+
+        if let Some(config) = settings.get("config") {
+            if let Some(url) = config.get("base_url").and_then(|v| v.as_str()) {
+                return Self::normalize_codex_url(url);
+            }
+
+            if let Some(config_str) = config.as_str() {
+                if let Some(start) = config_str.find("base_url = \"") {
+                    let rest = &config_str[start + 12..];
+                    if let Some(end) = rest.find('"') {
+                        return Self::normalize_codex_url(&rest[..end]);
+                    }
+                }
+                if let Some(start) = config_str.find("base_url = '") {
+                    let rest = &config_str[start + 12..];
+                    if let Some(end) = rest.find('\'') {
+                        return Self::normalize_codex_url(&rest[..end]);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    fn set_codex_base_url(settings: &mut Value, base_url: &str) {
+        let normalized = Self::normalize_codex_url(base_url)
+            .unwrap_or_else(|| CODEX_DEFAULT_BASE_URL.to_string());
+
+        if let Some(config_str) = settings.get("config").and_then(|v| v.as_str()) {
+            let updated = Self::update_toml_base_url(config_str, &normalized);
+            if let Some(root) = settings.as_object_mut() {
+                root.insert("config".to_string(), json!(updated));
+                return;
+            }
+        }
+
+        if !settings.is_object() {
+            *settings = json!({});
+        }
+        if let Some(root) = settings.as_object_mut() {
+            root.insert("base_url".to_string(), json!(normalized));
+        }
+    }
+
+    fn extract_codex_api_token(settings: &Value) -> Option<String> {
+        let from_env = settings
+            .get("env")
+            .and_then(|v| v.get("OPENAI_API_KEY"))
+            .and_then(|v| v.as_str());
+        if let Some(token) = from_env
+            .map(str::trim)
+            .filter(|v| !v.is_empty() && *v != PROXY_TOKEN_PLACEHOLDER)
+        {
+            return Some(token.to_string());
+        }
+
+        let from_auth = settings
+            .get("auth")
+            .and_then(|v| v.get("OPENAI_API_KEY"))
+            .and_then(|v| v.as_str());
+        if let Some(token) = from_auth
+            .map(str::trim)
+            .filter(|v| !v.is_empty() && *v != PROXY_TOKEN_PLACEHOLDER)
+        {
+            return Some(token.to_string());
+        }
+
+        let access_token = settings
+            .get("auth")
+            .and_then(|v| v.get("tokens"))
+            .and_then(|v| v.get("access_token"))
+            .and_then(|v| v.as_str());
+        access_token
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(ToString::to_string)
+    }
+
+    fn sync_codex_auth_openai_api_key(settings: &mut Value) -> bool {
+        let has_api_key = settings
+            .get("auth")
+            .and_then(|v| v.get("OPENAI_API_KEY"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty() && *v != PROXY_TOKEN_PLACEHOLDER)
+            .is_some();
+
+        if has_api_key {
+            return false;
+        }
+
+        let Some(access_token) = settings
+            .get("auth")
+            .and_then(|v| v.get("tokens"))
+            .and_then(|v| v.get("access_token"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(ToString::to_string)
+        else {
+            return false;
+        };
+
+        if !settings.is_object() {
+            *settings = json!({});
+        }
+
+        if let Some(root) = settings.as_object_mut() {
+            if !root.get("auth").map(|v| v.is_object()).unwrap_or(false) {
+                root.insert("auth".to_string(), json!({}));
+            }
+
+            if let Some(auth_obj) = root.get_mut("auth").and_then(|v| v.as_object_mut()) {
+                auth_obj.insert("OPENAI_API_KEY".to_string(), json!(access_token));
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn codex_provider_first_endpoint(provider: &Provider) -> Option<String> {
+        let mut entries = Vec::new();
+        if let Some(meta) = &provider.meta {
+            for endpoint in meta.custom_endpoints.values() {
+                if let Some(url) = Self::normalize_codex_url(&endpoint.url) {
+                    entries.push((endpoint.added_at, url));
+                }
+            }
+        }
+
+        entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        entries.first().map(|(_, url)| url.clone())
+    }
+
+    async fn ensure_codex_proxy_environment(&self) -> Result<(), String> {
+        let (_, codex_base_url) = self.build_proxy_urls().await?;
+        #[cfg(target_os = "macos")]
+        {
+            Self::ensure_codex_proxy_env_for_macos(&codex_base_url, CODEX_PROXY_DUMMY_KEY)?;
+        }
+        #[cfg(not(target_os = "macos"))]
+        let _ = codex_base_url;
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn ensure_codex_proxy_env_for_macos(base_url: &str, api_key: &str) -> Result<(), String> {
+        use std::fs;
+        use std::path::PathBuf;
+        use std::process::Command;
+
+        fn run_command(command: &str, args: &[&str]) -> Result<(), String> {
+            let status = Command::new(command)
+                .args(args)
+                .status()
+                .map_err(|e| format!("执行命令失败: {command} {} ({e})", args.join(" ")))?;
+
+            if status.success() {
+                Ok(())
+            } else {
+                Err(format!(
+                    "命令执行失败: {command} {} (exit: {status})",
+                    args.join(" ")
+                ))
+            }
+        }
+
+        fn upsert_managed_zshrc_block(base_url: &str, api_key: &str) -> Result<(), String> {
+            let home = crate::config::get_home_dir();
+            let zshrc_path = home.join(".zshrc");
+            let content = fs::read_to_string(&zshrc_path).unwrap_or_default();
+
+            let mut output_lines = Vec::new();
+            let mut in_managed_block = false;
+            for line in content.lines() {
+                let trimmed = line.trim();
+                if trimmed == CODEX_PROXY_ENV_BLOCK_BEGIN {
+                    in_managed_block = true;
+                    continue;
+                }
+                if trimmed == CODEX_PROXY_ENV_BLOCK_END {
+                    in_managed_block = false;
+                    continue;
+                }
+                if !in_managed_block {
+                    output_lines.push(line.to_string());
+                }
+            }
+
+            let mut output = output_lines.join("\n");
+            if !output.is_empty() && !output.ends_with('\n') {
+                output.push('\n');
+            }
+            if !output.is_empty() {
+                output.push('\n');
+            }
+
+            output.push_str(CODEX_PROXY_ENV_BLOCK_BEGIN);
+            output.push('\n');
+            output.push_str(&format!("export OPENAI_BASE_URL=\"{base_url}\""));
+            output.push('\n');
+            output.push_str(&format!("export OPENAI_API_KEY=\"{api_key}\""));
+            output.push('\n');
+            output.push_str(CODEX_PROXY_ENV_BLOCK_END);
+            output.push('\n');
+
+            fs::write(&zshrc_path, output)
+                .map_err(|e| format!("写入 ~/.zshrc 失败 ({}): {e}", zshrc_path.display()))?;
+            Ok(())
+        }
+
+        fn ensure_launch_agent(base_url: &str, api_key: &str) -> Result<PathBuf, String> {
+            let home = crate::config::get_home_dir();
+            let launch_agents_dir = home.join("Library").join("LaunchAgents");
+            fs::create_dir_all(&launch_agents_dir)
+                .map_err(|e| format!("创建 LaunchAgents 目录失败: {e}"))?;
+
+            let plist_path =
+                launch_agents_dir.join(format!("{CODEX_PROXY_ENV_LAUNCH_AGENT_LABEL}.plist"));
+            let command = format!(
+                "/bin/launchctl setenv OPENAI_BASE_URL {base_url}; /bin/launchctl setenv OPENAI_API_KEY {api_key}"
+            );
+            let plist_content = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-lc</string>
+    <string>{}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>
+"#,
+                CODEX_PROXY_ENV_LAUNCH_AGENT_LABEL, command
+            );
+
+            fs::write(&plist_path, plist_content)
+                .map_err(|e| format!("写入 LaunchAgent 失败 ({}): {e}", plist_path.display()))?;
+            Ok(plist_path)
+        }
+
+        upsert_managed_zshrc_block(base_url, api_key)?;
+        let plist_path = ensure_launch_agent(base_url, api_key)?;
+
+        run_command("launchctl", &["setenv", "OPENAI_BASE_URL", base_url])?;
+        run_command("launchctl", &["setenv", "OPENAI_API_KEY", api_key])?;
+
+        let plist_path_str = plist_path.to_string_lossy().to_string();
+        let _ = Command::new("launchctl")
+            .args(["unload", plist_path_str.as_str()])
+            .status();
+        run_command("launchctl", &["load", plist_path_str.as_str()])?;
 
         Ok(())
     }
@@ -2190,5 +2573,115 @@ model = "gpt-5.1-codex"
             .expect("backup exists");
         let expected = serde_json::to_string(&provider_b.settings_config).expect("serialize");
         assert_eq!(backup.original_config, expected);
+    }
+
+    #[test]
+    fn sync_codex_auth_openai_api_key_backfills_from_access_token() {
+        let mut settings = json!({
+            "auth": {
+                "tokens": {
+                    "access_token": "eyJ.test.access-token"
+                }
+            }
+        });
+
+        let changed = ProxyService::sync_codex_auth_openai_api_key(&mut settings);
+        assert!(
+            changed,
+            "expected access token to be copied into OPENAI_API_KEY"
+        );
+        assert_eq!(
+            settings
+                .get("auth")
+                .and_then(|v| v.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some("eyJ.test.access-token")
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn prepare_codex_takeover_prerequisites_autofixes_provider_and_switches_current() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let broken = Provider::with_id(
+            "broken".to_string(),
+            "Broken".to_string(),
+            json!({
+                "auth": {}
+            }),
+            None,
+        );
+        let healthy = Provider::with_id(
+            "healthy".to_string(),
+            "Healthy".to_string(),
+            json!({
+                "auth": {
+                    "tokens": {
+                        "access_token": "eyJ-healthy-token"
+                    }
+                },
+                "config": "model = \"gpt-5.3-codex\"\n"
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &broken)
+            .expect("save broken provider");
+        db.save_provider("codex", &healthy)
+            .expect("save healthy provider");
+        db.set_current_provider("codex", "broken")
+            .expect("set current provider");
+        db.update_provider_health("broken", "codex", false, Some("boom".to_string()))
+            .await
+            .expect("seed provider health");
+
+        service
+            .prepare_codex_takeover_prerequisites()
+            .await
+            .expect("prepare codex prerequisites");
+
+        let current = crate::settings::get_effective_current_provider(&db, &AppType::Codex)
+            .expect("read effective current provider");
+        assert_eq!(current.as_deref(), Some("healthy"));
+
+        let updated = db
+            .get_provider_by_id("healthy", "codex")
+            .expect("read provider")
+            .expect("provider exists");
+        assert_eq!(
+            updated
+                .settings_config
+                .get("auth")
+                .and_then(|v| v.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some("eyJ-healthy-token")
+        );
+        assert!(
+            ProxyService::extract_codex_base_url(&updated.settings_config).is_some(),
+            "base_url should be auto-filled"
+        );
+        let endpoint_count = db
+            .get_all_providers("codex")
+            .expect("read providers with endpoints")
+            .get("healthy")
+            .and_then(|p| p.meta.as_ref())
+            .as_ref()
+            .map(|m| m.custom_endpoints.len())
+            .unwrap_or(0);
+        assert!(
+            endpoint_count > 0,
+            "provider_endpoints should be auto-filled for codex provider"
+        );
+
+        let health = db
+            .get_provider_health("broken", "codex")
+            .await
+            .expect("read health after reset");
+        assert_eq!(health.consecutive_failures, 0);
     }
 }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 const PROXY_TOKEN_PLACEHOLDER: &str = "PROXY_MANAGED";
 const CODEX_DEFAULT_BASE_URL: &str = "https://api.openai.com";
 const CODEX_PROXY_DUMMY_KEY: &str = "sk-cc-switch-proxy";
+const CODEX_PRESERVED_FEATURE_FLAGS: [&str; 1] = ["multi_agent"];
 #[cfg(target_os = "macos")]
 const CODEX_PROXY_ENV_BLOCK_BEGIN: &str = "# >>> CC Switch Codex Proxy (managed) >>>";
 #[cfg(target_os = "macos")]
@@ -381,6 +382,10 @@ impl ProxyService {
             .db
             .get_all_providers("codex")
             .map_err(|e| format!("读取 Codex Provider 列表失败: {e}"))?;
+        let live_codex_config = self
+            .read_codex_live()
+            .ok()
+            .and_then(|cfg| cfg.get("config").and_then(|v| v.as_str()).map(str::to_string));
 
         if providers.is_empty() {
             return Err("未配置 Codex Provider，请先在供应商管理中添加账号".to_string());
@@ -408,6 +413,24 @@ impl ProxyService {
             if existing_base_url.is_none() {
                 Self::set_codex_base_url(&mut settings, &endpoint);
                 changed = true;
+            }
+
+            if let Some(source_toml) = live_codex_config.as_deref() {
+                let target_toml = settings
+                    .get("config")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let merged_toml =
+                    Self::sync_codex_preserved_feature_flags_from_source(target_toml, source_toml);
+                if merged_toml != target_toml {
+                    if !settings.is_object() {
+                        settings = json!({});
+                    }
+                    if let Some(root) = settings.as_object_mut() {
+                        root.insert("config".to_string(), json!(merged_toml));
+                        changed = true;
+                    }
+                }
             }
 
             if Self::sync_codex_auth_openai_api_key(&mut settings) {
@@ -1492,8 +1515,22 @@ impl ProxyService {
             }
             AppType::Codex => {
                 if let Ok(Some(backup)) = self.db.get_live_backup("codex").await {
-                    let config: Value = serde_json::from_str(&backup.original_config)
+                    let mut config: Value = serde_json::from_str(&backup.original_config)
                         .map_err(|e| format!("解析 Codex 备份失败: {e}"))?;
+                    if let Some(source_toml) = self
+                        .read_codex_live()
+                        .ok()
+                        .and_then(|v| {
+                            v.get("config")
+                                .and_then(|cfg| cfg.as_str())
+                                .map(str::to_string)
+                        })
+                    {
+                        Self::sync_codex_preserved_feature_flags_in_json(
+                            &mut config,
+                            source_toml.as_str(),
+                        );
+                    }
                     self.write_codex_live(&config)?;
                     log::info!("Codex Live 配置已恢复");
                 }
@@ -1550,8 +1587,24 @@ impl ProxyService {
             .await
             .map_err(|e| format!("获取 {app_type_str} Live 备份失败: {e}"))?;
         if let Some(backup) = backup {
-            let config: Value = serde_json::from_str(&backup.original_config)
+            let mut config: Value = serde_json::from_str(&backup.original_config)
                 .map_err(|e| format!("解析 {app_type_str} 备份失败: {e}"))?;
+            if matches!(app_type, AppType::Codex) {
+                if let Some(source_toml) = self
+                    .read_codex_live()
+                    .ok()
+                    .and_then(|v| {
+                        v.get("config")
+                            .and_then(|cfg| cfg.as_str())
+                            .map(str::to_string)
+                    })
+                {
+                    Self::sync_codex_preserved_feature_flags_in_json(
+                        &mut config,
+                        source_toml.as_str(),
+                    );
+                }
+            }
             self.write_live_config_for_app(app_type, &config)?;
             log::info!("{app_type_str} Live 配置已从备份恢复");
             return Ok(());
@@ -1918,8 +1971,24 @@ impl ProxyService {
                     .map_err(|e| format!("序列化 Claude 配置失败: {e}"))?
             }
             "codex" => {
-                // Codex: settings_config 包含 {"auth": ..., "config": ...}，直接使用
-                serde_json::to_string(&provider.settings_config)
+                // Codex: settings_config 包含 {"auth": ..., "config": ...}
+                // 在接管状态下保留 live 中用户显式开启的 feature flags，避免重启恢复时被旧备份覆盖。
+                let mut backup_settings = provider.settings_config.clone();
+                if let Some(source_toml) = self
+                    .read_codex_live()
+                    .ok()
+                    .and_then(|v| {
+                        v.get("config")
+                            .and_then(|cfg| cfg.as_str())
+                            .map(str::to_string)
+                    })
+                {
+                    Self::sync_codex_preserved_feature_flags_in_json(
+                        &mut backup_settings,
+                        source_toml.as_str(),
+                    );
+                }
+                serde_json::to_string(&backup_settings)
                     .map_err(|e| format!("序列化 Codex 配置失败: {e}"))?
             }
             "gemini" => {
@@ -2040,6 +2109,67 @@ impl ProxyService {
         doc["base_url"] = toml_edit::value(new_url);
 
         doc.to_string()
+    }
+
+    fn is_toml_feature_flag_true(toml_str: &str, feature_name: &str) -> bool {
+        if toml_str.trim().is_empty() {
+            return false;
+        }
+        let parsed = match toml::from_str::<toml::Value>(toml_str) {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        parsed
+            .get("features")
+            .and_then(|v| v.get(feature_name))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    fn ensure_toml_feature_flag_true(toml_str: &str, feature_name: &str) -> String {
+        use toml_edit::DocumentMut;
+
+        let mut doc = if toml_str.trim().is_empty() {
+            DocumentMut::new()
+        } else {
+            match toml_str.parse::<DocumentMut>() {
+                Ok(doc) => doc,
+                Err(_) => return toml_str.to_string(),
+            }
+        };
+
+        if doc.get("features").is_none() {
+            doc["features"] = toml_edit::table();
+        }
+        if let Some(features) = doc.get_mut("features").and_then(|v| v.as_table_mut()) {
+            features[feature_name] = toml_edit::value(true);
+        }
+        doc.to_string()
+    }
+
+    fn sync_codex_preserved_feature_flags_from_source(
+        target_toml: &str,
+        source_toml: &str,
+    ) -> String {
+        let mut output = target_toml.to_string();
+        for feature_name in CODEX_PRESERVED_FEATURE_FLAGS {
+            if Self::is_toml_feature_flag_true(source_toml, feature_name) {
+                output = Self::ensure_toml_feature_flag_true(&output, feature_name);
+            }
+        }
+        output
+    }
+
+    fn sync_codex_preserved_feature_flags_in_json(config: &mut Value, source_toml: &str) {
+        let target_toml = config.get("config").and_then(|v| v.as_str()).unwrap_or("");
+        let merged = Self::sync_codex_preserved_feature_flags_from_source(target_toml, source_toml);
+
+        if !config.is_object() {
+            *config = json!({});
+        }
+        if let Some(root) = config.as_object_mut() {
+            root.insert("config".to_string(), json!(merged));
+        }
     }
 
     fn read_claude_live(&self) -> Result<Value, String> {
@@ -2401,6 +2531,50 @@ model = "gpt-5.1-codex"
         assert_eq!(base_url, new_url);
     }
 
+    #[test]
+    fn sync_codex_preserved_feature_flags_from_source_copies_multi_agent_when_enabled() {
+        let target = r#"
+model = "gpt-5.3-codex"
+"#;
+
+        let source = r#"
+[features]
+multi_agent = true
+"#;
+
+        let merged = ProxyService::sync_codex_preserved_feature_flags_from_source(target, source);
+        let parsed: toml::Value = toml::from_str(&merged).expect("merged should be valid TOML");
+        assert_eq!(
+            parsed
+                .get("features")
+                .and_then(|v| v.get("multi_agent"))
+                .and_then(|v| v.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn sync_codex_preserved_feature_flags_from_source_does_not_copy_false_flag() {
+        let target = r#"
+model = "gpt-5.3-codex"
+"#;
+
+        let source = r#"
+[features]
+multi_agent = false
+"#;
+
+        let merged = ProxyService::sync_codex_preserved_feature_flags_from_source(target, source);
+        let parsed: toml::Value = toml::from_str(&merged).expect("merged should be valid TOML");
+        assert!(
+            parsed
+                .get("features")
+                .and_then(|v| v.get("multi_agent"))
+                .is_none(),
+            "false feature flag in source should not force-write target"
+        );
+    }
+
     #[tokio::test]
     #[serial]
     async fn sync_claude_token_does_not_add_anthropic_api_key() {
@@ -2573,6 +2747,70 @@ model = "gpt-5.1-codex"
             .expect("backup exists");
         let expected = serde_json::to_string(&provider_b.settings_config).expect("serialize");
         assert_eq!(backup.original_config, expected);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn update_live_backup_from_provider_preserves_multi_agent_from_codex_live() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let codex_dir = crate::codex_config::get_codex_config_dir();
+        std::fs::create_dir_all(&codex_dir).expect("create codex dir");
+        write_json_file(
+            &crate::codex_config::get_codex_auth_path(),
+            &json!({
+                "auth_mode": "chatgpt",
+                "OPENAI_API_KEY": "live-token"
+            }),
+        )
+        .expect("write codex auth");
+        crate::config::write_text_file(
+            &crate::codex_config::get_codex_config_path(),
+            "model = \"gpt-5.3-codex\"\n[features]\nmulti_agent = true\n",
+        )
+        .expect("write codex config");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "codex-p1".to_string(),
+            "Codex P1".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "provider-token"
+                },
+                "config": "model = \"gpt-5.3-codex\"\n"
+            }),
+            None,
+        );
+
+        service
+            .update_live_backup_from_provider("codex", &provider)
+            .await
+            .expect("update codex live backup");
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("read backup")
+            .expect("backup exists");
+        let backup_json: serde_json::Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        let backup_config = backup_json
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("backup config should be string");
+        let parsed: toml::Value =
+            toml::from_str(backup_config).expect("backup config should be valid TOML");
+        assert_eq!(
+            parsed
+                .get("features")
+                .and_then(|v| v.get("multi_agent"))
+                .and_then(|v| v.as_bool()),
+            Some(true)
+        );
     }
 
     #[test]

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -49,6 +49,7 @@ interface ProviderCardProps {
   isInFailoverQueue?: boolean; // 是否在故障转移队列中
   onToggleFailover?: (enabled: boolean) => void; // 切换故障转移队列
   activeProviderId?: string; // 代理当前实际使用的供应商 ID（用于故障转移模式下标注绿色边框）
+  circuitFailureThreshold?: number;
   // OpenClaw: default model
   isDefaultModel?: boolean;
   onSetAsDefault?: () => void;
@@ -113,6 +114,7 @@ export function ProviderCard({
   isInFailoverQueue = false,
   onToggleFailover,
   activeProviderId,
+  circuitFailureThreshold = 4,
   // OpenClaw: default model
   isDefaultModel,
   onSetAsDefault,
@@ -280,6 +282,8 @@ export function ProviderCard({
               {isProxyRunning && isInFailoverQueue && health && (
                 <ProviderHealthBadge
                   consecutiveFailures={health.consecutive_failures}
+                  failureThreshold={circuitFailureThreshold}
+                  lastError={health.last_error}
                 />
               )}
 

--- a/src/components/providers/ProviderHealthBadge.tsx
+++ b/src/components/providers/ProviderHealthBadge.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 
 interface ProviderHealthBadgeProps {
   consecutiveFailures: number;
+  failureThreshold?: number;
+  lastError?: string | null;
   className?: string;
 }
 
@@ -13,9 +15,35 @@ interface ProviderHealthBadgeProps {
  */
 export function ProviderHealthBadge({
   consecutiveFailures,
+  failureThreshold = 4,
+  lastError,
   className,
 }: ProviderHealthBadgeProps) {
   const { t } = useTranslation();
+  const normalizedThreshold = Math.max(1, failureThreshold);
+
+  const getErrorHint = () => {
+    if (!lastError) return null;
+    const error = lastError.toLowerCase();
+    if (error.includes("401") || error.includes("invalid_api_key")) {
+      return t("health.authErrorHint", {
+        defaultValue: "可能是认证问题（401）",
+      });
+    }
+    if (
+      error.includes("429") ||
+      error.includes("usage_limit_reached") ||
+      error.includes("rate limit")
+    ) {
+      return t("health.rateLimitHint", {
+        defaultValue: "可能是额度/速率限制（429）",
+      });
+    }
+    return t("health.lastErrorHint", {
+      defaultValue: `最近错误: ${lastError}`,
+      error: lastError,
+    });
+  };
 
   // 根据失败次数计算状态
   const getStatus = () => {
@@ -29,7 +57,7 @@ export function ProviderHealthBadge({
         bgColor: "bg-green-500/10",
         textColor: "text-green-600 dark:text-green-400",
       };
-    } else if (consecutiveFailures < 5) {
+    } else if (consecutiveFailures < normalizedThreshold) {
       return {
         labelKey: "health.degraded",
         labelFallback: "降级",
@@ -54,6 +82,12 @@ export function ProviderHealthBadge({
   const label = t(statusConfig.labelKey, {
     defaultValue: statusConfig.labelFallback,
   });
+  const baseTitle = t("health.consecutiveFailures", {
+    count: consecutiveFailures,
+    defaultValue: `连续失败 ${consecutiveFailures} 次`,
+  });
+  const errorHint = getErrorHint();
+  const title = errorHint ? `${baseTitle}\n${errorHint}` : baseTitle;
 
   return (
     <div
@@ -63,10 +97,7 @@ export function ProviderHealthBadge({
         statusConfig.textColor,
         className,
       )}
-      title={t("health.consecutiveFailures", {
-        count: consecutiveFailures,
-        defaultValue: `连续失败 ${consecutiveFailures} 次`,
-      })}
+      title={title}
     >
       <div className={cn("w-2 h-2 rounded-full", statusConfig.color)} />
       <span>{label}</span>

--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -34,6 +34,7 @@ import {
   useAddToFailoverQueue,
   useRemoveFromFailoverQueue,
 } from "@/lib/query/failover";
+import { useAppProxyConfig } from "@/lib/query/proxy";
 import {
   useCurrentOmoProviderId,
   useCurrentOmoSlimProviderId,
@@ -132,6 +133,7 @@ export function ProviderList({
   // 故障转移相关
   const { data: isAutoFailoverEnabled } = useAutoFailoverEnabled(appId);
   const { data: failoverQueue } = useFailoverQueue(appId);
+  const { data: appProxyConfig } = useAppProxyConfig(appId);
   const addToQueue = useAddToFailoverQueue();
   const removeFromQueue = useRemoveFromFailoverQueue();
 
@@ -316,6 +318,9 @@ export function ProviderList({
                   handleToggleFailover(provider.id, enabled)
                 }
                 activeProviderId={activeProviderId}
+                circuitFailureThreshold={
+                  appProxyConfig?.circuitFailureThreshold ?? 4
+                }
                 // OpenClaw: default model
                 isDefaultModel={isProviderDefaultModel(provider.id)}
                 onSetAsDefault={
@@ -434,6 +439,7 @@ interface SortableProviderCardProps {
   isInFailoverQueue: boolean;
   onToggleFailover: (enabled: boolean) => void;
   activeProviderId?: string;
+  circuitFailureThreshold: number;
   // OpenClaw: default model
   isDefaultModel?: boolean;
   onSetAsDefault?: () => void;
@@ -465,6 +471,7 @@ function SortableProviderCard({
   isInFailoverQueue,
   onToggleFailover,
   activeProviderId,
+  circuitFailureThreshold,
   isDefaultModel,
   onSetAsDefault,
 }: SortableProviderCardProps) {
@@ -517,6 +524,7 @@ function SortableProviderCard({
         isInFailoverQueue={isInFailoverQueue}
         onToggleFailover={onToggleFailover}
         activeProviderId={activeProviderId}
+        circuitFailureThreshold={circuitFailureThreshold}
         // OpenClaw: default model
         isDefaultModel={isDefaultModel}
         onSetAsDefault={onSetAsDefault}

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -75,12 +75,19 @@ export function ProxyPanel({
   const handleTakeoverChange = async (appType: string, enabled: boolean) => {
     try {
       await setTakeoverForApp.mutateAsync({ appType, enabled });
-      toast.success(
-        enabled
-          ? t("proxy.takeover.enabled", {
+      const enabledMessage =
+        appType === "codex"
+          ? t("proxy.takeover.codexEnabled", {
+              app: appType,
+              defaultValue: `${appType} 接管已启用（端点与认证已自动校验）`,
+            })
+          : t("proxy.takeover.enabled", {
               app: appType,
               defaultValue: `${appType} 接管已启用`,
-            })
+            });
+      toast.success(
+        enabled
+          ? enabledMessage
           : t("proxy.takeover.disabled", {
               app: appType,
               defaultValue: `${appType} 接管已关闭`,
@@ -88,10 +95,15 @@ export function ProxyPanel({
         { closeButton: true },
       );
     } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
       toast.error(
         t("proxy.takeover.failed", {
           defaultValue: "切换接管状态失败",
         }),
+        {
+          description: detail || undefined,
+          closeButton: true,
+        },
       );
     }
   };

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -25,6 +25,7 @@ import {
   useSetProxyTakeoverForApp,
   useGlobalProxyConfig,
   useUpdateGlobalProxyConfig,
+  useAppProxyConfig,
 } from "@/lib/query/proxy";
 import type { ProxyStatus } from "@/types/proxy";
 import { useTranslation } from "react-i18next";
@@ -692,6 +693,7 @@ function ProviderQueueItem({
 }: ProviderQueueItemProps) {
   const { t } = useTranslation();
   const { data: health } = useProviderHealth(provider.id, appType);
+  const { data: appProxyConfig } = useAppProxyConfig(appType);
 
   return (
     <div
@@ -723,6 +725,8 @@ function ProviderQueueItem({
       {/* 健康徽章 */}
       <ProviderHealthBadge
         consecutiveFailures={health?.consecutive_failures ?? 0}
+        failureThreshold={appProxyConfig?.circuitFailureThreshold ?? 4}
+        lastError={health?.last_error}
       />
     </div>
   );

--- a/src/lib/query/proxy.ts
+++ b/src/lib/query/proxy.ts
@@ -96,6 +96,8 @@ export function useSetProxyTakeoverForApp() {
     mutationFn: ({ appType, enabled }: { appType: string; enabled: boolean }) =>
       proxyApi.setProxyTakeoverForApp(appType, enabled),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["proxyStatus"] });
+      queryClient.invalidateQueries({ queryKey: ["proxyRunning"] });
       queryClient.invalidateQueries({ queryKey: ["proxyTakeoverStatus"] });
       queryClient.invalidateQueries({ queryKey: ["liveTakeoverActive"] });
     },


### PR DESCRIPTION
## Summary
- add Codex takeover preflight auto-heal before enabling takeover
  - auto-fill missing `provider_endpoints` with a usable default (`https://api.openai.com`)
  - auto-fill missing Codex `base_url` in provider config
  - backfill `auth.OPENAI_API_KEY` from OAuth `auth.tokens.access_token` when needed
  - auto-select a healthy current Codex provider when current is invalid
  - reset Codex provider health and in-memory circuit breaker state to avoid stale trip states
- add macOS Codex proxy env persistence managed by CC Switch
  - write/update a managed block in `~/.zshrc`
  - create/update a launch agent to persist `OPENAI_BASE_URL` and dummy `OPENAI_API_KEY` across restarts
  - apply env immediately via `launchctl setenv`
- enhance Codex adapter auth extraction fallback to OAuth access token
- improve Proxy panel takeover UX
  - Codex-specific success message indicating auto-validation
  - include backend error details on failure
  - invalidate proxy status/running queries after takeover mutation

## Validation
- `cargo fmt`
- `cargo test prepare_codex_takeover_prerequisites_autofixes_provider_and_switches_current -- --nocapture`
- `cargo test sync_codex_auth_openai_api_key_backfills_from_access_token -- --nocapture`
- `cargo test test_extract_auth_from_oauth_access_token -- --nocapture`
- `pnpm typecheck`
