### PR TITLE
Fix unclickable Linux window controls on GNOME/Wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux Window Controls**: Use the system title bar on Linux and disable custom drag regions there so GNOME/Wayland window buttons stay clickable
+
 ---
 
 ## [3.11.1] - 2026-02-28

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "CC Switch",
+        "titleBarStyle": "Visible",
+        "width": 1000,
+        "height": 650,
+        "minWidth": 900,
+        "minHeight": 600,
+        "visible": false,
+        "resizable": true,
+        "fullscreen": false,
+        "center": true
+      }
+    ]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,7 @@ interface WebDavSyncStatusUpdatedPayload {
 const DRAG_BAR_HEIGHT = isWindows() || isLinux() ? 0 : 28; // px
 const HEADER_HEIGHT = 64; // px
 const CONTENT_TOP_OFFSET = DRAG_BAR_HEIGHT + HEADER_HEIGHT;
+const ENABLE_CUSTOM_WINDOW_DRAG = !isLinux();
 
 const STORAGE_KEY = "cc-switch-last-app";
 const VALID_APPS: AppId[] = [
@@ -825,8 +826,15 @@ function App() {
     >
       <div
         className="fixed top-0 left-0 right-0 z-[60]"
-        data-tauri-drag-region
-        style={{ WebkitAppRegion: "drag", height: DRAG_BAR_HEIGHT } as any}
+        {...(ENABLE_CUSTOM_WINDOW_DRAG
+          ? { "data-tauri-drag-region": true }
+          : {})}
+        style={
+          {
+            ...(ENABLE_CUSTOM_WINDOW_DRAG ? { WebkitAppRegion: "drag" } : {}),
+            height: DRAG_BAR_HEIGHT,
+          } as any
+        }
       />
       {showEnvBanner && envConflicts.length > 0 && (
         <EnvWarningBanner
@@ -855,10 +863,12 @@ function App() {
 
       <header
         className="fixed z-50 w-full transition-all duration-300 bg-background/80 backdrop-blur-md"
-        data-tauri-drag-region
+        {...(ENABLE_CUSTOM_WINDOW_DRAG
+          ? { "data-tauri-drag-region": true }
+          : {})}
         style={
           {
-            WebkitAppRegion: "drag",
+            ...(ENABLE_CUSTOM_WINDOW_DRAG ? { WebkitAppRegion: "drag" } : {}),
             top: DRAG_BAR_HEIGHT,
             height: HEADER_HEIGHT,
           } as any
@@ -866,8 +876,14 @@ function App() {
       >
         <div
           className="flex h-full items-center justify-between gap-2 px-6"
-          data-tauri-drag-region
-          style={{ WebkitAppRegion: "drag" } as any}
+          {...(ENABLE_CUSTOM_WINDOW_DRAG
+            ? { "data-tauri-drag-region": true }
+            : {})}
+          style={
+            (ENABLE_CUSTOM_WINDOW_DRAG
+              ? { WebkitAppRegion: "drag" }
+              : undefined) as any
+          }
         >
           <div
             className="flex items-center gap-1"

--- a/src/components/common/FullScreenPanel.tsx
+++ b/src/components/common/FullScreenPanel.tsx
@@ -16,6 +16,7 @@ interface FullScreenPanelProps {
 
 const DRAG_BAR_HEIGHT = isWindows() || isLinux() ? 0 : 28; // px - match App.tsx
 const HEADER_HEIGHT = 64; // px - match App.tsx
+const ENABLE_CUSTOM_WINDOW_DRAG = !isLinux();
 
 /**
  * Reusable full-screen panel component
@@ -84,10 +85,14 @@ export const FullScreenPanel: React.FC<FullScreenPanelProps> = ({
         >
           {/* Drag region - match App.tsx */}
           <div
-            data-tauri-drag-region
+            {...(ENABLE_CUSTOM_WINDOW_DRAG
+              ? { "data-tauri-drag-region": true }
+              : {})}
             style={
               {
-                WebkitAppRegion: "drag",
+                ...(ENABLE_CUSTOM_WINDOW_DRAG
+                  ? { WebkitAppRegion: "drag" }
+                  : {}),
                 height: DRAG_BAR_HEIGHT,
               } as React.CSSProperties
             }
@@ -96,10 +101,14 @@ export const FullScreenPanel: React.FC<FullScreenPanelProps> = ({
           {/* Header - match App.tsx */}
           <div
             className="flex-shrink-0 flex items-center"
-            data-tauri-drag-region
+            {...(ENABLE_CUSTOM_WINDOW_DRAG
+              ? { "data-tauri-drag-region": true }
+              : {})}
             style={
               {
-                WebkitAppRegion: "drag",
+                ...(ENABLE_CUSTOM_WINDOW_DRAG
+                  ? { WebkitAppRegion: "drag" }
+                  : {}),
                 backgroundColor: "hsl(var(--background))",
                 height: HEADER_HEIGHT,
               } as React.CSSProperties
@@ -107,8 +116,14 @@ export const FullScreenPanel: React.FC<FullScreenPanelProps> = ({
           >
             <div
               className="px-6 w-full flex items-center gap-4"
-              data-tauri-drag-region
-              style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+              {...(ENABLE_CUSTOM_WINDOW_DRAG
+                ? { "data-tauri-drag-region": true }
+                : {})}
+              style={
+                (ENABLE_CUSTOM_WINDOW_DRAG
+                  ? { WebkitAppRegion: "drag" }
+                  : undefined) as React.CSSProperties
+              }
             >
               <Button
                 type="button"


### PR DESCRIPTION
## Summary
- add a Linux-specific Tauri config that uses the system title bar
- disable custom Tauri drag regions on Linux headers and full-screen panels
- note the fix in the changelog

## Problem
On Ubuntu 24.04 / GNOME 46 / Wayland, the main window's maximize and close buttons can appear but not receive clicks.

## Root cause
Linux was still inheriting the shared window setup while the frontend also marked the custom header as a Tauri drag region. In GNOME/Wayland this can leave the native controls underneath an overlapping custom title/header area.

## Fix
- add `src-tauri/tauri.linux.conf.json` with `titleBarStyle: "Visible"`
- gate custom drag-region attributes behind `!isLinux()` in:
  - `src/App.tsx`
  - `src/components/common/FullScreenPanel.tsx`

## Validation
- `corepack pnpm test:unit`
- `corepack pnpm build:renderer`
