### PR TITLE
[codex] 修复工具 schema type 为 null

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -494,6 +494,13 @@ fn convert_message_to_openai(
 pub fn clean_schema(mut schema: Value) -> Value {
     if let Some(obj) = schema.as_object_mut() {
         // 移除 "format": "uri"
+        let has_object_shape = obj.contains_key("properties")
+            || obj.contains_key("required")
+            || obj.contains_key("additionalProperties");
+        if has_object_shape && obj.get("type").is_none_or(Value::is_null) {
+            obj.insert("type".to_string(), json!("object"));
+        }
+
         if obj.get("format").and_then(|v| v.as_str()) == Some("uri") {
             obj.remove("format");
         }
@@ -818,6 +825,37 @@ mod tests {
         let result = anthropic_to_openai(input).unwrap();
         assert_eq!(result["tools"][0]["type"], "function");
         assert_eq!(result["tools"][0]["function"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_fills_missing_or_null_object_schema_type() {
+        let input = json!({
+            "model": "claude-3-opus",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Use the tools."}],
+            "tools": [
+                {
+                    "name": "missing_type",
+                    "description": "Schema inferred from properties",
+                    "input_schema": {"properties": {"location": {"type": "string"}}}
+                },
+                {
+                    "name": "null_type",
+                    "description": "Schema with explicit null type",
+                    "input_schema": {"type": null, "properties": {"query": {"type": "string"}}}
+                }
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"]["type"],
+            "object"
+        );
+        assert_eq!(
+            result["tools"][1]["function"]["parameters"]["type"],
+            "object"
+        );
     }
 
     #[test]


### PR DESCRIPTION
﻿## 关联问题

- Closes #2848
- 问题链接：https://github.com/farion1231/cc-switch/issues/2848

## 摘要

- 在 Anthropic 转 OpenAI Chat 的工具 schema 转换中，如果 object 形态的 schema 缺失 `type` 或 `type` 为 `null`，自动补成 `"object"`。
- 增加回归测试，覆盖 `type` 缺失和显式 `type: null` 两种工具 schema 场景。

## 原因

DeepSeek 对 OpenAI Chat 的 `function.parameters` 校验更严格，当 JSON Schema 中出现 `type: null` 时会拒绝请求。Anthropic 工具 schema 可能通过 `properties`、`required` 或 `additionalProperties` 表现为 object 形态，因此转换层需要在转发前把这类 schema 规范化。

## 验证

- `cargo test --manifest-path src-tauri/Cargo.toml test_anthropic_to_openai_fills_missing_or_null_object_schema_type --lib -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml transform --lib -- --nocapture`
- `.\node_modules\.bin\tsc.cmd --noEmit`
- `npx --yes pnpm@11.3.0 tauri build --config tauri-no-updater-artifacts.json`
