### PR TITLE
fix: add missing authHeader: true to Longcat provider preset

### DIFF
--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -421,6 +421,7 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
       baseUrl: "https://api.longcat.chat/v1",
       apiKey: "",
       api: "openai-completions",
+      authHeader: true,
       models: [
         {
           id: "LongCat-Flash-Chat",


### PR DESCRIPTION
## Description

Fixes issue where Longcat models were failing with 404 error when using OpenClaw integration.

The Longcat API requires `authHeader: true` configuration for proper authentication, but this setting was missing from the provider preset configuration.

## Problem

When users try to use Longcat models with OpenClaw through cc-switch, they encounter:
Agent failed before reply: All models failed (3): longcat/LongCat-Flash-Chat: 404
## Solution

Added the missing `authHeader: true` configuration to the Longcat provider preset in `src/config/openclawProviderPresets.ts`.

According to Longcat API documentation: https://longcat.chat/platform/docs/OpenClaw.html#configuration-option-1-modify-configuration-file

## Changes

- Added `authHeader: true` to Longcat provider preset configuration

## Related Issue

Closes #1376

## Testing

- Verified the configuration syntax is correct
- Confirmed the fix resolves the authentication issue