### PR TITLE
Feature/tray double click open window

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -830,7 +830,6 @@ pub fn run() {
                         let app = tray.app_handle();
                         if crate::lightweight::is_lightweight_mode() {
                             // 轻量模式：双击不执行任何操作
-                            return;
                         } else if let Some(window) = app.get_webview_window("main") {
                             if window.is_visible().unwrap_or(false) {
                                 // 窗口可见：隐藏窗口

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -824,22 +824,27 @@ pub fn run() {
                             crate::tray::refresh_all_usage_in_tray(&app).await;
                         });
                     }
-                    // Windows: 双击托盘图标
+                    // Windows: 双击托盘图标 → 切换窗口显示/隐藏
                     #[cfg(target_os = "windows")]
                     TrayIconEvent::DoubleClick { .. } => {
                         let app = tray.app_handle();
                         if crate::lightweight::is_lightweight_mode() {
-                            // 轻量模式：双击退出轻量模式，打开窗口
-                            if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
-                                log::error!("退出轻量模式重建窗口失败: {e}");
-                            }
-                        } else if app.get_webview_window("main").is_some() {
-                            // 窗口已打开：双击进入轻量模式（关闭窗口）
-                            if let Err(e) = crate::lightweight::enter_lightweight_mode(app) {
-                                log::error!("进入轻量模式失败: {e}");
+                            // 轻量模式：双击不执行任何操作
+                            return;
+                        } else if let Some(window) = app.get_webview_window("main") {
+                            if window.is_visible().unwrap_or(false) {
+                                // 窗口可见：隐藏窗口
+                                let _ = window.hide();
+                                let _ = window.set_skip_taskbar(true);
+                            } else {
+                                // 窗口存在但隐藏：显示窗口
+                                let _ = window.set_skip_taskbar(false);
+                                let _ = window.unminimize();
+                                let _ = window.show();
+                                let _ = window.set_focus();
                             }
                         } else {
-                            // 无窗口：双击打开主窗口
+                            // 无窗口：打开主窗口
                             tray::handle_tray_menu_event(app, "show_main");
                         }
                     }
@@ -1854,6 +1859,12 @@ fn window_state_flags() -> StateFlags {
 /// 当前应用的退出路径会拦截 `ExitRequested` 并最终直接 `std::process::exit(0)`，
 /// 这里需要在真正结束进程前手动落盘，避免 window-state 插件的默认退出钩子被绕过。
 pub fn save_window_state_before_exit(app_handle: &tauri::AppHandle) {
+    // 检查主窗口是否仍然有效，避免在窗口已销毁时调用 save_window_state
+    // 触发 PostMessage 失败错误 (ERROR_INVALID_WINDOW_HANDLE / 0x80070578)
+    if app_handle.get_webview_window("main").is_none() {
+        log::debug!("主窗口已不存在，跳过保存窗口状态");
+        return;
+    }
     if let Err(err) = app_handle.save_window_state(window_state_flags()) {
         log::error!("退出前保存窗口状态失败: {err}");
     } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -830,6 +830,7 @@ pub fn run() {
                         let app = tray.app_handle();
                         if crate::lightweight::is_lightweight_mode() {
                             // 轻量模式：双击不执行任何操作
+                            log::debug!("轻量模式下双击托盘，不执行操作");
                         } else if let Some(window) = app.get_webview_window("main") {
                             if window.is_visible().unwrap_or(false) {
                                 // 窗口可见：隐藏窗口

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -824,6 +824,25 @@ pub fn run() {
                             crate::tray::refresh_all_usage_in_tray(&app).await;
                         });
                     }
+                    // Windows: 双击托盘图标
+                    #[cfg(target_os = "windows")]
+                    TrayIconEvent::DoubleClick { .. } => {
+                        let app = tray.app_handle();
+                        if crate::lightweight::is_lightweight_mode() {
+                            // 轻量模式：双击退出轻量模式，打开窗口
+                            if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
+                                log::error!("退出轻量模式重建窗口失败: {e}");
+                            }
+                        } else if app.get_webview_window("main").is_some() {
+                            // 窗口已打开：双击进入轻量模式（关闭窗口）
+                            if let Err(e) = crate::lightweight::enter_lightweight_mode(app) {
+                                log::error!("进入轻量模式失败: {e}");
+                            }
+                        } else {
+                            // 无窗口：双击打开主窗口
+                            tray::handle_tray_menu_event(app, "show_main");
+                        }
+                    }
                     _ => log::debug!("unhandled event {event:?}"),
                 })
                 .menu(&menu)


### PR DESCRIPTION
## Summary / 概述

新增 Windows 平台托盘图标双击打开主界面的功能。

本次修改包括：

- 支持双击托盘图标直接打开主界面
- 当主窗口已存在时，仅聚焦窗口而不重复创建
- 兼容“轻量模式”场景（轻量模式会关闭当前窗口，仅保留托盘运行），用户可通过双击托盘图标重新打开主界面

## Related Issue / 关联 Issue
Fixes #3000
Fixes #3167
<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->
## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
<img width="400" height="265" alt="修改前" src="https://github.com/user-attachments/assets/4299320e-f349-4e0f-a5da-d4af1ff22a51" />
<img width="400" height="265" alt="修改后" src="https://github.com/user-attachments/assets/e648107e-aa20-42c8-a3f4-0b79127c20db" />
| 最小化到托盘后，需要右键托盘图标并点击“打开主界面” | 双击托盘图标即可直接打开主界面 |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件