### PR TITLE
feat(skills): add sync all CLIs action

### DIFF
--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -8,7 +8,7 @@ use crate::app_config::{AppType, InstalledSkill, UnmanagedSkill};
 use crate::error::format_skill_error;
 use crate::services::skill::{
     DiscoverableSkill, ImportSkillSelection, MigrationResult, Skill, SkillBackupEntry, SkillRepo,
-    SkillService, SkillStorageLocation, SkillUninstallResult, SkillUpdateInfo,
+    SkillService, SkillStorageLocation, SkillSyncAllResult, SkillUninstallResult, SkillUpdateInfo,
     SkillsShSearchResult,
 };
 use crate::store::AppState;
@@ -101,6 +101,13 @@ pub fn toggle_skill_app(
     let app_type = parse_app_type(&app)?;
     SkillService::toggle_app(&app_state.db, &id, &app_type, enabled).map_err(|e| e.to_string())?;
     Ok(true)
+}
+
+#[tauri::command]
+pub fn sync_all_skills_to_apps(
+    app_state: State<'_, AppState>,
+) -> Result<SkillSyncAllResult, String> {
+    SkillService::sync_all_to_supported_apps(&app_state.db).map_err(|e| e.to_string())
 }
 
 /// 扫描未管理的 Skills

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1156,6 +1156,7 @@ pub fn run() {
             commands::uninstall_skill_unified,
             commands::restore_skill_backup,
             commands::toggle_skill_app,
+            commands::sync_all_skills_to_apps,
             commands::scan_unmanaged_skills,
             commands::import_skills_from_apps,
             commands::discover_available_skills,

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -281,6 +281,26 @@ pub struct ImportSkillSelection {
     pub apps: SkillApps,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillSyncAllResult {
+    pub skill_count: usize,
+    pub app_count: usize,
+    pub synced_count: usize,
+    pub skipped_count: usize,
+    pub failures: Vec<SkillSyncFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillSyncFailure {
+    pub skill_id: String,
+    pub skill_name: String,
+    pub directory: String,
+    pub app: String,
+    pub error: String,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct LegacySkillMigrationRow {
     directory: String,
@@ -450,6 +470,16 @@ impl SkillService {
         Self
     }
 
+    fn supported_skill_apps() -> [AppType; 5] {
+        [
+            AppType::Claude,
+            AppType::Codex,
+            AppType::Gemini,
+            AppType::OpenCode,
+            AppType::Hermes,
+        ]
+    }
+
     /// 构建 Skill 文档 URL（指向仓库中的 SKILL.md 文件）
     fn build_skill_doc_url(owner: &str, repo: &str, branch: &str, doc_path: &str) -> String {
         format!("https://github.com/{owner}/{repo}/blob/{branch}/{doc_path}")
@@ -537,11 +567,7 @@ impl SkillService {
         }
 
         // 默认路径：回退到用户主目录下的标准位置
-        let home = dirs::home_dir().context(format_skill_error(
-            "GET_HOME_DIR_FAILED",
-            &[],
-            Some("checkPermission"),
-        ))?;
+        let home = crate::config::get_home_dir();
 
         Ok(match app {
             AppType::Claude => home.join(".claude").join("skills"),
@@ -1373,6 +1399,52 @@ impl SkillService {
         log::info!("Skill {} 的 {:?} 状态已更新为 {}", skill.name, app, enabled);
 
         Ok(())
+    }
+
+    /// Enable every installed Skill for every CLI that supports Skills.
+    pub fn sync_all_to_supported_apps(db: &Arc<Database>) -> Result<SkillSyncAllResult> {
+        let mut skills = db.get_all_installed_skills()?;
+        let supported_apps = Self::supported_skill_apps();
+        let mut synced_count = 0usize;
+        let mut skipped_count = 0usize;
+        let mut failures = Vec::new();
+
+        for skill in skills.values_mut() {
+            let mut updated_apps = skill.apps.clone();
+
+            for app in &supported_apps {
+                if skill.apps.is_enabled_for(app) {
+                    skipped_count += 1;
+                }
+
+                match Self::sync_to_app_dir(&skill.directory, app) {
+                    Ok(()) => {
+                        updated_apps.set_enabled_for(app, true);
+                        synced_count += 1;
+                    }
+                    Err(err) => failures.push(SkillSyncFailure {
+                        skill_id: skill.id.clone(),
+                        skill_name: skill.name.clone(),
+                        directory: skill.directory.clone(),
+                        app: app.as_str().to_string(),
+                        error: err.to_string(),
+                    }),
+                }
+            }
+
+            if updated_apps != skill.apps {
+                db.update_skill_apps(&skill.id, &updated_apps)?;
+                skill.apps = updated_apps;
+            }
+        }
+
+        Ok(SkillSyncAllResult {
+            skill_count: skills.len(),
+            app_count: supported_apps.len(),
+            synced_count,
+            skipped_count,
+            failures,
+        })
     }
 
     /// 扫描未管理的 Skills

--- a/src-tauri/tests/skill_sync.rs
+++ b/src-tauri/tests/skill_sync.rs
@@ -121,6 +121,77 @@ fn sync_to_app_removes_disabled_and_orphaned_ssot_symlinks() {
 }
 
 #[test]
+fn sync_all_to_supported_apps_enables_and_copies_every_installed_skill() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let ssot_skill_dir = home.join(".cc-switch").join("skills").join("bulk-skill");
+    write_skill(&ssot_skill_dir, "Bulk Skill");
+    fs::write(ssot_skill_dir.join("prompt.md"), "sync everywhere").expect("write prompt.md");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_skill(&InstalledSkill {
+            id: "local:bulk-skill".to_string(),
+            name: "Bulk Skill".to_string(),
+            description: None,
+            directory: "bulk-skill".to_string(),
+            repo_owner: None,
+            repo_name: None,
+            repo_branch: None,
+            readme_url: None,
+            apps: SkillApps {
+                claude: true,
+                ..Default::default()
+            },
+            installed_at: 0,
+            content_hash: None,
+            updated_at: 0,
+        })
+        .expect("save skill");
+
+    let result =
+        SkillService::sync_all_to_supported_apps(&state.db).expect("sync all installed skills");
+
+    assert_eq!(result.skill_count, 1);
+    assert_eq!(result.app_count, 5);
+    assert_eq!(result.failures.len(), 0);
+    assert_eq!(result.skipped_count, 1);
+
+    let updated = state
+        .db
+        .get_installed_skill("local:bulk-skill")
+        .expect("query skill")
+        .expect("skill should remain installed");
+    assert!(updated.apps.claude);
+    assert!(updated.apps.codex);
+    assert!(updated.apps.gemini);
+    assert!(updated.apps.opencode);
+    assert!(updated.apps.hermes);
+
+    let expected_paths = [
+        home.join(".claude").join("skills").join("bulk-skill"),
+        home.join(".codex").join("skills").join("bulk-skill"),
+        home.join(".gemini").join("skills").join("bulk-skill"),
+        home.join(".config")
+            .join("opencode")
+            .join("skills")
+            .join("bulk-skill"),
+        home.join(".hermes").join("skills").join("bulk-skill"),
+    ];
+
+    for path in expected_paths {
+        assert!(
+            path.join("SKILL.md").exists(),
+            "{} should contain synced skill files",
+            path.display()
+        );
+    }
+}
+
+#[test]
 fn uninstall_skill_creates_backup_before_removing_ssot() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -24,6 +24,7 @@ import {
   useInstallSkillsFromZip,
   useCheckSkillUpdates,
   useUpdateSkill,
+  useSyncAllSkillsToApps,
   type InstalledSkill,
   type SkillUpdateInfo,
 } from "@/hooks/useSkills";
@@ -100,6 +101,7 @@ const UnifiedSkillsPanel = React.forwardRef<
     isFetching: isCheckingUpdates,
   } = useCheckSkillUpdates();
   const updateSkillMutation = useUpdateSkill();
+  const syncAllMutation = useSyncAllSkillsToApps();
   const [isUpdatingAll, setIsUpdatingAll] = useState(false);
 
   const updatesMap = useMemo(() => {
@@ -275,6 +277,37 @@ const UnifiedSkillsPanel = React.forwardRef<
     }
   };
 
+  const handleSyncAllToApps = async () => {
+    try {
+      const result = await syncAllMutation.mutateAsync();
+      const failureCount = result.failures.length;
+
+      if (failureCount > 0) {
+        toast.warning(t("skills.syncAll.partial"), {
+          description: t("skills.syncAll.partialDescription", {
+            failed: failureCount,
+            firstError: result.failures[0]?.error ?? "",
+          }),
+          closeButton: true,
+        });
+        return;
+      }
+
+      toast.success(
+        t("skills.syncAll.success", {
+          skillCount: result.skillCount,
+          appCount: result.appCount,
+        }),
+        { closeButton: true },
+      );
+    } catch (error) {
+      toast.error(t("skills.syncAll.failed"), {
+        description: String(error),
+        closeButton: true,
+      });
+    }
+  };
+
   const handleOpenRestoreFromBackup = async () => {
     setRestoreDialogOpen(true);
     try {
@@ -352,6 +385,23 @@ const UnifiedSkillsPanel = React.forwardRef<
           appIds={SKILLS_APP_IDS}
         />
         <div className="flex items-center gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs gap-1 whitespace-nowrap"
+            onClick={handleSyncAllToApps}
+            disabled={syncAllMutation.isPending || !skills || skills.length === 0}
+          >
+            {syncAllMutation.isPending ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <RefreshCw size={12} />
+            )}
+            {syncAllMutation.isPending
+              ? t("skills.syncAll.syncing")
+              : t("skills.syncAll.button")}
+          </Button>
           <div
             className="transition-all duration-300 ease-out overflow-hidden"
             style={{

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -185,6 +185,16 @@ export function useToggleSkillApp() {
   });
 }
 
+export function useSyncAllSkillsToApps() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => skillsApi.syncAllToApps(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["skills", "installed"] });
+    },
+  });
+}
+
 /**
  * 扫描未管理的 Skills
  */

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1790,6 +1790,14 @@
     "updateAll": "Update All ({{count}})",
     "updatingAll": "Updating...",
     "updateAllSuccess": "Successfully updated {{count}} skill(s)",
+    "syncAll": {
+      "button": "Sync All CLIs",
+      "syncing": "Syncing...",
+      "success": "Synced {{skillCount}} skill(s) to {{appCount}} CLI(s)",
+      "partial": "Some skills failed to sync",
+      "partialDescription": "{{failed}} sync task(s) failed. First error: {{firstError}}",
+      "failed": "Failed to sync all CLIs"
+    },
     "error": {
       "skillNotFound": "Skill not found: {{directory}}",
       "missingRepoInfo": "Missing repository info (owner or name)",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1790,6 +1790,14 @@
     "updateAll": "すべて更新 ({{count}})",
     "updatingAll": "更新中...",
     "updateAllSuccess": "{{count}} 個のスキルを更新しました",
+    "syncAll": {
+      "button": "すべての CLI に同期",
+      "syncing": "同期中...",
+      "success": "{{skillCount}} 個のスキルを {{appCount}} 個の CLI に同期しました",
+      "partial": "一部のスキルの同期に失敗しました",
+      "partialDescription": "{{failed}} 件の同期タスクが失敗しました。最初のエラー: {{firstError}}",
+      "failed": "すべての CLI への同期に失敗しました"
+    },
     "error": {
       "skillNotFound": "スキルが見つかりません: {{directory}}",
       "missingRepoInfo": "リポジトリ情報（owner または name）が不足しています",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1790,6 +1790,14 @@
     "updateAll": "全部更新 ({{count}})",
     "updatingAll": "更新中...",
     "updateAllSuccess": "已成功更新 {{count}} 个技能",
+    "syncAll": {
+      "button": "同步全部 CLI",
+      "syncing": "同步中...",
+      "success": "已将 {{skillCount}} 个技能同步到 {{appCount}} 个 CLI",
+      "partial": "部分技能同步失败",
+      "partialDescription": "{{failed}} 个同步任务失败。首个错误：{{firstError}}",
+      "failed": "同步全部 CLI 失败"
+    },
     "error": {
       "skillNotFound": "技能不存在：{{directory}}",
       "missingRepoInfo": "缺少仓库信息（owner 或 name）",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -74,6 +74,22 @@ export interface ImportSkillSelection {
   apps: SkillApps;
 }
 
+export interface SkillSyncFailure {
+  skillId: string;
+  skillName: string;
+  directory: string;
+  app: string;
+  error: string;
+}
+
+export interface SkillSyncAllResult {
+  skillCount: number;
+  appCount: number;
+  syncedCount: number;
+  skippedCount: number;
+  failures: SkillSyncFailure[];
+}
+
 /** 技能对象（兼容旧 API） */
 export interface Skill {
   key: string;
@@ -173,6 +189,11 @@ export const skillsApi = {
   /** 切换 Skill 的应用启用状态 */
   async toggleApp(id: string, app: AppId, enabled: boolean): Promise<boolean> {
     return await invoke("toggle_skill_app", { id, app, enabled });
+  },
+
+  /** 同步所有已安装 Skills 到所有支持的 CLI */
+  async syncAllToApps(): Promise<SkillSyncAllResult> {
+    return await invoke("sync_all_skills_to_apps");
   },
 
   /** 扫描未管理的 Skills */


### PR DESCRIPTION
## Summary
- Add a Tauri command that syncs every installed skill to all supported CLI skill directories.
- Add a Skills panel button to trigger the bulk sync action with localized status messages.
- Add a regression test covering the all-CLI sync behavior.

## Test plan
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml sync_all_to_supported_apps_enables_and_copies_every_installed_skill` (blocked locally: disk space exhausted during compilation)
- [ ] `pnpm typecheck` (blocked locally: node_modules are not installed in this checkout)

## Notes
- This PR is intentionally split from the proxy usage bug fix to keep the feature review separate.