### PR TITLE
fix(usage): remove request-model fallback in cost backfill

### DIFF
--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -1646,7 +1646,22 @@ impl Database {
         cache: &mut HashMap<String, PricingInfo>,
         log: &RequestLogDetail,
     ) -> Result<Option<PricingInfo>, AppError> {
-        Self::get_model_pricing_cached(conn, cache, &log.model)
+        if let Some(pricing) = Self::get_model_pricing_cached(conn, cache, &log.model)? {
+            return Ok(Some(pricing));
+        }
+
+        if !is_placeholder_pricing_model(&log.model) {
+            return Ok(None);
+        }
+
+        let Some(request_model) = log.request_model.as_deref() else {
+            return Ok(None);
+        };
+        if request_model == log.model {
+            return Ok(None);
+        }
+
+        Self::get_model_pricing_cached(conn, cache, request_model)
     }
 }
 
@@ -2143,7 +2158,7 @@ mod tests {
     }
 
     #[test]
-    fn test_backfill_does_not_fall_back_to_request_model() -> Result<(), AppError> {
+    fn test_backfill_falls_back_to_request_model_for_placeholder() -> Result<(), AppError> {
         let db = Database::memory()?;
 
         {
@@ -2155,7 +2170,7 @@ mod tests {
                     input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd,
                     total_cost_usd, latency_ms, status_code, created_at, data_source
                 ) VALUES (
-                    'codex-request-model-no-fallback', '_codex_session', 'codex', 'unknown', 'gpt-5.5',
+                    'codex-unknown-model-placeholder', '_codex_session', 'codex', 'unknown', 'gpt-5.5',
                     1000000, 0, 0, 0,
                     '0', '0', '0', '0',
                     '0', 100, 200, 1000, 'codex_session'
@@ -2164,13 +2179,48 @@ mod tests {
             )?;
         }
 
-        // model='unknown' 无定价时不应回退到 request_model
+        assert_eq!(db.backfill_missing_usage_costs()?, 1);
+
+        let conn = lock_conn!(db.conn);
+        let total_cost: String = conn.query_row(
+            "SELECT total_cost_usd
+             FROM proxy_request_logs WHERE request_id = 'codex-unknown-model-placeholder'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(total_cost, "5.000000");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_backfill_does_not_fall_back_when_model_is_not_placeholder() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, request_model,
+                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                    input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd,
+                    total_cost_usd, latency_ms, status_code, created_at, data_source
+                ) VALUES (
+                    'routing-no-fallback', '_proxy', 'codex', 'deepseek-v4-pro-202606', 'claude-opus-4-8',
+                    1000000, 0, 0, 0,
+                    '0', '0', '0', '0',
+                    '0', 100, 200, 1000, 'proxy'
+                )",
+                [],
+            )?;
+        }
+
         assert_eq!(db.backfill_missing_usage_costs()?, 0);
 
         let conn = lock_conn!(db.conn);
         let total_cost: String = conn.query_row(
             "SELECT total_cost_usd
-             FROM proxy_request_logs WHERE request_id = 'codex-request-model-no-fallback'",
+             FROM proxy_request_logs WHERE request_id = 'routing-no-fallback'",
             [],
             |row| row.get(0),
         )?;

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -1646,18 +1646,7 @@ impl Database {
         cache: &mut HashMap<String, PricingInfo>,
         log: &RequestLogDetail,
     ) -> Result<Option<PricingInfo>, AppError> {
-        if let Some(pricing) = Self::get_model_pricing_cached(conn, cache, &log.model)? {
-            return Ok(Some(pricing));
-        }
-
-        let Some(request_model) = log.request_model.as_deref() else {
-            return Ok(None);
-        };
-        if request_model == log.model {
-            return Ok(None);
-        }
-
-        Self::get_model_pricing_cached(conn, cache, request_model)
+        Self::get_model_pricing_cached(conn, cache, &log.model)
     }
 }
 
@@ -2154,7 +2143,7 @@ mod tests {
     }
 
     #[test]
-    fn test_backfill_missing_usage_costs_falls_back_to_request_model() -> Result<(), AppError> {
+    fn test_backfill_does_not_fall_back_to_request_model() -> Result<(), AppError> {
         let db = Database::memory()?;
 
         {
@@ -2166,7 +2155,7 @@ mod tests {
                     input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd,
                     total_cost_usd, latency_ms, status_code, created_at, data_source
                 ) VALUES (
-                    'codex-request-model-fallback', '_codex_session', 'codex', 'unknown', 'gpt-5.5',
+                    'codex-request-model-no-fallback', '_codex_session', 'codex', 'unknown', 'gpt-5.5',
                     1000000, 0, 0, 0,
                     '0', '0', '0', '0',
                     '0', 100, 200, 1000, 'codex_session'
@@ -2175,16 +2164,17 @@ mod tests {
             )?;
         }
 
-        assert_eq!(db.backfill_missing_usage_costs()?, 1);
+        // model='unknown' 无定价时不应回退到 request_model
+        assert_eq!(db.backfill_missing_usage_costs()?, 0);
 
         let conn = lock_conn!(db.conn);
         let total_cost: String = conn.query_row(
             "SELECT total_cost_usd
-             FROM proxy_request_logs WHERE request_id = 'codex-request-model-fallback'",
+             FROM proxy_request_logs WHERE request_id = 'codex-request-model-no-fallback'",
             [],
             |row| row.get(0),
         )?;
-        assert_eq!(total_cost, "5.000000");
+        assert_eq!(total_cost, "0");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Remove the historical backfill fallback from `model` to `request_model` when resolving pricing.
- Keep backfill aligned with execution-model billing so routed requests are not repriced with the original request model.
- Add a regression test to prevent the fallback from returning.

## Related Issue
- Closes #3390

## Test Plan
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml -- usage_stats calculator session_usage`