### PR TITLE
[codex] Prune stale Claude command hooks from common config

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -247,11 +247,15 @@ pub async fn set_claude_common_config_snippet(
 ) -> Result<(), String> {
     let is_cleared = snippet.trim().is_empty();
 
-    if !snippet.trim().is_empty() {
+    let value = if is_cleared {
+        None
+    } else {
         serde_json::from_str::<serde_json::Value>(&snippet).map_err(invalid_json_format_error)?;
-    }
-
-    let value = if is_cleared { None } else { Some(snippet) };
+        Some(
+            crate::services::provider::sanitize_claude_common_config_snippet_text(&snippet)
+                .map_err(|e| e.to_string())?,
+        )
+    };
 
     state
         .db
@@ -289,7 +293,18 @@ pub async fn set_common_config_snippet(
 
     validate_common_config_snippet(&app_type, &snippet)?;
 
-    let value = if is_cleared { None } else { Some(snippet) };
+    let sanitized_snippet = if !is_cleared && app_type == "claude" {
+        crate::services::provider::sanitize_claude_common_config_snippet_text(&snippet)
+            .map_err(|e| e.to_string())?
+    } else {
+        snippet
+    };
+
+    let value = if is_cleared {
+        None
+    } else {
+        Some(sanitized_snippet)
+    };
 
     if matches!(app_type.as_str(), "claude" | "codex" | "gemini") {
         if let Some(legacy_snippet) = old_snippet

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -244,7 +244,7 @@ pub async fn get_claude_common_config_snippet(
 pub async fn set_claude_common_config_snippet(
     snippet: String,
     state: tauri::State<'_, crate::store::AppState>,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let is_cleared = snippet.trim().is_empty();
 
     let value = if is_cleared {
@@ -259,13 +259,13 @@ pub async fn set_claude_common_config_snippet(
 
     state
         .db
-        .set_config_snippet("claude", value)
+        .set_config_snippet("claude", value.clone())
         .map_err(|e| e.to_string())?;
     state
         .db
         .set_config_snippet_cleared("claude", is_cleared)
         .map_err(|e| e.to_string())?;
-    Ok(())
+    Ok(value)
 }
 
 #[tauri::command]
@@ -284,7 +284,7 @@ pub async fn set_common_config_snippet(
     app_type: String,
     snippet: String,
     state: tauri::State<'_, crate::store::AppState>,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let is_cleared = snippet.trim().is_empty();
     let old_snippet = state
         .db
@@ -323,7 +323,7 @@ pub async fn set_common_config_snippet(
 
     state
         .db
-        .set_config_snippet(&app_type, value)
+        .set_config_snippet(&app_type, value.clone())
         .map_err(|e| e.to_string())?;
     state
         .db
@@ -365,7 +365,7 @@ pub async fn set_common_config_snippet(
         )
         .map_err(|e| e.to_string())?;
     }
-    Ok(())
+    Ok(value)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1599,6 +1599,25 @@ async fn restore_proxy_state_on_startup(state: &store::AppState) {
 }
 
 fn initialize_common_config_snippets(state: &store::AppState) {
+    if let Ok(Some(snippet)) = state.db.get_config_snippet("claude") {
+        if !snippet.trim().is_empty() {
+            match crate::services::provider::sanitize_claude_common_config_snippet_text(&snippet) {
+                Ok(sanitized) if sanitized != snippet => {
+                    match state.db.set_config_snippet("claude", Some(sanitized)) {
+                        Ok(()) => log::info!(
+                            "✓ Pruned stale Claude command references from common config snippet"
+                        ),
+                        Err(e) => log::warn!(
+                            "✗ Failed to persist sanitized Claude common config snippet: {e}"
+                        ),
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => log::warn!("✗ Failed to sanitize Claude common config snippet: {e}"),
+            }
+        }
+    }
+
     // Auto-extract common config snippets from clean live files when snippet is missing.
     // This must run before proxy takeover is restored on startup, otherwise we'd read
     // proxy-placeholder configs instead of the user's actual live settings.

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -3,6 +3,7 @@
 //! Handles reading and writing live configuration files for Claude, Codex, and Gemini.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use serde_json::{json, Value};
 use toml_edit::{DocumentMut, Item, TableLike};
@@ -31,6 +32,141 @@ pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
         obj.remove("openrouterCompatMode");
     }
     v
+}
+
+fn first_shell_command_word(command: &str) -> Option<String> {
+    let command = command.trim_start();
+    if command.is_empty() {
+        return None;
+    }
+
+    let mut chars = command.chars();
+    let first = chars.next()?;
+
+    if matches!(first, '\'' | '"') {
+        let quote = first;
+        let mut word = String::new();
+        let mut escaped = false;
+        for ch in chars {
+            if escaped {
+                word.push(ch);
+                escaped = false;
+                continue;
+            }
+            if quote == '"' && ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == quote {
+                break;
+            }
+            word.push(ch);
+        }
+        return if word.is_empty() { None } else { Some(word) };
+    }
+
+    let mut word = String::new();
+    let mut escaped = false;
+    for ch in std::iter::once(first).chain(chars) {
+        if escaped {
+            word.push(ch);
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch.is_whitespace() {
+            break;
+        }
+        word.push(ch);
+    }
+    if word.is_empty() {
+        None
+    } else {
+        Some(word)
+    }
+}
+
+fn command_uses_missing_absolute_executable(command: &str) -> bool {
+    first_shell_command_word(command).is_some_and(|word| {
+        let path = Path::new(&word);
+        path.is_absolute() && !path.exists()
+    })
+}
+
+fn prune_hook_commands(value: &mut Value) -> bool {
+    let Some(events) = value.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return false;
+    };
+
+    let mut changed = false;
+    events.retain(|_, matchers| {
+        let Some(matchers_array) = matchers.as_array_mut() else {
+            return true;
+        };
+
+        matchers_array.retain_mut(|matcher| {
+            let Some(hooks_array) = matcher.get_mut("hooks").and_then(Value::as_array_mut) else {
+                return true;
+            };
+
+            let before = hooks_array.len();
+            hooks_array.retain(|hook| {
+                !hook
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .is_some_and(command_uses_missing_absolute_executable)
+            });
+            changed |= hooks_array.len() != before;
+
+            !hooks_array.is_empty()
+        });
+
+        !matchers_array.is_empty()
+    });
+
+    if events.is_empty() {
+        if let Some(obj) = value.as_object_mut() {
+            obj.remove("hooks");
+            changed = true;
+        }
+    }
+
+    changed
+}
+
+fn prune_status_line_command(value: &mut Value) -> bool {
+    let should_remove = value
+        .get("statusLine")
+        .and_then(|status_line| status_line.get("command"))
+        .and_then(Value::as_str)
+        .is_some_and(command_uses_missing_absolute_executable);
+
+    if should_remove {
+        if let Some(obj) = value.as_object_mut() {
+            obj.remove("statusLine");
+        }
+    }
+
+    should_remove
+}
+
+pub(crate) fn prune_missing_absolute_claude_command_references(value: &mut Value) -> bool {
+    let hooks_changed = prune_hook_commands(value);
+    let status_line_changed = prune_status_line_command(value);
+    hooks_changed || status_line_changed
+}
+
+pub(crate) fn sanitize_claude_common_config_snippet_text(
+    snippet: &str,
+) -> Result<String, AppError> {
+    let mut value = serde_json::from_str::<Value>(snippet)
+        .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
+    prune_missing_absolute_claude_command_references(&mut value);
+    serde_json::to_string_pretty(&value)
+        .map_err(|e| AppError::Message(format!("Serialization failed: {e}")))
 }
 
 pub(crate) fn provider_exists_in_live_config(
@@ -435,8 +571,9 @@ fn apply_common_config_to_settings(
 
     match app_type {
         AppType::Claude => {
-            let source = serde_json::from_str::<Value>(trimmed)
+            let mut source = serde_json::from_str::<Value>(trimmed)
                 .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
+            prune_missing_absolute_claude_command_references(&mut source);
             let mut result = settings.clone();
             json_deep_merge(&mut result, &source);
             Ok(result)
@@ -1547,6 +1684,43 @@ mod tests {
         let stripped =
             remove_common_config_from_settings(&AppType::Claude, &applied, snippet).unwrap();
         assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn claude_common_config_apply_prunes_missing_absolute_commands() {
+        let missing_command = std::env::temp_dir()
+            .join(format!("cc-switch-missing-command-{}", std::process::id()))
+            .join("bridge");
+        assert!(!missing_command.exists());
+
+        let settings = json!({
+            "env": {
+                "ANTHROPIC_API_KEY": "sk-test"
+            }
+        });
+        let snippet_value = json!({
+            "includeCoAuthoredBy": false,
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": missing_command.to_string_lossy()
+                    }]
+                }]
+            },
+            "statusLine": {
+                "type": "command",
+                "command": missing_command.to_string_lossy()
+            }
+        });
+        let snippet = serde_json::to_string(&snippet_value).unwrap();
+
+        let applied =
+            apply_common_config_to_settings(&AppType::Claude, &settings, &snippet).unwrap();
+
+        assert_eq!(applied["includeCoAuthoredBy"], json!(false));
+        assert!(applied.get("hooks").is_none());
+        assert!(applied.get("statusLine").is_none());
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -28,11 +28,13 @@ pub use live::{
 };
 
 // Internal re-exports (pub(crate))
-pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
     provider_exists_in_live_config, strip_common_config_from_live_settings,
     sync_current_provider_for_app_to_live, write_live_with_common_config,
+};
+pub(crate) use live::{
+    sanitize_claude_common_config_snippet_text, sanitize_claude_settings_for_live,
 };
 
 // Internal re-exports
@@ -346,6 +348,47 @@ mod tests {
             ProviderService::extract_credentials(&provider, &AppType::Claude).unwrap();
         assert_eq!(api_key, "token");
         assert_eq!(base_url, "https://claude.example");
+    }
+
+    #[test]
+    fn extract_claude_common_config_prunes_missing_absolute_commands() {
+        let missing_command = env::temp_dir()
+            .join(format!("cc-switch-missing-command-{}", std::process::id()))
+            .join("bridge");
+        assert!(!missing_command.exists());
+
+        let settings = json!({
+            "includeCoAuthoredBy": false,
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": missing_command.to_string_lossy()
+                    }]
+                }]
+            },
+            "statusLine": {
+                "type": "command",
+                "command": missing_command.to_string_lossy()
+            },
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "token",
+                "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1"
+            }
+        });
+
+        let extracted = ProviderService::extract_claude_common_config(&settings)
+            .expect("extract_claude_common_config should succeed");
+        let extracted: Value = serde_json::from_str(&extracted).unwrap();
+
+        assert_eq!(extracted["includeCoAuthoredBy"], json!(false));
+        assert_eq!(
+            extracted["env"]["CLAUDE_CODE_DISABLE_TERMINAL_TITLE"],
+            json!("1")
+        );
+        assert!(extracted.get("hooks").is_none());
+        assert!(extracted.get("statusLine").is_none());
+        assert!(extracted["env"].get("ANTHROPIC_AUTH_TOKEN").is_none());
     }
 
     #[test]
@@ -1998,6 +2041,8 @@ impl ProviderService {
                 obj.remove(*key);
             }
         }
+
+        live::prune_missing_absolute_claude_command_references(&mut config);
 
         // Check if result is empty
         if config.as_object().is_none_or(|obj| obj.is_empty()) {

--- a/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
@@ -51,6 +51,8 @@ export function useCommonConfigSnippet({
   const hasInitializedNewMode = useRef(false);
   // 用于跟踪编辑模式是否已初始化显式开关/预览
   const hasInitializedEditMode = useRef(false);
+  // 用于忽略较早保存请求返回的已清理片段
+  const snippetSaveRequestId = useRef(0);
 
   // 当预设变化时，重置初始化标记，使新预设能够重新触发初始化逻辑
   useEffect(() => {
@@ -84,9 +86,12 @@ export function useCommonConfigSnippet({
                 window.localStorage.getItem(LEGACY_STORAGE_KEY);
               if (legacySnippet && legacySnippet.trim()) {
                 // 迁移到 config.json
-                await configApi.setCommonConfigSnippet("claude", legacySnippet);
+                const savedSnippet = await configApi.setCommonConfigSnippet(
+                  "claude",
+                  legacySnippet,
+                );
                 if (mounted) {
-                  setCommonConfigSnippetState(legacySnippet);
+                  setCommonConfigSnippetState(savedSnippet ?? legacySnippet);
                 }
                 // 清理 localStorage
                 window.localStorage.removeItem(LEGACY_STORAGE_KEY);
@@ -229,21 +234,28 @@ export function useCommonConfigSnippet({
 
   // 处理通用配置片段变化
   const handleCommonConfigSnippetChange = useCallback(
-    (value: string) => {
+    async (value: string) => {
       const previousSnippet = commonConfigSnippet;
+      const requestId = snippetSaveRequestId.current + 1;
+      snippetSaveRequestId.current = requestId;
       setCommonConfigSnippetState(value);
 
       if (!value.trim()) {
         setCommonConfigError("");
         // 保存到 config.json（清空）
-        configApi
-          .setCommonConfigSnippet("claude", "")
-          .catch((error: unknown) => {
-            console.error("保存通用配置失败:", error);
-            setCommonConfigError(
-              t("claudeConfig.saveFailed", { error: String(error) }),
-            );
-          });
+        try {
+          await configApi.setCommonConfigSnippet("claude", "");
+        } catch (error) {
+          console.error("保存通用配置失败:", error);
+          setCommonConfigError(
+            t("claudeConfig.saveFailed", { error: String(error) }),
+          );
+          return;
+        }
+
+        if (snippetSaveRequestId.current !== requestId) {
+          return;
+        }
 
         if (useCommonConfig) {
           const { updatedConfig } = updateCommonConfigSnippet(
@@ -261,21 +273,29 @@ export function useCommonConfigSnippet({
       const validationError = validateJsonConfig(value, "通用配置片段");
       if (validationError) {
         setCommonConfigError(validationError);
-      } else {
-        setCommonConfigError("");
-        // 保存到 config.json
-        configApi
-          .setCommonConfigSnippet("claude", value)
-          .catch((error: unknown) => {
-            console.error("保存通用配置失败:", error);
-            setCommonConfigError(
-              t("claudeConfig.saveFailed", { error: String(error) }),
-            );
-          });
+        return;
       }
 
+      setCommonConfigError("");
+      let savedSnippet: string;
+      try {
+        savedSnippet =
+          (await configApi.setCommonConfigSnippet("claude", value)) ?? "";
+      } catch (error) {
+        console.error("保存通用配置失败:", error);
+        setCommonConfigError(
+          t("claudeConfig.saveFailed", { error: String(error) }),
+        );
+        return;
+      }
+
+      if (snippetSaveRequestId.current !== requestId) {
+        return;
+      }
+      setCommonConfigSnippetState(savedSnippet);
+
       // 若当前启用通用配置且格式正确，需要替换为最新片段
-      if (useCommonConfig && !validationError) {
+      if (useCommonConfig) {
         const removeResult = updateCommonConfigSnippet(
           settingsConfig,
           previousSnippet,
@@ -287,7 +307,7 @@ export function useCommonConfigSnippet({
         }
         const addResult = updateCommonConfigSnippet(
           removeResult.updatedConfig,
-          value,
+          savedSnippet,
           true,
         );
 
@@ -305,7 +325,7 @@ export function useCommonConfigSnippet({
         }, 0);
       }
     },
-    [commonConfigSnippet, settingsConfig, useCommonConfig, onConfigChange],
+    [commonConfigSnippet, settingsConfig, useCommonConfig, onConfigChange, t],
   );
 
   // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）
@@ -347,7 +367,13 @@ export function useCommonConfigSnippet({
       setCommonConfigSnippetState(extracted);
 
       // 保存到后端
-      await configApi.setCommonConfigSnippet("claude", extracted);
+      const savedSnippet = await configApi.setCommonConfigSnippet(
+        "claude",
+        extracted,
+      );
+      if (savedSnippet) {
+        setCommonConfigSnippetState(savedSnippet);
+      }
     } catch (error) {
       console.error("提取通用配置失败:", error);
       setCommonConfigError(

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -20,8 +20,8 @@ export async function getClaudeCommonConfigSnippet(): Promise<string | null> {
  */
 export async function setClaudeCommonConfigSnippet(
   snippet: string,
-): Promise<void> {
-  return invoke("set_claude_common_config_snippet", { snippet });
+): Promise<string | null> {
+  return invoke<string | null>("set_claude_common_config_snippet", { snippet });
 }
 
 /**
@@ -44,8 +44,11 @@ export async function getCommonConfigSnippet(
 export async function setCommonConfigSnippet(
   appType: AppType,
   snippet: string,
-): Promise<void> {
-  return invoke("set_common_config_snippet", { appType, snippet });
+): Promise<string | null> {
+  return invoke<string | null>("set_common_config_snippet", {
+    appType,
+    snippet,
+  });
 }
 
 /**

--- a/tests/hooks/useCommonConfigSave.test.tsx
+++ b/tests/hooks/useCommonConfigSave.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCommonConfigSnippet } from "@/components/providers/forms/hooks/useCommonConfigSnippet";
 import { useCodexCommonConfig } from "@/components/providers/forms/hooks/useCodexCommonConfig";
 import { useGeminiCommonConfig } from "@/components/providers/forms/hooks/useGeminiCommonConfig";
 
@@ -21,7 +22,7 @@ vi.mock("@/lib/api", () => ({
 describe("common config snippet saving", () => {
   beforeEach(() => {
     getCommonConfigSnippetMock.mockResolvedValue("");
-    setCommonConfigSnippetMock.mockResolvedValue(undefined);
+    setCommonConfigSnippetMock.mockResolvedValue(null);
     extractCommonConfigSnippetMock.mockResolvedValue("");
   });
 
@@ -75,5 +76,79 @@ describe("common config snippet saving", () => {
     expect(result.current.commonConfigError).toBe(
       "geminiConfig.commonConfigInvalidValues",
     );
+  });
+
+  it("uses the sanitized Claude snippet returned by the backend", async () => {
+    const previousSnippet = JSON.stringify(
+      {
+        includeCoAuthoredBy: false,
+      },
+      null,
+      2,
+    );
+    const settingsConfig = JSON.stringify(
+      {
+        env: { CLAUDE_CODE_DISABLE_TERMINAL_TITLE: "1" },
+        includeCoAuthoredBy: false,
+      },
+      null,
+      2,
+    );
+    const rawSnippet = JSON.stringify(
+      {
+        includeCoAuthoredBy: false,
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: "/missing/bridge",
+                },
+              ],
+            },
+          ],
+        },
+        statusLine: {
+          type: "command",
+          command: "/missing/statusline",
+        },
+      },
+      null,
+      2,
+    );
+    const sanitizedSnippet = previousSnippet;
+    const onConfigChange = vi.fn();
+
+    getCommonConfigSnippetMock.mockResolvedValue(previousSnippet);
+    setCommonConfigSnippetMock.mockResolvedValue(sanitizedSnippet);
+
+    const { result } = renderHook(() =>
+      useCommonConfigSnippet({
+        settingsConfig,
+        onConfigChange,
+        initialData: {
+          settingsConfig: JSON.parse(settingsConfig),
+        },
+        initialEnabled: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+
+    await act(async () => {
+      await result.current.handleCommonConfigSnippetChange(rawSnippet);
+    });
+
+    expect(setCommonConfigSnippetMock).toHaveBeenCalledWith(
+      "claude",
+      rawSnippet,
+    );
+    expect(result.current.commonConfigSnippet).toBe(sanitizedSnippet);
+
+    const updatedConfig = JSON.parse(onConfigChange.mock.lastCall?.[0] ?? "{}");
+    expect(updatedConfig.includeCoAuthoredBy).toBe(false);
+    expect(updatedConfig.hooks).toBeUndefined();
+    expect(updatedConfig.statusLine).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- prune Claude common config hook/statusLine commands when their first shell word is a missing absolute executable path
- sanitize existing Claude common config snippets on startup and when snippets are saved
- apply the same pruning before overlaying common config back into live Claude settings

## Root cause
Claude common config extraction preserved non-provider fields such as hooks and statusLine. If a third-party app was later uninstalled, cc-switch could keep that app's absolute hook path in common_config_claude and reapply it during provider switching.

## Validation
- cargo fmt --check
- cargo test missing_absolute_commands
- cargo test common_config