### PR TITLE
fix: avoid resetting usage query fields when editing extractor code

### DIFF
--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -873,7 +873,9 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
               <JsonEditor
                 id="usage-code"
                 value={script.code || ""}
-                onChange={(value) => setScript({ ...script, code: value })}
+                onChange={(value) =>
+                  setScript((prev) => ({ ...prev, code: value }))
+                }
                 height={480}
                 language="javascript"
                 showMinimap={false}


### PR DESCRIPTION
## 概要

修复用量查询配置弹窗中的状态覆盖问题。

对于尚未保存过用量查询配置的供应商，在填写 `apiKey`、`baseUrl` 等字段后，如果继续编辑提取器代码，已填写的字段会被重置。

## 复现

1. 打开任意一个尚未配置过“用量查询”的供应商
2. 点击“配置用量查询”
3. 保持默认的“通用模板”
4. 填写 `apiKey` 和 `baseUrl`
5. 修改下方“提取器代码”
6. 可以观察到上方已填写的字段被重置
<img width="1350" height="804" alt="image" src="https://github.com/user-attachments/assets/c2a7dcde-17c5-4ed7-95df-85fb46d68e3d" />

## 原因

`JsonEditor` 持有旧的 `onChange` 回调，而父组件在更新 `script.code`时使用了基于旧闭包的对象展开写法：

```tsx
setScript({ ...script, code: value })
```
当编辑器内容变化时，这个旧的 script 快照会把后续填写的新字段一起覆盖掉。

## 修复

将 script.code 的更新改为函数式更新：

```tsx
setScript((prev) => ({ ...prev, code: value }))
```

这样在编辑提取器代码时，会始终基于最新状态合并更新，不会再覆盖 apiKey、baseUrl 等字段。