### PR TITLE
fix: remove unsafe exec() in mod.rs

### DIFF
--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -246,7 +246,7 @@ fn launch_custom(
 
     let final_cmd_line = template
         .replace("{command}", cmd_str)
-        .replace("{cwd}", dir_str);
+        .replace("{cwd}", &shell_escape(dir_str));
 
     // Execute via sh -c
     let status = Command::new("sh")
@@ -272,8 +272,10 @@ fn build_shell_command(command: &str, cwd: Option<&str>) -> String {
 }
 
 fn shell_escape(value: &str) -> String {
-    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
-    format!("\"{escaped}\"")
+    // POSIX single-quote escaping: wrap in single quotes and replace any embedded
+    // single quote with '\''. This prevents all shell metacharacter expansion
+    // ($(), ``, $var, ;, &&, || etc.) regardless of shell implementation.
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn escape_osascript(value: &str) -> String {
@@ -333,6 +335,6 @@ mod tests {
         );
 
         // Verify shell_escape works correctly for paths with spaces
-        assert_eq!(shell_escape(cwd), "\"/tmp/project dir\"");
+        assert_eq!(shell_escape(cwd), "'/tmp/project dir'");
     }
 }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src-tauri/src/session_manager/mod.rs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src-tauri/src/session_manager/mod.rs:125` |

**Description**: The application constructs and executes shell commands for Claude terminal session restoration by incorporating a user-selected directory path (referenced in CHANGELOG.md:18). The session_manager/mod.rs backend builds these commands using string concatenation. If the directory path is not escaped before inclusion in the shell command string, an attacker can supply a path containing shell metacharacters (e.g., semicolons, backticks, dollar-sign subshells) to inject and execute arbitrary operating system commands with the full privileges of the logged-in user.

## Changes
- `src-tauri/src/session_manager/terminal/mod.rs`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
