### PR TITLE
feat(cloudflare): add Cloudflare AI Gateway support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,116 @@
+name: Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2022
+          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
+            arch: arm64
+          - os: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Add macOS targets
+        if: runner.os == 'macOS'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Install Linux system deps
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config curl wget file patchelf \
+            libssl-dev rpm flatpak flatpak-builder elfutils xdg-utils
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-3-dev librsvg2-dev libayatana-appindicator3-dev
+          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.1-dev \
+            || sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev
+          sudo apt-get install -y --no-install-recommends libsoup-3.0-dev \
+            || sudo apt-get install -y --no-install-recommends libsoup2.4-dev
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10.12.3
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-pnpm-
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Tauri signing key
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
+            echo "TAURI_SIGNING_PRIVATE_KEY=${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" >> "$GITHUB_ENV"
+          else
+            pnpm tauri signer generate -w "$RUNNER_TEMP/tauri.key"
+            echo "TAURI_SIGNING_PRIVATE_KEY=$(cat "$RUNNER_TEMP/tauri.key")" >> "$GITHUB_ENV"
+          fi
+          if [ -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}" ]; then
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build (macOS)
+        if: runner.os == 'macOS'
+        run: pnpm tauri build --target universal-apple-darwin
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: pnpm tauri build
+
+      - name: Build (Linux)
+        if: runner.os == 'Linux'
+        run: pnpm tauri build --bundles appimage,deb,rpm
+
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          find src-tauri/target -type f \( \
+            -name "*.dmg" -o -name "*.tar.gz" -o \
+            -name "*.msi" -o \
+            -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \
+          \) | grep -v "incremental\|\.rlib\|\.rmeta" | while read f; do
+            cp "$f" artifacts/ 2>/dev/null || true
+          done
+          ls -lh artifacts || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cc-switch-${{ runner.os }}-${{ matrix.arch || runner.arch }}
+          path: artifacts/*
+          if-no-files-found: warn

--- a/src-tauri/src/proxy/providers/auth.rs
+++ b/src-tauri/src/proxy/providers/auth.rs
@@ -85,8 +85,7 @@ impl AuthInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthStrategy {
     /// Anthropic 认证方式
-    /// - Header: `x-api-key: <api_key>`
-    /// - Header: `anthropic-version: 2023-06-01`
+    /// - Header: `Authorization: Bearer <api_key>`
     Anthropic,
 
     /// Claude 中转服务认证方式（仅 Bearer，无 x-api-key）
@@ -100,6 +99,13 @@ pub enum AuthStrategy {
     ///
     /// - Header: `Authorization: Bearer <api_key>`
     Bearer,
+
+    /// API Key Header 认证方式
+    ///
+    /// - Header: `x-api-key: <api_key>`
+    ///
+    /// 用于 Cloudflare AI Gateway 等要求 x-api-key 的代理服务
+    XApiKey,
 
     /// Google API Key 认证方式
     ///
@@ -240,6 +246,7 @@ mod tests {
             AuthStrategy::Anthropic,
             AuthStrategy::ClaudeAuth,
             AuthStrategy::Bearer,
+            AuthStrategy::XApiKey,
             AuthStrategy::Google,
             AuthStrategy::GoogleOAuth,
             AuthStrategy::GitHubCopilot,

--- a/src-tauri/src/proxy/providers/auth.rs
+++ b/src-tauri/src/proxy/providers/auth.rs
@@ -85,9 +85,7 @@ impl AuthInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthStrategy {
     /// Anthropic 认证方式
-    /// - Header: `x-api-key: <api_key>`
     /// - Header: `Authorization: Bearer <api_key>`
-    /// - Header: `anthropic-version: 2023-06-01`
     Anthropic,
 
     /// Claude 中转服务认证方式（仅 Bearer，无 x-api-key）

--- a/src-tauri/src/proxy/providers/auth.rs
+++ b/src-tauri/src/proxy/providers/auth.rs
@@ -85,7 +85,9 @@ impl AuthInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthStrategy {
     /// Anthropic 认证方式
+    /// - Header: `x-api-key: <api_key>`
     /// - Header: `Authorization: Bearer <api_key>`
+    /// - Header: `anthropic-version: 2023-06-01`
     Anthropic,
 
     /// Claude 中转服务认证方式（仅 Bearer，无 x-api-key）

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -274,6 +274,35 @@ impl ClaudeAdapter {
         get_claude_api_format(provider)
     }
 
+    /// 检测是否为 Cloudflare AI Gateway 或需要 x-api-key 的代理
+    fn is_x_api_key_mode(&self, provider: &Provider) -> bool {
+        if let Some(auth_mode) = provider
+            .settings_config
+            .get("auth_mode")
+            .and_then(|v| v.as_str())
+        {
+            if auth_mode == "x_api_key" {
+                return true;
+            }
+        }
+
+        if let Some(env) = provider.settings_config.get("env") {
+            if let Some(auth_mode) = env.get("AUTH_MODE").and_then(|v| v.as_str()) {
+                if auth_mode == "x_api_key" {
+                    return true;
+                }
+            }
+        }
+
+        if let Ok(base_url) = self.extract_base_url(provider) {
+            if base_url.contains("gateway.ai.cloudflare.com") {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// 检测是否为仅 Bearer 认证模式
     fn is_bearer_only_mode(&self, provider: &Provider) -> bool {
         // 检查 settings_config 中的 auth_mode
@@ -439,6 +468,23 @@ impl ProviderAdapter for ClaudeAdapter {
 
         let key = self.extract_key(provider)?;
 
+        if self.is_x_api_key_mode(provider) {
+            let cf_aig_token = provider
+                .settings_config
+                .get("env")
+                .and_then(|e| {
+                    e.get("CF_AIG_TOKEN")
+                        .or_else(|| e.get("CLOUDFLARE_AIG_TOKEN"))
+                })
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+            let mut auth_info = AuthInfo::new(key, AuthStrategy::XApiKey);
+            auth_info.access_token = cf_aig_token;
+            return Some(auth_info);
+        }
+
         match provider_type {
             ProviderType::GeminiCli => {
                 // Parse stored OAuth JSON and only attach access_token when
@@ -514,6 +560,23 @@ impl ProviderAdapter for ClaudeAdapter {
                     HeaderName::from_static("authorization"),
                     HeaderValue::from_str(&bearer).unwrap(),
                 )]
+            }
+            AuthStrategy::XApiKey => {
+                let mut headers = vec![(
+                    HeaderName::from_static("x-api-key"),
+                    HeaderValue::from_str(&auth.api_key).unwrap(),
+                )];
+                if let Some(cf_token) = &auth.access_token {
+                    if let Ok(hv) =
+                        HeaderValue::from_str(&format!("Bearer {cf_token}"))
+                    {
+                        headers.push((
+                            HeaderName::from_static("cf-aig-authorization"),
+                            hv,
+                        ));
+                    }
+                }
+                headers
             }
             AuthStrategy::Google => vec![(
                 HeaderName::from_static("x-goog-api-key"),
@@ -1452,5 +1515,111 @@ mod tests {
                 .unwrap();
 
         assert_eq!(transformed["prompt_cache_key"], "claude-cache-route");
+    }
+
+    #[test]
+    fn test_cloudflare_ai_gateway_auto_detected_by_url() {
+        let adapter = ClaudeAdapter::new();
+        let provider = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://gateway.ai.cloudflare.com/v1/abc/claude-code/anthropic",
+                "ANTHROPIC_API_KEY": "sk-ant-test"
+            }
+        }));
+
+        assert!(adapter.is_x_api_key_mode(&provider));
+
+        let auth = adapter.extract_auth(&provider).unwrap();
+        assert_eq!(auth.strategy, AuthStrategy::XApiKey);
+        assert_eq!(auth.api_key, "sk-ant-test");
+        assert!(auth.access_token.is_none());
+
+        let headers = adapter.get_auth_headers(&auth);
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].0.as_str(), "x-api-key");
+        assert_eq!(headers[0].1.to_str().unwrap(), "sk-ant-test");
+    }
+
+    #[test]
+    fn test_cloudflare_ai_gateway_with_cf_aig_token() {
+        let adapter = ClaudeAdapter::new();
+        let provider = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://gateway.ai.cloudflare.com/v1/abc/claude-code/anthropic",
+                "ANTHROPIC_API_KEY": "sk-ant-real-key",
+                "CF_AIG_TOKEN": "cfut_test_token"
+            }
+        }));
+
+        let auth = adapter.extract_auth(&provider).unwrap();
+        assert_eq!(auth.strategy, AuthStrategy::XApiKey);
+        assert_eq!(auth.api_key, "sk-ant-real-key");
+        assert_eq!(auth.access_token.as_deref(), Some("cfut_test_token"));
+
+        let headers = adapter.get_auth_headers(&auth);
+        assert_eq!(headers.len(), 2);
+
+        let x_api_key = headers.iter().find(|(k, _)| k.as_str() == "x-api-key").unwrap();
+        assert_eq!(x_api_key.1.to_str().unwrap(), "sk-ant-real-key");
+
+        let cf_auth = headers.iter().find(|(k, _)| k.as_str() == "cf-aig-authorization").unwrap();
+        assert_eq!(cf_auth.1.to_str().unwrap(), "Bearer cfut_test_token");
+    }
+
+    #[test]
+    fn test_x_api_key_mode_via_auth_mode_setting() {
+        let adapter = ClaudeAdapter::new();
+        let provider = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://some-proxy.example.com",
+                "ANTHROPIC_API_KEY": "sk-test-key"
+            },
+            "auth_mode": "x_api_key"
+        }));
+
+        assert!(adapter.is_x_api_key_mode(&provider));
+
+        let auth = adapter.extract_auth(&provider).unwrap();
+        assert_eq!(auth.strategy, AuthStrategy::XApiKey);
+
+        let headers = adapter.get_auth_headers(&auth);
+        assert_eq!(headers[0].0.as_str(), "x-api-key");
+    }
+
+    #[test]
+    fn test_cloudflare_ai_gateway_does_not_send_bearer() {
+        let adapter = ClaudeAdapter::new();
+        let provider = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://gateway.ai.cloudflare.com/v1/abc/my-gateway/anthropic",
+                "ANTHROPIC_API_KEY": "sk-ant-real"
+            }
+        }));
+
+        let auth = adapter.extract_auth(&provider).unwrap();
+        let headers = adapter.get_auth_headers(&auth);
+
+        let has_authorization = headers.iter().any(|(k, _)| k.as_str() == "authorization");
+        let has_x_api_key = headers.iter().any(|(k, _)| k.as_str() == "x-api-key");
+        assert!(!has_authorization, "CF AI Gateway must not send Authorization: Bearer");
+        assert!(has_x_api_key, "CF AI Gateway must send x-api-key");
+    }
+
+    #[test]
+    fn test_non_cf_url_still_uses_bearer() {
+        let adapter = ClaudeAdapter::new();
+        let provider = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+                "ANTHROPIC_API_KEY": "sk-ant-test"
+            }
+        }));
+
+        assert!(!adapter.is_x_api_key_mode(&provider));
+        let auth = adapter.extract_auth(&provider).unwrap();
+        assert_eq!(auth.strategy, AuthStrategy::Anthropic);
+
+        let headers = adapter.get_auth_headers(&auth);
+        assert_eq!(headers[0].0.as_str(), "authorization");
     }
 }

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -281,16 +281,12 @@ impl ClaudeAdapter {
             .get("auth_mode")
             .and_then(|v| v.as_str())
         {
-            if auth_mode == "x_api_key" {
-                return true;
-            }
+            return auth_mode == "x_api_key";
         }
 
         if let Some(env) = provider.settings_config.get("env") {
             if let Some(auth_mode) = env.get("AUTH_MODE").and_then(|v| v.as_str()) {
-                if auth_mode == "x_api_key" {
-                    return true;
-                }
+                return auth_mode == "x_api_key";
             }
         }
 

--- a/src-tauri/src/services/model_fetch.rs
+++ b/src-tauri/src/services/model_fetch.rs
@@ -192,7 +192,7 @@ fn truncate_body(body: String) -> String {
         body
     } else {
         let mut s: String = body.chars().take(ERROR_BODY_MAX_CHARS).collect();
-        s.push_str("…");
+        s.push('…');
         s
     }
 }

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -421,13 +421,6 @@ impl StreamCheckService {
                     .header("accept", "text/event-stream")
                     .header("accept-encoding", "identity"),
             };
-        } else if is_openai_chat || is_openai_responses {
-            // OpenAI-compatible targets: Bearer auth + SSE headers only
-            request_builder = request_builder
-                .header("authorization", format!("Bearer {}", auth.api_key))
-                .header("content-type", "application/json")
-                .header("accept", "text/event-stream")
-                .header("accept-encoding", "identity");
         } else if auth.strategy == AuthStrategy::XApiKey {
             request_builder = request_builder.header("x-api-key", &auth.api_key);
             if let Some(cf_token) = &auth.access_token {
@@ -442,6 +435,13 @@ impl StreamCheckService {
                 )
                 .header("content-type", "application/json")
                 .header("accept", "application/json")
+                .header("accept-encoding", "identity");
+        } else if is_openai_chat || is_openai_responses {
+            // OpenAI-compatible targets: Bearer auth + SSE headers only
+            request_builder = request_builder
+                .header("authorization", format!("Bearer {}", auth.api_key))
+                .header("content-type", "application/json")
+                .header("accept", "text/event-stream")
                 .header("accept-encoding", "identity");
         } else {
             // Anthropic native: full Claude CLI headers

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -428,6 +428,21 @@ impl StreamCheckService {
                 .header("content-type", "application/json")
                 .header("accept", "text/event-stream")
                 .header("accept-encoding", "identity");
+        } else if auth.strategy == AuthStrategy::XApiKey {
+            request_builder = request_builder.header("x-api-key", &auth.api_key);
+            if let Some(cf_token) = &auth.access_token {
+                request_builder = request_builder
+                    .header("cf-aig-authorization", format!("Bearer {cf_token}"));
+            }
+            request_builder = request_builder
+                .header("anthropic-version", "2023-06-01")
+                .header(
+                    "anthropic-beta",
+                    "claude-code-20250219,interleaved-thinking-2025-05-14",
+                )
+                .header("content-type", "application/json")
+                .header("accept", "application/json")
+                .header("accept-encoding", "identity");
         } else {
             // Anthropic native: full Claude CLI headers
             let os_name = Self::get_os_name();

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -422,20 +422,9 @@ impl StreamCheckService {
                     .header("accept-encoding", "identity"),
             };
         } else if auth.strategy == AuthStrategy::XApiKey {
-            request_builder = request_builder.header("x-api-key", &auth.api_key);
-            if let Some(cf_token) = &auth.access_token {
-                request_builder = request_builder
-                    .header("cf-aig-authorization", format!("Bearer {cf_token}"));
+            for (name, value) in Self::x_api_key_stream_headers(&auth) {
+                request_builder = request_builder.header(name, value);
             }
-            request_builder = request_builder
-                .header("anthropic-version", "2023-06-01")
-                .header(
-                    "anthropic-beta",
-                    "claude-code-20250219,interleaved-thinking-2025-05-14",
-                )
-                .header("content-type", "application/json")
-                .header("accept", "application/json")
-                .header("accept-encoding", "identity");
         } else if is_openai_chat || is_openai_responses {
             // OpenAI-compatible targets: Bearer auth + SSE headers only
             request_builder = request_builder
@@ -1518,6 +1507,24 @@ impl StreamCheckService {
         }
     }
 
+    fn x_api_key_stream_headers(auth: &AuthInfo) -> Vec<(&'static str, String)> {
+        let mut headers = vec![("x-api-key", auth.api_key.clone())];
+        if let Some(cf_token) = &auth.access_token {
+            headers.push(("cf-aig-authorization", format!("Bearer {cf_token}")));
+        }
+        headers.extend([
+            ("anthropic-version", "2023-06-01".to_string()),
+            (
+                "anthropic-beta",
+                "claude-code-20250219,interleaved-thinking-2025-05-14".to_string(),
+            ),
+            ("content-type", "application/json".to_string()),
+            ("accept", "application/json".to_string()),
+            ("accept-encoding", "identity".to_string()),
+        ]);
+        headers
+    }
+
     pub(crate) fn resolve_effective_test_model(
         app_type: &AppType,
         provider: &Provider,
@@ -1968,5 +1975,41 @@ mod tests {
                 "https://api.openai.com/v1/responses",
             ]
         );
+    }
+
+    #[test]
+    fn test_x_api_key_stream_headers_without_cf_token() {
+        let auth = AuthInfo::new("sk-ant-test".to_string(), AuthStrategy::XApiKey);
+        let headers = StreamCheckService::x_api_key_stream_headers(&auth);
+
+        let get = |name: &str| {
+            headers
+                .iter()
+                .find(|(k, _)| *k == name)
+                .map(|(_, v)| v.as_str())
+        };
+
+        assert_eq!(get("x-api-key"), Some("sk-ant-test"));
+        assert_eq!(get("anthropic-version"), Some("2023-06-01"));
+        assert_eq!(get("content-type"), Some("application/json"));
+        assert!(get("cf-aig-authorization").is_none());
+    }
+
+    #[test]
+    fn test_x_api_key_stream_headers_with_cf_token() {
+        let mut auth = AuthInfo::new("sk-ant-key".to_string(), AuthStrategy::XApiKey);
+        auth.access_token = Some("cfut_abc123".to_string());
+        let headers = StreamCheckService::x_api_key_stream_headers(&auth);
+
+        let get = |name: &str| {
+            headers
+                .iter()
+                .find(|(k, _)| *k == name)
+                .map(|(_, v)| v.as_str())
+        };
+
+        assert_eq!(get("x-api-key"), Some("sk-ant-key"));
+        assert_eq!(get("cf-aig-authorization"), Some("Bearer cfut_abc123"));
+        assert_eq!(get("anthropic-version"), Some("2023-06-01"));
     }
 }

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -425,7 +425,7 @@ export function ClaudeFormFields({
                 <Input
                   id={`template-${key}`}
                   type="text"
-                  required
+                  required={!config.optional}
                   value={
                     templateValues[key]?.editorValue ??
                     config.editorValue ??

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -436,6 +436,11 @@ export function ClaudeFormFields({
                   placeholder={config.placeholder || config.label}
                   autoComplete="off"
                 />
+                {config.hint && (
+                  <p className="text-xs text-muted-foreground">
+                    {t(config.hint)}
+                  </p>
+                )}
               </div>
             ))}
           </div>

--- a/src/components/providers/forms/hooks/useTemplateValues.ts
+++ b/src/components/providers/forms/hooks/useTemplateValues.ts
@@ -263,6 +263,9 @@ export function useTemplateValues({
     }
 
     for (const [key, config] of templateValueEntries) {
+      if (config.optional) {
+        continue;
+      }
       const entry = templateValues[key];
       const resolvedValue = (
         entry?.editorValue ??

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -8,6 +8,7 @@ export interface TemplateValueConfig {
   placeholder: string;
   defaultValue?: string;
   editorValue: string;
+  hint?: string;
 }
 
 /**
@@ -1005,5 +1006,43 @@ export const providerPresets: ProviderPreset[] = [
     },
     icon: "aws",
     iconColor: "#FF9900",
+  },
+  {
+    name: "Cloudflare AI Gateway",
+    websiteUrl: "https://developers.cloudflare.com/ai-gateway/",
+    apiKeyUrl: "https://dash.cloudflare.com/",
+    apiKeyField: "ANTHROPIC_API_KEY",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL:
+          "https://gateway.ai.cloudflare.com/v1/${ACCOUNT_ID}/${GATEWAY_NAME}/anthropic",
+        ANTHROPIC_API_KEY: "",
+        CF_AIG_TOKEN: "${CF_AIG_TOKEN}",
+      },
+    },
+    category: "cloud_provider",
+    templateValues: {
+      ACCOUNT_ID: {
+        label: "Account ID",
+        placeholder: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        editorValue: "",
+        hint: "providerForm.templateHints.cloudflareAccountId",
+      },
+      GATEWAY_NAME: {
+        label: "Gateway Name",
+        placeholder: "default",
+        defaultValue: "default",
+        editorValue: "default",
+        hint: "providerForm.templateHints.cloudflareGatewayName",
+      },
+      CF_AIG_TOKEN: {
+        label: "CF AIG Token (optional)",
+        placeholder: "cfut_...",
+        editorValue: "",
+        hint: "providerForm.templateHints.cloudflareAigToken",
+      },
+    },
+    icon: "cloudflare",
+    iconColor: "#F38020",
   },
 ];

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -9,6 +9,7 @@ export interface TemplateValueConfig {
   defaultValue?: string;
   editorValue: string;
   hint?: string;
+  optional?: boolean;
 }
 
 /**
@@ -1040,6 +1041,7 @@ export const providerPresets: ProviderPreset[] = [
         placeholder: "cfut_...",
         editorValue: "",
         hint: "providerForm.templateHints.cloudflareAigToken",
+        optional: true,
       },
     },
     icon: "cloudflare",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -822,6 +822,11 @@
     "fillConfigContent": "Please fill in configuration content",
     "fillParameter": "Please fill in {{label}}",
     "fillTemplateValue": "Please fill in {{label}}",
+    "templateHints": {
+      "cloudflareAccountId": "Find your Account ID at the top of the Cloudflare Dashboard → AI Gateway page",
+      "cloudflareGatewayName": "The name of your AI Gateway; Cloudflare's default is \"default\"",
+      "cloudflareAigToken": "Optional. Create one in AI Gateway → Access Control to restrict gateway access"
+    },
     "endpointRequired": "API endpoint is required for non-official providers",
     "apiKeyRequired": "API Key is required for non-official providers",
     "configJsonError": "Config JSON format error, please check syntax",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -822,6 +822,11 @@
     "fillConfigContent": "設定内容を入力してください",
     "fillParameter": "{{label}} を入力してください",
     "fillTemplateValue": "{{label}} を入力してください",
+    "templateHints": {
+      "cloudflareAccountId": "Cloudflare ダッシュボード → AI Gateway ページ上部で Account ID を確認できます",
+      "cloudflareGatewayName": "AI Gateway の名前。Cloudflare のデフォルトは \"default\"",
+      "cloudflareAigToken": "任意。AI Gateway → アクセス制御 で作成し、ゲートウェイへのアクセスを制限します"
+    },
     "endpointRequired": "公式以外は API エンドポイントが必須です",
     "apiKeyRequired": "公式以外は API Key が必須です",
     "configJsonError": "Config JSON の形式が正しくありません。構文を確認してください",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -822,6 +822,11 @@
     "fillConfigContent": "请填写配置内容",
     "fillParameter": "请填写 {{label}}",
     "fillTemplateValue": "请填写 {{label}}",
+    "templateHints": {
+      "cloudflareAccountId": "在 Cloudflare 控制台 → AI Gateway 页面顶部可以找到 Account ID",
+      "cloudflareGatewayName": "创建 AI Gateway 时填写的名称，Cloudflare 默认为 default",
+      "cloudflareAigToken": "可选。在 AI Gateway → 访问控制中创建，用于保护网关访问"
+    },
     "endpointRequired": "非官方供应商请填写 API 端点",
     "apiKeyRequired": "非官方供应商请填写 API Key",
     "configJsonError": "配置JSON格式错误，请检查语法",


### PR DESCRIPTION
Closes #2311

## Summary

- Add `XApiKey` auth strategy that sends `x-api-key` + optional `cf-aig-authorization` headers required by Cloudflare AI Gateway
- Auto-detect Cloudflare AI Gateway URLs so no manual `auth_mode` config is needed
- Fix stream check (connectivity test) to use correct headers for `XApiKey` strategy — previously sent `Authorization: Bearer` causing false 401s
- Add **Cloudflare AI Gateway** provider preset with Account ID / Gateway Name template fields, optional CF AIG Token, and per-field i18n hints (zh/en/ja)

## Test plan

- [ ] Add a Cloudflare AI Gateway provider via the new preset, fill in Account ID, Gateway Name, and Anthropic API key — stream check passes
- [ ] For access-controlled gateways: fill in CF AIG Token — stream check passes
- [ ] Gateways without access control (CF AIG Token left empty) still work
- [ ] Hints appear below each template field in zh/en/ja