### PR TITLE
fix: 修复最小化到托盘后应用过一段时间自动退出的问题

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1061,9 +1061,18 @@ pub fn run() {
 
     app.run(|app_handle, event| {
         // 处理退出请求（所有平台）
-        if let RunEvent::ExitRequested { api, .. } = &event {
-            log::info!("收到退出请求，开始清理...");
-            // 阻止立即退出，执行清理
+        if let RunEvent::ExitRequested { api, code, .. } = &event {
+            // code 为 None 表示运行时自动触发（如隐藏窗口的 WebView 被回收导致无存活窗口），
+            // 此时应仅阻止退出、保持托盘后台运行；
+            // code 为 Some(_) 表示用户主动调用 app.exit() 退出（如托盘菜单"退出"），
+            // 此时执行清理后退出。
+            if code.is_none() {
+                log::info!("运行时触发退出请求（无存活窗口），阻止退出以保持托盘后台运行");
+                api.prevent_exit();
+                return;
+            }
+
+            log::info!("收到用户主动退出请求 (code={code:?})，开始清理...");
             api.prevent_exit();
 
             let app_handle = app_handle.clone();


### PR DESCRIPTION
## 问题

Close #728

Windows 平台下，关闭窗口最小化到托盘后，应用过一段时间会自动退出。

## 根因

`ExitRequested` 事件处理器在调用 `api.prevent_exit()` 后，无条件 spawn 了一个异步任务执行 `cleanup_before_exit()` +
`std::process::exit(0)`，完全抵消了 `prevent_exit()` 的效果。

当隐藏窗口的 WebView 被 Windows 后台优化策略回收、窗口对象销毁后，Tauri 运行时检测到无存活窗口自动触发 `ExitRequested`，应用随即退出。

## 修复

通过 `ExitRequested` 的 `code` 字段区分两种场景：

- `code` 为 `None`（运行时自动触发）：仅 `prevent_exit()`，保持托盘后台运行
- `code` 为 `Some(_)`（用户主动调用 `app.exit()`）：执行清理后退出

参考 [Tauri 2 官方文档](https://docs.rs/tauri/2.9.2/tauri/struct.ExitRequestApi.html)：

> *"Prevents the app from exiting. This will cause the core thread to continue running in the background even without any open windows."*

## 测试

在 Windows 11 上编译安装，端到端验证
- [ ] 最小化到托盘后长时间不再自动退出
- [x] 托盘菜单"退出"功能正常。