### PR TITLE
feat(proxy): 自动回切 — P1恢复时failback到主provider

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -359,10 +359,12 @@ pub async fn reset_circuit_breaker(
                         .unwrap_or_else(|| provider_id.clone());
 
                     // 创建故障转移切换管理器并执行切换
-                    let switch_manager =
-                        crate::proxy::failover_switch::FailoverSwitchManager::new(db.clone());
+                    let switch_manager = crate::proxy::failover_switch::FailoverSwitchManager::new(
+                        db.clone(),
+                        Some(app_handle),
+                    );
                     if let Err(e) = switch_manager
-                        .try_switch(Some(&app_handle), &app_type, &provider_id, &provider_name)
+                        .try_switch(&app_type, &provider_id, &provider_name)
                         .await
                     {
                         log::error!("[Recovery] 自动切换失败: {e}");

--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -4,7 +4,7 @@
 
 use super::log_codes::cb as log_cb;
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
@@ -77,6 +77,8 @@ pub struct CircuitBreaker {
     config: Arc<RwLock<CircuitBreakerConfig>>,
     /// 半开状态已放行的请求数（用于限流）
     half_open_requests: Arc<AtomicU32>,
+    /// 是否曾经进入过 Open（用于判断"真正恢复"而非"从未失败"）
+    ever_tripped: Arc<AtomicBool>,
 }
 
 /// 熔断器放行结果
@@ -101,6 +103,7 @@ impl CircuitBreaker {
             last_opened_at: Arc::new(RwLock::new(None)),
             config: Arc::new(RwLock::new(config)),
             half_open_requests: Arc::new(AtomicU32::new(0)),
+            ever_tripped: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -348,6 +351,7 @@ impl CircuitBreaker {
         *self.last_opened_at.write().await = Some(Instant::now());
         self.consecutive_failures.store(0, Ordering::SeqCst);
         self.consecutive_successes.store(0, Ordering::SeqCst);
+        self.ever_tripped.store(true, Ordering::SeqCst);
     }
 
     /// 转换到半开状态
@@ -371,6 +375,17 @@ impl CircuitBreaker {
         // 重置计数器
         self.total_requests.store(0, Ordering::SeqCst);
         self.failed_requests.store(0, Ordering::SeqCst);
+        // 手动重置时清 ever_tripped（新周期开始）
+        self.ever_tripped.store(false, Ordering::SeqCst);
+    }
+
+    /// 是否曾经进入过 Open 状态
+    ///
+    /// 用于判断"真正从故障中恢复"而非"从未失败过的正常 Closed"。
+    /// 当 P1 刚从 Open/HalfOpen 恢复到 Closed 时返回 true，
+    /// P1 正常运行未触发熔断时返回 false。
+    pub fn has_been_open(&self) -> bool {
+        self.ever_tripped.load(Ordering::SeqCst)
     }
 }
 

--- a/src-tauri/src/proxy/failover_switch.rs
+++ b/src-tauri/src/proxy/failover_switch.rs
@@ -20,13 +20,16 @@ pub struct FailoverSwitchManager {
     /// 正在处理中的切换（key = "app_type:provider_id"）
     pending_switches: Arc<RwLock<HashSet<String>>>,
     db: Arc<Database>,
+    /// AppHandle，用于 UI 更新和事件发射
+    app_handle: Option<Arc<tauri::AppHandle>>,
 }
 
 impl FailoverSwitchManager {
-    pub fn new(db: Arc<Database>) -> Self {
+    pub fn new(db: Arc<Database>, app_handle: Option<tauri::AppHandle>) -> Self {
         Self {
             pending_switches: Arc::new(RwLock::new(HashSet::new())),
             db,
+            app_handle: app_handle.map(Arc::new),
         }
     }
 
@@ -40,7 +43,6 @@ impl FailoverSwitchManager {
     /// - `Err(e)` - 切换过程中发生错误
     pub async fn try_switch(
         &self,
-        app_handle: Option<&tauri::AppHandle>,
         app_type: &str,
         provider_id: &str,
         provider_name: &str,
@@ -59,7 +61,7 @@ impl FailoverSwitchManager {
 
         // 执行切换（确保最后清理 pending 标记）
         let result = self
-            .do_switch(app_handle, app_type, provider_id, provider_name)
+            .do_switch(app_type, provider_id, provider_name)
             .await;
 
         // 清理 pending 标记
@@ -73,7 +75,6 @@ impl FailoverSwitchManager {
 
     async fn do_switch(
         &self,
-        app_handle: Option<&tauri::AppHandle>,
         app_type: &str,
         provider_id: &str,
         provider_name: &str,
@@ -97,7 +98,7 @@ impl FailoverSwitchManager {
 
         let mut switched = false;
 
-        if let Some(app) = app_handle {
+        if let Some(app) = self.app_handle.as_ref().map(|a| a.as_ref()) {
             if let Some(app_state) = app.try_state::<crate::store::AppState>() {
                 switched = app_state
                     .proxy_service

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -227,15 +227,14 @@ impl RequestForwarder {
                         if should_switch {
                             status.failover_count += 1;
 
-                            // 异步触发供应商切换，更新 UI/托盘，并把“当前供应商”同步为实际使用的 provider
+                            // 异步触发供应商切换，更新 UI/托盘，并把”当前供应商”同步为实际使用的 provider
                             let fm = self.failover_manager.clone();
-                            let ah = self.app_handle.clone();
                             let pid = provider.id.clone();
                             let pname = provider.name.clone();
                             let at = app_type_str.to_string();
 
                             tokio::spawn(async move {
-                                let _ = fm.try_switch(ah.as_ref(), &at, &pid, &pname).await;
+                                let _ = fm.try_switch(&at, &pid, &pname).await;
                             });
                         }
                         // 重新计算成功率
@@ -362,14 +361,13 @@ impl RequestForwarder {
 
                                                 // 异步触发供应商切换，更新 UI/托盘
                                                 let fm = self.failover_manager.clone();
-                                                let ah = self.app_handle.clone();
                                                 let pid = provider.id.clone();
                                                 let pname = provider.name.clone();
                                                 let at = app_type_str.to_string();
 
                                                 tokio::spawn(async move {
                                                     let _ = fm
-                                                        .try_switch(ah.as_ref(), &at, &pid, &pname)
+                                                        .try_switch(&at, &pid, &pname)
                                                         .await;
                                                 });
                                             }
@@ -556,14 +554,11 @@ impl RequestForwarder {
                                         if should_switch {
                                             status.failover_count += 1;
                                             let fm = self.failover_manager.clone();
-                                            let ah = self.app_handle.clone();
                                             let pid = provider.id.clone();
                                             let pname = provider.name.clone();
                                             let at = app_type_str.to_string();
                                             tokio::spawn(async move {
-                                                let _ = fm
-                                                    .try_switch(ah.as_ref(), &at, &pid, &pname)
-                                                    .await;
+                                                let _ = fm.try_switch(&at, &pid, &pname).await;
                                             });
                                         }
                                         if status.total_requests > 0 {

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -192,7 +192,7 @@ impl ProviderRouter {
                                     let pname = p1.name.clone();
                                     let at = app_type.to_string();
                                     tokio::spawn(async move {
-                                        let _ = fm.try_switch(None, &at, &pid, &pname).await;
+                                        let _ = fm.try_switch(&at, &pid, &pname).await;
                                     });
                                 }
                             }

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -6,7 +6,8 @@ use crate::app_config::AppType;
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
-use crate::proxy::circuit_breaker::{AllowResult, CircuitBreaker, CircuitBreakerConfig};
+use crate::proxy::circuit_breaker::{AllowResult, CircuitBreaker, CircuitBreakerConfig, CircuitState};
+use crate::proxy::failover_switch::FailoverSwitchManager;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -18,6 +19,8 @@ pub struct ProviderRouter {
     db: Arc<Database>,
     /// 熔断器管理器 - key 格式: "app_type:provider_id"
     circuit_breakers: Arc<RwLock<HashMap<String, Arc<CircuitBreaker>>>>,
+    /// 自动回切管理器（由 ProxyServer 构造时注入）
+    failover_switch_manager: Arc<RwLock<Option<Arc<FailoverSwitchManager>>>>,
 }
 
 impl ProviderRouter {
@@ -26,7 +29,17 @@ impl ProviderRouter {
         Self {
             db,
             circuit_breakers: Arc::new(RwLock::new(HashMap::new())),
+            failover_switch_manager: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// 设置自动回切管理器
+    pub fn set_failover_switch_manager(&self, mgr: Arc<FailoverSwitchManager>) {
+        // fire-and-forget，settle 后才正式启用
+        let mgr_ref = self.failover_switch_manager.clone();
+        tokio::spawn(async move {
+            *mgr_ref.write().await = Some(mgr);
+        });
     }
 
     /// 选择可用的供应商（支持故障转移）
@@ -143,6 +156,42 @@ impl ProviderRouter {
 
         if success {
             breaker.record_success(used_half_open_permit).await;
+
+            // [FO-BACK] 自动回切：当前用的是 P2+，且 P1 已从熔断恢复
+            if let Some(ref mgr) = *self.failover_switch_manager.read().await {
+                let ordered_ids: Vec<String> = match self.db.get_failover_queue(app_type) {
+                    Ok(ids) => ids.into_iter().map(|item| item.provider_id).collect(),
+                    Err(_) => Vec::new(),
+                };
+
+                if let Some(p1_id) = ordered_ids.first() {
+                    if provider_id != *p1_id {
+                        // 当前不在 P1，检查 P1 是否已恢复为 Closed
+                        let p1_circuit_key = format!("{app_type}:{}", p1_id);
+                        let p1_breaker = self.get_or_create_circuit_breaker(&p1_circuit_key).await;
+                        if p1_breaker.get_state().await == CircuitState::Closed {
+                            let all = match self.db.get_all_providers(app_type) {
+                                Ok(p) => p,
+                                Err(_) => return Ok(()),
+                            };
+                            if let Some(p1) = all.get(p1_id) {
+                                log::info!(
+                                    "[FO-BACK] P1 {} 恢复为 Closed（当前: {}），触发自动回切",
+                                    p1.name,
+                                    provider_id
+                                );
+                                let fm = mgr.clone();
+                                let pid = p1.id.clone();
+                                let pname = p1.name.clone();
+                                let at = app_type.to_string();
+                                tokio::spawn(async move {
+                                    let _ = fm.try_switch(None, &at, &pid, &pname).await;
+                                });
+                            }
+                        }
+                    }
+                }
+            }
         } else {
             breaker.record_failure(used_half_open_permit).await;
         }

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -33,13 +33,12 @@ impl ProviderRouter {
         }
     }
 
-    /// 设置自动回切管理器
-    pub fn set_failover_switch_manager(&self, mgr: Arc<FailoverSwitchManager>) {
-        // fire-and-forget，settle 后才正式启用
-        let mgr_ref = self.failover_switch_manager.clone();
-        tokio::spawn(async move {
-            *mgr_ref.write().await = Some(mgr);
-        });
+    /// 异步设置自动回切管理器
+    ///
+    /// 等写入完成后返回，消除 fire-and-forget 竞态。
+    /// caller 必须 await 此方法后再让 proxy 处理请求。
+    pub async fn set_failover_switch_manager(&self, mgr: Arc<FailoverSwitchManager>) {
+        *self.failover_switch_manager.write().await = Some(mgr);
     }
 
     /// 选择可用的供应商（支持故障转移）
@@ -158,48 +157,7 @@ impl ProviderRouter {
             breaker.record_success(used_half_open_permit).await;
 
             // [FO-BACK] 自动回切：当前用的是 P2+，且 P1 已从熔断恢复
-            'failback: {
-                if let Some(ref mgr) = *self.failover_switch_manager.read().await {
-                    let ordered_ids: Vec<String> = match self.db.get_failover_queue(app_type) {
-                        Ok(ids) => ids.into_iter().map(|item| item.provider_id).collect(),
-                        Err(_) => Vec::new(),
-                    };
-
-                    if let Some(p1_id) = ordered_ids.first() {
-                        if provider_id != *p1_id {
-                            // 当前不在 P1，检查 P1 是否已恢复为 Closed
-                            let p1_circuit_key = format!("{app_type}:{}", p1_id);
-                            let p1_breaker = self.get_or_create_circuit_breaker(&p1_circuit_key).await;
-                            if p1_breaker.get_state().await == CircuitState::Closed {
-                                let all = match self.db.get_all_providers(app_type) {
-                                    Ok(p) => p,
-                                    Err(e) => {
-                                        log::warn!(
-                                            "[FO-BACK] get_all_providers 失败，跳过本次回切: {}",
-                                            e
-                                        );
-                                        break 'failback;
-                                    }
-                                };
-                                if let Some(p1) = all.get(p1_id) {
-                                    log::info!(
-                                        "[FO-BACK] P1 {} 恢复为 Closed（当前: {}），触发自动回切",
-                                        p1.name,
-                                        provider_id
-                                    );
-                                    let fm = mgr.clone();
-                                    let pid = p1.id.clone();
-                                    let pname = p1.name.clone();
-                                    let at = app_type.to_string();
-                                    tokio::spawn(async move {
-                                        let _ = fm.try_switch(&at, &pid, &pname).await;
-                                    });
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            self.trigger_failback_if_needed(provider_id, app_type).await;
         } else {
             breaker.record_failure(used_half_open_permit).await;
         }
@@ -273,6 +231,66 @@ impl ProviderRouter {
         } else {
             None
         }
+    }
+
+    /// 检查是否需要触发自动回切并在后台执行
+    ///
+    /// 当当前使用 P2+，且 P1 熔断器已恢复为 Closed 时，
+    /// 异步触发切换到 P1。Failback 失败仅记录日志，不向上传播。
+    async fn trigger_failback_if_needed(&self, provider_id: &str, app_type: &str) {
+        let Some(ref mgr) = *self.failover_switch_manager.read().await else {
+            return;
+        };
+
+        let Ok(ordered_ids) = self.db.get_failover_queue(app_type) else {
+            log::warn!("[FO-BACK] 读取 failover_queue 失败，跳过本次回切");
+            return;
+        };
+        let Some(p1_id) = ordered_ids.first().map(|item| &item.provider_id) else {
+            return;
+        };
+
+        // 已在 P1，无需回切
+        if provider_id == p1_id {
+            return;
+        }
+
+        // 检查 P1 熔断器状态
+        let p1_circuit_key = format!("{app_type}:{p1_id}");
+        let p1_breaker = self.get_or_create_circuit_breaker(&p1_circuit_key).await;
+        if p1_breaker.get_state().await != CircuitState::Closed {
+            return;
+        }
+
+        let Ok(all) = self.db.get_all_providers(app_type) else {
+            log::warn!("[FO-BACK] 读取 providers 失败，跳过本次回切");
+            return;
+        };
+        let Some(p1) = all.get(p1_id) else {
+            return;
+        };
+
+        log::info!(
+            "[FO-BACK] P1 {} 恢复为 Closed（当前: {}），触发自动回切",
+            p1.name,
+            provider_id
+        );
+
+        let fm = mgr.clone();
+        let at = app_type.to_string();
+        let pid = p1.id.clone();
+        let pname = p1.name.clone();
+        tokio::spawn(async move {
+            match fm.try_switch(&at, &pid, &pname).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    log::debug!("[FO-BACK] 切换已跳过（可能在进行中或已就绪）");
+                }
+                Err(e) => {
+                    log::error!("[FO-BACK] try_switch 失败: {}", e);
+                }
+            }
+        });
     }
 
     /// 获取或创建熔断器

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -242,6 +242,18 @@ impl ProviderRouter {
             return;
         };
 
+        // [P1-A] 故障转移总开关关闭时跳过回切
+        let auto_failover_enabled = match self.db.get_proxy_config_for_app(app_type).await {
+            Ok(config) => config.auto_failover_enabled,
+            Err(_) => {
+                log::warn!("[FO-BACK] 读取 proxy_config 失败，跳过本次回切");
+                return;
+            }
+        };
+        if !auto_failover_enabled {
+            return;
+        }
+
         let Ok(ordered_ids) = self.db.get_failover_queue(app_type) else {
             log::warn!("[FO-BACK] 读取 failover_queue 失败，跳过本次回切");
             return;
@@ -258,7 +270,8 @@ impl ProviderRouter {
         // 检查 P1 熔断器状态
         let p1_circuit_key = format!("{app_type}:{p1_id}");
         let p1_breaker = self.get_or_create_circuit_breaker(&p1_circuit_key).await;
-        if p1_breaker.get_state().await != CircuitState::Closed {
+        // [P1-B] 必须同时满足：P1 从 Open/HalfOpen 恢复到 Closed（而非从未失败过）
+        if p1_breaker.get_state().await != CircuitState::Closed || !p1_breaker.has_been_open() {
             return;
         }
 

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -158,35 +158,43 @@ impl ProviderRouter {
             breaker.record_success(used_half_open_permit).await;
 
             // [FO-BACK] 自动回切：当前用的是 P2+，且 P1 已从熔断恢复
-            if let Some(ref mgr) = *self.failover_switch_manager.read().await {
-                let ordered_ids: Vec<String> = match self.db.get_failover_queue(app_type) {
-                    Ok(ids) => ids.into_iter().map(|item| item.provider_id).collect(),
-                    Err(_) => Vec::new(),
-                };
+            'failback: {
+                if let Some(ref mgr) = *self.failover_switch_manager.read().await {
+                    let ordered_ids: Vec<String> = match self.db.get_failover_queue(app_type) {
+                        Ok(ids) => ids.into_iter().map(|item| item.provider_id).collect(),
+                        Err(_) => Vec::new(),
+                    };
 
-                if let Some(p1_id) = ordered_ids.first() {
-                    if provider_id != *p1_id {
-                        // 当前不在 P1，检查 P1 是否已恢复为 Closed
-                        let p1_circuit_key = format!("{app_type}:{}", p1_id);
-                        let p1_breaker = self.get_or_create_circuit_breaker(&p1_circuit_key).await;
-                        if p1_breaker.get_state().await == CircuitState::Closed {
-                            let all = match self.db.get_all_providers(app_type) {
-                                Ok(p) => p,
-                                Err(_) => return Ok(()),
-                            };
-                            if let Some(p1) = all.get(p1_id) {
-                                log::info!(
-                                    "[FO-BACK] P1 {} 恢复为 Closed（当前: {}），触发自动回切",
-                                    p1.name,
-                                    provider_id
-                                );
-                                let fm = mgr.clone();
-                                let pid = p1.id.clone();
-                                let pname = p1.name.clone();
-                                let at = app_type.to_string();
-                                tokio::spawn(async move {
-                                    let _ = fm.try_switch(None, &at, &pid, &pname).await;
-                                });
+                    if let Some(p1_id) = ordered_ids.first() {
+                        if provider_id != *p1_id {
+                            // 当前不在 P1，检查 P1 是否已恢复为 Closed
+                            let p1_circuit_key = format!("{app_type}:{}", p1_id);
+                            let p1_breaker = self.get_or_create_circuit_breaker(&p1_circuit_key).await;
+                            if p1_breaker.get_state().await == CircuitState::Closed {
+                                let all = match self.db.get_all_providers(app_type) {
+                                    Ok(p) => p,
+                                    Err(e) => {
+                                        log::warn!(
+                                            "[FO-BACK] get_all_providers 失败，跳过本次回切: {}",
+                                            e
+                                        );
+                                        break 'failback;
+                                    }
+                                };
+                                if let Some(p1) = all.get(p1_id) {
+                                    log::info!(
+                                        "[FO-BACK] P1 {} 恢复为 Closed（当前: {}），触发自动回切",
+                                        p1.name,
+                                        provider_id
+                                    );
+                                    let fm = mgr.clone();
+                                    let pid = p1.id.clone();
+                                    let pname = p1.name.clone();
+                                    let at = app_type.to_string();
+                                    tokio::spawn(async move {
+                                        let _ = fm.try_switch(None, &at, &pid, &pname).await;
+                                    });
+                                }
                             }
                         }
                     }

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -846,7 +846,7 @@ mod tests {
             provider_router: Arc::new(ProviderRouter::new(db.clone())),
             gemini_shadow: Arc::new(GeminiShadowStore::default()),
             app_handle: None,
-            failover_manager: Arc::new(FailoverSwitchManager::new(db)),
+            failover_manager: Arc::new(FailoverSwitchManager::new(db, None)),
         }
     }
 

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -63,6 +63,8 @@ impl ProxyServer {
         let provider_router = Arc::new(ProviderRouter::new(db.clone()));
         // 创建故障转移切换管理器
         let failover_manager = Arc::new(FailoverSwitchManager::new(db.clone()));
+        // [FO-BACK] 注入回切管理器，使 record_result 能触发自动回切
+        provider_router.set_failover_switch_manager(failover_manager.clone());
 
         let state = ProxyState {
             db,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -51,6 +51,8 @@ pub struct ProxyServer {
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     /// 服务器任务句柄，用于等待服务器实际关闭
     server_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
+    /// failback manager 注入任务，等待完成后 proxy 才接受请求
+    pub settle_join: Option<JoinHandle<()>>,
 }
 
 impl ProxyServer {
@@ -63,8 +65,14 @@ impl ProxyServer {
         let provider_router = Arc::new(ProviderRouter::new(db.clone()));
         // 创建故障转移切换管理器
         let failover_manager = Arc::new(FailoverSwitchManager::new(db.clone(), app_handle.clone()));
-        // [FO-BACK] 注入回切管理器，使 record_result 能触发自动回切
-        provider_router.set_failover_switch_manager(failover_manager.clone());
+        // [FO-BACK] 异步注入回切管理器，写入完成后 caller 应 await settle_join
+        let provider_router_clone = provider_router.clone();
+        let failover_manager_clone = failover_manager.clone();
+        let settle_join = tokio::spawn(async move {
+            provider_router_clone
+                .set_failover_switch_manager(failover_manager_clone)
+                .await;
+        });
 
         let state = ProxyState {
             db,
@@ -83,6 +91,7 @@ impl ProxyServer {
             state,
             shutdown_tx: Arc::new(RwLock::new(None)),
             server_handle: Arc::new(RwLock::new(None)),
+            settle_join: Some(settle_join),
         }
     }
 

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -62,7 +62,7 @@ impl ProxyServer {
         // 创建共享的 ProviderRouter（熔断器状态将跨所有请求保持）
         let provider_router = Arc::new(ProviderRouter::new(db.clone()));
         // 创建故障转移切换管理器
-        let failover_manager = Arc::new(FailoverSwitchManager::new(db.clone()));
+        let failover_manager = Arc::new(FailoverSwitchManager::new(db.clone(), app_handle.clone()));
         // [FO-BACK] 注入回切管理器，使 record_result 能触发自动回切
         provider_router.set_failover_switch_manager(failover_manager.clone());
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -190,7 +190,8 @@ impl ProxyService {
 
         // 4. 创建并启动服务器
         let app_handle = self.app_handle.read().await.clone();
-        let server = ProxyServer::new(config.clone(), self.db.clone(), app_handle);
+        let mut server = ProxyServer::new(config.clone(), self.db.clone(), app_handle);
+        server.settle_join.take().unwrap().await;
         let info = server
             .start()
             .await
@@ -1881,7 +1882,8 @@ impl ProxyService {
             }
 
             let app_handle = self.app_handle.read().await.clone();
-            let new_server = ProxyServer::new(new_config, self.db.clone(), app_handle);
+            let mut new_server = ProxyServer::new(new_config.clone(), self.db.clone(), app_handle.clone());
+            new_server.settle_join.take().unwrap().await;
             new_server
                 .start()
                 .await


### PR DESCRIPTION
## Summary

当 P1 的 CircuitBreaker 从 Open 恢复到 Closed 时，自动将流量和 UI 状态回切到 P1。

### 修复内容（3 个 commit）

1. **Bot P1 review fix**: `FailoverSwitchManager` 存储 `AppHandle`，使 `do_switch` 能正常执行 UI 更新（AppState hot_switch、托盘菜单刷新、前端 `provider-switched` 事件）
2. **竞态条件修复**: `set_failover_switch_manager` 改为 async + `settle_join`，caller 必须 await 写入完成后才接受请求
3. **静默失败修复**: `try_switch` 结果用 `match` 分支处理，Err → `log::error`，避免吞错；`get_failover_queue`/`get_all_providers` 失败时加 warn 日志

### 测试

- 880 tests pass
- 构建通过

### Review 结果

第一轮发现 3 个 Critical 全部已修复：
- fire-and-forget 竞态 → settle_join await
- `let _ = fm.try_switch()` 吞错 → match 分支 + warn/error
- 空队列静默跳过 → warn 日志