### PR TITLE
refactor: prefer default shell in commands::try_get_version

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -300,8 +300,13 @@ fn try_get_version(tool: &str) -> (Option<String>, Option<String>) {
 
     #[cfg(not(target_os = "windows"))]
     let output = {
-        Command::new("sh")
-            .arg("-c")
+        let shell = std::env::var("SHELL")
+            .ok()
+            .filter(|s| is_valid_shell(s))
+            .unwrap_or_else(|| "sh".to_string());
+        let flag = default_flag_for_shell(&shell);
+        Command::new(shell)
+            .arg(flag)
             .arg(format!("{tool} --version"))
             .output()
     };
@@ -345,7 +350,6 @@ fn is_valid_wsl_distro_name(name: &str) -> bool {
 }
 
 /// Validate that the given shell name is one of the allowed shells.
-#[cfg(target_os = "windows")]
 fn is_valid_shell(shell: &str) -> bool {
     matches!(
         shell.rsplit('/').next().unwrap_or(shell),
@@ -360,7 +364,6 @@ fn is_valid_shell_flag(flag: &str) -> bool {
 }
 
 /// Return the default invocation flag for the given shell.
-#[cfg(target_os = "windows")]
 fn default_flag_for_shell(shell: &str) -> &'static str {
     match shell.rsplit('/').next().unwrap_or(shell) {
         "dash" | "sh" => "-c",


### PR DESCRIPTION
我本地用的是 zsh 且安装路径在 pnpm 的全局安装路径下，所以 cc-switch 本地查找 codex/gemini 时，由于是通过 `pnpm install -g` 安装的，会找不到

pnpm 的全局安装路径是系统特化的，感觉在 `scan_cli_version` 里再拼新的 path 不如在 `try_get_version` 里调用用户默认的 SHELL

默认 SHELL 加载的 runtime config 里会拼 PATH 变量，但是只用 sh 的话，因为不会加载 `.zshrc` 等文件（实际也不认识），会导致 PATH 里缺少对应的搜索路径

cc @farion1231 