### PR TITLE
fix(usage): resolve per-app credentials for native balance/coding-plan queries

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -204,6 +204,29 @@ pub fn extract_codex_api_key(auth: Option<&Value>, config_text: Option<&str>) ->
         .or_else(|| config_text.and_then(extract_codex_experimental_bearer_token))
 }
 
+/// Extract the upstream base URL from a Codex `config.toml` string.
+///
+/// Prefers the active `[model_providers.<model_provider>].base_url`, falling
+/// back to a top-level `base_url` when no model provider is selected.
+pub fn extract_codex_base_url(config_text: &str) -> Option<String> {
+    let doc = config_text.parse::<toml::Value>().ok()?;
+
+    if let Some(active_provider) = doc.get("model_provider").and_then(|v| v.as_str()) {
+        if let Some(base_url) = doc
+            .get("model_providers")
+            .and_then(|providers| providers.get(active_provider))
+            .and_then(|provider| provider.get("base_url"))
+            .and_then(|v| v.as_str())
+        {
+            return Some(base_url.to_string());
+        }
+    }
+
+    doc.get("base_url")
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string)
+}
+
 pub fn codex_auth_has_login_material(auth: &Value) -> bool {
     let Some(obj) = auth.as_object() else {
         return false;

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -398,6 +398,14 @@ pub async fn queryProviderUsage(
     inner
 }
 
+/// Resolve `(base_url, api_key)` for native usage queries, delegating to the
+/// per-app resolver on `Provider`. Missing provider → empty credentials.
+fn resolve_native_credentials(app_type: &AppType, provider: Option<&Provider>) -> (String, String) {
+    provider
+        .map(|p| p.resolve_usage_credentials(app_type))
+        .unwrap_or_default()
+}
+
 async fn query_provider_usage_inner(
     state: &AppState,
     copilot_state: &CopilotAuthState,
@@ -455,25 +463,10 @@ async fn query_provider_usage_inner(
 
     // ── Coding Plan 专用路径 ──
     if template_type == TEMPLATE_TYPE_TOKEN_PLAN {
-        // 从供应商配置中提取 API Key 和 Base URL
-        let settings_config = provider
-            .map(|p| &p.settings_config)
-            .cloned()
-            .unwrap_or_default();
-        let env = settings_config.get("env");
-        let base_url = env
-            .and_then(|e| e.get("ANTHROPIC_BASE_URL"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let api_key = env
-            .and_then(|e| {
-                e.get("ANTHROPIC_AUTH_TOKEN")
-                    .or_else(|| e.get("ANTHROPIC_API_KEY"))
-            })
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        // 从供应商配置中提取 API Key 和 Base URL（按 app 区分存储格式）
+        let (base_url, api_key) = resolve_native_credentials(&app_type, provider);
 
-        let quota = crate::services::coding_plan::get_coding_plan_quota(base_url, api_key)
+        let quota = crate::services::coding_plan::get_coding_plan_quota(&base_url, &api_key)
             .await
             .map_err(|e| format!("Failed to query coding plan: {e}"))?;
 
@@ -515,24 +508,10 @@ async fn query_provider_usage_inner(
 
     // ── 官方余额查询路径 ──
     if template_type == TEMPLATE_TYPE_BALANCE {
-        let settings_config = provider
-            .map(|p| &p.settings_config)
-            .cloned()
-            .unwrap_or_default();
-        let env = settings_config.get("env");
-        let base_url = env
-            .and_then(|e| e.get("ANTHROPIC_BASE_URL"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let api_key = env
-            .and_then(|e| {
-                e.get("ANTHROPIC_AUTH_TOKEN")
-                    .or_else(|| e.get("ANTHROPIC_API_KEY"))
-            })
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        // 按 app 区分的凭据存储格式提取 Base URL 与 API Key
+        let (base_url, api_key) = resolve_native_credentials(&app_type, provider);
 
-        return crate::services::balance::get_balance(base_url, api_key)
+        return crate::services::balance::get_balance(&base_url, &api_key)
             .await
             .map_err(|e| format!("Failed to query balance: {e}"));
     }
@@ -955,5 +934,38 @@ mod import_claude_desktop_tests {
                 .label_override,
             None
         );
+    }
+}
+
+#[cfg(test)]
+mod native_query_credentials_tests {
+    use super::resolve_native_credentials;
+    use crate::app_config::AppType;
+    use crate::provider::Provider;
+    use serde_json::json;
+
+    #[test]
+    fn delegates_to_provider_for_codex() {
+        let provider = Provider::with_id(
+            "test".to_string(),
+            "Test".to_string(),
+            json!({
+                "auth": { "OPENAI_API_KEY": "sk-codex" },
+                "config": "model_provider = \"deepseek\"\n\
+                           [model_providers.deepseek]\n\
+                           base_url = \"https://api.deepseek.com\"\n",
+            }),
+            None,
+        );
+        let (base_url, api_key) = resolve_native_credentials(&AppType::Codex, Some(&provider));
+        assert_eq!(base_url, "https://api.deepseek.com");
+        assert_eq!(api_key, "sk-codex");
+    }
+
+    #[test]
+    fn missing_provider_yields_empty() {
+        let (base_url, api_key) = resolve_native_credentials(&AppType::Codex, None);
+        assert!(base_url.is_empty());
+        assert!(api_key.is_empty());
     }
 }

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -171,7 +171,8 @@ impl Provider {
             }
             // Claude and Claude Desktop both use the Anthropic-style env map, keeping
             // the OpenRouter/Google key fallbacks the JS-script path relies on.
-            _ => {
+            // Listed explicitly (not `_`) so a new AppType fails to compile here.
+            AppType::Claude | AppType::ClaudeDesktop => {
                 let env = settings.get("env");
                 let base_url = str_at(env.and_then(|e| e.get("ANTHROPIC_BASE_URL")));
                 let api_key = str_at(env.and_then(|e| {

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -129,6 +129,24 @@ impl Provider {
         let str_at =
             |value: Option<&Value>| value.and_then(|v| v.as_str()).unwrap_or("").to_string();
 
+        // First present, non-empty string among `keys`, mirroring the frontend's
+        // `a || b || c` — JS `||` skips empty strings, and presets seed fields like
+        // `ANTHROPIC_AUTH_TOKEN` as present-but-empty placeholders, so a plain
+        // `.get().or_else()` chain (which only skips *absent* keys) would stop short.
+        fn first_non_empty(env: Option<&Value>, keys: &[&str]) -> String {
+            let Some(env) = env else {
+                return String::new();
+            };
+            for key in keys {
+                if let Some(s) = env.get(key).and_then(|v| v.as_str()) {
+                    if !s.is_empty() {
+                        return s.to_string();
+                    }
+                }
+            }
+            String::new()
+        }
+
         let (base_url, api_key) = match app_type {
             // Codex keeps its key in `auth.OPENAI_API_KEY` and its base URL
             // inside a TOML `config` string, not in an `env` map.
@@ -146,9 +164,7 @@ impl Provider {
             AppType::Gemini => {
                 let env = settings.get("env");
                 let base_url = str_at(env.and_then(|e| e.get("GOOGLE_GEMINI_BASE_URL")));
-                let api_key = str_at(
-                    env.and_then(|e| e.get("GEMINI_API_KEY").or_else(|| e.get("GOOGLE_API_KEY"))),
-                );
+                let api_key = first_non_empty(env, &["GEMINI_API_KEY", "GOOGLE_API_KEY"]);
                 (base_url, api_key)
             }
             // Hermes (config.yaml) flattens credentials at the top level, snake_case.
@@ -175,12 +191,15 @@ impl Provider {
             AppType::Claude | AppType::ClaudeDesktop => {
                 let env = settings.get("env");
                 let base_url = str_at(env.and_then(|e| e.get("ANTHROPIC_BASE_URL")));
-                let api_key = str_at(env.and_then(|e| {
-                    e.get("ANTHROPIC_AUTH_TOKEN")
-                        .or_else(|| e.get("ANTHROPIC_API_KEY"))
-                        .or_else(|| e.get("OPENROUTER_API_KEY"))
-                        .or_else(|| e.get("GOOGLE_API_KEY"))
-                }));
+                let api_key = first_non_empty(
+                    env,
+                    &[
+                        "ANTHROPIC_AUTH_TOKEN",
+                        "ANTHROPIC_API_KEY",
+                        "OPENROUTER_API_KEY",
+                        "GOOGLE_API_KEY",
+                    ],
+                );
                 (base_url, api_key)
             }
         };
@@ -1302,6 +1321,36 @@ mod tests {
         let (base_url, api_key) = p.resolve_usage_credentials(&AppType::Gemini);
         assert_eq!(base_url, "https://generativelanguage.googleapis.com");
         assert_eq!(api_key, "g-legacy");
+    }
+
+    #[test]
+    fn resolve_credentials_claude_skips_empty_primary_key() {
+        // Presets seed ANTHROPIC_AUTH_TOKEN as a present-but-empty placeholder.
+        // The fallback chain must skip empty values (matching the frontend's
+        // `a || b` semantics), not just absent keys.
+        let p = provider_with(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://openrouter.ai/api/v1",
+                "ANTHROPIC_AUTH_TOKEN": "",
+                "ANTHROPIC_API_KEY": "",
+                "OPENROUTER_API_KEY": "sk-or",
+            }
+        }));
+        let (_, api_key) = p.resolve_usage_credentials(&AppType::Claude);
+        assert_eq!(api_key, "sk-or");
+    }
+
+    #[test]
+    fn resolve_credentials_gemini_skips_empty_primary_key() {
+        let p = provider_with(json!({
+            "env": {
+                "GOOGLE_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com",
+                "GEMINI_API_KEY": "",
+                "GOOGLE_API_KEY": "g-real",
+            }
+        }));
+        let (_, api_key) = p.resolve_usage_credentials(&AppType::Gemini);
+        assert_eq!(api_key, "g-real");
     }
 
     #[test]

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -107,6 +107,88 @@ impl Provider {
             .map(|s| s.enabled)
             .unwrap_or(false)
     }
+
+    /// Resolve `(base_url, api_key)` for native usage queries (balance /
+    /// coding-plan) from the stored provider config.
+    ///
+    /// Each app persists credentials in a different shape, so callers must pass
+    /// the owning app type. This mirrors the frontend `getProviderCredentials`
+    /// in `UsageScriptModal.tsx`.
+    ///
+    /// TODO: the env-only helpers in `services/provider/usage.rs`
+    /// (`extract_api_key_from_provider` / `extract_base_url_from_provider`)
+    /// duplicate this per-app logic on the JS-script path and could delegate
+    /// here in a follow-up to remove the remaining copy.
+    pub fn resolve_usage_credentials(
+        &self,
+        app_type: &crate::app_config::AppType,
+    ) -> (String, String) {
+        use crate::app_config::AppType;
+
+        let settings = &self.settings_config;
+        let str_at =
+            |value: Option<&Value>| value.and_then(|v| v.as_str()).unwrap_or("").to_string();
+
+        let (base_url, api_key) = match app_type {
+            // Codex keeps its key in `auth.OPENAI_API_KEY` and its base URL
+            // inside a TOML `config` string, not in an `env` map.
+            AppType::Codex => {
+                let auth = settings.get("auth");
+                let config_text = settings.get("config").and_then(|v| v.as_str());
+                let api_key = crate::codex_config::extract_codex_api_key(auth, config_text)
+                    .unwrap_or_default();
+                let base_url = config_text
+                    .and_then(crate::codex_config::extract_codex_base_url)
+                    .unwrap_or_default();
+                (base_url, api_key)
+            }
+            // Gemini uses Google-specific env keys (with a legacy GOOGLE_API_KEY fallback).
+            AppType::Gemini => {
+                let env = settings.get("env");
+                let base_url = str_at(env.and_then(|e| e.get("GOOGLE_GEMINI_BASE_URL")));
+                let api_key = str_at(
+                    env.and_then(|e| e.get("GEMINI_API_KEY").or_else(|| e.get("GOOGLE_API_KEY"))),
+                );
+                (base_url, api_key)
+            }
+            // Hermes (config.yaml) flattens credentials at the top level, snake_case.
+            AppType::Hermes => (
+                str_at(settings.get("base_url")),
+                str_at(settings.get("api_key")),
+            ),
+            // OpenClaw (openclaw.json) flattens credentials at the top level, camelCase.
+            AppType::OpenClaw => (
+                str_at(settings.get("baseUrl")),
+                str_at(settings.get("apiKey")),
+            ),
+            // OpenCode (OMO) nests credentials under `options` (the SDK options object).
+            AppType::OpenCode => {
+                let options = settings.get("options");
+                (
+                    str_at(options.and_then(|o| o.get("baseURL"))),
+                    str_at(options.and_then(|o| o.get("apiKey"))),
+                )
+            }
+            // Claude and Claude Desktop both use the Anthropic-style env map, keeping
+            // the OpenRouter/Google key fallbacks the JS-script path relies on.
+            _ => {
+                let env = settings.get("env");
+                let base_url = str_at(env.and_then(|e| e.get("ANTHROPIC_BASE_URL")));
+                let api_key = str_at(env.and_then(|e| {
+                    e.get("ANTHROPIC_AUTH_TOKEN")
+                        .or_else(|| e.get("ANTHROPIC_API_KEY"))
+                        .or_else(|| e.get("OPENROUTER_API_KEY"))
+                        .or_else(|| e.get("GOOGLE_API_KEY"))
+                }));
+                (base_url, api_key)
+            }
+        };
+
+        // Normalize like the JS-script path (extract_base_url_from_provider) so a
+        // future delegation from services/provider/usage.rs is behavior-preserving
+        // and `{{baseUrl}}/path` concatenation never produces a double slash.
+        (base_url.trim_end_matches('/').to_string(), api_key)
+    }
 }
 
 /// 供应商管理器
@@ -1149,5 +1231,167 @@ mod tests {
 
         assert!(toml.contains("base_url = \"https://example.com/openai\""));
         assert!(!toml.contains("https://example.com/openai/v1"));
+    }
+
+    // ── resolve_usage_credentials (per-app credential extraction) ──
+
+    use crate::app_config::AppType;
+
+    fn provider_with(settings_config: serde_json::Value) -> Provider {
+        Provider::with_id("p".to_string(), "P".to_string(), settings_config, None)
+    }
+
+    #[test]
+    fn resolve_credentials_claude_env() {
+        let p = provider_with(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+                "ANTHROPIC_AUTH_TOKEN": "sk-claude",
+            }
+        }));
+        assert_eq!(
+            p.resolve_usage_credentials(&AppType::Claude),
+            (
+                "https://api.deepseek.com/anthropic".to_string(),
+                "sk-claude".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_credentials_claude_openrouter_fallback() {
+        // OpenRouter-on-Claude keeps its key in OPENROUTER_API_KEY; the superset
+        // fallback must still find it (regression guard for the per-app refactor).
+        let p = provider_with(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://openrouter.ai/api/v1",
+                "OPENROUTER_API_KEY": "sk-or",
+            }
+        }));
+        let (base_url, api_key) = p.resolve_usage_credentials(&AppType::Claude);
+        assert_eq!(base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(api_key, "sk-or");
+    }
+
+    #[test]
+    fn resolve_credentials_codex_auth_and_toml() {
+        let p = provider_with(json!({
+            "auth": { "OPENAI_API_KEY": "sk-codex" },
+            "config": "model_provider = \"deepseek\"\n\
+                       [model_providers.deepseek]\n\
+                       base_url = \"https://api.deepseek.com\"\n",
+        }));
+        assert_eq!(
+            p.resolve_usage_credentials(&AppType::Codex),
+            (
+                "https://api.deepseek.com".to_string(),
+                "sk-codex".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_credentials_gemini_env_with_google_fallback() {
+        let p = provider_with(json!({
+            "env": {
+                "GOOGLE_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com",
+                "GOOGLE_API_KEY": "g-legacy",
+            }
+        }));
+        let (base_url, api_key) = p.resolve_usage_credentials(&AppType::Gemini);
+        assert_eq!(base_url, "https://generativelanguage.googleapis.com");
+        assert_eq!(api_key, "g-legacy");
+    }
+
+    #[test]
+    fn resolve_credentials_hermes_snake_case() {
+        let p = provider_with(json!({
+            "base_url": "https://api.deepseek.com",
+            "api_key": "sk-hermes",
+        }));
+        assert_eq!(
+            p.resolve_usage_credentials(&AppType::Hermes),
+            (
+                "https://api.deepseek.com".to_string(),
+                "sk-hermes".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_credentials_openclaw_camel_case() {
+        let p = provider_with(json!({
+            "baseUrl": "https://api.deepseek.com",
+            "apiKey": "sk-openclaw",
+        }));
+        assert_eq!(
+            p.resolve_usage_credentials(&AppType::OpenClaw),
+            (
+                "https://api.deepseek.com".to_string(),
+                "sk-openclaw".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_credentials_opencode_options() {
+        // OpenCode (OMO) nests creds under options.{baseURL,apiKey}; useOpencodeFormState
+        // writes config.options.apiKey, so the stored provider keeps them there.
+        let p = provider_with(json!({
+            "npm": "@ai-sdk/openai-compatible",
+            "options": {
+                "baseURL": "https://api.deepseek.com/v1",
+                "apiKey": "sk-opencode",
+                "setCacheKey": true,
+            }
+        }));
+        assert_eq!(
+            p.resolve_usage_credentials(&AppType::OpenCode),
+            (
+                "https://api.deepseek.com/v1".to_string(),
+                "sk-opencode".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_credentials_claude_desktop_uses_env() {
+        // ClaudeDesktop persists the Anthropic env shape (ClaudeDesktopProviderForm
+        // reads env.ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN), so it resolves via
+        // the default env branch — it is NOT unsupported.
+        let p = provider_with(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+                "ANTHROPIC_AUTH_TOKEN": "sk-desktop",
+            }
+        }));
+        assert_eq!(
+            p.resolve_usage_credentials(&AppType::ClaudeDesktop),
+            (
+                "https://api.deepseek.com/anthropic".to_string(),
+                "sk-desktop".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_credentials_trims_trailing_slash_on_base_url() {
+        let p = provider_with(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic/",
+                "ANTHROPIC_AUTH_TOKEN": "sk-claude",
+            }
+        }));
+        let (base_url, _) = p.resolve_usage_credentials(&AppType::Claude);
+        assert_eq!(base_url, "https://api.deepseek.com/anthropic");
+    }
+
+    #[test]
+    fn resolve_credentials_missing_fields_yield_empty() {
+        let p = provider_with(json!({}));
+        assert_eq!(
+            p.resolve_usage_credentials(&AppType::Claude),
+            (String::new(), String::new())
+        );
     }
 }

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -392,22 +392,9 @@ fn extract_codex_model_from_toml(config_text: &str) -> Option<String> {
 }
 
 fn extract_codex_base_url_from_toml(config_text: &str) -> Option<String> {
-    let doc = config_text.parse::<TomlValue>().ok()?;
-
-    if let Some(active_provider) = doc.get("model_provider").and_then(|v| v.as_str()) {
-        if let Some(base_url) = doc
-            .get("model_providers")
-            .and_then(|providers| providers.get(active_provider))
-            .and_then(|provider| provider.get("base_url"))
-            .and_then(|v| v.as_str())
-        {
-            return Some(base_url.to_string());
-        }
-    }
-
-    doc.get("base_url")
-        .and_then(|v| v.as_str())
-        .map(ToString::to_string)
+    // Canonical parser lives in codex_config; keep this thin alias so the
+    // proxy hot path and the usage-credential resolver share one implementation.
+    crate::codex_config::extract_codex_base_url(config_text)
 }
 
 impl CodexAdapter {

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -161,68 +161,80 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
     apiKey: string | undefined;
     baseUrl: string | undefined;
   } => {
-    try {
-      const config = provider.settingsConfig;
-      if (!config) return { apiKey: undefined, baseUrl: undefined };
+    const trimTrailingSlash = (url: string | undefined) =>
+      typeof url === "string" ? url.replace(/\/+$/, "") : url;
+    const raw = ((): {
+      apiKey: string | undefined;
+      baseUrl: string | undefined;
+    } => {
+      try {
+        const config = provider.settingsConfig;
+        if (!config) return { apiKey: undefined, baseUrl: undefined };
 
-      // 处理不同应用的配置格式
-      if (appId === "claude" || appId === "claude-desktop") {
-        // Claude / Claude Desktop: { env: { ANTHROPIC_AUTH_TOKEN | ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL } }
-        // Key fallbacks mirror the backend resolver (Provider::resolve_usage_credentials).
-        const env = (config as any).env || {};
-        return {
-          apiKey:
-            env.ANTHROPIC_AUTH_TOKEN ||
-            env.ANTHROPIC_API_KEY ||
-            env.OPENROUTER_API_KEY ||
-            env.GOOGLE_API_KEY,
-          baseUrl: env.ANTHROPIC_BASE_URL,
-        };
-      } else if (appId === "codex") {
-        // Codex: { auth: { OPENAI_API_KEY }, config: TOML string with base_url }
-        const auth = (config as any).auth || {};
-        const configToml = (config as any).config || "";
-        const apiKey =
-          typeof auth.OPENAI_API_KEY === "string" && auth.OPENAI_API_KEY.trim()
-            ? auth.OPENAI_API_KEY
-            : extractCodexExperimentalBearerToken(configToml);
-        return {
-          apiKey,
-          baseUrl: extractCodexBaseUrl(configToml),
-        };
-      } else if (appId === "gemini") {
-        // Gemini: { env: { GEMINI_API_KEY, GOOGLE_GEMINI_BASE_URL } }
-        // Key fallback mirrors the backend resolver (Provider::resolve_usage_credentials).
-        const env = (config as any).env || {};
-        return {
-          apiKey: env.GEMINI_API_KEY || env.GOOGLE_API_KEY,
-          baseUrl: env.GOOGLE_GEMINI_BASE_URL,
-        };
-      } else if (appId === "hermes") {
-        // Hermes: settingsConfig 顶层扁平（snake_case，对应 config.yaml）
-        return {
-          apiKey: (config as any).api_key,
-          baseUrl: (config as any).base_url,
-        };
-      } else if (appId === "openclaw") {
-        // OpenClaw: settingsConfig 顶层扁平（camelCase，对应 openclaw.json）
-        return {
-          apiKey: (config as any).apiKey,
-          baseUrl: (config as any).baseUrl,
-        };
-      } else if (appId === "opencode") {
-        // OpenCode (OMO): 凭据嵌在 options.{baseURL, apiKey}（SDK options 对象）
-        const options = (config as any).options || {};
-        return {
-          apiKey: options.apiKey,
-          baseUrl: options.baseURL,
-        };
+        // 处理不同应用的配置格式
+        if (appId === "claude" || appId === "claude-desktop") {
+          // Claude / Claude Desktop: { env: { ANTHROPIC_AUTH_TOKEN | ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL } }
+          // Key fallbacks mirror the backend resolver (Provider::resolve_usage_credentials).
+          const env = (config as any).env || {};
+          return {
+            apiKey:
+              env.ANTHROPIC_AUTH_TOKEN ||
+              env.ANTHROPIC_API_KEY ||
+              env.OPENROUTER_API_KEY ||
+              env.GOOGLE_API_KEY,
+            baseUrl: env.ANTHROPIC_BASE_URL,
+          };
+        } else if (appId === "codex") {
+          // Codex: { auth: { OPENAI_API_KEY }, config: TOML string with base_url }
+          const auth = (config as any).auth || {};
+          const configToml = (config as any).config || "";
+          const apiKey =
+            typeof auth.OPENAI_API_KEY === "string" &&
+            auth.OPENAI_API_KEY.trim()
+              ? auth.OPENAI_API_KEY
+              : extractCodexExperimentalBearerToken(configToml);
+          return {
+            apiKey,
+            baseUrl: extractCodexBaseUrl(configToml),
+          };
+        } else if (appId === "gemini") {
+          // Gemini: { env: { GEMINI_API_KEY, GOOGLE_GEMINI_BASE_URL } }
+          // Key fallback mirrors the backend resolver (Provider::resolve_usage_credentials).
+          const env = (config as any).env || {};
+          return {
+            apiKey: env.GEMINI_API_KEY || env.GOOGLE_API_KEY,
+            baseUrl: env.GOOGLE_GEMINI_BASE_URL,
+          };
+        } else if (appId === "hermes") {
+          // Hermes: settingsConfig 顶层扁平（snake_case，对应 config.yaml）
+          return {
+            apiKey: (config as any).api_key,
+            baseUrl: (config as any).base_url,
+          };
+        } else if (appId === "openclaw") {
+          // OpenClaw: settingsConfig 顶层扁平（camelCase，对应 openclaw.json）
+          return {
+            apiKey: (config as any).apiKey,
+            baseUrl: (config as any).baseUrl,
+          };
+        } else if (appId === "opencode") {
+          // OpenCode (OMO): 凭据嵌在 options.{baseURL, apiKey}（SDK options 对象）
+          const options = (config as any).options || {};
+          return {
+            apiKey: options.apiKey,
+            baseUrl: options.baseURL,
+          };
+        }
+        return { apiKey: undefined, baseUrl: undefined };
+      } catch (error) {
+        console.error("Failed to extract provider credentials:", error);
+        return { apiKey: undefined, baseUrl: undefined };
       }
-      return { apiKey: undefined, baseUrl: undefined };
-    } catch (error) {
-      console.error("Failed to extract provider credentials:", error);
-      return { apiKey: undefined, baseUrl: undefined };
-    }
+    })();
+    // Trim the trailing slash to mirror the backend resolver
+    // (Provider::resolve_usage_credentials), so `{{baseUrl}}/path` never
+    // produces a double slash regardless of which path runs the query.
+    return { apiKey: raw.apiKey, baseUrl: trimTrailingSlash(raw.baseUrl) };
   };
 
   const providerCredentials = getProviderCredentials();

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -166,11 +166,16 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
       if (!config) return { apiKey: undefined, baseUrl: undefined };
 
       // 处理不同应用的配置格式
-      if (appId === "claude") {
-        // Claude: { env: { ANTHROPIC_AUTH_TOKEN | ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL } }
+      if (appId === "claude" || appId === "claude-desktop") {
+        // Claude / Claude Desktop: { env: { ANTHROPIC_AUTH_TOKEN | ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL } }
+        // Key fallbacks mirror the backend resolver (Provider::resolve_usage_credentials).
         const env = (config as any).env || {};
         return {
-          apiKey: env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_API_KEY,
+          apiKey:
+            env.ANTHROPIC_AUTH_TOKEN ||
+            env.ANTHROPIC_API_KEY ||
+            env.OPENROUTER_API_KEY ||
+            env.GOOGLE_API_KEY,
           baseUrl: env.ANTHROPIC_BASE_URL,
         };
       } else if (appId === "codex") {
@@ -187,9 +192,10 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
         };
       } else if (appId === "gemini") {
         // Gemini: { env: { GEMINI_API_KEY, GOOGLE_GEMINI_BASE_URL } }
+        // Key fallback mirrors the backend resolver (Provider::resolve_usage_credentials).
         const env = (config as any).env || {};
         return {
-          apiKey: env.GEMINI_API_KEY,
+          apiKey: env.GEMINI_API_KEY || env.GOOGLE_API_KEY,
           baseUrl: env.GOOGLE_GEMINI_BASE_URL,
         };
       } else if (appId === "hermes") {
@@ -203,6 +209,13 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
         return {
           apiKey: (config as any).apiKey,
           baseUrl: (config as any).baseUrl,
+        };
+      } else if (appId === "opencode") {
+        // OpenCode (OMO): 凭据嵌在 options.{baseURL, apiKey}（SDK options 对象）
+        const options = (config as any).options || {};
+        return {
+          apiKey: options.apiKey,
+          baseUrl: options.baseURL,
         };
       }
       return { apiKey: undefined, baseUrl: undefined };


### PR DESCRIPTION
## Summary / 概述

The native usage-query paths (official **balance** + **coding-plan** templates) resolved provider credentials **only** from `env.ANTHROPIC_*`. That matches Claude providers, but every other app stores credentials in a different shape:

- **Codex** — key in `auth.OPENAI_API_KEY`, base URL inside the TOML `config` string
- **Hermes / OpenClaw** — flattened at the top level (`base_url`/`api_key`, `baseUrl`/`apiKey`)
- **OpenCode** — nested under `options.{baseURL, apiKey}`

So the card "refresh usage" / auto-query returned empty credentials and failed (`查询失败`) for those apps, even though the config-page "Test" button worked — because the frontend `getProviderCredentials` already extracts per-app. This PR removes that front/back asymmetry.

## Related Issue / 关联 Issue

Fixes #2625
Fixes #3100
Fixed #3358 
Likely also resolves #3158 (Codex `查询失败`; the report lacks reproduction detail, but the Codex native query was broken for the same root cause).

#3100 additionally mentions a `Hermes provider is missing api_mode field` health-check warning. That is unrelated to credential resolution and is **not** addressed here.

## Screenshots / 截图

Codex → DeepSeek provider card, native balance query (the "refresh usage" button). The Hermes / OpenClaw reports in #3100 / #2625 share the identical root cause and fix.

| Before / 修改前 (`查询失败`) | After / 修改后 (`剩余: 48.12 CNY`) |
|---|---|
|<img width="675" height="450" alt="before" src="https://github.com/user-attachments/assets/aeb184cb-8fda-4daa-a6cc-18616338ef58" /> | <img width="675" height="450" alt="after" src="https://github.com/user-attachments/assets/28da36f3-2341-4453-8d0b-486e9f51af1b" /> |

## Approach

- Add a single per-app resolver `Provider::resolve_usage_credentials(app_type) -> (base_url, api_key)` that mirrors the frontend `getProviderCredentials`, and route **both** native branches (`balance`, `token_plan`) in `query_provider_usage_inner` through it.
- Add `codex_config::extract_codex_base_url` as the **canonical** Codex `config.toml` base-URL parser (next to the existing `extract_codex_api_key`), and make the proxy adapter's private `extract_codex_base_url_from_toml` delegate to it — removing a byte-for-byte duplicate instead of adding a third copy.
- Trim a trailing `/` from the base URL (matching the JS-script path's `extract_base_url_from_provider`) so the resolver is a behavior-preserving superset.
- Align the frontend `getProviderCredentials` to also cover **OpenCode** and **Claude Desktop**, and to use the same `OPENROUTER_API_KEY` / `GOOGLE_API_KEY` key fallbacks as the backend, so the "Test" button and the live query stay in lockstep across all apps.

## Scope

This PR fixes the **native** query path (balance / coding-plan) and its matching frontend extraction. The JS-script usage path (`services/provider/usage.rs`) keeps its own env-only copy of this logic (`extract_api_key_from_provider` / `extract_base_url_from_provider`) and is intentionally **left untouched** to keep the change single-purpose and to avoid colliding with the in-flight #1479 / #2031, which already target that path. `resolve_usage_credentials` is written so those helpers can delegate to it later (a `TODO` marks the seam). Happy to send that consolidation as a separate PR if you'd like it.

## Tests

New unit tests in `src-tauri/src/provider.rs` cover the resolver for every app shape (Claude, Claude Desktop, Codex, Gemini, Hermes, OpenClaw, OpenCode), the OpenRouter/Google key fallbacks, trailing-slash trimming, empty-primary-field fallback, and the all-missing case; `src-tauri/src/commands/provider.rs` covers the `None`-provider path and delegation.

```
cargo test  --manifest-path src-tauri/Cargo.toml --lib            -> all pass*
cargo fmt   --manifest-path src-tauri/Cargo.toml --check          -> clean
cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings  -> clean for changed files
pnpm typecheck     -> pass
pnpm format:check  -> pass
pnpm test:unit     -> 280 pass*
```

\* Built and tested on Windows. One pre-existing OpenClaw session test and two `App.test.tsx` integration tests fail **only** under the full local run on Windows (temp-path JSON escaping / parallel-load flakiness); they are unrelated to this change and reproduce identically on a clean checkout (verified via `git stash`). They pass in isolation and on Linux CI.

## Manual verification

Built a local release bundle and verified on Windows 11:

- **Codex -> DeepSeek**: card "refresh usage" now returns the balance (previously `查询失败`); the config-page "Test" button still works.
- Confirmed the front/back credential extraction now matches for OpenCode and Claude Desktop.

## Notes for review

- `resolve_usage_credentials` lives on `Provider` because `Provider` owns `settings_config`. Every `AppType` has an explicit match arm — Claude and Claude Desktop share one (both Anthropic env shape), and OpenCode/Codex/Gemini/Hermes/OpenClaw each get their own; there is **no `_` catch-all**, so a new `AppType` fails to compile here until it's handled. The earlier comment that called Claude Desktop "unsupported" was wrong and is corrected — it resolves via the env branch.
- The api-key fallback chains use first-present-**non-empty** semantics (a `first_non_empty` helper), matching the frontend's `a || b` (JS `||` skips empty strings). Presets seed fields like `ANTHROPIC_AUTH_TOKEN` as present-but-empty placeholders, so skipping only *absent* keys (a plain `.get().or_else()` chain) would still resolve to an empty key on the native path while the frontend found the real one (e.g. OpenRouter-on-Claude) — the same Test-works / refresh-fails divergence this PR removes. Tests cover empty-primary + populated-fallback for Claude and Gemini.
- This deliberately **preserves** the `OPENROUTER_API_KEY` / `GOOGLE_API_KEY` key fallbacks (and adds `GOOGLE_API_KEY` to Gemini) on both sides, so it does **not** regress OpenRouter-on-Claude / legacy-Gemini configs.
- The trailing-slash trim is new for the native path but inert there (`balance.rs` / `coding_plan.rs` detect providers via substring `contains` and never concatenate `base_url`); it is included so a future `usage.rs` delegation is behavior-preserving.
- One residual, pre-existing asymmetry is left as-is: the JS `extractCodexBaseUrl` has a malformed-TOML recovery fallback that the strict `toml`-parse backend does not. For well-formed `config.toml` they agree; only broken TOML could diverge. Out of scope here.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 (N/A: no user-facing text changes)
