### PR TITLE
[codex] Fix Codex CLI detection for mise-managed Node installs

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -560,6 +560,27 @@ fn tool_executable_candidates(tool: &str, dir: &Path) -> Vec<std::path::PathBuf>
     }
 }
 
+fn extend_mise_node_search_paths(paths: &mut Vec<std::path::PathBuf>, home: &Path) {
+    if home.as_os_str().is_empty() {
+        return;
+    }
+
+    let mise_base = home.join(".local/share/mise");
+    push_unique_path(paths, mise_base.join("shims"));
+
+    let node_installs = mise_base.join("installs").join("node");
+    if node_installs.exists() {
+        if let Ok(entries) = std::fs::read_dir(&node_installs) {
+            for entry in entries.flatten() {
+                let bin_path = entry.path().join("bin");
+                if bin_path.exists() {
+                    push_unique_path(paths, bin_path);
+                }
+            }
+        }
+    }
+}
+
 /// 扫描常见路径查找 CLI
 fn scan_cli_version(tool: &str) -> (Option<String>, Option<String>) {
     use std::process::Command;
@@ -573,6 +594,7 @@ fn scan_cli_version(tool: &str) -> (Option<String>, Option<String>) {
         push_unique_path(&mut search_paths, home.join(".npm-global/bin"));
         push_unique_path(&mut search_paths, home.join("n/bin"));
         push_unique_path(&mut search_paths, home.join(".volta/bin"));
+        extend_mise_node_search_paths(&mut search_paths, &home);
     }
 
     #[cfg(target_os = "macos")]
@@ -1694,6 +1716,22 @@ mod tests {
             .filter(|path| path.as_path() == Path::new("/home/tester/.bun/bin"))
             .count();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn mise_node_search_paths_include_shims_and_installed_node_bins() {
+        let temp = tempfile::tempdir().expect("temp dir should be created");
+        let home = temp.path();
+        let node_bin = home
+            .join(".local/share/mise/installs/node/25.8.0")
+            .join("bin");
+        std::fs::create_dir_all(&node_bin).expect("node bin should be created");
+
+        let mut paths = Vec::new();
+        extend_mise_node_search_paths(&mut paths, home);
+
+        assert!(paths.contains(&home.join(".local/share/mise/shims")));
+        assert!(paths.contains(&node_bin));
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary

Fix false-negative local Codex CLI detection in CC Switch when Codex is installed through a mise-managed Node runtime.

In this setup, `codex --version` works in the user's terminal, but CC Switch may show `not installed or not executable` in Settings -> About -> Local Environment Check.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/2fed74b5-e0d3-4c3f-9612-4c97d0e9c473" />


## Problem

Tauri GUI apps often start with a reduced PATH compared with an interactive terminal session. When direct execution of `codex --version` fails, CC Switch falls back to scanning common CLI install locations.

Before this change, the fallback scan covered locations such as:

- `~/.local/bin`
- `~/.npm-global/bin`
- `~/n/bin`
- Volta
- fnm
- nvm

However, it did not cover mise-managed Node installs, such as:

- `~/.local/share/mise/shims`
- `~/.local/share/mise/installs/node/<version>/bin`

As a result, Codex could be installed and usable from the terminal while still being reported as unavailable by CC Switch.

## Changes

- Add mise Node search path support to the local CLI fallback scanner:
  - `~/.local/share/mise/shims`
  - `~/.local/share/mise/installs/node/*/bin`
- Reuse the existing path de-duplication helper.
- Add a unit test covering mise shims and installed Node bin directories.

## Validation

Ran:

```bash
cargo fmt
cargo test commands::misc::tests
```

Result:

- 14 passed
- 0 failed

Manual verification:

- Codex is installed under a mise-managed Node directory.
- After the fix, CC Switch detects the local Codex version correctly in the About page environment check.

## Risk

Low.

This change only extends fallback CLI search paths. It does not change:

- version parsing
- remote latest-version checks
- frontend rendering
- provider switching
- config read/write behavior
- WSL detection behavior

## Scope

Affects local tool version detection fallback logic on non-Windows platforms.

Expected impact:

- Codex installed via mise is now detected correctly.
- Existing Claude, Gemini, OpenCode, nvm, fnm, Volta, and standard PATH detection behavior remains unchanged.
