### PR TITLE
fix(opencode): auto-append /v1 to baseURL when writing provider config

### DIFF
--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -86,7 +86,28 @@ pub fn get_providers() -> Result<Map<String, Value>, AppError> {
         .unwrap_or_default())
 }
 
-pub fn set_provider(id: &str, config: Value) -> Result<(), AppError> {
+fn ensure_v1_suffix(config: &mut Value) {
+    let npm = config
+        .get("npm")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if !npm.starts_with("@ai-sdk/openai") {
+        return;
+    }
+    let base_url = config
+        .pointer_mut("/options/baseURL")
+        .and_then(|v| v.as_str().map(|s| s.to_string()));
+    let Some(base_url) = base_url else { return };
+    if base_url.is_empty() || base_url.ends_with("/v1") {
+        return;
+    }
+    let normalized = format!("{}/v1", base_url.trim_end_matches('/'));
+    config["options"]["baseURL"] = json!(normalized);
+}
+
+pub fn set_provider(id: &str, mut config: Value) -> Result<(), AppError> {
+    ensure_v1_suffix(&mut config);
+
     let mut full_config = read_opencode_config()?;
 
     if full_config.get("provider").is_none() {


### PR DESCRIPTION
## Summary / 概述

写入 opencode.json 时，对 OpenAI 兼容 provider 自动补上 `/v1` 后缀，与 `fetch_models` 中对 `/v1/models` 的补全逻辑保持一致。这样即使用户在配置中忘记写 `/v1`，最终写入的配置也会自动修正。

所有检查均通过：
- ✅ `pnpm typecheck` — 通过
- ✅ `pnpm format:check` — 通过
- ✅ `cargo clippy` — 通过（无警告）