### PR TITLE
feat(skills): support custom Git platforms and auto-update

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -167,6 +167,9 @@ pub struct InstalledSkill {
     /// 仓库分支
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_branch: Option<String>,
+    /// 仓库完整 URL（为空时默认 GitHub）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_url: Option<String>,
     /// README URL
     #[serde(skip_serializing_if = "Option::is_none")]
     pub readme_url: Option<String>,

--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -162,6 +162,34 @@ pub async fn update_skill(
         .map_err(|e| e.to_string())
 }
 
+/// 获取 Skill 自动更新频率
+#[tauri::command]
+pub async fn get_skill_auto_update_frequency(
+    app_state: State<'_, AppState>,
+) -> Result<String, String> {
+    app_state
+        .db
+        .get_setting("skill_auto_update_frequency")
+        .map(|v| v.unwrap_or_else(|| "daily".to_string()))
+        .map_err(|e| e.to_string())
+}
+
+/// 设置 Skill 自动更新频率
+#[tauri::command]
+pub async fn set_skill_auto_update_frequency(
+    frequency: String,
+    app_state: State<'_, AppState>,
+) -> Result<(), String> {
+    let valid = ["on_launch", "daily", "weekly", "monthly", "off"];
+    if !valid.contains(&frequency.as_str()) {
+        return Err(format!("无效的更新频率: {frequency}"));
+    }
+    app_state
+        .db
+        .set_setting("skill_auto_update_frequency", &frequency)
+        .map_err(|e| e.to_string())
+}
+
 /// 迁移 Skill 存储位置
 #[tauri::command]
 pub async fn migrate_skill_storage(

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -23,7 +23,7 @@ impl Database {
             .prepare(
                 "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
                         readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode,
-                        installed_at, content_hash, updated_at
+                        installed_at, content_hash, updated_at, repo_url
                  FROM skills ORDER BY name ASC",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -38,6 +38,7 @@ impl Database {
                     repo_owner: row.get(4)?,
                     repo_name: row.get(5)?,
                     repo_branch: row.get(6)?,
+                    repo_url: row.get::<_, String>(15).ok().filter(|s| !s.is_empty()),
                     readme_url: row.get(7)?,
                     apps: SkillApps {
                         claude: row.get(8)?,
@@ -67,7 +68,7 @@ impl Database {
             .prepare(
                 "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
                         readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode,
-                        installed_at, content_hash, updated_at
+                        installed_at, content_hash, updated_at, repo_url
                  FROM skills WHERE id = ?1",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -81,6 +82,7 @@ impl Database {
                 repo_owner: row.get(4)?,
                 repo_name: row.get(5)?,
                 repo_branch: row.get(6)?,
+                repo_url: row.get(15)?,
                 readme_url: row.get(7)?,
                 apps: SkillApps {
                     claude: row.get(8)?,
@@ -108,8 +110,8 @@ impl Database {
             "INSERT OR REPLACE INTO skills
              (id, name, description, directory, repo_owner, repo_name, repo_branch,
               readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode,
-              installed_at, content_hash, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+              installed_at, content_hash, updated_at, repo_url)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 skill.id,
                 skill.name,
@@ -126,6 +128,7 @@ impl Database {
                 skill.installed_at,
                 skill.content_hash,
                 skill.updated_at,
+                skill.repo_url.as_deref().unwrap_or(""),
             ],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -185,7 +188,7 @@ impl Database {
         let conn = lock_conn!(self.conn);
         let mut stmt = conn
             .prepare(
-                "SELECT owner, name, branch, enabled FROM skill_repos ORDER BY owner ASC, name ASC",
+                "SELECT owner, name, branch, enabled, url FROM skill_repos ORDER BY owner ASC, name ASC",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -196,6 +199,7 @@ impl Database {
                     name: row.get(1)?,
                     branch: row.get(2)?,
                     enabled: row.get(3)?,
+                    url: row.get::<_, String>(4).unwrap_or_default(),
                 })
             })
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -211,8 +215,8 @@ impl Database {
     pub fn save_skill_repo(&self, repo: &SkillRepo) -> Result<(), AppError> {
         let conn = lock_conn!(self.conn);
         conn.execute(
-            "INSERT OR REPLACE INTO skill_repos (owner, name, branch, enabled) VALUES (?1, ?2, ?3, ?4)",
-            params![repo.owner, repo.name, repo.branch, repo.enabled],
+            "INSERT OR REPLACE INTO skill_repos (owner, name, branch, enabled, url) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![repo.owner, repo.name, repo.branch, repo.enabled, repo.url],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(())

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -44,7 +44,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 9;
+pub(crate) const SCHEMA_VERSION: i32 = 10;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -423,6 +423,11 @@ impl Database {
                         Self::migrate_v8_to_v9(conn)?;
                         Self::set_user_version(conn, 9)?;
                     }
+                    9 => {
+                        log::info!("迁移数据库从 v9 到 v10（Skill 仓库支持自定义 Git 平台）");
+                        Self::migrate_v9_to_v10(conn)?;
+                        Self::set_user_version(conn, 10)?;
+                    }
                     _ => {
                         return Err(AppError::Database(format!(
                             "未知的数据库版本 {version}，无法迁移到 {SCHEMA_VERSION}"
@@ -1165,6 +1170,13 @@ impl Database {
             .map_err(|e| AppError::Database(format!("清空模型定价失败: {e}")))?;
         Self::seed_model_pricing(conn)?;
         log::info!("v8 -> v9 迁移完成：已刷新全部模型定价数据");
+        Ok(())
+    }
+
+    fn migrate_v9_to_v10(conn: &Connection) -> Result<(), AppError> {
+        Self::add_column_if_missing(conn, "skill_repos", "url", "TEXT NOT NULL DEFAULT ''")?;
+        Self::add_column_if_missing(conn, "skills", "repo_url", "TEXT NOT NULL DEFAULT ''")?;
+        log::info!("v9 -> v10 迁移完成：skill_repos 和 skills 表已支持自定义 Git 平台 URL");
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -893,6 +893,96 @@ pub fn run() {
                     }
                 });
 
+                // Skill 自动更新定时器
+                {
+                    let app_handle_for_skill = app.handle().clone();
+                    tauri::async_runtime::spawn(async move {
+                        // 启动后延迟 30 秒再检查，避免启动时 IO 竞争
+                        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+
+                        loop {
+                            let state = app_handle_for_skill.state::<AppState>();
+                            let skill_state = app_handle_for_skill
+                                .state::<commands::skill::SkillServiceState>();
+
+                            let frequency = state
+                                .db
+                                .get_setting("skill_auto_update_frequency")
+                                .unwrap_or(None)
+                                .unwrap_or_else(|| "daily".to_string());
+
+                            if frequency == "off" {
+                                tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                                continue;
+                            }
+
+                            let interval_secs: u64 = match frequency.as_str() {
+                                "on_launch" => 0,
+                                "daily" => 24 * 3600,
+                                "weekly" => 7 * 24 * 3600,
+                                "monthly" => 30 * 24 * 3600,
+                                _ => 24 * 3600,
+                            };
+
+                            let last_update = state
+                                .db
+                                .get_setting("skill_last_auto_update")
+                                .unwrap_or(None)
+                                .and_then(|s| s.parse::<u64>().ok())
+                                .unwrap_or(0);
+
+                            let now = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs();
+
+                            let should_update = frequency == "on_launch"
+                                || now.saturating_sub(last_update) >= interval_secs;
+
+                            if should_update {
+                                log::info!("Skill 自动更新检查开始（频率: {frequency}）");
+                                match skill_state.0.check_updates(&state.db).await {
+                                    Ok(updates) if !updates.is_empty() => {
+                                        log::info!(
+                                            "发现 {} 个 Skill 更新，开始自动更新",
+                                            updates.len()
+                                        );
+                                        for update in &updates {
+                                            match skill_state
+                                                .0
+                                                .update_skill(&state.db, &update.id)
+                                                .await
+                                            {
+                                                Ok(_) => log::info!(
+                                                    "✓ 自动更新 Skill: {}",
+                                                    update.name
+                                                ),
+                                                Err(e) => log::warn!(
+                                                    "✗ 自动更新 Skill {} 失败: {e}",
+                                                    update.name
+                                                ),
+                                            }
+                                        }
+                                    }
+                                    Ok(_) => log::info!("Skill 自动更新检查完成，无更新"),
+                                    Err(e) => log::warn!("Skill 自动更新检查失败: {e}"),
+                                }
+                                let _ = state
+                                    .db
+                                    .set_setting("skill_last_auto_update", &now.to_string());
+                            }
+
+                            // on_launch 模式只在启动时执行一次
+                            if frequency == "on_launch" {
+                                break;
+                            }
+
+                            // 每小时检查一次是否到了更新时间
+                            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                        }
+                    });
+                }
+
                 // Session log usage sync: 启动时同步一次，之后每 60 秒检查
                 let db_for_session_sync = state.db.clone();
                 tauri::async_runtime::spawn(async move {
@@ -1133,6 +1223,8 @@ pub fn run() {
             commands::discover_available_skills,
             commands::check_skill_updates,
             commands::update_skill,
+            commands::get_skill_auto_update_frequency,
+            commands::set_skill_auto_update_frequency,
             commands::migrate_skill_storage,
             commands::search_skills_sh,
             // Skill management (legacy API compatibility)

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -68,6 +68,9 @@ pub struct DiscoverableSkill {
     /// 分支名称
     #[serde(rename = "repoBranch")]
     pub repo_branch: String,
+    /// 仓库完整 URL（为空时默认 GitHub）
+    #[serde(rename = "repoUrl", default)]
+    pub repo_url: String,
 }
 
 /// 技能对象（兼容旧 API，内部使用 DiscoverableSkill）
@@ -100,7 +103,7 @@ pub struct Skill {
 /// 仓库配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillRepo {
-    /// GitHub 用户/组织名
+    /// 用户/组织名
     pub owner: String,
     /// 仓库名称
     pub name: String,
@@ -108,6 +111,9 @@ pub struct SkillRepo {
     pub branch: String,
     /// 是否启用
     pub enabled: bool,
+    /// 完整仓库 URL（为空时默认 GitHub）
+    #[serde(default)]
+    pub url: String,
 }
 
 /// 技能安装状态（旧版兼容）
@@ -139,24 +145,28 @@ impl Default for SkillStore {
                     name: "skills".to_string(),
                     branch: "main".to_string(),
                     enabled: true,
+                    url: String::new(),
                 },
                 SkillRepo {
                     owner: "ComposioHQ".to_string(),
                     name: "awesome-claude-skills".to_string(),
                     branch: "master".to_string(),
                     enabled: true,
+                    url: String::new(),
                 },
                 SkillRepo {
                     owner: "cexll".to_string(),
                     name: "myclaude".to_string(),
                     branch: "master".to_string(),
                     enabled: true,
+                    url: String::new(),
                 },
                 SkillRepo {
                     owner: "JimLiu".to_string(),
                     name: "baoyu-skills".to_string(),
                     branch: "main".to_string(),
                     enabled: true,
+                    url: String::new(),
                 },
             ],
         }
@@ -435,6 +445,69 @@ fn parse_agents_lock() -> HashMap<String, LockRepoInfo> {
     parsed
 }
 
+/// 检测本机是否安装了 git
+fn is_git_available() -> bool {
+    std::process::Command::new("git")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// 获取仓库的有效 git URL
+fn effective_repo_url(repo: &SkillRepo) -> String {
+    if !repo.url.is_empty() {
+        let mut url = repo.url.clone();
+        if !url.ends_with(".git") {
+            url.push_str(".git");
+        }
+        url
+    } else {
+        format!("https://github.com/{}/{}.git", repo.owner, repo.name)
+    }
+}
+
+/// 获取仓库的 web URL（用于浏览器打开）
+fn effective_repo_web_url(repo: &SkillRepo) -> String {
+    if !repo.url.is_empty() {
+        repo.url.trim_end_matches(".git").to_string()
+    } else {
+        format!("https://github.com/{}/{}", repo.owner, repo.name)
+    }
+}
+
+/// 根据仓库 URL 推断 Git 平台类型，返回 ZIP archive URL 模板
+fn build_zip_url(repo: &SkillRepo, branch: &str) -> String {
+    let web_url = effective_repo_web_url(repo);
+    let lower = web_url.to_lowercase();
+
+    if lower.contains("github.com") {
+        format!("{web_url}/archive/refs/heads/{branch}.zip")
+    } else if lower.contains("gitlab") {
+        format!("{web_url}/-/archive/{branch}/{}-{branch}.zip", repo.name)
+    } else {
+        // Gitea / Gogs / 其他平台通用格式
+        format!("{web_url}/archive/{branch}.zip")
+    }
+}
+
+/// 获取 repo-cache 目录
+fn get_repo_cache_dir(repo: &SkillRepo) -> PathBuf {
+    let base = get_app_config_dir().join("repo-cache");
+    if !repo.url.is_empty() {
+        let sanitized = repo.url
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .trim_end_matches(".git")
+            .replace(['/', '\\', ':'], "_");
+        base.join(sanitized)
+    } else {
+        base.join(format!("github.com_{}_{}", repo.owner, repo.name))
+    }
+}
+
 // ========== SkillService ==========
 
 pub struct SkillService;
@@ -451,8 +524,36 @@ impl SkillService {
     }
 
     /// 构建 Skill 文档 URL（指向仓库中的 SKILL.md 文件）
-    fn build_skill_doc_url(owner: &str, repo: &str, branch: &str, doc_path: &str) -> String {
-        format!("https://github.com/{owner}/{repo}/blob/{branch}/{doc_path}")
+    fn build_skill_doc_url(repo: &SkillRepo, branch: &str, doc_path: &str) -> String {
+        let base = effective_repo_web_url(repo);
+        let lower = base.to_lowercase();
+        if lower.contains("gitlab") {
+            format!("{base}/-/blob/{branch}/{doc_path}")
+        } else {
+            format!("{base}/blob/{branch}/{doc_path}")
+        }
+    }
+
+    /// 从 InstalledSkill 构建临时 SkillRepo（用于 URL 构建等）
+    fn skill_to_repo(skill: &InstalledSkill) -> SkillRepo {
+        SkillRepo {
+            owner: skill.repo_owner.clone().unwrap_or_default(),
+            name: skill.repo_name.clone().unwrap_or_default(),
+            branch: skill.repo_branch.clone().unwrap_or_else(|| "main".to_string()),
+            enabled: true,
+            url: skill.repo_url.clone().unwrap_or_default(),
+        }
+    }
+
+    /// 从 DiscoverableSkill 构建临时 SkillRepo
+    fn discoverable_to_repo(skill: &DiscoverableSkill) -> SkillRepo {
+        SkillRepo {
+            owner: skill.repo_owner.clone(),
+            name: skill.repo_name.clone(),
+            branch: skill.repo_branch.clone(),
+            enabled: true,
+            url: skill.repo_url.clone(),
+        }
     }
 
     /// 从旧 readme_url 中提取仓库内文档路径，兼容 `blob`/`tree` 两种格式
@@ -644,6 +745,7 @@ impl SkillService {
                 name: skill.repo_name.clone(),
                 branch: skill.repo_branch.clone(),
                 enabled: true,
+                url: skill.repo_url.clone(),
             };
 
             // 下载仓库
@@ -743,8 +845,7 @@ impl SkillService {
             .unwrap_or_else(|| format!("{}/SKILL.md", skill.directory.trim_end_matches('/')));
 
         let readme_url = Some(Self::build_skill_doc_url(
-            &skill.repo_owner,
-            &skill.repo_name,
+            &Self::discoverable_to_repo(&skill),
             &repo_branch,
             &doc_path,
         ));
@@ -768,6 +869,7 @@ impl SkillService {
             repo_owner: Some(skill.repo_owner.clone()),
             repo_name: Some(skill.repo_name.clone()),
             repo_branch: Some(repo_branch),
+            repo_url: if skill.repo_url.is_empty() { None } else { Some(skill.repo_url.clone()) },
             readme_url,
             apps: SkillApps::only(current_app),
             installed_at: chrono::Utc::now().timestamp(),
@@ -909,11 +1011,15 @@ impl SkillService {
         let ssot_dir = Self::get_ssot_dir()?;
 
         for ((owner, name, branch), group_skills) in &repo_groups {
+            let repo_url = group_skills.first()
+                .and_then(|s| s.repo_url.clone())
+                .unwrap_or_default();
             let repo = SkillRepo {
                 owner: owner.clone(),
                 name: name.clone(),
                 branch: branch.clone(),
                 enabled: true,
+                url: repo_url,
             };
 
             // 下载仓库 ZIP
@@ -1022,6 +1128,7 @@ impl SkillService {
             name: name.clone(),
             branch: branch.clone(),
             enabled: true,
+            url: skill.repo_url.clone().unwrap_or_default(),
         };
 
         let ssot_dir = Self::get_ssot_dir()?;
@@ -1106,6 +1213,7 @@ impl SkillService {
             repo_owner: skill.repo_owner.clone(),
             repo_name: skill.repo_name.clone(),
             repo_branch: Some(used_branch),
+            repo_url: skill.repo_url.clone(),
             readme_url,
             apps: skill.apps.clone(),
             installed_at: skill.installed_at,
@@ -1540,6 +1648,7 @@ impl SkillService {
                 repo_owner,
                 repo_name,
                 repo_branch,
+                repo_url: None,
                 readme_url,
                 apps,
                 installed_at: chrono::Utc::now().timestamp(),
@@ -1959,14 +2068,14 @@ impl SkillService {
             description: meta.description.unwrap_or_default(),
             directory: directory.to_string(),
             readme_url: Some(Self::build_skill_doc_url(
-                &repo.owner,
-                &repo.name,
+                repo,
                 &repo.branch,
                 doc_path,
             )),
             repo_owner: repo.owner.clone(),
             repo_name: repo.name.clone(),
             repo_branch: repo.branch.clone(),
+            repo_url: repo.url.clone(),
         })
     }
 
@@ -2120,10 +2229,6 @@ impl SkillService {
 
     /// 下载仓库
     async fn download_repo(&self, repo: &SkillRepo) -> Result<(PathBuf, String)> {
-        let temp_dir = tempfile::tempdir()?;
-        let temp_path = temp_dir.path().to_path_buf();
-        let _ = temp_dir.keep();
-
         let mut branches = Vec::new();
         if !repo.branch.is_empty() && !repo.branch.eq_ignore_ascii_case("HEAD") {
             branches.push(repo.branch.as_str());
@@ -2135,17 +2240,89 @@ impl SkillService {
             branches.push("master");
         }
 
-        let mut last_error = None;
-        for branch in branches {
-            let url = format!(
-                "https://github.com/{}/{}/archive/refs/heads/{}.zip",
-                repo.owner, repo.name, branch
-            );
+        // 优先使用 git clone
+        if is_git_available() {
+            let git_url = effective_repo_url(repo);
+            let cache_dir = get_repo_cache_dir(repo);
 
-            match self.download_and_extract(&url, &temp_path).await {
-                Ok(_) => {
+            // 如果缓存目录已存在且是 git 仓库，用 git pull
+            if cache_dir.join(".git").is_dir() {
+                for branch in &branches {
+                    let checkout = std::process::Command::new("git")
+                        .args(["checkout", branch])
+                        .current_dir(&cache_dir)
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::piped())
+                        .status();
+                    if checkout.map(|s| s.success()).unwrap_or(false) {
+                        let pull = std::process::Command::new("git")
+                            .args(["pull", "--ff-only"])
+                            .current_dir(&cache_dir)
+                            .stdout(std::process::Stdio::null())
+                            .stderr(std::process::Stdio::piped())
+                            .status();
+                        if pull.map(|s| s.success()).unwrap_or(false) {
+                            let temp_dir = tempfile::tempdir()?;
+                            let temp_path = temp_dir.path().to_path_buf();
+                            let _ = temp_dir.keep();
+                            Self::copy_dir_recursive_excluding(&cache_dir, &temp_path, ".git")?;
+                            return Ok((temp_path, branch.to_string()));
+                        }
+                    }
+                }
+                // pull 失败，删除缓存重新 clone
+                let _ = fs::remove_dir_all(&cache_dir);
+            }
+
+            // git clone --depth 1
+            for branch in &branches {
+                let _ = fs::create_dir_all(cache_dir.parent().unwrap_or(&cache_dir));
+                let status = std::process::Command::new("git")
+                    .args([
+                        "clone", "--depth", "1", "--branch", branch,
+                        &git_url,
+                        &cache_dir.to_string_lossy(),
+                    ])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::piped())
+                    .status();
+                if status.map(|s| s.success()).unwrap_or(false) {
+                    let temp_dir = tempfile::tempdir()?;
+                    let temp_path = temp_dir.path().to_path_buf();
+                    let _ = temp_dir.keep();
+                    Self::copy_dir_recursive_excluding(&cache_dir, &temp_path, ".git")?;
                     return Ok((temp_path, branch.to_string()));
                 }
+                let _ = fs::remove_dir_all(&cache_dir);
+            }
+
+            // 非 GitHub 仓库且 git clone 失败，直接报错
+            if !repo.url.is_empty() && !repo.url.to_lowercase().contains("github.com") {
+                return Err(anyhow!(format_skill_error(
+                    "GIT_CLONE_FAILED",
+                    &[("url", &git_url)],
+                    Some("checkNetwork"),
+                )));
+            }
+        } else if !repo.url.is_empty() && !repo.url.to_lowercase().contains("github.com") {
+            // 没有 git 且不是 GitHub 仓库，无法用 ZIP 兜底
+            return Err(anyhow!(format_skill_error(
+                "GIT_NOT_INSTALLED",
+                &[],
+                Some("installGit"),
+            )));
+        }
+
+        // ZIP 兜底（GitHub 或已知平台）
+        let temp_dir = tempfile::tempdir()?;
+        let temp_path = temp_dir.path().to_path_buf();
+        let _ = temp_dir.keep();
+
+        let mut last_error = None;
+        for branch in branches {
+            let url = build_zip_url(repo, branch);
+            match self.download_and_extract(&url, &temp_path).await {
+                Ok(_) => return Ok((temp_path, branch.to_string())),
                 Err(e) => {
                     last_error = Some(e);
                     continue;
@@ -2153,7 +2330,7 @@ impl SkillService {
             }
         }
 
-        Err(last_error.unwrap_or_else(|| anyhow::anyhow!("所有分支下载失败")))
+        Err(last_error.unwrap_or_else(|| anyhow!("所有分支下载失败")))
     }
 
     /// 下载并解压 ZIP
@@ -2240,6 +2417,29 @@ impl SkillService {
             let entry = entry?;
             let path = entry.path();
             let dest_path = dest.join(entry.file_name());
+
+            if path.is_dir() {
+                Self::copy_dir_recursive(&path, &dest_path)?;
+            } else {
+                fs::copy(&path, &dest_path)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// 递归复制目录，排除指定名称的子目录
+    fn copy_dir_recursive_excluding(src: &Path, dest: &Path, exclude: &str) -> Result<()> {
+        fs::create_dir_all(dest)?;
+
+        for entry in fs::read_dir(src)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            if name == exclude {
+                continue;
+            }
+            let path = entry.path();
+            let dest_path = dest.join(&name);
 
             if path.is_dir() {
                 Self::copy_dir_recursive(&path, &dest_path)?;
@@ -2565,6 +2765,7 @@ impl SkillService {
                 repo_owner: None,
                 repo_name: None,
                 repo_branch: None,
+                repo_url: None,
                 readme_url: None,
                 apps: SkillApps::only(current_app),
                 installed_at: chrono::Utc::now().timestamp(),
@@ -2795,8 +2996,13 @@ fn build_repo_info_from_lock(
             let fallback = format!("{dir_name}/SKILL.md");
             let doc_path = info.skill_path.as_deref().unwrap_or(&fallback);
             let url = Some(SkillService::build_skill_doc_url(
-                &info.owner,
-                &info.repo,
+                &SkillRepo {
+                    owner: info.owner.clone(),
+                    name: info.repo.clone(),
+                    branch: url_branch.clone(),
+                    enabled: true,
+                    url: String::new(),
+                },
                 &url_branch,
                 doc_path,
             ));
@@ -2833,9 +3039,9 @@ fn save_repos_from_lock(
                 let skill_repo = SkillRepo {
                     owner: info.owner.clone(),
                     name: info.repo.clone(),
-                    // 未知分支时使用 HEAD 语义，后续下载会回退到 main/master。
                     branch: info.branch.clone().unwrap_or_else(|| "HEAD".to_string()),
                     enabled: true,
+                    url: String::new(),
                 };
                 if let Err(e) = db.save_skill_repo(&skill_repo) {
                     log::warn!("保存 skill 仓库 {}/{} 失败: {}", info.owner, info.repo, e);
@@ -2952,6 +3158,7 @@ pub fn migrate_skills_to_ssot(db: &Arc<Database>) -> Result<usize> {
             repo_owner,
             repo_name,
             repo_branch,
+            repo_url: None,
             readme_url,
             apps,
             installed_at: chrono::Utc::now().timestamp(),

--- a/src/components/skills/RepoManager.tsx
+++ b/src/components/skills/RepoManager.tsx
@@ -45,20 +45,27 @@ export function RepoManager({
     ).length;
 
   const parseRepoUrl = (
-    url: string,
-  ): { owner: string; name: string } | null => {
+    input: string,
+  ): { owner: string; name: string; url: string } | null => {
     // 支持格式:
-    // - https://github.com/owner/name
-    // - owner/name
-    // - https://github.com/owner/name.git
+    // - https://any-host.com/owner/name
+    // - https://any-host.com/owner/name.git
+    // - owner/name (默认 GitHub)
 
-    let cleaned = url.trim();
-    cleaned = cleaned.replace(/^https?:\/\/github\.com\//, "");
-    cleaned = cleaned.replace(/\.git$/, "");
+    let cleaned = input.trim().replace(/\.git$/, "");
 
+    // 完整 URL
+    const urlMatch = cleaned.match(/^https?:\/\/([^/]+)\/([^/]+)\/([^/]+?)$/);
+    if (urlMatch) {
+      const [, host, owner, name] = urlMatch;
+      const isGitHub = host!.toLowerCase() === "github.com";
+      return { owner: owner!, name: name!, url: isGitHub ? "" : cleaned };
+    }
+
+    // 短格式 owner/name
     const parts = cleaned.split("/");
     if (parts.length === 2 && parts[0] && parts[1]) {
-      return { owner: parts[0], name: parts[1] };
+      return { owner: parts[0], name: parts[1], url: "" };
     }
 
     return null;
@@ -79,6 +86,7 @@ export function RepoManager({
         name: parsed.name,
         branch: branch || "main",
         enabled: true,
+        url: parsed.url,
       });
 
       setRepoUrl("");
@@ -88,9 +96,10 @@ export function RepoManager({
     }
   };
 
-  const handleOpenRepo = async (owner: string, name: string) => {
+  const handleOpenRepo = async (repo: SkillRepo) => {
     try {
-      await settingsApi.openExternal(`https://github.com/${owner}/${name}`);
+      const webUrl = repo.url || `https://github.com/${repo.owner}/${repo.name}`;
+      await settingsApi.openExternal(webUrl);
     } catch (error) {
       console.error("Failed to open URL:", error);
     }
@@ -157,7 +166,16 @@ export function RepoManager({
                     >
                       <div>
                         <div className="text-sm font-medium text-foreground">
-                          {repo.owner}/{repo.name}
+                          {repo.url ? (
+                            <>
+                              <span className="text-muted-foreground">
+                                {new URL(repo.url).host}/
+                              </span>
+                              {repo.owner}/{repo.name}
+                            </>
+                          ) : (
+                            <>{repo.owner}/{repo.name}</>
+                          )}
                         </div>
                         <div className="mt-1 text-xs text-muted-foreground">
                           {t("skills.repo.branch")}: {repo.branch || "main"}
@@ -173,7 +191,7 @@ export function RepoManager({
                           variant="ghost"
                           size="icon"
                           type="button"
-                          onClick={() => handleOpenRepo(repo.owner, repo.name)}
+                          onClick={() => handleOpenRepo(repo)}
                           title={t("common.view", { defaultValue: "查看" })}
                         >
                           <ExternalLink className="h-4 w-4" />

--- a/src/components/skills/RepoManagerPanel.tsx
+++ b/src/components/skills/RepoManagerPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -7,6 +7,7 @@ import { Trash2, ExternalLink, Plus } from "lucide-react";
 import { settingsApi } from "@/lib/api";
 import { FullScreenPanel } from "@/components/common/FullScreenPanel";
 import type { DiscoverableSkill, SkillRepo } from "@/lib/api/skills";
+import { skillsApi } from "@/lib/api/skills";
 
 interface RepoManagerPanelProps {
   repos: SkillRepo[];
@@ -27,6 +28,11 @@ export function RepoManagerPanel({
   const [repoUrl, setRepoUrl] = useState("");
   const [branch, setBranch] = useState("");
   const [error, setError] = useState("");
+  const [autoUpdateFreq, setAutoUpdateFreq] = useState("daily");
+
+  useEffect(() => {
+    skillsApi.getAutoUpdateFrequency().then(setAutoUpdateFreq).catch(console.error);
+  }, []);
 
   const getSkillCount = (repo: SkillRepo) =>
     skills.filter(
@@ -37,15 +43,20 @@ export function RepoManagerPanel({
     ).length;
 
   const parseRepoUrl = (
-    url: string,
-  ): { owner: string; name: string } | null => {
-    let cleaned = url.trim();
-    cleaned = cleaned.replace(/^https?:\/\/github\.com\//, "");
-    cleaned = cleaned.replace(/\.git$/, "");
+    input: string,
+  ): { owner: string; name: string; url: string } | null => {
+    let cleaned = input.trim().replace(/\.git$/, "");
+
+    const urlMatch = cleaned.match(/^https?:\/\/([^/]+)\/([^/]+)\/([^/]+?)$/);
+    if (urlMatch) {
+      const [, host, owner, name] = urlMatch;
+      const isGitHub = host!.toLowerCase() === "github.com";
+      return { owner: owner!, name: name!, url: isGitHub ? "" : cleaned };
+    }
 
     const parts = cleaned.split("/");
     if (parts.length === 2 && parts[0] && parts[1]) {
-      return { owner: parts[0], name: parts[1] };
+      return { owner: parts[0], name: parts[1], url: "" };
     }
 
     return null;
@@ -66,6 +77,7 @@ export function RepoManagerPanel({
         name: parsed.name,
         branch: branch || "main",
         enabled: true,
+        url: parsed.url,
       });
 
       setRepoUrl("");
@@ -75,9 +87,10 @@ export function RepoManagerPanel({
     }
   };
 
-  const handleOpenRepo = async (owner: string, name: string) => {
+  const handleOpenRepo = async (repo: SkillRepo) => {
     try {
-      await settingsApi.openExternal(`https://github.com/${owner}/${name}`);
+      const webUrl = repo.url || `https://github.com/${repo.owner}/${repo.name}`;
+      await settingsApi.openExternal(webUrl);
     } catch (error) {
       console.error("Failed to open URL:", error);
     }
@@ -153,7 +166,16 @@ export function RepoManagerPanel({
               >
                 <div>
                   <div className="text-sm font-medium text-foreground">
-                    {repo.owner}/{repo.name}
+                    {repo.url ? (
+                      <>
+                        <span className="text-muted-foreground">
+                          {new URL(repo.url).host}/
+                        </span>
+                        {repo.owner}/{repo.name}
+                      </>
+                    ) : (
+                      <>{repo.owner}/{repo.name}</>
+                    )}
                   </div>
                   <div className="mt-1 text-xs text-muted-foreground">
                     {t("skills.repo.branch")}: {repo.branch || "main"}
@@ -169,7 +191,7 @@ export function RepoManagerPanel({
                     variant="ghost"
                     size="icon"
                     type="button"
-                    onClick={() => handleOpenRepo(repo.owner, repo.name)}
+                    onClick={() => handleOpenRepo(repo)}
                     title={t("common.view", { defaultValue: "查看" })}
                     className="hover:bg-black/5 dark:hover:bg-white/5"
                   >
@@ -190,6 +212,38 @@ export function RepoManagerPanel({
             ))}
           </div>
         )}
+      </div>
+
+      {/* 自动更新设置 */}
+      <div className="space-y-4 glass-card rounded-xl p-6">
+        <h3 className="text-base font-semibold text-foreground">
+          {t("skills.autoUpdate.title")}
+        </h3>
+        <div className="flex items-center gap-3">
+          <Label htmlFor="auto-update-freq" className="text-foreground whitespace-nowrap">
+            {t("skills.autoUpdate.frequency")}
+          </Label>
+          <select
+            id="auto-update-freq"
+            value={autoUpdateFreq}
+            onChange={async (e) => {
+              const val = e.target.value;
+              setAutoUpdateFreq(val);
+              try {
+                await skillsApi.setAutoUpdateFrequency(val);
+              } catch (err) {
+                console.error("Failed to set auto-update frequency:", err);
+              }
+            }}
+            className="flex h-9 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <option value="on_launch">{t("skills.autoUpdate.onLaunch")}</option>
+            <option value="daily">{t("skills.autoUpdate.daily")}</option>
+            <option value="weekly">{t("skills.autoUpdate.weekly")}</option>
+            <option value="monthly">{t("skills.autoUpdate.monthly")}</option>
+            <option value="off">{t("skills.autoUpdate.off")}</option>
+          </select>
+        </div>
       </div>
     </FullScreenPanel>
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1722,6 +1722,8 @@
       "parseMetadataFailed": "Failed to parse skill metadata",
       "getHomeDirFailed": "Unable to get user home directory",
       "noSkillsInZip": "No skills found in ZIP file (requires SKILL.md file)",
+      "gitCloneFailed": "Failed to clone Git repository",
+      "gitNotInstalled": "This repository requires Git, but Git was not detected",
       "networkError": "Network error",
       "fsError": "File system error",
       "unknownError": "Unknown error",
@@ -1733,14 +1735,15 @@
         "checkDiskSpace": "Please check disk space",
         "checkPermission": "Please check directory permissions",
         "uninstallFirst": "Please uninstall the existing skill with the same name first",
-        "checkZipContent": "Please verify the ZIP file contains valid skill directories (with SKILL.md files)"
+        "checkZipContent": "Please verify the ZIP file contains valid skill directories (with SKILL.md files)",
+        "installGit": "Please install Git: https://git-scm.com/downloads"
       }
     },
     "repo": {
       "title": "Manage Skill Repositories",
-      "description": "Add or remove GitHub skill repository sources",
+      "description": "Add or remove skill repository sources (GitHub, GitLab, Gitea, etc.)",
       "url": "Repository URL",
-      "urlPlaceholder": "owner/name or https://github.com/owner/name",
+      "urlPlaceholder": "owner/name or https://gitlab.example.com/owner/name",
       "branch": "Branch",
       "branchPlaceholder": "main",
       "path": "Skills Path",
@@ -1754,6 +1757,15 @@
       "removeSuccess": "Repository {{owner}}/{{name}} removed",
       "removeFailed": "Failed to remove",
       "skillCount": "{{count}} skills detected"
+    },
+    "autoUpdate": {
+      "title": "Auto Update",
+      "frequency": "Frequency",
+      "onLaunch": "On Launch",
+      "daily": "Daily",
+      "weekly": "Weekly",
+      "monthly": "Monthly",
+      "off": "Off"
     },
     "search": "Search Skills",
     "searchPlaceholder": "Search skill name or repo...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1722,6 +1722,8 @@
       "parseMetadataFailed": "スキルメタデータの解析に失敗しました",
       "getHomeDirFailed": "ユーザーのホームディレクトリを取得できません",
       "noSkillsInZip": "ZIP ファイルにスキルが見つかりません（SKILL.md ファイルが必要です）",
+      "gitCloneFailed": "Git リポジトリのクローンに失敗しました",
+      "gitNotInstalled": "このリポジトリには Git が必要ですが、Git が検出されませんでした",
       "networkError": "ネットワークエラー",
       "fsError": "ファイルシステムエラー",
       "unknownError": "不明なエラー",
@@ -1733,14 +1735,15 @@
         "checkDiskSpace": "ディスク容量を確認してください",
         "checkPermission": "ディレクトリの権限を確認してください",
         "uninstallFirst": "同名のスキルを先にアンインストールしてください",
-        "checkZipContent": "ZIP ファイルに有効なスキルディレクトリ（SKILL.md を含む）が含まれていることを確認してください"
+        "checkZipContent": "ZIP ファイルに有効なスキルディレクトリ（SKILL.md を含む）が含まれていることを確認してください",
+        "installGit": "Git をインストールしてください: https://git-scm.com/downloads"
       }
     },
     "repo": {
       "title": "スキルリポジトリを管理",
-      "description": "GitHub のスキルリポジトリソースを追加または削除します",
+      "description": "スキルリポジトリソースを追加または削除します（GitHub、GitLab、Gitea など）",
       "url": "リポジトリ URL",
-      "urlPlaceholder": "owner/name または https://github.com/owner/name",
+      "urlPlaceholder": "owner/name または https://gitlab.example.com/owner/name",
       "branch": "ブランチ",
       "branchPlaceholder": "main",
       "path": "スキルパス",
@@ -1754,6 +1757,15 @@
       "removeSuccess": "リポジトリ {{owner}}/{{name}} を削除しました",
       "removeFailed": "削除に失敗しました",
       "skillCount": "{{count}} 件のスキルを検出"
+    },
+    "autoUpdate": {
+      "title": "自動更新",
+      "frequency": "更新頻度",
+      "onLaunch": "起動時",
+      "daily": "毎日",
+      "weekly": "毎週",
+      "monthly": "毎月",
+      "off": "オフ"
     },
     "search": "スキルを検索",
     "searchPlaceholder": "スキル名またはリポジトリで検索...",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1723,6 +1723,8 @@
       "parseMetadataFailed": "解析技能元数据失败",
       "getHomeDirFailed": "无法获取用户主目录",
       "noSkillsInZip": "ZIP 文件中未找到技能（需包含 SKILL.md 文件）",
+      "gitCloneFailed": "Git 克隆仓库失败",
+      "gitNotInstalled": "该仓库需要 Git 才能访问，但未检测到 Git",
       "networkError": "网络错误",
       "fsError": "文件系统错误",
       "unknownError": "未知错误",
@@ -1734,14 +1736,15 @@
         "checkDiskSpace": "请检查磁盘空间",
         "checkPermission": "请检查目录权限",
         "uninstallFirst": "请先卸载已安装的同名技能",
-        "checkZipContent": "请确认 ZIP 文件包含有效的技能目录（含 SKILL.md 文件）"
+        "checkZipContent": "请确认 ZIP 文件包含有效的技能目录（含 SKILL.md 文件）",
+        "installGit": "请安装 Git: https://git-scm.com/downloads"
       }
     },
     "repo": {
       "title": "管理技能仓库",
-      "description": "添加或删除 GitHub 技能仓库源",
+      "description": "添加或删除技能仓库源（支持 GitHub、GitLab、Gitea 等）",
       "url": "仓库 URL",
-      "urlPlaceholder": "owner/name 或 https://github.com/owner/name",
+      "urlPlaceholder": "owner/name 或 https://gitlab.example.com/owner/name",
       "branch": "分支",
       "branchPlaceholder": "main",
       "path": "技能路径",
@@ -1755,6 +1758,15 @@
       "removeSuccess": "仓库 {{owner}}/{{name}} 已删除",
       "removeFailed": "删除失败",
       "skillCount": "识别到 {{count}} 个技能"
+    },
+    "autoUpdate": {
+      "title": "自动更新",
+      "frequency": "更新频率",
+      "onLaunch": "每次启动",
+      "daily": "每天",
+      "weekly": "每周",
+      "monthly": "每月",
+      "off": "关闭"
     },
     "search": "搜索技能",
     "searchPlaceholder": "搜索技能名称或仓库名称...",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -22,6 +22,7 @@ export interface InstalledSkill {
   repoOwner?: string;
   repoName?: string;
   repoBranch?: string;
+  repoUrl?: string;
   readmeUrl?: string;
   apps: SkillApps;
   installedAt: number;
@@ -50,6 +51,7 @@ export interface DiscoverableSkill {
   repoOwner: string;
   repoName: string;
   repoBranch: string;
+  repoUrl: string;
 }
 
 /** 未管理的 Skill（用于导入） */
@@ -120,6 +122,8 @@ export interface SkillRepo {
   name: string;
   branch: string;
   enabled: boolean;
+  /** 完整仓库 URL（为空时默认 GitHub） */
+  url: string;
 }
 
 // ========== API ==========
@@ -270,5 +274,17 @@ export const skillsApi = {
     currentApp: AppId,
   ): Promise<InstalledSkill[]> {
     return await invoke("install_skills_from_zip", { filePath, currentApp });
+  },
+
+  // ========== 自动更新 ==========
+
+  /** 获取自动更新频率 */
+  async getAutoUpdateFrequency(): Promise<string> {
+    return await invoke("get_skill_auto_update_frequency");
+  },
+
+  /** 设置自动更新频率 */
+  async setAutoUpdateFrequency(frequency: string): Promise<void> {
+    return await invoke("set_skill_auto_update_frequency", { frequency });
   },
 };

--- a/src/lib/errors/skillErrorParser.ts
+++ b/src/lib/errors/skillErrorParser.ts
@@ -39,6 +39,8 @@ function getErrorI18nKey(code: string): string {
     EMPTY_ARCHIVE: "skills.error.emptyArchive",
     GET_HOME_DIR_FAILED: "skills.error.getHomeDirFailed",
     NO_SKILLS_IN_ZIP: "skills.error.noSkillsInZip",
+    GIT_CLONE_FAILED: "skills.error.gitCloneFailed",
+    GIT_NOT_INSTALLED: "skills.error.gitNotInstalled",
   };
 
   return mapping[code] || "skills.error.unknownError";
@@ -56,6 +58,7 @@ function getSuggestionI18nKey(suggestion: string): string {
     checkPermission: "skills.error.suggestion.checkPermission",
     uninstallFirst: "skills.error.suggestion.uninstallFirst",
     checkZipContent: "skills.error.suggestion.checkZipContent",
+    installGit: "skills.error.suggestion.installGit",
     http403: "skills.error.http403",
     http404: "skills.error.http404",
     http429: "skills.error.http429",


### PR DESCRIPTION
## Summary

- Support any Git platform (GitHub/GitLab/Gitea/Gogs) for skill repositories, not just GitHub
- Use `git clone/pull` when available for faster incremental updates, fall back to ZIP download for known platforms
- Add configurable auto-update scheduler (on_launch/daily/weekly/monthly/off)
- Frontend `parseRepoUrl` now accepts full URLs like `https://gitlab.example.com/owner/name`
- Short format `owner/name` still defaults to GitHub for backward compatibility

## Changes

- **Backend**: Add `url` field to `SkillRepo` and `InstalledSkill`, rewrite `download_repo` with git-first strategy, add repo cache directory, add auto-update timer in `lib.rs`
- **Database**: Migration v9→v10 adds `url` column to `skill_repos` and `repo_url` to `skills`
- **Frontend**: Updated `parseRepoUrl` in both `RepoManager` and `RepoManagerPanel`, added auto-update frequency selector, repo list shows host for non-GitHub repos
- **i18n**: New strings for zh/en/ja (auto-update UI, git error messages)
- **Error handling**: New `GIT_NOT_INSTALLED` and `GIT_CLONE_FAILED` error codes with user-friendly messages

## Test plan

- [ ] Add a GitHub repo via short format `owner/name` — should work as before
- [ ] Add a GitLab/Gitea repo via full URL — should clone via git
- [ ] Add a repo without git installed — GitHub repos fall back to ZIP, non-GitHub repos show "install git" error
- [ ] Change auto-update frequency in settings — verify it persists across app restarts
- [ ] Upgrade from v9 database — verify migration adds new columns without data loss