### PR TITLE
fix: toolbar compact mode not triggering on Windows due to left-side overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ flatpak/cc-switch.deb
 flatpak-build/
 flatpak-repo/
 .worktrees/
+.spec-workflow/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -996,10 +996,10 @@ function App() {
               )}
             <div
               ref={toolbarRef}
-              className="flex flex-1 min-w-0 overflow-x-hidden justify-end items-center"
+              className="flex flex-1 min-w-0 overflow-x-hidden items-center"
             >
               <div
-                className="flex shrink-0 items-center gap-1.5"
+                className="flex shrink-0 items-center gap-1.5 ml-auto"
                 style={{ WebkitAppRegion: "no-drag" } as any}
               >
                 {currentView === "prompts" && (


### PR DESCRIPTION
## Summary

- The toolbar container used `justify-end`, causing content overflow to the **left side** at minimum window width
- Browser `scrollWidth` does not account for left-side overflow, so `useAutoCompact` never detected it — compact mode never activated
- This resulted in clipped tab labels (e.g. "aude" instead of "Claude") on Windows at `minWidth: 900`

## Fix

- Remove `justify-end` from the `toolbarRef` container
- Add `ml-auto` to the child element to maintain right-aligned appearance
- Overflow now goes rightward, where `scrollWidth` correctly detects it and triggers compact mode

## Affected platforms

Primarily **Windows** and **Linux** (where `DRAG_BAR_HEIGHT = 0`), but the underlying bug exists on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)