### PR TITLE
fix: use LaunchAgent plist for macOS auto-launch (compatible with mac…

### DIFF
--- a/src-tauri/src/auto_launch.rs
+++ b/src-tauri/src/auto_launch.rs
@@ -21,7 +21,7 @@ fn get_auto_launch() -> Result<AutoLaunch, AppError> {
     let exe_path =
         std::env::current_exe().map_err(|e| AppError::Message(format!("无法获取应用路径: {e}")))?;
 
-    // macOS 需要使用 .app bundle 路径，否则 AppleScript login item 会打开终端
+    // macOS 需要使用 .app bundle 路径，确保以完整应用形式启动
     #[cfg(target_os = "macos")]
     let app_path = get_macos_app_bundle_path(&exe_path).unwrap_or(exe_path);
 
@@ -29,11 +29,12 @@ fn get_auto_launch() -> Result<AutoLaunch, AppError> {
     let app_path = exe_path;
 
     // 使用 AutoLaunchBuilder 消除平台差异
-    // macOS: 使用 AppleScript 方式（默认），需要 .app bundle 路径
+    // macOS: 使用 LaunchAgent plist 方式（兼容 macOS 13+）
     // Windows/Linux: 使用注册表/XDG autostart
     let auto_launch = AutoLaunchBuilder::new()
         .set_app_name(app_name)
         .set_app_path(&app_path.to_string_lossy())
+        .set_use_launch_agent(true)
         .build()
         .map_err(|e| AppError::Message(format!("创建 AutoLaunch 失败: {e}")))?;
 

--- a/src-tauri/src/auto_launch.rs
+++ b/src-tauri/src/auto_launch.rs
@@ -48,3 +48,62 @@ pub fn is_auto_launch_enabled() -> Result<bool, AppError> {
         .is_enabled()
         .map_err(|e| AppError::Message(format!("检查开机自启状态失败: {e}")))
 }
+
+/// 从旧的 AppleScript login item 迁移到 LaunchAgent plist（仅 macOS）
+/// 应用启动时调用一次，幂等操作
+#[cfg(target_os = "macos")]
+pub fn migrate_from_applescript() {
+    let app_name = "CC Switch";
+    let exe_path = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            log::warn!("迁移检查跳过：无法获取应用路径: {e}");
+            return;
+        }
+    };
+
+    // Build an AutoLaunch instance using the OLD AppleScript method
+    // (without set_use_launch_agent)
+    let old_auto_launch = match AutoLaunchBuilder::new()
+        .set_app_name(app_name)
+        .set_app_path(&exe_path.to_string_lossy())
+        .build()
+    {
+        Ok(al) => al,
+        Err(e) => {
+            log::warn!("迁移检查跳过：无法创建旧 AutoLaunch 实例: {e}");
+            return;
+        }
+    };
+
+    // Check if old AppleScript login item exists
+    let old_enabled = match old_auto_launch.is_enabled() {
+        Ok(enabled) => enabled,
+        Err(e) => {
+            log::warn!("迁移检查跳过：无法检查旧 AppleScript 状态: {e}");
+            return;
+        }
+    };
+
+    if !old_enabled {
+        log::debug!("无旧 AppleScript login item，跳过迁移");
+        return;
+    }
+
+    log::info!("检测到旧 AppleScript login item，开始迁移到 LaunchAgent...");
+
+    // Disable old AppleScript login item
+    if let Err(e) = old_auto_launch.disable() {
+        log::error!("迁移失败：无法禁用旧 AppleScript login item: {e}");
+        return;
+    }
+    log::info!("已禁用旧 AppleScript login item");
+
+    // Enable new LaunchAgent method
+    if let Err(e) = enable_auto_launch() {
+        log::error!("迁移部分完成：已清理旧 login item，但启用新 LaunchAgent 失败: {e}");
+        return;
+    }
+
+    log::info!("迁移完成：已从 AppleScript 切换到 LaunchAgent");
+}

--- a/src-tauri/src/auto_launch.rs
+++ b/src-tauri/src/auto_launch.rs
@@ -1,9 +1,10 @@
 use crate::error::AppError;
 use auto_launch::{AutoLaunch, AutoLaunchBuilder};
 
+const APP_NAME: &str = "CC Switch";
+
 /// 初始化 AutoLaunch 实例
 fn get_auto_launch() -> Result<AutoLaunch, AppError> {
-    let app_name = "CC Switch";
     let exe_path =
         std::env::current_exe().map_err(|e| AppError::Message(format!("无法获取应用路径: {e}")))?;
 
@@ -12,7 +13,7 @@ fn get_auto_launch() -> Result<AutoLaunch, AppError> {
     //        plist 的 ProgramArguments[0] 需要完整的可执行文件路径（非 .app 目录）
     // Windows/Linux: 使用注册表/XDG autostart
     let auto_launch = AutoLaunchBuilder::new()
-        .set_app_name(app_name)
+        .set_app_name(APP_NAME)
         .set_app_path(&exe_path.to_string_lossy())
         .set_use_launch_agent(true)
         .build()
@@ -53,7 +54,6 @@ pub fn is_auto_launch_enabled() -> Result<bool, AppError> {
 /// 应用启动时调用一次，幂等操作
 #[cfg(target_os = "macos")]
 pub fn migrate_from_applescript() {
-    let app_name = "CC Switch";
     let exe_path = match std::env::current_exe() {
         Ok(p) => p,
         Err(e) => {
@@ -65,7 +65,7 @@ pub fn migrate_from_applescript() {
     // Build an AutoLaunch instance using the OLD AppleScript method
     // (without set_use_launch_agent)
     let old_auto_launch = match AutoLaunchBuilder::new()
-        .set_app_name(app_name)
+        .set_app_name(APP_NAME)
         .set_app_path(&exe_path.to_string_lossy())
         .build()
     {

--- a/src-tauri/src/auto_launch.rs
+++ b/src-tauri/src/auto_launch.rs
@@ -62,11 +62,16 @@ pub fn migrate_from_applescript() {
         }
     };
 
+    // Old code used .app bundle path for AppleScript login items,
+    // so we must match that when checking/disabling the old item.
+    let old_app_path = get_macos_app_bundle_path(&exe_path)
+        .unwrap_or_else(|| exe_path.clone());
+
     // Build an AutoLaunch instance using the OLD AppleScript method
     // (without set_use_launch_agent)
     let old_auto_launch = match AutoLaunchBuilder::new()
         .set_app_name(APP_NAME)
-        .set_app_path(&exe_path.to_string_lossy())
+        .set_app_path(&old_app_path.to_string_lossy())
         .build()
     {
         Ok(al) => al,
@@ -92,18 +97,33 @@ pub fn migrate_from_applescript() {
 
     log::info!("检测到旧 AppleScript login item，开始迁移到 LaunchAgent...");
 
-    // Disable old AppleScript login item
-    if let Err(e) = old_auto_launch.disable() {
-        log::error!("迁移失败：无法禁用旧 AppleScript login item: {e}");
+    // Enable new LaunchAgent first, then disable old AppleScript.
+    // This order ensures the user never loses auto-launch capability:
+    // if new fails, old is preserved; brief dual-launch is harmless.
+    if let Err(e) = enable_auto_launch() {
+        log::error!("迁移失败：无法启用新 LaunchAgent: {e}，保留旧 AppleScript login item");
         return;
     }
-    log::info!("已禁用旧 AppleScript login item");
+    log::info!("已启用新 LaunchAgent");
 
-    // Enable new LaunchAgent method
-    if let Err(e) = enable_auto_launch() {
-        log::error!("迁移部分完成：已清理旧 login item，但启用新 LaunchAgent 失败: {e}");
+    // Disable old AppleScript login item
+    if let Err(e) = old_auto_launch.disable() {
+        log::warn!("迁移部分完成：新 LaunchAgent 已启用，但无法禁用旧 AppleScript login item: {e}");
         return;
     }
 
     log::info!("迁移完成：已从 AppleScript 切换到 LaunchAgent");
+}
+
+/// Convert exe path to .app bundle path for legacy AppleScript login item matching.
+/// e.g. `/Applications/CC Switch.app/Contents/MacOS/CC Switch` → `/Applications/CC Switch.app`
+#[cfg(target_os = "macos")]
+fn get_macos_app_bundle_path(exe_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let path_str = exe_path.to_string_lossy();
+    if let Some(app_pos) = path_str.find(".app/Contents/MacOS/") {
+        let app_bundle_end = app_pos + 4; // end of ".app"
+        Some(std::path::PathBuf::from(&path_str[..app_bundle_end]))
+    } else {
+        None
+    }
 }

--- a/src-tauri/src/auto_launch.rs
+++ b/src-tauri/src/auto_launch.rs
@@ -1,39 +1,19 @@
 use crate::error::AppError;
 use auto_launch::{AutoLaunch, AutoLaunchBuilder};
 
-/// 获取 macOS 上的 .app bundle 路径
-/// 将 `/path/to/CC Switch.app/Contents/MacOS/CC Switch` 转换为 `/path/to/CC Switch.app`
-#[cfg(target_os = "macos")]
-fn get_macos_app_bundle_path(exe_path: &std::path::Path) -> Option<std::path::PathBuf> {
-    let path_str = exe_path.to_string_lossy();
-    // 查找 .app/Contents/MacOS/ 模式
-    if let Some(app_pos) = path_str.find(".app/Contents/MacOS/") {
-        let app_bundle_end = app_pos + 4; // ".app" 的结束位置
-        Some(std::path::PathBuf::from(&path_str[..app_bundle_end]))
-    } else {
-        None
-    }
-}
-
 /// 初始化 AutoLaunch 实例
 fn get_auto_launch() -> Result<AutoLaunch, AppError> {
     let app_name = "CC Switch";
     let exe_path =
         std::env::current_exe().map_err(|e| AppError::Message(format!("无法获取应用路径: {e}")))?;
 
-    // macOS 需要使用 .app bundle 路径，确保以完整应用形式启动
-    #[cfg(target_os = "macos")]
-    let app_path = get_macos_app_bundle_path(&exe_path).unwrap_or(exe_path);
-
-    #[cfg(not(target_os = "macos"))]
-    let app_path = exe_path;
-
     // 使用 AutoLaunchBuilder 消除平台差异
-    // macOS: 使用 LaunchAgent plist 方式（兼容 macOS 13+）
+    // macOS: 使用 LaunchAgent plist 方式（兼容 macOS 13+），
+    //        plist 的 ProgramArguments[0] 需要完整的可执行文件路径（非 .app 目录）
     // Windows/Linux: 使用注册表/XDG autostart
     let auto_launch = AutoLaunchBuilder::new()
         .set_app_name(app_name)
-        .set_app_path(&app_path.to_string_lossy())
+        .set_app_path(&exe_path.to_string_lossy())
         .set_use_launch_agent(true)
         .build()
         .map_err(|e| AppError::Message(format!("创建 AutoLaunch 失败: {e}")))?;
@@ -67,51 +47,4 @@ pub fn is_auto_launch_enabled() -> Result<bool, AppError> {
     auto_launch
         .is_enabled()
         .map_err(|e| AppError::Message(format!("检查开机自启状态失败: {e}")))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn test_get_macos_app_bundle_path_valid() {
-        let exe_path = std::path::Path::new("/Applications/CC Switch.app/Contents/MacOS/CC Switch");
-        let result = get_macos_app_bundle_path(exe_path);
-        assert_eq!(
-            result,
-            Some(std::path::PathBuf::from("/Applications/CC Switch.app"))
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn test_get_macos_app_bundle_path_with_spaces() {
-        let exe_path =
-            std::path::Path::new("/Users/test/My Apps/CC Switch.app/Contents/MacOS/CC Switch");
-        let result = get_macos_app_bundle_path(exe_path);
-        assert_eq!(
-            result,
-            Some(std::path::PathBuf::from(
-                "/Users/test/My Apps/CC Switch.app"
-            ))
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn test_get_macos_app_bundle_path_not_in_bundle() {
-        let exe_path = std::path::Path::new("/usr/local/bin/cc-switch");
-        let result = get_macos_app_bundle_path(exe_path);
-        assert_eq!(result, None);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn test_get_macos_app_bundle_path_dev_build() {
-        // 开发环境下的路径通常不在 .app bundle 内
-        let exe_path = std::path::Path::new("/Users/dev/project/target/debug/cc-switch");
-        let result = get_macos_app_bundle_path(exe_path);
-        assert_eq!(result, None);
-    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -618,6 +618,10 @@ pub fn run() {
                 log::warn!("迁移 app_config_dir 失败: {e}");
             }
 
+            // 迁移旧的 AppleScript login item 到 LaunchAgent（macOS 13+ 兼容）
+            #[cfg(target_os = "macos")]
+            auto_launch::migrate_from_applescript();
+
             // 启动阶段不再无条件保存,避免意外覆盖用户配置。
 
             // 注册 deep-link URL 处理器（使用正确的 DeepLinkExt API）


### PR DESCRIPTION
…OS 13+)

AppleScript login items were deprecated since macOS 13 Ventura, causing silent failure on macOS 13+. Switch to LaunchAgent plist method.

Fixes https://github.com/farion1231/cc-switch/issues/1462