### PR TITLE
feat(proxy): add password authentication for LAN access

### DIFF
--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -99,7 +99,7 @@ pub async fn get_global_proxy_config(
 /// 更新全局代理配置
 ///
 /// 更新统一的全局配置字段，会同时更新三行（claude/codex/gemini）。
-/// 密码变更在下次代理启动时生效（代理启动时从 DB 读取配置）。
+/// 如果代理正在运行，同步更新运行时配置和 Live 接管配置。
 #[tauri::command]
 pub async fn update_global_proxy_config(
     state: tauri::State<'_, AppState>,
@@ -108,6 +108,13 @@ pub async fn update_global_proxy_config(
     state
         .db
         .update_global_proxy_config(config)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // 同步到运行中的代理（密码变更立即生效，接管客户端的 Live 配置也会刷新）
+    state
+        .proxy_service
+        .sync_global_config()
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -98,14 +98,16 @@ pub async fn get_global_proxy_config(
 
 /// 更新全局代理配置
 ///
-/// 更新统一的全局配置字段，会同时更新三行（claude/codex/gemini）
+/// 更新统一的全局配置字段，会同时更新三行（claude/codex/gemini）。
+/// 密码变更在下次代理启动时生效（代理启动时从 DB 读取配置）。
 #[tauri::command]
 pub async fn update_global_proxy_config(
     state: tauri::State<'_, AppState>,
     config: GlobalProxyConfig,
 ) -> Result<(), String> {
-    let db = &state.db;
-    db.update_global_proxy_config(config)
+    state
+        .db
+        .update_global_proxy_config(config)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -57,11 +57,18 @@ impl Database {
 
     /// 获取全局代理配置（统一字段）
     ///
-    /// 从 claude 行读取（三行镜像一致）
+    /// 从 claude 行读取（三行镜像一致），密码存储在 settings 表中。
     pub async fn get_global_proxy_config(&self) -> Result<GlobalProxyConfig, AppError> {
-        // 使用 block 限制 conn 的作用域，避免跨 await 持有锁
         let result = {
             let conn = lock_conn!(self.conn);
+            let pwd: Option<String> = conn
+                .query_row(
+                    "SELECT value FROM settings WHERE key = 'proxy_password'",
+                    [],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .ok()
+                .flatten();
             conn.query_row(
                 "SELECT proxy_enabled, listen_address, listen_port, enable_logging
                  FROM proxy_config WHERE app_type = 'claude'",
@@ -72,11 +79,11 @@ impl Database {
                         listen_address: row.get(1)?,
                         listen_port: row.get::<_, i32>(2)? as u16,
                         enable_logging: row.get::<_, i32>(3)? != 0,
+                        proxy_password: pwd,
                     })
                 },
             )
         };
-        // conn 已在 block 结束时释放
 
         match result {
             Ok(config) => Ok(config),
@@ -88,6 +95,7 @@ impl Database {
                     listen_address: "127.0.0.1".to_string(),
                     listen_port: 15721,
                     enable_logging: true,
+                    proxy_password: None,
                 })
             }
             Err(e) => Err(AppError::Database(e.to_string())),
@@ -95,6 +103,8 @@ impl Database {
     }
 
     /// 更新全局代理配置（镜像写三行）
+    ///
+    /// proxy_config 字段写 proxy_config 表，密码存 settings 表。
     pub async fn update_global_proxy_config(
         &self,
         config: GlobalProxyConfig,
@@ -114,6 +124,13 @@ impl Database {
                 config.listen_port as i32,
                 if config.enable_logging { 1 } else { 0 },
             ],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // 密码存储在 settings 表中（不修改数据库版本）
+        conn.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('proxy_password', ?1)",
+            rusqlite::params![config.proxy_password],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -415,6 +432,15 @@ impl Database {
                  FROM proxy_config WHERE app_type = 'claude'",
                 [],
                 |row| {
+                    let pwd: Option<String> = conn
+                        .query_row(
+                            "SELECT value FROM settings WHERE key = 'proxy_password'",
+                            [],
+                            |r| r.get::<_, Option<String>>(0),
+                        )
+                        .ok()
+                        .flatten();
+
                     Ok(ProxyConfig {
                         listen_address: row.get(0)?,
                         listen_port: row.get::<_, i32>(1)? as u16,
@@ -425,6 +451,7 @@ impl Database {
                         streaming_first_byte_timeout: row.get::<_, i32>(4).unwrap_or(60) as u64,
                         streaming_idle_timeout: row.get::<_, i32>(5).unwrap_or(120) as u64,
                         non_streaming_timeout: row.get::<_, i32>(6).unwrap_or(600) as u64,
+                        proxy_password: pwd,
                     })
                 },
             )
@@ -466,6 +493,13 @@ impl Database {
                 config.streaming_idle_timeout as i32,
                 config.non_streaming_timeout as i32,
             ],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // 密码存储在 settings 表中
+        conn.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('proxy_password', ?1)",
+            rusqlite::params![config.proxy_password],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
 

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -423,9 +423,18 @@ impl Database {
 
     /// 获取代理配置（兼容旧接口，返回 claude 行的配置）
     pub async fn get_proxy_config(&self) -> Result<ProxyConfig, AppError> {
-        // 使用 block 限制 conn 的作用域，避免跨 await 持有锁
         let result = {
             let conn = lock_conn!(self.conn);
+            // 先查密码，避免在 query_row 闭包中嵌套查询同一个 conn
+            let pwd: Option<String> = match conn.query_row(
+                "SELECT value FROM settings WHERE key = 'proxy_password'",
+                [],
+                |r| r.get::<_, Option<String>>(0),
+            ) {
+                Ok(val) => val,
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(AppError::Database(e.to_string())),
+            };
             conn.query_row(
                 "SELECT listen_address, listen_port, max_retries,
                         enable_logging,
@@ -433,16 +442,6 @@ impl Database {
                  FROM proxy_config WHERE app_type = 'claude'",
                 [],
                 |row| {
-                    let pwd: Option<String> = match conn.query_row(
-                        "SELECT value FROM settings WHERE key = 'proxy_password'",
-                        [],
-                        |r| r.get::<_, Option<String>>(0),
-                    ) {
-                        Ok(val) => val,
-                        Err(rusqlite::Error::QueryReturnedNoRows) => None,
-                        Err(e) => return Err(e),
-                    };
-
                     Ok(ProxyConfig {
                         listen_address: row.get(0)?,
                         listen_port: row.get::<_, i32>(1)? as u16,

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -61,14 +61,15 @@ impl Database {
     pub async fn get_global_proxy_config(&self) -> Result<GlobalProxyConfig, AppError> {
         let result = {
             let conn = lock_conn!(self.conn);
-            let pwd: Option<String> = conn
-                .query_row(
-                    "SELECT value FROM settings WHERE key = 'proxy_password'",
-                    [],
-                    |row| row.get::<_, Option<String>>(0),
-                )
-                .ok()
-                .flatten();
+            let pwd: Option<String> = match conn.query_row(
+                "SELECT value FROM settings WHERE key = 'proxy_password'",
+                [],
+                |row| row.get::<_, Option<String>>(0),
+            ) {
+                Ok(val) => val,
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(AppError::Database(e.to_string())),
+            };
             conn.query_row(
                 "SELECT proxy_enabled, listen_address, listen_port, enable_logging
                  FROM proxy_config WHERE app_type = 'claude'",
@@ -432,14 +433,15 @@ impl Database {
                  FROM proxy_config WHERE app_type = 'claude'",
                 [],
                 |row| {
-                    let pwd: Option<String> = conn
-                        .query_row(
-                            "SELECT value FROM settings WHERE key = 'proxy_password'",
-                            [],
-                            |r| r.get::<_, Option<String>>(0),
-                        )
-                        .ok()
-                        .flatten();
+                    let pwd: Option<String> = match conn.query_row(
+                        "SELECT value FROM settings WHERE key = 'proxy_password'",
+                        [],
+                        |r| r.get::<_, Option<String>>(0),
+                    ) {
+                        Ok(val) => val,
+                        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                        Err(e) => return Err(e),
+                    };
 
                     Ok(ProxyConfig {
                         listen_address: row.get(0)?,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -404,19 +404,25 @@ async fn proxy_auth_middleware(
     req: axum::http::Request<axum::body::Body>,
     next: middleware::Next,
 ) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
-    let config = state.config.read().await;
-    let password = config.proxy_password.as_deref().unwrap_or("");
+    // 提前提取密码并释放 config 读锁，避免长连接阻塞配置写入
+    let password = {
+        let config = state.config.read().await;
+        config.proxy_password.clone().unwrap_or_default()
+    };
 
     if !password.is_empty() {
         let mut authorized = false;
 
-        // 检查 Authorization 头（支持 Bearer 前缀）
+        // 检查 Authorization 头（Bearer 大小写不敏感，per RFC 6750）
         if let Some(val) = req
             .headers()
             .get("authorization")
             .and_then(|v| v.to_str().ok())
         {
-            let token = val.strip_prefix("Bearer ").unwrap_or(val);
+            let token = val
+                .strip_prefix("Bearer ")
+                .or_else(|| val.strip_prefix("bearer "))
+                .unwrap_or(val);
             if token == password {
                 authorized = true;
             }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -15,11 +15,15 @@ use super::{
 };
 use crate::database::Database;
 use axum::{
-    extract::DefaultBodyLimit,
+    extract::{DefaultBodyLimit, State},
+    http::StatusCode,
+    middleware,
+    response::IntoResponse,
     routing::{any, get, post},
-    Router,
+    Json, Router,
 };
 use hyper_util::rt::TokioIo;
+use serde_json::json;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
@@ -278,10 +282,8 @@ impl ProxyServer {
     }
 
     fn build_router(&self) -> Router {
-        Router::new()
-            // 健康检查
-            .route("/health", get(handlers::health_check))
-            .route("/status", get(handlers::get_status))
+        // 需要密码认证的 API 路由
+        let api_routes = Router::new()
             // Claude API (支持带前缀和不带前缀两种格式)
             .route("/v1/messages", post(handlers::handle_messages))
             .route("/claude/v1/messages", post(handlers::handle_messages))
@@ -340,6 +342,18 @@ impl ProxyServer {
             .route("/gemini/v1beta/*path", any(handlers::handle_gemini))
             // Gemini 的 GA 版本也叫 /v1，给原 SDK 留一条出口
             .route("/gemini/v1/*path", any(handlers::handle_gemini))
+            // 对 API 路由添加密码认证中间件
+            .layer(middleware::from_fn_with_state(
+                self.state.clone(),
+                proxy_auth_middleware,
+            ));
+
+        // 公共路由（无需认证）+ 合并 API 路由
+        Router::new()
+            // 健康检查（无需认证）
+            .route("/health", get(handlers::health_check))
+            .route("/status", get(handlers::get_status))
+            .merge(api_routes)
             // 提高默认请求体大小限制（避免 413 Payload Too Large）
             .layer(DefaultBodyLimit::max(200 * 1024 * 1024))
             .with_state(self.state.clone())
@@ -378,4 +392,74 @@ impl ProxyServer {
             .reset_provider_breaker(provider_id, app_type)
             .await;
     }
+}
+
+/// 代理密码认证中间件
+///
+/// 如果配置了代理密码，所有 API 请求需要携带正确密码。
+/// 支持三种认证头：Authorization (Bearer scheme)、x-api-key、x-goog-api-key。
+/// `/health` 和 `/status` 端点不受此中间件影响（在 router 外单独注册）。
+async fn proxy_auth_middleware(
+    State(state): State<ProxyState>,
+    req: axum::http::Request<axum::body::Body>,
+    next: middleware::Next,
+) -> Result<impl IntoResponse, (StatusCode, Json<serde_json::Value>)> {
+    let config = state.config.read().await;
+    let password = config.proxy_password.as_deref().unwrap_or("");
+
+    if !password.is_empty() {
+        let mut authorized = false;
+
+        // 检查 Authorization 头（支持 Bearer 前缀）
+        if let Some(val) = req
+            .headers()
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+        {
+            let token = val.strip_prefix("Bearer ").unwrap_or(val);
+            if token == password {
+                authorized = true;
+            }
+        }
+
+        // 检查 x-api-key 头
+        if !authorized {
+            if let Some(val) = req
+                .headers()
+                .get("x-api-key")
+                .and_then(|v| v.to_str().ok())
+            {
+                if val == password {
+                    authorized = true;
+                }
+            }
+        }
+
+        // 检查 x-goog-api-key 头
+        if !authorized {
+            if let Some(val) = req
+                .headers()
+                .get("x-goog-api-key")
+                .and_then(|v| v.to_str().ok())
+            {
+                if val == password {
+                    authorized = true;
+                }
+            }
+        }
+
+        if !authorized {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(json!({
+                    "error": {
+                        "message": "代理需要密码认证，请提供正确的 Authorization、x-api-key 或 x-goog-api-key 请求头",
+                        "type": "auth_error",
+                    }
+                })),
+            ));
+        }
+    }
+
+    Ok(next.run(req).await)
 }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -419,10 +419,12 @@ async fn proxy_auth_middleware(
             .get("authorization")
             .and_then(|v| v.to_str().ok())
         {
-            let token = val
-                .strip_prefix("Bearer ")
-                .or_else(|| val.strip_prefix("bearer "))
-                .unwrap_or(val);
+            // Bearer scheme 大小写不敏感 (per RFC 6750)
+            let token = if val.len() > 7 && val[..7].eq_ignore_ascii_case("Bearer ") {
+                val[7..].trim_start()
+            } else {
+                val
+            };
             if token == password {
                 authorized = true;
             }

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -25,6 +25,9 @@ pub struct ProxyConfig {
     /// 非流式总超时（秒）- 非流式请求的总超时时间，范围 60-1200 秒，默认 600 秒（10 分钟）
     #[serde(default = "default_non_streaming_timeout")]
     pub non_streaming_timeout: u64,
+    /// 代理密码认证（空字符串或 None 表示不启用）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_password: Option<String>,
 }
 
 fn default_streaming_first_byte_timeout() -> u64 {
@@ -51,6 +54,7 @@ impl Default for ProxyConfig {
             streaming_first_byte_timeout: 60,
             streaming_idle_timeout: 120,
             non_streaming_timeout: 600,
+            proxy_password: None,
         }
     }
 }
@@ -162,6 +166,9 @@ pub struct GlobalProxyConfig {
     pub listen_port: u16,
     /// 是否启用日志
     pub enable_logging: bool,
+    /// 代理密码认证（空字符串或 None 表示不启用）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_password: Option<String>,
 }
 
 /// 应用级代理配置（每个 app 独立）

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2012,6 +2012,19 @@ impl ProxyService {
             .map_err(|e| format!("获取代理配置失败: {e}"))
     }
 
+    /// 同步全局配置到运行中的代理
+    ///
+    /// 从 DB 重读最新配置并应用到运行中的代理服务和已接管 Live 配置。
+    /// 由 `update_global_proxy_config` 命令在落库后调用，使密码等变更立即生效。
+    pub async fn sync_global_config(&self) -> Result<(), String> {
+        let config = self
+            .db
+            .get_proxy_config()
+            .await
+            .map_err(|e| format!("获取代理配置失败: {e}"))?;
+        self.update_config(&config).await
+    }
+
     /// 更新代理配置
     pub async fn update_config(&self, config: &ProxyConfig) -> Result<(), String> {
         // 记录旧配置用于判定是否需要重启
@@ -2057,38 +2070,36 @@ impl ProxyService {
 
             *server_guard = Some(new_server);
             log::info!("代理配置已更新，服务器已自动重启应用最新配置");
-
-            // 如果当前存在任意 app 的 Live 接管，需要同步更新 Live 中的代理地址（否则客户端仍指向旧端口）
-            drop(server_guard);
-            if let Ok(takeover) = self.get_takeover_status().await {
-                let auth_token = self.get_current_auth_token().await;
-                let mut updated_any = false;
-
-                if takeover.claude {
-                    self.takeover_live_config_best_effort(&AppType::Claude, &auth_token)
-                        .await?;
-                    updated_any = true;
-                }
-                if takeover.codex {
-                    self.takeover_live_config_best_effort(&AppType::Codex, &auth_token)
-                        .await?;
-                    updated_any = true;
-                }
-                if takeover.gemini {
-                    self.takeover_live_config_best_effort(&AppType::Gemini, &auth_token)
-                        .await?;
-                    updated_any = true;
-                }
-
-                if updated_any {
-                    log::info!("已同步更新 Live 配置中的代理地址");
-                }
-            }
-
-            return Ok(());
         } else if let Some(server) = server_guard.as_ref() {
             server.apply_runtime_config(&new_config).await;
             log::info!("代理配置已实时应用，无需重启代理服务器");
+        }
+
+        // 如果当前存在任意 app 的 Live 接管，同步更新 Live 配置（包括地址变更和密码变更）
+        drop(server_guard);
+        if let Ok(takeover) = self.get_takeover_status().await {
+            let auth_token = self.get_current_auth_token().await;
+            let mut updated_any = false;
+
+            if takeover.claude {
+                self.takeover_live_config_best_effort(&AppType::Claude, &auth_token)
+                    .await?;
+                updated_any = true;
+            }
+            if takeover.codex {
+                self.takeover_live_config_best_effort(&AppType::Codex, &auth_token)
+                    .await?;
+                updated_any = true;
+            }
+            if takeover.gemini {
+                self.takeover_live_config_best_effort(&AppType::Gemini, &auth_token)
+                    .await?;
+                updated_any = true;
+            }
+
+            if updated_any {
+                log::info!("已同步更新 Live 配置中的代理地址");
+            }
         }
 
         Ok(())

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -69,7 +69,24 @@ impl ProxyService {
         }
     }
 
-    fn apply_claude_takeover_fields(config: &mut Value, proxy_url: &str) {
+    /// 根据当前 DB 配置决定接管时写入的 auth token
+    ///
+    /// 密码已设置 → 返回密码；密码未设置 → 返回 PROXY_TOKEN_PLACEHOLDER
+    async fn get_current_auth_token(&self) -> String {
+        match self.db.get_proxy_config().await {
+            Ok(config) => {
+                let pwd = config.proxy_password.unwrap_or_default();
+                if pwd.is_empty() {
+                    PROXY_TOKEN_PLACEHOLDER.to_string()
+                } else {
+                    pwd
+                }
+            }
+            Err(_) => PROXY_TOKEN_PLACEHOLDER.to_string(),
+        }
+    }
+
+    fn apply_claude_takeover_fields(config: &mut Value, proxy_url: &str, auth_token: &str) {
         // 必须在 remove/insert 前 snapshot：避免读到自己刚写入的接管别名。
         let takeover_model_fields = Self::build_claude_takeover_model_fields(config);
 
@@ -108,16 +125,13 @@ impl ProxyService {
         let mut replaced_any = false;
         for key in token_keys {
             if env.contains_key(key) {
-                env.insert(key.to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+                env.insert(key.to_string(), json!(auth_token));
                 replaced_any = true;
             }
         }
 
         if !replaced_any {
-            env.insert(
-                "ANTHROPIC_AUTH_TOKEN".to_string(),
-                json!(PROXY_TOKEN_PLACEHOLDER),
-            );
+            env.insert("ANTHROPIC_AUTH_TOKEN".to_string(), json!(auth_token));
         }
     }
 
@@ -228,7 +242,11 @@ impl ProxyService {
         .map_err(|e| format!("构建 claude 有效配置失败: {e}"))?;
         let (proxy_url, _) = self.build_proxy_urls().await?;
 
-        Self::apply_claude_takeover_fields(&mut effective_settings, &proxy_url);
+        Self::apply_claude_takeover_fields(
+            &mut effective_settings,
+            &proxy_url,
+            PROXY_TOKEN_PLACEHOLDER,
+        );
         self.write_claude_live(&effective_settings)?;
         Ok(())
     }
@@ -313,8 +331,9 @@ impl ProxyService {
             return Err(format!("设置接管状态失败: {e}"));
         }
 
-        // 4. 接管各应用的 Live 配置（写入代理地址，清空 Token）
-        if let Err(e) = self.takeover_live_configs().await {
+        // 4. 接管各应用的 Live 配置（写入代理地址和 auth token）
+        let auth_token = self.get_current_auth_token().await;
+        if let Err(e) = self.takeover_live_configs(&auth_token).await {
             // 接管失败（可能是部分写入），尝试恢复原始配置；若恢复失败则保留标志与备份，等待下次启动自动恢复。
             log::error!("接管 Live 配置失败，尝试恢复原始配置: {e}");
             match self.restore_live_configs().await {
@@ -436,7 +455,8 @@ impl ProxyService {
             }
 
             // 5) 写入接管配置（仅当前 app）
-            if let Err(e) = self.takeover_live_config_strict(&app).await {
+            let auth_token = self.get_current_auth_token().await;
+            if let Err(e) = self.takeover_live_config_strict(&app, &auth_token).await {
                 log::error!("{app_type_str} 接管 Live 配置失败，尝试恢复: {e}");
                 match self.restore_live_config_for_app(&app).await {
                     Ok(()) => {
@@ -1002,24 +1022,22 @@ impl ProxyService {
     /// - `/v1beta/*` → Gemini
     ///
     /// 因此不需要在 URL 中添加应用前缀。
-    async fn takeover_live_configs(&self) -> Result<(), String> {
+    async fn takeover_live_configs(&self, auth_token: &str) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
 
-        // Claude: 修改 ANTHROPIC_BASE_URL，使用占位符替代真实 Token（代理会注入真实 Token）
+        // Claude: 修改 ANTHROPIC_BASE_URL，写入 auth_token
         if let Ok(mut live_config) = self.read_claude_live() {
-            Self::apply_claude_takeover_fields(&mut live_config, &proxy_url);
+            Self::apply_claude_takeover_fields(&mut live_config, &proxy_url, auth_token);
             self.write_claude_live(&live_config)?;
             log::info!("Claude Live 配置已接管，代理地址: {proxy_url}");
         }
 
-        // Codex: 修改 config.toml 的 base_url，auth.json 的 OPENAI_API_KEY（代理会注入真实 Token）
+        // Codex: 修改 config.toml 的 base_url，auth.json 的 OPENAI_API_KEY
         if let Ok(mut live_config) = self.read_codex_live() {
-            // 1. 修改 auth.json 中的 OPENAI_API_KEY（使用占位符）
             if let Some(auth) = live_config.get_mut("auth").and_then(|v| v.as_object_mut()) {
-                auth.insert("OPENAI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+                auth.insert("OPENAI_API_KEY".to_string(), json!(auth_token));
             }
 
-            // 2. 修改 config.toml 中的 base_url
             let config_str = live_config
                 .get("config")
                 .and_then(|v| v.as_str())
@@ -1031,16 +1049,15 @@ impl ProxyService {
             log::info!("Codex Live 配置已接管，代理地址: {proxy_codex_base_url}");
         }
 
-        // Gemini: 修改 GOOGLE_GEMINI_BASE_URL，使用占位符替代真实 Token（代理会注入真实 Token）
+        // Gemini: 修改 GOOGLE_GEMINI_BASE_URL
         if let Ok(mut live_config) = self.read_gemini_live() {
             if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
                 env.insert("GOOGLE_GEMINI_BASE_URL".to_string(), json!(&proxy_url));
-                // 使用占位符，避免显示缺少 key 的警告
-                env.insert("GEMINI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+                env.insert("GEMINI_API_KEY".to_string(), json!(auth_token));
             } else {
                 live_config["env"] = json!({
                     "GOOGLE_GEMINI_BASE_URL": &proxy_url,
-                    "GEMINI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+                    "GEMINI_API_KEY": auth_token
                 });
             }
             self.write_gemini_live(&live_config)?;
@@ -1051,13 +1068,13 @@ impl ProxyService {
     }
 
     /// 接管指定应用的 Live 配置（严格模式：目标配置不存在则返回错误）
-    async fn takeover_live_config_strict(&self, app_type: &AppType) -> Result<(), String> {
+    async fn takeover_live_config_strict(&self, app_type: &AppType, auth_token: &str) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
 
         match app_type {
             AppType::Claude => {
                 let mut live_config = self.read_claude_live()?;
-                Self::apply_claude_takeover_fields(&mut live_config, &proxy_url);
+                Self::apply_claude_takeover_fields(&mut live_config, &proxy_url, auth_token);
                 self.write_claude_live(&live_config)?;
                 log::info!("Claude Live 配置已接管，代理地址: {proxy_url}");
             }
@@ -1065,7 +1082,7 @@ impl ProxyService {
                 let mut live_config = self.read_codex_live()?;
 
                 if let Some(auth) = live_config.get_mut("auth").and_then(|v| v.as_object_mut()) {
-                    auth.insert("OPENAI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+                    auth.insert("OPENAI_API_KEY".to_string(), json!(auth_token));
                 }
 
                 let config_str = live_config
@@ -1083,11 +1100,11 @@ impl ProxyService {
 
                 if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
                     env.insert("GOOGLE_GEMINI_BASE_URL".to_string(), json!(&proxy_url));
-                    env.insert("GEMINI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+                    env.insert("GEMINI_API_KEY".to_string(), json!(auth_token));
                 } else {
                     live_config["env"] = json!({
                         "GOOGLE_GEMINI_BASE_URL": &proxy_url,
-                        "GEMINI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+                        "GEMINI_API_KEY": auth_token
                     });
                 }
 
@@ -1101,13 +1118,13 @@ impl ProxyService {
     }
 
     /// 接管指定应用的 Live 配置（尽力而为：配置不存在/读取失败则跳过）
-    async fn takeover_live_config_best_effort(&self, app_type: &AppType) -> Result<(), String> {
+    async fn takeover_live_config_best_effort(&self, app_type: &AppType, auth_token: &str) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
 
         match app_type {
             AppType::Claude => {
                 if let Ok(mut live_config) = self.read_claude_live() {
-                    Self::apply_claude_takeover_fields(&mut live_config, &proxy_url);
+                    Self::apply_claude_takeover_fields(&mut live_config, &proxy_url, auth_token);
                     let _ = self.write_claude_live(&live_config);
                 }
             }
@@ -1115,7 +1132,7 @@ impl ProxyService {
                 if let Ok(mut live_config) = self.read_codex_live() {
                     if let Some(auth) = live_config.get_mut("auth").and_then(|v| v.as_object_mut())
                     {
-                        auth.insert("OPENAI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+                        auth.insert("OPENAI_API_KEY".to_string(), json!(auth_token));
                     }
 
                     let config_str = live_config
@@ -1133,11 +1150,11 @@ impl ProxyService {
                 if let Ok(mut live_config) = self.read_gemini_live() {
                     if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
                         env.insert("GOOGLE_GEMINI_BASE_URL".to_string(), json!(&proxy_url));
-                        env.insert("GEMINI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+                        env.insert("GEMINI_API_KEY".to_string(), json!(auth_token));
                     } else {
                         live_config["env"] = json!({
                             "GOOGLE_GEMINI_BASE_URL": &proxy_url,
-                            "GEMINI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+                            "GEMINI_API_KEY": auth_token
                         });
                     }
 
@@ -1940,20 +1957,21 @@ impl ProxyService {
             // 如果当前存在任意 app 的 Live 接管，需要同步更新 Live 中的代理地址（否则客户端仍指向旧端口）
             drop(server_guard);
             if let Ok(takeover) = self.get_takeover_status().await {
+                let auth_token = self.get_current_auth_token().await;
                 let mut updated_any = false;
 
                 if takeover.claude {
-                    self.takeover_live_config_best_effort(&AppType::Claude)
+                    self.takeover_live_config_best_effort(&AppType::Claude, &auth_token)
                         .await?;
                     updated_any = true;
                 }
                 if takeover.codex {
-                    self.takeover_live_config_best_effort(&AppType::Codex)
+                    self.takeover_live_config_best_effort(&AppType::Codex, &auth_token)
                         .await?;
                     updated_any = true;
                 }
                 if takeover.gemini {
-                    self.takeover_live_config_best_effort(&AppType::Gemini)
+                    self.takeover_live_config_best_effort(&AppType::Gemini, &auth_token)
                         .await?;
                     updated_any = true;
                 }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -594,6 +594,8 @@ impl ProxyService {
         app_type: &AppType,
         live_config: &Value,
     ) -> Result<(), String> {
+        // 获取实际代理 URL，精确判断 Live 配置中的 base_url 是否指向本代理
+        let proxy_urls = self.build_proxy_urls().await.ok();
         match app_type {
             AppType::Claude => {
                 let provider_id =
@@ -605,11 +607,12 @@ impl ProxyService {
                         self.db.get_provider_by_id(&provider_id, "claude")
                     {
                         if let Some(env) = live_config.get("env").and_then(|v| v.as_object()) {
-                            // 如果 base_url 指向本地代理，token 是代理认证凭据，不同步回 provider
-                            let base_url_is_local = env
-                                .get("ANTHROPIC_BASE_URL")
-                                .and_then(|v| v.as_str())
-                                .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost"));
+                            // 检查 base_url 是否精确指向本代理的 URL
+                            let base_url_is_local = proxy_urls.as_ref().is_some_and(|(proxy_url, _)| {
+                                env.get("ANTHROPIC_BASE_URL")
+                                    .and_then(|v| v.as_str())
+                                    .is_some_and(|u| u == proxy_url || u.starts_with(&format!("{proxy_url}/")))
+                            });
 
                             let token_pair = [
                                 "ANTHROPIC_AUTH_TOKEN",
@@ -705,11 +708,13 @@ impl ProxyService {
                     if let Ok(Some(mut provider)) =
                         self.db.get_provider_by_id(&provider_id, "codex")
                     {
-                        // 如果 config 指向本地代理，token 是代理认证凭据，不同步回 provider
-                        let codex_is_local = live_config
-                            .get("config")
-                            .and_then(|v| v.as_str())
-                            .is_some_and(|c| c.contains("127.0.0.1") || c.contains("localhost") || c.contains("[::1]"));
+                        // 检查 config TOML 是否包含本代理的 Codex base URL
+                        let codex_is_local = proxy_urls.as_ref().is_some_and(|(_, codex_url)| {
+                            live_config
+                                .get("config")
+                                .and_then(|v| v.as_str())
+                                .is_some_and(|c| c.contains(codex_url.as_str()))
+                        });
 
                         if let Some(token) = live_config
                             .get("auth")
@@ -763,12 +768,14 @@ impl ProxyService {
                     if let Ok(Some(mut provider)) =
                         self.db.get_provider_by_id(&provider_id, "gemini")
                     {
-                        // 如果 base_url 指向本地代理，token 是代理认证凭据，不同步回 provider
-                        let gemini_is_local = live_config
-                            .get("env")
-                            .and_then(|v| v.get("GOOGLE_GEMINI_BASE_URL"))
-                            .and_then(|v| v.as_str())
-                            .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost"));
+                        // 检查 base_url 是否精确指向本代理
+                        let gemini_is_local = proxy_urls.as_ref().is_some_and(|(proxy_url, _)| {
+                            live_config
+                                .get("env")
+                                .and_then(|v| v.get("GOOGLE_GEMINI_BASE_URL"))
+                                .and_then(|v| v.as_str())
+                                .is_some_and(|u| u == proxy_url || u.starts_with(&format!("{proxy_url}/")))
+                        });
 
                         if let Some(token) = live_config
                             .get("env")

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -595,7 +595,14 @@ impl ProxyService {
         live_config: &Value,
     ) -> Result<(), String> {
         // 获取实际代理 URL，精确判断 Live 配置中的 base_url 是否指向本代理
-        let proxy_urls = self.build_proxy_urls().await.ok();
+        // fail-closed: 无法确认时拒绝同步，避免误写 provider 凭据
+        let proxy_urls = match self.build_proxy_urls().await {
+            Ok(urls) => Some(urls),
+            Err(e) => {
+                log::warn!("无法获取代理 URL，跳过 Live->Provider 同步: {e}");
+                return Ok(());
+            }
+        };
         match app_type {
             AppType::Claude => {
                 let provider_id =
@@ -1400,23 +1407,30 @@ impl ProxyService {
             return Ok(());
         };
 
+        let base_url_is_local = env
+            .get("ANTHROPIC_BASE_URL")
+            .and_then(|v| v.as_str())
+            .map(Self::is_local_proxy_url)
+            .unwrap_or(false);
+
         for key in [
             "ANTHROPIC_AUTH_TOKEN",
             "ANTHROPIC_API_KEY",
             "OPENROUTER_API_KEY",
             "OPENAI_API_KEY",
         ] {
-            if env.get(key).and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER) {
+            let should_remove = match env.get(key).and_then(|v| v.as_str()) {
+                Some(PROXY_TOKEN_PLACEHOLDER) => true,
+                // 密码模式：base_url 指向本地代理且 token 非空，也是接管残留
+                Some(t) if base_url_is_local && !t.is_empty() => true,
+                _ => false,
+            };
+            if should_remove {
                 env.remove(key);
             }
         }
 
-        if env
-            .get("ANTHROPIC_BASE_URL")
-            .and_then(|v| v.as_str())
-            .map(Self::is_local_proxy_url)
-            .unwrap_or(false)
-        {
+        if base_url_is_local {
             env.remove("ANTHROPIC_BASE_URL");
         }
 
@@ -1427,16 +1441,30 @@ impl ProxyService {
     fn cleanup_codex_takeover_placeholders_in_live(&self) -> Result<(), String> {
         let mut config = self.read_codex_live()?;
 
+        let config_is_local = config
+            .get("config")
+            .and_then(|v| v.as_str())
+            .map_or(false, |c| {
+                c.contains("127.0.0.1") || c.contains("localhost") || c.contains("[::1]")
+            });
+
         if let Some(auth) = config.get_mut("auth").and_then(|v| v.as_object_mut()) {
-            if auth.get("OPENAI_API_KEY").and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER)
-            {
+            let token = auth.get("OPENAI_API_KEY").and_then(|v| v.as_str());
+            let should_remove = match token {
+                Some(PROXY_TOKEN_PLACEHOLDER) => true,
+                Some(t) if config_is_local && !t.is_empty() => true,
+                _ => false,
+            };
+            if should_remove {
                 auth.remove("OPENAI_API_KEY");
             }
         }
 
-        if let Some(cfg_str) = config.get("config").and_then(|v| v.as_str()) {
-            let updated = Self::remove_local_toml_base_url(cfg_str);
-            config["config"] = json!(updated);
+        if config_is_local {
+            if let Some(cfg_str) = config.get("config").and_then(|v| v.as_str()) {
+                let updated = Self::remove_local_toml_base_url(cfg_str);
+                config["config"] = json!(updated);
+            }
         }
 
         self.write_codex_live(&config)?;
@@ -1455,16 +1483,23 @@ impl ProxyService {
             return Ok(());
         };
 
-        if env.get("GEMINI_API_KEY").and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER) {
-            env.remove("GEMINI_API_KEY");
-        }
-
-        if env
+        let base_url_is_local = env
             .get("GOOGLE_GEMINI_BASE_URL")
             .and_then(|v| v.as_str())
             .map(Self::is_local_proxy_url)
-            .unwrap_or(false)
-        {
+            .unwrap_or(false);
+
+        let token = env.get("GEMINI_API_KEY").and_then(|v| v.as_str());
+        let should_remove_gemini_key = match token {
+            Some(PROXY_TOKEN_PLACEHOLDER) => true,
+            Some(t) if base_url_is_local && !t.is_empty() => true,
+            _ => false,
+        };
+        if should_remove_gemini_key {
+            env.remove("GEMINI_API_KEY");
+        }
+
+        if base_url_is_local {
             env.remove("GOOGLE_GEMINI_BASE_URL");
         }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -242,10 +242,12 @@ impl ProxyService {
         .map_err(|e| format!("构建 claude 有效配置失败: {e}"))?;
         let (proxy_url, _) = self.build_proxy_urls().await?;
 
+        let auth_token = self.get_current_auth_token().await;
+
         Self::apply_claude_takeover_fields(
             &mut effective_settings,
             &proxy_url,
-            PROXY_TOKEN_PLACEHOLDER,
+            &auth_token,
         );
         self.write_claude_live(&effective_settings)?;
         Ok(())

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -605,6 +605,12 @@ impl ProxyService {
                         self.db.get_provider_by_id(&provider_id, "claude")
                     {
                         if let Some(env) = live_config.get("env").and_then(|v| v.as_object()) {
+                            // 如果 base_url 指向本地代理，token 是代理认证凭据，不同步回 provider
+                            let base_url_is_local = env
+                                .get("ANTHROPIC_BASE_URL")
+                                .and_then(|v| v.as_str())
+                                .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost"));
+
                             let token_pair = [
                                 "ANTHROPIC_AUTH_TOKEN",
                                 "ANTHROPIC_API_KEY",
@@ -618,7 +624,7 @@ impl ProxyService {
                                     .map(|s| (key, s.trim()))
                             })
                             .filter(|(_, token)| {
-                                !token.is_empty() && *token != PROXY_TOKEN_PLACEHOLDER
+                                !token.is_empty() && *token != PROXY_TOKEN_PLACEHOLDER && !base_url_is_local
                             });
 
                             if let Some((token_key, token)) = token_pair {
@@ -699,12 +705,18 @@ impl ProxyService {
                     if let Ok(Some(mut provider)) =
                         self.db.get_provider_by_id(&provider_id, "codex")
                     {
+                        // 如果 config 指向本地代理，token 是代理认证凭据，不同步回 provider
+                        let codex_is_local = live_config
+                            .get("config")
+                            .and_then(|v| v.as_str())
+                            .is_some_and(|c| c.contains("127.0.0.1"));
+
                         if let Some(token) = live_config
                             .get("auth")
                             .and_then(|v| v.get("OPENAI_API_KEY"))
                             .and_then(|v| v.as_str())
                             .map(|s| s.trim())
-                            .filter(|s| !s.is_empty() && *s != PROXY_TOKEN_PLACEHOLDER)
+                            .filter(|s| !s.is_empty() && *s != PROXY_TOKEN_PLACEHOLDER && !codex_is_local)
                         {
                             if let Some(auth_obj) = provider
                                 .settings_config
@@ -751,12 +763,19 @@ impl ProxyService {
                     if let Ok(Some(mut provider)) =
                         self.db.get_provider_by_id(&provider_id, "gemini")
                     {
+                        // 如果 base_url 指向本地代理，token 是代理认证凭据，不同步回 provider
+                        let gemini_is_local = live_config
+                            .get("env")
+                            .and_then(|v| v.get("GOOGLE_GEMINI_BASE_URL"))
+                            .and_then(|v| v.as_str())
+                            .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost"));
+
                         if let Some(token) = live_config
                             .get("env")
                             .and_then(|v| v.get("GEMINI_API_KEY"))
                             .and_then(|v| v.as_str())
                             .map(|s| s.trim())
-                            .filter(|s| !s.is_empty() && *s != PROXY_TOKEN_PLACEHOLDER)
+                            .filter(|s| !s.is_empty() && *s != PROXY_TOKEN_PLACEHOLDER && !gemini_is_local)
                         {
                             if let Some(env_obj) = provider
                                 .settings_config
@@ -1508,13 +1527,24 @@ impl ProxyService {
             None => return false,
         };
 
+        // 检查 base_url 是否指向本地代理
+        let base_url_is_local = env
+            .get("ANTHROPIC_BASE_URL")
+            .and_then(|v| v.as_str())
+            .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost"));
+
         for key in [
             "ANTHROPIC_AUTH_TOKEN",
             "ANTHROPIC_API_KEY",
             "OPENROUTER_API_KEY",
             "OPENAI_API_KEY",
         ] {
-            if env.get(key).and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER) {
+            let token = env.get(key).and_then(|v| v.as_str());
+            if token == Some(PROXY_TOKEN_PLACEHOLDER) {
+                return true;
+            }
+            // 非空 token + 本地代理 base_url 也视为已接管（密码认证模式）
+            if base_url_is_local && token.is_some_and(|t| !t.is_empty()) {
                 return true;
             }
         }
@@ -1527,7 +1557,23 @@ impl ProxyService {
             Some(auth) => auth,
             None => return false,
         };
-        auth.get("OPENAI_API_KEY").and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER)
+
+        // OPENAI_API_KEY 为占位符 → 已接管
+        if auth.get("OPENAI_API_KEY").and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER) {
+            return true;
+        }
+
+        // 检查 base_url 是否指向本地代理 + 非空 token 存在（密码认证模式）
+        let base_url_is_local = config
+            .get("config")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .contains("127.0.0.1");
+        base_url_is_local
+            && auth
+                .get("OPENAI_API_KEY")
+                .and_then(|v| v.as_str())
+                .is_some_and(|t| !t.is_empty())
     }
 
     fn is_gemini_live_taken_over(config: &Value) -> bool {
@@ -1535,7 +1581,22 @@ impl ProxyService {
             Some(env) => env,
             None => return false,
         };
-        env.get("GEMINI_API_KEY").and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER)
+
+        // GEMINI_API_KEY 为占位符 → 已接管
+        if env.get("GEMINI_API_KEY").and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER) {
+            return true;
+        }
+
+        // 检查 base_url 是否指向本地代理 + 非空 token 存在（密码认证模式）
+        let base_url_is_local = env
+            .get("GOOGLE_GEMINI_BASE_URL")
+            .and_then(|v| v.as_str())
+            .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost"));
+        base_url_is_local
+            && env
+                .get("GEMINI_API_KEY")
+                .and_then(|v| v.as_str())
+                .is_some_and(|t| !t.is_empty())
     }
 
     /// 从供应商配置更新 Live 备份（用于代理模式下的热切换）

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1538,7 +1538,7 @@ impl ProxyService {
         let base_url_is_local = env
             .get("ANTHROPIC_BASE_URL")
             .and_then(|v| v.as_str())
-            .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost"));
+            .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost") || u.contains("[::1]"));
 
         for key in [
             "ANTHROPIC_AUTH_TOKEN",
@@ -1597,7 +1597,7 @@ impl ProxyService {
         let base_url_is_local = env
             .get("GOOGLE_GEMINI_BASE_URL")
             .and_then(|v| v.as_str())
-            .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost"));
+            .is_some_and(|u| u.contains("127.0.0.1") || u.contains("localhost") || u.contains("[::1]"));
         base_url_is_local
             && env
                 .get("GEMINI_API_KEY")

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -709,7 +709,7 @@ impl ProxyService {
                         let codex_is_local = live_config
                             .get("config")
                             .and_then(|v| v.as_str())
-                            .is_some_and(|c| c.contains("127.0.0.1"));
+                            .is_some_and(|c| c.contains("127.0.0.1") || c.contains("localhost") || c.contains("[::1]"));
 
                         if let Some(token) = live_config
                             .get("auth")
@@ -1567,8 +1567,7 @@ impl ProxyService {
         let base_url_is_local = config
             .get("config")
             .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .contains("127.0.0.1");
+            .is_some_and(|c| c.contains("127.0.0.1") || c.contains("localhost") || c.contains("[::1]"));
         base_url_is_local
             && auth
                 .get("OPENAI_API_KEY")

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -185,7 +185,7 @@ export function ProxyPanel({
         ...globalConfig,
         listenAddress: addressTrimmed,
         listenPort: port,
-        proxyPassword: proxyPassword || undefined,
+        proxyPassword: proxyPassword?.trim() || undefined,
       });
       toast.success(
         t("proxy.settings.configSaved", { defaultValue: "代理配置已保存" }),

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -623,7 +623,7 @@ export function ProxyPanel({
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                    tabIndex={-1}
+                    aria-label={showPassword ? "隐藏密码" : "显示密码"}
                   >
                     {showPassword ? (
                       <EyeOff className="h-4 w-4" />
@@ -635,7 +635,7 @@ export function ProxyPanel({
                 <p className="text-xs text-muted-foreground">
                   {t("proxy.settings.fields.password.description", {
                     defaultValue:
-                      "设置后局域网设备需在请求头中提供密码才能使用代理。CCI Switch 接管模式下会自动配置。",
+                      "设置后局域网设备需在请求头中提供密码才能使用代理。CC Switch 接管模式下会自动配置。",
                   })}
                 </p>
               </div>

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -9,6 +9,9 @@ import {
   Loader2,
   Zap,
   Power,
+  Lock,
+  Eye,
+  EyeOff,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -57,12 +60,16 @@ export function ProxyPanel({
   // 监听地址/端口的本地状态（端口用字符串以支持完全清空）
   const [listenAddress, setListenAddress] = useState("127.0.0.1");
   const [listenPort, setListenPort] = useState("15721");
+  // 代理密码本地状态
+  const [proxyPassword, setProxyPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
 
   // 同步全局配置到本地状态
   useEffect(() => {
     if (globalConfig) {
       setListenAddress(globalConfig.listenAddress);
       setListenPort(String(globalConfig.listenPort));
+      setProxyPassword(globalConfig.proxyPassword ?? "");
     }
   }, [globalConfig]);
 
@@ -178,6 +185,7 @@ export function ProxyPanel({
         ...globalConfig,
         listenAddress: addressTrimmed,
         listenPort: port,
+        proxyPassword: proxyPassword || undefined,
       });
       toast.success(
         t("proxy.settings.configSaved", { defaultValue: "代理配置已保存" }),
@@ -405,6 +413,38 @@ export function ProxyPanel({
                 </div>
               </div>
 
+              {/* Password auth status indicator */}
+              <div className="pt-3 border-t border-border">
+                <div className="flex items-center justify-between rounded-md border border-border bg-background/60 px-3 py-2">
+                  <div className="flex items-center gap-2">
+                    <Lock className="h-4 w-4 text-muted-foreground" />
+                    <div className="space-y-0.5">
+                      <Label className="text-sm font-medium">
+                        {t("proxy.settings.fields.password.status", {
+                          defaultValue: "密码认证",
+                        })}
+                      </Label>
+                      <p className="text-xs text-muted-foreground">
+                        {globalConfig?.proxyPassword
+                          ? t("proxy.settings.fields.password.enabled", {
+                              defaultValue: "已启用，客户端需在 Authorization、x-api-key 或 x-goog-api-key 头中提供密码",
+                            })
+                          : t("proxy.settings.fields.password.disabled", {
+                              defaultValue: "未启用，局域网设备可直接访问",
+                            })}
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className={`h-2 w-2 rounded-full ${
+                      globalConfig?.proxyPassword
+                        ? "bg-green-500"
+                        : "bg-muted-foreground/40"
+                    }`}
+                  />
+                </div>
+              </div>
+
               {/* [6] Provider queues */}
               {(claudeQueue.length > 0 ||
                 codexQueue.length > 0 ||
@@ -556,6 +596,48 @@ export function ProxyPanel({
                     })}
                   </p>
                 </div>
+              </div>
+
+              {/* 密码认证 */}
+              <div className="space-y-2">
+                <Label htmlFor="proxy-password">
+                  {t("proxy.settings.fields.password.label", {
+                    defaultValue: "代理密码（可选）",
+                  })}
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="proxy-password"
+                    type={showPassword ? "text" : "password"}
+                    value={proxyPassword}
+                    onChange={(e) => setProxyPassword(e.target.value)}
+                    placeholder={t(
+                      "proxy.settings.fields.password.placeholder",
+                      {
+                        defaultValue: "留空则不启用密码认证",
+                      },
+                    )}
+                    className="pr-10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    tabIndex={-1}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t("proxy.settings.fields.password.description", {
+                    defaultValue:
+                      "设置后局域网设备需在请求头中提供密码才能使用代理。CCI Switch 接管模式下会自动配置。",
+                  })}
+                </p>
               </div>
 
               <div className="flex justify-end">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2177,6 +2177,14 @@
           "label": "Enable Logging",
           "description": "Log all routing requests for troubleshooting"
         },
+        "password": {
+          "label": "Proxy Password (optional)",
+          "placeholder": "Leave empty to disable password authentication",
+          "description": "When set, LAN devices must provide this password in the request header. CC Switch configures it automatically in takeover mode.",
+          "status": "Password Authentication",
+          "enabled": "Enabled — clients must provide password in Authorization, x-api-key or x-goog-api-key header",
+          "disabled": "Disabled — LAN devices can access directly"
+        },
         "streamingFirstByteTimeout": {
           "label": "Streaming First Byte Timeout (sec)",
           "description": "Maximum time to wait for the first data chunk"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2177,6 +2177,14 @@
           "label": "ログ記録を有効化",
           "description": "トラブルシューティングのためにすべてのルーティングリクエストを記録"
         },
+        "password": {
+          "label": "プロキシパスワード（任意）",
+          "placeholder": "空白の場合はパスワード認証を無効",
+          "description": "設定すると、LANデバイスはリクエストヘッダーにパスワードを提供する必要があります。CC Switchはテイクオーバーモードで自動的に設定します。",
+          "status": "パスワード認証",
+          "enabled": "有効 — クライアントはAuthorization、x-api-keyまたはx-goog-api-keyヘッダーでパスワードを提供する必要があります",
+          "disabled": "無効 — LANデバイスは直接アクセス可能"
+        },
         "streamingFirstByteTimeout": {
           "label": "ストリーミング初回バイトタイムアウト（秒）",
           "description": "最初のデータチャンクを待つ最大時間"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2177,6 +2177,14 @@
           "label": "启用日志记录",
           "description": "记录所有路由请求，便于排查问题"
         },
+        "password": {
+          "label": "代理密码（可选）",
+          "placeholder": "留空则不启用密码认证",
+          "description": "设置后局域网设备需在请求头中提供密码才能使用代理。CC Switch 接管模式下会自动配置。",
+          "status": "密码认证",
+          "enabled": "已启用，客户端需在 Authorization、x-api-key 或 x-goog-api-key 头中提供密码",
+          "disabled": "未启用，局域网设备可直接访问"
+        },
         "streamingFirstByteTimeout": {
           "label": "流式首字超时（秒）",
           "description": "等待首个数据块的最大时间"

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -9,6 +9,7 @@ export interface ProxyConfig {
   streaming_first_byte_timeout: number;
   streaming_idle_timeout: number;
   non_streaming_timeout: number;
+  proxy_password?: string;
 }
 
 export interface ProxyStatus {
@@ -121,6 +122,7 @@ export interface GlobalProxyConfig {
   listenAddress: string;
   listenPort: number;
   enableLogging: boolean;
+  proxyPassword?: string;
 }
 
 // 应用级代理配置（每个 app 独立）


### PR DESCRIPTION
## Summary / 概述

为 CC Switch 代理服务器添加密码认证功能。当代理监听 `0.0.0.0` 允许局域网设备访问时，可通过密码防止未授权使用。

- 认证支持三种标准 HTTP 头：`Authorization: Bearer`、`x-api-key`、`x-goog-api-key`，与 CLI 工具原生认证机制兼容
- 密码通过现有 `settings` 表持久化，不修改数据库 schema version，兼容现有 CC Switch 安装
- 接管模式下 Live 配置自动写入实际密码（或 `PROXY_MANAGED` 占位符），客户端无需额外配置
- 切换供应商时 Live 配置中的密码保持不丢失
- `/health` 和 `/status` 端点不受密码认证影响

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图
- 开启效果

<img width="2467" height="840" alt="0fafb7417f8983d79789d07de945a7a0" src="https://github.com/user-attachments/assets/390810fa-bd75-43f3-84c5-7e3492885fce" />

- 配置方法
<img width="2484" height="807" alt="38cf01f6dbebce34b2b26735010b8a02" src="https://github.com/user-attachments/assets/62e817dd-4f57-4bd3-9111-b118b24f4b17" />



## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）— 改动文件零警告，26 个 error 均为上游已有 `settings.rs` / `commands/misc.rs` 的 dead code，非本次引入
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — en/zh/ja 三语言已补充 `proxy.settings.fields.password.*`