### PR TITLE
fix(skills): prevent duplicate imports when import button is double-clicked

### DIFF
--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -447,6 +447,7 @@ const UnifiedSkillsPanel = React.forwardRef<
       {importDialogOpen && unmanagedSkills && (
         <ImportSkillsDialog
           skills={unmanagedSkills}
+          isImporting={importMutation.isPending}
           onImport={handleImport}
           onClose={() => setImportDialogOpen(false)}
         />
@@ -593,6 +594,7 @@ interface ImportSkillsDialogProps {
     foundIn: string[];
     path: string;
   }>;
+  isImporting: boolean;
   onImport: (imports: ImportSkillSelection[]) => void;
   onClose: () => void;
 }
@@ -717,6 +719,7 @@ const RestoreSkillsDialog: React.FC<RestoreSkillsDialogProps> = ({
 
 const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
   skills,
+  isImporting,
   onImport,
   onClose,
 }) => {
@@ -835,10 +838,13 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
           </div>
 
           <div className="flex justify-end gap-3">
-            <Button variant="outline" onClick={onClose}>
+            <Button variant="outline" onClick={onClose} disabled={isImporting}>
               {t("common.cancel")}
             </Button>
-            <Button onClick={handleImport} disabled={selected.size === 0}>
+            <Button
+              onClick={handleImport}
+              disabled={selected.size === 0 || isImporting}
+            >
               {t("skills.importSelected", { count: selected.size })}
             </Button>
           </div>

--- a/src/hooks/useSkills.helpers.ts
+++ b/src/hooks/useSkills.helpers.ts
@@ -1,0 +1,19 @@
+import type { InstalledSkill } from "@/lib/api/skills";
+
+/**
+ * 合并本次导入结果到已安装缓存，按 id 去重。
+ *
+ * 同一技能重复出现时以新记录为准，避免 mutation 被重复触发时
+ * 在 installed 列表中看到重复条目。imported 为空时返回原引用，
+ * 让 React Query 跳过无谓的订阅者通知。
+ */
+export function mergeImportedSkills(
+  existing: InstalledSkill[] | undefined,
+  imported: InstalledSkill[],
+): InstalledSkill[] {
+  if (!existing) return imported;
+  if (imported.length === 0) return existing;
+  const importedIds = new Set(imported.map((s) => s.id));
+  const preserved = existing.filter((s) => !importedIds.has(s.id));
+  return [...preserved, ...imported];
+}

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -14,6 +14,7 @@ import {
   type SkillsShSearchResult,
 } from "@/lib/api/skills";
 import type { AppId } from "@/lib/api/types";
+import { mergeImportedSkills } from "@/hooks/useSkills.helpers";
 
 /**
  * 查询所有已安装的 Skills
@@ -208,10 +209,7 @@ export function useImportSkillsFromApps() {
       // 直接更新 installed 缓存
       queryClient.setQueryData<InstalledSkill[]>(
         ["skills", "installed"],
-        (oldData) => {
-          if (!oldData) return importedSkills;
-          return [...oldData, ...importedSkills];
-        },
+        (oldData) => mergeImportedSkills(oldData, importedSkills),
       );
       // 刷新 unmanaged 列表（已被导入的应该移除）
       queryClient.invalidateQueries({ queryKey: ["skills", "unmanaged"] });

--- a/tests/hooks/useImportSkillsFromApps.test.tsx
+++ b/tests/hooks/useImportSkillsFromApps.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { mergeImportedSkills } from "@/hooks/useSkills.helpers";
+import type { InstalledSkill } from "@/lib/api/skills";
+
+function makeSkill(overrides: Partial<InstalledSkill> = {}): InstalledSkill {
+  return {
+    id: "skill-a",
+    name: "Skill A",
+    directory: "skill-a",
+    apps: {
+      claude: true,
+      codex: false,
+      gemini: false,
+      opencode: false,
+      openclaw: false,
+    },
+    installedAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+// Regression coverage for issue #2139: when a user double-clicks the import
+// button (or the mutation otherwise fires twice with the same payload), the
+// installed cache must not accumulate duplicate entries for the same skill.
+describe("mergeImportedSkills", () => {
+  it("returns the imported list as-is when no cache exists yet", () => {
+    const imported = [makeSkill()];
+    expect(mergeImportedSkills(undefined, imported)).toEqual(imported);
+  });
+
+  it("dedupes by id when the same skill is imported twice in a row", () => {
+    const existing = [makeSkill()];
+    const secondImport = [makeSkill()];
+    const merged = mergeImportedSkills(existing, secondImport);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toBe(secondImport[0]);
+  });
+
+  it("replaces stale cache entries with fresh imports for the same id", () => {
+    const stale = [makeSkill({ name: "Stale Name" })];
+    const fresh = [makeSkill({ name: "Fresh Name" })];
+    const merged = mergeImportedSkills(stale, fresh);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].name).toBe("Fresh Name");
+  });
+
+  it("returns the existing reference unchanged when the imported list is empty", () => {
+    const existing = [makeSkill()];
+    expect(mergeImportedSkills(existing, [])).toBe(existing);
+  });
+
+  it("appends newly imported skills without dropping existing unrelated ones", () => {
+    const existing = [makeSkill({ id: "skill-a", directory: "skill-a" })];
+    const imported = [
+      makeSkill({ id: "skill-b", directory: "skill-b", name: "Skill B" }),
+    ];
+    const merged = mergeImportedSkills(existing, imported);
+    expect(merged.map((s) => s.id).sort()).toEqual(["skill-a", "skill-b"]);
+  });
+});


### PR DESCRIPTION
## Summary / 概述

When a user taps the "Import" confirm button multiple times in the Skills import dialog — either deliberately or because the UI lags while importing many skills — the installed-skills count balloons to a multiple of the real count.

Two related defects combined to produce this:

1. **The confirm button stayed clickable during a pending mutation.** It only checked `selected.size === 0`, so every extra tap fired another `importFromApps` mutation.
2. **`useImportSkillsFromApps` appended results to the installed cache without deduping.** Re-firing the mutation stacked the same skills into the list.

### Changes

- `ImportSkillsDialog` gains an `isImporting` prop; the Import and Cancel buttons are disabled while the mutation is pending. This follows the `isRestoring` / `isDeleting` pattern already used by `RestoreSkillsDialog` in the same file.
- Cache-merge logic is extracted as a pure function `mergeImportedSkills(existing, imported)` in a new `src/hooks/useSkills.helpers.ts` so it can be unit-tested without React / React Query setup. It dedupes by `InstalledSkill.id` (newer entries replace stale ones) and short-circuits to the original reference when `imported` is empty so React Query does not notify subscribers about a no-op update.
- Unit tests cover empty cache, re-import of the same id, stale replacement, empty-payload reference stability, and unrelated appends.

### Scope

Only `useImportSkillsFromApps` is touched here. `useInstallSkill` and `useInstallSkillsFromZip` also perform naive cache appends but are not reachable from a dialog double-click in the same way, and changing them is out of scope for this fix — happy to open a follow-up if desired.

## Related Issue / 关联 Issue

Fixes #2139

## Screenshots / 截图

N/A — the behaviour change is functional. Reproduction steps and root cause are documented in the linked issue; after the fix the confirm button goes disabled on first click and the installed count matches the imported count regardless of how many times the button is tapped.

## Checklist / 检查清单

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm format:check\` passes for the files touched in this PR (three pre-existing warnings in \`src/components/providers/forms/hooks/*\` are unchanged and not in scope)
- [ ] \`cargo clippy\` — N/A, no Rust changes
- [x] i18n — no new user-facing strings