### PR TITLE
fix: add kimi/moonshot to Anthropic tool thinking history normalizer

### DIFF
--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -21,6 +21,8 @@ use serde_json::{json, Value};
 
 const ANTHROPIC_THINKING_PLACEHOLDER: &str = "tool call";
 const ANTHROPIC_REDACTED_THINKING_PLACEHOLDER: &str = "[redacted thinking]";
+// Keep hints lowercase; matching lowercases only the input value.
+const REASONING_VENDOR_HINTS: &[&str] = &["moonshot", "kimi", "deepseek", "mimo", "xiaomimimo"];
 
 /// 获取 Claude 供应商的 API 格式
 ///
@@ -86,22 +88,11 @@ pub fn claude_api_format_needs_transform(api_format: &str) -> bool {
     )
 }
 
-fn is_reasoning_content_compatible_identifier(value: &str) -> bool {
+fn is_reasoning_vendor_identifier(value: &str) -> bool {
     let value = value.to_ascii_lowercase();
-    value.contains("moonshot")
-        || value.contains("kimi")
-        || value.contains("deepseek")
-        || value.contains("mimo")
-        || value.contains("xiaomimimo")
-}
-
-fn is_anthropic_tool_thinking_history_identifier(value: &str) -> bool {
-    let value = value.to_ascii_lowercase();
-    value.contains("deepseek")
-        || value.contains("mimo")
-        || value.contains("xiaomimimo")
-        || value.contains("kimi")
-        || value.contains("moonshot")
+    REASONING_VENDOR_HINTS
+        .iter()
+        .any(|hint| value.contains(hint))
 }
 
 fn should_normalize_anthropic_tool_thinking_history(
@@ -116,7 +107,7 @@ fn should_normalize_anthropic_tool_thinking_history(
     if body
         .get("model")
         .and_then(|m| m.as_str())
-        .is_some_and(is_anthropic_tool_thinking_history_identifier)
+        .is_some_and(is_reasoning_vendor_identifier)
     {
         return true;
     }
@@ -133,7 +124,7 @@ fn should_normalize_anthropic_tool_thinking_history(
     ]
     .into_iter()
     .flatten()
-    .any(is_anthropic_tool_thinking_history_identifier)
+    .any(is_reasoning_vendor_identifier)
 }
 
 /// DeepSeek's Anthropic-compatible endpoint requires thinking history to be
@@ -228,7 +219,7 @@ fn should_preserve_reasoning_content_for_openai_chat(provider: &Provider, body: 
     if body
         .get("model")
         .and_then(|m| m.as_str())
-        .is_some_and(is_reasoning_content_compatible_identifier)
+        .is_some_and(is_reasoning_vendor_identifier)
     {
         return true;
     }
@@ -247,7 +238,7 @@ fn should_preserve_reasoning_content_for_openai_chat(provider: &Provider, body: 
     base_urls
         .into_iter()
         .flatten()
-        .any(is_reasoning_content_compatible_identifier)
+        .any(is_reasoning_vendor_identifier)
 }
 
 pub fn transform_claude_request_for_api_format(
@@ -2002,6 +1993,37 @@ mod tests {
         assert_eq!(content[0]["thinking"], ANTHROPIC_THINKING_PLACEHOLDER);
         assert_eq!(content[1]["type"], "text");
         assert_eq!(content[2]["type"], "tool_use");
+    }
+
+    #[test]
+    fn test_kimi_anthropic_tool_history_injects_missing_thinking() {
+        let provider = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.kimi.com/coding",
+                "ANTHROPIC_API_KEY": "test-key"
+            }
+        }));
+        let mut body = json!({
+            "model": "kimi-for-coding",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "call_123", "name": "read_file", "input": {"path": "README.md"}}
+                ]
+            }]
+        });
+
+        let changed = normalize_anthropic_tool_thinking_history_for_provider(
+            &mut body,
+            &provider,
+            "anthropic",
+        );
+
+        assert!(changed);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["thinking"], ANTHROPIC_THINKING_PLACEHOLDER);
+        assert_eq!(content[1]["type"], "tool_use");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -97,7 +97,11 @@ fn is_reasoning_content_compatible_identifier(value: &str) -> bool {
 
 fn is_anthropic_tool_thinking_history_identifier(value: &str) -> bool {
     let value = value.to_ascii_lowercase();
-    value.contains("deepseek") || value.contains("mimo") || value.contains("xiaomimimo")
+    value.contains("deepseek")
+        || value.contains("mimo")
+        || value.contains("xiaomimimo")
+        || value.contains("kimi")
+        || value.contains("moonshot")
 }
 
 fn should_normalize_anthropic_tool_thinking_history(


### PR DESCRIPTION
## Summary

- 在 `is_anthropic_tool_thinking_history_identifier` 中补充 `kimi` 和 `moonshot` 的匹配，使其与 `is_reasoning_content_compatible_identifier` 保持一致
- 修复 Kimi Anthropic 兼容端点（`api.kimi.com/coding`）在 thinking 启用 + 多轮 tool call 对话时返回 400 的问题

**Root cause:** `is_anthropic_tool_thinking_history_identifier` only matched `deepseek`/`mimo`/`xiaomimimo`, missing `kimi`/`moonshot`. Kimi's Anthropic-compatible endpoint has the same requirement as DeepSeek — assistant tool call messages must include a thinking block when thinking is enabled.

Closes #3351

## Test plan

- [x] 配置 Kimi Code 供应商，API 格式选 `Anthropic Messages (原生)`，启用 thinking
- [x] 进行多轮对话并触发 tool call，确认不再返回 `400 thinking is enabled but reasoning_content is missing`
- [x] 回归测试：确认 DeepSeek/Mimo 路径不受影响

🤖 Generated with [Claude Code](https://claude.ai/code)