### PR TITLE
feat(opencode): support opencode.jsonc config files

### DIFF
--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -77,6 +77,8 @@ pub fn read_opencode_config() -> Result<Value, AppError> {
     })
 }
 
+/// Note: writes via `serde_json::to_string_pretty`, which strips comments
+/// and trailing commas from `.jsonc` files.
 pub fn write_opencode_config(config: &Value) -> Result<(), AppError> {
     let path = get_opencode_config_path();
     write_json_file(&path, config)?;
@@ -243,60 +245,80 @@ pub fn remove_plugins_by_prefixes(prefixes: &[&str]) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
 
-    fn setup_test_env() -> (TempDir, PathBuf) {
-        let temp_dir = TempDir::new().unwrap();
-        let opencode_dir = temp_dir.path().join(".config").join("opencode");
+    /// RAII helper that points `get_home_dir()` at a temp directory by
+    /// setting `CC_SWITCH_TEST_HOME` (the only env var the codebase honors —
+    /// see `config.rs` `get_home_dir`; `HOME` is intentionally *not* used
+    /// because it's unreliable on Windows). Saves and restores the prior
+    /// value via `OsString` so non-UTF-8 paths survive the round-trip.
+    struct TempHome {
+        dir: TempDir,
+        original_test_home: Option<std::ffi::OsString>,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let dir = TempDir::new().expect("failed to create temp home");
+            let original_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+            std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            Self {
+                dir,
+                original_test_home,
+            }
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            match &self.original_test_home {
+                Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+        }
+    }
+
+    fn setup_test_env() -> (TempHome, PathBuf) {
+        let home = TempHome::new();
+        let opencode_dir = home.dir.path().join(".config").join("opencode");
         fs::create_dir_all(&opencode_dir).unwrap();
-        (temp_dir, opencode_dir)
+        (home, opencode_dir)
     }
 
     #[test]
+    #[serial]
     fn test_read_opencode_config_prefers_jsonc() {
-        let (_temp, opencode_dir) = setup_test_env();
+        let (_home, opencode_dir) = setup_test_env();
 
-        // Create both .json and .jsonc files
         let json_path = opencode_dir.join("opencode.json");
         let jsonc_path = opencode_dir.join("opencode.jsonc");
 
         fs::write(&json_path, r#"{"provider": {"test-json": {}}}"#).unwrap();
         fs::write(&jsonc_path, r#"{"provider": {"test-jsonc": {}}}"#).unwrap();
 
-        // Set override dir to use temp directory
-        std::env::set_var("HOME", opencode_dir.parent().unwrap().parent().unwrap());
-
-        // Should prefer .jsonc file
         let path = get_opencode_config_path();
         assert!(path.ends_with("opencode.jsonc"));
-
-        // Clean up env var
-        std::env::remove_var("HOME");
     }
 
     #[test]
+    #[serial]
     fn test_read_opencode_config_fallback_to_json() {
-        let (_temp, opencode_dir) = setup_test_env();
+        let (_home, opencode_dir) = setup_test_env();
 
-        // Create only .json file
         let json_path = opencode_dir.join("opencode.json");
         fs::write(&json_path, r#"{"provider": {"test": {}}}"#).unwrap();
 
-        std::env::set_var("HOME", opencode_dir.parent().unwrap().parent().unwrap());
-
-        // Should fallback to .json file
         let path = get_opencode_config_path();
         assert!(path.ends_with("opencode.json"));
-
-        std::env::remove_var("HOME");
     }
 
     #[test]
+    #[serial]
     fn test_read_opencode_config_with_comments() {
-        let (_temp, opencode_dir) = setup_test_env();
+        let (_home, opencode_dir) = setup_test_env();
 
-        // Create .jsonc file with comments
         let jsonc_path = opencode_dir.join("opencode.jsonc");
         let config_with_comments = r#"{
             // This is a comment
@@ -311,9 +333,6 @@ mod tests {
         }"#;
         fs::write(&jsonc_path, config_with_comments).unwrap();
 
-        std::env::set_var("HOME", opencode_dir.parent().unwrap().parent().unwrap());
-
-        // Should successfully parse config with comments
         let config = read_opencode_config().unwrap();
         assert!(config.get("provider").is_some());
         assert!(config["provider"]
@@ -321,15 +340,13 @@ mod tests {
             .and_then(|p| p.get("apiKey"))
             .and_then(|k| k.as_str())
             == Some("test-key"));
-
-        std::env::remove_var("HOME");
     }
 
     #[test]
+    #[serial]
     fn test_read_opencode_config_trailing_commas() {
-        let (_temp, opencode_dir) = setup_test_env();
+        let (_home, opencode_dir) = setup_test_env();
 
-        // Create .jsonc file with trailing commas
         let jsonc_path = opencode_dir.join("opencode.jsonc");
         let config_with_trailing = r#"{
             "$schema": "https://opencode.ai/config.json",
@@ -342,12 +359,7 @@ mod tests {
         }"#;
         fs::write(&jsonc_path, config_with_trailing).unwrap();
 
-        std::env::set_var("HOME", opencode_dir.parent().unwrap().parent().unwrap());
-
-        // Should successfully parse config with trailing commas
         let config = read_opencode_config().unwrap();
         assert!(config.get("provider").is_some());
-
-        std::env::remove_var("HOME");
     }
 }

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -43,7 +43,15 @@ pub fn get_opencode_dir() -> PathBuf {
 }
 
 pub fn get_opencode_config_path() -> PathBuf {
-    get_opencode_dir().join("opencode.json")
+    let dir = get_opencode_dir();
+
+    // Prefer opencode.jsonc if it exists, fallback to opencode.json
+    let jsonc_path = dir.join("opencode.jsonc");
+    if jsonc_path.exists() {
+        return jsonc_path;
+    }
+
+    dir.join("opencode.json")
 }
 
 #[allow(dead_code)]
@@ -230,4 +238,116 @@ pub fn remove_plugins_by_prefixes(prefixes: &[&str]) -> Result<(), AppError> {
     }
 
     write_opencode_config(&config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn setup_test_env() -> (TempDir, PathBuf) {
+        let temp_dir = TempDir::new().unwrap();
+        let opencode_dir = temp_dir.path().join(".config").join("opencode");
+        fs::create_dir_all(&opencode_dir).unwrap();
+        (temp_dir, opencode_dir)
+    }
+
+    #[test]
+    fn test_read_opencode_config_prefers_jsonc() {
+        let (_temp, opencode_dir) = setup_test_env();
+
+        // Create both .json and .jsonc files
+        let json_path = opencode_dir.join("opencode.json");
+        let jsonc_path = opencode_dir.join("opencode.jsonc");
+
+        fs::write(&json_path, r#"{"provider": {"test-json": {}}}"#).unwrap();
+        fs::write(&jsonc_path, r#"{"provider": {"test-jsonc": {}}}"#).unwrap();
+
+        // Set override dir to use temp directory
+        std::env::set_var("HOME", opencode_dir.parent().unwrap().parent().unwrap());
+
+        // Should prefer .jsonc file
+        let path = get_opencode_config_path();
+        assert!(path.ends_with("opencode.jsonc"));
+
+        // Clean up env var
+        std::env::remove_var("HOME");
+    }
+
+    #[test]
+    fn test_read_opencode_config_fallback_to_json() {
+        let (_temp, opencode_dir) = setup_test_env();
+
+        // Create only .json file
+        let json_path = opencode_dir.join("opencode.json");
+        fs::write(&json_path, r#"{"provider": {"test": {}}}"#).unwrap();
+
+        std::env::set_var("HOME", opencode_dir.parent().unwrap().parent().unwrap());
+
+        // Should fallback to .json file
+        let path = get_opencode_config_path();
+        assert!(path.ends_with("opencode.json"));
+
+        std::env::remove_var("HOME");
+    }
+
+    #[test]
+    fn test_read_opencode_config_with_comments() {
+        let (_temp, opencode_dir) = setup_test_env();
+
+        // Create .jsonc file with comments
+        let jsonc_path = opencode_dir.join("opencode.jsonc");
+        let config_with_comments = r#"{
+            // This is a comment
+            "$schema": "https://opencode.ai/config.json",
+            /* Multi-line
+               comment */
+            "provider": {
+                "test-provider": {
+                    "apiKey": "test-key" // Inline comment
+                }
+            }
+        }"#;
+        fs::write(&jsonc_path, config_with_comments).unwrap();
+
+        std::env::set_var("HOME", opencode_dir.parent().unwrap().parent().unwrap());
+
+        // Should successfully parse config with comments
+        let config = read_opencode_config().unwrap();
+        assert!(config.get("provider").is_some());
+        assert!(config["provider"]
+            .get("test-provider")
+            .and_then(|p| p.get("apiKey"))
+            .and_then(|k| k.as_str())
+            == Some("test-key"));
+
+        std::env::remove_var("HOME");
+    }
+
+    #[test]
+    fn test_read_opencode_config_trailing_commas() {
+        let (_temp, opencode_dir) = setup_test_env();
+
+        // Create .jsonc file with trailing commas
+        let jsonc_path = opencode_dir.join("opencode.jsonc");
+        let config_with_trailing = r#"{
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+                "test-provider": {
+                    "apiKey": "test-key",
+                    "baseUrl": "https://api.example.com",
+                },
+            },
+        }"#;
+        fs::write(&jsonc_path, config_with_trailing).unwrap();
+
+        std::env::set_var("HOME", opencode_dir.parent().unwrap().parent().unwrap());
+
+        // Should successfully parse config with trailing commas
+        let config = read_opencode_config().unwrap();
+        assert!(config.get("provider").is_some());
+
+        std::env::remove_var("HOME");
+    }
 }


### PR DESCRIPTION
## Summary / 概述
Add support for opencode.jsonc to get_opencode_config_path(); when both opencode.json and opencode.jsonc exist, prefer opencode.jsonc, otherwise fall back to opencode.json. Restores the JSONC portion from [#1279](https://github.com/farion1231/cc-switch/pull/1279) (sosyz, 6c72a23) that was not merged due to a force push.
在 get_opencode_config_path() 新增 opencode.jsonc 支持，如果 opencode.json 同时存在时，优先选择 opencode.jsonc，否则回退到 opencode.json。恢复了 https://github.com/farion1231/cc-switch/pull/1279 (sosyz, 6c72a23) 中，由于被 force push 导致该PR 未合并的 JSONC 部分。

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue
Fixed https://github.com/farion1231/cc-switch/issues/2521
Ref https://github.com/farion1231/cc-switch/pull/1279
<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
