### PR TITLE
feat: support launch warp and execute session

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -947,6 +947,7 @@ exec bash --norc --noprofile
     // Note: Kitty doesn't need the -e flag, others do
     let result = match terminal {
         "iterm2" => launch_macos_iterm2(&script_file),
+        "warp" => launch_macos_warp(&script_file),
         "alacritty" => launch_macos_open_app("Alacritty", &script_file, true),
         "kitty" => launch_macos_open_app("kitty", &script_file, false),
         "ghostty" => launch_macos_open_app("Ghostty", &script_file, true),
@@ -1061,6 +1062,29 @@ fn launch_macos_open_app(
         return Err(format!(
             "{} 启动失败 (exit code: {:?}): {}",
             app_name,
+            output.status.code(),
+            stderr
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn launch_macos_warp(script_file: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+
+    let mut cmd = Command::new("open");
+    cmd.arg("-a").arg("Warp");
+
+    let warp_uri = format!("warp://action/new_tab?path={}", script_file.display());
+    cmd.arg(warp_uri);
+
+    let output = cmd.output().map_err(|e| format!("启动 Warp 失败: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Warp 启动失败 (exit code: {:?}): {}",
             output.status.code(),
             stderr
         ));
@@ -1356,6 +1380,7 @@ read -n 1 -s
 
         let result = match terminal {
             "iterm2" => launch_macos_iterm2(&script_file),
+            "warp" => launch_macos_warp(&script_file),
             "alacritty" => launch_macos_open_app("Alacritty", &script_file, true),
             "kitty" => launch_macos_open_app("kitty", &script_file, false),
             "ghostty" => launch_macos_open_app("Ghostty", &script_file, true),

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1072,12 +1072,40 @@ fn launch_macos_open_app(
 
 #[cfg(target_os = "macos")]
 fn launch_macos_warp(script_file: &std::path::Path) -> Result<(), String> {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
 
     let mut cmd = Command::new("open");
     cmd.arg("-a").arg("Warp");
 
-    let warp_uri = format!("warp://action/new_tab?path={}", script_file.display());
+    // Warp URI scheme cannot work well with script_file, because:
+    //
+    // 1. script_file's name ends up with .sh, so Warp would open the file rather than execute it
+    // 2. script_file has no execution permission, so we need to add one more indirection
+    let mut second_script_file = tempfile::Builder::new()
+        .disable_cleanup(true)
+        .permissions(std::fs::Permissions::from_mode(0o755))
+        .tempfile()
+        .map_err(|e| format!("Failed to create temporary script file: {e}"))?;
+
+    writeln!(
+        &mut second_script_file,
+        r#"
+        #!/usr/bin/env sh
+
+        rm -- $0
+
+        exec bash {}
+        "#,
+        script_file.display(),
+    )
+    .map_err(|e| format!("Failed to write to temporary script file for Warp: {e}"))?;
+
+    let warp_uri = format!(
+        "warp://action/new_tab?path={}",
+        second_script_file.path().display()
+    );
     cmd.arg(warp_uri);
 
     let output = cmd.output().map_err(|e| format!("启动 Warp 失败: {e}"))?;

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1091,10 +1091,9 @@ fn launch_macos_warp(script_file: &std::path::Path) -> Result<(), String> {
 
     writeln!(
         &mut second_script_file,
-        r#"
-        #!/usr/bin/env sh
+        r#"#!/usr/bin/env sh
 
-        rm -- $0
+        rm -- "$0"
 
         exec bash {}
         "#,
@@ -1102,11 +1101,12 @@ fn launch_macos_warp(script_file: &std::path::Path) -> Result<(), String> {
     )
     .map_err(|e| format!("Failed to write to temporary script file for Warp: {e}"))?;
 
-    let warp_uri = format!(
-        "warp://action/new_tab?path={}",
-        second_script_file.path().display()
-    );
-    cmd.arg(warp_uri);
+    let mut warp_url = url::Url::parse("warp://action/new_tab").unwrap();
+    warp_url
+        .query_pairs_mut()
+        .append_pair("path", &second_script_file.path().to_string_lossy());
+    let warp_url = warp_url.to_string();
+    cmd.arg(warp_url);
 
     let output = cmd.output().map_err(|e| format!("启动 Warp 失败: {e}"))?;
     if !output.status.success() {

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -211,6 +211,7 @@ fn launch_warp(command: &str, cwd: Option<&str>) -> Result<(), String> {
     let cwd = cwd.unwrap_or(".");
 
     let mut script_file = tempfile::Builder::new()
+        .disable_cleanup(true)
         .permissions(std::fs::Permissions::from_mode(0o755))
         .tempfile_in(cwd)
         .map_err(|e| format!("Failed to create temporary script file for launching Warp: {e}"))?;

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -234,7 +234,7 @@ fn launch_warp(command: &str, cwd: Option<&str>) -> Result<(), String> {
     );
 
     let status = Command::new("open")
-        .args(&["-a", "Warp", &warp_uri])
+        .args(["-a", "Warp", &warp_uri])
         .status()
         .map_err(|e| format!("Failed to launch Warp: {e}"))?;
 

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -22,6 +22,8 @@ pub fn launch_terminal(
         "wezterm" => launch_wezterm(command, cwd),
         "kaku" => launch_kaku(command, cwd),
         "alacritty" => launch_alacritty(command, cwd),
+        #[cfg(unix)]
+        "warp" => launch_warp(command, cwd),
         "custom" => launch_custom(command, cwd, custom_config),
         _ => Err(format!("Unsupported terminal target: {target}")),
     }
@@ -199,6 +201,47 @@ fn build_wezterm_compatible_args_with_shell(
     args.push("-c".to_string());
     args.push(full_command);
     args
+}
+
+#[cfg(unix)]
+fn launch_warp(command: &str, cwd: Option<&str>) -> Result<(), String> {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let cwd = cwd.unwrap_or(".");
+
+    let mut script_file = tempfile::Builder::new()
+        .permissions(std::fs::Permissions::from_mode(0o755))
+        .tempfile_in(cwd)
+        .map_err(|e| format!("Failed to create temporary script file for launching Warp: {e}"))?;
+
+    writeln!(
+        &mut script_file,
+        r#"
+        #!/usr/bin/env sh
+
+        rm -- $0
+
+        exec {command}
+        "#,
+    )
+    .map_err(|e| format!("Failed to write to temporary script file for Warp: {e}"))?;
+
+    let warp_uri = format!(
+        "warp://action/new_tab?path={}",
+        script_file.path().display()
+    );
+
+    let status = Command::new("open")
+        .args(&["-a", "Warp", &warp_uri])
+        .status()
+        .map_err(|e| format!("Failed to launch Warp: {e}"))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err("Failed to launch Warp.".to_string())
+    }
 }
 
 fn launch_alacritty(command: &str, cwd: Option<&str>) -> Result<(), String> {

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -208,7 +208,7 @@ fn launch_warp(command: &str, cwd: Option<&str>) -> Result<(), String> {
     use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
 
-    let cwd = cwd.unwrap_or(".");
+    let cwd = cwd.ok_or("Failed to resume session without cwd")?;
 
     let mut script_file = tempfile::Builder::new()
         .disable_cleanup(true)
@@ -218,23 +218,23 @@ fn launch_warp(command: &str, cwd: Option<&str>) -> Result<(), String> {
 
     writeln!(
         &mut script_file,
-        r#"
-        #!/usr/bin/env sh
+        r#"#!/usr/bin/env sh
 
-        rm -- $0
+        rm -- "$0"
 
         exec {command}
         "#,
     )
     .map_err(|e| format!("Failed to write to temporary script file for Warp: {e}"))?;
 
-    let warp_uri = format!(
-        "warp://action/new_tab?path={}",
-        script_file.path().display()
-    );
+    let mut warp_url = url::Url::parse("warp://action/new_tab").unwrap();
+    warp_url
+        .query_pairs_mut()
+        .append_pair("path", &script_file.path().to_string_lossy());
+    let warp_url = warp_url.to_string();
 
     let status = Command::new("open")
-        .args(["-a", "Warp", &warp_uri])
+        .args(["-a", "Warp", &warp_url])
         .status()
         .map_err(|e| format!("Failed to launch Warp: {e}"))?;
 

--- a/src/components/settings/TerminalSettings.tsx
+++ b/src/components/settings/TerminalSettings.tsx
@@ -17,6 +17,7 @@ const MACOS_TERMINALS = [
   { value: "ghostty", labelKey: "settings.terminal.options.macos.ghostty" },
   { value: "wezterm", labelKey: "settings.terminal.options.macos.wezterm" },
   { value: "kaku", labelKey: "settings.terminal.options.macos.kaku" },
+  { value: "warp", labelKey: "settings.terminal.options.macos.warp" },
 ] as const;
 
 const WINDOWS_TERMINALS = [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -549,7 +549,8 @@
           "kitty": "Kitty",
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
-          "kaku": "Kaku"
+          "kaku": "Kaku",
+          "warp": "Warp"
         },
         "windows": {
           "cmd": "Command Prompt",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -549,7 +549,8 @@
           "kitty": "Kitty",
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
-          "kaku": "Kaku"
+          "kaku": "Kaku",
+          "warp": "Warp"
         },
         "windows": {
           "cmd": "コマンドプロンプト",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -549,7 +549,8 @@
           "kitty": "Kitty",
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
-          "kaku": "Kaku"
+          "kaku": "Kaku",
+          "warp": "Warp"
         },
         "windows": {
           "cmd": "命令提示符",


### PR DESCRIPTION
Now you can use Warp as the default terminal app for resume session and launching terminal with provider.

I test locally and all works well.

cc @farion1231 