### PR TITLE
[codex] Fix Codex provider state sync

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -12,6 +12,9 @@ use std::path::Path;
 use toml_edit::DocumentMut;
 
 pub const CC_SWITCH_CODEX_MODEL_PROVIDER_ID: &str = "ccswitch";
+pub const CODEX_OFFICIAL_MODEL_PROVIDER_ID: &str = "openai";
+pub const CODEX_AUTH_MODE_CHATGPT: &str = "chatgpt";
+pub const CODEX_AUTH_MODE_APIKEY: &str = "apikey";
 
 /// Reserved built-in provider IDs from OpenAI Codex's config/model-provider
 /// catalog. Keep in sync with Codex `RESERVED_MODEL_PROVIDER_IDS` and legacy
@@ -157,6 +160,40 @@ fn active_codex_model_provider_id(doc: &DocumentMut) -> Option<String> {
         .map(str::trim)
         .filter(|id| !id.is_empty())
         .map(str::to_string)
+}
+
+pub fn effective_codex_model_provider_id_from_config(config_text: &str) -> String {
+    if config_text.trim().is_empty() {
+        return CODEX_OFFICIAL_MODEL_PROVIDER_ID.to_string();
+    }
+
+    config_text
+        .parse::<DocumentMut>()
+        .ok()
+        .and_then(|doc| active_codex_model_provider_id(&doc))
+        .unwrap_or_else(|| CODEX_OFFICIAL_MODEL_PROVIDER_ID.to_string())
+}
+
+pub fn infer_codex_auth_mode_from_settings(settings: &Value) -> &'static str {
+    let auth_has_key = settings
+        .get("auth")
+        .and_then(Value::as_object)
+        .and_then(|obj| obj.get("OPENAI_API_KEY"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+
+    let config_has_custom_provider = settings
+        .get("config")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+
+    if auth_has_key || config_has_custom_provider {
+        CODEX_AUTH_MODE_APIKEY
+    } else {
+        CODEX_AUTH_MODE_CHATGPT
+    }
 }
 
 fn is_custom_codex_model_provider_id(id: &str) -> bool {
@@ -529,6 +566,39 @@ pub fn remove_codex_toml_base_url_if(toml_str: &str, predicate: impl Fn(&str) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn official_empty_config_uses_openai_provider_bucket() {
+        assert_eq!(
+            effective_codex_model_provider_id_from_config(""),
+            CODEX_OFFICIAL_MODEL_PROVIDER_ID
+        );
+        assert_eq!(
+            effective_codex_model_provider_id_from_config(r#"model = "gpt-5.1""#),
+            CODEX_OFFICIAL_MODEL_PROVIDER_ID
+        );
+    }
+
+    #[test]
+    fn codex_auth_mode_infers_chatgpt_vs_apikey() {
+        assert_eq!(
+            infer_codex_auth_mode_from_settings(&json!({"auth": {}, "config": ""})),
+            CODEX_AUTH_MODE_CHATGPT
+        );
+        assert_eq!(
+            infer_codex_auth_mode_from_settings(
+                &json!({"auth": {"OPENAI_API_KEY": "sk-test"}, "config": ""})
+            ),
+            CODEX_AUTH_MODE_APIKEY
+        );
+        assert_eq!(
+            infer_codex_auth_mode_from_settings(
+                &json!({"auth": {}, "config": "model_provider = \"bold_ai_api\""})
+            ),
+            CODEX_AUTH_MODE_APIKEY
+        );
+    }
 
     #[test]
     fn normalize_live_config_preserves_current_custom_model_provider_id() {

--- a/src-tauri/src/codex_state.rs
+++ b/src-tauri/src/codex_state.rs
@@ -1,0 +1,392 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{params, Connection, OpenFlags};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::codex_config::{effective_codex_model_provider_id_from_config, get_codex_config_dir};
+use crate::config::read_json_file;
+use crate::error::AppError;
+
+const CODEX_STATE_DB: &str = "state_5.sqlite";
+const THREADS_TABLE: &str = "threads";
+const MODEL_PROVIDER_COLUMN: &str = "model_provider";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexModelProviderCount {
+    pub model_provider: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexStateDiagnosis {
+    pub config_model_provider: Option<String>,
+    pub effective_model_provider: String,
+    pub auth_mode: String,
+    pub state_db_path: Option<String>,
+    pub provider_counts: Vec<CodexModelProviderCount>,
+    pub config_auth_mismatch: bool,
+    pub index_mismatch: bool,
+    pub inconsistent: bool,
+    pub repairable_rows: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexStateRepairResult {
+    pub dry_run: bool,
+    pub target_model_provider: String,
+    pub affected_rows: i64,
+    pub backup_path: Option<String>,
+    pub diagnosis_before: CodexStateDiagnosis,
+    pub diagnosis_after: Option<CodexStateDiagnosis>,
+}
+
+pub fn diagnose_codex_state() -> Result<CodexStateDiagnosis, AppError> {
+    diagnose_codex_state_at(get_codex_config_dir())
+}
+
+pub fn repair_codex_state(dry_run: bool) -> Result<CodexStateRepairResult, AppError> {
+    repair_codex_state_at(get_codex_config_dir(), dry_run)
+}
+
+fn diagnose_codex_state_at(codex_dir: PathBuf) -> Result<CodexStateDiagnosis, AppError> {
+    let config_text = read_codex_config_text_at(&codex_dir).unwrap_or_default();
+    diagnose_codex_state_with_config(codex_dir, &config_text)
+}
+
+fn diagnose_codex_state_with_config(
+    codex_dir: PathBuf,
+    config_text: &str,
+) -> Result<CodexStateDiagnosis, AppError> {
+    let config_model_provider = parse_config_model_provider(config_text);
+    let effective_model_provider = effective_codex_model_provider_id_from_config(config_text);
+    let auth_mode = detect_codex_auth_mode_at(&codex_dir);
+    let state_db_path = codex_dir.join(CODEX_STATE_DB);
+    let provider_counts = read_provider_counts(&state_db_path)?;
+    let repairable_rows = provider_counts
+        .iter()
+        .filter(|row| row.model_provider != effective_model_provider)
+        .map(|row| row.count)
+        .sum();
+
+    let config_auth_mismatch = match auth_mode.as_str() {
+        "apikey" => effective_model_provider == "openai",
+        "chatgpt" | "empty" | "missing" => effective_model_provider != "openai",
+        _ => false,
+    };
+    let index_mismatch = repairable_rows > 0;
+
+    Ok(CodexStateDiagnosis {
+        config_model_provider,
+        effective_model_provider,
+        auth_mode,
+        state_db_path: state_db_path
+            .exists()
+            .then(|| state_db_path.to_string_lossy().to_string()),
+        provider_counts,
+        config_auth_mismatch,
+        index_mismatch,
+        inconsistent: config_auth_mismatch || index_mismatch,
+        repairable_rows,
+    })
+}
+
+fn repair_codex_state_at(
+    codex_dir: PathBuf,
+    dry_run: bool,
+) -> Result<CodexStateRepairResult, AppError> {
+    let config_text = read_codex_config_text_at(&codex_dir).unwrap_or_default();
+    let diagnosis_before = diagnose_codex_state_with_config(codex_dir.clone(), &config_text)?;
+    let target_model_provider = diagnosis_before.effective_model_provider.clone();
+    let affected_rows = diagnosis_before.repairable_rows;
+
+    if dry_run || affected_rows == 0 {
+        return Ok(CodexStateRepairResult {
+            dry_run,
+            target_model_provider,
+            affected_rows,
+            backup_path: None,
+            diagnosis_before,
+            diagnosis_after: None,
+        });
+    }
+
+    let state_db_path = codex_dir.join(CODEX_STATE_DB);
+    if !state_db_path.exists() {
+        return Err(AppError::Config(format!(
+            "Codex state database not found: {}",
+            state_db_path.display()
+        )));
+    }
+
+    let mut conn = open_state_db(&state_db_path, false)?;
+    ensure_threads_table(&conn)?;
+    let backup_path = backup_state_db(&conn, &state_db_path)?;
+
+    let tx = conn
+        .transaction()
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let changed = tx
+        .execute(
+            "UPDATE threads SET model_provider = ?1 WHERE model_provider <> ?1",
+            params![target_model_provider],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    tx.commit().map_err(|e| AppError::Database(e.to_string()))?;
+
+    let diagnosis_after = diagnose_codex_state_with_config(codex_dir, &config_text)?;
+
+    Ok(CodexStateRepairResult {
+        dry_run,
+        target_model_provider,
+        affected_rows: changed as i64,
+        backup_path: Some(backup_path.to_string_lossy().to_string()),
+        diagnosis_before,
+        diagnosis_after: Some(diagnosis_after),
+    })
+}
+
+fn read_codex_config_text_at(codex_dir: &Path) -> Result<String, AppError> {
+    let config_path = codex_dir.join("config.toml");
+    if config_path.exists() {
+        std::fs::read_to_string(&config_path).map_err(|e| AppError::io(&config_path, e))
+    } else {
+        Ok(String::new())
+    }
+}
+
+fn detect_codex_auth_mode_at(codex_dir: &Path) -> String {
+    let auth_path = codex_dir.join("auth.json");
+    let auth = match read_json_file::<Value>(&auth_path) {
+        Ok(value) => value,
+        Err(_) if !auth_path.exists() => return "missing".to_string(),
+        Err(_) => return "unknown".to_string(),
+    };
+
+    let Some(obj) = auth.as_object() else {
+        return "unknown".to_string();
+    };
+
+    if obj
+        .get("OPENAI_API_KEY")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+    {
+        return "apikey".to_string();
+    }
+
+    if obj.is_empty() {
+        return "empty".to_string();
+    }
+
+    "chatgpt".to_string()
+}
+
+fn parse_config_model_provider(config_text: &str) -> Option<String> {
+    let doc = config_text.parse::<toml_edit::DocumentMut>().ok()?;
+    doc.get("model_provider")
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn read_provider_counts(db_path: &Path) -> Result<Vec<CodexModelProviderCount>, AppError> {
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let conn = open_state_db(db_path, true)?;
+    if !threads_table_exists(&conn)? {
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT model_provider, COUNT(*) FROM threads GROUP BY model_provider ORDER BY COUNT(*) DESC, model_provider ASC",
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(CodexModelProviderCount {
+                model_provider: row.get(0)?,
+                count: row.get(1)?,
+            })
+        })
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let mut counts = Vec::new();
+    for row in rows {
+        counts.push(row.map_err(|e| AppError::Database(e.to_string()))?);
+    }
+    Ok(counts)
+}
+
+fn open_state_db(db_path: &Path, read_only: bool) -> Result<Connection, AppError> {
+    let flags = if read_only {
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+    } else {
+        OpenFlags::SQLITE_OPEN_READ_WRITE
+    };
+    Connection::open_with_flags(db_path, flags).map_err(|e| AppError::Database(e.to_string()))
+}
+
+fn threads_table_exists(conn: &Connection) -> Result<bool, AppError> {
+    let exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            params![THREADS_TABLE],
+            |row| row.get(0),
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    Ok(exists > 0)
+}
+
+fn ensure_threads_table(conn: &Connection) -> Result<(), AppError> {
+    if !threads_table_exists(conn)? {
+        return Err(AppError::Database(
+            "Codex state database has no threads table".to_string(),
+        ));
+    }
+
+    let has_column = conn
+        .prepare("PRAGMA table_info(threads)")
+        .and_then(|mut stmt| {
+            let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+            for row in rows {
+                if row? == MODEL_PROVIDER_COLUMN {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        })
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    if !has_column {
+        return Err(AppError::Database(
+            "Codex state threads table has no model_provider column".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn backup_state_db(conn: &Connection, db_path: &Path) -> Result<PathBuf, AppError> {
+    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S%3f");
+    let backup_path = db_path.with_file_name(format!("{CODEX_STATE_DB}.backup-{ts}"));
+    let backup_str = backup_path.to_string_lossy().to_string();
+
+    conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE);")
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    conn.execute("VACUUM main INTO ?1", params![backup_str])
+        .map_err(|e| AppError::Database(format!("Failed to backup Codex state database: {e}")))?;
+
+    Ok(backup_path)
+}
+
+#[allow(dead_code)]
+fn counts_to_map(counts: &[CodexModelProviderCount]) -> BTreeMap<String, i64> {
+    counts
+        .iter()
+        .map(|row| (row.model_provider.clone(), row.count))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    struct EnvGuard {
+        old_home: Option<std::ffi::OsString>,
+        old_test_home: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_home(path: &Path) -> Self {
+            let guard = Self {
+                old_home: std::env::var_os("HOME"),
+                old_test_home: std::env::var_os("CC_SWITCH_TEST_HOME"),
+            };
+            std::env::set_var("HOME", path);
+            std::env::set_var("CC_SWITCH_TEST_HOME", path);
+            guard
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.old_home.take() {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.old_test_home.take() {
+                Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+        }
+    }
+
+    fn create_state_db(path: &Path) {
+        let conn = Connection::open(path).expect("open test state db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE threads (
+                id TEXT PRIMARY KEY,
+                model_provider TEXT NOT NULL
+            );
+            INSERT INTO threads (id, model_provider) VALUES
+                ('a', 'bold_ai_api'),
+                ('b', 'bold_ai_api'),
+                ('c', 'openai');
+            "#,
+        )
+        .expect("create threads");
+    }
+
+    #[test]
+    fn repair_codex_state_dry_run_does_not_modify_threads() {
+        let temp = tempdir().expect("tempdir");
+        let _guard = EnvGuard::set_home(temp.path());
+        let codex_dir = temp.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).expect("create codex dir");
+        std::fs::write(codex_dir.join("auth.json"), "{}").expect("write auth");
+        std::fs::write(codex_dir.join("config.toml"), "").expect("write config");
+        create_state_db(&codex_dir.join(CODEX_STATE_DB));
+
+        let result = repair_codex_state_at(codex_dir.clone(), true).expect("dry run");
+        assert_eq!(result.affected_rows, 2);
+        assert!(result.backup_path.is_none());
+
+        let counts = read_provider_counts(&codex_dir.join(CODEX_STATE_DB)).expect("counts");
+        let map = counts_to_map(&counts);
+        assert_eq!(map.get("bold_ai_api"), Some(&2));
+        assert_eq!(map.get("openai"), Some(&1));
+    }
+
+    #[test]
+    fn repair_codex_state_updates_threads_and_creates_backup() {
+        let temp = tempdir().expect("tempdir");
+        let _guard = EnvGuard::set_home(temp.path());
+        let codex_dir = temp.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).expect("create codex dir");
+        std::fs::write(codex_dir.join("auth.json"), "{}").expect("write auth");
+        std::fs::write(codex_dir.join("config.toml"), "").expect("write config");
+        create_state_db(&codex_dir.join(CODEX_STATE_DB));
+
+        let result = repair_codex_state_at(codex_dir.clone(), false).expect("repair");
+        assert_eq!(result.affected_rows, 2);
+        let backup_path = result.backup_path.expect("backup path");
+        assert!(Path::new(&backup_path).exists());
+
+        let counts = read_provider_counts(&codex_dir.join(CODEX_STATE_DB)).expect("counts");
+        let map = counts_to_map(&counts);
+        assert_eq!(map.get("openai"), Some(&3));
+        assert!(map.get("bold_ai_api").is_none());
+    }
+}

--- a/src-tauri/src/commands/codex_state.rs
+++ b/src-tauri/src/commands/codex_state.rs
@@ -1,0 +1,11 @@
+use crate::codex_state::{CodexStateDiagnosis, CodexStateRepairResult};
+
+#[tauri::command]
+pub fn diagnose_codex_state() -> Result<CodexStateDiagnosis, String> {
+    crate::codex_state::diagnose_codex_state().map_err(|e| e.to_string())
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub fn repair_codex_state(dry_run: bool) -> Result<CodexStateRepairResult, String> {
+    crate::codex_state::repair_codex_state(dry_run).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@
 mod auth;
 mod balance;
 mod codex_oauth;
+mod codex_state;
 mod coding_plan;
 mod config;
 mod copilot;
@@ -36,6 +37,7 @@ mod workspace;
 pub use auth::*;
 pub use balance::*;
 pub use codex_oauth::*;
+pub use codex_state::*;
 pub use coding_plan::*;
 pub use config::*;
 pub use copilot::*;

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -3,7 +3,7 @@ use crate::error::AppError;
 use crate::provider::{Provider, ProviderMeta};
 use indexmap::IndexMap;
 use rusqlite::params;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 type OmoProviderRow = (
@@ -16,6 +16,49 @@ type OmoProviderRow = (
     Option<String>,
     String,
 );
+
+fn codex_official_default_settings() -> Value {
+    json!({"auth": {}, "config": ""})
+}
+
+fn codex_auth_has_api_key(settings: &Value) -> bool {
+    settings
+        .get("auth")
+        .and_then(Value::as_object)
+        .and_then(|obj| obj.get("OPENAI_API_KEY"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+}
+
+fn should_reset_codex_official_settings(settings: &Value) -> bool {
+    let Some(obj) = settings.as_object() else {
+        return true;
+    };
+
+    if !obj.contains_key("auth") || !obj.contains_key("config") {
+        return true;
+    }
+
+    if codex_auth_has_api_key(settings) {
+        return true;
+    }
+
+    let config_text = obj
+        .get("config")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if config_text.trim().is_empty() {
+        return false;
+    }
+
+    if crate::codex_config::validate_config_toml(config_text).is_err() {
+        return true;
+    }
+
+    crate::codex_config::effective_codex_model_provider_id_from_config(config_text)
+        != crate::codex_config::CODEX_OFFICIAL_MODEL_PROVIDER_ID
+}
 
 impl Database {
     pub fn get_all_providers(
@@ -686,8 +729,10 @@ impl Database {
                     provider.category = Some("official".to_string());
                     changed = true;
                 }
-                let official_settings = json!({"auth": {}, "config": ""});
-                if provider.settings_config != official_settings {
+                let official_settings = codex_official_default_settings();
+                if should_reset_codex_official_settings(&provider.settings_config)
+                    && provider.settings_config != official_settings
+                {
                     provider.settings_config = official_settings;
                     changed = true;
                 }
@@ -771,6 +816,49 @@ mod tests {
         assert_eq!(
             api_key.meta.and_then(|meta| meta.codex_auth_mode),
             Some(crate::codex_config::CODEX_AUTH_MODE_APIKEY.to_string())
+        );
+    }
+
+    #[test]
+    fn migrate_codex_provider_auth_metadata_preserves_chatgpt_snapshot() {
+        let db = Database::memory().expect("memory db");
+        let snapshot = json!({
+            "auth": {
+                "tokens": {
+                    "access_token": "chatgpt-access-token",
+                    "refresh_token": "chatgpt-refresh-token"
+                }
+            },
+            "config": "model_provider = \"openai\"\nmodel = \"gpt-5\"\n",
+        });
+
+        let mut chatgpt = Provider::with_id(
+            "codex-official".to_string(),
+            "OpenAI Official".to_string(),
+            snapshot.clone(),
+            None,
+        );
+        chatgpt.category = Some("official".to_string());
+        db.save_provider("codex", &chatgpt)
+            .expect("save chatgpt provider");
+
+        let changed = db
+            .migrate_codex_provider_auth_metadata()
+            .expect("migrate codex providers");
+        assert_eq!(changed, 1);
+
+        let chatgpt = db
+            .get_provider_by_id("codex-official", "codex")
+            .expect("load chatgpt")
+            .expect("chatgpt exists");
+        assert_eq!(chatgpt.name, "OpenAI Official (ChatGPT)");
+        assert_eq!(
+            chatgpt.settings_config, snapshot,
+            "migration should not discard a saved ChatGPT OAuth snapshot"
+        );
+        assert_eq!(
+            chatgpt.meta.and_then(|meta| meta.codex_auth_mode),
+            Some(crate::codex_config::CODEX_AUTH_MODE_CHATGPT.to_string())
         );
     }
 }

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -3,6 +3,7 @@ use crate::error::AppError;
 use crate::provider::{Provider, ProviderMeta};
 use indexmap::IndexMap;
 use rusqlite::params;
+use serde_json::json;
 use std::collections::{HashMap, HashSet};
 
 type OmoProviderRow = (
@@ -634,6 +635,12 @@ impl Database {
             provider.icon_color = Some(seed.icon_color.to_string());
             provider.sort_index = Some(next_sort_index);
             provider.created_at = Some(now_ms);
+            if seed.id == "codex-official" {
+                provider.meta = Some(ProviderMeta {
+                    codex_auth_mode: Some(crate::codex_config::CODEX_AUTH_MODE_CHATGPT.to_string()),
+                    ..ProviderMeta::default()
+                });
+            }
 
             self.save_provider(app_type_str, &provider)?;
             inserted += 1;
@@ -648,5 +655,122 @@ impl Database {
         self.set_setting("official_providers_seeded", "true")?;
 
         Ok(inserted)
+    }
+
+    /// Lightweight, idempotent migration for old Codex providers that used the
+    /// same display name for ChatGPT login and API-key providers.
+    pub fn migrate_codex_provider_auth_metadata(&self) -> Result<usize, AppError> {
+        let providers = self.get_all_providers(crate::app_config::AppType::Codex.as_str())?;
+        let mut changed_count = 0;
+
+        for (_, mut provider) in providers {
+            let mut changed = false;
+            let inferred_mode = if provider.id == "codex-official" {
+                crate::codex_config::CODEX_AUTH_MODE_CHATGPT
+            } else {
+                crate::codex_config::infer_codex_auth_mode_from_settings(&provider.settings_config)
+            };
+
+            let meta = provider.meta.get_or_insert_with(ProviderMeta::default);
+            if meta.codex_auth_mode.as_deref() != Some(inferred_mode) {
+                meta.codex_auth_mode = Some(inferred_mode.to_string());
+                changed = true;
+            }
+
+            if provider.id == "codex-official" {
+                if provider.name != "OpenAI Official (ChatGPT)" {
+                    provider.name = "OpenAI Official (ChatGPT)".to_string();
+                    changed = true;
+                }
+                if provider.category.as_deref() != Some("official") {
+                    provider.category = Some("official".to_string());
+                    changed = true;
+                }
+                let official_settings = json!({"auth": {}, "config": ""});
+                if provider.settings_config != official_settings {
+                    provider.settings_config = official_settings;
+                    changed = true;
+                }
+            } else if provider.name.trim() == "OpenAI Official"
+                && inferred_mode == crate::codex_config::CODEX_AUTH_MODE_APIKEY
+            {
+                provider.name = "OpenAI API Key".to_string();
+                changed = true;
+                if provider.category.as_deref() == Some("official") {
+                    provider.category = Some("third_party".to_string());
+                    changed = true;
+                }
+            }
+
+            if changed {
+                self.save_provider(crate::app_config::AppType::Codex.as_str(), &provider)?;
+                changed_count += 1;
+            }
+        }
+
+        Ok(changed_count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrate_codex_provider_auth_metadata_splits_duplicate_official_names() {
+        let db = Database::memory().expect("memory db");
+
+        let mut chatgpt = Provider::with_id(
+            "codex-official".to_string(),
+            "OpenAI Official".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "stale-company-key"},
+                "config": "model_provider = \"bold_ai_api\"",
+            }),
+            None,
+        );
+        chatgpt.category = Some("official".to_string());
+        db.save_provider("codex", &chatgpt)
+            .expect("save chatgpt provider");
+
+        let mut api_key = Provider::with_id(
+            "openai-api-key".to_string(),
+            "OpenAI Official".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "sk-test"},
+                "config": "model_provider = \"bold_ai_api\"",
+            }),
+            None,
+        );
+        api_key.category = Some("official".to_string());
+        db.save_provider("codex", &api_key)
+            .expect("save api key provider");
+
+        let changed = db
+            .migrate_codex_provider_auth_metadata()
+            .expect("migrate codex providers");
+        assert_eq!(changed, 2);
+
+        let chatgpt = db
+            .get_provider_by_id("codex-official", "codex")
+            .expect("load chatgpt")
+            .expect("chatgpt exists");
+        assert_eq!(chatgpt.name, "OpenAI Official (ChatGPT)");
+        assert_eq!(chatgpt.settings_config, json!({"auth": {}, "config": ""}));
+        assert_eq!(
+            chatgpt.meta.and_then(|meta| meta.codex_auth_mode),
+            Some(crate::codex_config::CODEX_AUTH_MODE_CHATGPT.to_string())
+        );
+
+        let api_key = db
+            .get_provider_by_id("openai-api-key", "codex")
+            .expect("load api key")
+            .expect("api key exists");
+        assert_eq!(api_key.name, "OpenAI API Key");
+        assert_eq!(api_key.category.as_deref(), Some("third_party"));
+        assert_eq!(
+            api_key.meta.and_then(|meta| meta.codex_auth_mode),
+            Some(crate::codex_config::CODEX_AUTH_MODE_APIKEY.to_string())
+        );
     }
 }

--- a/src-tauri/src/database/dao/providers_seed.rs
+++ b/src-tauri/src/database/dao/providers_seed.rs
@@ -5,7 +5,7 @@
 //!
 //! 字段与前端预设保持一致，参见：
 //! - `src/config/claudeProviderPresets.ts`（"Claude Official"）
-//! - `src/config/codexProviderPresets.ts`（"OpenAI Official"）
+//! - `src/config/codexProviderPresets.ts`（"OpenAI Official (ChatGPT)"）
 //! - `src/config/geminiProviderPresets.ts`（"Google Official"）
 
 use crate::app_config::AppType;
@@ -51,7 +51,7 @@ pub(crate) const OFFICIAL_SEEDS: &[OfficialProviderSeed] = &[
     OfficialProviderSeed {
         id: "codex-official",
         app_type: AppType::Codex,
-        name: "OpenAI Official",
+        name: "OpenAI Official (ChatGPT)",
         website_url: "https://chatgpt.com/codex",
         icon: "openai",
         icon_color: "#00A67E",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod claude_desktop_config;
 mod claude_mcp;
 mod claude_plugin;
 mod codex_config;
+mod codex_state;
 mod commands;
 mod config;
 mod database;
@@ -533,6 +534,14 @@ pub fn run() {
                 }
                 Ok(_) => {}
                 Err(e) => log::warn!("✗ Failed to seed official providers: {e}"),
+            }
+
+            match app_state.db.migrate_codex_provider_auth_metadata() {
+                Ok(count) if count > 0 => {
+                    log::info!("✓ Migrated {count} Codex provider auth metadata entries");
+                }
+                Ok(_) => {}
+                Err(e) => log::warn!("✗ Failed to migrate Codex provider auth metadata: {e}"),
             }
 
             // 老用户 / 已确认的路径由 `fresh_install_at_startup` 自行拦截，这里不做写入。
@@ -1155,6 +1164,8 @@ pub fn run() {
             commands::rename_db_backup,
             commands::delete_db_backup,
             commands::sync_current_providers_live,
+            commands::diagnose_codex_state,
+            commands::repair_codex_state,
             // Deep link import
             commands::parse_deeplink,
             commands::merge_deeplink_config,

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -316,6 +316,11 @@ pub struct ProviderMeta {
     /// Codex OAuth FAST mode: inject `service_tier = "priority"` for ChatGPT Codex requests.
     #[serde(rename = "codexFastMode", skip_serializing_if = "Option::is_none")]
     pub codex_fast_mode: Option<bool>,
+    /// Codex authentication mode for the Codex app itself.
+    /// - "chatgpt": official ChatGPT/Codex login state
+    /// - "apikey": OpenAI-compatible API key / gateway mode
+    #[serde(rename = "codexAuthMode", skip_serializing_if = "Option::is_none")]
+    pub codex_auth_mode: Option<String>,
     /// 累加模式应用中，该 provider 是否已写入 live config。
     /// `None` 表示旧数据/未知状态，`Some(false)` 表示明确仅存在于数据库中。
     #[serde(rename = "liveConfigManaged", skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -12,7 +12,9 @@ use crate::app_config::AppType;
 use crate::codex_config::{
     get_codex_auth_path, get_codex_config_path, write_codex_live_atomic_with_stable_provider,
 };
-use crate::config::{delete_file, get_claude_settings_path, read_json_file, write_json_file};
+use crate::config::{
+    atomic_write, delete_file, get_claude_settings_path, read_json_file, write_json_file,
+};
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
@@ -641,7 +643,7 @@ pub(crate) enum LiveSnapshot {
         settings: Option<Value>,
     },
     Codex {
-        auth: Option<Value>,
+        auth: Option<Vec<u8>>,
         config: Option<String>,
     },
     Gemini {
@@ -666,7 +668,7 @@ impl LiveSnapshot {
                 let auth_path = get_codex_auth_path();
                 let config_path = get_codex_config_path();
                 let auth = if auth_path.exists() {
-                    Some(read_json_file::<Value>(&auth_path)?)
+                    Some(fs::read(&auth_path).map_err(|e| AppError::io(&auth_path, e))?)
                 } else {
                     None
                 };
@@ -726,8 +728,8 @@ impl LiveSnapshot {
             LiveSnapshot::Codex { auth, config } => {
                 let auth_path = get_codex_auth_path();
                 let config_path = get_codex_config_path();
-                if let Some(value) = auth {
-                    write_json_file(&auth_path, value)?;
+                if let Some(bytes) = auth {
+                    atomic_write(&auth_path, bytes)?;
                 } else if auth_path.exists() {
                     delete_file(&auth_path)?;
                 }
@@ -1563,6 +1565,74 @@ pub fn remove_openclaw_provider_from_live(provider_id: &str) -> Result<(), AppEr
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, OnceLock};
+
+    struct TempHome {
+        _dir: tempfile::TempDir,
+        old_home: Option<OsString>,
+        old_userprofile: Option<OsString>,
+        old_test_home: Option<OsString>,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let old_home = std::env::var_os("HOME");
+            let old_userprofile = std::env::var_os("USERPROFILE");
+            let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+
+            std::env::set_var("HOME", dir.path());
+            std::env::set_var("USERPROFILE", dir.path());
+            std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            crate::settings::update_settings(crate::settings::AppSettings::default())
+                .expect("reset settings");
+
+            Self {
+                _dir: dir,
+                old_home,
+                old_userprofile,
+                old_test_home,
+            }
+        }
+
+        fn codex_dir(&self) -> PathBuf {
+            crate::codex_config::get_codex_config_dir()
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            match &self.old_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match &self.old_userprofile {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+            match &self.old_test_home {
+                Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+            let _ = crate::settings::reload_settings();
+        }
+    }
+
+    fn live_snapshot_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+    }
+
+    fn write_text(path: &Path, text: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent dir");
+        }
+        fs::write(path, text).expect("write test file");
+    }
 
     #[test]
     fn claude_common_config_apply_and_remove_roundtrip_for_non_overlapping_fields() {
@@ -1606,6 +1676,36 @@ mod tests {
         let stripped =
             remove_common_config_from_settings(&AppType::Codex, &applied, snippet).unwrap();
         assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn codex_live_snapshot_capture_preserves_malformed_auth_json() {
+        let _guard = live_snapshot_test_guard();
+        let home = TempHome::new();
+        let codex_dir = home.codex_dir();
+        let auth_path = codex_dir.join("auth.json");
+        let config_path = codex_dir.join("config.toml");
+        let broken_auth = "{not-valid-json";
+        let config = "model_provider = \"bold_ai_api\"\n";
+
+        write_text(&auth_path, broken_auth);
+        write_text(&config_path, config);
+
+        let snapshot = LiveSnapshot::capture(&AppType::Codex)
+            .expect("malformed auth.json should not block snapshot capture");
+
+        write_text(&auth_path, "{}");
+        write_text(&config_path, "");
+        snapshot.restore().expect("restore snapshot");
+
+        assert_eq!(
+            fs::read_to_string(&auth_path).expect("read restored auth"),
+            broken_auth
+        );
+        assert_eq!(
+            fs::read_to_string(&config_path).expect("read restored config"),
+            config
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -3,6 +3,7 @@
 //! Handles reading and writing live configuration files for Claude, Codex, and Gemini.
 
 use std::collections::HashMap;
+use std::fs;
 
 use serde_json::{json, Value};
 use toml_edit::{DocumentMut, Item, TableLike};
@@ -650,6 +651,67 @@ pub(crate) enum LiveSnapshot {
 }
 
 impl LiveSnapshot {
+    pub(crate) fn capture(app_type: &AppType) -> Result<Self, AppError> {
+        match app_type {
+            AppType::Claude => {
+                let path = get_claude_settings_path();
+                let settings = if path.exists() {
+                    Some(read_json_file::<Value>(&path)?)
+                } else {
+                    None
+                };
+                Ok(LiveSnapshot::Claude { settings })
+            }
+            AppType::Codex => {
+                let auth_path = get_codex_auth_path();
+                let config_path = get_codex_config_path();
+                let auth = if auth_path.exists() {
+                    Some(read_json_file::<Value>(&auth_path)?)
+                } else {
+                    None
+                };
+                let config = if config_path.exists() {
+                    Some(
+                        fs::read_to_string(&config_path)
+                            .map_err(|e| AppError::io(&config_path, e))?,
+                    )
+                } else {
+                    None
+                };
+                Ok(LiveSnapshot::Codex { auth, config })
+            }
+            AppType::Gemini => {
+                use crate::gemini_config::{
+                    get_gemini_env_path, get_gemini_settings_path, parse_env_file,
+                };
+
+                let env_path = get_gemini_env_path();
+                let env = if env_path.exists() {
+                    let content =
+                        fs::read_to_string(&env_path).map_err(|e| AppError::io(&env_path, e))?;
+                    Some(parse_env_file(&content))
+                } else {
+                    None
+                };
+
+                let settings_path = get_gemini_settings_path();
+                let config = if settings_path.exists() {
+                    Some(read_json_file::<Value>(&settings_path)?)
+                } else {
+                    None
+                };
+
+                Ok(LiveSnapshot::Gemini { env, config })
+            }
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::ClaudeDesktop => {
+                Err(AppError::Message(format!(
+                    "{} does not use an exclusive live snapshot",
+                    app_type.as_str()
+                )))
+            }
+        }
+    }
+
     #[allow(dead_code)]
     pub(crate) fn restore(&self) -> Result<(), AppError> {
         match self {

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
     provider_exists_in_live_config, strip_common_config_from_live_settings,
-    sync_current_provider_for_app_to_live, write_live_with_common_config,
+    sync_current_provider_for_app_to_live, write_live_with_common_config, LiveSnapshot,
 };
 
 // Internal re-exports
@@ -1487,6 +1487,7 @@ impl ProviderService {
         // Use effective current provider (validated existence) to ensure backfill targets valid provider
         let current_id = crate::settings::get_effective_current_provider(&state.db, &app_type)?;
 
+        let previous_current_id = current_id.clone();
         if let Some(current_id) = current_id {
             if current_id != id {
                 // Additive mode apps - all providers coexist in the same file,
@@ -1516,17 +1517,50 @@ impl ProviderService {
             }
         }
 
-        // Additive mode apps skip setting is_current (no such concept)
-        if !app_type.is_additive_mode() {
-            // Update local settings (device-level, takes priority)
-            crate::settings::set_current_provider(&app_type, Some(id))?;
+        if matches!(app_type, AppType::Codex) {
+            let live_snapshot = LiveSnapshot::capture(&app_type)?;
+            write_live_with_common_config(state.db.as_ref(), &app_type, provider)?;
 
-            // Update database is_current (as default for new devices)
-            state.db.set_current_provider(app_type.as_str(), id)?;
+            if let Err(err) = (|| -> Result<(), AppError> {
+                crate::settings::set_current_provider(&app_type, Some(id))?;
+                state.db.set_current_provider(app_type.as_str(), id)?;
+                Ok(())
+            })() {
+                let settings_restore = crate::settings::set_current_provider(
+                    &app_type,
+                    previous_current_id.as_deref(),
+                );
+                let live_restore = live_snapshot.restore();
+                return match (live_restore, settings_restore) {
+                    (Ok(()), Ok(())) => Err(AppError::Message(format!(
+                        "Failed to persist Codex provider switch; live config was rolled back: {err}"
+                    ))),
+                    (live_result, settings_result) => Err(AppError::Message(format!(
+                        "Failed to persist Codex provider switch: {err}; live rollback: {}; settings rollback: {}",
+                        live_result
+                            .err()
+                            .map(|e| e.to_string())
+                            .unwrap_or_else(|| "ok".to_string()),
+                        settings_result
+                            .err()
+                            .map(|e| e.to_string())
+                            .unwrap_or_else(|| "ok".to_string())
+                    ))),
+                };
+            }
+        } else {
+            // Additive mode apps skip setting is_current (no such concept)
+            if !app_type.is_additive_mode() {
+                // Update local settings (device-level, takes priority)
+                crate::settings::set_current_provider(&app_type, Some(id))?;
+
+                // Update database is_current (as default for new devices)
+                state.db.set_current_provider(app_type.as_str(), id)?;
+            }
+
+            // Sync to live (write_gemini_live handles security flag internally for Gemini)
+            write_live_with_common_config(state.db.as_ref(), &app_type, provider)?;
         }
-
-        // Sync to live (write_gemini_live handles security flag internally for Gemini)
-        write_live_with_common_config(state.db.as_ref(), &app_type, provider)?;
 
         // Hermes is additive, so "switching" doesn't overwrite a live config file
         // — we instead update the top-level `model:` section to point at this

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -62,6 +62,20 @@ interface ProviderCardProps {
 
 /** 判断是否为官方供应商（无自定义 base URL / API key，直连官方 API） */
 function isOfficialProvider(provider: Provider, appId: AppId): boolean {
+  if (appId === "codex") {
+    if (provider.meta?.codexAuthMode === "chatgpt") {
+      return true;
+    }
+    if (provider.meta?.codexAuthMode === "apikey") {
+      return false;
+    }
+
+    // 无 OPENAI_API_KEY → 使用 Codex CLI 内置 OAuth（官方）
+    const config = provider.settingsConfig as Record<string, any>;
+    const apiKey = config?.auth?.OPENAI_API_KEY;
+    return !apiKey || (typeof apiKey === "string" && apiKey.trim() === "");
+  }
+
   if (provider.category === "official") {
     return true;
   }
@@ -70,11 +84,6 @@ function isOfficialProvider(provider: Provider, appId: AppId): boolean {
   if (appId === "claude") {
     const baseUrl = config?.env?.ANTHROPIC_BASE_URL;
     return !baseUrl || (typeof baseUrl === "string" && baseUrl.trim() === "");
-  }
-  if (appId === "codex") {
-    // 无 OPENAI_API_KEY → 使用 Codex CLI 内置 OAuth（官方）
-    const apiKey = config?.auth?.OPENAI_API_KEY;
-    return !apiKey || (typeof apiKey === "string" && apiKey.trim() === "");
   }
   if (appId === "gemini") {
     // 无 GEMINI_API_KEY 且无 GOOGLE_GEMINI_BASE_URL → Google OAuth 官方模式
@@ -191,6 +200,8 @@ export function ProviderCard({
     appId === "hermes" && isHermesReadOnlyProvider(provider.settingsConfig);
   const isCodexOauth =
     provider.meta?.providerType === PROVIDER_TYPES.CODEX_OAUTH;
+  const codexAuthMode =
+    appId === "codex" ? provider.meta?.codexAuthMode : undefined;
 
   // 获取用量数据以判断是否有多套餐
   // 累加模式应用（OpenCode/OpenClaw/Hermes）：使用 isInConfig 代替 isCurrent
@@ -331,6 +342,22 @@ export function ProviderCard({
                     })}
                   </span>
                 )}
+
+              {codexAuthMode === "chatgpt" && (
+                <span className="inline-flex items-center rounded-md bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+                  {t("provider.codexChatGptBadge", {
+                    defaultValue: "ChatGPT",
+                  })}
+                </span>
+              )}
+
+              {codexAuthMode === "apikey" && (
+                <span className="inline-flex items-center rounded-md bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+                  {t("provider.codexApiKeyBadge", {
+                    defaultValue: "API Key",
+                  })}
+                </span>
+              )}
 
               {isProxyRunning && isInFailoverQueue && health && (
                 <ProviderHealthBadge

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -189,6 +189,7 @@ function ProviderFormFull({
     category?: ProviderCategory;
     isPartner?: boolean;
     partnerPromotionKey?: string;
+    codexAuthMode?: "chatgpt" | "apikey";
     suggestedDefaults?: OpenClawSuggestedDefaults;
   } | null>(null);
   const [isEndpointModalOpen, setIsEndpointModalOpen] = useState(false);
@@ -1166,6 +1167,23 @@ function ProviderFormFull({
     // 确定 providerType（新建时从预设获取，编辑时从现有数据获取）
     const providerType =
       templatePreset?.providerType || initialData?.meta?.providerType;
+    let codexAuthHasApiKey = false;
+    if (appId === "codex") {
+      try {
+        const authJson = JSON.parse(codexAuth || "{}");
+        codexAuthHasApiKey =
+          typeof authJson?.OPENAI_API_KEY === "string" &&
+          authJson.OPENAI_API_KEY.trim() !== "";
+      } catch {
+        codexAuthHasApiKey = false;
+      }
+    }
+    const codexAuthMode =
+      appId === "codex"
+        ? (activePreset?.codexAuthMode ??
+          initialData?.meta?.codexAuthMode ??
+          (codexAuthHasApiKey || codexConfig.trim() ? "apikey" : "chatgpt"))
+        : undefined;
 
     const nextMeta: ProviderMeta = {
       ...(baseMeta ?? {}),
@@ -1181,6 +1199,7 @@ function ProviderFormFull({
       claudeDesktopMode: undefined,
       // 保存 providerType（用于识别 Copilot / Codex OAuth 等特殊供应商）
       providerType,
+      codexAuthMode,
       authBinding: isCopilotProvider
         ? {
             source: "managed_account",
@@ -1375,11 +1394,17 @@ function ProviderFormFull({
       return;
     }
 
+    const codexPreset =
+      appId === "codex" ? (entry.preset as CodexProviderPreset) : undefined;
     setActivePreset({
       id: value,
       category: entry.preset.category,
       isPartner: entry.preset.isPartner,
       partnerPromotionKey: entry.preset.partnerPromotionKey,
+      codexAuthMode: codexPreset
+        ? (codexPreset.codexAuthMode ??
+          ((codexPreset.config ?? "").trim() ? "apikey" : "chatgpt"))
+        : undefined,
     });
 
     if (appId === "codex") {

--- a/src/components/settings/CodexStateRepairPanel.tsx
+++ b/src/components/settings/CodexStateRepairPanel.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Database, RefreshCw, Wrench } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { providersApi } from "@/lib/api";
+import type {
+  CodexStateDiagnosis,
+  CodexStateRepairResult,
+} from "@/lib/api/providers";
+import { cn } from "@/lib/utils";
+
+type Action = "diagnose" | "dryRun" | "repair" | null;
+
+function formatOptional(value?: string | null) {
+  return value && value.trim() ? value : "openai";
+}
+
+export function CodexStateRepairPanel() {
+  const [diagnosis, setDiagnosis] = useState<CodexStateDiagnosis | null>(null);
+  const [repairResult, setRepairResult] =
+    useState<CodexStateRepairResult | null>(null);
+  const [action, setAction] = useState<Action>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadDiagnosis = useCallback(async () => {
+    setAction("diagnose");
+    setError(null);
+    try {
+      const result = await providersApi.diagnoseCodexState();
+      setDiagnosis(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      toast.error(message);
+    } finally {
+      setAction(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadDiagnosis();
+  }, [loadDiagnosis]);
+
+  const runRepair = useCallback(async (dryRun: boolean) => {
+    setAction(dryRun ? "dryRun" : "repair");
+    setError(null);
+    try {
+      const result = await providersApi.repairCodexState(dryRun);
+      setRepairResult(result);
+      if (result.diagnosisAfter) {
+        setDiagnosis(result.diagnosisAfter);
+      }
+      toast.success(
+        dryRun
+          ? `Dry run: ${result.affectedRows} row(s) can be repaired`
+          : `Repaired ${result.affectedRows} row(s)`,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      toast.error(message);
+    } finally {
+      setAction(null);
+    }
+  }, []);
+
+  const hasRepairableRows = (diagnosis?.repairableRows ?? 0) > 0;
+  const providerCounts = diagnosis?.providerCounts ?? [];
+  const statusTone = useMemo(() => {
+    if (!diagnosis) return "border-border bg-muted/20";
+    return diagnosis.inconsistent
+      ? "border-amber-500/40 bg-amber-500/10"
+      : "border-emerald-500/40 bg-emerald-500/10";
+  }, [diagnosis]);
+
+  return (
+    <div className="space-y-4">
+      <div className={cn("rounded-lg border p-4", statusTone)}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex items-start gap-3">
+            {diagnosis?.inconsistent ? (
+              <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-600" />
+            ) : (
+              <Database className="mt-0.5 h-5 w-5 text-emerald-600" />
+            )}
+            <div className="space-y-2">
+              <div className="text-sm font-semibold">
+                {diagnosis?.inconsistent
+                  ? "Codex state mismatch detected"
+                  : "Codex state is aligned"}
+              </div>
+              {diagnosis ? (
+                <div className="grid gap-1 text-sm text-muted-foreground sm:grid-cols-2">
+                  <div>
+                    Config provider:{" "}
+                    <span className="font-mono text-foreground">
+                      {formatOptional(diagnosis.configModelProvider)}
+                    </span>
+                  </div>
+                  <div>
+                    Effective provider:{" "}
+                    <span className="font-mono text-foreground">
+                      {diagnosis.effectiveModelProvider}
+                    </span>
+                  </div>
+                  <div>
+                    Auth mode:{" "}
+                    <span className="font-mono text-foreground">
+                      {diagnosis.authMode}
+                    </span>
+                  </div>
+                  <div>
+                    Repairable rows:{" "}
+                    <span className="font-mono text-foreground">
+                      {diagnosis.repairableRows}
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-sm text-muted-foreground">
+                  Reading local Codex config, auth, and thread index.
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={loadDiagnosis}
+              disabled={action !== null}
+            >
+              <RefreshCw
+                className={cn(
+                  "mr-2 h-4 w-4",
+                  action === "diagnose" && "animate-spin",
+                )}
+              />
+              Diagnose
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => runRepair(true)}
+              disabled={action !== null || !hasRepairableRows}
+            >
+              Dry Run
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => runRepair(false)}
+              disabled={action !== null || !hasRepairableRows}
+            >
+              <Wrench className="mr-2 h-4 w-4" />
+              Repair
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {diagnosis?.stateDbPath && (
+        <div className="text-xs text-muted-foreground">
+          SQLite: <span className="font-mono">{diagnosis.stateDbPath}</span>
+        </div>
+      )}
+
+      {diagnosis?.configAuthMismatch && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+          Config/auth mismatch: Codex may still be using the wrong credential
+          mode for the selected provider.
+        </div>
+      )}
+
+      {providerCounts.length > 0 && (
+        <div className="rounded-lg border border-border">
+          <div className="border-b border-border px-3 py-2 text-sm font-medium">
+            Thread index buckets
+          </div>
+          <div className="divide-y divide-border">
+            {providerCounts.map((row) => (
+              <div
+                key={row.modelProvider}
+                className="flex items-center justify-between px-3 py-2 text-sm"
+              >
+                <span className="font-mono">{row.modelProvider}</span>
+                <span>{row.count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {repairResult && (
+        <div className="rounded-lg border border-border px-3 py-2 text-sm">
+          <div>
+            Last result: {repairResult.dryRun ? "dry run" : "repair"} to{" "}
+            <span className="font-mono">
+              {repairResult.targetModelProvider}
+            </span>
+            , affected {repairResult.affectedRows} row(s).
+          </div>
+          {repairResult.backupPath && (
+            <div className="mt-1 text-muted-foreground">
+              Backup:{" "}
+              <span className="font-mono">{repairResult.backupPath}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   ScrollText,
   HardDriveDownload,
   FlaskConical,
+  Wrench,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -44,6 +45,7 @@ import { ModelTestConfigPanel } from "@/components/usage/ModelTestConfigPanel";
 import { UsageDashboard } from "@/components/usage/UsageDashboard";
 import { LogConfigPanel } from "@/components/settings/LogConfigPanel";
 import { AuthCenterPanel } from "@/components/settings/AuthCenterPanel";
+import { CodexStateRepairPanel } from "@/components/settings/CodexStateRepairPanel";
 import { useInstalledSkills } from "@/hooks/useSkills";
 import { useSettings } from "@/hooks/useSettings";
 import { useImportExport } from "@/hooks/useImportExport";
@@ -435,6 +437,33 @@ export function SettingsPage({
                         </AccordionTrigger>
                         <AccordionContent className="px-6 pb-6 pt-4 border-t border-border/50">
                           <ModelTestConfigPanel />
+                        </AccordionContent>
+                      </AccordionItem>
+
+                      <AccordionItem
+                        value="codexState"
+                        className="rounded-xl glass-card overflow-hidden"
+                      >
+                        <AccordionTrigger className="px-6 py-4 hover:no-underline hover:bg-muted/50 data-[state=open]:bg-muted/50">
+                          <div className="flex items-center gap-3">
+                            <Wrench className="h-5 w-5 text-orange-500" />
+                            <div className="text-left">
+                              <h3 className="text-base font-semibold">
+                                {t("settings.advanced.codexState.title", {
+                                  defaultValue: "Codex State Repair",
+                                })}
+                              </h3>
+                              <p className="text-sm text-muted-foreground font-normal">
+                                {t("settings.advanced.codexState.description", {
+                                  defaultValue:
+                                    "Diagnose and repair Codex provider, auth, and history index mismatches",
+                                })}
+                              </p>
+                            </div>
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent className="px-6 pb-6 pt-4 border-t border-border/50">
+                          <CodexStateRepairPanel />
                         </AccordionContent>
                       </AccordionItem>
 

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -16,6 +16,7 @@ export interface CodexProviderPreset {
   isPartner?: boolean; // 标识是否为商业合作伙伴
   partnerPromotionKey?: string; // 合作伙伴促销信息的 i18n key
   category?: ProviderCategory; // 新增：分类
+  codexAuthMode?: "chatgpt" | "apikey"; // Codex 本体认证模式
   isCustomTemplate?: boolean; // 标识是否为自定义模板
   // 新增：请求地址候选列表（用于地址管理/测速）
   endpointCandidates?: string[];
@@ -64,10 +65,11 @@ requires_openai_auth = true`;
 
 export const codexProviderPresets: CodexProviderPreset[] = [
   {
-    name: "OpenAI Official",
+    name: "OpenAI Official (ChatGPT)",
     websiteUrl: "https://chatgpt.com/codex",
     isOfficial: true,
     category: "official",
+    codexAuthMode: "chatgpt",
     auth: {},
     config: ``,
     theme: {
@@ -90,6 +92,7 @@ export const codexProviderPresets: CodexProviderPreset[] = [
       "gpt-5.4",
     ),
     category: "aggregator",
+    codexAuthMode: "apikey",
     isPartner: true,
     partnerPromotionKey: "shengsuanyun",
     icon: "shengsuanyun",
@@ -100,6 +103,7 @@ export const codexProviderPresets: CodexProviderPreset[] = [
       "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/codex",
     category: "third_party",
     isOfficial: true,
+    codexAuthMode: "apikey",
     auth: generateThirdPartyAuth(""),
     config: `model_provider = "azure"
 model = "gpt-5.4"
@@ -126,6 +130,7 @@ requires_openai_auth = true`,
     name: "AiHubMix",
     websiteUrl: "https://aihubmix.com",
     category: "aggregator",
+    codexAuthMode: "apikey",
     auth: generateThirdPartyAuth(""),
     config: generateThirdPartyConfig(
       "aihubmix",
@@ -141,6 +146,7 @@ requires_openai_auth = true`,
     name: "DMXAPI",
     websiteUrl: "https://www.dmxapi.cn",
     category: "aggregator",
+    codexAuthMode: "apikey",
     auth: generateThirdPartyAuth(""),
     config: generateThirdPartyConfig(
       "dmxapi",
@@ -156,6 +162,7 @@ requires_openai_auth = true`,
     websiteUrl: "https://www.packyapi.com",
     apiKeyUrl: "https://www.packyapi.com/register?aff=cc-switch",
     category: "third_party",
+    codexAuthMode: "apikey",
     auth: generateThirdPartyAuth(""),
     config: generateThirdPartyConfig(
       "packycode",
@@ -187,6 +194,7 @@ requires_openai_auth = true`,
       "https://api-bwg.cubence.com/v1",
     ],
     category: "third_party",
+    codexAuthMode: "apikey",
     isPartner: true, // 合作伙伴
     partnerPromotionKey: "cubence", // 促销信息 i18n key
     icon: "cubence",
@@ -197,6 +205,7 @@ requires_openai_auth = true`,
     websiteUrl: "https://aigocode.com",
     apiKeyUrl: "https://aigocode.com/invite/CC-SWITCH",
     category: "third_party",
+    codexAuthMode: "apikey",
     auth: generateThirdPartyAuth(""),
     config: generateThirdPartyConfig(
       "aigocode",
@@ -220,6 +229,7 @@ requires_openai_auth = true`,
       "gpt-5.4",
     ),
     category: "third_party",
+    codexAuthMode: "apikey",
     isPartner: true,
     partnerPromotionKey: "rightcode",
     icon: "rc",

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -47,6 +47,32 @@ export interface ClaudeDesktopDefaultRoute {
   supports1m: boolean;
 }
 
+export interface CodexModelProviderCount {
+  modelProvider: string;
+  count: number;
+}
+
+export interface CodexStateDiagnosis {
+  configModelProvider?: string | null;
+  effectiveModelProvider: string;
+  authMode: string;
+  stateDbPath?: string | null;
+  providerCounts: CodexModelProviderCount[];
+  configAuthMismatch: boolean;
+  indexMismatch: boolean;
+  inconsistent: boolean;
+  repairableRows: number;
+}
+
+export interface CodexStateRepairResult {
+  dryRun: boolean;
+  targetModelProvider: string;
+  affectedRows: number;
+  backupPath?: string | null;
+  diagnosisBefore: CodexStateDiagnosis;
+  diagnosisAfter?: CodexStateDiagnosis | null;
+}
+
 export const providersApi = {
   async getAll(appId: AppId): Promise<Record<string, Provider>> {
     return await invoke("get_providers", { app: appId });
@@ -106,6 +132,14 @@ export const providersApi = {
 
   async getClaudeDesktopDefaultRoutes(): Promise<ClaudeDesktopDefaultRoute[]> {
     return await invoke("get_claude_desktop_default_routes");
+  },
+
+  async diagnoseCodexState(): Promise<CodexStateDiagnosis> {
+    return await invoke("diagnose_codex_state");
+  },
+
+  async repairCodexState(dryRun: boolean): Promise<CodexStateRepairResult> {
+    return await invoke("repair_codex_state", { dryRun });
   },
 
   async updateTrayMenu(): Promise<boolean> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,8 @@ export interface ProviderMeta {
   promptCacheKey?: string;
   // Codex OAuth FAST mode: injects service_tier="priority" on ChatGPT Codex requests
   codexFastMode?: boolean;
+  // Codex app auth mode: ChatGPT login state vs OpenAI-compatible API key/gateway
+  codexAuthMode?: "chatgpt" | "apikey";
   // 供应商类型（用于识别 Copilot 等特殊供应商）
   providerType?: string;
   // GitHub Copilot 关联账号 ID（旧字段，保留兼容读取）

--- a/tests/components/CodexStateRepairPanel.test.tsx
+++ b/tests/components/CodexStateRepairPanel.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CodexStateRepairPanel } from "@/components/settings/CodexStateRepairPanel";
+import type {
+  CodexStateDiagnosis,
+  CodexStateRepairResult,
+} from "@/lib/api/providers";
+import { server } from "../msw/server";
+
+const TAURI_ENDPOINT = "http://tauri.local";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const diagnosis: CodexStateDiagnosis = {
+  configModelProvider: "openai",
+  effectiveModelProvider: "shengsuanyun",
+  authMode: "apikey",
+  stateDbPath: "/tmp/codex-state.sqlite",
+  providerCounts: [
+    { modelProvider: "openai", count: 3 },
+    { modelProvider: "shengsuanyun", count: 7 },
+  ],
+  configAuthMismatch: true,
+  indexMismatch: true,
+  inconsistent: true,
+  repairableRows: 3,
+};
+
+describe("CodexStateRepairPanel", () => {
+  const repairPayloads: unknown[] = [];
+
+  beforeEach(() => {
+    repairPayloads.length = 0;
+
+    server.use(
+      http.post(`${TAURI_ENDPOINT}/diagnose_codex_state`, () =>
+        HttpResponse.json(diagnosis),
+      ),
+      http.post(`${TAURI_ENDPOINT}/repair_codex_state`, async ({ request }) => {
+        const payload = await request.json();
+        repairPayloads.push(payload);
+
+        const dryRun = Boolean((payload as { dryRun?: boolean }).dryRun);
+        const result: CodexStateRepairResult = {
+          dryRun,
+          targetModelProvider: "shengsuanyun",
+          affectedRows: 3,
+          backupPath: dryRun ? null : "/tmp/codex-state.sqlite.bak",
+          diagnosisBefore: diagnosis,
+          diagnosisAfter: { ...diagnosis, inconsistent: false },
+        };
+
+        return HttpResponse.json(result);
+      }),
+    );
+  });
+
+  it("renders inconsistent diagnosis details, repairable rows, and provider counts", async () => {
+    render(<CodexStateRepairPanel />);
+
+    expect(
+      await screen.findByText("Codex state mismatch detected"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Config/auth mismatch:", { exact: false }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("openai").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("shengsuanyun").length).toBeGreaterThan(0);
+    expect(screen.getByText("apikey")).toBeInTheDocument();
+    expect(
+      screen.getByText("Repairable rows:", { exact: false }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("/tmp/codex-state.sqlite")).toBeInTheDocument();
+    expect(screen.getByText("Thread index buckets")).toBeInTheDocument();
+    expect(screen.getAllByText("3").length).toBeGreaterThan(0);
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("calls repair_codex_state with dryRun true when Dry Run is clicked", async () => {
+    render(<CodexStateRepairPanel />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dry Run" }));
+
+    await waitFor(() =>
+      expect(repairPayloads).toContainEqual({ dryRun: true }),
+    );
+    expect(
+      await screen.findByText("Last result: dry run to", { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls repair_codex_state with dryRun false when Repair is clicked", async () => {
+    render(<CodexStateRepairPanel />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Repair$/ }));
+
+    await waitFor(() =>
+      expect(repairPayloads).toContainEqual({ dryRun: false }),
+    );
+    expect(
+      await screen.findByText("Last result: repair to", { exact: false }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/config/codexProviderPresets.test.ts
+++ b/tests/config/codexProviderPresets.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { codexProviderPresets } from "@/config/codexProviderPresets";
+
+describe("Codex provider presets", () => {
+  it("uses ChatGPT auth for the first OpenAI official preset", () => {
+    expect(codexProviderPresets[0]).toMatchObject({
+      name: "OpenAI Official (ChatGPT)",
+      codexAuthMode: "chatgpt",
+    });
+  });
+
+  it("uses API key auth for at least one non-official preset", () => {
+    const apiKeyPreset = codexProviderPresets.find(
+      (preset) => !preset.isOfficial && preset.codexAuthMode === "apikey",
+    );
+
+    expect(apiKeyPreset).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- keep Codex provider switching transactional across config.toml, auth.json, and persisted provider settings
- distinguish ChatGPT OAuth providers from API key providers in Codex metadata and UI labels
- add Codex state diagnosis and SQLite index repair commands with dry-run, backup, and settings panel support
- add backend and frontend tests for provider metadata migration and repair flows

## Why
Switching Codex providers could leave config, auth, and history index state in different provider buckets. That made ChatGPT sessions appear missing or fail with API-key gateway errors after switching accounts.

## Validation
- pnpm typecheck
- pnpm test:unit
- cargo test --manifest-path src-tauri/Cargo.toml
- direct Tauri macOS app bundle build succeeded locally

## Notes
The repair helper only updates state_5.sqlite threads.model_provider after creating a backup. It does not modify session JSONL message sources.
