### PR TITLE
feat(sync): add Codex session WebDAV sync

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages: []
 
+allowBuilds:
+  esbuild: true
+  msw: true
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'

--- a/src-tauri/src/services/webdav.rs
+++ b/src-tauri/src/services/webdav.rs
@@ -5,6 +5,7 @@
 
 use reqwest::{Method, RequestBuilder, StatusCode, Url};
 use std::time::Duration;
+use tokio::time::sleep;
 
 use crate::error::AppError;
 use crate::proxy::http_client;
@@ -13,6 +14,8 @@ use futures::StreamExt;
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 /// Timeout for large file transfers (PUT/GET of db.sql, skills.zip).
 const TRANSFER_TIMEOUT_SECS: u64 = 300;
+const GET_RETRY_ATTEMPTS: usize = 3;
+const GET_RETRY_BASE_DELAY_MS: u64 = 300;
 
 /// Auth pair: `(username, Some(password))`.
 pub type WebDavAuth = Option<(String, Option<String>)>;
@@ -119,11 +122,37 @@ fn webdav_transport_error(
     };
 
     let safe_url = redact_url(target_url);
+    let detail = sanitize_reqwest_error(err, target_url, &safe_url);
     AppError::localized(
         key,
-        format!("WebDAV {op_zh}失败（{zh_reason}）: {safe_url}"),
-        format!("WebDAV {op_en} failed ({en_reason}): {safe_url}"),
+        format!("WebDAV {op_zh}失败（{zh_reason}）: {safe_url}；详情: {detail}"),
+        format!("WebDAV {op_en} failed ({en_reason}): {safe_url}; detail: {detail}"),
     )
+}
+
+fn sanitize_reqwest_error(err: &reqwest::Error, target_url: &str, safe_url: &str) -> String {
+    err.to_string().replace(target_url, safe_url)
+}
+
+fn is_retryable_get_error(err: &reqwest::Error) -> bool {
+    err.is_timeout() || err.is_connect() || err.is_request() || err.is_body()
+}
+
+async fn retry_get_after_error(url: &str, attempt: usize, err: &reqwest::Error) -> bool {
+    if attempt + 1 >= GET_RETRY_ATTEMPTS || !is_retryable_get_error(err) {
+        return false;
+    }
+
+    let delay_ms = GET_RETRY_BASE_DELAY_MS.saturating_mul(1_u64 << attempt);
+    log::warn!(
+        "[WebDAV] GET failed for {}, retrying ({}/{}): {}",
+        redact_url(url),
+        attempt + 1,
+        GET_RETRY_ATTEMPTS,
+        sanitize_reqwest_error(err, url, &redact_url(url))
+    );
+    sleep(Duration::from_millis(delay_ms)).await;
+    true
 }
 
 // ─── HTTP operations ─────────────────────────────────────────
@@ -255,46 +284,72 @@ pub async fn get_bytes(
     auth: &WebDavAuth,
     max_bytes: usize,
 ) -> Result<Option<(Vec<u8>, Option<String>)>, AppError> {
-    let client = http_client::get();
-    let resp = apply_auth(
-        client
-            .get(url)
-            .timeout(Duration::from_secs(TRANSFER_TIMEOUT_SECS)),
-        auth,
-    )
-    .send()
-    .await
-    .map_err(|e| webdav_transport_error("webdav.get_failed", "GET 请求", "GET request", url, &e))?;
+    'attempts: for attempt in 0..GET_RETRY_ATTEMPTS {
+        let client = http_client::get();
+        let resp = match apply_auth(
+            client
+                .get(url)
+                .timeout(Duration::from_secs(TRANSFER_TIMEOUT_SECS)),
+            auth,
+        )
+        .send()
+        .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                if retry_get_after_error(url, attempt, &e).await {
+                    continue;
+                }
+                return Err(webdav_transport_error(
+                    "webdav.get_failed",
+                    "GET 请求",
+                    "GET request",
+                    url,
+                    &e,
+                ));
+            }
+        };
 
-    if resp.status() == StatusCode::NOT_FOUND {
-        return Ok(None);
-    }
-    if !resp.status().is_success() {
-        return Err(webdav_status_error("GET", resp.status(), url));
-    }
-    ensure_content_length_within_limit(resp.headers(), max_bytes, url)?;
-
-    let etag = resp
-        .headers()
-        .get("etag")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
-    let mut bytes = Vec::new();
-    let mut stream = resp.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| {
-            AppError::localized(
-                "webdav.response_read_failed",
-                format!("读取 WebDAV 响应失败: {e}"),
-                format!("Failed to read WebDAV response: {e}"),
-            )
-        })?;
-        if bytes.len().saturating_add(chunk.len()) > max_bytes {
-            return Err(response_too_large_error(url, max_bytes));
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
         }
-        bytes.extend_from_slice(&chunk);
+        if !resp.status().is_success() {
+            return Err(webdav_status_error("GET", resp.status(), url));
+        }
+        ensure_content_length_within_limit(resp.headers(), max_bytes, url)?;
+
+        let etag = resp
+            .headers()
+            .get("etag")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let mut bytes = Vec::new();
+        let mut stream = resp.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(e) => {
+                    if retry_get_after_error(url, attempt, &e).await {
+                        continue 'attempts;
+                    }
+                    let safe_url = redact_url(url);
+                    let detail = sanitize_reqwest_error(&e, url, &safe_url);
+                    return Err(AppError::localized(
+                        "webdav.response_read_failed",
+                        format!("读取 WebDAV 响应失败: {safe_url}；详情: {detail}"),
+                        format!("Failed to read WebDAV response: {safe_url}; detail: {detail}"),
+                    ));
+                }
+            };
+            if bytes.len().saturating_add(chunk.len()) > max_bytes {
+                return Err(response_too_large_error(url, max_bytes));
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        return Ok(Some((bytes, etag)));
     }
-    Ok(Some((bytes, etag)))
+
+    unreachable!("GET retry loop always returns on the final attempt")
 }
 
 /// HEAD request to retrieve the ETag. Returns `None` on 404.

--- a/src-tauri/src/services/webdav_auto_sync.rs
+++ b/src-tauri/src/services/webdav_auto_sync.rs
@@ -1,9 +1,11 @@
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
@@ -77,6 +79,12 @@ fn should_run_auto_sync(settings: Option<&WebDavSyncSettings>) -> bool {
         return false;
     };
     sync.enabled && sync.auto_sync
+}
+
+fn should_poll_codex_sessions(settings: Option<&WebDavSyncSettings>) -> bool {
+    settings
+        .map(|sync| sync.enabled && sync.auto_sync && sync.sync_codex_sessions)
+        .unwrap_or(false)
 }
 
 fn persist_auto_sync_error(settings: &mut WebDavSyncSettings, error: &AppError) {
@@ -159,8 +167,15 @@ pub fn start_worker(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
         return;
     }
 
+    let db_for_codex_sessions = Arc::clone(&db);
+    let app_for_codex_sessions = app.clone();
+
     tauri::async_runtime::spawn(async move {
         run_worker_loop(db, rx, app).await;
+    });
+
+    tauri::async_runtime::spawn(async move {
+        run_codex_session_poll_loop(db_for_codex_sessions, app_for_codex_sessions).await;
     });
 }
 
@@ -193,15 +208,116 @@ async fn run_worker_loop(
     }
 }
 
+async fn run_codex_session_poll_loop(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
+    let mut last_fingerprint: Option<String> = None;
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+
+        let settings = settings::get_webdav_sync_settings();
+        if !should_poll_codex_sessions(settings.as_ref()) {
+            last_fingerprint = None;
+            continue;
+        }
+
+        let fingerprint =
+            match tauri::async_runtime::spawn_blocking(codex_session_fingerprint).await {
+                Ok(Ok(value)) => value,
+                Ok(Err(err)) => {
+                    log::debug!("[WebDAV][AutoSync] Codex session fingerprint failed: {err}");
+                    continue;
+                }
+                Err(err) => {
+                    log::debug!("[WebDAV][AutoSync] Codex session fingerprint task failed: {err}");
+                    continue;
+                }
+            };
+
+        let Some(previous) = last_fingerprint.as_ref() else {
+            last_fingerprint = Some(fingerprint);
+            continue;
+        };
+
+        if previous == &fingerprint {
+            continue;
+        }
+
+        log::debug!("[WebDAV][AutoSync] Triggered by Codex session file change");
+        match run_auto_sync_upload(&db, &app).await {
+            Ok(()) => last_fingerprint = Some(fingerprint),
+            Err(err) => {
+                log::warn!("[WebDAV][AutoSync] Codex session upload failed: {err}");
+            }
+        }
+    }
+}
+
+fn codex_session_fingerprint() -> Result<String, AppError> {
+    let mut files = Vec::new();
+    for root in crate::session_manager::providers::codex::session_roots() {
+        collect_codex_session_file_stats(&root, &root, &mut files)?;
+    }
+    files.sort();
+
+    let mut hasher = Sha256::new();
+    for entry in files {
+        hasher.update(entry.as_bytes());
+        hasher.update(b"\n");
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn collect_codex_session_file_stats(
+    root: &Path,
+    current: &Path,
+    files: &mut Vec<String>,
+) -> Result<(), AppError> {
+    if !current.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(current).map_err(|e| AppError::io(current, e))? {
+        let entry = entry.map_err(|e| AppError::io(current, e))?;
+        let path = entry.path();
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            collect_codex_session_file_stats(root, &path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            let rel = path
+                .strip_prefix(root)
+                .map(|value| value.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_else(|_| path.to_string_lossy().to_string());
+            let root_name = root
+                .file_name()
+                .map(|value| value.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let modified = metadata
+                .modified()
+                .ok()
+                .and_then(|value| value.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|value| value.as_nanos())
+                .unwrap_or(0);
+            files.push(format!("{root_name}/{rel}:{}:{modified}", metadata.len()));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        auto_sync_wait_duration, enqueue_change_signal, is_auto_sync_suppressed,
-        should_run_auto_sync, should_trigger_for_table, AutoSyncSuppressionGuard,
-        MAX_AUTO_SYNC_WAIT_MS,
+        auto_sync_wait_duration, collect_codex_session_file_stats, enqueue_change_signal,
+        is_auto_sync_suppressed, should_poll_codex_sessions, should_run_auto_sync,
+        should_trigger_for_table, AutoSyncSuppressionGuard, MAX_AUTO_SYNC_WAIT_MS,
     };
     use crate::settings::WebDavSyncSettings;
     use std::time::{Duration, Instant};
+    use tempfile::tempdir;
     use tokio::sync::mpsc::channel;
 
     #[test]
@@ -260,6 +376,44 @@ mod tests {
             ..WebDavSyncSettings::default()
         };
         assert!(should_run_auto_sync(Some(&enabled)));
+    }
+
+    #[test]
+    fn should_poll_codex_sessions_requires_explicit_opt_in() {
+        let disabled = WebDavSyncSettings {
+            enabled: true,
+            auto_sync: true,
+            sync_codex_sessions: false,
+            ..WebDavSyncSettings::default()
+        };
+        assert!(!should_poll_codex_sessions(Some(&disabled)));
+
+        let enabled = WebDavSyncSettings {
+            enabled: true,
+            auto_sync: true,
+            sync_codex_sessions: true,
+            ..WebDavSyncSettings::default()
+        };
+        assert!(should_poll_codex_sessions(Some(&enabled)));
+    }
+
+    #[test]
+    fn codex_session_file_stats_include_root_and_nested_path() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("sessions");
+        let session_dir = root.join("2026").join("05").join("29");
+        std::fs::create_dir_all(&session_dir).expect("create session dir");
+        std::fs::write(session_dir.join("session.jsonl"), "{}\n").expect("write session");
+
+        let mut files = Vec::new();
+        collect_codex_session_file_stats(&root, &root, &mut files).expect("collect session stats");
+
+        assert_eq!(files.len(), 1);
+        assert!(
+            files[0].starts_with("sessions/2026/05/29/session.jsonl:"),
+            "fingerprint entry should preserve the Codex root and nested relative path: {:?}",
+            files
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/webdav_sync.rs
+++ b/src-tauri/src/services/webdav_sync.rs
@@ -1,7 +1,8 @@
 //! WebDAV v2 sync protocol layer with DB compatibility subdirectories.
 //!
 //! Implements manifest-based synchronization on top of the HTTP transport
-//! primitives in [`super::webdav`]. Artifact set: `db.sql` + `skills.zip`.
+//! primitives in [`super::webdav`]. Artifact set: `db.sql` + `skills.zip`
+//! and optional `codex-sessions.zip`.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -24,7 +25,8 @@ use crate::settings::{update_webdav_sync_status, WebDavSyncSettings, WebDavSyncS
 
 mod archive;
 use archive::{
-    backup_current_skills, restore_skills_from_backup, restore_skills_zip, zip_skills_ssot,
+    backup_current_skills, restore_codex_sessions_zip, restore_skills_from_backup,
+    restore_skills_zip, zip_codex_sessions, zip_skills_ssot,
 };
 
 // ─── Protocol constants ──────────────────────────────────────
@@ -35,6 +37,7 @@ const DB_COMPAT_VERSION: u32 = 6;
 const LEGACY_DB_COMPAT_VERSION: u32 = 5;
 const REMOTE_DB_SQL: &str = "db.sql";
 const REMOTE_SKILLS_ZIP: &str = "skills.zip";
+const REMOTE_CODEX_SESSIONS_ZIP: &str = "codex-sessions.zip";
 const REMOTE_MANIFEST: &str = "manifest.json";
 const MAX_DEVICE_NAME_LEN: usize = 64;
 const MAX_MANIFEST_BYTES: usize = 1024 * 1024;
@@ -95,6 +98,7 @@ struct ArtifactMeta {
 struct LocalSnapshot {
     db_sql: Vec<u8>,
     skills_zip: Vec<u8>,
+    codex_sessions_zip: Option<Vec<u8>>,
     manifest_bytes: Vec<u8>,
     manifest_hash: String,
 }
@@ -151,6 +155,18 @@ pub async fn upload(
 
     let skills_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_SKILLS_ZIP)?;
     put_bytes(&skills_url, &auth, snapshot.skills_zip, "application/zip").await?;
+
+    if let Some(codex_sessions_zip) = snapshot.codex_sessions_zip {
+        let codex_sessions_url =
+            remote_file_url(settings, RemoteLayout::Current, REMOTE_CODEX_SESSIONS_ZIP)?;
+        put_bytes(
+            &codex_sessions_url,
+            &auth,
+            codex_sessions_zip,
+            "application/zip",
+        )
+        .await?;
+    }
 
     let manifest_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_MANIFEST)?;
     put_bytes(
@@ -215,9 +231,28 @@ pub async fn download(
         &snapshot.manifest.artifacts,
     )
     .await?;
+    let codex_sessions_zip = if settings.sync_codex_sessions
+        && snapshot
+            .manifest
+            .artifacts
+            .contains_key(REMOTE_CODEX_SESSIONS_ZIP)
+    {
+        Some(
+            download_and_verify(
+                settings,
+                &auth,
+                snapshot.layout,
+                REMOTE_CODEX_SESSIONS_ZIP,
+                &snapshot.manifest.artifacts,
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
 
     // Apply snapshot
-    apply_snapshot(db, &db_sql, &skills_zip)?;
+    apply_snapshot(db, &db_sql, &skills_zip, codex_sessions_zip.as_deref())?;
 
     let manifest_hash = sha256_hex(&snapshot.manifest_bytes);
     let _persisted = persist_sync_success_best_effort(
@@ -300,7 +335,7 @@ where
 
 fn build_local_snapshot(
     db: &crate::database::Database,
-    _settings: &WebDavSyncSettings,
+    settings: &WebDavSyncSettings,
 ) -> Result<LocalSnapshot, AppError> {
     // Export database to SQL string
     let sql_string = db.export_sql_string_for_sync()?;
@@ -318,6 +353,16 @@ fn build_local_snapshot(
     let skills_zip_path = tmp.path().join(REMOTE_SKILLS_ZIP);
     zip_skills_ssot(&skills_zip_path)?;
     let skills_zip = fs::read(&skills_zip_path).map_err(|e| AppError::io(&skills_zip_path, e))?;
+    let codex_sessions_zip = if settings.sync_codex_sessions {
+        let codex_sessions_zip_path = tmp.path().join(REMOTE_CODEX_SESSIONS_ZIP);
+        zip_codex_sessions(&codex_sessions_zip_path)?;
+        Some(
+            fs::read(&codex_sessions_zip_path)
+                .map_err(|e| AppError::io(&codex_sessions_zip_path, e))?,
+        )
+    } else {
+        None
+    };
 
     // Build artifact map and compute hashes
     let mut artifacts = BTreeMap::new();
@@ -335,6 +380,15 @@ fn build_local_snapshot(
             size: skills_zip.len() as u64,
         },
     );
+    if let Some(codex_sessions_zip) = codex_sessions_zip.as_ref() {
+        artifacts.insert(
+            REMOTE_CODEX_SESSIONS_ZIP.to_string(),
+            ArtifactMeta {
+                sha256: sha256_hex(codex_sessions_zip),
+                size: codex_sessions_zip.len() as u64,
+            },
+        );
+    }
 
     let snapshot_id = compute_snapshot_id(&artifacts);
     let manifest = SyncManifest {
@@ -353,6 +407,7 @@ fn build_local_snapshot(
     Ok(LocalSnapshot {
         db_sql,
         skills_zip,
+        codex_sessions_zip,
         manifest_bytes,
         manifest_hash,
     })
@@ -591,6 +646,7 @@ fn apply_snapshot(
     db: &crate::database::Database,
     db_sql: &[u8],
     skills_zip: &[u8],
+    codex_sessions_zip: Option<&[u8]>,
 ) -> Result<(), AppError> {
     let sql_str = std::str::from_utf8(db_sql).map_err(|e| {
         localized(
@@ -615,6 +671,10 @@ fn apply_snapshot(
             ));
         }
         return Err(db_err);
+    }
+
+    if let Some(codex_sessions_zip) = codex_sessions_zip {
+        restore_codex_sessions_zip(codex_sessions_zip)?;
     }
 
     Ok(())

--- a/src-tauri/src/services/webdav_sync/archive.rs
+++ b/src-tauri/src/services/webdav_sync/archive.rs
@@ -1,12 +1,16 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
+use chrono::Utc;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tempfile::{tempdir, TempDir};
 use zip::write::SimpleFileOptions;
 use zip::DateTime;
 
+use crate::codex_config::get_codex_config_dir;
 use crate::error::AppError;
 use crate::services::skill::SkillService;
 
@@ -14,6 +18,8 @@ use super::{io_context_localized, localized, MAX_SYNC_ARTIFACT_BYTES, REMOTE_SKI
 
 /// Maximum number of entries allowed in a zip archive.
 const MAX_EXTRACT_ENTRIES: usize = 10_000;
+const CODEX_SESSION_ROOTS: [&str; 2] = ["sessions", "archived_sessions"];
+const CODEX_SESSION_BACKUP_DIR: &str = "session_sync_backups";
 
 pub(super) struct SkillsBackup {
     _tmp: TempDir,
@@ -202,6 +208,465 @@ pub(super) fn restore_skills_from_backup(backup: &SkillsBackup) -> Result<(), Ap
     Ok(())
 }
 
+pub(super) fn zip_codex_sessions(dest_path: &Path) -> Result<(), AppError> {
+    zip_codex_sessions_from_config_dir(&get_codex_config_dir(), dest_path)
+}
+
+fn zip_codex_sessions_from_config_dir(config_dir: &Path, dest_path: &Path) -> Result<(), AppError> {
+    if let Some(parent) = dest_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+
+    let file = fs::File::create(dest_path).map_err(|e| AppError::io(dest_path, e))?;
+    let mut writer = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .last_modified_time(DateTime::default());
+
+    for root_name in CODEX_SESSION_ROOTS {
+        let root_path = config_dir.join(root_name);
+        if !root_path.exists() {
+            continue;
+        }
+
+        let canonical_root = fs::canonicalize(&root_path).unwrap_or(root_path.clone());
+        let mut visited = HashSet::new();
+        mark_visited_dir(&canonical_root, &mut visited)?;
+        zip_codex_session_dir_recursive(
+            root_name,
+            &canonical_root,
+            &canonical_root,
+            &mut writer,
+            options,
+            &mut visited,
+        )?;
+    }
+
+    writer.finish().map_err(|e| {
+        localized(
+            "webdav.sync.codex_sessions_zip_write_failed",
+            format!("写入 codex-sessions.zip 失败: {e}"),
+            format!("Failed to write codex-sessions.zip: {e}"),
+        )
+    })?;
+    Ok(())
+}
+
+pub(super) fn restore_codex_sessions_zip(raw: &[u8]) -> Result<(), AppError> {
+    restore_codex_sessions_zip_into_config_dir(raw, &get_codex_config_dir())
+}
+
+fn restore_codex_sessions_zip_into_config_dir(
+    raw: &[u8],
+    config_dir: &Path,
+) -> Result<(), AppError> {
+    let tmp = tempdir().map_err(|e| {
+        io_context_localized(
+            "webdav.sync.codex_sessions_extract_tmpdir_failed",
+            "创建 Codex 会话解压临时目录失败",
+            "Failed to create temporary directory for Codex session extraction",
+            e,
+        )
+    })?;
+    let zip_path = tmp.path().join("codex-sessions.zip");
+    fs::write(&zip_path, raw).map_err(|e| AppError::io(&zip_path, e))?;
+
+    let file = fs::File::open(&zip_path).map_err(|e| AppError::io(&zip_path, e))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| {
+        localized(
+            "webdav.sync.codex_sessions_zip_parse_failed",
+            format!("解析 codex-sessions.zip 失败: {e}"),
+            format!("Failed to parse codex-sessions.zip: {e}"),
+        )
+    })?;
+
+    if archive.len() > MAX_EXTRACT_ENTRIES {
+        return Err(localized(
+            "webdav.sync.codex_sessions_zip_too_many_entries",
+            format!(
+                "codex-sessions.zip 条目数过多（{}），上限 {MAX_EXTRACT_ENTRIES}",
+                archive.len()
+            ),
+            format!(
+                "codex-sessions.zip has too many entries ({}), limit is {MAX_EXTRACT_ENTRIES}",
+                archive.len()
+            ),
+        ));
+    }
+
+    let extracted = tmp.path().join("codex-sessions-extracted");
+    fs::create_dir_all(&extracted).map_err(|e| AppError::io(&extracted, e))?;
+
+    let mut total_bytes: u64 = 0;
+    for idx in 0..archive.len() {
+        let mut entry = archive.by_index(idx).map_err(|e| {
+            localized(
+                "webdav.sync.codex_sessions_zip_entry_read_failed",
+                format!("读取 Codex 会话 ZIP 项失败: {e}"),
+                format!("Failed to read Codex session ZIP entry: {e}"),
+            )
+        })?;
+        if entry.is_dir() {
+            continue;
+        }
+        let Some(safe_name) = entry.enclosed_name() else {
+            continue;
+        };
+        if !is_allowed_codex_session_rel(&safe_name) {
+            continue;
+        }
+
+        let out_path = extracted.join(safe_name);
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+        }
+        let mut out = fs::File::create(&out_path).map_err(|e| AppError::io(&out_path, e))?;
+        let _written = copy_entry_with_total_limit(
+            &mut entry,
+            &mut out,
+            &mut total_bytes,
+            MAX_SYNC_ARTIFACT_BYTES,
+            &out_path,
+        )?;
+    }
+
+    restore_codex_sessions_from_dir(&extracted, config_dir)
+}
+
+#[derive(Debug)]
+struct CodexSessionFileInfo {
+    session_id: Option<String>,
+    last_active_at: Option<i64>,
+    hash: String,
+    bytes: Vec<u8>,
+}
+
+fn restore_codex_sessions_from_dir(extracted: &Path, config_dir: &Path) -> Result<(), AppError> {
+    let mut incoming_files = Vec::new();
+    collect_codex_jsonl_files(extracted, &mut incoming_files)?;
+    if incoming_files.is_empty() {
+        return Ok(());
+    }
+
+    let mut local_index = build_codex_session_index(config_dir)?;
+    let backup_root = config_dir
+        .join(CODEX_SESSION_BACKUP_DIR)
+        .join(Utc::now().format("%Y%m%dT%H%M%S%.3fZ").to_string());
+
+    for source in incoming_files {
+        let rel = source.strip_prefix(extracted).map_err(|e| {
+            localized(
+                "webdav.sync.codex_sessions_relative_path_failed",
+                format!("生成 Codex 会话相对路径失败: {e}"),
+                format!("Failed to build Codex session relative path: {e}"),
+            )
+        })?;
+
+        if let Some((session_id, target_path)) =
+            merge_codex_session_file(&source, rel, config_dir, &local_index, &backup_root)?
+        {
+            local_index.insert(session_id, target_path);
+        }
+    }
+
+    Ok(())
+}
+
+fn merge_codex_session_file(
+    incoming_path: &Path,
+    rel: &Path,
+    config_dir: &Path,
+    local_index: &HashMap<String, PathBuf>,
+    backup_root: &Path,
+) -> Result<Option<(String, PathBuf)>, AppError> {
+    let incoming = read_codex_session_file_info(incoming_path)?;
+    let default_target = config_dir.join(rel);
+    let existing_by_id = incoming
+        .session_id
+        .as_ref()
+        .and_then(|session_id| local_index.get(session_id))
+        .cloned();
+    let compare_path = existing_by_id.unwrap_or_else(|| default_target.clone());
+
+    if compare_path.exists() {
+        if is_symlink(&compare_path)? {
+            log::warn!(
+                "[WebDAV] Skipping Codex session restore over symlink: {}",
+                compare_path.display()
+            );
+            return Ok(None);
+        }
+
+        let local = read_codex_session_file_info(&compare_path)?;
+        if local.hash == incoming.hash {
+            return Ok(None);
+        }
+
+        let local_ts = local.last_active_at.unwrap_or(0);
+        let incoming_ts = incoming.last_active_at.unwrap_or(0);
+        if local_ts > incoming_ts {
+            return Ok(None);
+        }
+
+        backup_codex_session_file(config_dir, &compare_path, backup_root)?;
+        if compare_path != default_target {
+            fs::remove_file(&compare_path).map_err(|e| AppError::io(&compare_path, e))?;
+        }
+    }
+
+    if default_target.exists() {
+        if is_symlink(&default_target)? {
+            log::warn!(
+                "[WebDAV] Skipping Codex session restore over symlink: {}",
+                default_target.display()
+            );
+            return Ok(None);
+        }
+        if default_target != compare_path {
+            backup_codex_session_file(config_dir, &default_target, backup_root)?;
+        }
+    }
+
+    write_codex_session_file(&default_target, &incoming.bytes)?;
+    Ok(incoming
+        .session_id
+        .map(|session_id| (session_id, default_target)))
+}
+
+fn zip_codex_session_dir_recursive(
+    root_name: &str,
+    root: &Path,
+    current: &Path,
+    writer: &mut zip::ZipWriter<fs::File>,
+    options: SimpleFileOptions,
+    visited: &mut HashSet<PathBuf>,
+) -> Result<(), AppError> {
+    let mut entries: Vec<_> = fs::read_dir(current)
+        .map_err(|e| AppError::io(current, e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AppError::io(current, e))?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let path = entry.path();
+        if is_symlink(&path)? {
+            continue;
+        }
+
+        if path.is_dir() {
+            let real_path = fs::canonicalize(&path).unwrap_or(path.clone());
+            if !real_path.starts_with(root) || !mark_visited_dir(&real_path, visited)? {
+                continue;
+            }
+            zip_codex_session_dir_recursive(root_name, root, &real_path, writer, options, visited)?;
+            continue;
+        }
+
+        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+            continue;
+        }
+
+        let real_path = fs::canonicalize(&path).unwrap_or(path.clone());
+        if !real_path.starts_with(root) {
+            continue;
+        }
+
+        let rel = real_path
+            .strip_prefix(root)
+            .or_else(|_| path.strip_prefix(root))
+            .map_err(|e| {
+                localized(
+                    "webdav.sync.codex_sessions_zip_relative_path_failed",
+                    format!("生成 Codex 会话 ZIP 相对路径失败: {e}"),
+                    format!("Failed to build Codex session ZIP relative path: {e}"),
+                )
+            })?;
+        let zip_rel = Path::new(root_name).join(rel);
+        let zip_rel_str = zip_rel.to_string_lossy().replace('\\', "/");
+
+        writer.start_file(&zip_rel_str, options).map_err(|e| {
+            localized(
+                "webdav.sync.codex_sessions_zip_start_file_failed",
+                format!("写入 Codex 会话 ZIP 文件头失败: {e}"),
+                format!("Failed to start Codex session ZIP file entry: {e}"),
+            )
+        })?;
+        let mut file = fs::File::open(&real_path).map_err(|e| AppError::io(&real_path, e))?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)
+            .map_err(|e| AppError::io(&real_path, e))?;
+        writer.write_all(&buf).map_err(|e| {
+            localized(
+                "webdav.sync.codex_sessions_zip_write_file_failed",
+                format!("写入 Codex 会话 ZIP 文件内容失败: {e}"),
+                format!("Failed to write Codex session ZIP file content: {e}"),
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn build_codex_session_index(config_dir: &Path) -> Result<HashMap<String, PathBuf>, AppError> {
+    let mut files = Vec::new();
+    for root_name in CODEX_SESSION_ROOTS {
+        collect_codex_jsonl_files(&config_dir.join(root_name), &mut files)?;
+    }
+
+    let mut index = HashMap::new();
+    for path in files {
+        let info = read_codex_session_file_info(&path)?;
+        if let Some(session_id) = info.session_id {
+            index.insert(session_id, path);
+        }
+    }
+    Ok(index)
+}
+
+fn collect_codex_jsonl_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<(), AppError> {
+    if !root.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(root).map_err(|e| AppError::io(root, e))? {
+        let entry = entry.map_err(|e| AppError::io(root, e))?;
+        let path = entry.path();
+        if is_symlink(&path)? {
+            continue;
+        }
+        if path.is_dir() {
+            collect_codex_jsonl_files(&path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(())
+}
+
+fn read_codex_session_file_info(path: &Path) -> Result<CodexSessionFileInfo, AppError> {
+    let bytes = fs::read(path).map_err(|e| AppError::io(path, e))?;
+    let hash = sha256_hex_local(&bytes);
+    let mut session_id = None;
+    let mut last_active_at = None;
+    let reader = BufReader::new(bytes.as_slice());
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(parsed) => parsed,
+            Err(_) => continue,
+        };
+
+        last_active_at = max_timestamp(
+            last_active_at,
+            value.get("timestamp").and_then(parse_codex_timestamp_to_ms),
+        );
+
+        if value.get("type").and_then(Value::as_str) == Some("session_meta") {
+            if let Some(payload) = value.get("payload") {
+                if session_id.is_none() {
+                    session_id = payload
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                }
+                last_active_at = max_timestamp(
+                    last_active_at,
+                    payload
+                        .get("timestamp")
+                        .and_then(parse_codex_timestamp_to_ms),
+                );
+            }
+        }
+    }
+
+    Ok(CodexSessionFileInfo {
+        session_id,
+        last_active_at: last_active_at.or_else(|| file_modified_ms(path)),
+        hash,
+        bytes,
+    })
+}
+
+fn backup_codex_session_file(
+    config_dir: &Path,
+    source: &Path,
+    backup_root: &Path,
+) -> Result<(), AppError> {
+    let rel = source.strip_prefix(config_dir).unwrap_or_else(|_| {
+        source
+            .file_name()
+            .map(Path::new)
+            .unwrap_or_else(|| Path::new("session.jsonl"))
+    });
+    let backup_path = backup_root.join(rel);
+    if let Some(parent) = backup_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+    fs::copy(source, &backup_path).map_err(|e| AppError::io(&backup_path, e))?;
+    Ok(())
+}
+
+fn write_codex_session_file(target: &Path, bytes: &[u8]) -> Result<(), AppError> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+    crate::config::atomic_write(target, bytes)
+}
+
+fn is_allowed_codex_session_rel(path: &Path) -> bool {
+    let Some(root) = path
+        .components()
+        .next()
+        .and_then(|component| match component {
+            std::path::Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+    else {
+        return false;
+    };
+    CODEX_SESSION_ROOTS.contains(&root)
+        && path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+}
+
+fn parse_codex_timestamp_to_ms(value: &Value) -> Option<i64> {
+    value
+        .as_str()
+        .and_then(|raw| chrono::DateTime::parse_from_rfc3339(raw).ok())
+        .map(|ts| ts.timestamp_millis())
+}
+
+fn max_timestamp(current: Option<i64>, next: Option<i64>) -> Option<i64> {
+    match (current, next) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+fn file_modified_ms(path: &Path) -> Option<i64> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    let duration = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
+    Some(duration.as_millis().min(i64::MAX as u128) as i64)
+}
+
+fn sha256_hex_local(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn is_symlink(path: &Path) -> Result<bool, AppError> {
+    Ok(fs::symlink_metadata(path)
+        .map_err(|e| AppError::io(path, e))?
+        .file_type()
+        .is_symlink())
+}
+
 fn zip_dir_recursive(
     root: &Path,
     current: &Path,
@@ -366,11 +831,21 @@ fn copy_entry_with_total_limit<R: Read, W: Write>(
 
 #[cfg(test)]
 mod tests {
-    use super::{copy_entry_with_total_limit, mark_visited_dir};
+    use super::{
+        copy_entry_with_total_limit, mark_visited_dir, restore_codex_sessions_zip_into_config_dir,
+        zip_codex_sessions_from_config_dir,
+    };
     use std::collections::HashSet;
     use std::io::Cursor;
     use std::path::Path;
     use tempfile::tempdir;
+
+    fn codex_session(session_id: &str, timestamp: &str, body: &str) -> String {
+        format!(
+            "{{\"timestamp\":\"{timestamp}\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session_id}\",\"cwd\":\"/tmp/project\"}}}}\n\
+             {{\"timestamp\":\"{timestamp}\",\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"user\",\"content\":\"{body}\"}}}}\n"
+        )
+    }
 
     #[test]
     fn mark_visited_dir_tracks_canonical_duplicates() {
@@ -406,5 +881,117 @@ mod tests {
             0,
             "should not write when the first chunk exceeds limit"
         );
+    }
+
+    #[test]
+    fn zip_codex_sessions_includes_jsonl_under_session_roots_only() {
+        let temp = tempdir().expect("tempdir");
+        let config_dir = temp.path().join(".codex");
+        let session_dir = config_dir.join("sessions").join("2026").join("05");
+        std::fs::create_dir_all(&session_dir).expect("create sessions");
+        std::fs::write(
+            session_dir.join("session.jsonl"),
+            codex_session("session-1", "2026-05-01T00:00:00Z", "hello"),
+        )
+        .expect("write session");
+        std::fs::write(session_dir.join("ignore.txt"), "ignore").expect("write ignored");
+        std::fs::create_dir_all(config_dir.join("logs")).expect("create logs");
+        std::fs::write(config_dir.join("logs").join("other.jsonl"), "{}")
+            .expect("write outside session root");
+
+        let zip_path = temp.path().join("codex-sessions.zip");
+        zip_codex_sessions_from_config_dir(&config_dir, &zip_path).expect("zip sessions");
+
+        let file = std::fs::File::open(&zip_path).expect("open zip");
+        let mut archive = zip::ZipArchive::new(file).expect("read zip");
+        let mut names = Vec::new();
+        for idx in 0..archive.len() {
+            names.push(archive.by_index(idx).expect("entry").name().to_string());
+        }
+
+        assert_eq!(names, vec!["sessions/2026/05/session.jsonl"]);
+    }
+
+    #[test]
+    fn restore_codex_sessions_zip_uses_newer_remote_and_backs_up_local() {
+        let temp = tempdir().expect("tempdir");
+        let local_config = temp.path().join("local-codex");
+        let remote_config = temp.path().join("remote-codex");
+        let local_session = local_config
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("session.jsonl");
+        let remote_session = remote_config
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("session.jsonl");
+        std::fs::create_dir_all(local_session.parent().unwrap()).expect("local dir");
+        std::fs::create_dir_all(remote_session.parent().unwrap()).expect("remote dir");
+        std::fs::write(
+            &local_session,
+            codex_session("same-session", "2026-05-01T00:00:00Z", "local"),
+        )
+        .expect("write local");
+        std::fs::write(
+            &remote_session,
+            codex_session("same-session", "2026-05-02T00:00:00Z", "remote"),
+        )
+        .expect("write remote");
+
+        let zip_path = temp.path().join("codex-sessions.zip");
+        zip_codex_sessions_from_config_dir(&remote_config, &zip_path).expect("zip remote");
+        let raw = std::fs::read(&zip_path).expect("read zip");
+
+        restore_codex_sessions_zip_into_config_dir(&raw, &local_config).expect("restore zip");
+
+        let restored = std::fs::read_to_string(&local_session).expect("read restored");
+        assert!(restored.contains("remote"));
+
+        let backup_root = local_config.join("session_sync_backups");
+        let backups = std::fs::read_dir(&backup_root)
+            .expect("backup root should exist")
+            .flat_map(|entry| {
+                let entry = entry.expect("backup entry");
+                let path = entry.path().join("sessions/2026/05/session.jsonl");
+                std::fs::read_to_string(path).ok()
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            backups.iter().any(|content| content.contains("local")),
+            "expected replaced local session to be backed up"
+        );
+    }
+
+    #[test]
+    fn restore_codex_sessions_zip_keeps_newer_local_session() {
+        let temp = tempdir().expect("tempdir");
+        let local_config = temp.path().join("local-codex");
+        let remote_config = temp.path().join("remote-codex");
+        let local_session = local_config.join("sessions").join("session.jsonl");
+        let remote_session = remote_config.join("sessions").join("session.jsonl");
+        std::fs::create_dir_all(local_session.parent().unwrap()).expect("local dir");
+        std::fs::create_dir_all(remote_session.parent().unwrap()).expect("remote dir");
+        std::fs::write(
+            &local_session,
+            codex_session("same-session", "2026-05-03T00:00:00Z", "local-newer"),
+        )
+        .expect("write local");
+        std::fs::write(
+            &remote_session,
+            codex_session("same-session", "2026-05-02T00:00:00Z", "remote-older"),
+        )
+        .expect("write remote");
+
+        let zip_path = temp.path().join("codex-sessions.zip");
+        zip_codex_sessions_from_config_dir(&remote_config, &zip_path).expect("zip remote");
+        let raw = std::fs::read(&zip_path).expect("read zip");
+
+        restore_codex_sessions_zip_into_config_dir(&raw, &local_config).expect("restore zip");
+
+        let restored = std::fs::read_to_string(&local_session).expect("read restored");
+        assert!(restored.contains("local-newer"));
+        assert!(!local_config.join("session_sync_backups").exists());
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -110,6 +110,8 @@ pub struct WebDavSyncSettings {
     #[serde(default)]
     pub auto_sync: bool,
     #[serde(default)]
+    pub sync_codex_sessions: bool,
+    #[serde(default)]
     pub base_url: String,
     #[serde(default)]
     pub username: String,
@@ -128,6 +130,7 @@ impl Default for WebDavSyncSettings {
         Self {
             enabled: false,
             auto_sync: false,
+            sync_codex_sessions: false,
             base_url: String::new(),
             username: String::new(),
             password: String::new(),

--- a/src/components/settings/WebdavSyncSection.tsx
+++ b/src/components/settings/WebdavSyncSection.tsx
@@ -194,6 +194,7 @@ export function WebdavSyncSection({
     remoteRoot: config?.remoteRoot ?? "cc-switch-sync",
     profile: config?.profile ?? "default",
     autoSync: config?.autoSync ?? false,
+    syncCodexSessions: config?.syncCodexSessions ?? false,
   }));
 
   // Preset selector — derived from initial URL, updated on user selection
@@ -252,6 +253,7 @@ export function WebdavSyncSection({
         remoteRoot: nextRemoteRoot,
         profile: nextProfile,
         autoSync: config.autoSync ?? false,
+        syncCodexSessions: config.syncCodexSessions ?? false,
       };
     });
     setPasswordTouched(false);
@@ -311,6 +313,16 @@ export function WebdavSyncSection({
     [settings?.autoSyncConfirmed],
   );
 
+  const handleSyncCodexSessionsChange = useCallback((checked: boolean) => {
+    setForm((prev) => ({ ...prev, syncCodexSessions: checked }));
+    setDirty(true);
+    setJustSaved(false);
+    if (justSavedTimerRef.current) {
+      clearTimeout(justSavedTimerRef.current);
+      justSavedTimerRef.current = null;
+    }
+  }, []);
+
   const handleAutoSyncConfirm = useCallback(async () => {
     setShowAutoSyncConfirm(false);
     await onAutoSave?.({ autoSyncConfirmed: true });
@@ -335,6 +347,7 @@ export function WebdavSyncSection({
       remoteRoot: form.remoteRoot.trim() || "cc-switch-sync",
       profile: form.profile.trim() || "default",
       autoSync: form.autoSync,
+      syncCodexSessions: form.syncCodexSessions,
     };
   }, [form, passwordTouched]);
 
@@ -539,6 +552,8 @@ export function WebdavSyncSection({
     remoteInfo?.dbCompatVersion,
   );
   const remoteIsLegacy = remoteInfo?.layout === "legacy";
+  const remoteHasCodexSessions =
+    remoteInfo?.artifacts?.includes("codex-sessions.zip") ?? false;
 
   // ─── Render ─────────────────────────────────────────────
 
@@ -682,6 +697,32 @@ export function WebdavSyncSection({
               />
             </div>
           </div>
+
+          <div className="flex items-start gap-4">
+            <label className="w-40 text-xs font-medium text-foreground shrink-0">
+              {t("settings.webdavSync.syncCodexSessions")}
+              <span className="block text-[10px] font-normal text-muted-foreground">
+                {t("settings.webdavSync.syncCodexSessionsHint")}
+              </span>
+            </label>
+            <div className="pt-1">
+              <Switch
+                checked={form.syncCodexSessions}
+                onCheckedChange={handleSyncCodexSessionsChange}
+                aria-label={t("settings.webdavSync.syncCodexSessions")}
+                disabled={isLoading}
+              />
+            </div>
+          </div>
+
+          {form.syncCodexSessions && (
+            <div className="flex max-w-3xl items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/5 px-3 py-2 text-xs leading-relaxed text-amber-800 dark:text-amber-200">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+              <span>
+                {t("settings.webdavSync.codexSessionsPlaintextWarning")}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Last sync time */}
@@ -804,6 +845,11 @@ export function WebdavSyncSection({
                 <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
                   <li>{t("settings.webdavSync.confirmUpload.dbItem")}</li>
                   <li>{t("settings.webdavSync.confirmUpload.skillsItem")}</li>
+                  {form.syncCodexSessions && (
+                    <li>
+                      {t("settings.webdavSync.confirmUpload.codexSessionsItem")}
+                    </li>
+                  )}
                 </ul>
                 <p className="text-muted-foreground">
                   {t("settings.webdavSync.confirmUpload.targetPath")}
@@ -932,6 +978,13 @@ export function WebdavSyncSection({
                 <p className="text-destructive font-medium">
                   {t("settings.webdavSync.confirmDownload.warning")}
                 </p>
+                {form.syncCodexSessions && remoteHasCodexSessions && (
+                  <p className="font-medium text-amber-600 dark:text-amber-400">
+                    {t(
+                      "settings.webdavSync.confirmDownload.codexSessionsConflict",
+                    )}
+                  </p>
+                )}
               </div>
             </DialogDescription>
           </DialogHeader>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -472,6 +472,9 @@
       "profile": "Sync Profile Name",
       "autoSync": "Auto Sync",
       "autoSyncHint": "When enabled, each database change triggers an automatic WebDAV upload.",
+      "syncCodexSessions": "Sync Codex sessions",
+      "syncCodexSessionsHint": "Include Codex CLI conversation JSONL files in WebDAV sync.",
+      "codexSessionsPlaintextWarning": "Codex sessions may contain prompts, code, command output, paths, and secrets. They will be uploaded to WebDAV as plaintext.",
       "test": "Test Connection",
       "testing": "Testing...",
       "testSuccess": "Connection successful",
@@ -523,6 +526,7 @@
         "artifacts": "Contents",
         "legacyNotice": "A legacy remote path was detected. After restoring, the next upload will write to the new v2/db-v6 path.",
         "warning": "This will overwrite all local data and skill configurations",
+        "codexSessionsConflict": "Codex sessions will be merged by session ID. When both sides changed, the newer session wins and the replaced local file is backed up first.",
         "confirm": "Confirm Restore"
       },
       "confirmUpload": {
@@ -530,6 +534,7 @@
         "content": "The following will be synced to the WebDAV server:",
         "dbItem": "Database (all provider configs and data)",
         "skillsItem": "Skills (all custom skills)",
+        "codexSessionsItem": "Codex sessions (plaintext conversation history)",
         "targetPath": "Target path",
         "existingData": "Existing cloud data",
         "deviceName": "Uploaded by",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -472,6 +472,9 @@
       "profile": "同期プロファイル名",
       "autoSync": "自動同期",
       "autoSyncHint": "有効にすると、データベース変更のたびに WebDAV へ自動アップロードします。",
+      "syncCodexSessions": "Codex セッションを同期",
+      "syncCodexSessionsHint": "Codex CLI の会話 JSONL ファイルを WebDAV 同期に含めます。",
+      "codexSessionsPlaintextWarning": "Codex セッションにはプロンプト、コード、コマンド出力、パス、シークレットが含まれる場合があります。有効にすると WebDAV へ平文でアップロードされます。",
       "test": "接続テスト",
       "testing": "テスト中...",
       "testSuccess": "接続成功",
@@ -523,6 +526,7 @@
         "artifacts": "内容",
         "legacyNotice": "旧レイアウトのリモートパスを検出しました。復元後、次回のアップロードは新しい v2/db-v6 パスに書き込まれます。",
         "warning": "ローカルのすべてのデータとスキル設定が上書きされます",
+        "codexSessionsConflict": "Codex セッションは Session ID ごとにマージされます。両方で変更がある場合は新しいセッションを優先し、置き換えるローカルファイルを先にバックアップします。",
         "confirm": "復元を実行"
       },
       "confirmUpload": {
@@ -530,6 +534,7 @@
         "content": "以下の内容を WebDAV サーバーに同期します：",
         "dbItem": "データベース（すべてのプロバイダー設定とデータ）",
         "skillsItem": "スキル（すべてのカスタムスキル）",
+        "codexSessionsItem": "Codex セッション（平文の会話履歴）",
         "targetPath": "保存先パス",
         "existingData": "クラウドの既存データ",
         "deviceName": "アップロード元",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -472,6 +472,9 @@
       "profile": "同步設定名稱",
       "autoSync": "自動同步",
       "autoSyncHint": "開啟後每次資料庫變更都會自動上傳至 WebDAV。",
+      "syncCodexSessions": "同步 Codex 會話",
+      "syncCodexSessionsHint": "將 Codex CLI 的會話 JSONL 檔案納入 WebDAV 同步。",
+      "codexSessionsPlaintextWarning": "Codex 會話可能包含提示詞、程式碼、命令輸出、路徑和金鑰；開啟後會以明文上傳到 WebDAV。",
       "test": "測試連線",
       "testing": "測試中...",
       "testSuccess": "連線成功",
@@ -523,6 +526,7 @@
         "artifacts": "包含內容",
         "legacyNotice": "檢測到舊版雲端路徑。還原完成後，下次上傳將寫入新路徑 v2/db-v6。",
         "warning": "還原將覆寫本地所有資料和技能設定",
+        "codexSessionsConflict": "Codex 會話會按 Session ID 合併；兩端都有變更時保留較新的會話，並先備份被替換的本地檔案。",
         "confirm": "確認還原"
       },
       "confirmUpload": {
@@ -530,6 +534,7 @@
         "content": "將同步以下內容至 WebDAV 伺服器：",
         "dbItem": "資料庫（所有 Provider 設定和資料）",
         "skillsItem": "技能包（所有自訂技能）",
+        "codexSessionsItem": "Codex 會話（明文對話歷史）",
         "targetPath": "目標路徑",
         "existingData": "雲端已有資料",
         "deviceName": "上傳裝置",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -472,6 +472,9 @@
       "profile": "同步配置名",
       "autoSync": "自动同步",
       "autoSyncHint": "开启后每次数据库变更都会自动上传到 WebDAV。",
+      "syncCodexSessions": "同步 Codex 会话",
+      "syncCodexSessionsHint": "将 Codex CLI 的会话 JSONL 文件纳入 WebDAV 同步。",
+      "codexSessionsPlaintextWarning": "Codex 会话可能包含提示词、代码、命令输出、路径和密钥；开启后会以明文上传到 WebDAV。",
       "test": "测试连接",
       "testing": "测试中...",
       "testSuccess": "连接成功",
@@ -523,6 +526,7 @@
         "artifacts": "包含内容",
         "legacyNotice": "检测到旧版云端路径。恢复完成后，下次上传将写入新路径 v2/db-v6。",
         "warning": "恢复将覆盖本地所有数据和技能配置",
+        "codexSessionsConflict": "Codex 会话会按 Session ID 合并；两端都有变更时保留较新的会话，并先备份被替换的本地文件。",
         "confirm": "确认恢复"
       },
       "confirmUpload": {
@@ -530,6 +534,7 @@
         "content": "将同步以下内容到 WebDAV 服务器：",
         "dbItem": "数据库（所有 Provider 配置和数据）",
         "skillsItem": "技能包（所有自定义技能）",
+        "codexSessionsItem": "Codex 会话（明文对话历史）",
         "targetPath": "目标路径",
         "existingData": "云端已有数据",
         "deviceName": "上传设备",

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -39,6 +39,7 @@ export const settingsSchema = z.object({
     .object({
       enabled: z.boolean().optional(),
       autoSync: z.boolean().optional(),
+      syncCodexSessions: z.boolean().optional(),
       baseUrl: z.string().trim().optional().or(z.literal("")),
       username: z.string().trim().optional().or(z.literal("")),
       password: z.string().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,6 +281,7 @@ export interface WebDavSyncStatus {
 export interface WebDavSyncSettings {
   enabled?: boolean;
   autoSync?: boolean;
+  syncCodexSessions?: boolean;
   baseUrl?: string;
   username?: string;
   password?: string;

--- a/tests/components/WebdavSyncSection.test.tsx
+++ b/tests/components/WebdavSyncSection.test.tsx
@@ -27,7 +27,9 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Button: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 vi.mock("@/components/ui/input", () => ({
@@ -94,6 +96,7 @@ const baseConfig: WebDavSyncSettings = {
   remoteRoot: "cc-switch-sync",
   profile: "default",
   autoSync: false,
+  syncCodexSessions: false,
   status: {},
 };
 
@@ -138,7 +141,9 @@ describe("WebdavSyncSection", () => {
       artifacts: ["db.sql", "skills.zip"],
     });
     settingsApiMock.webdavSyncUpload.mockResolvedValue({ status: "uploaded" });
-    settingsApiMock.webdavSyncDownload.mockResolvedValue({ status: "downloaded" });
+    settingsApiMock.webdavSyncDownload.mockResolvedValue({
+      status: "downloaded",
+    });
   });
 
   it("shows auto sync error callout when last auto sync failed", () => {
@@ -187,16 +192,22 @@ describe("WebdavSyncSection", () => {
   it("shows validation error when saving without base url", async () => {
     renderSection({ ...baseConfig, baseUrl: "" });
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
-    expect(toastErrorMock).toHaveBeenCalledWith("settings.webdavSync.missingUrl");
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "settings.webdavSync.missingUrl",
+    );
     expect(settingsApiMock.webdavSyncSaveSettings).not.toHaveBeenCalled();
   });
 
   it("saves settings and auto tests connection", async () => {
     renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -226,7 +237,9 @@ describe("WebdavSyncSection", () => {
   it("preserves password only for the single post-save refresh", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -264,7 +277,9 @@ describe("WebdavSyncSection", () => {
   it("does not preserve password after a later external config refresh", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -304,7 +319,9 @@ describe("WebdavSyncSection", () => {
   it("does not submit a preserved password again when testing without touching it", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -316,7 +333,9 @@ describe("WebdavSyncSection", () => {
       </QueryClientProvider>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.test" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.test" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavTestConnection).toHaveBeenLastCalledWith(
@@ -342,12 +361,41 @@ describe("WebdavSyncSection", () => {
         screen.getByRole("switch", { name: "settings.webdavSync.autoSync" }),
       ).toHaveAttribute("aria-checked", "true");
     });
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledWith(
         expect.objectContaining({
           autoSync: true,
+        }),
+        false,
+      );
+    });
+  });
+
+  it("warns and saves when Codex session sync is enabled", async () => {
+    renderSection(baseConfig);
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "settings.webdavSync.syncCodexSessions",
+      }),
+    );
+
+    expect(
+      screen.getByText("settings.webdavSync.codexSessionsPlaintextWarning"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
+
+    await waitFor(() => {
+      expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          syncCodexSessions: true,
         }),
         false,
       );
@@ -394,7 +442,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(
@@ -418,7 +468,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.upload" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("cc-switch-sync"), {
@@ -446,7 +498,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(
@@ -470,7 +524,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.download" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("default"), {
@@ -491,7 +547,9 @@ describe("WebdavSyncSection", () => {
   });
 
   it("shows info when no remote snapshot is found for download", async () => {
-    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({ empty: true });
+    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({
+      empty: true,
+    });
     renderSection(baseConfig);
 
     fireEvent.click(
@@ -499,7 +557,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(toastInfoMock).toHaveBeenCalledWith("settings.webdavSync.noRemoteData");
+      expect(toastInfoMock).toHaveBeenCalledWith(
+        "settings.webdavSync.noRemoteData",
+      );
     });
     expect(settingsApiMock.webdavSyncDownload).not.toHaveBeenCalled();
   });
@@ -540,7 +600,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.download" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(


### PR DESCRIPTION
Closes #3264

## Summary
- Add opt-in WebDAV sync for Codex session JSONL files
- Restore Codex sessions with newer-wins conflict handling and local backups
- Add settings UI copy that clearly warns about plaintext WebDAV storage

## Validation
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml webdav
- node_modules/.bin/tsc.cmd --noEmit
- node_modules/.bin/vitest.cmd run tests/components/WebdavSyncSection.test.tsx
- pnpm tauri build --config '{bundle:{createUpdaterArtifacts:false}}'