### PR TITLE
fix(tray): use an app-specific tray id

### DIFF
--- a/src-tauri/src/commands/failover.rs
+++ b/src-tauri/src/commands/failover.rs
@@ -162,7 +162,7 @@ pub async fn set_auto_failover_enabled(
 
     // 刷新托盘菜单，确保状态同步
     if let Ok(new_menu) = crate::tray::create_tray_menu(&app, &state) {
-        if let Some(tray) = app.tray_by_id("main") {
+        if let Some(tray) = app.tray_by_id(crate::tray::TRAY_ID) {
             let _ = tray.set_menu(Some(new_menu));
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,7 +168,7 @@ async fn update_tray_menu(
 ) -> Result<bool, String> {
     match tray::create_tray_menu(&app, state.inner()) {
         Ok(new_menu) => {
-            if let Some(tray) = app.tray_by_id("main") {
+            if let Some(tray) = app.tray_by_id(tray::TRAY_ID) {
                 tray.set_menu(Some(new_menu))
                     .map_err(|e| format!("更新托盘菜单失败: {e}"))?;
                 return Ok(true);
@@ -728,7 +728,7 @@ pub fn run() {
             let menu = tray::create_tray_menu(app.handle(), &app_state)?;
 
             // 构建托盘
-            let mut tray_builder = TrayIconBuilder::with_id("main")
+            let mut tray_builder = TrayIconBuilder::with_id(tray::TRAY_ID)
                 .on_tray_icon_event(|_tray, event| match event {
                     // 左键点击已通过 show_menu_on_left_click(true) 打开菜单，这里不再额外处理
                     TrayIconEvent::Click { .. } => {}

--- a/src-tauri/src/proxy/failover_switch.rs
+++ b/src-tauri/src/proxy/failover_switch.rs
@@ -111,7 +111,7 @@ impl FailoverSwitchManager {
                 }
 
                 if let Ok(new_menu) = crate::tray::create_tray_menu(app, app_state.inner()) {
-                    if let Some(tray) = app.tray_by_id("main") {
+                    if let Some(tray) = app.tray_by_id(crate::tray::TRAY_ID) {
                         if let Err(e) = tray.set_menu(Some(new_menu)) {
                             log::error!("[Failover] 更新托盘菜单失败: {e}");
                         }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -58,6 +58,7 @@ pub struct TrayAppSection {
 
 /// Auto 菜单项后缀
 pub const AUTO_SUFFIX: &str = "auto";
+pub const TRAY_ID: &str = "cc-switch";
 
 pub const TRAY_SECTIONS: [TrayAppSection; 3] = [
     TrayAppSection {
@@ -207,7 +208,7 @@ fn handle_auto_click(app: &tauri::AppHandle, app_type: &AppType) -> Result<(), A
 
         // 4) 更新托盘菜单
         if let Ok(new_menu) = create_tray_menu(app, app_state.inner()) {
-            if let Some(tray) = app.tray_by_id("main") {
+            if let Some(tray) = app.tray_by_id(TRAY_ID) {
                 let _ = tray.set_menu(Some(new_menu));
             }
         }
@@ -255,7 +256,7 @@ fn handle_provider_click(
 
         // 更新托盘菜单
         if let Ok(new_menu) = create_tray_menu(app, app_state.inner()) {
-            if let Some(tray) = app.tray_by_id("main") {
+            if let Some(tray) = app.tray_by_id(TRAY_ID) {
                 let _ = tray.set_menu(Some(new_menu));
             }
         }
@@ -382,12 +383,23 @@ pub fn refresh_tray_menu(app: &tauri::AppHandle) {
 
     if let Some(state) = app.try_state::<AppState>() {
         if let Ok(new_menu) = create_tray_menu(app, state.inner()) {
-            if let Some(tray) = app.tray_by_id("main") {
+            if let Some(tray) = app.tray_by_id(TRAY_ID) {
                 if let Err(e) = tray.set_menu(Some(new_menu)) {
                     log::error!("刷新托盘菜单失败: {e}");
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TRAY_ID;
+
+    #[test]
+    fn tray_id_is_unique_to_app() {
+        assert_eq!(TRAY_ID, "cc-switch");
+        assert_ne!(TRAY_ID, "main");
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the shared tray id `"main"` with the app-specific id `"cc-switch"`
- update internal `tray_by_id(...)` lookups to use the same constant
- add a small unit test that guards against regressing back to `"main"`

## Why
On Linux, `tray-icon` derives both the AppIndicator identifier and the temporary PNG filename from the tray id. Using a generic id like `"main"` makes `cc-switch` collide with other Tauri apps that do the same thing.

A concrete reproducer is `clash-verge-rev`, which also uses `with_id("main")`:
- `cc-switch` starts first and exposes `/run/user/$UID/tray-icon/tray-icon-main-0.png`
- starting `clash-verge-rev` creates the same `tray-icon-main-0.png`
- when `clash-verge-rev` updates its tray icon, `tray-icon` deletes the previously active `tray-icon-main-0.png` and moves on to `tray-icon-main-1.png` / `tray-icon-main-3.png`
- GNOME AppIndicator then refreshes `cc-switch` against a stale path and the icon disappears or falls back to a broken placeholder

Using an app-specific tray id avoids the collision entirely.

Closes #1977.

## Verification
- `cargo test --lib tray_id_is_unique_to_app --manifest-path src-tauri/Cargo.toml`