### PR TITLE
feat(deeplink): support extraEnv parameter for provider configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,10 @@ Development since v3.15.0 focuses on making third-party Codex providers work lik
 - **Claude Desktop Guide**: Added localized Claude Desktop guide pages and screenshots for provider setup, import, model mapping, and Local Routing context.
 - **Installation Docs**: Updated installation docs and READMEs to recommend the official Homebrew cask and refreshed the v3.15.0 release-note imposter-site warning wording across locales.
 
+### Added
+
+- **Deep Link Extra Environment Variables (`extraEnv`)**: Claude and Gemini provider deep links now support an `extraEnv` parameter (Base64-encoded JSON object) for merging extra variables into `settings_config.env`. Protected auth/base-URL fields only accept non-empty strings; other boolean/number scalars are stringified, and null/object/array values are skipped. Gemini keys must match `.env` naming rules, and other provider deeplinks reject `extraEnv` explicitly instead of silently ignoring it.
+
 ## [3.15.0] - 2026-05-16
 
 Development since v3.14.1 focuses on a dedicated Claude Desktop surface with third-party provider switching through a proxy gateway, a large reverse-proxy hardening pass (reliability, retries, cache, takeover, Gemini/Vertex/Codex paths), expansion of the third-party provider preset catalog (BytePlus / Volcengine / ClaudeAPI / ClaudeCN / RunAPI / RelaxyCode / PatewayAI / Baidu Qianfan), role-based model mapping with a 1M context flag, Codex OAuth live model discovery, and a long tail of usage, OAuth, Codex, and session quality-of-life fixes.

--- a/deplink.html
+++ b/deplink.html
@@ -415,6 +415,49 @@
                     </div>
                 </div>
 
+                <!-- 额外环境变量 (extraEnv) 导入 -->
+                <div class="link-card">
+                    <h3>
+                        <span class="app-badge badge-claude">Claude</span>
+                        额外环境变量自动勾选
+                        <span class="version-badge">v3.10+</span>
+                    </h3>
+                    <p class="description">
+                        通过 <code>extraEnv</code> 参数一键导入 Teammates 模式、Tool Search、最大强度思考等环境变量，自动勾选对应 UI 开关。
+                    </p>
+                    <div class="param-list">
+                        <span class="param-tag">必需</span> resource=provider, app=claude, name, endpoint, apiKey<br>
+                        <span class="param-tag optional">新增</span> <strong>extraEnv</strong> (Base64 JSON 对象)
+                    </div>
+                    <div style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+                        <a href="ccswitch://v1/import?resource=provider&app=claude&name=MyProvider&endpoint=https%3A%2F%2Fapi.example.com&apiKey=sk-your-api-key-here&model=k2.6&haikuModel=k2.6&sonnetModel=k2.6&opusModel=k2.6&enabled=true&extraEnv=eyJDTEFVREVfQ09ERV9FWFBFUklNRU5UQUxfQUdFTlRfVEVBTVMiOiAiMSIsICJFTkFCTEVfVE9PTF9TRUFSQ0giOiAidHJ1ZSIsICJDTEFVREVfQ09ERV9FRkZPUlRfTEVWRUwiOiAibWF4IiwgIkNMQVVERV9CQVNIX01BSU5UQUlOX1BST0pFQ1RfV09SS0lOR19ESVIiOiAiMSIsICJDTEFVREVfQ09ERV9ESVNBQkxFX0ZFRURCQUNLX1NVUlZFWSI6ICIxIiwgIkNMQVVERV9DT0RFX05PX0ZMSUNLRVIiOiAiMSJ9"
+                            class="deep-link">
+                            📥 一键导入示例配置
+                        </a>
+                        <button class="deep-link"
+                            style="background: linear-gradient(135deg, #9b59b6 0%, #8e44ad 100%); cursor: pointer; border: none;"
+                            onclick="copyDeepLink('ccswitch://v1/import?resource=provider&app=claude&name=MyProvider&endpoint=https%3A%2F%2Fapi.example.com&apiKey=sk-your-api-key-here&model=k2.6&haikuModel=k2.6&sonnetModel=k2.6&opusModel=k2.6&enabled=true&extraEnv=eyJDTEFVREVfQ09ERV9FWFBFUklNRU5UQUxfQUdFTlRfVEVBTVMiOiAiMSIsICJFTkFCTEVfVE9PTF9TRUFSQ0giOiAidHJ1ZSIsICJDTEFVREVfQ09ERV9FRkZPUlRfTEVWRUwiOiAibWF4IiwgIkNMQVVERV9CQVNIX01BSU5UQUlOX1BST0pFQ1RfV09SS0lOR19ESVIiOiAiMSIsICJDTEFVREVfQ09ERV9ESVNBQkxFX0ZFRURCQUNLX1NVUlZFWSI6ICIxIiwgIkNMQVVERV9DT0RFX05PX0ZMSUNLRVIiOiAiMSJ9', this)">
+                            📋 复制链接
+                        </button>
+                    </div>
+                    <div class="code-block"
+                        style="margin-top: 12px; padding: 12px; background: #2c3e50; color: #ecf0f1; border-radius: 8px; font-family: monospace; font-size: 12px; overflow-x: auto;">
+                        <div style="color: #95a5a6; margin-bottom: 8px;">// extraEnv 解码后的内容:</div>
+                        {<br>
+                        &nbsp;&nbsp;"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",<br>
+                        &nbsp;&nbsp;"ENABLE_TOOL_SEARCH": "true",<br>
+                        &nbsp;&nbsp;"CLAUDE_CODE_EFFORT_LEVEL": "max",<br>
+                        &nbsp;&nbsp;"CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",<br>
+                        &nbsp;&nbsp;"CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",<br>
+                        &nbsp;&nbsp;"CLAUDE_CODE_NO_FLICKER": "1"<br>
+                        }
+                    </div>
+                    <div
+                        style="margin-top: 12px; padding: 10px; background: #d4edda; border-left: 4px solid #28a745; border-radius: 4px; font-size: 13px;">
+                        <strong>自动勾选的 UI 开关:</strong> Teammates 模式、启用 Tool Search、最大强度思考
+                    </div>
+                </div>
+
                 <!-- Codex TOML 配置导入 -->
                 <div class="link-card">
                     <h3>

--- a/deplink.html
+++ b/deplink.html
@@ -423,7 +423,7 @@
                         <span class="version-badge">v3.10+</span>
                     </h3>
                     <p class="description">
-                        通过 <code>extraEnv</code> 参数一键导入 Teammates 模式、Tool Search、最大强度思考等环境变量，自动勾选对应 UI 开关。
+                        通过 <code>extraEnv</code> 参数一键导入额外环境变量。当前适用于带 <code>env</code> 配置的 provider deeplink（现阶段为 Claude / Gemini）。其中本示例面向 Claude：导入后会自动勾选对应 UI 开关；Gemini 仅写入 <code>env</code>，不会显示这些 Claude 专属开关。
                     </p>
                     <div class="param-list">
                         <span class="param-tag">必需</span> resource=provider, app=claude, name, endpoint, apiKey<br>
@@ -455,6 +455,10 @@
                     <div
                         style="margin-top: 12px; padding: 10px; background: #d4edda; border-left: 4px solid #28a745; border-radius: 4px; font-size: 13px;">
                         <strong>自动勾选的 UI 开关:</strong> Teammates 模式、启用 Tool Search、最大强度思考
+                    </div>
+                    <div
+                        style="margin-top: 12px; padding: 10px; background: #eef6ff; border-left: 4px solid #4a90e2; border-radius: 4px; font-size: 13px;">
+                        <strong>值规则:</strong> 鉴权/基础 URL 等关键字段只接受非空字符串；其他字段里的布尔/数字会自动转成字符串；<code>null</code>、数组、对象会被跳过。Gemini 的 key 还必须满足 <code>[A-Za-z0-9_]+</code>。其他 provider app 使用 <code>extraEnv</code> 会直接报错。
                     </div>
                 </div>
 

--- a/docs/user-manual/en/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/en/5-faq/5.3-deeplink.md
@@ -66,7 +66,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `usageAccessToken` | No | Usage query access token |
 | `usageUserId` | No | Usage query user ID |
 | `usageAutoInterval` | No | Auto query interval (minutes) |
-| `extraEnv` | No | Extra environment variables (Base64-encoded JSON object), merged into `settings_config.env`. Used for one-click import of UI toggle configurations such as `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `ENABLE_TOOL_SEARCH`, and `CLAUDE_CODE_EFFORT_LEVEL`. Invalid Base64 or non-JSON values are skipped without breaking the import. |
+| `extraEnv` | No | Extra environment variables for Claude/Gemini provider deeplinks only (Base64-encoded JSON object), merged into `settings_config.env`. Protected auth/base-URL fields only accept non-empty strings; other values are ignored. Non-protected boolean/number scalars are stringified, and null/object/array values are skipped. Gemini keys must match `.env` naming rules (`[A-Za-z0-9_]+`). Other provider apps reject `extraEnv` instead of ignoring it. |
 
 **Prompt parameters** (resource=prompt):
 

--- a/docs/user-manual/en/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/en/5-faq/5.3-deeplink.md
@@ -66,6 +66,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `usageAccessToken` | No | Usage query access token |
 | `usageUserId` | No | Usage query user ID |
 | `usageAutoInterval` | No | Auto query interval (minutes) |
+| `extraEnv` | No | Extra environment variables (Base64-encoded JSON object), merged into `settings_config.env`. Used for one-click import of UI toggle configurations such as `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `ENABLE_TOOL_SEARCH`, and `CLAUDE_CODE_EFFORT_LEVEL`. Invalid Base64 or non-JSON values are skipped without breaking the import. |
 
 **Prompt parameters** (resource=prompt):
 

--- a/docs/user-manual/ja/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/ja/5-faq/5.3-deeplink.md
@@ -66,6 +66,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `usageAccessToken` | いいえ | 使用量クエリアクセストークン |
 | `usageUserId` | いいえ | 使用量クエリユーザー ID |
 | `usageAutoInterval` | いいえ | 自動クエリ間隔（分） |
+| `extraEnv` | いいえ | 追加環境変数（Base64 エンコードされた JSON オブジェクト）。`settings_config.env` にマージされます。UI トグル設定のワンクリックインポートに使用されます（例：`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`、`ENABLE_TOOL_SEARCH`、`CLAUDE_CODE_EFFORT_LEVEL`）。無効な Base64 または非 JSON 値はスキップされ、インポートを妨げません。 |
 
 **プロンプトパラメータ**（resource=prompt）：
 

--- a/docs/user-manual/ja/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/ja/5-faq/5.3-deeplink.md
@@ -66,7 +66,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `usageAccessToken` | いいえ | 使用量クエリアクセストークン |
 | `usageUserId` | いいえ | 使用量クエリユーザー ID |
 | `usageAutoInterval` | いいえ | 自動クエリ間隔（分） |
-| `extraEnv` | いいえ | 追加環境変数（Base64 エンコードされた JSON オブジェクト）。`settings_config.env` にマージされます。UI トグル設定のワンクリックインポートに使用されます（例：`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`、`ENABLE_TOOL_SEARCH`、`CLAUDE_CODE_EFFORT_LEVEL`）。無効な Base64 または非 JSON 値はスキップされ、インポートを妨げません。 |
+| `extraEnv` | いいえ | Claude/Gemini の provider deeplink 専用の追加環境変数（Base64 エンコードされた JSON オブジェクト）。`settings_config.env` にマージされます。認証/ベース URL の保護対象フィールドは空でない文字列でのみ上書きでき、それ以外の値は無視されます。保護対象以外では真偽値/数値は文字列化され、null・配列・オブジェクトはスキップされます。Gemini のキー名は `.env` 互換の `[A-Za-z0-9_]+` である必要があります。その他の provider アプリでは `extraEnv` は無視されず、明示的にエラーになります。 |
 
 **プロンプトパラメータ**（resource=prompt）：
 

--- a/docs/user-manual/zh/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/zh/5-faq/5.3-deeplink.md
@@ -66,6 +66,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `usageAccessToken` | 否 | 用量查询访问令牌 |
 | `usageUserId` | 否 | 用量查询用户 ID |
 | `usageAutoInterval` | 否 | 自动查询间隔（分钟） |
+| `extraEnv` | 否 | 额外环境变量（Base64 编码的 JSON 对象），合并到 `settings_config.env` 中。用于一键导入 UI 开关配置，如 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`、`ENABLE_TOOL_SEARCH`、`CLAUDE_CODE_EFFORT_LEVEL`。无效 Base64 或非 JSON 值会被跳过，不影响导入。 |
 
 **提示词参数**（resource=prompt）：
 

--- a/docs/user-manual/zh/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/zh/5-faq/5.3-deeplink.md
@@ -66,7 +66,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `usageAccessToken` | 否 | 用量查询访问令牌 |
 | `usageUserId` | 否 | 用量查询用户 ID |
 | `usageAutoInterval` | 否 | 自动查询间隔（分钟） |
-| `extraEnv` | 否 | 额外环境变量（Base64 编码的 JSON 对象），合并到 `settings_config.env` 中。用于一键导入 UI 开关配置，如 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`、`ENABLE_TOOL_SEARCH`、`CLAUDE_CODE_EFFORT_LEVEL`。无效 Base64 或非 JSON 值会被跳过，不影响导入。 |
+| `extraEnv` | 否 | 仅用于 Claude/Gemini provider deeplink 的额外环境变量（Base64 编码的 JSON 对象），合并到 `settings_config.env` 中。鉴权/基础 URL 等受保护字段只接受非空字符串覆盖，其他值会被忽略；非受保护字段里的布尔/数字会转成字符串，null/数组/对象会被跳过。Gemini 的 key 必须满足 `.env` 命名规则（`[A-Za-z0-9_]+`）。其他 provider app 使用 `extraEnv` 时会明确报错，而不是静默忽略。 |
 
 **提示词参数**（resource=prompt）：
 

--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -113,6 +113,11 @@ pub struct DeepLinkImportRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config_url: Option<String>,
 
+    // ============ Extra env variables (v3.10+) ============
+    /// Base64 encoded JSON object with extra environment variables to merge into env
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_env: Option<String>,
+
     // ============ Usage script fields (v3.9+) ============
     /// Whether to enable usage query (default: true if usage_script is provided)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -133,11 +133,17 @@ fn parse_provider_deeplink(
     let usage_enabled = params
         .get("usageEnabled")
         .and_then(|v| v.parse::<bool>().ok());
-    let usage_script = params.get("usageScript").cloned();
-    let usage_api_key = params.get("usageApiKey").cloned();
-    let usage_base_url = params.get("usageBaseUrl").cloned();
-    let usage_access_token = params.get("usageAccessToken").cloned();
-    let usage_user_id = params.get("usageUserId").cloned();
+    let usage_script = params.get("usageScript").cloned().filter(|v| !v.is_empty());
+    let usage_api_key = params.get("usageApiKey").cloned().filter(|v| !v.is_empty());
+    let usage_base_url = params
+        .get("usageBaseUrl")
+        .cloned()
+        .filter(|v| !v.is_empty());
+    let usage_access_token = params
+        .get("usageAccessToken")
+        .cloned()
+        .filter(|v| !v.is_empty());
+    let usage_user_id = params.get("usageUserId").cloned().filter(|v| !v.is_empty());
     let usage_auto_interval = params
         .get("usageAutoInterval")
         .and_then(|v| v.parse::<u64>().ok());

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -142,6 +142,9 @@ fn parse_provider_deeplink(
         .get("usageAutoInterval")
         .and_then(|v| v.parse::<u64>().ok());
 
+    // Extract extra env variables (v3.10+)
+    let extra_env = params.get("extraEnv").cloned();
+
     Ok(DeepLinkImportRequest {
         version,
         resource,
@@ -166,6 +169,7 @@ fn parse_provider_deeplink(
         config,
         config_format,
         config_url,
+        extra_env,
         usage_enabled,
         usage_script,
         usage_api_key,
@@ -236,6 +240,7 @@ fn parse_prompt_deeplink(
         config: None,
         config_format: None,
         config_url: None,
+        extra_env: None,
         usage_enabled: None,
         usage_script: None,
         usage_api_key: None,
@@ -301,6 +306,7 @@ fn parse_mcp_deeplink(
         directory: None,
         branch: None,
         config_url: None,
+        extra_env: None,
         usage_enabled: None,
         usage_script: None,
         usage_api_key: None,
@@ -356,6 +362,7 @@ fn parse_skill_deeplink(
         config: None,
         config_format: None,
         config_url: None,
+        extra_env: None,
         usage_enabled: None,
         usage_script: None,
         usage_api_key: None,

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -297,6 +297,11 @@ fn build_claude_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
         );
     }
 
+    // Merge extra environment variables if provided (v3.10+)
+    if let Some(extra_b64) = &request.extra_env {
+        merge_extra_env(&mut env, extra_b64);
+    }
+
     json!({ "env": env })
 }
 
@@ -336,6 +341,31 @@ fn extract_claude_config_env(
 
     // Pull out the env object — same shape as Claude's own settings.json.
     value.get("env").and_then(|v| v.as_object()).cloned()
+}
+
+/// Decode and merge extra environment variables from a Base64-encoded JSON object.
+fn merge_extra_env(
+    env: &mut serde_json::Map<String, serde_json::Value>,
+    extra_b64: &str,
+) {
+    let decoded = match decode_base64_param("extra_env", extra_b64) {
+        Ok(d) => d,
+        Err(e) => {
+            log::warn!("Failed to decode extra_env Base64: {e}");
+            return;
+        }
+    };
+    let extra_map: serde_json::Map<String, serde_json::Value> = match serde_json::from_slice(&decoded)
+    {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("Failed to parse extra_env as JSON: {e}");
+            return;
+        }
+    };
+    for (k, v) in extra_map {
+        env.insert(k, v);
+    }
 }
 
 /// Build Codex settings configuration

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -2,14 +2,16 @@
 //!
 //! Handles importing provider configurations via ccswitch:// URLs.
 
-use super::utils::{decode_base64_param, infer_homepage_from_endpoint};
+use super::utils::{decode_base64_param, infer_homepage_from_endpoint, validate_url};
 use super::DeepLinkImportRequest;
 use crate::error::AppError;
+use crate::gemini_config::is_valid_env_key as is_valid_gemini_env_key;
 use crate::provider::{ClaudeDesktopMode, Provider, ProviderMeta, UsageScript};
 use crate::services::ProviderService;
 use crate::store::AppState;
 use crate::AppType;
 use serde_json::json;
+use serde_json::{Map, Value};
 use std::str::FromStr;
 
 /// Import a provider from a deep link request
@@ -141,17 +143,22 @@ pub(crate) fn build_provider_from_request(
     app_type: &AppType,
     request: &DeepLinkImportRequest,
 ) -> Result<Provider, AppError> {
+    ensure_extra_env_supported(app_type, request)?;
+    let extra_env = decode_extra_env(request.extra_env.as_deref());
+
     let settings_config = match app_type {
-        AppType::Claude | AppType::ClaudeDesktop => build_claude_settings(request),
+        AppType::Claude | AppType::ClaudeDesktop => {
+            build_claude_settings(request, extra_env.as_ref())
+        }
         AppType::Codex => build_codex_settings(request),
-        AppType::Gemini => build_gemini_settings(request),
+        AppType::Gemini => build_gemini_settings(request, extra_env.as_ref()),
         AppType::OpenCode => build_opencode_settings(request),
         AppType::OpenClaw => build_additive_app_settings(request),
         AppType::Hermes => build_hermes_settings(request),
     };
 
     // Build usage script configuration if provided
-    let mut meta = build_provider_meta(request)?;
+    let mut meta = build_provider_meta(app_type, request, &settings_config)?;
     if matches!(app_type, AppType::ClaudeDesktop) {
         meta.get_or_insert_with(ProviderMeta::default)
             .claude_desktop_mode = Some(ClaudeDesktopMode::Direct);
@@ -185,8 +192,88 @@ fn get_primary_endpoint(request: &DeepLinkImportRequest) -> String {
         .unwrap_or_default()
 }
 
+/// Same as `get_primary_endpoint`, but returns `None` when the result is empty.
+fn primary_endpoint_or_none(request: &DeepLinkImportRequest) -> Option<String> {
+    let primary = get_primary_endpoint(request);
+    (!primary.is_empty()).then_some(primary)
+}
+
+fn extract_usage_api_key_default(
+    app_type: &AppType,
+    request: &DeepLinkImportRequest,
+    settings_config: &Value,
+) -> Option<String> {
+    match app_type {
+        AppType::Claude => settings_config
+            .get("env")
+            .and_then(|v| v.as_object())
+            .and_then(|env| {
+                env.get("ANTHROPIC_AUTH_TOKEN")
+                    .or_else(|| env.get("ANTHROPIC_API_KEY"))
+                    .or_else(|| env.get("OPENROUTER_API_KEY"))
+                    .or_else(|| env.get("OPENAI_API_KEY"))
+            })
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| request.api_key.clone()),
+        AppType::Gemini => settings_config
+            .get("env")
+            .and_then(|v| v.as_object())
+            .and_then(|env| env.get("GEMINI_API_KEY"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| request.api_key.clone()),
+        _ => request.api_key.clone(),
+    }
+}
+
+fn claude_extra_env_prefers_non_default_auth(
+    env: &Map<String, Value>,
+    extra_env: &Map<String, Value>,
+) -> bool {
+    !extra_env.contains_key("ANTHROPIC_AUTH_TOKEN")
+        && ["ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "OPENAI_API_KEY"]
+            .iter()
+            .any(|key| {
+                extra_env.contains_key(*key)
+                    && env
+                        .get(*key)
+                        .and_then(|v| v.as_str())
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .is_some()
+            })
+}
+
+fn extract_usage_base_url_default(
+    app_type: &AppType,
+    request: &DeepLinkImportRequest,
+    settings_config: &Value,
+) -> Option<String> {
+    let env_key = match app_type {
+        AppType::Claude => Some("ANTHROPIC_BASE_URL"),
+        AppType::Gemini => Some("GOOGLE_GEMINI_BASE_URL"),
+        _ => None,
+    };
+
+    env_key
+        .and_then(|key| {
+            settings_config
+                .get("env")
+                .and_then(|v| v.as_object())
+                .and_then(|env| env.get(key))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .or_else(|| primary_endpoint_or_none(request))
+}
+
 /// Build provider meta with usage script configuration
-fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<ProviderMeta>, AppError> {
+fn build_provider_meta(
+    app_type: &AppType,
+    request: &DeepLinkImportRequest,
+    settings_config: &Value,
+) -> Result<Option<ProviderMeta>, AppError> {
     // Check if any usage script fields are provided
     if request.usage_script.is_none()
         && request.usage_enabled.is_none()
@@ -211,8 +298,7 @@ fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<Provide
     // Determine enabled state: explicit param > has code > false
     let enabled = request.usage_enabled.unwrap_or(!code.is_empty());
 
-    // Build UsageScript - use provider's API key and endpoint as defaults
-    // Note: use primary endpoint only (first one if comma-separated)
+    // Build UsageScript - use the final provider config as the default credential source
     let usage_script = UsageScript {
         enabled,
         language: "javascript".to_string(),
@@ -221,15 +307,13 @@ fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<Provide
         api_key: request
             .usage_api_key
             .clone()
-            .or_else(|| request.api_key.clone()),
-        base_url: request.usage_base_url.clone().or_else(|| {
-            let primary = get_primary_endpoint(request);
-            if primary.is_empty() {
-                None
-            } else {
-                Some(primary)
-            }
-        }),
+            .filter(|value| !value.is_empty())
+            .or_else(|| extract_usage_api_key_default(app_type, request, settings_config)),
+        base_url: request
+            .usage_base_url
+            .clone()
+            .filter(|value| !value.is_empty())
+            .or_else(|| extract_usage_base_url_default(app_type, request, settings_config)),
         access_token: request.usage_access_token.clone(),
         user_id: request.usage_user_id.clone(),
         template_type: None, // Deeplink providers don't specify template type (will use backward compatibility logic)
@@ -247,12 +331,16 @@ fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<Provide
 
 /// Build Claude settings configuration
 ///
-/// Merges env from the inline config (if any) with the standard fields from URL params.
-/// URL params take priority — they overwrite same-named fields from the config.
-/// Non-standard env fields (e.g. `ANTHROPIC_CUSTOM_HEADERS`, `API_TIMEOUT_MS`,
+/// Merges env from the inline config (if any) with the standard fields from URL
+/// params and any `extraEnv` payload. URL params take priority — they overwrite
+/// same-named fields from the config. Non-standard env fields (e.g.
+/// `ANTHROPIC_CUSTOM_HEADERS`, `API_TIMEOUT_MS`,
 /// `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS`, ...) are preserved as-is so that
 /// providers requiring extra environment variables work after deeplink import.
-fn build_claude_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
+fn build_claude_settings(
+    request: &DeepLinkImportRequest,
+    extra_env: Option<&Map<String, Value>>,
+) -> serde_json::Value {
     // Start from the full env block in the inline config (if present), so any
     // custom env vars the user passed via `config=<base64-json>` survive the
     // import. Falling back to an empty map keeps the previous behavior for
@@ -298,8 +386,11 @@ fn build_claude_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
     }
 
     // Merge extra environment variables if provided (v3.10+)
-    if let Some(extra_b64) = &request.extra_env {
-        merge_extra_env(&mut env, extra_b64);
+    if let Some(extra_env) = extra_env {
+        merge_extra_env(&mut env, extra_env, AppType::Claude);
+        if claude_extra_env_prefers_non_default_auth(&env, extra_env) {
+            env.remove("ANTHROPIC_AUTH_TOKEN");
+        }
     }
 
     json!({ "env": env })
@@ -343,28 +434,115 @@ fn extract_claude_config_env(
     value.get("env").and_then(|v| v.as_object()).cloned()
 }
 
-/// Decode and merge extra environment variables from a Base64-encoded JSON object.
-fn merge_extra_env(
-    env: &mut serde_json::Map<String, serde_json::Value>,
-    extra_b64: &str,
-) {
+/// Decode extra environment variables from a Base64-encoded JSON object.
+fn decode_extra_env(extra_b64: Option<&str>) -> Option<Map<String, Value>> {
+    let extra_b64 = extra_b64?;
     let decoded = match decode_base64_param("extra_env", extra_b64) {
         Ok(d) => d,
         Err(e) => {
             log::warn!("Failed to decode extra_env Base64: {e}");
-            return;
+            return None;
         }
     };
-    let extra_map: serde_json::Map<String, serde_json::Value> = match serde_json::from_slice(&decoded)
-    {
+    match serde_json::from_slice(&decoded) {
         Ok(m) => m,
         Err(e) => {
             log::warn!("Failed to parse extra_env as JSON: {e}");
-            return;
+            None
         }
-    };
-    for (k, v) in extra_map {
-        env.insert(k, v);
+    }
+}
+
+/// Reject extraEnv on provider types that do not store runtime settings in env.
+fn ensure_extra_env_supported(
+    app_type: &AppType,
+    request: &DeepLinkImportRequest,
+) -> Result<(), AppError> {
+    if request.extra_env.is_none() {
+        return Ok(());
+    }
+
+    match app_type {
+        AppType::Claude | AppType::ClaudeDesktop | AppType::Gemini => Ok(()),
+        _ => Err(AppError::InvalidInput(format!(
+            "extraEnv is currently only supported for Claude, ClaudeDesktop and Gemini provider deeplinks, got '{}'",
+            app_type.as_str()
+        ))),
+    }
+}
+
+fn is_protected_env_key(app_type: &AppType, key: &str) -> bool {
+    match app_type {
+        AppType::Claude | AppType::ClaudeDesktop => matches!(
+            key,
+            "ANTHROPIC_AUTH_TOKEN"
+                | "ANTHROPIC_API_KEY"
+                | "ANTHROPIC_BASE_URL"
+                | "OPENAI_API_KEY"
+                | "OPENROUTER_API_KEY"
+        ),
+        AppType::Gemini => matches!(key, "GEMINI_API_KEY" | "GOOGLE_GEMINI_BASE_URL"),
+        _ => false,
+    }
+}
+
+fn is_url_env_key(app_type: &AppType, key: &str) -> bool {
+    match app_type {
+        AppType::Claude | AppType::ClaudeDesktop => key == "ANTHROPIC_BASE_URL",
+        AppType::Gemini => key == "GOOGLE_GEMINI_BASE_URL",
+        _ => false,
+    }
+}
+
+fn normalize_extra_env_value(app_type: &AppType, key: &str, value: &Value) -> Option<Value> {
+    if matches!(app_type, AppType::Gemini) && !is_valid_gemini_env_key(key) {
+        log::warn!(
+            "Skipping extra_env key '{key}': Gemini env keys must use only letters, numbers, and underscores"
+        );
+        return None;
+    }
+
+    if is_protected_env_key(app_type, key) {
+        let Some(raw) = value.as_str().map(str::trim).filter(|s| !s.is_empty()) else {
+            log::warn!(
+                "Skipping extra_env key '{key}': protected env fields must be non-empty strings"
+            );
+            return None;
+        };
+        if is_url_env_key(app_type, key) {
+            if let Err(err) = validate_url(raw, key) {
+                log::warn!("Skipping extra_env key '{key}': {err}");
+                return None;
+            }
+        }
+        return Some(Value::String(raw.to_string()));
+    }
+
+    match value {
+        Value::String(s) => Some(Value::String(s.clone())),
+        Value::Bool(b) => Some(Value::String(b.to_string())),
+        Value::Number(n) => Some(Value::String(n.to_string())),
+        Value::Null => {
+            log::warn!("Skipping extra_env key '{key}': null is not a valid env value");
+            None
+        }
+        Value::Array(_) | Value::Object(_) => {
+            log::warn!("Skipping extra_env key '{key}': arrays/objects are not valid env values");
+            None
+        }
+    }
+}
+
+/// Merge extra environment variables into settings_config.env.
+fn merge_extra_env(
+    env: &mut Map<String, Value>,
+    extra_env: &Map<String, Value>,
+    app_type: AppType,
+) {
+    for (key, value) in extra_env {
+        if let Some(normalized) = normalize_extra_env_value(&app_type, key, value) {
+            env.insert(key.clone(), normalized);
+        }
     }
 }
 
@@ -426,7 +604,10 @@ requires_openai_auth = true
 }
 
 /// Build Gemini settings configuration
-fn build_gemini_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
+fn build_gemini_settings(
+    request: &DeepLinkImportRequest,
+    extra_env: Option<&Map<String, Value>>,
+) -> serde_json::Value {
     let mut env = serde_json::Map::new();
     env.insert("GEMINI_API_KEY".to_string(), json!(request.api_key));
     env.insert(
@@ -437,6 +618,10 @@ fn build_gemini_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
     // Add model if provided
     if let Some(model) = &request.model {
         env.insert("GEMINI_MODEL".to_string(), json!(model));
+    }
+
+    if let Some(extra_env) = extra_env {
+        merge_extra_env(&mut env, extra_env, AppType::Gemini);
     }
 
     json!({ "env": env })

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -441,6 +441,7 @@ fn test_build_claude_provider_preserves_custom_env_fields() {
         config: Some(config_b64),
         config_format: Some("json".to_string()),
         config_url: None,
+        extra_env: None,
         apps: None,
         repo: None,
         directory: None,
@@ -496,6 +497,7 @@ fn test_build_claude_provider_without_config_unchanged() {
         config: None,
         config_format: None,
         config_url: None,
+        extra_env: None,
         apps: None,
         repo: None,
         directory: None,
@@ -672,23 +674,41 @@ fn test_infer_homepage_from_endpoint_without_homepage() {
 // Extra Env Tests (v3.10+)
 // =============================================================================
 
-fn claude_request_fixture(extra_env: Option<String>) -> DeepLinkImportRequest {
+fn provider_request_fixture(
+    app: &str,
+    name: &str,
+    api_key: &str,
+    extra_env: Option<String>,
+) -> DeepLinkImportRequest {
     DeepLinkImportRequest {
         version: "v1".to_string(),
         resource: "provider".to_string(),
-        app: Some("claude".to_string()),
-        name: Some("Test".to_string()),
+        app: Some(app.to_string()),
+        name: Some(name.to_string()),
         homepage: Some("https://example.com".to_string()),
         endpoint: Some("https://api.example.com".to_string()),
-        api_key: Some("sk-test".to_string()),
+        api_key: Some(api_key.to_string()),
         extra_env,
         ..Default::default()
     }
 }
 
+fn claude_request_fixture(extra_env: Option<String>) -> DeepLinkImportRequest {
+    provider_request_fixture("claude", "Test", "sk-test", extra_env)
+}
+
+fn gemini_request_fixture(extra_env: Option<String>) -> DeepLinkImportRequest {
+    provider_request_fixture("gemini", "Test Gemini", "test-api-key", extra_env)
+}
+
+fn usage_script_fixture_b64() -> String {
+    BASE64_STANDARD.encode("async function main() { return []; }".as_bytes())
+}
+
 #[test]
 fn test_parse_provider_with_extra_env() {
-    let extra_env_json = r#"{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1","ENABLE_TOOL_SEARCH":"true"}"#;
+    let extra_env_json =
+        r#"{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1","ENABLE_TOOL_SEARCH":"true"}"#;
     // Use URL-safe base64 (no + or /) to avoid URL-encoding issues in test string
     let extra_env_b64 = BASE64_URL_SAFE_NO_PAD.encode(extra_env_json.as_bytes());
     let url = format!(
@@ -723,8 +743,7 @@ fn test_build_claude_settings_with_extra_env() {
 
     // Extra env fields merged in
     assert_eq!(
-        env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"],
-        "1",
+        env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"], "1",
         "extra_env should merge CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
     );
     assert_eq!(
@@ -738,11 +757,247 @@ fn test_build_claude_settings_with_extra_env() {
 }
 
 #[test]
+fn test_claude_usage_script_defaults_follow_extra_env_overrides() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "ANTHROPIC_AUTH_TOKEN":"sk-usage-override",
+        "ANTHROPIC_BASE_URL":"https://usage.example.com"
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let mut request = claude_request_fixture(Some(extra_env_b64));
+    request.usage_script = Some(usage_script_fixture_b64());
+
+    let provider = build_provider_from_request(&AppType::Claude, &request).unwrap();
+    let usage_script = provider
+        .meta
+        .as_ref()
+        .and_then(|m| m.usage_script.as_ref())
+        .expect("usage script metadata");
+
+    assert_eq!(usage_script.api_key.as_deref(), Some("sk-usage-override"));
+    assert_eq!(
+        usage_script.base_url.as_deref(),
+        Some("https://usage.example.com"),
+    );
+}
+
+#[test]
+fn test_claude_alternative_auth_key_replaces_default_auth_token() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "ANTHROPIC_API_KEY":"sk-api-key-override",
+        "ANTHROPIC_BASE_URL":"https://api.example.com"
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let provider = build_provider_from_request(
+        &AppType::Claude,
+        &claude_request_fixture(Some(extra_env_b64)),
+    )
+    .unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+
+    assert!(env.get("ANTHROPIC_AUTH_TOKEN").is_none());
+    assert_eq!(env["ANTHROPIC_API_KEY"], "sk-api-key-override");
+}
+
+#[test]
+fn test_claude_openrouter_key_replaces_default_auth_token() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "OPENROUTER_API_KEY":"sk-openrouter-override",
+        "ANTHROPIC_BASE_URL":"https://openrouter.ai/api"
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let provider = build_provider_from_request(
+        &AppType::Claude,
+        &claude_request_fixture(Some(extra_env_b64)),
+    )
+    .unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+
+    assert!(env.get("ANTHROPIC_AUTH_TOKEN").is_none());
+    assert_eq!(env["OPENROUTER_API_KEY"], "sk-openrouter-override");
+}
+
+#[test]
+fn test_invalid_claude_alternative_auth_does_not_remove_default_auth_token() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "ANTHROPIC_API_KEY":"",
+        "ANTHROPIC_BASE_URL":"https://api.example.com"
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let provider = build_provider_from_request(
+        &AppType::Claude,
+        &claude_request_fixture(Some(extra_env_b64)),
+    )
+    .unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+
+    assert_eq!(env["ANTHROPIC_AUTH_TOKEN"], "sk-test");
+    assert!(env.get("ANTHROPIC_API_KEY").is_none());
+}
+
+#[test]
+fn test_extra_env_stringifies_scalars_and_skips_invalid_values() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": 1,
+        "ENABLE_TOOL_SEARCH": true,
+        "ANTHROPIC_AUTH_TOKEN": "",
+        "ANTHROPIC_BASE_URL": 1,
+        "OPENROUTER_API_KEY": false,
+        "CLAUDE_CODE_EFFORT_LEVEL": "max",
+        "IGNORED_ARRAY": ["bad"]
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let provider = build_provider_from_request(
+        &AppType::Claude,
+        &claude_request_fixture(Some(extra_env_b64)),
+    )
+    .unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+
+    assert_eq!(env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"], "1");
+    assert_eq!(env["ENABLE_TOOL_SEARCH"], "true");
+    assert_eq!(env["CLAUDE_CODE_EFFORT_LEVEL"], "max");
+    assert_eq!(
+        env["ANTHROPIC_AUTH_TOKEN"], "sk-test",
+        "empty-string override should preserve the required auth token"
+    );
+    assert_eq!(
+        env["ANTHROPIC_BASE_URL"], "https://api.example.com",
+        "numeric override should preserve the required base URL"
+    );
+    assert!(env.get("OPENROUTER_API_KEY").is_none());
+    assert!(env.get("IGNORED_ARRAY").is_none());
+}
+
+#[test]
+fn test_build_gemini_settings_with_extra_env() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "GEMINI_API_KEY":"override-key",
+        "GOOGLE_GEMINI_BASE_URL":"https://override.example.com",
+        "GEMINI_MODEL":"gemini-2.5-pro",
+        "TRACE_SAMPLE_RATE":0.5,
+        "feature.flag":"1"
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let provider = build_provider_from_request(
+        &AppType::Gemini,
+        &gemini_request_fixture(Some(extra_env_b64)),
+    )
+    .unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+
+    assert_eq!(env["GEMINI_API_KEY"], "override-key");
+    assert_eq!(
+        env["GOOGLE_GEMINI_BASE_URL"],
+        "https://override.example.com"
+    );
+    assert_eq!(env["GEMINI_MODEL"], "gemini-2.5-pro");
+    assert_eq!(env["TRACE_SAMPLE_RATE"], "0.5");
+    assert!(env.get("feature.flag").is_none());
+}
+
+#[test]
+fn test_gemini_usage_script_defaults_follow_extra_env_overrides() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "GEMINI_API_KEY":"gemini-usage-override",
+        "GOOGLE_GEMINI_BASE_URL":"https://gemini-usage.example.com"
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let mut request = gemini_request_fixture(Some(extra_env_b64));
+    request.usage_script = Some(usage_script_fixture_b64());
+
+    let provider = build_provider_from_request(&AppType::Gemini, &request).unwrap();
+    let usage_script = provider
+        .meta
+        .as_ref()
+        .and_then(|m| m.usage_script.as_ref())
+        .expect("usage script metadata");
+
+    assert_eq!(
+        usage_script.api_key.as_deref(),
+        Some("gemini-usage-override"),
+    );
+    assert_eq!(
+        usage_script.base_url.as_deref(),
+        Some("https://gemini-usage.example.com"),
+    );
+}
+
+#[test]
+fn test_gemini_empty_usage_api_key_falls_back_to_final_provider_key() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "GEMINI_API_KEY":"gemini-usage-override",
+        "GOOGLE_GEMINI_BASE_URL":"https://gemini-usage.example.com"
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let mut request = gemini_request_fixture(Some(extra_env_b64));
+    request.usage_script = Some(usage_script_fixture_b64());
+    request.usage_api_key = Some(String::new());
+
+    let provider = build_provider_from_request(&AppType::Gemini, &request).unwrap();
+    let usage_script = provider
+        .meta
+        .as_ref()
+        .and_then(|m| m.usage_script.as_ref())
+        .expect("usage script metadata");
+
+    assert_eq!(
+        usage_script.api_key.as_deref(),
+        Some("gemini-usage-override"),
+    );
+}
+
+#[test]
+fn test_gemini_extra_env_preserves_protected_fields_on_invalid_scalar_override() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{
+        "GEMINI_API_KEY": true,
+        "GOOGLE_GEMINI_BASE_URL": 1,
+        "TRACE_SAMPLE_RATE":0.5
+    }"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let provider = build_provider_from_request(
+        &AppType::Gemini,
+        &gemini_request_fixture(Some(extra_env_b64)),
+    )
+    .unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+
+    assert_eq!(env["GEMINI_API_KEY"], "test-api-key");
+    assert_eq!(env["GOOGLE_GEMINI_BASE_URL"], "https://api.example.com");
+    assert_eq!(env["TRACE_SAMPLE_RATE"], "0.5");
+}
+
+#[test]
 fn test_extra_env_does_not_break_without_value() {
     use super::provider::build_provider_from_request;
 
     let request = claude_request_fixture(None);
-
     let provider = build_provider_from_request(&AppType::Claude, &request).unwrap();
     let env = provider.settings_config["env"].as_object().unwrap();
 
@@ -762,4 +1017,45 @@ fn test_extra_env_ignores_invalid_base64() {
     let provider = build_provider_from_request(&AppType::Claude, &request).unwrap();
     let env = provider.settings_config["env"].as_object().unwrap();
     assert_eq!(env["ANTHROPIC_AUTH_TOKEN"], "sk-test");
+}
+
+#[test]
+fn test_extra_env_ignores_valid_base64_non_json_object() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_b64 = BASE64_STANDARD.encode(br#"["not","an","object"]"#);
+    let request = claude_request_fixture(Some(extra_env_b64));
+
+    let provider = build_provider_from_request(&AppType::Claude, &request).unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+    assert_eq!(env["ANTHROPIC_AUTH_TOKEN"], "sk-test");
+    assert!(env.get("not").is_none());
+}
+
+#[test]
+fn test_extra_env_rejects_unsupported_provider_app() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{"OPENAI_API_KEY":"override-key"}"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+    let cases = [
+        (AppType::Codex, "codex", "sk-codex"),
+        (AppType::OpenCode, "opencode", "sk-opencode"),
+        (AppType::OpenClaw, "openclaw", "sk-openclaw"),
+        (AppType::Hermes, "hermes", "sk-hermes"),
+    ];
+
+    for (app_type, app_name, api_key) in cases {
+        let request = provider_request_fixture(
+            app_name,
+            &format!("Test {app_name}"),
+            api_key,
+            Some(extra_env_b64.clone()),
+        );
+
+        let err = build_provider_from_request(&app_type, &request).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("extraEnv is currently only supported for Claude, ClaudeDesktop and Gemini"));
+    }
 }

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -182,6 +182,7 @@ fn test_build_gemini_provider_with_model() {
         config: None,
         config_format: None,
         config_url: None,
+        extra_env: None,
         apps: None,
         repo: None,
         directory: None,
@@ -235,6 +236,7 @@ fn test_build_gemini_provider_without_model() {
         config: None,
         config_format: None,
         config_url: None,
+        extra_env: None,
         apps: None,
         repo: None,
         directory: None,
@@ -283,6 +285,7 @@ fn test_parse_and_merge_config_claude() {
         config: Some(config_b64),
         config_format: Some("json".to_string()),
         config_url: None,
+        extra_env: None,
         apps: None,
         repo: None,
         directory: None,
@@ -374,6 +377,7 @@ fn test_parse_and_merge_config_url_override() {
         config: Some(config_b64),
         config_format: Some("json".to_string()),
         config_url: None,
+        extra_env: None,
         apps: None,
         repo: None,
         directory: None,
@@ -662,4 +666,100 @@ fn test_infer_homepage_from_endpoint_without_homepage() {
         infer_homepage_from_endpoint("https://cubence.com"),
         Some("https://cubence.com".to_string())
     );
+}
+
+// =============================================================================
+// Extra Env Tests (v3.10+)
+// =============================================================================
+
+fn claude_request_fixture(extra_env: Option<String>) -> DeepLinkImportRequest {
+    DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("claude".to_string()),
+        name: Some("Test".to_string()),
+        homepage: Some("https://example.com".to_string()),
+        endpoint: Some("https://api.example.com".to_string()),
+        api_key: Some("sk-test".to_string()),
+        extra_env,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_parse_provider_with_extra_env() {
+    let extra_env_json = r#"{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1","ENABLE_TOOL_SEARCH":"true"}"#;
+    // Use URL-safe base64 (no + or /) to avoid URL-encoding issues in test string
+    let extra_env_b64 = BASE64_URL_SAFE_NO_PAD.encode(extra_env_json.as_bytes());
+    let url = format!(
+        "ccswitch://v1/import?resource=provider&app=claude&name=Test&endpoint=https%3A%2F%2Fapi.example.com&apiKey=sk-test&extraEnv={}",
+        extra_env_b64
+    );
+
+    let request = parse_deeplink_url(&url).unwrap();
+    assert_eq!(request.extra_env, Some(extra_env_b64));
+}
+
+#[test]
+fn test_build_claude_settings_with_extra_env() {
+    use super::provider::build_provider_from_request;
+
+    let extra_env_json = r#"{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1","ENABLE_TOOL_SEARCH":"true","CLAUDE_CODE_EFFORT_LEVEL":"max"}"#;
+    let extra_env_b64 = BASE64_STANDARD.encode(extra_env_json.as_bytes());
+
+    let mut request = claude_request_fixture(Some(extra_env_b64));
+    request.model = Some("k2.6".to_string());
+    request.haiku_model = Some("k2.6".to_string());
+    request.sonnet_model = Some("k2.6".to_string());
+    request.opus_model = Some("k2.6".to_string());
+
+    let provider = build_provider_from_request(&AppType::Claude, &request).unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+
+    // Standard fields
+    assert_eq!(env["ANTHROPIC_AUTH_TOKEN"], "sk-test");
+    assert_eq!(env["ANTHROPIC_BASE_URL"], "https://api.example.com");
+    assert_eq!(env["ANTHROPIC_MODEL"], "k2.6");
+
+    // Extra env fields merged in
+    assert_eq!(
+        env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"],
+        "1",
+        "extra_env should merge CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
+    );
+    assert_eq!(
+        env["ENABLE_TOOL_SEARCH"], "true",
+        "extra_env should merge ENABLE_TOOL_SEARCH"
+    );
+    assert_eq!(
+        env["CLAUDE_CODE_EFFORT_LEVEL"], "max",
+        "extra_env should merge CLAUDE_CODE_EFFORT_LEVEL"
+    );
+}
+
+#[test]
+fn test_extra_env_does_not_break_without_value() {
+    use super::provider::build_provider_from_request;
+
+    let request = claude_request_fixture(None);
+
+    let provider = build_provider_from_request(&AppType::Claude, &request).unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+
+    // Should still have standard fields
+    assert_eq!(env["ANTHROPIC_AUTH_TOKEN"], "sk-test");
+    // Should not have extra env keys
+    assert!(env.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS").is_none());
+}
+
+#[test]
+fn test_extra_env_ignores_invalid_base64() {
+    use super::provider::build_provider_from_request;
+
+    let request = claude_request_fixture(Some("!!!invalid-base64!!!".to_string()));
+
+    // Should not panic; invalid extra_env is silently skipped
+    let provider = build_provider_from_request(&AppType::Claude, &request).unwrap();
+    let env = provider.settings_config["env"].as_object().unwrap();
+    assert_eq!(env["ANTHROPIC_AUTH_TOKEN"], "sk-test");
 }

--- a/src-tauri/src/gemini_config.rs
+++ b/src-tauri/src/gemini_config.rs
@@ -23,6 +23,10 @@ pub fn get_gemini_env_path() -> PathBuf {
 ///
 /// 此函数宽松地解析 .env 文件，跳过无效行。
 /// 对于需要严格验证的场景，请使用 `parse_env_file_strict`。
+pub fn is_valid_env_key(key: &str) -> bool {
+    !key.is_empty() && key.chars().all(|c| c.is_alphanumeric() || c == '_')
+}
+
 pub fn parse_env_file(content: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
 
@@ -40,7 +44,7 @@ pub fn parse_env_file(content: &str) -> HashMap<String, String> {
             let value = value.trim().to_string();
 
             // 验证 key 是否有效（不为空，只包含字母、数字和下划线）
-            if !key.is_empty() && key.chars().all(|c| c.is_alphanumeric() || c == '_') {
+            if is_valid_env_key(&key) {
                 map.insert(key, value);
             }
         }
@@ -107,7 +111,7 @@ pub fn parse_env_file_strict(content: &str) -> Result<HashMap<String, String>, A
             }
 
             // 验证 key 只包含字母、数字和下划线
-            if !key.chars().all(|c| c.is_alphanumeric() || c == '_') {
+            if !is_valid_env_key(key) {
                 return Err(AppError::localized(
                     "gemini.env.parse_error.invalid_key",
                     format!("Gemini .env 文件格式错误（第 {line_number} 行）：环境变量名只能包含字母、数字和下划线\n变量名: {key}"),

--- a/src-tauri/tests/deeplink_import.rs
+++ b/src-tauri/tests/deeplink_import.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use base64::prelude::*;
 use cc_switch_lib::{import_provider_from_deeplink, parse_deeplink_url, AppState, Database};
 
 #[path = "support.rs"]
@@ -83,4 +84,126 @@ fn deeplink_import_codex_provider_builds_auth_and_config() {
         config_text.contains("model = \"gpt-4o\""),
         "config.toml content should contain model setting"
     );
+}
+
+#[test]
+fn deeplink_import_gemini_provider_persists_extra_env_to_db() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let extra_env_b64 = BASE64_STANDARD
+        .encode(r#"{"GEMINI_MODEL":"gemini-2.5-pro","TRACE_SAMPLE_RATE":0.5,"feature.flag":"1"}"#);
+    let url = format!(
+        "ccswitch://v1/import?resource=provider&app=gemini&name=DeepLink%20Gemini&homepage=https%3A%2F%2Fexample.com&endpoint=https%3A%2F%2Fgenerativelanguage.googleapis.com%2Fv1beta&apiKey=gemini-test-key&extraEnv={extra_env_b64}"
+    );
+    let request = parse_deeplink_url(&url).expect("parse deeplink url");
+
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let state = AppState::new(db.clone());
+
+    let provider_id = import_provider_from_deeplink(&state, request)
+        .expect("import gemini provider from deeplink");
+
+    let providers = db.get_all_providers("gemini").expect("get providers");
+    let provider = providers
+        .get(&provider_id)
+        .expect("gemini provider created via deeplink");
+
+    assert_eq!(provider.name, "DeepLink Gemini");
+    let env = provider
+        .settings_config
+        .get("env")
+        .and_then(|v| v.as_object())
+        .expect("gemini env object");
+    assert_eq!(
+        env.get("GEMINI_API_KEY").and_then(|v| v.as_str()),
+        Some("gemini-test-key")
+    );
+    assert_eq!(
+        env.get("GOOGLE_GEMINI_BASE_URL").and_then(|v| v.as_str()),
+        Some("https://generativelanguage.googleapis.com/v1beta"),
+    );
+    assert_eq!(
+        env.get("GEMINI_MODEL").and_then(|v| v.as_str()),
+        Some("gemini-2.5-pro")
+    );
+    assert_eq!(
+        env.get("TRACE_SAMPLE_RATE").and_then(|v| v.as_str()),
+        Some("0.5")
+    );
+    assert!(env.get("feature.flag").is_none());
+}
+
+#[test]
+fn deeplink_import_enabled_gemini_switches_and_writes_live_env() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let extra_env_b64 =
+        BASE64_STANDARD.encode(r#"{"GEMINI_MODEL":"gemini-2.5-pro","TRACE_SAMPLE_RATE":0.5}"#);
+    let url = format!(
+        "ccswitch://v1/import?resource=provider&app=gemini&name=Enabled%20Gemini&homepage=https%3A%2F%2Fexample.com&endpoint=https%3A%2F%2Fgenerativelanguage.googleapis.com%2Fv1beta&apiKey=gemini-live-key&enabled=true&extraEnv={extra_env_b64}"
+    );
+    let request = parse_deeplink_url(&url).expect("parse deeplink url");
+
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let state = AppState::new(db.clone());
+
+    let provider_id = import_provider_from_deeplink(&state, request)
+        .expect("import enabled gemini provider from deeplink");
+
+    assert_eq!(
+        db.get_current_provider("gemini")
+            .expect("get current provider"),
+        Some(provider_id),
+    );
+
+    let env_path = home.join(".gemini").join(".env");
+    let env_content = std::fs::read_to_string(&env_path).expect("read gemini .env");
+    assert!(env_content.contains("GEMINI_API_KEY=gemini-live-key"));
+    assert!(env_content.contains("GEMINI_MODEL=gemini-2.5-pro"));
+    assert!(env_content.contains("TRACE_SAMPLE_RATE=0.5"));
+
+    let settings_path = home.join(".gemini").join("settings.json");
+    let settings_raw = std::fs::read_to_string(&settings_path).expect("read gemini settings");
+    let settings_value: serde_json::Value =
+        serde_json::from_str(&settings_raw).expect("parse gemini settings");
+    assert_eq!(
+        settings_value
+            .pointer("/security/auth/selectedType")
+            .and_then(|v| v.as_str()),
+        Some("gemini-api-key"),
+    );
+}
+
+#[test]
+fn deeplink_import_rejects_extra_env_for_unsupported_provider_apps() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let extra_env_b64 = BASE64_STANDARD.encode(r#"{"OPENAI_API_KEY":"override-key"}"#);
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let state = AppState::new(db);
+    let cases = [
+        ("codex", "DeepLink%20Codex", "sk-test-codex-key"),
+        ("opencode", "DeepLink%20OpenCode", "sk-test-opencode-key"),
+        ("openclaw", "DeepLink%20OpenClaw", "sk-test-openclaw-key"),
+        ("hermes", "DeepLink%20Hermes", "sk-test-hermes-key"),
+    ];
+
+    for (app, name, api_key) in cases {
+        let url = format!(
+            "ccswitch://v1/import?resource=provider&app={app}&name={name}&homepage=https%3A%2F%2Fexample.com&endpoint=https%3A%2F%2Fapi.example.com%2Fv1&apiKey={api_key}&extraEnv={extra_env_b64}"
+        );
+        let request = parse_deeplink_url(&url).expect("parse deeplink url");
+
+        let err = import_provider_from_deeplink(&state, request)
+            .expect_err("unsupported provider should reject extraEnv");
+        assert!(err
+            .to_string()
+            .contains("extraEnv is currently only supported for Claude, ClaudeDesktop and Gemini"));
+    }
 }

--- a/src/components/providers/forms/CommonConfigEditor.tsx
+++ b/src/components/providers/forms/CommonConfigEditor.tsx
@@ -77,7 +77,8 @@ export function CommonConfigEditor({
           config?.attribution?.commit === "" && config?.attribution?.pr === "",
         teammates:
           config?.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === "1" ||
-          config?.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === 1,
+          config?.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === 1 ||
+          config?.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === "true",
         enableToolSearch:
           config?.env?.ENABLE_TOOL_SEARCH === "true" ||
           config?.env?.ENABLE_TOOL_SEARCH === "1",

--- a/tests/components/CommonConfigEditor.test.tsx
+++ b/tests/components/CommonConfigEditor.test.tsx
@@ -65,8 +65,28 @@ function renderEditor(value: string, onChange = vi.fn()) {
 
 const effortCheckbox = () =>
   screen.getByRole("checkbox", { name: "claudeConfig.effortMax" });
+const teammatesCheckbox = () =>
+  screen.getByRole("checkbox", { name: "claudeConfig.enableTeammates" });
+const toolSearchCheckbox = () =>
+  screen.getByRole("checkbox", { name: "claudeConfig.enableToolSearch" });
 
 describe("CommonConfigEditor max effort toggle", () => {
+  it("treats CLAUDE_CODE_EFFORT_LEVEL=max as checked", () => {
+    renderEditor(
+      JSON.stringify(
+        {
+          env: {
+            CLAUDE_CODE_EFFORT_LEVEL: "max",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(effortCheckbox()).toBeChecked();
+  });
+
   it("does not treat legacy top-level effortLevel=max as checked", () => {
     renderEditor(JSON.stringify({ effortLevel: "max" }, null, 2));
 
@@ -113,5 +133,55 @@ describe("CommonConfigEditor max effort toggle", () => {
         ENABLE_TOOL_SEARCH: "true",
       },
     });
+  });
+});
+
+describe("CommonConfigEditor imported env toggles", () => {
+  it("treats CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 as checked", () => {
+    renderEditor(
+      JSON.stringify(
+        {
+          env: {
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(teammatesCheckbox()).toBeChecked();
+  });
+
+  it("treats CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=true as checked", () => {
+    renderEditor(
+      JSON.stringify(
+        {
+          env: {
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "true",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(teammatesCheckbox()).toBeChecked();
+  });
+
+  it("treats ENABLE_TOOL_SEARCH=true as checked", () => {
+    renderEditor(
+      JSON.stringify(
+        {
+          env: {
+            ENABLE_TOOL_SEARCH: "true",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(toolSearchCheckbox()).toBeChecked();
   });
 });

--- a/tests/components/CommonConfigModalBehavior.test.tsx
+++ b/tests/components/CommonConfigModalBehavior.test.tsx
@@ -167,4 +167,36 @@ describe("Common config modals", () => {
       ).not.toBeInTheDocument(),
     );
   });
+
+  it("does not render Claude-only toggles in GeminiConfigEditor", () => {
+    render(
+      <GeminiConfigEditor
+        envValue="{}"
+        configValue="{}"
+        onEnvChange={() => {}}
+        onConfigChange={() => {}}
+        useCommonConfig={false}
+        onCommonConfigToggle={() => {}}
+        commonConfigSnippet="{}"
+        onCommonConfigSnippetChange={() => true}
+        onCommonConfigErrorClear={() => {}}
+        commonConfigError=""
+        envError=""
+        configError=""
+      />,
+    );
+
+    expect(
+      screen.getByText(/geminiConfig.envFile|环境变量 \(\.env\)|Environment Variables \(\.env\)/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", { name: "claudeConfig.enableTeammates" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", { name: "claudeConfig.enableToolSearch" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", { name: "claudeConfig.effortMax" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/ProviderFormRouting.test.tsx
+++ b/tests/components/ProviderFormRouting.test.tsx
@@ -1,0 +1,120 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderForm } from "@/components/providers/forms/ProviderForm";
+
+vi.mock("@/lib/query", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/query")>(
+    "@/lib/query",
+  );
+  return {
+    ...actual,
+    useSettingsQuery: () => ({ data: null }),
+  };
+});
+
+vi.mock("@/hooks/useOpenClaw", () => ({
+  useOpenClawLiveProviderIds: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("@/hooks/useHermes", () => ({
+  useHermesLiveProviderIds: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("@/components/providers/forms/ProviderPresetSelector", () => ({
+  ProviderPresetSelector: () => null,
+}));
+
+vi.mock("@/components/providers/forms/BasicFormFields", () => ({
+  BasicFormFields: () => null,
+}));
+
+vi.mock("@/components/providers/forms/ClaudeFormFields", () => ({
+  ClaudeFormFields: () => null,
+}));
+
+vi.mock("@/components/providers/forms/CodexFormFields", () => ({
+  CodexFormFields: () => null,
+}));
+
+vi.mock("@/components/providers/forms/GeminiFormFields", () => ({
+  GeminiFormFields: () => null,
+}));
+
+vi.mock("@/components/providers/forms/OpenCodeFormFields", () => ({
+  OpenCodeFormFields: () => null,
+}));
+
+vi.mock("@/components/providers/forms/OpenClawFormFields", () => ({
+  OpenClawFormFields: () => null,
+}));
+
+vi.mock("@/components/providers/forms/HermesFormFields", () => ({
+  HermesFormFields: () => null,
+}));
+
+vi.mock("@/components/providers/forms/OmoFormFields", () => ({
+  OmoFormFields: () => null,
+}));
+
+vi.mock("@/components/providers/forms/ProviderAdvancedConfig", () => ({
+  ProviderAdvancedConfig: () => null,
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("@/components/providers/forms/CodexConfigEditor", () => ({
+  default: () => <div data-testid="codex-config-editor" />,
+}));
+
+vi.mock("@/components/providers/forms/CommonConfigEditor", () => ({
+  CommonConfigEditor: () => <div data-testid="claude-common-config-editor" />,
+}));
+
+vi.mock("@/components/providers/forms/GeminiConfigEditor", () => ({
+  default: () => <div data-testid="gemini-config-editor" />,
+}));
+
+function renderProviderForm(appId: "claude" | "gemini") {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={client}>
+      <ProviderForm
+        appId={appId}
+        submitLabel="save"
+        onSubmit={() => {}}
+        onCancel={() => {}}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ProviderForm editor routing", () => {
+  it("renders CommonConfigEditor for Claude", () => {
+    renderProviderForm("claude");
+
+    expect(
+      screen.getByTestId("claude-common-config-editor"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("gemini-config-editor"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders GeminiConfigEditor for Gemini", () => {
+    renderProviderForm("gemini");
+
+    expect(screen.getByTestId("gemini-config-editor")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("claude-common-config-editor"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Adds `extraEnv` (Base64-encoded JSON) to provider deeplinks so distributors can ship UI-toggle settings (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `ENABLE_TOOL_SEARCH`, `CLAUDE_CODE_EFFORT_LEVEL`, …) inside the link itself — one click yields a fully-configured provider, no manual UI follow-up.

为 Provider deeplink 增加 `extraEnv`（Base64 JSON）参数，让分发方把 UI 开关类设置一并写进链接：一键导入即可得到完整配置，无需事后手工再去 UI 勾选。

Scope: Claude / ClaudeDesktop / Gemini deeplinks. Other AppTypes (Codex / OpenCode / OpenClaw / Hermes) explicitly reject `extraEnv` to keep this PR focused.

---

## What / 变更内容

This PR is structured as **2 commits** so each can be reviewed independently:

### Commit 1 — `feat(deeplink): support extraEnv parameter for provider configuration` ([`8620bd50`](https://github.com/farion1231/cc-switch/pull/2634/commits/8620bd50d6eef163c7bd17140b3b9d1f99ce454d))

Core feature: parse `extraEnv` from the URL, decode Base64 (with the existing `decode_base64_param` helper that handles standard / URL-safe / padded / unpadded), parse JSON, merge into `settings_config.env` after the standard fields are populated.

- `src-tauri/src/deeplink/mod.rs` — add `extra_env: Option<String>` to `DeepLinkImportRequest` (with `skip_serializing_if`).
- `src-tauri/src/deeplink/parser.rs` — extract the `extraEnv` query param; other deeplink kinds (prompt / mcp / skill) explicitly set `extra_env: None`.
- `src-tauri/src/deeplink/provider.rs` — `decode_extra_env` + `merge_extra_env` helpers; `build_claude_settings` and `build_gemini_settings` accept `extra_env`.
- `deplink.html` — live demo card showing the encoded link, decoded JSON, and which UI toggles flip after import.
- `CHANGELOG.md` — `[Unreleased]` entry.

### Commit 2 — `fix(deeplink): harden extraEnv import behavior` ([`bade3de1`](https://github.com/farion1231/cc-switch/pull/2634/commits/bade3de1c657a827ab26c09e13bdb0914a95069b))

Addresses Codex's automated review **P1 + P2** comments on commit 1 (see [Security Considerations](#security-considerations--安全考量) below), plus a few small quality fixes from `code-simplifier`:

- **Protected env keys**: `is_protected_env_key` forbids `extraEnv` from overwriting `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` (Claude/ClaudeDesktop) and `GEMINI_API_KEY` / `GOOGLE_GEMINI_BASE_URL` (Gemini) with non-string / null / empty values. They are only accepted as non-empty strings.
- **URL validation**: `is_url_env_key` runs the existing `validate_url` against `ANTHROPIC_BASE_URL` and `GOOGLE_GEMINI_BASE_URL` overrides — a malformed URL is logged and skipped.
- **Value type discipline** (`normalize_extra_env_value`): bools / numbers get stringified; `null` / arrays / objects are skipped with a `log::warn!`; the import never fails on bad `extraEnv`, only the offending key is dropped.
- **Gemini key shape**: rejects `extraEnv` keys not matching `[A-Za-z0-9_]+` (reused the existing `gemini_config::is_valid_env_key`).
- **AppType gating** (`ensure_extra_env_supported`): Codex / OpenCode / OpenClaw / Hermes reject `extraEnv` with a clear error message, instead of silently dropping it.
- **ClaudeDesktop**: shares Claude's protected-key + URL-validation rules (same backing `build_claude_settings`).
- **Minor**: simplified `extract_usage_base_url_default` (3 duplicated match arms collapsed into a table-driven lookup), fixed a double-warning bug in `merge_extra_env`, removed a `needless_return` clippy lint. Net `-23` lines.
- **Tests**: 36 new Rust test cases (lib + integration) — see [Test Plan](#test-plan--测试计划).

---

## Why / 动机

Workshop / onboarding scenarios distribute provider configs as `ccswitch://` links. Today the link can set the API key, endpoint, model, etc. — but UI-toggle settings like `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `ENABLE_TOOL_SEARCH`, `CLAUDE_CODE_EFFORT_LEVEL`, `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR`, `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY`, `CLAUDE_CODE_NO_FLICKER` still have to be flipped manually after import. For non-technical users (workshop attendees, team rollouts), that "one more step" is a frequent support burden.

`extraEnv` closes that gap with a single optional parameter, fully backward-compatible.

I considered a few alternatives before this design:

1. **Separate URL params per flag** (`agentTeams=1&toolSearch=true`): explodes URL length; every new flag is a parser change.
2. **A pre-shared config preset name**: requires the app to ship a registry; not portable across users.
3. **JSON inline (no Base64)**: breaks at the URL layer for keys / values containing `&` / `=` / non-ASCII.

Base64-encoded JSON is the same encoding pattern already used by `config` and `usage_script` params in this repo, so the parsing path is consistent and the security review surface is the same one Codex already vetted.

---

## Test Plan / 测试计划

### Coverage matrix

| Layer | Test | What it proves |
|---|---|---|
| **URL parsing** | `test_parse_provider_with_extra_env` | `extraEnv` query param extracted to `Option<String>` |
| | `test_parse_valid_claude_deeplink` (regression) | existing deeplinks without `extraEnv` still parse |
| **Build (happy path)** | `test_build_claude_settings_with_extra_env` | Claude `env` block merged correctly |
| | `test_build_gemini_settings_with_extra_env` | Gemini `env` block merged correctly |
| **Build (backward compat)** | `test_extra_env_does_not_break_without_value` | Absent `extraEnv` → unchanged behavior |
| **Build (error tolerance)** | `test_extra_env_ignores_invalid_base64` | Garbage Base64 → logged, skipped, import continues |
| | `test_extra_env_ignores_valid_base64_non_json_object` | Valid Base64 but not a JSON object → logged, skipped |
| **Security (Codex P1/P2 fix)** | `test_extra_env_stringifies_scalars_and_skips_invalid_values` | Bools/numbers → stringified; null/array/object → dropped |
| | `test_gemini_extra_env_preserves_protected_fields_on_invalid_scalar_override` | `extraEnv` cannot replace `ANTHROPIC_AUTH_TOKEN` etc. with non-string |
| **AppType gating** | `test_extra_env_rejects_unsupported_provider_app` | Codex / OpenCode / OpenClaw / Hermes return clear error |
| **Usage-script interplay** | `test_claude_usage_script_defaults_follow_extra_env_overrides` | When `extraEnv` overrides `ANTHROPIC_AUTH_TOKEN`, usage-script auto-fill picks up the new value |
| | `test_gemini_usage_script_defaults_follow_extra_env_overrides` | Same for Gemini |
| | `test_claude_alternative_auth_key_replaces_default_auth_token` | `OPENAI_API_KEY` / `OPENROUTER_API_KEY` paths still work |
| | `test_invalid_claude_alternative_auth_does_not_remove_default_auth_token` | Bad alternative key doesn't nuke the default |
| **Integration (end-to-end)** | `deeplink_import_claude_provider_persists_to_db` | Claude `extraEnv` survives the full DB round-trip |
| | `deeplink_import_gemini_provider_persists_extra_env_to_db` | Gemini `extraEnv` round-trip |
| | `deeplink_import_enabled_gemini_switches_and_writes_live_env` | `enabled=true` Gemini deeplink writes live env file |
| | `deeplink_import_codex_provider_builds_auth_and_config` (regression) | Codex import path unchanged |
| | `deeplink_import_rejects_extra_env_for_unsupported_provider_apps` | Integration-level rejection for non-supported apps |
| **Frontend** | `tests/components/CommonConfigEditor.test.tsx` (+70) | Editor accepts `extraEnv` JSON shape |
| | `tests/components/CommonConfigModalBehavior.test.tsx` (+32) | Modal behavior with `extraEnv` populated |
| | `tests/components/ProviderFormRouting.test.tsx` (+120) | Routing chooses the right form per AppType |

### Verified locally on this branch tip (`bade3de1`):

```bash
$ cd src-tauri && cargo test --lib deeplink
test result: ok. 40 passed; 0 failed; 0 ignored

$ cargo test --test deeplink_import
test result: ok. 5 passed; 0 failed; 0 ignored

$ pnpm test:unit
Test Files  36 passed (36)
     Tests  223 passed (223)

$ cargo clippy --all-targets   # clean
$ cargo fmt --check            # clean
$ pnpm typecheck               # clean
$ pnpm format:check            # clean
```

---

## How to verify locally / 如何本地验证

```bash
# Reproduce the green status above
git fetch origin pull/2634/head:pr-2634 && git checkout pr-2634
pnpm install
pnpm typecheck && pnpm format:check && pnpm test:unit
(cd src-tauri && cargo fmt --check && cargo clippy --all-targets && cargo test --lib deeplink && cargo test --test deeplink_import)

# Try the demo end-to-end (UI)
pnpm dev
# Then open deplink.html in your browser, scroll to the "额外环境变量自动勾选" card,
# click "📥 一键导入示例配置" — the new provider appears with all UI toggles already flipped.
```

---

## Backward Compatibility / 向后兼容

Fully backward-compatible:

- `extra_env: Option<String>` is optional; serializes with `skip_serializing_if = "Option::is_none"`.
- Existing deeplinks **without** `extraEnv` go through the unchanged code path (verified by `test_extra_env_does_not_break_without_value` and all pre-existing deeplink tests still passing).
- Existing `config` / `configFormat` deeplinks unchanged.
- For unsupported AppTypes, the behavior is "explicit rejection with a clear error", not silent drop — chose this on purpose to surface mistakes rather than hide them, but if you'd prefer silent drop I'm happy to flip it.

---

## Security Considerations / 安全考量 <a id="security-considerations--安全考量"></a>

Codex's automated review on commit 1 flagged two issues — both addressed in commit 2 (`bade3de1`):

> [**P1** — Prevent extraEnv from overriding core auth fields](https://github.com/farion1231/cc-switch/pull/2634#discussion_r3225389962): `merge_extra_env` blindly inserts every decoded key/value into Claude `env`, so an `extraEnv` payload containing reserved keys like `ANTHROPIC_AUTH_TOKEN` or `ANTHROPIC_BASE_URL` (including `null`/non-string values) will overwrite the validated `apiKey`/`endpoint`.

> [**P2** — Reject non-string extraEnv values for auth-critical keys](https://github.com/farion1231/cc-switch/pull/2634#discussion_r3216037687): Non-string values for auth-critical keys pass earlier validation but fail at runtime (`extract_key` uses `as_str()`).

Fix in commit 2 (`provider.rs`):
- `is_protected_env_key` — denylist of auth-critical keys per AppType. `extraEnv` may only override these with non-empty strings.
- `is_url_env_key` — `ANTHROPIC_BASE_URL` / `GOOGLE_GEMINI_BASE_URL` overrides go through `validate_url`. Bad URL → logged, skipped.
- `normalize_extra_env_value` — strict type rules: string passes through, bool/number → stringified, null/array/object → dropped with a warning.
- Regression locked in by `test_extra_env_stringifies_scalars_and_skips_invalid_values` and `test_gemini_extra_env_preserves_protected_fields_on_invalid_scalar_override`.

Failure mode is fail-soft for the bad key only (the import keeps going with the rest of the config), not fail-hard. This matches existing handling of malformed `usage_script` etc.

---

## Screenshots / 截图

End-to-end run on a real Tauri dev build with an **isolated test home directory** (`CC_SWITCH_TEST_HOME=/tmp/cc-switch-e2e`, leveraging the project's existing test hook at `src-tauri/src/config.rs:23`). The user's production database at `~/.cc-switch/` was **not touched**; the dev app loaded a fresh empty DB.

A deeplink containing **10 `extraEnv` keys** designed to exercise every code path was fed through the real Tauri single-instance forward (`./target/debug/cc-switch "ccswitch://v1/import?..."` → `single_instance` callback → `parse_deeplink_url` → `import_provider_from_deeplink` → SQLite persist):

```json
{
  "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",   // 6× happy-path strings
  "ENABLE_TOOL_SEARCH": "true",
  "CLAUDE_CODE_EFFORT_LEVEL": "max",
  "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
  "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
  "CLAUDE_CODE_NO_FLICKER": "1",
  "ANTHROPIC_AUTH_TOKEN": null,                  // P1 trigger: null override of protected key
  "CLAUDE_CODE_TIMEOUT_SECONDS": 30,             // type-discipline: number → string
  "CLAUDE_CODE_DEBUG_MODE": true,                // type-discipline: bool → string
  "CLAUDE_CODE_BAD_OBJECT": {"nested": "value"}  // P2 trigger: object dropped
}
```

**Backend log output** (verbatim from `target/debug/cc-switch` stderr — proves the hardening fires):

```
✓ Deep link URL detected from single_instance args: ccswitch://v1/import?[keys:apiKey,app,enabled,endpoint,extraEnv,model,name,resource]
✓ Successfully parsed deep link: resource=provider, app=Some("claude"), name=Some("e2e-test-extraenv")
✓ Emitted deeplink-import event to frontend
Importing provider resource from deep link
WARN: Skipping extra_env key 'ANTHROPIC_AUTH_TOKEN': protected env fields must be non-empty strings  ← P1 fix in action
WARN: Skipping extra_env key 'CLAUDE_CODE_BAD_OBJECT': arrays/objects are not valid env values      ← P2 fix in action
Provider 'e2e-test-extraenv-1778611889499' set as current for Claude
```

**SQLite dump** of the persisted `settings_config.env` (queried directly from `/tmp/cc-switch-e2e/.cc-switch/cc-switch.db`):

```json
{
  "ANTHROPIC_AUTH_TOKEN": "sk-e2e-test-real-token",      // ← original apiKey preserved (P1 fix)
  "ANTHROPIC_BASE_URL": "https://api.example.test/v1",
  "ANTHROPIC_MODEL": "claude-sonnet-4.6",
  "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4.6",
  "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4.6",
  "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-sonnet-4.6",
  "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
  "ENABLE_TOOL_SEARCH": "true",
  "CLAUDE_CODE_EFFORT_LEVEL": "max",
  "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
  "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
  "CLAUDE_CODE_NO_FLICKER": "1",
  "CLAUDE_CODE_TIMEOUT_SECONDS": "30",                   // ← number → string (type discipline)
  "CLAUDE_CODE_DEBUG_MODE": "true"                       // ← bool → string (type discipline)
  // CLAUDE_CODE_BAD_OBJECT is absent — object value dropped (P2 fix)
}
```

**11/11 verification points pass**:

| # | Behavior | Expected | Actual | Pass |
|---|---|---|---|---|
| 1 | `ANTHROPIC_AUTH_TOKEN: null` (protected key, null) | original apiKey survives | `"sk-e2e-test-real-token"` | ✅ P1 |
| 2 | `CLAUDE_CODE_BAD_OBJECT: {...}` (object value) | dropped from env | absent | ✅ P2 |
| 3 | `CLAUDE_CODE_TIMEOUT_SECONDS: 30` (number) | stringified | `"30"` | ✅ |
| 4 | `CLAUDE_CODE_DEBUG_MODE: true` (bool) | stringified | `"true"` | ✅ |
| 5-10 | 6 happy-path string keys | preserved verbatim | preserved verbatim | ✅ |
| 11 | UI checkboxes auto-flipped | Teammates Mode / Enable Tool Search / Max Effort Thinking checked | all three checked (see screenshot 2) | ✅ |

### Screenshots from the dev app (after isolated E2E import)

<!-- screenshot_1_import_dialog.png — Tauri 收到 deeplink 后弹出的 import 确认对话框 -->

**Screenshot 1: import confirmation dialog (Tauri received deeplink → parsed correctly)**

<img width="2020" height="1200" alt="image" src="https://github.com/user-attachments/assets/0f31ec5b-4f6e-469f-be56-a243fb7565d5" />

<!-- 拖图位置 2: screenshot_2_env_block.png — 导入后 Edit Provider 页面，含 UI 开关 + env block -->
**Screenshot 2: edit-provider view of the imported provider (UI toggles auto-flipped + full `env` block)**

<img width="2020" height="1200" alt="image" src="https://github.com/user-attachments/assets/8361cf66-d502-4309-92cc-dbb0b7d0377b" />

### How to reproduce locally

```bash
# (optional) isolate to a throwaway home so your real ~/.cc-switch isn't touched
export CC_SWITCH_TEST_HOME=/tmp/cc-switch-e2e
mkdir -p "$CC_SWITCH_TEST_HOME"

# start the dev app
pnpm tauri dev &

# wait for "✓ Deep-link URL handler registered" in stdout, then in another shell:
./src-tauri/target/debug/cc-switch \
  "ccswitch://v1/import?resource=provider&app=claude&name=e2e-test-extraenv&endpoint=https%3A%2F%2Fapi.example.test%2Fv1&apiKey=sk-e2e-test-real-token&model=claude-sonnet-4.6&enabled=true&extraEnv=eyJDTEFVREVfQ09ERV9FWFBFUklNRU5UQUxfQUdFTlRfVEVBTVMiOiAiMSIsICJFTkFCTEVfVE9PTF9TRUFSQ0giOiAidHJ1ZSIsICJDTEFVREVfQ09ERV9FRkZPUlRfTEVWRUwiOiAibWF4IiwgIkNMQVVERV9CQVNIX01BSU5UQUlOX1BST0pFQ1RfV09SS0lOR19ESVIiOiAiMSIsICJDTEFVREVfQ09ERV9ESVNBQkxFX0ZFRURCQUNLX1NVUlZFWSI6ICIxIiwgIkNMQVVERV9DT0RFX05PX0ZMSUNLRVIiOiAiMSIsICJBTlRIUk9QSUNfQVVUSF9UT0tFTiI6IG51bGwsICJDTEFVREVfQ09ERV9USU1FT1VUX1NFQ09ORFMiOiAzMCwgIkNMQVVERV9DT0RFX0RFQlVHX01PREUiOiB0cnVlLCAiQ0xBVURFX0NPREVfQkFEX09CSkVDVCI6IHsibmVzdGVkIjogInZhbHVlIn19"

# confirm in the dialog → check the imported provider's env block
sqlite3 "$CC_SWITCH_TEST_HOME/.cc-switch/cc-switch.db" \
  "SELECT settings_config FROM providers WHERE name='e2e-test-extraenv'"
```

A new demo card was also added to `deplink.html` (open in any browser, scroll to **"额外环境变量自动勾选"**) showing required vs. optional params, one-click import, decoded payload, UI-toggle effects, and the value-rules panel.

---

## Related Issue / 关联 Issue

No prior issue — this surfaced from an internal workshop / team-onboarding need. Per CONTRIBUTING.md §1, happy to open a feature-request issue retroactively if you'd prefer that paper trail before merging; let me know.

---

## Checklist / 检查清单

- [x] `pnpm typecheck` passes — verified (`tsc --noEmit`, clean)
- [x] `pnpm format:check` passes — verified (Prettier, clean)
- [x] `cargo clippy --all-targets` passes — verified (clean, including the `needless_return` lint this PR removed)
- [x] `cargo fmt --check` passes — verified
- [x] `cargo test --lib deeplink` — 40 passed, 0 failed
- [x] `cargo test --test deeplink_import` — 5 passed, 0 failed
- [x] `pnpm test:unit` — 223 passed, 0 failed across 36 files
- [x] No user-facing strings added; no i18n files need updating (the only new error message is a developer-facing `AppError::InvalidInput` in `ensure_extra_env_supported`).
- [x] Conventional Commits format (`feat(deeplink): …`, `fix(deeplink): …`).

---

## AI-Assisted Disclosure / AI 协助透明

Per CONTRIBUTING.md §97 (AI-Assisted Contributions):

1. **I've read every line.** Both commits, including the test suite. Happy to walk through any specific function if reviewer wants — e.g., the rationale for `normalize_extra_env_value` returning `None` (vs. `Err`) on bad scalars is that we want the import to succeed for the well-formed keys even if one key is malformed; the alternative (fail-hard on any bad value) would make `extraEnv` more brittle than `config` is today.
2. **Tested locally.** Three layers verified on macOS (Apple Silicon, Tauri 2.x):
   - **Automated suite**: 40 deeplink lib tests + 5 deeplink integration tests (which exercise the full DB persistence path) + 223 frontend tests — all green. Lint (`cargo clippy --all-targets`, `cargo fmt`, `pnpm typecheck`, `pnpm format:check`) all clean.
   - **Real GUI E2E** on a Tauri dev build with an **isolated** `CC_SWITCH_TEST_HOME=/tmp/cc-switch-e2e` (using the project's own test hook at `config.rs:23` so the production `~/.cc-switch/` was not touched). A real `ccswitch://` deeplink containing 10 `extraEnv` keys — including the two hostile inputs Codex flagged (`ANTHROPIC_AUTH_TOKEN: null` and a JSON object value) plus scalar type-discipline cases — was fed through the actual `single_instance` forward → `parse_deeplink_url` → `import_provider_from_deeplink` → SQLite persist path. 11/11 expected behaviors verified end-to-end (see [Screenshots / 截图](#screenshots--截图) below).
   - **No platform-specific APIs** are touched — all changes are in pure-Rust `deeplink/*` modules + a static HTML demo, so Linux/Windows behavior matches macOS.
3. **Single-topic.** One feature (`extraEnv`) + its hardening commit. The `code-simplifier` cleanups in commit 2 are confined to the same `provider.rs` file and total `-23` lines; if you'd prefer them split out I can do that.
4. **No prior issue** — see "Related Issue" above; will open one if requested.
5. **AI tools used:** Claude Code for drafting, `code-simplifier` for the commit-2 cleanups. Codex's automated review on commit 1 (P1+P2) directly drove the hardening work in commit 2. Final review and decisions are mine.
