### PR TITLE
fix: URL path segment dedup + stream check User-Agent fallback

### DIFF
--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -575,20 +575,48 @@ impl ProviderAdapter for ClaudeAdapter {
         // 现在 OpenRouter 已推出 Claude Code 兼容接口，因此默认直接透传 endpoint。
         // 如需回退旧逻辑，可在 forwarder 中根据 needs_transform 改写 endpoint。
         //
-        let mut base = format!(
-            "{}/{}",
-            base_url.trim_end_matches('/'),
-            endpoint.trim_start_matches('/')
-        );
+        let base = base_url.trim_end_matches('/');
+        let ep = endpoint.trim_start_matches('/');
+        let (ep_path, ep_query) = ep.split_once('?').unwrap_or((ep, ""));
 
-        // 去除重复的 /v1/v1（可能由 base_url 与 endpoint 都带版本导致）
-        while base.contains("/v1/v1") {
-            base = base.replace("/v1/v1", "/v1");
+        // 分离 base URL 的 origin 和 path
+        let (origin, base_path) = if let Some(scheme_end) = base.find("://") {
+            let after = &base[scheme_end + 3..];
+            if let Some(path_start) = after.find('/') {
+                (&base[..scheme_end + 3 + path_start], &after[path_start..])
+            } else {
+                (base, "/")
+            }
+        } else {
+            (base, "/")
+        };
+
+        // 将 path 拆为段，计算尾部重叠（防止 /v1/messages + /v1/messages → /v1/messages/v1/messages）
+        let base_segs: Vec<&str> = base_path.split('/').filter(|s| !s.is_empty()).collect();
+        let ep_segs: Vec<&str> = ep_path.split('/').filter(|s| !s.is_empty()).collect();
+
+        // 找最大重叠：base 尾部 N 段 == endpoint 头部 N 段
+        let overlap = (0..=base_segs.len().min(ep_segs.len()))
+            .filter(|&n| n == 0 || base_segs[base_segs.len() - n..] == ep_segs[..n])
+            .max()
+            .unwrap_or(0);
+
+        let mut all_segs = base_segs.clone();
+        all_segs.extend_from_slice(&ep_segs[overlap..]);
+
+        let path = if all_segs.is_empty() {
+            String::new()
+        } else {
+            format!("/{}", all_segs.join("/"))
+        };
+
+        let mut url = format!("{}{}", origin, path);
+        if !ep_query.is_empty() {
+            url.push('?');
+            url.push_str(ep_query);
         }
-
-        base
+        url
     }
-
     fn get_auth_headers(
         &self,
         auth: &AuthInfo,

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -425,7 +425,8 @@ impl StreamCheckService {
                     .header("x-goog-api-key", &auth.api_key)
                     .header("content-type", "application/json")
                     .header("accept", "text/event-stream")
-                    .header("accept-encoding", "identity"),
+                    .header("accept-encoding", "identity")
+                    .header("user-agent", "cc-switch-stream-check/1.0"),
             };
         } else if is_openai_chat || is_openai_responses {
             // OpenAI-compatible targets: Bearer auth + SSE headers only
@@ -636,7 +637,8 @@ impl StreamCheckService {
             .post(&url)
             .header("x-goog-api-key", &auth.api_key)
             .header("Content-Type", "application/json")
-            .header("Accept", "text/event-stream");
+            .header("Accept", "text/event-stream")
+            .header("User-Agent", "cc-switch-stream-check/1.0");
 
         // 供应商自定义 headers 最后追加
         if let Some(headers) = extra_headers {


### PR DESCRIPTION
## 修复内容

### Fix 1: build_url() 路径段去重逻辑改进

原逻辑只做 `/v1/v1` 去重，无法处理 `/v1/messages/v1/messages` 等更长重复模式。

改为将 base URL 和 endpoint 拆成路径段，计算尾部最大重叠后精确去重。

### Fix 2: stream_check 内部探测加 User-Agent

Gemini 原生（非 OAuth）流检测路径缺少 User-Agent header，被 OpenResty WAF 拦截（403）。

两处 Gemini 路径均添加 `cc-switch-stream-check/1.0` 作为兜底。

### 验证

- cargo check 通过，零新增 warning
- 12 个 build_url 相关单元测试全部通过
- 覆盖场景：`/v1` + `/v1/messages`、`/v1/messages` + `/v1/messages`、`/v1/responses` + `/v1/messages` 等
