### PR TITLE
feat(openClaw form): add input type selection for models Advanced Options / 为模型高级选项添加输入类型选择

### DIFF
--- a/src/components/providers/forms/OpenClawFormFields.tsx
+++ b/src/components/providers/forms/OpenClawFormFields.tsx
@@ -17,6 +17,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Plus, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ApiKeySection } from "./shared";
 import { openclawApiProtocols } from "@/config/openclawProviderPresets";
 import type { ProviderCategory, OpenClawModel } from "@/types";
@@ -95,6 +96,7 @@ export function OpenClawFormFields({
         contextWindow: undefined,
         maxTokens: undefined,
         cost: undefined,
+        input: ["text"],
       },
     ]);
   };
@@ -318,6 +320,62 @@ export function OpenClawFormFields({
                     </Button>
                   </CollapsibleTrigger>
                   <CollapsibleContent className="space-y-3 pt-2">
+                    {/* Reasoning, Input Types row */}
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1 space-y-1">
+                        <label className="text-xs text-muted-foreground">
+                          {t("openclaw.reasoning", {
+                            defaultValue: "推理模式",
+                          })}
+                        </label>
+                        <div className="flex items-center h-9 gap-2">
+                          <Switch
+                            checked={model.reasoning ?? false}
+                            onCheckedChange={(checked) =>
+                              handleModelChange(index, "reasoning", checked)
+                            }
+                          />
+                          <span className="text-xs text-muted-foreground">
+                            {model.reasoning
+                              ? t("openclaw.reasoningOn", {
+                                  defaultValue: "启用",
+                                })
+                              : t("openclaw.reasoningOff", {
+                                  defaultValue: "关闭",
+                                })}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex-1 space-y-1">
+                        <label className="text-xs text-muted-foreground">
+                          {t("openclaw.inputTypes", {
+                            defaultValue: "输入类型",
+                          })}
+                        </label>
+                        <div className="flex items-center gap-4 h-9">
+                          {(["text", "image"] as const).map((type) => (
+                            <label
+                              key={type}
+                              className="flex items-center gap-1.5 cursor-pointer select-none"
+                            >
+                              <Checkbox
+                                checked={(model.input ?? ["text"]).includes(type)}
+                                onCheckedChange={(checked) => {
+                                  const current = model.input ?? ["text"];
+                                  const next = checked
+                                    ? [...new Set([...current, type])]
+                                    : current.filter((v) => v !== type);
+                                  handleModelChange(index, "input", next);
+                                }}
+                              />
+                              <span className="text-xs">{type}</span>
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="flex-1" />
+                    </div>
+
                     {/* Context Window, Max Tokens and Reasoning row */}
                     <div className="flex items-center gap-2">
                       <div className="flex-1 space-y-1">
@@ -362,30 +420,7 @@ export function OpenClawFormFields({
                           placeholder="32000"
                         />
                       </div>
-                      <div className="flex-1 space-y-1">
-                        <label className="text-xs text-muted-foreground">
-                          {t("openclaw.reasoning", {
-                            defaultValue: "推理模式",
-                          })}
-                        </label>
-                        <div className="flex items-center h-9 gap-2">
-                          <Switch
-                            checked={model.reasoning ?? false}
-                            onCheckedChange={(checked) =>
-                              handleModelChange(index, "reasoning", checked)
-                            }
-                          />
-                          <span className="text-xs text-muted-foreground">
-                            {model.reasoning
-                              ? t("openclaw.reasoningOn", {
-                                  defaultValue: "启用",
-                                })
-                              : t("openclaw.reasoningOff", {
-                                  defaultValue: "关闭",
-                                })}
-                          </span>
-                        </div>
-                      </div>
+                      <div className="flex-1" />
                     </div>
 
                     {/* Cost row */}


### PR DESCRIPTION
### 概述

优化了 `OpenClawFormFields` 中模型高级选项的界面，新增了**输入类型**字段，并对布局进行了重组，提升可读性与一致性。

### 背景

- OpenClaw 目前最新版本（2026.3.2）中存在这个问题：如果是支持视觉模态的模型，但是配置文件中 `models.providers.name.models.input` 配置不存在或者不包含`image`，则无法使用视觉能力。
<img width="1861" height="732" alt="image" src="https://github.com/user-attachments/assets/0afb2c5f-8b88-411d-b76f-0dad40235112" />

- CC Switch 目前最新版本（3.11.1）中没有配置上述 `input` 的地方，生成的配置文件里没有  `input`，故添加，默认选中 `text`，可选 `image` 

### 变更内容

**新功能：输入类型选择器**

- 新增 `Checkbox` 复选框组（`text` / `image`），允许用户为每个模型指定支持的输入模态
- 新建模型时默认初始化 `input: ["text"]`
- 使用 `Set` 去重，防止选中时出现重复项

**布局优化：推理模式位置调整**
- 将"推理模式"开关从"上下文窗口 / 最大输出 Tokens"所在行移出
- 在高级选项折叠区顶部新增独立行，将"推理模式"与"输入类型"并排展示
- 使相关能力配置集中在一起，层次更清晰

### 涉及文件

- OpenClawFormFields.tsx
  - 引入 `Checkbox` 组件（来自 `@/components/ui/checkbox`）
  - 在 `handleAddModel` 中为新模型初始化 `input: ["text"]`
  - 在 `CollapsibleContent` 顶部新增"推理模式 + 输入类型"行
  - 从"上下文窗口 / 最大输出 Tokens"行中移除推理模式开关

### 测试项

- [x] 新建 OpenClaw 供应商，验证默认模型的 `input` 字段为 `["text"]`
- [x] 勾选/取消勾选 `image` 类型，验证状态更新正确
- [x] 验证推理模式开关在新位置正常显示和工作
- [x] 验证上下文窗口、最大输出 Tokens 字段无回归问题