### PR TITLE
fix(proxy): handle CRLF SSE delimiters (#1787)

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -2,7 +2,7 @@
 //!
 //! 实现 OpenAI SSE → Anthropic SSE 格式转换
 
-use crate::proxy::sse::strip_sse_field;
+use crate::proxy::sse::{strip_sse_field, take_sse_block};
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -110,10 +110,7 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                     let text = String::from_utf8_lossy(&bytes);
                     buffer.push_str(&text);
 
-                    while let Some(pos) = buffer.find("\n\n") {
-                        let line = buffer[..pos].to_string();
-                        buffer = buffer[pos + 2..].to_string();
-
+                    while let Some(line) = take_sse_block(&mut buffer) {
                         if line.trim().is_empty() {
                             continue;
                         }

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -9,7 +9,7 @@
 //! 与 Chat Completions 的 delta chunk 模型完全不同，需要独立的状态机处理。
 
 use super::transform_responses::{build_anthropic_usage_from_responses, map_responses_stop_reason};
-use crate::proxy::sse::strip_sse_field;
+use crate::proxy::sse::{strip_sse_field, take_sse_block};
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use serde_json::{json, Value};
@@ -121,11 +121,8 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                     let text = String::from_utf8_lossy(&bytes);
                     buffer.push_str(&text);
 
-                    // SSE 事件由 \n\n 分隔
-                    while let Some(pos) = buffer.find("\n\n") {
-                        let block = buffer[..pos].to_string();
-                        buffer = buffer[pos + 2..].to_string();
-
+                    // SSE 事件由空行分隔 (\n\n 或 \r\n\r\n)
+                    while let Some(block) = take_sse_block(&mut buffer) {
                         if block.trim().is_empty() {
                             continue;
                         }

--- a/src-tauri/src/proxy/response_handler.rs
+++ b/src-tauri/src/proxy/response_handler.rs
@@ -5,7 +5,7 @@
 use super::session::ProxySession;
 use super::usage::parser::TokenUsage;
 use super::ProxyError;
-use crate::proxy::sse::strip_sse_field;
+use crate::proxy::sse::{strip_sse_field, take_sse_block};
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use serde_json::Value;
@@ -86,10 +86,7 @@ impl StreamHandler {
                         buffer.push_str(&text);
 
                         // 提取完整事件
-                        while let Some(pos) = buffer.find("\n\n") {
-                            let event_text = buffer[..pos].to_string();
-                            buffer = buffer[pos + 2..].to_string();
-
+                        while let Some(event_text) = take_sse_block(&mut buffer) {
                             for line in event_text.lines() {
                                 if let Some(data) = strip_sse_field(line, "data") {
                                     if data.trim() != "[DONE]" {

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -7,7 +7,7 @@ use super::{
     handler_context::{RequestContext, StreamingTimeoutConfig},
     hyper_client::ProxyResponse,
     server::ProxyState,
-    sse::strip_sse_field,
+    sse::{strip_sse_field, take_sse_block},
     usage::parser::TokenUsage,
     ProxyError,
 };
@@ -623,10 +623,7 @@ pub fn create_logged_passthrough_stream(
                     buffer.push_str(&text);
 
                     // 尝试解析并记录完整的 SSE 事件
-                    while let Some(pos) = buffer.find("\n\n") {
-                        let event_text = buffer[..pos].to_string();
-                        buffer = buffer[pos + 2..].to_string();
-
+                    while let Some(event_text) = take_sse_block(&mut buffer) {
                         if !event_text.trim().is_empty() {
                             // 提取 data 部分并尝试解析为 JSON
                             for line in event_text.lines() {

--- a/src-tauri/src/proxy/sse.rs
+++ b/src-tauri/src/proxy/sse.rs
@@ -4,9 +4,36 @@ pub(crate) fn strip_sse_field<'a>(line: &'a str, field: &str) -> Option<&'a str>
         .or_else(|| line.strip_prefix(&format!("{field}:")))
 }
 
+pub(crate) fn take_sse_block(buffer: &mut String) -> Option<String> {
+    let lf = buffer.find("\n\n");
+    let crlf = buffer.find("\r\n\r\n");
+    let (pos, delim_len) = match (lf, crlf) {
+        (Some(lf_pos), Some(crlf_pos)) => {
+            if lf_pos < crlf_pos {
+                (lf_pos, 2)
+            } else {
+                (crlf_pos, 4)
+            }
+        }
+        (Some(lf_pos), None) => (lf_pos, 2),
+        (None, Some(crlf_pos)) => (crlf_pos, 4),
+        (None, None) => return None,
+    };
+
+    let mut block = buffer[..pos].to_string();
+    *buffer = buffer[pos + delim_len..].to_string();
+
+    if block.contains('\r') {
+        block = block.replace("\r\n", "\n");
+        block = block.replace('\r', "\n");
+    }
+
+    Some(block)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::strip_sse_field;
+    use super::{strip_sse_field, take_sse_block};
 
     #[test]
     fn strip_sse_field_accepts_optional_space() {
@@ -27,5 +54,21 @@ mod tests {
             Some("message_start")
         );
         assert_eq!(strip_sse_field("id:1", "data"), None);
+    }
+
+    #[test]
+    fn take_sse_block_handles_crlf_delimiter() {
+        let mut buffer = "data: {\"ok\":true}\r\n\r\nrest".to_string();
+        let block = take_sse_block(&mut buffer).expect("block");
+        assert_eq!(block, "data: {\"ok\":true}");
+        assert_eq!(buffer, "rest");
+    }
+
+    #[test]
+    fn take_sse_block_handles_lf_delimiter() {
+        let mut buffer = "event: ping\n\ndata:1".to_string();
+        let block = take_sse_block(&mut buffer).expect("block");
+        assert_eq!(block, "event: ping");
+        assert_eq!(buffer, "data:1");
     }
 }


### PR DESCRIPTION
## Summary / 概述

- handle SSE blocks delimited by \r\n\r\n by normalizing CRLF and splitting with a shared helper
- apply the helper across all SSE parsing paths

## Related Issue / 关联 Issue

Fixes #1787

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
