### PR TITLE
feat(preset): add Tencent Cloud TokenHub provider preset

### DIFF
--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -150,6 +150,22 @@ export const claudeDesktopProviderPresets: ClaudeDesktopProviderPreset[] = [
     iconColor: "#D4915D",
   },
   {
+    name: "腾讯云",
+    websiteUrl: "https://console.cloud.tencent.com/tokenhub/models",
+    apiKeyUrl: "https://console.cloud.tencent.com/tokenhub/apikey",
+    category: "cn_official",
+    baseUrl: "https://tokenhub.tencentmaas.com",
+    mode: "proxy",
+    apiFormat: "anthropic",
+    modelRoutes: brandedRoutes(
+      "deepseek-v4-pro-202606",
+      "deepseek-v4-pro-202606",
+      "deepseek-v4-flash-202605",
+    ),
+    icon: "tencent",
+    iconColor: "#006EFF",
+  },
+  {
     name: "Shengsuanyun",
     nameKey: "providerForm.presets.shengsuanyun",
     websiteUrl: "https://www.shengsuanyun.com/?from=CH_4HHXMRYF",

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -90,6 +90,24 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#D4915D",
   },
   {
+    name: "腾讯云",
+    websiteUrl: "https://console.cloud.tencent.com/tokenhub/models",
+    apiKeyUrl: "https://console.cloud.tencent.com/tokenhub/apikey",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://tokenhub.tencentmaas.com",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "deepseek-v4-pro-202606",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "deepseek-v4-flash-202605",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "deepseek-v4-pro-202606",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "deepseek-v4-pro-202606",
+      },
+    },
+    category: "cn_official",
+    icon: "tencent",
+    iconColor: "#006EFF",
+  },
+  {
     name: "Shengsuanyun",
     nameKey: "providerForm.presets.shengsuanyun",
     websiteUrl: "https://www.shengsuanyun.com/?from=CH_4HHXMRYF",


### PR DESCRIPTION
## Summary / 概述

Add Tencent Cloud TokenHub provider presets for Claude Code and Claude Desktop.

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件