### PR TITLE
fix: Claude Desktop 官方供应商添加报错 #3402

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -320,7 +320,7 @@ pub fn direct_gateway_credentials(
 }
 
 pub fn validate_direct_provider(provider: &Provider) -> Result<(), AppError> {
-    if is_official_provider(provider) {
+    if is_official_provider(provider) || provider.category.as_deref() == Some("official") {
         return Ok(());
     }
 
@@ -380,7 +380,7 @@ pub fn validate_direct_provider(provider: &Provider) -> Result<(), AppError> {
 }
 
 pub fn validate_proxy_provider(provider: &Provider) -> Result<(), AppError> {
-    if is_official_provider(provider) {
+    if is_official_provider(provider) || provider.category.as_deref() == Some("official") {
         return Ok(());
     }
 
@@ -465,7 +465,7 @@ fn is_managed_oauth_proxy_provider(provider: &Provider) -> bool {
 }
 
 pub fn validate_provider(provider: &Provider) -> Result<(), AppError> {
-    if is_official_provider(provider) {
+    if is_official_provider(provider) || provider.category.as_deref() == Some("official") {
         return Ok(());
     }
 
@@ -885,7 +885,7 @@ fn apply_provider_to_paths(
     provider: &Provider,
     paths: &ClaudeDesktopPaths,
 ) -> Result<(), AppError> {
-    if is_official_provider(provider) {
+    if is_official_provider(provider) || provider.category.as_deref() == Some("official") {
         return restore_official_at_paths(paths);
     }
 

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -320,7 +320,7 @@ pub fn direct_gateway_credentials(
 }
 
 pub fn validate_direct_provider(provider: &Provider) -> Result<(), AppError> {
-    if is_official_provider(provider) || provider.category.as_deref() == Some("official") {
+    if is_official_provider(provider) {
         return Ok(());
     }
 
@@ -380,7 +380,7 @@ pub fn validate_direct_provider(provider: &Provider) -> Result<(), AppError> {
 }
 
 pub fn validate_proxy_provider(provider: &Provider) -> Result<(), AppError> {
-    if is_official_provider(provider) || provider.category.as_deref() == Some("official") {
+    if is_official_provider(provider) {
         return Ok(());
     }
 
@@ -465,7 +465,7 @@ fn is_managed_oauth_proxy_provider(provider: &Provider) -> bool {
 }
 
 pub fn validate_provider(provider: &Provider) -> Result<(), AppError> {
-    if is_official_provider(provider) || provider.category.as_deref() == Some("official") {
+    if is_official_provider(provider) {
         return Ok(());
     }
 
@@ -885,7 +885,7 @@ fn apply_provider_to_paths(
     provider: &Provider,
     paths: &ClaudeDesktopPaths,
 ) -> Result<(), AppError> {
-    if is_official_provider(provider) || provider.category.as_deref() == Some("official") {
+    if is_official_provider(provider) {
         return restore_official_at_paths(paths);
     }
 
@@ -1947,12 +1947,13 @@ mod tests {
         let direct = direct_provider("direct");
         assert!(is_compatible_direct_provider(&direct));
 
-        let claude_official = Provider::with_id(
+        let mut claude_official = Provider::with_id(
             "claude-official".to_string(),
             "Claude Official".to_string(),
             json!({"env": {}}),
             Some("https://www.anthropic.com/claude-code".to_string()),
         );
+        claude_official.category = Some("official".to_string());
         assert!(!is_compatible_direct_provider(&claude_official));
 
         let mut openai_format = direct_provider("openai");

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -219,6 +219,17 @@ pub fn import_claude_desktop_providers_from_claude(
     Ok(imported)
 }
 
+#[tauri::command]
+pub fn ensure_claude_desktop_official_provider(state: State<'_, AppState>) -> Result<bool, String> {
+    state
+        .db
+        .ensure_official_seed_by_id(
+            crate::database::CLAUDE_DESKTOP_OFFICIAL_PROVIDER_ID,
+            AppType::ClaudeDesktop,
+        )
+        .map_err(|e| e.to_string())
+}
+
 fn claude_provider_models_are_claude_safe(provider: &Provider) -> bool {
     let Some(env) = provider
         .settings_config

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1105,6 +1105,7 @@ pub fn run() {
             commands::get_claude_desktop_status,
             commands::get_claude_desktop_default_routes,
             commands::import_claude_desktop_providers_from_claude,
+            commands::ensure_claude_desktop_official_provider,
             commands::get_claude_config_status,
             commands::get_config_status,
             commands::get_claude_code_config_path,

--- a/src/components/providers/AddProviderDialog.tsx
+++ b/src/components/providers/AddProviderDialog.tsx
@@ -30,6 +30,7 @@ interface AddProviderDialogProps {
     provider: Omit<Provider, "id"> & {
       providerKey?: string;
       suggestedDefaults?: OpenClawSuggestedDefaults;
+      ensureClaudeDesktopOfficialSeed?: boolean;
     },
   ) => Promise<void> | void;
 }
@@ -98,6 +99,7 @@ export function AddProviderDialog({
       const providerData: Omit<Provider, "id"> & {
         providerKey?: string;
         suggestedDefaults?: OpenClawSuggestedDefaults;
+        ensureClaudeDesktopOfficialSeed?: boolean;
       } = {
         name: values.name.trim(),
         notes: values.notes?.trim() || undefined,
@@ -108,6 +110,16 @@ export function AddProviderDialog({
         ...(values.presetCategory ? { category: values.presetCategory } : {}),
         ...(values.meta ? { meta: values.meta } : {}),
       };
+
+      if (appId === "claude-desktop" && values.presetId) {
+        const presetIndex = parseInt(
+          values.presetId.replace("claude-desktop-", ""),
+        );
+        const preset = claudeDesktopProviderPresets[presetIndex];
+        providerData.ensureClaudeDesktopOfficialSeed =
+          values.presetCategory === "official" &&
+          preset?.category === "official";
+      }
 
       // OpenCode/OpenClaw: pass providerKey for ID generation
       if (

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -75,6 +75,7 @@ export function useProviderActions(
         providerKey?: string;
         suggestedDefaults?: OpenClawSuggestedDefaults;
         addToLive?: boolean;
+        ensureClaudeDesktopOfficialSeed?: boolean;
       },
     ) => {
       const enhanced = injectCodingPlanUsageScript(activeApp, provider);

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -99,6 +99,10 @@ export const providersApi = {
     return await invoke("import_claude_desktop_providers_from_claude");
   },
 
+  async ensureClaudeDesktopOfficialProvider(): Promise<boolean> {
+    return await invoke("ensure_claude_desktop_official_provider");
+  },
+
   async getClaudeDesktopStatus(): Promise<ClaudeDesktopStatus> {
     return await invoke("get_claude_desktop_status");
   },

--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -19,8 +19,26 @@ export const useAddProviderMutation = (appId: AppId) => {
       providerInput: Omit<Provider, "id"> & {
         providerKey?: string;
         addToLive?: boolean;
+        ensureClaudeDesktopOfficialSeed?: boolean;
       },
     ) => {
+      const {
+        providerKey: _providerKey,
+        addToLive,
+        ensureClaudeDesktopOfficialSeed,
+        ...rest
+      } = providerInput;
+
+      if (appId === "claude-desktop" && ensureClaudeDesktopOfficialSeed) {
+        await providersApi.ensureClaudeDesktopOfficialProvider();
+        const providers = await providersApi.getAll(appId);
+        const officialProvider = providers["claude-desktop-official"];
+        if (!officialProvider) {
+          throw new Error("Claude Desktop official provider was not created");
+        }
+        return officialProvider;
+      }
+
       let id: string;
 
       if (appId === "opencode" || appId === "openclaw" || appId === "hermes") {
@@ -36,17 +54,9 @@ export const useAddProviderMutation = (appId: AppId) => {
           }
           id = providerInput.providerKey;
         }
-      } else if (
-        appId === "claude-desktop" &&
-        providerInput.category === "official"
-      ) {
-        // 官方供应商使用固定 id，与后端 seed 和 is_official_provider 校验一致
-        id = "claude-desktop-official";
       } else {
         id = generateUUID();
       }
-
-      const { providerKey: _providerKey, addToLive, ...rest } = providerInput;
 
       const newProvider: Provider = {
         ...rest,

--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -36,6 +36,12 @@ export const useAddProviderMutation = (appId: AppId) => {
           }
           id = providerInput.providerKey;
         }
+      } else if (
+        appId === "claude-desktop" &&
+        providerInput.category === "official"
+      ) {
+        // 官方供应商使用固定 id，与后端 seed 和 is_official_provider 校验一致
+        id = "claude-desktop-official";
       } else {
         id = generateUUID();
       }

--- a/tests/hooks/useAddProviderMutation.test.tsx
+++ b/tests/hooks/useAddProviderMutation.test.tsx
@@ -1,0 +1,136 @@
+import type { ReactNode } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAddProviderMutation } from "@/lib/query/mutations";
+import type { Provider } from "@/types";
+
+const apiMocks = vi.hoisted(() => ({
+  add: vi.fn(),
+  ensureClaudeDesktopOfficialProvider: vi.fn(),
+  getAll: vi.fn(),
+  updateTrayMenu: vi.fn(),
+}));
+
+const uuidMocks = vi.hoisted(() => ({
+  generateUUID: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  providersApi: {
+    add: (...args: unknown[]) => apiMocks.add(...args),
+    ensureClaudeDesktopOfficialProvider: (...args: unknown[]) =>
+      apiMocks.ensureClaudeDesktopOfficialProvider(...args),
+    getAll: (...args: unknown[]) => apiMocks.getAll(...args),
+    updateTrayMenu: (...args: unknown[]) => apiMocks.updateTrayMenu(...args),
+  },
+  sessionsApi: {},
+  settingsApi: {},
+}));
+
+vi.mock("@/utils/uuid", () => ({
+  generateUUID: () => uuidMocks.generateUUID(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { wrapper };
+}
+
+beforeEach(() => {
+  apiMocks.add.mockReset().mockResolvedValue(true);
+  apiMocks.ensureClaudeDesktopOfficialProvider
+    .mockReset()
+    .mockResolvedValue(true);
+  apiMocks.getAll.mockReset().mockResolvedValue({});
+  apiMocks.updateTrayMenu.mockReset().mockResolvedValue(true);
+  uuidMocks.generateUUID.mockReset().mockReturnValue("generated-uuid");
+});
+
+describe("useAddProviderMutation", () => {
+  it("duplicates Claude Desktop official providers with a fresh id", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useAddProviderMutation("claude-desktop"),
+      { wrapper },
+    );
+
+    const duplicatedProvider = await act(async () =>
+      result.current.mutateAsync({
+        name: "Claude Desktop Official copy",
+        settingsConfig: { env: {} },
+        category: "official",
+      }),
+    );
+
+    expect(apiMocks.ensureClaudeDesktopOfficialProvider).not.toHaveBeenCalled();
+    expect(apiMocks.add).toHaveBeenCalledTimes(1);
+    expect(apiMocks.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "generated-uuid",
+        name: "Claude Desktop Official copy",
+        category: "official",
+      }),
+      "claude-desktop",
+      undefined,
+    );
+    expect(duplicatedProvider.id).toBe("generated-uuid");
+    expect(duplicatedProvider.id).not.toBe("claude-desktop-official");
+  });
+
+  it("returns the persisted seed row for the Claude Desktop official preset", async () => {
+    const seedProvider: Provider = {
+      id: "claude-desktop-official",
+      name: "Claude Desktop Official",
+      settingsConfig: { env: {} },
+      websiteUrl: "https://claude.ai/download",
+      category: "official",
+      icon: "anthropic",
+      iconColor: "#D4915D",
+      createdAt: 123,
+    };
+    apiMocks.getAll.mockResolvedValueOnce({
+      "claude-desktop-official": seedProvider,
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useAddProviderMutation("claude-desktop"),
+      { wrapper },
+    );
+
+    const persistedProvider = await act(async () =>
+      result.current.mutateAsync({
+        name: "Renamed by form",
+        settingsConfig: { env: { ignored: true } },
+        websiteUrl: "https://example.invalid",
+        category: "official",
+        icon: "custom-icon",
+        ensureClaudeDesktopOfficialSeed: true,
+      }),
+    );
+
+    expect(apiMocks.ensureClaudeDesktopOfficialProvider).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(apiMocks.getAll).toHaveBeenCalledWith("claude-desktop");
+    expect(apiMocks.add).not.toHaveBeenCalled();
+    expect(persistedProvider).toEqual(seedProvider);
+  });
+});


### PR DESCRIPTION
## Summary

- 修复添加 Claude Desktop 官方供应商时报错 "缺少 ANTHROPIC_BASE_URL" (#3402)
- **根因**：`validate_direct_provider`、`validate_proxy_provider`、`validate_provider` 和 `apply_provider_to_paths` 四个函数仅通过 `is_official_provider()`（基于 provider id/name）判断官方供应商，但新添加的官方供应商尚未分配固定 id，导致校验失败
- **前端**：为 `claude-desktop` 官方供应商分配固定 id `claude-desktop-official`，与后端 seed 和 `is_official_provider` 校验一致

## Changes

### Rust 后端 (`claude_desktop_config.rs`)
- 4 处增加 `provider.category.as_deref() == Some("official")` 兜底判断

### 前端 (`mutations.ts`)
- 添加 `claude-desktop` + `official` category 时使用固定 id `claude-desktop-official`

## Test plan

- [ ] 打开 Claude Desktop 供应商列表
- [ ] 选择 "Claude Desktop Official" 预设
- [ ] 点击"添加"，应成功添加不再报错
- [ ] 验证其他非官方供应商添加/编辑不受影响

Closes #3402