### PR TITLE
fix: Windows工具版本探测改用直接执行可执行文件避免cmd /C引号转义

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1459,8 +1459,9 @@ fn scan_cli_version(tool: &str) -> ShellProbe {
 
             #[cfg(target_os = "windows")]
             let output = {
-                Command::new("cmd")
-                    .args(["/C", &format!("\"{}\" --version", tool_path.display())])
+                use std::os::windows::process::CommandExt;
+                Command::new(&tool_path)
+                    .arg("--version")
                     .env("PATH", &new_path)
                     .creation_flags(CREATE_NO_WINDOW)
                     .output()
@@ -1650,8 +1651,8 @@ fn enumerate_tool_installations(tool: &str) -> Vec<ToolInstallation> {
             #[cfg(target_os = "windows")]
             let output = {
                 use std::os::windows::process::CommandExt;
-                Command::new("cmd")
-                    .args(["/C", &format!("\"{}\" --version", tool_path.display())])
+                Command::new(&tool_path)
+                    .arg("--version")
                     .env("PATH", &new_path)
                     .creation_flags(CREATE_NO_WINDOW)
                     .output()


### PR DESCRIPTION
在 Windows 上，scan_cli_version 和 enumerate_tool_installations 通过 cmd /C 包裹工具可执行文件路径来探测版本。Rust 的 Command::args() 在 Windows 上会通过 make_command_line() 对参数中的双引号进行额外转义，导致 cmd.exe 收到 "C:\path\to\tool.cmd" 这样的路径而报错 'not recognized'。

修复方案：既然这两个函数已通过 tool_path.exists() 确认了可执行文件的绝对路径，
就不再需要 cmd /C 做间接调用，改为直接 Command::new(&tool_path) 执行， 与 Linux/macOS 平台一致，同时保留 CREATE_NO_WINDOW creation flag。

## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #3364 #3375 #3371 #3344

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
