### PR TITLE
feat(terminal): add Warp as a preferred terminal option

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -944,6 +944,7 @@ exec bash --norc --noprofile
     // Note: Kitty doesn't need the -e flag, others do
     let result = match terminal {
         "iterm2" => launch_macos_iterm2(&script_file),
+        "warp" => launch_macos_warp(&script_file),
         "alacritty" => launch_macos_open_app("Alacritty", &script_file, true),
         "kitty" => launch_macos_open_app("kitty", &script_file, false),
         "ghostty" => launch_macos_open_app("Ghostty", &script_file, true),
@@ -1032,6 +1033,76 @@ end tell"#,
     Ok(())
 }
 
+/// macOS: Warp - 通过 AppleScript 激活并使用 System Events 发送键盘事件
+/// 运行脚本（Warp 不支持 Terminal.app 的 `do script` AppleScript 词汇）。
+#[cfg(target_os = "macos")]
+fn launch_macos_warp(script_file: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+    use std::thread;
+    use std::time::Duration;
+
+    // First make sure Warp is running and bring it to the foreground.
+    let activate_script = r#"tell application "Warp" to activate"#;
+    let activate_output = Command::new("osascript")
+        .arg("-e")
+        .arg(activate_script)
+        .output()
+        .map_err(|e| format!("启动 Warp 失败: {e}"))?;
+
+    if !activate_output.status.success() {
+        let stderr = String::from_utf8_lossy(&activate_output.stderr);
+        return Err(format!(
+            "Warp 启动失败 (exit code: {:?}): {}",
+            activate_output.status.code(),
+            stderr
+        ));
+    }
+
+    // Open a brand-new tab via the standard Cmd+T shortcut, then give the UI a
+    // moment to focus the new prompt before we type the launcher command.
+    let new_tab_script = r#"tell application "System Events"
+    tell process "Warp"
+        keystroke "t" using {command down}
+    end tell
+end tell"#;
+    let _ = Command::new("osascript")
+        .arg("-e")
+        .arg(new_tab_script)
+        .output();
+
+    thread::sleep(Duration::from_millis(600));
+
+    // Send the bash command to launch the cc-switch script.
+    let cmd_text = format!("bash '{}'", script_file.display());
+    // Escape backslashes and double quotes for AppleScript string literal.
+    let escaped_cmd = cmd_text.replace('\\', "\\\\").replace('"', "\\\"");
+    let keystroke_script = format!(
+        r#"tell application "System Events"
+    tell process "Warp"
+        keystroke "{escaped_cmd}"
+        key code 36
+    end tell
+end tell"#
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&keystroke_script)
+        .output()
+        .map_err(|e| format!("向 Warp 发送键盘事件失败: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Warp 执行失败 (exit code: {:?}): {}. 提示: 需要在「系统设置 → 隐私与安全 → 辅助功能」中授权 cc-switch。",
+            output.status.code(),
+            stderr
+        ));
+    }
+
+    Ok(())
+}
+
 /// macOS: 使用 open -a 启动支持 --args 参数的终端（Alacritty/Kitty/Ghostty）
 #[cfg(target_os = "macos")]
 fn launch_macos_open_app(
@@ -1084,6 +1155,7 @@ fn launch_linux_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> R
         ("alacritty", vec!["-e"]),
         ("kitty", vec!["-e"]),
         ("ghostty", vec!["-e"]),
+        ("warp-terminal", vec!["-e"]),
     ];
 
     // Create temp script file
@@ -1353,6 +1425,7 @@ read -n 1 -s
 
         let result = match terminal {
             "iterm2" => launch_macos_iterm2(&script_file),
+            "warp" => launch_macos_warp(&script_file),
             "alacritty" => launch_macos_open_app("Alacritty", &script_file, true),
             "kitty" => launch_macos_open_app("kitty", &script_file, false),
             "ghostty" => launch_macos_open_app("Ghostty", &script_file, true),
@@ -1392,6 +1465,7 @@ read -n 1 -s
             ("alacritty", vec!["-e"]),
             ("kitty", vec!["-e"]),
             ("ghostty", vec!["-e"]),
+            ("warp-terminal", vec!["-e"]),
         ];
 
         let terminals_to_try: Vec<(&str, Vec<&str>)> = if let Some(ref pref) = preferred {

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -22,6 +22,7 @@ pub fn launch_terminal(
         "wezterm" => launch_wezterm(command, cwd),
         "kaku" => launch_kaku(command, cwd),
         "alacritty" => launch_alacritty(command, cwd),
+        "warp" => launch_warp(command, cwd),
         "custom" => launch_custom(command, cwd, custom_config),
         _ => Err(format!("Unsupported terminal target: {target}")),
     }
@@ -199,6 +200,63 @@ fn build_wezterm_compatible_args_with_shell(
     args.push("-c".to_string());
     args.push(full_command);
     args
+}
+
+fn launch_warp(command: &str, cwd: Option<&str>) -> Result<(), String> {
+    use std::thread;
+    use std::time::Duration;
+
+    // Warp does not implement the Terminal.app `do script` AppleScript verb.
+    // The pragmatic workaround is to activate Warp, open a fresh tab, then
+    // synthesize keystrokes via System Events to type the command. This
+    // requires the user to grant cc-switch the Accessibility permission.
+    let activate_status = Command::new("osascript")
+        .arg("-e")
+        .arg(r#"tell application "Warp" to activate"#)
+        .status()
+        .map_err(|e| format!("Failed to activate Warp: {e}"))?;
+
+    if !activate_status.success() {
+        return Err("Failed to activate Warp. Make sure it is installed.".to_string());
+    }
+
+    let new_tab_script = r#"tell application "System Events"
+    tell process "Warp"
+        keystroke "t" using {command down}
+    end tell
+end tell"#;
+    let _ = Command::new("osascript")
+        .arg("-e")
+        .arg(new_tab_script)
+        .status();
+
+    thread::sleep(Duration::from_millis(600));
+
+    let full_command = build_shell_command(command, cwd);
+    let escaped = escape_osascript(&full_command);
+    let keystroke_script = format!(
+        r#"tell application "System Events"
+    tell process "Warp"
+        keystroke "{escaped}"
+        key code 36
+    end tell
+end tell"#
+    );
+
+    let status = Command::new("osascript")
+        .arg("-e")
+        .arg(keystroke_script)
+        .status()
+        .map_err(|e| format!("Failed to send keystrokes to Warp: {e}"))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(
+            "Warp command execution failed. Grant cc-switch Accessibility permission in System Settings."
+                .to_string(),
+        )
+    }
 }
 
 fn launch_alacritty(command: &str, cwd: Option<&str>) -> Result<(), String> {

--- a/src/components/settings/TerminalSettings.tsx
+++ b/src/components/settings/TerminalSettings.tsx
@@ -12,6 +12,7 @@ import { isMac, isWindows, isLinux } from "@/lib/platform";
 const MACOS_TERMINALS = [
   { value: "terminal", labelKey: "settings.terminal.options.macos.terminal" },
   { value: "iterm2", labelKey: "settings.terminal.options.macos.iterm2" },
+  { value: "warp", labelKey: "settings.terminal.options.macos.warp" },
   { value: "alacritty", labelKey: "settings.terminal.options.macos.alacritty" },
   { value: "kitty", labelKey: "settings.terminal.options.macos.kitty" },
   { value: "ghostty", labelKey: "settings.terminal.options.macos.ghostty" },
@@ -41,6 +42,10 @@ const LINUX_TERMINALS = [
   { value: "alacritty", labelKey: "settings.terminal.options.linux.alacritty" },
   { value: "kitty", labelKey: "settings.terminal.options.linux.kitty" },
   { value: "ghostty", labelKey: "settings.terminal.options.linux.ghostty" },
+  {
+    value: "warp-terminal",
+    labelKey: "settings.terminal.options.linux.warp",
+  },
 ] as const;
 
 // Get terminals for the current platform

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -545,6 +545,7 @@
         "macos": {
           "terminal": "Terminal.app",
           "iterm2": "iTerm2",
+          "warp": "Warp",
           "alacritty": "Alacritty",
           "kitty": "Kitty",
           "ghostty": "Ghostty",
@@ -562,7 +563,8 @@
           "xfce4Terminal": "Xfce4 Terminal",
           "alacritty": "Alacritty",
           "kitty": "Kitty",
-          "ghostty": "Ghostty"
+          "ghostty": "Ghostty",
+          "warp": "Warp"
         }
       }
     },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -545,6 +545,7 @@
         "macos": {
           "terminal": "Terminal.app",
           "iterm2": "iTerm2",
+          "warp": "Warp",
           "alacritty": "Alacritty",
           "kitty": "Kitty",
           "ghostty": "Ghostty",
@@ -562,7 +563,8 @@
           "xfce4Terminal": "Xfce4 Terminal",
           "alacritty": "Alacritty",
           "kitty": "Kitty",
-          "ghostty": "Ghostty"
+          "ghostty": "Ghostty",
+          "warp": "Warp"
         }
       }
     },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -545,6 +545,7 @@
         "macos": {
           "terminal": "Terminal.app",
           "iterm2": "iTerm2",
+          "warp": "Warp",
           "alacritty": "Alacritty",
           "kitty": "Kitty",
           "ghostty": "Ghostty",
@@ -562,7 +563,8 @@
           "xfce4Terminal": "Xfce4 Terminal",
           "alacritty": "Alacritty",
           "kitty": "Kitty",
-          "ghostty": "Ghostty"
+          "ghostty": "Ghostty",
+          "warp": "Warp"
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds Warp Terminal as a selectable preferred-terminal target on macOS and Linux, alongside Terminal.app, iTerm2, Alacritty, Kitty, Ghostty, WezTerm and Kaku.

Selecting **Warp** in *Settings → Preferred Terminal* and clicking the terminal button (or *Resume in terminal* in the Session Manager) will activate Warp, open a new tab, and run the cc-switch launcher command in it.

## Why a custom launcher

Warp does not implement Terminal.app's `do script` AppleScript verb, so the standard cc-switch launcher pattern (write a temp `.sh`, then `tell application "X" to do script`) does not work as-is. The launcher therefore:

1. Activates Warp via AppleScript.
2. Opens a new tab with Cmd+T (System Events).
3. Sends keystrokes via System Events to type `bash '/tmp/cc_switch_launcher_<pid>.sh'` and Enter.

This requires the user to grant cc-switch the **Accessibility** permission (System Settings → Privacy & Security → Accessibility) the first time. If Warp fails to launch for any reason, cc-switch falls back to Terminal.app like it already does for every other preferred terminal.

On Linux, `warp-terminal` is added to the default terminal list with the `-e` argument convention used by the other CLI terminals.

## Files touched

- `src/components/settings/TerminalSettings.tsx` — `warp` option in the macOS dropdown, `warp-terminal` option in the Linux dropdown.
- `src/i18n/locales/{en,zh,ja}.json` — *Warp* label under `settings.terminal.options.macos.warp` and `...linux.warp`.
- `src-tauri/src/commands/misc.rs` — new `launch_macos_warp` helper, `warp` branches added to `launch_macos_terminal` and `launch_terminal_running`, `warp-terminal` added to both Linux fallback lists.
- `src-tauri/src/session_manager/terminal/mod.rs` — `launch_warp` function and `warp` branch in the `launch_terminal` dispatcher used by the *Resume in terminal* flow.

## Verification

- `pnpm typecheck` — passes.
- `cargo check` — passes.
- `pnpm tauri build` — builds `CC Switch.app` successfully (the optional updater signing step is skipped because `TAURI_SIGNING_PRIVATE_KEY` is not set, but that is unrelated to this change).
- Manually verified end-to-end on macOS: selecting Warp opens a new Warp tab and runs the cc-switch launcher script automatically.

## How to test

1. Build and run.
2. *Settings → Preferred Terminal* → **Warp**.
3. Click any *Open in Terminal* button on a provider, or *Resume in terminal* in the Session Manager.
4. First run only: macOS will prompt to grant cc-switch Accessibility permission. After approving, click again — Warp will activate, open a fresh tab and run the bash launcher.

[Conversation link](https://app.warp.dev/conversation/c9d93262-d946-4e99-9234-89e18273d1af)

Co-Authored-By: Oz <oz-agent@warp.dev>