### PR TITLE
feat(webdav): add module-scoped cloud sync(API, skills, mcps, prompts)

### DIFF
--- a/doc/DEVELOPMENT_AND_TESTING.md
+++ b/doc/DEVELOPMENT_AND_TESTING.md
@@ -1,0 +1,118 @@
+# CC Switch 开发测试指南
+
+本文档旨在指导开发者如何在不影响本地已安装的 CC Switch 正式版的情况下，进行开发、编译、安装和隔离测试。
+
+## 1. 开发环境配置
+
+### 前提条件
+在开始之前，请确保您的系统已安装以下工具：
+- **Node.js**: v18+ 
+- **pnpm**: v8+ (项目使用 pnpm 管理依赖)
+- **Rust**: v1.85+ (及 Cargo)
+- **Tauri 依赖**: 请参考 [Tauri 2.0 官方指南](https://v2.tauri.app/start/prerequisites/) 安装各平台（Windows/macOS/Linux）所需的系统库。
+
+### 初始化项目
+```bash
+# 克隆仓库（如果你还没克隆）
+# git clone <repository-url>
+# cd cc-switch
+
+# 安装前端依赖
+pnpm install
+```
+
+---
+
+## 2. 编译与运行
+
+### 开发模式 (热重载)
+这是最常用的开发方式，前端支持热重载，后端修改后会自动重新编译运行。
+```bash
+pnpm dev
+```
+*注意：在热重载模式下，程序会自动进入 Debug 模式。*
+
+### 生产版本构建
+如果您想测试完整的打包流程，可以运行：
+```bash
+pnpm build
+```
+构建产物将位于 `src-tauri/target/release/bundle/` 下。
+
+---
+
+## 3. 隔离测试（不影响本地正式版）
+
+CC Switch 默认将配置文件和数据库存储在 `~/.cc-switch` (Linux/macOS) 或 `%USERPROFILE%\.cc-switch` (Windows) 目录下。为了避免开发版本覆盖您正式版的数据，建议使用以下方法进行隔离：
+
+### 方法 A：更改标识符（推荐用于长期开发）
+在 `src-tauri/tauri.conf.json` 中，临时修改 `identifier`：
+```json
+{
+  "identifier": "com.ccswitch.dev",  // 原始为 com.ccswitch.desktop
+  "productName": "CC Switch Dev"
+}
+```
+这样 Tauri 插件（如 `window-state`）将使用不同的存储空间。
+
+### 方法 B：环境变量隔离（适用于 Linux/macOS）
+在启动命令前指定不同的 `HOME` 目录，强制程序在新的位置创建配置：
+```bash
+# 创建一个专门的测试目录
+mkdir -p ./test-env
+
+# 以隔离的路径运行
+HOME=$PWD/test-env pnpm dev
+```
+这样，所有的配置文件和 `.cc-switch` 数据库都会生成在 `./test-env/.cc-switch` 中，完全不会触碰您原本的 `~/.cc-switch`。
+
+---
+
+## 4. 安装测试
+
+### 运行未封包的二进制文件
+您可以直接运行编译器生成的 release 二进制文件：
+- **Linux**: `./src-tauri/target/release/cc-switch`
+- **Windows**: `.\src-tauri\target\release\cc_switch.exe`
+
+### 安装包测试
+在 `pnpm build` 完成后：
+- **Windows**: 运行 `src-tauri/target/release/bundle/msi/*.msi` 或 `exe`。
+- **macOS**: 打开 `src-tauri/target/release/bundle/dmg/*.dmg`。
+- **Linux**: 运行 `src-tauri/target/release/bundle/deb/*.deb` 或 `AppImage`。
+
+**提示**：在安装测试版本前，建议先卸载正式版，或者使用上述的“更改标识符”方法使两者共存。
+
+---
+
+## 5. 自动化测试
+
+项目包含了完整的测试套件，建议在提交代码前运行：
+
+### 前端测试 (Vitest)
+```bash
+pnpm test:unit
+```
+
+### 后端测试 (Cargo)
+```bash
+cd src-tauri
+cargo test
+```
+
+### 静态检查
+```bash
+pnpm typecheck  # TypeScript 类型检查
+cargo clippy    # Rust 代码检查
+```
+
+---
+
+## 6. 常见问题 (FAQ)
+
+- **Q: 为什么我修改了 Rust 代码但没有生效？**
+  - A: `pnpm dev` 会监控 Rust 变更，但有时由于文件锁定可能失败。尝试关闭程序，运行 `cargo clean` 后重新 `pnpm dev`。
+- **Q: 如何查看后端日志？**
+  - A: 在 `pnpm dev` 运行的终端中，你会看到后端的 `println!` 或 `log::info!` 输出。
+- **Q: 数据库在哪里？**
+  - A: 默认在 `~/.cc-switch/cc-switch.db`，是一个 SQLite 数据库。

--- a/doc/webdav-module-sync-isolated-readme.md
+++ b/doc/webdav-module-sync-isolated-readme.md
@@ -1,0 +1,556 @@
+# WebDAV 分模块同步隔离编译与测试 README
+
+这份文档专门说明这次 `WebDAV 分模块同步` 改动如何在**不污染你本地现有 CC Switch 配置**的前提下完成：
+
+- 编译
+- 单元测试
+- 手工功能测试
+- 真实坚果云 WebDAV smoke test
+
+本文默认你在本仓库根目录执行命令。
+
+---
+
+## 1. 原则
+
+这次测试必须遵守下面两条：
+
+1. **不要复用你现在的本地 CC Switch 配置目录**
+   - 不要直接读写你当前的 `~/.cc-switch`
+   - 不要直接复用你当前的 `cc-switch-sync/default`
+
+2. **开发版必须在隔离环境里运行**
+   - 本地配置隔离：通过 `CC_SWITCH_TEST_HOME` 和 `HOME`
+   - 云端目录隔离：通过新的 `remoteRoot` 和/或新的 `profile`
+
+---
+
+## 2. 一次性准备
+
+### 2.1 安装依赖
+
+```bash
+pnpm install
+```
+
+如果你的 `pnpm` 是 11.x，且提示 `Ignored build scripts`，执行：
+
+```bash
+pnpm approve-builds --all
+pnpm install
+```
+
+当前分支里也已经在 [pnpm-workspace.yaml](/home/fan/.config/superpowers/worktrees/cc-switch/feat-webdav-module-sync/pnpm-workspace.yaml) 增加了：
+
+```yaml
+allowBuilds:
+  esbuild: true
+  msw: true
+```
+
+这是为了让 `typecheck` / `vitest` 可以在当前环境下正常执行。它是**前端工具链验证配置**，不是 WebDAV 业务逻辑的一部分。
+
+### 2.2 Rust 依赖
+
+Rust 依赖会在第一次执行 `cargo test` / `cargo clippy` 时自动拉取。
+
+---
+
+## 3. 创建隔离运行环境
+
+下面这组命令是最重要的。它会把开发版的 HOME、CC Switch 配置目录和 XDG 目录都隔离出去。
+
+```bash
+export DEV_ROOT="$(mktemp -d /tmp/cc-switch-webdav-dev.XXXXXX)"
+mkdir -p "$DEV_ROOT"/home
+
+export CC_SWITCH_TEST_HOME="$DEV_ROOT/home"
+
+# 可选：把 Cargo 构建产物也隔离
+export CARGO_TARGET_DIR="$PWD/.isolated-target"
+
+echo "DEV_ROOT=$DEV_ROOT"
+echo "CC_SWITCH_TEST_HOME=$CC_SWITCH_TEST_HOME"
+```
+
+### 3.1 为什么要设置这个变量
+
+- `CC_SWITCH_TEST_HOME`
+  - CC Switch 后端优先使用它来决定“用户主目录”。
+  - 这能把 `~/.cc-switch`、skills 等全部导向这个临时目录，实现完全的数据隔离。
+  - 我们**不再**重写原生的 `HOME` 或 `XDG_*`，这样就能保证你的 `cargo` 缓存、`mise` 配置、系统工具正常工作，做到秒级增量编译，而不是每次都在新 `HOME` 里重新下载几百个包并编译！
+
+### 3.2 验证隔离是否生效
+
+运行下面命令：
+
+```bash
+echo "$CC_SWITCH_TEST_HOME"
+ls -la "$CC_SWITCH_TEST_HOME"
+```
+
+然后启动开发版后，新的 CC Switch 配置会写到：
+
+```bash
+$CC_SWITCH_TEST_HOME/.cc-switch
+```
+
+而不是你真实的：
+
+```bash
+~/.cc-switch
+```
+
+---
+
+## 4. 如何编译和跑静态检查
+
+### 4.1 前端检查
+
+```bash
+pnpm format:check
+pnpm typecheck
+pnpm test:unit
+```
+
+### 4.2 后端检查
+
+```bash
+cd src-tauri
+cargo fmt --check
+cargo clippy --no-deps
+cargo test --no-fail-fast
+cd ..
+```
+
+### 4.3 一次跑完整验证矩阵
+
+```bash
+pnpm format:check
+pnpm typecheck
+pnpm test:unit
+
+cd src-tauri
+cargo fmt --check
+cargo clippy --no-deps
+cargo test --no-fail-fast
+cd ..
+```
+
+---
+
+## 5. 如何编译开发版 / 构建包
+
+### 5.1 启动开发版
+
+```bash
+pnpm tauri dev
+```
+
+或：
+
+```bash
+pnpm dev
+```
+
+推荐使用：
+
+```bash
+pnpm tauri dev
+```
+
+因为它会同时启动前端和 Tauri 后端。
+
+### 5.2 构建发行包
+
+```bash
+pnpm build
+```
+
+构建产物通常在：
+
+```bash
+src-tauri/target/release/bundle/
+```
+
+如果你设置了：
+
+```bash
+export CARGO_TARGET_DIR="$PWD/.isolated-target"
+```
+
+那么 Rust 构建产物会走：
+
+```bash
+.isolated-target/
+```
+
+---
+
+## 6. 手工功能测试：推荐用两个隔离环境
+
+为了验证“上传只改选中模块、下载只覆盖选中模块”，最稳妥的方法是开两个完全隔离的开发环境：
+
+- 环境 A：模拟“上传端”
+- 环境 B：模拟“下载端”
+
+### 6.1 环境 A
+
+终端 A：
+
+```bash
+export DEV_ROOT_A="$(mktemp -d /tmp/cc-switch-webdav-A.XXXXXX)"
+mkdir -p "$DEV_ROOT_A"/home
+export CC_SWITCH_TEST_HOME="$DEV_ROOT_A/home"
+
+pnpm tauri dev
+```
+
+### 6.2 环境 B
+
+终端 B：
+
+```bash
+export DEV_ROOT_B="$(mktemp -d /tmp/cc-switch-webdav-B.XXXXXX)"
+mkdir -p "$DEV_ROOT_B"/home
+export CC_SWITCH_TEST_HOME="$DEV_ROOT_B/home"
+export CC_SWITCH_DISABLE_SINGLE_INSTANCE=1
+
+pnpm tauri dev
+```
+
+> **注意：** 环境变量 `CC_SWITCH_DISABLE_SINGLE_INSTANCE=1` 非常重要，它能绕过 Tauri 的单实例检测，允许双开。同时，得益于 Vite 的 `strictPort: false`，终端 B 的前端会自动占用 3001 等可用端口，后端也会极速复用编译缓存（0秒启动）。
+
+---
+
+## 7. WebDAV 测试配置建议
+
+### 7.1 坚果云配置
+
+在开发版设置页填：
+
+- `WebDAV Server URL`
+  - `https://dav.jianguoyun.com/dav/`
+- `Username`
+  - 你的坚果云邮箱账号
+- `Password`
+  - 坚果云第三方应用密码
+
+### 7.2 remoteRoot 一定要用短名字
+
+坚果云对根目录新建目录名有长度限制。
+
+不要用太长的目录名，比如：
+
+```text
+cc-switch-sync-live-1779087934214
+```
+
+它会返回：
+
+```text
+sandbox name is too long
+```
+
+推荐使用短名字，例如：
+
+```bash
+csl-$(date +%s)
+```
+
+例如：
+
+```text
+csl-1779088000
+```
+
+### 7.3 profile 也建议用独立值
+
+例如：
+
+```text
+module-sync
+```
+
+或：
+
+```text
+manual-a
+```
+
+### 7.4 不要使用你的生产路径
+
+不要使用：
+
+- `remoteRoot = cc-switch-sync`
+- `profile = default`
+
+用于这次开发测试。
+
+---
+
+## 8. 手工功能测试步骤
+
+下面给出一套最完整、最稳妥的验证流程。
+
+---
+
+### 8.1 测试 1：全模块首次上传
+
+在环境 A 中：
+
+1. 打开设置页，配置 WebDAV
+2. `remoteRoot` 填一个新的短目录，例如：
+   - `csl-1779088000`
+3. `profile` 填：
+   - `module-sync`
+4. 上传默认模块保持全选：
+   - API
+   - MCP
+   - Prompts
+   - Skills
+5. 下载默认模块也保持全选
+6. 点击“保存配置”
+7. 点击“测试连接”
+8. 在开发版里创建一些隔离测试数据：
+   - API provider：`provider-a`
+   - MCP：`mcp-a`
+   - Prompt：`prompt-a`
+   - Skill：`skill-a`
+9. 点击“Upload to Cloud”
+10. 确认上传
+
+预期：
+
+- 上传成功
+- 远端创建新的 `v3/db-v6/<profile>` 结构
+- 不影响你真实 `~/.cc-switch`
+- 不影响你现在坚果云里的生产目录
+
+---
+
+### 8.2 测试 2：仅上传 MCP，确认远端其他模块保留
+
+继续在环境 A 中：
+
+1. 只保留“上传默认模块”里的 `MCP`
+2. API / Prompts / Skills 全部取消
+3. 保存配置
+4. 修改 MCP 数据：
+   - 删除 `mcp-a`
+   - 新建 `mcp-b`
+5. 不改 API / Prompt / Skill
+6. 再次点击“Upload to Cloud”
+
+预期：
+
+- 上传成功
+- 远端 MCP 变成新内容
+- 远端 API / Prompts / Skills 仍保留第一次上传的内容
+
+---
+
+### 8.3 测试 3：仅下载 Prompts，确认本地未选模块保持不变
+
+切换到环境 B：
+
+1. 配置同一个坚果云地址
+2. `remoteRoot` 填和环境 A 相同的值
+3. `profile` 填和环境 A 相同的值
+4. 在环境 B 里先创建本地专属数据：
+   - API provider：`provider-local`
+   - MCP：`mcp-local`
+   - Skill：`skill-local`
+   - Prompt：`prompt-local`
+5. 将“下载默认模块”改成只选：
+   - Prompts
+6. 保存配置
+7. 点击“Download from Cloud”
+8. 确认下载
+
+预期：
+
+- `prompt-a` 会从远端同步到环境 B
+- `provider-local` 保持不变
+- `mcp-local` 保持不变
+- `skill-local` 保持不变
+- 未勾选模块不会被清空
+
+---
+
+### 8.4 测试 4：自动同步只跟随上传模块
+
+继续在环境 B：
+
+1. 将“上传默认模块”改成只选：
+   - Skills
+2. 开启 `Auto Sync`
+3. 保存配置
+4. 修改一个 API provider
+5. 观察：
+   - 不应该触发 WebDAV 上传
+6. 修改一个 skill
+7. 再观察：
+   - 应该触发 WebDAV 上传
+
+建议观察方式：
+
+- 看应用里的 `Last sync`
+- 看运行 `pnpm tauri dev` 的终端日志
+- 搜索类似：
+
+```text
+[WebDAV][AutoSync]
+```
+
+预期：
+
+- provider 修改不触发 auto sync
+- skill 修改才触发 auto sync
+
+---
+
+## 9. 自动化真实 WebDAV smoke test
+
+这次改动里已经加了一个 `ignored` 的 live test：
+
+- 位置：
+  - [src-tauri/src/services/webdav_sync.rs](/home/fan/.config/superpowers/worktrees/cc-switch/feat-webdav-module-sync/src-tauri/src/services/webdav_sync.rs)
+- 测试名：
+  - `live_webdav_module_sync_roundtrip_preserves_unselected_modules`
+
+### 9.1 运行方式
+
+```bash
+cd src-tauri
+
+CC_SWITCH_LIVE_WEBDAV_URL='https://dav.jianguoyun.com/dav/' \
+CC_SWITCH_LIVE_WEBDAV_USERNAME='你的坚果云账号' \
+CC_SWITCH_LIVE_WEBDAV_PASSWORD='你的坚果云第三方应用密码' \
+cargo test live_webdav_module_sync_roundtrip_preserves_unselected_modules -- --ignored --nocapture
+```
+
+### 9.2 它会做什么
+
+这个测试会：
+
+1. 自动创建临时 `CC_SWITCH_TEST_HOME`
+2. 自动生成新的短 `remoteRoot`
+3. 用全模块上传一轮
+4. 再做一轮“只上传 MCP”
+5. 再在另一套隔离本地状态上做“只下载 Prompts”
+6. 断言未勾选模块在本地保持不变
+
+### 9.3 它不会做什么
+
+它不会：
+
+- 读写你的真实 `~/.cc-switch`
+- 使用你当前生产的 `cc-switch-sync/default`
+
+### 9.4 注意
+
+这个 live test 会在坚果云里留下一个新的测试目录。
+
+测试完成后，如果你想清理，可以到坚果云网页端或 WebDAV 目录里手动删除。
+
+---
+
+## 10. 快速命令清单
+
+### 10.1 隔离启动开发版
+
+```bash
+export DEV_ROOT="$(mktemp -d /tmp/cc-switch-webdav-dev.XXXXXX)"
+mkdir -p "$DEV_ROOT"/home
+export CC_SWITCH_TEST_HOME="$DEV_ROOT/home"
+pnpm tauri dev
+```
+
+### 10.2 跑前端验证
+
+```bash
+pnpm format:check
+pnpm typecheck
+pnpm test:unit
+```
+
+### 10.3 跑后端验证
+
+```bash
+cd src-tauri
+cargo fmt --check
+cargo clippy --no-deps
+cargo test --no-fail-fast
+cd ..
+```
+
+### 10.4 跑真实 WebDAV smoke test
+
+```bash
+cd src-tauri
+
+CC_SWITCH_LIVE_WEBDAV_URL='https://dav.jianguoyun.com/dav/' \
+CC_SWITCH_LIVE_WEBDAV_USERNAME='你的坚果云账号' \
+CC_SWITCH_LIVE_WEBDAV_PASSWORD='你的坚果云第三方应用密码' \
+cargo test live_webdav_module_sync_roundtrip_preserves_unselected_modules -- --ignored --nocapture
+```
+
+---
+
+## 11. 测试完成后如何清理
+
+### 11.1 删除本地隔离目录
+
+如果你用了 `mktemp -d`，记住输出的 `DEV_ROOT`，测试完直接删：
+
+```bash
+rm -rf "$DEV_ROOT"
+```
+
+如果你开了 A/B 两个环境：
+
+```bash
+rm -rf "$DEV_ROOT_A" "$DEV_ROOT_B"
+```
+
+### 11.2 删除隔离构建目录（如果设置过）
+
+```bash
+rm -rf .isolated-target
+```
+
+### 11.3 删除坚果云测试目录
+
+删除你这次测试使用的：
+
+- `remoteRoot`
+- 对应 `profile`
+
+例如：
+
+```text
+csl-1779088000
+```
+
+---
+
+## 12. 结论
+
+如果你只是想“安全地编译和跑测试”，最短路径就是：
+
+1. 先导出隔离环境变量
+2. 跑：
+
+```bash
+pnpm typecheck
+pnpm test:unit
+cd src-tauri && cargo test --no-fail-fast && cargo clippy --no-deps && cd ..
+```
+
+如果你想“真的测这个功能”，推荐再做两件事：
+
+1. 用 `pnpm tauri dev` 起两个隔离开发版，做 A/B 手工验证
+2. 跑一次 `live_webdav_module_sync_roundtrip_preserves_unselected_modules`
+
+这样你既能验证代码层，又能验证真实坚果云链路，而且不会污染你当前本地 CC Switch 配置。

--- a/doc/webdav-module-sync-risk-and-merge.md
+++ b/doc/webdav-module-sync-risk-and-merge.md
@@ -1,0 +1,163 @@
+# WebDAV 模块化同步风险与合并建议
+
+## 范围
+
+本文档仅针对当前工作区未提交的 WebDAV 模块化同步相关改动，不评价其他历史代码。
+
+涉及的主要文件：
+
+- `src-tauri/src/services/webdav_sync.rs`
+- `src-tauri/src/services/webdav_auto_sync.rs`
+- `src-tauri/src/database/backup.rs`
+- `src-tauri/src/settings.rs`
+- `src/components/settings/WebdavSyncSection.tsx`
+- `src/lib/schemas/settings.ts`
+- `src/types.ts`
+- `tests/components/WebdavSyncSection.test.tsx`
+- `src/i18n/locales/{en,ja,zh}.json`
+
+## 当前结论
+
+当前工作区内，本文档跟踪的 WebDAV 模块化同步正确性与数据安全问题已完成最小必要修复。
+
+当前剩余的主要合并风险不是功能逻辑，而是 merge scope：
+
+- `src-tauri/tauri.conf.json`
+- `vite.config.ts`
+
+这两处仍包含与 WebDAV 模块化同步无直接关系的改动，建议拆分或单独说明后再合并。
+
+## 已解决风险
+
+### 1. `model_pricing` 存在静默漏同步风险
+
+原问题：
+
+- 自动同步触发表与模块映射仍将 `model_pricing` 归入 API 模块。
+- `webdav_sync.rs` 的 `API_TABLES` 中缺少 `model_pricing`。
+
+影响：
+
+- 用户修改了定价数据后，自动同步会触发，看起来上传成功。
+- 但远端快照不包含该表，后续下载无法恢复这部分数据。
+
+当前状态：
+
+- 已解决。
+- `model_pricing` 已纳入 API 模块同步表。
+- 已补充回归测试覆盖该表的选择性导入/替换行为。
+
+### 2. 选择性下载丢失数据库安全备份
+
+原问题：
+
+- 新的选择性下载路径通过 `replace_tables_from_sql_strings()` 覆盖目标表。
+- 该路径目前不会像旧的整库导入那样先创建安全备份。
+
+影响：
+
+- 一旦远端快照数据异常但 SQL 仍可成功导入，应用内将失去原有的可恢复保障。
+
+当前状态：
+
+- 已解决。
+- 选择性表替换前已恢复数据库安全备份。
+- Skills 文件夹回滚逻辑仍保留。
+
+### 3. 前端默认模块回归
+
+原问题：
+
+- 后端默认值为：上传仅 `api` 开启，下载四个模块全部开启。
+- 前端 `normalizeModules()` 对缺失字段默认补 `true`。
+- 旧配置缺少 `uploadModules` / `downloadModules` 时，打开设置并保存可能把上传范围放大到全部模块。
+
+影响：
+
+- 行为变更不是用户主动选择，属于静默回归。
+
+当前状态：
+
+- 已解决。
+- 前端已区分“整个对象缺失”和“对象部分字段缺失”两种情况。
+- 缺失整个对象时，上传/下载默认值已与后端保持一致。
+
+## 已解决次级问题
+
+### 4. 有一条前端测试不构成有效回归保护
+
+原问题：
+
+- 当前测试使用的 `baseConfig` 已显式带有模块配置。
+- 因此它没有覆盖“旧配置缺少模块字段”的真实回归场景。
+
+当前状态：
+
+- 已解决。
+- 已改为用缺失模块字段的配置断言前端默认行为。
+- 额外补充了“部分 legacy 模块对象缺字段”的兼容测试。
+
+### 5. legacy v2 快照的模块可用性展示不准确
+
+原问题：
+
+- 代码把 v2 快照的可用模块默认为 `WebDavSyncModules::default()`。
+- 这会把 legacy 快照错误展示成仅 API 可用。
+
+影响：
+
+- 下载前预览会低估 legacy 快照可恢复的模块范围。
+
+当前状态：
+
+- 已解决。
+- v2 快照的远端可用模块展示已视为全模块可恢复。
+- 已补充对应断言。
+
+## 本次最小必要清理边界
+
+本次已处理内容：
+
+- 与上述风险直接相关的逻辑修复。
+- 与修复直接绑定的测试补充与修正。
+- 一处明显重复的前端模块标签 helper 清理。
+
+本次不建议混入的内容：
+
+- WebDAV 模块同步以外的新功能。
+- 大范围重构或抽象化。
+- 与本功能无关的 UI 调整。
+
+## 剩余合并范围风险
+
+当前仍建议优先处理的剩余项：
+
+- `src-tauri/tauri.conf.json`
+- `vite.config.ts`
+
+这些改动不属于本文档跟踪的 WebDAV 模块化同步修复本身。
+
+## 建议从本次功能 diff 中剥离的无关改动
+
+下列改动与 WebDAV 模块化同步无直接关系，建议单独评估或拆出：
+
+- `src-tauri/tauri.conf.json`
+  - `productName` 改为 `CC Switch Dev`
+  - `identifier` 改为 `com.ccswitch.desktop.dev`
+- `vite.config.ts`
+  - `strictPort` 从 `true` 改为 `false`
+
+原因：
+
+- 这些改动会影响开发体验、应用身份或数据目录，风险独立于本次功能。
+- 将其混入当前功能 diff 会增加 review 噪音，并削弱回归定位能力。
+
+## 合并前检查项
+
+- `model_pricing` 已包含在 API 模块同步中。
+- 选择性下载前会创建数据库安全备份。
+- 前后端模块默认值一致。
+- 针对旧配置缺字段场景的前端回归测试已覆盖。
+- 针对 `model_pricing` 的后端回归测试已覆盖。
+- legacy v2 快照的模块可见性断言已修正。
+- 无关的 dev 配置改动已确认是否保留、拆分，或明确记录为有意保留。

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages: []
 
+allowBuilds:
+  esbuild: set this to true or false
+  msw: set this to true or false
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -431,6 +431,9 @@ impl Database {
 
     /// 生成一致性快照备份，返回备份文件路径（不存在主库时返回 None）
     pub(crate) fn backup_database_file(&self) -> Result<Option<PathBuf>, AppError> {
+        if self.is_in_memory {
+            return Ok(None);
+        }
         let db_path = get_app_config_dir().join("cc-switch.db");
         if !db_path.exists() {
             return Ok(None);
@@ -1239,6 +1242,81 @@ mod tests {
             Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
             None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
         }
+
+        result
+    }
+
+    #[test]
+    #[serial]
+    fn selective_sync_import_on_memory_db_does_not_touch_redirected_backup_dir(
+    ) -> Result<(), AppError> {
+        // Reproduces the CI race that flipped CI red on this branch.
+        //
+        // The other selective_sync_import_* tests create memory Databases and call
+        // `replace_tables_from_sql_strings`, which unconditionally invokes
+        // `backup_database_file()`. Once a sibling test sets `CC_SWITCH_TEST_HOME`
+        // and Database::init() lands a real cc-switch.db inside it, the memory-DB
+        // siblings start writing safety backups into that redirected path, blowing
+        // up the "exactly one new safety backup" assertion.
+        //
+        // We reproduce the "landmine" deterministically: set CC_SWITCH_TEST_HOME,
+        // place an existing cc-switch.db there, then run the memory-DB import and
+        // assert that no backup is written.
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        let test_home =
+            std::env::temp_dir().join("cc-switch-selective-sync-memory-no-backup-test");
+        let _ = std::fs::remove_dir_all(&test_home);
+        std::fs::create_dir_all(&test_home).expect("create test home");
+        std::env::set_var("CC_SWITCH_TEST_HOME", &test_home);
+
+        let result = (|| -> Result<(), AppError> {
+            let app_dir = get_app_config_dir();
+            std::fs::create_dir_all(&app_dir).expect("create app dir");
+            std::fs::write(app_dir.join("cc-switch.db"), b"landmine")
+                .expect("plant landmine cc-switch.db");
+            let backup_dir = app_dir.join("backups");
+            let backups_before = std::fs::read_dir(&backup_dir)
+                .ok()
+                .into_iter()
+                .flat_map(|entries| entries.filter_map(|e| e.ok()))
+                .filter(|e| e.path().extension().map(|ext| ext == "db").unwrap_or(false))
+                .count();
+
+            let remote_db = Database::memory()?;
+            {
+                let conn = crate::database::lock_conn!(remote_db.conn);
+                conn.execute(
+                    "INSERT INTO mcp_servers (
+                        id, name, server_config, tags,
+                        enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes
+                    ) VALUES ('remote-mcp', 'Remote MCP', '{}', '[]', 1, 0, 0, 0, 0)",
+                    [],
+                )?;
+            }
+            let remote_sql = remote_db.export_sql_string_for_tables(&["mcp_servers"])?;
+
+            let local_db = Database::memory()?;
+            local_db.replace_tables_from_sql_strings(&[remote_sql.as_str()], &["mcp_servers"])?;
+
+            let backups_after = std::fs::read_dir(&backup_dir)
+                .ok()
+                .into_iter()
+                .flat_map(|entries| entries.filter_map(|e| e.ok()))
+                .filter(|e| e.path().extension().map(|ext| ext == "db").unwrap_or(false))
+                .count();
+
+            assert_eq!(
+                backups_after, backups_before,
+                "memory Database must not write safety backups into the redirected app dir"
+            );
+            Ok(())
+        })();
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&test_home);
 
         result
     }

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -9,6 +9,7 @@ use chrono::{Local, Utc};
 use rusqlite::backup::Backup;
 use rusqlite::types::ValueRef;
 use rusqlite::Connection;
+use std::ffi::CString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
@@ -304,28 +305,66 @@ impl Database {
         sql_content: &str,
         tables: &[&str],
     ) -> Result<(), AppError> {
-        for table in tables {
-            let filtered = sql_content
-                .lines()
-                .filter(|line| {
-                    let quoted = format!("INSERT INTO \"{table}\"");
-                    let plain = format!("INSERT INTO {table}");
-                    line.starts_with(&quoted) || line.starts_with(&plain)
-                })
-                .collect::<Vec<_>>();
+        let statements = Self::split_complete_sql_statements(sql_content)?;
 
-            if filtered.is_empty() {
+        for table in tables {
+            let quoted = format!("INSERT INTO \"{table}\"");
+            let plain = format!("INSERT INTO {table}");
+            let mut cleared = false;
+
+            for statement in &statements {
+                let sql = statement.trim_start();
+                if !sql.starts_with(&quoted) && !sql.starts_with(&plain) {
+                    continue;
+                }
+
+                if !cleared {
+                    conn.execute(&format!("DELETE FROM \"{table}\""), [])
+                        .map_err(|e| AppError::Database(format!("清空表 {table} 失败: {e}")))?;
+                    cleared = true;
+                }
+
+                conn.execute_batch(sql)
+                    .map_err(|e| AppError::Database(format!("执行 SQL 导入失败: {e}")))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn split_complete_sql_statements(sql_content: &str) -> Result<Vec<&str>, AppError> {
+        let mut statements = Vec::new();
+        let mut start = 0;
+
+        for (idx, ch) in sql_content.char_indices() {
+            if ch != ';' {
                 continue;
             }
 
-            conn.execute(&format!("DELETE FROM \"{table}\""), [])
-                .map_err(|e| AppError::Database(format!("清空表 {table} 失败: {e}")))?;
+            let candidate = &sql_content[start..idx + 1];
+            if !Self::is_complete_sql_statement(candidate)? {
+                continue;
+            }
 
-            let batch = filtered.join("\n");
-            conn.execute_batch(&batch)
-                .map_err(|e| AppError::Database(format!("执行 SQL 导入失败: {e}")))?;
+            let trimmed = candidate.trim();
+            if !trimmed.is_empty() {
+                statements.push(trimmed);
+            }
+            start = idx + 1;
         }
-        Ok(())
+
+        let trailing = sql_content[start..].trim();
+        if !trailing.is_empty() {
+            return Err(AppError::Database("SQL 导出包含未完成的语句".to_string()));
+        }
+
+        Ok(statements)
+    }
+
+    fn is_complete_sql_statement(sql: &str) -> Result<bool, AppError> {
+        let c_sql = CString::new(sql).map_err(|_| {
+            AppError::Database("SQL 导出包含 NUL 字符，无法解析语句边界".to_string())
+        })?;
+        Ok(unsafe { rusqlite::ffi::sqlite3_complete(c_sql.as_ptr()) == 1 })
     }
 
     /// Periodic backup: create a new backup if the latest one is older than the configured interval
@@ -952,6 +991,67 @@ mod tests {
 
         assert_eq!(provider_count, 1);
         assert_eq!(prompt_count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn selective_sync_import_preserves_multiline_prompt_content() -> Result<(), AppError> {
+        let multiline_content = "line1\nline2\nline3";
+
+        let remote_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(remote_db.conn);
+            conn.execute(
+                "INSERT INTO prompts (id, app_type, name, content, enabled)
+                 VALUES (?1, 'claude', 'Remote Prompt', ?2, 1)",
+                rusqlite::params!["remote-prompt", multiline_content],
+            )?;
+        }
+        let remote_sql = remote_db.export_sql_string_for_tables(&["prompts"])?;
+
+        let local_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(local_db.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('local-provider', 'claude', 'Local Provider', '{}', '{}')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO prompts (id, app_type, name, content, enabled)
+                 VALUES ('local-prompt', 'claude', 'Local Prompt', 'hello', 1)",
+                [],
+            )?;
+        }
+
+        local_db.replace_tables_from_sql_strings(&[remote_sql.as_str()], &["prompts"])?;
+
+        let conn = crate::database::lock_conn!(local_db.conn);
+        let provider_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM providers WHERE id = 'local-provider' AND app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+        let local_prompt_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM prompts WHERE id = 'local-prompt' AND app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+        let remote_content: String = conn.query_row(
+            "SELECT content FROM prompts WHERE id = 'remote-prompt' AND app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(
+            provider_count, 1,
+            "unselected provider data should stay local"
+        );
+        assert_eq!(
+            local_prompt_count, 0,
+            "selected prompts table should be replaced"
+        );
+        assert_eq!(remote_content, multiline_content);
         Ok(())
     }
 

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -26,6 +26,7 @@ const SYNC_SKIP_TABLES: &[&str] = &[
 
 /// Tables whose local data is preserved (restored from local snapshot) during WebDAV import.
 /// Excludes ephemeral tables like provider_health that can safely rebuild at runtime.
+#[cfg_attr(not(test), allow(dead_code))]
 const SYNC_PRESERVE_TABLES: &[&str] = &[
     "proxy_request_logs",
     "stream_check_logs",
@@ -46,13 +47,63 @@ impl Database {
     /// 导出为 SQLite 兼容的 SQL 文本（内存字符串，完整导出）
     pub fn export_sql_string(&self) -> Result<String, AppError> {
         let snapshot = self.snapshot_to_memory()?;
-        Self::dump_sql(&snapshot, &[])
+        Self::dump_sql(&snapshot, None, &[])
     }
 
     /// Export SQL for sync (WebDAV), skipping local-only tables' data
     pub fn export_sql_string_for_sync(&self) -> Result<String, AppError> {
         let snapshot = self.snapshot_to_memory()?;
-        Self::dump_sql(&snapshot, SYNC_SKIP_TABLES)
+        Self::dump_sql(&snapshot, None, SYNC_SKIP_TABLES)
+    }
+
+    /// Export SQL containing full schema but only the selected tables' rows.
+    pub(crate) fn export_sql_string_for_tables(&self, tables: &[&str]) -> Result<String, AppError> {
+        let snapshot = self.snapshot_to_memory()?;
+        Self::export_sql_string_from_connection_for_tables(&snapshot, tables)
+    }
+
+    pub(crate) fn export_sql_string_from_connection_for_tables(
+        conn: &Connection,
+        tables: &[&str],
+    ) -> Result<String, AppError> {
+        Self::dump_sql(conn, Some(tables), &[])
+    }
+
+    /// Replace only the selected tables from one or more SQL exports.
+    ///
+    /// Each SQL document must be a CC Switch export. All documents are imported
+    /// into a temporary database first, then the selected tables are copied
+    /// back into the main database inside a single transaction.
+    pub(crate) fn replace_tables_from_sql_strings(
+        &self,
+        sql_documents: &[&str],
+        tables: &[&str],
+    ) -> Result<(), AppError> {
+        let _safety_backup = self.backup_database_file()?;
+        let temp_file = NamedTempFile::new().map_err(|e| AppError::IoContext {
+            context: "创建临时数据库文件失败".to_string(),
+            source: e,
+        })?;
+        let temp_path = temp_file.path().to_path_buf();
+        let temp_conn =
+            Connection::open(&temp_path).map_err(|e| AppError::Database(e.to_string()))?;
+
+        Self::create_tables_on_conn(&temp_conn)?;
+        Self::apply_schema_migrations_on_conn(&temp_conn)?;
+
+        for sql_raw in sql_documents {
+            let sql_content = sql_raw.trim_start_matches('\u{feff}');
+            Self::validate_cc_switch_sql_export(sql_content)?;
+            Self::import_selected_table_rows_from_sql(&temp_conn, sql_content, tables)?;
+        }
+
+        let mut main_conn = lock_conn!(self.conn);
+        let tx = main_conn
+            .transaction()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Self::restore_tables(&temp_conn, &tx, tables)?;
+        tx.commit().map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(())
     }
 
     /// 导出为 SQLite 兼容的 SQL 文本
@@ -87,6 +138,7 @@ impl Database {
 
     /// Import SQL generated for sync, then restore local-only tables from the
     /// current device snapshot before replacing the main database.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn import_sql_string_for_sync(&self, sql_raw: &str) -> Result<String, AppError> {
         self.import_sql_string_inner(sql_raw, SYNC_PRESERVE_TABLES)
     }
@@ -187,7 +239,15 @@ impl Database {
                 continue;
             }
 
-            let columns = Self::get_table_columns(source_conn, table)?;
+            let source_columns = Self::get_table_columns(source_conn, table)?;
+            let target_columns = Self::get_table_columns(target_conn, table)?;
+            if source_columns.is_empty() || target_columns.is_empty() {
+                continue;
+            }
+            let columns = target_columns
+                .into_iter()
+                .filter(|column| source_columns.iter().any(|src| src == column))
+                .collect::<Vec<_>>();
             if columns.is_empty() {
                 continue;
             }
@@ -208,7 +268,14 @@ impl Database {
             let insert_sql = format!("INSERT INTO \"{table}\" ({cols}) VALUES ({placeholders})");
 
             let mut stmt = source_conn
-                .prepare(&format!("SELECT * FROM \"{table}\""))
+                .prepare(&format!(
+                    "SELECT {} FROM \"{table}\"",
+                    columns
+                        .iter()
+                        .map(|column| format!("\"{column}\""))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ))
                 .map_err(|e| AppError::Database(format!("读取表 {table} 失败: {e}")))?;
             let mut rows = stmt
                 .query([])
@@ -229,6 +296,35 @@ impl Database {
             }
         }
 
+        Ok(())
+    }
+
+    fn import_selected_table_rows_from_sql(
+        conn: &Connection,
+        sql_content: &str,
+        tables: &[&str],
+    ) -> Result<(), AppError> {
+        for table in tables {
+            let filtered = sql_content
+                .lines()
+                .filter(|line| {
+                    let quoted = format!("INSERT INTO \"{table}\"");
+                    let plain = format!("INSERT INTO {table}");
+                    line.starts_with(&quoted) || line.starts_with(&plain)
+                })
+                .collect::<Vec<_>>();
+
+            if filtered.is_empty() {
+                continue;
+            }
+
+            conn.execute(&format!("DELETE FROM \"{table}\""), [])
+                .map_err(|e| AppError::Database(format!("清空表 {table} 失败: {e}")))?;
+
+            let batch = filtered.join("\n");
+            conn.execute_batch(&batch)
+                .map_err(|e| AppError::Database(format!("执行 SQL 导入失败: {e}")))?;
+        }
         Ok(())
     }
 
@@ -384,7 +480,11 @@ impl Database {
     }
 
     /// 导出数据库为 SQL 文本
-    fn dump_sql(conn: &Connection, skip_tables: &[&str]) -> Result<String, AppError> {
+    fn dump_sql(
+        conn: &Connection,
+        included_tables: Option<&[&str]>,
+        skip_tables: &[&str],
+    ) -> Result<String, AppError> {
         let mut output = String::new();
         let timestamp = Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
         let user_version: i64 = conn
@@ -432,6 +532,11 @@ impl Database {
 
         // 导出数据
         for table in tables {
+            if let Some(included_tables) = included_tables {
+                if !included_tables.iter().any(|candidate| *candidate == table) {
+                    continue;
+                }
+            }
             if skip_tables.iter().any(|t| *t == table) {
                 continue;
             }
@@ -689,10 +794,354 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
+    use super::get_app_config_dir;
     use super::Database;
     use crate::error::AppError;
     use crate::settings::{update_settings, AppSettings};
     use serial_test::serial;
+
+    #[test]
+    fn sync_export_for_selected_tables_excludes_unselected_rows() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('provider-1', 'claude', 'Provider 1', '{}', '{}')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO mcp_servers (
+                    id, name, server_config, tags,
+                    enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes
+                ) VALUES ('mcp-fetch', 'Fetch', '{}', '[]', 1, 0, 0, 0, 0)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO prompts (id, app_type, name, content, enabled)
+                 VALUES ('prompt-1', 'claude', 'Prompt 1', 'hello', 1)",
+                [],
+            )?;
+        }
+
+        let sql = db.export_sql_string_for_tables(&["mcp_servers"])?;
+
+        assert!(sql.contains("INSERT INTO \"mcp_servers\""));
+        assert!(sql.contains("mcp-fetch"));
+        assert!(!sql.contains("provider-1"));
+        assert!(!sql.contains("prompt-1"));
+        Ok(())
+    }
+
+    #[test]
+    fn selective_sync_import_replaces_only_target_tables() -> Result<(), AppError> {
+        let remote_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(remote_db.conn);
+            conn.execute(
+                "INSERT INTO mcp_servers (
+                    id, name, server_config, tags,
+                    enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes
+                ) VALUES ('remote-mcp', 'Remote MCP', '{}', '[]', 1, 1, 0, 0, 0)",
+                [],
+            )?;
+        }
+        let remote_sql = remote_db.export_sql_string_for_tables(&["mcp_servers"])?;
+
+        let local_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(local_db.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('local-provider', 'claude', 'Local Provider', '{}', '{}')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO mcp_servers (
+                    id, name, server_config, tags,
+                    enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes
+                ) VALUES ('local-mcp', 'Local MCP', '{}', '[]', 1, 0, 0, 0, 0)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO prompts (id, app_type, name, content, enabled)
+                 VALUES ('local-prompt', 'claude', 'Local Prompt', 'hello', 1)",
+                [],
+            )?;
+        }
+
+        local_db.replace_tables_from_sql_strings(&[remote_sql.as_str()], &["mcp_servers"])?;
+
+        let conn = crate::database::lock_conn!(local_db.conn);
+        let provider_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM providers WHERE id = 'local-provider' AND app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+        let local_prompt_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM prompts WHERE id = 'local-prompt' AND app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+        let local_mcp_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM mcp_servers WHERE id = 'local-mcp'",
+            [],
+            |row| row.get(0),
+        )?;
+        let remote_mcp_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM mcp_servers WHERE id = 'remote-mcp'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(
+            provider_count, 1,
+            "unselected provider data should stay local"
+        );
+        assert_eq!(
+            local_prompt_count, 1,
+            "unselected prompts should stay local"
+        );
+        assert_eq!(local_mcp_count, 0, "selected table should be replaced");
+        assert_eq!(remote_mcp_count, 1, "selected table should use remote rows");
+        Ok(())
+    }
+
+    #[test]
+    fn selective_sync_import_supports_multiple_sql_documents_without_unique_conflicts(
+    ) -> Result<(), AppError> {
+        let api_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(api_db.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('remote-provider', 'claude', 'Remote Provider', '{}', '{}')",
+                [],
+            )?;
+        }
+        let api_sql = api_db.export_sql_string_for_tables(&["providers"])?;
+
+        let prompt_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(prompt_db.conn);
+            conn.execute(
+                "INSERT INTO prompts (id, app_type, name, content, enabled)
+                 VALUES ('remote-prompt', 'claude', 'Remote Prompt', 'hello', 1)",
+                [],
+            )?;
+        }
+        let prompt_sql = prompt_db.export_sql_string_for_tables(&["prompts"])?;
+
+        let local_db = Database::memory()?;
+        local_db.replace_tables_from_sql_strings(
+            &[api_sql.as_str(), prompt_sql.as_str()],
+            &["providers", "prompts"],
+        )?;
+
+        let conn = crate::database::lock_conn!(local_db.conn);
+        let provider_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM providers WHERE id = 'remote-provider' AND app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+        let prompt_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM prompts WHERE id = 'remote-prompt' AND app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(provider_count, 1);
+        assert_eq!(prompt_count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn selective_sync_import_replaces_model_pricing_rows_for_api_module() -> Result<(), AppError> {
+        let remote_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(remote_db.conn);
+            conn.execute("DELETE FROM model_pricing", [])?;
+            conn.execute(
+                "INSERT INTO model_pricing (
+                    model_id, display_name, input_cost_per_million, output_cost_per_million
+                ) VALUES ('gpt-test', 'GPT Test', 1.23, 4.56)",
+                [],
+            )?;
+        }
+        let remote_sql = remote_db.export_sql_string_for_tables(&["model_pricing"])?;
+
+        let local_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(local_db.conn);
+            conn.execute("DELETE FROM model_pricing", [])?;
+            conn.execute(
+                "INSERT INTO model_pricing (
+                    model_id, display_name, input_cost_per_million, output_cost_per_million
+                ) VALUES ('local-model', 'Local Model', 0.11, 0.22)",
+                [],
+            )?;
+        }
+
+        local_db.replace_tables_from_sql_strings(&[remote_sql.as_str()], &["model_pricing"])?;
+
+        let conn = crate::database::lock_conn!(local_db.conn);
+        let local_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM model_pricing WHERE model_id = 'local-model'",
+            [],
+            |row| row.get(0),
+        )?;
+        let remote_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM model_pricing WHERE model_id = 'gpt-test'",
+            [],
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(local_count, 0);
+        assert_eq!(remote_count, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn selective_sync_import_replaces_seeded_proxy_config_rows_without_unique_conflicts(
+    ) -> Result<(), AppError> {
+        let remote_db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(remote_db.conn);
+            conn.execute(
+                "UPDATE proxy_config
+                 SET listen_port = 17777
+                 WHERE app_type = 'claude'",
+                [],
+            )?;
+        }
+        let proxy_sql = remote_db.export_sql_string_for_tables(&["proxy_config"])?;
+
+        let local_db = Database::memory()?;
+        local_db.replace_tables_from_sql_strings(&[proxy_sql.as_str()], &["proxy_config"])?;
+
+        let conn = crate::database::lock_conn!(local_db.conn);
+        let listen_port: i64 = conn.query_row(
+            "SELECT listen_port FROM proxy_config WHERE app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(listen_port, 17777);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn selective_sync_import_creates_observable_safety_backup_for_file_database(
+    ) -> Result<(), AppError> {
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        let test_home = std::env::temp_dir().join("cc-switch-selective-sync-safety-backup-test");
+        let _ = std::fs::remove_dir_all(&test_home);
+        std::fs::create_dir_all(&test_home).expect("create test home");
+        std::env::set_var("CC_SWITCH_TEST_HOME", &test_home);
+        update_settings(AppSettings::default()).expect("reset settings");
+
+        let result = (|| -> Result<(), AppError> {
+            let remote_db = Database::memory()?;
+            {
+                let conn = crate::database::lock_conn!(remote_db.conn);
+                conn.execute(
+                    "INSERT INTO mcp_servers (
+                        id, name, server_config, tags,
+                        enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes
+                    ) VALUES ('remote-mcp-backup', 'Remote MCP Backup', '{}', '[]', 1, 1, 0, 0, 0)",
+                    [],
+                )?;
+            }
+            let remote_sql = remote_db.export_sql_string_for_tables(&["mcp_servers"])?;
+
+            let local_db = Database::init()?;
+            let backup_dir = get_app_config_dir().join("backups");
+            let backup_paths_before = std::fs::read_dir(&backup_dir)
+                .ok()
+                .into_iter()
+                .flat_map(|entries| entries.filter_map(|entry| entry.ok()))
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().map(|ext| ext == "db").unwrap_or(false))
+                .collect::<Vec<_>>();
+            {
+                let conn = crate::database::lock_conn!(local_db.conn);
+                conn.execute(
+                    "INSERT INTO mcp_servers (
+                        id, name, server_config, tags,
+                        enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes
+                    ) VALUES ('local-mcp-backup', 'Local MCP Backup', '{}', '[]', 1, 0, 0, 0, 0)",
+                    [],
+                )?;
+            }
+
+            local_db.replace_tables_from_sql_strings(&[remote_sql.as_str()], &["mcp_servers"])?;
+
+            let conn = crate::database::lock_conn!(local_db.conn);
+            let local_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM mcp_servers WHERE id = 'local-mcp-backup'",
+                [],
+                |row| row.get(0),
+            )?;
+            let remote_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM mcp_servers WHERE id = 'remote-mcp-backup'",
+                [],
+                |row| row.get(0),
+            )?;
+            assert_eq!(local_count, 0, "selected table should be replaced");
+            assert_eq!(remote_count, 1, "remote row should be imported");
+
+            drop(conn);
+
+            let backup_paths_after = std::fs::read_dir(&backup_dir)
+                .expect("backup directory should exist")
+                .filter_map(|entry| entry.ok())
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().map(|ext| ext == "db").unwrap_or(false))
+                .collect::<Vec<_>>();
+            let new_backup_paths = backup_paths_after
+                .iter()
+                .filter(|path| !backup_paths_before.iter().any(|before| before == *path))
+                .cloned()
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                new_backup_paths.len(),
+                1,
+                "selective sync import should create exactly one new safety backup"
+            );
+
+            let backup_conn =
+                rusqlite::Connection::open(&new_backup_paths[0]).expect("open backup database");
+            let backed_up_local_count: i64 = backup_conn.query_row(
+                "SELECT COUNT(*) FROM mcp_servers WHERE id = 'local-mcp-backup'",
+                [],
+                |row| row.get(0),
+            )?;
+            let backed_up_remote_count: i64 = backup_conn.query_row(
+                "SELECT COUNT(*) FROM mcp_servers WHERE id = 'remote-mcp-backup'",
+                [],
+                |row| row.get(0),
+            )?;
+
+            assert_eq!(
+                backed_up_local_count, 1,
+                "safety backup should preserve pre-import local rows"
+            );
+            assert_eq!(
+                backed_up_remote_count, 0,
+                "safety backup should not already contain imported remote rows"
+            );
+
+            Ok(())
+        })();
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+
+        result
+    }
 
     #[test]
     fn sync_import_preserves_local_only_tables() -> Result<(), AppError> {

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -75,6 +75,7 @@ pub(crate) use lock_conn;
 /// rusqlite::Connection 本身不是 Sync 的，因此需要这层包装。
 pub struct Database {
     pub(crate) conn: Mutex<Connection>,
+    pub(crate) is_in_memory: bool,
 }
 
 fn register_db_change_hook(conn: &Connection) {
@@ -117,6 +118,7 @@ impl Database {
 
         let db = Self {
             conn: Mutex::new(conn),
+            is_in_memory: false,
         };
         db.create_tables()?;
 
@@ -172,6 +174,7 @@ impl Database {
 
         let db = Self {
             conn: Mutex::new(conn),
+            is_in_memory: true,
         };
         db.create_tables()?;
         db.ensure_model_pricing_seeded()?;

--- a/src-tauri/src/services/webdav.rs
+++ b/src-tauri/src/services/webdav.rs
@@ -175,15 +175,15 @@ pub async fn ensure_remote_directories(
     for depth in 1..=segments.len() {
         let prefix = &segments[..depth];
         let url = build_remote_url(base_url, prefix)?;
-        let dir_url = if url.ends_with('/') {
-            url
+        let propfind_url = if url.ends_with('/') {
+            url.clone()
         } else {
             format!("{url}/")
         };
 
         let resp = apply_auth(
             client
-                .request(method_mkcol(), &dir_url)
+                .request(method_mkcol(), &url)
                 .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS)),
             auth,
         )
@@ -194,7 +194,7 @@ pub async fn ensure_remote_directories(
                 "webdav.mkcol_failed",
                 "MKCOL 请求",
                 "MKCOL request",
-                &dir_url,
+                &url,
                 &e,
             )
         })?;
@@ -202,19 +202,19 @@ pub async fn ensure_remote_directories(
         let status = resp.status();
         match status {
             s if s == StatusCode::CREATED || s.is_success() => {
-                log::info!("[WebDAV] MKCOL ok: {}", redact_url(&dir_url));
+                log::info!("[WebDAV] MKCOL ok: {}", redact_url(&url));
             }
             // Ambiguous — verify directory actually exists via PROPFIND
             s if s == StatusCode::METHOD_NOT_ALLOWED
                 || s == StatusCode::CONFLICT
                 || s.is_redirection() =>
             {
-                if !propfind_exists(&client, &dir_url, auth).await? {
-                    return Err(webdav_status_error("MKCOL", status, &dir_url));
+                if !propfind_exists(&client, &propfind_url, auth).await? {
+                    return Err(webdav_status_error("MKCOL", status, &url));
                 }
             }
             _ => {
-                return Err(webdav_status_error("MKCOL", status, &dir_url));
+                return Err(webdav_status_error("MKCOL", status, &url));
             }
         }
     }

--- a/src-tauri/src/services/webdav_auto_sync.rs
+++ b/src-tauri/src/services/webdav_auto_sync.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -10,7 +11,7 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use crate::error::AppError;
 use crate::services::webdav_sync as webdav_sync_service;
-use crate::settings::{self, WebDavSyncSettings};
+use crate::settings::{self, WebDavSyncModules, WebDavSyncSettings};
 
 const AUTO_SYNC_DEBOUNCE_MS: u64 = 1000;
 pub(crate) const MAX_AUTO_SYNC_WAIT_MS: u64 = 10_000;
@@ -46,8 +47,10 @@ pub fn should_trigger_for_table(table: &str) -> bool {
         normalized.as_str(),
         "providers"
             | "provider_endpoints"
+            | "model_pricing"
             | "mcp_servers"
             | "prompts"
+            | "session_log_sync"
             | "skills"
             | "skill_repos"
             | "settings"
@@ -79,6 +82,26 @@ fn should_run_auto_sync(settings: Option<&WebDavSyncSettings>) -> bool {
     sync.enabled && sync.auto_sync
 }
 
+fn table_matches_upload_module(selection: &WebDavSyncModules, table: &str) -> bool {
+    match table {
+        "providers" | "provider_endpoints" | "model_pricing" | "session_log_sync" | "settings"
+        | "proxy_config" => selection.api,
+        "mcp_servers" => selection.mcp,
+        "prompts" => selection.prompts,
+        "skills" | "skill_repos" => selection.skills,
+        _ => false,
+    }
+}
+
+pub(crate) fn should_upload_for_changed_tables(
+    selection: &WebDavSyncModules,
+    changed_tables: &BTreeSet<String>,
+) -> bool {
+    changed_tables
+        .iter()
+        .any(|table| table_matches_upload_module(selection, table))
+}
+
 fn persist_auto_sync_error(settings: &mut WebDavSyncSettings, error: &AppError) {
     settings.status.last_error = Some(error.to_string());
     settings.status.last_error_source = Some("auto".to_string());
@@ -106,6 +129,7 @@ fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&s
 async fn run_auto_sync_upload(
     db: &crate::database::Database,
     app: &AppHandle,
+    changed_tables: &BTreeSet<String>,
 ) -> Result<(), AppError> {
     let mut settings = settings::get_webdav_sync_settings();
     if !should_run_auto_sync(settings.as_ref()) {
@@ -116,6 +140,14 @@ async fn run_auto_sync_upload(
         Some(value) => value,
         None => return Ok(()),
     };
+
+    if !should_upload_for_changed_tables(&sync_settings.upload_modules, changed_tables) {
+        log::debug!(
+            "[WebDAV][AutoSync] Skipping upload; changed tables do not match selected modules: {:?}",
+            changed_tables
+        );
+        return Ok(());
+    }
 
     let result = webdav_sync_service::run_with_sync_lock(webdav_sync_service::upload(
         db,
@@ -172,22 +204,27 @@ async fn run_worker_loop(
     while let Some(first_table) = rx.recv().await {
         let started_at = Instant::now();
         let mut merged_count = 1usize;
+        let mut changed_tables = BTreeSet::from([first_table.clone()]);
 
         while let Some(wait_for) = auto_sync_wait_duration(started_at, Instant::now()) {
             let timeout = tokio::time::timeout(wait_for, rx.recv()).await;
 
             match timeout {
-                Ok(Some(_)) => merged_count += 1,
+                Ok(Some(table)) => {
+                    merged_count += 1;
+                    changed_tables.insert(table);
+                }
                 Ok(None) => return,
                 Err(_) => break,
             }
         }
 
         log::debug!(
-            "[WebDAV][AutoSync] Triggered by table={first_table}, merged_changes={merged_count}"
+            "[WebDAV][AutoSync] Triggered by table={first_table}, merged_changes={merged_count}, changed_tables={:?}",
+            changed_tables
         );
 
-        if let Err(err) = run_auto_sync_upload(&db, &app).await {
+        if let Err(err) = run_auto_sync_upload(&db, &app, &changed_tables).await {
             log::warn!("[WebDAV][AutoSync] Upload failed: {err}");
         }
     }
@@ -197,10 +234,11 @@ async fn run_worker_loop(
 mod tests {
     use super::{
         auto_sync_wait_duration, enqueue_change_signal, is_auto_sync_suppressed,
-        should_run_auto_sync, should_trigger_for_table, AutoSyncSuppressionGuard,
-        MAX_AUTO_SYNC_WAIT_MS,
+        should_run_auto_sync, should_trigger_for_table, should_upload_for_changed_tables,
+        AutoSyncSuppressionGuard, MAX_AUTO_SYNC_WAIT_MS,
     };
-    use crate::settings::WebDavSyncSettings;
+    use crate::settings::{WebDavSyncModules, WebDavSyncSettings};
+    use std::collections::BTreeSet;
     use std::time::{Duration, Instant};
     use tokio::sync::mpsc::channel;
 
@@ -208,6 +246,7 @@ mod tests {
     fn should_trigger_sync_for_config_tables_only() {
         assert!(should_trigger_for_table("providers"));
         assert!(should_trigger_for_table("settings"));
+        assert!(should_trigger_for_table("model_pricing"));
         assert!(!should_trigger_for_table("proxy_request_logs"));
         assert!(!should_trigger_for_table("provider_health"));
     }
@@ -270,5 +309,71 @@ mod tests {
             !source.contains(&needle),
             "services layer should not depend on commands layer"
         );
+    }
+
+    #[test]
+    fn upload_module_selection_controls_auto_sync_trigger() {
+        let changed_tables = BTreeSet::from(["providers".to_string()]);
+
+        let skills_only = WebDavSyncModules {
+            api: false,
+            mcp: false,
+            prompts: false,
+            skills: true,
+        };
+        assert!(
+            !should_upload_for_changed_tables(&skills_only, &changed_tables),
+            "provider changes should not trigger skills-only uploads"
+        );
+
+        let api_enabled = WebDavSyncModules {
+            api: true,
+            ..skills_only
+        };
+        assert!(
+            should_upload_for_changed_tables(&api_enabled, &changed_tables),
+            "provider changes should trigger api uploads"
+        );
+    }
+
+    #[test]
+    fn model_pricing_changes_trigger_upload_only_when_api_module_is_enabled() {
+        let changed_tables = BTreeSet::from(["model_pricing".to_string()]);
+
+        let mcp_only = WebDavSyncModules {
+            api: false,
+            mcp: true,
+            prompts: false,
+            skills: false,
+        };
+        assert!(
+            !should_upload_for_changed_tables(&mcp_only, &changed_tables),
+            "model_pricing changes should not trigger non-api uploads"
+        );
+
+        let api_enabled = WebDavSyncModules {
+            api: true,
+            ..mcp_only
+        };
+        assert!(
+            should_upload_for_changed_tables(&api_enabled, &changed_tables),
+            "model_pricing changes should trigger api uploads"
+        );
+    }
+
+    #[test]
+    fn skills_tables_trigger_upload_when_skills_module_is_enabled() {
+        let changed_tables = BTreeSet::from(["skills".to_string(), "skill_repos".to_string()]);
+        let selection = WebDavSyncModules {
+            api: false,
+            mcp: false,
+            prompts: false,
+            skills: true,
+        };
+
+        assert!(should_upload_for_changed_tables(
+            &selection,
+            &changed_tables
+        ));
     }
 }

--- a/src-tauri/src/services/webdav_sync.rs
+++ b/src-tauri/src/services/webdav_sync.rs
@@ -1,33 +1,66 @@
-//! WebDAV v2 sync protocol layer with DB compatibility subdirectories.
+//! WebDAV sync protocol layer with DB compatibility subdirectories.
 //!
 //! Implements manifest-based synchronization on top of the HTTP transport
-//! primitives in [`super::webdav`]. Artifact set: `db.sql` + `skills.zip`.
+//! primitives in [`super::webdav`]. The current v3 protocol stores module-
+//! scoped SQL artifacts plus `skills.zip`, while v2 compatibility is preserved
+//! for reading legacy snapshots.
 
 use std::collections::BTreeMap;
+use std::fs;
 use std::future::Future;
 use std::sync::OnceLock;
 
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tempfile::tempdir;
 
 use crate::error::AppError;
 use crate::services::webdav::{
     auth_from_credentials, build_remote_url, ensure_remote_directories, get_bytes, head_etag,
     path_segments, put_bytes, test_connection, WebDavAuth,
 };
-use crate::settings::{update_webdav_sync_status, WebDavSyncSettings, WebDavSyncStatus};
+use crate::settings::{
+    update_webdav_sync_status, WebDavSyncModules, WebDavSyncSettings, WebDavSyncStatus,
+};
 
 use super::sync_protocol::{
-    apply_snapshot, build_local_snapshot, effective_db_compat_version, localized,
-    persist_sync_success_best_effort, sha256_hex, validate_artifact_size_limit,
-    validate_manifest_compat, verify_artifact, ArtifactMeta, RemoteLayout, SyncManifest,
-    DB_COMPAT_VERSION, MAX_MANIFEST_BYTES, MAX_SYNC_ARTIFACT_BYTES, PROTOCOL_VERSION,
-    REMOTE_DB_SQL, REMOTE_MANIFEST, REMOTE_SKILLS_ZIP,
+    io_context_localized, localized, sha256_hex,
+    detect_system_device_name,
+    verify_artifact, validate_artifact_size_limit,
+    ArtifactMeta, RemoteLayout,
+    MAX_MANIFEST_BYTES, MAX_SYNC_ARTIFACT_BYTES,
+    REMOTE_DB_SQL, REMOTE_SKILLS_ZIP, REMOTE_MANIFEST,
 };
+#[cfg(test)]
+use super::sync_protocol::normalize_device_name;
 
 pub(crate) mod archive;
 
-// ─── Sync lock ───────────────────────────────────────────────
+use archive::{backup_current_skills, restore_skills_from_backup, restore_skills_zip, zip_skills_ssot};
+
+const PROTOCOL_FORMAT: &str = "cc-switch-webdav-sync";
+const PROTOCOL_VERSION: u32 = 3;
+const LEGACY_PROTOCOL_VERSION: u32 = 2;
+/// Must stay in sync with sync_protocol::DB_COMPAT_VERSION when DB schema changes.
+const DB_COMPAT_VERSION: u32 = 6;
+const LEGACY_DB_COMPAT_VERSION: u32 = 5;
+const REMOTE_API_SQL: &str = "api.sql";
+const REMOTE_MCP_SQL: &str = "mcp.sql";
+const REMOTE_PROMPTS_SQL: &str = "prompts.sql";
+const REMOTE_SKILLS_SQL: &str = "skills.sql";
+
+const API_TABLES: &[&str] = &[
+    "providers",
+    "provider_endpoints",
+    "model_pricing",
+    "settings",
+    "proxy_config",
+    "session_log_sync",
+];
+const MCP_TABLES: &[&str] = &["mcp_servers"];
+const PROMPT_TABLES: &[&str] = &["prompts"];
+const SKILL_TABLES: &[&str] = &["skills", "skill_repos"];
 
 pub fn sync_mutex() -> &'static tokio::sync::Mutex<()> {
     static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
@@ -42,8 +75,151 @@ where
     operation.await
 }
 
-struct RemoteSnapshot {
+
+// ─── Types ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncManifest {
+    format: String,
+    version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    db_compat_version: Option<u32>,
+    device_name: String,
+    created_at: String,
+    artifacts: BTreeMap<String, ArtifactMeta>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    modules: Option<ManifestModules>,
+    snapshot_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManifestModules {
+    api: Vec<String>,
+    mcp: Vec<String>,
+    prompts: Vec<String>,
+    skills: Vec<String>,
+}
+
+struct LocalSnapshot {
+    artifacts: BTreeMap<String, Vec<u8>>,
+    manifest_bytes: Vec<u8>,
+    manifest_hash: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RemoteLocation {
+    protocol_version: u32,
     layout: RemoteLayout,
+}
+
+impl RemoteLocation {
+    fn v3_current() -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            layout: RemoteLayout::Current,
+        }
+    }
+
+    fn v2_current() -> Self {
+        Self {
+            protocol_version: LEGACY_PROTOCOL_VERSION,
+            layout: RemoteLayout::Current,
+        }
+    }
+
+    fn v2_legacy() -> Self {
+        Self {
+            protocol_version: LEGACY_PROTOCOL_VERSION,
+            layout: RemoteLayout::Legacy,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ModulePayloads {
+    api_sql: Option<Vec<u8>>,
+    mcp_sql: Option<Vec<u8>>,
+    prompts_sql: Option<Vec<u8>>,
+    skills_sql: Option<Vec<u8>>,
+    skills_zip: Option<Vec<u8>>,
+}
+
+impl ModulePayloads {
+    fn available_modules(&self) -> WebDavSyncModules {
+        WebDavSyncModules {
+            api: self.api_sql.is_some(),
+            mcp: self.mcp_sql.is_some(),
+            prompts: self.prompts_sql.is_some(),
+            skills: self.skills_sql.is_some() && self.skills_zip.is_some(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.api_sql.is_none()
+            && self.mcp_sql.is_none()
+            && self.prompts_sql.is_none()
+            && self.skills_sql.is_none()
+            && self.skills_zip.is_none()
+    }
+
+    fn to_manifest_modules(&self) -> ManifestModules {
+        ManifestModules {
+            api: module_artifact_names(self.api_sql.as_ref(), None),
+            mcp: module_artifact_names(self.mcp_sql.as_ref(), Some(REMOTE_MCP_SQL)),
+            prompts: module_artifact_names(self.prompts_sql.as_ref(), Some(REMOTE_PROMPTS_SQL)),
+            skills: {
+                let mut names = Vec::new();
+                if self.skills_sql.is_some() {
+                    names.push(REMOTE_SKILLS_SQL.to_string());
+                }
+                if self.skills_zip.is_some() {
+                    names.push(REMOTE_SKILLS_ZIP.to_string());
+                }
+                names
+            },
+        }
+    }
+
+    fn artifacts_map(&self) -> BTreeMap<String, Vec<u8>> {
+        let mut artifacts = BTreeMap::new();
+        if let Some(bytes) = self.api_sql.clone() {
+            artifacts.insert(REMOTE_API_SQL.to_string(), bytes);
+        }
+        if let Some(bytes) = self.mcp_sql.clone() {
+            artifacts.insert(REMOTE_MCP_SQL.to_string(), bytes);
+        }
+        if let Some(bytes) = self.prompts_sql.clone() {
+            artifacts.insert(REMOTE_PROMPTS_SQL.to_string(), bytes);
+        }
+        if let Some(bytes) = self.skills_sql.clone() {
+            artifacts.insert(REMOTE_SKILLS_SQL.to_string(), bytes);
+        }
+        if let Some(bytes) = self.skills_zip.clone() {
+            artifacts.insert(REMOTE_SKILLS_ZIP.to_string(), bytes);
+        }
+        artifacts
+    }
+}
+
+fn module_artifact_names(sql: Option<&Vec<u8>>, sql_name: Option<&str>) -> Vec<String> {
+    let Some(name) = sql_name else {
+        return if sql.is_some() {
+            vec![REMOTE_API_SQL.to_string()]
+        } else {
+            Vec::new()
+        };
+    };
+    if sql.is_some() {
+        vec![name.to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
+struct RemoteSnapshot {
+    location: RemoteLocation,
     manifest: SyncManifest,
     manifest_bytes: Vec<u8>,
     manifest_etag: Option<String>,
@@ -55,31 +231,56 @@ pub async fn check_connection(settings: &WebDavSyncSettings) -> Result<(), AppEr
     settings.validate()?;
     let auth = auth_for(settings);
     test_connection(&settings.base_url, &auth).await?;
-    let dir_segs = remote_dir_segments(settings, RemoteLayout::Current);
+    let dir_segs = remote_dir_segments(settings, RemoteLocation::v3_current());
     ensure_remote_directories(&settings.base_url, &dir_segs, &auth).await?;
     Ok(())
 }
 
-/// Upload local snapshot (db + skills) to remote.
+/// Upload local module snapshot to remote.
 pub async fn upload(
     db: &crate::database::Database,
     settings: &mut WebDavSyncSettings,
 ) -> Result<Value, AppError> {
     settings.validate()?;
     let auth = auth_for(settings);
-    let dir_segs = remote_dir_segments(settings, RemoteLayout::Current);
+    let location = RemoteLocation::v3_current();
+    let dir_segs = remote_dir_segments(settings, location);
     ensure_remote_directories(&settings.base_url, &dir_segs, &auth).await?;
 
-    let snapshot = build_local_snapshot(db)?;
+    let local_payloads = build_local_module_payloads(db)?;
+    let remote_payloads = match find_remote_snapshot(settings, &auth).await? {
+        Some(snapshot) => Some(load_remote_module_payloads(settings, &auth, &snapshot).await?),
+        None => None,
+    };
+    let final_payloads = merge_module_payloads(
+        &local_payloads,
+        remote_payloads.as_ref(),
+        &settings.upload_modules,
+    );
+    if final_payloads.is_empty() {
+        return Err(localized(
+            "webdav.sync.no_artifacts_selected",
+            "没有可上传的同步模块数据",
+            "No selected sync module has data to upload.",
+        ));
+    }
+
+    let snapshot = build_local_snapshot_from_payloads(&final_payloads)?;
 
     // Upload order: artifacts first, manifest last (best-effort consistency)
-    let db_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_DB_SQL)?;
-    put_bytes(&db_url, &auth, snapshot.db_sql, "application/sql").await?;
+    for (artifact_name, bytes) in snapshot.artifacts {
+        let artifact_url = remote_file_url(settings, location, &artifact_name)?;
+        let content_type = if artifact_name.ends_with(".zip") {
+            "application/zip"
+        } else if artifact_name.ends_with(".json") {
+            "application/json"
+        } else {
+            "application/sql"
+        };
+        put_bytes(&artifact_url, &auth, bytes, content_type).await?;
+    }
 
-    let skills_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_SKILLS_ZIP)?;
-    put_bytes(&skills_url, &auth, snapshot.skills_zip, "application/zip").await?;
-
-    let manifest_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_MANIFEST)?;
+    let manifest_url = remote_file_url(settings, location, REMOTE_MANIFEST)?;
     put_bytes(
         &manifest_url,
         &auth,
@@ -106,7 +307,7 @@ pub async fn upload(
     Ok(serde_json::json!({ "status": "uploaded" }))
 }
 
-/// Download remote snapshot and apply to local database + skills.
+/// Download remote snapshot and apply only the selected modules.
 pub async fn download(
     db: &crate::database::Database,
     settings: &mut WebDavSyncSettings,
@@ -123,28 +324,11 @@ pub async fn download(
             )
         })?;
 
-    validate_manifest_compat(&snapshot.manifest, snapshot.layout)?;
+    validate_manifest_compat(&snapshot.manifest, snapshot.location)?;
 
-    // Download and verify artifacts
-    let db_sql = download_and_verify(
-        settings,
-        &auth,
-        snapshot.layout,
-        REMOTE_DB_SQL,
-        &snapshot.manifest.artifacts,
-    )
-    .await?;
-    let skills_zip = download_and_verify(
-        settings,
-        &auth,
-        snapshot.layout,
-        REMOTE_SKILLS_ZIP,
-        &snapshot.manifest.artifacts,
-    )
-    .await?;
-
-    // Apply snapshot
-    apply_snapshot(db, &db_sql, &skills_zip)?;
+    let payloads = load_remote_module_payloads(settings, &auth, &snapshot).await?;
+    ensure_requested_modules_available(&payloads, &settings.download_modules)?;
+    apply_selected_modules(db, &payloads, &settings.download_modules)?;
 
     let manifest_hash = sha256_hex(&snapshot.manifest_bytes);
     let _persisted = persist_sync_success_best_effort(
@@ -155,8 +339,8 @@ pub async fn download(
     );
     Ok(serde_json::json!({
         "status": "downloaded",
-        "sourceLayout": snapshot.layout.as_str(),
-        "sourcePath": remote_dir_display(settings, snapshot.layout),
+        "sourceLayout": snapshot.location.layout.as_str(),
+        "sourcePath": remote_dir_display(settings, snapshot.location),
     }))
 }
 
@@ -167,8 +351,9 @@ pub async fn fetch_remote_info(settings: &WebDavSyncSettings) -> Result<Option<V
     let Some(snapshot) = find_remote_snapshot(settings, &auth).await? else {
         return Ok(None);
     };
-    let compatible = validate_manifest_compat(&snapshot.manifest, snapshot.layout).is_ok();
-    let db_compat_version = effective_db_compat_version(&snapshot.manifest, snapshot.layout);
+    let compatible = validate_manifest_compat(&snapshot.manifest, snapshot.location).is_ok();
+    let db_compat_version = effective_db_compat_version(&snapshot.manifest, snapshot.location);
+    let available_modules = available_modules_from_manifest(&snapshot.manifest, snapshot.location);
 
     let payload = serde_json::json!({
         "deviceName": snapshot.manifest.device_name,
@@ -179,8 +364,14 @@ pub async fn fetch_remote_info(settings: &WebDavSyncSettings) -> Result<Option<V
         "dbCompatVersion": db_compat_version,
         "compatible": compatible,
         "artifacts": snapshot.manifest.artifacts.keys().collect::<Vec<_>>(),
-        "layout": snapshot.layout.as_str(),
-        "remotePath": remote_dir_display(settings, snapshot.layout),
+        "layout": snapshot.location.layout.as_str(),
+        "remotePath": remote_dir_display(settings, snapshot.location),
+        "availableModules": {
+            "api": available_modules.api,
+            "mcp": available_modules.mcp,
+            "prompts": available_modules.prompts,
+            "skills": available_modules.skills,
+        }
     });
 
     Ok(Some(payload))
@@ -205,22 +396,266 @@ fn persist_sync_success(
     update_webdav_sync_status(status)
 }
 
+fn persist_sync_success_best_effort<F>(
+    settings: &mut WebDavSyncSettings,
+    manifest_hash: String,
+    etag: Option<String>,
+    persist_fn: F,
+) -> bool
+where
+    F: FnOnce(&mut WebDavSyncSettings, String, Option<String>) -> Result<(), AppError>,
+{
+    match persist_fn(settings, manifest_hash, etag) {
+        Ok(()) => true,
+        Err(err) => {
+            log::warn!("[WebDAV] Persist sync status failed, keep operation success: {err}");
+            false
+        }
+    }
+}
+
+// ─── Snapshot building ───────────────────────────────────────
+
+fn build_skills_zip() -> Result<Vec<u8>, AppError> {
+    let tmp = tempdir().map_err(|e| {
+        io_context_localized(
+            "webdav.sync.snapshot_tmpdir_failed",
+            "创建 WebDAV 快照临时目录失败",
+            "Failed to create temporary directory for WebDAV snapshot",
+            e,
+        )
+    })?;
+    let skills_zip_path = tmp.path().join(REMOTE_SKILLS_ZIP);
+    zip_skills_ssot(&skills_zip_path)?;
+    fs::read(&skills_zip_path).map_err(|e| AppError::io(&skills_zip_path, e))
+}
+
+fn build_local_module_payloads(db: &crate::database::Database) -> Result<ModulePayloads, AppError> {
+    Ok(ModulePayloads {
+        api_sql: Some(db.export_sql_string_for_tables(API_TABLES)?.into_bytes()),
+        mcp_sql: Some(db.export_sql_string_for_tables(MCP_TABLES)?.into_bytes()),
+        prompts_sql: Some(db.export_sql_string_for_tables(PROMPT_TABLES)?.into_bytes()),
+        skills_sql: Some(db.export_sql_string_for_tables(SKILL_TABLES)?.into_bytes()),
+        skills_zip: Some(build_skills_zip()?),
+    })
+}
+
+fn merge_module_payloads(
+    local_payloads: &ModulePayloads,
+    remote_payloads: Option<&ModulePayloads>,
+    selection: &WebDavSyncModules,
+) -> ModulePayloads {
+    ModulePayloads {
+        api_sql: if selection.api {
+            local_payloads.api_sql.clone()
+        } else {
+            remote_payloads.and_then(|payloads| payloads.api_sql.clone())
+        },
+        mcp_sql: if selection.mcp {
+            local_payloads.mcp_sql.clone()
+        } else {
+            remote_payloads.and_then(|payloads| payloads.mcp_sql.clone())
+        },
+        prompts_sql: if selection.prompts {
+            local_payloads.prompts_sql.clone()
+        } else {
+            remote_payloads.and_then(|payloads| payloads.prompts_sql.clone())
+        },
+        skills_sql: if selection.skills {
+            local_payloads.skills_sql.clone()
+        } else {
+            remote_payloads.and_then(|payloads| payloads.skills_sql.clone())
+        },
+        skills_zip: if selection.skills {
+            local_payloads.skills_zip.clone()
+        } else {
+            remote_payloads.and_then(|payloads| payloads.skills_zip.clone())
+        },
+    }
+}
+
+fn build_local_snapshot_from_payloads(
+    payloads: &ModulePayloads,
+) -> Result<LocalSnapshot, AppError> {
+    let artifacts_bytes = payloads.artifacts_map();
+    let mut artifacts = BTreeMap::new();
+    for (name, bytes) in &artifacts_bytes {
+        artifacts.insert(
+            name.clone(),
+            ArtifactMeta {
+                sha256: sha256_hex(bytes),
+                size: bytes.len() as u64,
+            },
+        );
+    }
+
+    let snapshot_id = compute_snapshot_id(&artifacts);
+    let manifest = SyncManifest {
+        format: PROTOCOL_FORMAT.to_string(),
+        version: PROTOCOL_VERSION,
+        db_compat_version: Some(DB_COMPAT_VERSION),
+        device_name: detect_system_device_name().unwrap_or_else(|| "Unknown Device".to_string()),
+        created_at: Utc::now().to_rfc3339(),
+        artifacts,
+        modules: Some(payloads.to_manifest_modules()),
+        snapshot_id,
+    };
+    let manifest_bytes =
+        serde_json::to_vec_pretty(&manifest).map_err(|e| AppError::JsonSerialize { source: e })?;
+    let manifest_hash = sha256_hex(&manifest_bytes);
+
+    Ok(LocalSnapshot {
+        artifacts: artifacts_bytes,
+        manifest_bytes,
+        manifest_hash,
+    })
+}
+
+/// Compute a deterministic snapshot identity from artifact hashes.
+///
+/// BTreeMap iteration order is sorted by key, ensuring stability.
+fn compute_snapshot_id(artifacts: &BTreeMap<String, ArtifactMeta>) -> String {
+    let parts: Vec<String> = artifacts
+        .iter()
+        .map(|(name, meta)| format!("{}:{}", name, meta.sha256))
+        .collect();
+    sha256_hex(parts.join("|").as_bytes())
+}
+
+fn effective_db_compat_version(manifest: &SyncManifest, location: RemoteLocation) -> Option<u32> {
+    manifest.db_compat_version.or_else(|| {
+        (location.protocol_version == LEGACY_PROTOCOL_VERSION
+            && location.layout == RemoteLayout::Legacy)
+            .then_some(LEGACY_DB_COMPAT_VERSION)
+    })
+}
+
+fn validate_manifest_compat(
+    manifest: &SyncManifest,
+    location: RemoteLocation,
+) -> Result<(), AppError> {
+    if manifest.format != PROTOCOL_FORMAT {
+        return Err(localized(
+            "webdav.sync.manifest_format_incompatible",
+            format!("远端 manifest 格式不兼容: {}", manifest.format),
+            format!(
+                "Remote manifest format is incompatible: {}",
+                manifest.format
+            ),
+        ));
+    }
+    if manifest.version != location.protocol_version {
+        return Err(localized(
+            "webdav.sync.manifest_version_incompatible",
+            format!(
+                "远端 manifest 协议版本不兼容: v{} (当前路径期望 v{})",
+                manifest.version, location.protocol_version
+            ),
+            format!(
+                "Remote manifest protocol version is incompatible: v{} (expected v{} for this path)",
+                manifest.version, location.protocol_version
+            ),
+        ));
+    }
+    if location.protocol_version == PROTOCOL_VERSION && manifest.modules.is_none() {
+        return Err(localized(
+            "webdav.sync.manifest_modules_missing",
+            "远端 v3 manifest 缺少 modules 字段",
+            "Remote v3 manifest is missing the modules field.",
+        ));
+    }
+    let Some(db_compat_version) = effective_db_compat_version(manifest, location) else {
+        return Err(localized(
+            "webdav.sync.manifest_db_version_missing",
+            "远端 manifest 缺少数据库兼容版本",
+            "Remote manifest is missing the database compatibility version.",
+        ));
+    };
+    match location.layout {
+        RemoteLayout::Current if db_compat_version != DB_COMPAT_VERSION => {
+            return Err(localized(
+                "webdav.sync.manifest_db_version_incompatible",
+                format!(
+                    "远端数据库快照版本不兼容: db-v{db_compat_version} (本地 db-v{DB_COMPAT_VERSION})"
+                ),
+                format!(
+                    "Remote database snapshot version is incompatible: db-v{db_compat_version} (local db-v{DB_COMPAT_VERSION})"
+                ),
+            ));
+        }
+        RemoteLayout::Legacy if db_compat_version > DB_COMPAT_VERSION => {
+            return Err(localized(
+                "webdav.sync.manifest_db_version_incompatible",
+                format!(
+                    "远端数据库快照版本不兼容: db-v{db_compat_version} (本地最高支持 db-v{DB_COMPAT_VERSION})"
+                ),
+                format!(
+                    "Remote database snapshot version is incompatible: db-v{db_compat_version} (local supports up to db-v{DB_COMPAT_VERSION})"
+                ),
+            ));
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn available_modules_from_manifest(
+    manifest: &SyncManifest,
+    location: RemoteLocation,
+) -> WebDavSyncModules {
+    if location.protocol_version == LEGACY_PROTOCOL_VERSION {
+        return WebDavSyncModules {
+            api: true,
+            mcp: true,
+            prompts: true,
+            skills: true,
+        };
+    }
+
+    if let Some(modules) = &manifest.modules {
+        return WebDavSyncModules {
+            api: modules.api.iter().any(|name| name == REMOTE_API_SQL),
+            mcp: modules.mcp.iter().any(|name| name == REMOTE_MCP_SQL),
+            prompts: modules
+                .prompts
+                .iter()
+                .any(|name| name == REMOTE_PROMPTS_SQL),
+            skills: modules.skills.iter().any(|name| name == REMOTE_SKILLS_SQL)
+                && modules.skills.iter().any(|name| name == REMOTE_SKILLS_ZIP),
+        };
+    }
+
+    WebDavSyncModules {
+        api: manifest.artifacts.contains_key(REMOTE_API_SQL),
+        mcp: manifest.artifacts.contains_key(REMOTE_MCP_SQL),
+        prompts: manifest.artifacts.contains_key(REMOTE_PROMPTS_SQL),
+        skills: manifest.artifacts.contains_key(REMOTE_SKILLS_SQL)
+            && manifest.artifacts.contains_key(REMOTE_SKILLS_ZIP),
+    }
+}
+
 async fn find_remote_snapshot(
     settings: &WebDavSyncSettings,
     auth: &WebDavAuth,
 ) -> Result<Option<RemoteSnapshot>, AppError> {
-    if let Some(snapshot) = fetch_remote_snapshot(settings, auth, RemoteLayout::Current).await? {
-        return Ok(Some(snapshot));
+    for location in [
+        RemoteLocation::v3_current(),
+        RemoteLocation::v2_current(),
+        RemoteLocation::v2_legacy(),
+    ] {
+        if let Some(snapshot) = fetch_remote_snapshot(settings, auth, location).await? {
+            return Ok(Some(snapshot));
+        }
     }
-    fetch_remote_snapshot(settings, auth, RemoteLayout::Legacy).await
+    Ok(None)
 }
 
 async fn fetch_remote_snapshot(
     settings: &WebDavSyncSettings,
     auth: &WebDavAuth,
-    layout: RemoteLayout,
+    location: RemoteLocation,
 ) -> Result<Option<RemoteSnapshot>, AppError> {
-    let manifest_url = remote_file_url(settings, layout, REMOTE_MANIFEST)?;
+    let manifest_url = remote_file_url(settings, location, REMOTE_MANIFEST)?;
     let Some((manifest_bytes, manifest_etag)) =
         get_bytes(&manifest_url, auth, MAX_MANIFEST_BYTES).await?
     else {
@@ -234,7 +669,7 @@ async fn fetch_remote_snapshot(
         })?;
 
     Ok(Some(RemoteSnapshot {
-        layout,
+        location,
         manifest,
         manifest_bytes,
         manifest_etag,
@@ -245,7 +680,7 @@ async fn fetch_remote_snapshot(
 async fn download_and_verify(
     settings: &WebDavSyncSettings,
     auth: &WebDavAuth,
-    layout: RemoteLayout,
+    location: RemoteLocation,
     artifact_name: &str,
     artifacts: &BTreeMap<String, ArtifactMeta>,
 ) -> Result<Vec<u8>, AppError> {
@@ -258,7 +693,7 @@ async fn download_and_verify(
     })?;
     validate_artifact_size_limit(artifact_name, meta.size)?;
 
-    let url = remote_file_url(settings, layout, artifact_name)?;
+    let url = remote_file_url(settings, location, artifact_name)?;
     let (bytes, _) = get_bytes(&url, auth, MAX_SYNC_ARTIFACT_BYTES as usize)
         .await?
         .ok_or_else(|| {
@@ -273,13 +708,279 @@ async fn download_and_verify(
     Ok(bytes)
 }
 
+async fn download_optional_artifact(
+    settings: &WebDavSyncSettings,
+    auth: &WebDavAuth,
+    location: RemoteLocation,
+    artifact_name: &str,
+    artifacts: &BTreeMap<String, ArtifactMeta>,
+) -> Result<Option<Vec<u8>>, AppError> {
+    if !artifacts.contains_key(artifact_name) {
+        return Ok(None);
+    }
+    download_and_verify(settings, auth, location, artifact_name, artifacts)
+        .await
+        .map(Some)
+}
+
+async fn load_remote_module_payloads(
+    settings: &WebDavSyncSettings,
+    auth: &WebDavAuth,
+    snapshot: &RemoteSnapshot,
+) -> Result<ModulePayloads, AppError> {
+    if snapshot.location.protocol_version == LEGACY_PROTOCOL_VERSION {
+        let db_sql = download_and_verify(
+            settings,
+            auth,
+            snapshot.location,
+            REMOTE_DB_SQL,
+            &snapshot.manifest.artifacts,
+        )
+        .await?;
+        let skills_zip = download_and_verify(
+            settings,
+            auth,
+            snapshot.location,
+            REMOTE_SKILLS_ZIP,
+            &snapshot.manifest.artifacts,
+        )
+        .await?;
+        return split_v2_snapshot_into_module_payloads(&db_sql, &skills_zip);
+    }
+
+    Ok(ModulePayloads {
+        api_sql: download_optional_artifact(
+            settings,
+            auth,
+            snapshot.location,
+            REMOTE_API_SQL,
+            &snapshot.manifest.artifacts,
+        )
+        .await?,
+        mcp_sql: download_optional_artifact(
+            settings,
+            auth,
+            snapshot.location,
+            REMOTE_MCP_SQL,
+            &snapshot.manifest.artifacts,
+        )
+        .await?,
+        prompts_sql: download_optional_artifact(
+            settings,
+            auth,
+            snapshot.location,
+            REMOTE_PROMPTS_SQL,
+            &snapshot.manifest.artifacts,
+        )
+        .await?,
+        skills_sql: download_optional_artifact(
+            settings,
+            auth,
+            snapshot.location,
+            REMOTE_SKILLS_SQL,
+            &snapshot.manifest.artifacts,
+        )
+        .await?,
+        skills_zip: download_optional_artifact(
+            settings,
+            auth,
+            snapshot.location,
+            REMOTE_SKILLS_ZIP,
+            &snapshot.manifest.artifacts,
+        )
+        .await?,
+    })
+}
+
+fn split_v2_snapshot_into_module_payloads(
+    db_sql: &[u8],
+    skills_zip: &[u8],
+) -> Result<ModulePayloads, AppError> {
+    let sql_str = std::str::from_utf8(db_sql).map_err(|e| {
+        localized(
+            "webdav.sync.sql_not_utf8",
+            format!("SQL 非 UTF-8: {e}"),
+            format!("SQL is not valid UTF-8: {e}"),
+        )
+    })?;
+    let conn =
+        rusqlite::Connection::open_in_memory().map_err(|e| AppError::Database(e.to_string()))?;
+    conn.execute_batch(sql_str)
+        .map_err(|e| AppError::Database(format!("执行 SQL 导入失败: {e}")))?;
+    crate::database::Database::create_tables_on_conn(&conn)?;
+    crate::database::Database::apply_schema_migrations_on_conn(&conn)?;
+
+    Ok(ModulePayloads {
+        api_sql: Some(
+            crate::database::Database::export_sql_string_from_connection_for_tables(
+                &conn, API_TABLES,
+            )?
+            .into_bytes(),
+        ),
+        mcp_sql: Some(
+            crate::database::Database::export_sql_string_from_connection_for_tables(
+                &conn, MCP_TABLES,
+            )?
+            .into_bytes(),
+        ),
+        prompts_sql: Some(
+            crate::database::Database::export_sql_string_from_connection_for_tables(
+                &conn,
+                PROMPT_TABLES,
+            )?
+            .into_bytes(),
+        ),
+        skills_sql: Some(
+            crate::database::Database::export_sql_string_from_connection_for_tables(
+                &conn,
+                SKILL_TABLES,
+            )?
+            .into_bytes(),
+        ),
+        skills_zip: Some(skills_zip.to_vec()),
+    })
+}
+
+fn ensure_requested_modules_available(
+    payloads: &ModulePayloads,
+    selection: &WebDavSyncModules,
+) -> Result<(), AppError> {
+    let available = payloads.available_modules();
+    let missing = [
+        (selection.api && !available.api, "API"),
+        (selection.mcp && !available.mcp, "MCP"),
+        (selection.prompts && !available.prompts, "Prompts"),
+        (selection.skills && !available.skills, "Skills"),
+    ]
+    .into_iter()
+    .filter_map(|(missing, label)| missing.then_some(label))
+    .collect::<Vec<_>>();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(localized(
+        "webdav.sync.requested_modules_missing",
+        format!("远端缺少所选同步模块: {}", missing.join(", ")),
+        format!(
+            "The remote snapshot is missing the selected sync modules: {}",
+            missing.join(", ")
+        ),
+    ))
+}
+
+fn decode_sql_payload(bytes: &[u8]) -> Result<String, AppError> {
+    std::str::from_utf8(bytes)
+        .map(|sql| sql.to_string())
+        .map_err(|e| {
+            localized(
+                "webdav.sync.sql_not_utf8",
+                format!("SQL 非 UTF-8: {e}"),
+                format!("SQL is not valid UTF-8: {e}"),
+            )
+        })
+}
+
+fn apply_selected_modules(
+    db: &crate::database::Database,
+    payloads: &ModulePayloads,
+    selection: &WebDavSyncModules,
+) -> Result<(), AppError> {
+    let mut sql_documents = Vec::new();
+    let mut selected_tables = Vec::new();
+
+    if selection.api {
+        sql_documents.push(decode_sql_payload(
+            payloads.api_sql.as_deref().ok_or_else(|| {
+                localized(
+                    "webdav.sync.api_missing",
+                    "缺少 API SQL",
+                    "Missing API SQL.",
+                )
+            })?,
+        )?);
+        selected_tables.extend_from_slice(API_TABLES);
+    }
+    if selection.mcp {
+        sql_documents.push(decode_sql_payload(
+            payloads.mcp_sql.as_deref().ok_or_else(|| {
+                localized(
+                    "webdav.sync.mcp_missing",
+                    "缺少 MCP SQL",
+                    "Missing MCP SQL.",
+                )
+            })?,
+        )?);
+        selected_tables.extend_from_slice(MCP_TABLES);
+    }
+    if selection.prompts {
+        sql_documents.push(decode_sql_payload(
+            payloads.prompts_sql.as_deref().ok_or_else(|| {
+                localized(
+                    "webdav.sync.prompts_missing",
+                    "缺少 Prompts SQL",
+                    "Missing Prompts SQL.",
+                )
+            })?,
+        )?);
+        selected_tables.extend_from_slice(PROMPT_TABLES);
+    }
+    if selection.skills {
+        sql_documents.push(decode_sql_payload(
+            payloads.skills_sql.as_deref().ok_or_else(|| {
+                localized(
+                    "webdav.sync.skills_sql_missing",
+                    "缺少 Skills SQL",
+                    "Missing Skills SQL.",
+                )
+            })?,
+        )?);
+        selected_tables.extend_from_slice(SKILL_TABLES);
+    }
+
+    let skills_backup = if selection.skills {
+        Some(backup_current_skills()?)
+    } else {
+        None
+    };
+
+    if selection.skills {
+        restore_skills_zip(payloads.skills_zip.as_deref().ok_or_else(|| {
+            localized(
+                "webdav.sync.skills_zip_missing",
+                "缺少 skills.zip",
+                "Missing skills.zip.",
+            )
+        })?)?;
+    }
+
+    let sql_refs = sql_documents.iter().map(String::as_str).collect::<Vec<_>>();
+    if let Err(db_err) = db.replace_tables_from_sql_strings(&sql_refs, &selected_tables) {
+        if let Some(skills_backup) = skills_backup.as_ref() {
+            if let Err(rollback_err) = restore_skills_from_backup(skills_backup) {
+                return Err(localized(
+                    "webdav.sync.db_import_and_rollback_failed",
+                    format!("导入数据库失败: {db_err}; 同时回滚 Skills 失败: {rollback_err}"),
+                    format!(
+                        "Database import failed: {db_err}; skills rollback also failed: {rollback_err}"
+                    ),
+                ));
+            }
+        }
+        return Err(db_err);
+    }
+
+    Ok(())
+}
+
 // ─── Remote path helpers ─────────────────────────────────────
 
-fn remote_dir_segments(settings: &WebDavSyncSettings, layout: RemoteLayout) -> Vec<String> {
+fn remote_dir_segments(settings: &WebDavSyncSettings, location: RemoteLocation) -> Vec<String> {
     let mut segs = Vec::new();
     segs.extend(path_segments(&settings.remote_root).map(str::to_string));
-    segs.push(format!("v{PROTOCOL_VERSION}"));
-    if layout == RemoteLayout::Current {
+    segs.push(format!("v{}", location.protocol_version));
+    if location.layout == RemoteLayout::Current {
         segs.push(format!("db-v{DB_COMPAT_VERSION}"));
     }
     segs.extend(path_segments(&settings.profile).map(str::to_string));
@@ -288,16 +989,16 @@ fn remote_dir_segments(settings: &WebDavSyncSettings, layout: RemoteLayout) -> V
 
 fn remote_file_url(
     settings: &WebDavSyncSettings,
-    layout: RemoteLayout,
+    location: RemoteLocation,
     file_name: &str,
 ) -> Result<String, AppError> {
-    let mut segs = remote_dir_segments(settings, layout);
+    let mut segs = remote_dir_segments(settings, location);
     segs.extend(path_segments(file_name).map(str::to_string));
     build_remote_url(&settings.base_url, &segs)
 }
 
-fn remote_dir_display(settings: &WebDavSyncSettings, layout: RemoteLayout) -> String {
-    let segs = remote_dir_segments(settings, layout);
+fn remote_dir_display(settings: &WebDavSyncSettings, location: RemoteLocation) -> String {
+    let segs = remote_dir_segments(settings, location);
     format!("/{}", segs.join("/"))
 }
 
@@ -310,6 +1011,15 @@ fn auth_for(settings: &WebDavSyncSettings) -> WebDavAuth {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::fs;
+
+    fn artifact(hash: &str, size: u64) -> ArtifactMeta {
+        ArtifactMeta {
+            sha256: hash.to_string(),
+            size,
+        }
+    }
 
     #[test]
     fn remote_dir_segments_uses_current_layout() {
@@ -318,8 +1028,8 @@ mod tests {
             profile: "default".to_string(),
             ..WebDavSyncSettings::default()
         };
-        let segs = remote_dir_segments(&settings, RemoteLayout::Current);
-        assert_eq!(segs, vec!["cc-switch-sync", "v2", "db-v6", "default"]);
+        let segs = remote_dir_segments(&settings, RemoteLocation::v3_current());
+        assert_eq!(segs, vec!["cc-switch-sync", "v3", "db-v6", "default"]);
     }
 
     #[test]
@@ -329,7 +1039,480 @@ mod tests {
             profile: "default".to_string(),
             ..WebDavSyncSettings::default()
         };
-        let segs = remote_dir_segments(&settings, RemoteLayout::Legacy);
+        let segs = remote_dir_segments(&settings, RemoteLocation::v2_legacy());
         assert_eq!(segs, vec!["cc-switch-sync", "v2", "default"]);
+    }
+
+    #[test]
+    fn sha256_hex_is_correct() {
+        let hash = sha256_hex(b"hello");
+        assert_eq!(
+            hash,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn persist_best_effort_returns_true_on_success() {
+        let mut settings = WebDavSyncSettings::default();
+        let ok = persist_sync_success_best_effort(
+            &mut settings,
+            "hash".to_string(),
+            Some("etag".to_string()),
+            |_settings, _hash, _etag| Ok(()),
+        );
+        assert!(ok);
+    }
+
+    #[test]
+    fn persist_best_effort_returns_false_on_error() {
+        let mut settings = WebDavSyncSettings::default();
+        let ok = persist_sync_success_best_effort(
+            &mut settings,
+            "hash".to_string(),
+            None,
+            |_settings, _hash, _etag| Err(AppError::Config("boom".to_string())),
+        );
+        assert!(!ok);
+    }
+
+    fn manifest_with(format: &str, version: u32, db_compat_version: Option<u32>) -> SyncManifest {
+        let mut artifacts = BTreeMap::new();
+        let modules = if version == PROTOCOL_VERSION {
+            artifacts.insert(REMOTE_API_SQL.to_string(), artifact("abc", 1));
+            artifacts.insert(REMOTE_MCP_SQL.to_string(), artifact("def", 2));
+            artifacts.insert(REMOTE_PROMPTS_SQL.to_string(), artifact("ghi", 3));
+            artifacts.insert(REMOTE_SKILLS_SQL.to_string(), artifact("jkl", 4));
+            artifacts.insert(REMOTE_SKILLS_ZIP.to_string(), artifact("mno", 5));
+            Some(ManifestModules {
+                api: vec![REMOTE_API_SQL.to_string()],
+                mcp: vec![REMOTE_MCP_SQL.to_string()],
+                prompts: vec![REMOTE_PROMPTS_SQL.to_string()],
+                skills: vec![REMOTE_SKILLS_SQL.to_string(), REMOTE_SKILLS_ZIP.to_string()],
+            })
+        } else {
+            artifacts.insert(REMOTE_DB_SQL.to_string(), artifact("abc", 1));
+            artifacts.insert(REMOTE_SKILLS_ZIP.to_string(), artifact("def", 2));
+            None
+        };
+        SyncManifest {
+            format: format.to_string(),
+            version,
+            db_compat_version,
+            device_name: "My MacBook".to_string(),
+            created_at: "2026-02-12T00:00:00Z".to_string(),
+            artifacts,
+            modules,
+            snapshot_id: "snap-1".to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_compat_accepts_supported_manifest() {
+        let manifest = manifest_with(PROTOCOL_FORMAT, PROTOCOL_VERSION, Some(DB_COMPAT_VERSION));
+        assert!(validate_manifest_compat(&manifest, RemoteLocation::v3_current()).is_ok());
+    }
+
+    #[test]
+    fn validate_manifest_compat_rejects_wrong_format() {
+        let manifest = manifest_with("other-format", PROTOCOL_VERSION, Some(DB_COMPAT_VERSION));
+        assert!(validate_manifest_compat(&manifest, RemoteLocation::v3_current()).is_err());
+    }
+
+    #[test]
+    fn validate_manifest_compat_rejects_wrong_version() {
+        let manifest = manifest_with(
+            PROTOCOL_FORMAT,
+            PROTOCOL_VERSION + 1,
+            Some(DB_COMPAT_VERSION),
+        );
+        assert!(validate_manifest_compat(&manifest, RemoteLocation::v3_current()).is_err());
+    }
+
+    #[test]
+    fn validate_manifest_compat_accepts_legacy_manifest_without_db_compat() {
+        let manifest = manifest_with(PROTOCOL_FORMAT, LEGACY_PROTOCOL_VERSION, None);
+        assert!(validate_manifest_compat(&manifest, RemoteLocation::v2_legacy()).is_ok());
+    }
+
+    #[test]
+    fn validate_manifest_compat_rejects_current_manifest_with_wrong_db_compat() {
+        let manifest = manifest_with(
+            PROTOCOL_FORMAT,
+            PROTOCOL_VERSION,
+            Some(LEGACY_DB_COMPAT_VERSION),
+        );
+        assert!(validate_manifest_compat(&manifest, RemoteLocation::v3_current()).is_err());
+    }
+
+    #[test]
+    fn validate_manifest_compat_rejects_legacy_manifest_from_newer_db_generation() {
+        let manifest = manifest_with(
+            PROTOCOL_FORMAT,
+            LEGACY_PROTOCOL_VERSION,
+            Some(DB_COMPAT_VERSION + 1),
+        );
+        assert!(validate_manifest_compat(&manifest, RemoteLocation::v2_legacy()).is_err());
+    }
+
+    #[test]
+    fn effective_db_compat_version_defaults_legacy_layout_to_v5() {
+        let manifest = manifest_with(PROTOCOL_FORMAT, LEGACY_PROTOCOL_VERSION, None);
+        assert_eq!(
+            effective_db_compat_version(&manifest, RemoteLocation::v2_legacy()),
+            Some(LEGACY_DB_COMPAT_VERSION)
+        );
+        assert_eq!(
+            effective_db_compat_version(&manifest, RemoteLocation::v2_current()),
+            None
+        );
+    }
+
+    #[test]
+    fn available_modules_defaults_to_all_enabled_for_v2_snapshots() {
+        let manifest = manifest_with(PROTOCOL_FORMAT, LEGACY_PROTOCOL_VERSION, None);
+        let modules = available_modules_from_manifest(&manifest, RemoteLocation::v2_legacy());
+        assert_eq!(
+            modules,
+            WebDavSyncModules {
+                api: true,
+                mcp: true,
+                prompts: true,
+                skills: true,
+            }
+        );
+    }
+
+    #[test]
+    fn available_modules_respects_v3_manifest_entries() {
+        let manifest = manifest_with(PROTOCOL_FORMAT, PROTOCOL_VERSION, Some(DB_COMPAT_VERSION));
+        let modules = available_modules_from_manifest(&manifest, RemoteLocation::v3_current());
+        assert!(modules.api);
+        assert!(modules.mcp);
+        assert!(modules.prompts);
+        assert!(modules.skills);
+    }
+
+    #[test]
+    fn build_local_module_payloads_includes_model_pricing_in_api_sql() -> Result<(), AppError> {
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        let test_home = std::env::temp_dir().join("cc-switch-webdav-model-pricing-payload-test");
+        let _ = fs::remove_dir_all(&test_home);
+        fs::create_dir_all(&test_home).expect("create isolated test home");
+        std::env::set_var("CC_SWITCH_TEST_HOME", &test_home);
+
+        let result = (|| -> Result<(), AppError> {
+            let db = crate::database::Database::memory()?;
+            {
+                let conn = crate::database::lock_conn!(db.conn);
+                conn.execute("DELETE FROM model_pricing", [])?;
+                conn.execute(
+                    "INSERT INTO model_pricing (
+                        model_id, display_name, input_cost_per_million, output_cost_per_million
+                    ) VALUES ('pricing-from-api-sync', 'Pricing From Sync', 1.23, 4.56)",
+                    [],
+                )?;
+            }
+
+            let payloads = build_local_module_payloads(&db)?;
+            let api_sql = std::str::from_utf8(
+                payloads
+                    .api_sql
+                    .as_deref()
+                    .expect("api payload should be present"),
+            )
+            .expect("api sql should be utf-8");
+
+            assert!(
+                api_sql.contains("INSERT INTO \"model_pricing\""),
+                "api module export should include model_pricing rows"
+            );
+            assert!(
+                api_sql.contains("pricing-from-api-sync"),
+                "api module export should include model_pricing data"
+            );
+
+            Ok(())
+        })();
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+
+        result
+    }
+
+    #[test]
+    fn normalize_device_name_returns_none_for_blank_input() {
+        assert_eq!(normalize_device_name("   \n\t  "), None);
+    }
+
+    #[test]
+    fn normalize_device_name_collapses_whitespace_and_drops_control_chars() {
+        assert_eq!(
+            normalize_device_name("  Mac\tBook \n Pro\u{0007} "),
+            Some("Mac Book Pro".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_device_name_truncates_to_max_len() {
+        let long = "a".repeat(80);
+        assert_eq!(normalize_device_name(&long).map(|s| s.len()), Some(64));
+    }
+
+    #[test]
+    fn manifest_serialization_uses_device_name_only() {
+        let manifest = manifest_with(PROTOCOL_FORMAT, PROTOCOL_VERSION, Some(DB_COMPAT_VERSION));
+        let value = serde_json::to_value(&manifest).expect("serialize manifest");
+        assert!(
+            value.get("deviceName").is_some(),
+            "manifest should contain deviceName"
+        );
+        assert_eq!(
+            value.get("dbCompatVersion").and_then(|v| v.as_u64()),
+            Some(DB_COMPAT_VERSION as u64)
+        );
+        assert!(
+            value.get("deviceId").is_none(),
+            "manifest should not contain deviceId"
+        );
+    }
+
+    #[test]
+    fn validate_artifact_size_limit_rejects_oversized_artifacts() {
+        let err = validate_artifact_size_limit("skills.zip", MAX_SYNC_ARTIFACT_BYTES + 1)
+            .expect_err("artifact larger than limit should be rejected");
+        assert!(
+            err.to_string().contains("too large") || err.to_string().contains("超过"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_artifact_size_limit_accepts_limit_boundary() {
+        assert!(validate_artifact_size_limit("skills.zip", MAX_SYNC_ARTIFACT_BYTES).is_ok());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn live_webdav_module_sync_roundtrip_preserves_unselected_modules() {
+        let base_url = std::env::var("CC_SWITCH_LIVE_WEBDAV_URL")
+            .expect("CC_SWITCH_LIVE_WEBDAV_URL must be set");
+        let username = std::env::var("CC_SWITCH_LIVE_WEBDAV_USERNAME")
+            .expect("CC_SWITCH_LIVE_WEBDAV_USERNAME must be set");
+        let password = std::env::var("CC_SWITCH_LIVE_WEBDAV_PASSWORD")
+            .expect("CC_SWITCH_LIVE_WEBDAV_PASSWORD must be set");
+
+        let test_home = std::env::temp_dir().join(format!(
+            "cc-switch-webdav-live-{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        let _ = fs::remove_dir_all(&test_home);
+        fs::create_dir_all(&test_home).expect("create live test home");
+        std::env::set_var("CC_SWITCH_TEST_HOME", &test_home);
+        crate::settings::update_settings(crate::settings::AppSettings::default())
+            .expect("reset app settings");
+
+        let remote_root = format!("csl-{}", chrono::Utc::now().timestamp());
+        let profile = "module-sync".to_string();
+
+        let first_db = crate::database::Database::memory().expect("create db");
+        seed_provider(&first_db, "provider-remote-a");
+        seed_mcp(&first_db, "mcp-remote-a");
+        seed_prompt(&first_db, "prompt-remote-a", "remote prompt A");
+        seed_skill_dir("skill-remote-a");
+
+        let mut first_settings = live_settings(
+            &base_url,
+            &username,
+            &password,
+            &remote_root,
+            &profile,
+            WebDavSyncModules::default(),
+            WebDavSyncModules::default(),
+        );
+        check_connection(&first_settings)
+            .await
+            .expect("check connection");
+        upload(&first_db, &mut first_settings)
+            .await
+            .expect("initial upload");
+
+        reset_skill_dir("skill-remote-b");
+        replace_mcp(&first_db, "mcp-remote-b");
+        first_settings.upload_modules = WebDavSyncModules {
+            api: false,
+            mcp: true,
+            prompts: false,
+            skills: false,
+        };
+        upload(&first_db, &mut first_settings)
+            .await
+            .expect("mcp-only upload");
+
+        let second_db = crate::database::Database::memory().expect("create second db");
+        seed_provider(&second_db, "provider-local");
+        seed_mcp(&second_db, "mcp-local");
+        seed_prompt(&second_db, "prompt-local", "local prompt");
+        reset_skill_dir("skill-local");
+
+        let mut second_settings = live_settings(
+            &base_url,
+            &username,
+            &password,
+            &remote_root,
+            &profile,
+            WebDavSyncModules::default(),
+            WebDavSyncModules {
+                api: false,
+                mcp: false,
+                prompts: true,
+                skills: false,
+            },
+        );
+        download(&second_db, &mut second_settings)
+            .await
+            .expect("prompts-only download");
+
+        assert_provider_exists(&second_db, "provider-local");
+        assert_mcp_exists(&second_db, "mcp-local");
+        assert_prompt_exists(&second_db, "prompt-remote-a");
+        assert_skill_dir_contains("skill-local");
+    }
+
+    fn live_settings(
+        base_url: &str,
+        username: &str,
+        password: &str,
+        remote_root: &str,
+        profile: &str,
+        upload_modules: WebDavSyncModules,
+        download_modules: WebDavSyncModules,
+    ) -> WebDavSyncSettings {
+        WebDavSyncSettings {
+            enabled: true,
+            auto_sync: false,
+            base_url: base_url.to_string(),
+            username: username.to_string(),
+            password: password.to_string(),
+            remote_root: remote_root.to_string(),
+            profile: profile.to_string(),
+            upload_modules,
+            download_modules,
+            ..WebDavSyncSettings::default()
+        }
+    }
+
+    fn seed_provider(db: &crate::database::Database, id: &str) {
+        let conn = db.conn.lock().expect("lock db");
+        conn.execute(
+            "INSERT INTO providers (id, app_type, name, settings_config, meta)
+             VALUES (?1, 'claude', ?1, '{}', '{}')",
+            [id],
+        )
+        .expect("insert provider");
+    }
+
+    fn seed_mcp(db: &crate::database::Database, id: &str) {
+        let conn = db.conn.lock().expect("lock db");
+        conn.execute(
+            "INSERT INTO mcp_servers (
+                id, name, server_config, tags,
+                enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes
+            ) VALUES (?1, ?1, '{}', '[]', 1, 0, 0, 0, 0)",
+            [id],
+        )
+        .expect("insert mcp");
+    }
+
+    fn replace_mcp(db: &crate::database::Database, id: &str) {
+        let conn = db.conn.lock().expect("lock db");
+        conn.execute("DELETE FROM mcp_servers", [])
+            .expect("clear mcp");
+        conn.execute(
+            "INSERT INTO mcp_servers (
+                id, name, server_config, tags,
+                enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes
+            ) VALUES (?1, ?1, '{}', '[]', 1, 1, 0, 0, 0)",
+            [id],
+        )
+        .expect("insert replacement mcp");
+    }
+
+    fn seed_prompt(db: &crate::database::Database, id: &str, content: &str) {
+        let conn = db.conn.lock().expect("lock db");
+        conn.execute(
+            "INSERT INTO prompts (id, app_type, name, content, enabled)
+             VALUES (?1, 'claude', ?1, ?2, 1)",
+            rusqlite::params![id, content],
+        )
+        .expect("insert prompt");
+    }
+
+    fn seed_skill_dir(name: &str) {
+        let ssot_dir =
+            crate::services::skill::SkillService::get_ssot_dir().expect("resolve skills dir");
+        let skill_dir = ssot_dir.join(name);
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("# {name}\n\nLive WebDAV test skill\n"),
+        )
+        .expect("write skill file");
+    }
+
+    fn reset_skill_dir(name: &str) {
+        let ssot_dir =
+            crate::services::skill::SkillService::get_ssot_dir().expect("resolve skills dir");
+        let _ = fs::remove_dir_all(&ssot_dir);
+        seed_skill_dir(name);
+    }
+
+    fn assert_provider_exists(db: &crate::database::Database, id: &str) {
+        let conn = db.conn.lock().expect("lock db");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM providers WHERE id = ?1 AND app_type = 'claude'",
+                [id],
+                |row| row.get(0),
+            )
+            .expect("query provider count");
+        assert_eq!(count, 1, "expected provider {id} to remain local");
+    }
+
+    fn assert_mcp_exists(db: &crate::database::Database, id: &str) {
+        let conn = db.conn.lock().expect("lock db");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM mcp_servers WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )
+            .expect("query mcp count");
+        assert_eq!(count, 1, "expected MCP {id} to remain local");
+    }
+
+    fn assert_prompt_exists(db: &crate::database::Database, id: &str) {
+        let conn = db.conn.lock().expect("lock db");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM prompts WHERE id = ?1 AND app_type = 'claude'",
+                [id],
+                |row| row.get(0),
+            )
+            .expect("query prompt count");
+        assert_eq!(count, 1, "expected prompt {id} to be downloaded");
+    }
+
+    fn assert_skill_dir_contains(name: &str) {
+        let ssot_dir =
+            crate::services::skill::SkillService::get_ssot_dir().expect("resolve skills dir");
+        assert!(
+            ssot_dir.join(name).join("SKILL.md").exists(),
+            "expected local skill directory {name} to remain untouched"
+        );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -94,6 +94,67 @@ pub struct WebDavSyncStatus {
     pub last_remote_manifest_hash: Option<String>,
 }
 
+/// WebDAV 分模块同步选择
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WebDavSyncModules {
+    #[serde(default = "default_enabled_module")]
+    pub api: bool,
+    #[serde(default = "default_enabled_module")]
+    pub mcp: bool,
+    #[serde(default = "default_enabled_module")]
+    pub prompts: bool,
+    #[serde(default = "default_enabled_module")]
+    pub skills: bool,
+}
+
+impl Default for WebDavSyncModules {
+    fn default() -> Self {
+        Self {
+            api: true,
+            mcp: false,
+            prompts: false,
+            skills: false,
+        }
+    }
+}
+
+impl WebDavSyncModules {
+    pub fn any_enabled(&self) -> bool {
+        self.api || self.mcp || self.prompts || self.skills
+    }
+
+    pub fn upload_default() -> Self {
+        Self {
+            api: true,
+            mcp: false,
+            prompts: false,
+            skills: false,
+        }
+    }
+
+    pub fn download_default() -> Self {
+        Self {
+            api: true,
+            mcp: true,
+            prompts: true,
+            skills: true,
+        }
+    }
+}
+
+fn default_enabled_module() -> bool {
+    true
+}
+
+fn default_upload_modules() -> WebDavSyncModules {
+    WebDavSyncModules::upload_default()
+}
+
+fn default_download_modules() -> WebDavSyncModules {
+    WebDavSyncModules::download_default()
+}
+
 fn default_remote_root() -> String {
     "cc-switch-sync".to_string()
 }
@@ -119,6 +180,10 @@ pub struct WebDavSyncSettings {
     pub remote_root: String,
     #[serde(default = "default_profile")]
     pub profile: String,
+    #[serde(default = "default_upload_modules")]
+    pub upload_modules: WebDavSyncModules,
+    #[serde(default = "default_download_modules")]
+    pub download_modules: WebDavSyncModules,
     #[serde(default)]
     pub status: WebDavSyncStatus,
 }
@@ -133,6 +198,8 @@ impl Default for WebDavSyncSettings {
             password: String::new(),
             remote_root: default_remote_root(),
             profile: default_profile(),
+            upload_modules: WebDavSyncModules::upload_default(),
+            download_modules: WebDavSyncModules::download_default(),
             status: WebDavSyncStatus::default(),
         }
     }
@@ -152,6 +219,20 @@ impl WebDavSyncSettings {
                 "webdav.username.required",
                 "WebDAV 用户名不能为空",
                 "WebDAV username is required.",
+            ));
+        }
+        if !self.upload_modules.any_enabled() {
+            return Err(crate::error::AppError::localized(
+                "webdav.upload_modules.required",
+                "请至少选择一个上传同步模块",
+                "Please select at least one upload sync module.",
+            ));
+        }
+        if !self.download_modules.any_enabled() {
+            return Err(crate::error::AppError::localized(
+                "webdav.download_modules.required",
+                "请至少选择一个下载同步模块",
+                "Please select at least one download sync module.",
             ));
         }
         Ok(())
@@ -1112,6 +1193,7 @@ pub fn update_s3_sync_status(status: WebDavSyncStatus) -> Result<(), AppError> {
 mod tests {
     use super::*;
     use crate::app_config::AppType;
+    use serde_json::json;
 
     #[test]
     fn visible_apps_old_settings_default_claude_desktop_visible() {
@@ -1142,5 +1224,38 @@ mod tests {
         .expect("visible apps");
 
         assert!(!visible.is_visible(&AppType::ClaudeDesktop));
+    }
+
+    #[test]
+    fn webdav_sync_settings_default_uses_api_only_upload_and_full_download_modules() {
+        let settings = WebDavSyncSettings::default();
+
+        assert!(settings.upload_modules.api);
+        assert!(!settings.upload_modules.mcp);
+        assert!(!settings.upload_modules.prompts);
+        assert!(!settings.upload_modules.skills);
+        assert!(settings.download_modules.api);
+        assert!(settings.download_modules.mcp);
+        assert!(settings.download_modules.prompts);
+        assert!(settings.download_modules.skills);
+    }
+
+    #[test]
+    fn webdav_sync_settings_deserialize_defaults_module_selection_when_missing() {
+        let settings: WebDavSyncSettings = serde_json::from_value(json!({
+            "enabled": true,
+            "baseUrl": "https://dav.example.com/dav/",
+            "username": "alice"
+        }))
+        .expect("webdav sync settings");
+
+        assert!(settings.upload_modules.api);
+        assert!(!settings.upload_modules.mcp);
+        assert!(!settings.upload_modules.prompts);
+        assert!(!settings.upload_modules.skills);
+        assert!(settings.download_modules.api);
+        assert!(settings.download_modules.mcp);
+        assert!(settings.download_modules.prompts);
+        assert!(settings.download_modules.skills);
     }
 }

--- a/src/components/settings/WebdavSyncSection.tsx
+++ b/src/components/settings/WebdavSyncSection.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -38,6 +39,7 @@ import type { SettingsFormState } from "@/hooks/useSettings";
 import type {
   RemoteSnapshotInfo,
   S3SyncSettings,
+  WebDavSyncModules,
   WebDavSyncSettings,
 } from "@/types";
 
@@ -185,6 +187,56 @@ type SyncType = "webdav" | "s3";
 
 type DialogType = "upload" | "download" | "mutual_exclusion" | null;
 
+const DEFAULT_SYNC_MODULES: WebDavSyncModules = {
+  api: true,
+  mcp: false,
+  prompts: false,
+  skills: false,
+};
+
+const DEFAULT_DOWNLOAD_SYNC_MODULES: WebDavSyncModules = {
+  api: true,
+  mcp: true,
+  prompts: true,
+  skills: true,
+};
+
+const MODULE_KEYS = ["api", "mcp", "prompts", "skills"] as const;
+
+function hasAnyModuleField(
+  value: Partial<WebDavSyncModules> | null | undefined,
+): value is Partial<WebDavSyncModules> {
+  return MODULE_KEYS.some((key) => value?.[key] !== undefined);
+}
+
+function normalizeModules(
+  value: Partial<WebDavSyncModules> | null | undefined,
+  defaults: WebDavSyncModules,
+): WebDavSyncModules {
+  if (!hasAnyModuleField(value)) {
+    return defaults;
+  }
+  return {
+    api: value.api ?? true,
+    mcp: value.mcp ?? true,
+    prompts: value.prompts ?? true,
+    skills: value.skills ?? true,
+  };
+}
+
+function hasEnabledModule(modules: WebDavSyncModules): boolean {
+  return MODULE_KEYS.some((key) => modules[key]);
+}
+
+function listModuleLabels(
+  modules: WebDavSyncModules,
+  t: (key: string) => string,
+): string[] {
+  return MODULE_KEYS.filter((key) => modules[key]).map((key) =>
+    t(`settings.webdavSync.modules.${key}`),
+  );
+}
+
 interface WebdavSyncSectionProps {
   config?: WebDavSyncSettings;
   s3Config?: S3SyncSettings;
@@ -270,6 +322,14 @@ export function WebdavSyncSection({
     remoteRoot: config?.remoteRoot ?? "cc-switch-sync",
     profile: config?.profile ?? "default",
     autoSync: config?.autoSync ?? false,
+    uploadModules: normalizeModules(
+      config?.uploadModules,
+      DEFAULT_SYNC_MODULES,
+    ),
+    downloadModules: normalizeModules(
+      config?.downloadModules,
+      DEFAULT_DOWNLOAD_SYNC_MODULES,
+    ),
   }));
 
   // ─── S3 form state ─────────────────────────────────────────
@@ -366,6 +426,14 @@ export function WebdavSyncSection({
         remoteRoot: nextRemoteRoot,
         profile: nextProfile,
         autoSync: config.autoSync ?? false,
+        uploadModules: normalizeModules(
+          config.uploadModules,
+          DEFAULT_SYNC_MODULES,
+        ),
+        downloadModules: normalizeModules(
+          config.downloadModules,
+          DEFAULT_DOWNLOAD_SYNC_MODULES,
+        ),
       };
     });
     setPasswordTouched(false);
@@ -399,6 +467,29 @@ export function WebdavSyncSection({
       justSavedTimerRef.current = null;
     }
   }, []);
+
+  const updateModuleSelection = useCallback(
+    (
+      group: "uploadModules" | "downloadModules",
+      key: keyof WebDavSyncModules,
+      checked: boolean,
+    ) => {
+      setForm((prev) => ({
+        ...prev,
+        [group]: {
+          ...prev[group],
+          [key]: checked,
+        },
+      }));
+      setDirty(true);
+      setJustSaved(false);
+      if (justSavedTimerRef.current) {
+        clearTimeout(justSavedTimerRef.current);
+        justSavedTimerRef.current = null;
+      }
+    },
+    [],
+  );
 
   const handlePresetChange = useCallback((id: string) => {
     setPresetId(id);
@@ -464,6 +555,11 @@ export function WebdavSyncSection({
       remoteRoot: form.remoteRoot.trim() || "cc-switch-sync",
       profile: form.profile.trim() || "default",
       autoSync: form.autoSync,
+      uploadModules: normalizeModules(form.uploadModules, DEFAULT_SYNC_MODULES),
+      downloadModules: normalizeModules(
+        form.downloadModules,
+        DEFAULT_DOWNLOAD_SYNC_MODULES,
+      ),
     };
   }, [form, passwordTouched]);
 
@@ -473,6 +569,14 @@ export function WebdavSyncSection({
     const settings = buildSettings();
     if (!settings) {
       toast.error(t("settings.webdavSync.missingUrl"));
+      return;
+    }
+    if (!hasEnabledModule(settings.uploadModules ?? DEFAULT_SYNC_MODULES)) {
+      toast.error(t("settings.webdavSync.noUploadModules"));
+      return;
+    }
+    if (!hasEnabledModule(settings.downloadModules ?? DEFAULT_SYNC_MODULES)) {
+      toast.error(t("settings.webdavSync.noDownloadModules"));
       return;
     }
     setActionState("testing");
@@ -494,6 +598,14 @@ export function WebdavSyncSection({
     const settings = buildSettings();
     if (!settings) {
       toast.error(t("settings.webdavSync.missingUrl"));
+      return;
+    }
+    if (!hasEnabledModule(settings.uploadModules ?? DEFAULT_SYNC_MODULES)) {
+      toast.error(t("settings.webdavSync.noUploadModules"));
+      return;
+    }
+    if (!hasEnabledModule(settings.downloadModules ?? DEFAULT_SYNC_MODULES)) {
+      toast.error(t("settings.webdavSync.noDownloadModules"));
       return;
     }
     setActionState("saving");
@@ -548,6 +660,10 @@ export function WebdavSyncSection({
       toast.error(t("settings.webdavSync.unsavedChanges"));
       return;
     }
+    if (!hasEnabledModule(form.uploadModules)) {
+      toast.error(t("settings.webdavSync.noUploadModules"));
+      return;
+    }
     setActionState("fetching_remote");
     try {
       const info = await settingsApi.webdavSyncFetchRemoteInfo();
@@ -564,7 +680,7 @@ export function WebdavSyncSection({
       return;
     }
     setActionState("idle");
-  }, [dirty, t]);
+  }, [dirty, form.uploadModules, t]);
 
   /** Actually perform the upload after user confirms. */
   const handleUploadConfirm = useCallback(async () => {
@@ -593,6 +709,10 @@ export function WebdavSyncSection({
   const handleDownloadClick = useCallback(async () => {
     if (dirty) {
       toast.error(t("settings.webdavSync.unsavedChanges"));
+      return;
+    }
+    if (!hasEnabledModule(form.downloadModules)) {
+      toast.error(t("settings.webdavSync.noDownloadModules"));
       return;
     }
     setActionState("fetching_remote");
@@ -624,7 +744,7 @@ export function WebdavSyncSection({
     } finally {
       setActionState("idle");
     }
-  }, [dirty, t]);
+  }, [dirty, form.downloadModules, t]);
 
   /** Actually perform the download after user confirms. */
   const handleDownloadConfirm = useCallback(async () => {
@@ -933,6 +1053,17 @@ export function WebdavSyncSection({
   const hasS3SavedConfig = Boolean(
     s3Config?.bucket?.trim() && s3Config?.accessKeyId?.trim(),
   );
+  const hasUploadSelection = hasEnabledModule(form.uploadModules);
+  const hasDownloadSelection = hasEnabledModule(form.downloadModules);
+  const uploadModuleLabels = listModuleLabels(form.uploadModules, t);
+  const downloadModuleLabels = listModuleLabels(form.downloadModules, t);
+  const remoteAvailableModules = normalizeModules(
+    remoteInfo?.availableModules,
+    DEFAULT_DOWNLOAD_SYNC_MODULES,
+  );
+  const remoteAvailableModuleLabels = remoteInfo
+    ? listModuleLabels(remoteAvailableModules, t)
+    : [];
 
   const lastSyncAt = config?.status?.lastSyncAt;
   const lastSyncDisplay = lastSyncAt
@@ -941,7 +1072,7 @@ export function WebdavSyncSection({
   const lastError = config?.status?.lastError?.trim();
   const showAutoSyncError =
     !!lastError && config?.status?.lastErrorSource === "auto";
-  const currentRemotePath = `/${form.remoteRoot.trim() || "cc-switch-sync"}/v2/db-v6/${form.profile.trim() || "default"}`;
+  const currentRemotePath = `/${form.remoteRoot.trim() || "cc-switch-sync"}/v3/db-v6/${form.profile.trim() || "default"}`;
   const currentS3RemotePath = `${s3Bucket.trim() || "bucket"}/${s3RemoteRoot.trim() || "cc-switch-sync"}/v2/db-v6/${s3Profile.trim() || "default"}`;
   const remoteDbCompatDisplay = formatDbCompatVersion(
     remoteInfo?.dbCompatVersion,
@@ -1124,6 +1255,70 @@ export function WebdavSyncSection({
             </div>
           </div>
 
+          <div className="flex items-start gap-4">
+            <label className="w-40 text-xs font-medium text-foreground shrink-0">
+              {t("settings.webdavSync.uploadModulesTitle")}
+            </label>
+            <div className="grid flex-1 grid-cols-4 gap-2">
+              {MODULE_KEYS.map((key) => (
+                <label
+                  key={`upload-${key}`}
+                  className="flex items-center gap-2 rounded-md border border-border bg-background/70 px-3 py-2 text-xs"
+                >
+                  <Checkbox
+                    checked={form.uploadModules[key]}
+                    onCheckedChange={(checked) =>
+                      updateModuleSelection(
+                        "uploadModules",
+                        key,
+                        checked === true,
+                      )
+                    }
+                    disabled={isLoading}
+                  />
+                  <span>{t(`settings.webdavSync.modules.${key}`)}</span>
+                </label>
+              ))}
+              {!hasUploadSelection && (
+                <p className="col-span-4 text-xs text-destructive">
+                  {t("settings.webdavSync.noUploadModules")}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-start gap-4">
+            <label className="w-40 text-xs font-medium text-foreground shrink-0">
+              {t("settings.webdavSync.downloadModulesTitle")}
+            </label>
+            <div className="grid flex-1 grid-cols-4 gap-2">
+              {MODULE_KEYS.map((key) => (
+                <label
+                  key={`download-${key}`}
+                  className="flex items-center gap-2 rounded-md border border-border bg-background/70 px-3 py-2 text-xs"
+                >
+                  <Checkbox
+                    checked={form.downloadModules[key]}
+                    onCheckedChange={(checked) =>
+                      updateModuleSelection(
+                        "downloadModules",
+                        key,
+                        checked === true,
+                      )
+                    }
+                    disabled={isLoading}
+                  />
+                  <span>{t(`settings.webdavSync.modules.${key}`)}</span>
+                </label>
+              ))}
+              {!hasDownloadSelection && (
+                <p className="col-span-4 text-xs text-destructive">
+                  {t("settings.webdavSync.noDownloadModules")}
+                </p>
+              )}
+            </div>
+          </div>
+
           {/* Last sync time */}
           {lastSyncDisplay && (
             <p className="text-xs text-muted-foreground">
@@ -1188,7 +1383,7 @@ export function WebdavSyncSection({
               type="button"
               size="sm"
               onClick={handleUploadClick}
-              disabled={!hasSavedConfig}
+              disabled={!hasSavedConfig || !hasUploadSelection}
               actionState={actionState}
               targetState="uploading"
               alsoActiveFor={["fetching_remote"]}
@@ -1205,7 +1400,7 @@ export function WebdavSyncSection({
               variant="secondary"
               size="sm"
               onClick={handleDownloadClick}
-              disabled={!hasSavedConfig}
+              disabled={!hasSavedConfig || !hasDownloadSelection}
               actionState={actionState}
               targetState="downloading"
               alsoActiveFor={["fetching_remote"]}
@@ -1556,8 +1751,9 @@ export function WebdavSyncSection({
               <div className="space-y-3 text-sm leading-relaxed">
                 <p>{t("settings.webdavSync.confirmUpload.content")}</p>
                 <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
-                  <li>{t("settings.webdavSync.confirmUpload.dbItem")}</li>
-                  <li>{t("settings.webdavSync.confirmUpload.skillsItem")}</li>
+                  {uploadModuleLabels.map((label) => (
+                    <li key={label}>{label}</li>
+                  ))}
                 </ul>
                 <p className="text-muted-foreground">
                   {t("settings.webdavSync.confirmUpload.targetPath")}
@@ -1567,40 +1763,65 @@ export function WebdavSyncSection({
                   </code>
                 </p>
                 {remoteInfo && (
-                  <div className="rounded-lg border border-border bg-muted/50 p-3 space-y-2">
-                    <p className="text-xs font-medium text-foreground">
-                      {t("settings.webdavSync.confirmUpload.existingData")}
-                    </p>
-                    <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
-                      <dt className="font-medium text-foreground">
-                        {t("settings.webdavSync.confirmUpload.deviceName")}
-                      </dt>
-                      <dd>
-                        <code className="bg-muted px-1.5 py-0.5 rounded">
-                          {remoteInfo.deviceName}
-                        </code>
-                      </dd>
-                      <dt className="font-medium text-foreground">
-                        {t("settings.webdavSync.confirmUpload.createdAt")}
-                      </dt>
-                      <dd>{formatDate(remoteInfo.createdAt)}</dd>
-                      <dt className="font-medium text-foreground">
-                        {t("settings.webdavSync.confirmUpload.path")}
-                      </dt>
-                      <dd>
-                        <code className="bg-muted px-1.5 py-0.5 rounded">
-                          {remoteInfo.remotePath}
-                        </code>
-                      </dd>
-                      {remoteDbCompatDisplay && (
-                        <>
-                          <dt className="font-medium text-foreground">
-                            {t("settings.webdavSync.confirmUpload.dbCompat")}
-                          </dt>
-                          <dd>{remoteDbCompatDisplay}</dd>
-                        </>
-                      )}
-                    </dl>
+                  <div className="space-y-3">
+                    <div className="rounded-lg border border-cyan-300/70 bg-cyan-50/80 p-3 text-xs text-cyan-950 dark:border-cyan-500/40 dark:bg-cyan-950/30 dark:text-cyan-100">
+                      <p className="font-medium">
+                        {t(
+                          "settings.webdavSync.confirmUpload.availableModules",
+                        )}
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {remoteAvailableModuleLabels.length > 0 ? (
+                          remoteAvailableModuleLabels.map((label) => (
+                            <span
+                              key={label}
+                              className="rounded-full border border-cyan-300/70 bg-background/80 px-2.5 py-1 text-[11px] font-medium text-cyan-900 dark:border-cyan-400/40 dark:bg-cyan-900/40 dark:text-cyan-50"
+                            >
+                              {label}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="text-[11px] text-cyan-800/80 dark:text-cyan-100/80">
+                            -
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="rounded-lg border border-border bg-muted/50 p-3 space-y-2">
+                      <p className="text-xs font-medium text-foreground">
+                        {t("settings.webdavSync.confirmUpload.existingData")}
+                      </p>
+                      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+                        <dt className="font-medium text-foreground">
+                          {t("settings.webdavSync.confirmUpload.deviceName")}
+                        </dt>
+                        <dd>
+                          <code className="bg-muted px-1.5 py-0.5 rounded">
+                            {remoteInfo.deviceName}
+                          </code>
+                        </dd>
+                        <dt className="font-medium text-foreground">
+                          {t("settings.webdavSync.confirmUpload.createdAt")}
+                        </dt>
+                        <dd>{formatDate(remoteInfo.createdAt)}</dd>
+                        <dt className="font-medium text-foreground">
+                          {t("settings.webdavSync.confirmUpload.path")}
+                        </dt>
+                        <dd>
+                          <code className="bg-muted px-1.5 py-0.5 rounded">
+                            {remoteInfo.remotePath}
+                          </code>
+                        </dd>
+                        {remoteDbCompatDisplay && (
+                          <>
+                            <dt className="font-medium text-foreground">
+                              {t("settings.webdavSync.confirmUpload.dbCompat")}
+                            </dt>
+                            <dd>{remoteDbCompatDisplay}</dd>
+                          </>
+                        )}
+                      </dl>
+                    </div>
                   </div>
                 )}
                 {remoteInfo && !remoteIsLegacy && (
@@ -1643,40 +1864,71 @@ export function WebdavSyncSection({
             <DialogDescription asChild>
               <div className="space-y-3 text-sm leading-relaxed">
                 {remoteInfo && (
-                  <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-muted-foreground">
-                    <dt className="font-medium text-foreground">
-                      {t("settings.webdavSync.confirmDownload.deviceName")}
-                    </dt>
-                    <dd>
-                      <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                        {remoteInfo.deviceName}
-                      </code>
-                    </dd>
-                    <dt className="font-medium text-foreground">
-                      {t("settings.webdavSync.confirmDownload.createdAt")}
-                    </dt>
-                    <dd>{formatDate(remoteInfo.createdAt)}</dd>
-                    <dt className="font-medium text-foreground">
-                      {t("settings.webdavSync.confirmDownload.path")}
-                    </dt>
-                    <dd>
-                      <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                        {remoteInfo.remotePath}
-                      </code>
-                    </dd>
-                    {remoteDbCompatDisplay && (
-                      <>
-                        <dt className="font-medium text-foreground">
-                          {t("settings.webdavSync.confirmDownload.dbCompat")}
-                        </dt>
-                        <dd>{remoteDbCompatDisplay}</dd>
-                      </>
-                    )}
-                    <dt className="font-medium text-foreground">
-                      {t("settings.webdavSync.confirmDownload.artifacts")}
-                    </dt>
-                    <dd>{remoteInfo.artifacts.join(", ")}</dd>
-                  </dl>
+                  <div className="space-y-3">
+                    <div className="rounded-lg border border-cyan-300/70 bg-cyan-50/80 p-3 text-xs text-cyan-950 dark:border-cyan-500/40 dark:bg-cyan-950/30 dark:text-cyan-100">
+                      <p className="font-medium">
+                        {t(
+                          "settings.webdavSync.confirmDownload.availableModules",
+                        )}
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {remoteAvailableModuleLabels.length > 0 ? (
+                          remoteAvailableModuleLabels.map((label) => (
+                            <span
+                              key={label}
+                              className="rounded-full border border-cyan-300/70 bg-background/80 px-2.5 py-1 text-[11px] font-medium text-cyan-900 dark:border-cyan-400/40 dark:bg-cyan-900/40 dark:text-cyan-50"
+                            >
+                              {label}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="text-[11px] text-cyan-800/80 dark:text-cyan-100/80">
+                            -
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-muted-foreground">
+                      <dt className="font-medium text-foreground">
+                        {t("settings.webdavSync.confirmDownload.deviceName")}
+                      </dt>
+                      <dd>
+                        <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                          {remoteInfo.deviceName}
+                        </code>
+                      </dd>
+                      <dt className="font-medium text-foreground">
+                        {t("settings.webdavSync.confirmDownload.createdAt")}
+                      </dt>
+                      <dd>{formatDate(remoteInfo.createdAt)}</dd>
+                      <dt className="font-medium text-foreground">
+                        {t("settings.webdavSync.confirmDownload.path")}
+                      </dt>
+                      <dd>
+                        <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                          {remoteInfo.remotePath}
+                        </code>
+                      </dd>
+                      {remoteDbCompatDisplay && (
+                        <>
+                          <dt className="font-medium text-foreground">
+                            {t("settings.webdavSync.confirmDownload.dbCompat")}
+                          </dt>
+                          <dd>{remoteDbCompatDisplay}</dd>
+                        </>
+                      )}
+                      <dt className="font-medium text-foreground">
+                        {t("settings.webdavSync.confirmDownload.artifacts")}
+                      </dt>
+                      <dd>{remoteInfo.artifacts.join(", ")}</dd>
+                      <dt className="font-medium text-foreground">
+                        {t(
+                          "settings.webdavSync.confirmDownload.selectedModules",
+                        )}
+                      </dt>
+                      <dd>{downloadModuleLabels.join(", ")}</dd>
+                    </dl>
+                  </div>
                 )}
                 {remoteInfo?.layout === "legacy" && (
                   <p className="font-medium text-amber-600 dark:text-amber-400">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -479,7 +479,7 @@
     },
     "webdavSync": {
       "title": "WebDAV Cloud Sync",
-      "description": "Sync database and skill configurations across devices via WebDAV.",
+      "description": "Sync selected modules across devices via WebDAV.",
       "baseUrl": "WebDAV Server URL",
       "baseUrlPlaceholder": "https://dav.example.com/dav/",
       "username": "WebDAV Account",
@@ -522,10 +522,20 @@
       },
       "remoteRootDefault": "Default: cc-switch-sync",
       "profileDefault": "Default: default",
+      "uploadModulesTitle": "Default upload modules",
+      "downloadModulesTitle": "Default download modules",
+      "noUploadModules": "Select at least one upload module",
+      "noDownloadModules": "Select at least one download module",
+      "modules": {
+        "api": "API providers",
+        "mcp": "MCP",
+        "prompts": "Prompts",
+        "skills": "Skills"
+      },
       "saveAndTestSuccess": "Config saved, connection OK",
       "saveAndTestFailed": "Config saved, but connection test failed: {{error}}",
       "noRemoteData": "No sync data found on the remote server",
-      "incompatibleVersion": "Remote data is incompatible (protocol v{{protocolVersion}}, database {{dbCompatVersion}}). This client supports protocol v2 / db-v6.",
+      "incompatibleVersion": "Remote data is incompatible (protocol v{{protocolVersion}}, database {{dbCompatVersion}}). This client supports protocol v3 / db-v6.",
       "unsaved": "Unsaved",
       "saved": "Saved",
       "unsavedChanges": "Please save config first",
@@ -539,7 +549,9 @@
         "path": "Remote path",
         "dbCompat": "DB compatibility",
         "artifacts": "Contents",
-        "legacyNotice": "A legacy remote path was detected. After restoring, the next upload will write to the new v2/db-v6 path.",
+        "selectedModules": "Selected modules",
+        "availableModules": "Remote available modules",
+        "legacyNotice": "A legacy remote path was detected. After restoring, the next upload will write to the new v3/db-v6 path.",
         "warning": "This will overwrite all local data and skill configurations",
         "confirm": "Confirm Restore"
       },
@@ -554,8 +566,9 @@
         "createdAt": "Uploaded at",
         "path": "Remote path",
         "dbCompat": "DB compatibility",
+        "availableModules": "Remote available modules",
         "warning": "This will overwrite existing sync data on the remote server",
-        "legacyNotice": "Legacy remote data was detected. This upload will write to the new v2/db-v6 path and will not overwrite the legacy path.",
+        "legacyNotice": "Legacy remote data was detected. This upload will write to the new v3/db-v6 path and will not overwrite the legacy path.",
         "confirm": "Confirm Upload"
       }
     },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -479,7 +479,7 @@
     },
     "webdavSync": {
       "title": "WebDAV クラウド同期",
-      "description": "WebDAV を使ってデバイス間でデータベースとスキル設定を同期します。",
+      "description": "WebDAV を使って選択したモジュールをデバイス間で同期します。",
       "baseUrl": "WebDAV サーバー URL",
       "baseUrlPlaceholder": "https://example.com/remote.php/dav/files/user",
       "username": "ユーザー名",
@@ -522,10 +522,20 @@
       },
       "remoteRootDefault": "デフォルト: cc-switch-sync",
       "profileDefault": "デフォルト: default",
+      "uploadModulesTitle": "アップロード既定モジュール",
+      "downloadModulesTitle": "ダウンロード既定モジュール",
+      "noUploadModules": "少なくとも1つのアップロードモジュールを選択してください",
+      "noDownloadModules": "少なくとも1つのダウンロードモジュールを選択してください",
+      "modules": {
+        "api": "API プロバイダー",
+        "mcp": "MCP",
+        "prompts": "プロンプト",
+        "skills": "Skills"
+      },
       "saveAndTestSuccess": "設定を保存しました。接続正常です",
       "saveAndTestFailed": "設定を保存しましたが、接続テストに失敗しました：{{error}}",
       "noRemoteData": "クラウドに同期データが見つかりません",
-      "incompatibleVersion": "リモートデータに互換性がありません（プロトコル v{{protocolVersion}}、データベース {{dbCompatVersion}}）。このクライアントは protocol v2 / db-v6 をサポートしています。",
+      "incompatibleVersion": "リモートデータに互換性がありません（プロトコル v{{protocolVersion}}、データベース {{dbCompatVersion}}）。このクライアントは protocol v3 / db-v6 をサポートしています。",
       "unsaved": "未保存",
       "saved": "保存済み",
       "unsavedChanges": "先に設定を保存してください",
@@ -539,7 +549,9 @@
         "path": "リモートパス",
         "dbCompat": "DB 互換レイヤー",
         "artifacts": "内容",
-        "legacyNotice": "旧レイアウトのリモートパスを検出しました。復元後、次回のアップロードは新しい v2/db-v6 パスに書き込まれます。",
+        "selectedModules": "今回のダウンロード対象",
+        "availableModules": "リモートで利用可能なモジュール",
+        "legacyNotice": "旧レイアウトのリモートパスを検出しました。復元後、次回のアップロードは新しい v3/db-v6 パスに書き込まれます。",
         "warning": "ローカルのすべてのデータとスキル設定が上書きされます",
         "confirm": "復元を実行"
       },
@@ -554,8 +566,9 @@
         "createdAt": "アップロード日時",
         "path": "リモートパス",
         "dbCompat": "DB 互換レイヤー",
+        "availableModules": "リモートで利用可能なモジュール",
         "warning": "リモートの既存同期データが上書きされます",
-        "legacyNotice": "旧レイアウトのリモートデータを検出しました。今回のアップロードは新しい v2/db-v6 パスに書き込み、旧パスは上書きしません。",
+        "legacyNotice": "旧レイアウトのリモートデータを検出しました。今回のアップロードは新しい v3/db-v6 パスに書き込み、旧パスは上書きしません。",
         "confirm": "アップロードを実行"
       }
     },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -479,7 +479,7 @@
     },
     "webdavSync": {
       "title": "WebDAV 云同步",
-      "description": "通过 WebDAV 在多设备间同步数据库和技能配置。",
+      "description": "通过 WebDAV 在多设备间同步选定模块。",
       "baseUrl": "WebDAV 服务器地址",
       "baseUrlPlaceholder": "https://dav.jianguoyun.com/dav/",
       "username": "WebDAV 账户",
@@ -522,10 +522,20 @@
       },
       "remoteRootDefault": "默认: cc-switch-sync",
       "profileDefault": "默认: default",
+      "uploadModulesTitle": "上传默认同步模块",
+      "downloadModulesTitle": "下载默认同步模块",
+      "noUploadModules": "请至少选择一个上传模块",
+      "noDownloadModules": "请至少选择一个下载模块",
+      "modules": {
+        "api": "API 供应商",
+        "mcp": "MCP",
+        "prompts": "提示词",
+        "skills": "Skills"
+      },
       "saveAndTestSuccess": "配置已保存，连接正常",
       "saveAndTestFailed": "配置已保存，但连接测试失败：{{error}}",
       "noRemoteData": "云端没有找到同步数据",
-      "incompatibleVersion": "远端数据版本不兼容（协议 v{{protocolVersion}}，数据库 {{dbCompatVersion}}），当前支持协议 v2 / db-v6",
+      "incompatibleVersion": "远端数据版本不兼容（协议 v{{protocolVersion}}，数据库 {{dbCompatVersion}}），当前支持协议 v3 / db-v6",
       "unsaved": "未保存",
       "saved": "已保存",
       "unsavedChanges": "请先保存配置",
@@ -539,7 +549,9 @@
         "path": "远端路径",
         "dbCompat": "数据库兼容层",
         "artifacts": "包含内容",
-        "legacyNotice": "检测到旧版云端路径。恢复完成后，下次上传将写入新路径 v2/db-v6。",
+        "selectedModules": "本次下载模块",
+        "availableModules": "远端可用模块",
+        "legacyNotice": "检测到旧版云端路径。恢复完成后，下次上传将写入新路径 v3/db-v6。",
         "warning": "恢复将覆盖本地所有数据和技能配置",
         "confirm": "确认恢复"
       },
@@ -554,8 +566,9 @@
         "createdAt": "上传时间",
         "path": "远端路径",
         "dbCompat": "数据库兼容层",
+        "availableModules": "远端可用模块",
         "warning": "将覆盖云端已有的同步数据",
-        "legacyNotice": "检测到旧版云端路径数据。本次上传将写入新路径 v2/db-v6，不会覆盖旧路径。",
+        "legacyNotice": "检测到旧版云端路径数据。本次上传将写入新路径 v3/db-v6，不会覆盖旧路径。",
         "confirm": "确认上传"
       }
     },

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -7,6 +7,15 @@ const directorySchema = z
   .optional()
   .or(z.literal(""));
 
+const webdavModulesSchema = z
+  .object({
+    api: z.boolean().optional(),
+    mcp: z.boolean().optional(),
+    prompts: z.boolean().optional(),
+    skills: z.boolean().optional(),
+  })
+  .partial();
+
 export const settingsSchema = z.object({
   // 设备级 UI 设置
   showInTray: z.boolean(),
@@ -46,6 +55,8 @@ export const settingsSchema = z.object({
       password: z.string().optional(),
       remoteRoot: z.string().trim().optional().or(z.literal("")),
       profile: z.string().trim().optional().or(z.literal("")),
+      uploadModules: webdavModulesSchema.optional(),
+      downloadModules: webdavModulesSchema.optional(),
       status: z
         .object({
           lastSyncAt: z.number().nullable().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,6 +280,13 @@ export interface WebDavSyncStatus {
 }
 
 // WebDAV 同步配置
+export interface WebDavSyncModules {
+  api: boolean;
+  mcp: boolean;
+  prompts: boolean;
+  skills: boolean;
+}
+
 export interface WebDavSyncSettings {
   enabled?: boolean;
   autoSync?: boolean;
@@ -288,6 +295,8 @@ export interface WebDavSyncSettings {
   password?: string;
   remoteRoot?: string;
   profile?: string;
+  uploadModules?: WebDavSyncModules;
+  downloadModules?: WebDavSyncModules;
   status?: WebDavSyncStatus;
 }
 
@@ -319,6 +328,7 @@ export interface RemoteSnapshotInfo {
   artifacts: string[];
   layout: RemoteSnapshotLayout;
   remotePath: string;
+  availableModules: WebDavSyncModules;
 }
 
 // 应用设置类型（用于设置对话框与 Tauri API）

--- a/tests/components/WebdavSyncSection.test.tsx
+++ b/tests/components/WebdavSyncSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -38,6 +38,18 @@ vi.mock("@/components/ui/switch", () => ({
   Switch: ({ checked, onCheckedChange, ...props }: any) => (
     <button
       role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange?.(!checked)}
+      {...props}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({ checked, onCheckedChange, ...props }: any) => (
+    <button
+      type="button"
+      role="checkbox"
       aria-checked={checked}
       onClick={() => onCheckedChange?.(!checked)}
       {...props}
@@ -94,6 +106,18 @@ const baseConfig: WebDavSyncSettings = {
   remoteRoot: "cc-switch-sync",
   profile: "default",
   autoSync: false,
+  uploadModules: {
+    api: true,
+    mcp: false,
+    prompts: false,
+    skills: false,
+  },
+  downloadModules: {
+    api: true,
+    mcp: true,
+    prompts: true,
+    skills: true,
+  },
   status: {},
 };
 
@@ -110,6 +134,12 @@ function renderSection(config?: WebDavSyncSettings) {
     </QueryClientProvider>,
   );
   return { ...view, client };
+}
+
+function getModuleGroups(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll("div.grid.flex-1.grid-cols-4.gap-2"),
+  );
 }
 
 describe("WebdavSyncSection", () => {
@@ -133,9 +163,19 @@ describe("WebdavSyncSection", () => {
       deviceName: "My MacBook",
       createdAt: "2026-02-01T10:00:00Z",
       snapshotId: "snapshot-1",
-      version: 2,
+      version: 3,
+      protocolVersion: 3,
+      dbCompatVersion: 6,
       compatible: true,
-      artifacts: ["db.sql", "skills.zip"],
+      artifacts: ["api.sql", "mcp.sql", "prompts.sql", "skills.sql", "skills.zip"],
+      layout: "current",
+      remotePath: "/cc-switch-sync/v3/db-v6/default",
+      availableModules: {
+        api: true,
+        mcp: true,
+        prompts: true,
+        skills: true,
+      },
     });
     settingsApiMock.webdavSyncUpload.mockResolvedValue({ status: "uploaded" });
     settingsApiMock.webdavSyncDownload.mockResolvedValue({ status: "downloaded" });
@@ -191,6 +231,132 @@ describe("WebdavSyncSection", () => {
 
     expect(toastErrorMock).toHaveBeenCalledWith("settings.webdavSync.missingUrl");
     expect(settingsApiMock.webdavSyncSaveSettings).not.toHaveBeenCalled();
+  });
+
+  it("renders upload and download module groups in a single four-column row", () => {
+    const { container } = renderSection(baseConfig);
+
+    const groups = Array.from(
+      container.querySelectorAll("div.grid.flex-1.gap-2"),
+    );
+
+    expect(groups).toHaveLength(2);
+    for (const group of groups) {
+      expect(group).toHaveClass("grid-cols-4");
+      expect(group).not.toHaveClass("sm:grid-cols-2");
+    }
+  });
+
+  it("uses backend-aligned defaults when upload/download module objects are missing", () => {
+    const { container } = renderSection({
+      ...baseConfig,
+      uploadModules: undefined,
+      downloadModules: undefined,
+    });
+
+    const groups = getModuleGroups(container);
+    expect(groups).toHaveLength(2);
+
+    const uploadGroup = within(groups[0] as HTMLElement);
+    const downloadGroup = within(groups[1] as HTMLElement);
+    const uploadApi = uploadGroup.getByRole("checkbox", {
+      name: "settings.webdavSync.modules.api",
+    });
+    const uploadMcp = uploadGroup.getByRole("checkbox", {
+      name: "settings.webdavSync.modules.mcp",
+    });
+    const uploadPrompts = uploadGroup.getByRole("checkbox", {
+      name: "settings.webdavSync.modules.prompts",
+    });
+    const uploadSkills = uploadGroup.getByRole("checkbox", {
+      name: "settings.webdavSync.modules.skills",
+    });
+
+    expect(uploadApi).toHaveAttribute("aria-checked", "true");
+    expect(uploadMcp).toHaveAttribute("aria-checked", "false");
+    expect(uploadPrompts).toHaveAttribute("aria-checked", "false");
+    expect(uploadSkills).toHaveAttribute("aria-checked", "false");
+
+    expect(
+      downloadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.api",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      downloadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.mcp",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      downloadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.prompts",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      downloadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.skills",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("fills missing module fields as enabled when a legacy module object is partially present", () => {
+    const legacyConfig = {
+      ...baseConfig,
+      uploadModules: { api: false } as unknown as WebDavSyncSettings["uploadModules"],
+      downloadModules: {
+        api: true,
+        mcp: false,
+      } as unknown as WebDavSyncSettings["downloadModules"],
+    };
+    const { container } = renderSection(legacyConfig);
+
+    const groups = getModuleGroups(container);
+    expect(groups).toHaveLength(2);
+
+    const uploadGroup = within(groups[0] as HTMLElement);
+    const downloadGroup = within(groups[1] as HTMLElement);
+
+    expect(
+      uploadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.api",
+      }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      uploadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.mcp",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      uploadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.prompts",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      uploadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.skills",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+
+    expect(
+      downloadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.api",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      downloadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.mcp",
+      }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      downloadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.prompts",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      downloadGroup.getByRole("checkbox", {
+        name: "settings.webdavSync.modules.skills",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
   });
 
   it("saves settings and auto tests connection", async () => {
@@ -396,6 +562,9 @@ describe("WebdavSyncSection", () => {
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
     });
+    expect(
+      screen.getByText("settings.webdavSync.confirmUpload.availableModules"),
+    ).toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("button", {

--- a/tests/lib/settingsSchema.test.ts
+++ b/tests/lib/settingsSchema.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { settingsSchema } from "@/lib/schemas/settings";
+
+describe("settingsSchema webdav legacy module parsing", () => {
+  it("accepts partially present legacy module objects", () => {
+    const parsed = settingsSchema.parse({
+      showInTray: true,
+      minimizeToTrayOnClose: true,
+      webdavSync: {
+        uploadModules: {
+          api: false,
+        },
+        downloadModules: {
+          api: true,
+          mcp: false,
+        },
+      },
+    });
+
+    expect(parsed.webdavSync?.uploadModules).toEqual({ api: false });
+    expect(parsed.webdavSync?.downloadModules).toEqual({
+      api: true,
+      mcp: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary / 概述

This PR implements issue #1761 by adding module-scoped WebDAV sync, so upload and download can be performed selectively instead of always syncing the full snapshot.

Changes included:
- add per-module WebDAV upload/download selection for `API`, `MCP`, `Prompts`, and `Skills`
- persist separate upload/download module settings in the WebDAV settings flow
- show selected modules and remote available modules in the sync confirmation flow
- keep partial sync isolated to selected modules only:
  - non-selected local modules are not overwritten during download
  - non-selected remote modules are not overwritten during upload
- add compatibility/safety handling required for modular sync, including selective import backup coverage and legacy/default handling for module settings

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->
Fixes #1761

## Screenshots / 截图


<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| <img width="418" height="445" alt="ui-ccswitch-old" src="https://github.com/user-attachments/assets/fb4b47c6-a5fc-45f3-b572-ae0c0b54db70" />  | <img width="399" height="535" alt="ui" src="https://github.com/user-attachments/assets/bf4b22a9-7ba6-4fa1-a9b8-b5c72565b04d" />  |
|  <img width="1147" height="451" alt="ui-old" src="https://github.com/user-attachments/assets/f108fb9f-27c7-4bf5-8042-4ac94f228673" />   |  <img width="1341" height="443" alt="ui-ccswitch" src="https://github.com/user-attachments/assets/7e95dd8a-0f5c-4c17-8822-86b8e0c13f88" />    |

## Testing / 测试

Manual verification completed with real WebDAV sync flows:
- upload all modules, download all modules
- upload partial modules, download partial modules
- upload selected modules to overwrite only part of the remote snapshot
- download selected modules to overwrite only part of the local snapshot
- download non-conflicting partial modules while unrelated local modules remain unchanged
  - example: local `api` changed, download `mcp`, local `api` is not overwritten
- upload non-conflicting partial modules while unrelated remote modules remain unchanged
  - example: local `api` changed, upload `mcp`, remote `api` is not modified
- additional partial overwrite / non-conflicting combinations across `API`, `MCP`, `Prompts`, and `Skills`

Automated verification:
- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --check`
- `cargo clippy`
- `cargo test`
- targeted WebDAV frontend/backend regression tests for module defaults, selective import safety backup, and module-aware sync coverage


## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
