### PR TITLE
fix(provider): prevent config JSON blinking when editing with proxy running

### DIFF
--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -139,6 +139,8 @@ export function EditProviderDialog({
   }, [liveSettings, provider?.settingsConfig]); // 只依赖 settingsConfig，不依赖整个 provider
 
   // 固定 initialData，防止 provider 对象更新时重置表单
+  // 注意：不依赖 provider?.meta，避免 providers refetch 时触发重新计算导致闪烁
+  // meta 的初始化已在 ProviderForm 中通过 useEffect 处理（line 203-225）
   const initialData = useMemo(() => {
     if (!provider) return null;
     return {
@@ -147,14 +149,13 @@ export function EditProviderDialog({
       websiteUrl: provider.websiteUrl,
       settingsConfig: initialSettingsConfig,
       category: provider.category,
-      meta: provider.meta,
+      meta: provider.meta, // 使用当前 meta，但不在依赖中
       icon: provider.icon,
       iconColor: provider.iconColor,
     };
   }, [
     open, // 修复：编辑保存后再次打开显示旧数据，依赖 open 确保每次打开时重新读取最新 provider 数据
     provider?.id, // 只依赖 ID，provider 对象更新不会触发重新计算
-    provider?.meta, // 需要依赖 meta 以便正确初始化 testConfig 和 proxyConfig
     initialSettingsConfig,
   ]);
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -384,9 +384,15 @@ export function ProviderForm({
     }
   }, [appId, initialData, selectedPresetId, resetCodexConfig]);
 
+  // Only reset form when defaultValues changes in NEW mode (not edit mode)
+  // In edit mode, resetting on every provider data change would cause blinking
+  // and discard user's ongoing edits when providers refetch periodically
   useEffect(() => {
+    if (isEditMode && initialData) {
+      return;
+    }
     form.reset(defaultValues);
-  }, [defaultValues, form]);
+  }, [defaultValues, form, isEditMode, initialData]);
 
   const presetCategoryLabels: Record<string, string> = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

Fixes an issue where the config JSON editor would blink/flash constantly when editing a provider while the proxy is running.

## Root Cause

When the proxy is running, the providers query refetches every 10 seconds ([queries.ts:64](src/lib/query/queries.ts#L64)). This triggered a cascade of state updates:

1. Provider object reference changes on refetch
2. `initialData` recomputes (due to `provider?.meta` dependency)
3. `defaultValues` recomputes → `form.reset()` was called
4. `settingsConfig` changes → `useCommonConfigSnippet` triggers state updates → **blinking**

## Fix

- **ProviderForm.tsx**: Skip `form.reset()` in edit mode - the form should only initialize once when the dialog opens, not on every provider data change
- **EditProviderDialog.tsx**: Remove `provider?.meta` from `initialData` dependencies to stabilize memoization

## Test Plan

1. Start the app with proxy running
2. Open edit dialog for a provider
3. Observe the config JSON - it should remain stable without blinking
4. Wait 10+ seconds (through multiple refetch cycles)
5. Confirm config still stable

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [ ] No Rust code changed
- [ ] No user-facing text changed (no i18n updates needed)