### PR TITLE
fix(backend): avoid misclassifying shell aliases as env conflicts; detect bun-installed CLIs

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -573,6 +573,7 @@ fn scan_cli_version(tool: &str) -> (Option<String>, Option<String>) {
         push_unique_path(&mut search_paths, home.join(".npm-global/bin"));
         push_unique_path(&mut search_paths, home.join("n/bin"));
         push_unique_path(&mut search_paths, home.join(".volta/bin"));
+        push_unique_path(&mut search_paths, home.join(".bun/bin"));
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/services/env_checker.rs
+++ b/src-tauri/src/services/env_checker.rs
@@ -116,22 +116,9 @@ fn check_shell_configs(keywords: &[&str]) -> Result<Vec<EnvConflict>, String> {
 
     for file_path in config_files {
         if let Ok(content) = fs::read_to_string(&file_path) {
-            // Parse lines for export statements
             for (line_num, line) in content.lines().enumerate() {
-                let trimmed = line.trim();
-
-                if trimmed.starts_with('#') {
+                let Some(assignment) = extract_exporting_assignment(line.trim()) else {
                     continue;
-                }
-
-                // Only treat lines as env assignments when they are explicit exports
-                // or bare `NAME=VALUE` forms. Skip alias/function/local/declare/etc.
-                let assignment = if let Some(rest) = trimmed.strip_prefix("export ") {
-                    rest.trim_start()
-                } else if !trimmed.contains('=') {
-                    continue;
-                } else {
-                    trimmed
                 };
 
                 let Some(eq_pos) = assignment.find('=') else {
@@ -162,6 +149,61 @@ fn check_shell_configs(keywords: &[&str]) -> Result<Vec<EnvConflict>, String> {
     }
 
     Ok(conflicts)
+}
+
+/// Strip exporting builtins (`export`, `declare -x`, `typeset -gx`, …) from a
+/// trimmed shell line and return the inner `NAME=VALUE` portion. Returns None
+/// for comments, non-assignment lines, or `declare`/`typeset` calls without
+/// `-x` (which create function-local, non-exported variables).
+#[cfg(not(target_os = "windows"))]
+fn extract_exporting_assignment(trimmed: &str) -> Option<&str> {
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("export ") {
+        return Some(rest.trim_start());
+    }
+
+    // bash `declare` and zsh `typeset` only export when `-x` is in the flags
+    // (e.g. `declare -x FOO=bar`, `typeset -gx FOO=bar`).
+    for builtin in ["declare", "typeset"] {
+        let Some(after) = trimmed.strip_prefix(builtin) else {
+            continue;
+        };
+        let Some(first) = after.chars().next() else {
+            continue;
+        };
+        if !first.is_whitespace() {
+            // e.g. `declared=foo` — different variable, fall through to bare path.
+            continue;
+        }
+
+        let mut s = after.trim_start();
+        let mut has_x = false;
+        while let Some(rest) = s.strip_prefix('-') {
+            let end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+            let flag = &rest[..end];
+            if flag == "-" {
+                // `--` end-of-options marker
+                s = rest[end..].trim_start();
+                break;
+            }
+            if flag.contains('x') {
+                has_x = true;
+            }
+            s = rest[end..].trim_start();
+        }
+
+        return if has_x { Some(s) } else { None };
+    }
+
+    // Bare `NAME=VALUE` — common in rc files paired with a later `export NAME`.
+    if trimmed.contains('=') {
+        Some(trimmed)
+    } else {
+        None
+    }
 }
 
 /// A valid POSIX-ish env var name: starts with letter or `_`, then alphanumerics/`_`.
@@ -203,5 +245,65 @@ mod tests {
         assert!(!is_valid_env_name("1FOO"));
         assert!(!is_valid_env_name(""));
         assert!(!is_valid_env_name("FOO-BAR"));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_extract_exporting_assignment() {
+        // export
+        assert_eq!(
+            extract_exporting_assignment("export GEMINI_API_KEY=foo"),
+            Some("GEMINI_API_KEY=foo")
+        );
+
+        // bash `declare -x`
+        assert_eq!(
+            extract_exporting_assignment("declare -x OPENAI_API_KEY=sk-x"),
+            Some("OPENAI_API_KEY=sk-x")
+        );
+
+        // zsh `typeset -gx` (combined flags)
+        assert_eq!(
+            extract_exporting_assignment("typeset -gx GEMINI_API_KEY=bar"),
+            Some("GEMINI_API_KEY=bar")
+        );
+
+        // Multiple flags including -x
+        assert_eq!(
+            extract_exporting_assignment("declare -r -x ANTHROPIC_API_KEY=k"),
+            Some("ANTHROPIC_API_KEY=k")
+        );
+
+        // declare without -x is function-local — must be skipped
+        assert_eq!(
+            extract_exporting_assignment("declare GEMINI_API_KEY=local"),
+            None
+        );
+        assert_eq!(
+            extract_exporting_assignment("typeset -g GEMINI_API_KEY=local"),
+            None
+        );
+
+        // alias must fall through and be rejected later by is_valid_env_name
+        assert_eq!(
+            extract_exporting_assignment("alias gemini=\"/path/to/gemini -y\""),
+            Some("alias gemini=\"/path/to/gemini -y\"")
+        );
+
+        // bare assignment is preserved
+        assert_eq!(
+            extract_exporting_assignment("FOO=bar"),
+            Some("FOO=bar")
+        );
+
+        // comments and empty lines
+        assert_eq!(extract_exporting_assignment("# export FOO=bar"), None);
+        assert_eq!(extract_exporting_assignment(""), None);
+
+        // `declared` (different variable name starting with "declare") should not be eaten
+        assert_eq!(
+            extract_exporting_assignment("declared=foo"),
+            Some("declared=foo")
+        );
     }
 }

--- a/src-tauri/src/services/env_checker.rs
+++ b/src-tauri/src/services/env_checker.rs
@@ -120,35 +120,59 @@ fn check_shell_configs(keywords: &[&str]) -> Result<Vec<EnvConflict>, String> {
             for (line_num, line) in content.lines().enumerate() {
                 let trimmed = line.trim();
 
-                // Match patterns like: export VAR=value or VAR=value
-                if trimmed.starts_with("export ")
-                    || (!trimmed.starts_with('#') && trimmed.contains('='))
-                {
-                    let export_line = trimmed.strip_prefix("export ").unwrap_or(trimmed);
+                if trimmed.starts_with('#') {
+                    continue;
+                }
 
-                    if let Some(eq_pos) = export_line.find('=') {
-                        let var_name = export_line[..eq_pos].trim();
-                        let var_value = export_line[eq_pos + 1..].trim();
+                // Only treat lines as env assignments when they are explicit exports
+                // or bare `NAME=VALUE` forms. Skip alias/function/local/declare/etc.
+                let assignment = if let Some(rest) = trimmed.strip_prefix("export ") {
+                    rest.trim_start()
+                } else if !trimmed.contains('=') {
+                    continue;
+                } else {
+                    trimmed
+                };
 
-                        // Check if variable name contains any keyword
-                        if keywords.iter().any(|k| var_name.to_uppercase().contains(k)) {
-                            conflicts.push(EnvConflict {
-                                var_name: var_name.to_string(),
-                                var_value: var_value
-                                    .trim_matches('"')
-                                    .trim_matches('\'')
-                                    .to_string(),
-                                source_type: "file".to_string(),
-                                source_path: format!("{}:{}", file_path, line_num + 1),
-                            });
-                        }
-                    }
+                let Some(eq_pos) = assignment.find('=') else {
+                    continue;
+                };
+                let var_name = assignment[..eq_pos].trim();
+                let var_value = assignment[eq_pos + 1..].trim();
+
+                // Reject anything that isn't a valid shell identifier — this filters
+                // out aliases (`alias gemini=...`), functions, and lines with spaces.
+                if !is_valid_env_name(var_name) {
+                    continue;
+                }
+
+                if keywords.iter().any(|k| var_name.to_uppercase().contains(k)) {
+                    conflicts.push(EnvConflict {
+                        var_name: var_name.to_string(),
+                        var_value: var_value
+                            .trim_matches('"')
+                            .trim_matches('\'')
+                            .to_string(),
+                        source_type: "file".to_string(),
+                        source_path: format!("{}:{}", file_path, line_num + 1),
+                    });
                 }
             }
         }
     }
 
     Ok(conflicts)
+}
+
+/// A valid POSIX-ish env var name: starts with letter or `_`, then alphanumerics/`_`.
+#[cfg(not(target_os = "windows"))]
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 #[cfg(test)]
@@ -164,5 +188,20 @@ mod tests {
             vec!["GEMINI", "GOOGLE_GEMINI"]
         );
         assert_eq!(get_keywords_for_app("unknown"), Vec::<&str>::new());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_is_valid_env_name() {
+        assert!(is_valid_env_name("GEMINI_API_KEY"));
+        assert!(is_valid_env_name("_FOO"));
+        assert!(is_valid_env_name("Foo123"));
+
+        // aliases / functions / multi-word — must be rejected
+        assert!(!is_valid_env_name("alias gemini"));
+        assert!(!is_valid_env_name("function gemini()"));
+        assert!(!is_valid_env_name("1FOO"));
+        assert!(!is_valid_env_name(""));
+        assert!(!is_valid_env_name("FOO-BAR"));
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes in the backend env/tool detection layer.

### 1. Shell alias misclassified as env-var conflict

`env_checker::check_shell_configs` parsed any line containing `=` as an env assignment, then matched the LHS against per-app keywords. A line like:

```sh
alias gemini="/Users/me/.bun/bin/gemini -y"
```

was parsed into `var_name = "alias gemini"`, uppercased to `ALIAS GEMINI`, which contains the `GEMINI` keyword — so the alias surfaced as a conflicting env var on app startup.

**Fix:** require the LHS to be a valid POSIX env-var identifier (`[A-Za-z_][A-Za-z0-9_]*`) before treating the line as an assignment. Aliases, function definitions, and lines with embedded spaces are now skipped. Added unit tests for `is_valid_env_name`.

### 2. `~/.bun/bin` missing from CLI scan paths

`scan_cli_version` (the path-scan fallback after `$SHELL -lic 'tool --version'` fails) checked `~/.local/bin`, `~/.npm-global/bin`, `~/n/bin`, `~/.volta/bin`, and the various nvm/fnm/volta layouts — but not `~/.bun/bin`. CLIs installed via `bun install -g` (gemini, codex, etc.) were therefore reported as not installed when the shell invocation couldn't resolve them (e.g. when the alias is in `.bash_profile` but the user's shell is zsh).

**Fix:** add `~/.bun/bin` to the home-relative search paths.

## Test plan

- [x] `cargo test --lib env_checker` passes (existing + new `test_is_valid_env_name`).
- [x] `cargo build --lib` clean.
- [x] Manual: with `alias gemini="..."` in `.bash_profile`, the env-conflict banner no longer flags it.
- [x] Manual: with gemini installed via `bun install -g @google/gemini-cli`, the version is detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)