### PR TITLE
fix(lightweight): persist lightweight-mode preference across sessions

### DIFF
--- a/src-tauri/src/commands/lightweight.rs
+++ b/src-tauri/src/commands/lightweight.rs
@@ -1,14 +1,14 @@
 #[tauri::command]
 pub fn enter_lightweight_mode(app: tauri::AppHandle) -> Result<(), String> {
-    crate::lightweight::enter_lightweight_mode(&app)
+    crate::lightweight::set_lightweight_preference(&app, true)
 }
 
 #[tauri::command]
 pub fn exit_lightweight_mode(app: tauri::AppHandle) -> Result<(), String> {
-    crate::lightweight::exit_lightweight_mode(&app)
+    crate::lightweight::set_lightweight_preference(&app, false)
 }
 
 #[tauri::command]
 pub fn is_lightweight_mode() -> bool {
-    crate::lightweight::is_lightweight_mode()
+    crate::lightweight::is_lightweight_preferred()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -213,9 +213,10 @@ pub fn run() {
                 log::debug!("  arg[{i}]: {}", redact_url_for_log(arg));
             }
 
-            if crate::lightweight::is_lightweight_mode() {
-                if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
-                    log::error!("退出轻量模式重建窗口失败: {e}");
+            // 第二实例触发：仅恢复主窗口，保留用户偏好
+            if crate::lightweight::is_lightweight_runtime() {
+                if let Err(e) = crate::lightweight::exit_lightweight_runtime(app) {
+                    log::error!("退出轻量运行期重建窗口失败: {e}");
                 }
             }
 
@@ -253,7 +254,15 @@ pub fn run() {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 let settings = crate::settings::get_settings();
 
-                if settings.minimize_to_tray_on_close {
+                if settings.lightweight_mode {
+                    // 偏好为轻量：进入轻量运行期（销毁窗口、隐藏 dock），偏好保持
+                    api.prevent_close();
+                    if let Err(e) =
+                        crate::lightweight::enter_lightweight_runtime(window.app_handle())
+                    {
+                        log::error!("关窗口时进入轻量运行期失败: {e}");
+                    }
+                } else if settings.minimize_to_tray_on_close {
                     api.prevent_close();
                     let _ = window.hide();
                     #[cfg(target_os = "windows")]
@@ -732,9 +741,10 @@ pub fn run() {
                     let urls = event.urls();
                     log::info!("Received {} URL(s)", urls.len());
 
-                    if crate::lightweight::is_lightweight_mode() {
-                        if let Err(e) = crate::lightweight::exit_lightweight_mode(&app_handle) {
-                            log::error!("退出轻量模式重建窗口失败: {e}");
+                    // Deep link 唤起：仅恢复运行期窗口，偏好保持
+                    if crate::lightweight::is_lightweight_runtime() {
+                        if let Err(e) = crate::lightweight::exit_lightweight_runtime(&app_handle) {
+                            log::error!("退出轻量运行期重建窗口失败: {e}");
                         }
                     }
 
@@ -1003,7 +1013,15 @@ pub fn run() {
                 // 仅 Linux 生效：解决 Wayland 下系统窗口按钮不可用的问题
                 #[cfg(target_os = "linux")]
                 let _ = window.set_decorations(!settings.use_app_window_controls);
-                if settings.silent_startup {
+                if settings.lightweight_mode {
+                    // 用户偏好轻量：直接进入轻量运行期（销毁主窗口、隐藏 dock）
+                    // 优先级高于 silent_startup，因为轻量模式更激进
+                    if let Err(e) = crate::lightweight::enter_lightweight_runtime(app.handle()) {
+                        log::error!("启动时进入轻量运行期失败：{e}");
+                    } else {
+                        log::info!("轻量运行期：跟随用户偏好启动");
+                    }
+                } else if settings.silent_startup {
                     // 静默启动模式：保持窗口隐藏
                     let _ = window.hide();
                     #[cfg(target_os = "windows")]
@@ -1377,9 +1395,10 @@ pub fn run() {
                         let _ = window.show();
                         let _ = window.set_focus();
                         tray::apply_tray_policy(app_handle, true);
-                    } else if crate::lightweight::is_lightweight_mode() {
-                        if let Err(e) = crate::lightweight::exit_lightweight_mode(app_handle) {
-                            log::error!("退出轻量模式重建窗口失败: {e}");
+                    } else if crate::lightweight::is_lightweight_runtime() {
+                        // Reopen（点 dock / Spotlight 唤起）：仅恢复运行期窗口，偏好保持
+                        if let Err(e) = crate::lightweight::exit_lightweight_runtime(app_handle) {
+                            log::error!("退出轻量运行期重建窗口失败: {e}");
                         }
                     }
                 }
@@ -1390,10 +1409,12 @@ pub fn run() {
                         log::info!("RunEvent::Opened with URL: {url_str}");
 
                         if url_str.starts_with("ccswitch://") {
-                            if crate::lightweight::is_lightweight_mode() {
-                                if let Err(e) = crate::lightweight::exit_lightweight_mode(app_handle)
+                            // Deep link 唤起：仅恢复运行期窗口，偏好保持
+                            if crate::lightweight::is_lightweight_runtime() {
+                                if let Err(e) =
+                                    crate::lightweight::exit_lightweight_runtime(app_handle)
                                 {
-                                    log::error!("退出轻量模式重建窗口失败: {e}");
+                                    log::error!("退出轻量运行期重建窗口失败: {e}");
                                 }
                             }
 

--- a/src-tauri/src/lightweight.rs
+++ b/src-tauri/src/lightweight.rs
@@ -2,9 +2,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use tauri::Manager;
 
-static LIGHTWEIGHT_MODE: AtomicBool = AtomicBool::new(false);
+/// 运行期是否处于轻量状态（主窗口已销毁）。仅内存，进程级。
+static LIGHTWEIGHT_RUNTIME: AtomicBool = AtomicBool::new(false);
 
-pub fn enter_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
+// ===== 运行期：仅操作窗口/dock，不修改用户偏好 =====
+
+/// 进入轻量运行期：销毁主窗口、隐藏 dock。
+///
+/// 不会写偏好；调用方负责决定是否同时持久化偏好。
+pub fn enter_lightweight_runtime(app: &tauri::AppHandle) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         if let Some(window) = app.get_webview_window("main") {
@@ -22,15 +28,17 @@ pub fn enter_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
             .destroy()
             .map_err(|e| format!("销毁主窗口失败: {e}"))?;
     }
-    // else: already in lightweight mode or window not found, just set the flag
+    // else: 窗口已不存在，仅同步标志位
 
-    LIGHTWEIGHT_MODE.store(true, Ordering::Release);
-    crate::tray::refresh_tray_menu(app);
-    log::info!("进入轻量模式");
+    LIGHTWEIGHT_RUNTIME.store(true, Ordering::Release);
+    log::info!("进入轻量运行期");
     Ok(())
 }
 
-pub fn exit_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
+/// 退出轻量运行期：恢复主窗口与 dock 图标。
+///
+/// 不会写偏好；调用方负责决定是否同时持久化偏好。
+pub fn exit_lightweight_runtime(app: &tauri::AppHandle) -> Result<(), String> {
     use tauri::WebviewWindowBuilder;
 
     if let Some(window) = app.get_webview_window("main") {
@@ -49,9 +57,8 @@ pub fn exit_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
         {
             crate::tray::apply_tray_policy(app, true);
         }
-        LIGHTWEIGHT_MODE.store(false, Ordering::Release);
-        crate::tray::refresh_tray_menu(app);
-        log::info!("退出轻量模式");
+        LIGHTWEIGHT_RUNTIME.store(false, Ordering::Release);
+        log::info!("退出轻量运行期");
         return Ok(());
     }
 
@@ -89,12 +96,37 @@ pub fn exit_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
         crate::tray::apply_tray_policy(app, true);
     }
 
-    LIGHTWEIGHT_MODE.store(false, Ordering::Release);
-    crate::tray::refresh_tray_menu(app);
-    log::info!("退出轻量模式");
+    LIGHTWEIGHT_RUNTIME.store(false, Ordering::Release);
+    log::info!("退出轻量运行期");
     Ok(())
 }
 
-pub fn is_lightweight_mode() -> bool {
-    LIGHTWEIGHT_MODE.load(Ordering::Acquire)
+pub fn is_lightweight_runtime() -> bool {
+    LIGHTWEIGHT_RUNTIME.load(Ordering::Acquire)
+}
+
+// ===== 偏好：持久化在 settings.json 中 =====
+
+/// 用户是否偏好轻量模式（持久化）。
+pub fn is_lightweight_preferred() -> bool {
+    crate::settings::get_lightweight_mode_persisted()
+}
+
+/// 写入轻量模式偏好，并把运行期状态同步到偏好。
+///
+/// - 偏好开启且当前不在运行期：进入运行期。
+/// - 偏好关闭且当前在运行期：退出运行期。
+/// - 写盘失败时仍尝试同步运行期，但返回错误以便调用方告警。
+pub fn set_lightweight_preference(app: &tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let persist_result = crate::settings::set_lightweight_mode_persisted(enabled)
+        .map_err(|e| format!("持久化轻量模式偏好失败: {e}"));
+
+    if enabled && !is_lightweight_runtime() {
+        enter_lightweight_runtime(app)?;
+    } else if !enabled && is_lightweight_runtime() {
+        exit_lightweight_runtime(app)?;
+    }
+
+    crate::tray::refresh_tray_menu(app);
+    persist_result
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -193,6 +193,10 @@ pub struct AppSettings {
     /// 静默启动（程序启动时不显示主窗口，仅托盘运行）
     #[serde(default)]
     pub silent_startup: bool,
+    /// 轻量模式偏好：用户是否选择默认以轻量模式（销毁主窗口、隐藏 dock）运行
+    /// 由托盘 ✓ 切换；运行期状态独立维护于 `lightweight::LIGHTWEIGHT_RUNTIME`，两者互不污染
+    #[serde(default)]
+    pub lightweight_mode: bool,
     /// 是否在主页面启用本地代理功能（默认关闭）
     #[serde(default)]
     pub enable_local_proxy: bool,
@@ -309,6 +313,7 @@ impl Default for AppSettings {
             skip_claude_onboarding: false,
             launch_on_startup: false,
             silent_startup: false,
+            lightweight_mode: false,
             enable_local_proxy: false,
             proxy_confirmed: None,
             usage_confirmed: None,
@@ -512,11 +517,15 @@ pub fn get_settings_for_frontend() -> AppSettings {
         sync.password.clear();
     }
     settings.webdav_backup = None;
+    // 轻量模式偏好由托盘切换独占维护，前端不应感知/写回
+    settings.lightweight_mode = false;
     settings
 }
 
 pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
     new_settings.normalize_paths();
+    // 轻量模式偏好由托盘切换流程独占维护，避免前端 save_settings 携带过期值时回写 false
+    new_settings.lightweight_mode = get_lightweight_mode_persisted();
     save_settings_file(&new_settings)?;
 
     let mut guard = settings_store().write().unwrap_or_else(|e| {
@@ -670,6 +679,26 @@ pub fn get_effective_current_provider(
 
     // Fallback 到数据库的 is_current
     db.get_current_provider(app_type.as_str())
+}
+
+// ===== 轻量模式状态持久化 =====
+
+/// 读取上次会话结束时的轻量模式状态
+pub fn get_lightweight_mode_persisted() -> bool {
+    settings_store()
+        .read()
+        .unwrap_or_else(|e| {
+            log::warn!("设置锁已毒化，使用恢复值: {e}");
+            e.into_inner()
+        })
+        .lightweight_mode
+}
+
+/// 持久化轻量模式状态。失败不应阻断模式切换本身，调用方仅记录 warn。
+pub fn set_lightweight_mode_persisted(enabled: bool) -> Result<(), AppError> {
+    mutate_settings(|s| {
+        s.lightweight_mode = enabled;
+    })
 }
 
 // ===== Skill 同步方式管理函数 =====

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -569,7 +569,7 @@ pub fn create_tray_menu(
         "lightweight_mode",
         tray_texts.lightweight_mode,
         true,
-        crate::lightweight::is_lightweight_mode(),
+        crate::lightweight::is_lightweight_preferred(),
         None::<&str>,
     )
     .map_err(|e| AppError::Message(format!("创建轻量模式菜单失败: {e}")))?;
@@ -684,19 +684,18 @@ pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
                 {
                     apply_tray_policy(app, true);
                 }
-            } else if crate::lightweight::is_lightweight_mode() {
-                if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
-                    log::error!("退出轻量模式重建窗口失败: {e}");
+            } else if crate::lightweight::is_lightweight_runtime() {
+                // "打开主界面" 仅退出运行期，保留用户的轻量模式偏好
+                if let Err(e) = crate::lightweight::exit_lightweight_runtime(app) {
+                    log::error!("退出轻量运行期失败: {e}");
                 }
             }
         }
         "lightweight_mode" => {
-            if crate::lightweight::is_lightweight_mode() {
-                if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
-                    log::error!("退出轻量模式失败: {e}");
-                }
-            } else if let Err(e) = crate::lightweight::enter_lightweight_mode(app) {
-                log::error!("进入轻量模式失败: {e}");
+            // 切换偏好；set_lightweight_preference 会同步运行期并刷新菜单
+            let next = !crate::lightweight::is_lightweight_preferred();
+            if let Err(e) = crate::lightweight::set_lightweight_preference(app, next) {
+                log::error!("切换轻量模式偏好失败: {e}");
             }
         }
         "quit" => {


### PR DESCRIPTION
## Summary

修复轻量模式（Lightweight Mode）的两个相关问题：

1. **偏好不持久化** — 托盘"轻量模式"开关在每次重启后被重置为 false。从用户视角看是一个看似带 ✓ 标记的"持久开关"，实际却只在当前会话生效。
2. **临时打开窗口会清除偏好** — 托盘"打开主界面"、macOS Reopen（点 dock）、单实例唤起、deep link 等任何"重新看一眼窗口"的动作都会把偏好一起清掉，导致下次关窗口/重启不再是轻量模式。

根因：`LIGHTWEIGHT_MODE` 一个 `AtomicBool` 同时承担"运行期是否处于轻量"和"用户是否偏好轻量"两个不同的概念，且没有持久化。

## What Changed

把这两个概念彻底拆开：

| 概念 | 存储 | 谁能改 |
|---|---|---|
| 偏好 `lightweight_mode` | `~/.cc-switch/settings.json`（设备级） | 仅托盘 ✓ 轻量模式开关 |
| 运行期 `LIGHTWEIGHT_RUNTIME` | AtomicBool（内存） | 启动 / 关窗口 / 打开主界面 / Reopen / deep link |

`lightweight.rs` 拆分为：
- `enter_lightweight_runtime` / `exit_lightweight_runtime`：仅操作窗口与 dock
- `is_lightweight_runtime`：当前运行期状态
- `set_lightweight_preference`：写偏好 + 同步运行期 + 刷新菜单
- `is_lightweight_preferred`：读偏好

并修正各调用点的语义：

- 启动时若偏好=true → 进入轻量运行期（优先级高于 `silent_startup`）
- `WindowEvent::CloseRequested`：偏好=true 时关窗口直接进入轻量运行期，否则沿用 `minimize_to_tray_on_close`
- 托盘"打开主界面"、macOS Reopen、单实例、deep link → 仅 `exit_lightweight_runtime`，**不动偏好**
- 托盘 ✓ checkmark 改为反映偏好（即使临时调出窗口看，✓ 仍亮着）

防御前端污染：`get_settings_for_frontend` 把 `lightweightMode` 抹零，`update_settings` 保留磁盘上的真值，避免 `save_settings` 携带过期值时回写 false。

Tauri 命令名（`enter_lightweight_mode` / `exit_lightweight_mode` / `is_lightweight_mode`）保留不变以维护 IPC 稳定性，但语义改为读写偏好。

## Test plan

- [x] `cargo fmt`
- [x] `cargo check`
- [x] `cargo clippy --lib --bins`
- [x] `cargo test --lib settings::`（4/4 passed）
- 手动验证（macOS Apple Silicon）：
  - [x] 托盘 ✓ 轻量模式 → `~/.cc-switch/settings.json` 中 `lightweightMode: true`
  - [x] 托盘"打开主界面" → 主窗口出现，但 ✓ 仍亮，`lightweightMode` 仍为 `true`
  - [x] 关闭主窗口（X / Cmd+W）→ 销毁窗口、隐藏 dock，回到轻量运行期（不是 hide）
  - [x] 退出应用 → 重启 → 直接进入轻量模式（无窗口、无 dock）
  - [x] 托盘 ✓ 取消勾选 → 主窗口立即出现 + dock 图标恢复 + 文件写为 `false`
  - [x] `open -a cc-switch`（已运行时）→ 窗口出现但偏好仍为 `true`，下次关窗口仍回轻量
- 不影响：偏好=false 时所有路径行为完全不变（`silent_startup` / `minimize_to_tray_on_close` 等）

## Notes

- 无前端改动；TypeScript 类型也无需新增字段
- 无需 migration：缺失 `lightweightMode` 字段的旧 settings.json 会按 `#[serde(default)]` 落到 `false`
- 主要测试平台为 macOS Apple Silicon；Windows/Linux 路径沿用既有 `set_skip_taskbar` / Linux fix 逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)