### PR TITLE
fix(macos): open new terminal window instead of reusing existing one

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1015,7 +1015,7 @@ end tell"#,
     Ok(())
 }
 
-/// macOS: 使用 open -a 启动支持 --args 参数的终端（Alacritty/Kitty/Ghostty）
+/// macOS: 使用 open -na 启动支持 --args 参数的终端（Alacritty/Kitty/Ghostty/WezTerm）
 #[cfg(target_os = "macos")]
 fn launch_macos_open_app(
     app_name: &str,
@@ -1025,7 +1025,7 @@ fn launch_macos_open_app(
     use std::process::Command;
 
     let mut cmd = Command::new("open");
-    cmd.arg("-a").arg(app_name).arg("--args");
+    cmd.arg("-na").arg(app_name).arg("--args");
 
     if use_e_flag {
         cmd.arg("-e");


### PR DESCRIPTION
## Summary

- Use `open -na` instead of `open -a` in `launch_macos_open_app` so that clicking "Open Terminal" from the provider list always spawns a **new** terminal window rather than activating an existing one
- This aligns behavior with `session_manager/terminal/mod.rs` which already uses `-na` for all terminal types (Ghostty, WezTerm, Alacritty, Kitty, iTerm2)

## Problem

When a user configures Ghostty (or other terminals using `launch_macos_open_app`) and clicks "Open Terminal" from the model list, macOS `open -a` activates the existing terminal window instead of opening a new one. This is inconsistent with the session manager which correctly uses `open -na` to always create a new instance.

## Test plan

- [ ] Configure Ghostty as preferred terminal
- [ ] Open a terminal from provider list → verify a new Ghostty window opens
- [ ] With Ghostty already running, open terminal again → verify a **second** new window opens (not just activating the first)
- [ ] Repeat with Alacritty, Kitty, WezTerm to confirm consistent behavior