### PR TITLE
Fix race condition in useEffect hooks and type assertion bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -333,34 +333,42 @@ function App() {
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
+    let active = true;
 
     const setupListener = async () => {
       try {
-        unsubscribe = await providersApi.onSwitched(
+        const off = await providersApi.onSwitched(
           async (event: ProviderSwitchEvent) => {
             if (event.appType === activeApp) {
               await refetch();
             }
           },
         );
+        if (!active) {
+          off();
+          return;
+        }
+        unsubscribe = off;
       } catch (error) {
         console.error("[App] Failed to subscribe provider switch event", error);
       }
     };
 
-    setupListener();
+    void setupListener();
     return () => {
+      active = false;
       unsubscribe?.();
     };
   }, [activeApp, refetch]);
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
+    let active = true;
 
     const setupListener = async () => {
       try {
         const { listen } = await import("@tauri-apps/api/event");
-        unsubscribe = await listen("universal-provider-synced", async () => {
+        const off = await listen("universal-provider-synced", async () => {
           await queryClient.invalidateQueries({ queryKey: ["providers"] });
           try {
             await providersApi.updateTrayMenu();
@@ -368,6 +376,11 @@ function App() {
             console.error("[App] Failed to update tray menu", error);
           }
         });
+        if (!active) {
+          off();
+          return;
+        }
+        unsubscribe = off;
       } catch (error) {
         console.error(
           "[App] Failed to subscribe universal-provider-synced event",
@@ -376,8 +389,9 @@ function App() {
       }
     };
 
-    setupListener();
+    void setupListener();
     return () => {
+      active = false;
       unsubscribe?.();
     };
   }, [queryClient]);
@@ -429,9 +443,10 @@ function App() {
   // Listen for proxy-official-warning: warn when takeover is enabled with an official provider
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
+    let active = true;
 
     const setup = async () => {
-      unsubscribe = await listen("proxy-official-warning", (event) => {
+      const off = await listen("proxy-official-warning", (event) => {
         const { providerName } = event.payload as {
           appType: string;
           providerName: string;
@@ -444,10 +459,16 @@ function App() {
           { duration: 8000 },
         );
       });
+      if (!active) {
+        off();
+        return;
+      }
+      unsubscribe = off;
     };
 
     void setup();
     return () => {
+      active = false;
       unsubscribe?.();
     };
   }, [t]);

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -14,8 +14,6 @@ import {
 } from "./useDirectorySettings";
 import { useSettingsMetadata } from "./useSettingsMetadata";
 
-type Language = "zh" | "en" | "ja";
-
 interface SaveResult {
   requiresRestart: boolean;
 }
@@ -402,11 +400,8 @@ export function useSettings(): UseSettingsResult {
         );
 
         try {
-          if (typeof window !== "undefined") {
-            window.localStorage.setItem(
-              "language",
-              payload.language as Language,
-            );
+          if (typeof window !== "undefined" && payload.language) {
+            window.localStorage.setItem("language", payload.language);
           }
         } catch (error) {
           console.warn(


### PR DESCRIPTION
## Summary
修复两个 bug：

1. **App.tsx 竞态条件** - 3 个 useEffect 中的异步事件监听器在组件卸载时可能泄漏
2. **useSettings.ts 类型断言** - `payload.language as Language` 可能将 undefined 写入 localStorage

## Bug #1: App.tsx 竞态条件

**问题**：3 个 useEffect 中的异步事件监听器设置存在竞态条件。

**场景**：
1. 组件挂载，useEffect 开始执行
2. 异步 `setupListener()` 开始执行，但还没完成（await 还没返回）
3. 用户切换页面或组件重新渲染，useEffect 的 cleanup 函数执行
4. 此时 `unsubscribe` 还是 `undefined`，所以 `unsubscribe?.()` 不会执行任何操作
5. 异步 `setupListener()` 完成，返回 unsubscribe 函数
6. 但 cleanup 已经执行过了，这个监听器永远不会被清理 → **内存泄漏**

**修复**：添加 `active` 标志模式，参考第 385-427 行的正确实现：
- `providersApi.onSwitched` listener
- `universal-provider-synced` listener  
- `proxy-official-warning` listener

```typescript
let active = true;
// 异步 setup 完成后检查
if (!active) {
  off();  // 组件已卸载，立即清理
  return;
}
unsubscribe = off;
// cleanup 时设置 active = false
```

## Bug #2: useSettings.ts 类型断言

**问题**：第 408 行使用 `payload.language as Language`，但 `payload` 是 `Partial<SettingsFormState>`，所以 `payload.language` 可能是 undefined。

**后果**：
- 如果 `payload.language` 是 `undefined`
- `as Language` 强制转换后，localStorage 存储的是字符串 `"undefined"`
- 下次读取时得到 `"undefined"` 而不是有效的语言代码
- 应用可能显示错误的语言或崩溃

**修复**：在 localStorage.setItem 前添加 `if (payload.language)` 检查，并移除未使用的 Language 类型定义。

```typescript
if (payload.language) {  // 先检查是否存在
  window.localStorage.setItem("language", payload.language);
}
```

## Test plan
- [x] TypeScript 类型检查通过
- [x] 单元测试通过（2 个预存的 Tauri API mock 问题与本次修改无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)