### PR TITLE
feat(proxy): add tool schema rectifier for non-OpenAI provider compatibility

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -825,18 +825,21 @@ impl RequestForwarder {
         // 默认使用空白名单，过滤所有 _ 前缀字段
         let mut filtered_body = filter_private_params_with_whitelist(request_body, &[]);
 
-        // Tool Schema 整流：修复非 OpenAI provider 的 tool 兼容性
-        // - 移除非 function 类型的 tool（如 web_search）
-        // - 为缺少 required 字段的 parameters 补充空数组
-        let tool_rectify_result =
-            super::tool_schema_rectifier::rectify_tool_schema(&mut filtered_body);
-        if tool_rectify_result.applied {
-            let tag = adapter.name();
-            log::info!(
-                "[{tag}] [TOOL-001] Tool Schema 整流: 移除 {} 个非 function tool, 修补 {} 个缺失 required 字段",
-                tool_rectify_result.removed_non_function_tools,
-                tool_rectify_result.patched_required_count,
-            );
+        // Tool Schema 整流：仅对 Codex adapter 且非 OpenAI 原生端点生效
+        // OpenAI 原生支持 web_search / code_interpreter 等内置 tool 类型，无需整流
+        // Claude / Gemini adapter 使用自有格式，不适用此整流逻辑
+        let is_openai_native = base_url.contains("api.openai.com");
+        if adapter.name() == "Codex" && !is_openai_native {
+            let tool_rectify_result =
+                super::tool_schema_rectifier::rectify_tool_schema(&mut filtered_body);
+            if tool_rectify_result.applied {
+                let tag = adapter.name();
+                log::info!(
+                    "[{tag}] [TOOL-001] Tool Schema 整流: 移除 {} 个非 function tool, 修补 {} 个缺失 required 字段",
+                    tool_rectify_result.removed_non_function_tools,
+                    tool_rectify_result.patched_required_count,
+                );
+            }
         }
 
         let force_identity_encoding = needs_transform

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -823,7 +823,22 @@ impl RequestForwarder {
 
         // 过滤私有参数（以 `_` 开头的字段），防止内部信息泄露到上游
         // 默认使用空白名单，过滤所有 _ 前缀字段
-        let filtered_body = filter_private_params_with_whitelist(request_body, &[]);
+        let mut filtered_body = filter_private_params_with_whitelist(request_body, &[]);
+
+        // Tool Schema 整流：修复非 OpenAI provider 的 tool 兼容性
+        // - 移除非 function 类型的 tool（如 web_search）
+        // - 为缺少 required 字段的 parameters 补充空数组
+        let tool_rectify_result =
+            super::tool_schema_rectifier::rectify_tool_schema(&mut filtered_body);
+        if tool_rectify_result.applied {
+            let tag = adapter.name();
+            log::info!(
+                "[{tag}] [TOOL-001] Tool Schema 整流: 移除 {} 个非 function tool, 修补 {} 个缺失 required 字段",
+                tool_rectify_result.removed_non_function_tools,
+                tool_rectify_result.patched_required_count,
+            );
+        }
+
         let force_identity_encoding = needs_transform
             || should_force_identity_encoding(&effective_endpoint, &filtered_body, headers);
 

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod sse;
 pub mod thinking_budget_rectifier;
 pub mod thinking_optimizer;
 pub mod thinking_rectifier;
+pub mod tool_schema_rectifier;
 pub(crate) mod types;
 pub mod usage;
 

--- a/src-tauri/src/proxy/tool_schema_rectifier.rs
+++ b/src-tauri/src/proxy/tool_schema_rectifier.rs
@@ -1,0 +1,219 @@
+//! Tool Schema 整流器
+//!
+//! 修复 OpenAI Responses API 中 tool 定义与第三方 Provider 的兼容性问题。
+//!
+//! ## 问题背景
+//! Codex CLI 通过 OpenAI Responses API 发送的 tool 列表中可能包含：
+//! 1. 非标准 tool 类型（如 `web_search`），部分 Provider（如阿里云百炼/DashScope）不支持
+//! 2. `parameters` 对象缺少 `required` 字段，部分 Provider 要求该字段必须存在
+//!
+//! ## 整流策略
+//! - 移除 `type` 不为 `"function"` 的 tool（如 `web_search`、`code_interpreter` 等）
+//! - 对 `parameters` 存在但缺少 `required` 的 function tool，补充 `"required": []`
+
+use serde_json::Value;
+
+/// 整流结果
+#[derive(Debug, Clone, Default)]
+pub struct ToolSchemaRectifyResult {
+    /// 是否应用了整流（有任何修改即为 true）
+    pub applied: bool,
+    /// 移除的非 function 类型 tool 数量
+    pub removed_non_function_tools: usize,
+    /// 补充 `required` 字段的 tool 数量
+    pub patched_required_count: usize,
+}
+
+/// 整流请求体中的 tool schema
+///
+/// 就地修改 `body` 中的 `tools` 数组：
+/// 1. 移除非 `function` 类型的 tool
+/// 2. 为缺少 `required` 字段的 `parameters` 补充空数组
+pub fn rectify_tool_schema(body: &mut Value) -> ToolSchemaRectifyResult {
+    let mut result = ToolSchemaRectifyResult::default();
+
+    let Some(tools) = body.get_mut("tools").and_then(|v| v.as_array_mut()) else {
+        return result;
+    };
+
+    // 统计移除的非 function tool
+    let original_len = tools.len();
+    tools.retain(|tool| {
+        let tool_type = tool.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        tool_type == "function"
+    });
+    result.removed_non_function_tools = original_len - tools.len();
+
+    // 补充缺失的 required 字段
+    for tool in tools.iter_mut() {
+        if let Some(params) = tool.get_mut("parameters") {
+            if params.is_object() && params.get("required").is_none() {
+                params
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("required".to_string(), Value::Array(vec![]));
+                result.patched_required_count += 1;
+            }
+        }
+    }
+
+    result.applied = result.removed_non_function_tools > 0 || result.patched_required_count > 0;
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_no_tools_field() {
+        let mut body = json!({"model": "qwen3-max", "input": "hello"});
+        let result = rectify_tool_schema(&mut body);
+        assert!(!result.applied);
+        assert_eq!(result.removed_non_function_tools, 0);
+        assert_eq!(result.patched_required_count, 0);
+    }
+
+    #[test]
+    fn test_empty_tools_array() {
+        let mut body = json!({"model": "qwen3-max", "tools": []});
+        let result = rectify_tool_schema(&mut body);
+        assert!(!result.applied);
+    }
+
+    #[test]
+    fn test_remove_web_search_tool() {
+        let mut body = json!({
+            "model": "qwen3-max",
+            "tools": [
+                {"type": "function", "name": "exec_command", "parameters": {"type": "object", "properties": {}, "required": []}},
+                {"type": "web_search", "external_web_access": true},
+                {"type": "function", "name": "write_file", "parameters": {"type": "object", "properties": {}, "required": []}}
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        assert!(result.applied);
+        assert_eq!(result.removed_non_function_tools, 1);
+        assert_eq!(body["tools"].as_array().unwrap().len(), 2);
+        // Verify remaining tools are both function type
+        for tool in body["tools"].as_array().unwrap() {
+            assert_eq!(tool["type"].as_str().unwrap(), "function");
+        }
+    }
+
+    #[test]
+    fn test_remove_code_interpreter_tool() {
+        let mut body = json!({
+            "tools": [
+                {"type": "code_interpreter"},
+                {"type": "function", "name": "test", "parameters": {"type": "object", "properties": {}, "required": []}}
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        assert!(result.applied);
+        assert_eq!(result.removed_non_function_tools, 1);
+        assert_eq!(body["tools"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_patch_missing_required_field() {
+        let mut body = json!({
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "list_resources",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "uri": {"type": "string"}
+                        },
+                        "additionalProperties": false
+                    }
+                }
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        assert!(result.applied);
+        assert_eq!(result.patched_required_count, 1);
+        // Verify required field was added
+        let params = &body["tools"][0]["parameters"];
+        assert!(params.get("required").is_some());
+        assert_eq!(params["required"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_skip_tools_with_existing_required() {
+        let mut body = json!({
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"cmd": {"type": "string"}},
+                        "required": ["cmd"]
+                    }
+                }
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        assert!(!result.applied);
+        assert_eq!(result.patched_required_count, 0);
+    }
+
+    #[test]
+    fn test_combined_rectification() {
+        let mut body = json!({
+            "model": "qwen3-max",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}, "required": ["cmd"]}
+                },
+                {"type": "web_search", "external_web_access": true},
+                {
+                    "type": "function",
+                    "name": "list_resources",
+                    "parameters": {"type": "object", "properties": {"uri": {"type": "string"}}, "additionalProperties": false}
+                },
+                {
+                    "type": "function",
+                    "name": "spawn_agent",
+                    "parameters": {"type": "object", "properties": {}, "additionalProperties": false}
+                }
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        assert!(result.applied);
+        assert_eq!(result.removed_non_function_tools, 1); // web_search removed
+        assert_eq!(result.patched_required_count, 2); // list_resources + spawn_agent
+        assert_eq!(body["tools"].as_array().unwrap().len(), 3); // 4 - 1 = 3
+    }
+
+    #[test]
+    fn test_tools_without_parameters() {
+        // Some function tools might not have parameters at all
+        let mut body = json!({
+            "tools": [
+                {"type": "function", "name": "no_params"}
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        assert!(!result.applied);
+        assert_eq!(result.patched_required_count, 0);
+    }
+
+    #[test]
+    fn test_tools_with_non_object_parameters() {
+        // Edge case: parameters is not an object
+        let mut body = json!({
+            "tools": [
+                {"type": "function", "name": "weird", "parameters": "not_an_object"}
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        assert!(!result.applied);
+    }
+}

--- a/src-tauri/src/proxy/tool_schema_rectifier.rs
+++ b/src-tauri/src/proxy/tool_schema_rectifier.rs
@@ -37,10 +37,11 @@ pub fn rectify_tool_schema(body: &mut Value) -> ToolSchemaRectifyResult {
     };
 
     // 统计移除的非 function tool
+    // 保留 type == "function" 的工具，以及没有 type 字段的工具（如 Anthropic 格式）
     let original_len = tools.len();
-    tools.retain(|tool| {
-        let tool_type = tool.get("type").and_then(|v| v.as_str()).unwrap_or("");
-        tool_type == "function"
+    tools.retain(|tool| match tool.get("type").and_then(|v| v.as_str()) {
+        Some(t) => t == "function",
+        None => true, // 保留无 type 字段的工具（Anthropic 格式使用 name + input_schema）
     });
     result.removed_non_function_tools = original_len - tools.len();
 
@@ -215,5 +216,57 @@ mod tests {
         });
         let result = rectify_tool_schema(&mut body);
         assert!(!result.applied);
+    }
+
+    #[test]
+    fn test_preserve_anthropic_typeless_tools() {
+        // Anthropic 格式的工具没有 type 字段，使用 name + input_schema
+        let mut body = json!({
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather info",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"]
+                    }
+                },
+                {
+                    "name": "search",
+                    "description": "Search the web",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"]
+                    }
+                }
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        // Anthropic 格式工具不应被移除
+        assert!(!result.applied);
+        assert_eq!(result.removed_non_function_tools, 0);
+        assert_eq!(body["tools"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_mixed_openai_and_typeless_tools() {
+        // 混合场景：同时存在 OpenAI 格式和无 type 字段的工具
+        let mut body = json!({
+            "tools": [
+                {"type": "function", "name": "exec", "parameters": {"type": "object", "properties": {}, "required": []}},
+                {"type": "web_search"},
+                {"name": "anthropic_tool", "input_schema": {"type": "object", "properties": {}}}
+            ]
+        });
+        let result = rectify_tool_schema(&mut body);
+        assert!(result.applied);
+        assert_eq!(result.removed_non_function_tools, 1); // web_search removed
+        assert_eq!(body["tools"].as_array().unwrap().len(), 2); // function + typeless preserved
+        // 验证保留的工具
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["name"].as_str().unwrap(), "exec");
+        assert_eq!(tools[1]["name"].as_str().unwrap(), "anthropic_tool");
     }
 }


### PR DESCRIPTION
## Problem

When using Codex CLI (v0.117+) with CC Switch proxying to DashScope/Bailian, requests fail with:

```
InvalidParameter: The parameters, when provided as a dict, must confirm to a valid openai-compatible JSON schema
```

## Root Cause

Codex CLI sends ~188 tools via the OpenAI Responses API. Two patterns are incompatible with DashScope and similar providers:

1. **Non-function tool types** (e.g. `web_search`, `code_interpreter`) - these are OpenAI-specific built-in tools that third-party providers don't recognize
2. **Missing `required` field** in tool `parameters` - DashScope requires this field to be present even when empty (`[]`), but ~48 of Codex's tools omit it (all-optional-param tools)

## Solution

Add a **Tool Schema Rectifier** that runs in the proxy `forward()` pipeline (after `filter_private_params_with_whitelist`):

- Filter out tools where `type != "function"`
- Patch `"required": []` into any tool parameters missing the field

This follows the same pattern as existing rectifiers (`thinking_rectifier`, `thinking_budget_rectifier`).

## Testing

- 9 unit tests covering: no tools, empty tools, web_search removal, code_interpreter removal, missing required patch, existing required skip, combined rectification, no-params tools, non-object params
- All tests pass: `cargo test -- tool_schema_rectifier`
- Manually verified: Codex CLI `codex exec 'say hello'` works through CC Switch -> DashScope after this fix

## Files Changed

| File | Change |
|---|---|
| `src-tauri/src/proxy/tool_schema_rectifier.rs` | New - rectifier implementation + 9 tests |
| `src-tauri/src/proxy/mod.rs` | Register new module |
| `src-tauri/src/proxy/forwarder.rs` | Call rectifier in forward() pipeline |
