### PR TITLE
fix(env-checker): stop false-positives from inline-prefix vars in shell functions

### DIFF
--- a/src-tauri/src/services/env_checker.rs
+++ b/src-tauri/src/services/env_checker.rs
@@ -31,12 +31,30 @@ pub fn check_env_conflicts(app: &str) -> Result<Vec<EnvConflict>, String> {
     Ok(conflicts)
 }
 
-/// Get relevant keywords for each app
-fn get_keywords_for_app(app: &str) -> Vec<&str> {
+/// Get the list of environment variable names that, when present in the
+/// user's shell or process environment, can override what cc-switch
+/// configures. Names must match exactly (case-insensitive); substring
+/// matching produced false positives for unrelated vars whose names merely
+/// contained "ANTHROPIC", "OPENAI", or "GEMINI" (e.g. local helper vars
+/// such as `LOG_ANTHROPIC_*`, `v_gemini_remote`).
+fn get_keywords_for_app(app: &str) -> Vec<&'static str> {
     match app.to_lowercase().as_str() {
-        "claude" => vec!["ANTHROPIC"],
-        "codex" => vec!["OPENAI"],
-        "gemini" => vec!["GEMINI", "GOOGLE_GEMINI"],
+        "claude" => vec![
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            "ANTHROPIC_REASONING_MODEL",
+        ],
+        "codex" => vec!["OPENAI_API_KEY", "OPENAI_BASE_URL"],
+        "gemini" => vec![
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GOOGLE_GEMINI_API_KEY",
+        ],
         _ => vec![],
     }
 }
@@ -49,7 +67,7 @@ fn check_system_env(keywords: &[&str]) -> Result<Vec<EnvConflict>, String> {
     // Check HKEY_CURRENT_USER\Environment
     if let Ok(hkcu) = RegKey::predef(HKEY_CURRENT_USER).open_subkey("Environment") {
         for (name, value) in hkcu.enum_values().filter_map(Result::ok) {
-            if keywords.iter().any(|k| name.to_uppercase().contains(k)) {
+            if keywords.iter().any(|k| name.eq_ignore_ascii_case(k)) {
                 conflicts.push(EnvConflict {
                     var_name: name.clone(),
                     var_value: value.to_string(),
@@ -65,7 +83,7 @@ fn check_system_env(keywords: &[&str]) -> Result<Vec<EnvConflict>, String> {
         .open_subkey("SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment")
     {
         for (name, value) in hklm.enum_values().filter_map(Result::ok) {
-            if keywords.iter().any(|k| name.to_uppercase().contains(k)) {
+            if keywords.iter().any(|k| name.eq_ignore_ascii_case(k)) {
                 conflicts.push(EnvConflict {
                     var_name: name.clone(),
                     var_value: value.to_string(),
@@ -85,7 +103,7 @@ fn check_system_env(keywords: &[&str]) -> Result<Vec<EnvConflict>, String> {
 
     // Check current process environment
     for (key, value) in std::env::vars() {
-        if keywords.iter().any(|k| key.to_uppercase().contains(k)) {
+        if keywords.iter().any(|k| key.eq_ignore_ascii_case(k)) {
             conflicts.push(EnvConflict {
                 var_name: key,
                 var_value: value,
@@ -115,35 +133,70 @@ fn check_shell_configs(keywords: &[&str]) -> Result<Vec<EnvConflict>, String> {
     ];
 
     for file_path in config_files {
-        if let Ok(content) = fs::read_to_string(&file_path) {
-            // Parse lines for export statements
-            for (line_num, line) in content.lines().enumerate() {
-                let trimmed = line.trim();
+        let Ok(content) = fs::read_to_string(&file_path) else {
+            continue;
+        };
 
-                // Match patterns like: export VAR=value or VAR=value
-                if trimmed.starts_with("export ")
-                    || (!trimmed.starts_with('#') && trimmed.contains('='))
-                {
-                    let export_line = trimmed.strip_prefix("export ").unwrap_or(trimmed);
+        // Track shell function/block depth so assignments inside function
+        // bodies are ignored. Variables defined in `name() { ... }` are
+        // either function-scoped or — when written as the inline command
+        // prefix `VAR=value cmd ...` — only visible to the spawned child
+        // process, neither of which leaks into a process started later from
+        // the same login shell. A naive `{`/`}` counter is good enough for
+        // typical rc files; braces inside strings/comments cause harmless
+        // over-skipping rather than false positives.
+        let mut brace_depth: i32 = 0;
 
-                    if let Some(eq_pos) = export_line.find('=') {
-                        let var_name = export_line[..eq_pos].trim();
-                        let var_value = export_line[eq_pos + 1..].trim();
+        for (line_num, line) in content.lines().enumerate() {
+            let line_delta: i32 = line
+                .chars()
+                .map(|c| match c {
+                    '{' => 1,
+                    '}' => -1,
+                    _ => 0,
+                })
+                .sum();
+            let depth_after = brace_depth + line_delta;
+            // Skip the line if we are inside a block at any point during it,
+            // i.e. either entered the line inside a block, or left the line
+            // inside one. This correctly skips both `name() {` and `}`.
+            let inside_block = brace_depth > 0 || depth_after > 0;
+            brace_depth = depth_after.max(0);
 
-                        // Check if variable name contains any keyword
-                        if keywords.iter().any(|k| var_name.to_uppercase().contains(k)) {
-                            conflicts.push(EnvConflict {
-                                var_name: var_name.to_string(),
-                                var_value: var_value
-                                    .trim_matches('"')
-                                    .trim_matches('\'')
-                                    .to_string(),
-                                source_type: "file".to_string(),
-                                source_path: format!("{}:{}", file_path, line_num + 1),
-                            });
-                        }
-                    }
-                }
+            if inside_block {
+                continue;
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+
+            // Only flag explicit `export VAR=...`. A bare `VAR=value` at the
+            // top of an rc file is most often the inline command-prefix
+            // form (`VAR=value some_cmd`) — POSIX semantics make that
+            // assignment visible only to `some_cmd` — or an unexported
+            // shell variable. Neither leaks into descendant processes that
+            // would override what cc-switch configures.
+            let Some(rest) = trimmed.strip_prefix("export ") else {
+                continue;
+            };
+            let Some(eq_pos) = rest.find('=') else {
+                continue;
+            };
+            let var_name = rest[..eq_pos].trim();
+            let var_value = rest[eq_pos + 1..].trim();
+
+            if keywords.iter().any(|k| var_name.eq_ignore_ascii_case(k)) {
+                conflicts.push(EnvConflict {
+                    var_name: var_name.to_string(),
+                    var_value: var_value
+                        .trim_matches('"')
+                        .trim_matches('\'')
+                        .to_string(),
+                    source_type: "file".to_string(),
+                    source_path: format!("{}:{}", file_path, line_num + 1),
+                });
             }
         }
     }
@@ -156,13 +209,108 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_keywords() {
-        assert_eq!(get_keywords_for_app("claude"), vec!["ANTHROPIC"]);
-        assert_eq!(get_keywords_for_app("codex"), vec!["OPENAI"]);
-        assert_eq!(
-            get_keywords_for_app("gemini"),
-            vec!["GEMINI", "GOOGLE_GEMINI"]
-        );
+    fn test_get_keywords_returns_exact_var_names() {
+        let claude = get_keywords_for_app("claude");
+        assert!(claude.contains(&"ANTHROPIC_API_KEY"));
+        assert!(claude.contains(&"ANTHROPIC_AUTH_TOKEN"));
+        assert!(claude.contains(&"ANTHROPIC_BASE_URL"));
+
+        let codex = get_keywords_for_app("codex");
+        assert!(codex.contains(&"OPENAI_API_KEY"));
+
+        let gemini = get_keywords_for_app("gemini");
+        assert!(gemini.contains(&"GEMINI_API_KEY"));
+        assert!(gemini.contains(&"GOOGLE_API_KEY"));
+
         assert_eq!(get_keywords_for_app("unknown"), Vec::<&str>::new());
+    }
+
+    // The shell-config scanner reads `$HOME` at runtime, so the helper below
+    // mutates the process env. Tests that touch HOME must run serially or
+    // they will race each other.
+    #[cfg(not(target_os = "windows"))]
+    fn scan_with_rc(rc_content: &str, app: &str) -> Vec<EnvConflict> {
+        let dir = tempfile::tempdir().unwrap();
+        let rc_path = dir.path().join(".zshrc");
+        fs::write(&rc_path, rc_content).unwrap();
+
+        // Re-run check_shell_configs against a synthetic $HOME so we only
+        // see hits from the file we control.
+        let prev_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", dir.path());
+        let keywords = get_keywords_for_app(app);
+        let result = check_shell_configs(&keywords).unwrap();
+        if let Some(h) = prev_home {
+            std::env::set_var("HOME", h);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        result
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[serial_test::serial]
+    #[test]
+    fn test_skips_inline_command_prefix_inside_function() {
+        // Reproduces the user-reported false-positive from issue #516:
+        // every var here is scoped to the spawned `claude` child only.
+        let rc = r#"
+cc() {
+  ANTHROPIC_AUTH_TOKEN="sk-test" \
+  ANTHROPIC_BASE_URL="https://example.com" \
+  claude --dangerously-skip-permissions "$@"
+}
+"#;
+        let conflicts = scan_with_rc(rc, "claude");
+        assert!(
+            conflicts.is_empty(),
+            "function-body inline-prefix vars must not be flagged: {conflicts:?}"
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[serial_test::serial]
+    #[test]
+    fn test_flags_top_level_export() {
+        let rc = r#"
+# real export — would actually leak to children
+export ANTHROPIC_API_KEY="sk-real"
+"#;
+        let conflicts = scan_with_rc(rc, "claude");
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].var_name, "ANTHROPIC_API_KEY");
+        assert_eq!(conflicts[0].var_value, "sk-real");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[serial_test::serial]
+    #[test]
+    fn test_does_not_flag_unrelated_var_with_keyword_substring() {
+        // Pre-fix: contains("ANTHROPIC") matched these and false-positived.
+        let rc = r#"
+export LOG_ANTHROPIC_REQUESTS="1"
+export MY_OPENAI_PROXY_LOG="/tmp/log"
+local v_gemini_remote="something"
+"#;
+        let claude = scan_with_rc(rc, "claude");
+        let codex = scan_with_rc(rc, "codex");
+        let gemini = scan_with_rc(rc, "gemini");
+        assert!(claude.is_empty(), "claude false-positive: {claude:?}");
+        assert!(codex.is_empty(), "codex false-positive: {codex:?}");
+        assert!(gemini.is_empty(), "gemini false-positive: {gemini:?}");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[serial_test::serial]
+    #[test]
+    fn test_does_not_flag_bare_top_level_assignment() {
+        // Without `export`, this is either a non-exported shell var or
+        // (more commonly) syntactically the start of an inline command
+        // prefix on a continued line. Either way it does not pollute
+        // child processes.
+        let rc = r#"ANTHROPIC_API_KEY="sk-not-exported"
+"#;
+        let conflicts = scan_with_rc(rc, "claude");
+        assert!(conflicts.is_empty(), "{conflicts:?}");
     }
 }


### PR DESCRIPTION
## Problem

The env-conflict scanner in `src-tauri/src/services/env_checker.rs` produces aggressive false positives. The detector uses substring matching (`name.to_uppercase().contains(keyword)`) and treats every non-comment `VAR=value` line as a global export, which incorrectly flags two very common patterns:

**1. Variable names that merely *contain* a keyword**

```bash
export LOG_ANTHROPIC_TIMING=1   # not the API key
local v_gemini_remote=...       # local helper
```

**2. Inline command-prefix assignments inside shell functions** — the user-reported pattern from #516:

```bash
cc() {
  ANTHROPIC_AUTH_TOKEN="..." \
  ANTHROPIC_BASE_URL="..." \
  claude --dangerously-skip-permissions "$@"
}
```

POSIX semantics make those assignments visible **only** to the spawned `claude` child. They don't pollute the calling shell, don't leak into siblings, and cannot override what cc-switch configures. A user with five such helper functions sees the conflict dialog report **26 phantom conflicts on every launch**.

Verified empirically — the user's clean login shell shows zero leaked vars:

```bash
$ env -i HOME="$HOME" PATH="/usr/bin:/bin" zsh -i -c \
    'env | grep -iE "anthropic|claude_code"'
# (empty)
```

Closes #516.

## Fix

`src-tauri/src/services/env_checker.rs`:

- **Exact (case-insensitive) name matching** against a whitelist of variables that actually drive each managed CLI (Anthropic API/auth token/base URL/model selectors for `claude`, `OPENAI_*` for `codex`, `GEMINI_API_KEY` / `GOOGLE_API_KEY` / `GOOGLE_GEMINI_API_KEY` for `gemini`). No more `contains`.
- **Brace-depth tracking** while scanning rc files: any line that lies inside a `{ ... }` block is skipped, which is exactly where inline command prefixes live.
- **`export`-only matching** at the top level. A bare `VAR=value` outside `export` is either an inline prefix on a continued line or an unexported shell var; neither leaks into descendant processes.

A naive char-counter for `{`/`}` is good enough for typical rc files; braces inside strings/comments cause harmless over-skipping rather than false positives.

## Tests

Four new regression tests cover the exact patterns from the bug report, plus the property we still want to preserve (real exports must still be flagged):

- `test_skips_inline_command_prefix_inside_function` — the user-reported pattern
- `test_flags_top_level_export` — must still flag genuine `export ANTHROPIC_API_KEY=...`
- `test_does_not_flag_unrelated_var_with_keyword_substring` — `LOG_ANTHROPIC_REQUESTS`, `MY_OPENAI_PROXY_LOG`, `local v_gemini_remote`
- `test_does_not_flag_bare_top_level_assignment` — `VAR=...` without `export`

Tests share `$HOME` so they're annotated with `#[serial_test::serial]` (the crate is already in dev-dependencies).

```text
running 5 tests
test services::env_checker::tests::test_get_keywords_returns_exact_var_names ... ok
test services::env_checker::tests::test_does_not_flag_unrelated_var_with_keyword_substring ... ok
test services::env_checker::tests::test_flags_top_level_export ... ok
test services::env_checker::tests::test_does_not_flag_bare_top_level_assignment ... ok
test services::env_checker::tests::test_skips_inline_command_prefix_inside_function ... ok

test result: ok. 5 passed; 0 failed
```

## Behavior change worth a second look

Previously a bare top-level `ANTHROPIC_API_KEY="..."` (no `export`) was flagged. Now it isn't, because POSIX shells don't propagate non-exported vars to children. If you'd rather keep flagging it for the rare `set -a` (allexport) case, happy to gate that on detecting `set -a` earlier in the file — let me know.