### PR TITLE
fix: 修复 OpenCode 会话恢复命令

### DIFF
--- a/src-tauri/src/session_manager/providers/opencode.rs
+++ b/src-tauri/src/session_manager/providers/opencode.rs
@@ -149,7 +149,7 @@ fn scan_sessions_sqlite() -> Vec<SessionMeta> {
             created_at: Some(created),
             last_active_at: Some(updated),
             source_path: Some(format!("sqlite:{db_display}:{session_id}")),
-            resume_command: Some(format!("opencode session resume {session_id}")),
+            resume_command: Some(format!("opencode -s {session_id}")),
         });
     }
     sessions
@@ -473,7 +473,7 @@ fn parse_session(storage: &Path, path: &Path) -> Option<SessionMeta> {
         created_at,
         last_active_at: updated_at.or(created_at),
         source_path: Some(source_path),
-        resume_command: Some(format!("opencode session resume {session_id}")),
+        resume_command: Some(format!("opencode -s {session_id}")),
     })
 }
 
@@ -824,6 +824,10 @@ mod tests {
         assert_eq!(
             sessions[1].source_path.as_deref(),
             Some(expected_source.as_str())
+        );
+        assert_eq!(
+            sessions[1].resume_command.as_deref(),
+            Some("opencode -s ses_1")
         );
     }
 


### PR DESCRIPTION
## 概述

- 将 OpenCode 会话列表生成的恢复命令从 `opencode session resume <id>` 更新为 `opencode -s <id>`。
- 同时覆盖 SQLite 会话和 legacy JSON 会话两条元数据路径。
- 在现有 SQLite 会话扫描测试中增加恢复命令断言。

## 背景

OpenCode 最新 CLI 使用 `--session` / `-s` 继续指定会话，`opencode session` 子命令下没有 `resume`。当前提示的旧命令会误导用户。

Fixes #2308
Fixes #2885
Fixes #3115
Fixes #3788

## 验证

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml scan_sessions_sqlite_reads_temp_database`
