### PR TITLE
fix(tray): avoid linux submenu title hot updates

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -825,9 +825,6 @@ pub fn run() {
                     // 让用户下一次（或快速打开菜单的那一刻）看到较新的数字。
                     // refresh_all_usage_in_tray 内部有 10 秒防抖。
                     TrayIconEvent::Enter { .. } | TrayIconEvent::Click { .. } => {
-                        if !crate::tray::supports_in_place_tray_submenu_text_updates() {
-                            return;
-                        }
                         let app = tray.app_handle().clone();
                         tauri::async_runtime::spawn(async move {
                             crate::tray::refresh_all_usage_in_tray(&app).await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -824,7 +824,14 @@ pub fn run() {
                     // 鼠标悬停/点击到托盘图标时，后台异步刷新用量缓存，
                     // 让用户下一次（或快速打开菜单的那一刻）看到较新的数字。
                     // refresh_all_usage_in_tray 内部有 10 秒防抖。
-                    TrayIconEvent::Enter { .. } | TrayIconEvent::Click { .. } => {
+                    TrayIconEvent::Enter { .. } => {
+                        let app = tray.app_handle().clone();
+                        tauri::async_runtime::spawn(async move {
+                            crate::tray::refresh_all_usage_in_tray(&app).await;
+                        });
+                    }
+                    TrayIconEvent::Click { .. } => {
+                        crate::tray::note_linux_tray_menu_open_request();
                         let app = tray.app_handle().clone();
                         tauri::async_runtime::spawn(async move {
                             crate::tray::refresh_all_usage_in_tray(&app).await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -825,6 +825,9 @@ pub fn run() {
                     // 让用户下一次（或快速打开菜单的那一刻）看到较新的数字。
                     // refresh_all_usage_in_tray 内部有 10 秒防抖。
                     TrayIconEvent::Enter { .. } | TrayIconEvent::Click { .. } => {
+                        if !crate::tray::supports_in_place_tray_submenu_text_updates() {
+                            return;
+                        }
                         let app = tray.app_handle().clone();
                         tauri::async_runtime::spawn(async move {
                             crate::tray::refresh_all_usage_in_tray(&app).await;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -108,6 +108,10 @@ pub const TRAY_SECTIONS: [TrayAppSection; 3] = [
 const UTIL_WARN_PCT: f64 = 70.0;
 const UTIL_DANGER_PCT: f64 = 90.0;
 
+pub(crate) fn supports_in_place_tray_submenu_text_updates() -> bool {
+    !cfg!(target_os = "linux")
+}
+
 fn emoji_for_utilization(pct: f64) -> &'static str {
     if pct >= UTIL_DANGER_PCT {
         "\u{1F534}" // 🔴
@@ -758,7 +762,13 @@ pub fn schedule_tray_refresh(app: &tauri::AppHandle) {
         // 共享一次标题更新。
         std::thread::sleep(std::time::Duration::from_millis(50));
         TRAY_REBUILD_SCHEDULED.store(false, Ordering::Release);
-        update_tray_usage_labels(&app);
+        if supports_in_place_tray_submenu_text_updates() {
+            update_tray_usage_labels(&app);
+        } else {
+            // Linux / AppIndicator 后端上 Submenu::set_text 会导致 Fedora 44 等环境
+            // 的托盘子菜单标题丢失；退回整菜单重建，避免出现“空白但可点击”的条目。
+            refresh_tray_menu(&app);
+        }
     });
 }
 
@@ -872,7 +882,10 @@ pub(crate) async fn refresh_all_usage_in_tray(app: &tauri::AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_script_summary, format_subscription_summary, TRAY_ID};
+    use super::{
+        format_script_summary, format_subscription_summary,
+        supports_in_place_tray_submenu_text_updates, TRAY_ID,
+    };
     use crate::provider::{UsageData, UsageResult};
     use crate::services::subscription::{
         CredentialStatus, QuotaTier, SubscriptionQuota, TIER_FIVE_HOUR, TIER_WEEKLY_LIMIT,
@@ -882,6 +895,21 @@ mod tests {
     fn tray_id_is_unique_to_app() {
         assert_eq!(TRAY_ID, "cc-switch");
         assert_ne!(TRAY_ID, "main");
+    }
+
+    #[test]
+    fn linux_avoids_in_place_submenu_title_updates() {
+        #[cfg(target_os = "linux")]
+        assert!(
+            !supports_in_place_tray_submenu_text_updates(),
+            "linux tray submenu title updates should avoid Submenu::set_text"
+        );
+
+        #[cfg(not(target_os = "linux"))]
+        assert!(
+            supports_in_place_tray_submenu_text_updates(),
+            "non-linux platforms should keep in-place submenu title updates"
+        );
     }
 
     fn make_quota(tool: &str, success: bool, tiers: Vec<QuotaTier>) -> SubscriptionQuota {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -744,6 +744,40 @@ pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
 static LAST_TRAY_USAGE_REFRESH: std::sync::Mutex<Option<std::time::Instant>> =
     std::sync::Mutex::new(None);
 const MIN_TRAY_USAGE_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+#[cfg(target_os = "linux")]
+static LAST_LINUX_TRAY_MENU_OPEN_REQUEST: std::sync::Mutex<Option<std::time::Instant>> =
+    std::sync::Mutex::new(None);
+#[cfg(target_os = "linux")]
+const LINUX_TRAY_MENU_REBUILD_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[cfg(target_os = "linux")]
+pub(crate) fn note_linux_tray_menu_open_request() {
+    let mut guard = LAST_LINUX_TRAY_MENU_OPEN_REQUEST
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *guard = Some(std::time::Instant::now());
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn note_linux_tray_menu_open_request() {}
+
+fn linux_tray_menu_rebuild_delay() -> Option<std::time::Duration> {
+    #[cfg(target_os = "linux")]
+    {
+        let guard = LAST_LINUX_TRAY_MENU_OPEN_REQUEST
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let elapsed = guard
+            .as_ref()
+            .map(std::time::Instant::elapsed)
+            .unwrap_or(LINUX_TRAY_MENU_REBUILD_GRACE);
+        if elapsed < LINUX_TRAY_MENU_REBUILD_GRACE {
+            return Some(LINUX_TRAY_MENU_REBUILD_GRACE - elapsed);
+        }
+    }
+
+    None
+}
 
 /// 合并多次快速触发的"usage 标题软更新"：批量刷新期间多个 usage 命令
 /// 同时成功时，只会产生一次就地 `set_text` 批量调用。走软更新而不是
@@ -765,8 +799,12 @@ pub fn schedule_tray_refresh(app: &tauri::AppHandle) {
         if supports_in_place_tray_submenu_text_updates() {
             update_tray_usage_labels(&app);
         } else {
-            // Linux / AppIndicator 后端上 Submenu::set_text 会导致 Fedora 44 等环境
-            // 的托盘子菜单标题丢失；退回整菜单重建，避免出现“空白但可点击”的条目。
+            // Linux / AppIndicator 后端不能安全地热更新 submenu 文本；同时用户点击
+            // tray icon 打开菜单时立即 set_menu 也会让 Fedora 44 菜单文字变空。
+            // usage cache 仍会刷新，这里只把可见菜单重建延后到打开动作之后。
+            if let Some(delay) = linux_tray_menu_rebuild_delay() {
+                std::thread::sleep(delay);
+            }
             refresh_tray_menu(&app);
         }
     });


### PR DESCRIPTION
## Summary / 概述

Fix blank tray submenu labels on Fedora 44 / Linux tray backends.

This PR avoids in-place submenu title hot updates on Linux, where `Submenu::set_text` is not reliable. Linux now falls back to a full tray menu rebuild, and hover-triggered tray refreshes no longer re-enter the broken update path.

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| <img width="3472" height="4624" alt="cc-switch" src="https://github.com/user-attachments/assets/b6e087e3-eee8-4e48-a9a6-979380824a97" /> | <img width="3472" height="4624" alt="cc-switch-traymenu-fix" src="https://github.com/user-attachments/assets/e3f19354-b6ce-44b3-a287-bbf187c73854" /> |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件不适用