### PR TITLE
feat(usage): add speed metrics for model and request logs

### DIFF
--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -60,6 +60,7 @@ pub struct ModelStats {
     pub total_tokens: u64,
     pub total_cost: String,
     pub avg_cost_per_request: String,
+    pub avg_tokens_per_second: f64,
 }
 
 /// 请求日志过滤器
@@ -477,19 +478,45 @@ impl Database {
                 model,
                 SUM(request_count) as request_count,
                 SUM(total_tokens) as total_tokens,
-                SUM(total_cost) as total_cost
+                SUM(total_cost) as total_cost,
+                CASE
+                    WHEN SUM(speed_duration_ms) > 0
+                    THEN (SUM(speed_output_tokens) * 1000.0 / SUM(speed_duration_ms))
+                    ELSE 0
+                END as avg_tokens_per_second
             FROM (
                 SELECT model,
                     COUNT(*) as request_count,
                     COALESCE(SUM(input_tokens + output_tokens), 0) as total_tokens,
-                    COALESCE(SUM(CAST(total_cost_usd AS REAL)), 0) as total_cost
+                    COALESCE(SUM(CAST(total_cost_usd AS REAL)), 0) as total_cost,
+                    COALESCE(SUM(
+                        CASE
+                            WHEN status_code >= 200 AND status_code < 300 AND output_tokens > 0 THEN
+                                CASE
+                                    WHEN duration_ms IS NOT NULL AND duration_ms > 0 THEN duration_ms
+                                    WHEN first_token_ms IS NOT NULL AND latency_ms > first_token_ms
+                                        THEN latency_ms - first_token_ms
+                                    WHEN latency_ms > 0 THEN latency_ms
+                                    ELSE 0
+                                END
+                            ELSE 0
+                        END
+                    ), 0) as speed_duration_ms,
+                    COALESCE(SUM(
+                        CASE
+                            WHEN status_code >= 200 AND status_code < 300 THEN output_tokens
+                            ELSE 0
+                        END
+                    ), 0) as speed_output_tokens
                 FROM proxy_request_logs
                 GROUP BY model
                 UNION ALL
                 SELECT model,
                     COALESCE(SUM(request_count), 0),
                     COALESCE(SUM(input_tokens + output_tokens), 0),
-                    COALESCE(SUM(CAST(total_cost_usd AS REAL)), 0)
+                    COALESCE(SUM(CAST(total_cost_usd AS REAL)), 0),
+                    0,
+                    0
                 FROM usage_daily_rollups
                 GROUP BY model
             )
@@ -512,6 +539,7 @@ impl Database {
                 total_tokens: row.get::<_, i64>(2)? as u64,
                 total_cost: format!("{total_cost:.6}"),
                 avg_cost_per_request: format!("{avg_cost:.6}"),
+                avg_tokens_per_second: row.get::<_, f64>(4)?,
             })
         })?;
 

--- a/src/components/usage/ModelStatsTable.tsx
+++ b/src/components/usage/ModelStatsTable.tsx
@@ -37,6 +37,9 @@ export function ModelStatsTable({ refreshIntervalMs }: ModelStatsTableProps) {
               {t("usage.tokens", "Tokens")}
             </TableHead>
             <TableHead className="text-right">
+              {t("usage.tokensPerSecond", "速度")}
+            </TableHead>
+            <TableHead className="text-right">
               {t("usage.totalCost", "总成本")}
             </TableHead>
             <TableHead className="text-right">
@@ -48,7 +51,7 @@ export function ModelStatsTable({ refreshIntervalMs }: ModelStatsTableProps) {
           {stats?.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={5}
+                colSpan={6}
                 className="text-center text-muted-foreground"
               >
                 {t("usage.noData", "暂无数据")}
@@ -65,6 +68,11 @@ export function ModelStatsTable({ refreshIntervalMs }: ModelStatsTableProps) {
                 </TableCell>
                 <TableCell className="text-right">
                   {stat.totalTokens.toLocaleString()}
+                </TableCell>
+                <TableCell className="text-right">
+                  {Number.isFinite(stat.avgTokensPerSecond)
+                    ? Math.round(stat.avgTokensPerSecond).toLocaleString()
+                    : "0"}
                 </TableCell>
                 <TableCell className="text-right">
                   {fmtUsd(stat.totalCost, 4)}

--- a/src/components/usage/RequestDetailPanel.tsx
+++ b/src/components/usage/RequestDetailPanel.tsx
@@ -50,6 +50,20 @@ export function RequestDetailPanel({
     );
   }
 
+  const generationDurationMs =
+    typeof request.durationMs === "number" && request.durationMs > 0
+      ? request.durationMs
+      : typeof request.firstTokenMs === "number" &&
+          request.latencyMs > request.firstTokenMs
+        ? request.latencyMs - request.firstTokenMs
+        : request.latencyMs > 0
+          ? request.latencyMs
+          : null;
+  const tokensPerSecond =
+    generationDurationMs && request.outputTokens > 0
+      ? (request.outputTokens * 1000) / generationDurationMs
+      : null;
+
   return (
     <Dialog open onOpenChange={onClose}>
       <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
@@ -265,6 +279,16 @@ export function RequestDetailPanel({
                   {t("usage.latency", "延迟")}
                 </dt>
                 <dd className="font-mono">{request.latencyMs}ms</dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">
+                  {t("usage.tokensPerSecond", "Tokens/s")}
+                </dt>
+                <dd className="font-mono">
+                  {tokensPerSecond != null && Number.isFinite(tokensPerSecond)
+                    ? Math.round(tokensPerSecond).toLocaleString()
+                    : "--"}
+                </dd>
               </div>
             </dl>
           </div>

--- a/src/components/usage/RequestLogTable.tsx
+++ b/src/components/usage/RequestLogTable.tsx
@@ -37,6 +37,38 @@ const MAX_FIXED_RANGE_SECONDS = 30 * ONE_DAY_SECONDS;
 
 type TimeMode = "rolling" | "fixed";
 
+function getGenerationDurationMs(log: {
+  latencyMs: number;
+  durationMs?: number;
+  firstTokenMs?: number;
+}): number | null {
+  if (typeof log.durationMs === "number" && log.durationMs > 0) {
+    return log.durationMs;
+  }
+  if (
+    typeof log.firstTokenMs === "number" &&
+    Number.isFinite(log.firstTokenMs) &&
+    log.latencyMs > log.firstTokenMs
+  ) {
+    return log.latencyMs - log.firstTokenMs;
+  }
+  if (log.latencyMs > 0) {
+    return log.latencyMs;
+  }
+  return null;
+}
+
+function getTokensPerSecond(log: {
+  outputTokens: number;
+  latencyMs: number;
+  durationMs?: number;
+  firstTokenMs?: number;
+}): number | null {
+  const durationMs = getGenerationDurationMs(log);
+  if (!durationMs || log.outputTokens <= 0) return null;
+  return (log.outputTokens * 1000) / durationMs;
+}
+
 export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
@@ -360,6 +392,9 @@ export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
                     {t("usage.cacheCreationTokens")}
                   </TableHead>
                   <TableHead className="text-right whitespace-nowrap">
+                    {t("usage.tokensPerSecond", "Tokens/s")}
+                  </TableHead>
+                  <TableHead className="text-right whitespace-nowrap">
                     {t("usage.multiplier")}
                   </TableHead>
                   <TableHead className="text-right whitespace-nowrap">
@@ -377,7 +412,7 @@ export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
                 {logs.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={11}
+                      colSpan={12}
                       className="text-center text-muted-foreground"
                     >
                       {t("usage.noData")}
@@ -424,6 +459,14 @@ export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
                       <TableCell className="text-right">
                         {fmtInt(log.cacheCreationTokens, locale)}
                       </TableCell>
+                      <TableCell className="text-right font-mono">
+                        {(() => {
+                          const speed = getTokensPerSecond(log);
+                          return speed != null && Number.isFinite(speed)
+                            ? fmtInt(Math.round(speed), locale)
+                            : "--";
+                        })()}
+                      </TableCell>
                       <TableCell className="text-right font-mono text-xs">
                         {(parseFiniteNumber(log.costMultiplier) ?? 1) !== 1 ? (
                           <span className="text-orange-600">
@@ -440,9 +483,7 @@ export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
                         <div className="flex items-center justify-center gap-1">
                           {(() => {
                             const durationMs =
-                              typeof log.durationMs === "number"
-                                ? log.durationMs
-                                : log.latencyMs;
+                              getGenerationDurationMs(log) ?? log.latencyMs;
                             const durationSec = durationMs / 1000;
                             const durationColor = Number.isFinite(durationSec)
                               ? durationSec <= 5

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1065,7 +1065,8 @@
     "pricingAdded": "Pricing added",
     "pricingUpdated": "Pricing updated",
     "cacheReadCostPerMillion": "Cache Read Cost (per million tokens, USD)",
-    "cacheCreationCostPerMillion": "Cache Write Cost (per million tokens, USD)"
+    "cacheCreationCostPerMillion": "Cache Write Cost (per million tokens, USD)",
+    "tokensPerSecond": "Speed"
   },
   "usageScript": {
     "title": "Configure Usage Query",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1065,7 +1065,8 @@
     "pricingAdded": "価格設定が追加されました",
     "pricingUpdated": "価格設定が更新されました",
     "cacheReadCostPerMillion": "キャッシュ読み取りコスト（100万トークンあたり、USD）",
-    "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）"
+    "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）",
+    "tokensPerSecond": "速度"
   },
   "usageScript": {
     "title": "利用状況を設定",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1065,7 +1065,8 @@
     "pricingAdded": "定价已添加",
     "pricingUpdated": "定价已更新",
     "cacheReadCostPerMillion": "缓存读取成本 (每百万 tokens, USD)",
-    "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)"
+    "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)",
+    "tokensPerSecond": "速度"
   },
   "usageScript": {
     "title": "配置用量查询",

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -86,6 +86,7 @@ export interface ModelStats {
   totalTokens: number;
   totalCost: string;
   avgCostPerRequest: string;
+  avgTokensPerSecond: number;
 }
 
 export interface LogFilters {


### PR DESCRIPTION
## Summary
- add `avgTokensPerSecond` to backend model stats aggregation based on existing timing fields and output tokens
- add speed column to model stats and request logs, and expose speed in request detail panel
- display speed as integer values; place request-log speed column before multiplier; add i18n key `usage.tokensPerSecond` (`速度`/`Speed`)

## Test plan
- [x] `pnpm typecheck`
- [x] verify model stats page shows speed column next to Tokens
- [x] verify request logs show speed column before multiplier with integer values
- [x] verify request detail panel shows speed consistent with request log calculation

Made with [Cursor](https://cursor.com)