### PR TITLE
fix: 移除 enable_logging 错误拦截

### DIFF
--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -386,11 +386,6 @@ fn create_usage_collector(
     status_code: u16,
     parser_config: &UsageParserConfig,
 ) -> SseUsageCollector {
-    let logging_enabled = state
-        .config
-        .try_read()
-        .map(|c| c.enable_logging)
-        .unwrap_or(true);
     let state = state.clone();
     let provider_id = ctx.provider.id.clone();
     let request_model = ctx.request_model.clone();
@@ -402,9 +397,6 @@ fn create_usage_collector(
     let session_id = ctx.session_id.clone();
 
     SseUsageCollector::new(start_time, move |events, first_token_ms| {
-        if !logging_enabled {
-            return;
-        }
         if let Some(usage) = stream_parser(&events) {
             let model = model_extractor(&events, &request_model);
             let latency_ms = start_time.elapsed().as_millis() as u64;
@@ -469,13 +461,6 @@ fn spawn_log_usage(
     status_code: u16,
     is_streaming: bool,
 ) {
-    // Check enable_logging before spawning the log task
-    if let Ok(config) = state.config.try_read() {
-        if !config.enable_logging {
-            return;
-        }
-    }
-
     let state = state.clone();
     let provider_id = ctx.provider.id.clone();
     let app_type_str = ctx.app_type_str.to_string();


### PR DESCRIPTION
### 问题描述

  使用统计（Usage Statistics）在升级到某个版本后不再记录到数据库 proxy_request_logs 表中。

### 问题原因

  提交: bf40b01

  这个提交本意是：当用户关闭"启用日志记录"开关时，跳过 HTTP请求详情的日志写入。但同时跳过了使用统计记录，导致未开启日志记录时，使用统计无法记录。


  问题代码

  ```rust
  src-tauri/src/proxy/response_processor.rs 中有两处问题代码：

  1. 流式响应处理（第 283-302 行）:
  SseUsageCollector::new(start_time, move |events, first_token_ms| {
      if !logging_enabled {
          return;  // 错误：同时跳过了使用统计记录
      }
      // ...
  });

  2. 非流式响应处理（第 366-371 行）:
  fn spawn_log_usage(...) {
      if let Ok(config) = state.config.try_read() {
          if !config.enable_logging {
              return;  // 错误：同时跳过了使用统计记录
          }
      }
      // ...
  }
```

### 修复内容

  1. 移除 enable_logging 检查：删除 response_processor.rs 中两处对 enable_logging
  的检查，让使用统计始终记录，不受日志开关影响
### 测试计划
  - 关闭"启用日志记录"开关，验证使用统计仍能正常记录
  - 开启"启用日志记录"开关，验证使用统计能正常记录
  - 验证数据库 proxy_request_logs 表中有数据
  - 已通过 cargo test proxy --lib 测试 (296 passed)