### PR TITLE
fix(proxy): drop empty pages from Read tool input

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -416,12 +416,13 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                             tool_index_by_item_id.insert(item_id.to_string(), index);
                                         }
                                         tool_name_by_index.insert(index, name.to_string());
-                                        tool_args_by_index.insert(index, String::new());
                                         last_tool_index = Some(index);
 
                                         if open_indices.contains(&index) {
                                             continue;
                                         }
+
+                                        tool_args_by_index.insert(index, String::new());
 
                                         let event = json!({
                                             "type": "content_block_start",
@@ -890,6 +891,40 @@ mod tests {
             .collect::<String>();
 
         assert!(merged.contains("\"name\":\"Read\""));
+        assert!(merged.contains("\"partial_json\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\",\\\"limit\\\":2000,\\\"offset\\\":0}"));
+        assert!(!merged.contains("\\\"pages\\\":\\\"\\\""));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_read_tool_duplicate_start_preserves_buffered_args() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_read\",\"model\":\"gpt-5.5\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_read\",\"type\":\"function_call\",\"call_id\":\"call_read\",\"name\":\"Read\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_read\",\"delta\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\",\\\"limit\\\":2000,\\\"offset\\\":0,\\\"pages\\\":\\\"\\\"}\"}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_read\",\"type\":\"function_call\",\"call_id\":\"call_read\",\"name\":\"Read\"}}\n\n",
+            "event: response.function_call_arguments.done\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_read\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
+            input.as_bytes().to_vec(),
+        ))]);
+        let converted = create_anthropic_sse_stream_from_responses(upstream);
+        let chunks: Vec<_> = converted.collect().await;
+
+        let merged = chunks
+            .into_iter()
+            .map(|c| String::from_utf8_lossy(c.unwrap().as_ref()).to_string())
+            .collect::<String>();
+
+        assert_eq!(merged.matches("event: content_block_start").count(), 1);
+        assert_eq!(merged.matches("event: content_block_stop").count(), 1);
         assert!(merged.contains("\"partial_json\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\",\\\"limit\\\":2000,\\\"offset\\\":0}"));
         assert!(!merged.contains("\\\"pages\\\":\\\"\\\""));
     }

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -8,7 +8,10 @@
 //!
 //! 与 Chat Completions 的 delta chunk 模型完全不同，需要独立的状态机处理。
 
-use super::transform_responses::{build_anthropic_usage_from_responses, map_responses_stop_reason};
+use super::transform_responses::{
+    build_anthropic_usage_from_responses, map_responses_stop_reason,
+    sanitize_anthropic_tool_use_input_json,
+};
 use crate::proxy::sse::{strip_sse_field, take_sse_block};
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
@@ -112,6 +115,8 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
         let mut fallback_open_index: Option<u32> = None;
         let mut current_text_index: Option<u32> = None;
         let mut tool_index_by_item_id: HashMap<String, u32> = HashMap::new();
+        let mut tool_name_by_index: HashMap<u32, String> = HashMap::new();
+        let mut tool_args_by_index: HashMap<u32, String> = HashMap::new();
         let mut last_tool_index: Option<u32> = None;
 
         tokio::pin!(stream);
@@ -410,6 +415,8 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                         {
                                             tool_index_by_item_id.insert(item_id.to_string(), index);
                                         }
+                                        tool_name_by_index.insert(index, name.to_string());
+                                        tool_args_by_index.insert(index, String::new());
                                         last_tool_index = Some(index);
 
                                         if open_indices.contains(&index) {
@@ -479,6 +486,14 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                         open_indices.insert(index);
                                     }
 
+                                    if tool_name_by_index.get(&index).map(String::as_str) == Some("Read") {
+                                        tool_args_by_index
+                                            .entry(index)
+                                            .or_default()
+                                            .push_str(delta);
+                                        continue;
+                                    }
+
                                     let event = json!({
                                         "type": "content_block_delta",
                                         "index": index,
@@ -512,6 +527,32 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                     if !open_indices.remove(&index) {
                                         continue;
                                     }
+                                    if tool_name_by_index.get(&index).map(String::as_str) == Some("Read") {
+                                        let raw = data
+                                            .get("arguments")
+                                            .and_then(|v| v.as_str())
+                                            .map(str::to_string)
+                                            .unwrap_or_else(|| {
+                                                tool_args_by_index
+                                                    .get(&index)
+                                                    .cloned()
+                                                    .unwrap_or_default()
+                                            });
+                                        let sanitized = sanitize_anthropic_tool_use_input_json("Read", &raw);
+                                        if !sanitized.is_empty() {
+                                            let event = json!({
+                                                "type": "content_block_delta",
+                                                "index": index,
+                                                "delta": {
+                                                    "type": "input_json_delta",
+                                                    "partial_json": sanitized
+                                                }
+                                            });
+                                            let sse = format!("event: content_block_delta\ndata: {}\n\n",
+                                                serde_json::to_string(&event).unwrap_or_default());
+                                            yield Ok(Bytes::from(sse));
+                                        }
+                                    }
                                     let event = json!({
                                         "type": "content_block_stop",
                                         "index": index
@@ -522,6 +563,8 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                     if let Some(item_id) = item_id {
                                         tool_index_by_item_id.remove(item_id);
                                     }
+                                    tool_name_by_index.remove(&index);
+                                    tool_args_by_index.remove(&index);
                                 }
                             }
 
@@ -818,6 +861,37 @@ mod tests {
         assert!(merged.contains("\"input_tokens\":12"));
         assert!(merged.contains("\"output_tokens\":3"));
         assert!(merged.contains("\"type\":\"message_stop\""));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_read_tool_drops_empty_pages() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_read\",\"model\":\"gpt-5.5\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_read\",\"type\":\"function_call\",\"call_id\":\"call_read\",\"name\":\"Read\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_read\",\"delta\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\",\\\"limit\\\":2000,\\\"offset\\\":0,\\\"pages\\\":\\\"\\\"}\"}\n\n",
+            "event: response.function_call_arguments.done\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_read\",\"arguments\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\",\\\"limit\\\":2000,\\\"offset\\\":0,\\\"pages\\\":\\\"\\\"}\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
+            input.as_bytes().to_vec(),
+        ))]);
+        let converted = create_anthropic_sse_stream_from_responses(upstream);
+        let chunks: Vec<_> = converted.collect().await;
+
+        let merged = chunks
+            .into_iter()
+            .map(|c| String::from_utf8_lossy(c.unwrap().as_ref()).to_string())
+            .collect::<String>();
+
+        assert!(merged.contains("\"name\":\"Read\""));
+        assert!(merged.contains("\"partial_json\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\",\\\"limit\\\":2000,\\\"offset\\\":0}"));
+        assert!(!merged.contains("\\\"pages\\\":\\\"\\\""));
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -11,6 +11,35 @@
 use crate::proxy::error::ProxyError;
 use serde_json::{json, Value};
 
+pub(crate) fn sanitize_anthropic_tool_use_input(name: &str, input: Value) -> Value {
+    if name != "Read" {
+        return input;
+    }
+
+    match input {
+        Value::Object(mut object) => {
+            if matches!(object.get("pages"), Some(Value::String(value)) if value.is_empty()) {
+                object.remove("pages");
+            }
+            Value::Object(object)
+        }
+        other => other,
+    }
+}
+
+pub(crate) fn sanitize_anthropic_tool_use_input_json(name: &str, raw: &str) -> String {
+    if name != "Read" || raw.is_empty() {
+        return raw.to_string();
+    }
+
+    let Ok(input) = serde_json::from_str::<Value>(raw) else {
+        return raw.to_string();
+    };
+
+    serde_json::to_string(&sanitize_anthropic_tool_use_input(name, input))
+        .unwrap_or_else(|_| raw.to_string())
+}
+
 /// Anthropic 请求 → OpenAI Responses 请求
 ///
 /// `cache_key`: optional prompt_cache_key to inject for improved cache routing
@@ -454,6 +483,7 @@ pub fn responses_to_anthropic(body: Value) -> Result<Value, ProxyError> {
                     .and_then(|a| a.as_str())
                     .unwrap_or("{}");
                 let input: Value = serde_json::from_str(args_str).unwrap_or(json!({}));
+                let input = sanitize_anthropic_tool_use_input(name, input);
 
                 content.push(json!({
                     "type": "tool_use",
@@ -766,6 +796,56 @@ mod tests {
         assert_eq!(result["content"][0]["name"], "get_weather");
         assert_eq!(result["content"][0]["input"]["location"], "Tokyo");
         assert_eq!(result["stop_reason"], "tool_use");
+    }
+
+    #[test]
+    fn test_responses_to_anthropic_read_drops_empty_pages() {
+        let input = json!({
+            "id": "resp_read",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [{
+                "type": "function_call",
+                "id": "fc_read",
+                "call_id": "call_read",
+                "name": "Read",
+                "arguments": "{\"file_path\":\"/tmp/demo.py\",\"limit\":2000,\"offset\":0,\"pages\":\"\"}",
+                "status": "completed"
+            }]
+        });
+
+        let result = responses_to_anthropic(input).unwrap();
+        let tool_input = &result["content"][0]["input"];
+
+        assert_eq!(result["content"][0]["type"], "tool_use");
+        assert_eq!(result["content"][0]["name"], "Read");
+        assert_eq!(tool_input["file_path"], "/tmp/demo.py");
+        assert_eq!(tool_input["limit"], 2000);
+        assert_eq!(tool_input["offset"], 0);
+        assert!(tool_input.get("pages").is_none());
+    }
+
+    #[test]
+    fn test_responses_to_anthropic_preserves_empty_strings_for_other_tools() {
+        let input = json!({
+            "id": "resp_other",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [{
+                "type": "function_call",
+                "id": "fc_other",
+                "call_id": "call_other",
+                "name": "search",
+                "arguments": "{\"query\":\"\"}",
+                "status": "completed"
+            }]
+        });
+
+        let result = responses_to_anthropic(input).unwrap();
+
+        assert_eq!(result["content"][0]["input"]["query"], "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

- 在 Responses API 转 Anthropic `tool_use` 时，移除 `Read` 工具输入里的空 `pages` 字段
- 对非流式和流式转换路径都应用同样的清理逻辑
- 添加回归测试，覆盖普通转换和 SSE 流式转换场景

## Related Issue / 关联 Issue

Fixes #2471 

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|<img width="770" height="427" alt="Screenshot_2026-04-30_03-08-54" src="https://github.com/user-attachments/assets/31ed1627-fef3-495d-9b58-814f8a903acd" />| <img width="802" height="465" alt="Screenshot_2026-04-30_03-05-49" src="https://github.com/user-attachments/assets/0bf8b28e-07c5-4442-9351-69c38ab6d403" />|

注1：这里是两个新对话使用了同一个提示词时，首次执行文件查看 tool 产生的，经过两次对比测试可稳定复现
注2：该问题和修复思路参考了[Wei-Shaw/sub2api#1996](https://github.com/Wei-Shaw/sub2api/pull/1996)的类似处理，本 PR 针对 cc-switch 的 Responses API → Anthropic 转换逻辑进行了独立适配。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

