### PR TITLE
fix(skills): sync imported skills to app directories after import

### DIFF
--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -1549,6 +1549,20 @@ impl SkillService {
 
             // 保存到数据库
             db.save_skill(&skill)?;
+
+            // 同步到已启用的应用目录（创建 symlink 或复制文件）
+            for app in AppType::all() {
+                if skill.apps.is_enabled_for(&app) {
+                    if let Err(e) = Self::sync_to_app_dir(&skill.directory, &app) {
+                        log::warn!(
+                            "导入后同步 Skill '{}' 到 {:?} 失败: {e:#}",
+                            skill.directory,
+                            app
+                        );
+                    }
+                }
+            }
+
             imported.push(skill);
         }
 


### PR DESCRIPTION
import_from_apps() saves skills to the database but never calls sync_to_app_dir(), so skills appear as "installed" in the UI while symlinks are missing from the target app directories.
Added sync_to_app_dir() calls after db.save_skill(), matching the pattern used by install() and toggle_app().