### PR TITLE
feat: add Codex session provider switch 

### DIFF
--- a/src-tauri/src/commands/session_manager.rs
+++ b/src-tauri/src/commands/session_manager.rs
@@ -83,3 +83,30 @@ pub async fn delete_sessions(
         .await
         .map_err(|e| format!("Failed to delete sessions: {e}"))
 }
+
+#[tauri::command]
+pub async fn get_codex_session_provider(
+    sessionId: String,
+    sourcePath: String,
+) -> Result<Option<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        session_manager::get_codex_session_provider(&sessionId, &sourcePath)
+    })
+    .await
+    .map_err(|e| format!("Failed to get Codex session provider: {e}"))?
+}
+
+#[tauri::command]
+pub async fn switch_codex_session_provider(
+    request: session_manager::SwitchCodexSessionProviderRequest,
+) -> Result<Option<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        session_manager::switch_codex_session_provider(
+            &request.session_id,
+            &request.source_path,
+            &request.target_provider,
+        )
+    })
+    .await
+    .map_err(|e| format!("Failed to switch Codex session provider: {e}"))?
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1232,6 +1232,8 @@ pub fn run() {
             commands::get_session_messages,
             commands::delete_session,
             commands::delete_sessions,
+            commands::get_codex_session_provider,
+            commands::switch_codex_session_provider,
             commands::launch_session_terminal,
             commands::get_tool_versions,
             // Provider terminal

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -55,6 +55,14 @@ pub struct DeleteSessionOutcome {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwitchCodexSessionProviderRequest {
+    pub session_id: String,
+    pub source_path: String,
+    pub target_provider: String,
+}
+
 pub fn scan_sessions() -> Vec<SessionMeta> {
     let (r1, r2, r3, r4, r5, r6) = std::thread::scope(|s| {
         let h1 = s.spawn(codex::scan_sessions);
@@ -136,6 +144,21 @@ pub fn delete_sessions(requests: &[DeleteSessionRequest]) -> Vec<DeleteSessionOu
             &request.source_path,
         )
     })
+}
+
+pub fn get_codex_session_provider(
+    session_id: &str,
+    source_path: &str,
+) -> Result<Option<String>, String> {
+    codex::get_session_provider(session_id, Path::new(source_path))
+}
+
+pub fn switch_codex_session_provider(
+    session_id: &str,
+    source_path: &str,
+    target_provider: &str,
+) -> Result<Option<String>, String> {
+    codex::switch_session_provider(session_id, Path::new(source_path), target_provider)
 }
 
 fn delete_session_with_root(

--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -165,8 +165,24 @@ fn switch_session_provider_with_paths(
         ));
     }
 
+    let original_content = fs::read_to_string(&source).map_err(|e| {
+        format!(
+            "Failed to read Codex session file {}: {e}",
+            source.display()
+        )
+    })?;
     let provider = update_session_file_model_provider(&source, session_id, target_provider)?;
-    update_state_db_model_provider(state_db_path, session_id, target_provider)?;
+    if let Err(update_error) =
+        update_state_db_model_provider(state_db_path, session_id, target_provider)
+    {
+        fs::write(&source, original_content).map_err(|restore_error| {
+            format!(
+                "{update_error}; failed to restore Codex session file {}: {restore_error}",
+                source.display()
+            )
+        })?;
+        return Err(update_error);
+    }
 
     Ok(provider)
 }
@@ -651,6 +667,40 @@ mod tests {
             )
             .expect("query provider");
         assert_eq!(provider, "custom");
+    }
+
+    #[test]
+    fn switch_session_provider_restores_jsonl_when_state_db_update_fails() {
+        let temp = tempdir().expect("tempdir");
+        let sessions_root = temp.path().join("sessions");
+        std::fs::create_dir_all(&sessions_root).expect("create sessions root");
+        let path = sessions_root.join("session.jsonl");
+        let original_content = concat!(
+            "{\"timestamp\":\"2026-03-06T21:50:12Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"test-id\",\"cwd\":\"/tmp/project\",\"model_provider\":\"openai\"}}\n",
+            "{\"timestamp\":\"2026-03-06T21:50:13Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":\"Hello\"}}\n"
+        );
+        std::fs::write(&path, original_content).expect("write");
+
+        let db_path = temp.path().join("state_5.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).expect("open db");
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY)", [])
+            .expect("create threads without provider");
+        drop(conn);
+
+        let error = switch_session_provider_with_paths(
+            "test-id",
+            &path,
+            "custom",
+            &sessions_root,
+            &db_path,
+        )
+        .expect_err("missing model_provider should fail");
+
+        assert!(error.contains("model_provider column"));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read session"),
+            original_content
+        );
     }
 
     #[test]

--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -401,11 +401,17 @@ fn update_state_db_model_provider(
         return Err("Codex threads table is missing model_provider column".to_string());
     }
 
-    conn.execute(
-        "UPDATE threads SET model_provider = ?1 WHERE id = ?2",
-        rusqlite::params![target_provider, session_id],
-    )
-    .map_err(|e| format!("Failed to update Codex state database: {e}"))?;
+    let rows_affected = conn
+        .execute(
+            "UPDATE threads SET model_provider = ?1 WHERE id = ?2",
+            rusqlite::params![target_provider, session_id],
+        )
+        .map_err(|e| format!("Failed to update Codex state database: {e}"))?;
+    if rows_affected == 0 {
+        return Err(format!(
+            "Codex state database thread not found for session: {session_id}"
+        ));
+    }
 
     Ok(())
 }
@@ -697,6 +703,43 @@ mod tests {
         .expect_err("missing model_provider should fail");
 
         assert!(error.contains("model_provider column"));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read session"),
+            original_content
+        );
+    }
+
+    #[test]
+    fn switch_session_provider_fails_when_state_db_thread_is_missing() {
+        let temp = tempdir().expect("tempdir");
+        let sessions_root = temp.path().join("sessions");
+        std::fs::create_dir_all(&sessions_root).expect("create sessions root");
+        let path = sessions_root.join("session.jsonl");
+        let original_content = concat!(
+            "{\"timestamp\":\"2026-03-06T21:50:12Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"test-id\",\"cwd\":\"/tmp/project\",\"model_provider\":\"openai\"}}\n",
+            "{\"timestamp\":\"2026-03-06T21:50:13Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":\"Hello\"}}\n"
+        );
+        std::fs::write(&path, original_content).expect("write");
+
+        let db_path = temp.path().join("state_5.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).expect("open db");
+        conn.execute(
+            "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT NOT NULL)",
+            [],
+        )
+        .expect("create threads");
+        drop(conn);
+
+        let error = switch_session_provider_with_paths(
+            "test-id",
+            &path,
+            "custom",
+            &sessions_root,
+            &db_path,
+        )
+        .expect_err("missing thread should fail");
+
+        assert!(error.contains("thread"));
         assert_eq!(
             std::fs::read_to_string(&path).expect("read session"),
             original_content

--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -122,6 +122,276 @@ pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<boo
     })?;
 
     Ok(true)
+}
+
+pub fn get_session_provider(
+    session_id: &str,
+    source_path: &Path,
+) -> Result<Option<String>, String> {
+    let config_dir = get_codex_config_dir();
+    get_session_provider_with_root(session_id, source_path, &config_dir.join("sessions"))
+}
+
+pub fn switch_session_provider(
+    session_id: &str,
+    source_path: &Path,
+    target_provider: &str,
+) -> Result<Option<String>, String> {
+    let config_dir = get_codex_config_dir();
+    switch_session_provider_with_paths(
+        session_id,
+        source_path,
+        target_provider,
+        &config_dir.join("sessions"),
+        &config_dir.join("state_5.sqlite"),
+    )
+}
+
+fn switch_session_provider_with_paths(
+    session_id: &str,
+    source_path: &Path,
+    target_provider: &str,
+    sessions_root: &Path,
+    state_db_path: &Path,
+) -> Result<Option<String>, String> {
+    validate_codex_model_provider(target_provider)?;
+
+    let root = canonicalize_existing(sessions_root, "Codex sessions root")?;
+    let source = canonicalize_existing(source_path, "Codex session file")?;
+    if !source.starts_with(&root) {
+        return Err(format!(
+            "Codex session file is outside sessions root: {}",
+            source_path.display()
+        ));
+    }
+
+    let provider = update_session_file_model_provider(&source, session_id, target_provider)?;
+    update_state_db_model_provider(state_db_path, session_id, target_provider)?;
+
+    Ok(provider)
+}
+
+fn get_session_provider_with_root(
+    session_id: &str,
+    source_path: &Path,
+    sessions_root: &Path,
+) -> Result<Option<String>, String> {
+    let root = canonicalize_existing(sessions_root, "Codex sessions root")?;
+    let source = canonicalize_existing(source_path, "Codex session file")?;
+    if !source.starts_with(&root) {
+        return Err(format!(
+            "Codex session file is outside sessions root: {}",
+            source_path.display()
+        ));
+    }
+
+    read_session_file_model_provider(&source, session_id)
+}
+
+fn validate_codex_model_provider(provider: &str) -> Result<(), String> {
+    match provider {
+        "openai" | "custom" => Ok(()),
+        _ => Err(format!("Unsupported Codex model provider: {provider}")),
+    }
+}
+
+fn canonicalize_existing(path: &Path, label: &str) -> Result<PathBuf, String> {
+    if !path.exists() {
+        return Err(format!("{label} not found: {}", path.display()));
+    }
+    path.canonicalize()
+        .map_err(|e| format!("Failed to resolve {label} {}: {e}", path.display()))
+}
+
+fn read_session_file_model_provider(
+    path: &Path,
+    session_id: &str,
+) -> Result<Option<String>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read Codex session file {}: {e}", path.display()))?;
+
+    for line in content.lines() {
+        let value: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if value.get("type").and_then(Value::as_str) != Some("session_meta") {
+            continue;
+        }
+
+        let actual_id = value
+            .get("payload")
+            .and_then(|payload| payload.get("id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("Codex session metadata is missing id: {}", path.display()))?;
+
+        if actual_id != session_id {
+            return Err(format!(
+                "Codex session ID mismatch: expected {session_id}, found {actual_id}"
+            ));
+        }
+
+        return Ok(value
+            .get("payload")
+            .and_then(|payload| payload.get("model_provider"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string));
+    }
+
+    Err(format!(
+        "Codex session metadata not found in file: {}",
+        path.display()
+    ))
+}
+
+fn update_session_file_model_provider(
+    path: &Path,
+    session_id: &str,
+    target_provider: &str,
+) -> Result<Option<String>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read Codex session file {}: {e}", path.display()))?;
+
+    let mut lines: Vec<String> = content.lines().map(ToString::to_string).collect();
+    if lines.is_empty() {
+        return Err(format!("Codex session file is empty: {}", path.display()));
+    }
+
+    let mut meta_index = None;
+    let mut meta_value = None;
+
+    for (index, line) in lines.iter().enumerate() {
+        let value: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if value.get("type").and_then(Value::as_str) == Some("session_meta") {
+            meta_index = Some(index);
+            meta_value = Some(value);
+            break;
+        }
+    }
+
+    let index = meta_index.ok_or_else(|| {
+        format!(
+            "Codex session metadata not found in file: {}",
+            path.display()
+        )
+    })?;
+    let mut value = meta_value.expect("metadata value exists when index exists");
+
+    let actual_id = value
+        .get("payload")
+        .and_then(|payload| payload.get("id"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("Codex session metadata is missing id: {}", path.display()))?;
+
+    if actual_id != session_id {
+        return Err(format!(
+            "Codex session ID mismatch: expected {session_id}, found {actual_id}"
+        ));
+    }
+
+    let payload = value
+        .get_mut("payload")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| {
+            format!(
+                "Codex session metadata payload is invalid: {}",
+                path.display()
+            )
+        })?;
+    payload.insert(
+        "model_provider".to_string(),
+        Value::String(target_provider.to_string()),
+    );
+
+    lines[index] =
+        serde_json::to_string(&value).map_err(|e| format!("Failed to encode metadata: {e}"))?;
+
+    let backup_path = session_backup_path(path);
+    fs::copy(path, &backup_path).map_err(|e| {
+        format!(
+            "Failed to create Codex session backup {}: {e}",
+            backup_path.display()
+        )
+    })?;
+
+    let mut output = lines.join("\n");
+    if content.ends_with('\n') {
+        output.push('\n');
+    }
+    fs::write(path, output)
+        .map_err(|e| format!("Failed to write Codex session file {}: {e}", path.display()))?;
+
+    Ok(Some(target_provider.to_string()))
+}
+
+fn session_backup_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("session.jsonl");
+    path.with_file_name(format!("{file_name}.cc-switch.bak"))
+}
+
+fn update_state_db_model_provider(
+    state_db_path: &Path,
+    session_id: &str,
+    target_provider: &str,
+) -> Result<(), String> {
+    if !state_db_path.exists() {
+        return Ok(());
+    }
+
+    let conn = rusqlite::Connection::open(state_db_path).map_err(|e| {
+        format!(
+            "Failed to open Codex state database {}: {e}",
+            state_db_path.display()
+        )
+    })?;
+
+    let has_threads: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'threads'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Failed to inspect Codex state database: {e}"))?;
+    if has_threads == 0 {
+        return Err("Codex state database is missing threads table".to_string());
+    }
+
+    let has_model_provider = {
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(threads)")
+            .map_err(|e| format!("Failed to inspect Codex threads schema: {e}"))?;
+        let columns = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| format!("Failed to read Codex threads schema: {e}"))?;
+        let mut found = false;
+        for column in columns {
+            if column.map_err(|e| format!("Failed to read Codex threads column: {e}"))?
+                == "model_provider"
+            {
+                found = true;
+                break;
+            }
+        }
+        found
+    };
+
+    if !has_model_provider {
+        return Err("Codex threads table is missing model_provider column".to_string());
+    }
+
+    conn.execute(
+        "UPDATE threads SET model_provider = ?1 WHERE id = ?2",
+        rusqlite::params![target_provider, session_id],
+    )
+    .map_err(|e| format!("Failed to update Codex state database: {e}"))?;
+
+    Ok(())
 }
 
 fn parse_session(path: &Path) -> Option<SessionMeta> {
@@ -306,6 +576,81 @@ mod tests {
 
         let meta = parse_session(&path).unwrap();
         assert_eq!(meta.title.as_deref(), Some("How do I deploy?"));
+    }
+
+    #[test]
+    fn reads_session_model_provider() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"timestamp\":\"2026-03-06T21:50:12Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"test-id\",\"cwd\":\"/tmp/project\",\"model_provider\":\"custom\"}}\n",
+                "{\"timestamp\":\"2026-03-06T21:50:13Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":\"Hello\"}}\n"
+            ),
+        )
+        .expect("write");
+
+        let provider = read_session_file_model_provider(&path, "test-id").unwrap();
+        assert_eq!(provider.as_deref(), Some("custom"));
+    }
+
+    #[test]
+    fn switch_session_provider_updates_jsonl_and_state_db() {
+        let temp = tempdir().expect("tempdir");
+        let sessions_root = temp.path().join("sessions");
+        std::fs::create_dir_all(&sessions_root).expect("create sessions root");
+        let path = sessions_root.join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"timestamp\":\"2026-03-06T21:50:12Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"test-id\",\"cwd\":\"/tmp/project\",\"model_provider\":\"openai\"}}\n",
+                "{\"timestamp\":\"2026-03-06T21:50:13Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":\"Hello\"}}\n"
+            ),
+        )
+        .expect("write");
+
+        let db_path = temp.path().join("state_5.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).expect("open db");
+        conn.execute(
+            "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT NOT NULL)",
+            [],
+        )
+        .expect("create threads");
+        conn.execute(
+            "INSERT INTO threads (id, model_provider) VALUES ('test-id', 'openai')",
+            [],
+        )
+        .expect("insert thread");
+        drop(conn);
+
+        switch_session_provider_with_paths("test-id", &path, "custom", &sessions_root, &db_path)
+            .expect("switch provider");
+
+        let first_line = std::fs::read_to_string(&path)
+            .expect("read session")
+            .lines()
+            .next()
+            .expect("first line")
+            .to_string();
+        let value: Value = serde_json::from_str(&first_line).expect("parse first line");
+        assert_eq!(
+            value
+                .get("payload")
+                .and_then(|payload| payload.get("model_provider"))
+                .and_then(Value::as_str),
+            Some("custom")
+        );
+
+        let conn = rusqlite::Connection::open(&db_path).expect("reopen db");
+        let provider: String = conn
+            .query_row(
+                "SELECT model_provider FROM threads WHERE id = 'test-id'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query provider");
+        assert_eq!(provider, "custom");
     }
 
     #[test]

--- a/src/components/sessions/CodexSessionProviderSwitch.tsx
+++ b/src/components/sessions/CodexSessionProviderSwitch.tsx
@@ -1,0 +1,126 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { sessionsApi } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { extractErrorMessage } from "@/utils/errorUtils";
+import type { SessionMeta } from "@/types";
+
+type CodexProviderGroup = "custom" | "openai";
+
+interface CodexSessionProviderSwitchProps {
+  session: SessionMeta;
+}
+
+function isCodexProviderGroup(
+  value: string | null | undefined,
+): value is CodexProviderGroup {
+  return value === "custom" || value === "openai";
+}
+
+export function CodexSessionProviderSwitch({
+  session,
+}: CodexSessionProviderSwitchProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const enabled = session.providerId === "codex" && Boolean(session.sourcePath);
+  const queryKey = [
+    "codexSessionProvider",
+    session.sessionId,
+    session.sourcePath,
+  ];
+
+  const { data: provider } = useQuery({
+    queryKey,
+    enabled,
+    queryFn: () =>
+      sessionsApi.getCodexProvider(session.sessionId, session.sourcePath!),
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (targetProvider: CodexProviderGroup) => {
+      return await sessionsApi.switchCodexProvider({
+        sessionId: session.sessionId,
+        sourcePath: session.sourcePath!,
+        targetProvider,
+      });
+    },
+    onSuccess: async (updatedProvider) => {
+      queryClient.setQueryData(queryKey, updatedProvider);
+      await queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      toast.success(
+        t("sessionManager.codexProviderSwitchSuccess", {
+          defaultValue: "Codex 会话分组已更新",
+        }),
+      );
+    },
+    onError: (error: Error) => {
+      const detail = extractErrorMessage(error) || t("common.unknown");
+      toast.error(
+        t("sessionManager.codexProviderSwitchFailed", {
+          defaultValue: "Codex 会话分组更新失败: {{error}}",
+          error: detail,
+        }),
+      );
+    },
+  });
+
+  if (!enabled || !isCodexProviderGroup(provider)) {
+    return null;
+  }
+
+  const handleSwitch = (checked: boolean) => {
+    const targetProvider: CodexProviderGroup = checked ? "openai" : "custom";
+    if (provider === targetProvider) return;
+    mutation.mutate(targetProvider);
+  };
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2">
+      <div>
+        <div className="text-xs font-medium">
+          {t("sessionManager.codexProviderGroup", {
+            defaultValue: "Codex 会话分组",
+          })}
+        </div>
+        <div className="text-[11px] text-muted-foreground">
+          {t("sessionManager.codexProviderGroupHint", {
+            defaultValue: "切换后，此会话会出现在 Codex 对应分组的历史列表中。",
+          })}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "text-xs transition-colors",
+            provider === "custom"
+              ? "font-semibold text-primary"
+              : "text-muted-foreground",
+          )}
+        >
+          Custom
+        </span>
+        <Switch
+          checked={provider === "openai"}
+          disabled={mutation.isPending}
+          aria-label={t("sessionManager.codexProviderGroup", {
+            defaultValue: "Codex 会话分组",
+          })}
+          onCheckedChange={handleSwitch}
+        />
+        <span
+          className={cn(
+            "text-xs transition-colors",
+            provider === "openai"
+              ? "font-semibold text-primary"
+              : "text-muted-foreground",
+          )}
+        >
+          OpenAI
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -47,6 +47,7 @@ import { ProviderIcon } from "@/components/ProviderIcon";
 import { SessionItem } from "./SessionItem";
 import { SessionMessageItem } from "./SessionMessageItem";
 import { SessionTocDialog, SessionTocSidebar } from "./SessionToc";
+import { CodexSessionProviderSwitch } from "./CodexSessionProviderSwitch";
 import {
   formatSessionTitle,
   formatTimestamp,
@@ -981,6 +982,8 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                         </Tooltip>
                       </div>
                     )}
+
+                    <CodexSessionProviderSwitch session={selectedSession} />
                   </CardHeader>
 
                   {/* 消息列表区域 */}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -738,7 +738,7 @@
     "expandContent": "Expand full content",
     "collapseContent": "Collapse",
     "codexProviderGroup": "Codex session group",
-    "codexProviderGroupHint": "After switching, this session appears in the matching Codex history group.",
+    "codexProviderGroupHint": "Use OpenAI for official OpenAI subscriptions and Custom for custom providers so this session appears in the matching Codex history list.",
     "codexProviderSwitchSuccess": "Codex session group updated",
     "codexProviderSwitchFailed": "Failed to update Codex session group: {{error}}"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -736,7 +736,11 @@
     "messageCopied": "Message copied",
     "conversationHistory": "Conversation History",
     "expandContent": "Expand full content",
-    "collapseContent": "Collapse"
+    "collapseContent": "Collapse",
+    "codexProviderGroup": "Codex session group",
+    "codexProviderGroupHint": "After switching, this session appears in the matching Codex history group.",
+    "codexProviderSwitchSuccess": "Codex session group updated",
+    "codexProviderSwitchFailed": "Failed to update Codex session group: {{error}}"
   },
   "console": {
     "providerSwitchReceived": "Received provider switch event:",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -738,7 +738,7 @@
     "expandContent": "全文を表示",
     "collapseContent": "折りたたむ",
     "codexProviderGroup": "Codex セッショングループ",
-    "codexProviderGroupHint": "切り替えると、このセッションは対応する Codex 履歴グループに表示されます。",
+    "codexProviderGroupHint": "OpenAI 公式サブスクリプションを使う場合は OpenAI、カスタム Provider を使う場合は Custom に切り替えると、このセッションが対応する Codex 履歴一覧に表示されます。",
     "codexProviderSwitchSuccess": "Codex セッショングループを更新しました",
     "codexProviderSwitchFailed": "Codex セッショングループの更新に失敗しました: {{error}}"
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -736,7 +736,11 @@
     "messageCopied": "メッセージがコピーされました",
     "conversationHistory": "会話履歴",
     "expandContent": "全文を表示",
-    "collapseContent": "折りたたむ"
+    "collapseContent": "折りたたむ",
+    "codexProviderGroup": "Codex セッショングループ",
+    "codexProviderGroupHint": "切り替えると、このセッションは対応する Codex 履歴グループに表示されます。",
+    "codexProviderSwitchSuccess": "Codex セッショングループを更新しました",
+    "codexProviderSwitchFailed": "Codex セッショングループの更新に失敗しました: {{error}}"
   },
   "console": {
     "providerSwitchReceived": "プロバイダー切り替えイベントを受信:",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -738,7 +738,7 @@
     "expandContent": "展开完整内容",
     "collapseContent": "收起",
     "codexProviderGroup": "Codex 会话分组",
-    "codexProviderGroupHint": "切换后，此会话会出现在 Codex 对应分组的历史列表中。",
+    "codexProviderGroupHint": "切换会话显示的分组：官方订阅选 OpenAI，自定义订阅选 Custom。",
     "codexProviderSwitchSuccess": "Codex 会话分组已更新",
     "codexProviderSwitchFailed": "Codex 会话分组更新失败: {{error}}"
   },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -736,7 +736,11 @@
     "messageCopied": "已复制消息内容",
     "conversationHistory": "对话记录",
     "expandContent": "展开完整内容",
-    "collapseContent": "收起"
+    "collapseContent": "收起",
+    "codexProviderGroup": "Codex 会话分组",
+    "codexProviderGroupHint": "切换后，此会话会出现在 Codex 对应分组的历史列表中。",
+    "codexProviderSwitchSuccess": "Codex 会话分组已更新",
+    "codexProviderSwitchFailed": "Codex 会话分组更新失败: {{error}}"
   },
   "console": {
     "providerSwitchReceived": "收到供应商切换事件:",

--- a/src/lib/api/sessions.ts
+++ b/src/lib/api/sessions.ts
@@ -12,6 +12,12 @@ export interface DeleteSessionResult extends DeleteSessionOptions {
   error?: string;
 }
 
+export interface SwitchCodexSessionProviderOptions {
+  sessionId: string;
+  sourcePath: string;
+  targetProvider: "openai" | "custom";
+}
+
 export const sessionsApi = {
   async list(): Promise<SessionMeta[]> {
     return await invoke("list_sessions");
@@ -37,6 +43,22 @@ export const sessionsApi = {
     items: DeleteSessionOptions[],
   ): Promise<DeleteSessionResult[]> {
     return await invoke("delete_sessions", { items });
+  },
+
+  async getCodexProvider(
+    sessionId: string,
+    sourcePath: string,
+  ): Promise<string | null> {
+    return await invoke("get_codex_session_provider", {
+      sessionId,
+      sourcePath,
+    });
+  },
+
+  async switchCodexProvider(
+    request: SwitchCodexSessionProviderOptions,
+  ): Promise<string | null> {
+    return await invoke("switch_codex_session_provider", { request });
   },
 
   async launchTerminal(options: {


### PR DESCRIPTION
## Summary / 概述

### 问题

Codex 会按 Provider 维护两类 session：`openai` 和 `custom`。

这种分类维护使得通过 CC Switch 在自定义 Provider 和 OpenAI 官方订阅之间切换时，Codex 的 resume 列表只会展示当前 Provider 分组下的 session。

尽管可以直接使用 `codex resume [session id]` 直接 resume 到指定的 session，不过使用 Codex App 的用户就不能在选择列表中这么操作了。

因此就出现了 Provider switch 了但是之前没跑完的 session 在 switch 之后不可见的情况。

### 解决方案

解决这个问题的方案有很多。

底层上，Codex 会把完整会话内容保存在本地 JSONL 文件中，同时在本地 SQLite 的 `threads` 表中维护一份会话索引。两处都会记录 `model_provider` 字段，用来标识该 session 属于 `openai` 还是 `custom` 分组。

考虑到使用 [CC Switch 的默认配置](https://github.com/LanternCX/cc-switch/blob/main/src/config/codexTemplates.ts)会把非官方订阅默认配置为 `custom`，而且不可能存在一个 `session` 同时属于 `openai` 和 `custom` 两类的情况：

本 PR 为 Codex session 单独增加了一个 Provider 切换开关。用户可以通过该开关把指定 session 在 `openai` 和 `custom` 分组之间切换。

具体实现上，切换开关会同时更新 JSONL 会话元信息和 SQLite `threads` 表中的 `model_provider`，确保 Codex resume 历史列表能在目标 Provider 下正确展示该 session。

## Related Issue / 关联 Issue

Issue #1709 #1294 #1526 和 PR #2090 都提到了这个问题，原因和上述的一样。现在解决方案有这些：

1. #1709：提到了一个解决方案是直接不使用 custom 分组，统一使用 openai 分组

2. #1294 和 #1526：提到了实现了一个脚本用来解决这个问题，不过脚本链接似乎 404 了

3. #2090：这个 PR 的方案是在切换 Codex Provider 时直接全部自动同步历史会话分组。

本次 PR 中的方案介于 1 2 和 3 之间，在不破坏默认的 `custom` 配置的情况下给用户提供了一个极小的切换方式。而方案 3 的全量切换则过于重了。

## Screenshots / 截图

### Before / 修改前
 
<img width="647" height="205" alt="image" src="https://github.com/user-attachments/assets/822cf157-1c4c-43d6-ba49-c703ea22f8b0" />

### After / 修改后 

<img width="617" height="210" alt="image" src="https://github.com/user-attachments/assets/42956b38-2797-4b88-8b59-a87e469783d7" />

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
