### PR TITLE
fix(ui): remove fixed width constraint on AppSwitcher text to prevent clipping

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1294,7 +1294,7 @@ function App() {
               )}
             <div
               ref={toolbarRef}
-              className="flex flex-1 min-w-0 items-center py-4 pr-2"
+              className="flex flex-1 min-w-0 overflow-x-hidden items-center py-4 pr-2"
             >
               <div
                 className="flex shrink-0 items-center gap-1.5 ml-auto"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1294,7 +1294,7 @@ function App() {
               )}
             <div
               ref={toolbarRef}
-              className="flex flex-1 min-w-0 overflow-x-hidden items-center py-4 pr-2"
+              className="flex flex-1 min-w-0 items-center py-4 pr-2"
             >
               <div
                 className="flex shrink-0 items-center gap-1.5 ml-auto"

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -117,7 +117,7 @@ export function AppSwitcher({
                 "transition-all duration-200 whitespace-nowrap overflow-hidden",
                 compact
                   ? "max-w-0 opacity-0 ml-0"
-                  : "max-w-none opacity-100 ml-2",
+                  : "max-w-[120px] opacity-100 ml-2",
               )}
             >
               {appDisplayName[app]}

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -117,7 +117,7 @@ export function AppSwitcher({
                 "transition-all duration-200 whitespace-nowrap overflow-hidden",
                 compact
                   ? "max-w-0 opacity-0 ml-0"
-                  : "max-w-[90px] opacity-100 ml-2",
+                  : "max-w-none opacity-100 ml-2",
               )}
             >
               {appDisplayName[app]}


### PR DESCRIPTION
<img width="1184" height="600" alt="CleanShot 2026-05-26 at 12 21 16" src="https://github.com/user-attachments/assets/1b9e982a-662b-4503-8edb-85bca8db056b" />

## Summary
- The AppSwitcher text label had a fixed `max-w-[90px]` constraint that clipped longer app names (e.g. "Claude Desktop"). Changed to `max-w-none` so text adapts to content width.
- Removed `overflow-x-hidden` from the parent toolbar container to prevent clipping of the wider content.

## Changes
- `src/components/AppSwitcher.tsx`: `max-w-[90px]` → `max-w-none`
- `src/App.tsx`: remove `overflow-x-hidden` from toolbar container

## Test plan
- [ ] All app names (Claude Code, Claude Desktop, Codex, etc.) display fully without clipping
- [ ] Compact mode still hides text correctly (`max-w-0` behavior unchanged)
- [ ] Toolbar layout doesn't break on narrow window widths