### PR TITLE
feat(hermes): add discover_models toggle to provider form

### DIFF
--- a/src/components/providers/forms/HermesFormFields.tsx
+++ b/src/components/providers/forms/HermesFormFields.tsx
@@ -30,6 +30,7 @@ import {
   ChevronDown,
   ChevronRight,
   Loader2,
+  Search,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -39,6 +40,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ToggleRow } from "@/components/ui/toggle-row";
 import { ApiKeySection } from "./shared";
 import {
   fetchModelsForConfig,
@@ -68,6 +70,8 @@ interface HermesFormFieldsProps {
   onModelsChange: (models: HermesModel[]) => void;
   rateLimitDelay: number | undefined;
   onRateLimitDelayChange: (delay: number | undefined) => void;
+  discoverModels: boolean;
+  onDiscoverModelsChange: (enabled: boolean) => void;
 }
 
 type BaseUrlErrorCode = "empty" | "invalid" | "scheme";
@@ -155,6 +159,8 @@ export function HermesFormFields({
   onModelsChange,
   rateLimitDelay,
   onRateLimitDelayChange,
+  discoverModels,
+  onDiscoverModelsChange,
 }: HermesFormFieldsProps) {
   const { t } = useTranslation();
   const [expandedModels, setExpandedModels] = useState<Record<number, boolean>>(
@@ -335,6 +341,19 @@ export function HermesFormFields({
         websiteUrl={websiteUrl}
         isPartner={isPartner}
         partnerPromotionKey={partnerPromotionKey}
+      />
+
+      <ToggleRow
+        icon={<Search className="h-4 w-4" />}
+        title={t("hermes.form.discoverModelsLabel", {
+          defaultValue: "从 API 发现模型",
+        })}
+        description={t("hermes.form.discoverModelsDescription", {
+          defaultValue:
+            "关闭后仅使用下方手动配置的模型列表，不再从 /models 端点拉取",
+        })}
+        checked={discoverModels}
+        onCheckedChange={onDiscoverModelsChange}
       />
 
       <div className="space-y-3">

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -2154,6 +2154,10 @@ function ProviderFormFull({
               onRateLimitDelayChange={
                 hermesForm.handleHermesRateLimitDelayChange
               }
+              discoverModels={hermesForm.hermesDiscoverModels}
+              onDiscoverModelsChange={
+                hermesForm.handleHermesDiscoverModelsChange
+              }
             />
           )}
 

--- a/src/components/providers/forms/hooks/useHermesFormState.ts
+++ b/src/components/providers/forms/hooks/useHermesFormState.ts
@@ -38,12 +38,14 @@ export interface HermesFormState {
   hermesApiMode: HermesApiMode;
   hermesModels: HermesModel[];
   hermesRateLimitDelay: number | undefined;
+  hermesDiscoverModels: boolean;
   existingHermesKeys: string[];
   handleHermesBaseUrlChange: (baseUrl: string) => void;
   handleHermesApiKeyChange: (apiKey: string) => void;
   handleHermesApiModeChange: (mode: HermesApiMode) => void;
   handleHermesModelsChange: (models: HermesModel[]) => void;
   handleHermesRateLimitDelayChange: (delay: number | undefined) => void;
+  handleHermesDiscoverModelsChange: (enabled: boolean) => void;
   resetHermesState: (config?: Partial<HermesProviderSettingsConfig>) => void;
 }
 
@@ -123,6 +125,16 @@ export function useHermesFormState({
     return parseRateLimitDelay(initialData?.settingsConfig?.rate_limit_delay);
   });
 
+  const [hermesDiscoverModels, setHermesDiscoverModels] = useState<boolean>(
+    () => {
+      if (appId !== "hermes") return true;
+      const raw = initialData?.settingsConfig?.discover_models;
+      // Explicit false → false; anything else → true (Hermes default).
+      if (raw === false || raw === "false") return false;
+      return true;
+    },
+  );
+
   const updateHermesConfig = useCallback(
     (updater: (config: Record<string, unknown>) => void) => {
       try {
@@ -194,6 +206,19 @@ export function useHermesFormState({
     [updateHermesConfig],
   );
 
+  const handleHermesDiscoverModelsChange = useCallback(
+    (enabled: boolean) => {
+      setHermesDiscoverModels(enabled);
+      updateHermesConfig((config) => {
+        // Explicitly write true / false so the Rust forward-compat
+        // merge doesn't resurrect a stale 'false' from the on-disk
+        // YAML when the user re-enables discovery.
+        config.discover_models = enabled;
+      });
+    },
+    [updateHermesConfig],
+  );
+
   const resetHermesState = useCallback(
     (config?: Partial<HermesProviderSettingsConfig>) => {
       setHermesProviderKey("");
@@ -202,6 +227,7 @@ export function useHermesFormState({
       setHermesApiMode(config?.api_mode ?? HERMES_DEFAULT_API_MODE);
       setHermesModels(config?.models ?? []);
       setHermesRateLimitDelay(parseRateLimitDelay(config?.rate_limit_delay));
+      setHermesDiscoverModels(config?.discover_models !== false);
     },
     [],
   );
@@ -214,12 +240,14 @@ export function useHermesFormState({
     hermesApiMode,
     hermesModels,
     hermesRateLimitDelay,
+    hermesDiscoverModels,
     existingHermesKeys,
     handleHermesBaseUrlChange,
     handleHermesApiKeyChange,
     handleHermesApiModeChange,
     handleHermesModelsChange,
     handleHermesRateLimitDelayChange,
+    handleHermesDiscoverModelsChange,
     resetHermesState,
   };
 }

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -124,6 +124,8 @@ export interface HermesProviderSettingsConfig {
   models?: HermesModel[];
   /** Delay in seconds between consecutive requests to this provider. */
   rate_limit_delay?: number;
+  /** Whether to probe the /models endpoint for live model discovery. */
+  discover_models?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1828,7 +1828,9 @@
       "fallbackModel": "Alternate",
       "providerAdvanced": "Provider advanced options",
       "rateLimitDelay": "Rate limit delay (seconds)",
-      "rateLimitDelayHint": "Minimum delay in seconds between consecutive requests (optional). Leave empty for no limit."
+      "rateLimitDelayHint": "Minimum delay in seconds between consecutive requests (optional). Leave empty for no limit.",
+      "discoverModelsLabel": "Discover models from API",
+      "discoverModelsDescription": "When disabled, only the manually configured models below are used and the /models endpoint is not probed. Corresponds to discover_models: false in Hermes config."
     },
     "webui": {
       "open": "Open Hermes Web UI",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1828,7 +1828,9 @@
       "fallbackModel": "予備",
       "providerAdvanced": "プロバイダー詳細オプション",
       "rateLimitDelay": "リクエスト間隔（秒）",
-      "rateLimitDelayHint": "連続したリクエスト間の最小待機秒数（任意）。空欄の場合は制限なし。"
+      "rateLimitDelayHint": "連続したリクエスト間の最小待機秒数（任意）。空欄の場合は制限なし。",
+      "discoverModelsLabel": "APIからモデルを検出",
+      "discoverModelsDescription": "無効にすると、下の手動設定モデルリストのみを使用し、/modelsエンドポイントへの問い合わせを行いません。Hermes設定のdiscover_models: falseに対応します。"
     },
     "webui": {
       "open": "Hermes Web UI を開く",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1774,7 +1774,9 @@
       "fallbackModel": "備用模型",
       "providerAdvanced": "供應商進階選項",
       "rateLimitDelay": "請求間隔（秒）",
-      "rateLimitDelayHint": "連續請求間的最小間隔秒數（選填）。留空表示無限制。"
+      "rateLimitDelayHint": "連續請求間的最小間隔秒數（選填）。留空表示無限制。",
+      "discoverModelsLabel": "從 API 發現模型",
+      "discoverModelsDescription": "關閉後僅使用下方手動設定的模型列表，不再從 /models 端點拉取。對應 Hermes 設定中的 discover_models: false。"
     },
     "webui": {
       "open": "開啟 Hermes Web UI",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1828,7 +1828,9 @@
       "fallbackModel": "备选模型",
       "providerAdvanced": "供应商高级选项",
       "rateLimitDelay": "请求间隔（秒）",
-      "rateLimitDelayHint": "连续请求间的最小间隔秒数（可选）。留空表示无限制。"
+      "rateLimitDelayHint": "连续请求间的最小间隔秒数（可选）。留空表示无限制。",
+      "discoverModelsLabel": "从 API 发现模型",
+      "discoverModelsDescription": "关闭后仅使用下方手动配置的模型列表，不再从 /models 端点拉取。对应 Hermes 配置中的 discover_models: false。"
     },
     "webui": {
       "open": "打开 Hermes Web UI",


### PR DESCRIPTION
## What does this PR do?

Adds a "Discover models from API" toggle switch to the Hermes provider configuration form. When disabled, the provider writes `discover_models: false` to Hermes's `config.yaml`, so Hermes only uses the manually configured model list and does not probe the `/models` endpoint.

## Why is this needed?

Hermes's live `/models` discovery currently replaces the user's entire configured model list (see NousResearch/hermes-agent#35145). While that bug is being fixed upstream, users also need a UI-level control to opt out of live discovery entirely for providers where they only want specific models.

CC Switch had no way to set `discover_models: false` — the only option was to manually edit `config.yaml`.

## Changes

| File | Change |
|------|--------|
| `useHermesFormState.ts` | Add `hermesDiscoverModels` state + `handleHermesDiscoverModelsChange` handler |
| `HermesFormFields.tsx` | Add `ToggleRow` switch UI (Search icon, between API key and model list) |
| `ProviderForm.tsx` | Pass `discoverModels` / `onDiscoverModelsChange` props to `HermesFormFields` |
| `hermesProviderPresets.ts` | Add `discover_models?: boolean` to `HermesProviderSettingsConfig` interface |
| `zh.json`, `en.json`, `ja.json`, `zh-TW.json` | Add i18n translations for the toggle label and description |


## Design decisions

- The toggle writes an explicit `true` / `false` value rather than deleting the key on re-enable. This prevents the Rust forward-compat merge from resurrecting a stale `false` from the on-disk YAML.
- The toggle defaults to `true` (Hermes default behavior). Only `discover_models: false` is explicitly written when the user opts out.
- The implementation follows the exact same pattern as `rate_limit_delay` (same hook structure, same props passing, same ToggleRow component).

## Screenshots

<img width="2000" height="1302" alt="image" src="https://github.com/user-attachments/assets/fb4c14cc-e25e-4c9b-8886-a3f2971f6161" />

## Checklist

- [x] I've tested my changes
- [x] I've added i18n translations for all
- [x] My changes follow the existing code patterns in this project
- [x] I've added type declarations for new fields
