### PR TITLE
feat: add support for custom icons

### DIFF
--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -24,15 +24,17 @@ export const IconPicker: React.FC<IconPickerProps> = ({
     isHttpsIconUrl(value) ? (value ?? "") : "",
   );
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 250);
+  const trimmedQuery = searchQuery.trim();
   const debouncedTrimmedQuery = debouncedSearchQuery.trim();
+  const isSearchImageUrl = isHttpsIconUrl(trimmedQuery);
   const isImageUrl = isHttpsIconUrl(debouncedTrimmedQuery);
 
   // 过滤图标列表
   const filteredIcons = useMemo(() => {
-    if (isImageUrl) return [];
+    if (isSearchImageUrl) return [];
     if (!searchQuery) return iconList;
     return searchIcons(searchQuery);
-  }, [isImageUrl, searchQuery]);
+  }, [isSearchImageUrl, searchQuery]);
 
   return (
     <div className="space-y-4">
@@ -121,7 +123,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
         </div>
       )}
 
-      {!isImageUrl && filteredIcons.length === 0 && (
+      {!isSearchImageUrl && filteredIcons.length === 0 && (
         <div className="text-center py-8 text-muted-foreground">
           {t("iconPicker.noResults", { defaultValue: "未找到匹配的图标" })}
         </div>

--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -1,11 +1,13 @@
-import React, { useState, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ProviderIcon } from "./ProviderIcon";
 import { iconList } from "@/icons/extracted";
 import { searchIcons, getIconMetadata } from "@/icons/extracted/metadata";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { cn } from "@/lib/utils";
+import { isHttpsIconUrl } from "@/utils/iconUtils";
 
 interface IconPickerProps {
   value?: string; // 当前选中的图标
@@ -18,13 +20,32 @@ export const IconPicker: React.FC<IconPickerProps> = ({
   onValueChange,
 }) => {
   const { t } = useTranslation();
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(() =>
+    isHttpsIconUrl(value) ? (value ?? "") : "",
+  );
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, 250);
+  const debouncedTrimmedQuery = debouncedSearchQuery.trim();
+  const isImageUrl = isHttpsIconUrl(debouncedTrimmedQuery);
+
+  useEffect(() => {
+    if (isImageUrl) {
+      if (value !== debouncedTrimmedQuery) {
+        onValueChange(debouncedTrimmedQuery);
+      }
+      return;
+    }
+
+    if (!debouncedTrimmedQuery && isHttpsIconUrl(value)) {
+      onValueChange("");
+    }
+  }, [debouncedTrimmedQuery, isImageUrl, onValueChange, value]);
 
   // 过滤图标列表
   const filteredIcons = useMemo(() => {
+    if (isImageUrl) return [];
     if (!searchQuery) return iconList;
     return searchIcons(searchQuery);
-  }, [searchQuery]);
+  }, [isImageUrl, searchQuery]);
 
   return (
     <div className="space-y-4">
@@ -44,38 +65,61 @@ export const IconPicker: React.FC<IconPickerProps> = ({
         />
       </div>
 
-      <div className="max-h-[65vh] overflow-y-auto pr-1">
-        <div className="grid grid-cols-6 sm:grid-cols-8 lg:grid-cols-10 gap-2">
-          {filteredIcons.map((iconName) => {
-            const meta = getIconMetadata(iconName);
-            const isSelected = value === iconName;
+      {isImageUrl ? (
+        <button
+          type="button"
+          onClick={() => onValueChange(debouncedTrimmedQuery)}
+          className={cn(
+            "flex w-full items-center gap-3 rounded-lg border-2 p-3 text-left",
+            value === debouncedTrimmedQuery
+              ? "border-primary bg-primary/10"
+              : "border-transparent hover:bg-accent hover:border-primary/50",
+          )}
+          title={debouncedTrimmedQuery}
+        >
+          <ProviderIcon
+            icon={debouncedTrimmedQuery}
+            name={t("providerIcon.imageUrl", { defaultValue: "Image URL" })}
+            size={32}
+          />
+          <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+            {debouncedTrimmedQuery}
+          </span>
+        </button>
+      ) : (
+        <div className="max-h-[65vh] overflow-y-auto pr-1">
+          <div className="grid grid-cols-6 sm:grid-cols-8 lg:grid-cols-10 gap-2">
+            {filteredIcons.map((iconName) => {
+              const meta = getIconMetadata(iconName);
+              const isSelected = value === iconName;
 
-            return (
-              <button
-                key={iconName}
-                type="button"
-                onClick={() => onValueChange(iconName)}
-                className={cn(
-                  "flex flex-col items-center gap-1 p-3 rounded-lg",
-                  "border-2 transition-all duration-200",
-                  "hover:bg-accent hover:border-primary/50",
-                  isSelected
-                    ? "border-primary bg-primary/10"
-                    : "border-transparent",
-                )}
-                title={meta?.displayName || iconName}
-              >
-                <ProviderIcon icon={iconName} name={iconName} size={32} />
-                <span className="text-xs text-muted-foreground truncate w-full text-center">
-                  {meta?.displayName || iconName}
-                </span>
-              </button>
-            );
-          })}
+              return (
+                <button
+                  key={iconName}
+                  type="button"
+                  onClick={() => onValueChange(iconName)}
+                  className={cn(
+                    "flex flex-col items-center gap-1 p-3 rounded-lg",
+                    "border-2 transition-all duration-200",
+                    "hover:bg-accent hover:border-primary/50",
+                    isSelected
+                      ? "border-primary bg-primary/10"
+                      : "border-transparent",
+                  )}
+                  title={meta?.displayName || iconName}
+                >
+                  <ProviderIcon icon={iconName} name={iconName} size={32} />
+                  <span className="text-xs text-muted-foreground truncate w-full text-center">
+                    {meta?.displayName || iconName}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      )}
 
-      {filteredIcons.length === 0 && (
+      {!isImageUrl && filteredIcons.length === 0 && (
         <div className="text-center py-8 text-muted-foreground">
           {t("iconPicker.noResults", { defaultValue: "未找到匹配的图标" })}
         </div>

--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -29,6 +29,19 @@ export const IconPicker: React.FC<IconPickerProps> = ({
   const isSearchImageUrl = isHttpsIconUrl(trimmedQuery);
   const isImageUrl = isHttpsIconUrl(debouncedTrimmedQuery);
 
+  useEffect(() => {
+    if (isImageUrl) {
+      if (value !== debouncedTrimmedQuery) {
+        onValueChange(debouncedTrimmedQuery);
+      }
+      return;
+    }
+
+    if (!debouncedTrimmedQuery && isHttpsIconUrl(value)) {
+      onValueChange("");
+    }
+  }, [debouncedTrimmedQuery, isImageUrl, onValueChange, value]);
+
   // 过滤图标列表
   const filteredIcons = useMemo(() => {
     if (isSearchImageUrl) return [];
@@ -50,20 +63,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
           })}
           value={searchQuery}
           onChange={(e) => {
-            const nextValue = e.target.value;
-            const trimmedValue = nextValue.trim();
-            setSearchQuery(nextValue);
-
-            if (isHttpsIconUrl(trimmedValue)) {
-              if (value !== trimmedValue) {
-                onValueChange(trimmedValue);
-              }
-              return;
-            }
-
-            if (!trimmedValue && isHttpsIconUrl(value)) {
-              onValueChange("");
-            }
+            setSearchQuery(e.target.value);
           }}
           className="mt-2"
         />

--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,19 +27,6 @@ export const IconPicker: React.FC<IconPickerProps> = ({
   const debouncedTrimmedQuery = debouncedSearchQuery.trim();
   const isImageUrl = isHttpsIconUrl(debouncedTrimmedQuery);
 
-  useEffect(() => {
-    if (isImageUrl) {
-      if (value !== debouncedTrimmedQuery) {
-        onValueChange(debouncedTrimmedQuery);
-      }
-      return;
-    }
-
-    if (!debouncedTrimmedQuery && isHttpsIconUrl(value)) {
-      onValueChange("");
-    }
-  }, [debouncedTrimmedQuery, isImageUrl, onValueChange, value]);
-
   // 过滤图标列表
   const filteredIcons = useMemo(() => {
     if (isImageUrl) return [];
@@ -60,7 +47,22 @@ export const IconPicker: React.FC<IconPickerProps> = ({
             defaultValue: "输入图标名称...",
           })}
           value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
+          onChange={(e) => {
+            const nextValue = e.target.value;
+            const trimmedValue = nextValue.trim();
+            setSearchQuery(nextValue);
+
+            if (isHttpsIconUrl(trimmedValue)) {
+              if (value !== trimmedValue) {
+                onValueChange(trimmedValue);
+              }
+              return;
+            }
+
+            if (!trimmedValue && isHttpsIconUrl(value)) {
+              onValueChange("");
+            }
+          }}
           className="mt-2"
         />
       </div>

--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ProviderIcon } from "./ProviderIcon";
 import { iconList } from "@/icons/extracted";
 import { searchIcons, getIconMetadata } from "@/icons/extracted/metadata";
-import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { cn } from "@/lib/utils";
 import { isHttpsIconUrl } from "@/utils/iconUtils";
 
@@ -23,31 +22,31 @@ export const IconPicker: React.FC<IconPickerProps> = ({
   const [searchQuery, setSearchQuery] = useState(() =>
     isHttpsIconUrl(value) ? (value ?? "") : "",
   );
-  const debouncedSearchQuery = useDebouncedValue(searchQuery, 250);
   const trimmedQuery = searchQuery.trim();
-  const debouncedTrimmedQuery = debouncedSearchQuery.trim();
-  const isSearchImageUrl = isHttpsIconUrl(trimmedQuery);
-  const isImageUrl = isHttpsIconUrl(debouncedTrimmedQuery);
+  const isImageUrl = isHttpsIconUrl(trimmedQuery);
 
-  useEffect(() => {
-    if (isImageUrl) {
-      if (value !== debouncedTrimmedQuery) {
-        onValueChange(debouncedTrimmedQuery);
+  const handleSearchChange = (nextQuery: string) => {
+    setSearchQuery(nextQuery);
+
+    const nextTrimmedQuery = nextQuery.trim();
+    if (isHttpsIconUrl(nextTrimmedQuery)) {
+      if (value !== nextTrimmedQuery) {
+        onValueChange(nextTrimmedQuery);
       }
       return;
     }
 
-    if (!debouncedTrimmedQuery && isHttpsIconUrl(value)) {
+    if (!nextTrimmedQuery && isHttpsIconUrl(value)) {
       onValueChange("");
     }
-  }, [debouncedTrimmedQuery, isImageUrl, onValueChange, value]);
+  };
 
   // 过滤图标列表
   const filteredIcons = useMemo(() => {
-    if (isSearchImageUrl) return [];
+    if (isImageUrl) return [];
     if (!searchQuery) return iconList;
     return searchIcons(searchQuery);
-  }, [isSearchImageUrl, searchQuery]);
+  }, [isImageUrl, searchQuery]);
 
   return (
     <div className="space-y-4">
@@ -63,7 +62,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
           })}
           value={searchQuery}
           onChange={(e) => {
-            setSearchQuery(e.target.value);
+            handleSearchChange(e.target.value);
           }}
           className="mt-2"
         />
@@ -72,22 +71,22 @@ export const IconPicker: React.FC<IconPickerProps> = ({
       {isImageUrl ? (
         <button
           type="button"
-          onClick={() => onValueChange(debouncedTrimmedQuery)}
+          onClick={() => onValueChange(trimmedQuery)}
           className={cn(
             "flex w-full items-center gap-3 rounded-lg border-2 p-3 text-left",
-            value === debouncedTrimmedQuery
+            value === trimmedQuery
               ? "border-primary bg-primary/10"
               : "border-transparent hover:bg-accent hover:border-primary/50",
           )}
-          title={debouncedTrimmedQuery}
+          title={trimmedQuery}
         >
           <ProviderIcon
-            icon={debouncedTrimmedQuery}
+            icon={trimmedQuery}
             name={t("providerIcon.imageUrl", { defaultValue: "Image URL" })}
             size={32}
           />
           <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-            {debouncedTrimmedQuery}
+            {trimmedQuery}
           </span>
         </button>
       ) : (
@@ -123,7 +122,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
         </div>
       )}
 
-      {!isSearchImageUrl && filteredIcons.length === 0 && (
+      {!isImageUrl && filteredIcons.length === 0 && (
         <div className="text-center py-8 text-muted-foreground">
           {t("iconPicker.noResults", { defaultValue: "未找到匹配的图标" })}
         </div>

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -7,6 +7,7 @@ import {
   isUrlIcon,
 } from "@/icons/extracted";
 import { cn } from "@/lib/utils";
+import { isHttpsIconUrl } from "@/utils/iconUtils";
 
 interface ProviderIconProps {
   icon?: string; // 图标名称
@@ -35,6 +36,9 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
 
   // 获取图标 URL（URL_ICONS 列表中的 SVG / 光栅图片）
   const iconUrl = useMemo(() => {
+    if (isHttpsIconUrl(icon)) {
+      return icon;
+    }
     if (icon && isUrlIcon(icon)) {
       return getIconUrl(icon);
     }

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   getIcon,
   hasIcon,
@@ -26,6 +26,8 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
   className,
   showFallback = true,
 }) => {
+  const [imgError, setImgError] = useState(false);
+
   // 获取内联 SVG 字符串
   const iconSvg = useMemo(() => {
     if (icon && !isUrlIcon(icon) && hasIcon(icon)) {
@@ -44,6 +46,10 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
     }
     return "";
   }, [icon]);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [iconUrl]);
 
   // 计算尺寸样式
   const sizeStyle = useMemo(() => {
@@ -85,7 +91,7 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
   }
 
   // URL-based 图标（大型 SVG / 光栅图片）：以 <img> 渲染
-  if (iconUrl) {
+  if (iconUrl && !imgError) {
     return (
       <img
         src={iconUrl}
@@ -96,6 +102,7 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
         )}
         style={{ width: sizeStyle.width, height: sizeStyle.height }}
         loading="lazy"
+        onError={() => setImgError(true)}
       />
     );
   }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1895,7 +1895,7 @@
   },
   "iconPicker": {
     "search": "Search Icons",
-    "searchPlaceholder": "Enter icon name...",
+    "searchPlaceholder": "Search icon name or paste image URL...",
     "noResults": "No matching icons found",
     "category": {
       "aiProvider": "AI Providers",
@@ -1911,7 +1911,8 @@
     "preview": "Preview",
     "clickToChange": "Click to change icon",
     "clickToSelect": "Click to select icon",
-    "color": "Icon Color"
+    "color": "Icon Color",
+    "imageUrl": "Image URL"
   },
   "migration": {
     "success": "Configuration migrated successfully",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1895,7 +1895,7 @@
   },
   "iconPicker": {
     "search": "アイコンを検索",
-    "searchPlaceholder": "アイコン名を入力...",
+    "searchPlaceholder": "アイコン名を検索、または画像 URL を貼り付け...",
     "noResults": "一致するアイコンが見つかりません",
     "category": {
       "aiProvider": "AI プロバイダー",
@@ -1911,7 +1911,8 @@
     "preview": "プレビュー",
     "clickToChange": "クリックでアイコンを変更",
     "clickToSelect": "クリックでアイコンを選択",
-    "color": "アイコンカラー"
+    "color": "アイコンカラー",
+    "imageUrl": "画像 URL"
   },
   "migration": {
     "success": "設定の移行が完了しました",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1896,7 +1896,7 @@
   },
   "iconPicker": {
     "search": "搜索图标",
-    "searchPlaceholder": "输入图标名称...",
+    "searchPlaceholder": "搜索图标名称，或粘贴图片 URL...",
     "noResults": "未找到匹配的图标",
     "category": {
       "aiProvider": "AI 服务商",
@@ -1912,7 +1912,8 @@
     "preview": "预览",
     "clickToChange": "点击更换图标",
     "clickToSelect": "点击选择图标",
-    "color": "图标颜色"
+    "color": "图标颜色",
+    "imageUrl": "图片 URL"
   },
   "migration": {
     "success": "配置迁移成功",

--- a/src/lib/schemas/provider.ts
+++ b/src/lib/schemas/provider.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isHttpsIconUrl } from "@/utils/iconUtils";
 
 /**
  * 解析 JSON 语法错误，提取位置信息
@@ -53,7 +54,21 @@ export const providerSchema = z.object({
       }
     }),
   // 图标配置
-  icon: z.string().optional(),
+  icon: z
+    .string()
+    .optional()
+    .superRefine((value, ctx) => {
+      if (
+        value &&
+        /^[a-z][a-z0-9+.-]*:\/\//i.test(value) &&
+        !isHttpsIconUrl(value)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "图标图片 URL 仅支持 HTTPS",
+        });
+      }
+    }),
   iconColor: z.string().optional(),
 });
 

--- a/src/utils/iconUtils.ts
+++ b/src/utils/iconUtils.ts
@@ -1,0 +1,9 @@
+export function isHttpsIconUrl(value?: string): boolean {
+  if (!value) return false;
+
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/tests/components/IconPicker.test.tsx
+++ b/tests/components/IconPicker.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IconPicker } from "@/components/IconPicker";
+
+vi.mock("@/components/ProviderIcon", () => ({
+  ProviderIcon: ({ icon, name }: { icon?: string; name: string }) => (
+    <span data-icon={icon}>{name}</span>
+  ),
+}));
+
+vi.mock("@/icons/extracted", () => ({
+  iconList: ["claude", "openai"],
+}));
+
+vi.mock("@/icons/extracted/metadata", () => ({
+  getIconMetadata: (name: string) => ({
+    name,
+    displayName: name,
+    defaultColor: "currentColor",
+  }),
+  searchIcons: (query: string) =>
+    ["claude", "openai"].filter((name) => name.includes(query)),
+}));
+
+describe("IconPicker", () => {
+  it("commits a pasted custom icon URL before the picker unmounts", () => {
+    const onValueChange = vi.fn();
+    const customIconUrl = "https://cdn.example.com/provider-icon.png";
+    const { unmount } = render(
+      <IconPicker value="openai" onValueChange={onValueChange} />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: customIconUrl },
+    });
+    unmount();
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledWith(customIconUrl);
+  });
+
+  it("clears an existing custom icon URL before the picker unmounts", () => {
+    const onValueChange = vi.fn();
+    const customIconUrl = "https://cdn.example.com/provider-icon.png";
+    const { unmount } = render(
+      <IconPicker value={customIconUrl} onValueChange={onValueChange} />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "" },
+    });
+    unmount();
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledWith("");
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Add support for custom provider icons via image URLs in the icon picker.

Users can now paste an image URL into the existing icon search input. Built-in icon search continues to work as before, while valid HTTPS image URLs are rendered as provider icons with `<img>`. URL detection is debounced to avoid updating the icon on every keystroke.

## Related Issue / 关联 Issue

None

## Screenshots / 截图
|||
|---|---|
|<img width="1112" height="763" alt="image" src="https://github.com/user-attachments/assets/9243ae2c-6055-42b4-99a8-175dca395050" />|<img width="1112" height="763" alt="image" src="https://github.com/user-attachments/assets/bcd1e5df-e1fa-47b0-8b48-ee918c609ac8" />|

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| Icon picker only supported selecting from built-in icons. | Icon picker supports searching built-in icons and pasting an image URL in the same input. |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件