### PR TITLE
feat: DeepSeek Codex integration with proxy format conversion and reasoning support

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -172,6 +172,7 @@ fn build_default_catalog_entries(models: &[String]) -> Vec<CodexModelCatalogEntr
 }
 
 /// 从 config.toml 文本中提取 model 字段
+#[allow(dead_code)]
 fn extract_model_from_config_text(config_text: &str) -> Option<String> {
     let doc = config_text.parse::<DocumentMut>().ok()?;
     doc.get("model")
@@ -192,6 +193,20 @@ fn write_codex_models_catalog(models: &[String]) -> Result<(), AppError> {
     let json_text = serde_json::to_string_pretty(&catalog)
         .map_err(|e| AppError::Message(format!("Failed to serialize models catalog: {e}")))?;
     std::fs::write(&catalog_path, &json_text)
+        .map_err(|e| AppError::io(&catalog_path, e))
+}
+
+/// 直接写入原始 JSON 内容到 models_catalog.json（用于前端编辑后保存的场景）。
+/// 会先校验 JSON 合法性，再写入。
+fn write_codex_models_catalog_raw(json_text: &str) -> Result<(), AppError> {
+    // Validate that it's valid JSON before writing
+    let _: serde_json::Value = serde_json::from_str(json_text)
+        .map_err(|e| AppError::Message(format!("Invalid models_catalog.json: {e}")))?;
+    let catalog_path = get_codex_models_catalog_path();
+    if let Some(parent) = catalog_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+    std::fs::write(&catalog_path, json_text)
         .map_err(|e| AppError::io(&catalog_path, e))
 }
 
@@ -223,10 +238,13 @@ fn ensure_model_catalog_json_in_toml(config_text: &str) -> String {
 ///
 /// `catalog_models`：models_catalog.json 中应包含的模型 ID 列表；
 /// 为 `None` 时从 config_text 中提取单个模型名作为兜底。
+/// `catalog_json`：models_catalog.json 的完整 JSON 内容。
+/// 当 `catalog_json` 为 `Some` 且非空时，优先直接写入，不再从 `catalog_models` 重新生成。
 pub fn write_codex_live_atomic(
     auth: &Value,
     config_text_opt: Option<&str>,
     catalog_models: Option<&[String]>,
+    catalog_json: Option<&str>,
 ) -> Result<(), AppError> {
     let auth_path = get_codex_auth_path();
     let config_path = get_codex_config_path();
@@ -274,14 +292,14 @@ pub fn write_codex_live_atomic(
     }
 
     // 第三步：生成 models_catalog.json（非关键，失败不阻塞）
-    let model_ids: Vec<String> = match catalog_models {
-        Some(models) if !models.is_empty() => models.to_vec(),
-        _ => extract_model_from_config_text(&cfg_text)
-            .into_iter()
-            .collect(),
-    };
-    if !model_ids.is_empty() {
-        if let Err(e) = write_codex_models_catalog(&model_ids) {
+    // catalog_json 优先（前端编辑后保存的完整 JSON），其次从 catalog_models 生成。
+    // 当两者都未提供时，保留已有 models_catalog.json 不覆盖（适用代理接管等场景）。
+    if let Some(json) = catalog_json.filter(|s| !s.trim().is_empty()) {
+        if let Err(e) = write_codex_models_catalog_raw(json) {
+            log::warn!("[Codex] Failed to write models_catalog.json from raw JSON: {e}");
+        }
+    } else if let Some(models) = catalog_models.filter(|m| !m.is_empty()) {
+        if let Err(e) = write_codex_models_catalog(models) {
             log::warn!("[Codex] Failed to write models_catalog.json: {e}");
         }
     }
@@ -562,6 +580,7 @@ pub fn write_codex_live_atomic_with_stable_provider(
     auth: &Value,
     config_text_opt: Option<&str>,
     catalog_models: Option<&[String]>,
+    catalog_json: Option<&str>,
 ) -> Result<(), AppError> {
     match config_text_opt {
         Some(config_text) => {
@@ -573,9 +592,9 @@ pub fn write_codex_live_atomic_with_stable_provider(
                 .get("config")
                 .and_then(|value| value.as_str())
                 .unwrap_or(config_text);
-            write_codex_live_atomic(auth, Some(config_text), catalog_models)
+            write_codex_live_atomic(auth, Some(config_text), catalog_models, catalog_json)
         }
-        None => write_codex_live_atomic(auth, None, catalog_models),
+        None => write_codex_live_atomic(auth, None, catalog_models, catalog_json),
     }
 }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -192,8 +192,7 @@ fn write_codex_models_catalog(models: &[String]) -> Result<(), AppError> {
     let catalog = CodexModelsCatalog { models: entries };
     let json_text = serde_json::to_string_pretty(&catalog)
         .map_err(|e| AppError::Message(format!("Failed to serialize models catalog: {e}")))?;
-    std::fs::write(&catalog_path, &json_text)
-        .map_err(|e| AppError::io(&catalog_path, e))
+    std::fs::write(&catalog_path, &json_text).map_err(|e| AppError::io(&catalog_path, e))
 }
 
 /// 直接写入原始 JSON 内容到 models_catalog.json（用于前端编辑后保存的场景）。
@@ -206,8 +205,7 @@ fn write_codex_models_catalog_raw(json_text: &str) -> Result<(), AppError> {
     if let Some(parent) = catalog_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
     }
-    std::fs::write(&catalog_path, json_text)
-        .map_err(|e| AppError::io(&catalog_path, e))
+    std::fs::write(&catalog_path, json_text).map_err(|e| AppError::io(&catalog_path, e))
 }
 
 /// 确保 config.toml 中包含 model_catalog_json 字段
@@ -221,9 +219,7 @@ fn ensure_model_catalog_json_in_toml(config_text: &str) -> String {
 
     match config_text.parse::<DocumentMut>() {
         Ok(mut doc) => {
-            let existing = doc
-                .get("model_catalog_json")
-                .and_then(|item| item.as_str());
+            let existing = doc.get("model_catalog_json").and_then(|item| item.as_str());
             if existing == Some(&catalog_path_str) {
                 return config_text.to_string();
             }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -127,11 +127,80 @@ struct CodexModelsCatalog {
     models: Vec<CodexModelCatalogEntry>,
 }
 
+/// 每个模型的能力，通过模型名称模式匹配查找。
+#[derive(Copy, Clone)]
+struct ModelCapabilities {
+    context_window: u32,
+    max_context_window: u32,
+    effective_context_window_percent: u32,
+    supports_reasoning: bool,
+}
+
+const DEFAULT_CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    context_window: 128000,
+    max_context_window: 128000,
+    effective_context_window_percent: 95,
+    supports_reasoning: false,
+};
+
+/// 静态模型能力查找表。
+/// 按前缀长度降序排列，长前缀优先匹配。
+const MODEL_CAPABILITIES: &[(&str, ModelCapabilities)] = &[
+    (
+        "deepseek-reasoner",
+        ModelCapabilities {
+            context_window: 64000,
+            max_context_window: 64000,
+            effective_context_window_percent: 95,
+            supports_reasoning: true,
+        },
+    ),
+    (
+        "deepseek-chat",
+        ModelCapabilities {
+            context_window: 128000,
+            max_context_window: 128000,
+            effective_context_window_percent: 95,
+            supports_reasoning: false,
+        },
+    ),
+    (
+        "deepseek",
+        ModelCapabilities {
+            context_window: 128000,
+            max_context_window: 128000,
+            effective_context_window_percent: 95,
+            supports_reasoning: true,
+        },
+    ),
+];
+
+fn lookup_model_capabilities(model_id: &str) -> ModelCapabilities {
+    for (prefix, caps) in MODEL_CAPABILITIES {
+        if model_id == *prefix || model_id.starts_with(&format!("{prefix}-")) {
+            return *caps;
+        }
+    }
+    DEFAULT_CAPABILITIES
+}
+
 /// 从模型名列表构建默认 catalog entries
 fn build_default_catalog_entries(models: &[String]) -> Vec<CodexModelCatalogEntry> {
     models
         .iter()
         .map(|model_id| {
+            let caps = lookup_model_capabilities(model_id);
+            let (default_reasoning_level, supported_reasoning_levels) = if caps.supports_reasoning {
+                (
+                    Some("high".to_string()),
+                    vec![
+                        json!({"effort": "high", "description": "深度推理"}),
+                        json!({"effort": "low", "description": "快速响应"}),
+                    ],
+                )
+            } else {
+                (None, vec![])
+            };
             let display_name = model_id.clone();
             CodexModelCatalogEntry {
                 slug: model_id.clone(),
@@ -142,11 +211,8 @@ fn build_default_catalog_entries(models: &[String]) -> Vec<CodexModelCatalogEntr
                 supported_in_api: true,
                 priority: 0,
                 additional_speed_tiers: vec![],
-                default_reasoning_level: Some("high".to_string()),
-                supported_reasoning_levels: vec![
-                    json!({"effort": "high", "description": "深度推理"}),
-                    json!({"effort": "low", "description": "快速响应"}),
-                ],
+                default_reasoning_level,
+                supported_reasoning_levels,
                 availability_nux: None,
                 upgrade: None,
                 base_instructions: "You are a helpful coding assistant.".to_string(),
@@ -159,10 +225,10 @@ fn build_default_catalog_entries(models: &[String]) -> Vec<CodexModelCatalogEntr
                 truncation_policy: json!({"mode": "tokens", "limit": 10000}),
                 supports_parallel_tool_calls: true,
                 supports_image_detail_original: false,
-                context_window: Some(200000),
-                max_context_window: Some(200000),
+                context_window: Some(caps.context_window),
+                max_context_window: Some(caps.max_context_window),
                 auto_compact_token_limit: None,
-                effective_context_window_percent: 95,
+                effective_context_window_percent: caps.effective_context_window_percent,
                 experimental_supported_tools: vec![],
                 input_modalities: vec!["text".to_string()],
                 supports_search_tool: false,
@@ -1210,15 +1276,47 @@ model = "deepseek-v4-pro"
 
     #[test]
     fn build_catalog_entries_creates_valid_structure() {
-        let entries = build_default_catalog_entries(&["deepseek-v4-pro".to_string()]);
+        // Use a model ID that doesn't match any prefix to test DEFAULT_CAPABILITIES
+        let entries = build_default_catalog_entries(&["unknown-model".to_string()]);
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].slug, "deepseek-v4-pro");
-        assert_eq!(entries[0].display_name, "deepseek-v4-pro");
+        assert_eq!(entries[0].slug, "unknown-model");
+        assert_eq!(entries[0].display_name, "unknown-model");
         assert_eq!(entries[0].shell_type, "unified_exec");
-        assert_eq!(entries[0].context_window, Some(200000));
+        assert_eq!(entries[0].context_window, Some(128000));
         assert!(entries[0].additional_speed_tiers.is_empty());
         assert!(entries[0].experimental_supported_tools.is_empty());
-        assert_eq!(entries[0].supported_reasoning_levels.len(), 2);
+        assert!(
+            entries[0].supported_reasoning_levels.is_empty(),
+            "non-matching model should have no reasoning levels by default"
+        );
+        assert!(entries[0].default_reasoning_level.is_none());
         assert_eq!(entries[0].input_modalities, vec!["text"]);
+    }
+
+    #[test]
+    fn test_reasoner_model_capabilities() {
+        let entries = build_default_catalog_entries(&["deepseek-reasoner".to_string()]);
+        assert_eq!(entries[0].context_window, Some(64000));
+        assert_eq!(entries[0].default_reasoning_level, Some("high".to_string()));
+        assert_eq!(entries[0].supported_reasoning_levels.len(), 2);
+    }
+
+    #[test]
+    fn test_chat_model_capabilities() {
+        let entries = build_default_catalog_entries(&["deepseek-chat".to_string()]);
+        assert_eq!(entries[0].context_window, Some(128000));
+        assert!(entries[0].default_reasoning_level.is_none());
+        assert!(entries[0].supported_reasoning_levels.is_empty());
+    }
+
+    #[test]
+    fn test_deepseek_prefix_does_not_match_chat() {
+        // "deepseek" prefix must not match before "deepseek-chat" is tried
+        let entries = build_default_catalog_entries(&["deepseek-chat".to_string()]);
+        assert_eq!(entries[0].context_window, Some(128000));
+        assert!(
+            entries[0].default_reasoning_level.is_none(),
+            "deepseek-chat should not get reasoning capabilities from 'deepseek' fallback"
+        );
     }
 }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -6,7 +6,7 @@ use crate::config::{
     write_text_file,
 };
 use crate::error::AppError;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::fs;
 use std::path::Path;
 use toml_edit::DocumentMut;
@@ -44,6 +44,11 @@ pub fn get_codex_config_path() -> PathBuf {
     get_codex_config_dir().join("config.toml")
 }
 
+/// 获取 Codex models_catalog.json 路径
+pub fn get_codex_models_catalog_path() -> PathBuf {
+    get_codex_config_dir().join("models_catalog.json")
+}
+
 /// 获取 Codex 供应商配置文件路径
 #[allow(dead_code)]
 pub fn get_codex_provider_paths(
@@ -74,10 +79,154 @@ pub fn delete_codex_provider_config(
     Ok(())
 }
 
-/// 原子写 Codex 的 `auth.json` 与 `config.toml`，在第二步失败时回滚第一步
+/// Codex models_catalog.json 中的模型条目（字段对齐 Moon Bridge ModelInfo）
+#[derive(serde::Serialize)]
+struct CodexModelCatalogEntry {
+    slug: String,
+    display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    shell_type: String,
+    visibility: String,
+    supported_in_api: bool,
+    priority: u32,
+    additional_speed_tiers: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_reasoning_level: Option<String>,
+    supported_reasoning_levels: Vec<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    availability_nux: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    upgrade: Option<Value>,
+    base_instructions: String,
+    supports_reasoning_summaries: bool,
+    default_reasoning_summary: String,
+    support_verbosity: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_verbosity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    apply_patch_tool_type: Option<String>,
+    web_search_tool_type: String,
+    truncation_policy: Value,
+    supports_parallel_tool_calls: bool,
+    supports_image_detail_original: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context_window: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_context_window: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_compact_token_limit: Option<u32>,
+    effective_context_window_percent: u32,
+    experimental_supported_tools: Vec<String>,
+    input_modalities: Vec<String>,
+    supports_search_tool: bool,
+}
+
+#[derive(serde::Serialize)]
+struct CodexModelsCatalog {
+    models: Vec<CodexModelCatalogEntry>,
+}
+
+/// 从模型名列表构建默认 catalog entries
+fn build_default_catalog_entries(models: &[String]) -> Vec<CodexModelCatalogEntry> {
+    models
+        .iter()
+        .map(|model_id| {
+            let display_name = model_id.clone();
+            CodexModelCatalogEntry {
+                slug: model_id.clone(),
+                display_name,
+                description: None,
+                shell_type: "unified_exec".to_string(),
+                visibility: "list".to_string(),
+                supported_in_api: true,
+                priority: 0,
+                additional_speed_tiers: vec![],
+                default_reasoning_level: Some("high".to_string()),
+                supported_reasoning_levels: vec![
+                    json!({"effort": "high", "description": "深度推理"}),
+                    json!({"effort": "low", "description": "快速响应"}),
+                ],
+                availability_nux: None,
+                upgrade: None,
+                base_instructions: "You are a helpful coding assistant.".to_string(),
+                supports_reasoning_summaries: false,
+                default_reasoning_summary: "none".to_string(),
+                support_verbosity: false,
+                default_verbosity: None,
+                apply_patch_tool_type: Some("freeform".to_string()),
+                web_search_tool_type: "text".to_string(),
+                truncation_policy: json!({"mode": "tokens", "limit": 10000}),
+                supports_parallel_tool_calls: true,
+                supports_image_detail_original: false,
+                context_window: Some(200000),
+                max_context_window: Some(200000),
+                auto_compact_token_limit: None,
+                effective_context_window_percent: 95,
+                experimental_supported_tools: vec![],
+                input_modalities: vec!["text".to_string()],
+                supports_search_tool: false,
+            }
+        })
+        .collect()
+}
+
+/// 从 config.toml 文本中提取 model 字段
+fn extract_model_from_config_text(config_text: &str) -> Option<String> {
+    let doc = config_text.parse::<DocumentMut>().ok()?;
+    doc.get("model")
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// 写入 Codex models_catalog.json
+fn write_codex_models_catalog(models: &[String]) -> Result<(), AppError> {
+    let catalog_path = get_codex_models_catalog_path();
+    if let Some(parent) = catalog_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+    let entries = build_default_catalog_entries(models);
+    let catalog = CodexModelsCatalog { models: entries };
+    let json_text = serde_json::to_string_pretty(&catalog)
+        .map_err(|e| AppError::Message(format!("Failed to serialize models catalog: {e}")))?;
+    std::fs::write(&catalog_path, &json_text)
+        .map_err(|e| AppError::io(&catalog_path, e))
+}
+
+/// 确保 config.toml 中包含 model_catalog_json 字段
+fn ensure_model_catalog_json_in_toml(config_text: &str) -> String {
+    let catalog_path = get_codex_config_dir().join("models_catalog.json");
+    let catalog_path_str = catalog_path.to_string_lossy().to_string();
+
+    if config_text.trim().is_empty() {
+        return format!("model_catalog_json = \"{catalog_path_str}\"\n");
+    }
+
+    match config_text.parse::<DocumentMut>() {
+        Ok(mut doc) => {
+            let existing = doc
+                .get("model_catalog_json")
+                .and_then(|item| item.as_str());
+            if existing == Some(&catalog_path_str) {
+                return config_text.to_string();
+            }
+            doc["model_catalog_json"] = toml_edit::value(catalog_path_str.as_str());
+            doc.to_string()
+        }
+        Err(_) => config_text.to_string(),
+    }
+}
+
+/// 原子写 Codex 的 `auth.json` 与 `config.toml`，在第二步失败时回滚第一步。
+///
+/// `catalog_models`：models_catalog.json 中应包含的模型 ID 列表；
+/// 为 `None` 时从 config_text 中提取单个模型名作为兜底。
 pub fn write_codex_live_atomic(
     auth: &Value,
     config_text_opt: Option<&str>,
+    catalog_models: Option<&[String]>,
 ) -> Result<(), AppError> {
     let auth_path = get_codex_auth_path();
     let config_path = get_codex_config_path();
@@ -98,14 +247,17 @@ pub fn write_codex_live_atomic(
         None
     };
 
-    // 准备写入内容
-    let cfg_text = match config_text_opt {
+    // 准备写入内容，注入 model_catalog_json
+    let raw_text = match config_text_opt {
         Some(s) => s.to_string(),
         None => String::new(),
     };
-    if !cfg_text.trim().is_empty() {
-        toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;
-    }
+    let cfg_text = if raw_text.trim().is_empty() {
+        raw_text
+    } else {
+        toml::from_str::<toml::Table>(&raw_text).map_err(|e| AppError::toml(&config_path, e))?;
+        ensure_model_catalog_json_in_toml(&raw_text)
+    };
 
     // 第一步：写 auth.json
     write_json_file(&auth_path, auth)?;
@@ -119,6 +271,19 @@ pub fn write_codex_live_atomic(
             let _ = delete_file(&auth_path);
         }
         return Err(e);
+    }
+
+    // 第三步：生成 models_catalog.json（非关键，失败不阻塞）
+    let model_ids: Vec<String> = match catalog_models {
+        Some(models) if !models.is_empty() => models.to_vec(),
+        _ => extract_model_from_config_text(&cfg_text)
+            .into_iter()
+            .collect(),
+    };
+    if !model_ids.is_empty() {
+        if let Err(e) = write_codex_models_catalog(&model_ids) {
+            log::warn!("[Codex] Failed to write models_catalog.json: {e}");
+        }
     }
 
     Ok(())
@@ -396,6 +561,7 @@ pub fn restore_codex_settings_config_model_provider_for_backfill(
 pub fn write_codex_live_atomic_with_stable_provider(
     auth: &Value,
     config_text_opt: Option<&str>,
+    catalog_models: Option<&[String]>,
 ) -> Result<(), AppError> {
     match config_text_opt {
         Some(config_text) => {
@@ -407,9 +573,9 @@ pub fn write_codex_live_atomic_with_stable_provider(
                 .get("config")
                 .and_then(|value| value.as_str())
                 .unwrap_or(config_text);
-            write_codex_live_atomic(auth, Some(config_text))
+            write_codex_live_atomic(auth, Some(config_text), catalog_models)
         }
-        None => write_codex_live_atomic(auth, None),
+        None => write_codex_live_atomic(auth, None, catalog_models),
     }
 }
 
@@ -977,5 +1143,67 @@ base_url = "https://production.api/v1"
             .and_then(|v| v.get("base_url"))
             .and_then(|v| v.as_str());
         assert_eq!(base_url, Some("https://production.api/v1"));
+    }
+
+    #[test]
+    fn extract_model_from_standard_config() {
+        let config = r#"model_provider = "deepseek"
+model = "deepseek-v4-pro"
+
+[model_providers.deepseek]
+name = "deepseek"
+wire_api = "responses"
+"#;
+        assert_eq!(
+            extract_model_from_config_text(config),
+            Some("deepseek-v4-pro".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_model_returns_none_when_absent() {
+        let config = r#"model_provider = "deepseek"
+[model_providers.deepseek]
+name = "deepseek"
+"#;
+        assert_eq!(extract_model_from_config_text(config), None);
+    }
+
+    #[test]
+    fn ensure_model_catalog_json_adds_field() {
+        let config = r#"model_provider = "deepseek"
+model = "deepseek-v4-pro"
+"#;
+        let result = ensure_model_catalog_json_in_toml(config);
+        assert!(result.contains("model_catalog_json"));
+        assert!(result.contains("models_catalog.json"));
+        assert!(result.contains("deepseek-v4-pro")); // original content preserved
+    }
+
+    #[test]
+    fn ensure_model_catalog_json_preserves_existing_value() {
+        let catalog_path = get_codex_config_dir().join("models_catalog.json");
+        let catalog_str = catalog_path.to_string_lossy();
+        let config = format!("model = \"test\"\nmodel_catalog_json = \"{catalog_str}\"\n");
+        let result = ensure_model_catalog_json_in_toml(&config);
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        assert_eq!(
+            parsed.get("model_catalog_json").and_then(|v| v.as_str()),
+            Some(catalog_str.as_ref())
+        );
+    }
+
+    #[test]
+    fn build_catalog_entries_creates_valid_structure() {
+        let entries = build_default_catalog_entries(&["deepseek-v4-pro".to_string()]);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].slug, "deepseek-v4-pro");
+        assert_eq!(entries[0].display_name, "deepseek-v4-pro");
+        assert_eq!(entries[0].shell_type, "unified_exec");
+        assert_eq!(entries[0].context_window, Some(200000));
+        assert!(entries[0].additional_speed_tiers.is_empty());
+        assert!(entries[0].experimental_supported_tools.is_empty());
+        assert_eq!(entries[0].supported_reasoning_levels.len(), 2);
+        assert_eq!(entries[0].input_modalities, vec!["text"]);
     }
 }

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -56,7 +56,7 @@ pub fn update_provider(
     // 保存 Codex provider 时同步更新 models_catalog.json（在 update 前提取数据）
     let needs_codex_sync = app_type == AppType::Codex
         && crate::settings::get_current_provider(&app_type)
-            .is_some_and(|cid| cid == originalId.as_deref().unwrap_or(&"") || cid == provider.id);
+            .is_some_and(|cid| cid == originalId.as_deref().unwrap_or("") || cid == provider.id);
     let codex_sync_data = if needs_codex_sync {
         provider.settings_config.as_object().and_then(|s| {
             let auth = s.get("auth")?;

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -53,8 +53,51 @@ pub fn update_provider(
     #[allow(non_snake_case)] originalId: Option<String>,
 ) -> Result<bool, String> {
     let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
-    ProviderService::update(state.inner(), app_type, originalId.as_deref(), provider)
-        .map_err(|e| e.to_string())
+    // 保存 Codex provider 时同步更新 models_catalog.json（在 update 前提取数据）
+    let needs_codex_sync = app_type == AppType::Codex
+        && crate::settings::get_current_provider(&app_type)
+            .is_some_and(|cid| cid == originalId.as_deref().unwrap_or(&"") || cid == provider.id);
+    let codex_sync_data = if needs_codex_sync {
+        provider.settings_config.as_object().and_then(|s| {
+            let auth = s.get("auth")?;
+            let cfg = s.get("config")?.as_str()?;
+            let models = provider.meta.as_ref().and_then(|m| m.codex_models.as_deref());
+            Some((auth.clone(), cfg.to_string(), models.map(|v| v.to_vec())))
+        })
+    } else {
+        None
+    };
+
+    let result = ProviderService::update(state.inner(), app_type.clone(), originalId.as_deref(), provider)
+        .map_err(|e| e.to_string())?;
+
+    if let Some((auth, cfg, models)) = codex_sync_data {
+        let model_slice: Option<Vec<String>> = models;
+        let _ = crate::codex_config::write_codex_live_atomic_with_stable_provider(
+            &auth,
+            Some(&cfg),
+            model_slice.as_deref(),
+        );
+        // 如果代理接管处于激活状态，重新应用代理地址到 config.toml
+        let is_proxy_running = futures::executor::block_on(state.proxy_service.is_running());
+        if is_proxy_running {
+            let has_live_backup = futures::executor::block_on(
+                state.db.get_live_backup(app_type.as_str()),
+            )
+            .ok()
+            .flatten()
+            .is_some();
+            if has_live_backup {
+                let _ = futures::executor::block_on(
+                    state
+                        .proxy_service
+                        .takeover_live_config_best_effort(&app_type),
+                );
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -61,19 +61,32 @@ pub fn update_provider(
         provider.settings_config.as_object().and_then(|s| {
             let auth = s.get("auth")?;
             let cfg = s.get("config")?.as_str()?;
-            let models = provider.meta.as_ref().and_then(|m| m.codex_models.as_deref());
+            let models = provider
+                .meta
+                .as_ref()
+                .and_then(|m| m.codex_models.as_deref());
             let catalog_json = provider
                 .meta
                 .as_ref()
                 .and_then(|m| m.codex_models_catalog.as_deref());
-            Some((auth.clone(), cfg.to_string(), models.map(|v| v.to_vec()), catalog_json.map(|s| s.to_string())))
+            Some((
+                auth.clone(),
+                cfg.to_string(),
+                models.map(|v| v.to_vec()),
+                catalog_json.map(|s| s.to_string()),
+            ))
         })
     } else {
         None
     };
 
-    let result = ProviderService::update(state.inner(), app_type.clone(), originalId.as_deref(), provider)
-        .map_err(|e| e.to_string())?;
+    let result = ProviderService::update(
+        state.inner(),
+        app_type.clone(),
+        originalId.as_deref(),
+        provider,
+    )
+    .map_err(|e| e.to_string())?;
 
     if let Some((auth, cfg, models, catalog_json)) = codex_sync_data {
         let model_slice: Option<Vec<String>> = models;
@@ -86,12 +99,11 @@ pub fn update_provider(
         // 如果代理接管处于激活状态，重新应用代理地址到 config.toml
         let is_proxy_running = futures::executor::block_on(state.proxy_service.is_running());
         if is_proxy_running {
-            let has_live_backup = futures::executor::block_on(
-                state.db.get_live_backup(app_type.as_str()),
-            )
-            .ok()
-            .flatten()
-            .is_some();
+            let has_live_backup =
+                futures::executor::block_on(state.db.get_live_backup(app_type.as_str()))
+                    .ok()
+                    .flatten()
+                    .is_some();
             if has_live_backup {
                 let _ = futures::executor::block_on(
                     state

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -62,7 +62,11 @@ pub fn update_provider(
             let auth = s.get("auth")?;
             let cfg = s.get("config")?.as_str()?;
             let models = provider.meta.as_ref().and_then(|m| m.codex_models.as_deref());
-            Some((auth.clone(), cfg.to_string(), models.map(|v| v.to_vec())))
+            let catalog_json = provider
+                .meta
+                .as_ref()
+                .and_then(|m| m.codex_models_catalog.as_deref());
+            Some((auth.clone(), cfg.to_string(), models.map(|v| v.to_vec()), catalog_json.map(|s| s.to_string())))
         })
     } else {
         None
@@ -71,12 +75,13 @@ pub fn update_provider(
     let result = ProviderService::update(state.inner(), app_type.clone(), originalId.as_deref(), provider)
         .map_err(|e| e.to_string())?;
 
-    if let Some((auth, cfg, models)) = codex_sync_data {
+    if let Some((auth, cfg, models, catalog_json)) = codex_sync_data {
         let model_slice: Option<Vec<String>> = models;
         let _ = crate::codex_config::write_codex_live_atomic_with_stable_provider(
             &auth,
             Some(&cfg),
             model_slice.as_deref(),
+            catalog_json.as_deref(),
         );
         // 如果代理接管处于激活状态，重新应用代理地址到 config.toml
         let is_proxy_running = futures::executor::block_on(state.proxy_service.is_running());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,7 +35,10 @@ mod tray;
 mod usage_script;
 
 pub use app_config::{AppType, InstalledSkill, McpApps, McpServer, MultiAppConfig, SkillApps};
-pub use codex_config::{get_codex_auth_path, get_codex_config_path, get_codex_models_catalog_path, write_codex_live_atomic, write_codex_live_atomic_with_stable_provider};
+pub use codex_config::{
+    get_codex_auth_path, get_codex_config_path, get_codex_models_catalog_path,
+    write_codex_live_atomic, write_codex_live_atomic_with_stable_provider,
+};
 pub use commands::open_provider_terminal;
 pub use commands::*;
 pub use config::{get_claude_mcp_path, get_claude_settings_path, read_json_file};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,7 +35,7 @@ mod tray;
 mod usage_script;
 
 pub use app_config::{AppType, InstalledSkill, McpApps, McpServer, MultiAppConfig, SkillApps};
-pub use codex_config::{get_codex_auth_path, get_codex_config_path, write_codex_live_atomic};
+pub use codex_config::{get_codex_auth_path, get_codex_config_path, get_codex_models_catalog_path, write_codex_live_atomic, write_codex_live_atomic_with_stable_provider};
 pub use commands::open_provider_terminal;
 pub use commands::*;
 pub use config::{get_claude_mcp_path, get_claude_settings_path, read_json_file};

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -328,6 +328,12 @@ pub struct ProviderMeta {
     /// 用于多账号支持，关联到特定的 GitHub 账号
     #[serde(rename = "githubAccountId", skip_serializing_if = "Option::is_none")]
     pub github_account_id: Option<String>,
+    /// Codex 模型映射：models_catalog.json 中包含的模型 slug 列表
+    #[serde(rename = "codexModels", skip_serializing_if = "Option::is_none")]
+    pub codex_models: Option<Vec<String>>,
+    /// Codex 默认模型：config.toml 中的 model 字段值
+    #[serde(rename = "codexDefaultModel", skip_serializing_if = "Option::is_none")]
+    pub codex_default_model: Option<String>,
 }
 
 impl ProviderMeta {

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -334,6 +334,10 @@ pub struct ProviderMeta {
     /// Codex 默认模型：config.toml 中的 model 字段值
     #[serde(rename = "codexDefaultModel", skip_serializing_if = "Option::is_none")]
     pub codex_default_model: Option<String>,
+    /// Codex models_catalog.json 完整内容（前端可编辑的 JSON 字符串）
+    /// 当此字段存在且为合法 JSON 时，优先直接写入 models_catalog.json，不再从 codexModels 重新生成
+    #[serde(rename = "codexModelsCatalog", skip_serializing_if = "Option::is_none")]
+    pub codex_models_catalog: Option<String>,
 }
 
 impl ProviderMeta {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1624,7 +1624,7 @@ impl RequestForwarder {
             }
             req_logger::log_upstream_req(
                 app_type.as_str(),
-                &method.to_string(),
+                method.as_ref(),
                 &url,
                 &String::from_utf8_lossy(&body_bytes),
             );
@@ -1653,7 +1653,7 @@ impl RequestForwarder {
             // 如果有 HTTP 代理，hyper_client 会用 CONNECT 隧道穿过代理
             req_logger::log_upstream_req(
                 app_type.as_str(),
-                &method.to_string(),
+                method.as_ref(),
                 &url,
                 &String::from_utf8_lossy(&body_bytes),
             );

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -14,6 +14,7 @@ use super::{
         gemini_shadow::GeminiShadowStore, get_adapter, AuthInfo, AuthStrategy, ProviderAdapter,
         ProviderType,
     },
+    req_logger,
     thinking_budget_rectifier::{rectify_thinking_budget, should_rectify_thinking_budget},
     thinking_rectifier::{
         normalize_thinking_type, rectify_anthropic_request, should_rectify_thinking_signature,
@@ -1621,6 +1622,12 @@ impl RequestForwarder {
             for (key, value) in &ordered_headers {
                 request = request.header(key, value);
             }
+            req_logger::log_upstream_req(
+                app_type.as_str(),
+                &method.to_string(),
+                &url,
+                &String::from_utf8_lossy(&body_bytes),
+            );
             let send = request.body(body_bytes).send();
             let send_result = if request_is_streaming {
                 let header_timeout = if self.streaming_first_byte_timeout.is_zero() {
@@ -1644,6 +1651,12 @@ impl RequestForwarder {
         } else {
             // HTTP 代理或直连：走 hyper raw write（保持 header 大小写）
             // 如果有 HTTP 代理，hyper_client 会用 CONNECT 隧道穿过代理
+            req_logger::log_upstream_req(
+                app_type.as_str(),
+                &method.to_string(),
+                &url,
+                &String::from_utf8_lossy(&body_bytes),
+            );
             let uri: http::Uri = url
                 .parse()
                 .map_err(|e| ProxyError::ForwardFailed(format!("Invalid URL '{url}': {e}")))?;

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -32,6 +32,7 @@ use super::{
     types::*,
     usage::parser::TokenUsage,
     hyper_client::ProxyResponse,
+    req_logger,
     ProxyError,
 };
 use crate::app_config::AppType;
@@ -165,6 +166,14 @@ async fn handle_messages_for_app(
         .to_bytes();
     let body: Value = serde_json::from_slice(&body_bytes)
         .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+
+    req_logger::log_incoming(
+        tag,
+        &parts.method.to_string(),
+        &uri.to_string(),
+        &format!("{:?}", headers),
+        &serde_json::to_string_pretty(&body).unwrap_or_else(|_| format!("{:?}", body)),
+    );
 
     let mut ctx =
         RequestContext::new(&state, &body, &headers, app_type.clone(), tag, app_type_str).await?;
@@ -380,6 +389,7 @@ async fn handle_claude_transform(
         let logged_stream = create_logged_passthrough_stream(
             sse_stream,
             "Claude/OpenRouter",
+            0, // status not readily available in this legacy path
             usage_collector,
             timeout_config,
             connection_guard,
@@ -524,6 +534,14 @@ pub async fn handle_chat_completions(
     let body: Value = serde_json::from_slice(&body_bytes)
         .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
 
+    req_logger::log_incoming(
+        "Codex",
+        &parts.method.to_string(),
+        &uri.to_string(),
+        &format!("{:?}", headers),
+        &serde_json::to_string_pretty(&body).unwrap_or_else(|_| format!("{:?}", body)),
+    );
+
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
     let endpoint = endpoint_with_query(&uri, "/chat/completions");
@@ -560,14 +578,24 @@ pub async fn handle_chat_completions(
     ctx.provider = result.provider;
     let response = result.response;
 
-    process_response(
+    let result = process_response(
         response,
         &ctx,
         &state,
         &OPENAI_PARSER_CONFIG,
         connection_guard,
     )
-    .await
+    .await;
+    match &result {
+        Ok(resp) => req_logger::log_return(
+            "Codex",
+            resp.status().as_u16(),
+            "chat",
+            &format!("{:?}", resp.headers()),
+        ),
+        Err(e) => log::error!("[Codex] → RETURN error: {e}"),
+    }
+    result
 }
 
 /// 处理 /v1/responses 请求（OpenAI Responses API - Codex CLI 透传）
@@ -591,6 +619,14 @@ pub async fn handle_responses(
         .to_bytes();
     let body: Value = serde_json::from_slice(&body_bytes)
         .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+
+    req_logger::log_incoming(
+        "Codex",
+        &parts.method.to_string(),
+        &uri.to_string(),
+        &format!("{:?}", headers),
+        &serde_json::to_string_pretty(&body).unwrap_or_else(|_| format!("{:?}", body)),
+    );
 
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
@@ -659,10 +695,25 @@ pub async fn handle_responses(
         };
 
         let chat_body: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
+        req_logger::log_upstream_resp(
+            "codex",
+            upstream_status.as_u16(),
+            &String::from_utf8_lossy(&body_bytes),
+        );
         let responses_body = transform_codex::chat_completions_to_responses(chat_body);
 
         // 如果原始请求是流式，包装为 SSE 事件流（Codex CLI 需要 SSE 格式）
         if was_streaming {
+            let event_count = responses_body
+                .get("output")
+                .and_then(|o| o.as_array())
+                .map_or(0, |a| a.len());
+            req_logger::log_return(
+                "Codex",
+                upstream_status.as_u16(),
+                &format!("stream SSE, {event_count} events"),
+                "<SSE stream>",
+            );
             let sse_stream = transform_codex::wrap_responses_as_sse(responses_body);
             let mut sse_response = axum::response::Response::new(
                 axum::body::Body::from_stream(sse_stream),
@@ -675,6 +726,12 @@ pub async fn handle_responses(
         }
 
         let new_body = serde_json::to_vec(&responses_body).unwrap_or_default();
+        req_logger::log_return(
+            "Codex",
+            upstream_status.as_u16(),
+            "",
+            &String::from_utf8_lossy(&new_body),
+        );
         let reconstructed: axum::response::Response = (
             upstream_status,
             [(
@@ -689,14 +746,24 @@ pub async fn handle_responses(
         return Ok(reconstructed);
     }
 
-    process_response(
+    let result = process_response(
         response,
         &ctx,
         &state,
         &CODEX_PARSER_CONFIG,
         connection_guard,
     )
-    .await
+    .await;
+    match &result {
+        Ok(resp) => req_logger::log_return(
+            "Codex",
+            resp.status().as_u16(),
+            "native",
+            &format!("{:?}", resp.headers()),
+        ),
+        Err(e) => log::error!("[Codex] → RETURN error: {e}"),
+    }
+    result
 }
 
 /// 处理 /v1/responses/compact 请求（OpenAI Responses Compact API - Codex CLI 透传）
@@ -716,6 +783,14 @@ pub async fn handle_responses_compact(
         .to_bytes();
     let body: Value = serde_json::from_slice(&body_bytes)
         .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+
+    req_logger::log_incoming(
+        "Codex",
+        &parts.method.to_string(),
+        &uri.to_string(),
+        &format!("{:?}", headers),
+        &serde_json::to_string_pretty(&body).unwrap_or_else(|_| format!("{:?}", body)),
+    );
 
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -701,6 +701,8 @@ pub async fn handle_responses(
             &String::from_utf8_lossy(&body_bytes),
         );
         let responses_body = transform_codex::chat_completions_to_responses(chat_body);
+        let converted_json = serde_json::to_string(&responses_body)
+            .unwrap_or_else(|_| format!("{:?}", responses_body));
 
         // 如果原始请求是流式，包装为 SSE 事件流（Codex CLI 需要 SSE 格式）
         if was_streaming {
@@ -712,7 +714,7 @@ pub async fn handle_responses(
                 "Codex",
                 upstream_status.as_u16(),
                 &format!("stream SSE, {event_count} events"),
-                "<SSE stream>",
+                &converted_json,
             );
             let sse_stream = transform_codex::wrap_responses_as_sse(responses_body);
             let mut sse_response = axum::response::Response::new(

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -16,10 +16,11 @@ use super::{
     },
     handler_context::RequestContext,
     providers::{
-        get_adapter, get_claude_api_format, streaming::create_anthropic_sse_stream,
+        get_adapter, get_claude_api_format, get_codex_api_format,
+        streaming::create_anthropic_sse_stream,
         streaming_gemini::create_anthropic_sse_stream_from_gemini,
         streaming_responses::create_anthropic_sse_stream_from_responses, transform,
-        transform_gemini, transform_responses,
+        transform_codex, transform_gemini, transform_responses,
     },
     response_processor::{
         create_logged_passthrough_stream, process_response, read_decoded_body,
@@ -30,6 +31,7 @@ use super::{
     sse::{strip_sse_field, take_sse_block},
     types::*,
     usage::parser::TokenUsage,
+    hyper_client::ProxyResponse,
     ProxyError,
 };
 use crate::app_config::AppType;
@@ -534,6 +536,10 @@ pub async fn handle_chat_completions(
 }
 
 /// 处理 /v1/responses 请求（OpenAI Responses API - Codex CLI 透传）
+///
+/// 当 provider 的 `meta.apiFormat` 为 `"openai_chat"` 时，
+/// 自动将 Responses API 请求转换为 Chat Completions 格式转发给上游，
+/// 并将 Chat Completions 响应转换回 Responses API 格式返回给 Codex CLI。
 pub async fn handle_responses(
     State(state): State<ProxyState>,
     request: axum::extract::Request,
@@ -553,12 +559,28 @@ pub async fn handle_responses(
 
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
-    let endpoint = endpoint_with_query(&uri, "/responses");
 
-    let is_stream = body
+    let api_format = get_codex_api_format(&ctx.provider);
+    let needs_chat_transform =
+        super::providers::codex_api_format_needs_transform(api_format);
+
+    let was_streaming = body
         .get("stream")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+
+    // 如果需要转换为 Chat Completions，修改请求体和端点
+    let (transform_body, transform_endpoint) = if needs_chat_transform {
+        let mut chat_body = transform_codex::responses_to_chat_completions(body);
+        // 格式转换时用非流式请求保证完整性，响应端再包装为 SSE
+        if was_streaming {
+            chat_body["stream"] = json!(false);
+        }
+        (chat_body, "/chat/completions".to_string())
+    } else {
+        (body, "/responses".to_string())
+    };
+    let endpoint = endpoint_with_query(&uri, &transform_endpoint);
 
     let forwarder = ctx.create_forwarder(&state);
     let mut result = match forwarder
@@ -566,7 +588,7 @@ pub async fn handle_responses(
             &AppType::Codex,
             method,
             &endpoint,
-            body,
+            transform_body,
             headers,
             extensions,
             ctx.get_providers(),
@@ -578,7 +600,7 @@ pub async fn handle_responses(
             if let Some(provider) = err.provider.take() {
                 ctx.provider = provider;
             }
-            log_forward_error(&state, &ctx, is_stream, &err.error);
+            log_forward_error(&state, &ctx, was_streaming, &err.error);
             return Err(err.error);
         }
     };
@@ -586,6 +608,51 @@ pub async fn handle_responses(
     let connection_guard = result.connection_guard.take();
     ctx.provider = result.provider;
     let response = result.response;
+
+    // 如果做了格式转换，需要把 Chat Completions 响应转回 Responses API 格式
+    if needs_chat_transform {
+        // 读取响应体和状态：forwarder 可能返回 Buffered/Reqwest/Hyper 多种类型
+        let upstream_status = response.status();
+        let body_bytes = match response {
+            ProxyResponse::Buffered { body, .. } => body,
+            other => {
+                read_decoded_body(other, "Codex/Transform", std::time::Duration::from_secs(30))
+                    .await
+                    .map(|(_, _, body)| body)
+                    .unwrap_or_default()
+            }
+        };
+
+        let chat_body: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
+        let responses_body = transform_codex::chat_completions_to_responses(chat_body);
+
+        // 如果原始请求是流式，包装为 SSE 事件流（Codex CLI 需要 SSE 格式）
+        if was_streaming {
+            let sse_stream = transform_codex::wrap_responses_as_sse(responses_body);
+            let mut sse_response = axum::response::Response::new(
+                axum::body::Body::from_stream(sse_stream),
+            );
+            *sse_response.status_mut() = upstream_status;
+            let hm = sse_response.headers_mut();
+            hm.insert("content-type", "text/event-stream".parse().unwrap());
+            hm.insert("cache-control", "no-cache".parse().unwrap());
+            return Ok(sse_response);
+        }
+
+        let new_body = serde_json::to_vec(&responses_body).unwrap_or_default();
+        let reconstructed: axum::response::Response = (
+            upstream_status,
+            [(
+                "content-type".parse::<axum::http::HeaderName>().unwrap(),
+                "application/json".parse().unwrap(),
+            )]
+            .into_iter()
+            .collect::<axum::http::HeaderMap>(),
+            new_body,
+        )
+            .into_response();
+        return Ok(reconstructed);
+    }
 
     process_response(
         response,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -110,6 +110,41 @@ pub async fn handle_claude_desktop_models(
     Ok(Json(response))
 }
 
+/// GET /v1/models — 转发到上游供应商获取可用模型列表
+pub async fn handle_codex_models(
+    State(state): State<ProxyState>,
+) -> Result<Json<Value>, ProxyError> {
+    let providers = state
+        .provider_router
+        .select_providers("codex")
+        .await
+        .map_err(|e| ProxyError::DatabaseError(e.to_string()))?;
+    let provider = providers.first().ok_or(ProxyError::NoAvailableProvider)?;
+
+    let adapter = get_adapter(&AppType::Codex);
+    let base_url = adapter.extract_base_url(provider)?;
+    let auth = adapter
+        .extract_auth(provider)
+        .ok_or_else(|| ProxyError::ConfigError("Provider has no API key".to_string()))?;
+
+    let models = crate::services::model_fetch::fetch_models(&base_url, &auth.api_key, false, None)
+        .await
+        .map_err(|e| ProxyError::ConfigError(e))?;
+
+    let data: Vec<Value> = models
+        .into_iter()
+        .map(|m| {
+            json!({
+                "id": m.id,
+                "object": "model",
+                "owned_by": m.owned_by.unwrap_or_default()
+            })
+        })
+        .collect();
+
+    Ok(Json(json!({"object": "list", "data": data})))
+}
+
 async fn handle_messages_for_app(
     state: ProxyState,
     request: axum::extract::Request,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -15,6 +15,7 @@ use super::{
         GEMINI_PARSER_CONFIG, OPENAI_PARSER_CONFIG,
     },
     handler_context::RequestContext,
+    hyper_client::ProxyResponse,
     providers::{
         get_adapter, get_claude_api_format, get_codex_api_format,
         streaming::create_anthropic_sse_stream,
@@ -22,6 +23,7 @@ use super::{
         streaming_responses::create_anthropic_sse_stream_from_responses, transform,
         transform_codex, transform_gemini, transform_responses,
     },
+    req_logger,
     response_processor::{
         create_logged_passthrough_stream, process_response, read_decoded_body,
         strip_entity_headers_for_rebuilt_body, strip_hop_by_hop_response_headers,
@@ -31,8 +33,6 @@ use super::{
     sse::{strip_sse_field, take_sse_block},
     types::*,
     usage::parser::TokenUsage,
-    hyper_client::ProxyResponse,
-    req_logger,
     ProxyError,
 };
 use crate::app_config::AppType;
@@ -632,8 +632,7 @@ pub async fn handle_responses(
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
 
     let api_format = get_codex_api_format(&ctx.provider);
-    let needs_chat_transform =
-        super::providers::codex_api_format_needs_transform(api_format);
+    let needs_chat_transform = super::providers::codex_api_format_needs_transform(api_format);
 
     let was_streaming = body
         .get("stream")
@@ -717,9 +716,8 @@ pub async fn handle_responses(
                 &converted_json,
             );
             let sse_stream = transform_codex::wrap_responses_as_sse(responses_body);
-            let mut sse_response = axum::response::Response::new(
-                axum::body::Body::from_stream(sse_stream),
-            );
+            let mut sse_response =
+                axum::response::Response::new(axum::body::Body::from_stream(sse_stream));
             *sse_response.status_mut() = upstream_status;
             let hm = sse_response.headers_mut();
             hm.insert("content-type", "text/event-stream".parse().unwrap());

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -128,7 +128,12 @@ pub async fn handle_codex_models(
         .extract_auth(provider)
         .ok_or_else(|| ProxyError::ConfigError("Provider has no API key".to_string()))?;
 
-    let models = crate::services::model_fetch::fetch_models(&base_url, &auth.api_key, false, None)
+    let is_full_url = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.is_full_url)
+        .unwrap_or(false);
+    let models = crate::services::model_fetch::fetch_models(&base_url, &auth.api_key, is_full_url, None)
         .await
         .map_err(ProxyError::ConfigError)?;
 
@@ -683,6 +688,7 @@ pub async fn handle_responses(
     if needs_chat_transform {
         // 读取响应体和状态：forwarder 可能返回 Buffered/Reqwest/Hyper 多种类型
         let upstream_status = response.status();
+        let upstream_headers = response.headers().clone();
         let body_bytes = match response {
             ProxyResponse::Buffered { body, .. } => body,
             other => {
@@ -725,25 +731,30 @@ pub async fn handle_responses(
             return Ok(sse_response);
         }
 
-        let new_body = serde_json::to_vec(&responses_body).unwrap_or_default();
-        req_logger::log_return(
-            "Codex",
-            upstream_status.as_u16(),
-            "",
-            &String::from_utf8_lossy(&new_body),
-        );
-        let reconstructed: axum::response::Response = (
-            upstream_status,
-            [(
-                "content-type".parse::<axum::http::HeaderName>().unwrap(),
-                "application/json".parse().unwrap(),
-            )]
-            .into_iter()
-            .collect::<axum::http::HeaderMap>(),
-            new_body,
+        let converted_body = serde_json::to_vec(&responses_body).unwrap_or_default();
+        let buffered = ProxyResponse::Buffered {
+            status: upstream_status,
+            headers: upstream_headers,
+            body: Bytes::from(converted_body),
+        };
+        let result = process_response(
+            buffered,
+            &ctx,
+            &state,
+            &CODEX_PARSER_CONFIG,
+            connection_guard,
         )
-            .into_response();
-        return Ok(reconstructed);
+        .await;
+        match &result {
+            Ok(resp) => req_logger::log_return(
+                "Codex",
+                resp.status().as_u16(),
+                "native",
+                &format!("{:?}", resp.headers()),
+            ),
+            Err(e) => log::error!("[Codex] → RETURN error: {e}"),
+        }
+        return result;
     }
 
     let result = process_response(

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -130,7 +130,7 @@ pub async fn handle_codex_models(
 
     let models = crate::services::model_fetch::fetch_models(&base_url, &auth.api_key, false, None)
         .await
-        .map_err(|e| ProxyError::ConfigError(e))?;
+        .map_err(ProxyError::ConfigError)?;
 
     let data: Vec<Value> = models
         .into_iter()
@@ -169,7 +169,7 @@ async fn handle_messages_for_app(
 
     req_logger::log_incoming(
         tag,
-        &parts.method.to_string(),
+        parts.method.as_ref(),
         &uri.to_string(),
         &format!("{:?}", headers),
         &serde_json::to_string_pretty(&body).unwrap_or_else(|_| format!("{:?}", body)),
@@ -536,7 +536,7 @@ pub async fn handle_chat_completions(
 
     req_logger::log_incoming(
         "Codex",
-        &parts.method.to_string(),
+        parts.method.as_ref(),
         &uri.to_string(),
         &format!("{:?}", headers),
         &serde_json::to_string_pretty(&body).unwrap_or_else(|_| format!("{:?}", body)),
@@ -622,7 +622,7 @@ pub async fn handle_responses(
 
     req_logger::log_incoming(
         "Codex",
-        &parts.method.to_string(),
+        parts.method.as_ref(),
         &uri.to_string(),
         &format!("{:?}", headers),
         &serde_json::to_string_pretty(&body).unwrap_or_else(|_| format!("{:?}", body)),
@@ -786,7 +786,7 @@ pub async fn handle_responses_compact(
 
     req_logger::log_incoming(
         "Codex",
-        &parts.method.to_string(),
+        parts.method.as_ref(),
         &uri.to_string(),
         &format!("{:?}", headers),
         &serde_json::to_string_pretty(&body).unwrap_or_else(|_| format!("{:?}", body)),

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -22,6 +22,7 @@ pub mod log_codes;
 pub mod model_mapper;
 pub mod provider_router;
 pub mod providers;
+pub(crate) mod req_logger;
 pub mod response_handler;
 pub mod response_processor;
 pub(crate) mod server;

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -4,12 +4,36 @@
 //!
 //! ## 客户端检测
 //! 支持检测官方 Codex 客户端 (codex_vscode, codex_cli_rs)
+//!
+//! ## API 格式
+//! 支持通过 `meta.apiFormat` 在 OpenAI Responses（原生）和 Chat Completions 间切换。
 
 use super::{AuthInfo, AuthStrategy, ProviderAdapter};
 use crate::provider::Provider;
 use crate::proxy::error::ProxyError;
 use regex::Regex;
 use std::sync::LazyLock;
+
+/// 从 Provider meta 解析 Codex API 格式
+///
+/// 优先级：
+/// 1. `meta.apiFormat`（SSOT）
+/// 2. 默认 `"openai_responses"`（Codex 原生格式）
+pub fn get_codex_api_format(provider: &Provider) -> &'static str {
+    if let Some(meta) = provider.meta.as_ref() {
+        if let Some(api_format) = meta.api_format.as_deref() {
+            return match api_format {
+                "openai_chat" => "openai_chat",
+                _ => "openai_responses",
+            };
+        }
+    }
+    "openai_responses"
+}
+
+pub fn codex_api_format_needs_transform(api_format: &str) -> bool {
+    api_format == "openai_chat"
+}
 
 /// 官方 Codex 客户端 User-Agent 正则
 #[allow(dead_code)]

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -41,9 +41,7 @@ pub use claude::{
     claude_api_format_needs_transform, get_claude_api_format,
     transform_claude_request_for_api_format, ClaudeAdapter,
 };
-pub use codex::{
-    codex_api_format_needs_transform, get_codex_api_format, CodexAdapter,
-};
+pub use codex::{codex_api_format_needs_transform, get_codex_api_format, CodexAdapter};
 pub use gemini::GeminiAdapter;
 
 /// 供应商类型枚举

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -26,6 +26,7 @@ pub mod streaming;
 pub mod streaming_gemini;
 pub mod streaming_responses;
 pub mod transform;
+pub mod transform_codex;
 pub mod transform_gemini;
 pub mod transform_responses;
 
@@ -40,7 +41,9 @@ pub use claude::{
     claude_api_format_needs_transform, get_claude_api_format,
     transform_claude_request_for_api_format, ClaudeAdapter,
 };
-pub use codex::CodexAdapter;
+pub use codex::{
+    codex_api_format_needs_transform, get_codex_api_format, CodexAdapter,
+};
 pub use gemini::GeminiAdapter;
 
 /// 供应商类型枚举

--- a/src-tauri/src/proxy/providers/transform_codex.rs
+++ b/src-tauri/src/proxy/providers/transform_codex.rs
@@ -261,6 +261,16 @@ pub fn chat_completions_to_responses(body: Value) -> Value {
                     }
                 }
 
+                // Reasoning content (DeepSeek reasoning models)
+                if let Some(reasoning) = message.get("reasoning_content").and_then(|v| v.as_str()) {
+                    if !reasoning.is_empty() {
+                        output.push(json!({
+                            "type": "reasoning",
+                            "summary": [{"type": "summary_text", "text": reasoning}]
+                        }));
+                    }
+                }
+
                 // Tool calls → function_call items
                 if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
                     for tc in tool_calls {
@@ -503,6 +513,42 @@ pub fn wrap_responses_as_sse(
                                 "item_id": &item_id,
                                 "output_index": output_index,
                                 "arguments": arguments
+                            })
+                        ))));
+                    }
+                    "reasoning" => {
+                        let summary = item
+                            .get("summary")
+                            .and_then(|v| v.as_array())
+                            .and_then(|arr| {
+                                arr.first()
+                                    .and_then(|s| s.get("text").and_then(|t| t.as_str()))
+                            })
+                            .unwrap_or("");
+
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.output_item.added\ndata: {}\n\n",
+                            json!({
+                                "type": "response.output_item.added",
+                                "output_index": output_index,
+                                "item": {
+                                    "id": &item_id,
+                                    "type": "reasoning",
+                                    "summary": [{"type": "summary_text", "text": summary}]
+                                }
+                            })
+                        ))));
+
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.output_item.done\ndata: {}\n\n",
+                            json!({
+                                "type": "response.output_item.done",
+                                "output_index": output_index,
+                                "item": {
+                                    "id": &item_id,
+                                    "type": "reasoning",
+                                    "summary": [{"type": "summary_text", "text": summary}]
+                                }
                             })
                         ))));
                     }

--- a/src-tauri/src/proxy/providers/transform_codex.rs
+++ b/src-tauri/src/proxy/providers/transform_codex.rs
@@ -1,0 +1,750 @@
+//! Codex OpenAI 格式转换模块
+//!
+//! 实现 OpenAI Responses API ↔ OpenAI Chat Completions API 格式转换。
+//! 用于 Codex CLI（仅支持 Responses API）连接到仅支持 Chat Completions 的供应商（如 DeepSeek）。
+
+use bytes::Bytes;
+use futures::{stream, Stream};
+use serde_json::{json, Value};
+
+/// OpenAI Responses API 请求 → OpenAI Chat Completions 请求
+pub fn responses_to_chat_completions(body: Value) -> Value {
+    let mut result = json!({});
+
+    if let Some(model) = body.get("model") {
+        result["model"] = model.clone();
+    }
+
+    let mut messages: Vec<Value> = Vec::new();
+
+    // instructions → system message
+    if let Some(instructions) = body.get("instructions").and_then(|v| v.as_str()) {
+        messages.push(json!({
+            "role": "system",
+            "content": instructions
+        }));
+    }
+
+    // input 数组 → messages
+    if let Some(input) = body.get("input").and_then(|v| v.as_array()) {
+        convert_input_to_messages(input, &mut messages);
+    }
+
+    result["messages"] = json!(messages);
+
+    // max_output_tokens → max_tokens
+    if let Some(v) = body.get("max_output_tokens") {
+        result["max_tokens"] = v.clone();
+    }
+
+    for key in &["temperature", "top_p", "stream", "stop"] {
+        if let Some(v) = body.get(key) {
+            result[key] = v.clone();
+        }
+    }
+
+    // tools: Responses API → Chat Completions
+    // Responses 支持多种 tool type (function, namespace, web_search 等)
+    // Chat Completions/DeepSeek 仅支持 function
+    if let Some(tools) = body.get("tools").and_then(|v| v.as_array()) {
+        let mut chat_tools: Vec<Value> = Vec::new();
+        for tool in tools {
+            let tool_type = tool
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("function");
+
+            match tool_type {
+                "function" => {
+                    let mut function_obj = json!({});
+                    for key in &["name", "description", "parameters", "strict"] {
+                        if let Some(v) = tool.get(key) {
+                            function_obj[key] = v.clone();
+                        }
+                    }
+                    chat_tools.push(json!({
+                        "type": "function",
+                        "function": function_obj
+                    }));
+                }
+                // namespace: MCP server tools — 展开内嵌的 functions
+                "namespace" => {
+                    if let Some(ns_tools) = tool.get("tools").and_then(|v| v.as_array()) {
+                        let ns_prefix = tool
+                            .get("namespace")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        for ns_tool in ns_tools {
+                            if ns_tool.get("type").and_then(|v| v.as_str()) == Some("function")
+                            {
+                                let mut function_obj = json!({});
+                                let orig_name = ns_tool
+                                    .get("name")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+                                // Prepend namespace: "filesystem/read_file"
+                                let qualified_name = if ns_prefix.is_empty() {
+                                    orig_name.to_string()
+                                } else {
+                                    format!("{ns_prefix}/{orig_name}")
+                                };
+                                function_obj["name"] = json!(qualified_name);
+                                for key in &["description", "parameters", "strict"] {
+                                    if let Some(v) = ns_tool.get(key) {
+                                        function_obj[key] = v.clone();
+                                    }
+                                }
+                                chat_tools.push(json!({
+                                    "type": "function",
+                                    "function": function_obj
+                                }));
+                            }
+                        }
+                    }
+                }
+                // web_search, code_interpreter 等 — 跳过（DeepSeek 不支持）
+                _ => {}
+            }
+        }
+        if !chat_tools.is_empty() {
+            result["tools"] = json!(chat_tools);
+        }
+    }
+
+    // tool_choice: 过滤掉 Chat Completions 不支持的值
+    if let Some(v) = body.get("tool_choice") {
+        let mapped = match v {
+            Value::String(s) => match s.as_str() {
+                "auto" | "none" | "required" => v.clone(),
+                _ => json!("auto"),
+            },
+            Value::Object(_) => v.clone(),
+            _ => json!("auto"),
+        };
+        result["tool_choice"] = mapped;
+    }
+
+    // reasoning (Responses API) → thinking (DeepSeek)
+    if let Some(reasoning) = body.get("reasoning") {
+        if let Some(effort) = reasoning.get("effort").and_then(|v| v.as_str()) {
+            result["thinking"] = json!({
+                "type": "enabled",
+                "reasoning_effort": effort
+            });
+        }
+    }
+
+    result
+}
+
+fn convert_input_to_messages(input: &[Value], messages: &mut Vec<Value>) {
+    for item in input {
+        let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        match item_type {
+            "function_call" => {
+                messages.push(json!({
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": item.get("call_id").cloned().unwrap_or_default(),
+                        "type": "function",
+                        "function": {
+                            "name": item.get("name").cloned().unwrap_or_default(),
+                            "arguments": item.get("arguments").cloned().unwrap_or(json!("{}"))
+                        }
+                    }]
+                }));
+            }
+
+            "function_call_output" => {
+                messages.push(json!({
+                    "role": "tool",
+                    "tool_call_id": item.get("call_id").and_then(|v| v.as_str()).unwrap_or(""),
+                    "content": item.get("output").map(|v| v.as_str().unwrap_or("")).unwrap_or("")
+                }));
+            }
+
+            // Responses API message items use "role" without an explicit "type" field
+            _ => {
+                let role = match item.get("role").and_then(|v| v.as_str()) {
+                    Some(r) => r,
+                    None => continue,
+                };
+                let resolved_role = match role {
+                    "assistant" => "assistant",
+                    "developer" => "system",
+                    other => other,
+                };
+
+                if let Some(content_blocks) = item.get("content").and_then(|v| v.as_array()) {
+                    let texts: Vec<&str> = content_blocks
+                        .iter()
+                        .filter_map(|block| {
+                            let bt = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                            match bt {
+                                "input_text" | "output_text" => {
+                                    block.get("text").and_then(|v| v.as_str())
+                                }
+                                "refusal" => block.get("refusal").and_then(|v| v.as_str()),
+                                _ => None,
+                            }
+                        })
+                        .collect();
+
+                    if !texts.is_empty() {
+                        messages.push(json!({
+                            "role": resolved_role,
+                            "content": texts.join("")
+                        }));
+                    } else if content_blocks.iter().any(|b| {
+                        b.get("type").and_then(|v| v.as_str()) == Some("input_image")
+                    }) {
+                        let parts: Vec<Value> = content_blocks
+                            .iter()
+                            .filter_map(|block| {
+                                if block.get("type").and_then(|v| v.as_str()) == Some("input_image")
+                                {
+                                    Some(json!({
+                                        "type": "image_url",
+                                        "image_url": block.get("image_url").cloned().unwrap_or(json!({}))
+                                    }))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+                        if !parts.is_empty() {
+                            messages.push(json!({
+                                "role": resolved_role,
+                                "content": parts
+                            }));
+                        }
+                    }
+                } else if let Some(text) = item.get("content").and_then(|v| v.as_str()) {
+                    messages.push(json!({
+                        "role": resolved_role,
+                        "content": text
+                    }));
+                }
+            }
+        }
+    }
+}
+
+/// OpenAI Chat Completions 响应 → OpenAI Responses 响应
+pub fn chat_completions_to_responses(body: Value) -> Value {
+    let model = body
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let choices = body.get("choices").and_then(|v| v.as_array());
+    let usage = body.get("usage");
+
+    let mut output: Vec<Value> = Vec::new();
+
+    if let Some(choices) = choices {
+        for choice in choices {
+            let message = choice.get("message");
+
+            if let Some(message) = message {
+                // Text content
+                if let Some(text) = message.get("content").and_then(|v| v.as_str()) {
+                    if !text.is_empty() {
+                        output.push(json!({
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": text}]
+                        }));
+                    }
+                }
+
+                // Tool calls → function_call items
+                if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
+                    for tc in tool_calls {
+                        let function = tc.get("function");
+                        output.push(json!({
+                            "type": "function_call",
+                            "call_id": tc.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+                            "name": function.and_then(|f| f.get("name")).and_then(|v| v.as_str()).unwrap_or(""),
+                            "arguments": function.and_then(|f| f.get("arguments").cloned()).unwrap_or(json!("{}"))
+                        }));
+                    }
+                }
+            }
+        }
+    }
+
+    let usage_json = if let Some(usage) = usage {
+        json!({
+            "input_tokens": usage.get("prompt_tokens").cloned().unwrap_or(json!(0)),
+            "output_tokens": usage.get("completion_tokens").cloned().unwrap_or(json!(0)),
+            "total_tokens": usage.get("total_tokens").cloned().unwrap_or(json!(0))
+        })
+    } else {
+        json!({
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0
+        })
+    };
+
+    json!({
+        "id": body.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+        "object": "response",
+        "model": model,
+        "output": output,
+        "status": "completed",
+        "usage": usage_json
+    })
+}
+
+/// 将完整的 Responses API 响应包装为 SSE 事件流
+///
+/// 当原始请求为流式但格式转换需降级为非流式时，用此函数生成一次性 SSE 流。
+/// Codex CLI 发送 `stream: true` 时依赖 SSE 事件完成解析。
+pub fn wrap_responses_as_sse(
+    responses_body: Value,
+) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
+    let response_id = responses_body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("resp_chat")
+        .to_string();
+    let msg_id = format!("msg_{response_id}");
+
+    let model_name = responses_body
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let usage_json = responses_body
+        .get("usage")
+        .cloned()
+        .unwrap_or(json!({"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}));
+    let initial_usage = json!({
+        "input_tokens": usage_json.get("input_tokens").cloned().unwrap_or(json!(0)),
+        "output_tokens": 0,
+        "total_tokens": usage_json.get("total_tokens").cloned().unwrap_or(json!(0))
+    });
+
+    let created = format!(
+        "event: response.created\ndata: {}\n\n",
+        json!({
+            "type": "response.created",
+            "response": {
+                "id": &response_id,
+                "model": model_name,
+                "usage": initial_usage
+            }
+        })
+    );
+
+    let completed = format!(
+        "event: response.completed\ndata: {}\n\n",
+        json!({
+            "type": "response.completed",
+            "response": &responses_body
+        })
+    );
+
+    let events: Vec<Result<Bytes, std::io::Error>> = {
+        let mut v: Vec<Result<Bytes, std::io::Error>> = Vec::new();
+
+        // response.created MUST be first
+        v.push(Ok(Bytes::from(created)));
+
+        // Append per-output-item events for tool calls and text
+        if let Some(output) = responses_body.get("output").and_then(|v| v.as_array()) {
+            for (i, item) in output.iter().enumerate() {
+                let output_index = i;
+                let item_id = item
+                    .get("call_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&msg_id)
+                    .to_string();
+
+                let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+                match item_type {
+                    "message" => {
+                        let text = item
+                            .get("content")
+                            .and_then(|v| v.as_array())
+                            .and_then(|arr| {
+                                arr.first()
+                                    .and_then(|c| c.get("text").and_then(|t| t.as_str()))
+                            })
+                            .unwrap_or("");
+
+                        // output_item.added
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.output_item.added\ndata: {}\n\n",
+                            json!({
+                                "type": "response.output_item.added",
+                                "output_index": output_index,
+                                "item": {
+                                    "id": &item_id,
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "status": "in_progress",
+                                    "content": []
+                                }
+                            })
+                        ))));
+
+                        // content_part.added
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.content_part.added\ndata: {}\n\n",
+                            json!({
+                                "type": "response.content_part.added",
+                                "item_id": &item_id,
+                                "output_index": output_index,
+                                "content_index": 0,
+                                "part": {
+                                    "type": "output_text",
+                                    "text": "",
+                                    "annotations": []
+                                }
+                            })
+                        ))));
+
+                        // output_text.delta
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.output_text.delta\ndata: {}\n\n",
+                            json!({
+                                "type": "response.output_text.delta",
+                                "item_id": &item_id,
+                                "output_index": output_index,
+                                "content_index": 0,
+                                "delta": text
+                            })
+                        ))));
+
+                        // content_part.done
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.content_part.done\ndata: {}\n\n",
+                            json!({
+                                "type": "response.content_part.done",
+                                "item_id": &item_id,
+                                "output_index": output_index,
+                                "content_index": 0,
+                                "part": {
+                                    "type": "output_text",
+                                    "text": text,
+                                    "annotations": []
+                                }
+                            })
+                        ))));
+
+                        // output_item.done
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.output_item.done\ndata: {}\n\n",
+                            json!({
+                                "type": "response.output_item.done",
+                                "output_index": output_index,
+                                "item": {
+                                    "id": &item_id,
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "status": "completed",
+                                    "content": [{
+                                        "type": "output_text",
+                                        "text": text,
+                                        "annotations": []
+                                    }]
+                                }
+                            })
+                        ))));
+                    }
+                    "function_call" => {
+                        let name = item
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        let arguments = item
+                            .get("arguments")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("{}");
+
+                        // output_item.added for function_call
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.output_item.added\ndata: {}\n\n",
+                            json!({
+                                "type": "response.output_item.added",
+                                "output_index": output_index,
+                                "item": {
+                                    "id": &item_id,
+                                    "type": "function_call",
+                                    "call_id": &item_id,
+                                    "name": name,
+                                    "arguments": ""
+                                }
+                            })
+                        ))));
+
+                        // function_call_arguments.delta
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.function_call_arguments.delta\ndata: {}\n\n",
+                            json!({
+                                "type": "response.function_call_arguments.delta",
+                                "item_id": &item_id,
+                                "output_index": output_index,
+                                "delta": arguments
+                            })
+                        ))));
+
+                        // function_call_arguments.done
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.function_call_arguments.done\ndata: {}\n\n",
+                            json!({
+                                "type": "response.function_call_arguments.done",
+                                "item_id": &item_id,
+                                "output_index": output_index,
+                                "arguments": arguments
+                            })
+                        ))));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        v.push(Ok(Bytes::from(completed)));
+        v
+    };
+
+    stream::iter(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_responses_to_chat_simple() {
+        let input = json!({
+            "model": "deepseek-chat",
+            "instructions": "You are a helpful assistant.",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "Hello"}]}
+            ],
+            "max_output_tokens": 1024,
+            "stream": false
+        });
+
+        let result = responses_to_chat_completions(input);
+        assert_eq!(result["model"], "deepseek-chat");
+        assert_eq!(result["max_tokens"], 1024);
+        assert_eq!(result["messages"][0]["role"], "system");
+        assert_eq!(
+            result["messages"][0]["content"],
+            "You are a helpful assistant."
+        );
+        assert_eq!(result["messages"][1]["role"], "user");
+        assert_eq!(result["messages"][1]["content"], "Hello");
+    }
+
+    #[test]
+    fn test_responses_to_chat_with_tool_calls() {
+        let input = json!({
+            "model": "deepseek-chat",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "Read file"}]},
+                {"type": "function_call", "call_id": "call_1", "name": "read_file", "arguments": "{\"path\": \"/tmp/x\"}"},
+                {"type": "function_call_output", "call_id": "call_1", "output": "content here"}
+            ]
+        });
+
+        let result = responses_to_chat_completions(input);
+        let msgs = result["messages"].as_array().unwrap();
+
+        assert_eq!(msgs[0]["role"], "user");
+        assert_eq!(msgs[0]["content"], "Read file");
+
+        assert_eq!(msgs[1]["role"], "assistant");
+        assert_eq!(msgs[1]["content"], json!(null));
+        let tc = &msgs[1]["tool_calls"][0];
+        assert_eq!(tc["function"]["name"], "read_file");
+
+        assert_eq!(msgs[2]["role"], "tool");
+        assert_eq!(msgs[2]["tool_call_id"], "call_1");
+    }
+
+    #[test]
+    fn test_chat_to_responses_simple() {
+        let input = json!({
+            "id": "chatcmpl-123",
+            "model": "deepseek-chat",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hi there!"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+        });
+
+        let result = chat_completions_to_responses(input);
+        assert_eq!(result["id"], "chatcmpl-123");
+        assert_eq!(result["object"], "response");
+        assert_eq!(result["output"][0]["type"], "message");
+        assert_eq!(
+            result["output"][0]["content"][0]["text"],
+            "Hi there!"
+        );
+        assert_eq!(result["usage"]["input_tokens"], 5);
+        assert_eq!(result["usage"]["output_tokens"], 3);
+    }
+
+    #[test]
+    fn test_responses_to_chat_no_instructions() {
+        let input = json!({
+            "model": "deepseek-chat",
+            "input": [
+                {"role": "user", "content": "ping"}
+            ]
+        });
+
+        let result = responses_to_chat_completions(input);
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_responses_to_chat_tools_wrapping() {
+        let input = json!({
+            "model": "deepseek-chat",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+            ],
+            "tools": [{
+                "type": "function",
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+                "strict": true
+            }]
+        });
+
+        let result = responses_to_chat_completions(input);
+        let tools = result["tools"].as_array().unwrap();
+        assert_eq!(tools[0]["type"], "function");
+        assert_eq!(tools[0]["function"]["name"], "read_file");
+        assert_eq!(tools[0]["function"]["description"], "Read a file");
+        assert_eq!(tools[0]["function"]["strict"], true);
+        assert!(tools[0].get("name").is_none());
+    }
+
+    #[test]
+    fn test_namespace_tools_unwrapped() {
+        let input = json!({
+            "model": "deepseek-chat",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+            ],
+            "tools": [
+                {
+                    "type": "namespace",
+                    "namespace": "filesystem",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "read_file",
+                            "description": "Read a file",
+                            "parameters": {}
+                        },
+                        {
+                            "type": "function",
+                            "name": "write_file",
+                            "description": "Write a file",
+                            "parameters": {}
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {}
+                },
+                {
+                    "type": "web_search",
+                    "name": "search"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input);
+        let tools = result["tools"].as_array().unwrap();
+        // 2 namespace functions + 1 plain function = 3; web_search filtered out
+        assert_eq!(tools.len(), 3);
+        assert_eq!(tools[0]["function"]["name"], "filesystem/read_file");
+        assert_eq!(tools[1]["function"]["name"], "filesystem/write_file");
+        assert_eq!(tools[2]["function"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_sse_event_ordering() {
+        let body = json!({
+            "id": "resp_1",
+            "object": "response",
+            "model": "deepseek-chat",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Hello"}]
+            }],
+            "status": "completed",
+            "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8}
+        });
+
+        let stream = wrap_responses_as_sse(body);
+        let chunks: Vec<Bytes> = futures::executor::block_on(
+            futures::StreamExt::collect::<Vec<Result<Bytes, std::io::Error>>>(stream)
+        )
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+        let combined = chunks.concat();
+        let text = String::from_utf8_lossy(&combined);
+
+        // response.created MUST be the first event
+        let created_pos = text.find("event: response.created").unwrap();
+        let completed_pos = text.find("event: response.completed").unwrap();
+        let first_output = text.find("event: response.output_item.added").unwrap();
+
+        assert!(
+            created_pos < first_output,
+            "response.created ({created_pos}) must come before first output_item.added ({first_output})\nFull SSE:\n{text}"
+        );
+        assert!(
+            completed_pos > first_output,
+            "response.completed ({completed_pos}) must come after output events ({first_output})\nFull SSE:\n{text}"
+        );
+
+        // Parse the first event (response.created) and verify required fields
+        let created_data_str = text
+            .lines()
+            .skip_while(|l| !l.starts_with("data: "))
+            .next()
+            .unwrap()
+            .strip_prefix("data: ")
+            .unwrap();
+        let created_data: Value = serde_json::from_str(created_data_str).unwrap();
+        let created_response = &created_data["response"];
+
+        assert_eq!(
+            created_response["id"], "resp_1",
+            "response.created must include id"
+        );
+        assert_eq!(
+            created_response["model"], "deepseek-chat",
+            "response.created must include model\nFull SSE:\n{text}"
+        );
+        assert!(
+            created_response.get("usage").is_some(),
+            "response.created must include usage\nFull SSE:\n{text}"
+        );
+    }
+}

--- a/src-tauri/src/proxy/providers/transform_codex.rs
+++ b/src-tauri/src/proxy/providers/transform_codex.rs
@@ -240,46 +240,96 @@ pub fn chat_completions_to_responses(body: Value) -> Value {
         .unwrap_or("")
         .to_string();
 
+    let id = body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
     let choices = body.get("choices").and_then(|v| v.as_array());
     let usage = body.get("usage");
 
     let mut output: Vec<Value> = Vec::new();
+    let mut status = "completed";
 
     if let Some(choices) = choices {
         for choice in choices {
+            let finish_reason = choice
+                .get("finish_reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("stop");
             let message = choice.get("message");
 
+            // Map finish_reason to status (last choice wins)
+            status = match finish_reason {
+                "stop" | "tool_calls" => "completed",
+                "length" => "incomplete",
+                "content_filter" => "incomplete",
+                _ => "completed",
+            };
+
             if let Some(message) = message {
-                // Text content
-                if let Some(text) = message.get("content").and_then(|v| v.as_str()) {
-                    if !text.is_empty() {
+                // Text content — need null check because tool_calls messages have content: null
+                let text = message
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty());
+
+                // Reasoning content (DeepSeek reasoning models)
+                let reasoning = message
+                    .get("reasoning_content")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty());
+
+                // Tool calls
+                let tool_calls = message.get("tool_calls").and_then(|v| v.as_array());
+
+                let has_tool_calls = tool_calls.map_or(false, |tc| !tc.is_empty());
+
+                if text.is_some() || has_tool_calls {
+                    let mut content: Vec<Value> = Vec::new();
+                    if let Some(t) = text {
+                        content.push(json!({"type": "output_text", "text": t}));
+                    }
+                    if let Some(tc) = tool_calls {
+                        for call in tc {
+                            if let Some(f) = call.get("function") {
+                                content.push(json!({
+                                    "type": "tool_use",
+                                    "id": call.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+                                    "name": f.get("name").and_then(|v| v.as_str()).unwrap_or(""),
+                                    "input": f.get("arguments").cloned().unwrap_or(json!({}))
+                                }));
+                            }
+                        }
+                    }
+                    if !content.is_empty() {
                         output.push(json!({
                             "type": "message",
                             "role": "assistant",
-                            "content": [{"type": "output_text", "text": text}]
+                            "status": "completed",
+                            "content": content
                         }));
                     }
                 }
 
-                // Reasoning content (DeepSeek reasoning models)
-                if let Some(reasoning) = message.get("reasoning_content").and_then(|v| v.as_str()) {
-                    if !reasoning.is_empty() {
-                        output.push(json!({
-                            "type": "reasoning",
-                            "summary": [{"type": "summary_text", "text": reasoning}]
-                        }));
-                    }
+                // Reasoning content → reasoning item
+                if let Some(reasoning_text) = reasoning {
+                    output.push(json!({
+                        "type": "reasoning",
+                        "content": [{"type": "summary_text", "text": reasoning_text}]
+                    }));
                 }
 
-                // Tool calls → function_call items
-                if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
-                    for tc in tool_calls {
+                // Legacy tool_calls → function_call items (for backward compat with simpler schemas)
+                if has_tool_calls {
+                    for tc in tool_calls.unwrap() {
                         let function = tc.get("function");
                         output.push(json!({
                             "type": "function_call",
                             "call_id": tc.get("id").and_then(|v| v.as_str()).unwrap_or(""),
                             "name": function.and_then(|f| f.get("name")).and_then(|v| v.as_str()).unwrap_or(""),
-                            "arguments": function.and_then(|f| f.get("arguments").cloned()).unwrap_or(json!("{}"))
+                            "arguments": function.and_then(|f| f.get("arguments").cloned()).unwrap_or(json!("{}")),
+                            "status": "completed"
                         }));
                     }
                 }
@@ -288,10 +338,21 @@ pub fn chat_completions_to_responses(body: Value) -> Value {
     }
 
     let usage_json = if let Some(usage) = usage {
+        let prompt_tokens = usage.get("prompt_tokens").cloned().unwrap_or(json!(0));
+        let completion_tokens = usage.get("completion_tokens").cloned().unwrap_or(json!(0));
+        let total_tokens = usage.get("total_tokens").cloned().unwrap_or(json!(0));
+        // OpenAI Responses API 期望 input_tokens 包含 cache_read (Anthropic) 或 prompt_cache_hit (OpenAI)
+        // 对于 DeepSeek，prompt_cache_hit_tokens 也可能存在
+        let cache_hit = usage
+            .get("prompt_cache_hit_tokens")
+            .or_else(|| usage.get("prompt_tokens_details").and_then(|d| d.get("cached_tokens")))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let input_tokens = prompt_tokens.as_u64().unwrap_or(0) + cache_hit;
         json!({
-            "input_tokens": usage.get("prompt_tokens").cloned().unwrap_or(json!(0)),
-            "output_tokens": usage.get("completion_tokens").cloned().unwrap_or(json!(0)),
-            "total_tokens": usage.get("total_tokens").cloned().unwrap_or(json!(0))
+            "input_tokens": input_tokens,
+            "output_tokens": completion_tokens,
+            "total_tokens": total_tokens
         })
     } else {
         json!({
@@ -302,11 +363,11 @@ pub fn chat_completions_to_responses(body: Value) -> Value {
     };
 
     json!({
-        "id": body.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+        "id": id,
         "object": "response",
         "model": model,
         "output": output,
-        "status": "completed",
+        "status": status,
         "usage": usage_json
     })
 }
@@ -351,6 +412,18 @@ pub fn wrap_responses_as_sse(
         })
     );
 
+    let in_progress = format!(
+        "event: response.in_progress\ndata: {}\n\n",
+        json!({
+            "type": "response.in_progress",
+            "response": {
+                "id": &response_id,
+                "model": model_name,
+                "status": "in_progress"
+            }
+        })
+    );
+
     let completed = format!(
         "event: response.completed\ndata: {}\n\n",
         json!({
@@ -365,7 +438,10 @@ pub fn wrap_responses_as_sse(
         // response.created MUST be first
         v.push(Ok(Bytes::from(created)));
 
-        // Append per-output-item events for tool calls and text
+        // response.in_progress MUST follow response.created
+        v.push(Ok(Bytes::from(in_progress)));
+
+        // Append per-output-item events for tool calls, text, and reasoning
         if let Some(output) = responses_body.get("output").and_then(|v| v.as_array()) {
             for (i, item) in output.iter().enumerate() {
                 let output_index = i;
@@ -517,8 +593,10 @@ pub fn wrap_responses_as_sse(
                         ))));
                     }
                     "reasoning" => {
-                        let summary = item
-                            .get("summary")
+                        // Support both old "summary" and new "content" format
+                        let summary_text = item
+                            .get("content")
+                            .or_else(|| item.get("summary"))
                             .and_then(|v| v.as_array())
                             .and_then(|arr| {
                                 arr.first()
@@ -534,7 +612,7 @@ pub fn wrap_responses_as_sse(
                                 "item": {
                                     "id": &item_id,
                                     "type": "reasoning",
-                                    "summary": [{"type": "summary_text", "text": summary}]
+                                    "content": [{"type": "summary_text", "text": summary_text}]
                                 }
                             })
                         ))));
@@ -547,7 +625,7 @@ pub fn wrap_responses_as_sse(
                                 "item": {
                                     "id": &item_id,
                                     "type": "reasoning",
-                                    "summary": [{"type": "summary_text", "text": summary}]
+                                    "content": [{"type": "summary_text", "text": summary_text}]
                                 }
                             })
                         ))));
@@ -757,12 +835,17 @@ mod tests {
 
         // response.created MUST be the first event
         let created_pos = text.find("event: response.created").unwrap();
+        let in_progress_pos = text.find("event: response.in_progress").unwrap();
         let completed_pos = text.find("event: response.completed").unwrap();
         let first_output = text.find("event: response.output_item.added").unwrap();
 
         assert!(
-            created_pos < first_output,
-            "response.created ({created_pos}) must come before first output_item.added ({first_output})\nFull SSE:\n{text}"
+            created_pos < in_progress_pos,
+            "response.created ({created_pos}) must come before response.in_progress ({in_progress_pos})"
+        );
+        assert!(
+            in_progress_pos < first_output,
+            "response.in_progress ({in_progress_pos}) must come before first output_item.added ({first_output})\nFull SSE:\n{text}"
         );
         assert!(
             completed_pos > first_output,
@@ -792,5 +875,96 @@ mod tests {
             created_response.get("usage").is_some(),
             "response.created must include usage\nFull SSE:\n{text}"
         );
+    }
+
+    #[test]
+    fn test_chat_to_responses_with_tool_calls_null_content() {
+        let input = json!({
+            "id": "chatcmpl-456",
+            "model": "deepseek-chat",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"/tmp/x\"}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+        });
+
+        let result = chat_completions_to_responses(input);
+        let output = result["output"].as_array().unwrap();
+
+        // Should have 1 message item + 1 function_call item
+        assert_eq!(output.len(), 2, "should have message + function_call items");
+        assert_eq!(output[0]["type"], "message");
+        assert_eq!(output[1]["type"], "function_call");
+        assert_eq!(output[1]["call_id"], "call_abc");
+        assert_eq!(output[1]["name"], "read_file");
+        assert_eq!(result["status"], "completed");
+    }
+
+    #[test]
+    fn test_chat_to_responses_handles_length_finish() {
+        let input = json!({
+            "id": "chatcmpl-789",
+            "model": "deepseek-chat",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "未完成的"},
+                "finish_reason": "length"
+            }]
+        });
+
+        let result = chat_completions_to_responses(input);
+        assert_eq!(result["status"], "incomplete");
+    }
+
+    #[test]
+    fn test_chat_to_responses_with_reasoning_content() {
+        let input = json!({
+            "id": "chatcmpl-reason",
+            "model": "deepseek-reasoner",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "答案是42",
+                    "reasoning_content": "让我思考一下..."
+                },
+                "finish_reason": "stop"
+            }]
+        });
+
+        let result = chat_completions_to_responses(input);
+        let output = result["output"].as_array().unwrap();
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0]["type"], "message");
+        assert_eq!(output[1]["type"], "reasoning");
+        assert_eq!(output[1]["content"][0]["type"], "summary_text");
+        assert_eq!(output[1]["content"][0]["text"], "让我思考一下...");
+    }
+
+    #[test]
+    fn test_chat_to_responses_session_id_preserved() {
+        let input = json!({
+            "id": "chatcmpl-session-123",
+            "model": "deepseek-chat",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop"
+            }]
+        });
+
+        let result = chat_completions_to_responses(input);
+        assert_eq!(result["id"], "chatcmpl-session-123");
+        assert_eq!(result["object"], "response");
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex.rs
+++ b/src-tauri/src/proxy/providers/transform_codex.rs
@@ -6,6 +6,33 @@
 use bytes::Bytes;
 use futures::{stream, Stream};
 use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+/// DeepSeek 要求 reasoning_content 必须在后续请求中原样回传。
+/// 此缓存按 tool_call.id 存储 reasoning_content，跨请求注入。
+static REASONING_CACHE: LazyLock<Mutex<HashMap<String, String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// 缓存 reasoning_content，按 tool_call IDs
+pub fn cache_reasoning_for_tool_calls(reasoning: &str, tool_call_ids: &[String]) {
+    if reasoning.is_empty() || tool_call_ids.is_empty() {
+        return;
+    }
+    if let Ok(mut cache) = REASONING_CACHE.lock() {
+        for id in tool_call_ids {
+            cache.insert(id.clone(), reasoning.to_string());
+        }
+    }
+}
+
+/// 按 tool_call ID 查找缓存的 reasoning_content
+fn get_cached_reasoning(tool_call_id: &str) -> Option<String> {
+    REASONING_CACHE
+        .lock()
+        .ok()
+        .and_then(|cache| cache.get(tool_call_id).cloned())
+}
 
 /// OpenAI Responses API 请求 → OpenAI Chat Completions 请求
 pub fn responses_to_chat_completions(body: Value) -> Value {
@@ -138,26 +165,42 @@ pub fn responses_to_chat_completions(body: Value) -> Value {
 }
 
 fn convert_input_to_messages(input: &[Value], messages: &mut Vec<Value>) {
+    let mut pending_tool_calls: Vec<Value> = Vec::new();
+
     for item in input {
         let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
         match item_type {
             "function_call" => {
-                messages.push(json!({
-                    "role": "assistant",
-                    "content": null,
-                    "tool_calls": [{
-                        "id": item.get("call_id").cloned().unwrap_or_default(),
-                        "type": "function",
-                        "function": {
-                            "name": item.get("name").cloned().unwrap_or_default(),
-                            "arguments": item.get("arguments").cloned().unwrap_or(json!("{}"))
-                        }
-                    }]
+                let call_id = item
+                    .get("call_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                // Accumulate consecutive function_calls into one assistant message
+                pending_tool_calls.push(json!({
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name").cloned().unwrap_or_default(),
+                        "arguments": item.get("arguments").cloned().unwrap_or(json!("{}"))
+                    }
                 }));
             }
 
             "function_call_output" => {
+                // Flush pending tool_calls before processing output
+                if !pending_tool_calls.is_empty() {
+                    let mut msg = json!({
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": pending_tool_calls
+                    });
+                    // Inject cached reasoning_content (DeepSeek requirement)
+                    inject_reasoning_into_message(&mut msg);
+                    messages.push(msg);
+                    pending_tool_calls = Vec::new();
+                }
                 messages.push(json!({
                     "role": "tool",
                     "tool_call_id": item.get("call_id").and_then(|v| v.as_str()).unwrap_or(""),
@@ -230,6 +273,37 @@ fn convert_input_to_messages(input: &[Value], messages: &mut Vec<Value>) {
             }
         }
     }
+
+    // Flush any remaining pending tool_calls
+    if !pending_tool_calls.is_empty() {
+        let mut msg = json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": pending_tool_calls
+        });
+        inject_reasoning_into_message(&mut msg);
+        messages.push(msg);
+    }
+}
+
+/// 为 assistant message 注入缓存的 reasoning_content（DeepSeek 硬性要求）
+fn inject_reasoning_into_message(msg: &mut Value) {
+    let tool_calls = match msg.get("tool_calls").and_then(|v| v.as_array()) {
+        Some(tc) => tc,
+        None => return,
+    };
+    // 检查任意 tool_call 是否有缓存
+    for tc in tool_calls {
+        if let Some(call_id) = tc.get("id").and_then(|v| v.as_str()) {
+            if let Some(reasoning) = get_cached_reasoning(call_id) {
+                msg["reasoning_content"] = json!(reasoning);
+                return;
+            }
+        }
+    }
+    // 兜底：即使缓存为空，DeepSeek 也要求字段存在
+    // 设置空字符串以确保 JSON 序列化时输出 "reasoning_content": ""
+    msg["reasoning_content"] = json!("");
 }
 
 /// OpenAI Chat Completions 响应 → OpenAI Responses 响应
@@ -268,7 +342,7 @@ pub fn chat_completions_to_responses(body: Value) -> Value {
             };
 
             if let Some(message) = message {
-                // Text content — need null check because tool_calls messages have content: null
+                // Text content — may be null when only tool_calls are present
                 let text = message
                     .get("content")
                     .and_then(|v| v.as_str())
@@ -280,57 +354,50 @@ pub fn chat_completions_to_responses(body: Value) -> Value {
                     .and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty());
 
-                // Tool calls
+                // Tool calls → separate function_call output items
                 let tool_calls = message.get("tool_calls").and_then(|v| v.as_array());
 
-                let has_tool_calls = tool_calls.map_or(false, |tc| !tc.is_empty());
-
-                if text.is_some() || has_tool_calls {
-                    let mut content: Vec<Value> = Vec::new();
-                    if let Some(t) = text {
-                        content.push(json!({"type": "output_text", "text": t}));
-                    }
-                    if let Some(tc) = tool_calls {
-                        for call in tc {
-                            if let Some(f) = call.get("function") {
-                                content.push(json!({
-                                    "type": "tool_use",
-                                    "id": call.get("id").and_then(|v| v.as_str()).unwrap_or(""),
-                                    "name": f.get("name").and_then(|v| v.as_str()).unwrap_or(""),
-                                    "input": f.get("arguments").cloned().unwrap_or(json!({}))
-                                }));
-                            }
-                        }
-                    }
-                    if !content.is_empty() {
-                        output.push(json!({
-                            "type": "message",
-                            "role": "assistant",
-                            "status": "completed",
-                            "content": content
-                        }));
-                    }
+                // Message item: only for text content (not for tool_calls)
+                // OpenAI Responses API uses separate function_call items, not tool_use within message
+                if let Some(t) = text {
+                    output.push(json!({
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": t}]
+                    }));
                 }
 
                 // Reasoning content → reasoning item
                 if let Some(reasoning_text) = reasoning {
                     output.push(json!({
                         "type": "reasoning",
-                        "content": [{"type": "summary_text", "text": reasoning_text}]
+                        "summary": [{"type": "text", "text": reasoning_text}],
+                        "status": "completed"
                     }));
                 }
 
-                // Legacy tool_calls → function_call items (for backward compat with simpler schemas)
-                if has_tool_calls {
-                    for tc in tool_calls.unwrap() {
-                        let function = tc.get("function");
+                // Tool calls → function_call items (separate from message)
+                if let Some(tc) = tool_calls {
+                    let mut tc_ids: Vec<String> = Vec::new();
+                    for call in tc {
+                        let function = call.get("function");
+                        let call_id = call.get("id").and_then(|v| v.as_str()).unwrap_or("");
                         output.push(json!({
                             "type": "function_call",
-                            "call_id": tc.get("id").and_then(|v| v.as_str()).unwrap_or(""),
+                            "id": call_id,
+                            "call_id": call_id,
                             "name": function.and_then(|f| f.get("name")).and_then(|v| v.as_str()).unwrap_or(""),
                             "arguments": function.and_then(|f| f.get("arguments").cloned()).unwrap_or(json!("{}")),
                             "status": "completed"
                         }));
+                        if !call_id.is_empty() {
+                            tc_ids.push(call_id.to_string());
+                        }
+                    }
+                    // Cache reasoning_content for next round (DeepSeek requirement)
+                    if let Some(r) = reasoning {
+                        cache_reasoning_for_tool_calls(r, &tc_ids);
                     }
                 }
             }
@@ -553,6 +620,7 @@ pub fn wrap_responses_as_sse(
                             .get("arguments")
                             .and_then(|v| v.as_str())
                             .unwrap_or("{}");
+                        let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or(&item_id);
 
                         // output_item.added for function_call
                         v.push(Ok(Bytes::from(format!(
@@ -561,9 +629,9 @@ pub fn wrap_responses_as_sse(
                                 "type": "response.output_item.added",
                                 "output_index": output_index,
                                 "item": {
-                                    "id": &item_id,
+                                    "id": call_id,
                                     "type": "function_call",
-                                    "call_id": &item_id,
+                                    "call_id": call_id,
                                     "name": name,
                                     "arguments": ""
                                 }
@@ -575,7 +643,7 @@ pub fn wrap_responses_as_sse(
                             "event: response.function_call_arguments.delta\ndata: {}\n\n",
                             json!({
                                 "type": "response.function_call_arguments.delta",
-                                "item_id": &item_id,
+                                "item_id": call_id,
                                 "output_index": output_index,
                                 "delta": arguments
                             })
@@ -586,17 +654,34 @@ pub fn wrap_responses_as_sse(
                             "event: response.function_call_arguments.done\ndata: {}\n\n",
                             json!({
                                 "type": "response.function_call_arguments.done",
-                                "item_id": &item_id,
+                                "item_id": call_id,
                                 "output_index": output_index,
                                 "arguments": arguments
                             })
                         ))));
+
+                        // output_item.done for function_call
+                        v.push(Ok(Bytes::from(format!(
+                            "event: response.output_item.done\ndata: {}\n\n",
+                            json!({
+                                "type": "response.output_item.done",
+                                "output_index": output_index,
+                                "item": {
+                                    "id": call_id,
+                                    "type": "function_call",
+                                    "call_id": call_id,
+                                    "name": name,
+                                    "arguments": arguments,
+                                    "status": "completed"
+                                }
+                            })
+                        ))));
+
                     }
                     "reasoning" => {
-                        // Support both old "summary" and new "content" format
                         let summary_text = item
-                            .get("content")
-                            .or_else(|| item.get("summary"))
+                            .get("summary")
+                            .or_else(|| item.get("content"))
                             .and_then(|v| v.as_array())
                             .and_then(|arr| {
                                 arr.first()
@@ -612,7 +697,8 @@ pub fn wrap_responses_as_sse(
                                 "item": {
                                     "id": &item_id,
                                     "type": "reasoning",
-                                    "content": [{"type": "summary_text", "text": summary_text}]
+                                    "summary": [{"type": "text", "text": summary_text}],
+                                    "status": "completed"
                                 }
                             })
                         ))));
@@ -625,7 +711,8 @@ pub fn wrap_responses_as_sse(
                                 "item": {
                                     "id": &item_id,
                                     "type": "reasoning",
-                                    "content": [{"type": "summary_text", "text": summary_text}]
+                                    "summary": [{"type": "text", "text": summary_text}],
+                                    "status": "completed"
                                 }
                             })
                         ))));
@@ -901,12 +988,11 @@ mod tests {
         let result = chat_completions_to_responses(input);
         let output = result["output"].as_array().unwrap();
 
-        // Should have 1 message item + 1 function_call item
-        assert_eq!(output.len(), 2, "should have message + function_call items");
-        assert_eq!(output[0]["type"], "message");
-        assert_eq!(output[1]["type"], "function_call");
-        assert_eq!(output[1]["call_id"], "call_abc");
-        assert_eq!(output[1]["name"], "read_file");
+        // Only function_call items (no message item when content is null)
+        assert_eq!(output.len(), 1, "should have only function_call item when content is null");
+        assert_eq!(output[0]["type"], "function_call");
+        assert_eq!(output[0]["call_id"], "call_abc");
+        assert_eq!(output[0]["name"], "read_file");
         assert_eq!(result["status"], "completed");
     }
 
@@ -947,8 +1033,40 @@ mod tests {
         assert_eq!(output.len(), 2);
         assert_eq!(output[0]["type"], "message");
         assert_eq!(output[1]["type"], "reasoning");
-        assert_eq!(output[1]["content"][0]["type"], "summary_text");
-        assert_eq!(output[1]["content"][0]["text"], "让我思考一下...");
+        assert_eq!(output[1]["summary"][0]["type"], "text");
+        assert_eq!(output[1]["summary"][0]["text"], "让我思考一下...");
+    }
+
+    #[test]
+    fn test_chat_to_responses_text_plus_tool_calls() {
+        // Model says something before calling a tool
+        let input = json!({
+            "id": "chatcmpl-789",
+            "model": "deepseek-chat",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Let me search for that.",
+                    "tool_calls": [{
+                        "id": "call_x1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{\"q\":\"test\"}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let result = chat_completions_to_responses(input);
+        let output = result["output"].as_array().unwrap();
+
+        // message item (text) + function_call item
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0]["type"], "message");
+        assert_eq!(output[0]["content"][0]["text"], "Let me search for that.");
+        assert_eq!(output[1]["type"], "function_call");
+        assert_eq!(output[1]["name"], "search");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex.rs
+++ b/src-tauri/src/proxy/providers/transform_codex.rs
@@ -222,47 +222,67 @@ fn convert_input_to_messages(input: &[Value], messages: &mut Vec<Value>) {
                 };
 
                 if let Some(content_blocks) = item.get("content").and_then(|v| v.as_array()) {
-                    let texts: Vec<&str> = content_blocks
+                    let has_images = content_blocks
                         .iter()
-                        .filter_map(|block| {
+                        .any(|b| b.get("type").and_then(|v| v.as_str()) == Some("input_image"));
+
+                    if has_images {
+                        let mut parts: Vec<Value> = Vec::new();
+                        for block in content_blocks {
                             let bt = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
                             match bt {
                                 "input_text" | "output_text" => {
-                                    block.get("text").and_then(|v| v.as_str())
+                                    if let Some(t) = block.get("text").and_then(|v| v.as_str()) {
+                                        parts.push(json!({"type": "text", "text": t}));
+                                    }
                                 }
-                                "refusal" => block.get("refusal").and_then(|v| v.as_str()),
-                                _ => None,
-                            }
-                        })
-                        .collect();
-
-                    if !texts.is_empty() {
-                        messages.push(json!({
-                            "role": resolved_role,
-                            "content": texts.join("")
-                        }));
-                    } else if content_blocks
-                        .iter()
-                        .any(|b| b.get("type").and_then(|v| v.as_str()) == Some("input_image"))
-                    {
-                        let parts: Vec<Value> = content_blocks
-                            .iter()
-                            .filter_map(|block| {
-                                if block.get("type").and_then(|v| v.as_str()) == Some("input_image")
-                                {
-                                    Some(json!({
+                                "refusal" => {
+                                    if let Some(r) =
+                                        block.get("refusal").and_then(|v| v.as_str())
+                                    {
+                                        parts.push(json!({"type": "text", "text": r}));
+                                    }
+                                }
+                                "input_image" => {
+                                    parts.push(json!({
                                         "type": "image_url",
-                                        "image_url": block.get("image_url").cloned().unwrap_or(json!({}))
-                                    }))
-                                } else {
-                                    None
+                                        "image_url": block
+                                            .get("image_url")
+                                            .cloned()
+                                            .unwrap_or(json!({}))
+                                    }));
                                 }
-                            })
-                            .collect();
+                                _ => {}
+                            }
+                        }
                         if !parts.is_empty() {
                             messages.push(json!({
                                 "role": resolved_role,
                                 "content": parts
+                            }));
+                        }
+                    } else {
+                        let texts: Vec<&str> = content_blocks
+                            .iter()
+                            .filter_map(|block| {
+                                let bt =
+                                    block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                                match bt {
+                                    "input_text" | "output_text" => {
+                                        block.get("text").and_then(|v| v.as_str())
+                                    }
+                                    "refusal" => {
+                                        block.get("refusal").and_then(|v| v.as_str())
+                                    }
+                                    _ => None,
+                                }
+                            })
+                            .collect();
+
+                        if !texts.is_empty() {
+                            messages.push(json!({
+                                "role": resolved_role,
+                                "content": texts.join("")
                             }));
                         }
                     }

--- a/src-tauri/src/proxy/providers/transform_codex.rs
+++ b/src-tauri/src/proxy/providers/transform_codex.rs
@@ -97,18 +97,13 @@ pub fn responses_to_chat_completions(body: Value) -> Value {
                 // namespace: MCP server tools — 展开内嵌的 functions
                 "namespace" => {
                     if let Some(ns_tools) = tool.get("tools").and_then(|v| v.as_array()) {
-                        let ns_prefix = tool
-                            .get("namespace")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("");
+                        let ns_prefix =
+                            tool.get("namespace").and_then(|v| v.as_str()).unwrap_or("");
                         for ns_tool in ns_tools {
-                            if ns_tool.get("type").and_then(|v| v.as_str()) == Some("function")
-                            {
+                            if ns_tool.get("type").and_then(|v| v.as_str()) == Some("function") {
                                 let mut function_obj = json!({});
-                                let orig_name = ns_tool
-                                    .get("name")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("");
+                                let orig_name =
+                                    ns_tool.get("name").and_then(|v| v.as_str()).unwrap_or("");
                                 // Prepend namespace: "filesystem/read_file"
                                 let qualified_name = if ns_prefix.is_empty() {
                                     orig_name.to_string()
@@ -240,9 +235,10 @@ fn convert_input_to_messages(input: &[Value], messages: &mut Vec<Value>) {
                             "role": resolved_role,
                             "content": texts.join("")
                         }));
-                    } else if content_blocks.iter().any(|b| {
-                        b.get("type").and_then(|v| v.as_str()) == Some("input_image")
-                    }) {
+                    } else if content_blocks
+                        .iter()
+                        .any(|b| b.get("type").and_then(|v| v.as_str()) == Some("input_image"))
+                    {
                         let parts: Vec<Value> = content_blocks
                             .iter()
                             .filter_map(|block| {
@@ -412,7 +408,11 @@ pub fn chat_completions_to_responses(body: Value) -> Value {
         // 对于 DeepSeek，prompt_cache_hit_tokens 也可能存在
         let cache_hit = usage
             .get("prompt_cache_hit_tokens")
-            .or_else(|| usage.get("prompt_tokens_details").and_then(|d| d.get("cached_tokens")))
+            .or_else(|| {
+                usage
+                    .get("prompt_tokens_details")
+                    .and_then(|d| d.get("cached_tokens"))
+            })
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
         let input_tokens = prompt_tokens.as_u64().unwrap_or(0) + cache_hit;
@@ -612,15 +612,15 @@ pub fn wrap_responses_as_sse(
                         ))));
                     }
                     "function_call" => {
-                        let name = item
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("");
+                        let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
                         let arguments = item
                             .get("arguments")
                             .and_then(|v| v.as_str())
                             .unwrap_or("{}");
-                        let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or(&item_id);
+                        let call_id = item
+                            .get("call_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(&item_id);
 
                         // output_item.added for function_call
                         v.push(Ok(Bytes::from(format!(
@@ -676,7 +676,6 @@ pub fn wrap_responses_as_sse(
                                 }
                             })
                         ))));
-
                     }
                     "reasoning" => {
                         let summary_text = item
@@ -800,10 +799,7 @@ mod tests {
         assert_eq!(result["id"], "chatcmpl-123");
         assert_eq!(result["object"], "response");
         assert_eq!(result["output"][0]["type"], "message");
-        assert_eq!(
-            result["output"][0]["content"][0]["text"],
-            "Hi there!"
-        );
+        assert_eq!(result["output"][0]["content"][0]["text"], "Hi there!");
         assert_eq!(result["usage"]["input_tokens"], 5);
         assert_eq!(result["usage"]["output_tokens"], 3);
     }
@@ -910,9 +906,9 @@ mod tests {
         });
 
         let stream = wrap_responses_as_sse(body);
-        let chunks: Vec<Bytes> = futures::executor::block_on(
-            futures::StreamExt::collect::<Vec<Result<Bytes, std::io::Error>>>(stream)
-        )
+        let chunks: Vec<Bytes> = futures::executor::block_on(futures::StreamExt::collect::<
+            Vec<Result<Bytes, std::io::Error>>,
+        >(stream))
         .into_iter()
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
@@ -989,7 +985,11 @@ mod tests {
         let output = result["output"].as_array().unwrap();
 
         // Only function_call items (no message item when content is null)
-        assert_eq!(output.len(), 1, "should have only function_call item when content is null");
+        assert_eq!(
+            output.len(),
+            1,
+            "should have only function_call item when content is null"
+        );
         assert_eq!(output[0]["type"], "function_call");
         assert_eq!(output[0]["call_id"], "call_abc");
         assert_eq!(output[0]["name"], "read_file");

--- a/src-tauri/src/proxy/providers/transform_codex.rs
+++ b/src-tauri/src/proxy/providers/transform_codex.rs
@@ -14,24 +14,30 @@ use std::sync::{LazyLock, Mutex};
 static REASONING_CACHE: LazyLock<Mutex<HashMap<String, String>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// REASONING_CACHE 中允许的最大条目数，防止未消费 ID 失控。
+const REASONING_CACHE_MAX_ENTRIES: usize = 100;
+
 /// 缓存 reasoning_content，按 tool_call IDs
 pub fn cache_reasoning_for_tool_calls(reasoning: &str, tool_call_ids: &[String]) {
     if reasoning.is_empty() || tool_call_ids.is_empty() {
         return;
     }
     if let Ok(mut cache) = REASONING_CACHE.lock() {
+        if cache.len() + tool_call_ids.len() > REASONING_CACHE_MAX_ENTRIES {
+            cache.clear();
+        }
         for id in tool_call_ids {
             cache.insert(id.clone(), reasoning.to_string());
         }
     }
 }
 
-/// 按 tool_call ID 查找缓存的 reasoning_content
-fn get_cached_reasoning(tool_call_id: &str) -> Option<String> {
+/// 按 tool_call ID 查找并移除缓存的 reasoning_content（消费即删除，防止内存泄漏）
+fn remove_cached_reasoning(tool_call_id: &str) -> Option<String> {
     REASONING_CACHE
         .lock()
         .ok()
-        .and_then(|cache| cache.get(tool_call_id).cloned())
+        .and_then(|mut cache| cache.remove(tool_call_id))
 }
 
 /// OpenAI Responses API 请求 → OpenAI Chat Completions 请求
@@ -291,14 +297,15 @@ fn inject_reasoning_into_message(msg: &mut Value) {
     // 检查任意 tool_call 是否有缓存
     for tc in tool_calls {
         if let Some(call_id) = tc.get("id").and_then(|v| v.as_str()) {
-            if let Some(reasoning) = get_cached_reasoning(call_id) {
+            if let Some(reasoning) = remove_cached_reasoning(call_id) {
                 msg["reasoning_content"] = json!(reasoning);
                 return;
             }
         }
     }
-    // 兜底：即使缓存为空，DeepSeek 也要求字段存在
-    // 设置空字符串以确保 JSON 序列化时输出 "reasoning_content": ""
+    // 兜底：即使缓存为空，DeepSeek 推理 API 也要求 assistant tool_calls 消息中存在
+    // reasoning_content 字段。非推理模型不会触发此路径（它们不产生 reasoning_content
+    // 也不会被 cache_reasoning_for_tool_calls 缓存），故此兜底安全。
     msg["reasoning_content"] = json!("");
 }
 
@@ -1084,5 +1091,67 @@ mod tests {
         let result = chat_completions_to_responses(input);
         assert_eq!(result["id"], "chatcmpl-session-123");
         assert_eq!(result["object"], "response");
+    }
+
+    #[test]
+    fn test_reasoning_cache_round_trip() {
+        // Step 1: Simulate DeepSeek response with reasoning_content + tool_calls
+        let deepseek_resp = json!({
+            "id": "chatcmpl-r1",
+            "model": "deepseek-reasoner",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Thinking...",
+                    "reasoning_content": "I need to calculate...",
+                    "tool_calls": [{
+                        "id": "call_u1",
+                        "type": "function",
+                        "function": {"name": "calc", "arguments": "{\"x\":1}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15}
+        });
+        let _result = chat_completions_to_responses(deepseek_resp);
+        // Cache should now contain call_u1 -> "I need to calculate..."
+
+        // Step 2: Convert next request — should inject cached reasoning
+        let next_req = json!({
+            "model": "deepseek-reasoner",
+            "input": [
+                {"type": "function_call", "call_id": "call_u1",
+                 "name": "calc", "arguments": "{\"x\":1}"},
+                {"type": "function_call_output", "call_id": "call_u1",
+                 "output": "42"}
+            ]
+        });
+        let result = responses_to_chat_completions(next_req);
+        let msgs = result["messages"].as_array().unwrap();
+        assert_eq!(msgs[0]["role"], "assistant");
+        assert_eq!(
+            msgs[0]["reasoning_content"], "I need to calculate...",
+            "first request should inject cached reasoning_content"
+        );
+
+        // Step 3: Same call_id again — should NOT have reasoning_content (consumed)
+        let third_req = json!({
+            "model": "deepseek-reasoner",
+            "input": [
+                {"type": "function_call", "call_id": "call_u1",
+                 "name": "calc", "arguments": "{\"x\":1}"},
+                {"type": "function_call_output", "call_id": "call_u1",
+                 "output": "100"}
+            ]
+        });
+        let result2 = responses_to_chat_completions(third_req);
+        let msgs2 = result2["messages"].as_array().unwrap();
+        assert_eq!(msgs2[0]["role"], "assistant");
+        assert_eq!(
+            msgs2[0]["reasoning_content"], "",
+            "after consumption, reasoning_content should be empty string (DeepSeek requires field)"
+        );
     }
 }

--- a/src-tauri/src/proxy/req_logger.rs
+++ b/src-tauri/src/proxy/req_logger.rs
@@ -17,10 +17,11 @@ fn append_line(line: &str) {
     }
 }
 
-/// 美化 JSON 并截断，返回带缩进的多行字符串
+/// 美化 JSON 并截断长文本值，保持 JSON 结构完整
 fn indented_field(label: &str, raw: &str) -> String {
     let content = if let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) {
-        serde_json::to_string_pretty(&v).unwrap_or_else(|_| raw.to_string())
+        let trimmed = trim_json_values(v);
+        serde_json::to_string_pretty(&trimmed).unwrap_or_else(|_| raw.to_string())
     } else {
         raw.to_string()
     };
@@ -28,6 +29,7 @@ fn indented_field(label: &str, raw: &str) -> String {
     let content = if content.len() <= MAX_LEN {
         content
     } else {
+        // Fallback: hard truncation only if still too large after trim
         format!("{}...(truncated)", &content[..MAX_LEN])
     };
     let lines: Vec<&str> = content.lines().collect();
@@ -39,6 +41,45 @@ fn indented_field(label: &str, raw: &str) -> String {
             s.push_str(&format!("    {line}\n"));
         }
         s
+    }
+}
+
+/// 递归裁剪 JSON 中的长文本值，保持结构完整
+fn trim_json_values(v: serde_json::Value) -> serde_json::Value {
+    const MAX_VAL_LEN: usize = 500;
+    const MAX_ARRAY_ITEMS: usize = 20;
+    match v {
+        serde_json::Value::String(s) => {
+            if s.len() > MAX_VAL_LEN {
+                let head: String = s.chars().take(MAX_VAL_LEN).collect();
+                serde_json::Value::String(format!("{head}...(truncated)"))
+            } else {
+                serde_json::Value::String(s)
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            let total = arr.len();
+            if total > MAX_ARRAY_ITEMS {
+                let mut trimmed: Vec<serde_json::Value> = arr
+                    .into_iter()
+                    .take(MAX_ARRAY_ITEMS)
+                    .map(trim_json_values)
+                    .collect();
+                trimmed.push(serde_json::Value::String(format!(
+                    "...({} more items)",
+                    total - MAX_ARRAY_ITEMS
+                )));
+                serde_json::Value::Array(trimmed)
+            } else {
+                serde_json::Value::Array(arr.into_iter().map(trim_json_values).collect())
+            }
+        }
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.into_iter()
+                .map(|(k, val)| (k, trim_json_values(val)))
+                .collect(),
+        ),
+        other => other,
     }
 }
 

--- a/src-tauri/src/proxy/req_logger.rs
+++ b/src-tauri/src/proxy/req_logger.rs
@@ -7,6 +7,9 @@ use std::io::Write;
 
 /// 追加一行到 req.log，忽略写入失败
 fn append_line(line: &str) {
+    if !crate::settings::get_settings().enable_log_req {
+        return;
+    }
     let path = crate::config::get_app_config_dir().join("req.log");
     if let Ok(mut file) = std::fs::OpenOptions::new()
         .create(true)

--- a/src-tauri/src/proxy/req_logger.rs
+++ b/src-tauri/src/proxy/req_logger.rs
@@ -70,7 +70,12 @@ fn sanitize_headers(headers: &str) -> String {
         let lower = line.to_lowercase();
         if lower.contains("authorization")
             || lower.contains("api-key")
-            || lower.contains("x-api-key")
+            || lower.contains("proxy-authorization")
+            || lower.contains("chatgpt-account-id")
+            || lower.contains("cookie")
+            || lower.contains("x-forwarded-for")
+            || lower.contains("x-real-ip")
+            || lower.contains("csrf-token")
         {
             if let Some(colon) = line.find(':') {
                 result.push_str(&line[..=colon]);

--- a/src-tauri/src/proxy/req_logger.rs
+++ b/src-tauri/src/proxy/req_logger.rs
@@ -1,0 +1,94 @@
+//! 请求/响应日志模块
+//!
+//! 默认写入 `~/.cc-switch/req.log`，无需开启 debug 级别。
+//! 每条事件 2 行：时间 + 方向 + 摘要，header/body 详情。
+
+use std::io::Write;
+
+/// 追加一行到 req.log，忽略写入失败
+fn append_line(line: &str) {
+    let path = crate::config::get_app_config_dir().join("req.log");
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = writeln!(file, "{line}");
+    }
+}
+
+/// 截断过长的 body（8KB）
+fn truncate_body(body: &str) -> &str {
+    const MAX_LEN: usize = 8192;
+    if body.len() <= MAX_LEN {
+        body
+    } else {
+        &body[..MAX_LEN]
+    }
+}
+
+/// 脱敏 headers：authorization / api-key 类替换为 `***`
+fn sanitize_headers(headers: &str) -> String {
+    let mut result = String::with_capacity(headers.len());
+    let mut remaining = headers;
+    while let Some(line_end) = remaining.find('\n') {
+        let line = &remaining[..line_end];
+        remaining = &remaining[line_end + 1..];
+        let lower = line.to_lowercase();
+        if lower.contains("authorization")
+            || lower.contains("api-key")
+            || lower.contains("x-api-key")
+        {
+            if let Some(colon) = line.find(':') {
+                result.push_str(&line[..=colon]);
+                result.push_str(" ***");
+            } else {
+                result.push_str(line);
+            }
+        } else {
+            result.push_str(line);
+        }
+        result.push('\n');
+    }
+    if result.ends_with('\n') {
+        result.pop();
+    }
+    result
+}
+
+/// ① Codex CLI → cc-switch 入口请求
+pub fn log_incoming(tag: &str, method: &str, uri: &str, headers: &str, body: &str) {
+    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+    let body = truncate_body(body);
+    let headers = sanitize_headers(headers);
+    append_line(&format!("{ts} [{tag}] ← INCOMING {method} {uri}"));
+    append_line(&format!("  headers: {headers} | body: {body}"));
+}
+
+/// ④ cc-switch → 上游提供商请求
+pub fn log_upstream_req(tag: &str, method: &str, url: &str, body: &str) {
+    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+    let body = truncate_body(body);
+    append_line(&format!("{ts} [{tag}] → UPSTREAM {method} {url}"));
+    append_line(&format!("  body: {body}"));
+}
+
+/// ⑤ 上游 → cc-switch 响应
+pub fn log_upstream_resp(tag: &str, status: u16, body: &str) {
+    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+    let body = truncate_body(body);
+    append_line(&format!("{ts} [{tag}] ← UPSTREAM RESPONSE {status}"));
+    append_line(&format!("  body: {body}"));
+}
+
+/// ⑥ cc-switch → Codex CLI 最终返回
+pub fn log_return(tag: &str, status: u16, extra: &str, body: &str) {
+    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+    let body = truncate_body(body);
+    if extra.is_empty() {
+        append_line(&format!("{ts} [{tag}] → RETURN {status}"));
+    } else {
+        append_line(&format!("{ts} [{tag}] → RETURN {status} ({extra})"));
+    }
+    append_line(&format!("  body: {body}"));
+}

--- a/src-tauri/src/proxy/req_logger.rs
+++ b/src-tauri/src/proxy/req_logger.rs
@@ -17,13 +17,28 @@ fn append_line(line: &str) {
     }
 }
 
-/// 截断过长的 body（8KB）
-fn truncate_body(body: &str) -> &str {
-    const MAX_LEN: usize = 8192;
-    if body.len() <= MAX_LEN {
-        body
+/// 美化 JSON 并截断，返回带缩进的多行字符串
+fn indented_field(label: &str, raw: &str) -> String {
+    let content = if let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) {
+        serde_json::to_string_pretty(&v).unwrap_or_else(|_| raw.to_string())
     } else {
-        &body[..MAX_LEN]
+        raw.to_string()
+    };
+    const MAX_LEN: usize = 8192;
+    let content = if content.len() <= MAX_LEN {
+        content
+    } else {
+        format!("{}...(truncated)", &content[..MAX_LEN])
+    };
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.len() == 1 {
+        format!("  {label}: {}", lines[0])
+    } else {
+        let mut s = format!("  {label}:\n");
+        for line in &lines {
+            s.push_str(&format!("    {line}\n"));
+        }
+        s
     }
 }
 
@@ -59,36 +74,33 @@ fn sanitize_headers(headers: &str) -> String {
 /// ① Codex CLI → cc-switch 入口请求
 pub fn log_incoming(tag: &str, method: &str, uri: &str, headers: &str, body: &str) {
     let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
-    let body = truncate_body(body);
     let headers = sanitize_headers(headers);
     append_line(&format!("{ts} [{tag}] ← INCOMING {method} {uri}"));
-    append_line(&format!("  headers: {headers} | body: {body}"));
+    append_line(&indented_field("headers", &headers));
+    append_line(&indented_field("body", body));
 }
 
 /// ④ cc-switch → 上游提供商请求
 pub fn log_upstream_req(tag: &str, method: &str, url: &str, body: &str) {
     let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
-    let body = truncate_body(body);
     append_line(&format!("{ts} [{tag}] → UPSTREAM {method} {url}"));
-    append_line(&format!("  body: {body}"));
+    append_line(&indented_field("body", body));
 }
 
 /// ⑤ 上游 → cc-switch 响应
 pub fn log_upstream_resp(tag: &str, status: u16, body: &str) {
     let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
-    let body = truncate_body(body);
     append_line(&format!("{ts} [{tag}] ← UPSTREAM RESPONSE {status}"));
-    append_line(&format!("  body: {body}"));
+    append_line(&indented_field("body", body));
 }
 
 /// ⑥ cc-switch → Codex CLI 最终返回
 pub fn log_return(tag: &str, status: u16, extra: &str, body: &str) {
     let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
-    let body = truncate_body(body);
     if extra.is_empty() {
         append_line(&format!("{ts} [{tag}] → RETURN {status}"));
     } else {
         append_line(&format!("{ts} [{tag}] → RETURN {status} ({extra})"));
     }
-    append_line(&format!("  body: {body}"));
+    append_line(&indented_field("body", body));
 }

--- a/src-tauri/src/proxy/req_logger.rs
+++ b/src-tauri/src/proxy/req_logger.rs
@@ -17,20 +17,13 @@ fn append_line(line: &str) {
     }
 }
 
-/// 美化 JSON 并截断长文本值，保持 JSON 结构完整
+/// 美化 JSON 输出为带缩进的多行字符串，仅截断长文本值
 fn indented_field(label: &str, raw: &str) -> String {
     let content = if let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) {
-        let trimmed = trim_json_values(v);
+        let trimmed = trim_long_strings(v);
         serde_json::to_string_pretty(&trimmed).unwrap_or_else(|_| raw.to_string())
     } else {
         raw.to_string()
-    };
-    const MAX_LEN: usize = 8192;
-    let content = if content.len() <= MAX_LEN {
-        content
-    } else {
-        // Fallback: hard truncation only if still too large after trim
-        format!("{}...(truncated)", &content[..MAX_LEN])
     };
     let lines: Vec<&str> = content.lines().collect();
     if lines.len() == 1 {
@@ -44,39 +37,20 @@ fn indented_field(label: &str, raw: &str) -> String {
     }
 }
 
-/// 递归裁剪 JSON 中的长文本值，保持结构完整
-fn trim_json_values(v: serde_json::Value) -> serde_json::Value {
+/// 递归裁剪 JSON 中的长字符串 value，保持结构和 key 完整
+fn trim_long_strings(v: serde_json::Value) -> serde_json::Value {
     const MAX_VAL_LEN: usize = 500;
-    const MAX_ARRAY_ITEMS: usize = 20;
     match v {
-        serde_json::Value::String(s) => {
-            if s.len() > MAX_VAL_LEN {
-                let head: String = s.chars().take(MAX_VAL_LEN).collect();
-                serde_json::Value::String(format!("{head}...(truncated)"))
-            } else {
-                serde_json::Value::String(s)
-            }
+        serde_json::Value::String(s) if s.len() > MAX_VAL_LEN => {
+            let head: String = s.chars().take(MAX_VAL_LEN).collect();
+            serde_json::Value::String(format!("{head}...(truncated)"))
         }
         serde_json::Value::Array(arr) => {
-            let total = arr.len();
-            if total > MAX_ARRAY_ITEMS {
-                let mut trimmed: Vec<serde_json::Value> = arr
-                    .into_iter()
-                    .take(MAX_ARRAY_ITEMS)
-                    .map(trim_json_values)
-                    .collect();
-                trimmed.push(serde_json::Value::String(format!(
-                    "...({} more items)",
-                    total - MAX_ARRAY_ITEMS
-                )));
-                serde_json::Value::Array(trimmed)
-            } else {
-                serde_json::Value::Array(arr.into_iter().map(trim_json_values).collect())
-            }
+            serde_json::Value::Array(arr.into_iter().map(trim_long_strings).collect())
         }
         serde_json::Value::Object(map) => serde_json::Value::Object(
             map.into_iter()
-                .map(|(k, val)| (k, trim_json_values(val)))
+                .map(|(k, val)| (k, trim_long_strings(val)))
                 .collect(),
         ),
         other => other,

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -7,6 +7,7 @@ use super::{
     handler_config::{StreamUsageEventFilter, UsageParserConfig},
     handler_context::{RequestContext, StreamingTimeoutConfig},
     hyper_client::ProxyResponse,
+    req_logger,
     server::ProxyState,
     sse::{strip_sse_field, take_sse_block},
     usage::parser::TokenUsage,
@@ -224,6 +225,7 @@ pub async fn handle_streaming(
     let logged_stream = create_logged_passthrough_stream(
         stream,
         ctx.tag,
+        status.as_u16(),
         usage_collector,
         timeout_config,
         connection_guard,
@@ -259,10 +261,10 @@ pub async fn handle_non_streaming(
         read_decoded_body(response, ctx.tag, body_timeout).await?;
     strip_hop_by_hop_response_headers(&mut response_headers);
 
-    log::debug!(
-        "[{}] 上游响应体内容: {}",
+    req_logger::log_upstream_resp(
         ctx.tag,
-        String::from_utf8_lossy(&body_bytes)
+        status.as_u16(),
+        &String::from_utf8_lossy(&body_bytes),
     );
 
     // 解析并记录使用量。关闭 usage logging 时直接跳过，避免非流式响应整包 JSON parse。
@@ -678,6 +680,7 @@ async fn log_usage_internal(
 pub fn create_logged_passthrough_stream(
     stream: impl Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
     tag: &'static str,
+    status: u16,
     usage_collector: Option<SseUsageCollector>,
     timeout_config: StreamingTimeoutConfig,
     connection_guard: Option<ActiveConnectionGuard>,
@@ -691,6 +694,8 @@ pub fn create_logged_passthrough_stream(
         let inspect_sse_events =
             collector.is_some() || log::log_enabled!(log::Level::Debug);
         let mut is_first_chunk = true;
+        // 收集所有 SSE data 事件，流结束后拼合为完整响应体打印
+        let mut stream_body_parts: Vec<String> = Vec::new();
 
         // 超时配置
         let first_byte_timeout = if timeout_config.first_byte_timeout > 0 {
@@ -750,23 +755,18 @@ pub fn create_logged_passthrough_stream(
                                 for line in event_text.lines() {
                                     if let Some(data) = strip_sse_field(line, "data") {
                                         if data.trim() != "[DONE]" {
-                                            let collected = match &collector {
-                                                Some(c) if c.should_collect(data) => {
-                                                    match serde_json::from_str::<Value>(data) {
-                                                        Ok(json_value) => {
-                                                            c.push(json_value).await;
-                                                            true
-                                                        }
-                                                        Err(_) => false,
+                                            // 收集 data 用于流结束后还原完整响应体
+                                            stream_body_parts.push(data.to_string());
+                                            if let Some(c) = &collector {
+                                                if c.should_collect(data) {
+                                                    if let Ok(json_value) =
+                                                        serde_json::from_str::<Value>(data)
+                                                    {
+                                                        c.push(json_value).await;
                                                     }
                                                 }
-                                                _ => false,
-                                            };
-                                            if collected {
-                                                log::debug!("[{tag}] <<< SSE 事件: {data}");
-                                            } else {
-                                                log::debug!("[{tag}] <<< SSE 数据: {data}");
                                             }
+                                            log::debug!("[{tag}] <<< SSE: {data}");
                                         } else {
                                             log::debug!("[{tag}] <<< SSE: [DONE]");
                                         }
@@ -795,6 +795,11 @@ pub fn create_logged_passthrough_stream(
         }
         if let Some(guard) = &mut finish_guard {
             guard.disarm();
+        }
+        // 流结束后，拼合所有 SSE data 事件为完整响应体并打印
+        let reconstructed: String = stream_body_parts.join("");
+        if !reconstructed.is_empty() {
+            req_logger::log_upstream_resp(tag, status, &reconstructed);
         }
     }
 }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -294,6 +294,11 @@ impl ProxyServer {
                 "/claude-desktop/v1/messages",
                 post(handlers::handle_claude_desktop_messages),
             )
+            // OpenAI Models API (Codex CLI 模型列表)
+            .route("/models", get(handlers::handle_codex_models))
+            .route("/v1/models", get(handlers::handle_codex_models))
+            .route("/v1/v1/models", get(handlers::handle_codex_models))
+            .route("/codex/v1/models", get(handlers::handle_codex_models))
             // OpenAI Chat Completions API (Codex CLI，支持带前缀和不带前缀)
             .route("/chat/completions", post(handlers::handle_chat_completions))
             .route(

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -159,7 +159,15 @@ impl ConfigService {
         }
         let cfg_text = settings.get("config").and_then(Value::as_str);
 
-        crate::codex_config::write_codex_live_atomic_with_stable_provider(auth, cfg_text)?;
+        let catalog_models = provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.codex_models.as_deref());
+        crate::codex_config::write_codex_live_atomic_with_stable_provider(
+            auth,
+            cfg_text,
+            catalog_models,
+        )?;
         // 注意：MCP 同步在 v3.7.0 中已通过 McpService 进行，不再在此调用
         // sync_enabled_to_codex 使用旧的 config.mcp.codex 结构，在新架构中为空
         // MCP 的启用/禁用应通过 McpService::toggle_app 进行

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -163,10 +163,15 @@ impl ConfigService {
             .meta
             .as_ref()
             .and_then(|m| m.codex_models.as_deref());
+        let catalog_json = provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.codex_models_catalog.as_deref());
         crate::codex_config::write_codex_live_atomic_with_stable_provider(
             auth,
             cfg_text,
             catalog_models,
+            catalog_json,
         )?;
         // 注意：MCP 同步在 v3.7.0 中已通过 McpService 进行，不再在此调用
         // sync_enabled_to_codex 使用旧的 config.mcp.codex 结构，在新架构中为空

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -740,7 +740,12 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
                 .meta
                 .as_ref()
                 .and_then(|m| m.codex_models_catalog.as_deref());
-            write_codex_live_atomic_with_stable_provider(auth, Some(config_str), catalog_models, catalog_json)?;
+            write_codex_live_atomic_with_stable_provider(
+                auth,
+                Some(config_str),
+                catalog_models,
+                catalog_json,
+            )?;
         }
         AppType::Gemini => {
             // Delegate to write_gemini_live which handles env file writing correctly

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -736,7 +736,11 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
                 .meta
                 .as_ref()
                 .and_then(|m| m.codex_models.as_deref());
-            write_codex_live_atomic_with_stable_provider(auth, Some(config_str), catalog_models)?;
+            let catalog_json = provider
+                .meta
+                .as_ref()
+                .and_then(|m| m.codex_models_catalog.as_deref());
+            write_codex_live_atomic_with_stable_provider(auth, Some(config_str), catalog_models, catalog_json)?;
         }
         AppType::Gemini => {
             // Delegate to write_gemini_live which handles env file writing correctly

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -732,7 +732,11 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
                 AppError::Config("Codex 供应商配置缺少 'config' 字段或不是字符串".to_string())
             })?;
 
-            write_codex_live_atomic_with_stable_provider(auth, Some(config_str))?;
+            let catalog_models = provider
+                .meta
+                .as_ref()
+                .and_then(|m| m.codex_models.as_deref());
+            write_codex_live_atomic_with_stable_provider(auth, Some(config_str), catalog_models)?;
         }
         AppType::Gemini => {
             // Delegate to write_gemini_live which handles env file writing correctly

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1259,6 +1259,14 @@ impl ProviderService {
                     )
                     .map_err(|e| AppError::Message(format!("同步 Claude Live 配置失败: {e}")))?;
                 }
+                if matches!(app_type, AppType::Codex) {
+                    futures::executor::block_on(
+                        state
+                            .proxy_service
+                            .takeover_live_config_best_effort(&AppType::Codex),
+                    )
+                    .map_err(|e| AppError::Message(format!("同步 Codex Live 配置失败: {e}")))?;
+                }
             } else {
                 write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
                 // Sync MCP

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1830,7 +1830,7 @@ impl ProxyService {
         // Proxy restore writes saved live backups verbatim. Provider-driven writes go
         // through write_live_with_common_config(), which normalizes Codex provider ids.
         match (auth, config_str) {
-            (Some(auth), Some(cfg)) => write_codex_live_atomic(auth, Some(cfg), None)
+            (Some(auth), Some(cfg)) => write_codex_live_atomic(auth, Some(cfg), None, None)
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?,
             (Some(auth), None) => {
                 let auth_path = get_codex_auth_path();

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1101,7 +1101,7 @@ impl ProxyService {
     }
 
     /// 接管指定应用的 Live 配置（尽力而为：配置不存在/读取失败则跳过）
-    async fn takeover_live_config_best_effort(&self, app_type: &AppType) -> Result<(), String> {
+    pub async fn takeover_live_config_best_effort(&self, app_type: &AppType) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
 
         match app_type {
@@ -1830,7 +1830,7 @@ impl ProxyService {
         // Proxy restore writes saved live backups verbatim. Provider-driven writes go
         // through write_live_with_common_config(), which normalizes Codex provider ids.
         match (auth, config_str) {
-            (Some(auth), Some(cfg)) => write_codex_live_atomic(auth, Some(cfg))
+            (Some(auth), Some(cfg)) => write_codex_live_atomic(auth, Some(cfg), None)
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?,
             (Some(auth), None) => {
                 let auth_path = get_codex_auth_path();

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -301,6 +301,11 @@ pub struct AppSettings {
     /// - Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preferred_terminal: Option<String>,
+
+    // ===== 请求日志 =====
+    /// 是否启用 req.log 请求/响应日志（默认关闭）
+    #[serde(default)]
+    pub enable_log_req: bool,
 }
 
 fn default_show_in_tray() -> bool {
@@ -351,6 +356,7 @@ impl Default for AppSettings {
             backup_interval_hours: None,
             backup_retain_count: None,
             preferred_terminal: None,
+            enable_log_req: false,
         }
     }
 }

--- a/src-tauri/tests/import_export_sync.rs
+++ b/src-tauri/tests/import_export_sync.rs
@@ -3,8 +3,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use cc_switch_lib::{
-    get_claude_settings_path, read_json_file, AppError, AppType, ConfigService, MultiAppConfig,
-    Provider, ProviderMeta,
+    get_claude_settings_path, get_codex_models_catalog_path, read_json_file, AppError, AppType,
+    ConfigService, MultiAppConfig, Provider, ProviderMeta,
 };
 
 #[path = "support.rs"]
@@ -154,7 +154,7 @@ base_url = "https://rightcode.example/v1"
 wire_api = "responses"
 requires_openai_auth = true
 "#;
-    cc_switch_lib::write_codex_live_atomic(&legacy_auth, Some(legacy_config))
+    cc_switch_lib::write_codex_live_atomic(&legacy_auth, Some(legacy_config), None, None)
         .expect("seed existing Codex live config");
 
     let mut config = MultiAppConfig::default();
@@ -478,7 +478,7 @@ command = "echo"
 args = ["ok"]
 "#;
 
-    cc_switch_lib::write_codex_live_atomic(&auth, Some(config_text))
+    cc_switch_lib::write_codex_live_atomic(&auth, Some(config_text), None, None)
         .expect("atomic write should succeed");
 
     let auth_path = cc_switch_lib::get_codex_auth_path();
@@ -517,7 +517,7 @@ type = "stdio"
 command = "noop"
 "#;
 
-    let err = cc_switch_lib::write_codex_live_atomic(&auth, Some(config_text))
+    let err = cc_switch_lib::write_codex_live_atomic(&auth, Some(config_text), None, None)
         .expect_err("config write should fail when target is directory");
     match err {
         cc_switch_lib::AppError::Io { path, .. } => {
@@ -545,6 +545,192 @@ command = "noop"
             .expect("config path metadata")
             .is_dir(),
         "config path should remain a directory after failure"
+    );
+}
+
+#[test]
+fn write_codex_models_catalog_includes_all_models_from_catalog_models() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+
+    let auth = json!({"OPENAI_API_KEY": "test-key"});
+    let config = r#"model = "gpt-5"
+base_url = "https://example.com/v1"
+"#;
+    let models: Vec<String> = vec!["gpt-5".to_string(), "gpt-5-mini".to_string()];
+
+    cc_switch_lib::write_codex_live_atomic(&auth, Some(config), Some(&models), None)
+        .expect("atomic write should succeed");
+
+    let catalog_path = get_codex_models_catalog_path();
+    assert!(
+        catalog_path.exists(),
+        "models_catalog.json should be created at {}",
+        catalog_path.display()
+    );
+
+    let catalog_text = fs::read_to_string(&catalog_path).expect("read models_catalog.json");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&catalog_text).expect("parse models_catalog.json");
+
+    let entries = catalog["models"]
+        .as_array()
+        .expect("models should be an array");
+    assert_eq!(
+        entries.len(),
+        2,
+        "models_catalog.json should contain 2 model entries, got {}: {catalog_text}",
+        entries.len()
+    );
+
+    let slugs: Vec<&str> = entries
+        .iter()
+        .filter_map(|e| e["slug"].as_str())
+        .collect();
+    assert!(slugs.contains(&"gpt-5"), "should contain gpt-5");
+    assert!(slugs.contains(&"gpt-5-mini"), "should contain gpt-5-mini");
+}
+
+#[test]
+fn write_codex_models_catalog_raw_json_writes_exact_content() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+
+    let auth = json!({"OPENAI_API_KEY": "test-key"});
+    let config = r#"model = "gpt-5"
+"#;
+    let catalog_json = r#"{"models":[{"slug":"gpt-5","display_name":"GPT-5","shell_type":"unified_exec","visibility":"list","supported_in_api":true,"priority":0,"additional_speed_tiers":[],"default_reasoning_level":"high","supported_reasoning_levels":[{"effort":"high","description":"深度推理"}],"base_instructions":"You are a helpful coding assistant.","supports_reasoning_summaries":false,"default_reasoning_summary":"none","support_verbosity":false,"apply_patch_tool_type":"freeform","web_search_tool_type":"text","truncation_policy":{"mode":"tokens","limit":10000},"supports_parallel_tool_calls":true,"supports_image_detail_original":false,"context_window":200000,"max_context_window":200000,"effective_context_window_percent":95,"experimental_supported_tools":[],"input_modalities":["text"],"supports_search_tool":false},{"slug":"gpt-5-mini","display_name":"GPT-5 Mini","shell_type":"unified_exec","visibility":"list","supported_in_api":true,"priority":0,"additional_speed_tiers":[],"default_reasoning_level":"high","supported_reasoning_levels":[{"effort":"high","description":"深度推理"}],"base_instructions":"You are a helpful coding assistant.","supports_reasoning_summaries":false,"default_reasoning_summary":"none","support_verbosity":false,"apply_patch_tool_type":"freeform","web_search_tool_type":"text","truncation_policy":{"mode":"tokens","limit":10000},"supports_parallel_tool_calls":true,"supports_image_detail_original":false,"context_window":200000,"max_context_window":200000,"effective_context_window_percent":95,"experimental_supported_tools":[],"input_modalities":["text"],"supports_search_tool":false}]}"#;
+
+    cc_switch_lib::write_codex_live_atomic(&auth, Some(config), None, Some(catalog_json))
+        .expect("atomic write should succeed");
+
+    let catalog_path = get_codex_models_catalog_path();
+    let catalog_text = fs::read_to_string(&catalog_path).expect("read models_catalog.json");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&catalog_text).expect("parse models_catalog.json");
+
+    let entries = catalog["models"]
+        .as_array()
+        .expect("models should be an array");
+    assert_eq!(
+        entries.len(),
+        2,
+        "raw JSON catalog should contain 2 model entries"
+    );
+    assert_eq!(
+        entries[0]["display_name"].as_str(),
+        Some("GPT-5"),
+        "raw JSON should preserve custom display_name"
+    );
+}
+
+#[test]
+fn write_codex_models_catalog_no_catalog_params_preserves_existing_file() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+
+    let auth = json!({"OPENAI_API_KEY": "test-key"});
+    let config = r#"model = "gpt-5"
+base_url = "https://example.com/v1"
+"#;
+
+    // When neither catalog_json nor catalog_models is provided, no models_catalog.json
+    // should be created (don't clobber existing data from proxy takeover recovery).
+    cc_switch_lib::write_codex_live_atomic(&auth, Some(config), None, None)
+        .expect("atomic write should succeed");
+
+    let catalog_path = get_codex_models_catalog_path();
+    assert!(
+        !catalog_path.exists(),
+        "models_catalog.json should NOT be created when no catalog params are provided"
+    );
+}
+
+#[test]
+fn write_codex_live_atomic_with_stable_provider_preserves_all_catalog_models() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+
+    let auth = json!({"OPENAI_API_KEY": "test-key"});
+    // Realistic config with model_provider section — this is what most providers use
+    let config = r#"model_provider = "myprovider"
+model = "gpt-5"
+base_url = "https://example.com/v1"
+
+[model_providers.myprovider]
+name = "MyProvider"
+base_url = "https://example.com/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+    let models: Vec<String> = vec!["gpt-5".to_string(), "gpt-5-mini".to_string()];
+
+    cc_switch_lib::write_codex_live_atomic_with_stable_provider(
+        &auth,
+        Some(config),
+        Some(&models),
+        None,
+    )
+    .expect("atomic write should succeed");
+
+    let catalog_path = get_codex_models_catalog_path();
+    let catalog_text = fs::read_to_string(&catalog_path).expect("read models_catalog.json");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&catalog_text).expect("parse models_catalog.json");
+
+    let entries = catalog["models"]
+        .as_array()
+        .expect("models should be an array");
+    assert_eq!(
+        entries.len(),
+        2,
+        "stable provider wrapper should write 2 model entries, got {}: {catalog_text}",
+        entries.len()
+    );
+}
+
+#[test]
+fn write_codex_live_atomic_without_catalog_preserves_existing_models_catalog() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+
+    let auth = json!({"OPENAI_API_KEY": "test-key"});
+    let config = r#"model_provider = "myprovider"
+model = "gpt-5"
+
+[model_providers.myprovider]
+name = "MyProvider"
+base_url = "https://example.com/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+    let models: Vec<String> = vec!["gpt-5".to_string(), "gpt-5-mini".to_string()];
+
+    // Step 1: provider save writes catalog with 2 models
+    cc_switch_lib::write_codex_live_atomic(&auth, Some(config), Some(&models), None)
+        .expect("step 1: provider save");
+
+    let catalog_path = get_codex_models_catalog_path();
+    let initial_text = fs::read_to_string(&catalog_path).expect("read after step 1");
+    let initial: serde_json::Value = serde_json::from_str(&initial_text).unwrap();
+    assert_eq!(
+        initial["models"].as_array().unwrap().len(),
+        2,
+        "step 1 should write 2 models"
+    );
+
+    // Step 2: proxy takeover re-applies config WITHOUT catalog data
+    // This simulates what proxy::write_codex_live does — it calls
+    // write_codex_live_atomic(auth, Some(cfg), None, None)
+    cc_switch_lib::write_codex_live_atomic(&auth, Some(config), None, None)
+        .expect("step 2: proxy takeover");
+
+    let after_text = fs::read_to_string(&catalog_path).expect("read after step 2");
+    let after: serde_json::Value = serde_json::from_str(&after_text).unwrap();
+    let count = after["models"].as_array().unwrap().len();
+    assert_eq!(
+        count, 2,
+        "step 2 (proxy takeover) should PRESERVE existing models_catalog.json (2 models), but got {count}: {after_text}"
     );
 }
 

--- a/src-tauri/tests/import_export_sync.rs
+++ b/src-tauri/tests/import_export_sync.rs
@@ -583,10 +583,7 @@ base_url = "https://example.com/v1"
         entries.len()
     );
 
-    let slugs: Vec<&str> = entries
-        .iter()
-        .filter_map(|e| e["slug"].as_str())
-        .collect();
+    let slugs: Vec<&str> = entries.iter().filter_map(|e| e["slug"].as_str()).collect();
     assert!(slugs.contains(&"gpt-5"), "should contain gpt-5");
     assert!(slugs.contains(&"gpt-5-mini"), "should contain gpt-5-mini");
 }

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -27,7 +27,7 @@ fn codex_startup_import_fresh_install_imports_once_and_syncs_current_setting() {
     let auth = json!({"OPENAI_API_KEY": "fresh-key"});
     let config = r#"model = "gpt-5"
 "#;
-    write_codex_live_atomic(&auth, Some(config)).expect("seed codex live config");
+    write_codex_live_atomic(&auth, Some(config), None, None).expect("seed codex live config");
 
     let state = create_test_state().expect("create test state");
 
@@ -102,7 +102,7 @@ fn codex_startup_import_skips_when_only_official_seed_exists() {
     let auth = json!({"OPENAI_API_KEY": "fresh-key"});
     let config = r#"model = "gpt-5"
 "#;
-    write_codex_live_atomic(&auth, Some(config)).expect("seed codex live config");
+    write_codex_live_atomic(&auth, Some(config), None, None).expect("seed codex live config");
 
     let state = create_test_state().expect("create test state");
     state
@@ -153,7 +153,7 @@ fn switch_provider_updates_codex_live_and_state() {
 type = "stdio"
 command = "echo"
 "#;
-    write_codex_live_atomic(&legacy_auth, Some(legacy_config))
+    write_codex_live_atomic(&legacy_auth, Some(legacy_config), None, None)
         .expect("seed existing codex live config");
 
     let mut config = MultiAppConfig::default();

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -106,7 +106,7 @@ fn provider_service_switch_codex_updates_live_and_config() {
 type = "stdio"
 command = "echo"
 "#;
-    write_codex_live_atomic(&legacy_auth, Some(legacy_config))
+    write_codex_live_atomic(&legacy_auth, Some(legacy_config), None, None)
         .expect("seed existing codex live config");
 
     let mut initial_config = MultiAppConfig::default();
@@ -255,7 +255,7 @@ base_url = "https://rightcode.example/v1"
 wire_api = "responses"
 requires_openai_auth = true
 "#;
-    write_codex_live_atomic(&legacy_auth, Some(legacy_config))
+    write_codex_live_atomic(&legacy_auth, Some(legacy_config), None, None)
         .expect("seed existing codex live config");
 
     let mut initial_config = MultiAppConfig::default();
@@ -363,7 +363,7 @@ base_url = "https://rightcode.example/v1"
 wire_api = "responses"
 requires_openai_auth = true
 "#;
-    write_codex_live_atomic(&legacy_auth, Some(provider_a_config))
+    write_codex_live_atomic(&legacy_auth, Some(provider_a_config), None, None)
         .expect("seed existing codex live config");
 
     let mut initial_config = MultiAppConfig::default();

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -361,6 +361,17 @@ export function ProviderCard({
                 </span>
               )}
 
+              {appId === "codex" &&
+                provider.category !== "official" &&
+                provider.meta?.apiFormat &&
+                provider.meta.apiFormat !== "openai_responses" && (
+                  <span className="inline-flex items-center rounded-md bg-sky-100 px-1.5 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+                    {t("codex.needsRouting", {
+                      defaultValue: "需要路由",
+                    })}
+                  </span>
+              )}
+
               {isProxyRunning && isInFailoverQueue && health && (
                 <ProviderHealthBadge
                   consecutiveFailures={health.consecutive_failures}

--- a/src/components/providers/forms/CodexConfigEditor.tsx
+++ b/src/components/providers/forms/CodexConfigEditor.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
-import { CodexAuthSection, CodexConfigSection } from "./CodexConfigSections";
+import {
+  CodexAuthSection,
+  CodexConfigSection,
+  CodexModelsCatalogSection,
+} from "./CodexConfigSections";
 import { CodexCommonConfigModal } from "./CodexCommonConfigModal";
 
 interface CodexConfigEditorProps {
@@ -32,6 +36,12 @@ interface CodexConfigEditorProps {
   onExtract?: () => void;
 
   isExtracting?: boolean;
+
+  modelsCatalogValue: string;
+
+  onModelsCatalogChange: (value: string) => void;
+
+  modelsCatalogError?: string;
 }
 
 const CodexConfigEditor: React.FC<CodexConfigEditorProps> = ({
@@ -50,6 +60,9 @@ const CodexConfigEditor: React.FC<CodexConfigEditorProps> = ({
   configError,
   onExtract,
   isExtracting,
+  modelsCatalogValue,
+  onModelsCatalogChange,
+  modelsCatalogError,
 }) => {
   const [isCommonConfigModalOpen, setIsCommonConfigModalOpen] = useState(false);
 
@@ -66,6 +79,13 @@ const CodexConfigEditor: React.FC<CodexConfigEditorProps> = ({
         onChange={onAuthChange}
         onBlur={onAuthBlur}
         error={authError}
+      />
+
+      {/* Models Catalog JSON Section */}
+      <CodexModelsCatalogSection
+        value={modelsCatalogValue}
+        onChange={onModelsCatalogChange}
+        error={modelsCatalogError}
       />
 
       {/* Config TOML Section */}

--- a/src/components/providers/forms/CodexConfigSections.tsx
+++ b/src/components/providers/forms/CodexConfigSections.tsx
@@ -302,3 +302,87 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
     </div>
   );
 };
+
+interface CodexModelsCatalogSectionProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+/**
+ * CodexModelsCatalogSection - models_catalog.json editor section
+ */
+export const CodexModelsCatalogSection: React.FC<
+  CodexModelsCatalogSectionProps
+> = ({ value, onChange, error }) => {
+  const { t } = useTranslation();
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    setIsDarkMode(document.documentElement.classList.contains("dark"));
+
+    const observer = new MutationObserver(() => {
+      setIsDarkMode(document.documentElement.classList.contains("dark"));
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  const [localValue, setLocalValue] = useState(value);
+  const localValueRef = useRef(value);
+  useEffect(() => {
+    setLocalValue(value);
+    localValueRef.current = value;
+  }, [value]);
+
+  const handleLocalChange = useCallback(
+    (newValue: string) => {
+      if (newValue === localValueRef.current) return;
+      localValueRef.current = newValue;
+      setLocalValue(newValue);
+      onChange(newValue);
+    },
+    [onChange],
+  );
+
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor="codexModelsCatalog"
+        className="block text-sm font-medium text-foreground"
+      >
+        {t("codexConfig.modelsCatalogJson", {
+          defaultValue: "models_catalog.json",
+        })}
+      </label>
+
+      <JsonEditor
+        value={localValue}
+        onChange={handleLocalChange}
+        placeholder=""
+        darkMode={isDarkMode}
+        rows={10}
+        showValidation={true}
+        language="json"
+      />
+
+      {error && (
+        <p className="text-xs text-red-500 dark:text-red-400">{error}</p>
+      )}
+
+      {!error && (
+        <p className="text-xs text-muted-foreground">
+          {t("codexConfig.modelsCatalogHint", {
+            defaultValue:
+              "自动从模型映射生成，也可手动编辑。保存后将随供应商配置一起存储。",
+          })}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -241,7 +241,8 @@ export function CodexFormFields({
                           ) : (
                             availableModels.map((m) => (
                               <option key={m.id} value={m.id}>
-                                {m.id}{index === 0 ? " (默认)" : ""}
+                                {m.id}
+                                {index === 0 ? " (默认)" : ""}
                               </option>
                             ))
                           )}
@@ -303,14 +304,16 @@ export function CodexFormFields({
               </Button>
             </div>
           )}
-          {fetchedModels.length === 0 && codexModels.length === 0 && !isFetchingModels && (
-            <p className="text-xs text-muted-foreground">
-              {t("providerForm.fetchModelsToConfigure", {
-                defaultValue: "输入 API Key 和 Base URL 后点击'获取模型'来配置模型映射",
-              })}
-            </p>
-          )}
-
+          {fetchedModels.length === 0 &&
+            codexModels.length === 0 &&
+            !isFetchingModels && (
+              <p className="text-xs text-muted-foreground">
+                {t("providerForm.fetchModelsToConfigure", {
+                  defaultValue:
+                    "输入 API Key 和 Base URL 后点击'获取模型'来配置模型映射",
+                })}
+              </p>
+            )}
         </div>
       )}
 

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import { Download, Loader2 } from "lucide-react";
+import { Download, Loader2, Minus, Plus } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/select";
 import { FormLabel } from "@/components/ui/form";
 import EndpointSpeedTest from "./EndpointSpeedTest";
-import { ApiKeySection, EndpointField, ModelInputWithFetch } from "./shared";
+import { ApiKeySection, EndpointField } from "./shared";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -47,17 +47,18 @@ interface CodexFormFieldsProps {
   autoSelect: boolean;
   onAutoSelectChange: (checked: boolean) => void;
 
-  // Model Name
-  shouldShowModelField?: boolean;
-  modelName?: string;
-  onModelNameChange?: (model: string) => void;
-
   // Speed Test Endpoints
   speedTestEndpoints: EndpointCandidate[];
 
   // API Format
   apiFormat: string;
   onApiFormatChange: (format: string) => void;
+
+  // Model Mapping
+  codexModels: string[];
+  onCodexModelsChange: (models: string[]) => void;
+  codexDefaultModel: string;
+  onCodexDefaultModelChange: (model: string) => void;
 }
 
 export function CodexFormFields({
@@ -79,12 +80,12 @@ export function CodexFormFields({
   onCustomEndpointsChange,
   autoSelect,
   onAutoSelectChange,
-  shouldShowModelField = true,
-  modelName = "",
-  onModelNameChange,
   speedTestEndpoints,
   apiFormat,
   onApiFormatChange,
+  codexModels,
+  onCodexModelsChange,
+  onCodexDefaultModelChange,
 }: CodexFormFieldsProps) {
   const { t } = useTranslation();
 
@@ -173,31 +174,12 @@ export function CodexFormFields({
         </div>
       )}
 
-      {/* Codex Base URL 输入框 */}
+      {/* 获取模型 + 模型映射（动态行，第一行为默认模型） */}
       {shouldShowSpeedTest && (
-        <EndpointField
-          id="codexBaseUrl"
-          label={t("codexConfig.apiUrlLabel")}
-          value={codexBaseUrl}
-          onChange={onBaseUrlChange}
-          placeholder={t("providerForm.codexApiEndpointPlaceholder")}
-          hint={t("providerForm.codexApiHint")}
-          showFullUrlToggle
-          isFullUrl={isFullUrl}
-          onFullUrlChange={onFullUrlChange}
-          onManageClick={() => onEndpointModalToggle(true)}
-        />
-      )}
-
-      {/* Codex Model Name 输入框 */}
-      {shouldShowModelField && onModelNameChange && (
-        <div className="space-y-2">
+        <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <label
-              htmlFor="codexModelName"
-              className="block text-sm font-medium text-foreground"
-            >
-              {t("codexConfig.modelName", { defaultValue: "模型名称" })}
+            <label className="block text-sm font-medium text-foreground">
+              {t("providerForm.modelMapping", { defaultValue: "模型映射" })}
             </label>
             <Button
               type="button"
@@ -215,26 +197,137 @@ export function CodexFormFields({
               {t("providerForm.fetchModels")}
             </Button>
           </div>
-          <ModelInputWithFetch
-            id="codexModelName"
-            value={modelName}
-            onChange={(v) => onModelNameChange!(v)}
-            placeholder={t("codexConfig.modelNamePlaceholder", {
-              defaultValue: "例如: gpt-5.4",
-            })}
-            fetchedModels={fetchedModels}
-            isLoading={isFetchingModels}
-          />
-          <p className="text-xs text-muted-foreground">
-            {modelName.trim()
-              ? t("codexConfig.modelNameHint", {
-                  defaultValue: "指定使用的模型，将自动更新到 config.toml 中",
-                })
-              : t("providerForm.modelHint", {
-                  defaultValue: "💡 留空将使用供应商的默认模型",
-                })}
-          </p>
+
+          {(fetchedModels.length > 0 || codexModels.length > 0) && (
+            <div className="space-y-1.5">
+              {codexModels.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {t("providerForm.addModelRow", {
+                    defaultValue: "点击 + 添加模型，第一个模型作为默认模型",
+                  })}
+                </p>
+              )}
+              {codexModels.map((modelId, index) => {
+                // 合并已保存但不在 fetchedModels 中的模型名，确保显示
+                const allOptions = [
+                  ...fetchedModels,
+                  ...(!fetchedModels.some((m) => m.id === modelId)
+                    ? [{ id: modelId, ownedBy: null as string | null }]
+                    : []),
+                ];
+                const availableModels = allOptions.filter(
+                  (m) => !codexModels.includes(m.id) || m.id === modelId,
+                );
+                const hasFetched = fetchedModels.length > 0;
+                return (
+                  <div key={index} className="flex items-center gap-2">
+                    <div className="flex-1">
+                      {hasFetched ? (
+                        <select
+                          value={modelId}
+                          onChange={(e) => {
+                            const newId = e.target.value;
+                            const updated = [...codexModels];
+                            updated[index] = newId;
+                            onCodexModelsChange(updated);
+                            if (index === 0) {
+                              onCodexDefaultModelChange(newId);
+                            }
+                          }}
+                          className="flex h-9 w-full rounded-md border border-border-default bg-background px-3 py-2 text-sm focus:outline-none focus:border-border-active"
+                        >
+                          {availableModels.length === 0 ? (
+                            <option value={modelId}>{modelId}</option>
+                          ) : (
+                            availableModels.map((m) => (
+                              <option key={m.id} value={m.id}>
+                                {m.id}{index === 0 ? " (默认)" : ""}
+                              </option>
+                            ))
+                          )}
+                        </select>
+                      ) : (
+                        <div className="flex h-9 items-center rounded-md border px-3 text-sm">
+                          {modelId}
+                          {index === 0 && (
+                            <span className="ml-1 text-muted-foreground">
+                              {t("providerForm.defaultModelTag", {
+                                defaultValue: "(默认)",
+                              })}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => {
+                        const updated = codexModels.filter(
+                          (_, i) => i !== index,
+                        );
+                        onCodexModelsChange(updated);
+                        if (index === 0 && updated.length > 0) {
+                          onCodexDefaultModelChange(updated[0]);
+                        }
+                      }}
+                    >
+                      <Minus className="h-4 w-4" />
+                    </Button>
+                  </div>
+                );
+              })}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-1"
+                onClick={() => {
+                  const available = fetchedModels.find(
+                    (m) => !codexModels.includes(m.id),
+                  );
+                  if (available) {
+                    const updated = [...codexModels, available.id];
+                    onCodexModelsChange(updated);
+                    if (updated.length === 1) {
+                      onCodexDefaultModelChange(available.id);
+                    }
+                  }
+                }}
+                disabled={codexModels.length >= fetchedModels.length}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                {t("providerForm.addModel", { defaultValue: "添加模型" })}
+              </Button>
+            </div>
+          )}
+          {fetchedModels.length === 0 && codexModels.length === 0 && !isFetchingModels && (
+            <p className="text-xs text-muted-foreground">
+              {t("providerForm.fetchModelsToConfigure", {
+                defaultValue: "输入 API Key 和 Base URL 后点击'获取模型'来配置模型映射",
+              })}
+            </p>
+          )}
+
         </div>
+      )}
+
+      {/* Codex Base URL 输入框 */}
+      {shouldShowSpeedTest && (
+        <EndpointField
+          id="codexBaseUrl"
+          label={t("codexConfig.apiUrlLabel")}
+          value={codexBaseUrl}
+          onChange={onBaseUrlChange}
+          placeholder={t("providerForm.codexApiEndpointPlaceholder")}
+          hint={t("providerForm.codexApiHint")}
+          showFullUrlToggle
+          isFullUrl={isFullUrl}
+          onFullUrlChange={onFullUrlChange}
+          onManageClick={() => onEndpointModalToggle(true)}
+        />
       )}
 
       {/* 端点测速弹窗 - Codex */}
@@ -251,6 +344,54 @@ export function CodexFormFields({
           onAutoSelectChange={onAutoSelectChange}
           onCustomEndpointsChange={onCustomEndpointsChange}
         />
+      )}
+
+      {/* models_catalog.json 预览 */}
+      {codexModels.length > 0 && (
+        <details className="text-xs">
+          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+            {t("providerForm.modelsCatalogPreview", {
+              defaultValue: "models_catalog.json 预览",
+            })}
+          </summary>
+          <pre className="mt-1 rounded bg-muted p-2 text-xs overflow-x-auto max-h-40">
+            {JSON.stringify(
+              {
+                models: codexModels.map((slug) => ({
+                  slug,
+                  display_name: slug,
+                  shell_type: "unified_exec",
+                  visibility: "list",
+                  supported_in_api: true,
+                  priority: 0,
+                  additional_speed_tiers: [],
+                  default_reasoning_level: "high",
+                  supported_reasoning_levels: [
+                    { effort: "high", description: "深度推理" },
+                    { effort: "low", description: "快速响应" },
+                  ],
+                  base_instructions: "You are a helpful coding assistant.",
+                  supports_reasoning_summaries: false,
+                  default_reasoning_summary: "none",
+                  support_verbosity: false,
+                  apply_patch_tool_type: "freeform",
+                  web_search_tool_type: "text",
+                  truncation_policy: { mode: "tokens", limit: 10000 },
+                  supports_parallel_tool_calls: true,
+                  supports_image_detail_original: false,
+                  context_window: 200000,
+                  max_context_window: 200000,
+                  effective_context_window_percent: 95,
+                  experimental_supported_tools: [],
+                  input_modalities: ["text"],
+                  supports_search_tool: false,
+                })),
+              },
+              null,
+              2,
+            )}
+          </pre>
+        </details>
       )}
     </>
   );

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -3,6 +3,14 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { Download, Loader2 } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { FormLabel } from "@/components/ui/form";
 import EndpointSpeedTest from "./EndpointSpeedTest";
 import { ApiKeySection, EndpointField, ModelInputWithFetch } from "./shared";
 import {
@@ -46,6 +54,10 @@ interface CodexFormFieldsProps {
 
   // Speed Test Endpoints
   speedTestEndpoints: EndpointCandidate[];
+
+  // API Format
+  apiFormat: string;
+  onApiFormatChange: (format: string) => void;
 }
 
 export function CodexFormFields({
@@ -71,6 +83,8 @@ export function CodexFormFields({
   modelName = "",
   onModelNameChange,
   speedTestEndpoints,
+  apiFormat,
+  onApiFormatChange,
 }: CodexFormFieldsProps) {
   const { t } = useTranslation();
 
@@ -126,6 +140,38 @@ export function CodexFormFields({
           }),
         }}
       />
+
+      {/* Codex API 格式选择 */}
+      {shouldShowSpeedTest && (
+        <div className="space-y-2">
+          <FormLabel htmlFor="codexApiFormat">
+            {t("providerForm.apiFormat", { defaultValue: "API 格式" })}
+          </FormLabel>
+          <Select value={apiFormat} onValueChange={onApiFormatChange}>
+            <SelectTrigger id="codexApiFormat" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="openai_responses">
+                {t("providerForm.apiFormatOpenAIResponses", {
+                  defaultValue: "OpenAI Responses API (原生)",
+                })}
+              </SelectItem>
+              <SelectItem value="openai_chat">
+                {t("providerForm.apiFormatOpenAIChat", {
+                  defaultValue: "OpenAI Chat Completions (需开启路由)",
+                })}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {t("providerForm.codexApiFormatHint", {
+              defaultValue:
+                "OpenAI Responses API 是 Codex CLI 原生格式。选择 Chat Completions 需要 cc-switch 路由进行格式转换。",
+            })}
+          </p>
+        </div>
+      )}
 
       {/* Codex Base URL 输入框 */}
       {shouldShowSpeedTest && (

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -345,54 +345,6 @@ export function CodexFormFields({
           onCustomEndpointsChange={onCustomEndpointsChange}
         />
       )}
-
-      {/* models_catalog.json 预览 */}
-      {codexModels.length > 0 && (
-        <details className="text-xs">
-          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-            {t("providerForm.modelsCatalogPreview", {
-              defaultValue: "models_catalog.json 预览",
-            })}
-          </summary>
-          <pre className="mt-1 rounded bg-muted p-2 text-xs overflow-x-auto max-h-40">
-            {JSON.stringify(
-              {
-                models: codexModels.map((slug) => ({
-                  slug,
-                  display_name: slug,
-                  shell_type: "unified_exec",
-                  visibility: "list",
-                  supported_in_api: true,
-                  priority: 0,
-                  additional_speed_tiers: [],
-                  default_reasoning_level: "high",
-                  supported_reasoning_levels: [
-                    { effort: "high", description: "深度推理" },
-                    { effort: "low", description: "快速响应" },
-                  ],
-                  base_instructions: "You are a helpful coding assistant.",
-                  supports_reasoning_summaries: false,
-                  default_reasoning_summary: "none",
-                  support_verbosity: false,
-                  apply_patch_tool_type: "freeform",
-                  web_search_tool_type: "text",
-                  truncation_policy: { mode: "tokens", limit: 10000 },
-                  supports_parallel_tool_calls: true,
-                  supports_image_detail_original: false,
-                  context_window: 200000,
-                  max_context_window: 200000,
-                  effective_context_window_percent: 95,
-                  experimental_supported_tools: [],
-                  input_modalities: ["text"],
-                  supports_search_tool: false,
-                })),
-              },
-              null,
-              2,
-            )}
-          </pre>
-        </details>
-      )}
     </>
   );
 }

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -154,12 +154,12 @@ export function CodexFormFields({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="openai_responses">
-                {t("providerForm.apiFormatOpenAIResponses", {
+                {t("providerForm.codexApiFormatOpenAIResponses", {
                   defaultValue: "OpenAI Responses API (原生)",
                 })}
               </SelectItem>
               <SelectItem value="openai_chat">
-                {t("providerForm.apiFormatOpenAIChat", {
+                {t("providerForm.codexApiFormatOpenAIChat", {
                   defaultValue: "OpenAI Chat Completions (需开启路由)",
                 })}
               </SelectItem>

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -360,10 +360,11 @@ function ProviderFormFull({
   });
 
   const [localApiFormat, setLocalApiFormat] = useState<ClaudeApiFormat>(() => {
-    if (appId === "claude")
-      return initialData?.meta?.apiFormat ?? "anthropic";
+    if (appId === "claude") return initialData?.meta?.apiFormat ?? "anthropic";
     if (appId === "codex")
-      return (initialData?.meta?.apiFormat as ClaudeApiFormat) ?? "openai_responses";
+      return (
+        (initialData?.meta?.apiFormat as ClaudeApiFormat) ?? "openai_responses"
+      );
     return "anthropic";
   });
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -359,8 +359,11 @@ function ProviderFormFull({
   });
 
   const [localApiFormat, setLocalApiFormat] = useState<ClaudeApiFormat>(() => {
-    if (appId !== "claude") return "anthropic";
-    return initialData?.meta?.apiFormat ?? "anthropic";
+    if (appId === "claude")
+      return initialData?.meta?.apiFormat ?? "anthropic";
+    if (appId === "codex")
+      return (initialData?.meta?.apiFormat as ClaudeApiFormat) ?? "openai_responses";
+    return "anthropic";
   });
 
   const handleApiFormatChange = useCallback((format: ClaudeApiFormat) => {
@@ -1227,7 +1230,7 @@ function ProviderFormFull({
           ? pricingConfig.pricingModelSource
           : undefined,
       apiFormat:
-        appId === "claude" && category !== "official"
+        (appId === "claude" || appId === "codex") && category !== "official"
           ? localApiFormat
           : undefined,
       apiKeyField:
@@ -1857,6 +1860,8 @@ function ProviderFormFull({
               modelName={codexModelName}
               onModelNameChange={handleCodexModelNameChange}
               speedTestEndpoints={speedTestEndpoints}
+              apiFormat={localApiFormat}
+              onApiFormatChange={handleApiFormatChange}
             />
           )}
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -48,6 +48,7 @@ import type { UniversalProviderPreset } from "@/config/universalProviderPresets"
 import {
   applyTemplateValues,
   hasApiKeyField,
+  generateModelsCatalogJson,
 } from "@/utils/providerConfigUtils";
 import { mergeProviderMeta } from "@/utils/providerMetaUtils";
 import { isNonNegativeDecimalString } from "@/types/usage";
@@ -415,6 +416,27 @@ function ProviderFormFull({
   const [localCodexModels, setLocalCodexModels] = useState<string[]>(
     () => initialData?.meta?.codexModels ?? [],
   );
+
+  const [localCodexModelsCatalog, setLocalCodexModelsCatalog] = useState(
+    () =>
+      initialData?.meta?.codexModelsCatalog ||
+      (initialData?.meta?.codexModels?.length
+        ? generateModelsCatalogJson(initialData.meta.codexModels)
+        : ""),
+  );
+
+  // Auto-generate models_catalog.json from model list when models change
+  useEffect(() => {
+    if (localCodexModels.length > 0) {
+      setLocalCodexModelsCatalog(generateModelsCatalogJson(localCodexModels));
+    } else {
+      setLocalCodexModelsCatalog("");
+    }
+  }, [localCodexModels]);
+
+  const handleCodexModelsCatalogChange = useCallback((value: string) => {
+    setLocalCodexModelsCatalog(value);
+  }, []);
 
   const {
     codexAuth,
@@ -1275,6 +1297,7 @@ function ProviderFormFull({
       nextMeta.codexModels =
         localCodexModels.length > 0 ? localCodexModels : undefined;
       nextMeta.codexDefaultModel = localCodexDefaultModel || undefined;
+      nextMeta.codexModelsCatalog = localCodexModelsCatalog || undefined;
     }
 
     payload.meta = nextMeta;
@@ -2029,6 +2052,8 @@ function ProviderFormFull({
                 configError={codexConfigError}
                 onExtract={handleCodexExtract}
                 isExtracting={isCodexExtracting}
+                modelsCatalogValue={localCodexModelsCatalog}
+                onModelsCatalogChange={handleCodexModelsCatalogChange}
               />
               {settingsConfigErrorField}
             </>

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -366,8 +366,8 @@ function ProviderFormFull({
     return "anthropic";
   });
 
-  const handleApiFormatChange = useCallback((format: ClaudeApiFormat) => {
-    setLocalApiFormat(format);
+  const handleApiFormatChange = useCallback((format: string) => {
+    setLocalApiFormat(format as ClaudeApiFormat);
   }, []);
 
   const handleApiKeyFieldChange = useCallback(
@@ -412,13 +412,16 @@ function ProviderFormFull({
   const [codexFastMode, setCodexFastMode] = useState<boolean>(
     () => initialData?.meta?.codexFastMode ?? false,
   );
+  const [localCodexModels, setLocalCodexModels] = useState<string[]>(
+    () => initialData?.meta?.codexModels ?? [],
+  );
 
   const {
     codexAuth,
     codexConfig,
     codexApiKey,
     codexBaseUrl,
-    codexModelName,
+    codexModelName: _codexModelName,
     codexAuthError,
     setCodexAuth,
     handleCodexApiKeyChange,
@@ -427,6 +430,24 @@ function ProviderFormFull({
     handleCodexConfigChange: originalHandleCodexConfigChange,
     resetCodexConfig,
   } = useCodexConfigState({ initialData });
+
+  const localCodexDefaultModel =
+    localCodexModels.length > 0 ? localCodexModels[0] : "";
+  const handleCodexDefaultModelChange = useCallback(
+    (model: string) => {
+      if (model) {
+        handleCodexModelNameChange(model);
+      }
+    },
+    [handleCodexModelNameChange],
+  );
+
+  // 初次加载时，用 codexModels[0] 同步 TOML model 字段
+  useEffect(() => {
+    if (localCodexDefaultModel) {
+      handleCodexModelNameChange(localCodexDefaultModel);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { configError: codexConfigError, debouncedValidate } =
     useCodexTomlValidation();
@@ -1249,6 +1270,13 @@ function ProviderFormFull({
       delete nextMeta.codexFastMode;
     }
 
+    // Codex model mapping
+    if (appId === "codex" && category !== "official") {
+      nextMeta.codexModels =
+        localCodexModels.length > 0 ? localCodexModels : undefined;
+      nextMeta.codexDefaultModel = localCodexDefaultModel || undefined;
+    }
+
     payload.meta = nextMeta;
 
     await onSubmit(payload);
@@ -1856,12 +1884,13 @@ function ProviderFormFull({
               }
               autoSelect={endpointAutoSelect}
               onAutoSelectChange={setEndpointAutoSelect}
-              shouldShowModelField={category !== "official"}
-              modelName={codexModelName}
-              onModelNameChange={handleCodexModelNameChange}
               speedTestEndpoints={speedTestEndpoints}
               apiFormat={localApiFormat}
               onApiFormatChange={handleApiFormatChange}
+              codexModels={localCodexModels}
+              onCodexModelsChange={setLocalCodexModels}
+              codexDefaultModel={localCodexDefaultModel}
+              onCodexDefaultModelChange={handleCodexDefaultModelChange}
             />
           )}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -178,6 +178,7 @@
     "noRoutingSupport": "No Routing Support"
   },
   "codex": {
+    "needsRouting": "Needs Routing",
     "noRoutingSupport": "No Routing Support"
   },
   "claudeDesktop": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -908,6 +908,8 @@
     "apiFormatAnthropic": "Anthropic Messages (Native)",
     "apiFormatOpenAIChat": "OpenAI Chat Completions (Requires routing)",
     "apiFormatOpenAIResponses": "OpenAI Responses API (Requires routing)",
+    "codexApiFormatOpenAIChat": "OpenAI Chat Completions (Requires routing)",
+    "codexApiFormatOpenAIResponses": "OpenAI Responses API (Native)",
     "apiFormatGeminiNative": "Gemini Native generateContent (Requires routing)",
     "authField": "Auth Field",
     "authFieldAuthToken": "ANTHROPIC_AUTH_TOKEN (Default)",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -178,6 +178,7 @@
     "noRoutingSupport": "ルーティング非対応"
   },
   "codex": {
+    "needsRouting": "ルーティングが必要",
     "noRoutingSupport": "ルーティング非対応"
   },
   "claudeDesktop": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -908,6 +908,8 @@
     "apiFormatAnthropic": "Anthropic Messages（ネイティブ）",
     "apiFormatOpenAIChat": "OpenAI Chat Completions（ルーティングが必要）",
     "apiFormatOpenAIResponses": "OpenAI Responses API（ルーティングが必要）",
+    "codexApiFormatOpenAIChat": "OpenAI Chat Completions（ルーティングが必要）",
+    "codexApiFormatOpenAIResponses": "OpenAI Responses API（ネイティブ）",
     "apiFormatGeminiNative": "Gemini Native generateContent（ルーティングが必要）",
     "authField": "認証フィールド",
     "authFieldAuthToken": "ANTHROPIC_AUTH_TOKEN（デフォルト）",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -178,6 +178,7 @@
     "noRoutingSupport": "不支持路由"
   },
   "codex": {
+    "needsRouting": "需要路由",
     "noRoutingSupport": "不支持路由"
   },
   "claudeDesktop": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -908,6 +908,8 @@
     "apiFormatAnthropic": "Anthropic Messages (原生)",
     "apiFormatOpenAIChat": "OpenAI Chat Completions (需开启路由)",
     "apiFormatOpenAIResponses": "OpenAI Responses API (需开启路由)",
+    "codexApiFormatOpenAIChat": "OpenAI Chat Completions (需开启路由)",
+    "codexApiFormatOpenAIResponses": "OpenAI Responses API (原生)",
     "apiFormatGeminiNative": "Gemini Native generateContent (需开启路由)",
     "authField": "认证字段",
     "authFieldAuthToken": "ANTHROPIC_AUTH_TOKEN（默认）",

--- a/src/types.ts
+++ b/src/types.ts
@@ -349,6 +349,8 @@ export interface Settings {
   // Windows: "cmd" | "powershell" | "wt"
   // Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
   preferredTerminal?: string;
+  // 是否启用 req.log 请求/响应日志（默认 false）
+  enableLogReq?: boolean;
 }
 
 export interface SessionMeta {

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,10 @@ export interface ProviderMeta {
   providerType?: string;
   // GitHub Copilot 关联账号 ID（旧字段，保留兼容读取）
   githubAccountId?: string;
+  // Codex 模型映射：models_catalog.json 中包含的模型 slug 列表
+  codexModels?: string[];
+  // Codex 默认模型：config.toml 中的 model 字段值
+  codexDefaultModel?: string;
 }
 
 // Skill 同步方式

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,8 @@ export interface ProviderMeta {
   codexModels?: string[];
   // Codex 默认模型：config.toml 中的 model 字段值
   codexDefaultModel?: string;
+  // Codex models_catalog.json 完整内容（可编辑的 JSON 字符串）
+  codexModelsCatalog?: string;
 }
 
 // Skill 同步方式

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -925,7 +925,7 @@ export interface ModelsCatalogEntry {
   supported_in_api: boolean;
   priority: number;
   additional_speed_tiers: string[];
-  default_reasoning_level: string;
+  default_reasoning_level?: string;
   supported_reasoning_levels: Array<{
     effort: string;
     description: string;
@@ -947,39 +947,100 @@ export interface ModelsCatalogEntry {
   supports_search_tool: boolean;
 }
 
+interface ModelCapabilities {
+  contextWindow: number;
+  maxContextWindow: number;
+  effectiveContextWindowPercent: number;
+  supportsReasoning: boolean;
+}
+
+const DEFAULT_CAPABILITIES: ModelCapabilities = {
+  contextWindow: 128000,
+  maxContextWindow: 128000,
+  effectiveContextWindowPercent: 95,
+  supportsReasoning: false,
+};
+
+// 按前缀长度降序排列，长前缀优先匹配
+const MODEL_CAPABILITIES: Array<[string, ModelCapabilities]> = [
+  [
+    "deepseek-reasoner",
+    {
+      contextWindow: 64000,
+      maxContextWindow: 64000,
+      effectiveContextWindowPercent: 95,
+      supportsReasoning: true,
+    },
+  ],
+  [
+    "deepseek-chat",
+    {
+      contextWindow: 128000,
+      maxContextWindow: 128000,
+      effectiveContextWindowPercent: 95,
+      supportsReasoning: false,
+    },
+  ],
+  [
+    "deepseek",
+    {
+      contextWindow: 128000,
+      maxContextWindow: 128000,
+      effectiveContextWindowPercent: 95,
+      supportsReasoning: true,
+    },
+  ],
+];
+
+function lookupModelCapabilities(modelId: string): ModelCapabilities {
+  for (const [prefix, caps] of MODEL_CAPABILITIES) {
+    if (modelId === prefix || modelId.startsWith(`${prefix}-`)) {
+      return caps;
+    }
+  }
+  return DEFAULT_CAPABILITIES;
+}
+
 export function generateModelsCatalog(models: string[]): {
   models: ModelsCatalogEntry[];
 } {
   return {
-    models: models.map((slug) => ({
-      slug,
-      display_name: slug,
-      shell_type: "unified_exec",
-      visibility: "list",
-      supported_in_api: true,
-      priority: 0,
-      additional_speed_tiers: [],
-      default_reasoning_level: "high",
-      supported_reasoning_levels: [
-        { effort: "high", description: "深度推理" },
-        { effort: "low", description: "快速响应" },
-      ],
-      base_instructions: "You are a helpful coding assistant.",
-      supports_reasoning_summaries: false,
-      default_reasoning_summary: "none",
-      support_verbosity: false,
-      apply_patch_tool_type: "freeform",
-      web_search_tool_type: "text",
-      truncation_policy: { mode: "tokens", limit: 10000 },
-      supports_parallel_tool_calls: true,
-      supports_image_detail_original: false,
-      context_window: 200000,
-      max_context_window: 200000,
-      effective_context_window_percent: 95,
-      experimental_supported_tools: [],
-      input_modalities: ["text"],
-      supports_search_tool: false,
-    })),
+    models: models.map((slug) => {
+      const caps = lookupModelCapabilities(slug);
+      const defaultReasoningLevel = caps.supportsReasoning ? "high" : undefined;
+      const supportedReasoningLevels = caps.supportsReasoning
+        ? [
+            { effort: "high" as const, description: "深度推理" },
+            { effort: "low" as const, description: "快速响应" },
+          ]
+        : [];
+      return {
+        slug,
+        display_name: slug,
+        shell_type: "unified_exec",
+        visibility: "list",
+        supported_in_api: true,
+        priority: 0,
+        additional_speed_tiers: [],
+        default_reasoning_level: defaultReasoningLevel,
+        supported_reasoning_levels: supportedReasoningLevels,
+        base_instructions: "You are a helpful coding assistant.",
+        supports_reasoning_summaries: false,
+        default_reasoning_summary: "none",
+        support_verbosity: false,
+        apply_patch_tool_type: "freeform",
+        web_search_tool_type: "text",
+        truncation_policy: { mode: "tokens", limit: 10000 },
+        supports_parallel_tool_calls: true,
+        supports_image_detail_original: false,
+        context_window: caps.contextWindow,
+        max_context_window: caps.maxContextWindow,
+        effective_context_window_percent: caps.effectiveContextWindowPercent,
+        experimental_supported_tools: [],
+        input_modalities: ["text"],
+        supports_search_tool: false,
+      };
+    }),
   };
 }
 

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -916,3 +916,73 @@ export const removeCodexTopLevelField = (
   }
   return finalizeTomlText(lines);
 };
+
+export interface ModelsCatalogEntry {
+  slug: string;
+  display_name: string;
+  shell_type: string;
+  visibility: string;
+  supported_in_api: boolean;
+  priority: number;
+  additional_speed_tiers: string[];
+  default_reasoning_level: string;
+  supported_reasoning_levels: Array<{
+    effort: string;
+    description: string;
+  }>;
+  base_instructions: string;
+  supports_reasoning_summaries: boolean;
+  default_reasoning_summary: string;
+  support_verbosity: boolean;
+  apply_patch_tool_type: string;
+  web_search_tool_type: string;
+  truncation_policy: { mode: string; limit: number };
+  supports_parallel_tool_calls: boolean;
+  supports_image_detail_original: boolean;
+  context_window: number;
+  max_context_window: number;
+  effective_context_window_percent: number;
+  experimental_supported_tools: string[];
+  input_modalities: string[];
+  supports_search_tool: boolean;
+}
+
+export function generateModelsCatalog(models: string[]): {
+  models: ModelsCatalogEntry[];
+} {
+  return {
+    models: models.map((slug) => ({
+      slug,
+      display_name: slug,
+      shell_type: "unified_exec",
+      visibility: "list",
+      supported_in_api: true,
+      priority: 0,
+      additional_speed_tiers: [],
+      default_reasoning_level: "high",
+      supported_reasoning_levels: [
+        { effort: "high", description: "深度推理" },
+        { effort: "low", description: "快速响应" },
+      ],
+      base_instructions: "You are a helpful coding assistant.",
+      supports_reasoning_summaries: false,
+      default_reasoning_summary: "none",
+      support_verbosity: false,
+      apply_patch_tool_type: "freeform",
+      web_search_tool_type: "text",
+      truncation_policy: { mode: "tokens", limit: 10000 },
+      supports_parallel_tool_calls: true,
+      supports_image_detail_original: false,
+      context_window: 200000,
+      max_context_window: 200000,
+      effective_context_window_percent: 95,
+      experimental_supported_tools: [],
+      input_modalities: ["text"],
+      supports_search_tool: false,
+    })),
+  };
+}
+
+export function generateModelsCatalogJson(models: string[]): string {
+  return JSON.stringify(generateModelsCatalog(models), null, 2);
+}

--- a/tests/components/CommonConfigModalBehavior.test.tsx
+++ b/tests/components/CommonConfigModalBehavior.test.tsx
@@ -62,6 +62,8 @@ describe("Common config modals", () => {
         commonConfigError="Invalid TOML"
         authError=""
         configError=""
+        modelsCatalogValue=""
+        onModelsCatalogChange={() => {}}
       />,
     );
 


### PR DESCRIPTION
## Summary

This PR adds DeepSeek as a Codex-compatible provider in cc-switch, enabling DeepSeek models (including reasoning models like deepseek-reasoner) to be used seamlessly with the Codex app through the proxy layer.

Closes #3187

## Key Changes

### DeepSeek Codex Integration
- **Responses ↔ Chat Completions format conversion**: Bidirectional conversion between Codex's Responses API and DeepSeek's Chat Completions API, including tool_calls, function_call, and reasoning_content mapping
- **reasoning_content caching**: Preserve and re-inject reasoning_content across tool call round-trips, since DeepSeek does not return reasoning content in subsequent turns after tool calls
- **SSE wrapping**: Wrap DeepSeek Chat Completions SSE streams as Responses API SSE format

### Proxy Enhancements
- **req.log**: Add request/response logging (JSON pretty-printed) for debugging without needing the debug flag; controlled by `enableLogReq` setting (default off)
- **Long value truncation**: Smart truncation of long JSON string values in req.log while preserving full structure
- **/v1/models endpoint**: Support Codex model listing through provider's models endpoint

### Codex Model Management
- **Model mapping UI**: Frontend UI for configuring model mappings in Codex
- **models_catalog.json editor**: Editable catalog with DB-level persistence
- **Proxy takeover fixes**: Properly re-apply proxy settings when running

### Other
- Code formatting across the codebase (cargo fmt + prettier)
- User manual restructuring

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes  
- [x] `pnpm test:unit` (40 test files, 233 tests)
- [x] `cargo clippy` (warnings only, no errors)
- [x] `cargo test` (25 tests)
- [x] Manual testing with DeepSeek API key + Codex app
- [x] Verify reasoning_content preserved across tool call round-trips
- [x] Verify model mapping UI in Codex provider form