### PR TITLE
Fix Linux desktop integration and GNOME window startup

### DIFF
--- a/flatpak/com.ccswitch.desktop.desktop
+++ b/flatpak/com.ccswitch.desktop.desktop
@@ -5,5 +5,6 @@ Comment=All-in-One Assistant for Claude Code, Codex & Gemini CLI
 Exec=cc-switch
 Icon=com.ccswitch.desktop
 Terminal=false
-Categories=Utility;Development;
+Categories=Development;IDE;
 StartupNotify=true
+StartupWMClass=cc-switch

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "dirs 5.0.1",
  "flate2",
  "futures",
+ "gtk",
  "http",
  "http-body",
  "http-body-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -84,6 +84,7 @@ json-five = "0.3.1"
 tauri-plugin-single-instance = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18.2"
 webkit2gtk = { version = "2.0.1", features = ["v2_16"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src-tauri/desktop/cc-switch.desktop.hbs
+++ b/src-tauri/desktop/cc-switch.desktop.hbs
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name={{name}}
+Comment={{comment}}
+Exec={{exec}}
+Icon={{icon}}
+Terminal=false
+Categories={{categories}}
+StartupNotify=true
+StartupWMClass=cc-switch

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,10 @@ use tauri::RunEvent;
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
+fn use_app_window_controls_effective(settings: &AppSettings) -> bool {
+    settings.use_app_window_controls
+}
+
 fn redact_url_for_log(url_str: &str) -> String {
     match url::Url::parse(url_str) {
         Ok(url) => {
@@ -139,6 +143,7 @@ fn handle_deeplink_url(
                     let _ = window.set_focus();
                     #[cfg(target_os = "linux")]
                     {
+                        linux_fix::present_after_tauri_show(&window);
                         linux_fix::nudge_main_window(window.clone());
                     }
                     log::info!("✓ Window shown and focused");
@@ -240,6 +245,7 @@ pub fn run() {
                 let _ = window.set_focus();
                 #[cfg(target_os = "linux")]
                 {
+                    linux_fix::present_after_tauri_show(&window);
                     linux_fix::nudge_main_window(window.clone());
                 }
             }
@@ -251,11 +257,22 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         // 拦截窗口关闭：根据设置决定是否最小化到托盘
         .on_window_event(|window, event| {
+            #[cfg(target_os = "linux")]
+            if window.label() == "main" {
+                if let Some(webview_window) = window.app_handle().get_webview_window("main") {
+                    linux_fix::handle_window_event(event, &webview_window);
+                }
+            }
+
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 let settings = crate::settings::get_settings();
 
                 if settings.minimize_to_tray_on_close {
                     api.prevent_close();
+                    #[cfg(target_os = "linux")]
+                    if window.label() == "main" {
+                        linux_fix::save_current_window_size_now(window.app_handle());
+                    }
                     let _ = window.hide();
                     #[cfg(target_os = "windows")]
                     {
@@ -1013,10 +1030,16 @@ pub fn run() {
             // 静默启动：根据设置决定是否显示主窗口
             let settings = crate::settings::get_settings();
             if let Some(window) = app.get_webview_window("main") {
-                // 在窗口首次显示前同步装饰状态，避免前端加载后再切换导致标题栏闪烁
-                // 仅 Linux 生效：解决 Wayland 下系统窗口按钮不可用的问题
                 #[cfg(target_os = "linux")]
-                let _ = window.set_decorations(!settings.use_app_window_controls);
+                {
+                    linux_fix::start_window_size_tracking();
+                    linux_fix::restore_saved_window_size(&window);
+                }
+
+                // 在窗口首次显示前同步装饰状态，避免前端加载后再切换导致标题栏闪烁。
+                // Linux 默认仍使用系统装饰栏；应用级按钮只作为用户显式开启的 fallback。
+                #[cfg(target_os = "linux")]
+                let _ = window.set_decorations(!use_app_window_controls_effective(&settings));
                 if settings.silent_startup {
                     // 静默启动模式：保持窗口隐藏
                     let _ = window.hide();
@@ -1028,11 +1051,14 @@ pub fn run() {
                 } else {
                     // 正常启动模式：显示窗口
                     let _ = window.show();
+                    #[cfg(target_os = "linux")]
+                    {
+                        linux_fix::present_after_tauri_show(&window);
+                    }
                     log::info!("正常启动模式：主窗口已显示");
 
-                    // Linux: 解决首次启动 UI 无响应问题（Tauri #10746 + wry #637）。
-                    // 启动时 webview 未获取焦点 + surface 尺寸协商失败，导致点击无效。
-                    // 这里做 set_focus + 伪 resize，等价于无视觉版本的"最大化-还原"。
+                    // Linux: 启动后延迟 focus，避免首次点击被窗口管理器消耗。
+                    // 不再做 resize nudge；GNOME/XWayland 下它会放大窗口。
                     #[cfg(target_os = "linux")]
                     {
                         linux_fix::nudge_main_window(window.clone());
@@ -1782,6 +1808,12 @@ fn show_database_init_error_dialog(
 // 在应用主动退出前显式持久化窗口状态
 // ============================================================
 
+#[cfg(target_os = "linux")]
+fn window_state_flags() -> StateFlags {
+    StateFlags::MAXIMIZED
+}
+
+#[cfg(not(target_os = "linux"))]
 fn window_state_flags() -> StateFlags {
     StateFlags::POSITION | StateFlags::SIZE | StateFlags::MAXIMIZED
 }

--- a/src-tauri/src/lightweight.rs
+++ b/src-tauri/src/lightweight.rs
@@ -35,10 +35,15 @@ pub fn exit_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
 
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.unminimize();
+        #[cfg(target_os = "linux")]
+        {
+            crate::linux_fix::restore_saved_window_size(&window);
+        }
         let _ = window.show();
         let _ = window.set_focus();
         #[cfg(target_os = "linux")]
         {
+            crate::linux_fix::present_after_tauri_show(&window);
             crate::linux_fix::nudge_main_window(window.clone());
         }
         #[cfg(target_os = "windows")]
@@ -69,11 +74,16 @@ pub fn exit_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
         .map_err(|e| format!("创建主窗口失败: {e}"))?;
 
     if let Some(window) = app.get_webview_window("main") {
+        #[cfg(target_os = "linux")]
+        {
+            crate::linux_fix::restore_saved_window_size(&window);
+        }
         let _ = window.unminimize();
         let _ = window.show();
         let _ = window.set_focus();
         #[cfg(target_os = "linux")]
         {
+            crate::linux_fix::present_after_tauri_show(&window);
             crate::linux_fix::nudge_main_window(window.clone());
         }
     }

--- a/src-tauri/src/linux_fix.rs
+++ b/src-tauri/src/linux_fix.rs
@@ -1,121 +1,254 @@
-//! Linux 专用的主窗口恢复补丁。
+//! Linux-specific window startup and size handling.
 //!
-//! 解决 Tauri 2.x 在部分 Linux 发行版（尤其是 Wayland / 某些 WebKitGTK
-//! 版本）上启动后 UI 无法响应点击的问题：
-//!
-//! - **失效模式 A**（Tauri #10746 / wry #637）：webview 在 `show()` 后
-//!   没有获得 keyboard focus，导致首次点击被 X11/Wayland 用作
-//!   click-to-activate 而非传给 webview。
-//! - **失效模式 B**：GTK surface 与 WebKitWebView 的 input region 尺寸
-//!   协商在 `visible:false` → `show()` 的路径上失败，整窗永远不响应
-//!   点击，只有重新 `size_allocate`（例如最大化-还原）才能恢复。
-//!
-//! 本模块导出 [`nudge_main_window`]，它通过「显式 set_focus + 无视觉
-//! 版本的 ±1px 伪 resize」精确模拟用户手动最大化再还原的 workaround，
-//! 但肉眼无法察觉。所有"让主窗口出现在用户面前"的路径（正常启动、
-//! deeplink 唤起、single_instance 回调、托盘 show_main、lightweight
-//! 退出）都应在现有 `set_focus()` 之后追加一次调用。
+//! GNOME/Wayland is sensitive to how a hidden Tauri/WebKitGTK window is first
+//! shown. The startup path keeps Tauri's normal `show()` call, then refreshes
+//! the GTK top-level presentation so native titlebar hit testing is initialized.
+//! The old +/-1px resize nudge is intentionally not used because it inflated
+//! window size and polluted persisted state on GNOME.
 
-use std::time::Duration;
+use std::{
+    fs,
+    path::PathBuf,
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
 
-use tauri::{PhysicalSize, WebviewWindow};
+use serde::{Deserialize, Serialize};
+use tauri::{LogicalSize, Manager, PhysicalSize, Size, WebviewWindow, WindowEvent};
 
-/// 在 webview realize 之后的延迟，等 GTK 主循环把 realize 事件处理完。
-/// 200ms 是社区经验值；太短 set_focus 仍会无效，太长会让首屏可交互
-/// 时间被肉眼感知到。
 const REALIZE_WAIT: Duration = Duration::from_millis(200);
+const STARTUP_RESIZE_IGNORE: Duration = Duration::from_secs(2);
 
-/// ±1px 伪 resize 两步之间的间隔，确保 GTK 先处理了第一次
-/// `size_allocate` 再收到第二次 resize。放宽到 100ms 是因为 Tao 在 Linux
-/// 上的尺寸 API 是异步的（底层走 `gtk_window_resize` → 合成器 configure），
-/// 太短会让合成器把两次连续 resize coalesce 成一次。
-const RESIZE_GAP: Duration = Duration::from_millis(100);
+const DEFAULT_WIDTH: u32 = 1000;
+const DEFAULT_HEIGHT: u32 = 650;
+const MIN_WIDTH: u32 = 900;
+const MIN_HEIGHT: u32 = 600;
+const MAX_SAVED_WIDTH: u32 = 10_000;
+const MAX_SAVED_HEIGHT: u32 = 10_000;
+const MONITOR_MARGIN: u32 = 80;
+const WINDOW_SIZE_STATE_FILE: &str = "linux-window-size.json";
 
-/// 尺寸对账回读前的额外等待。200ms + 100ms + 500ms = 总共 ~800ms 后
-/// 校验窗口尺寸是否回到 original。这个时间足够所有合成器处理完
-/// resize 消息队列。
-const RECONCILE_WAIT: Duration = Duration::from_millis(500);
+static STARTED_AT: OnceLock<Instant> = OnceLock::new();
 
-/// 对主窗口执行 Linux 专用的「focus + surface 重激活」序列。
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+struct SavedWindowSize {
+    width: u32,
+    height: u32,
+}
+
+pub(crate) fn start_window_size_tracking() {
+    let _ = STARTED_AT.set(Instant::now());
+}
+
+pub(crate) fn restore_saved_window_size(window: &WebviewWindow) {
+    let Some(size) = read_saved_window_size() else {
+        return;
+    };
+
+    let size = clamp_to_current_monitor(window, size);
+    if size.width == DEFAULT_WIDTH && size.height == DEFAULT_HEIGHT {
+        return;
+    }
+
+    match window.set_size(Size::Logical(LogicalSize::new(
+        size.width as f64,
+        size.height as f64,
+    ))) {
+        Ok(()) => log::info!(
+            "Linux: restored saved window size {}x{}",
+            size.width,
+            size.height
+        ),
+        Err(err) => log::warn!("Linux: failed to restore saved window size: {err}"),
+    }
+}
+
+/// Refresh native GTK/GNOME presentation after Tauri has shown the WebView.
 ///
-/// 调用是 fire-and-forget：内部 spawn 一个异步任务在 ~250ms 后完成。
-/// 调用线程立即返回，不阻塞 UI。
+/// Calling GTK `present()` instead of Tauri `show()` can leave the WebView
+/// blank. Calling it after Tauri `show()` preserves native decorations and fixes
+/// the GNOME/Wayland titlebar button hit-test initialization.
+pub(crate) fn present_after_tauri_show(window: &WebviewWindow) {
+    let presentation_window = window.clone();
+    if let Err(err) = window.run_on_main_thread(move || {
+        refresh_gtk_presentation(&presentation_window);
+    }) {
+        log::warn!("Linux: failed to schedule GTK presentation refresh: {err}");
+    }
+}
+
 pub(crate) fn nudge_main_window(window: WebviewWindow) {
-    // 第一次 set_focus：webview 可能还没 realize，这一次通常是无效的，
-    // 但成本极低（线程安全，内部 run_on_main_thread），顺手做掉。
     let _ = window.set_focus();
 
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(REALIZE_WAIT).await;
-
-        // 第二次 set_focus：此时 webview realize 已完成，在绝大多数
-        // 发行版上这一次会真的生效，消除失效模式 A。
+        present_after_tauri_show(&window);
         let _ = window.set_focus();
-
-        // 伪 resize：读取当前 inner_size，先加 1px 再还原。这会触发
-        // GTK 的 size-allocate → WebKitWebViewBase::size_allocate →
-        // 重新 attach input surface，消除失效模式 B。
-        //
-        // 使用 PhysicalSize 避免跨 DPI 的逻辑坐标漂移；saturating_add
-        // 防止极端尺寸溢出。
-        match window.inner_size() {
-            Ok(original) => {
-                let bumped = PhysicalSize::new(original.width.saturating_add(1), original.height);
-                let _ = window.set_size(bumped);
-                tokio::time::sleep(RESIZE_GAP).await;
-                let _ = window.set_size(original);
-                log::info!("Linux: 已对主窗口执行 focus + surface 重激活");
-
-                // 尺寸对账回读：Tao Linux 的尺寸 API 是异步的，`set_size` 只是把
-                // resize 请求送进 GTK 主循环队列，合成器可能会 coalesce 两次连续
-                // 请求（尤其是第二次 `set_size(original)`），导致窗口永久停留在
-                // width+1。这里等合成器处理完队列后读一次实际尺寸，发现 drift 就
-                // 再补一次 `set_size(original)` 兜底。
-                //
-                // 已知限制：tiling Wayland 合成器（sway/river/hyprland）会完全忽略
-                // `set_size`，此时对账永远 drift=0（因为两次 set_size 都是 no-op），
-                // 看起来"没问题"但失效模式 B 其实没被修复；这是已知限制，需要用户
-                // 侧用 GDK_BACKEND=x11 绕过，README 应该有说明。
-                tokio::time::sleep(RECONCILE_WAIT).await;
-                match window.inner_size() {
-                    Ok(after) => {
-                        if after.width != original.width || after.height != original.height {
-                            log::info!(
-                                "Linux nudge 尺寸 drift: expected={}x{}, got={}x{}，已补偿",
-                                original.width,
-                                original.height,
-                                after.width,
-                                after.height
-                            );
-                            let _ = window.set_size(original);
-                            // 最终校验：如果补偿后仍然不一致，记 warn 让用户/开发者
-                            // 知道对账失败。这时窗口会停在非预期尺寸（通常是 +1px），
-                            // 属于极端兜底场景。
-                            if let Ok(final_size) = window.inner_size() {
-                                if final_size.width != original.width
-                                    || final_size.height != original.height
-                                {
-                                    log::warn!(
-                                        "Linux nudge 尺寸 drift 补偿后仍不一致: expected={}x{}, got={}x{}",
-                                        original.width,
-                                        original.height,
-                                        final_size.width,
-                                        final_size.height
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        log::warn!("Linux nudge: 对账回读 inner_size 失败: {e}");
-                    }
-                }
-            }
-            Err(e) => {
-                // 极罕见的失败路径；只做了 set_focus 也比什么都不做强，
-                // 不要让 resize 失败把整个补丁吞掉。
-                log::warn!("Linux nudge: 读取 inner_size 失败，跳过伪 resize: {e}");
-            }
-        }
+        log::info!("Linux: retried main window focus");
     });
+}
+
+pub(crate) fn handle_window_event(event: &WindowEvent, window: &WebviewWindow) {
+    if let WindowEvent::Resized(_) = event {
+        save_window_size_after_resize(window);
+    }
+}
+
+pub(crate) fn save_current_window_size_now(app_handle: &tauri::AppHandle) {
+    let Some(window) = app_handle.get_webview_window("main") else {
+        return;
+    };
+
+    if let Err(err) = save_window_size_for_window(&window) {
+        log::warn!("Linux: failed to save window size: {err}");
+    }
+}
+
+fn save_window_size_after_resize(window: &WebviewWindow) {
+    if STARTED_AT
+        .get()
+        .map(|started| started.elapsed() < STARTUP_RESIZE_IGNORE)
+        .unwrap_or(true)
+    {
+        return;
+    }
+
+    if let Err(err) = save_window_size_for_window(window) {
+        log::warn!("Linux: failed to save window size: {err}");
+    }
+}
+
+fn save_window_size_for_window(window: &WebviewWindow) -> Result<(), String> {
+    if !is_normal_visible_window(window) {
+        return Ok(());
+    }
+
+    let size = gtk_content_size(window)?;
+    if !is_valid_saved_size(size) {
+        return Ok(());
+    }
+
+    write_saved_window_size(size)
+}
+
+fn refresh_gtk_presentation(window: &WebviewWindow) {
+    match window.gtk_window() {
+        Ok(gtk_window) => {
+            use gtk::prelude::{GtkWindowExt, WidgetExt};
+            gtk_window.show_all();
+            gtk_window.present();
+            log::info!("Linux: refreshed GTK presentation after Tauri show");
+        }
+        Err(err) => {
+            log::warn!("Linux: failed to get GTK window for presentation refresh: {err}");
+        }
+    }
+}
+
+fn gtk_content_size(window: &WebviewWindow) -> Result<PhysicalSize<u32>, String> {
+    let gtk_window = window
+        .gtk_window()
+        .map_err(|err| format!("failed to get GTK window: {err}"))?;
+
+    use gtk::prelude::{BinExt, WidgetExt};
+
+    let child = gtk_window
+        .child()
+        .ok_or_else(|| "GTK window has no content child".to_string())?;
+    let allocation = child.allocation();
+    let width = u32::try_from(allocation.width()).unwrap_or(0);
+    let height = u32::try_from(allocation.height()).unwrap_or(0);
+
+    Ok(PhysicalSize::new(width, height))
+}
+
+fn is_normal_visible_window(window: &WebviewWindow) -> bool {
+    let visible = window.is_visible().unwrap_or(false);
+    let maximized = window.is_maximized().unwrap_or(false);
+    let minimized = window.is_minimized().unwrap_or(false);
+    visible && !maximized && !minimized
+}
+
+fn is_valid_saved_size(size: PhysicalSize<u32>) -> bool {
+    (MIN_WIDTH..=MAX_SAVED_WIDTH).contains(&size.width)
+        && (MIN_HEIGHT..=MAX_SAVED_HEIGHT).contains(&size.height)
+}
+
+fn read_saved_window_size() -> Option<PhysicalSize<u32>> {
+    let path = window_size_state_path();
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            log::warn!(
+                "Linux: failed to read saved window size {}: {err}",
+                path.display()
+            );
+            return None;
+        }
+    };
+
+    let saved = match serde_json::from_str::<SavedWindowSize>(&raw) {
+        Ok(saved) => saved,
+        Err(err) => {
+            log::warn!(
+                "Linux: failed to parse saved window size {}: {err}",
+                path.display()
+            );
+            return None;
+        }
+    };
+
+    let size = PhysicalSize::new(saved.width, saved.height);
+    is_valid_saved_size(size).then_some(size)
+}
+
+fn write_saved_window_size(size: PhysicalSize<u32>) -> Result<(), String> {
+    let path = window_size_state_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+    }
+
+    let saved = SavedWindowSize {
+        width: size.width,
+        height: size.height,
+    };
+    let raw = serde_json::to_string_pretty(&saved)
+        .map_err(|err| format!("failed to encode saved window size: {err}"))?;
+    fs::write(&path, format!("{raw}\n"))
+        .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
+
+    Ok(())
+}
+
+fn clamp_to_current_monitor(window: &WebviewWindow, size: PhysicalSize<u32>) -> PhysicalSize<u32> {
+    let monitor_size = window
+        .current_monitor()
+        .ok()
+        .flatten()
+        .or_else(|| window.primary_monitor().ok().flatten())
+        .map(|monitor| monitor.work_area().size);
+
+    let Some(monitor_size) = monitor_size else {
+        return size;
+    };
+
+    let max_width = monitor_size
+        .width
+        .saturating_sub(MONITOR_MARGIN)
+        .max(MIN_WIDTH);
+    let max_height = monitor_size
+        .height
+        .saturating_sub(MONITOR_MARGIN)
+        .max(MIN_HEIGHT);
+
+    PhysicalSize::new(
+        size.width.clamp(MIN_WIDTH, max_width),
+        size.height.clamp(MIN_HEIGHT, max_height),
+    )
+}
+
+fn window_size_state_path() -> PathBuf {
+    crate::config::get_app_config_dir().join(WINDOW_SIZE_STATE_FILE)
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -690,6 +690,7 @@ pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
                 let _ = window.set_focus();
                 #[cfg(target_os = "linux")]
                 {
+                    crate::linux_fix::present_after_tauri_show(&window);
                     crate::linux_fix::nudge_main_window(window.clone());
                 }
                 #[cfg(target_os = "macos")]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,10 +10,11 @@
     "beforeBuildCommand": "pnpm run build:renderer"
   },
   "app": {
+    "enableGTKAppId": true,
     "windows": [
       {
         "label": "main",
-        "title": "",
+        "title": "CC Switch",
         "titleBarStyle": "Overlay",
         "width": 1000,
         "height": 650,
@@ -36,6 +37,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "category": "DeveloperTool",
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
@@ -47,6 +49,14 @@
     "windows": {
       "wix": {
         "template": "wix/per-user-main.wxs"
+      }
+    },
+    "linux": {
+      "deb": {
+        "desktopTemplate": "desktop/cc-switch.desktop.hbs"
+      },
+      "rpm": {
+        "desktopTemplate": "desktop/cc-switch.desktop.hbs"
       }
     },
     "macOS": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -177,8 +177,7 @@ function App() {
   }, [currentView]);
 
   const { data: settingsData } = useSettingsQuery();
-  const useAppWindowControls =
-    isLinux() && (settingsData?.useAppWindowControls ?? false);
+  const useAppWindowControls = settingsData?.useAppWindowControls ?? false;
   const dragBarHeight = useAppWindowControls ? 32 : DEFAULT_DRAG_BAR_HEIGHT;
   const contentTopOffset = dragBarHeight + HEADER_HEIGHT;
   const visibleApps: VisibleApps = settingsData?.visibleApps ?? {
@@ -1063,8 +1062,8 @@ function App() {
       {(dragBarHeight > 0 || useAppWindowControls) && (
         <div
           className="fixed top-0 left-0 right-0 z-[70] flex items-center justify-end px-2"
-          data-tauri-drag-region
-          style={{ WebkitAppRegion: "drag", height: dragBarHeight } as any}
+          {...DRAG_REGION_ATTR}
+          style={{ ...DRAG_REGION_STYLE, height: dragBarHeight } as any}
         >
           {useAppWindowControls && (
             <div


### PR DESCRIPTION
## Summary

This PR fixes several Linux desktop integration and GNOME/Wayland window startup issues observed on ZorinOS 18.1 with the native GTK/Wayland backend.

### Desktop integration

- Enables the GTK application id so Linux desktops can associate the runtime window with `com.ccswitch.desktop`.
- Sets the main window title to `CC Switch` instead of an empty title.
- Adds a deb/rpm desktop template with `StartupWMClass=cc-switch`.
- Changes the Linux bundle category to `DeveloperTool`, producing development-oriented desktop categories.
- Updates the Flatpak desktop entry to use `Development;IDE;` and `StartupWMClass=cc-switch`.

### GNOME/Wayland window startup

- Keeps the native GTK/GNOME titlebar instead of forcing app-managed window controls.
- Removes the previous Linux resize nudge that resized the window by 1px and then restored it. On GNOME/Wayland this could inflate the startup window and pollute saved window state.
- After Tauri shows the window, refreshes GTK presentation with `gtk_window.show_all()` and `gtk_window.present()`. This fixes the native titlebar button hit-testing issue where minimize/maximize/close could be inert until the user manually maximized/restored the window.
- Keeps a delayed focus retry to avoid first-click focus loss.

### Linux window size memory

- On Linux, the Tauri window-state plugin now persists only maximized state.
- Adds separate Linux-only normal window size memory.
- Does not persist or restore window position, matching Wayland expectations.
- Ignores startup resize noise and skips saving maximized/minimized/hidden window sizes.
- Clamps restored size to the current monitor work area.
- Saves the latest normal size before close-to-tray hiding and app exit.

## Verification

- `cargo check` passes in `src-tauri`.
- `pnpm tauri build --bundles deb` produced a deb package successfully:
  - `src-tauri/target/release/bundle/deb/CC Switch_3.15.0_amd64.deb`
  - The command exits non-zero only at updater signing because the local environment has a public updater key but no `TAURI_SIGNING_PRIVATE_KEY`.
- The generated deb was manually installed and tested on ZorinOS 18.1 / GNOME Wayland:
  - app appears in the expected development app category
  - window identity is registered correctly
  - cold-start window size is normal
  - native GNOME titlebar buttons work immediately
  - Linux normal window size memory works without restoring position

## Notes

- Runtime diagnostics showed a Wayland backend (`WaylandWindowHandle`), so X11-only diagnostics such as `xprop` and `xwininfo` are not useful for this issue.
- A client-side/app-managed titlebar workaround was tested and rejected because it changed native GNOME behavior and regressed window dragging.
