### PR TITLE
fix(terminal): Ghostty opens clean window instead of cloning existing tabs

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -950,7 +950,7 @@ exec bash --norc --noprofile
         "warp" => launch_macos_warp(&script_file),
         "alacritty" => launch_macos_open_app("Alacritty", &script_file, true),
         "kitty" => launch_macos_open_app("kitty", &script_file, false),
-        "ghostty" => launch_macos_open_app("Ghostty", &script_file, true),
+        "ghostty" => launch_macos_ghostty(&script_file),
         "wezterm" => launch_macos_open_app("WezTerm", &script_file, true),
         "kaku" => launch_macos_open_app("Kaku", &script_file, true),
         _ => launch_macos_terminal_app(&script_file), // "terminal" or default
@@ -1061,7 +1061,37 @@ fn launch_macos_iterm2(script_file: &std::path::Path) -> Result<(), String> {
     Ok(())
 }
 
-/// macOS: 使用 open -a 启动支持 --args 参数的终端（Alacritty/Kitty/Ghostty）
+/// macOS: Ghostty — use --quit-after-last-window-closed to avoid cloning existing tabs
+#[cfg(target_os = "macos")]
+fn launch_macos_ghostty(script_file: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+
+    let output = Command::new("open")
+        .args([
+            "-na",
+            "Ghostty",
+            "--args",
+            "--quit-after-last-window-closed=true",
+            "-e",
+            "bash",
+        ])
+        .arg(script_file)
+        .output()
+        .map_err(|e| format!("启动 Ghostty 失败: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Ghostty 启动失败 (exit code: {:?}): {}",
+            output.status.code(),
+            stderr
+        ));
+    }
+
+    Ok(())
+}
+
+/// macOS: 使用 open -na 启动支持 --args 参数的终端（Alacritty/Kitty/WezTerm/Kaku）
 #[cfg(target_os = "macos")]
 fn launch_macos_open_app(
     app_name: &str,
@@ -1071,7 +1101,7 @@ fn launch_macos_open_app(
     use std::process::Command;
 
     let mut cmd = Command::new("open");
-    cmd.arg("-a").arg(app_name).arg("--args");
+    cmd.arg("-na").arg(app_name).arg("--args");
 
     if use_e_flag {
         cmd.arg("-e");
@@ -1436,7 +1466,7 @@ read -n 1 -s
             "warp" => launch_macos_warp(&script_file),
             "alacritty" => launch_macos_open_app("Alacritty", &script_file, true),
             "kitty" => launch_macos_open_app("kitty", &script_file, false),
-            "ghostty" => launch_macos_open_app("Ghostty", &script_file, true),
+            "ghostty" => launch_macos_ghostty(&script_file),
             "wezterm" => launch_macos_open_app("WezTerm", &script_file, true),
             "kaku" => launch_macos_open_app("Kaku", &script_file, true),
             _ => launch_macos_terminal_app(&script_file),


### PR DESCRIPTION
## Summary

- Add dedicated `launch_macos_ghostty` with `--quit-after-last-window-closed=true` so Ghostty opens a single clean window running claude, instead of cloning all existing tabs
- Change `launch_macos_open_app` from `open -a` to `open -na` so other terminals (Alacritty/Kitty/WezTerm/Kaku) correctly open a new window when already running

## Root Cause

- `open -a Ghostty --args ...`: when Ghostty is already running, macOS silently ignores `--args` — no new window, no claude
- `open -na Ghostty --args ...`: forces a new instance but clones all existing tabs into it
- Fix: use Ghostty-specific args (`--quit-after-last-window-closed=true -e bash <script>`) consistent with the existing `launch_ghostty` in `session_manager/terminal/mod.rs`

## Test Plan

- [x] Ghostty already running → click "Open Terminal" → single clean window with claude launches
- [x] `cargo check` passes

Closes #2798