### PR TITLE
fix(copilot): 调高无限空白检测阈值 20 → 500

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -97,7 +97,7 @@ struct ToolBlockState {
 }
 
 /// 无限空白 bug 的连续空白字符阈值
-const INFINITE_WHITESPACE_THRESHOLD: usize = 20;
+const INFINITE_WHITESPACE_THRESHOLD: usize = 500;
 
 fn build_anthropic_usage_json(usage: &Usage) -> Value {
     let mut usage_json = json!({

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -90,7 +90,7 @@ struct ToolBlockState {
     started: bool,
     pending_args: String,
     /// 连续空白字符计数 — 用于检测 Copilot 无限换行 bug
-    /// 当 function call 参数中出现连续 20+ 空白字符时，强制终止流
+    /// 当 function call 参数中的连续空白字符达到阈值时，强制终止流
     consecutive_whitespace: usize,
     /// 是否已因无限空白 bug 被中止
     aborted: bool,


### PR DESCRIPTION
## Summary

- 将 `INFINITE_WHITESPACE_THRESHOLD` 从 `20` 调高到 `500`，避免误伤包含缩进代码的合法 tool call。
- 阈值 20 太激进：write_file / edit_file 写入 4~8 层缩进的 Python/YAML/Rust/Markdown 代码时，单段连续空白（含 `\n` `\t`）轻松超过 20，导致整个 tool call 被静默丢弃。
- 真实的 "infinite whitespace bug" 会持续输出数百~数千个空白，500 仍能可靠兜底，同时大幅降低误判。

详见 #2646。

## Test

- [x] 用 Copilot 路由触发一次 write_file，写入 8 层缩进的 YAML 或嵌套 Python 函数，确认 tool call 不再被中止、日志不再出现 `检测到无限空白 bug`。
- [x] 回归现有用例（普通对话 / 短工具调用），确认无影响。
