### PR TITLE
feat(codex): 增加可配置的stable codex provider id，以解决旧用户历史记录丢失问题

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -226,12 +226,16 @@ fn normalize_codex_live_config_model_provider_with_anchors<'a>(
         return Ok(config_text.to_string());
     }
 
-    let stable_provider_id = anchor_config_texts
-        .into_iter()
-        .find_map(stable_codex_model_provider_id_from_config)
+    // Priority for stable provider id:
+    // 1. User-configured stable id (settings)
+    // 2. Anchor config's stable id (backfill/live anchor)
+    // 3. If source provider is a custom id, reuse it
+    // 4. Fallback to CC_SWITCH_CODEX_MODEL_PROVIDER_ID
+    let stable_provider_id = crate::settings::get_stable_codex_model_provider_id()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| anchor_config_texts.into_iter().find_map(stable_codex_model_provider_id_from_config))
         .or_else(|| {
-            is_custom_codex_model_provider_id(&source_provider_id)
-                .then(|| source_provider_id.clone())
+            is_custom_codex_model_provider_id(&source_provider_id).then(|| source_provider_id.clone())
         })
         .unwrap_or_else(|| CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string());
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -257,6 +257,9 @@ pub struct AppSettings {
     /// 当前 Codex 供应商 ID（本地存储，优先于数据库 is_current）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_codex: Option<String>,
+    /// Codex 稳定 供应商 id（用于避免历史记录摇摆）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stable_codex_model_provider_id: Option<String>,
     /// 当前 Gemini 供应商 ID（本地存储，优先于数据库 is_current）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_gemini: Option<String>,
@@ -340,6 +343,7 @@ impl Default for AppSettings {
             current_provider_claude: None,
             current_provider_claude_desktop: None,
             current_provider_codex: None,
+            stable_codex_model_provider_id: None,
             current_provider_gemini: None,
             current_provider_opencode: None,
             current_provider_openclaw: None,
@@ -582,6 +586,14 @@ pub fn get_codex_override_dir() -> Option<PathBuf> {
         .codex_config_dir
         .as_ref()
         .map(|p| resolve_override_path(p))
+}
+
+/// 获取用户设置的 Codex 稳定供应商 id（若未设置返回 None）
+pub fn get_stable_codex_model_provider_id() -> Option<String> {
+    settings_store()
+        .read()
+        .ok()
+        .and_then(|s| s.stable_codex_model_provider_id.clone())
 }
 
 pub fn get_gemini_override_dir() -> Option<PathBuf> {

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { FormLabel } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -51,6 +52,10 @@ interface CodexFormFieldsProps {
   apiFormat: CodexApiFormat;
   onApiFormatChange: (format: CodexApiFormat) => void;
 
+  // Stable provider id
+  stableModelProviderId: string;
+  onStableModelProviderIdChange: (value: string) => void;
+
   // Model Name
   shouldShowModelField?: boolean;
   modelName?: string;
@@ -81,6 +86,8 @@ export function CodexFormFields({
   onAutoSelectChange,
   apiFormat,
   onApiFormatChange,
+  stableModelProviderId,
+  onStableModelProviderIdChange,
   shouldShowModelField = true,
   modelName = "",
   onModelNameChange,
@@ -241,6 +248,32 @@ export function CodexFormFields({
           </p>
         </div>
       )}
+
+      {/* Stable model_provider id */}
+      <div className="space-y-2">
+        <FormLabel htmlFor="codexStableModelProviderId">
+          {t("provider.form.codex.stableModelProviderId", {
+            defaultValue: "Stable model_provider ID",
+          })}
+        </FormLabel>
+        <Input
+          id="codexStableModelProviderId"
+          value={stableModelProviderId}
+          onChange={(e) => onStableModelProviderIdChange(e.target.value)}
+          placeholder={t(
+            "provider.form.codex.stableModelProviderIdPlaceholder",
+            {
+              defaultValue: "ccswitch",
+            },
+          )}
+        />
+        <p className="text-xs text-muted-foreground">
+          {t("provider.form.codex.stableModelProviderIdHint", {
+            defaultValue:
+              "CC Switch writes this value to Codex config.toml as model_provider. Leave empty to use the default ccswitch.",
+          })}
+        </p>
+      </div>
 
       {/* 端点测速弹窗 - Codex */}
       {shouldShowSpeedTest && isEndpointModalOpen && (

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -416,6 +416,40 @@ function ProviderFormFull({
     [localApiKeyField, form, handleSettingsConfigChange],
   );
 
+  // Codex 稳定供应商 ID（用户输入时立即保存）
+  const [codexStableModelProviderId, setCodexStableModelProviderId] =
+    useState<string>(() => {
+      return settingsData?.codexStableModelProviderId ?? "";
+    });
+
+  // 从 settingsData 同步初值
+  useEffect(() => {
+    if (appId === "codex" && settingsData) {
+      setCodexStableModelProviderId(
+        settingsData.codexStableModelProviderId ?? "",
+      );
+    }
+  }, [appId, settingsData]);
+
+  // 用户输入时立即保存到 settings
+  const handleStableProviderIdChange = useCallback(
+    async (value: string) => {
+      setCodexStableModelProviderId(value);
+      try {
+        const currentSettings = settingsData ?? (await settingsApi.get());
+        await settingsApi.save({
+          ...currentSettings,
+          codexStableModelProviderId: value.trim() || undefined,
+        });
+        await queryClient.invalidateQueries({ queryKey: ["settings"] });
+      } catch (error) {
+        console.error("Failed to save stable provider id:", error);
+        toast.error(t("failedToSaveSettings"));
+      }
+    },
+    [settingsData, queryClient, t],
+  );
+
   // Copilot OAuth 认证状态（仅 Claude 应用需要）
   const { isAuthenticated: isCopilotAuthenticated } = useCopilotAuth();
 
@@ -1937,6 +1971,8 @@ function ProviderFormFull({
               onAutoSelectChange={setEndpointAutoSelect}
               apiFormat={localCodexApiFormat}
               onApiFormatChange={handleCodexApiFormatChange}
+              stableModelProviderId={codexStableModelProviderId}
+              onStableModelProviderIdChange={handleStableProviderIdChange}
               shouldShowModelField={category !== "official"}
               modelName={codexModelName}
               onModelNameChange={handleCodexModelNameChange}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -170,6 +170,11 @@
         "oauthTitle": "OAuth Authentication Mode",
         "oauthHint": "Google official uses OAuth personal authentication, no need to fill in API Key. The browser will automatically open for login on first use.",
         "apiKeyPlaceholder": "Enter Gemini API Key"
+      },
+      "codex": {
+        "stableModelProviderId": "Stable model_provider ID",
+        "stableModelProviderIdHint": "This provider id is written to Codex config.toml as model_provider. If different providers use different values here, Codex will split history. Leave empty to use the default ccswitch, which is fine for most cases.",
+        "stableModelProviderIdPlaceholder": "ccswitch"
       }
     }
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -170,6 +170,11 @@
         "oauthTitle": "OAuth 認証モード",
         "oauthHint": "Google 公式は OAuth 個人認証を使用するため API Key は不要です。初回利用時にブラウザが開きます。",
         "apiKeyPlaceholder": "Gemini API Key を入力"
+      },
+      "codex": {
+        "stableModelProviderId": "固定 model_provider ID",
+        "stableModelProviderIdHint": "この provider id は Codex config.toml の model_provider に書き込まれます。プロバイダーごとに値が異なると、Codex の履歴が分かれてしまいます。未設定の場合は既定の ccswitch を使用します。",
+        "stableModelProviderIdPlaceholder": "ccswitch"
       }
     }
   },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -170,6 +170,11 @@
         "oauthTitle": "OAuth 认证模式",
         "oauthHint": "Google 官方使用 OAuth 个人认证，无需填写 API Key。首次使用时会自动打开浏览器进行登录。",
         "apiKeyPlaceholder": "请输入 Gemini API Key"
+      },
+      "codex": {
+        "stableModelProviderId": "model_provider",
+        "stableModelProviderIdHint": "传递给 Codex 的 provider id。若不同供应商设置中该值不同，会导致丢失对话历史。留空则默认为 ccswitch，适用于大多数情况。",
+        "stableModelProviderIdPlaceholder": "ccswitch"
       }
     }
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -327,6 +327,9 @@ export interface Settings {
   // 当前 Gemini 供应商 ID（优先于数据库 is_current）
   currentProviderGemini?: string;
 
+  // Codex 稳定供应商 ID（用于 Codex config.toml 写回时的默认值）
+  codexStableModelProviderId?: string;
+
   // ===== Skill 同步设置 =====
   // Skill 同步方式：auto（默认，优先 symlink）、symlink、copy
   skillSyncMethod?: SkillSyncMethod;


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

本次改动为 Codex 供应商新增了可配置的 stable provider id，用来控制写回到 Codex config.toml 中的 model_provider 值。默认仍然使用 ccswitch，以保证现有行为不变；同时用户现在可以在 Codex 供应商编辑界面手动调整该值，比如切回 openai，以便查看原先按 openai 分组的历史记录。

这次改动的核心目标是解决 Codex 历史记录按 model_provider 分桶后出现“历史看不到”的问题。在之前的更新当中，CC switch新增了将 codex 供应商设置为固定值的特性，来保证切换供应商时历史记录丢失。然而，把 provider id 统一写成固定值反而导致用户不能查看 CC switch 更新前的历史对话；现在则把这个值暴露为可配置项，让用户可以根据自己的历史数据选择稳定 id

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #2934 
Fixes #2904 
Fixes #2847 
（均为同一问题）

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
