### PR TITLE
Fix Claude Desktop Cowork egress profile

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -816,6 +816,7 @@ fn build_gateway_profile(
     model_specs: Option<&[InferenceModelSpec]>,
 ) -> Value {
     let mut profile = json!({
+        "coworkEgressAllowedHosts": ["*"],
         "disableDeploymentModeChooser": true,
         "inferenceGatewayApiKey": api_key,
         "inferenceGatewayAuthScheme": "bearer",
@@ -1249,6 +1250,7 @@ mod tests {
         assert_eq!(profile["inferenceGatewayApiKey"], json!("test-token"));
         assert_eq!(profile["inferenceGatewayAuthScheme"], json!("bearer"));
         assert_eq!(profile["disableDeploymentModeChooser"], json!(true));
+        assert_eq!(profile["coworkEgressAllowedHosts"], json!(["*"]));
         assert!(profile.get("inferenceModels").is_none());
         assert_eq!(meta["appliedId"], json!(PROFILE_ID));
         assert!(meta["entries"]
@@ -1293,6 +1295,7 @@ mod tests {
             json!("http://127.0.0.1:15721/claude-desktop")
         );
         assert_eq!(profile["inferenceGatewayAuthScheme"], json!("bearer"));
+        assert_eq!(profile["coworkEgressAllowedHosts"], json!(["*"]));
         assert_ne!(profile["inferenceGatewayApiKey"], json!("test-token"));
         assert!(profile["inferenceGatewayApiKey"]
             .as_str()


### PR DESCRIPTION
## Summary / 概述

为 CC Switch 生成的 Claude Desktop 3P gateway profile 添加：

```json
"coworkEgressAllowedHosts": ["*"]
```

这样在 Claude Desktop 通过 CC Switch 本地网关进入 3P 模式时，Cowork 的 WebFetch 和 sandbox 网络访问可以正常访问外部主机。

目前 CC Switch 会生成并重写 Claude Desktop 3P profile。用户即使手动添加 `coworkEgressAllowedHosts`，切换 Provider 或重新应用配置后也可能丢失。因此这里把该配置加入 `build_gateway_profile`，让 direct 和 local proxy 两种 Claude Desktop gateway profile 都稳定包含该配置。

本 PR 不改变 WebSearch 行为。Claude Desktop 3P 的 WebSearch 是 server-side tool，仍然依赖上游 Provider/Gateway 支持 Anthropic 的 `web_search` server tool。

## Related Issue / 关联 Issue

Fixes #3171

## Screenshots / 截图
<img width="1312" height="950" alt="スクリーンショット 2026-05-26 17 19 54" src="https://github.com/user-attachments/assets/0dd6bd60-1972-4011-8487-4f74ab369e9e" />

该修改只影响生成的 Claude Desktop 3P 配置文件。

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 生成的 Claude Desktop 3P gateway profile 不包含 `coworkEgressAllowedHosts`，Cowork WebFetch 无法访问外部 URL。 | 生成的 profile 包含 `coworkEgressAllowedHosts: ["*"]`，Cowork WebFetch 可以访问外部 URL。 |

## Testing / 测试

已运行：

```bash
cargo test claude_desktop --manifest-path src-tauri/Cargo.toml
cargo clippy --manifest-path src-tauri/Cargo.toml
```

结果：

```text
cargo test claude_desktop: 27 passed; 0 failed
cargo clippy: passed
```

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

说明：

- 本 PR 只修改 Rust 侧 Claude Desktop 3P profile 生成逻辑，没有修改前端代码，因此未运行 `pnpm typecheck` / `pnpm format:check`。
- 本 PR 没有修改用户可见文本，因此无需更新 i18n 文件。
