### PR TITLE
feat(provider-form): soften validation with "save anyway" prompt

### DIFF
--- a/src-tauri/src/services/model_fetch.rs
+++ b/src-tauri/src/services/model_fetch.rs
@@ -192,7 +192,7 @@ fn truncate_body(body: String) -> String {
         body
     } else {
         let mut s: String = body.chars().take(ERROR_BODY_MAX_CHARS).collect();
-        s.push_str("…");
+        s.push('…');
         s
     }
 }

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -297,9 +297,16 @@ export function ProviderForm({
     },
   );
 
+  // 软校验：收集"业务约束"类问题（空值/缺项），由用户决定是否仍要保存
+  const [softIssues, setSoftIssues] = useState<string[] | null>(null);
+  const [pendingFormValues, setPendingFormValues] =
+    useState<ProviderFormData | null>(null);
+  // 确认框走的提交路径绕过了 react-hook-form 的 isSubmitting，单独追踪
+  const [isConfirmSubmitting, setIsConfirmSubmitting] = useState(false);
+
   useEffect(() => {
-    onSubmittingChange?.(isSubmitting);
-  }, [isSubmitting, onSubmittingChange]);
+    onSubmittingChange?.(isSubmitting || isConfirmSubmitting);
+  }, [isSubmitting, isConfirmSubmitting, onSubmittingChange]);
 
   const {
     apiKey,
@@ -765,11 +772,6 @@ export function ProviderForm({
 
   const [isCommonConfigModalOpen, setIsCommonConfigModalOpen] = useState(false);
 
-  // 软校验：收集"业务约束"类问题（空值/缺项），由用户决定是否仍要保存
-  const [softIssues, setSoftIssues] = useState<string[] | null>(null);
-  const [pendingFormValues, setPendingFormValues] =
-    useState<ProviderFormData | null>(null);
-
   const handleSubmit = async (values: ProviderFormData) => {
     // 软性问题（业务约束，用户可选择仍要保存）
     const issues: string[] = [];
@@ -801,10 +803,13 @@ export function ProviderForm({
     const keyPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
     if (appId === "opencode" && !isAnyOmoCategory) {
+      // providerKey 是 opencode / openclaw / hermes 的主键 ID，空或格式不合法
+      // 都属于完整性约束，保留硬拒绝（mutations 层也会 throw，软化只会让错误更晦涩）
       if (!opencodeForm.opencodeProviderKey.trim()) {
-        issues.push(t("opencode.providerKeyRequired"));
-      } else if (!keyPattern.test(opencodeForm.opencodeProviderKey)) {
-        // B 类：格式错会造成文件路径问题，硬拒绝
+        toast.error(t("opencode.providerKeyRequired"));
+        return;
+      }
+      if (!keyPattern.test(opencodeForm.opencodeProviderKey)) {
         toast.error(t("opencode.providerKeyInvalid"));
         return;
       }
@@ -817,11 +822,9 @@ export function ProviderForm({
         return;
       }
       if (
-        opencodeForm.opencodeProviderKey.trim() &&
         !isProviderKeyLocked &&
         additiveExistingProviderKeys.includes(opencodeForm.opencodeProviderKey)
       ) {
-        // B 类：重复会覆盖其它供应商，硬拒绝
         toast.error(t("opencode.providerKeyDuplicate"));
         return;
       }
@@ -832,8 +835,10 @@ export function ProviderForm({
 
     if (appId === "openclaw") {
       if (!openclawForm.openclawProviderKey.trim()) {
-        issues.push(t("openclaw.providerKeyRequired"));
-      } else if (!keyPattern.test(openclawForm.openclawProviderKey)) {
+        toast.error(t("openclaw.providerKeyRequired"));
+        return;
+      }
+      if (!keyPattern.test(openclawForm.openclawProviderKey)) {
         toast.error(t("openclaw.providerKeyInvalid"));
         return;
       }
@@ -846,7 +851,6 @@ export function ProviderForm({
         return;
       }
       if (
-        openclawForm.openclawProviderKey.trim() &&
         !isProviderKeyLocked &&
         additiveExistingProviderKeys.includes(openclawForm.openclawProviderKey)
       ) {
@@ -857,8 +861,10 @@ export function ProviderForm({
 
     if (appId === "hermes") {
       if (!hermesForm.hermesProviderKey.trim()) {
-        issues.push(t("hermes.form.providerKeyRequired"));
-      } else if (!keyPattern.test(hermesForm.hermesProviderKey)) {
+        toast.error(t("hermes.form.providerKeyRequired"));
+        return;
+      }
+      if (!keyPattern.test(hermesForm.hermesProviderKey)) {
         toast.error(t("hermes.form.providerKeyInvalid"));
         return;
       }
@@ -871,7 +877,6 @@ export function ProviderForm({
         return;
       }
       if (
-        hermesForm.hermesProviderKey.trim() &&
         !isProviderKeyLocked &&
         additiveExistingProviderKeys.includes(hermesForm.hermesProviderKey)
       ) {
@@ -2110,7 +2115,10 @@ export function ProviderForm({
               <Button variant="outline" type="button" onClick={onCancel}>
                 {t("common.cancel")}
               </Button>
-              <Button type="submit" disabled={isSubmitting}>
+              <Button
+                type="submit"
+                disabled={isSubmitting || isConfirmSubmitting}
+              >
                 {submitLabel}
               </Button>
             </div>
@@ -2146,15 +2154,27 @@ export function ProviderForm({
           defaultValue: "仍要保存",
         })}
         cancelText={t("common.cancel")}
-        onConfirm={() => {
+        onConfirm={async () => {
+          if (isConfirmSubmitting) return;
           const values = pendingFormValues;
-          setSoftIssues(null);
-          setPendingFormValues(null);
-          if (values) {
-            void performSubmit(values);
+          if (!values) {
+            setSoftIssues(null);
+            return;
+          }
+          setIsConfirmSubmitting(true);
+          try {
+            await performSubmit(values);
+            setSoftIssues(null);
+            setPendingFormValues(null);
+          } catch (error) {
+            console.error("[ProviderForm] soft-confirm submit failed:", error);
+            // 保留确认框和 pending values，让用户可以重试或取消
+          } finally {
+            setIsConfirmSubmitting(false);
           }
         }}
         onCancel={() => {
+          if (isConfirmSubmitting) return;
           setSoftIssues(null);
           setPendingFormValues(null);
         }}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -765,36 +765,46 @@ export function ProviderForm({
 
   const [isCommonConfigModalOpen, setIsCommonConfigModalOpen] = useState(false);
 
+  // 软校验：收集"业务约束"类问题（空值/缺项），由用户决定是否仍要保存
+  const [softIssues, setSoftIssues] = useState<string[] | null>(null);
+  const [pendingFormValues, setPendingFormValues] =
+    useState<ProviderFormData | null>(null);
+
   const handleSubmit = async (values: ProviderFormData) => {
+    // 软性问题（业务约束，用户可选择仍要保存）
+    const issues: string[] = [];
+
+    // 模板变量未填：A 类（空值）
     if (appId === "claude" && templateValueEntries.length > 0) {
       const validation = validateTemplateValues();
       if (!validation.isValid && validation.missingField) {
-        toast.error(
+        issues.push(
           t("providerForm.fillParameter", {
             label: validation.missingField.label,
             defaultValue: `请填写 ${validation.missingField.label}`,
           }),
         );
-        return;
       }
     }
 
+    // 供应商名空：A 类
     if (!values.name.trim()) {
-      toast.error(
+      issues.push(
         t("providerForm.fillSupplierName", {
           defaultValue: "请填写供应商名称",
         }),
       );
-      return;
     }
 
+    // opencode / openclaw / hermes: providerKey 相关
+    // A 类（空）归到 issues；B 类（正则不合法 / 重复 / 状态加载中）仍硬拒绝
+    const keyPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
     if (appId === "opencode" && !isAnyOmoCategory) {
-      const keyPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
       if (!opencodeForm.opencodeProviderKey.trim()) {
-        toast.error(t("opencode.providerKeyRequired"));
-        return;
-      }
-      if (!keyPattern.test(opencodeForm.opencodeProviderKey)) {
+        issues.push(t("opencode.providerKeyRequired"));
+      } else if (!keyPattern.test(opencodeForm.opencodeProviderKey)) {
+        // B 类：格式错会造成文件路径问题，硬拒绝
         toast.error(t("opencode.providerKeyInvalid"));
         return;
       }
@@ -807,26 +817,23 @@ export function ProviderForm({
         return;
       }
       if (
+        opencodeForm.opencodeProviderKey.trim() &&
         !isProviderKeyLocked &&
         additiveExistingProviderKeys.includes(opencodeForm.opencodeProviderKey)
       ) {
+        // B 类：重复会覆盖其它供应商，硬拒绝
         toast.error(t("opencode.providerKeyDuplicate"));
         return;
       }
       if (Object.keys(opencodeForm.opencodeModels).length === 0) {
-        toast.error(t("opencode.modelsRequired"));
-        return;
+        issues.push(t("opencode.modelsRequired"));
       }
     }
 
-    // OpenClaw: validate provider key
     if (appId === "openclaw") {
-      const keyPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
       if (!openclawForm.openclawProviderKey.trim()) {
-        toast.error(t("openclaw.providerKeyRequired"));
-        return;
-      }
-      if (!keyPattern.test(openclawForm.openclawProviderKey)) {
+        issues.push(t("openclaw.providerKeyRequired"));
+      } else if (!keyPattern.test(openclawForm.openclawProviderKey)) {
         toast.error(t("openclaw.providerKeyInvalid"));
         return;
       }
@@ -839,6 +846,7 @@ export function ProviderForm({
         return;
       }
       if (
+        openclawForm.openclawProviderKey.trim() &&
         !isProviderKeyLocked &&
         additiveExistingProviderKeys.includes(openclawForm.openclawProviderKey)
       ) {
@@ -847,14 +855,10 @@ export function ProviderForm({
       }
     }
 
-    // Hermes: validate provider key
     if (appId === "hermes") {
-      const keyPattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
       if (!hermesForm.hermesProviderKey.trim()) {
-        toast.error(t("hermes.form.providerKeyRequired"));
-        return;
-      }
-      if (!keyPattern.test(hermesForm.hermesProviderKey)) {
+        issues.push(t("hermes.form.providerKeyRequired"));
+      } else if (!keyPattern.test(hermesForm.hermesProviderKey)) {
         toast.error(t("hermes.form.providerKeyInvalid"));
         return;
       }
@@ -867,6 +871,7 @@ export function ProviderForm({
         return;
       }
       if (
+        hermesForm.hermesProviderKey.trim() &&
         !isProviderKeyLocked &&
         additiveExistingProviderKeys.includes(hermesForm.hermesProviderKey)
       ) {
@@ -875,9 +880,7 @@ export function ProviderForm({
       }
     }
 
-    // 非官方供应商必填校验：端点和 API Key
-    // cloud_provider（如 Bedrock）通过模板变量处理认证，跳过通用校验
-    // GitHub Copilot 使用 OAuth 认证，不需要 API Key
+    // OAuth 未登录：B 类（token 根本不存在，保存了也没法建立）
     const isCopilotProvider =
       templatePreset?.providerType === "github_copilot" ||
       initialData?.meta?.providerType === "github_copilot" ||
@@ -885,7 +888,6 @@ export function ProviderForm({
     const isCodexOauthProvider =
       templatePreset?.providerType === "codex_oauth" ||
       initialData?.meta?.providerType === "codex_oauth";
-    // GitHub Copilot 必须先登录才能添加
     if (isCopilotProvider && !isCopilotAuthenticated) {
       toast.error(
         t("copilot.loginRequired", {
@@ -894,7 +896,6 @@ export function ProviderForm({
       );
       return;
     }
-    // Codex OAuth 必须先登录才能添加
     if (isCodexOauthProvider && !isCodexOauthAuthenticated) {
       toast.error(
         t("codexOauth.loginRequired", {
@@ -904,60 +905,107 @@ export function ProviderForm({
       return;
     }
 
+    // OMO Other Fields JSON：B 类（格式错了保存下去数据就坏了）
+    if (
+      appId === "opencode" &&
+      isAnyOmoCategory &&
+      omoDraft.omoOtherFieldsStr.trim()
+    ) {
+      try {
+        const otherFields = parseOmoOtherFieldsObject(
+          omoDraft.omoOtherFieldsStr,
+        );
+        if (!otherFields) {
+          toast.error(
+            t("omo.jsonMustBeObject", {
+              field: t("omo.otherFields", {
+                defaultValue: "Other Config",
+              }),
+              defaultValue: "{{field}} must be a JSON object",
+            }),
+          );
+          return;
+        }
+      } catch {
+        toast.error(
+          t("omo.invalidJson", {
+            defaultValue: "Other Fields contains invalid JSON",
+          }),
+        );
+        return;
+      }
+    }
+
+    // 非官方供应商端点 / API Key 空：A 类
+    // cloud_provider（如 Bedrock）通过模板变量处理认证，跳过通用校验
     if (category !== "official" && category !== "cloud_provider") {
       if (appId === "claude") {
         if (!isCodexOauthProvider && !baseUrl.trim()) {
-          toast.error(
+          issues.push(
             t("providerForm.endpointRequired", {
               defaultValue: "非官方供应商请填写 API 端点",
             }),
           );
-          return;
         }
         if (!isCopilotProvider && !isCodexOauthProvider && !apiKey.trim()) {
-          toast.error(
+          issues.push(
             t("providerForm.apiKeyRequired", {
               defaultValue: "非官方供应商请填写 API Key",
             }),
           );
-          return;
         }
       } else if (appId === "codex") {
         if (!codexBaseUrl.trim()) {
-          toast.error(
+          issues.push(
             t("providerForm.endpointRequired", {
               defaultValue: "非官方供应商请填写 API 端点",
             }),
           );
-          return;
         }
         if (!codexApiKey.trim()) {
-          toast.error(
+          issues.push(
             t("providerForm.apiKeyRequired", {
               defaultValue: "非官方供应商请填写 API Key",
             }),
           );
-          return;
         }
       } else if (appId === "gemini") {
         if (!geminiBaseUrl.trim()) {
-          toast.error(
+          issues.push(
             t("providerForm.endpointRequired", {
               defaultValue: "非官方供应商请填写 API 端点",
             }),
           );
-          return;
         }
         if (!geminiApiKey.trim()) {
-          toast.error(
+          issues.push(
             t("providerForm.apiKeyRequired", {
               defaultValue: "非官方供应商请填写 API Key",
             }),
           );
-          return;
         }
       }
     }
+
+    if (issues.length > 0) {
+      // 弹确认框让用户决定是否仍要保存
+      setSoftIssues(issues);
+      setPendingFormValues(values);
+      return;
+    }
+
+    await performSubmit(values);
+  };
+
+  const performSubmit = async (values: ProviderFormData) => {
+    // OAuth / 其它身份识别（与 handleSubmit 保持一致）
+    const isCopilotProvider =
+      templatePreset?.providerType === "github_copilot" ||
+      initialData?.meta?.providerType === "github_copilot" ||
+      baseUrl.includes("githubcopilot.com");
+    const isCodexOauthProvider =
+      templatePreset?.providerType === "codex_oauth" ||
+      initialData?.meta?.providerType === "codex_oauth";
 
     let settingsConfig: string;
 
@@ -999,29 +1047,12 @@ export function ProviderForm({
         omoConfig.categories = omoDraft.omoCategories;
       }
       if (omoDraft.omoOtherFieldsStr.trim()) {
-        try {
-          const otherFields = parseOmoOtherFieldsObject(
-            omoDraft.omoOtherFieldsStr,
-          );
-          if (!otherFields) {
-            toast.error(
-              t("omo.jsonMustBeObject", {
-                field: t("omo.otherFields", {
-                  defaultValue: "Other Config",
-                }),
-                defaultValue: "{{field}} must be a JSON object",
-              }),
-            );
-            return;
-          }
+        // 格式已在 handleSubmit 前置校验中验证过，此处可以安全解析
+        const otherFields = parseOmoOtherFieldsObject(
+          omoDraft.omoOtherFieldsStr,
+        );
+        if (otherFields) {
           omoConfig.otherFields = otherFields;
-        } catch {
-          toast.error(
-            t("omo.invalidJson", {
-              defaultValue: "Other Fields contains invalid JSON",
-            }),
-          );
-          return;
         }
       }
       settingsConfig = JSON.stringify(omoConfig);
@@ -2095,6 +2126,38 @@ export function ProviderForm({
         confirmText={t("confirm.commonConfig.confirm")}
         onConfirm={() => void handleCommonConfigConfirm()}
         onCancel={() => void handleCommonConfigConfirm()}
+      />
+
+      <ConfirmDialog
+        isOpen={softIssues !== null && softIssues.length > 0}
+        variant="info"
+        title={t("providerForm.softValidation.title", {
+          defaultValue: "配置存在以下问题",
+        })}
+        message={
+          (softIssues ?? []).map((issue) => `• ${issue}`).join("\n") +
+          "\n\n" +
+          t("providerForm.softValidation.hint", {
+            defaultValue:
+              "仍要保存吗？保存后切换此供应商时可能失败，可以之后再补全。",
+          })
+        }
+        confirmText={t("providerForm.softValidation.saveAnyway", {
+          defaultValue: "仍要保存",
+        })}
+        cancelText={t("common.cancel")}
+        onConfirm={() => {
+          const values = pendingFormValues;
+          setSoftIssues(null);
+          setPendingFormValues(null);
+          if (values) {
+            void performSubmit(values);
+          }
+        }}
+        onCancel={() => {
+          setSoftIssues(null);
+          setPendingFormValues(null);
+        }}
       />
     </>
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -824,6 +824,11 @@
     "fillTemplateValue": "Please fill in {{label}}",
     "endpointRequired": "API endpoint is required for non-official providers",
     "apiKeyRequired": "API Key is required for non-official providers",
+    "softValidation": {
+      "title": "Configuration has the following issues",
+      "hint": "Save anyway? Switching to this provider may fail; you can fill these in later.",
+      "saveAnyway": "Save anyway"
+    },
     "configJsonError": "Config JSON format error, please check syntax",
     "authJsonRequired": "auth.json must be a JSON object",
     "authJsonError": "auth.json format error, please check JSON syntax",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -824,6 +824,11 @@
     "fillTemplateValue": "{{label}} を入力してください",
     "endpointRequired": "公式以外は API エンドポイントが必須です",
     "apiKeyRequired": "公式以外は API Key が必須です",
+    "softValidation": {
+      "title": "設定に以下の問題があります",
+      "hint": "それでも保存しますか？保存後、このプロバイダーへの切り替えが失敗する可能性がありますが、後から補完できます。",
+      "saveAnyway": "それでも保存"
+    },
     "configJsonError": "Config JSON の形式が正しくありません。構文を確認してください",
     "authJsonRequired": "auth.json は JSON オブジェクトで入力してください",
     "authJsonError": "auth.json の形式が正しくありません。JSON を確認してください",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -824,6 +824,11 @@
     "fillTemplateValue": "请填写 {{label}}",
     "endpointRequired": "非官方供应商请填写 API 端点",
     "apiKeyRequired": "非官方供应商请填写 API Key",
+    "softValidation": {
+      "title": "配置存在以下问题",
+      "hint": "仍要保存吗？保存后切换此供应商时可能失败，可以之后再补全。",
+      "saveAnyway": "仍要保存"
+    },
     "configJsonError": "配置JSON格式错误，请检查语法",
     "authJsonRequired": "auth.json 必须是 JSON 对象",
     "authJsonError": "auth.json 格式错误，请检查JSON语法",


### PR DESCRIPTION
## 背景

起因：#2196（Bedrock / Gemini 自定义 BASE_URL 被硬拒绝保存）、#1204（Vertex AI 支持）。详细讨论见 #2196 的评论区。

## 问题

`ProviderForm.tsx` 的 `handleSubmit` 里有 24 处 `toast.error + return` 一刀切拒绝保存，但：
- **后端** `src-tauri/src/gemini_config.rs` 已经有「宽松保存 / 严格切换」分层：`validate_gemini_settings`（保存）vs `validate_gemini_settings_strict`（切换）
- **前端**却没跟上，导致 Bedrock、Vertex、自定义 Gemini BASE_URL 等合法配置明明后端能接受，UI 却拒绝保存

本 PR 让前端对齐后端现有模式。

## 改动思路

把校验分两类：

### A 类：业务约束（软化 → 弹确认框）

空值、缺项，放行后数据结构仍正确，只是切换时后端 strict 校验会再兜底一次：
- 供应商名为空
- 非官方 claude / codex / gemini 的 API 端点为空
- 非官方 claude / codex / gemini 的 API Key 为空
- opencode 未选 model
- Claude 模板变量未填
- opencode / openclaw / hermes providerKey 为空

### B 类：完整性约束（保持硬拒绝）

放行后会产生损坏数据或根本无法工作：
- providerKey 正则不合法（会影响文件路径）
- providerKey 与其它供应商重复（会互相覆盖）
- Copilot / Codex OAuth 未登录（没 token 根本建立不了）
- omo Other Fields JSON 不是对象 / JSON 解析失败
- providerKey lock 状态加载中

## 实现

- 在 `handleSubmit` 中将 A 类改为 `issues.push(...)`，B 类保留 `toast.error + return`
- 若 `issues.length > 0`，弹 `ConfirmDialog`（variant=info）列出所有问题
- 用户选择「仍要保存」则调 `performSubmit(values)`；「取消」则清空 state，不影响原表单
- 抽出 `performSubmit` 承载原 handleSubmit 后半段（构造 payload、组装 meta、调用 `onSubmit`）
- 顺手把 omo Other Fields 的 JSON 格式校验（B 类）前置到入口处，避免用户点「仍要保存」后又被弹错

## 手动验证步骤

（由于 `ProviderForm` 已有 2000+ 行依赖外部 Tauri API 和多个 react-query hook，仓库现有的 `AddProviderDialog.test.tsx` 也是把整个 ProviderForm mock 掉的，所以 PR 未新增单测；现有 213 个单测全部通过。）

### 场景 1：Claude + Bedrock / Vertex AI（原 issue 核心诉求）
1. 新建 Claude 供应商 → 选「自定义」类型
2. 只填 `ANTHROPIC_AUTH_TOKEN` 的值为空，或仅通过 `env` 中的 `AWS_*` / `GOOGLE_APPLICATION_CREDENTIALS` 等环境变量认证
3. 点「添加」
4. ✅ 预期：弹出确认框列出「非官方供应商请填写 API 端点 / API Key」；点「仍要保存」后成功保存

### 场景 2：Gemini 自定义 BASE_URL
1. 新建 Gemini 供应商 → 选「自定义」
2. 填入 `GEMINI_API_KEY` 和 `GEMINI_API_BASE_URL`（不填 UI 里的端点输入框）
3. ✅ 预期：弹确认框 → 仍要保存 → 成功

### 场景 3：正常配置不被干扰
1. 完整填写一个官方 Claude 供应商配置
2. ✅ 预期：直接保存，不弹确认框

### 场景 4：B 类硬约束保持原有拒绝
1. 新建 OpenCode 供应商 → 填入非法 providerKey（如大写 `Foo_Bar`）
2. ✅ 预期：显示原有 `providerKeyInvalid` 错误 toast，无法进入确认框流程
3. Copilot 预设但未登录 → ✅ 仍弹「请先登录 GitHub Copilot」

### 自动化校验
- `pnpm typecheck` ✅
- `pnpm test:unit` ✅（34 files / 213 tests all passing）
- `pnpm format` ✅

## 三语 i18n

新增 `providerForm.softValidation.{title, hint, saveAnyway}`，覆盖 zh / en / ja。

## 替代方案与取舍

曾考虑：
- **A. 全部软化**：所有 24 处都弹确认框。太激进，可能让新手保存完全坏的数据。
- **C. 只精准放行 Bedrock / Vertex**：识别 env-based 认证跳过端点必填。太窄，每个新场景都要改。
- **B. 本 PR 采用**：按「数据是否仍有效」分类；与后端现有「relaxed save / strict switch」呼应；默认体验不变、给进阶用户一个逃生口。

相关 issue / PR：
- Closes #2196 (部分)
- 可能帮助 #1204 (Vertex AI 配置保存)

如果方向需要调整（比如更偏向 C），欢迎在 review 中指出，我来改动。