### PR TITLE
fix(usage): reduce price input step to 0.0001 for sub-cent precision

### DIFF
--- a/src/components/usage/PricingEditModal.tsx
+++ b/src/components/usage/PricingEditModal.tsx
@@ -16,6 +16,8 @@ interface PricingEditModalProps {
   onClose: () => void;
 }
 
+const PRICE_INPUT_STEP = "0.0001";
+
 export function PricingEditModal({
   open,
   model,
@@ -151,7 +153,7 @@ export function PricingEditModal({
           <Input
             id="inputCost"
             type="number"
-            step="0.01"
+            step={PRICE_INPUT_STEP}
             min="0"
             value={formData.inputCost}
             onChange={(e) =>
@@ -168,7 +170,7 @@ export function PricingEditModal({
           <Input
             id="outputCost"
             type="number"
-            step="0.01"
+            step={PRICE_INPUT_STEP}
             min="0"
             value={formData.outputCost}
             onChange={(e) =>
@@ -188,7 +190,7 @@ export function PricingEditModal({
           <Input
             id="cacheReadCost"
             type="number"
-            step="0.01"
+            step={PRICE_INPUT_STEP}
             min="0"
             value={formData.cacheReadCost}
             onChange={(e) =>
@@ -208,7 +210,7 @@ export function PricingEditModal({
           <Input
             id="cacheCreationCost"
             type="number"
-            step="0.01"
+            step={PRICE_INPUT_STEP}
             min="0"
             value={formData.cacheCreationCost}
             onChange={(e) =>

--- a/tests/components/PricingEditModal.test.tsx
+++ b/tests/components/PricingEditModal.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PricingEditModal } from "@/components/usage/PricingEditModal";
+import type { ModelPricing } from "@/types/usage";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | { defaultValue?: string }) =>
+      typeof options === "string" ? options : options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/query/usage", () => ({
+  useUpdateModelPricing: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/components/common/FullScreenPanel", () => ({
+  FullScreenPanel: ({
+    children,
+    footer,
+  }: {
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) => (
+    <div>
+      {children}
+      {footer}
+    </div>
+  ),
+}));
+
+const model: ModelPricing = {
+  modelId: "deepseek-v4",
+  displayName: "DeepSeek V4",
+  inputCostPerMillion: "1",
+  outputCostPerMillion: "3",
+  cacheReadCostPerMillion: "0.0028",
+  cacheCreationCostPerMillion: "0",
+};
+
+const PRICE_FIELDS = [
+  { id: "inputCost", label: "输入成本" },
+  { id: "outputCost", label: "输出成本" },
+  { id: "cacheReadCost", label: "缓存读取成本" },
+  { id: "cacheCreationCost", label: "缓存写入成本" },
+] as const;
+
+describe("PricingEditModal", () => {
+  it("all price inputs have step=0.0001", () => {
+    render(<PricingEditModal open model={model} onClose={() => {}} />);
+
+    for (const { id } of PRICE_FIELDS) {
+      const input = screen.getByLabelText(/每百万 tokens/ as unknown as string, {
+        selector: `#${id}`,
+      }) as HTMLInputElement;
+      expect(input).toHaveAttribute("step", "0.0001");
+    }
+  });
+
+  it("accepts precise cache read cost like 0.0028", () => {
+    render(<PricingEditModal open model={model} onClose={() => {}} />);
+
+    const cacheReadInput = document.getElementById(
+      "cacheReadCost",
+    ) as HTMLInputElement;
+    expect(cacheReadInput.value).toBe("0.0028");
+    expect(cacheReadInput.checkValidity()).toBe(true);
+  });
+
+  it("allows user to input sub-cent prices via change event", () => {
+    render(
+      <PricingEditModal open model={model} onClose={() => {}} isNew />,
+    );
+
+    const cacheReadInput = document.getElementById(
+      "cacheReadCost",
+    ) as HTMLInputElement;
+
+    fireEvent.change(cacheReadInput, { target: { value: "0.0015" } });
+    expect(cacheReadInput.value).toBe("0.0015");
+  });
+});


### PR DESCRIPTION
## Summary
- Reduce all price input `step` from `0.01` to `0.0001` to allow sub-cent precision (e.g. DeepSeek cache read cost $0.0028/million tokens)
- Extract step value to `PRICE_INPUT_STEP` constant
- Add tests covering step attribute on all four price fields and precise value input

Closes #2503

## Test plan
- [x] `npx vitest run tests/components/PricingEditModal.test.tsx` — 3/3 passed
- [ ] Manual: open pricing edit modal, verify all price fields accept values like `0.0028`