### PR TITLE
fix: 修复 macOS 26.2 下 Ghostty 作为默认终端时“打开终端”无效的问题

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1015,16 +1015,18 @@ fn launch_macos_ghostty(script_file: &std::path::Path) -> Result<(), String> {
         .output()
         .map_err(|e| format!("执行 Ghostty AppleScript 失败: {e}"))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!(
-            "Ghostty 执行失败 (exit code: {:?}): {}",
-            output.status.code(),
-            stderr
-        ));
+    if output.status.success() {
+        return Ok(());
     }
 
-    Ok(())
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    log::warn!(
+        "Ghostty AppleScript 启动失败，回退到 open -a Ghostty --args: exit_code={:?}, stderr={}",
+        output.status.code(),
+        stderr.trim()
+    );
+
+    launch_macos_open_app("Ghostty", script_file, true)
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -884,7 +884,7 @@ exec bash --norc --noprofile
         "iterm2" => launch_macos_iterm2(&script_file),
         "alacritty" => launch_macos_open_app("Alacritty", &script_file, true),
         "kitty" => launch_macos_open_app("kitty", &script_file, false),
-        "ghostty" => launch_macos_open_app("Ghostty", &script_file, true),
+        "ghostty" => launch_macos_ghostty(&script_file),
         "wezterm" => launch_macos_open_app("WezTerm", &script_file, true),
         _ => launch_macos_terminal_app(&script_file), // "terminal" or default
     };
@@ -1001,6 +1001,84 @@ fn launch_macos_open_app(
     }
 
     Ok(())
+}
+
+/// macOS: Ghostty 使用 AppleScript 显式新建窗口并执行脚本
+#[cfg(target_os = "macos")]
+fn launch_macos_ghostty(script_file: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+
+    let applescript = build_ghostty_launcher_osascript(script_file);
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&applescript)
+        .output()
+        .map_err(|e| format!("执行 Ghostty AppleScript 失败: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Ghostty 执行失败 (exit code: {:?}): {}",
+            output.status.code(),
+            stderr
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn build_ghostty_launcher_osascript(script_file: &std::path::Path) -> String {
+    let command = format!(
+        "bash {}",
+        shell_escape(script_file.to_string_lossy().as_ref())
+    );
+
+    format!(
+        r#"tell application "Ghostty"
+    activate
+    set cfg to new surface configuration
+    set win to new window with configuration cfg
+    set term to focused terminal of selected tab of win
+    input text {} to term
+    send key "enter" to term
+    focus term
+end tell"#,
+        applescript_string_expr(&command)
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn applescript_string_expr(value: &str) -> String {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+
+    for ch in value.chars() {
+        match ch {
+            '\\' => current.push_str("\\\\"),
+            '"' => current.push_str("\\\""),
+            '\n' => {
+                parts.push(format!("\"{current}\""));
+                current.clear();
+                parts.push("linefeed".to_string());
+            }
+            '\r' => {
+                parts.push(format!("\"{current}\""));
+                current.clear();
+                parts.push("return".to_string());
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    parts.push(format!("\"{current}\""));
+    parts.join(" & ")
+}
+
+#[cfg(target_os = "macos")]
+fn shell_escape(value: &str) -> String {
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
 }
 
 /// Linux: 根据用户首选终端启动


### PR DESCRIPTION
## 问题说明

在 macOS 26.2 环境下，如果 CC Switch 的默认终端设置为 Ghostty，点击“打开终端”存在异常：

- 当 Ghostty 未启动时，通常可以拉起 Ghostty
- 当 Ghostty 已经启动时，点击“打开终端”没有反应
- 不会新建 Ghostty 窗口
- 也不会执行 CC Switch 应该启动的命令

这会导致将 Ghostty 设置为默认终端后，功能实际不可用。

## 修改内容

本次修改主要覆盖了两条 Ghostty 启动链路：

1. 修复“打开终端”按钮实际使用的 macOS 启动逻辑
2. 修复 session manager 中 Ghostty 的会话恢复启动逻辑

具体调整如下：

- 将原来基于 `open -a Ghostty --args ...` 的启动方式，改为使用 Ghostty 的 AppleScript 能力显式创建新窗口
- 在新创建的 Ghostty terminal 中主动输入命令，并显式发送回车执行
- 保留原有 `open` 方式作为回退逻辑，避免 AppleScript 不可用时完全失效
- 增加 Ghostty 相关测试，覆盖脚本生成和命令执行逻辑

## 修复效果

修复后，在 macOS 26.2 下：

- Ghostty 未启动时，点击“打开终端”可以正常拉起并执行命令
- Ghostty 已启动时，点击“打开终端”可以正常新建窗口并执行命令
- Ghostty 作为默认终端时可以正常使用，不再出现点击无效的问题

## 验证情况

已完成以下验证：

- `cargo test --manifest-path src-tauri/Cargo.toml ghostty -- --nocapture`
- 本地编译生成 `.app` 并完成验证
- 本地实际验证以下场景：
  - Ghostty 未启动时可以正常打开并执行命令
  - Ghostty 已启动时可以正常新建窗口并执行命令
