### PR TITLE
fix: use lowercase 1m suffix for DeepSeek V4 Pro

### DIFF
--- a/src-tauri/src/proxy/model_mapper.rs
+++ b/src-tauri/src/proxy/model_mapper.rs
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn strips_one_m_suffix_before_upstream() {
-        let body = json!({"model": "deepseek-v4-pro[1M]"});
+        let body = json!({"model": "deepseek-v4-pro[1m]"});
         let result = strip_one_m_suffix_for_upstream_from_body(body);
         assert_eq!(result["model"], "deepseek-v4-pro");
     }
@@ -292,7 +292,7 @@ mod tests {
         let mut provider = create_provider_with_mapping();
         provider.settings_config = json!({
             "env": {
-                "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro [1M]"
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro [1m]"
             }
         });
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2553,7 +2553,7 @@ model = "gpt-5.1-codex"
                     "ANTHROPIC_MODEL": "claude-new",
                     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash",
                     "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME": "DeepSeek V4 Flash",
-                    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1M]",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]",
                     "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME": "DeepSeek V4 Pro",
                     "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-ultra [1m]"
                 },

--- a/src/components/providers/forms/hooks/useModelState.ts
+++ b/src/components/providers/forms/hooks/useModelState.ts
@@ -15,6 +15,8 @@ export type ClaudeModelEnvField =
   | "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME";
 
 export const CLAUDE_ONE_M_MARKER = "[1M]";
+const DEEPSEEK_V4_PRO_MODEL = "deepseek-v4-pro";
+const DEEPSEEK_ONE_M_MARKER = "[1m]";
 
 export function hasClaudeOneMMarker(model: string): boolean {
   return model.trimEnd().toLowerCase().endsWith("[1m]");
@@ -29,7 +31,11 @@ export function stripClaudeOneMMarker(model: string): string {
 export function setClaudeOneMMarker(model: string, enabled: boolean): string {
   const base = stripClaudeOneMMarker(model).trim();
   if (!base) return "";
-  return enabled ? `${base}${CLAUDE_ONE_M_MARKER}` : base;
+  const marker =
+    base.toLowerCase() === DEEPSEEK_V4_PRO_MODEL
+      ? DEEPSEEK_ONE_M_MARKER
+      : CLAUDE_ONE_M_MARKER;
+  return enabled ? `${base}${marker}` : base;
 }
 
 /**

--- a/tests/hooks/useModelState.test.tsx
+++ b/tests/hooks/useModelState.test.tsx
@@ -79,7 +79,7 @@ describe("useModelState", () => {
   it("keeps the 1M marker on request models but strips it from fallback display names", () => {
     const settingsConfig = JSON.stringify({
       env: {
-        ANTHROPIC_DEFAULT_SONNET_MODEL: "deepseek-v4-pro[1M]",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "deepseek-v4-pro[1m]",
       },
     });
 
@@ -90,21 +90,18 @@ describe("useModelState", () => {
       }),
     );
 
-    expect(result.current.defaultSonnetModel).toBe("deepseek-v4-pro[1M]");
+    expect(result.current.defaultSonnetModel).toBe("deepseek-v4-pro[1m]");
     expect(result.current.defaultSonnetModelName).toBe("deepseek-v4-pro");
   });
 
   it("normalizes Claude Code 1M markers for UI toggles", () => {
     expect(hasClaudeOneMMarker("deepseek-v4-pro[1m]")).toBe(true);
-    expect(hasClaudeOneMMarker("deepseek-v4-pro [1M]  ")).toBe(true);
-    expect(stripClaudeOneMMarker("deepseek-v4-pro [1M]  ")).toBe(
-      "deepseek-v4-pro",
-    );
-    expect(setClaudeOneMMarker("deepseek-v4-pro [1M]", false)).toBe(
-      "deepseek-v4-pro",
-    );
+    expect(hasClaudeOneMMarker("kimi-k2 [1M]  ")).toBe(true);
+    expect(stripClaudeOneMMarker("kimi-k2 [1M]  ")).toBe("kimi-k2");
+    expect(setClaudeOneMMarker("kimi-k2 [1M]", false)).toBe("kimi-k2");
     expect(setClaudeOneMMarker("deepseek-v4-pro", true)).toBe(
-      "deepseek-v4-pro[1M]",
+      "deepseek-v4-pro[1m]",
     );
+    expect(setClaudeOneMMarker("kimi-k2", true)).toBe("kimi-k2[1M]");
   });
 });


### PR DESCRIPTION
Summary:
- Update DeepSeek V4 Pro 1M model IDs from `deepseek-v4-pro[1M]` to `deepseek-v4-pro[1m]`.
- Keep human-readable `1M` labels unchanged where they only describe the context size.
- Align generated Claude Code configuration with DeepSeek official documentation.

Why:
DeepSeek's official Claude Code integration documentation uses the lowercase `[1m]` suffix for the 1M context model ID, for example:
`ANTHROPIC_MODEL=deepseek-v4-pro[1m]`,
`ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-pro[1m]`,
and `ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-pro[1m]`.

Reference:
https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/claude_code

Testing:
- `pnpm vitest run tests/hooks/useModelState.test.tsx`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit`

Not run:
- `cargo test strips_one_m_suffix` (local environment does not have `cargo` installed)

Notes:
- This PR intentionally does not change user-facing `1M` labels when they refer to context size rather than model ID.
- This PR intentionally does not modify other providers.
- This PR intentionally avoids unrelated refactoring and UI changes.