### PR TITLE
fix: support JSON-with-comments for OpenCode/Claude config and keep provider save on live sync failure

### DIFF
--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -5,7 +5,8 @@ use crate::app_config::AppType;
 use crate::error::AppError;
 use crate::provider::Provider;
 use crate::services::{
-    EndpointLatency, ProviderService, ProviderSortUpdate, SpeedtestService, SwitchResult,
+    EndpointLatency, ProviderMutationResult, ProviderService, ProviderSortUpdate, SpeedtestService,
+    SwitchResult,
 };
 use crate::store::AppState;
 use std::str::FromStr;
@@ -30,7 +31,7 @@ pub fn add_provider(
     state: State<'_, AppState>,
     app: String,
     provider: Provider,
-) -> Result<bool, String> {
+) -> Result<ProviderMutationResult, String> {
     let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
     ProviderService::add(state.inner(), app_type, provider).map_err(|e| e.to_string())
 }
@@ -40,7 +41,7 @@ pub fn update_provider(
     state: State<'_, AppState>,
     app: String,
     provider: Provider,
-) -> Result<bool, String> {
+) -> Result<ProviderMutationResult, String> {
     let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
     ProviderService::update(state.inner(), app_type, provider).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -159,6 +159,18 @@ pub fn read_json_file<T: for<'a> Deserialize<'a>>(path: &Path) -> Result<T, AppE
     serde_json::from_str(&content).map_err(|e| AppError::json(path, e))
 }
 
+/// 读取允许注释/尾随逗号的 JSON 配置文件（JSON5 兼容）
+pub fn read_jsonc_file<T: for<'a> Deserialize<'a>>(path: &Path) -> Result<T, AppError> {
+    if !path.exists() {
+        return Err(AppError::Config(format!("文件不存在: {}", path.display())));
+    }
+
+    let content = fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
+
+    json5::from_str(&content)
+        .map_err(|e| AppError::Config(format!("JSON5 解析失败 ({}): {e}", path.display())))
+}
+
 /// 写入 JSON 配置文件
 pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppError> {
     // 确保目录存在

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -35,7 +35,8 @@ pub fn read_opencode_config() -> Result<Value, AppError> {
     }
 
     let content = std::fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
-    serde_json::from_str(&content).map_err(|e| AppError::json(&path, e))
+    json5::from_str(&content)
+        .map_err(|e| AppError::Config(format!("Failed to parse OpenCode config as JSON5: {e}")))
 }
 
 pub fn write_opencode_config(config: &Value) -> Result<(), AppError> {

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -18,7 +18,7 @@ pub use config::ConfigService;
 pub use mcp::McpService;
 pub use omo::OmoService;
 pub use prompt::PromptService;
-pub use provider::{ProviderService, ProviderSortUpdate, SwitchResult};
+pub use provider::{ProviderMutationResult, ProviderService, ProviderSortUpdate, SwitchResult};
 pub use proxy::ProxyService;
 #[allow(unused_imports)]
 pub use skill::{DiscoverableSkill, Skill, SkillRepo, SkillService};

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -8,7 +8,9 @@ use serde_json::{json, Value};
 
 use crate::app_config::AppType;
 use crate::codex_config::{get_codex_auth_path, get_codex_config_path};
-use crate::config::{delete_file, get_claude_settings_path, read_json_file, write_json_file};
+use crate::config::{
+    delete_file, get_claude_settings_path, read_json_file, read_jsonc_file, write_json_file,
+};
 use crate::error::AppError;
 use crate::provider::Provider;
 use crate::services::mcp::McpService;
@@ -332,7 +334,7 @@ pub fn read_live_settings(app_type: AppType) -> Result<Value, AppError> {
                     "Claude settings file is missing",
                 ));
             }
-            read_json_file(&path)
+            read_jsonc_file(&path)
         }
         AppType::Gemini => {
             use crate::gemini_config::{
@@ -441,7 +443,7 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
                     "Claude settings file is missing",
                 ));
             }
-            let mut v = read_json_file::<Value>(&settings_path)?;
+            let mut v = read_jsonc_file::<Value>(&settings_path)?;
             let _ = normalize_claude_models_in_value(&mut v);
             v
         }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -45,6 +45,13 @@ pub struct SwitchResult {
     pub warnings: Vec<String>,
 }
 
+/// Result of provider add/update, including non-fatal live sync warnings.
+#[derive(Debug, serde::Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderMutationResult {
+    pub warnings: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,6 +135,12 @@ base_url = "http://localhost:8080"
 }
 
 impl ProviderService {
+    fn push_non_fatal_warning(result: &mut ProviderMutationResult, action: &str, err: &AppError) {
+        let message = format!("已保存到 CC Switch，但 {action} 失败：{err}");
+        log::warn!("{message}");
+        result.warnings.push(message);
+    }
+
     fn normalize_provider_if_claude(app_type: &AppType, provider: &mut Provider) {
         if matches!(app_type, AppType::Claude) {
             let mut v = provider.settings_config.clone();
@@ -162,7 +175,12 @@ impl ProviderService {
     }
 
     /// Add a new provider
-    pub fn add(state: &AppState, app_type: AppType, provider: Provider) -> Result<bool, AppError> {
+    pub fn add(
+        state: &AppState,
+        app_type: AppType,
+        provider: Provider,
+    ) -> Result<ProviderMutationResult, AppError> {
+        let mut result = ProviderMutationResult::default();
         let mut provider = provider;
         // Normalize Claude model keys
         Self::normalize_provider_if_claude(&app_type, &mut provider);
@@ -179,10 +197,16 @@ impl ProviderService {
             {
                 // Do not auto-enable newly added OMO / OMO Slim providers.
                 // Users must explicitly switch/apply an OMO provider to activate it.
-                return Ok(true);
+                return Ok(result);
             }
-            write_live_snapshot(&app_type, &provider)?;
-            return Ok(true);
+            if let Err(err) = write_live_snapshot(&app_type, &provider) {
+                Self::push_non_fatal_warning(
+                    &mut result,
+                    &format!("同步 {} live 配置", app_type.as_str()),
+                    &err,
+                );
+            }
+            return Ok(result);
         }
 
         // For other apps: Check if sync is needed (if this is current provider, or no current provider)
@@ -192,10 +216,16 @@ impl ProviderService {
             state
                 .db
                 .set_current_provider(app_type.as_str(), &provider.id)?;
-            write_live_snapshot(&app_type, &provider)?;
+            if let Err(err) = write_live_snapshot(&app_type, &provider) {
+                Self::push_non_fatal_warning(
+                    &mut result,
+                    &format!("同步 {} live 配置", app_type.as_str()),
+                    &err,
+                );
+            }
         }
 
-        Ok(true)
+        Ok(result)
     }
 
     /// Update a provider
@@ -203,7 +233,8 @@ impl ProviderService {
         state: &AppState,
         app_type: AppType,
         provider: Provider,
-    ) -> Result<bool, AppError> {
+    ) -> Result<ProviderMutationResult, AppError> {
+        let mut result = ProviderMutationResult::default();
         let mut provider = provider;
         // Normalize Claude model keys
         Self::normalize_provider_if_claude(&app_type, &mut provider);
@@ -226,7 +257,7 @@ impl ProviderService {
                         &crate::services::omo::STANDARD,
                     )?;
                 }
-                return Ok(true);
+                return Ok(result);
             }
             if matches!(app_type, AppType::OpenCode)
                 && provider.category.as_deref() == Some("omo-slim")
@@ -242,10 +273,16 @@ impl ProviderService {
                         &crate::services::omo::SLIM,
                     )?;
                 }
-                return Ok(true);
+                return Ok(result);
             }
-            write_live_snapshot(&app_type, &provider)?;
-            return Ok(true);
+            if let Err(err) = write_live_snapshot(&app_type, &provider) {
+                Self::push_non_fatal_warning(
+                    &mut result,
+                    &format!("同步 {} live 配置", app_type.as_str()),
+                    &err,
+                );
+            }
+            return Ok(result);
         }
 
         // For other apps: Check if this is current provider (use effective current, not just DB)
@@ -273,13 +310,19 @@ impl ProviderService {
                 )
                 .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
             } else {
-                write_live_snapshot(&app_type, &provider)?;
-                // Sync MCP
-                McpService::sync_all_enabled(state)?;
+                if let Err(err) = write_live_snapshot(&app_type, &provider) {
+                    Self::push_non_fatal_warning(
+                        &mut result,
+                        &format!("同步 {} live 配置", app_type.as_str()),
+                        &err,
+                    );
+                } else if let Err(err) = McpService::sync_all_enabled(state) {
+                    Self::push_non_fatal_warning(&mut result, "同步 MCP 到 live 配置", &err);
+                }
             }
         }
 
-        Ok(true)
+        Ok(result)
     }
 
     /// Delete a provider

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3,7 +3,7 @@
 //! 提供代理服务器的启动、停止和配置管理
 
 use crate::app_config::AppType;
-use crate::config::{get_claude_settings_path, read_json_file, write_json_file};
+use crate::config::{get_claude_settings_path, read_json_file, read_jsonc_file, write_json_file};
 use crate::database::Database;
 use crate::provider::Provider;
 use crate::proxy::server::ProxyServer;
@@ -1666,7 +1666,7 @@ impl ProxyService {
         }
 
         let mut value: Value =
-            read_json_file(&path).map_err(|e| format!("读取 Claude 配置失败: {e}"))?;
+            read_jsonc_file(&path).map_err(|e| format!("读取 Claude 配置失败: {e}"))?;
 
         if value.is_null() {
             value = json!({});

--- a/src/components/UsageFooter.tsx
+++ b/src/components/UsageFooter.tsx
@@ -183,7 +183,10 @@ const UsageFooter: React.FC<UsageFooterProps> = ({
 
           {/* 扩展字段 extra */}
           {firstUsage.extra && (
-            <span className="text-gray-500 dark:text-gray-400 truncate max-w-[150px]" title={firstUsage.extra}>
+            <span
+              className="text-gray-500 dark:text-gray-400 truncate max-w-[150px]"
+              title={firstUsage.extra}
+            >
               {firstUsage.extra}
             </span>
           )}

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -133,12 +133,13 @@ export const providerPresets: ProviderPreset[] = [
     icon: "bailian",
     iconColor: "#624AFF",
   },
-{
+  {
     name: "Bailian For Coding",
     websiteUrl: "https://bailian.console.aliyun.com",
     settingsConfig: {
       env: {
-        ANTHROPIC_BASE_URL: "https://coding.dashscope.aliyuncs.com/apps/anthropic",
+        ANTHROPIC_BASE_URL:
+          "https://coding.dashscope.aliyuncs.com/apps/anthropic",
         ANTHROPIC_AUTH_TOKEN: "",
       },
     },

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -208,7 +208,10 @@ export function useProviderActions(activeApp: AppId) {
           },
         };
 
-        await providersApi.update(updatedProvider, activeApp);
+        const updateResult = await providersApi.update(
+          updatedProvider,
+          activeApp,
+        );
         await queryClient.invalidateQueries({
           queryKey: ["providers", activeApp],
         });
@@ -223,6 +226,13 @@ export function useProviderActions(activeApp: AppId) {
           }),
           { closeButton: true },
         );
+
+        if (updateResult.warnings?.length) {
+          toast.warning(updateResult.warnings.join("\n"), {
+            closeButton: true,
+            duration: 8000,
+          });
+        }
       } catch (error) {
         const detail =
           extractErrorMessage(error) ||

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -375,6 +375,17 @@ export function useSettings(): UseSettingsResult {
               "[useSettings] Failed to sync current providers after directory change",
               syncResult.error,
             );
+            toast.warning(
+              t("notifications.settingsSavedButLiveSyncFailed", {
+                defaultValue:
+                  "设置已保存到 CC Switch，但同步到应用配置失败：{{error}}",
+                error: syncResult.error?.message ?? t("common.unknown"),
+              }),
+              {
+                closeButton: true,
+                duration: 8000,
+              },
+            );
           }
         }
 

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -21,6 +21,10 @@ export interface SwitchResult {
   warnings: string[];
 }
 
+export interface ProviderMutationResult {
+  warnings: string[];
+}
+
 export const providersApi = {
   async getAll(appId: AppId): Promise<Record<string, Provider>> {
     return await invoke("get_providers", { app: appId });
@@ -30,11 +34,17 @@ export const providersApi = {
     return await invoke("get_current_provider", { app: appId });
   },
 
-  async add(provider: Provider, appId: AppId): Promise<boolean> {
+  async add(
+    provider: Provider,
+    appId: AppId,
+  ): Promise<ProviderMutationResult> {
     return await invoke("add_provider", { provider, app: appId });
   },
 
-  async update(provider: Provider, appId: AppId): Promise<boolean> {
+  async update(
+    provider: Provider,
+    appId: AppId,
+  ): Promise<ProviderMutationResult> {
     return await invoke("update_provider", { provider, app: appId });
   },
 

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -34,10 +34,7 @@ export const providersApi = {
     return await invoke("get_current_provider", { app: appId });
   },
 
-  async add(
-    provider: Provider,
-    appId: AppId,
-  ): Promise<ProviderMutationResult> {
+  async add(provider: Provider, appId: AppId): Promise<ProviderMutationResult> {
     return await invoke("add_provider", { provider, app: appId });
   },
 

--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -44,10 +44,13 @@ export const useAddProviderMutation = (appId: AppId) => {
       };
       delete (newProvider as any).providerKey;
 
-      await providersApi.add(newProvider, appId);
-      return newProvider;
+      const mutationResult = await providersApi.add(newProvider, appId);
+      return {
+        provider: newProvider,
+        warnings: mutationResult.warnings ?? [],
+      };
     },
-    onSuccess: async () => {
+    onSuccess: async ({ warnings }) => {
       await queryClient.invalidateQueries({ queryKey: ["providers", appId] });
 
       if (appId === "opencode") {
@@ -82,6 +85,13 @@ export const useAddProviderMutation = (appId: AppId) => {
           closeButton: true,
         },
       );
+
+      if (warnings.length > 0) {
+        toast.warning(warnings.join("\n"), {
+          closeButton: true,
+          duration: 8000,
+        });
+      }
     },
     onError: (error: Error) => {
       const detail = extractErrorMessage(error) || t("common.unknown");
@@ -101,10 +111,13 @@ export const useUpdateProviderMutation = (appId: AppId) => {
 
   return useMutation({
     mutationFn: async (provider: Provider) => {
-      await providersApi.update(provider, appId);
-      return provider;
+      const mutationResult = await providersApi.update(provider, appId);
+      return {
+        provider,
+        warnings: mutationResult.warnings ?? [],
+      };
     },
-    onSuccess: async () => {
+    onSuccess: async ({ warnings }) => {
       await queryClient.invalidateQueries({ queryKey: ["providers", appId] });
       toast.success(
         t("notifications.updateSuccess", {
@@ -114,6 +127,13 @@ export const useUpdateProviderMutation = (appId: AppId) => {
           closeButton: true,
         },
       );
+
+      if (warnings.length > 0) {
+        toast.warning(warnings.join("\n"), {
+          closeButton: true,
+          duration: 8000,
+        });
+      }
     },
     onError: (error: Error) => {
       const detail = extractErrorMessage(error) || t("common.unknown");

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -80,7 +80,7 @@ export const handlers = [
 
     const newId = provider.id ?? `mock-${Date.now()}`;
     addProvider(app, { ...provider, id: newId });
-    return success(true);
+    return success({ warnings: [] });
   }),
 
   http.post(`${TAURI_ENDPOINT}/update_provider`, async ({ request }) => {
@@ -89,7 +89,7 @@ export const handlers = [
       app: AppId;
     }>(request);
     updateProvider(app, provider);
-    return success(true);
+    return success({ warnings: [] });
   }),
 
   http.post(`${TAURI_ENDPOINT}/delete_provider`, async ({ request }) => {


### PR DESCRIPTION
## Background

  When `opencode.json` or Claude live config contains comments, strict JSON parsing fails.
  This could block provider-related save flows (including non-OpenCode providers) because live sync paths also touch OpenCode/Claude config parsing.

  ## What changed

  1. Enabled comment-tolerant JSON parsing for OpenCode and Claude live config reads.
  2. Changed provider add/update flow to preserve CC Switch internal save (DB) even if live sync fails.
     - Live sync / MCP sync failures are now returned as warnings instead of hard-failing the whole save.
  3. Added frontend warning toasts for these non-fatal sync failures, so users still see clear error feedback.
  4. Updated related API typing and test mocks for the new warning payload.

  ## Why this fixes the issue

  - Commented config files are now parsed correctly, avoiding unnecessary parse failures.
  - Save behavior is split into:
    - **internal config persistence** (must succeed)
    - **live sync** (best-effort with explicit warnings)

  So users no longer lose save capability in CC Switch due to external live config parse/sync errors.

  ## Validation

  - `pnpm typecheck`
  - `pnpm format:check`
  - `pnpm test:unit` (24 files, 167 tests)

  All passed.

  Thanks for the review.