### PR TITLE
fix: improve the responsive design when toc title exists

### DIFF
--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -606,10 +606,10 @@ export function SessionManagerPage({ appId }: { appId: string }) {
 
                   {/* 消息列表区域 */}
                   <CardContent className="flex-1 overflow-hidden p-0">
-                    <div className="flex h-full">
+                    <div className="flex h-full min-w-0">
                       {/* 消息列表 */}
-                      <ScrollArea className="flex-1">
-                        <div className="p-4">
+                      <ScrollArea className="flex-1 min-w-0">
+                        <div className="p-4 min-w-0">
                           <div className="flex items-center gap-2 mb-3">
                             <MessageSquare className="size-4 text-muted-foreground" />
                             <span className="text-sm font-medium">

--- a/src/components/sessions/SessionMessageItem.tsx
+++ b/src/components/sessions/SessionMessageItem.tsx
@@ -31,7 +31,7 @@ export function SessionMessageItem({
     <div
       ref={setRef}
       className={cn(
-        "rounded-lg border px-3 py-2.5 relative group transition-all",
+        "rounded-lg border px-3 py-2.5 relative group transition-all min-w-0",
         message.role.toLowerCase() === "user"
           ? "bg-primary/5 border-primary/20 ml-8"
           : message.role.toLowerCase() === "assistant"
@@ -67,7 +67,7 @@ export function SessionMessageItem({
           </span>
         )}
       </div>
-      <div className="whitespace-pre-wrap text-sm leading-relaxed">
+      <div className="whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-sm leading-relaxed min-w-0">
         {message.content}
       </div>
     </div>


### PR DESCRIPTION
This PR cherry-picks commit b59370362e3e27ca9d034876a91773ec8ca665fd only.

Changes:
- add min-width constraints in session message layout to prevent overflow when TOC exists
- add robust wrapping for long message content

before:
<img width="1810" height="1200" alt="image" src="https://github.com/user-attachments/assets/27fd44da-bc0c-4017-b381-5bdeda0e35af" />
<img width="2560" height="1474" alt="image" src="https://github.com/user-attachments/assets/ecccf075-51dc-4624-844a-727dbe1535c2" />

after:
<img width="2560" height="1474" alt="image" src="https://github.com/user-attachments/assets/579dfe3a-e070-40a7-a1f3-4fcbe5e3202a" />
<img width="2560" height="1474" alt="image" src="https://github.com/user-attachments/assets/20b9069e-b6cf-4cce-87a6-4d4a5a33f373" />


