### PR TITLE
feat(proxy): add experimental Codex api_format support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,9 +151,15 @@ jobs:
           echo "✅ Tauri signing key prepared"
 
       - name: Import Apple signing certificate
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        if: runner.os == 'macOS'
+        id: apple-signing
         shell: bash
         run: |
+          if [ -z "${{ secrets.APPLE_CERTIFICATE }}" ]; then
+            echo "No APPLE_CERTIFICATE secret, skipping macOS signing"
+            echo "signed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           set -euo pipefail
           # Decode .p12 certificate from base64
           CERT_PATH="$RUNNER_TEMP/certificate.p12"
@@ -188,12 +194,13 @@ jobs:
           fi
           echo "✅ Signing identity: $IDENTITY"
           echo "APPLE_SIGNING_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+          echo "signed=true" >> $GITHUB_OUTPUT
 
           # Cleanup certificate file
           rm -f "$CERT_PATH"
 
       - name: Build Tauri App (macOS)
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        if: runner.os == 'macOS' && steps.apple-signing.outputs.signed != 'false'
         shell: bash
         timeout-minutes: 60
         env:
@@ -230,7 +237,7 @@ jobs:
         run: pnpm tauri build --bundles appimage,deb,rpm
 
       - name: Prepare macOS Assets
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        if: runner.os == 'macOS' && steps.apple-signing.outputs.signed != 'false'
         shell: bash
         run: |
           set -euxo pipefail
@@ -305,7 +312,7 @@ jobs:
           echo "✅ Styled DMG created: $NEW_DMG"
 
       - name: Notarize macOS DMG
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        if: runner.os == 'macOS' && steps.apple-signing.outputs.signed != 'false'
         shell: bash
         timeout-minutes: 30
         env:
@@ -347,7 +354,7 @@ jobs:
           done
 
       - name: Verify macOS code signing and notarization
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        if: runner.os == 'macOS' && steps.apple-signing.outputs.signed != 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -478,7 +485,7 @@ jobs:
           fi
 
       - name: Prepare empty macOS assets
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE == ''
+        if: runner.os == 'macOS' && steps.apple-signing.outputs.signed == 'false'
         shell: bash
         run: |
           mkdir -p release-assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           echo "✅ Tauri signing key prepared"
 
       - name: Import Apple signing certificate
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
         shell: bash
         run: |
           set -euo pipefail
@@ -193,7 +193,7 @@ jobs:
           rm -f "$CERT_PATH"
 
       - name: Build Tauri App (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
         shell: bash
         timeout-minutes: 60
         env:
@@ -230,7 +230,7 @@ jobs:
         run: pnpm tauri build --bundles appimage,deb,rpm
 
       - name: Prepare macOS Assets
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
         shell: bash
         run: |
           set -euxo pipefail
@@ -305,7 +305,7 @@ jobs:
           echo "✅ Styled DMG created: $NEW_DMG"
 
       - name: Notarize macOS DMG
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
         shell: bash
         timeout-minutes: 30
         env:
@@ -347,7 +347,7 @@ jobs:
           done
 
       - name: Verify macOS code signing and notarization
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
         shell: bash
         run: |
           set -euo pipefail
@@ -476,6 +476,13 @@ jobs:
           else
             echo "No .rpm found (optional)"
           fi
+
+      - name: Prepare empty macOS assets
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE == ''
+        shell: bash
+        run: |
+          mkdir -p release-assets
+          touch release-assets/.macos-skipped
 
       - name: List prepared assets
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,7 +508,7 @@ jobs:
         with:
           name: release-assets-${{ runner.os }}-${{ matrix.arch || runner.arch }}
           path: release-assets/*
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: List generated bundles (debug)
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ copilot-api
 CODEBUDDY.md
 .github
 mainWindow.js
+
+docs/superpowers/

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -1355,4 +1355,43 @@ mod tests {
         );
         assert!(!is_compatible_direct_provider(&missing_bearer));
     }
+
+    #[test]
+    fn claude_desktop_upstream_model_id_skips_one_m_for_non_claude() {
+        // Non-Claude upstream + supports_1m=true → no [1M] suffix
+        assert_eq!(
+            upstream_model_id("deepseek-v4-pro", true),
+            "deepseek-v4-pro"
+        );
+
+        // Claude upstream + supports_1m=true → append [1M]
+        assert_eq!(
+            upstream_model_id("claude-sonnet-4-6", true),
+            "claude-sonnet-4-6 [1M]"
+        );
+
+        // Claude upstream + supports_1m=false → no suffix
+        assert_eq!(
+            upstream_model_id("claude-sonnet-4-6", false),
+            "claude-sonnet-4-6"
+        );
+
+        // Non-Claude upstream + supports_1m=false → no suffix
+        assert_eq!(
+            upstream_model_id("deepseek-v4-pro", false),
+            "deepseek-v4-pro"
+        );
+
+        // anthropic/ prefix + supports_1m=true → append [1M]
+        assert_eq!(
+            upstream_model_id("anthropic/claude-sonnet-4.6", true),
+            "anthropic/claude-sonnet-4.6 [1M]"
+        );
+
+        // [1m]-suffixed non-Claude upstream → strip suffix, no re-append
+        assert_eq!(
+            upstream_model_id("deepseek-v4-pro [1m]", true),
+            "deepseek-v4-pro"
+        );
+    }
 }

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -239,7 +239,15 @@ fn desktop_model_id(model_id: &str, supports_1m: bool) -> String {
 }
 
 fn upstream_model_id(model_id: &str, supports_1m: bool) -> String {
-    desktop_model_id(model_id, supports_1m)
+    let normalized = strip_one_m_context_suffix(model_id);
+    // Only append [1M] for Claude-series upstream models
+    let is_claude_upstream = normalized.starts_with("claude-")
+        || normalized.starts_with("anthropic/");
+    if supports_1m && is_claude_upstream {
+        format!("{normalized}{ONE_M_CONTEXT_SUFFIX}")
+    } else {
+        normalized
+    }
 }
 
 pub fn get_or_create_gateway_token(db: &Database) -> Result<String, AppError> {
@@ -1181,7 +1189,7 @@ mod tests {
             &provider,
         )
         .expect("map route");
-        assert_eq!(mapped["model"], json!("kimi-k2 [1M]"));
+        assert_eq!(mapped["model"], json!("kimi-k2"));
 
         let models = model_list_response(&provider).expect("model list");
         assert_eq!(models["data"][0]["id"], json!("claude-sonnet-4-6 [1M]"));
@@ -1200,7 +1208,7 @@ mod tests {
             &provider,
         )
         .expect("base name should fallback-match the [1M] route");
-        assert_eq!(mapped["model"], json!("kimi-k2 [1M]"));
+        assert_eq!(mapped["model"], json!("kimi-k2"));
     }
 
     #[test]

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -3,9 +3,9 @@ use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::config::{atomic_write, delete_file, read_json_file, write_json_file};
 #[cfg(any(target_os = "macos", windows))]
 use crate::config::get_home_dir;
+use crate::config::{atomic_write, delete_file, read_json_file, write_json_file};
 use crate::database::Database;
 use crate::database::CLAUDE_DESKTOP_OFFICIAL_PROVIDER_ID;
 use crate::error::AppError;

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -241,8 +241,8 @@ fn desktop_model_id(model_id: &str, supports_1m: bool) -> String {
 fn upstream_model_id(model_id: &str, supports_1m: bool) -> String {
     let normalized = strip_one_m_context_suffix(model_id);
     // Only append [1M] for Claude-series upstream models
-    let is_claude_upstream = normalized.starts_with("claude-")
-        || normalized.starts_with("anthropic/");
+    let is_claude_upstream =
+        normalized.starts_with("claude-") || normalized.starts_with("anthropic/");
     if supports_1m && is_claude_upstream {
         format!("{normalized}{ONE_M_CONTEXT_SUFFIX}")
     } else {

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -3,9 +3,9 @@ use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::config::{atomic_write, delete_file, read_json_file, write_json_file};
 #[cfg(any(target_os = "macos", windows))]
 use crate::config::get_home_dir;
-use crate::config::{atomic_write, delete_file, read_json_file, write_json_file};
 use crate::database::Database;
 use crate::database::CLAUDE_DESKTOP_OFFICIAL_PROVIDER_ID;
 use crate::error::AppError;

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -965,21 +965,39 @@ impl RequestForwarder {
                 }
             }
         }
-        let resolved_claude_api_format = if adapter.name() == "Claude" {
+        let resolved_api_format: Option<String> = if adapter.name() == "Claude" {
             Some(
                 self.resolve_claude_api_format(provider, &mapped_body, is_copilot)
                     .await,
             )
+        } else if adapter.name() == "Codex" {
+            let fmt = super::providers::get_codex_api_format(provider);
+            if super::providers::codex_api_format_needs_transform(fmt) {
+                Some(fmt.to_string())
+            } else {
+                None
+            }
         } else {
             None
         };
-        let needs_transform = match resolved_claude_api_format.as_deref() {
-            Some(api_format) => super::providers::claude_api_format_needs_transform(api_format),
+        let needs_transform = match resolved_api_format.as_deref() {
+            Some(api_format) => {
+                if adapter.name() == "Claude" {
+                    super::providers::claude_api_format_needs_transform(api_format)
+                } else if adapter.name() == "Codex" {
+                    super::providers::codex_api_format_needs_transform(api_format)
+                } else {
+                    false
+                }
+            }
             None => adapter.needs_transform(provider),
         };
         let (effective_endpoint, passthrough_query) =
-            if needs_transform && adapter.name() == "Claude" {
-                let api_format = resolved_claude_api_format
+            if needs_transform && adapter.name() == "Codex" {
+                let api_format = resolved_api_format.as_deref().unwrap_or("openai_chat");
+                rewrite_codex_transform_endpoint(endpoint, api_format)
+            } else if needs_transform && adapter.name() == "Claude" {
+                let api_format = resolved_api_format
                     .as_deref()
                     .unwrap_or_else(|| super::providers::get_claude_api_format(provider));
                 rewrite_claude_transform_endpoint(endpoint, api_format, is_copilot, &mapped_body)
@@ -992,7 +1010,7 @@ impl RequestForwarder {
                 )
             };
 
-        let url = if matches!(resolved_claude_api_format.as_deref(), Some("gemini_native")) {
+        let url = if matches!(resolved_api_format.as_deref(), Some("gemini_native")) {
             super::gemini_url::resolve_gemini_native_url(
                 &base_url,
                 &effective_endpoint,
@@ -1006,8 +1024,14 @@ impl RequestForwarder {
 
         // 转换请求体（如果需要）
         let request_body = if needs_transform {
-            if adapter.name() == "Claude" {
-                let api_format = resolved_claude_api_format
+            if adapter.name() == "Codex" {
+                let api_format = resolved_api_format.as_deref().unwrap_or("openai_chat");
+                return Err(ProxyError::ConfigError(format!(
+                    "[Codex] api_format \"{}\" body transform not yet implemented (experimental)",
+                    api_format
+                )));
+            } else if adapter.name() == "Claude" {
+                let api_format = resolved_api_format
                     .as_deref()
                     .unwrap_or_else(|| super::providers::get_claude_api_format(provider));
                 super::providers::transform_claude_request_for_api_format(
@@ -1032,7 +1056,7 @@ impl RequestForwarder {
             app_type,
             provider,
             &effective_endpoint,
-            resolved_claude_api_format.as_deref(),
+            resolved_api_format.as_deref(),
             &filtered_body,
             self.session_client_provided,
         );
@@ -1234,7 +1258,7 @@ impl RequestForwarder {
             .and_then(|u| u.authority().map(|a| a.to_string()));
 
         let should_send_anthropic_headers = adapter.name() == "Claude"
-            && matches!(resolved_claude_api_format.as_deref(), Some("anthropic"));
+            && matches!(resolved_api_format.as_deref(), Some("anthropic"));
 
         // 预计算 anthropic-beta 值（仅 Claude）
         let anthropic_beta_value = if should_send_anthropic_headers {
@@ -1462,7 +1486,7 @@ impl RequestForwarder {
         let preserve_exact_header_case = should_preserve_exact_header_case(
             adapter.name(),
             provider,
-            resolved_claude_api_format.as_deref(),
+            resolved_api_format.as_deref(),
             is_copilot,
         );
 
@@ -1529,7 +1553,7 @@ impl RequestForwarder {
         let status = response.status();
 
         if status.is_success() {
-            Ok((response, resolved_claude_api_format))
+            Ok((response, resolved_api_format))
         } else {
             let status_code = status.as_u16();
             let body_text = String::from_utf8(response.bytes().await?.to_vec()).ok();
@@ -1881,6 +1905,38 @@ fn rewrite_claude_transform_endpoint(
 
     (rewritten, passthrough_query)
 }
+/// Codex 端点重写：将 OpenAI 格式的端点路径映射到目标 api_format。
+///
+/// Codex 原生格式为 openai_chat（/v1/chat/completions），无需重写。
+/// 其他格式需要将路径映射到对应的 API 路径。
+fn rewrite_codex_transform_endpoint(endpoint: &str, api_format: &str) -> (String, Option<String>) {
+    let (path, query) = split_endpoint_and_query(endpoint);
+    let passthrough_query = query.map(ToString::to_string);
+
+    // openai_chat 是 Codex 原生格式，不需要重写
+    // 如果是 openai_chat 请求但 path 是 /v1/responses，需要转换
+    let target_path = match api_format {
+        "openai_responses" if path == "/v1/chat/completions" => "/v1/responses",
+        "openai_chat" if path == "/v1/responses" => "/v1/chat/completions",
+        "anthropic" => "/v1/messages",
+        "gemini_native" => {
+            // Gemini 需要完整的 model 信息，这里只做路径映射
+            // URL 构建由 resolve_gemini_native_url 处理
+            return (endpoint.to_string(), passthrough_query);
+        }
+        _ => {
+            // 未知格式或不需重写，保持原路径
+            return (endpoint.to_string(), passthrough_query);
+        }
+    };
+
+    let rewritten = match passthrough_query.as_deref() {
+        Some(query) if !query.is_empty() => format!("{target_path}?{query}"),
+        _ => target_path.to_string(),
+    };
+
+    (rewritten, passthrough_query)
+}
 
 fn merge_query_params(base_query: Option<&str>, extra_param: Option<&str>) -> Option<String> {
     let mut params: Vec<String> = base_query
@@ -1940,7 +1996,7 @@ fn build_codex_oauth_session_headers(
 fn should_preserve_exact_header_case(
     adapter_name: &str,
     provider: &Provider,
-    resolved_claude_api_format: Option<&str>,
+    resolved_api_format: Option<&str>,
     is_copilot: bool,
 ) -> bool {
     if matches!(adapter_name, "Codex" | "Gemini") {
@@ -1951,7 +2007,7 @@ fn should_preserve_exact_header_case(
         return false;
     }
 
-    matches!(resolved_claude_api_format, None | Some("anthropic"))
+    matches!(resolved_api_format, None | Some("anthropic"))
 }
 
 fn is_streaming_request(endpoint: &str, body: &Value, headers: &axum::http::HeaderMap) -> bool {

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -82,6 +82,33 @@ pub fn claude_api_format_needs_transform(api_format: &str) -> bool {
     )
 }
 
+/// 获取 Codex 供应商的 API 格式
+///
+/// Codex 原生格式为 "openai_chat"，其他格式需要转换。
+/// 优先级：meta.apiFormat > 默认 "openai_chat"
+pub fn get_codex_api_format(provider: &Provider) -> &'static str {
+    if let Some(meta) = provider.meta.as_ref() {
+        if let Some(api_format) = meta.api_format.as_deref() {
+            return match api_format {
+                "anthropic" => "anthropic",
+                "openai_responses" => "openai_responses",
+                "gemini_native" => "gemini_native",
+                "openai_chat" => "openai_chat",
+                _ => "openai_chat",
+            };
+        }
+    }
+    "openai_chat"
+}
+
+/// Codex api_format 是否需要格式转换（非 openai_chat 均需转换）
+pub fn codex_api_format_needs_transform(api_format: &str) -> bool {
+    matches!(
+        api_format,
+        "anthropic" | "openai_responses" | "gemini_native"
+    )
+}
+
 fn is_reasoning_content_compatible_identifier(value: &str) -> bool {
     let value = value.to_ascii_lowercase();
     value.contains("moonshot") || value.contains("kimi") || value.contains("deepseek")

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -37,8 +37,8 @@ use serde::{Deserialize, Serialize};
 pub use adapter::ProviderAdapter;
 pub use auth::{AuthInfo, AuthStrategy};
 pub use claude::{
-    claude_api_format_needs_transform, get_claude_api_format,
-    transform_claude_request_for_api_format, ClaudeAdapter,
+    claude_api_format_needs_transform, codex_api_format_needs_transform, get_claude_api_format,
+    get_codex_api_format, transform_claude_request_for_api_format, ClaudeAdapter,
 };
 pub use codex::CodexAdapter;
 pub use gemini::GeminiAdapter;

--- a/src-tauri/src/usage_script.rs
+++ b/src-tauri/src/usage_script.rs
@@ -109,9 +109,20 @@ pub async fn execute_usage_script(
 
     // 6. 发送 HTTP 请求
     let response_data = send_http_request(&request, timeout_secs).await?;
-    let _content_type = response_data.content_type.as_deref();
 
-    // 7. 在独立作用域中执行 extractor（确保 Runtime/Context 在函数结束前释放）
+    // 7. 根据 Content-Type 判断响应格式
+    let is_html = response_data
+        .content_type
+        .as_deref()
+        .map(|ct| ct.to_lowercase().contains("text/html"))
+        .unwrap_or(false);
+    let is_json = response_data
+        .content_type
+        .as_deref()
+        .map(|ct| ct.to_lowercase().contains("application/json"))
+        .unwrap_or(true); // Content-Type 为空时默认按 JSON 处理（向后兼容）
+
+    // 8. 在独立作用域中执行 extractor（确保 Runtime/Context 在函数结束前释放）
     let result: Value = {
         let runtime = Runtime::new().map_err(|e| {
             AppError::localized(
@@ -147,15 +158,40 @@ pub async fn execute_usage_script(
                 )
             })?;
 
-            // 将响应数据转换为 JS 值
-            let response_js: rquickjs::Value =
+            // 根据响应格式准备 JS 参数
+            let response_js: rquickjs::Value = if is_html {
+                // HTML：直接作为字符串传入
+                rquickjs::String::from_str(ctx.clone(), &response_data.body)
+                    .map(|s| s.into_value())
+                    .map_err(|e| {
+                        AppError::localized(
+                            "usage_script.response_to_string_failed",
+                            format!("响应转 JS 字符串失败: {e}"),
+                            format!("Failed to convert response to JS string: {e}"),
+                        )
+                    })?
+            } else if is_json {
+                // JSON：解析为 JS 对象
                 ctx.json_parse(response_data.body.as_str()).map_err(|e| {
                     AppError::localized(
                         "usage_script.response_parse_failed",
                         format!("解析响应 JSON 失败: {e}"),
                         format!("Failed to parse response JSON: {e}"),
                     )
-                })?;
+                })?
+            } else {
+                return Err(AppError::localized(
+                    "usage_script.unsupported_content_type",
+                    format!(
+                        "不支持的响应格式: {}（仅支持 application/json 和 text/html）",
+                        response_data.content_type.as_deref().unwrap_or("unknown")
+                    ),
+                    format!(
+                        "Unsupported content type: {} (only application/json and text/html are supported)",
+                        response_data.content_type.as_deref().unwrap_or("unknown")
+                    ),
+                ));
+            };
 
             // 调用 extractor(response)
             let result_js: rquickjs::Value = extractor.call((response_js,)).map_err(|e| {
@@ -203,7 +239,7 @@ pub async fn execute_usage_script(
         })?
     }; // Runtime 和 Context 在这里被 drop
 
-    // 8. 验证返回值格式
+    // 9. 验证返回值格式
     validate_result(&result)?;
 
     Ok(result)
@@ -228,7 +264,10 @@ struct RequestConfig {
 }
 
 /// 发送 HTTP 请求
-async fn send_http_request(config: &RequestConfig, timeout_secs: u64) -> Result<HttpResponse, AppError> {
+async fn send_http_request(
+    config: &RequestConfig,
+    timeout_secs: u64,
+) -> Result<HttpResponse, AppError> {
     // 使用全局 HTTP 客户端（已包含代理配置）
     let client = crate::proxy::http_client::get();
     // 约束超时范围，防止异常配置导致长时间阻塞（最小 2 秒，最大 30 秒）
@@ -655,6 +694,58 @@ mod tests {
                     request_url
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_html_content_type_parsing() {
+        // 验证各种 HTML Content-Type 格式
+        let html_types = vec![
+            "text/html",
+            "text/html; charset=utf-8",
+            "text/html; charset=ISO-8859-1",
+            "TEXT/HTML", // 大小写不敏感
+        ];
+        for ct in html_types {
+            assert!(
+                ct.to_lowercase().contains("text/html"),
+                "{ct} should be recognized as HTML"
+            );
+        }
+
+        // 验证 JSON Content-Type 格式
+        let json_types = vec![
+            "application/json",
+            "application/json; charset=utf-8",
+            "APPLICATION/JSON",
+        ];
+        for ct in json_types {
+            assert!(
+                ct.to_lowercase().contains("application/json"),
+                "{ct} should be recognized as JSON"
+            );
+        }
+    }
+
+    #[test]
+    fn test_empty_content_type_defaults_to_json() {
+        // Content-Type 为空时，is_json 应为 true（向后兼容）
+        let content_type: Option<&str> = None;
+        let is_json = content_type
+            .map(|ct| ct.contains("application/json"))
+            .unwrap_or(true);
+        assert!(is_json, "Empty Content-Type should default to JSON");
+    }
+
+    #[test]
+    fn test_unsupported_content_type_detection() {
+        // 验证不支持的 Content-Type 不会被误判为 JSON 或 HTML
+        let unsupported_types = vec!["text/plain", "application/xml", "image/png"];
+        for ct in unsupported_types {
+            let is_html = ct.to_lowercase().contains("text/html");
+            let is_json = ct.to_lowercase().contains("application/json");
+            assert!(!is_html, "{ct} should not be HTML");
+            assert!(!is_json, "{ct} should not be JSON");
         }
     }
 }

--- a/src-tauri/src/usage_script.rs
+++ b/src-tauri/src/usage_script.rs
@@ -109,6 +109,7 @@ pub async fn execute_usage_script(
 
     // 6. 发送 HTTP 请求
     let response_data = send_http_request(&request, timeout_secs).await?;
+    let _content_type = response_data.content_type.as_deref();
 
     // 7. 在独立作用域中执行 extractor（确保 Runtime/Context 在函数结束前释放）
     let result: Value = {
@@ -148,7 +149,7 @@ pub async fn execute_usage_script(
 
             // 将响应数据转换为 JS 值
             let response_js: rquickjs::Value =
-                ctx.json_parse(response_data.as_str()).map_err(|e| {
+                ctx.json_parse(response_data.body.as_str()).map_err(|e| {
                     AppError::localized(
                         "usage_script.response_parse_failed",
                         format!("解析响应 JSON 失败: {e}"),
@@ -208,6 +209,13 @@ pub async fn execute_usage_script(
     Ok(result)
 }
 
+/// HTTP 响应结构
+#[derive(Debug)]
+struct HttpResponse {
+    content_type: Option<String>,
+    body: String,
+}
+
 /// 请求配置结构
 #[derive(Debug, serde::Deserialize)]
 struct RequestConfig {
@@ -220,7 +228,7 @@ struct RequestConfig {
 }
 
 /// 发送 HTTP 请求
-async fn send_http_request(config: &RequestConfig, timeout_secs: u64) -> Result<String, AppError> {
+async fn send_http_request(config: &RequestConfig, timeout_secs: u64) -> Result<HttpResponse, AppError> {
     // 使用全局 HTTP 客户端（已包含代理配置）
     let client = crate::proxy::http_client::get();
     // 约束超时范围，防止异常配置导致长时间阻塞（最小 2 秒，最大 30 秒）
@@ -259,6 +267,11 @@ async fn send_http_request(config: &RequestConfig, timeout_secs: u64) -> Result<
     })?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
     let text = resp.text().await.map_err(|e| {
         AppError::localized(
             "usage_script.read_response_failed",
@@ -284,7 +297,10 @@ async fn send_http_request(config: &RequestConfig, timeout_secs: u64) -> Result<
         ));
     }
 
-    Ok(text)
+    Ok(HttpResponse {
+        content_type,
+        body: text,
+    })
 }
 
 /// 验证脚本返回值（支持单对象或数组）

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,9 +60,9 @@
       }
     },
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM4MDI4QzlBNTczOTI4RTMKUldUaktEbFhtb3dDeUM5US9kT0FmdGR5Ti9vQzcwa2dTMlpibDVDUmQ2M0VGTzVOWnd0SGpFVlEK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQyMTg3MDk4MjZFNjQzNEIKUldSTFErWW1tSEFZUXROL2t0KzV0WHA1ZXRKWWdFYmZteEdIVEJ2d0lHUEt4TkhrQTdabldGTWEK",
       "endpoints": [
-        "https://github.com/farion1231/cc-switch/releases/latest/download/latest.json"
+        "https://github.com/ManLOK-Chu/cc-switch/releases/latest/download/latest.json"
       ]
     }
   }

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -3,6 +3,14 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { Download, Loader2 } from "lucide-react";
+import { FormLabel } from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import EndpointSpeedTest from "./EndpointSpeedTest";
 import { ApiKeySection, EndpointField, ModelInputWithFetch } from "./shared";
 import {
@@ -10,7 +18,7 @@ import {
   showFetchModelsError,
   type FetchedModel,
 } from "@/lib/api/model-fetch";
-import type { ProviderCategory } from "@/types";
+import type { ProviderCategory, ClaudeApiFormat } from "@/types";
 
 interface EndpointCandidate {
   url: string;
@@ -44,6 +52,10 @@ interface CodexFormFieldsProps {
   modelName?: string;
   onModelNameChange?: (model: string) => void;
 
+  // API Format
+  apiFormat?: ClaudeApiFormat;
+  onApiFormatChange?: (format: ClaudeApiFormat) => void;
+
   // Speed Test Endpoints
   speedTestEndpoints: EndpointCandidate[];
 }
@@ -70,6 +82,8 @@ export function CodexFormFields({
   shouldShowModelField = true,
   modelName = "",
   onModelNameChange,
+  apiFormat = "openai_chat",
+  onApiFormatChange,
   speedTestEndpoints,
 }: CodexFormFieldsProps) {
   const { t } = useTranslation();
@@ -187,6 +201,47 @@ export function CodexFormFields({
               : t("providerForm.modelHint", {
                   defaultValue: "💡 留空将使用供应商的默认模型",
                 })}
+          </p>
+        </div>
+      )}
+
+      {/* API 格式选择（实验性，仅非官方供应商显示） */}
+      {onApiFormatChange && category !== "official" && (
+        <div className="space-y-2">
+          <FormLabel htmlFor="codexApiFormat">
+            {t("providerForm.apiFormat", { defaultValue: "API 格式" })}
+          </FormLabel>
+          <Select value={apiFormat} onValueChange={onApiFormatChange}>
+            <SelectTrigger id="codexApiFormat" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="openai_chat">
+                {t("providerForm.apiFormatOpenAIChat", {
+                  defaultValue: "OpenAI Chat Completions (原生)",
+                })}
+              </SelectItem>
+              <SelectItem value="openai_responses">
+                {t("providerForm.apiFormatOpenAIResponses", {
+                  defaultValue: "OpenAI Responses API (需转换)",
+                })}
+              </SelectItem>
+              <SelectItem value="anthropic">
+                {t("providerForm.apiFormatAnthropic", {
+                  defaultValue: "Anthropic Messages (需转换)",
+                })}
+              </SelectItem>
+              <SelectItem value="gemini_native">
+                {t("providerForm.apiFormatGeminiNative", {
+                  defaultValue: "Gemini Native generateContent (需转换)",
+                })}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {t("providerForm.apiFormatHint", {
+              defaultValue: "选择供应商 API 的输入格式，默认 OpenAI Chat Completions",
+            })}
           </p>
         </div>
       )}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -355,8 +355,8 @@ function ProviderFormFull({
   });
 
   const [localApiFormat, setLocalApiFormat] = useState<ClaudeApiFormat>(() => {
-    if (appId !== "claude") return "anthropic";
-    return initialData?.meta?.apiFormat ?? "anthropic";
+    const defaultFormat = appId === "codex" ? "openai_chat" : "anthropic";
+    return initialData?.meta?.apiFormat ?? defaultFormat;
   });
 
   const handleApiFormatChange = useCallback((format: ClaudeApiFormat) => {
@@ -1209,7 +1209,7 @@ function ProviderFormFull({
           ? pricingConfig.pricingModelSource
           : undefined,
       apiFormat:
-        appId === "claude" && category !== "official"
+        (appId === "claude" || appId === "codex") && category !== "official"
           ? localApiFormat
           : undefined,
       apiKeyField:
@@ -1853,6 +1853,8 @@ function ProviderFormFull({
               shouldShowModelField={category !== "official"}
               modelName={codexModelName}
               onModelNameChange={handleCodexModelNameChange}
+              apiFormat={localApiFormat}
+              onApiFormatChange={handleApiFormatChange}
               speedTestEndpoints={speedTestEndpoints}
             />
           )}


### PR DESCRIPTION
## Summary

- 为 Codex 供应商表单添加 `api_format` 选择器，支持 4 种格式：`openai_chat`（原生）、`openai_responses`、`anthropic`、`gemini_native`
- 后端新增 `get_codex_api_format()` 和 `codex_api_format_needs_transform()` 函数
- `forwarder.rs` 扩展 api_format 解析逻辑以涵盖 Codex 适配器，包括端点重写（`rewrite_codex_transform_endpoint`）
- 非原生格式的请求体转换暂未实现，返回 `ConfigError` — 此功能为实验性

## Behavior

| api_format | Behavior |
|---|---|
| `openai_chat` | 直通（原生，完全可用） |
| `openai_responses` | 端点重写已完成，请求体转换返回 ConfigError |
| `anthropic` | 端点重写已完成，请求体转换返回 ConfigError |
| `gemini_native` | 端点重写已完成，请求体转换返回 ConfigError |

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `cargo check` 通过
- [x] `cargo clippy --all-targets` 无警告
- [x] `cargo fmt --check` 通过
- [x] `cargo test` 通过（1129 passed, 1 个已存在的端口占用失败与本次改动无关）