### PR TITLE
feat(sync): add full Codex WebDAV sync

### DIFF
--- a/src-tauri/src/services/webdav_auto_sync.rs
+++ b/src-tauri/src/services/webdav_auto_sync.rs
@@ -13,6 +13,7 @@ use crate::services::webdav_sync as webdav_sync_service;
 use crate::settings::{self, WebDavSyncSettings};
 
 const AUTO_SYNC_DEBOUNCE_MS: u64 = 1000;
+const CODEX_AUTO_SYNC_POLL_MS: u64 = 60_000;
 pub(crate) const MAX_AUTO_SYNC_WAIT_MS: u64 = 10_000;
 
 static DB_CHANGE_TX: OnceLock<Sender<String>> = OnceLock::new();
@@ -77,6 +78,13 @@ fn should_run_auto_sync(settings: Option<&WebDavSyncSettings>) -> bool {
         return false;
     };
     sync.enabled && sync.auto_sync
+}
+
+fn should_poll_codex_data(settings: Option<&WebDavSyncSettings>) -> bool {
+    let Some(sync) = settings else {
+        return false;
+    };
+    should_run_auto_sync(Some(sync)) && sync.sync_codex_data
 }
 
 fn persist_auto_sync_error(settings: &mut WebDavSyncSettings, error: &AppError) {
@@ -159,8 +167,14 @@ pub fn start_worker(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
         return;
     }
 
+    let codex_db = db.clone();
+    let codex_app = app.clone();
+
     tauri::async_runtime::spawn(async move {
         run_worker_loop(db, rx, app).await;
+    });
+    tauri::async_runtime::spawn(async move {
+        run_codex_data_poll_loop(codex_db, codex_app).await;
     });
 }
 
@@ -193,12 +207,55 @@ async fn run_worker_loop(
     }
 }
 
+async fn run_codex_data_poll_loop(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
+    let mut last_fingerprint: Option<String> = None;
+    let interval = Duration::from_millis(CODEX_AUTO_SYNC_POLL_MS);
+
+    loop {
+        let settings = settings::get_webdav_sync_settings();
+        if !should_poll_codex_data(settings.as_ref()) {
+            last_fingerprint = None;
+            tokio::time::sleep(interval).await;
+            continue;
+        }
+
+        let fingerprint = match webdav_sync_service::codex_sync_fingerprint() {
+            Ok(value) => value,
+            Err(err) => {
+                log::debug!("[WebDAV][AutoSync] Failed to fingerprint Codex data: {err}");
+                tokio::time::sleep(interval).await;
+                continue;
+            }
+        };
+
+        match (&last_fingerprint, fingerprint.as_ref()) {
+            (Some(previous), Some(current)) if previous != current => {
+                let current = current.clone();
+                log::debug!("[WebDAV][AutoSync] Triggered by Codex data change");
+                match run_auto_sync_upload(&db, &app).await {
+                    Ok(()) => last_fingerprint = Some(current),
+                    Err(err) => log::warn!("[WebDAV][AutoSync] Codex data upload failed: {err}"),
+                }
+            }
+            (None, Some(current)) => {
+                last_fingerprint = Some(current.clone());
+            }
+            (Some(_), None) => {
+                last_fingerprint = None;
+            }
+            _ => {}
+        }
+
+        tokio::time::sleep(interval).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         auto_sync_wait_duration, enqueue_change_signal, is_auto_sync_suppressed,
-        should_run_auto_sync, should_trigger_for_table, AutoSyncSuppressionGuard,
-        MAX_AUTO_SYNC_WAIT_MS,
+        should_poll_codex_data, should_run_auto_sync, should_trigger_for_table,
+        AutoSyncSuppressionGuard, MAX_AUTO_SYNC_WAIT_MS,
     };
     use crate::settings::WebDavSyncSettings;
     use std::time::{Duration, Instant};
@@ -260,6 +317,27 @@ mod tests {
             ..WebDavSyncSettings::default()
         };
         assert!(should_run_auto_sync(Some(&enabled)));
+    }
+
+    #[test]
+    fn should_poll_codex_data_requires_enabled_auto_sync_and_codex_flag() {
+        assert!(!should_poll_codex_data(None));
+
+        let without_codex = WebDavSyncSettings {
+            enabled: true,
+            auto_sync: true,
+            sync_codex_data: false,
+            ..WebDavSyncSettings::default()
+        };
+        assert!(!should_poll_codex_data(Some(&without_codex)));
+
+        let enabled = WebDavSyncSettings {
+            enabled: true,
+            auto_sync: true,
+            sync_codex_data: true,
+            ..WebDavSyncSettings::default()
+        };
+        assert!(should_poll_codex_data(Some(&enabled)));
     }
 
     #[test]

--- a/src-tauri/src/services/webdav_sync.rs
+++ b/src-tauri/src/services/webdav_sync.rs
@@ -1,7 +1,8 @@
 //! WebDAV v2 sync protocol layer with DB compatibility subdirectories.
 //!
 //! Implements manifest-based synchronization on top of the HTTP transport
-//! primitives in [`super::webdav`]. Artifact set: `db.sql` + `skills.zip`.
+//! primitives in [`super::webdav`]. Artifact set: `db.sql` + `skills.zip`,
+//! plus optional `codex.zip`.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -24,7 +25,8 @@ use crate::settings::{update_webdav_sync_status, WebDavSyncSettings, WebDavSyncS
 
 mod archive;
 use archive::{
-    backup_current_skills, restore_skills_from_backup, restore_skills_zip, zip_skills_ssot,
+    backup_current_skills, codex_data_fingerprint, restore_codex_data_zip,
+    restore_skills_from_backup, restore_skills_zip, zip_codex_data, zip_skills_ssot,
 };
 
 // ─── Protocol constants ──────────────────────────────────────
@@ -35,6 +37,7 @@ const DB_COMPAT_VERSION: u32 = 6;
 const LEGACY_DB_COMPAT_VERSION: u32 = 5;
 const REMOTE_DB_SQL: &str = "db.sql";
 const REMOTE_SKILLS_ZIP: &str = "skills.zip";
+const REMOTE_CODEX_ZIP: &str = "codex.zip";
 const REMOTE_MANIFEST: &str = "manifest.json";
 const MAX_DEVICE_NAME_LEN: usize = 64;
 const MAX_MANIFEST_BYTES: usize = 1024 * 1024;
@@ -51,6 +54,10 @@ where
 {
     let _guard = sync_mutex().lock().await;
     operation.await
+}
+
+pub(crate) fn codex_sync_fingerprint() -> Result<Option<String>, AppError> {
+    codex_data_fingerprint()
 }
 
 fn localized(key: &'static str, zh: impl Into<String>, en: impl Into<String>) -> AppError {
@@ -95,6 +102,7 @@ struct ArtifactMeta {
 struct LocalSnapshot {
     db_sql: Vec<u8>,
     skills_zip: Vec<u8>,
+    codex_zip: Option<Vec<u8>>,
     manifest_bytes: Vec<u8>,
     manifest_hash: String,
 }
@@ -151,6 +159,11 @@ pub async fn upload(
 
     let skills_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_SKILLS_ZIP)?;
     put_bytes(&skills_url, &auth, snapshot.skills_zip, "application/zip").await?;
+
+    if let Some(codex_zip) = snapshot.codex_zip {
+        let codex_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_CODEX_ZIP)?;
+        put_bytes(&codex_url, &auth, codex_zip, "application/zip").await?;
+    }
 
     let manifest_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_MANIFEST)?;
     put_bytes(
@@ -215,9 +228,24 @@ pub async fn download(
         &snapshot.manifest.artifacts,
     )
     .await?;
+    let codex_zip =
+        if settings.sync_codex_data && snapshot.manifest.artifacts.contains_key(REMOTE_CODEX_ZIP) {
+            Some(
+                download_and_verify(
+                    settings,
+                    &auth,
+                    snapshot.layout,
+                    REMOTE_CODEX_ZIP,
+                    &snapshot.manifest.artifacts,
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
 
     // Apply snapshot
-    apply_snapshot(db, &db_sql, &skills_zip)?;
+    apply_snapshot(db, &db_sql, &skills_zip, codex_zip.as_deref())?;
 
     let manifest_hash = sha256_hex(&snapshot.manifest_bytes);
     let _persisted = persist_sync_success_best_effort(
@@ -300,7 +328,7 @@ where
 
 fn build_local_snapshot(
     db: &crate::database::Database,
-    _settings: &WebDavSyncSettings,
+    settings: &WebDavSyncSettings,
 ) -> Result<LocalSnapshot, AppError> {
     // Export database to SQL string
     let sql_string = db.export_sql_string_for_sync()?;
@@ -318,6 +346,13 @@ fn build_local_snapshot(
     let skills_zip_path = tmp.path().join(REMOTE_SKILLS_ZIP);
     zip_skills_ssot(&skills_zip_path)?;
     let skills_zip = fs::read(&skills_zip_path).map_err(|e| AppError::io(&skills_zip_path, e))?;
+    let codex_zip = if settings.sync_codex_data {
+        let codex_zip_path = tmp.path().join(REMOTE_CODEX_ZIP);
+        zip_codex_data(&codex_zip_path)?;
+        Some(fs::read(&codex_zip_path).map_err(|e| AppError::io(&codex_zip_path, e))?)
+    } else {
+        None
+    };
 
     // Build artifact map and compute hashes
     let mut artifacts = BTreeMap::new();
@@ -335,6 +370,15 @@ fn build_local_snapshot(
             size: skills_zip.len() as u64,
         },
     );
+    if let Some(codex_zip) = codex_zip.as_ref() {
+        artifacts.insert(
+            REMOTE_CODEX_ZIP.to_string(),
+            ArtifactMeta {
+                sha256: sha256_hex(codex_zip),
+                size: codex_zip.len() as u64,
+            },
+        );
+    }
 
     let snapshot_id = compute_snapshot_id(&artifacts);
     let manifest = SyncManifest {
@@ -353,6 +397,7 @@ fn build_local_snapshot(
     Ok(LocalSnapshot {
         db_sql,
         skills_zip,
+        codex_zip,
         manifest_bytes,
         manifest_hash,
     })
@@ -591,6 +636,7 @@ fn apply_snapshot(
     db: &crate::database::Database,
     db_sql: &[u8],
     skills_zip: &[u8],
+    codex_zip: Option<&[u8]>,
 ) -> Result<(), AppError> {
     let sql_str = std::str::from_utf8(db_sql).map_err(|e| {
         localized(
@@ -615,6 +661,10 @@ fn apply_snapshot(
             ));
         }
         return Err(db_err);
+    }
+
+    if let Some(codex_zip) = codex_zip {
+        restore_codex_data_zip(codex_zip)?;
     }
 
     Ok(())

--- a/src-tauri/src/services/webdav_sync/archive.rs
+++ b/src-tauri/src/services/webdav_sync/archive.rs
@@ -1,12 +1,19 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Component, Path, PathBuf};
 
+use chrono::Utc;
+use rusqlite::{
+    params_from_iter, types::Value as SqlValue, Connection, OpenFlags, OptionalExtension,
+};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tempfile::{tempdir, TempDir};
 use zip::write::SimpleFileOptions;
 use zip::DateTime;
 
+use crate::codex_config::get_codex_config_dir;
 use crate::error::AppError;
 use crate::services::skill::SkillService;
 
@@ -14,6 +21,28 @@ use super::{io_context_localized, localized, MAX_SYNC_ARTIFACT_BYTES, REMOTE_SKI
 
 /// Maximum number of entries allowed in a zip archive.
 const MAX_EXTRACT_ENTRIES: usize = 10_000;
+const CODEX_SYNC_BACKUP_DIR: &str = "codex_sync_backups";
+const CODEX_SESSION_ROOTS: [&str; 2] = ["sessions", "archived_sessions"];
+const CODEX_SQLITE_FILES: [&str; 2] = ["state_5.sqlite", "goals_1.sqlite"];
+const CODEX_EXCLUDED_ROOT_DIRS: [&str; 9] = [
+    ".tmp",
+    "tmp",
+    "cache",
+    ".sandbox",
+    ".sandbox-bin",
+    ".sandbox-secrets",
+    "session_sync_backups",
+    CODEX_SYNC_BACKUP_DIR,
+    "vendor_imports",
+];
+const CODEX_EXCLUDED_ROOT_FILES: [&str; 6] = [
+    "logs_2.sqlite",
+    "logs_2.sqlite-wal",
+    "logs_2.sqlite-shm",
+    "models_cache.json",
+    "cap_sid",
+    "installation_id",
+];
 
 pub(super) struct SkillsBackup {
     _tmp: TempDir,
@@ -202,6 +231,1032 @@ pub(super) fn restore_skills_from_backup(backup: &SkillsBackup) -> Result<(), Ap
     Ok(())
 }
 
+pub(super) fn zip_codex_data(dest_path: &Path) -> Result<(), AppError> {
+    zip_codex_data_from_config_dir(&get_codex_config_dir(), dest_path)
+}
+
+fn zip_codex_data_from_config_dir(config_dir: &Path, dest_path: &Path) -> Result<(), AppError> {
+    if let Some(parent) = dest_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+
+    let tmp = tempdir().map_err(|e| {
+        io_context_localized(
+            "webdav.sync.codex_tmpdir_failed",
+            "创建 Codex 同步临时目录失败",
+            "Failed to create temporary directory for Codex sync",
+            e,
+        )
+    })?;
+    let sqlite_snapshots = stage_codex_sqlite_snapshots(config_dir, tmp.path())?;
+
+    let file = fs::File::create(dest_path).map_err(|e| AppError::io(dest_path, e))?;
+    let mut writer = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .last_modified_time(DateTime::default());
+
+    if config_dir.exists() {
+        let canonical_root =
+            fs::canonicalize(config_dir).unwrap_or_else(|_| config_dir.to_path_buf());
+        let mut visited = HashSet::new();
+        mark_visited_dir(&canonical_root, &mut visited)?;
+        zip_codex_dir_recursive(
+            &canonical_root,
+            &canonical_root,
+            &mut writer,
+            options,
+            &mut visited,
+            &sqlite_snapshots,
+        )?;
+    }
+
+    writer.finish().map_err(|e| {
+        localized(
+            "webdav.sync.codex_zip_write_failed",
+            format!("写入 codex.zip 失败: {e}"),
+            format!("Failed to write codex.zip: {e}"),
+        )
+    })?;
+    Ok(())
+}
+
+pub(super) fn restore_codex_data_zip(raw: &[u8]) -> Result<(), AppError> {
+    restore_codex_data_zip_into_config_dir(raw, &get_codex_config_dir())
+}
+
+pub(super) fn codex_data_fingerprint() -> Result<Option<String>, AppError> {
+    codex_data_fingerprint_from_config_dir(&get_codex_config_dir())
+}
+
+fn restore_codex_data_zip_into_config_dir(raw: &[u8], config_dir: &Path) -> Result<(), AppError> {
+    let tmp = tempdir().map_err(|e| {
+        io_context_localized(
+            "webdav.sync.codex_extract_tmpdir_failed",
+            "创建 Codex 解压临时目录失败",
+            "Failed to create temporary directory for Codex extraction",
+            e,
+        )
+    })?;
+    let zip_path = tmp.path().join("codex.zip");
+    fs::write(&zip_path, raw).map_err(|e| AppError::io(&zip_path, e))?;
+
+    let file = fs::File::open(&zip_path).map_err(|e| AppError::io(&zip_path, e))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| {
+        localized(
+            "webdav.sync.codex_zip_parse_failed",
+            format!("解析 codex.zip 失败: {e}"),
+            format!("Failed to parse codex.zip: {e}"),
+        )
+    })?;
+
+    if archive.len() > MAX_EXTRACT_ENTRIES {
+        return Err(localized(
+            "webdav.sync.codex_zip_too_many_entries",
+            format!(
+                "codex.zip 条目数过多（{}），上限 {MAX_EXTRACT_ENTRIES}",
+                archive.len()
+            ),
+            format!(
+                "codex.zip has too many entries ({}), limit is {MAX_EXTRACT_ENTRIES}",
+                archive.len()
+            ),
+        ));
+    }
+
+    let extracted = tmp.path().join("codex-extracted");
+    fs::create_dir_all(&extracted).map_err(|e| AppError::io(&extracted, e))?;
+
+    let mut total_bytes: u64 = 0;
+    for idx in 0..archive.len() {
+        let mut entry = archive.by_index(idx).map_err(|e| {
+            localized(
+                "webdav.sync.codex_zip_entry_read_failed",
+                format!("读取 Codex ZIP 项失败: {e}"),
+                format!("Failed to read Codex ZIP entry: {e}"),
+            )
+        })?;
+        if entry.is_dir() {
+            continue;
+        }
+        let Some(safe_name) = entry.enclosed_name() else {
+            continue;
+        };
+        if should_skip_codex_rel(&safe_name) {
+            continue;
+        }
+
+        let out_path = extracted.join(safe_name);
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+        }
+        let mut out = fs::File::create(&out_path).map_err(|e| AppError::io(&out_path, e))?;
+        let _written = copy_entry_with_total_limit(
+            &mut entry,
+            &mut out,
+            &mut total_bytes,
+            MAX_SYNC_ARTIFACT_BYTES,
+            &out_path,
+        )?;
+    }
+
+    restore_codex_data_from_dir(&extracted, config_dir)
+}
+
+fn codex_data_fingerprint_from_config_dir(config_dir: &Path) -> Result<Option<String>, AppError> {
+    if !config_dir.exists() {
+        return Ok(None);
+    }
+
+    let root = fs::canonicalize(config_dir).unwrap_or_else(|_| config_dir.to_path_buf());
+    let mut visited = HashSet::new();
+    mark_visited_dir(&root, &mut visited)?;
+
+    let mut entries = Vec::new();
+    collect_codex_fingerprint_entries(&root, &root, &mut visited, &mut entries)?;
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    for (rel, len, modified_ms) in entries {
+        hasher.update(rel.as_bytes());
+        hasher.update([0]);
+        hasher.update(len.to_le_bytes());
+        hasher.update(modified_ms.to_le_bytes());
+        hasher.update([0]);
+    }
+    Ok(Some(format!("{:x}", hasher.finalize())))
+}
+
+fn collect_codex_fingerprint_entries(
+    root: &Path,
+    current: &Path,
+    visited: &mut HashSet<PathBuf>,
+    entries: &mut Vec<(String, u64, i64)>,
+) -> Result<(), AppError> {
+    let mut dir_entries: Vec<_> = fs::read_dir(current)
+        .map_err(|e| AppError::io(current, e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AppError::io(current, e))?;
+    dir_entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in dir_entries {
+        let path = entry.path();
+        if is_symlink(&path)? {
+            continue;
+        }
+        let rel = path.strip_prefix(root).map_err(|e| {
+            localized(
+                "webdav.sync.codex_fingerprint_relative_path_failed",
+                format!("生成 Codex 指纹相对路径失败: {e}"),
+                format!("Failed to build Codex fingerprint relative path: {e}"),
+            )
+        })?;
+        if should_skip_codex_fingerprint_rel(rel) {
+            continue;
+        }
+
+        if path.is_dir() {
+            let real_path = fs::canonicalize(&path).unwrap_or(path.clone());
+            if !real_path.starts_with(root) || !mark_visited_dir(&real_path, visited)? {
+                continue;
+            }
+            collect_codex_fingerprint_entries(root, &real_path, visited, entries)?;
+            continue;
+        }
+
+        let metadata = fs::metadata(&path).map_err(|e| AppError::io(&path, e))?;
+        let modified_ms = file_modified_ms(&path).unwrap_or(0);
+        entries.push((
+            rel.to_string_lossy().replace('\\', "/"),
+            metadata.len(),
+            modified_ms,
+        ));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct CodexSessionFileInfo {
+    session_id: Option<String>,
+    last_active_at: Option<i64>,
+    hash: String,
+    bytes: Vec<u8>,
+}
+
+#[derive(Clone, Copy)]
+struct SqlMergeTable {
+    name: &'static str,
+    primary_keys: &'static [&'static str],
+    timestamp_column: Option<&'static str>,
+}
+
+const CODEX_STATE_MERGE_TABLES: &[SqlMergeTable] = &[
+    SqlMergeTable {
+        name: "threads",
+        primary_keys: &["id"],
+        timestamp_column: Some("updated_at_ms"),
+    },
+    SqlMergeTable {
+        name: "thread_dynamic_tools",
+        primary_keys: &["thread_id", "position"],
+        timestamp_column: None,
+    },
+    SqlMergeTable {
+        name: "stage1_outputs",
+        primary_keys: &["thread_id"],
+        timestamp_column: Some("source_updated_at"),
+    },
+    SqlMergeTable {
+        name: "agent_jobs",
+        primary_keys: &["id"],
+        timestamp_column: Some("updated_at"),
+    },
+    SqlMergeTable {
+        name: "agent_job_items",
+        primary_keys: &["job_id", "item_id"],
+        timestamp_column: Some("updated_at"),
+    },
+    SqlMergeTable {
+        name: "thread_spawn_edges",
+        primary_keys: &["child_thread_id"],
+        timestamp_column: None,
+    },
+    SqlMergeTable {
+        name: "remote_control_enrollments",
+        primary_keys: &["websocket_url", "account_id", "app_server_client_name"],
+        timestamp_column: Some("updated_at"),
+    },
+];
+
+const CODEX_GOAL_MERGE_TABLES: &[SqlMergeTable] = &[SqlMergeTable {
+    name: "thread_goals",
+    primary_keys: &["thread_id"],
+    timestamp_column: Some("updated_at_ms"),
+}];
+
+fn restore_codex_data_from_dir(extracted: &Path, config_dir: &Path) -> Result<(), AppError> {
+    if !extracted.exists() {
+        return Ok(());
+    }
+
+    let backup_root = config_dir
+        .join(CODEX_SYNC_BACKUP_DIR)
+        .join(Utc::now().format("%Y%m%dT%H%M%S%.3fZ").to_string());
+
+    restore_codex_sessions_from_dir(extracted, config_dir, &backup_root)?;
+    restore_codex_sqlite_files(extracted, config_dir, &backup_root)?;
+    restore_regular_codex_files(extracted, config_dir, &backup_root)?;
+    Ok(())
+}
+
+fn restore_codex_sessions_from_dir(
+    extracted: &Path,
+    config_dir: &Path,
+    backup_root: &Path,
+) -> Result<(), AppError> {
+    let mut incoming_files = Vec::new();
+    for root_name in CODEX_SESSION_ROOTS {
+        collect_codex_files(&extracted.join(root_name), &mut incoming_files)?;
+    }
+
+    if incoming_files.is_empty() {
+        return Ok(());
+    }
+
+    let mut local_index = build_codex_session_index(config_dir)?;
+    for source in incoming_files {
+        let rel = source.strip_prefix(extracted).map_err(|e| {
+            localized(
+                "webdav.sync.codex_relative_path_failed",
+                format!("生成 Codex 相对路径失败: {e}"),
+                format!("Failed to build Codex relative path: {e}"),
+            )
+        })?;
+        let incoming = read_codex_session_file_info(&source)?;
+        let target = incoming
+            .session_id
+            .as_ref()
+            .and_then(|session_id| local_index.get(session_id).cloned())
+            .unwrap_or_else(|| config_dir.join(rel));
+
+        if target.exists() {
+            if is_symlink(&target)? {
+                log::warn!(
+                    "[WebDAV] Skipping Codex session restore over symlink: {}",
+                    target.display()
+                );
+                continue;
+            }
+            let local = read_codex_session_file_info(&target)?;
+            if local.hash == incoming.hash || is_local_session_newer(&local, &incoming) {
+                continue;
+            }
+            let _ = backup_codex_file(config_dir, &target, backup_root)?;
+        }
+
+        write_codex_file(&target, &incoming.bytes)?;
+        if let Some(session_id) = incoming.session_id {
+            local_index.insert(session_id, target);
+        }
+    }
+
+    Ok(())
+}
+
+fn restore_codex_sqlite_files(
+    extracted: &Path,
+    config_dir: &Path,
+    backup_root: &Path,
+) -> Result<(), AppError> {
+    for file_name in CODEX_SQLITE_FILES {
+        let incoming = extracted.join(file_name);
+        if !incoming.exists() {
+            continue;
+        }
+        let target = config_dir.join(file_name);
+        if target.exists() && is_symlink(&target)? {
+            log::warn!(
+                "[WebDAV] Skipping Codex SQLite restore over symlink: {}",
+                target.display()
+            );
+            continue;
+        }
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+        }
+
+        if !target.exists() {
+            fs::copy(&incoming, &target).map_err(|e| AppError::io(&target, e))?;
+            rewrite_codex_sqlite_paths(&target, config_dir, file_name)?;
+            continue;
+        }
+
+        let backup_path = backup_codex_file(config_dir, &target, backup_root)?;
+        let merge_result = merge_codex_sqlite(&incoming, &target, config_dir, file_name);
+        if let Err(err) = merge_result {
+            if let Some(backup_path) = backup_path {
+                let _ = fs::copy(&backup_path, &target);
+            }
+            return Err(err);
+        }
+        rewrite_codex_sqlite_paths(&target, config_dir, file_name)?;
+    }
+
+    Ok(())
+}
+
+fn restore_regular_codex_files(
+    extracted: &Path,
+    config_dir: &Path,
+    backup_root: &Path,
+) -> Result<(), AppError> {
+    let mut files = Vec::new();
+    collect_codex_files(extracted, &mut files)?;
+    for source in files {
+        let rel = source.strip_prefix(extracted).map_err(|e| {
+            localized(
+                "webdav.sync.codex_relative_path_failed",
+                format!("生成 Codex 相对路径失败: {e}"),
+                format!("Failed to build Codex relative path: {e}"),
+            )
+        })?;
+        if is_codex_session_rel(rel) || is_codex_sqlite_rel(rel) || should_skip_codex_rel(rel) {
+            continue;
+        }
+        let target = config_dir.join(rel);
+        if target.exists() {
+            if is_symlink(&target)? {
+                log::warn!(
+                    "[WebDAV] Skipping Codex file restore over symlink: {}",
+                    target.display()
+                );
+                continue;
+            }
+            let incoming = fs::read(&source).map_err(|e| AppError::io(&source, e))?;
+            let local = fs::read(&target).map_err(|e| AppError::io(&target, e))?;
+            if incoming == local {
+                continue;
+            }
+            let _ = backup_codex_file(config_dir, &target, backup_root)?;
+            write_codex_file(&target, &incoming)?;
+        } else {
+            let incoming = fs::read(&source).map_err(|e| AppError::io(&source, e))?;
+            write_codex_file(&target, &incoming)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn stage_codex_sqlite_snapshots(
+    config_dir: &Path,
+    tmp_root: &Path,
+) -> Result<HashMap<PathBuf, PathBuf>, AppError> {
+    let mut snapshots = HashMap::new();
+    for file_name in CODEX_SQLITE_FILES {
+        let source = config_dir.join(file_name);
+        if !source.exists() {
+            continue;
+        }
+        let dest = tmp_root.join(file_name);
+        copy_sqlite_snapshot(&source, &dest)?;
+        snapshots.insert(PathBuf::from(file_name), dest);
+    }
+    Ok(snapshots)
+}
+
+fn copy_sqlite_snapshot(source: &Path, dest: &Path) -> Result<(), AppError> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+    let source_conn = Connection::open_with_flags(source, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| AppError::Database(format!("Open Codex SQLite failed: {e}")))?;
+    let mut dest_conn = Connection::open(dest)
+        .map_err(|e| AppError::Database(format!("Create Codex SQLite snapshot failed: {e}")))?;
+    let backup = rusqlite::backup::Backup::new(&source_conn, &mut dest_conn)
+        .map_err(|e| AppError::Database(format!("Create Codex SQLite backup failed: {e}")))?;
+    backup
+        .step(-1)
+        .map_err(|e| AppError::Database(format!("Copy Codex SQLite backup failed: {e}")))?;
+    Ok(())
+}
+
+fn zip_codex_dir_recursive(
+    root: &Path,
+    current: &Path,
+    writer: &mut zip::ZipWriter<fs::File>,
+    options: SimpleFileOptions,
+    visited: &mut HashSet<PathBuf>,
+    sqlite_snapshots: &HashMap<PathBuf, PathBuf>,
+) -> Result<(), AppError> {
+    let mut entries: Vec<_> = fs::read_dir(current)
+        .map_err(|e| AppError::io(current, e))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AppError::io(current, e))?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let path = entry.path();
+        if is_symlink(&path)? {
+            continue;
+        }
+        let rel = path.strip_prefix(root).map_err(|e| {
+            localized(
+                "webdav.sync.codex_zip_relative_path_failed",
+                format!("生成 Codex ZIP 相对路径失败: {e}"),
+                format!("Failed to build Codex ZIP relative path: {e}"),
+            )
+        })?;
+        if should_skip_codex_rel(rel) {
+            continue;
+        }
+
+        if path.is_dir() {
+            let real_path = fs::canonicalize(&path).unwrap_or(path.clone());
+            if !real_path.starts_with(root) || !mark_visited_dir(&real_path, visited)? {
+                continue;
+            }
+            zip_codex_dir_recursive(root, &real_path, writer, options, visited, sqlite_snapshots)?;
+            continue;
+        }
+
+        let zip_rel = rel.to_string_lossy().replace('\\', "/");
+        writer.start_file(&zip_rel, options).map_err(|e| {
+            localized(
+                "webdav.sync.codex_zip_start_file_failed",
+                format!("写入 Codex ZIP 文件头失败: {e}"),
+                format!("Failed to start Codex ZIP file entry: {e}"),
+            )
+        })?;
+
+        let bytes = if let Some(snapshot_path) = sqlite_snapshots.get(rel) {
+            fs::read(snapshot_path).map_err(|e| AppError::io(snapshot_path, e))?
+        } else {
+            fs::read(&path).map_err(|e| AppError::io(&path, e))?
+        };
+        writer.write_all(&bytes).map_err(|e| {
+            localized(
+                "webdav.sync.codex_zip_write_file_failed",
+                format!("写入 Codex ZIP 文件内容失败: {e}"),
+                format!("Failed to write Codex ZIP file content: {e}"),
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn build_codex_session_index(config_dir: &Path) -> Result<HashMap<String, PathBuf>, AppError> {
+    let mut files = Vec::new();
+    for root_name in CODEX_SESSION_ROOTS {
+        collect_codex_files(&config_dir.join(root_name), &mut files)?;
+    }
+
+    let mut index = HashMap::new();
+    for path in files {
+        let info = read_codex_session_file_info(&path)?;
+        if let Some(session_id) = info.session_id {
+            index.insert(session_id, path);
+        }
+    }
+    Ok(index)
+}
+
+fn collect_codex_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<(), AppError> {
+    if !root.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(root).map_err(|e| AppError::io(root, e))? {
+        let entry = entry.map_err(|e| AppError::io(root, e))?;
+        let path = entry.path();
+        if is_symlink(&path)? {
+            continue;
+        }
+        if path.is_dir() {
+            collect_codex_files(&path, files)?;
+        } else {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(())
+}
+
+fn read_codex_session_file_info(path: &Path) -> Result<CodexSessionFileInfo, AppError> {
+    let bytes = fs::read(path).map_err(|e| AppError::io(path, e))?;
+    let hash = sha256_hex_local(&bytes);
+    let mut session_id = None;
+    let mut last_active_at = None;
+    let reader = BufReader::new(bytes.as_slice());
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(parsed) => parsed,
+            Err(_) => continue,
+        };
+
+        last_active_at = max_timestamp(
+            last_active_at,
+            value.get("timestamp").and_then(parse_codex_timestamp_to_ms),
+        );
+
+        if value.get("type").and_then(Value::as_str) == Some("session_meta") {
+            if let Some(payload) = value.get("payload") {
+                if session_id.is_none() {
+                    session_id = payload
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                }
+                last_active_at = max_timestamp(
+                    last_active_at,
+                    payload
+                        .get("timestamp")
+                        .and_then(parse_codex_timestamp_to_ms),
+                );
+            }
+        }
+    }
+
+    Ok(CodexSessionFileInfo {
+        session_id,
+        last_active_at: last_active_at.or_else(|| file_modified_ms(path)),
+        hash,
+        bytes,
+    })
+}
+
+fn is_local_session_newer(local: &CodexSessionFileInfo, incoming: &CodexSessionFileInfo) -> bool {
+    match (local.last_active_at, incoming.last_active_at) {
+        (Some(local_ts), Some(incoming_ts)) => local_ts > incoming_ts,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+fn merge_codex_sqlite(
+    incoming_path: &Path,
+    target_path: &Path,
+    config_dir: &Path,
+    file_name: &str,
+) -> Result<(), AppError> {
+    let incoming = Connection::open_with_flags(incoming_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| AppError::Database(format!("Open incoming Codex SQLite failed: {e}")))?;
+    let target = Connection::open(target_path)
+        .map_err(|e| AppError::Database(format!("Open local Codex SQLite failed: {e}")))?;
+
+    let tables = match file_name {
+        "state_5.sqlite" => CODEX_STATE_MERGE_TABLES,
+        "goals_1.sqlite" => CODEX_GOAL_MERGE_TABLES,
+        _ => &[],
+    };
+
+    for table in tables {
+        merge_sqlite_table(&incoming, &target, table, config_dir)?;
+    }
+    Ok(())
+}
+
+fn merge_sqlite_table(
+    incoming: &Connection,
+    target: &Connection,
+    table: &SqlMergeTable,
+    config_dir: &Path,
+) -> Result<(), AppError> {
+    if !sqlite_table_exists(incoming, table.name)? || !sqlite_table_exists(target, table.name)? {
+        return Ok(());
+    }
+
+    let incoming_columns = sqlite_table_columns(incoming, table.name)?;
+    let target_columns = sqlite_table_columns(target, table.name)?;
+    let columns: Vec<String> = incoming_columns
+        .into_iter()
+        .filter(|column| target_columns.contains(column))
+        .collect();
+    if columns.is_empty()
+        || !table
+            .primary_keys
+            .iter()
+            .all(|pk| columns.iter().any(|column| column == pk))
+    {
+        return Ok(());
+    }
+
+    let timestamp_column = table
+        .timestamp_column
+        .filter(|column| columns.iter().any(|existing| existing == column))
+        .or_else(|| {
+            (table.name == "threads")
+                .then(|| {
+                    ["updated_at", "created_at"]
+                        .into_iter()
+                        .find(|column| columns.iter().any(|existing| existing == column))
+                })
+                .flatten()
+        });
+    let select_sql = format!(
+        "SELECT {} FROM {}",
+        columns
+            .iter()
+            .map(|column| quote_ident(column))
+            .collect::<Vec<_>>()
+            .join(", "),
+        quote_ident(table.name)
+    );
+    let mut stmt = incoming
+        .prepare(&select_sql)
+        .map_err(|e| AppError::Database(format!("Prepare Codex SQLite select failed: {e}")))?;
+    let mut rows = stmt
+        .query([])
+        .map_err(|e| AppError::Database(format!("Query Codex SQLite rows failed: {e}")))?;
+
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| AppError::Database(format!("Read Codex SQLite row failed: {e}")))?
+    {
+        let mut values = Vec::with_capacity(columns.len());
+        for idx in 0..columns.len() {
+            values.push(
+                row.get::<_, SqlValue>(idx).map_err(|e| {
+                    AppError::Database(format!("Read Codex SQLite value failed: {e}"))
+                })?,
+            );
+        }
+
+        rewrite_thread_rollout_path(table.name, &columns, &mut values, config_dir);
+
+        if should_replace_sqlite_row(target, table, &columns, &values, timestamp_column)? {
+            insert_or_replace_sqlite_row(target, table.name, &columns, &values)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn should_replace_sqlite_row(
+    target: &Connection,
+    table: &SqlMergeTable,
+    columns: &[String],
+    values: &[SqlValue],
+    timestamp_column: Option<&str>,
+) -> Result<bool, AppError> {
+    let where_clause = table
+        .primary_keys
+        .iter()
+        .map(|pk| format!("{} = ?", quote_ident(pk)))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    let key_values = table
+        .primary_keys
+        .iter()
+        .filter_map(|pk| columns.iter().position(|column| column == pk))
+        .map(|idx| values[idx].clone())
+        .collect::<Vec<_>>();
+
+    if let Some(timestamp_column) = timestamp_column {
+        let incoming_ts = columns
+            .iter()
+            .position(|column| column == timestamp_column)
+            .and_then(|idx| sql_value_as_i64(&values[idx]))
+            .unwrap_or(0);
+        let query = format!(
+            "SELECT {} FROM {} WHERE {}",
+            quote_ident(timestamp_column),
+            quote_ident(table.name),
+            where_clause
+        );
+        let local_ts = target
+            .query_row(&query, params_from_iter(key_values.iter()), |row| {
+                row.get::<_, SqlValue>(0)
+            })
+            .optional()
+            .map_err(|e| {
+                AppError::Database(format!("Read local Codex SQLite timestamp failed: {e}"))
+            })?
+            .and_then(|value| sql_value_as_i64(&value));
+        return Ok(local_ts.map(|ts| incoming_ts >= ts).unwrap_or(true));
+    }
+
+    Ok(true)
+}
+
+fn insert_or_replace_sqlite_row(
+    target: &Connection,
+    table_name: &str,
+    columns: &[String],
+    values: &[SqlValue],
+) -> Result<(), AppError> {
+    let sql = format!(
+        "INSERT OR REPLACE INTO {} ({}) VALUES ({})",
+        quote_ident(table_name),
+        columns
+            .iter()
+            .map(|column| quote_ident(column))
+            .collect::<Vec<_>>()
+            .join(", "),
+        std::iter::repeat("?")
+            .take(columns.len())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    target
+        .execute(&sql, params_from_iter(values.iter()))
+        .map_err(|e| AppError::Database(format!("Merge Codex SQLite row failed: {e}")))?;
+    Ok(())
+}
+
+fn rewrite_thread_rollout_path(
+    table_name: &str,
+    columns: &[String],
+    values: &mut [SqlValue],
+    config_dir: &Path,
+) {
+    if table_name != "threads" {
+        return;
+    }
+    let Some(idx) = columns.iter().position(|column| column == "rollout_path") else {
+        return;
+    };
+    let rewritten = match &values[idx] {
+        SqlValue::Text(raw) => Some(rewrite_codex_path_to_local(raw, config_dir)),
+        _ => None,
+    };
+    if let Some(rewritten) = rewritten {
+        values[idx] = SqlValue::Text(rewritten);
+    }
+}
+
+fn rewrite_codex_path_to_local(raw: &str, config_dir: &Path) -> String {
+    let normalized = raw.replace('\\', "/");
+    for marker in ["archived_sessions/", "sessions/"] {
+        if let Some(pos) = normalized.find(marker) {
+            let rel = &normalized[pos..];
+            return config_dir.join(rel).to_string_lossy().to_string();
+        }
+    }
+    raw.to_string()
+}
+
+fn rewrite_codex_sqlite_paths(
+    target_path: &Path,
+    config_dir: &Path,
+    file_name: &str,
+) -> Result<(), AppError> {
+    if file_name != "state_5.sqlite" {
+        return Ok(());
+    }
+    let conn = Connection::open(target_path).map_err(|e| {
+        AppError::Database(format!("Open Codex SQLite for path rewrite failed: {e}"))
+    })?;
+    if !sqlite_table_exists(&conn, "threads")? {
+        return Ok(());
+    }
+    let columns = sqlite_table_columns(&conn, "threads")?;
+    if !columns.contains("id") || !columns.contains("rollout_path") {
+        return Ok(());
+    }
+
+    let updates = {
+        let mut stmt = conn
+            .prepare("SELECT id, rollout_path FROM threads")
+            .map_err(|e| AppError::Database(format!("Prepare Codex path rewrite failed: {e}")))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| AppError::Database(format!("Read Codex paths failed: {e}")))?;
+        let mut updates = Vec::new();
+        for row in rows {
+            let (id, path) =
+                row.map_err(|e| AppError::Database(format!("Read Codex path row failed: {e}")))?;
+            let rewritten = rewrite_codex_path_to_local(&path, config_dir);
+            if rewritten != path {
+                updates.push((id, rewritten));
+            }
+        }
+        updates
+    };
+
+    for (id, path) in updates {
+        conn.execute(
+            "UPDATE threads SET rollout_path=?1 WHERE id=?2",
+            [&path, &id],
+        )
+        .map_err(|e| AppError::Database(format!("Rewrite Codex rollout path failed: {e}")))?;
+    }
+    Ok(())
+}
+
+fn sqlite_table_exists(conn: &Connection, table_name: &str) -> Result<bool, AppError> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+        [table_name],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|count| count > 0)
+    .map_err(|e| AppError::Database(format!("Check Codex SQLite table failed: {e}")))
+}
+
+fn sqlite_table_columns(conn: &Connection, table_name: &str) -> Result<HashSet<String>, AppError> {
+    let sql = format!("PRAGMA table_info({})", quote_ident(table_name));
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| AppError::Database(format!("Read Codex SQLite schema failed: {e}")))?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| AppError::Database(format!("Read Codex SQLite columns failed: {e}")))?;
+    let mut columns = HashSet::new();
+    for row in rows {
+        columns.insert(
+            row.map_err(|e| AppError::Database(format!("Read Codex SQLite column failed: {e}")))?,
+        );
+    }
+    Ok(columns)
+}
+
+fn quote_ident(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn sql_value_as_i64(value: &SqlValue) -> Option<i64> {
+    match value {
+        SqlValue::Integer(value) => Some(*value),
+        SqlValue::Real(value) => Some(*value as i64),
+        SqlValue::Text(value) => value.parse().ok(),
+        _ => None,
+    }
+}
+
+fn backup_codex_file(
+    config_dir: &Path,
+    source: &Path,
+    backup_root: &Path,
+) -> Result<Option<PathBuf>, AppError> {
+    if !source.exists() {
+        return Ok(None);
+    }
+    let rel = source.strip_prefix(config_dir).unwrap_or_else(|_| {
+        source
+            .file_name()
+            .map(Path::new)
+            .unwrap_or_else(|| Path::new("codex-file"))
+    });
+    let backup_path = backup_root.join(rel);
+    if let Some(parent) = backup_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+    fs::copy(source, &backup_path).map_err(|e| AppError::io(&backup_path, e))?;
+    Ok(Some(backup_path))
+}
+
+fn write_codex_file(target: &Path, bytes: &[u8]) -> Result<(), AppError> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+    crate::config::atomic_write(target, bytes)
+}
+
+fn should_skip_codex_rel(path: &Path) -> bool {
+    let components = path
+        .components()
+        .filter_map(normal_component)
+        .collect::<Vec<_>>();
+    let Some(first) = components.first().copied() else {
+        return true;
+    };
+    if CODEX_EXCLUDED_ROOT_DIRS.contains(&first) {
+        return true;
+    }
+    if first == "plugins" && components.get(1).copied() == Some("cache") {
+        return true;
+    }
+
+    let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    CODEX_EXCLUDED_ROOT_FILES.contains(&file_name)
+        || file_name.ends_with(".sqlite-wal")
+        || file_name.ends_with(".sqlite-shm")
+}
+
+fn should_skip_codex_fingerprint_rel(path: &Path) -> bool {
+    if is_codex_sqlite_sidecar_rel(path) {
+        return false;
+    }
+    should_skip_codex_rel(path)
+}
+
+fn normal_component(component: Component<'_>) -> Option<&str> {
+    match component {
+        Component::Normal(value) => value.to_str(),
+        _ => None,
+    }
+}
+
+fn is_codex_session_rel(path: &Path) -> bool {
+    path.components()
+        .next()
+        .and_then(normal_component)
+        .map(|root| CODEX_SESSION_ROOTS.contains(&root))
+        .unwrap_or(false)
+}
+
+fn is_codex_sqlite_rel(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .map(|file_name| CODEX_SQLITE_FILES.contains(&file_name))
+        .unwrap_or(false)
+}
+
+fn is_codex_sqlite_sidecar_rel(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    CODEX_SQLITE_FILES.iter().any(|db_name| {
+        file_name == format!("{db_name}-wal") || file_name == format!("{db_name}-shm")
+    })
+}
+
+fn parse_codex_timestamp_to_ms(value: &Value) -> Option<i64> {
+    value
+        .as_str()
+        .and_then(|raw| chrono::DateTime::parse_from_rfc3339(raw).ok())
+        .map(|ts| ts.timestamp_millis())
+}
+
+fn max_timestamp(current: Option<i64>, next: Option<i64>) -> Option<i64> {
+    match (current, next) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+fn file_modified_ms(path: &Path) -> Option<i64> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    let duration = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
+    Some(duration.as_millis().min(i64::MAX as u128) as i64)
+}
+
+fn sha256_hex_local(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn is_symlink(path: &Path) -> Result<bool, AppError> {
+    Ok(fs::symlink_metadata(path)
+        .map_err(|e| AppError::io(path, e))?
+        .file_type()
+        .is_symlink())
+}
+
 fn zip_dir_recursive(
     root: &Path,
     current: &Path,
@@ -366,11 +1421,21 @@ fn copy_entry_with_total_limit<R: Read, W: Write>(
 
 #[cfg(test)]
 mod tests {
-    use super::{copy_entry_with_total_limit, mark_visited_dir};
+    use super::{
+        copy_entry_with_total_limit, mark_visited_dir, restore_codex_data_zip_into_config_dir,
+        zip_codex_data_from_config_dir,
+    };
     use std::collections::HashSet;
     use std::io::Cursor;
     use std::path::Path;
     use tempfile::tempdir;
+
+    fn codex_session(session_id: &str, timestamp: &str, body: &str) -> String {
+        format!(
+            "{{\"timestamp\":\"{timestamp}\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session_id}\",\"cwd\":\"/tmp/project\"}}}}\n\
+             {{\"timestamp\":\"{timestamp}\",\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"user\",\"content\":\"{body}\"}}}}\n"
+        )
+    }
 
     #[test]
     fn mark_visited_dir_tracks_canonical_duplicates() {
@@ -405,6 +1470,157 @@ mod tests {
             writer.len(),
             0,
             "should not write when the first chunk exceeds limit"
+        );
+    }
+
+    #[test]
+    fn zip_codex_data_includes_auth_and_excludes_runtime_cache() {
+        let temp = tempdir().expect("tempdir");
+        let config_dir = temp.path().join(".codex");
+        std::fs::create_dir_all(config_dir.join("sessions/2026/05")).expect("create sessions");
+        std::fs::create_dir_all(config_dir.join("plugins/cache/big")).expect("create cache");
+        std::fs::create_dir_all(config_dir.join(".tmp")).expect("create tmp");
+        std::fs::write(config_dir.join("auth.json"), "{\"token\":\"secret\"}").expect("write auth");
+        std::fs::write(
+            config_dir.join("sessions/2026/05/session.jsonl"),
+            codex_session("session-1", "2026-05-01T00:00:00Z", "hello"),
+        )
+        .expect("write session");
+        std::fs::write(config_dir.join("plugins/cache/big/cache.bin"), "cache")
+            .expect("write cache");
+        std::fs::write(config_dir.join(".tmp/runtime.txt"), "runtime").expect("write runtime");
+        std::fs::write(config_dir.join("logs_2.sqlite"), "logs").expect("write logs");
+
+        let zip_path = temp.path().join("codex.zip");
+        zip_codex_data_from_config_dir(&config_dir, &zip_path).expect("zip codex data");
+
+        let file = std::fs::File::open(&zip_path).expect("open zip");
+        let mut archive = zip::ZipArchive::new(file).expect("read zip");
+        let mut names = Vec::new();
+        for idx in 0..archive.len() {
+            names.push(archive.by_index(idx).expect("entry").name().to_string());
+        }
+        names.sort();
+
+        assert!(names.contains(&"auth.json".to_string()));
+        assert!(names.contains(&"sessions/2026/05/session.jsonl".to_string()));
+        assert!(!names.iter().any(|name| name.starts_with("plugins/cache")));
+        assert!(!names.iter().any(|name| name.starts_with(".tmp")));
+        assert!(!names.contains(&"logs_2.sqlite".to_string()));
+    }
+
+    #[test]
+    fn restore_codex_data_merges_sessions_and_preserves_newer_local() {
+        let temp = tempdir().expect("tempdir");
+        let local_config = temp.path().join("local-codex");
+        let remote_config = temp.path().join("remote-codex");
+        let local_session = local_config.join("sessions").join("session.jsonl");
+        let remote_session = remote_config.join("sessions").join("session.jsonl");
+        std::fs::create_dir_all(local_session.parent().unwrap()).expect("local dir");
+        std::fs::create_dir_all(remote_session.parent().unwrap()).expect("remote dir");
+        std::fs::write(
+            &local_session,
+            codex_session("same-session", "2026-05-03T00:00:00Z", "local-newer"),
+        )
+        .expect("write local");
+        std::fs::write(
+            &remote_session,
+            codex_session("same-session", "2026-05-02T00:00:00Z", "remote-older"),
+        )
+        .expect("write remote");
+        std::fs::write(remote_config.join("auth.json"), "{\"token\":\"remote\"}")
+            .expect("write remote auth");
+
+        let zip_path = temp.path().join("codex.zip");
+        zip_codex_data_from_config_dir(&remote_config, &zip_path).expect("zip remote");
+        let raw = std::fs::read(&zip_path).expect("read zip");
+
+        restore_codex_data_zip_into_config_dir(&raw, &local_config).expect("restore zip");
+
+        let restored = std::fs::read_to_string(&local_session).expect("read restored");
+        assert!(restored.contains("local-newer"));
+        assert_eq!(
+            std::fs::read_to_string(local_config.join("auth.json")).expect("read auth"),
+            "{\"token\":\"remote\"}"
+        );
+    }
+
+    #[test]
+    fn restore_codex_data_rewrites_thread_rollout_paths() {
+        let temp = tempdir().expect("tempdir");
+        let local_config = temp.path().join("local-codex");
+        let remote_config = temp.path().join("remote-codex");
+        std::fs::create_dir_all(&local_config).expect("local dir");
+        std::fs::create_dir_all(remote_config.join("sessions/2026/05")).expect("remote sessions");
+        std::fs::create_dir_all(remote_config.join("archived_sessions/2026/05"))
+            .expect("remote archived sessions");
+        std::fs::write(
+            remote_config.join("sessions/2026/05/session.jsonl"),
+            codex_session("thread-1", "2026-05-02T00:00:00Z", "remote"),
+        )
+        .expect("write remote session");
+        std::fs::write(
+            remote_config.join("archived_sessions/2026/05/archived.jsonl"),
+            codex_session("thread-2", "2026-05-03T00:00:00Z", "archived"),
+        )
+        .expect("write remote archived session");
+
+        let db_path = remote_config.join("state_5.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).expect("open db");
+        conn.execute_batch(
+            "CREATE TABLE threads (
+                id TEXT PRIMARY KEY,
+                rollout_path TEXT NOT NULL,
+                updated_at_ms INTEGER NOT NULL
+            );
+            INSERT INTO threads (id, rollout_path, updated_at_ms)
+            VALUES
+                ('thread-1', 'C:/Other/.codex/sessions/2026/05/session.jsonl', 10),
+                ('thread-2', 'C:/Other/.codex/archived_sessions/2026/05/archived.jsonl', 20);",
+        )
+        .expect("seed db");
+
+        let zip_path = temp.path().join("codex.zip");
+        zip_codex_data_from_config_dir(&remote_config, &zip_path).expect("zip remote");
+        let raw = std::fs::read(&zip_path).expect("read zip");
+
+        restore_codex_data_zip_into_config_dir(&raw, &local_config).expect("restore zip");
+
+        let local_db = rusqlite::Connection::open(local_config.join("state_5.sqlite"))
+            .expect("open restored db");
+        let rollout_path: String = local_db
+            .query_row(
+                "SELECT rollout_path FROM threads WHERE id='thread-1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read rollout path");
+        assert!(
+            rollout_path.starts_with(local_config.to_string_lossy().as_ref()),
+            "rollout path should be rewritten to local config dir: {rollout_path}"
+        );
+        assert!(
+            rollout_path
+                .replace('\\', "/")
+                .contains("/sessions/2026/05/"),
+            "active rollout path should stay under sessions: {rollout_path}"
+        );
+        let archived_rollout_path: String = local_db
+            .query_row(
+                "SELECT rollout_path FROM threads WHERE id='thread-2'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read archived rollout path");
+        assert!(
+            archived_rollout_path.starts_with(local_config.to_string_lossy().as_ref()),
+            "archived rollout path should be rewritten to local config dir: {archived_rollout_path}"
+        );
+        assert!(
+            archived_rollout_path
+                .replace('\\', "/")
+                .contains("/archived_sessions/2026/05/"),
+            "archived rollout path should stay under archived_sessions: {archived_rollout_path}"
         );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -110,6 +110,8 @@ pub struct WebDavSyncSettings {
     #[serde(default)]
     pub auto_sync: bool,
     #[serde(default)]
+    pub sync_codex_data: bool,
+    #[serde(default)]
     pub base_url: String,
     #[serde(default)]
     pub username: String,
@@ -128,6 +130,7 @@ impl Default for WebDavSyncSettings {
         Self {
             enabled: false,
             auto_sync: false,
+            sync_codex_data: false,
             base_url: String::new(),
             username: String::new(),
             password: String::new(),

--- a/src/components/settings/WebdavSyncSection.tsx
+++ b/src/components/settings/WebdavSyncSection.tsx
@@ -194,6 +194,7 @@ export function WebdavSyncSection({
     remoteRoot: config?.remoteRoot ?? "cc-switch-sync",
     profile: config?.profile ?? "default",
     autoSync: config?.autoSync ?? false,
+    syncCodexData: config?.syncCodexData ?? false,
   }));
 
   // Preset selector — derived from initial URL, updated on user selection
@@ -252,6 +253,7 @@ export function WebdavSyncSection({
         remoteRoot: nextRemoteRoot,
         profile: nextProfile,
         autoSync: config.autoSync ?? false,
+        syncCodexData: config.syncCodexData ?? false,
       };
     });
     setPasswordTouched(false);
@@ -323,6 +325,16 @@ export function WebdavSyncSection({
     }
   }, [onAutoSave]);
 
+  const handleSyncCodexDataChange = useCallback((checked: boolean) => {
+    setForm((prev) => ({ ...prev, syncCodexData: checked }));
+    setDirty(true);
+    setJustSaved(false);
+    if (justSavedTimerRef.current) {
+      clearTimeout(justSavedTimerRef.current);
+      justSavedTimerRef.current = null;
+    }
+  }, []);
+
   const buildSettings = useCallback((): WebDavSyncSettings | null => {
     const baseUrl = form.baseUrl.trim();
     if (!baseUrl) return null;
@@ -335,6 +347,7 @@ export function WebdavSyncSection({
       remoteRoot: form.remoteRoot.trim() || "cc-switch-sync",
       profile: form.profile.trim() || "default",
       autoSync: form.autoSync,
+      syncCodexData: form.syncCodexData,
     };
   }, [form, passwordTouched]);
 
@@ -539,6 +552,8 @@ export function WebdavSyncSection({
     remoteInfo?.dbCompatVersion,
   );
   const remoteIsLegacy = remoteInfo?.layout === "legacy";
+  const remoteHasCodexData =
+    remoteInfo?.artifacts?.includes("codex.zip") ?? false;
 
   // ─── Render ─────────────────────────────────────────────
 
@@ -682,6 +697,30 @@ export function WebdavSyncSection({
               />
             </div>
           </div>
+
+          <div className="flex items-start gap-4">
+            <label className="w-40 text-xs font-medium text-foreground shrink-0">
+              {t("settings.webdavSync.syncCodexData")}
+              <span className="block text-[10px] font-normal text-muted-foreground">
+                {t("settings.webdavSync.syncCodexDataHint")}
+              </span>
+            </label>
+            <div className="pt-1">
+              <Switch
+                checked={form.syncCodexData}
+                onCheckedChange={handleSyncCodexDataChange}
+                aria-label={t("settings.webdavSync.syncCodexData")}
+                disabled={isLoading}
+              />
+            </div>
+          </div>
+
+          {form.syncCodexData && (
+            <div className="flex max-w-3xl items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/5 px-3 py-2 text-xs leading-relaxed text-amber-800 dark:text-amber-200">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+              <span>{t("settings.webdavSync.codexDataAuthWarning")}</span>
+            </div>
+          )}
         </div>
 
         {/* Last sync time */}
@@ -804,6 +843,11 @@ export function WebdavSyncSection({
                 <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
                   <li>{t("settings.webdavSync.confirmUpload.dbItem")}</li>
                   <li>{t("settings.webdavSync.confirmUpload.skillsItem")}</li>
+                  {form.syncCodexData && (
+                    <li>
+                      {t("settings.webdavSync.confirmUpload.codexDataItem")}
+                    </li>
+                  )}
                 </ul>
                 <p className="text-muted-foreground">
                   {t("settings.webdavSync.confirmUpload.targetPath")}
@@ -932,6 +976,11 @@ export function WebdavSyncSection({
                 <p className="text-destructive font-medium">
                   {t("settings.webdavSync.confirmDownload.warning")}
                 </p>
+                {form.syncCodexData && remoteHasCodexData && (
+                  <p className="font-medium text-amber-600 dark:text-amber-400">
+                    {t("settings.webdavSync.confirmDownload.codexDataMerge")}
+                  </p>
+                )}
               </div>
             </DialogDescription>
           </DialogHeader>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -461,7 +461,7 @@
     },
     "webdavSync": {
       "title": "WebDAV Cloud Sync",
-      "description": "Sync database and skill configurations across devices via WebDAV.",
+      "description": "Sync database, skill configurations, and optional Codex data across devices via WebDAV.",
       "baseUrl": "WebDAV Server URL",
       "baseUrlPlaceholder": "https://dav.example.com/dav/",
       "username": "WebDAV Account",
@@ -472,6 +472,9 @@
       "profile": "Sync Profile Name",
       "autoSync": "Auto Sync",
       "autoSyncHint": "When enabled, each database change triggers an automatic WebDAV upload.",
+      "syncCodexData": "Sync Codex Data",
+      "syncCodexDataHint": "Includes sessions, project state, goals, config.toml, and auth.json.",
+      "codexDataAuthWarning": "Codex sync includes auth.json. Your WebDAV storage will contain Codex login credentials.",
       "test": "Test Connection",
       "testing": "Testing...",
       "testSuccess": "Connection successful",
@@ -523,6 +526,7 @@
         "artifacts": "Contents",
         "legacyNotice": "A legacy remote path was detected. After restoring, the next upload will write to the new v2/db-v6 path.",
         "warning": "This will overwrite all local data and skill configurations",
+        "codexDataMerge": "Codex data will be merged with local sessions and backed up before conflicts are replaced.",
         "confirm": "Confirm Restore"
       },
       "confirmUpload": {
@@ -530,6 +534,7 @@
         "content": "The following will be synced to the WebDAV server:",
         "dbItem": "Database (all provider configs and data)",
         "skillsItem": "Skills (all custom skills)",
+        "codexDataItem": "Codex data (sessions, project state, goals, config.toml, auth.json)",
         "targetPath": "Target path",
         "existingData": "Existing cloud data",
         "deviceName": "Uploaded by",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -461,7 +461,7 @@
     },
     "webdavSync": {
       "title": "WebDAV クラウド同期",
-      "description": "WebDAV を使ってデバイス間でデータベースとスキル設定を同期します。",
+      "description": "WebDAV を使ってデバイス間でデータベース、スキル設定、任意の Codex データを同期します。",
       "baseUrl": "WebDAV サーバー URL",
       "baseUrlPlaceholder": "https://example.com/remote.php/dav/files/user",
       "username": "ユーザー名",
@@ -472,6 +472,9 @@
       "profile": "同期プロファイル名",
       "autoSync": "自動同期",
       "autoSyncHint": "有効にすると、データベース変更のたびに WebDAV へ自動アップロードします。",
+      "syncCodexData": "Codex データを同期",
+      "syncCodexDataHint": "セッション、プロジェクト状態、ゴール、config.toml、auth.json を含めます。",
+      "codexDataAuthWarning": "Codex 同期には auth.json が含まれます。WebDAV ストレージに Codex のログイン認証情報が保存されます。",
       "test": "接続テスト",
       "testing": "テスト中...",
       "testSuccess": "接続成功",
@@ -523,6 +526,7 @@
         "artifacts": "内容",
         "legacyNotice": "旧レイアウトのリモートパスを検出しました。復元後、次回のアップロードは新しい v2/db-v6 パスに書き込まれます。",
         "warning": "ローカルのすべてのデータとスキル設定が上書きされます",
+        "codexDataMerge": "Codex データはローカルセッションとマージされ、競合ファイルは置換前にバックアップされます。",
         "confirm": "復元を実行"
       },
       "confirmUpload": {
@@ -530,6 +534,7 @@
         "content": "以下の内容を WebDAV サーバーに同期します：",
         "dbItem": "データベース（すべてのプロバイダー設定とデータ）",
         "skillsItem": "スキル（すべてのカスタムスキル）",
+        "codexDataItem": "Codex データ（セッション、プロジェクト状態、ゴール、config.toml、auth.json）",
         "targetPath": "保存先パス",
         "existingData": "クラウドの既存データ",
         "deviceName": "アップロード元",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -461,7 +461,7 @@
     },
     "webdavSync": {
       "title": "WebDAV 雲端同步",
-      "description": "透過 WebDAV 在多裝置間同步資料庫和技能設定。",
+      "description": "透過 WebDAV 在多裝置間同步資料庫、技能設定和可選 Codex 資料。",
       "baseUrl": "WebDAV 伺服器位址",
       "baseUrlPlaceholder": "https://dav.jianguoyun.com/dav/",
       "username": "WebDAV 帳號",
@@ -472,6 +472,9 @@
       "profile": "同步設定名稱",
       "autoSync": "自動同步",
       "autoSyncHint": "開啟後每次資料庫變更都會自動上傳至 WebDAV。",
+      "syncCodexData": "同步 Codex 資料",
+      "syncCodexDataHint": "包含會話、專案狀態、目標、config.toml 和 auth.json。",
+      "codexDataAuthWarning": "Codex 同步會包含 auth.json，WebDAV 儲存空間中將保存 Codex 登入憑證。",
       "test": "測試連線",
       "testing": "測試中...",
       "testSuccess": "連線成功",
@@ -523,6 +526,7 @@
         "artifacts": "包含內容",
         "legacyNotice": "檢測到舊版雲端路徑。還原完成後，下次上傳將寫入新路徑 v2/db-v6。",
         "warning": "還原將覆寫本地所有資料和技能設定",
+        "codexDataMerge": "Codex 資料會與本機會話合併，衝突檔案替換前會先備份。",
         "confirm": "確認還原"
       },
       "confirmUpload": {
@@ -530,6 +534,7 @@
         "content": "將同步以下內容至 WebDAV 伺服器：",
         "dbItem": "資料庫（所有 Provider 設定和資料）",
         "skillsItem": "技能包（所有自訂技能）",
+        "codexDataItem": "Codex 資料（會話、專案狀態、目標、config.toml、auth.json）",
         "targetPath": "目標路徑",
         "existingData": "雲端已有資料",
         "deviceName": "上傳裝置",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -461,7 +461,7 @@
     },
     "webdavSync": {
       "title": "WebDAV 云同步",
-      "description": "通过 WebDAV 在多设备间同步数据库和技能配置。",
+      "description": "通过 WebDAV 在多设备间同步数据库、技能配置和可选 Codex 数据。",
       "baseUrl": "WebDAV 服务器地址",
       "baseUrlPlaceholder": "https://dav.jianguoyun.com/dav/",
       "username": "WebDAV 账户",
@@ -472,6 +472,9 @@
       "profile": "同步配置名",
       "autoSync": "自动同步",
       "autoSyncHint": "开启后每次数据库变更都会自动上传到 WebDAV。",
+      "syncCodexData": "同步 Codex 数据",
+      "syncCodexDataHint": "包含会话、项目状态、目标、config.toml 和 auth.json。",
+      "codexDataAuthWarning": "Codex 同步会包含 auth.json，WebDAV 存储中将保存 Codex 登录凭据。",
       "test": "测试连接",
       "testing": "测试中...",
       "testSuccess": "连接成功",
@@ -523,6 +526,7 @@
         "artifacts": "包含内容",
         "legacyNotice": "检测到旧版云端路径。恢复完成后，下次上传将写入新路径 v2/db-v6。",
         "warning": "恢复将覆盖本地所有数据和技能配置",
+        "codexDataMerge": "Codex 数据会与本机会话合并，冲突文件替换前会先备份。",
         "confirm": "确认恢复"
       },
       "confirmUpload": {
@@ -530,6 +534,7 @@
         "content": "将同步以下内容到 WebDAV 服务器：",
         "dbItem": "数据库（所有 Provider 配置和数据）",
         "skillsItem": "技能包（所有自定义技能）",
+        "codexDataItem": "Codex 数据（会话、项目状态、目标、config.toml、auth.json）",
         "targetPath": "目标路径",
         "existingData": "云端已有数据",
         "deviceName": "上传设备",

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -39,6 +39,7 @@ export const settingsSchema = z.object({
     .object({
       enabled: z.boolean().optional(),
       autoSync: z.boolean().optional(),
+      syncCodexData: z.boolean().optional(),
       baseUrl: z.string().trim().optional().or(z.literal("")),
       username: z.string().trim().optional().or(z.literal("")),
       password: z.string().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,6 +281,7 @@ export interface WebDavSyncStatus {
 export interface WebDavSyncSettings {
   enabled?: boolean;
   autoSync?: boolean;
+  syncCodexData?: boolean;
   baseUrl?: string;
   username?: string;
   password?: string;

--- a/tests/components/WebdavSyncSection.test.tsx
+++ b/tests/components/WebdavSyncSection.test.tsx
@@ -27,7 +27,9 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Button: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 vi.mock("@/components/ui/input", () => ({
@@ -94,6 +96,7 @@ const baseConfig: WebDavSyncSettings = {
   remoteRoot: "cc-switch-sync",
   profile: "default",
   autoSync: false,
+  syncCodexData: false,
   status: {},
 };
 
@@ -138,7 +141,9 @@ describe("WebdavSyncSection", () => {
       artifacts: ["db.sql", "skills.zip"],
     });
     settingsApiMock.webdavSyncUpload.mockResolvedValue({ status: "uploaded" });
-    settingsApiMock.webdavSyncDownload.mockResolvedValue({ status: "downloaded" });
+    settingsApiMock.webdavSyncDownload.mockResolvedValue({
+      status: "downloaded",
+    });
   });
 
   it("shows auto sync error callout when last auto sync failed", () => {
@@ -187,16 +192,22 @@ describe("WebdavSyncSection", () => {
   it("shows validation error when saving without base url", async () => {
     renderSection({ ...baseConfig, baseUrl: "" });
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
-    expect(toastErrorMock).toHaveBeenCalledWith("settings.webdavSync.missingUrl");
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "settings.webdavSync.missingUrl",
+    );
     expect(settingsApiMock.webdavSyncSaveSettings).not.toHaveBeenCalled();
   });
 
   it("saves settings and auto tests connection", async () => {
     renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -207,6 +218,7 @@ describe("WebdavSyncSection", () => {
         username: "alice",
         password: "",
         autoSync: false,
+        syncCodexData: false,
       }),
       false,
     );
@@ -226,7 +238,9 @@ describe("WebdavSyncSection", () => {
   it("preserves password only for the single post-save refresh", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -264,7 +278,9 @@ describe("WebdavSyncSection", () => {
   it("does not preserve password after a later external config refresh", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -304,7 +320,9 @@ describe("WebdavSyncSection", () => {
   it("does not submit a preserved password again when testing without touching it", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -316,7 +334,9 @@ describe("WebdavSyncSection", () => {
       </QueryClientProvider>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.test" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.test" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavTestConnection).toHaveBeenLastCalledWith(
@@ -342,12 +362,41 @@ describe("WebdavSyncSection", () => {
         screen.getByRole("switch", { name: "settings.webdavSync.autoSync" }),
       ).toHaveAttribute("aria-checked", "true");
     });
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledWith(
         expect.objectContaining({
           autoSync: true,
+        }),
+        false,
+      );
+    });
+  });
+
+  it("saves codex data sync as true after toggle", async () => {
+    renderSection(baseConfig);
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "settings.webdavSync.syncCodexData",
+      }),
+    );
+
+    expect(
+      screen.getByText("settings.webdavSync.codexDataAuthWarning"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
+
+    await waitFor(() => {
+      expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          syncCodexData: true,
         }),
         false,
       );
@@ -394,7 +443,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(
@@ -411,6 +462,20 @@ describe("WebdavSyncSection", () => {
     );
   });
 
+  it("shows codex data in upload confirmation when enabled", async () => {
+    renderSection({ ...baseConfig, syncCodexData: true });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.upload" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("settings.webdavSync.confirmUpload.codexDataItem"),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("blocks upload confirmation if form changes after dialog opens", async () => {
     renderSection(baseConfig);
 
@@ -418,7 +483,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.upload" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("cc-switch-sync"), {
@@ -446,7 +513,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(
@@ -463,6 +532,28 @@ describe("WebdavSyncSection", () => {
     );
   });
 
+  it("shows codex merge notice in download confirmation when remote includes codex data", async () => {
+    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({
+      deviceName: "My MacBook",
+      createdAt: "2026-02-01T10:00:00Z",
+      snapshotId: "snapshot-1",
+      version: 2,
+      compatible: true,
+      artifacts: ["db.sql", "skills.zip", "codex.zip"],
+    });
+    renderSection({ ...baseConfig, syncCodexData: true });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.download" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("settings.webdavSync.confirmDownload.codexDataMerge"),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("blocks download confirmation if form changes after dialog opens", async () => {
     renderSection(baseConfig);
 
@@ -470,7 +561,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.download" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("default"), {
@@ -491,7 +584,9 @@ describe("WebdavSyncSection", () => {
   });
 
   it("shows info when no remote snapshot is found for download", async () => {
-    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({ empty: true });
+    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({
+      empty: true,
+    });
     renderSection(baseConfig);
 
     fireEvent.click(
@@ -499,7 +594,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(toastInfoMock).toHaveBeenCalledWith("settings.webdavSync.noRemoteData");
+      expect(toastInfoMock).toHaveBeenCalledWith(
+        "settings.webdavSync.noRemoteData",
+      );
     });
     expect(settingsApiMock.webdavSyncDownload).not.toHaveBeenCalled();
   });
@@ -540,7 +637,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.download" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(


### PR DESCRIPTION
﻿## Summary
- add an optional WebDAV switch to sync full Codex data while keeping it off by default
- include auth.json, config.toml, sessions, archived sessions, state/goals SQLite data, and other Codex state needed for multi-device continuity
- exclude plugin caches, runtime caches, temp files, and SQLite sidecar files; merge sessions/SQLite data and rewrite local Codex paths on restore
- add settings UI, i18n copy, and focused tests for the new Codex sync option

## Notes
This supersedes the session-only approach in #3286 by syncing the broader Codex data set needed for multi-device use.

## Testing
- git diff --check
- tsc --noEmit
- vitest run tests/components/WebdavSyncSection.test.tsx
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo test --manifest-path src-tauri/Cargo.toml webdav
- built Windows NSIS installer: CC Switch_3.16.0_x64-setup.exe
