### PR TITLE
fix: map developer role to system in Codex Chat conversion

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -203,7 +203,11 @@ fn flush_pending_tool_calls(messages: &mut Vec<Value>, pending_tool_calls: &mut 
 }
 
 fn responses_message_item_to_chat_message(item: &Value) -> Value {
-    let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("user");
+    let raw_role = item.get("role").and_then(|v| v.as_str()).unwrap_or("user");
+    let role = match raw_role {
+        "developer" => "system",
+        other => other,
+    };
     let content = item
         .get("content")
         .map(|value| responses_content_to_chat_content(role, value))


### PR DESCRIPTION
## Summary

When using Codex CLI with third-party providers (e.g., NewAPI + DeepSeek) through CC Switch's Responses → Chat Completions proxy conversion, the request fails because non-OpenAI models do not recognize the `developer` role.

The OpenAI Chat Completions API introduced the `developer` role as a more structured replacement for `system`. Codex CLI sends messages with `role: "developer"`, but providers like DeepSeek only accept `system`, `user`, `assistant`, `tool`, and `latest_reminder`.

## Error before fix

```
messages[1].role: unknown variant `developer`, expected one of `system`, `user`, `assistant`, `tool`, `latest_reminder`
```

## Changes

- **`src-tauri/src/proxy/providers/transform_codex_chat.rs`**: Map `developer` → `system` during Responses → Chat Completions request conversion in `responses_message_item_to_chat_message()`.

## Testing

Tested with Codex CLI → CC Switch (dev build) → NewAPI → DeepSeek (`deepseek-v4-flash`). The `developer` role is correctly translated and Codex CLI works as expected.