### PR TITLE
fix(terminal): silence ShellExecute dialog when launching Windows Terminal

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1180,6 +1180,49 @@ fn which_command(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve the full path to `wt.exe` (Windows Terminal). Returns None if not found.
+///
+/// We must resolve a concrete path *before* invoking `cmd /C start wt …`. If
+/// `start` can't locate `wt` it routes through ShellExecute, which pops a modal
+/// "Windows 找不到文件 'wt'" dialog and only *then* returns failure — the existing
+/// fallback to cmd happens after the dialog is already on screen.
+///
+/// `where wt` covers the normal case. The explicit `LOCALAPPDATA\Microsoft\
+/// WindowsApps\wt.exe` probe covers the common elevated-launch scenario, where
+/// the SYSTEM PATH inherited by an admin-elevated cc-switch lacks the user's
+/// per-user WindowsApps directory.
+#[cfg(target_os = "windows")]
+fn resolve_windows_terminal_path() -> Option<String> {
+    use std::process::Command;
+
+    if let Ok(output) = Command::new("cmd")
+        .args(["/C", "where", "wt"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+    {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Some(first) = stdout.lines().next() {
+                let trimmed = first.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+    }
+
+    let local_appdata = std::env::var_os("LOCALAPPDATA")?;
+    let wt_path = std::path::Path::new(&local_appdata)
+        .join("Microsoft")
+        .join("WindowsApps")
+        .join("wt.exe");
+    if wt_path.exists() {
+        wt_path.to_str().map(|s| s.to_string())
+    } else {
+        None
+    }
+}
+
 /// Windows: 根据用户首选终端启动
 #[cfg(target_os = "windows")]
 fn launch_windows_terminal(
@@ -1220,7 +1263,13 @@ del \"%~f0\" >nul 2>&1
             &["powershell", "-NoExit", "-Command", &ps_cmd],
             "PowerShell",
         ),
-        "wt" => run_windows_start_command(&["wt", "cmd", "/K", &bat_path], "Windows Terminal"),
+        "wt" => match resolve_windows_terminal_path() {
+            Some(wt_path) => run_windows_start_command(
+                &["", &wt_path, "cmd", "/K", &bat_path],
+                "Windows Terminal",
+            ),
+            None => Err("Windows Terminal (wt.exe) 未找到".to_string()),
+        },
         _ => run_windows_start_command(&["cmd", "/K", &bat_path], "cmd"), // "cmd" or default
     };
 
@@ -1464,7 +1513,13 @@ read -n 1 -s
                 &["powershell", "-NoExit", "-Command", &ps_cmd],
                 "PowerShell",
             ),
-            "wt" => run_windows_start_command(&["wt", "cmd", "/K", &bat_path], "Windows Terminal"),
+            "wt" => match resolve_windows_terminal_path() {
+                Some(wt_path) => run_windows_start_command(
+                    &["", &wt_path, "cmd", "/K", &bat_path],
+                    "Windows Terminal",
+                ),
+                None => Err("Windows Terminal (wt.exe) 未找到".to_string()),
+            },
             _ => run_windows_start_command(&["cmd", "/K", &bat_path], "cmd"),
         };
 


### PR DESCRIPTION
## Summary

Fixes a long-standing bug where picking **Windows Terminal** as the preferred terminal causes a modal dialog `Windows 找不到文件 'wt'` to pop up on every launch, even though the existing fallback to `cmd` is supposed to handle the failure silently.

### Root cause

`launch_windows_terminal` and the Windows branch of `launch_terminal_running` both invoke:

```rust
run_windows_start_command(&["wt", "cmd", "/K", &bat_path], "Windows Terminal")
```

which expands to `cmd /C start wt cmd /K <bat>`. When `start` cannot resolve `wt`, it routes through `ShellExecute`, which **first pops a modal "Windows cannot find" dialog and only then returns failure**. By the time the existing `result.is_err()` cmd-fallback fires, the user has already seen the popup.

This commonly hits users who run cc-switch elevated: an admin-elevated process inherits the SYSTEM PATH, which lacks the per-user `%LOCALAPPDATA%\Microsoft\WindowsApps` directory where `wt.exe` lives — so even though `wt` is installed, `start wt` can't find it.

### Fix

Resolve a concrete path to `wt.exe` *before* invoking `start`:

1. Try `where wt` (covers the normal case).
2. Fall back to an explicit probe of `%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe` (covers the elevated-launch scenario).
3. If neither resolves, return `Err(...)` so the existing cmd fallback path kicks in cleanly — no modal dialog.

When `wt.exe` is found, pass the **full resolved path** to `start` (with an empty title argument: `start "" "<full path>" cmd /K <bat>`). `ShellExecute` against a concrete path doesn't show the "cannot find" dialog.

The change is minimal and contained: one new helper `resolve_windows_terminal_path()` plus a two-line replacement at each of the two existing Windows launch sites.

## Test plan

- [x] Built locally with `pnpm tauri build --no-bundle` on Windows 11 Pro 23H2 (MSVC 14.44, rustc 1.95.0)
- [x] Reproduced the bug with the released v3.14.1 binary: dialog shows on every Provider launch when wt is the preferred terminal
- [x] Verified the patched binary launches Windows Terminal cleanly with no dialog under both normal and elevated launch contexts
- [x] Verified `cmd` and `PowerShell` selections continue to work unchanged
- [x] No new warnings introduced; existing warnings in this file are pre-existing