### PR TITLE
fix: change darkMode selector to use .dark class

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  darkMode: ["selector", "class"],
+  darkMode: ["selector", ".dark"],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
修复在暗色模式下，"dark:"声明的css样式失效。
例如：EnvWarningBanner组件在暗色模式下，背景色的样式失效，导致部分文字看不清。
修正前：
<img width="1860" height="1294" alt="image" src="https://github.com/user-attachments/assets/48f2f300-a168-457e-bff8-cf08294b8e45" />
修正后：
<img width="1352" height="1292" alt="image" src="https://github.com/user-attachments/assets/0540a4d7-691c-46f2-b7eb-714eedd6d2c3" />
