### PR TITLE
fix(proxy): finalize OpenAI streaming tool calls

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -6,14 +6,17 @@ use crate::proxy::sse::{strip_sse_field, take_sse_block};
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 /// OpenAI 流式响应数据结构
 #[derive(Debug, Deserialize)]
 struct OpenAIStreamChunk {
+    #[serde(default)]
     id: String,
+    #[serde(default)]
     model: String,
+    #[serde(default)]
     choices: Vec<StreamChoice>,
     #[serde(default)]
     usage: Option<Usage>,
@@ -95,6 +98,68 @@ struct ToolBlockState {
 /// 无限空白 bug 的连续空白字符阈值
 const INFINITE_WHITESPACE_THRESHOLD: usize = 20;
 
+fn build_anthropic_usage_json(usage: &Usage) -> Value {
+    let mut usage_json = json!({
+        "input_tokens": usage.prompt_tokens,
+        "output_tokens": usage.completion_tokens
+    });
+    if let Some(cached) = extract_cache_read_tokens(usage) {
+        usage_json["cache_read_input_tokens"] = json!(cached);
+    }
+    if let Some(created) = usage.cache_creation_input_tokens {
+        usage_json["cache_creation_input_tokens"] = json!(created);
+    }
+    usage_json
+}
+
+fn build_anthropic_sse_event(event_name: &str, event: Value) -> Bytes {
+    Bytes::from(format!(
+        "event: {event_name}\ndata: {}\n\n",
+        serde_json::to_string(&event).unwrap_or_default()
+    ))
+}
+
+fn build_message_delta_sse(stop_reason: &str, usage: Option<&Value>) -> Bytes {
+    build_anthropic_sse_event(
+        "message_delta",
+        json!({
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": stop_reason,
+                "stop_sequence": null
+            },
+            "usage": usage.cloned()
+        }),
+    )
+}
+
+fn build_message_stop_sse() -> Bytes {
+    build_anthropic_sse_event("message_stop", json!({"type": "message_stop"}))
+}
+
+fn finalize_message_events(
+    pending_stop_reason: &mut Option<String>,
+    usage: Option<&Value>,
+    message_delta_sent: &mut bool,
+    message_stop_sent: &mut bool,
+) -> Vec<Bytes> {
+    let mut events = Vec::new();
+
+    if !*message_delta_sent {
+        if let Some(stop_reason) = pending_stop_reason.take() {
+            events.push(build_message_delta_sse(&stop_reason, usage));
+            *message_delta_sent = true;
+        }
+    }
+
+    if !*message_stop_sent {
+        events.push(build_message_stop_sse());
+        *message_stop_sent = true;
+    }
+
+    events
+}
+
 /// 创建 Anthropic SSE 流
 pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
     stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
@@ -110,6 +175,10 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         let mut current_non_tool_block_index: Option<u32> = None;
         let mut tool_blocks_by_index: HashMap<usize, ToolBlockState> = HashMap::new();
         let mut open_tool_block_indices: HashSet<u32> = HashSet::new();
+        let mut latest_usage: Option<Value> = None;
+        let mut pending_stop_reason: Option<String> = None;
+        let mut message_delta_sent = false;
+        let mut message_stop_sent = false;
 
         tokio::pin!(stream);
 
@@ -127,23 +196,32 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                             if let Some(data) = strip_sse_field(l, "data") {
                                 if data.trim() == "[DONE]" {
                                     log::debug!("[Claude/OpenRouter] <<< OpenAI SSE: [DONE]");
-                                    let event = json!({"type": "message_stop"});
-                                    let sse_data = format!("event: message_stop\ndata: {}\n\n",
-                                        serde_json::to_string(&event).unwrap_or_default());
-                                    log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
-                                    yield Ok(Bytes::from(sse_data));
+                                    for event in finalize_message_events(
+                                        &mut pending_stop_reason,
+                                        latest_usage.as_ref(),
+                                        &mut message_delta_sent,
+                                        &mut message_stop_sent,
+                                    ) {
+                                        yield Ok(event);
+                                    }
                                     continue;
                                 }
 
                                 if let Ok(chunk) = serde_json::from_str::<OpenAIStreamChunk>(data) {
                                     log::debug!("[Claude/OpenRouter] <<< SSE chunk received");
 
-                                    if message_id.is_none() {
+                                    if message_id.is_none() && !chunk.id.is_empty() {
                                         message_id = Some(chunk.id.clone());
                                     }
-                                    if current_model.is_none() {
+                                    if current_model.is_none() && !chunk.model.is_empty() {
                                         current_model = Some(chunk.model.clone());
                                     }
+                                    let saw_usage_this_chunk = if let Some(usage) = &chunk.usage {
+                                        latest_usage = Some(build_anthropic_usage_json(usage));
+                                        true
+                                    } else {
+                                        false
+                                    };
 
                                     if let Some(choice) = chunk.choices.first() {
                                         if !has_sent_message_start {
@@ -172,9 +250,7 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                                     "usage": start_usage
                                                 }
                                             });
-                                            let sse_data = format!("event: message_start\ndata: {}\n\n",
-                                                serde_json::to_string(&event).unwrap_or_default());
-                                            yield Ok(Bytes::from(sse_data));
+                                            yield Ok(build_anthropic_sse_event("message_start", event));
                                             has_sent_message_start = true;
                                         }
 
@@ -511,32 +587,20 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                                 open_tool_block_indices.clear();
                                             }
 
-                                            let stop_reason = map_stop_reason(Some(finish_reason));
-                                            // Build usage with cache token fields
-                                            let usage_json = chunk.usage.as_ref().map(|u| {
-                                                let mut uj = json!({
-                                                    "input_tokens": u.prompt_tokens,
-                                                    "output_tokens": u.completion_tokens
-                                                });
-                                                if let Some(cached) = extract_cache_read_tokens(u) {
-                                                    uj["cache_read_input_tokens"] = json!(cached);
-                                                }
-                                                if let Some(created) = u.cache_creation_input_tokens {
-                                                    uj["cache_creation_input_tokens"] = json!(created);
-                                                }
-                                                uj
-                                            });
-                                            let event = json!({
-                                                "type": "message_delta",
-                                                "delta": {
-                                                    "stop_reason": stop_reason,
-                                                    "stop_sequence": null
-                                                },
-                                                "usage": usage_json
-                                            });
-                                            let sse_data = format!("event: message_delta\ndata: {}\n\n",
-                                                serde_json::to_string(&event).unwrap_or_default());
-                                            yield Ok(Bytes::from(sse_data));
+                                            if !message_delta_sent {
+                                                pending_stop_reason = map_stop_reason(Some(finish_reason));
+                                            }
+                                        }
+                                    }
+
+                                    if saw_usage_this_chunk && pending_stop_reason.is_some() {
+                                        for event in finalize_message_events(
+                                            &mut pending_stop_reason,
+                                            latest_usage.as_ref(),
+                                            &mut message_delta_sent,
+                                            &mut message_stop_sent,
+                                        ) {
+                                            yield Ok(event);
                                         }
                                     }
                                 }
@@ -545,6 +609,18 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                     }
                 }
                 Err(e) => {
+                    if pending_stop_reason.is_some() && !message_stop_sent {
+                        for event in finalize_message_events(
+                            &mut pending_stop_reason,
+                            latest_usage.as_ref(),
+                            &mut message_delta_sent,
+                            &mut message_stop_sent,
+                        ) {
+                            yield Ok(event);
+                        }
+                        break;
+                    }
+
                     log::error!("Stream error: {e}");
                     let error_event = json!({
                         "type": "error",
@@ -558,6 +634,17 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                     yield Ok(Bytes::from(sse_data));
                     break;
                 }
+            }
+        }
+
+        if pending_stop_reason.is_some() && !message_stop_sent {
+            for event in finalize_message_events(
+                &mut pending_stop_reason,
+                latest_usage.as_ref(),
+                &mut message_delta_sent,
+                &mut message_stop_sent,
+            ) {
+                yield Ok(event);
             }
         }
     }
@@ -602,6 +689,32 @@ mod tests {
     use serde_json::Value;
     use std::collections::HashMap;
 
+    async fn collect_anthropic_events(input: &str) -> Vec<Value> {
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
+            input.as_bytes().to_vec(),
+        ))]);
+        let converted = create_anthropic_sse_stream(upstream);
+        let chunks: Vec<_> = converted.collect().await;
+        let merged = chunks
+            .into_iter()
+            .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
+            .collect::<String>();
+
+        merged
+            .split("\n\n")
+            .filter_map(|block| {
+                let data = block
+                    .lines()
+                    .find_map(|line| strip_sse_field(line, "data"))?;
+                serde_json::from_str::<Value>(data).ok()
+            })
+            .collect()
+    }
+
+    fn event_type(event: &Value) -> Option<&str> {
+        event.get("type").and_then(|v| v.as_str())
+    }
+
     #[test]
     fn test_map_stop_reason_legacy_and_filtered_values() {
         assert_eq!(
@@ -611,6 +724,78 @@ mod tests {
         assert_eq!(
             map_stop_reason(Some("content_filter")),
             Some("end_turn".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_tool_call_uses_usage_chunk_after_finish_reason() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_split\",\"model\":\"glm-5.1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"tool-0924\",\"type\":\"function\",\"function\":{\"name\":\"Bash\",\"arguments\":\"{\\\"command\\\":\\\"pwd\\\"}\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_split\",\"model\":\"glm-5.1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl_split\",\"model\":\"glm-5.1\",\"choices\":[],\"usage\":{\"prompt_tokens\":13312,\"completion_tokens\":79,\"prompt_tokens_details\":{\"cached_tokens\":100}}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+        let message_deltas: Vec<&Value> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("message_delta"))
+            .collect();
+        let message_stops = events
+            .iter()
+            .filter(|event| event_type(event) == Some("message_stop"))
+            .count();
+
+        assert_eq!(message_deltas.len(), 1);
+        assert_eq!(message_stops, 1);
+
+        let message_delta = message_deltas[0];
+        assert_eq!(
+            message_delta
+                .pointer("/delta/stop_reason")
+                .and_then(|v| v.as_str()),
+            Some("tool_use")
+        );
+        assert_eq!(
+            message_delta
+                .pointer("/usage/input_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(13312)
+        );
+        assert_eq!(
+            message_delta
+                .pointer("/usage/output_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(79)
+        );
+        assert_eq!(
+            message_delta
+                .pointer("/usage/cache_read_input_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(100)
+        );
+        assert_eq!(
+            events.last().and_then(|event| event_type(event)),
+            Some("message_stop")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_finalizes_after_finish_when_done_is_missing() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_no_done\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_no_done\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        assert!(events.iter().any(|event| {
+            event_type(event) == Some("message_delta")
+                && event.pointer("/delta/stop_reason").and_then(|v| v.as_str()) == Some("end_turn")
+        }));
+        assert_eq!(
+            events.last().and_then(|event| event_type(event)),
+            Some("message_stop")
         );
     }
 


### PR DESCRIPTION
## Summary / 概述

- Finalize OpenAI-compatible streaming responses after `finish_reason`, even when `[DONE]` is missing or the upstream stream ends early.
- Preserve usage from a later OpenAI usage-only chunk before emitting Anthropic `message_delta` and `message_stop`.
- Add regression coverage for split tool-call finish/usage chunks and missing `[DONE]` finalization.

## Related Issue / 关联 Issue

Fixes #2354

## Screenshots / 截图

N/A - proxy streaming logic only.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

## Test Plan / 测试计划

- [x] `pnpm typecheck && pnpm format:check && pnpm test:unit`
- [x] `cd src-tauri && cargo fmt --check && cargo clippy && cargo test`
