### PR TITLE
fix: common config checkbox state not persisting for Codex/Claude/Gemini

### DIFF
--- a/src/components/providers/forms/hooks/useCodexCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useCodexCommonConfig.ts
@@ -160,9 +160,13 @@ export function useCodexCommonConfig({
       config,
       commonConfigSnippet,
     );
-    const hasCommon = initialEnabled ?? inferredHasCommon;
 
-    if (hasCommon && !inferredHasCommon) {
+    // 优先级：显式设置的 initialEnabled > 从配置推断的值
+    // 如果 initialEnabled 为 undefined，使用推断值
+    const hasCommon = initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
+
+    // 如果应该启用通用配置但配置中还没有，则自动添加
+    if (hasCommon && !inferredHasCommon && parsedSnippet.hasContent) {
       const { updatedConfig, error } = updateTomlCommonConfigSnippet(
         codexConfig,
         commonConfigSnippet,

--- a/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
@@ -118,17 +118,22 @@ export function useCommonConfigSnippet({
   // 初始化时检查通用配置片段（编辑模式）
   useEffect(() => {
     if (!enabled) return;
-    if (initialData && !isLoading) {
+    if (initialData && !isLoading && !hasInitializedEditMode.current) {
+      hasInitializedEditMode.current = true;
+
       const configString = JSON.stringify(initialData.settingsConfig, null, 2);
       const inferredHasCommon = hasCommonConfigSnippet(
         configString,
         commonConfigSnippet,
       );
-      const hasCommon = initialEnabled ?? inferredHasCommon;
+
+      // 优先级：显式设置的 initialEnabled > 从配置推断的值
+      // 如果 initialEnabled 为 undefined，使用推断值
+      const hasCommon = initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
       setUseCommonConfig(hasCommon);
 
-      if (hasCommon && !inferredHasCommon && !hasInitializedEditMode.current) {
-        hasInitializedEditMode.current = true;
+      // 如果应该启用通用配置但配置中还没有，则自动添加
+      if (hasCommon && !inferredHasCommon) {
         const { updatedConfig, error } = updateCommonConfigSnippet(
           settingsConfig,
           commonConfigSnippet,
@@ -141,8 +146,6 @@ export function useCommonConfigSnippet({
             isUpdatingFromCommonConfig.current = false;
           }, 0);
         }
-      } else {
-        hasInitializedEditMode.current = true;
       }
     }
   }, [

--- a/src/components/providers/forms/hooks/useGeminiCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useGeminiCommonConfig.ts
@@ -244,9 +244,13 @@ export function useGeminiCommonConfig({
         env,
         parsed.env as Record<string, string>,
       );
-      const hasCommon = initialEnabled ?? inferredHasCommon;
 
-      if (hasCommon && !inferredHasCommon) {
+      // 优先级：显式设置的 initialEnabled > 从配置推断的值
+      // 如果 initialEnabled 为 undefined，使用推断值
+      const hasCommon = initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
+
+      // 如果应该启用通用配置但配置中还没有，则自动添加
+      if (hasCommon && !inferredHasCommon && Object.keys(parsed.env).length > 0) {
         const currentEnv = envStringToObj(envValue);
         const merged = applySnippetToEnv(currentEnv, parsed.env);
         const nextEnvString = envObjToString(merged);


### PR DESCRIPTION
修复：Codex/Claude/Gemini 通用配置勾选状态无法正确保存的问题

## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
