### PR TITLE
feat(usage): add memory for date range selection -   remember last choice across app restarts and tab   switches

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -468,7 +468,7 @@ export function SettingsPage({
                 <AboutSection isPortable={isPortable} />
               </TabsContent>
 
-              <TabsContent value="usage" className="mt-0">
+              <TabsContent value="usage" className="mt-0" forceMount>
                 <UsageDashboard />
               </TabsContent>
             </div>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -468,7 +468,7 @@ export function SettingsPage({
                 <AboutSection isPortable={isPortable} />
               </TabsContent>
 
-              <TabsContent value="usage" className="mt-0" forceMount>
+              <TabsContent value="usage" className="mt-0">
                 <UsageDashboard />
               </TabsContent>
             </div>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -211,7 +211,7 @@ export function SettingsPage({
 
           <div className="flex-1 min-h-0 flex flex-col">
             <div className="flex-1 overflow-y-auto overflow-x-hidden pr-2">
-              <TabsContent value="general" className="space-y-6 mt-0">
+              <TabsContent value="general" className="space-y-6 mt-0" forceMount>
                 {settings ? (
                   <motion.div
                     initial={{ opacity: 0, y: 10 }}
@@ -255,7 +255,7 @@ export function SettingsPage({
                 ) : null}
               </TabsContent>
 
-              <TabsContent value="proxy" className="space-y-6 mt-0 pb-4">
+              <TabsContent value="proxy" className="space-y-6 mt-0 pb-4" forceMount>
                 {settings ? (
                   <ProxyTabContent
                     settings={settings}
@@ -264,7 +264,7 @@ export function SettingsPage({
                 ) : null}
               </TabsContent>
 
-              <TabsContent value="auth" className="space-y-6 mt-0 pb-4">
+              <TabsContent value="auth" className="space-y-6 mt-0 pb-4" forceMount>
                 <motion.div
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -275,7 +275,7 @@ export function SettingsPage({
                 </motion.div>
               </TabsContent>
 
-              <TabsContent value="advanced" className="space-y-6 mt-0 pb-4">
+              <TabsContent value="advanced" className="space-y-6 mt-0 pb-4" forceMount>
                 {settings ? (
                   <motion.div
                     initial={{ opacity: 0, y: 10 }}
@@ -464,7 +464,7 @@ export function SettingsPage({
                 ) : null}
               </TabsContent>
 
-              <TabsContent value="about" className="mt-0">
+              <TabsContent value="about" className="mt-0" forceMount>
                 <AboutSection isPortable={isPortable} />
               </TabsContent>
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -211,7 +211,7 @@ export function SettingsPage({
 
           <div className="flex-1 min-h-0 flex flex-col">
             <div className="flex-1 overflow-y-auto overflow-x-hidden pr-2">
-              <TabsContent value="general" className="space-y-6 mt-0" forceMount>
+              <TabsContent value="general" className="space-y-6 mt-0">
                 {settings ? (
                   <motion.div
                     initial={{ opacity: 0, y: 10 }}
@@ -255,7 +255,7 @@ export function SettingsPage({
                 ) : null}
               </TabsContent>
 
-              <TabsContent value="proxy" className="space-y-6 mt-0 pb-4" forceMount>
+              <TabsContent value="proxy" className="space-y-6 mt-0 pb-4">
                 {settings ? (
                   <ProxyTabContent
                     settings={settings}
@@ -264,7 +264,7 @@ export function SettingsPage({
                 ) : null}
               </TabsContent>
 
-              <TabsContent value="auth" className="space-y-6 mt-0 pb-4" forceMount>
+              <TabsContent value="auth" className="space-y-6 mt-0 pb-4">
                 <motion.div
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -275,7 +275,7 @@ export function SettingsPage({
                 </motion.div>
               </TabsContent>
 
-              <TabsContent value="advanced" className="space-y-6 mt-0 pb-4" forceMount>
+              <TabsContent value="advanced" className="space-y-6 mt-0 pb-4">
                 {settings ? (
                   <motion.div
                     initial={{ opacity: 0, y: 10 }}
@@ -464,7 +464,7 @@ export function SettingsPage({
                 ) : null}
               </TabsContent>
 
-              <TabsContent value="about" className="mt-0" forceMount>
+              <TabsContent value="about" className="mt-0">
                 <AboutSection isPortable={isPortable} />
               </TabsContent>
 

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -1,11 +1,11 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { UsageSummaryCards } from "./UsageSummaryCards";
 import { UsageTrendChart } from "./UsageTrendChart";
 import { RequestLogTable } from "./RequestLogTable";
 import { ProviderStatsTable } from "./ProviderStatsTable";
 import { ModelStatsTable } from "./ModelStatsTable";
-import type { AppTypeFilter, UsageRangeSelection } from "@/types/usage";
+import type { AppTypeFilter, UsageRangeSelection, UsageRangePreset } from "@/types/usage";
 import { motion } from "framer-motion";
 import {
   BarChart3,
@@ -37,10 +37,65 @@ const APP_FILTER_OPTIONS: AppTypeFilter[] = [
   "gemini",
 ];
 
+const STORAGE_KEY = "cc-switch-last-usage-range";
+
+function loadSavedRange(): UsageRangeSelection {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return { preset: "today" };
+
+    const parsed = JSON.parse(saved) as unknown;
+
+    // Validate structure
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "preset" in parsed &&
+      typeof parsed.preset === "string"
+    ) {
+      const preset = parsed.preset as UsageRangePreset;
+      const validPresets: UsageRangePreset[] = [
+        "today",
+        "1d",
+        "7d",
+        "14d",
+        "30d",
+        "custom",
+      ];
+
+      if (validPresets.includes(preset)) {
+        if (preset === "custom") {
+          if (
+            "customStartDate" in parsed &&
+            typeof parsed.customStartDate === "number" &&
+            "customEndDate" in parsed &&
+            typeof parsed.customEndDate === "number"
+          ) {
+            return {
+              preset: "custom",
+              customStartDate: parsed.customStartDate,
+              customEndDate: parsed.customEndDate,
+            };
+          }
+          // Invalid custom range, fall back to today
+          return { preset: "today" };
+        }
+        return { preset };
+      }
+    }
+
+    // Invalid format, fall back
+    return { preset: "today" };
+  } catch {
+    // Ignore errors, fall back to default
+    return { preset: "today" };
+  }
+}
+
 export function UsageDashboard() {
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
-  const [range, setRange] = useState<UsageRangeSelection>({ preset: "today" });
+  const [range, setRange] = useState<UsageRangeSelection>(loadSavedRange());
   const [appType, setAppType] = useState<AppTypeFilter>("all");
   const [refreshIntervalMs, setRefreshIntervalMs] = useState(30000);
 
@@ -68,6 +123,14 @@ export function UsageDashboard() {
       resolvedRange.endDate * 1000,
     ).toLocaleString(locale)}`;
   }, [locale, range, resolvedRange.endDate, resolvedRange.startDate, t]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(range));
+    } catch {
+      // Ignore storage errors (e.g., private browsing mode where storage is disabled)
+    }
+  }, [range]);
 
   return (
     <motion.div

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -53,18 +53,13 @@ function loadSavedRange(): UsageRangeSelection {
       "preset" in parsed &&
       typeof parsed.preset === "string"
     ) {
-      const preset = parsed.preset as UsageRangePreset;
-      const validPresets: UsageRangePreset[] = [
-        "today",
-        "1d",
-        "7d",
-        "14d",
-        "30d",
-        "custom",
-      ];
+      const preset = parsed.preset;
+      // Check if preset is one of the valid values
+      const isPresetValid = (["today", "1d", "7d", "14d", "30d", "custom"] as const).includes(preset as any);
 
-      if (validPresets.includes(preset)) {
-        if (preset === "custom") {
+      if (isPresetValid) {
+        const validPreset = preset as UsageRangePreset;
+        if (validPreset === "custom") {
           if (
             "customStartDate" in parsed &&
             typeof parsed.customStartDate === "number" &&
@@ -80,7 +75,7 @@ function loadSavedRange(): UsageRangeSelection {
           // Invalid custom range, fall back to today
           return { preset: "today" };
         }
-        return { preset };
+        return { preset: validPreset };
       }
     }
 

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -5,7 +5,11 @@ import { UsageTrendChart } from "./UsageTrendChart";
 import { RequestLogTable } from "./RequestLogTable";
 import { ProviderStatsTable } from "./ProviderStatsTable";
 import { ModelStatsTable } from "./ModelStatsTable";
-import type { AppTypeFilter, UsageRangeSelection, UsageRangePreset } from "@/types/usage";
+import type {
+  AppTypeFilter,
+  UsageRangeSelection,
+  UsageRangePreset,
+} from "@/types/usage";
 import { motion } from "framer-motion";
 import {
   BarChart3,
@@ -95,7 +99,9 @@ function loadSavedRange(): UsageRangeSelection {
 export function UsageDashboard() {
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
-  const [range, setRange] = useState<UsageRangeSelection>(loadSavedRange());
+  const [range, setRange] = useState<UsageRangeSelection>(() =>
+    loadSavedRange(),
+  );
   const [appType, setAppType] = useState<AppTypeFilter>("all");
   const [refreshIntervalMs, setRefreshIntervalMs] = useState(30000);
 

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -53,13 +53,18 @@ function loadSavedRange(): UsageRangeSelection {
       "preset" in parsed &&
       typeof parsed.preset === "string"
     ) {
-      const preset = parsed.preset;
-      // Check if preset is one of the valid values
-      const isPresetValid = (["today", "1d", "7d", "14d", "30d", "custom"] as const).includes(preset as any);
+      const preset = parsed.preset as UsageRangePreset;
+      const validPresets: UsageRangePreset[] = [
+        "today",
+        "1d",
+        "7d",
+        "14d",
+        "30d",
+        "custom",
+      ];
 
-      if (isPresetValid) {
-        const validPreset = preset as UsageRangePreset;
-        if (validPreset === "custom") {
+      if (validPresets.includes(preset)) {
+        if (preset === "custom") {
           if (
             "customStartDate" in parsed &&
             typeof parsed.customStartDate === "number" &&
@@ -75,7 +80,7 @@ function loadSavedRange(): UsageRangeSelection {
           // Invalid custom range, fall back to today
           return { preset: "today" };
         }
-        return { preset: validPreset };
+        return { preset };
       }
     }
 


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

After Change The Tab Or Reload The App, the date range selection have memory 

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|      <img width="1000" height="650" alt="image" src="https://github.com/user-attachments/assets/3b65c357-6733-4a04-84d4-2edab6b43413" />    |       <img width="1000" height="650" alt="image" src="https://github.com/user-attachments/assets/100c3a5f-ab5d-4272-84ae-42252297e76d" />        |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
