### PR TITLE
fix(ui): suppress default browser context menu

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,6 +26,24 @@ try {
   // 忽略平台检测失败
 }
 
+// 禁用默认浏览器右键菜单；在可编辑区域保留原生编辑菜单。
+document.addEventListener("contextmenu", (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    event.preventDefault();
+    return;
+  }
+
+  const editableTarget = target.closest(
+    "input, textarea, select, [contenteditable='true'], .cm-editor",
+  );
+  if (editableTarget) {
+    return;
+  }
+
+  event.preventDefault();
+});
+
 // 配置加载错误payload类型
 interface ConfigLoadErrorPayload {
   path?: string;


### PR DESCRIPTION
Prevent the WebView/browser context menu from appearing on regular app surfaces, which can expose browser-like actions such as Back, Forward, Stop, and Reload in the desktop UI.

Keep native context menus enabled for editable controls and CodeMirror editors so copy, paste, and text editing actions remain available.

## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
