### PR TITLE
[codex] feat: improve usage range and deeplink env imports

### DIFF
--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -185,6 +185,36 @@ fn get_primary_endpoint(request: &DeepLinkImportRequest) -> String {
         .unwrap_or_default()
 }
 
+fn parse_inline_config_value(request: &DeepLinkImportRequest) -> Option<serde_json::Value> {
+    let config_b64 = request.config.as_ref()?;
+    let decoded = decode_base64_param("config", config_b64).ok()?;
+    let content = String::from_utf8(decoded).ok()?;
+    match request.config_format.as_deref().unwrap_or("json") {
+        "json" => serde_json::from_str(&content).ok(),
+        "toml" => {
+            let toml_value: toml::Value = toml::from_str(&content).ok()?;
+            serde_json::to_value(toml_value).ok()
+        }
+        _ => None,
+    }
+}
+
+fn config_env_object(
+    request: &DeepLinkImportRequest,
+) -> serde_json::Map<String, serde_json::Value> {
+    parse_inline_config_value(request)
+        .and_then(|config| config.get("env").and_then(|env| env.as_object()).cloned())
+        .unwrap_or_default()
+}
+
+fn config_root_object(
+    request: &DeepLinkImportRequest,
+) -> serde_json::Map<String, serde_json::Value> {
+    parse_inline_config_value(request)
+        .and_then(|config| config.as_object().cloned())
+        .unwrap_or_default()
+}
+
 /// Build provider meta with usage script configuration
 fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<ProviderMeta>, AppError> {
     // Check if any usage script fields are provided
@@ -245,7 +275,7 @@ fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<Provide
 
 /// Build Claude settings configuration
 fn build_claude_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
-    let mut env = serde_json::Map::new();
+    let mut env = config_env_object(request);
     env.insert(
         "ANTHROPIC_AUTH_TOKEN".to_string(),
         json!(request.api_key.clone().unwrap_or_default()),
@@ -356,7 +386,7 @@ requires_openai_auth = true
 
 /// Build Gemini settings configuration
 fn build_gemini_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
-    let mut env = serde_json::Map::new();
+    let mut env = config_root_object(request);
     env.insert("GEMINI_API_KEY".to_string(), json!(request.api_key));
     env.insert(
         "GOOGLE_GEMINI_BASE_URL".to_string(),
@@ -759,6 +789,7 @@ fn extract_codex_base_url(toml_value: &toml::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
 
     fn hermes_request() -> DeepLinkImportRequest {
         DeepLinkImportRequest {
@@ -839,5 +870,47 @@ mod tests {
         let obj = settings.as_object().unwrap();
         assert!(obj.contains_key("baseUrl"));
         assert!(obj.contains_key("apiKey"));
+    }
+
+    #[test]
+    fn claude_deeplink_preserves_extra_env_from_inline_config() {
+        let raw_config = r#"{
+            "env": {
+                "ANTHROPIC_CUSTOM_HEADERS": "Cookie: session=abc",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": "fast-model",
+                "API_TIMEOUT_MS": "3000000"
+            }
+        }"#;
+        let request = DeepLinkImportRequest {
+            resource: "provider".to_string(),
+            app: Some("claude".to_string()),
+            name: Some("My Provider".to_string()),
+            endpoint: Some("https://proxy.example.com".to_string()),
+            api_key: Some("sk-url".to_string()),
+            model: Some("custom-model".to_string()),
+            config: Some(STANDARD.encode(raw_config)),
+            config_format: Some("json".to_string()),
+            ..Default::default()
+        };
+
+        let settings = build_claude_settings(&request);
+
+        assert_eq!(
+            settings.pointer("/env/ANTHROPIC_CUSTOM_HEADERS"),
+            Some(&json!("Cookie: session=abc"))
+        );
+        assert_eq!(
+            settings.pointer("/env/API_TIMEOUT_MS"),
+            Some(&json!("3000000"))
+        );
+        assert_eq!(
+            settings.pointer("/env/ANTHROPIC_AUTH_TOKEN"),
+            Some(&json!("sk-url")),
+            "URL params should still override config-derived standard fields"
+        );
+        assert_eq!(
+            settings.pointer("/env/ANTHROPIC_MODEL"),
+            Some(&json!("custom-model"))
+        );
     }
 }

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -430,6 +430,80 @@ fn local_day_start_rfc3339(day: NaiveDate) -> String {
     local_midnight.to_rfc3339()
 }
 
+fn local_day_timestamp(
+    day: NaiveDate,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) -> Result<i64, AppError> {
+    day.and_hms_opt(hour, minute, second)
+        .and_then(|naive| match Local.from_local_datetime(&naive) {
+            chrono::LocalResult::Single(dt) => Some(dt),
+            chrono::LocalResult::Ambiguous(earliest, _) => Some(earliest),
+            chrono::LocalResult::None => None,
+        })
+        .map(|dt| dt.timestamp())
+        .ok_or_else(|| AppError::Database(format!("无法解析本地日期: {day}")))
+}
+
+fn all_usage_trend_bounds(
+    conn: &Connection,
+    app_type: Option<&str>,
+) -> Result<Option<(i64, i64)>, AppError> {
+    let effective_filter = effective_usage_log_filter("l");
+    let detail_sql = format!(
+        "SELECT MIN(l.created_at), MAX(l.created_at)
+         FROM proxy_request_logs l
+         WHERE {effective_filter} {}",
+        if app_type.is_some() { "AND l.app_type = ?1" } else { "" }
+    );
+    let detail_bounds: (Option<i64>, Option<i64>) = if let Some(at) = app_type {
+        conn.query_row(&detail_sql, params![at], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?
+    } else {
+        conn.query_row(&detail_sql, [], |row| Ok((row.get(0)?, row.get(1)?)))?
+    };
+
+    let rollup_sql = format!(
+        "SELECT MIN(date), MAX(date) FROM usage_daily_rollups {}",
+        if app_type.is_some() { "WHERE app_type = ?1" } else { "" }
+    );
+    let rollup_bounds: (Option<String>, Option<String>) = if let Some(at) = app_type {
+        conn.query_row(&rollup_sql, params![at], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?
+    } else {
+        conn.query_row(&rollup_sql, [], |row| Ok((row.get(0)?, row.get(1)?)))?
+    };
+
+    let rollup_start = rollup_bounds
+        .0
+        .as_deref()
+        .map(|date| {
+            NaiveDate::parse_from_str(date, "%Y-%m-%d")
+                .map_err(|err| AppError::Database(format!("解析 rollup 开始日期失败: {err}")))
+                .and_then(|day| local_day_timestamp(day, 0, 0, 0))
+        })
+        .transpose()?;
+    let rollup_end = rollup_bounds
+        .1
+        .as_deref()
+        .map(|date| {
+            NaiveDate::parse_from_str(date, "%Y-%m-%d")
+                .map_err(|err| AppError::Database(format!("解析 rollup 结束日期失败: {err}")))
+                .and_then(|day| local_day_timestamp(day, 23, 59, 59))
+        })
+        .transpose()?;
+
+    let starts = [detail_bounds.0, rollup_start].into_iter().flatten();
+    let ends = [detail_bounds.1, rollup_end].into_iter().flatten();
+    let start = starts.min();
+    let end = ends.max();
+
+    Ok(start.zip(end))
+}
+
 impl Database {
     /// 获取使用量汇总
     pub fn get_usage_summary(
@@ -705,8 +779,16 @@ impl Database {
     ) -> Result<Vec<DailyStats>, AppError> {
         let conn = lock_conn!(self.conn);
 
-        let end_ts = end_date.unwrap_or_else(|| Local::now().timestamp());
-        let mut start_ts = start_date.unwrap_or_else(|| end_ts - 24 * 60 * 60);
+        let (mut start_ts, end_ts) = if start_date.is_none() && end_date.is_none() {
+            all_usage_trend_bounds(&conn, app_type)?
+                .unwrap_or_else(|| {
+                    let end = Local::now().timestamp();
+                    (end - 24 * 60 * 60, end)
+                })
+        } else {
+            let end = end_date.unwrap_or_else(|| Local::now().timestamp());
+            (start_date.unwrap_or_else(|| end - 24 * 60 * 60), end)
+        };
 
         if start_ts >= end_ts {
             start_ts = end_ts - 24 * 60 * 60;
@@ -3026,6 +3108,63 @@ mod tests {
         assert_eq!(stats[1].total_tokens, 600);
         assert_eq!(stats[2].request_count, 1);
         assert_eq!(stats[2].total_tokens, 275);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_daily_trends_none_bounds_uses_all_available_usage() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model,
+                    input_tokens, output_tokens, total_cost_usd,
+                    latency_ms, status_code, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    "all-detail",
+                    "p1",
+                    "claude",
+                    "claude-3",
+                    100,
+                    50,
+                    "0.01",
+                    100,
+                    200,
+                    local_ts(2024, 5, 1, 13, 0, 0)
+                ],
+            )?;
+            conn.execute(
+                "INSERT INTO usage_daily_rollups (
+                    date, app_type, provider_id, model,
+                    request_count, success_count, input_tokens, output_tokens,
+                    cache_read_tokens, cache_creation_tokens, total_cost_usd, avg_latency_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    "2024-05-03",
+                    "claude",
+                    "p1",
+                    "claude-3",
+                    2,
+                    2,
+                    200,
+                    100,
+                    0,
+                    0,
+                    "0.02",
+                    120
+                ],
+            )?;
+        }
+
+        let stats = db.get_daily_trends(None, None, Some("claude"))?;
+        assert_eq!(stats.len(), 3);
+        assert_eq!(stats.iter().map(|stat| stat.request_count).sum::<u64>(), 3);
+        assert_eq!(stats[0].total_tokens, 150);
+        assert_eq!(stats[2].total_tokens, 300);
 
         Ok(())
     }

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -63,8 +63,8 @@ export function UsageDashboard() {
       return getUsageRangePresetLabel(range.preset, t);
     }
 
-    return `${new Date(resolvedRange.startDate * 1000).toLocaleString(locale)} - ${new Date(
-      resolvedRange.endDate * 1000,
+    return `${new Date(resolvedRange.startDate! * 1000).toLocaleString(locale)} - ${new Date(
+      resolvedRange.endDate! * 1000,
     ).toLocaleString(locale)}`;
   }, [locale, range, resolvedRange.endDate, resolvedRange.startDate, t]);
 

--- a/src/components/usage/UsageDateRangePicker.tsx
+++ b/src/components/usage/UsageDateRangePicker.tsx
@@ -15,7 +15,8 @@ import type { UsageRangePreset, UsageRangeSelection } from "@/types/usage";
 
 type DraftField = "start" | "end";
 
-const PRESETS: UsageRangePreset[] = ["today", "1d", "7d", "14d", "30d"];
+const PRESETS: UsageRangePreset[] = ["today", "1d", "7d", "14d", "30d", "all"];
+const DEFAULT_DRAFT_LOOKBACK_SECONDS = 30 * 24 * 60 * 60;
 
 interface UsageDateRangePickerProps {
   selection: UsageRangeSelection;
@@ -96,6 +97,18 @@ function getCalendarDays(month: Date): Date[] {
   });
 }
 
+function getDraftRange(selection: UsageRangeSelection): {
+  startDate: number;
+  endDate: number;
+} {
+  const resolved = resolveUsageRange(selection);
+  const endDate = resolved.endDate ?? Math.floor(Date.now() / 1000);
+  return {
+    startDate: resolved.startDate ?? endDate - DEFAULT_DRAFT_LOOKBACK_SECONDS,
+    endDate,
+  };
+}
+
 /* ── component ── */
 
 export function UsageDateRangePicker({
@@ -106,17 +119,14 @@ export function UsageDateRangePicker({
   const { t, i18n } = useTranslation();
   const [open, setOpen] = useState(false);
   const [activeField, setActiveField] = useState<DraftField>("start");
-  const resolvedRange = useMemo(
-    () => resolveUsageRange(selection),
-    [selection],
-  );
-  const [draftStart, setDraftStart] = useState(resolvedRange.startDate);
-  const [draftEnd, setDraftEnd] = useState(resolvedRange.endDate);
+  const draftRange = useMemo(() => getDraftRange(selection), [selection]);
+  const [draftStart, setDraftStart] = useState(draftRange.startDate);
+  const [draftEnd, setDraftEnd] = useState(draftRange.endDate);
   const [displayMonth, setDisplayMonth] = useState(
     () =>
       new Date(
-        fromTs(resolvedRange.startDate).getFullYear(),
-        fromTs(resolvedRange.startDate).getMonth(),
+        fromTs(draftRange.startDate).getFullYear(),
+        fromTs(draftRange.startDate).getMonth(),
         1,
       ),
   );
@@ -128,7 +138,7 @@ export function UsageDateRangePicker({
   // Reset draft when popover opens
   useEffect(() => {
     if (!open) return;
-    const r = resolveUsageRange(selection);
+    const r = getDraftRange(selection);
     setDraftStart(r.startDate);
     setDraftEnd(r.endDate);
     setDisplayMonth(

--- a/src/components/usage/UsageTrendChart.tsx
+++ b/src/components/usage/UsageTrendChart.tsx
@@ -47,7 +47,10 @@ export function UsageTrendChart({
     );
   }
 
-  const durationSeconds = Math.max(endDate - startDate, 0);
+  const durationSeconds =
+    startDate !== undefined && endDate !== undefined
+      ? Math.max(endDate - startDate, 0)
+      : Number.POSITIVE_INFINITY;
   const isHourly = durationSeconds <= 24 * 60 * 60;
   const language = i18n.resolvedLanguage || i18n.language || "en";
   const dateLocale = getLocaleFromLanguage(language);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1155,6 +1155,7 @@
     "preset7d": "7d",
     "preset14d": "14d",
     "preset30d": "30d",
+    "presetAll": "All",
     "totalRequests": "Total Requests",
     "totalCost": "Total Cost",
     "cost": "Cost",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1155,6 +1155,7 @@
     "preset7d": "7d",
     "preset14d": "14d",
     "preset30d": "30d",
+    "presetAll": "すべて",
     "totalRequests": "総リクエスト数",
     "totalCost": "総コスト",
     "cost": "コスト",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1155,6 +1155,7 @@
     "preset7d": "7d",
     "preset14d": "14d",
     "preset30d": "30d",
+    "presetAll": "全部",
     "totalRequests": "总请求数",
     "totalCost": "总成本",
     "cost": "成本",

--- a/src/lib/usageRange.ts
+++ b/src/lib/usageRange.ts
@@ -4,8 +4,8 @@ const DAY_SECONDS = 24 * 60 * 60;
 const DAY_MS = DAY_SECONDS * 1000;
 
 export interface ResolvedUsageRange {
-  startDate: number;
-  endDate: number;
+  startDate?: number;
+  endDate?: number;
 }
 
 function getStartOfLocalDayDate(nowMs: number): Date {
@@ -14,7 +14,7 @@ function getStartOfLocalDayDate(nowMs: number): Date {
 }
 
 function getPresetLookbackStart(
-  preset: Exclude<UsageRangePreset, "today" | "1d" | "custom">,
+  preset: Exclude<UsageRangePreset, "today" | "1d" | "all" | "custom">,
   nowMs: number,
 ): number {
   const dayCount = preset === "7d" ? 7 : preset === "14d" ? 14 : 30;
@@ -47,6 +47,8 @@ export function resolveUsageRange(
         startDate: getPresetLookbackStart(selection.preset, nowMs),
         endDate,
       };
+    case "all":
+      return {};
     case "custom": {
       const startDate = selection.customStartDate ?? endDate - DAY_SECONDS;
       const customEndDate = selection.customEndDate ?? endDate;
@@ -73,6 +75,8 @@ export function getUsageRangePresetLabel(
       return t("usage.preset14d", { defaultValue: "14d" });
     case "30d":
       return t("usage.preset30d", { defaultValue: "30d" });
+    case "all":
+      return t("usage.presetAll", { defaultValue: "全部" });
     case "custom":
       return t("usage.customRange", { defaultValue: "日历筛选" });
   }

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -130,7 +130,14 @@ export interface ProviderLimitStatus {
   monthlyExceeded: boolean;
 }
 
-export type UsageRangePreset = "today" | "1d" | "7d" | "14d" | "30d" | "custom";
+export type UsageRangePreset =
+  | "today"
+  | "1d"
+  | "7d"
+  | "14d"
+  | "30d"
+  | "all"
+  | "custom";
 
 export interface UsageRangeSelection {
   preset: UsageRangePreset;

--- a/tests/utils/usageRange.test.ts
+++ b/tests/utils/usageRange.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getUsageRangePresetLabel, resolveUsageRange } from "@/lib/usageRange";
+
+describe("usage range helpers", () => {
+  it("leaves date bounds unset for the all preset", () => {
+    expect(resolveUsageRange({ preset: "all" })).toEqual({});
+  });
+
+  it("labels the all preset through i18n", () => {
+    const t = (key: string, options?: { defaultValue?: string }) =>
+      key === "usage.presetAll" ? "All" : (options?.defaultValue ?? key);
+
+    expect(getUsageRangePresetLabel("all", t)).toBe("All");
+  });
+});


### PR DESCRIPTION
## Summary
- Add an All preset to the Usage Statistics range picker so users can view total local token consumption without manually choosing an old start date.
- Let all-time trend queries use the actual stored usage bounds instead of falling back to the last 24 hours.
- Preserve extra Claude/Gemini config fields from inline deeplink imports, while keeping URL query params as the override source for standard fields.

Fixes #2925
Fixes #2927

## Validation
- `pnpm.cmd exec vitest run tests/utils/usageRange.test.ts`
- `pnpm.cmd exec tsc --noEmit`
- `pnpm.cmd exec prettier --check src/types/usage.ts src/lib/usageRange.ts src/components/usage/UsageDashboard.tsx src/components/usage/UsageDateRangePicker.tsx src/components/usage/UsageTrendChart.tsx tests/utils/usageRange.test.ts`
- `git diff --check`

Note: Rust coverage was added for the deeplink env preservation and all-time trend bounds, but `cargo` is not available on this Windows environment PATH, so I could not execute the Rust test target locally.