### PR TITLE
fix(codex/azure): remove conflicting requires_openai_auth from Azure preset

### DIFF
--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -111,8 +111,7 @@ name = "Azure OpenAI"
 base_url = "https://YOUR_RESOURCE_NAME.openai.azure.com/openai"
 env_key = "OPENAI_API_KEY"
 query_params = { "api-version" = "2025-04-01-preview" }
-wire_api = "responses"
-requires_openai_auth = true`,
+wire_api = "responses"`,
     endpointCandidates: ["https://YOUR_RESOURCE_NAME.openai.azure.com/openai"],
     theme: {
       icon: "codex",


### PR DESCRIPTION
## Problem

The Azure OpenAI preset in `codexProviderPresets.ts` ships with both:

- `env_key = "OPENAI_API_KEY"` (env-variable auth)
- `requires_openai_auth = true` (OpenAI OAuth login)

These two fields are mutually exclusive per the Codex [config reference](https://developers.openai.com/codex/config-reference):

> Do not combine with `env_key`, `experimental_bearer_token`, or `requires_openai_auth`.

When a user follows the README and sets `OPENAI_API_KEY`, Codex still errors out with `Missing environment variable: OPENAI_API_KEY.` — because `requires_openai_auth = true` makes Codex demand an OpenAI OAuth login flow and ignore the env-key auth path.

## Fix

Remove the conflicting `requires_openai_auth = true` line from the Azure preset. Azure OpenAI authenticates via API key (`env_key`), not OpenAI OAuth.

## Verification

- Generated config now matches the [Microsoft Learn canonical Azure setup](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/codex).
- Setting `OPENAI_API_KEY` env var and running `codex` connects to Azure OpenAI successfully (reproduced on Windows 10, Codex v0.130.0, model `gpt-5.5`).

## Scope

Intentionally minimal — only the Azure preset is touched. Some third-party presets generated by `generateThirdPartyConfig()` may have the same conflict, but each needs case-by-case verification and is out of scope for this fix.

Related: #1309 (broader Azure compatibility PR, but does not modify this file).
