### PR TITLE
Add Bailian For Coding preset configuration

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -133,6 +133,19 @@ export const providerPresets: ProviderPreset[] = [
     icon: "bailian",
     iconColor: "#624AFF",
   },
+{
+    name: "Bailian For Coding",
+    websiteUrl: "https://bailian.console.aliyun.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://coding.dashscope.aliyuncs.com/apps/anthropic",
+        ANTHROPIC_AUTH_TOKEN: "",
+      },
+    },
+    category: "cn_official",
+    icon: "bailian",
+    iconColor: "#624AFF",
+  },
   {
     name: "Kimi",
     websiteUrl: "https://platform.moonshot.cn/console",


### PR DESCRIPTION
问题描述
bailian 模块使用的请求地址  https://dashscope.aliyuncs.com/apps/anthropic  仅适用于普通订阅用户，订阅 code 的用户调用该地址会无法正常使用

修改内容
增加bailian For Coding模块提供给 code 订阅用户：
正确地址:  https://coding.dashscope.aliyuncs.com/apps/anthropic 

测试验证
测试环境：本地搭建 ccswitch 运行环境，使用 code 订阅的阿里云 DashScope 账号 测试步骤：
  1. 修改地址前：调用 bailian 接口提示请求失败/无权限
  2. 修改地址后：成功调用接口，返回正常响应结果 影响范围：仅增加bailian For Coding模块，未改动其他逻辑，不影响非 code 订阅用户的使用