### PR TITLE
feat: add GET /v1/models endpoint for Claude Code compatibility

### DIFF
--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -105,6 +105,50 @@ pub async fn handle_claude_desktop_models(
     Ok(Json(response))
 }
 
+/// GET /v1/models — 返回当前 Claude provider 的模型列表
+///
+/// Claude Code 启动时会请求 `GET /v1/models` 和 `GET /v1/models?limit=1`
+/// 来验证连接和获取可用模型。此端点复用 `model_list_response` 构造响应，
+/// 如果 provider 没有配置 `claude_desktop_model_routes`，则从 `settings_config`
+/// 中提取 `ANTHROPIC_MODEL` 构造一个基本的单模型列表。
+pub async fn handle_models(
+    State(state): State<ProxyState>,
+) -> Result<Json<Value>, ProxyError> {
+    let providers = state
+        .provider_router
+        .select_providers("claude")
+        .await
+        .map_err(|e| ProxyError::DatabaseError(e.to_string()))?;
+    let provider = providers.first().ok_or(ProxyError::NoAvailableProvider)?;
+
+    // 优先使用 claude_desktop_model_routes 构造完整列表
+    if let Ok(response) = crate::claude_desktop_config::model_list_response(provider) {
+        return Ok(Json(response));
+    }
+
+    // 兜底：从 settings_config.env 中提取 ANTHROPIC_MODEL 构造基本列表
+    let model_id = provider
+        .settings_config
+        .get("env")
+        .and_then(|env| env.get("ANTHROPIC_MODEL"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("claude-sonnet-4-20250514");
+
+    Ok(Json(json!({
+        "data": [
+            {
+                "type": "model",
+                "id": model_id,
+                "display_name": model_id,
+                "created_at": "2025-05-14T00:00:00Z",
+            }
+        ],
+        "has_more": false,
+        "first_id": model_id,
+        "last_id": model_id,
+    })))
+}
+
 async fn handle_messages_for_app(
     state: ProxyState,
     request: axum::extract::Request,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -285,6 +285,9 @@ impl ProxyServer {
             // Claude API (支持带前缀和不带前缀两种格式)
             .route("/v1/messages", post(handlers::handle_messages))
             .route("/claude/v1/messages", post(handlers::handle_messages))
+            // Claude Code /v1/models — 供 Claude Code 连接验证和模型列表查询
+            .route("/v1/models", get(handlers::handle_models))
+            .route("/claude/v1/models", get(handlers::handle_models))
             // Claude Desktop 3P 本地 gateway（独立 provider namespace）
             .route(
                 "/claude-desktop/v1/models",


### PR DESCRIPTION
## Summary

Claude Code sends `GET /v1/models` and `GET /v1/models?limit=1` during startup to validate the connection and query available models. The local proxy did not register this route, causing HTTP 404 errors that prevent Claude Code from connecting through CC Switch.

Closes #2526

## Changes

- **`src-tauri/src/proxy/handlers.rs`**: Add `handle_models` handler
  - If the provider has `claude_desktop_model_routes` configured, reuse `model_list_response` to build a full model list
  - Otherwise, fallback to building a basic list from `ANTHROPIC_MODEL` env setting in the provider config
- **`src-tauri/src/proxy/server.rs`**: Register two new routes:
  - `GET /v1/models`
  - `GET /claude/v1/models`

## Behavior

| Scenario | Response |
|---|---|
| Provider has `claude_desktop_model_routes` | Full model list (same as Claude Desktop) |
| Provider only has `ANTHROPIC_MODEL` env | Single-model list based on configured model name |
| No model config at all | Single-model list with `claude-sonnet-4-20250514` as default |

## Notes

This is a minimal, non-breaking change. The new handler follows the same pattern as `handle_claude_desktop_models` but without the gateway auth requirement, since Claude Code uses the standard `claude` app type. Axum automatically matches query strings (e.g. `?limit=1`) against registered routes, so no additional handling is needed for `GET /v1/models?limit=1`.