### PR TITLE
[codex] restore auth tab localization in settings

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -243,6 +243,7 @@
     "title": "Settings",
     "general": "General",
     "tabGeneral": "General",
+    "tabAuth": "Auth",
     "tabAdvanced": "Advanced",
     "tabProxy": "Proxy",
     "authCenter": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -243,6 +243,7 @@
     "title": "設定",
     "general": "一般",
     "tabGeneral": "一般",
+    "tabAuth": "認証",
     "tabAdvanced": "詳細",
     "tabProxy": "プロキシ",
     "authCenter": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -243,6 +243,7 @@
     "title": "设置",
     "general": "通用",
     "tabGeneral": "通用",
+    "tabAuth": "认证",
     "tabAdvanced": "高级",
     "tabProxy": "代理",
     "authCenter": {


### PR DESCRIPTION
## What changed
- added the missing `settings.tabAuth` locale entry in `zh`, `en`, and `ja`
- kept the existing settings tab rendering logic unchanged

## Why
The settings page already reads the auth tab label from i18n, but the locale bundles did not define `settings.tabAuth`. That caused the auth tab to fall back to the hardcoded Chinese default instead of showing the proper localized label.

## Impact
- the auth tab now shows the expected localized label in Chinese, English, and Japanese
- no component behavior or layout logic changed

## Root cause
The auth tab was wired to a translation key that was never added to the locale files.

## Validation
- `pnpm format:check`
- `pnpm typecheck`