### PR TITLE
fix(usage): keep deleted model pricing removed

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -104,4 +104,5 @@ strip = "symbols"
 
 [dev-dependencies]
 serial_test = "3"
+tauri = { version = "2.8.2", features = ["test"] }
 tempfile = "3"

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -81,7 +81,6 @@ pub fn get_request_detail(
 #[tauri::command]
 pub fn get_model_pricing(state: State<'_, AppState>) -> Result<Vec<ModelPricingInfo>, AppError> {
     log::info!("获取模型定价列表");
-    state.db.ensure_model_pricing_seeded()?;
 
     let db = state.db.clone();
     let conn = crate::database::lock_conn!(db.conn);

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1896,7 +1896,15 @@ impl Database {
     }
 
     fn ensure_model_pricing_seeded_on_conn(conn: &Connection) -> Result<(), AppError> {
-        // 每次启动都执行 INSERT OR IGNORE，增量追加新模型，已有数据不覆盖
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM model_pricing", [], |row| row.get(0))
+            .map_err(|e| AppError::Database(format!("读取模型定价数量失败: {e}")))?;
+
+        if count > 0 {
+            log::debug!("模型定价表已有数据，跳过默认定价填充");
+            return Ok(());
+        }
+
         Self::seed_model_pricing(conn)
     }
 

--- a/src-tauri/tests/model_pricing_commands.rs
+++ b/src-tauri/tests/model_pricing_commands.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use cc_switch_lib::{delete_model_pricing, get_model_pricing, AppState, Database};
+use tauri::Manager;
+
+fn build_test_app(db: Arc<Database>) -> tauri::App<tauri::test::MockRuntime> {
+    tauri::test::mock_builder()
+        .manage(AppState::new(db))
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("build test app")
+}
+
+#[test]
+fn get_model_pricing_does_not_restore_deleted_default_pricing() {
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let app = build_test_app(db);
+    let state = app.state::<AppState>();
+    let model_id = "claude-sonnet-4-5-20250929".to_string();
+
+    let seeded_pricing = get_model_pricing(state.clone()).expect("list seeded pricing");
+    assert!(
+        seeded_pricing
+            .iter()
+            .any(|pricing| pricing.model_id == model_id),
+        "default pricing should exist before deletion"
+    );
+
+    delete_model_pricing(state.clone(), model_id.clone()).expect("delete default pricing");
+
+    let pricing_after_delete = get_model_pricing(state).expect("list pricing after deletion");
+    assert!(
+        !pricing_after_delete
+            .iter()
+            .any(|pricing| pricing.model_id == model_id),
+        "deleted default pricing should not be restored by listing pricing"
+    );
+}

--- a/src-tauri/tests/model_pricing_commands.rs
+++ b/src-tauri/tests/model_pricing_commands.rs
@@ -35,3 +35,24 @@ fn get_model_pricing_does_not_restore_deleted_default_pricing() {
         "deleted default pricing should not be restored by listing pricing"
     );
 }
+
+#[test]
+fn startup_pricing_seed_does_not_restore_deleted_default_pricing() {
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let app = build_test_app(db.clone());
+    let state = app.state::<AppState>();
+    let model_id = "claude-sonnet-4-5-20250929".to_string();
+
+    delete_model_pricing(state.clone(), model_id.clone()).expect("delete default pricing");
+
+    db.ensure_model_pricing_seeded()
+        .expect("simulate startup pricing seed");
+
+    let pricing_after_seed = get_model_pricing(state).expect("list pricing after startup seed");
+    assert!(
+        !pricing_after_seed
+            .iter()
+            .any(|pricing| pricing.model_id == model_id),
+        "deleted default pricing should not be restored by startup seeding"
+    );
+}


### PR DESCRIPTION
## Summary / 概述

- Stop reseeding default model pricing when reading the pricing list, so deleted default pricing stays deleted.
- Keep default pricing seeded at database initialization for new installs/databases.
- Add a command-level regression test for deleting a seeded pricing row and reading the list again.

## Related Issue / 关联 Issue

Fixes #2436

## Screenshots / 截图

Not applicable; backend behavior change only.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

## Test Plan

- [x] `git diff --check`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml get_model_pricing_does_not_restore_deleted_default_pricing`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml`
- [x] `pnpm typecheck && pnpm format:check && pnpm test:unit`
