### PR TITLE
fix(proxy): align Claude OpenAI-compatible URL building

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -770,6 +770,12 @@ impl RequestForwarder {
             .and_then(|m| m.provider_type.as_deref())
             == Some("github_copilot")
             || base_url.contains("githubcopilot.com");
+        let is_openrouter = provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.provider_type.as_deref())
+            == Some("openrouter")
+            || base_url.contains("openrouter.ai");
         let resolved_claude_api_format = if adapter.name() == "Claude" {
             Some(
                 self.resolve_claude_api_format(provider, &mapped_body, is_copilot)
@@ -799,11 +805,12 @@ impl RequestForwarder {
 
         let url = if is_full_url {
             append_query_to_full_url(&base_url, passthrough_query.as_deref())
-        } else if adapter.name() == "Claude" && is_copilot {
-            // ClaudeAdapter::build_url 只能看到 base_url，而 Copilot 还支持通过
-            // meta.provider_type = github_copilot 走自定义域名/中继，因此运行时
-            // 需要在 forwarder 这里基于 metadata 做最终 URL 归一。
-            build_claude_runtime_url(&base_url, &effective_endpoint, true)
+        } else if adapter.name() == "Claude" && needs_transform {
+            // Claude/OpenAI 兼容路径在运行时还需要结合 provider metadata 做归一：
+            // - Copilot: chat 不带 /v1，responses 保持单个 /v1
+            // - OpenRouter / origin OpenAI: 兼容端点需要补 /v1
+            // - 其他自定义前缀 relay: 保持无额外 /v1
+            build_claude_runtime_url(&base_url, &effective_endpoint, is_copilot, is_openrouter)
         } else {
             adapter.build_url(&base_url, &effective_endpoint)
         };
@@ -1463,27 +1470,50 @@ fn append_query_to_full_url(base_url: &str, query: Option<&str>) -> String {
     }
 }
 
-fn build_claude_runtime_url(base_url: &str, endpoint: &str, is_copilot: bool) -> String {
+fn build_claude_runtime_url(
+    base_url: &str,
+    endpoint: &str,
+    is_copilot: bool,
+    is_openrouter: bool,
+) -> String {
     let base_trimmed = base_url.trim_end_matches('/');
     let endpoint_trimmed = endpoint.trim_start_matches('/');
-
-    if !is_copilot {
-        return format!("{base_trimmed}/{endpoint_trimmed}");
-    }
-
     let already_has_v1 = base_trimmed.ends_with("/v1");
+    let origin_only = match base_trimmed.split_once("://") {
+        Some((_scheme, rest)) => !rest.contains('/'),
+        None => !base_trimmed.contains('/'),
+    };
     let copilot_base = base_trimmed.strip_suffix("/v1").unwrap_or(base_trimmed);
+    let endpoint_is_openai_compat = matches!(
+        endpoint_trimmed,
+        value
+            if value.starts_with("chat/completions")
+                || value.starts_with("responses")
+                || value.starts_with("v1/chat/completions")
+                || value.starts_with("v1/responses")
+    );
 
-    if endpoint_trimmed.starts_with("chat/completions") {
+    let mut url = if is_copilot && endpoint_trimmed.starts_with("chat/completions") {
         format!("{copilot_base}/{endpoint_trimmed}")
     } else if already_has_v1 && endpoint_trimmed.starts_with("v1/") {
         format!(
             "{base_trimmed}/{}",
             endpoint_trimmed.trim_start_matches("v1/")
         )
+    } else if (is_openrouter || origin_only) && endpoint_is_openai_compat {
+        format!(
+            "{base_trimmed}/v1/{}",
+            endpoint_trimmed.trim_start_matches("v1/")
+        )
     } else {
         format!("{base_trimmed}/{endpoint_trimmed}")
+    };
+
+    while url.contains("/v1/v1") {
+        url = url.replace("/v1/v1", "/v1");
     }
+
+    url
 }
 
 fn should_force_identity_encoding(
@@ -1642,33 +1672,100 @@ mod tests {
 
     #[test]
     fn build_claude_runtime_url_preserves_metadata_copilot_chat_path_for_custom_host() {
-        let url =
-            build_claude_runtime_url("https://relay.example", "/chat/completions?x-id=1", true);
+        let url = build_claude_runtime_url(
+            "https://relay.example",
+            "/chat/completions?x-id=1",
+            true,
+            false,
+        );
 
         assert_eq!(url, "https://relay.example/chat/completions?x-id=1");
     }
 
     #[test]
     fn build_claude_runtime_url_strips_v1_for_metadata_copilot_chat_path() {
-        let url =
-            build_claude_runtime_url("https://relay.example/v1", "/chat/completions?x-id=1", true);
+        let url = build_claude_runtime_url(
+            "https://relay.example/v1",
+            "/chat/completions?x-id=1",
+            true,
+            false,
+        );
 
         assert_eq!(url, "https://relay.example/chat/completions?x-id=1");
     }
 
     #[test]
     fn build_claude_runtime_url_preserves_metadata_copilot_responses_path_for_custom_host() {
-        let url = build_claude_runtime_url("https://relay.example", "/v1/responses?x-id=1", true);
+        let url =
+            build_claude_runtime_url("https://relay.example", "/v1/responses?x-id=1", true, false);
 
         assert_eq!(url, "https://relay.example/v1/responses?x-id=1");
     }
 
     #[test]
     fn build_claude_runtime_url_preserves_single_v1_for_metadata_copilot_responses() {
-        let url =
-            build_claude_runtime_url("https://relay.example/v1", "/v1/responses?x-id=1", true);
+        let url = build_claude_runtime_url(
+            "https://relay.example/v1",
+            "/v1/responses?x-id=1",
+            true,
+            false,
+        );
 
         assert_eq!(url, "https://relay.example/v1/responses?x-id=1");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_adds_v1_for_openrouter_chat_compat() {
+        let url = build_claude_runtime_url(
+            "https://openrouter.ai/api",
+            "/chat/completions",
+            false,
+            true,
+        );
+
+        assert_eq!(url, "https://openrouter.ai/api/v1/chat/completions");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_adds_v1_for_openrouter_responses_compat() {
+        let url = build_claude_runtime_url("https://openrouter.ai/api", "/responses", false, true);
+
+        assert_eq!(url, "https://openrouter.ai/api/v1/responses");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_adds_v1_for_metadata_openrouter_chat_compat() {
+        let url =
+            build_claude_runtime_url("https://relay.example", "/chat/completions", false, true);
+
+        assert_eq!(url, "https://relay.example/v1/chat/completions");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_adds_v1_for_metadata_openrouter_responses_compat() {
+        let url = build_claude_runtime_url("https://relay.example", "/responses", false, true);
+
+        assert_eq!(url, "https://relay.example/v1/responses");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_preserves_custom_prefix_for_non_copilot_chat() {
+        let url = build_claude_runtime_url(
+            "https://relay.example/openai",
+            "/chat/completions",
+            false,
+            false,
+        );
+
+        assert_eq!(url, "https://relay.example/openai/chat/completions");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_preserves_custom_prefix_for_non_copilot_responses() {
+        let url =
+            build_claude_runtime_url("https://relay.example/openai", "/responses", false, false);
+
+        assert_eq!(url, "https://relay.example/openai/responses");
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -9,7 +9,11 @@ use super::{
     failover_switch::FailoverSwitchManager,
     log_codes::fwd as log_fwd,
     provider_router::ProviderRouter,
-    providers::{get_adapter, AuthInfo, AuthStrategy, ProviderAdapter, ProviderType},
+    providers::{
+        get_adapter,
+        url_classify::{dedup_v1, is_openai_compat_endpoint, BaseUrlInfo},
+        AuthInfo, AuthStrategy, ProviderAdapter, ProviderType,
+    },
     thinking_budget_rectifier::{rectify_thinking_budget, should_rectify_thinking_budget},
     thinking_rectifier::{
         normalize_thinking_type, rectify_anthropic_request, should_rectify_thinking_signature,
@@ -1478,29 +1482,17 @@ fn build_claude_runtime_url(
 ) -> String {
     let base_trimmed = base_url.trim_end_matches('/');
     let endpoint_trimmed = endpoint.trim_start_matches('/');
-    let already_has_v1 = base_trimmed.ends_with("/v1");
-    let origin_only = match base_trimmed.split_once("://") {
-        Some((_scheme, rest)) => !rest.contains('/'),
-        None => !base_trimmed.contains('/'),
-    };
-    let copilot_base = base_trimmed.strip_suffix("/v1").unwrap_or(base_trimmed);
-    let endpoint_is_openai_compat = matches!(
-        endpoint_trimmed,
-        value
-            if value.starts_with("chat/completions")
-                || value.starts_with("responses")
-                || value.starts_with("v1/chat/completions")
-                || value.starts_with("v1/responses")
-    );
+    let info = BaseUrlInfo::new(base_trimmed);
+    let endpoint_is_openai_compat = is_openai_compat_endpoint(endpoint_trimmed);
 
     let mut url = if is_copilot && endpoint_trimmed.starts_with("chat/completions") {
-        format!("{copilot_base}/{endpoint_trimmed}")
-    } else if already_has_v1 && endpoint_trimmed.starts_with("v1/") {
+        format!("{}/{endpoint_trimmed}", info.copilot_base)
+    } else if info.already_has_v1 && endpoint_trimmed.starts_with("v1/") {
         format!(
             "{base_trimmed}/{}",
             endpoint_trimmed.trim_start_matches("v1/")
         )
-    } else if (is_openrouter || origin_only) && endpoint_is_openai_compat {
+    } else if (is_openrouter || info.origin_only) && endpoint_is_openai_compat {
         format!(
             "{base_trimmed}/v1/{}",
             endpoint_trimmed.trim_start_matches("v1/")
@@ -1509,9 +1501,7 @@ fn build_claude_runtime_url(
         format!("{base_trimmed}/{endpoint_trimmed}")
     };
 
-    while url.contains("/v1/v1") {
-        url = url.replace("/v1/v1", "/v1");
-    }
+    dedup_v1(&mut url);
 
     url
 }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1432,9 +1432,9 @@ fn rewrite_claude_transform_endpoint(
     } else if is_copilot {
         "/chat/completions"
     } else if api_format == "openai_responses" {
-        "/v1/responses"
+        "/responses"
     } else {
-        "/v1/chat/completions"
+        "/chat/completions"
     };
 
     let rewritten = match passthrough_query.as_deref() {
@@ -1575,7 +1575,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(endpoint, "/v1/chat/completions?foo=bar");
+        assert_eq!(endpoint, "/chat/completions?foo=bar");
         assert_eq!(passthrough_query.as_deref(), Some("foo=bar"));
     }
 
@@ -1587,7 +1587,7 @@ mod tests {
             false,
         );
 
-        assert_eq!(endpoint, "/v1/responses?x-id=1");
+        assert_eq!(endpoint, "/responses?x-id=1");
         assert_eq!(passthrough_query.as_deref(), Some("x-id=1"));
     }
 

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -799,6 +799,11 @@ impl RequestForwarder {
 
         let url = if is_full_url {
             append_query_to_full_url(&base_url, passthrough_query.as_deref())
+        } else if adapter.name() == "Claude" && is_copilot {
+            // ClaudeAdapter::build_url 只能看到 base_url，而 Copilot 还支持通过
+            // meta.provider_type = github_copilot 走自定义域名/中继，因此运行时
+            // 需要在 forwarder 这里基于 metadata 做最终 URL 归一。
+            build_claude_runtime_url(&base_url, &effective_endpoint, true)
         } else {
             adapter.build_url(&base_url, &effective_endpoint)
         };
@@ -1458,6 +1463,29 @@ fn append_query_to_full_url(base_url: &str, query: Option<&str>) -> String {
     }
 }
 
+fn build_claude_runtime_url(base_url: &str, endpoint: &str, is_copilot: bool) -> String {
+    let base_trimmed = base_url.trim_end_matches('/');
+    let endpoint_trimmed = endpoint.trim_start_matches('/');
+
+    if !is_copilot {
+        return format!("{base_trimmed}/{endpoint_trimmed}");
+    }
+
+    let already_has_v1 = base_trimmed.ends_with("/v1");
+    let copilot_base = base_trimmed.strip_suffix("/v1").unwrap_or(base_trimmed);
+
+    if endpoint_trimmed.starts_with("chat/completions") {
+        format!("{copilot_base}/{endpoint_trimmed}")
+    } else if already_has_v1 && endpoint_trimmed.starts_with("v1/") {
+        format!(
+            "{base_trimmed}/{}",
+            endpoint_trimmed.trim_start_matches("v1/")
+        )
+    } else {
+        format!("{base_trimmed}/{endpoint_trimmed}")
+    }
+}
+
 fn should_force_identity_encoding(
     endpoint: &str,
     body: &Value,
@@ -1610,6 +1638,37 @@ mod tests {
 
         assert_eq!(endpoint, "/v1/responses?x-id=1");
         assert_eq!(passthrough_query.as_deref(), Some("x-id=1"));
+    }
+
+    #[test]
+    fn build_claude_runtime_url_preserves_metadata_copilot_chat_path_for_custom_host() {
+        let url =
+            build_claude_runtime_url("https://relay.example", "/chat/completions?x-id=1", true);
+
+        assert_eq!(url, "https://relay.example/chat/completions?x-id=1");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_strips_v1_for_metadata_copilot_chat_path() {
+        let url =
+            build_claude_runtime_url("https://relay.example/v1", "/chat/completions?x-id=1", true);
+
+        assert_eq!(url, "https://relay.example/chat/completions?x-id=1");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_preserves_metadata_copilot_responses_path_for_custom_host() {
+        let url = build_claude_runtime_url("https://relay.example", "/v1/responses?x-id=1", true);
+
+        assert_eq!(url, "https://relay.example/v1/responses?x-id=1");
+    }
+
+    #[test]
+    fn build_claude_runtime_url_preserves_single_v1_for_metadata_copilot_responses() {
+        let url =
+            build_claude_runtime_url("https://relay.example/v1", "/v1/responses?x-id=1", true);
+
+        assert_eq!(url, "https://relay.example/v1/responses?x-id=1");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -672,10 +672,7 @@ mod tests {
     #[test]
     fn test_build_url_preserves_query_for_github_copilot_chat_completions() {
         let adapter = ClaudeAdapter::new();
-        let url = adapter.build_url(
-            "https://api.githubcopilot.com",
-            "/chat/completions?x-id=1",
-        );
+        let url = adapter.build_url("https://api.githubcopilot.com", "/chat/completions?x-id=1");
         assert_eq!(url, "https://api.githubcopilot.com/chat/completions?x-id=1");
     }
 

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -315,18 +315,26 @@ impl ProviderAdapter for ClaudeAdapter {
     }
 
     fn build_url(&self, base_url: &str, endpoint: &str) -> String {
-        // NOTE:
-        // 过去 OpenRouter 只有 OpenAI Chat Completions 兼容接口，需要把 Claude 的 `/v1/messages`
-        // 映射到 `/v1/chat/completions`，并做 Anthropic ↔ OpenAI 的格式转换。
-        //
-        // 现在 OpenRouter 已推出 Claude Code 兼容接口，因此默认直接透传 endpoint。
-        // 如需回退旧逻辑，可在 forwarder 中根据 needs_transform 改写 endpoint。
-        //
-        let mut base = format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            endpoint.trim_start_matches('/')
-        );
+        let base_trimmed = base_url.trim_end_matches('/');
+        let endpoint_trimmed = endpoint.trim_start_matches('/');
+
+        // Claude/OpenAI 兼容供应商的 base_url 可能是：
+        // - 纯 origin: https://api.openai.com         (需要自动补 /v1)
+        // - 已含 /v1: https://api.openai.com/v1      (直接拼接)
+        // - 自定义前缀: https://relay.example/openai (不添加 /v1，直接拼接)
+        let already_has_v1 = base_trimmed.ends_with("/v1");
+        let origin_only = match base_trimmed.split_once("://") {
+            Some((_scheme, rest)) => !rest.contains('/'),
+            None => !base_trimmed.contains('/'),
+        };
+
+        let mut base = if already_has_v1 {
+            format!("{base_trimmed}/{endpoint_trimmed}")
+        } else if origin_only {
+            format!("{base_trimmed}/v1/{endpoint_trimmed}")
+        } else {
+            format!("{base_trimmed}/{endpoint_trimmed}")
+        };
 
         // 去除重复的 /v1/v1（可能由 base_url 与 endpoint 都带版本导致）
         while base.contains("/v1/v1") {
@@ -627,6 +635,20 @@ mod tests {
         let adapter = ClaudeAdapter::new();
         let url = adapter.build_url("https://integrate.api.nvidia.com", "/v1/chat/completions");
         assert_eq!(url, "https://integrate.api.nvidia.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn test_build_url_adds_v1_for_origin_openai_style_paths() {
+        let adapter = ClaudeAdapter::new();
+        let url = adapter.build_url("https://api.openai.com", "/chat/completions");
+        assert_eq!(url, "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn test_build_url_preserves_custom_prefix_for_openai_style_paths() {
+        let adapter = ClaudeAdapter::new();
+        let url = adapter.build_url("https://relay.example/openai", "/responses");
+        assert_eq!(url, "https://relay.example/openai/responses");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -317,6 +317,7 @@ impl ProviderAdapter for ClaudeAdapter {
     fn build_url(&self, base_url: &str, endpoint: &str) -> String {
         let base_trimmed = base_url.trim_end_matches('/');
         let endpoint_trimmed = endpoint.trim_start_matches('/');
+        let is_github_copilot = base_trimmed.contains("githubcopilot.com");
 
         // Claude/OpenAI 兼容供应商的 base_url 可能是：
         // - 纯 origin: https://api.openai.com         (需要自动补 /v1)
@@ -328,7 +329,9 @@ impl ProviderAdapter for ClaudeAdapter {
             None => !base_trimmed.contains('/'),
         };
 
-        let mut base = if already_has_v1 {
+        let mut base = if is_github_copilot && endpoint_trimmed == "chat/completions" {
+            format!("{base_trimmed}/{endpoint_trimmed}")
+        } else if already_has_v1 {
             format!("{base_trimmed}/{endpoint_trimmed}")
         } else if origin_only {
             format!("{base_trimmed}/v1/{endpoint_trimmed}")
@@ -649,6 +652,13 @@ mod tests {
         let adapter = ClaudeAdapter::new();
         let url = adapter.build_url("https://relay.example/openai", "/responses");
         assert_eq!(url, "https://relay.example/openai/responses");
+    }
+
+    #[test]
+    fn test_build_url_no_extra_v1_for_github_copilot_chat_completions() {
+        let adapter = ClaudeAdapter::new();
+        let url = adapter.build_url("https://api.githubcopilot.com", "/chat/completions");
+        assert_eq!(url, "https://api.githubcopilot.com/chat/completions");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -330,7 +330,7 @@ impl ProviderAdapter for ClaudeAdapter {
             None => !base_trimmed.contains('/'),
         };
 
-        let mut base = if is_github_copilot && endpoint_trimmed == "chat/completions" {
+        let mut base = if is_github_copilot && endpoint_trimmed.starts_with("chat/completions") {
             format!("{copilot_base}/{endpoint_trimmed}")
         } else if already_has_v1 {
             format!("{base_trimmed}/{endpoint_trimmed}")
@@ -667,6 +667,16 @@ mod tests {
         let adapter = ClaudeAdapter::new();
         let url = adapter.build_url("https://api.githubcopilot.com/v1", "/chat/completions");
         assert_eq!(url, "https://api.githubcopilot.com/chat/completions");
+    }
+
+    #[test]
+    fn test_build_url_preserves_query_for_github_copilot_chat_completions() {
+        let adapter = ClaudeAdapter::new();
+        let url = adapter.build_url(
+            "https://api.githubcopilot.com",
+            "/chat/completions?x-id=1",
+        );
+        assert_eq!(url, "https://api.githubcopilot.com/chat/completions?x-id=1");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -13,6 +13,7 @@
 //! - **OpenRouter**: 已支持 Claude Code 兼容接口，默认透传
 //! - **GitHubCopilot**: GitHub Copilot (OAuth + Copilot Token)
 
+use super::url_classify::{dedup_v1, is_openai_compat_endpoint, BaseUrlInfo};
 use super::{AuthInfo, AuthStrategy, ProviderAdapter, ProviderType};
 use crate::provider::Provider;
 use crate::proxy::error::ProxyError;
@@ -317,47 +318,27 @@ impl ProviderAdapter for ClaudeAdapter {
     fn build_url(&self, base_url: &str, endpoint: &str) -> String {
         let base_trimmed = base_url.trim_end_matches('/');
         let endpoint_trimmed = endpoint.trim_start_matches('/');
+        let info = BaseUrlInfo::new(base_trimmed);
         let is_github_copilot = base_trimmed.contains("githubcopilot.com");
         let is_openrouter = base_trimmed.contains("openrouter.ai");
-        let copilot_base = base_trimmed.strip_suffix("/v1").unwrap_or(base_trimmed);
-
-        // Claude/OpenAI 兼容供应商的 base_url 可能是：
-        // - 纯 origin: https://api.openai.com         (需要自动补 /v1)
-        // - 已含 /v1: https://api.openai.com/v1      (直接拼接)
-        // - 自定义前缀: https://relay.example/openai (不添加 /v1，直接拼接)
-        let already_has_v1 = base_trimmed.ends_with("/v1");
-        let origin_only = match base_trimmed.split_once("://") {
-            Some((_scheme, rest)) => !rest.contains('/'),
-            None => !base_trimmed.contains('/'),
-        };
-        let endpoint_is_openai_compat = matches!(
-            endpoint_trimmed,
-            value
-                if value.starts_with("chat/completions")
-                    || value.starts_with("responses")
-                    || value.starts_with("v1/chat/completions")
-                    || value.starts_with("v1/responses")
-        );
+        let endpoint_is_openai_compat = is_openai_compat_endpoint(endpoint_trimmed);
 
         let mut base = if is_github_copilot && endpoint_trimmed.starts_with("chat/completions") {
-            format!("{copilot_base}/{endpoint_trimmed}")
-        } else if already_has_v1 {
+            format!("{}/{endpoint_trimmed}", info.copilot_base)
+        } else if info.already_has_v1 {
             format!("{base_trimmed}/{endpoint_trimmed}")
         } else if is_openrouter && endpoint_is_openai_compat {
             format!(
                 "{base_trimmed}/v1/{}",
                 endpoint_trimmed.trim_start_matches("v1/")
             )
-        } else if origin_only {
+        } else if info.origin_only {
             format!("{base_trimmed}/v1/{endpoint_trimmed}")
         } else {
             format!("{base_trimmed}/{endpoint_trimmed}")
         };
 
-        // 去除重复的 /v1/v1（可能由 base_url 与 endpoint 都带版本导致）
-        while base.contains("/v1/v1") {
-            base = base.replace("/v1/v1", "/v1");
-        }
+        dedup_v1(&mut base);
 
         base
     }

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -318,6 +318,7 @@ impl ProviderAdapter for ClaudeAdapter {
         let base_trimmed = base_url.trim_end_matches('/');
         let endpoint_trimmed = endpoint.trim_start_matches('/');
         let is_github_copilot = base_trimmed.contains("githubcopilot.com");
+        let copilot_base = base_trimmed.strip_suffix("/v1").unwrap_or(base_trimmed);
 
         // Claude/OpenAI 兼容供应商的 base_url 可能是：
         // - 纯 origin: https://api.openai.com         (需要自动补 /v1)
@@ -330,7 +331,7 @@ impl ProviderAdapter for ClaudeAdapter {
         };
 
         let mut base = if is_github_copilot && endpoint_trimmed == "chat/completions" {
-            format!("{base_trimmed}/{endpoint_trimmed}")
+            format!("{copilot_base}/{endpoint_trimmed}")
         } else if already_has_v1 {
             format!("{base_trimmed}/{endpoint_trimmed}")
         } else if origin_only {
@@ -658,6 +659,13 @@ mod tests {
     fn test_build_url_no_extra_v1_for_github_copilot_chat_completions() {
         let adapter = ClaudeAdapter::new();
         let url = adapter.build_url("https://api.githubcopilot.com", "/chat/completions");
+        assert_eq!(url, "https://api.githubcopilot.com/chat/completions");
+    }
+
+    #[test]
+    fn test_build_url_strips_v1_for_github_copilot_chat_completions() {
+        let adapter = ClaudeAdapter::new();
+        let url = adapter.build_url("https://api.githubcopilot.com/v1", "/chat/completions");
         assert_eq!(url, "https://api.githubcopilot.com/chat/completions");
     }
 

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -318,6 +318,7 @@ impl ProviderAdapter for ClaudeAdapter {
         let base_trimmed = base_url.trim_end_matches('/');
         let endpoint_trimmed = endpoint.trim_start_matches('/');
         let is_github_copilot = base_trimmed.contains("githubcopilot.com");
+        let is_openrouter = base_trimmed.contains("openrouter.ai");
         let copilot_base = base_trimmed.strip_suffix("/v1").unwrap_or(base_trimmed);
 
         // Claude/OpenAI 兼容供应商的 base_url 可能是：
@@ -329,11 +330,24 @@ impl ProviderAdapter for ClaudeAdapter {
             Some((_scheme, rest)) => !rest.contains('/'),
             None => !base_trimmed.contains('/'),
         };
+        let endpoint_is_openai_compat = matches!(
+            endpoint_trimmed,
+            value
+                if value.starts_with("chat/completions")
+                    || value.starts_with("responses")
+                    || value.starts_with("v1/chat/completions")
+                    || value.starts_with("v1/responses")
+        );
 
         let mut base = if is_github_copilot && endpoint_trimmed.starts_with("chat/completions") {
             format!("{copilot_base}/{endpoint_trimmed}")
         } else if already_has_v1 {
             format!("{base_trimmed}/{endpoint_trimmed}")
+        } else if is_openrouter && endpoint_is_openai_compat {
+            format!(
+                "{base_trimmed}/v1/{}",
+                endpoint_trimmed.trim_start_matches("v1/")
+            )
         } else if origin_only {
             format!("{base_trimmed}/v1/{endpoint_trimmed}")
         } else {
@@ -653,6 +667,20 @@ mod tests {
         let adapter = ClaudeAdapter::new();
         let url = adapter.build_url("https://relay.example/openai", "/responses");
         assert_eq!(url, "https://relay.example/openai/responses");
+    }
+
+    #[test]
+    fn test_build_url_adds_v1_for_openrouter_chat_compat() {
+        let adapter = ClaudeAdapter::new();
+        let url = adapter.build_url("https://openrouter.ai/api", "/chat/completions");
+        assert_eq!(url, "https://openrouter.ai/api/v1/chat/completions");
+    }
+
+    #[test]
+    fn test_build_url_adds_v1_for_openrouter_responses_compat() {
+        let adapter = ClaudeAdapter::new();
+        let url = adapter.build_url("https://openrouter.ai/api", "/responses");
+        assert_eq!(url, "https://openrouter.ai/api/v1/responses");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -5,6 +5,7 @@
 //! ## 客户端检测
 //! 支持检测官方 Codex 客户端 (codex_vscode, codex_cli_rs)
 
+use super::url_classify::{dedup_v1, BaseUrlInfo};
 use super::{AuthInfo, AuthStrategy, ProviderAdapter};
 use crate::provider::Provider;
 use crate::proxy::error::ProxyError;
@@ -139,36 +140,17 @@ impl ProviderAdapter for CodexAdapter {
     fn build_url(&self, base_url: &str, endpoint: &str) -> String {
         let base_trimmed = base_url.trim_end_matches('/');
         let endpoint_trimmed = endpoint.trim_start_matches('/');
+        let info = BaseUrlInfo::new(base_trimmed);
 
-        // OpenAI/Codex 的 base_url 可能是：
-        // - 纯 origin: https://api.openai.com  (需要自动补 /v1)
-        // - 已含 /v1: https://api.openai.com/v1 (直接拼接)
-        // - 自定义前缀: https://xxx/openai (不添加 /v1，直接拼接)
-
-        // 检查 base_url 是否已经包含 /v1
-        let already_has_v1 = base_trimmed.ends_with("/v1");
-
-        // 检查是否是纯 origin（没有路径部分）
-        let origin_only = match base_trimmed.split_once("://") {
-            Some((_scheme, rest)) => !rest.contains('/'),
-            None => !base_trimmed.contains('/'),
-        };
-
-        let mut url = if already_has_v1 {
-            // 已经有 /v1，直接拼接
+        let mut url = if info.already_has_v1 {
             format!("{base_trimmed}/{endpoint_trimmed}")
-        } else if origin_only {
-            // 纯 origin，添加 /v1
+        } else if info.origin_only {
             format!("{base_trimmed}/v1/{endpoint_trimmed}")
         } else {
-            // 自定义前缀，不添加 /v1，直接拼接
             format!("{base_trimmed}/{endpoint_trimmed}")
         };
 
-        // 去除重复的 /v1/v1（可能由 base_url 与 endpoint 都带版本导致）
-        while url.contains("/v1/v1") {
-            url = url.replace("/v1/v1", "/v1");
-        }
+        dedup_v1(&mut url);
 
         url
     }

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -22,6 +22,7 @@ pub mod streaming;
 pub mod streaming_responses;
 pub mod transform;
 pub mod transform_responses;
+pub mod url_classify;
 
 use crate::app_config::AppType;
 use crate::provider::Provider;

--- a/src-tauri/src/proxy/providers/url_classify.rs
+++ b/src-tauri/src/proxy/providers/url_classify.rs
@@ -1,0 +1,170 @@
+#[derive(Debug, Clone)]
+pub struct BaseUrlInfo<'a> {
+    pub already_has_v1: bool,
+    /// `true` when `base_trimmed` is a bare origin with no path component.
+    pub origin_only: bool,
+    /// `base_trimmed` with a trailing `/v1` stripped (if present).
+    pub copilot_base: &'a str,
+}
+
+impl<'a> BaseUrlInfo<'a> {
+    pub fn new(base_trimmed: &'a str) -> Self {
+        let already_has_v1 = base_trimmed.ends_with("/v1");
+        let origin_only = match base_trimmed.split_once("://") {
+            Some((_scheme, rest)) => !rest.contains('/'),
+            None => !base_trimmed.contains('/'),
+        };
+        let copilot_base = base_trimmed.strip_suffix("/v1").unwrap_or(base_trimmed);
+
+        Self {
+            already_has_v1,
+            origin_only,
+            copilot_base,
+        }
+    }
+}
+
+pub fn is_openai_compat_endpoint(endpoint_trimmed: &str) -> bool {
+    endpoint_trimmed.starts_with("chat/completions")
+        || endpoint_trimmed.starts_with("responses")
+        || endpoint_trimmed.starts_with("v1/chat/completions")
+        || endpoint_trimmed.starts_with("v1/responses")
+}
+
+pub fn dedup_v1(url: &mut String) {
+    while url.contains("/v1/v1") {
+        *url = url.replace("/v1/v1", "/v1");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── BaseUrlInfo ──────────────────────────────────────────────
+
+    #[test]
+    fn test_origin_only_https() {
+        let info = BaseUrlInfo::new("https://api.openai.com");
+        assert!(info.origin_only);
+        assert!(!info.already_has_v1);
+        assert_eq!(info.copilot_base, "https://api.openai.com");
+    }
+
+    #[test]
+    fn test_already_has_v1() {
+        let info = BaseUrlInfo::new("https://api.openai.com/v1");
+        assert!(!info.origin_only);
+        assert!(info.already_has_v1);
+        assert_eq!(info.copilot_base, "https://api.openai.com");
+    }
+
+    #[test]
+    fn test_custom_prefix() {
+        let info = BaseUrlInfo::new("https://relay.example/openai");
+        assert!(!info.origin_only);
+        assert!(!info.already_has_v1);
+        assert_eq!(info.copilot_base, "https://relay.example/openai");
+    }
+
+    #[test]
+    fn test_copilot_url() {
+        let info = BaseUrlInfo::new("https://api.githubcopilot.com");
+        assert!(info.origin_only);
+        assert!(!info.already_has_v1);
+        assert_eq!(info.copilot_base, "https://api.githubcopilot.com");
+    }
+
+    #[test]
+    fn test_copilot_url_with_v1() {
+        let info = BaseUrlInfo::new("https://api.githubcopilot.com/v1");
+        assert!(!info.origin_only);
+        assert!(info.already_has_v1);
+        assert_eq!(info.copilot_base, "https://api.githubcopilot.com");
+    }
+
+    #[test]
+    fn test_openrouter_api() {
+        let info = BaseUrlInfo::new("https://openrouter.ai/api");
+        assert!(!info.origin_only);
+        assert!(!info.already_has_v1);
+        assert_eq!(info.copilot_base, "https://openrouter.ai/api");
+    }
+
+    #[test]
+    fn test_openrouter_api_v1() {
+        let info = BaseUrlInfo::new("https://openrouter.ai/api/v1");
+        assert!(!info.origin_only);
+        assert!(info.already_has_v1);
+        assert_eq!(info.copilot_base, "https://openrouter.ai/api");
+    }
+
+    #[test]
+    fn test_no_scheme() {
+        let info = BaseUrlInfo::new("localhost:8080");
+        assert!(info.origin_only);
+        assert!(!info.already_has_v1);
+    }
+
+    #[test]
+    fn test_no_scheme_with_path() {
+        let info = BaseUrlInfo::new("localhost:8080/api");
+        assert!(!info.origin_only);
+        assert!(!info.already_has_v1);
+    }
+
+    // ── is_openai_compat_endpoint ────────────────────────────────
+
+    #[test]
+    fn test_endpoint_chat_completions() {
+        assert!(is_openai_compat_endpoint("chat/completions"));
+    }
+
+    #[test]
+    fn test_endpoint_responses() {
+        assert!(is_openai_compat_endpoint("responses"));
+    }
+
+    #[test]
+    fn test_endpoint_v1_chat_completions() {
+        assert!(is_openai_compat_endpoint("v1/chat/completions"));
+    }
+
+    #[test]
+    fn test_endpoint_v1_responses() {
+        assert!(is_openai_compat_endpoint("v1/responses"));
+    }
+
+    #[test]
+    fn test_endpoint_messages_not_compat() {
+        assert!(!is_openai_compat_endpoint("messages"));
+    }
+
+    #[test]
+    fn test_endpoint_v1_messages_not_compat() {
+        assert!(!is_openai_compat_endpoint("v1/messages"));
+    }
+
+    // ── dedup_v1 ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_dedup_single() {
+        let mut url = "https://api.example.com/v1/v1/chat/completions".to_string();
+        dedup_v1(&mut url);
+        assert_eq!(url, "https://api.example.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn test_dedup_double() {
+        let mut url = "https://api.example.com/v1/v1/v1/chat/completions".to_string();
+        dedup_v1(&mut url);
+        assert_eq!(url, "https://api.example.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn test_dedup_noop() {
+        let mut url = "https://api.example.com/v1/chat/completions".to_string();
+        dedup_v1(&mut url);
+        assert_eq!(url, "https://api.example.com/v1/chat/completions");
+    }
+}

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -751,7 +751,11 @@ impl StreamCheckService {
         };
 
         if is_github_copilot && api_format == "openai_responses" {
-            format!("{base}/v1/responses")
+            if already_has_v1 {
+                format!("{base}/responses")
+            } else {
+                format!("{base}/v1/responses")
+            }
         } else if is_github_copilot {
             format!("{base}/chat/completions")
         } else if api_format == "openai_responses" {
@@ -930,6 +934,18 @@ mod tests {
     fn test_resolve_claude_stream_url_for_github_copilot_responses() {
         let url = StreamCheckService::resolve_claude_stream_url(
             "https://api.githubcopilot.com",
+            AuthStrategy::GitHubCopilot,
+            "openai_responses",
+            false,
+        );
+
+        assert_eq!(url, "https://api.githubcopilot.com/v1/responses");
+    }
+
+    #[test]
+    fn test_resolve_claude_stream_url_for_github_copilot_responses_with_v1_base() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://api.githubcopilot.com/v1",
             AuthStrategy::GitHubCopilot,
             "openai_responses",
             false,

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -744,24 +744,33 @@ impl StreamCheckService {
 
         let base = base_url.trim_end_matches('/');
         let is_github_copilot = auth_strategy == AuthStrategy::GitHubCopilot;
+        let already_has_v1 = base.ends_with("/v1");
+        let origin_only = match base.split_once("://") {
+            Some((_scheme, rest)) => !rest.contains('/'),
+            None => !base.contains('/'),
+        };
 
         if is_github_copilot && api_format == "openai_responses" {
             format!("{base}/v1/responses")
         } else if is_github_copilot {
             format!("{base}/chat/completions")
         } else if api_format == "openai_responses" {
-            if base.ends_with("/v1") {
+            if already_has_v1 {
                 format!("{base}/responses")
-            } else {
+            } else if origin_only {
                 format!("{base}/v1/responses")
+            } else {
+                format!("{base}/responses")
             }
         } else if api_format == "openai_chat" {
-            if base.ends_with("/v1") {
+            if already_has_v1 {
                 format!("{base}/chat/completions")
-            } else {
+            } else if origin_only {
                 format!("{base}/v1/chat/completions")
+            } else {
+                format!("{base}/chat/completions")
             }
-        } else if base.ends_with("/v1") {
+        } else if already_has_v1 {
             format!("{base}/messages")
         } else {
             format!("{base}/v1/messages")
@@ -951,6 +960,30 @@ mod tests {
         );
 
         assert_eq!(url, "https://example.com/v1/responses");
+    }
+
+    #[test]
+    fn test_resolve_claude_stream_url_for_openai_responses_with_custom_prefix() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://example.com/openai",
+            AuthStrategy::Bearer,
+            "openai_responses",
+            false,
+        );
+
+        assert_eq!(url, "https://example.com/openai/responses");
+    }
+
+    #[test]
+    fn test_resolve_claude_stream_url_for_openai_chat_with_custom_prefix() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://example.com/openai",
+            AuthStrategy::Bearer,
+            "openai_chat",
+            false,
+        );
+
+        assert_eq!(url, "https://example.com/openai/chat/completions");
     }
 
     #[test]

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -15,6 +15,7 @@ use crate::provider::Provider;
 use crate::proxy::providers::copilot_auth;
 use crate::proxy::providers::transform::anthropic_to_openai;
 use crate::proxy::providers::transform_responses::anthropic_to_responses;
+use crate::proxy::providers::url_classify::BaseUrlInfo;
 use crate::proxy::providers::{get_adapter, AuthInfo, AuthStrategy};
 
 /// 健康状态枚举
@@ -755,39 +756,34 @@ impl StreamCheckService {
         }
 
         let base = base_url.trim_end_matches('/');
+        let info = BaseUrlInfo::new(base);
         let is_github_copilot = auth_strategy == AuthStrategy::GitHubCopilot;
-        let already_has_v1 = base.ends_with("/v1");
-        let copilot_base = base.strip_suffix("/v1").unwrap_or(base);
-        let origin_only = match base.split_once("://") {
-            Some((_scheme, rest)) => !rest.contains('/'),
-            None => !base.contains('/'),
-        };
 
         if is_github_copilot && api_format == "openai_responses" {
-            if already_has_v1 {
+            if info.already_has_v1 {
                 format!("{base}/responses")
             } else {
                 format!("{base}/v1/responses")
             }
         } else if is_github_copilot {
-            format!("{copilot_base}/chat/completions")
+            format!("{}/chat/completions", info.copilot_base)
         } else if api_format == "openai_responses" {
-            if already_has_v1 {
+            if info.already_has_v1 {
                 format!("{base}/responses")
-            } else if is_openrouter || origin_only {
+            } else if is_openrouter || info.origin_only {
                 format!("{base}/v1/responses")
             } else {
                 format!("{base}/responses")
             }
         } else if api_format == "openai_chat" {
-            if already_has_v1 {
+            if info.already_has_v1 {
                 format!("{base}/chat/completions")
-            } else if is_openrouter || origin_only {
+            } else if is_openrouter || info.origin_only {
                 format!("{base}/v1/chat/completions")
             } else {
                 format!("{base}/chat/completions")
             }
-        } else if already_has_v1 {
+        } else if info.already_has_v1 {
             format!("{base}/messages")
         } else {
             format!("{base}/v1/messages")

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -339,8 +339,19 @@ impl StreamCheckService {
             .unwrap_or(false);
         let is_openai_chat = effective_api_format == "openai_chat";
         let is_openai_responses = effective_api_format == "openai_responses";
-        let url =
-            Self::resolve_claude_stream_url(base, auth.strategy, effective_api_format, is_full_url);
+        let is_openrouter = provider
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.provider_type.as_deref())
+            == Some("openrouter")
+            || base.contains("openrouter.ai");
+        let url = Self::resolve_claude_stream_url(
+            base,
+            auth.strategy,
+            effective_api_format,
+            is_full_url,
+            is_openrouter,
+        );
 
         let max_tokens = if is_openai_responses { 16 } else { 1 };
 
@@ -737,6 +748,7 @@ impl StreamCheckService {
         auth_strategy: AuthStrategy,
         api_format: &str,
         is_full_url: bool,
+        is_openrouter: bool,
     ) -> String {
         if is_full_url {
             return base_url.to_string();
@@ -762,7 +774,7 @@ impl StreamCheckService {
         } else if api_format == "openai_responses" {
             if already_has_v1 {
                 format!("{base}/responses")
-            } else if origin_only {
+            } else if is_openrouter || origin_only {
                 format!("{base}/v1/responses")
             } else {
                 format!("{base}/responses")
@@ -770,7 +782,7 @@ impl StreamCheckService {
         } else if api_format == "openai_chat" {
             if already_has_v1 {
                 format!("{base}/chat/completions")
-            } else if origin_only {
+            } else if is_openrouter || origin_only {
                 format!("{base}/v1/chat/completions")
             } else {
                 format!("{base}/chat/completions")
@@ -914,6 +926,7 @@ mod tests {
             AuthStrategy::Bearer,
             "openai_chat",
             true,
+            false,
         );
 
         assert_eq!(url, "https://relay.example/v1/chat/completions");
@@ -925,6 +938,7 @@ mod tests {
             "https://api.githubcopilot.com",
             AuthStrategy::GitHubCopilot,
             "openai_chat",
+            false,
             false,
         );
 
@@ -938,6 +952,7 @@ mod tests {
             AuthStrategy::GitHubCopilot,
             "openai_chat",
             false,
+            false,
         );
 
         assert_eq!(url, "https://api.githubcopilot.com/chat/completions");
@@ -949,6 +964,7 @@ mod tests {
             "https://api.githubcopilot.com",
             AuthStrategy::GitHubCopilot,
             "openai_responses",
+            false,
             false,
         );
 
@@ -962,6 +978,7 @@ mod tests {
             AuthStrategy::GitHubCopilot,
             "openai_responses",
             false,
+            false,
         );
 
         assert_eq!(url, "https://api.githubcopilot.com/v1/responses");
@@ -973,6 +990,7 @@ mod tests {
             "https://example.com/v1",
             AuthStrategy::Bearer,
             "openai_chat",
+            false,
             false,
         );
 
@@ -986,6 +1004,7 @@ mod tests {
             AuthStrategy::Bearer,
             "openai_responses",
             false,
+            false,
         );
 
         assert_eq!(url, "https://example.com/v1/responses");
@@ -997,6 +1016,7 @@ mod tests {
             "https://example.com/openai",
             AuthStrategy::Bearer,
             "openai_responses",
+            false,
             false,
         );
 
@@ -1010,6 +1030,7 @@ mod tests {
             AuthStrategy::Bearer,
             "openai_chat",
             false,
+            false,
         );
 
         assert_eq!(url, "https://example.com/openai/chat/completions");
@@ -1022,9 +1043,62 @@ mod tests {
             AuthStrategy::Anthropic,
             "anthropic",
             false,
+            false,
         );
 
         assert_eq!(url, "https://api.anthropic.com/v1/messages");
+    }
+
+    #[test]
+    fn test_resolve_claude_stream_url_for_openrouter_chat_compat() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://openrouter.ai/api",
+            AuthStrategy::Bearer,
+            "openai_chat",
+            false,
+            true,
+        );
+
+        assert_eq!(url, "https://openrouter.ai/api/v1/chat/completions");
+    }
+
+    #[test]
+    fn test_resolve_claude_stream_url_for_openrouter_responses_compat() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://openrouter.ai/api",
+            AuthStrategy::Bearer,
+            "openai_responses",
+            false,
+            true,
+        );
+
+        assert_eq!(url, "https://openrouter.ai/api/v1/responses");
+    }
+
+    #[test]
+    fn test_resolve_claude_stream_url_for_metadata_openrouter_chat_compat() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://relay.example",
+            AuthStrategy::Bearer,
+            "openai_chat",
+            false,
+            true,
+        );
+
+        assert_eq!(url, "https://relay.example/v1/chat/completions");
+    }
+
+    #[test]
+    fn test_resolve_claude_stream_url_for_metadata_openrouter_responses_compat() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://relay.example",
+            AuthStrategy::Bearer,
+            "openai_responses",
+            false,
+            true,
+        );
+
+        assert_eq!(url, "https://relay.example/v1/responses");
     }
 
     #[test]

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -745,6 +745,7 @@ impl StreamCheckService {
         let base = base_url.trim_end_matches('/');
         let is_github_copilot = auth_strategy == AuthStrategy::GitHubCopilot;
         let already_has_v1 = base.ends_with("/v1");
+        let copilot_base = base.strip_suffix("/v1").unwrap_or(base);
         let origin_only = match base.split_once("://") {
             Some((_scheme, rest)) => !rest.contains('/'),
             None => !base.contains('/'),
@@ -757,7 +758,7 @@ impl StreamCheckService {
                 format!("{base}/v1/responses")
             }
         } else if is_github_copilot {
-            format!("{base}/chat/completions")
+            format!("{copilot_base}/chat/completions")
         } else if api_format == "openai_responses" {
             if already_has_v1 {
                 format!("{base}/responses")
@@ -922,6 +923,18 @@ mod tests {
     fn test_resolve_claude_stream_url_for_github_copilot() {
         let url = StreamCheckService::resolve_claude_stream_url(
             "https://api.githubcopilot.com",
+            AuthStrategy::GitHubCopilot,
+            "openai_chat",
+            false,
+        );
+
+        assert_eq!(url, "https://api.githubcopilot.com/chat/completions");
+    }
+
+    #[test]
+    fn test_resolve_claude_stream_url_for_github_copilot_chat_with_v1_base() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://api.githubcopilot.com/v1",
             AuthStrategy::GitHubCopilot,
             "openai_chat",
             false,


### PR DESCRIPTION
## Summary

Fix Claude OpenAI-compatible URL building so custom base URLs with path prefixes (for example `https://example.com/openai`) no longer force an extra `/v1` segment.

Closes #1873

## What changed

- rewrite Claude-transformed OpenAI endpoints to logical paths (`/responses`, `/chat/completions`) instead of always forcing `/v1/...`
- align `ClaudeAdapter::build_url` with the Codex URL-building rules:
  - pure origin -> add `/v1`
  - existing `/v1` -> reuse it
  - custom path prefix -> do not add another `/v1`
- update `stream_check` to use the same URL resolution rules as runtime forwarding
- add focused tests for custom-prefix OpenAI-compatible base URLs

## Why

Codex already handles custom OpenAI-compatible base URLs like `https://example.com/openai` without injecting another `/v1` segment, but Claude forwarding previously produced URLs such as:

- `https://example.com/openai/v1/responses`
- `https://example.com/openai/v1/chat/completions`

Some relays only expose:

- `https://example.com/openai/responses`
- `https://example.com/openai/chat/completions`

which results in upstream 404s.

## Verification

Passed:

- `cargo test rewrite_claude_transform_endpoint --manifest-path src-tauri/Cargo.toml`
- `cargo test test_build_url_ --manifest-path src-tauri/Cargo.toml`
- `cargo test test_resolve_claude_stream_url_ --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm tauri build --debug`
- `pnpm tauri build`

Note:

- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` currently fails on pre-existing warnings outside the touched files (for example in `src/commands/misc.rs`, `src/commands/settings.rs`, `src/database/backup.rs`, `src/provider.rs`, and `src/proxy/response_processor.rs`). I did not fold those unrelated cleanups into this PR to keep it focused.
