### PR TITLE
feat: add OfoxAI as universal provider preset

### DIFF
--- a/src/config/universalProviderPresets.ts
+++ b/src/config/universalProviderPresets.ts
@@ -74,6 +74,21 @@ export const universalProviderPresets: UniversalProviderPreset[] = [
       "NewAPI 是一个可自部署的 API 网关，支持 Anthropic、OpenAI、Gemini 等多种协议",
   },
   {
+    name: "OfoxAI",
+    providerType: "ofoxai",
+    defaultApps: {
+      claude: true,
+      codex: true,
+      gemini: true,
+    },
+    defaultModels: NEWAPI_DEFAULT_MODELS,
+    websiteUrl: "https://ofox.ai",
+    icon: "openai",
+    iconColor: "#FF6B35",
+    description:
+      "OfoxAI is a unified LLM API gateway — one API key for 100+ models (Claude, GPT, Gemini, DeepSeek, etc.) with native OpenAI, Anthropic, and Gemini protocol support. Pay per token, no monthly fees.",
+  },
+  {
     name: "自定义网关",
     providerType: "custom_gateway",
     defaultApps: {


### PR DESCRIPTION
## Add OfoxAI Universal Provider Preset

Adds **OfoxAI** (https://ofox.ai) as a new universal provider preset in `universalProviderPresets.ts`.

### About OfoxAI

OfoxAI is a unified LLM API gateway that provides access to 100+ models through a single OpenAI-compatible endpoint:
- **100+ LLMs** — Claude, GPT, Gemini, DeepSeek, and more
- **Protocol support** — Native OpenAI, Anthropic, and Gemini protocol compatibility
- **No monthly fees** — Pay per token billing
- **Universal** — Works with Claude Code, Codex, Gemini CLI and other tools

Since OfoxAI uses the same API gateway pattern as NewAPI (OpenAI-compatible endpoint), it fits naturally as a universal provider preset.

### Changes

- Added `OfoxAI` preset to `universalProviderPresets` array
- Provider type: `ofoxai`
- Supports all three apps: Claude, Codex, Gemini