### PR TITLE
[codex] Normalize fragmented OpenAI chat system prompts

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -113,6 +113,7 @@ pub fn anthropic_to_openai(body: Value, cache_key: Option<&str>) -> Result<Value
         }
     }
 
+    normalize_openai_system_messages(&mut messages);
     result["messages"] = json!(messages);
 
     // 转换参数 — o-series 模型需要 max_completion_tokens
@@ -180,6 +181,57 @@ pub fn anthropic_to_openai(body: Value, cache_key: Option<&str>) -> Result<Value
     }
 
     Ok(result)
+}
+
+fn normalize_openai_system_messages(messages: &mut Vec<Value>) {
+    let system_count = messages
+        .iter()
+        .filter(|message| message.get("role").and_then(|value| value.as_str()) == Some("system"))
+        .count();
+
+    if system_count == 0 {
+        return;
+    }
+
+    if system_count == 1 {
+        if let Some(index) = messages.iter().position(|message| {
+            message.get("role").and_then(|value| value.as_str()) == Some("system")
+        }) {
+            if index > 0 {
+                let message = messages.remove(index);
+                messages.insert(0, message);
+            }
+        }
+        return;
+    }
+
+    let mut parts = Vec::new();
+    messages.retain(|message| {
+        if message.get("role").and_then(|value| value.as_str()) != Some("system") {
+            return true;
+        }
+
+        match message.get("content") {
+            Some(Value::String(text)) if !text.is_empty() => parts.push(text.clone()),
+            Some(Value::Array(content_parts)) => {
+                let text = content_parts
+                    .iter()
+                    .filter_map(|part| part.get("text").and_then(|value| value.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if !text.is_empty() {
+                    parts.push(text);
+                }
+            }
+            _ => {}
+        }
+
+        false
+    });
+
+    if !parts.is_empty() {
+        messages.insert(0, json!({"role": "system", "content": parts.join("\n")}));
+    }
 }
 
 /// 转换单条消息到 OpenAI 格式（可能产生多条消息）
@@ -558,6 +610,31 @@ mod tests {
         let result = anthropic_to_openai(input, None).unwrap();
         assert_eq!(result["tools"][0]["type"], "function");
         assert_eq!(result["tools"][0]["function"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_normalizes_fragmented_system_messages() {
+        let input = json!({
+            "model": "claude-3-sonnet",
+            "max_tokens": 1024,
+            "system": [
+                {"type": "text", "text": "You are Claude Code."},
+                {"type": "text", "text": "Be concise."}
+            ],
+            "messages": [
+                {"role": "system", "content": "Follow repo conventions."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        let result = anthropic_to_openai(input, None).unwrap();
+        assert_eq!(result["messages"].as_array().unwrap().len(), 2);
+        assert_eq!(result["messages"][0]["role"], "system");
+        assert_eq!(
+            result["messages"][0]["content"],
+            "You are Claude Code.\nBe concise.\nFollow repo conventions."
+        );
+        assert_eq!(result["messages"][1]["role"], "user");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- normalize fragmented `system` prompts into a single leading OpenAI chat `system` message
- preserve the existing non-system message conversion flow
- add a regression test covering fragmented `system` prompt normalization

## Why
Some strict OpenAI-compatible chat backends, including the Nvidia/Qwen path discussed in #1881, reject requests when Claude-side prompt fragments are forwarded as multiple `system` messages. Reordering alone is not sufficient for those providers; the prompt needs to be collapsed into one leading `system` message.

## Validation
- `cargo test proxy::providers::transform --manifest-path src-tauri/Cargo.toml`

Closes #1881