### PR TITLE
fix: security hardening and correctness fixes from code audit

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,9 @@
     "core:window:allow-close",
     "core:window:allow-set-decorations",
     "process:allow-restart",
-    "dialog:default"
+    "dialog:default",
+    "deep-link:default",
+    "store:default",
+    "window-state:default"
   ]
 }

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -316,12 +316,21 @@ fn build_shell_command(command: &str, cwd: Option<&str>) -> String {
 }
 
 fn shell_escape(value: &str) -> String {
-    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
-    format!("\"{escaped}\"")
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    // Single-quote wrapping prevents all shell metacharacter expansion ($, `, !, etc.)
+    // Embedded single quotes are escaped by closing, adding escaped quote, reopening: '\''
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn escape_osascript(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
 }
 
 #[cfg(test)]
@@ -377,6 +386,26 @@ mod tests {
         );
 
         // Verify shell_escape works correctly for paths with spaces
-        assert_eq!(shell_escape(cwd), "\"/tmp/project dir\"");
+        assert_eq!(shell_escape(cwd), "'/tmp/project dir'");
+    }
+
+    #[test]
+    fn shell_escape_handles_special_characters() {
+        assert_eq!(shell_escape("simple"), "'simple'");
+        assert_eq!(shell_escape("has space"), "'has space'");
+        assert_eq!(shell_escape("has$dollar"), "'has$dollar'");
+        assert_eq!(shell_escape("has`backtick"), "'has`backtick'");
+        assert_eq!(shell_escape("has!bang"), "'has!bang'");
+        assert_eq!(shell_escape("has'single"), "'has'\\''single'");
+        assert_eq!(shell_escape(""), "''");
+    }
+
+    #[test]
+    fn escape_osascript_handles_control_characters() {
+        assert_eq!(escape_osascript("simple"), "simple");
+        assert_eq!(escape_osascript("has\\back"), "has\\\\back");
+        assert_eq!(escape_osascript("has\"quote"), "has\\\"quote");
+        assert_eq!(escape_osascript("has\nnewline"), "has\\nnewline");
+        assert_eq!(escape_osascript("has\ttab"), "has\\ttab");
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: https: http:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost https: http:",
+      "csp": "default-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost",
       "assetProtocol": {
         "enable": true,
         "scope": []

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, useRef } from "react";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
@@ -1002,6 +1003,7 @@ function App() {
   };
 
   return (
+    <ErrorBoundary>
     <div
       className="flex flex-col h-screen overflow-hidden bg-background text-foreground selection:bg-primary/30 pb-4"
       style={{ overflowX: "hidden", paddingTop: contentTopOffset }}
@@ -1598,6 +1600,7 @@ function App() {
       <DeepLinkImportDialog />
       <FirstRunNoticeDialog />
     </div>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import React, { Component, ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("[ErrorBoundary] Caught error:", error, errorInfo);
+  }
+
+  handleReload = () => {
+    this.setState({ hasError: false, error: null });
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex h-screen w-screen items-center justify-center bg-background">
+          <div className="mx-4 max-w-md rounded-lg border border-border bg-card p-6 shadow-lg">
+            <h2 className="mb-2 text-lg font-semibold text-foreground">
+              Something went wrong
+            </h2>
+            <p className="mb-4 text-sm text-muted-foreground">
+              {this.state.error?.message || "An unexpected error occurred."}
+            </p>
+            <button
+              onClick={this.handleReload}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/JsonEditor.tsx
+++ b/src/components/JsonEditor.tsx
@@ -37,6 +37,8 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
   const { t } = useTranslation();
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   // JSON linter 函数
   const jsonLinter = useMemo(
@@ -145,7 +147,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           const newValue = update.state.doc.toString();
-          onChange(newValue);
+          onChangeRef.current(newValue);
         }
       }),
     ];
@@ -208,7 +210,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
       view.destroy();
       viewRef.current = null;
     };
-  }, [darkMode, rows, height, language, jsonLinter]); // 依赖项中不包含 onChange 和 placeholder，避免不必要的重建
+  }, [darkMode, rows, height, language, jsonLinter]); // onChange via ref, placeholder excluded to avoid unnecessary rebuilds
 
   // 当 value 从外部改变时更新编辑器内容
   useEffect(() => {

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -28,6 +28,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
 }) => {
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   useEffect(() => {
     if (!editorRef.current) return;
@@ -68,8 +70,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       extensions.push(
         placeholderExt(placeholderText),
         EditorView.updateListener.of((update) => {
-          if (update.docChanged && onChange) {
-            onChange(update.state.doc.toString());
+          if (update.docChanged && onChangeRef.current) {
+            onChangeRef.current(update.state.doc.toString());
           }
         }),
       );

--- a/src/hooks/usePromptActions.ts
+++ b/src/hooks/usePromptActions.ts
@@ -75,29 +75,25 @@ export function usePromptActions(appId: AppId) {
 
   const toggleEnabled = useCallback(
     async (id: string, enabled: boolean) => {
-      // Optimistic update
+      // Snapshot for rollback (captured from current closure)
       const previousPrompts = prompts;
 
-      // 如果要启用当前提示词，先禁用其他所有提示词
+      // Optimistic update: use functional updater for both branches
       if (enabled) {
-        const updatedPrompts = Object.keys(prompts).reduce(
-          (acc, key) => {
-            acc[key] = {
-              ...prompts[key],
-              enabled: key === id,
-            };
-            return acc;
-          },
-          {} as Record<string, Prompt>,
+        // 启用当前提示词，先禁用其他所有提示词
+        setPrompts((prev) =>
+          Object.keys(prev).reduce(
+            (acc, key) => {
+              acc[key] = { ...prev[key], enabled: key === id };
+              return acc;
+            },
+            {} as Record<string, Prompt>,
+          ),
         );
-        setPrompts(updatedPrompts);
       } else {
         setPrompts((prev) => ({
           ...prev,
-          [id]: {
-            ...prev[id],
-            enabled: false,
-          },
+          [id]: { ...prev[id], enabled: false },
         }));
       }
 
@@ -106,7 +102,6 @@ export function usePromptActions(appId: AppId) {
           await promptsApi.enablePrompt(appId, id);
           toast.success(t("prompts.enableSuccess"), { closeButton: true });
         } else {
-          // 禁用提示词 - 需要后端支持
           await promptsApi.upsertPrompt(appId, id, {
             ...prompts[id],
             enabled: false,
@@ -115,7 +110,6 @@ export function usePromptActions(appId: AppId) {
         }
         await reload();
       } catch (error) {
-        // Rollback on failure
         setPrompts(previousPrompts);
         toast.error(
           enabled ? t("prompts.enableFailed") : t("prompts.disableFailed"),


### PR DESCRIPTION
## Summary

Code audit fixes covering security hardening and frontend correctness.

### 1. Harden shell escaping in terminal launchers
- `shell_escape`: switch from double-quote to single-quote wrapping to prevent `$`, backtick, `!` expansion
- `escape_osascript`: add escaping for `
`, ``, `	` control characters
- Add test coverage for special characters

### 2. Tighten CSP and add missing plugin permissions
- Remove `http:` from `img-src` and `connect-src` — the frontend makes no direct HTTP requests (all via Tauri IPC)
- Add `deep-link:default`, `store:default`, `window-state:default` capabilities for registered plugins

### 3. Fix stale closures in editors and prompt hook
- JsonEditor/MarkdownEditor: use `useRef` pattern for `onChange` to avoid stale closure in CodeMirror update listener
- usePromptActions: use functional updater for `enabled:true` branch (consistent with `enabled:false`)

### 4. Add React Error Boundary
- Prevent white-screen crashes from unhandled render errors
- Shows fallback UI with reload button

## Test plan

- [ ] Verify terminal launch works on macOS (shell_escape change)
- [ ] Verify deep-link, store, window-state plugins work after CSP/permissions change
- [ ] Verify prompt toggle works correctly with rapid clicks
- [ ] Verify editor onChange callbacks fire with latest state
- [ ] Verify ErrorBoundary catches and displays render errors