### PR TITLE
Feat/自动获取模型列表

### DIFF
--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -366,12 +366,18 @@ export function ClaudeFormFields({
       ? handleFetchCodexOauthModels
       : handleFetchModels;
 
-  const autoFetchTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const autoFetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    clearTimeout(autoFetchTimerRef.current);
+    if (autoFetchTimerRef.current) {
+      clearTimeout(autoFetchTimerRef.current);
+    }
     if (!baseUrl || !apiKey) return;
     autoFetchTimerRef.current = setTimeout(handleModelFetchClick, 800);
-    return () => clearTimeout(autoFetchTimerRef.current);
+    return () => {
+      if (autoFetchTimerRef.current) {
+        clearTimeout(autoFetchTimerRef.current);
+      }
+    };
   }, [baseUrl, apiKey, handleModelFetchClick]);
 
   // 模型输入框：支持手动输入 + 下拉选择

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -366,6 +366,37 @@ export function ClaudeFormFields({
       ? handleFetchCodexOauthModels
       : handleFetchModels;
 
+  const autoFetchRef = useRef(false);
+  useEffect(() => {
+    if (autoFetchRef.current) return;
+    if (isCopilotPreset) {
+      if (isCopilotAuthenticated) {
+        autoFetchRef.current = true;
+        handleFetchCopilotModels();
+      }
+    } else if (isCodexOauthPreset) {
+      if (isCodexOauthAuthenticated) {
+        autoFetchRef.current = true;
+        handleFetchCodexOauthModels();
+      }
+    } else {
+      if (baseUrl && apiKey) {
+        autoFetchRef.current = true;
+        handleFetchModels();
+      }
+    }
+  }, [
+    baseUrl,
+    apiKey,
+    isCopilotPreset,
+    isCopilotAuthenticated,
+    isCodexOauthPreset,
+    isCodexOauthAuthenticated,
+    handleFetchCopilotModels,
+    handleFetchCodexOauthModels,
+    handleFetchModels,
+  ]);
+
   // 模型输入框：支持手动输入 + 下拉选择
   const renderModelInput = (
     id: string,

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -366,36 +366,13 @@ export function ClaudeFormFields({
       ? handleFetchCodexOauthModels
       : handleFetchModels;
 
-  const autoFetchRef = useRef(false);
+  const autoFetchTimerRef = useRef<ReturnType<typeof setTimeout>>();
   useEffect(() => {
-    if (autoFetchRef.current) return;
-    if (isCopilotPreset) {
-      if (isCopilotAuthenticated) {
-        autoFetchRef.current = true;
-        handleFetchCopilotModels();
-      }
-    } else if (isCodexOauthPreset) {
-      if (isCodexOauthAuthenticated) {
-        autoFetchRef.current = true;
-        handleFetchCodexOauthModels();
-      }
-    } else {
-      if (baseUrl && apiKey) {
-        autoFetchRef.current = true;
-        handleFetchModels();
-      }
-    }
-  }, [
-    baseUrl,
-    apiKey,
-    isCopilotPreset,
-    isCopilotAuthenticated,
-    isCodexOauthPreset,
-    isCodexOauthAuthenticated,
-    handleFetchCopilotModels,
-    handleFetchCodexOauthModels,
-    handleFetchModels,
-  ]);
+    clearTimeout(autoFetchTimerRef.current);
+    if (!baseUrl || !apiKey) return;
+    autoFetchTimerRef.current = setTimeout(handleModelFetchClick, 800);
+    return () => clearTimeout(autoFetchTimerRef.current);
+  }, [baseUrl, apiKey, handleModelFetchClick]);
 
   // 模型输入框：支持手动输入 + 下拉选择
   const renderModelInput = (


### PR DESCRIPTION
## Summary / 概述

在进入Claude的编辑供应商界面和修改apikey、endpoint的时候，自动获取模型列表

## Related Issue / 关联 Issue

none

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |       
<img width="1353" height="945" alt="image" src="https://github.com/user-attachments/assets/791ae6c7-0ce9-406b-ac93-d0c7a784f2b2" />
        |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
