### PR TITLE
fix: normalize localhost listen address

### DIFF
--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -139,6 +139,8 @@ export function ProxyPanel({
         return false;
       }
     };
+    const normalizedAddress =
+      addressTrimmed === "localhost" ? "127.0.0.1" : addressTrimmed;
     const isValidAddress =
       addressTrimmed === "localhost" ||
       addressTrimmed === "0.0.0.0" ||
@@ -176,7 +178,7 @@ export function ProxyPanel({
     try {
       await updateGlobalConfig.mutateAsync({
         ...globalConfig,
-        listenAddress: addressTrimmed,
+        listenAddress: normalizedAddress,
         listenPort: port,
       });
       toast.success(


### PR DESCRIPTION
## Summary / 概述

Save `localhost` as `127.0.0.1` in the local routing listen address, because the routing server only accepts IPs

## Related Issue / 关联 Issue

Fixes #3005

## Screenshots / 截图



## Checklist / 检查清单

- [ ] pnpm typecheck passes / 通过 TypeScript 类型检查
- [x] pnpm format:check passes / 通过代码格式检查
- [x] cargo clippy passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件