### PR TITLE
fix(mcp): infer Codex URL-only MCP transport

### DIFF
--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -71,11 +71,7 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
                 continue;
             };
 
-            // type 缺省为 stdio
-            let typ = entry_tbl
-                .get("type")
-                .and_then(|v| v.as_str())
-                .unwrap_or("stdio");
+            let typ = infer_codex_mcp_type(entry_tbl);
 
             // 构建 JSON 规范
             let mut spec = serde_json::Map::new();
@@ -270,6 +266,22 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
     }
 
     Ok(changed_total)
+}
+
+fn infer_codex_mcp_type(entry_tbl: &toml::value::Table) -> &str {
+    if let Some(typ) = entry_tbl.get("type").and_then(|v| v.as_str()) {
+        return typ;
+    }
+
+    if entry_tbl
+        .get("url")
+        .and_then(|v| v.as_str())
+        .is_some_and(|url| !url.trim().is_empty())
+    {
+        return "sse";
+    }
+
+    "stdio"
 }
 
 /// 将 config.json 中 Codex 的 enabled==true 项以 TOML 形式写入 ~/.codex/config.toml

--- a/src-tauri/tests/import_export_sync.rs
+++ b/src-tauri/tests/import_export_sync.rs
@@ -608,6 +608,40 @@ url = "https://example.com"
 }
 
 #[test]
+fn import_from_codex_infers_sse_for_url_only_mcp_server() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let path = cc_switch_lib::get_codex_config_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create codex dir");
+    }
+    fs::write(
+        &path,
+        r#"[mcp_servers.pycharm]
+url = "http://127.0.0.1:64342/stream"
+"#,
+    )
+    .expect("write codex config");
+
+    let mut config = MultiAppConfig::default();
+    let changed = cc_switch_lib::import_from_codex(&mut config).expect("import codex");
+    assert_eq!(changed, 1, "url-only MCP server should be imported");
+
+    let servers = config
+        .mcp
+        .servers
+        .as_ref()
+        .expect("unified servers should exist");
+    let pycharm = servers.get("pycharm").expect("pycharm server");
+    let spec = pycharm.server.as_object().expect("server spec");
+    assert_eq!(spec.get("type").and_then(|v| v.as_str()), Some("sse"));
+    assert_eq!(
+        spec.get("url").and_then(|v| v.as_str()),
+        Some("http://127.0.0.1:64342/stream")
+    );
+}
+
+#[test]
 fn import_from_codex_merges_into_existing_entries() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();


### PR DESCRIPTION
## Summary
- Infer Codex MCP entries with a URL but no explicit type as SSE instead of stdio
- Preserve the existing stdio default for entries without a URL
- Add a regression test for importing a Codex URL-only MCP server such as the PyCharm `/stream` config

Fixes #2492

## Test Plan
- [x] `git diff --check`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test import_export_sync`
