### PR TITLE
fix: respect OpenClaw workspace path from config

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -4,7 +4,7 @@ use tauri::AppHandle;
 use tauri_plugin_opener::OpenerExt;
 
 use crate::config::write_text_file;
-use crate::openclaw_config::get_openclaw_dir;
+use crate::openclaw_config::get_openclaw_workspace_dir;
 
 /// Allowed workspace filenames (whitelist for security)
 const ALLOWED_FILES: &[&str] = &[
@@ -58,7 +58,7 @@ pub struct DailyMemoryFileInfo {
 /// List all daily memory files under `workspace/memory/`.
 #[tauri::command]
 pub async fn list_daily_memory_files() -> Result<Vec<DailyMemoryFileInfo>, String> {
-    let memory_dir = get_openclaw_dir().join("workspace").join("memory");
+    let memory_dir = get_openclaw_workspace_dir().join("memory");
 
     if !memory_dir.exists() {
         return Ok(Vec::new());
@@ -119,10 +119,7 @@ pub async fn list_daily_memory_files() -> Result<Vec<DailyMemoryFileInfo>, Strin
 pub async fn read_daily_memory_file(filename: String) -> Result<Option<String>, String> {
     validate_daily_memory_filename(&filename)?;
 
-    let path = get_openclaw_dir()
-        .join("workspace")
-        .join("memory")
-        .join(&filename);
+    let path = get_openclaw_workspace_dir().join("memory").join(&filename);
 
     if !path.exists() {
         return Ok(None);
@@ -138,7 +135,7 @@ pub async fn read_daily_memory_file(filename: String) -> Result<Option<String>, 
 pub async fn write_daily_memory_file(filename: String, content: String) -> Result<(), String> {
     validate_daily_memory_filename(&filename)?;
 
-    let memory_dir = get_openclaw_dir().join("workspace").join("memory");
+    let memory_dir = get_openclaw_workspace_dir().join("memory");
 
     std::fs::create_dir_all(&memory_dir)
         .map_err(|e| format!("Failed to create memory directory: {e}"))?;
@@ -194,7 +191,7 @@ pub struct DailyMemorySearchResult {
 pub async fn search_daily_memory_files(
     query: String,
 ) -> Result<Vec<DailyMemorySearchResult>, String> {
-    let memory_dir = get_openclaw_dir().join("workspace").join("memory");
+    let memory_dir = get_openclaw_workspace_dir().join("memory");
 
     if !memory_dir.exists() || query.is_empty() {
         return Ok(Vec::new());
@@ -289,10 +286,7 @@ pub async fn search_daily_memory_files(
 pub async fn delete_daily_memory_file(filename: String) -> Result<(), String> {
     validate_daily_memory_filename(&filename)?;
 
-    let path = get_openclaw_dir()
-        .join("workspace")
-        .join("memory")
-        .join(&filename);
+    let path = get_openclaw_workspace_dir().join("memory").join(&filename);
 
     if path.exists() {
         std::fs::remove_file(&path)
@@ -310,7 +304,7 @@ pub async fn delete_daily_memory_file(filename: String) -> Result<(), String> {
 pub async fn read_workspace_file(filename: String) -> Result<Option<String>, String> {
     validate_filename(&filename)?;
 
-    let path = get_openclaw_dir().join("workspace").join(&filename);
+    let path = get_openclaw_workspace_dir().join(&filename);
 
     if !path.exists() {
         return Ok(None);
@@ -327,7 +321,7 @@ pub async fn read_workspace_file(filename: String) -> Result<Option<String>, Str
 pub async fn write_workspace_file(filename: String, content: String) -> Result<(), String> {
     validate_filename(&filename)?;
 
-    let workspace_dir = get_openclaw_dir().join("workspace");
+    let workspace_dir = get_openclaw_workspace_dir();
 
     // Ensure workspace directory exists
     std::fs::create_dir_all(&workspace_dir)
@@ -340,13 +334,18 @@ pub async fn write_workspace_file(filename: String, content: String) -> Result<(
 }
 
 /// Open the workspace or memory directory in the system file manager.
-/// `subdir`: "workspace" opens `~/.openclaw/workspace/`,
-///           "memory" opens `~/.openclaw/workspace/memory/`.
+/// `subdir`: "workspace" opens the resolved OpenClaw workspace root,
+///           "memory" opens `<workspace>/memory/`.
+#[tauri::command]
+pub async fn get_workspace_root_directory() -> Result<String, String> {
+    Ok(get_openclaw_workspace_dir().to_string_lossy().to_string())
+}
+
 #[tauri::command]
 pub async fn open_workspace_directory(handle: AppHandle, subdir: String) -> Result<bool, String> {
     let dir = match subdir.as_str() {
-        "memory" => get_openclaw_dir().join("workspace").join("memory"),
-        _ => get_openclaw_dir().join("workspace"),
+        "memory" => get_openclaw_workspace_dir().join("memory"),
+        _ => get_openclaw_workspace_dir(),
     };
 
     if !dir.exists() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1079,6 +1079,7 @@ pub fn run() {
             // Workspace files (OpenClaw)
             commands::read_workspace_file,
             commands::write_workspace_file,
+            commands::get_workspace_root_directory,
             // Daily memory files (OpenClaw workspace)
             commands::list_daily_memory_files,
             commands::read_daily_memory_file,

--- a/src-tauri/src/openclaw_config.rs
+++ b/src-tauri/src/openclaw_config.rs
@@ -24,26 +24,27 @@
 //!     ANTHROPIC_API_KEY: "sk-...",
 //!     vars: { ... }
 //!   },
-//!   // Agent 默认模型配置
+//!   // Agent 默认配置
 //!   agents: {
 //!     defaults: {
 //!       model: {
 //!         primary: "provider/model",
 //!         fallbacks: ["provider2/model2"]
-//!       }
+//!       },
+//!       workspace: "~/.openclaw/workspace"
 //!     }
 //!   }
 //! }
 //! ```
 
-use crate::config::write_json_file;
+use crate::config::{get_home_dir, write_json_file};
 use crate::error::AppError;
 use crate::settings::get_openclaw_override_dir;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // ============================================================================
 // Path Functions
@@ -59,9 +60,7 @@ pub fn get_openclaw_dir() -> PathBuf {
     }
 
     // 所有平台统一使用 ~/.openclaw
-    dirs::home_dir()
-        .map(|h| h.join(".openclaw"))
-        .unwrap_or_else(|| PathBuf::from(".openclaw"))
+    get_home_dir().join(".openclaw")
 }
 
 /// 获取 OpenClaw 配置文件路径
@@ -69,6 +68,86 @@ pub fn get_openclaw_dir() -> PathBuf {
 /// 返回 `~/.openclaw/openclaw.json`
 pub fn get_openclaw_config_path() -> PathBuf {
     get_openclaw_dir().join("openclaw.json")
+}
+
+/// 获取 OpenClaw 工作区目录
+///
+/// 优先级：
+/// 1. `agents.defaults.workspace`（OpenClaw 官方配置）
+/// 2. `agent.workspace`（兼容部分官方文档示例）
+/// 3. `workspace.path`（兼容旧配置/旧文档）
+/// 4. 默认值 `~/.openclaw/workspace`
+///
+/// 额外兼容 OpenClaw profile：
+/// - 若 `OPENCLAW_PROFILE` 存在且不为 `default`，默认路径为 `~/.openclaw/workspace-<profile>`
+pub fn get_openclaw_workspace_dir() -> PathBuf {
+    if let Ok(config) = read_openclaw_config() {
+        if let Some(path) = config
+            .get("agents")
+            .and_then(|agents| agents.get("defaults"))
+            .and_then(|defaults| defaults.get("workspace"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return expand_workspace_path(path);
+        }
+
+        if let Some(path) = config
+            .get("agent")
+            .and_then(|agent| agent.get("workspace"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return expand_workspace_path(path);
+        }
+
+        if let Some(path) = config
+            .get("workspace")
+            .and_then(|workspace| workspace.get("path"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return expand_workspace_path(path);
+        }
+    }
+
+    default_openclaw_workspace_dir()
+}
+
+fn default_openclaw_workspace_dir() -> PathBuf {
+    let profile = std::env::var("OPENCLAW_PROFILE")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty() && value != "default");
+
+    match profile {
+        Some(profile) => get_openclaw_dir().join(format!("workspace-{profile}")),
+        None => get_openclaw_dir().join("workspace"),
+    }
+}
+
+fn expand_workspace_path(path: &str) -> PathBuf {
+    if path == "~" {
+        return get_home_dir();
+    }
+
+    if let Some(stripped) = path.strip_prefix("~/") {
+        return get_home_dir().join(stripped);
+    }
+
+    let candidate = PathBuf::from(path);
+    if candidate.is_relative() {
+        return normalize_relative_workspace_path(&candidate);
+    }
+
+    candidate
+}
+
+fn normalize_relative_workspace_path(path: &Path) -> PathBuf {
+    get_openclaw_dir().join(path)
 }
 
 // ============================================================================
@@ -355,6 +434,104 @@ pub fn get_default_model() -> Result<Option<OpenClawDefaultModel>, AppError> {
         .map_err(|e| AppError::Config(format!("Failed to parse agents.defaults.model: {e}")))?;
 
     Ok(Some(model))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    fn set_test_home(temp_dir: &TempDir) {
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp_dir.path());
+        std::env::remove_var("OPENCLAW_PROFILE");
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_dir_defaults_to_openclaw_workspace() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        set_test_home(&temp_dir);
+
+        assert_eq!(
+            get_openclaw_workspace_dir(),
+            temp_dir.path().join(".openclaw").join("workspace")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_dir_reads_agents_defaults_workspace() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        set_test_home(&temp_dir);
+
+        std::fs::create_dir_all(get_openclaw_dir()).expect("create openclaw dir");
+        std::fs::write(
+            get_openclaw_config_path(),
+            r#"{
+              agents: {
+                defaults: {
+                  workspace: "~/custom-agent-workspace",
+                },
+              },
+            }"#,
+        )
+        .expect("write openclaw config");
+
+        assert_eq!(
+            get_openclaw_workspace_dir(),
+            temp_dir.path().join("custom-agent-workspace")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_dir_reads_agent_workspace() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        set_test_home(&temp_dir);
+
+        std::fs::create_dir_all(get_openclaw_dir()).expect("create openclaw dir");
+        std::fs::write(
+            get_openclaw_config_path(),
+            r#"{
+              agent: {
+                workspace: "/tmp/openclaw-agent-workspace",
+              },
+            }"#,
+        )
+        .expect("write openclaw config");
+
+        assert_eq!(
+            get_openclaw_workspace_dir(),
+            PathBuf::from("/tmp/openclaw-agent-workspace")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_dir_falls_back_to_legacy_workspace_path() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        set_test_home(&temp_dir);
+
+        std::fs::create_dir_all(get_openclaw_dir()).expect("create openclaw dir");
+        std::fs::write(
+            get_openclaw_config_path(),
+            r#"{
+              workspace: {
+                path: "workspace-from-legacy",
+              },
+            }"#,
+        )
+        .expect("write openclaw config");
+
+        assert_eq!(
+            get_openclaw_workspace_dir(),
+            temp_dir
+                .path()
+                .join(".openclaw")
+                .join("workspace-from-legacy")
+        );
+    }
 }
 
 /// 设置默认模型配置（agents.defaults.model）

--- a/src/components/workspace/DailyMemoryPanel.tsx
+++ b/src/components/workspace/DailyMemoryPanel.tsx
@@ -48,6 +48,7 @@ const DailyMemoryPanel: React.FC<DailyMemoryPanelProps> = ({
   // List state
   const [files, setFiles] = useState<DailyMemoryFileInfo[]>([]);
   const [loadingList, setLoadingList] = useState(false);
+  const [workspaceRoot, setWorkspaceRoot] = useState("~/.openclaw/workspace");
 
   // Edit state
   const [editingFile, setEditingFile] = useState<string | null>(null);
@@ -176,6 +177,16 @@ const DailyMemoryPanel: React.FC<DailyMemoryPanelProps> = ({
       }
     };
   }, []);
+
+  // Load file list
+  useEffect(() => {
+    if (!isOpen) return;
+
+    void workspaceApi
+      .getRootDirectory()
+      .then(setWorkspaceRoot)
+      .catch(() => undefined);
+  }, [isOpen]);
 
   // Load file list
   const loadFiles = useCallback(async () => {
@@ -357,7 +368,7 @@ const DailyMemoryPanel: React.FC<DailyMemoryPanelProps> = ({
               onClick={() => workspaceApi.openDirectory("memory")}
               title={t("workspace.openDirectory")}
             >
-              ~/.openclaw/workspace/memory/
+              {workspaceRoot}/memory/
               <FolderOpen className="w-3.5 h-3.5" />
             </p>
             <div className="flex items-center gap-1.5">

--- a/src/components/workspace/WorkspaceFilesPanel.tsx
+++ b/src/components/workspace/WorkspaceFilesPanel.tsx
@@ -56,6 +56,7 @@ const WorkspaceFilesPanel: React.FC = () => {
   const [editingFile, setEditingFile] = useState<string | null>(null);
   const [fileExists, setFileExists] = useState<Record<string, boolean>>({});
   const [showDailyMemory, setShowDailyMemory] = useState(false);
+  const [workspaceRoot, setWorkspaceRoot] = useState("~/.openclaw/workspace");
 
   const checkFileExistence = async () => {
     const results: Record<string, boolean> = {};
@@ -76,6 +77,13 @@ const WorkspaceFilesPanel: React.FC = () => {
     void checkFileExistence();
   }, []);
 
+  useEffect(() => {
+    void workspaceApi
+      .getRootDirectory()
+      .then(setWorkspaceRoot)
+      .catch(() => undefined);
+  }, []);
+
   const handleEditorClose = () => {
     setEditingFile(null);
     // Re-check file existence after closing editor (file may have been created)
@@ -89,7 +97,7 @@ const WorkspaceFilesPanel: React.FC = () => {
         onClick={() => workspaceApi.openDirectory("workspace")}
         title={t("workspace.openDirectory")}
       >
-        ~/.openclaw/workspace/
+        {workspaceRoot}/
         <FolderOpen className="w-3.5 h-3.5" />
       </p>
 

--- a/src/lib/api/workspace.ts
+++ b/src/lib/api/workspace.ts
@@ -18,6 +18,10 @@ export interface DailyMemorySearchResult {
 }
 
 export const workspaceApi = {
+  async getRootDirectory(): Promise<string> {
+    return invoke<string>("get_workspace_root_directory");
+  },
+
   async readFile(filename: string): Promise<string | null> {
     return invoke<string | null>("read_workspace_file", { filename });
   },


### PR DESCRIPTION
## Summary
- resolve OpenClaw workspace files and daily memory paths from the OpenClaw config instead of hardcoding ~/.openclaw/workspace
- support agents.defaults.workspace, agent.workspace, legacy workspace.path, and OPENCLAW_PROFILE fallback behavior
- expose the resolved workspace root to the frontend so the UI shows the actual active directory

## Verification
- pnpm typecheck
- cargo test --manifest-path src-tauri/Cargo.toml workspace_dir_