### PR TITLE
ci: add dependabot.yml config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      frontend-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "rust"
+      - "backend"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "actions"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-      - "rust"
       - "backend"
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Changes

Introduces `Dependabot` to help automate dependency updates and improve supply chain security.

After merging this PR, you don't need to wait for the scheduled cycle. You can directly go to the repository panel's `Insights` -> `Dependency graph` -> `Dependabot` and click `Check for updates` to immediately trigger a scan test.