### PR TITLE
fix(claude): add /v1 to Nvidia preset base URL

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -711,7 +711,7 @@ export const providerPresets: ProviderPreset[] = [
     apiKeyUrl: "https://build.nvidia.com/settings/api-keys",
     settingsConfig: {
       env: {
-        ANTHROPIC_BASE_URL: "https://integrate.api.nvidia.com",
+        ANTHROPIC_BASE_URL: "https://integrate.api.nvidia.com/v1",
         ANTHROPIC_AUTH_TOKEN: "",
         ANTHROPIC_MODEL: "moonshotai/kimi-k2.5",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "moonshotai/kimi-k2.5",


### PR DESCRIPTION
## 变更背景
- 当前仓库中，OpenCode 与 OpenClaw 的 NVIDIA 预设都已显式使用 `https://integrate.api.nvidia.com/v1`。
- Claude 的 NVIDIA 预设仍为 `https://integrate.api.nvidia.com`，直接使用预设会出错。


## 本次改动
- 仅修改 `src/config/claudeProviderPresets.ts`。
- 将 Claude 的 NVIDIA 预设 `ANTHROPIC_BASE_URL` 从 `https://integrate.api.nvidia.com` 改为 `https://integrate.api.nvidia.com/v1`。

## scope
- OpenCode 的 NVIDIA 预设当前已显式使用 `/v1`：`options.baseURL = https://integrate.api.nvidia.com/v1`。
- OpenClaw 的 NVIDIA 预设当前也已显式使用 `/v1`：`baseUrl = https://integrate.api.nvidia.com/v1`。
- 因此本 PR 只做 preset 对齐，不改运行时逻辑，不改 `stream_check`，不增加 fallback / 兜底。

## 影响
- 这是一个纯预设修正。
- 让 Claude / OpenCode / OpenClaw 三个 NVIDIA 预设的默认值保持一致。
