### PR TITLE
fix(proxy): use x-api-key for AuthStrategy::Anthropic in Claude provider

### DIFF
--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -509,7 +509,13 @@ impl ProviderAdapter for ClaudeAdapter {
         // 注意：anthropic-version 由 forwarder.rs 统一处理（透传客户端值或设置默认值）
         let bearer = format!("Bearer {}", auth.api_key);
         match auth.strategy {
-            AuthStrategy::Anthropic | AuthStrategy::ClaudeAuth | AuthStrategy::Bearer => {
+            AuthStrategy::Anthropic => {
+                vec![(
+                    HeaderName::from_static("x-api-key"),
+                    HeaderValue::from_str(&auth.api_key).unwrap(),
+                )]
+            }
+            AuthStrategy::ClaudeAuth | AuthStrategy::Bearer => {
                 vec![(
                     HeaderName::from_static("authorization"),
                     HeaderValue::from_str(&bearer).unwrap(),


### PR DESCRIPTION
Fixes #2368

## Problem

`AuthStrategy::Anthropic` was incorrectly grouped with `AuthStrategy::ClaudeAuth`
and `AuthStrategy::Bearer` in `get_auth_headers()`, producing
`Authorization: Bearer ***` instead of `x-api-key: ***`.

This causes failures with Anthropic-compatible endpoints that require the
`x-api-key` authentication header, such as OpenCode Go.

## Root Cause

In `src-tauri/src/proxy/providers/claude.rs`, the `get_auth_headers()` method
had a single match arm covering three distinct strategies:

```rust
AuthStrategy::Anthropic | AuthStrategy::ClaudeAuth | AuthStrategy::Bearer => {
    vec![("authorization", "Bearer ***")]
}
```

Per `auth.rs`, `AuthStrategy::Anthropic` is documented as using
`x-api-key: <api_key>` with `anthropic-version: 2023-06-01`.

## Fix

Split the match arm so `AuthStrategy::Anthropic` uses the correct header:

```rust
AuthStrategy::Anthropic => {
    vec![("x-api-key", "<api_key>")]
}
AuthStrategy::ClaudeAuth | AuthStrategy::Bearer => {
    vec![("authorization", "Bearer ***")]
}
```

The `anthropic-version` header continues to be handled by `forwarder.rs`
as before.

## Changes

- **File**: `src-tauri/src/proxy/providers/claude.rs`
- **Line 512**: Split `AuthStrategy::Anthropic` from `ClaudeAuth | Bearer`
  to use `x-api-key` header instead of `Authorization: Bearer`.