### PR TITLE
fix: 修正 OpenCode 的 Kimi For Coding 预设

### DIFF
--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -453,10 +453,10 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     websiteUrl: "https://www.kimi.com/coding/docs/",
     apiKeyUrl: "https://platform.moonshot.cn/console/api-keys",
     settingsConfig: {
-      npm: "@ai-sdk/openai-compatible",
+      npm: "@ai-sdk/anthropic",
       name: "Kimi For Coding",
       options: {
-        baseURL: "https://api.kimi.com/v1",
+        baseURL: "https://api.kimi.com/coding/v1",
         apiKey: "",
         setCacheKey: true,
       },
@@ -470,8 +470,8 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     templateValues: {
       baseURL: {
         label: "Base URL",
-        placeholder: "https://api.kimi.com/v1",
-        defaultValue: "https://api.kimi.com/v1",
+        placeholder: "https://api.kimi.com/coding/v1",
+        defaultValue: "https://api.kimi.com/coding/v1",
         editorValue: "",
       },
       apiKey: {

--- a/tests/config/opencodeProviderPresets.test.ts
+++ b/tests/config/opencodeProviderPresets.test.ts
@@ -65,4 +65,19 @@ describe("AWS Bedrock OpenCode Provider Presets", () => {
       modelIds.some((id) => id.includes("anthropic.claude")),
     ).toBe(true);
   });
+
+  it("Kimi For Coding preset should use Anthropic with the coding endpoint", () => {
+    const kimiForCodingPreset = opencodeProviderPresets.find(
+      (p) => p.name === "Kimi For Coding",
+    );
+
+    expect(kimiForCodingPreset).toBeDefined();
+    expect(kimiForCodingPreset!.settingsConfig.npm).toBe("@ai-sdk/anthropic");
+    expect(kimiForCodingPreset!.settingsConfig.options?.baseURL).toBe(
+      "https://api.kimi.com/coding/v1",
+    );
+    expect(kimiForCodingPreset!.templateValues?.baseURL.defaultValue).toBe(
+      "https://api.kimi.com/coding/v1",
+    );
+  });
 });


### PR DESCRIPTION
## 背景
cc-switch 当前的 OpenCode `Kimi For Coding` 预设填写错误，会导致生成的 OpenCode provider 配置与 Kimi 官方要求不一致。

我核对了本地成功日志、OpenCode 内置 provider 定义和 Kimi For Coding 的实际行为，确认 OpenCode 这条链路应使用 Anthropic 协议，并且 base URL 需要包含 `/coding/v1`。

## 问题
当前预设存在两个错误：
1. 协议错误：误写为 `@ai-sdk/openai-compatible`
2. 地址错误：误写为 `https://api.kimi.com/v1`，缺少 `/coding`

这会让 OpenCode 实际请求走到 OpenAI Chat Completions 风格的端点，无法匹配 Kimi For Coding 面向 coding agent 的兼容链路。

## 修复
- 将 OpenCode 的 `Kimi For Coding` 预设从 `@ai-sdk/openai-compatible` 改为 `@ai-sdk/anthropic`
- 将 base URL 从 `https://api.kimi.com/v1` 改为 `https://api.kimi.com/coding/v1`
- 同步更新表单中的默认值和占位符
- 补充单元测试，锁定协议与 base URL，避免后续回归

## 为什么这里是 `/coding/v1`
这里特意说明一下，避免和 `Claude Code` 的 Kimi 预设混淆：

- OpenCode 走的是 `@ai-sdk/anthropic`
- 这套 SDK 的 `baseURL` 语义是“Anthropic API 版本前缀”，SDK 自己只会再补 `/messages`
- 因此 OpenCode 这里必须写成 `https://api.kimi.com/coding/v1`

而 `Claude Code` 的 `ANTHROPIC_BASE_URL` 语义不同，它提供的是更上层的网关前缀，客户端内部会再请求 `/v1/messages`。所以 `Claude Code` 预设里保留 `https://api.kimi.com/coding/` 是合理的，这个 PR 不改那一侧。

## 验证
- 核对本地成功日志：`kimi-for-coding-copy` 使用 `@ai-sdk/anthropic`
- 对比失败日志：旧配置会请求到 `/chat/completions`，并被 Kimi 返回 `access_terminated_error`
- 单测通过：
  `corepack pnpm --dir /Users/fishowo/coding-workspace/external/cc-switch test:unit tests/config/opencodeProviderPresets.test.ts`
