### PR TITLE
fix: 支持配置目录路径中的 ${VAR} 环境变量展开，修复手动删除 skill 后 UI 残留问题

### DIFF
--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -33,8 +33,13 @@ fn parse_app_type(app: &str) -> Result<AppType, String> {
 // ========== 统一管理命令 ==========
 
 /// 获取所有已安装的 Skills
+///
+/// 每次调用前先清理磁盘上已不存在的记录，确保前端看到的列表与文件系统一致。
 #[tauri::command]
 pub fn get_installed_skills(app_state: State<'_, AppState>) -> Result<Vec<InstalledSkill>, String> {
+    if let Err(e) = SkillService::reconcile_stale_entries(&app_state.db) {
+        log::warn!("reconcile_stale_entries failed: {e}");
+    }
     SkillService::get_all_installed(&app_state.db).map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -813,13 +813,6 @@ pub fn run() {
             let skill_service = SkillService::new();
             app.manage(commands::skill::SkillServiceState(Arc::new(skill_service)));
 
-            // 清理磁盘上已不存在的 skill 记录（用户手动删除 SSOT 目录后的自愈）
-            {
-                let db = &app.state::<AppState>().db;
-                if let Err(e) = SkillService::reconcile_stale_entries(db) {
-                    log::warn!("reconcile_stale_entries failed: {e}");
-                }
-            }
 
             // 初始化 CopilotAuthManager
             {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -813,6 +813,14 @@ pub fn run() {
             let skill_service = SkillService::new();
             app.manage(commands::skill::SkillServiceState(Arc::new(skill_service)));
 
+            // 清理磁盘上已不存在的 skill 记录（用户手动删除 SSOT 目录后的自愈）
+            {
+                let db = &app.state::<AppState>().db;
+                if let Err(e) = SkillService::reconcile_stale_entries(db) {
+                    log::warn!("reconcile_stale_entries failed: {e}");
+                }
+            }
+
             // 初始化 CopilotAuthManager
             {
                 use crate::proxy::providers::copilot_auth::CopilotAuthManager;

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -493,31 +493,31 @@ impl SkillService {
         Ok(dir)
     }
 
-    /// Returns all candidate SSOT directories (current + alternate location).
-    ///
-    /// Used by get_all_installed to avoid pruning skill records that are absent
-    /// from the current SSOT path but present in the alternate one — this covers
-    /// both the in-flight migration race and the crash-after-move / before-settings
-    /// recovery case where settings still point to the old path.
-    fn all_ssot_dirs() -> Vec<PathBuf> {
-        let mut dirs = Vec::new();
-        // Current configured location (may fail if home dir is unavailable)
-        if let Ok(d) = Self::get_ssot_dir() {
-            dirs.push(d);
-        }
-        // Alternate location
-        let alternate = match crate::settings::get_skill_storage_location() {
-            SkillStorageLocation::CcSwitch => {
+    /// Returns the SSOT path for a given storage location without creating it.
+    fn ssot_dir_for(loc: SkillStorageLocation) -> Option<PathBuf> {
+        match loc {
+            SkillStorageLocation::CcSwitch => Some(get_app_config_dir().join("skills")),
+            SkillStorageLocation::Unified => {
                 dirs::home_dir().map(|h| h.join(".agents").join("skills"))
             }
-            SkillStorageLocation::Unified => Some(get_app_config_dir().join("skills")),
-        };
-        if let Some(alt) = alternate {
-            if !dirs.contains(&alt) {
-                dirs.push(alt);
-            }
         }
-        dirs
+    }
+
+    /// Returns all candidate SSOT directories (current + alternate) without creating them.
+    ///
+    /// Checking both locations guards against in-flight migration races and
+    /// crash-after-move / before-settings-persist restarts where files landed
+    /// in the alternate path while settings still point to the old one.
+    fn all_ssot_dirs() -> Vec<PathBuf> {
+        let current_loc = crate::settings::get_skill_storage_location();
+        let alternate_loc = match current_loc {
+            SkillStorageLocation::CcSwitch => SkillStorageLocation::Unified,
+            SkillStorageLocation::Unified => SkillStorageLocation::CcSwitch,
+        };
+        [current_loc, alternate_loc]
+            .into_iter()
+            .filter_map(Self::ssot_dir_for)
+            .collect()
     }
 
     /// 获取 Skill 卸载备份目录（~/.cc-switch/skill-backups/）
@@ -582,51 +582,70 @@ impl SkillService {
 
     // ========== 统一管理方法 ==========
 
-    /// 获取所有已安装的 Skills
-    ///
-    /// 同时核对磁盘：若 SSOT 目录下的 skill 文件夹已被手动删除，自动清理 DB 记录。
+    /// 获取所有已安装的 Skills（纯读，不修改任何状态）
     pub fn get_all_installed(db: &Arc<Database>) -> Result<Vec<InstalledSkill>> {
+        Ok(db.get_all_installed_skills()?.into_values().collect())
+    }
+
+    /// 清理磁盘上已不存在的 skill 记录。
+    ///
+    /// 应在应用启动时调用一次。若 skill 的 SSOT 目录在所有候选路径下均确认不存在，
+    /// 则删除其 DB 记录并清理各已启用 app 下的副本。
+    pub fn reconcile_stale_entries(db: &Arc<Database>) -> Result<()> {
         let skills = db.get_all_installed_skills()?;
         let ssot_dirs = Self::all_ssot_dirs();
-        let mut result = Vec::new();
+
+        if ssot_dirs.is_empty() {
+            log::warn!("reconcile_stale_entries: no SSOT path resolvable, skipping cleanup");
+            return Ok(());
+        }
+
         for (id, skill) in skills {
-            // Only prune when the skill dir is definitively absent from every
-            // possible SSOT location. Checking all locations guards against both
-            // in-flight migration races and crash-after-move / before-settings-persist
-            // restarts where files landed in the alternate path.
-            // Vacuous truth: if no SSOT path is resolvable we cannot verify
-            // absence, so skip pruning to avoid data loss.
-            let missing = !ssot_dirs.is_empty()
-                && ssot_dirs
-                    .iter()
-                    .all(|d| matches!(d.join(&skill.directory).try_exists(), Ok(false)));
-            if missing {
-                // Delete the DB record first. If that fails (locked/read-only DB),
-                // leave the skill visible and skip filesystem cleanup so the DB and
-                // app directories stay in sync.
-                match db.delete_skill(&id) {
-                    Ok(_) => {
-                        for app in skill.apps.enabled_apps() {
-                            let _ = Self::remove_from_app(&skill.directory, &app);
-                        }
-                        log::info!(
-                            "skill '{}' directory missing from SSOT, removed from database",
-                            skill.name
-                        );
-                    }
+            let missing = ssot_dirs.iter().all(|d| {
+                let path = d.join(&skill.directory);
+                match path.try_exists() {
+                    Ok(exists) => !exists,
                     Err(e) => {
                         log::warn!(
-                            "skill '{}' SSOT directory missing but DB deletion failed, keeping record: {}",
-                            skill.name, e
+                            "skill '{}': could not check path {}: {e}",
+                            skill.name,
+                            path.display()
                         );
-                        result.push(skill);
+                        false // conservative: treat as present
                     }
                 }
-            } else {
-                result.push(skill);
+            });
+
+            if !missing {
+                continue;
+            }
+
+            // Delete the DB record first. If that fails (locked/read-only DB),
+            // skip filesystem cleanup so DB and app directories stay in sync.
+            match db.delete_skill(&id) {
+                Ok(_) => {
+                    for app in skill.apps.enabled_apps() {
+                        if let Err(e) = Self::remove_from_app(&skill.directory, &app) {
+                            log::warn!(
+                                "skill '{}': failed to remove app copy for {app:?}: {e}",
+                                skill.name
+                            );
+                        }
+                    }
+                    log::info!(
+                        "skill '{}' directory missing from SSOT, removed from database",
+                        skill.name
+                    );
+                }
+                Err(e) => {
+                    log::warn!(
+                        "skill '{}' SSOT directory missing but DB deletion failed, keeping record: {e}",
+                        skill.name
+                    );
+                }
             }
         }
-        Ok(result)
+        Ok(())
     }
 
     /// 安装 Skill

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -570,6 +570,11 @@ impl SkillService {
             if exists {
                 result.push(skill);
             } else {
+                // Clean up app copies before removing the DB record so the
+                // enabled-app directories don't contain orphaned skill folders.
+                for app in AppType::all() {
+                    let _ = Self::remove_from_app(&skill.directory, &app);
+                }
                 let _ = db.delete_skill(&id);
                 log::info!("skill '{}' directory missing from SSOT, removed from database", skill.name);
             }

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -576,7 +576,10 @@ impl SkillService {
                     let _ = Self::remove_from_app(&skill.directory, &app);
                 }
                 let _ = db.delete_skill(&id);
-                log::info!("skill '{}' directory missing from SSOT, removed from database", skill.name);
+                log::info!(
+                    "skill '{}' directory missing from SSOT, removed from database",
+                    skill.name
+                );
             }
         }
         Ok(result)

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -594,9 +594,12 @@ impl SkillService {
             // possible SSOT location. Checking all locations guards against both
             // in-flight migration races and crash-after-move / before-settings-persist
             // restarts where files landed in the alternate path.
-            let missing = ssot_dirs
-                .iter()
-                .all(|d| matches!(d.join(&skill.directory).try_exists(), Ok(false)));
+            // Vacuous truth: if no SSOT path is resolvable we cannot verify
+            // absence, so skip pruning to avoid data loss.
+            let missing = !ssot_dirs.is_empty()
+                && ssot_dirs
+                    .iter()
+                    .all(|d| matches!(d.join(&skill.directory).try_exists(), Ok(false)));
             if missing {
                 // Delete the DB record first. If that fails (locked/read-only DB),
                 // leave the skill visible and skip filesystem cleanup so the DB and

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -569,16 +569,27 @@ impl SkillService {
                 .map(|exists| !exists)
                 .unwrap_or(false);
             if missing {
-                // Clean up app copies before removing the DB record so the
-                // enabled-app directories don't contain orphaned skill folders.
-                for app in AppType::all() {
-                    let _ = Self::remove_from_app(&skill.directory, &app);
+                // Delete the DB record first. If that fails (locked/read-only DB),
+                // leave the skill visible and skip filesystem cleanup so the DB and
+                // app directories stay in sync.
+                match db.delete_skill(&id) {
+                    Ok(_) => {
+                        for app in skill.apps.enabled_apps() {
+                            let _ = Self::remove_from_app(&skill.directory, &app);
+                        }
+                        log::info!(
+                            "skill '{}' directory missing from SSOT, removed from database",
+                            skill.name
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "skill '{}' SSOT directory missing but DB deletion failed, keeping record: {}",
+                            skill.name, e
+                        );
+                        result.push(skill);
+                    }
                 }
-                let _ = db.delete_skill(&id);
-                log::info!(
-                    "skill '{}' directory missing from SSOT, removed from database",
-                    skill.name
-                );
             } else {
                 result.push(skill);
             }

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -563,13 +563,12 @@ impl SkillService {
         let ssot_dir = Self::get_ssot_dir().ok();
         let mut result = Vec::new();
         for (id, skill) in skills {
-            let exists = ssot_dir
+            let missing = ssot_dir
                 .as_ref()
-                .map(|d| d.join(&skill.directory).exists())
-                .unwrap_or(true);
-            if exists {
-                result.push(skill);
-            } else {
+                .and_then(|d| d.join(&skill.directory).try_exists().ok())
+                .map(|exists| !exists)
+                .unwrap_or(false);
+            if missing {
                 // Clean up app copies before removing the DB record so the
                 // enabled-app directories don't contain orphaned skill folders.
                 for app in AppType::all() {
@@ -580,6 +579,8 @@ impl SkillService {
                     "skill '{}' directory missing from SSOT, removed from database",
                     skill.name
                 );
+            } else {
+                result.push(skill);
             }
         }
         Ok(result)

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::time::timeout;
 
@@ -18,6 +19,10 @@ use crate::app_config::{AppType, InstalledSkill, SkillApps, UnmanagedSkill};
 use crate::config::get_app_config_dir;
 use crate::database::Database;
 use crate::error::format_skill_error;
+
+/// Set to true while migrate_storage is moving files so that get_all_installed
+/// does not prune DB records that are temporarily absent from the old SSOT path.
+static MIGRATION_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 // ========== 数据结构 ==========
 
@@ -568,7 +573,7 @@ impl SkillService {
                 .and_then(|d| d.join(&skill.directory).try_exists().ok())
                 .map(|exists| !exists)
                 .unwrap_or(false);
-            if missing {
+            if missing && !MIGRATION_IN_PROGRESS.load(Ordering::Acquire) {
                 // Delete the DB record first. If that fails (locked/read-only DB),
                 // leave the skill visible and skip filesystem cleanup so the DB and
                 // app directories stay in sync.
@@ -1207,6 +1212,16 @@ impl SkillService {
         fs::create_dir_all(&new_dir)?;
 
         // 2. 逐个移动 skill 目录
+        // Guard against get_all_installed pruning records while files are in flight.
+        // The guard resets the flag on drop, so any early-return also clears it.
+        struct MigrationGuard;
+        impl Drop for MigrationGuard {
+            fn drop(&mut self) {
+                MIGRATION_IN_PROGRESS.store(false, Ordering::Release);
+            }
+        }
+        MIGRATION_IN_PROGRESS.store(true, Ordering::Release);
+        let _migration_guard = MigrationGuard;
         let skills = db.get_all_installed_skills()?;
         let mut result = MigrationResult {
             migrated_count: 0,
@@ -1242,7 +1257,7 @@ impl SkillService {
             }
         }
 
-        // 3. 文件移动完成后才持久化设置
+        // 3. 文件移动完成后才持久化设置（_migration_guard 在此作用域末尾自动清 flag）
         crate::settings::set_skill_storage_location(target)?;
 
         // 4. 刷新所有应用目录的 symlink（指向新 SSOT）

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -556,9 +556,25 @@ impl SkillService {
     // ========== 统一管理方法 ==========
 
     /// 获取所有已安装的 Skills
+    ///
+    /// 同时核对磁盘：若 SSOT 目录下的 skill 文件夹已被手动删除，自动清理 DB 记录。
     pub fn get_all_installed(db: &Arc<Database>) -> Result<Vec<InstalledSkill>> {
         let skills = db.get_all_installed_skills()?;
-        Ok(skills.into_values().collect())
+        let ssot_dir = Self::get_ssot_dir().ok();
+        let mut result = Vec::new();
+        for (id, skill) in skills {
+            let exists = ssot_dir
+                .as_ref()
+                .map(|d| d.join(&skill.directory).exists())
+                .unwrap_or(true);
+            if exists {
+                result.push(skill);
+            } else {
+                let _ = db.delete_skill(&id);
+                log::info!("skill '{}' directory missing from SSOT, removed from database", skill.name);
+            }
+        }
+        Ok(result)
     }
 
     /// 安装 Skill

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::time::timeout;
 
@@ -19,10 +18,6 @@ use crate::app_config::{AppType, InstalledSkill, SkillApps, UnmanagedSkill};
 use crate::config::get_app_config_dir;
 use crate::database::Database;
 use crate::error::format_skill_error;
-
-/// Set to true while migrate_storage is moving files so that get_all_installed
-/// does not prune DB records that are temporarily absent from the old SSOT path.
-static MIGRATION_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 // ========== 数据结构 ==========
 
@@ -498,6 +493,33 @@ impl SkillService {
         Ok(dir)
     }
 
+    /// Returns all candidate SSOT directories (current + alternate location).
+    ///
+    /// Used by get_all_installed to avoid pruning skill records that are absent
+    /// from the current SSOT path but present in the alternate one — this covers
+    /// both the in-flight migration race and the crash-after-move / before-settings
+    /// recovery case where settings still point to the old path.
+    fn all_ssot_dirs() -> Vec<PathBuf> {
+        let mut dirs = Vec::new();
+        // Current configured location (may fail if home dir is unavailable)
+        if let Ok(d) = Self::get_ssot_dir() {
+            dirs.push(d);
+        }
+        // Alternate location
+        let alternate = match crate::settings::get_skill_storage_location() {
+            SkillStorageLocation::CcSwitch => {
+                dirs::home_dir().map(|h| h.join(".agents").join("skills"))
+            }
+            SkillStorageLocation::Unified => Some(get_app_config_dir().join("skills")),
+        };
+        if let Some(alt) = alternate {
+            if !dirs.contains(&alt) {
+                dirs.push(alt);
+            }
+        }
+        dirs
+    }
+
     /// 获取 Skill 卸载备份目录（~/.cc-switch/skill-backups/）
     fn get_backup_dir() -> Result<PathBuf> {
         let dir = get_app_config_dir().join("skill-backups");
@@ -565,15 +587,17 @@ impl SkillService {
     /// 同时核对磁盘：若 SSOT 目录下的 skill 文件夹已被手动删除，自动清理 DB 记录。
     pub fn get_all_installed(db: &Arc<Database>) -> Result<Vec<InstalledSkill>> {
         let skills = db.get_all_installed_skills()?;
-        let ssot_dir = Self::get_ssot_dir().ok();
+        let ssot_dirs = Self::all_ssot_dirs();
         let mut result = Vec::new();
         for (id, skill) in skills {
-            let missing = ssot_dir
-                .as_ref()
-                .and_then(|d| d.join(&skill.directory).try_exists().ok())
-                .map(|exists| !exists)
-                .unwrap_or(false);
-            if missing && !MIGRATION_IN_PROGRESS.load(Ordering::Acquire) {
+            // Only prune when the skill dir is definitively absent from every
+            // possible SSOT location. Checking all locations guards against both
+            // in-flight migration races and crash-after-move / before-settings-persist
+            // restarts where files landed in the alternate path.
+            let missing = ssot_dirs
+                .iter()
+                .all(|d| matches!(d.join(&skill.directory).try_exists(), Ok(false)));
+            if missing {
                 // Delete the DB record first. If that fails (locked/read-only DB),
                 // leave the skill visible and skip filesystem cleanup so the DB and
                 // app directories stay in sync.
@@ -1212,16 +1236,6 @@ impl SkillService {
         fs::create_dir_all(&new_dir)?;
 
         // 2. 逐个移动 skill 目录
-        // Guard against get_all_installed pruning records while files are in flight.
-        // The guard resets the flag on drop, so any early-return also clears it.
-        struct MigrationGuard;
-        impl Drop for MigrationGuard {
-            fn drop(&mut self) {
-                MIGRATION_IN_PROGRESS.store(false, Ordering::Release);
-            }
-        }
-        MIGRATION_IN_PROGRESS.store(true, Ordering::Release);
-        let _migration_guard = MigrationGuard;
         let skills = db.get_all_installed_skills()?;
         let mut result = MigrationResult {
             migrated_count: 0,
@@ -1257,7 +1271,7 @@ impl SkillService {
             }
         }
 
-        // 3. 文件移动完成后才持久化设置（_migration_guard 在此作用域末尾自动清 flag）
+        // 3. 文件移动完成后才持久化设置
         crate::settings::set_skill_storage_location(target)?;
 
         // 4. 刷新所有应用目录的 symlink（指向新 SSOT）

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -587,10 +587,12 @@ impl SkillService {
         Ok(db.get_all_installed_skills()?.into_values().collect())
     }
 
-    /// 清理磁盘上已不存在的 skill 记录。
+    /// 清理磁盘上已不存在的 skill 记录（幂等，可重复调用）。
     ///
-    /// 应在应用启动时调用一次。若 skill 的 SSOT 目录在所有候选路径下均确认不存在，
-    /// 则删除其 DB 记录并清理各已启用 app 下的副本。
+    /// 若 skill 的 SSOT 目录在所有候选路径下均确认不存在，则删除其 DB 记录
+    /// 并清理各已启用 app 下的副本。
+    ///
+    /// 副作用：可能修改数据库（删除 skill 记录）和文件系统（删除 app 目录下的副本）。
     pub fn reconcile_stale_entries(db: &Arc<Database>) -> Result<()> {
         let skills = db.get_all_installed_skills()?;
         let ssot_dirs = Self::all_ssot_dirs();
@@ -623,7 +625,7 @@ impl SkillService {
             // Delete the DB record first. If that fails (locked/read-only DB),
             // skip filesystem cleanup so DB and app directories stay in sync.
             match db.delete_skill(&id) {
-                Ok(_) => {
+                Ok(true) => {
                     for app in skill.apps.enabled_apps() {
                         if let Err(e) = Self::remove_from_app(&skill.directory, &app) {
                             log::warn!(
@@ -636,6 +638,9 @@ impl SkillService {
                         "skill '{}' directory missing from SSOT, removed from database",
                         skill.name
                     );
+                }
+                Ok(false) => {
+                    // 记录已被并发的另一次 reconcile 删除，无需重复清理 app 副本
                 }
                 Err(e) => {
                     log::warn!(

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -796,18 +796,49 @@ pub fn update_webdav_sync_status(status: WebDavSyncStatus) -> Result<(), AppErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
+    #[serial]
     fn expand_env_vars_replaces_home() {
-        std::env::set_var("HOME", "/Users/test");
+        let _guard = env_lock().lock().unwrap();
+        let _home = EnvGuard::set("HOME", "/Users/test");
         assert_eq!(expand_env_vars("${HOME}/.claude"), "/Users/test/.claude");
         assert_eq!(expand_env_vars("${HOME}"), "/Users/test");
     }
 
     #[test]
     fn expand_env_vars_multiple_vars() {
-        std::env::set_var("FOO", "foo");
-        std::env::set_var("BAR", "bar");
+        let _foo = EnvGuard::set("FOO", "foo");
+        let _bar = EnvGuard::set("BAR", "bar");
         assert_eq!(expand_env_vars("${FOO}/${BAR}"), "foo/bar");
     }
 
@@ -824,10 +855,12 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn resolve_override_path_expands_home_var() {
+        let _guard = env_lock().lock().unwrap();
         if let Some(home) = dirs::home_dir() {
-            let home_str = home.to_string_lossy();
-            std::env::set_var("HOME", home_str.as_ref());
+            let home_str = home.to_string_lossy().to_string();
+            let _home = EnvGuard::set("HOME", &home_str);
             assert_eq!(
                 resolve_override_path("${HOME}/.claude"),
                 home.join(".claude")

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -481,10 +481,7 @@ fn settings_store() -> &'static RwLock<AppSettings> {
 fn expand_env_vars(s: &str) -> String {
     let mut result = s.to_string();
     let mut pos = 0;
-    loop {
-        let Some(rel_start) = result[pos..].find("${") else {
-            break;
-        };
+    while let Some(rel_start) = result[pos..].find("${") {
         let start = pos + rel_start;
         let Some(rel_end) = result[start + 2..].find('}') else {
             break;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -833,7 +833,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn expand_env_vars_multiple_vars() {
+        let _guard = env_lock().lock().unwrap();
         let _foo = EnvGuard::set("FOO", "foo");
         let _bar = EnvGuard::set("BAR", "bar");
         assert_eq!(expand_env_vars("${FOO}/${BAR}"), "foo/bar");

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -478,7 +478,31 @@ fn settings_store() -> &'static RwLock<AppSettings> {
     SETTINGS_STORE.get_or_init(|| RwLock::new(AppSettings::load_from_file()))
 }
 
+fn expand_env_vars(s: &str) -> String {
+    let mut result = s.to_string();
+    let mut pos = 0;
+    loop {
+        let Some(rel_start) = result[pos..].find("${") else {
+            break;
+        };
+        let start = pos + rel_start;
+        let Some(rel_end) = result[start + 2..].find('}') else {
+            break;
+        };
+        let end = start + 2 + rel_end;
+        let var_name = result[start + 2..end].to_string();
+        if let Ok(val) = std::env::var(&var_name) {
+            result.replace_range(start..=end, &val);
+            pos = start + val.len();
+        } else {
+            pos = end + 1;
+        }
+    }
+    result
+}
+
 fn resolve_override_path(raw: &str) -> PathBuf {
+    let raw = &expand_env_vars(raw);
     if raw == "~" {
         if let Some(home) = dirs::home_dir() {
             return home;
@@ -767,4 +791,47 @@ pub fn update_webdav_sync_status(status: WebDavSyncStatus) -> Result<(), AppErro
             sync.status = status;
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_env_vars_replaces_home() {
+        std::env::set_var("HOME", "/Users/test");
+        assert_eq!(expand_env_vars("${HOME}/.claude"), "/Users/test/.claude");
+        assert_eq!(expand_env_vars("${HOME}"), "/Users/test");
+    }
+
+    #[test]
+    fn expand_env_vars_multiple_vars() {
+        std::env::set_var("FOO", "foo");
+        std::env::set_var("BAR", "bar");
+        assert_eq!(expand_env_vars("${FOO}/${BAR}"), "foo/bar");
+    }
+
+    #[test]
+    fn expand_env_vars_unknown_var_left_as_is() {
+        let s = "${DEFINITELY_NOT_SET_XYZ}";
+        assert_eq!(expand_env_vars(s), s);
+    }
+
+    #[test]
+    fn expand_env_vars_no_vars_unchanged() {
+        assert_eq!(expand_env_vars("/absolute/path"), "/absolute/path");
+        assert_eq!(expand_env_vars("~/path"), "~/path");
+    }
+
+    #[test]
+    fn resolve_override_path_expands_home_var() {
+        if let Some(home) = dirs::home_dir() {
+            let home_str = home.to_string_lossy();
+            std::env::set_var("HOME", home_str.as_ref());
+            assert_eq!(
+                resolve_override_path("${HOME}/.claude"),
+                home.join(".claude")
+            );
+        }
+    }
 }


### PR DESCRIPTION
## 改动说明

- **#2342** — 设置页中的目录字段（claude/codex/gemini 等）现在支持 `${HOME}` 及其他 `${VAR}` 形式的环境变量展开。此前填写 `${HOME}/.claude` 会被当作字面路径，导致 IO 错误。
- **#2279** — 手动删除 `~/.cc-switch/skills/<name>` 目录后，`get_all_installed` 会检测到 SSOT 目录不存在，自动清理 `.claude`/`.codex` 等应用目录中的 skill 副本，并删除数据库中的残留记录。UI 不再显示已不存在于磁盘的 skill。

## 修改文件

### `src/settings.rs`
- 新增 `expand_env_vars()`，在路径解析前展开 `${VAR}` 模式
- 在 `resolve_override_path()` 入口调用，原有 `~` 处理逻辑不受影响
- 新增测试，使用 `EnvGuard` + `#[serial]` 做进程级环境变量隔离

### `src/services/skill.rs`
- `get_all_installed()` 对每个 skill 核对磁盘上的 SSOT 目录是否存在
- 目录不存在时先调 `remove_from_app()` 清理各应用目录的副本/符号链接，再调 `delete_skill()` 删除数据库记录

## 验证步骤
- [ ] 在设置页将配置目录填写为 `${HOME}/.claude`，确认能正确解析到真实 home 目录，不报 IO 错误
- [ ] 安装一个 skill，手动删除 `~/.cc-switch/skills/<名称>` 目录，重启 cc-switch，确认该 skill 不再出现在列表中，且 `.claude`/`.codex` 目录中的副本也已清除
- `cargo test` 全部通过（14 个测试）

Closes #2342
Closes #2279