### PR TITLE
[codex] Auto-fill OpenCode models from fetched list

### DIFF
--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
 import {
   getModelExtraFields,
   isKnownModelKey,
+  mergeFetchedModelsIntoOpenCodeModels,
 } from "./helpers/opencodeFormUtils";
 import type { ProviderCategory, OpenCodeModel } from "@/types";
 
@@ -190,6 +191,11 @@ export function OpenCodeFormFields({
 
   const [fetchedModels, setFetchedModels] = useState<FetchedModel[]>([]);
   const [isFetchingModels, setIsFetchingModels] = useState(false);
+  const modelsRef = useRef(models);
+
+  useEffect(() => {
+    modelsRef.current = models;
+  }, [models]);
 
   const handleFetchModels = useCallback(() => {
     if (!baseUrl || !apiKey) {
@@ -201,13 +207,20 @@ export function OpenCodeFormFields({
     }
     setIsFetchingModels(true);
     fetchModelsForConfig(baseUrl, apiKey)
-      .then((models) => {
-        setFetchedModels(models);
-        if (models.length === 0) {
+      .then((fetched) => {
+        setFetchedModels(fetched);
+        if (fetched.length === 0) {
           toast.info(t("providerForm.fetchModelsEmpty"));
         } else {
+          const mergedModels = mergeFetchedModelsIntoOpenCodeModels(
+            modelsRef.current,
+            fetched,
+          );
+          if (mergedModels !== modelsRef.current) {
+            onModelsChange(mergedModels);
+          }
           toast.success(
-            t("providerForm.fetchModelsSuccess", { count: models.length }),
+            t("providerForm.fetchModelsSuccess", { count: fetched.length }),
           );
         }
       })
@@ -216,7 +229,7 @@ export function OpenCodeFormFields({
         showFetchModelsError(err, t);
       })
       .finally(() => setIsFetchingModels(false));
-  }, [baseUrl, apiKey, t]);
+  }, [baseUrl, apiKey, onModelsChange, t]);
 
   // Track which models have expanded options panel
   const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());

--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -197,6 +197,14 @@ export function OpenCodeFormFields({
     modelsRef.current = models;
   }, [models]);
 
+  const commitModelsChange = useCallback(
+    (nextModels: Record<string, OpenCodeModel>) => {
+      modelsRef.current = nextModels;
+      onModelsChange(nextModels);
+    },
+    [onModelsChange],
+  );
+
   const handleFetchModels = useCallback(() => {
     if (!baseUrl || !apiKey) {
       showFetchModelsError(null, t, {
@@ -217,7 +225,7 @@ export function OpenCodeFormFields({
             fetched,
           );
           if (mergedModels !== modelsRef.current) {
-            onModelsChange(mergedModels);
+            commitModelsChange(mergedModels);
           }
           toast.success(
             t("providerForm.fetchModelsSuccess", { count: fetched.length }),
@@ -229,7 +237,7 @@ export function OpenCodeFormFields({
         showFetchModelsError(err, t);
       })
       .finally(() => setIsFetchingModels(false));
-  }, [baseUrl, apiKey, onModelsChange, t]);
+  }, [baseUrl, apiKey, commitModelsChange, t]);
 
   // Track which models have expanded options panel
   const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());
@@ -247,17 +255,18 @@ export function OpenCodeFormFields({
   // Add a new model entry
   const handleAddModel = () => {
     const newKey = `model-${Date.now()}`;
-    onModelsChange({
-      ...models,
+    const currentModels = modelsRef.current;
+    commitModelsChange({
+      ...currentModels,
       [newKey]: { name: "" },
     });
   };
 
   // Remove a model entry
   const handleRemoveModel = (key: string) => {
-    const newModels = { ...models };
+    const newModels = { ...modelsRef.current };
     delete newModels[key];
-    onModelsChange(newModels);
+    commitModelsChange(newModels);
     // Also remove from expanded set
     setExpandedModels((prev) => {
       const next = new Set(prev);
@@ -270,14 +279,14 @@ export function OpenCodeFormFields({
   const handleModelIdChange = (oldKey: string, newKey: string) => {
     if (oldKey === newKey || !newKey.trim()) return;
     const newModels: Record<string, OpenCodeModel> = {};
-    for (const [k, v] of Object.entries(models)) {
+    for (const [k, v] of Object.entries(modelsRef.current)) {
       if (k === oldKey) {
         newModels[newKey] = v;
       } else {
         newModels[k] = v;
       }
     }
-    onModelsChange(newModels);
+    commitModelsChange(newModels);
     // Update expanded set if this model was expanded
     if (expandedModels.has(oldKey)) {
       setExpandedModels((prev) => {
@@ -291,18 +300,20 @@ export function OpenCodeFormFields({
 
   // Update model name
   const handleModelNameChange = (key: string, name: string) => {
-    onModelsChange({
-      ...models,
-      [key]: { ...models[key], name },
+    const currentModels = modelsRef.current;
+    commitModelsChange({
+      ...currentModels,
+      [key]: { ...currentModels[key], name },
     });
   };
 
   // Model options handlers
   const handleAddModelOption = (modelKey: string) => {
-    const model = models[modelKey];
+    const currentModels = modelsRef.current;
+    const model = currentModels[modelKey];
     const newOptionKey = `option-${Date.now()}`;
-    onModelsChange({
-      ...models,
+    commitModelsChange({
+      ...currentModels,
       [modelKey]: {
         ...model,
         options: { ...model.options, [newOptionKey]: "" },
@@ -311,11 +322,12 @@ export function OpenCodeFormFields({
   };
 
   const handleRemoveModelOption = (modelKey: string, optionKey: string) => {
-    const model = models[modelKey];
+    const currentModels = modelsRef.current;
+    const model = currentModels[modelKey];
     const newOptions = { ...model.options };
     delete newOptions[optionKey];
-    onModelsChange({
-      ...models,
+    commitModelsChange({
+      ...currentModels,
       [modelKey]: {
         ...model,
         options: Object.keys(newOptions).length > 0 ? newOptions : undefined,
@@ -329,14 +341,15 @@ export function OpenCodeFormFields({
     newKey: string,
   ) => {
     if (!newKey.trim() || oldKey === newKey) return;
-    const model = models[modelKey];
+    const currentModels = modelsRef.current;
+    const model = currentModels[modelKey];
     const newOptions: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(model.options || {})) {
       if (k === oldKey) newOptions[newKey] = v;
       else newOptions[k] = v;
     }
-    onModelsChange({
-      ...models,
+    commitModelsChange({
+      ...currentModels,
       [modelKey]: { ...model, options: newOptions },
     });
   };
@@ -346,15 +359,16 @@ export function OpenCodeFormFields({
     optionKey: string,
     value: string,
   ) => {
-    const model = models[modelKey];
+    const currentModels = modelsRef.current;
+    const model = currentModels[modelKey];
     let parsedValue: unknown;
     try {
       parsedValue = JSON.parse(value);
     } catch {
       parsedValue = value;
     }
-    onModelsChange({
-      ...models,
+    commitModelsChange({
+      ...currentModels,
       [modelKey]: {
         ...model,
         options: { ...model.options, [optionKey]: parsedValue },
@@ -364,20 +378,22 @@ export function OpenCodeFormFields({
 
   // Model extra field handlers (top-level properties like variants, cost)
   const handleAddModelExtraField = (modelKey: string) => {
-    const model = models[modelKey];
+    const currentModels = modelsRef.current;
+    const model = currentModels[modelKey];
     const newFieldKey = `option-${Date.now()}`;
-    onModelsChange({
-      ...models,
+    commitModelsChange({
+      ...currentModels,
       [modelKey]: { ...model, [newFieldKey]: "" },
     });
   };
 
   const handleRemoveModelExtraField = (modelKey: string, fieldKey: string) => {
-    const model = models[modelKey];
+    const currentModels = modelsRef.current;
+    const model = currentModels[modelKey];
     const newModel = { ...model };
     delete newModel[fieldKey];
-    onModelsChange({
-      ...models,
+    commitModelsChange({
+      ...currentModels,
       [modelKey]: newModel,
     });
   };
@@ -388,7 +404,8 @@ export function OpenCodeFormFields({
     newKey: string,
   ) => {
     if (!newKey.trim() || oldKey === newKey) return;
-    const model = models[modelKey];
+    const currentModels = modelsRef.current;
+    const model = currentModels[modelKey];
     // Reject reserved keys and duplicate extra field names
     if (isKnownModelKey(newKey) || (newKey !== oldKey && newKey in model))
       return;
@@ -397,8 +414,8 @@ export function OpenCodeFormFields({
       if (k === oldKey) newModel[newKey] = v;
       else newModel[k] = v;
     }
-    onModelsChange({
-      ...models,
+    commitModelsChange({
+      ...currentModels,
       [modelKey]: newModel as OpenCodeModel,
     });
   };
@@ -408,15 +425,16 @@ export function OpenCodeFormFields({
     fieldKey: string,
     value: string,
   ) => {
-    const model = models[modelKey];
+    const currentModels = modelsRef.current;
+    const model = currentModels[modelKey];
     let parsedValue: unknown;
     try {
       parsedValue = JSON.parse(value);
     } catch {
       parsedValue = value;
     }
-    onModelsChange({
-      ...models,
+    commitModelsChange({
+      ...currentModels,
       [modelKey]: { ...model, [fieldKey]: parsedValue },
     });
   };

--- a/src/components/providers/forms/helpers/opencodeFormUtils.ts
+++ b/src/components/providers/forms/helpers/opencodeFormUtils.ts
@@ -152,6 +152,24 @@ export function toOpencodeExtraOptions(
   return extra;
 }
 
+export function mergeFetchedModelsIntoOpenCodeModels(
+  current: Record<string, OpenCodeModel>,
+  fetched: Array<{ id: string }>,
+): Record<string, OpenCodeModel> {
+  let changed = false;
+  const next = { ...current };
+
+  for (const model of fetched) {
+    const id = model.id.trim();
+    if (!id || next[id]) continue;
+
+    next[id] = { name: id };
+    changed = true;
+  }
+
+  return changed ? next : current;
+}
+
 export { buildOmoProfilePreview } from "@/types/omo";
 
 export const normalizePricingSource = (

--- a/tests/components/opencodeFormUtils.test.ts
+++ b/tests/components/opencodeFormUtils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeFetchedModelsIntoOpenCodeModels } from "@/components/providers/forms/helpers/opencodeFormUtils";
+import type { OpenCodeModel } from "@/types";
+
+describe("mergeFetchedModelsIntoOpenCodeModels", () => {
+  it("adds fetched models to an empty OpenCode model config", () => {
+    const merged = mergeFetchedModelsIntoOpenCodeModels(
+      {},
+      [{ id: "claude-sonnet-4-6" }, { id: "gpt-5.4" }],
+    );
+
+    expect(merged).toEqual({
+      "claude-sonnet-4-6": { name: "claude-sonnet-4-6" },
+      "gpt-5.4": { name: "gpt-5.4" },
+    });
+  });
+
+  it("preserves existing model configuration", () => {
+    const current: Record<string, OpenCodeModel> = {
+      "gpt-5.4": {
+        name: "GPT 5.4",
+        options: { provider: "apiway" },
+      },
+    };
+
+    const merged = mergeFetchedModelsIntoOpenCodeModels(current, [
+      { id: "gpt-5.4" },
+      { id: "claude-sonnet-4-6" },
+    ]);
+
+    expect(merged["gpt-5.4"]).toEqual({
+      name: "GPT 5.4",
+      options: { provider: "apiway" },
+    });
+    expect(merged["claude-sonnet-4-6"]).toEqual({
+      name: "claude-sonnet-4-6",
+    });
+  });
+
+  it("returns the original object when no new models are added", () => {
+    const current = { "gpt-5.4": { name: "GPT 5.4" } };
+
+    const merged = mergeFetchedModelsIntoOpenCodeModels(current, [
+      { id: "gpt-5.4" },
+      { id: " " },
+    ]);
+
+    expect(merged).toBe(current);
+  });
+});


### PR DESCRIPTION
## Summary
- automatically merge fetched OpenCode model IDs into the provider model config
- preserve existing model names and advanced options when fetching again
- add unit coverage for the merge behavior

## Root Cause
The OpenCode fetch button only populated a temporary dropdown source. When no model rows existed, the fetched list was not visible and the saved models config stayed empty.

## Validation
- pnpm vitest run tests/components/opencodeFormUtils.test.ts
- pnpm tsc --noEmit