### PR TITLE
Fix New API usage query default endpoint (#1768)

### DIFF
--- a/docs/user-manual/en/2-providers/2.5-usage-query.md
+++ b/docs/user-manual/en/2-providers/2.5-usage-query.md
@@ -64,12 +64,12 @@ Designed specifically for New API-type proxy services:
 ```javascript
 ({
   request: {
-    url: "{{baseUrl}}/api/user/self",
+    url: "{{baseUrl}}/api/usage/token",
     method: "GET",
     headers: {
       "Content-Type": "application/json",
-      "Authorization": "Bearer {{accessToken}}",
-      "New-Api-User": "{{userId}}"
+      "Authorization": "Bearer {{apiKey}}",
+      "User-Agent": "cc-switch/1.0"
     },
   },
   extractor: function (response) {
@@ -93,9 +93,8 @@ Designed specifically for New API-type proxy services:
 **Configuration parameters**:
 | Parameter | Description |
 |-----------|-------------|
+| API Key | Authentication key for the New API service |
 | Base URL | New API service URL |
-| Access Token | Access token |
-| User ID | User ID |
 
 ## General Configuration
 

--- a/docs/user-manual/ja/2-providers/2.5-usage-query.md
+++ b/docs/user-manual/ja/2-providers/2.5-usage-query.md
@@ -64,12 +64,12 @@ New API タイプの中継サービス専用に設計されています：
 ```javascript
 ({
   request: {
-    url: "{{baseUrl}}/api/user/self",
+    url: "{{baseUrl}}/api/usage/token",
     method: "GET",
     headers: {
       "Content-Type": "application/json",
-      "Authorization": "Bearer {{accessToken}}",
-      "New-Api-User": "{{userId}}"
+      "Authorization": "Bearer {{apiKey}}",
+      "User-Agent": "cc-switch/1.0"
     },
   },
   extractor: function (response) {
@@ -93,9 +93,8 @@ New API タイプの中継サービス専用に設計されています：
 **設定パラメータ**：
 | パラメータ | 説明 |
 |------|------|
+| API Key | New API サービス認証キー |
 | Base URL | New API サービスアドレス |
-| Access Token | アクセストークン |
-| User ID | ユーザー ID |
 
 ## 共通設定
 

--- a/docs/user-manual/zh/2-providers/2.5-usage-query.md
+++ b/docs/user-manual/zh/2-providers/2.5-usage-query.md
@@ -64,12 +64,12 @@ CC Switch 提供三种预设模板：
 ```javascript
 ({
   request: {
-    url: "{{baseUrl}}/api/user/self",
+    url: "{{baseUrl}}/api/usage/token",
     method: "GET",
     headers: {
       "Content-Type": "application/json",
-      "Authorization": "Bearer {{accessToken}}",
-      "New-Api-User": "{{userId}}"
+      "Authorization": "Bearer {{apiKey}}",
+      "User-Agent": "cc-switch/1.0"
     },
   },
   extractor: function (response) {
@@ -93,9 +93,8 @@ CC Switch 提供三种预设模板：
 **配置参数**：
 | 参数 | 说明 |
 |------|------|
+| API Key | New API 服务认证密钥 |
 | Base URL | New API 服务地址 |
-| Access Token | 访问令牌 |
-| User ID | 用户 ID |
 
 ## 通用配置
 

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -68,12 +68,12 @@ const generatePresetTemplates = (
 
   [TEMPLATE_TYPES.NEW_API]: `({
   request: {
-    url: "{{baseUrl}}/api/user/self",
+    url: "{{baseUrl}}/api/usage/token",
     method: "GET",
     headers: {
       "Content-Type": "application/json",
-      "Authorization": "Bearer {{accessToken}}",
-      "New-Api-User": "{{userId}}"
+      "Authorization": "Bearer {{apiKey}}",
+      "User-Agent": "cc-switch/1.0"
     },
   },
   extractor: function (response) {
@@ -714,6 +714,43 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                   {selectedTemplate === TEMPLATE_TYPES.NEW_API && (
                     <>
                       <div className="space-y-2">
+                        <Label htmlFor="usage-newapi-api-key">
+                          API Key
+                        </Label>
+                        <div className="relative">
+                          <Input
+                            id="usage-newapi-api-key"
+                            type={showApiKey ? "text" : "password"}
+                            value={script.apiKey || ""}
+                            onChange={(e) =>
+                              setScript({ ...script, apiKey: e.target.value })
+                            }
+                            placeholder={t("usageScript.apiKeyPlaceholder")}
+                            autoComplete="off"
+                            className="border-white/10"
+                          />
+                          {script.apiKey && (
+                            <button
+                              type="button"
+                              onClick={() => setShowApiKey(!showApiKey)}
+                              className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground transition-colors"
+                              aria-label={
+                                showApiKey
+                                  ? t("apiKeyInput.hide")
+                                  : t("apiKeyInput.show")
+                              }
+                            >
+                              {showApiKey ? (
+                                <EyeOff size={16} />
+                              ) : (
+                                <Eye size={16} />
+                              )}
+                            </button>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
                         <Label htmlFor="usage-newapi-base-url">
                           {t("usageScript.baseUrl")}
                         </Label>
@@ -725,67 +762,6 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                             setScript({ ...script, baseUrl: e.target.value })
                           }
                           placeholder="https://api.newapi.com"
-                          autoComplete="off"
-                          className="border-white/10"
-                        />
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="usage-access-token">
-                          {t("usageScript.accessToken")}
-                        </Label>
-                        <div className="relative">
-                          <Input
-                            id="usage-access-token"
-                            type={showAccessToken ? "text" : "password"}
-                            value={script.accessToken || ""}
-                            onChange={(e) =>
-                              setScript({
-                                ...script,
-                                accessToken: e.target.value,
-                              })
-                            }
-                            placeholder={t(
-                              "usageScript.accessTokenPlaceholder",
-                            )}
-                            autoComplete="off"
-                            className="border-white/10"
-                          />
-                          {script.accessToken && (
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setShowAccessToken(!showAccessToken)
-                              }
-                              className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground hover:text-foreground transition-colors"
-                              aria-label={
-                                showAccessToken
-                                  ? t("apiKeyInput.hide")
-                                  : t("apiKeyInput.show")
-                              }
-                            >
-                              {showAccessToken ? (
-                                <EyeOff size={16} />
-                              ) : (
-                                <Eye size={16} />
-                              )}
-                            </button>
-                          )}
-                        </div>
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="usage-user-id">
-                          {t("usageScript.userId")}
-                        </Label>
-                        <Input
-                          id="usage-user-id"
-                          type="text"
-                          value={script.userId || ""}
-                          onChange={(e) =>
-                            setScript({ ...script, userId: e.target.value })
-                          }
-                          placeholder={t("usageScript.userIdPlaceholder")}
                           autoComplete="off"
                           className="border-white/10"
                         />


### PR DESCRIPTION
## Summary
- Change the built-in New API usage-query template endpoint from `/api/user/self` to `/api/usage/token`
- Switch authentication from `Access Token` + `User ID` headers to `Bearer {{apiKey}}` + `User-Agent`
- Update the UI credential fields to show `API Key` + `Base URL` instead of `Base URL` + `Access Token` + `User ID`
- Update documentation (en, zh, ja) to match the new template

## Test plan
- [ ] Open a provider's usage-query modal, select the New API template, and verify the script shows `/api/usage/token` with `apiKey`
- [ ] Verify the credential fields show API Key and Base URL (no Access Token or User ID)
- [ ] Test the usage query against a New API service to confirm data fetches successfully

Closes #1768