### PR TITLE
fix: support Qwen3.5 thinking mode and fix tool-call loop in openai_chat

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -328,6 +328,17 @@ pub struct ProviderMeta {
     /// 用于多账号支持，关联到特定的 GitHub 账号
     #[serde(rename = "githubAccountId", skip_serializing_if = "Option::is_none")]
     pub github_account_id: Option<String>,
+    /// 通过 chat_template_kwargs.enable_thinking=false 关闭模型 thinking 输出
+    /// 仅对 openai_chat 路径生效（vLLM/SGLang 等支持 chat_template_kwargs 的 backend）
+    #[serde(rename = "disableThinking", skip_serializing_if = "Option::is_none")]
+    pub disable_thinking: Option<bool>,
+    /// 在 openai_chat 路径中，将 assistant 消息的 reasoning_content 回传给上游
+    /// 用于 Qwen3.5 等需要 reasoning_content 才能正确执行 tool call 的模型
+    #[serde(
+        rename = "preserveReasoningContent",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub preserve_reasoning_content: Option<bool>,
 }
 
 impl ProviderMeta {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1005,6 +1005,31 @@ impl RequestForwarder {
             mapped_body
         };
 
+        // 注入 chat_template_kwargs.enable_thinking=false（仅 openai_chat 路径）
+        let mut request_body = request_body;
+        if provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.disable_thinking)
+            .unwrap_or(false)
+        {
+            let is_openai_chat = adapter.name() == "Claude"
+                && resolved_claude_api_format
+                    .as_deref()
+                    .unwrap_or_else(|| super::providers::get_claude_api_format(provider))
+                    == "openai_chat";
+            if is_openai_chat {
+                if let serde_json::Value::Object(obj) = &mut request_body {
+                    let kwargs = obj
+                        .entry("chat_template_kwargs".to_string())
+                        .or_insert_with(|| serde_json::json!({}));
+                    if let serde_json::Value::Object(k) = kwargs {
+                        k.insert("enable_thinking".to_string(), serde_json::json!(false));
+                    }
+                }
+            }
+        }
+
         // 过滤私有参数（以 `_` 开头的字段），防止内部信息泄露到上游
         // 默认使用空白名单，过滤所有 _ 前缀字段
         let filtered_body = filter_private_params_with_whitelist(request_body, &[]);

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -91,6 +91,16 @@ fn should_preserve_reasoning_content_for_openai_chat(
     provider: &Provider,
     body: &serde_json::Value,
 ) -> bool {
+    // 显式 meta 标志优先（支持 Qwen3.5 等任意模型）
+    if provider
+        .meta
+        .as_ref()
+        .and_then(|m| m.preserve_reasoning_content)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
     if body
         .get("model")
         .and_then(|m| m.as_str())

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -9,6 +9,7 @@ import {
 import { toast } from "sonner";
 import { FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -134,6 +135,10 @@ interface ClaudeFormFieldsProps {
   // Full URL mode
   isFullUrl: boolean;
   onFullUrlChange: (value: boolean) => void;
+
+  // Thinking mode (openai_chat only)
+  thinkingEnabled?: boolean;
+  onThinkingChange?: (enabled: boolean) => void;
 }
 
 export function ClaudeFormFields({
@@ -182,6 +187,8 @@ export function ClaudeFormFields({
   onApiKeyFieldChange,
   isFullUrl,
   onFullUrlChange,
+  thinkingEnabled,
+  onThinkingChange,
 }: ClaudeFormFieldsProps) {
   const { t } = useTranslation();
   const hasAnyAdvancedValue = !!(
@@ -190,7 +197,8 @@ export function ClaudeFormFields({
     defaultSonnetModel ||
     defaultOpusModel ||
     apiFormat !== "anthropic" ||
-    apiKeyField !== "ANTHROPIC_AUTH_TOKEN"
+    apiKeyField !== "ANTHROPIC_AUTH_TOKEN" ||
+    thinkingEnabled !== undefined
   );
   const [advancedExpanded, setAdvancedExpanded] = useState(hasAnyAdvancedValue);
 
@@ -554,6 +562,34 @@ export function ClaudeFormFields({
                     defaultValue: "选择供应商 API 的输入格式",
                   })}
                 </p>
+              </div>
+            )}
+
+            {/* 思考模式（仅 openai_chat 格式显示） */}
+            {category !== "cloud_provider" && apiFormat === "openai_chat" && (
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <FormLabel>
+                    {t("providerForm.thinkingMode", {
+                      defaultValue: "思考模式",
+                    })}
+                  </FormLabel>
+                  <p className="text-xs text-muted-foreground">
+                    {thinkingEnabled
+                      ? t("providerForm.thinkingModeOnHint", {
+                          defaultValue:
+                            "模型生成思考链，自动修复 tool call 循环问题",
+                        })
+                      : t("providerForm.thinkingModeOffHint", {
+                          defaultValue:
+                            "禁用思考链（节省 token），适用于 vLLM / SGLang",
+                        })}
+                  </p>
+                </div>
+                <Switch
+                  checked={thinkingEnabled ?? false}
+                  onCheckedChange={onThinkingChange}
+                />
               </div>
             )}
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -363,6 +363,17 @@ function ProviderFormFull({
     setLocalApiFormat(format);
   }, []);
 
+  const [localThinkingEnabled, setLocalThinkingEnabled] = useState<
+    boolean | undefined
+  >(() => {
+    if (appId !== "claude") return undefined;
+    const meta = initialData?.meta;
+    if (!meta) return undefined;
+    if (meta.preserveReasoningContent === true) return true;
+    if (meta.disableThinking === true) return false;
+    return undefined;
+  });
+
   const handleApiKeyFieldChange = useCallback(
     (field: ClaudeApiKeyField) => {
       const prev = localApiKeyField;
@@ -1222,6 +1233,20 @@ function ProviderFormFull({
         supportsFullUrl && category !== "official" && localIsFullUrl
           ? true
           : undefined,
+      disableThinking:
+        appId === "claude" &&
+        category !== "official" &&
+        localApiFormat === "openai_chat" &&
+        localThinkingEnabled === false
+          ? true
+          : undefined,
+      preserveReasoningContent:
+        appId === "claude" &&
+        category !== "official" &&
+        localApiFormat === "openai_chat" &&
+        localThinkingEnabled === true
+          ? true
+          : undefined,
     };
 
     if (!isCodexOauthProvider && "codexFastMode" in nextMeta) {
@@ -1825,6 +1850,8 @@ function ProviderFormFull({
               onApiKeyFieldChange={handleApiKeyFieldChange}
               isFullUrl={localIsFullUrl}
               onFullUrlChange={setLocalIsFullUrl}
+              thinkingEnabled={localThinkingEnabled}
+              onThinkingChange={setLocalThinkingEnabled}
             />
           )}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,10 @@ export interface ProviderMeta {
   providerType?: string;
   // GitHub Copilot 关联账号 ID（旧字段，保留兼容读取）
   githubAccountId?: string;
+  // 关闭模型思考模式（openai_chat 路径注入 chat_template_kwargs.enable_thinking=false）
+  disableThinking?: boolean;
+  // 回传 reasoning_content（openai_chat + thinking 开启时修复 tool loop）
+  preserveReasoningContent?: boolean;
 }
 
 // Skill 同步方式


### PR DESCRIPTION
Closes #2712

## Summary

- Add `preserveReasoningContent` meta flag: when set, cc-switch echoes `reasoning_content` back in tool_result turns, fixing the infinite tool-call loop with Qwen3.5 and other thinking models served via vLLM/SGLang
- Add `disableThinking` meta flag: injects `chat_template_kwargs.enable_thinking=false` into openai_chat requests for deployments where thinking is unnecessary (saves tokens)
- Add **思考模式 / Thinking Mode** toggle in provider Advanced settings UI, visible only when API format is `openai_chat`; ON → `preserveReasoningContent`, OFF → `disableThinking`

## Changed Files

| File | Change |
|------|--------|
| `src-tauri/src/provider.rs` | Two new optional fields in `ProviderMeta` |
| `src-tauri/src/proxy/providers/claude.rs` | Honour `preserveReasoningContent` flag in `should_preserve_reasoning_content_for_openai_chat()` |
| `src-tauri/src/proxy/forwarder.rs` | Inject `chat_template_kwargs.enable_thinking=false` when `disableThinking` is set |
| `src/types.ts` | Expose new meta fields to frontend |
| `src/components/providers/forms/ClaudeFormFields.tsx` | Thinking Mode toggle UI |
| `src/components/providers/forms/ProviderForm.tsx` | State management for new toggle |

## Test

Verified against Qwen3.5-397B-A17B-INT8 on vLLM 0.17 — tool calls complete correctly with `preserveReasoningContent: true`.