### PR TITLE
fix: preserve takeover live state during provider refresh

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -212,23 +212,7 @@ pub async fn set_claude_common_config_snippet(
     snippet: String,
     state: tauri::State<'_, crate::store::AppState>,
 ) -> Result<(), String> {
-    let is_cleared = snippet.trim().is_empty();
-
-    if !snippet.trim().is_empty() {
-        serde_json::from_str::<serde_json::Value>(&snippet).map_err(invalid_json_format_error)?;
-    }
-
-    let value = if is_cleared { None } else { Some(snippet) };
-
-    state
-        .db
-        .set_config_snippet("claude", value)
-        .map_err(|e| e.to_string())?;
-    state
-        .db
-        .set_config_snippet_cleared("claude", is_cleared)
-        .map_err(|e| e.to_string())?;
-    Ok(())
+    set_common_config_snippet("claude".to_string(), snippet, state).await
 }
 
 #[tauri::command]
@@ -286,7 +270,13 @@ pub async fn set_common_config_snippet(
         let app = AppType::from_str(&app_type).map_err(|e| e.to_string())?;
         crate::services::provider::ProviderService::sync_current_provider_for_app(
             state.inner(),
+            app.clone(),
+        )
+        .map_err(|e| e.to_string())?;
+        crate::services::provider::ProviderService::sync_current_common_config_for_app(
+            state.inner(),
             app,
+            old_snippet.as_deref(),
         )
         .map_err(|e| e.to_string())?;
     }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -435,11 +435,121 @@ base_url = "http://localhost:8080"
             Some("http://127.0.0.1:15721"),
             "proxy base URL should stay intact"
         );
-        assert!(
+        assert_eq!(
             live.get("env")
                 .and_then(|env| env.get("ANTHROPIC_MODEL"))
-                .is_none(),
-            "model override should be removed in takeover live config"
+                .and_then(|v| v.as_str()),
+            Some("model-updated"),
+            "current provider model should be refreshed into takeover live config"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn update_current_gemini_provider_syncs_live_when_proxy_takeover_detected_without_backup()
+    {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+
+        let original = Provider::with_id(
+            "g1".into(),
+            "Gemini A".into(),
+            json!({
+                "env": {
+                    "GEMINI_API_KEY": "token-a",
+                    "GOOGLE_GEMINI_BASE_URL": "https://gemini.a.example",
+                    "GEMINI_MODEL": "gemini-old"
+                }
+            }),
+            None,
+        );
+        db.save_provider("gemini", &original)
+            .expect("save provider");
+        db.set_current_provider("gemini", "g1")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Gemini, Some("g1"))
+            .expect("set local current provider");
+
+        db.update_proxy_config(ProxyConfig {
+            live_takeover_active: true,
+            ..Default::default()
+        })
+        .await
+        .expect("update proxy config");
+        {
+            let mut config = db
+                .get_proxy_config_for_app("gemini")
+                .await
+                .expect("get app proxy config");
+            config.enabled = true;
+            db.update_proxy_config_for_app(config)
+                .await
+                .expect("update app proxy config");
+        }
+
+        crate::gemini_config::write_gemini_env_atomic(&std::collections::HashMap::from([
+            (
+                "GOOGLE_GEMINI_BASE_URL".to_string(),
+                "http://127.0.0.1:15721".to_string(),
+            ),
+            ("GEMINI_API_KEY".to_string(), "PROXY_MANAGED".to_string()),
+            ("GEMINI_MODEL".to_string(), "stale-model".to_string()),
+        ]))
+        .expect("seed taken-over live env");
+
+        state
+            .proxy_service
+            .start()
+            .await
+            .expect("start proxy service");
+
+        let updated = Provider::with_id(
+            "g1".into(),
+            "Gemini A".into(),
+            json!({
+                "env": {
+                    "GEMINI_API_KEY": "token-updated",
+                    "GOOGLE_GEMINI_BASE_URL": "https://gemini.updated.example",
+                    "GEMINI_MODEL": "gemini-updated"
+                }
+            }),
+            None,
+        );
+
+        ProviderService::update(&state, AppType::Gemini, None, updated.clone())
+            .expect("update current provider");
+
+        let backup = db
+            .get_live_backup("gemini")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let stored_provider = db
+            .get_provider_by_id("g1", "gemini")
+            .expect("get stored provider")
+            .expect("stored provider exists");
+        let expected_backup =
+            serde_json::to_string(&stored_provider.settings_config).expect("serialize");
+        assert_eq!(backup.original_config, expected_backup);
+
+        let live_env = crate::gemini_config::read_gemini_env().expect("read live env");
+        assert_eq!(
+            live_env.get("GEMINI_API_KEY").map(String::as_str),
+            Some("PROXY_MANAGED"),
+            "takeover placeholder should stay intact"
+        );
+        assert_eq!(
+            live_env.get("GOOGLE_GEMINI_BASE_URL").map(String::as_str),
+            Some("http://127.0.0.1:15721"),
+            "proxy base URL should stay intact"
+        );
+        assert_eq!(
+            live_env.get("GEMINI_MODEL").map(String::as_str),
+            Some("gemini-updated"),
+            "current provider model should be refreshed into Gemini live env"
         );
     }
 
@@ -1197,9 +1307,9 @@ impl ProviderService {
         let is_current = effective_current.as_deref() == Some(provider.id.as_str());
 
         if is_current {
-            // 如果 Claude 代理接管处于激活状态，并且代理服务正在运行：
+            // 如果当前 switch-mode app 处于代理接管状态，并且代理服务正在运行：
             // - 不直接走普通 Live 写入逻辑
-            // - 改为更新 Live 备份，并在 Claude 下同步代理安全的 Live 配置
+            // - 改为更新 Live 备份，并同步代理安全的 Live 配置
             let has_live_backup =
                 futures::executor::block_on(state.db.get_live_backup(app_type.as_str()))
                     .ok()
@@ -1215,18 +1325,9 @@ impl ProviderService {
                 futures::executor::block_on(
                     state
                         .proxy_service
-                        .update_live_backup_from_provider(app_type.as_str(), &provider),
+                        .refresh_takeover_state_from_provider(&app_type, &provider),
                 )
-                .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
-
-                if matches!(app_type, AppType::Claude) {
-                    futures::executor::block_on(
-                        state
-                            .proxy_service
-                            .sync_claude_live_from_provider_while_proxy_active(&provider),
-                    )
-                    .map_err(|e| AppError::Message(format!("同步 Claude Live 配置失败: {e}")))?;
-                }
+                .map_err(|e| AppError::Message(format!("同步代理接管态失败: {e}")))?;
             } else {
                 write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
                 // Sync MCP

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1102,6 +1102,131 @@ base_url = "http://localhost:8080"
         );
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn sync_current_common_config_for_app_tolerates_malformed_previous_snippet() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+
+        let mut provider = Provider::with_id(
+            "p1".into(),
+            "Claude A".into(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "model-a"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        db.save_provider("claude", &provider)
+            .expect("save provider");
+        db.set_current_provider("claude", "p1")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("p1"))
+            .expect("set local current provider");
+
+        db.update_proxy_config(ProxyConfig {
+            live_takeover_active: true,
+            ..Default::default()
+        })
+        .await
+        .expect("update proxy config");
+        {
+            let mut config = db
+                .get_proxy_config_for_app("claude")
+                .await
+                .expect("get app proxy config");
+            config.enabled = true;
+            db.update_proxy_config_for_app(config)
+                .await
+                .expect("update app proxy config");
+        }
+
+        write_json_file(
+            &get_claude_settings_path(),
+            &json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
+                    "ANTHROPIC_AUTH_TOKEN": "PROXY_MANAGED",
+                    "ANTHROPIC_MODEL": "model-a"
+                },
+                "permissions": { "allow": ["Bash"] }
+            }),
+        )
+        .expect("seed taken-over live file");
+        db.save_live_backup(
+            "claude",
+            &serde_json::to_string(&json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "model-a"
+                },
+                "permissions": { "allow": ["Bash"] }
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("seed live backup");
+
+        state.proxy_service.mark_running_for_test().await;
+
+        db.set_config_snippet(
+            "claude",
+            Some(r#"{ "includeCoAuthoredBy": true }"#.to_string()),
+        )
+        .expect("set new common config");
+
+        ProviderService::sync_current_common_config_for_app(
+            &state,
+            AppType::Claude,
+            Some("{ invalid previous snippet"),
+        )
+        .expect("sync common config should tolerate malformed previous snippet");
+
+        let live: Value = read_json_file(&get_claude_settings_path()).expect("read live");
+        assert_eq!(
+            live.get("includeCoAuthoredBy").and_then(|v| v.as_bool()),
+            Some(true),
+            "takeover live should still update when the previous snippet is malformed"
+        );
+        assert_eq!(
+            live.get("permissions"),
+            Some(&json!({ "allow": ["Bash"] })),
+            "live-only Claude settings should be preserved when previous snippet removal is skipped"
+        );
+
+        let backup = db
+            .get_live_backup("claude")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        assert_eq!(
+            backup_value
+                .get("includeCoAuthoredBy")
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "restore backup should still refresh when the previous snippet is malformed"
+        );
+        assert_eq!(
+            backup_value.get("permissions"),
+            Some(&json!({ "allow": ["Bash"] })),
+            "backup should preserve existing live-only Claude settings when previous snippet removal is skipped"
+        );
+    }
+
     #[test]
     #[serial]
     fn rename_rejects_missing_original_provider() {

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -29,7 +29,8 @@ pub use live::{
 pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
-    provider_exists_in_live_config, strip_common_config_from_live_settings,
+    provider_exists_in_live_config, provider_uses_common_config,
+    remove_common_config_from_settings, strip_common_config_from_live_settings,
     sync_current_provider_for_app_to_live, write_live_with_common_config,
 };
 
@@ -372,29 +373,25 @@ base_url = "http://localhost:8080"
                 "env": {
                     "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
                     "ANTHROPIC_API_KEY": "PROXY_MANAGED",
-                    "ANTHROPIC_MODEL": "stale-model"
+                    "ANTHROPIC_MODEL": "stale-model",
+                    "ANTHROPIC_SMALL_FAST_MODEL": "legacy-fast-model"
                 },
                 "permissions": { "allow": ["Bash"] }
             }),
         )
         .expect("seed taken-over live file");
 
-        state
-            .proxy_service
-            .start()
-            .await
-            .expect("start proxy service");
+        state.proxy_service.mark_running_for_test().await;
 
         let updated = Provider::with_id(
             "p1".into(),
             "Claude A".into(),
             json!({
                 "env": {
-                    "ANTHROPIC_API_KEY": "token-updated",
-                    "ANTHROPIC_BASE_URL": "https://api.updated.example",
+                    "OPENROUTER_API_KEY": "token-updated",
+                    "ANTHROPIC_BASE_URL": "https://openrouter.example/api",
                     "ANTHROPIC_MODEL": "model-updated"
-                },
-                "permissions": { "allow": ["Read"] }
+                }
             }),
             None,
         );
@@ -407,26 +404,21 @@ base_url = "http://localhost:8080"
             .await
             .expect("get live backup")
             .expect("backup exists");
-        let stored_provider = db
-            .get_provider_by_id("p1", "claude")
-            .expect("get stored provider")
-            .expect("stored provider exists");
-        let expected_backup =
-            serde_json::to_string(&stored_provider.settings_config).expect("serialize");
-        assert_eq!(backup.original_config, expected_backup);
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
 
         let live: Value = read_json_file(&get_claude_settings_path()).expect("read live");
         assert_eq!(
             live.get("permissions"),
-            updated.settings_config.get("permissions"),
-            "provider edits should propagate into Claude live config during takeover"
+            original.settings_config.get("permissions"),
+            "live-only Claude settings should remain intact during takeover refresh"
         );
         assert_eq!(
             live.get("env")
-                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .and_then(|env| env.get("OPENROUTER_API_KEY"))
                 .and_then(|v| v.as_str()),
             Some("PROXY_MANAGED"),
-            "takeover placeholder should stay intact"
+            "takeover placeholder should move with the updated Claude credential family"
         );
         assert_eq!(
             live.get("env")
@@ -441,6 +433,187 @@ base_url = "http://localhost:8080"
                 .and_then(|v| v.as_str()),
             Some("model-updated"),
             "current provider model should be refreshed into takeover live config"
+        );
+        assert!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .is_none(),
+            "stale Claude credential families should be removed from live"
+        );
+        assert!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_SMALL_FAST_MODEL"))
+                .is_none(),
+            "legacy Claude small-fast model overrides should be removed from live"
+        );
+        assert_eq!(
+            backup_value.get("permissions"),
+            original.settings_config.get("permissions"),
+            "backup should keep the existing live-only Claude settings"
+        );
+        assert_eq!(
+            backup_value
+                .get("env")
+                .and_then(|env| env.get("OPENROUTER_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some("token-updated"),
+            "backup should store the updated provider credential"
+        );
+        assert!(
+            backup_value
+                .get("env")
+                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .is_none(),
+            "backup should not retain stale Claude credential families"
+        );
+        assert!(
+            backup_value
+                .get("env")
+                .and_then(|env| env.get("ANTHROPIC_SMALL_FAST_MODEL"))
+                .is_none(),
+            "backup should not retain legacy Claude small-fast model overrides"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn update_current_claude_provider_refreshes_top_level_fields_when_proxy_takeover_detected(
+    ) {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+
+        let original = Provider::with_id(
+            "p1".into(),
+            "Claude A".into(),
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "token-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "model-a"
+                },
+                "apiBaseUrl": "https://stale.provider.example",
+                "primaryModel": "claude-stale-primary",
+                "smallFastModel": "claude-stale-small",
+                "permissions": { "allow": ["Bash"] }
+            }),
+            None,
+        );
+        db.save_provider("claude", &original)
+            .expect("save provider");
+        db.set_current_provider("claude", "p1")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("p1"))
+            .expect("set local current provider");
+
+        db.update_proxy_config(ProxyConfig {
+            live_takeover_active: true,
+            ..Default::default()
+        })
+        .await
+        .expect("update proxy config");
+        {
+            let mut config = db
+                .get_proxy_config_for_app("claude")
+                .await
+                .expect("get app proxy config");
+            config.enabled = true;
+            db.update_proxy_config_for_app(config)
+                .await
+                .expect("update app proxy config");
+        }
+
+        write_json_file(
+            &get_claude_settings_path(),
+            &json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
+                    "ANTHROPIC_API_KEY": "PROXY_MANAGED",
+                    "ANTHROPIC_MODEL": "stale-model"
+                },
+                "apiBaseUrl": "https://live-stale.example",
+                "primaryModel": "live-stale-primary",
+                "smallFastModel": "live-stale-small",
+                "permissions": { "allow": ["Bash"] }
+            }),
+        )
+        .expect("seed taken-over live file");
+
+        state.proxy_service.mark_running_for_test().await;
+
+        let updated = Provider::with_id(
+            "p1".into(),
+            "Claude A".into(),
+            json!({
+                "env": {
+                    "OPENROUTER_API_KEY": "token-updated",
+                    "ANTHROPIC_BASE_URL": "https://openrouter.example/api",
+                    "ANTHROPIC_MODEL": "model-updated"
+                },
+                "apiBaseUrl": "https://provider-updated.example",
+                "primaryModel": "claude-updated-primary"
+            }),
+            None,
+        );
+
+        ProviderService::update(&state, AppType::Claude, None, updated.clone())
+            .expect("update current provider");
+
+        let backup = db
+            .get_live_backup("claude")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+
+        let live: Value = read_json_file(&get_claude_settings_path()).expect("read live");
+        assert_eq!(
+            live.get("permissions"),
+            original.settings_config.get("permissions"),
+            "live-only Claude settings should remain intact during takeover refresh"
+        );
+        assert_eq!(
+            live.get("apiBaseUrl").and_then(|v| v.as_str()),
+            Some("https://provider-updated.example"),
+            "live should refresh Claude apiBaseUrl from the current provider"
+        );
+        assert_eq!(
+            live.get("primaryModel").and_then(|v| v.as_str()),
+            Some("claude-updated-primary"),
+            "live should refresh Claude primaryModel from the current provider"
+        );
+        assert!(
+            live.get("smallFastModel").is_none(),
+            "live should remove stale Claude smallFastModel when the provider no longer defines it"
+        );
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+                .and_then(|v| v.as_str()),
+            Some("http://127.0.0.1:15721"),
+            "proxy base URL should stay intact"
+        );
+        assert_eq!(
+            backup_value.get("permissions"),
+            original.settings_config.get("permissions"),
+            "backup should keep the existing live-only Claude settings"
+        );
+        assert_eq!(
+            backup_value.get("apiBaseUrl").and_then(|v| v.as_str()),
+            Some("https://provider-updated.example"),
+            "backup should refresh Claude apiBaseUrl from the current provider"
+        );
+        assert_eq!(
+            backup_value.get("primaryModel").and_then(|v| v.as_str()),
+            Some("claude-updated-primary"),
+            "backup should refresh Claude primaryModel from the current provider"
+        );
+        assert!(
+            backup_value.get("smallFastModel").is_none(),
+            "backup should remove stale Claude smallFastModel when the provider no longer defines it"
         );
     }
 
@@ -497,14 +670,12 @@ base_url = "http://localhost:8080"
             ),
             ("GEMINI_API_KEY".to_string(), "PROXY_MANAGED".to_string()),
             ("GEMINI_MODEL".to_string(), "stale-model".to_string()),
+            ("GEMINI_EXTRA_FLAG".to_string(), "stale-extra".to_string()),
+            ("GEMINI_STALE_ONLY".to_string(), "stale-only".to_string()),
         ]))
         .expect("seed taken-over live env");
 
-        state
-            .proxy_service
-            .start()
-            .await
-            .expect("start proxy service");
+        state.proxy_service.mark_running_for_test().await;
 
         let updated = Provider::with_id(
             "g1".into(),
@@ -513,7 +684,8 @@ base_url = "http://localhost:8080"
                 "env": {
                     "GEMINI_API_KEY": "token-updated",
                     "GOOGLE_GEMINI_BASE_URL": "https://gemini.updated.example",
-                    "GEMINI_MODEL": "gemini-updated"
+                    "GEMINI_MODEL": "gemini-updated",
+                    "GEMINI_EXTRA_FLAG": "provider-updated"
                 }
             }),
             None,
@@ -527,13 +699,8 @@ base_url = "http://localhost:8080"
             .await
             .expect("get live backup")
             .expect("backup exists");
-        let stored_provider = db
-            .get_provider_by_id("g1", "gemini")
-            .expect("get stored provider")
-            .expect("stored provider exists");
-        let expected_backup =
-            serde_json::to_string(&stored_provider.settings_config).expect("serialize");
-        assert_eq!(backup.original_config, expected_backup);
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
 
         let live_env = crate::gemini_config::read_gemini_env().expect("read live env");
         assert_eq!(
@@ -550,6 +717,388 @@ base_url = "http://localhost:8080"
             live_env.get("GEMINI_MODEL").map(String::as_str),
             Some("gemini-updated"),
             "current provider model should be refreshed into Gemini live env"
+        );
+        assert_eq!(
+            live_env.get("GEMINI_EXTRA_FLAG").map(String::as_str),
+            Some("provider-updated"),
+            "Gemini takeover refresh should rewrite provider-managed env keys from the updated provider"
+        );
+        assert!(
+            live_env.get("GEMINI_STALE_ONLY").is_none(),
+            "Gemini takeover refresh should remove stale env keys that are no longer present in provider settings"
+        );
+        assert_eq!(
+            backup_value
+                .get("env")
+                .and_then(|env| env.get("GEMINI_EXTRA_FLAG"))
+                .and_then(|v| v.as_str()),
+            Some("provider-updated"),
+            "backup should store the updated Gemini provider env keys"
+        );
+        assert!(
+            backup_value
+                .get("env")
+                .and_then(|env| env.get("GEMINI_STALE_ONLY"))
+                .is_none(),
+            "backup should remove stale Gemini env keys that are no longer present in provider settings"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn sync_current_common_config_for_app_updates_taken_over_live_and_backup() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+
+        let mut provider = Provider::with_id(
+            "p1".into(),
+            "Claude A".into(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "model-a"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        db.save_provider("claude", &provider)
+            .expect("save provider");
+        db.set_current_provider("claude", "p1")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("p1"))
+            .expect("set local current provider");
+
+        db.update_proxy_config(ProxyConfig {
+            live_takeover_active: true,
+            ..Default::default()
+        })
+        .await
+        .expect("update proxy config");
+        {
+            let mut config = db
+                .get_proxy_config_for_app("claude")
+                .await
+                .expect("get app proxy config");
+            config.enabled = true;
+            db.update_proxy_config_for_app(config)
+                .await
+                .expect("update app proxy config");
+        }
+
+        write_json_file(
+            &get_claude_settings_path(),
+            &json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
+                    "ANTHROPIC_AUTH_TOKEN": "PROXY_MANAGED",
+                    "ANTHROPIC_MODEL": "model-a"
+                },
+                "includeCoAuthoredBy": true,
+                "permissions": { "allow": ["Bash"] }
+            }),
+        )
+        .expect("seed taken-over live file");
+        db.save_live_backup(
+            "claude",
+            &serde_json::to_string(&json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "model-a"
+                },
+                "includeCoAuthoredBy": true,
+                "permissions": { "allow": ["Bash"] }
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("seed live backup");
+
+        state.proxy_service.mark_running_for_test().await;
+
+        db.set_config_snippet(
+            "claude",
+            Some(r#"{ "includeCoAuthoredBy": true }"#.to_string()),
+        )
+        .expect("set old common config");
+        db.set_config_snippet(
+            "claude",
+            Some(r#"{ "includeCoAuthoredBy": false }"#.to_string()),
+        )
+        .expect("set new common config");
+
+        ProviderService::sync_current_common_config_for_app(
+            &state,
+            AppType::Claude,
+            Some(r#"{ "includeCoAuthoredBy": true }"#),
+        )
+        .expect("sync common config transition");
+
+        let live: Value = read_json_file(&get_claude_settings_path()).expect("read live");
+        assert_eq!(
+            live.get("includeCoAuthoredBy").and_then(|v| v.as_bool()),
+            Some(false),
+            "taken-over live should refresh to the updated common-config value"
+        );
+        assert_eq!(
+            live.get("permissions"),
+            Some(&json!({ "allow": ["Bash"] })),
+            "common-config sync should preserve live-only Claude settings"
+        );
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_AUTH_TOKEN"))
+                .and_then(|v| v.as_str()),
+            Some("PROXY_MANAGED"),
+            "common-config sync should keep the takeover auth placeholder in live"
+        );
+
+        let backup = db
+            .get_live_backup("claude")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        assert_eq!(
+            backup_value
+                .get("includeCoAuthoredBy")
+                .and_then(|v| v.as_bool()),
+            Some(false),
+            "restore backup should refresh to the updated common-config value"
+        );
+        assert_eq!(
+            backup_value.get("permissions"),
+            Some(&json!({ "allow": ["Bash"] })),
+            "backup should preserve existing live-only Claude settings"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn sync_current_common_config_for_app_removes_cleared_values_from_live_and_backup() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+
+        let mut provider = Provider::with_id(
+            "p1".into(),
+            "Claude A".into(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "model-a"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        db.save_provider("claude", &provider)
+            .expect("save provider");
+        db.set_current_provider("claude", "p1")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("p1"))
+            .expect("set local current provider");
+
+        db.update_proxy_config(ProxyConfig {
+            live_takeover_active: true,
+            ..Default::default()
+        })
+        .await
+        .expect("update proxy config");
+        {
+            let mut config = db
+                .get_proxy_config_for_app("claude")
+                .await
+                .expect("get app proxy config");
+            config.enabled = true;
+            db.update_proxy_config_for_app(config)
+                .await
+                .expect("update app proxy config");
+        }
+
+        write_json_file(
+            &get_claude_settings_path(),
+            &json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
+                    "ANTHROPIC_AUTH_TOKEN": "PROXY_MANAGED",
+                    "ANTHROPIC_MODEL": "model-a"
+                },
+                "includeCoAuthoredBy": false,
+                "permissions": { "allow": ["Bash"] }
+            }),
+        )
+        .expect("seed taken-over live file");
+        db.save_live_backup(
+            "claude",
+            &serde_json::to_string(&json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "model-a"
+                },
+                "includeCoAuthoredBy": false,
+                "permissions": { "allow": ["Bash"] }
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("seed live backup");
+
+        state.proxy_service.mark_running_for_test().await;
+
+        db.set_config_snippet(
+            "claude",
+            Some(r#"{ "includeCoAuthoredBy": false }"#.to_string()),
+        )
+        .expect("set old common config");
+        db.set_config_snippet("claude", None)
+            .expect("clear common config");
+
+        ProviderService::sync_current_common_config_for_app(
+            &state,
+            AppType::Claude,
+            Some(r#"{ "includeCoAuthoredBy": false }"#),
+        )
+        .expect("sync cleared common config");
+
+        let live: Value = read_json_file(&get_claude_settings_path()).expect("read live");
+        assert!(
+            live.get("includeCoAuthoredBy").is_none(),
+            "taken-over live should remove cleared common-config values"
+        );
+        assert_eq!(
+            live.get("permissions"),
+            Some(&json!({ "allow": ["Bash"] })),
+            "clearing common config should preserve live-only Claude settings"
+        );
+
+        let backup = db
+            .get_live_backup("claude")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        assert!(
+            backup_value.get("includeCoAuthoredBy").is_none(),
+            "restore backup should remove cleared common-config values"
+        );
+        assert_eq!(
+            backup_value.get("permissions"),
+            Some(&json!({ "allow": ["Bash"] })),
+            "backup should preserve existing live-only Claude settings when clearing common config"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn sync_current_common_config_for_app_tolerates_malformed_backup() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+
+        let mut provider = Provider::with_id(
+            "p1".into(),
+            "Claude A".into(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "model-a"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        db.save_provider("claude", &provider)
+            .expect("save provider");
+        db.set_current_provider("claude", "p1")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("p1"))
+            .expect("set local current provider");
+
+        db.update_proxy_config(ProxyConfig {
+            live_takeover_active: true,
+            ..Default::default()
+        })
+        .await
+        .expect("update proxy config");
+        {
+            let mut config = db
+                .get_proxy_config_for_app("claude")
+                .await
+                .expect("get app proxy config");
+            config.enabled = true;
+            db.update_proxy_config_for_app(config)
+                .await
+                .expect("update app proxy config");
+        }
+
+        write_json_file(
+            &get_claude_settings_path(),
+            &json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
+                    "ANTHROPIC_AUTH_TOKEN": "PROXY_MANAGED",
+                    "ANTHROPIC_MODEL": "model-a"
+                }
+            }),
+        )
+        .expect("seed taken-over live file");
+        db.save_live_backup("claude", "{ invalid backup json")
+            .await
+            .expect("seed malformed backup");
+
+        state.proxy_service.mark_running_for_test().await;
+
+        db.set_config_snippet(
+            "claude",
+            Some(r#"{ "includeCoAuthoredBy": true }"#.to_string()),
+        )
+        .expect("set new common config");
+
+        ProviderService::sync_current_common_config_for_app(&state, AppType::Claude, None)
+            .expect("sync common config should tolerate malformed backup");
+
+        let live: Value = read_json_file(&get_claude_settings_path()).expect("read live");
+        assert_eq!(
+            live.get("includeCoAuthoredBy").and_then(|v| v.as_bool()),
+            Some(true),
+            "takeover live should still update when backup parsing fails"
+        );
+
+        let backup = db
+            .get_live_backup("claude")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        assert_eq!(
+            backup.original_config, "{ invalid backup json",
+            "malformed backup should be left untouched when refresh is skipped"
         );
     }
 
@@ -1677,6 +2226,7 @@ impl ProviderService {
             futures::executor::block_on(state.db.get_proxy_config_for_app(app_type.as_str()))
                 .map(|config| config.enabled)
                 .unwrap_or(false);
+        let is_proxy_running = futures::executor::block_on(state.proxy_service.is_running());
 
         let has_live_backup =
             futures::executor::block_on(state.db.get_live_backup(app_type.as_str()))
@@ -1689,16 +2239,84 @@ impl ProviderService {
             .detect_takeover_in_live_config_for_app(&app_type);
 
         if takeover_enabled && (has_live_backup || live_taken_over) {
-            futures::executor::block_on(
-                state
-                    .proxy_service
-                    .update_live_backup_from_provider(app_type.as_str(), provider),
-            )
-            .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
+            if is_proxy_running {
+                futures::executor::block_on(
+                    state
+                        .proxy_service
+                        .refresh_takeover_state_from_provider(&app_type, provider),
+                )
+                .map_err(|e| AppError::Message(format!("刷新代理接管状态失败: {e}")))?;
+            } else {
+                futures::executor::block_on(
+                    state
+                        .proxy_service
+                        .refresh_restore_state_from_provider(&app_type, provider),
+                )
+                .map_err(|e| AppError::Message(format!("刷新恢复态配置失败: {e}")))?;
+            }
             return Ok(());
         }
 
         sync_current_provider_for_app_to_live(state, &app_type)
+    }
+
+    pub(crate) fn sync_current_common_config_for_app(
+        state: &AppState,
+        app_type: AppType,
+        previous_common_snippet: Option<&str>,
+    ) -> Result<(), AppError> {
+        if app_type.is_additive_mode() {
+            return Ok(());
+        }
+
+        let current_id =
+            match crate::settings::get_effective_current_provider(&state.db, &app_type)? {
+                Some(id) => id,
+                None => return Ok(()),
+            };
+
+        let providers = state.db.get_all_providers(app_type.as_str())?;
+        let Some(provider) = providers.get(&current_id) else {
+            return Ok(());
+        };
+
+        let takeover_enabled =
+            futures::executor::block_on(state.db.get_proxy_config_for_app(app_type.as_str()))
+                .map(|config| config.enabled)
+                .unwrap_or(false);
+        let is_proxy_running = futures::executor::block_on(state.proxy_service.is_running());
+        let has_live_backup =
+            futures::executor::block_on(state.db.get_live_backup(app_type.as_str()))
+                .ok()
+                .flatten()
+                .is_some();
+        let live_taken_over = state
+            .proxy_service
+            .detect_takeover_in_live_config_for_app(&app_type);
+
+        if !takeover_enabled || !(has_live_backup || live_taken_over) {
+            return Ok(());
+        }
+
+        if is_proxy_running {
+            futures::executor::block_on(
+                state.proxy_service.sync_takeover_common_config_transition(
+                    &app_type,
+                    provider,
+                    previous_common_snippet,
+                ),
+            )
+            .map_err(|e| AppError::Message(format!("同步代理接管态通用配置失败: {e}")))?;
+        } else {
+            futures::executor::block_on(state.proxy_service.sync_restore_common_config_transition(
+                &app_type,
+                provider,
+                previous_common_snippet,
+            ))
+            .map_err(|e| AppError::Message(format!("同步恢复态通用配置失败: {e}")))?;
+        }
+
+        Ok(())
     }
 
     pub fn migrate_legacy_common_config_usage(

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -10,7 +10,8 @@ use crate::proxy::server::ProxyServer;
 use crate::proxy::switch_lock::SwitchLockManager;
 use crate::proxy::types::*;
 use crate::services::provider::{
-    build_effective_settings_with_common_config, write_live_with_common_config,
+    build_effective_settings_with_common_config, provider_uses_common_config,
+    remove_common_config_from_settings, write_live_with_common_config,
 };
 use serde_json::{json, Value};
 use std::str::FromStr;
@@ -19,6 +20,26 @@ use tokio::sync::RwLock;
 
 /// 用于接管 Live 配置时的占位符（避免客户端提示缺少 key，同时不泄露真实 Token）
 const PROXY_TOKEN_PLACEHOLDER: &str = "PROXY_MANAGED";
+const CLAUDE_PROVIDER_ENV_KEYS: &[&str] = &[
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_REASONING_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+];
+const CLAUDE_PROVIDER_TOP_LEVEL_KEYS: &[&str] = &["apiBaseUrl", "primaryModel", "smallFastModel"];
+const CODEX_PROVIDER_TOP_LEVEL_KEYS: &[&str] = &[
+    "model_provider",
+    "model",
+    "model_reasoning_effort",
+    "base_url",
+];
 
 #[derive(Clone)]
 pub struct ProxyService {
@@ -205,16 +226,702 @@ impl ProxyService {
             .await
     }
 
+    pub async fn refresh_restore_state_from_provider(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<(), String> {
+        let _guard = self.switch_locks.lock_for_app(app_type.as_str()).await;
+        self.refresh_restore_state_from_provider_inner(app_type, provider)
+            .await
+    }
+
+    pub async fn sync_takeover_common_config_transition(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+        previous_common_snippet: Option<&str>,
+    ) -> Result<(), String> {
+        self.sync_common_config_transition(app_type, provider, previous_common_snippet, true)
+            .await
+    }
+
+    pub async fn sync_restore_common_config_transition(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+        previous_common_snippet: Option<&str>,
+    ) -> Result<(), String> {
+        self.sync_common_config_transition(app_type, provider, previous_common_snippet, false)
+            .await
+    }
+
+    async fn sync_common_config_transition(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+        previous_common_snippet: Option<&str>,
+        apply_takeover_overlay_in_live: bool,
+    ) -> Result<(), String> {
+        let current_snippet = self
+            .db
+            .get_config_snippet(app_type.as_str())
+            .map_err(|e| format!("读取 {} 通用配置失败: {e}", app_type.as_str()))?;
+        let previous_common_snippet = previous_common_snippet
+            .map(str::trim)
+            .filter(|snippet| !snippet.is_empty());
+
+        let had_previous_common_config = previous_common_snippet
+            .is_some_and(|snippet| provider_uses_common_config(app_type, provider, Some(snippet)));
+        let has_current_common_config =
+            provider_uses_common_config(app_type, provider, current_snippet.as_deref());
+
+        if !had_previous_common_config && !has_current_common_config {
+            return Ok(());
+        }
+
+        let _guard = self.switch_locks.lock_for_app(app_type.as_str()).await;
+        self.sync_takeover_common_config_transition_inner(
+            app_type,
+            provider,
+            previous_common_snippet,
+            apply_takeover_overlay_in_live,
+        )
+        .await
+    }
+
     async fn refresh_takeover_state_from_provider_inner(
         &self,
         app_type: &AppType,
         provider: &Provider,
     ) -> Result<(), String> {
-        self.update_live_backup_from_provider_inner(app_type.as_str(), provider)
-            .await?;
-        self.sync_live_from_provider_while_proxy_active_inner(app_type, provider)
-            .await?;
+        let provider_settings = self.build_effective_provider_settings(app_type, provider)?;
+        self.refresh_proxy_active_backup_from_provider_settings_inner(
+            app_type,
+            provider,
+            &provider_settings,
+        )
+        .await?;
+        self.refresh_proxy_active_live_from_provider_settings_inner(
+            app_type,
+            provider,
+            &provider_settings,
+        )
+        .await?;
         Ok(())
+    }
+
+    async fn refresh_restore_state_from_provider_inner(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<(), String> {
+        let provider_settings = self.build_effective_provider_settings(app_type, provider)?;
+        let live_snapshot = self
+            .build_proxy_refresh_snapshot_from_candidates(
+                app_type,
+                &provider_settings,
+                self.collect_live_refresh_candidates(app_type).await,
+                false,
+            )
+            .await?;
+        let mut restore_snapshot = self
+            .apply_common_config_transition_to_snapshot(
+                app_type,
+                provider,
+                live_snapshot,
+                None,
+                false,
+            )
+            .await?;
+        self.write_live_config_for_app(app_type, &restore_snapshot)?;
+
+        if matches!(app_type, AppType::Gemini) {
+            restore_snapshot = json!({
+                "env": restore_snapshot.get("env").cloned().unwrap_or_else(|| json!({}))
+            });
+        }
+
+        let backup_json = serde_json::to_string(&restore_snapshot)
+            .map_err(|e| format!("序列化 {} 恢复快照失败: {e}", app_type.as_str()))?;
+        self.db
+            .save_live_backup(app_type.as_str(), &backup_json)
+            .await
+            .map_err(|e| format!("更新 {} 恢复备份失败: {e}", app_type.as_str()))?;
+
+        Ok(())
+    }
+
+    async fn sync_takeover_common_config_transition_inner(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+        previous_common_snippet: Option<&str>,
+        apply_takeover_overlay_in_live: bool,
+    ) -> Result<(), String> {
+        if let Ok(existing_live) = self.read_live_snapshot_for_app(app_type) {
+            let live_base = if self.detect_takeover_in_live_config_for_app(app_type) {
+                Self::strip_takeover_fields_from_taken_over_live(app_type, &existing_live)
+            } else {
+                existing_live
+            };
+            let updated_live = self
+                .apply_common_config_transition_to_snapshot(
+                    app_type,
+                    provider,
+                    live_base,
+                    previous_common_snippet,
+                    apply_takeover_overlay_in_live,
+                )
+                .await?;
+            self.write_live_config_for_app(app_type, &updated_live)?;
+        }
+
+        if let Some(existing_backup) = self
+            .db
+            .get_live_backup(app_type.as_str())
+            .await
+            .map_err(|e| format!("读取 {} 备份失败: {e}", app_type.as_str()))?
+        {
+            let backup_value: Value = match serde_json::from_str(&existing_backup.original_config) {
+                Ok(value) => value,
+                Err(err) => {
+                    log::warn!(
+                        "解析 {} 备份失败，将跳过通用配置备份刷新并继续更新 Live: {err}",
+                        app_type.as_str()
+                    );
+                    return Ok(());
+                }
+            };
+            let mut updated_backup = self
+                .apply_common_config_transition_to_snapshot(
+                    app_type,
+                    provider,
+                    backup_value,
+                    previous_common_snippet,
+                    false,
+                )
+                .await?;
+
+            if matches!(app_type, AppType::Gemini) {
+                updated_backup = json!({
+                    "env": updated_backup.get("env").cloned().unwrap_or_else(|| json!({}))
+                });
+            }
+
+            let backup_json = serde_json::to_string(&updated_backup)
+                .map_err(|e| format!("序列化 {} 备份失败: {e}", app_type.as_str()))?;
+            self.db
+                .save_live_backup(app_type.as_str(), &backup_json)
+                .await
+                .map_err(|e| format!("更新 {} 备份失败: {e}", app_type.as_str()))?;
+        }
+
+        Ok(())
+    }
+
+    async fn apply_common_config_transition_to_snapshot(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+        mut snapshot: Value,
+        previous_common_snippet: Option<&str>,
+        apply_takeover_overlay: bool,
+    ) -> Result<Value, String> {
+        if let Some(previous_common_snippet) = previous_common_snippet
+            .filter(|snippet| provider_uses_common_config(app_type, provider, Some(*snippet)))
+        {
+            snapshot =
+                remove_common_config_from_settings(app_type, &snapshot, previous_common_snippet)
+                    .map_err(|e| format!("移除 {} 旧通用配置失败: {e}", app_type.as_str()))?;
+        }
+
+        let mut snapshot_provider = provider.clone();
+        snapshot_provider.settings_config = snapshot;
+        let mut updated_snapshot =
+            self.build_effective_provider_settings(app_type, &snapshot_provider)?;
+
+        if apply_takeover_overlay {
+            let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+            Self::apply_takeover_overlay(
+                app_type,
+                &mut updated_snapshot,
+                &proxy_url,
+                &proxy_codex_base_url,
+            )?;
+        }
+
+        Ok(updated_snapshot)
+    }
+
+    fn build_effective_provider_settings(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<Value, String> {
+        build_effective_settings_with_common_config(self.db.as_ref(), app_type, provider)
+            .map_err(|e| format!("构建 {} 有效配置失败: {e}", app_type.as_str()))
+    }
+
+    async fn refresh_proxy_active_backup_from_provider_settings_inner(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+        provider_settings: &Value,
+    ) -> Result<(), String> {
+        let mut effective_settings = self
+            .build_proxy_refresh_snapshot_from_candidates(
+                app_type,
+                provider_settings,
+                self.collect_backup_refresh_candidates(app_type).await,
+                false,
+            )
+            .await?;
+
+        // Backup should preserve live-only sections from the chosen base snapshot while still
+        // reflecting common-config changes applied to the current effective provider.
+        let mut backup_provider = provider.clone();
+        backup_provider.settings_config = effective_settings;
+        effective_settings = self.build_effective_provider_settings(app_type, &backup_provider)?;
+
+        if matches!(app_type, AppType::Gemini) {
+            effective_settings = json!({
+                "env": effective_settings.get("env").cloned().unwrap_or_else(|| json!({}))
+            });
+        }
+
+        let backup_json = serde_json::to_string(&effective_settings)
+            .map_err(|e| format!("序列化 {} 配置失败: {e}", app_type.as_str()))?;
+        self.db
+            .save_live_backup(app_type.as_str(), &backup_json)
+            .await
+            .map_err(|e| format!("更新 {} 备份失败: {e}", app_type.as_str()))?;
+
+        Ok(())
+    }
+
+    async fn refresh_proxy_active_live_from_provider_settings_inner(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+        provider_settings: &Value,
+    ) -> Result<(), String> {
+        let live_snapshot = self
+            .build_proxy_refresh_snapshot_from_candidates(
+                app_type,
+                provider_settings,
+                self.collect_live_refresh_candidates(app_type).await,
+                false,
+            )
+            .await?;
+        let mut live_provider = provider.clone();
+        live_provider.settings_config = live_snapshot;
+        let mut effective_settings =
+            self.build_effective_provider_settings(app_type, &live_provider)?;
+        let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+        Self::apply_takeover_overlay(
+            app_type,
+            &mut effective_settings,
+            &proxy_url,
+            &proxy_codex_base_url,
+        )?;
+        self.write_live_config_for_app(app_type, &effective_settings)?;
+        Ok(())
+    }
+
+    async fn build_proxy_refresh_snapshot_from_candidates(
+        &self,
+        app_type: &AppType,
+        provider_settings: &Value,
+        candidates: Vec<(&'static str, Value)>,
+        apply_takeover_overlay: bool,
+    ) -> Result<Value, String> {
+        for (label, mut candidate) in candidates {
+            match Self::patch_provider_owned_fields(app_type, &mut candidate, provider_settings) {
+                Ok(()) => {
+                    if apply_takeover_overlay {
+                        let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+                        Self::apply_takeover_overlay(
+                            app_type,
+                            &mut candidate,
+                            &proxy_url,
+                            &proxy_codex_base_url,
+                        )?;
+                    }
+                    return Ok(candidate);
+                }
+                Err(err) => {
+                    log::warn!(
+                        "基于现有 {} {}刷新接管配置失败，将尝试下一个候选基线: {err}",
+                        app_type.as_str(),
+                        label
+                    );
+                }
+            }
+        }
+
+        let mut effective_settings = provider_settings.clone();
+        if apply_takeover_overlay {
+            let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+            Self::apply_takeover_overlay(
+                app_type,
+                &mut effective_settings,
+                &proxy_url,
+                &proxy_codex_base_url,
+            )?;
+        }
+        Ok(effective_settings)
+    }
+
+    async fn collect_backup_refresh_candidates(
+        &self,
+        app_type: &AppType,
+    ) -> Vec<(&'static str, Value)> {
+        let mut candidates = Vec::new();
+
+        if self.detect_takeover_in_live_config_for_app(app_type) {
+            match self.read_live_snapshot_for_app(app_type) {
+                Ok(existing_live) => candidates.push((
+                    "当前 Live 快照",
+                    Self::strip_takeover_fields_from_taken_over_live(app_type, &existing_live),
+                )),
+                Err(err) => log::warn!(
+                    "读取当前 {} Live 配置失败，将跳过该基线: {err}",
+                    app_type.as_str()
+                ),
+            }
+        }
+
+        match self.db.get_live_backup(app_type.as_str()).await {
+            Ok(Some(backup)) => match serde_json::from_str::<Value>(&backup.original_config) {
+                Ok(existing_backup) => candidates.push(("备份快照", existing_backup)),
+                Err(err) => log::warn!(
+                    "解析现有 {} 备份失败，将跳过该基线: {err}",
+                    app_type.as_str()
+                ),
+            },
+            Ok(None) => {}
+            Err(err) => log::warn!("读取 {} 现有备份失败: {err}", app_type.as_str()),
+        }
+
+        candidates
+    }
+
+    async fn collect_live_refresh_candidates(
+        &self,
+        app_type: &AppType,
+    ) -> Vec<(&'static str, Value)> {
+        let mut candidates = Vec::new();
+
+        match self.read_live_snapshot_for_app(app_type) {
+            Ok(existing_live) => {
+                let live_base = if self.detect_takeover_in_live_config_for_app(app_type) {
+                    Self::strip_takeover_fields_from_taken_over_live(app_type, &existing_live)
+                } else {
+                    existing_live
+                };
+                candidates.push(("当前 Live 快照", live_base));
+            }
+            Err(err) => log::warn!(
+                "读取当前 {} Live 配置失败，将尝试其它基线: {err}",
+                app_type.as_str()
+            ),
+        }
+
+        match self.db.get_live_backup(app_type.as_str()).await {
+            Ok(Some(backup)) => match serde_json::from_str::<Value>(&backup.original_config) {
+                Ok(existing_backup) => candidates.push(("备份快照", existing_backup)),
+                Err(err) => log::warn!(
+                    "解析现有 {} 备份失败，将跳过该基线: {err}",
+                    app_type.as_str()
+                ),
+            },
+            Ok(None) => {}
+            Err(err) => log::warn!("读取 {} 现有备份失败: {err}", app_type.as_str()),
+        }
+
+        candidates
+    }
+
+    fn patch_provider_owned_fields(
+        app_type: &AppType,
+        base_snapshot: &mut Value,
+        provider_settings: &Value,
+    ) -> Result<(), String> {
+        match app_type {
+            AppType::Claude => {
+                Self::patch_claude_provider_owned_fields(base_snapshot, provider_settings)
+            }
+            AppType::Codex => {
+                Self::patch_codex_provider_owned_fields(base_snapshot, provider_settings)
+            }
+            AppType::Gemini => {
+                Self::patch_gemini_provider_owned_fields(base_snapshot, provider_settings)
+            }
+            AppType::OpenCode => Err("OpenCode 不支持代理功能".to_string()),
+            AppType::OpenClaw => Err("OpenClaw 不支持代理功能".to_string()),
+        }
+    }
+
+    fn patch_claude_provider_owned_fields(
+        base_snapshot: &mut Value,
+        provider_settings: &Value,
+    ) -> Result<(), String> {
+        if !base_snapshot.is_object() {
+            *base_snapshot = json!({});
+        }
+
+        Self::patch_json_provider_env_fields(
+            base_snapshot,
+            provider_settings,
+            CLAUDE_PROVIDER_ENV_KEYS,
+        );
+
+        let root = base_snapshot
+            .as_object_mut()
+            .expect("Claude snapshot should be normalized to an object");
+        for key in CLAUDE_PROVIDER_TOP_LEVEL_KEYS {
+            root.remove(*key);
+        }
+
+        let provider_root = provider_settings
+            .as_object()
+            .ok_or_else(|| "Claude provider settings should be a JSON object".to_string())?;
+        for key in CLAUDE_PROVIDER_TOP_LEVEL_KEYS {
+            if let Some(value) = provider_root.get(*key) {
+                root.insert((*key).to_string(), value.clone());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn patch_gemini_provider_owned_fields(
+        base_snapshot: &mut Value,
+        provider_settings: &Value,
+    ) -> Result<(), String> {
+        if !base_snapshot.is_object() {
+            *base_snapshot = json!({});
+        }
+
+        let env = provider_settings
+            .get("env")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        if !env.is_object() {
+            return Err("Gemini provider settings env should be a JSON object".to_string());
+        }
+
+        base_snapshot
+            .as_object_mut()
+            .expect("Gemini snapshot should be normalized to an object")
+            .insert("env".to_string(), env);
+
+        Ok(())
+    }
+
+    fn patch_json_provider_env_fields(
+        base_snapshot: &mut Value,
+        provider_settings: &Value,
+        keys: &[&str],
+    ) {
+        if !base_snapshot.is_object() {
+            *base_snapshot = json!({});
+        }
+
+        let root = base_snapshot
+            .as_object_mut()
+            .expect("JSON snapshot should be normalized to an object");
+        let env = root.entry("env".to_string()).or_insert_with(|| json!({}));
+        if !env.is_object() {
+            *env = json!({});
+        }
+
+        let env_obj = env
+            .as_object_mut()
+            .expect("JSON env should be normalized to an object");
+        for key in keys {
+            env_obj.remove(*key);
+        }
+
+        if let Some(provider_env) = provider_settings.get("env").and_then(|v| v.as_object()) {
+            for key in keys {
+                if let Some(value) = provider_env.get(*key) {
+                    env_obj.insert((*key).to_string(), value.clone());
+                }
+            }
+        }
+    }
+
+    fn patch_codex_provider_owned_fields(
+        base_snapshot: &mut Value,
+        provider_settings: &Value,
+    ) -> Result<(), String> {
+        if !base_snapshot.is_object() {
+            *base_snapshot = json!({});
+        }
+
+        let root = base_snapshot
+            .as_object_mut()
+            .expect("Codex snapshot should be normalized to an object");
+        let auth = root.entry("auth".to_string()).or_insert_with(|| json!({}));
+        if !auth.is_object() {
+            *auth = json!({});
+        }
+        let auth_obj = auth
+            .as_object_mut()
+            .expect("Codex auth should be normalized to an object");
+        auth_obj.remove("OPENAI_API_KEY");
+        if let Some(value) = provider_settings
+            .get("auth")
+            .and_then(|v| v.get("OPENAI_API_KEY"))
+        {
+            auth_obj.insert("OPENAI_API_KEY".to_string(), value.clone());
+        }
+
+        let base_config = root.get("config").and_then(|v| v.as_str()).unwrap_or("");
+        let provider_config = provider_settings
+            .get("config")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let patched_config = Self::patch_codex_provider_owned_config(base_config, provider_config)?;
+        root.insert("config".to_string(), json!(patched_config));
+
+        Ok(())
+    }
+
+    fn patch_codex_provider_owned_config(
+        base_config: &str,
+        provider_config: &str,
+    ) -> Result<String, String> {
+        let mut base_doc = if base_config.trim().is_empty() {
+            toml_edit::DocumentMut::new()
+        } else {
+            base_config
+                .parse::<toml_edit::DocumentMut>()
+                .map_err(|e| format!("解析现有 Codex config.toml 失败: {e}"))?
+        };
+        let provider_doc = if provider_config.trim().is_empty() {
+            toml_edit::DocumentMut::new()
+        } else {
+            provider_config
+                .parse::<toml_edit::DocumentMut>()
+                .map_err(|e| format!("解析新的 Codex config.toml 失败: {e}"))?
+        };
+
+        let previous_provider_key = base_doc
+            .get("model_provider")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let current_provider_key = provider_doc
+            .get("model_provider")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        for key in CODEX_PROVIDER_TOP_LEVEL_KEYS {
+            base_doc.as_table_mut().remove(*key);
+        }
+
+        if let Some(model_providers) = base_doc
+            .get_mut("model_providers")
+            .and_then(|v| v.as_table_mut())
+        {
+            if let Some(key) = previous_provider_key.as_deref() {
+                model_providers.remove(key);
+            }
+            if let Some(key) = current_provider_key.as_deref() {
+                model_providers.remove(key);
+            }
+            if model_providers.is_empty() {
+                base_doc.as_table_mut().remove("model_providers");
+            }
+        }
+
+        for key in CODEX_PROVIDER_TOP_LEVEL_KEYS {
+            if let Some(item) = provider_doc.get(*key) {
+                base_doc[*key] = item.clone();
+            }
+        }
+
+        if let Some(key) = current_provider_key.as_deref() {
+            if let Some(provider_item) = provider_doc
+                .get("model_providers")
+                .and_then(|v| v.as_table_like())
+                .and_then(|table| table.get(key))
+            {
+                if base_doc.get("model_providers").is_none() {
+                    base_doc["model_providers"] = toml_edit::table();
+                }
+
+                if let Some(model_providers) = base_doc["model_providers"].as_table_mut() {
+                    model_providers.insert(key, provider_item.clone());
+                }
+            }
+        }
+
+        Ok(base_doc.to_string())
+    }
+
+    fn strip_takeover_fields_from_taken_over_live(app_type: &AppType, snapshot: &Value) -> Value {
+        let mut stripped = snapshot.clone();
+        match app_type {
+            AppType::Claude => {
+                if let Some(env) = stripped.get_mut("env").and_then(|v| v.as_object_mut()) {
+                    for key in [
+                        "ANTHROPIC_AUTH_TOKEN",
+                        "ANTHROPIC_API_KEY",
+                        "OPENROUTER_API_KEY",
+                        "OPENAI_API_KEY",
+                    ] {
+                        if env.get(key).and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER) {
+                            env.remove(key);
+                        }
+                    }
+
+                    if env
+                        .get("ANTHROPIC_BASE_URL")
+                        .and_then(|v| v.as_str())
+                        .map(Self::is_local_proxy_url)
+                        .unwrap_or(false)
+                    {
+                        env.remove("ANTHROPIC_BASE_URL");
+                    }
+                }
+            }
+            AppType::Codex => {
+                if let Some(auth) = stripped.get_mut("auth").and_then(|v| v.as_object_mut()) {
+                    if auth.get("OPENAI_API_KEY").and_then(|v| v.as_str())
+                        == Some(PROXY_TOKEN_PLACEHOLDER)
+                    {
+                        auth.remove("OPENAI_API_KEY");
+                    }
+                }
+
+                if let Some(cfg_str) = stripped.get("config").and_then(|v| v.as_str()) {
+                    stripped["config"] = json!(Self::remove_local_toml_base_url(cfg_str));
+                }
+            }
+            AppType::Gemini => {
+                if let Some(env) = stripped.get_mut("env").and_then(|v| v.as_object_mut()) {
+                    if env.get("GEMINI_API_KEY").and_then(|v| v.as_str())
+                        == Some(PROXY_TOKEN_PLACEHOLDER)
+                    {
+                        env.remove("GEMINI_API_KEY");
+                    }
+                    if env
+                        .get("GOOGLE_GEMINI_BASE_URL")
+                        .and_then(|v| v.as_str())
+                        .map(Self::is_local_proxy_url)
+                        .unwrap_or(false)
+                    {
+                        env.remove("GOOGLE_GEMINI_BASE_URL");
+                    }
+                }
+            }
+            AppType::OpenCode | AppType::OpenClaw => {}
+        }
+
+        stripped
     }
 
     async fn build_takeover_live_config_from_provider(
@@ -222,9 +929,7 @@ impl ProxyService {
         app_type: &AppType,
         provider: &Provider,
     ) -> Result<Value, String> {
-        let mut effective_settings =
-            build_effective_settings_with_common_config(self.db.as_ref(), app_type, provider)
-                .map_err(|e| format!("构建 {} 有效配置失败: {e}", app_type.as_str()))?;
+        let mut effective_settings = self.build_effective_provider_settings(app_type, provider)?;
 
         if matches!(app_type, AppType::Codex) {
             if let Ok(existing_live) = self.read_codex_live() {
@@ -1068,21 +1773,11 @@ impl ProxyService {
     /// 接管指定应用的 Live 配置（尽力而为：配置不存在/读取失败则跳过）
     async fn takeover_live_config_best_effort(&self, app_type: &AppType) -> Result<(), String> {
         let _guard = self.switch_locks.lock_for_app(app_type.as_str()).await;
-        match self
-            .sync_live_from_current_provider_while_proxy_active_inner(app_type)
-            .await
-        {
-            Ok(true) => {}
-            Ok(false) => {
-                let _ = self.overlay_takeover_on_existing_live(app_type).await;
-            }
-            Err(err) => {
-                log::warn!(
-                    "基于当前 {} 供应商重建接管配置失败，将回退到现有 Live 配置: {err}",
-                    app_type.as_str()
-                );
-                let _ = self.overlay_takeover_on_existing_live(app_type).await;
-            }
+        if let Err(err) = self.overlay_takeover_on_existing_live(app_type).await {
+            log::debug!(
+                "{} Live 配置不可用，跳过 best-effort 接管: {err}",
+                app_type.as_str()
+            );
         }
 
         Ok(())
@@ -1222,6 +1917,16 @@ impl ProxyService {
                 // OpenClaw doesn't support proxy features
                 Err("OpenClaw 不支持代理功能".to_string())
             }
+        }
+    }
+
+    fn read_live_snapshot_for_app(&self, app_type: &AppType) -> Result<Value, String> {
+        match app_type {
+            AppType::Claude => self.read_claude_live(),
+            AppType::Codex => self.read_codex_live(),
+            AppType::Gemini => self.read_gemini_live(),
+            AppType::OpenCode => Err("OpenCode 不支持代理功能".to_string()),
+            AppType::OpenClaw => Err("OpenClaw 不支持代理功能".to_string()),
         }
     }
 
@@ -1589,16 +2294,8 @@ impl ProxyService {
             .map_err(|e| format!("更新本地当前供应商失败: {e}"))?;
 
         if should_sync_backup {
-            self.update_live_backup_from_provider_inner(app_type, &provider)
+            self.refresh_takeover_state_from_provider_inner(&app_type_enum, &provider)
                 .await?;
-
-            if matches!(
-                app_type_enum,
-                AppType::Claude | AppType::Codex | AppType::Gemini
-            ) {
-                self.sync_live_from_provider_while_proxy_active_inner(&app_type_enum, &provider)
-                    .await?;
-            }
         }
 
         if let Some(server) = self.server.read().await.as_ref() {
@@ -1615,6 +2312,12 @@ impl ProxyService {
     #[cfg(test)]
     async fn lock_switch_for_test(&self, app_type: &str) -> tokio::sync::OwnedMutexGuard<()> {
         self.switch_locks.lock_for_app(app_type).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn mark_running_for_test(&self) {
+        let server = ProxyServer::new(ProxyConfig::default(), self.db.clone(), None);
+        *self.server.write().await = Some(server);
     }
 
     fn preserve_codex_mcp_servers(
@@ -2272,11 +2975,10 @@ model = "gpt-5.1-codex"
             "B".to_string(),
             json!({
                 "env": {
-                    "ANTHROPIC_API_KEY": "b-key",
-                    "ANTHROPIC_BASE_URL": "https://api.b.example",
+                    "OPENROUTER_API_KEY": "b-key",
+                    "ANTHROPIC_BASE_URL": "https://openrouter.example/api",
                     "ANTHROPIC_MODEL": "claude-new"
-                },
-                "permissions": { "allow": ["Read"] }
+                }
             }),
             None,
         );
@@ -2314,15 +3016,15 @@ model = "gpt-5.1-codex"
         let live = service.read_claude_live().expect("read live config");
         assert_eq!(
             live.get("permissions"),
-            provider_b.settings_config.get("permissions"),
-            "provider-derived live settings should be refreshed"
+            provider_a.settings_config.get("permissions"),
+            "live-only Claude settings should remain intact during takeover refresh"
         );
         assert_eq!(
             live.get("env")
-                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .and_then(|env| env.get("OPENROUTER_API_KEY"))
                 .and_then(|v| v.as_str()),
             Some(PROXY_TOKEN_PLACEHOLDER),
-            "takeover token placeholder should be preserved"
+            "takeover token placeholder should follow the updated Claude credential family"
         );
         assert_eq!(
             live.get("env")
@@ -2338,14 +3040,123 @@ model = "gpt-5.1-codex"
             Some("claude-new"),
             "Claude takeover live config should refresh to the current provider model"
         );
+        assert!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .is_none(),
+            "stale Claude credential families should be removed from live"
+        );
 
         let backup = db
             .get_live_backup("claude")
             .await
             .expect("get live backup")
             .expect("backup exists");
-        let expected = serde_json::to_string(&provider_b.settings_config).expect("serialize");
-        assert_eq!(backup.original_config, expected);
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        assert_eq!(
+            backup_value.get("permissions"),
+            provider_a.settings_config.get("permissions"),
+            "backup should keep the existing live-only Claude settings"
+        );
+        assert_eq!(
+            backup_value
+                .get("env")
+                .and_then(|env| env.get("OPENROUTER_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some("b-key"),
+            "backup should store the updated Claude provider credential"
+        );
+        assert!(
+            backup_value
+                .get("env")
+                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .is_none(),
+            "backup should not retain stale Claude credential families"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hot_switch_provider_keeps_current_claude_live_authority_over_richer_backup() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "A".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "a-key",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example",
+                    "ANTHROPIC_MODEL": "claude-old"
+                },
+                "permissions": { "allow": ["Bash"] }
+            }),
+            None,
+        );
+        let provider_b = Provider::with_id(
+            "b".to_string(),
+            "B".to_string(),
+            json!({
+                "env": {
+                    "OPENROUTER_API_KEY": "b-key",
+                    "ANTHROPIC_BASE_URL": "https://openrouter.example/api",
+                    "ANTHROPIC_MODEL": "claude-new"
+                }
+            }),
+            None,
+        );
+
+        db.save_provider("claude", &provider_a)
+            .expect("save provider a");
+        db.save_provider("claude", &provider_b)
+            .expect("save provider b");
+        db.set_current_provider("claude", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("a"))
+            .expect("set local current provider");
+        db.save_live_backup(
+            "claude",
+            &serde_json::to_string(&provider_a.settings_config).expect("serialize provider a"),
+        )
+        .await
+        .expect("seed live backup");
+        service
+            .write_claude_live(&json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
+                    "ANTHROPIC_API_KEY": PROXY_TOKEN_PLACEHOLDER,
+                    "ANTHROPIC_MODEL": "stale-model"
+                }
+            }))
+            .expect("seed partial taken-over live file");
+
+        service
+            .hot_switch_provider("claude", "b")
+            .await
+            .expect("hot switch provider");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert!(
+            live.get("permissions").is_none(),
+            "live refresh should keep the current Claude live shape instead of resurrecting richer backup-only settings"
+        );
+
+        let backup = db
+            .get_live_backup("claude")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        assert!(
+            backup_value.get("permissions").is_none(),
+            "backup refresh should follow the current Claude live shape so restore does not resurrect stale backup-only settings"
+        );
     }
 
     #[tokio::test]
@@ -2384,7 +3195,6 @@ wire_api = "responses"
                 },
                 "config": r#"model_provider = "any"
 model = "gpt-new"
-model_reasoning_effort = "high"
 
 [model_providers.any]
 base_url = "https://api.b.example/v1"
@@ -2469,12 +3279,9 @@ args = ["echo-server"]
             Some("gpt-new"),
             "Codex takeover live config should refresh to the current provider model"
         );
-        assert_eq!(
-            parsed
-                .get("model_reasoning_effort")
-                .and_then(|v| v.as_str()),
-            Some("high"),
-            "Codex takeover live config should refresh reasoning effort"
+        assert!(
+            parsed.get("model_reasoning_effort").is_none(),
+            "provider-owned Codex fields removed by the new provider should not survive in live"
         );
         assert_eq!(
             parsed
@@ -2491,6 +3298,459 @@ args = ["echo-server"]
                 .and_then(|v| v.get("echo"))
                 .is_some(),
             "Codex takeover live config should preserve MCP servers from the current live config"
+        );
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        let backup_config = backup_value
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("backup config string");
+        let parsed_backup: toml::Value =
+            toml::from_str(backup_config).expect("parse backup codex config");
+        assert_eq!(
+            parsed_backup.get("model").and_then(|v| v.as_str()),
+            Some("gpt-new"),
+            "backup should refresh the current Codex model"
+        );
+        assert!(
+            parsed_backup.get("model_reasoning_effort").is_none(),
+            "backup should drop provider-owned Codex fields removed by the new provider"
+        );
+        assert_eq!(
+            parsed_backup
+                .get("model_providers")
+                .and_then(|v| v.get("any"))
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("https://api.b.example/v1"),
+            "backup should keep the provider base URL instead of the proxy URL"
+        );
+        assert!(
+            parsed_backup
+                .get("mcp_servers")
+                .and_then(|v| v.get("echo"))
+                .is_some(),
+            "backup should preserve existing Codex MCP servers"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hot_switch_provider_updates_codex_live_when_model_provider_alias_changes() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "A".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "a-key"
+                },
+                "config": r#"model_provider = "openai"
+model = "gpt-old"
+
+[model_providers.openai]
+base_url = "https://api.a.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+        let provider_b = Provider::with_id(
+            "b".to_string(),
+            "B".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "b-key"
+                },
+                "config": r#"model_provider = "azure"
+model = "gpt-new"
+
+[model_providers.azure]
+base_url = "https://api.azure.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider_a)
+            .expect("save provider a");
+        db.save_provider("codex", &provider_b)
+            .expect("save provider b");
+        db.set_current_provider("codex", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("a"))
+            .expect("set local current provider");
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": "a-key"
+                },
+                "config": r#"model_provider = "openai"
+model = "gpt-old"
+
+[model_providers.openai]
+base_url = "https://api.a.example/v1"
+wire_api = "responses"
+
+[mcp_servers.echo]
+command = "npx"
+args = ["echo-server"]
+"#
+            }))
+            .expect("serialize provider a backup"),
+        )
+        .await
+        .expect("seed live backup");
+        service
+            .write_codex_live(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+                },
+                "config": r#"model_provider = "openai"
+model = "stale-model"
+
+[model_providers.openai]
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+
+[mcp_servers.echo]
+command = "npx"
+args = ["echo-server"]
+"#
+            }))
+            .expect("seed taken-over live file");
+
+        service
+            .hot_switch_provider("codex", "b")
+            .await
+            .expect("hot switch provider");
+
+        let live = service.read_codex_live().expect("read live config");
+        let live_config = live
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("live config string");
+        let parsed_live: toml::Value =
+            toml::from_str(live_config).expect("parse live codex config");
+        assert_eq!(
+            parsed_live.get("model_provider").and_then(|v| v.as_str()),
+            Some("azure"),
+            "live should refresh Codex model_provider when switching aliases"
+        );
+        assert_eq!(
+            parsed_live.get("model").and_then(|v| v.as_str()),
+            Some("gpt-new"),
+            "live should refresh the current Codex model when switching aliases"
+        );
+        assert!(
+            parsed_live
+                .get("model_providers")
+                .and_then(|v| v.get("openai"))
+                .is_none(),
+            "live should remove the stale provider-owned Codex alias table"
+        );
+        assert_eq!(
+            parsed_live
+                .get("model_providers")
+                .and_then(|v| v.get("azure"))
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("http://127.0.0.1:15721/v1"),
+            "live should rewrite the new active Codex alias to the proxy URL"
+        );
+        assert!(
+            parsed_live
+                .get("mcp_servers")
+                .and_then(|v| v.get("echo"))
+                .is_some(),
+            "live should preserve existing Codex MCP servers when switching aliases"
+        );
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        let backup_config = backup_value
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("backup config string");
+        let parsed_backup: toml::Value =
+            toml::from_str(backup_config).expect("parse backup codex config");
+        assert_eq!(
+            parsed_backup.get("model_provider").and_then(|v| v.as_str()),
+            Some("azure"),
+            "backup should refresh Codex model_provider when switching aliases"
+        );
+        assert!(
+            parsed_backup
+                .get("model_providers")
+                .and_then(|v| v.get("openai"))
+                .is_none(),
+            "backup should remove the stale provider-owned Codex alias table"
+        );
+        assert_eq!(
+            parsed_backup
+                .get("model_providers")
+                .and_then(|v| v.get("azure"))
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("https://api.azure.example/v1"),
+            "backup should keep the provider URL for the new active Codex alias"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hot_switch_provider_refreshes_codex_backup_from_current_live_when_live_only_sections_exist(
+    ) {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "A".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "a-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-old"
+
+[model_providers.any]
+base_url = "https://api.a.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+        let provider_b = Provider::with_id(
+            "b".to_string(),
+            "B".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "b-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-new"
+
+[model_providers.any]
+base_url = "https://api.b.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider_a)
+            .expect("save provider a");
+        db.save_provider("codex", &provider_b)
+            .expect("save provider b");
+        db.set_current_provider("codex", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("a"))
+            .expect("set local current provider");
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": "a-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-old"
+
+[model_providers.any]
+base_url = "https://api.a.example/v1"
+wire_api = "responses"
+"#
+            }))
+            .expect("serialize partial backup"),
+        )
+        .await
+        .expect("seed partial live backup");
+        service
+            .write_codex_live(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+                },
+                "config": r#"model_provider = "any"
+model = "stale-model"
+
+[model_providers.any]
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+
+[mcp_servers.echo]
+command = "npx"
+args = ["echo-server"]
+"#
+            }))
+            .expect("seed taken-over live file");
+
+        service
+            .hot_switch_provider("codex", "b")
+            .await
+            .expect("hot switch provider");
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        let backup_config = backup_value
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("backup config string");
+        let parsed_backup: toml::Value =
+            toml::from_str(backup_config).expect("parse backup codex config");
+
+        assert!(
+            parsed_backup
+                .get("mcp_servers")
+                .and_then(|v| v.get("echo"))
+                .is_some(),
+            "backup refresh should preserve current live-only Codex sections so restore stays in sync"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hot_switch_provider_tolerates_malformed_codex_live_config_during_takeover_refresh() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "A".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "a-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-old"
+
+[model_providers.any]
+base_url = "https://api.a.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+        let provider_b = Provider::with_id(
+            "b".to_string(),
+            "B".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "b-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-new"
+
+[model_providers.any]
+base_url = "https://api.b.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider_a)
+            .expect("save provider a");
+        db.save_provider("codex", &provider_b)
+            .expect("save provider b");
+        db.set_current_provider("codex", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("a"))
+            .expect("set local current provider");
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": "a-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-old"
+
+[model_providers.any]
+base_url = "https://api.a.example/v1"
+wire_api = "responses"
+
+[mcp_servers.echo]
+command = "npx"
+args = ["echo-server"]
+"#
+            }))
+            .expect("serialize provider a backup"),
+        )
+        .await
+        .expect("seed live backup");
+        write_json_file(
+            &crate::codex_config::get_codex_auth_path(),
+            &json!({
+                "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+            }),
+        )
+        .expect("seed codex auth file");
+        std::fs::write(
+            crate::codex_config::get_codex_config_path(),
+            "[mcp_servers.echo]\ncommand = ",
+        )
+        .expect("seed malformed codex config");
+
+        service
+            .hot_switch_provider("codex", "b")
+            .await
+            .expect("hot switch should ignore malformed Codex live config");
+
+        let live = service.read_codex_live().expect("read live config");
+        assert_eq!(
+            live.get("auth")
+                .and_then(|auth| auth.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "takeover placeholder should remain intact after fallback refresh"
+        );
+
+        let live_config = live
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("live config string");
+        let parsed_live: toml::Value =
+            toml::from_str(live_config).expect("parse recovered live codex config");
+        assert_eq!(
+            parsed_live.get("model").and_then(|v| v.as_str()),
+            Some("gpt-new"),
+            "live config should still refresh to the new provider after fallback"
+        );
+        assert!(
+            parsed_live
+                .get("mcp_servers")
+                .and_then(|v| v.get("echo"))
+                .is_some(),
+            "live config should fall back to the backup baseline when malformed live TOML cannot be patched"
         );
     }
 
@@ -2674,7 +3934,88 @@ args = ["echo-server"]
 
     #[tokio::test]
     #[serial]
-    async fn takeover_live_config_best_effort_refreshes_claude_model_fields() {
+    async fn takeover_live_config_best_effort_overlays_existing_claude_live_without_provider_rebuild(
+    ) {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "current".to_string(),
+            "Current".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "provider-key",
+                    "ANTHROPIC_BASE_URL": "https://api.current.example",
+                    "ANTHROPIC_MODEL": "claude-current"
+                },
+                "permissions": { "allow": ["Read"] }
+            }),
+            None,
+        );
+
+        db.save_provider("claude", &provider)
+            .expect("save current provider");
+        db.set_current_provider("claude", "current")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("current"))
+            .expect("set local current provider");
+
+        service
+            .write_claude_live(&json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "live-key",
+                    "ANTHROPIC_BASE_URL": "https://live.example",
+                    "ANTHROPIC_MODEL": "claude-live"
+                },
+                "permissions": { "allow": ["Bash"] }
+            }))
+            .expect("seed live config");
+
+        service
+            .takeover_live_config_best_effort(&AppType::Claude)
+            .await
+            .expect("best-effort rewrite");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_MODEL"))
+                .and_then(|v| v.as_str()),
+            Some("claude-live"),
+            "best-effort takeover should keep existing live-only Claude model fields"
+        );
+        assert_eq!(
+            live.get("permissions"),
+            Some(&json!({ "allow": ["Bash"] })),
+            "best-effort takeover should preserve existing live-only top-level Claude settings"
+        );
+        assert_ne!(
+            live.get("permissions"),
+            provider.settings_config.get("permissions"),
+            "best-effort takeover must not rebuild Claude live config from provider-only top-level settings"
+        );
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "best-effort takeover should still mask Claude credentials in the live file"
+        );
+        assert!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+                .and_then(|v| v.as_str())
+                .is_some_and(ProxyService::is_local_proxy_url),
+            "best-effort takeover should still rewrite Claude base URL to the local proxy"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn takeover_live_config_best_effort_skips_missing_claude_live_without_creating_file() {
         let _home = TempHome::new();
         crate::settings::reload_settings().expect("reload settings");
 
@@ -2701,28 +4042,218 @@ args = ["echo-server"]
         crate::settings::set_current_provider(&AppType::Claude, Some("current"))
             .expect("set local current provider");
 
-        service
-            .write_claude_live(&json!({
-                "env": {
-                    "ANTHROPIC_API_KEY": PROXY_TOKEN_PLACEHOLDER,
-                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:9999",
-                    "ANTHROPIC_MODEL": "stale-model"
-                }
-            }))
-            .expect("seed taken-over live config");
+        let live_path = get_claude_settings_path();
+        assert!(
+            !live_path.exists(),
+            "test precondition: missing Claude live file should remain missing"
+        );
 
         service
             .takeover_live_config_best_effort(&AppType::Claude)
             .await
-            .expect("best-effort rewrite");
+            .expect("best-effort takeover should skip missing live files");
 
-        let live = service.read_claude_live().expect("read live config");
+        assert!(
+            !live_path.exists(),
+            "best-effort takeover must not create a new Claude live file when none existed"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn takeover_live_config_best_effort_skips_partial_codex_live_without_creating_auth() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "current".to_string(),
+            "Current".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "provider-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-current"
+
+[model_providers.any]
+base_url = "https://api.current.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider)
+            .expect("save current provider");
+        db.set_current_provider("codex", "current")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("current"))
+            .expect("set local current provider");
+
+        let auth_path = crate::codex_config::get_codex_auth_path();
+        let config_path = crate::codex_config::get_codex_config_path();
+        std::fs::create_dir_all(config_path.parent().expect("config dir"))
+            .expect("create codex dir");
+        std::fs::write(&config_path, "model = \"partial\"\n").expect("seed partial codex config");
+        assert!(
+            !auth_path.exists(),
+            "test precondition: partial Codex live should not have auth.json"
+        );
+
+        service
+            .takeover_live_config_best_effort(&AppType::Codex)
+            .await
+            .expect("best-effort takeover should skip partial Codex live");
+
+        assert!(
+            !auth_path.exists(),
+            "best-effort takeover must not create Codex auth.json when only config.toml exists"
+        );
         assert_eq!(
-            live.get("env")
-                .and_then(|env| env.get("ANTHROPIC_MODEL"))
+            std::fs::read_to_string(&config_path).expect("read codex config"),
+            "model = \"partial\"\n",
+            "skipped best-effort takeover should leave the existing partial Codex config untouched"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn takeover_live_config_best_effort_overlays_auth_only_codex_live_and_creates_proxy_config(
+    ) {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "current".to_string(),
+            "Current".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "provider-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-current"
+
+[model_providers.any]
+base_url = "https://api.current.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider)
+            .expect("save current provider");
+        db.set_current_provider("codex", "current")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("current"))
+            .expect("set local current provider");
+
+        let auth_path = crate::codex_config::get_codex_auth_path();
+        let config_path = crate::codex_config::get_codex_config_path();
+        std::fs::create_dir_all(auth_path.parent().expect("auth dir")).expect("create codex dir");
+        write_json_file(
+            &auth_path,
+            &json!({
+                "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+            }),
+        )
+        .expect("seed auth-only codex live");
+        assert!(
+            !config_path.exists(),
+            "test precondition: auth-only Codex live should not have config.toml"
+        );
+
+        service
+            .takeover_live_config_best_effort(&AppType::Codex)
+            .await
+            .expect("best-effort takeover should overlay auth-only Codex live");
+
+        assert!(
+            config_path.exists(),
+            "best-effort takeover should create Codex config.toml when auth-only live needs a proxy base_url"
+        );
+
+        let live = service.read_codex_live().expect("read codex live");
+        assert_eq!(
+            live.get("auth")
+                .and_then(|auth| auth.get("OPENAI_API_KEY"))
                 .and_then(|v| v.as_str()),
-            Some("claude-current"),
-            "best-effort takeover refresh should rewrite stale Claude model fields"
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "best-effort takeover should keep the auth placeholder for auth-only Codex live"
+        );
+
+        let config = live
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("config string");
+        let parsed: toml::Value = toml::from_str(config).expect("parse generated codex config");
+        assert_eq!(
+            parsed.get("base_url").and_then(|v| v.as_str()),
+            Some("http://127.0.0.1:15721/v1"),
+            "best-effort takeover should create a proxy base_url for auth-only Codex live"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn takeover_live_config_best_effort_preserves_malformed_codex_config_without_rebuild() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "current".to_string(),
+            "Current".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "provider-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-current"
+
+[model_providers.any]
+base_url = "https://api.current.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider)
+            .expect("save current provider");
+        db.set_current_provider("codex", "current")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("current"))
+            .expect("set local current provider");
+
+        let config_path = crate::codex_config::get_codex_config_path();
+        write_json_file(
+            &crate::codex_config::get_codex_auth_path(),
+            &json!({
+                "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+            }),
+        )
+        .expect("seed codex auth file");
+        let malformed = "[mcp_servers.echo]\ncommand = ";
+        std::fs::write(&config_path, malformed).expect("seed malformed codex config");
+
+        service
+            .takeover_live_config_best_effort(&AppType::Codex)
+            .await
+            .expect("best-effort takeover should preserve malformed Codex live");
+
+        assert_eq!(
+            std::fs::read_to_string(&config_path).expect("read malformed codex config"),
+            malformed,
+            "best-effort takeover should keep the existing malformed Codex config instead of rebuilding it from provider state"
         );
     }
 
@@ -3074,6 +4605,91 @@ args = ["echo-server"]
                 .and_then(|v| v.as_str()),
             Some("claude-refresh"),
             "the combined helper should refresh live config from the provider under takeover"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn refresh_takeover_state_from_provider_reapplies_current_common_config_to_live() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        db.set_config_snippet(
+            "claude",
+            Some(r#"{ "includeCoAuthoredBy": true }"#.to_string()),
+        )
+        .expect("set common config snippet");
+
+        let mut provider = Provider::with_id(
+            "p1".to_string(),
+            "P1".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token",
+                    "ANTHROPIC_BASE_URL": "https://claude.example",
+                    "ANTHROPIC_MODEL": "claude-refresh"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        write_json_file(
+            &get_claude_settings_path(),
+            &json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:14555",
+                    "ANTHROPIC_AUTH_TOKEN": PROXY_TOKEN_PLACEHOLDER,
+                    "ANTHROPIC_MODEL": "stale-model"
+                },
+                "permissions": { "allow": ["Bash"] }
+            }),
+        )
+        .expect("seed taken-over live file");
+
+        db.save_live_backup(
+            "claude",
+            &serde_json::to_string(&json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "token",
+                    "ANTHROPIC_BASE_URL": "https://claude.example",
+                    "ANTHROPIC_MODEL": "claude-refresh"
+                },
+                "permissions": { "allow": ["Bash"] }
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("seed live backup");
+
+        service
+            .refresh_takeover_state_from_provider(&AppType::Claude, &provider)
+            .await
+            .expect("refresh takeover state");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("includeCoAuthoredBy").and_then(|v| v.as_bool()),
+            Some(true),
+            "takeover live refresh should reapply current common-config fields"
+        );
+        assert_eq!(
+            live.get("permissions"),
+            Some(&json!({ "allow": ["Bash"] })),
+            "takeover live refresh should preserve live-only Claude settings"
+        );
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_AUTH_TOKEN"))
+                .and_then(|v| v.as_str()),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "takeover live refresh should keep proxy placeholders after reapplying common config"
         );
     }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -819,7 +819,7 @@ impl ProxyService {
             .map(str::to_string);
 
         for key in CODEX_PROVIDER_TOP_LEVEL_KEYS {
-            base_doc.as_table_mut().remove(*key);
+            base_doc.as_table_mut().remove(key);
         }
 
         if let Some(model_providers) = base_doc
@@ -838,8 +838,8 @@ impl ProxyService {
         }
 
         for key in CODEX_PROVIDER_TOP_LEVEL_KEYS {
-            if let Some(item) = provider_doc.get(*key) {
-                base_doc[*key] = item.clone();
+            if let Some(item) = provider_doc.get(key) {
+                base_doc[key] = item.clone();
             }
         }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -431,9 +431,16 @@ impl ProxyService {
         if let Some(previous_common_snippet) = previous_common_snippet
             .filter(|snippet| provider_uses_common_config(app_type, provider, Some(*snippet)))
         {
-            snapshot =
-                remove_common_config_from_settings(app_type, &snapshot, previous_common_snippet)
-                    .map_err(|e| format!("移除 {} 旧通用配置失败: {e}", app_type.as_str()))?;
+            match remove_common_config_from_settings(app_type, &snapshot, previous_common_snippet) {
+                Ok(updated_snapshot) => snapshot = updated_snapshot,
+                Err(err) => {
+                    log::warn!(
+                        "Skipping previous common config removal for {} provider '{}' during transition: {err}",
+                        app_type.as_str(),
+                        provider.id
+                    );
+                }
+            }
         }
 
         let mut snapshot_provider = provider.clone();

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -20,20 +20,6 @@ use tokio::sync::RwLock;
 /// 用于接管 Live 配置时的占位符（避免客户端提示缺少 key，同时不泄露真实 Token）
 const PROXY_TOKEN_PLACEHOLDER: &str = "PROXY_MANAGED";
 
-/// 代理接管模式下需要从 Claude Live 配置中移除的"模型覆盖"字段。
-///
-/// 原因：接管模式切换供应商时不会写回 Live 配置，如果保留这些字段，
-/// Claude Code 会继续以旧模型名发起请求，导致新供应商不支持时失败。
-const CLAUDE_MODEL_OVERRIDE_ENV_KEYS: [&str; 6] = [
-    "ANTHROPIC_MODEL",
-    "ANTHROPIC_REASONING_MODEL",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL",
-    // Legacy key (已废弃)：历史版本使用该字段区分 small/fast 模型
-    "ANTHROPIC_SMALL_FAST_MODEL",
-];
-
 #[derive(Clone)]
 pub struct ProxyService {
     db: Arc<Database>,
@@ -58,31 +44,6 @@ impl ProxyService {
         }
     }
 
-    /// 清理接管模式下 Claude Live 配置中的模型覆盖字段。
-    ///
-    /// 这可以避免"接管开启后切换供应商仍使用旧模型"的问题。
-    /// 注意：此方法不会修改 Token/Base URL 的接管占位符，仅移除模型字段。
-    pub fn cleanup_claude_model_overrides_in_live(&self) -> Result<(), String> {
-        let mut config = self.read_claude_live()?;
-
-        let Some(env) = config.get_mut("env").and_then(|v| v.as_object_mut()) else {
-            return Ok(());
-        };
-
-        let mut changed = false;
-        for key in CLAUDE_MODEL_OVERRIDE_ENV_KEYS {
-            if env.remove(key).is_some() {
-                changed = true;
-            }
-        }
-
-        if changed {
-            self.write_claude_live(&config)?;
-        }
-
-        Ok(())
-    }
-
     fn apply_claude_takeover_fields(config: &mut Value, proxy_url: &str) {
         if !config.is_object() {
             *config = json!({});
@@ -100,10 +61,6 @@ impl ProxyService {
             .as_object_mut()
             .expect("Claude env should be normalized to an object");
         env.insert("ANTHROPIC_BASE_URL".to_string(), json!(proxy_url));
-
-        for key in CLAUDE_MODEL_OVERRIDE_ENV_KEYS {
-            env.remove(key);
-        }
 
         let token_keys = [
             "ANTHROPIC_AUTH_TOKEN",
@@ -128,20 +85,180 @@ impl ProxyService {
         }
     }
 
-    pub async fn sync_claude_live_from_provider_while_proxy_active(
+    fn apply_codex_takeover_fields(config: &mut Value, proxy_codex_base_url: &str) {
+        if !config.is_object() {
+            *config = json!({});
+        }
+
+        let root = config
+            .as_object_mut()
+            .expect("Codex config should be normalized to an object");
+        let auth = root.entry("auth".to_string()).or_insert_with(|| json!({}));
+        if !auth.is_object() {
+            *auth = json!({});
+        }
+        auth.as_object_mut()
+            .expect("Codex auth should be normalized to an object")
+            .insert("OPENAI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+
+        let config_str = root.get("config").and_then(|v| v.as_str()).unwrap_or("");
+        let updated_config = Self::update_toml_base_url(config_str, proxy_codex_base_url);
+        root.insert("config".to_string(), json!(updated_config));
+    }
+
+    fn apply_gemini_takeover_fields(config: &mut Value, proxy_url: &str) {
+        if !config.is_object() {
+            *config = json!({});
+        }
+
+        let root = config
+            .as_object_mut()
+            .expect("Gemini config should be normalized to an object");
+        let env = root.entry("env".to_string()).or_insert_with(|| json!({}));
+        if !env.is_object() {
+            *env = json!({});
+        }
+
+        let env = env
+            .as_object_mut()
+            .expect("Gemini env should be normalized to an object");
+        env.insert("GOOGLE_GEMINI_BASE_URL".to_string(), json!(proxy_url));
+        env.insert("GEMINI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+    }
+
+    fn apply_takeover_overlay(
+        app_type: &AppType,
+        config: &mut Value,
+        proxy_url: &str,
+        proxy_codex_base_url: &str,
+    ) -> Result<(), String> {
+        match app_type {
+            AppType::Claude => {
+                Self::apply_claude_takeover_fields(config, proxy_url);
+                Ok(())
+            }
+            AppType::Codex => {
+                Self::apply_codex_takeover_fields(config, proxy_codex_base_url);
+                Ok(())
+            }
+            AppType::Gemini => {
+                Self::apply_gemini_takeover_fields(config, proxy_url);
+                Ok(())
+            }
+            AppType::OpenCode => Err("OpenCode 不支持代理功能".to_string()),
+            AppType::OpenClaw => Err("OpenClaw 不支持代理功能".to_string()),
+        }
+    }
+
+    pub async fn sync_live_from_provider_while_proxy_active(
         &self,
+        app_type: &AppType,
         provider: &Provider,
     ) -> Result<(), String> {
-        let mut effective_settings = build_effective_settings_with_common_config(
-            self.db.as_ref(),
-            &AppType::Claude,
-            provider,
-        )
-        .map_err(|e| format!("构建 claude 有效配置失败: {e}"))?;
-        let (proxy_url, _) = self.build_proxy_urls().await?;
+        let _guard = self.switch_locks.lock_for_app(app_type.as_str()).await;
+        self.sync_live_from_provider_while_proxy_active_inner(app_type, provider)
+            .await
+    }
 
-        Self::apply_claude_takeover_fields(&mut effective_settings, &proxy_url);
-        self.write_claude_live(&effective_settings)?;
+    async fn sync_live_from_provider_while_proxy_active_inner(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<(), String> {
+        let effective_settings = self
+            .build_takeover_live_config_from_provider(app_type, provider)
+            .await?;
+        self.write_live_config_for_app(app_type, &effective_settings)?;
+        Ok(())
+    }
+
+    async fn sync_live_from_current_provider_while_proxy_active_inner(
+        &self,
+        app_type: &AppType,
+    ) -> Result<bool, String> {
+        let current_id = crate::settings::get_effective_current_provider(&self.db, app_type)
+            .map_err(|e| format!("读取当前 {} 供应商失败: {e}", app_type.as_str()))?;
+        let Some(current_id) = current_id else {
+            return Ok(false);
+        };
+
+        let provider = self
+            .db
+            .get_provider_by_id(&current_id, app_type.as_str())
+            .map_err(|e| format!("读取当前 {} 供应商配置失败: {e}", app_type.as_str()))?;
+        let Some(provider) = provider else {
+            return Ok(false);
+        };
+
+        self.sync_live_from_provider_while_proxy_active_inner(app_type, &provider)
+            .await?;
+        Ok(true)
+    }
+
+    pub async fn refresh_takeover_state_from_provider(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<(), String> {
+        let _guard = self.switch_locks.lock_for_app(app_type.as_str()).await;
+        self.refresh_takeover_state_from_provider_inner(app_type, provider)
+            .await
+    }
+
+    async fn refresh_takeover_state_from_provider_inner(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<(), String> {
+        self.update_live_backup_from_provider_inner(app_type.as_str(), provider)
+            .await?;
+        self.sync_live_from_provider_while_proxy_active_inner(app_type, provider)
+            .await?;
+        Ok(())
+    }
+
+    async fn build_takeover_live_config_from_provider(
+        &self,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<Value, String> {
+        let mut effective_settings =
+            build_effective_settings_with_common_config(self.db.as_ref(), app_type, provider)
+                .map_err(|e| format!("构建 {} 有效配置失败: {e}", app_type.as_str()))?;
+
+        if matches!(app_type, AppType::Codex) {
+            if let Ok(existing_live) = self.read_codex_live() {
+                Self::preserve_codex_mcp_servers(&mut effective_settings, &existing_live)?;
+            }
+        }
+
+        let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+        Self::apply_takeover_overlay(
+            app_type,
+            &mut effective_settings,
+            &proxy_url,
+            &proxy_codex_base_url,
+        )?;
+        Ok(effective_settings)
+    }
+
+    async fn overlay_takeover_on_existing_live(&self, app_type: &AppType) -> Result<(), String> {
+        let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+        let mut live_config = match app_type {
+            AppType::Claude => self.read_claude_live()?,
+            AppType::Codex => self.read_codex_live()?,
+            AppType::Gemini => self.read_gemini_live()?,
+            AppType::OpenCode => return Err("OpenCode 不支持代理功能".to_string()),
+            AppType::OpenClaw => return Err("OpenClaw 不支持代理功能".to_string()),
+        };
+
+        Self::apply_takeover_overlay(
+            app_type,
+            &mut live_config,
+            &proxy_url,
+            &proxy_codex_base_url,
+        )?;
+        self.write_live_config_for_app(app_type, &live_config)?;
         Ok(())
     }
 
@@ -907,48 +1024,8 @@ impl ProxyService {
     ///
     /// 因此不需要在 URL 中添加应用前缀。
     async fn takeover_live_configs(&self) -> Result<(), String> {
-        let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
-
-        // Claude: 修改 ANTHROPIC_BASE_URL，使用占位符替代真实 Token（代理会注入真实 Token）
-        if let Ok(mut live_config) = self.read_claude_live() {
-            Self::apply_claude_takeover_fields(&mut live_config, &proxy_url);
-            self.write_claude_live(&live_config)?;
-            log::info!("Claude Live 配置已接管，代理地址: {proxy_url}");
-        }
-
-        // Codex: 修改 config.toml 的 base_url，auth.json 的 OPENAI_API_KEY（代理会注入真实 Token）
-        if let Ok(mut live_config) = self.read_codex_live() {
-            // 1. 修改 auth.json 中的 OPENAI_API_KEY（使用占位符）
-            if let Some(auth) = live_config.get_mut("auth").and_then(|v| v.as_object_mut()) {
-                auth.insert("OPENAI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
-            }
-
-            // 2. 修改 config.toml 中的 base_url
-            let config_str = live_config
-                .get("config")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let updated_config = Self::update_toml_base_url(config_str, &proxy_codex_base_url);
-            live_config["config"] = json!(updated_config);
-
-            self.write_codex_live(&live_config)?;
-            log::info!("Codex Live 配置已接管，代理地址: {proxy_codex_base_url}");
-        }
-
-        // Gemini: 修改 GOOGLE_GEMINI_BASE_URL，使用占位符替代真实 Token（代理会注入真实 Token）
-        if let Ok(mut live_config) = self.read_gemini_live() {
-            if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
-                env.insert("GOOGLE_GEMINI_BASE_URL".to_string(), json!(&proxy_url));
-                // 使用占位符，避免显示缺少 key 的警告
-                env.insert("GEMINI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
-            } else {
-                live_config["env"] = json!({
-                    "GOOGLE_GEMINI_BASE_URL": &proxy_url,
-                    "GEMINI_API_KEY": PROXY_TOKEN_PLACEHOLDER
-                });
-            }
-            self.write_gemini_live(&live_config)?;
-            log::info!("Gemini Live 配置已接管，代理地址: {proxy_url}");
+        for app_type in [AppType::Claude, AppType::Codex, AppType::Gemini] {
+            self.takeover_live_config_best_effort(&app_type).await?;
         }
 
         Ok(())
@@ -956,56 +1033,33 @@ impl ProxyService {
 
     /// 接管指定应用的 Live 配置（严格模式：目标配置不存在则返回错误）
     async fn takeover_live_config_strict(&self, app_type: &AppType) -> Result<(), String> {
+        let _guard = self.switch_locks.lock_for_app(app_type.as_str()).await;
+        match self
+            .sync_live_from_current_provider_while_proxy_active_inner(app_type)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                self.overlay_takeover_on_existing_live(app_type).await?;
+            }
+            Err(err) => {
+                log::warn!(
+                    "基于当前 {} 供应商重建接管配置失败，将回退到现有 Live 配置: {err}",
+                    app_type.as_str()
+                );
+                self.overlay_takeover_on_existing_live(app_type).await?;
+            }
+        }
+
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
-
         match app_type {
-            AppType::Claude => {
-                let mut live_config = self.read_claude_live()?;
-                Self::apply_claude_takeover_fields(&mut live_config, &proxy_url);
-                self.write_claude_live(&live_config)?;
-                log::info!("Claude Live 配置已接管，代理地址: {proxy_url}");
-            }
+            AppType::Claude => log::info!("Claude Live 配置已接管，代理地址: {proxy_url}"),
             AppType::Codex => {
-                let mut live_config = self.read_codex_live()?;
-
-                if let Some(auth) = live_config.get_mut("auth").and_then(|v| v.as_object_mut()) {
-                    auth.insert("OPENAI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
-                }
-
-                let config_str = live_config
-                    .get("config")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let updated_config = Self::update_toml_base_url(config_str, &proxy_codex_base_url);
-                live_config["config"] = json!(updated_config);
-
-                self.write_codex_live(&live_config)?;
-                log::info!("Codex Live 配置已接管，代理地址: {proxy_codex_base_url}");
+                log::info!("Codex Live 配置已接管，代理地址: {proxy_codex_base_url}")
             }
-            AppType::Gemini => {
-                let mut live_config = self.read_gemini_live()?;
-
-                if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
-                    env.insert("GOOGLE_GEMINI_BASE_URL".to_string(), json!(&proxy_url));
-                    env.insert("GEMINI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
-                } else {
-                    live_config["env"] = json!({
-                        "GOOGLE_GEMINI_BASE_URL": &proxy_url,
-                        "GEMINI_API_KEY": PROXY_TOKEN_PLACEHOLDER
-                    });
-                }
-
-                self.write_gemini_live(&live_config)?;
-                log::info!("Gemini Live 配置已接管，代理地址: {proxy_url}");
-            }
-            AppType::OpenCode => {
-                // OpenCode doesn't support proxy features
-                return Err("OpenCode 不支持代理功能".to_string());
-            }
-            AppType::OpenClaw => {
-                // OpenClaw doesn't support proxy features
-                return Err("OpenClaw 不支持代理功能".to_string());
-            }
+            AppType::Gemini => log::info!("Gemini Live 配置已接管，代理地址: {proxy_url}"),
+            AppType::OpenCode => return Err("OpenCode 不支持代理功能".to_string()),
+            AppType::OpenClaw => return Err("OpenClaw 不支持代理功能".to_string()),
         }
 
         Ok(())
@@ -1013,53 +1067,21 @@ impl ProxyService {
 
     /// 接管指定应用的 Live 配置（尽力而为：配置不存在/读取失败则跳过）
     async fn takeover_live_config_best_effort(&self, app_type: &AppType) -> Result<(), String> {
-        let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
-
-        match app_type {
-            AppType::Claude => {
-                if let Ok(mut live_config) = self.read_claude_live() {
-                    Self::apply_claude_takeover_fields(&mut live_config, &proxy_url);
-                    let _ = self.write_claude_live(&live_config);
-                }
+        let _guard = self.switch_locks.lock_for_app(app_type.as_str()).await;
+        match self
+            .sync_live_from_current_provider_while_proxy_active_inner(app_type)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                let _ = self.overlay_takeover_on_existing_live(app_type).await;
             }
-            AppType::Codex => {
-                if let Ok(mut live_config) = self.read_codex_live() {
-                    if let Some(auth) = live_config.get_mut("auth").and_then(|v| v.as_object_mut())
-                    {
-                        auth.insert("OPENAI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
-                    }
-
-                    let config_str = live_config
-                        .get("config")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    let updated_config =
-                        Self::update_toml_base_url(config_str, &proxy_codex_base_url);
-                    live_config["config"] = json!(updated_config);
-
-                    let _ = self.write_codex_live(&live_config);
-                }
-            }
-            AppType::Gemini => {
-                if let Ok(mut live_config) = self.read_gemini_live() {
-                    if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
-                        env.insert("GOOGLE_GEMINI_BASE_URL".to_string(), json!(&proxy_url));
-                        env.insert("GEMINI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
-                    } else {
-                        live_config["env"] = json!({
-                            "GOOGLE_GEMINI_BASE_URL": &proxy_url,
-                            "GEMINI_API_KEY": PROXY_TOKEN_PLACEHOLDER
-                        });
-                    }
-
-                    let _ = self.write_gemini_live(&live_config);
-                }
-            }
-            AppType::OpenCode => {
-                // OpenCode doesn't support proxy features, skip silently
-            }
-            AppType::OpenClaw => {
-                // OpenClaw doesn't support proxy features, skip silently
+            Err(err) => {
+                log::warn!(
+                    "基于当前 {} 供应商重建接管配置失败，将回退到现有 Live 配置: {err}",
+                    app_type.as_str()
+                );
+                let _ = self.overlay_takeover_on_existing_live(app_type).await;
             }
         }
 
@@ -1497,10 +1519,7 @@ impl ProxyService {
             if let Some(existing_backup) = existing_backup {
                 let existing_value: Value = serde_json::from_str(&existing_backup.original_config)
                     .map_err(|e| format!("解析 {app_type} 现有备份失败: {e}"))?;
-                Self::preserve_codex_mcp_servers_in_backup(
-                    &mut effective_settings,
-                    &existing_value,
-                )?;
+                Self::preserve_codex_mcp_servers(&mut effective_settings, &existing_value)?;
             }
         }
 
@@ -1573,12 +1592,12 @@ impl ProxyService {
             self.update_live_backup_from_provider_inner(app_type, &provider)
                 .await?;
 
-            if matches!(app_type_enum, AppType::Claude) {
-                self.sync_claude_live_from_provider_while_proxy_active(&provider)
+            if matches!(
+                app_type_enum,
+                AppType::Claude | AppType::Codex | AppType::Gemini
+            ) {
+                self.sync_live_from_provider_while_proxy_active_inner(&app_type_enum, &provider)
                     .await?;
-                if let Err(e) = self.cleanup_claude_model_overrides_in_live() {
-                    log::warn!("清理 Claude Live 模型字段失败（不影响热切换结果）: {e}");
-                }
             }
         }
 
@@ -1598,9 +1617,9 @@ impl ProxyService {
         self.switch_locks.lock_for_app(app_type).await
     }
 
-    fn preserve_codex_mcp_servers_in_backup(
+    fn preserve_codex_mcp_servers(
         target_settings: &mut Value,
-        existing_backup: &Value,
+        existing_snapshot: &Value,
     ) -> Result<(), String> {
         let target_obj = target_settings
             .as_object_mut()
@@ -1618,7 +1637,7 @@ impl ProxyService {
                 .map_err(|e| format!("解析新的 Codex config.toml 失败: {e}"))?
         };
 
-        let existing_config = existing_backup
+        let existing_config = existing_snapshot
             .get("config")
             .and_then(|v| v.as_str())
             .unwrap_or("");
@@ -2312,11 +2331,12 @@ model = "gpt-5.1-codex"
             Some("http://127.0.0.1:15721"),
             "takeover proxy URL should remain active"
         );
-        assert!(
+        assert_eq!(
             live.get("env")
                 .and_then(|env| env.get("ANTHROPIC_MODEL"))
-                .is_none(),
-            "Claude model override fields should be removed in takeover mode"
+                .and_then(|v| v.as_str()),
+            Some("claude-new"),
+            "Claude takeover live config should refresh to the current provider model"
         );
 
         let backup = db
@@ -2326,6 +2346,418 @@ model = "gpt-5.1-codex"
             .expect("backup exists");
         let expected = serde_json::to_string(&provider_b.settings_config).expect("serialize");
         assert_eq!(backup.original_config, expected);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hot_switch_provider_updates_codex_live_while_preserving_takeover_fields() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "A".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "a-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-old"
+model_reasoning_effort = "low"
+
+[model_providers.any]
+base_url = "https://api.a.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+        let provider_b = Provider::with_id(
+            "b".to_string(),
+            "B".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "b-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-new"
+model_reasoning_effort = "high"
+
+[model_providers.any]
+base_url = "https://api.b.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider_a)
+            .expect("save provider a");
+        db.save_provider("codex", &provider_b)
+            .expect("save provider b");
+        db.set_current_provider("codex", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("a"))
+            .expect("set local current provider");
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": "a-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-old"
+model_reasoning_effort = "low"
+
+[model_providers.any]
+base_url = "https://api.a.example/v1"
+wire_api = "responses"
+
+[mcp_servers.echo]
+command = "npx"
+args = ["echo-server"]
+"#
+            }))
+            .expect("serialize provider a backup"),
+        )
+        .await
+        .expect("seed live backup");
+        service
+            .write_codex_live(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+                },
+                "config": r#"model_provider = "any"
+model = "stale-model"
+model_reasoning_effort = "minimal"
+
+[model_providers.any]
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+
+[mcp_servers.echo]
+command = "npx"
+args = ["echo-server"]
+"#
+            }))
+            .expect("seed taken-over live file");
+
+        service
+            .hot_switch_provider("codex", "b")
+            .await
+            .expect("hot switch provider");
+
+        let live = service.read_codex_live().expect("read live config");
+        assert_eq!(
+            live.get("auth")
+                .and_then(|auth| auth.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "takeover token placeholder should be preserved"
+        );
+
+        let config = live
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("config string");
+        let parsed: toml::Value = toml::from_str(config).expect("parse live codex config");
+        assert_eq!(
+            parsed.get("model").and_then(|v| v.as_str()),
+            Some("gpt-new"),
+            "Codex takeover live config should refresh to the current provider model"
+        );
+        assert_eq!(
+            parsed
+                .get("model_reasoning_effort")
+                .and_then(|v| v.as_str()),
+            Some("high"),
+            "Codex takeover live config should refresh reasoning effort"
+        );
+        assert_eq!(
+            parsed
+                .get("model_providers")
+                .and_then(|v| v.get("any"))
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("http://127.0.0.1:15721/v1"),
+            "takeover proxy URL should remain active"
+        );
+        assert!(
+            parsed
+                .get("mcp_servers")
+                .and_then(|v| v.get("echo"))
+                .is_some(),
+            "Codex takeover live config should preserve MCP servers from the current live config"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn takeover_live_config_strict_rebuilds_claude_live_from_current_provider() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "current".to_string(),
+            "Current".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "provider-key",
+                    "ANTHROPIC_BASE_URL": "https://api.current.example",
+                    "ANTHROPIC_MODEL": "claude-current"
+                },
+                "permissions": { "allow": ["Read"] }
+            }),
+            None,
+        );
+
+        db.save_provider("claude", &provider)
+            .expect("save current provider");
+        db.set_current_provider("claude", "current")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("current"))
+            .expect("set local current provider");
+
+        service
+            .write_claude_live(&json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "live-key",
+                    "ANTHROPIC_BASE_URL": "https://live.example"
+                },
+                "permissions": { "allow": ["Bash"] }
+            }))
+            .expect("seed live config");
+
+        service
+            .takeover_live_config_strict(&AppType::Claude)
+            .await
+            .expect("take over claude live config");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "takeover should still mask provider credentials"
+        );
+        assert!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+                .and_then(|v| v.as_str())
+                .is_some_and(ProxyService::is_local_proxy_url),
+            "takeover should still rewrite Claude base URL to the local proxy"
+        );
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_MODEL"))
+                .and_then(|v| v.as_str()),
+            Some("claude-current"),
+            "takeover should write the current provider model into Claude live config"
+        );
+        assert_eq!(
+            live.get("permissions"),
+            provider.settings_config.get("permissions"),
+            "takeover should rebuild live config from the current provider"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn takeover_live_config_strict_rebuilds_codex_live_from_current_provider() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "current".to_string(),
+            "Current".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "provider-key"
+                },
+                "config": r#"model_provider = "any"
+model = "gpt-current"
+model_reasoning_effort = "medium"
+
+[model_providers.any]
+base_url = "https://api.current.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider)
+            .expect("save current provider");
+        db.set_current_provider("codex", "current")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("current"))
+            .expect("set local current provider");
+
+        service
+            .write_codex_live(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": "live-key"
+                },
+                "config": r#"model_provider = "any"
+model = "stale-model"
+model_reasoning_effort = "low"
+
+[model_providers.any]
+base_url = "https://live.example/v1"
+wire_api = "responses"
+
+[mcp_servers.echo]
+command = "npx"
+args = ["echo-server"]
+"#
+            }))
+            .expect("seed live config");
+
+        service
+            .takeover_live_config_strict(&AppType::Codex)
+            .await
+            .expect("take over codex live config");
+
+        let live = service.read_codex_live().expect("read live config");
+        assert_eq!(
+            live.get("auth")
+                .and_then(|auth| auth.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "takeover should still mask provider credentials"
+        );
+
+        let config = live
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("config string");
+        let parsed: toml::Value = toml::from_str(config).expect("parse live codex config");
+        assert_eq!(
+            parsed.get("model").and_then(|v| v.as_str()),
+            Some("gpt-current"),
+            "takeover should write the current provider model into Codex live config"
+        );
+        assert_eq!(
+            parsed
+                .get("model_reasoning_effort")
+                .and_then(|v| v.as_str()),
+            Some("medium"),
+            "takeover should rebuild Codex live config from the current provider"
+        );
+        assert_eq!(
+            parsed
+                .get("model_providers")
+                .and_then(|v| v.get("any"))
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("http://127.0.0.1:15721/v1"),
+            "takeover should still rewrite Codex base URL to the local proxy"
+        );
+        assert!(
+            parsed
+                .get("mcp_servers")
+                .and_then(|v| v.get("echo"))
+                .is_some(),
+            "takeover should preserve Codex MCP servers while rebuilding the current provider config"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn takeover_live_config_best_effort_refreshes_claude_model_fields() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "current".to_string(),
+            "Current".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "provider-key",
+                    "ANTHROPIC_BASE_URL": "https://api.current.example",
+                    "ANTHROPIC_MODEL": "claude-current"
+                }
+            }),
+            None,
+        );
+
+        db.save_provider("claude", &provider)
+            .expect("save current provider");
+        db.set_current_provider("claude", "current")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("current"))
+            .expect("set local current provider");
+
+        service
+            .write_claude_live(&json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": PROXY_TOKEN_PLACEHOLDER,
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:9999",
+                    "ANTHROPIC_MODEL": "stale-model"
+                }
+            }))
+            .expect("seed taken-over live config");
+
+        service
+            .takeover_live_config_best_effort(&AppType::Claude)
+            .await
+            .expect("best-effort rewrite");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_MODEL"))
+                .and_then(|v| v.as_str()),
+            Some("claude-current"),
+            "best-effort takeover refresh should rewrite stale Claude model fields"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn takeover_live_config_strict_fallback_preserves_existing_claude_model_fields() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        service
+            .write_claude_live(&json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "live-key",
+                    "ANTHROPIC_BASE_URL": "https://live.example",
+                    "ANTHROPIC_MODEL": "stale-model"
+                }
+            }))
+            .expect("seed live config");
+
+        service
+            .takeover_live_config_strict(&AppType::Claude)
+            .await
+            .expect("take over claude live config");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_MODEL"))
+                .and_then(|v| v.as_str()),
+            Some("stale-model"),
+            "fallback takeover should preserve provider-owned model fields when no current provider exists"
+        );
     }
 
     #[tokio::test]
@@ -2504,6 +2936,144 @@ model = "gpt-5.1-codex"
         assert_eq!(
             service.read_claude_live().expect("read live"),
             provider_b.settings_config
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn sync_live_from_provider_while_proxy_active_waits_for_app_lock() {
+        use tokio::time::{sleep, Duration};
+
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "p1".to_string(),
+            "P1".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "token",
+                    "ANTHROPIC_BASE_URL": "https://claude.example",
+                    "ANTHROPIC_MODEL": "claude-locked"
+                }
+            }),
+            None,
+        );
+
+        let guard = service.lock_switch_for_test("claude").await;
+        let service_for_sync = service.clone();
+        let provider_for_sync = provider.clone();
+
+        let sync_task = tokio::spawn(async move {
+            service_for_sync
+                .sync_live_from_provider_while_proxy_active(&AppType::Claude, &provider_for_sync)
+                .await
+                .expect("sync live while proxy active");
+        });
+
+        sleep(Duration::from_millis(20)).await;
+        assert!(
+            !sync_task.is_finished(),
+            "proxy-active live rebuild should wait for the per-app switch lock"
+        );
+
+        drop(guard);
+        sync_task.await.expect("join sync task");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "takeover placeholder should still be applied after the lock is released"
+        );
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_MODEL"))
+                .and_then(|v| v.as_str()),
+            Some("claude-locked"),
+            "live config should still refresh from the provider once the lock is available"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn refresh_takeover_state_from_provider_waits_for_app_lock_and_updates_backup_and_live() {
+        use tokio::time::{sleep, Duration};
+
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider = Provider::with_id(
+            "p1".to_string(),
+            "P1".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "token",
+                    "ANTHROPIC_BASE_URL": "https://claude.example",
+                    "ANTHROPIC_MODEL": "claude-refresh"
+                }
+            }),
+            None,
+        );
+
+        let guard = service.lock_switch_for_test("claude").await;
+        let service_for_refresh = service.clone();
+        let provider_for_refresh = provider.clone();
+
+        let refresh_task = tokio::spawn(async move {
+            service_for_refresh
+                .refresh_takeover_state_from_provider(&AppType::Claude, &provider_for_refresh)
+                .await
+                .expect("refresh takeover state");
+        });
+
+        sleep(Duration::from_millis(20)).await;
+        assert!(
+            !refresh_task.is_finished(),
+            "the combined takeover refresh should wait for the per-app switch lock"
+        );
+
+        drop(guard);
+        refresh_task.await.expect("join refresh task");
+
+        let backup = db
+            .get_live_backup("claude")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        assert_eq!(
+            backup_value
+                .get("env")
+                .and_then(|env| env.get("ANTHROPIC_MODEL"))
+                .and_then(|v| v.as_str()),
+            Some("claude-refresh"),
+            "the combined helper should update the restore backup from the provider"
+        );
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some(PROXY_TOKEN_PLACEHOLDER),
+            "the combined helper should keep takeover credentials masked in live config"
+        );
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_MODEL"))
+                .and_then(|v| v.as_str()),
+            Some("claude-refresh"),
+            "the combined helper should refresh live config from the provider under takeover"
         );
     }
 

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -239,7 +239,7 @@ command = "say"
 }
 
 #[test]
-fn sync_current_provider_for_app_keeps_live_takeover_and_updates_restore_backup() {
+fn sync_current_provider_for_app_skips_proxy_refresh_when_proxy_server_is_not_running() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();
     let _home = ensure_test_home();
@@ -250,53 +250,56 @@ fn sync_current_provider_for_app_keeps_live_takeover_and_updates_restore_backup(
             .get_manager_mut(&AppType::Claude)
             .expect("claude manager");
         manager.current = "current-provider".to_string();
-
-        let mut provider = Provider::with_id(
+        manager.providers.insert(
             "current-provider".to_string(),
-            "Current".to_string(),
-            json!({
-                "env": {
-                    "ANTHROPIC_AUTH_TOKEN": "real-token",
-                    "ANTHROPIC_BASE_URL": "https://claude.example"
-                }
-            }),
-            None,
+            Provider::with_id(
+                "current-provider".to_string(),
+                "Current".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "real-token",
+                        "ANTHROPIC_BASE_URL": "https://claude.example",
+                        "ANTHROPIC_MODEL": "claude-sync-target"
+                    },
+                    "primaryModel": "claude-primary-target"
+                }),
+                None,
+            ),
         );
-        provider.meta = Some(ProviderMeta {
-            common_config_enabled: Some(true),
-            ..Default::default()
-        });
-
-        manager
-            .providers
-            .insert("current-provider".to_string(), provider);
     }
 
     let state = create_test_state_with_config(&config).expect("create test state");
-    state
-        .db
-        .set_config_snippet(
-            AppType::Claude.as_str(),
-            Some(r#"{ "includeCoAuthoredBy": false }"#.to_string()),
-        )
-        .expect("set common config snippet");
-
-    let taken_over_live = json!({
-        "env": {
-            "ANTHROPIC_BASE_URL": "http://127.0.0.1:5000",
-            "ANTHROPIC_AUTH_TOKEN": "PROXY_MANAGED"
-        }
-    });
     let settings_path = get_claude_settings_path();
     std::fs::create_dir_all(settings_path.parent().expect("settings dir")).expect("create dir");
     std::fs::write(
         &settings_path,
-        serde_json::to_string_pretty(&taken_over_live).expect("serialize taken over live"),
+        serde_json::to_string_pretty(&json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
+                "ANTHROPIC_AUTH_TOKEN": "PROXY_MANAGED",
+                "ANTHROPIC_MODEL": "claude-stale-live"
+            },
+            "permissions": {
+                "allow": ["Bash"]
+            }
+        }))
+        .expect("serialize taken over live"),
     )
     .expect("write taken over live");
 
-    futures::executor::block_on(state.db.save_live_backup("claude", "{\"env\":{}}"))
-        .expect("seed live backup");
+    futures::executor::block_on(
+        state.db.save_live_backup(
+            "claude",
+            &serde_json::to_string(&json!({
+                "env": {},
+                "permissions": {
+                    "allow": ["Bash"]
+                }
+            }))
+            .expect("serialize live backup"),
+        ),
+    )
+    .expect("seed live backup");
 
     let mut proxy_config = futures::executor::block_on(state.db.get_proxy_config_for_app("claude"))
         .expect("get proxy config");
@@ -310,8 +313,38 @@ fn sync_current_provider_for_app_keeps_live_takeover_and_updates_restore_backup(
     let live_after: serde_json::Value =
         read_json_file(&settings_path).expect("read live settings after sync");
     assert_eq!(
-        live_after, taken_over_live,
-        "sync should not overwrite live config while takeover is active"
+        live_after
+            .get("env")
+            .and_then(|v| v.get("ANTHROPIC_AUTH_TOKEN"))
+            .and_then(|v| v.as_str()),
+        Some("real-token"),
+        "direct sync should restore the real auth token when the proxy server is down"
+    );
+    assert_eq!(
+        live_after
+            .get("env")
+            .and_then(|v| v.get("ANTHROPIC_BASE_URL"))
+            .and_then(|v| v.as_str()),
+        Some("https://claude.example"),
+        "direct sync should not leave Claude pointing at the dead local proxy URL"
+    );
+    assert_eq!(
+        live_after
+            .get("env")
+            .and_then(|v| v.get("ANTHROPIC_MODEL"))
+            .and_then(|v| v.as_str()),
+        Some("claude-sync-target"),
+        "direct sync should still refresh provider-owned live fields"
+    );
+    assert_eq!(
+        live_after.get("primaryModel").and_then(|v| v.as_str()),
+        Some("claude-primary-target"),
+        "direct sync should refresh top-level current-provider fields when takeover is inactive"
+    );
+    assert_eq!(
+        live_after.get("permissions"),
+        Some(&json!({ "allow": ["Bash"] })),
+        "direct sync should preserve Claude live-only settings while restoring provider-owned fields"
     );
 
     let backup = futures::executor::block_on(state.db.get_live_backup("claude"))
@@ -319,13 +352,126 @@ fn sync_current_provider_for_app_keeps_live_takeover_and_updates_restore_backup(
         .expect("backup exists");
     let backup_value: serde_json::Value =
         serde_json::from_str(&backup.original_config).expect("parse backup value");
-
     assert_eq!(
         backup_value
-            .get("includeCoAuthoredBy")
-            .and_then(|v| v.as_bool()),
-        Some(false),
-        "restore backup should receive the updated effective config"
+            .get("env")
+            .and_then(|v| v.get("ANTHROPIC_AUTH_TOKEN"))
+            .and_then(|v| v.as_str()),
+        Some("real-token"),
+        "backup should stay in sync with the current provider even when the proxy server is down"
+    );
+    assert_eq!(
+        backup_value
+            .get("env")
+            .and_then(|v| v.get("ANTHROPIC_MODEL"))
+            .and_then(|v| v.as_str()),
+        Some("claude-sync-target"),
+        "backup should refresh provider-owned fields so restore cannot roll back the latest change"
+    );
+    assert_eq!(
+        backup_value.get("primaryModel").and_then(|v| v.as_str()),
+        Some("claude-primary-target"),
+        "backup should refresh top-level fields so later restore stays consistent"
+    );
+    assert_eq!(
+        backup_value.get("permissions"),
+        Some(&json!({ "allow": ["Bash"] })),
+        "backup should preserve live-only settings so later restore does not drop Claude permissions"
+    );
+}
+
+#[test]
+fn sync_current_provider_for_app_preserves_taken_over_live_when_proxy_server_is_not_running_without_backup(
+) {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "current-provider".to_string();
+        manager.providers.insert(
+            "current-provider".to_string(),
+            Provider::with_id(
+                "current-provider".to_string(),
+                "Current".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_AUTH_TOKEN": "real-token",
+                        "ANTHROPIC_BASE_URL": "https://claude.example",
+                        "ANTHROPIC_MODEL": "claude-sync-target"
+                    },
+                    "primaryModel": "claude-primary-target"
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = create_test_state_with_config(&config).expect("create test state");
+    let settings_path = get_claude_settings_path();
+    std::fs::create_dir_all(settings_path.parent().expect("settings dir")).expect("create dir");
+    std::fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721",
+                "ANTHROPIC_AUTH_TOKEN": "PROXY_MANAGED",
+                "ANTHROPIC_MODEL": "claude-stale-live"
+            },
+            "permissions": {
+                "allow": ["Bash"]
+            }
+        }))
+        .expect("serialize taken over live"),
+    )
+    .expect("write taken over live");
+
+    let mut proxy_config = futures::executor::block_on(state.db.get_proxy_config_for_app("claude"))
+        .expect("get proxy config");
+    proxy_config.enabled = true;
+    futures::executor::block_on(state.db.update_proxy_config_for_app(proxy_config))
+        .expect("enable takeover");
+
+    ProviderService::sync_current_provider_for_app(&state, AppType::Claude)
+        .expect("sync current provider should succeed");
+
+    let live_after: serde_json::Value =
+        read_json_file(&settings_path).expect("read live settings after sync");
+    assert_eq!(
+        live_after
+            .get("env")
+            .and_then(|v| v.get("ANTHROPIC_AUTH_TOKEN"))
+            .and_then(|v| v.as_str()),
+        Some("real-token"),
+        "restore-safe sync should restore the real auth token when only taken-over live exists"
+    );
+    assert_eq!(
+        live_after
+            .get("env")
+            .and_then(|v| v.get("ANTHROPIC_BASE_URL"))
+            .and_then(|v| v.as_str()),
+        Some("https://claude.example"),
+        "restore-safe sync should remove the dead proxy URL when rebuilding from taken-over live"
+    );
+    assert_eq!(
+        live_after.get("permissions"),
+        Some(&json!({ "allow": ["Bash"] })),
+        "restore-safe sync should preserve Claude live-only settings from the taken-over live snapshot"
+    );
+
+    let backup = futures::executor::block_on(state.db.get_live_backup("claude"))
+        .expect("get live backup")
+        .expect("backup should be recreated from taken-over live");
+    let backup_value: serde_json::Value =
+        serde_json::from_str(&backup.original_config).expect("parse backup value");
+    assert_eq!(
+        backup_value.get("permissions"),
+        Some(&json!({ "allow": ["Bash"] })),
+        "recreated backup should preserve live-only settings from the taken-over live snapshot"
     );
     assert_eq!(
         backup_value
@@ -333,7 +479,7 @@ fn sync_current_provider_for_app_keeps_live_takeover_and_updates_restore_backup(
             .and_then(|v| v.get("ANTHROPIC_AUTH_TOKEN"))
             .and_then(|v| v.as_str()),
         Some("real-token"),
-        "restore backup should preserve the provider token rather than proxy placeholder"
+        "recreated backup should store restored provider credentials"
     );
 }
 


### PR DESCRIPTION
## Summary / 概述

This PR fixes the original stale takeover config issue in switch-mode apps: after provider changes, Claude takeover could keep provider-owned live fields stale even though the current provider had already changed.

The follow-up update narrows the implementation so takeover refresh works from the existing live/backup state, refreshes provider-owned fields, and then reapplies takeover-owned overlay fields instead of rebuilding unrelated live config from scratch.

- Refresh taken-over live config after hot switch or current-provider update so displayed/effective provider settings stay aligned
- Preserve live-only settings while updating provider-owned fields under takeover
- Keep proxy-down restore-safe refresh consistent for taken-over live state, including the no-backup case
- Treat malformed backup, malformed previous common-config snippets, or Codex live parse failures as warnings in takeover refresh paths instead of failing provider updates
- Skip best-effort takeover refresh when the live config is missing
- Add regression coverage for takeover live refresh, common-config updates, and proxy-down fallback behavior
- OpenCode and OpenClaw remain unchanged because they do not use takeover in the current architecture
- Verification run:
  - `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
  - `git diff --check`
  - `cargo test sync_current_provider_for_app_skips_proxy_refresh_when_proxy_server_is_not_running --manifest-path src-tauri/Cargo.toml`
  - `cargo test sync_current_provider_for_app_preserves_taken_over_live_when_proxy_server_is_not_running_without_backup --manifest-path src-tauri/Cargo.toml`
  - `cargo test sync_current_common_config_for_app_tolerates_malformed_backup --manifest-path src-tauri/Cargo.toml`
  - `cargo test sync_current_common_config_for_app_tolerates_malformed_previous_snippet --manifest-path src-tauri/Cargo.toml`
  - `cargo test refresh_takeover_state_from_provider_reapplies_current_common_config_to_live --manifest-path src-tauri/Cargo.toml`

## Related Issue / 关联 Issue

Fixes #1850

Follow-up to #1828 (which closed #1827)

## Screenshots / 截图

N/A (backend / service-layer change)

| Before / 修改前 | After / 修改后 |
| --- | --- |
| Under Claude takeover, hot switch or current-provider update could leave provider-owned live fields stale, so displayed/effective settings drifted from the current provider | Takeover refresh now reapplies provider-owned fields onto existing live/backup state and then reapplies takeover overlay fields, keeping displayed/effective settings aligned without dropping live-only config |
| Proxy-down or best-effort takeover refresh could lose existing takeover state in edge cases introduced by the earlier rebuild-based path | Restore-safe and best-effort refresh paths now preserve existing takeover state, skip missing-live cases, and tolerate malformed best-effort inputs |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查 [not applicable]
- [ ] `pnpm format:check` passes / 通过代码格式检查 [not applicable]
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] No i18n update needed (no user-facing text change) / 无用户可见文案变更，无需更新国际化