### PR TITLE
fix(claude): align Nvidia preset base URL with /v1

### DIFF
--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -874,6 +874,17 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_claude_stream_url_for_openai_chat_without_v1() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://example.com",
+            AuthStrategy::Bearer,
+            "openai_chat",
+        );
+
+        assert_eq!(url, "https://example.com/v1/chat/completions");
+    }
+
+    #[test]
     fn test_resolve_claude_stream_url_for_anthropic() {
         let url = StreamCheckService::resolve_claude_stream_url(
             "https://api.anthropic.com",

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -711,7 +711,7 @@ export const providerPresets: ProviderPreset[] = [
     apiKeyUrl: "https://build.nvidia.com/settings/api-keys",
     settingsConfig: {
       env: {
-        ANTHROPIC_BASE_URL: "https://integrate.api.nvidia.com",
+        ANTHROPIC_BASE_URL: "https://integrate.api.nvidia.com/v1",
         ANTHROPIC_AUTH_TOKEN: "",
         ANTHROPIC_MODEL: "moonshotai/kimi-k2.5",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "moonshotai/kimi-k2.5",

--- a/tests/config/claudeProviderPresets.test.ts
+++ b/tests/config/claudeProviderPresets.test.ts
@@ -76,3 +76,17 @@ describe("AWS Bedrock Provider Presets", () => {
     expect(bedrockApiKey!.category).toBe("cloud_provider");
   });
 });
+
+describe("Nvidia Provider Preset", () => {
+  const nvidia = providerPresets.find((p) => p.name === "Nvidia");
+
+  it("should include Nvidia preset", () => {
+    expect(nvidia).toBeDefined();
+  });
+
+  it("should use the versioned NVIDIA base URL for Claude openai_chat", () => {
+    const env = (nvidia!.settingsConfig as any).env;
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://integrate.api.nvidia.com/v1");
+    expect(nvidia!.apiFormat).toBe("openai_chat");
+  });
+});


### PR DESCRIPTION
## 变更背景
- #1604 中反馈 NVIDIA 在 Claude 后端测试模型失败（404），核心问题既有历史兼容链路差异，也有默认 preset 与用户填写认知不一致导致的误导。
- 仓库里 OpenCode 与 OpenClaw 的 NVIDIA preset 已明确使用 `.../v1`，但 Claude 的 NVIDIA preset 之前是裸域名 `https://integrate.api.nvidia.com`，在某些场景下会增加误配置概率。

## 变更内容
1. 明确 Claude 的 NVIDIA 预设默认 `ANTHROPIC_BASE_URL`
- 文件: `src/config/claudeProviderPresets.ts`
- 将 `ANTHROPIC_BASE_URL` 从 `https://integrate.api.nvidia.com` 改为 `https://integrate.api.nvidia.com/v1`。
- 该 preset 已声明 `apiFormat = "openai_chat"`，与 OpenAI 兼容路径保持一致。

2. 增加 NVIDIA preset 回归测试
- 文件: `tests/config/claudeProviderPresets.test.ts`
- 新增断言：NVIDIA preset 存在、`ANTHROPIC_BASE_URL` 为 `https://integrate.api.nvidia.com/v1`、`apiFormat` 为 `openai_chat`。

3. 增加 stream_check URL 兼容用例
- 文件: `src-tauri/src/services/stream_check.rs`
- 新增 `test_resolve_claude_stream_url_for_openai_chat_without_v1`：
  - base 为 `https://example.com` 时，`openai_chat` 分支应解析为 `https://example.com/v1/chat/completions`。
- 与已有 `base` 带 `/v1` 的用例形成成对回归。

## 为什么只改 Claude 这一个
- OpenCode 预设 (`src/config/opencodeProviderPresets.ts`)：`options.baseURL` 已是 `https://integrate.api.nvidia.com/v1`。
- OpenClaw 预设 (`src/config/openclawProviderPresets.ts`)：`baseUrl` 已是 `https://integrate.api.nvidia.com/v1`，并配套 `api: "openai-completions"`。
- 所以本次仅对 Claude 默认值进行一致化修复，不改代理核心协议转换链路。

## 已跑验证
- 已通过新增/既有 Rust 单测：`cargo test test_resolve_claude_stream_url_for_openai_chat --manifest-path src-tauri/Cargo.toml`。
- 相关新增用例覆盖 openai_chat 场景下 `base_url` 有/无 `/v1` 的 URL 生成。