### PR TITLE
feat(provider): add TheRouter presets for Claude, Codex, and Gemini

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -671,6 +671,24 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#6566F1",
   },
   {
+    name: "TheRouter",
+    websiteUrl: "https://therouter.ai",
+    apiKeyUrl: "https://dashboard.therouter.ai",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.therouter.ai",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_API_KEY: "",
+        ANTHROPIC_MODEL: "anthropic/claude-sonnet-4.6",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "anthropic/claude-haiku-4.5",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-sonnet-4.6",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-4.6",
+      },
+    },
+    category: "aggregator",
+    endpointCandidates: ["https://api.therouter.ai"],
+  },
+  {
     name: "Novita AI",
     websiteUrl: "https://novita.ai",
     apiKeyUrl: "https://novita.ai",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -365,4 +365,17 @@ requires_openai_auth = true`,
     icon: "openrouter",
     iconColor: "#6566F1",
   },
+  {
+    name: "TheRouter",
+    websiteUrl: "https://therouter.ai",
+    apiKeyUrl: "https://dashboard.therouter.ai",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "therouter",
+      "https://api.therouter.ai/v1",
+      "openai/gpt-5.3-codex",
+    ),
+    endpointCandidates: ["https://api.therouter.ai/v1"],
+    category: "aggregator",
+  },
 ];

--- a/src/config/geminiProviderPresets.ts
+++ b/src/config/geminiProviderPresets.ts
@@ -242,6 +242,22 @@ export const geminiProviderPresets: GeminiProviderPreset[] = [
     iconColor: "#6566F1",
   },
   {
+    name: "TheRouter",
+    websiteUrl: "https://therouter.ai",
+    apiKeyUrl: "https://dashboard.therouter.ai",
+    settingsConfig: {
+      env: {
+        GOOGLE_GEMINI_BASE_URL: "https://api.therouter.ai",
+        GEMINI_MODEL: "gemini-2.5-pro",
+      },
+    },
+    baseURL: "https://api.therouter.ai",
+    model: "gemini-2.5-pro",
+    description: "TheRouter",
+    category: "aggregator",
+    endpointCandidates: ["https://api.therouter.ai"],
+  },
+  {
     name: "自定义",
     websiteUrl: "",
     settingsConfig: {

--- a/tests/config/therouterProviderPresets.test.ts
+++ b/tests/config/therouterProviderPresets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { providerPresets } from "@/config/claudeProviderPresets";
 import { codexProviderPresets } from "@/config/codexProviderPresets";
+import { geminiProviderPresets } from "@/config/geminiProviderPresets";
 
 describe("TheRouter provider presets", () => {
   it("uses the Anthropic-compatible root endpoint for Claude", () => {
@@ -45,5 +46,21 @@ describe("TheRouter provider presets", () => {
       'base_url = "https://api.therouter.ai/v1"',
     );
     expect(preset?.config).toContain('wire_api = "responses"');
+  });
+
+  it("uses the Gemini-native root endpoint for Gemini", () => {
+    const preset = geminiProviderPresets.find((item) => item.name === "TheRouter");
+
+    expect(preset).toBeDefined();
+    expect(preset?.websiteUrl).toBe("https://therouter.ai");
+    expect(preset?.apiKeyUrl).toBe("https://dashboard.therouter.ai");
+    expect(preset?.category).toBe("aggregator");
+    expect(preset?.endpointCandidates).toEqual(["https://api.therouter.ai"]);
+    expect(preset?.baseURL).toBe("https://api.therouter.ai");
+    expect(preset?.model).toBe("gemini-2.5-pro");
+
+    const env = (preset?.settingsConfig as { env: Record<string, string> }).env;
+    expect(env.GOOGLE_GEMINI_BASE_URL).toBe("https://api.therouter.ai");
+    expect(env.GEMINI_MODEL).toBe("gemini-2.5-pro");
   });
 });

--- a/tests/config/therouterProviderPresets.test.ts
+++ b/tests/config/therouterProviderPresets.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { providerPresets } from "@/config/claudeProviderPresets";
+import { codexProviderPresets } from "@/config/codexProviderPresets";
+
+describe("TheRouter provider presets", () => {
+  it("uses the Anthropic-compatible root endpoint for Claude", () => {
+    const preset = providerPresets.find((item) => item.name === "TheRouter");
+
+    expect(preset).toBeDefined();
+    expect(preset?.websiteUrl).toBe("https://therouter.ai");
+    expect(preset?.apiKeyUrl).toBe("https://dashboard.therouter.ai");
+    expect(preset?.category).toBe("aggregator");
+    expect(preset?.endpointCandidates).toEqual(["https://api.therouter.ai"]);
+
+    const env = (preset?.settingsConfig as { env: Record<string, string> }).env;
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://api.therouter.ai");
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("");
+    expect(env.ANTHROPIC_API_KEY).toBe("");
+    expect(env.ANTHROPIC_MODEL).toBe("anthropic/claude-sonnet-4.6");
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe(
+      "anthropic/claude-haiku-4.5",
+    );
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(
+      "anthropic/claude-sonnet-4.6",
+    );
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe(
+      "anthropic/claude-opus-4.6",
+    );
+  });
+
+  it("uses the OpenAI-compatible v1 endpoint for Codex", () => {
+    const preset = codexProviderPresets.find((item) => item.name === "TheRouter");
+
+    expect(preset).toBeDefined();
+    expect(preset?.websiteUrl).toBe("https://therouter.ai");
+    expect(preset?.apiKeyUrl).toBe("https://dashboard.therouter.ai");
+    expect(preset?.category).toBe("aggregator");
+    expect(preset?.endpointCandidates).toEqual([
+      "https://api.therouter.ai/v1",
+    ]);
+    expect(preset?.auth).toEqual({ OPENAI_API_KEY: "" });
+    expect(preset?.config).toContain('model_provider = "therouter"');
+    expect(preset?.config).toContain('model = "openai/gpt-5.3-codex"');
+    expect(preset?.config).toContain(
+      'base_url = "https://api.therouter.ai/v1"',
+    );
+    expect(preset?.config).toContain('wire_api = "responses"');
+  });
+});


### PR DESCRIPTION
## Summary / 概述

- add TheRouter presets for Claude, Codex, and Gemini
- point the presets at `https://api.therouter.ai` with provider-specific env keys
- add unit coverage for the new TheRouter presets

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| N/A | N/A |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
