### PR TITLE
Fix Codex quota display and HTTP usage checks

### DIFF
--- a/src-tauri/src/commands/subscription.rs
+++ b/src-tauri/src/commands/subscription.rs
@@ -39,3 +39,83 @@ pub async fn get_subscription_quota(
     }
     inner
 }
+
+/// 查询指定 Codex provider 自带 OAuth 凭据的订阅额度。
+///
+/// 普通 `get_subscription_quota("codex")` 只能读取当前写入 `~/.codex/auth.json`
+/// 的 live 凭据；provider 列表里同时展示多个官方 Codex 账号时，需要读取每张
+/// 卡片自己的 `settings_config.auth`。
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_codex_provider_quota(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    provider_id: String,
+) -> Result<SubscriptionQuota, String> {
+    let app_type = AppType::Codex;
+    let app_type_str = app_type.as_str();
+
+    let mut provider = state
+        .db
+        .get_provider_by_id(&provider_id, app_type_str)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Codex provider not found: {provider_id}"))?;
+    let before_settings = provider.settings_config.clone();
+    let current_provider_id = state
+        .db
+        .get_current_provider(app_type_str)
+        .map_err(|e| e.to_string())?;
+    let is_current_provider = current_provider_id.as_deref() == Some(provider_id.as_str());
+
+    let inner =
+        crate::services::subscription::get_codex_provider_subscription_quota(
+            &mut provider.settings_config,
+        )
+        .await;
+
+    if provider.settings_config != before_settings {
+        state
+            .db
+            .save_provider(app_type_str, &provider)
+            .map_err(|e| e.to_string())?;
+
+        if is_current_provider {
+            if let Some(auth) = provider.settings_config.get("auth") {
+                let cfg_text = provider
+                    .settings_config
+                    .get("config")
+                    .and_then(serde_json::Value::as_str);
+                if let Err(e) = crate::codex_config::write_codex_live_atomic(auth, cfg_text) {
+                    log::warn!(
+                        "[CodexQuota] refreshed current provider token but failed to sync live auth: {e}"
+                    );
+                }
+            }
+        }
+    }
+
+    let snapshot = match &inner {
+        Ok(q) => q.clone(),
+        Err(err_msg) => SubscriptionQuota::error("codex", CredentialStatus::Valid, err_msg.clone()),
+    };
+
+    state.usage_cache.put_provider_subscription(
+        app_type.clone(),
+        provider_id.clone(),
+        snapshot.clone(),
+    );
+
+    if is_current_provider {
+        let payload = serde_json::json!({
+            "kind": "subscription",
+            "appType": app_type.as_str(),
+            "data": &snapshot,
+        });
+        if let Err(e) = app.emit("usage-cache-updated", payload) {
+            log::error!("emit usage-cache-updated (codex provider subscription) 失败: {e}");
+        }
+        state.usage_cache.put_subscription(app_type, snapshot);
+        crate::tray::schedule_tray_refresh(&app);
+    }
+
+    inner
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1085,6 +1085,7 @@ pub fn run() {
             commands::testUsageScript,
             // subscription quota
             commands::get_subscription_quota,
+            commands::get_codex_provider_quota,
             commands::get_codex_oauth_quota,
             commands::get_coding_plan_quota,
             commands::get_balance,

--- a/src-tauri/src/services/subscription.rs
+++ b/src-tauri/src/services/subscription.rs
@@ -1,7 +1,7 @@
 //! 官方订阅额度查询服务
 //!
 //! 读取 CLI 工具的已有 OAuth 凭据，查询官方订阅额度。
-//! 第一层：仅读取凭据，不实现登录/刷新。
+//! 第一层：读取 CLI 已有凭据，不实现交互式登录。
 
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -13,7 +13,7 @@ use crate::config;
 // ── 数据类型 ──────────────────────────────────────────────
 
 /// 凭据状态
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CredentialStatus {
     Valid,
@@ -438,33 +438,76 @@ struct CodexAuthJson {
 #[derive(Deserialize)]
 struct CodexTokens {
     access_token: Option<String>,
+    refresh_token: Option<String>,
     account_id: Option<String>,
 }
 
-/// (access_token, account_id, status, message)
-type CodexCredentials = (
-    Option<String>,
-    Option<String>,
-    CredentialStatus,
-    Option<String>,
-);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexCredentialSource {
+    File,
+    Provider,
+    #[cfg(target_os = "macos")]
+    Keychain,
+}
+
+#[derive(Debug, Clone)]
+struct CodexCredentials {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    account_id: Option<String>,
+    status: CredentialStatus,
+    message: Option<String>,
+    source: CodexCredentialSource,
+}
+
+impl CodexCredentials {
+    fn new(
+        access_token: Option<String>,
+        refresh_token: Option<String>,
+        account_id: Option<String>,
+        status: CredentialStatus,
+        message: Option<String>,
+        source: CodexCredentialSource,
+    ) -> Self {
+        Self {
+            access_token,
+            refresh_token,
+            account_id,
+            status,
+            message,
+            source,
+        }
+    }
+}
 
 /// 读取 Codex OAuth 凭据
 ///
 /// 按优先级尝试以下来源：
-/// 1. macOS Keychain (service: "Codex Auth")
-/// 2. 凭据文件 ~/.codex/auth.json
+/// 1. 凭据文件 ~/.codex/auth.json（Codex CLI 会在刷新后更新这里）
+/// 2. macOS Keychain (service: "Codex Auth")
 ///
 /// 仅 auth_mode == "chatgpt" (OAuth) 时有效，API key 模式不支持用量查询。
 fn read_codex_credentials() -> CodexCredentials {
+    let file_credentials = read_codex_credentials_from_file();
+    if file_credentials.status == CredentialStatus::Valid
+        || (file_credentials.status == CredentialStatus::Expired
+            && file_credentials.refresh_token.is_some())
+    {
+        return file_credentials;
+    }
+
     #[cfg(target_os = "macos")]
     {
         if let Some(result) = read_codex_credentials_from_keychain() {
-            return result;
+            if result.status == CredentialStatus::Valid
+                || result.status == CredentialStatus::Expired
+            {
+                return result;
+            }
         }
     }
 
-    read_codex_credentials_from_file()
+    file_credentials
 }
 
 /// 从 macOS Keychain 读取 Codex 凭据
@@ -485,7 +528,10 @@ fn read_codex_credentials_from_keychain() -> Option<CodexCredentials> {
         return None;
     }
 
-    Some(parse_codex_credentials_json(json_str))
+    Some(parse_codex_credentials_json(
+        json_str,
+        CodexCredentialSource::Keychain,
+    ))
 }
 
 /// 从文件读取 Codex 凭据
@@ -493,56 +539,74 @@ fn read_codex_credentials_from_file() -> CodexCredentials {
     let auth_path = crate::codex_config::get_codex_auth_path();
 
     if !auth_path.exists() {
-        return (None, None, CredentialStatus::NotFound, None);
+        return CodexCredentials::new(
+            None,
+            None,
+            None,
+            CredentialStatus::NotFound,
+            None,
+            CodexCredentialSource::File,
+        );
     }
 
     let content = match std::fs::read_to_string(&auth_path) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return CodexCredentials::new(
+                None,
                 None,
                 None,
                 CredentialStatus::ParseError,
                 Some(format!("Failed to read Codex auth file: {e}")),
+                CodexCredentialSource::File,
             );
         }
     };
 
-    parse_codex_credentials_json(&content)
+    parse_codex_credentials_json(&content, CodexCredentialSource::File)
 }
 
 /// 解析 Codex 凭据 JSON（Keychain 和文件共用）
-fn parse_codex_credentials_json(content: &str) -> CodexCredentials {
+fn parse_codex_credentials_json(
+    content: &str,
+    source: CodexCredentialSource,
+) -> CodexCredentials {
     let auth: CodexAuthJson = match serde_json::from_str(content) {
         Ok(a) => a,
         Err(e) => {
-            return (
+            return CodexCredentials::new(
+                None,
                 None,
                 None,
                 CredentialStatus::ParseError,
                 Some(format!("Failed to parse Codex auth JSON: {e}")),
+                source,
             );
         }
     };
 
     // 仅 OAuth 模式有用量数据
     if auth.auth_mode.as_deref() != Some("chatgpt") {
-        return (
+        return CodexCredentials::new(
+            None,
             None,
             None,
             CredentialStatus::NotFound,
             Some("Codex not using OAuth mode".to_string()),
+            source,
         );
     }
 
     let tokens = match auth.tokens {
         Some(t) => t,
         None => {
-            return (
+            return CodexCredentials::new(
+                None,
                 None,
                 None,
                 CredentialStatus::ParseError,
                 Some("No tokens in Codex auth".to_string()),
+                source,
             );
         }
     };
@@ -550,33 +614,57 @@ fn parse_codex_credentials_json(content: &str) -> CodexCredentials {
     let access_token = match tokens.access_token {
         Some(t) if !t.is_empty() => t,
         _ => {
-            return (
+            return CodexCredentials::new(
                 None,
                 None,
+                tokens.account_id,
                 CredentialStatus::ParseError,
                 Some("access_token is empty or missing".to_string()),
+                source,
             );
         }
     };
+    let refresh_token = tokens.refresh_token.filter(|t| !t.is_empty());
 
     // 检查 token 是否可能过期（距上次刷新 > 8 天）
     if let Some(ref last_refresh) = auth.last_refresh {
         if is_codex_token_stale(last_refresh) {
-            return (
+            return CodexCredentials::new(
                 Some(access_token),
+                refresh_token,
                 tokens.account_id,
                 CredentialStatus::Expired,
                 Some("Codex token may be stale (>8 days since last refresh)".to_string()),
+                source,
             );
         }
     }
 
-    (
+    CodexCredentials::new(
         Some(access_token),
+        refresh_token,
         tokens.account_id,
         CredentialStatus::Valid,
         None,
+        source,
     )
+}
+
+fn parse_codex_credentials_value(
+    auth: &serde_json::Value,
+    source: CodexCredentialSource,
+) -> CodexCredentials {
+    match serde_json::to_string(auth) {
+        Ok(content) => parse_codex_credentials_json(&content, source),
+        Err(e) => CodexCredentials::new(
+            None,
+            None,
+            None,
+            CredentialStatus::ParseError,
+            Some(format!("Failed to serialize Codex auth JSON: {e}")),
+            source,
+        ),
+    }
 }
 
 /// 判断 Codex token 是否可能过期（Codex CLI 在 >8 天时自动刷新）
@@ -591,6 +679,386 @@ fn is_codex_token_stale(last_refresh: &str) -> bool {
         age_secs > 8 * 24 * 3600
     } else {
         false
+    }
+}
+
+const CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CODEX_OAUTH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+
+#[derive(Deserialize)]
+struct CodexRefreshResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    #[serde(default)]
+    id_token: Option<String>,
+}
+
+async fn refresh_codex_access_token(credentials: &CodexCredentials) -> Option<String> {
+    // Avoid consuming a rotating refresh token from Keychain unless we can also
+    // persist the replacement. The file path can be updated atomically below.
+    if credentials.source != CodexCredentialSource::File {
+        return None;
+    }
+
+    let refresh_token = credentials.refresh_token.as_deref()?;
+    let refreshed = request_codex_token_refresh(refresh_token).await?;
+
+    if let Err(e) =
+        persist_refreshed_codex_file_token(&refreshed, credentials.account_id.as_deref())
+    {
+        log::warn!("[CodexQuota] failed to persist refreshed Codex auth token: {e}");
+    }
+
+    Some(refreshed.access_token)
+}
+
+async fn request_codex_token_refresh(refresh_token: &str) -> Option<CodexRefreshResponse> {
+    let client = crate::proxy::http_client::get();
+    let response = client
+        .post(CODEX_OAUTH_TOKEN_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("User-Agent", "codex-cli")
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+            ("client_id", CODEX_CLIENT_ID),
+            ("scope", "openid profile email"),
+        ])
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .ok()?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        log::warn!("[CodexQuota] refresh token failed: HTTP {status}: {body}");
+        return None;
+    }
+
+    let refreshed: CodexRefreshResponse = match response.json().await {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            log::warn!("[CodexQuota] failed to parse refresh response: {e}");
+            return None;
+        }
+    };
+    if refreshed.access_token.trim().is_empty() {
+        log::warn!("[CodexQuota] refresh response returned an empty access_token");
+        return None;
+    }
+
+    Some(refreshed)
+}
+
+fn persist_refreshed_codex_file_token(
+    refreshed: &CodexRefreshResponse,
+    fallback_account_id: Option<&str>,
+) -> Result<(), String> {
+    let auth_path = crate::codex_config::get_codex_auth_path();
+    let content = std::fs::read_to_string(&auth_path)
+        .map_err(|e| format!("Failed to read Codex auth file: {e}"))?;
+    let mut auth: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse Codex auth JSON: {e}"))?;
+
+    let auth_obj = auth
+        .as_object_mut()
+        .ok_or_else(|| "Codex auth JSON root must be an object".to_string())?;
+    apply_refreshed_codex_auth_token(auth_obj, refreshed, fallback_account_id)?;
+
+    config::write_json_file(&auth_path, &auth).map_err(|e| e.to_string())
+}
+
+fn apply_refreshed_codex_auth_token(
+    auth_obj: &mut serde_json::Map<String, serde_json::Value>,
+    refreshed: &CodexRefreshResponse,
+    fallback_account_id: Option<&str>,
+) -> Result<(), String> {
+    let tokens = auth_obj
+        .entry("tokens")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| "Codex auth tokens must be an object".to_string())?;
+
+    tokens.insert(
+        "access_token".to_string(),
+        serde_json::Value::String(refreshed.access_token.clone()),
+    );
+    if let Some(refresh_token) = refreshed.refresh_token.as_ref() {
+        tokens.insert(
+            "refresh_token".to_string(),
+            serde_json::Value::String(refresh_token.clone()),
+        );
+    }
+    if let Some(id_token) = refreshed.id_token.as_ref() {
+        tokens.insert(
+            "id_token".to_string(),
+            serde_json::Value::String(id_token.clone()),
+        );
+    }
+    if !tokens.contains_key("account_id") {
+        if let Some(account_id) = fallback_account_id {
+            tokens.insert(
+                "account_id".to_string(),
+                serde_json::Value::String(account_id.to_string()),
+            );
+        }
+    }
+    auth_obj.insert(
+        "last_refresh".to_string(),
+        serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+    );
+
+    Ok(())
+}
+
+async fn query_codex_quota_with_account_fallback(
+    token: &str,
+    account_id: Option<&str>,
+    tool_label: &str,
+    expired_message: &str,
+) -> SubscriptionQuota {
+    let result = query_codex_quota(token, account_id, tool_label, expired_message).await;
+    if result.credential_status == CredentialStatus::Expired && account_id.is_some() {
+        let fallback = query_codex_quota(token, None, tool_label, expired_message).await;
+        if fallback.success {
+            return fallback;
+        }
+    }
+    result
+}
+
+async fn query_codex_quota_with_refresh(
+    credentials: &CodexCredentials,
+    tool_label: &str,
+    expired_message: &str,
+) -> SubscriptionQuota {
+    if credentials.status == CredentialStatus::Expired {
+        if let Some(token) = refresh_codex_access_token(credentials).await {
+            let result = query_codex_quota_with_account_fallback(
+                &token,
+                credentials.account_id.as_deref(),
+                tool_label,
+                expired_message,
+            )
+            .await;
+            if result.success {
+                return result;
+            }
+        }
+    }
+
+    let Some(token) = credentials.access_token.as_deref() else {
+        return SubscriptionQuota::error(
+            tool_label,
+            CredentialStatus::ParseError,
+            "access_token is empty or missing".to_string(),
+        );
+    };
+
+    let result = query_codex_quota_with_account_fallback(
+        token,
+        credentials.account_id.as_deref(),
+        tool_label,
+        expired_message,
+    )
+    .await;
+
+    if result.credential_status == CredentialStatus::Expired {
+        if let Some(token) = refresh_codex_access_token(credentials).await {
+            return query_codex_quota_with_account_fallback(
+                &token,
+                credentials.account_id.as_deref(),
+                tool_label,
+                expired_message,
+            )
+            .await;
+        }
+    }
+
+    result
+}
+
+async fn query_refreshed_codex_provider_quota(
+    settings_config: &mut serde_json::Value,
+    credentials: &CodexCredentials,
+    tool_label: &str,
+    expired_message: &str,
+) -> Option<SubscriptionQuota> {
+    let refresh_token = credentials.refresh_token.as_deref()?;
+    let refreshed = request_codex_token_refresh(refresh_token).await?;
+
+    let auth = settings_config.get_mut("auth")?.as_object_mut()?;
+    if let Err(e) =
+        apply_refreshed_codex_auth_token(auth, &refreshed, credentials.account_id.as_deref())
+    {
+        log::warn!("[CodexQuota] failed to apply refreshed provider auth token: {e}");
+    }
+
+    Some(
+        query_codex_quota_with_account_fallback(
+            &refreshed.access_token,
+            credentials.account_id.as_deref(),
+            tool_label,
+            expired_message,
+        )
+        .await,
+    )
+}
+
+async fn query_codex_provider_quota_with_refresh(
+    settings_config: &mut serde_json::Value,
+    credentials: &CodexCredentials,
+    tool_label: &str,
+    expired_message: &str,
+) -> SubscriptionQuota {
+    if credentials.status == CredentialStatus::Expired {
+        if let Some(result) = query_refreshed_codex_provider_quota(
+            settings_config,
+            credentials,
+            tool_label,
+            expired_message,
+        )
+        .await
+        {
+            if result.success {
+                return result;
+            }
+        }
+    }
+
+    let Some(token) = credentials.access_token.as_deref() else {
+        return SubscriptionQuota::error(
+            tool_label,
+            CredentialStatus::ParseError,
+            "access_token is empty or missing".to_string(),
+        );
+    };
+
+    let result = query_codex_quota_with_account_fallback(
+        token,
+        credentials.account_id.as_deref(),
+        tool_label,
+        expired_message,
+    )
+    .await;
+
+    if result.credential_status == CredentialStatus::Expired {
+        if let Some(refreshed_result) = query_refreshed_codex_provider_quota(
+            settings_config,
+            credentials,
+            tool_label,
+            expired_message,
+        )
+        .await
+        {
+            return refreshed_result;
+        }
+    }
+
+    result
+}
+
+pub async fn get_codex_provider_subscription_quota(
+    settings_config: &mut serde_json::Value,
+) -> Result<SubscriptionQuota, String> {
+    let Some(auth) = settings_config.get("auth") else {
+        return Ok(SubscriptionQuota::not_found("codex"));
+    };
+    let credentials = parse_codex_credentials_value(auth, CodexCredentialSource::Provider);
+
+    match credentials.status {
+        CredentialStatus::NotFound => Ok(SubscriptionQuota::not_found("codex")),
+        CredentialStatus::ParseError => Ok(SubscriptionQuota::error(
+            "codex",
+            CredentialStatus::ParseError,
+            credentials
+                .message
+                .unwrap_or_else(|| "Failed to parse credentials".to_string()),
+        )),
+        CredentialStatus::Expired => {
+            let result = query_codex_provider_quota_with_refresh(
+                settings_config,
+                &credentials,
+                "codex",
+                "Authentication failed. Please re-login with Codex CLI.",
+            )
+            .await;
+            if result.success || result.credential_status != CredentialStatus::Expired {
+                Ok(result)
+            } else {
+                Ok(SubscriptionQuota::error(
+                    "codex",
+                    CredentialStatus::Expired,
+                    credentials
+                        .message
+                        .unwrap_or_else(|| "Codex OAuth token may be stale".to_string()),
+                ))
+            }
+        }
+        CredentialStatus::Valid => {
+            Ok(query_codex_provider_quota_with_refresh(
+                settings_config,
+                &credentials,
+                "codex",
+                "Authentication failed. Please re-login with Codex CLI.",
+            )
+            .await)
+        }
+    }
+}
+
+#[cfg(test)]
+mod codex_subscription_tests {
+    use super::*;
+
+    #[test]
+    fn parse_codex_credentials_keeps_refresh_token() {
+        let credentials = parse_codex_credentials_json(
+            r#"{
+              "auth_mode": "chatgpt",
+              "tokens": {
+                "access_token": "access-1",
+                "refresh_token": "refresh-1",
+                "account_id": "account-1"
+              }
+            }"#,
+            CodexCredentialSource::File,
+        );
+
+        assert_eq!(credentials.status, CredentialStatus::Valid);
+        assert_eq!(credentials.access_token.as_deref(), Some("access-1"));
+        assert_eq!(credentials.refresh_token.as_deref(), Some("refresh-1"));
+        assert_eq!(credentials.account_id.as_deref(), Some("account-1"));
+        assert_eq!(credentials.source, CodexCredentialSource::File);
+    }
+
+    #[test]
+    fn parse_stale_codex_credentials_can_still_refresh() {
+        let credentials = parse_codex_credentials_json(
+            r#"{
+              "auth_mode": "chatgpt",
+              "last_refresh": "2000-01-01T00:00:00Z",
+              "tokens": {
+                "access_token": "access-1",
+                "refresh_token": "refresh-1",
+                "account_id": "account-1"
+              }
+            }"#,
+            CodexCredentialSource::File,
+        );
+
+        assert_eq!(credentials.status, CredentialStatus::Expired);
+        assert_eq!(credentials.access_token.as_deref(), Some("access-1"));
+        assert_eq!(credentials.refresh_token.as_deref(), Some("refresh-1"));
+    }
+
+    #[test]
+    fn codex_usage_percent_uses_api_value_directly() {
+        assert_eq!(clamp_percent(51.0), 51.0);
+        assert_eq!(clamp_percent(9.0), 9.0);
+        assert_eq!(clamp_percent(150.0), 100.0);
+        assert_eq!(clamp_percent(-20.0), 0.0);
     }
 }
 
@@ -612,6 +1080,10 @@ struct CodexRateLimit {
 #[derive(Deserialize)]
 struct CodexUsageResponse {
     rate_limit: Option<CodexRateLimit>,
+}
+
+fn clamp_percent(percent: f64) -> f64 {
+    percent.clamp(0.0, 100.0)
 }
 
 /// 根据窗口秒数映射到 tier 名称（与 Claude 的命名兼容以复用前端 i18n）
@@ -712,7 +1184,7 @@ pub(crate) async fn query_codex_quota(
                         .limit_window_seconds
                         .map(window_seconds_to_tier_name)
                         .unwrap_or_else(|| "unknown".to_string()),
-                    utilization: used,
+                    utilization: clamp_percent(used),
                     resets_at: window.reset_at.and_then(unix_ts_to_iso),
                 });
             }
@@ -1232,40 +1704,39 @@ pub async fn get_subscription_quota(tool: &str) -> Result<SubscriptionQuota, Str
             }
         }
         "codex" => {
-            let (token, account_id, status, message) = read_codex_credentials();
+            let credentials = read_codex_credentials();
 
-            match status {
+            match credentials.status {
                 CredentialStatus::NotFound => Ok(SubscriptionQuota::not_found("codex")),
                 CredentialStatus::ParseError => Ok(SubscriptionQuota::error(
                     "codex",
                     CredentialStatus::ParseError,
-                    message.unwrap_or_else(|| "Failed to parse credentials".to_string()),
+                    credentials
+                        .message
+                        .unwrap_or_else(|| "Failed to parse credentials".to_string()),
                 )),
                 CredentialStatus::Expired => {
-                    // 即使可能过期也尝试调用 API
-                    if let Some(token) = token {
-                        let result = query_codex_quota(
-                            &token,
-                            account_id.as_deref(),
-                            "codex",
-                            "Authentication failed. Please re-login with Codex CLI.",
-                        )
-                        .await;
-                        if result.success {
-                            return Ok(result);
-                        }
-                    }
-                    Ok(SubscriptionQuota::error(
+                    let result = query_codex_quota_with_refresh(
+                        &credentials,
                         "codex",
-                        CredentialStatus::Expired,
-                        message.unwrap_or_else(|| "Codex OAuth token may be stale".to_string()),
-                    ))
+                        "Authentication failed. Please re-login with Codex CLI.",
+                    )
+                    .await;
+                    if result.success || result.credential_status != CredentialStatus::Expired {
+                        Ok(result)
+                    } else {
+                        Ok(SubscriptionQuota::error(
+                            "codex",
+                            CredentialStatus::Expired,
+                            credentials
+                                .message
+                                .unwrap_or_else(|| "Codex OAuth token may be stale".to_string()),
+                        ))
+                    }
                 }
                 CredentialStatus::Valid => {
-                    let token = token.expect("token must be Some when status is Valid");
-                    Ok(query_codex_quota(
-                        &token,
-                        account_id.as_deref(),
+                    Ok(query_codex_quota_with_refresh(
+                        &credentials,
                         "codex",
                         "Authentication failed. Please re-login with Codex CLI.",
                     )

--- a/src-tauri/src/services/usage_cache.rs
+++ b/src-tauri/src/services/usage_cache.rs
@@ -13,6 +13,7 @@ use crate::services::subscription::SubscriptionQuota;
 #[derive(Default)]
 pub struct UsageCache {
     subscription: RwLock<HashMap<AppType, SubscriptionQuota>>,
+    provider_subscription: RwLock<HashMap<(AppType, String), SubscriptionQuota>>,
     script: RwLock<HashMap<(AppType, String), UsageResult>>,
 }
 
@@ -24,6 +25,17 @@ impl UsageCache {
     pub fn put_subscription(&self, app_type: AppType, quota: SubscriptionQuota) {
         if let Ok(mut w) = self.subscription.write() {
             w.insert(app_type, quota);
+        }
+    }
+
+    pub fn put_provider_subscription(
+        &self,
+        app_type: AppType,
+        provider_id: String,
+        quota: SubscriptionQuota,
+    ) {
+        if let Ok(mut w) = self.provider_subscription.write() {
+            w.insert((app_type, provider_id), quota);
         }
     }
 
@@ -43,6 +55,20 @@ impl UsageCache {
             .read()
             .ok()
             .and_then(|r| r.get(app_type).map(f))
+    }
+
+    /// 以 provider 为粒度暴露订阅快照。Codex 官方多账号每张卡片都有独立
+    /// `settings_config.auth`，不能共享 app 级订阅缓存。
+    pub fn with_provider_subscription<R>(
+        &self,
+        app_type: &AppType,
+        provider_id: &str,
+        f: impl FnOnce(&SubscriptionQuota) -> R,
+    ) -> Option<R> {
+        self.provider_subscription
+            .read()
+            .ok()
+            .and_then(|r| r.get(&(app_type.clone(), provider_id.to_string())).map(f))
     }
 
     /// 以借用形式暴露脚本型用量结果，同上。
@@ -110,6 +136,21 @@ mod tests {
         assert!(got);
         assert!(cache
             .with_subscription(&AppType::Codex, |q| q.success)
+            .is_none());
+    }
+
+    #[test]
+    fn provider_subscription_keys_are_isolated() {
+        let cache = UsageCache::new();
+        cache.put_provider_subscription(AppType::Codex, "a".to_string(), fake_quota());
+        assert!(cache
+            .with_provider_subscription(&AppType::Codex, "a", |q| q.success)
+            .is_some());
+        assert!(cache
+            .with_provider_subscription(&AppType::Codex, "b", |q| q.success)
+            .is_none());
+        assert!(cache
+            .with_provider_subscription(&AppType::Claude, "a", |q| q.success)
             .is_none());
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -257,6 +257,18 @@ fn format_usage_suffix(
     }
 
     if provider.category.as_deref() == Some("official") {
+        if let Some(Some(s)) = app_state.usage_cache.with_provider_subscription(
+            app_type,
+            provider_id,
+            format_subscription_summary,
+        ) {
+            return Some(format!(" · {s}"));
+        }
+
+        if *app_type == AppType::Codex {
+            return None;
+        }
+
         if let Some(Some(s)) = app_state
             .usage_cache
             .with_subscription(app_type, format_subscription_summary)
@@ -444,6 +456,14 @@ fn handle_provider_click(
             }
         }
 
+        let app_clone = app.clone();
+        let app_type_clone = app_type.clone();
+        let provider_id_for_refresh = provider_id.to_string();
+        tauri::async_runtime::spawn(async move {
+            refresh_provider_usage_for_tray(&app_clone, &app_type_clone, &provider_id_for_refresh)
+                .await;
+        });
+
         // 发射事件到前端
         let event_data = serde_json::json!({
             "appType": app_type_str,
@@ -460,6 +480,61 @@ fn handle_provider_click(
         }
     }
     Ok(())
+}
+
+async fn refresh_provider_usage_for_tray(
+    app: &tauri::AppHandle,
+    app_type: &AppType,
+    provider_id: &str,
+) {
+    use crate::commands::CopilotAuthState;
+
+    let Some(app_state) = app.try_state::<AppState>() else {
+        return;
+    };
+    let app_type_str = app_type.as_str();
+    let provider = match app_state.db.get_provider_by_id(provider_id, app_type_str) {
+        Ok(Some(provider)) => provider,
+        Ok(None) => return,
+        Err(e) => {
+            log::debug!("[Tray] 切换后读取{}当前供应商失败: {e}", app_type_str);
+            return;
+        }
+    };
+
+    if provider.has_usage_script_enabled() {
+        let Some(copilot_state) = app.try_state::<CopilotAuthState>() else {
+            return;
+        };
+        if let Err(e) = crate::commands::queryProviderUsage(
+            app.clone(),
+            app_state,
+            copilot_state,
+            provider_id.to_string(),
+            app_type_str.to_string(),
+        )
+        .await
+        {
+            log::debug!("[Tray] 切换后刷新{}供应商 {provider_id} 用量失败: {e}", app_type_str);
+        }
+        return;
+    }
+
+    if provider.category.as_deref() != Some("official") {
+        return;
+    }
+
+    let result = if *app_type == AppType::Codex {
+        crate::commands::get_codex_provider_quota(app.clone(), app_state, provider_id.to_string())
+            .await
+    } else {
+        crate::commands::get_subscription_quota(app.clone(), app_state, app_type_str.to_string())
+            .await
+    };
+
+    if let Err(e) = result {
+        log::debug!("[Tray] 切换后刷新{}订阅用量失败（可能未登录）: {e}", app_type_str);
+    }
 }
 
 /// 创建动态托盘菜单
@@ -830,11 +905,16 @@ pub(crate) async fn refresh_all_usage_in_tray(app: &tauri::AppHandle) {
         } else if current.category.as_deref() == Some("official") {
             let app_clone = app.clone();
             let state = app.state::<AppState>();
+            let provider_id = current_id.clone();
             let tool = app_type_str.to_string();
+            let is_codex = section.app_type == AppType::Codex;
             subscription_futures.push(async move {
-                if let Err(e) =
+                let result = if is_codex {
+                    crate::commands::get_codex_provider_quota(app_clone, state, provider_id).await
+                } else {
                     crate::commands::get_subscription_quota(app_clone, state, tool).await
-                {
+                };
+                if let Err(e) = result {
                     log::debug!("[Tray] 刷新{log_name}订阅用量失败（可能未登录）: {e}");
                 }
             });

--- a/src-tauri/src/usage_script.rs
+++ b/src-tauri/src/usage_script.rs
@@ -438,14 +438,13 @@ fn validate_base_url(base_url: &str) -> Result<(), AppError> {
         )
     })?;
 
-    let is_loopback = is_loopback_host(&parsed_url);
-
-    // 必须是 HTTPS（允许 localhost 用于开发）
-    if parsed_url.scheme() != "https" && !is_loopback {
+    // 仅允许 HTTP(S)。是否允许非 localhost HTTP 由 request URL 的同源校验决定，
+    // 以兼容用户配置的内网/自建 HTTP 供应商。
+    if parsed_url.scheme() != "https" && parsed_url.scheme() != "http" {
         return Err(AppError::localized(
-            "usage_script.base_url_https_required",
-            "base_url 必须使用 HTTPS 协议（localhost 除外）",
-            "base_url must use HTTPS (localhost allowed)",
+            "usage_script.base_url_scheme_invalid",
+            "base_url 必须使用 HTTP 或 HTTPS 协议",
+            "base_url must use HTTP or HTTPS",
         ));
     }
 
@@ -470,7 +469,7 @@ fn validate_base_url(base_url: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-/// 验证请求 URL 是否安全（HTTPS 强制 + 同源检查）
+/// 验证请求 URL 是否安全（HTTPS/同源 HTTP + 同源检查）
 fn validate_request_url(
     request_url: &str,
     base_url: &str,
@@ -485,29 +484,59 @@ fn validate_request_url(
         )
     })?;
 
-    let is_request_loopback = is_loopback_host(&parsed_request);
-
-    // 必须使用 HTTPS（允许 localhost 用于开发）
-    // 自定义模板模式下，允许用户自行决定是否使用 HTTP（用户需自行承担安全风险）
-    if !is_custom_template && parsed_request.scheme() != "https" && !is_request_loopback {
-        return Err(AppError::localized(
-            "usage_script.request_https_required",
-            "请求 URL 必须使用 HTTPS 协议（localhost 除外）",
-            "Request URL must use HTTPS (localhost allowed)",
-        ));
-    }
-
     // 如果提供了 base_url（非空），则进行同源检查
     // 🔧 自定义模板模式下，用户可以自由访问任意 HTTPS 域名，跳过同源检查
-    if !base_url.is_empty() && !is_custom_template {
+    let parsed_base = if !base_url.is_empty() && !is_custom_template {
         // 解析 base URL
-        let parsed_base = Url::parse(base_url).map_err(|e| {
+        Some(Url::parse(base_url).map_err(|e| {
             AppError::localized(
                 "usage_script.base_url_invalid",
                 format!("无效的 base_url: {e}"),
                 format!("Invalid base_url: {e}"),
             )
-        })?;
+        })?)
+    } else {
+        None
+    };
+
+    let is_request_loopback = is_loopback_host(&parsed_request);
+    let is_same_origin_http = parsed_base.as_ref().is_some_and(|base| {
+        parsed_request.scheme() == "http"
+            && base.scheme() == "http"
+            && parsed_request.host_str() == base.host_str()
+            && parsed_request.port_or_known_default() == base.port_or_known_default()
+    });
+
+    // 必须使用 HTTPS（允许 localhost 或与 HTTP base_url 同源）
+    // 自定义模板模式下，允许用户自行决定是否使用 HTTP（用户需自行承担安全风险）
+    if !is_custom_template
+        && parsed_request.scheme() != "https"
+        && !is_request_loopback
+        && !is_same_origin_http
+    {
+        return Err(AppError::localized(
+            "usage_script.request_https_required",
+            "请求 URL 必须使用 HTTPS 协议（localhost 或同源 HTTP base_url 除外）",
+            "Request URL must use HTTPS (except localhost or same-origin HTTP base_url)",
+        ));
+    }
+
+    if let Some(parsed_base) = parsed_base {
+        if parsed_request.scheme() != parsed_base.scheme() {
+            return Err(AppError::localized(
+                "usage_script.request_scheme_mismatch",
+                format!(
+                    "请求协议 {} 必须与 base_url 协议 {} 匹配",
+                    parsed_request.scheme(),
+                    parsed_base.scheme()
+                ),
+                format!(
+                    "Request scheme {} must match base_url scheme {}",
+                    parsed_request.scheme(),
+                    parsed_base.scheme()
+                ),
+            ));
+        }
 
         // 核心安全检查：必须与 base_url 同源（相同域名和端口）
         if parsed_request.host_str() != parsed_base.host_str() {
@@ -573,10 +602,38 @@ mod tests {
     #[test]
     fn test_https_bypass_prevention() {
         // 非本地域名的 HTTP 应该被拒绝
-        let result = validate_base_url("http://127.0.0.1.evil.com/api");
+        let result = validate_request_url("http://127.0.0.1.evil.com/api", "", false);
         assert!(
             result.is_err(),
             "Should reject HTTP for non-localhost domains"
+        );
+    }
+
+    #[test]
+    fn test_same_origin_http_base_url_allowed() {
+        validate_base_url("http://api.example.com").unwrap();
+        let result = validate_request_url(
+            "http://api.example.com/v1/usage",
+            "http://api.example.com",
+            false,
+        );
+        assert!(
+            result.is_ok(),
+            "Should allow HTTP request when it matches HTTP base_url origin: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_http_request_must_match_http_base_url_origin() {
+        let result = validate_request_url(
+            "http://other.example.com/v1/usage",
+            "http://api.example.com",
+            false,
+        );
+        assert!(
+            result.is_err(),
+            "Should reject non-same-origin HTTP requests"
         );
     }
 

--- a/src/components/CodexOauthQuotaFooter.tsx
+++ b/src/components/CodexOauthQuotaFooter.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import type { ProviderMeta } from "@/types";
-import { useCodexOauthQuota } from "@/lib/query/subscription";
+import {
+  useCodexOauthQuota,
+  useCodexOauthQuotaByAccountId,
+} from "@/lib/query/subscription";
 import { SubscriptionQuotaView } from "@/components/SubscriptionQuotaFooter";
 
 interface CodexOauthQuotaFooterProps {
   meta?: ProviderMeta;
+  accountId?: string | null;
   inline?: boolean;
   /** 是否为当前激活的供应商 */
   isCurrent?: boolean;
@@ -18,14 +22,27 @@ interface CodexOauthQuotaFooterProps {
  */
 const CodexOauthQuotaFooter: React.FC<CodexOauthQuotaFooterProps> = ({
   meta,
+  accountId,
   inline = false,
-  isCurrent = false,
 }) => {
+  const hasExplicitAccount = accountId !== undefined;
+  const hasMetaBinding = meta !== undefined;
+
+  const accountQuery = useCodexOauthQuotaByAccountId(accountId, {
+    enabled: hasExplicitAccount,
+    autoQuery: hasExplicitAccount,
+  });
+  const metaQuery = useCodexOauthQuota(meta, {
+    enabled: !hasExplicitAccount && hasMetaBinding,
+    autoQuery: !hasExplicitAccount && hasMetaBinding,
+  });
+
+  const query = hasExplicitAccount ? accountQuery : metaQuery;
   const {
     data: quota,
     isFetching: loading,
     refetch,
-  } = useCodexOauthQuota(meta, { enabled: true, autoQuery: isCurrent });
+  } = query;
 
   return (
     <SubscriptionQuotaView

--- a/src/components/SubscriptionQuotaFooter.tsx
+++ b/src/components/SubscriptionQuotaFooter.tsx
@@ -2,11 +2,15 @@ import React from "react";
 import { RefreshCw, AlertCircle, Clock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AppId } from "@/lib/api";
-import { useSubscriptionQuota } from "@/lib/query/subscription";
+import {
+  useCodexProviderQuota,
+  useSubscriptionQuota,
+} from "@/lib/query/subscription";
 import type { QuotaTier, SubscriptionQuota } from "@/types/subscription";
 
 interface SubscriptionQuotaFooterProps {
   appId: AppId;
+  providerId?: string;
   inline?: boolean;
   isCurrent?: boolean;
 }
@@ -388,16 +392,24 @@ const TierBar: React.FC<{
  */
 const SubscriptionQuotaFooter: React.FC<SubscriptionQuotaFooterProps> = ({
   appId,
+  providerId,
   inline = false,
   isCurrent = false,
 }) => {
+  const useProviderQuota = appId === "codex" && Boolean(providerId);
+  const appQuery = useSubscriptionQuota(appId, !useProviderQuota && isCurrent, isCurrent);
+  const providerQuery = useCodexProviderQuota(providerId, {
+    enabled: useProviderQuota,
+    autoQuery: useProviderQuota,
+  });
+
   const {
     data: quota,
     isFetching: loading,
     refetch,
-  } = useSubscriptionQuota(appId, isCurrent, isCurrent);
+  } = useProviderQuota ? providerQuery : appQuery;
 
-  if (!isCurrent) return null;
+  if (!useProviderQuota && !isCurrent) return null;
 
   return (
     <SubscriptionQuotaView

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -393,6 +393,7 @@ export function ProviderCard({
               ) : isOfficial ? (
                 <SubscriptionQuotaFooter
                   appId={appId}
+                  providerId={appId === "codex" ? provider.id : undefined}
                   inline={true}
                   isCurrent={isCurrent}
                 />

--- a/src/components/providers/forms/CodexOAuthSection.tsx
+++ b/src/components/providers/forms/CodexOAuthSection.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { useCodexOauth } from "./hooks/useCodexOauth";
 import { copyText } from "@/lib/clipboard";
+import CodexOauthQuotaFooter from "@/components/CodexOauthQuotaFooter";
 
 interface CodexOAuthSectionProps {
   className?: string;
@@ -194,7 +195,12 @@ export const CodexOAuthSection: React.FC<CodexOAuthSectionProps> = ({
                     </Badge>
                   )}
                 </div>
-                <div className="flex items-center gap-1">
+                <div className="flex items-center gap-3">
+                  <CodexOauthQuotaFooter
+                    accountId={account.id}
+                    inline={true}
+                    isCurrent={true}
+                  />
                   {defaultAccountId !== account.id && (
                     <Button
                       type="button"

--- a/src/components/providers/forms/hooks/useManagedAuth.ts
+++ b/src/components/providers/forms/hooks/useManagedAuth.ts
@@ -10,6 +10,12 @@ import type {
 
 type PollingState = "idle" | "polling" | "success" | "error";
 
+function quotaQueryKeyForAuthProvider(authProvider: ManagedAuthProvider) {
+  if (authProvider === "codex_oauth") return ["codex_oauth", "quota"] as const;
+  if (authProvider === "github_copilot") return ["copilot", "quota"] as const;
+  return null;
+}
+
 export function useManagedAuth(
   authProvider: ManagedAuthProvider,
   githubDomain?: string,
@@ -97,6 +103,10 @@ export function useManagedAuth(
             setPollingState("success");
             await refetchStatus();
             await queryClient.invalidateQueries({ queryKey });
+            const quotaQueryKey = quotaQueryKeyForAuthProvider(authProvider);
+            if (quotaQueryKey) {
+              await queryClient.invalidateQueries({ queryKey: quotaQueryKey });
+            }
             setPollingState("idle");
             setDeviceCode(null);
           }
@@ -140,6 +150,10 @@ export function useManagedAuth(
         accounts: [],
       });
       await queryClient.invalidateQueries({ queryKey });
+      const quotaQueryKey = quotaQueryKeyForAuthProvider(authProvider);
+      if (quotaQueryKey) {
+        await queryClient.invalidateQueries({ queryKey: quotaQueryKey });
+      }
     },
     onError: async (e) => {
       console.error("[ManagedAuth] Failed to logout:", e);
@@ -157,6 +171,10 @@ export function useManagedAuth(
       setError(null);
       await refetchStatus();
       await queryClient.invalidateQueries({ queryKey });
+      const quotaQueryKey = quotaQueryKeyForAuthProvider(authProvider);
+      if (quotaQueryKey) {
+        await queryClient.invalidateQueries({ queryKey: quotaQueryKey });
+      }
     },
     onError: (e) => {
       console.error("[ManagedAuth] Failed to remove account:", e);
@@ -170,6 +188,10 @@ export function useManagedAuth(
     onSuccess: async () => {
       await refetchStatus();
       await queryClient.invalidateQueries({ queryKey });
+      const quotaQueryKey = quotaQueryKeyForAuthProvider(authProvider);
+      if (quotaQueryKey) {
+        await queryClient.invalidateQueries({ queryKey: quotaQueryKey });
+      }
     },
     onError: (e) => {
       console.error("[ManagedAuth] Failed to set default account:", e);

--- a/src/lib/api/subscription.ts
+++ b/src/lib/api/subscription.ts
@@ -4,6 +4,8 @@ import type { SubscriptionQuota } from "@/types/subscription";
 export const subscriptionApi = {
   getQuota: (tool: string): Promise<SubscriptionQuota> =>
     invoke("get_subscription_quota", { tool }),
+  getCodexProviderQuota: (providerId: string): Promise<SubscriptionQuota> =>
+    invoke("get_codex_provider_quota", { providerId }),
   getCodexOauthQuota: (accountId: string | null): Promise<SubscriptionQuota> =>
     invoke("get_codex_oauth_quota", { accountId }),
   getCodingPlanQuota: (

--- a/src/lib/query/subscription.ts
+++ b/src/lib/query/subscription.ts
@@ -10,6 +10,8 @@ const REFETCH_INTERVAL = 5 * 60 * 1000; // 5 minutes
 export const subscriptionKeys = {
   all: ["subscription"] as const,
   quota: (appId: AppId) => [...subscriptionKeys.all, "quota", appId] as const,
+  codexProviderQuota: (providerId: string | null | undefined) =>
+    [...subscriptionKeys.all, "quota", "codex", "provider", providerId] as const,
 };
 
 export function useSubscriptionQuota(
@@ -35,6 +37,24 @@ export interface UseCodexOauthQuotaOptions {
   autoQuery?: boolean;
 }
 
+export function useCodexProviderQuota(
+  providerId: string | null | undefined,
+  options: UseCodexOauthQuotaOptions = {},
+) {
+  const { enabled = true, autoQuery = false } = options;
+  return useQuery({
+    queryKey: subscriptionKeys.codexProviderQuota(providerId),
+    queryFn: () => subscriptionApi.getCodexProviderQuota(providerId!),
+    enabled: enabled && Boolean(providerId),
+    refetchInterval: autoQuery ? REFETCH_INTERVAL : false,
+    refetchIntervalInBackground: autoQuery,
+    refetchOnWindowFocus: autoQuery,
+    refetchOnMount: autoQuery ? "always" : true,
+    staleTime: REFETCH_INTERVAL,
+    retry: 1,
+  });
+}
+
 /**
  * Codex OAuth (ChatGPT Plus/Pro 反代) 订阅额度查询 hook
  *
@@ -48,15 +68,24 @@ export function useCodexOauthQuota(
   meta: ProviderMeta | undefined,
   options: UseCodexOauthQuotaOptions = {},
 ) {
-  const { enabled = true, autoQuery = false } = options;
   const accountId = resolveManagedAccountId(meta, PROVIDER_TYPES.CODEX_OAUTH);
+  return useCodexOauthQuotaByAccountId(accountId, options);
+}
+
+export function useCodexOauthQuotaByAccountId(
+  accountId: string | null | undefined,
+  options: UseCodexOauthQuotaOptions = {},
+) {
+  const { enabled = true, autoQuery = false } = options;
+  const resolvedAccountId = accountId ?? null;
   return useQuery({
-    queryKey: ["codex_oauth", "quota", accountId ?? "default"],
-    queryFn: () => subscriptionApi.getCodexOauthQuota(accountId),
+    queryKey: ["codex_oauth", "quota", resolvedAccountId ?? "default"],
+    queryFn: () => subscriptionApi.getCodexOauthQuota(resolvedAccountId),
     enabled,
     refetchInterval: autoQuery ? REFETCH_INTERVAL : false,
     refetchIntervalInBackground: autoQuery,
     refetchOnWindowFocus: autoQuery,
+    refetchOnMount: autoQuery ? "always" : true,
     staleTime: REFETCH_INTERVAL,
     retry: 1,
   });


### PR DESCRIPTION
## Summary
- Allow same-origin HTTP usage script checks while preserving HTTPS/loopback validation for unrelated URLs.
- Query and refresh Codex official quotas from each provider's stored ChatGPT OAuth credentials, so multiple official accounts can render at the same time.
- Cache Codex official quotas by provider and refresh tray labels after quick switching so status-bar h/w usage follows the selected account.

Fixes #1857

## Validation
- pnpm typecheck
- cargo check
- cargo test codex_subscription_tests --lib
- cargo test tray::tests --lib
- cargo test services::usage_cache::tests --lib