### PR TITLE
feat(codex): add github copilot provider preset

### DIFF
--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -144,6 +144,14 @@ impl CodexAdapter {
         Self
     }
 
+    fn is_github_copilot(provider: &Provider) -> bool {
+        provider
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.provider_type.as_deref())
+            == Some("github_copilot")
+    }
+
     /// 检测是否为官方 Codex 客户端
     ///
     /// 匹配 User-Agent 模式: `^(codex_vscode|codex_cli_rs)/[\d.]+`
@@ -252,6 +260,10 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn extract_auth(&self, provider: &Provider) -> Option<AuthInfo> {
+        if Self::is_github_copilot(provider) {
+            return Some(AuthInfo::new("", AuthStrategy::GitHubCopilot));
+        }
+
         self.extract_key(provider)
             .map(|key| AuthInfo::new(key, AuthStrategy::Bearer))
     }
@@ -351,6 +363,23 @@ mod tests {
         let auth = adapter.extract_auth(&provider).unwrap();
         assert_eq!(auth.api_key, "sk-test-key-12345678");
         assert_eq!(auth.strategy, AuthStrategy::Bearer);
+    }
+
+    #[test]
+    fn test_extract_auth_uses_github_copilot_strategy_for_managed_provider() {
+        let adapter = CodexAdapter::new();
+        let mut provider = create_provider(json!({
+            "auth": {
+                "OPENAI_API_KEY": ""
+            }
+        }));
+        provider.meta = Some(crate::provider::ProviderMeta {
+            provider_type: Some("github_copilot".to_string()),
+            ..Default::default()
+        });
+
+        let auth = adapter.extract_auth(&provider).unwrap();
+        assert_eq!(auth.strategy, AuthStrategy::GitHubCopilot);
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -57,7 +57,7 @@ mod tests {
     use super::*;
     use crate::config::{get_claude_settings_path, read_json_file, write_json_file};
     use crate::database::Database;
-    use crate::provider::ProviderMeta;
+    use crate::provider::{AuthBinding, AuthBindingSource, ProviderMeta};
     use crate::proxy::types::ProxyConfig;
     use crate::store::AppState;
     use serde_json::json;
@@ -348,6 +348,149 @@ base_url = "http://localhost:8080"
         assert!(
             extracted.contains("http://localhost:8080"),
             "should keep mcp_servers.* base_url"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn switching_codex_copilot_provider_enables_proxy_takeover() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+        let proxy_port = listener.local_addr().expect("local address").port();
+        drop(listener);
+        db.update_proxy_config(ProxyConfig {
+            listen_port: proxy_port,
+            ..Default::default()
+        })
+        .await
+        .expect("use ephemeral proxy port");
+
+        let normal = Provider::with_id(
+            "normal".into(),
+            "Normal".into(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "normal-token"
+                },
+                "config": r#"model_provider = "normal"
+model = "gpt-5.4-codex"
+
+[model_providers.normal]
+name = "Normal"
+base_url = "https://normal.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+            }),
+            None,
+        );
+        let mut copilot = Provider::with_id(
+            "copilot".into(),
+            "GitHub Copilot".into(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": ""
+                },
+                "config": r#"model_provider = "github-copilot"
+model = "gpt-5.4-codex"
+
+[model_providers.github-copilot]
+name = "GitHub Copilot"
+base_url = "https://api.githubcopilot.com"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+            }),
+            None,
+        );
+        copilot.meta = Some(ProviderMeta {
+            provider_type: Some("github_copilot".to_string()),
+            auth_binding: Some(AuthBinding {
+                source: AuthBindingSource::ManagedAccount,
+                auth_provider: Some("github_copilot".to_string()),
+                account_id: Some("account-1".to_string()),
+            }),
+            ..ProviderMeta::default()
+        });
+
+        db.save_provider("codex", &normal).expect("save normal");
+        db.save_provider("codex", &copilot).expect("save copilot");
+        db.set_current_provider("codex", "normal")
+            .expect("set db current");
+        crate::settings::set_current_provider(&AppType::Codex, Some("normal"))
+            .expect("set local current");
+
+        crate::codex_config::write_codex_live_atomic(
+            normal
+                .settings_config
+                .get("auth")
+                .expect("normal auth exists"),
+            normal
+                .settings_config
+                .get("config")
+                .and_then(|value| value.as_str()),
+        )
+        .expect("seed codex live config");
+
+        ProviderService::switch(&state, AppType::Codex, "copilot")
+            .expect("switch to codex copilot");
+
+        assert_eq!(
+            crate::settings::get_current_provider(&AppType::Codex).as_deref(),
+            Some("copilot")
+        );
+        assert_eq!(
+            db.get_current_provider("codex")
+                .expect("get db current")
+                .as_deref(),
+            Some("copilot")
+        );
+        assert!(
+            db.get_proxy_config_for_app("codex")
+                .await
+                .expect("get codex proxy config")
+                .enabled,
+            "Codex proxy takeover should be enabled for GitHub Copilot"
+        );
+
+        let live_auth: Value =
+            crate::config::read_json_file(&crate::codex_config::get_codex_auth_path())
+                .expect("read codex auth");
+        assert_eq!(
+            live_auth
+                .get("OPENAI_API_KEY")
+                .and_then(|value| value.as_str()),
+            Some("PROXY_MANAGED")
+        );
+
+        let live_config = crate::codex_config::read_codex_config_text().expect("read codex config");
+        assert!(
+            live_config.contains(&format!("http://127.0.0.1:{proxy_port}/v1")),
+            "Codex live config should point at the local proxy"
+        );
+        assert!(
+            !live_config.contains("https://api.githubcopilot.com"),
+            "Copilot upstream should stay behind the proxy, not in Codex live config"
+        );
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("get codex backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup");
+        assert_eq!(
+            backup_value
+                .get("auth")
+                .and_then(|auth| auth.get("OPENAI_API_KEY"))
+                .and_then(|value| value.as_str()),
+            Some("normal-token"),
+            "the original live config should remain restorable"
         );
     }
 
@@ -1431,6 +1574,10 @@ impl ProviderService {
             return Self::switch_normal(state, app_type, id, &providers);
         }
 
+        if matches!(app_type, AppType::Codex) && _provider.is_github_copilot() {
+            return Self::switch_codex_managed_proxy_provider(state, id, &providers);
+        }
+
         // Check if proxy takeover mode is active AND proxy server is actually running
         // Both conditions must be true to use hot-switch mode
         // Use blocking wait since this is a sync function
@@ -1479,6 +1626,58 @@ impl ProviderService {
 
         // Normal mode: full switch with Live config write
         Self::switch_normal(state, app_type, id, &providers)
+    }
+
+    fn switch_codex_managed_proxy_provider(
+        state: &AppState,
+        id: &str,
+        providers: &indexmap::IndexMap<String, Provider>,
+    ) -> Result<SwitchResult, AppError> {
+        let app_type = AppType::Codex;
+        let provider = providers
+            .get(id)
+            .ok_or_else(|| AppError::Message(format!("供应商 {id} 不存在")))?;
+        let mut result = SwitchResult::default();
+
+        let current_id = crate::settings::get_effective_current_provider(&state.db, &app_type)?;
+        if let Some(current_id) = current_id {
+            if current_id != id {
+                if let Ok(live_config) = read_live_settings(app_type.clone()) {
+                    if let Some(mut current_provider) = providers.get(&current_id).cloned() {
+                        current_provider.settings_config = strip_common_config_from_live_settings(
+                            state.db.as_ref(),
+                            &app_type,
+                            &current_provider,
+                            live_config,
+                        );
+                        if let Err(e) = state.db.save_provider(app_type.as_str(), &current_provider)
+                        {
+                            log::warn!("Backfill failed: {e}");
+                            result
+                                .warnings
+                                .push(format!("backfill_failed:{current_id}"));
+                        }
+                    }
+                }
+            }
+        }
+
+        futures::executor::block_on(state.proxy_service.ensure_takeover_for_app(&app_type))
+            .map_err(|e| AppError::Message(format!("启用 Codex 本地代理接管失败: {e}")))?;
+
+        crate::settings::set_current_provider(&app_type, Some(id))?;
+        state.db.set_current_provider(app_type.as_str(), id)?;
+
+        futures::executor::block_on(
+            state
+                .proxy_service
+                .hot_switch_provider(app_type.as_str(), &provider.id),
+        )
+        .map_err(|e| AppError::Message(format!("切换 Codex 代理目标失败: {e}")))?;
+
+        McpService::sync_all_enabled(state)?;
+
+        Ok(result)
     }
 
     /// Normal switch flow (non-proxy mode)

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1179,6 +1179,60 @@ impl ProxyService {
         Ok(())
     }
 
+    /// Ensure a single app is routed through the local proxy.
+    ///
+    /// This is used when selecting providers that cannot be written directly to
+    /// the client live config, such as Codex GitHub Copilot. The live config is
+    /// backed up once, the selected provider is saved as the current logical
+    /// target, and the client file is rewritten to the local proxy endpoint.
+    pub async fn ensure_takeover_for_app(&self, app_type: &AppType) -> Result<(), String> {
+        let app_type_str = app_type.as_str();
+
+        if !self.is_running().await {
+            self.start().await?;
+        }
+
+        let has_backup = self
+            .db
+            .get_live_backup(app_type_str)
+            .await
+            .map_err(|e| format!("读取 {app_type_str} 备份失败: {e}"))?
+            .is_some();
+        let live_taken_over = self.detect_takeover_in_live_config_for_app(app_type);
+
+        if !has_backup {
+            self.backup_live_config_strict(app_type).await?;
+            if let Err(e) = self.sync_live_to_provider(app_type).await {
+                let _ = self.db.delete_live_backup(app_type_str).await;
+                return Err(e);
+            }
+        }
+
+        if !live_taken_over {
+            if let Err(e) = self.takeover_live_config_strict(app_type).await {
+                if !has_backup {
+                    let _ = self.restore_live_config_for_app(app_type).await;
+                    let _ = self.db.delete_live_backup(app_type_str).await;
+                }
+                return Err(e);
+            }
+        }
+
+        let mut updated_config = self
+            .db
+            .get_proxy_config_for_app(app_type_str)
+            .await
+            .map_err(|e| format!("获取 {app_type_str} 配置失败: {e}"))?;
+        updated_config.enabled = true;
+        self.db
+            .update_proxy_config_for_app(updated_config)
+            .await
+            .map_err(|e| format!("设置 {app_type_str} enabled 状态失败: {e}"))?;
+        let _ = self.db.set_live_takeover_active(true).await;
+
+        Ok(())
+    }
+
     /// 接管指定应用的 Live 配置（尽力而为：配置不存在/读取失败则跳过）
     async fn takeover_live_config_best_effort(&self, app_type: &AppType) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
@@ -1741,10 +1795,18 @@ impl ProxyService {
         crate::settings::set_current_provider(&app_type_enum, Some(provider_id))
             .map_err(|e| format!("更新本地当前供应商失败: {e}"))?;
 
-        if should_sync_backup {
+        if should_sync_backup && !provider.uses_managed_account_auth() {
             self.update_live_backup_from_provider_inner(app_type, &provider)
                 .await?;
+        } else if should_sync_backup {
+            log::info!(
+                "跳过 {} managed-account provider '{}' 的 Live 备份覆盖",
+                app_type,
+                provider.id
+            );
+        }
 
+        if should_sync_backup {
             if matches!(app_type_enum, AppType::Claude) {
                 self.sync_claude_live_from_provider_while_proxy_active(&provider)
                     .await?;

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -184,11 +184,13 @@ export function ProviderCard({
 
   const usageEnabled = provider.meta?.usage_script?.enabled ?? false;
   const isOfficial = isOfficialProvider(provider, appId);
-  const isOfficialBlockedByProxy =
-    isProxyTakeover && (provider.category === "official" || isOfficial);
   const isCopilot =
     provider.meta?.providerType === PROVIDER_TYPES.GITHUB_COPILOT ||
     provider.meta?.usage_script?.templateType === "github_copilot";
+  const isOfficialBlockedByProxy =
+    isProxyTakeover &&
+    !isCopilot &&
+    (provider.category === "official" || isOfficial);
   // Hermes v12+ overlay entries live under the `providers:` dict and are
   // read-only here — writes have to go through Hermes Web UI.
   const isHermesReadOnly =

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { FormLabel } from "@/components/ui/form";
@@ -13,6 +13,12 @@ import { toast } from "sonner";
 import { Download, Loader2 } from "lucide-react";
 import EndpointSpeedTest from "./EndpointSpeedTest";
 import { ApiKeySection, EndpointField, ModelInputWithFetch } from "./shared";
+import { CopilotAuthSection } from "./CopilotAuthSection";
+import {
+  copilotGetModels,
+  copilotGetModelsForAccount,
+  type CopilotModel,
+} from "@/lib/api/copilot";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -34,6 +40,10 @@ interface CodexFormFieldsProps {
   websiteUrl: string;
   isPartner?: boolean;
   partnerPromotionKey?: string;
+  isCopilotPreset?: boolean;
+  usesOAuth?: boolean;
+  selectedGitHubAccountId?: string | null;
+  onGitHubAccountSelect?: (accountId: string | null) => void;
 
   // Base URL
   shouldShowSpeedTest: boolean;
@@ -69,6 +79,10 @@ export function CodexFormFields({
   websiteUrl,
   isPartner,
   partnerPromotionKey,
+  isCopilotPreset,
+  usesOAuth,
+  selectedGitHubAccountId,
+  onGitHubAccountSelect,
   shouldShowSpeedTest,
   codexBaseUrl,
   onBaseUrlChange,
@@ -90,8 +104,56 @@ export function CodexFormFields({
 
   const [fetchedModels, setFetchedModels] = useState<FetchedModel[]>([]);
   const [isFetchingModels, setIsFetchingModels] = useState(false);
+  const copilotModelsRequestRef = useRef(0);
+
+  const showModelFetchResult = useCallback(
+    (count: number) => {
+      if (count === 0) {
+        toast.info(t("providerForm.fetchModelsEmpty"));
+      } else {
+        toast.success(t("providerForm.fetchModelsSuccess", { count }));
+      }
+    },
+    [t],
+  );
 
   const handleFetchModels = useCallback(() => {
+    if (isCopilotPreset) {
+      const requestId = copilotModelsRequestRef.current + 1;
+      copilotModelsRequestRef.current = requestId;
+      setIsFetchingModels(true);
+      const fetchModels = selectedGitHubAccountId
+        ? copilotGetModelsForAccount(selectedGitHubAccountId)
+        : copilotGetModels();
+
+      fetchModels
+        .then((models: CopilotModel[]) => {
+          if (copilotModelsRequestRef.current !== requestId) return;
+          setFetchedModels(
+            models.map((model) => ({
+              id: model.id,
+              ownedBy: model.vendor || null,
+            })),
+          );
+          showModelFetchResult(models.length);
+        })
+        .catch((err) => {
+          if (copilotModelsRequestRef.current !== requestId) return;
+          console.warn("[Copilot] Failed to fetch models:", err);
+          toast.error(
+            t("copilot.loadModelsFailed", {
+              defaultValue: "加载 Copilot 模型列表失败",
+            }),
+          );
+        })
+        .finally(() => {
+          if (copilotModelsRequestRef.current === requestId) {
+            setIsFetchingModels(false);
+          }
+        });
+      return;
+    }
+
     if (!codexBaseUrl || !codexApiKey) {
       showFetchModelsError(null, t, {
         hasApiKey: !!codexApiKey,
@@ -103,43 +165,61 @@ export function CodexFormFields({
     fetchModelsForConfig(codexBaseUrl, codexApiKey, isFullUrl)
       .then((models) => {
         setFetchedModels(models);
-        if (models.length === 0) {
-          toast.info(t("providerForm.fetchModelsEmpty"));
-        } else {
-          toast.success(
-            t("providerForm.fetchModelsSuccess", { count: models.length }),
-          );
-        }
+        showModelFetchResult(models.length);
       })
       .catch((err) => {
         console.warn("[ModelFetch] Failed:", err);
         showFetchModelsError(err, t);
       })
       .finally(() => setIsFetchingModels(false));
-  }, [codexBaseUrl, codexApiKey, isFullUrl, t]);
+  }, [
+    codexBaseUrl,
+    codexApiKey,
+    isCopilotPreset,
+    isFullUrl,
+    selectedGitHubAccountId,
+    showModelFetchResult,
+    t,
+  ]);
+
+  useEffect(() => {
+    copilotModelsRequestRef.current += 1;
+    setFetchedModels([]);
+    setIsFetchingModels(false);
+  }, [isCopilotPreset, selectedGitHubAccountId]);
 
   return (
     <>
+      {/* GitHub Copilot OAuth 认证 */}
+      {isCopilotPreset && (
+        <CopilotAuthSection
+          selectedAccountId={selectedGitHubAccountId}
+          onAccountSelect={onGitHubAccountSelect}
+        />
+      )}
+
       {/* Codex API Key 输入框 */}
-      <ApiKeySection
-        id="codexApiKey"
-        label="API Key"
-        value={codexApiKey}
-        onChange={onApiKeyChange}
-        category={category}
-        shouldShowLink={shouldShowApiKeyLink}
-        websiteUrl={websiteUrl}
-        isPartner={isPartner}
-        partnerPromotionKey={partnerPromotionKey}
-        placeholder={{
-          official: t("providerForm.codexOfficialNoApiKey", {
-            defaultValue: "官方供应商无需 API Key",
-          }),
-          thirdParty: t("providerForm.codexApiKeyAutoFill", {
-            defaultValue: "输入 API Key，将自动填充到配置",
-          }),
-        }}
-      />
+      {!usesOAuth && (
+        <ApiKeySection
+          id="codexApiKey"
+          label="API Key"
+          value={codexApiKey}
+          onChange={onApiKeyChange}
+          category={category}
+          shouldShowLink={shouldShowApiKeyLink}
+          websiteUrl={websiteUrl}
+          isPartner={isPartner}
+          partnerPromotionKey={partnerPromotionKey}
+          placeholder={{
+            official: t("providerForm.codexOfficialNoApiKey", {
+              defaultValue: "官方供应商无需 API Key",
+            }),
+            thirdParty: t("providerForm.codexApiKeyAutoFill", {
+              defaultValue: "输入 API Key，将自动填充到配置",
+            }),
+          }}
+        />
+      )}
 
       {/* Codex Base URL 输入框 */}
       {shouldShowSpeedTest && (

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -142,6 +142,14 @@ const codexApiFormatFromWireApi = (
   }
 };
 
+const presetProviderType = (
+  preset: PresetEntry["preset"],
+): string | undefined =>
+  "providerType" in preset ? preset.providerType : undefined;
+
+const presetRequiresOAuth = (preset: PresetEntry["preset"]): boolean =>
+  "requiresOAuth" in preset ? preset.requiresOAuth === true : false;
+
 export interface ProviderFormProps {
   appId: AppId;
   providerId?: string;
@@ -215,6 +223,8 @@ function ProviderFormFull({
     category?: ProviderCategory;
     isPartner?: boolean;
     partnerPromotionKey?: string;
+    providerType?: string;
+    requiresOAuth?: boolean;
     suggestedDefaults?: OpenClawSuggestedDefaults;
   } | null>(null);
   const [isEndpointModalOpen, setIsEndpointModalOpen] = useState(false);
@@ -979,10 +989,12 @@ function ProviderFormFull({
 
     // OAuth 未登录：B 类（token 根本不存在，保存了也没法建立）
     const isCopilotProvider =
+      activePreset?.providerType === "github_copilot" ||
       templatePreset?.providerType === "github_copilot" ||
       initialData?.meta?.providerType === "github_copilot" ||
       baseUrl.includes("githubcopilot.com");
     const isCodexOauthProvider =
+      activePreset?.providerType === "codex_oauth" ||
       templatePreset?.providerType === "codex_oauth" ||
       initialData?.meta?.providerType === "codex_oauth";
     if (isCopilotProvider && !isCopilotAuthenticated) {
@@ -1097,10 +1109,12 @@ function ProviderFormFull({
   const performSubmit = async (values: ProviderFormData) => {
     // OAuth / 其它身份识别（与 handleSubmit 保持一致）
     const isCopilotProvider =
+      activePreset?.providerType === "github_copilot" ||
       templatePreset?.providerType === "github_copilot" ||
       initialData?.meta?.providerType === "github_copilot" ||
       baseUrl.includes("githubcopilot.com");
     const isCodexOauthProvider =
+      activePreset?.providerType === "codex_oauth" ||
       templatePreset?.providerType === "codex_oauth" ||
       initialData?.meta?.providerType === "codex_oauth";
 
@@ -1254,7 +1268,9 @@ function ProviderFormFull({
 
     // 确定 providerType（新建时从预设获取，编辑时从现有数据获取）
     const providerType =
-      templatePreset?.providerType || initialData?.meta?.providerType;
+      activePreset?.providerType ||
+      templatePreset?.providerType ||
+      initialData?.meta?.providerType;
 
     const nextMeta: ProviderMeta = {
       ...(baseMeta ?? {}),
@@ -1458,6 +1474,8 @@ function ProviderFormFull({
       category: entry.preset.category,
       isPartner: entry.preset.isPartner,
       partnerPromotionKey: entry.preset.partnerPromotionKey,
+      providerType: presetProviderType(entry.preset),
+      requiresOAuth: presetRequiresOAuth(entry.preset),
     });
 
     if (appId === "codex") {
@@ -1855,19 +1873,24 @@ function ProviderFormFull({
               isPartner={isClaudePartner}
               partnerPromotionKey={claudePartnerPromotionKey}
               isCopilotPreset={
+                activePreset?.providerType === "github_copilot" ||
                 templatePreset?.providerType === "github_copilot" ||
                 initialData?.meta?.providerType === "github_copilot" ||
                 baseUrl.includes("githubcopilot.com")
               }
               isCodexOauthPreset={
+                activePreset?.providerType === "codex_oauth" ||
                 templatePreset?.providerType === "codex_oauth" ||
                 initialData?.meta?.providerType === "codex_oauth"
               }
               usesOAuth={
+                activePreset?.requiresOAuth === true ||
                 templatePreset?.requiresOAuth === true ||
+                activePreset?.providerType === "github_copilot" ||
                 templatePreset?.providerType === "github_copilot" ||
                 initialData?.meta?.providerType === "github_copilot" ||
                 baseUrl.includes("githubcopilot.com") ||
+                activePreset?.providerType === "codex_oauth" ||
                 templatePreset?.providerType === "codex_oauth" ||
                 initialData?.meta?.providerType === "codex_oauth"
               }

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -992,7 +992,8 @@ function ProviderFormFull({
       activePreset?.providerType === "github_copilot" ||
       templatePreset?.providerType === "github_copilot" ||
       initialData?.meta?.providerType === "github_copilot" ||
-      baseUrl.includes("githubcopilot.com");
+      baseUrl.includes("githubcopilot.com") ||
+      codexBaseUrl.includes("githubcopilot.com");
     const isCodexOauthProvider =
       activePreset?.providerType === "codex_oauth" ||
       templatePreset?.providerType === "codex_oauth" ||
@@ -1071,7 +1072,11 @@ function ProviderFormFull({
             }),
           );
         }
-        if (!codexApiKey.trim()) {
+        if (
+          !isCopilotProvider &&
+          !isCodexOauthProvider &&
+          !codexApiKey.trim()
+        ) {
           issues.push(
             t("providerForm.apiKeyRequired", {
               defaultValue: "非官方供应商请填写 API Key",
@@ -1112,7 +1117,8 @@ function ProviderFormFull({
       activePreset?.providerType === "github_copilot" ||
       templatePreset?.providerType === "github_copilot" ||
       initialData?.meta?.providerType === "github_copilot" ||
-      baseUrl.includes("githubcopilot.com");
+      baseUrl.includes("githubcopilot.com") ||
+      codexBaseUrl.includes("githubcopilot.com");
     const isCodexOauthProvider =
       activePreset?.providerType === "codex_oauth" ||
       templatePreset?.providerType === "codex_oauth" ||
@@ -1946,6 +1952,19 @@ function ProviderFormFull({
               websiteUrl={codexWebsiteUrl}
               isPartner={isCodexPartner}
               partnerPromotionKey={codexPartnerPromotionKey}
+              isCopilotPreset={
+                activePreset?.providerType === "github_copilot" ||
+                initialData?.meta?.providerType === "github_copilot" ||
+                codexBaseUrl.includes("githubcopilot.com")
+              }
+              usesOAuth={
+                activePreset?.requiresOAuth === true ||
+                activePreset?.providerType === "github_copilot" ||
+                initialData?.meta?.providerType === "github_copilot" ||
+                codexBaseUrl.includes("githubcopilot.com")
+              }
+              selectedGitHubAccountId={selectedGitHubAccountId}
+              onGitHubAccountSelect={setSelectedGitHubAccountId}
               shouldShowSpeedTest={shouldShowSpeedTest}
               codexBaseUrl={codexBaseUrl}
               onBaseUrlChange={handleCodexBaseUrlChange}

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -27,6 +27,10 @@ export interface CodexProviderPreset {
   iconColor?: string; // 图标颜色
   // Codex API 格式
   apiFormat?: CodexApiFormat;
+  // 供应商类型标识（用于特殊供应商检测）
+  providerType?: "github_copilot" | "codex_oauth";
+  // 是否需要 OAuth 认证（而非 API Key）
+  requiresOAuth?: boolean;
 }
 
 /**
@@ -140,6 +144,23 @@ requires_openai_auth = true`,
     },
     icon: "azure",
     iconColor: "#0078D4",
+  },
+  {
+    name: "GitHub Copilot",
+    websiteUrl: "https://github.com/features/copilot",
+    category: "third_party",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "github_copilot",
+      "https://api.githubcopilot.com",
+      "gpt-5.4-codex",
+    ),
+    endpointCandidates: ["https://api.githubcopilot.com"],
+    apiFormat: "openai_responses",
+    providerType: "github_copilot",
+    requiresOAuth: true,
+    icon: "github",
+    iconColor: "#000000",
   },
   {
     name: "AiHubMix",

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -151,7 +151,7 @@ export function useProviderActions(
   const switchProvider = useCallback(
     async (provider: Provider) => {
       const isCopilotProvider =
-        activeApp === "claude" &&
+        (activeApp === "claude" || activeApp === "codex") &&
         provider.meta?.providerType === "github_copilot";
       const isCodexChatFormat =
         activeApp === "codex" &&
@@ -169,7 +169,7 @@ export function useProviderActions(
       if (!isProxyRunning && provider.category !== "official") {
         if (isCopilotProvider) {
           proxyRequiredReason = t("notifications.proxyReasonCopilot", {
-            defaultValue: "使用 GitHub Copilot 作为 Claude 供应商",
+            defaultValue: "使用 GitHub Copilot 作为供应商",
           });
         } else if (
           provider.meta?.apiFormat === "openai_chat" &&

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -247,7 +247,7 @@
     "settingsSaved": "Settings saved",
     "settingsSaveFailed": "Failed to save settings: {{error}}",
     "proxyRequiredForSwitch": "This provider {{reason}}, requires the routing service to work properly. Start routing first.",
-    "proxyReasonCopilot": "uses GitHub Copilot as a Claude provider",
+    "proxyReasonCopilot": "uses GitHub Copilot as a provider",
     "proxyReasonOpenAIChat": "uses OpenAI Chat API format",
     "proxyReasonOpenAIResponses": "uses OpenAI Responses API format",
     "proxyReasonFullUrl": "has full URL connection mode enabled",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -247,7 +247,7 @@
     "settingsSaved": "設定を保存しました",
     "settingsSaveFailed": "設定の保存に失敗しました: {{error}}",
     "proxyRequiredForSwitch": "このプロバイダーは{{reason}}、ルーティングサービスが必要です。先にルーティングを起動してください",
-    "proxyReasonCopilot": "GitHub Copilot を Claude プロバイダーとして使用しており",
+    "proxyReasonCopilot": "GitHub Copilot をプロバイダーとして使用しており",
     "proxyReasonOpenAIChat": "OpenAI Chat API フォーマットを使用しており",
     "proxyReasonOpenAIResponses": "OpenAI Responses API フォーマットを使用しており",
     "proxyReasonFullUrl": "完全 URL 接続モードが有効になっており",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -247,7 +247,7 @@
     "settingsSaved": "设置已保存",
     "settingsSaveFailed": "保存设置失败：{{error}}",
     "proxyRequiredForSwitch": "此供应商{{reason}}，需要路由服务才能正常使用，请先启动路由",
-    "proxyReasonCopilot": "使用 GitHub Copilot 作为 Claude 供应商",
+    "proxyReasonCopilot": "使用 GitHub Copilot 作为供应商",
     "proxyReasonOpenAIChat": "使用 OpenAI Chat 接口格式",
     "proxyReasonOpenAIResponses": "使用 OpenAI Responses 接口格式",
     "proxyReasonFullUrl": "开启了完整 URL 连接模式",

--- a/tests/config/therouterProviderPresets.test.ts
+++ b/tests/config/therouterProviderPresets.test.ts
@@ -24,21 +24,19 @@ describe("TheRouter provider presets", () => {
     expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(
       "anthropic/claude-sonnet-4.6",
     );
-    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe(
-      "anthropic/claude-opus-4.7",
-    );
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("anthropic/claude-opus-4.7");
   });
 
   it("uses the OpenAI-compatible v1 endpoint for Codex", () => {
-    const preset = codexProviderPresets.find((item) => item.name === "TheRouter");
+    const preset = codexProviderPresets.find(
+      (item) => item.name === "TheRouter",
+    );
 
     expect(preset).toBeDefined();
     expect(preset?.websiteUrl).toBe("https://therouter.ai");
     expect(preset?.apiKeyUrl).toBe("https://dashboard.therouter.ai");
     expect(preset?.category).toBe("aggregator");
-    expect(preset?.endpointCandidates).toEqual([
-      "https://api.therouter.ai/v1",
-    ]);
+    expect(preset?.endpointCandidates).toEqual(["https://api.therouter.ai/v1"]);
     expect(preset?.auth).toEqual({ OPENAI_API_KEY: "" });
     expect(preset?.config).toContain('model_provider = "therouter"');
     expect(preset?.config).toContain('model = "openai/gpt-5.3-codex"');
@@ -48,8 +46,34 @@ describe("TheRouter provider presets", () => {
     expect(preset?.config).toContain('wire_api = "responses"');
   });
 
+  it("adds GitHub Copilot as a managed Codex provider", () => {
+    const preset = codexProviderPresets.find(
+      (item) => item.name === "GitHub Copilot",
+    );
+
+    expect(preset).toBeDefined();
+    expect(preset?.websiteUrl).toBe("https://github.com/features/copilot");
+    expect(preset?.category).toBe("third_party");
+    expect(preset?.auth).toEqual({ OPENAI_API_KEY: "" });
+    expect(preset?.endpointCandidates).toEqual([
+      "https://api.githubcopilot.com",
+    ]);
+    expect(preset?.apiFormat).toBe("openai_responses");
+    expect(preset?.providerType).toBe("github_copilot");
+    expect(preset?.requiresOAuth).toBe(true);
+    expect(preset?.config).toContain('model_provider = "github_copilot"');
+    expect(preset?.config).toContain('model = "gpt-5.4-codex"');
+    expect(preset?.config).toContain(
+      'base_url = "https://api.githubcopilot.com"',
+    );
+    expect(preset?.config).toContain('wire_api = "responses"');
+    expect(preset?.config).toContain("requires_openai_auth = true");
+  });
+
   it("uses the Gemini-native root endpoint for Gemini", () => {
-    const preset = geminiProviderPresets.find((item) => item.name === "TheRouter");
+    const preset = geminiProviderPresets.find(
+      (item) => item.name === "TheRouter",
+    );
 
     expect(preset).toBeDefined();
     expect(preset?.websiteUrl).toBe("https://therouter.ai");


### PR DESCRIPTION
## Summary / 概述

Adds a Codex provider preset for GitHub Copilot and wires it into CC Switch's existing managed Copilot auth flow. Codex can route Responses API requests through the local CC Switch proxy while reusing the selected Copilot account, without storing Copilot tokens in `~/.codex/auth.json`.

## Changes / 主要改动

- Add the `GitHub Copilot` preset to Codex provider presets.
- Persist Codex preset `providerType`, OAuth metadata, and selected GitHub account binding.
- Use the GitHub Copilot auth strategy for managed Codex Copilot providers so the proxy injects the real Copilot token.
- Show the Copilot OAuth account selector for the Codex Copilot preset and hide the API key field.
- Fetch Codex Copilot models through the Copilot OAuth model APIs instead of requiring an API key.
- Route Codex GitHub Copilot switches through local proxy takeover instead of writing the Copilot upstream directly into `~/.codex/config.toml`.
- When Codex Copilot is selected, ensure `~/.codex/config.toml` points to the local proxy and `auth.json` uses `PROXY_MANAGED`, while the real Copilot account stays in CC Switch provider metadata.
- Preserve the original Codex live config backup for restore and avoid overwriting it with managed-account providers during hot switch.
- Exclude Codex Copilot providers from the official-provider proxy block state, so saved providers no longer show `Blocked` / `已拦截` incorrectly.
- Warn Codex Copilot users when local routing is not running.
- Update English, Chinese, and Japanese proxy-reason text.
- Add tests covering the Codex Copilot preset, auth strategy, and proxy-takeover switch path.

## Related Issue / 关联 Issue

Fixes #2283

## Screenshots / 截图

N/A. Preset/config behavior only.

## Validation / 验证

- [x] `tsc --noEmit`
- [x] `vitest run tests/config/therouterProviderPresets.test.ts`
- [x] `cargo test --lib services::provider::tests::switching_codex_copilot_provider_enables_proxy_takeover`
- [x] `prettier --check` on changed frontend files
- [x] `git diff --check` on changed files
- [ ] Full `cargo fmt --check` currently reports pre-existing formatting drift in `src-tauri/src/proxy/providers/codex.rs`, which is outside this latest commit.

## Notes / 备注

`pnpm install --frozen-lockfile` completed dependency linking but returned `ERR_PNPM_IGNORED_BUILDS` because local pnpm build-script approval is required for packages such as `esbuild` and `msw`. The frontend validation commands above were run directly through `node_modules/.bin` after dependencies were present.

Manual retest focus:
- In Codex provider creation, selecting `GitHub Copilot` should show OAuth account selection and should not require an API key to fetch models.
- After saving a Codex Copilot provider, the provider list should not show the provider as `已拦截` solely because the API key is empty.
- Switching to a Codex Copilot provider should enable/use Codex local proxy takeover: `auth.json` should contain `PROXY_MANAGED`, `config.toml` should point to the local proxy `/v1`, and Copilot's upstream/token should remain behind CC Switch.