### PR TITLE
fix(skills): detect nested SKILL.md in unmanaged scan

### DIFF
--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -880,25 +880,37 @@ impl SkillService {
         let mut unmanaged: HashMap<String, UnmanagedSkill> = HashMap::new();
 
         for (scan_dir, label) in &scan_sources {
-            let entries = match fs::read_dir(scan_dir) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if !path.is_dir() {
+            let skill_dirs = match Self::scan_skills_in_dir(scan_dir) {
+                Ok(dirs) => dirs,
+                Err(err) => {
+                    log::warn!("Failed to scan skills in {}: {err}", scan_dir.display());
                     continue;
                 }
-                let dir_name = entry.file_name().to_string_lossy().to_string();
+            };
+
+            for skill_dir in skill_dirs {
+                let rel = match skill_dir.strip_prefix(scan_dir) {
+                    Ok(path) => path,
+                    Err(_) => continue,
+                };
+                if rel.components().next().is_none() {
+                    continue;
+                }
+                let dir_name = rel.to_string_lossy().to_string();
                 if dir_name.starts_with('.') || managed_dirs.contains(&dir_name) {
                     continue;
                 }
 
-                let skill_md = path.join("SKILL.md");
+                let skill_md = skill_dir.join("SKILL.md");
                 if !skill_md.exists() {
                     continue;
                 }
-                let (name, description) = Self::read_skill_name_desc(&skill_md, &dir_name);
+
+                let fallback_name = skill_dir
+                    .file_name()
+                    .map(|name| name.to_string_lossy().to_string())
+                    .unwrap_or_else(|| dir_name.clone());
+                let (name, description) = Self::read_skill_name_desc(&skill_md, &fallback_name);
 
                 unmanaged
                     .entry(dir_name.clone())
@@ -908,7 +920,7 @@ impl SkillService {
                         name,
                         description,
                         found_in: vec![label.clone()],
-                        path: path.display().to_string(),
+                        path: skill_dir.display().to_string(),
                     });
             }
         }


### PR DESCRIPTION
## Summary / 概述

Support nested skill layouts when scanning for unmanaged skills by recursively finding SKILL.md and using the relative path as the directory key. This restores detection for repos that bundle multiple skills under subfolders (e.g. ai-skills/skills/<skill>/SKILL.md).

## Related Issue / 关联 Issue

Fixes #1842

## Screenshots / 截图

N/A

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| Nested skills were ignored unless SKILL.md lived at repo root | Nested SKILL.md is detected and listed for import |

## Checklist / 检查清单

- [ ] 
> cc-switch@3.12.3 typecheck /home/sober/github/working/cc-switch
> tsc --noEmit passes / 通过 TypeScript 类型检查 (not run)
- [ ] 
> cc-switch@3.12.3 format:check /home/sober/github/working/cc-switch
> prettier --check "src/**/*.{js,jsx,ts,tsx,css,json}"

Checking formatting...
All matched files use Prettier code style! passes / 通过代码格式检查 (not run)
- [ ]  passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）(not run)
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 (not needed)