### PR TITLE
feat(opencode): add dedicated UI for model token limits (limit.context & limit.output)

### DIFF
--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -466,6 +466,53 @@ export function OpenCodeFormFields({
     });
   };
 
+  // Model limit handlers (limit.context and limit.output)
+  const handleModelLimitContextChange = (modelKey: string, value: string) => {
+    const model = models[modelKey];
+    const numValue = value.trim() ? Number(value) : undefined;
+    if (numValue !== undefined && !Number.isFinite(numValue)) return;
+    const currentLimit = model.limit || {};
+    // If both context and output are undefined, remove limit entirely
+    if (numValue === undefined && currentLimit.output === undefined) {
+      const { limit: _, ...rest } = model;
+      onModelsChange({
+        ...models,
+        [modelKey]: rest as OpenCodeModel,
+      });
+    } else {
+      onModelsChange({
+        ...models,
+        [modelKey]: {
+          ...model,
+          limit: { ...currentLimit, context: numValue },
+        },
+      });
+    }
+  };
+
+  const handleModelLimitOutputChange = (modelKey: string, value: string) => {
+    const model = models[modelKey];
+    const numValue = value.trim() ? Number(value) : undefined;
+    if (numValue !== undefined && !Number.isFinite(numValue)) return;
+    const currentLimit = model.limit || {};
+    // If both context and output are undefined, remove limit entirely
+    if (currentLimit.context === undefined && numValue === undefined) {
+      const { limit: _, ...rest } = model;
+      onModelsChange({
+        ...models,
+        [modelKey]: rest as OpenCodeModel,
+      });
+    } else {
+      onModelsChange({
+        ...models,
+        [modelKey]: {
+          ...model,
+          limit: { ...currentLimit, output: numValue },
+        },
+      });
+    }
+  };
+
   // Extra Options handlers
   const handleAddExtraOption = () => {
     const newKey = `option-${Date.now()}`;
@@ -825,6 +872,59 @@ export function OpenCodeFormFields({
                           ),
                         )
                       )}
+                    </div>
+
+                    {/* Token Limits (model.limit) */}
+                    <div className="space-y-2">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {t("opencode.tokenLimits", {
+                          defaultValue: "Token Limits",
+                        })}
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground w-24 shrink-0">
+                          {t("opencode.limitContext", {
+                            defaultValue: "Context Window",
+                          })}
+                        </span>
+                        <Input
+                          type="number"
+                          value={model.limit?.context ?? ""}
+                          onChange={(e) =>
+                            handleModelLimitContextChange(key, e.target.value)
+                          }
+                          placeholder={t("opencode.limitContextPlaceholder", {
+                            defaultValue: "e.g. 128000",
+                          })}
+                          className="flex-1"
+                          min={1}
+                        />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground w-24 shrink-0">
+                          {t("opencode.limitOutput", {
+                            defaultValue: "Max Output",
+                          })}
+                        </span>
+                        <Input
+                          type="number"
+                          value={model.limit?.output ?? ""}
+                          onChange={(e) =>
+                            handleModelLimitOutputChange(key, e.target.value)
+                          }
+                          placeholder={t("opencode.limitOutputPlaceholder", {
+                            defaultValue: "e.g. 4096",
+                          })}
+                          className="flex-1"
+                          min={1}
+                        />
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {t("opencode.tokenLimitsHint", {
+                          defaultValue:
+                            "Set context window and max output token limits for this model",
+                        })}
+                      </p>
                     </div>
 
                     {/* SDK Options (model.options) */}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1028,7 +1028,13 @@
     "modelExtraFieldKeyPlaceholder": "variants",
     "sdkOptions": "SDK Options",
     "modelOptionKeyPlaceholder": "provider",
-    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
+    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}",
+    "tokenLimits": "Token Limits",
+    "limitContext": "Context Window",
+    "limitOutput": "Max Output",
+    "limitContextPlaceholder": "e.g. 128000",
+    "limitOutputPlaceholder": "e.g. 4096",
+    "tokenLimitsHint": "Set context window and max output token limits for this model"
   },
   "providerPreset": {
     "label": "Provider Preset",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1028,7 +1028,13 @@
     "modelExtraFieldKeyPlaceholder": "variants",
     "sdkOptions": "SDK オプション",
     "modelOptionKeyPlaceholder": "provider",
-    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
+    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}",
+    "tokenLimits": "トークン制限",
+    "limitContext": "コンテキストウィンドウ",
+    "limitOutput": "最大出力",
+    "limitContextPlaceholder": "例: 128000",
+    "limitOutputPlaceholder": "例: 4096",
+    "tokenLimitsHint": "このモデルのコンテキストウィンドウと最大出力トークン制限を設定"
   },
   "providerPreset": {
     "label": "プロバイダータイプ",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1029,7 +1029,13 @@
     "modelExtraFieldKeyPlaceholder": "variants",
     "sdkOptions": "SDK 选项",
     "modelOptionKeyPlaceholder": "provider",
-    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
+    "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}",
+    "tokenLimits": "Token 限制",
+    "limitContext": "上下文窗口",
+    "limitOutput": "最大输出",
+    "limitContextPlaceholder": "如 128000",
+    "limitOutputPlaceholder": "如 4096",
+    "tokenLimitsHint": "设置此模型的上下文窗口和最大输出 token 限制"
   },
   "providerPreset": {
     "label": "预设供应商",


### PR DESCRIPTION
## Summary

Previously, there was no way to edit OpenCode model token limits in the UI. The `limit` field was excluded from extra fields as a known/reserved key (`OPENCODE_KNOWN_MODEL_KEYS`), but had no dedicated input. Users could only set limits via presets.

This PR adds a **Token Limits** section with number inputs for `limit.context` (context window) and `limit.output` (max output), placed between Model Properties and SDK Options in the expanded model details.

## Changes

- `OpenCodeFormFields.tsx`: Added `handleModelLimitContextChange` and `handleModelLimitOutputChange` handlers + Token Limits UI section
- `src/i18n/locales/en.json`, `zh.json`, `ja.json`: Added 6 i18n keys (tokenLimits, limitContext, limitOutput, limitContextPlaceholder, limitOutputPlaceholder, tokenLimitsHint)

## Testing

- `pnpm typecheck` passed
- Manual verification: Token Limits section appears in expanded model details with working number inputs

## Screenshots

The Token Limits section appears when expanding a model in the OpenCode provider form, allowing users to set context window and max output token limits directly.