### PR TITLE
fix(config): update StepFun API endpoint domain from .ai to .com

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -192,7 +192,7 @@ export const providerPresets: ProviderPreset[] = [
     apiKeyUrl: "https://platform.stepfun.ai/interface-key",
     settingsConfig: {
       env: {
-        ANTHROPIC_BASE_URL: "https://api.stepfun.ai/v1",
+        ANTHROPIC_BASE_URL: "https://api.stepfun.com/v1",
         ANTHROPIC_AUTH_TOKEN: "",
         ANTHROPIC_MODEL: "step-3.5-flash",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "step-3.5-flash",
@@ -201,7 +201,7 @@ export const providerPresets: ProviderPreset[] = [
       },
     },
     category: "cn_official",
-    endpointCandidates: ["https://api.stepfun.ai/v1"],
+    endpointCandidates: ["https://api.stepfun.com/v1"],
     apiFormat: "openai_chat",
     icon: "stepfun",
     iconColor: "#005AFF",

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -298,7 +298,7 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     websiteUrl: "https://platform.stepfun.ai",
     apiKeyUrl: "https://platform.stepfun.ai/interface-key",
     settingsConfig: {
-      baseUrl: "https://api.stepfun.ai/v1",
+      baseUrl: "https://api.stepfun.com/v1",
       apiKey: "",
       api: "openai-completions",
       models: [
@@ -315,8 +315,8 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     templateValues: {
       baseUrl: {
         label: "Base URL",
-        placeholder: "https://api.stepfun.ai/v1",
-        defaultValue: "https://api.stepfun.ai/v1",
+        placeholder: "https://api.stepfun.com/v1",
+        defaultValue: "https://api.stepfun.com/v1",
         editorValue: "",
       },
       apiKey: {

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -489,7 +489,7 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
       npm: "@ai-sdk/openai-compatible",
       name: "StepFun",
       options: {
-        baseURL: "https://api.stepfun.ai/v1",
+        baseURL: "https://api.stepfun.com/v1",
         apiKey: "",
         setCacheKey: true,
       },
@@ -503,8 +503,8 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     templateValues: {
       baseURL: {
         label: "Base URL",
-        placeholder: "https://api.stepfun.ai/v1",
-        defaultValue: "https://api.stepfun.ai/v1",
+        placeholder: "https://api.stepfun.com/v1",
+        defaultValue: "https://api.stepfun.com/v1",
         editorValue: "",
       },
       apiKey: {


### PR DESCRIPTION
## Summary

- Update StepFun API base URL from `https://api.stepfun.ai/v1` to `https://api.stepfun.com/v1` across all provider preset configs
- Affects Claude, OpenClaw, and OpenCode provider presets

## Changes

- `src/config/claudeProviderPresets.ts`
- `src/config/openclawProviderPresets.ts`
- `src/config/opencodeProviderPresets.ts`