### PR TITLE
fix(deeplink): accept claude-desktop aliases in provider import URLs

### DIFF
--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -96,6 +96,11 @@ fn parse_provider_deeplink(
             "Invalid app type: must be 'claude', 'claude-desktop', 'codex', 'gemini', 'opencode', 'openclaw', or 'hermes', got '{app}'"
         )));
     }
+    let app = if matches!(app.as_str(), "claude_desktop" | "claudedesktop") {
+        "claude-desktop".to_string()
+    } else {
+        app
+    };
 
     let name = params
         .get("name")

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -79,12 +79,21 @@ fn parse_provider_deeplink(
         .clone();
 
     // Validate app type
+    // Note: keep aliases in sync with AppType::from_str in app_config.rs.
     if !matches!(
         app.as_str(),
-        "claude" | "codex" | "gemini" | "opencode" | "openclaw" | "hermes"
+        "claude"
+            | "claude-desktop"
+            | "claude_desktop"
+            | "claudedesktop"
+            | "codex"
+            | "gemini"
+            | "opencode"
+            | "openclaw"
+            | "hermes"
     ) {
         return Err(AppError::InvalidInput(format!(
-            "Invalid app type: must be 'claude', 'codex', 'gemini', 'opencode', 'openclaw', or 'hermes', got '{app}'"
+            "Invalid app type: must be 'claude', 'claude-desktop', 'codex', 'gemini', 'opencode', 'openclaw', or 'hermes', got '{app}'"
         )));
     }
 

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -526,6 +526,12 @@ pub fn parse_and_merge_config(
     match request.app.as_deref().unwrap_or("") {
         "claude" | "claude-desktop" | "claude_desktop" | "claudedesktop" => {
             merge_claude_config(&mut merged, &config_value)?;
+            if matches!(
+                merged.app.as_deref(),
+                Some("claude_desktop" | "claudedesktop")
+            ) {
+                merged.app = Some("claude-desktop".to_string());
+            }
         }
         "codex" => merge_codex_config(&mut merged, &config_value)?,
         "gemini" => merge_gemini_config(&mut merged, &config_value)?,

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -524,7 +524,9 @@ pub fn parse_and_merge_config(
     }
 
     match request.app.as_deref().unwrap_or("") {
-        "claude" => merge_claude_config(&mut merged, &config_value)?,
+        "claude" | "claude-desktop" | "claude_desktop" | "claudedesktop" => {
+            merge_claude_config(&mut merged, &config_value)?;
+        }
         "codex" => merge_codex_config(&mut merged, &config_value)?,
         "gemini" => merge_gemini_config(&mut merged, &config_value)?,
         // Additive mode apps use JSON config directly; pass through as-is

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -77,6 +77,32 @@ fn test_parse_missing_required_field() {
         .contains("Missing 'name' parameter"));
 }
 
+#[test]
+fn test_parse_provider_accepts_claude_desktop_aliases() {
+    // AppType::from_str accepts "claude-desktop", "claude_desktop" and
+    // "claudedesktop"; provider deep links must accept the same aliases so users
+    // can import Claude Desktop providers via ccswitch:// links (issue #3112).
+    for alias in ["claude-desktop", "claude_desktop", "claudedesktop"] {
+        let url = format!(
+            "ccswitch://v1/import?resource=provider&app={alias}&name=Test&endpoint=https%3A%2F%2Fexample.com&apiKey=sk-test"
+        );
+        let request = parse_deeplink_url(&url)
+            .unwrap_or_else(|e| panic!("alias '{alias}' should be accepted, got: {e}"));
+        assert_eq!(request.app, Some(alias.to_string()));
+    }
+}
+
+#[test]
+fn test_parse_provider_invalid_app_error_lists_claude_desktop() {
+    let url = "ccswitch://v1/import?resource=provider&app=bogus&name=Test";
+    let err = parse_deeplink_url(url).unwrap_err().to_string();
+    assert!(err.contains("Invalid app type"), "got: {err}");
+    assert!(
+        err.contains("claude-desktop"),
+        "error message should advertise claude-desktop alias, got: {err}"
+    );
+}
+
 // =============================================================================
 // Utils Tests
 // =============================================================================

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -294,6 +294,34 @@ fn test_parse_and_merge_config_claude() {
 }
 
 #[test]
+fn test_parse_and_merge_config_claude_desktop_aliases() {
+    let config_json = r#"{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-ant-xxx","ANTHROPIC_BASE_URL":"https://api.anthropic.com/v1","ANTHROPIC_MODEL":"claude-sonnet-4.5"}}"#;
+    let config_b64 = BASE64_STANDARD.encode(config_json.as_bytes());
+
+    for alias in ["claude-desktop", "claude_desktop", "claudedesktop"] {
+        let request = DeepLinkImportRequest {
+            version: "v1".to_string(),
+            resource: "provider".to_string(),
+            app: Some(alias.to_string()),
+            name: Some("Test".to_string()),
+            config: Some(config_b64.clone()),
+            config_format: Some("json".to_string()),
+            ..Default::default()
+        };
+
+        let merged = parse_and_merge_config(&request)
+            .unwrap_or_else(|e| panic!("alias '{alias}' should merge Claude config, got: {e}"));
+
+        assert_eq!(merged.api_key, Some("sk-ant-xxx".to_string()));
+        assert_eq!(
+            merged.endpoint,
+            Some("https://api.anthropic.com/v1".to_string())
+        );
+        assert_eq!(merged.model, Some("claude-sonnet-4.5".to_string()));
+    }
+}
+
+#[test]
 fn test_parse_and_merge_config_codex_uses_bearer_token() {
     let config_toml = r#"model_provider = "rightcode"
 model = "gpt-5-codex"

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -88,7 +88,7 @@ fn test_parse_provider_accepts_claude_desktop_aliases() {
         );
         let request = parse_deeplink_url(&url)
             .unwrap_or_else(|e| panic!("alias '{alias}' should be accepted, got: {e}"));
-        assert_eq!(request.app, Some(alias.to_string()));
+        assert_eq!(request.app, Some("claude-desktop".to_string()));
     }
 }
 
@@ -318,6 +318,7 @@ fn test_parse_and_merge_config_claude_desktop_aliases() {
             Some("https://api.anthropic.com/v1".to_string())
         );
         assert_eq!(merged.model, Some("claude-sonnet-4.5".to_string()));
+        assert_eq!(merged.app, Some("claude-desktop".to_string()));
     }
 }
 

--- a/src/lib/api/deeplink.ts
+++ b/src/lib/api/deeplink.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import type { AppId } from "./types";
 
 export type ResourceType = "provider" | "prompt" | "mcp" | "skill";
 
@@ -7,7 +8,7 @@ export interface DeepLinkImportRequest {
   resource: ResourceType;
 
   // Common fields
-  app?: "claude" | "codex" | "gemini";
+  app?: AppId | "claude_desktop" | "claudedesktop";
   name?: string;
   enabled?: boolean;
 


### PR DESCRIPTION
## Summary / 概述

`AppType::from_str` already accepts `claude-desktop`, `claude_desktop`, and `claudedesktop` (see `src-tauri/src/app_config.rs:398`), and the deep link provider builder dispatches `AppType::ClaudeDesktop` end-to-end (`src-tauri/src/deeplink/provider.rs:145`). But the parser's hardcoded allowlist in `parse_provider_deeplink` rejects all three aliases before `from_str` ever runs, so any `ccswitch://v1/import?resource=provider&app=claudedesktop&...` link fails with `Invalid app type` as #3112 reports.

This PR adds those three aliases to the provider parser allowlist, updates the error message to advertise `claude-desktop`, and keeps the inline config merge path aligned so `app=claudedesktop` links with `config=` do not parse successfully and then fail later during `parse_and_merge_config`.

The frontend deep link request type is also widened to match the backend app identifiers and accepted Claude Desktop aliases. This is a type-contract cleanup only; the runtime import path still goes through the existing Tauri commands.

`parse_prompt_deeplink` and `parse_mcp_deeplink` are intentionally **not** widened:

- `prompt_files::prompt_file_path` (`src-tauri/src/prompt_files.rs:13-18`) explicitly errors out with `Claude Desktop does not support Prompts` for `AppType::ClaudeDesktop`.
- `McpService` (`src-tauri/src/services/mcp.rs:115`) treats `AppType::ClaudeDesktop` as a no-op with a debug log.

Accepting Claude Desktop in those two parsers would just surface a confusing downstream error or a silent no-op, so the parser-level rejection there is the right behaviour today.

## Related Issue / 关联 Issue

Fixes #3112

## Screenshots / 截图

N/A — deeplink parsing / import logic only, no UI change.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 (N/A — only a developer-facing error message string changed; not routed through `t()`)

## Local verification

```
pnpm typecheck                                       # pass
pnpm format:check                                    # pass (Prettier clean)
cd src-tauri
cargo fmt --check                                    # pass
cargo clippy --tests --lib -- -D warnings            # pass, 0 warnings
cargo test --lib deeplink::tests                     # 25 passed, 0 failed
  - test_parse_provider_accepts_claude_desktop_aliases ... ok
  - test_parse_provider_invalid_app_error_lists_claude_desktop ... ok
  - test_parse_and_merge_config_claude_desktop_aliases ... ok
```

I also checked the exact URL shape from #3112 (`app=claudedesktop` with URL params only) against the parser path locally; it now parses successfully. `pnpm test:unit` still has a pre-existing timeout in `tests/integration/App.test.tsx` on `main` as well, unrelated to this change.