### PR TITLE
fix: Codex OAuth 多账号 token 解析缺失导致 401

### DIFF
--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -540,8 +540,13 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn extract_auth(&self, provider: &Provider) -> Option<AuthInfo> {
-        self.extract_key(provider)
-            .map(|key| AuthInfo::new(key, AuthStrategy::Bearer))
+        self.extract_key(provider).map(|key| {
+            if key == "codex_oauth_placeholder" {
+                AuthInfo::new(key, AuthStrategy::CodexOAuth)
+            } else {
+                AuthInfo::new(key, AuthStrategy::Bearer)
+            }
+        })
     }
 
     fn build_url(&self, base_url: &str, endpoint: &str) -> String {


### PR DESCRIPTION
## Bug

Codex OAuth 多账号模式下，通过 CC Switch UI 添加的 Codex OAuth 账号在代理转发时全部返回 401。

## 根因

`CodexAdapter::extract_auth()` 对所有 API Key 统一返回 `AuthStrategy::Bearer`：

```rust
fn extract_auth(&self, provider: &Provider) -> Option<AuthInfo> {
    self.extract_key(provider)
        .map(|key| AuthInfo::new(key, AuthStrategy::Bearer))  // ← 始终 Bearer
}
```

当 provider 的 `OPENAI_API_KEY` 为 `codex_oauth_placeholder` 时，forwarder 中的 CodexOAuth token 自动刷新分支：

```rust
if auth.strategy == AuthStrategy::CodexOAuth {  // ← 永远不会命中
    codex_auth.get_valid_token_for_account(id).await
}
```

永远不会被触发，导致 `codex_oauth_placeholder` 原样发送到上游 ChatGPT API，返回 401。

## 修复

`extract_auth` 中检测 `codex_oauth_placeholder`，返回 `AuthStrategy::CodexOAuth`：

```rust
fn extract_auth(&self, provider: &Provider) -> Option<AuthInfo> {
    self.extract_key(provider).map(|key| {
        if key == "codex_oauth_placeholder" {
            AuthInfo::new(key, AuthStrategy::CodexOAuth)
        } else {
            AuthInfo::new(key, AuthStrategy::Bearer)
        }
    })
}
```

这样 forwarder 的 `CodexOAuth` 分支能正确命中，调用 `CodexOAuthManager` 自动刷新 token 并注入 `ChatGPT-Account-Id` header。

## 验证

修复前：6 个 Codex OAuth 账号全部 401
修复后（workaround 验证）：通过手动注入 access_token，5 个账号全部 HTTP 200，failover 正常工作

## 影响范围

- 仅影响使用 `codex_oauth_placeholder` 的 managed Codex OAuth provider
- 普通 API Key（sk-xxx / eyJxxx）不受影响，仍走 Bearer 路径