### PR TITLE
feat: 优先使用 CODEX_HOME 环境变量作为配置目录

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -25,6 +25,18 @@ const CODEX_RESERVED_MODEL_PROVIDER_IDS: &[&str] = &[
     "ollama-chat",
 ];
 
+fn resolve_tilde_path(raw: &str) -> PathBuf {
+    if raw == "~" {
+        get_home_dir()
+    } else if let Some(stripped) = raw.strip_prefix("~/") {
+        get_home_dir().join(stripped)
+    } else if let Some(stripped) = raw.strip_prefix("~\\") {
+        get_home_dir().join(stripped)
+    } else {
+        PathBuf::from(raw)
+    }
+}
+
 /// 获取 Codex 配置目录路径
 pub fn get_codex_config_dir() -> PathBuf {
     if let Some(custom) = crate::settings::get_codex_override_dir() {
@@ -34,7 +46,7 @@ pub fn get_codex_config_dir() -> PathBuf {
     if let Ok(codex_home) = std::env::var("CODEX_HOME") {
         let trimmed = codex_home.trim();
         if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
+            return resolve_tilde_path(trimmed);
         }
     }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -31,6 +31,13 @@ pub fn get_codex_config_dir() -> PathBuf {
         return custom;
     }
 
+    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
+        let trimmed = codex_home.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+
     get_home_dir().join(".codex")
 }
 


### PR DESCRIPTION
### 概述
本 PR 增加了对 `CODEX_HOME` 环境变量的支持，用于解析 Codex 的配置目录路径，使其符合 OpenAI Codex 的官方规范。

### 背景
根据 [OpenAI Codex 规范](https://developers.openai.com/codex/guides/agents-md)，如果用户定义了 `CODEX_HOME` 环境变量，配置目录解析应优先采用该变量。在此之前，`cc-switch` 仅检查了本地覆盖设置，并直接回退至 `~/.codex` 目录，未对 `CODEX_HOME` 进行解析。

### 修改内容
- 修改了 `src-tauri/src/codex_config.rs` 中的 `get_codex_config_dir` 函数。
- 调整后的配置目录解析优先级为：
  1. 用户在 CC Switch 设置中配置的自定义覆盖路径。
  2. `CODEX_HOME` 环境变量（若存在且不为空）。
  3. 默认的 `~/.codex` 路径。
- 严格保持 UTF-8 编码，未影响现有的中文注释。