### PR TITLE
fix(proxy): include input in streamed tool starts

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -450,7 +450,8 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                                         "content_block": {
                                                             "type": "tool_use",
                                                             "id": id,
-                                                            "name": name
+                                                            "name": name,
+                                                            "input": {}
                                                         }
                                                     });
                                                     let sse_data = format!("event: content_block_start\ndata: {}\n\n",
@@ -558,7 +559,8 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                                     "content_block": {
                                                         "type": "tool_use",
                                                         "id": id,
-                                                        "name": name
+                                                        "name": name,
+                                                        "input": {}
                                                     }
                                                 });
                                                 let sse_data = format!("event: content_block_start\ndata: {}\n\n",

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -779,6 +779,15 @@ mod tests {
         }
 
         assert_eq!(tool_index_by_call.len(), 2);
+        for event in events.iter().filter(|event| {
+            event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                && event
+                    .pointer("/content_block/type")
+                    .and_then(|v| v.as_str())
+                    == Some("tool_use")
+        }) {
+            assert_eq!(event["content_block"]["input"], json!({}));
+        }
         assert_ne!(
             tool_index_by_call.get("call_0"),
             tool_index_by_call.get("call_1")
@@ -875,6 +884,7 @@ mod tests {
                 .unwrap_or(""),
             "first_tool"
         );
+        assert_eq!(starts[0]["content_block"]["input"], json!({}));
 
         let deltas: Vec<&str> = events
             .iter()

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -782,6 +782,15 @@ mod tests {
         }
 
         assert_eq!(tool_index_by_call.len(), 2);
+        for event in events.iter().filter(|event| {
+            event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                && event
+                    .pointer("/content_block/type")
+                    .and_then(|v| v.as_str())
+                    == Some("tool_use")
+        }) {
+            assert_eq!(event["content_block"]["input"], json!({}));
+        }
         assert_ne!(
             tool_index_by_call.get("call_0"),
             tool_index_by_call.get("call_1")
@@ -878,6 +887,7 @@ mod tests {
                 .unwrap_or(""),
             "first_tool"
         );
+        assert_eq!(starts[0]["content_block"]["input"], json!({}));
 
         let deltas: Vec<&str> = events
             .iter()

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -452,7 +452,8 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                                             "content_block": {
                                                                 "type": "tool_use",
                                                                 "id": id,
-                                                                "name": name
+                                                                "name": name,
+                                                                "input": {}
                                                             }
                                                         });
                                                         let sse_data = format!("event: content_block_start\ndata: {}\n\n",
@@ -561,7 +562,8 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                                     "content_block": {
                                                         "type": "tool_use",
                                                         "id": id,
-                                                        "name": name
+                                                        "name": name,
+                                                        "input": {}
                                                     }
                                                 });
                                                 let sse_data = format!("event: content_block_start\ndata: {}\n\n",

--- a/src-tauri/src/proxy/providers/streaming_gemini.rs
+++ b/src-tauri/src/proxy/providers/streaming_gemini.rs
@@ -654,7 +654,9 @@ mod tests {
         let events: Vec<Value> = output
             .split("\n\n")
             .filter_map(|block| {
-                let data = block.lines().find_map(|line| strip_sse_field(line, "data"))?;
+                let data = block
+                    .lines()
+                    .find_map(|line| strip_sse_field(line, "data"))?;
                 serde_json::from_str::<Value>(data).ok()
             })
             .collect();

--- a/src-tauri/src/proxy/providers/streaming_gemini.rs
+++ b/src-tauri/src/proxy/providers/streaming_gemini.rs
@@ -651,9 +651,26 @@ mod tests {
             "data: {\"responseId\":\"resp_2\",\"modelVersion\":\"gemini-2.5-pro\",\"candidates\":[{\"finishReason\":\"STOP\",\"content\":{\"parts\":[{\"functionCall\":{\"id\":\"call_1\",\"name\":\"get_weather\",\"args\":{\"city\":\"Tokyo\"}},\"thoughtSignature\":\"sig-1\"}]}}],\"usageMetadata\":{\"promptTokenCount\":5,\"totalTokenCount\":8}}\n\n",
         ]);
 
-        assert!(output.contains("\"type\":\"tool_use\""));
-        assert!(output.contains("\"name\":\"get_weather\""));
-        assert!(output.contains("\"input\":{}"));
+        let events: Vec<Value> = output
+            .split("\n\n")
+            .filter_map(|block| {
+                let data = block.lines().find_map(|line| strip_sse_field(line, "data"))?;
+                serde_json::from_str::<Value>(data).ok()
+            })
+            .collect();
+        let tool_start = events
+            .iter()
+            .find(|event| {
+                event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                    && event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
+                        == Some("tool_use")
+            })
+            .unwrap();
+
+        assert_eq!(tool_start["content_block"]["name"], json!("get_weather"));
+        assert_eq!(tool_start["content_block"]["input"], json!({}));
         assert!(output.contains("\"type\":\"input_json_delta\""));
         assert!(output.contains("\"stop_reason\":\"tool_use\""));
     }

--- a/src-tauri/src/proxy/providers/streaming_gemini.rs
+++ b/src-tauri/src/proxy/providers/streaming_gemini.rs
@@ -653,6 +653,7 @@ mod tests {
 
         assert!(output.contains("\"type\":\"tool_use\""));
         assert!(output.contains("\"name\":\"get_weather\""));
+        assert!(output.contains("\"input\":{}"));
         assert!(output.contains("\"type\":\"input_json_delta\""));
         assert!(output.contains("\"stop_reason\":\"tool_use\""));
     }

--- a/src-tauri/src/proxy/providers/streaming_gemini.rs
+++ b/src-tauri/src/proxy/providers/streaming_gemini.rs
@@ -530,7 +530,8 @@ pub fn create_anthropic_sse_stream_from_gemini<E: std::error::Error + Send + 'st
                 "content_block": {
                     "type": "tool_use",
                     "id": tool_call.id.clone().unwrap_or_default(),
-                    "name": tool_call.name
+                    "name": tool_call.name,
+                    "input": {}
                 }
             });
             yield Ok(encode_sse("content_block_start", &start_event));

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -1036,6 +1036,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_streaming_responses_tool_start_normal_path_includes_empty_input() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_tool\",\"model\":\"gpt-4o\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"get_weather\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"{\\\"city\\\":\\\"Tokyo\\\"}\"}\n\n",
+            "event: response.function_call_arguments.done\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_1\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
+            input.as_bytes().to_vec(),
+        ))]);
+        let converted = create_anthropic_sse_stream_from_responses(upstream);
+        let chunks: Vec<_> = converted.collect().await;
+        let events: Vec<Value> = chunks
+            .into_iter()
+            .flat_map(|chunk| {
+                let bytes = chunk.unwrap();
+                let text = String::from_utf8_lossy(bytes.as_ref()).to_string();
+                text.split("\n\n")
+                    .filter_map(|block| {
+                        block.lines().find_map(|line| {
+                            strip_sse_field(line, "data")
+                                .and_then(|payload| serde_json::from_str::<Value>(payload).ok())
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        let tool_start = events
+            .iter()
+            .find(|event| {
+                event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                    && event.pointer("/content_block/type").and_then(|v| v.as_str())
+                        == Some("tool_use")
+            })
+            .unwrap();
+        assert_eq!(tool_start["content_block"]["input"], json!({}));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_responses_tool_start_fallback_path_includes_empty_input() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_tool\",\"model\":\"gpt-4o\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"get_weather\",\"delta\":\"{\\\"city\\\":\"}\n\n",
+            "event: response.function_call_arguments.done\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_1\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
+            input.as_bytes().to_vec(),
+        ))]);
+        let converted = create_anthropic_sse_stream_from_responses(upstream);
+        let chunks: Vec<_> = converted.collect().await;
+        let events: Vec<Value> = chunks
+            .into_iter()
+            .flat_map(|chunk| {
+                let bytes = chunk.unwrap();
+                let text = String::from_utf8_lossy(bytes.as_ref()).to_string();
+                text.split("\n\n")
+                    .filter_map(|block| {
+                        block.lines().find_map(|line| {
+                            strip_sse_field(line, "data")
+                                .and_then(|payload| serde_json::from_str::<Value>(payload).ok())
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        let tool_start = events
+            .iter()
+            .find(|event| {
+                event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                    && event.pointer("/content_block/type").and_then(|v| v.as_str())
+                        == Some("tool_use")
+            })
+            .unwrap();
+        assert_eq!(tool_start["content_block"]["input"], json!({}));
+    }
+
+    #[tokio::test]
     async fn test_streaming_responses_chinese_split_across_chunks_no_replacement_chars() {
         // Chinese text delta split across two TCP chunks.
         let full = concat!(

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -1075,7 +1075,9 @@ mod tests {
             .iter()
             .find(|event| {
                 event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
-                    && event.pointer("/content_block/type").and_then(|v| v.as_str())
+                    && event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
                         == Some("tool_use")
             })
             .unwrap();
@@ -1120,7 +1122,9 @@ mod tests {
             .iter()
             .find(|event| {
                 event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
-                    && event.pointer("/content_block/type").and_then(|v| v.as_str())
+                    && event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
                         == Some("tool_use")
             })
             .unwrap();

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -425,7 +425,8 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                             "content_block": {
                                                 "type": "tool_use",
                                                 "id": call_id,
-                                                "name": name
+                                                "name": name,
+                                                "input": {}
                                             }
                                         });
                                         let sse = format!("event: content_block_start\ndata: {}\n\n",
@@ -473,7 +474,8 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                                 "name": data
                                                     .get("name")
                                                     .and_then(|v| v.as_str())
-                                                    .unwrap_or("")
+                                                    .unwrap_or(""),
+                                                "input": {}
                                             }
                                         });
                                         let start_sse = format!("event: content_block_start\ndata: {}\n\n",

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -1184,7 +1184,9 @@ mod tests {
             .iter()
             .find(|event| {
                 event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
-                    && event.pointer("/content_block/type").and_then(|v| v.as_str())
+                    && event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
                         == Some("tool_use")
             })
             .unwrap();
@@ -1229,7 +1231,9 @@ mod tests {
             .iter()
             .find(|event| {
                 event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
-                    && event.pointer("/content_block/type").and_then(|v| v.as_str())
+                    && event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
                         == Some("tool_use")
             })
             .unwrap();

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -433,7 +433,8 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                             "content_block": {
                                                 "type": "tool_use",
                                                 "id": call_id,
-                                                "name": name
+                                                "name": name,
+                                                "input": {}
                                             }
                                         });
                                         let sse = format!("event: content_block_start\ndata: {}\n\n",
@@ -481,7 +482,8 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                                 "name": data
                                                     .get("name")
                                                     .and_then(|v| v.as_str())
-                                                    .unwrap_or("")
+                                                    .unwrap_or(""),
+                                                "input": {}
                                             }
                                         });
                                         let start_sse = format!("event: content_block_start\ndata: {}\n\n",

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -1145,6 +1145,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_streaming_responses_tool_start_normal_path_includes_empty_input() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_tool\",\"model\":\"gpt-4o\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"get_weather\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"{\\\"city\\\":\\\"Tokyo\\\"}\"}\n\n",
+            "event: response.function_call_arguments.done\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_1\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
+            input.as_bytes().to_vec(),
+        ))]);
+        let converted = create_anthropic_sse_stream_from_responses(upstream);
+        let chunks: Vec<_> = converted.collect().await;
+        let events: Vec<Value> = chunks
+            .into_iter()
+            .flat_map(|chunk| {
+                let bytes = chunk.unwrap();
+                let text = String::from_utf8_lossy(bytes.as_ref()).to_string();
+                text.split("\n\n")
+                    .filter_map(|block| {
+                        block.lines().find_map(|line| {
+                            strip_sse_field(line, "data")
+                                .and_then(|payload| serde_json::from_str::<Value>(payload).ok())
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        let tool_start = events
+            .iter()
+            .find(|event| {
+                event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                    && event.pointer("/content_block/type").and_then(|v| v.as_str())
+                        == Some("tool_use")
+            })
+            .unwrap();
+        assert_eq!(tool_start["content_block"]["input"], json!({}));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_responses_tool_start_fallback_path_includes_empty_input() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_tool\",\"model\":\"gpt-4o\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"get_weather\",\"delta\":\"{\\\"city\\\":\"}\n\n",
+            "event: response.function_call_arguments.done\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_1\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
+            input.as_bytes().to_vec(),
+        ))]);
+        let converted = create_anthropic_sse_stream_from_responses(upstream);
+        let chunks: Vec<_> = converted.collect().await;
+        let events: Vec<Value> = chunks
+            .into_iter()
+            .flat_map(|chunk| {
+                let bytes = chunk.unwrap();
+                let text = String::from_utf8_lossy(bytes.as_ref()).to_string();
+                text.split("\n\n")
+                    .filter_map(|block| {
+                        block.lines().find_map(|line| {
+                            strip_sse_field(line, "data")
+                                .and_then(|payload| serde_json::from_str::<Value>(payload).ok())
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        let tool_start = events
+            .iter()
+            .find(|event| {
+                event.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                    && event.pointer("/content_block/type").and_then(|v| v.as_str())
+                        == Some("tool_use")
+            })
+            .unwrap();
+        assert_eq!(tool_start["content_block"]["input"], json!({}));
+    }
+
+    #[tokio::test]
     async fn test_streaming_responses_chinese_split_across_chunks_no_replacement_chars() {
         // Chinese text delta split across two TCP chunks.
         let full = concat!(


### PR DESCRIPTION
## Summary
- Add empty `input: {}` objects to streamed Anthropic `tool_use` `content_block_start` events
- Cover OpenAI-compatible streaming, Responses streaming, and Gemini streaming conversion paths
- Prevent clients from receiving malformed streaming tool blocks before argument deltas arrive

Closes #2556

## Test plan
- [ ] GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)