### PR TITLE
fix: always show name on hover

### DIFF
--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -74,6 +74,7 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
           "inline-flex items-center justify-center flex-shrink-0",
           className,
         )}
+        title={name}
         style={{ ...sizeStyle, color: effectiveColor }}
         dangerouslySetInnerHTML={{ __html: iconSvg }}
       />
@@ -86,6 +87,7 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
       <img
         src={iconUrl}
         alt={name}
+        title={name}
         className={cn(
           "inline-flex items-center justify-center flex-shrink-0 object-contain",
           className,
@@ -113,6 +115,7 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
           "bg-muted text-muted-foreground font-semibold",
           className,
         )}
+        title={name}
         style={sizeStyle}
       >
         <span


### PR DESCRIPTION
cc @farion1231 

Codex 调查显示这里少了 name 加上 Hermes 的图片是 PNG 而不是有 title 属性的 SVG 所以 hover Hermes 图标不显示文本。

试着改了一下。Codex 提示说可能可以改用项目统一的 ToolTip 组件，但我不知道它是干嘛的也不知道具体样式长啥样，就还没加上去。

暂时不知道本地怎么构建和测试，看起来好像是那么会事，推个 PR 上来以供测试（x）