### PR TITLE
fix(proxy): use max_completion_tokens for o1/o3 series models

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -6,6 +6,14 @@
 use crate::proxy::error::ProxyError;
 use serde_json::{json, Value};
 
+/// Detect OpenAI o-series reasoning models (o1, o3, o4-mini, etc.)
+/// These models require `max_completion_tokens` instead of `max_tokens`.
+pub fn is_openai_o_series(model: &str) -> bool {
+    model.len() > 1
+        && model.starts_with('o')
+        && model.as_bytes().get(1).is_some_and(|b| b.is_ascii_digit())
+}
+
 /// Anthropic 请求 → OpenAI 请求
 ///
 /// `cache_key`: optional prompt_cache_key to inject for improved cache routing
@@ -50,13 +58,10 @@ pub fn anthropic_to_openai(body: Value, cache_key: Option<&str>) -> Result<Value
 
     result["messages"] = json!(messages);
 
-    // 转换参数
-    // 检测模型类型：o1/o3 系列模型需要使用 max_completion_tokens 而不是 max_tokens
+    // 转换参数 — o-series 模型需要 max_completion_tokens
     let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
-    let is_o_series = model.starts_with("o1") || model.starts_with("o3");
-
     if let Some(v) = body.get("max_tokens") {
-        if is_o_series {
+        if is_openai_o_series(model) {
             result["max_completion_tokens"] = v.clone();
         } else {
             result["max_tokens"] = v.clone();
@@ -782,43 +787,42 @@ mod tests {
     }
 
     #[test]
-    fn test_anthropic_to_openai_o_series_max_completion_tokens() {
-        // o1/o3 系列模型应该使用 max_completion_tokens 而不是 max_tokens
-        let input_o1 = json!({
-            "model": "o1-mini",
-            "max_tokens": 1024,
-            "messages": [{"role": "user", "content": "Hello"}]
-        });
-
-        let result = anthropic_to_openai(input_o1, None).unwrap();
-        assert!(
-            result.get("max_completion_tokens").is_some(),
-            "o1 模型应该使用 max_completion_tokens"
-        );
-        assert!(
-            result.get("max_tokens").is_none(),
-            "o1 模型不应该使用 max_tokens"
-        );
-        assert_eq!(result["max_completion_tokens"], 1024);
-
-        // 测试 o3 系列
-        let input_o3 = json!({
-            "model": "o3-mini",
-            "max_tokens": 2048,
-            "messages": [{"role": "user", "content": "Hello"}]
-        });
-
-        let result_o3 = anthropic_to_openai(input_o3, None).unwrap();
-        assert!(
-            result_o3.get("max_completion_tokens").is_some(),
-            "o3 模型应该使用 max_completion_tokens"
-        );
-        assert_eq!(result_o3["max_completion_tokens"], 2048);
+    fn test_is_openai_o_series() {
+        assert!(is_openai_o_series("o1"));
+        assert!(is_openai_o_series("o1-preview"));
+        assert!(is_openai_o_series("o1-mini"));
+        assert!(is_openai_o_series("o3"));
+        assert!(is_openai_o_series("o3-mini"));
+        assert!(is_openai_o_series("o4-mini"));
+        assert!(!is_openai_o_series("gpt-4o"));
+        assert!(!is_openai_o_series("openai-gpt"));
+        assert!(!is_openai_o_series("o"));
+        assert!(!is_openai_o_series(""));
     }
 
     #[test]
-    fn test_anthropic_to_openai_non_o_series_max_tokens() {
-        // 非 o 系列模型应该继续使用 max_tokens
+    fn test_anthropic_to_openai_o_series_max_completion_tokens() {
+        for model in &["o1", "o3-mini", "o4-mini"] {
+            let input = json!({
+                "model": model,
+                "max_tokens": 4096,
+                "messages": [{"role": "user", "content": "Hello"}]
+            });
+
+            let result = anthropic_to_openai(input, None).unwrap();
+            assert!(
+                result.get("max_tokens").is_none(),
+                "{model} should not have max_tokens"
+            );
+            assert_eq!(
+                result["max_completion_tokens"], 4096,
+                "{model} should use max_completion_tokens"
+            );
+        }
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_non_o_series_keeps_max_tokens() {
         let input = json!({
             "model": "gpt-4o",
             "max_tokens": 1024,
@@ -826,14 +830,7 @@ mod tests {
         });
 
         let result = anthropic_to_openai(input, None).unwrap();
-        assert!(
-            result.get("max_tokens").is_some(),
-            "gpt-4o 应该使用 max_tokens"
-        );
-        assert!(
-            result.get("max_completion_tokens").is_none(),
-            "gpt-4o 不应该使用 max_completion_tokens"
-        );
         assert_eq!(result["max_tokens"], 1024);
+        assert!(result.get("max_completion_tokens").is_none());
     }
 }

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -45,7 +45,7 @@ pub fn anthropic_to_responses(body: Value, cache_key: Option<&str>) -> Result<Va
         result["input"] = json!(input);
     }
 
-    // max_tokens → max_output_tokens
+    // max_tokens → max_output_tokens (Responses API uses max_output_tokens for all models)
     if let Some(v) = body.get("max_tokens") {
         result["max_output_tokens"] = v.clone();
     }
@@ -896,5 +896,18 @@ mod tests {
         let result = responses_to_anthropic(input).unwrap();
         assert_eq!(result["usage"]["cache_read_input_tokens"], 60);
         assert_eq!(result["usage"]["cache_creation_input_tokens"], 20);
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_o_series_uses_max_output_tokens() {
+        // Responses API always uses max_output_tokens, even for o-series models
+        let input = json!({
+            "model": "o3-mini",
+            "max_tokens": 4096,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+        let result = anthropic_to_responses(input, None).unwrap();
+        assert_eq!(result["max_output_tokens"], 4096);
+        assert!(result.get("max_completion_tokens").is_none());
     }
 }


### PR DESCRIPTION
## Description

When using Claude Code CLI with GPT models (especially o1/o3 series like o1-mini, o3-mini), the API returns an error:

```
API Error: 400 {"error":{"code":"unsupported_parameter","message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.","param":"max_tokens","type":"invalid_request_error"}}
```

This PR fixes the issue by detecting o1/o3 series models in the `anthropic_to_openai` transform function and using `max_completion_tokens` instead of `max_tokens` for these models.

## Changes

- Modified `src-tauri/src/proxy/providers/transform.rs`:
  - Detect o1/o3 series models by checking if model name starts with "o1" or "o3"
  - Use `max_completion_tokens` for o-series models
  - Keep `max_tokens` for other models (gpt-4, gpt-4o, etc.)
  - Added unit tests to verify the behavior

## Testing

Added two new test cases:
- `test_anthropic_to_openai_o_series_max_completion_tokens`: Verifies o1/o3 models use max_completion_tokens
- `test_anthropic_to_openai_non_o_series_max_tokens`: Verifies non-o models continue using max_tokens

Fixes #1448