### PR TITLE
fix(proxy): preserve Vertex AI full URLs

### DIFF
--- a/src-tauri/src/proxy/gemini_url.rs
+++ b/src-tauri/src/proxy/gemini_url.rs
@@ -81,6 +81,10 @@ fn should_normalize_gemini_full_url(base_url: &str) -> bool {
     let path = path.trim_end_matches('/');
     let on_google_host = is_google_gemini_host(extract_host(origin));
 
+    if matches_vertex_ai_publisher_model_path(path) {
+        return false;
+    }
+
     // Unconditional layer: only paths whose grammar is *intrinsically*
     // Gemini-specific — the `/models/...:generateContent` method-call
     // shape and the deep OpenAI-compat endpoints (`/openai/chat/completions`,
@@ -238,6 +242,27 @@ fn matches_structured_gemini_models_path(path: &str) -> bool {
     false
 }
 
+/// Vertex AI endpoint paths include project/location/publisher routing before
+/// `models/*:generateContent`; in full-URL mode that routing is user-provided
+/// and must not be collapsed into the public Gemini `/v1beta/models/*` shape.
+fn matches_vertex_ai_publisher_model_path(path: &str) -> bool {
+    let Some(projects_index) = path.find("/projects/") else {
+        return false;
+    };
+    let Some(publisher_models_index) = path.find("/publishers/google/models/") else {
+        return false;
+    };
+
+    if projects_index >= publisher_models_index
+        || !path[projects_index..publisher_models_index].contains("/locations/")
+    {
+        return false;
+    }
+
+    let after_model = &path[publisher_models_index + "/publishers/google/models/".len()..];
+    after_model.contains(":generateContent") || after_model.contains(":streamGenerateContent")
+}
+
 fn merge_queries(base_query: Option<&str>, endpoint_query: Option<&str>) -> Option<String> {
     let parts: Vec<&str> = [base_query, endpoint_query]
         .into_iter()
@@ -332,6 +357,20 @@ mod tests {
         );
 
         assert_eq!(url, "https://relay.example/custom/generate-content?alt=sse");
+    }
+
+    #[test]
+    fn preserves_cloudflare_vertex_ai_full_url_with_action() {
+        let url = resolve_gemini_native_url(
+            "https://gateway.ai.cloudflare.com/v1/account/gateway/google-vertex-ai/v1/projects/project/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent",
+            "/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+            true,
+        );
+
+        assert_eq!(
+            url,
+            "https://gateway.ai.cloudflare.com/v1/account/gateway/google-vertex-ai/v1/projects/project/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -1903,6 +1903,22 @@ mod tests {
         assert_eq!(url, "https://relay.example/custom/generate-content?alt=sse");
     }
 
+    #[test]
+    fn test_resolve_claude_stream_url_for_gemini_native_cloudflare_vertex_full_url() {
+        let url = StreamCheckService::resolve_claude_stream_url(
+            "https://gateway.ai.cloudflare.com/v1/account/gateway/google-vertex-ai/v1/projects/project/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent",
+            AuthStrategy::Google,
+            "gemini_native",
+            true,
+            "gemini-2.5-flash",
+        );
+
+        assert_eq!(
+            url,
+            "https://gateway.ai.cloudflare.com/v1/account/gateway/google-vertex-ai/v1/projects/project/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse"
+        );
+    }
+
     /// Regression: Gemini SDK outputs commonly surface model ids as the
     /// resource-name form `models/gemini-2.5-pro`. Interpolating that raw
     /// value used to produce `/v1beta/models/models/gemini-2.5-pro:...`


### PR DESCRIPTION
## Summary / 概述

- Preserve Cloudflare AI Gateway Vertex AI full URLs in Gemini Native full URL mode.
- Avoid rewriting Vertex AI `projects/.../locations/.../publishers/google/models/*:streamGenerateContent` paths into public Gemini `/v1beta/models/*` endpoints.
- Add regression coverage for proxy URL resolution and stream check URL resolution.

## Related Issue / 关联 Issue

Fixes #2324

## Screenshots / 截图

N/A - proxy URL resolution logic only.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

## Test Plan / 测试计划

- [x] `pnpm typecheck && pnpm format:check && pnpm test:unit`
- [x] `cd src-tauri && cargo fmt --check && cargo clippy && cargo test`
