### PR TITLE
fix(session): render tool details in history

### DIFF
--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -348,6 +348,7 @@ mod tests {
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0].role, "assistant");
         assert!(msgs[0].content.contains("[Tool: Write]"));
+        assert!(msgs[0].content.contains("File: a.txt"));
         assert_eq!(msgs[1].role, "tool");
         assert_eq!(msgs[1].content, "File written");
     }

--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -10,8 +10,8 @@ use crate::codex_config::get_codex_config_dir;
 use crate::session_manager::{SessionMessage, SessionMeta};
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines, truncate_summary,
-    TITLE_MAX_CHARS,
+    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines, render_tool_call,
+    truncate_summary, TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "codex";
@@ -78,7 +78,12 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
                     .get("name")
                     .and_then(Value::as_str)
                     .unwrap_or("unknown");
-                ("assistant".to_string(), format!("[Tool: {name}]"))
+                let arguments = parse_function_call_arguments(payload.get("arguments"));
+                let call_id = payload.get("call_id").and_then(Value::as_str);
+                (
+                    "assistant".to_string(),
+                    render_tool_call(name, arguments.as_ref(), call_id),
+                )
             }
             "function_call_output" => {
                 let output = payload
@@ -101,6 +106,17 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
     }
 
     Ok(messages)
+}
+
+fn parse_function_call_arguments(value: Option<&Value>) -> Option<Value> {
+    match value {
+        Some(Value::String(raw)) if raw.trim().is_empty() => None,
+        Some(Value::String(raw)) => serde_json::from_str(raw)
+            .ok()
+            .or_else(|| Some(Value::String(raw.clone()))),
+        Some(other) => Some(other.clone()),
+        None => None,
+    }
 }
 
 pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<bool, String> {
@@ -438,6 +454,8 @@ mod tests {
 
         assert_eq!(msgs[1].role, "assistant");
         assert!(msgs[1].content.contains("[Tool: shell]"));
+        assert!(msgs[1].content.contains("Call ID: call_1"));
+        assert!(msgs[1].content.contains("\"cmd\""));
 
         assert_eq!(msgs[2].role, "tool");
         assert!(msgs[2].content.contains("file1.txt"));

--- a/src-tauri/src/session_manager/providers/gemini.rs
+++ b/src-tauri/src/session_manager/providers/gemini.rs
@@ -150,11 +150,13 @@ fn collect_gemini_tool_result(value: &Value, lines: &mut Vec<String>) {
                 .get("response")
                 .and_then(|response| response.get("output"))
             {
-                if let Some(rendered) = render_json_value(output) {
+                let sanitized = sanitize_gemini_result_value(output);
+                if let Some(rendered) = render_json_value(&sanitized) {
                     lines.push(format!("Output:\n{rendered}"));
                 }
             } else if let Some(output) = obj.get("output") {
-                if let Some(rendered) = render_json_value(output) {
+                let sanitized = sanitize_gemini_result_value(output);
+                if let Some(rendered) = render_json_value(&sanitized) {
                     lines.push(format!("Output:\n{rendered}"));
                 }
             }
@@ -179,7 +181,8 @@ fn collect_gemini_function_response(value: &Value, lines: &mut Vec<String>) {
         .get("response")
         .and_then(|response| response.get("output"))
     {
-        if let Some(rendered) = render_json_value(output) {
+        let sanitized = sanitize_gemini_result_value(output);
+        if let Some(rendered) = render_json_value(&sanitized) {
             lines.push(format!("Output:\n{rendered}"));
         }
     } else if let Some(response) = obj.get("response") {
@@ -431,5 +434,27 @@ mod tests {
             .content
             .contains("inlineData: application/pdf, ~4 bytes"));
         assert!(!msgs[1].content.contains("QUJDRA=="));
+    }
+
+    #[test]
+    fn load_messages_sanitizes_function_response_output_data() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session.json");
+        let large_data = "QUJD".repeat(200);
+        let session = format!(
+            r#"{{
+              "sessionId": "test",
+              "messages": [
+                {{"id":"1","timestamp":"2026-03-10T08:24:50Z","type":"gemini","content":"","toolCalls":[{{"id":"call_1","name":"read_image","args":{{"path":"image.png"}},"result":[{{"functionResponse":{{"id":"call_1","name":"read_image","response":{{"output":{{"mimeType":"image/png","data":"{large_data}"}}}}}}}}]}}]}}
+              ]
+            }}"#
+        );
+        std::fs::write(&path, session).expect("write");
+
+        let msgs = load_messages(&path).expect("load");
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].content.contains("Output:"));
+        assert!(msgs[0].content.contains("<base64 omitted: ~600 bytes>"));
+        assert!(!msgs[0].content.contains(&large_data));
     }
 }

--- a/src-tauri/src/session_manager/providers/gemini.rs
+++ b/src-tauri/src/session_manager/providers/gemini.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::session_manager::{SessionMessage, SessionMeta};
 
-use super::utils::{parse_timestamp_to_ms, truncate_summary};
+use super::utils::{parse_timestamp_to_ms, render_json_value, render_tool_call, truncate_summary};
 
 const PROVIDER_ID: &str = "gemini";
 
@@ -84,14 +84,23 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
             _ => String::new(),
         };
 
-        // Append tool call names from the optional toolCalls array
+        // Append tool calls from the optional toolCalls array, including args so
+        // history/search/export do not lose what was invoked.
         if let Some(Value::Array(calls)) = msg.get("toolCalls") {
             for call in calls {
                 if let Some(name) = call.get("name").and_then(Value::as_str) {
                     if !content.is_empty() {
                         content.push('\n');
                     }
-                    content.push_str(&format!("[Tool: {name}]"));
+                    let args = call.get("args").or_else(|| call.get("arguments"));
+                    let call_id = call.get("id").and_then(Value::as_str);
+                    content.push_str(&render_tool_call(name, args, call_id));
+                    if let Some(result) = call.get("result") {
+                        if let Some(rendered_result) = render_gemini_tool_result(result) {
+                            content.push('\n');
+                            content.push_str(&rendered_result);
+                        }
+                    }
                 }
             }
         }
@@ -110,6 +119,165 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
     }
 
     Ok(result)
+}
+
+fn render_gemini_tool_result(result: &Value) -> Option<String> {
+    let mut lines = Vec::new();
+    collect_gemini_tool_result(result, &mut lines);
+
+    if !lines.is_empty() {
+        return Some(format!("Result:\n{}", lines.join("\n")));
+    }
+
+    let sanitized = sanitize_gemini_result_value(result);
+    render_json_value(&sanitized).map(|rendered| format!("Result:\n{rendered}"))
+}
+
+fn collect_gemini_tool_result(value: &Value, lines: &mut Vec<String>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_gemini_tool_result(item, lines);
+            }
+        }
+        Value::Object(obj) => {
+            if let Some(function_response) = obj.get("functionResponse") {
+                collect_gemini_function_response(function_response, lines);
+                return;
+            }
+
+            if let Some(output) = obj
+                .get("response")
+                .and_then(|response| response.get("output"))
+            {
+                if let Some(rendered) = render_json_value(output) {
+                    lines.push(format!("Output:\n{rendered}"));
+                }
+            } else if let Some(output) = obj.get("output") {
+                if let Some(rendered) = render_json_value(output) {
+                    lines.push(format!("Output:\n{rendered}"));
+                }
+            }
+
+            append_gemini_part_summaries(obj.get("parts"), lines);
+        }
+        Value::String(text) if !text.trim().is_empty() => {
+            lines.push(format!("Output:\n{text}"));
+        }
+        _ => {}
+    }
+}
+
+fn collect_gemini_function_response(value: &Value, lines: &mut Vec<String>) {
+    let Some(obj) = value.as_object() else {
+        collect_gemini_tool_result(value, lines);
+        return;
+    };
+
+    let before_len = lines.len();
+    if let Some(output) = obj
+        .get("response")
+        .and_then(|response| response.get("output"))
+    {
+        if let Some(rendered) = render_json_value(output) {
+            lines.push(format!("Output:\n{rendered}"));
+        }
+    } else if let Some(response) = obj.get("response") {
+        let sanitized = sanitize_gemini_result_value(response);
+        if let Some(rendered) = render_json_value(&sanitized) {
+            lines.push(format!("Response:\n{rendered}"));
+        }
+    }
+
+    append_gemini_part_summaries(obj.get("parts"), lines);
+
+    if lines.len() == before_len {
+        let sanitized = sanitize_gemini_result_value(value);
+        if let Some(rendered) = render_json_value(&sanitized) {
+            lines.push(rendered);
+        }
+    }
+}
+
+fn append_gemini_part_summaries(parts: Option<&Value>, lines: &mut Vec<String>) {
+    let Some(Value::Array(parts)) = parts else {
+        return;
+    };
+
+    let mut summaries = Vec::new();
+    for part in parts {
+        if let Some(summary) = summarize_gemini_part(part) {
+            summaries.push(summary);
+        }
+    }
+
+    if !summaries.is_empty() {
+        lines.push(format!("Attachments:\n{}", summaries.join("\n")));
+    }
+}
+
+fn summarize_gemini_part(part: &Value) -> Option<String> {
+    let inline_data = part.get("inlineData").or_else(|| part.get("inline_data"));
+    if let Some(inline_data) = inline_data.and_then(Value::as_object) {
+        let mime = inline_data
+            .get("mimeType")
+            .or_else(|| inline_data.get("mime_type"))
+            .and_then(Value::as_str)
+            .unwrap_or("inline data");
+        let byte_count = inline_data
+            .get("data")
+            .and_then(Value::as_str)
+            .map(estimated_base64_bytes)
+            .unwrap_or(0);
+        if byte_count > 0 {
+            return Some(format!(
+                "- inlineData: {mime}, ~{byte_count} bytes (base64 omitted)"
+            ));
+        }
+        return Some(format!("- inlineData: {mime} (base64 omitted)"));
+    }
+
+    if let Some(file_data) = part.get("fileData").or_else(|| part.get("file_data")) {
+        let sanitized = sanitize_gemini_result_value(file_data);
+        return render_json_value(&sanitized).map(|rendered| format!("- fileData: {rendered}"));
+    }
+
+    None
+}
+
+fn sanitize_gemini_result_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => {
+            Value::Array(items.iter().map(sanitize_gemini_result_value).collect())
+        }
+        Value::Object(obj) => {
+            let mut sanitized = Map::new();
+            for (key, value) in obj {
+                if key == "data" {
+                    if let Some(data) = value.as_str() {
+                        if data.len() > 512 {
+                            sanitized.insert(
+                                key.clone(),
+                                Value::String(format!(
+                                    "<base64 omitted: ~{} bytes>",
+                                    estimated_base64_bytes(data)
+                                )),
+                            );
+                            continue;
+                        }
+                    }
+                }
+                sanitized.insert(key.clone(), sanitize_gemini_result_value(value));
+            }
+            Value::Object(sanitized)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn estimated_base64_bytes(data: &str) -> usize {
+    let trimmed = data.trim_end_matches('=');
+    trimmed.len() * 3 / 4
 }
 
 pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<bool, String> {
@@ -240,8 +408,8 @@ mod tests {
             r#"{
               "sessionId": "test",
               "messages": [
-                {"id":"1","timestamp":"2026-03-10T08:24:50Z","type":"gemini","content":"","toolCalls":[{"id":"call_1","name":"web_search","args":{"query":"test"}}]},
-                {"id":"2","timestamp":"2026-03-10T08:25:00Z","type":"gemini","content":"Here are the results.","toolCalls":[{"id":"call_2","name":"web_fetch","args":{"url":"http://example.com"}}]}
+                {"id":"1","timestamp":"2026-03-10T08:24:50Z","type":"gemini","content":"","toolCalls":[{"id":"call_1","name":"web_search","args":{"query":"test"},"result":[{"functionResponse":{"id":"call_1","name":"web_search","response":{"output":"result text"}}}]}]},
+                {"id":"2","timestamp":"2026-03-10T08:25:00Z","type":"gemini","content":"Here are the results.","toolCalls":[{"id":"call_2","name":"web_fetch","args":{"url":"http://example.com"},"result":[{"functionResponse":{"id":"call_2","name":"web_fetch","response":{"output":"Binary content provided (1 item(s))."},"parts":[{"inlineData":{"mimeType":"application/pdf","data":"QUJDRA=="}}]}}]}]}
               ]
             }"#,
         )
@@ -251,8 +419,17 @@ mod tests {
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0].role, "assistant");
         assert!(msgs[0].content.contains("[Tool: web_search]"));
+        assert!(msgs[0].content.contains("Call ID: call_1"));
+        assert!(msgs[0].content.contains("Query: test"));
+        assert!(msgs[0].content.contains("Result:\nOutput:\nresult text"));
         assert_eq!(msgs[1].role, "assistant");
         assert!(msgs[1].content.contains("Here are the results."));
         assert!(msgs[1].content.contains("[Tool: web_fetch]"));
+        assert!(msgs[1].content.contains("URL: http://example.com"));
+        assert!(msgs[1].content.contains("Output:\nBinary content provided"));
+        assert!(msgs[1]
+            .content
+            .contains("inlineData: application/pdf, ~4 bytes"));
+        assert!(!msgs[1].content.contains("QUJDRA=="));
     }
 }

--- a/src-tauri/src/session_manager/providers/openclaw.rs
+++ b/src-tauri/src/session_manager/providers/openclaw.rs
@@ -20,11 +20,29 @@ const PROVIDER_ID: &str = "openclaw";
 
 /// Strip trailing `\n[message_id: ...]` metadata injected by OpenClaw gateway.
 fn strip_message_id_suffix(text: &str) -> &str {
-    if let Some(pos) = text.rfind("\n[message_id:") {
-        text[..pos].trim_end()
+    let trimmed_end = text.trim_end();
+    let Some(pos) = trimmed_end.rfind('\n') else {
+        return text;
+    };
+
+    let suffix = &trimmed_end[pos + 1..];
+    if is_message_id_metadata_line(suffix) {
+        &text[..pos]
     } else {
         text
     }
+}
+
+fn is_message_id_metadata_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    let Some(id) = trimmed
+        .strip_prefix("[message_id:")
+        .and_then(|value| value.strip_suffix(']'))
+    else {
+        return false;
+    };
+
+    !id.trim().is_empty()
 }
 
 pub fn scan_sessions() -> Vec<SessionMeta> {
@@ -110,6 +128,7 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
         };
 
         let content = message.get("content").map(extract_text).unwrap_or_default();
+        let content = strip_message_id_suffix(&content).to_string();
         if content.trim().is_empty() {
             continue;
         }
@@ -427,6 +446,66 @@ mod tests {
         let title = meta.title.unwrap();
         assert!(title.len() <= TITLE_MAX_CHARS + 3); // +3 for "..."
         assert!(title.ends_with("..."));
+    }
+
+    #[test]
+    fn load_messages_strips_message_id_suffix_and_renders_tool_input() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"message\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"Bash\",\"input\":{\"command\":\"pwd\"}}]},\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+                "{\"type\":\"message\",\"message\":{\"role\":\"toolResult\",\"content\":\"/tmp/project\\n[message_id: msg_1]\"},\"timestamp\":\"2026-03-06T10:00:01Z\"}\n"
+            ),
+        )
+        .expect("write session");
+
+        let messages = load_messages(&path).expect("load messages");
+        assert_eq!(messages.len(), 2);
+        assert!(messages[0].content.contains("[Tool: Bash]"));
+        assert!(messages[0].content.contains("Command: pwd"));
+        assert_eq!(messages[1].role, "tool");
+        assert_eq!(messages[1].content, "/tmp/project");
+    }
+
+    #[test]
+    fn load_messages_preserves_content_whitespace_without_message_id_suffix() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            "{\"type\":\"message\",\"message\":{\"role\":\"toolResult\",\"content\":\"  indented output\\nline\\n  \"},\"timestamp\":\"2026-03-06T10:00:01Z\"}\n",
+        )
+        .expect("write session");
+
+        let messages = load_messages(&path).expect("load messages");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, "tool");
+        assert_eq!(messages[0].content, "  indented output\nline\n  ");
+    }
+
+    #[test]
+    fn strip_message_id_suffix_preserves_embedded_message_id_lines() {
+        let content = "command output\n[message_id: visible]\nmore output";
+
+        assert_eq!(strip_message_id_suffix(content), content);
+        assert_eq!(
+            strip_message_id_suffix("command output\n[message_id: msg_1] trailing"),
+            "command output\n[message_id: msg_1] trailing"
+        );
+    }
+
+    #[test]
+    fn strip_message_id_suffix_allows_trailing_whitespace_after_metadata() {
+        assert_eq!(
+            strip_message_id_suffix("command output\n[message_id: msg_1]\n  "),
+            "command output"
+        );
+        assert_eq!(
+            strip_message_id_suffix("command output\n\n[message_id: msg_1]\n  "),
+            "command output\n"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session_manager/providers/opencode.rs
+++ b/src-tauri/src/session_manager/providers/opencode.rs
@@ -5,7 +5,9 @@ use serde_json::Value;
 
 use crate::session_manager::{SessionMessage, SessionMeta};
 
-use super::utils::{parse_timestamp_to_ms, path_basename, truncate_summary};
+use super::utils::{
+    parse_timestamp_to_ms, path_basename, render_json_value, render_tool_call, truncate_summary,
+};
 
 const PROVIDER_ID: &str = "opencode";
 
@@ -149,7 +151,7 @@ fn scan_sessions_sqlite() -> Vec<SessionMeta> {
             created_at: Some(created),
             last_active_at: Some(updated),
             source_path: Some(format!("sqlite:{db_display}:{session_id}")),
-            resume_command: Some(format!("opencode session resume {session_id}")),
+            resume_command: Some(format!("opencode --session {session_id}")),
         });
     }
     sessions
@@ -473,7 +475,7 @@ fn parse_session(storage: &Path, path: &Path) -> Option<SessionMeta> {
         created_at,
         last_active_at: updated_at.or(created_at),
         source_path: Some(source_path),
-        resume_command: Some(format!("opencode session resume {session_id}")),
+        resume_command: Some(format!("opencode --session {session_id}")),
     })
 }
 
@@ -537,15 +539,64 @@ fn extract_part_text(part_value: &Value) -> Option<String> {
             .and_then(Value::as_str)
             .filter(|t| !t.trim().is_empty())
             .map(|t| t.to_string()),
-        Some("tool") => {
-            let tool = part_value
-                .get("tool")
-                .and_then(Value::as_str)
-                .unwrap_or("unknown");
-            Some(format!("[Tool: {tool}]"))
-        }
+        Some("tool") => Some(extract_tool_part_text(part_value)),
         _ => None,
     }
+}
+
+fn extract_tool_part_text(part_value: &Value) -> String {
+    let tool = part_value
+        .get("tool")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let call_id = part_value
+        .get("callID")
+        .or_else(|| part_value.get("call_id"))
+        .and_then(Value::as_str);
+
+    let mut lines = vec![render_tool_call(
+        tool,
+        part_value.get("state").and_then(|state| state.get("input")),
+        call_id,
+    )];
+
+    if let Some(state) = part_value.get("state") {
+        if let Some(status) = state
+            .get("status")
+            .and_then(Value::as_str)
+            .filter(|status| !status.trim().is_empty())
+        {
+            lines.push(format!("Status: {status}"));
+        }
+
+        if let Some(output) = state.get("output") {
+            if let Some(rendered) = render_json_value(output) {
+                lines.push(format!("Output:\n{rendered}"));
+            }
+        }
+
+        if let Some(error) = state.get("error") {
+            if let Some(rendered) = render_json_value(error) {
+                lines.push(format!("Error:\n{rendered}"));
+            }
+        }
+
+        let mut remaining = serde_json::Map::new();
+        if let Some(obj) = state.as_object() {
+            for (key, value) in obj {
+                if key != "input" && key != "output" && key != "error" && key != "status" {
+                    remaining.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        if !remaining.is_empty() {
+            if let Some(rendered) = render_json_value(&Value::Object(remaining)) {
+                lines.push(format!("State:\n{rendered}"));
+            }
+        }
+    }
+
+    lines.join("\n")
 }
 
 fn collect_parts_text(part_dir: &Path) -> String {
@@ -761,6 +812,9 @@ mod tests {
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "assistant");
         assert!(msgs[0].content.contains("[Tool: bash]"));
+        assert!(msgs[0].content.contains("Status: completed"));
+        assert!(msgs[0].content.contains("Command: ls"));
+        assert!(msgs[0].content.contains("Output:\nfile.txt"));
         assert!(msgs[0].content.contains("Here are the files."));
     }
 
@@ -861,7 +915,7 @@ mod tests {
                 "ses_1",
                 "msg_2",
                 2000_i64,
-                r#"{"type":"tool","tool":"bash"}"#,
+                r#"{"type":"tool","tool":"bash","state":{"status":"completed","input":{"command":"ls"},"output":"file.txt"}}"#,
             ),
         )
         .expect("insert part 2");
@@ -886,7 +940,11 @@ mod tests {
         assert_eq!(messages[0].content, "Hello");
         assert_eq!(messages[0].ts, Some(1000));
         assert_eq!(messages[1].role, "assistant");
-        assert_eq!(messages[1].content, "[Tool: bash]\nDone");
+        assert!(messages[1].content.contains("[Tool: bash]"));
+        assert!(messages[1].content.contains("Status: completed"));
+        assert!(messages[1].content.contains("Command: ls"));
+        assert!(messages[1].content.contains("Output:\nfile.txt"));
+        assert!(messages[1].content.contains("Done"));
         assert_eq!(messages[1].ts, Some(2000));
     }
 

--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -3,7 +3,7 @@ use std::io::{self, BufRead, BufReader, Seek, SeekFrom};
 use std::path::Path;
 
 use chrono::{DateTime, FixedOffset};
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 /// Maximum number of characters for session titles (shared across providers).
 pub const TITLE_MAX_CHARS: usize = 80;
@@ -76,8 +76,9 @@ pub fn extract_text(content: &Value) -> String {
         Value::Object(map) => map
             .get("text")
             .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string(),
+            .map(|text| text.to_string())
+            .or_else(|| render_json_value(content))
+            .unwrap_or_default(),
         _ => String::new(),
     }
 }
@@ -85,22 +86,25 @@ pub fn extract_text(content: &Value) -> String {
 fn extract_text_from_item(item: &Value) -> Option<String> {
     let item_type = item.get("type").and_then(Value::as_str).unwrap_or("");
 
-    // tool_use: show tool name
+    // tool_use: show tool name plus input parameters so history/search/export
+    // preserve what was actually executed.
     if item_type == "tool_use" {
         let name = item
             .get("name")
             .and_then(Value::as_str)
             .unwrap_or("unknown");
-        return Some(format!("[Tool: {name}]"));
+        let call_id = item
+            .get("id")
+            .or_else(|| item.get("tool_use_id"))
+            .and_then(Value::as_str);
+        return Some(render_tool_call(name, item.get("input"), call_id));
     }
 
-    // tool_result: extract nested content
+    // tool_result: extract nested content, but summarize non-text blocks so
+    // image/audio payloads do not dump large base64 blobs into history views.
     if item_type == "tool_result" {
         if let Some(content) = item.get("content") {
-            let text = extract_text(content);
-            if !text.is_empty() {
-                return Some(text);
-            }
+            return extract_tool_result_content(content);
         }
         return None;
     }
@@ -125,6 +129,222 @@ fn extract_text_from_item(item: &Value) -> Option<String> {
     }
 
     None
+}
+
+fn extract_tool_result_content(content: &Value) -> Option<String> {
+    let text = extract_text_without_json_fallback(content);
+    if !text.trim().is_empty() {
+        return Some(text);
+    }
+
+    summarize_tool_result_content(content).or_else(|| render_json_value(content))
+}
+
+fn extract_text_without_json_fallback(content: &Value) -> String {
+    match content {
+        Value::String(text) => text.to_string(),
+        Value::Array(items) => items
+            .iter()
+            .filter_map(extract_text_from_item)
+            .filter(|text| !text.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Value::Object(map) => ["text", "input_text", "output_text"]
+            .iter()
+            .find_map(|key| map.get(*key).and_then(Value::as_str))
+            .map(|text| text.to_string())
+            .or_else(|| {
+                map.get("content")
+                    .map(extract_text_without_json_fallback)
+                    .filter(|text| !text.trim().is_empty())
+            })
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+fn summarize_tool_result_content(content: &Value) -> Option<String> {
+    match content {
+        Value::Array(items) => {
+            if items.is_empty() {
+                return None;
+            }
+
+            let summaries = items
+                .iter()
+                .filter_map(summarize_tool_result_item)
+                .collect::<Vec<_>>();
+
+            if summaries.is_empty() {
+                Some("[Tool result: non-text content]".to_string())
+            } else {
+                Some(summaries.join("\n"))
+            }
+        }
+        Value::Object(_) => summarize_tool_result_item(content),
+        _ => None,
+    }
+}
+
+fn summarize_tool_result_item(item: &Value) -> Option<String> {
+    let item_type = item.get("type").and_then(Value::as_str)?;
+
+    match item_type {
+        "image" => {
+            let media_type = item
+                .get("source")
+                .and_then(|source| source.get("media_type"))
+                .or_else(|| item.get("media_type"))
+                .and_then(Value::as_str);
+
+            Some(match media_type {
+                Some(media_type) if !media_type.trim().is_empty() => {
+                    format!("[Image: {media_type}]")
+                }
+                _ => "[Image]".to_string(),
+            })
+        }
+        "audio" => Some("[Audio]".to_string()),
+        "file" => item
+            .get("name")
+            .or_else(|| item.get("filename"))
+            .or_else(|| item.get("path"))
+            .and_then(Value::as_str)
+            .filter(|name| !name.trim().is_empty())
+            .map(|name| format!("[File: {name}]"))
+            .or_else(|| Some("[File]".to_string())),
+        other if !other.trim().is_empty() => Some(format!("[Tool result: {other}]")),
+        _ => None,
+    }
+}
+
+pub fn render_tool_call(name: &str, input: Option<&Value>, call_id: Option<&str>) -> String {
+    let mut lines = vec![format!("[Tool: {name}]")];
+
+    if let Some(call_id) = call_id.filter(|id| !id.trim().is_empty()) {
+        lines.push(format!("Call ID: {call_id}"));
+    }
+
+    let Some(input) = input else {
+        return lines.join("\n");
+    };
+
+    match input {
+        Value::Object(map) => append_tool_input_object(name, map, &mut lines),
+        Value::Null => {}
+        _ => {
+            if let Some(rendered) = render_json_value(input) {
+                lines.push(format!("Input:\n{rendered}"));
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn append_tool_input_object(name: &str, input: &Map<String, Value>, lines: &mut Vec<String>) {
+    if input.is_empty() {
+        return;
+    }
+
+    let lower_name = name.to_ascii_lowercase();
+    if lower_name == "todowrite" || lower_name == "todo_write" {
+        if let Some(todos) = input.get("todos").and_then(Value::as_array) {
+            if !todos.is_empty() {
+                for todo in todos {
+                    let content = todo
+                        .get("content")
+                        .or_else(|| todo.get("task"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let status = todo
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown");
+                    if content.trim().is_empty() {
+                        if let Some(rendered) = render_json_value(todo) {
+                            lines.push(format!("- {status}: {rendered}"));
+                        }
+                    } else {
+                        lines.push(format!("- {status}: {content}"));
+                    }
+                }
+                append_remaining_input(input, &["todos"], lines);
+                return;
+            }
+        }
+    }
+
+    let ordered_keys = [
+        "command",
+        "description",
+        "file_path",
+        "filePath",
+        "path",
+        "pattern",
+        "url",
+        "query",
+        "prompt",
+        "old_string",
+        "new_string",
+        "replace_all",
+    ];
+    let mut consumed = Vec::new();
+
+    for key in ordered_keys {
+        if let Some(value) = input.get(key) {
+            if let Some(rendered) = render_json_value(value) {
+                lines.push(format!("{}: {rendered}", tool_input_label(key)));
+                consumed.push(key);
+            }
+        }
+    }
+
+    append_remaining_input(input, &consumed, lines);
+}
+
+fn append_remaining_input(input: &Map<String, Value>, consumed: &[&str], lines: &mut Vec<String>) {
+    let mut remaining = Map::new();
+    for (key, value) in input {
+        if !consumed.iter().any(|consumed_key| consumed_key == key) {
+            remaining.insert(key.clone(), value.clone());
+        }
+    }
+
+    if remaining.is_empty() {
+        return;
+    }
+
+    if let Some(rendered) = render_json_value(&Value::Object(remaining)) {
+        lines.push(format!("Input:\n{rendered}"));
+    }
+}
+
+fn tool_input_label(key: &str) -> &'static str {
+    match key {
+        "command" => "Command",
+        "description" => "Description",
+        "file_path" | "filePath" => "File",
+        "path" => "Path",
+        "pattern" => "Pattern",
+        "url" => "URL",
+        "query" => "Query",
+        "prompt" => "Prompt",
+        "old_string" => "Old",
+        "new_string" => "New",
+        "replace_all" => "Replace All",
+        _ => "Input",
+    }
+}
+
+pub fn render_json_value(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(text) => (!text.trim().is_empty()).then(|| text.to_string()),
+        Value::Array(items) if items.is_empty() => None,
+        Value::Object(map) if map.is_empty() => None,
+        _ => serde_json::to_string_pretty(value).ok(),
+    }
 }
 
 pub fn truncate_summary(text: &str, max_chars: usize) -> String {
@@ -173,5 +393,90 @@ mod tests {
             parse_timestamp_to_ms(&json!("1970-01-01T00:00:01Z")),
             Some(1_000)
         );
+    }
+
+    #[test]
+    fn extract_text_renders_tool_use_input() {
+        let content = json!([{
+            "type": "tool_use",
+            "id": "toolu_1",
+            "name": "Bash",
+            "input": {
+                "command": "ls -la",
+                "description": "list files"
+            }
+        }]);
+
+        let text = extract_text(&content);
+        assert!(text.contains("[Tool: Bash]"));
+        assert!(text.contains("Call ID: toolu_1"));
+        assert!(text.contains("Command: ls -la"));
+        assert!(text.contains("Description: list files"));
+    }
+
+    #[test]
+    fn extract_text_summarizes_non_text_tool_result_blocks() {
+        let content = json!([{
+            "type": "tool_result",
+            "tool_use_id": "toolu_1",
+            "content": [{
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "iVBORw0KGgoAAAANSUhEUgAA"
+                }
+            }]
+        }]);
+
+        let text = extract_text(&content);
+        assert_eq!(text, "[Image: image/png]");
+        assert!(!text.contains("iVBORw0KGgo"));
+        assert!(!text.contains("\"data\""));
+    }
+
+    #[test]
+    fn extract_text_preserves_structured_tool_result_without_typed_blocks() {
+        let content = json!([{
+            "type": "tool_result",
+            "content": {
+                "status": "ok",
+                "count": 2
+            }
+        }]);
+
+        let text = extract_text(&content);
+        assert!(text.contains("\"status\": \"ok\""));
+        assert!(text.contains("\"count\": 2"));
+    }
+
+    #[test]
+    fn render_tool_call_preserves_unknown_input_json() {
+        let text = render_tool_call(
+            "mcp__demo__tool",
+            Some(&json!({"custom": {"nested": true}})),
+            None,
+        );
+
+        assert!(text.contains("[Tool: mcp__demo__tool]"));
+        assert!(text.contains("Input:"));
+        assert!(text.contains("\"nested\": true"));
+    }
+
+    #[test]
+    fn render_tool_call_formats_todos() {
+        let text = render_tool_call(
+            "TodoWrite",
+            Some(&json!({
+                "todos": [
+                    {"status": "pending", "content": "implement backend renderer"},
+                    {"status": "completed", "content": "add plan"}
+                ]
+            })),
+            None,
+        );
+
+        assert!(text.contains("- pending: implement backend renderer"));
+        assert!(text.contains("- completed: add plan"));
     }
 }

--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -132,12 +132,24 @@ fn extract_text_from_item(item: &Value) -> Option<String> {
 }
 
 fn extract_tool_result_content(content: &Value) -> Option<String> {
+    let mut parts = Vec::new();
+
     let text = extract_text_without_json_fallback(content);
     if !text.trim().is_empty() {
-        return Some(text);
+        parts.push(text);
     }
 
-    summarize_tool_result_content(content).or_else(|| render_json_value(content))
+    if let Some(summary) = summarize_tool_result_content(content) {
+        if !summary.trim().is_empty() {
+            parts.push(summary);
+        }
+    }
+
+    if parts.is_empty() {
+        render_json_value(content)
+    } else {
+        Some(parts.join("\n"))
+    }
 }
 
 fn extract_text_without_json_fallback(content: &Value) -> String {
@@ -170,8 +182,17 @@ fn summarize_tool_result_content(content: &Value) -> Option<String> {
                 return None;
             }
 
-            let summaries = items
+            let non_text_items = items
                 .iter()
+                .filter(|item| extract_text_without_json_fallback(item).trim().is_empty())
+                .collect::<Vec<_>>();
+
+            if non_text_items.is_empty() {
+                return None;
+            }
+
+            let summaries = non_text_items
+                .into_iter()
                 .filter_map(summarize_tool_result_item)
                 .collect::<Vec<_>>();
 
@@ -181,7 +202,16 @@ fn summarize_tool_result_content(content: &Value) -> Option<String> {
                 Some(summaries.join("\n"))
             }
         }
-        Value::Object(_) => summarize_tool_result_item(content),
+        Value::Object(_) => {
+            if !extract_text_without_json_fallback(content)
+                .trim()
+                .is_empty()
+            {
+                None
+            } else {
+                summarize_tool_result_item(content)
+            }
+        }
         _ => None,
     }
 }
@@ -433,6 +463,31 @@ mod tests {
         assert_eq!(text, "[Image: image/png]");
         assert!(!text.contains("iVBORw0KGgo"));
         assert!(!text.contains("\"data\""));
+    }
+
+    #[test]
+    fn extract_text_preserves_mixed_tool_result_text_and_attachments() {
+        let content = json!([{
+            "type": "tool_result",
+            "tool_use_id": "toolu_1",
+            "content": [
+                {"type": "text", "text": "Created screenshot"},
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "iVBORw0KGgoAAAANSUhEUgAA"
+                    }
+                }
+            ]
+        }]);
+
+        let text = extract_text(&content);
+        assert!(text.contains("Created screenshot"));
+        assert!(text.contains("[Image: image/png]"));
+        assert!(!text.contains("iVBORw0KGgo"));
+        assert!(!text.contains("[Tool result: text]"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR improves session history parsing/rendering for tool calls and tool results across multiple CLI providers.

Changes included:

- Fix OpenCode resume command
  - `opencode session resume <id>` -> `opencode --session <id>`

- Fix OpenCode history tool information rendering
  - Render tool call input arguments
  - Render tool status, output, error, and remaining state fields
  - Preserve useful tool details for history/search/export instead of showing only `[Tool: ...]`

- Improve Claude Code history tool rendering
  - Render `tool_use` name, call id, and input arguments
  - Preserve useful `tool_result` content for history/search/export
  - Summarize non-text tool result blocks instead of dropping them

- Fix Gemini history tool information rendering
  - Render `toolCalls[].args`
  - Render `toolCalls[].result`, especially `functionResponse.response.output`
  - Avoid dumping large `inlineData.data` base64 payloads; show attachment summaries instead

- Fix OpenClaw history tool information rendering
  - Render tool input details
  - Map `toolResult` messages to tool role
  - Strip trailing `[message_id: ...]` metadata from displayed content

- Improve Codex function call rendering
  - Render `call_id`
  - Parse and display function call arguments

## Notes

Hermes is intentionally not changed in this PR.

While reviewing the session providers, I did not find a clear Hermes session entry point in the current frontend. To avoid making backend-only behavior changes without a visible UI path or real usage context, I left Hermes untouched in this PR.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml session_manager::providers --lib`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
