### PR TITLE
fix(skills): clean up orphaned database records when skill directory is missing

### DIFF
--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -556,9 +556,35 @@ impl SkillService {
     // ========== 统一管理方法 ==========
 
     /// 获取所有已安装的 Skills
+    ///
+    /// 返回值仅包含 SSOT 目录中实际存在的 Skills。
+    /// 如果数据库记录对应的目录已被手动删除，会自动清理该记录。
     pub fn get_all_installed(db: &Arc<Database>) -> Result<Vec<InstalledSkill>> {
         let skills = db.get_all_installed_skills()?;
-        Ok(skills.into_values().collect())
+        let ssot_dir = Self::get_ssot_dir()?;
+
+        if !ssot_dir.exists() || !ssot_dir.is_dir() {
+            log::error!("SSOT 目录不可访问: {}, 跳过清理以避免误删", ssot_dir.display());
+            return Ok(skills.into_values().collect());
+        }
+
+        let mut valid = Vec::new();
+        for skill in skills.into_values() {
+            let skill_path = ssot_dir.join(&skill.directory);
+            if skill_path.exists() {
+                valid.push(skill);
+            } else {
+                log::warn!(
+                    "Skill '{}' (id={}) 的目录不存在，清理孤立数据库记录: {}",
+                    skill.name,
+                    skill.id,
+                    skill_path.display()
+                );
+                let _ = db.delete_skill(&skill.id);
+            }
+        }
+
+        Ok(valid)
     }
 
     /// 安装 Skill

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -561,10 +561,19 @@ impl SkillService {
     /// 如果数据库记录对应的目录已被手动删除，会自动清理该记录。
     pub fn get_all_installed(db: &Arc<Database>) -> Result<Vec<InstalledSkill>> {
         let skills = db.get_all_installed_skills()?;
-        let ssot_dir = Self::get_ssot_dir()?;
+        let ssot_dir = match Self::get_ssot_dir() {
+            Ok(dir) => dir,
+            Err(e) => {
+                log::error!("SSOT 目录不可访问: {}, 跳过清理以避免误删", e);
+                return Ok(skills.into_values().collect());
+            }
+        };
 
         if !ssot_dir.exists() || !ssot_dir.is_dir() {
-            log::error!("SSOT 目录不可访问: {}, 跳过清理以避免误删", ssot_dir.display());
+            log::error!(
+                "SSOT 目录不可访问: {}, 跳过清理以避免误删",
+                ssot_dir.display()
+            );
             return Ok(skills.into_values().collect());
         }
 


### PR DESCRIPTION
## Problem / 问题

When users manually delete skill directories from the filesystem (e.g., `~/.cc-switch/skills/`, `~/.claude/skills/`, `~/.codex/skills/`), the CC Switch client still displays these deleted skills because `get_all_installed()` only reads from the database without verifying that the skill directory exists on disk.

Closes #2279

## Solution / 解决方案

Modified `get_all_installed()` in `src-tauri/src/services/skill.rs` to:

1. Verify the SSOT directory is accessible before cleanup
2. Check each database record against the filesystem
3. Auto-remove orphaned records where the directory has been deleted
4. Log warnings for each cleanup operation

## Safety / 安全性

- If the SSOT directory itself is inaccessible, cleanup is skipped and all records are returned (no false deletions)
- Only the `get_all_installed` function is modified — no changes to uninstall, install, or database logic

## Files Changed / 文件变更

- `src-tauri/src/services/skill.rs` — `get_all_installed()` function (+27/-1)