### PR TITLE
fix(proxy): block browser CORS access to local proxy

### DIFF
--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -23,7 +23,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
 use tokio::task::JoinHandle;
-use tower_http::cors::{Any, CorsLayer};
 
 /// 代理服务器状态（共享）
 #[derive(Clone)]
@@ -275,11 +274,6 @@ impl ProxyServer {
     }
 
     fn build_router(&self) -> Router {
-        let cors = CorsLayer::new()
-            .allow_origin(Any)
-            .allow_methods(Any)
-            .allow_headers(Any);
-
         Router::new()
             // 健康检查
             .route("/health", get(handlers::health_check))
@@ -328,7 +322,6 @@ impl ProxyServer {
             .route("/gemini/v1beta/*path", post(handlers::handle_gemini))
             // 提高默认请求体大小限制（避免 413 Payload Too Large）
             .layer(DefaultBodyLimit::max(200 * 1024 * 1024))
-            .layer(cors)
             .with_state(self.state.clone())
     }
 


### PR DESCRIPTION
## Summary / 概述

Remove the permissive CORS layer from the local proxy HTTP server so browsers cannot issue cross-origin requests to 127.0.0.1:15721. This keeps CLI clients working while preventing web pages from abusing the proxy to exfiltrate API usage.

## Related Issue / 关联 Issue

Fixes #1841

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| N/A | N/A |

## Checklist / 检查清单

- [ ] pnpm typecheck passes / 通过 TypeScript 类型检查
- [ ] pnpm format:check passes / 通过代码格式检查
- [ ] cargo clippy passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

Notes:
- Rust-only change; tests not run locally.