### PR TITLE
fix(opencode): separate model properties and advanced properties sect…

### DIFF
--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -15,8 +15,7 @@ import { ApiKeySection } from "./shared";
 import { opencodeNpmPackages } from "@/config/opencodeProviderPresets";
 import { cn } from "@/lib/utils";
 import {
-  getModelExtraFields,
-  isKnownModelKey,
+  getModelAdvancedFields,
 } from "./helpers/opencodeFormUtils";
 import type { ProviderCategory, OpenCodeModel } from "@/types";
 
@@ -248,7 +247,8 @@ export function OpenCodeFormFields({
     });
   };
 
-  // Model options handlers
+
+  // Model options handlers (model.options - nested properties)
   const handleAddModelOption = (modelKey: string) => {
     const model = models[modelKey];
     const newOptionKey = `option-${Date.now()}`;
@@ -313,17 +313,17 @@ export function OpenCodeFormFields({
     });
   };
 
-  // Model extra field handlers (top-level properties like variants, cost)
-  const handleAddModelExtraField = (modelKey: string) => {
+  // Advanced field handlers (limit, modalities, variants, etc.)
+  const handleAddAdvancedField = (modelKey: string) => {
     const model = models[modelKey];
-    const newFieldKey = `option-${Date.now()}`;
+    const newFieldKey = `field-${Date.now()}`;
     onModelsChange({
       ...models,
       [modelKey]: { ...model, [newFieldKey]: "" },
     });
   };
 
-  const handleRemoveModelExtraField = (modelKey: string, fieldKey: string) => {
+  const handleRemoveAdvancedField = (modelKey: string, fieldKey: string) => {
     const model = models[modelKey];
     const newModel = { ...model };
     delete newModel[fieldKey];
@@ -333,15 +333,15 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleModelExtraFieldKeyChange = (
+  const handleAdvancedFieldKeyChange = (
     modelKey: string,
     oldKey: string,
     newKey: string,
   ) => {
     if (!newKey.trim() || oldKey === newKey) return;
     const model = models[modelKey];
-    // Reject reserved keys and duplicate extra field names
-    if (isKnownModelKey(newKey) || (newKey !== oldKey && newKey in model))
+    // Reject reserved keys (name, limit, options) and duplicates
+    if (newKey === "name" || newKey === "options" || (newKey !== oldKey && newKey in model))
       return;
     const newModel: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(model)) {
@@ -354,7 +354,7 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleModelExtraFieldValueChange = (
+  const handleAdvancedFieldValueChange = (
     modelKey: string,
     fieldKey: string,
     value: string,
@@ -641,85 +641,6 @@ export function OpenCodeFormFields({
                           type="button"
                           variant="ghost"
                           size="sm"
-                          onClick={() => handleAddModelExtraField(key)}
-                          className="h-6 px-2 gap-1"
-                        >
-                          <Plus className="h-3 w-3" />
-                        </Button>
-                      </div>
-                      {Object.keys(getModelExtraFields(model)).length === 0 ? (
-                        <p className="text-xs text-muted-foreground py-1">
-                          {t("opencode.noModelExtraFields", {
-                            defaultValue:
-                              "模型属性 (variants, cost 等)，点击 + 添加",
-                          })}
-                        </p>
-                      ) : (
-                        Object.entries(getModelExtraFields(model)).map(
-                          ([fKey, fValue]) => (
-                            <div key={fKey} className="flex items-center gap-2">
-                              <ModelOptionKeyInput
-                                optionKey={fKey}
-                                onChange={(newKey) =>
-                                  handleModelExtraFieldKeyChange(
-                                    key,
-                                    fKey,
-                                    newKey,
-                                  )
-                                }
-                                placeholder={t(
-                                  "opencode.modelExtraFieldKeyPlaceholder",
-                                  {
-                                    defaultValue: "variants",
-                                  },
-                                )}
-                              />
-                              <Input
-                                value={fValue}
-                                onChange={(e) =>
-                                  handleModelExtraFieldValueChange(
-                                    key,
-                                    fKey,
-                                    e.target.value,
-                                  )
-                                }
-                                placeholder={t(
-                                  "opencode.modelOptionValuePlaceholder",
-                                  {
-                                    defaultValue: '{"order": ["baseten"]}',
-                                  },
-                                )}
-                                className="flex-1"
-                              />
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                onClick={() =>
-                                  handleRemoveModelExtraField(key, fKey)
-                                }
-                                className="h-9 w-9 text-muted-foreground hover:text-destructive"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </div>
-                          ),
-                        )
-                      )}
-                    </div>
-
-                    {/* SDK Options (model.options) */}
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-medium text-muted-foreground">
-                          {t("opencode.sdkOptions", {
-                            defaultValue: "SDK 选项",
-                          })}
-                        </span>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
                           onClick={() => handleAddModelOption(key)}
                           className="h-6 px-2 gap-1"
                         >
@@ -728,17 +649,15 @@ export function OpenCodeFormFields({
                       </div>
                       {Object.keys(model.options || {}).length === 0 ? (
                         <p className="text-xs text-muted-foreground py-1">
-                          {t("opencode.noModelOptions", {
-                            defaultValue: "模型选项，点击 + 添加",
+                          {t("opencode.noModelExtraFields", {
+                            defaultValue:
+                              "模型属性 (插入到 options 对象)，点击 + 添加",
                           })}
                         </p>
                       ) : (
                         Object.entries(model.options || {}).map(
                           ([optKey, optValue]) => (
-                            <div
-                              key={optKey}
-                              className="flex items-center gap-2"
-                            >
+                            <div key={optKey} className="flex items-center gap-2">
                               <ModelOptionKeyInput
                                 optionKey={optKey}
                                 onChange={(newKey) =>
@@ -749,7 +668,7 @@ export function OpenCodeFormFields({
                                   )
                                 }
                                 placeholder={t(
-                                  "opencode.modelOptionKeyPlaceholder",
+                                  "opencode.modelExtraFieldKeyPlaceholder",
                                   {
                                     defaultValue: "provider",
                                   },
@@ -782,6 +701,85 @@ export function OpenCodeFormFields({
                                 size="icon"
                                 onClick={() =>
                                   handleRemoveModelOption(key, optKey)
+                                }
+                                className="h-9 w-9 text-muted-foreground hover:text-destructive"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ),
+                        )
+                      )}
+                    </div>
+
+                    {/* Advanced Properties (top-level fields like limit, modalities, variants) */}
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {t("opencode.advancedProperties", {
+                            defaultValue: "高级属性",
+                          })}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleAddAdvancedField(key)}
+                          className="h-6 px-2 gap-1"
+                        >
+                          <Plus className="h-3 w-3" />
+                        </Button>
+                      </div>
+                      {Object.keys(getModelAdvancedFields(model)).length === 0 ? (
+                        <p className="text-xs text-muted-foreground py-1">
+                          {t("opencode.noAdvancedProperties", {
+                            defaultValue:
+                              "高级属性 (与 options 同级的顶层字段)，点击 + 添加",
+                          })}
+                        </p>
+                      ) : (
+                        Object.entries(getModelAdvancedFields(model)).map(
+                          ([fKey, fValue]) => (
+                            <div key={fKey} className="flex items-center gap-2">
+                              <ModelOptionKeyInput
+                                optionKey={fKey}
+                                onChange={(newKey) =>
+                                  handleAdvancedFieldKeyChange(
+                                    key,
+                                    fKey,
+                                    newKey,
+                                  )
+                                }
+                                placeholder={t(
+                                  "opencode.advancedPropertyKeyPlaceholder",
+                                  {
+                                    defaultValue: "limit",
+                                  },
+                                )}
+                              />
+                              <Input
+                                value={fValue}
+                                onChange={(e) =>
+                                  handleAdvancedFieldValueChange(
+                                    key,
+                                    fKey,
+                                    e.target.value,
+                                  )
+                                }
+                                placeholder={t(
+                                  "opencode.advancedPropertyValuePlaceholder",
+                                  {
+                                    defaultValue: '{"context":200000,"output":64000}',
+                                  },
+                                )}
+                                className="flex-1"
+                              />
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() =>
+                                  handleRemoveAdvancedField(key, fKey)
                                 }
                                 className="h-9 w-9 text-muted-foreground hover:text-destructive"
                               >

--- a/src/components/providers/forms/helpers/opencodeFormUtils.ts
+++ b/src/components/providers/forms/helpers/opencodeFormUtils.ts
@@ -118,16 +118,52 @@ export function isKnownModelKey(key: string): boolean {
   );
 }
 
+/**
+ * 获取模型的额外字段（用户自定义字段）
+ * 排除保留字段（name, limit, options）和高级字段
+ * 这些字段不会在 UI 中显示，仅用于内部处理
+ */
 export function getModelExtraFields(
   model: OpenCodeModel,
 ): Record<string, string> {
   const extra: Record<string, string> = {};
   for (const [k, v] of Object.entries(model)) {
-    if (!isKnownModelKey(k)) {
+    if (!isKnownModelKey(k) && !isAdvancedModelKey(k)) {
       extra[k] = typeof v === "string" ? v : JSON.stringify(v);
     }
   }
   return extra;
+}
+
+// 高级属性：limit, modalities, variants 等顶层字段（排除 name 和 options）
+export const OPENCODE_ADVANCED_MODEL_KEYS = ["limit", "modalities", "variants", "cost", "contextLimit", "outputLimit"] as const;
+
+/**
+ * 检查字段是否为高级模型属性
+ * 高级属性包括：limit, modalities, variants, cost, contextLimit, outputLimit
+ * 这些字段在 UI 的"高级属性"区域显示，与 options 同级（顶层字段）
+ */
+export function isAdvancedModelKey(key: string): boolean {
+  return OPENCODE_ADVANCED_MODEL_KEYS.includes(
+    key as (typeof OPENCODE_ADVANCED_MODEL_KEYS)[number],
+  );
+}
+
+/**
+ * 获取模型的高级属性字段（顶层字段，与 options 同级）
+ * 返回所有非保留字段（排除 name, limit, options），包括高级字段和用户自定义字段
+ */
+export function getModelAdvancedFields(
+  model: OpenCodeModel,
+): Record<string, string> {
+  const advanced: Record<string, string> = {};
+  for (const [k, v] of Object.entries(model)) {
+    // 排除保留字段 name, limit, options，返回所有其他顶层字段
+    if (k !== "name" && k !== "limit" && k !== "options") {
+      advanced[k] = typeof v === "string" ? v : JSON.stringify(v);
+    }
+  }
+  return advanced;
 }
 
 export function toOpencodeExtraOptions(


### PR DESCRIPTION
…ions

问题描述： 在使用的时候 
<img width="673" height="426" alt="f8c4f5a8f9fcf1a5acaf7884847d3745" src="https://github.com/user-attachments/assets/dc64452d-8e4a-41c0-8505-ef60b8b598d0" />
如图，我需要配置 "modalities": {
                        "input": ["text", "image"],
                        "output": ["text"]
                    } 才能在opencode被识别为多模态的模型，但是模型属性都是往options里面去push值，在不改动原来的流程下增加了个属性 高级属性和options同级别如 `   "claude-sonnet-4-5-20250929": {
      "modalities": {
        "input": [
          "text",
          "image"
        ],
        "output": [
          "text"
        ]
      },
      "name": "claude-sonnet-4-5-20250929",
      "options": {
        "thinking": {
          "type": "enabled",
          "budgetTokens": 8192
        }
      }
    }`
    结果 
<img width="584" height="363" alt="f0f96b799ef366c67ed3419a5a09d514" src="https://github.com/user-attachments/assets/02efe195-9b5b-4a2c-97ae-6a7220007fe2" />

Fix the issue where editing "模型属性" (Model Properties) would incorrectly populate "高级属性" (Advanced Properties) fields on blur.

Changes:
- Restore original logic for "模型属性" section to operate on model.options (nested properties)
- Add new "高级属性" section to operate on top-level fields (limit, modalities, variants, etc.) that are siblings to options
- Update getModelAdvancedFields() to return all non-reserved top-level fields (excluding name, limit, options)
- Add proper JSDoc comments explaining the three-tier field classification
- Remove unused imports (getModelExtraFields, isKnownModelKey)

The two sections are now completely isolated:
- Model Properties: edits model.options.* (nested)
- Advanced Properties: edits model.* top-level fields (siblings to options)

Fixes the cross-contamination bug where both sections were operating on overlapping field sets.