### PR TITLE
fix: align newapi usage query with token endpoint

### DIFF
--- a/docs/user-manual/zh/2-providers/2.5-usage-query.md
+++ b/docs/user-manual/zh/2-providers/2.5-usage-query.md
@@ -5,6 +5,7 @@
 用量查询功能允许你配置自定义脚本，实时查询供应商的剩余额度、已用量等信息。
 
 **使用场景**：
+
 - 查看 API 账户剩余余额
 - 监控套餐使用情况
 - 多套餐额度汇总显示
@@ -37,18 +38,18 @@ CC Switch 提供三种预设模板：
     url: "{{baseUrl}}/user/balance",
     method: "GET",
     headers: {
-      "Authorization": "Bearer {{apiKey}}",
-      "User-Agent": "cc-switch/1.0"
-    }
+      Authorization: "Bearer {{apiKey}}",
+      "User-Agent": "cc-switch/1.0",
+    },
   },
-  extractor: function(response) {
+  extractor: function (response) {
     return {
       isValid: response.is_active || true,
       remaining: response.balance,
-      unit: "USD"
+      unit: "USD",
     };
-  }
-})
+  },
+});
 ```
 
 **配置参数**：
@@ -64,38 +65,38 @@ CC Switch 提供三种预设模板：
 ```javascript
 ({
   request: {
-    url: "{{baseUrl}}/api/user/self",
+    url: "{{baseUrl}}/api/usage/token",
     method: "GET",
     headers: {
-      "Content-Type": "application/json",
-      "Authorization": "Bearer {{accessToken}}",
-      "New-Api-User": "{{userId}}"
+      Authorization: "Bearer {{apiKey}}",
+      "User-Agent": "cc-switch/1.0",
     },
   },
   extractor: function (response) {
-    if (response.success && response.data) {
-      return {
-        planName: response.data.group || "默认套餐",
-        remaining: response.data.quota / 500000,
-        used: response.data.used_quota / 500000,
-        total: (response.data.quota + response.data.used_quota) / 500000,
-        unit: "USD",
-      };
-    }
+    const hasTotalAvailable = response?.data?.total_available !== undefined;
     return {
-      isValid: false,
-      invalidMessage: response.message || "查询失败"
+      isValid: response.code === true && hasTotalAvailable,
+      remaining: hasTotalAvailable
+        ? response.data.total_available / 500000
+        : undefined,
+      unit: "USD",
     };
   },
-})
+});
 ```
 
 **配置参数**：
 | 参数 | 说明 |
 |------|------|
 | Base URL | New API 服务地址 |
-| Access Token | 访问令牌 |
-| User ID | 用户 ID |
+| API Key | 用于认证的密钥 |
+
+**结果说明**：
+
+- 只有当 `response.code === true` 且 `response.data.total_available` 存在时，才视为有效返回
+- 当余额为 `0` 时，依然视为查询成功，只是表示当前可用余额为 0
+- `500000` 是这套内置预设使用的默认换算值，不代表所有服务都使用同一规则
+- 如果你的服务返回格式或换算方式不同，请改用「自定义模板」
 
 ## 通用配置
 
@@ -106,6 +107,7 @@ CC Switch 提供三种预设模板：
 ### 自动查询间隔
 
 自动刷新用量数据的间隔（分钟）：
+
 - 设为 `0` 表示禁用自动查询
 - 范围：0-1440 分钟（最长 24 小时）
 - 仅当供应商处于「当前启用」状态时生效
@@ -114,16 +116,16 @@ CC Switch 提供三种预设模板：
 
 提取器函数需要返回包含以下字段的对象：
 
-| 字段 | 类型 | 必填 | 说明 |
-|------|------|------|------|
-| `isValid` | boolean | 否 | 账户是否有效，默认 true |
-| `invalidMessage` | string | 否 | 无效时的提示信息 |
-| `remaining` | number | 是 | 剩余额度 |
-| `unit` | string | 是 | 单位（如 USD、CNY、次） |
-| `planName` | string | 否 | 套餐名称（支持多套餐） |
-| `total` | number | 否 | 总额度 |
-| `used` | number | 否 | 已使用额度 |
-| `extra` | object | 否 | 额外信息 |
+| 字段             | 类型    | 必填 | 说明                    |
+| ---------------- | ------- | ---- | ----------------------- |
+| `isValid`        | boolean | 否   | 账户是否有效，默认 true |
+| `invalidMessage` | string  | 否   | 无效时的提示信息        |
+| `remaining`      | number  | 是   | 剩余额度                |
+| `unit`           | string  | 是   | 单位（如 USD、CNY、次） |
+| `planName`       | string  | 否   | 套餐名称（支持多套餐）  |
+| `total`          | number  | 否   | 总额度                  |
+| `used`           | number  | 否   | 已使用额度              |
+| `extra`          | object  | 否   | 额外信息                |
 
 ## 测试脚本
 
@@ -144,12 +146,10 @@ CC Switch 提供三种预设模板：
 
 脚本中可使用以下占位符，运行时自动替换：
 
-| 占位符 | 说明 |
-|--------|------|
-| `{{apiKey}}` | 配置的 API Key |
+| 占位符        | 说明            |
+| ------------- | --------------- |
+| `{{apiKey}}`  | 配置的 API Key  |
 | `{{baseUrl}}` | 配置的 Base URL |
-| `{{accessToken}}` | 配置的 Access Token（New API） |
-| `{{userId}}` | 配置的 User ID（New API） |
 
 ## 常见供应商配置示例
 
@@ -158,6 +158,7 @@ CC Switch 提供三种预设模板：
 ### 查询失败
 
 **检查**：
+
 1. API Key 是否正确
 2. Base URL 是否正确
 3. 网络是否可访问
@@ -166,6 +167,7 @@ CC Switch 提供三种预设模板：
 ### 返回数据为空
 
 **检查**：
+
 1. 提取器函数是否有 `return` 语句
 2. 响应数据结构是否与提取器匹配
 3. 使用「测试脚本」查看原始响应

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -31,10 +31,13 @@ interface UsageScriptModalProps {
 }
 
 // 生成预设模板的函数（支持国际化）
-const generatePresetTemplates = (
+export const generatePresetTemplates = (
   t: (key: string) => string,
-): Record<string, string> => ({
-  [TEMPLATE_TYPES.CUSTOM]: `({
+): Record<string, string> => {
+  void t;
+
+  return {
+    [TEMPLATE_TYPES.CUSTOM]: `({
   request: {
     url: "",
     method: "GET",
@@ -48,7 +51,7 @@ const generatePresetTemplates = (
   }
 })`,
 
-  [TEMPLATE_TYPES.GENERAL]: `({
+    [TEMPLATE_TYPES.GENERAL]: `({
   request: {
     url: "{{baseUrl}}/user/balance",
     method: "GET",
@@ -66,36 +69,29 @@ const generatePresetTemplates = (
   }
 })`,
 
-  [TEMPLATE_TYPES.NEW_API]: `({
+    [TEMPLATE_TYPES.NEW_API]: `({
   request: {
-    url: "{{baseUrl}}/api/user/self",
+    url: "{{baseUrl}}/api/usage/token",
     method: "GET",
     headers: {
-      "Content-Type": "application/json",
-      "Authorization": "Bearer {{accessToken}}",
-      "New-Api-User": "{{userId}}"
-    },
-  },
-  extractor: function (response) {
-    if (response.success && response.data) {
-      return {
-        planName: response.data.group || "${t("usageScript.defaultPlan")}",
-        remaining: response.data.quota / 500000,
-        used: response.data.used_quota / 500000,
-        total: (response.data.quota + response.data.used_quota) / 500000,
-        unit: "USD",
-      };
+      "Authorization": "Bearer {{apiKey}}",
+      "User-Agent": "cc-switch/1.0"
     }
+  },
+  extractor: function(response) {
+    const hasTotalAvailable = response?.data?.total_available !== undefined;
     return {
-      isValid: false,
-      invalidMessage: response.message || "${t("usageScript.queryFailedMessage")}"
+      isValid: response.code === true && hasTotalAvailable,
+      remaining: hasTotalAvailable ? response.data.total_available / 500000 : undefined,
+      unit: "USD"
     };
   },
 })`,
 
-  // GitHub Copilot 模板不需要脚本，使用专用 API
-  [TEMPLATE_TYPES.GITHUB_COPILOT]: "",
-});
+    // GitHub Copilot 模板不需要脚本，使用专用 API
+    [TEMPLATE_TYPES.GITHUB_COPILOT]: "",
+  };
+};
 
 // 模板名称国际化键映射
 const TEMPLATE_NAME_KEYS: Record<string, string> = {
@@ -238,8 +234,8 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
       if (existingScript?.templateType) {
         return existingScript.templateType;
       }
-      // 向后兼容：根据字段推断模板类型
-      // 检测 NEW_API 模板（有 accessToken 或 userId）
+      // 向后兼容：旧的已保存配置仍可能只带 accessToken/userId。
+      // 这里继续识别为 NEW_API，避免已有数据打开时模板类型丢失。
       if (existingScript?.accessToken || existingScript?.userId) {
         return TEMPLATE_TYPES.NEW_API;
       }
@@ -253,8 +249,6 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
   );
 
   const [showApiKey, setShowApiKey] = useState(false);
-  const [showAccessToken, setShowAccessToken] = useState(false);
-
   const handleEnableToggle = (checked: boolean) => {
     if (checked && !settingsData?.usageConfirmed) {
       setShowUsageConfirm(true);
@@ -435,7 +429,8 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
         setScript({
           ...script,
           code: preset,
-          apiKey: undefined,
+          accessToken: undefined,
+          userId: undefined,
         });
       } else if (presetName === TEMPLATE_TYPES.GITHUB_COPILOT) {
         // Copilot 模板不需要脚本和凭证，使用专用 API
@@ -714,6 +709,41 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                   {selectedTemplate === TEMPLATE_TYPES.NEW_API && (
                     <>
                       <div className="space-y-2">
+                        <Label htmlFor="usage-api-key">API Key</Label>
+                        <div className="relative">
+                          <Input
+                            id="usage-api-key"
+                            type={showApiKey ? "text" : "password"}
+                            value={script.apiKey || ""}
+                            onChange={(e) =>
+                              setScript({ ...script, apiKey: e.target.value })
+                            }
+                            placeholder={t("usageScript.apiKeyPlaceholder")}
+                            autoComplete="off"
+                            className="border-white/10"
+                          />
+                          {script.apiKey && (
+                            <button
+                              type="button"
+                              onClick={() => setShowApiKey(!showApiKey)}
+                              className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground transition-colors"
+                              aria-label={
+                                showApiKey
+                                  ? t("apiKeyInput.hide")
+                                  : t("apiKeyInput.show")
+                              }
+                            >
+                              {showApiKey ? (
+                                <EyeOff size={16} />
+                              ) : (
+                                <Eye size={16} />
+                              )}
+                            </button>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
                         <Label htmlFor="usage-newapi-base-url">
                           {t("usageScript.baseUrl")}
                         </Label>
@@ -725,67 +755,6 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                             setScript({ ...script, baseUrl: e.target.value })
                           }
                           placeholder="https://api.newapi.com"
-                          autoComplete="off"
-                          className="border-white/10"
-                        />
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="usage-access-token">
-                          {t("usageScript.accessToken")}
-                        </Label>
-                        <div className="relative">
-                          <Input
-                            id="usage-access-token"
-                            type={showAccessToken ? "text" : "password"}
-                            value={script.accessToken || ""}
-                            onChange={(e) =>
-                              setScript({
-                                ...script,
-                                accessToken: e.target.value,
-                              })
-                            }
-                            placeholder={t(
-                              "usageScript.accessTokenPlaceholder",
-                            )}
-                            autoComplete="off"
-                            className="border-white/10"
-                          />
-                          {script.accessToken && (
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setShowAccessToken(!showAccessToken)
-                              }
-                              className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground transition-colors"
-                              aria-label={
-                                showAccessToken
-                                  ? t("apiKeyInput.hide")
-                                  : t("apiKeyInput.show")
-                              }
-                            >
-                              {showAccessToken ? (
-                                <EyeOff size={16} />
-                              ) : (
-                                <Eye size={16} />
-                              )}
-                            </button>
-                          )}
-                        </div>
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="usage-user-id">
-                          {t("usageScript.userId")}
-                        </Label>
-                        <Input
-                          id="usage-user-id"
-                          type="text"
-                          value={script.userId || ""}
-                          onChange={(e) =>
-                            setScript({ ...script, userId: e.target.value })
-                          }
-                          placeholder={t("usageScript.userIdPlaceholder")}
                           autoComplete="off"
                           className="border-white/10"
                         />
@@ -893,17 +862,18 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                   <pre className="mt-1 p-2 bg-black/20 text-foreground rounded border border-white/10 text-[10px] overflow-x-auto">
                     {`({
   request: {
-    url: "{{baseUrl}}/api/usage",
-    method: "POST",
+    url: "{{baseUrl}}/api/usage/token",
+    method: "GET",
     headers: {
       "Authorization": "Bearer {{apiKey}}",
       "User-Agent": "cc-switch/1.0"
     }
   },
   extractor: function(response) {
+    const hasTotalAvailable = response?.data?.total_available !== undefined;
     return {
-      isValid: !response.error,
-      remaining: response.balance,
+      isValid: response.code === true && hasTotalAvailable,
+      remaining: hasTotalAvailable ? response.data.total_available / 500000 : undefined,
       unit: "USD"
     };
   }

--- a/tests/components/UsageScriptModal.newapi-fields.test.tsx
+++ b/tests/components/UsageScriptModal.newapi-fields.test.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from "react";
+import { render } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import UsageScriptModal from "@/components/UsageScriptModal";
+import { TEMPLATE_TYPES } from "@/config/constants";
+import type { Provider, UsageScript } from "@/types";
+import { createTestQueryClient } from "../utils/testQueryClient";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/lib/query", () => ({
+  useSettingsQuery: () => ({ data: null }),
+}));
+
+vi.mock("@/components/JsonEditor", () => ({
+  default: ({ id, value }: { id: string; value: string }) => (
+    <textarea data-testid={id} value={value} readOnly />
+  ),
+}));
+
+vi.mock("@/components/common/FullScreenPanel", () => ({
+  FullScreenPanel: ({
+    isOpen,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    children: ReactNode;
+    footer?: ReactNode;
+  }) =>
+    isOpen ? (
+      <div>
+        <div>{children}</div>
+        <div>{footer}</div>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+function createProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    id: overrides.id ?? "provider-1",
+    name: overrides.name ?? "Test Provider",
+    settingsConfig: overrides.settingsConfig ?? {},
+    meta: {
+      usage_script: {
+        enabled: true,
+        language: "javascript",
+        code: "return true;",
+        ...overrides.meta?.usage_script,
+      },
+      ...overrides.meta,
+    },
+  };
+}
+
+function renderNewApiModal(scriptOverrides: Partial<UsageScript> = {}) {
+  const provider = createProvider({
+    meta: {
+      usage_script: {
+        enabled: true,
+        language: "javascript",
+        code: "return true;",
+        ...scriptOverrides,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <UsageScriptModal
+        provider={provider}
+        appId="codex"
+        isOpen
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("UsageScriptModal New API fields", () => {
+  it("renders api key and base url fields for the New API template", () => {
+    const { container } = renderNewApiModal({
+      templateType: TEMPLATE_TYPES.NEW_API,
+    });
+
+    expect(container.querySelector("#usage-api-key")).toBeTruthy();
+    expect(container.querySelector("#usage-newapi-base-url")).toBeTruthy();
+    expect(container.querySelector("#usage-access-token")).toBeNull();
+    expect(container.querySelector("#usage-user-id")).toBeNull();
+  });
+
+  it("keeps legacy accessToken/userId configs classified as New API", () => {
+    const { container } = renderNewApiModal({
+      accessToken: "legacy-token",
+      userId: "legacy-user",
+    });
+
+    expect(container.querySelector("#usage-newapi-base-url")).toBeTruthy();
+  });
+});

--- a/tests/components/UsageScriptModal.templates.test.ts
+++ b/tests/components/UsageScriptModal.templates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { TEMPLATE_TYPES } from "@/config/constants";
+import { generatePresetTemplates } from "@/components/UsageScriptModal";
+
+const mockT = (key: string) => key;
+
+describe("UsageScriptModal preset templates", () => {
+  it("uses the token usage endpoint for the New API template", () => {
+    const templates = generatePresetTemplates(mockT);
+    const newApiTemplate = templates[TEMPLATE_TYPES.NEW_API];
+
+    expect(newApiTemplate).toContain("{{baseUrl}}/api/usage/token");
+    expect(newApiTemplate).toContain('method: "GET"');
+    expect(newApiTemplate).toContain('"Authorization": "Bearer {{apiKey}}"');
+    expect(newApiTemplate).toContain('"User-Agent": "cc-switch/1.0"');
+    expect(newApiTemplate).toContain("response.code === true");
+    expect(newApiTemplate).toContain(
+      "response?.data?.total_available !== undefined",
+    );
+    expect(newApiTemplate).toContain("response.data.total_available / 500000");
+    expect(newApiTemplate).not.toContain("/api/user/self");
+    expect(newApiTemplate).not.toContain("New-Api-User");
+    expect(newApiTemplate).not.toContain("Content-Type");
+    expect(newApiTemplate).not.toContain("{{accessToken}}");
+    expect(newApiTemplate).not.toContain("{{userId}}");
+  });
+});


### PR DESCRIPTION
## What problem are you trying to solve?

CC Switch's built-in `New API` usage-query flow was using an unsuitable default. It pointed users to `/api/user/self` and exposed `Access Token` plus `User ID` as the main input model, even though the more appropriate default for this flow is a token-usage query based on `Base URL + API Key`.

This made the built-in path harder to use than it needed to be and created a mismatch between the expected setup and the default guidance shown in the product.

## What does this PR change?

This PR updates the built-in `New API` usage-query default to use `GET {{baseUrl}}/api/usage/token` with `Bearer {{apiKey}}`, aligns the New API modal fields and help example with that flow, refreshes the Chinese usage-query guide, and adds regression tests for the template and field behavior.

## Is this change appropriate for the core library?

Yes.

This is a correction to shared built-in product behavior, not a project-specific customization. Anyone using the existing `New API` usage-query flow in CC Switch can benefit from a more appropriate default.

## What alternatives did you consider?

1. Keep the old `/api/user/self` default and add a second New API template.
   This would preserve the old flow, but it would also keep the less suitable default in place and force users to pick between overlapping options.

2. Partially update the old template while keeping the old credential model.
   That would mix the new endpoint with the old input expectations and make the built-in flow even more confusing.

3. Make the conversion value configurable in the same PR.
   That may be reasonable later, but it would widen this change from "fix the default flow" into a broader product change. I kept this PR focused.

## Does this PR contain multiple unrelated changes?

No.

The code, UI, tests, and documentation changes all serve the same single goal: correcting the built-in `New API` usage-query default flow and keeping all user-facing entry points consistent with it.

## Existing PRs

- [x] I have reviewed open and closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness  | Model           | Model version/ID |
| -------- | --------------- | ---------------- |
| OpenCode | GPT-5.4(newapi) | openai/gpt-5.4   |

## Evaluation

- What was the initial prompt used to start the session that led to this change?
  - fix issue #1768
- How many verification runs did you execute after making the change?
  - Two targeted test runs after fixing the local environment, plus a production build attempt and a human review.
- How did outcomes change compared to before the change?
  - Before: the built-in `New API` flow still pointed to the old endpoint and old credential model.
  - After: the built-in template, help example, modal fields, and Chinese guide all point to the token-usage endpoint with API Key auth, and the targeted regression tests pass.

## Verification

- [x] Targeted regression tests were added for the New API template and field behavior
- [x] This change was tested beyond the happy path

Coverage included:

- checking that the template no longer contains `/api/user/self`
- checking that the template no longer contains `New-Api-User`, `{{accessToken}}`, or `{{userId}}`
- checking that `total_available = 0` remains a valid result via presence-based validation
- checking that legacy saved `accessToken` / `userId` configurations still open in New API mode

## Human review

- [x] A human has reviewed the complete proposed diff before submission

Fix #1768
