### PR TITLE
feat: Windows Terminal支持选择Profile

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1145,7 +1145,16 @@ del \"%~f0\" >nul 2>&1
             &["powershell", "-NoExit", "-Command", &ps_cmd],
             "PowerShell",
         ),
-        "wt" => run_windows_start_command(&["wt", "cmd", "/K", &bat_path], "Windows Terminal"),
+        "wt" => {
+            let profile = crate::settings::get_preferred_terminal_profile();
+            match profile.as_ref().filter(|p| !p.is_empty()) {
+                Some(p) => run_windows_start_command(
+                    &["wt", "-p", p.as_str(), "--", &bat_path],
+                    "Windows Terminal",
+                ),
+                None => run_windows_start_command(&["wt", "--", &bat_path], "Windows Terminal"),
+            }
+        }
         _ => run_windows_start_command(&["cmd", "/K", &bat_path], "cmd"), // "cmd" or default
     };
 
@@ -1202,6 +1211,127 @@ pub async fn set_window_theme(window: tauri::Window, theme: String) -> Result<()
     };
 
     window.set_theme(tauri_theme).map_err(|e| e.to_string())
+}
+
+// ===== Windows Terminal Profile 管理 =====
+
+#[derive(serde::Serialize)]
+pub struct WtProfile {
+    guid: String,
+    name: String,
+}
+
+/// 获取 Windows Terminal 配置文件的可能路径
+#[cfg(target_os = "windows")]
+fn get_wt_settings_paths() -> Vec<std::path::PathBuf> {
+    use std::env;
+    let mut paths = Vec::new();
+
+    if let Ok(local_app_data) = env::var("LOCALAPPDATA") {
+        let base = std::path::PathBuf::from(&local_app_data);
+
+        // 1. Microsoft Store 稳定版
+        paths.push(
+            base.join("Packages")
+                .join("Microsoft.WindowsTerminal_8wekyb3d8bbwe")
+                .join("LocalState")
+                .join("settings.json"),
+        );
+
+        // 2. Microsoft Store 预览版
+        paths.push(
+            base.join("Packages")
+                .join("Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe")
+                .join("LocalState")
+                .join("settings.json"),
+        );
+    }
+
+    // 3. 便携版 / GitHub releases / scoop 等通常在同目录下
+    // 尝试从 wt.exe 位置查找
+    if let Ok(output) = std::process::Command::new("where")
+        .arg("wt.exe")
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+    {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Some(wt_path) = stdout.lines().next() {
+                if let Some(parent) = std::path::Path::new(wt_path).parent() {
+                    paths.push(parent.join("settings.json"));
+                }
+            }
+        }
+    }
+
+    paths
+}
+
+/// 获取 Windows Terminal 的所有 profile 列表
+#[tauri::command]
+pub fn get_windows_terminal_profiles() -> Result<Vec<WtProfile>, String> {
+    #[cfg(not(target_os = "windows"))]
+    return Ok(Vec::new());
+
+    #[cfg(target_os = "windows")]
+    {
+        let paths = get_wt_settings_paths();
+
+        for settings_path in paths {
+            if !settings_path.exists() {
+                continue;
+            }
+
+            match std::fs::read_to_string(&settings_path) {
+                Ok(content) => match serde_json::from_str::<serde_json::Value>(&content) {
+                    Ok(json) => {
+                        if let Some(profiles) = json
+                            .get("profiles")
+                            .and_then(|p| p.get("list"))
+                            .and_then(|l| l.as_array())
+                        {
+                            let result: Vec<WtProfile> = profiles
+                                .iter()
+                                .filter(|p| {
+                                    p.get("hidden")
+                                        .and_then(|h| h.as_bool())
+                                        .unwrap_or(false)
+                                        == false
+                                })
+                                .filter_map(|p| {
+                                    let guid = p.get("guid")?.as_str()?.to_string();
+                                    let name = p.get("name")?.as_str()?.to_string();
+                                    Some(WtProfile { guid, name })
+                                })
+                                .collect();
+
+                            if !result.is_empty() {
+                                return Ok(result);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to parse WT settings {}: {}",
+                            settings_path.display(),
+                            e
+                        );
+                        continue;
+                    }
+                },
+                Err(e) => {
+                    log::warn!(
+                        "Failed to read WT settings {}: {}",
+                        settings_path.display(),
+                        e
+                    );
+                    continue;
+                }
+            }
+        }
+
+        Err("terminal.wt.not_found".to_string())
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1012,6 +1012,8 @@ pub fn run() {
             commands::get_tool_versions,
             // Provider terminal
             commands::open_provider_terminal,
+            // Windows Terminal profiles
+            commands::get_windows_terminal_profiles,
             // Universal Provider management
             commands::get_universal_providers,
             commands::get_universal_provider,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -269,6 +269,10 @@ pub struct AppSettings {
     /// - Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preferred_terminal: Option<String>,
+
+    /// Windows Terminal Profile GUID（仅当 preferred_terminal 为 "wt" 时使用）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preferred_terminal_profile: Option<String>,
 }
 
 fn default_show_in_tray() -> bool {
@@ -312,6 +316,7 @@ impl Default for AppSettings {
             backup_interval_hours: None,
             backup_retain_count: None,
             preferred_terminal: None,
+            preferred_terminal_profile: None,
         }
     }
 }
@@ -683,6 +688,15 @@ pub fn get_preferred_terminal() -> Option<String> {
             e.into_inner()
         })
         .preferred_terminal
+        .clone()
+}
+
+/// 获取首选终端 Profile（仅 Windows Terminal 使用）
+pub fn get_preferred_terminal_profile() -> Option<String> {
+    settings_store()
+        .read()
+        .ok()?
+        .preferred_terminal_profile
         .clone()
 }
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -240,6 +240,10 @@ export function SettingsPage({
                       onChange={(terminal) =>
                         handleAutoSave({ preferredTerminal: terminal })
                       }
+                      profileValue={settings.preferredTerminalProfile}
+                      onProfileChange={(profile) =>
+                        handleAutoSave({ preferredTerminalProfile: profile })
+                      }
                     />
                   </motion.div>
                 ) : null}

--- a/src/components/settings/TerminalSettings.tsx
+++ b/src/components/settings/TerminalSettings.tsx
@@ -1,4 +1,6 @@
+import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { Loader2 } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -7,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { isMac, isWindows, isLinux } from "@/lib/platform";
+import { terminalApi, type WtProfile } from "@/lib/api/terminal";
 
 // Terminal options per platform
 const MACOS_TERMINALS = [
@@ -74,15 +77,53 @@ function getDefaultTerminal(): string {
 export interface TerminalSettingsProps {
   value?: string;
   onChange: (value: string) => void;
+  profileValue?: string;
+  onProfileChange?: (value: string) => void;
 }
 
-export function TerminalSettings({ value, onChange }: TerminalSettingsProps) {
+export function TerminalSettings({
+  value,
+  onChange,
+  profileValue,
+  onProfileChange,
+}: TerminalSettingsProps) {
   const { t } = useTranslation();
   const terminals = getTerminalOptions();
   const defaultTerminal = getDefaultTerminal();
 
   // Use value or default
   const currentValue = value || defaultTerminal;
+
+  // WT Profiles 状态
+  const [wtProfiles, setWtProfiles] = useState<WtProfile[]>([]);
+  const [isLoadingProfiles, setIsLoadingProfiles] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+  const hasLoadedProfiles = useRef(false);
+
+  // 当选择 wt 时，加载 profiles（仅首次）
+  useEffect(() => {
+    if (
+      isWindows() &&
+      currentValue === "wt" &&
+      onProfileChange &&
+      !hasLoadedProfiles.current
+    ) {
+      hasLoadedProfiles.current = true;
+      setIsLoadingProfiles(true);
+      setProfileError(null);
+      terminalApi
+        .getWtProfiles()
+        .then((profiles) => {
+          setWtProfiles(profiles);
+          // 如果没有已选中的 profile，自动选择第一项
+          if (!profileValue && profiles.length > 0) {
+            onProfileChange(profiles[0].guid);
+          }
+        })
+        .catch(() => setProfileError(t("settings.terminal.options.windows.profileError")))
+        .finally(() => setIsLoadingProfiles(false));
+    }
+  }, [currentValue, onProfileChange, t, profileValue]);
 
   return (
     <section className="space-y-2">
@@ -92,18 +133,53 @@ export function TerminalSettings({ value, onChange }: TerminalSettingsProps) {
           {t("settings.terminal.description")}
         </p>
       </header>
-      <Select value={currentValue} onValueChange={onChange}>
-        <SelectTrigger className="w-[200px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {terminals.map((terminal) => (
-            <SelectItem key={terminal.value} value={terminal.value}>
-              {t(terminal.labelKey)}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+
+      <div className="flex items-center gap-3">
+        <Select value={currentValue} onValueChange={onChange}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {terminals.map((terminal) => (
+              <SelectItem key={terminal.value} value={terminal.value}>
+                {t(terminal.labelKey)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* WT Profile 选择器 - 仅当选择 wt 且在 Windows 上时显示 */}
+        {isWindows() && currentValue === "wt" && onProfileChange && (
+          <>
+            {isLoadingProfiles ? (
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            ) : profileError ? (
+              <span className="text-xs text-destructive">{profileError}</span>
+            ) : wtProfiles.length === 0 ? (
+              <span className="text-xs text-muted-foreground">
+                {t("settings.terminal.options.windows.noProfiles")}
+              </span>
+            ) : (
+              <Select
+                value={profileValue || wtProfiles[0]?.guid || ""}
+                onValueChange={onProfileChange}
+              >
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {wtProfiles.map((profile) => (
+                    <SelectItem key={profile.guid} value={profile.guid}>
+                      {profile.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </>
+        )}
+      </div>
+
       <p className="text-xs text-muted-foreground">
         {t("settings.terminal.fallbackHint")}
       </p>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -495,7 +495,9 @@
         "windows": {
           "cmd": "Command Prompt",
           "powershell": "PowerShell",
-          "wt": "Windows Terminal"
+          "wt": "Windows Terminal",
+          "profileError": "Cannot find Windows Terminal settings. Please make sure Windows Terminal is installed.",
+          "noProfiles": "No profiles found"
         },
         "linux": {
           "gnomeTerminal": "GNOME Terminal",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -495,7 +495,9 @@
         "windows": {
           "cmd": "コマンドプロンプト",
           "powershell": "PowerShell",
-          "wt": "Windows Terminal"
+          "wt": "Windows Terminal",
+          "profileError": "Windows Terminal の設定が見つかりません。Windows Terminal がインストされていることを確認してください。",
+          "noProfiles": "プロファイルが見つかりません"
         },
         "linux": {
           "gnomeTerminal": "GNOME Terminal",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -495,7 +495,9 @@
         "windows": {
           "cmd": "命令提示符",
           "powershell": "PowerShell",
-          "wt": "Windows Terminal"
+          "wt": "Windows Terminal",
+          "profileError": "无法找到 Windows Terminal 配置文件。请确保已安装 Windows Terminal。",
+          "noProfiles": "未找到 Profile"
         },
         "linux": {
           "gnomeTerminal": "GNOME Terminal",

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -11,6 +11,7 @@ export { proxyApi } from "./proxy";
 export { openclawApi } from "./openclaw";
 export { sessionsApi } from "./sessions";
 export { workspaceApi } from "./workspace";
+export { terminalApi } from "./terminal";
 export * as configApi from "./config";
 export * as authApi from "./auth";
 export * as copilotApi from "./copilot";
@@ -27,3 +28,4 @@ export type {
   ManagedAuthStatus,
   ManagedAuthDeviceCodeResponse,
 } from "./auth";
+export type { WtProfile } from "./terminal";

--- a/src/lib/api/terminal.ts
+++ b/src/lib/api/terminal.ts
@@ -1,0 +1,12 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface WtProfile {
+  guid: string;
+  name: string;
+}
+
+export const terminalApi = {
+  async getWtProfiles(): Promise<WtProfile[]> {
+    return await invoke("get_windows_terminal_profiles");
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,6 +305,9 @@ export interface Settings {
   // Windows: "cmd" | "powershell" | "wt"
   // Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
   preferredTerminal?: string;
+
+  // Windows Terminal Profile GUID
+  preferredTerminalProfile?: string;
 }
 
 export interface SessionMeta {


### PR DESCRIPTION
## 变更描述

实现 #1597 ：
  - 后端添加 `preferred_terminal_profile` 设置字段
  - 添加 `get_windows_terminal_profiles` 命令获取 WT profiles 列表
  - 启动终端时使用 `wt -p <profile>` 指定 profile, 移除使用cmd运行配置
  - 前端添加 profile 选择器，自动选择第一项

## 前端变更

 - **选中 `Windows Terminal` 作为首选终端后，追加下拉选择框，支持选择本地配置的Profile** ：

<img width="902" height="632" alt="image" src="https://github.com/user-attachments/assets/ef89d320-ac55-4560-8e35-a61f13668ad8" />
