### PR TITLE
feat(proxy): add per-app usage stats source for takeover mode

### DIFF
--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -188,39 +188,11 @@ pub fn delete_model_pricing(state: State<'_, AppState>, model_id: String) -> Res
 
 /// 手动触发会话日志同步
 #[tauri::command]
-pub fn sync_session_usage(
+pub async fn sync_session_usage(
     state: State<'_, AppState>,
 ) -> Result<crate::services::session_usage::SessionSyncResult, AppError> {
-    // 同步 Claude 会话日志
-    let mut result = crate::services::session_usage::sync_claude_session_logs(&state.db)?;
-
-    // 同步 Codex 使用数据
-    match crate::services::session_usage_codex::sync_codex_usage(&state.db) {
-        Ok(codex_result) => {
-            result.imported += codex_result.imported;
-            result.skipped += codex_result.skipped;
-            result.files_scanned += codex_result.files_scanned;
-            result.errors.extend(codex_result.errors);
-        }
-        Err(e) => {
-            result.errors.push(format!("Codex 同步失败: {e}"));
-        }
-    }
-
-    // 同步 Gemini 使用数据
-    match crate::services::session_usage_gemini::sync_gemini_usage(&state.db) {
-        Ok(gemini_result) => {
-            result.imported += gemini_result.imported;
-            result.skipped += gemini_result.skipped;
-            result.files_scanned += gemini_result.files_scanned;
-            result.errors.extend(gemini_result.errors);
-        }
-        Err(e) => {
-            result.errors.push(format!("Gemini 同步失败: {e}"));
-        }
-    }
-
-    Ok(result)
+    crate::services::usage_source::sync_session_usage_by_policy(&state.db, &state.proxy_service)
+        .await
 }
 
 /// 获取数据来源分布

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -197,7 +197,7 @@ impl Database {
         let result = {
             let conn = lock_conn!(self.conn);
             conn.query_row(
-                "SELECT app_type, enabled, auto_failover_enabled,
+                "SELECT app_type, enabled, auto_failover_enabled, usage_stats_source,
                         max_retries, streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
                         circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
                         circuit_error_rate_threshold, circuit_min_requests
@@ -208,15 +208,18 @@ impl Database {
                         app_type: row.get(0)?,
                         enabled: row.get::<_, i32>(1)? != 0,
                         auto_failover_enabled: row.get::<_, i32>(2)? != 0,
-                        max_retries: row.get::<_, i32>(3)? as u32,
-                        streaming_first_byte_timeout: row.get::<_, i32>(4)? as u32,
-                        streaming_idle_timeout: row.get::<_, i32>(5)? as u32,
-                        non_streaming_timeout: row.get::<_, i32>(6)? as u32,
-                        circuit_failure_threshold: row.get::<_, i32>(7)? as u32,
-                        circuit_success_threshold: row.get::<_, i32>(8)? as u32,
-                        circuit_timeout_seconds: row.get::<_, i32>(9)? as u32,
-                        circuit_error_rate_threshold: row.get(10)?,
-                        circuit_min_requests: row.get::<_, i32>(11)? as u32,
+                        usage_stats_source: UsageStatsSource::from_db_value(
+                            &row.get::<_, String>(3)?,
+                        ),
+                        max_retries: row.get::<_, i32>(4)? as u32,
+                        streaming_first_byte_timeout: row.get::<_, i32>(5)? as u32,
+                        streaming_idle_timeout: row.get::<_, i32>(6)? as u32,
+                        non_streaming_timeout: row.get::<_, i32>(7)? as u32,
+                        circuit_failure_threshold: row.get::<_, i32>(8)? as u32,
+                        circuit_success_threshold: row.get::<_, i32>(9)? as u32,
+                        circuit_timeout_seconds: row.get::<_, i32>(10)? as u32,
+                        circuit_error_rate_threshold: row.get(11)?,
+                        circuit_min_requests: row.get::<_, i32>(12)? as u32,
                     })
                 },
             )
@@ -232,6 +235,7 @@ impl Database {
                     app_type: app_type_owned,
                     enabled: false,
                     auto_failover_enabled: false,
+                    usage_stats_source: UsageStatsSource::Proxy,
                     max_retries: 3,
                     streaming_first_byte_timeout: 60,
                     streaming_idle_timeout: 120,
@@ -258,21 +262,23 @@ impl Database {
             "UPDATE proxy_config SET
                 enabled = ?2,
                 auto_failover_enabled = ?3,
-                max_retries = ?4,
-                streaming_first_byte_timeout = ?5,
-                streaming_idle_timeout = ?6,
-                non_streaming_timeout = ?7,
-                circuit_failure_threshold = ?8,
-                circuit_success_threshold = ?9,
-                circuit_timeout_seconds = ?10,
-                circuit_error_rate_threshold = ?11,
-                circuit_min_requests = ?12,
+                usage_stats_source = ?4,
+                max_retries = ?5,
+                streaming_first_byte_timeout = ?6,
+                streaming_idle_timeout = ?7,
+                non_streaming_timeout = ?8,
+                circuit_failure_threshold = ?9,
+                circuit_success_threshold = ?10,
+                circuit_timeout_seconds = ?11,
+                circuit_error_rate_threshold = ?12,
+                circuit_min_requests = ?13,
                 updated_at = datetime('now')
              WHERE app_type = ?1",
             rusqlite::params![
                 config.app_type,
                 if config.enabled { 1 } else { 0 },
                 if config.auto_failover_enabled { 1 } else { 0 },
+                config.usage_stats_source.as_db_value(),
                 config.max_retries as i32,
                 config.streaming_first_byte_timeout as i32,
                 config.streaming_idle_timeout as i32,
@@ -820,6 +826,22 @@ impl Database {
         .unwrap_or((false, false))
     }
 
+    /// 同步获取应用的用量统计来源
+    pub fn get_usage_stats_source_sync(&self, app_type: &str) -> UsageStatsSource {
+        let conn = match self.conn.lock() {
+            Ok(c) => c,
+            Err(_) => return UsageStatsSource::Proxy,
+        };
+
+        conn.query_row(
+            "SELECT usage_stats_source FROM proxy_config WHERE app_type = ?1",
+            [app_type],
+            |row| row.get::<_, String>(0),
+        )
+        .map(|value| UsageStatsSource::from_db_value(&value))
+        .unwrap_or(UsageStatsSource::Proxy)
+    }
+
     /// 同步设置应用的 proxy 启用状态和自动故障转移状态
     ///
     /// 用于托盘菜单点击等同步场景
@@ -852,6 +874,7 @@ impl Database {
 mod tests {
     use crate::database::Database;
     use crate::error::AppError;
+    use crate::proxy::types::UsageStatsSource;
 
     #[tokio::test]
     async fn test_default_cost_multiplier_round_trip() -> Result<(), AppError> {
@@ -910,6 +933,27 @@ mod tests {
                 ..
             }
         ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_usage_stats_source_round_trip() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        let default = db.get_proxy_config_for_app("claude").await?;
+        assert_eq!(default.usage_stats_source, UsageStatsSource::Proxy);
+
+        let mut updated = default.clone();
+        updated.usage_stats_source = UsageStatsSource::Session;
+        db.update_proxy_config_for_app(updated).await?;
+
+        let saved = db.get_proxy_config_for_app("claude").await?;
+        assert_eq!(saved.usage_stats_source, UsageStatsSource::Session);
+        assert_eq!(
+            db.get_usage_stats_source_sync("claude"),
+            UsageStatsSource::Session
+        );
 
         Ok(())
     }

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -939,6 +939,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_usage_stats_source_round_trip() -> Result<(), AppError> {
+        // 新增的 usage source 列应默认是 proxy，并能正确完成读写往返。
         let db = Database::memory()?;
 
         let default = db.get_proxy_config_for_app("claude").await?;

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -44,7 +44,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 9;
+pub(crate) const SCHEMA_VERSION: i32 = 10;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -124,6 +124,7 @@ impl Database {
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 15721, enable_logging INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
+            usage_stats_source TEXT NOT NULL DEFAULT 'proxy' CHECK (usage_stats_source IN ('proxy','session')),
             max_retries INTEGER NOT NULL DEFAULT 3, streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60,
             streaming_idle_timeout INTEGER NOT NULL DEFAULT 120, non_streaming_timeout INTEGER NOT NULL DEFAULT 600,
             circuit_failure_threshold INTEGER NOT NULL DEFAULT 4, circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
@@ -422,6 +423,11 @@ impl Database {
                         log::info!("迁移数据库从 v8 到 v9（全面补充模型定价）");
                         Self::migrate_v8_to_v9(conn)?;
                         Self::set_user_version(conn, 9)?;
+                    }
+                    9 => {
+                        log::info!("迁移数据库从 v9 到 v10（代理接管用量来源配置）");
+                        Self::migrate_v9_to_v10(conn)?;
+                        Self::set_user_version(conn, 10)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -744,6 +750,7 @@ impl Database {
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 15721, enable_logging INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
+            usage_stats_source TEXT NOT NULL DEFAULT 'proxy' CHECK (usage_stats_source IN ('proxy','session')),
             max_retries INTEGER NOT NULL DEFAULT 3, streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60,
             streaming_idle_timeout INTEGER NOT NULL DEFAULT 120, non_streaming_timeout INTEGER NOT NULL DEFAULT 600,
             circuit_failure_threshold INTEGER NOT NULL DEFAULT 4, circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
@@ -1165,6 +1172,21 @@ impl Database {
             .map_err(|e| AppError::Database(format!("清空模型定价失败: {e}")))?;
         Self::seed_model_pricing(conn)?;
         log::info!("v8 -> v9 迁移完成：已刷新全部模型定价数据");
+        Ok(())
+    }
+
+    /// v9 -> v10: 代理接管时的用量统计来源配置
+    fn migrate_v9_to_v10(conn: &Connection) -> Result<(), AppError> {
+        if Self::table_exists(conn, "proxy_config")? {
+            Self::add_column_if_missing(
+                conn,
+                "proxy_config",
+                "usage_stats_source",
+                "TEXT NOT NULL DEFAULT 'proxy'",
+            )?;
+        }
+
+        log::info!("v9 -> v10 迁移完成：已添加 usage_stats_source 列");
         Ok(())
     }
 

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -363,6 +363,7 @@ fn schema_migration_v4_adds_pricing_model_columns() {
 
 #[test]
 fn schema_migration_v9_adds_usage_stats_source_column() {
+    // 从 v9 旧库升级后，应补齐 usage source 列，且默认值为 proxy。
     let conn = Connection::open_in_memory().expect("open memory db");
     conn.execute_batch(
         r#"

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -286,6 +286,14 @@ fn schema_create_tables_include_pricing_model_columns() {
         Some("response")
     );
 
+    let usage_source = get_column_info(&conn, "proxy_config", "usage_stats_source");
+    assert_eq!(usage_source.r#type, "TEXT");
+    assert_eq!(usage_source.notnull, 1);
+    assert_eq!(
+        normalize_default(&usage_source.default).as_deref(),
+        Some("proxy")
+    );
+
     let request_model = get_column_info(&conn, "proxy_request_logs", "request_model");
     assert_eq!(request_model.r#type, "TEXT");
     assert_eq!(request_model.notnull, 0);
@@ -335,6 +343,14 @@ fn schema_migration_v4_adds_pricing_model_columns() {
         Some("response")
     );
 
+    let usage_source = get_column_info(&conn, "proxy_config", "usage_stats_source");
+    assert_eq!(usage_source.r#type, "TEXT");
+    assert_eq!(usage_source.notnull, 1);
+    assert_eq!(
+        normalize_default(&usage_source.default).as_deref(),
+        Some("proxy")
+    );
+
     let request_model = get_column_info(&conn, "proxy_request_logs", "request_model");
     assert_eq!(request_model.r#type, "TEXT");
     assert_eq!(request_model.notnull, 0);
@@ -342,6 +358,52 @@ fn schema_migration_v4_adds_pricing_model_columns() {
     assert_eq!(
         Database::get_user_version(&conn).expect("version after migration"),
         SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn schema_migration_v9_adds_usage_stats_source_column() {
+    let conn = Connection::open_in_memory().expect("open memory db");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE proxy_config (
+            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','gemini')),
+            proxy_enabled INTEGER NOT NULL DEFAULT 0,
+            listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
+            listen_port INTEGER NOT NULL DEFAULT 15721,
+            enable_logging INTEGER NOT NULL DEFAULT 1,
+            enabled INTEGER NOT NULL DEFAULT 0,
+            auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
+            max_retries INTEGER NOT NULL DEFAULT 3,
+            streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60,
+            streaming_idle_timeout INTEGER NOT NULL DEFAULT 120,
+            non_streaming_timeout INTEGER NOT NULL DEFAULT 600,
+            circuit_failure_threshold INTEGER NOT NULL DEFAULT 4,
+            circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
+            circuit_timeout_seconds INTEGER NOT NULL DEFAULT 60,
+            circuit_error_rate_threshold REAL NOT NULL DEFAULT 0.6,
+            circuit_min_requests INTEGER NOT NULL DEFAULT 10,
+            default_cost_multiplier TEXT NOT NULL DEFAULT '1',
+            pricing_model_source TEXT NOT NULL DEFAULT 'response',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO proxy_config (app_type) VALUES ('claude');
+        INSERT INTO proxy_config (app_type) VALUES ('codex');
+        INSERT INTO proxy_config (app_type) VALUES ('gemini');
+        "#,
+    )
+    .expect("seed v9 schema");
+
+    Database::set_user_version(&conn, 9).expect("set user_version=9");
+    Database::apply_schema_migrations_on_conn(&conn).expect("apply migrations");
+
+    let usage_source = get_column_info(&conn, "proxy_config", "usage_stats_source");
+    assert_eq!(usage_source.r#type, "TEXT");
+    assert_eq!(usage_source.notnull, 1);
+    assert_eq!(
+        normalize_default(&usage_source.default).as_deref(),
+        Some("proxy")
     );
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -895,30 +895,18 @@ pub fn run() {
 
                 // Session log usage sync: 启动时同步一次，之后每 60 秒检查
                 let db_for_session_sync = state.db.clone();
+                let proxy_service_for_session_sync = state.proxy_service.clone();
                 tauri::async_runtime::spawn(async move {
                     const SESSION_SYNC_INTERVAL_SECS: u64 = 60;
 
                     // 首次同步
-                    if let Err(e) =
-                        crate::services::session_usage::sync_claude_session_logs(
-                            &db_for_session_sync,
-                        )
+                    if let Err(e) = crate::services::usage_source::sync_session_usage_by_policy(
+                        &db_for_session_sync,
+                        &proxy_service_for_session_sync,
+                    )
+                    .await
                     {
                         log::warn!("Session usage initial sync failed: {e}");
-                    }
-                    if let Err(e) =
-                        crate::services::session_usage_codex::sync_codex_usage(
-                            &db_for_session_sync,
-                        )
-                    {
-                        log::warn!("Codex usage initial sync failed: {e}");
-                    }
-                    if let Err(e) =
-                        crate::services::session_usage_gemini::sync_gemini_usage(
-                            &db_for_session_sync,
-                        )
-                    {
-                        log::warn!("Gemini usage initial sync failed: {e}");
                     }
 
                     // 定期同步
@@ -929,25 +917,13 @@ pub fn run() {
                     loop {
                         interval.tick().await;
                         if let Err(e) =
-                            crate::services::session_usage::sync_claude_session_logs(
+                            crate::services::usage_source::sync_session_usage_by_policy(
                                 &db_for_session_sync,
+                                &proxy_service_for_session_sync,
                             )
+                            .await
                         {
                             log::warn!("Session usage periodic sync failed: {e}");
-                        }
-                        if let Err(e) =
-                            crate::services::session_usage_codex::sync_codex_usage(
-                                &db_for_session_sync,
-                            )
-                        {
-                            log::warn!("Codex usage periodic sync failed: {e}");
-                        }
-                        if let Err(e) =
-                            crate::services::session_usage_gemini::sync_gemini_usage(
-                                &db_for_session_sync,
-                            )
-                        {
-                            log::warn!("Gemini usage periodic sync failed: {e}");
                         }
                     }
                 });

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -573,8 +573,8 @@ fn log_forward_error(
 ) {
     use super::usage::logger::UsageLogger;
 
-    let (takeover_enabled, _) = state.db.get_proxy_flags_sync(&ctx.app_type_str);
-    let usage_source = state.db.get_usage_stats_source_sync(&ctx.app_type_str);
+    let (takeover_enabled, _) = state.db.get_proxy_flags_sync(ctx.app_type_str);
+    let usage_source = state.db.get_usage_stats_source_sync(ctx.app_type_str);
     if takeover_enabled && usage_source == crate::proxy::types::UsageStatsSource::Session {
         log::debug!(
             "[{}] 已切换为 Session 用量来源，跳过代理失败请求日志写入",

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -573,6 +573,16 @@ fn log_forward_error(
 ) {
     use super::usage::logger::UsageLogger;
 
+    let (takeover_enabled, _) = state.db.get_proxy_flags_sync(&ctx.app_type_str);
+    let usage_source = state.db.get_usage_stats_source_sync(&ctx.app_type_str);
+    if takeover_enabled && usage_source == crate::proxy::types::UsageStatsSource::Session {
+        log::debug!(
+            "[{}] 已切换为 Session 用量来源，跳过代理失败请求日志写入",
+            ctx.app_type_str
+        );
+        return;
+    }
+
     let logger = UsageLogger::new(&state.db);
     let status_code = map_proxy_error_to_status(error);
     let error_message = get_error_message(error);
@@ -609,6 +619,17 @@ async fn log_usage(
     status_code: u16,
 ) {
     use super::usage::logger::UsageLogger;
+
+    match crate::services::usage_source::should_record_proxy_usage(&state.db, app_type).await {
+        Ok(false) => {
+            log::debug!("[{app_type}] 已切换为 Session 用量来源，跳过代理请求日志写入");
+            return;
+        }
+        Err(e) => {
+            log::warn!("[{app_type}] 解析用量来源策略失败，继续写入代理请求日志: {e}");
+        }
+        Ok(true) => {}
+    }
 
     let logger = UsageLogger::new(&state.db);
 

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -1019,6 +1019,7 @@ mod tests {
     #[tokio::test]
     async fn test_log_usage_skips_proxy_write_when_session_source_selected() -> Result<(), AppError>
     {
+        // 接管后若选择 Session 日志统计，则代理响应侧不应再写入用量记录。
         let db = Arc::new(Database::memory()?);
         let app_type = "claude";
 

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -558,6 +558,17 @@ async fn log_usage_internal(
 ) {
     use super::usage::logger::UsageLogger;
 
+    match crate::services::usage_source::should_record_proxy_usage(&state.db, app_type).await {
+        Ok(false) => {
+            log::debug!("[{app_type}] 已切换为 Session 用量来源，跳过代理请求日志写入");
+            return;
+        }
+        Err(e) => {
+            log::warn!("[{app_type}] 解析用量来源策略失败，继续写入代理请求日志: {e}");
+        }
+        Ok(true) => {}
+    }
+
     let logger = UsageLogger::new(&state.db);
     let (multiplier, pricing_model_source) =
         logger.resolve_pricing_config(provider_id, app_type).await;

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -1015,4 +1015,60 @@ mod tests {
         );
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_log_usage_skips_proxy_write_when_session_source_selected() -> Result<(), AppError>
+    {
+        let db = Arc::new(Database::memory()?);
+        let app_type = "claude";
+
+        let mut config = db.get_proxy_config_for_app(app_type).await?;
+        config.enabled = true;
+        config.usage_stats_source = crate::proxy::types::UsageStatsSource::Session;
+        db.update_proxy_config_for_app(config).await?;
+
+        db.set_default_cost_multiplier(app_type, "1.5").await?;
+        db.set_pricing_model_source(app_type, "response").await?;
+        seed_pricing(&db)?;
+
+        let meta = ProviderMeta::default();
+        insert_provider(&db, "provider-3", app_type, meta)?;
+
+        let state = build_state(db.clone());
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            model: None,
+            message_id: None,
+        };
+
+        log_usage_internal(
+            &state,
+            "provider-3",
+            app_type,
+            "resp-model",
+            "req-model",
+            usage,
+            10,
+            None,
+            false,
+            200,
+            None,
+        )
+        .await;
+
+        let conn = crate::database::lock_conn!(db.conn);
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM proxy_request_logs WHERE provider_id = ?1",
+                ["provider-3"],
+                |row| row.get(0),
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        assert_eq!(count, 0);
+
+        Ok(())
+    }
 }

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -164,6 +164,31 @@ pub struct GlobalProxyConfig {
     pub enable_logging: bool,
 }
 
+/// 用量统计来源
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum UsageStatsSource {
+    #[default]
+    Proxy,
+    Session,
+}
+
+impl UsageStatsSource {
+    pub fn from_db_value(value: &str) -> Self {
+        match value {
+            "session" => Self::Session,
+            _ => Self::Proxy,
+        }
+    }
+
+    pub fn as_db_value(self) -> &'static str {
+        match self {
+            Self::Proxy => "proxy",
+            Self::Session => "session",
+        }
+    }
+}
+
 /// 应用级代理配置（每个 app 独立）
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -174,6 +199,9 @@ pub struct AppProxyConfig {
     pub enabled: bool,
     /// 该 app 自动故障转移开关
     pub auto_failover_enabled: bool,
+    /// 该 app 在代理接管时的用量统计来源
+    #[serde(default)]
+    pub usage_stats_source: UsageStatsSource,
     /// 最大重试次数
     pub max_retries: u32,
     /// 流式首字超时（秒）

--- a/src-tauri/src/proxy/usage/logger.rs
+++ b/src-tauri/src/proxy/usage/logger.rs
@@ -78,8 +78,8 @@ impl<'a> UsageLogger<'a> {
                 input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
                 input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd, total_cost_usd,
                 latency_ms, first_token_ms, status_code, error_message, session_id,
-                provider_type, is_streaming, cost_multiplier, created_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)",
+                provider_type, is_streaming, cost_multiplier, created_at, data_source
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)",
             rusqlite::params![
                 log.request_id,
                 log.provider_id,
@@ -104,6 +104,7 @@ impl<'a> UsageLogger<'a> {
                 log.is_streaming as i64,
                 log.cost_multiplier,
                 created_at,
+                "proxy",
             ],
         )
         .map_err(|e| AppError::Database(format!("记录请求日志失败: {e}")))?;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod skill;
 pub mod speedtest;
 pub mod stream_check;
 pub mod subscription;
+pub mod usage_source;
 pub mod usage_stats;
 pub mod webdav;
 pub mod webdav_auto_sync;

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -55,11 +55,6 @@ struct ParsedAssistantUsage {
 }
 
 /// 同步 Claude Code 会话日志到使用统计数据库
-pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppError> {
-    sync_claude_session_logs_with_mode(db, true)
-}
-
-/// 同步 Claude Code 会话日志到使用统计数据库
 ///
 /// 当 `record_usage=false` 时，仅推进同步游标，不写入请求日志。
 pub fn sync_claude_session_logs_with_mode(

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -56,6 +56,16 @@ struct ParsedAssistantUsage {
 
 /// 同步 Claude Code 会话日志到使用统计数据库
 pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_claude_session_logs_with_mode(db, true)
+}
+
+/// 同步 Claude Code 会话日志到使用统计数据库
+///
+/// 当 `record_usage=false` 时，仅推进同步游标，不写入请求日志。
+pub fn sync_claude_session_logs_with_mode(
+    db: &Database,
+    record_usage: bool,
+) -> Result<SessionSyncResult, AppError> {
     let projects_dir = get_claude_config_dir().join("projects");
     if !projects_dir.exists() {
         return Ok(SessionSyncResult {
@@ -79,7 +89,7 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
     for file_path in &jsonl_files {
         result.files_scanned += 1;
 
-        match sync_single_file(db, file_path) {
+        match sync_single_file(db, file_path, record_usage) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -133,7 +143,11 @@ fn collect_jsonl_files(projects_dir: &Path) -> Vec<PathBuf> {
 }
 
 /// 同步单个 JSONL 文件，返回 (imported, skipped)
-fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+fn sync_single_file(
+    db: &Database,
+    file_path: &Path,
+    record_usage: bool,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
     // 获取文件元数据
@@ -272,29 +286,31 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
     let mut imported: u32 = 0;
     let mut skipped: u32 = 0;
 
-    for msg in messages.values() {
-        // 只导入有 stop_reason 的最终条目（完整的 API 调用）
-        if msg.stop_reason.is_none() {
-            continue;
-        }
+    if record_usage {
+        for msg in messages.values() {
+            // 只导入有 stop_reason 的最终条目（完整的 API 调用）
+            if msg.stop_reason.is_none() {
+                continue;
+            }
 
-        let request_id = format!(
-            "{}{}",
-            crate::proxy::usage::parser::SESSION_REQUEST_ID_PREFIX,
-            msg.message_id
-        );
+            let request_id = format!(
+                "{}{}",
+                crate::proxy::usage::parser::SESSION_REQUEST_ID_PREFIX,
+                msg.message_id
+            );
 
-        // 跳过 output_tokens 为 0 的无意义条目
-        if msg.output_tokens == 0 {
-            continue;
-        }
+            // 跳过 output_tokens 为 0 的无意义条目
+            if msg.output_tokens == 0 {
+                continue;
+            }
 
-        match insert_session_log_entry(db, &request_id, msg) {
-            Ok(true) => imported += 1,
-            Ok(false) => skipped += 1,
-            Err(e) => {
-                log::warn!("[SESSION-SYNC] 插入失败 ({}): {e}", msg.message_id);
-                skipped += 1;
+            match insert_session_log_entry(db, &request_id, msg) {
+                Ok(true) => imported += 1,
+                Ok(false) => skipped += 1,
+                Err(e) => {
+                    log::warn!("[SESSION-SYNC] 插入失败 ({}): {e}", msg.message_id);
+                    skipped += 1;
+                }
             }
         }
     }
@@ -558,6 +574,7 @@ pub fn get_data_source_breakdown(db: &Database) -> Result<Vec<DataSourceSummary>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn test_parse_usage_from_jsonl_line() {
@@ -635,5 +652,42 @@ mod tests {
 
         messages.insert("msg_1".to_string(), final_entry);
         assert_eq!(messages.get("msg_1").unwrap().output_tokens, 1349);
+    }
+
+    #[test]
+    fn test_sync_single_file_can_advance_cursor_without_recording() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":12,\"output_tokens\":6},\"stop_reason\":\"end_turn\"},\"timestamp\":\"2026-04-05T12:00:00Z\",\"sessionId\":\"session-1\"}\n",
+                "{\"type\":\"assistant\",\"message\":{\"id\":\"msg_2\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":8,\"output_tokens\":4},\"stop_reason\":\"end_turn\"},\"timestamp\":\"2026-04-05T12:01:00Z\",\"sessionId\":\"session-1\"}\n"
+            ),
+        )
+        .expect("write session log");
+
+        let db = Database::memory().expect("db");
+        let (imported, skipped) =
+            sync_single_file(&db, &path, false).expect("sync without recording");
+        assert_eq!(imported, 0);
+        assert_eq!(skipped, 0);
+
+        let conn = db.conn.lock().expect("lock conn");
+        let sync_offset: i64 = conn
+            .query_row(
+                "SELECT last_line_offset FROM session_log_sync WHERE file_path = ?1",
+                rusqlite::params![path.to_string_lossy().to_string()],
+                |row| row.get(0),
+            )
+            .expect("read sync offset");
+        assert_eq!(sync_offset, 2);
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM proxy_request_logs", [], |row| {
+                row.get(0)
+            })
+            .expect("count logs");
+        assert_eq!(count, 0);
     }
 }

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -651,6 +651,7 @@ mod tests {
 
     #[test]
     fn test_sync_single_file_can_advance_cursor_without_recording() {
+        // record_usage=false 时，只推进文件游标，不写入用量记录。
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("session.jsonl");
         std::fs::write(

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -826,6 +826,7 @@ mod tests {
 
     #[test]
     fn test_sync_single_codex_file_can_advance_cursor_without_recording() {
+        // Codex 同步在关闭用量写入时，也应正常持久化文件游标。
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("codex.jsonl");
         std::fs::write(

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -140,6 +140,16 @@ fn parse_cumulative_tokens(total_usage: &serde_json::Value) -> Option<Cumulative
 
 /// 同步 Codex 使用数据（从 JSONL 会话日志）
 pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_codex_usage_with_mode(db, true)
+}
+
+/// 同步 Codex 使用数据（从 JSONL 会话日志）
+///
+/// 当 `record_usage=false` 时，仅推进同步游标和增量状态，不写入请求日志。
+pub fn sync_codex_usage_with_mode(
+    db: &Database,
+    record_usage: bool,
+) -> Result<SessionSyncResult, AppError> {
     let codex_dir = get_codex_config_dir();
 
     let files = collect_codex_session_files(&codex_dir);
@@ -156,7 +166,7 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     }
 
     for file_path in &files {
-        match sync_single_codex_file(db, file_path) {
+        match sync_single_codex_file(db, file_path, record_usage) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -225,7 +235,11 @@ fn collect_jsonl_recursive(dir: &Path, files: &mut Vec<PathBuf>, depth: u32, max
 }
 
 /// 同步单�� Codex JSONL 文件，返回 (imported, skipped)
-fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+fn sync_single_codex_file(
+    db: &Database,
+    file_path: &Path,
+    record_usage: bool,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
     // 获取文件元数据
@@ -391,29 +405,32 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                     continue;
                 }
 
-                // 生成唯一 request_id
-                let session_id_str = state.session_id.as_deref().unwrap_or("unknown");
-                let request_id = format!("codex_session:{}:{}", session_id_str, state.event_index);
+                if record_usage {
+                    // 生成唯一 request_id
+                    let session_id_str = state.session_id.as_deref().unwrap_or("unknown");
+                    let request_id =
+                        format!("codex_session:{}:{}", session_id_str, state.event_index);
 
-                // 提取时间戳
-                let timestamp = value
-                    .get("timestamp")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                    // 提取时间戳
+                    let timestamp = value
+                        .get("timestamp")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
 
-                match insert_codex_session_entry(
-                    db,
-                    &request_id,
-                    &delta,
-                    &state.current_model,
-                    state.session_id.as_deref(),
-                    timestamp.as_deref(),
-                ) {
-                    Ok(true) => imported += 1,
-                    Ok(false) => skipped += 1,
-                    Err(e) => {
-                        log::warn!("[CODEX-SYNC] 插入失败 ({}): {e}", request_id);
-                        skipped += 1;
+                    match insert_codex_session_entry(
+                        db,
+                        &request_id,
+                        &delta,
+                        &state.current_model,
+                        state.session_id.as_deref(),
+                        timestamp.as_deref(),
+                    ) {
+                        Ok(true) => imported += 1,
+                        Ok(false) => skipped += 1,
+                        Err(e) => {
+                            log::warn!("[CODEX-SYNC] 插入失败 ({}): {e}", request_id);
+                            skipped += 1;
+                        }
                     }
                 }
             }
@@ -623,6 +640,7 @@ fn try_find_pricing(conn: &rusqlite::Connection, model_id: &str) -> Option<Model
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn test_delta_first_event() {
@@ -809,5 +827,43 @@ mod tests {
         // 实际钳制在调用侧：delta.cached_input.min(delta.input)
         let clamped = delta.cached_input.min(delta.input);
         assert_eq!(clamped, 10);
+    }
+
+    #[test]
+    fn test_sync_single_codex_file_can_advance_cursor_without_recording() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("codex.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"timestamp\":\"2026-03-06T21:50:12Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"session-1\"}}\n",
+                "{\"timestamp\":\"2026-03-06T21:50:13Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n",
+                "{\"timestamp\":\"2026-03-06T21:50:14Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"model\":\"gpt-5.4\",\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":30}}}}\n"
+            ),
+        )
+        .expect("write codex session log");
+
+        let db = Database::memory().expect("db");
+        let (imported, skipped) =
+            sync_single_codex_file(&db, &path, false).expect("sync without recording");
+        assert_eq!(imported, 0);
+        assert_eq!(skipped, 0);
+
+        let conn = db.conn.lock().expect("lock conn");
+        let sync_offset: i64 = conn
+            .query_row(
+                "SELECT last_line_offset FROM session_log_sync WHERE file_path = ?1",
+                rusqlite::params![path.to_string_lossy().to_string()],
+                |row| row.get(0),
+            )
+            .expect("read sync offset");
+        assert_eq!(sync_offset, 3);
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM proxy_request_logs", [], |row| {
+                row.get(0)
+            })
+            .expect("count logs");
+        assert_eq!(count, 0);
     }
 }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -139,11 +139,6 @@ fn parse_cumulative_tokens(total_usage: &serde_json::Value) -> Option<Cumulative
 }
 
 /// 同步 Codex 使用数据（从 JSONL 会话日志）
-pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
-    sync_codex_usage_with_mode(db, true)
-}
-
-/// 同步 Codex 使用数据（从 JSONL 会话日志）
 ///
 /// 当 `record_usage=false` 时，仅推进同步游标和增量状态，不写入请求日志。
 pub fn sync_codex_usage_with_mode(

--- a/src-tauri/src/services/session_usage_gemini.rs
+++ b/src-tauri/src/services/session_usage_gemini.rs
@@ -35,6 +35,16 @@ struct GeminiTokens {
 
 /// 同步 Gemini 使用数据（从 JSON 会话日志）
 pub fn sync_gemini_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_gemini_usage_with_mode(db, true)
+}
+
+/// 同步 Gemini 使用数据（从 JSON 会话日志）
+///
+/// 当 `record_usage=false` 时，仅推进同步状态，不写入请求日志。
+pub fn sync_gemini_usage_with_mode(
+    db: &Database,
+    record_usage: bool,
+) -> Result<SessionSyncResult, AppError> {
     let gemini_dir = get_gemini_dir();
 
     let files = collect_gemini_session_files(&gemini_dir);
@@ -51,7 +61,7 @@ pub fn sync_gemini_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     }
 
     for file_path in &files {
-        match sync_single_gemini_file(db, file_path) {
+        match sync_single_gemini_file(db, file_path, record_usage) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -119,7 +129,11 @@ fn collect_gemini_session_files(gemini_dir: &Path) -> Vec<PathBuf> {
 }
 
 /// 同步单个 Gemini 会话 JSON 文件，返回 (imported, skipped)
-fn sync_single_gemini_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+fn sync_single_gemini_file(
+    db: &Database,
+    file_path: &Path,
+    record_usage: bool,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
     // 获取文件元数据
@@ -189,23 +203,25 @@ fn sync_single_gemini_file(db: &Database, file_path: &Path) -> Result<(u32, u32)
             .unwrap_or("unknown");
         let timestamp = msg.get("timestamp").and_then(|v| v.as_str());
 
-        // 生成唯一 request_id
-        let session_id_str = session_id.as_deref().unwrap_or("unknown");
-        let request_id = format!("gemini_session:{session_id_str}:{message_id}");
+        if record_usage {
+            // 生成唯一 request_id
+            let session_id_str = session_id.as_deref().unwrap_or("unknown");
+            let request_id = format!("gemini_session:{session_id_str}:{message_id}");
 
-        match insert_gemini_session_entry(
-            db,
-            &request_id,
-            &tokens,
-            model,
-            session_id.as_deref(),
-            timestamp,
-        ) {
-            Ok(true) => imported += 1,
-            Ok(false) => skipped += 1,
-            Err(e) => {
-                log::warn!("[GEMINI-SYNC] 插入失败 ({}): {e}", request_id);
-                skipped += 1;
+            match insert_gemini_session_entry(
+                db,
+                &request_id,
+                &tokens,
+                model,
+                session_id.as_deref(),
+                timestamp,
+            ) {
+                Ok(true) => imported += 1,
+                Ok(false) => skipped += 1,
+                Err(e) => {
+                    log::warn!("[GEMINI-SYNC] 插入失败 ({}): {e}", request_id);
+                    skipped += 1;
+                }
             }
         }
     }
@@ -426,6 +442,7 @@ fn try_find_pricing(conn: &rusqlite::Connection, model_id: &str) -> Option<Model
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn test_collect_gemini_session_files_nonexistent() {
@@ -500,5 +517,56 @@ mod tests {
         let should_skip =
             tokens.input == 0 && tokens.output == 0 && tokens.thoughts == 0 && tokens.cached == 0;
         assert!(!should_skip, "纯缓存命中记录不应被跳过");
+    }
+
+    #[test]
+    fn test_sync_single_gemini_file_can_advance_cursor_without_recording() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-test.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "sessionId": "gemini-session-1",
+                "messages": [
+                    {
+                        "id": "msg-1",
+                        "type": "gemini",
+                        "model": "gemini-2.5-pro",
+                        "timestamp": "2026-04-05T12:00:00Z",
+                        "tokens": {
+                            "input": 50,
+                            "output": 10,
+                            "cached": 5,
+                            "thoughts": 2
+                        }
+                    }
+                ]
+            })
+            .to_string(),
+        )
+        .expect("write gemini session");
+
+        let db = Database::memory().expect("db");
+        let (imported, skipped) =
+            sync_single_gemini_file(&db, &path, false).expect("sync without recording");
+        assert_eq!(imported, 0);
+        assert_eq!(skipped, 0);
+
+        let conn = db.conn.lock().expect("lock conn");
+        let sync_offset: i64 = conn
+            .query_row(
+                "SELECT last_line_offset FROM session_log_sync WHERE file_path = ?1",
+                rusqlite::params![path.to_string_lossy().to_string()],
+                |row| row.get(0),
+            )
+            .expect("read sync offset");
+        assert_eq!(sync_offset, 1);
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM proxy_request_logs", [], |row| {
+                row.get(0)
+            })
+            .expect("count logs");
+        assert_eq!(count, 0);
     }
 }

--- a/src-tauri/src/services/session_usage_gemini.rs
+++ b/src-tauri/src/services/session_usage_gemini.rs
@@ -34,11 +34,6 @@ struct GeminiTokens {
 }
 
 /// 同步 Gemini 使用数据（从 JSON 会话日志）
-pub fn sync_gemini_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
-    sync_gemini_usage_with_mode(db, true)
-}
-
-/// 同步 Gemini 使用数据（从 JSON 会话日志）
 ///
 /// 当 `record_usage=false` 时，仅推进同步状态，不写入请求日志。
 pub fn sync_gemini_usage_with_mode(

--- a/src-tauri/src/services/session_usage_gemini.rs
+++ b/src-tauri/src/services/session_usage_gemini.rs
@@ -516,6 +516,7 @@ mod tests {
 
     #[test]
     fn test_sync_single_gemini_file_can_advance_cursor_without_recording() {
+        // Gemini 同步在不写用量明细时，也应将文件标记为已消费。
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("session-test.json");
         std::fs::write(

--- a/src-tauri/src/services/usage_source.rs
+++ b/src-tauri/src/services/usage_source.rs
@@ -1,0 +1,206 @@
+use crate::database::Database;
+use crate::error::AppError;
+use crate::proxy::types::UsageStatsSource;
+use crate::services::proxy::ProxyService;
+use crate::services::session_usage::{sync_claude_session_logs_with_mode, SessionSyncResult};
+use crate::services::session_usage_codex::sync_codex_usage_with_mode;
+use crate::services::session_usage_gemini::sync_gemini_usage_with_mode;
+
+pub async fn resolve_effective_usage_source(
+    db: &Database,
+    proxy_running: bool,
+    app_type: &str,
+) -> Result<UsageStatsSource, AppError> {
+    if !proxy_running {
+        return Ok(UsageStatsSource::Session);
+    }
+
+    let config = db.get_proxy_config_for_app(app_type).await?;
+    if config.enabled {
+        Ok(config.usage_stats_source)
+    } else {
+        Ok(UsageStatsSource::Session)
+    }
+}
+
+pub async fn should_record_proxy_usage(db: &Database, app_type: &str) -> Result<bool, AppError> {
+    let config = db.get_proxy_config_for_app(app_type).await?;
+    Ok(!(config.enabled && config.usage_stats_source == UsageStatsSource::Session))
+}
+
+pub async fn should_record_session_usage(
+    db: &Database,
+    proxy_running: bool,
+    app_type: &str,
+) -> Result<bool, AppError> {
+    // - 代理未接管时：仍按 Session 日志补录
+    // - 代理已接管且 source=proxy：Session 只推进游标，不入库
+    // - 代理已接管且 source=session：Session 正常入库
+    Ok(
+        resolve_effective_usage_source(db, proxy_running, app_type).await?
+            == UsageStatsSource::Session,
+    )
+}
+
+pub async fn sync_session_usage_by_policy(
+    db: &Database,
+    proxy_service: &ProxyService,
+) -> Result<SessionSyncResult, AppError> {
+    let proxy_running = proxy_service.is_running().await;
+    let mut result = SessionSyncResult {
+        imported: 0,
+        skipped: 0,
+        files_scanned: 0,
+        errors: Vec::new(),
+    };
+
+    let claude_record_usage = match should_record_session_usage(db, proxy_running, "claude").await {
+        Ok(value) => value,
+        Err(e) => {
+            result.errors.push(format!("Claude 策略解析失败: {e}"));
+            true
+        }
+    };
+    merge_sync_result(
+        &mut result,
+        sync_claude_session_logs_with_mode(db, claude_record_usage),
+        "Claude",
+    );
+
+    let codex_record_usage = match should_record_session_usage(db, proxy_running, "codex").await {
+        Ok(value) => value,
+        Err(e) => {
+            result.errors.push(format!("Codex 策略解析失败: {e}"));
+            true
+        }
+    };
+    merge_sync_result(
+        &mut result,
+        sync_codex_usage_with_mode(db, codex_record_usage),
+        "Codex",
+    );
+
+    let gemini_record_usage = match should_record_session_usage(db, proxy_running, "gemini").await {
+        Ok(value) => value,
+        Err(e) => {
+            result.errors.push(format!("Gemini 策略解析失败: {e}"));
+            true
+        }
+    };
+    merge_sync_result(
+        &mut result,
+        sync_gemini_usage_with_mode(db, gemini_record_usage),
+        "Gemini",
+    );
+
+    Ok(result)
+}
+
+fn merge_sync_result(
+    aggregate: &mut SessionSyncResult,
+    next: Result<SessionSyncResult, AppError>,
+    app_label: &str,
+) {
+    match next {
+        Ok(sync_result) => {
+            aggregate.imported += sync_result.imported;
+            aggregate.skipped += sync_result.skipped;
+            aggregate.files_scanned += sync_result.files_scanned;
+            aggregate.errors.extend(sync_result.errors);
+        }
+        Err(e) => {
+            aggregate.errors.push(format!("{app_label} 同步失败: {e}"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proxy::types::UsageStatsSource;
+
+    #[tokio::test]
+    async fn effective_usage_source_falls_back_to_session_when_proxy_not_running(
+    ) -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        let source = resolve_effective_usage_source(&db, false, "claude").await?;
+        assert_eq!(source, UsageStatsSource::Session);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn effective_usage_source_uses_config_when_takeover_enabled() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let mut config = db.get_proxy_config_for_app("claude").await?;
+        config.enabled = true;
+        config.usage_stats_source = UsageStatsSource::Session;
+        db.update_proxy_config_for_app(config).await?;
+
+        let source = resolve_effective_usage_source(&db, true, "claude").await?;
+        assert_eq!(source, UsageStatsSource::Session);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_record_proxy_usage_only_blocks_session_mode_during_takeover(
+    ) -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let mut config = db.get_proxy_config_for_app("codex").await?;
+        config.enabled = true;
+        config.usage_stats_source = UsageStatsSource::Session;
+        db.update_proxy_config_for_app(config).await?;
+
+        assert!(!should_record_proxy_usage(&db, "codex").await?);
+
+        let mut proxy_mode = db.get_proxy_config_for_app("gemini").await?;
+        proxy_mode.enabled = true;
+        proxy_mode.usage_stats_source = UsageStatsSource::Proxy;
+        db.update_proxy_config_for_app(proxy_mode).await?;
+        assert!(should_record_proxy_usage(&db, "gemini").await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_record_session_usage_when_proxy_not_running() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        assert!(should_record_session_usage(&db, false, "claude").await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_record_session_usage_uses_session_as_fallback_when_not_taken_over(
+    ) -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let mut config = db.get_proxy_config_for_app("codex").await?;
+        config.enabled = false;
+        config.usage_stats_source = UsageStatsSource::Proxy;
+        db.update_proxy_config_for_app(config).await?;
+
+        assert!(should_record_session_usage(&db, true, "codex").await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_record_session_usage_respects_takeover_source() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        let mut proxy_mode = db.get_proxy_config_for_app("gemini").await?;
+        proxy_mode.enabled = true;
+        proxy_mode.usage_stats_source = UsageStatsSource::Proxy;
+        db.update_proxy_config_for_app(proxy_mode).await?;
+        assert!(!should_record_session_usage(&db, true, "gemini").await?);
+
+        let mut session_mode = db.get_proxy_config_for_app("claude").await?;
+        session_mode.enabled = true;
+        session_mode.usage_stats_source = UsageStatsSource::Session;
+        db.update_proxy_config_for_app(session_mode).await?;
+        assert!(should_record_session_usage(&db, true, "claude").await?);
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/services/usage_source.rs
+++ b/src-tauri/src/services/usage_source.rs
@@ -47,6 +47,13 @@ pub async fn sync_session_usage_by_policy(
     proxy_service: &ProxyService,
 ) -> Result<SessionSyncResult, AppError> {
     let proxy_running = proxy_service.is_running().await;
+    sync_session_usage_by_policy_with_proxy_running(db, proxy_running).await
+}
+
+async fn sync_session_usage_by_policy_with_proxy_running(
+    db: &Database,
+    proxy_running: bool,
+) -> Result<SessionSyncResult, AppError> {
     let mut result = SessionSyncResult {
         imported: 0,
         skipped: 0,
@@ -118,6 +125,59 @@ fn merge_sync_result(
 mod tests {
     use super::*;
     use crate::proxy::types::UsageStatsSource;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::tempdir;
+
+    fn test_env_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+    }
+
+    struct TestHomeScope {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        temp: tempfile::TempDir,
+        old_test_home: Option<OsString>,
+        old_home: Option<OsString>,
+    }
+
+    impl TestHomeScope {
+        fn new() -> Self {
+            let guard = test_env_guard();
+            let temp = tempdir().expect("tempdir");
+            let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+            let old_home = std::env::var_os("HOME");
+            std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+            std::env::set_var("HOME", temp.path());
+
+            Self {
+                _guard: guard,
+                temp,
+                old_test_home,
+                old_home,
+            }
+        }
+
+        fn root(&self) -> &std::path::Path {
+            self.temp.path()
+        }
+    }
+
+    impl Drop for TestHomeScope {
+        fn drop(&mut self) {
+            match &self.old_test_home {
+                Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+            match &self.old_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
 
     #[tokio::test]
     async fn effective_usage_source_falls_back_to_session_when_proxy_not_running(
@@ -138,6 +198,20 @@ mod tests {
         db.update_proxy_config_for_app(config).await?;
 
         let source = resolve_effective_usage_source(&db, true, "claude").await?;
+        assert_eq!(source, UsageStatsSource::Session);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn effective_usage_source_falls_back_to_session_when_app_not_taken_over(
+    ) -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let mut config = db.get_proxy_config_for_app("codex").await?;
+        config.enabled = false;
+        config.usage_stats_source = UsageStatsSource::Proxy;
+        db.update_proxy_config_for_app(config).await?;
+
+        let source = resolve_effective_usage_source(&db, true, "codex").await?;
         assert_eq!(source, UsageStatsSource::Session);
         Ok(())
     }
@@ -200,6 +274,131 @@ mod tests {
         session_mode.usage_stats_source = UsageStatsSource::Session;
         db.update_proxy_config_for_app(session_mode).await?;
         assert!(should_record_session_usage(&db, true, "claude").await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sync_session_usage_by_policy_applies_per_app_recording_modes() -> Result<(), AppError>
+    {
+        let scope = TestHomeScope::new();
+        let home = scope.root();
+
+        let claude_path = home
+            .join(".claude")
+            .join("projects")
+            .join("project-a")
+            .join("session.jsonl");
+        fs::create_dir_all(claude_path.parent().expect("claude parent"))
+            .expect("create claude dirs");
+        fs::write(
+            &claude_path,
+            "{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":12,\"output_tokens\":6},\"stop_reason\":\"end_turn\"},\"timestamp\":\"2026-04-05T12:00:00Z\",\"sessionId\":\"session-1\"}\n",
+        )
+        .expect("write claude session log");
+
+        let codex_path = home
+            .join(".codex")
+            .join("sessions")
+            .join("2026")
+            .join("03")
+            .join("06")
+            .join("codex.jsonl");
+        fs::create_dir_all(codex_path.parent().expect("codex parent")).expect("create codex dirs");
+        fs::write(
+            &codex_path,
+            concat!(
+                "{\"timestamp\":\"2026-03-06T21:50:12Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"session-1\"}}\n",
+                "{\"timestamp\":\"2026-03-06T21:50:13Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\"}}\n",
+                "{\"timestamp\":\"2026-03-06T21:50:14Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"model\":\"gpt-5.4\",\"total_token_usage\":{\"input_tokens\":100,\"cached_input_tokens\":20,\"output_tokens\":30}}}}\n"
+            ),
+        )
+        .expect("write codex session log");
+
+        let gemini_path = home
+            .join(".gemini")
+            .join("tmp")
+            .join("project-hash")
+            .join("chats")
+            .join("session-1.json");
+        fs::create_dir_all(gemini_path.parent().expect("gemini parent"))
+            .expect("create gemini dirs");
+        fs::write(
+            &gemini_path,
+            serde_json::json!({
+                "sessionId": "gemini-session-1",
+                "messages": [
+                    {
+                        "id": "msg-1",
+                        "type": "gemini",
+                        "model": "gemini-2.5-pro",
+                        "timestamp": "2026-04-05T12:00:00Z",
+                        "tokens": {
+                            "input": 50,
+                            "output": 10,
+                            "cached": 5,
+                            "thoughts": 2
+                        }
+                    }
+                ]
+            })
+            .to_string(),
+        )
+        .expect("write gemini session");
+
+        let db = Database::memory()?;
+
+        let mut claude_config = db.get_proxy_config_for_app("claude").await?;
+        claude_config.enabled = true;
+        claude_config.usage_stats_source = UsageStatsSource::Proxy;
+
+        let mut codex_config = db.get_proxy_config_for_app("codex").await?;
+        codex_config.enabled = true;
+        codex_config.usage_stats_source = UsageStatsSource::Session;
+
+        let mut gemini_config = db.get_proxy_config_for_app("gemini").await?;
+        gemini_config.enabled = false;
+        gemini_config.usage_stats_source = UsageStatsSource::Proxy;
+
+        db.update_proxy_config_for_app(claude_config).await?;
+        db.update_proxy_config_for_app(codex_config).await?;
+        db.update_proxy_config_for_app(gemini_config).await?;
+
+        let result = sync_session_usage_by_policy_with_proxy_running(&db, true).await?;
+
+        assert_eq!(result.imported, 2);
+        assert_eq!(result.skipped, 0);
+        assert_eq!(result.files_scanned, 3);
+        assert!(result.errors.is_empty());
+
+        let conn = crate::database::lock_conn!(db.conn);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM proxy_request_logs", [], |row| {
+                row.get(0)
+            })
+            .expect("count imported logs");
+        assert_eq!(count, 2);
+
+        let data_sources: Vec<String> = {
+            let mut stmt = conn
+                .prepare("SELECT data_source FROM proxy_request_logs ORDER BY data_source")
+                .expect("prepare data sources");
+            stmt.query_map([], |row| row.get::<_, String>(0))
+                .expect("query data sources")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("collect data sources")
+        };
+        assert_eq!(
+            data_sources,
+            vec!["codex_session".to_string(), "gemini_session".to_string()]
+        );
+
+        let sync_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_log_sync", [], |row| {
+                row.get(0)
+            })
+            .expect("count sync cursors");
+        assert_eq!(sync_count, 3);
 
         Ok(())
     }

--- a/src-tauri/src/services/usage_source.rs
+++ b/src-tauri/src/services/usage_source.rs
@@ -182,6 +182,7 @@ mod tests {
     #[tokio::test]
     async fn effective_usage_source_falls_back_to_session_when_proxy_not_running(
     ) -> Result<(), AppError> {
+        // 代理未运行时，用量统计始终回退到 Session 日志。
         let db = Database::memory()?;
 
         let source = resolve_effective_usage_source(&db, false, "claude").await?;
@@ -191,6 +192,7 @@ mod tests {
 
     #[tokio::test]
     async fn effective_usage_source_uses_config_when_takeover_enabled() -> Result<(), AppError> {
+        // 本地路由/代理接管生效时，以 app 级别配置的统计来源为准。
         let db = Database::memory()?;
         let mut config = db.get_proxy_config_for_app("claude").await?;
         config.enabled = true;
@@ -205,6 +207,7 @@ mod tests {
     #[tokio::test]
     async fn effective_usage_source_falls_back_to_session_when_app_not_taken_over(
     ) -> Result<(), AppError> {
+        // 未被接管的 app 即使配置为上游统计，也仍然回退到 Session 日志。
         let db = Database::memory()?;
         let mut config = db.get_proxy_config_for_app("codex").await?;
         config.enabled = false;
@@ -219,6 +222,7 @@ mod tests {
     #[tokio::test]
     async fn should_record_proxy_usage_only_blocks_session_mode_during_takeover(
     ) -> Result<(), AppError> {
+        // 只有“已接管且明确选择 Session 日志”的 app，才会跳过代理侧用量写入。
         let db = Database::memory()?;
         let mut config = db.get_proxy_config_for_app("codex").await?;
         config.enabled = true;
@@ -238,6 +242,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_record_session_usage_when_proxy_not_running() -> Result<(), AppError> {
+        // 代理完全未运行时，Session 日志同步应保持开启。
         let db = Database::memory()?;
 
         assert!(should_record_session_usage(&db, false, "claude").await?);
@@ -248,6 +253,7 @@ mod tests {
     #[tokio::test]
     async fn should_record_session_usage_uses_session_as_fallback_when_not_taken_over(
     ) -> Result<(), AppError> {
+        // 接管策略不应影响未实际接管的 app，其 Session 同步仍应作为回退路径。
         let db = Database::memory()?;
         let mut config = db.get_proxy_config_for_app("codex").await?;
         config.enabled = false;
@@ -261,6 +267,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_record_session_usage_respects_takeover_source() -> Result<(), AppError> {
+        // 接管生效后，是否记录 Session 用量取决于每个 app 选择的统计来源。
         let db = Database::memory()?;
 
         let mut proxy_mode = db.get_proxy_config_for_app("gemini").await?;
@@ -281,9 +288,11 @@ mod tests {
     #[tokio::test]
     async fn sync_session_usage_by_policy_applies_per_app_recording_modes() -> Result<(), AppError>
     {
+        // 编排层端到端测试：只有最终解析为 Session 模式的 app 才应导入用量。
         let scope = TestHomeScope::new();
         let home = scope.root();
 
+        // Claude 保持上游统计模式，因此只扫描日志文件，不导入用量。
         let claude_path = home
             .join(".claude")
             .join("projects")
@@ -297,6 +306,7 @@ mod tests {
         )
         .expect("write claude session log");
 
+        // Codex 在接管开启时显式选择 Session 日志统计。
         let codex_path = home
             .join(".codex")
             .join("sessions")
@@ -315,6 +325,7 @@ mod tests {
         )
         .expect("write codex session log");
 
+        // Gemini 未被接管，因此会回退到 Session 日志统计。
         let gemini_path = home
             .join(".gemini")
             .join("tmp")
@@ -366,6 +377,7 @@ mod tests {
 
         let result = sync_session_usage_by_policy_with_proxy_running(&db, true).await?;
 
+        // 最终只有 Codex 和 Gemini 会写入用量，但三个文件的游标都应推进。
         assert_eq!(result.imported, 2);
         assert_eq!(result.skipped, 0);
         assert_eq!(result.files_scanned, 3);

--- a/src/components/proxy/AutoFailoverConfigPanel.tsx
+++ b/src/components/proxy/AutoFailoverConfigPanel.tsx
@@ -163,6 +163,7 @@ export function AutoFailoverConfigPanel({
         appType,
         enabled: config.enabled,
         autoFailoverEnabled: formData.autoFailoverEnabled,
+        usageStatsSource: config.usageStatsSource,
         maxRetries: raw.maxRetries,
         streamingFirstByteTimeout: raw.streamingFirstByteTimeout,
         streamingIdleTimeout: raw.streamingIdleTimeout,

--- a/src/components/proxy/UsageStatsSourcePanel.tsx
+++ b/src/components/proxy/UsageStatsSourcePanel.tsx
@@ -1,0 +1,80 @@
+import { Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAppProxyConfig, useUpdateAppProxyConfig } from "@/lib/query/proxy";
+import type { UsageStatsSource } from "@/types/proxy";
+
+interface UsageStatsSourcePanelProps {
+  appType: string;
+}
+
+export function UsageStatsSourcePanel({ appType }: UsageStatsSourcePanelProps) {
+  const { t } = useTranslation();
+  const { data: config, isLoading } = useAppProxyConfig(appType);
+  const updateConfig = useUpdateAppProxyConfig();
+
+  const handleChange = async (value: string) => {
+    if (!config) return;
+    await updateConfig.mutateAsync({
+      ...config,
+      usageStatsSource: value as UsageStatsSource,
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center rounded-lg border border-border/50 bg-muted/30 p-4">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border/50 bg-muted/30 p-4">
+      <div className="space-y-1">
+        <h4 className="text-sm font-semibold">
+          {t("proxy.usageStatsSource.title")}
+        </h4>
+        <p className="text-xs text-muted-foreground">
+          {t("proxy.usageStatsSource.description")}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`usage-stats-source-${appType}`}>
+          {t("proxy.usageStatsSource.label")}
+        </Label>
+        <Select
+          value={config?.usageStatsSource ?? "proxy"}
+          onValueChange={(value) => void handleChange(value)}
+          disabled={!config || updateConfig.isPending}
+        >
+          <SelectTrigger
+            id={`usage-stats-source-${appType}`}
+            className="w-full sm:w-[220px]"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="proxy">
+              {t("proxy.usageStatsSource.proxy")}
+            </SelectItem>
+            <SelectItem value="session">
+              {t("proxy.usageStatsSource.session")}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          {t("proxy.usageStatsSource.hint")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { ProxyPanel } from "@/components/proxy";
 import { AutoFailoverConfigPanel } from "@/components/proxy/AutoFailoverConfigPanel";
 import { FailoverQueueManager } from "@/components/proxy/FailoverQueueManager";
+import { UsageStatsSourcePanel } from "@/components/proxy/UsageStatsSourcePanel";
 import { RectifierConfigPanel } from "@/components/settings/RectifierConfigPanel";
 import { GlobalProxySettings } from "@/components/settings/GlobalProxySettings";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -119,14 +120,35 @@ export function ProxyTabContent({
             </div>
           </AccordionTrigger>
           <AccordionContent className="px-6 pb-6 pt-4 border-t border-border/50">
-            <ProxyPanel
-              enableLocalProxy={settings?.enableLocalProxy ?? false}
-              onEnableLocalProxyChange={(checked) =>
-                onAutoSave({ enableLocalProxy: checked })
-              }
-              onToggleProxy={handleToggleProxy}
-              isProxyPending={isProxyPending}
-            />
+            <div className="space-y-6">
+              <ProxyPanel
+                enableLocalProxy={settings?.enableLocalProxy ?? false}
+                onEnableLocalProxyChange={(checked) =>
+                  onAutoSave({ enableLocalProxy: checked })
+                }
+                onToggleProxy={handleToggleProxy}
+                isProxyPending={isProxyPending}
+              />
+
+              <div className="border-t border-border/50 pt-6">
+                <Tabs defaultValue="claude" className="w-full">
+                  <TabsList className="grid w-full grid-cols-3">
+                    <TabsTrigger value="claude">Claude</TabsTrigger>
+                    <TabsTrigger value="codex">Codex</TabsTrigger>
+                    <TabsTrigger value="gemini">Gemini</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="claude" className="mt-4">
+                    <UsageStatsSourcePanel appType="claude" />
+                  </TabsContent>
+                  <TabsContent value="codex" className="mt-4">
+                    <UsageStatsSourcePanel appType="codex" />
+                  </TabsContent>
+                  <TabsContent value="gemini" className="mt-4">
+                    <UsageStatsSourcePanel appType="gemini" />
+                  </TabsContent>
+                </Tabs>
+              </div>
+            </div>
           </AccordionContent>
         </AccordionItem>
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2064,6 +2064,14 @@
         "inactive": "Route {{appLabel}}'s requests through local routing"
       }
     },
+    "usageStatsSource": {
+      "title": "Usage Stats Source",
+      "description": "Only applies while proxy takeover is enabled for this app.",
+      "label": "Stats source during takeover",
+      "proxy": "Prefer upstream usage",
+      "session": "Prefer Session logs",
+      "hint": "When takeover is off, usage still falls back to Session log imports."
+    },
     "failover": {
       "proxyRequired": "Routing service must be started to configure failover",
       "autoSwitch": "Auto Failover",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2064,6 +2064,14 @@
         "inactive": "{{appLabel}} のリクエストをローカルルーティング経由でルーティング"
       }
     },
+    "usageStatsSource": {
+      "title": "使用量統計のソース",
+      "description": "このアプリケーションでプロキシによる引き継ぎが有効な場合にのみ有効です。",
+      "label": "接管中の統計ソース",
+      "proxy": "上流の usage を優先",
+      "session": "Session ログを優先",
+      "hint": "接管をオフにすると、使用量は引き続き Session ログから補完されます。"
+    },
     "failover": {
       "proxyRequired": "フェイルオーバーを設定するには、ルーティングサービスを先に起動する必要があります",
       "autoSwitch": "自動フェイルオーバー",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2065,6 +2065,14 @@
         "inactive": "路由 {{appLabel}} 的请求，让该应用请求走本地路由"
       }
     },
+    "usageStatsSource": {
+      "title": "用量统计来源",
+      "description": "仅在该应用启用代理接管时生效。",
+      "label": "接管期间的统计来源",
+      "proxy": "以上游返回为主",
+      "session": "以 Session 日志为主",
+      "hint": "关闭接管后，仍会继续按 Session 日志补录用量。"
+    },
     "failover": {
       "proxyRequired": "需要先启动路由服务才能配置故障转移",
       "autoSwitch": "自动故障转移",

--- a/src/lib/query/proxy.ts
+++ b/src/lib/query/proxy.ts
@@ -3,6 +3,7 @@ import { proxyApi } from "@/lib/api/proxy";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import type { GlobalProxyConfig, AppProxyConfig } from "@/types/proxy";
+import { usageKeys } from "@/lib/query/usage";
 
 // ========== 代理服务器状态 Hooks ==========
 
@@ -82,6 +83,8 @@ export function useStopProxyServer() {
       queryClient.invalidateQueries({ queryKey: ["proxyRunning"] });
       queryClient.invalidateQueries({ queryKey: ["liveTakeoverActive"] });
       queryClient.invalidateQueries({ queryKey: ["proxyTakeoverStatus"] });
+      queryClient.invalidateQueries({ queryKey: ["appProxyConfig"] });
+      queryClient.invalidateQueries({ queryKey: ["proxyConfig"] });
     },
   });
 }
@@ -95,9 +98,13 @@ export function useSetProxyTakeoverForApp() {
   return useMutation({
     mutationFn: ({ appType, enabled }: { appType: string; enabled: boolean }) =>
       proxyApi.setProxyTakeoverForApp(appType, enabled),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["proxyTakeoverStatus"] });
       queryClient.invalidateQueries({ queryKey: ["liveTakeoverActive"] });
+      queryClient.invalidateQueries({
+        queryKey: ["appProxyConfig", variables.appType],
+      });
+      queryClient.invalidateQueries({ queryKey: ["proxyConfig"] });
     },
   });
 }
@@ -229,6 +236,7 @@ export function useUpdateAppProxyConfig() {
       });
       queryClient.invalidateQueries({ queryKey: ["proxyConfig"] });
       queryClient.invalidateQueries({ queryKey: ["circuitBreakerConfig"] });
+      queryClient.invalidateQueries({ queryKey: usageKeys.all });
     },
     onError: (error: Error) => {
       toast.error(

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -121,11 +121,14 @@ export interface GlobalProxyConfig {
   enableLogging: boolean;
 }
 
+export type UsageStatsSource = "proxy" | "session";
+
 // 应用级代理配置（每个 app 独立）
 export interface AppProxyConfig {
   appType: string;
   enabled: boolean;
   autoFailoverEnabled: boolean;
+  usageStatsSource: UsageStatsSource;
   maxRetries: number;
   streamingFirstByteTimeout: number;
   streamingIdleTimeout: number;


### PR DESCRIPTION
## Summary / 概述

本 PR 为代理接管场景新增了“用量统计来源”开关，支持按 app 选择：

- `Session`：以本地 Session 日志为主进行用量统计
- `Proxy`：以上游返回的用量数据为主进行统计

策略规则如下：

- 当本地路由/代理未运行时，仍统一回退到 `Session`
- 当本地路由/代理已接管且 app 启用了接管时，按该 app 的 `usage_stats_source` 配置决定统计来源
- 当本地路由/代理运行但某个 app 未被接管时，仍回退到 `Session`
- 当选择 `Session` 作为统计来源时，代理响应侧不再写入 proxy usage，避免重复统计

## Related Issue / 关联 Issue

Fixes #2164 

## Screenshots / 截图

<img width="1209" height="791" alt="屏幕截图 2026-04-21 145856" src="https://github.com/user-attachments/assets/44f2e7ca-b8b6-482d-9040-a46c46d2da29" />

<img width="1135" height="793" alt="图片" src="https://github.com/user-attachments/assets/eb3fab6c-599f-49a6-aa72-5a810a84dfc4" />

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

## 测试情况

  | 测试内容 | 覆盖点 | 结果 |
  | --- | --- | --- |
  | 用量来源策略解析测试 | 验证代理未运行、接管启用、未接管回退、Session/Proxy 两种来源下的行为是否正确 | 通过 |
  | Session 日志同步游标推进测试 | 验证 `record_usage=false` 时 Claude/Codex/Gemini 仅推进同步游标、不写入 usage 记录 | 通过 |
  | 配置读写往返测试 | 验证 `usage_stats_source` 默认值、更新后持久化、同步读取是否一致 | 通过 |
  | 数据库迁移测试 | 验证旧 schema 升级后 `proxy_config` 新增 `usage_stats_source` 字段，且默认值为 `proxy`  | 通过 |
  | 代理写库 gating 测试 | 验证接管后若选择 `Session` 作为统计来源，则代理响应侧不会写入 proxy usage | 通过 |
  | 代码格式化 | 验证 Rust 代码格式一致性 | 通过 |

## 说明

- 测试过程中存在仓库内已有的无关 warning（如 `settings.rs`、`commands/misc.rs` 的未使用代码告警），不属于本 PR 引入的问题