### PR TITLE
fix(provider): show persistent config highlight for additive-mode providers

### DIFF
--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -123,8 +123,7 @@ export function ProviderCard({
   // OMO and OMO Slim share the same card behavior
   const isAnyOmo = isOmo || isOmoSlim;
   const handleDisableAnyOmo = isOmoSlim ? onDisableOmoSlim : onDisableOmo;
-  const isAdditiveMode =
-    (appId === "opencode" && !isAnyOmo) || appId === "openclaw";
+  const isAdditiveMode = appId === "opencode" && !isAnyOmo;
 
   const { data: health } = useProviderHealth(provider.id, appId);
 
@@ -229,7 +228,8 @@ export function ProviderCard({
         shouldUseGreen &&
           "border-emerald-500/60 shadow-sm shadow-emerald-500/10",
         shouldUseBlue && "border-blue-500/60 shadow-sm shadow-blue-500/10",
-        !(isActiveProvider || hasPersistentConfigHighlight) && "hover:shadow-sm",
+        !(isActiveProvider || hasPersistentConfigHighlight) &&
+          "hover:shadow-sm",
         dragHandleProps?.isDragging &&
           "cursor-grabbing border-primary shadow-lg scale-105 z-10",
       )}


### PR DESCRIPTION
## Summary
- Provider cards in additive-mode apps (opencode, openclaw) now show a persistent blue highlight when the provider is in the live config, instead of only on hover
- This makes it easy to scan which configurations are enabled at a glance without hovering each card

Closes https://github.com/farion1231/cc-switch/issues/1692

## Test plan
- [x] Verify opencode/openclaw provider cards show blue border when in config (without hover)
- [x] Verify non-additive apps (Claude/Codex/Gemini) retain existing behavior
- [x] Verify OMO cards are unaffected
- [x] Verify proxy-takeover green highlight still works correctly