### PR TITLE
feat(codex-encryp-cont-retry): add a feature in api error handling

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -299,3 +299,23 @@ pub async fn set_log_config(
     );
     Ok(true)
 }
+
+/// 获取 encrypted_content 剥离开关状态（默认 true）
+#[tauri::command]
+pub async fn get_strip_encrypted_content_enabled(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<bool, String> {
+    let value = state.db.get_setting("strip_encrypted_content_enabled").map_err(|e| e.to_string())?;
+    Ok(value.map(|v| v != "false" && v != "0").unwrap_or(true))
+}
+
+/// 设置 encrypted_content 剥离开关
+#[tauri::command]
+pub async fn set_strip_encrypted_content_enabled(
+    state: tauri::State<'_, crate::AppState>,
+    enabled: bool,
+) -> Result<bool, String> {
+    state.db.set_setting("strip_encrypted_content_enabled", if enabled { "true" } else { "false" })
+        .map_err(|e| e.to_string())?;
+    Ok(true)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1066,6 +1066,8 @@ pub fn run() {
             commands::set_copilot_optimizer_config,
             commands::get_log_config,
             commands::set_log_config,
+            commands::get_strip_encrypted_content_enabled,
+            commands::set_strip_encrypted_content_enabled,
             commands::restart_app,
             commands::check_for_updates,
             commands::is_portable_mode,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -416,6 +416,45 @@ pub async fn handle_chat_completions(
     process_response(response, &ctx, &state, &OPENAI_PARSER_CONFIG).await
 }
 
+/// Remove all encrypted_content from the request body.
+///
+/// Two places must be cleaned:
+/// 1. `include` array — prevents the API from returning NEW encrypted_content
+/// 2. `input` array (reasoning/compaction items) — removes OLD encrypted_content
+///    that was stored in Codex session files from previous turns and can no
+///    longer be decrypted after the proxy rotated API keys.
+///
+/// Returns `true` if anything was actually stripped.
+fn strip_all_encrypted_content(body: &mut Value) -> bool {
+    let mut stripped = false;
+
+    // 1. Prevent new encrypted_content from being returned.
+    if let Some(include) = body.get_mut("include").and_then(|v| v.as_array_mut()) {
+        let before = include.len();
+        include.retain(|v| v.as_str() != Some("reasoning.encrypted_content"));
+        stripped |= before != include.len();
+    }
+
+    // 2. Remove old encrypted_content from input items so the API
+    //    doesn't try (and fail) to decrypt blobs from a different key.
+    if let Some(input) = body.get_mut("input").and_then(|v| v.as_array_mut()) {
+        for item in input.iter_mut() {
+            if let Some(obj) = item.as_object_mut() {
+                match obj.get("type").and_then(|v| v.as_str()) {
+                    Some("reasoning") | Some("compaction") => {
+                        if obj.remove("encrypted_content").is_some() {
+                            stripped = true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    stripped
+}
+
 /// 处理 /v1/responses 请求（OpenAI Responses API - Codex CLI 透传）
 pub async fn handle_responses(
     State(state): State<ProxyState>,
@@ -430,8 +469,26 @@ pub async fn handle_responses(
         .await
         .map_err(|e| ProxyError::Internal(format!("Failed to read request body: {e}")))?
         .to_bytes();
-    let body: Value = serde_json::from_slice(&body_bytes)
+    let mut body: Value = serde_json::from_slice(&body_bytes)
         .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+
+    let smart_enabled = state
+        .db
+        .get_setting("strip_encrypted_content_enabled")
+        .unwrap_or(None)
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(true);
+
+    // Keep a clone for potential retry with stripping after error detection.
+    let original_body = body.clone();
+
+    // Proactive strip: if any provider has a recent encrypted_content error,
+    // strip ahead of time to avoid hitting the error at all.
+    let proactively_stripped = if smart_enabled && state.has_recent_encrypted_error() {
+        strip_all_encrypted_content(&mut body)
+    } else {
+        false
+    };
 
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
@@ -443,31 +500,228 @@ pub async fn handle_responses(
         .unwrap_or(false);
 
     let forwarder = ctx.create_forwarder(&state);
-    let result = match forwarder
+    let (fwd_response, provider) = match forwarder
         .forward_with_retry(
             &AppType::Codex,
             &endpoint,
             body,
-            headers,
-            extensions,
+            headers.clone(),
+            extensions.clone(),
             ctx.get_providers(),
         )
         .await
     {
-        Ok(result) => result,
+        Ok(result) => (result.response, result.provider),
         Err(mut err) => {
-            if let Some(provider) = err.provider.take() {
-                ctx.provider = provider;
+            let provider = err.provider.clone();
+            if let Some(ref p) = provider {
+                ctx.provider = p.clone();
             }
+
+            // Reactive detection from forwarder error: forward_with_retry
+            // converts non-2xx responses to Err(UpstreamError), so the Ok-branch
+            // reactive check below never fires. Detect here instead.
+            if smart_enabled && !proactively_stripped {
+                let is_encrypted_error = matches!(
+                    &err.error,
+                    ProxyError::UpstreamError { body: Some(b), .. }
+                        if b.contains("invalid_encrypted_content")
+                );
+                if is_encrypted_error {
+                    if let Some(ref p) = provider {
+                        state.record_encrypted_error(&p.id);
+                    }
+                    log::warn!(
+                        "[Codex] 检测到 invalid_encrypted_content (provider={}), 剥离后重试",
+                        provider.as_ref().map(|p| p.id.as_str()).unwrap_or("unknown")
+                    );
+
+                    let mut retry_body = original_body;
+                    strip_all_encrypted_content(&mut retry_body);
+
+                    let retry_ctx = RequestContext::new(
+                        &state, &retry_body, &headers, AppType::Codex, "Codex", "codex",
+                    )
+                    .await?;
+                    let retry_forwarder = retry_ctx.create_forwarder(&state);
+
+                    match retry_forwarder
+                        .forward_with_retry(
+                            &AppType::Codex,
+                            &endpoint,
+                            retry_body,
+                            headers,
+                            extensions,
+                            retry_ctx.get_providers(),
+                        )
+                        .await
+                    {
+                        Ok(retry_result) => {
+                            log::info!(
+                                "[Codex] 剥离 encrypted_content 后重试成功 (provider={})",
+                                retry_result.provider.id
+                            );
+                            ctx.provider = retry_result.provider;
+                            return process_response(
+                                retry_result.response,
+                                &retry_ctx,
+                                &state,
+                                &CODEX_PARSER_CONFIG,
+                            )
+                            .await;
+                        }
+                        Err(retry_err) => {
+                            log::error!(
+                                "[Codex] 剥离 encrypted_content 后重试仍失败: {}",
+                                retry_err.error
+                            );
+                            let wrapped = ProxyError::Internal(format!(
+                                "[CC Switch] Auto-detected invalid_encrypted_content, stripped encrypted_content from request (include + input items), and retried — but the retry also failed.\nOriginal error: {}\n\nTip: If you see this repeatedly, try restarting your Codex session with --resume to clear session state.",
+                                retry_err.error
+                            ));
+                            log_forward_error(&state, &ctx, is_stream, &wrapped);
+                            return Err(wrapped);
+                        }
+                    }
+                }
+            }
+
             log_forward_error(&state, &ctx, is_stream, &err.error);
             return Err(err.error);
         }
     };
 
-    ctx.provider = result.provider;
-    let response = result.response;
+    // Reactive detection: if smart mode is on, we didn't already strip, and the
+    // response is a non-SSE error — check whether it's invalid_encrypted_content.
+    // Note: most error responses are converted to Err by forward(), so this branch
+    // is rarely reached. The primary detection lives in the Err branch above.
+    let error_status = fwd_response.status();
+    if smart_enabled && !proactively_stripped && !error_status.is_success() && !fwd_response.is_sse() {
+        let error_headers = fwd_response.headers().clone();
+        let error_bytes = fwd_response.bytes().await?;
+        let error_str = String::from_utf8_lossy(&error_bytes);
 
-    process_response(response, &ctx, &state, &CODEX_PARSER_CONFIG).await
+        if error_str.contains("invalid_encrypted_content") {
+            state.record_encrypted_error(&provider.id);
+            log::warn!(
+                "[Codex] 检测到 invalid_encrypted_content (provider={}), 剥离后重试",
+                provider.id
+            );
+
+            let mut retry_body = original_body;
+            strip_all_encrypted_content(&mut retry_body);
+
+            let retry_ctx = RequestContext::new(
+                &state, &retry_body, &headers, AppType::Codex, "Codex", "codex",
+            )
+            .await?;
+            let retry_forwarder = retry_ctx.create_forwarder(&state);
+
+            match retry_forwarder
+                .forward_with_retry(
+                    &AppType::Codex,
+                    &endpoint,
+                    retry_body,
+                    headers,
+                    extensions,
+                    retry_ctx.get_providers(),
+                )
+                .await
+            {
+                Ok(retry_result) => {
+                    let retry_response = retry_result.response;
+                    if !retry_response.status().is_success() && !retry_response.is_sse() {
+                        let hdrs = retry_response.headers().clone();
+                        let st = retry_response.status();
+                        let body_bytes = retry_response.bytes().await?;
+                        let mut body_json: Value =
+                            serde_json::from_slice(&body_bytes).unwrap_or_default();
+                        if let Some(obj) = body_json.as_object_mut() {
+                            if let Some(error) = obj.get_mut("error").and_then(|v| v.as_object_mut())
+                            {
+                                if let Some(msg) =
+                                    error.get("message").and_then(|v| v.as_str()).map(|s| s.to_string())
+                                {
+                                    error.insert(
+                                        "message".to_string(),
+                                        Value::String(format!(
+                                            "[CC Switch] Auto-detected invalid_encrypted_content, stripped encrypted_content from include + input items, and retried — but the retry also failed.\nOriginal API error: {msg}"
+                                        )),
+                                    );
+                                }
+                                error.insert(
+                                    "cc_switch_note".to_string(),
+                                    Value::String(
+                                        "encrypted_content was automatically stripped from this request by CC Switch. If this error persists, try restarting your Codex session with --resume, or disable this feature in proxy settings."
+                                            .to_string(),
+                                    ),
+                                );
+                            }
+                        }
+                        let body_str = serde_json::to_string(&body_json).unwrap_or_default();
+                        let mut axum_resp = axum::response::Response::builder().status(st);
+                        if let Some(h) = axum_resp.headers_mut() {
+                            for (k, v) in hdrs.iter() {
+                                h.insert(k, v.clone());
+                            }
+                        }
+                        log::warn!(
+                            "[Codex] 剥离后重试仍返回错误 (provider={}): {}",
+                            retry_result.provider.id,
+                            body_str
+                        );
+                        return Ok(axum_resp
+                            .body(axum::body::Body::from(body_str))
+                            .unwrap());
+                    }
+
+                    log::info!(
+                        "[Codex] 剥离 encrypted_content 后重试成功 (provider={})",
+                        retry_result.provider.id
+                    );
+                    ctx.provider = retry_result.provider;
+                    return process_response(
+                        retry_response,
+                        &retry_ctx,
+                        &state,
+                        &CODEX_PARSER_CONFIG,
+                    )
+                    .await;
+                }
+                Err(mut err) => {
+                    if let Some(p) = err.provider.take() {
+                        ctx.provider = p;
+                    }
+                    log::error!(
+                        "[Codex] 剥离 encrypted_content 后重试仍失败: {}",
+                        err.error
+                    );
+                    let wrapped = ProxyError::Internal(format!(
+                        "[CC Switch] Auto-detected invalid_encrypted_content, stripped encrypted_content from request (include + input items), and retried — but the retry also failed.\nOriginal error: {}\n\nTip: If you see this repeatedly, try restarting your Codex session with --resume to clear session state.",
+                        err.error
+                    ));
+                    log_forward_error(&state, &ctx, is_stream, &wrapped);
+                    return Err(wrapped);
+                }
+            }
+        }
+
+        // Not an encrypted_content error — rebuild the response and return as-is.
+        let mut axum_resp = axum::response::Response::builder()
+            .status(error_status);
+        {
+            let h = axum_resp.headers_mut().unwrap();
+            for (k, v) in error_headers.iter() {
+                h.insert(k, v.clone());
+            }
+        }
+        return Ok(axum_resp
+            .body(axum::body::Body::from(error_bytes.to_vec()))
+            .unwrap());
+    }
+
+    ctx.provider = provider;
+    process_response(fwd_response, &ctx, &state, &CODEX_PARSER_CONFIG).await
 }
 
 /// 处理 /v1/responses/compact 请求（OpenAI Responses Compact API - Codex CLI 透传）

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -42,6 +42,43 @@ pub struct ProxyState {
     pub app_handle: Option<tauri::AppHandle>,
     /// 故障转移切换管理器
     pub failover_manager: Arc<FailoverSwitchManager>,
+    /// 记录各 provider 最近一次 encrypted_content 错误的时间戳 (provider_id -> unix_secs)
+    /// 用于智能剥离：有过错误记录的 provider 会被主动剥离，冷却后恢复
+    pub encrypted_content_errors: Arc<RwLock<std::collections::HashMap<String, i64>>>,
+}
+
+impl ProxyState {
+    /// Cooldown before re-enabling encrypted_content for a provider (30 minutes).
+    const ENCRYPTED_ERROR_COOLDOWN_SECS: i64 = 1800;
+
+    /// Check whether any provider has a recent encrypted_content error.
+    /// If so, we proactively strip to avoid hitting the error again.
+    pub fn has_recent_encrypted_error(&self) -> bool {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        if let Ok(errors) = self.encrypted_content_errors.try_read() {
+            errors
+                .values()
+                .any(|&ts| now - ts < Self::ENCRYPTED_ERROR_COOLDOWN_SECS)
+        } else {
+            false
+        }
+    }
+
+    /// Record an encrypted_content error for a provider.
+    pub fn record_encrypted_error(&self, provider_id: &str) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        if let Ok(mut errors) = self.encrypted_content_errors.try_write() {
+            errors.insert(provider_id.to_string(), now);
+            // Clean up expired entries while we're at it.
+            errors.retain(|_, ts| now - *ts < Self::ENCRYPTED_ERROR_COOLDOWN_SECS);
+        }
+    }
 }
 
 /// 代理HTTP服务器
@@ -74,6 +111,7 @@ impl ProxyServer {
             gemini_shadow: Arc::new(GeminiShadowStore::default()),
             app_handle,
             failover_manager,
+            encrypted_content_errors: Arc::new(RwLock::new(std::collections::HashMap::new())),
         };
 
         Self {

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -1,5 +1,12 @@
-import { useState } from "react";
-import { Server, Activity, Zap, Globe, ShieldAlert } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  Server,
+  Activity,
+  Zap,
+  Globe,
+  ShieldAlert,
+  ShieldCheck,
+} from "lucide-react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import {
@@ -18,6 +25,8 @@ import { GlobalProxySettings } from "@/components/settings/GlobalProxySettings";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { ToggleRow } from "@/components/ui/toggle-row";
 import { useProxyStatus } from "@/hooks/useProxyStatus";
+import { settingsApi } from "@/lib/api/settings";
+import { toast } from "sonner";
 import type { SettingsFormState } from "@/hooks/useSettings";
 
 interface ProxyTabContentProps {
@@ -32,6 +41,7 @@ export function ProxyTabContent({
   const { t } = useTranslation();
   const [showProxyConfirm, setShowProxyConfirm] = useState(false);
   const [showFailoverConfirm, setShowFailoverConfirm] = useState(false);
+  const [stripEncryptedEnabled, setStripEncryptedEnabled] = useState(true);
 
   const {
     isRunning,
@@ -78,6 +88,24 @@ export function ProxyTabContent({
       await onAutoSave({ failoverConfirmed: true, enableFailoverToggle: true });
     } catch (error) {
       console.error("Failover confirm failed:", error);
+    }
+  };
+
+  useEffect(() => {
+    settingsApi
+      .getStripEncryptedContentEnabled()
+      .then(setStripEncryptedEnabled)
+      .catch(() => setStripEncryptedEnabled(true));
+  }, []);
+
+  const handleStripEncryptedChange = async (checked: boolean) => {
+    setStripEncryptedEnabled(checked);
+    try {
+      await settingsApi.setStripEncryptedContentEnabled(checked);
+    } catch (e) {
+      console.error("Failed to save encrypted content strip setting:", e);
+      toast.error(String(e));
+      setStripEncryptedEnabled(!checked);
     }
   };
 
@@ -158,6 +186,16 @@ export function ProxyTabContent({
                 )}
                 checked={settings?.enableFailoverToggle ?? false}
                 onCheckedChange={handleFailoverToggleChange}
+              />
+
+              <ToggleRow
+                icon={<ShieldCheck className="h-4 w-4 text-blue-500" />}
+                title={t("settings.advanced.codexCompat.toggleTitle")}
+                description={t(
+                  "settings.advanced.codexCompat.toggleDescription",
+                )}
+                checked={stripEncryptedEnabled}
+                onCheckedChange={handleStripEncryptedChange}
               />
 
               {!isRunning && (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -352,6 +352,13 @@
           "debug": "Detailed info including SSE stream and request/response",
           "trace": "All logs, most verbose"
         }
+      },
+      "codexCompat": {
+        "title": "Codex: Encrypted Content Recovery",
+        "description": "Auto-recover from encrypted_content decryption failures caused by API key rotation",
+        "toggleTitle": "Auto-recover from encrypted_content errors",
+        "toggleDescription": "Different API keys cannot decrypt each other's encrypted reasoning blocks. When enabled, encrypted_content is automatically stripped from requests and retried silently — reasoning quality is unaffected. Strongly recommended when rotating API keys across providers.",
+        "injectedErrorNote": "encrypted_content was automatically stripped from this request by CC Switch. If this error persists, try restarting your Codex session with --resume, or disable this feature in proxy settings."
       }
     },
     "language": "Language",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -352,6 +352,13 @@
           "debug": "SSE ストリームとリクエスト/レスポンスを含む詳細情報",
           "trace": "すべてのログ、最も詳細"
         }
+      },
+      "codexCompat": {
+        "title": "Codex: 暗号化コンテンツ修復",
+        "description": "APIキー切り替えによる暗号化コンテンツの復号失敗を自動修復",
+        "toggleTitle": "encrypted_content エラー自動修復",
+        "toggleDescription": "異なるAPIキーでは互いの暗号化推論ブロックを復号できません。有効にするとリクエストからencrypted_contentを自動除去してサイレントリトライし、推論品質に影響はありません。プロバイダー間でキーをローテーションする環境で推奨。",
+        "injectedErrorNote": "CC Switchがこのリクエストからencrypted_contentを自動的に除去しました。このエラーが続く場合は、--resumeでCodexセッションを再起動するか、プロキシ設定でこの機能を無効にしてください。"
       }
     },
     "language": "言語",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -352,6 +352,13 @@
           "debug": "详细信息，包含 SSE 流和请求/响应详情",
           "trace": "全部日志，最详细"
         }
+      },
+      "codexCompat": {
+        "title": "Codex: 加密内容修复",
+        "description": "检测并阻止因 API key 轮换导致的 invalid_encrypted_content 错误",
+        "toggleTitle": "encrypted_content 错误自动重试",
+        "toggleDescription": "Codex 返回携带的部分推理块加密, 区分apikey. 启用此选项将会在检测到 invalid_encrypted_content 错误时, 智能处理 include 参数和请求 input 中的 reasoning/compaction 条目, 尝试剥离 encrypted_content, 不会影响推理摘要和推理性能, cli 中无感。如果你经常切换 provider, 或者中转商存在多 apikey 轮换行为, 强烈建议开启此功能.",
+        "injectedErrorNote": "CC Switch 已自动从此请求中剥离 encrypted_content。如果此错误持续出现，请尝试用 --resume 重启 Codex 会话，或在代理设置中关闭此功能。"
       }
     },
     "language": "界面语言",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -215,6 +215,14 @@ export const settingsApi = {
   async setLogConfig(config: LogConfig): Promise<boolean> {
     return await invoke("set_log_config", { config });
   },
+
+  async getStripEncryptedContentEnabled(): Promise<boolean> {
+    return await invoke("get_strip_encrypted_content_enabled");
+  },
+
+  async setStripEncryptedContentEnabled(enabled: boolean): Promise<boolean> {
+    return await invoke("set_strip_encrypted_content_enabled", { enabled });
+  },
 };
 
 export interface RectifierConfig {


### PR DESCRIPTION
Codex encrypts unknown intermediate reasoning state into session-stored encrypted_content blocks, which break when the proxy rotates to a provider using a different API key, or the provider too cheap to serve users with different API keys changing with time — the new key cannot decrypt blobs produced by the old one, and the upstream returns invalid_encrypted_content. This feature detects that error from the forwarder's UpstreamError body, strips encrypted_content from both the include parameter and any reasoning or compaction items in the request input, then retries with the cleaned body. Once a provider triggers this error it is remembered for 30 minutes and subsequent requests are proactively stripped to avoid the round-trip entirely. The toggle is placed under the failover error-handling section rather than as a separate panel, since it is a recovery behavior rather than a standalone configuration concern.

Refs:
- Codex session handover & encrypted summary: https://tonylee.im/zh-CN/blog/codex-compaction-encrypted-summary-session-handover/
- Encrypted reasoning items: https://developers.openai.com/api/docs/guides/reasoning#encrypted-reasoning-items
- Community report of the same issue: https://linux.do/t/topic/2102361

## Summary / 概述
Codex stores encrypted reasoning blocks in its session state, keyed to the user's API key. When CC-Switch routes to a different provider — or when a routing service cycles API keys over time — the old blocks become unreadable, and the OpenAI upstream returns:

```json
    {"error":{"message":"The encrypted content gAAA...SQ== could not be verified.","type":"invalid_request_error","code":"invalid_encrypted_content"}}
```

Since CC-Switch already sits in the error-handling path, I find it makes sense to catch this and recover automatically. This PR does exactly that: on detecting an invalid_encrypted_content error, the proxy strips encrypted_content from the include parameter and from any reasoning/compaction items in the request input, then retries silently. A provider that triggers the error is remembered for 30 minutes so that subsequent requests are proactively cleaned, avoiding the round-trip entirely. No CLI interruption, no session rewrite.

The toggle lives under the failover section in proxy settings, since this is an error-recovery behavior rather than a standalone feature. Enabled by default; turn it off only if all your providers share the same API key.

Discussions remain open for any missed edge cases, code issues, or localization corrections.


## Related Issue / 关联 Issue

None

Fixes #

## Screenshots / 截图
<img width="1272" height="687" alt="image" src="https://github.com/user-attachments/assets/a8bc09e9-756c-41cf-afd4-d53e6ad41735" />

Item added in Settings.


## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
