### PR TITLE
fix(opencode): use json5 parser for trailing comma tolerance

### DIFF
--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -61,7 +61,8 @@ pub fn read_opencode_config() -> Result<Value, AppError> {
     }
 
     let content = std::fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
-    serde_json::from_str(&content).map_err(|e| AppError::json(&path, e))
+    json5::from_str(&content)
+        .map_err(|e| AppError::Config(format!("Failed to parse OpenCode config: {}: {e}", path.display())))
 }
 
 pub fn write_opencode_config(config: &Value) -> Result<(), AppError> {

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -61,8 +61,12 @@ pub fn read_opencode_config() -> Result<Value, AppError> {
     }
 
     let content = std::fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
-    json5::from_str(&content)
-        .map_err(|e| AppError::Config(format!("Failed to parse OpenCode config: {}: {e}", path.display())))
+    json5::from_str(&content).map_err(|e| {
+        AppError::Config(format!(
+            "Failed to parse OpenCode config: {}: {e}",
+            path.display()
+        ))
+    })
 }
 
 pub fn write_opencode_config(config: &Value) -> Result<(), AppError> {


### PR DESCRIPTION
## Summary

OpenCode CLI writes `opencode.json` with trailing commas (valid JSONC), but CC Switch parsed it with `serde_json` (strict JSON), causing errors like:

> JSON 解析错误: /home/wm/.config/opencode/opencode.json: trailing comma at line 35 column 3

Switch to `json5::from_str` which accepts both JSON and JSONC. The `json5` crate is already a project dependency (used by `openclaw_config.rs` for the same reason).

## Changes

- `src-tauri/src/opencode_config.rs`: Changed `serde_json::from_str(&content)` to `json5::from_str(&content)`, error type from `AppError::json()` to `AppError::Config()`

## Testing

- `cargo check` passed
- `cargo clippy` — 0 warnings
- `cargo test` — all 743+ tests passed