### PR TITLE
fix(claude): disable attribution header

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -31,8 +31,13 @@ pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
         obj.remove("apiFormat");
         obj.remove("openrouter_compat_mode");
         obj.remove("openrouterCompatMode");
-        obj.entry("env").or_insert_with(|| json!({}))["CLAUDE_CODE_ATTRIBUTION_HEADER"] =
-            json!("0");
+        let env = obj.entry("env").or_insert_with(|| json!({}));
+        if !env.is_object() {
+            *env = json!({});
+        }
+        if let Some(env) = env.as_object_mut() {
+            env.insert("CLAUDE_CODE_ATTRIBUTION_HEADER".to_string(), json!("0"));
+        }
     }
     v
 }
@@ -1521,6 +1526,24 @@ mod tests {
             json!("0")
         );
         assert_eq!(sanitized["env"]["ANTHROPIC_AUTH_TOKEN"], json!("sk-test"));
+    }
+
+    #[test]
+    fn sanitize_claude_settings_for_live_normalizes_non_object_env() {
+        let settings = json!({
+            "env": []
+        });
+
+        let sanitized = sanitize_claude_settings_for_live(&settings);
+
+        assert_eq!(
+            sanitized,
+            json!({
+                "env": {
+                    "CLAUDE_CODE_ATTRIBUTION_HEADER": "0"
+                }
+            })
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -31,6 +31,8 @@ pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
         obj.remove("apiFormat");
         obj.remove("openrouter_compat_mode");
         obj.remove("openrouterCompatMode");
+        obj.entry("env").or_insert_with(|| json!({}))["CLAUDE_CODE_ATTRIBUTION_HEADER"] =
+            json!("0");
     }
     v
 }
@@ -1501,6 +1503,25 @@ pub fn remove_openclaw_provider_from_live(provider_id: &str) -> Result<(), AppEr
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn sanitize_claude_settings_for_live_disables_attribution_header() {
+        let settings = json!({
+            "api_format": "openai_chat",
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "sk-test"
+            }
+        });
+
+        let sanitized = sanitize_claude_settings_for_live(&settings);
+
+        assert!(sanitized.get("api_format").is_none());
+        assert_eq!(
+            sanitized["env"]["CLAUDE_CODE_ATTRIBUTION_HEADER"],
+            json!("0")
+        );
+        assert_eq!(sanitized["env"]["ANTHROPIC_AUTH_TOKEN"], json!("sk-test"));
+    }
 
     #[test]
     fn claude_common_config_apply_and_remove_roundtrip_for_non_overlapping_fields() {

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2648,7 +2648,12 @@ model = "gpt-5.1-codex"
         assert_eq!(backup.original_config, expected);
         assert_eq!(
             service.read_claude_live().expect("read live"),
-            provider_b.settings_config
+            json!({
+                "env": {
+                    "ANTHROPIC_API_KEY": "b-key",
+                    "CLAUDE_CODE_ATTRIBUTION_HEADER": "0"
+                }
+            })
         );
     }
 

--- a/src-tauri/tests/import_export_sync.rs
+++ b/src-tauri/tests/import_export_sync.rs
@@ -52,15 +52,25 @@ fn sync_claude_provider_writes_live_settings() {
         settings_path.display()
     );
 
+    let expected_live_config = json!({
+        "env": {
+            "ANTHROPIC_AUTH_TOKEN": "test-key",
+            "ANTHROPIC_BASE_URL": "https://api.test",
+            "CLAUDE_CODE_ATTRIBUTION_HEADER": "0"
+        },
+        "ui": {
+            "displayName": "Test Provider"
+        }
+    });
     let live_value: serde_json::Value = read_json_file(&settings_path).expect("read live file");
-    assert_eq!(live_value, provider_config);
+    assert_eq!(live_value, expected_live_config);
 
     // 确认 SSOT 中的供应商也同步了最新内容
     let updated = config
         .get_manager(&AppType::Claude)
         .and_then(|m| m.providers.get("prov-1"))
         .expect("provider in config");
-    assert_eq!(updated.settings_config, provider_config);
+    assert_eq!(updated.settings_config, expected_live_config);
 
     // 额外确认写入位置位于测试 HOME 下
     assert!(


### PR DESCRIPTION
## Summary / 概述

Claude Code 会在请求的 `system` 里插入一段 attribution 信息：

```text
x-anthropic-billing-header: cc_version=2.1.128.bd9; cc_entrypoint=sdk-cli; cch=78ef3;
```

其中 `cch=` 是每次请求都会变化的随机字符串。第三方 API 如果基于 prompt 前缀做缓存，这个随机值会让前缀每次都不同，导致缓存命中失败。

本机逆向 Claude Code `2.1.128` 后确认，`CLAUDE_CODE_ATTRIBUTION_HEADER` 会控制这段 header 是否生成：

```js
function wd_(H){
  if(pK(process.env.CLAUDE_CODE_ATTRIBUTION_HEADER))return"";
  ...
  return`x-anthropic-billing-header: cc_version=${A}; cc_entrypoint=${P}; cch=${Z};`
}
```

`pK()` 会把 `"0"`、`"false"`、`"no"`、`"off"` 识别为关闭值。因此在 Claude Code `settings.json` 的 `env` 里写入：

```json
{
  "env": {
    "CLAUDE_CODE_ATTRIBUTION_HEADER": "0"
  }
}
```

可以关闭这段动态 attribution header。

我在本机用抓包验证过：

- 未设置 `CLAUDE_CODE_ATTRIBUTION_HEADER` 时，请求体里包含 `x-anthropic-billing-header` 和随机 `cch=...`
- 设置 `CLAUDE_CODE_ATTRIBUTION_HEADER=0` 后，请求体里不再包含 `x-anthropic-billing-header`，也没有 `cch=...`

当前 cc-switch 的处理不够完整：现有逻辑只在 OpenAI Chat / OpenAI Responses 转换路径里 strip 了这段 attribution。我在本机验证过，如果第三方 API 使用的是 Anthropic 透传格式或 Gemini native 格式，请求仍会带着动态 `cch=` 发出去，缓存仍会失效。

本 PR 在 Claude live settings 写出时加入 `CLAUDE_CODE_ATTRIBUTION_HEADER = "0"`，从源头解决这个问题。

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

N/A. Backend config change only.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo fmt --check` passes / 通过 Rust 格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Rust tests pass / Rust 测试通过
  - `cargo test sanitize_claude_settings_for_live_disables_attribution_header --lib`
  - `cargo test sync_claude_provider_writes_live_settings --test import_export_sync`
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
  - No user-facing text changed.
