### PR TITLE
fix: 修复 Codex base_url 被写入错误 TOML section

### DIFF
--- a/src/components/providers/AddProviderDialog.tsx
+++ b/src/components/providers/AddProviderDialog.tsx
@@ -17,6 +17,7 @@ import { UniversalProviderPanel } from "@/components/universal";
 import { providerPresets } from "@/config/claudeProviderPresets";
 import { codexProviderPresets } from "@/config/codexProviderPresets";
 import { geminiProviderPresets } from "@/config/geminiProviderPresets";
+import { extractCodexBaseUrl } from "@/utils/providerConfigUtils";
 import type { OpenClawSuggestedDefaults } from "@/config/openclawProviderPresets";
 import type { UniversalProviderPreset } from "@/config/universalProviderPresets";
 
@@ -179,11 +180,9 @@ export function AddProviderDialog({
         } else if (appId === "codex") {
           const config = parsedConfig.config as string | undefined;
           if (config) {
-            const baseUrlMatch = config.match(
-              /base_url\s*=\s*["']([^"']+)["']/,
-            );
-            if (baseUrlMatch?.[1]) {
-              addUrl(baseUrlMatch[1]);
+            const extractedBaseUrl = extractCodexBaseUrl(config);
+            if (extractedBaseUrl) {
+              addUrl(extractedBaseUrl);
             }
           }
         } else if (appId === "gemini") {

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -13,6 +13,7 @@ import { ProviderIcon } from "@/components/ProviderIcon";
 import UsageFooter from "@/components/UsageFooter";
 import { ProviderHealthBadge } from "@/components/providers/ProviderHealthBadge";
 import { FailoverPriorityBadge } from "@/components/providers/FailoverPriorityBadge";
+import { extractCodexBaseUrl } from "@/utils/providerConfigUtils";
 import { useProviderHealth } from "@/lib/query/failover";
 import { useUsageQuery } from "@/lib/query/queries";
 
@@ -76,9 +77,9 @@ const extractApiUrl = (provider: Provider, fallbackText: string) => {
     const baseUrl = (config as Record<string, any>)?.config;
 
     if (typeof baseUrl === "string" && baseUrl.includes("base_url")) {
-      const match = baseUrl.match(/base_url\s*=\s*['"]([^'"]+)['"]/);
-      if (match?.[1]) {
-        return match[1];
+      const extractedBaseUrl = extractCodexBaseUrl(baseUrl);
+      if (extractedBaseUrl) {
+        return extractedBaseUrl;
       }
     }
   }

--- a/src/components/providers/forms/hooks/useSpeedTestEndpoints.ts
+++ b/src/components/providers/forms/hooks/useSpeedTestEndpoints.ts
@@ -3,6 +3,7 @@ import type { AppId } from "@/lib/api";
 import type { ProviderPreset } from "@/config/claudeProviderPresets";
 import type { CodexProviderPreset } from "@/config/codexProviderPresets";
 import type { ProviderMeta, EndpointCandidate } from "@/types";
+import { extractCodexBaseUrl } from "@/utils/providerConfigUtils";
 
 type PresetEntry = {
   id: string;
@@ -128,10 +129,9 @@ export function useSpeedTestEndpoints({
         }
       | undefined;
     const configStr = initialCodexConfig?.config ?? "";
-    // 从 TOML 中提取 base_url
-    const match = /base_url\s*=\s*["']([^"']+)["']/i.exec(configStr);
-    if (match?.[1]) {
-      add(match[1]);
+    const extractedBaseUrl = extractCodexBaseUrl(configStr);
+    if (extractedBaseUrl) {
+      add(extractedBaseUrl);
     }
 
     // 3. 预设中的 endpointCandidates
@@ -141,11 +141,9 @@ export function useSpeedTestEndpoints({
         const preset = entry.preset as CodexProviderPreset;
         // 添加预设自己的 baseUrl
         const presetConfig = preset.config || "";
-        const presetMatch = /base_url\s*=\s*["']([^"']+)["']/i.exec(
-          presetConfig,
-        );
-        if (presetMatch?.[1]) {
-          add(presetMatch[1]);
+        const presetBaseUrl = extractCodexBaseUrl(presetConfig);
+        if (presetBaseUrl) {
+          add(presetBaseUrl);
         }
         // 添加预设的候选端点
         if (preset.endpointCandidates) {

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -414,17 +414,176 @@ export const hasTomlCommonConfigSnippet = (
 
 // ========== Codex base_url utils ==========
 
+const TOML_SECTION_HEADER_PATTERN = /^\s*\[([^\]\r\n]+)\]\s*$/;
+const TOML_BASE_URL_PATTERN =
+  /^\s*base_url\s*=\s*(["'])([^"'\r\n]+)\1\s*(?:#.*)?$/;
+const TOML_MODEL_PROVIDER_PATTERN =
+  /^\s*model_provider\s*=\s*(["'])([^"'\r\n]+)\1\s*(?:#.*)?$/m;
+
+interface TomlSectionRange {
+  bodyEndIndex: number;
+  bodyStartIndex: number;
+}
+
+interface TomlAssignmentMatch {
+  index: number;
+  sectionName?: string;
+  value: string;
+}
+
+const finalizeTomlText = (lines: string[]): string =>
+  lines
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/^\n+/, "");
+
+const getTomlSectionRange = (
+  lines: string[],
+  sectionName: string,
+): TomlSectionRange | undefined => {
+  let headerLineIndex = -1;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(TOML_SECTION_HEADER_PATTERN);
+    if (!match) {
+      continue;
+    }
+
+    if (headerLineIndex === -1) {
+      if (match[1] === sectionName) {
+        headerLineIndex = index;
+      }
+      continue;
+    }
+
+    return {
+      bodyStartIndex: headerLineIndex + 1,
+      bodyEndIndex: index,
+    };
+  }
+
+  if (headerLineIndex === -1) {
+    return undefined;
+  }
+
+  return {
+    bodyStartIndex: headerLineIndex + 1,
+    bodyEndIndex: lines.length,
+  };
+};
+
+const getCodexModelProviderName = (configText: string): string | undefined => {
+  const match = configText.match(TOML_MODEL_PROVIDER_PATTERN);
+  const providerName = match?.[2]?.trim();
+  return providerName || undefined;
+};
+
+const findTomlAssignmentInRange = (
+  lines: string[],
+  pattern: RegExp,
+  startIndex: number,
+  endIndex: number,
+  sectionName?: string,
+): TomlAssignmentMatch | undefined => {
+  for (let index = startIndex; index < endIndex; index += 1) {
+    const match = lines[index].match(pattern);
+    if (match?.[2]) {
+      return {
+        index,
+        sectionName,
+        value: match[2],
+      };
+    }
+  }
+
+  return undefined;
+};
+
+const findTomlAssignments = (
+  lines: string[],
+  pattern: RegExp,
+): TomlAssignmentMatch[] => {
+  const assignments: TomlAssignmentMatch[] = [];
+  let currentSectionName: string | undefined;
+
+  lines.forEach((line, index) => {
+    const sectionMatch = line.match(TOML_SECTION_HEADER_PATTERN);
+    if (sectionMatch) {
+      currentSectionName = sectionMatch[1];
+      return;
+    }
+
+    const match = line.match(pattern);
+    if (!match?.[2]) {
+      return;
+    }
+
+    assignments.push({
+      index,
+      sectionName: currentSectionName,
+      value: match[2],
+    });
+  });
+
+  return assignments;
+};
+
+const getCodexProviderSectionName = (
+  configText: string,
+): string | undefined => {
+  const providerName = getCodexModelProviderName(configText);
+  return providerName ? `model_providers.${providerName}` : undefined;
+};
+
+const getTomlSectionInsertIndex = (
+  lines: string[],
+  sectionRange: TomlSectionRange,
+): number => {
+  let insertIndex = sectionRange.bodyEndIndex;
+  while (
+    insertIndex > sectionRange.bodyStartIndex &&
+    lines[insertIndex - 1].trim() === ""
+  ) {
+    insertIndex -= 1;
+  }
+  return insertIndex;
+};
+
 // 从 Codex 的 TOML 配置文本中提取 base_url（支持单/双引号）
 export const extractCodexBaseUrl = (
   configText: string | undefined | null,
 ): string | undefined => {
   try {
     const raw = typeof configText === "string" ? configText : "";
-    // 归一化中文/全角引号，避免正则提取失败
-    const text = normalizeQuotes(raw);
+    const text = normalizeTomlText(raw);
     if (!text) return undefined;
-    const m = text.match(/base_url\s*=\s*(['"])([^'\"]+)\1/);
-    return m && m[2] ? m[2] : undefined;
+
+    const lines = text.split("\n");
+    const targetSectionName = getCodexProviderSectionName(text);
+
+    if (targetSectionName) {
+      const sectionRange = getTomlSectionRange(lines, targetSectionName);
+      if (sectionRange) {
+        const match = findTomlAssignmentInRange(
+          lines,
+          TOML_BASE_URL_PATTERN,
+          sectionRange.bodyStartIndex,
+          sectionRange.bodyEndIndex,
+          targetSectionName,
+        );
+        if (match?.value) {
+          return match.value;
+        }
+      }
+    }
+
+    const fallbackMatch = findTomlAssignmentInRange(
+      lines,
+      TOML_BASE_URL_PATTERN,
+      0,
+      lines.length,
+    );
+    return fallbackMatch?.value;
   } catch {
     return undefined;
   }
@@ -451,36 +610,98 @@ export const setCodexBaseUrl = (
   baseUrl: string,
 ): string => {
   const trimmed = baseUrl.trim();
-  // 归一化原文本中的引号（既能匹配，也能输出稳定格式）
-  const normalizedText = normalizeQuotes(configText);
+  const normalizedText = normalizeTomlText(configText);
+  const lines = normalizedText ? normalizedText.split("\n") : [];
+  const targetSectionName = getCodexProviderSectionName(normalizedText);
+  const allAssignments = findTomlAssignments(lines, TOML_BASE_URL_PATTERN);
 
   // 允许清空：当 baseUrl 为空时，移除 base_url 行
   if (!trimmed) {
     if (!normalizedText) return normalizedText;
-    const next = normalizedText
-      .split("\n")
-      .filter((line) => !/^\s*base_url\s*=/.test(line))
-      .join("\n")
-      // 避免移除后留下过多空行
-      .replace(/\n{3,}/g, "\n\n")
-      // 避免开头出现空行
-      .replace(/^\n+/, "");
-    return next;
+
+    if (targetSectionName) {
+      const sectionRange = getTomlSectionRange(lines, targetSectionName);
+      const targetMatch = sectionRange
+        ? findTomlAssignmentInRange(
+            lines,
+            TOML_BASE_URL_PATTERN,
+            sectionRange.bodyStartIndex,
+            sectionRange.bodyEndIndex,
+            targetSectionName,
+          )
+        : undefined;
+
+      if (targetMatch) {
+        lines.splice(targetMatch.index, 1);
+        return finalizeTomlText(lines);
+      }
+    }
+
+    if (allAssignments.length === 1) {
+      lines.splice(allAssignments[0].index, 1);
+      return finalizeTomlText(lines);
+    }
+
+    return finalizeTomlText(lines);
   }
 
   const normalizedUrl = trimmed.replace(/\s+/g, "");
   const replacementLine = `base_url = "${normalizedUrl}"`;
-  const pattern = /base_url\s*=\s*(["'])([^"']+)\1/;
 
-  if (pattern.test(normalizedText)) {
-    return normalizedText.replace(pattern, replacementLine);
+  if (targetSectionName) {
+    let targetSectionRange = getTomlSectionRange(lines, targetSectionName);
+    const targetMatch = targetSectionRange
+      ? findTomlAssignmentInRange(
+          lines,
+          TOML_BASE_URL_PATTERN,
+          targetSectionRange.bodyStartIndex,
+          targetSectionRange.bodyEndIndex,
+          targetSectionName,
+        )
+      : undefined;
+
+    if (targetMatch) {
+      lines[targetMatch.index] = replacementLine;
+      return finalizeTomlText(lines);
+    }
+
+    if (
+      allAssignments.length === 1 &&
+      allAssignments[0].sectionName !== targetSectionName
+    ) {
+      lines.splice(allAssignments[0].index, 1);
+      targetSectionRange = getTomlSectionRange(lines, targetSectionName);
+    }
+
+    if (targetSectionRange) {
+      const insertIndex = getTomlSectionInsertIndex(lines, targetSectionRange);
+      lines.splice(insertIndex, 0, replacementLine);
+      return finalizeTomlText(lines);
+    }
+
+    if (lines.length > 0 && lines[lines.length - 1].trim() !== "") {
+      lines.push("");
+    }
+    lines.push(`[${targetSectionName}]`, replacementLine);
+    return finalizeTomlText(lines);
   }
 
-  const prefix =
-    normalizedText && !normalizedText.endsWith("\n")
-      ? `${normalizedText}\n`
-      : normalizedText;
-  return `${prefix}${replacementLine}\n`;
+  const firstAssignment = allAssignments[0];
+  if (firstAssignment) {
+    lines[firstAssignment.index] = replacementLine;
+    return finalizeTomlText(lines);
+  }
+
+  if (lines.length === 0) {
+    return `${replacementLine}\n`;
+  }
+
+  if (lines[lines.length - 1].trim() !== "") {
+    lines.push(replacementLine);
+  } else {
+    lines.splice(lines.length - 1, 0, replacementLine);
+  }
+  return finalizeTomlText(lines);
 };
 
 // ========== Codex model name utils ==========

--- a/tests/utils/providerConfigUtils.codex.test.ts
+++ b/tests/utils/providerConfigUtils.codex.test.ts
@@ -51,5 +51,91 @@ describe("Codex TOML utils", () => {
     const output2 = setCodexModelName(output1, " new-model \n");
     expect(extractCodexModelName(output2)).toBe("new-model");
   });
-});
 
+  it("writes base_url into the active provider section when other sections follow", () => {
+    const input = [
+      'model_provider = "custom"',
+      'model = "gpt-5.4"',
+      "",
+      "[model_providers.custom]",
+      'name = "custom"',
+      'wire_api = "responses"',
+      "",
+      "[profiles.default]",
+      'approval_policy = "never"',
+      "",
+    ].join("\n");
+
+    const output = setCodexBaseUrl(input, "https://api.example.com/v1");
+
+    expect(output).toContain(
+      '[model_providers.custom]\nname = "custom"\nwire_api = "responses"\nbase_url = "https://api.example.com/v1"',
+    );
+    expect(output).not.toContain(
+      '[profiles.default]\napproval_policy = "never"\nbase_url = "https://api.example.com/v1"',
+    );
+    expect(extractCodexBaseUrl(output)).toBe("https://api.example.com/v1");
+  });
+
+  it("moves a misplaced base_url back into the active provider section", () => {
+    const input = [
+      'model_provider = "custom"',
+      'model = "gpt-5.4"',
+      "",
+      "[model_providers.custom]",
+      'name = "custom"',
+      'wire_api = "responses"',
+      "",
+      "[profiles.default]",
+      'approval_policy = "never"',
+      'base_url = "https://wrong.example/v1"',
+      "",
+    ].join("\n");
+
+    const output = setCodexBaseUrl(input, "https://fixed.example/v1");
+
+    expect(output).toContain(
+      '[model_providers.custom]\nname = "custom"\nwire_api = "responses"\nbase_url = "https://fixed.example/v1"',
+    );
+    expect(output).not.toContain("https://wrong.example/v1");
+    expect(output.match(/base_url\s*=/g)).toHaveLength(1);
+    expect(extractCodexBaseUrl(output)).toBe("https://fixed.example/v1");
+  });
+
+  it("prefers the active provider section when extracting base_url", () => {
+    const input = [
+      'model_provider = "custom"',
+      'model = "gpt-5.4"',
+      "",
+      "[model_providers.custom]",
+      'name = "custom"',
+      'base_url = "https://provider.example/v1"',
+      'wire_api = "responses"',
+      "",
+      "[profiles.default]",
+      'approval_policy = "never"',
+      'base_url = "https://profile.example/v1"',
+      "",
+    ].join("\n");
+
+    expect(extractCodexBaseUrl(input)).toBe("https://provider.example/v1");
+  });
+
+  it("falls back to a misplaced base_url when the provider section has none", () => {
+    const input = [
+      'model_provider = "custom"',
+      'model = "gpt-5.4"',
+      "",
+      "[model_providers.custom]",
+      'name = "custom"',
+      'wire_api = "responses"',
+      "",
+      "[profiles.default]",
+      'approval_policy = "never"',
+      'base_url = "https://misplaced.example/v1"',
+      "",
+    ].join("\n");
+
+    expect(extractCodexBaseUrl(input)).toBe("https://misplaced.example/v1");
+  });
+});


### PR DESCRIPTION
Fixes #1441

## 用户视角的问题描述
用户在新增 Codex BYOK / 自定义供应商时，填写的 API 请求地址看起来已经保存成功，但实际写入 `config.toml` 后，`base_url` 可能被追加到文件最后一个 TOML section，而不是当前供应商对应的 `[model_providers.<name>]` 下。

从用户角度看，现象就是：
- 新增渠道后界面没有明显报错
- 配置文件里能看到 `base_url`
- 但 Codex 实际无法按预期识别这个渠道，新增渠道不可用

这个问题在配置里已经存在 Codex common config、并且 common config 会生成额外 section 时尤其容易触发，因为此时“追加到文件末尾”不再等价于“写入当前 provider section”。

说明：这个 PR 处理的是 Codex BYOK / 自定义渠道的 `config.toml` 写入问题，不涉及官方 OAuth 登录令牌本身的生成或刷新逻辑。

## 变更说明
- 让 Codex `base_url` 的读取和写入都基于当前 `model_provider` 做 section-aware 处理
- 将 `base_url` 写入 `[model_providers.<当前供应商>]`，不再简单追加到文件末尾
- 当配置里只有一条被错误写到其他 section 的 `base_url` 时，保存时会将其迁回当前供应商 section
- 将 Codex 相关的几个读取入口统一复用共享 helper，避免继续各自手写正则
- 补充回归测试，覆盖 `[model_providers.custom]` 后面还有其他 section 的场景

## 测试
- `corepack pnpm vitest run tests\utils\providerConfigUtils.codex.test.ts tests\hooks\useCommonConfigSave.test.tsx tests\components\CommonConfigModalBehavior.test.tsx tests\components\AddProviderDialog.test.tsx`
- `corepack pnpm tsc --noEmit`
- `cargo test` in `src-tauri` on commit `db42dfc8`: passed (`488` unit tests in `src/lib.rs` plus all Rust integration tests, `0 failed`)

## 风险与验证建议
- 对于正常由 cc-switch 生成的 Codex BYOK 配置，这次修改应当符合预期；如果本地 `config.toml` 曾被手工修改，或者已经残留了被旧逻辑写到错误 section 的 `base_url`，建议额外 spot check 一次
- 建议在 macOS / Windows 上实际验证：开启 Codex common config 后新增 BYOK provider、填写 Base URL、保存并切换，确认 `config.toml` 中的 `base_url` 落在正确的 `[model_providers.<name>]` section 内
