### PR TITLE
feat(skills): add pin, bulk actions, and filter/sort toolbar

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -198,6 +198,9 @@ pub struct InstalledSkill {
     /// 最近更新时间（Unix 时间戳，0 = 从未更新）
     #[serde(default)]
     pub updated_at: i64,
+    /// 置顶时间（Unix 时间戳；None = 未置顶；按值降序作为置顶顺序）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pinned_at: Option<i64>,
 }
 
 /// 未管理的 Skill（在应用目录中发现但未被 CC Switch 管理）

--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -97,6 +97,19 @@ pub fn toggle_skill_app(
     Ok(true)
 }
 
+/// 设置 Skill 的置顶状态
+///
+/// `pinned = true`：置顶（记录当前时间戳）；`false`：取消置顶。
+#[tauri::command]
+pub fn set_skill_pin(
+    id: String,
+    pinned: bool,
+    app_state: State<'_, AppState>,
+) -> Result<bool, String> {
+    SkillService::set_pin(&app_state.db, &id, pinned).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
 /// 扫描未管理的 Skills
 #[tauri::command]
 pub fn scan_unmanaged_skills(

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -23,7 +23,7 @@ impl Database {
             .prepare(
                 "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
                         readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode,
-                        enabled_hermes, installed_at, content_hash, updated_at
+                        enabled_hermes, installed_at, content_hash, updated_at, pinned_at
                  FROM skills ORDER BY name ASC",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -49,6 +49,7 @@ impl Database {
                     installed_at: row.get(13)?,
                     content_hash: row.get(14)?,
                     updated_at: row.get::<_, i64>(15).unwrap_or(0),
+                    pinned_at: row.get(16).ok(),
                 })
             })
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -68,7 +69,7 @@ impl Database {
             .prepare(
                 "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
                         readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode,
-                        enabled_hermes, installed_at, content_hash, updated_at
+                        enabled_hermes, installed_at, content_hash, updated_at, pinned_at
                  FROM skills WHERE id = ?1",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -93,6 +94,7 @@ impl Database {
                 installed_at: row.get(13)?,
                 content_hash: row.get(14)?,
                 updated_at: row.get::<_, i64>(15).unwrap_or(0),
+                pinned_at: row.get(16).ok(),
             })
         });
 
@@ -110,8 +112,8 @@ impl Database {
             "INSERT OR REPLACE INTO skills
              (id, name, description, directory, repo_owner, repo_name, repo_branch,
               readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes,
-              installed_at, content_hash, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+              installed_at, content_hash, updated_at, pinned_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             params![
                 skill.id,
                 skill.name,
@@ -129,6 +131,7 @@ impl Database {
                 skill.installed_at,
                 skill.content_hash,
                 skill.updated_at,
+                skill.pinned_at,
             ],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -159,6 +162,24 @@ impl Database {
             .execute(
                 "UPDATE skills SET enabled_claude = ?1, enabled_codex = ?2, enabled_gemini = ?3, enabled_opencode = ?4, enabled_hermes = ?5 WHERE id = ?6",
                 params![apps.claude, apps.codex, apps.gemini, apps.opencode, apps.hermes, id],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(affected > 0)
+    }
+
+    /// 更新 Skill 的置顶状态
+    ///
+    /// `pinned_at = None` 表示取消置顶，`Some(unix_ts)` 表示置顶时间戳。
+    pub fn update_skill_pin(
+        &self,
+        id: &str,
+        pinned_at: Option<i64>,
+    ) -> Result<bool, AppError> {
+        let conn = lock_conn!(self.conn);
+        let affected = conn
+            .execute(
+                "UPDATE skills SET pinned_at = ?1 WHERE id = ?2",
+                params![pinned_at, id],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(affected > 0)

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -49,7 +49,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 10;
+pub(crate) const SCHEMA_VERSION: i32 = 11;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -97,7 +97,8 @@ impl Database {
             enabled_hermes BOOLEAN NOT NULL DEFAULT 0,
             installed_at INTEGER NOT NULL DEFAULT 0,
             content_hash TEXT,
-            updated_at INTEGER NOT NULL DEFAULT 0
+            updated_at INTEGER NOT NULL DEFAULT 0,
+            pinned_at INTEGER
         )",
             [],
         )
@@ -430,6 +431,11 @@ impl Database {
                         log::info!("迁移数据库从 v9 到 v10（添加 Hermes Agent 支持）");
                         Self::migrate_v9_to_v10(conn)?;
                         Self::set_user_version(conn, 10)?;
+                    }
+                    10 => {
+                        log::info!("迁移数据库从 v10 到 v11（Skills 置顶字段）");
+                        Self::migrate_v10_to_v11(conn)?;
+                        Self::set_user_version(conn, 11)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -1197,6 +1203,16 @@ impl Database {
         }
 
         log::info!("v9 -> v10 迁移完成：已添加 Hermes Agent 支持");
+        Ok(())
+    }
+
+    /// v10 -> v11 迁移：为 skills 表添加 pinned_at 字段（置顶时间戳，NULL = 未置顶）
+    fn migrate_v10_to_v11(conn: &Connection) -> Result<(), AppError> {
+        if Self::table_exists(conn, "skills")? {
+            Self::add_column_if_missing(conn, "skills", "pinned_at", "INTEGER")?;
+        }
+
+        log::info!("v10 -> v11 迁移完成：已为 skills 表添加 pinned_at 字段");
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1174,6 +1174,7 @@ pub fn run() {
             commands::uninstall_skill_unified,
             commands::restore_skill_backup,
             commands::toggle_skill_app,
+            commands::set_skill_pin,
             commands::scan_unmanaged_skills,
             commands::import_skills_from_apps,
             commands::discover_available_skills,

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -762,6 +762,7 @@ impl SkillService {
             installed_at: chrono::Utc::now().timestamp(),
             content_hash,
             updated_at: 0,
+            pinned_at: None,
         };
 
         // 保存到数据库
@@ -1100,6 +1101,8 @@ impl SkillService {
             installed_at: skill.installed_at,
             content_hash: new_hash,
             updated_at: chrono::Utc::now().timestamp(),
+            // 保留原置顶状态（update_skill 不应清除用户的置顶）
+            pinned_at: skill.pinned_at,
         };
 
         db.save_skill(&updated_skill)?;
@@ -1378,6 +1381,38 @@ impl SkillService {
         Ok(())
     }
 
+    /// 设置 Skill 置顶状态
+    ///
+    /// `pinned = true`：以当前 Unix 时间戳置顶；`false`：取消置顶。
+    pub fn set_pin(db: &Arc<Database>, id: &str, pinned: bool) -> Result<()> {
+        let pinned_at = if pinned {
+            Some(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| anyhow!("获取系统时间失败: {e}"))?
+                    .as_secs() as i64,
+            )
+        } else {
+            None
+        };
+
+        let affected = db
+            .update_skill_pin(id, pinned_at)
+            .map_err(|e| anyhow!("更新置顶状态失败: {e}"))?;
+
+        if !affected {
+            return Err(anyhow!("Skill not found: {id}"));
+        }
+
+        log::info!(
+            "Skill {} 置顶状态已更新为 {}",
+            id,
+            if pinned { "已置顶" } else { "未置顶" }
+        );
+
+        Ok(())
+    }
+
     /// 扫描未管理的 Skills
     ///
     /// 扫描各应用目录，找出未被 CC Switch 管理的 Skills
@@ -1534,6 +1569,7 @@ impl SkillService {
                 installed_at: chrono::Utc::now().timestamp(),
                 content_hash,
                 updated_at: 0,
+                pinned_at: None,
             };
 
             // 保存到数据库
@@ -2655,6 +2691,7 @@ impl SkillService {
                 installed_at: chrono::Utc::now().timestamp(),
                 content_hash,
                 updated_at: 0,
+                pinned_at: None,
             };
 
             // 保存到数据库
@@ -3042,6 +3079,8 @@ pub fn migrate_skills_to_ssot(db: &Arc<Database>) -> Result<usize> {
             installed_at: chrono::Utc::now().timestamp(),
             content_hash,
             updated_at: 0,
+            // 重建路径无法恢复 pin（DB 已 clear），用户重新安装后须重新置顶
+            pinned_at: None,
         };
 
         db.save_skill(&skill)?;

--- a/src/components/common/AppCountBar.tsx
+++ b/src/components/common/AppCountBar.tsx
@@ -2,34 +2,62 @@ import React from "react";
 import { Badge } from "@/components/ui/badge";
 import type { AppId } from "@/lib/api/types";
 import { APP_IDS, APP_ICON_MAP } from "@/config/appConfig";
+import { cn } from "@/lib/utils";
 
 interface AppCountBarProps {
   totalLabel: string;
   counts: Partial<Record<AppId, number>>;
   appIds?: AppId[];
+  /** 已激活的 App 过滤集合；当提供 onAppClick 时启用 chip 高亮 */
+  activeApps?: Set<AppId>;
+  /** 给每个 App badge 添加点击行为；提供时 badge 变为按钮 */
+  onAppClick?: (app: AppId) => void;
 }
 
 export const AppCountBar: React.FC<AppCountBarProps> = ({
   totalLabel,
   counts,
   appIds = APP_IDS,
+  activeApps,
+  onAppClick,
 }) => {
+  const interactive = !!onAppClick;
   return (
     <div className="flex-shrink-0 py-4 glass rounded-xl border border-white/10 mb-4 px-6 flex items-center justify-between gap-4">
       <Badge variant="outline" className="bg-background/50 h-7 px-3">
         {totalLabel}
       </Badge>
       <div className="flex items-center gap-2 overflow-x-auto no-scrollbar">
-        {appIds.map((app) => (
-          <Badge
-            key={app}
-            variant="secondary"
-            className={APP_ICON_MAP[app].badgeClass}
-          >
-            <span className="opacity-75">{APP_ICON_MAP[app].label}:</span>
-            <span className="font-bold ml-1">{counts[app] ?? 0}</span>
-          </Badge>
-        ))}
+        {appIds.map((app) => {
+          const active = activeApps?.has(app) ?? false;
+          const badge = (
+            <Badge
+              key={app}
+              variant="secondary"
+              className={cn(
+                APP_ICON_MAP[app].badgeClass,
+                interactive && "cursor-pointer transition-shadow",
+                active &&
+                  "ring-2 ring-primary ring-offset-1 ring-offset-background",
+              )}
+            >
+              <span className="opacity-75">{APP_ICON_MAP[app].label}:</span>
+              <span className="font-bold ml-1">{counts[app] ?? 0}</span>
+            </Badge>
+          );
+          if (!interactive) return badge;
+          return (
+            <button
+              key={app}
+              type="button"
+              onClick={() => onAppClick(app)}
+              className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md"
+              aria-pressed={active}
+            >
+              {badge}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/skills/SkillsBulkActionBar.tsx
+++ b/src/components/skills/SkillsBulkActionBar.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Trash2, RefreshCw, X, ChevronDown, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { APP_ICON_MAP } from "@/config/appConfig";
+import type { AppId } from "@/lib/api/types";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface SkillsBulkActionBarProps {
+  selectedCount: number;
+  selectedHasUpdate: number;
+  appIds: AppId[];
+  onUninstall: () => void;
+  onToggleApp: (app: AppId, enabled: boolean) => void;
+  onUpdateAvailable: () => void;
+  onCancel: () => void;
+  onSelectAll: () => void;
+  totalVisible: number;
+  isWorking: boolean;
+}
+
+export function SkillsBulkActionBar({
+  selectedCount,
+  selectedHasUpdate,
+  appIds,
+  onUninstall,
+  onToggleApp,
+  onUpdateAvailable,
+  onCancel,
+  onSelectAll,
+  totalVisible,
+  isWorking,
+}: SkillsBulkActionBarProps) {
+  const { t } = useTranslation();
+  const [enableOpen, setEnableOpen] = useState(false);
+  const [disableOpen, setDisableOpen] = useState(false);
+
+  const allSelected = selectedCount > 0 && selectedCount === totalVisible;
+
+  return (
+    <div className="-mx-6 px-6 py-2 border-t border-border-default flex flex-wrap items-center gap-2 bg-muted/30">
+      <span className="text-sm font-medium">
+        {t("skills.bulk.selected", { count: selectedCount })}
+      </span>
+
+      <Button
+        type="button"
+        variant="link"
+        onClick={onSelectAll}
+        className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
+      >
+        {allSelected
+          ? t("skills.bulk.selectNone")
+          : t("skills.bulk.selectAll", { count: totalVisible })}
+      </Button>
+
+      <div className="ml-auto flex flex-wrap items-center gap-1.5">
+        <DropdownMenu open={enableOpen} onOpenChange={setEnableOpen}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={selectedCount === 0 || isWorking}
+              className="h-8 gap-1"
+            >
+              <Check className="h-3.5 w-3.5" />
+              {t("skills.bulk.enableIn")}
+              <ChevronDown className="h-3 w-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            {appIds.map((app) => (
+              <DropdownMenuItem
+                key={app}
+                onSelect={() => onToggleApp(app, true)}
+              >
+                {APP_ICON_MAP[app]?.label ?? app}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu open={disableOpen} onOpenChange={setDisableOpen}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={selectedCount === 0 || isWorking}
+              className="h-8 gap-1"
+            >
+              <X className="h-3.5 w-3.5" />
+              {t("skills.bulk.disableIn")}
+              <ChevronDown className="h-3 w-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            {appIds.map((app) => (
+              <DropdownMenuItem
+                key={app}
+                onSelect={() => onToggleApp(app, false)}
+              >
+                {APP_ICON_MAP[app]?.label ?? app}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {selectedHasUpdate > 0 && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isWorking}
+            className="h-8 gap-1"
+            onClick={onUpdateAvailable}
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            {t("skills.bulk.updateAvailable", { count: selectedHasUpdate })}
+          </Button>
+        )}
+
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          disabled={selectedCount === 0 || isWorking}
+          className="h-8 gap-1"
+          onClick={onUninstall}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          {t("skills.bulk.uninstall")}
+        </Button>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8"
+          onClick={onCancel}
+        >
+          {t("skills.bulk.cancel")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/skills/SkillsToolbar.tsx
+++ b/src/components/skills/SkillsToolbar.tsx
@@ -1,0 +1,260 @@
+import { useTranslation } from "react-i18next";
+import { Search, X, CheckSquare, XSquare } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  LOCAL_SOURCE_KEY,
+  type GroupKey,
+  type SortKey,
+} from "./useSkillsFilterSort";
+
+interface SkillsToolbarProps {
+  searchQuery: string;
+  onSearchChange: (q: string) => void;
+
+  sourceOptions: string[];
+  filterSources: Set<string>;
+  onToggleSource: (key: string) => void;
+
+  filterUpdateOnly: boolean;
+  onToggleUpdateOnly: () => void;
+  updateAvailableCount: number;
+
+  sortKey: SortKey;
+  onSortChange: (k: SortKey) => void;
+
+  groupKey: GroupKey;
+  onGroupChange: (k: GroupKey) => void;
+
+  selectionMode: boolean;
+  onToggleSelectionMode: () => void;
+
+  hasFilters: boolean;
+  onClearFilters: () => void;
+
+  total: number;
+  filteredCount: number;
+}
+
+const SORT_OPTIONS: SortKey[] = [
+  "nameAsc",
+  "nameDesc",
+  "installedNewest",
+  "installedOldest",
+  "sourceAsc",
+];
+
+const GROUP_OPTIONS: GroupKey[] = ["none", "source", "app"];
+
+export function SkillsToolbar({
+  searchQuery,
+  onSearchChange,
+  sourceOptions,
+  filterSources,
+  onToggleSource,
+  filterUpdateOnly,
+  onToggleUpdateOnly,
+  updateAvailableCount,
+  sortKey,
+  onSortChange,
+  groupKey,
+  onGroupChange,
+  selectionMode,
+  onToggleSelectionMode,
+  hasFilters,
+  onClearFilters,
+  total,
+  filteredCount,
+}: SkillsToolbarProps) {
+  const { t } = useTranslation();
+  const showSecondRow =
+    sourceOptions.length > 0 || updateAvailableCount > 0 || hasFilters;
+
+  return (
+    <div className="flex flex-col gap-2 pb-2">
+      {/* 第一行：搜索 + 计数 + 排序 + 分组 + 多选 */}
+      <div className="flex flex-col gap-2 md:flex-row md:items-center">
+        <div className="relative flex-1 min-w-0">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          <Input
+            type="text"
+            placeholder={t("skills.toolbar.searchPlaceholder")}
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="pl-9 pr-9"
+          />
+          {searchQuery && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => onSearchChange("")}
+              className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7"
+              aria-label={t("common.clear")}
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+
+        <span className="text-xs text-muted-foreground whitespace-nowrap min-w-[3.5rem] text-right">
+          {t("skills.toolbar.showing", {
+            filtered: filteredCount,
+            total,
+          })}
+        </span>
+
+        <div className="flex items-center gap-2">
+          <div className="w-40">
+            <Select
+              value={sortKey}
+              onValueChange={(v) => onSortChange(v as SortKey)}
+            >
+              <SelectTrigger className="bg-card border shadow-sm text-foreground">
+                <SelectValue
+                  placeholder={t("skills.toolbar.sortBy")}
+                  className="text-left truncate"
+                />
+              </SelectTrigger>
+              <SelectContent className="bg-card text-foreground shadow-lg">
+                {SORT_OPTIONS.map((k) => (
+                  <SelectItem key={k} value={k}>
+                    {t(`skills.sort.${k}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="w-32">
+            <Select
+              value={groupKey}
+              onValueChange={(v) => onGroupChange(v as GroupKey)}
+            >
+              <SelectTrigger className="bg-card border shadow-sm text-foreground">
+                <SelectValue
+                  placeholder={t("skills.toolbar.groupBy")}
+                  className="text-left truncate"
+                />
+              </SelectTrigger>
+              <SelectContent className="bg-card text-foreground shadow-lg">
+                {GROUP_OPTIONS.map((k) => (
+                  <SelectItem key={k} value={k}>
+                    <span className="flex flex-col items-start">
+                      <span>{t(`skills.group.${k}`)}</span>
+                      {k === "app" && (
+                        <span className="text-[10px] text-muted-foreground">
+                          {t("skills.group.appHint")}
+                        </span>
+                      )}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button
+            type="button"
+            variant={selectionMode ? "default" : "outline"}
+            size="sm"
+            className="h-9 gap-1 shrink-0"
+            onClick={onToggleSelectionMode}
+            title={
+              selectionMode
+                ? t("skills.toolbar.exitMultiSelect")
+                : t("skills.toolbar.multiSelectMode")
+            }
+          >
+            {selectionMode ? (
+              <XSquare className="h-4 w-4" />
+            ) : (
+              <CheckSquare className="h-4 w-4" />
+            )}
+            <span className="hidden md:inline">
+              {selectionMode
+                ? t("skills.toolbar.exitMultiSelect")
+                : t("skills.toolbar.multiSelectMode")}
+            </span>
+          </Button>
+        </div>
+      </div>
+
+      {/* 第二行：来源 chips + 仅有更新 + 清除筛选（仅当有内容时显示） */}
+      {showSecondRow && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs">
+          {sourceOptions.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-muted-foreground mr-0.5">
+                {t("skills.filter.source")}:
+              </span>
+              {sourceOptions.map((src) => {
+                const active = filterSources.has(src);
+                return (
+                  <button
+                    key={src}
+                    type="button"
+                    onClick={() => onToggleSource(src)}
+                    className="focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-full"
+                  >
+                    <Badge
+                      variant={active ? "default" : "outline"}
+                      className={cn(
+                        "cursor-pointer font-normal",
+                        !active && "hover:bg-muted",
+                      )}
+                    >
+                      {src === LOCAL_SOURCE_KEY
+                        ? t("skills.filter.local")
+                        : src}
+                    </Badge>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {updateAvailableCount > 0 && (
+            <button
+              type="button"
+              onClick={onToggleUpdateOnly}
+              className="focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-full"
+            >
+              <Badge
+                variant={filterUpdateOnly ? "default" : "outline"}
+                className={cn(
+                  "cursor-pointer font-normal",
+                  !filterUpdateOnly && "hover:bg-muted",
+                )}
+              >
+                {t("skills.filter.updateOnly", {
+                  count: updateAvailableCount,
+                })}
+              </Badge>
+            </button>
+          )}
+
+          {hasFilters && (
+            <Button
+              type="button"
+              variant="link"
+              onClick={onClearFilters}
+              className="ml-auto h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
+            >
+              {t("skills.toolbar.clearFilters")}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -42,10 +42,19 @@ import { ListItemRow } from "@/components/common/ListItemRow";
 import { cn } from "@/lib/utils";
 import { SkillsToolbar } from "./SkillsToolbar";
 import { SkillsBulkActionBar } from "./SkillsBulkActionBar";
+import { SkillLoadModeChip } from "./SkillLoadModeChip";
+import { SkillRuntimeSettings } from "./SkillRuntimeSettings";
+import {
+  useClaudeRuntimeConfig,
+  useDiscoverAllSkills,
+  useSetSkillLoadMode,
+} from "@/hooks/useSkillLoadMode";
+import type { DiscoveredSkill, SkillLoadMode } from "@/lib/api/skills";
 import {
   useSkillsFilterSort,
   LOCAL_SOURCE_KEY,
   ALL_GROUP_KEY,
+  UNASSIGNED_GROUP_KEY,
 } from "./useSkillsFilterSort";
 import {
   Dialog,
@@ -115,6 +124,22 @@ const UnifiedSkillsPanel = React.forwardRef<
   const setPinMutation = useSetSkillPin();
   const [isUpdatingAll, setIsUpdatingAll] = useState(false);
   const [isBulkWorking, setIsBulkWorking] = useState(false);
+
+  // Claude Code 运行时（skill 加载模式）
+  const { data: runtimeConfig } = useClaudeRuntimeConfig();
+  const { data: discoveredSkills } = useDiscoverAllSkills();
+  const setLoadModeMutation = useSetSkillLoadMode();
+
+  const loadModeFor = (name: string): SkillLoadMode =>
+    runtimeConfig?.skillLoadModes[name] ?? "on";
+
+  const handleChangeLoadMode = async (name: string, mode: SkillLoadMode) => {
+    try {
+      await setLoadModeMutation.mutateAsync({ name, mode });
+    } catch (error) {
+      toast.error(t("common.error"), { description: String(error) });
+    }
+  };
 
   const updatesMap = useMemo(() => {
     const map: Record<string, SkillUpdateInfo> = {};
@@ -304,10 +329,18 @@ const UnifiedSkillsPanel = React.forwardRef<
     return `${installName}:${skill.repoOwner?.toLowerCase() || ""}:${skill.repoName?.toLowerCase() || ""}`;
   };
 
+  // 批量操作只能作用在“当前可见”的选中项上：用户改变过滤器后，
+  // 不可见但仍记录在 selectedIds 中的 skill 不能被静默卸载/切换/更新。
+  // 清除过滤器后选中状态会重新出现，符合用户预期。
   const getSelectedSkills = (): InstalledSkill[] => {
-    if (!skills) return [];
-    return skills.filter((s) => toolbar.state.selectedIds.has(s.id));
+    return toolbar.filtered.filter((s) => toolbar.state.selectedIds.has(s.id));
   };
+
+  const visibleSelectedCount = useMemo(
+    () => getSelectedSkills().length,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [toolbar.filtered, toolbar.state.selectedIds],
+  );
 
   const handleBulkUninstall = () => {
     const selected = getSelectedSkills();
@@ -405,7 +438,7 @@ const UnifiedSkillsPanel = React.forwardRef<
   const selectedHasUpdate = useMemo(() => {
     return getSelectedSkills().filter((s) => updatesMap[s.id]).length;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [toolbar.state.selectedIds, skills, updatesMap]);
+  }, [toolbar.state.selectedIds, toolbar.filtered, updatesMap]);
 
   const handleOpenRestoreFromBackup = async () => {
     setRestoreDialogOpen(true);
@@ -548,6 +581,7 @@ const UnifiedSkillsPanel = React.forwardRef<
                 ? t("skills.checkingUpdates")
                 : t("skills.checkUpdates")}
             </Button>
+            <SkillRuntimeSettings />
           </div>
         </div>
 
@@ -583,7 +617,7 @@ const UnifiedSkillsPanel = React.forwardRef<
         {/* 多选条：与 toolbar 同处 sticky 顶部组合，避免 top-offset 计算 */}
         {toolbar.state.selectionMode && (
           <SkillsBulkActionBar
-            selectedCount={toolbar.state.selectedIds.size}
+            selectedCount={visibleSelectedCount}
             selectedHasUpdate={selectedHasUpdate}
             appIds={SKILLS_APP_IDS}
             onUninstall={handleBulkUninstall}
@@ -592,7 +626,7 @@ const UnifiedSkillsPanel = React.forwardRef<
             onCancel={toolbar.exitSelectionMode}
             onSelectAll={() => {
               if (
-                toolbar.state.selectedIds.size === toolbar.filteredCount &&
+                visibleSelectedCount === toolbar.filteredCount &&
                 toolbar.filteredCount > 0
               ) {
                 toolbar.clearSelection();
@@ -650,7 +684,9 @@ const UnifiedSkillsPanel = React.forwardRef<
                 const collapsed = toolbar.state.collapsed.has(group.key);
                 const groupLabel =
                   toolbar.state.groupKey === "app"
-                    ? (APP_ICON_MAP[group.key as AppId]?.label ?? group.label)
+                    ? group.key === UNASSIGNED_GROUP_KEY
+                      ? t("skills.group.unassigned")
+                      : (APP_ICON_MAP[group.key as AppId]?.label ?? group.label)
                     : group.key === LOCAL_SOURCE_KEY
                       ? t("skills.local")
                       : group.label;
@@ -694,6 +730,10 @@ const UnifiedSkillsPanel = React.forwardRef<
                             onToggleSelect={() =>
                               toolbar.toggleSelected(skill.id)
                             }
+                            loadMode={loadModeFor(skill.name)}
+                            onChangeLoadMode={(mode) =>
+                              handleChangeLoadMode(skill.name, mode)
+                            }
                           />
                         ))}
                       </div>
@@ -728,6 +768,12 @@ const UnifiedSkillsPanel = React.forwardRef<
         />
       )}
 
+      <DiscoveredOnlySection
+        skills={discoveredSkills ?? []}
+        managedNames={new Set((skills ?? []).map((s) => s.name))}
+        onChangeLoadMode={handleChangeLoadMode}
+      />
+
       <RestoreSkillsDialog
         backups={skillBackups}
         isDeleting={deleteBackupMutation.isPending}
@@ -744,6 +790,104 @@ const UnifiedSkillsPanel = React.forwardRef<
 
 UnifiedSkillsPanel.displayName = "UnifiedSkillsPanel";
 
+/**
+ * 列出非 cc-switch 管理的 skill（plugin、用户级、`~/.agents/skills/`），
+ * 仅暴露加载模式控制；不提供安装/卸载/置顶。
+ */
+const DiscoveredOnlySection: React.FC<{
+  skills: DiscoveredSkill[];
+  /** cc-switch 已经在主列表里渲染过的 skill name，本 section 跳过这些 */
+  managedNames: Set<string>;
+  onChangeLoadMode: (name: string, mode: SkillLoadMode) => void;
+}> = ({ skills, managedNames, onChangeLoadMode }) => {
+  const { t } = useTranslation();
+  const [collapsed, setCollapsed] = useState(false);
+
+  const filtered = useMemo(
+    () =>
+      skills.filter(
+        (s) => s.source.kind !== "cc-switch" && !managedNames.has(s.name),
+      ),
+    [skills, managedNames],
+  );
+
+  if (filtered.length === 0) return null;
+
+  return (
+    <div className="mt-4 mb-6">
+      <button
+        type="button"
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+      >
+        {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+        <span>{t("skills.discoveredOnly.title")}</span>
+        <span className="text-muted-foreground/60">({filtered.length})</span>
+      </button>
+      {!collapsed && (
+        <div className="mt-2 rounded-xl border border-border-default overflow-hidden">
+          {filtered.map((s, idx) => (
+            <DiscoveredOnlyRow
+              key={`${s.name}:${s.sourcePath}`}
+              skill={s}
+              isLast={idx === filtered.length - 1}
+              onChangeLoadMode={(mode) => onChangeLoadMode(s.name, mode)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const DiscoveredOnlyRow: React.FC<{
+  skill: DiscoveredSkill;
+  isLast: boolean;
+  onChangeLoadMode: (mode: SkillLoadMode) => void;
+}> = ({ skill, isLast, onChangeLoadMode }) => {
+  const { t } = useTranslation();
+
+  const sourceLabel = useMemo(() => {
+    switch (skill.source.kind) {
+      case "plugin":
+        return `${skill.source.marketplace}/${skill.source.plugin}`;
+      case "user-level":
+        return t("skills.discoveredOnly.userLevel");
+      case "agents-dir":
+        return t("skills.discoveredOnly.agentsDir");
+      default:
+        return "";
+    }
+  }, [skill.source, t]);
+
+  return (
+    <ListItemRow isLast={isLast}>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="font-medium text-sm text-foreground truncate">
+            {skill.name}
+          </span>
+          <Badge
+            variant="outline"
+            className="shrink-0 text-[10px] px-1.5 py-0 h-4"
+          >
+            {sourceLabel}
+          </Badge>
+        </div>
+        {skill.description && (
+          <p
+            className="text-xs text-muted-foreground truncate"
+            title={skill.description}
+          >
+            {skill.description}
+          </p>
+        )}
+      </div>
+      <SkillLoadModeChip value={skill.loadMode} onChange={onChangeLoadMode} />
+    </ListItemRow>
+  );
+};
+
 interface InstalledSkillListItemProps {
   skill: InstalledSkill;
   hasUpdate?: boolean;
@@ -756,6 +900,8 @@ interface InstalledSkillListItemProps {
   selectionMode?: boolean;
   isSelected?: boolean;
   onToggleSelect?: () => void;
+  loadMode: SkillLoadMode;
+  onChangeLoadMode: (mode: SkillLoadMode) => void;
 }
 
 const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
@@ -770,6 +916,8 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
   selectionMode,
   isSelected,
   onToggleSelect,
+  loadMode,
+  onChangeLoadMode,
 }) => {
   const { t } = useTranslation();
   const isPinned = !!skill.pinnedAt;
@@ -850,6 +998,15 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
           </p>
         )}
       </div>
+
+      <SkillLoadModeChip
+        value={loadMode}
+        onChange={onChangeLoadMode}
+        disabled={!skill.apps.claude}
+        disabledReason={
+          !skill.apps.claude ? t("skills.loadMode.disabledClaude") : undefined
+        }
+      />
 
       <AppToggleGroup
         apps={skill.apps}

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -6,9 +6,13 @@ import {
   ExternalLink,
   RefreshCw,
   Loader2,
+  Star,
+  ChevronDown,
+  ChevronRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   type ImportSkillSelection,
@@ -24,6 +28,7 @@ import {
   useInstallSkillsFromZip,
   useCheckSkillUpdates,
   useUpdateSkill,
+  useSetSkillPin,
   type InstalledSkill,
   type SkillUpdateInfo,
 } from "@/hooks/useSkills";
@@ -31,10 +36,17 @@ import type { AppId } from "@/lib/api/types";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi, skillsApi } from "@/lib/api";
 import { toast } from "sonner";
-import { SKILLS_APP_IDS } from "@/config/appConfig";
-import { AppCountBar } from "@/components/common/AppCountBar";
+import { SKILLS_APP_IDS, APP_ICON_MAP } from "@/config/appConfig";
 import { AppToggleGroup } from "@/components/common/AppToggleGroup";
 import { ListItemRow } from "@/components/common/ListItemRow";
+import { cn } from "@/lib/utils";
+import { SkillsToolbar } from "./SkillsToolbar";
+import { SkillsBulkActionBar } from "./SkillsBulkActionBar";
+import {
+  useSkillsFilterSort,
+  LOCAL_SOURCE_KEY,
+  ALL_GROUP_KEY,
+} from "./useSkillsFilterSort";
 import {
   Dialog,
   DialogContent,
@@ -100,7 +112,9 @@ const UnifiedSkillsPanel = React.forwardRef<
     isFetching: isCheckingUpdates,
   } = useCheckSkillUpdates();
   const updateSkillMutation = useUpdateSkill();
+  const setPinMutation = useSetSkillPin();
   const [isUpdatingAll, setIsUpdatingAll] = useState(false);
+  const [isBulkWorking, setIsBulkWorking] = useState(false);
 
   const updatesMap = useMemo(() => {
     const map: Record<string, SkillUpdateInfo> = {};
@@ -111,6 +125,9 @@ const UnifiedSkillsPanel = React.forwardRef<
     }
     return map;
   }, [skillUpdates]);
+
+  // Skills 工具栏：搜索/过滤/排序/分组/多选状态
+  const toolbar = useSkillsFilterSort(skills ?? [], updatesMap, SKILLS_APP_IDS);
 
   const enabledCounts = useMemo(() => {
     const counts = {
@@ -276,6 +293,120 @@ const UnifiedSkillsPanel = React.forwardRef<
     }
   };
 
+  const handleTogglePin = (skill: InstalledSkill) => {
+    setPinMutation.mutate({ id: skill.id, pinned: !skill.pinnedAt });
+  };
+
+  const buildSkillKey = (skill: InstalledSkill): string => {
+    const installName =
+      skill.directory.split(/[/\\]/).pop()?.toLowerCase() ||
+      skill.directory.toLowerCase();
+    return `${installName}:${skill.repoOwner?.toLowerCase() || ""}:${skill.repoName?.toLowerCase() || ""}`;
+  };
+
+  const getSelectedSkills = (): InstalledSkill[] => {
+    if (!skills) return [];
+    return skills.filter((s) => toolbar.state.selectedIds.has(s.id));
+  };
+
+  const handleBulkUninstall = () => {
+    const selected = getSelectedSkills();
+    if (selected.length === 0) return;
+    setConfirmDialog({
+      isOpen: true,
+      title: t("skills.bulk.confirmUninstallTitle"),
+      message: t("skills.bulk.confirmUninstallMessage", {
+        count: selected.length,
+      }),
+      variant: "destructive",
+      confirmText: t("skills.uninstall"),
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        setIsBulkWorking(true);
+        let okCount = 0;
+        for (const skill of selected) {
+          try {
+            await uninstallMutation.mutateAsync({
+              id: skill.id,
+              skillKey: buildSkillKey(skill),
+            });
+            okCount++;
+          } catch (error) {
+            toast.error(t("skills.uninstallFailed"), {
+              description: `${skill.name}: ${String(error)}`,
+            });
+          }
+        }
+        setIsBulkWorking(false);
+        toolbar.exitSelectionMode();
+        if (okCount > 0) {
+          toast.success(t("skills.bulk.uninstallSuccess", { count: okCount }), {
+            closeButton: true,
+          });
+        }
+      },
+    });
+  };
+
+  const handleBulkToggleApp = async (app: AppId, enabled: boolean) => {
+    const selected = getSelectedSkills();
+    if (selected.length === 0) return;
+    setIsBulkWorking(true);
+    let okCount = 0;
+    for (const skill of selected) {
+      try {
+        await toggleAppMutation.mutateAsync({ id: skill.id, app, enabled });
+        okCount++;
+      } catch (error) {
+        toast.error(t("common.error"), {
+          description: `${skill.name}: ${String(error)}`,
+        });
+      }
+    }
+    setIsBulkWorking(false);
+    if (okCount > 0) {
+      toast.success(
+        t(
+          enabled ? "skills.bulk.enableSuccess" : "skills.bulk.disableSuccess",
+          {
+            count: okCount,
+            app: APP_ICON_MAP[app]?.label ?? app,
+          },
+        ),
+        { closeButton: true },
+      );
+    }
+  };
+
+  const handleBulkUpdateAvailable = async () => {
+    const selected = getSelectedSkills().filter((s) => updatesMap[s.id]);
+    if (selected.length === 0) return;
+    setIsBulkWorking(true);
+    let okCount = 0;
+    for (const skill of selected) {
+      try {
+        await updateSkillMutation.mutateAsync(skill.id);
+        okCount++;
+      } catch (error) {
+        toast.error(t("skills.updateFailed"), {
+          description: `${skill.name}: ${String(error)}`,
+        });
+      }
+    }
+    setIsBulkWorking(false);
+    toolbar.exitSelectionMode();
+    if (okCount > 0) {
+      toast.success(t("skills.updateAllSuccess", { count: okCount }), {
+        closeButton: true,
+      });
+    }
+  };
+
+  const selectedHasUpdate = useMemo(() => {
+    return getSelectedSkills().filter((s) => updatesMap[s.id]).length;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolbar.state.selectedIds, skills, updatesMap]);
+
   const handleOpenRestoreFromBackup = async () => {
     setRestoreDialogOpen(true);
     try {
@@ -345,61 +476,137 @@ const UnifiedSkillsPanel = React.forwardRef<
   }));
 
   return (
-    <div className="px-6 flex flex-col flex-1 min-h-0 overflow-hidden">
-      <div className="flex items-center justify-between">
-        <AppCountBar
-          totalLabel={t("skills.installed", { count: skills?.length || 0 })}
-          counts={enabledCounts}
-          appIds={SKILLS_APP_IDS}
-        />
-        <div className="flex items-center gap-1.5">
-          <div
-            className="transition-all duration-300 ease-out overflow-hidden"
-            style={{
-              maxWidth:
-                skillUpdates && skillUpdates.length > 0 ? "200px" : "0px",
-              opacity: skillUpdates && skillUpdates.length > 0 ? 1 : 0,
-            }}
-          >
+    <div className="px-6 flex flex-col flex-1 min-h-0">
+      {/* 粘性顶部：标题/计数 chips/更新操作 + 工具栏 + 多选条 */}
+      <div className="sticky top-0 z-20 -mx-6 px-6 border-b border-border-default bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        {/* 紧凑 header：标题 + App 计数 chips（点击切换过滤）+ 更新操作 */}
+        <div className="flex items-center justify-between gap-3 py-3">
+          <div className="flex items-center gap-2 flex-wrap min-w-0">
+            <span className="text-sm font-medium whitespace-nowrap text-foreground">
+              {t("skills.installed", { count: skills?.length || 0 })}
+            </span>
+            {SKILLS_APP_IDS.length > 0 && (
+              <span className="h-4 w-px bg-border" />
+            )}
+            {SKILLS_APP_IDS.map((app) => {
+              const active = toolbar.state.filterApps.has(app);
+              const cfg = APP_ICON_MAP[app];
+              return (
+                <button
+                  key={app}
+                  type="button"
+                  onClick={() => toolbar.toggleApp(app)}
+                  aria-pressed={active}
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    cfg.badgeClass,
+                    active
+                      ? "ring-2 ring-primary ring-offset-1 ring-offset-background"
+                      : "opacity-80 hover:opacity-100",
+                  )}
+                >
+                  <span className="opacity-75">{cfg.label}:</span>
+                  <span className="font-bold">{enabledCounts[app] ?? 0}</span>
+                </button>
+              );
+            })}
+          </div>
+          <div className="flex items-center gap-1.5 shrink-0">
+            {skillUpdates && skillUpdates.length > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 text-xs gap-1 whitespace-nowrap"
+                onClick={handleUpdateAll}
+                disabled={isUpdatingAll || updateSkillMutation.isPending}
+              >
+                {isUpdatingAll ? (
+                  <Loader2 size={12} className="animate-spin" />
+                ) : (
+                  <RefreshCw size={12} />
+                )}
+                {isUpdatingAll
+                  ? t("skills.updatingAll")
+                  : t("skills.updateAll", { count: skillUpdates.length })}
+              </Button>
+            )}
             <Button
               type="button"
-              variant="outline"
+              variant="ghost"
               size="sm"
-              className="h-7 text-xs gap-1 whitespace-nowrap"
-              onClick={handleUpdateAll}
-              disabled={isUpdatingAll || updateSkillMutation.isPending}
+              className="h-7 text-xs gap-1"
+              onClick={handleCheckUpdates}
+              disabled={isCheckingUpdates || !skills || skills.length === 0}
             >
-              {isUpdatingAll ? (
+              {isCheckingUpdates ? (
                 <Loader2 size={12} className="animate-spin" />
               ) : (
                 <RefreshCw size={12} />
               )}
-              {isUpdatingAll
-                ? t("skills.updatingAll")
-                : t("skills.updateAll", { count: skillUpdates?.length ?? 0 })}
+              {isCheckingUpdates
+                ? t("skills.checkingUpdates")
+                : t("skills.checkUpdates")}
             </Button>
           </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 text-xs gap-1"
-            onClick={handleCheckUpdates}
-            disabled={isCheckingUpdates || !skills || skills.length === 0}
-          >
-            {isCheckingUpdates ? (
-              <Loader2 size={12} className="animate-spin" />
-            ) : (
-              <RefreshCw size={12} />
-            )}
-            {isCheckingUpdates
-              ? t("skills.checkingUpdates")
-              : t("skills.checkUpdates")}
-          </Button>
         </div>
-      </div>
 
-      <div className="flex-1 overflow-y-auto overflow-x-hidden pb-24">
+        {skills && skills.length > 0 && (
+          <SkillsToolbar
+            searchQuery={toolbar.state.searchQuery}
+            onSearchChange={toolbar.setSearchQuery}
+            sourceOptions={toolbar.sourceOptions}
+            filterSources={toolbar.state.filterSources}
+            onToggleSource={toolbar.toggleSource}
+            filterUpdateOnly={toolbar.state.filterUpdateOnly}
+            onToggleUpdateOnly={() =>
+              toolbar.setFilterUpdateOnly(!toolbar.state.filterUpdateOnly)
+            }
+            updateAvailableCount={skillUpdates?.length ?? 0}
+            sortKey={toolbar.state.sortKey}
+            onSortChange={toolbar.setSortKey}
+            groupKey={toolbar.state.groupKey}
+            onGroupChange={toolbar.setGroupKey}
+            selectionMode={toolbar.state.selectionMode}
+            onToggleSelectionMode={() =>
+              toolbar.state.selectionMode
+                ? toolbar.exitSelectionMode()
+                : toolbar.enterSelectionMode()
+            }
+            hasFilters={toolbar.hasFilters}
+            onClearFilters={toolbar.clearFilters}
+            total={toolbar.total}
+            filteredCount={toolbar.filteredCount}
+          />
+        )}
+
+        {/* 多选条：与 toolbar 同处 sticky 顶部组合，避免 top-offset 计算 */}
+        {toolbar.state.selectionMode && (
+          <SkillsBulkActionBar
+            selectedCount={toolbar.state.selectedIds.size}
+            selectedHasUpdate={selectedHasUpdate}
+            appIds={SKILLS_APP_IDS}
+            onUninstall={handleBulkUninstall}
+            onToggleApp={handleBulkToggleApp}
+            onUpdateAvailable={handleBulkUpdateAvailable}
+            onCancel={toolbar.exitSelectionMode}
+            onSelectAll={() => {
+              if (
+                toolbar.state.selectedIds.size === toolbar.filteredCount &&
+                toolbar.filteredCount > 0
+              ) {
+                toolbar.clearSelection();
+              } else {
+                toolbar.selectAllVisible();
+              }
+            }}
+            totalVisible={toolbar.filteredCount}
+            isWorking={isBulkWorking}
+          />
+        )}
+      </div>
+      {/* 列表区（main 是 scroll container，此处不再独立滚动） */}
+      <div className="pt-3 pb-24">
         {isLoading ? (
           <div className="text-center py-12 text-muted-foreground">
             {t("skills.loading")}
@@ -416,24 +623,84 @@ const UnifiedSkillsPanel = React.forwardRef<
               {t("skills.noInstalledDescription")}
             </p>
           </div>
+        ) : toolbar.filteredCount === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-sm text-muted-foreground">
+              {t("skills.noResults")}
+            </p>
+            {toolbar.hasFilters && (
+              <Button
+                type="button"
+                variant="link"
+                onClick={toolbar.clearFilters}
+                className="mt-2 h-auto p-0 text-sm"
+              >
+                {t("skills.toolbar.clearFilters")}
+              </Button>
+            )}
+          </div>
         ) : (
           <TooltipProvider delayDuration={300}>
-            <div className="rounded-xl border border-border-default overflow-hidden">
-              {skills.map((skill, index) => (
-                <InstalledSkillListItem
-                  key={skill.id}
-                  skill={skill}
-                  hasUpdate={!!updatesMap[skill.id]}
-                  isUpdating={
-                    updateSkillMutation.isPending &&
-                    updateSkillMutation.variables === skill.id
-                  }
-                  onToggleApp={handleToggleApp}
-                  onUninstall={() => handleUninstall(skill)}
-                  onUpdate={() => handleUpdateSkill(skill)}
-                  isLast={index === skills.length - 1}
-                />
-              ))}
+            <div className="flex flex-col gap-3">
+              {toolbar.groups.map((group) => {
+                if (group.items.length === 0) return null;
+                const showHeader =
+                  toolbar.state.groupKey !== "none" &&
+                  group.key !== ALL_GROUP_KEY;
+                const collapsed = toolbar.state.collapsed.has(group.key);
+                const groupLabel =
+                  toolbar.state.groupKey === "app"
+                    ? (APP_ICON_MAP[group.key as AppId]?.label ?? group.label)
+                    : group.key === LOCAL_SOURCE_KEY
+                      ? t("skills.local")
+                      : group.label;
+                return (
+                  <div key={group.key}>
+                    {showHeader && (
+                      <button
+                        type="button"
+                        onClick={() => toolbar.toggleCollapsed(group.key)}
+                        className="w-full flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+                      >
+                        {collapsed ? (
+                          <ChevronRight size={14} />
+                        ) : (
+                          <ChevronDown size={14} />
+                        )}
+                        <span>{groupLabel}</span>
+                        <span className="text-muted-foreground/60">
+                          ({group.items.length})
+                        </span>
+                      </button>
+                    )}
+                    {!collapsed && (
+                      <div className="rounded-xl border border-border-default overflow-hidden">
+                        {group.items.map((skill, index) => (
+                          <InstalledSkillListItem
+                            key={`${group.key}:${skill.id}`}
+                            skill={skill}
+                            hasUpdate={!!updatesMap[skill.id]}
+                            isUpdating={
+                              updateSkillMutation.isPending &&
+                              updateSkillMutation.variables === skill.id
+                            }
+                            onToggleApp={handleToggleApp}
+                            onUninstall={() => handleUninstall(skill)}
+                            onUpdate={() => handleUpdateSkill(skill)}
+                            onTogglePin={() => handleTogglePin(skill)}
+                            isLast={index === group.items.length - 1}
+                            selectionMode={toolbar.state.selectionMode}
+                            isSelected={toolbar.state.selectedIds.has(skill.id)}
+                            onToggleSelect={() =>
+                              toolbar.toggleSelected(skill.id)
+                            }
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </TooltipProvider>
         )}
@@ -484,7 +751,11 @@ interface InstalledSkillListItemProps {
   onToggleApp: (id: string, app: AppId, enabled: boolean) => void;
   onUninstall: () => void;
   onUpdate?: () => void;
+  onTogglePin?: () => void;
   isLast?: boolean;
+  selectionMode?: boolean;
+  isSelected?: boolean;
+  onToggleSelect?: () => void;
 }
 
 const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
@@ -494,9 +765,14 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
   onToggleApp,
   onUninstall,
   onUpdate,
+  onTogglePin,
   isLast,
+  selectionMode,
+  isSelected,
+  onToggleSelect,
 }) => {
   const { t } = useTranslation();
+  const isPinned = !!skill.pinnedAt;
 
   const openDocs = async () => {
     if (!skill.readmeUrl) return;
@@ -516,6 +792,29 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
 
   return (
     <ListItemRow isLast={isLast}>
+      {selectionMode ? (
+        <Checkbox
+          checked={!!isSelected}
+          onCheckedChange={() => onToggleSelect?.()}
+          aria-label={t("skills.bulk.select")}
+          className="shrink-0"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={onTogglePin}
+          title={isPinned ? t("skills.pin.unpin") : t("skills.pin.pin")}
+          className={cn(
+            "shrink-0 grid place-content-center w-6 h-6 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-opacity",
+            isPinned
+              ? "opacity-100 text-amber-500 hover:text-amber-600"
+              : "opacity-0 group-hover:opacity-100",
+          )}
+        >
+          <Star size={14} className={isPinned ? "fill-current" : ""} />
+        </button>
+      )}
+
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
           <span className="font-medium text-sm text-foreground truncate">
@@ -558,38 +857,40 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
         appIds={SKILLS_APP_IDS}
       />
 
-      <div
-        className="flex-shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
-        style={hasUpdate ? { opacity: 1 } : undefined}
-      >
-        {hasUpdate && onUpdate && (
+      {!selectionMode && (
+        <div
+          className="flex-shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+          style={hasUpdate ? { opacity: 1 } : undefined}
+        >
+          {hasUpdate && onUpdate && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 hover:text-blue-500 hover:bg-blue-100 dark:hover:text-blue-400 dark:hover:bg-blue-500/10"
+              onClick={onUpdate}
+              disabled={isUpdating}
+              title={t("skills.update")}
+            >
+              {isUpdating ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <RefreshCw size={14} />
+              )}
+            </Button>
+          )}
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            className="h-7 w-7 hover:text-blue-500 hover:bg-blue-100 dark:hover:text-blue-400 dark:hover:bg-blue-500/10"
-            onClick={onUpdate}
-            disabled={isUpdating}
-            title={t("skills.update")}
+            className="h-7 w-7 hover:text-red-500 hover:bg-red-100 dark:hover:text-red-400 dark:hover:bg-red-500/10"
+            onClick={onUninstall}
+            title={t("skills.uninstall")}
           >
-            {isUpdating ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : (
-              <RefreshCw size={14} />
-            )}
+            <Trash2 size={14} />
           </Button>
-        )}
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 hover:text-red-500 hover:bg-red-100 dark:hover:text-red-400 dark:hover:bg-red-500/10"
-          onClick={onUninstall}
-          title={t("skills.uninstall")}
-        >
-          <Trash2 size={14} />
-        </Button>
-      </div>
+        </div>
+      )}
     </ListItemRow>
   );
 };
@@ -780,25 +1081,33 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
   };
 
   return (
-    <TooltipProvider delayDuration={300}>
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div className="bg-background rounded-xl p-6 max-w-lg w-full mx-4 shadow-xl max-h-[80vh] flex flex-col">
-          <h2 className="text-lg font-semibold mb-2">{t("skills.import")}</h2>
-          <p className="text-sm text-muted-foreground mb-4">
-            {t("skills.importDescription")}
-          </p>
+    <Dialog
+      open
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && !isImporting) onClose();
+      }}
+    >
+      <DialogContent
+        className="max-w-2xl max-h-[85vh] flex flex-col"
+        zIndex="alert"
+      >
+        <DialogHeader>
+          <DialogTitle>{t("skills.import")}</DialogTitle>
+          <DialogDescription>{t("skills.importDescription")}</DialogDescription>
+        </DialogHeader>
 
-          <div className="flex-1 overflow-y-auto space-y-2 mb-4">
+        <TooltipProvider delayDuration={300}>
+          <div className="flex-1 overflow-y-auto px-6 py-4 space-y-2">
             {skills.map((skill) => (
               <div
                 key={skill.directory}
                 className="flex items-start gap-3 p-3 rounded-lg border hover:bg-muted"
               >
-                <input
-                  type="checkbox"
+                <Checkbox
                   checked={selected.has(skill.directory)}
-                  onChange={() => toggleSelect(skill.directory)}
-                  className="mt-1"
+                  onCheckedChange={() => toggleSelect(skill.directory)}
+                  aria-label={skill.name}
+                  className="mt-1 shrink-0"
                 />
                 <div className="flex-1 min-w-0">
                   <div className="font-medium">{skill.name}</div>
@@ -848,21 +1157,21 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
               </div>
             ))}
           </div>
+        </TooltipProvider>
 
-          <div className="flex justify-end gap-3">
-            <Button variant="outline" onClick={onClose} disabled={isImporting}>
-              {t("common.cancel")}
-            </Button>
-            <Button
-              onClick={handleImport}
-              disabled={selected.size === 0 || isImporting}
-            >
-              {t("skills.importSelected", { count: selected.size })}
-            </Button>
-          </div>
-        </div>
-      </div>
-    </TooltipProvider>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isImporting}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            onClick={handleImport}
+            disabled={selected.size === 0 || isImporting}
+          >
+            {t("skills.importSelected", { count: selected.size })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/components/skills/useSkillsFilterSort.ts
+++ b/src/components/skills/useSkillsFilterSort.ts
@@ -1,0 +1,330 @@
+import { useCallback, useMemo, useState } from "react";
+import type { AppId } from "@/lib/api/types";
+import type { InstalledSkill, SkillUpdateInfo } from "@/lib/api/skills";
+
+export type SortKey =
+  | "nameAsc"
+  | "nameDesc"
+  | "installedNewest"
+  | "installedOldest"
+  | "sourceAsc";
+
+export type GroupKey = "none" | "source" | "app";
+
+export interface FilterSortState {
+  searchQuery: string;
+  filterSources: Set<string>;
+  filterApps: Set<AppId>;
+  filterUpdateOnly: boolean;
+  sortKey: SortKey;
+  groupKey: GroupKey;
+  collapsed: Set<string>;
+  selectionMode: boolean;
+  selectedIds: Set<string>;
+}
+
+export interface SkillGroup {
+  key: string;
+  label: string;
+  items: InstalledSkill[];
+}
+
+export const LOCAL_SOURCE_KEY = "__local__";
+export const ALL_GROUP_KEY = "__all__";
+
+/** 组成 skill 的来源 key（owner/name 或 LOCAL_SOURCE_KEY） */
+export function getSourceKey(skill: InstalledSkill): string {
+  if (skill.repoOwner && skill.repoName) {
+    return `${skill.repoOwner}/${skill.repoName}`;
+  }
+  return LOCAL_SOURCE_KEY;
+}
+
+/** 全部独立的搜索匹配：name/description/directory/owner/name 任意命中 */
+export function matchSkillBySearch(
+  skill: InstalledSkill,
+  query: string,
+): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    skill.name.toLowerCase().includes(q) ||
+    (skill.description?.toLowerCase().includes(q) ?? false) ||
+    skill.directory.toLowerCase().includes(q) ||
+    (skill.repoOwner?.toLowerCase().includes(q) ?? false) ||
+    (skill.repoName?.toLowerCase().includes(q) ?? false) ||
+    `${skill.repoOwner ?? ""}/${skill.repoName ?? ""}`.toLowerCase().includes(q)
+  );
+}
+
+const SORT_FNS: Record<
+  SortKey,
+  (a: InstalledSkill, b: InstalledSkill) => number
+> = {
+  nameAsc: (a, b) => a.name.localeCompare(b.name),
+  nameDesc: (a, b) => b.name.localeCompare(a.name),
+  installedNewest: (a, b) => b.installedAt - a.installedAt,
+  installedOldest: (a, b) => a.installedAt - b.installedAt,
+  sourceAsc: (a, b) => getSourceKey(a).localeCompare(getSourceKey(b)),
+};
+
+/** 应用排序，置顶项始终在前；置顶之间按 pinnedAt 降序 */
+export function sortSkills(
+  skills: InstalledSkill[],
+  sortKey: SortKey,
+): InstalledSkill[] {
+  const cmp = SORT_FNS[sortKey];
+  return [...skills].sort((a, b) => {
+    const pa = a.pinnedAt ?? 0;
+    const pb = b.pinnedAt ?? 0;
+    if (pa !== pb) return pb - pa;
+    return cmp(a, b);
+  });
+}
+
+/** 仅做搜索 + 过滤（不排序、不分组） */
+export function filterSkills(
+  skills: InstalledSkill[],
+  state: Pick<
+    FilterSortState,
+    "searchQuery" | "filterSources" | "filterApps" | "filterUpdateOnly"
+  >,
+  updatesMap: Record<string, SkillUpdateInfo>,
+): InstalledSkill[] {
+  const q = state.searchQuery.trim();
+  return skills.filter((skill) => {
+    if (!matchSkillBySearch(skill, q)) return false;
+
+    if (state.filterSources.size > 0) {
+      if (!state.filterSources.has(getSourceKey(skill))) return false;
+    }
+
+    if (state.filterApps.size > 0) {
+      const hit = [...state.filterApps].some(
+        (app) => skill.apps[app as keyof typeof skill.apps] === true,
+      );
+      if (!hit) return false;
+    }
+
+    if (state.filterUpdateOnly) {
+      if (!updatesMap[skill.id]) return false;
+    }
+
+    return true;
+  });
+}
+
+/** 应用分组（不分组返回单一 group） */
+export function groupSkills(
+  skills: InstalledSkill[],
+  groupKey: GroupKey,
+  appIds: AppId[],
+): SkillGroup[] {
+  if (groupKey === "none") {
+    return [{ key: ALL_GROUP_KEY, label: "", items: skills }];
+  }
+
+  if (groupKey === "source") {
+    const map = new Map<string, InstalledSkill[]>();
+    for (const s of skills) {
+      const key = getSourceKey(s);
+      const arr = map.get(key) ?? [];
+      arr.push(s);
+      map.set(key, arr);
+    }
+    return [...map.entries()]
+      .sort(([a], [b]) => {
+        if (a === LOCAL_SOURCE_KEY) return 1;
+        if (b === LOCAL_SOURCE_KEY) return -1;
+        return a.localeCompare(b);
+      })
+      .map(([key, items]) => ({
+        key,
+        label: key === LOCAL_SOURCE_KEY ? "" : key,
+        items,
+      }));
+  }
+
+  // groupKey === "app"：同一 skill 可能出现在多组
+  return appIds.map((app) => ({
+    key: app,
+    label: app,
+    items: skills.filter((s) => s.apps[app as keyof typeof s.apps] === true),
+  }));
+}
+
+/** 完整流水线：过滤 → 排序 → 分组 */
+export function computeGroups(
+  skills: InstalledSkill[],
+  state: Pick<
+    FilterSortState,
+    | "searchQuery"
+    | "filterSources"
+    | "filterApps"
+    | "filterUpdateOnly"
+    | "sortKey"
+    | "groupKey"
+  >,
+  updatesMap: Record<string, SkillUpdateInfo>,
+  appIds: AppId[],
+): { filtered: InstalledSkill[]; groups: SkillGroup[] } {
+  const filtered = filterSkills(skills, state, updatesMap);
+  const sorted = sortSkills(filtered, state.sortKey);
+  const groups = groupSkills(sorted, state.groupKey, appIds);
+  return { filtered, groups };
+}
+
+const DEFAULT_STATE: FilterSortState = {
+  searchQuery: "",
+  filterSources: new Set(),
+  filterApps: new Set(),
+  filterUpdateOnly: false,
+  sortKey: "nameAsc",
+  groupKey: "none",
+  collapsed: new Set(),
+  selectionMode: false,
+  selectedIds: new Set(),
+};
+
+/** 派生出当前 skills 中可用的来源 key 列表（已排序，含 LOCAL_SOURCE_KEY 时排末尾） */
+export function deriveSourceOptions(skills: InstalledSkill[]): string[] {
+  const set = new Set<string>();
+  for (const s of skills) {
+    set.add(getSourceKey(s));
+  }
+  return [...set].sort((a, b) => {
+    if (a === LOCAL_SOURCE_KEY) return 1;
+    if (b === LOCAL_SOURCE_KEY) return -1;
+    return a.localeCompare(b);
+  });
+}
+
+/**
+ * Skills 列表的搜索/过滤/排序/分组/多选/置顶 hook
+ *
+ * 状态全部内部管理，对外暴露派生数据与 setters。
+ */
+export function useSkillsFilterSort(
+  skills: InstalledSkill[],
+  updatesMap: Record<string, SkillUpdateInfo>,
+  appIds: AppId[],
+) {
+  const [state, setState] = useState<FilterSortState>(DEFAULT_STATE);
+
+  const { filtered, groups } = useMemo(
+    () => computeGroups(skills, state, updatesMap, appIds),
+    [skills, state, updatesMap, appIds],
+  );
+
+  const sourceOptions = useMemo(() => deriveSourceOptions(skills), [skills]);
+
+  const setSearchQuery = useCallback((q: string) => {
+    setState((s) => ({ ...s, searchQuery: q }));
+  }, []);
+
+  const toggleSource = useCallback((key: string) => {
+    setState((s) => {
+      const next = new Set(s.filterSources);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return { ...s, filterSources: next };
+    });
+  }, []);
+
+  const toggleApp = useCallback((app: AppId) => {
+    setState((s) => {
+      const next = new Set(s.filterApps);
+      if (next.has(app)) next.delete(app);
+      else next.add(app);
+      return { ...s, filterApps: next };
+    });
+  }, []);
+
+  const setFilterUpdateOnly = useCallback((v: boolean) => {
+    setState((s) => ({ ...s, filterUpdateOnly: v }));
+  }, []);
+
+  const setSortKey = useCallback((k: SortKey) => {
+    setState((s) => ({ ...s, sortKey: k }));
+  }, []);
+
+  const setGroupKey = useCallback((k: GroupKey) => {
+    setState((s) => ({ ...s, groupKey: k }));
+  }, []);
+
+  const toggleCollapsed = useCallback((key: string) => {
+    setState((s) => {
+      const next = new Set(s.collapsed);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return { ...s, collapsed: next };
+    });
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setState((s) => ({
+      ...s,
+      searchQuery: "",
+      filterSources: new Set(),
+      filterApps: new Set(),
+      filterUpdateOnly: false,
+    }));
+  }, []);
+
+  const enterSelectionMode = useCallback(() => {
+    setState((s) => ({ ...s, selectionMode: true, selectedIds: new Set() }));
+  }, []);
+
+  const exitSelectionMode = useCallback(() => {
+    setState((s) => ({ ...s, selectionMode: false, selectedIds: new Set() }));
+  }, []);
+
+  const toggleSelected = useCallback((id: string) => {
+    setState((s) => {
+      const next = new Set(s.selectedIds);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return { ...s, selectedIds: next };
+    });
+  }, []);
+
+  const selectAllVisible = useCallback(() => {
+    setState((s) => ({
+      ...s,
+      selectedIds: new Set(filtered.map((sk) => sk.id)),
+    }));
+  }, [filtered]);
+
+  const clearSelection = useCallback(() => {
+    setState((s) => ({ ...s, selectedIds: new Set() }));
+  }, []);
+
+  const hasFilters =
+    state.searchQuery.trim().length > 0 ||
+    state.filterSources.size > 0 ||
+    state.filterApps.size > 0 ||
+    state.filterUpdateOnly;
+
+  return {
+    state,
+    filtered,
+    groups,
+    sourceOptions,
+    total: skills.length,
+    filteredCount: filtered.length,
+    hasFilters,
+    setSearchQuery,
+    toggleSource,
+    toggleApp,
+    setFilterUpdateOnly,
+    setSortKey,
+    setGroupKey,
+    toggleCollapsed,
+    clearFilters,
+    enterSelectionMode,
+    exitSelectionMode,
+    toggleSelected,
+    selectAllVisible,
+    clearSelection,
+  };
+}

--- a/src/components/skills/useSkillsFilterSort.ts
+++ b/src/components/skills/useSkillsFilterSort.ts
@@ -31,6 +31,7 @@ export interface SkillGroup {
 
 export const LOCAL_SOURCE_KEY = "__local__";
 export const ALL_GROUP_KEY = "__all__";
+export const UNASSIGNED_GROUP_KEY = "__unassigned__";
 
 /** 组成 skill 的来源 key（owner/name 或 LOCAL_SOURCE_KEY） */
 export function getSourceKey(skill: InstalledSkill): string {
@@ -145,12 +146,23 @@ export function groupSkills(
       }));
   }
 
-  // groupKey === "app"：同一 skill 可能出现在多组
-  return appIds.map((app) => ({
+  // groupKey === "app"：同一 skill 可能出现在多组；未启用任何 app 的 skill 收到“未分配”组
+  const groups: SkillGroup[] = appIds.map((app) => ({
     key: app,
     label: app,
     items: skills.filter((s) => s.apps[app as keyof typeof s.apps] === true),
   }));
+  const unassigned = skills.filter(
+    (s) => !appIds.some((app) => s.apps[app as keyof typeof s.apps] === true),
+  );
+  if (unassigned.length > 0) {
+    groups.push({
+      key: UNASSIGNED_GROUP_KEY,
+      label: UNASSIGNED_GROUP_KEY,
+      items: unassigned,
+    });
+  }
+  return groups;
 }
 
 /** 完整流水线：过滤 → 排序 → 分组 */

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -165,6 +165,28 @@ export function useRestoreSkillBackup() {
 }
 
 /**
+ * 设置 Skill 置顶状态
+ * 成功后用 setQueryData 同步更新缓存，无需 invalidate
+ */
+export function useSetSkillPin() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, pinned }: { id: string; pinned: boolean }) =>
+      skillsApi.setPin(id, pinned),
+    onSuccess: (_result, { id, pinned }) => {
+      queryClient.setQueryData<InstalledSkill[]>(
+        ["skills", "installed"],
+        (oldData) => {
+          if (!oldData) return oldData;
+          const ts = pinned ? Math.floor(Date.now() / 1000) : undefined;
+          return oldData.map((s) => (s.id === id ? { ...s, pinnedAt: ts } : s));
+        },
+      );
+    },
+  });
+}
+
+/**
  * 切换 Skill 在特定应用的启用状态
  */
 export function useToggleSkillApp() {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1938,7 +1938,53 @@
       "installed": "Installed",
       "uninstalled": "Not installed",
       "repo": "Filter by repo",
-      "allRepos": "All repos"
+      "allRepos": "All repos",
+      "source": "Source",
+      "app": "App",
+      "local": "Local",
+      "updateOnly": "Updates available ({{count}})"
+    },
+    "toolbar": {
+      "searchPlaceholder": "Search skills by name, description, directory, or source",
+      "sortBy": "Sort by",
+      "groupBy": "Group by",
+      "multiSelectMode": "Multi-select",
+      "exitMultiSelect": "Exit multi-select",
+      "clearFilters": "Clear filters",
+      "showing": "{{filtered}}/{{total}}"
+    },
+    "sort": {
+      "nameAsc": "Name A→Z",
+      "nameDesc": "Name Z→A",
+      "installedNewest": "Newest installed",
+      "installedOldest": "Oldest installed",
+      "sourceAsc": "Source A→Z"
+    },
+    "group": {
+      "none": "No grouping",
+      "source": "By source",
+      "app": "By app",
+      "appHint": "(a skill may appear in multiple groups)"
+    },
+    "bulk": {
+      "selected": "{{count}} selected",
+      "selectAll": "Select all ({{count}})",
+      "selectNone": "Select none",
+      "uninstall": "Uninstall",
+      "enableIn": "Enable in",
+      "disableIn": "Disable in",
+      "updateAvailable": "Update ({{count}})",
+      "cancel": "Cancel",
+      "select": "Select skill",
+      "confirmUninstallTitle": "Uninstall {{count}} skills?",
+      "confirmUninstallMessage": "This will uninstall {{count}} selected skills. Are you sure?",
+      "uninstallSuccess": "Uninstalled {{count}} skills",
+      "enableSuccess": "Enabled {{count}} skills in {{app}}",
+      "disableSuccess": "Disabled {{count}} skills in {{app}}"
+    },
+    "pin": {
+      "pin": "Pin to top",
+      "unpin": "Remove from pinned"
     },
     "noResults": "No matching skills found",
     "noInstalled": "No skills installed",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1964,7 +1964,8 @@
       "none": "No grouping",
       "source": "By source",
       "app": "By app",
-      "appHint": "(a skill may appear in multiple groups)"
+      "appHint": "(a skill may appear in multiple groups)",
+      "unassigned": "Unassigned"
     },
     "bulk": {
       "selected": "{{count}} selected",
@@ -2034,6 +2035,34 @@
       "successSingle": "Skill {{name}} installed",
       "successMultiple": "Successfully installed {{count}} skills",
       "noSkillsFound": "No skills found in ZIP file (requires SKILL.md file)"
+    },
+    "loadMode": {
+      "on": "Full",
+      "onDesc": "Name + description loaded into Claude Code system prompt (default)",
+      "nameOnly": "Name only",
+      "nameOnlyDesc": "Only the name is exposed; description is hidden until you invoke it",
+      "userInvocableOnly": "Only on /command",
+      "userInvocableOnlyDesc": "Skill is only triggered when you explicitly type its slash command",
+      "off": "Off",
+      "offDesc": "Skill files remain but Claude Code skips loading them",
+      "ariaLabel": "Load mode: {{mode}}",
+      "disabledClaude": "Skill is not enabled for Claude — load mode has no effect"
+    },
+    "runtime": {
+      "title": "Skill loading settings",
+      "subtitle": "Tune how Claude Code displays the skill list at session start",
+      "budgetFraction": "Listing budget fraction",
+      "budgetHelp": "Portion of total context allocated to the skill list. Skills beyond the budget are collapsed to name-only automatically.",
+      "maxDescChars": "Max description chars",
+      "maxDescHelp": "Truncate each skill description to at most this many characters.",
+      "useDefault": "Use Claude Code default",
+      "default": "Default {{value}}",
+      "reset": "Reset to default"
+    },
+    "discoveredOnly": {
+      "title": "From plugins & user-level",
+      "userLevel": "User-level",
+      "agentsDir": "~/.agents/skills"
     }
   },
   "deeplink": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1964,7 +1964,8 @@
       "none": "グループ化しない",
       "source": "ソース別",
       "app": "アプリ別",
-      "appHint": "（同じスキルが複数のグループに表示されることがあります）"
+      "appHint": "（同じスキルが複数のグループに表示されることがあります）",
+      "unassigned": "未割り当て"
     },
     "bulk": {
       "selected": "{{count}} 件選択中",
@@ -2034,6 +2035,34 @@
       "successSingle": "スキル {{name}} をインストールしました",
       "successMultiple": "{{count}} 件のスキルをインストールしました",
       "noSkillsFound": "ZIP ファイルにスキルが見つかりません（SKILL.md が必要です）"
+    },
+    "loadMode": {
+      "on": "フル",
+      "onDesc": "Claude Code のシステムプロンプトに name + description を読み込む（デフォルト）",
+      "nameOnly": "名前のみ",
+      "nameOnlyDesc": "name だけを公開し、description は呼び出すまで隠す",
+      "userInvocableOnly": "/コマンドのみ",
+      "userInvocableOnlyDesc": "スラッシュコマンドを明示的に入力したときだけ有効になる",
+      "off": "オフ",
+      "offDesc": "スキルファイルは残るが、Claude Code は読み込まない",
+      "ariaLabel": "読み込みモード：{{mode}}",
+      "disabledClaude": "このスキルは Claude で無効です — 読み込みモードは効果がありません"
+    },
+    "runtime": {
+      "title": "スキル読み込み設定",
+      "subtitle": "セッション開始時に Claude Code がスキル一覧をどう表示するかを調整します",
+      "budgetFraction": "一覧予算比率",
+      "budgetHelp": "スキル一覧が総コンテキストに占める比率。予算を超えたスキルは自動で name-only に折りたたまれます。",
+      "maxDescChars": "Description 文字上限",
+      "maxDescHelp": "各スキルの description をこの文字数で切り詰めます。",
+      "useDefault": "Claude Code のデフォルトを使用",
+      "default": "デフォルト {{value}}",
+      "reset": "デフォルトにリセット"
+    },
+    "discoveredOnly": {
+      "title": "プラグイン・ユーザーレベル",
+      "userLevel": "ユーザーレベル",
+      "agentsDir": "~/.agents/skills"
     }
   },
   "deeplink": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1938,7 +1938,53 @@
       "installed": "インストール済み",
       "uninstalled": "未インストール",
       "repo": "リポジトリで絞り込み",
-      "allRepos": "すべてのリポジトリ"
+      "allRepos": "すべてのリポジトリ",
+      "source": "ソース",
+      "app": "アプリ",
+      "local": "ローカル",
+      "updateOnly": "更新あり ({{count}})"
+    },
+    "toolbar": {
+      "searchPlaceholder": "名前・説明・ディレクトリ・ソースで検索",
+      "sortBy": "並び替え",
+      "groupBy": "グループ化",
+      "multiSelectMode": "複数選択",
+      "exitMultiSelect": "複数選択を終了",
+      "clearFilters": "フィルターをクリア",
+      "showing": "{{filtered}}/{{total}}"
+    },
+    "sort": {
+      "nameAsc": "名前 A→Z",
+      "nameDesc": "名前 Z→A",
+      "installedNewest": "新しい順",
+      "installedOldest": "古い順",
+      "sourceAsc": "ソース A→Z"
+    },
+    "group": {
+      "none": "グループ化しない",
+      "source": "ソース別",
+      "app": "アプリ別",
+      "appHint": "（同じスキルが複数のグループに表示されることがあります）"
+    },
+    "bulk": {
+      "selected": "{{count}} 件選択中",
+      "selectAll": "すべて選択 ({{count}})",
+      "selectNone": "選択を解除",
+      "uninstall": "アンインストール",
+      "enableIn": "有効化",
+      "disableIn": "無効化",
+      "updateAvailable": "更新 ({{count}})",
+      "cancel": "キャンセル",
+      "select": "スキルを選択",
+      "confirmUninstallTitle": "{{count}} 件のスキルをアンインストール？",
+      "confirmUninstallMessage": "選択した {{count}} 件のスキルをアンインストールします。よろしいですか？",
+      "uninstallSuccess": "{{count}} 件のスキルをアンインストールしました",
+      "enableSuccess": "{{app}} で {{count}} 件のスキルを有効化しました",
+      "disableSuccess": "{{app}} で {{count}} 件のスキルを無効化しました"
+    },
+    "pin": {
+      "pin": "上にピン留め",
+      "unpin": "ピン留めを解除"
     },
     "noResults": "一致するスキルが見つかりませんでした",
     "noInstalled": "インストールされたスキルがありません",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1938,7 +1938,53 @@
       "installed": "已安装",
       "uninstalled": "未安装",
       "repo": "仓库筛选",
-      "allRepos": "全部仓库"
+      "allRepos": "全部仓库",
+      "source": "来源",
+      "app": "应用",
+      "local": "本地",
+      "updateOnly": "仅显示有更新 ({{count}})"
+    },
+    "toolbar": {
+      "searchPlaceholder": "按名称、描述、目录或来源搜索",
+      "sortBy": "排序",
+      "groupBy": "分组",
+      "multiSelectMode": "批量选择",
+      "exitMultiSelect": "退出多选",
+      "clearFilters": "清除筛选",
+      "showing": "{{filtered}}/{{total}}"
+    },
+    "sort": {
+      "nameAsc": "名称 A→Z",
+      "nameDesc": "名称 Z→A",
+      "installedNewest": "最新安装",
+      "installedOldest": "最早安装",
+      "sourceAsc": "来源 A→Z"
+    },
+    "group": {
+      "none": "不分组",
+      "source": "按来源",
+      "app": "按应用",
+      "appHint": "（同一技能可能跨组出现）"
+    },
+    "bulk": {
+      "selected": "已选 {{count}} 项",
+      "selectAll": "全选 ({{count}})",
+      "selectNone": "取消全选",
+      "uninstall": "卸载",
+      "enableIn": "启用到",
+      "disableIn": "禁用于",
+      "updateAvailable": "更新可用项 ({{count}})",
+      "cancel": "取消",
+      "select": "选择技能",
+      "confirmUninstallTitle": "卸载 {{count}} 个技能？",
+      "confirmUninstallMessage": "将卸载选中的 {{count}} 个技能，确认继续？",
+      "uninstallSuccess": "已卸载 {{count}} 个技能",
+      "enableSuccess": "已在 {{app}} 启用 {{count}} 个技能",
+      "disableSuccess": "已在 {{app}} 禁用 {{count}} 个技能"
+    },
+    "pin": {
+      "pin": "置顶",
+      "unpin": "取消置顶"
     },
     "noResults": "未找到匹配的技能",
     "noInstalled": "暂无已安装的技能",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1964,7 +1964,8 @@
       "none": "不分组",
       "source": "按来源",
       "app": "按应用",
-      "appHint": "（同一技能可能跨组出现）"
+      "appHint": "（同一技能可能跨组出现）",
+      "unassigned": "未分配"
     },
     "bulk": {
       "selected": "已选 {{count}} 项",
@@ -2034,6 +2035,34 @@
       "successSingle": "技能 {{name}} 已安装",
       "successMultiple": "成功安装 {{count}} 个技能",
       "noSkillsFound": "ZIP 文件中未找到技能（需包含 SKILL.md 文件）"
+    },
+    "loadMode": {
+      "on": "完整加载",
+      "onDesc": "在 Claude Code 系统提示中加载 name + description（默认）",
+      "nameOnly": "仅名称",
+      "nameOnlyDesc": "只暴露 name，模型不会主动推荐；需手动 /skill 触发",
+      "userInvocableOnly": "仅 /命令触发",
+      "userInvocableOnlyDesc": "只有显式输入对应斜杠命令才会启用该 skill",
+      "off": "屏蔽",
+      "offDesc": "skill 文件保留，但 Claude Code 跳过加载",
+      "ariaLabel": "加载模式：{{mode}}",
+      "disabledClaude": "Claude 已禁用该 skill — 加载模式当前不生效"
+    },
+    "runtime": {
+      "title": "Skill 加载设置",
+      "subtitle": "调整 Claude Code 启动时如何展示 skill 列表",
+      "budgetFraction": "清单预算占比",
+      "budgetHelp": "skill 清单允许占总上下文的比例。超出预算的 skill 会被自动折叠为 name-only。",
+      "maxDescChars": "Description 字符上限",
+      "maxDescHelp": "每个 skill 的 description 最多保留多少字符。",
+      "useDefault": "使用 Claude Code 默认值",
+      "default": "默认 {{value}}",
+      "reset": "重置为默认"
+    },
+    "discoveredOnly": {
+      "title": "来自 plugin 与用户级",
+      "userLevel": "用户级",
+      "agentsDir": "~/.agents/skills"
     }
   },
   "deeplink": {

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -36,6 +36,8 @@ export interface InstalledSkill {
   installedAt: number;
   contentHash?: string;
   updatedAt: number;
+  /** 置顶时间（Unix 时间戳；undefined = 未置顶；多个置顶项按值降序排列） */
+  pinnedAt?: number;
 }
 
 export interface SkillUninstallResult {
@@ -175,6 +177,11 @@ export const skillsApi = {
   /** 切换 Skill 的应用启用状态 */
   async toggleApp(id: string, app: AppId, enabled: boolean): Promise<boolean> {
     return await invoke("toggle_skill_app", { id, app, enabled });
+  },
+
+  /** 设置 Skill 的置顶状态（pinned=true 时记录当前时间戳，false 时清空） */
+  async setPin(id: string, pinned: boolean): Promise<boolean> {
+    return await invoke("set_skill_pin", { id, pinned });
   },
 
   /** 扫描未管理的 Skills */

--- a/tests/components/SkillsBulkActionBar.test.tsx
+++ b/tests/components/SkillsBulkActionBar.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SkillsBulkActionBar } from "@/components/skills/SkillsBulkActionBar";
+import type { AppId } from "@/lib/api/types";
+
+const APP_IDS: AppId[] = [
+  "claude",
+  "codex",
+  "gemini",
+  "opencode",
+  "hermes",
+];
+
+function renderBar(
+  overrides: Partial<Parameters<typeof SkillsBulkActionBar>[0]> = {},
+) {
+  const props: Parameters<typeof SkillsBulkActionBar>[0] = {
+    selectedCount: 0,
+    selectedHasUpdate: 0,
+    appIds: APP_IDS,
+    onUninstall: vi.fn(),
+    onToggleApp: vi.fn(),
+    onUpdateAvailable: vi.fn(),
+    onCancel: vi.fn(),
+    onSelectAll: vi.fn(),
+    totalVisible: 10,
+    isWorking: false,
+    ...overrides,
+  };
+  const result = render(<SkillsBulkActionBar {...props} />);
+  return { ...result, props };
+}
+
+describe("SkillsBulkActionBar", () => {
+  it("renders the selected-count key", () => {
+    renderBar({ selectedCount: 3 });
+    expect(screen.getByText(/skills\.bulk\.selected/)).toBeInTheDocument();
+  });
+
+  it("shows 'select all' label when selectedCount < totalVisible", () => {
+    renderBar({ selectedCount: 0, totalVisible: 10 });
+    expect(screen.getByText(/skills\.bulk\.selectAll/)).toBeInTheDocument();
+  });
+
+  it("shows 'select none' label when all visible are selected", () => {
+    renderBar({ selectedCount: 10, totalVisible: 10 });
+    expect(screen.getByText("skills.bulk.selectNone")).toBeInTheDocument();
+  });
+
+  it("disables uninstall when nothing is selected", () => {
+    renderBar({ selectedCount: 0 });
+    const btn = screen.getByText("skills.bulk.uninstall").closest("button");
+    expect(btn).toBeDisabled();
+  });
+
+  it("calls onUninstall when uninstall is clicked with a selection", () => {
+    const { props } = renderBar({ selectedCount: 2 });
+    fireEvent.click(screen.getByText("skills.bulk.uninstall"));
+    expect(props.onUninstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when cancel is clicked", () => {
+    const { props } = renderBar({ selectedCount: 0 });
+    fireEvent.click(screen.getByText("skills.bulk.cancel"));
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSelectAll when select-all link is clicked", () => {
+    const { props } = renderBar();
+    fireEvent.click(screen.getByText(/skills\.bulk\.selectAll/));
+    expect(props.onSelectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render updateAvailable button when selectedHasUpdate is 0", () => {
+    renderBar({ selectedCount: 2, selectedHasUpdate: 0 });
+    expect(
+      screen.queryByText(/skills\.bulk\.updateAvailable/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders updateAvailable button when selectedHasUpdate > 0", () => {
+    renderBar({ selectedCount: 2, selectedHasUpdate: 1 });
+    expect(
+      screen.getByText(/skills\.bulk\.updateAvailable/),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onUpdateAvailable when update button is clicked", () => {
+    const { props } = renderBar({ selectedCount: 2, selectedHasUpdate: 1 });
+    fireEvent.click(screen.getByText(/skills\.bulk\.updateAvailable/));
+    expect(props.onUpdateAvailable).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables actions while isWorking", () => {
+    renderBar({ selectedCount: 2, isWorking: true });
+    const uninstallBtn = screen
+      .getByText("skills.bulk.uninstall")
+      .closest("button");
+    const enableBtn = screen
+      .getByText("skills.bulk.enableIn")
+      .closest("button");
+    expect(uninstallBtn).toBeDisabled();
+    expect(enableBtn).toBeDisabled();
+  });
+
+  it("enables enable/disable buttons when selectedCount > 0", () => {
+    renderBar({ selectedCount: 1, isWorking: false });
+    expect(
+      screen.getByText("skills.bulk.enableIn").closest("button"),
+    ).not.toBeDisabled();
+    expect(
+      screen.getByText("skills.bulk.disableIn").closest("button"),
+    ).not.toBeDisabled();
+  });
+
+  it("opens enable menu and fires onToggleApp(app, true) on selection", async () => {
+    const user = userEvent.setup();
+    const { props } = renderBar({ selectedCount: 2 });
+    await user.click(screen.getByText("skills.bulk.enableIn"));
+    // DropdownMenu content should now be visible; click the Claude menu item.
+    const claudeOption = await screen.findByRole("menuitem", { name: "Claude" });
+    await user.click(claudeOption);
+    expect(props.onToggleApp).toHaveBeenCalledWith("claude", true);
+  });
+
+  it("opens disable menu and fires onToggleApp(app, false) on selection", async () => {
+    const user = userEvent.setup();
+    const { props } = renderBar({ selectedCount: 2 });
+    await user.click(screen.getByText("skills.bulk.disableIn"));
+    const codexOption = await screen.findByRole("menuitem", { name: "Codex" });
+    await user.click(codexOption);
+    expect(props.onToggleApp).toHaveBeenCalledWith("codex", false);
+  });
+});

--- a/tests/components/SkillsToolbar.test.tsx
+++ b/tests/components/SkillsToolbar.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SkillsToolbar } from "@/components/skills/SkillsToolbar";
+import { LOCAL_SOURCE_KEY } from "@/components/skills/useSkillsFilterSort";
+
+function renderToolbar(overrides: Partial<Parameters<typeof SkillsToolbar>[0]> = {}) {
+  const props: Parameters<typeof SkillsToolbar>[0] = {
+    searchQuery: "",
+    onSearchChange: vi.fn(),
+    sourceOptions: ["forrest/kit", "kar/tools", LOCAL_SOURCE_KEY],
+    filterSources: new Set(),
+    onToggleSource: vi.fn(),
+    filterUpdateOnly: false,
+    onToggleUpdateOnly: vi.fn(),
+    updateAvailableCount: 0,
+    sortKey: "nameAsc",
+    onSortChange: vi.fn(),
+    groupKey: "none",
+    onGroupChange: vi.fn(),
+    selectionMode: false,
+    onToggleSelectionMode: vi.fn(),
+    hasFilters: false,
+    onClearFilters: vi.fn(),
+    total: 70,
+    filteredCount: 70,
+    ...overrides,
+  };
+  const result = render(<SkillsToolbar {...props} />);
+  return { ...result, props };
+}
+
+describe("SkillsToolbar", () => {
+  it("renders the search input with placeholder key", () => {
+    renderToolbar();
+    expect(
+      screen.getByPlaceholderText("skills.toolbar.searchPlaceholder"),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onSearchChange when typing", () => {
+    const { props } = renderToolbar();
+    const input = screen.getByPlaceholderText(
+      "skills.toolbar.searchPlaceholder",
+    );
+    fireEvent.change(input, { target: { value: "auth" } });
+    expect(props.onSearchChange).toHaveBeenCalledWith("auth");
+  });
+
+  it("shows clear button only when searchQuery is non-empty", () => {
+    const { props, rerender } = renderToolbar();
+    expect(screen.queryByLabelText("common.clear")).not.toBeInTheDocument();
+    rerender(<SkillsToolbar {...props} searchQuery="abc" />);
+    expect(screen.getByLabelText("common.clear")).toBeInTheDocument();
+  });
+
+  it("clears search via the inline X button", () => {
+    const { props } = renderToolbar({ searchQuery: "abc" });
+    fireEvent.click(screen.getByLabelText("common.clear"));
+    expect(props.onSearchChange).toHaveBeenCalledWith("");
+  });
+
+  it("renders showing count", () => {
+    renderToolbar({ filteredCount: 12, total: 70 });
+    // i18n is initialized with empty resources, so the key is returned literally;
+    // the interpolation in i18next still applies and the rendered text is the
+    // key with placeholders replaced. We assert the slash form is visible
+    // through both interpolation and the raw key. Using a regex tolerates
+    // either form.
+    expect(
+      screen.getByText(/skills\.toolbar\.showing|12\s*\/\s*70/),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onToggleSelectionMode on the multi-select button", () => {
+    const { props } = renderToolbar();
+    const btn = screen.getByTitle("skills.toolbar.multiSelectMode");
+    fireEvent.click(btn);
+    expect(props.onToggleSelectionMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the exit-multi-select title when selectionMode is true", () => {
+    renderToolbar({ selectionMode: true });
+    expect(
+      screen.getByTitle("skills.toolbar.exitMultiSelect"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the local source label for LOCAL_SOURCE_KEY", () => {
+    renderToolbar();
+    expect(screen.getByText("skills.filter.local")).toBeInTheDocument();
+    expect(screen.getByText("forrest/kit")).toBeInTheDocument();
+    expect(screen.getByText("kar/tools")).toBeInTheDocument();
+  });
+
+  it("fires onToggleSource for the clicked source chip", () => {
+    const { props } = renderToolbar();
+    fireEvent.click(screen.getByText("forrest/kit"));
+    expect(props.onToggleSource).toHaveBeenCalledWith("forrest/kit");
+  });
+
+  it("hides the second row when no sources, no updates and no active filters", () => {
+    renderToolbar({
+      sourceOptions: [],
+      updateAvailableCount: 0,
+      hasFilters: false,
+    });
+    expect(screen.queryByText("skills.filter.source")).not.toBeInTheDocument();
+  });
+
+  it("renders the updateOnly chip only when updateAvailableCount > 0", () => {
+    const { rerender, props } = renderToolbar({ updateAvailableCount: 0 });
+    expect(
+      screen.queryByText(/skills\.filter\.updateOnly/),
+    ).not.toBeInTheDocument();
+
+    rerender(<SkillsToolbar {...props} updateAvailableCount={3} />);
+    expect(
+      screen.getByText(/skills\.filter\.updateOnly/),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onToggleUpdateOnly when the chip is clicked", () => {
+    const { props } = renderToolbar({ updateAvailableCount: 2 });
+    fireEvent.click(screen.getByText(/skills\.filter\.updateOnly/));
+    expect(props.onToggleUpdateOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the Clear filters button only when hasFilters is true", () => {
+    const { rerender, props } = renderToolbar();
+    expect(
+      screen.queryByText("skills.toolbar.clearFilters"),
+    ).not.toBeInTheDocument();
+
+    rerender(<SkillsToolbar {...props} hasFilters={true} />);
+    expect(
+      screen.getByText("skills.toolbar.clearFilters"),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onClearFilters when clear is clicked", () => {
+    const { props } = renderToolbar({ hasFilters: true });
+    fireEvent.click(screen.getByText("skills.toolbar.clearFilters"));
+    expect(props.onClearFilters).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -32,6 +32,24 @@ vi.mock("sonner", () => ({
   },
 }));
 
+vi.mock("@/hooks/useSkillLoadMode", () => ({
+  useClaudeRuntimeConfig: () => ({
+    data: { skillLoadModes: {} },
+  }),
+  useDiscoverAllSkills: () => ({
+    data: [],
+  }),
+  useSetSkillLoadMode: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useSetSkillListingBudget: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useSetMaxSkillDescriptionChars: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
 vi.mock("@/hooks/useSkills", () => ({
   useInstalledSkills: () => ({
     data: mocks.installed,
@@ -288,5 +306,43 @@ describe("UnifiedSkillsPanel", () => {
     );
     fireEvent.change(input, { target: { value: "ZZZNotMatching" } });
     expect(screen.getByText("skills.noResults")).toBeInTheDocument();
+  });
+
+  it("bulk uninstall only acts on currently visible selections", async () => {
+    mocks.installed = [
+      skill({ id: "a", name: "Apple" }),
+      skill({ id: "b", name: "Banana" }),
+    ];
+    mocks.uninstallSkillMock.mockResolvedValue({ backupPath: null });
+
+    renderPanel();
+
+    // Enter multi-select and select both rows.
+    fireEvent.click(screen.getByTitle("skills.toolbar.multiSelectMode"));
+    const checkboxes = screen.getAllByLabelText("skills.bulk.select");
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+
+    // Filter to hide Banana so only Apple is visible.
+    const input = screen.getByPlaceholderText(
+      "skills.toolbar.searchPlaceholder",
+    );
+    fireEvent.change(input, { target: { value: "Apple" } });
+
+    // Trigger bulk uninstall and confirm.
+    fireEvent.click(screen.getByText("skills.bulk.uninstall"));
+    await waitFor(() => {
+      expect(
+        screen.getByText("skills.bulk.confirmUninstallTitle"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("skills.uninstall"));
+
+    await waitFor(() => {
+      expect(mocks.uninstallSkillMock).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.uninstallSkillMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "a" }),
+    );
   });
 });

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -1,18 +1,28 @@
 import { createRef } from "react";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import UnifiedSkillsPanel, {
   type UnifiedSkillsPanelHandle,
 } from "@/components/skills/UnifiedSkillsPanel";
+import type { InstalledSkill, SkillUpdateInfo } from "@/lib/api/skills";
 
-const scanUnmanagedMock = vi.fn();
-const toggleSkillAppMock = vi.fn();
-const uninstallSkillMock = vi.fn();
-const importSkillsMock = vi.fn();
-const installFromZipMock = vi.fn();
-const deleteSkillBackupMock = vi.fn();
-const restoreSkillBackupMock = vi.fn();
+// Hoisted mock state so vi.mock factories can reference it.
+const mocks = vi.hoisted(() => {
+  return {
+    installed: [] as InstalledSkill[],
+    updates: [] as SkillUpdateInfo[],
+    scanUnmanagedMock: vi.fn(),
+    toggleSkillAppMock: vi.fn(),
+    uninstallSkillMock: vi.fn(),
+    importSkillsMock: vi.fn(),
+    installFromZipMock: vi.fn(),
+    deleteSkillBackupMock: vi.fn(),
+    restoreSkillBackupMock: vi.fn(),
+    setPinMutateMock: vi.fn(),
+    updateSkillMock: vi.fn(),
+  };
+});
 
 vi.mock("sonner", () => ({
   toast: {
@@ -24,7 +34,7 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/hooks/useSkills", () => ({
   useInstalledSkills: () => ({
-    data: [],
+    data: mocks.installed,
     isLoading: false,
   }),
   useSkillBackups: () => ({
@@ -33,18 +43,18 @@ vi.mock("@/hooks/useSkills", () => ({
     isFetching: false,
   }),
   useDeleteSkillBackup: () => ({
-    mutateAsync: deleteSkillBackupMock,
+    mutateAsync: mocks.deleteSkillBackupMock,
     isPending: false,
   }),
   useToggleSkillApp: () => ({
-    mutateAsync: toggleSkillAppMock,
+    mutateAsync: mocks.toggleSkillAppMock,
   }),
   useRestoreSkillBackup: () => ({
-    mutateAsync: restoreSkillBackupMock,
+    mutateAsync: mocks.restoreSkillBackupMock,
     isPending: false,
   }),
   useUninstallSkill: () => ({
-    mutateAsync: uninstallSkillMock,
+    mutateAsync: mocks.uninstallSkillMock,
   }),
   useScanUnmanagedSkills: () => ({
     data: [
@@ -56,28 +66,68 @@ vi.mock("@/hooks/useSkills", () => ({
         path: "/tmp/shared-skill",
       },
     ],
-    refetch: scanUnmanagedMock,
+    refetch: mocks.scanUnmanagedMock,
   }),
   useImportSkillsFromApps: () => ({
-    mutateAsync: importSkillsMock,
+    mutateAsync: mocks.importSkillsMock,
   }),
   useInstallSkillsFromZip: () => ({
-    mutateAsync: installFromZipMock,
+    mutateAsync: mocks.installFromZipMock,
   }),
   useCheckSkillUpdates: () => ({
-    data: [],
+    data: mocks.updates,
     refetch: vi.fn(),
     isFetching: false,
   }),
   useUpdateSkill: () => ({
+    mutateAsync: mocks.updateSkillMock,
+    isPending: false,
+  }),
+  useSetSkillPin: () => ({
+    mutate: mocks.setPinMutateMock,
     mutateAsync: vi.fn(),
     isPending: false,
   }),
 }));
 
+function skill(overrides: Partial<InstalledSkill> = {}): InstalledSkill {
+  return {
+    id: "s1",
+    name: "Skill 1",
+    directory: "skill-1",
+    repoOwner: "forrest",
+    repoName: "kit",
+    apps: {
+      claude: true,
+      codex: false,
+      gemini: false,
+      opencode: false,
+      openclaw: false,
+      hermes: false,
+    },
+    installedAt: 1000,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function renderPanel() {
+  const ref = createRef<UnifiedSkillsPanelHandle>();
+  const utils = render(
+    <UnifiedSkillsPanel
+      ref={ref}
+      onOpenDiscovery={() => {}}
+      currentApp="claude"
+    />,
+  );
+  return { ref, ...utils };
+}
+
 describe("UnifiedSkillsPanel", () => {
   beforeEach(() => {
-    scanUnmanagedMock.mockResolvedValue({
+    mocks.installed = [];
+    mocks.updates = [];
+    mocks.scanUnmanagedMock.mockResolvedValue({
       data: [
         {
           directory: "shared-skill",
@@ -88,24 +138,18 @@ describe("UnifiedSkillsPanel", () => {
         },
       ],
     });
-    toggleSkillAppMock.mockReset();
-    uninstallSkillMock.mockReset();
-    importSkillsMock.mockReset();
-    installFromZipMock.mockReset();
-    deleteSkillBackupMock.mockReset();
-    restoreSkillBackupMock.mockReset();
+    mocks.toggleSkillAppMock.mockReset();
+    mocks.uninstallSkillMock.mockReset();
+    mocks.importSkillsMock.mockReset();
+    mocks.installFromZipMock.mockReset();
+    mocks.deleteSkillBackupMock.mockReset();
+    mocks.restoreSkillBackupMock.mockReset();
+    mocks.setPinMutateMock.mockReset();
+    mocks.updateSkillMock.mockReset();
   });
 
   it("opens the import dialog without crashing when app toggles render", async () => {
-    const ref = createRef<UnifiedSkillsPanelHandle>();
-
-    render(
-      <UnifiedSkillsPanel
-        ref={ref}
-        onOpenDiscovery={() => {}}
-        currentApp="claude"
-      />,
-    );
+    const { ref } = renderPanel();
 
     await act(async () => {
       await ref.current?.openImport();
@@ -116,5 +160,133 @@ describe("UnifiedSkillsPanel", () => {
       expect(screen.getByText("Shared Skill")).toBeInTheDocument();
       expect(screen.getByText("/tmp/shared-skill")).toBeInTheDocument();
     });
+  });
+
+  it("renders the empty state when no skills are installed", () => {
+    mocks.installed = [];
+    renderPanel();
+    expect(screen.getByText("skills.noInstalled")).toBeInTheDocument();
+  });
+
+  it("renders installed skills in the list", () => {
+    mocks.installed = [
+      skill({ id: "a", name: "Apple", description: "First skill" }),
+      skill({ id: "b", name: "Banana", description: "Second skill" }),
+    ];
+    renderPanel();
+    expect(screen.getByText("Apple")).toBeInTheDocument();
+    expect(screen.getByText("Banana")).toBeInTheDocument();
+  });
+
+  it("filters skills by search query", () => {
+    mocks.installed = [
+      skill({ id: "a", name: "Apple" }),
+      skill({ id: "b", name: "Banana" }),
+    ];
+    renderPanel();
+    const input = screen.getByPlaceholderText(
+      "skills.toolbar.searchPlaceholder",
+    );
+    fireEvent.change(input, { target: { value: "Apple" } });
+    expect(screen.getByText("Apple")).toBeInTheDocument();
+    expect(screen.queryByText("Banana")).not.toBeInTheDocument();
+  });
+
+  it("clicking the Star button calls setPin via the mocked hook", () => {
+    mocks.installed = [skill({ id: "a", name: "Apple" })];
+    renderPanel();
+    const pinBtn = screen.getByTitle("skills.pin.pin");
+    fireEvent.click(pinBtn);
+    expect(mocks.setPinMutateMock).toHaveBeenCalledWith({
+      id: "a",
+      pinned: true,
+    });
+  });
+
+  it("when pinned, clicking the star unpins", () => {
+    mocks.installed = [
+      skill({ id: "a", name: "Apple", pinnedAt: 1234 }),
+    ];
+    renderPanel();
+    const unpinBtn = screen.getByTitle("skills.pin.unpin");
+    fireEvent.click(unpinBtn);
+    expect(mocks.setPinMutateMock).toHaveBeenCalledWith({
+      id: "a",
+      pinned: false,
+    });
+  });
+
+  it("enters selection mode and renders checkboxes", () => {
+    mocks.installed = [
+      skill({ id: "a", name: "Apple" }),
+      skill({ id: "b", name: "Banana" }),
+    ];
+    renderPanel();
+    const multiSelectBtn = screen.getByTitle("skills.toolbar.multiSelectMode");
+    fireEvent.click(multiSelectBtn);
+    // After entering selection mode, two checkboxes (one per row) appear with
+    // aria-label = "skills.bulk.select".
+    const checkboxes = screen.getAllByLabelText("skills.bulk.select");
+    expect(checkboxes).toHaveLength(2);
+  });
+
+  it("App chip in header acts as a filter (toggles filterApps)", () => {
+    mocks.installed = [
+      skill({
+        id: "claude-only",
+        name: "ClaudeOnly",
+        apps: {
+          claude: true,
+          codex: false,
+          gemini: false,
+          opencode: false,
+          openclaw: false,
+          hermes: false,
+        },
+      }),
+      skill({
+        id: "codex-only",
+        name: "CodexOnly",
+        apps: {
+          claude: false,
+          codex: true,
+          gemini: false,
+          opencode: false,
+          openclaw: false,
+          hermes: false,
+        },
+      }),
+    ];
+    renderPanel();
+    // Initially both visible.
+    expect(screen.getByText("ClaudeOnly")).toBeInTheDocument();
+    expect(screen.getByText("CodexOnly")).toBeInTheDocument();
+
+    // Find the App chip "Claude" in the header (aria-pressed="false" initially).
+    // Multiple "Claude" texts may exist (header chip + app toggle row icons),
+    // pick the chip by its aria-pressed attribute.
+    const claudeChip = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("aria-pressed") === "false" &&
+          b.textContent?.includes("Claude"),
+      );
+    expect(claudeChip).toBeDefined();
+    fireEvent.click(claudeChip!);
+
+    // After clicking, only Claude-enabled skill remains.
+    expect(screen.getByText("ClaudeOnly")).toBeInTheDocument();
+    expect(screen.queryByText("CodexOnly")).not.toBeInTheDocument();
+  });
+
+  it("noResults state shows when filters yield empty list", () => {
+    mocks.installed = [skill({ id: "a", name: "Apple" })];
+    renderPanel();
+    const input = screen.getByPlaceholderText(
+      "skills.toolbar.searchPlaceholder",
+    );
+    fireEvent.change(input, { target: { value: "ZZZNotMatching" } });
+    expect(screen.getByText("skills.noResults")).toBeInTheDocument();
   });
 });

--- a/tests/hooks/useSkillsFilterSort.test.ts
+++ b/tests/hooks/useSkillsFilterSort.test.ts
@@ -12,6 +12,7 @@ import {
   LOCAL_SOURCE_KEY,
   matchSkillBySearch,
   sortSkills,
+  UNASSIGNED_GROUP_KEY,
   useSkillsFilterSort,
   type FilterSortState,
 } from "@/components/skills/useSkillsFilterSort";
@@ -258,6 +259,23 @@ describe("groupSkills", () => {
     expect(totalAcross).toBe(4);
     const claudeGroup = out.find((g) => g.key === "claude")!;
     expect(claudeGroup.items.map((s) => s.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("app grouping surfaces skills with no enabled app in an unassigned group", () => {
+    const orphan = makeSkill({
+      id: "orphan",
+      name: "Orphan",
+      apps: appsWith([]),
+    });
+    const out = groupSkills([...skills, orphan], "app", APP_IDS);
+    const unassigned = out.find((g) => g.key === UNASSIGNED_GROUP_KEY);
+    expect(unassigned).toBeDefined();
+    expect(unassigned!.items.map((s) => s.id)).toEqual(["orphan"]);
+    // The unassigned group only appears when needed
+    const outNoOrphans = groupSkills(skills, "app", APP_IDS);
+    expect(
+      outNoOrphans.find((g) => g.key === UNASSIGNED_GROUP_KEY),
+    ).toBeUndefined();
   });
 });
 

--- a/tests/hooks/useSkillsFilterSort.test.ts
+++ b/tests/hooks/useSkillsFilterSort.test.ts
@@ -1,0 +1,482 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { InstalledSkill, SkillUpdateInfo } from "@/lib/api/skills";
+import type { AppId } from "@/lib/api/types";
+import {
+  ALL_GROUP_KEY,
+  computeGroups,
+  deriveSourceOptions,
+  filterSkills,
+  getSourceKey,
+  groupSkills,
+  LOCAL_SOURCE_KEY,
+  matchSkillBySearch,
+  sortSkills,
+  useSkillsFilterSort,
+  type FilterSortState,
+} from "@/components/skills/useSkillsFilterSort";
+
+const APP_IDS: AppId[] = [
+  "claude",
+  "codex",
+  "gemini",
+  "opencode",
+  "hermes",
+];
+
+function makeSkill(overrides: Partial<InstalledSkill> = {}): InstalledSkill {
+  return {
+    id: "skill-a",
+    name: "Skill A",
+    directory: "skill-a",
+    repoOwner: "forrest",
+    repoName: "kit",
+    apps: {
+      claude: true,
+      codex: false,
+      gemini: false,
+      opencode: false,
+      openclaw: false,
+      hermes: false,
+    },
+    installedAt: 1000,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function emptyState(
+  overrides: Partial<FilterSortState> = {},
+): Pick<
+  FilterSortState,
+  | "searchQuery"
+  | "filterSources"
+  | "filterApps"
+  | "filterUpdateOnly"
+  | "sortKey"
+  | "groupKey"
+> {
+  return {
+    searchQuery: overrides.searchQuery ?? "",
+    filterSources: overrides.filterSources ?? new Set(),
+    filterApps: overrides.filterApps ?? new Set(),
+    filterUpdateOnly: overrides.filterUpdateOnly ?? false,
+    sortKey: overrides.sortKey ?? "nameAsc",
+    groupKey: overrides.groupKey ?? "none",
+  };
+}
+
+describe("getSourceKey", () => {
+  it("returns owner/name for repo-backed skill", () => {
+    expect(getSourceKey(makeSkill())).toBe("forrest/kit");
+  });
+
+  it("returns LOCAL_SOURCE_KEY when repo info missing", () => {
+    const s = makeSkill({ repoOwner: undefined, repoName: undefined });
+    expect(getSourceKey(s)).toBe(LOCAL_SOURCE_KEY);
+  });
+});
+
+describe("matchSkillBySearch", () => {
+  const skill = makeSkill({
+    id: "x",
+    name: "Auth Flow Helper",
+    description: "OAuth login utility",
+    directory: "auth-helper",
+    repoOwner: "forrest",
+    repoName: "kit",
+  });
+
+  it("returns true for empty query", () => {
+    expect(matchSkillBySearch(skill, "")).toBe(true);
+  });
+
+  it("matches by name (case-insensitive)", () => {
+    expect(matchSkillBySearch(skill, "auth")).toBe(true);
+    expect(matchSkillBySearch(skill, "AUTH")).toBe(true);
+  });
+
+  it("matches by description", () => {
+    expect(matchSkillBySearch(skill, "oauth login")).toBe(true);
+  });
+
+  it("matches by directory", () => {
+    expect(matchSkillBySearch(skill, "helper")).toBe(true);
+  });
+
+  it("matches by owner or name", () => {
+    expect(matchSkillBySearch(skill, "forrest")).toBe(true);
+    expect(matchSkillBySearch(skill, "kit")).toBe(true);
+  });
+
+  it("matches by composite owner/name", () => {
+    expect(matchSkillBySearch(skill, "forrest/kit")).toBe(true);
+  });
+
+  it("returns false when nothing matches", () => {
+    expect(matchSkillBySearch(skill, "nope-zzz")).toBe(false);
+  });
+});
+
+describe("filterSkills", () => {
+  const skills: InstalledSkill[] = [
+    makeSkill({ id: "a", repoOwner: "forrest", repoName: "kit", apps: appsWith(["claude"]) }),
+    makeSkill({ id: "b", repoOwner: "kar", repoName: "tools", apps: appsWith(["codex"]) }),
+    makeSkill({ id: "c", repoOwner: undefined, repoName: undefined, apps: appsWith(["claude", "gemini"]) }),
+  ];
+
+  it("returns all when no filters", () => {
+    expect(filterSkills(skills, emptyState(), {})).toHaveLength(3);
+  });
+
+  it("filterSources is union (OR within axis)", () => {
+    const out = filterSkills(
+      skills,
+      emptyState({ filterSources: new Set(["forrest/kit", "kar/tools"]) }),
+      {},
+    );
+    expect(out.map((s) => s.id)).toEqual(["a", "b"]);
+  });
+
+  it("filterApps is OR within axis", () => {
+    const out = filterSkills(
+      skills,
+      emptyState({ filterApps: new Set<AppId>(["codex", "gemini"]) }),
+      {},
+    );
+    expect(out.map((s) => s.id).sort()).toEqual(["b", "c"]);
+  });
+
+  it("crosses axes with AND", () => {
+    const out = filterSkills(
+      skills,
+      emptyState({
+        filterSources: new Set(["forrest/kit"]),
+        filterApps: new Set<AppId>(["claude"]),
+      }),
+      {},
+    );
+    expect(out.map((s) => s.id)).toEqual(["a"]);
+  });
+
+  it("filterUpdateOnly leaves only skills present in updatesMap", () => {
+    const updatesMap: Record<string, SkillUpdateInfo> = {
+      a: { id: "a", name: "Skill A", remoteHash: "abc" },
+    };
+    const out = filterSkills(
+      skills,
+      emptyState({ filterUpdateOnly: true }),
+      updatesMap,
+    );
+    expect(out.map((s) => s.id)).toEqual(["a"]);
+  });
+
+  it("local source key matches no-repo skill", () => {
+    const out = filterSkills(
+      skills,
+      emptyState({ filterSources: new Set([LOCAL_SOURCE_KEY]) }),
+      {},
+    );
+    expect(out.map((s) => s.id)).toEqual(["c"]);
+  });
+});
+
+describe("sortSkills", () => {
+  const skills = [
+    makeSkill({ id: "z", name: "Zebra", installedAt: 100, repoOwner: "z", repoName: "z" }),
+    makeSkill({ id: "a", name: "Apple", installedAt: 300, repoOwner: "a", repoName: "a" }),
+    makeSkill({ id: "m", name: "Mango", installedAt: 200, repoOwner: "m", repoName: "m" }),
+  ];
+
+  it("sorts by name ascending", () => {
+    expect(sortSkills(skills, "nameAsc").map((s) => s.id)).toEqual(["a", "m", "z"]);
+  });
+
+  it("sorts by name descending", () => {
+    expect(sortSkills(skills, "nameDesc").map((s) => s.id)).toEqual(["z", "m", "a"]);
+  });
+
+  it("sorts by installedAt newest first", () => {
+    expect(sortSkills(skills, "installedNewest").map((s) => s.id)).toEqual(["a", "m", "z"]);
+  });
+
+  it("sorts by installedAt oldest first", () => {
+    expect(sortSkills(skills, "installedOldest").map((s) => s.id)).toEqual(["z", "m", "a"]);
+  });
+
+  it("sorts by source key ascending", () => {
+    expect(sortSkills(skills, "sourceAsc").map((s) => s.id)).toEqual(["a", "m", "z"]);
+  });
+
+  it("places pinned skills before non-pinned regardless of sort key", () => {
+    const withPin = [
+      ...skills,
+      makeSkill({ id: "p", name: "Zebra-Pinned", installedAt: 50, pinnedAt: 9999 }),
+    ];
+    const out = sortSkills(withPin, "nameAsc");
+    expect(out[0].id).toBe("p");
+  });
+
+  it("orders multiple pinned skills by pinnedAt descending", () => {
+    const pins = [
+      makeSkill({ id: "p1", name: "A", pinnedAt: 100 }),
+      makeSkill({ id: "p2", name: "Z", pinnedAt: 200 }),
+    ];
+    expect(sortSkills(pins, "nameAsc").map((s) => s.id)).toEqual(["p2", "p1"]);
+  });
+});
+
+describe("groupSkills", () => {
+  const skills = [
+    makeSkill({ id: "a", repoOwner: "forrest", repoName: "kit", apps: appsWith(["claude"]) }),
+    makeSkill({ id: "b", repoOwner: "kar", repoName: "tools", apps: appsWith(["codex", "claude"]) }),
+    makeSkill({ id: "c", repoOwner: undefined, repoName: undefined, apps: appsWith(["gemini"]) }),
+  ];
+
+  it("none returns a single all-group", () => {
+    const out = groupSkills(skills, "none", APP_IDS);
+    expect(out).toHaveLength(1);
+    expect(out[0].key).toBe(ALL_GROUP_KEY);
+    expect(out[0].items).toHaveLength(3);
+  });
+
+  it("source groups have one entry per unique source; local sorted last", () => {
+    const out = groupSkills(skills, "source", APP_IDS);
+    expect(out.map((g) => g.key)).toEqual([
+      "forrest/kit",
+      "kar/tools",
+      LOCAL_SOURCE_KEY,
+    ]);
+    expect(out.reduce((n, g) => n + g.items.length, 0)).toBe(3);
+  });
+
+  it("app groups one per app id; skill repeats across enabled apps", () => {
+    const out = groupSkills(skills, "app", APP_IDS);
+    expect(out.map((g) => g.key)).toEqual(APP_IDS);
+    const totalAcross = out.reduce((n, g) => n + g.items.length, 0);
+    // a→claude(1), b→codex+claude(2), c→gemini(1) = 4 occurrences
+    expect(totalAcross).toBe(4);
+    const claudeGroup = out.find((g) => g.key === "claude")!;
+    expect(claudeGroup.items.map((s) => s.id).sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("deriveSourceOptions", () => {
+  it("returns sorted unique sources with local key last", () => {
+    const skills = [
+      makeSkill({ id: "a", repoOwner: "z", repoName: "z" }),
+      makeSkill({ id: "b", repoOwner: "a", repoName: "x" }),
+      makeSkill({ id: "c", repoOwner: undefined, repoName: undefined }),
+      makeSkill({ id: "d", repoOwner: "a", repoName: "x" }),
+    ];
+    expect(deriveSourceOptions(skills)).toEqual([
+      "a/x",
+      "z/z",
+      LOCAL_SOURCE_KEY,
+    ]);
+  });
+});
+
+describe("computeGroups (pipeline)", () => {
+  it("empty input yields empty groups (none mode)", () => {
+    const out = computeGroups([], emptyState(), {}, APP_IDS);
+    expect(out.filtered).toHaveLength(0);
+    expect(out.groups[0].items).toHaveLength(0);
+  });
+
+  it("end-to-end: search + source filter + sort + group", () => {
+    const skills = [
+      makeSkill({ id: "a", name: "Apple", repoOwner: "x", repoName: "y", installedAt: 100 }),
+      makeSkill({ id: "b", name: "Banana", repoOwner: "x", repoName: "y", installedAt: 200 }),
+      makeSkill({ id: "c", name: "Apricot", repoOwner: "p", repoName: "q", installedAt: 300 }),
+    ];
+    const out = computeGroups(
+      skills,
+      emptyState({
+        searchQuery: "ap",
+        filterSources: new Set(["x/y"]),
+        sortKey: "installedNewest",
+        groupKey: "source",
+      }),
+      {},
+      APP_IDS,
+    );
+    // search "ap" → Apple, Apricot
+    // source filter "x/y" → only Apple
+    // group by source → only "x/y"
+    expect(out.filtered.map((s) => s.id)).toEqual(["a"]);
+    expect(out.groups).toHaveLength(1);
+    expect(out.groups[0].key).toBe("x/y");
+  });
+
+  it("pinned floats to top inside its group", () => {
+    const skills = [
+      makeSkill({ id: "a", name: "Apple", repoOwner: "x", repoName: "y" }),
+      makeSkill({ id: "b", name: "Banana", repoOwner: "x", repoName: "y", pinnedAt: 100 }),
+    ];
+    const out = computeGroups(
+      skills,
+      emptyState({ groupKey: "source", sortKey: "nameAsc" }),
+      {},
+      APP_IDS,
+    );
+    expect(out.groups[0].items.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("useSkillsFilterSort (hook)", () => {
+  const skills = [
+    makeSkill({ id: "a", name: "Apple", repoOwner: "x", repoName: "y" }),
+    makeSkill({ id: "b", name: "Banana", repoOwner: "x", repoName: "y" }),
+    makeSkill({
+      id: "c",
+      name: "Cherry",
+      repoOwner: undefined,
+      repoName: undefined,
+    }),
+  ];
+
+  it("initial state: no filters, defaults applied", () => {
+    const { result } = renderHook(() =>
+      useSkillsFilterSort(skills, {}, APP_IDS),
+    );
+    expect(result.current.total).toBe(3);
+    expect(result.current.filteredCount).toBe(3);
+    expect(result.current.hasFilters).toBe(false);
+    expect(result.current.state.sortKey).toBe("nameAsc");
+    expect(result.current.state.groupKey).toBe("none");
+    expect(result.current.state.selectionMode).toBe(false);
+  });
+
+  it("setSearchQuery sets searchQuery and impacts hasFilters", () => {
+    const { result } = renderHook(() =>
+      useSkillsFilterSort(skills, {}, APP_IDS),
+    );
+    act(() => result.current.setSearchQuery("apple"));
+    expect(result.current.state.searchQuery).toBe("apple");
+    expect(result.current.hasFilters).toBe(true);
+    expect(result.current.filteredCount).toBe(1);
+  });
+
+  it("toggleSource adds and removes a source filter", () => {
+    const { result } = renderHook(() =>
+      useSkillsFilterSort(skills, {}, APP_IDS),
+    );
+    act(() => result.current.toggleSource("x/y"));
+    expect(result.current.state.filterSources.has("x/y")).toBe(true);
+    expect(result.current.filteredCount).toBe(2);
+
+    act(() => result.current.toggleSource("x/y"));
+    expect(result.current.state.filterSources.has("x/y")).toBe(false);
+    expect(result.current.filteredCount).toBe(3);
+  });
+
+  it("toggleApp adds and removes app filters", () => {
+    const { result } = renderHook(() =>
+      useSkillsFilterSort(skills, {}, APP_IDS),
+    );
+    act(() => result.current.toggleApp("claude"));
+    expect(result.current.state.filterApps.has("claude")).toBe(true);
+    act(() => result.current.toggleApp("claude"));
+    expect(result.current.state.filterApps.has("claude")).toBe(false);
+  });
+
+  it("setFilterUpdateOnly and clearFilters reset state", () => {
+    const { result } = renderHook(() =>
+      useSkillsFilterSort(skills, {}, APP_IDS),
+    );
+    act(() => {
+      result.current.setSearchQuery("apple");
+      result.current.toggleSource("x/y");
+      result.current.setFilterUpdateOnly(true);
+    });
+    expect(result.current.hasFilters).toBe(true);
+
+    act(() => result.current.clearFilters());
+    expect(result.current.hasFilters).toBe(false);
+    expect(result.current.state.searchQuery).toBe("");
+    expect(result.current.state.filterSources.size).toBe(0);
+    expect(result.current.state.filterUpdateOnly).toBe(false);
+  });
+
+  it("toggleCollapsed toggles a group key in collapsed set", () => {
+    const { result } = renderHook(() =>
+      useSkillsFilterSort(skills, {}, APP_IDS),
+    );
+    act(() => result.current.toggleCollapsed("x/y"));
+    expect(result.current.state.collapsed.has("x/y")).toBe(true);
+    act(() => result.current.toggleCollapsed("x/y"));
+    expect(result.current.state.collapsed.has("x/y")).toBe(false);
+  });
+
+  it("selection mode lifecycle: enter, toggle, select all, exit", () => {
+    const { result } = renderHook(() =>
+      useSkillsFilterSort(skills, {}, APP_IDS),
+    );
+    act(() => result.current.enterSelectionMode());
+    expect(result.current.state.selectionMode).toBe(true);
+    expect(result.current.state.selectedIds.size).toBe(0);
+
+    act(() => result.current.toggleSelected("a"));
+    expect(result.current.state.selectedIds.has("a")).toBe(true);
+
+    act(() => result.current.selectAllVisible());
+    expect(result.current.state.selectedIds.size).toBe(3);
+
+    act(() => result.current.clearSelection());
+    expect(result.current.state.selectedIds.size).toBe(0);
+
+    act(() => result.current.exitSelectionMode());
+    expect(result.current.state.selectionMode).toBe(false);
+  });
+
+  it("sourceOptions stays in sync with skills", () => {
+    const { result, rerender } = renderHook(
+      ({ list }: { list: InstalledSkill[] }) =>
+        useSkillsFilterSort(list, {}, APP_IDS),
+      { initialProps: { list: skills } },
+    );
+    expect(result.current.sourceOptions).toEqual([
+      "x/y",
+      LOCAL_SOURCE_KEY,
+    ]);
+
+    rerender({
+      list: [
+        ...skills,
+        makeSkill({ id: "d", repoOwner: "z", repoName: "z" }),
+      ],
+    });
+    expect(result.current.sourceOptions).toEqual([
+      "x/y",
+      "z/z",
+      LOCAL_SOURCE_KEY,
+    ]);
+  });
+
+  it("setSortKey and setGroupKey update state without other changes", () => {
+    const { result } = renderHook(() =>
+      useSkillsFilterSort(skills, {}, APP_IDS),
+    );
+    act(() => {
+      result.current.setSortKey("installedNewest");
+      result.current.setGroupKey("source");
+    });
+    expect(result.current.state.sortKey).toBe("installedNewest");
+    expect(result.current.state.groupKey).toBe("source");
+    expect(result.current.state.searchQuery).toBe("");
+  });
+});
+
+// ---- helpers ----
+
+function appsWith(enabled: AppId[]): InstalledSkill["apps"] {
+  return {
+    claude: enabled.includes("claude"),
+    codex: enabled.includes("codex"),
+    gemini: enabled.includes("gemini"),
+    opencode: enabled.includes("opencode"),
+    openclaw: enabled.includes("openclaw"),
+    hermes: enabled.includes("hermes"),
+  };
+}


### PR DESCRIPTION
## Summary / 概述

为 Skills 面板新增**置顶能力**、**批量操作栏**与**筛选/排序工具栏**，并将 `UnifiedSkillsPanel` 拆分为更小的组件与 Hook，降低维护成本。

### 主要改动

- **置顶 (Pin)**：新增 `pinned_at` 字段，伴随 SQLite schema 迁移与新的 Tauri command `set_skill_pin`；列表按置顶时间戳降序优先展示，未置顶项保持原有顺序。
- **批量操作栏 (`SkillsBulkActionBar`)**：多选场景下提供批量启用 / 禁用 / 置顶 / 取消置顶 / 删除。
- **筛选与排序 (`SkillsToolbar` + `useSkillsFilterSort`)**：抽离独立 Hook 与子组件，统一处理搜索、来源筛选与排序；`UnifiedSkillsPanel` 仅保留容器职责。
- **i18n**：同步更新 `zh` / `en` / `ja` 三套文案。
- **测试**：为 `SkillsBulkActionBar`、`SkillsToolbar`、`useSkillsFilterSort` 新增 Vitest / RTL 单元测试；更新现有 `UnifiedSkillsPanel` 测试覆盖新交互。

### 涉及范围

- 后端：`src-tauri/src/{app_config,commands/skill,database/{dao/skills,mod,schema},lib,services/skill}.rs`
- 前端：`src/components/skills/{UnifiedSkillsPanel,SkillsBulkActionBar,SkillsToolbar,useSkillsFilterSort}` + `src/hooks/useSkills.ts` + `src/lib/api/skills.ts`
- i18n：`src/i18n/locales/{en,zh,ja}.json`
- 测试：`tests/{components,hooks}/*`

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

<img width="2535" height="294" alt="QQ_1779128549346" src="https://github.com/user-attachments/assets/44d0c58c-00b2-4cdd-ada9-45551c087cfe" /> 

## Checklist / 检查清单

- [x] \`pnpm typecheck\` passes / 通过 TypeScript 类型检查
- [x] \`pnpm format:check\` passes / 通过代码格式检查
- [x] \`cargo clippy\` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>