### PR TITLE
Add Chat tool compatibility for Responses routing

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,10 @@
 packages: []
 
+allowBuilds:
+  esbuild: true
+  msw: true
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'
+  - esbuild
+  - msw

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -319,6 +319,8 @@ pub struct ProviderMeta {
     /// - "openai_responses": OpenAI Responses API 格式，需要转换
     #[serde(rename = "apiFormat", skip_serializing_if = "Option::is_none")]
     pub api_format: Option<String>,
+    #[serde(rename = "toolCompatEnabled", skip_serializing_if = "Option::is_none")]
+    pub tool_compat_enabled: Option<bool>,
     /// 通用认证绑定（provider_config / managed_account）
     ///
     /// 新代码应只写入该字段；githubAccountId 仅保留兼容读取。
@@ -358,6 +360,10 @@ impl ProviderMeta {
     /// 会按更高速率消耗 ChatGPT 订阅配额，用户需显式开启以换取更低延迟。
     pub fn codex_fast_mode_enabled(&self) -> bool {
         self.codex_fast_mode.unwrap_or(false)
+    }
+
+    pub fn tool_compat_enabled(&self, default_enabled: bool) -> bool {
+        self.tool_compat_enabled.unwrap_or(default_enabled)
     }
 
     /// 解析指定托管认证供应商绑定的账号 ID。
@@ -805,6 +811,24 @@ mod tests {
         let value = serde_json::to_value(&meta).expect("serialize ProviderMeta");
 
         assert!(value.get("pricingModelSource").is_none());
+    }
+
+    #[test]
+    fn provider_meta_serializes_tool_compat_flag() {
+        let meta = ProviderMeta {
+            tool_compat_enabled: Some(true),
+            ..ProviderMeta::default()
+        };
+
+        let value = serde_json::to_value(&meta).expect("serialize ProviderMeta");
+
+        assert_eq!(
+            value
+                .get("toolCompatEnabled")
+                .and_then(|item| item.as_bool()),
+            Some(true)
+        );
+        assert!(value.get("tool_compat_enabled").is_none());
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1144,9 +1144,24 @@ impl RequestForwarder {
             adapter.build_url(&base_url, &effective_endpoint)
         };
 
+        let tool_ctx = if codex_responses_to_chat
+            && super::providers::tool_compat_enabled_for_provider(provider)
+        {
+            Some(super::providers::tool_compat::ToolCompatContext::from_request(&mapped_body))
+        } else {
+            None
+        };
+
         // 转换请求体（如果需要）
         let request_body = if codex_responses_to_chat {
-            super::providers::transform_codex_chat::responses_to_chat_completions(mapped_body)?
+            if let Some(tool_ctx) = tool_ctx.as_ref() {
+                super::providers::transform_codex_chat::responses_to_chat_completions_with_context(
+                    mapped_body,
+                    Some(tool_ctx),
+                )?
+            } else {
+                super::providers::transform_codex_chat::responses_to_chat_completions(mapped_body)?
+            }
         } else if needs_transform {
             if adapter.name() == "Claude" {
                 let api_format = resolved_claude_api_format

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -17,7 +17,7 @@ use super::{
     handler_context::RequestContext,
     providers::{
         get_adapter, get_claude_api_format, streaming::create_anthropic_sse_stream,
-        streaming_codex_chat::create_responses_sse_stream_from_chat,
+        streaming_codex_chat::create_responses_sse_stream_from_chat_with_context,
         streaming_gemini::create_anthropic_sse_stream_from_gemini,
         streaming_responses::create_anthropic_sse_stream_from_responses, transform,
         transform_codex_chat, transform_gemini, transform_responses,
@@ -503,7 +503,7 @@ pub async fn handle_chat_completions(
             &AppType::Codex,
             method,
             &endpoint,
-            body,
+            body.clone(),
             headers,
             extensions,
             ctx.get_providers(),
@@ -567,7 +567,7 @@ pub async fn handle_responses(
             &AppType::Codex,
             method,
             &endpoint,
-            body,
+            body.clone(),
             headers,
             extensions,
             ctx.get_providers(),
@@ -593,6 +593,7 @@ pub async fn handle_responses(
             response,
             &ctx,
             &state,
+            &body,
             is_stream,
             connection_guard,
         )
@@ -642,7 +643,7 @@ pub async fn handle_responses_compact(
             &AppType::Codex,
             method,
             &endpoint,
-            body,
+            body.clone(),
             headers,
             extensions,
             ctx.get_providers(),
@@ -668,6 +669,7 @@ pub async fn handle_responses_compact(
             response,
             &ctx,
             &state,
+            &body,
             is_stream,
             connection_guard,
         )
@@ -688,6 +690,7 @@ async fn handle_codex_chat_to_responses_transform(
     response: super::hyper_client::ProxyResponse,
     ctx: &RequestContext,
     state: &ProxyState,
+    original_body: &Value,
     is_stream: bool,
     connection_guard: Option<ActiveConnectionGuard>,
 ) -> Result<axum::response::Response, ProxyError> {
@@ -698,9 +701,16 @@ async fn handle_codex_chat_to_responses_transform(
             .await;
     }
 
+    let tool_ctx = if super::providers::tool_compat_enabled_for_provider(&ctx.provider) {
+        Some(super::providers::tool_compat::ToolCompatContext::from_request(original_body))
+    } else {
+        None
+    };
+
     if is_stream || response.is_sse() {
         let stream = response.bytes_stream();
-        let sse_stream = create_responses_sse_stream_from_chat(stream);
+        let sse_stream =
+            create_responses_sse_stream_from_chat_with_context(stream, tool_ctx.clone());
 
         let usage_collector = if usage_logging_enabled(state) {
             let state = state.clone();
@@ -781,11 +791,18 @@ async fn handle_codex_chat_to_responses_transform(
         log::error!("[Codex] 解析 Chat 上游响应失败: {e}, body: {body_str}");
         ProxyError::TransformError(format!("Failed to parse upstream chat response: {e}"))
     })?;
-    let responses_response = transform_codex_chat::chat_completion_to_response(chat_response)
-        .map_err(|e| {
-            log::error!("[Codex] Chat → Responses 响应转换失败: {e}");
-            e
-        })?;
+    let responses_response = if let Some(tool_ctx) = tool_ctx.as_ref() {
+        transform_codex_chat::chat_completion_to_response_with_context(
+            chat_response,
+            Some(tool_ctx),
+        )
+    } else {
+        transform_codex_chat::chat_completion_to_response(chat_response)
+    }
+    .map_err(|e| {
+        log::error!("[Proxy] Chat → Responses 响应转换失败: {e}");
+        e
+    })?;
 
     if let Some(usage) = TokenUsage::from_codex_response_auto(&responses_response) {
         let model = responses_response

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -82,6 +82,19 @@ pub fn should_convert_codex_responses_to_chat(provider: &Provider, endpoint: &st
     ) && codex_provider_uses_chat_completions(provider)
 }
 
+pub fn tool_compat_enabled_for_provider(provider: &Provider) -> bool {
+    let default_enabled = codex_provider_uses_chat_completions(provider);
+    if let Some(meta) = provider.meta.as_ref() {
+        return meta.tool_compat_enabled(default_enabled);
+    }
+
+    provider
+        .settings_config
+        .get("toolCompatEnabled")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(default_enabled)
+}
+
 fn is_chat_wire_api(value: &str) -> bool {
     matches!(
         value.trim().to_ascii_lowercase().as_str(),
@@ -480,5 +493,32 @@ wire_api = "chat"
             &provider,
             "/responses/compact?stream=true"
         ));
+    }
+
+    #[test]
+    fn tool_compat_defaults_on_for_chat_format() {
+        let mut provider = create_provider(json!({
+            "base_url": "https://example.com/v1"
+        }));
+        provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_chat".to_string()),
+            ..Default::default()
+        });
+
+        assert!(tool_compat_enabled_for_provider(&provider));
+    }
+
+    #[test]
+    fn tool_compat_can_be_disabled_for_chat_format() {
+        let mut provider = create_provider(json!({
+            "base_url": "https://example.com/v1"
+        }));
+        provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_chat".to_string()),
+            tool_compat_enabled: Some(false),
+            ..Default::default()
+        });
+
+        assert!(!tool_compat_enabled_for_provider(&provider));
     }
 }

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -26,6 +26,7 @@ pub mod streaming;
 pub mod streaming_codex_chat;
 pub mod streaming_gemini;
 pub mod streaming_responses;
+pub mod tool_compat;
 pub mod transform;
 pub mod transform_codex_chat;
 pub mod transform_gemini;
@@ -43,6 +44,7 @@ pub use claude::{
     transform_claude_request_for_api_format, ClaudeAdapter,
 };
 pub use codex::should_convert_codex_responses_to_chat;
+pub use codex::tool_compat_enabled_for_provider;
 pub use codex::CodexAdapter;
 pub use gemini::GeminiAdapter;
 

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -1,5 +1,6 @@
 //! OpenAI Chat Completions SSE → OpenAI Responses SSE conversion.
 
+use super::tool_compat::ToolCompatContext;
 use super::transform_codex_chat::{
     chat_usage_to_responses_usage, response_id_from_chat_id, response_status_from_finish_reason,
     split_leading_think_block, strip_leading_think_open_tag,
@@ -68,6 +69,7 @@ struct ChatToResponsesState {
     output_items: Vec<(u32, Value)>,
     latest_usage: Option<Value>,
     finish_reason: Option<String>,
+    tool_ctx: Option<ToolCompatContext>,
 }
 
 impl Default for ChatToResponsesState {
@@ -86,11 +88,19 @@ impl Default for ChatToResponsesState {
             output_items: Vec::new(),
             latest_usage: None,
             finish_reason: None,
+            tool_ctx: None,
         }
     }
 }
 
 impl ChatToResponsesState {
+    fn with_tool_context(tool_ctx: Option<ToolCompatContext>) -> Self {
+        Self {
+            tool_ctx,
+            ..Default::default()
+        }
+    }
+
     fn handle_chat_chunk(&mut self, chunk: &Value) -> Vec<Bytes> {
         let mut events = Vec::new();
 
@@ -396,6 +406,7 @@ impl ChatToResponsesState {
         let mut output_index = None;
         let mut item_id = String::new();
         let mut pending_arguments = String::new();
+        let current_name;
 
         {
             let state = self.tools.entry(chat_index).or_default();
@@ -408,6 +419,7 @@ impl ChatToResponsesState {
             if !args_delta.is_empty() {
                 state.arguments.push_str(&args_delta);
             }
+            current_name = state.name.clone();
 
             if !state.added && (!state.call_id.is_empty() || !state.name.is_empty()) {
                 should_add = true;
@@ -419,9 +431,15 @@ impl ChatToResponsesState {
         }
 
         let mut events = Vec::new();
+        let is_custom = self
+            .tool_ctx
+            .as_ref()
+            .map(|ctx| ctx.is_custom_proxy(&current_name))
+            .unwrap_or(false);
 
         if should_add {
             let assigned = self.next_output_index();
+            let tool_ctx = self.tool_ctx.clone();
             let state = self.tools.get_mut(&chat_index).expect("tool state exists");
             state.added = true;
             if state.call_id.is_empty() {
@@ -431,26 +449,47 @@ impl ChatToResponsesState {
                 state.name = "unknown_tool".to_string();
             }
             state.output_index = Some(assigned);
-            state.item_id = format!("fc_{}", state.call_id);
+            state.item_id = if is_custom {
+                format!("ctc_{}", state.call_id)
+            } else {
+                format!("fc_{}", state.call_id)
+            };
             item_id = state.item_id.clone();
+
+            let item = if is_custom {
+                let name = tool_ctx
+                    .as_ref()
+                    .map(|ctx| ctx.original_custom_name(&state.name))
+                    .unwrap_or_else(|| state.name.clone());
+                json!({
+                    "id": item_id,
+                    "type": "custom_tool_call",
+                    "status": "in_progress",
+                    "call_id": state.call_id,
+                    "name": name,
+                    "input": ""
+                })
+            } else {
+                json!({
+                    "id": item_id,
+                    "type": "function_call",
+                    "status": "in_progress",
+                    "call_id": state.call_id,
+                    "name": state.name,
+                    "arguments": ""
+                })
+            };
 
             events.push(sse_event(
                 "response.output_item.added",
                 json!({
                     "type": "response.output_item.added",
                     "output_index": assigned,
-                    "item": {
-                        "id": item_id,
-                        "type": "function_call",
-                        "status": "in_progress",
-                        "call_id": state.call_id,
-                        "name": state.name,
-                        "arguments": ""
-                    }
+                    "item": item
                 }),
             ));
 
-            if !pending_arguments.is_empty() {
+            if !pending_arguments.is_empty() && !is_custom {
                 events.push(sse_event(
                     "response.function_call_arguments.delta",
                     json!({
@@ -461,7 +500,7 @@ impl ChatToResponsesState {
                     }),
                 ));
             }
-        } else if !args_delta.is_empty() {
+        } else if !args_delta.is_empty() && !is_custom {
             if let Some(output_index) = output_index {
                 events.push(sse_event(
                     "response.function_call_arguments.delta",
@@ -633,6 +672,7 @@ impl ChatToResponsesState {
                 .unwrap_or(false)
             {
                 let assigned = self.next_output_index();
+                let tool_ctx = self.tool_ctx.clone();
                 let state = self.tools.get_mut(&key).expect("tool state exists");
                 state.added = true;
                 if state.call_id.is_empty() {
@@ -641,21 +681,45 @@ impl ChatToResponsesState {
                 if state.name.is_empty() {
                     state.name = "unknown_tool".to_string();
                 }
+                let is_custom = tool_ctx
+                    .as_ref()
+                    .map(|ctx| ctx.is_custom_proxy(&state.name))
+                    .unwrap_or(false);
                 state.output_index = Some(assigned);
-                state.item_id = format!("fc_{}", state.call_id);
+                state.item_id = if is_custom {
+                    format!("ctc_{}", state.call_id)
+                } else {
+                    format!("fc_{}", state.call_id)
+                };
+                let item = if is_custom {
+                    let name = tool_ctx
+                        .as_ref()
+                        .map(|ctx| ctx.original_custom_name(&state.name))
+                        .unwrap_or_else(|| state.name.clone());
+                    json!({
+                        "id": state.item_id,
+                        "type": "custom_tool_call",
+                        "status": "in_progress",
+                        "call_id": state.call_id,
+                        "name": name,
+                        "input": ""
+                    })
+                } else {
+                    json!({
+                        "id": state.item_id,
+                        "type": "function_call",
+                        "status": "in_progress",
+                        "call_id": state.call_id,
+                        "name": state.name,
+                        "arguments": ""
+                    })
+                };
                 add_event = Some(sse_event(
                     "response.output_item.added",
                     json!({
                         "type": "response.output_item.added",
                         "output_index": assigned,
-                        "item": {
-                            "id": state.item_id,
-                            "type": "function_call",
-                            "status": "in_progress",
-                            "call_id": state.call_id,
-                            "name": state.name,
-                            "arguments": ""
-                        }
+                        "item": item
                     }),
                 ));
             }
@@ -666,7 +730,57 @@ impl ChatToResponsesState {
 
             let state = self.tools.get_mut(&key).expect("tool state exists");
             let output_index = state.output_index.unwrap_or(0);
-            let item = json!({
+            let tool_ctx = self.tool_ctx.clone();
+            if let Some(ctx) = tool_ctx
+                .as_ref()
+                .filter(|ctx| ctx.is_custom_proxy(&state.name))
+            {
+                let input = ctx.reconstruct_custom_input(&state.name, &state.arguments);
+                let item = json!({
+                    "id": state.item_id,
+                    "type": "custom_tool_call",
+                    "status": "completed",
+                    "call_id": state.call_id,
+                    "name": ctx.original_custom_name(&state.name),
+                    "input": input.clone()
+                });
+                state.done = true;
+                self.output_items.push((output_index, item.clone()));
+
+                if !input.is_empty() {
+                    events.push(sse_event(
+                        "response.custom_tool_call_input.delta",
+                        json!({
+                            "type": "response.custom_tool_call_input.delta",
+                            "item_id": state.item_id,
+                            "call_id": state.call_id,
+                            "output_index": output_index,
+                            "delta": input.clone()
+                        }),
+                    ));
+                }
+                events.push(sse_event(
+                    "response.custom_tool_call_input.done",
+                    json!({
+                        "type": "response.custom_tool_call_input.done",
+                        "item_id": state.item_id,
+                        "call_id": state.call_id,
+                        "output_index": output_index,
+                        "input": input.clone()
+                    }),
+                ));
+                events.push(sse_event(
+                    "response.output_item.done",
+                    json!({
+                        "type": "response.output_item.done",
+                        "output_index": output_index,
+                        "item": item
+                    }),
+                ));
+                continue;
+            }
+
+            let mut item = json!({
                 "id": state.item_id,
                 "type": "function_call",
                 "status": "completed",
@@ -674,6 +788,9 @@ impl ChatToResponsesState {
                 "name": state.name,
                 "arguments": state.arguments
             });
+            if let Some(ctx) = tool_ctx.as_ref() {
+                ctx.apply_namespace_to_response_item(&mut item);
+            }
             state.done = true;
             self.output_items.push((output_index, item.clone()));
 
@@ -800,10 +917,17 @@ fn leading_think_prefix_decision(buffer: &str) -> ThinkPrefixDecision {
 pub fn create_responses_sse_stream_from_chat<E: std::error::Error + Send + 'static>(
     stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
+    create_responses_sse_stream_from_chat_with_context(stream, None)
+}
+
+pub fn create_responses_sse_stream_from_chat_with_context<E: std::error::Error + Send + 'static>(
+    stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
+    tool_ctx: Option<ToolCompatContext>,
+) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     async_stream::stream! {
         let mut buffer = String::new();
         let mut utf8_remainder: Vec<u8> = Vec::new();
-        let mut state = ChatToResponsesState::default();
+        let mut state = ChatToResponsesState::with_tool_context(tool_ctx);
         let mut stream_failed = false;
 
         tokio::pin!(stream);
@@ -926,6 +1050,18 @@ mod tests {
         String::from_utf8(bytes.concat()).unwrap()
     }
 
+    async fn collect_with_tools(chunks: Vec<&str>, tool_ctx: ToolCompatContext) -> String {
+        let chunks: Vec<Result<Bytes, std::io::Error>> = chunks
+            .into_iter()
+            .map(|chunk| Ok(Bytes::copy_from_slice(chunk.as_bytes())))
+            .collect();
+        let upstream = stream::iter(chunks);
+        let converted =
+            create_responses_sse_stream_from_chat_with_context(upstream, Some(tool_ctx));
+        let bytes: Vec<Bytes> = converted.map(|item| item.unwrap()).collect().await;
+        String::from_utf8(bytes.concat()).unwrap()
+    }
+
     #[tokio::test]
     async fn converts_text_chat_sse_to_responses_sse() {
         let output = collect(vec![
@@ -996,6 +1132,30 @@ mod tests {
         assert!(output.contains("event: response.function_call_arguments.done"));
         assert!(output.contains("\"type\":\"function_call\""));
         assert!(output.contains("\"call_id\":\"call_1\""));
+    }
+
+    #[tokio::test]
+    async fn converts_custom_tool_stream_without_function_argument_events() {
+        let tool_ctx = ToolCompatContext::from_tools(&[json!({
+            "type": "custom",
+            "name": "apply_patch"
+        })]);
+        let output = collect_with_tools(
+            vec![
+                "data: {\"id\":\"chatcmpl_custom\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"apply_patch_add_file\"}}]}}]}\n\n",
+                "data: {\"id\":\"chatcmpl_custom\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"docs/test.md\\\",\\\"content\\\":\\\"# Test\\\\n\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+                "data: [DONE]\n\n",
+            ],
+            tool_ctx,
+        )
+        .await;
+
+        assert!(output.contains("event: response.custom_tool_call_input.delta"));
+        assert!(output.contains("event: response.custom_tool_call_input.done"));
+        assert!(output.contains("\"type\":\"custom_tool_call\""));
+        assert!(output.contains("*** Add File: docs/test.md"));
+        assert!(!output.contains("response.function_call_arguments.delta"));
+        assert!(!output.contains("response.function_call_arguments.done"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/tool_compat.rs
+++ b/src-tauri/src/proxy/providers/tool_compat.rs
@@ -1,0 +1,1367 @@
+use crate::proxy::json_canonical::canonical_json_string;
+use serde_json::{json, Map, Value};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct ToolCompatContext {
+    custom_tools: BTreeMap<String, CustomToolSpec>,
+    function_tools: BTreeMap<String, FunctionToolSpec>,
+    has_custom_tools: bool,
+    has_namespace_tools: bool,
+}
+
+#[derive(Debug, Clone)]
+struct CustomToolSpec {
+    upstream_name: String,
+    kind: CustomToolKind,
+    proxy_action: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CustomToolKind {
+    Raw,
+    ApplyPatch,
+    BuiltIn,
+}
+
+#[derive(Debug, Clone)]
+struct FunctionToolSpec {
+    namespace: Option<String>,
+    name: String,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PatchOperation {
+    op_type: String,
+    path: String,
+    move_to: String,
+    content: String,
+    hunks: Vec<PatchHunk>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PatchHunk {
+    context: String,
+    lines: Vec<PatchLine>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PatchLine {
+    op: String,
+    text: String,
+}
+
+impl ToolCompatContext {
+    pub fn from_request(body: &Value) -> Self {
+        body.get("tools")
+            .and_then(|value| value.as_array())
+            .map(|tools| Self::from_tools(tools))
+            .unwrap_or_default()
+    }
+
+    pub fn from_tools(tools: &[Value]) -> Self {
+        let mut ctx = Self::default();
+
+        for raw_tool in tools {
+            if let Some(name) = raw_tool.as_str().filter(|name| !name.is_empty()) {
+                if let Some(action) = proxy_action_from_name(name) {
+                    if name.starts_with("apply_patch_") {
+                        ctx.custom_tools.insert(
+                            name.to_string(),
+                            CustomToolSpec {
+                                upstream_name: "apply_patch".to_string(),
+                                kind: CustomToolKind::ApplyPatch,
+                                proxy_action: Some(action),
+                            },
+                        );
+                    } else {
+                        ctx.custom_tools.insert(
+                            name.to_string(),
+                            CustomToolSpec {
+                                upstream_name: name.to_string(),
+                                kind: CustomToolKind::Raw,
+                                proxy_action: None,
+                            },
+                        );
+                    }
+                } else {
+                    ctx.custom_tools.insert(
+                        name.to_string(),
+                        CustomToolSpec {
+                            upstream_name: name.to_string(),
+                            kind: CustomToolKind::Raw,
+                            proxy_action: None,
+                        },
+                    );
+                }
+                ctx.has_custom_tools = true;
+                continue;
+            }
+
+            let Some(tool) = raw_tool.as_object() else {
+                continue;
+            };
+            let tool_type = tool
+                .get("type")
+                .and_then(|value| value.as_str())
+                .unwrap_or("");
+            match tool_type {
+                "custom" => ctx.add_custom_tool(tool),
+                "function" => {
+                    if let Some(name) = extract_tool_name(tool) {
+                        ctx.function_tools.insert(
+                            name.clone(),
+                            FunctionToolSpec {
+                                namespace: None,
+                                name,
+                            },
+                        );
+                    }
+                }
+                "namespace" => ctx.add_namespace_tool(tool),
+                "web_search" | "local_shell" | "computer_use" => {
+                    let name = extract_tool_name(tool).unwrap_or_else(|| tool_type.to_string());
+                    ctx.custom_tools.insert(
+                        name.clone(),
+                        CustomToolSpec {
+                            upstream_name: name,
+                            kind: CustomToolKind::BuiltIn,
+                            proxy_action: None,
+                        },
+                    );
+                    ctx.has_custom_tools = true;
+                }
+                _ => {}
+            }
+        }
+
+        ctx
+    }
+
+    pub fn convert_tools_to_chat(&self, tools: &[Value]) -> Vec<Value> {
+        if !self.has_custom_tools && !self.has_namespace_tools {
+            return tools
+                .iter()
+                .filter_map(simple_responses_tool_to_chat_tool)
+                .collect();
+        }
+
+        let mut result = Vec::new();
+        let mut seen_patch_roots = BTreeMap::<String, bool>::new();
+
+        for raw_tool in tools {
+            if let Some(name) = raw_tool.as_str().filter(|name| !name.is_empty()) {
+                result.push(generic_custom_proxy_tool(name, None));
+                continue;
+            }
+
+            let Some(tool) = raw_tool.as_object() else {
+                continue;
+            };
+            let tool_type = tool
+                .get("type")
+                .and_then(|value| value.as_str())
+                .unwrap_or("");
+            match tool_type {
+                "function" => {
+                    if let Some(value) = simple_responses_tool_to_chat_tool(raw_tool) {
+                        result.push(value);
+                    }
+                }
+                "namespace" => result.extend(self.namespace_tools_to_chat(tool)),
+                "custom" | "web_search" | "local_shell" | "computer_use" => {
+                    let name = extract_tool_name(tool).unwrap_or_else(|| tool_type.to_string());
+                    let description = extract_tool_description(tool);
+                    let spec = self.custom_tools.get(&name);
+                    if matches!(spec.map(|spec| spec.kind), Some(CustomToolKind::ApplyPatch)) {
+                        if seen_patch_roots.insert(name.clone(), true).is_none() {
+                            result.extend(apply_patch_proxy_tools(&name, description.as_deref()));
+                        }
+                    } else {
+                        result.push(generic_custom_proxy_tool(&name, description.as_deref()));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        result
+    }
+
+    pub fn convert_tool_choice(&self, tool_choice: &Value) -> Option<Value> {
+        let Some(obj) = tool_choice.as_object() else {
+            return Some(tool_choice.clone());
+        };
+        let choice_type = obj
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        match choice_type {
+            "function" => {
+                if let Some(namespace) = obj.get("namespace").and_then(|value| value.as_str()) {
+                    let name = obj
+                        .get("name")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("");
+                    return Some(chat_function_choice(&flatten_namespace_tool_name(
+                        namespace, name,
+                    )));
+                }
+                if let Some(function) = obj.get("function").and_then(|value| value.as_object()) {
+                    if let Some(namespace) = function.get("namespace").and_then(|v| v.as_str()) {
+                        let name = function.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                        return Some(chat_function_choice(&flatten_namespace_tool_name(
+                            namespace, name,
+                        )));
+                    }
+                    if let Some(name) = function.get("name").and_then(|v| v.as_str()) {
+                        return Some(chat_function_choice(name));
+                    }
+                }
+                let name = obj
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                Some(chat_function_choice(name))
+            }
+            "custom" => {
+                let name = obj
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                let spec = self.custom_tools.get(name)?;
+                let upstream = if spec.kind == CustomToolKind::ApplyPatch {
+                    format!("{}_batch", spec.upstream_name)
+                } else {
+                    spec.upstream_name.clone()
+                };
+                Some(chat_function_choice(&upstream))
+            }
+            _ => Some(tool_choice.clone()),
+        }
+    }
+
+    pub fn custom_history_arguments(&self, original_name: &str, input: &str) -> (String, String) {
+        let Some(spec) = self.custom_tools.get(original_name) else {
+            return (
+                original_name.to_string(),
+                serde_json::to_string(&json!({ "input": input })).unwrap_or_else(|_| "{}".into()),
+            );
+        };
+
+        if spec.kind != CustomToolKind::ApplyPatch {
+            return (
+                spec.upstream_name.clone(),
+                serde_json::to_string(&json!({ "input": input })).unwrap_or_else(|_| "{}".into()),
+            );
+        }
+
+        let Some(ops) = parse_patch_operations(input).filter(|ops| !ops.is_empty()) else {
+            return (
+                format!("{}_batch", spec.upstream_name),
+                serde_json::to_string(&json!({
+                    "operations": [],
+                    "raw_patch": input
+                }))
+                .unwrap_or_else(|_| "{}".into()),
+            );
+        };
+
+        if ops.len() == 1 {
+            let action = choose_single_proxy_action(&ops[0].op_type);
+            return (
+                format!("{}_{}", spec.upstream_name, action),
+                single_patch_operation_args(&ops[0]),
+            );
+        }
+
+        (
+            format!("{}_batch", spec.upstream_name),
+            batch_patch_operations_args(&ops),
+        )
+    }
+
+    pub fn flatten_response_function_name(&self, item: &Value) -> String {
+        let namespace = item.get("namespace").and_then(|value| value.as_str());
+        let name = item
+            .get("name")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        namespace
+            .map(|namespace| flatten_namespace_tool_name(namespace, name))
+            .unwrap_or_else(|| name.to_string())
+    }
+
+    pub fn custom_response_item(
+        &self,
+        call_id: &str,
+        upstream_name: &str,
+        raw_arguments: &str,
+    ) -> Option<Value> {
+        let spec = self.custom_tools.get(upstream_name)?;
+        let input = self.reconstruct_custom_input(upstream_name, raw_arguments);
+        Some(json!({
+            "id": format!("ctc_{call_id}"),
+            "type": "custom_tool_call",
+            "status": "completed",
+            "call_id": call_id,
+            "name": spec.upstream_name,
+            "input": input
+        }))
+    }
+
+    pub fn apply_namespace_to_response_item(&self, item: &mut Value) {
+        let Some(name) = item.get("name").and_then(|value| value.as_str()) else {
+            return;
+        };
+        let Some(spec) = self.function_tools.get(name) else {
+            return;
+        };
+        let Some(namespace) = spec.namespace.as_deref() else {
+            return;
+        };
+        item["name"] = json!(spec.name);
+        item["namespace"] = json!(namespace);
+    }
+
+    pub fn is_custom_proxy(&self, upstream_name: &str) -> bool {
+        self.custom_tools.contains_key(upstream_name)
+    }
+
+    pub fn original_custom_name(&self, upstream_name: &str) -> String {
+        self.custom_tools
+            .get(upstream_name)
+            .map(|spec| spec.upstream_name.clone())
+            .unwrap_or_else(|| upstream_name.to_string())
+    }
+
+    pub fn reconstruct_custom_input(&self, upstream_name: &str, raw_arguments: &str) -> String {
+        let Some(spec) = self.custom_tools.get(upstream_name) else {
+            return raw_arguments.to_string();
+        };
+
+        if spec.kind == CustomToolKind::ApplyPatch {
+            let action = spec
+                .proxy_action
+                .or_else(|| proxy_action_from_name(upstream_name))
+                .unwrap_or("");
+            return apply_patch_input_from_proxy_arguments(raw_arguments, action);
+        }
+
+        serde_json::from_str::<Value>(raw_arguments)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("input")
+                    .and_then(|input| input.as_str())
+                    .map(ToString::to_string)
+            })
+            .unwrap_or_else(|| raw_arguments.to_string())
+    }
+
+    fn add_custom_tool(&mut self, tool: &Map<String, Value>) {
+        let Some(name) = extract_tool_name(tool) else {
+            return;
+        };
+        let kind = detect_custom_tool_kind(tool);
+        let spec = CustomToolSpec {
+            upstream_name: name.clone(),
+            kind,
+            proxy_action: None,
+        };
+        if kind == CustomToolKind::ApplyPatch {
+            self.custom_tools.insert(name.clone(), spec.clone());
+            for action in [
+                "add_file",
+                "delete_file",
+                "update_file",
+                "replace_file",
+                "batch",
+            ] {
+                let mut proxy_spec = spec.clone();
+                proxy_spec.proxy_action = Some(action);
+                self.custom_tools
+                    .insert(format!("{name}_{action}"), proxy_spec);
+            }
+        } else {
+            self.custom_tools.insert(name, spec);
+        }
+        self.has_custom_tools = true;
+    }
+
+    fn add_namespace_tool(&mut self, tool: &Map<String, Value>) {
+        let namespace = extract_tool_name(tool).unwrap_or_default();
+        let Some(children) = tool.get("tools").and_then(|value| value.as_array()) else {
+            return;
+        };
+
+        for child in children {
+            let Some(child_obj) = child.as_object() else {
+                continue;
+            };
+            if child_obj.get("type").and_then(|value| value.as_str()) != Some("function") {
+                continue;
+            }
+            let Some(name) = extract_tool_name(child_obj) else {
+                continue;
+            };
+            let flat = flatten_namespace_tool_name(&namespace, &name);
+            if self
+                .function_tools
+                .get(&flat)
+                .and_then(|spec| spec.namespace.as_deref())
+                .is_none()
+                && self.function_tools.contains_key(&flat)
+            {
+                continue;
+            }
+            self.function_tools.insert(
+                flat,
+                FunctionToolSpec {
+                    namespace: (!namespace.is_empty()).then_some(namespace.clone()),
+                    name,
+                },
+            );
+            self.has_namespace_tools = true;
+        }
+    }
+
+    fn namespace_tools_to_chat(&self, tool: &Map<String, Value>) -> Vec<Value> {
+        let namespace = extract_tool_name(tool).unwrap_or_default();
+        let namespace_description = extract_tool_description(tool);
+        let Some(children) = tool.get("tools").and_then(|value| value.as_array()) else {
+            return Vec::new();
+        };
+
+        children
+            .iter()
+            .filter_map(|child| {
+                let child_obj = child.as_object()?;
+                if child_obj.get("type").and_then(|value| value.as_str()) != Some("function") {
+                    return None;
+                }
+                let name = extract_tool_name(child_obj)?;
+                let flat = flatten_namespace_tool_name(&namespace, &name);
+                if !namespace.is_empty()
+                    && self
+                        .function_tools
+                        .get(&flat)
+                        .and_then(|spec| spec.namespace.as_deref())
+                        .is_none()
+                {
+                    return None;
+                }
+
+                let (_, child_description, parameters, strict) =
+                    extract_responses_tool_fields(child_obj);
+                let combined = combine_namespace_description(
+                    namespace_description.as_deref(),
+                    child_description.as_deref(),
+                );
+                Some(function_tool(
+                    &flat,
+                    combined.as_deref(),
+                    parameters,
+                    strict,
+                ))
+            })
+            .collect()
+    }
+}
+
+fn simple_responses_tool_to_chat_tool(tool: &Value) -> Option<Value> {
+    let obj = tool.as_object()?;
+    if obj.get("type").and_then(|value| value.as_str()) != Some("function") {
+        return None;
+    }
+
+    if obj.get("function").is_some() {
+        let mut chat_tool = tool.clone();
+        if let Some(strict) = obj.get("strict").cloned() {
+            if let Some(function) = chat_tool
+                .get_mut("function")
+                .and_then(|value| value.as_object_mut())
+            {
+                function.entry("strict".to_string()).or_insert(strict);
+            }
+            if let Some(obj) = chat_tool.as_object_mut() {
+                obj.remove("strict");
+            }
+        }
+        return Some(chat_tool);
+    }
+
+    let (name, description, parameters, strict) = extract_responses_tool_fields(obj);
+    Some(function_tool(
+        &name,
+        description.as_deref(),
+        parameters,
+        strict,
+    ))
+}
+
+fn extract_responses_tool_fields(
+    obj: &Map<String, Value>,
+) -> (String, Option<String>, Value, Option<Value>) {
+    if let Some(function) = obj.get("function").and_then(|value| value.as_object()) {
+        return (
+            function
+                .get("name")
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+                .to_string(),
+            function
+                .get("description")
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string),
+            function
+                .get("parameters")
+                .cloned()
+                .unwrap_or_else(|| json!({})),
+            function
+                .get("strict")
+                .cloned()
+                .or_else(|| obj.get("strict").cloned()),
+        );
+    }
+
+    (
+        obj.get("name")
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .to_string(),
+        obj.get("description")
+            .and_then(|value| value.as_str())
+            .map(ToString::to_string),
+        obj.get("parameters").cloned().unwrap_or_else(|| json!({})),
+        obj.get("strict").cloned(),
+    )
+}
+
+fn extract_tool_name(obj: &Map<String, Value>) -> Option<String> {
+    let name = extract_responses_tool_fields(obj).0;
+    (!name.trim().is_empty()).then_some(name)
+}
+
+fn extract_tool_description(obj: &Map<String, Value>) -> Option<String> {
+    extract_responses_tool_fields(obj).1
+}
+
+fn detect_custom_tool_kind(tool: &Map<String, Value>) -> CustomToolKind {
+    let name = extract_tool_name(tool).unwrap_or_default();
+    let grammar = tool
+        .get("format")
+        .and_then(|value| value.get("definition"))
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    if name == "apply_patch"
+        || (grammar.contains("begin_patch")
+            && grammar.contains("end_patch")
+            && grammar.contains("add_hunk"))
+    {
+        CustomToolKind::ApplyPatch
+    } else {
+        CustomToolKind::Raw
+    }
+}
+
+fn flatten_namespace_tool_name(namespace: &str, name: &str) -> String {
+    if namespace.is_empty() {
+        return name.to_string();
+    }
+    if name.is_empty() {
+        return namespace.to_string();
+    }
+    if namespace.ends_with("__") || name.starts_with("__") {
+        format!("{namespace}{name}")
+    } else {
+        format!("{namespace}__{name}")
+    }
+}
+
+fn combine_namespace_description(
+    namespace_description: Option<&str>,
+    child_description: Option<&str>,
+) -> Option<String> {
+    let namespace_description = namespace_description.unwrap_or("").trim();
+    let child_description = child_description.unwrap_or("").trim();
+    match (
+        namespace_description.is_empty(),
+        child_description.is_empty(),
+    ) {
+        (true, true) => None,
+        (true, false) => Some(child_description.to_string()),
+        (false, true) => Some(namespace_description.to_string()),
+        (false, false) => Some(format!("{namespace_description}\n\n{child_description}")),
+    }
+}
+
+fn generic_custom_proxy_tool(name: &str, description: Option<&str>) -> Value {
+    let description = match description.filter(|value| !value.trim().is_empty()) {
+        Some(description) => {
+            format!("{description}\n\nThis is a FREEFORM tool. Do not wrap the input in JSON or markdown.")
+        }
+        None => format!("FREEFORM custom tool: {name}. Put only the tool input text here."),
+    };
+
+    function_tool(
+        name,
+        Some(&description),
+        json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "input": {
+                    "type": "string",
+                    "description": "Raw freeform input for this custom tool."
+                }
+            },
+            "required": ["input"]
+        }),
+        None,
+    )
+}
+
+fn function_tool(
+    name: &str,
+    description: Option<&str>,
+    parameters: Value,
+    strict: Option<Value>,
+) -> Value {
+    let mut function = json!({
+        "name": name,
+        "parameters": parameters
+    });
+    if let Some(description) = description.filter(|value| !value.is_empty()) {
+        function["description"] = json!(description);
+    }
+    if let Some(strict) = strict {
+        function["strict"] = strict;
+    }
+    json!({
+        "type": "function",
+        "function": function
+    })
+}
+
+fn apply_patch_proxy_tools(name: &str, description: Option<&str>) -> Vec<Value> {
+    vec![
+        function_tool(
+            &format!("{name}_add_file"),
+            Some(&patch_proxy_description(
+                description,
+                "add_file",
+                "Create one new file by providing a target path and full file content.",
+            )),
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "path": {"type": "string", "description": "Target file path."},
+                    "content": {"type": "string", "description": "Full file content without patch '+' prefixes."}
+                },
+                "required": ["path", "content"]
+            }),
+            None,
+        ),
+        function_tool(
+            &format!("{name}_delete_file"),
+            Some(&patch_proxy_description(
+                description,
+                "delete_file",
+                "Delete one file by providing a target path.",
+            )),
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "path": {"type": "string", "description": "Target file path."}
+                },
+                "required": ["path"]
+            }),
+            None,
+        ),
+        function_tool(
+            &format!("{name}_update_file"),
+            Some(&patch_proxy_description(
+                description,
+                "update_file",
+                "Edit one existing file with structured hunks.",
+            )),
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "path": {"type": "string", "description": "Target file path."},
+                    "move_to": {"type": "string", "description": "Optional destination path for move operations."},
+                    "hunks": patch_hunks_schema()
+                },
+                "required": ["path", "hunks"]
+            }),
+            None,
+        ),
+        function_tool(
+            &format!("{name}_replace_file"),
+            Some(&patch_proxy_description(
+                description,
+                "replace_file",
+                "Replace one existing file by providing a target path and full new file content.",
+            )),
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "path": {"type": "string", "description": "Target file path."},
+                    "content": {"type": "string", "description": "Full replacement content."}
+                },
+                "required": ["path", "content"]
+            }),
+            None,
+        ),
+        function_tool(
+            &format!("{name}_batch"),
+            Some(&patch_proxy_description(
+                description,
+                "batch",
+                "Edit files by providing structured JSON patch operations.",
+            )),
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "operations": {
+                        "type": "array",
+                        "description": "Ordered list of file patch operations.",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "type": {"type": "string", "enum": ["add_file", "delete_file", "update_file", "replace_file"]},
+                                "path": {"type": "string"},
+                                "move_to": {"type": "string", "description": "Optional destination path for move operations."},
+                                "content": {"type": "string", "description": "Full file content for add_file / replace_file."},
+                                "hunks": patch_hunks_schema()
+                            },
+                            "required": ["type", "path"]
+                        }
+                    }
+                },
+                "required": ["operations"]
+            }),
+            None,
+        ),
+    ]
+}
+
+fn patch_proxy_description(description: Option<&str>, action: &str, fallback: &str) -> String {
+    match description.filter(|value| !value.trim().is_empty()) {
+        Some(description) => format!("{description} (proxy action: {action})"),
+        None => fallback.to_string(),
+    }
+}
+
+fn patch_hunks_schema() -> Value {
+    json!({
+        "type": "array",
+        "description": "Structured update hunks.",
+        "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "context": {"type": "string", "description": "Optional @@ context header text."},
+                "lines": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "op": {"type": "string", "enum": ["context", "add", "remove"]},
+                            "text": {"type": "string"}
+                        },
+                        "required": ["op", "text"]
+                    }
+                }
+            },
+            "required": ["lines"]
+        }
+    })
+}
+
+fn chat_function_choice(name: &str) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": name
+        }
+    })
+}
+
+fn proxy_action_from_name(name: &str) -> Option<&'static str> {
+    if name.ends_with("_add_file") {
+        Some("add_file")
+    } else if name.ends_with("_delete_file") {
+        Some("delete_file")
+    } else if name.ends_with("_update_file") {
+        Some("update_file")
+    } else if name.ends_with("_replace_file") {
+        Some("replace_file")
+    } else if name.ends_with("_batch") {
+        Some("batch")
+    } else {
+        None
+    }
+}
+
+fn apply_patch_input_from_proxy_arguments(raw_arguments: &str, action: &str) -> String {
+    let Ok(mut parsed) = serde_json::from_str::<Value>(raw_arguments) else {
+        return raw_arguments.to_string();
+    };
+
+    if !action.is_empty() {
+        if let Some(input) = parsed.get("input").and_then(|value| value.as_str()) {
+            if let Ok(nested) = serde_json::from_str::<Value>(input) {
+                if let (Some(parsed_obj), Some(nested_obj)) =
+                    (parsed.as_object_mut(), nested.as_object())
+                {
+                    for (key, value) in nested_obj {
+                        parsed_obj
+                            .entry(key.clone())
+                            .or_insert_with(|| value.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let Some(obj) = parsed.as_object() else {
+        return raw_arguments.to_string();
+    };
+
+    let mut ops = Vec::new();
+    match action {
+        "add_file" => ops.push(PatchOperation {
+            op_type: "add_file".to_string(),
+            path: string_field(obj, "path"),
+            content: string_field(obj, "content"),
+            ..Default::default()
+        }),
+        "delete_file" => ops.push(PatchOperation {
+            op_type: "delete_file".to_string(),
+            path: string_field(obj, "path"),
+            ..Default::default()
+        }),
+        "update_file" => ops.push(PatchOperation {
+            op_type: "update_file".to_string(),
+            path: string_field(obj, "path"),
+            move_to: string_field(obj, "move_to"),
+            hunks: parse_hunks_value(obj.get("hunks")),
+            ..Default::default()
+        }),
+        "replace_file" => ops.push(PatchOperation {
+            op_type: "replace_file".to_string(),
+            path: string_field(obj, "path"),
+            content: string_field(obj, "content"),
+            ..Default::default()
+        }),
+        "batch" => {
+            if let Some(items) = obj.get("operations").and_then(|value| value.as_array()) {
+                for item in items {
+                    let Some(item_obj) = item.as_object() else {
+                        continue;
+                    };
+                    ops.push(PatchOperation {
+                        op_type: string_field(item_obj, "type"),
+                        path: string_field(item_obj, "path"),
+                        move_to: string_field(item_obj, "move_to"),
+                        content: string_field(item_obj, "content"),
+                        hunks: parse_hunks_value(item_obj.get("hunks")),
+                    });
+                }
+            }
+        }
+        _ => {
+            return obj
+                .get("input")
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string)
+                .unwrap_or_else(|| raw_arguments.to_string());
+        }
+    }
+
+    if ops.is_empty() {
+        raw_arguments.to_string()
+    } else {
+        build_patch_input(&ops)
+    }
+}
+
+fn parse_patch_operations(input: &str) -> Option<Vec<PatchOperation>> {
+    if input.is_empty() || !input.starts_with("*** Begin Patch") {
+        return None;
+    }
+
+    let mut ops = Vec::<PatchOperation>::new();
+    let mut current: Option<PatchOperation> = None;
+
+    for raw_line in input.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        if line == "*** Begin Patch" || line == "*** End Patch" {
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Add File: ") {
+            if let Some(op) = current.take() {
+                ops.push(op);
+            }
+            current = Some(PatchOperation {
+                op_type: "add_file".to_string(),
+                path: path.to_string(),
+                ..Default::default()
+            });
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Delete File: ") {
+            if let Some(op) = current.take() {
+                ops.push(op);
+            }
+            current = Some(PatchOperation {
+                op_type: "delete_file".to_string(),
+                path: path.to_string(),
+                ..Default::default()
+            });
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Update File: ") {
+            if let Some(op) = current.take() {
+                ops.push(op);
+            }
+            current = Some(PatchOperation {
+                op_type: "update_file".to_string(),
+                path: path.to_string(),
+                ..Default::default()
+            });
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("*** Move to: ") {
+            if let Some(op) = current.as_mut().filter(|op| op.op_type == "update_file") {
+                op.move_to = path.to_string();
+            }
+            continue;
+        }
+
+        if line.starts_with("@@") {
+            if let Some(op) = current.as_mut().filter(|op| op.op_type == "update_file") {
+                op.hunks.push(PatchHunk {
+                    context: line.trim_start_matches("@@").trim().to_string(),
+                    lines: Vec::new(),
+                });
+            }
+            continue;
+        }
+
+        if let Some(op) = current.as_mut() {
+            match op.op_type.as_str() {
+                "add_file" => {
+                    if let Some(text) = line.strip_prefix('+') {
+                        op.content.push_str(text);
+                        op.content.push('\n');
+                    }
+                }
+                "update_file" => {
+                    if let Some(hunk) = op.hunks.last_mut() {
+                        if let Some((prefix, op_name)) = line_op_from_prefix(line) {
+                            hunk.lines.push(PatchLine {
+                                op: op_name.to_string(),
+                                text: line.strip_prefix(prefix).unwrap_or(line).to_string(),
+                            });
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if let Some(op) = current {
+        ops.push(op);
+    }
+
+    (!ops.is_empty()).then_some(ops)
+}
+
+fn build_patch_input(ops: &[PatchOperation]) -> String {
+    let mut out = String::from("*** Begin Patch\n");
+    for op in ops {
+        match op.op_type.as_str() {
+            "add_file" => {
+                out.push_str("*** Add File: ");
+                out.push_str(&op.path);
+                out.push('\n');
+                write_added_content(&mut out, &op.content);
+            }
+            "delete_file" => {
+                out.push_str("*** Delete File: ");
+                out.push_str(&op.path);
+                out.push('\n');
+            }
+            "update_file" => {
+                out.push_str("*** Update File: ");
+                out.push_str(&op.path);
+                out.push('\n');
+                if !op.move_to.is_empty() {
+                    out.push_str("*** Move to: ");
+                    out.push_str(&op.move_to);
+                    out.push('\n');
+                }
+                for hunk in &op.hunks {
+                    if hunk.context.is_empty() {
+                        out.push_str("@@\n");
+                    } else {
+                        out.push_str("@@ ");
+                        out.push_str(&hunk.context);
+                        out.push('\n');
+                    }
+                    for line in &hunk.lines {
+                        out.push_str(line_op_prefix(&line.op));
+                        out.push_str(&line.text);
+                        out.push('\n');
+                    }
+                }
+            }
+            "replace_file" => {
+                out.push_str("*** Delete File: ");
+                out.push_str(&op.path);
+                out.push('\n');
+                out.push_str("*** Add File: ");
+                out.push_str(&op.path);
+                out.push('\n');
+                write_added_content(&mut out, &op.content);
+            }
+            _ => {}
+        }
+    }
+    out.push_str("*** End Patch");
+    out
+}
+
+fn write_added_content(out: &mut String, content: &str) {
+    let content = content.trim_end_matches('\n');
+    if content.is_empty() {
+        return;
+    }
+    for line in content.split('\n') {
+        out.push('+');
+        out.push_str(line);
+        out.push('\n');
+    }
+}
+
+fn single_patch_operation_args(op: &PatchOperation) -> String {
+    let value = match op.op_type.as_str() {
+        "add_file" | "replace_file" => json!({
+            "path": op.path,
+            "content": op.content
+        }),
+        "delete_file" => json!({
+            "path": op.path
+        }),
+        "update_file" => {
+            let mut value = json!({
+                "path": op.path,
+                "hunks": hunks_to_value(&op.hunks)
+            });
+            if !op.move_to.is_empty() {
+                value["move_to"] = json!(op.move_to);
+            }
+            value
+        }
+        _ => json!({
+            "path": op.path
+        }),
+    };
+    canonical_json_string(&value)
+}
+
+fn batch_patch_operations_args(ops: &[PatchOperation]) -> String {
+    let operations = ops
+        .iter()
+        .map(|op| {
+            let mut value = json!({
+                "type": op.op_type,
+                "path": op.path
+            });
+            if !op.move_to.is_empty() {
+                value["move_to"] = json!(op.move_to);
+            }
+            if !op.content.is_empty() {
+                value["content"] = json!(op.content);
+            }
+            if !op.hunks.is_empty() {
+                value["hunks"] = hunks_to_value(&op.hunks);
+            }
+            value
+        })
+        .collect::<Vec<_>>();
+    canonical_json_string(&json!({ "operations": operations }))
+}
+
+fn hunks_to_value(hunks: &[PatchHunk]) -> Value {
+    Value::Array(
+        hunks
+            .iter()
+            .map(|hunk| {
+                json!({
+                    "context": hunk.context,
+                    "lines": hunk.lines.iter().map(|line| {
+                        json!({
+                            "op": line.op,
+                            "text": line.text
+                        })
+                    }).collect::<Vec<_>>()
+                })
+            })
+            .collect(),
+    )
+}
+
+fn parse_hunks_value(raw: Option<&Value>) -> Vec<PatchHunk> {
+    raw.and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let obj = item.as_object()?;
+                    Some(PatchHunk {
+                        context: string_field(obj, "context"),
+                        lines: obj
+                            .get("lines")
+                            .and_then(|value| value.as_array())
+                            .map(|lines| {
+                                lines
+                                    .iter()
+                                    .filter_map(|line| {
+                                        let obj = line.as_object()?;
+                                        Some(PatchLine {
+                                            op: string_field(obj, "op"),
+                                            text: string_field(obj, "text"),
+                                        })
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn choose_single_proxy_action(op_type: &str) -> &'static str {
+    match op_type {
+        "add_file" => "add_file",
+        "delete_file" => "delete_file",
+        "update_file" => "update_file",
+        "replace_file" => "replace_file",
+        _ => "batch",
+    }
+}
+
+fn string_field(obj: &Map<String, Value>, key: &str) -> String {
+    obj.get(key)
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn line_op_prefix(op: &str) -> &'static str {
+    match op {
+        "add" => "+",
+        "remove" | "delete" => "-",
+        _ => " ",
+    }
+}
+
+fn line_op_from_prefix(line: &str) -> Option<(&str, &'static str)> {
+    if line.starts_with(' ') {
+        Some((" ", "context"))
+    } else if line.starts_with('+') {
+        Some(("+", "add"))
+    } else if line.starts_with('-') {
+        Some(("-", "remove"))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_custom_and_namespace_tools_to_chat_functions() {
+        let tools = vec![
+            json!({
+                "type": "custom",
+                "name": "apply_patch",
+                "description": "Patch files"
+            }),
+            json!({
+                "type": "namespace",
+                "name": "mcp__editor__",
+                "description": "Editor actions",
+                "tools": [{
+                    "type": "function",
+                    "name": "save_all",
+                    "description": "Save files",
+                    "parameters": {"type": "object"}
+                }]
+            }),
+            json!("exec_command"),
+        ];
+
+        let ctx = ToolCompatContext::from_tools(&tools);
+        let converted = ctx.convert_tools_to_chat(&tools);
+        let names = converted
+            .iter()
+            .map(|tool| tool["function"]["name"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"apply_patch_add_file".to_string()));
+        assert!(names.contains(&"apply_patch_batch".to_string()));
+        assert!(names.contains(&"mcp__editor__save_all".to_string()));
+        assert!(names.contains(&"exec_command".to_string()));
+    }
+
+    #[test]
+    fn rebuilds_patch_input_from_proxy_arguments() {
+        let ctx = ToolCompatContext::from_tools(&[json!({
+            "type": "custom",
+            "name": "apply_patch"
+        })]);
+
+        let item = ctx
+            .custom_response_item(
+                "call_1",
+                "apply_patch_add_file",
+                r##"{"path":"docs/test.md","content":"# Test\n"}"##,
+            )
+            .unwrap();
+
+        assert_eq!(item["type"], "custom_tool_call");
+        assert_eq!(item["name"], "apply_patch");
+        assert_eq!(
+            item["input"],
+            "*** Begin Patch\n*** Add File: docs/test.md\n+# Test\n*** End Patch"
+        );
+        assert!(item.get("arguments").is_none());
+    }
+
+    #[test]
+    fn restores_string_patch_proxy_tool_calls() {
+        let ctx = ToolCompatContext::from_tools(&[
+            json!("apply_patch_add_file"),
+            json!("apply_patch_batch"),
+            json!("exec_command"),
+        ]);
+
+        let patch_item = ctx
+            .custom_response_item(
+                "call_patch",
+                "apply_patch_add_file",
+                r##"{"path":"docs/test.md","content":"# Test\n"}"##,
+            )
+            .unwrap();
+        let exec_item = ctx
+            .custom_response_item(
+                "call_exec",
+                "exec_command",
+                r##"{"input":"Get-ChildItem"}"##,
+            )
+            .unwrap();
+
+        assert_eq!(patch_item["name"], "apply_patch");
+        assert_eq!(
+            patch_item["input"],
+            "*** Begin Patch\n*** Add File: docs/test.md\n+# Test\n*** End Patch"
+        );
+        assert_eq!(exec_item["name"], "exec_command");
+        assert_eq!(exec_item["input"], "Get-ChildItem");
+    }
+
+    #[test]
+    fn converts_builtin_tools_to_generic_function_proxies() {
+        let tools = vec![
+            json!({"type": "web_search"}),
+            json!({"type": "local_shell", "name": "shell"}),
+            json!({"type": "computer_use", "name": "desktop"}),
+        ];
+        let ctx = ToolCompatContext::from_tools(&tools);
+        let converted = ctx.convert_tools_to_chat(&tools);
+        let names = converted
+            .iter()
+            .map(|tool| tool["function"]["name"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"web_search".to_string()));
+        assert!(names.contains(&"shell".to_string()));
+        assert!(names.contains(&"desktop".to_string()));
+    }
+
+    #[test]
+    fn maps_history_custom_call_to_proxy_arguments() {
+        let ctx = ToolCompatContext::from_tools(&[json!({
+            "type": "custom",
+            "name": "apply_patch"
+        })]);
+
+        let (name, args) = ctx.custom_history_arguments(
+            "apply_patch",
+            "*** Begin Patch\n*** Add File: docs/test.md\n+# Test\n*** End Patch",
+        );
+        let args_value: Value = serde_json::from_str(&args).unwrap();
+
+        assert_eq!(name, "apply_patch_add_file");
+        assert_eq!(args_value["path"], "docs/test.md");
+        assert_eq!(args_value["content"], "# Test\n");
+    }
+
+    #[test]
+    fn restores_namespace_on_response_items() {
+        let ctx = ToolCompatContext::from_tools(&[json!({
+            "type": "namespace",
+            "name": "mcp__editor__",
+            "tools": [{
+                "type": "function",
+                "name": "save_all",
+                "parameters": {"type": "object"}
+            }]
+        })]);
+        let mut item = json!({
+            "type": "function_call",
+            "name": "mcp__editor__save_all",
+            "arguments": "{}"
+        });
+
+        ctx.apply_namespace_to_response_item(&mut item);
+
+        assert_eq!(item["name"], "save_all");
+        assert_eq!(item["namespace"], "mcp__editor__");
+    }
+
+    #[test]
+    fn converts_custom_tool_choice_to_proxy_function() {
+        let ctx = ToolCompatContext::from_tools(&[json!({
+            "type": "custom",
+            "name": "apply_patch"
+        })]);
+
+        let choice = ctx
+            .convert_tool_choice(&json!({"type": "custom", "name": "apply_patch"}))
+            .unwrap();
+
+        assert_eq!(choice["function"]["name"], "apply_patch_batch");
+    }
+}

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -7,6 +7,8 @@
 use crate::proxy::{error::ProxyError, json_canonical::canonical_json_string};
 use serde_json::{json, Value};
 
+use super::tool_compat::ToolCompatContext;
+
 const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
     "frequency_penalty",
     "logit_bias",
@@ -28,6 +30,13 @@ const THINK_CLOSE_TAG: &str = "</think>";
 
 /// Convert an OpenAI Responses request into an OpenAI Chat Completions request.
 pub fn responses_to_chat_completions(body: Value) -> Result<Value, ProxyError> {
+    responses_to_chat_completions_with_context(body, None)
+}
+
+pub fn responses_to_chat_completions_with_context(
+    body: Value,
+    tool_ctx: Option<&ToolCompatContext>,
+) -> Result<Value, ProxyError> {
     let mut result = json!({});
 
     if let Some(model) = body.get("model") {
@@ -46,7 +55,7 @@ pub fn responses_to_chat_completions(body: Value) -> Result<Value, ProxyError> {
     }
 
     if let Some(input) = body.get("input") {
-        append_responses_input_as_chat_messages(input, &mut messages)?;
+        append_responses_input_as_chat_messages(input, &mut messages, tool_ctx)?;
     }
     result["messages"] = json!(messages);
 
@@ -78,17 +87,25 @@ pub fn responses_to_chat_completions(body: Value) -> Result<Value, ProxyError> {
     }
 
     if let Some(tools) = body.get("tools").and_then(|v| v.as_array()) {
-        let tools: Vec<Value> = tools
-            .iter()
-            .filter_map(responses_tool_to_chat_tool)
-            .collect();
+        let tools: Vec<Value> = tool_ctx
+            .map(|ctx| ctx.convert_tools_to_chat(tools))
+            .unwrap_or_else(|| {
+                tools
+                    .iter()
+                    .filter_map(responses_tool_to_chat_tool)
+                    .collect()
+            });
         if !tools.is_empty() {
             result["tools"] = json!(tools);
         }
     }
 
     if let Some(tool_choice) = body.get("tool_choice") {
-        result["tool_choice"] = responses_tool_choice_to_chat(tool_choice);
+        if let Some(converted) = tool_ctx.and_then(|ctx| ctx.convert_tool_choice(tool_choice)) {
+            result["tool_choice"] = converted;
+        } else if tool_ctx.is_none() {
+            result["tool_choice"] = responses_tool_choice_to_chat(tool_choice);
+        }
     }
 
     for key in EXTRA_CHAT_PASSTHROUGH_FIELDS {
@@ -120,6 +137,7 @@ fn instruction_text(value: &Value) -> String {
 fn append_responses_input_as_chat_messages(
     input: &Value,
     messages: &mut Vec<Value>,
+    tool_ctx: Option<&ToolCompatContext>,
 ) -> Result<(), ProxyError> {
     let mut pending_tool_calls = Vec::new();
 
@@ -132,11 +150,21 @@ fn append_responses_input_as_chat_messages(
         }
         Value::Array(items) => {
             for item in items {
-                append_responses_item_as_chat_message(item, messages, &mut pending_tool_calls)?;
+                append_responses_item_as_chat_message(
+                    item,
+                    messages,
+                    &mut pending_tool_calls,
+                    tool_ctx,
+                )?;
             }
         }
         Value::Object(_) => {
-            append_responses_item_as_chat_message(input, messages, &mut pending_tool_calls)?;
+            append_responses_item_as_chat_message(
+                input,
+                messages,
+                &mut pending_tool_calls,
+                tool_ctx,
+            )?;
         }
         _ => {}
     }
@@ -149,25 +177,27 @@ fn append_responses_item_as_chat_message(
     item: &Value,
     messages: &mut Vec<Value>,
     pending_tool_calls: &mut Vec<Value>,
+    tool_ctx: Option<&ToolCompatContext>,
 ) -> Result<(), ProxyError> {
     let item_type = item.get("type").and_then(|v| v.as_str());
     match item_type {
         Some("function_call") => {
-            pending_tool_calls.push(responses_function_call_to_chat_tool_call(item));
+            pending_tool_calls.push(responses_function_call_to_chat_tool_call(item, tool_ctx));
+        }
+        Some("custom_tool_call") => {
+            if let Some(ctx) = tool_ctx {
+                pending_tool_calls.push(responses_custom_tool_call_to_chat_tool_call(item, ctx));
+            }
         }
         Some("function_call_output") => {
             flush_pending_tool_calls(messages, pending_tool_calls);
-            let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
-            let output = match item.get("output") {
-                Some(Value::String(s)) => s.clone(),
-                Some(v) => canonical_json_string(v),
-                None => String::new(),
-            };
-            messages.push(json!({
-                "role": "tool",
-                "tool_call_id": call_id,
-                "content": output
-            }));
+            messages.push(responses_tool_output_to_chat_message(item));
+        }
+        Some("custom_tool_call_output") => {
+            if tool_ctx.is_some() {
+                flush_pending_tool_calls(messages, pending_tool_calls);
+                messages.push(responses_tool_output_to_chat_message(item));
+            }
         }
         Some("reasoning") => {
             // Reasoning items are Responses-specific context. Chat-only providers
@@ -188,6 +218,20 @@ fn append_responses_item_as_chat_message(
     }
 
     Ok(())
+}
+
+fn responses_tool_output_to_chat_message(item: &Value) -> Value {
+    let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
+    let output = match item.get("output") {
+        Some(Value::String(s)) => s.clone(),
+        Some(v) => canonical_json_string(v),
+        None => String::new(),
+    };
+    json!({
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": output
+    })
 }
 
 fn flush_pending_tool_calls(messages: &mut Vec<Value>, pending_tool_calls: &mut Vec<Value>) {
@@ -281,18 +325,55 @@ fn responses_content_to_chat_content(_role: &str, content: &Value) -> Value {
     Value::Array(chat_parts)
 }
 
-fn responses_function_call_to_chat_tool_call(item: &Value) -> Value {
+fn responses_function_call_to_chat_tool_call(
+    item: &Value,
+    tool_ctx: Option<&ToolCompatContext>,
+) -> Value {
+    let call_id = item
+        .get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let name = tool_ctx
+        .map(|ctx| ctx.flatten_response_function_name(item))
+        .unwrap_or_else(|| {
+            item.get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        });
+    let arguments = match item.get("arguments") {
+        Some(Value::String(s)) => s.clone(),
+        Some(v) => canonical_json_string(v),
+        None => "{}".to_string(),
+    };
+
+    json!({
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments
+        }
+    })
+}
+
+fn responses_custom_tool_call_to_chat_tool_call(
+    item: &Value,
+    tool_ctx: &ToolCompatContext,
+) -> Value {
     let call_id = item
         .get("call_id")
         .or_else(|| item.get("id"))
         .and_then(|v| v.as_str())
         .unwrap_or("");
     let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
-    let arguments = match item.get("arguments") {
-        Some(Value::String(s)) => s.clone(),
-        Some(v) => canonical_json_string(v),
-        None => "{}".to_string(),
-    };
+    let input = item
+        .get("input")
+        .and_then(|v| v.as_str())
+        .or_else(|| item.get("output").and_then(|v| v.as_str()))
+        .unwrap_or("");
+    let (name, arguments) = tool_ctx.custom_history_arguments(name, input);
 
     json!({
         "id": call_id,
@@ -356,6 +437,13 @@ fn responses_tool_choice_to_chat(tool_choice: &Value) -> Value {
 
 /// Convert a non-streaming Chat Completions response into a Responses response.
 pub fn chat_completion_to_response(body: Value) -> Result<Value, ProxyError> {
+    chat_completion_to_response_with_context(body, None)
+}
+
+pub fn chat_completion_to_response_with_context(
+    body: Value,
+    tool_ctx: Option<&ToolCompatContext>,
+) -> Result<Value, ProxyError> {
     let choices = body
         .get("choices")
         .and_then(|v| v.as_array())
@@ -379,7 +467,7 @@ pub fn chat_completion_to_response(body: Value) -> Result<Value, ProxyError> {
     if let Some(message_item) = chat_message_to_response_output_item(message, &response_id) {
         output.push(message_item);
     }
-    output.extend(chat_tool_calls_to_response_output_items(message));
+    output.extend(chat_tool_calls_to_response_output_items(message, tool_ctx));
 
     let mut response = json!({
         "id": response_id,
@@ -540,21 +628,31 @@ fn strip_think_answer_separator(text: &str) -> &str {
     text.trim_start_matches(['\r', '\n', '\t', ' '])
 }
 
-fn chat_tool_calls_to_response_output_items(message: &Value) -> Vec<Value> {
+fn chat_tool_calls_to_response_output_items(
+    message: &Value,
+    tool_ctx: Option<&ToolCompatContext>,
+) -> Vec<Value> {
     let mut output = Vec::new();
 
     if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
         for (index, tool_call) in tool_calls.iter().enumerate() {
-            output.push(chat_tool_call_to_response_item(tool_call, index));
+            output.push(chat_tool_call_to_response_item(tool_call, index, tool_ctx));
         }
     } else if let Some(function_call) = message.get("function_call") {
-        output.push(chat_legacy_function_call_to_response_item(function_call));
+        output.push(chat_legacy_function_call_to_response_item(
+            function_call,
+            tool_ctx,
+        ));
     }
 
     output
 }
 
-fn chat_tool_call_to_response_item(tool_call: &Value, index: usize) -> Value {
+fn chat_tool_call_to_response_item(
+    tool_call: &Value,
+    index: usize,
+    tool_ctx: Option<&ToolCompatContext>,
+) -> Value {
     let call_id = tool_call
         .get("id")
         .and_then(|v| v.as_str())
@@ -569,17 +667,30 @@ fn chat_tool_call_to_response_item(tool_call: &Value, index: usize) -> Value {
         None => "{}".to_string(),
     };
 
-    json!({
+    if let Some(custom_item) =
+        tool_ctx.and_then(|ctx| ctx.custom_response_item(&call_id, name, &arguments))
+    {
+        return custom_item;
+    }
+
+    let mut item = json!({
         "id": format!("fc_{call_id}"),
         "type": "function_call",
         "status": "completed",
         "call_id": call_id,
         "name": name,
         "arguments": arguments
-    })
+    });
+    if let Some(ctx) = tool_ctx {
+        ctx.apply_namespace_to_response_item(&mut item);
+    }
+    item
 }
 
-fn chat_legacy_function_call_to_response_item(function_call: &Value) -> Value {
+fn chat_legacy_function_call_to_response_item(
+    function_call: &Value,
+    tool_ctx: Option<&ToolCompatContext>,
+) -> Value {
     let call_id = function_call
         .get("id")
         .and_then(|v| v.as_str())
@@ -595,14 +706,24 @@ fn chat_legacy_function_call_to_response_item(function_call: &Value) -> Value {
         None => "{}".to_string(),
     };
 
-    json!({
+    if let Some(custom_item) =
+        tool_ctx.and_then(|ctx| ctx.custom_response_item(call_id, name, &arguments))
+    {
+        return custom_item;
+    }
+
+    let mut item = json!({
         "id": format!("fc_{call_id}"),
         "type": "function_call",
         "status": "completed",
         "call_id": call_id,
         "name": name,
         "arguments": arguments
-    })
+    });
+    if let Some(ctx) = tool_ctx {
+        ctx.apply_namespace_to_response_item(&mut item);
+    }
+    item
 }
 
 pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
@@ -781,6 +902,188 @@ mod tests {
         assert_eq!(messages[2]["tool_call_id"], "call_2");
         assert_eq!(messages[2]["content"], "[\"main.rs\",\"lib.rs\"]");
         assert_eq!(messages[3]["role"], "user");
+    }
+
+    #[test]
+    fn responses_request_to_chat_maps_custom_and_namespace_tools_when_context_enabled() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "call_id": "call_patch",
+                    "name": "apply_patch",
+                    "input": "*** Begin Patch\n*** Add File: docs/test.md\n+# Test\n*** End Patch"
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_ns",
+                    "namespace": "mcp__editor__",
+                    "name": "save_all",
+                    "arguments": "{}"
+                }
+            ],
+            "tools": [
+                {"type": "custom", "name": "apply_patch"},
+                {
+                    "type": "namespace",
+                    "name": "mcp__editor__",
+                    "tools": [{
+                        "type": "function",
+                        "name": "save_all",
+                        "parameters": {"type": "object"}
+                    }]
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "namespace": "mcp__editor__",
+                "name": "save_all"
+            }
+        });
+        let ctx = ToolCompatContext::from_request(&input);
+
+        let result = responses_to_chat_completions_with_context(input, Some(&ctx)).unwrap();
+        let tool_names = result["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["function"]["name"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(tool_names.contains(&"apply_patch_add_file".to_string()));
+        assert!(tool_names.contains(&"apply_patch_batch".to_string()));
+        assert!(tool_names.contains(&"mcp__editor__save_all".to_string()));
+        assert_eq!(
+            result["messages"][0]["tool_calls"][0]["function"]["name"],
+            "apply_patch_add_file"
+        );
+        assert_eq!(
+            result["messages"][0]["tool_calls"][1]["function"]["name"],
+            "mcp__editor__save_all"
+        );
+        assert_eq!(
+            result["tool_choice"]["function"]["name"],
+            "mcp__editor__save_all"
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_uses_legacy_path_without_tool_context() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "call_id": "call_patch",
+                    "name": "apply_patch",
+                    "input": "*** Begin Patch\n*** Add File: docs/test.md\n+# Test\n*** End Patch"
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_patch",
+                    "output": "ok"
+                }
+            ],
+            "tools": [{"type": "custom", "name": "apply_patch"}]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+
+        assert!(result.get("tools").is_none());
+        assert_eq!(result["messages"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn responses_request_to_chat_maps_custom_tool_outputs_when_context_enabled() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "call_id": "call_patch",
+                    "name": "apply_patch",
+                    "input": "*** Begin Patch\n*** Add File: docs/test.md\n+# Test\n*** End Patch"
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_patch",
+                    "output": "ok"
+                }
+            ],
+            "tools": [{"type": "custom", "name": "apply_patch"}]
+        });
+        let ctx = ToolCompatContext::from_request(&input);
+
+        let result = responses_to_chat_completions_with_context(input, Some(&ctx)).unwrap();
+
+        assert_eq!(
+            result["messages"][0]["tool_calls"][0]["function"]["name"],
+            "apply_patch_add_file"
+        );
+        assert_eq!(result["messages"][1]["role"], "tool");
+        assert_eq!(result["messages"][1]["tool_call_id"], "call_patch");
+        assert_eq!(result["messages"][1]["content"], "ok");
+    }
+
+    #[test]
+    fn chat_response_to_responses_restores_custom_and_namespace_calls() {
+        let request = json!({
+            "tools": [
+                {"type": "custom", "name": "apply_patch"},
+                {
+                    "type": "namespace",
+                    "name": "mcp__editor__",
+                    "tools": [{
+                        "type": "function",
+                        "name": "save_all",
+                        "parameters": {"type": "object"}
+                    }]
+                }
+            ]
+        });
+        let ctx = ToolCompatContext::from_request(&request);
+        let response = json!({
+            "id": "chatcmpl_1",
+            "created": 123,
+            "model": "gpt-5.4",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_patch",
+                            "type": "function",
+                            "function": {
+                                "name": "apply_patch_add_file",
+                                "arguments": "{\"path\":\"docs/test.md\",\"content\":\"# Test\\n\"}"
+                            }
+                        },
+                        {
+                            "id": "call_ns",
+                            "type": "function",
+                            "function": {
+                                "name": "mcp__editor__save_all",
+                                "arguments": "{}"
+                            }
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let result = chat_completion_to_response_with_context(response, Some(&ctx)).unwrap();
+
+        assert_eq!(result["output"][0]["type"], "custom_tool_call");
+        assert_eq!(result["output"][0]["name"], "apply_patch");
+        assert_eq!(
+            result["output"][0]["input"],
+            "*** Begin Patch\n*** Add File: docs/test.md\n+# Test\n*** End Patch"
+        );
+        assert_eq!(result["output"][1]["type"], "function_call");
+        assert_eq!(result["output"][1]["name"], "save_all");
+        assert_eq!(result["output"][1]["namespace"], "mcp__editor__");
     }
 
     #[test]

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -219,6 +219,7 @@ export function EditProviderDialog({
       }
     >
       <ProviderForm
+        key={`${provider.id}:${open ? "open" : "closed"}`}
         appId={appId}
         providerId={provider.id}
         submitLabel={t("common.save")}

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { FormLabel } from "@/components/ui/form";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -9,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import { Download, Loader2 } from "lucide-react";
 import EndpointSpeedTest from "./EndpointSpeedTest";
@@ -50,6 +52,8 @@ interface CodexFormFieldsProps {
   // API Format
   apiFormat: CodexApiFormat;
   onApiFormatChange: (format: CodexApiFormat) => void;
+  toolCompatEnabled: boolean;
+  onToolCompatChange: (enabled: boolean) => void;
 
   // Model Name
   shouldShowModelField?: boolean;
@@ -81,6 +85,8 @@ export function CodexFormFields({
   onAutoSelectChange,
   apiFormat,
   onApiFormatChange,
+  toolCompatEnabled,
+  onToolCompatChange,
   shouldShowModelField = true,
   modelName = "",
   onModelNameChange,
@@ -191,6 +197,28 @@ export function CodexFormFields({
                 "选择供应商真实支持的 Codex API 格式；Chat Completions 会通过本地路由自动转换为 Responses。",
             })}
           </p>
+          {apiFormat === "openai_chat" && (
+            <div className="flex items-center justify-between rounded-md border px-3 py-2">
+              <div className="space-y-0.5">
+                <Label htmlFor="toolCompatEnabled" className="text-sm">
+                  {t("providerForm.toolCompatEnabled", {
+                    defaultValue: "Tool compatibility",
+                  })}
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  {t("providerForm.toolCompatHint", {
+                    defaultValue:
+                      "Map custom, namespace, and built-in tools to Chat functions, then restore them on response.",
+                  })}
+                </p>
+              </div>
+              <Switch
+                id="toolCompatEnabled"
+                checked={toolCompatEnabled}
+                onCheckedChange={onToolCompatChange}
+              />
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -451,24 +451,31 @@ function ProviderFormFull({
     resetCodexConfig,
   } = useCodexConfigState({ initialData });
 
+  const getInitialCodexApiFormat = useCallback((): CodexApiFormat => {
+    if (initialData?.meta?.apiFormat === "openai_chat") {
+      return "openai_chat";
+    }
+    if (initialData?.meta?.apiFormat === "openai_responses") {
+      return "openai_responses";
+    }
+    return (
+      codexApiFormatFromWireApi(
+        extractCodexWireApi(
+          typeof initialData?.settingsConfig?.config === "string"
+            ? initialData.settingsConfig.config
+            : "",
+        ),
+      ) ?? "openai_responses"
+    );
+  }, [initialData]);
+
   const [localCodexApiFormat, setLocalCodexApiFormat] =
-    useState<CodexApiFormat>(() => {
-      if (initialData?.meta?.apiFormat === "openai_chat") {
-        return "openai_chat";
-      }
-      if (initialData?.meta?.apiFormat === "openai_responses") {
-        return "openai_responses";
-      }
-      return (
-        codexApiFormatFromWireApi(
-          extractCodexWireApi(
-            typeof initialData?.settingsConfig?.config === "string"
-              ? initialData.settingsConfig.config
-              : "",
-          ),
-        ) ?? "openai_responses"
-      );
-    });
+    useState<CodexApiFormat>(getInitialCodexApiFormat);
+  const [localToolCompatEnabled, setLocalToolCompatEnabled] = useState<boolean>(
+    () =>
+      initialData?.meta?.toolCompatEnabled ??
+      getInitialCodexApiFormat() === "openai_chat",
+  );
 
   const { configError: codexConfigError, debouncedValidate } =
     useCodexTomlValidation();
@@ -479,6 +486,7 @@ function ProviderFormFull({
       const nextFormat = codexApiFormatFromWireApi(extractCodexWireApi(value));
       if (nextFormat) {
         setLocalCodexApiFormat(nextFormat);
+        setLocalToolCompatEnabled(nextFormat === "openai_chat");
       }
       debouncedValidate(value);
     },
@@ -488,6 +496,7 @@ function ProviderFormFull({
   const handleCodexApiFormatChange = useCallback(
     (format: CodexApiFormat) => {
       setLocalCodexApiFormat(format);
+      setLocalToolCompatEnabled(format === "openai_chat");
       setCodexConfig((prev) => {
         const updated = setCodexWireApi(prev, "responses");
         debouncedValidate(updated);
@@ -1303,6 +1312,12 @@ function ProviderFormFull({
           : appId === "codex" && category !== "official"
             ? localCodexApiFormat
             : undefined,
+      toolCompatEnabled:
+        appId === "codex" &&
+        category !== "official" &&
+        localCodexApiFormat === "openai_chat"
+          ? localToolCompatEnabled
+          : undefined,
       apiKeyField:
         appId === "claude" &&
         category !== "official" &&
@@ -1425,11 +1440,12 @@ function ProviderFormFull({
 
       if (appId === "codex") {
         const template = getCodexCustomTemplate();
-        resetCodexConfig(template.auth, template.config);
-        setLocalCodexApiFormat(
+        const nextFormat =
           codexApiFormatFromWireApi(extractCodexWireApi(template.config)) ??
-            "openai_responses",
-        );
+          "openai_responses";
+        resetCodexConfig(template.auth, template.config);
+        setLocalCodexApiFormat(nextFormat);
+        setLocalToolCompatEnabled(nextFormat === "openai_chat");
       }
       if (appId === "gemini") {
         resetGeminiConfig({}, {});
@@ -1464,13 +1480,14 @@ function ProviderFormFull({
       const preset = entry.preset as CodexProviderPreset;
       const auth = preset.auth ?? {};
       const config = preset.config ?? "";
+      const nextFormat =
+        preset.apiFormat ??
+        codexApiFormatFromWireApi(extractCodexWireApi(config)) ??
+        "openai_responses";
 
       resetCodexConfig(auth, config);
-      setLocalCodexApiFormat(
-        preset.apiFormat ??
-          codexApiFormatFromWireApi(extractCodexWireApi(config)) ??
-          "openai_responses",
-      );
+      setLocalCodexApiFormat(nextFormat);
+      setLocalToolCompatEnabled(nextFormat === "openai_chat");
 
       form.reset({
         name: preset.nameKey ? t(preset.nameKey) : preset.name,
@@ -1937,6 +1954,8 @@ function ProviderFormFull({
               onAutoSelectChange={setEndpointAutoSelect}
               apiFormat={localCodexApiFormat}
               onApiFormatChange={handleCodexApiFormatChange}
+              toolCompatEnabled={localToolCompatEnabled}
+              onToolCompatChange={setLocalToolCompatEnabled}
               shouldShowModelField={category !== "official"}
               modelName={codexModelName}
               onModelNameChange={handleCodexModelNameChange}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -912,6 +912,8 @@
     "codexApiFormatResponses": "OpenAI Responses API (Native)",
     "codexApiFormatOpenAIChat": "OpenAI Chat Completions (Requires routing)",
     "codexApiFormatHint": "Select the Codex API format actually supported by this provider; the config stays on Responses for newer Codex versions, while Chat Completions is converted through local routing.",
+    "toolCompatEnabled": "Tool compatibility",
+    "toolCompatHint": "Map custom, namespace, and built-in tools to Chat functions, then restore them on response.",
     "authField": "Auth Field",
     "authFieldAuthToken": "ANTHROPIC_AUTH_TOKEN (Default)",
     "authFieldApiKey": "ANTHROPIC_API_KEY",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -912,6 +912,8 @@
     "codexApiFormatResponses": "OpenAI Responses API（ネイティブ）",
     "codexApiFormatOpenAIChat": "OpenAI Chat Completions（ルーティングが必要）",
     "codexApiFormatHint": "このプロバイダーが実際に対応している Codex API フォーマットを選択します。新しい Codex との互換性のため設定は Responses のままにし、Chat Completions はローカルルーティングで変換します。",
+    "toolCompatEnabled": "ツール互換",
+    "toolCompatHint": "カスタム、名前空間、組み込みツールを Chat 関数に変換し、応答時に元の形式へ戻します。",
     "authField": "認証フィールド",
     "authFieldAuthToken": "ANTHROPIC_AUTH_TOKEN（デフォルト）",
     "authFieldApiKey": "ANTHROPIC_API_KEY",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -912,6 +912,8 @@
     "codexApiFormatResponses": "OpenAI Responses API (原生)",
     "codexApiFormatOpenAIChat": "OpenAI Chat Completions (需开启路由)",
     "codexApiFormatHint": "选择供应商真实支持的 Codex API 格式；配置仍保持 Responses 以兼容新版 Codex，Chat Completions 会通过本地路由自动转换。",
+    "toolCompatEnabled": "工具兼容",
+    "toolCompatHint": "将自定义、命名空间和内置工具映射为 Chat 函数，并在响应时还原。",
     "authField": "认证字段",
     "authFieldAuthToken": "ANTHROPIC_AUTH_TOKEN（默认）",
     "authFieldApiKey": "ANTHROPIC_API_KEY",

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,7 @@ export interface ProviderMeta {
     | "openai_chat"
     | "openai_responses"
     | "gemini_native";
+  toolCompatEnabled?: boolean;
   // 通用认证绑定
   authBinding?: AuthBinding;
   // Claude 认证字段名


### PR DESCRIPTION
﻿## Summary

Adds compatibility support for providers that expose OpenAI Chat Completions while the local entry point keeps receiving Responses-format requests.

Main changes:
- map custom, namespace, web search, local shell, computer use, and string tool declarations into upstream function proxies
- restore proxy function calls back into Responses custom tool calls for normal responses and streaming responses
- persist a per-provider tool compatibility option and default it on for Chat format providers
- fix edit-form rehydration so saved API format choices display correctly when reopening a provider
- add localized copy for the new option in Chinese, English, and Japanese

## Validation

- formatting check passed
- TypeScript check passed
- Rust formatting check passed
- focused Rust tests passed for tool compatibility, request conversion, streaming conversion, and provider behavior
- production desktop build completed and produced Windows installer artifacts
