### PR TITLE
[codex] Fix #1981: restore OMO Slim council support

### DIFF
--- a/src/components/providers/forms/OmoFormFields.tsx
+++ b/src/components/providers/forms/OmoFormFields.tsx
@@ -1264,12 +1264,22 @@ export function OmoFormFields({
           ) : undefined,
         maxHeightClass: "max-h-[500px]",
         children: (
-          <Textarea
-            value={otherFieldsStr}
-            onChange={(e) => onOtherFieldsStrChange(e.target.value)}
-            placeholder='{ "custom_key": "value" }'
-            className="font-mono text-xs min-h-[60px]"
-          />
+          <>
+            <Textarea
+              value={otherFieldsStr}
+              onChange={(e) => onOtherFieldsStrChange(e.target.value)}
+              placeholder='{ "custom_key": "value" }'
+              className="font-mono text-xs min-h-[60px]"
+            />
+            {isSlim && (
+              <p className="mt-1 text-[10px] text-muted-foreground">
+                {t("omo.slimOtherFieldsHint", {
+                  defaultValue:
+                    "Use this area for top-level OMO Slim config such as council, fallback, multiplexer, disabled_mcps, and todoContinuation.",
+                })}
+              </p>
+            )}
+          </>
         ),
       })}
     </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2275,6 +2275,7 @@
     "enabledModelsCount": "{{count}} configured models available",
     "source": "from:",
     "otherFieldsJson": "Other Fields (JSON)",
+    "slimOtherFieldsHint": "Use this area for top-level OMO Slim config such as council, fallback, multiplexer, disabled_mcps, and todoContinuation.",
     "searchOrType": "Search or type custom value...",
     "noMatches": "No matches",
     "jsonMustBeObject": "{{field}} must be a JSON object",
@@ -2351,7 +2352,8 @@
       "librarian": "Librarian",
       "explorer": "Explorer",
       "designer": "Designer",
-      "fixer": "Fixer"
+      "fixer": "Fixer",
+      "council": "Council"
     },
     "slimAgentTooltip": {
       "orchestrator": "Writes executable code, orchestrates multi-agent workflow, summons experts",
@@ -2359,7 +2361,8 @@
       "librarian": "Documentation lookup, GitHub code search (read-only)",
       "explorer": "Regex search, AST pattern matching, file discovery (read-only)",
       "designer": "Modern responsive design, CSS/Tailwind expertise",
-      "fixer": "Code implementation, refactoring, testing, verification"
+      "fixer": "Code implementation, refactoring, testing, verification",
+      "council": "Multi-model consensus agent. Runs multiple read-only councillors in parallel, then lets the master synthesize the final answer."
     }
   },
   "openclawConfig": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2275,6 +2275,7 @@
     "enabledModelsCount": "設定済みモデル {{count}} 件",
     "source": "出典:",
     "otherFieldsJson": "その他のフィールド (JSON)",
+    "slimOtherFieldsHint": "council、fallback、multiplexer、disabled_mcps、todoContinuation など、OMO Slim のトップレベル設定はここに記述します。",
     "searchOrType": "検索またはカスタム値を入力...",
     "noMatches": "一致する項目がありません",
     "jsonMustBeObject": "{{field}} は JSON オブジェクトである必要があります",
@@ -2351,7 +2352,8 @@
       "librarian": "ライブラリアン",
       "explorer": "エクスプローラー",
       "designer": "デザイナー",
-      "fixer": "フィクサー"
+      "fixer": "フィクサー",
+      "council": "カウンシル"
     },
     "slimAgentTooltip": {
       "orchestrator": "実行コードの作成、マルチエージェントワークフローの調整、エキスパートの召喚",
@@ -2359,7 +2361,8 @@
       "librarian": "ドキュメント検索、GitHubコード検索（読み取り専用）",
       "explorer": "正規表現検索、ASTパターンマッチング、ファイル検出（読み取り専用）",
       "designer": "モダンなレスポンシブデザイン、CSS/Tailwindの専門知識",
-      "fixer": "コード実装、リファクタリング、テスト、検証"
+      "fixer": "コード実装、リファクタリング、テスト、検証",
+      "council": "複数モデルの合議エージェント。複数の読み取り専用 councillor を並列実行し、master が最終回答を統合します。"
     }
   },
   "openclawConfig": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2275,6 +2275,7 @@
     "enabledModelsCount": "可选已配置模型 {{count}} 个",
     "source": "来源:",
     "otherFieldsJson": "其他字段 (JSON)",
+    "slimOtherFieldsHint": "OMO Slim 的 council、fallback、multiplexer、disabled_mcps、todoContinuation 等顶层配置请写在这里。",
     "searchOrType": "搜索或输入自定义值...",
     "noMatches": "无匹配项",
     "jsonMustBeObject": "{{field}} 必须是 JSON 对象",
@@ -2351,7 +2352,8 @@
       "librarian": "图书管理员",
       "explorer": "探索者",
       "designer": "设计师",
-      "fixer": "修复者"
+      "fixer": "修复者",
+      "council": "议会"
     },
     "slimAgentTooltip": {
       "orchestrator": "编写执行代码，编排多代理工作流，召唤专家",
@@ -2359,7 +2361,8 @@
       "librarian": "文档查询、GitHub 代码搜索（只读）",
       "explorer": "正则搜索、AST 模式匹配、文件发现（只读）",
       "designer": "现代响应式设计、CSS/Tailwind 精通",
-      "fixer": "代码实现、重构、测试、验证"
+      "fixer": "代码实现、重构、测试、验证",
+      "council": "多模型共识代理，并行运行多个只读 councillor，再由 master 汇总最终答案。"
     }
   },
   "openclawConfig": {

--- a/src/types/omo.ts
+++ b/src/types/omo.ts
@@ -362,6 +362,14 @@ export const OMO_SLIM_BUILTIN_AGENTS: OmoAgentDef[] = [
     recommended: "gpt-5.4",
     group: "sub",
   },
+  {
+    key: "council",
+    display: "Council",
+    descKey: "omo.slimAgentDesc.council",
+    tooltipKey: "omo.slimAgentTooltip.council",
+    recommended: "gpt-5.4-mini",
+    group: "sub",
+  },
 ];
 
 export const OMO_SLIM_DISABLEABLE_AGENTS = [
@@ -371,6 +379,7 @@ export const OMO_SLIM_DISABLEABLE_AGENTS = [
   { value: "explorer", label: "Explorer" },
   { value: "designer", label: "Designer" },
   { value: "fixer", label: "Fixer" },
+  { value: "council", label: "Council" },
 ] as const;
 
 export const OMO_SLIM_DISABLEABLE_MCPS = [

--- a/tests/utils/omoConfig.test.ts
+++ b/tests/utils/omoConfig.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildOmoProfilePreview,
+  buildOmoSlimProfilePreview,
+  OMO_SLIM_BUILTIN_AGENTS,
+  OMO_SLIM_DISABLEABLE_AGENTS,
   parseOmoOtherFieldsObject,
 } from "@/types/omo";
 
@@ -26,5 +29,40 @@ describe("buildOmoProfilePreview", () => {
 
     const fromObject = buildOmoProfilePreview({}, {}, '{ "foo": "bar" }');
     expect(fromObject).toEqual({ foo: "bar" });
+  });
+});
+
+describe("buildOmoSlimProfilePreview", () => {
+  it("保留 top-level council 配置，同时写入 council agent 模型", () => {
+    const preview = buildOmoSlimProfilePreview(
+      {
+        council: { model: "openai/gpt-5.4-mini" },
+      },
+      '{ "council": { "default_preset": "default" }, "fallback": { "enabled": true } }',
+    );
+
+    expect(preview).toEqual({
+      council: { default_preset: "default" },
+      fallback: { enabled: true },
+      agents: {
+        council: { model: "openai/gpt-5.4-mini" },
+      },
+    });
+  });
+});
+
+describe("OMO Slim metadata", () => {
+  it("将 council 视为内置且可禁用的 agent", () => {
+    expect(OMO_SLIM_BUILTIN_AGENTS).toContainEqual(
+      expect.objectContaining({
+        key: "council",
+        display: "Council",
+        group: "sub",
+      }),
+    );
+    expect(OMO_SLIM_DISABLEABLE_AGENTS).toContainEqual({
+      value: "council",
+      label: "Council",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1981.

Restore first-class OMO Slim support for the upstream `council` agent in CC Switch.

## What Changed

- add `council` to the built-in OMO Slim agent metadata so it appears as a first-class agent in the form
- add localized OMO Slim copy that explains top-level config like `council`, `fallback`, and `multiplexer`
- add regression coverage for OMO Slim preview generation and built-in council metadata

## Root Cause

CC Switch could already persist arbitrary OMO Slim agent keys and top-level config fields, but the built-in metadata and UI copy still reflected the pre-council upstream agent set. That made the feature look unsupported and pushed users toward manual JSON-only setup.

## Impact

Users configuring `oh-my-opencode-slim` can now discover and configure `council` directly in the OMO Slim form instead of relying on custom-agent workarounds.

## Validation

- `pnpm exec vitest run tests/utils/omoConfig.test.ts tests/components/OmoFormFields.mergeCustomModelsIntoStore.test.ts`
- `pnpm typecheck`
