### PR TITLE
feat: add provider user agent override

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -284,6 +284,9 @@ pub struct ProviderMeta {
     /// Codex OAuth FAST mode: inject `service_tier = "priority"` for ChatGPT Codex requests.
     #[serde(rename = "codexFastMode", skip_serializing_if = "Option::is_none")]
     pub codex_fast_mode: Option<bool>,
+    /// Custom User-Agent for local proxy routing.
+    #[serde(rename = "customUserAgent", skip_serializing_if = "Option::is_none")]
+    pub custom_user_agent: Option<String>,
     /// 累加模式应用中，该 provider 是否已写入 live config。
     /// `None` 表示旧数据/未知状态，`Some(false)` 表示明确仅存在于数据库中。
     #[serde(rename = "liveConfigManaged", skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1123,6 +1123,15 @@ impl RequestForwarder {
                 Vec::new()
             };
 
+        let custom_user_agent = provider
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.custom_user_agent.as_deref())
+            .map(str::trim)
+            .filter(|ua| !ua.is_empty())
+            .filter(|_| !is_copilot)
+            .and_then(|ua| http::HeaderValue::from_str(ua).ok());
+
         // --- Copilot 优化器：动态 header 注入 ---
         if let Some((ref classification, ref det_request_id, ref interaction_id)) =
             copilot_optimization
@@ -1217,6 +1226,7 @@ impl RequestForwarder {
         let mut ordered_headers = http::HeaderMap::new();
         let mut saw_auth = false;
         let mut saw_accept_encoding = false;
+        let mut saw_user_agent = false;
         let mut saw_anthropic_beta = false;
         let mut saw_anthropic_version = false;
 
@@ -1297,6 +1307,19 @@ impl RequestForwarder {
                 continue;
             }
 
+            // --- user-agent: provider-level override for local proxy routing ---
+            if !is_copilot && key_str.eq_ignore_ascii_case("user-agent") {
+                if !saw_user_agent {
+                    saw_user_agent = true;
+                    if let Some(ref ua) = custom_user_agent {
+                        ordered_headers.append(http::header::USER_AGENT, ua.clone());
+                    } else {
+                        ordered_headers.append(key.clone(), value.clone());
+                    }
+                }
+                continue;
+            }
+
             // --- anthropic-beta — 用重建值替换（确保含 claude-code 标记） ---
             if key_str.eq_ignore_ascii_case("anthropic-beta") {
                 if !saw_anthropic_beta {
@@ -1344,6 +1367,12 @@ impl RequestForwarder {
                 http::header::ACCEPT_ENCODING,
                 http::HeaderValue::from_static("identity"),
             );
+        }
+
+        if !saw_user_agent {
+            if let Some(ref ua) = custom_user_agent {
+                ordered_headers.append(http::header::USER_AGENT, ua.clone());
+            }
         }
 
         // 如果原始请求中没有 anthropic-beta 且有值需要添加，追加

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -133,6 +133,10 @@ interface ClaudeFormFieldsProps {
   // Full URL mode
   isFullUrl: boolean;
   onFullUrlChange: (value: boolean) => void;
+
+  // Local proxy User-Agent override
+  customUserAgent: string;
+  onCustomUserAgentChange: (value: string) => void;
 }
 
 export function ClaudeFormFields({
@@ -180,6 +184,8 @@ export function ClaudeFormFields({
   onApiKeyFieldChange,
   isFullUrl,
   onFullUrlChange,
+  customUserAgent,
+  onCustomUserAgentChange,
 }: ClaudeFormFieldsProps) {
   const { t } = useTranslation();
   const hasAnyAdvancedValue = !!(
@@ -487,7 +493,30 @@ export function ClaudeFormFields({
         />
       )}
 
-      {/* 高级选项（API 格式 + 认证字段 + 模型映射） */}
+      {category !== "official" && (
+        <div className="space-y-2">
+          <FormLabel htmlFor="claude-custom-user-agent">
+            {t("providerForm.customUserAgent", {
+              defaultValue: "自定义 User-Agent",
+            })}
+          </FormLabel>
+          <Input
+            id="claude-custom-user-agent"
+            type="text"
+            value={customUserAgent}
+            onChange={(e) => onCustomUserAgentChange(e.target.value)}
+            placeholder="Mozilla/5.0 ..."
+            autoComplete="off"
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("providerForm.customUserAgentHint", {
+              defaultValue:
+                "仅在开启本地路由/代理接管后生效，会替换转发到供应商 API 请求中的 User-Agent。",
+            })}
+          </p>
+        </div>
+      )}
+
       {shouldShowModelSelector && (
         <Collapsible open={advancedExpanded} onOpenChange={setAdvancedExpanded}>
           <CollapsibleTrigger asChild>

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
 import { Download, Loader2 } from "lucide-react";
 import EndpointSpeedTest from "./EndpointSpeedTest";
@@ -46,6 +47,10 @@ interface CodexFormFieldsProps {
 
   // Speed Test Endpoints
   speedTestEndpoints: EndpointCandidate[];
+
+  // Local proxy User-Agent override
+  customUserAgent: string;
+  onCustomUserAgentChange: (value: string) => void;
 }
 
 export function CodexFormFields({
@@ -71,6 +76,8 @@ export function CodexFormFields({
   modelName = "",
   onModelNameChange,
   speedTestEndpoints,
+  customUserAgent,
+  onCustomUserAgentChange,
 }: CodexFormFieldsProps) {
   const { t } = useTranslation();
 
@@ -205,6 +212,33 @@ export function CodexFormFields({
           onAutoSelectChange={onAutoSelectChange}
           onCustomEndpointsChange={onCustomEndpointsChange}
         />
+      )}
+
+      {category !== "official" && (
+        <div className="space-y-2">
+          <label
+            htmlFor="codex-custom-user-agent"
+            className="block text-sm font-medium text-foreground"
+          >
+            {t("providerForm.customUserAgent", {
+              defaultValue: "自定义 User-Agent",
+            })}
+          </label>
+          <Input
+            id="codex-custom-user-agent"
+            type="text"
+            value={customUserAgent}
+            onChange={(e) => onCustomUserAgentChange(e.target.value)}
+            placeholder="Mozilla/5.0 ..."
+            autoComplete="off"
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("providerForm.customUserAgentHint", {
+              defaultValue:
+                "仅在开启本地路由/代理接管后生效，会替换转发到供应商 API 请求中的 User-Agent。",
+            })}
+          </p>
+        </div>
       )}
     </>
   );

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -245,6 +245,7 @@ export function ProviderForm({
         initialData?.meta?.pricingModelSource,
       ),
     });
+    setCustomUserAgent(initialData?.meta?.customUserAgent ?? "");
   }, [appId, initialData, supportsFullUrl]);
 
   const defaultValues: ProviderFormData = useMemo(
@@ -391,6 +392,9 @@ export function ProviderForm({
   >(() => resolveManagedAccountId(initialData?.meta, "codex_oauth"));
   const [codexFastMode, setCodexFastMode] = useState<boolean>(
     () => initialData?.meta?.codexFastMode ?? false,
+  );
+  const [customUserAgent, setCustomUserAgent] = useState<string>(
+    () => initialData?.meta?.customUserAgent ?? "",
   );
 
   const {
@@ -1186,6 +1190,10 @@ export function ProviderForm({
           ? selectedGitHubAccountId
           : undefined,
       codexFastMode: isCodexOauthProvider ? codexFastMode : undefined,
+      customUserAgent:
+        appId === "claude" || appId === "codex"
+          ? customUserAgent.trim() || undefined
+          : undefined,
       testConfig: testConfig.enabled ? testConfig : undefined,
       costMultiplier: pricingConfig.enabled
         ? pricingConfig.costMultiplier
@@ -1810,6 +1818,8 @@ export function ProviderForm({
               onApiKeyFieldChange={handleApiKeyFieldChange}
               isFullUrl={localIsFullUrl}
               onFullUrlChange={setLocalIsFullUrl}
+              customUserAgent={customUserAgent}
+              onCustomUserAgentChange={setCustomUserAgent}
             />
           )}
 
@@ -1839,6 +1849,8 @@ export function ProviderForm({
               modelName={codexModelName}
               onModelNameChange={handleCodexModelNameChange}
               speedTestEndpoints={speedTestEndpoints}
+              customUserAgent={customUserAgent}
+              onCustomUserAgentChange={setCustomUserAgent}
             />
           )}
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -1191,7 +1191,7 @@ export function ProviderForm({
           : undefined,
       codexFastMode: isCodexOauthProvider ? codexFastMode : undefined,
       customUserAgent:
-        appId === "claude" || appId === "codex"
+        (appId === "claude" || appId === "codex") && category !== "official"
           ? customUserAgent.trim() || undefined
           : undefined,
       testConfig: testConfig.enabled ? testConfig : undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,8 @@ export interface ProviderMeta {
   promptCacheKey?: string;
   // Codex OAuth FAST mode: injects service_tier="priority" on ChatGPT Codex requests
   codexFastMode?: boolean;
+  // Custom User-Agent for local proxy routing. Only applied by the local proxy.
+  customUserAgent?: string;
   // 供应商类型（用于识别 Copilot 等特殊供应商）
   providerType?: string;
   // GitHub Copilot 关联账号 ID（旧字段，保留兼容读取）


### PR DESCRIPTION
## 概述

新增供应商级别的自定义 User-Agent 覆盖能力。

- 为供应商元数据新增 `customUserAgent` 字段。
- 在非官方 Claude / Codex 供应商表单中新增自定义 User-Agent 输入项。
- 保存供应商配置时会持久化去除首尾空格后的 User-Agent。
- 本地代理转发请求时，会替换或注入 `User-Agent` 请求头。
- GitHub Copilot 供应商不会应用该覆盖，避免影响 Copilot 指纹请求头。
