### PR TITLE
fix(claude): preserve hooks and includeCoAuthoredBy

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -666,7 +666,24 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
     match app_type {
         AppType::Claude => {
             let path = get_claude_settings_path();
-            let settings = sanitize_claude_settings_for_live(&provider.settings_config);
+            let mut settings = sanitize_claude_settings_for_live(&provider.settings_config);
+
+            if path.exists() {
+                if let Ok(existing) = read_json_file::<Value>(&path) {
+                    if let (Some(existing_obj), Some(settings_obj)) =
+                        (existing.as_object(), settings.as_object_mut())
+                    {
+                        for key in ["hooks", "includeCoAuthoredBy"] {
+                            if !settings_obj.contains_key(key) {
+                                if let Some(value) = existing_obj.get(key) {
+                                    settings_obj.insert(key.to_string(), value.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             write_json_file(&path, &settings)?;
         }
         AppType::Codex => {

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -594,7 +594,11 @@ fn provider_service_switch_claude_updates_live_and_state() {
         },
         "workspace": {
             "path": "/tmp/workspace"
-        }
+        },
+        "hooks": {
+            "before": ["echo hello"]
+        },
+        "includeCoAuthoredBy": false
     });
     std::fs::write(
         &settings_path,
@@ -647,6 +651,20 @@ fn provider_service_switch_claude_updates_live_and_state() {
             .and_then(|key| key.as_str()),
         Some("fresh-key"),
         "live settings.json should reflect new provider auth"
+    );
+
+    assert_eq!(
+        live_after.get("hooks"),
+        legacy_live.get("hooks"),
+        "hooks should be preserved when switching providers"
+    );
+
+    assert_eq!(
+        live_after
+            .get("includeCoAuthoredBy")
+            .and_then(|value| value.as_bool()),
+        Some(false),
+        "includeCoAuthoredBy should be preserved when switching providers"
     );
 
     let providers = state


### PR DESCRIPTION
## Summary / 概述

When syncing Claude providers, preserve existing `hooks` and `includeCoAuthoredBy` values from the current `~/.claude/settings.json` if the provider config does not define them. This prevents those fields from being wiped during node/provider switches.

## Related Issue / 关联 Issue

Fixes #1907

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| N/A | N/A |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
