### PR TITLE
fix(openai-streaming): 解决 openai chat 类型后端没有token usage 的问题

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -44,6 +44,44 @@ pub struct Provider {
 
 impl Provider {
     /// 从现有ID创建供应商
+    /// 读取 stream_include_usage 设置。
+    /// 如果 provider 自身未设置，则根据 API 格式自动判断默认值：
+    /// - openai_chat 兼容模式默认 true
+    /// - anthropic 原生模式默认 false
+    pub fn stream_include_usage(&self) -> bool {
+        let explicit = self
+            .settings_config
+            .get("stream_include_usage")
+            .and_then(|v| v.as_bool());
+
+        if let Some(value) = explicit {
+            return value;
+        }
+
+        // 自动根据 API 格式推断默认值
+        let api_format = self
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.api_format.as_deref())
+            .or_else(|| {
+                self.settings_config
+                    .get("api_format")
+                    .and_then(|v| v.as_str())
+            });
+
+        match api_format {
+            Some("openai_chat") => true,
+            _ => {
+                // 未显式设置 api_format 时，根据常见字段推断是否为 OpenAI 兼容供应商
+                let has_openai_fields = self.settings_config.get("baseUrl").is_some()
+                    || self.settings_config.get("base_url").is_some()
+                    || self.settings_config.get("apiKey").is_some()
+                    || self.settings_config.get("api_key").is_some();
+                has_openai_fields
+            }
+        }
+    }
+
     pub fn with_id(
         id: String,
         name: String,

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -90,6 +90,12 @@ impl ProviderRouter {
             if let Some(current_id) = current_id {
                 if let Some(current) = self.db.get_provider_by_id(&current_id, app_type)? {
                     total_providers = 1;
+                    log::info!(
+                        "[ProviderRouter] [{}] selected provider: {} (stream_include_usage={})",
+                        app_type,
+                        current.name,
+                        current.stream_include_usage()
+                    );
                     result.push(current);
                 }
             }

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -177,6 +177,15 @@ pub fn transform_claude_request_for_api_format(
             .or(explicit_cache_key)
             .unwrap_or(&provider.id)
     };
+
+    let stream_include_usage = provider.stream_include_usage();
+    if stream_include_usage {
+        log::info!(
+            "[ClaudeAdapter] Provider '{}' stream_include_usage enabled",
+            provider.name
+        );
+    }
+
     match api_format {
         "openai_responses" => {
             // Codex OAuth (ChatGPT Plus/Pro 反代) 需要在请求体里强制 store: false
@@ -195,6 +204,7 @@ pub fn transform_claude_request_for_api_format(
             let mut result = super::transform::anthropic_to_openai_with_reasoning_content(
                 body,
                 preserve_reasoning_content,
+                stream_include_usage,
             )?;
             // Inject prompt_cache_key only if explicitly configured in meta
             if let Some(key) = provider

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -172,6 +172,15 @@ pub fn transform_claude_request_for_api_format(
     } else {
         (None, "none")
     };
+
+    let stream_include_usage = provider.stream_include_usage();
+    if stream_include_usage {
+        log::info!(
+            "[ClaudeAdapter] Provider '{}' stream_include_usage enabled",
+            provider.name
+        );
+    }
+
     match api_format {
         "openai_responses" => {
             log::debug!(
@@ -195,6 +204,7 @@ pub fn transform_claude_request_for_api_format(
             let mut result = super::transform::anthropic_to_openai_with_reasoning_content(
                 body,
                 preserve_reasoning_content,
+                stream_include_usage,
             )?;
             // Inject prompt_cache_key only if explicitly configured in meta
             if let Some(key) = provider

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -17,6 +17,7 @@ struct OpenAIStreamChunk {
     #[serde(default)]
     model: String,
     #[serde(default)]
+    object: Option<String>,
     choices: Vec<StreamChoice>,
     #[serde(default)]
     usage: Option<Usage>,
@@ -160,7 +161,6 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         let mut current_non_tool_block_index: Option<u32> = None;
         let mut tool_blocks_by_index: HashMap<usize, ToolBlockState> = HashMap::new();
         let mut open_tool_block_indices: HashSet<u32> = HashSet::new();
-
         tokio::pin!(stream);
 
         while let Some(chunk) = stream.next().await {
@@ -177,7 +177,6 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                             if let Some(data) = strip_sse_field(l, "data") {
                                 if data.trim() == "[DONE]" {
                                     log::debug!("[Claude/OpenRouter] <<< OpenAI SSE: [DONE]");
-
                                     // 流正常结束，发出缓存的 message_delta（含完整 usage）。
                                     if let Some((stop_reason, usage_json)) = pending_message_delta.take() {
                                         let event = build_message_delta_event(stop_reason, usage_json);
@@ -187,12 +186,14 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         yield Ok(Bytes::from(sse_data));
                                     }
 
-                                    let event = json!({"type": "message_stop"});
-                                    let sse_data = format!("event: message_stop\ndata: {}\n\n",
-                                        serde_json::to_string(&event).unwrap_or_default());
-                                    log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
-                                    yield Ok(Bytes::from(sse_data));
-                                    has_sent_message_stop = true;
+                                    if !has_sent_message_stop {
+                                        let event = json!({"type": "message_stop"});
+                                        let sse_data = format!("event: message_stop\ndata: {}\n\n",
+                                            serde_json::to_string(&event).unwrap_or_default());
+                                        log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
+                                        yield Ok(Bytes::from(sse_data));
+                                        has_sent_message_stop = true;
+                                    }
                                     continue;
                                 }
 
@@ -213,6 +214,33 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         if let Some((_, pending_usage)) = pending_message_delta.as_mut() {
                                             *pending_usage = Some(usage_json.clone());
                                         }
+                                    }
+
+                                    // Handle the OpenAI include_usage trailer:
+                                    // a `chat.completion.chunk` with `choices: []` and `usage`.
+                                    if is_usage_only_chunk(&chunk) {
+                                        if let Some(usage_json) = chunk_usage_json {
+                                            latest_usage = Some(usage_json.clone());
+                                            if let Some((_, pending_usage)) = pending_message_delta.as_mut() {
+                                                *pending_usage = Some(usage_json.clone());
+                                            }
+                                        }
+
+                                        if let Some((stop_reason, usage_json)) = pending_message_delta.take() {
+                                            let event = build_message_delta_event(stop_reason, usage_json);
+                                            let sse_data = format!("event: message_delta\ndata: {}\n\n",
+                                                serde_json::to_string(&event).unwrap_or_default());
+                                            log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_delta (from usage trailer)");
+                                            yield Ok(Bytes::from(sse_data));
+
+                                            let event = json!({"type": "message_stop"});
+                                            let sse_data = format!("event: message_stop\ndata: {}\n\n",
+                                                serde_json::to_string(&event).unwrap_or_default());
+                                            log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
+                                            yield Ok(Bytes::from(sse_data));
+                                            has_sent_message_stop = true;
+                                        }
+                                        continue;
                                     }
 
                                     if let Some(choice) = chunk.choices.first() {
@@ -665,6 +693,15 @@ fn extract_cache_read_tokens(usage: &Usage) -> Option<u32> {
         .filter(|&v| v > 0)
 }
 
+fn is_usage_only_chunk(chunk: &OpenAIStreamChunk) -> bool {
+    chunk.choices.is_empty()
+        && chunk.usage.is_some()
+        && chunk
+            .object
+            .as_deref()
+            .is_none_or(|object| object == "chat.completion.chunk")
+}
+
 /// 映射停止原因
 fn map_stop_reason(finish_reason: Option<&str>) -> Option<String> {
     finish_reason.map(|r| {
@@ -935,56 +972,54 @@ mod tests {
 
     #[tokio::test]
     async fn test_duplicate_finish_reason_emits_only_one_message_delta() {
-        // Simulates OpenRouter behavior where two chunks carry finish_reason:
-        // first with null usage, second with populated usage.
         let input = concat!(
             "data: {\"id\":\"chatcmpl_dup\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
             "data: {\"id\":\"chatcmpl_dup\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n",
             "data: [DONE]\n\n"
         );
 
-        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
-            input.as_bytes().to_vec(),
-        ))]);
-        let converted = create_anthropic_sse_stream(upstream);
-        let chunks: Vec<_> = converted.collect().await;
-
-        let merged = chunks
-            .into_iter()
-            .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
-            .collect::<String>();
-
-        let events: Vec<Value> = merged
-            .split("\n\n")
-            .filter_map(|block| {
-                let data = block
-                    .lines()
-                    .find_map(|line| strip_sse_field(line, "data"))?;
-                serde_json::from_str::<Value>(data).ok()
-            })
-            .collect();
-
+        let events = collect_anthropic_events(input).await;
         let message_deltas: Vec<&Value> = events
             .iter()
-            .filter(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_delta"))
+            .filter(|event| event_type(event) == Some("message_delta"))
             .collect();
 
-        assert_eq!(
-            message_deltas.len(),
-            1,
-            "duplicate finish_reason chunks must produce exactly one message_delta, got {}: {:?}",
-            message_deltas.len(),
-            message_deltas
-        );
-
+        assert_eq!(message_deltas.len(), 1);
         assert_eq!(message_deltas[0]["usage"]["input_tokens"], 10);
         assert_eq!(message_deltas[0]["usage"]["output_tokens"], 5);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event_type(event) == Some("message_stop"))
+                .count(),
+            1
+        );
+    }
 
-        let message_stops = events
+    #[tokio::test]
+    async fn stream_options_include_usage_trailing_chunk_is_used() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+        let message_delta = events
             .iter()
-            .filter(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop"))
-            .count();
-        assert_eq!(message_stops, 1, "message_stop must only be emitted once");
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
+
+        assert_eq!(message_delta["usage"]["input_tokens"], 10);
+        assert_eq!(message_delta["usage"]["output_tokens"], 5);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event_type(event) == Some("message_stop"))
+                .count(),
+            1
+        );
     }
 
     #[tokio::test]
@@ -997,19 +1032,11 @@ mod tests {
         );
 
         let events = collect_anthropic_events(input).await;
-        let message_deltas: Vec<&Value> = events
+        let message_delta = events
             .iter()
-            .filter(|event| event_type(event) == Some("message_delta"))
-            .collect();
-        let message_stops = events
-            .iter()
-            .filter(|event| event_type(event) == Some("message_stop"))
-            .count();
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
 
-        assert_eq!(message_deltas.len(), 1);
-        assert_eq!(message_stops, 1);
-
-        let message_delta = message_deltas[0];
         assert_eq!(
             message_delta
                 .pointer("/delta/stop_reason")
@@ -1034,6 +1061,9 @@ mod tests {
                 .and_then(|v| v.as_u64()),
             Some(100)
         );
+        assert!(events
+            .iter()
+            .any(|event| event_type(event) == Some("message_stop")));
     }
 
     #[tokio::test]
@@ -1045,13 +1075,11 @@ mod tests {
         );
 
         let events = collect_anthropic_events(input).await;
-        let message_deltas: Vec<&Value> = events
+        let message_delta = events
             .iter()
-            .filter(|event| event_type(event) == Some("message_delta"))
-            .collect();
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
 
-        assert_eq!(message_deltas.len(), 1);
-        let message_delta = message_deltas[0];
         assert_eq!(
             message_delta
                 .pointer("/delta/stop_reason")
@@ -1130,12 +1158,53 @@ mod tests {
 
         assert!(events
             .iter()
-            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("error")));
+            .any(|event| event_type(event) == Some("error")));
         assert!(!events
             .iter()
-            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_delta")));
+            .any(|event| event_type(event) == Some("message_delta")));
         assert!(!events
             .iter()
-            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+            .any(|event| event_type(event) == Some("message_stop")));
+    }
+
+    #[tokio::test]
+    async fn stream_finishes_without_done_flushes_pending_terminal_events() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_4\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_4\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3}}\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+        let message_delta = events
+            .iter()
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
+
+        assert!(events
+            .iter()
+            .any(|event| event_type(event) == Some("message_stop")));
+        assert_eq!(message_delta["usage"]["input_tokens"], 7);
+        assert_eq!(message_delta["usage"]["output_tokens"], 3);
+    }
+
+    #[tokio::test]
+    async fn trailing_usage_without_done_flushes_immediately() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_5\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_5\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
+            "data: {\"id\":\"chatcmpl_5\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":6}}\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+        let message_delta = events
+            .iter()
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
+
+        assert_eq!(message_delta["usage"]["input_tokens"], 11);
+        assert_eq!(message_delta["usage"]["output_tokens"], 6);
+        assert!(events
+            .iter()
+            .any(|event| event_type(event) == Some("message_stop")));
     }
 }

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -17,6 +17,7 @@ struct OpenAIStreamChunk {
     #[serde(default)]
     model: String,
     #[serde(default)]
+    object: Option<String>,
     choices: Vec<StreamChoice>,
     #[serde(default)]
     usage: Option<Usage>,
@@ -159,7 +160,6 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         let mut current_non_tool_block_index: Option<u32> = None;
         let mut tool_blocks_by_index: HashMap<usize, ToolBlockState> = HashMap::new();
         let mut open_tool_block_indices: HashSet<u32> = HashSet::new();
-
         tokio::pin!(stream);
 
         while let Some(chunk) = stream.next().await {
@@ -176,7 +176,6 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                             if let Some(data) = strip_sse_field(l, "data") {
                                 if data.trim() == "[DONE]" {
                                     log::debug!("[Claude/OpenRouter] <<< OpenAI SSE: [DONE]");
-
                                     // 流正常结束，发出缓存的 message_delta（含完整 usage）。
                                     if let Some((stop_reason, usage_json)) = pending_message_delta.take() {
                                         let event = build_message_delta_event(stop_reason, usage_json);
@@ -186,12 +185,14 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         yield Ok(Bytes::from(sse_data));
                                     }
 
-                                    let event = json!({"type": "message_stop"});
-                                    let sse_data = format!("event: message_stop\ndata: {}\n\n",
-                                        serde_json::to_string(&event).unwrap_or_default());
-                                    log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
-                                    yield Ok(Bytes::from(sse_data));
-                                    has_sent_message_stop = true;
+                                    if !has_sent_message_stop {
+                                        let event = json!({"type": "message_stop"});
+                                        let sse_data = format!("event: message_stop\ndata: {}\n\n",
+                                            serde_json::to_string(&event).unwrap_or_default());
+                                        log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
+                                        yield Ok(Bytes::from(sse_data));
+                                        has_sent_message_stop = true;
+                                    }
                                     continue;
                                 }
 
@@ -212,6 +213,33 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         if let Some((_, pending_usage)) = pending_message_delta.as_mut() {
                                             *pending_usage = Some(usage_json.clone());
                                         }
+                                    }
+
+                                    // Handle the OpenAI include_usage trailer:
+                                    // a `chat.completion.chunk` with `choices: []` and `usage`.
+                                    if is_usage_only_chunk(&chunk) {
+                                        if let Some(usage_json) = chunk_usage_json {
+                                            latest_usage = Some(usage_json.clone());
+                                            if let Some((_, pending_usage)) = pending_message_delta.as_mut() {
+                                                *pending_usage = Some(usage_json.clone());
+                                            }
+                                        }
+
+                                        if let Some((stop_reason, usage_json)) = pending_message_delta.take() {
+                                            let event = build_message_delta_event(stop_reason, usage_json);
+                                            let sse_data = format!("event: message_delta\ndata: {}\n\n",
+                                                serde_json::to_string(&event).unwrap_or_default());
+                                            log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_delta (from usage trailer)");
+                                            yield Ok(Bytes::from(sse_data));
+
+                                            let event = json!({"type": "message_stop"});
+                                            let sse_data = format!("event: message_stop\ndata: {}\n\n",
+                                                serde_json::to_string(&event).unwrap_or_default());
+                                            log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
+                                            yield Ok(Bytes::from(sse_data));
+                                            has_sent_message_stop = true;
+                                        }
+                                        continue;
                                     }
 
                                     if let Some(choice) = chunk.choices.first() {
@@ -664,6 +692,15 @@ fn extract_cache_read_tokens(usage: &Usage) -> Option<u32> {
         .filter(|&v| v > 0)
 }
 
+fn is_usage_only_chunk(chunk: &OpenAIStreamChunk) -> bool {
+    chunk.choices.is_empty()
+        && chunk.usage.is_some()
+        && chunk
+            .object
+            .as_deref()
+            .is_none_or(|object| object == "chat.completion.chunk")
+}
+
 /// 映射停止原因
 fn map_stop_reason(finish_reason: Option<&str>) -> Option<String> {
     finish_reason.map(|r| {
@@ -934,56 +971,54 @@ mod tests {
 
     #[tokio::test]
     async fn test_duplicate_finish_reason_emits_only_one_message_delta() {
-        // Simulates OpenRouter behavior where two chunks carry finish_reason:
-        // first with null usage, second with populated usage.
         let input = concat!(
             "data: {\"id\":\"chatcmpl_dup\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
             "data: {\"id\":\"chatcmpl_dup\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n",
             "data: [DONE]\n\n"
         );
 
-        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
-            input.as_bytes().to_vec(),
-        ))]);
-        let converted = create_anthropic_sse_stream(upstream);
-        let chunks: Vec<_> = converted.collect().await;
-
-        let merged = chunks
-            .into_iter()
-            .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
-            .collect::<String>();
-
-        let events: Vec<Value> = merged
-            .split("\n\n")
-            .filter_map(|block| {
-                let data = block
-                    .lines()
-                    .find_map(|line| strip_sse_field(line, "data"))?;
-                serde_json::from_str::<Value>(data).ok()
-            })
-            .collect();
-
+        let events = collect_anthropic_events(input).await;
         let message_deltas: Vec<&Value> = events
             .iter()
-            .filter(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_delta"))
+            .filter(|event| event_type(event) == Some("message_delta"))
             .collect();
 
-        assert_eq!(
-            message_deltas.len(),
-            1,
-            "duplicate finish_reason chunks must produce exactly one message_delta, got {}: {:?}",
-            message_deltas.len(),
-            message_deltas
-        );
-
+        assert_eq!(message_deltas.len(), 1);
         assert_eq!(message_deltas[0]["usage"]["input_tokens"], 10);
         assert_eq!(message_deltas[0]["usage"]["output_tokens"], 5);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event_type(event) == Some("message_stop"))
+                .count(),
+            1
+        );
+    }
 
-        let message_stops = events
+    #[tokio::test]
+    async fn stream_options_include_usage_trailing_chunk_is_used() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+        let message_delta = events
             .iter()
-            .filter(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop"))
-            .count();
-        assert_eq!(message_stops, 1, "message_stop must only be emitted once");
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
+
+        assert_eq!(message_delta["usage"]["input_tokens"], 10);
+        assert_eq!(message_delta["usage"]["output_tokens"], 5);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event_type(event) == Some("message_stop"))
+                .count(),
+            1
+        );
     }
 
     #[tokio::test]
@@ -996,19 +1031,11 @@ mod tests {
         );
 
         let events = collect_anthropic_events(input).await;
-        let message_deltas: Vec<&Value> = events
+        let message_delta = events
             .iter()
-            .filter(|event| event_type(event) == Some("message_delta"))
-            .collect();
-        let message_stops = events
-            .iter()
-            .filter(|event| event_type(event) == Some("message_stop"))
-            .count();
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
 
-        assert_eq!(message_deltas.len(), 1);
-        assert_eq!(message_stops, 1);
-
-        let message_delta = message_deltas[0];
         assert_eq!(
             message_delta
                 .pointer("/delta/stop_reason")
@@ -1033,6 +1060,9 @@ mod tests {
                 .and_then(|v| v.as_u64()),
             Some(100)
         );
+        assert!(events
+            .iter()
+            .any(|event| event_type(event) == Some("message_stop")));
     }
 
     #[tokio::test]
@@ -1044,13 +1074,11 @@ mod tests {
         );
 
         let events = collect_anthropic_events(input).await;
-        let message_deltas: Vec<&Value> = events
+        let message_delta = events
             .iter()
-            .filter(|event| event_type(event) == Some("message_delta"))
-            .collect();
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
 
-        assert_eq!(message_deltas.len(), 1);
-        let message_delta = message_deltas[0];
         assert_eq!(
             message_delta
                 .pointer("/delta/stop_reason")
@@ -1129,12 +1157,53 @@ mod tests {
 
         assert!(events
             .iter()
-            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("error")));
+            .any(|event| event_type(event) == Some("error")));
         assert!(!events
             .iter()
-            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_delta")));
+            .any(|event| event_type(event) == Some("message_delta")));
         assert!(!events
             .iter()
-            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+            .any(|event| event_type(event) == Some("message_stop")));
+    }
+
+    #[tokio::test]
+    async fn stream_finishes_without_done_flushes_pending_terminal_events() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_4\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_4\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3}}\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+        let message_delta = events
+            .iter()
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
+
+        assert!(events
+            .iter()
+            .any(|event| event_type(event) == Some("message_stop")));
+        assert_eq!(message_delta["usage"]["input_tokens"], 7);
+        assert_eq!(message_delta["usage"]["output_tokens"], 3);
+    }
+
+    #[tokio::test]
+    async fn trailing_usage_without_done_flushes_immediately() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_5\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_5\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":null}\n\n",
+            "data: {\"id\":\"chatcmpl_5\",\"model\":\"gpt-4o\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":6}}\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+        let message_delta = events
+            .iter()
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("message_delta event");
+
+        assert_eq!(message_delta["usage"]["input_tokens"], 11);
+        assert_eq!(message_delta["usage"]["output_tokens"], 6);
+        assert!(events
+            .iter()
+            .any(|event| event_type(event) == Some("message_stop")));
     }
 }

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -112,8 +112,8 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
 }
 
 /// Anthropic 请求 → OpenAI Chat Completions 请求
-pub fn anthropic_to_openai(body: Value) -> Result<Value, ProxyError> {
-    anthropic_to_openai_with_reasoning_content(body, false)
+pub fn anthropic_to_openai(body: Value, stream_include_usage: bool) -> Result<Value, ProxyError> {
+    anthropic_to_openai_with_options(body, false, stream_include_usage)
 }
 
 /// Anthropic 请求 → OpenAI Chat Completions 请求
@@ -124,6 +124,15 @@ pub fn anthropic_to_openai(body: Value) -> Result<Value, ProxyError> {
 pub fn anthropic_to_openai_with_reasoning_content(
     body: Value,
     preserve_reasoning_content: bool,
+    stream_include_usage: bool,
+) -> Result<Value, ProxyError> {
+    anthropic_to_openai_with_options(body, preserve_reasoning_content, stream_include_usage)
+}
+
+fn anthropic_to_openai_with_options(
+    body: Value,
+    preserve_reasoning_content: bool,
+    stream_include_usage: bool,
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
 
@@ -192,6 +201,9 @@ pub fn anthropic_to_openai_with_reasoning_content(
     }
     if let Some(v) = body.get("stream") {
         result["stream"] = v.clone();
+        if stream_include_usage && v.as_bool() == Some(true) {
+            result["stream_options"] = json!({"include_usage": true});
+        }
     }
 
     // Map Anthropic thinking → OpenAI reasoning_effort
@@ -659,7 +671,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["model"], "claude-3-opus");
         assert_eq!(result["max_tokens"], 1024);
         assert_eq!(result["messages"][0]["role"], "user");
@@ -675,7 +687,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -693,7 +705,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -714,7 +726,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(result["messages"][0]["content"], "Stable prompt");
         assert_eq!(result["messages"][1]["role"], "user");
@@ -732,7 +744,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -750,7 +762,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -771,7 +783,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["tools"][0]["type"], "function");
         assert_eq!(result["tools"][0]["function"]["name"], "get_weather");
     }
@@ -788,7 +800,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"].as_array().unwrap().len(), 2);
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
@@ -811,7 +823,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -832,7 +844,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -855,7 +867,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert!(msg.get("tool_calls").is_some());
@@ -877,7 +889,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai_with_reasoning_content(input, true).unwrap();
+        let result = anthropic_to_openai_with_reasoning_content(input, true, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert_eq!(msg["reasoning_content"], "I should call the tool.");
@@ -898,7 +910,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai_with_reasoning_content(input, true).unwrap();
+        let result = anthropic_to_openai_with_reasoning_content(input, true, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert_eq!(msg["reasoning_content"], "tool call");
@@ -920,7 +932,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert!(msg.get("tool_calls").is_some());
@@ -940,7 +952,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"].as_array().unwrap().len(), 0);
     }
 
@@ -957,7 +969,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "tool");
         assert_eq!(msg["tool_call_id"], "call_123");
@@ -1057,7 +1069,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["model"], "gpt-4o");
     }
 
@@ -1069,7 +1081,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert!(result.get("prompt_cache_key").is_none());
     }
 
@@ -1095,7 +1107,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         // System message cache_control preserved
         assert_eq!(result["messages"][0]["cache_control"]["type"], "ephemeral");
         // Text block cache_control preserved
@@ -1349,7 +1361,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert!(result.get("reasoning_effort").is_none());
     }
 
@@ -1362,7 +1374,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["reasoning_effort"], "medium");
     }
 
@@ -1375,7 +1387,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["reasoning_effort"], "xhigh");
     }
 
@@ -1388,7 +1400,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["reasoning_effort"], "low");
     }
 
@@ -1401,7 +1413,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["reasoning_effort"], "xhigh");
     }
 
@@ -1413,7 +1425,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert!(result.get("reasoning_effort").is_none());
     }
 
@@ -1426,7 +1438,7 @@ mod tests {
                 "messages": [{"role": "user", "content": "Hello"}]
             });
 
-            let result = anthropic_to_openai(input).unwrap();
+            let result = anthropic_to_openai(input, false).unwrap();
             assert!(
                 result.get("max_tokens").is_none(),
                 "{model} should not have max_tokens"
@@ -1446,8 +1458,53 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["max_tokens"], 1024);
         assert!(result.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn anthropic_to_openai_injects_stream_options_when_enabled() {
+        let input = json!({
+            "model": "gpt-4",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true
+        });
+
+        let result = anthropic_to_openai(input, true).unwrap();
+
+        assert_eq!(result["stream"], true);
+        assert_eq!(result["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn anthropic_to_openai_does_not_inject_stream_options_when_disabled() {
+        let input = json!({
+            "model": "gpt-4",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true
+        });
+
+        let result = anthropic_to_openai(input, false).unwrap();
+
+        assert_eq!(result["stream"], true);
+        assert!(result.get("stream_options").is_none());
+    }
+
+    #[test]
+    fn anthropic_to_openai_does_not_inject_stream_options_when_stream_is_false() {
+        let input = json!({
+            "model": "gpt-4",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": false
+        });
+
+        let result = anthropic_to_openai(input, true).unwrap();
+
+        assert_eq!(result["stream"], false);
+        assert!(result.get("stream_options").is_none());
     }
 }

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -112,8 +112,8 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
 }
 
 /// Anthropic 请求 → OpenAI Chat Completions 请求
-pub fn anthropic_to_openai(body: Value) -> Result<Value, ProxyError> {
-    anthropic_to_openai_with_reasoning_content(body, false)
+pub fn anthropic_to_openai(body: Value, stream_include_usage: bool) -> Result<Value, ProxyError> {
+    anthropic_to_openai_with_options(body, false, stream_include_usage)
 }
 
 /// Anthropic 请求 → OpenAI Chat Completions 请求
@@ -124,6 +124,15 @@ pub fn anthropic_to_openai(body: Value) -> Result<Value, ProxyError> {
 pub fn anthropic_to_openai_with_reasoning_content(
     body: Value,
     preserve_reasoning_content: bool,
+    stream_include_usage: bool,
+) -> Result<Value, ProxyError> {
+    anthropic_to_openai_with_options(body, preserve_reasoning_content, stream_include_usage)
+}
+
+fn anthropic_to_openai_with_options(
+    body: Value,
+    preserve_reasoning_content: bool,
+    stream_include_usage: bool,
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
 
@@ -192,6 +201,9 @@ pub fn anthropic_to_openai_with_reasoning_content(
     }
     if let Some(v) = body.get("stream") {
         result["stream"] = v.clone();
+        if stream_include_usage && v.as_bool() == Some(true) {
+            result["stream_options"] = json!({"include_usage": true});
+        }
     }
 
     // Map Anthropic thinking → OpenAI reasoning_effort
@@ -703,7 +715,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["model"], "claude-3-opus");
         assert_eq!(result["max_tokens"], 1024);
         assert_eq!(result["messages"][0]["role"], "user");
@@ -719,7 +731,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -737,7 +749,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -758,7 +770,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(result["messages"][0]["content"], "Stable prompt");
         assert_eq!(result["messages"][1]["role"], "user");
@@ -776,7 +788,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -794,7 +806,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -815,7 +827,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["tools"][0]["type"], "function");
         assert_eq!(result["tools"][0]["function"]["name"], "get_weather");
     }
@@ -832,7 +844,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"].as_array().unwrap().len(), 2);
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
@@ -855,7 +867,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -876,7 +888,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"][0]["role"], "system");
         assert_eq!(
             result["messages"][0]["content"],
@@ -899,7 +911,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert!(msg.get("tool_calls").is_some());
@@ -921,7 +933,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai_with_reasoning_content(input, true).unwrap();
+        let result = anthropic_to_openai_with_reasoning_content(input, true, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert_eq!(msg["reasoning_content"], "I should call the tool.");
@@ -942,7 +954,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai_with_reasoning_content(input, true).unwrap();
+        let result = anthropic_to_openai_with_reasoning_content(input, true, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert_eq!(msg["reasoning_content"], "tool call");
@@ -964,7 +976,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert!(msg.get("tool_calls").is_some());
@@ -984,7 +996,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["messages"].as_array().unwrap().len(), 0);
     }
 
@@ -1001,7 +1013,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "tool");
         assert_eq!(msg["tool_call_id"], "call_123");
@@ -1134,7 +1146,7 @@ mod tests {
                 "content": anthropic_response["content"].clone()
             }]
         });
-        let replayed = anthropic_to_openai_with_reasoning_content(follow_up_request, true).unwrap();
+        let replayed = anthropic_to_openai_with_reasoning_content(follow_up_request, true, false).unwrap();
         let msg = &replayed["messages"][0];
 
         assert_eq!(
@@ -1154,7 +1166,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["model"], "gpt-4o");
     }
 
@@ -1166,7 +1178,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert!(result.get("prompt_cache_key").is_none());
     }
 
@@ -1192,7 +1204,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         // System message cache_control preserved
         assert_eq!(result["messages"][0]["cache_control"]["type"], "ephemeral");
         // Text block cache_control preserved
@@ -1446,7 +1458,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert!(result.get("reasoning_effort").is_none());
     }
 
@@ -1459,7 +1471,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["reasoning_effort"], "medium");
     }
 
@@ -1472,7 +1484,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["reasoning_effort"], "xhigh");
     }
 
@@ -1485,7 +1497,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["reasoning_effort"], "low");
     }
 
@@ -1498,7 +1510,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["reasoning_effort"], "xhigh");
     }
 
@@ -1510,7 +1522,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert!(result.get("reasoning_effort").is_none());
     }
 
@@ -1523,7 +1535,7 @@ mod tests {
                 "messages": [{"role": "user", "content": "Hello"}]
             });
 
-            let result = anthropic_to_openai(input).unwrap();
+            let result = anthropic_to_openai(input, false).unwrap();
             assert!(
                 result.get("max_tokens").is_none(),
                 "{model} should not have max_tokens"
@@ -1543,7 +1555,7 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_openai(input).unwrap();
+        let result = anthropic_to_openai(input, false).unwrap();
         assert_eq!(result["max_tokens"], 1024);
         assert!(result.get("max_completion_tokens").is_none());
     }
@@ -1559,7 +1571,7 @@ mod tests {
             }],
             "tool_choice": value,
         });
-        anthropic_to_openai(input).unwrap()["tool_choice"].clone()
+        anthropic_to_openai(input, false).unwrap()["tool_choice"].clone()
     }
 
     #[test]
@@ -1593,5 +1605,50 @@ mod tests {
             run_tool_choice(json!({"type": "tool", "name": "search"})),
             json!({"type": "function", "function": {"name": "search"}}),
         );
+    }
+
+    #[test]
+    fn anthropic_to_openai_injects_stream_options_when_enabled() {
+        let input = json!({
+            "model": "gpt-4",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true
+        });
+
+        let result = anthropic_to_openai(input, true).unwrap();
+
+        assert_eq!(result["stream"], true);
+        assert_eq!(result["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn anthropic_to_openai_does_not_inject_stream_options_when_disabled() {
+        let input = json!({
+            "model": "gpt-4",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": true
+        });
+
+        let result = anthropic_to_openai(input, false).unwrap();
+
+        assert_eq!(result["stream"], true);
+        assert!(result.get("stream_options").is_none());
+    }
+
+    #[test]
+    fn anthropic_to_openai_does_not_inject_stream_options_when_stream_is_false() {
+        let input = json!({
+            "model": "gpt-4",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": false
+        });
+
+        let result = anthropic_to_openai(input, true).unwrap();
+
+        assert_eq!(result["stream"], false);
+        assert!(result.get("stream_options").is_none());
     }
 }

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -376,7 +376,8 @@ impl StreamCheckService {
             anthropic_to_gemini(anthropic_body)
                 .map_err(|e| AppError::Message(format!("Failed to build test request: {e}")))?
         } else if is_openai_chat {
-            anthropic_to_openai(anthropic_body)
+            let stream_include_usage = provider.stream_include_usage();
+            anthropic_to_openai(anthropic_body, stream_include_usage)
                 .map_err(|e| AppError::Message(format!("Failed to build test request: {e}")))?
         } else {
             anthropic_body

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -372,7 +372,8 @@ impl StreamCheckService {
             anthropic_to_gemini(anthropic_body)
                 .map_err(|e| AppError::Message(format!("Failed to build test request: {e}")))?
         } else if is_openai_chat {
-            anthropic_to_openai(anthropic_body)
+            let stream_include_usage = provider.stream_include_usage();
+            anthropic_to_openai(anthropic_body, stream_include_usage)
                 .map_err(|e| AppError::Message(format!("Failed to build test request: {e}")))?
         } else {
             anthropic_body


### PR DESCRIPTION
 ## Summary / 概述

 Enable stream_options.include_usage for supported OpenAI-style providers, cache trailing usage chunks, and flush
 terminal events when receiving the usage trailer, [DONE], or EOF.

 This improves message_delta usage accuracy for providers that emit a trailing usage chunk, while still preserving inline
 usage as a fallback for providers that do not support it.

 为支持的 OpenAI 风格提供商启用 stream_options.include_usage，缓存流末尾的 usage chunk，并在收到 usage trailer、[DONE] 或
 EOF 时刷新终端事件。

 这样可以提升 message_delta 中 usage 统计的准确性；同时，对于不支持尾部 usage chunk 的提供商，仍然保留 inline usage  作为回退机制。

解决一下问题 

* claude code 中看不到 context 用量
* pi code agent 执行会因为没有 token usage 报错

## Related Issue / 关联 Issue

 Fixes #1957 

## Screenshots / 截图

修改前

没截图了, 就是没有 token usage

修改后

<img width="407" height="385" alt="图片" src="https://github.com/user-attachments/assets/f2dbf2af-005c-447e-bc61-79a037b3826f" />

