### PR TITLE
fix(session): hide Codex subagent sessions

### DIFF
--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -143,6 +143,9 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
         }
         if value.get("type").and_then(Value::as_str) == Some("session_meta") {
             if let Some(payload) = value.get("payload") {
+                if is_subagent_source(payload.get("source")) {
+                    return None;
+                }
                 if session_id.is_none() {
                     session_id = payload
                         .get("id")
@@ -239,6 +242,13 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
     })
 }
 
+fn is_subagent_source(source: Option<&Value>) -> bool {
+    source
+        .and_then(|value| value.as_object())
+        .map(|source| source.contains_key("subagent"))
+        .unwrap_or(false)
+}
+
 fn infer_session_id_from_filename(path: &Path) -> Option<String> {
     let file_name = path.file_name()?.to_string_lossy();
     UUID_RE.find(&file_name).map(|mat| mat.as_str().to_string())
@@ -326,6 +336,22 @@ mod tests {
         let meta = parse_session(&path).unwrap();
         // Should skip AGENTS.md injection and use the real user message
         assert_eq!(meta.title.as_deref(), Some("Fix the login bug"));
+    }
+
+    #[test]
+    fn parse_session_skips_subagent_sessions() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"timestamp\":\"2026-04-28T10:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"subagent-id\",\"cwd\":\"/tmp/project\",\"originator\":\"codex-tui\",\"source\":{\"subagent\":{\"thread_spawn\":{\"parent_thread_id\":\"parent-id\",\"depth\":1,\"agent_role\":\"explorer\"}}}}}\n",
+                "{\"timestamp\":\"2026-04-28T10:00:01Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":\"Inspect the project\"}}\n"
+            ),
+        )
+        .expect("write");
+
+        assert!(parse_session(&path).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

Codex 的会话文件里有一段来源信息，用来标记会话来源。

普通用户会话的来源通常是正常入口，比如命令行或编辑器，而 subagent 会话的来源里会带一个明确标记：subagent。

当前的实现中， CC Switch 扫描 Codex 会话时，只要看到会话文件格式对，就会把它当成普通会话展示，没有区分是不是 subagent。

这导致了用户的 session 和 subagent session 都被纳入了管理。

本 PR 的方案是直接将 Subagent 会话隐藏，不过也可以通过向 UI 中添加标识区分。

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #2444 

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

第三项没有通过，不过这不是当前 PR 造成的

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
