### PR TITLE
feat(provider-preset): add sorting tabs

### DIFF
--- a/src/components/providers/forms/ProviderPresetSelector.tsx
+++ b/src/components/providers/forms/ProviderPresetSelector.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FormLabel } from "@/components/ui/form";
 import { ClaudeIcon, CodexIcon, GeminiIcon } from "@/components/BrandIcons";
 import { Zap, Star, Layers, Settings2 } from "lucide-react";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { ProviderPreset } from "@/config/claudeProviderPresets";
 import type { CodexProviderPreset } from "@/config/codexProviderPresets";
 import type { GeminiProviderPreset } from "@/config/geminiProviderPresets";
@@ -30,6 +32,10 @@ type PresetEntry = {
   preset: AnyPreset;
 };
 
+type PresetSortMode = "default" | "alphabetical";
+
+const PRESET_SORT_MODE_STORAGE_KEY = "provider-preset-sort-mode";
+
 interface ProviderPresetSelectorProps {
   selectedPresetId: string | null;
   presetEntries: PresetEntry[];
@@ -49,7 +55,13 @@ export function ProviderPresetSelector({
   onManageUniversalProviders,
   category,
 }: ProviderPresetSelectorProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const [sortMode, setSortMode] = useState<PresetSortMode>(() => {
+    if (typeof window === "undefined") return "default";
+
+    const stored = window.localStorage.getItem(PRESET_SORT_MODE_STORAGE_KEY);
+    return stored === "alphabetical" ? "alphabetical" : "default";
+  });
 
   const getCategoryHint = (): React.ReactNode => {
     switch (category) {
@@ -128,10 +140,68 @@ export function ProviderPresetSelector({
     };
   };
 
+  const getPresetDisplayName = useCallback(
+    (preset: AnyPreset) => (preset.nameKey ? t(preset.nameKey) : preset.name),
+    [t],
+  );
+
+  const displayedPresetEntries = useMemo(() => {
+    if (sortMode === "default") return presetEntries;
+
+    const collator = new Intl.Collator(i18n.resolvedLanguage || i18n.language, {
+      sensitivity: "base",
+      numeric: true,
+    });
+
+    return [...presetEntries].sort((left, right) =>
+      collator.compare(
+        getPresetDisplayName(left.preset),
+        getPresetDisplayName(right.preset),
+      ),
+    );
+  }, [
+    getPresetDisplayName,
+    i18n.language,
+    i18n.resolvedLanguage,
+    presetEntries,
+    sortMode,
+  ]);
+
+  const handleSortModeChange = (value: string) => {
+    const nextMode: PresetSortMode =
+      value === "alphabetical" ? "alphabetical" : "default";
+    setSortMode(nextMode);
+
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(PRESET_SORT_MODE_STORAGE_KEY, nextMode);
+    }
+  };
+
   return (
     <div className="space-y-3">
-      <FormLabel>{t("providerPreset.label")}</FormLabel>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <FormLabel>{t("providerPreset.label")}</FormLabel>
+        <Tabs value={sortMode} onValueChange={handleSortModeChange}>
+          <TabsList className="h-auto gap-1 p-1">
+            <TabsTrigger
+              value="default"
+              className="min-w-0 px-3 py-1 text-xs sm:text-sm"
+            >
+              {t("providerPreset.sortDefault")}
+            </TabsTrigger>
+            <TabsTrigger
+              value="alphabetical"
+              className="min-w-0 px-3 py-1 text-xs sm:text-sm"
+            >
+              {t("providerPreset.sortAlphabetical")}
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+      <div
+        className="flex flex-wrap gap-2"
+        data-testid="provider-preset-options"
+      >
         <button
           type="button"
           onClick={() => onPresetChange("custom")}
@@ -144,7 +214,7 @@ export function ProviderPresetSelector({
           {t("providerPreset.custom")}
         </button>
 
-        {presetEntries.map((entry) => {
+        {displayedPresetEntries.map((entry) => {
           const isSelected = selectedPresetId === entry.id;
           const isPartner = entry.preset.isPartner;
           const presetCategory = entry.preset.category ?? "others";
@@ -161,9 +231,7 @@ export function ProviderPresetSelector({
               }
             >
               {renderPresetIcon(entry.preset)}
-              {entry.preset.nameKey
-                ? t(entry.preset.nameKey)
-                : entry.preset.name}
+              {getPresetDisplayName(entry.preset)}
               {isPartner && (
                 <span className="absolute -top-1 -right-1 flex items-center gap-0.5 rounded-full bg-gradient-to-r from-amber-500 to-yellow-500 px-1.5 py-0.5 text-[10px] font-bold text-white shadow-md">
                   <Star className="h-2.5 w-2.5 fill-current" />

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1199,6 +1199,8 @@
   "providerPreset": {
     "label": "Provider Preset",
     "custom": "Custom Configuration",
+    "sortDefault": "Default",
+    "sortAlphabetical": "A-Z",
     "other": "Other",
     "hint": "You can continue to adjust the fields below after selecting a preset."
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1199,6 +1199,8 @@
   "providerPreset": {
     "label": "プロバイダータイプ",
     "custom": "カスタム設定",
+    "sortDefault": "デフォルト",
+    "sortAlphabetical": "アルファベット順",
     "other": "その他",
     "hint": "プリセットを選んだ後でも、下のフィールドで調整できます。"
   },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1199,6 +1199,8 @@
   "providerPreset": {
     "label": "预设供应商",
     "custom": "自定义配置",
+    "sortDefault": "默认",
+    "sortAlphabetical": "按字母",
     "other": "其他",
     "hint": "选择预设后可继续调整下方字段。"
   },

--- a/tests/components/ProviderPresetSelector.test.tsx
+++ b/tests/components/ProviderPresetSelector.test.tsx
@@ -1,11 +1,16 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useForm } from "react-hook-form";
 import { Form } from "@/components/ui/form";
 import { ProviderPresetSelector } from "@/components/providers/forms/ProviderPresetSelector";
 
 describe("ProviderPresetSelector", () => {
-  it("按传入的预设数组顺序渲染，不按分类重新排序", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("provider-preset-sort-mode");
+  });
+
+  const renderSelector = () => {
     const Wrapper = () => {
       const form = useForm();
 
@@ -17,7 +22,7 @@ describe("ProviderPresetSelector", () => {
               {
                 id: "preset-0",
                 preset: {
-                  name: "First",
+                  name: "Zoo",
                   websiteUrl: "https://first.example.com",
                   settingsConfig: {},
                   category: "third_party",
@@ -26,7 +31,7 @@ describe("ProviderPresetSelector", () => {
               {
                 id: "preset-1",
                 preset: {
-                  name: "Second",
+                  name: "Alpha",
                   websiteUrl: "https://second.example.com",
                   settingsConfig: {},
                   category: "official",
@@ -35,7 +40,7 @@ describe("ProviderPresetSelector", () => {
               {
                 id: "preset-2",
                 preset: {
-                  name: "Third",
+                  name: "Moon",
                   websiteUrl: "https://third.example.com",
                   settingsConfig: {},
                   category: "aggregator",
@@ -44,7 +49,7 @@ describe("ProviderPresetSelector", () => {
               {
                 id: "preset-3",
                 preset: {
-                  name: "Fourth",
+                  name: "Beta",
                   websiteUrl: "https://fourth.example.com",
                   settingsConfig: {},
                   category: "official",
@@ -62,10 +67,57 @@ describe("ProviderPresetSelector", () => {
       );
     };
 
-    render(<Wrapper />);
+    return render(<Wrapper />);
+  };
+
+  const presetButtonTexts = () =>
+    within(screen.getByTestId("provider-preset-options"))
+      .getAllByRole("button")
+      .map((button) => button.textContent);
+
+  it("Default 模式按传入的预设数组顺序渲染，不按分类重新排序", () => {
+    window.localStorage.removeItem("provider-preset-sort-mode");
+    renderSelector();
+
+    expect(presetButtonTexts()).toEqual([
+      "providerPreset.custom",
+      "Zoo",
+      "Alpha",
+      "Moon",
+      "Beta",
+    ]);
+  });
+
+  it("按字母模式基于显示名称排序，并保持 Custom Configuration 固定在最前", async () => {
+    window.localStorage.removeItem("provider-preset-sort-mode");
+    renderSelector();
+
+    await userEvent.click(
+      screen.getByRole("tab", { name: "providerPreset.sortAlphabetical" }),
+    );
+
+    expect(presetButtonTexts()).toEqual([
+      "providerPreset.custom",
+      "Alpha",
+      "Beta",
+      "Moon",
+      "Zoo",
+    ]);
+  });
+
+  it("会从 localStorage 恢复上次选择的排序模式", () => {
+    window.localStorage.setItem("provider-preset-sort-mode", "alphabetical");
+    renderSelector();
 
     expect(
-      screen.getAllByRole("button").map((button) => button.textContent),
-    ).toEqual(["providerPreset.custom", "First", "Second", "Third", "Fourth"]);
+      screen.getByRole("tab", { name: "providerPreset.sortAlphabetical" }),
+    ).toHaveAttribute("data-state", "active");
+    expect(presetButtonTexts()).toEqual([
+      "providerPreset.custom",
+      "Alpha",
+      "Beta",
+      "Moon",
+      "Zoo",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Add sorting tabs to the Provider Preset selector so users can switch between the existing default order and an alphabetical view without changing the underlying preset definitions.

This keeps the current behavior as the default, adds a faster way to find providers when the list is long, and remembers the selected sort mode across repeated add-provider flows.

## Screenshots

| Before | After |
|-----------------|---------------|
| <img width="1944" height="1000" alt="image" src="https://github.com/user-attachments/assets/c0aa46b5-a759-42c3-8477-96bcdac53e33" /> | <img width="1966" height="1170" alt="image" src="https://github.com/user-attachments/assets/d76b69c2-c027-4265-b723-3a5abe69c786" /> |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件