### PR TITLE
fix: sync claude mcp on first enable

### DIFF
--- a/src-tauri/src/mcp/claude.rs
+++ b/src-tauri/src/mcp/claude.rs
@@ -41,9 +41,10 @@ fn collect_enabled_servers(cfg: &McpConfig) -> HashMap<String, Value> {
 pub fn sync_enabled_to_claude(config: &MultiAppConfig) -> Result<(), AppError> {
     // 先收集当前已显式启用的 Claude MCP 服务器。
     let enabled = collect_enabled_servers(&config.mcp.claude);
-    // 兼容首次同步场景：如果 Claude 尚未初始化，但当前已经存在启用项，也允许首次写入 ~/.claude.json。
-    if should_sync_claude_mcp() == false && enabled.is_empty() == true {
-        return Ok(());
+    // 兼容首次同步场景：仅当 Claude 尚未初始化且当前没有任何启用项时，才跳过写入。
+    match (should_sync_claude_mcp(), enabled.is_empty()) {
+        (false, true) => return Ok(()),
+        _ => {}
     }
     // 将启用的服务器写入 Claude MCP 配置文件。
     crate::claude_mcp::set_mcp_servers_map(&enabled)
@@ -120,17 +121,13 @@ pub fn sync_single_server_to_claude(
     id: &str,
     server_spec: &Value,
 ) -> Result<(), AppError> {
-    if !should_sync_claude_mcp() {
-        return Ok(());
-    }
-    // 读取现有的 MCP 配置
+    // 读取现有的 MCP 配置；若配置文件尚不存在，则由底层读取逻辑返回空集合。
     let current = crate::claude_mcp::read_mcp_servers_map()?;
-
-    // 创建新的 HashMap，包含现有的所有服务器 + 当前要同步的服务器
+    // 创建新的 HashMap，包含现有的所有服务器与当前要同步的服务器。
     let mut updated = current;
+    // 将当前服务器合并进待写回的配置。
     updated.insert(id.to_string(), server_spec.clone());
-
-    // 写回
+    // 将新的服务器集合写回 Claude MCP 配置文件。
     crate::claude_mcp::set_mcp_servers_map(&updated)
 }
 

--- a/src-tauri/src/mcp/claude.rs
+++ b/src-tauri/src/mcp/claude.rs
@@ -39,10 +39,13 @@ fn collect_enabled_servers(cfg: &McpConfig) -> HashMap<String, Value> {
 
 /// 将 config.json 中 enabled==true 的项投影写入 ~/.claude.json
 pub fn sync_enabled_to_claude(config: &MultiAppConfig) -> Result<(), AppError> {
-    if !should_sync_claude_mcp() {
+    // 先收集当前已显式启用的 Claude MCP 服务器。
+    let enabled = collect_enabled_servers(&config.mcp.claude);
+    // 兼容首次同步场景：如果 Claude 尚未初始化，但当前已经存在启用项，也允许首次写入 ~/.claude.json。
+    if should_sync_claude_mcp() == false && enabled.is_empty() == true {
         return Ok(());
     }
-    let enabled = collect_enabled_servers(&config.mcp.claude);
+    // 将启用的服务器写入 Claude MCP 配置文件。
     crate::claude_mcp::set_mcp_servers_map(&enabled)
 }
 


### PR DESCRIPTION
# fix: allow Claude MCP sync on first explicit enable

本次修复可能可以解决[#293](https://github.com/farion1231/cc-switch/issues/293)、[#1330 的讨论](https://github.com/farion1231/cc-switch/issues/1330#issuecomment-4140518611)、[#1937](https://github.com/farion1231/cc-switch/issues/1937)



# Operating environment/运行环境

- Claude Code: v2.1.104
- CC Switch: v3.13.0
- System: Windows 10/11 x86_64

# Verification status/验证情况

已在 Windows 10 x86_64 下构建了.exe文件，测试后可以识别到MCP。

<img width="1644" height="498" alt="成功修复截图" src="https://github.com/user-attachments/assets/f2ee8e4c-d263-4fd9-8112-35dc9ed96807" />

# Scenario of bug occurrence/bug出现场景
在 cc-switch 里把 Claude 的 MCP 都配好了，但 Claude Code 里就是不生效，怎么设置cc-switch都修不好。



---


***以下内容由ai生成：***

## Summary / 摘要

**中文：**
这个 PR 修复了 `cc-switch` 中一个只影响 Claude Code 的 MCP 同步问题。

当用户已经在 cc-switch 中把 Claude 的 MCP 服务器完整配置好时，界面看起来是正常的，但 Claude Code 仍然看不到、也用不了这些 MCP 服务器。从用户视角看，就像配置已经完成，但始终没有真正生效。

**English:**
This PR fixes a Claude-specific MCP sync issue in `cc-switch`.

When users fully configure MCP servers for Claude in cc-switch, the UI looks correct, but Claude Code still cannot see or use those MCP servers. From the user perspective, it looks like the setup is complete, but it never actually takes effect.

## Problem / 问题描述

**中文：**
在一台全新机器，或者一个全新的用户环境里，Claude 可能还没有生成下面这些路径：

- `~/.claude`
- `~/.claude.json`

在这种情况下，用户依然可以在 cc-switch 中为 Claude 配置 MCP 服务器，但这些配置不会在 Claude Code 中真正生效。

典型用户场景如下：

1. 打开 cc-switch。
2. 为 Claude 配置好全部需要的 MCP 设置。
3. 确认这些 MCP 项已经在 cc-switch 中正确显示。
4. 打开 Claude Code，尝试使用 MCP，或者执行 `claude mcp list`。
5. 结果什么都没有出现。

这会让用户非常困惑，因为界面看起来已经配置完成，但 Claude Code 的行为却像是什么都没配置过一样。

**English:**
On a fresh machine or fresh user profile, Claude may not have created either of these paths yet:

- `~/.claude`
- `~/.claude.json`

In that state, users can still configure MCP servers for Claude inside cc-switch, but the configuration does not become effective in Claude Code.

Typical user flow:

1. Open cc-switch.
2. Configure all required MCP settings for Claude.
3. Confirm the MCP entries appear correctly in cc-switch.
4. Open Claude Code and try to use MCP, or run `claude mcp list`.
5. Nothing shows up.

This is especially confusing because the UI suggests the configuration is already complete, while Claude Code behaves as if nothing was configured.

## Why this is hard to diagnose / 为什么这个问题很难定位

**中文：**
从用户角度看，这更像是一个“明明已经配置好了，但就是不工作”的问题：

- MCP 配置已经填好了
- 开关状态看起来也是对的
- 反复检查配置也没有用
- 重新同步也没有用
- 其他客户端甚至可能表现正常

所以用户往往会以为是自己配置错了，但真实原因是 Claude 对应的 MCP 配置文件根本没有被首次创建出来，或者没有被更新。

**English:**
From the user side, this feels like a persistent "configured but not working" problem:

- the MCP settings are already filled in
- the toggle state looks correct
- rechecking the config does not help
- retrying sync does not help
- other clients may appear normal

So users often assume they configured something incorrectly, while the real issue is that Claude's MCP file was never created or updated.

## Root cause / 根因分析

**中文：**
Claude 的同步逻辑在真正写入之前，有一个存在性判断：

- `~/.claude` 已存在，或者
- `~/.claude.json` 已存在

如果这两个路径都不存在，就会直接提前返回。

这意味着：即使用户已经在 cc-switch 中明确启用了 Claude MCP 服务器，只要这是第一次配置 Claude MCP，cc-switch 也可能完全跳过写入。

结果就是首次显式同步时，`~/.claude.json` 根本不会被创建，Claude Code 自然也就看不到这些已经配置好的 MCP 服务器。

**English:**
Claude sync was gated by an existence check before writing:

- `~/.claude` exists, or
- `~/.claude.json` exists

If both are missing, sync returns early.

That means on first-time Claude MCP setup, cc-switch may skip writing entirely, even when the user has explicitly enabled Claude MCP servers.

As a result, `~/.claude.json` is never created on the first explicit sync, and Claude Code cannot see the configured MCP servers.

## Fix / 修复方式

**中文：**
这次修改尽量保持原有同步结构不变，只修补首次同步的缺口：

- 如果 Claude 配置已经存在，同步行为保持原样
- 如果 Claude 配置还不存在，但当前确实有显式启用的 Claude MCP 项，也允许首次写入 `~/.claude.json`
- 没有去扩大改动范围，也没有去重构整个 Claude 同步逻辑

简而言之：

> 只要用户已经在 cc-switch 中明确启用了 Claude MCP，cc-switch 就应该允许首次创建 Claude 的 MCP 配置文件。

**English:**
This change keeps the original sync structure as much as possible and only fixes the first-sync gap:

- if Claude config already exists, sync behaves as before
- if Claude config does not exist yet, but there are explicitly enabled Claude MCP entries, cc-switch now allows the initial `~/.claude.json` write
- the change stays minimal and does not broadly refactor Claude sync behavior

In short:

> Explicit Claude MCP enablement in cc-switch should be enough to create the first Claude MCP config file.

## Reproduction / 复现步骤

### Before the fix / 修复前

1. Use a machine or user profile where `~/.claude` and `~/.claude.json` do not exist. / 使用一个不存在 `~/.claude` 和 `~/.claude.json` 的全新机器或全新用户环境。
2. Open cc-switch. / 打开 cc-switch。
3. Add one or more MCP servers and enable them for Claude. / 添加一个或多个 MCP 服务器，并为 Claude 启用它们。
4. Open Claude Code. / 打开 Claude Code。
5. Run `claude mcp list` or try to use the MCP server. / 执行 `claude mcp list`，或者直接尝试使用 MCP。

### Actual result / 实际结果

Claude Code does not show the configured MCP servers. / Claude Code 看不到这些已经配置好的 MCP 服务器。

### Expected result / 期望结果

cc-switch should create or update `~/.claude.json` on the first explicit Claude MCP sync, and Claude Code should immediately see those MCP servers. / 在第一次显式同步 Claude MCP 时，cc-switch 应该创建或更新 `~/.claude.json`，并让 Claude Code 立即看到这些 MCP 服务器。

## Scope / 影响范围

**中文：**
这个修复只针对 Claude MCP 的首次同步行为。

它不会改变通用 MCP 模型，也不会影响其他客户端的同步逻辑。

**English:**
This fix only targets Claude MCP first-sync behavior.

It does not change the general MCP model or the behavior of other clients.

## Manual verification / 手动验证

- fresh environment without `~/.claude` and `~/.claude.json` / 在不存在 `~/.claude` 和 `~/.claude.json` 的环境中验证
- configure Claude MCP in cc-switch / 在 cc-switch 中配置 Claude MCP
- confirm `~/.claude.json` is created on first explicit sync / 确认首次显式同步时会创建 `~/.claude.json`
- confirm Claude Code can see the configured MCP servers / 确认 Claude Code 能看到这些 MCP 服务器

## Risk assessment / 风险评估

**中文：**
风险较低。

修改范围只在 Claude MCP 的首次同步判断上，目标是修复首次落盘缺口，同时保持已经初始化过的 Claude 环境继续按原有方式工作。

**English:**
Low risk.

The change is localized to Claude MCP first-sync gating logic and is intended to preserve the existing behavior for already-initialized Claude environments.

## Notes for reviewers / 给审阅者的说明

**中文：**
这个 PR 的目标不是去整体重构 Claude 的配置管理，而是修复一个非常具体、但对用户体验影响很大的问题：用户已经在 cc-switch 中完成全部 Claude MCP 配置，但 Claude Code 侧完全没有效果。

**English:**
The goal of this PR is not to broadly change Claude config management, but to fix a very specific and user-visible gap: users can complete all Claude MCP setup in cc-switch, yet still get no effect in Claude Code.