### PR TITLE
Refine MCP import reconciliation and validation

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -290,7 +290,7 @@ use crate::prompt_files::prompt_file_path;
 use crate::provider::ProviderManager;
 
 /// 应用类型
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AppType {
     Claude,

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -196,11 +196,8 @@ pub async fn toggle_mcp_app(
 
 /// 从所有应用导入 MCP 服务器（复用已有的导入逻辑）
 #[tauri::command]
-pub async fn import_mcp_from_apps(state: State<'_, AppState>) -> Result<usize, String> {
-    let mut total = 0;
-    total += McpService::import_from_claude(&state).unwrap_or(0);
-    total += McpService::import_from_codex(&state).unwrap_or(0);
-    total += McpService::import_from_gemini(&state).unwrap_or(0);
-    total += McpService::import_from_opencode(&state).unwrap_or(0);
-    Ok(total)
+pub async fn import_mcp_from_apps(
+    state: State<'_, AppState>,
+) -> Result<crate::mcp::McpImportResult, String> {
+    McpService::import_from_apps_detailed(&state).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/database/dao/mcp.rs
+++ b/src-tauri/src/database/dao/mcp.rs
@@ -5,6 +5,7 @@
 use crate::app_config::{McpApps, McpServer};
 use crate::database::{lock_conn, Database};
 use crate::error::AppError;
+use crate::mcp::normalize_server_spec;
 use indexmap::IndexMap;
 use rusqlite::params;
 
@@ -66,6 +67,7 @@ impl Database {
 
     /// 保存 MCP 服务器
     pub fn save_mcp_server(&self, server: &McpServer) -> Result<(), AppError> {
+        let canonical_server = normalize_server_spec(&server.server)?;
         let conn = lock_conn!(self.conn);
         conn.execute(
             "INSERT OR REPLACE INTO mcp_servers (
@@ -75,7 +77,7 @@ impl Database {
             params![
                 server.id,
                 server.name,
-                serde_json::to_string(&server.server).map_err(|e| AppError::Database(format!(
+                serde_json::to_string(&canonical_server).map_err(|e| AppError::Database(format!(
                     "Failed to serialize server config: {e}"
                 )))?,
                 server.description,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,10 +38,11 @@ pub use database::Database;
 pub use deeplink::{import_provider_from_deeplink, parse_deeplink_url, DeepLinkImportRequest};
 pub use error::AppError;
 pub use mcp::{
-    import_from_claude, import_from_codex, import_from_gemini, remove_server_from_claude,
-    remove_server_from_codex, remove_server_from_gemini, sync_enabled_to_claude,
-    sync_enabled_to_codex, sync_enabled_to_gemini, sync_single_server_to_claude,
-    sync_single_server_to_codex, sync_single_server_to_gemini,
+    import_from_claude, import_from_codex, import_from_gemini, McpImportIssue,
+    McpImportIssueKind, McpImportResult, remove_server_from_claude, remove_server_from_codex,
+    remove_server_from_gemini, sync_enabled_to_claude, sync_enabled_to_codex,
+    sync_enabled_to_gemini, sync_single_server_to_claude, sync_single_server_to_codex,
+    sync_single_server_to_gemini,
 };
 pub use provider::{Provider, ProviderMeta};
 pub use services::{

--- a/src-tauri/src/mcp/claude.rs
+++ b/src-tauri/src/mcp/claude.rs
@@ -3,10 +3,11 @@
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::app_config::{McpApps, McpConfig, McpServer, MultiAppConfig};
+use crate::app_config::{AppType, McpConfig, MultiAppConfig};
 use crate::error::AppError;
 
-use super::validation::{extract_server_spec, validate_server_spec};
+use super::validation::{extract_server_spec, normalize_server_spec};
+use super::{apply_parsed_import, build_imported_server, invalid_issue, ParsedImport};
 
 fn should_sync_claude_mcp() -> bool {
     // Claude 未安装/未初始化时：通常 ~/.claude 目录与 ~/.claude.json 都不存在。
@@ -49,66 +50,39 @@ pub fn sync_enabled_to_claude(config: &MultiAppConfig) -> Result<(), AppError> {
 /// 从 ~/.claude.json 导入 mcpServers 到统一结构（v3.7.0+）
 /// 已存在的服务器将启用 Claude 应用，不覆盖其他字段和应用状态
 pub fn import_from_claude(config: &mut MultiAppConfig) -> Result<usize, AppError> {
+    let parsed = parse_import_from_claude()?;
+    apply_parsed_import(config, parsed, AppType::Claude)
+}
+
+pub(crate) fn parse_import_from_claude() -> Result<ParsedImport, AppError> {
     let text_opt = crate::claude_mcp::read_mcp_json()?;
-    let Some(text) = text_opt else { return Ok(0) };
+    let Some(text) = text_opt else {
+        return Ok(ParsedImport::default());
+    };
 
     let v: Value = serde_json::from_str(&text)
         .map_err(|e| AppError::McpValidation(format!("解析 ~/.claude.json 失败: {e}")))?;
     let Some(map) = v.get("mcpServers").and_then(|x| x.as_object()) else {
-        return Ok(0);
+        return Ok(ParsedImport::default());
     };
 
-    // 确保新结构存在
-    let servers = config.mcp.servers.get_or_insert_with(HashMap::new);
-
-    let mut changed = 0;
-    let mut errors = Vec::new();
+    let mut parsed = ParsedImport::default();
 
     for (id, spec) in map.iter() {
-        // 校验：单项失败不中止，收集错误继续处理
-        if let Err(e) = validate_server_spec(spec) {
-            log::warn!("跳过无效 MCP 服务器 '{id}': {e}");
-            errors.push(format!("{id}: {e}"));
-            continue;
-        }
-
-        if let Some(existing) = servers.get_mut(id) {
-            // 已存在：仅启用 Claude 应用
-            if !existing.apps.claude {
-                existing.apps.claude = true;
-                changed += 1;
-                log::info!("MCP 服务器 '{id}' 已启用 Claude 应用");
+        match normalize_server_spec(spec) {
+            Ok(spec) => parsed
+                .servers
+                .push(build_imported_server(id.clone(), AppType::Claude, spec)),
+            Err(e) => {
+                log::warn!("跳过无效 MCP 服务器 '{id}': {e}");
+                parsed
+                    .issues
+                    .push(invalid_issue(id.clone(), AppType::Claude, e.to_string()));
             }
-        } else {
-            // 新建服务器：默认仅启用 Claude
-            servers.insert(
-                id.clone(),
-                McpServer {
-                    id: id.clone(),
-                    name: id.clone(),
-                    server: spec.clone(),
-                    apps: McpApps {
-                        claude: true,
-                        codex: false,
-                        gemini: false,
-                        opencode: false,
-                    },
-                    description: None,
-                    homepage: None,
-                    docs: None,
-                    tags: Vec::new(),
-                },
-            );
-            changed += 1;
-            log::info!("导入新 MCP 服务器 '{id}'");
         }
     }
 
-    if !errors.is_empty() {
-        log::warn!("导入完成，但有 {} 项失败: {:?}", errors.len(), errors);
-    }
-
-    Ok(changed)
+    Ok(parsed)
 }
 
 /// 将单个 MCP 服务器同步到 Claude live 配置

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -8,10 +8,11 @@
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
-use crate::app_config::{McpApps, McpConfig, McpServer, MultiAppConfig};
+use crate::app_config::{AppType, McpConfig, MultiAppConfig};
 use crate::error::AppError;
 
-use super::validation::{extract_server_spec, validate_server_spec};
+use super::validation::{extract_server_spec, normalize_server_spec};
+use super::{apply_parsed_import, build_imported_server, invalid_issue, ParsedImport};
 
 fn should_sync_codex_mcp() -> bool {
     // Codex 未安装/未初始化时：~/.codex 目录不存在。
@@ -50,109 +51,102 @@ fn collect_enabled_servers(cfg: &McpConfig) -> HashMap<String, Value> {
 ///
 /// 已存在的服务器将启用 Codex 应用，不覆盖其他字段和应用状态
 pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError> {
+    let parsed = parse_import_from_codex()?;
+    apply_parsed_import(config, parsed, AppType::Codex)
+}
+
+pub(crate) fn parse_import_from_codex() -> Result<ParsedImport, AppError> {
     let text = crate::codex_config::read_and_validate_codex_config_text()?;
     if text.trim().is_empty() {
-        return Ok(0);
+        return Ok(ParsedImport::default());
     }
 
     let root: toml::Table = toml::from_str(&text)
         .map_err(|e| AppError::McpValidation(format!("解析 ~/.codex/config.toml 失败: {e}")))?;
 
-    // 确保新结构存在
-    let servers = config.mcp.servers.get_or_insert_with(HashMap::new);
-
-    let mut changed_total = 0usize;
+    let mut parsed = ParsedImport::default();
 
     // helper：处理一组 servers 表
     let mut import_servers_tbl = |servers_tbl: &toml::value::Table| {
-        let mut changed = 0usize;
         for (id, entry_val) in servers_tbl.iter() {
             let Some(entry_tbl) = entry_val.as_table() else {
                 continue;
             };
 
-            // type 缺省为 stdio
-            let typ = entry_tbl
-                .get("type")
-                .and_then(|v| v.as_str())
-                .unwrap_or("stdio");
-
-            // 构建 JSON 规范
-            let mut spec = serde_json::Map::new();
-            spec.insert("type".into(), json!(typ));
-
-            // 核心字段（需要手动处理的字段）
-            let core_fields = match typ {
-                "stdio" => vec!["type", "command", "args", "env", "cwd"],
-                "http" | "sse" => vec!["type", "url", "http_headers"],
-                _ => vec!["type"],
-            };
-
-            // 1. 处理核心字段（强类型）
-            match typ {
-                "stdio" => {
-                    if let Some(cmd) = entry_tbl.get("command").and_then(|v| v.as_str()) {
-                        spec.insert("command".into(), json!(cmd));
-                    }
-                    if let Some(args) = entry_tbl.get("args").and_then(|v| v.as_array()) {
-                        let arr = args
-                            .iter()
-                            .filter_map(|x| x.as_str())
-                            .map(|s| json!(s))
-                            .collect::<Vec<_>>();
-                        if !arr.is_empty() {
-                            spec.insert("args".into(), serde_json::Value::Array(arr));
-                        }
-                    }
-                    if let Some(cwd) = entry_tbl.get("cwd").and_then(|v| v.as_str()) {
-                        if !cwd.trim().is_empty() {
-                            spec.insert("cwd".into(), json!(cwd));
-                        }
-                    }
-                    if let Some(env_tbl) = entry_tbl.get("env").and_then(|v| v.as_table()) {
-                        let mut env_json = serde_json::Map::new();
-                        for (k, v) in env_tbl.iter() {
-                            if let Some(sv) = v.as_str() {
-                                env_json.insert(k.clone(), json!(sv));
-                            }
-                        }
-                        if !env_json.is_empty() {
-                            spec.insert("env".into(), serde_json::Value::Object(env_json));
-                        }
-                    }
-                }
-                "http" | "sse" => {
-                    if let Some(url) = entry_tbl.get("url").and_then(|v| v.as_str()) {
-                        spec.insert("url".into(), json!(url));
-                    }
-                    // Read from http_headers (correct Codex format) or headers (legacy) with priority to http_headers
-                    let headers_tbl = entry_tbl
-                        .get("http_headers")
-                        .and_then(|v| v.as_table())
-                        .or_else(|| entry_tbl.get("headers").and_then(|v| v.as_table()));
-
-                    if let Some(headers_tbl) = headers_tbl {
-                        let mut headers_json = serde_json::Map::new();
-                        for (k, v) in headers_tbl.iter() {
-                            if let Some(sv) = v.as_str() {
-                                headers_json.insert(k.clone(), json!(sv));
-                            }
-                        }
-                        if !headers_json.is_empty() {
-                            spec.insert("headers".into(), serde_json::Value::Object(headers_json));
-                        }
-                    }
-                }
-                _ => {
+            let typ = entry_tbl.get("type").and_then(|v| v.as_str());
+            if let Some(typ) = typ {
+                if !matches!(typ, "stdio" | "http" | "sse") {
                     log::warn!("跳过未知类型 '{typ}' 的 Codex MCP 项 '{id}'");
-                    return changed;
+                    parsed.issues.push(invalid_issue(
+                        id.clone(),
+                        AppType::Codex,
+                        format!("未知的 Codex MCP 类型: {typ}"),
+                    ));
+                    continue;
+                }
+            }
+
+            let mut spec = serde_json::Map::new();
+            if let Some(typ) = typ {
+                spec.insert("type".into(), json!(typ));
+            }
+
+            if let Some(cmd) = entry_tbl.get("command").and_then(|v| v.as_str()) {
+                spec.insert("command".into(), json!(cmd));
+            }
+            if let Some(args) = entry_tbl.get("args").and_then(|v| v.as_array()) {
+                let arr = args
+                    .iter()
+                    .filter_map(|x| x.as_str())
+                    .map(|s| json!(s))
+                    .collect::<Vec<_>>();
+                if !arr.is_empty() {
+                    spec.insert("args".into(), serde_json::Value::Array(arr));
+                }
+            }
+            if let Some(cwd) = entry_tbl.get("cwd").and_then(|v| v.as_str()) {
+                if !cwd.trim().is_empty() {
+                    spec.insert("cwd".into(), json!(cwd));
+                }
+            }
+            if let Some(env_tbl) = entry_tbl.get("env").and_then(|v| v.as_table()) {
+                let mut env_json = serde_json::Map::new();
+                for (k, v) in env_tbl.iter() {
+                    if let Some(sv) = v.as_str() {
+                        env_json.insert(k.clone(), json!(sv));
+                    }
+                }
+                if !env_json.is_empty() {
+                    spec.insert("env".into(), serde_json::Value::Object(env_json));
+                }
+            }
+            if let Some(url) = entry_tbl.get("url").and_then(|v| v.as_str()) {
+                spec.insert("url".into(), json!(url));
+            }
+            let headers_tbl = entry_tbl
+                .get("http_headers")
+                .and_then(|v| v.as_table())
+                .or_else(|| entry_tbl.get("headers").and_then(|v| v.as_table()));
+            if let Some(headers_tbl) = headers_tbl {
+                let mut headers_json = serde_json::Map::new();
+                for (k, v) in headers_tbl.iter() {
+                    if let Some(sv) = v.as_str() {
+                        headers_json.insert(k.clone(), json!(sv));
+                    }
+                }
+                if !headers_json.is_empty() {
+                    spec.insert("headers".into(), serde_json::Value::Object(headers_json));
                 }
             }
 
             // 2. 处理扩展字段和其他未知字段（通用 TOML → JSON 转换）
             for (key, toml_val) in entry_tbl.iter() {
                 // 跳过已处理的核心字段
-                if core_fields.contains(&key.as_str()) {
+                if matches!(
+                    key.as_str(),
+                    "type" | "command" | "args" | "env" | "cwd" | "url" | "http_headers"
+                        | "headers"
+                ) {
                     continue;
                 }
 
@@ -210,44 +204,18 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
 
             let spec_v = serde_json::Value::Object(spec);
 
-            // 校验：单项失败继续处理
-            if let Err(e) = validate_server_spec(&spec_v) {
-                log::warn!("跳过无效 Codex MCP 项 '{id}': {e}");
-                continue;
-            }
-
-            if let Some(existing) = servers.get_mut(id) {
-                // 已存在：仅启用 Codex 应用
-                if !existing.apps.codex {
-                    existing.apps.codex = true;
-                    changed += 1;
-                    log::info!("MCP 服务器 '{id}' 已启用 Codex 应用");
+            match normalize_server_spec(&spec_v) {
+                Ok(spec) => parsed
+                    .servers
+                    .push(build_imported_server(id.clone(), AppType::Codex, spec)),
+                Err(e) => {
+                    log::warn!("跳过无效 Codex MCP 项 '{id}': {e}");
+                    parsed
+                        .issues
+                        .push(invalid_issue(id.clone(), AppType::Codex, e.to_string()));
                 }
-            } else {
-                // 新建服务器：默认仅启用 Codex
-                servers.insert(
-                    id.clone(),
-                    McpServer {
-                        id: id.clone(),
-                        name: id.clone(),
-                        server: spec_v,
-                        apps: McpApps {
-                            claude: false,
-                            codex: true,
-                            gemini: false,
-                            opencode: false,
-                        },
-                        description: None,
-                        homepage: None,
-                        docs: None,
-                        tags: Vec::new(),
-                    },
-                );
-                changed += 1;
-                log::info!("导入新 MCP 服务器 '{id}'");
             }
         }
-        changed
     };
 
     // 1) 处理 mcp.servers
@@ -255,7 +223,7 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
         if let Some(mcp_tbl) = mcp_val.as_table() {
             if let Some(servers_val) = mcp_tbl.get("servers") {
                 if let Some(servers_tbl) = servers_val.as_table() {
-                    changed_total += import_servers_tbl(servers_tbl);
+                    import_servers_tbl(servers_tbl);
                 }
             }
         }
@@ -264,11 +232,11 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
     // 2) 处理 mcp_servers
     if let Some(servers_val) = root.get("mcp_servers") {
         if let Some(servers_tbl) = servers_val.as_table() {
-            changed_total += import_servers_tbl(servers_tbl);
+            import_servers_tbl(servers_tbl);
         }
     }
 
-    Ok(changed_total)
+    Ok(parsed)
 }
 
 /// 将 config.json 中 Codex 的 enabled==true 项以 TOML 形式写入 ~/.codex/config.toml
@@ -561,15 +529,23 @@ fn json_value_to_toml_item(value: &Value, field_name: &str) -> Option<toml_edit:
 fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError> {
     use toml_edit::{Array, Item, Table};
 
+    let spec = normalize_server_spec(spec)?;
     let mut t = Table::new();
-    let typ = spec.get("type").and_then(|v| v.as_str()).unwrap_or("stdio");
+    let typ = spec
+        .get("type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::McpValidation("MCP 服务器缺少合法的 type 字段".into()))?;
     t["type"] = toml_edit::value(typ);
 
     // 定义核心字段（已在下方处理，跳过通用转换）
     let core_fields = match typ {
         "stdio" => vec!["type", "command", "args", "env", "cwd"],
-        "http" | "sse" => vec!["type", "url", "http_headers"],
-        _ => vec!["type"],
+        "http" | "sse" => vec!["type", "url", "headers", "http_headers"],
+        _ => {
+            return Err(AppError::McpValidation(format!(
+                "不支持的 MCP 服务器类型: {typ}"
+            )));
+        }
     };
 
     // 定义扩展字段白名单（Codex 常见可选字段）
@@ -603,7 +579,10 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
     // 1. 处理核心字段（强类型）
     match typ {
         "stdio" => {
-            let cmd = spec.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            let cmd = spec
+                .get("command")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| AppError::McpValidation("stdio 类型的 MCP 服务器缺少 command 字段".into()))?;
             t["command"] = toml_edit::value(cmd);
 
             if let Some(args) = spec.get("args").and_then(|v| v.as_array()) {
@@ -635,7 +614,10 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
             }
         }
         "http" | "sse" => {
-            let url = spec.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            let url = spec
+                .get("url")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| AppError::McpValidation(format!("{typ} 类型的 MCP 服务器缺少 url 字段")))?;
             t["url"] = toml_edit::value(url);
 
             if let Some(headers) = spec.get("headers").and_then(|v| v.as_object()) {
@@ -650,7 +632,7 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
                 }
             }
         }
-        _ => {}
+        _ => unreachable!("type already validated"),
     }
 
     // 2. 处理扩展字段和其他未知字段

--- a/src-tauri/src/mcp/gemini.rs
+++ b/src-tauri/src/mcp/gemini.rs
@@ -3,10 +3,11 @@
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::app_config::{McpApps, McpConfig, McpServer, MultiAppConfig};
+use crate::app_config::{AppType, McpConfig, MultiAppConfig};
 use crate::error::AppError;
 
-use super::validation::{extract_server_spec, validate_server_spec};
+use super::validation::{extract_server_spec, normalize_server_spec};
+use super::{apply_parsed_import, build_imported_server, invalid_issue, ParsedImport};
 
 fn should_sync_gemini_mcp() -> bool {
     // Gemini 未安装/未初始化时：~/.gemini 目录不存在。
@@ -49,62 +50,33 @@ pub fn sync_enabled_to_gemini(config: &MultiAppConfig) -> Result<(), AppError> {
 /// 从 Gemini MCP 配置导入到统一结构（v3.7.0+）
 /// 已存在的服务器将启用 Gemini 应用，不覆盖其他字段和应用状态
 pub fn import_from_gemini(config: &mut MultiAppConfig) -> Result<usize, AppError> {
+    let parsed = parse_import_from_gemini()?;
+    apply_parsed_import(config, parsed, AppType::Gemini)
+}
+
+pub(crate) fn parse_import_from_gemini() -> Result<ParsedImport, AppError> {
     let map = crate::gemini_mcp::read_mcp_servers_map()?;
     if map.is_empty() {
-        return Ok(0);
+        return Ok(ParsedImport::default());
     }
 
-    // 确保新结构存在
-    let servers = config.mcp.servers.get_or_insert_with(HashMap::new);
-
-    let mut changed = 0;
-    let mut errors = Vec::new();
+    let mut parsed = ParsedImport::default();
 
     for (id, spec) in map.iter() {
-        // 校验：单项失败不中止，收集错误继续处理
-        if let Err(e) = validate_server_spec(spec) {
-            log::warn!("跳过无效 MCP 服务器 '{id}': {e}");
-            errors.push(format!("{id}: {e}"));
-            continue;
-        }
-
-        if let Some(existing) = servers.get_mut(id) {
-            // 已存在：仅启用 Gemini 应用
-            if !existing.apps.gemini {
-                existing.apps.gemini = true;
-                changed += 1;
-                log::info!("MCP 服务器 '{id}' 已启用 Gemini 应用");
+        match normalize_server_spec(spec) {
+            Ok(spec) => parsed
+                .servers
+                .push(build_imported_server(id.clone(), AppType::Gemini, spec)),
+            Err(e) => {
+                log::warn!("跳过无效 MCP 服务器 '{id}': {e}");
+                parsed
+                    .issues
+                    .push(invalid_issue(id.clone(), AppType::Gemini, e.to_string()));
             }
-        } else {
-            // 新建服务器：默认仅启用 Gemini
-            servers.insert(
-                id.clone(),
-                McpServer {
-                    id: id.clone(),
-                    name: id.clone(),
-                    server: spec.clone(),
-                    apps: McpApps {
-                        claude: false,
-                        codex: false,
-                        gemini: true,
-                        opencode: false,
-                    },
-                    description: None,
-                    homepage: None,
-                    docs: None,
-                    tags: Vec::new(),
-                },
-            );
-            changed += 1;
-            log::info!("导入新 MCP 服务器 '{id}'");
         }
     }
 
-    if !errors.is_empty() {
-        log::warn!("导入完成，但有 {} 项失败: {:?}", errors.len(), errors);
-    }
-
-    Ok(changed)
+    Ok(parsed)
 }
 
 /// 将单个 MCP 服务器同步到 Gemini live 配置

--- a/src-tauri/src/mcp/importing.rs
+++ b/src-tauri/src/mcp/importing.rs
@@ -111,6 +111,19 @@ pub(crate) fn conflict_issue(
     }
 }
 
+pub(crate) fn source_import_error_issue(
+    source_app: AppType,
+    message: impl Into<String>,
+) -> McpImportIssue {
+    McpImportIssue {
+        id: format!("{}:import", source_app.as_str()),
+        source_app,
+        kind: McpImportIssueKind::Invalid,
+        message: message.into(),
+        existing_apps: Vec::new(),
+    }
+}
+
 pub(crate) fn build_imported_server(
     id: impl Into<String>,
     source_app: AppType,
@@ -132,9 +145,9 @@ pub(crate) fn build_imported_server(
     }
 }
 
-fn is_owned_by_source_or_unassigned(server: &McpServer, source_app: &AppType) -> bool {
+fn is_owned_by_source(server: &McpServer, source_app: &AppType) -> bool {
     let enabled_apps = server.apps.enabled_apps();
-    enabled_apps.is_empty() || enabled_apps.iter().all(|app| app == source_app)
+    !enabled_apps.is_empty() && enabled_apps.iter().all(|app| app == source_app)
 }
 
 pub(crate) fn reconcile_imported_server(
@@ -150,17 +163,14 @@ pub(crate) fn reconcile_imported_server(
             Ok(ImportMergeAction::Added)
         }
         Some(existing) => {
-            let canonical_existing = normalize_server_spec(&existing.server).ok();
-            let same_spec = canonical_existing
-                .as_ref()
-                .map(|spec| spec == &imported.server)
-                .unwrap_or(false);
+            let canonical_existing = normalize_server_spec(&existing.server)?;
+            let same_spec = canonical_existing == imported.server;
 
             if same_spec {
                 let mut changed = false;
 
-                if canonical_existing.as_ref().is_some_and(|spec| spec != &existing.server) {
-                    existing.server = canonical_existing.expect("checked Some above");
+                if canonical_existing != existing.server {
+                    existing.server = canonical_existing;
                     changed = true;
                 }
 
@@ -180,7 +190,7 @@ pub(crate) fn reconcile_imported_server(
                 });
             }
 
-            if is_owned_by_source_or_unassigned(existing, &source_app) {
+            if is_owned_by_source(existing, &source_app) {
                 existing.server = imported.server;
                 existing.apps.set_enabled_for(&source_app, true);
                 return Ok(ImportMergeAction::Refreshed);
@@ -190,6 +200,108 @@ pub(crate) fn reconcile_imported_server(
                 existing_apps: existing.apps.enabled_apps(),
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_config::McpApps;
+    use serde_json::json;
+
+    fn server(id: &str, app: AppType, spec: Value) -> McpServer {
+        build_imported_server(id.to_string(), app, spec)
+    }
+
+    #[test]
+    fn reconcile_does_not_overwrite_disabled_entry() {
+        let mut servers = HashMap::new();
+        servers.insert(
+            "shared".to_string(),
+            McpServer {
+                id: "shared".to_string(),
+                name: "shared".to_string(),
+                server: json!({
+                    "type": "stdio",
+                    "command": "local"
+                }),
+                apps: McpApps::default(),
+                description: None,
+                homepage: None,
+                docs: None,
+                tags: Vec::new(),
+            },
+        );
+
+        let action = reconcile_imported_server(
+            &mut servers,
+            server(
+                "shared",
+                AppType::Codex,
+                json!({
+                    "type": "stdio",
+                    "command": "external"
+                }),
+            ),
+            AppType::Codex,
+        )
+        .expect("reconcile should succeed");
+
+        assert_eq!(
+            action,
+            ImportMergeAction::Conflict {
+                existing_apps: Vec::new()
+            }
+        );
+        assert_eq!(
+            servers["shared"].server.get("command").and_then(|v| v.as_str()),
+            Some("local")
+        );
+        assert!(servers["shared"].apps.is_empty());
+    }
+
+    #[test]
+    fn reconcile_surfaces_invalid_existing_spec() {
+        let mut servers = HashMap::new();
+        servers.insert(
+            "shared".to_string(),
+            McpServer {
+                id: "shared".to_string(),
+                name: "shared".to_string(),
+                server: json!({
+                    "type": "stdio"
+                }),
+                apps: McpApps {
+                    claude: true,
+                    codex: false,
+                    gemini: false,
+                    opencode: false,
+                },
+                description: None,
+                homepage: None,
+                docs: None,
+                tags: Vec::new(),
+            },
+        );
+
+        let err = reconcile_imported_server(
+            &mut servers,
+            server(
+                "shared",
+                AppType::Codex,
+                json!({
+                    "type": "stdio",
+                    "command": "echo"
+                }),
+            ),
+            AppType::Codex,
+        )
+        .expect_err("invalid existing spec should bubble up");
+
+        assert!(
+            err.to_string().contains("stdio 类型的 MCP 服务器缺少 command 字段"),
+            "unexpected error: {err}"
+        );
     }
 }
 

--- a/src-tauri/src/mcp/importing.rs
+++ b/src-tauri/src/mcp/importing.rs
@@ -1,0 +1,226 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::app_config::{AppType, McpApps, McpServer, MultiAppConfig};
+use crate::error::AppError;
+
+use super::validation::normalize_server_spec;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum McpImportIssueKind {
+    Conflict,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpImportIssue {
+    pub id: String,
+    pub source_app: AppType,
+    pub kind: McpImportIssueKind,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub existing_apps: Vec<AppType>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpImportResult {
+    pub added: usize,
+    pub refreshed: usize,
+    pub enabled_only: usize,
+    pub conflicts: usize,
+    pub invalid: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issues: Vec<McpImportIssue>,
+}
+
+impl McpImportResult {
+    pub fn changed_count(&self) -> usize {
+        self.added + self.refreshed + self.enabled_only
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        self.added += other.added;
+        self.refreshed += other.refreshed;
+        self.enabled_only += other.enabled_only;
+        self.conflicts += other.conflicts;
+        self.invalid += other.invalid;
+        self.issues.extend(other.issues);
+    }
+
+    pub fn push_issue(&mut self, issue: McpImportIssue) {
+        match issue.kind {
+            McpImportIssueKind::Conflict => self.conflicts += 1,
+            McpImportIssueKind::Invalid => self.invalid += 1,
+        }
+        self.issues.push(issue);
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ParsedImport {
+    pub servers: Vec<McpServer>,
+    pub issues: Vec<McpImportIssue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ImportMergeAction {
+    Added,
+    Refreshed,
+    EnabledOnly,
+    Unchanged,
+    Conflict { existing_apps: Vec<AppType> },
+}
+
+pub(crate) fn invalid_issue(
+    id: impl Into<String>,
+    source_app: AppType,
+    message: impl Into<String>,
+) -> McpImportIssue {
+    McpImportIssue {
+        id: id.into(),
+        source_app,
+        kind: McpImportIssueKind::Invalid,
+        message: message.into(),
+        existing_apps: Vec::new(),
+    }
+}
+
+pub(crate) fn conflict_issue(
+    id: impl Into<String>,
+    source_app: AppType,
+    existing_apps: Vec<AppType>,
+) -> McpImportIssue {
+    let app_list = existing_apps
+        .iter()
+        .map(AppType::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    McpImportIssue {
+        id: id.into(),
+        source_app,
+        kind: McpImportIssueKind::Conflict,
+        message: format!(
+            "同一 ID 已被其他应用使用且配置不同，当前不会自动覆盖（现有应用: {app_list})"
+        ),
+        existing_apps,
+    }
+}
+
+pub(crate) fn build_imported_server(
+    id: impl Into<String>,
+    source_app: AppType,
+    server: Value,
+) -> McpServer {
+    let id = id.into();
+    let mut apps = McpApps::default();
+    apps.set_enabled_for(&source_app, true);
+
+    McpServer {
+        id: id.clone(),
+        name: id,
+        server,
+        apps,
+        description: None,
+        homepage: None,
+        docs: None,
+        tags: Vec::new(),
+    }
+}
+
+fn is_owned_by_source_or_unassigned(server: &McpServer, source_app: &AppType) -> bool {
+    let enabled_apps = server.apps.enabled_apps();
+    enabled_apps.is_empty() || enabled_apps.iter().all(|app| app == source_app)
+}
+
+pub(crate) fn reconcile_imported_server(
+    servers: &mut HashMap<String, McpServer>,
+    mut imported: McpServer,
+    source_app: AppType,
+) -> Result<ImportMergeAction, AppError> {
+    imported.server = normalize_server_spec(&imported.server)?;
+
+    match servers.get_mut(&imported.id) {
+        None => {
+            servers.insert(imported.id.clone(), imported);
+            Ok(ImportMergeAction::Added)
+        }
+        Some(existing) => {
+            let canonical_existing = normalize_server_spec(&existing.server).ok();
+            let same_spec = canonical_existing
+                .as_ref()
+                .map(|spec| spec == &imported.server)
+                .unwrap_or(false);
+
+            if same_spec {
+                let mut changed = false;
+
+                if canonical_existing.as_ref().is_some_and(|spec| spec != &existing.server) {
+                    existing.server = canonical_existing.expect("checked Some above");
+                    changed = true;
+                }
+
+                if !existing.apps.is_enabled_for(&source_app) {
+                    existing.apps.set_enabled_for(&source_app, true);
+                    return Ok(if changed {
+                        ImportMergeAction::Refreshed
+                    } else {
+                        ImportMergeAction::EnabledOnly
+                    });
+                }
+
+                return Ok(if changed {
+                    ImportMergeAction::Refreshed
+                } else {
+                    ImportMergeAction::Unchanged
+                });
+            }
+
+            if is_owned_by_source_or_unassigned(existing, &source_app) {
+                existing.server = imported.server;
+                existing.apps.set_enabled_for(&source_app, true);
+                return Ok(ImportMergeAction::Refreshed);
+            }
+
+            Ok(ImportMergeAction::Conflict {
+                existing_apps: existing.apps.enabled_apps(),
+            })
+        }
+    }
+}
+
+pub(crate) fn apply_parsed_import(
+    config: &mut MultiAppConfig,
+    parsed: ParsedImport,
+    source_app: AppType,
+) -> Result<usize, AppError> {
+    let servers = config
+        .mcp
+        .servers
+        .get_or_insert_with(HashMap::<String, McpServer>::new);
+    let mut changed = 0usize;
+
+    for issue in &parsed.issues {
+        log::warn!(
+            "跳过 {} 导入的 MCP '{}': {}",
+            issue.source_app.as_str(),
+            issue.id,
+            issue.message
+        );
+    }
+
+    for server in parsed.servers {
+        match reconcile_imported_server(servers, server, source_app.clone())? {
+            ImportMergeAction::Added
+            | ImportMergeAction::Refreshed
+            | ImportMergeAction::EnabledOnly => changed += 1,
+            ImportMergeAction::Unchanged | ImportMergeAction::Conflict { .. } => {}
+        }
+    }
+
+    Ok(changed)
+}

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -37,8 +37,8 @@ pub(crate) use claude::parse_import_from_claude;
 pub(crate) use codex::parse_import_from_codex;
 pub(crate) use gemini::parse_import_from_gemini;
 pub(crate) use importing::{
-    apply_parsed_import, build_imported_server, conflict_issue, invalid_issue, reconcile_imported_server,
-    ImportMergeAction, ParsedImport,
+    apply_parsed_import, build_imported_server, conflict_issue, invalid_issue,
+    reconcile_imported_server, source_import_error_issue, ImportMergeAction, ParsedImport,
 };
 pub(crate) use opencode::parse_import_from_opencode;
 pub(crate) use validation::normalize_server_spec;

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -13,6 +13,7 @@
 mod claude;
 mod codex;
 mod gemini;
+mod importing;
 mod opencode;
 mod validation;
 
@@ -28,6 +29,16 @@ pub use gemini::{
     import_from_gemini, remove_server_from_gemini, sync_enabled_to_gemini,
     sync_single_server_to_gemini,
 };
+pub use importing::{McpImportIssue, McpImportIssueKind, McpImportResult};
 pub use opencode::{
     import_from_opencode, remove_server_from_opencode, sync_single_server_to_opencode,
 };
+pub(crate) use claude::parse_import_from_claude;
+pub(crate) use codex::parse_import_from_codex;
+pub(crate) use gemini::parse_import_from_gemini;
+pub(crate) use importing::{
+    apply_parsed_import, build_imported_server, conflict_issue, invalid_issue, reconcile_imported_server,
+    ImportMergeAction, ParsedImport,
+};
+pub(crate) use opencode::parse_import_from_opencode;
+pub(crate) use validation::normalize_server_spec;

--- a/src-tauri/src/mcp/opencode.rs
+++ b/src-tauri/src/mcp/opencode.rs
@@ -13,13 +13,13 @@
 //! | `url`                | `url`               |
 
 use serde_json::{json, Value};
-use std::collections::HashMap;
 
-use crate::app_config::{McpApps, McpServer, MultiAppConfig};
+use crate::app_config::{AppType, MultiAppConfig};
 use crate::error::AppError;
 use crate::opencode_config;
 
-use super::validation::validate_server_spec;
+use super::validation::normalize_server_spec;
+use super::{apply_parsed_import, build_imported_server, invalid_issue, ParsedImport};
 
 // ============================================================================
 // Helper Functions
@@ -210,16 +210,17 @@ pub fn remove_server_from_opencode(id: &str) -> Result<(), AppError> {
 ///
 /// Existing servers will have OpenCode app enabled without overwriting other fields.
 pub fn import_from_opencode(config: &mut MultiAppConfig) -> Result<usize, AppError> {
+    let parsed = parse_import_from_opencode()?;
+    apply_parsed_import(config, parsed, AppType::OpenCode)
+}
+
+pub(crate) fn parse_import_from_opencode() -> Result<ParsedImport, AppError> {
     let mcp_map = opencode_config::get_mcp_servers()?;
     if mcp_map.is_empty() {
-        return Ok(0);
+        return Ok(ParsedImport::default());
     }
 
-    // Ensure servers map exists
-    let servers = config.mcp.servers.get_or_insert_with(HashMap::new);
-
-    let mut changed = 0;
-    let mut errors = Vec::new();
+    let mut parsed = ParsedImport::default();
 
     for (id, spec) in mcp_map {
         // Convert from OpenCode format to unified format
@@ -227,59 +228,27 @@ pub fn import_from_opencode(config: &mut MultiAppConfig) -> Result<usize, AppErr
             Ok(s) => s,
             Err(e) => {
                 log::warn!("Skip invalid OpenCode MCP server '{id}': {e}");
-                errors.push(format!("{id}: {e}"));
+                parsed
+                    .issues
+                    .push(invalid_issue(id, AppType::OpenCode, e.to_string()));
                 continue;
             }
         };
 
-        // Validate the converted spec
-        if let Err(e) = validate_server_spec(&unified_spec) {
-            log::warn!("Skip invalid MCP server '{id}' after conversion: {e}");
-            errors.push(format!("{id}: {e}"));
-            continue;
-        }
-
-        if let Some(existing) = servers.get_mut(&id) {
-            // Existing server: just enable OpenCode app
-            if !existing.apps.opencode {
-                existing.apps.opencode = true;
-                changed += 1;
-                log::info!("MCP server '{id}' enabled for OpenCode");
+        match normalize_server_spec(&unified_spec) {
+            Ok(spec) => parsed
+                .servers
+                .push(build_imported_server(id.clone(), AppType::OpenCode, spec)),
+            Err(e) => {
+                log::warn!("Skip invalid MCP server '{id}' after conversion: {e}");
+                parsed
+                    .issues
+                    .push(invalid_issue(id, AppType::OpenCode, e.to_string()));
             }
-        } else {
-            // New server: default to only OpenCode enabled
-            servers.insert(
-                id.clone(),
-                McpServer {
-                    id: id.clone(),
-                    name: id.clone(),
-                    server: unified_spec,
-                    apps: McpApps {
-                        claude: false,
-                        codex: false,
-                        gemini: false,
-                        opencode: true,
-                    },
-                    description: None,
-                    homepage: None,
-                    docs: None,
-                    tags: Vec::new(),
-                },
-            );
-            changed += 1;
-            log::info!("Imported new MCP server '{id}' from OpenCode");
         }
     }
 
-    if !errors.is_empty() {
-        log::warn!(
-            "Import completed with {} failures: {:?}",
-            errors.len(),
-            errors
-        );
-    }
-
-    Ok(changed)
+    Ok(parsed)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mcp/validation.rs
+++ b/src-tauri/src/mcp/validation.rs
@@ -55,10 +55,10 @@ pub fn normalize_server_spec(spec: &Value) -> Result<Value, AppError> {
         Some(_) => {
             return Err(AppError::McpValidation(INVALID_TYPE.into()));
         }
-        None if has_command => "stdio".to_string(),
         None if has_url => {
             return Err(AppError::McpValidation(TYPE_REQUIRED_FOR_URL.into()));
         }
+        None if has_command => "stdio".to_string(),
         None => "stdio".to_string(),
     };
 
@@ -108,4 +108,24 @@ pub fn extract_server_spec(entry: &Value) -> Result<Value, AppError> {
     }
 
     Ok(server.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn normalize_rejects_url_without_explicit_remote_type_even_with_command() {
+        let err = normalize_server_spec(&json!({
+            "command": "node",
+            "url": "https://example.com/mcp"
+        }))
+        .expect_err("url without explicit type should be rejected");
+
+        assert!(
+            err.to_string().contains(TYPE_REQUIRED_FOR_URL),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src-tauri/src/mcp/validation.rs
+++ b/src-tauri/src/mcp/validation.rs
@@ -4,49 +4,91 @@ use serde_json::Value;
 
 use crate::error::AppError;
 
-/// 基础校验：允许 stdio/http/sse；或省略 type（视为 stdio）。对应必填字段存在
-pub fn validate_server_spec(spec: &Value) -> Result<(), AppError> {
+const TYPE_REQUIRED_FOR_URL: &str =
+    "包含 url 字段的 MCP 服务器必须显式指定 type 为 'http' 或 'sse'";
+const INVALID_TYPE: &str = "MCP 服务器 type 必须是 'stdio'、'http' 或 'sse'";
+
+fn require_string_field(spec: &Value, field: &str, error: &str) -> Result<(), AppError> {
+    let value = spec.get(field).and_then(|x| x.as_str()).unwrap_or("");
+    if value.trim().is_empty() {
+        return Err(AppError::McpValidation(error.into()));
+    }
+
+    Ok(())
+}
+
+/// 规范化并校验服务器配置。
+///
+/// 统一规则：
+/// - `http_headers` 统一转为 `headers`
+/// - 缺少 `type` 且有 `command` 时补齐为 `stdio`
+/// - 缺少 `type` 且有 `url` 时直接报错，要求显式指定 `http` 或 `sse`
+pub fn normalize_server_spec(spec: &Value) -> Result<Value, AppError> {
     if !spec.is_object() {
         return Err(AppError::McpValidation(
             "MCP 服务器连接定义必须为 JSON 对象".into(),
         ));
     }
-    let t_opt = spec.get("type").and_then(|x| x.as_str());
-    // 支持三种：stdio/http/sse；若缺省 type 则按 stdio 处理（与社区常见 .mcp.json 一致）
-    let is_stdio = t_opt.map(|t| t == "stdio").unwrap_or(true);
-    let is_http = t_opt.map(|t| t == "http").unwrap_or(false);
-    let is_sse = t_opt.map(|t| t == "sse").unwrap_or(false);
 
-    if !(is_stdio || is_http || is_sse) {
-        return Err(AppError::McpValidation(
-            "MCP 服务器 type 必须是 'stdio'、'http' 或 'sse'（或省略表示 stdio）".into(),
-        ));
+    let mut normalized = spec
+        .as_object()
+        .cloned()
+        .ok_or_else(|| AppError::McpValidation("MCP 服务器连接定义必须为 JSON 对象".into()))?;
+
+    if let Some(http_headers) = normalized.remove("http_headers") {
+        if let Some(headers) = normalized.get("headers") {
+            if headers != &http_headers {
+                return Err(AppError::McpValidation(
+                    "MCP 服务器不能同时包含不同的 headers 与 http_headers".into(),
+                ));
+            }
+        } else {
+            normalized.insert("headers".into(), http_headers);
+        }
     }
 
-    if is_stdio {
-        let cmd = spec.get("command").and_then(|x| x.as_str()).unwrap_or("");
-        if cmd.trim().is_empty() {
-            return Err(AppError::McpValidation(
-                "stdio 类型的 MCP 服务器缺少 command 字段".into(),
-            ));
+    let has_command = normalized.contains_key("command");
+    let has_url = normalized.contains_key("url");
+
+    let normalized_type = match normalized.get("type") {
+        Some(Value::String(t)) => t.clone(),
+        Some(_) => {
+            return Err(AppError::McpValidation(INVALID_TYPE.into()));
         }
-    }
-    if is_http {
-        let url = spec.get("url").and_then(|x| x.as_str()).unwrap_or("");
-        if url.trim().is_empty() {
-            return Err(AppError::McpValidation(
-                "http 类型的 MCP 服务器缺少 url 字段".into(),
-            ));
+        None if has_command => "stdio".to_string(),
+        None if has_url => {
+            return Err(AppError::McpValidation(TYPE_REQUIRED_FOR_URL.into()));
         }
+        None => "stdio".to_string(),
+    };
+
+    match normalized_type.as_str() {
+        "stdio" => require_string_field(
+            &Value::Object(normalized.clone()),
+            "command",
+            "stdio 类型的 MCP 服务器缺少 command 字段",
+        )?,
+        "http" => require_string_field(
+            &Value::Object(normalized.clone()),
+            "url",
+            "http 类型的 MCP 服务器缺少 url 字段",
+        )?,
+        "sse" => require_string_field(
+            &Value::Object(normalized.clone()),
+            "url",
+            "sse 类型的 MCP 服务器缺少 url 字段",
+        )?,
+        _ => return Err(AppError::McpValidation(INVALID_TYPE.into())),
     }
-    if is_sse {
-        let url = spec.get("url").and_then(|x| x.as_str()).unwrap_or("");
-        if url.trim().is_empty() {
-            return Err(AppError::McpValidation(
-                "sse 类型的 MCP 服务器缺少 url 字段".into(),
-            ));
-        }
-    }
+
+    normalized.insert("type".into(), Value::String(normalized_type));
+
+    Ok(Value::Object(normalized))
+}
+
+/// 严格校验：数据库中的 MCP spec 必须是 canonical 形式。
+pub fn validate_server_spec(spec: &Value) -> Result<(), AppError> {
+    normalize_server_spec(spec)?;
     Ok(())
 }
 

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -184,16 +184,16 @@ impl McpService {
         Ok(())
     }
 
-    fn import_from_app_detailed(
+    fn prepare_import_from_app_detailed(
         state: &AppState,
         source_app: AppType,
-    ) -> Result<McpImportResult, AppError> {
+    ) -> Result<(McpImportResult, Vec<McpServer>), AppError> {
         let parsed = match &source_app {
             AppType::Claude => mcp::parse_import_from_claude()?,
             AppType::Codex => mcp::parse_import_from_codex()?,
             AppType::Gemini => mcp::parse_import_from_gemini()?,
             AppType::OpenCode => mcp::parse_import_from_opencode()?,
-            AppType::OpenClaw => return Ok(McpImportResult::default()),
+            AppType::OpenClaw => return Ok((McpImportResult::default(), Vec::new())),
         };
 
         let mut result = McpImportResult::default();
@@ -202,7 +202,7 @@ impl McpService {
         }
 
         if parsed.servers.is_empty() {
-            return Ok(result);
+            return Ok((result, Vec::new()));
         }
 
         let mut servers: HashMap<String, McpServer> =
@@ -231,24 +231,60 @@ impl McpService {
             }
         }
 
-        for id in changed_ids {
-            let server = servers
+        let changed_servers = changed_ids
+            .into_iter()
+            .map(|id| {
+                servers
                 .get(&id)
                 .cloned()
-                .expect("changed server must exist after reconciliation");
+                .expect("changed server must exist after reconciliation")
+            })
+            .collect();
+
+        Ok((result, changed_servers))
+    }
+
+    fn persist_import_changes(
+        state: &AppState,
+        changed_servers: Vec<McpServer>,
+    ) -> Result<(), AppError> {
+        for server in changed_servers {
             state.db.save_mcp_server(&server)?;
             Self::sync_server_to_apps(state, &server)?;
         }
 
+        Ok(())
+    }
+
+    fn import_from_app_detailed(
+        state: &AppState,
+        source_app: AppType,
+    ) -> Result<McpImportResult, AppError> {
+        let (result, changed_servers) = Self::prepare_import_from_app_detailed(state, source_app)?;
+        Self::persist_import_changes(state, changed_servers)?;
         Ok(result)
     }
 
     pub fn import_from_apps_detailed(state: &AppState) -> Result<McpImportResult, AppError> {
         let mut result = McpImportResult::default();
-        result.merge(Self::import_from_app_detailed(state, AppType::Claude)?);
-        result.merge(Self::import_from_app_detailed(state, AppType::Codex)?);
-        result.merge(Self::import_from_app_detailed(state, AppType::Gemini)?);
-        result.merge(Self::import_from_app_detailed(state, AppType::OpenCode)?);
+
+        for source_app in [
+            AppType::Claude,
+            AppType::Codex,
+            AppType::Gemini,
+            AppType::OpenCode,
+        ] {
+            match Self::prepare_import_from_app_detailed(state, source_app.clone()) {
+                Ok((app_result, changed_servers)) => {
+                    Self::persist_import_changes(state, changed_servers)?;
+                    result.merge(app_result);
+                }
+                Err(err) => {
+                    result.push_issue(mcp::source_import_error_issue(source_app, err.to_string()))
+                }
+            }
+        }
+
         Ok(result)
     }
 

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::app_config::{AppType, McpServer};
 use crate::error::AppError;
-use crate::mcp;
+use crate::mcp::{self, McpImportResult};
 use crate::store::AppState;
 
 /// MCP 相关业务逻辑（v3.7.0 统一结构）
@@ -16,7 +16,9 @@ impl McpService {
     }
 
     /// 添加或更新 MCP 服务器
-    pub fn upsert_server(state: &AppState, server: McpServer) -> Result<(), AppError> {
+    pub fn upsert_server(state: &AppState, mut server: McpServer) -> Result<(), AppError> {
+        server.server = mcp::normalize_server_spec(&server.server)?;
+
         // 读取旧状态：用于处理“编辑时取消勾选某个应用”的场景（需要从对应 live 配置中移除）
         let prev_apps = state
             .db
@@ -182,6 +184,74 @@ impl McpService {
         Ok(())
     }
 
+    fn import_from_app_detailed(
+        state: &AppState,
+        source_app: AppType,
+    ) -> Result<McpImportResult, AppError> {
+        let parsed = match &source_app {
+            AppType::Claude => mcp::parse_import_from_claude()?,
+            AppType::Codex => mcp::parse_import_from_codex()?,
+            AppType::Gemini => mcp::parse_import_from_gemini()?,
+            AppType::OpenCode => mcp::parse_import_from_opencode()?,
+            AppType::OpenClaw => return Ok(McpImportResult::default()),
+        };
+
+        let mut result = McpImportResult::default();
+        for issue in parsed.issues {
+            result.push_issue(issue);
+        }
+
+        if parsed.servers.is_empty() {
+            return Ok(result);
+        }
+
+        let mut servers: HashMap<String, McpServer> =
+            state.db.get_all_mcp_servers()?.into_iter().collect();
+        let mut changed_ids = Vec::new();
+
+        for imported in parsed.servers {
+            let id = imported.id.clone();
+            match mcp::reconcile_imported_server(&mut servers, imported, source_app.clone())? {
+                mcp::ImportMergeAction::Added => {
+                    result.added += 1;
+                    changed_ids.push(id);
+                }
+                mcp::ImportMergeAction::Refreshed => {
+                    result.refreshed += 1;
+                    changed_ids.push(id);
+                }
+                mcp::ImportMergeAction::EnabledOnly => {
+                    result.enabled_only += 1;
+                    changed_ids.push(id);
+                }
+                mcp::ImportMergeAction::Unchanged => {}
+                mcp::ImportMergeAction::Conflict { existing_apps } => {
+                    result.push_issue(mcp::conflict_issue(id, source_app.clone(), existing_apps));
+                }
+            }
+        }
+
+        for id in changed_ids {
+            let server = servers
+                .get(&id)
+                .cloned()
+                .expect("changed server must exist after reconciliation");
+            state.db.save_mcp_server(&server)?;
+            Self::sync_server_to_apps(state, &server)?;
+        }
+
+        Ok(result)
+    }
+
+    pub fn import_from_apps_detailed(state: &AppState) -> Result<McpImportResult, AppError> {
+        let mut result = McpImportResult::default();
+        result.merge(Self::import_from_app_detailed(state, AppType::Claude)?);
+        result.merge(Self::import_from_app_detailed(state, AppType::Codex)?);
+        result.merge(Self::import_from_app_detailed(state, AppType::Gemini)?);
+        result.merge(Self::import_from_app_detailed(state, AppType::OpenCode)?);
+        Ok(result)
+    }
+
     // ========================================================================
     // 兼容层：支持旧的 v3.6.x 命令（已废弃，将在 v4.0 移除）
     // ========================================================================
@@ -232,153 +302,21 @@ impl McpService {
 
     /// 从 Claude 导入 MCP（v3.7.0 已更新为统一结构）
     pub fn import_from_claude(state: &AppState) -> Result<usize, AppError> {
-        // 创建临时 MultiAppConfig 用于导入
-        let mut temp_config = crate::app_config::MultiAppConfig::default();
-
-        // 调用原有的导入逻辑（从 mcp.rs）
-        let count = crate::mcp::import_from_claude(&mut temp_config)?;
-
-        let mut new_count = 0;
-
-        // 如果有导入的服务器，保存到数据库
-        if count > 0 {
-            if let Some(servers) = &temp_config.mcp.servers {
-                let mut existing = state.db.get_all_mcp_servers()?;
-                for server in servers.values() {
-                    // 已存在：仅启用 Claude，不覆盖其他字段（与导入模块语义保持一致）
-                    let to_save = if let Some(existing_server) = existing.get(&server.id) {
-                        let mut merged = existing_server.clone();
-                        merged.apps.claude = true;
-                        merged
-                    } else {
-                        // 真正的新服务器
-                        new_count += 1;
-                        server.clone()
-                    };
-
-                    state.db.save_mcp_server(&to_save)?;
-                    existing.insert(to_save.id.clone(), to_save.clone());
-
-                    // 同步到对应应用 live 配置
-                    Self::sync_server_to_apps(state, &to_save)?;
-                }
-            }
-        }
-
-        Ok(new_count)
+        Ok(Self::import_from_app_detailed(state, AppType::Claude)?.changed_count())
     }
 
     /// 从 Codex 导入 MCP（v3.7.0 已更新为统一结构）
     pub fn import_from_codex(state: &AppState) -> Result<usize, AppError> {
-        // 创建临时 MultiAppConfig 用于导入
-        let mut temp_config = crate::app_config::MultiAppConfig::default();
-
-        // 调用原有的导入逻辑（从 mcp.rs）
-        let count = crate::mcp::import_from_codex(&mut temp_config)?;
-
-        let mut new_count = 0;
-
-        // 如果有导入的服务器，保存到数据库
-        if count > 0 {
-            if let Some(servers) = &temp_config.mcp.servers {
-                let mut existing = state.db.get_all_mcp_servers()?;
-                for server in servers.values() {
-                    // 已存在：仅启用 Codex，不覆盖其他字段（与导入模块语义保持一致）
-                    let to_save = if let Some(existing_server) = existing.get(&server.id) {
-                        let mut merged = existing_server.clone();
-                        merged.apps.codex = true;
-                        merged
-                    } else {
-                        // 真正的新服务器
-                        new_count += 1;
-                        server.clone()
-                    };
-
-                    state.db.save_mcp_server(&to_save)?;
-                    existing.insert(to_save.id.clone(), to_save.clone());
-
-                    // 同步到对应应用 live 配置
-                    Self::sync_server_to_apps(state, &to_save)?;
-                }
-            }
-        }
-
-        Ok(new_count)
+        Ok(Self::import_from_app_detailed(state, AppType::Codex)?.changed_count())
     }
 
     /// 从 Gemini 导入 MCP（v3.7.0 已更新为统一结构）
     pub fn import_from_gemini(state: &AppState) -> Result<usize, AppError> {
-        // 创建临时 MultiAppConfig 用于导入
-        let mut temp_config = crate::app_config::MultiAppConfig::default();
-
-        // 调用原有的导入逻辑（从 mcp.rs）
-        let count = crate::mcp::import_from_gemini(&mut temp_config)?;
-
-        let mut new_count = 0;
-
-        // 如果有导入的服务器，保存到数据库
-        if count > 0 {
-            if let Some(servers) = &temp_config.mcp.servers {
-                let mut existing = state.db.get_all_mcp_servers()?;
-                for server in servers.values() {
-                    // 已存在：仅启用 Gemini，不覆盖其他字段（与导入模块语义保持一致）
-                    let to_save = if let Some(existing_server) = existing.get(&server.id) {
-                        let mut merged = existing_server.clone();
-                        merged.apps.gemini = true;
-                        merged
-                    } else {
-                        // 真正的新服务器
-                        new_count += 1;
-                        server.clone()
-                    };
-
-                    state.db.save_mcp_server(&to_save)?;
-                    existing.insert(to_save.id.clone(), to_save.clone());
-
-                    // 同步到对应应用 live 配置
-                    Self::sync_server_to_apps(state, &to_save)?;
-                }
-            }
-        }
-
-        Ok(new_count)
+        Ok(Self::import_from_app_detailed(state, AppType::Gemini)?.changed_count())
     }
 
     /// 从 OpenCode 导入 MCP（v3.9.2+ 新增）
     pub fn import_from_opencode(state: &AppState) -> Result<usize, AppError> {
-        // 创建临时 MultiAppConfig 用于导入
-        let mut temp_config = crate::app_config::MultiAppConfig::default();
-
-        // 调用原有的导入逻辑（从 mcp/opencode.rs）
-        let count = crate::mcp::import_from_opencode(&mut temp_config)?;
-
-        let mut new_count = 0;
-
-        // 如果有导入的服务器，保存到数据库
-        if count > 0 {
-            if let Some(servers) = &temp_config.mcp.servers {
-                let mut existing = state.db.get_all_mcp_servers()?;
-                for server in servers.values() {
-                    // 已存在：仅启用 OpenCode，不覆盖其他字段（与导入模块语义保持一致）
-                    let to_save = if let Some(existing_server) = existing.get(&server.id) {
-                        let mut merged = existing_server.clone();
-                        merged.apps.opencode = true;
-                        merged
-                    } else {
-                        // 真正的新服务器
-                        new_count += 1;
-                        server.clone()
-                    };
-
-                    state.db.save_mcp_server(&to_save)?;
-                    existing.insert(to_save.id.clone(), to_save.clone());
-
-                    // 同步到对应应用 live 配置
-                    Self::sync_server_to_apps(state, &to_save)?;
-                }
-            }
-        }
-
-        Ok(new_count)
+        Ok(Self::import_from_app_detailed(state, AppType::OpenCode)?.changed_count())
     }
 }

--- a/src-tauri/tests/import_export_sync.rs
+++ b/src-tauri/tests/import_export_sync.rs
@@ -577,12 +577,53 @@ command = "echo"
     // 验证 Codex 应用已启用
     assert!(entry.apps.codex, "Codex app should be enabled after import");
 
-    // 验证现有配置被保留（server 不应被覆盖）
+    // 新策略：仅属于 Codex / 未被其他应用使用时，应刷新 server 配置
     let spec = entry.server.as_object().expect("server spec");
     assert_eq!(
         spec.get("command").and_then(|v| v.as_str()),
-        Some("prev"),
-        "existing server config should be preserved, not overwritten by import"
+        Some("echo"),
+        "Codex-owned entry should be refreshed from imported config"
+    );
+}
+
+#[test]
+fn import_from_codex_normalizes_http_headers_to_headers() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let path = cc_switch_lib::get_codex_config_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create codex dir");
+    }
+    fs::write(
+        &path,
+        r#"[mcp_servers.remote]
+type = "http"
+url = "https://example.com/mcp"
+
+[mcp_servers.remote.http_headers]
+Authorization = "Bearer token"
+"#,
+    )
+    .expect("write codex config");
+
+    let mut config = MultiAppConfig::default();
+    let changed = cc_switch_lib::import_from_codex(&mut config).expect("import codex");
+    assert!(changed >= 1, "should import remote server");
+
+    let entry = config
+        .mcp
+        .servers
+        .as_ref()
+        .unwrap()
+        .get("remote")
+        .expect("remote server");
+    assert!(
+        entry.server.get("http_headers").is_none(),
+        "canonical unified spec should not keep http_headers"
+    );
+    assert_eq!(
+        entry.server.pointer("/headers/Authorization").and_then(|v| v.as_str()),
+        Some("Bearer token")
     );
 }
 
@@ -708,13 +749,75 @@ fn import_from_claude_merges_into_config() {
         "Claude app should be enabled after import"
     );
 
-    // 验证现有配置被保留（server 不应被覆盖）
+    // 新策略：仅属于 Claude / 未被其他应用使用时，应刷新 server 配置
     let server = entry.server.as_object().expect("server obj");
     assert_eq!(
         server.get("command").and_then(|v| v.as_str()).unwrap_or(""),
-        "prev",
-        "existing server config should be preserved"
+        "echo",
+        "Claude-owned entry should be refreshed from imported config"
     );
+}
+
+#[test]
+fn sync_single_server_to_codex_normalizes_headers_to_http_headers() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let path = cc_switch_lib::get_codex_config_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create codex dir");
+    }
+
+    cc_switch_lib::sync_single_server_to_codex(
+        &MultiAppConfig::default(),
+        "remote",
+        &json!({
+            "type": "http",
+            "url": "https://example.com/mcp",
+            "headers": {
+                "Authorization": "Bearer token"
+            }
+        }),
+    )
+    .expect("sync codex remote server");
+
+    let text = fs::read_to_string(&path).expect("read codex config");
+    assert!(
+        text.contains("http_headers"),
+        "Codex export should use http_headers for remote servers"
+    );
+    assert!(
+        text.contains("Authorization"),
+        "headers should be serialized into codex config"
+    );
+}
+
+#[test]
+fn sync_single_server_to_codex_rejects_url_without_type() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let path = cc_switch_lib::get_codex_config_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create codex dir");
+    }
+
+    let err = cc_switch_lib::sync_single_server_to_codex(
+        &MultiAppConfig::default(),
+        "broken",
+        &json!({
+            "url": "https://example.com/mcp"
+        }),
+    )
+    .expect_err("url-only spec without type should be rejected");
+
+    match err {
+        AppError::McpValidation(msg) => {
+            assert!(
+                msg.contains("显式指定 type") || msg.contains("type"),
+                "unexpected error message: {msg}"
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
 }
 
 #[test]

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -638,6 +638,115 @@ command = "echo"
 }
 
 #[test]
+fn import_from_apps_detailed_continues_when_one_source_parse_fails() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let claude_dir = home.join(".claude");
+    fs::create_dir_all(&claude_dir).expect("create claude dir");
+    fs::write(
+        home.join(".claude.json"),
+        serde_json::to_string_pretty(&json!({
+            "mcpServers": {
+                "claude-ok": {
+                    "type": "stdio",
+                    "command": "echo"
+                }
+            }
+        }))
+        .expect("serialize claude config"),
+    )
+    .expect("seed claude config");
+
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    fs::write(codex_dir.join("config.toml"), "not = [valid toml")
+        .expect("seed invalid codex config");
+
+    let state = create_test_state().expect("create test state");
+    let result = McpService::import_from_apps_detailed(&state).expect("import from apps");
+
+    assert_eq!(result.added, 1, "valid Claude source should still import");
+    assert_eq!(result.refreshed, 0);
+    assert_eq!(result.enabled_only, 0);
+    assert_eq!(result.conflicts, 0);
+    assert_eq!(result.invalid, 1, "invalid Codex source should become a warning");
+    assert!(
+        result.issues.iter().any(|issue| {
+            issue.source_app == AppType::Codex
+                && issue.kind == cc_switch_lib::McpImportIssueKind::Invalid
+                && issue.message.contains("config.toml")
+        }),
+        "should report the broken Codex source as an invalid import issue"
+    );
+
+    let servers = state.db.get_all_mcp_servers().expect("get all mcp servers");
+    let entry = servers.get("claude-ok").expect("claude server should be imported");
+    assert!(entry.apps.claude);
+    assert_eq!(
+        entry.server.get("command").and_then(|v| v.as_str()),
+        Some("echo")
+    );
+}
+
+#[test]
+fn import_from_apps_detailed_preserves_all_disabled_entry() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    fs::write(
+        codex_dir.join("config.toml"),
+        r#"[mcp_servers.shared]
+type = "stdio"
+command = "echo"
+"#,
+    )
+    .expect("seed codex config");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_mcp_server(&McpServer {
+            id: "shared".to_string(),
+            name: "shared".to_string(),
+            server: json!({
+                "type": "stdio",
+                "command": "local"
+            }),
+            apps: McpApps::default(),
+            description: Some("disabled locally".to_string()),
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        })
+        .expect("seed disabled shared server");
+
+    let result = McpService::import_from_apps_detailed(&state).expect("import from apps");
+    assert_eq!(result.added, 0);
+    assert_eq!(result.refreshed, 0);
+    assert_eq!(result.enabled_only, 0);
+    assert_eq!(result.conflicts, 1, "disabled local entry should not be overwritten");
+    assert_eq!(result.invalid, 0);
+
+    let servers = state.db.get_all_mcp_servers().expect("get all mcp servers");
+    let entry = servers.get("shared").expect("shared entry");
+    assert!(
+        entry.apps.is_empty(),
+        "conflicting import should not enable any source app"
+    );
+    assert_eq!(
+        entry.server.get("command").and_then(|v| v.as_str()),
+        Some("local"),
+        "existing disabled entry should remain untouched"
+    );
+    assert_eq!(entry.description.as_deref(), Some("disabled locally"));
+}
+
+#[test]
 fn import_mcp_from_gemini_sse_url_only_is_valid() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -301,6 +301,48 @@ fn enabling_codex_mcp_skips_when_codex_dir_missing() {
 }
 
 #[test]
+fn upsert_mcp_server_rejects_url_without_type() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let state = create_test_state().expect("create test state");
+
+    let err = McpService::upsert_server(
+        &state,
+        McpServer {
+            id: "remote-server".to_string(),
+            name: "Remote Server".to_string(),
+            server: json!({
+                "url": "https://example.com/mcp"
+            }),
+            apps: McpApps {
+                claude: false,
+                codex: false,
+                gemini: false,
+                opencode: false,
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        },
+    )
+    .expect_err("url-only server without type should be rejected");
+
+    match err {
+        AppError::McpValidation(msg) => assert!(
+            msg.contains("显式指定 type") || msg.contains("type"),
+            "unexpected error message: {msg}"
+        ),
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+
+    let servers = state.db.get_all_mcp_servers().expect("get all mcp servers");
+    assert!(servers.is_empty(), "invalid server should not be persisted");
+}
+
+#[test]
 fn upsert_mcp_server_disabling_app_removes_from_claude_live_config() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();
@@ -418,6 +460,181 @@ command = "echo"
     let entry = servers.get("shared").expect("shared server exists");
     assert!(entry.apps.claude, "shared should enable Claude");
     assert!(entry.apps.codex, "shared should enable Codex");
+}
+
+#[test]
+fn import_from_codex_refreshes_codex_owned_entry() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    fs::write(
+        codex_dir.join("config.toml"),
+        r#"[mcp_servers.existing]
+type = "stdio"
+command = "echo"
+"#,
+    )
+    .expect("seed codex config");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_mcp_server(&McpServer {
+            id: "existing".to_string(),
+            name: "existing".to_string(),
+            server: json!({
+                "type": "stdio",
+                "command": "prev"
+            }),
+            apps: McpApps {
+                claude: false,
+                codex: true,
+                gemini: false,
+                opencode: false,
+            },
+            description: Some("Keep me".to_string()),
+            homepage: Some("https://example.com".to_string()),
+            docs: None,
+            tags: vec!["demo".to_string()],
+        })
+        .expect("seed codex-owned server");
+
+    let changed = McpService::import_from_codex(&state).expect("import from codex");
+    assert!(changed >= 1, "import should refresh changed server");
+
+    let servers = state.db.get_all_mcp_servers().expect("get all mcp servers");
+    let entry = servers.get("existing").expect("existing entry");
+    assert_eq!(
+        entry.server.get("command").and_then(|v| v.as_str()),
+        Some("echo"),
+        "Codex-owned entry should be refreshed from import"
+    );
+    assert_eq!(entry.description.as_deref(), Some("Keep me"));
+    assert_eq!(entry.homepage.as_deref(), Some("https://example.com"));
+    assert_eq!(entry.tags, vec!["demo".to_string()]);
+}
+
+#[test]
+fn import_from_apps_detailed_only_enables_matching_cross_app_server() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    fs::write(
+        codex_dir.join("config.toml"),
+        r#"[mcp_servers.shared]
+type = "stdio"
+command = "echo"
+"#,
+    )
+    .expect("seed codex config");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_mcp_server(&McpServer {
+            id: "shared".to_string(),
+            name: "shared".to_string(),
+            server: json!({
+                "type": "stdio",
+                "command": "echo"
+            }),
+            apps: McpApps {
+                claude: true,
+                codex: false,
+                gemini: false,
+                opencode: false,
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        })
+        .expect("seed shared server");
+
+    let result = McpService::import_from_apps_detailed(&state).expect("import from apps");
+    assert_eq!(result.added, 0);
+    assert_eq!(result.refreshed, 0);
+    assert_eq!(result.enabled_only, 1);
+    assert_eq!(result.conflicts, 0);
+    assert_eq!(result.invalid, 0);
+
+    let servers = state.db.get_all_mcp_servers().expect("get all mcp servers");
+    let entry = servers.get("shared").expect("shared entry");
+    assert!(entry.apps.claude);
+    assert!(entry.apps.codex, "Codex should be enabled for identical spec");
+    assert_eq!(
+        entry.server.get("command").and_then(|v| v.as_str()),
+        Some("echo"),
+        "same-spec import should not rewrite server config"
+    );
+}
+
+#[test]
+fn import_from_apps_detailed_reports_conflict_for_shared_mismatch() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    fs::write(
+        codex_dir.join("config.toml"),
+        r#"[mcp_servers.shared]
+type = "stdio"
+command = "echo"
+"#,
+    )
+    .expect("seed codex config");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_mcp_server(&McpServer {
+            id: "shared".to_string(),
+            name: "shared".to_string(),
+            server: json!({
+                "type": "stdio",
+                "command": "prev"
+            }),
+            apps: McpApps {
+                claude: true,
+                codex: false,
+                gemini: true,
+                opencode: false,
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        })
+        .expect("seed multi-app shared server");
+
+    let result = McpService::import_from_apps_detailed(&state).expect("import from apps");
+    assert_eq!(result.added, 0);
+    assert_eq!(result.refreshed, 0);
+    assert_eq!(result.enabled_only, 0);
+    assert_eq!(result.conflicts, 1);
+    assert_eq!(result.invalid, 0);
+    assert_eq!(result.issues[0].id, "shared");
+    assert_eq!(result.issues[0].source_app.as_str(), "codex");
+
+    let servers = state.db.get_all_mcp_servers().expect("get all mcp servers");
+    let entry = servers.get("shared").expect("shared entry");
+    assert!(
+        !entry.apps.codex,
+        "conflicting import should not silently enable source app"
+    );
+    assert_eq!(
+        entry.server.get("command").and_then(|v| v.as_str()),
+        Some("prev"),
+        "conflicting import should preserve existing server config"
+    );
 }
 
 #[test]

--- a/src/components/mcp/UnifiedMcpPanel.tsx
+++ b/src/components/mcp/UnifiedMcpPanel.tsx
@@ -9,7 +9,7 @@ import {
   useDeleteMcpServer,
   useImportMcpFromApps,
 } from "@/hooks/useMcp";
-import type { McpServer } from "@/types";
+import type { McpImportIssue, McpServer } from "@/types";
 import type { AppId } from "@/lib/api/types";
 import McpFormModal from "./McpFormModal";
 import { ConfirmDialog } from "../ConfirmDialog";
@@ -65,6 +65,41 @@ const UnifiedMcpPanel = React.forwardRef<
     return counts;
   }, [serverEntries]);
 
+  const formatImportIssues = (issues: McpImportIssue[]) => {
+    const visibleIssues = issues.slice(0, 3);
+    const lines = visibleIssues.map((issue) => {
+      const sourceApp = t(`mcp.unifiedPanel.apps.${issue.sourceApp}`);
+
+      if (issue.kind === "conflict") {
+        const existingApps = issue.existingApps
+          .map((app) => t(`mcp.unifiedPanel.apps.${app}`))
+          .join(", ");
+
+        return t("mcp.unifiedPanel.importConflictItem", {
+          id: issue.id,
+          sourceApp,
+          existingApps,
+        });
+      }
+
+      return t("mcp.unifiedPanel.importInvalidItem", {
+        id: issue.id,
+        sourceApp,
+      });
+    });
+
+    if (issues.length > visibleIssues.length) {
+      lines.push(
+        t("mcp.unifiedPanel.importWarningMore", {
+          count: issues.length - visibleIssues.length,
+        }),
+      );
+    }
+
+    lines.push(t("mcp.unifiedPanel.importWarningHint"));
+    return lines.join("\n");
+  };
+
   const handleToggleApp = async (
     serverId: string,
     app: AppId,
@@ -89,13 +124,33 @@ const UnifiedMcpPanel = React.forwardRef<
 
   const handleImport = async () => {
     try {
-      const count = await importMutation.mutateAsync();
-      if (count === 0) {
+      const result = await importMutation.mutateAsync();
+      const changedCount = result.added + result.refreshed + result.enabledOnly;
+      const hasWarnings = result.conflicts > 0 || result.invalid > 0;
+
+      if (changedCount === 0 && !hasWarnings) {
         toast.success(t("mcp.unifiedPanel.noImportFound"), {
           closeButton: true,
         });
-      } else {
-        toast.success(t("mcp.unifiedPanel.importSuccess", { count }), {
+        return;
+      }
+
+      if (changedCount > 0) {
+        toast.success(
+          t("mcp.unifiedPanel.importSummary", {
+            added: result.added,
+            refreshed: result.refreshed,
+            enabledOnly: result.enabledOnly,
+          }),
+          {
+            closeButton: true,
+          },
+        );
+      }
+
+      if (hasWarnings) {
+        toast.warning(t("mcp.unifiedPanel.importWarningTitle"), {
+          description: formatImportIssues(result.issues),
           closeButton: true,
         });
       }

--- a/src/components/mcp/UnifiedMcpPanel.tsx
+++ b/src/components/mcp/UnifiedMcpPanel.tsx
@@ -85,6 +85,7 @@ const UnifiedMcpPanel = React.forwardRef<
       return t("mcp.unifiedPanel.importInvalidItem", {
         id: issue.id,
         sourceApp,
+        message: issue.message,
       });
     });
 

--- a/src/components/mcp/useMcpValidation.ts
+++ b/src/components/mcp/useMcpValidation.ts
@@ -73,11 +73,23 @@ export function useMcpValidation() {
           }
 
           const typ = (obj as any)?.type;
+          const hasUrl = Object.prototype.hasOwnProperty.call(obj, "url");
+          const hasCommand = Object.prototype.hasOwnProperty.call(
+            obj,
+            "command",
+          );
+
+          if (!typ && hasUrl) {
+            return t("mcp.error.typeRequiredForUrl");
+          }
           if (typ === "stdio" && !(obj as any)?.command?.trim()) {
             return t("mcp.error.commandRequired");
           }
           if ((typ === "http" || typ === "sse") && !(obj as any)?.url?.trim()) {
             return t("mcp.wizard.urlRequired");
+          }
+          if (!typ && hasCommand) {
+            return "";
           }
         }
       } catch {

--- a/src/components/providers/AddProviderDialog.tsx
+++ b/src/components/providers/AddProviderDialog.tsx
@@ -42,9 +42,9 @@ export function AddProviderDialog({
   const { t } = useTranslation();
   // OpenCode and OpenClaw don't support universal providers
   const showUniversalTab = appId !== "opencode" && appId !== "openclaw";
-  const [activeTab, setActiveTab] = useState<
-    "app-specific" | "universal"
-  >("app-specific");
+  const [activeTab, setActiveTab] = useState<"app-specific" | "universal">(
+    "app-specific",
+  );
   const [universalFormOpen, setUniversalFormOpen] = useState(false);
   const [selectedUniversalPreset, setSelectedUniversalPreset] =
     useState<UniversalProviderPreset | null>(null);
@@ -284,9 +284,7 @@ export function AddProviderDialog({
       {showUniversalTab ? (
         <Tabs
           value={activeTab}
-          onValueChange={(v) =>
-            setActiveTab(v as "app-specific" | "universal")
-          }
+          onValueChange={(v) => setActiveTab(v as "app-specific" | "universal")}
         >
           <TabsList className="grid w-full grid-cols-2 mb-6">
             <TabsTrigger value="app-specific">

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -160,8 +160,7 @@ export function ClaudeFormFields({
     apiFormat !== "anthropic" ||
     apiKeyField !== "ANTHROPIC_AUTH_TOKEN"
   );
-  const [advancedExpanded, setAdvancedExpanded] =
-    useState(hasAnyAdvancedValue);
+  const [advancedExpanded, setAdvancedExpanded] = useState(hasAnyAdvancedValue);
 
   // 预设填充高级值后自动展开（仅从折叠→展开，不会自动折叠）
   useEffect(() => {
@@ -400,10 +399,7 @@ export function ClaudeFormFields({
 
       {/* 高级选项（API 格式 + 认证字段 + 模型映射） */}
       {shouldShowModelSelector && (
-        <Collapsible
-          open={advancedExpanded}
-          onOpenChange={setAdvancedExpanded}
-        >
+        <Collapsible open={advancedExpanded} onOpenChange={setAdvancedExpanded}>
           <CollapsibleTrigger asChild>
             <Button
               type="button"

--- a/src/components/providers/forms/CodexConfigSections.tsx
+++ b/src/components/providers/forms/CodexConfigSections.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import JsonEditor from "@/components/JsonEditor";
 import {
@@ -175,10 +181,7 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
         }
       } else {
         toml = removeCodexTopLevelField(toml, "model_context_window");
-        toml = removeCodexTopLevelField(
-          toml,
-          "model_auto_compact_token_limit",
-        );
+        toml = removeCodexTopLevelField(toml, "model_auto_compact_token_limit");
       }
       handleLocalChange(toml);
     },

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,5 +11,4 @@ export const TEMPLATE_TYPES = {
   GITHUB_COPILOT: "github_copilot",
 } as const;
 
-export type TemplateType =
-  (typeof TEMPLATE_TYPES)[keyof typeof TEMPLATE_TYPES];
+export type TemplateType = (typeof TEMPLATE_TYPES)[keyof typeof TEMPLATE_TYPES];

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1143,6 +1143,12 @@
       "enabledApps": "Enabled Apps",
       "noImportFound": "No MCP servers to import found. All servers are already managed by CC Switch.",
       "importSuccess": "Successfully imported {{count}} MCP servers",
+      "importSummary": "Import complete: added {{added}}, refreshed {{refreshed}}, enabled existing {{enabledOnly}}.",
+      "importWarningTitle": "Some MCP entries were skipped",
+      "importConflictItem": "{{id}} (from {{sourceApp}}) conflicts with existing apps: {{existingApps}}",
+      "importInvalidItem": "{{id}} (from {{sourceApp}}) is invalid and was skipped",
+      "importWarningMore": "And {{count}} more item(s).",
+      "importWarningHint": "One ID represents one unified MCP server. If definitions differ, reconcile them in CC-Switch or rename them in the external app.",
       "apps": {
         "claude": "Claude",
         "codex": "Codex",
@@ -1239,6 +1245,7 @@
       "jsonInvalid": "Invalid JSON format",
       "tomlInvalid": "Invalid TOML format",
       "commandRequired": "Please enter command",
+      "typeRequiredForUrl": "Servers with a url must explicitly set type to http or sse",
       "singleServerObjectRequired": "Please paste a single MCP server object (do not include top-level mcpServers)",
       "saveFailed": "Save failed",
       "deleteFailed": "Delete failed"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1146,7 +1146,7 @@
       "importSummary": "Import complete: added {{added}}, refreshed {{refreshed}}, enabled existing {{enabledOnly}}.",
       "importWarningTitle": "Some MCP entries were skipped",
       "importConflictItem": "{{id}} (from {{sourceApp}}) conflicts with existing apps: {{existingApps}}",
-      "importInvalidItem": "{{id}} (from {{sourceApp}}) is invalid and was skipped",
+      "importInvalidItem": "{{id}} (from {{sourceApp}}) is invalid and was skipped: {{message}}",
       "importWarningMore": "And {{count}} more item(s).",
       "importWarningHint": "One ID represents one unified MCP server. If definitions differ, reconcile them in CC-Switch or rename them in the external app.",
       "apps": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1143,6 +1143,12 @@
       "enabledApps": "有効なアプリ",
       "noImportFound": "インポートする MCP サーバーが見つかりませんでした。すべてのサーバーは CC Switch で管理されています。",
       "importSuccess": "{{count}} 個の MCP サーバーをインポートしました",
+      "importSummary": "インポート完了: 追加 {{added}} 件、更新 {{refreshed}} 件、既存有効化 {{enabledOnly}} 件。",
+      "importWarningTitle": "一部の MCP 項目をスキップしました",
+      "importConflictItem": "{{id}}（{{sourceApp}} から） は既存アプリ {{existingApps}} と競合しています",
+      "importInvalidItem": "{{id}}（{{sourceApp}} から） は不正なためスキップしました",
+      "importWarningMore": "ほか {{count}} 件あります。",
+      "importWarningHint": "1 つの ID は 1 つの統一 MCP サーバーを表します。定義が異なる場合は CC-Switch で統一するか、外部アプリ側で名前を変更してください。",
       "apps": {
         "claude": "Claude",
         "codex": "Codex",
@@ -1239,6 +1245,7 @@
       "jsonInvalid": "JSON 形式が無効です",
       "tomlInvalid": "TOML 形式が無効です",
       "commandRequired": "コマンドを入力してください",
+      "typeRequiredForUrl": "url を持つサーバーは type を http または sse に明示してください",
       "singleServerObjectRequired": "単一の MCP サーバーオブジェクトを貼り付けてください（トップレベルの mcpServers は不要）",
       "saveFailed": "保存に失敗しました",
       "deleteFailed": "削除に失敗しました"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1146,7 +1146,7 @@
       "importSummary": "インポート完了: 追加 {{added}} 件、更新 {{refreshed}} 件、既存有効化 {{enabledOnly}} 件。",
       "importWarningTitle": "一部の MCP 項目をスキップしました",
       "importConflictItem": "{{id}}（{{sourceApp}} から） は既存アプリ {{existingApps}} と競合しています",
-      "importInvalidItem": "{{id}}（{{sourceApp}} から） は不正なためスキップしました",
+      "importInvalidItem": "{{id}}（{{sourceApp}} から） は不正なためスキップしました: {{message}}",
       "importWarningMore": "ほか {{count}} 件あります。",
       "importWarningHint": "1 つの ID は 1 つの統一 MCP サーバーを表します。定義が異なる場合は CC-Switch で統一するか、外部アプリ側で名前を変更してください。",
       "apps": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1146,7 +1146,7 @@
       "importSummary": "导入完成：新增 {{added}} 个，刷新 {{refreshed}} 个，仅启用来源应用 {{enabledOnly}} 个。",
       "importWarningTitle": "部分 MCP 条目已跳过",
       "importConflictItem": "{{id}}（来自 {{sourceApp}}）与现有应用定义冲突：{{existingApps}}",
-      "importInvalidItem": "{{id}}（来自 {{sourceApp}}）配置无效，已跳过",
+      "importInvalidItem": "{{id}}（来自 {{sourceApp}}）配置无效，已跳过：{{message}}",
       "importWarningMore": "另有 {{count}} 个条目未在此显示。",
       "importWarningHint": "统一 MCP 中同一 ID 代表同一个服务器。如定义不同，请在 CC-Switch 中统一，或在外部应用中改名。",
       "apps": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1143,6 +1143,12 @@
       "enabledApps": "启用的应用",
       "noImportFound": "未发现需要导入的 MCP 服务器。所有服务器已在 CC Switch 统一管理中。",
       "importSuccess": "成功导入 {{count}} 个 MCP 服务器",
+      "importSummary": "导入完成：新增 {{added}} 个，刷新 {{refreshed}} 个，仅启用来源应用 {{enabledOnly}} 个。",
+      "importWarningTitle": "部分 MCP 条目已跳过",
+      "importConflictItem": "{{id}}（来自 {{sourceApp}}）与现有应用定义冲突：{{existingApps}}",
+      "importInvalidItem": "{{id}}（来自 {{sourceApp}}）配置无效，已跳过",
+      "importWarningMore": "另有 {{count}} 个条目未在此显示。",
+      "importWarningHint": "统一 MCP 中同一 ID 代表同一个服务器。如定义不同，请在 CC-Switch 中统一，或在外部应用中改名。",
       "apps": {
         "claude": "Claude",
         "codex": "Codex",
@@ -1239,6 +1245,7 @@
       "jsonInvalid": "JSON 格式错误，请检查",
       "tomlInvalid": "TOML 格式错误，请检查",
       "commandRequired": "请填写命令",
+      "typeRequiredForUrl": "包含 url 的服务器必须显式指定 type 为 http 或 sse",
       "singleServerObjectRequired": "此处只需单个服务器对象，请不要粘贴包含 mcpServers 的整份配置",
       "saveFailed": "保存失败",
       "deleteFailed": "删除失败"

--- a/src/lib/api/mcp.ts
+++ b/src/lib/api/mcp.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   McpConfigResponse,
+  McpImportResult,
   McpServer,
   McpServerSpec,
   McpServersMap,
@@ -123,7 +124,7 @@ export const mcpApi = {
   /**
    * 从所有应用导入 MCP 服务器
    */
-  async importFromApps(): Promise<number> {
+  async importFromApps(): Promise<McpImportResult> {
     return await invoke("import_mcp_from_apps");
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -366,6 +366,32 @@ export interface McpServer {
   [key: string]: any;
 }
 
+export type McpImportSourceApp =
+  | "claude"
+  | "codex"
+  | "gemini"
+  | "opencode"
+  | "openclaw";
+
+export type McpImportIssueKind = "conflict" | "invalid";
+
+export interface McpImportIssue {
+  id: string;
+  sourceApp: McpImportSourceApp;
+  kind: McpImportIssueKind;
+  message: string;
+  existingApps: McpImportSourceApp[];
+}
+
+export interface McpImportResult {
+  added: number;
+  refreshed: number;
+  enabledOnly: number;
+  conflicts: number;
+  invalid: number;
+  issues: McpImportIssue[];
+}
+
 // MCP 服务器映射（id -> McpServer）
 export type McpServersMap = Record<string, McpServer>;
 

--- a/src/utils/tomlUtils.ts
+++ b/src/utils/tomlUtils.ts
@@ -103,7 +103,19 @@ function normalizeServerConfig(config: any): McpServerSpec {
     throw new Error("服务器配置必须是对象");
   }
 
-  const type = (config.type as string) || "stdio";
+  let type = typeof config.type === "string" ? config.type : undefined;
+  const hasCommand = Object.prototype.hasOwnProperty.call(config, "command");
+  const hasUrl = Object.prototype.hasOwnProperty.call(config, "url");
+
+  if (!type) {
+    if (hasCommand) {
+      type = "stdio";
+    } else if (hasUrl) {
+      throw new Error("包含 url 字段时必须显式指定 type 为 http 或 sse");
+    } else {
+      type = "stdio";
+    }
+  }
 
   // 已知字段列表（用于后续排除）
   const knownFields = new Set<string>();
@@ -157,15 +169,17 @@ function normalizeServerConfig(config: any): McpServerSpec {
     };
     knownFields.add("type");
     knownFields.add("url");
+    knownFields.add("headers");
+    knownFields.add("http_headers");
 
     // 可选字段
-    if (config.headers && typeof config.headers === "object") {
+    const rawHeaders = config.headers ?? config.http_headers;
+    if (rawHeaders && typeof rawHeaders === "object") {
       const headers: Record<string, string> = {};
-      for (const [k, v] of Object.entries(config.headers)) {
+      for (const [k, v] of Object.entries(rawHeaders)) {
         headers[k] = String(v);
       }
       server.headers = headers;
-      knownFields.add("headers");
     }
 
     // 保留所有未知字段

--- a/tests/components/UnifiedMcpPanel.test.tsx
+++ b/tests/components/UnifiedMcpPanel.test.tsx
@@ -1,0 +1,124 @@
+import { createRef } from "react";
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import UnifiedMcpPanel, {
+  type UnifiedMcpPanelHandle,
+} from "@/components/mcp/UnifiedMcpPanel";
+import { toast } from "sonner";
+
+const importMock = vi.fn();
+const toggleAppMock = vi.fn();
+const deleteServerMock = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useMcp", () => ({
+  useAllMcpServers: () => ({
+    data: {},
+    isLoading: false,
+  }),
+  useToggleMcpApp: () => ({
+    mutateAsync: toggleAppMock,
+  }),
+  useDeleteMcpServer: () => ({
+    mutateAsync: deleteServerMock,
+  }),
+  useImportMcpFromApps: () => ({
+    mutateAsync: importMock,
+  }),
+}));
+
+describe("UnifiedMcpPanel", () => {
+  beforeEach(() => {
+    importMock.mockReset();
+    toggleAppMock.mockReset();
+    deleteServerMock.mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.warning).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("shows no-import toast when nothing changed", async () => {
+    importMock.mockResolvedValue({
+      added: 0,
+      refreshed: 0,
+      enabledOnly: 0,
+      conflicts: 0,
+      invalid: 0,
+      issues: [],
+    });
+
+    const ref = createRef<UnifiedMcpPanelHandle>();
+    render(<UnifiedMcpPanel ref={ref} onOpenChange={() => {}} />);
+
+    await act(async () => {
+      await ref.current?.openImport();
+    });
+
+    expect(toast.success).toHaveBeenCalledWith(
+      "mcp.unifiedPanel.noImportFound",
+      { closeButton: true },
+    );
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it("shows structured success and warning toasts", async () => {
+    importMock.mockResolvedValue({
+      added: 1,
+      refreshed: 2,
+      enabledOnly: 3,
+      conflicts: 1,
+      invalid: 1,
+      issues: [
+        {
+          id: "shared",
+          sourceApp: "codex",
+          kind: "conflict",
+          message: "",
+          existingApps: ["claude", "gemini"],
+        },
+        {
+          id: "broken",
+          sourceApp: "claude",
+          kind: "invalid",
+          message: "",
+          existingApps: [],
+        },
+      ],
+    });
+
+    const ref = createRef<UnifiedMcpPanelHandle>();
+    render(<UnifiedMcpPanel ref={ref} onOpenChange={() => {}} />);
+
+    await act(async () => {
+      await ref.current?.openImport();
+    });
+
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining("mcp.unifiedPanel.importSummary"),
+      { closeButton: true },
+    );
+    expect(toast.warning).toHaveBeenCalledTimes(1);
+
+    const [, options] = vi.mocked(toast.warning).mock.calls[0];
+    expect(options?.description).toContain("shared");
+    expect(options?.description).toContain("broken");
+    expect(options?.description).toContain(
+      "mcp.unifiedPanel.importWarningHint",
+    );
+  });
+});

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -11,6 +11,9 @@ const toggleSkillAppMock = vi.fn();
 const uninstallSkillMock = vi.fn();
 const importSkillsMock = vi.fn();
 const installFromZipMock = vi.fn();
+const skillBackupsRefetchMock = vi.fn();
+const deleteSkillBackupMock = vi.fn();
+const restoreSkillBackupMock = vi.fn();
 
 vi.mock("sonner", () => ({
   toast: {
@@ -25,11 +28,24 @@ vi.mock("@/hooks/useSkills", () => ({
     data: [],
     isLoading: false,
   }),
+  useSkillBackups: () => ({
+    data: [],
+    refetch: skillBackupsRefetchMock,
+    isFetching: false,
+  }),
+  useDeleteSkillBackup: () => ({
+    mutateAsync: deleteSkillBackupMock,
+    isPending: false,
+  }),
   useToggleSkillApp: () => ({
     mutateAsync: toggleSkillAppMock,
   }),
   useUninstallSkill: () => ({
     mutateAsync: uninstallSkillMock,
+  }),
+  useRestoreSkillBackup: () => ({
+    mutateAsync: restoreSkillBackupMock,
+    isPending: false,
   }),
   useScanUnmanagedSkills: () => ({
     data: [
@@ -68,6 +84,9 @@ describe("UnifiedSkillsPanel", () => {
     uninstallSkillMock.mockReset();
     importSkillsMock.mockReset();
     installFromZipMock.mockReset();
+    skillBackupsRefetchMock.mockReset();
+    deleteSkillBackupMock.mockReset();
+    restoreSkillBackupMock.mockReset();
   });
 
   it("opens the import dialog without crashing when app toggles render", async () => {

--- a/tests/hooks/useMcpValidation.test.tsx
+++ b/tests/hooks/useMcpValidation.test.tsx
@@ -153,6 +153,20 @@ describe("useMcpValidation", () => {
       );
     });
 
+    it("requires explicit type when url exists without type", () => {
+      const { validateJsonConfig } = getHookResult();
+      expect(validateJsonConfig('{"url":"https://example.com/mcp"}')).toBe(
+        "mcp.error.typeRequiredForUrl",
+      );
+    });
+
+    it("allows stdio command without explicit type", () => {
+      const { validateJsonConfig } = getHookResult();
+      expect(
+        validateJsonConfig('{"command":"node","args":["server.js"]}'),
+      ).toBe("");
+    });
+
     it("returns empty string when json config valid", () => {
       const { validateJsonConfig } = getHookResult();
       expect(

--- a/tests/utils/tomlUtils.test.ts
+++ b/tests/utils/tomlUtils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { tomlToMcpServer } from "@/utils/tomlUtils";
+
+describe("tomlUtils", () => {
+  it("reads http_headers into canonical headers", () => {
+    const server = tomlToMcpServer(`
+type = "http"
+url = "https://example.com/mcp"
+
+[http_headers]
+Authorization = "Bearer token"
+`);
+
+    expect(server).toEqual({
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: {
+        Authorization: "Bearer token",
+      },
+    });
+  });
+
+  it("rejects url without explicit type", () => {
+    expect(() =>
+      tomlToMcpServer(`
+url = "https://example.com/mcp"
+`),
+    ).toThrow("包含 url 字段时必须显式指定 type 为 http 或 sse");
+  });
+
+  it("allows command without explicit type and normalizes to stdio", () => {
+    const server = tomlToMcpServer(`
+command = "node"
+args = ["server.js"]
+`);
+
+    expect(server).toEqual({
+      type: "stdio",
+      command: "node",
+      args: ["server.js"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared MCP import reconciliation helper so Claude/Codex/Gemini/OpenCode follow the same merge policy
- canonicalize MCP specs at import and persistence boundaries, including `http_headers` -> `headers` normalization and strict remote `type` handling
- return structured import results with conflict/invalid reporting and surface them in the unified MCP import UI
- tighten Codex TOML import/export behavior and add coverage for reconciliation, validation, and frontend toast/parse flows
- fix the existing `UnifiedSkillsPanel` test mock drift and clean up unrelated Prettier formatting so the documented frontend checks pass cleanly

## Validation
- `pnpm typecheck` ✅
- `pnpm format:check` ✅
- `pnpm test:unit` ✅
- `pnpm exec vitest run tests/hooks/useMcpValidation.test.tsx tests/utils/tomlUtils.test.ts tests/components/UnifiedMcpPanel.test.tsx` ✅
- Rust tests not run in this environment because `cargo`/`rustfmt` are unavailable

## Notes
- README contribution guidance asks contributors to run `pnpm typecheck`, `pnpm format:check`, and `pnpm test:unit`
- This PR is a bugfix/reconciliation change rather than a net-new feature
