### PR TITLE
fix: respect visible apps in skills and mcp UI

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -11,6 +11,20 @@ use std::fs;
 use std::path::Path;
 use toml_edit::DocumentMut;
 
+pub const CC_SWITCH_CODEX_MODEL_PROVIDER_ID: &str = "ccswitch";
+
+/// Reserved built-in provider IDs from OpenAI Codex's config/model-provider
+/// catalog. Keep in sync with Codex `RESERVED_MODEL_PROVIDER_IDS` and legacy
+/// removed provider aliases.
+const CODEX_RESERVED_MODEL_PROVIDER_IDS: &[&str] = &[
+    "amazon-bedrock",
+    "openai",
+    "ollama",
+    "lmstudio",
+    "oss",
+    "ollama-chat",
+];
+
 /// 获取 Codex 配置目录路径
 pub fn get_codex_config_dir() -> PathBuf {
     if let Some(custom) = crate::settings::get_codex_override_dir() {
@@ -137,6 +151,174 @@ pub fn read_and_validate_codex_config_text() -> Result<String, AppError> {
     Ok(s)
 }
 
+fn active_codex_model_provider_id(doc: &DocumentMut) -> Option<String> {
+    doc.get("model_provider")
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+}
+
+fn is_custom_codex_model_provider_id(id: &str) -> bool {
+    let id = id.trim();
+    !id.is_empty()
+        && !CODEX_RESERVED_MODEL_PROVIDER_IDS
+            .iter()
+            .any(|reserved| reserved.eq_ignore_ascii_case(id))
+}
+
+fn stable_codex_model_provider_id_from_config(config_text: &str) -> Option<String> {
+    let doc = config_text.parse::<DocumentMut>().ok()?;
+    let provider_id = active_codex_model_provider_id(&doc)?;
+
+    if is_custom_codex_model_provider_id(&provider_id) {
+        Some(provider_id)
+    } else {
+        None
+    }
+}
+
+fn normalize_codex_live_config_model_provider_with_anchors<'a>(
+    config_text: &str,
+    anchor_config_texts: impl IntoIterator<Item = &'a str>,
+) -> Result<String, AppError> {
+    if config_text.trim().is_empty() {
+        return Ok(config_text.to_string());
+    }
+
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+
+    let Some(source_provider_id) = active_codex_model_provider_id(&doc) else {
+        return Ok(config_text.to_string());
+    };
+
+    let has_source_provider_table = doc
+        .get("model_providers")
+        .and_then(|item| item.as_table())
+        .and_then(|table| table.get(source_provider_id.as_str()))
+        .is_some();
+    if !has_source_provider_table {
+        return Ok(config_text.to_string());
+    }
+
+    let stable_provider_id = anchor_config_texts
+        .into_iter()
+        .find_map(stable_codex_model_provider_id_from_config)
+        .or_else(|| {
+            is_custom_codex_model_provider_id(&source_provider_id)
+                .then(|| source_provider_id.clone())
+        })
+        .unwrap_or_else(|| CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string());
+
+    if stable_provider_id == source_provider_id {
+        return Ok(config_text.to_string());
+    }
+
+    if let Some(model_providers) = doc
+        .get_mut("model_providers")
+        .and_then(|item| item.as_table_mut())
+    {
+        let Some(provider_table) = model_providers.remove(source_provider_id.as_str()) else {
+            return Ok(config_text.to_string());
+        };
+        model_providers[stable_provider_id.as_str()] = provider_table;
+    }
+
+    rewrite_codex_profile_model_provider_refs(&mut doc, &source_provider_id, &stable_provider_id);
+    doc["model_provider"] = toml_edit::value(stable_provider_id.as_str());
+
+    Ok(doc.to_string())
+}
+
+fn rewrite_codex_profile_model_provider_refs(
+    doc: &mut DocumentMut,
+    source_provider_id: &str,
+    stable_provider_id: &str,
+) {
+    let Some(profiles) = doc
+        .get_mut("profiles")
+        .and_then(|item| item.as_table_like_mut())
+    else {
+        return;
+    };
+
+    let profile_keys: Vec<String> = profiles.iter().map(|(key, _)| key.to_string()).collect();
+    for profile_key in profile_keys {
+        let Some(profile_table) = profiles
+            .get_mut(&profile_key)
+            .and_then(|item| item.as_table_like_mut())
+        else {
+            continue;
+        };
+
+        let references_source = profile_table
+            .get("model_provider")
+            .and_then(|item| item.as_str())
+            == Some(source_provider_id);
+        if references_source {
+            profile_table.insert("model_provider", toml_edit::value(stable_provider_id));
+        }
+    }
+}
+
+/// Keep Codex's active `model_provider` stable across CC Switch provider changes.
+///
+/// Codex stores and filters resume history by `model_provider`, so switching between
+/// provider-specific ids like `rightcode` and `aihubmix` makes history appear to move.
+/// We preserve an existing custom provider id when possible and only rewrite the
+/// live config text that Codex sees at provider-driven write boundaries.
+pub fn normalize_codex_settings_config_model_provider(
+    settings: &mut Value,
+    anchor_config_text: Option<&str>,
+) -> Result<(), AppError> {
+    let Some(config_text) = settings
+        .get("config")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+    else {
+        return Ok(());
+    };
+
+    let current_config_text = read_codex_config_text().ok();
+    let anchors = anchor_config_text
+        .into_iter()
+        .chain(current_config_text.as_deref());
+    let normalized =
+        normalize_codex_live_config_model_provider_with_anchors(&config_text, anchors)?;
+
+    if let Some(obj) = settings.as_object_mut() {
+        obj.insert("config".to_string(), Value::String(normalized));
+    }
+
+    Ok(())
+}
+
+/// Atomically write Codex live config after normalizing provider-specific ids.
+///
+/// Use this for provider-driven live writes. Keep `write_codex_live_atomic` available
+/// for exact restore/backup paths that must preserve the config text byte-for-byte.
+pub fn write_codex_live_atomic_with_stable_provider(
+    auth: &Value,
+    config_text_opt: Option<&str>,
+) -> Result<(), AppError> {
+    match config_text_opt {
+        Some(config_text) => {
+            let mut settings = serde_json::Map::new();
+            settings.insert("config".to_string(), Value::String(config_text.to_string()));
+            let mut settings = Value::Object(settings);
+            normalize_codex_settings_config_model_provider(&mut settings, None)?;
+            let config_text = settings
+                .get("config")
+                .and_then(|value| value.as_str())
+                .unwrap_or(config_text);
+            write_codex_live_atomic(auth, Some(config_text))
+        }
+        None => write_codex_live_atomic(auth, None),
+    }
+}
+
 /// Update a field in Codex config.toml using toml_edit (syntax-preserving).
 ///
 /// Supported fields:
@@ -253,6 +435,241 @@ pub fn remove_codex_toml_base_url_if(toml_str: &str, predicate: impl Fn(&str) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_live_config_preserves_current_custom_model_provider_id() {
+        let current = r#"model_provider = "rightcode"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+"#;
+        let target = r#"model_provider = "aihubmix"
+model = "gpt-5.4"
+
+[model_providers.aihubmix]
+name = "AiHubMix"
+base_url = "https://aihubmix.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+
+[mcp_servers.context7]
+command = "npx"
+"#;
+
+        let result =
+            normalize_codex_live_config_model_provider_with_anchors(target, Some(current)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("rightcode")
+        );
+
+        let model_providers = parsed
+            .get("model_providers")
+            .and_then(|v| v.as_table())
+            .expect("model_providers should exist");
+        assert!(
+            model_providers.get("aihubmix").is_none(),
+            "source provider id should not remain in live config"
+        );
+
+        let stable_provider = model_providers
+            .get("rightcode")
+            .expect("stable provider table should exist");
+        assert_eq!(
+            stable_provider.get("base_url").and_then(|v| v.as_str()),
+            Some("https://aihubmix.example/v1")
+        );
+        assert!(
+            parsed.get("mcp_servers").is_some(),
+            "unrelated config should be preserved"
+        );
+    }
+
+    #[test]
+    fn normalize_live_config_uses_target_custom_provider_when_current_is_reserved() {
+        let current = r#"model_provider = "openai""#;
+        let target = r#"model_provider = "aihubmix"
+
+[model_providers.aihubmix]
+name = "AiHubMix"
+base_url = "https://aihubmix.example/v1"
+wire_api = "responses"
+"#;
+
+        let result =
+            normalize_codex_live_config_model_provider_with_anchors(target, Some(current)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("aihubmix")
+        );
+        assert!(
+            parsed
+                .get("model_providers")
+                .and_then(|v| v.get("aihubmix"))
+                .is_some(),
+            "target provider id should be kept when there is no reusable live custom id"
+        );
+    }
+
+    #[test]
+    fn normalize_live_config_leaves_official_empty_config_unchanged() {
+        let current = r#"model_provider = "rightcode"
+
+[model_providers.rightcode]
+base_url = "https://rightcode.example/v1"
+"#;
+
+        let result =
+            normalize_codex_live_config_model_provider_with_anchors("", Some(current)).unwrap();
+
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn normalize_live_config_rewrites_matching_profile_model_provider_refs() {
+        let current = r#"model_provider = "session_anchor"
+
+[model_providers.session_anchor]
+name = "Session Anchor"
+base_url = "https://anchor.example/v1"
+wire_api = "responses"
+"#;
+        let target = r#"model_provider = "vendor_alpha"
+model = "gpt-5.4"
+profile = "work"
+
+[model_providers.vendor_alpha]
+name = "Vendor Alpha"
+base_url = "https://alpha.example/v1"
+wire_api = "responses"
+
+[profiles.work]
+model_provider = "vendor_alpha"
+model = "gpt-5.4"
+"#;
+
+        let result =
+            normalize_codex_live_config_model_provider_with_anchors(target, Some(current)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("session_anchor")
+        );
+        assert_eq!(
+            parsed
+                .get("profiles")
+                .and_then(|v| v.get("work"))
+                .and_then(|v| v.get("model_provider"))
+                .and_then(|v| v.as_str()),
+            Some("session_anchor"),
+            "profile override matching the rewritten provider should stay valid"
+        );
+    }
+
+    #[test]
+    fn normalize_live_config_keeps_unrelated_profile_model_provider_refs() {
+        let current = r#"model_provider = "session_anchor"
+
+[model_providers.session_anchor]
+name = "Session Anchor"
+base_url = "https://anchor.example/v1"
+wire_api = "responses"
+"#;
+        let target = r#"model_provider = "vendor_alpha"
+model = "gpt-5.4"
+
+[model_providers.vendor_alpha]
+name = "Vendor Alpha"
+base_url = "https://alpha.example/v1"
+wire_api = "responses"
+
+[model_providers.local_profile]
+name = "Local Profile"
+base_url = "http://localhost:11434/v1"
+wire_api = "responses"
+
+[profiles.local]
+model_provider = "local_profile"
+model = "local-model"
+"#;
+
+        let result =
+            normalize_codex_live_config_model_provider_with_anchors(target, Some(current)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        assert_eq!(
+            parsed
+                .get("profiles")
+                .and_then(|v| v.get("local"))
+                .and_then(|v| v.get("model_provider"))
+                .and_then(|v| v.as_str()),
+            Some("local_profile"),
+            "unrelated profile provider references should be preserved"
+        );
+        assert!(
+            parsed
+                .get("model_providers")
+                .and_then(|v| v.get("local_profile"))
+                .is_some(),
+            "unrelated provider tables should also remain available"
+        );
+    }
+
+    #[test]
+    fn normalize_live_config_keeps_stable_provider_across_repeated_switches() {
+        let anchor = r#"model_provider = "session_anchor"
+
+[model_providers.session_anchor]
+name = "Session Anchor"
+base_url = "https://anchor.example/v1"
+wire_api = "responses"
+"#;
+        let first_target = r#"model_provider = "vendor_alpha"
+
+[model_providers.vendor_alpha]
+name = "Vendor Alpha"
+base_url = "https://alpha.example/v1"
+wire_api = "responses"
+"#;
+        let second_target = r#"model_provider = "vendor_beta"
+
+[model_providers.vendor_beta]
+name = "Vendor Beta"
+base_url = "https://beta.example/v1"
+wire_api = "responses"
+"#;
+
+        let first =
+            normalize_codex_live_config_model_provider_with_anchors(first_target, Some(anchor))
+                .unwrap();
+        let second = normalize_codex_live_config_model_provider_with_anchors(
+            second_target,
+            Some(first.as_str()),
+        )
+        .unwrap();
+        let parsed: toml::Value = toml::from_str(&second).unwrap();
+
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("session_anchor"),
+            "stable provider id should not drift across repeated switches"
+        );
+        assert_eq!(
+            parsed
+                .get("model_providers")
+                .and_then(|v| v.get("session_anchor"))
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("https://beta.example/v1")
+        );
+    }
 
     #[test]
     fn base_url_writes_into_correct_model_provider_section() {

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -178,6 +178,29 @@ fn stable_codex_model_provider_id_from_config(config_text: &str) -> Option<Strin
     }
 }
 
+fn codex_model_provider_id_with_table_from_config(
+    config_text: &str,
+) -> Result<Option<String>, AppError> {
+    if config_text.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+    let Some(provider_id) = active_codex_model_provider_id(&doc) else {
+        return Ok(None);
+    };
+
+    let has_provider_table = doc
+        .get("model_providers")
+        .and_then(|item| item.as_table())
+        .and_then(|table| table.get(provider_id.as_str()))
+        .is_some();
+
+    Ok(has_provider_table.then_some(provider_id))
+}
+
 fn normalize_codex_live_config_model_provider_with_anchors<'a>(
     config_text: &str,
     anchor_config_texts: impl IntoIterator<Item = &'a str>,
@@ -290,6 +313,77 @@ pub fn normalize_codex_settings_config_model_provider(
 
     if let Some(obj) = settings.as_object_mut() {
         obj.insert("config".to_string(), Value::String(normalized));
+    }
+
+    Ok(())
+}
+
+fn restore_codex_backfill_model_provider_id(
+    config_text: &str,
+    template_config_text: &str,
+) -> Result<String, AppError> {
+    let Some(template_provider_id) =
+        codex_model_provider_id_with_table_from_config(template_config_text)?
+    else {
+        return Ok(config_text.to_string());
+    };
+
+    if config_text.trim().is_empty() {
+        return Ok(config_text.to_string());
+    }
+
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+    let Some(live_provider_id) = active_codex_model_provider_id(&doc) else {
+        return Ok(config_text.to_string());
+    };
+
+    if live_provider_id == template_provider_id {
+        return Ok(config_text.to_string());
+    }
+
+    if let Some(model_providers) = doc
+        .get_mut("model_providers")
+        .and_then(|item| item.as_table_mut())
+    {
+        let Some(provider_table) = model_providers.remove(live_provider_id.as_str()) else {
+            return Ok(config_text.to_string());
+        };
+        model_providers[template_provider_id.as_str()] = provider_table;
+    } else {
+        return Ok(config_text.to_string());
+    }
+
+    rewrite_codex_profile_model_provider_refs(&mut doc, &live_provider_id, &template_provider_id);
+    doc["model_provider"] = toml_edit::value(template_provider_id.as_str());
+
+    Ok(doc.to_string())
+}
+
+/// Convert a Codex live config that was normalized for history stability back
+/// to the provider-specific id used by the stored provider template.
+pub fn restore_codex_settings_config_model_provider_for_backfill(
+    settings: &mut Value,
+    template_settings: &Value,
+) -> Result<(), AppError> {
+    let Some(config_text) = settings
+        .get("config")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+    else {
+        return Ok(());
+    };
+    let Some(template_config_text) = template_settings
+        .get("config")
+        .and_then(|value| value.as_str())
+    else {
+        return Ok(());
+    };
+
+    let restored = restore_codex_backfill_model_provider_id(&config_text, template_config_text)?;
+    if let Some(obj) = settings.as_object_mut() {
+        obj.insert("config".to_string(), Value::String(restored));
     }
 
     Ok(())

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use indexmap::IndexMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::Serialize;
 use tauri::State;
@@ -194,14 +194,51 @@ pub async fn toggle_mcp_app(
     McpService::toggle_app(&state, &server_id, app_ty, enabled).map_err(|e| e.to_string())
 }
 
-/// 从所有应用导入 MCP 服务器（复用已有的导入逻辑）
-#[tauri::command]
-pub async fn import_mcp_from_apps(state: State<'_, AppState>) -> Result<usize, String> {
+fn import_mcp_from_app(state: &AppState, app: &AppType) -> usize {
+    match app {
+        AppType::Claude => McpService::import_from_claude(state),
+        AppType::Codex => McpService::import_from_codex(state),
+        AppType::Gemini => McpService::import_from_gemini(state),
+        AppType::OpenCode => McpService::import_from_opencode(state),
+        AppType::OpenClaw => Ok(0),
+        AppType::Hermes => McpService::import_from_hermes(state),
+    }
+    .unwrap_or(0)
+}
+
+pub fn import_mcp_from_selected_apps(
+    state: &AppState,
+    apps: Option<Vec<String>>,
+) -> Result<usize, String> {
+    let mut apps_to_import = match apps {
+        Some(apps) => apps
+            .iter()
+            .map(|app| AppType::from_str(app).map_err(|e| e.to_string()))
+            .collect::<Result<Vec<_>, _>>()?,
+        None => vec![
+            AppType::Claude,
+            AppType::Codex,
+            AppType::Gemini,
+            AppType::OpenCode,
+            AppType::Hermes,
+        ],
+    };
+    let mut seen = HashSet::new();
+    apps_to_import.retain(|app| seen.insert(app.clone()));
+
     let mut total = 0;
-    total += McpService::import_from_claude(&state).unwrap_or(0);
-    total += McpService::import_from_codex(&state).unwrap_or(0);
-    total += McpService::import_from_gemini(&state).unwrap_or(0);
-    total += McpService::import_from_opencode(&state).unwrap_or(0);
-    total += McpService::import_from_hermes(&state).unwrap_or(0);
+    for app in apps_to_import {
+        total += import_mcp_from_app(state, &app);
+    }
+
     Ok(total)
+}
+
+/// 从指定应用导入 MCP 服务器（复用已有的导入逻辑）；未指定时保持全量导入。
+#[tauri::command]
+pub async fn import_mcp_from_apps(
+    state: State<'_, AppState>,
+    apps: Option<Vec<String>>,
+) -> Result<usize, String> {
+    import_mcp_from_selected_apps(&state, apps)
 }

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -156,7 +156,7 @@ impl ConfigService {
         }
         let cfg_text = settings.get("config").and_then(Value::as_str);
 
-        crate::codex_config::write_codex_live_atomic(auth, cfg_text)?;
+        crate::codex_config::write_codex_live_atomic_with_stable_provider(auth, cfg_text)?;
         // 注意：MCP 同步在 v3.7.0 中已通过 McpService 进行，不再在此调用
         // sync_enabled_to_codex 使用旧的 config.mcp.codex 结构，在新架构中为空
         // MCP 的启用/禁用应通过 McpService::toggle_app 进行

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -530,29 +530,55 @@ pub(crate) fn strip_common_config_from_live_settings(
                 app_type.as_str(),
                 provider.id
             );
-            return live_settings;
+            return restore_live_settings_for_provider_backfill(app_type, provider, live_settings);
         }
     };
 
-    if !provider_uses_common_config(app_type, provider, snippet.as_deref()) {
-        return live_settings;
-    }
-
-    let Some(snippet_text) = snippet.as_deref() else {
-        return live_settings;
+    let backfill_settings = if provider_uses_common_config(app_type, provider, snippet.as_deref()) {
+        match snippet.as_deref() {
+            Some(snippet_text) => {
+                match remove_common_config_from_settings(app_type, &live_settings, snippet_text) {
+                    Ok(settings) => settings,
+                    Err(err) => {
+                        log::warn!(
+                            "Failed to strip common config for {} provider '{}': {err}",
+                            app_type.as_str(),
+                            provider.id
+                        );
+                        live_settings
+                    }
+                }
+            }
+            None => live_settings,
+        }
+    } else {
+        live_settings
     };
 
-    match remove_common_config_from_settings(app_type, &live_settings, snippet_text) {
-        Ok(settings) => settings,
-        Err(err) => {
-            log::warn!(
-                "Failed to strip common config for {} provider '{}': {err}",
-                app_type.as_str(),
-                provider.id
-            );
-            live_settings
-        }
+    restore_live_settings_for_provider_backfill(app_type, provider, backfill_settings)
+}
+
+fn restore_live_settings_for_provider_backfill(
+    app_type: &AppType,
+    provider: &Provider,
+    live_settings: Value,
+) -> Value {
+    if !matches!(app_type, AppType::Codex) {
+        return live_settings;
     }
+
+    let mut settings = live_settings;
+    if let Err(err) = crate::codex_config::restore_codex_settings_config_model_provider_for_backfill(
+        &mut settings,
+        &provider.settings_config,
+    ) {
+        log::warn!(
+            "Failed to restore Codex provider id while backfilling '{}': {err}",
+            provider.id
+        );
+    }
+
+    settings
 }
 
 pub(crate) fn normalize_provider_common_config_for_storage(

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -8,7 +8,9 @@ use serde_json::{json, Value};
 use toml_edit::{DocumentMut, Item, TableLike};
 
 use crate::app_config::AppType;
-use crate::codex_config::{get_codex_auth_path, get_codex_config_path};
+use crate::codex_config::{
+    get_codex_auth_path, get_codex_config_path, write_codex_live_atomic_with_stable_provider,
+};
 use crate::config::{delete_file, get_claude_settings_path, read_json_file, write_json_file};
 use crate::database::Database;
 use crate::error::AppError;
@@ -683,10 +685,7 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
                 AppError::Config("Codex 供应商配置缺少 'config' 字段或不是字符串".to_string())
             })?;
 
-            let auth_path = get_codex_auth_path();
-            write_json_file(&auth_path, auth)?;
-            let config_path = get_codex_config_path();
-            std::fs::write(&config_path, config_str).map_err(|e| AppError::io(&config_path, e))?;
+            write_codex_live_atomic_with_stable_provider(auth, Some(config_str))?;
         }
         AppType::Gemini => {
             // Delegate to write_gemini_live which handles env file writing correctly

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1476,20 +1476,33 @@ impl ProxyService {
                 .map_err(|e| format!("构建 {app_type} 有效配置失败: {e}"))?;
 
         if matches!(app_type_enum, AppType::Codex) {
-            let existing_backup = self
+            let existing_backup_value = self
                 .db
                 .get_live_backup(app_type)
                 .await
-                .map_err(|e| format!("读取 {app_type} 现有备份失败: {e}"))?;
+                .map_err(|e| format!("读取 {app_type} 现有备份失败: {e}"))?
+                .map(|backup| {
+                    serde_json::from_str::<Value>(&backup.original_config)
+                        .map_err(|e| format!("解析 {app_type} 现有备份失败: {e}"))
+                })
+                .transpose()?;
 
-            if let Some(existing_backup) = existing_backup {
-                let existing_value: Value = serde_json::from_str(&existing_backup.original_config)
-                    .map_err(|e| format!("解析 {app_type} 现有备份失败: {e}"))?;
+            if let Some(existing_value) = existing_backup_value.as_ref() {
                 Self::preserve_codex_mcp_servers_in_backup(
                     &mut effective_settings,
-                    &existing_value,
+                    existing_value,
                 )?;
             }
+
+            let anchor_config_text = existing_backup_value
+                .as_ref()
+                .and_then(|value| value.get("config"))
+                .and_then(|value| value.as_str());
+            crate::codex_config::normalize_codex_settings_config_model_provider(
+                &mut effective_settings,
+                anchor_config_text,
+            )
+            .map_err(|e| format!("归一化 Codex restore backup 失败: {e}"))?;
         }
 
         let backup_json = match app_type_enum {
@@ -1749,6 +1762,8 @@ impl ProxyService {
         let auth = config.get("auth");
         let config_str = config.get("config").and_then(|v| v.as_str());
 
+        // Proxy restore writes saved live backups verbatim. Provider-driven writes go
+        // through write_live_with_common_config(), which normalizes Codex provider ids.
         match (auth, config_str) {
             (Some(auth), Some(cfg)) => write_codex_live_atomic(auth, Some(cfg))
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?,
@@ -2690,6 +2705,147 @@ base_url = "https://new.example/v1"
         assert!(
             config.contains("https://new.example/v1"),
             "provider-specific base_url should still update to the new provider"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hot_switch_codex_provider_keeps_model_provider_stable_in_backup_and_restore() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "RightCode".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "rightcode-key"
+                },
+                "config": r#"model_provider = "rightcode"
+model = "gpt-5.4"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+            }),
+            None,
+        );
+        let provider_b = Provider::with_id(
+            "b".to_string(),
+            "AiHubMix".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "aihubmix-key"
+                },
+                "config": r#"model_provider = "aihubmix"
+model = "gpt-5.4"
+
+[model_providers.aihubmix]
+name = "AiHubMix"
+base_url = "https://aihubmix.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+            }),
+            None,
+        );
+
+        db.save_provider("codex", &provider_a)
+            .expect("save provider a");
+        db.save_provider("codex", &provider_b)
+            .expect("save provider b");
+        db.set_current_provider("codex", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("a"))
+            .expect("set local current provider");
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&provider_a.settings_config).expect("serialize provider a"),
+        )
+        .await
+        .expect("seed live backup");
+        service
+            .write_codex_live(&json!({
+                "auth": {
+                    "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER
+                },
+                "config": r#"model_provider = "rightcode"
+model = "gpt-5.4"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+            }))
+            .expect("seed taken-over Codex live config");
+
+        service
+            .hot_switch_provider("codex", "b")
+            .await
+            .expect("hot switch Codex provider");
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("get live backup")
+            .expect("backup exists");
+        let stored: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup json");
+        let backup_config = stored
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("backup config string");
+        let parsed_backup: toml::Value =
+            toml::from_str(backup_config).expect("parse backup config");
+        assert_eq!(
+            parsed_backup.get("model_provider").and_then(|v| v.as_str()),
+            Some("rightcode"),
+            "provider-derived restore backup should retain stable Codex model_provider"
+        );
+        let backup_model_providers = parsed_backup
+            .get("model_providers")
+            .and_then(|v| v.as_table())
+            .expect("backup model_providers");
+        assert!(backup_model_providers.get("aihubmix").is_none());
+        assert_eq!(
+            backup_model_providers
+                .get("rightcode")
+                .and_then(|v| v.get("base_url"))
+                .and_then(|v| v.as_str()),
+            Some("https://aihubmix.example/v1"),
+            "stable provider id should point at the hot-switched provider endpoint"
+        );
+
+        service
+            .restore_live_config_for_app_with_fallback(&AppType::Codex)
+            .await
+            .expect("restore Codex live config");
+
+        let live = service.read_codex_live().expect("read Codex live config");
+        let live_config = live
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("live config string");
+        let parsed_live: toml::Value = toml::from_str(live_config).expect("parse live config");
+        assert_eq!(
+            parsed_live.get("model_provider").and_then(|v| v.as_str()),
+            Some("rightcode"),
+            "restored Codex live config should not switch history buckets"
+        );
+        assert_eq!(
+            live.get("auth")
+                .and_then(|auth| auth.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some("aihubmix-key"),
+            "restore should still use the hot-switched provider auth"
         );
     }
 

--- a/src-tauri/tests/import_export_sync.rs
+++ b/src-tauri/tests/import_export_sync.rs
@@ -140,6 +140,93 @@ fn sync_codex_provider_writes_auth_and_config() {
 }
 
 #[test]
+fn sync_codex_provider_preserves_live_model_provider_id_for_history() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+
+    let legacy_auth = json!({ "OPENAI_API_KEY": "rightcode-key" });
+    let legacy_config = r#"model_provider = "rightcode"
+model = "gpt-5.4"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+    cc_switch_lib::write_codex_live_atomic(&legacy_auth, Some(legacy_config))
+        .expect("seed existing Codex live config");
+
+    let mut config = MultiAppConfig::default();
+    let provider_config = json!({
+        "auth": {
+            "OPENAI_API_KEY": "fresh-key"
+        },
+        "config": r#"model_provider = "aihubmix"
+model = "gpt-5.4"
+
+[model_providers.aihubmix]
+name = "AiHubMix"
+base_url = "https://aihubmix.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+    });
+
+    let provider = Provider::with_id(
+        "codex-1".to_string(),
+        "Codex Test".to_string(),
+        provider_config,
+        None,
+    );
+
+    let manager = config
+        .get_manager_mut(&AppType::Codex)
+        .expect("codex manager");
+    manager.providers.insert("codex-1".to_string(), provider);
+    manager.current = "codex-1".to_string();
+
+    ConfigService::sync_current_providers_to_live(&mut config).expect("sync codex live");
+
+    let toml_text =
+        fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read config.toml");
+    let parsed: toml::Value = toml::from_str(&toml_text).expect("parse config.toml");
+
+    assert_eq!(
+        parsed.get("model_provider").and_then(|v| v.as_str()),
+        Some("rightcode"),
+        "legacy ConfigService sync should use the stable live provider id"
+    );
+
+    let model_providers = parsed
+        .get("model_providers")
+        .and_then(|v| v.as_table())
+        .expect("model_providers should exist");
+    assert!(
+        model_providers.get("aihubmix").is_none(),
+        "provider-specific target id should not be written to live config"
+    );
+    assert_eq!(
+        model_providers
+            .get("rightcode")
+            .and_then(|v| v.get("base_url"))
+            .and_then(|v| v.as_str()),
+        Some("https://aihubmix.example/v1")
+    );
+
+    let synced_cfg = config
+        .get_manager(&AppType::Codex)
+        .and_then(|manager| manager.providers.get("codex-1"))
+        .and_then(|provider| provider.settings_config.get("config"))
+        .and_then(|v| v.as_str())
+        .expect("synced config string");
+    assert!(
+        synced_cfg.contains("[model_providers.rightcode]"),
+        "ConfigService keeps its existing behavior of syncing provider config from live"
+    );
+}
+
+#[test]
 fn sync_enabled_to_codex_writes_enabled_servers() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -4,8 +4,9 @@ use std::fs;
 use serde_json::json;
 
 use cc_switch_lib::{
-    get_claude_mcp_path, get_claude_settings_path, import_default_config_test_hook, AppError,
-    AppType, McpApps, McpServer, McpService, MultiAppConfig,
+    get_claude_mcp_path, get_claude_settings_path, import_default_config_test_hook,
+    import_mcp_from_selected_apps, AppError, AppType, McpApps, McpServer, McpService,
+    MultiAppConfig,
 };
 
 #[path = "support.rs"]
@@ -422,6 +423,59 @@ command = "echo"
     let entry = servers.get("shared").expect("shared server exists");
     assert!(entry.apps.claude, "shared should enable Claude");
     assert!(entry.apps.codex, "shared should enable Codex");
+}
+
+#[test]
+fn import_mcp_from_selected_apps_skips_hidden_apps() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let mcp_path = get_claude_mcp_path();
+    let claude_json = json!({
+        "mcpServers": {
+            "claude-only": {
+                "type": "stdio",
+                "command": "echo"
+            }
+        }
+    });
+    fs::write(
+        &mcp_path,
+        serde_json::to_string_pretty(&claude_json).expect("serialize claude mcp"),
+    )
+    .expect("seed ~/.claude.json");
+
+    let gemini_dir = home.join(".gemini");
+    fs::create_dir_all(&gemini_dir).expect("create gemini dir");
+    let gemini_settings = json!({
+        "mcpServers": {
+            "hidden-gemini": {
+                "type": "stdio",
+                "command": "gemini-echo"
+            }
+        }
+    });
+    fs::write(
+        gemini_dir.join("settings.json"),
+        serde_json::to_string_pretty(&gemini_settings).expect("serialize gemini settings"),
+    )
+    .expect("seed ~/.gemini/settings.json");
+
+    let state = support::create_test_state().expect("create test state");
+    let changed = import_mcp_from_selected_apps(&state, Some(vec!["claude".to_string()]))
+        .expect("import selected MCP apps");
+
+    assert_eq!(changed, 1, "only Claude server should be imported");
+    let servers = state.db.get_all_mcp_servers().expect("get all mcp servers");
+    assert!(
+        servers.contains_key("claude-only"),
+        "visible Claude server should be imported"
+    );
+    assert!(
+        !servers.contains_key("hidden-gemini"),
+        "hidden Gemini server should not be imported"
+    );
 }
 
 #[test]

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -240,6 +240,114 @@ command = "say"
 }
 
 #[test]
+fn provider_service_switch_codex_preserves_live_model_provider_id_for_history() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let legacy_auth = json!({ "OPENAI_API_KEY": "rightcode-key" });
+    let legacy_config = r#"model_provider = "rightcode"
+model = "gpt-5.4"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+    write_codex_live_atomic(&legacy_auth, Some(legacy_config))
+        .expect("seed existing codex live config");
+
+    let mut initial_config = MultiAppConfig::default();
+    {
+        let manager = initial_config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "old-provider".to_string();
+        manager.providers.insert(
+            "old-provider".to_string(),
+            Provider::with_id(
+                "old-provider".to_string(),
+                "RightCode".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "stale"},
+                    "config": legacy_config
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "new-provider".to_string(),
+            Provider::with_id(
+                "new-provider".to_string(),
+                "AiHubMix".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "fresh-key"},
+                    "config": r#"model_provider = "aihubmix"
+model = "gpt-5.4"
+
+[model_providers.aihubmix]
+name = "AiHubMix"
+base_url = "https://aihubmix.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = create_test_state_with_config(&initial_config).expect("create test state");
+
+    ProviderService::switch(&state, AppType::Codex, "new-provider")
+        .expect("switch provider should succeed");
+
+    let config_text =
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read config.toml");
+    let parsed: toml::Value = toml::from_str(&config_text).expect("parse config.toml");
+
+    assert_eq!(
+        parsed.get("model_provider").and_then(|v| v.as_str()),
+        Some("rightcode"),
+        "live Codex model_provider should stay stable so resume history remains visible"
+    );
+
+    let model_providers = parsed
+        .get("model_providers")
+        .and_then(|v| v.as_table())
+        .expect("model_providers table exists");
+    assert!(
+        model_providers.get("aihubmix").is_none(),
+        "target provider-specific id should be rewritten in live config"
+    );
+    assert_eq!(
+        model_providers
+            .get("rightcode")
+            .and_then(|v| v.get("base_url"))
+            .and_then(|v| v.as_str()),
+        Some("https://aihubmix.example/v1"),
+        "stable provider id should point at the newly selected supplier endpoint"
+    );
+
+    let providers = state
+        .db
+        .get_all_providers(AppType::Codex.as_str())
+        .expect("read providers after switch");
+    let new_config_text = providers
+        .get("new-provider")
+        .expect("new provider exists")
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        new_config_text.contains("[model_providers.aihubmix]"),
+        "stored provider template should remain provider-specific"
+    );
+}
+
+#[test]
 fn sync_current_provider_for_app_keeps_live_takeover_and_updates_restore_backup() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -348,6 +348,133 @@ requires_openai_auth = true
 }
 
 #[test]
+fn provider_service_switch_codex_backfill_keeps_provider_specific_model_provider_id() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let legacy_auth = json!({ "OPENAI_API_KEY": "rightcode-key" });
+    let provider_a_config = r#"model_provider = "rightcode"
+model = "gpt-5.4"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+    write_codex_live_atomic(&legacy_auth, Some(provider_a_config))
+        .expect("seed existing codex live config");
+
+    let mut initial_config = MultiAppConfig::default();
+    {
+        let manager = initial_config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "provider-a".to_string();
+        manager.providers.insert(
+            "provider-a".to_string(),
+            Provider::with_id(
+                "provider-a".to_string(),
+                "RightCode".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "rightcode-key"},
+                    "config": provider_a_config
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "provider-b".to_string(),
+            Provider::with_id(
+                "provider-b".to_string(),
+                "AiHubMix".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "aihubmix-key"},
+                    "config": r#"model_provider = "aihubmix"
+model = "gpt-5.4"
+profile = "work"
+
+[model_providers.aihubmix]
+name = "AiHubMix"
+base_url = "https://aihubmix.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+
+[profiles.work]
+model_provider = "aihubmix"
+model = "gpt-5.4"
+"#
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "provider-c".to_string(),
+            Provider::with_id(
+                "provider-c".to_string(),
+                "Vendor C".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "vendor-c-key"},
+                    "config": r#"model_provider = "vendor_c"
+model = "gpt-5.4"
+
+[model_providers.vendor_c]
+name = "Vendor C"
+base_url = "https://vendor-c.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = create_test_state_with_config(&initial_config).expect("create test state");
+
+    ProviderService::switch(&state, AppType::Codex, "provider-b")
+        .expect("switch to provider b should succeed");
+    ProviderService::switch(&state, AppType::Codex, "provider-c")
+        .expect("switch to provider c should succeed");
+
+    let providers = state
+        .db
+        .get_all_providers(AppType::Codex.as_str())
+        .expect("read providers after switches");
+    let provider_b_config = providers
+        .get("provider-b")
+        .expect("provider b exists")
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .expect("provider b config");
+    let parsed: toml::Value = toml::from_str(provider_b_config).expect("parse provider b config");
+
+    assert_eq!(
+        parsed.get("model_provider").and_then(|v| v.as_str()),
+        Some("aihubmix"),
+        "backfill should restore provider b's storage-specific model_provider id"
+    );
+    assert!(
+        parsed
+            .get("model_providers")
+            .and_then(|v| v.get("aihubmix"))
+            .is_some(),
+        "provider b should keep its own model_providers table after backfill"
+    );
+    assert_eq!(
+        parsed
+            .get("profiles")
+            .and_then(|v| v.get("work"))
+            .and_then(|v| v.get("model_provider"))
+            .and_then(|v| v.as_str()),
+        Some("aihubmix"),
+        "profile overrides should be restored to provider b's storage-specific id"
+    );
+}
+
+#[test]
 fn sync_current_provider_for_app_keeps_live_takeover_and_updates_restore_backup() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,12 @@ import ToolsPanel from "@/components/openclaw/ToolsPanel";
 import AgentsDefaultsPanel from "@/components/openclaw/AgentsDefaultsPanel";
 import OpenClawHealthBanner from "@/components/openclaw/OpenClawHealthBanner";
 import HermesMemoryPanel from "@/components/hermes/HermesMemoryPanel";
+import {
+  EMPTY_VISIBLE_APPS,
+  getFirstVisibleApp,
+  getSkillTargetApp,
+  resolveVisibleApps,
+} from "@/config/appConfig";
 
 type View =
   | "providers"
@@ -177,30 +183,22 @@ function App() {
     isLinux() && (settingsData?.useAppWindowControls ?? false);
   const dragBarHeight = useAppWindowControls ? 32 : DEFAULT_DRAG_BAR_HEIGHT;
   const contentTopOffset = dragBarHeight + HEADER_HEIGHT;
-  const visibleApps: VisibleApps = settingsData?.visibleApps ?? {
-    claude: true,
-    codex: true,
-    gemini: true,
-    opencode: true,
-    openclaw: true,
-    hermes: true,
-  };
-
-  const getFirstVisibleApp = (): AppId => {
-    if (visibleApps.claude) return "claude";
-    if (visibleApps.codex) return "codex";
-    if (visibleApps.gemini) return "gemini";
-    if (visibleApps.opencode) return "opencode";
-    if (visibleApps.openclaw) return "openclaw";
-    if (visibleApps.hermes) return "hermes";
-    return "claude"; // fallback
-  };
+  const visibleApps: VisibleApps | null = useMemo(
+    () => (settingsData ? resolveVisibleApps(settingsData.visibleApps) : null),
+    [settingsData],
+  );
+  const uiVisibleApps = visibleApps ?? EMPTY_VISIBLE_APPS;
 
   useEffect(() => {
+    if (!visibleApps) return;
     if (!visibleApps[activeApp]) {
-      setActiveApp(getFirstVisibleApp());
+      setActiveApp(getFirstVisibleApp(visibleApps));
     }
   }, [visibleApps, activeApp]);
+  const skillTargetApp = useMemo(
+    () => (visibleApps ? getSkillTargetApp(activeApp, visibleApps) : null),
+    [activeApp, visibleApps],
+  );
 
   // Fallback from sessions view when switching to an app without session support
   useEffect(() => {
@@ -917,14 +915,15 @@ function App() {
             <UnifiedSkillsPanel
               ref={unifiedSkillsPanelRef}
               onOpenDiscovery={() => setCurrentView("skillsDiscovery")}
-              currentApp={activeApp === "openclaw" ? "claude" : activeApp}
+              currentApp={skillTargetApp}
+              visibleApps={uiVisibleApps}
             />
           );
         case "skillsDiscovery":
           return (
             <SkillsPage
               ref={skillsPageRef}
-              initialApp={activeApp === "openclaw" ? "claude" : activeApp}
+              initialApp={skillTargetApp ?? null}
             />
           );
         case "mcp":
@@ -932,6 +931,7 @@ function App() {
             <UnifiedMcpPanel
               ref={mcpPanelRef}
               onOpenChange={() => setCurrentView("providers")}
+              visibleApps={uiVisibleApps}
             />
           );
         case "agents":
@@ -1360,12 +1360,14 @@ function App() {
                 )}
                 {currentView === "providers" && (
                   <>
-                    <AppSwitcher
-                      activeApp={activeApp}
-                      onSwitch={setActiveApp}
-                      visibleApps={visibleApps}
-                      compact={isToolbarCompact}
-                    />
+                    {visibleApps && (
+                      <AppSwitcher
+                        activeApp={activeApp}
+                        onSwitch={setActiveApp}
+                        visibleApps={visibleApps}
+                        compact={isToolbarCompact}
+                      />
+                    )}
 
                     <div className="flex items-center gap-1 p-1 bg-muted rounded-xl">
                       <AnimatePresence mode="wait">

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -2,6 +2,7 @@ import type { AppId } from "@/lib/api";
 import type { VisibleApps } from "@/types";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { cn } from "@/lib/utils";
+import { APP_IDS, filterVisibleAppIds } from "@/config/appConfig";
 
 interface AppSwitcherProps {
   activeApp: AppId;
@@ -10,14 +11,6 @@ interface AppSwitcherProps {
   compact?: boolean;
 }
 
-const ALL_APPS: AppId[] = [
-  "claude",
-  "codex",
-  "gemini",
-  "opencode",
-  "openclaw",
-  "hermes",
-];
 const STORAGE_KEY = "cc-switch-last-app";
 
 export function AppSwitcher({
@@ -49,11 +42,7 @@ export function AppSwitcher({
     hermes: "Hermes",
   };
 
-  // Filter apps based on visibility settings (default all visible)
-  const appsToShow = ALL_APPS.filter((app) => {
-    if (!visibleApps) return true;
-    return visibleApps[app];
-  });
+  const appsToShow = filterVisibleAppIds(APP_IDS, visibleApps);
 
   return (
     <div className="inline-flex bg-muted rounded-xl p-1 gap-1">

--- a/src/components/mcp/McpFormModal.tsx
+++ b/src/components/mcp/McpFormModal.tsx
@@ -9,6 +9,7 @@ import JsonEditor from "@/components/JsonEditor";
 import type { AppId } from "@/lib/api/types";
 import { McpServer, McpServerSpec } from "@/types";
 import { mcpPresets, getMcpPresetWithDescription } from "@/config/mcpPresets";
+import { MCP_APP_IDS } from "@/config/appConfig";
 import McpWizardModal from "./McpWizardModal";
 import {
   extractErrorMessage,
@@ -33,6 +34,7 @@ interface McpFormModalProps {
   existingIds?: string[];
   defaultFormat?: "json" | "toml";
   defaultEnabledApps?: AppId[];
+  visibleAppIds?: AppId[];
 }
 
 const McpFormModal: React.FC<McpFormModalProps> = ({
@@ -43,6 +45,7 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
   existingIds = [],
   defaultFormat = "json",
   defaultEnabledApps = ["claude", "codex", "gemini"],
+  visibleAppIds = MCP_APP_IDS,
 }) => {
   const { t } = useTranslation();
   const { formatTomlError, validateTomlConfig, validateJsonConfig } =
@@ -73,14 +76,33 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
       return { ...initialData.apps };
     }
     return {
-      claude: defaultEnabledApps.includes("claude"),
-      codex: defaultEnabledApps.includes("codex"),
-      gemini: defaultEnabledApps.includes("gemini"),
-      opencode: defaultEnabledApps.includes("opencode"),
-      openclaw: defaultEnabledApps.includes("openclaw"),
-      hermes: defaultEnabledApps.includes("hermes"),
+      claude:
+        visibleAppIds.includes("claude") &&
+        defaultEnabledApps.includes("claude"),
+      codex:
+        visibleAppIds.includes("codex") && defaultEnabledApps.includes("codex"),
+      gemini:
+        visibleAppIds.includes("gemini") &&
+        defaultEnabledApps.includes("gemini"),
+      opencode:
+        visibleAppIds.includes("opencode") &&
+        defaultEnabledApps.includes("opencode"),
+      openclaw:
+        visibleAppIds.includes("openclaw") &&
+        defaultEnabledApps.includes("openclaw"),
+      hermes:
+        visibleAppIds.includes("hermes") &&
+        defaultEnabledApps.includes("hermes"),
     };
   });
+  const enabledAppOptions = useMemo(
+    () => MCP_APP_IDS.filter((app) => visibleAppIds.includes(app)),
+    [visibleAppIds],
+  );
+  const visibleAppSet = useMemo(
+    () => new Set<AppId>(visibleAppIds),
+    [visibleAppIds],
+  );
 
   const isEditing = !!editingId;
 
@@ -282,6 +304,20 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
     }
   };
 
+  const getSubmitApps = () => {
+    if (isEditing) {
+      return enabledApps;
+    }
+
+    return MCP_APP_IDS.reduce(
+      (apps, app) => ({
+        ...apps,
+        [app]: visibleAppSet.has(app) && enabledApps[app],
+      }),
+      { ...enabledApps, openclaw: false },
+    );
+  };
+
   const handleSubmit = async () => {
     const trimmedId = formId.trim();
     if (!trimmedId) {
@@ -362,7 +398,7 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
         id: trimmedId,
         name: finalName,
         server: serverSpec,
-        apps: enabledApps,
+        apps: getSubmitApps(),
       };
 
       const descriptionTrimmed = formDescription.trim();
@@ -518,85 +554,23 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
                 {t("mcp.form.enabledApps")}
               </label>
               <div className="flex flex-wrap gap-4">
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="enable-claude"
-                    checked={enabledApps.claude}
-                    onCheckedChange={(checked: boolean) =>
-                      setEnabledApps({ ...enabledApps, claude: checked })
-                    }
-                  />
-                  <label
-                    htmlFor="enable-claude"
-                    className="text-sm text-foreground cursor-pointer select-none"
-                  >
-                    {t("mcp.unifiedPanel.apps.claude")}
-                  </label>
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="enable-codex"
-                    checked={enabledApps.codex}
-                    onCheckedChange={(checked: boolean) =>
-                      setEnabledApps({ ...enabledApps, codex: checked })
-                    }
-                  />
-                  <label
-                    htmlFor="enable-codex"
-                    className="text-sm text-foreground cursor-pointer select-none"
-                  >
-                    {t("mcp.unifiedPanel.apps.codex")}
-                  </label>
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="enable-gemini"
-                    checked={enabledApps.gemini}
-                    onCheckedChange={(checked: boolean) =>
-                      setEnabledApps({ ...enabledApps, gemini: checked })
-                    }
-                  />
-                  <label
-                    htmlFor="enable-gemini"
-                    className="text-sm text-foreground cursor-pointer select-none"
-                  >
-                    {t("mcp.unifiedPanel.apps.gemini")}
-                  </label>
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="enable-opencode"
-                    checked={enabledApps.opencode}
-                    onCheckedChange={(checked: boolean) =>
-                      setEnabledApps({ ...enabledApps, opencode: checked })
-                    }
-                  />
-                  <label
-                    htmlFor="enable-opencode"
-                    className="text-sm text-foreground cursor-pointer select-none"
-                  >
-                    {t("mcp.unifiedPanel.apps.opencode")}
-                  </label>
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="enable-hermes"
-                    checked={enabledApps.hermes}
-                    onCheckedChange={(checked: boolean) =>
-                      setEnabledApps({ ...enabledApps, hermes: checked })
-                    }
-                  />
-                  <label
-                    htmlFor="enable-hermes"
-                    className="text-sm text-foreground cursor-pointer select-none"
-                  >
-                    {t("mcp.unifiedPanel.apps.hermes")}
-                  </label>
-                </div>
+                {enabledAppOptions.map((app) => (
+                  <div key={app} className="flex items-center gap-2">
+                    <Checkbox
+                      id={`enable-${app}`}
+                      checked={enabledApps[app]}
+                      onCheckedChange={(checked: boolean) =>
+                        setEnabledApps({ ...enabledApps, [app]: checked })
+                      }
+                    />
+                    <label
+                      htmlFor={`enable-${app}`}
+                      className="text-sm text-foreground cursor-pointer select-none"
+                    >
+                      {t(`mcp.unifiedPanel.apps.${app}`)}
+                    </label>
+                  </div>
+                ))}
               </div>
             </div>
 

--- a/src/components/mcp/UnifiedMcpPanel.tsx
+++ b/src/components/mcp/UnifiedMcpPanel.tsx
@@ -9,7 +9,7 @@ import {
   useDeleteMcpServer,
   useImportMcpFromApps,
 } from "@/hooks/useMcp";
-import type { McpServer } from "@/types";
+import type { McpServer, VisibleApps } from "@/types";
 import type { AppId } from "@/lib/api/types";
 import McpFormModal from "./McpFormModal";
 import { ConfirmDialog } from "../ConfirmDialog";
@@ -17,13 +17,14 @@ import { Edit3, Trash2, ExternalLink } from "lucide-react";
 import { settingsApi } from "@/lib/api";
 import { mcpPresets } from "@/config/mcpPresets";
 import { toast } from "sonner";
-import { MCP_APP_IDS } from "@/config/appConfig";
+import { filterVisibleAppIds, MCP_APP_IDS } from "@/config/appConfig";
 import { AppCountBar } from "@/components/common/AppCountBar";
 import { AppToggleGroup } from "@/components/common/AppToggleGroup";
 import { ListItemRow } from "@/components/common/ListItemRow";
 
 interface UnifiedMcpPanelProps {
   onOpenChange: (open: boolean) => void;
+  visibleApps?: VisibleApps;
 }
 
 export interface UnifiedMcpPanelHandle {
@@ -34,7 +35,7 @@ export interface UnifiedMcpPanelHandle {
 const UnifiedMcpPanel = React.forwardRef<
   UnifiedMcpPanelHandle,
   UnifiedMcpPanelProps
->(({ onOpenChange: _onOpenChange }, ref) => {
+>(({ onOpenChange: _onOpenChange, visibleApps }, ref) => {
   const { t } = useTranslation();
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -49,6 +50,10 @@ const UnifiedMcpPanel = React.forwardRef<
   const toggleAppMutation = useToggleMcpApp();
   const deleteServerMutation = useDeleteMcpServer();
   const importMutation = useImportMcpFromApps();
+  const visibleMcpAppIds = useMemo(
+    () => filterVisibleAppIds(MCP_APP_IDS, visibleApps),
+    [visibleApps],
+  );
 
   const serverEntries = useMemo((): Array<[string, McpServer]> => {
     if (!serversMap) return [];
@@ -96,7 +101,7 @@ const UnifiedMcpPanel = React.forwardRef<
 
   const handleImport = async () => {
     try {
-      const count = await importMutation.mutateAsync();
+      const count = await importMutation.mutateAsync(visibleMcpAppIds);
       if (count === 0) {
         toast.success(t("mcp.unifiedPanel.noImportFound"), {
           closeButton: true,
@@ -143,7 +148,7 @@ const UnifiedMcpPanel = React.forwardRef<
       <AppCountBar
         totalLabel={t("mcp.serverCount", { count: serverEntries.length })}
         counts={enabledCounts}
-        appIds={MCP_APP_IDS}
+        appIds={visibleMcpAppIds}
       />
 
       <div className="flex-1 overflow-y-auto overflow-x-hidden pb-24">
@@ -174,6 +179,7 @@ const UnifiedMcpPanel = React.forwardRef<
                   onToggleApp={handleToggleApp}
                   onEdit={handleEdit}
                   onDelete={handleDelete}
+                  visibleAppIds={visibleMcpAppIds}
                   isLast={index === serverEntries.length - 1}
                 />
               ))}
@@ -190,6 +196,7 @@ const UnifiedMcpPanel = React.forwardRef<
           }
           existingIds={serversMap ? Object.keys(serversMap) : []}
           defaultFormat="json"
+          visibleAppIds={visibleMcpAppIds}
           onSave={async () => {
             setIsFormOpen(false);
             setEditingId(null);
@@ -219,6 +226,7 @@ interface UnifiedMcpListItemProps {
   onToggleApp: (serverId: string, app: AppId, enabled: boolean) => void;
   onEdit: (id: string) => void;
   onDelete: (id: string) => void;
+  visibleAppIds: AppId[];
   isLast?: boolean;
 }
 
@@ -228,6 +236,7 @@ const UnifiedMcpListItem: React.FC<UnifiedMcpListItemProps> = ({
   onToggleApp,
   onEdit,
   onDelete,
+  visibleAppIds,
   isLast,
 }) => {
   const { t } = useTranslation();
@@ -285,7 +294,7 @@ const UnifiedMcpListItem: React.FC<UnifiedMcpListItemProps> = ({
       <AppToggleGroup
         apps={server.apps}
         onToggle={(app, enabled) => onToggleApp(id, app, enabled)}
-        appIds={MCP_APP_IDS}
+        appIds={visibleAppIds}
       />
 
       <div className="flex items-center gap-0.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -5,6 +5,7 @@ import { ProviderIcon } from "@/components/ProviderIcon";
 import type { SettingsFormState } from "@/hooks/useSettings";
 import type { VisibleApps } from "@/types";
 import type { AppId } from "@/lib/api";
+import { resolveVisibleApps } from "@/config/appConfig";
 
 interface AppVisibilitySettingsProps {
   settings: SettingsFormState;
@@ -30,14 +31,7 @@ export function AppVisibilitySettings({
 }: AppVisibilitySettingsProps) {
   const { t } = useTranslation();
 
-  const visibleApps: VisibleApps = settings.visibleApps ?? {
-    claude: true,
-    codex: true,
-    gemini: true,
-    opencode: true,
-    openclaw: true,
-    hermes: true,
-  };
+  const visibleApps: VisibleApps = resolveVisibleApps(settings.visibleApps);
 
   // Count how many apps are currently visible
   const visibleCount = Object.values(visibleApps).filter(Boolean).length;

--- a/src/components/skills/SkillsPage.tsx
+++ b/src/components/skills/SkillsPage.tsx
@@ -37,7 +37,7 @@ import type {
 import { formatSkillError } from "@/lib/errors/skillErrorParser";
 
 interface SkillsPageProps {
-  initialApp?: AppId;
+  initialApp?: AppId | null;
 }
 
 export interface SkillsPageHandle {
@@ -212,6 +212,11 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
 
       if (!skill) {
         toast.error(t("skills.notFound"));
+        return;
+      }
+
+      if (!currentApp) {
+        toast.error(t("skills.noVisibleTargetApp"));
         return;
       }
 

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -31,10 +31,15 @@ import type { AppId } from "@/lib/api/types";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi, skillsApi } from "@/lib/api";
 import { toast } from "sonner";
-import { SKILLS_APP_IDS } from "@/config/appConfig";
+import {
+  filterVisibleAppIds,
+  getSkillTargetApp,
+  SKILLS_APP_IDS,
+} from "@/config/appConfig";
 import { AppCountBar } from "@/components/common/AppCountBar";
 import { AppToggleGroup } from "@/components/common/AppToggleGroup";
 import { ListItemRow } from "@/components/common/ListItemRow";
+import type { VisibleApps } from "@/types";
 import {
   Dialog,
   DialogContent,
@@ -46,7 +51,8 @@ import {
 
 interface UnifiedSkillsPanelProps {
   onOpenDiscovery: () => void;
-  currentApp: AppId;
+  currentApp: AppId | null;
+  visibleApps?: VisibleApps;
 }
 
 export interface UnifiedSkillsPanelHandle {
@@ -67,7 +73,7 @@ function formatSkillBackupDate(unixSeconds: number): string {
 const UnifiedSkillsPanel = React.forwardRef<
   UnifiedSkillsPanelHandle,
   UnifiedSkillsPanelProps
->(({ onOpenDiscovery, currentApp }, ref) => {
+>(({ onOpenDiscovery, currentApp, visibleApps }, ref) => {
   const { t } = useTranslation();
   const [confirmDialog, setConfirmDialog] = useState<{
     isOpen: boolean;
@@ -101,6 +107,14 @@ const UnifiedSkillsPanel = React.forwardRef<
   } = useCheckSkillUpdates();
   const updateSkillMutation = useUpdateSkill();
   const [isUpdatingAll, setIsUpdatingAll] = useState(false);
+  const visibleSkillAppIds = useMemo(
+    () => filterVisibleAppIds(SKILLS_APP_IDS, visibleApps),
+    [visibleApps],
+  );
+  const targetApp = useMemo(
+    () => (currentApp ? getSkillTargetApp(currentApp, visibleApps) : null),
+    [currentApp, visibleApps],
+  );
 
   const updatesMap = useMemo(() => {
     const map: Record<string, SkillUpdateInfo> = {};
@@ -196,12 +210,17 @@ const UnifiedSkillsPanel = React.forwardRef<
 
   const handleInstallFromZip = async () => {
     try {
+      if (!targetApp) {
+        toast.error(t("skills.noVisibleTargetApp"));
+        return;
+      }
+
       const filePath = await skillsApi.openZipFileDialog();
       if (!filePath) return;
 
       const installed = await installFromZipMutation.mutateAsync({
         filePath,
-        currentApp,
+        currentApp: targetApp,
       });
 
       if (installed.length === 0) {
@@ -286,9 +305,14 @@ const UnifiedSkillsPanel = React.forwardRef<
 
   const handleRestoreFromBackup = async (backupId: string) => {
     try {
+      if (!targetApp) {
+        toast.error(t("skills.noVisibleTargetApp"));
+        return;
+      }
+
       const restored = await restoreBackupMutation.mutateAsync({
         backupId,
-        currentApp,
+        currentApp: targetApp,
       });
       setRestoreDialogOpen(false);
       toast.success(
@@ -349,7 +373,7 @@ const UnifiedSkillsPanel = React.forwardRef<
         <AppCountBar
           totalLabel={t("skills.installed", { count: skills?.length || 0 })}
           counts={enabledCounts}
-          appIds={SKILLS_APP_IDS}
+          appIds={visibleSkillAppIds}
         />
         <div className="flex items-center gap-1.5">
           <div
@@ -430,6 +454,7 @@ const UnifiedSkillsPanel = React.forwardRef<
                   onToggleApp={handleToggleApp}
                   onUninstall={() => handleUninstall(skill)}
                   onUpdate={() => handleUpdateSkill(skill)}
+                  visibleAppIds={visibleSkillAppIds}
                   isLast={index === skills.length - 1}
                 />
               ))}
@@ -457,6 +482,7 @@ const UnifiedSkillsPanel = React.forwardRef<
           isImporting={importMutation.isPending}
           onImport={handleImport}
           onClose={() => setImportDialogOpen(false)}
+          visibleAppIds={visibleSkillAppIds}
         />
       )}
 
@@ -483,6 +509,7 @@ interface InstalledSkillListItemProps {
   onToggleApp: (id: string, app: AppId, enabled: boolean) => void;
   onUninstall: () => void;
   onUpdate?: () => void;
+  visibleAppIds: AppId[];
   isLast?: boolean;
 }
 
@@ -493,6 +520,7 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
   onToggleApp,
   onUninstall,
   onUpdate,
+  visibleAppIds,
   isLast,
 }) => {
   const { t } = useTranslation();
@@ -554,7 +582,7 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
       <AppToggleGroup
         apps={skill.apps}
         onToggle={(app, enabled) => onToggleApp(skill.id, app, enabled)}
-        appIds={SKILLS_APP_IDS}
+        appIds={visibleAppIds}
       />
 
       <div
@@ -604,6 +632,7 @@ interface ImportSkillsDialogProps {
   isImporting: boolean;
   onImport: (imports: ImportSkillSelection[]) => void;
   onClose: () => void;
+  visibleAppIds: AppId[];
 }
 
 interface RestoreSkillsDialogProps {
@@ -729,8 +758,37 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
   isImporting,
   onImport,
   onClose,
+  visibleAppIds,
 }) => {
   const { t } = useTranslation();
+  const visibleAppSet = useMemo(() => new Set(visibleAppIds), [visibleAppIds]);
+  const emptyApps = (): ImportSkillSelection["apps"] => ({
+    claude: false,
+    codex: false,
+    gemini: false,
+    opencode: false,
+    openclaw: false,
+    hermes: false,
+  });
+  const applyVisibleAppMask = (
+    apps: ImportSkillSelection["apps"],
+  ): ImportSkillSelection["apps"] => ({
+    claude: visibleAppSet.has("claude") && apps.claude,
+    codex: visibleAppSet.has("codex") && apps.codex,
+    gemini: visibleAppSet.has("gemini") && apps.gemini,
+    opencode: visibleAppSet.has("opencode") && apps.opencode,
+    openclaw: visibleAppSet.has("openclaw") && apps.openclaw,
+    hermes: visibleAppSet.has("hermes") && apps.hermes,
+  });
+  const appsFromFoundIn = (foundIn: string[]): ImportSkillSelection["apps"] =>
+    applyVisibleAppMask({
+      claude: foundIn.includes("claude"),
+      codex: foundIn.includes("codex"),
+      gemini: foundIn.includes("gemini"),
+      opencode: foundIn.includes("opencode"),
+      openclaw: false,
+      hermes: foundIn.includes("hermes"),
+    });
   const [selected, setSelected] = useState<Set<string>>(
     new Set(skills.map((s) => s.directory)),
   );
@@ -738,17 +796,7 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
     Record<string, ImportSkillSelection["apps"]>
   >(() =>
     Object.fromEntries(
-      skills.map((skill) => [
-        skill.directory,
-        {
-          claude: skill.foundIn.includes("claude"),
-          codex: skill.foundIn.includes("codex"),
-          gemini: skill.foundIn.includes("gemini"),
-          opencode: skill.foundIn.includes("opencode"),
-          openclaw: false,
-          hermes: skill.foundIn.includes("hermes"),
-        },
-      ]),
+      skills.map((skill) => [skill.directory, appsFromFoundIn(skill.foundIn)]),
     ),
   );
 
@@ -766,14 +814,7 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
     onImport(
       Array.from(selected).map((directory) => ({
         directory,
-        apps: selectedApps[directory] ?? {
-          claude: false,
-          codex: false,
-          gemini: false,
-          opencode: false,
-          openclaw: false,
-          hermes: false,
-        },
+        apps: applyVisibleAppMask(selectedApps[directory] ?? emptyApps()),
       })),
     );
   };
@@ -808,33 +849,17 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
                   )}
                   <div className="mt-2">
                     <AppToggleGroup
-                      apps={
-                        selectedApps[skill.directory] ?? {
-                          claude: false,
-                          codex: false,
-                          gemini: false,
-                          opencode: false,
-                          openclaw: false,
-                          hermes: false,
-                        }
-                      }
+                      apps={selectedApps[skill.directory] ?? emptyApps()}
                       onToggle={(app, enabled) => {
                         setSelectedApps((prev) => ({
                           ...prev,
                           [skill.directory]: {
-                            ...(prev[skill.directory] ?? {
-                              claude: false,
-                              codex: false,
-                              gemini: false,
-                              opencode: false,
-                              openclaw: false,
-                              hermes: false,
-                            }),
+                            ...(prev[skill.directory] ?? emptyApps()),
                             [app]: enabled,
                           },
                         }));
                       }}
-                      appIds={SKILLS_APP_IDS}
+                      appIds={visibleAppIds}
                     />
                   </div>
                   <div

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { AppId } from "@/lib/api/types";
+import type { VisibleApps } from "@/types";
 import {
   ClaudeIcon,
   CodexIcon,
@@ -24,6 +25,43 @@ export const APP_IDS: AppId[] = [
   "hermes",
 ];
 
+export const DEFAULT_VISIBLE_APPS: VisibleApps = {
+  claude: true,
+  codex: true,
+  gemini: true,
+  opencode: true,
+  openclaw: true,
+  hermes: false,
+};
+
+export const EMPTY_VISIBLE_APPS: VisibleApps = {
+  claude: false,
+  codex: false,
+  gemini: false,
+  opencode: false,
+  openclaw: false,
+  hermes: false,
+};
+
+export function resolveVisibleApps(visibleApps?: VisibleApps): VisibleApps {
+  return {
+    ...DEFAULT_VISIBLE_APPS,
+    ...visibleApps,
+  };
+}
+
+export function filterVisibleAppIds(
+  appIds: readonly AppId[],
+  visibleApps?: VisibleApps,
+): AppId[] {
+  const resolved = resolveVisibleApps(visibleApps);
+  return appIds.filter((app) => resolved[app]);
+}
+
+export function getFirstVisibleApp(visibleApps?: VisibleApps): AppId {
+  return filterVisibleAppIds(APP_IDS, visibleApps)[0] ?? "claude";
+}
+
 /** App IDs shown in Skills panels (excludes OpenClaw — it doesn't support Skills) */
 export const SKILLS_APP_IDS: AppId[] = [
   "claude",
@@ -32,6 +70,16 @@ export const SKILLS_APP_IDS: AppId[] = [
   "opencode",
   "hermes",
 ];
+
+export function getSkillTargetApp(
+  currentApp: AppId,
+  visibleApps?: VisibleApps,
+): AppId | null {
+  const visibleSkillAppIds = filterVisibleAppIds(SKILLS_APP_IDS, visibleApps);
+  return visibleSkillAppIds.includes(currentApp)
+    ? currentApp
+    : (visibleSkillAppIds[0] ?? null);
+}
 
 /** App IDs shown in MCP panels (excludes OpenClaw) */
 export const MCP_APP_IDS: AppId[] = [...SKILLS_APP_IDS];

--- a/src/hooks/useMcp.ts
+++ b/src/hooks/useMcp.ts
@@ -66,7 +66,7 @@ export function useDeleteMcpServer() {
 export function useImportMcpFromApps() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => mcpApi.importFromApps(),
+    mutationFn: (apps?: AppId[]) => mcpApi.importFromApps(apps),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["mcp", "all"] });
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1775,6 +1775,7 @@
     "loadFailed": "Failed to load",
     "installSuccess": "Skill {{name}} installed",
     "installFailed": "Failed to install",
+    "noVisibleTargetApp": "Enable Claude, Codex, Gemini, OpenCode, or Hermes before installing skills",
     "uninstallSuccess": "Skill {{name}} uninstalled",
     "uninstallFailed": "Failed to uninstall",
     "update": "Update",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1775,6 +1775,7 @@
     "loadFailed": "読み込みに失敗しました",
     "installSuccess": "スキル {{name}} をインストールしました",
     "installFailed": "インストールに失敗しました",
+    "noVisibleTargetApp": "スキルをインストールする前に Claude、Codex、Gemini、OpenCode、Hermes のいずれかを表示してください",
     "uninstallSuccess": "スキル {{name}} をアンインストールしました",
     "uninstallFailed": "アンインストールに失敗しました",
     "update": "更新",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1775,6 +1775,7 @@
     "loadFailed": "加载失败",
     "installSuccess": "技能 {{name}} 已安装",
     "installFailed": "安装失败",
+    "noVisibleTargetApp": "请先显示 Claude、Codex、Gemini、OpenCode 或 Hermes，再安装技能",
     "uninstallSuccess": "技能 {{name}} 已卸载",
     "uninstallFailed": "卸载失败",
     "update": "更新",

--- a/src/lib/api/mcp.ts
+++ b/src/lib/api/mcp.ts
@@ -123,7 +123,7 @@ export const mcpApi = {
   /**
    * 从所有应用导入 MCP 服务器
    */
-  async importFromApps(): Promise<number> {
-    return await invoke("import_mcp_from_apps");
+  async importFromApps(apps?: AppId[]): Promise<number> {
+    return await invoke("import_mcp_from_apps", { apps });
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,7 +284,7 @@ export interface Settings {
   // 首选语言（可选，默认中文）
   language?: "en" | "zh" | "ja";
 
-  // 主页面显示的应用（默认全部显示）
+  // 主页面显示的应用（默认显示 Claude/Codex/Gemini/OpenCode/OpenClaw，Hermes 默认隐藏）
   visibleApps?: VisibleApps;
 
   // ===== 设备级目录覆盖 =====

--- a/tests/components/McpFormModal.test.tsx
+++ b/tests/components/McpFormModal.test.tsx
@@ -156,7 +156,7 @@ describe("McpFormModal", () => {
     } = props ?? {};
     const onSave = overrideOnSave ?? vi.fn().mockResolvedValue(undefined);
     const onClose = overrideOnClose ?? vi.fn();
-    render(
+    const renderResult = render(
       <McpFormModal
         onSave={onSave}
         onClose={onClose}
@@ -165,7 +165,7 @@ describe("McpFormModal", () => {
         {...rest}
       />,
     );
-    return { onSave, onClose };
+    return { onSave, onClose, ...renderResult };
   };
 
   it("应用预设后填充 ID 与配置内容", async () => {
@@ -393,6 +393,117 @@ type = "stdio"
     });
     expect(onSave).toHaveBeenCalledTimes(1);
     expect(onSave).toHaveBeenCalledWith();
+  });
+
+  it("隐藏应用不显示复选框，保存时保留隐藏应用已有状态", async () => {
+    const initialData: McpServer = {
+      id: "existing",
+      name: "Existing",
+      server: { type: "stdio", command: "old" },
+      apps: {
+        claude: true,
+        codex: false,
+        gemini: true,
+        opencode: false,
+        openclaw: false,
+        hermes: false,
+      },
+    };
+
+    renderForm({
+      editingId: "existing",
+      initialData,
+      visibleAppIds: ["claude", "codex"],
+    });
+
+    expect(
+      screen.queryByLabelText("mcp.unifiedPanel.apps.gemini"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.jsonPlaceholder"), {
+      target: { value: '{"type":"stdio","command":"updated"}' },
+    });
+    fireEvent.click(screen.getByText("common.save"));
+
+    await waitFor(() => expect(upsertMock).toHaveBeenCalledTimes(1));
+    const [entry] = upsertMock.mock.calls.at(-1) ?? [];
+    expect(entry.apps).toEqual({
+      claude: true,
+      codex: false,
+      gemini: true,
+      opencode: false,
+      openclaw: false,
+      hermes: false,
+    });
+  });
+
+  it("新增时隐藏应用不会被默认启用", async () => {
+    renderForm({ visibleAppIds: ["claude", "codex"] });
+
+    expect(
+      screen.queryByLabelText("mcp.unifiedPanel.apps.gemini"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.titlePlaceholder"), {
+      target: { value: "visible-only" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.jsonPlaceholder"), {
+      target: { value: '{"type":"stdio","command":"run"}' },
+    });
+    fireEvent.click(screen.getByText("common.add"));
+
+    await waitFor(() => expect(upsertMock).toHaveBeenCalledTimes(1));
+    const [entry] = upsertMock.mock.calls.at(-1) ?? [];
+    expect(entry.apps).toEqual({
+      claude: true,
+      codex: true,
+      gemini: false,
+      opencode: false,
+      openclaw: false,
+      hermes: false,
+    });
+  });
+
+  it("新增表单打开后应用变为隐藏时不会保存隐藏应用启用状态", async () => {
+    const { onSave, onClose, rerender } = renderForm({
+      visibleAppIds: ["claude", "codex", "gemini"],
+    });
+
+    expect(screen.getByLabelText("mcp.unifiedPanel.apps.gemini")).toBeChecked();
+
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.titlePlaceholder"), {
+      target: { value: "visible-changed" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.jsonPlaceholder"), {
+      target: { value: '{"type":"stdio","command":"run"}' },
+    });
+
+    rerender(
+      <McpFormModal
+        onSave={onSave}
+        onClose={onClose}
+        existingIds={[]}
+        defaultFormat="json"
+        visibleAppIds={["claude", "codex"]}
+      />,
+    );
+
+    expect(
+      screen.queryByLabelText("mcp.unifiedPanel.apps.gemini"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("common.add"));
+
+    await waitFor(() => expect(upsertMock).toHaveBeenCalledTimes(1));
+    const [entry] = upsertMock.mock.calls.at(-1) ?? [];
+    expect(entry.apps).toEqual({
+      claude: true,
+      codex: true,
+      gemini: false,
+      opencode: false,
+      openclaw: false,
+      hermes: false,
+    });
   });
 
   it("允许未选择任何应用保存配置，并保持 apps 全 false", async () => {

--- a/tests/components/UnifiedMcpPanel.test.tsx
+++ b/tests/components/UnifiedMcpPanel.test.tsx
@@ -1,0 +1,101 @@
+import { createRef } from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import UnifiedMcpPanel, {
+  type UnifiedMcpPanelHandle,
+} from "@/components/mcp/UnifiedMcpPanel";
+
+const importMcpMock = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+vi.mock("@/hooks/useMcp", () => ({
+  useAllMcpServers: () => ({
+    data: {},
+    isLoading: false,
+  }),
+  useToggleMcpApp: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useDeleteMcpServer: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useImportMcpFromApps: () => ({
+    mutateAsync: (...args: unknown[]) => importMcpMock(...args),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, type = "button", ...rest }: any) => (
+    <button type={type} onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, ...rest }: any) => <span {...rest}>{children}</span>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: any) => <div>{children}</div>,
+  Tooltip: ({ children }: any) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: any) => <>{children}</>,
+  TooltipContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/mcp/McpFormModal", () => ({
+  default: () => <div data-testid="mcp-form" />,
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+describe("UnifiedMcpPanel", () => {
+  beforeEach(() => {
+    importMcpMock.mockReset();
+    importMcpMock.mockResolvedValue(0);
+  });
+
+  it("imports MCP servers only from visible apps", async () => {
+    const ref = createRef<UnifiedMcpPanelHandle>();
+
+    render(
+      <UnifiedMcpPanel
+        ref={ref}
+        onOpenChange={() => {}}
+        visibleApps={{
+          claude: true,
+          codex: true,
+          gemini: false,
+          opencode: true,
+          openclaw: true,
+          hermes: false,
+        }}
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openImport();
+    });
+
+    await waitFor(() => expect(importMcpMock).toHaveBeenCalledTimes(1));
+    expect(importMcpMock).toHaveBeenCalledWith(["claude", "codex", "opencode"]);
+  });
+});

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -1,5 +1,11 @@
 import { createRef } from "react";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  act,
+  fireEvent,
+} from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import UnifiedSkillsPanel, {
@@ -13,12 +19,26 @@ const importSkillsMock = vi.fn();
 const installFromZipMock = vi.fn();
 const deleteSkillBackupMock = vi.fn();
 const restoreSkillBackupMock = vi.fn();
+const openZipFileDialogMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+const toastInfoMock = vi.hoisted(() => vi.fn());
+let unmanagedSkillsData = [
+  {
+    directory: "shared-skill",
+    name: "Shared Skill",
+    description: "Imported from Claude",
+    foundIn: ["claude"],
+    path: "/tmp/shared-skill",
+  },
+];
+let skillBackupsData: any[] = [];
 
 vi.mock("sonner", () => ({
   toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+    info: (...args: unknown[]) => toastInfoMock(...args),
   },
 }));
 
@@ -28,7 +48,7 @@ vi.mock("@/hooks/useSkills", () => ({
     isLoading: false,
   }),
   useSkillBackups: () => ({
-    data: [],
+    data: skillBackupsData,
     refetch: vi.fn(),
     isFetching: false,
   }),
@@ -47,15 +67,7 @@ vi.mock("@/hooks/useSkills", () => ({
     mutateAsync: uninstallSkillMock,
   }),
   useScanUnmanagedSkills: () => ({
-    data: [
-      {
-        directory: "shared-skill",
-        name: "Shared Skill",
-        description: "Imported from Claude",
-        foundIn: ["claude"],
-        path: "/tmp/shared-skill",
-      },
-    ],
+    data: unmanagedSkillsData,
     refetch: scanUnmanagedMock,
   }),
   useImportSkillsFromApps: () => ({
@@ -75,23 +87,39 @@ vi.mock("@/hooks/useSkills", () => ({
   }),
 }));
 
+vi.mock("@/lib/api", () => ({
+  settingsApi: {
+    openExternal: vi.fn(),
+  },
+  skillsApi: {
+    openZipFileDialog: openZipFileDialogMock,
+  },
+}));
+
 describe("UnifiedSkillsPanel", () => {
   beforeEach(() => {
+    unmanagedSkillsData = [
+      {
+        directory: "shared-skill",
+        name: "Shared Skill",
+        description: "Imported from Claude",
+        foundIn: ["claude"],
+        path: "/tmp/shared-skill",
+      },
+    ];
+    skillBackupsData = [];
     scanUnmanagedMock.mockResolvedValue({
-      data: [
-        {
-          directory: "shared-skill",
-          name: "Shared Skill",
-          description: "Imported from Claude",
-          foundIn: ["claude"],
-          path: "/tmp/shared-skill",
-        },
-      ],
+      data: unmanagedSkillsData,
     });
     toggleSkillAppMock.mockReset();
     uninstallSkillMock.mockReset();
     importSkillsMock.mockReset();
     installFromZipMock.mockReset();
+    openZipFileDialogMock.mockReset();
+    openZipFileDialogMock.mockResolvedValue(null);
+    toastErrorMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastInfoMock.mockReset();
     deleteSkillBackupMock.mockReset();
     restoreSkillBackupMock.mockReset();
   });
@@ -116,5 +144,238 @@ describe("UnifiedSkillsPanel", () => {
       expect(screen.getByText("Shared Skill")).toBeInTheDocument();
       expect(screen.getByText("/tmp/shared-skill")).toBeInTheDocument();
     });
+  });
+
+  it("does not enable hidden apps when importing unmanaged skills", async () => {
+    unmanagedSkillsData = [
+      {
+        directory: "hermes-only-skill",
+        name: "Hermes Only Skill",
+        description: "Imported from Hermes",
+        foundIn: ["hermes"],
+        path: "/tmp/hermes-only-skill",
+      },
+    ];
+    scanUnmanagedMock.mockResolvedValue({ data: unmanagedSkillsData });
+    importSkillsMock.mockResolvedValue([]);
+
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp="claude"
+        visibleApps={{
+          claude: true,
+          codex: true,
+          gemini: true,
+          opencode: true,
+          openclaw: true,
+          hermes: false,
+        }}
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openImport();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hermes Only Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Hermes")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("skills.importSelected"));
+
+    await waitFor(() => expect(importSkillsMock).toHaveBeenCalledTimes(1));
+    expect(importSkillsMock).toHaveBeenCalledWith([
+      {
+        directory: "hermes-only-skill",
+        apps: {
+          claude: false,
+          codex: false,
+          gemini: false,
+          opencode: false,
+          openclaw: false,
+          hermes: false,
+        },
+      },
+    ]);
+  });
+
+  it("uses the first visible skills app for ZIP install when current app cannot host skills", async () => {
+    installFromZipMock.mockResolvedValue([]);
+    openZipFileDialogMock.mockResolvedValue("/tmp/skills.zip");
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp="openclaw"
+        visibleApps={{
+          claude: false,
+          codex: true,
+          gemini: true,
+          opencode: true,
+          openclaw: true,
+          hermes: false,
+        }}
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openInstallFromZip();
+    });
+
+    await waitFor(() => expect(installFromZipMock).toHaveBeenCalledTimes(1));
+    expect(installFromZipMock).toHaveBeenCalledWith({
+      filePath: "/tmp/skills.zip",
+      currentApp: "codex",
+    });
+  });
+
+  it("uses the first visible skills app for backup restore when current app cannot host skills", async () => {
+    skillBackupsData = [
+      {
+        backupId: "backup-1",
+        backupPath: "/tmp/backup-1",
+        createdAt: 1,
+        skill: {
+          id: "restored-skill",
+          name: "Restored Skill",
+          directory: "restored-skill",
+          apps: {
+            claude: true,
+            codex: false,
+            gemini: false,
+            opencode: false,
+            openclaw: false,
+            hermes: false,
+          },
+          installedAt: 1,
+          updatedAt: 0,
+        },
+      },
+    ];
+    restoreSkillBackupMock.mockResolvedValue({
+      name: "Restored Skill",
+    });
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp="claude"
+        visibleApps={{
+          claude: false,
+          codex: true,
+          gemini: true,
+          opencode: true,
+          openclaw: true,
+          hermes: false,
+        }}
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openRestoreFromBackup();
+    });
+
+    fireEvent.click(
+      await screen.findByText("skills.restoreFromBackup.restore"),
+    );
+
+    await waitFor(() =>
+      expect(restoreSkillBackupMock).toHaveBeenCalledTimes(1),
+    );
+    expect(restoreSkillBackupMock).toHaveBeenCalledWith({
+      backupId: "backup-1",
+      currentApp: "codex",
+    });
+  });
+
+  it("does not install from ZIP when only OpenClaw is visible", async () => {
+    openZipFileDialogMock.mockResolvedValue("/tmp/skills.zip");
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp={null}
+        visibleApps={{
+          claude: false,
+          codex: false,
+          gemini: false,
+          opencode: false,
+          openclaw: true,
+          hermes: false,
+        }}
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openInstallFromZip();
+    });
+
+    expect(openZipFileDialogMock).not.toHaveBeenCalled();
+    expect(installFromZipMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith("skills.noVisibleTargetApp");
+  });
+
+  it("does not restore a backup when only OpenClaw is visible", async () => {
+    skillBackupsData = [
+      {
+        backupId: "backup-1",
+        backupPath: "/tmp/backup-1",
+        createdAt: 1,
+        skill: {
+          id: "restored-skill",
+          name: "Restored Skill",
+          directory: "restored-skill",
+          apps: {
+            claude: true,
+            codex: false,
+            gemini: false,
+            opencode: false,
+            openclaw: false,
+            hermes: false,
+          },
+          installedAt: 1,
+          updatedAt: 0,
+        },
+      },
+    ];
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp={null}
+        visibleApps={{
+          claude: false,
+          codex: false,
+          gemini: false,
+          opencode: false,
+          openclaw: true,
+          hermes: false,
+        }}
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openRestoreFromBackup();
+    });
+
+    fireEvent.click(
+      await screen.findByText("skills.restoreFromBackup.restore"),
+    );
+
+    expect(restoreSkillBackupMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith("skills.noVisibleTargetApp");
   });
 });

--- a/tests/config/appConfig.test.ts
+++ b/tests/config/appConfig.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_VISIBLE_APPS,
+  EMPTY_VISIBLE_APPS,
+  filterVisibleAppIds,
+  getSkillTargetApp,
+  resolveVisibleApps,
+} from "@/config/appConfig";
+
+describe("appConfig visibility helpers", () => {
+  it("keeps Hermes hidden by default and hides every app before settings resolve", () => {
+    expect(DEFAULT_VISIBLE_APPS.hermes).toBe(false);
+    expect(Object.values(EMPTY_VISIBLE_APPS).every((visible) => !visible)).toBe(
+      true,
+    );
+    expect(resolveVisibleApps().hermes).toBe(false);
+  });
+
+  it("filters app ids using persisted defaults after settings load", () => {
+    expect(filterVisibleAppIds(["claude", "hermes"], undefined)).toEqual([
+      "claude",
+    ]);
+    expect(
+      filterVisibleAppIds(["claude", "hermes"], EMPTY_VISIBLE_APPS),
+    ).toEqual([]);
+  });
+
+  it("selects a visible app for skill install flows", () => {
+    const visibleApps = {
+      claude: false,
+      codex: true,
+      gemini: true,
+      opencode: true,
+      openclaw: true,
+      hermes: false,
+    };
+
+    expect(getSkillTargetApp("openclaw", visibleApps)).toBe("codex");
+    expect(getSkillTargetApp("claude", visibleApps)).toBe("codex");
+    expect(getSkillTargetApp("gemini", visibleApps)).toBe("gemini");
+    expect(
+      getSkillTargetApp("openclaw", {
+        claude: false,
+        codex: false,
+        gemini: false,
+        opencode: false,
+        openclaw: true,
+        hermes: false,
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- centralize visible-app defaults and filtering for app switcher, settings, Skills, and MCP panels
- hide disabled apps from Skills/MCP counts, toggles, forms, and import dialogs while preserving hidden app state on edit
- prevent hidden apps from being enabled by new/import/ZIP/restore flows, including loading state and only-OpenClaw-visible edge cases
- restrict MCP import to currently visible MCP-capable apps

## Tests
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run tests/config/appConfig.test.ts tests/components/McpFormModal.test.tsx tests/components/UnifiedMcpPanel.test.tsx tests/components/UnifiedSkillsPanel.test.tsx
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml --test mcp_commands import_mcp_from_selected_apps_skips_hidden_apps
- git diff --check

## Review
- final subagent review: No findings