### PR TITLE
fix: prevent selecting theme from causing segfault on Linux

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { isLinux } from "@/lib/platform";
 import { invoke } from "@tauri-apps/api/core";
 
 type Theme = "light" | "dark" | "system";
@@ -147,7 +148,12 @@ export function ThemeProvider({
         );
 
         // Use View Transitions API if available, otherwise fall back to instant change
-        if (document.startViewTransition) {
+        // Disable for Linux, since WebKitGTK crashes on `document.startViewTransition`
+        if (
+          typeof document !== "undefined" &&
+          document.startViewTransition &&
+          !isLinux()
+        ) {
           document.startViewTransition(() => {
             setThemeState(nextTheme);
           });


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

Currently, selecting theme calls View Translation API at frontend, however this may cause WebKitGTK freezing for seconds and then crashing with SIGSEGV on Linux. This might be due to some incorrect handling logic between Tauri and WebKit.

Stacktrace caught by `coredumpctl`: [cc-switch.coredump.log](https://github.com/user-attachments/files/27266018/cc-switch.coredump.log)

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
