### PR TITLE
chore: allow esbuild and msw build scripts for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.15.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild", "msw"]
+  },
   "scripts": {
     "dev": "pnpm tauri dev",
     "build": "pnpm tauri build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages: []
 
+allowBuilds:
+  esbuild: false
+  msw: false
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'


### PR DESCRIPTION
## Summary
Unblocks frontend unit tests in CI by allowing esbuild and msw to build via `pnpm.onlyBuiltDependencies`.

## Problem
CI fails at install step with:
`[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.21.5, esbuild@0.27.2, msw@2.11.6`

This prevents `pnpm test:unit` from running in CI.

## Solution
Add `pnpm.onlyBuiltDependencies` to `package.json` to explicitly allow esbuild and msw to run their build scripts during `pnpm install`.

## Testing
- [x] `pnpm install` completes without prompts
- [x] `pnpm typecheck` runs successfully  
- [x] `pnpm test:unit` executes