### PR TITLE
fix: show fallback message when import config error is empty

### DIFF
--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -240,7 +240,7 @@ export function ProviderList({
       }
     },
     onError: (error: Error) => {
-      toast.error(error.message);
+      toast.error(error.message || t("provider.importCurrentFailed"));
     },
   });
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -148,7 +148,8 @@
         "oauthHint": "Google official uses OAuth personal authentication, no need to fill in API Key. The browser will automatically open for login on first use.",
         "apiKeyPlaceholder": "Enter Gemini API Key"
       }
-    }
+    },
+    "importCurrentFailed": "Failed to import current configuration"
   },
   "notifications": {
     "providerAdded": "Provider added",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -148,7 +148,8 @@
         "oauthHint": "Google 公式は OAuth 個人認証を使用するため API Key は不要です。初回利用時にブラウザが開きます。",
         "apiKeyPlaceholder": "Gemini API Key を入力"
       }
-    }
+    },
+    "importCurrentFailed": "現在の設定のインポートに失敗しました"
   },
   "notifications": {
     "providerAdded": "プロバイダーを追加しました",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -148,7 +148,8 @@
         "oauthHint": "Google 官方使用 OAuth 个人认证，无需填写 API Key。首次使用时会自动打开浏览器进行登录。",
         "apiKeyPlaceholder": "请输入 Gemini API Key"
       }
-    }
+    },
+    "importCurrentFailed": "导入当前配置失败"
   },
   "notifications": {
     "providerAdded": "供应商已添加",


### PR DESCRIPTION
## Problem

When clicking "Import Current Config" and the import fails (for example no model configuration available), the error notification popup shows with empty text. User sees the toast but has no idea what went wrong.

Screenshot from issue shows the empty error message clearly.

## Root Cause

In `ProviderList.tsx` line 243, the `onError` handler does `toast.error(error.message)`. But sometimes the Tauri invoke returns an error where `error.message` is empty string. The toast then renders with no visible text.

## Fix

Added fallback using `||` operator:

```typescript
toast.error(error.message || t("provider.importCurrentFailed"));
```

When `error.message` is empty, it shows the localized "Failed to import current configuration" text instead.

Also added the `importCurrentFailed` i18n key to all 3 locale files:
- English: "Failed to import current configuration"
- Chinese: "导入当前配置失败"
- Japanese: "現在の設定のインポートに失敗しました"

## Files changed

- `src/components/providers/ProviderList.tsx` - added fallback in onError handler
- `src/i18n/locales/en.json` - added importCurrentFailed key
- `src/i18n/locales/zh.json` - added importCurrentFailed key  
- `src/i18n/locales/ja.json` - added importCurrentFailed key

Closes #1715