### PR TITLE
fix(proxy): normalize system messages for Claude Code >= 2.1.154 compatibility

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages: []
 
+allowBuilds:
+  esbuild: true
+  msw: true
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1147,6 +1147,52 @@ impl RequestForwarder {
             adapter.build_url(&base_url, &effective_endpoint)
         };
 
+        // Claude Code >= 2.1.154 ("Lean system prompt") may send the system prompt
+        // as `role: "system"` messages inside `messages` instead of the top-level
+        // `system` field. Normalize to the top-level field so all transform paths
+        // and passthrough upstream providers handle it correctly.
+        let mapped_body = if self.rectifier_config.enabled && self.rectifier_config.normalize_system_messages {
+            let before = mapped_body.clone();
+            let normalized = super::providers::transform::normalize_system_messages(mapped_body);
+
+            // Log if normalization actually happened
+            if before != normalized {
+                let system_count = before
+                    .get("messages")
+                    .and_then(|m| m.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("system"))
+                            .count()
+                    })
+                    .unwrap_or(0);
+
+                let system_type = match normalized.get("system") {
+                    Some(serde_json::Value::String(_)) => "string",
+                    Some(serde_json::Value::Array(_)) => "array",
+                    _ => "none",
+                };
+
+                log::info!(
+                    "[Rectifier] System messages normalized: moved {} system message(s) from messages array to top-level system field (system type: {})",
+                    system_count,
+                    system_type
+                );
+
+                // DEBUG: Log the actual system field structure
+                if let Some(system) = normalized.get("system") {
+                    log::debug!(
+                        "[Rectifier] Normalized system field: {}",
+                        serde_json::to_string_pretty(system).unwrap_or_else(|_| format!("{:?}", system))
+                    );
+                }
+            }
+
+            normalized
+        } else {
+            mapped_body
+        };
+
         // 转换请求体（如果需要）
         let request_body = if codex_responses_to_chat {
             let mut mapped_body = mapped_body;

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -498,6 +498,118 @@ fn convert_message_to_openai(
     Ok(result)
 }
 
+/// Extract `role: "system"` messages from the `messages` array and promote them
+/// to the top-level `system` field.
+///
+/// Claude Code >= 2.1.154 ("Lean system prompt becomes default") may send the
+/// system prompt as `role: "system"` messages inside `messages` instead of the
+/// top-level `system` field. Most third-party providers — and the Anthropic API
+/// spec itself — do not support `role: "system"` in the messages array. This
+/// function extracts such messages and merges them into the standard top-level
+/// `system` field so that all downstream transform paths (anthropic passthrough,
+/// openai_chat, openai_responses, gemini_native) handle them correctly.
+///
+/// The function is a no-op when no `role: "system"` messages are present.
+pub fn normalize_system_messages(mut body: Value) -> Value {
+    // Quick check: are there any system messages in the array?
+    let has_system_in_messages = body
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .is_some_and(|msgs| {
+            msgs.iter()
+                .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("system"))
+        });
+
+    if !has_system_in_messages {
+        return body;
+    }
+
+    // Extract system message contents from the messages array
+    let mut extracted_parts: Vec<Value> = Vec::new();
+    if let Some(messages) = body.get_mut("messages").and_then(|m| m.as_array_mut()) {
+        messages.retain(|msg| {
+            if msg.get("role").and_then(|r| r.as_str()) != Some("system") {
+                return true;
+            }
+
+            // Extract content from this system message
+            if let Some(content) = msg.get("content") {
+                match content {
+                    Value::String(text) => {
+                        let text = strip_leading_anthropic_billing_header(text);
+                        if !text.is_empty() {
+                            extracted_parts.push(json!({"text": text}));
+                        }
+                    }
+                    Value::Array(blocks) => {
+                        for block in blocks {
+                            if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                                let text = strip_leading_anthropic_billing_header(text);
+                                if !text.is_empty() {
+                                    let mut part = json!({"text": text});
+                                    // Preserve cache_control for proxy cache compatibility
+                                    if let Some(cc) = block.get("cache_control") {
+                                        part["cache_control"] = cc.clone();
+                                    }
+                                    extracted_parts.push(part);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            false // remove from messages array
+        });
+    }
+
+    if extracted_parts.is_empty() {
+        return body;
+    }
+
+    // Merge extracted parts with existing top-level system
+    // Always produce a string format for maximum provider compatibility
+    let existing_system = body.get("system").cloned();
+
+    // Collect all text parts (existing + extracted)
+    let mut all_texts: Vec<String> = Vec::new();
+
+    // Add existing system text
+    match existing_system {
+        Some(Value::String(text)) => {
+            if !text.is_empty() {
+                all_texts.push(text);
+            }
+        }
+        Some(Value::Array(arr)) => {
+            for part in arr {
+                if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                    if !text.is_empty() {
+                        all_texts.push(text.to_string());
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // Add extracted text parts
+    for part in &extracted_parts {
+        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+            if !text.is_empty() {
+                all_texts.push(text.to_string());
+            }
+        }
+    }
+
+    // Always use string format for maximum compatibility
+    if !all_texts.is_empty() {
+        body["system"] = json!(all_texts.join("\n\n"));
+    }
+
+    body
+}
+
 /// 清理 JSON schema（移除不支持的 format）
 pub fn clean_schema(mut schema: Value) -> Value {
     if let Some(obj) = schema.as_object_mut() {
@@ -1621,5 +1733,122 @@ mod tests {
             run_tool_choice(json!({"type": "tool", "name": "search"})),
             json!({"type": "function", "function": {"name": "search"}}),
         );
+    }
+
+    // --- normalize_system_messages tests ---
+
+    #[test]
+    fn normalize_system_messages_noop_when_no_system_in_messages() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "system": "You are helpful.",
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body.clone());
+        assert_eq!(result, body);
+    }
+
+    #[test]
+    fn normalize_system_messages_extracts_string_system_to_top_level() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        assert_eq!(result["system"], "You are a helpful assistant.");
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(result["messages"][0]["role"], "user");
+    }
+
+    #[test]
+    fn normalize_system_messages_extracts_array_system_to_top_level() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": [
+                    {"type": "text", "text": "You are a helpful assistant."}
+                ]},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        // Single part without cache_control → promoted to string
+        assert_eq!(result["system"], "You are a helpful assistant.");
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn normalize_system_messages_merges_with_existing_string_system() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "system": "Existing system prompt.",
+            "messages": [
+                {"role": "system", "content": "Additional system prompt."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        // Both should be joined as a string
+        assert_eq!(
+            result["system"],
+            "Existing system prompt.\n\nAdditional system prompt."
+        );
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn normalize_system_messages_extracts_cache_control_as_string() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": [
+                    {"type": "text", "text": "Cached system prompt.", "cache_control": {"type": "ephemeral"}}
+                ]},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        // cache_control is dropped for maximum compatibility
+        assert_eq!(result["system"], "Cached system prompt.");
+    }
+
+    #[test]
+    fn normalize_system_messages_strips_billing_header() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": "x-anthropic-billing-header: cc_version=2.1.154; cch=abc;\n\nYou are helpful."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        assert_eq!(result["system"], "You are helpful.");
+    }
+
+    #[test]
+    fn normalize_system_messages_multiple_system_messages_merged() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": "Part 1."},
+                {"role": "system", "content": "Part 2."},
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+                {"role": "system", "content": "Part 3."}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        // All parts joined as a string
+        assert_eq!(result["system"], "Part 1.\n\nPart 2.\n\nPart 3.");
+        // Only user and assistant messages remain
+        let messages = result["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[1]["role"], "assistant");
     }
 }

--- a/src-tauri/src/proxy/thinking_budget_rectifier.rs
+++ b/src-tauri/src/proxy/thinking_budget_rectifier.rs
@@ -148,6 +148,7 @@ mod tests {
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
         }
     }
 
@@ -156,6 +157,7 @@ mod tests {
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: false,
+            normalize_system_messages: true,
         }
     }
 
@@ -164,6 +166,7 @@ mod tests {
             enabled: false,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
         }
     }
 

--- a/src-tauri/src/proxy/thinking_rectifier.rs
+++ b/src-tauri/src/proxy/thinking_rectifier.rs
@@ -251,6 +251,7 @@ mod tests {
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
         }
     }
 
@@ -259,6 +260,7 @@ mod tests {
             enabled: true,
             request_thinking_signature: false,
             request_thinking_budget: false,
+            normalize_system_messages: true,
         }
     }
 
@@ -267,6 +269,7 @@ mod tests {
             enabled: false,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
         }
     }
 

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -213,6 +213,13 @@ pub struct RectifierConfig {
     /// 处理错误：budget_tokens + thinking 相关约束
     #[serde(default = "default_true")]
     pub request_thinking_budget: bool,
+    /// 请求整流：启用 system 消息归一化（默认开启）
+    ///
+    /// Claude Code >= 2.1.154 ("Lean system prompt") 将 system prompt 作为
+    /// `role: "system"` 消息放在 messages 数组中。许多第三方 provider 不支持
+    /// 此格式，需要将其提升到 Anthropic API 标准的顶层 `system` 字段。
+    #[serde(default = "default_true")]
+    pub normalize_system_messages: bool,
 }
 
 fn default_true() -> bool {
@@ -229,6 +236,7 @@ impl Default for RectifierConfig {
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
         }
     }
 }

--- a/src/components/settings/RectifierConfigPanel.tsx
+++ b/src/components/settings/RectifierConfigPanel.tsx
@@ -15,6 +15,7 @@ export function RectifierConfigPanel() {
     enabled: true,
     requestThinkingSignature: true,
     requestThinkingBudget: true,
+    normalizeSystemMessages: true,
   });
   const [optimizerConfig, setOptimizerConfig] = useState<OptimizerConfig>({
     enabled: false,
@@ -108,6 +109,25 @@ export function RectifierConfigPanel() {
             disabled={!config.enabled}
             onCheckedChange={(checked) =>
               handleChange({ requestThinkingBudget: checked })
+            }
+          />
+        </div>
+        <div className="flex items-center justify-between pl-4">
+          <div className="space-y-0.5">
+            <Label>
+              {t("settings.advanced.rectifier.normalizeSystemMessages")}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                "settings.advanced.rectifier.normalizeSystemMessagesDescription",
+              )}
+            </p>
+          </div>
+          <Switch
+            checked={config.normalizeSystemMessages}
+            disabled={!config.enabled}
+            onCheckedChange={(checked) =>
+              handleChange({ normalizeSystemMessages: checked })
             }
           />
         </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -366,7 +366,9 @@
         "thinkingSignature": "Thinking Signature Rectification",
         "thinkingSignatureDescription": "When an Anthropic-type provider returns thinking signature incompatibility or illegal request errors, automatically removes incompatible thinking-related blocks and retries once with the same provider",
         "thinkingBudget": "Thinking Budget Rectification",
-        "thinkingBudgetDescription": "When an Anthropic-type provider returns budget_tokens constraint errors (such as at least 1024), automatically normalizes thinking to enabled, sets thinking budget to 32000, and raises max_tokens to 64000 if needed, then retries once"
+        "thinkingBudgetDescription": "When an Anthropic-type provider returns budget_tokens constraint errors (such as at least 1024), automatically normalizes thinking to enabled, sets thinking budget to 32000, and raises max_tokens to 64000 if needed, then retries once",
+        "normalizeSystemMessages": "Normalize System Messages",
+        "normalizeSystemMessagesDescription": "Promote role:system messages from Claude Code ≥ 2.1.154 to the top-level system field for third-party provider compatibility"
       },
       "optimizer": {
         "title": "Bedrock Request Optimizer",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -366,7 +366,9 @@
         "thinkingSignature": "Thinking 署名整流",
         "thinkingSignatureDescription": "Anthropic タイプのプロバイダーが thinking 署名の非互換性や不正なリクエストエラーを返した場合、互換性のない thinking 関連ブロックを自動削除し、同じプロバイダーで 1 回リトライします",
         "thinkingBudget": "Thinking Budget 整流",
-        "thinkingBudgetDescription": "Anthropic タイプのプロバイダーが budget_tokens 制約エラー（例: 1024 以上）を返した場合、thinking を enabled に正規化し、thinking 予算を 32000 に設定し、必要に応じて max_tokens を 64000 に引き上げて 1 回リトライします"
+        "thinkingBudgetDescription": "Anthropic タイプのプロバイダーが budget_tokens 制約エラー（例: 1024 以上）を返した場合、thinking を enabled に正規化し、thinking 予算を 32000 に設定し、必要に応じて max_tokens を 64000 に引き上げて 1 回リトライします",
+        "normalizeSystemMessages": "System メッセージ正規化",
+        "normalizeSystemMessagesDescription": "Claude Code ≥ 2.1.154 の role:system メッセージをトップレベルの system フィールドに昇格させ、この形式をサポートしないサードパーティ Provider との互換性を確保"
       },
       "optimizer": {
         "title": "Bedrock リクエストオプティマイザー",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -366,7 +366,9 @@
         "thinkingSignature": "Thinking 簽章整流",
         "thinkingSignatureDescription": "當 Anthropic 類型供應商回傳 thinking 簽章不相容或非法請求等錯誤時，自動移除不相容的 thinking 相關區塊，並對同一供應商重試一次",
         "thinkingBudget": "Thinking Budget 整流",
-        "thinkingBudgetDescription": "當 Anthropic 類型供應商回傳 budget_tokens 限制錯誤（如至少 1024）時，自動將 thinking 規範為 enabled，並將 budget 設為 32000，同時在需要時將 max_tokens 設為 64000，然後重試一次"
+        "thinkingBudgetDescription": "當 Anthropic 類型供應商回傳 budget_tokens 限制錯誤（如至少 1024）時，自動將 thinking 規範為 enabled，並將 budget 設為 32000，同時在需要時將 max_tokens 設為 64000，然後重試一次",
+        "normalizeSystemMessages": "System 訊息正規化",
+        "normalizeSystemMessagesDescription": "將 Claude Code ≥ 2.1.154 的 role:system 訊息提升到頂層 system 欄位，相容不支援此格式的第三方 Provider"
       },
       "optimizer": {
         "title": "Bedrock 請求最佳化工具",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -366,7 +366,9 @@
         "thinkingSignature": "Thinking 签名整流",
         "thinkingSignatureDescription": "当 Anthropic 类型供应商返回 thinking 签名不兼容或非法请求等错误时，自动移除不兼容的 thinking 相关块并对同一供应商重试一次",
         "thinkingBudget": "Thinking Budget 整流",
-        "thinkingBudgetDescription": "当 Anthropic 类型供应商返回 budget_tokens 约束错误（如至少 1024）时，自动将 thinking 规范为 enabled 并将 budget 设为 32000，同时在需要时将 max_tokens 设为 64000，然后重试一次"
+        "thinkingBudgetDescription": "当 Anthropic 类型供应商返回 budget_tokens 约束错误（如至少 1024）时，自动将 thinking 规范为 enabled 并将 budget 设为 32000，同时在需要时将 max_tokens 设为 64000，然后重试一次",
+        "normalizeSystemMessages": "System 消息归一化",
+        "normalizeSystemMessagesDescription": "将 Claude Code ≥ 2.1.154 的 role:system 消息提升到顶层 system 字段，兼容不支持此格式的第三方 Provider"
       },
       "optimizer": {
         "title": "Bedrock 请求优化器",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -265,6 +265,7 @@ export interface RectifierConfig {
   enabled: boolean;
   requestThinkingSignature: boolean;
   requestThinkingBudget: boolean;
+  normalizeSystemMessages: boolean;
 }
 
 export interface OptimizerConfig {


### PR DESCRIPTION
## Summary

Claude Code >= 2.1.154 ("Lean system prompt") sends system prompts as `role:system` messages in the messages array instead of the top-level `system` field. Many third-party providers (DashScope, etc.) only accept `system` as a string field, causing 400 errors.

This PR adds a Rectifier toggle that extracts `role:system` messages from the messages array and merges them into the top-level `system` field as a single string (joined with `\n\n`) for maximum provider compatibility.

## Changes

- Added `normalize_system_messages` field to `RectifierConfig` (default: true)
- Implemented normalization logic in `proxy/providers/transform.rs`
- Integrated into forwarder pipeline with rectifier config check
- Added UI toggle in `RectifierConfigPanel` with i18n (en/zh/zh-TW/ja)
- Added comprehensive unit tests
- Debug logging for troubleshooting

## Testing

- All 7 unit tests pass
- Tested with DashScope provider (previously failing with 400 error, now working)
- Tested with various system message formats (string, array, multiple messages)

## Impact

- Fixes compatibility with DashScope and other providers that reject non-standard system message formats
- Toggle is enabled by default but can be disabled if needed
- No breaking changes to existing functionality

## Important

Remember to turn on Routing. 
<img width="1391" height="473" alt="image" src="https://github.com/user-attachments/assets/cf4fbf9e-bd17-4d83-af8e-a476a67a6090" />

<img width="1398" height="403" alt="image" src="https://github.com/user-attachments/assets/4ec05fd5-4b97-43ad-b4a4-1b4297828bd3" />


## Related issues
#3294 
#3277 
#3281 