### PR TITLE
feat(usage): display output tokens per second (TPS) in RequestLogTable

### DIFF
--- a/src/components/usage/RequestDetailPanel.tsx
+++ b/src/components/usage/RequestDetailPanel.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/dialog";
 import { useRequestDetail } from "@/lib/query/usage";
 import { getFreshInputTokens, isUnpricedUsage } from "@/types/usage";
+import { formatOutputTokensPerSecond } from "./format";
 
 interface RequestDetailPanelProps {
   requestId: string;
@@ -56,6 +57,7 @@ export function RequestDetailPanel({
   const freshInput = getFreshInputTokens(request);
   const isCacheInclusive = request.inputTokens !== freshInput;
   const unpriced = isUnpricedUsage(request);
+  const outputTps = formatOutputTokensPerSecond(request);
 
   return (
     <Dialog open onOpenChange={onClose}>
@@ -157,14 +159,9 @@ export function RequestDetailPanel({
                 </dt>
                 <dd className="font-mono">
                   {request.outputTokens.toLocaleString()}
-                  {request.latencyMs > 0 && request.outputTokens > 0 && (
+                  {outputTps != null && (
                     <span className="ml-2 text-xs text-muted-foreground font-normal">
-                      (
-                      {(() => {
-                        const rawTps = request.outputTokens / (request.latencyMs / 1000);
-                        return rawTps >= 1 ? Math.round(rawTps).toString() : rawTps.toFixed(1);
-                      })()}
-                      tps)
+                      ({outputTps} tps)
                     </span>
                   )}
                 </dd>

--- a/src/components/usage/RequestDetailPanel.tsx
+++ b/src/components/usage/RequestDetailPanel.tsx
@@ -157,6 +157,16 @@ export function RequestDetailPanel({
                 </dt>
                 <dd className="font-mono">
                   {request.outputTokens.toLocaleString()}
+                  {request.latencyMs > 0 && request.outputTokens > 0 && (
+                    <span className="ml-2 text-xs text-muted-foreground font-normal">
+                      (
+                      {(() => {
+                        const rawTps = request.outputTokens / (request.latencyMs / 1000);
+                        return rawTps >= 1 ? Math.round(rawTps).toString() : rawTps.toFixed(1);
+                      })()}
+                      tps)
+                    </span>
+                  )}
                 </dd>
               </div>
               <div>

--- a/src/components/usage/RequestLogTable.tsx
+++ b/src/components/usage/RequestLogTable.tsx
@@ -367,8 +367,21 @@ export function RequestLogTable({
                             </div>
                           )}
                         </TableCell>
-                        <TableCell className="text-center">
-                          {fmtInt(log.outputTokens, locale)}
+                        <TableCell className="text-center px-1.5">
+                          <div className="tabular-nums">
+                            {fmtInt(log.outputTokens, locale)}
+                            {(() => {
+                              if (!log.latencyMs || log.outputTokens <= 0) return null;
+                              const rawTps = log.outputTokens / (log.latencyMs / 1000);
+                              if (rawTps <= 0) return null;
+                              const tpsStr = rawTps >= 1 ? Math.round(rawTps).toString() : rawTps.toFixed(1);
+                              return (
+                                <span className="text-muted-foreground text-xs">
+                                  /{tpsStr} tps
+                                </span>
+                              );
+                            })()}
+                          </div>
                         </TableCell>
                         <TableCell className="text-center px-1.5">
                           <div

--- a/src/components/usage/RequestLogTable.tsx
+++ b/src/components/usage/RequestLogTable.tsx
@@ -28,6 +28,7 @@ import {
 import { ChevronLeft, ChevronRight, Search, X } from "lucide-react";
 import { UsageDateRangePicker } from "./UsageDateRangePicker";
 import {
+  formatOutputTokensPerSecond,
   fmtInt,
   fmtUsd,
   getLocaleFromLanguage,
@@ -371,10 +372,8 @@ export function RequestLogTable({
                           <div className="tabular-nums">
                             {fmtInt(log.outputTokens, locale)}
                             {(() => {
-                              if (!log.latencyMs || log.outputTokens <= 0) return null;
-                              const rawTps = log.outputTokens / (log.latencyMs / 1000);
-                              if (rawTps <= 0) return null;
-                              const tpsStr = rawTps >= 1 ? Math.round(rawTps).toString() : rawTps.toFixed(1);
+                              const tpsStr = formatOutputTokensPerSecond(log);
+                              if (tpsStr == null) return null;
                               return (
                                 <span className="text-muted-foreground text-xs">
                                   /{tpsStr} tps

--- a/src/components/usage/format.ts
+++ b/src/components/usage/format.ts
@@ -31,6 +31,52 @@ export function fmtUsd(
   return `$${num.toFixed(digits)}`;
 }
 
+interface OutputTokensPerSecondInput {
+  outputTokens: unknown;
+  latencyMs: unknown;
+  firstTokenMs?: unknown;
+  durationMs?: unknown;
+}
+
+function getOutputGenerationDurationMs(
+  log: OutputTokensPerSecondInput,
+): number | null {
+  const durationMs = parseFiniteNumber(log.durationMs);
+  if (durationMs != null && durationMs > 0) return durationMs;
+
+  const firstTokenMs = parseFiniteNumber(log.firstTokenMs);
+  if (firstTokenMs != null) {
+    const latencyMs = parseFiniteNumber(log.latencyMs);
+    if (latencyMs == null) return null;
+    const generationMs = latencyMs - firstTokenMs;
+    return generationMs > 0 ? generationMs : null;
+  }
+
+  const latencyMs = parseFiniteNumber(log.latencyMs);
+  return latencyMs != null && latencyMs > 0 ? latencyMs : null;
+}
+
+export function getOutputTokensPerSecond(
+  log: OutputTokensPerSecondInput,
+): number | null {
+  const outputTokens = parseFiniteNumber(log.outputTokens);
+  if (outputTokens == null || outputTokens <= 0) return null;
+
+  const durationMs = getOutputGenerationDurationMs(log);
+  if (durationMs == null) return null;
+
+  const tps = outputTokens / (durationMs / 1000);
+  return Number.isFinite(tps) && tps > 0 ? tps : null;
+}
+
+export function formatOutputTokensPerSecond(
+  log: OutputTokensPerSecondInput,
+): string | null {
+  const tps = getOutputTokensPerSecond(log);
+  if (tps == null) return null;
+  return tps >= 1 ? Math.round(tps).toString() : tps.toFixed(1);
+}
+
 function normalizeLanguageTag(language: string): string {
   return language.toLowerCase().replace(/_/g, "-");
 }

--- a/tests/components/usageFormat.test.ts
+++ b/tests/components/usageFormat.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatOutputTokensPerSecond,
   formatTokensShort,
+  getOutputTokensPerSecond,
   getLocaleFromLanguage,
 } from "@/components/usage/format";
 
@@ -13,5 +15,66 @@ describe("usage format helpers", () => {
   it("resolves Traditional Chinese locale aliases", () => {
     expect(getLocaleFromLanguage("zh_TW")).toBe("zh-TW");
     expect(getLocaleFromLanguage("zh-HK")).toBe("zh-TW");
+  });
+
+  it("calculates streaming TPS from generation duration after first token", () => {
+    expect(
+      getOutputTokensPerSecond({
+        outputTokens: 120,
+        latencyMs: 10_000,
+        firstTokenMs: 4_000,
+      }),
+    ).toBe(20);
+  });
+
+  it("prefers explicit durationMs for output TPS", () => {
+    expect(
+      getOutputTokensPerSecond({
+        outputTokens: 120,
+        latencyMs: 10_000,
+        firstTokenMs: 4_000,
+        durationMs: 3_000,
+      }),
+    ).toBe(40);
+  });
+
+  it("falls back to full latency when first token timing is missing", () => {
+    expect(
+      getOutputTokensPerSecond({
+        outputTokens: 120,
+        latencyMs: 10_000,
+      }),
+    ).toBe(12);
+  });
+
+  it("does not show TPS without positive tokens or duration", () => {
+    expect(
+      formatOutputTokensPerSecond({
+        outputTokens: 0,
+        latencyMs: 10_000,
+      }),
+    ).toBeNull();
+    expect(
+      formatOutputTokensPerSecond({
+        outputTokens: 120,
+        latencyMs: 4_000,
+        firstTokenMs: 4_000,
+      }),
+    ).toBeNull();
+  });
+
+  it("formats TPS with integer or single-decimal precision", () => {
+    expect(
+      formatOutputTokensPerSecond({
+        outputTokens: 121,
+        latencyMs: 10_000,
+      }),
+    ).toBe("12");
+    expect(
+      formatOutputTokensPerSecond({
+        outputTokens: 1,
+        latencyMs: 4_000,
+      }),
+    ).toBe("0.3");
   });
 });


### PR DESCRIPTION
This PR adds a calculation and display of output tokens per second (TPS) inside the output tokens cell of the RequestLogTable if latency and output token count are valid.