### PR TITLE
feat(codex): launch provider-scoped CLI sessions

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -752,6 +752,25 @@ pub async fn open_provider_terminal(
         .get(&providerId)
         .ok_or_else(|| format!("提供商 {providerId} 不存在"))?;
 
+    let is_codex_oauth_provider = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.provider_type.as_deref())
+        == Some("codex_oauth");
+
+    if app_type == AppType::Codex || is_codex_oauth_provider {
+        let proxy_info = state.proxy_service.start().await?;
+        launch_codex_provider_terminal(
+            &providerId,
+            app_type.as_str(),
+            &proxy_info.address,
+            proxy_info.port,
+            launch_cwd.as_deref(),
+        )
+        .map_err(|e| format!("启动 Codex 终端失败: {e}"))?;
+        return Ok(true);
+    }
+
     // 从提供商配置中提取环境变量
     let config = &provider.settings_config;
     let env_vars = extract_env_vars_from_config(config, &app_type);
@@ -811,6 +830,183 @@ fn extract_env_vars_from_config(
     }
 
     env_vars
+}
+
+fn launch_codex_provider_terminal(
+    provider_id: &str,
+    provider_app: &str,
+    proxy_address: &str,
+    proxy_port: u16,
+    cwd: Option<&Path>,
+) -> Result<(), String> {
+    let home = dirs::home_dir().ok_or_else(|| "无法定位用户 Home 目录".to_string())?;
+    let codex_home = home
+        .join(".cc-switch")
+        .join("codex-cli")
+        .join(sanitize_shell_name(provider_id));
+    std::fs::create_dir_all(&codex_home).map_err(|e| format!("创建 Codex Home 失败: {e}"))?;
+
+    let base_url = format!(
+        "http://{proxy_address}:{proxy_port}/codex/provider/{provider_app}/{provider_id}/v1"
+    );
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let temp_dir = std::env::temp_dir();
+        let script_file = temp_dir.join(format!(
+            "cc_switch_codex_launcher_{}_{}.sh",
+            sanitize_shell_name(provider_id),
+            std::process::id()
+        ));
+        let cd_command = build_shell_cd_command(cwd);
+        let script_content = format!(
+            r#"#!/bin/bash
+set -e
+{cd_command}
+export CODEX_HOME={codex_home}
+export OPENAI_API_KEY="PROXY_MANAGED"
+echo "Using provider-scoped Codex config:"
+echo "  provider: {provider_app}/{provider_id}"
+echo "  CODEX_HOME: $CODEX_HOME"
+echo "  base_url: {base_url}"
+codex -c {config_arg}
+exec bash --norc --noprofile
+"#,
+            cd_command = cd_command,
+            codex_home = shell_single_quote(&codex_home.to_string_lossy()),
+            provider_app = provider_app,
+            provider_id = provider_id,
+            base_url = base_url,
+            config_arg = shell_single_quote(&format!("base_url=\"{base_url}\"")),
+        );
+
+        std::fs::write(&script_file, script_content)
+            .map_err(|e| format!("写入 Codex 启动脚本失败: {e}"))?;
+        std::fs::set_permissions(&script_file, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("设置 Codex 启动脚本权限失败: {e}"))?;
+
+        #[cfg(target_os = "macos")]
+        {
+            return launch_macos_script_file(&script_file);
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            return launch_linux_script_file(&script_file);
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let temp_dir = std::env::temp_dir();
+        let bat_file = temp_dir.join(format!(
+            "cc_switch_codex_launcher_{}_{}.bat",
+            sanitize_shell_name(provider_id),
+            std::process::id()
+        ));
+        let cwd_command = build_windows_cwd_command(cwd);
+        let codex_home = escape_windows_batch_value(&codex_home.to_string_lossy());
+        let base_url_escaped = escape_windows_batch_value(&base_url);
+        let content = format!(
+            "@echo off\r\n{cwd_command}set \"CODEX_HOME={codex_home}\"\r\nset \"OPENAI_API_KEY=PROXY_MANAGED\"\r\necho Using provider-scoped Codex config:\r\necho   provider: {provider_app}/{provider_id}\r\necho   CODEX_HOME: %CODEX_HOME%\r\necho   base_url: {base_url_escaped}\r\ncodex -c \"base_url=\\\"{base_url_escaped}\\\"\"\r\n",
+        );
+        std::fs::write(&bat_file, content).map_err(|e| format!("写入 Codex 启动脚本失败: {e}"))?;
+        let bat_path = bat_file.to_string_lossy();
+        return run_windows_start_command(&["cmd", "/K", &bat_path], "cmd");
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    Err("不支持的操作系统".to_string())
+}
+
+fn sanitize_shell_name(value: &str) -> String {
+    let cleaned: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    cleaned.trim_matches('_').to_string()
+}
+
+#[cfg(target_os = "macos")]
+fn launch_macos_script_file(script_file: &std::path::Path) -> Result<(), String> {
+    let preferred = crate::settings::get_preferred_terminal();
+    let terminal = preferred.as_deref().unwrap_or("terminal");
+
+    let result = match terminal {
+        "iterm2" => launch_macos_iterm2(script_file),
+        "alacritty" => launch_macos_open_app("Alacritty", script_file, true),
+        "kitty" => launch_macos_open_app("kitty", script_file, false),
+        "ghostty" => launch_macos_open_app("Ghostty", script_file, true),
+        "wezterm" => launch_macos_open_app("WezTerm", script_file, true),
+        "kaku" => launch_macos_open_app("Kaku", script_file, true),
+        _ => launch_macos_terminal_app(script_file),
+    };
+
+    if result.is_err() && terminal != "terminal" {
+        return launch_macos_terminal_app(script_file);
+    }
+
+    result
+}
+
+#[cfg(target_os = "linux")]
+fn launch_linux_script_file(script_file: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+
+    let preferred = crate::settings::get_preferred_terminal();
+    let default_terminals = [
+        ("gnome-terminal", vec!["--"]),
+        ("konsole", vec!["-e"]),
+        ("xfce4-terminal", vec!["-e"]),
+        ("mate-terminal", vec!["--"]),
+        ("lxterminal", vec!["-e"]),
+        ("alacritty", vec!["-e"]),
+        ("kitty", vec!["-e"]),
+        ("ghostty", vec!["-e"]),
+    ];
+
+    let terminals_to_try: Vec<(&str, Vec<&str>)> = if let Some(ref pref) = preferred {
+        let pref_args = default_terminals
+            .iter()
+            .find(|(name, _)| *name == pref.as_str())
+            .map(|(_, args)| args.to_vec())
+            .unwrap_or_else(|| vec!["-e"]);
+        let mut list = vec![(pref.as_str(), pref_args)];
+        for (name, args) in &default_terminals {
+            if *name != pref.as_str() {
+                list.push((*name, args.to_vec()));
+            }
+        }
+        list
+    } else {
+        default_terminals
+            .iter()
+            .map(|(name, args)| (*name, args.to_vec()))
+            .collect()
+    };
+
+    let mut last_error = String::from("未找到可用的终端");
+    for (terminal, args) in terminals_to_try {
+        if which_command(terminal) {
+            match Command::new(terminal)
+                .args(&args)
+                .arg("bash")
+                .arg(script_file.to_string_lossy().as_ref())
+                .spawn()
+            {
+                Ok(_) => return Ok(()),
+                Err(e) => last_error = format!("执行 {terminal} 失败: {e}"),
+            }
+        }
+    }
+    Err(last_error)
 }
 
 fn resolve_launch_cwd(cwd: Option<String>) -> Result<Option<PathBuf>, String> {

--- a/src-tauri/src/proxy/handler_context.rs
+++ b/src-tauri/src/proxy/handler_context.rs
@@ -88,6 +88,45 @@ impl RequestContext {
         tag: &'static str,
         app_type_str: &'static str,
     ) -> Result<Self, ProxyError> {
+        Self::new_internal(state, body, headers, app_type, tag, app_type_str, None).await
+    }
+
+    /// Create a request context pinned to one provider.
+    ///
+    /// `provider_app_type` controls where the provider is read from. The
+    /// request can still be processed by a different handler, for example a
+    /// Codex CLI request using a Claude Codex-OAuth provider.
+    pub async fn new_with_provider_id(
+        state: &ProxyState,
+        body: &serde_json::Value,
+        headers: &HeaderMap,
+        request_app_type: AppType,
+        tag: &'static str,
+        request_app_type_str: &'static str,
+        provider_app_type: AppType,
+        provider_id: &str,
+    ) -> Result<Self, ProxyError> {
+        Self::new_internal(
+            state,
+            body,
+            headers,
+            request_app_type,
+            tag,
+            request_app_type_str,
+            Some((provider_app_type, provider_id)),
+        )
+        .await
+    }
+
+    async fn new_internal(
+        state: &ProxyState,
+        body: &serde_json::Value,
+        headers: &HeaderMap,
+        app_type: AppType,
+        tag: &'static str,
+        app_type_str: &'static str,
+        forced_provider: Option<(AppType, &str)>,
+    ) -> Result<Self, ProxyError> {
         let start_time = Instant::now();
 
         // 从数据库读取应用级代理配置（per-app）
@@ -124,24 +163,42 @@ impl RequestContext {
             session_result.client_provided
         );
 
-        // 使用共享的 ProviderRouter 选择 Provider（熔断器状态跨请求保持）
-        // 注意：只在这里调用一次，结果传递给 forwarder，避免重复消耗 HalfOpen 名额
-        let providers = state
-            .provider_router
-            .select_providers(app_type_str)
-            .await
-            .map_err(|e| match e {
-                crate::error::AppError::AllProvidersCircuitOpen => {
-                    ProxyError::AllProvidersCircuitOpen
-                }
-                crate::error::AppError::NoProvidersConfigured => ProxyError::NoProvidersConfigured,
-                _ => ProxyError::DatabaseError(e.to_string()),
-            })?;
+        let (providers, provider, current_provider_id) =
+            if let Some((provider_app_type, provider_id)) = forced_provider {
+                let provider_app_type_str = provider_app_type.as_str();
+                let provider = state
+                    .provider_router
+                    .select_provider_by_id(provider_app_type_str, provider_id)
+                    .await
+                    .map_err(|e| ProxyError::DatabaseError(e.to_string()))?;
+                (
+                    vec![provider.clone()],
+                    provider.clone(),
+                    provider.id.clone(),
+                )
+            } else {
+                // 使用共享的 ProviderRouter 选择 Provider（熔断器状态跨请求保持）
+                // 注意：只在这里调用一次，结果传递给 forwarder，避免重复消耗 HalfOpen 名额
+                let providers = state
+                    .provider_router
+                    .select_providers(app_type_str)
+                    .await
+                    .map_err(|e| match e {
+                        crate::error::AppError::AllProvidersCircuitOpen => {
+                            ProxyError::AllProvidersCircuitOpen
+                        }
+                        crate::error::AppError::NoProvidersConfigured => {
+                            ProxyError::NoProvidersConfigured
+                        }
+                        _ => ProxyError::DatabaseError(e.to_string()),
+                    })?;
 
-        let provider = providers
-            .first()
-            .cloned()
-            .ok_or(ProxyError::NoAvailableProvider)?;
+                let provider = providers
+                    .first()
+                    .cloned()
+                    .ok_or(ProxyError::NoAvailableProvider)?;
+                (providers, provider, current_provider_id)
+            };
 
         log::debug!(
             "[{}] Provider: {}, model: {}, failover chain: {} providers, session: {}",

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -31,10 +31,16 @@ use super::{
     ProxyError,
 };
 use crate::app_config::AppType;
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
 use bytes::Bytes;
 use http_body_util::BodyExt;
 use serde_json::{json, Value};
+use std::str::FromStr;
 
 // ============================================================================
 // 健康检查和状态查询（简单端点）
@@ -367,6 +373,40 @@ pub async fn handle_chat_completions(
     State(state): State<ProxyState>,
     request: axum::extract::Request,
 ) -> Result<axum::response::Response, ProxyError> {
+    handle_codex_request(
+        state,
+        request,
+        "/chat/completions",
+        &OPENAI_PARSER_CONFIG,
+        None,
+    )
+    .await
+}
+
+pub async fn handle_chat_completions_scoped(
+    State(state): State<ProxyState>,
+    Path((provider_app, provider_id)): Path<(String, String)>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    let provider_app_type =
+        AppType::from_str(&provider_app).map_err(|e| ProxyError::InvalidRequest(e.to_string()))?;
+    handle_codex_request(
+        state,
+        request,
+        "/chat/completions",
+        &OPENAI_PARSER_CONFIG,
+        Some((provider_app_type, provider_id)),
+    )
+    .await
+}
+
+async fn handle_codex_request(
+    state: ProxyState,
+    request: axum::extract::Request,
+    endpoint: &str,
+    parser_config: &'static super::handler_config::UsageParserConfig,
+    scoped_provider: Option<(AppType, String)>,
+) -> Result<axum::response::Response, ProxyError> {
     let (parts, req_body) = request.into_parts();
     let uri = parts.uri;
     let headers = parts.headers;
@@ -379,9 +419,22 @@ pub async fn handle_chat_completions(
     let body: Value = serde_json::from_slice(&body_bytes)
         .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
 
-    let mut ctx =
-        RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
-    let endpoint = endpoint_with_query(&uri, "/chat/completions");
+    let mut ctx = if let Some((provider_app_type, provider_id)) = scoped_provider.as_ref() {
+        RequestContext::new_with_provider_id(
+            &state,
+            &body,
+            &headers,
+            AppType::Codex,
+            "Codex",
+            "codex",
+            provider_app_type.clone(),
+            provider_id,
+        )
+        .await?
+    } else {
+        RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?
+    };
+    let endpoint = endpoint_with_query(&uri, endpoint);
 
     let is_stream = body
         .get("stream")
@@ -413,7 +466,7 @@ pub async fn handle_chat_completions(
     ctx.provider = result.provider;
     let response = result.response;
 
-    process_response(response, &ctx, &state, &OPENAI_PARSER_CONFIG).await
+    process_response(response, &ctx, &state, parser_config).await
 }
 
 /// 处理 /v1/responses 请求（OpenAI Responses API - Codex CLI 透传）
@@ -421,53 +474,24 @@ pub async fn handle_responses(
     State(state): State<ProxyState>,
     request: axum::extract::Request,
 ) -> Result<axum::response::Response, ProxyError> {
-    let (parts, req_body) = request.into_parts();
-    let uri = parts.uri;
-    let headers = parts.headers;
-    let extensions = parts.extensions;
-    let body_bytes = req_body
-        .collect()
-        .await
-        .map_err(|e| ProxyError::Internal(format!("Failed to read request body: {e}")))?
-        .to_bytes();
-    let body: Value = serde_json::from_slice(&body_bytes)
-        .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+    handle_codex_request(state, request, "/responses", &CODEX_PARSER_CONFIG, None).await
+}
 
-    let mut ctx =
-        RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
-    let endpoint = endpoint_with_query(&uri, "/responses");
-
-    let is_stream = body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
-    let forwarder = ctx.create_forwarder(&state);
-    let result = match forwarder
-        .forward_with_retry(
-            &AppType::Codex,
-            &endpoint,
-            body,
-            headers,
-            extensions,
-            ctx.get_providers(),
-        )
-        .await
-    {
-        Ok(result) => result,
-        Err(mut err) => {
-            if let Some(provider) = err.provider.take() {
-                ctx.provider = provider;
-            }
-            log_forward_error(&state, &ctx, is_stream, &err.error);
-            return Err(err.error);
-        }
-    };
-
-    ctx.provider = result.provider;
-    let response = result.response;
-
-    process_response(response, &ctx, &state, &CODEX_PARSER_CONFIG).await
+pub async fn handle_responses_scoped(
+    State(state): State<ProxyState>,
+    Path((provider_app, provider_id)): Path<(String, String)>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    let provider_app_type =
+        AppType::from_str(&provider_app).map_err(|e| ProxyError::InvalidRequest(e.to_string()))?;
+    handle_codex_request(
+        state,
+        request,
+        "/responses",
+        &CODEX_PARSER_CONFIG,
+        Some((provider_app_type, provider_id)),
+    )
+    .await
 }
 
 /// 处理 /v1/responses/compact 请求（OpenAI Responses Compact API - Codex CLI 透传）
@@ -475,53 +499,31 @@ pub async fn handle_responses_compact(
     State(state): State<ProxyState>,
     request: axum::extract::Request,
 ) -> Result<axum::response::Response, ProxyError> {
-    let (parts, req_body) = request.into_parts();
-    let uri = parts.uri;
-    let headers = parts.headers;
-    let extensions = parts.extensions;
-    let body_bytes = req_body
-        .collect()
-        .await
-        .map_err(|e| ProxyError::Internal(format!("Failed to read request body: {e}")))?
-        .to_bytes();
-    let body: Value = serde_json::from_slice(&body_bytes)
-        .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+    handle_codex_request(
+        state,
+        request,
+        "/responses/compact",
+        &CODEX_PARSER_CONFIG,
+        None,
+    )
+    .await
+}
 
-    let mut ctx =
-        RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
-    let endpoint = endpoint_with_query(&uri, "/responses/compact");
-
-    let is_stream = body
-        .get("stream")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
-    let forwarder = ctx.create_forwarder(&state);
-    let result = match forwarder
-        .forward_with_retry(
-            &AppType::Codex,
-            &endpoint,
-            body,
-            headers,
-            extensions,
-            ctx.get_providers(),
-        )
-        .await
-    {
-        Ok(result) => result,
-        Err(mut err) => {
-            if let Some(provider) = err.provider.take() {
-                ctx.provider = provider;
-            }
-            log_forward_error(&state, &ctx, is_stream, &err.error);
-            return Err(err.error);
-        }
-    };
-
-    ctx.provider = result.provider;
-    let response = result.response;
-
-    process_response(response, &ctx, &state, &CODEX_PARSER_CONFIG).await
+pub async fn handle_responses_compact_scoped(
+    State(state): State<ProxyState>,
+    Path((provider_app, provider_id)): Path<(String, String)>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    let provider_app_type =
+        AppType::from_str(&provider_app).map_err(|e| ProxyError::InvalidRequest(e.to_string()))?;
+    handle_codex_request(
+        state,
+        request,
+        "/responses/compact",
+        &CODEX_PARSER_CONFIG,
+        Some((provider_app_type, provider_id)),
+    )
+    .await
 }
 
 // ============================================================================

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -108,6 +108,22 @@ impl ProviderRouter {
         Ok(result)
     }
 
+    /// Select one exact provider for provider-scoped requests.
+    ///
+    /// This bypasses current-provider and failover selection so a dedicated
+    /// Codex CLI window can keep using the provider it was launched with.
+    pub async fn select_provider_by_id(
+        &self,
+        app_type: &str,
+        provider_id: &str,
+    ) -> Result<Provider, AppError> {
+        self.db
+            .get_provider_by_id(provider_id, app_type)?
+            .ok_or_else(|| {
+                AppError::Message(format!("Provider not found: {app_type}/{provider_id}"))
+            })
+    }
+
     /// 请求执行前获取熔断器“放行许可”
     ///
     /// - Closed：直接放行

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -85,6 +85,15 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn extract_base_url(&self, provider: &Provider) -> Result<String, ProxyError> {
+        if provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.provider_type.as_deref())
+            == Some("codex_oauth")
+        {
+            return Ok("https://chatgpt.com/backend-api/codex".to_string());
+        }
+
         // 1. 尝试直接获取 base_url 字段
         if let Some(url) = provider
             .settings_config
@@ -132,6 +141,18 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn extract_auth(&self, provider: &Provider) -> Option<AuthInfo> {
+        if provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.provider_type.as_deref())
+            == Some("codex_oauth")
+        {
+            return Some(AuthInfo::new(
+                "codex_oauth_placeholder".to_string(),
+                AuthStrategy::CodexOAuth,
+            ));
+        }
+
         self.extract_key(provider)
             .map(|key| AuthInfo::new(key, AuthStrategy::Bearer))
     }
@@ -185,6 +206,7 @@ impl ProviderAdapter for CodexAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::ProviderMeta;
     use serde_json::json;
 
     fn create_provider(config: serde_json::Value) -> Provider {
@@ -240,6 +262,23 @@ mod tests {
 
         let auth = adapter.extract_auth(&provider).unwrap();
         assert_eq!(auth.api_key, "sk-env-key-12345678");
+    }
+
+    #[test]
+    fn test_codex_oauth_provider_uses_managed_auth() {
+        let adapter = CodexAdapter::new();
+        let mut provider = create_provider(json!({}));
+        provider.meta = Some(ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            ..Default::default()
+        });
+
+        let url = adapter.extract_base_url(&provider).unwrap();
+        assert_eq!(url, "https://chatgpt.com/backend-api/codex");
+
+        let auth = adapter.extract_auth(&provider).unwrap();
+        assert_eq!(auth.api_key, "codex_oauth_placeholder");
+        assert_eq!(auth.strategy, AuthStrategy::CodexOAuth);
     }
 
     #[test]

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -299,11 +299,19 @@ impl ProxyServer {
                 "/codex/v1/chat/completions",
                 post(handlers::handle_chat_completions),
             )
+            .route(
+                "/codex/provider/:provider_app/:provider_id/v1/chat/completions",
+                post(handlers::handle_chat_completions_scoped),
+            )
             // OpenAI Responses API (Codex CLI，支持带前缀和不带前缀)
             .route("/responses", post(handlers::handle_responses))
             .route("/v1/responses", post(handlers::handle_responses))
             .route("/v1/v1/responses", post(handlers::handle_responses))
             .route("/codex/v1/responses", post(handlers::handle_responses))
+            .route(
+                "/codex/provider/:provider_app/:provider_id/v1/responses",
+                post(handlers::handle_responses_scoped),
+            )
             // OpenAI Responses Compact API (Codex CLI 远程压缩，透传)
             .route(
                 "/responses/compact",
@@ -320,6 +328,10 @@ impl ProxyServer {
             .route(
                 "/codex/v1/responses/compact",
                 post(handlers::handle_responses_compact),
+            )
+            .route(
+                "/codex/provider/:provider_app/:provider_id/v1/responses/compact",
+                post(handlers::handle_responses_compact_scoped),
             )
             // Gemini API (支持带前缀和不带前缀)
             .route("/v1beta/*path", post(handlers::handle_gemini))


### PR DESCRIPTION
## Summary

Adds provider-scoped Codex CLI launch support so users can open multiple Codex terminal sessions pinned to different CC Switch providers/accounts without copying OAuth tokens into separate Codex homes.

## Changes

- Add provider-scoped Codex proxy routes under `/codex/provider/:provider_app/:provider_id/v1/...`.
- Let scoped Codex requests select an exact provider without changing the current provider or consuming the normal failover selection path.
- Launch Codex terminals with a persistent per-provider `CODEX_HOME` under `~/.cc-switch/codex-cli/<provider_id>`.
- Set only routing env/config in the launched terminal: `OPENAI_API_KEY=PROXY_MANAGED` and `codex -c base_url=...`.
- Reuse the existing Codex OAuth manager for `providerType=codex_oauth`; no `refresh_token`, `access_token`, or `id_token` is copied into CLI profiles.
- Start the local proxy automatically before opening a Codex provider terminal.

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo test proxy::providers::codex:: --lib`
- `cargo test proxy::providers::codex::tests::test_codex_oauth_provider_uses_managed_auth --lib`
- `git diff --check`

`cargo test --lib` compiled and ran, with 1018 passed and 1 failed because a local running CC Switch instance already occupied `127.0.0.1:15721` for `services::provider::tests::update_current_claude_provider_syncs_live_when_proxy_takeover_detected_without_backup`.

## Privacy

This change does not include real account IDs, emails, API keys, access tokens, refresh tokens, or id tokens.