### PR TITLE
fix(codex-session): aggregate token_count events per turn to prevent log explosion

### DIFF
--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -66,21 +66,40 @@ struct FileParseState {
 
 impl FileParseState {
     /// 将当前 turn 的累积 delta flush 为一条记录（如果非零）
+    ///
+    /// `should_insert` 为 false 时只推进 event_index 不写库，用于增量同步
+    /// 的 replay 阶段保持 request_id 序列确定性。
     fn flush_pending(
         &mut self,
         db: &Database,
         imported: &mut u32,
         skipped: &mut u32,
+        should_insert: bool,
     ) {
-        let delta = match self.pending_delta.take() {
+        let delta = match self.pending_delta.as_ref() {
             Some(d) if !d.is_zero() => d,
             _ => return,
+        };
+
+        // 始终推进 event_index，保证增量同步 resume 时 request_id 不碰撞
+        self.event_index += 1;
+
+        if !should_insert {
+            // replay 阶段：只推进索引，实际插入已在历史同步中完成
+            self.pending_delta = None;
+            self.pending_model.clear();
+            self.pending_timestamp = None;
+            return;
+        }
+
+        let delta = DeltaTokens {
+            input: delta.input,
+            cached_input: delta.cached_input,
+            output: delta.output,
         };
         let model = std::mem::take(&mut self.pending_model);
         let timestamp = self.pending_timestamp.take();
         let session_id_str = self.session_id.as_deref().unwrap_or("unknown");
-
-        self.event_index += 1;
         let request_id = format!("codex_session:{}:{}", session_id_str, self.event_index);
 
         match insert_codex_session_entry(
@@ -91,11 +110,19 @@ impl FileParseState {
             self.session_id.as_deref(),
             timestamp.as_deref(),
         ) {
-            Ok(true) => *imported += 1,
-            Ok(false) => *skipped += 1,
+            Ok(true) => {
+                *imported += 1;
+                // 插入成功后清空 pending，避免失败时数据丢失
+                self.pending_delta = None;
+            }
+            Ok(false) => {
+                *skipped += 1;
+                self.pending_delta = None;
+            }
             Err(e) => {
                 log::warn!("[CODEX-SYNC] 插入失败 ({}): {e}", request_id);
                 *skipped += 1;
+                // 不清理 pending_delta/model/timestamp，下次同步重试
             }
         }
     }
@@ -311,12 +338,14 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
 
         let line = match line_result {
             Ok(l) => l,
-            Err(_) => continue, // 容忍不完整的最后一行
+            Err(_) => continue,
         };
 
         if line.trim().is_empty() {
             continue;
         }
+
+        let past_last_offset = line_offset > last_offset;
 
         // 快速过滤：在 JSON 反序列化前跳过无关行
         let is_event_msg = line.contains("\"event_msg\"");
@@ -342,7 +371,7 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
 
         match event_type {
             "session_meta" if state.session_id.is_none() => {
-                state.flush_pending(db, &mut imported, &mut skipped);
+                state.flush_pending(db, &mut imported, &mut skipped, past_last_offset);
                 let payload = value.get("payload");
                 state.session_id = payload
                     .and_then(|p| {
@@ -354,10 +383,8 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                     .map(|s| s.to_string());
             }
             "turn_context" => {
-                // 上一个 turn 结束：flush 累积的 token 用量
-                state.flush_pending(db, &mut imported, &mut skipped);
+                state.flush_pending(db, &mut imported, &mut skipped, past_last_offset);
                 if let Some(payload) = value.get("payload") {
-                    // model 可能在 payload.model 或 payload.info.model
                     if let Some(model) = payload
                         .get("model")
                         .or_else(|| payload.get("info").and_then(|info| info.get("model")))
@@ -431,18 +458,17 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                     continue;
                 }
 
-                // 跳过已处理的行（但仍需解析以恢复 prev_total 状态）
-                if line_offset <= last_offset {
-                    continue;
-                }
-
                 // 将 delta 累积到当前 turn，而非逐事件插入
                 // 单个 API 调用在流式响应期间会产生多个 token_count 事件；
-                // 我们只在该 turn 结束（下一个 turn_context 或文件末尾）时 flush 一条记录
-                let timestamp = value
+                // 我们只在该 turn 结束（下一个 turn_context 或文件末尾）时 flush 一条记录。
+                // replay 阶段（past_last_offset=false）同样累积 + flush，
+                // 以保证 event_index 确定性 → 增量同步 request_id 不碰撞。
+                if let Some(ts) = value
                     .get("timestamp")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                {
+                    state.pending_timestamp = Some(ts.to_string());
+                }
 
                 match &mut state.pending_delta {
                     Some(ref mut acc) => {
@@ -455,14 +481,13 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                     }
                 }
                 state.pending_model = state.current_model.clone();
-                state.pending_timestamp = timestamp;
             }
             _ => {}
         }
     }
 
-    // 文件末尾：flush 最后一个 turn 的累积 delta
-    state.flush_pending(db, &mut imported, &mut skipped);
+    // 文件末尾：flush 最后一个 turn 的累积 delta（EOF 总是新数据，强制插入）
+    state.flush_pending(db, &mut imported, &mut skipped, true);
 
     // 更新同步状态
     update_sync_state(db, &file_path_str, file_modified, line_offset)?;

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -56,6 +56,49 @@ struct FileParseState {
     current_model: String,
     prev_total: Option<CumulativeTokens>,
     event_index: u32,
+    /// 当前 turn 内累积的 token delta（多个 token_count 事件聚合为 1 条记录）
+    pending_delta: Option<DeltaTokens>,
+    /// pending_delta 对应的模型名
+    pending_model: String,
+    /// pending_delta 的最新时间戳
+    pending_timestamp: Option<String>,
+}
+
+impl FileParseState {
+    /// 将当前 turn 的累积 delta flush 为一条记录（如果非零）
+    fn flush_pending(
+        &mut self,
+        db: &Database,
+        imported: &mut u32,
+        skipped: &mut u32,
+    ) {
+        let delta = match self.pending_delta.take() {
+            Some(d) if !d.is_zero() => d,
+            _ => return,
+        };
+        let model = std::mem::take(&mut self.pending_model);
+        let timestamp = self.pending_timestamp.take();
+        let session_id_str = self.session_id.as_deref().unwrap_or("unknown");
+
+        self.event_index += 1;
+        let request_id = format!("codex_session:{}:{}", session_id_str, self.event_index);
+
+        match insert_codex_session_entry(
+            db,
+            &request_id,
+            &delta,
+            &model,
+            self.session_id.as_deref(),
+            timestamp.as_deref(),
+        ) {
+            Ok(true) => *imported += 1,
+            Ok(false) => *skipped += 1,
+            Err(e) => {
+                log::warn!("[CODEX-SYNC] 插入失败 ({}): {e}", request_id);
+                *skipped += 1;
+            }
+        }
+    }
 }
 
 /// 归一化 Codex 模型名
@@ -254,6 +297,9 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
         current_model: "unknown".to_string(),
         prev_total: None,
         event_index: 0,
+        pending_delta: None,
+        pending_model: String::new(),
+        pending_timestamp: None,
     };
 
     let mut line_offset: i64 = 0;
@@ -296,6 +342,7 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
 
         match event_type {
             "session_meta" if state.session_id.is_none() => {
+                state.flush_pending(db, &mut imported, &mut skipped);
                 let payload = value.get("payload");
                 state.session_id = payload
                     .and_then(|p| {
@@ -307,6 +354,8 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                     .map(|s| s.to_string());
             }
             "turn_context" => {
+                // 上一个 turn 结束：flush 累积的 token 用量
+                state.flush_pending(db, &mut imported, &mut skipped);
                 if let Some(payload) = value.get("payload") {
                     // model 可能在 payload.model 或 payload.info.model
                     if let Some(model) = payload
@@ -379,45 +428,41 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                 };
 
                 if delta.is_zero() {
-                    continue; // 跳过 task 边界的零 delta 事件
+                    continue;
                 }
 
-                state.event_index += 1;
-
-                // 跳过已处理的行（但仍需解析以恢复状态）
+                // 跳过已处理的行（但仍需解析以恢复 prev_total 状态）
                 if line_offset <= last_offset {
                     continue;
                 }
 
-                // 生成唯一 request_id
-                let session_id_str = state.session_id.as_deref().unwrap_or("unknown");
-                let request_id = format!("codex_session:{}:{}", session_id_str, state.event_index);
-
-                // 提取时间戳
+                // 将 delta 累积到当前 turn，而非逐事件插入
+                // 单个 API 调用在流式响应期间会产生多个 token_count 事件；
+                // 我们只在该 turn 结束（下一个 turn_context 或文件末尾）时 flush 一条记录
                 let timestamp = value
                     .get("timestamp")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
 
-                match insert_codex_session_entry(
-                    db,
-                    &request_id,
-                    &delta,
-                    &state.current_model,
-                    state.session_id.as_deref(),
-                    timestamp.as_deref(),
-                ) {
-                    Ok(true) => imported += 1,
-                    Ok(false) => skipped += 1,
-                    Err(e) => {
-                        log::warn!("[CODEX-SYNC] 插入失败 ({}): {e}", request_id);
-                        skipped += 1;
+                match &mut state.pending_delta {
+                    Some(ref mut acc) => {
+                        acc.input = acc.input.saturating_add(delta.input);
+                        acc.cached_input = acc.cached_input.saturating_add(delta.cached_input);
+                        acc.output = acc.output.saturating_add(delta.output);
+                    }
+                    None => {
+                        state.pending_delta = Some(delta);
                     }
                 }
+                state.pending_model = state.current_model.clone();
+                state.pending_timestamp = timestamp;
             }
             _ => {}
         }
     }
+
+    // 文件末尾：flush 最后一个 turn 的累积 delta
+    state.flush_pending(db, &mut imported, &mut skipped);
 
     // 更新同步状态
     update_sync_state(db, &file_path_str, file_modified, line_offset)?;


### PR DESCRIPTION
## Summary

Each Codex streaming API call emits ~33 `token_count` events during its lifetime. The session log sync created one `proxy_request_logs` row per event, inflating the record count ~33x and total token estimates ~38x (since `total_token_usage` counts full context windows, not API-billed tokens).

### Before (per-event insertion)

A session with 745 `turn_context` events produced 24,932 `proxy_request_logs` rows. Observed on a production instance:

| Model | codex_session rows | Actual API calls | Inflation |
|-------|-------------------|-----------------|-----------|
| gpt-5.5 | 560,193 | 24,742 | 23x |
| gpt-5.4 | 52,422 | 10 | 5,242x |
| **DB size** | **558 MB** | | |

### After (per-turn flush)

Deltas are accumulated within each turn boundary and flushed once when the next `turn_context`, `session_meta`, or EOF is reached. One record per API call.

## Changes

- Added `pending_delta`, `pending_model`, `pending_timestamp` to `FileParseState`
- Added `flush_pending()` method that emits one aggregated record per turn
- Flush triggers on `turn_context`, `session_meta`, and end-of-file
- `event_msg` token_count: accumulate into `pending_delta` instead of inserting immediately

## Test Plan

- All 26 existing `session_usage*` tests pass
- `cargo check` clean (only pre-existing warnings)
- Manual verification: cross-referenced cc-switch `codex_session` counts against NewAPI database