### PR TITLE
fix(provider): preserve user-global fields across provider switches

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -33,6 +33,25 @@ pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
     v
 }
 
+/// Strip user-global fields from a Claude snapshot before saving to the database.
+///
+/// These fields are written by Claude Code itself (e.g. plugin install, hooks config)
+/// and are shared across all providers. Storing them in per-provider snapshots causes
+/// stale values to overwrite the live file when switching providers.
+pub(crate) fn strip_global_fields_for_backfill(app_type: &AppType, settings: Value) -> Value {
+    if !matches!(app_type, AppType::Claude) {
+        return settings;
+    }
+    let mut v = settings;
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("enabledPlugins");
+        obj.remove("hooks");
+        obj.remove("spinnerVerbs");
+        obj.remove("permissions");
+    }
+    v
+}
+
 fn json_is_subset(target: &Value, source: &Value) -> bool {
     match source {
         Value::Object(source_map) => {
@@ -653,8 +672,30 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
     match app_type {
         AppType::Claude => {
             let path = get_claude_settings_path();
-            let settings = sanitize_claude_settings_for_live(&provider.settings_config);
-            write_json_file(&path, &settings)?;
+            let provider_settings = sanitize_claude_settings_for_live(&provider.settings_config);
+            // Strip user-global fields from the snapshot before merge.
+            // This is a defensive guard against stale snapshots that were saved before
+            // strip_global_fields_for_backfill was introduced (pre-fix historical data).
+            let provider_settings =
+                strip_global_fields_for_backfill(app_type, provider_settings);
+            // Merge provider settings into the existing live file instead of full overwrite.
+            // This preserves user-managed fields (enabledPlugins, hooks, spinnerVerbs, etc.)
+            // that Claude Code writes directly and are not tracked per-provider.
+            let merged = if path.exists() {
+                match read_json_file(&path) {
+                    Ok(mut live) => {
+                        json_deep_merge(&mut live, &provider_settings);
+                        live
+                    }
+                    Err(err) => {
+                        log::warn!("Failed to read live Claude settings for merge, falling back to full write: {err}");
+                        provider_settings
+                    }
+                }
+            } else {
+                provider_settings
+            };
+            write_json_file(&path, &merged)?;
         }
         AppType::Codex => {
             let obj = provider
@@ -1437,5 +1478,83 @@ mod tests {
             .map(|value| value.as_str().expect("tool id should be string"))
             .collect();
         assert_eq!(values, vec!["tool2"]);
+    }
+
+    #[test]
+    fn strip_global_fields_removes_user_managed_fields_for_claude() {
+        let settings = json!({
+            "env": { "ANTHROPIC_AUTH_TOKEN": "sk-test" },
+            "enabledPlugins": ["plugin-a", "plugin-b"],
+            "hooks": { "PreToolUse": [] },
+            "spinnerVerbs": ["思考", "分析"],
+            "permissions": { "allow": [], "deny": [] }
+        });
+
+        let result = strip_global_fields_for_backfill(&AppType::Claude, settings);
+
+        assert!(result.get("enabledPlugins").is_none(), "enabledPlugins should be stripped");
+        assert!(result.get("hooks").is_none(), "hooks should be stripped");
+        assert!(result.get("spinnerVerbs").is_none(), "spinnerVerbs should be stripped");
+        assert!(result.get("permissions").is_none(), "permissions should be stripped");
+        assert_eq!(result["env"]["ANTHROPIC_AUTH_TOKEN"], json!("sk-test"), "provider fields should be preserved");
+    }
+
+    #[test]
+    fn strip_global_fields_is_noop_for_non_claude_app_types() {
+        let settings = json!({
+            "enabledPlugins": ["plugin-a"],
+            "hooks": { "PreToolUse": [] }
+        });
+
+        for app_type in [AppType::Codex, AppType::Gemini] {
+            let result = strip_global_fields_for_backfill(&app_type, settings.clone());
+            assert_eq!(result, settings, "non-Claude app types should not be modified");
+        }
+    }
+
+    #[test]
+    fn write_live_snapshot_merges_global_fields_from_existing_file() {
+        // Simulate the merge logic: live has enabledPlugins, provider snapshot does not.
+        // After merge, enabledPlugins should be preserved.
+        let mut live = json!({
+            "env": { "ANTHROPIC_AUTH_TOKEN": "old-token" },
+            "enabledPlugins": ["my-plugin"],
+            "spinnerVerbs": ["思考"]
+        });
+        let provider_snapshot = json!({
+            "env": { "ANTHROPIC_AUTH_TOKEN": "new-token" }
+        });
+
+        json_deep_merge(&mut live, &provider_snapshot);
+
+        assert_eq!(live["env"]["ANTHROPIC_AUTH_TOKEN"], json!("new-token"), "provider field should be updated");
+        assert_eq!(live["enabledPlugins"], json!(["my-plugin"]), "enabledPlugins should survive merge");
+        assert_eq!(live["spinnerVerbs"], json!(["思考"]), "spinnerVerbs should survive merge");
+    }
+
+    #[test]
+    fn provider_snapshot_with_stale_plugins_does_not_overwrite_live() {
+        // Simulate: provider snapshot has stale enabledPlugins (from before strip_global_fields fix).
+        // After strip_global_fields_for_backfill, snapshot no longer has enabledPlugins,
+        // so merge preserves the live value.
+        let stale_snapshot = json!({
+            "env": { "ANTHROPIC_AUTH_TOKEN": "token" },
+            "enabledPlugins": ["stale-plugin"]
+        });
+        let cleaned_snapshot =
+            strip_global_fields_for_backfill(&AppType::Claude, stale_snapshot);
+        assert!(cleaned_snapshot.get("enabledPlugins").is_none());
+
+        let mut live = json!({
+            "env": { "ANTHROPIC_AUTH_TOKEN": "token" },
+            "enabledPlugins": ["current-plugin"]
+        });
+        json_deep_merge(&mut live, &cleaned_snapshot);
+
+        assert_eq!(
+            live["enabledPlugins"],
+            json!(["current-plugin"]),
+            "live enabledPlugins should not be overwritten by stale snapshot"
+        );
     }
 }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -29,8 +29,8 @@ pub use live::{
 pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
-    strip_common_config_from_live_settings, sync_current_provider_for_app_to_live,
-    write_live_with_common_config,
+    strip_common_config_from_live_settings, strip_global_fields_for_backfill,
+    sync_current_provider_for_app_to_live, write_live_with_common_config,
 };
 
 // Internal re-exports
@@ -567,11 +567,14 @@ impl ProviderService {
                     if let Ok(live_config) = read_live_settings(app_type.clone()) {
                         if let Some(mut current_provider) = providers.get(&current_id).cloned() {
                             current_provider.settings_config =
-                                strip_common_config_from_live_settings(
-                                    state.db.as_ref(),
+                                strip_global_fields_for_backfill(
                                     &app_type,
-                                    &current_provider,
-                                    live_config,
+                                    strip_common_config_from_live_settings(
+                                        state.db.as_ref(),
+                                        &app_type,
+                                        &current_provider,
+                                        live_config,
+                                    ),
                                 );
                             if let Err(e) =
                                 state.db.save_provider(app_type.as_str(), &current_provider)

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1103,8 +1103,14 @@ impl ProxyService {
         match app_type {
             AppType::Claude => {
                 if let Ok(Some(backup)) = self.db.get_live_backup("claude").await {
-                    let config: Value = serde_json::from_str(&backup.original_config)
+                    let mut config: Value = serde_json::from_str(&backup.original_config)
                         .map_err(|e| format!("解析 Claude 备份失败: {e}"))?;
+                    // Preserve current live's user-global fields if the backup doesn't have them.
+                    // Mirrors restore_live_config_for_app_with_fallback to close the same
+                    // historical-backup gap on rollback and manual disable paths.
+                    if let Ok(current_live) = self.read_claude_live() {
+                        Self::preserve_claude_global_fields_in_backup(&mut config, &current_live);
+                    }
                     self.write_claude_live(&config)?;
                     log::info!("Claude Live 配置已恢复");
                 }
@@ -1169,8 +1175,16 @@ impl ProxyService {
             .await
             .map_err(|e| format!("获取 {app_type_str} Live 备份失败: {e}"))?;
         if let Some(backup) = backup {
-            let config: Value = serde_json::from_str(&backup.original_config)
+            let mut config: Value = serde_json::from_str(&backup.original_config)
                 .map_err(|e| format!("解析 {app_type_str} 备份失败: {e}"))?;
+            // For Claude: preserve current live's user-global fields if the backup doesn't have them.
+            // The backup may have been saved before global fields were tracked (pre-fix historical data),
+            // or after a previous switch had already stripped them.
+            if matches!(app_type, AppType::Claude) {
+                if let Ok(current_live) = self.read_claude_live() {
+                    Self::preserve_claude_global_fields_in_backup(&mut config, &current_live);
+                }
+            }
             self.write_live_config_for_app(app_type, &config)?;
             log::info!("{app_type_str} Live 配置已从备份恢复");
             return Ok(());
@@ -1494,7 +1508,7 @@ impl ProxyService {
             build_effective_settings_with_common_config(self.db.as_ref(), &app_type_enum, provider)
                 .map_err(|e| format!("构建 {app_type} 有效配置失败: {e}"))?;
 
-        if matches!(app_type_enum, AppType::Codex) {
+        if matches!(app_type_enum, AppType::Claude | AppType::Codex) {
             let existing_backup = self
                 .db
                 .get_live_backup(app_type)
@@ -1504,10 +1518,21 @@ impl ProxyService {
             if let Some(existing_backup) = existing_backup {
                 let existing_value: Value = serde_json::from_str(&existing_backup.original_config)
                     .map_err(|e| format!("解析 {app_type} 现有备份失败: {e}"))?;
-                Self::preserve_codex_mcp_servers_in_backup(
-                    &mut effective_settings,
-                    &existing_value,
-                )?;
+                match app_type_enum {
+                    AppType::Claude => {
+                        Self::preserve_claude_global_fields_in_backup(
+                            &mut effective_settings,
+                            &existing_value,
+                        );
+                    }
+                    AppType::Codex => {
+                        Self::preserve_codex_mcp_servers_in_backup(
+                            &mut effective_settings,
+                            &existing_value,
+                        )?;
+                    }
+                    _ => {}
+                }
             }
         }
 
@@ -1538,6 +1563,38 @@ impl ProxyService {
 
         log::info!("已更新 {app_type} Live 备份（热切换）");
         Ok(())
+    }
+
+    /// Preserve user-global fields (enabledPlugins, hooks, etc.) from the existing Claude live
+    /// backup into the new provider-based backup.
+    ///
+    /// In proxy takeover mode the live file is replaced with proxy placeholders, so we store
+    /// the "original live" in live_backup. When the user hot-switches providers we rebuild the
+    /// backup from the new provider's settings_config — but that snapshot won't contain the
+    /// user-global fields that Claude Code manages itself. This function copies those fields
+    /// from the previous backup so they survive the hot-switch.
+    fn preserve_claude_global_fields_in_backup(
+        target_settings: &mut Value,
+        existing_backup: &Value,
+    ) {
+        const GLOBAL_FIELDS: &[&str] =
+            &["enabledPlugins", "hooks", "spinnerVerbs", "permissions"];
+        let Some(target_obj) = target_settings.as_object_mut() else {
+            return;
+        };
+        let Some(backup_obj) = existing_backup.as_object() else {
+            return;
+        };
+        for field in GLOBAL_FIELDS {
+            if let Some(backup_value) = backup_obj.get(*field) {
+                // Only copy fields that the provider snapshot doesn't explicitly set.
+                // This mirrors the write_live_snapshot merge semantic: provider wins on
+                // provider-specific keys, backup (i.e. the original live) wins on global keys.
+                target_obj
+                    .entry(field.to_string())
+                    .or_insert_with(|| backup_value.clone());
+            }
+        }
     }
 
     fn preserve_codex_mcp_servers_in_backup(


### PR DESCRIPTION
## 问题

切换 provider 时，`~/.claude/settings.json` 中由 Claude Code 自己管理的用户全局字段（`enabledPlugins`、`hooks`、`spinnerVerbs`、`permissions`）会被 cc-switch 的 provider 快照全量覆盖，导致已安装启用的插件在切换后失效。

相关 issue：#1570、#1594、#370、#674、#806、#947、#1277

## 根本原因

`write_live_snapshot` 对 Claude 的 `settings.json` 执行全量覆盖，而 provider 快照里不包含这些全局字段。另外，backfill 阶段会把包含全局字段的 live 内容存入 provider 快照，下次切换时旧值又会覆盖最新状态。

## 修复方案

### 1. `live.rs` — 写入时 merge 而非覆盖

切换 provider 时，先读取当前 live 文件，把 provider 快照 merge 进去（provider 字段优先），live 里有而快照没有的字段（`enabledPlugins` 等）原封不动保留。

### 2. `live.rs` — 新增 `strip_global_fields_for_backfill`

backfill 存库前，从 Claude provider 快照中剔除全局字段，确保快照里永远不会存入这些值，避免后续切换时被旧值覆盖。

### 3. `proxy.rs` — 代理接管模式下保留全局字段

新增 `preserve_claude_global_fields_in_backup`，在代理模式下热切换 provider 重建 live_backup 时，从上一份 backup 复制全局字段，确保代理模式下切换也不丢插件。

## 测试

新增 4 个单元测试，全部通过：
- `strip_global_fields_removes_user_managed_fields_for_claude`
- `strip_global_fields_is_noop_for_non_claude_app_types`
- `write_live_snapshot_merges_global_fields_from_existing_file`
- `provider_snapshot_with_stale_plugins_does_not_overwrite_live`
