### PR TITLE
fix(usage): add manual backfill for missing historical costs

### DIFF
--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -1,5 +1,6 @@
 //! 使用统计相关命令
 
+use crate::database::Database;
 use crate::error::AppError;
 use crate::services::usage_stats::*;
 use crate::store::AppState;
@@ -186,6 +187,23 @@ pub fn delete_model_pricing(state: State<'_, AppState>, model_id: String) -> Res
     Ok(())
 }
 
+/// 手动回填历史记录中缺失的成本
+#[tauri::command]
+pub fn backfill_missing_usage_costs(
+    state: State<'_, AppState>,
+) -> Result<BackfillUsageCostsResult, AppError> {
+    backfill_missing_usage_costs_for_db(state.db.as_ref())
+}
+
+fn backfill_missing_usage_costs_for_db(
+    db: &Database,
+) -> Result<BackfillUsageCostsResult, AppError> {
+    let backfilled_cost_rows = db.backfill_missing_usage_costs()?;
+    Ok(BackfillUsageCostsResult {
+        backfilled_cost_rows,
+    })
+}
+
 /// 手动触发会话日志同步
 #[tauri::command]
 pub fn sync_session_usage(
@@ -241,4 +259,160 @@ pub struct ModelPricingInfo {
     pub output_cost_per_million: String,
     pub cache_read_cost_per_million: String,
     pub cache_creation_cost_per_million: String,
+}
+
+/// 历史成本回填结果
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackfillUsageCostsResult {
+    pub backfilled_cost_rows: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::{lock_conn, Database};
+    use rusqlite::params;
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_usage_log(
+        db: &Database,
+        request_id: &str,
+        model: &str,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_creation_tokens: i64,
+        total_cost_usd: &str,
+    ) -> Result<(), AppError> {
+        let conn = lock_conn!(db.conn);
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model, request_model,
+                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd,
+                total_cost_usd, latency_ms, status_code, created_at, data_source
+            ) VALUES (?1, '_codex_session', 'codex', ?2, ?2, ?3, ?4, ?5, ?6,
+                      '0', '0', '0', '0', ?7, 100, 200, 1000, 'codex_session')",
+            params![
+                request_id,
+                model,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
+                total_cost_usd
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn insert_model_pricing(
+        db: &Database,
+        model_id: &str,
+        input_cost: &str,
+        output_cost: &str,
+        cache_read_cost: &str,
+        cache_creation_cost: &str,
+    ) -> Result<(), AppError> {
+        let conn = lock_conn!(db.conn);
+        conn.execute(
+            "INSERT OR REPLACE INTO model_pricing (
+                model_id, display_name, input_cost_per_million,
+                output_cost_per_million, cache_read_cost_per_million,
+                cache_creation_cost_per_million
+            ) VALUES (?1, ?1, ?2, ?3, ?4, ?5)",
+            params![
+                model_id,
+                input_cost,
+                output_cost,
+                cache_read_cost,
+                cache_creation_cost
+            ],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_backfill_missing_usage_costs_for_db_reprices_all_known_zero_cost_models(
+    ) -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        insert_model_pricing(&db, "priced-model-a", "5", "30", "0.5", "5")?;
+        insert_model_pricing(&db, "priced-model-b", "2", "10", "0", "0")?;
+
+        insert_usage_log(
+            &db,
+            "priced-model-a-zero-cost",
+            "priced-model-a",
+            1_000_000,
+            100_000,
+            200_000,
+            50_000,
+            "0",
+        )?;
+        insert_usage_log(
+            &db,
+            "priced-model-a-existing-cost",
+            "priced-model-a",
+            1_000_000,
+            100_000,
+            200_000,
+            50_000,
+            "123.000000",
+        )?;
+        insert_usage_log(
+            &db,
+            "priced-model-b-zero-cost",
+            "priced-model-b",
+            2_000_000,
+            0,
+            0,
+            0,
+            "0",
+        )?;
+        insert_usage_log(
+            &db,
+            "unknown-model-zero-cost",
+            "unknown-new-model",
+            1_000_000,
+            100_000,
+            200_000,
+            50_000,
+            "0",
+        )?;
+
+        let result = backfill_missing_usage_costs_for_db(&db)?;
+
+        assert_eq!(result.backfilled_cost_rows, 2);
+
+        let conn = lock_conn!(db.conn);
+        let priced_model_a_cost: String = conn.query_row(
+            "SELECT total_cost_usd FROM proxy_request_logs WHERE request_id = 'priced-model-a-zero-cost'",
+            [],
+            |row| row.get(0),
+        )?;
+        let existing_cost: String = conn.query_row(
+            "SELECT total_cost_usd FROM proxy_request_logs WHERE request_id = 'priced-model-a-existing-cost'",
+            [],
+            |row| row.get(0),
+        )?;
+        let priced_model_b_cost: String = conn.query_row(
+            "SELECT total_cost_usd FROM proxy_request_logs WHERE request_id = 'priced-model-b-zero-cost'",
+            [],
+            |row| row.get(0),
+        )?;
+        let other_model_cost: String = conn.query_row(
+            "SELECT total_cost_usd FROM proxy_request_logs WHERE request_id = 'unknown-model-zero-cost'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(priced_model_a_cost, "7.350000");
+        assert_eq!(priced_model_b_cost, "4.000000");
+        assert_eq!(existing_cost, "123.000000");
+        assert_eq!(other_model_cost, "0");
+
+        Ok(())
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1220,6 +1220,7 @@ pub fn run() {
             commands::get_model_pricing,
             commands::update_model_pricing,
             commands::delete_model_pricing,
+            commands::backfill_missing_usage_costs,
             commands::check_provider_limits,
             // Session usage sync
             commands::sync_session_usage,

--- a/src/components/usage/PricingConfigPanel.tsx
+++ b/src/components/usage/PricingConfigPanel.tsx
@@ -26,10 +26,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useModelPricing, useDeleteModelPricing } from "@/lib/query/usage";
+import {
+  useModelPricing,
+  useDeleteModelPricing,
+  useBackfillMissingUsageCosts,
+} from "@/lib/query/usage";
 import { PricingEditModal } from "./PricingEditModal";
 import type { ModelPricing } from "@/types/usage";
-import { Plus, Pencil, Trash2, Loader2 } from "lucide-react";
+import { Plus, Pencil, Trash2, Loader2, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { proxyApi } from "@/lib/api/proxy";
 
@@ -48,6 +52,7 @@ export function PricingConfigPanel() {
   const { t } = useTranslation();
   const { data: pricing, isLoading, error } = useModelPricing();
   const deleteMutation = useDeleteModelPricing();
+  const backfillMutation = useBackfillMissingUsageCosts();
   const [editingModel, setEditingModel] = useState<ModelPricing | null>(null);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
@@ -183,6 +188,29 @@ export function PricingConfigPanel() {
     deleteMutation.mutate(modelId, {
       onSuccess: () => setDeleteConfirm(null),
     });
+  };
+
+  const handleBackfillMissingCosts = async () => {
+    try {
+      const result = await backfillMutation.mutateAsync();
+      if (result.backfilledCostRows > 0) {
+        toast.success(
+          t("usage.backfillMissingCostsDone", {
+            count: result.backfilledCostRows,
+          }),
+          { closeButton: true },
+        );
+        return;
+      }
+
+      toast.success(t("usage.backfillMissingCostsNone"), {
+        closeButton: true,
+      });
+    } catch (error) {
+      toast.error(
+        t("usage.backfillMissingCostsFailed", { error: String(error) }),
+      );
+    }
   };
 
   const handleAddNew = () => {
@@ -342,16 +370,34 @@ export function PricingConfigPanel() {
           <h4 className="text-sm font-medium text-muted-foreground">
             {t("usage.modelPricingDesc")} {t("usage.perMillion")}
           </h4>
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              handleAddNew();
-            }}
-            size="sm"
-          >
-            <Plus className="mr-1 h-4 w-4" />
-            {t("common.add")}
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleBackfillMissingCosts();
+              }}
+              disabled={backfillMutation.isPending || !pricing?.length}
+              size="sm"
+            >
+              {backfillMutation.isPending ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-1 h-4 w-4" />
+              )}
+              {t("usage.backfillMissingCosts")}
+            </Button>
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                handleAddNew();
+              }}
+              size="sm"
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              {t("common.add")}
+            </Button>
+          </div>
         </div>
 
         <div className="space-y-4">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1215,6 +1215,10 @@
     "editPricing": "Edit Pricing",
     "pricingAdded": "Pricing added",
     "pricingUpdated": "Pricing updated",
+    "backfillMissingCosts": "Backfill Costs",
+    "backfillMissingCostsDone": "Backfilled {{count}} historical cost records",
+    "backfillMissingCostsNone": "No historical costs need backfilling",
+    "backfillMissingCostsFailed": "Failed to backfill historical costs: {{error}}",
     "cacheReadCostPerMillion": "Cache Read Cost (per million tokens, USD)",
     "cacheCreationCostPerMillion": "Cache Write Cost (per million tokens, USD)"
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1215,6 +1215,10 @@
     "editPricing": "価格設定を編集",
     "pricingAdded": "価格設定が追加されました",
     "pricingUpdated": "価格設定が更新されました",
+    "backfillMissingCosts": "履歴コストを補完",
+    "backfillMissingCostsDone": "{{count}} 件の履歴コストを補完しました",
+    "backfillMissingCostsNone": "補完が必要な履歴コストはありません",
+    "backfillMissingCostsFailed": "履歴コストの補完に失敗しました: {{error}}",
     "cacheReadCostPerMillion": "キャッシュ読み取りコスト（100万トークンあたり、USD）",
     "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）"
   },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1215,6 +1215,10 @@
     "editPricing": "编辑定价",
     "pricingAdded": "定价已添加",
     "pricingUpdated": "定价已更新",
+    "backfillMissingCosts": "补全历史成本",
+    "backfillMissingCostsDone": "已补全 {{count}} 条历史成本",
+    "backfillMissingCostsNone": "没有需要补全的历史成本",
+    "backfillMissingCostsFailed": "补全历史成本失败：{{error}}",
     "cacheReadCostPerMillion": "缓存读取成本 (每百万 tokens, USD)",
     "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)"
   },

--- a/src/lib/api/usage.ts
+++ b/src/lib/api/usage.ts
@@ -16,6 +16,10 @@ import type { UsageResult } from "@/types";
 import type { AppId } from "./types";
 import type { TemplateType } from "@/config/constants";
 
+export type BackfillMissingUsageCostsResult = {
+  backfilledCostRows: number;
+};
+
 export const usageApi = {
   // Provider usage script methods
   query: async (providerId: string, appId: AppId): Promise<UsageResult> => {
@@ -120,6 +124,11 @@ export const usageApi = {
   deleteModelPricing: async (modelId: string): Promise<void> => {
     return invoke("delete_model_pricing", { modelId });
   },
+
+  backfillMissingUsageCosts:
+    async (): Promise<BackfillMissingUsageCostsResult> => {
+      return invoke("backfill_missing_usage_costs");
+    },
 
   checkProviderLimits: async (
     providerId: string,

--- a/src/lib/query/usage.ts
+++ b/src/lib/query/usage.ts
@@ -276,6 +276,17 @@ export function useUpdateModelPricing() {
   });
 }
 
+export function useBackfillMissingUsageCosts() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: usageApi.backfillMissingUsageCosts,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: usageKeys.all });
+    },
+  });
+}
+
 export function useDeleteModelPricing() {
   const queryClient = useQueryClient();
 

--- a/tests/components/PricingConfigPanel.test.tsx
+++ b/tests/components/PricingConfigPanel.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PricingConfigPanel } from "@/components/usage/PricingConfigPanel";
+
+const mocks = vi.hoisted(() => ({
+  deleteMutate: vi.fn(),
+  backfillMutateAsync: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  t: (key: string, options?: Record<string, unknown>) =>
+    options && "count" in options ? `${key}:${options.count}` : key,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: mocks.t,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+  },
+}));
+
+vi.mock("@/lib/api/proxy", () => ({
+  proxyApi: {
+    getDefaultCostMultiplier: vi.fn().mockResolvedValue("1"),
+    getPricingModelSource: vi.fn().mockResolvedValue("response"),
+    setDefaultCostMultiplier: vi.fn().mockResolvedValue(undefined),
+    setPricingModelSource: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/query/usage", () => ({
+  useModelPricing: () => ({
+    data: [
+      {
+        modelId: "priced-model-a",
+        displayName: "Priced Model A",
+        inputCostPerMillion: "5",
+        outputCostPerMillion: "30",
+        cacheReadCostPerMillion: "0.5",
+        cacheCreationCostPerMillion: "5",
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+  useDeleteModelPricing: () => ({
+    mutate: mocks.deleteMutate,
+    isPending: false,
+  }),
+  useBackfillMissingUsageCosts: () => ({
+    mutateAsync: mocks.backfillMutateAsync,
+    isPending: false,
+  }),
+  useUpdateModelPricing: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("PricingConfigPanel", () => {
+  beforeEach(() => {
+    mocks.deleteMutate.mockReset();
+    mocks.backfillMutateAsync.mockReset();
+    mocks.toastSuccess.mockReset();
+    mocks.toastError.mockReset();
+  });
+
+  it("backfills historical zero-cost usage when the user clicks the pricing backfill button", async () => {
+    mocks.backfillMutateAsync.mockResolvedValue({ backfilledCostRows: 2 });
+
+    render(<PricingConfigPanel />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "usage.backfillMissingCosts" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.backfillMutateAsync).toHaveBeenCalledTimes(1),
+    );
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "usage.backfillMissingCostsDone:2",
+      { closeButton: true },
+    );
+  });
+});


### PR DESCRIPTION
## Summary / 概述

为“用量统计 / 模型定价”面板增加一个手动“补全历史成本”操作。

当用户在已有用量记录之后才补充某个模型的定价时，历史记录里的 `0` 成本不会自动重新计算。这个 PR 把已有的历史成本回填能力暴露到前端，让用户在补充或更新模型定价后，可以主动把历史上未计费的用量重新计算出来。

## Problem / 问题背景

用量成本是在请求日志写入时计算的。如果当时模型还没有价格配置，这些日志会以 `0` 成本保存。

之后用户虽然可以在模型定价里手动添加价格，但这只更新了价格表，并不会自动改写已经存在的历史用量记录。因此会出现“新价格已经配置了，但历史统计金额仍然缺失”的情况。

## What Changed / 变更内容

- 在模型定价面板增加“补全历史成本”按钮。
- 新增 Tauri command，调用现有的 `backfill_missing_usage_costs` 数据库回填逻辑。
- 回填后返回实际更新的历史用量行数。
- 前端回填成功后刷新用量相关查询缓存。
- 根据回填结果显示本地化 toast：已补全多少条，或没有需要补全的记录。
- 更新中 / 英 / 日三种语言文案。
- 增加 `PricingConfigPanel` 组件测试，覆盖点击按钮、触发回填和成功提示。

## Related Issue / 关联 Issue

Fixes #2532

## Screenshots / 截图

| After / 修改后 |
|----------------|
| <img width="456" alt="Pricing backfill button and success toast" src="https://raw.githubusercontent.com/Ghibli1024/cc-switch/pr-assets/usage-backfill-screenshot/pr-assets/usage-backfill-after-click.png" /> |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

## Validation / 验证

- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] `pnpm vitest run tests/components/PricingConfigPanel.test.tsx --maxWorkers=1 --minWorkers=1`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `TZ=UTC cargo test`
- [x] Fork GitHub Actions CI passed: [Ghibli1024/cc-switch#1](https://github.com/Ghibli1024/cc-switch/pull/1) / [CI run](https://github.com/Ghibli1024/cc-switch/actions/runs/25396941003) (`Frontend Checks`, `Backend Checks`)