### PR TITLE
fix: resolve MCP config sync path bug when claudeConfigDir is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP sync ignored when `claudeConfigDir` is set**: when users configured a custom Claude config directory (matching Claude Code's `CLAUDE_CONFIG_DIR` env var), cc-switch wrote `mcpServers` updates to `<override>.json` *next to* the override directory instead of to `<override>/.claude.json` *inside* it. Claude Code reads the latter, so toggling MCP servers in cc-switch silently had no effect on the running Claude Code instance. cc-switch now writes to the correct in-directory path, and migrates existing data from the legacy sibling location on first launch after upgrade.
+
 ## [3.15.0] - 2026-05-16
 
 Development since v3.14.1 focuses on a dedicated Claude Desktop surface with third-party provider switching through a proxy gateway, a large reverse-proxy hardening pass (reliability, retries, cache, takeover, Gemini/Vertex/Codex paths), expansion of the third-party provider preset catalog (BytePlus / Volcengine / ClaudeAPI / ClaudeCN / RunAPI / RelaxyCode / PatewayAI / Baidu Qianfan), role-based model mapping with a 1M context flag, Codex OAuth live model discovery, and a long tail of usage, OAuth, Codex, and session quality-of-life fixes.

--- a/src-tauri/src/claude_mcp.rs
+++ b/src-tauri/src/claude_mcp.rs
@@ -103,19 +103,28 @@ fn user_config_path() -> PathBuf {
 }
 
 fn ensure_mcp_override_migrated() {
-    if crate::settings::get_claude_override_dir().is_none() {
+    let Some(override_dir) = crate::settings::get_claude_override_dir() else {
         return;
-    }
+    };
 
     let new_path = get_claude_mcp_path();
     if new_path.exists() {
         return;
     }
 
-    let legacy_path = get_default_claude_mcp_path();
-    if !legacy_path.exists() {
-        return;
-    }
+    // 迁移来源优先级：
+    //   1. 旧版本（v3.15.x 及更早）写错的"覆盖目录同级"位置——这是本次修复
+    //      的主要历史包袱，先尝试它，避免老用户配置看似消失。
+    //   2. 默认位置 `~/.claude.json`——首次为已有 Claude Code 用户启用覆盖目录时的兜底。
+    let candidates = [
+        crate::config::derive_legacy_sibling_mcp_path(&override_dir),
+        Some(get_default_claude_mcp_path()),
+    ];
+    let source = candidates
+        .into_iter()
+        .flatten()
+        .find(|p| p.exists() && p != &new_path);
+    let Some(source) = source else { return };
 
     if let Some(parent) = new_path.parent() {
         if let Err(err) = fs::create_dir_all(parent) {
@@ -124,18 +133,18 @@ fn ensure_mcp_override_migrated() {
         }
     }
 
-    match fs::copy(&legacy_path, &new_path) {
+    match fs::copy(&source, &new_path) {
         Ok(_) => {
             log::info!(
                 "已根据覆盖目录复制 MCP 配置: {} -> {}",
-                legacy_path.display(),
+                source.display(),
                 new_path.display()
             );
         }
         Err(err) => {
             log::warn!(
                 "复制 MCP 配置失败: {} -> {}: {}",
-                legacy_path.display(),
+                source.display(),
                 new_path.display(),
                 err
             );

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -47,7 +47,16 @@ pub fn get_default_claude_mcp_path() -> PathBuf {
     get_home_dir().join(".claude.json")
 }
 
-fn derive_mcp_path_from_override(dir: &Path) -> Option<PathBuf> {
+/// 旧版（v3.15.x 及更早）在设置了覆盖目录时，将 MCP 配置写到目录**同级**的位置，
+/// 例如覆盖目录为 `/tmp/profile/.claude` 时写到 `/tmp/profile/.claude.json`。
+///
+/// 该假设在默认布局（`~/.claude` 目录与 `~/.claude.json` 平级）下成立，但与
+/// Claude Code 在 `CLAUDE_CONFIG_DIR` 模式下的实际行为不符——Claude Code 读取
+/// 的是 `$CLAUDE_CONFIG_DIR/.claude.json`，即目录**内部**。
+///
+/// 该函数已不再用于决定新的写入位置，仅在迁移逻辑中用于定位旧版本写错的位置，
+/// 以便把它们搬到 [`get_claude_mcp_path`] 返回的正确位置。
+pub(crate) fn derive_legacy_sibling_mcp_path(dir: &Path) -> Option<PathBuf> {
     let file_name = dir
         .file_name()
         .map(|name| name.to_string_lossy().to_string())?
@@ -60,12 +69,14 @@ fn derive_mcp_path_from_override(dir: &Path) -> Option<PathBuf> {
     Some(parent.join(format!("{file_name}.json")))
 }
 
-/// 获取 Claude MCP 配置文件路径，若设置了目录覆盖则与覆盖目录同级
+/// 获取 Claude MCP 配置文件路径。
+///
+/// - 默认（未设置覆盖目录）：`~/.claude.json`
+/// - 设置了覆盖目录（对应 Claude Code 的 `CLAUDE_CONFIG_DIR`）：返回该目录**内部**的
+///   `.claude.json`，与 Claude Code 自身读取 `$CLAUDE_CONFIG_DIR/.claude.json` 的行为一致。
 pub fn get_claude_mcp_path() -> PathBuf {
     if let Some(custom_dir) = crate::settings::get_claude_override_dir() {
-        if let Some(path) = derive_mcp_path_from_override(&custom_dir) {
-            return path;
-        }
+        return custom_dir.join(".claude.json");
     }
     get_default_claude_mcp_path()
 }
@@ -263,33 +274,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn derive_mcp_path_from_override_preserves_folder_name() {
+    fn derive_legacy_sibling_mcp_path_preserves_folder_name() {
         let override_dir = PathBuf::from("/tmp/profile/.claude");
-        let derived = derive_mcp_path_from_override(&override_dir)
+        let derived = derive_legacy_sibling_mcp_path(&override_dir)
             .expect("should derive path for nested dir");
         assert_eq!(derived, PathBuf::from("/tmp/profile/.claude.json"));
     }
 
     #[test]
-    fn derive_mcp_path_from_override_handles_non_hidden_folder() {
+    fn derive_legacy_sibling_mcp_path_handles_non_hidden_folder() {
         let override_dir = PathBuf::from("/data/claude-config");
-        let derived = derive_mcp_path_from_override(&override_dir)
+        let derived = derive_legacy_sibling_mcp_path(&override_dir)
             .expect("should derive path for standard dir");
         assert_eq!(derived, PathBuf::from("/data/claude-config.json"));
     }
 
     #[test]
-    fn derive_mcp_path_from_override_supports_relative_rootless_dir() {
+    fn derive_legacy_sibling_mcp_path_supports_relative_rootless_dir() {
         let override_dir = PathBuf::from("claude");
-        let derived = derive_mcp_path_from_override(&override_dir)
+        let derived = derive_legacy_sibling_mcp_path(&override_dir)
             .expect("should derive path for single segment");
         assert_eq!(derived, PathBuf::from("claude.json"));
     }
 
     #[test]
-    fn derive_mcp_path_from_root_like_dir_returns_none() {
+    fn derive_legacy_sibling_mcp_path_from_root_like_dir_returns_none() {
         let override_dir = PathBuf::from("/");
-        assert!(derive_mcp_path_from_override(&override_dir).is_none());
+        assert!(derive_legacy_sibling_mcp_path(&override_dir).is_none());
     }
 
     #[test]

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -4,8 +4,9 @@ use std::fs;
 use serde_json::json;
 
 use cc_switch_lib::{
-    get_claude_mcp_path, get_claude_settings_path, import_default_config_test_hook, AppError,
-    AppType, McpApps, McpServer, McpService, MultiAppConfig,
+    get_claude_mcp_path, get_claude_settings_path, import_default_config_test_hook,
+    update_settings, AppError, AppSettings, AppType, McpApps, McpServer, McpService,
+    MultiAppConfig,
 };
 
 #[path = "support.rs"]
@@ -766,4 +767,183 @@ fn sync_all_enabled_removes_known_disabled_but_preserves_unknown_live_entries() 
         servers.contains_key("external-only"),
         "live entries unknown to DB should be preserved"
     );
+}
+
+/// 回归测试：当用户配置了 `claudeConfigDir`（对应 Claude Code 的
+/// `CLAUDE_CONFIG_DIR`），启用某个 MCP 服务器后，cc-switch 必须把它写到
+/// `<override>/.claude.json`（即覆盖目录**内部**，与 Claude Code 实际读取的位置一致）；
+/// 而不是 `<override>.json`（v3.15.x 及更早的 bug：会写到目录的同级位置）。同时
+/// 不应覆盖目标文件中 `mcpServers` 之外的字段。
+#[test]
+fn toggle_claude_mcp_writes_into_override_dir() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let parent = home.join("toggle-override-path");
+    let override_dir = parent.join(".claude");
+    fs::create_dir_all(&override_dir).expect("create override dir");
+
+    // 预先在正确位置准备一份带有其他字段的 .claude.json，验证写入不会清掉它们
+    let existing = json!({
+        "userID": "preserve-me",
+        "mcpServers": {
+            "preexisting": { "type": "stdio", "command": "echo" }
+        }
+    });
+    fs::write(
+        override_dir.join(".claude.json"),
+        serde_json::to_string_pretty(&existing).expect("serialize"),
+    )
+    .expect("seed existing .claude.json");
+
+    let settings = AppSettings {
+        claude_config_dir: Some(override_dir.to_string_lossy().into_owned()),
+        ..AppSettings::default()
+    };
+    update_settings(settings).expect("apply override settings");
+
+    // 验证路径解析也走的是正确位置
+    assert_eq!(
+        get_claude_mcp_path(),
+        override_dir.join(".claude.json"),
+        "get_claude_mcp_path must point inside the override directory"
+    );
+
+    let state = create_test_state().expect("create test state");
+    McpService::upsert_server(
+        &state,
+        McpServer {
+            id: "new-server".to_string(),
+            name: "New".to_string(),
+            server: json!({ "type": "stdio", "command": "echo" }),
+            apps: McpApps {
+                claude: true,
+                codex: false,
+                gemini: false,
+                opencode: false,
+                hermes: false,
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        },
+    )
+    .expect("upsert with claude enabled");
+
+    let target = override_dir.join(".claude.json");
+    assert!(
+        target.exists(),
+        "override-internal .claude.json should exist"
+    );
+    let sibling_wrong = parent.join(".claude.json");
+    assert!(
+        !sibling_wrong.exists(),
+        "must not write to legacy sibling path"
+    );
+
+    let text = fs::read_to_string(&target).expect("read .claude.json");
+    let value: serde_json::Value = serde_json::from_str(&text).expect("parse json");
+    assert_eq!(
+        value.get("userID").and_then(|v| v.as_str()),
+        Some("preserve-me"),
+        "non-mcp fields must be preserved"
+    );
+    let servers = value
+        .get("mcpServers")
+        .and_then(|v| v.as_object())
+        .expect("mcpServers");
+    assert!(servers.contains_key("preexisting"));
+    assert!(servers.contains_key("new-server"));
+
+    update_settings(AppSettings::default()).expect("reset settings");
+}
+
+/// 回归测试：升级场景。如果用户在旧 cc-switch（v3.15.x 及更早）下已经把
+/// MCP 配置写到了"覆盖目录同级"的错误位置，升级后首次写入应自动将该文件
+/// 搬迁到正确的目录内部位置，保留其中所有条目。
+#[test]
+fn override_migrates_legacy_sibling_file_to_inside_dir() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let parent = home.join("migration-override-path");
+    let override_dir = parent.join(".claude");
+    // 创建覆盖目录本身（模拟 Claude Code 已经使用过该目录），让
+    // should_sync_claude_mcp 通过；但不在内部留下 .claude.json，迫使迁移逻辑
+    // 从旧的同级位置搬数据过来。
+    fs::create_dir_all(&override_dir).expect("create override dir");
+
+    // 模拟旧 cc-switch 写错的位置：parent/.claude.json
+    let legacy_sibling = parent.join(".claude.json");
+    let legacy_payload = json!({
+        "userID": "from-legacy",
+        "mcpServers": {
+            "legacy-server": { "type": "stdio", "command": "echo" }
+        }
+    });
+    fs::write(
+        &legacy_sibling,
+        serde_json::to_string_pretty(&legacy_payload).expect("serialize"),
+    )
+    .expect("seed legacy sibling file");
+
+    let settings = AppSettings {
+        claude_config_dir: Some(override_dir.to_string_lossy().into_owned()),
+        ..AppSettings::default()
+    };
+    update_settings(settings).expect("apply override settings");
+
+    // 触发一次写入路径（启用新服务器），让 ensure_mcp_override_migrated 被调用
+    let state = create_test_state().expect("create test state");
+    McpService::upsert_server(
+        &state,
+        McpServer {
+            id: "fresh-server".to_string(),
+            name: "Fresh".to_string(),
+            server: json!({ "type": "stdio", "command": "echo" }),
+            apps: McpApps {
+                claude: true,
+                codex: false,
+                gemini: false,
+                opencode: false,
+                hermes: false,
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        },
+    )
+    .expect("upsert with claude enabled");
+
+    let target = override_dir.join(".claude.json");
+    assert!(
+        target.exists(),
+        "migrated file should exist at new location"
+    );
+
+    let text = fs::read_to_string(&target).expect("read migrated file");
+    let value: serde_json::Value = serde_json::from_str(&text).expect("parse json");
+    assert_eq!(
+        value.get("userID").and_then(|v| v.as_str()),
+        Some("from-legacy"),
+        "non-mcp fields from legacy file must be carried over"
+    );
+    let servers = value
+        .get("mcpServers")
+        .and_then(|v| v.as_object())
+        .expect("mcpServers");
+    assert!(
+        servers.contains_key("legacy-server"),
+        "legacy entries must survive the migration"
+    );
+    assert!(
+        servers.contains_key("fresh-server"),
+        "newly-enabled server must also be written"
+    );
+
+    update_settings(AppSettings::default()).expect("reset settings");
 }


### PR DESCRIPTION
## Summary / 概述
修复 cc-switch 在用户设置了 `claudeConfigDir`（对应 Claude Code 的 `CLAUDE_CONFIG_DIR` 环境变量）时，MCP 配置写入到错误位置、导致对 Claude Code 完全不生效的 bug。

**根因**：`src-tauri/src/config.rs::derive_mcp_path_from_override` 把 MCP 路径拼到了覆盖目录的**同级**位置（如 `.../claude code/.claude.json`），但 Claude Code 在 `CLAUDE_CONFIG_DIR` 模式下实际读取的是覆盖目录的**内部**（`.../claude code/.claude/.claude.json`)。这个假设在默认布局（`~/.claude` 与 `~/.claude.json` 平级）下成立，但在覆盖模式下与 Claude Code 行为不符。

**现象**：用户在 cc-switch UI 启用 MCP → cc-switch DB 里 `enabled_claude=1` ✅ → cc-switch 写盘到"幽灵文件" ✅ → 但 Claude Code 读的是另一个文件，看不到这条 MCP；表面上像是"启用按钮不生效"。

**修复**：
- `get_claude_mcp_path()` 在设置了覆盖目录时返回 `dir.join(".claude.json")`（覆盖目录**内部**），与 Claude Code 真实行为对齐。
- 原 `derive_mcp_path_from_override` 重命名为 `derive_legacy_sibling_mcp_path` 并 `pub(crate)` 化——不再决定新写入位置，仅供升级迁移逻辑用于定位旧版本写错的同级位置。
- `ensure_mcp_override_migrated()` 升级：候选迁移来源按优先级试探"旧版同级位置"→"默认 `~/.claude.json`"，让从旧版升级的用户配置自动搬到正确位置，且当新位置已存在文件时跳过、不覆盖。

新增 2 个集成测试覆盖正向写入和升级迁移两个场景。

此bug影响所有使用`CLAUDE_CONFIG_DIR`或在cc-switch中设置`claudeConfigDir`的Claude Code用户，适用于任何平台。

## Related Issue / 关联 Issue

Fixes #3023 

## Screenshots / 截图

<details>
<summary>Disk-level evidence (no UI screenshot needed to demonstrate the bug) / 磁盘层面证据</summary>

设置 `claudeConfigDir = E:\Programming\claude code\.claude` 后，在 cc-switch UI 启用一个 MCP，磁盘上同时出现两个 `.claude.json`：

| Path | Size | Contents | Used by |
|---|---|---|---|
| `E:\Programming\claude code\.claude.json` | 694 B | tavily + **serper** | **cc-switch ghost write (bug)** |
| `E:\Programming\claude code\.claude\.claude.json` | 14 KB | tavily only | **Claude Code (real read)** |

修复后 cc-switch 只会写入第二条路径，且 `/mcp` 在 Claude Code 内能立即看到新启用的服务器。

</details>

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查 *(no frontend changes in this PR / 此 PR 未改前端)*
- [x] `pnpm format:check` passes / 通过代码格式检查 *(no frontend changes in this PR / 此 PR 未改前端)*
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码） *(this PR introduces no new clippy warnings; 25 pre-existing warnings in `src/commands/misc.rs` are untouched and unrelated / 本次改动未引入新的 clippy 告警；`src/commands/misc.rs` 中既有的 25 条告警与本修复无关)*
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 *(no user-facing text changed / 未修改用户可见文本)*

### Additional verification / 附加验证

- `cargo fmt --check` — clean / 干净
- `cargo test --test mcp_commands -- --test-threads=1` — **16/16 passed**, including 2 new regression tests:
  - `toggle_claude_mcp_writes_into_override_dir`
  - `override_migrates_legacy_sibling_file_to_inside_dir`
- Toolchain: rustc 1.95 (matches `rust-toolchain.toml`)
