### PR TITLE
fix(proxy): convert upstream errors to Anthropic format in transform path

### DIFF
--- a/src-tauri/src/proxy/error.rs
+++ b/src-tauri/src/proxy/error.rs
@@ -204,3 +204,218 @@ pub fn categorize_error(error: &reqwest::Error) -> ErrorCategory {
         ErrorCategory::Retryable
     }
 }
+
+/// Convert a ProxyError into the Anthropic error format when the response
+/// is destined for a Claude Code client that went through a format-transform
+/// path (openai_chat / openai_responses / gemini_native).
+///
+/// Claude Code expects errors in Anthropic shape:
+///
+/// ```json
+/// {"type": "error", "error": {"type": "<error_type>", "message": "..."}}
+/// ```
+///
+/// Without this mapping, upstream OpenAI/LiteLLM error bodies like:
+///
+/// ```json
+/// {"error": {"message": "...", "type": "...", "code": "500"}}
+/// ```
+///
+/// are passed through verbatim, which Claude Code cannot parse correctly.
+/// This can cause Claude Code to hang or retry indefinitely because it never
+/// receives a properly structured error response.
+pub fn map_proxy_error_to_anthropic(error: ProxyError) -> ProxyError {
+    let (status, error_type, message) = match &error {
+        ProxyError::UpstreamError {
+            status,
+            body: Some(body_str),
+        } => {
+            let error_type = if *status >= 500 {
+                "api_error"
+            } else {
+                "invalid_request_error"
+            };
+            let message = extract_openai_error_message(body_str).unwrap_or_else(|| body_str.clone());
+            (*status, error_type.to_string(), message)
+        }
+        ProxyError::UpstreamError { status, body: None } => {
+            let error_type = if *status >= 500 {
+                "api_error"
+            } else {
+                "invalid_request_error"
+            };
+            (
+                *status,
+                error_type.to_string(),
+                format!("Upstream error (status {})", status),
+            )
+        }
+        ProxyError::Timeout(msg) => (504, "timeout_error".to_string(), msg.clone()),
+        ProxyError::StreamIdleTimeout(secs) => (
+            504,
+            "timeout_error".to_string(),
+            format!("Stream idle timeout: {}s without data", secs),
+        ),
+        ProxyError::ForwardFailed(msg) => (502, "api_error".to_string(), msg.clone()),
+        ProxyError::NoAvailableProvider
+        | ProxyError::AllProvidersCircuitOpen
+        | ProxyError::NoProvidersConfigured => (
+            503,
+            "api_error".to_string(),
+            "No available provider".to_string(),
+        ),
+        ProxyError::MaxRetriesExceeded => (
+            503,
+            "api_error".to_string(),
+            "Max retries exceeded".to_string(),
+        ),
+        ProxyError::TransformError(msg) => (
+            500,
+            "api_error".to_string(),
+            format!("Transform error: {}", msg),
+        ),
+        ProxyError::AuthError(msg) => (401, "authentication_error".to_string(), msg.clone()),
+        ProxyError::ConfigError(msg) | ProxyError::InvalidRequest(msg) => {
+            (400, "invalid_request_error".to_string(), msg.clone())
+        }
+        _ => (500, "api_error".to_string(), error.to_string()),
+    };
+
+    let anthropic_body = json!({
+        "type": "error",
+        "error": {
+            "type": error_type,
+            "message": message
+        }
+    });
+    ProxyError::UpstreamError {
+        status,
+        body: Some(serde_json::to_string(&anthropic_body).unwrap_or_else(|_| message)),
+    }
+}
+
+/// Try to extract a human-readable message from an OpenAI-format error body.
+///
+/// OpenAI/LiteLLM errors look like:
+/// ```json
+/// {"error": {"message": "...", "type": "...", "code": "500"}}
+/// ```
+fn extract_openai_error_message(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    let message = v.get("error")?.get("message")?.as_str()?;
+    Some(message.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upstream_500_maps_to_anthropic_api_error() {
+        let openai_body = r#"{"error":{"message":"Internal Server Error","type":"server_error","code":"500"}}"#;
+        let error = ProxyError::UpstreamError {
+            status: 500,
+            body: Some(openai_body.to_string()),
+        };
+        let result = map_proxy_error_to_anthropic(error);
+        match result {
+            ProxyError::UpstreamError { status, body } => {
+                assert_eq!(status, 500);
+                let v: serde_json::Value = serde_json::from_str(body.unwrap().as_str()).unwrap();
+                assert_eq!(v["type"], "error");
+                assert_eq!(v["error"]["type"], "api_error");
+                assert_eq!(v["error"]["message"], "Internal Server Error");
+            }
+            _ => panic!("Expected UpstreamError"),
+        }
+    }
+
+    #[test]
+    fn test_upstream_400_maps_to_anthropic_invalid_request() {
+        let openai_body = r#"{"error":{"message":"Invalid model name","type":"invalid_request_error","code":"400"}}"#;
+        let error = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(openai_body.to_string()),
+        };
+        let result = map_proxy_error_to_anthropic(error);
+        match result {
+            ProxyError::UpstreamError { status, body } => {
+                assert_eq!(status, 400);
+                let v: serde_json::Value = serde_json::from_str(body.unwrap().as_str()).unwrap();
+                assert_eq!(v["type"], "error");
+                assert_eq!(v["error"]["type"], "invalid_request_error");
+                assert_eq!(v["error"]["message"], "Invalid model name");
+            }
+            _ => panic!("Expected UpstreamError"),
+        }
+    }
+
+    #[test]
+    fn test_timeout_maps_to_anthropic_timeout_error() {
+        let error = ProxyError::Timeout("request timed out".to_string());
+        let result = map_proxy_error_to_anthropic(error);
+        match result {
+            ProxyError::UpstreamError { status, body } => {
+                assert_eq!(status, 504);
+                let v: serde_json::Value = serde_json::from_str(body.unwrap().as_str()).unwrap();
+                assert_eq!(v["type"], "error");
+                assert_eq!(v["error"]["type"], "timeout_error");
+                assert_eq!(v["error"]["message"], "request timed out");
+            }
+            _ => panic!("Expected UpstreamError"),
+        }
+    }
+
+    #[test]
+    fn test_extract_openai_error_message() {
+        let body = r#"{"error":{"message":"Invalid tool_choice","type":"invalid_request_error","code":"400"}}"#;
+        assert_eq!(
+            extract_openai_error_message(body),
+            Some("Invalid tool_choice".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_openai_error_message_non_json() {
+        assert_eq!(extract_openai_error_message("not json"), None);
+    }
+
+    #[test]
+    fn test_upstream_no_body_uses_default_message() {
+        let error = ProxyError::UpstreamError {
+            status: 502,
+            body: None,
+        };
+        let result = map_proxy_error_to_anthropic(error);
+        match result {
+            ProxyError::UpstreamError { status, body } => {
+                assert_eq!(status, 502);
+                let v: serde_json::Value = serde_json::from_str(body.unwrap().as_str()).unwrap();
+                assert_eq!(v["type"], "error");
+                assert_eq!(v["error"]["type"], "api_error");
+                assert!(v["error"]["message"].as_str().unwrap().contains("502"));
+            }
+            _ => panic!("Expected UpstreamError"),
+        }
+    }
+
+    #[test]
+    fn test_litellm_tool_choice_error_maps_correctly() {
+        let litellm_body = r#"{"error":{"message":"litellm.APIConnectionError: Invalid tool_choice, tool_choice={'type': 'tool', 'name': 'web_search'}","type":null,"param":null,"code":"500"}}"#;
+        let error = ProxyError::UpstreamError {
+            status: 500,
+            body: Some(litellm_body.to_string()),
+        };
+        let result = map_proxy_error_to_anthropic(error);
+        match result {
+            ProxyError::UpstreamError { status, body } => {
+                assert_eq!(status, 500);
+                let v: serde_json::Value = serde_json::from_str(body.unwrap().as_str()).unwrap();
+                assert_eq!(v["type"], "error");
+                assert_eq!(v["error"]["type"], "api_error");
+                assert!(v["error"]["message"].as_str().unwrap().contains("Invalid tool_choice"));
+            }
+            _ => panic!("Expected UpstreamError"),
+        }
+    }
+}

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -26,6 +26,7 @@ use super::{
         strip_entity_headers_for_rebuilt_body, strip_hop_by_hop_response_headers,
         usage_logging_enabled, SseUsageCollector,
     },
+    error::map_proxy_error_to_anthropic,
     server::ProxyState,
     sse::{strip_sse_field, take_sse_block},
     types::*,
@@ -165,6 +166,12 @@ async fn handle_messages_for_app(
                 ctx.provider = provider;
             }
             log_forward_error(&state, &ctx, is_stream, &err.error);
+
+            let adapter = get_adapter(&app_type);
+            let needs_transform = adapter.needs_transform(&ctx.provider);
+            if needs_transform {
+                return Err(map_proxy_error_to_anthropic(err.error));
+            }
             return Err(err.error);
         }
     };


### PR DESCRIPTION
## Summary

When cc-switch proxies requests with `needs_transform=true` (e.g., OpenAI-format providers used through Claude Code), upstream errors are forwarded verbatim in OpenAI format. Claude Code cannot parse these non-Anthropic error responses, causing it to silently retry indefinitely — resulting in tool execution hangs.

## Changes

- Added `map_proxy_error_to_anthropic()` in `src-tauri/src/proxy/error.rs` to convert upstream error responses into Anthropic's expected `{"type":"error","error":{"type":"...","message":"..."}}` format
- Added `extract_openai_error_message()` helper to parse OpenAI-style error bodies
- Applied the conversion in `src-tauri/src/proxy/handlers.rs` when `needs_transform=true` and the forwarder returns an error
- Added 7 unit tests covering various error format scenarios

## Test Plan

- [x] `cargo test` — all 7 new tests pass
- [x] Built release binary and live-tested with Claude Code + LiteLLM proxy
- [x] Verified: tool_choice conversion works (existing fix by author)
- [x] Verified: upstream errors now properly surfaced to Claude Code instead of hanging
- [x] Verified: streaming responses unaffected