### PR TITLE
fix(proxy): parse SSE fields with optional spaces in streaming handlers

### DIFF
--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -22,6 +22,7 @@ pub mod response_handler;
 pub mod response_processor;
 pub(crate) mod server;
 pub mod session;
+pub(crate) mod sse;
 pub mod thinking_budget_rectifier;
 pub mod thinking_optimizer;
 pub mod thinking_rectifier;

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -2,17 +2,12 @@
 //!
 //! 实现 OpenAI SSE → Anthropic SSE 格式转换
 
+use crate::proxy::sse::strip_sse_field;
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
-
-#[inline]
-fn strip_sse_field<'a>(line: &'a str, field: &str) -> Option<&'a str> {
-    line.strip_prefix(&format!("{field}: "))
-        .or_else(|| line.strip_prefix(&format!("{field}:")))
-}
 
 /// OpenAI 流式响应数据结构
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -9,16 +9,11 @@
 //! 与 Chat Completions 的 delta chunk 模型完全不同，需要独立的状态机处理。
 
 use super::transform_responses::{build_anthropic_usage_from_responses, map_responses_stop_reason};
+use crate::proxy::sse::strip_sse_field;
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
-
-#[inline]
-fn strip_sse_field<'a>(line: &'a str, field: &str) -> Option<&'a str> {
-    line.strip_prefix(&format!("{field}: "))
-        .or_else(|| line.strip_prefix(&format!("{field}:")))
-}
 
 #[inline]
 fn response_object_from_event(data: &Value) -> &Value {

--- a/src-tauri/src/proxy/response_handler.rs
+++ b/src-tauri/src/proxy/response_handler.rs
@@ -5,6 +5,7 @@
 use super::session::ProxySession;
 use super::usage::parser::TokenUsage;
 use super::ProxyError;
+use crate::proxy::sse::strip_sse_field;
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use serde_json::Value;
@@ -12,12 +13,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tokio::time::timeout;
-
-#[inline]
-fn strip_sse_field<'a>(line: &'a str, field: &str) -> Option<&'a str> {
-    line.strip_prefix(&format!("{field}: "))
-        .or_else(|| line.strip_prefix(&format!("{field}:")))
-}
 
 /// 响应类型
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -221,19 +216,19 @@ mod tests {
     #[test]
     fn test_strip_sse_field_accepts_optional_space() {
         assert_eq!(
-            strip_sse_field("data: {\"ok\":true}", "data"),
+            super::strip_sse_field("data: {\"ok\":true}", "data"),
             Some("{\"ok\":true}")
         );
         assert_eq!(
-            strip_sse_field("data:{\"ok\":true}", "data"),
+            super::strip_sse_field("data:{\"ok\":true}", "data"),
             Some("{\"ok\":true}")
         );
         assert_eq!(
-            strip_sse_field("event: message_start", "event"),
+            super::strip_sse_field("event: message_start", "event"),
             Some("message_start")
         );
         assert_eq!(
-            strip_sse_field("event:message_start", "event"),
+            super::strip_sse_field("event:message_start", "event"),
             Some("message_start")
         );
     }

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -6,6 +6,7 @@ use super::{
     handler_config::UsageParserConfig,
     handler_context::{RequestContext, StreamingTimeoutConfig},
     server::ProxyState,
+    sse::strip_sse_field,
     usage::parser::TokenUsage,
     ProxyError,
 };
@@ -22,12 +23,6 @@ use std::{
     time::Duration,
 };
 use tokio::sync::Mutex;
-
-#[inline]
-fn strip_sse_field<'a>(line: &'a str, field: &str) -> Option<&'a str> {
-    line.strip_prefix(&format!("{field}: "))
-        .or_else(|| line.strip_prefix(&format!("{field}:")))
-}
 
 // ============================================================================
 // 公共接口
@@ -600,22 +595,22 @@ mod tests {
     #[test]
     fn test_strip_sse_field_accepts_optional_space() {
         assert_eq!(
-            strip_sse_field("data: {\"ok\":true}", "data"),
+            super::strip_sse_field("data: {\"ok\":true}", "data"),
             Some("{\"ok\":true}")
         );
         assert_eq!(
-            strip_sse_field("data:{\"ok\":true}", "data"),
+            super::strip_sse_field("data:{\"ok\":true}", "data"),
             Some("{\"ok\":true}")
         );
         assert_eq!(
-            strip_sse_field("event: message_start", "event"),
+            super::strip_sse_field("event: message_start", "event"),
             Some("message_start")
         );
         assert_eq!(
-            strip_sse_field("event:message_start", "event"),
+            super::strip_sse_field("event:message_start", "event"),
             Some("message_start")
         );
-        assert_eq!(strip_sse_field("id:1", "data"), None);
+        assert_eq!(super::strip_sse_field("id:1", "data"), None);
     }
 
     fn build_state(db: Arc<Database>) -> ProxyState {

--- a/src-tauri/src/proxy/sse.rs
+++ b/src-tauri/src/proxy/sse.rs
@@ -1,0 +1,31 @@
+#[inline]
+pub(crate) fn strip_sse_field<'a>(line: &'a str, field: &str) -> Option<&'a str> {
+    line.strip_prefix(&format!("{field}: "))
+        .or_else(|| line.strip_prefix(&format!("{field}:")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_sse_field;
+
+    #[test]
+    fn strip_sse_field_accepts_optional_space() {
+        assert_eq!(
+            strip_sse_field("data: {\"ok\":true}", "data"),
+            Some("{\"ok\":true}")
+        );
+        assert_eq!(
+            strip_sse_field("data:{\"ok\":true}", "data"),
+            Some("{\"ok\":true}")
+        );
+        assert_eq!(
+            strip_sse_field("event: message_start", "event"),
+            Some("message_start")
+        );
+        assert_eq!(
+            strip_sse_field("event:message_start", "event"),
+            Some("message_start")
+        );
+        assert_eq!(strip_sse_field("id:1", "data"), None);
+    }
+}


### PR DESCRIPTION
## Summary
- accept `data:` / `event:` SSE lines with or without a following space
- apply the same parsing logic in streaming adapters and response logging
- add tests covering optional-space SSE field parsing

## Why
DashScope Anthropic-compatible streaming responses may emit SSE fields without a space after `:`. That caused some streaming events to be skipped, so usage/token stats were not recorded correctly.

Fixes #1662
