### PR TITLE
fix: 修复模型测试 toast 变量未插值

### DIFF
--- a/src/hooks/useStreamCheck.ts
+++ b/src/hooks/useStreamCheck.ts
@@ -26,8 +26,8 @@ export function useStreamCheck(appId: AppId) {
         if (result.status === "operational") {
           toast.success(
             t("streamCheck.operational", {
-              name: providerName,
-              time: result.responseTimeMs,
+              providerName,
+              responseTimeMs: result.responseTimeMs,
               defaultValue: `${providerName} 运行正常 (${result.responseTimeMs}ms)`,
             }),
             { closeButton: true },
@@ -38,8 +38,8 @@ export function useStreamCheck(appId: AppId) {
         } else if (result.status === "degraded") {
           toast.warning(
             t("streamCheck.degraded", {
-              name: providerName,
-              time: result.responseTimeMs,
+              providerName,
+              responseTimeMs: result.responseTimeMs,
               defaultValue: `${providerName} 响应较慢 (${result.responseTimeMs}ms)`,
             }),
           );
@@ -49,8 +49,8 @@ export function useStreamCheck(appId: AppId) {
         } else {
           toast.error(
             t("streamCheck.failed", {
-              name: providerName,
-              error: result.message,
+              providerName,
+              message: result.message,
               defaultValue: `${providerName} 检查失败: ${result.message}`,
             }),
           );
@@ -60,7 +60,7 @@ export function useStreamCheck(appId: AppId) {
       } catch (e) {
         toast.error(
           t("streamCheck.error", {
-            name: providerName,
+            providerName,
             error: String(e),
             defaultValue: `${providerName} 检查出错: ${String(e)}`,
           }),

--- a/tests/hooks/useStreamCheck.test.tsx
+++ b/tests/hooks/useStreamCheck.test.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStreamCheck } from "@/hooks/useStreamCheck";
+
+const toastSuccessMock = vi.fn();
+const toastWarningMock = vi.fn();
+const toastErrorMock = vi.fn();
+const streamCheckProviderMock = vi.fn();
+const resetCircuitBreakerMutateMock = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    warning: (...args: unknown[]) => toastWarningMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+vi.mock("@/lib/api/model-test", () => ({
+  streamCheckProvider: (...args: unknown[]) => streamCheckProviderMock(...args),
+}));
+
+vi.mock("@/lib/query/failover", () => ({
+  useResetCircuitBreaker: () => ({
+    mutate: (...args: unknown[]) => resetCircuitBreakerMutateMock(...args),
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      switch (key) {
+        case "streamCheck.operational":
+          return `${options?.providerName} 运行正常 (${options?.responseTimeMs}ms)`;
+        case "streamCheck.degraded":
+          return `${options?.providerName} 响应较慢 (${options?.responseTimeMs}ms)`;
+        case "streamCheck.failed":
+          return `${options?.providerName} 检查失败: ${options?.message}`;
+        case "streamCheck.error":
+          return `${options?.providerName} 检查出错: ${options?.error}`;
+        default:
+          return typeof options?.defaultValue === "string"
+            ? options.defaultValue
+            : key;
+      }
+    },
+  }),
+}));
+
+describe("useStreamCheck", () => {
+  beforeEach(() => {
+    toastSuccessMock.mockReset();
+    toastWarningMock.mockReset();
+    toastErrorMock.mockReset();
+    streamCheckProviderMock.mockReset();
+    resetCircuitBreakerMutateMock.mockReset();
+  });
+
+  it("shows interpolated provider name and latency for operational result", async () => {
+    streamCheckProviderMock.mockResolvedValue({
+      status: "operational",
+      success: true,
+      message: "ok",
+      responseTimeMs: 123,
+      modelUsed: "test-model",
+      testedAt: 1,
+      retryCount: 0,
+    });
+
+    const { result } = renderHook(() => useStreamCheck("gemini"));
+
+    await act(async () => {
+      await result.current.checkProvider("provider-1", "Gemini");
+    });
+
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Gemini 运行正常 (123ms)",
+      { closeButton: true },
+    );
+    expect(resetCircuitBreakerMutateMock).toHaveBeenCalledWith({
+      providerId: "provider-1",
+      appType: "gemini",
+    });
+  });
+
+  it("shows interpolated provider name and latency for degraded result", async () => {
+    streamCheckProviderMock.mockResolvedValue({
+      status: "degraded",
+      success: true,
+      message: "slow",
+      responseTimeMs: 456,
+      modelUsed: "test-model",
+      testedAt: 1,
+      retryCount: 0,
+    });
+
+    const { result } = renderHook(() => useStreamCheck("claude"));
+
+    await act(async () => {
+      await result.current.checkProvider("provider-2", "Claude");
+    });
+
+    expect(toastWarningMock).toHaveBeenCalledWith("Claude 响应较慢 (456ms)");
+    expect(resetCircuitBreakerMutateMock).toHaveBeenCalledWith({
+      providerId: "provider-2",
+      appType: "claude",
+    });
+  });
+
+  it("shows interpolated provider name and message for failed result", async () => {
+    streamCheckProviderMock.mockResolvedValue({
+      status: "failed",
+      success: false,
+      message: "HTTP 500",
+      responseTimeMs: 0,
+      modelUsed: "test-model",
+      testedAt: 1,
+      retryCount: 0,
+    });
+
+    const { result } = renderHook(() => useStreamCheck("codex"));
+
+    await act(async () => {
+      await result.current.checkProvider("provider-3", "Codex");
+    });
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Codex 检查失败: HTTP 500");
+    expect(resetCircuitBreakerMutateMock).not.toHaveBeenCalled();
+  });
+
+  it("shows interpolated provider name and error when request throws", async () => {
+    streamCheckProviderMock.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useStreamCheck("claude"));
+
+    await act(async () => {
+      await result.current.checkProvider("provider-4", "Claude");
+    });
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Claude 检查出错: Error: network down",
+    );
+    expect(resetCircuitBreakerMutateMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 问题出现时机
- 在供应商列表执行模型测试 / Stream Check 时，toast 会直接显示变量名
- 例如会显示 {{providerName}} 和 {{responseTimeMs}}，而不是实际供应商名称和耗时
- 如下图所示：
<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/ba2d20c3-75ea-4a21-8a53-1946161b2e44" />
<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/e7ea2526-728c-4527-993f-7b6ba52b9ac1" />
<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/f9f30f26-da9c-498e-908e-dc70351b918e" />


## 变更说明
- 修复 useStreamCheck 中传给 i18n 的参数名，与 locale 占位符保持一致
- 覆盖 operational、degraded、failed、error 四个分支
- 新增 hook 回归测试，避免同类插值问题再次出现
- 修复后如图所示：
<img width="892" height="630" alt="image" src="https://github.com/user-attachments/assets/b6a8929e-7e6b-4b90-bf37-e4edb8540f3a" />
<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/ef4662e9-3442-499a-a0c5-1f3211517bbc" />



## 验证
- pnpm vitest run tests/hooks/useStreamCheck.test.tsx
- pnpm typecheck

Closes #1411