### PR TITLE
fix: Claude Desktop 代理模式支持版本化模型 ID 前缀匹配

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -720,6 +720,10 @@ pub fn map_proxy_request_model(mut body: Value, provider: &Provider) -> Result<V
 ///
 /// For example, `claude-haiku-4-5-20251001` matches route `claude-haiku-4-5`.
 /// Uses longest-prefix match to disambiguate when multiple routes share a prefix.
+///
+/// Only matches version-like suffixes (starting with a digit) to avoid silently
+/// routing arbitrary model ID variants or typos (e.g. `claude-sonnet-4-6-beta`
+/// will NOT match route `claude-sonnet-4-6`).
 fn find_route_by_prefix<'a>(
     requested: &str,
     routes: &'a [ResolvedModelRoute],
@@ -729,9 +733,12 @@ fn find_route_by_prefix<'a>(
         .iter()
         .filter(|r| {
             let id_bytes = r.route_id.as_bytes();
-            requested_bytes.len() > id_bytes.len()
+            let suffix_start = id_bytes.len();
+            requested_bytes.len() > suffix_start
                 && requested_bytes.starts_with(id_bytes)
-                && requested_bytes[id_bytes.len()] == b'-'
+                && requested_bytes[suffix_start] == b'-'
+                && suffix_start + 1 < requested_bytes.len()
+                && requested_bytes[suffix_start + 1].is_ascii_digit()
         })
         .max_by_key(|r| r.route_id.len())
 }
@@ -1524,9 +1531,20 @@ mod tests {
             ..Default::default()
         });
 
+        // Completely unrelated model
         let err = map_proxy_request_model(json!({"model": "claude-opus-4-7"}), &provider)
             .expect_err("unrelated model should fail");
         assert!(err.to_string().contains("claude-opus-4-7"));
+
+        // Model sharing a prefix but with a non-version suffix (e.g. typo / variant)
+        // should NOT match via prefix fallback (only version-like suffixes with
+        // leading digit are accepted).
+        let err = map_proxy_request_model(
+            json!({"model": "claude-haiku-4-5-beta", "messages": []}),
+            &provider,
+        )
+        .expect_err("non-version suffix should fail");
+        assert!(err.to_string().contains("claude-haiku-4-5-beta"));
     }
 
     #[test]

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -696,7 +696,14 @@ pub fn map_proxy_request_model(mut body: Value, provider: &Provider) -> Result<V
         })?;
 
     let routes = proxy_model_routes(provider)?;
-    let route = routes.iter().find(|r| r.route_id == requested);
+
+    // First try exact match, then fall back to prefix matching for versioned
+    // model IDs (e.g. "claude-haiku-4-5-20251001" should match route "claude-haiku-4-5").
+    let route = routes
+        .iter()
+        .find(|r| r.route_id == requested)
+        .or_else(|| find_route_by_prefix(&requested, &routes));
+
     let Some(route) = route else {
         return Err(AppError::localized(
             "claude_desktop.provider.route_unknown",
@@ -707,6 +714,26 @@ pub fn map_proxy_request_model(mut body: Value, provider: &Provider) -> Result<V
 
     body["model"] = json!(route.upstream_model);
     Ok(body)
+}
+
+/// Try to match a versioned model ID to a configured generic route prefix.
+///
+/// For example, `claude-haiku-4-5-20251001` matches route `claude-haiku-4-5`.
+/// Uses longest-prefix match to disambiguate when multiple routes share a prefix.
+fn find_route_by_prefix<'a>(
+    requested: &str,
+    routes: &'a [ResolvedModelRoute],
+) -> Option<&'a ResolvedModelRoute> {
+    let requested_bytes = requested.as_bytes();
+    routes
+        .iter()
+        .filter(|r| {
+            let id_bytes = r.route_id.as_bytes();
+            requested_bytes.len() > id_bytes.len()
+                && requested_bytes.starts_with(id_bytes)
+                && requested_bytes[id_bytes.len()] == b'-'
+        })
+        .max_by_key(|r| r.route_id.len())
 }
 
 pub fn proxy_gateway_base_url_from_db(db: &Database) -> Result<String, AppError> {
@@ -1406,6 +1433,146 @@ mod tests {
         )
         .expect_err("1M suffix route should not be accepted");
         assert!(err.to_string().contains("claude-sonnet-4-6 [1M]"));
+    }
+
+    #[test]
+    fn claude_desktop_proxy_maps_versioned_model_id_via_prefix() {
+        // Issue #2900: Claude Desktop sub-agents send full Anthropic model IDs
+        // like "claude-haiku-4-5-20251001". These should match the generic route
+        // "claude-haiku-4-5" via prefix-based fallback matching.
+        let mut provider = proxy_provider("proxy");
+        provider.meta = Some(ProviderMeta {
+            claude_desktop_mode: Some(ClaudeDesktopMode::Proxy),
+            api_format: Some("openai_chat".to_string()),
+            claude_desktop_model_routes: std::collections::HashMap::from([
+                (
+                    "claude-sonnet-4-6".to_string(),
+                    ClaudeDesktopModelRoute {
+                        model: "deepseek-v4-pro".to_string(),
+                        label_override: None,
+                        supports_1m: Some(true),
+                    },
+                ),
+                (
+                    "claude-haiku-4-5".to_string(),
+                    ClaudeDesktopModelRoute {
+                        model: "deepseek-v4-mini".to_string(),
+                        label_override: None,
+                        supports_1m: Some(false),
+                    },
+                ),
+                (
+                    "claude-opus-4-7".to_string(),
+                    ClaudeDesktopModelRoute {
+                        model: "deepseek-v4-max".to_string(),
+                        label_override: None,
+                        supports_1m: Some(true),
+                    },
+                ),
+            ]),
+            ..Default::default()
+        });
+
+        // Exact match still works
+        let mapped = map_proxy_request_model(
+            json!({"model": "claude-sonnet-4-6", "messages": []}),
+            &provider,
+        )
+        .expect("exact match");
+        assert_eq!(mapped["model"], json!("deepseek-v4-pro"));
+
+        // Versioned haiku matches haiku route
+        let mapped = map_proxy_request_model(
+            json!({"model": "claude-haiku-4-5-20251001", "messages": []}),
+            &provider,
+        )
+        .expect("versioned haiku");
+        assert_eq!(mapped["model"], json!("deepseek-v4-mini"));
+
+        // Versioned sonnet matches sonnet route
+        let mapped = map_proxy_request_model(
+            json!({"model": "claude-sonnet-4-6-20250605", "messages": []}),
+            &provider,
+        )
+        .expect("versioned sonnet");
+        assert_eq!(mapped["model"], json!("deepseek-v4-pro"));
+
+        // Versioned opus matches opus route
+        let mapped = map_proxy_request_model(
+            json!({"model": "claude-opus-4-7-20250605", "messages": []}),
+            &provider,
+        )
+        .expect("versioned opus");
+        assert_eq!(mapped["model"], json!("deepseek-v4-max"));
+    }
+
+    #[test]
+    fn claude_desktop_proxy_prefix_match_rejects_unknown_unrelated_model() {
+        // A model name that doesn't match any route exactly or via prefix should still error.
+        let mut provider = proxy_provider("proxy");
+        provider.meta = Some(ProviderMeta {
+            claude_desktop_mode: Some(ClaudeDesktopMode::Proxy),
+            api_format: Some("openai_chat".to_string()),
+            claude_desktop_model_routes: std::collections::HashMap::from([(
+                "claude-haiku-4-5".to_string(),
+                ClaudeDesktopModelRoute {
+                    model: "deepseek-v4-mini".to_string(),
+                    label_override: None,
+                    supports_1m: Some(false),
+                },
+            )]),
+            ..Default::default()
+        });
+
+        let err = map_proxy_request_model(json!({"model": "claude-opus-4-7"}), &provider)
+            .expect_err("unrelated model should fail");
+        assert!(err.to_string().contains("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn claude_desktop_proxy_prefix_match_longest_wins() {
+        // When both "claude-haiku-4-5" and "claude-haiku-4-5-special" are configured,
+        // "claude-haiku-4-5-special-20251001" should match the longer prefix.
+        let mut provider = proxy_provider("proxy");
+        provider.meta = Some(ProviderMeta {
+            claude_desktop_mode: Some(ClaudeDesktopMode::Proxy),
+            api_format: Some("openai_chat".to_string()),
+            claude_desktop_model_routes: std::collections::HashMap::from([
+                (
+                    "claude-haiku-4-5".to_string(),
+                    ClaudeDesktopModelRoute {
+                        model: "mini".to_string(),
+                        label_override: None,
+                        supports_1m: Some(false),
+                    },
+                ),
+                (
+                    "claude-haiku-4-5-special".to_string(),
+                    ClaudeDesktopModelRoute {
+                        model: "mini-special".to_string(),
+                        label_override: None,
+                        supports_1m: Some(true),
+                    },
+                ),
+            ]),
+            ..Default::default()
+        });
+
+        // Longer prefix wins
+        let mapped = map_proxy_request_model(
+            json!({"model": "claude-haiku-4-5-special-20251001", "messages": []}),
+            &provider,
+        )
+        .expect("longest prefix match");
+        assert_eq!(mapped["model"], json!("mini-special"));
+
+        // Shorter prefix still works for simpler version
+        let mapped = map_proxy_request_model(
+            json!({"model": "claude-haiku-4-5-20251001", "messages": []}),
+            &provider,
+        )
+        .expect("shorter prefix match");
+        assert_eq!(mapped["model"], json!("mini"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

Claude Desktop 生成子代理（sub-agent）时发送完整模型 ID（如 `claude-haiku-4-5-20251001`），
但模型映射仅配置了通用路由 ID（如 `claude-haiku-4-5`）。此前仅支持精确匹配，导致请求失败。

本次修改在 `map_proxy_request_model` 中增加前缀回退匹配：
精确匹配失败后，检查请求模型名是否以某个已配置路由 ID + "-" 开头，
采用最长前缀匹配以避免歧义。新增 3 个测试用例覆盖核心场景。
## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #2900 #3250

## Checklist / 检查清单

- [x] `pnpm typecheck` — 通过
- [x] `pnpm format:check` — 通过
- [x] `pnpm test:unit` — 239/241 通过（2 个失败为 `App.test.tsx` 已有问题，与本次改动无关）
- [x] `cargo clippy` — 通过
- [x] i18n — N/A（无新增用户可见文本）