### PR TITLE
feat: add conversation export feature to support exporting the current or selected conversations in MD/JSON formats, closes

### DIFF
--- a/src-tauri/src/commands/session_manager.rs
+++ b/src-tauri/src/commands/session_manager.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use crate::session_manager;
+use tauri_plugin_dialog::DialogExt;
 
 #[tauri::command]
 pub async fn list_sessions() -> Result<Vec<session_manager::SessionMeta>, String> {
@@ -56,4 +57,67 @@ pub async fn launch_session_terminal(
     .map_err(|e| format!("Failed to launch terminal: {e}"))??;
 
     Ok(true)
+}
+
+#[tauri::command]
+pub async fn save_session_export_file_dialog<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    defaultName: String,
+    format: String,
+) -> Result<Option<String>, String> {
+    let ext = match format.as_str() {
+        "md" => "md",
+        "json" => "json",
+        _ => return Err(format!("Unsupported export format: {format}")),
+    };
+
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        app.dialog()
+            .file()
+            .add_filter(ext.to_uppercase(), &[ext])
+            .set_file_name(&defaultName)
+            .blocking_save_file()
+    })
+    .await
+    .map_err(|e| format!("Failed to open save dialog: {e}"))?;
+
+    Ok(result.map(|p| p.to_string()))
+}
+
+#[tauri::command]
+pub async fn export_session_to_file(
+    providerId: String,
+    sourcePath: String,
+    format: String,
+    filePath: String,
+    sessionId: Option<String>,
+    title: Option<String>,
+) -> Result<bool, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        session_manager::export_session_to_file(
+            &providerId,
+            &sourcePath,
+            sessionId.as_deref(),
+            title.as_deref(),
+            &format,
+            &filePath,
+        )
+    })
+    .await
+    .map_err(|e| format!("Failed to export session: {e}"))??;
+
+    Ok(true)
+}
+
+#[tauri::command]
+pub async fn export_sessions_to_directory(
+    sessions: Vec<session_manager::SessionExportTarget>,
+    format: String,
+    directoryPath: String,
+) -> Result<usize, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        session_manager::export_sessions_to_directory(sessions, &format, &directoryPath)
+    })
+    .await
+    .map_err(|e| format!("Failed to batch export sessions: {e}"))?
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1037,6 +1037,9 @@ pub fn run() {
             commands::list_sessions,
             commands::get_session_messages,
             commands::launch_session_terminal,
+            commands::save_session_export_file_dialog,
+            commands::export_session_to_file,
+            commands::export_sessions_to_directory,
             commands::get_tool_versions,
             // Provider terminal
             commands::open_provider_terminal,

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -1,8 +1,11 @@
 pub mod providers;
 pub mod terminal;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::Path;
+
+use crate::config::{write_json_file, write_text_file};
 
 use providers::{claude, codex, gemini, openclaw, opencode};
 
@@ -34,6 +37,32 @@ pub struct SessionMessage {
     pub content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ts: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionExportTarget {
+    pub provider_id: String,
+    pub source_path: String,
+    pub session_id: Option<String>,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionExportData {
+    schema_version: String,
+    session: SessionExportSession,
+    messages: Vec<SessionMessage>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionExportSession {
+    provider_id: String,
+    source_path: String,
+    session_id: Option<String>,
+    title: Option<String>,
 }
 
 pub fn scan_sessions() -> Vec<SessionMeta> {
@@ -77,5 +106,222 @@ pub fn load_messages(provider_id: &str, source_path: &str) -> Result<Vec<Session
         "openclaw" => openclaw::load_messages(path),
         "gemini" => gemini::load_messages(path),
         _ => Err(format!("Unsupported provider: {provider_id}")),
+    }
+}
+
+pub fn export_session_to_file(
+    provider_id: &str,
+    source_path: &str,
+    session_id: Option<&str>,
+    title: Option<&str>,
+    format: &str,
+    file_path: &str,
+) -> Result<(), String> {
+    let messages = load_messages(provider_id, source_path)?;
+    let payload = build_export_data(provider_id, source_path, session_id, title, messages);
+    write_export_file(Path::new(file_path), format, &payload)
+}
+
+pub fn export_sessions_to_directory(
+    sessions: Vec<SessionExportTarget>,
+    format: &str,
+    directory_path: &str,
+) -> Result<usize, String> {
+    let directory = Path::new(directory_path);
+    if !directory.exists() {
+        return Err(format!("Directory does not exist: {}", directory.display()));
+    }
+    if !directory.is_dir() {
+        return Err(format!("Path is not a directory: {}", directory.display()));
+    }
+
+    let extension = match format {
+        "md" => "md",
+        "json" => "json",
+        _ => return Err(format!("Unsupported export format: {format}")),
+    };
+
+    let mut used_names = HashSet::new();
+    let mut exported = 0usize;
+
+    for session in sessions {
+        let messages = load_messages(&session.provider_id, &session.source_path)?;
+        let payload = build_export_data(
+            &session.provider_id,
+            &session.source_path,
+            session.session_id.as_deref(),
+            session.title.as_deref(),
+            messages,
+        );
+
+        let base = build_export_base_name(
+            &session.provider_id,
+            session.session_id.as_deref(),
+            session.title.as_deref(),
+            &session.source_path,
+        );
+
+        let unique_name = allocate_unique_file_name(directory, &base, extension, &mut used_names);
+        let target = directory.join(unique_name);
+        write_export_file(&target, format, &payload)?;
+        exported += 1;
+    }
+
+    Ok(exported)
+}
+
+fn build_export_data(
+    provider_id: &str,
+    source_path: &str,
+    session_id: Option<&str>,
+    title: Option<&str>,
+    messages: Vec<SessionMessage>,
+) -> SessionExportData {
+    SessionExportData {
+        schema_version: "1.0".to_string(),
+        session: SessionExportSession {
+            provider_id: provider_id.to_string(),
+            source_path: source_path.to_string(),
+            session_id: session_id.map(ToOwned::to_owned),
+            title: title.map(ToOwned::to_owned),
+        },
+        messages,
+    }
+}
+
+fn write_export_file(path: &Path, format: &str, payload: &SessionExportData) -> Result<(), String> {
+    match format {
+        "json" => write_json_file(path, payload).map_err(|e| format!("Failed to write JSON export: {e}")),
+        "md" => {
+            let markdown = render_markdown(payload);
+            write_text_file(path, &markdown).map_err(|e| format!("Failed to write Markdown export: {e}"))
+        }
+        _ => Err(format!("Unsupported export format: {format}")),
+    }
+}
+
+fn render_markdown(payload: &SessionExportData) -> String {
+    let title = payload
+        .session
+        .title
+        .as_deref()
+        .unwrap_or("Untitled Session");
+
+    let mut out = String::new();
+    out.push_str("# ");
+    out.push_str(title);
+    out.push_str("\n\n");
+
+    out.push_str("## Metadata\n");
+    out.push_str("- Provider: `");
+    out.push_str(&payload.session.provider_id);
+    out.push_str("`\n");
+
+    if let Some(session_id) = payload.session.session_id.as_deref() {
+        out.push_str("- Session ID: `");
+        out.push_str(session_id);
+        out.push_str("`\n");
+    }
+
+    out.push_str("- Source Path: `");
+    out.push_str(&payload.session.source_path.replace('`', "\\`"));
+    out.push_str("`\n");
+    out.push_str("- Messages: ");
+    out.push_str(&payload.messages.len().to_string());
+    out.push_str("\n\n");
+
+    out.push_str("## Messages\n\n");
+    for (index, message) in payload.messages.iter().enumerate() {
+        out.push_str("### ");
+        out.push_str(&(index + 1).to_string());
+        out.push_str(". ");
+        out.push_str(&message.role);
+        out.push_str("\n\n");
+
+        if let Some(ts) = message.ts {
+            out.push_str("_Timestamp: `");
+            out.push_str(&ts.to_string());
+            out.push_str("`_\n\n");
+        }
+
+        out.push_str(&message.content);
+        out.push_str("\n\n");
+    }
+
+    out
+}
+
+fn build_export_base_name(
+    provider_id: &str,
+    session_id: Option<&str>,
+    title: Option<&str>,
+    source_path: &str,
+) -> String {
+    let preferred = title
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .or_else(|| session_id.map(str::trim).filter(|s| !s.is_empty()))
+        .or_else(|| {
+            Path::new(source_path)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or("session");
+
+    let safe_provider = sanitize_file_component(provider_id);
+    let safe_name = sanitize_file_component(preferred);
+    format!("{safe_provider}-{safe_name}")
+}
+
+fn sanitize_file_component(input: &str) -> String {
+    let mut out = String::new();
+    for ch in input.chars() {
+        let invalid = matches!(
+            ch,
+            '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' | '\u{0000}'..='\u{001F}'
+        );
+        if invalid {
+            out.push('-');
+        } else {
+            out.push(ch);
+        }
+    }
+
+    let collapsed = out
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("-")
+        .trim_matches(['.', '-', ' '])
+        .to_string();
+
+    if collapsed.is_empty() {
+        "session".to_string()
+    } else {
+        collapsed
+    }
+}
+
+fn allocate_unique_file_name(
+    directory: &Path,
+    base_name: &str,
+    extension: &str,
+    used_names: &mut HashSet<String>,
+) -> String {
+    let mut index = 0usize;
+    loop {
+        let candidate = if index == 0 {
+            format!("{base_name}.{extension}")
+        } else {
+            format!("{base_name}-{index}.{extension}")
+        };
+
+        let path = directory.join(&candidate);
+        if !used_names.contains(&candidate) && !path.exists() {
+            used_names.insert(candidate.clone());
+            return candidate;
+        }
+        index += 1;
     }
 }

--- a/src/components/sessions/SessionItem.tsx
+++ b/src/components/sessions/SessionItem.tsx
@@ -5,6 +5,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import type { SessionMeta } from "@/types";
@@ -19,13 +20,17 @@ import {
 interface SessionItemProps {
   session: SessionMeta;
   isSelected: boolean;
+  isChecked: boolean;
   onSelect: (key: string) => void;
+  onToggleChecked: (key: string) => void;
 }
 
 export function SessionItem({
   session,
   isSelected,
+  isChecked,
   onSelect,
+  onToggleChecked,
 }: SessionItemProps) {
   const { t } = useTranslation();
   const title = formatSessionTitle(session);
@@ -33,17 +38,44 @@ export function SessionItem({
   const sessionKey = getSessionKey(session);
 
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => onSelect(sessionKey)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect(sessionKey);
+        }
+      }}
       className={cn(
-        "w-full text-left rounded-lg px-3 py-2.5 transition-all group",
+        "w-full text-left rounded-lg px-3 py-2.5 transition-all group cursor-pointer",
         isSelected
           ? "bg-primary/10 border border-primary/30"
           : "hover:bg-muted/60 border border-transparent",
       )}
     >
       <div className="flex items-center gap-2 mb-1">
+        <span
+          className="shrink-0"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.stopPropagation();
+            }
+          }}
+        >
+          <Checkbox
+            checked={isChecked}
+            onCheckedChange={() => onToggleChecked(sessionKey)}
+            aria-label={t("sessionManager.selectForBatchExport", {
+              defaultValue: "Select for batch export",
+            })}
+          />
+        </span>
+
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="shrink-0">
@@ -73,6 +105,6 @@ export function SessionItem({
           {lastActive ? formatRelativeTime(lastActive, t) : t("common.unknown")}
         </span>
       </div>
-    </button>
+    </div>
   );
 }

--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   FolderOpen,
   X,
+  Download,
 } from "lucide-react";
 import { useSessionMessagesQuery, useSessionsQuery } from "@/lib/query";
 import { sessionsApi } from "@/lib/api";
@@ -34,6 +35,7 @@ import {
 import { extractErrorMessage } from "@/utils/errorUtils";
 import { isMac } from "@/lib/platform";
 import { ProviderIcon } from "@/components/ProviderIcon";
+import type { SessionExportFormat, SessionMeta } from "@/types";
 import { SessionItem } from "./SessionItem";
 import { SessionMessageItem } from "./SessionMessageItem";
 import { SessionTocDialog, SessionTocSidebar } from "./SessionToc";
@@ -73,6 +75,12 @@ export function SessionManagerPage({ appId }: { appId: string }) {
     appId as ProviderFilter,
   );
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [selectedSessionKeys, setSelectedSessionKeys] = useState<Set<string>>(
+    new Set(),
+  );
+  const [exportFormat, setExportFormat] = useState<SessionExportFormat>("md");
+  const [isExportingCurrent, setIsExportingCurrent] = useState(false);
+  const [isExportingBatch, setIsExportingBatch] = useState(false);
 
   // 使用 FlexSearch 全文搜索
   const { search: searchSessions } = useSessionSearch({
@@ -101,12 +109,13 @@ export function SessionManagerPage({ appId }: { appId: string }) {
 
   const selectedSession = useMemo(() => {
     if (!selectedKey) return null;
-    return (
-      filteredSessions.find(
-        (session) => getSessionKey(session) === selectedKey,
-      ) || null
-    );
-  }, [filteredSessions, selectedKey]);
+    return sessions.find((session) => getSessionKey(session) === selectedKey) || null;
+  }, [sessions, selectedKey]);
+
+  const selectedExportSessions = useMemo(() => {
+    if (selectedSessionKeys.size === 0) return [] as SessionMeta[];
+    return sessions.filter((session) => selectedSessionKeys.has(getSessionKey(session)));
+  }, [sessions, selectedSessionKeys]);
 
   const { data: messages = [], isLoading: isLoadingMessages } =
     useSessionMessagesQuery(
@@ -181,6 +190,107 @@ export function SessionManagerPage({ appId }: { appId: string }) {
       const fallback = selectedSession.resumeCommand;
       await handleCopy(fallback, t("sessionManager.resumeFallbackCopied"));
       toast.error(extractErrorMessage(error) || t("sessionManager.openFailed"));
+    }
+  };
+
+  const getDefaultExportName = (
+    session: SessionMeta,
+    format: SessionExportFormat,
+  ) => {
+    const base =
+      formatSessionTitle(session)
+        .trim()
+        .replace(/[\\/:*?"<>|]/g, "-")
+        .replace(/\s+/g, "-") || session.sessionId;
+    return `${base}.${format}`;
+  };
+
+  const toggleSessionChecked = (key: string) => {
+    setSelectedSessionKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const handleExportCurrent = async () => {
+    if (!selectedSession?.sourcePath || isExportingCurrent) return;
+
+    setIsExportingCurrent(true);
+    try {
+      const filePath = await sessionsApi.saveExportFileDialog({
+        defaultName: getDefaultExportName(selectedSession, exportFormat),
+        format: exportFormat,
+      });
+      if (!filePath) return;
+
+      await sessionsApi.exportSingle({
+        providerId: selectedSession.providerId,
+        sourcePath: selectedSession.sourcePath,
+        format: exportFormat,
+        filePath,
+        sessionId: selectedSession.sessionId,
+        title: selectedSession.title,
+      });
+      toast.success(t("sessionManager.exportCurrentSuccess"));
+    } catch (error) {
+      toast.error(
+        extractErrorMessage(error) ||
+          t("sessionManager.exportCurrentFailed", {
+            defaultValue: "Failed to export current session",
+          }),
+      );
+    } finally {
+      setIsExportingCurrent(false);
+    }
+  };
+
+  const handleExportBatch = async () => {
+    if (selectedExportSessions.length === 0 || isExportingBatch) {
+      if (selectedExportSessions.length === 0) {
+        toast.warning(t("sessionManager.noSelectedSessions"));
+      }
+      return;
+    }
+
+    setIsExportingBatch(true);
+    try {
+      const directoryPath = await sessionsApi.pickExportDirectoryDialog();
+      if (!directoryPath) return;
+
+      const exportTargets = selectedExportSessions
+        .filter((session) => Boolean(session.sourcePath))
+        .map((session) => ({
+          providerId: session.providerId,
+          sourcePath: session.sourcePath!,
+          sessionId: session.sessionId,
+          title: session.title,
+        }));
+
+      if (exportTargets.length === 0) {
+        toast.warning(t("sessionManager.noSelectedSessions"));
+        return;
+      }
+
+      const count = await sessionsApi.exportBatch({
+        sessions: exportTargets,
+        format: exportFormat,
+        directoryPath,
+      });
+      toast.success(t("sessionManager.exportBatchSuccess", { count }));
+    } catch (error) {
+      toast.error(
+        extractErrorMessage(error) ||
+          t("sessionManager.exportBatchFailed", {
+            defaultValue: "Failed to batch export sessions",
+          }),
+      );
+    } finally {
+      setIsExportingBatch(false);
     }
   };
 
@@ -348,6 +458,32 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                         </SelectContent>
                       </Select>
 
+                      <Select
+                        value={exportFormat}
+                        onValueChange={(value) =>
+                          setExportFormat(value as SessionExportFormat)
+                        }
+                      >
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <SelectTrigger className="h-7 w-[72px] px-2 text-xs border-dashed">
+                              {exportFormat.toUpperCase()}
+                            </SelectTrigger>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {t("sessionManager.exportFormat")}
+                          </TooltipContent>
+                        </Tooltip>
+                        <SelectContent>
+                          <SelectItem value="md">
+                            {t("sessionManager.exportFormatMd")}
+                          </SelectItem>
+                          <SelectItem value="json">
+                            {t("sessionManager.exportFormatJson")}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Button
@@ -366,7 +502,25 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                 )}
               </CardHeader>
               <CardContent className="flex-1 overflow-hidden p-0">
-                <ScrollArea className="h-full">
+                <div className="p-2 border-b">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="w-full gap-1.5"
+                    onClick={() => void handleExportBatch()}
+                    disabled={selectedExportSessions.length === 0 || isExportingBatch}
+                  >
+                    <Download className="size-3.5" />
+                    <span>
+                      {isExportingBatch
+                        ? t("sessionManager.exporting")
+                        : t("sessionManager.exportSelected", {
+                            count: selectedExportSessions.length,
+                          })}
+                    </span>
+                  </Button>
+                </div>
+                <ScrollArea className="h-[calc(100%-48px)]">
                   <div className="p-2">
                     {isLoading ? (
                       <div className="flex items-center justify-center py-12">
@@ -382,16 +536,18 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                     ) : (
                       <div className="space-y-1">
                         {filteredSessions.map((session) => {
+                          const key = getSessionKey(session);
                           const isSelected =
-                            selectedKey !== null &&
-                            getSessionKey(session) === selectedKey;
+                            selectedKey !== null && key === selectedKey;
 
                           return (
                             <SessionItem
-                              key={getSessionKey(session)}
+                              key={key}
                               session={session}
                               isSelected={isSelected}
+                              isChecked={selectedSessionKeys.has(key)}
                               onSelect={setSelectedKey}
+                              onToggleChecked={toggleSessionChecked}
                             />
                           );
                         })}
@@ -489,6 +645,21 @@ export function SessionManagerPage({ appId }: { appId: string }) {
 
                       {/* 右侧：操作按钮组 */}
                       <div className="flex items-center gap-2 shrink-0">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="gap-1.5"
+                          onClick={() => void handleExportCurrent()}
+                          disabled={!selectedSession.sourcePath || isExportingCurrent}
+                        >
+                          <Download className="size-3.5" />
+                          <span className="hidden sm:inline">
+                            {isExportingCurrent
+                              ? t("sessionManager.exporting")
+                              : t("sessionManager.exportCurrent")}
+                          </span>
+                        </Button>
+
                         {isMac() && (
                           <Tooltip>
                             <TooltipTrigger asChild>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -601,7 +601,19 @@
     "daysAgo": "{{count}} days ago",
     "roleUser": "User",
     "roleSystem": "System",
-    "roleTool": "Tool"
+    "roleTool": "Tool",
+    "exportCurrent": "Export current",
+    "exportSelected": "Export selected ({{count}})",
+    "exportFormat": "Export format",
+    "exportFormatMd": "Markdown (.md)",
+    "exportFormatJson": "JSON (.json)",
+    "exporting": "Exporting...",
+    "exportCurrentSuccess": "Current session exported",
+    "exportCurrentFailed": "Failed to export current session",
+    "exportBatchSuccess": "Exported {{count}} sessions",
+    "exportBatchFailed": "Failed to batch export sessions",
+    "noSelectedSessions": "Please select sessions first",
+    "selectForBatchExport": "Select for batch export"
   },
   "console": {
     "providerSwitchReceived": "Received provider switch event:",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -601,7 +601,19 @@
     "daysAgo": "{{count}}日前",
     "roleUser": "ユーザー",
     "roleSystem": "システム",
-    "roleTool": "ツール"
+    "roleTool": "ツール",
+    "exportCurrent": "現在のセッションをエクスポート",
+    "exportSelected": "選択を一括エクスポート（{{count}}）",
+    "exportFormat": "エクスポート形式",
+    "exportFormatMd": "Markdown (.md)",
+    "exportFormatJson": "JSON (.json)",
+    "exporting": "エクスポート中...",
+    "exportCurrentSuccess": "現在のセッションをエクスポートしました",
+    "exportCurrentFailed": "現在のセッションのエクスポートに失敗しました",
+    "exportBatchSuccess": "{{count}} 件のセッションをエクスポートしました",
+    "exportBatchFailed": "セッションの一括エクスポートに失敗しました",
+    "noSelectedSessions": "先にセッションを選択してください",
+    "selectForBatchExport": "一括エクスポート対象として選択"
   },
   "console": {
     "providerSwitchReceived": "プロバイダー切り替えイベントを受信:",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -601,7 +601,19 @@
     "daysAgo": "{{count}} 天前",
     "roleUser": "用户",
     "roleSystem": "系统",
-    "roleTool": "工具"
+    "roleTool": "工具",
+    "exportCurrent": "导出当前会话",
+    "exportSelected": "批量导出（已选 {{count}}）",
+    "exportFormat": "导出格式",
+    "exportFormatMd": "Markdown (.md)",
+    "exportFormatJson": "JSON (.json)",
+    "exporting": "导出中...",
+    "exportCurrentSuccess": "当前会话导出成功",
+    "exportCurrentFailed": "导出当前会话失败",
+    "exportBatchSuccess": "已成功导出 {{count}} 个会话",
+    "exportBatchFailed": "批量导出会话失败",
+    "noSelectedSessions": "请先选择会话",
+    "selectForBatchExport": "选择用于批量导出"
   },
   "console": {
     "providerSwitchReceived": "收到供应商切换事件:",

--- a/src/lib/api/sessions.ts
+++ b/src/lib/api/sessions.ts
@@ -1,5 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { SessionMessage, SessionMeta } from "@/types";
+import type {
+  SessionExportFormat,
+  SessionExportTarget,
+  SessionMessage,
+  SessionMeta,
+} from "@/types";
 
 export const sessionsApi = {
   async list(): Promise<SessionMeta[]> {
@@ -23,6 +28,53 @@ export const sessionsApi = {
       command,
       cwd,
       customConfig,
+    });
+  },
+
+  async saveExportFileDialog(options: {
+    defaultName: string;
+    format: SessionExportFormat;
+  }): Promise<string | null> {
+    const { defaultName, format } = options;
+    return await invoke("save_session_export_file_dialog", {
+      defaultName,
+      format,
+    });
+  },
+
+  async pickExportDirectoryDialog(): Promise<string | null> {
+    return await invoke("pick_directory", { defaultPath: undefined });
+  },
+
+  async exportSingle(options: {
+    providerId: string;
+    sourcePath: string;
+    format: SessionExportFormat;
+    filePath: string;
+    sessionId?: string;
+    title?: string;
+  }): Promise<boolean> {
+    const { providerId, sourcePath, format, filePath, sessionId, title } = options;
+    return await invoke("export_session_to_file", {
+      providerId,
+      sourcePath,
+      format,
+      filePath,
+      sessionId,
+      title,
+    });
+  },
+
+  async exportBatch(options: {
+    sessions: SessionExportTarget[];
+    format: SessionExportFormat;
+    directoryPath: string;
+  }): Promise<number> {
+    const { sessions, format, directoryPath } = options;
+    return await invoke("export_sessions_to_directory", {
+      sessions,
+      format,
+      directoryPath,
     });
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -286,6 +286,15 @@ export interface SessionMessage {
   ts?: number;
 }
 
+export type SessionExportFormat = "md" | "json";
+
+export interface SessionExportTarget {
+  providerId: string;
+  sourcePath: string;
+  sessionId?: string;
+  title?: string;
+}
+
 // MCP 服务器连接参数（宽松：允许扩展字段）
 export interface McpServerSpec {
   // 可选：社区常见 .mcp.json 中 stdio 配置可不写 type


### PR DESCRIPTION
<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/f89b85a9-c274-4484-b7a1-cc264d5ecfb5" />
在会话管理界面添加了对话记录批量导出功能，可以将最近的会话导出为json或者为md格式，方便长期保存