### PR TITLE
feat(settings): 添加 Claude Code 和 Codex 配置档切换

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,11 +1,20 @@
 #![allow(non_snake_case)]
 
 use tauri::AppHandle;
+use tauri::{Emitter, State};
 
 fn merge_settings_for_save(
     mut incoming: crate::settings::AppSettings,
     existing: &crate::settings::AppSettings,
 ) -> crate::settings::AppSettings {
+    if incoming.profiles.is_empty()
+        && incoming.active_profile_id.is_none()
+        && !existing.profiles.is_empty()
+    {
+        incoming.profiles = existing.profiles.clone();
+        incoming.active_profile_id = existing.active_profile_id.clone();
+    }
+
     match (&mut incoming.webdav_sync, &existing.webdav_sync) {
         // incoming 没有 webdav → 保留现有
         (None, _) => {
@@ -53,11 +62,66 @@ pub async fn get_settings() -> Result<crate::settings::AppSettings, String> {
 pub async fn save_settings(settings: crate::settings::AppSettings) -> Result<bool, String> {
     let existing = crate::settings::get_settings();
     let merged = merge_settings_for_save(settings, &existing);
-    crate::settings::update_settings(merged).map_err(|e| e.to_string())?;
+    let profiles_are_authoritative = merged.profiles != existing.profiles
+        || merged.active_profile_id != existing.active_profile_id;
+    crate::settings::update_settings_from_frontend(merged, profiles_are_authoritative)
+        .map_err(|e| e.to_string())?;
     Ok(true)
 }
 
+/// 切换环境配置档
+#[tauri::command]
+pub async fn switch_profile(
+    app: AppHandle,
+    state: State<'_, crate::AppState>,
+    #[allow(non_snake_case)] profileId: String,
+) -> Result<crate::settings::AppSettings, String> {
+    let db = state.db.clone();
+    let profile_id_for_event = profileId.clone();
+    let _settings = tauri::async_runtime::spawn_blocking(move || {
+        let settings = crate::settings::switch_profile(&profileId)?;
+        let app_state = crate::AppState::new(db);
+        crate::services::ProviderService::sync_profile_managed_to_live(&app_state)?;
+        Ok::<_, crate::AppError>(settings)
+    })
+    .await
+    .map_err(|e| format!("切换 Profile 失败: {e}"))?
+    .map_err(|e| e.to_string())?;
+
+    let frontend_settings = crate::settings::get_settings_for_frontend();
+    crate::tray::refresh_tray_menu(&app);
+    if let Err(err) = app.emit(
+        "profile-switched",
+        serde_json::json!({
+            "profileId": profile_id_for_event,
+            "settings": frontend_settings,
+        }),
+    ) {
+        log::warn!("发射 profile-switched 事件失败: {err}");
+    }
+
+    Ok(frontend_settings)
+}
+
 /// 重启应用程序（当 app_config_dir 变更后使用）
+#[tauri::command]
+pub async fn sync_profile_managed_providers_live(
+    state: State<'_, crate::AppState>,
+) -> Result<serde_json::Value, String> {
+    let db = state.db.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let app_state = crate::AppState::new(db);
+        crate::services::ProviderService::sync_profile_managed_to_live(&app_state)?;
+        Ok::<_, crate::AppError>(serde_json::json!({
+            "success": true,
+            "message": "Profile-managed live configuration synchronized"
+        }))
+    })
+    .await
+    .map_err(|e| format!("同步 Profile 供应商失败: {e}"))?
+    .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub async fn restart_app(app: AppHandle) -> Result<bool, String> {
     crate::save_window_state_before_exit(&app);
@@ -103,7 +167,7 @@ mod tests {
     use super::merge_settings_for_save;
     use crate::settings::{
         AppSettings, CodexProviderTemplateMigration, CodexThirdPartyHistoryProviderBucketMigration,
-        LocalMigrations, WebDavSyncSettings,
+        LocalMigrations, Profile, WebDavSyncSettings,
     };
 
     #[test]
@@ -224,6 +288,36 @@ mod tests {
             merged.webdav_sync.as_ref().map(|v| v.password.as_str()),
             Some("")
         );
+    }
+
+    #[test]
+    fn save_settings_should_preserve_existing_profiles_when_payload_omits_them() {
+        let existing = AppSettings {
+            profiles: vec![Profile {
+                id: "wsl".to_string(),
+                label: "WSL".to_string(),
+                claude_config_dir: Some("\\\\wsl.localhost\\Ubuntu\\home\\me\\.claude".to_string()),
+                codex_config_dir: Some("\\\\wsl.localhost\\Ubuntu\\home\\me\\.codex".to_string()),
+                current_provider_claude: Some("claude-wsl".to_string()),
+                current_provider_codex: Some("codex-wsl".to_string()),
+                ..Profile::default()
+            }],
+            active_profile_id: Some("wsl".to_string()),
+            ..AppSettings::default()
+        };
+
+        let incoming = AppSettings {
+            claude_config_dir: Some("C:\\Users\\me\\.claude".to_string()),
+            codex_config_dir: Some("C:\\Users\\me\\.codex".to_string()),
+            current_provider_claude: Some("claude-win".to_string()),
+            current_provider_codex: Some("codex-win".to_string()),
+            ..AppSettings::default()
+        };
+
+        let merged = merge_settings_for_save(incoming, &existing);
+
+        assert_eq!(merged.active_profile_id.as_deref(), Some("wsl"));
+        assert_eq!(merged.profiles, existing.profiles);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1125,6 +1125,7 @@ pub fn run() {
             commands::read_live_provider_settings,
             commands::get_settings,
             commands::save_settings,
+            commands::switch_profile,
             commands::get_rectifier_config,
             commands::set_rectifier_config,
             commands::get_optimizer_config,
@@ -1206,6 +1207,7 @@ pub fn run() {
             commands::rename_db_backup,
             commands::delete_db_backup,
             commands::sync_current_providers_live,
+            commands::sync_profile_managed_providers_live,
             // Deep link import
             commands::parse_deeplink,
             commands::merge_deeplink_config,

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -178,18 +178,23 @@ impl McpService {
 
     /// 手动同步所有启用的 MCP 服务器到对应的应用
     pub fn sync_all_enabled(state: &AppState) -> Result<(), AppError> {
+        let apps: Vec<AppType> = AppType::all().collect();
+        Self::sync_enabled_for_apps(state, &apps)
+    }
+
+    pub fn sync_enabled_for_apps(state: &AppState, apps: &[AppType]) -> Result<(), AppError> {
         let servers = Self::get_all_servers(state)?;
 
-        for app in AppType::all() {
+        for app in apps {
             if matches!(app, AppType::OpenClaw | AppType::ClaudeDesktop) {
                 continue;
             }
 
             for server in servers.values() {
-                if server.apps.is_enabled_for(&app) {
-                    Self::sync_server_to_app(state, server, &app)?;
+                if server.apps.is_enabled_for(app) {
+                    Self::sync_server_to_app(state, server, app)?;
                 } else {
-                    Self::remove_server_from_app(state, &server.id, &app)?;
+                    Self::remove_server_from_app(state, &server.id, app)?;
                 }
             }
         }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -890,6 +890,16 @@ pub(crate) fn sync_current_provider_for_app_to_live(
     state: &AppState,
     app_type: &AppType,
 ) -> Result<(), AppError> {
+    sync_current_provider_config_for_app_to_live(state, app_type)?;
+    McpService::sync_all_enabled(state)?;
+
+    Ok(())
+}
+
+fn sync_current_provider_config_for_app_to_live(
+    state: &AppState,
+    app_type: &AppType,
+) -> Result<(), AppError> {
     if app_type.is_additive_mode() {
         sync_all_providers_to_live(state, app_type)?;
     } else {
@@ -905,7 +915,23 @@ pub(crate) fn sync_current_provider_for_app_to_live(
         }
     }
 
-    McpService::sync_all_enabled(state)?;
+    Ok(())
+}
+
+pub fn sync_profile_managed_to_live(state: &AppState) -> Result<(), AppError> {
+    let apps = [AppType::Claude, AppType::Codex];
+
+    for app_type in &apps {
+        sync_current_provider_config_for_app_to_live(state, app_type)?;
+    }
+
+    McpService::sync_enabled_for_apps(state, &apps)?;
+
+    for app_type in &apps {
+        if let Err(e) = crate::services::skill::SkillService::sync_to_app(&state.db, app_type) {
+            log::warn!("同步 Profile 管理的 Skill 到 {app_type:?} 失败: {e}");
+        }
+    }
 
     Ok(())
 }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -24,7 +24,7 @@ use crate::store::AppState;
 pub use live::{
     import_default_config, import_hermes_providers_from_live, import_openclaw_providers_from_live,
     import_opencode_providers_from_live, read_live_settings,
-    should_import_default_config_on_startup, sync_current_to_live,
+    should_import_default_config_on_startup, sync_current_to_live, sync_profile_managed_to_live,
 };
 
 // Internal re-exports (pub(crate))
@@ -1779,6 +1779,10 @@ impl ProviderService {
     /// Sync current provider to live configuration (re-export)
     pub fn sync_current_to_live(state: &AppState) -> Result<(), AppError> {
         sync_current_to_live(state)
+    }
+
+    pub fn sync_profile_managed_to_live(state: &AppState) -> Result<(), AppError> {
+        sync_profile_managed_to_live(state)
     }
 
     pub fn sync_current_provider_for_app(

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
+#[cfg(unix)]
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{OnceLock, RwLock};
@@ -176,6 +177,92 @@ impl WebDavSyncSettings {
     }
 }
 
+/// 本机环境配置档。
+///
+/// Profile 保存每个环境自己的目录覆盖和当前供应商选择；切换时再把这些值
+/// 拷贝回 AppSettings 的单值字段，让现有读写路径继续复用原逻辑。
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Profile {
+    pub id: String,
+    pub label: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gemini_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub opencode_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openclaw_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hermes_config_dir: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_claude: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_claude_desktop: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_codex: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_gemini: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_opencode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_openclaw: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_hermes: Option<String>,
+}
+
+fn normalize_optional_string(value: &mut Option<String>) {
+    *value = value
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+}
+
+impl Profile {
+    fn from_settings(
+        id: impl Into<String>,
+        label: impl Into<String>,
+        settings: &AppSettings,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            claude_config_dir: settings.claude_config_dir.clone(),
+            codex_config_dir: settings.codex_config_dir.clone(),
+            current_provider_claude: settings.current_provider_claude.clone(),
+            current_provider_codex: settings.current_provider_codex.clone(),
+            ..Default::default()
+        }
+    }
+
+    fn normalize(&mut self) {
+        self.id = self.id.trim().to_string();
+        self.label = self.label.trim().to_string();
+        normalize_optional_string(&mut self.claude_config_dir);
+        normalize_optional_string(&mut self.codex_config_dir);
+        normalize_optional_string(&mut self.gemini_config_dir);
+        normalize_optional_string(&mut self.opencode_config_dir);
+        normalize_optional_string(&mut self.openclaw_config_dir);
+        normalize_optional_string(&mut self.hermes_config_dir);
+        normalize_optional_string(&mut self.current_provider_claude);
+        normalize_optional_string(&mut self.current_provider_claude_desktop);
+        normalize_optional_string(&mut self.current_provider_codex);
+        normalize_optional_string(&mut self.current_provider_gemini);
+        normalize_optional_string(&mut self.current_provider_opencode);
+        normalize_optional_string(&mut self.current_provider_openclaw);
+        normalize_optional_string(&mut self.current_provider_hermes);
+        if self.label.is_empty() {
+            self.label = self.id.clone();
+        }
+    }
+}
+
 /// 本机自动迁移状态。
 ///
 /// 这里记录的是本机启动时执行过的一次性迁移；标记不随数据库同步。
@@ -306,6 +393,13 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_hermes: Option<String>,
 
+    // ===== 环境配置档（设备级）=====
+    /// 多环境配置档。切换时会同步到上面的单值字段以保持旧逻辑兼容。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub profiles: Vec<Profile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_profile_id: Option<String>,
+
     // ===== Skill 同步设置 =====
     /// Skill 同步方式：auto（默认，优先 symlink）、symlink、copy
     #[serde(default)]
@@ -384,6 +478,8 @@ impl Default for AppSettings {
             current_provider_opencode: None,
             current_provider_openclaw: None,
             current_provider_hermes: None,
+            profiles: Vec::new(),
+            active_profile_id: None,
             skill_sync_method: SyncMethod::default(),
             skill_storage_location: SkillStorageLocation::default(),
             webdav_sync: None,
@@ -407,47 +503,19 @@ impl AppSettings {
     }
 
     fn normalize_paths(&mut self) {
-        self.claude_config_dir = self
-            .claude_config_dir
-            .as_ref()
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        self.codex_config_dir = self
-            .codex_config_dir
-            .as_ref()
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        self.gemini_config_dir = self
-            .gemini_config_dir
-            .as_ref()
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        self.opencode_config_dir = self
-            .opencode_config_dir
-            .as_ref()
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        self.openclaw_config_dir = self
-            .openclaw_config_dir
-            .as_ref()
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
-
-        self.hermes_config_dir = self
-            .hermes_config_dir
-            .as_ref()
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
+        normalize_optional_string(&mut self.claude_config_dir);
+        normalize_optional_string(&mut self.codex_config_dir);
+        normalize_optional_string(&mut self.gemini_config_dir);
+        normalize_optional_string(&mut self.opencode_config_dir);
+        normalize_optional_string(&mut self.openclaw_config_dir);
+        normalize_optional_string(&mut self.hermes_config_dir);
+        normalize_optional_string(&mut self.current_provider_claude);
+        normalize_optional_string(&mut self.current_provider_claude_desktop);
+        normalize_optional_string(&mut self.current_provider_codex);
+        normalize_optional_string(&mut self.current_provider_gemini);
+        normalize_optional_string(&mut self.current_provider_opencode);
+        normalize_optional_string(&mut self.current_provider_openclaw);
+        normalize_optional_string(&mut self.current_provider_hermes);
 
         self.language = self
             .language
@@ -462,6 +530,88 @@ impl AppSettings {
                 self.webdav_sync = None;
             }
         }
+
+        self.normalize_profiles();
+    }
+
+    fn normalize_for_save(&mut self) {
+        self.normalize_paths();
+        self.save_single_fields_to_active_profile();
+        self.normalize_profiles();
+    }
+
+    fn normalize_profiles(&mut self) {
+        normalize_optional_string(&mut self.active_profile_id);
+
+        let mut seen = std::collections::HashSet::new();
+        let mut normalized_profiles = Vec::with_capacity(self.profiles.len());
+        for mut profile in std::mem::take(&mut self.profiles) {
+            profile.normalize();
+            if profile.id.is_empty() || !seen.insert(profile.id.clone()) {
+                continue;
+            }
+            normalized_profiles.push(profile);
+        }
+        self.profiles = normalized_profiles;
+
+        if let Some(active_id) = self.active_profile_id.clone() {
+            if !self.profiles.iter().any(|profile| profile.id == active_id) {
+                self.active_profile_id = None;
+            }
+        }
+
+        if self.active_profile_id.is_none() && !self.profiles.is_empty() {
+            self.active_profile_id = self.profiles.first().map(|profile| profile.id.clone());
+        }
+
+        if self.profiles.is_empty() && self.has_profile_managed_values() {
+            let profile = Profile::from_settings("default", "Default", self);
+            self.profiles.push(profile);
+            self.active_profile_id = Some("default".to_string());
+        }
+    }
+
+    fn has_profile_managed_values(&self) -> bool {
+        self.claude_config_dir.is_some()
+            || self.codex_config_dir.is_some()
+            || self.current_provider_claude.is_some()
+            || self.current_provider_codex.is_some()
+    }
+
+    fn save_single_fields_to_active_profile(&mut self) {
+        let Some(active_id) = self.active_profile_id.clone() else {
+            return;
+        };
+        let snapshot = Profile::from_settings(active_id.clone(), active_id.clone(), self);
+        if let Some(profile) = self
+            .profiles
+            .iter_mut()
+            .find(|profile| profile.id == active_id)
+        {
+            profile.claude_config_dir = snapshot.claude_config_dir;
+            profile.codex_config_dir = snapshot.codex_config_dir;
+            profile.current_provider_claude = snapshot.current_provider_claude;
+            profile.current_provider_codex = snapshot.current_provider_codex;
+        }
+    }
+
+    fn apply_active_profile_to_single_fields(&mut self) {
+        let Some(active_id) = self.active_profile_id.as_deref() else {
+            return;
+        };
+        let Some(profile) = self
+            .profiles
+            .iter()
+            .find(|profile| profile.id == active_id)
+            .cloned()
+        else {
+            return;
+        };
+
+        self.claude_config_dir = profile.claude_config_dir;
+        self.codex_config_dir = profile.codex_config_dir;
+        self.current_provider_claude = profile.current_provider_claude;
+        self.current_provider_codex = profile.current_provider_codex;
     }
 
     fn load_from_file() -> Self {
@@ -472,6 +622,7 @@ impl AppSettings {
             match serde_json::from_str::<AppSettings>(&content) {
                 Ok(mut settings) => {
                     settings.normalize_paths();
+                    settings.apply_active_profile_to_single_fields();
                     settings
                 }
                 Err(err) => {
@@ -491,7 +642,7 @@ impl AppSettings {
 
 fn save_settings_file(settings: &AppSettings) -> Result<(), AppError> {
     let mut normalized = settings.clone();
-    normalized.normalize_paths();
+    normalized.normalize_for_save();
     let Some(path) = AppSettings::settings_path() else {
         return Err(AppError::Config("无法获取用户主目录".to_string()));
     };
@@ -570,7 +721,7 @@ pub fn get_settings_for_frontend() -> AppSettings {
 }
 
 pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
-    new_settings.normalize_paths();
+    new_settings.normalize_for_save();
     save_settings_file(&new_settings)?;
 
     let mut guard = settings_store().write().unwrap_or_else(|e| {
@@ -579,6 +730,17 @@ pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
     });
     *guard = new_settings;
     Ok(())
+}
+
+pub fn update_settings_from_frontend(
+    mut new_settings: AppSettings,
+    profiles_are_authoritative: bool,
+) -> Result<(), AppError> {
+    if profiles_are_authoritative {
+        new_settings.normalize_paths();
+        new_settings.apply_active_profile_to_single_fields();
+    }
+    update_settings(new_settings)
 }
 
 fn mutate_settings<F>(mutator: F) -> Result<(), AppError>
@@ -591,10 +753,44 @@ where
     });
     let mut next = guard.clone();
     mutator(&mut next);
-    next.normalize_paths();
+    next.normalize_for_save();
     save_settings_file(&next)?;
     *guard = next;
     Ok(())
+}
+
+/// 切换环境配置档，并把旧环境的当前单值字段保存回 profile。
+pub fn switch_profile(profile_id: &str) -> Result<AppSettings, AppError> {
+    let profile_id = profile_id.trim();
+    if profile_id.is_empty() {
+        return Err(AppError::Message("Profile ID 不能为空".to_string()));
+    }
+
+    let mut guard = settings_store().write().unwrap_or_else(|e| {
+        log::warn!("设置锁已毒化，使用恢复值: {e}");
+        e.into_inner()
+    });
+
+    let mut next = guard.clone();
+    next.normalize_paths();
+    next.save_single_fields_to_active_profile();
+    let target_profile = next
+        .profiles
+        .iter()
+        .find(|profile| profile.id == profile_id)
+        .cloned()
+        .ok_or_else(|| AppError::Message(format!("Profile {profile_id} 不存在")))?;
+
+    next.active_profile_id = Some(profile_id.to_string());
+    next.claude_config_dir = target_profile.claude_config_dir;
+    next.codex_config_dir = target_profile.codex_config_dir;
+    next.current_provider_claude = target_profile.current_provider_claude;
+    next.current_provider_codex = target_profile.current_provider_codex;
+    next.normalize_for_save();
+
+    save_settings_file(&next)?;
+    *guard = next.clone();
+    Ok(next)
 }
 
 pub fn is_codex_third_party_history_provider_bucket_migrated() -> bool {
@@ -901,5 +1097,216 @@ mod tests {
         .expect("visible apps");
 
         assert!(!visible.is_visible(&AppType::ClaudeDesktop));
+    }
+
+    #[test]
+    fn profile_from_settings_snapshots_only_claude_code_and_codex() {
+        let settings = AppSettings {
+            claude_config_dir: Some("/profiles/claude".to_string()),
+            codex_config_dir: Some("/profiles/codex".to_string()),
+            gemini_config_dir: Some("/profiles/gemini".to_string()),
+            opencode_config_dir: Some("/profiles/opencode".to_string()),
+            openclaw_config_dir: Some("/profiles/openclaw".to_string()),
+            hermes_config_dir: Some("/profiles/hermes".to_string()),
+            current_provider_claude: Some("claude-provider".to_string()),
+            current_provider_claude_desktop: Some("desktop-provider".to_string()),
+            current_provider_codex: Some("codex-provider".to_string()),
+            current_provider_gemini: Some("gemini-provider".to_string()),
+            current_provider_opencode: Some("opencode-provider".to_string()),
+            current_provider_openclaw: Some("openclaw-provider".to_string()),
+            current_provider_hermes: Some("hermes-provider".to_string()),
+            ..AppSettings::default()
+        };
+
+        let profile = Profile::from_settings("work", "Work", &settings);
+
+        assert_eq!(
+            profile.claude_config_dir.as_deref(),
+            Some("/profiles/claude")
+        );
+        assert_eq!(profile.codex_config_dir.as_deref(), Some("/profiles/codex"));
+        assert_eq!(
+            profile.current_provider_claude.as_deref(),
+            Some("claude-provider")
+        );
+        assert_eq!(
+            profile.current_provider_codex.as_deref(),
+            Some("codex-provider")
+        );
+        assert_eq!(profile.gemini_config_dir, None);
+        assert_eq!(profile.opencode_config_dir, None);
+        assert_eq!(profile.openclaw_config_dir, None);
+        assert_eq!(profile.hermes_config_dir, None);
+        assert_eq!(profile.current_provider_claude_desktop, None);
+        assert_eq!(profile.current_provider_gemini, None);
+        assert_eq!(profile.current_provider_opencode, None);
+        assert_eq!(profile.current_provider_openclaw, None);
+        assert_eq!(profile.current_provider_hermes, None);
+    }
+
+    #[test]
+    fn applying_active_profile_preserves_unmanaged_app_fields() {
+        let mut settings = AppSettings {
+            claude_config_dir: Some("/old/claude".to_string()),
+            codex_config_dir: Some("/old/codex".to_string()),
+            gemini_config_dir: Some("/keep/gemini".to_string()),
+            opencode_config_dir: Some("/keep/opencode".to_string()),
+            openclaw_config_dir: Some("/keep/openclaw".to_string()),
+            hermes_config_dir: Some("/keep/hermes".to_string()),
+            current_provider_claude: Some("old-claude".to_string()),
+            current_provider_claude_desktop: Some("keep-desktop".to_string()),
+            current_provider_codex: Some("old-codex".to_string()),
+            current_provider_gemini: Some("keep-gemini".to_string()),
+            current_provider_opencode: Some("keep-opencode".to_string()),
+            current_provider_openclaw: Some("keep-openclaw".to_string()),
+            current_provider_hermes: Some("keep-hermes".to_string()),
+            profiles: vec![Profile {
+                id: "work".to_string(),
+                label: "Work".to_string(),
+                claude_config_dir: Some("/new/claude".to_string()),
+                codex_config_dir: Some("/new/codex".to_string()),
+                gemini_config_dir: Some("/ignored/gemini".to_string()),
+                opencode_config_dir: Some("/ignored/opencode".to_string()),
+                openclaw_config_dir: Some("/ignored/openclaw".to_string()),
+                hermes_config_dir: Some("/ignored/hermes".to_string()),
+                current_provider_claude: Some("new-claude".to_string()),
+                current_provider_claude_desktop: Some("ignored-desktop".to_string()),
+                current_provider_codex: Some("new-codex".to_string()),
+                current_provider_gemini: Some("ignored-gemini".to_string()),
+                current_provider_opencode: Some("ignored-opencode".to_string()),
+                current_provider_openclaw: Some("ignored-openclaw".to_string()),
+                current_provider_hermes: Some("ignored-hermes".to_string()),
+            }],
+            active_profile_id: Some("work".to_string()),
+            ..AppSettings::default()
+        };
+
+        settings.apply_active_profile_to_single_fields();
+
+        assert_eq!(settings.claude_config_dir.as_deref(), Some("/new/claude"));
+        assert_eq!(settings.codex_config_dir.as_deref(), Some("/new/codex"));
+        assert_eq!(
+            settings.current_provider_claude.as_deref(),
+            Some("new-claude")
+        );
+        assert_eq!(
+            settings.current_provider_codex.as_deref(),
+            Some("new-codex")
+        );
+        assert_eq!(settings.gemini_config_dir.as_deref(), Some("/keep/gemini"));
+        assert_eq!(
+            settings.opencode_config_dir.as_deref(),
+            Some("/keep/opencode")
+        );
+        assert_eq!(
+            settings.openclaw_config_dir.as_deref(),
+            Some("/keep/openclaw")
+        );
+        assert_eq!(settings.hermes_config_dir.as_deref(), Some("/keep/hermes"));
+        assert_eq!(
+            settings.current_provider_claude_desktop.as_deref(),
+            Some("keep-desktop")
+        );
+        assert_eq!(
+            settings.current_provider_gemini.as_deref(),
+            Some("keep-gemini")
+        );
+        assert_eq!(
+            settings.current_provider_opencode.as_deref(),
+            Some("keep-opencode")
+        );
+        assert_eq!(
+            settings.current_provider_openclaw.as_deref(),
+            Some("keep-openclaw")
+        );
+        assert_eq!(
+            settings.current_provider_hermes.as_deref(),
+            Some("keep-hermes")
+        );
+    }
+
+    #[test]
+    fn saving_single_fields_updates_only_active_profile_managed_fields() {
+        let mut settings = AppSettings {
+            claude_config_dir: Some("/active/claude".to_string()),
+            codex_config_dir: Some("/active/codex".to_string()),
+            gemini_config_dir: Some("/single/gemini".to_string()),
+            current_provider_claude: Some("active-claude".to_string()),
+            current_provider_codex: Some("active-codex".to_string()),
+            current_provider_gemini: Some("single-gemini".to_string()),
+            profiles: vec![Profile {
+                id: "active".to_string(),
+                label: "Active".to_string(),
+                claude_config_dir: Some("/profile/claude".to_string()),
+                codex_config_dir: Some("/profile/codex".to_string()),
+                gemini_config_dir: Some("/profile/gemini".to_string()),
+                current_provider_claude: Some("profile-claude".to_string()),
+                current_provider_codex: Some("profile-codex".to_string()),
+                current_provider_gemini: Some("profile-gemini".to_string()),
+                ..Profile::default()
+            }],
+            active_profile_id: Some("active".to_string()),
+            ..AppSettings::default()
+        };
+
+        settings.save_single_fields_to_active_profile();
+        let profile = settings.profiles.first().expect("active profile");
+
+        assert_eq!(profile.claude_config_dir.as_deref(), Some("/active/claude"));
+        assert_eq!(profile.codex_config_dir.as_deref(), Some("/active/codex"));
+        assert_eq!(
+            profile.current_provider_claude.as_deref(),
+            Some("active-claude")
+        );
+        assert_eq!(
+            profile.current_provider_codex.as_deref(),
+            Some("active-codex")
+        );
+        assert_eq!(
+            profile.gemini_config_dir.as_deref(),
+            Some("/profile/gemini")
+        );
+        assert_eq!(
+            profile.current_provider_gemini.as_deref(),
+            Some("profile-gemini")
+        );
+    }
+
+    #[test]
+    fn saving_then_applying_active_profile_uses_latest_single_fields() {
+        let mut settings = AppSettings {
+            claude_config_dir: Some("/latest/claude".to_string()),
+            codex_config_dir: Some("/latest/codex".to_string()),
+            current_provider_claude: Some("latest-claude".to_string()),
+            current_provider_codex: Some("latest-codex".to_string()),
+            profiles: vec![Profile {
+                id: "active".to_string(),
+                label: "Active".to_string(),
+                claude_config_dir: Some("/stale/claude".to_string()),
+                codex_config_dir: Some("/stale/codex".to_string()),
+                current_provider_claude: Some("stale-claude".to_string()),
+                current_provider_codex: Some("stale-codex".to_string()),
+                ..Profile::default()
+            }],
+            active_profile_id: Some("active".to_string()),
+            ..AppSettings::default()
+        };
+
+        settings.save_single_fields_to_active_profile();
+        settings.apply_active_profile_to_single_fields();
+
+        assert_eq!(
+            settings.claude_config_dir.as_deref(),
+            Some("/latest/claude")
+        );
+        assert_eq!(settings.codex_config_dir.as_deref(), Some("/latest/codex"));
+        assert_eq!(
+            settings.current_provider_claude.as_deref(),
+            Some("latest-claude")
+        );
+        assert_eq!(
+            settings.current_provider_codex.as_deref(),
+            Some("latest-codex")
+        );
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -22,6 +22,7 @@ static TRAY_SECTION_SUBMENUS: Lazy<
 pub struct TrayTexts {
     pub show_main: &'static str,
     pub open_website: &'static str,
+    pub switch_profile: &'static str,
     pub no_providers_label: &'static str,
     pub lightweight_mode: &'static str,
     pub quit: &'static str,
@@ -34,6 +35,7 @@ impl TrayTexts {
             "en" => Self {
                 show_main: "Open main window",
                 open_website: "Open Official Website",
+                switch_profile: "Switch profile",
                 no_providers_label: "(no providers)",
                 lightweight_mode: "Lightweight Mode",
                 quit: "Quit",
@@ -42,6 +44,7 @@ impl TrayTexts {
             "ja" => Self {
                 show_main: "メインウィンドウを開く",
                 open_website: "公式サイトを開く",
+                switch_profile: "プロファイル切替",
                 no_providers_label: "(プロバイダーなし)",
                 lightweight_mode: "軽量モード",
                 quit: "終了",
@@ -50,6 +53,7 @@ impl TrayTexts {
             "zh-TW" => Self {
                 show_main: "開啟主介面",
                 open_website: "開啟官方網站",
+                switch_profile: "切換 Profile",
                 no_providers_label: "(無供應商)",
                 lightweight_mode: "輕量模式",
                 quit: "退出",
@@ -58,6 +62,7 @@ impl TrayTexts {
             _ => Self {
                 show_main: "打开主界面",
                 open_website: "打开官方网站",
+                switch_profile: "切换 Profile",
                 no_providers_label: "(无供应商)",
                 lightweight_mode: "轻量模式",
                 quit: "退出",
@@ -79,6 +84,7 @@ pub struct TrayAppSection {
 /// Auto 菜单项后缀
 pub const AUTO_SUFFIX: &str = "auto";
 pub const TRAY_ID: &str = "cc-switch";
+const PROFILE_EVENT_PREFIX: &str = "profile_";
 
 pub const TRAY_SECTIONS: [TrayAppSection; 3] = [
     TrayAppSection {
@@ -338,6 +344,44 @@ pub fn handle_provider_tray_event(app: &tauri::AppHandle, event_id: &str) -> boo
     false
 }
 
+fn handle_profile_tray_event(app: &tauri::AppHandle, event_id: &str) -> bool {
+    let Some(profile_id) = event_id.strip_prefix(PROFILE_EVENT_PREFIX) else {
+        return false;
+    };
+
+    let app_handle = app.clone();
+    let profile_id = profile_id.to_string();
+    tauri::async_runtime::spawn_blocking(move || {
+        if let Err(e) = handle_profile_click(&app_handle, &profile_id) {
+            log::error!("切换 Profile 失败: {e}");
+        }
+    });
+    true
+}
+
+fn handle_profile_click(app: &tauri::AppHandle, profile_id: &str) -> Result<(), AppError> {
+    let Some(app_state) = app.try_state::<AppState>() else {
+        return Ok(());
+    };
+
+    crate::settings::switch_profile(profile_id)?;
+    crate::services::ProviderService::sync_profile_managed_to_live(app_state.inner())?;
+    refresh_tray_menu(app);
+    let frontend_settings = crate::settings::get_settings_for_frontend();
+
+    if let Err(e) = app.emit(
+        "profile-switched",
+        serde_json::json!({
+            "profileId": profile_id,
+            "settings": frontend_settings,
+        }),
+    ) {
+        log::error!("发射 profile-switched 事件失败: {e}");
+    }
+
+    Ok(())
+}
+
 /// 处理 Auto 点击：启用 proxy 和 auto_failover
 fn handle_auto_click(app: &tauri::AppHandle, app_type: &AppType) -> Result<(), AppError> {
     if let Some(app_state) = app.try_state::<AppState>() {
@@ -502,6 +546,30 @@ pub fn create_tray_menu(
         .item(&show_main_item)
         .item(&open_website_item)
         .separator();
+
+    if app_settings.profiles.len() > 1 {
+        let mut profile_submenu_builder =
+            SubmenuBuilder::with_id(app, "submenu_profiles", tray_texts.switch_profile);
+        let active_profile_id = app_settings.active_profile_id.as_deref();
+
+        for profile in &app_settings.profiles {
+            let item = CheckMenuItem::with_id(
+                app,
+                format!("{PROFILE_EVENT_PREFIX}{}", profile.id),
+                &profile.label,
+                true,
+                active_profile_id == Some(profile.id.as_str()),
+                None::<&str>,
+            )
+            .map_err(|e| AppError::Message(format!("创建 Profile 菜单项失败: {e}")))?;
+            profile_submenu_builder = profile_submenu_builder.item(&item);
+        }
+
+        let profile_submenu = profile_submenu_builder
+            .build()
+            .map_err(|e| AppError::Message(format!("构建 Profile 子菜单失败: {e}")))?;
+        menu_builder = menu_builder.item(&profile_submenu).separator();
+    }
 
     // Pre-compute proxy running state (used to disable official providers in tray menu)
     let is_proxy_running = futures::executor::block_on(app_state.proxy_service.is_running());
@@ -729,6 +797,9 @@ pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
             app.exit(0);
         }
         _ => {
+            if handle_profile_tray_event(app, event_id) {
+                return;
+            }
             if handle_provider_tray_event(app, event_id) {
                 return;
             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import {
   LayoutDashboard,
 } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { Provider, VisibleApps } from "@/types";
+import type { Provider, Settings as AppSettings, VisibleApps } from "@/types";
 import type { EnvConflict } from "@/types/env";
 import { useProvidersQuery, useSettingsQuery } from "@/lib/query";
 import {
@@ -58,6 +58,7 @@ import {
   DRAG_REGION_STYLE,
 } from "@/lib/platform";
 import { AppSwitcher } from "@/components/AppSwitcher";
+import { ProfileSwitcher } from "@/components/ProfileSwitcher";
 import { ProviderList } from "@/components/providers/ProviderList";
 import { AddProviderDialog } from "@/components/providers/AddProviderDialog";
 import { EditProviderDialog } from "@/components/providers/EditProviderDialog";
@@ -111,6 +112,11 @@ interface WebDavSyncStatusUpdatedPayload {
   source?: string;
   status?: string;
   error?: string;
+}
+
+interface ProfileSwitchedPayload {
+  profileId?: string;
+  settings?: AppSettings;
 }
 
 const DEFAULT_DRAG_BAR_HEIGHT = isWindows() || isLinux() ? 0 : 28; // px
@@ -370,6 +376,22 @@ function App() {
       console.error("[App] Failed to update tray menu", error);
     }
   });
+
+  useTauriEvent<ProfileSwitchedPayload | null | undefined>(
+    "profile-switched",
+    async (payload) => {
+      if (payload?.settings) {
+        queryClient.setQueryData(["settings"], payload.settings);
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["settings"] }),
+        queryClient.invalidateQueries({ queryKey: ["providers"] }),
+        queryClient.invalidateQueries({ queryKey: ["proxyStatus"] }),
+        queryClient.invalidateQueries({ queryKey: ["proxyTakeoverStatus"] }),
+      ]);
+      await refetch();
+    },
+  );
 
   useTauriEvent<WebDavSyncStatusUpdatedPayload | null | undefined>(
     "webdav-sync-status-updated",
@@ -1196,6 +1218,12 @@ function App() {
           </div>
 
           <div className="flex flex-1 min-w-0 items-center justify-end gap-1.5">
+            <div
+              className="shrink-0"
+              style={{ WebkitAppRegion: "no-drag" } as any}
+            >
+              <ProfileSwitcher settings={settingsData} />
+            </div>
             {currentView === "providers" &&
               activeApp !== "opencode" &&
               activeApp !== "openclaw" &&

--- a/src/components/ProfileSwitcher.tsx
+++ b/src/components/ProfileSwitcher.tsx
@@ -1,0 +1,116 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Layers, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+import { settingsApi } from "@/lib/api";
+import type { Settings } from "@/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface ProfileSwitcherProps {
+  settings?: Settings;
+}
+
+export function ProfileSwitcher({ settings }: ProfileSwitcherProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [isSwitching, setIsSwitching] = useState(false);
+
+  const profiles = settings?.profiles ?? [];
+  const activeProfileId = settings?.activeProfileId ?? profiles[0]?.id;
+
+  const activeProfile = useMemo(
+    () => profiles.find((profile) => profile.id === activeProfileId),
+    [profiles, activeProfileId],
+  );
+
+  if (profiles.length <= 1 || !activeProfileId) {
+    return null;
+  }
+
+  const handleSwitch = async (nextProfileId: string) => {
+    if (nextProfileId === activeProfileId || isSwitching) {
+      return;
+    }
+
+    const nextProfile = profiles.find(
+      (profile) => profile.id === nextProfileId,
+    );
+    try {
+      setIsSwitching(true);
+      const nextSettings = await settingsApi.switchProfile(nextProfileId);
+      queryClient.setQueryData(["settings"], nextSettings);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["settings"] }),
+        queryClient.invalidateQueries({ queryKey: ["providers"] }),
+        queryClient.invalidateQueries({ queryKey: ["proxyStatus"] }),
+        queryClient.invalidateQueries({ queryKey: ["proxyTakeoverStatus"] }),
+      ]);
+      toast.success(
+        t("notifications.profileSwitchSuccess", {
+          profile: nextProfile?.label ?? nextProfileId,
+          defaultValue: "Switched to {{profile}}",
+        }),
+        { closeButton: true },
+      );
+    } catch (error) {
+      console.error("[ProfileSwitcher] Failed to switch profile", error);
+      toast.error(
+        t("notifications.profileSwitchFailed", {
+          error: (error as Error)?.message ?? String(error),
+          defaultValue: "Switch profile failed: {{error}}",
+        }),
+      );
+    } finally {
+      setIsSwitching(false);
+    }
+  };
+
+  return (
+    <Select
+      value={activeProfileId}
+      onValueChange={(value) => void handleSwitch(value)}
+      disabled={isSwitching}
+    >
+      <SelectTrigger
+        className="h-8 w-[150px] rounded-lg bg-background/70 px-2.5 text-xs shadow-none"
+        title={t("settings.profiles.switch", {
+          defaultValue: "Switch profile",
+        })}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {isSwitching ? (
+            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+          ) : (
+            <Layers className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <SelectValue
+            placeholder={t("settings.profiles.placeholder", {
+              defaultValue: "Profile",
+            })}
+          >
+            <span className="truncate">
+              {activeProfile?.label ??
+                t("settings.profiles.placeholder", {
+                  defaultValue: "Profile",
+                })}
+            </span>
+          </SelectValue>
+        </div>
+      </SelectTrigger>
+      <SelectContent align="end" className="min-w-[180px]">
+        {profiles.map((profile) => (
+          <SelectItem key={profile.id} value={profile.id}>
+            {profile.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/settings/ProfilesSettings.tsx
+++ b/src/components/settings/ProfilesSettings.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Check, Copy, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { generateUUID } from "@/utils/uuid";
+import type { SettingsFormState } from "@/hooks/useSettings";
+import type { Profile } from "@/types";
+
+interface ProfilesSettingsProps {
+  settings: SettingsFormState;
+  onChange: (updates: Partial<SettingsFormState>) => void;
+}
+
+const PROFILE_DIR_FIELDS: Array<{
+  key: keyof Pick<Profile, "claudeConfigDir" | "codexConfigDir">;
+  labelKey: string;
+  defaultLabel: string;
+}> = [
+  {
+    key: "claudeConfigDir",
+    labelKey: "settings.profiles.apps.claudeCode",
+    defaultLabel: "Claude Code",
+  },
+  {
+    key: "codexConfigDir",
+    labelKey: "settings.profiles.apps.codex",
+    defaultLabel: "Codex",
+  },
+];
+
+const sanitize = (value?: string | null): string | undefined => {
+  const trimmed = value?.trim() ?? "";
+  return trimmed ? trimmed : undefined;
+};
+
+const currentProfileFromSettings = (
+  id: string,
+  label: string,
+  settings: SettingsFormState,
+): Profile => ({
+  id,
+  label,
+  claudeConfigDir: sanitize(settings.claudeConfigDir),
+  codexConfigDir: sanitize(settings.codexConfigDir),
+  currentProviderClaude: settings.currentProviderClaude,
+  currentProviderCodex: settings.currentProviderCodex,
+});
+
+export function ProfilesSettings({
+  settings,
+  onChange,
+}: ProfilesSettingsProps) {
+  const { t } = useTranslation();
+  const defaultProfileName = t("settings.profiles.defaultName", {
+    defaultValue: "Default",
+  });
+  const profiles = settings.profiles?.length
+    ? settings.profiles
+    : [currentProfileFromSettings("default", defaultProfileName, settings)];
+  const persistedActiveProfileId = settings.activeProfileId ?? profiles[0]?.id;
+  const [selectedProfileId, setSelectedProfileId] = useState<
+    string | undefined
+  >(persistedActiveProfileId);
+
+  useEffect(() => {
+    if (
+      !selectedProfileId ||
+      !profiles.some((profile) => profile.id === selectedProfileId)
+    ) {
+      setSelectedProfileId(persistedActiveProfileId);
+    }
+  }, [persistedActiveProfileId, profiles, selectedProfileId]);
+
+  const selectedProfile =
+    profiles.find((profile) => profile.id === selectedProfileId) ?? profiles[0];
+
+  const profileIds = useMemo(
+    () => new Set(profiles.map((profile) => profile.id)),
+    [profiles],
+  );
+
+  const applyProfiles = (
+    nextProfiles: Profile[],
+    nextActiveProfileId = persistedActiveProfileId,
+    nextSelectedProfileId = selectedProfileId,
+  ) => {
+    const nextActive = nextProfiles.find(
+      (profile) => profile.id === nextActiveProfileId,
+    );
+    setSelectedProfileId(nextSelectedProfileId);
+    onChange({
+      profiles: nextProfiles,
+      activeProfileId: nextActiveProfileId,
+      ...(nextActive
+        ? {
+            claudeConfigDir: nextActive.claudeConfigDir,
+            codexConfigDir: nextActive.codexConfigDir,
+            currentProviderClaude: nextActive.currentProviderClaude,
+            currentProviderCodex: nextActive.currentProviderCodex,
+          }
+        : {}),
+    });
+  };
+
+  const updateProfile = (profileId: string, updates: Partial<Profile>) => {
+    const nextProfiles = profiles.map((profile) =>
+      profile.id === profileId ? { ...profile, ...updates } : profile,
+    );
+    applyProfiles(nextProfiles, persistedActiveProfileId, profileId);
+  };
+
+  const addProfile = () => {
+    let baseId = `profile-${profiles.length + 1}`;
+    while (profileIds.has(baseId)) {
+      baseId = `profile-${generateUUID().slice(0, 8)}`;
+    }
+    const newProfile: Profile = {
+      id: baseId,
+      label: t("settings.profiles.defaultLabel", {
+        number: profiles.length + 1,
+        defaultValue: "Profile {{number}}",
+      }),
+    };
+    applyProfiles(
+      [...profiles, newProfile],
+      persistedActiveProfileId ?? newProfile.id,
+      newProfile.id,
+    );
+  };
+
+  const duplicateProfile = (source: Profile) => {
+    const id = `profile-${generateUUID().slice(0, 8)}`;
+    const copy: Profile = {
+      ...source,
+      id,
+      label: t("settings.profiles.copyLabel", {
+        label: source.label,
+        defaultValue: "{{label}} Copy",
+      }),
+    };
+    applyProfiles([...profiles, copy], persistedActiveProfileId, copy.id);
+  };
+
+  const deleteProfile = (profileId: string) => {
+    if (profiles.length <= 1) {
+      return;
+    }
+    const nextProfiles = profiles.filter((profile) => profile.id !== profileId);
+    const nextActiveProfileId =
+      persistedActiveProfileId === profileId
+        ? nextProfiles[0]?.id
+        : persistedActiveProfileId;
+    const nextSelectedProfileId =
+      selectedProfileId === profileId ? nextActiveProfileId : selectedProfileId;
+    applyProfiles(nextProfiles, nextActiveProfileId, nextSelectedProfileId);
+  };
+
+  if (!selectedProfile) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-medium">
+              {t("settings.profiles.title", { defaultValue: "Profiles" })}
+            </h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("settings.profiles.description", {
+                defaultValue:
+                  "Isolate local directories and current providers.",
+              })}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="icon"
+            variant="outline"
+            onClick={addProfile}
+            title={t("settings.profiles.add", { defaultValue: "Add profile" })}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="space-y-1">
+          {profiles.map((profile) => {
+            const active = profile.id === persistedActiveProfileId;
+            const selected = profile.id === selectedProfile.id;
+            return (
+              <button
+                key={profile.id}
+                type="button"
+                className={cn(
+                  "flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors",
+                  selected
+                    ? "border-blue-500/50 bg-blue-500/10 text-foreground"
+                    : "border-border-default bg-background hover:bg-muted/60",
+                )}
+                onClick={() => setSelectedProfileId(profile.id)}
+              >
+                <span className="min-w-0 flex-1 truncate">{profile.label}</span>
+                {active ? (
+                  <Badge variant="outline" className="shrink-0 px-1.5 py-0">
+                    {t("settings.profiles.active", { defaultValue: "Active" })}
+                  </Badge>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-5">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="profile-label">
+              {t("settings.profiles.name", { defaultValue: "Name" })}
+            </Label>
+            <Input
+              id="profile-label"
+              value={selectedProfile.label}
+              onChange={(event) =>
+                updateProfile(selectedProfile.id, { label: event.target.value })
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="profile-id">
+              {t("settings.profiles.id", { defaultValue: "ID" })}
+            </Label>
+            <Input id="profile-id" value={selectedProfile.id} disabled />
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h4 className="text-sm font-medium">
+                {t("settings.profiles.configDirectories", {
+                  defaultValue: "Config directories",
+                })}
+              </h4>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t("settings.profiles.emptyHint", {
+                  defaultValue:
+                    "Empty fields use the default location for that app.",
+                })}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => duplicateProfile(selectedProfile)}
+              >
+                <Copy className="h-3.5 w-3.5" />
+                {t("settings.profiles.duplicate", {
+                  defaultValue: "Duplicate",
+                })}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  applyProfiles(
+                    profiles,
+                    selectedProfile.id,
+                    selectedProfile.id,
+                  )
+                }
+              >
+                <Check className="h-3.5 w-3.5" />
+                {t("settings.profiles.setActive", {
+                  defaultValue: "Set active",
+                })}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={profiles.length <= 1}
+                onClick={() => deleteProfile(selectedProfile.id)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                {t("common.delete")}
+              </Button>
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            {PROFILE_DIR_FIELDS.map((field) => (
+              <div
+                key={field.key}
+                className="grid gap-2 sm:grid-cols-[120px_1fr] sm:items-center"
+              >
+                <Label className="text-xs text-muted-foreground">
+                  {t(field.labelKey, { defaultValue: field.defaultLabel })}
+                </Label>
+                <Input
+                  value={
+                    (selectedProfile[field.key] as string | undefined) ?? ""
+                  }
+                  placeholder={t("settings.profiles.defaultPlaceholder", {
+                    defaultValue: "Default",
+                  })}
+                  className="text-xs"
+                  onChange={(event) =>
+                    updateProfile(selectedProfile.id, {
+                      [field.key]: sanitize(event.target.value),
+                    } as Partial<Profile>)
+                  }
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -4,6 +4,7 @@ import {
   Loader2,
   Save,
   FolderSearch,
+  Layers,
   Database,
   Cloud,
   ScrollText,
@@ -35,6 +36,7 @@ import { SkillStorageLocationSettings } from "@/components/settings/SkillStorage
 import { SkillSyncMethodSettings } from "@/components/settings/SkillSyncMethodSettings";
 import { TerminalSettings } from "@/components/settings/TerminalSettings";
 import { DirectorySettings } from "@/components/settings/DirectorySettings";
+import { ProfilesSettings } from "@/components/settings/ProfilesSettings";
 import { ImportExportSection } from "@/components/settings/ImportExportSection";
 import { BackupListSection } from "@/components/settings/BackupListSection";
 import { WebdavSyncSection } from "@/components/settings/WebdavSyncSection";
@@ -288,6 +290,36 @@ export function SettingsPage({
                       defaultValue={[]}
                       className="w-full space-y-4"
                     >
+                      <AccordionItem
+                        value="profiles"
+                        className="rounded-xl glass-card overflow-hidden"
+                      >
+                        <AccordionTrigger className="px-6 py-4 hover:no-underline hover:bg-muted/50 data-[state=open]:bg-muted/50">
+                          <div className="flex items-center gap-3">
+                            <Layers className="h-5 w-5 text-blue-500" />
+                            <div className="text-left">
+                              <h3 className="text-base font-semibold">
+                                {t("settings.advanced.profiles.title", {
+                                  defaultValue: "Profiles",
+                                })}
+                              </h3>
+                              <p className="text-sm text-muted-foreground font-normal">
+                                {t("settings.advanced.profiles.description", {
+                                  defaultValue:
+                                    "Switch local environments without changing provider data",
+                                })}
+                              </p>
+                            </div>
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent className="px-6 pb-6 pt-4 border-t border-border/50">
+                          <ProfilesSettings
+                            settings={settings}
+                            onChange={updateSettings}
+                          />
+                        </AccordionContent>
+                      </AccordionItem>
+
                       <AccordionItem
                         value="directory"
                         className="rounded-xl glass-card overflow-hidden"

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -3,7 +3,10 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { providersApi, settingsApi } from "@/lib/api";
-import { syncCurrentProvidersLiveSafe } from "@/utils/postChangeSync";
+import {
+  syncCurrentProvidersLiveSafe,
+  syncProfileManagedProvidersLiveSafe,
+} from "@/utils/postChangeSync";
 import { useSettingsQuery, useSaveSettingsMutation } from "@/lib/query";
 import type { Settings } from "@/types";
 import { useSettingsForm, type SettingsFormState } from "./useSettingsForm";
@@ -147,7 +150,7 @@ export function useSettings(): UseSettingsResult {
           await settingsApi.applyClaudePluginConfig({ official: true });
         }
 
-        const syncResult = await syncCurrentProvidersLiveSafe();
+        const syncResult = await syncProfileManagedProvidersLiveSafe();
         if (!syncResult.ok) {
           console.warn(
             "[useSettings] Failed to sync providers after toggling Claude plugin",
@@ -193,6 +196,7 @@ export function useSettings(): UseSettingsResult {
         const sanitizedOpenclawDir = sanitizeDir(
           mergedSettings.openclawConfigDir,
         );
+        const sanitizedHermesDir = sanitizeDir(mergedSettings.hermesConfigDir);
         const { webdavSync: _ignoredWebdavSync, ...restSettings } =
           mergedSettings;
 
@@ -203,6 +207,7 @@ export function useSettings(): UseSettingsResult {
           geminiConfigDir: sanitizedGeminiDir,
           opencodeConfigDir: sanitizedOpencodeDir,
           openclawConfigDir: sanitizedOpenclawDir,
+          hermesConfigDir: sanitizedHermesDir,
           language: mergedSettings.language,
         };
 
@@ -321,12 +326,14 @@ export function useSettings(): UseSettingsResult {
         const sanitizedOpenclawDir = sanitizeDir(
           mergedSettings.openclawConfigDir,
         );
+        const sanitizedHermesDir = sanitizeDir(mergedSettings.hermesConfigDir);
         const previousAppDir = initialAppConfigDir;
         const previousClaudeDir = sanitizeDir(data?.claudeConfigDir);
         const previousCodexDir = sanitizeDir(data?.codexConfigDir);
         const previousGeminiDir = sanitizeDir(data?.geminiConfigDir);
         const previousOpencodeDir = sanitizeDir(data?.opencodeConfigDir);
         const previousOpenclawDir = sanitizeDir(data?.openclawConfigDir);
+        const previousHermesDir = sanitizeDir(data?.hermesConfigDir);
         const { webdavSync: _ignoredWebdavSync, ...restSettings } =
           mergedSettings;
 
@@ -337,6 +344,7 @@ export function useSettings(): UseSettingsResult {
           geminiConfigDir: sanitizedGeminiDir,
           opencodeConfigDir: sanitizedOpencodeDir,
           openclawConfigDir: sanitizedOpenclawDir,
+          hermesConfigDir: sanitizedHermesDir,
           language: mergedSettings.language,
         };
 
@@ -423,18 +431,36 @@ export function useSettings(): UseSettingsResult {
         const geminiDirChanged = sanitizedGeminiDir !== previousGeminiDir;
         const opencodeDirChanged = sanitizedOpencodeDir !== previousOpencodeDir;
         const openclawDirChanged = sanitizedOpenclawDir !== previousOpenclawDir;
-        if (
-          !pluginSynced &&
-          (claudeDirChanged ||
-            codexDirChanged ||
-            geminiDirChanged ||
-            opencodeDirChanged ||
-            openclawDirChanged)
-        ) {
+        const hermesDirChanged = sanitizedHermesDir !== previousHermesDir;
+        const profilesChanged =
+          JSON.stringify(payload.profiles ?? []) !==
+          JSON.stringify(data?.profiles ?? []);
+        const activeProfileChanged =
+          (payload.activeProfileId ?? undefined) !==
+          (data?.activeProfileId ?? undefined);
+        const profileManagedChanged =
+          claudeDirChanged ||
+          codexDirChanged ||
+          profilesChanged ||
+          activeProfileChanged;
+        const otherDirChanged =
+          geminiDirChanged ||
+          opencodeDirChanged ||
+          openclawDirChanged ||
+          hermesDirChanged;
+        if (!pluginSynced && otherDirChanged) {
           const syncResult = await syncCurrentProvidersLiveSafe();
           if (!syncResult.ok) {
             console.warn(
               "[useSettings] Failed to sync current providers after directory change",
+              syncResult.error,
+            );
+          }
+        } else if (!pluginSynced && profileManagedChanged) {
+          const syncResult = await syncProfileManagedProvidersLiveSafe();
+          if (!syncResult.ok) {
+            console.warn(
+              "[useSettings] Failed to sync profile-managed providers after profile change",
               syncResult.error,
             );
           }

--- a/src/hooks/useSettingsForm.ts
+++ b/src/hooks/useSettingsForm.ts
@@ -121,6 +121,7 @@ export function useSettingsForm(): UseSettingsFormResult {
       geminiConfigDir: sanitizeDir(data.geminiConfigDir),
       opencodeConfigDir: sanitizeDir(data.opencodeConfigDir),
       openclawConfigDir: sanitizeDir(data.openclawConfigDir),
+      hermesConfigDir: sanitizeDir(data.hermesConfigDir),
       language: normalizedLanguage,
     };
 
@@ -182,6 +183,7 @@ export function useSettingsForm(): UseSettingsFormResult {
         geminiConfigDir: sanitizeDir(serverData.geminiConfigDir),
         opencodeConfigDir: sanitizeDir(serverData.opencodeConfigDir),
         openclawConfigDir: sanitizeDir(serverData.openclawConfigDir),
+        hermesConfigDir: sanitizeDir(serverData.hermesConfigDir),
         language: normalizedLanguage,
       };
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -246,6 +246,8 @@
     "deleteFailed": "Failed to delete provider: {{error}}",
     "settingsSaved": "Settings saved",
     "settingsSaveFailed": "Failed to save settings: {{error}}",
+    "profileSwitchSuccess": "Switched to {{profile}}",
+    "profileSwitchFailed": "Switch profile failed: {{error}}",
     "proxyRequiredForSwitch": "This provider {{reason}}, requires the routing service to work properly. Start routing first.",
     "proxyReasonCopilot": "uses GitHub Copilot as a Claude provider",
     "proxyReasonOpenAIChat": "uses OpenAI Chat API format",
@@ -314,6 +316,10 @@
       "codexOauthDescription": "Manage ChatGPT accounts"
     },
     "advanced": {
+      "profiles": {
+        "title": "Profiles",
+        "description": "Isolate directory overrides and current providers by local environment"
+      },
       "configDir": {
         "title": "Configuration Directory",
         "description": "Manage storage paths for Claude, Codex and Gemini configurations"
@@ -402,6 +408,28 @@
           "debug": "Detailed info including SSE stream and request/response",
           "trace": "All logs, most verbose"
         }
+      }
+    },
+    "profiles": {
+      "title": "Profiles",
+      "description": "Isolate local directories and current provider selections.",
+      "switch": "Switch profile",
+      "placeholder": "Profile",
+      "add": "Add profile",
+      "active": "Active",
+      "name": "Name",
+      "id": "ID",
+      "configDirectories": "Config directories",
+      "emptyHint": "Empty fields use the default location for that app.",
+      "duplicate": "Duplicate",
+      "setActive": "Set active",
+      "defaultPlaceholder": "Default",
+      "defaultName": "Default",
+      "defaultLabel": "Profile {{number}}",
+      "copyLabel": "{{label}} Copy",
+      "apps": {
+        "claudeCode": "Claude Code",
+        "codex": "Codex"
       }
     },
     "language": "Language",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -246,6 +246,8 @@
     "deleteFailed": "プロバイダーの削除に失敗しました: {{error}}",
     "settingsSaved": "設定を保存しました",
     "settingsSaveFailed": "設定の保存に失敗しました: {{error}}",
+    "profileSwitchSuccess": "{{profile}} に切り替えました",
+    "profileSwitchFailed": "プロファイルの切り替えに失敗しました: {{error}}",
     "proxyRequiredForSwitch": "このプロバイダーは{{reason}}、ルーティングサービスが必要です。先にルーティングを起動してください",
     "proxyReasonCopilot": "GitHub Copilot を Claude プロバイダーとして使用しており",
     "proxyReasonOpenAIChat": "OpenAI Chat API フォーマットを使用しており",
@@ -314,6 +316,10 @@
       "codexOauthDescription": "ChatGPT アカウントを管理します"
     },
     "advanced": {
+      "profiles": {
+        "title": "プロファイル",
+        "description": "ローカル環境ごとにディレクトリ上書きと現在のプロバイダーを分離"
+      },
       "configDir": {
         "title": "設定ディレクトリ",
         "description": "Claude、Codex、Gemini の設定保存パスを管理"
@@ -402,6 +408,28 @@
           "debug": "SSE ストリームとリクエスト/レスポンスを含む詳細情報",
           "trace": "すべてのログ、最も詳細"
         }
+      }
+    },
+    "profiles": {
+      "title": "プロファイル",
+      "description": "ローカルディレクトリと現在のプロバイダー選択を分離します。",
+      "switch": "プロファイルを切り替え",
+      "placeholder": "プロファイル",
+      "add": "プロファイルを追加",
+      "active": "現在",
+      "name": "名前",
+      "id": "ID",
+      "configDirectories": "設定ディレクトリ",
+      "emptyHint": "空欄の場合、そのアプリのデフォルト位置を使用します。",
+      "duplicate": "複製",
+      "setActive": "現在に設定",
+      "defaultPlaceholder": "デフォルト",
+      "defaultName": "デフォルト",
+      "defaultLabel": "プロファイル {{number}}",
+      "copyLabel": "{{label}} のコピー",
+      "apps": {
+        "claudeCode": "Claude Code",
+        "codex": "Codex"
       }
     },
     "language": "言語",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -246,6 +246,8 @@
     "deleteFailed": "刪除供應商失敗：{{error}}",
     "settingsSaved": "設定已儲存",
     "settingsSaveFailed": "儲存設定失敗：{{error}}",
+    "profileSwitchSuccess": "已切換到 {{profile}}",
+    "profileSwitchFailed": "切換設定檔失敗：{{error}}",
     "proxyRequiredForSwitch": "此供應商 {{reason}}，需要路由服務才能正常使用，請先啟動路由",
     "proxyReasonCopilot": "使用 GitHub Copilot 作為 Claude 供應商",
     "proxyReasonOpenAIChat": "使用 OpenAI Chat API 格式",
@@ -314,6 +316,10 @@
       "codexOauthDescription": "管理 ChatGPT 帳號"
     },
     "advanced": {
+      "profiles": {
+        "title": "環境設定檔",
+        "description": "依本機環境隔離目錄覆寫與目前供應商"
+      },
       "configDir": {
         "title": "設定檔目錄",
         "description": "管理 Claude、Codex 和 Gemini 的設定儲存路徑"
@@ -402,6 +408,28 @@
           "debug": "詳細資訊，包含 SSE 串流與請求/回應詳情",
           "trace": "全部日誌，最詳細"
         }
+      }
+    },
+    "profiles": {
+      "title": "設定檔",
+      "description": "隔離本機目錄和目前供應商選擇。",
+      "switch": "切換設定檔",
+      "placeholder": "設定檔",
+      "add": "新增設定檔",
+      "active": "目前",
+      "name": "名稱",
+      "id": "ID",
+      "configDirectories": "設定目錄",
+      "emptyHint": "留空時使用該應用程式的預設位置。",
+      "duplicate": "複製",
+      "setActive": "設為目前",
+      "defaultPlaceholder": "預設",
+      "defaultName": "預設",
+      "defaultLabel": "設定檔 {{number}}",
+      "copyLabel": "{{label}} 副本",
+      "apps": {
+        "claudeCode": "Claude Code",
+        "codex": "Codex"
       }
     },
     "language": "介面語言",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -246,6 +246,8 @@
     "deleteFailed": "删除供应商失败：{{error}}",
     "settingsSaved": "设置已保存",
     "settingsSaveFailed": "保存设置失败：{{error}}",
+    "profileSwitchSuccess": "已切换到 {{profile}}",
+    "profileSwitchFailed": "切换配置档失败：{{error}}",
     "proxyRequiredForSwitch": "此供应商{{reason}}，需要路由服务才能正常使用，请先启动路由",
     "proxyReasonCopilot": "使用 GitHub Copilot 作为 Claude 供应商",
     "proxyReasonOpenAIChat": "使用 OpenAI Chat 接口格式",
@@ -314,6 +316,10 @@
       "codexOauthDescription": "管理 ChatGPT 账号"
     },
     "advanced": {
+      "profiles": {
+        "title": "环境配置档",
+        "description": "按本机环境隔离目录覆盖和当前供应商"
+      },
       "configDir": {
         "title": "配置文件目录",
         "description": "管理 Claude、Codex 和 Gemini 的配置存储路径"
@@ -402,6 +408,28 @@
           "debug": "详细信息，包含 SSE 流和请求/响应详情",
           "trace": "全部日志，最详细"
         }
+      }
+    },
+    "profiles": {
+      "title": "配置档",
+      "description": "隔离本机目录和当前供应商选择。",
+      "switch": "切换配置档",
+      "placeholder": "配置档",
+      "add": "添加配置档",
+      "active": "当前",
+      "name": "名称",
+      "id": "ID",
+      "configDirectories": "配置目录",
+      "emptyHint": "留空时使用该应用的默认位置。",
+      "duplicate": "复制",
+      "setActive": "设为当前",
+      "defaultPlaceholder": "默认",
+      "defaultName": "默认",
+      "defaultLabel": "配置档 {{number}}",
+      "copyLabel": "{{label}} 副本",
+      "apps": {
+        "claudeCode": "Claude Code",
+        "codex": "Codex"
       }
     },
     "language": "界面语言",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -27,6 +27,10 @@ export const settingsApi = {
     return await invoke("save_settings", { settings });
   },
 
+  async switchProfile(profileId: string): Promise<Settings> {
+    return await invoke("switch_profile", { profileId });
+  },
+
   async restart(): Promise<boolean> {
     return await invoke("restart_app");
   },
@@ -149,6 +153,18 @@ export const settingsApi = {
     };
     if (!result?.success) {
       throw new Error(result?.message || "Sync current providers failed");
+    }
+  },
+
+  async syncProfileManagedProvidersLive(): Promise<void> {
+    const result = (await invoke("sync_profile_managed_providers_live")) as {
+      success?: boolean;
+      message?: string;
+    };
+    if (!result?.success) {
+      throw new Error(
+        result?.message || "Sync profile-managed providers failed",
+      );
     }
   },
 

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -7,6 +7,24 @@ const directorySchema = z
   .optional()
   .or(z.literal(""));
 
+const profileSchema = z.object({
+  id: z.string().trim().min(1, "Profile ID 不能为空"),
+  label: z.string().trim().min(1, "Profile 名称不能为空"),
+  claudeConfigDir: directorySchema.nullable().optional(),
+  codexConfigDir: directorySchema.nullable().optional(),
+  geminiConfigDir: directorySchema.nullable().optional(),
+  opencodeConfigDir: directorySchema.nullable().optional(),
+  openclawConfigDir: directorySchema.nullable().optional(),
+  hermesConfigDir: directorySchema.nullable().optional(),
+  currentProviderClaude: z.string().optional(),
+  currentProviderClaudeDesktop: z.string().optional(),
+  currentProviderCodex: z.string().optional(),
+  currentProviderGemini: z.string().optional(),
+  currentProviderOpencode: z.string().optional(),
+  currentProviderOpenclaw: z.string().optional(),
+  currentProviderHermes: z.string().optional(),
+});
+
 export const settingsSchema = z.object({
   // 设备级 UI 设置
   showInTray: z.boolean(),
@@ -23,12 +41,20 @@ export const settingsSchema = z.object({
   geminiConfigDir: directorySchema.nullable().optional(),
   opencodeConfigDir: directorySchema.nullable().optional(),
   openclawConfigDir: directorySchema.nullable().optional(),
+  hermesConfigDir: directorySchema.nullable().optional(),
 
   // 当前供应商 ID（设备级）
   currentProviderClaude: z.string().optional(),
   currentProviderClaudeDesktop: z.string().optional(),
   currentProviderCodex: z.string().optional(),
   currentProviderGemini: z.string().optional(),
+  currentProviderOpencode: z.string().optional(),
+  currentProviderOpenclaw: z.string().optional(),
+  currentProviderHermes: z.string().optional(),
+
+  // 环境配置档
+  profiles: z.array(profileSchema).optional(),
+  activeProfileId: z.string().optional(),
 
   // Skill 同步设置
   skillSyncMethod: z.enum(["auto", "symlink", "copy"]).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,25 @@ export interface WebDavSyncSettings {
 
 export type RemoteSnapshotLayout = "current" | "legacy";
 
+// 本机环境配置档：目录覆盖和当前供应商选择按 profile 隔离。
+export interface Profile {
+  id: string;
+  label: string;
+  claudeConfigDir?: string;
+  codexConfigDir?: string;
+  geminiConfigDir?: string;
+  opencodeConfigDir?: string;
+  openclawConfigDir?: string;
+  hermesConfigDir?: string;
+  currentProviderClaude?: string;
+  currentProviderClaudeDesktop?: string;
+  currentProviderCodex?: string;
+  currentProviderGemini?: string;
+  currentProviderOpencode?: string;
+  currentProviderOpenclaw?: string;
+  currentProviderHermes?: string;
+}
+
 // 远端快照信息（下载前预览）
 export interface RemoteSnapshotInfo {
   deviceName: string;
@@ -370,6 +389,16 @@ export interface Settings {
   currentProviderCodex?: string;
   // 当前 Gemini 供应商 ID（优先于数据库 is_current）
   currentProviderGemini?: string;
+  // 当前 OpenCode 供应商 ID（优先于数据库 is_current）
+  currentProviderOpencode?: string;
+  // 当前 OpenClaw 供应商 ID（优先于数据库 is_current）
+  currentProviderOpenclaw?: string;
+  // 当前 Hermes 供应商 ID（优先于数据库 is_current）
+  currentProviderHermes?: string;
+
+  // ===== 环境配置档（设备级）=====
+  profiles?: Profile[];
+  activeProfileId?: string;
 
   // ===== Skill 同步设置 =====
   // Skill 同步方式：auto（默认，优先 symlink）、symlink、copy

--- a/src/utils/postChangeSync.ts
+++ b/src/utils/postChangeSync.ts
@@ -16,3 +16,16 @@ export async function syncCurrentProvidersLiveSafe(): Promise<{
     return { ok: false, error };
   }
 }
+
+export async function syncProfileManagedProvidersLiveSafe(): Promise<{
+  ok: boolean;
+  error?: Error;
+}> {
+  try {
+    await settingsApi.syncProfileManagedProvidersLive();
+    return { ok: true };
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err ?? ""));
+    return { ok: false, error };
+  }
+}

--- a/tests/hooks/useSettings.test.tsx
+++ b/tests/hooks/useSettings.test.tsx
@@ -10,6 +10,7 @@ const applyClaudePluginConfigMock = vi.fn();
 const applyClaudeOnboardingSkipMock = vi.fn();
 const clearClaudeOnboardingSkipMock = vi.fn();
 const syncCurrentProvidersLiveMock = vi.fn();
+const syncProfileManagedProvidersLiveMock = vi.fn();
 const updateTrayMenuMock = vi.fn();
 const getCurrentMock = vi.fn();
 const getAllMock = vi.fn();
@@ -73,6 +74,8 @@ vi.mock("@/lib/api", () => ({
       clearClaudeOnboardingSkipMock(...args),
     syncCurrentProvidersLive: (...args: unknown[]) =>
       syncCurrentProvidersLiveMock(...args),
+    syncProfileManagedProvidersLive: (...args: unknown[]) =>
+      syncProfileManagedProvidersLiveMock(...args),
   },
   providersApi: {
     updateTrayMenu: (...args: unknown[]) => updateTrayMenuMock(...args),
@@ -144,6 +147,7 @@ describe("useSettings hook", () => {
     applyClaudeOnboardingSkipMock.mockReset();
     clearClaudeOnboardingSkipMock.mockReset();
     syncCurrentProvidersLiveMock.mockReset();
+    syncProfileManagedProvidersLiveMock.mockReset();
     getCurrentMock.mockReset();
     getAllMock.mockReset();
     getQueryDataMock.mockReset();
@@ -184,6 +188,7 @@ describe("useSettings hook", () => {
     applyClaudeOnboardingSkipMock.mockResolvedValue(true);
     clearClaudeOnboardingSkipMock.mockResolvedValue(true);
     syncCurrentProvidersLiveMock.mockResolvedValue({ ok: true });
+    syncProfileManagedProvidersLiveMock.mockResolvedValue({ ok: true });
     getCurrentMock.mockResolvedValue(null);
     getAllMock.mockResolvedValue({});
     // 默认将 queryClient 缓存对齐到 serverSettings，既有断言的 "prev === data" 语义保持不变
@@ -301,8 +306,9 @@ describe("useSettings hook", () => {
     expect(metadataMock.setRequiresRestart).toHaveBeenCalledWith(true);
     expect(window.localStorage.getItem("language")).toBe("en");
     expect(toastErrorMock).not.toHaveBeenCalled();
-    // 插件同步已包含 syncCurrentProvidersLiveSafe，目录变更不再重复调用
-    expect(syncCurrentProvidersLiveMock).toHaveBeenCalledTimes(1);
+    // 插件同步已包含 syncProfileManagedProvidersLiveSafe，目录变更不再重复调用
+    expect(syncProfileManagedProvidersLiveMock).toHaveBeenCalledTimes(1);
+    expect(syncCurrentProvidersLiveMock).not.toHaveBeenCalled();
   });
 
   it("saves settings without restart when directory unchanged", async () => {
@@ -421,7 +427,8 @@ describe("useSettings hook", () => {
 
     // 修复生效：读的是缓存实时值 true，payload=false，差异触发 clear_claude_config
     expect(applyClaudePluginConfigMock).toHaveBeenCalledWith({ official: true });
-    expect(syncCurrentProvidersLiveMock).toHaveBeenCalled();
+    expect(syncProfileManagedProvidersLiveMock).toHaveBeenCalled();
+    expect(syncCurrentProvidersLiveMock).not.toHaveBeenCalled();
   });
 
   it("resets form, language and directories using server data", () => {

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -218,7 +218,7 @@ describe("App integration with MSW", () => {
 
     expect(toastErrorMock).not.toHaveBeenCalled();
     expect(toastSuccessMock).toHaveBeenCalled();
-  });
+  }, 15000);
 
   it("shows toast when auto sync fails in background", async () => {
     const { default: App } = await import("@/App");


### PR DESCRIPTION
## 概要

新增本地配置档（Profiles），用于在不同 Claude Code / Codex 环境之间切换配置目录和当前供应商。

- 新增 `profiles` 与 `activeProfileId` 设置字段，并保持旧的单值设置字段兼容。
- 新增顶部 Profile 切换器和托盘菜单 Profile 切换入口。
- 在 Advanced 设置页新增 Profiles 管理区，支持新增、复制、删除、编辑和设为当前配置档。
- 切换配置档时会先保存当前配置档快照，再应用目标配置档，并同步 Claude Code / Codex 的 live 配置。
- Profile 管理范围限定为 Claude Code 和 Codex，避免改写无关应用配置。
- 保存旧版或局部 settings payload 时，避免误删已有 profiles。

## 验证

- `tsc --noEmit`
- `prettier --check` 本次改动的前端和 i18n 文件
- `git diff --check`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
  - 本次新增的 profile/settings 测试通过。
  - 全量测试中有 2 个既有失败，分别在 usage rollup 和 OpenClaw session 测试，不在本 PR 改动范围。
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
  - 被既有 `src/commands/misc.rs` warning 阻塞，不在本 PR 改动范围。