### PR TITLE
fix: implement skill synchronization to enabled application directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,json}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css,json}\"",
     "test:unit": "vitest run",
-    "test:unit:watch": "vitest watch"
+    "test:unit:watch": "vitest watch",
+    "cargo:check": "bash scripts/cargo-with-real-cc.sh check",
+    "cargo:clippy": "bash scripts/cargo-with-real-cc.sh clippy",
+    "check:all": "pnpm typecheck && pnpm format && pnpm test:unit && pnpm cargo:check && pnpm cargo:clippy"
   },
   "keywords": [],
   "author": "Jason Young",

--- a/scripts/cargo-with-real-cc.sh
+++ b/scripts/cargo-with-real-cc.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# pnpm/npm 脚本在非交互 shell 中也可能继承把 `cc` 指到非编译器的环境；
+# cc-rs 会调用 `cc`，此处在未显式设置 CC 时强制使用系统 Clang/GCC。
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${ROOT}/src-tauri"
+
+# 显式 SDK：cc-rs 使用 --target=*-apple-macosx 时必须能解析系统头文件。
+# 环境中可能残留指向旧版 Xcode 的 SDKROOT（例如 MacOSX12.3.sdk），会导致 stdlib.h 找不到；
+# 此处始终用当前 xcrun 的 macOS SDK，除非显式设置 CC_SWITCH_KEEP_SDKROOT=1。
+if [[ "$(uname -s)" == "Darwin" && -z "${CC_SWITCH_KEEP_SDKROOT:-}" ]]; then
+  _SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null || true)"
+  if [[ -n "${_SDK}" ]]; then
+    export SDKROOT="${_SDK}"
+    # cc-rs 子进程对 SDKROOT 的传递偶有不一致，CFLAGS 更稳妥
+    if [[ "${CFLAGS:-}" != *"-isysroot"* ]]; then
+      export CFLAGS="${CFLAGS:+$CFLAGS }-isysroot ${_SDK}"
+    fi
+    if [[ "${CXXFLAGS:-}" != *"-isysroot"* ]]; then
+      export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }-isysroot ${_SDK}"
+    fi
+  fi
+fi
+
+if [[ -z "${CC:-}" ]]; then
+  case "$(uname -s)" in
+    Darwin)
+      if [[ -x /usr/bin/clang ]]; then
+        export CC=/usr/bin/clang
+      elif command -v clang >/dev/null 2>&1; then
+        export CC="$(command -v clang)"
+      fi
+      ;;
+    *)
+      if command -v clang >/dev/null 2>&1; then
+        export CC="$(command -v clang)"
+      elif command -v gcc >/dev/null 2>&1; then
+        export CC="$(command -v gcc)"
+      fi
+      ;;
+  esac
+fi
+
+if [[ -z "${CXX:-}" ]]; then
+  case "$(uname -s)" in
+    Darwin)
+      if [[ -x /usr/bin/clang++ ]]; then
+        export CXX=/usr/bin/clang++
+      elif command -v clang++ >/dev/null 2>&1; then
+        export CXX="$(command -v clang++)"
+      fi
+      ;;
+    *)
+      if command -v clang++ >/dev/null 2>&1; then
+        export CXX="$(command -v clang++)"
+      elif command -v g++ >/dev/null 2>&1; then
+        export CXX="$(command -v g++)"
+      fi
+      ;;
+  esac
+fi
+
+exec cargo "$@"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -797,6 +797,7 @@ dependencies = [
  "uuid",
  "webkit2gtk",
  "webpki-roots 0.26.11",
+ "windows-sys 0.61.2",
  "winreg 0.52.0",
  "zip 2.4.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -87,6 +87,7 @@ webkit2gtk = { version = "2.0.1", features = ["v2_16"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -154,7 +154,7 @@ pub async fn get_tool_versions(
     #[cfg(target_os = "windows")]
     {
         let _ = (tools, wsl_shell_by_tool);
-        return Ok(Vec::new());
+        Ok(Vec::new())
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -879,7 +879,7 @@ fn launch_terminal_with_env(
     #[cfg(target_os = "windows")]
     {
         launch_windows_terminal(&temp_dir, &config_file, cwd)?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -435,6 +435,14 @@ fn parse_agents_lock() -> HashMap<String, LockRepoInfo> {
     parsed
 }
 
+/// `import_from_apps` 将 Skill 同步到各应用目录时的回滚状态。
+/// 成功路径下由 `TempDir` 析构删除临时备份；回滚且恢复失败时须 `into_path()` 保留以免误删用户数据。
+struct ImportedAppSyncState {
+    dest: PathBuf,
+    backup_path: Option<PathBuf>,
+    backup_dir: Option<tempfile::TempDir>,
+}
+
 // ========== SkillService ==========
 
 pub struct SkillService;
@@ -1505,7 +1513,8 @@ impl SkillService {
 
             // 复制到 SSOT
             let dest = ssot_dir.join(&dir_name);
-            if !dest.exists() {
+            let created_ssot = !dest.exists();
+            if created_ssot {
                 Self::copy_dir_recursive(&source, &dest)?;
             }
 
@@ -1540,8 +1549,113 @@ impl SkillService {
                 updated_at: 0,
             };
 
+            let enabled_apps = skill.apps.enabled_apps();
+
             // 保存到数据库
-            db.save_skill(&skill)?;
+            if let Err(err) = db.save_skill(&skill) {
+                if created_ssot {
+                    let _ = Self::remove_path(&dest);
+                }
+                return Err(err.into());
+            }
+
+            // 按用户配置的同步方式（symlink/copy）同步到各已启用的应用目录
+            let mut synced_apps = Vec::new();
+            for app in &enabled_apps {
+                let sync_result: Result<()> = (|| {
+                    let app_dir = Self::get_app_skills_dir(app)?;
+                    fs::create_dir_all(&app_dir)?;
+
+                    let app_dest = app_dir.join(&skill.directory);
+                    let mut backup_path = None;
+                    let mut backup_dir = None;
+
+                    if app_dest.exists() || Self::is_symlink(&app_dest) {
+                        let temp_backup_dir = tempfile::Builder::new()
+                            .prefix(".cc-switch-import-backup-")
+                            .tempdir_in(&app_dir)
+                            .with_context(|| {
+                                format!(
+                                    "创建 Skill 导入回滚备份目录失败: {} ({app:?})",
+                                    app_dir.display()
+                                )
+                            })?;
+                        let original_backup_path = temp_backup_dir.path().join("original");
+                        fs::rename(&app_dest, &original_backup_path).with_context(|| {
+                            format!(
+                                "备份现有 Skill 目录失败: {} -> {}",
+                                app_dest.display(),
+                                original_backup_path.display()
+                            )
+                        })?;
+                        backup_path = Some(original_backup_path);
+                        backup_dir = Some(temp_backup_dir);
+                    }
+
+                    synced_apps.push(ImportedAppSyncState {
+                        dest: app_dest.clone(),
+                        backup_path,
+                        backup_dir,
+                    });
+
+                    Self::sync_to_app_dir(&skill.directory, app)
+                })();
+
+                if let Err(err) = sync_result {
+                    // 先尽力恢复各应用目录，再删库，避免「库已删但盘上仍是新同步」的更难排查状态
+                    for mut synced_app in synced_apps.into_iter().rev() {
+                        if synced_app.dest.exists() || Self::is_symlink(&synced_app.dest) {
+                            if let Err(remove_err) = Self::remove_path(&synced_app.dest) {
+                                log::warn!(
+                                    "回滚导入 Skill '{}' 时删除同步目录失败: {} ({remove_err:#})",
+                                    skill.directory,
+                                    synced_app.dest.display()
+                                );
+                            }
+                        }
+
+                        if let Some(backup_path) = synced_app.backup_path.take() {
+                            match fs::rename(&backup_path, &synced_app.dest) {
+                                Ok(()) => {}
+                                Err(restore_err) => {
+                                    log::warn!(
+                                        "回滚导入 Skill '{}' 时恢复原目录失败: {} -> {} ({restore_err:#})；已保留临时备份目录以免数据丢失",
+                                        skill.directory,
+                                        backup_path.display(),
+                                        synced_app.dest.display(),
+                                    );
+                                    // 恢复失败时不得让 TempDir 析构删除仍含备份的目录（例如 remove_path 未清空目标时）
+                                    if let Some(td) = synced_app.backup_dir.take() {
+                                        let preserved = td.keep();
+                                        log::warn!(
+                                            "Skill '{}' 导入回滚失败：用户原目录备份仍保留在 {}",
+                                            skill.directory,
+                                            preserved.display()
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    match db.delete_skill(&skill.id) {
+                        Ok(true) => {}
+                        Ok(false) => log::warn!(
+                            "回滚导入 Skill '{}' 时删除数据库记录：未找到 id {}",
+                            skill.directory,
+                            skill.id
+                        ),
+                        Err(e) => log::warn!(
+                            "回滚导入 Skill '{}' 时删除数据库记录失败: {e:#}",
+                            skill.directory
+                        ),
+                    }
+                    if created_ssot {
+                        let _ = Self::remove_path(&dest);
+                    }
+                    return Err(err);
+                }
+            }
+
             imported.push(skill);
         }
 
@@ -1564,15 +1678,144 @@ impl SkillService {
 
     #[cfg(windows)]
     fn create_symlink(src: &Path, dest: &Path) -> Result<()> {
-        std::os::windows::fs::symlink_dir(src, dest)
-            .with_context(|| format!("创建符号链接失败: {} -> {}", src.display(), dest.display()))
+        // 优先尝试真正的 symlink（需要开发者模式或管理员权限）
+        match std::os::windows::fs::symlink_dir(src, dest) {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                log::debug!(
+                    "Windows symlink 创建失败（需要开发者模式或管理员权限），尝试 junction: {err}"
+                );
+            }
+        }
+
+        // 回退到 junction（无需特殊权限，同卷目录链接）
+        Self::create_junction(src, dest)
     }
 
-    /// 检查路径是否为符号链接
+    /// 在 Windows 上创建目录联接（junction），不需要管理员权限
+    #[cfg(windows)]
+    fn create_junction(src: &Path, dest: &Path) -> Result<()> {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        let output = std::process::Command::new("cmd")
+            .arg("/c")
+            .arg("mklink")
+            .arg("/J")
+            .arg(dest.as_os_str())
+            .arg(src.as_os_str())
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+            .with_context(|| {
+                format!("创建目录联接失败: {} -> {}", dest.display(), src.display())
+            })?;
+
+        if output.status.success() {
+            log::debug!(
+                "已通过 junction 创建目录链接: {} -> {}",
+                dest.display(),
+                src.display()
+            );
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let detail = [stderr.trim(), stdout.trim()]
+                .into_iter()
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ");
+            Err(anyhow!(
+                "创建目录联接失败: {} -> {}. {}",
+                dest.display(),
+                src.display(),
+                if detail.is_empty() {
+                    "(无输出)".to_string()
+                } else {
+                    detail
+                }
+            ))
+        }
+    }
+
+    /// 检查路径是否为符号链接或目录联接（junction）
+    ///
+    /// Windows 上 `FileType::is_symlink()` 仅检测 IO_REPARSE_TAG_SYMLINK，
+    /// 不包括 junction（IO_REPARSE_TAG_MOUNT_POINT）。带
+    /// `FILE_ATTRIBUTE_REPARSE_POINT` 的路径还可能是云占位符等非链接
+    /// reparse 类型，若误判为链接，`remove_path` 会走 `remove_dir` 分支，
+    /// 在非空目录上会失败。因此仅在 reparse 标签为 symlink 或 mount-point
+    ///（junction）时视为链接；若无法读取标签，则用 `read_link` 作为回退
+    /// （与 junction 行为一致），避免误伤云目录。
     fn is_symlink(path: &Path) -> bool {
-        path.symlink_metadata()
-            .map(|m| m.file_type().is_symlink())
-            .unwrap_or(false)
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::MetadataExt;
+            const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+            const IO_REPARSE_TAG_SYMLINK: u32 = 0xA000_000C;
+            const IO_REPARSE_TAG_MOUNT_POINT: u32 = 0xA000_0003;
+
+            let Ok(meta) = path.symlink_metadata() else {
+                return false;
+            };
+            if meta.file_type().is_symlink() {
+                return true;
+            }
+            if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT == 0 {
+                return false;
+            }
+            if let Some(tag) = Self::windows_reparse_point_tag(path) {
+                return tag == IO_REPARSE_TAG_SYMLINK || tag == IO_REPARSE_TAG_MOUNT_POINT;
+            }
+            fs::read_link(path).is_ok()
+        }
+        #[cfg(not(windows))]
+        {
+            path.symlink_metadata()
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+        }
+    }
+
+    /// 读取路径的 Windows reparse 标签（需已判定为 reparse 点且非 `is_symlink()`）。
+    #[cfg(windows)]
+    fn windows_reparse_point_tag(path: &Path) -> Option<u32> {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::Storage::FileSystem::{
+            CreateFileW, FileAttributeTagInfo, GetFileInformationByHandleEx,
+            FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+            FILE_GENERIC_READ, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        };
+
+        let wide: Vec<u16> = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        unsafe {
+            let handle = CreateFileW(
+                wide.as_ptr(),
+                FILE_GENERIC_READ,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+                std::ptr::null_mut(),
+            );
+            if handle == INVALID_HANDLE_VALUE {
+                return None;
+            }
+            let mut info = FILE_ATTRIBUTE_TAG_INFO::default();
+            let ok = GetFileInformationByHandleEx(
+                handle,
+                FileAttributeTagInfo,
+                &raw mut info as *mut _,
+                std::mem::size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+            );
+            CloseHandle(handle);
+            (ok != 0).then_some(info.ReparseTag)
+        }
     }
 
     /// 获取当前同步方式配置
@@ -1645,14 +1888,14 @@ impl SkillService {
         Self::sync_to_app_dir(directory, app)
     }
 
-    /// 删除路径（支持 symlink 和真实目录）
+    /// 删除路径（支持 symlink、junction 和真实目录）
     fn remove_path(path: &Path) -> Result<()> {
         if Self::is_symlink(path) {
-            // 符号链接：仅删除链接本身，不影响源文件
+            // symlink / junction：仅删除链接本身，不影响源文件
             #[cfg(unix)]
             fs::remove_file(path)?;
             #[cfg(windows)]
-            fs::remove_dir(path)?; // Windows 的目录 symlink 需要用 remove_dir
+            fs::remove_dir(path)?; // Windows 的目录 symlink 和 junction 都用 remove_dir
         } else if path.is_dir() {
             // 真实目录：递归删除
             fs::remove_dir_all(path)?;

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -1,10 +1,10 @@
-import { createRef } from "react";
-import { render, screen, waitFor, act } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createRef } from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import UnifiedSkillsPanel, {
   type UnifiedSkillsPanelHandle,
-} from "@/components/skills/UnifiedSkillsPanel";
+} from '@/components/skills/UnifiedSkillsPanel';
 
 const scanUnmanagedMock = vi.fn();
 const toggleSkillAppMock = vi.fn();
@@ -14,7 +14,7 @@ const installFromZipMock = vi.fn();
 const deleteSkillBackupMock = vi.fn();
 const restoreSkillBackupMock = vi.fn();
 
-vi.mock("sonner", () => ({
+vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
     error: vi.fn(),
@@ -22,7 +22,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("@/hooks/useSkills", () => ({
+vi.mock('@/hooks/useSkills', () => ({
   useInstalledSkills: () => ({
     data: [],
     isLoading: false,
@@ -49,11 +49,11 @@ vi.mock("@/hooks/useSkills", () => ({
   useScanUnmanagedSkills: () => ({
     data: [
       {
-        directory: "shared-skill",
-        name: "Shared Skill",
-        description: "Imported from Claude",
-        foundIn: ["claude"],
-        path: "/tmp/shared-skill",
+        directory: 'shared-skill',
+        name: 'Shared Skill',
+        description: 'Imported from Claude',
+        foundIn: ['claude'],
+        path: '/tmp/shared-skill',
       },
     ],
     refetch: scanUnmanagedMock,
@@ -75,16 +75,16 @@ vi.mock("@/hooks/useSkills", () => ({
   }),
 }));
 
-describe("UnifiedSkillsPanel", () => {
+describe('UnifiedSkillsPanel', () => {
   beforeEach(() => {
     scanUnmanagedMock.mockResolvedValue({
       data: [
         {
-          directory: "shared-skill",
-          name: "Shared Skill",
-          description: "Imported from Claude",
-          foundIn: ["claude"],
-          path: "/tmp/shared-skill",
+          directory: 'shared-skill',
+          name: 'Shared Skill',
+          description: 'Imported from Claude',
+          foundIn: ['claude'],
+          path: '/tmp/shared-skill',
         },
       ],
     });
@@ -96,14 +96,14 @@ describe("UnifiedSkillsPanel", () => {
     restoreSkillBackupMock.mockReset();
   });
 
-  it("opens the import dialog without crashing when app toggles render", async () => {
+  it('opens the import dialog without crashing when app toggles render', async () => {
     const ref = createRef<UnifiedSkillsPanelHandle>();
 
     render(
       <UnifiedSkillsPanel
         ref={ref}
         onOpenDiscovery={() => {}}
-        currentApp="claude"
+        currentApp='claude'
       />,
     );
 
@@ -112,9 +112,9 @@ describe("UnifiedSkillsPanel", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("skills.import")).toBeInTheDocument();
-      expect(screen.getByText("Shared Skill")).toBeInTheDocument();
-      expect(screen.getByText("/tmp/shared-skill")).toBeInTheDocument();
+      expect(screen.getByText('skills.import')).toBeInTheDocument();
+      expect(screen.getByText('Shared Skill')).toBeInTheDocument();
+      expect(screen.getByText('/tmp/shared-skill')).toBeInTheDocument();
     });
   });
 });

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -163,62 +163,66 @@ describe("App integration with MSW", () => {
     toastErrorMock.mockReset();
   });
 
-  it("covers basic provider flows via real hooks", async () => {
-    const { default: App } = await import("@/App");
-    renderApp(App);
+  it(
+    "covers basic provider flows via real hooks",
+    async () => {
+      const { default: App } = await import("@/App");
+      renderApp(App);
 
-    await waitFor(() =>
-      expect(screen.getByTestId("provider-list").textContent).toContain(
-        "claude-1",
-      ),
-    );
+      await waitFor(() =>
+        expect(screen.getByTestId("provider-list").textContent).toContain(
+          "claude-1",
+        ),
+      );
 
-    fireEvent.click(screen.getByText("switch-codex"));
-    await waitFor(() =>
-      expect(screen.getByTestId("provider-list").textContent).toContain(
-        "codex-1",
-      ),
-    );
+      fireEvent.click(screen.getByText("switch-codex"));
+      await waitFor(() =>
+        expect(screen.getByTestId("provider-list").textContent).toContain(
+          "codex-1",
+        ),
+      );
 
-    fireEvent.click(screen.getByText("usage"));
-    expect(screen.getByTestId("usage-modal")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("save-script"));
-    fireEvent.click(screen.getByText("close-usage"));
+      fireEvent.click(screen.getByText("usage"));
+      expect(screen.getByTestId("usage-modal")).toBeInTheDocument();
+      fireEvent.click(screen.getByText("save-script"));
+      fireEvent.click(screen.getByText("close-usage"));
 
-    fireEvent.click(screen.getByText("create"));
-    expect(screen.getByTestId("add-provider-dialog")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("confirm-add"));
-    await waitFor(() =>
-      expect(screen.getByTestId("provider-list").textContent).toMatch(
-        /New codex Provider/,
-      ),
-    );
+      fireEvent.click(screen.getByText("create"));
+      expect(screen.getByTestId("add-provider-dialog")).toBeInTheDocument();
+      fireEvent.click(screen.getByText("confirm-add"));
+      await waitFor(() =>
+        expect(screen.getByTestId("provider-list").textContent).toMatch(
+          /New codex Provider/,
+        ),
+      );
 
-    fireEvent.click(screen.getByText("edit"));
-    expect(screen.getByTestId("edit-provider-dialog")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("confirm-edit"));
-    await waitFor(() =>
-      expect(screen.getByTestId("provider-list").textContent).toMatch(
-        /-edited/,
-      ),
-    );
+      fireEvent.click(screen.getByText("edit"));
+      expect(screen.getByTestId("edit-provider-dialog")).toBeInTheDocument();
+      fireEvent.click(screen.getByText("confirm-edit"));
+      await waitFor(() =>
+        expect(screen.getByTestId("provider-list").textContent).toMatch(
+          /-edited/,
+        ),
+      );
 
-    fireEvent.click(screen.getByText("switch"));
-    fireEvent.click(screen.getByText("duplicate"));
-    await waitFor(() =>
-      expect(screen.getByTestId("provider-list").textContent).toMatch(/copy/),
-    );
+      fireEvent.click(screen.getByText("switch"));
+      fireEvent.click(screen.getByText("duplicate"));
+      await waitFor(() =>
+        expect(screen.getByTestId("provider-list").textContent).toMatch(/copy/),
+      );
 
-    fireEvent.click(screen.getByText("open-website"));
+      fireEvent.click(screen.getByText("open-website"));
 
-    emitTauriEvent("provider-switched", {
-      appType: "codex",
-      providerId: "codex-2",
-    });
+      emitTauriEvent("provider-switched", {
+        appType: "codex",
+        providerId: "codex-2",
+      });
 
-    expect(toastErrorMock).not.toHaveBeenCalled();
-    expect(toastSuccessMock).toHaveBeenCalled();
-  });
+      expect(toastErrorMock).not.toHaveBeenCalled();
+      expect(toastSuccessMock).toHaveBeenCalled();
+    },
+    15_000,
+  );
 
   it("shows toast when auto sync fails in background", async () => {
     const { default: App } = await import("@/App");


### PR DESCRIPTION
Add functionality to sync imported skills to application directories based on user configuration (symlink/copy). Enhance Windows symlink creation with fallback to junctions for better compatibility. Update path removal logic to support both symlinks and junctions, ensuring safe deletion without affecting source files.

## Summary / 概述

1. 安装skill时会以复制方式安装到具体产品中，而没有读取配置中是否使用软链接方式。
2. windows系统中 skill 无法以软链接方式创建。

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|  <img width="393" height="157" alt="206f24ac1c7f4357b6f43a47a9ef177c" src="https://github.com/user-attachments/assets/51ac3739-d5d2-41f5-b3fc-32d585938eea" /> |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
