### PR TITLE
fix: harden Codex chat tool conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,6 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.1.12"
-  }
+  },
+  "packageManager": "pnpm@10.33.0+sha1.46a0bef28aad690765997ab6da6d5475bdd4148e"
 }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1148,7 +1148,7 @@ impl RequestForwarder {
         let request_body = if codex_responses_to_chat {
             let input_items = mapped_body.get("input").and_then(|v| v.as_array());
             if let Some(items) = input_items {
-                log::warn!(
+                log::debug!(
                     "[codex->chat] converting {} input items: {}",
                     items.len(),
                     items.iter().enumerate().map(|(i, item)| {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1146,7 +1146,45 @@ impl RequestForwarder {
 
         // 转换请求体（如果需要）
         let request_body = if codex_responses_to_chat {
-            super::providers::transform_codex_chat::responses_to_chat_completions(mapped_body)?
+            let input_items = mapped_body.get("input").and_then(|v| v.as_array());
+            if let Some(items) = input_items {
+                log::warn!(
+                    "[codex->chat] converting {} input items: {}",
+                    items.len(),
+                    items.iter().enumerate().map(|(i, item)| {
+                        let t = item.get("type").and_then(|v| v.as_str()).unwrap_or("message");
+                        let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("-");
+                        let call_id = item.get("call_id").or_else(|| item.get("id"))
+                            .and_then(|v| v.as_str()).unwrap_or("-");
+                        format!("[{i}] type={t} role={role} call_id={call_id}")
+                    }).collect::<Vec<_>>().join(", ")
+                );
+            }
+            let converted = super::providers::transform_codex_chat::responses_to_chat_completions(mapped_body)?;
+            if let Some(msgs) = converted.get("messages").and_then(|v| v.as_array()) {
+                log::debug!(
+                    "[codex->chat] produced {} chat messages: {}",
+                    msgs.len(),
+                    msgs.iter().enumerate().map(|(i, m)| {
+                        let role = m.get("role").and_then(|v| v.as_str()).unwrap_or("?");
+                        let tc_ids: Vec<&str> = m.get("tool_calls")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| arr.iter()
+                                .filter_map(|tc| tc.get("id").and_then(|v| v.as_str()))
+                                .collect())
+                            .unwrap_or_default();
+                        let tid = m.get("tool_call_id").and_then(|v| v.as_str()).unwrap_or("-");
+                        if !tc_ids.is_empty() {
+                            format!("[{i}] role={role} tool_calls={}", tc_ids.join("+"))
+                        } else if tid != "-" {
+                            format!("[{i}] role={role} tool_call_id={tid}")
+                        } else {
+                            format!("[{i}] role={role}")
+                        }
+                    }).collect::<Vec<_>>().join(", ")
+                );
+            }
+            converted
         } else if needs_transform {
             if adapter.name() == "Claude" {
                 let api_format = resolved_claude_api_format

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -121,8 +121,6 @@ fn append_responses_input_as_chat_messages(
     input: &Value,
     messages: &mut Vec<Value>,
 ) -> Result<(), ProxyError> {
-    let mut pending_tool_calls = Vec::new();
-
     match input {
         Value::String(text) => {
             messages.push(json!({
@@ -130,57 +128,107 @@ fn append_responses_input_as_chat_messages(
                 "content": text
             }));
         }
-        Value::Array(items) => {
-            for item in items {
-                append_responses_item_as_chat_message(item, messages, &mut pending_tool_calls)?;
-            }
-        }
+        Value::Array(items) => append_responses_items_as_chat_messages(items, messages)?,
         Value::Object(_) => {
-            append_responses_item_as_chat_message(input, messages, &mut pending_tool_calls)?;
+            append_responses_item_as_chat_message(input, messages)?;
         }
         _ => {}
     }
-
-    flush_pending_tool_calls(messages, &mut pending_tool_calls);
     Ok(())
+}
+
+fn append_responses_items_as_chat_messages(
+    items: &[Value],
+    messages: &mut Vec<Value>,
+) -> Result<(), ProxyError> {
+    let mut index = 0;
+    while index < items.len() {
+        if is_responses_function_call(&items[index]) {
+            index = append_contiguous_tool_block(items, index, messages);
+            continue;
+        }
+
+        append_responses_item_as_chat_message(&items[index], messages)?;
+        index += 1;
+    }
+
+    Ok(())
+}
+
+fn append_contiguous_tool_block(items: &[Value], start: usize, messages: &mut Vec<Value>) -> usize {
+    let mut next_index = start;
+    let mut tool_calls = Vec::new();
+    let mut call_id_to_index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    while next_index < items.len() && is_responses_function_call(&items[next_index]) {
+        let tc = responses_function_call_to_chat_tool_call(&items[next_index]);
+        if let Some(id) = tc.get("id").and_then(|v| v.as_str()).filter(|id| !id.is_empty()) {
+            call_id_to_index.insert(id.to_string(), tool_calls.len());
+        }
+        tool_calls.push(tc);
+        next_index += 1;
+    }
+
+    if tool_calls.is_empty() {
+        return next_index;
+    }
+
+    let mut output_index = next_index;
+    let mut paired_call_indices: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut tool_messages: Vec<Value> = Vec::new();
+    while output_index < items.len() {
+        let output_item = &items[output_index];
+        if !is_responses_function_call_output(output_item) {
+            break;
+        };
+        let Some(output_call_id) = responses_call_id(output_item) else {
+            break;
+        };
+        if let Some(&call_index) = call_id_to_index.get(output_call_id) {
+            if !paired_call_indices.contains(&call_index) {
+                paired_call_indices.insert(call_index);
+                tool_messages.push(responses_function_call_output_to_chat_message(output_item));
+                output_index += 1;
+                continue;
+            }
+        }
+        break;
+    }
+
+    if paired_call_indices.is_empty() {
+        return next_index;
+    }
+
+    let final_tool_calls: Vec<Value> = tool_calls.into_iter().enumerate()
+        .filter(|(i, _)| paired_call_indices.contains(&i))
+        .map(|(_, tc)| tc)
+        .collect();
+
+    messages.push(json!({
+        "role": "assistant",
+        "content": null,
+        "tool_calls": final_tool_calls
+    }));
+    messages.extend(tool_messages);
+    output_index
 }
 
 fn append_responses_item_as_chat_message(
     item: &Value,
     messages: &mut Vec<Value>,
-    pending_tool_calls: &mut Vec<Value>,
 ) -> Result<(), ProxyError> {
     let item_type = item.get("type").and_then(|v| v.as_str());
     match item_type {
-        Some("function_call") => {
-            pending_tool_calls.push(responses_function_call_to_chat_tool_call(item));
-        }
-        Some("function_call_output") => {
-            flush_pending_tool_calls(messages, pending_tool_calls);
-            let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
-            let output = match item.get("output") {
-                Some(Value::String(s)) => s.clone(),
-                Some(v) => canonical_json_string(v),
-                None => String::new(),
-            };
-            messages.push(json!({
-                "role": "tool",
-                "tool_call_id": call_id,
-                "content": output
-            }));
-        }
+        Some("function_call") | Some("function_call_output") => {}
         Some("reasoning") => {
             // Reasoning items are Responses-specific context. Chat-only providers
             // cannot consume encrypted reasoning state, so omit it.
         }
         Some("message") | None => {
-            flush_pending_tool_calls(messages, pending_tool_calls);
             if item.get("role").is_some() || item.get("content").is_some() {
                 messages.push(responses_message_item_to_chat_message(item));
             }
         }
         _ => {
-            flush_pending_tool_calls(messages, pending_tool_calls);
             if item.get("role").is_some() || item.get("content").is_some() {
                 messages.push(responses_message_item_to_chat_message(item));
             }
@@ -190,16 +238,32 @@ fn append_responses_item_as_chat_message(
     Ok(())
 }
 
-fn flush_pending_tool_calls(messages: &mut Vec<Value>, pending_tool_calls: &mut Vec<Value>) {
-    if pending_tool_calls.is_empty() {
-        return;
-    }
+fn is_responses_function_call(item: &Value) -> bool {
+    item.get("type").and_then(|value| value.as_str()) == Some("function_call")
+}
 
-    messages.push(json!({
-        "role": "assistant",
-        "content": null,
-        "tool_calls": std::mem::take(pending_tool_calls)
-    }));
+fn is_responses_function_call_output(item: &Value) -> bool {
+    item.get("type").and_then(|value| value.as_str()) == Some("function_call_output")
+}
+
+fn responses_call_id(item: &Value) -> Option<&str> {
+    item.get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(|value| value.as_str())
+}
+
+fn responses_function_call_output_to_chat_message(item: &Value) -> Value {
+    let call_id = responses_call_id(item).unwrap_or("");
+    let output = match item.get("output") {
+        Some(Value::String(s)) => s.clone(),
+        Some(v) => canonical_json_string(v),
+        None => String::new(),
+    };
+    json!({
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": output
+    })
 }
 
 fn responses_message_item_to_chat_message(item: &Value) -> Value {
@@ -867,6 +931,78 @@ mod tests {
             result["usage"]["output_tokens_details"]["reasoning_tokens"],
             18
         );
+    }
+
+    #[test]
+    fn orphan_function_call_without_output_is_dropped() {
+        // function_call with no matching function_call_output must not produce an
+        // assistant.tool_calls entry, as that would cause a 400 from Chat Completions.
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "orphan_1",
+                    "name": "no_result_tool",
+                    "arguments": "{}"
+                },
+                {
+                    "role": "user",
+                    "content": "Hello"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        // Only the user message should appear; orphan tool call must be gone.
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "user");
+    }
+
+    #[test]
+    fn partial_tool_calls_only_paired_ones_are_kept() {
+        // call_1 has an output; call_2 does not. Only call_1 must appear.
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "tool_a",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_2",
+                    "name": "tool_b",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "ok"
+                },
+                {
+                    "role": "user",
+                    "content": "Done"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        // assistant message with only call_1, then tool result for call_1, then user.
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "assistant");
+        let tool_calls = messages[0]["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["id"], "call_1");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
+        assert_eq!(messages[2]["role"], "user");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1006,6 +1006,105 @@ mod tests {
     }
 
     #[test]
+    fn interleaved_tool_output_after_message_is_dropped() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "tool_a",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_2",
+                    "name": "tool_b",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "ok"
+                },
+                {
+                    "role": "user",
+                    "content": "Continue"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_2",
+                    "output": "late"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "assistant");
+        let tool_calls = messages[0]["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["id"], "call_1");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
+        assert_eq!(messages[2]["role"], "user");
+    }
+
+    #[test]
+    fn orphan_function_call_output_is_dropped() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "orphan"
+                },
+                {
+                    "role": "user",
+                    "content": "Hello"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "user");
+    }
+
+    #[test]
+    fn function_call_output_uses_id_fallback() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "tool_a",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "id": "call_1",
+                    "output": "ok"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
+    }
+
+    #[test]
     fn chat_response_length_maps_to_incomplete_response() {
         let input = json!({
             "id": "chatcmpl_2",

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -142,6 +142,11 @@ const codexApiFormatFromWireApi = (
   }
 };
 
+const codexWireApiFromApiFormat = (
+  apiFormat: CodexApiFormat,
+): "responses" | "chat" =>
+  apiFormat === "openai_chat" ? "chat" : "responses";
+
 export interface ProviderFormProps {
   appId: AppId;
   providerId?: string;
@@ -489,7 +494,10 @@ function ProviderFormFull({
     (format: CodexApiFormat) => {
       setLocalCodexApiFormat(format);
       setCodexConfig((prev) => {
-        const updated = setCodexWireApi(prev, "responses");
+        const updated = setCodexWireApi(
+          prev,
+          codexWireApiFromApiFormat(format),
+        );
         debouncedValidate(updated);
         return updated;
       });
@@ -1111,7 +1119,10 @@ function ProviderFormFull({
         const authJson = JSON.parse(codexAuth);
         const normalizedCodexConfig =
           category !== "official" && (codexConfig ?? "").trim()
-            ? setCodexWireApi(codexConfig ?? "", "responses")
+            ? setCodexWireApi(
+                codexConfig ?? "",
+                codexWireApiFromApiFormat(localCodexApiFormat),
+              )
             : (codexConfig ?? "");
         const configObj = {
           auth: authJson,


### PR DESCRIPTION
## Problem

When Codex App is configured to use an OpenAI-compatible Chat Completions upstream, CC Switch converts Codex `Responses API` requests into Chat Completions requests.

Some Codex workflows, including generating commit messages, rely on tool calls. In those flows the Responses input may contain `function_call` / `function_call_output` items that are not a perfectly valid Chat Completions tool-message block after a naive conversion.

This can produce invalid Chat Completions message sequences such as:

- an `assistant.tool_calls` message without matching following `tool` messages
- a standalone `role=tool` message without a preceding assistant tool call
- a delayed/interleaved tool output after a normal user/assistant message

Many OpenAI-compatible Chat Completions providers reject those sequences with 400-level errors, which makes Codex features such as commit-message generation fail.

## Root Cause

The previous Responses → Chat conversion treated tool call items too independently:

- `function_call` could be converted into `assistant.tool_calls` even when no valid output followed.
- `function_call_output` could become a `role=tool` message even when it was orphaned or separated from its matching call.
- The converter did not fully enforce the Chat Completions invariant that every `assistant.tool_calls` block must be immediately followed by corresponding `tool` messages.

Responses API input is more flexible as a sequence of typed items, but Chat Completions has stricter adjacency and pairing rules for tool calls.

## Solution

This PR hardens the Codex Responses → Chat Completions conversion by converting tool items as contiguous tool blocks instead of independent messages.

Changes include:

- scan consecutive `function_call` items as a candidate tool block
- only emit `assistant.tool_calls` for calls that have immediately following matching `function_call_output` items
- drop orphan `function_call` items instead of emitting invalid assistant tool calls
- drop orphan or interleaved `function_call_output` items instead of emitting standalone `role=tool` messages
- support both `call_id` and `id` when matching tool outputs
- lower the Codex conversion summary log from `warn` to `debug` to avoid noisy production logs

The goal is to prefer a valid, non-400 Chat Completions request over preserving invalid tool fragments that the upstream cannot accept.

## Validation

Ran targeted Rust tests:

```bash
cargo test transform_codex_chat --lib
```

Result:

- 10 passed
- 0 failed

New coverage includes:

- orphan function calls are dropped
- partial tool calls only keep paired calls
- interleaved tool output after a normal message is dropped
- orphan tool output is dropped
- tool output matching supports `id` fallback

## Risk

Low to medium.

This only affects Codex Responses → Chat Completions conversion. The change intentionally drops invalid/orphaned tool fragments that would otherwise cause Chat Completions upstreams to reject the request. In rare malformed histories, this may lose some tool context, but it avoids hard request failure and keeps the generated Chat message sequence protocol-valid.
