### PR TITLE
feat(usage): add speed column to request logs

### DIFF
--- a/src/components/usage/RequestLogTable.tsx
+++ b/src/components/usage/RequestLogTable.tsx
@@ -37,6 +37,41 @@ const MAX_FIXED_RANGE_SECONDS = 30 * ONE_DAY_SECONDS;
 
 type TimeMode = "rolling" | "fixed";
 
+function getGenerationDurationMs(log: {
+  latencyMs: number;
+  durationMs?: number;
+  firstTokenMs?: number;
+}): number | null {
+  if (typeof log.durationMs === "number" && log.durationMs > 0) {
+    return log.durationMs;
+  }
+  if (
+    typeof log.firstTokenMs === "number" &&
+    Number.isFinite(log.firstTokenMs) &&
+    log.latencyMs > log.firstTokenMs
+  ) {
+    return log.latencyMs - log.firstTokenMs;
+  }
+  if (log.latencyMs > 0) {
+    return log.latencyMs;
+  }
+  return null;
+}
+
+function getTokensPerSecond(log: {
+  outputTokens: number;
+  latencyMs: number;
+  durationMs?: number;
+  firstTokenMs?: number;
+  statusCode: number;
+}): number | null {
+  // 与后端模型聚合口径保持一致：仅统计成功请求的生成速度
+  if (log.statusCode < 200 || log.statusCode >= 300) return null;
+  const durationMs = getGenerationDurationMs(log);
+  if (!durationMs || log.outputTokens <= 0) return null;
+  return (log.outputTokens * 1000) / durationMs;
+}
+
 export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
@@ -360,6 +395,9 @@ export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
                     {t("usage.cacheCreationTokens")}
                   </TableHead>
                   <TableHead className="text-right whitespace-nowrap">
+                    {t("usage.tokensPerSecond", "Tokens/s")}
+                  </TableHead>
+                  <TableHead className="text-right whitespace-nowrap">
                     {t("usage.multiplier")}
                   </TableHead>
                   <TableHead className="text-right whitespace-nowrap">
@@ -377,7 +415,7 @@ export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
                 {logs.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={11}
+                      colSpan={12}
                       className="text-center text-muted-foreground"
                     >
                       {t("usage.noData")}
@@ -424,6 +462,14 @@ export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
                       <TableCell className="text-right">
                         {fmtInt(log.cacheCreationTokens, locale)}
                       </TableCell>
+                      <TableCell className="text-right font-mono">
+                        {(() => {
+                          const speed = getTokensPerSecond(log);
+                          return speed != null && Number.isFinite(speed)
+                            ? fmtInt(Math.round(speed), locale)
+                            : "--";
+                        })()}
+                      </TableCell>
                       <TableCell className="text-right font-mono text-xs">
                         {(parseFiniteNumber(log.costMultiplier) ?? 1) !== 1 ? (
                           <span className="text-orange-600">
@@ -440,9 +486,7 @@ export function RequestLogTable({ refreshIntervalMs }: RequestLogTableProps) {
                         <div className="flex items-center justify-center gap-1">
                           {(() => {
                             const durationMs =
-                              typeof log.durationMs === "number"
-                                ? log.durationMs
-                                : log.latencyMs;
+                              getGenerationDurationMs(log) ?? log.latencyMs;
                             const durationSec = durationMs / 1000;
                             const durationColor = Number.isFinite(durationSec)
                               ? durationSec <= 5

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1066,7 +1066,8 @@
     "pricingAdded": "Pricing added",
     "pricingUpdated": "Pricing updated",
     "cacheReadCostPerMillion": "Cache Read Cost (per million tokens, USD)",
-    "cacheCreationCostPerMillion": "Cache Write Cost (per million tokens, USD)"
+    "cacheCreationCostPerMillion": "Cache Write Cost (per million tokens, USD)",
+    "tokensPerSecond": "Speed"
   },
   "usageScript": {
     "title": "Configure Usage Query",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1066,7 +1066,8 @@
     "pricingAdded": "価格設定が追加されました",
     "pricingUpdated": "価格設定が更新されました",
     "cacheReadCostPerMillion": "キャッシュ読み取りコスト（100万トークンあたり、USD）",
-    "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）"
+    "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）",
+    "tokensPerSecond": "速度"
   },
   "usageScript": {
     "title": "利用状況を設定",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1066,7 +1066,8 @@
     "pricingAdded": "定价已添加",
     "pricingUpdated": "定价已更新",
     "cacheReadCostPerMillion": "缓存读取成本 (每百万 tokens, USD)",
-    "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)"
+    "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)",
+    "tokensPerSecond": "速度"
   },
   "usageScript": {
     "title": "配置用量查询",


### PR DESCRIPTION
## Summary
- add a per-request speed column in the request log table
- compute speed from output tokens and generation duration fallback logic
- add `tokensPerSecond` locale entries for zh/en/ja

## Test plan
- [x] `pnpm typecheck`
- [x] confirm only 4 files changed vs `main`

Made with [Cursor](https://cursor.com)