### PR TITLE
修复 Completions转Anthropic时不记录实际返回模型、Input token记录错误问题

### DIFF
--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -333,7 +333,7 @@ async fn handle_claude_transform(
         let usage_collector = if usage_logging_enabled(state) {
             let state = state.clone();
             let provider_id = ctx.provider.id.clone();
-            let model = ctx.request_model.clone();
+            let request_model = ctx.request_model.clone();
             let status_code = status.as_u16();
             let start_time = ctx.start_time;
             let session_id = ctx.session_id.clone();
@@ -343,11 +343,15 @@ async fn handle_claude_transform(
                 Some(claude_stream_usage_event_filter),
                 move |events, first_token_ms| {
                     if let Some(usage) = TokenUsage::from_claude_stream_events(&events) {
+                        let model = usage
+                            .model
+                            .clone()
+                            .unwrap_or(request_model.clone());
                         let latency_ms = start_time.elapsed().as_millis() as u64;
                         let state = state.clone();
                         let provider_id = provider_id.clone();
-                        let model = model.clone();
                         let session_id = session_id.clone();
+                        let request_model = request_model.clone();
 
                         tokio::spawn(async move {
                             log_usage(
@@ -355,7 +359,7 @@ async fn handle_claude_transform(
                                 &provider_id,
                                 "claude",
                                 &model,
-                                &model,
+                                &request_model,
                                 usage,
                                 latency_ms,
                                 first_token_ms,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -343,10 +343,7 @@ async fn handle_claude_transform(
                 Some(claude_stream_usage_event_filter),
                 move |events, first_token_ms| {
                     if let Some(usage) = TokenUsage::from_claude_stream_events(&events) {
-                        let model = usage
-                            .model
-                            .clone()
-                            .unwrap_or(request_model.clone());
+                        let model = usage.model.clone().unwrap_or(request_model.clone());
                         let latency_ms = start_time.elapsed().as_millis() as u64;
                         let state = state.clone();
                         let provider_id = provider_id.clone();

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -102,11 +102,7 @@ const INFINITE_WHITESPACE_THRESHOLD: usize = 500;
 fn build_anthropic_usage_json(usage: &Usage) -> Value {
     // OpenAI prompt_tokens 含缓存，Anthropic input_tokens 不含，需减去
     let cached = extract_cache_read_tokens(usage).unwrap_or(0);
-    let input_tokens = if usage.prompt_tokens > cached {
-        usage.prompt_tokens - cached
-    } else {
-        usage.prompt_tokens
-    };
+    let input_tokens = usage.prompt_tokens.saturating_sub(cached);
     let mut usage_json = json!({
         "input_tokens": input_tokens,
         "output_tokens": usage.completion_tokens
@@ -231,11 +227,7 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                             });
                                             if let Some(u) = &chunk.usage {
                                                 let cached = extract_cache_read_tokens(u).unwrap_or(0);
-                                                let input = if u.prompt_tokens > cached {
-                                                    u.prompt_tokens - cached
-                                                } else {
-                                                    u.prompt_tokens
-                                                };
+                                                let input = u.prompt_tokens.saturating_sub(cached);
                                                 start_usage["input_tokens"] = json!(input);
                                                 if cached > 0 {
                                                     start_usage["cache_read_input_tokens"] = json!(cached);

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -1027,7 +1027,7 @@ mod tests {
             message_delta
                 .pointer("/usage/input_tokens")
                 .and_then(|v| v.as_u64()),
-            Some(13312)
+            Some(13212)
         );
         assert_eq!(
             message_delta

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -100,11 +100,18 @@ struct ToolBlockState {
 const INFINITE_WHITESPACE_THRESHOLD: usize = 500;
 
 fn build_anthropic_usage_json(usage: &Usage) -> Value {
+    // OpenAI prompt_tokens 含缓存，Anthropic input_tokens 不含，需减去
+    let cached = extract_cache_read_tokens(usage).unwrap_or(0);
+    let input_tokens = if usage.prompt_tokens > cached {
+        usage.prompt_tokens - cached
+    } else {
+        usage.prompt_tokens
+    };
     let mut usage_json = json!({
-        "input_tokens": usage.prompt_tokens,
+        "input_tokens": input_tokens,
         "output_tokens": usage.completion_tokens
     });
-    if let Some(cached) = extract_cache_read_tokens(usage) {
+    if cached > 0 {
         usage_json["cache_read_input_tokens"] = json!(cached);
     }
     if let Some(created) = usage.cache_creation_input_tokens {
@@ -223,8 +230,14 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                                 "output_tokens": 0
                                             });
                                             if let Some(u) = &chunk.usage {
-                                                start_usage["input_tokens"] = json!(u.prompt_tokens);
-                                                if let Some(cached) = extract_cache_read_tokens(u) {
+                                                let cached = extract_cache_read_tokens(u).unwrap_or(0);
+                                                let input = if u.prompt_tokens > cached {
+                                                    u.prompt_tokens - cached
+                                                } else {
+                                                    u.prompt_tokens
+                                                };
+                                                start_usage["input_tokens"] = json!(input);
+                                                if cached > 0 {
                                                     start_usage["cache_read_input_tokens"] = json!(cached);
                                                 }
                                                 if let Some(created) = u.cache_creation_input_tokens {


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->
修复 completions→claude 格式转换路径（OpenCode-Zen 等 OpenAI 兼容供应商）的两个问题：

  1. 流式响应未记录实际命中模型：usage_collector 将请求模型同时作为响应模型传入计费日志，导致供应商返回的实际模型（如
  deepseek-v4-flash）未被记录。改为从上游 SSE 事件中提取实际响应模型。
  2. input 与 cache_read 重复计费：OpenAI 格式 prompt_tokens 包含缓存部分，Anthropic 格式 input_tokens
  不含，转换时直接透传导致缓存 token 被重复计入 input 和 cache_read。修复为 input_tokens = prompt_tokens -
  cached_tokens，并对非标准供应商做了兼容保护。

> 2026-05-26 opencode go接入的DeepSeek到claude code依旧有此问题，联动#3159 提的issue，现在还原撤销的重复计费修正
## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->
Fixes #2773

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

修改前：
<img width="1514" height="698" alt="image" src="https://github.com/user-attachments/assets/17adf360-c734-4360-8506-ffe77294a590" />

修改后：
<img width="1575" height="398" alt="image" src="https://github.com/user-attachments/assets/22ddde29-213c-476d-acf9-bf0caf98a797" />

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
