### PR TITLE
fix(auto-launch): clean up legacy macOS login items left by pre-#462 builds

### DIFF
--- a/src-tauri/src/auto_launch.rs
+++ b/src-tauri/src/auto_launch.rs
@@ -68,6 +68,88 @@ pub fn is_auto_launch_enabled() -> Result<bool, AppError> {
         .map_err(|e| AppError::Message(format!("检查开机自启状态失败: {e}")))
 }
 
+/// 迁移由旧版本写入的 macOS 登录项。
+///
+/// PR #462 之前的构建版本将 `.app/Contents/MacOS/<exe>` 这一可执行文件路径
+/// 直接注册为登录项；这条路径在 LaunchServices 看来是 "Unix Executable
+/// File"，被打开时会附带一个终端窗口（用户能看到 cc-switch 的全部启动日志）。
+/// 老版本注册时使用的显示名也是 `cc-switch`（小写连字符），而当前代码使用
+/// `CC Switch`，因此 [`is_auto_launch_enabled`] 永远查不到这一条旧记录，
+/// 它会一直驻留在系统登录项里。
+///
+/// 此函数在启动期调用一次：
+/// 1. 通过 AppleScript 查找名为 `cc-switch` 或 `CC Switch`、且路径包含
+///    `/Contents/MacOS/` 的登录项 —— 这种路径形态一定是错的；
+/// 2. 删除命中的登录项；
+/// 3. 若确实删除了任何条目，立即用正确的 `.app` bundle 路径重新启用开机
+///    自启，保留用户原本的意图。
+///
+/// 在非 macOS 平台上是空操作。
+#[cfg(target_os = "macos")]
+pub fn migrate_legacy_macos_login_items() {
+    use std::process::Command;
+
+    // AppleScript 返回 "true" / "false" 表示是否发生了删除。
+    // 同时检查两种可能存在的显示名（旧版用 "cc-switch"，新版用 "CC Switch"），
+    // 这样即便当前版本曾经写错了一次也能被自愈。
+    const SCRIPT: &str = r#"
+        on cleanup(itemName)
+            tell application "System Events"
+                try
+                    set li to login item itemName
+                    if (path of li) contains "/Contents/MacOS/" then
+                        delete li
+                        return true
+                    end if
+                end try
+                return false
+            end tell
+        end cleanup
+
+        set didRemove to false
+        if cleanup("cc-switch") then set didRemove to true
+        if cleanup("CC Switch") then set didRemove to true
+        return didRemove
+    "#;
+
+    let output = match Command::new("osascript").arg("-e").arg(SCRIPT).output() {
+        Ok(o) => o,
+        Err(e) => {
+            log::warn!("Skipped legacy login item migration (osascript not runnable): {e}");
+            return;
+        }
+    };
+
+    if !output.status.success() {
+        log::warn!(
+            "Legacy login item migration script exited with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        return;
+    }
+
+    let removed = String::from_utf8_lossy(&output.stdout).trim() == "true";
+    if !removed {
+        return;
+    }
+
+    log::info!(
+        "✓ Removed legacy macOS login item with .app/Contents/MacOS/ path (would have caused a Terminal window on login)"
+    );
+
+    // 重新注册以保留用户的开机自启意图，这一次会走 .app bundle 路径。
+    match enable_auto_launch() {
+        Ok(()) => log::info!("✓ Re-registered auto-launch using the .app bundle path"),
+        Err(e) => log::warn!("Failed to re-register auto-launch after legacy cleanup: {e}"),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn migrate_legacy_macos_login_items() {
+    // 仅 macOS 受此 bug 影响，其他平台无需处理。
+}
+
 #[cfg(test)]
 mod tests {
     #[allow(unused_imports)]
@@ -113,5 +195,23 @@ mod tests {
         let exe_path = std::path::Path::new("/Users/dev/project/target/debug/cc-switch");
         let result = get_macos_app_bundle_path(exe_path);
         assert_eq!(result, None);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn test_migrate_legacy_login_items_is_noop_on_non_macos() {
+        // Must compile and not panic on Windows / Linux. The function is a
+        // no-op there and has no observable effect to assert on.
+        super::migrate_legacy_macos_login_items();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_migrate_legacy_login_items_compiles_on_macos() {
+        // We can't safely exercise the AppleScript path under `cargo test`
+        // because it would touch the developer's actual login items.
+        // This test exists purely to keep the function reachable from the
+        // test target and surface any compile-time regressions.
+        let _ = super::migrate_legacy_macos_login_items;
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -327,6 +327,12 @@ pub fn run() {
                 )?;
             }
 
+            // 一次性自愈：清理旧版本写入的 macOS 登录项
+            // 旧版本曾把 .app/Contents/MacOS/<exe> 注册为登录项，导致每次开机都会
+            // 弹出一个终端窗口。此调用会删除路径错误的旧条目并用正确的 .app bundle
+            // 路径重新注册（前提是删除前确实存在错误条目）。非 macOS 平台是 no-op。
+            crate::auto_launch::migrate_legacy_macos_login_items();
+
             // 初始化数据库
             let app_config_dir = crate::config::get_app_config_dir();
             let db_path = app_config_dir.join("cc-switch.db");


### PR DESCRIPTION
## Problem

#462 fixed `auto_launch.rs` to register the `.app` bundle path on macOS so login items don't open via Terminal.app. **However, users who had auto-launch enabled before that fix still have a broken login item** that points at the inner Unix executable:

```
/Applications/CC Switch.app/Contents/MacOS/cc-switch
```

That path makes LaunchServices treat the entry as a *Unix Executable File*, so every login spawns a Terminal window full of cc-switch's startup logs. The legacy entry also uses the old display name `cc-switch` (lowercase, hyphen) while current code uses `CC Switch` — meaning:

- `is_auto_launch_enabled()` returns `false` (the in-app toggle shows "off"), and
- `disable_auto_launch()` can't see the legacy item to remove it,

so the broken state is **invisible from inside the app** and persists indefinitely. Reproduced on cc-switch 3.14.1 upgraded from a pre-#462 install:

```bash
$ osascript -e 'tell application "System Events" to get the path of login item "cc-switch"'
/Applications/CC Switch.app/Contents/MacOS/cc-switch
$ osascript -e 'tell application "System Events" to get the kind of login item "cc-switch"'
Unix Executable File
```

## Fix

Add a one-shot self-heal called from the Tauri `setup` hook:

`src-tauri/src/auto_launch.rs` — new `migrate_legacy_macos_login_items()`:
1. Runs an AppleScript that looks for login items named **`cc-switch`** *or* **`CC Switch`** whose `path` contains `/Contents/MacOS/`. That path shape is unambiguously the buggy one — no `.app` bundle ever has its bundle path inside `Contents/MacOS/`.
2. Deletes the matching entries.
3. If anything was removed, calls `enable_auto_launch()` to re-register with the proper `.app` bundle path so the user keeps their original auto-launch preference.

The AppleScript uses `try` blocks so a missing item is not an error. On non-macOS targets the function is a no-op.

`src-tauri/src/lib.rs` — invoke once from `setup`, right after the log plugin is configured so the migration log line is captured.

The migration only fires when a buggy entry is actually found (returns early otherwise), and it never touches login items that don't match the cc-switch display names.

## Tests

```text
running 5 tests
test auto_launch::tests::test_migrate_legacy_login_items_compiles_on_macos ... ok
test auto_launch::tests::test_get_macos_app_bundle_path_not_in_bundle ... ok
test auto_launch::tests::test_get_macos_app_bundle_path_dev_build ... ok
test auto_launch::tests::test_get_macos_app_bundle_path_valid ... ok
test auto_launch::tests::test_get_macos_app_bundle_path_with_spaces ... ok

test result: ok. 5 passed; 0 failed
```

The AppleScript path itself is intentionally not exercised in `cargo test` because it would mutate the developer's actual login items; the test ensures the function stays compileable and reachable.

## Manual verification plan for reviewer

On a macOS host that has the buggy state (or simulated via `osascript -e 'tell application "System Events" to make login item at end with properties {name:"cc-switch", path:"/Applications/CC Switch.app/Contents/MacOS/cc-switch", hidden:false}'`):

1. Launch the dev build → log shows `✓ Removed legacy macOS login item …` and `✓ Re-registered auto-launch using the .app bundle path`.
2. Verify `osascript -e 'tell application "System Events" to get the path of every login item whose name is "CC Switch"'` now returns the `.app` bundle path.
3. Re-launch → migration is silent (no false repeat).

## Note on UX choice

The migration runs silently rather than prompting the user — the buggy state is unambiguously wrong and the heal preserves the user's intent (`enable_auto_launch` after delete). Happy to swap in a one-time toast/notification if you'd prefer something more visible.