### PR TITLE
feat(opencode): add StepFun Step Plan provider preset

### DIFF
--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -515,6 +515,33 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     },
   },
   {
+    name: "StepFun Step Plan",
+    websiteUrl: "https://platform.stepfun.com/docs/zh/step-plan/overview",
+    apiKeyUrl: "https://platform.stepfun.com/interface-key",
+    settingsConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "StepFun Step Plan",
+      options: {
+        baseURL: "https://api.stepfun.com/step_plan/v1",
+        apiKey: "",
+        setCacheKey: true,
+      },
+      models: {
+        "step-3.5-flash": { name: "Step 3.5 Flash" },
+      },
+    },
+    category: "cn_official",
+    icon: "stepfun",
+    iconColor: "#005AFF",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "step-...",
+        editorValue: "",
+      },
+    },
+  },
+  {
     name: "ModelScope",
     websiteUrl: "https://modelscope.cn",
     apiKeyUrl: "https://modelscope.cn/my/myaccesstoken",


### PR DESCRIPTION
## Summary

Adds **StepFun Step Plan** (阶跃星辰 Step Plan) as a new provider preset for OpenCode in cc-switch.

### What is StepFun Step Plan?

[StepFun Step Plan](https://platform.stepfun.com/docs/zh/step-plan/overview) is a subscription-based coding AI service by StepFun (阶跃星辰). It provides access to the `step-3.5-flash` model through a dedicated API endpoint (`/step_plan/v1`), separate from the standard StepFun API. The plan is priced at ¥49–699/month and is designed for high-frequency AI coding usage.

### Changes

**`src/config/opencodeProviderPresets.ts`** — added one new preset entry after the existing `StepFun` entry:

```ts
{
  name: "StepFun Step Plan",
  websiteUrl: "https://platform.stepfun.com/docs/zh/step-plan/overview",
  apiKeyUrl: "https://platform.stepfun.com/interface-key",
  settingsConfig: {
    npm: "@ai-sdk/openai-compatible",
    name: "StepFun Step Plan",
    options: {
      baseURL: "https://api.stepfun.com/step_plan/v1",
      apiKey: "",
      setCacheKey: true,
    },
    models: {
      "step-3.5-flash": { name: "Step 3.5 Flash" },
    },
  },
  category: "cn_official",
  icon: "stepfun",
  iconColor: "#005AFF",
  templateValues: {
    apiKey: {
      label: "API Key",
      placeholder: "step-...",
      editorValue: "",
    },
  },
},
```

### Notes

- Uses the same `stepfun` icon and color as the existing StepFun preset
- `baseURL` is not exposed as a template field since it is fixed for the Step Plan
- A corresponding PR has been submitted to [anomalyco/models.dev#1262](https://github.com/anomalyco/models.dev/pull/1262) to register the provider there as well

Made with [Cursor](https://cursor.com)