### PR TITLE
Feature : Add Upstream Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ copilot-api
 .history
 CODEBUDDY.md
 .github
+.pnpm-store/
+
+Dockerfile
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,3 @@ copilot-api
 .history
 CODEBUDDY.md
 .github
-.pnpm-store/
-
-Dockerfile
-docker-compose.yml

--- a/docs/changes-2026-03-04-upstream-proxy.md
+++ b/docs/changes-2026-03-04-upstream-proxy.md
@@ -1,0 +1,75 @@
+# Upstream Proxy（写回地址）+ Rust 编译修复
+
+日期：2026-03-04
+
+## 背景 / 目标
+当前本地代理的「监听端口」与写回到各客户端（Claude/Codex/Gemini Live 配置）的代理地址是强绑定的。
+
+本次新增 **GlobalProxyConfig.upstreamUrl**：
+- 写回 Live 配置时使用该 upstreamUrl（仅允许 `http(s)://host:port` 的 origin）
+- 代理服务实际启动/监听仍使用本地 `listen_address/listen_port`
+
+该能力用于给用户提供一个“中间层端口”，便于插入调试/转发代理。
+
+## 功能变更
+### 1) 数据库与后端接口
+- 在 `proxy_config` 表新增字段 `upstream_url`，并将数据库版本从 v5 升级到 v6，提供迁移逻辑（ALTER TABLE / add_column_if_missing）。
+- 新增/扩展 Tauri Command：`get_global_proxy_config` / `update_global_proxy_config` 读取与写入 `upstream_url`。
+- 在 `update_global_proxy_config` 增加 upstreamUrl 校验与规范化：
+  - 仅允许 http/https
+  - 必须包含 host 与 port
+  - 不允许 path/query/fragment
+  - 入库时规范化为 origin（不带末尾 `/`）
+
+相关文件：
+- src-tauri/src/database/schema.rs
+- src-tauri/src/database/mod.rs
+- src-tauri/src/database/dao/proxy.rs
+- src-tauri/src/commands/proxy.rs
+- src-tauri/src/proxy/types.rs
+
+### 2) 写回 Live 配置逻辑
+- 构造写回 URL 时（build_proxy_urls）：
+  - 若设置了 `upstream_url`，则写回使用它
+  - 否则回退到 `http://{listen_address}:{listen_port}`（并对 0.0.0.0 / IPv6 做回环地址处理）
+
+相关文件：
+- src-tauri/src/services/proxy.rs
+
+### 3) 前端配置 UI
+- Proxy 面板新增 Upstream URL 输入框
+- 保存前做同等规则的 URL 校验
+- i18n（en/ja/zh）新增对应文案
+- TS 类型 `GlobalProxyConfig` 新增 `upstreamUrl?: string | null`
+
+相关文件：
+- src/components/proxy/ProxyPanel.tsx
+- src/types/proxy.ts
+- src/i18n/locales/en.json
+- src/i18n/locales/ja.json
+- src/i18n/locales/zh.json
+
+## Rust 编译修复（你本次遇到的 E0308）
+问题：`ProxyServer::new` 需要 `ProxyConfig`，但 `ProxyService::start()` 误传了 `GlobalProxyConfig`。
+
+修复：
+- `ProxyService::start()` 改为使用 `db.get_proxy_config()`（旧版 ProxyConfig，包含运行时配置）
+- `GlobalProxyConfig` 继续用于 UI 全局字段与写回 upstream_url
+
+## 补充：macOS / Unix 构建修复（E0599: write_all not found）
+问题：在 `#[cfg(unix)]` 分支中调用 `file.write_all(...)`，需要 `std::io::Write` trait 在作用域内；此前移除全局 `use std::io::Write;` 后，macOS aarch64 构建会报错。
+
+修复：
+- 在 `#[cfg(unix)]` 代码块内局部 `use std::io::Write;`，仅对 Unix 生效，不影响 Windows。
+
+相关文件：
+- src-tauri/src/settings.rs
+
+## 测试 / 构建验证
+- 已在 Windows 环境执行：
+  - `cargo build --manifest-path src-tauri/Cargo.toml`
+  - 结果：编译通过
+
+## 注意事项
+- upstreamUrl 只影响“写回客户端配置”的地址；不改变本地代理真实监听端口。
+- upstreamUrl 必须是 origin（`http(s)://host:port`），不允许包含 path/query/fragment。

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -6,6 +6,7 @@ use crate::error::AppError;
 use crate::proxy::types::*;
 use crate::proxy::{CircuitBreakerConfig, CircuitBreakerStats};
 use crate::store::AppState;
+use url::Url;
 
 /// 启动代理服务器（仅启动服务，不接管 Live 配置）
 #[tauri::command]
@@ -84,8 +85,44 @@ pub async fn get_global_proxy_config(
 #[tauri::command]
 pub async fn update_global_proxy_config(
     state: tauri::State<'_, AppState>,
-    config: GlobalProxyConfig,
+    mut config: GlobalProxyConfig,
 ) -> Result<(), String> {
+    // upstream_url 校验（仅允许 origin，http/https://host:port；空表示使用 listen_address/listen_port）
+    if let Some(raw) = config.upstream_url.as_ref() {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            config.upstream_url = None;
+        } else {
+            let url = Url::parse(trimmed).map_err(|e| format!("upstreamUrl 无效: {e}"))?;
+            match url.scheme() {
+                "http" | "https" => {}
+                other => {
+                    return Err(format!(
+                        "upstreamUrl 仅支持 http/https，当前为 {other}"
+                    ))
+                }
+            }
+            if url.host_str().is_none() {
+                return Err("upstreamUrl 必须包含 host".to_string());
+            }
+            if url.port().is_none() {
+                return Err("upstreamUrl 必须包含 port".to_string());
+            }
+            if !url.path().is_empty() && url.path() != "/" {
+                return Err("upstreamUrl 只允许 origin，不允许包含 path".to_string());
+            }
+            if url.query().is_some() {
+                return Err("upstreamUrl 不允许包含 query".to_string());
+            }
+            if url.fragment().is_some() {
+                return Err("upstreamUrl 不允许包含 fragment".to_string());
+            }
+
+            // 规范化：存 origin（包含 scheme://host[:port]，不带末尾 /）
+            config.upstream_url = Some(url.origin().ascii_serialization());
+        }
+    }
+
     let db = &state.db;
     db.update_global_proxy_config(config)
         .await

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -19,7 +19,7 @@ impl Database {
         let result = {
             let conn = lock_conn!(self.conn);
             conn.query_row(
-                "SELECT proxy_enabled, listen_address, listen_port, enable_logging
+                "SELECT proxy_enabled, listen_address, listen_port, enable_logging, upstream_url
                  FROM proxy_config WHERE app_type = 'claude'",
                 [],
                 |row| {
@@ -28,6 +28,7 @@ impl Database {
                         listen_address: row.get(1)?,
                         listen_port: row.get::<_, i32>(2)? as u16,
                         enable_logging: row.get::<_, i32>(3)? != 0,
+                        upstream_url: row.get(4)?,
                     })
                 },
             )
@@ -44,6 +45,7 @@ impl Database {
                     listen_address: "127.0.0.1".to_string(),
                     listen_port: 15721,
                     enable_logging: true,
+                    upstream_url: None,
                 })
             }
             Err(e) => Err(AppError::Database(e.to_string())),
@@ -63,12 +65,14 @@ impl Database {
                 listen_address = ?2,
                 listen_port = ?3,
                 enable_logging = ?4,
+                upstream_url = ?5,
                 updated_at = datetime('now')",
             rusqlite::params![
                 if config.proxy_enabled { 1 } else { 0 },
                 config.listen_address,
                 config.listen_port as i32,
                 if config.enable_logging { 1 } else { 0 },
+                config.upstream_url,
             ],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -123,6 +123,7 @@ impl Database {
             app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','gemini')),
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 15721, enable_logging INTEGER NOT NULL DEFAULT 1,
+            upstream_url TEXT,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
             max_retries INTEGER NOT NULL DEFAULT 3, streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60,
             streaming_idle_timeout INTEGER NOT NULL DEFAULT 120, non_streaming_timeout INTEGER NOT NULL DEFAULT 600,
@@ -283,6 +284,9 @@ impl Database {
             [],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // 尝试添加 upstream_url 列到 proxy_config 表
+        let _ = conn.execute("ALTER TABLE proxy_config ADD COLUMN upstream_url TEXT", []);
 
         // 尝试添加 live_takeover_active 列到 proxy_config 表
         let _ = conn.execute(

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -162,6 +162,8 @@ pub struct GlobalProxyConfig {
     pub listen_port: u16,
     /// 是否启用日志
     pub enable_logging: bool,
+    /// 写回 Live 配置用的上游 URL（origin，仅 http/https://host:port；为空则使用 listen_address/listen_port）
+    pub upstream_url: Option<String>,
 }
 
 /// 应用级代理配置（每个 app 独立）

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -170,8 +170,11 @@ impl ProxyService {
                 .map_err(|e| format!("更新代理总开关失败: {e}"))?;
         }
 
-        // 2. 获取配置
-        let config = self
+        // 2. 获取配置（用于启动本地监听服务）
+        //
+        // 注意：这里需要的是旧版 ProxyConfig（包含 max_retries/timeout 等运行时配置），
+        // 而不是 GlobalProxyConfig（仅用于 UI 统一字段与写回 Live 的 upstream_url）。
+        let proxy_config = self
             .db
             .get_proxy_config()
             .await
@@ -190,7 +193,7 @@ impl ProxyService {
 
         // 4. 创建并启动服务器
         let app_handle = self.app_handle.read().await.clone();
-        let server = ProxyServer::new(config.clone(), self.db.clone(), app_handle);
+        let server = ProxyServer::new(proxy_config.clone(), self.db.clone(), app_handle);
         let info = server
             .start()
             .await
@@ -895,7 +898,7 @@ impl ProxyService {
     async fn build_proxy_urls(&self) -> Result<(String, String), String> {
         let config = self
             .db
-            .get_proxy_config()
+            .get_global_proxy_config()
             .await
             .map_err(|e| format!("获取代理配置失败: {e}"))?;
 
@@ -912,9 +915,12 @@ impl ProxyService {
             connect_host
         };
 
-        let proxy_origin = format!("http://{}:{}", connect_host_for_url, config.listen_port);
+        let proxy_origin = match &config.upstream_url {
+            Some(url) if !url.trim().is_empty() => url.trim().trim_end_matches('/').to_string(),
+            _ => format!("http://{}:{}", connect_host_for_url, config.listen_port),
+        };
         let proxy_url = proxy_origin.clone();
-        let proxy_codex_base_url = format!("{}/v1", proxy_origin.trim_end_matches('/'));
+        let proxy_codex_base_url = format!("{}/v1", proxy_origin);
 
         Ok((proxy_url, proxy_codex_base_url))
     }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{OnceLock, RwLock};
 
@@ -433,6 +432,7 @@ fn save_settings_file(settings: &AppSettings) -> Result<(), AppError> {
     #[cfg(unix)]
     {
         use std::fs::OpenOptions;
+        use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
 
         let mut file = OpenOptions::new()

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -54,15 +54,17 @@ export function ProxyPanel({
   const { data: globalConfig } = useGlobalProxyConfig();
   const updateGlobalConfig = useUpdateGlobalProxyConfig();
 
-  // 监听地址/端口的本地状态（端口用字符串以支持完全清空）
+  // 监听地址/端口/Upstream URL 的本地状态（端口用字符串以支持完全清空）
   const [listenAddress, setListenAddress] = useState("127.0.0.1");
   const [listenPort, setListenPort] = useState("15721");
+  const [upstreamUrl, setUpstreamUrl] = useState("");
 
   // 同步全局配置到本地状态
   useEffect(() => {
     if (globalConfig) {
       setListenAddress(globalConfig.listenAddress);
       setListenPort(String(globalConfig.listenPort));
+      setUpstreamUrl(globalConfig.upstreamUrl ?? "");
     }
   }, [globalConfig]);
 
@@ -159,11 +161,78 @@ export function ProxyPanel({
       );
       return;
     }
+
+    // upstreamUrl 校验：仅允许 http/https origin（scheme + host + port），不允许 path/query/fragment
+    const upstreamTrimmed = upstreamUrl.trim();
+    let upstreamUrlToSave: string | null = null;
+    if (upstreamTrimmed.length > 0) {
+      let url: URL;
+      try {
+        url = new URL(upstreamTrimmed);
+      } catch {
+        toast.error(
+          t("proxy.settings.invalidUpstreamUrl", {
+            defaultValue: "Upstream URL 无效，请输入 http(s)://host:port",
+          }),
+        );
+        return;
+      }
+
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        toast.error(
+          t("proxy.settings.invalidUpstreamUrl", {
+            defaultValue: "Upstream URL 仅支持 http/https",
+          }),
+        );
+        return;
+      }
+
+      if (!url.hostname) {
+        toast.error(
+          t("proxy.settings.invalidUpstreamUrl", {
+            defaultValue: "Upstream URL 必须包含 host",
+          }),
+        );
+        return;
+      }
+
+      if (!url.port) {
+        toast.error(
+          t("proxy.settings.invalidUpstreamUrl", {
+            defaultValue: "Upstream URL 必须包含 port（1024-65535）",
+          }),
+        );
+        return;
+      }
+      const uPort = parseInt(url.port);
+      if (isNaN(uPort) || uPort < 1024 || uPort > 65535) {
+        toast.error(
+          t("proxy.settings.invalidUpstreamUrl", {
+            defaultValue: "Upstream URL 端口必须在 1024-65535 范围内",
+          }),
+        );
+        return;
+      }
+
+      if (url.pathname !== "/" || url.search || url.hash) {
+        toast.error(
+          t("proxy.settings.invalidUpstreamUrl", {
+            defaultValue:
+              "Upstream URL 只允许 origin（不允许包含 path/query/fragment）",
+          }),
+        );
+        return;
+      }
+
+      upstreamUrlToSave = `${url.protocol}//${url.host}`;
+    }
+
     try {
       await updateGlobalConfig.mutateAsync({
         ...globalConfig,
         listenAddress: addressTrimmed,
         listenPort: port,
+        upstreamUrl: upstreamUrlToSave,
       });
       toast.success(
         t("proxy.settings.configSaved", { defaultValue: "代理配置已保存" }),
@@ -539,6 +608,31 @@ export function ProxyPanel({
                   <p className="text-xs text-muted-foreground">
                     {t("proxy.settings.fields.listenPort.description", {
                       defaultValue: "代理服务器监听的端口号（1024 ~ 65535）",
+                    })}
+                  </p>
+                </div>
+
+                <div className="space-y-2 md:col-span-2">
+                  <Label htmlFor="upstream-url">
+                    {t("proxy.settings.fields.upstreamUrl.label", {
+                      defaultValue: "Upstream URL",
+                    })}
+                  </Label>
+                  <Input
+                    id="upstream-url"
+                    value={upstreamUrl}
+                    onChange={(e) => setUpstreamUrl(e.target.value)}
+                    placeholder={t(
+                      "proxy.settings.fields.upstreamUrl.placeholder",
+                      {
+                        defaultValue: "http://127.0.0.1:15721",
+                      },
+                    )}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {t("proxy.settings.fields.upstreamUrl.description", {
+                      defaultValue:
+                        "写回到各应用配置的代理地址（仅支持 http/https origin；留空则使用监听地址/端口）。如果指向其他端口，请在该地址上运行转发/调试代理并转发到本应用监听端口。",
                     })}
                   </p>
                 </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1979,6 +1979,11 @@
           "placeholder": "15721",
           "description": "Port number the routing server listens on (1024 ~ 65535)"
         },
+        "upstreamUrl": {
+          "label": "Upstream URL",
+          "placeholder": "http://127.0.0.1:15721",
+          "description": "Proxy URL written back to client configs (http/https origin only; leave empty to use listen address/port). If you point to another port, run a forwarding/debug proxy there that forwards to this app's listen port."
+        },
         "maxRetries": {
           "label": "Max Retries",
           "placeholder": "3",
@@ -2029,6 +2034,7 @@
       "invalidAddress": "Invalid address, please enter a valid IP address (e.g. 127.0.0.1) or localhost",
       "configSaved": "Routing configuration saved",
       "configSaveFailed": "Failed to save configuration",
+      "invalidUpstreamUrl": "Invalid upstream URL, please enter http(s)://host:port (origin only)",
       "restartRequired": "Restart routing service for address or port changes to take effect"
     },
     "switchFailed": "Switch failed: {{error}}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1979,6 +1979,11 @@
           "placeholder": "15721",
           "description": "ルーティングサーバーがリッスンするポート番号（1024 ~ 65535）"
         },
+        "upstreamUrl": {
+          "label": "Upstream URL",
+          "placeholder": "http://127.0.0.1:15721",
+          "description": "クライアント設定へ書き戻すプロキシURL（http/httpsのoriginのみ。空ならlistenアドレス/ポートを使用）。別ポートを指定する場合、そのアドレスで転送/デバッグプロキシを起動して本アプリのlistenポートへ転送してください。"
+        },
         "maxRetries": {
           "label": "最大リトライ回数",
           "placeholder": "3",
@@ -2029,6 +2034,7 @@
       "invalidAddress": "無効なアドレスです。有効な IP アドレス（例: 127.0.0.1）または localhost を入力してください",
       "configSaved": "ルーティング設定を保存しました",
       "configSaveFailed": "設定の保存に失敗しました",
+      "invalidUpstreamUrl": "Upstream URL が無効です。http(s)://host:port（origin のみ）を入力してください",
       "restartRequired": "アドレスまたはポートの変更を反映するにはルーティングサービスの再起動が必要です"
     },
     "switchFailed": "切り替えに失敗しました: {{error}}",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1980,6 +1980,11 @@
           "placeholder": "15721",
           "description": "路由服务器监听的端口号（1024 ~ 65535）"
         },
+        "upstreamUrl": {
+          "label": "Upstream URL",
+          "placeholder": "http://127.0.0.1:15721",
+          "description": "写回到各应用配置的代理地址（仅支持 http/https origin；留空则使用监听地址/端口）。如果指向其他端口，请在该地址上运行转发/调试代理并转发到本应用监听端口。"
+        },
         "maxRetries": {
           "label": "最大重试次数",
           "placeholder": "3",
@@ -2030,6 +2035,7 @@
       "invalidAddress": "地址无效，请输入有效的 IP 地址（如 127.0.0.1）或 localhost",
       "configSaved": "路由配置已保存",
       "configSaveFailed": "保存配置失败",
+      "invalidUpstreamUrl": "Upstream URL 无效，请输入 http(s)://host:port（仅 origin，不允许 path/query/fragment）",
       "restartRequired": "修改地址或端口后需要重启路由服务才能生效"
     },
     "switchFailed": "切换失败: {{error}}",

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -118,6 +118,7 @@ export interface GlobalProxyConfig {
   listenAddress: string;
   listenPort: number;
   enableLogging: boolean;
+  upstreamUrl?: string | null;
 }
 
 // 应用级代理配置（每个 app 独立）


### PR DESCRIPTION
本 PR 为 CC-Switch 增加了 Upstream Proxy（上游代理）配置项，用于满足部分高级用户在调试 agent ↔ LLM 通信链路时的需求。通过该配置，用户可以在 CC-Switch 本地代理之前插入自定义的中间层，用于日志记录、流量过滤、协议分析等扩展能力。

## 背景与动机
在某些开发场景中，用户希望观察或处理 LLM 请求链路，因此需要在 CC-Switch 的本地代理之前加入一个可控的中间代理层。相关讨论可参考 Issue [#1206]。

我非常喜欢CC-Switch这款软件,为保持 CC-Switch 一贯的简洁性，本 PR 仅添加 Upstream Proxy 配置项，并将中间层逻辑完全解耦，不引入任何额外复杂度。

## 架构说明
Code
```
Agent → Upstream Proxy（用户自定义） → User Intermediate Server → CC-Switch Local Proxy → Remote LLM Endpoint
```
当 Upstream Proxy 配置留空时，CC-Switch 将完全按照原有逻辑工作，不会产生任何行为变化。

## 变更内容
新增 upstream-proxy 配置项，并适配多语言文案。

更新前端 UI，允许用户输入上游代理地址。

更新数据库 schema 以保存该配置。

修改后端逻辑，使 Live 配置写回时支持该字段。

文档更新（详见 docs/changes.md）。

## 兼容性
默认情况下（留空）行为完全与旧版本一致。

不影响现有用户配置。

不改变默认代理链路。

## 测试情况
已通过现有单元测试。

已在 Windows 环境成功构建并验证功能。

<img width="832" height="367" alt="image" src="https://github.com/user-attachments/assets/a999e7c0-496e-4f57-9310-e8635099ae9f" />

## Summary
This pull request introduces an Upstream Proxy configuration option to CC‑Switch, enabling advanced users to insert a custom intermediate proxy layer between their agent and the CC‑Switch local proxy. This feature is designed for scenarios where developers need to inspect, log, or filter LLM traffic without altering CC‑Switch’s core behavior.

## Motivation
Certain development and debugging workflows require visibility into the communication between agents and LLM endpoints. By allowing CC‑Switch to forward requests to a user‑defined upstream proxy, developers can introduce their own intermediate server for logging, traffic inspection, or custom routing logic. This concept was previously discussed in Issue #1206.

To preserve CC‑Switch’s simplicity and purity, this PR only adds the upstream proxy configuration and keeps all intermediate processing logic fully decoupled. When the upstream proxy field is left empty, CC‑Switch behaves exactly as before, ensuring zero impact on regular users.

## Architecture
Code
Agent → Upstream Proxy (user-defined) → User Intermediate Server → CC‑Switch Local Proxy → Remote LLM Endpoint
The upstream proxy is optional. When unset, the request flow remains unchanged.

## Changes
Added a new upstream-proxy configuration option with full multi-language support.

Updated the frontend UI to allow users to input an upstream proxy address.

Extended the database schema to persist the new configuration field.

Updated backend logic to correctly apply the upstream proxy when writing the live configuration.

Added documentation updates (see docs/changes.md for details).

## Compatibility
Leaving the upstream proxy field empty preserves the original behavior entirely.

No breaking changes to existing configurations.

No impact on users who do not enable this feature.

## Testing
All existing unit tests pass.

Successfully built and tested on Windows.
