### PR TITLE
fix(usage): populate provider credentials for {{baseUrl}}/{{apiKey}} …

### DIFF
--- a/src-tauri/src/services/provider/usage.rs
+++ b/src-tauri/src/services/provider/usage.rs
@@ -83,30 +83,56 @@ pub(crate) async fn execute_and_format_usage_result(
 
 /// Extract API key from provider configuration
 fn extract_api_key_from_provider(provider: &crate::provider::Provider) -> Option<String> {
-    if let Some(env) = provider.settings_config.get("env") {
-        // Try multiple possible API key fields
-        env.get("ANTHROPIC_AUTH_TOKEN")
-            .or_else(|| env.get("ANTHROPIC_API_KEY"))
-            .or_else(|| env.get("OPENROUTER_API_KEY"))
-            .or_else(|| env.get("GOOGLE_API_KEY"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-    } else {
-        None
+    // Try env-specific keys first (Claude, Gemini, etc.)
+    let from_env = provider
+        .settings_config
+        .get("env")
+        .and_then(|env| {
+            env.get("ANTHROPIC_AUTH_TOKEN")
+                .or_else(|| env.get("ANTHROPIC_API_KEY"))
+                .or_else(|| env.get("OPENROUTER_API_KEY"))
+                .or_else(|| env.get("GOOGLE_API_KEY"))
+        })
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    if from_env.is_some() {
+        return from_env;
     }
+
+    // Fallback to top-level apiKey/api_key (Hermes, OpenClaw, Custom, etc.)
+    provider
+        .settings_config
+        .get("apiKey")
+        .or_else(|| provider.settings_config.get("api_key"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
 }
 
 /// Extract base URL from provider configuration
 fn extract_base_url_from_provider(provider: &crate::provider::Provider) -> Option<String> {
-    if let Some(env) = provider.settings_config.get("env") {
-        // Try multiple possible base URL fields
-        env.get("ANTHROPIC_BASE_URL")
-            .or_else(|| env.get("GOOGLE_GEMINI_BASE_URL"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.trim_end_matches('/').to_string())
-    } else {
-        None
+    // Try env-specific keys first (Claude, Gemini, etc.)
+    let from_env = provider
+        .settings_config
+        .get("env")
+        .and_then(|env| {
+            env.get("ANTHROPIC_BASE_URL")
+                .or_else(|| env.get("GOOGLE_GEMINI_BASE_URL"))
+        })
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim_end_matches('/').to_string());
+
+    if from_env.is_some() {
+        return from_env;
     }
+
+    // Fallback to top-level baseUrl/base_url (Hermes, OpenClaw, Custom, etc.)
+    provider
+        .settings_config
+        .get("baseUrl")
+        .or_else(|| provider.settings_config.get("base_url"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim_end_matches('/').to_string())
 }
 
 /// Query provider usage (using saved script configuration)
@@ -185,9 +211,9 @@ pub async fn query_usage(
 /// Test usage script (using temporary script content, not saved)
 #[allow(clippy::too_many_arguments)]
 pub async fn test_usage_script(
-    _state: &AppState,
-    _app_type: AppType,
-    _provider_id: &str,
+    state: &AppState,
+    app_type: AppType,
+    provider_id: &str,
     script_code: &str,
     timeout: u64,
     api_key: Option<&str>,
@@ -196,11 +222,35 @@ pub async fn test_usage_script(
     user_id: Option<&str>,
     template_type: Option<&str>,
 ) -> Result<UsageResult, AppError> {
-    // Use provided credential parameters directly for testing
+    // Resolve credentials: prefer explicit params, fallback to provider config
+    let (resolved_api_key, resolved_base_url) = if api_key.is_none() || base_url.is_none() {
+        let providers = state.db.get_all_providers(app_type.as_str())?;
+        if let Some(provider) = providers.get(provider_id) {
+            (
+                api_key
+                    .map(|s| s.to_string())
+                    .or_else(|| extract_api_key_from_provider(provider)),
+                base_url
+                    .map(|s| s.to_string())
+                    .or_else(|| extract_base_url_from_provider(provider)),
+            )
+        } else {
+            (
+                api_key.map(|s| s.to_string()),
+                base_url.map(|s| s.to_string()),
+            )
+        }
+    } else {
+        (
+            api_key.map(|s| s.to_string()),
+            base_url.map(|s| s.to_string()),
+        )
+    };
+
     execute_and_format_usage_result(
         script_code,
-        api_key.unwrap_or(""),
-        base_url.unwrap_or(""),
+        &resolved_api_key.unwrap_or_default(),
+        &resolved_base_url.unwrap_or_default(),
         timeout,
         access_token,
         user_id,

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -554,15 +554,12 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
     const preset = PRESET_TEMPLATES[presetName];
     if (preset !== undefined) {
       if (presetName === TEMPLATE_TYPES.CUSTOM) {
-        // 🔧 自定义模式：用户应该在脚本中直接写完整 URL 和凭证，而不是依赖变量替换
-        // 这样可以避免同源检查导致的问题
-        // 如果用户想使用变量，需要手动在配置中设置 baseUrl/apiKey
         setScript({
           ...script,
           code: preset,
-          // 清除凭证，用户可选择手动输入或保持空
-          apiKey: undefined,
-          baseUrl: undefined,
+          // 预填供应商凭证以支持 {{baseUrl}}/{{apiKey}} 变量替换
+          apiKey: providerCredentials.apiKey || script.apiKey,
+          baseUrl: providerCredentials.baseUrl || script.baseUrl,
           accessToken: undefined,
           userId: undefined,
         });
@@ -570,6 +567,9 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
         setScript({
           ...script,
           code: preset,
+          // 预填供应商凭证以支持 {{baseUrl}}/{{apiKey}} 变量替换
+          apiKey: providerCredentials.apiKey || script.apiKey,
+          baseUrl: providerCredentials.baseUrl || script.baseUrl,
           accessToken: undefined,
           userId: undefined,
         });
@@ -577,6 +577,8 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
         setScript({
           ...script,
           code: preset,
+          // 预填供应商 baseUrl 以支持 {{baseUrl}} 变量替换
+          baseUrl: providerCredentials.baseUrl || script.baseUrl,
           apiKey: undefined,
         });
       } else if (presetName === TEMPLATE_TYPES.GITHUB_COPILOT) {


### PR DESCRIPTION
fix(usage): populate provider credentials for {{baseUrl}}/{{apiKey}}  in Custom/General/NewAPI modes

- Pre-fill apiKey/baseUrl from provider config when selecting Custom/General template
- Pre-fill baseUrl from provider config when selecting NewAPI template
- Show credential input fields for Custom mode
- Extend Rust fallback to check top-level settings_config apiKey/baseUrl
- Add provider config fallback to test_usage_script path

## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

#### 问题

在用量查询脚本编辑器中，Custom / General / NewAPI 三种模式的 Extractor code 里 `{{baseUrl}}` 和 `{{apiKey}}` 变量无法被替换为实际值，导致请求失败。

#### 原因

1. **前端**：切换模板时清空了 `apiKey`/`baseUrl`，且 Custom 模式不显示凭证输入框
2. **Rust `extract_api_key_from_provider`**：仅在 `settings_config.env` 中查找特定环境变量，未兜底顶层 `apiKey`/`baseUrl` 字段（Hermes/OpenClaw 等供应商凭证存在顶层）
3. **Rust `test_usage_script`**：忽略传入的 `state`/`provider_id`，无法从供应商配置中兜底提取凭证

#### 修改

**前端** (`UsageScriptModal.tsx`)：

- Custom / General 模式预填 `providerCredentials.apiKey` + `providerCredentials.baseUrl`
- NewAPI 模式预填 `providerCredentials.baseUrl`
- Custom 模式显示凭证输入框（apiKey + baseUrl）

**Rust** (`usage.rs`)：

- `extract_api_key_from_provider` 新增兜底 `settings_config.apiKey` / `settings_config.api_key`
- `extract_base_url_from_provider` 新增兜底 `settings_config.baseUrl` / `settings_config.base_url`
- `test_usage_script` 利用 `state`/`provider_id` 从供应商配置中兜底提取凭证

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #3158 

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
