### PR TITLE
修复获取模型列表失败的bug

### DIFF
--- a/src-tauri/src/services/model_fetch.rs
+++ b/src-tauri/src/services/model_fetch.rs
@@ -75,40 +75,52 @@ pub async fn fetch_models(
         {
             Ok(r) => r,
             Err(e) => {
-                return Err(format!("Request failed: {e}"));
+                log::debug!("[ModelFetch] Request error for {url}: {e}");
+                last_err = Some(format!("Request failed: {e}"));
+                continue;
             }
         };
 
         let status = response.status();
 
         if status.is_success() {
-            let resp: ModelsResponse = response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse response: {e}"))?;
+            let body = response.text().await.unwrap_or_default();
+            match serde_json::from_str::<ModelsResponse>(&body) {
+                Ok(resp) => {
+                    let mut models: Vec<FetchedModel> = resp
+                        .data
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|m| FetchedModel {
+                            id: m.id,
+                            owned_by: m.owned_by,
+                        })
+                        .collect();
 
-            let mut models: Vec<FetchedModel> = resp
-                .data
-                .unwrap_or_default()
-                .into_iter()
-                .map(|m| FetchedModel {
-                    id: m.id,
-                    owned_by: m.owned_by,
-                })
-                .collect();
-
-            models.sort_by(|a, b| a.id.cmp(&b.id));
-            return Ok(models);
+                    models.sort_by(|a, b| a.id.cmp(&b.id));
+                    return Ok(models);
+                }
+                Err(e) => {
+                    log::debug!("[ModelFetch] Parse error for {url}: {e}");
+                    last_err = Some(format!(
+                        "Failed to parse response: {}",
+                        truncate_body(body)
+                    ));
+                    continue;
+                }
+            }
         }
 
-        if status == StatusCode::NOT_FOUND || status == StatusCode::METHOD_NOT_ALLOWED {
+        // 401/403 说明 API Key 有问题，再试其他候选也没用，直接退出
+        if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
             let body = truncate_body(response.text().await.unwrap_or_default());
-            last_err = Some(format!("HTTP {status}: {body}"));
-            continue;
+            return Err(format!("HTTP {status}: {body}"));
         }
 
         let body = truncate_body(response.text().await.unwrap_or_default());
-        return Err(format!("HTTP {status}: {body}"));
+        log::debug!("[ModelFetch] Non-success for {url}: HTTP {status}");
+        last_err = Some(format!("HTTP {status}: {body}"));
+        // 继续尝试下一个候选
     }
 
     Err(format!(


### PR DESCRIPTION
问题描述
在"编辑供应商"页面，点击"获取模型列表"按钮时报错，提示"该供应商不支持获取模型列表"。

触发条件
当供应商的 Base URL 带有 Anthropic 兼容子路径（例如 https://api.xiaomimimo.com/anthropic）时触发。这类 URL 中 /anthropic 只是路由后缀，实际的 /v1/models 接口存在于根路径下。

复现步骤
添加一个 Base URL 为 https://xxx.com/anthropic 的第三方供应商
填入有效 API Key
点击"获取模型列表"
观察：报错"该供应商不支持获取模型列表"

原因分析
候选 URL 生成了，但 fetch_models 函数的错误处理过于激进，导致第一个候选失败后直接退出，不尝试后续候选。

修复方案
思路：将"只要失败就退出"改为"只要不是认证错误（401/403）就继续尝试下一个候选"，让兜底候选 URL 真正生效。
修改文件：src-tauri/src/services/model_fetch.rs，函数 fetch_models

