### PR TITLE
ci: switch ubuntu-22.04 to ubuntu-latest to reduce runner queue time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
   backend:
     name: Backend Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         include:
           - os: windows-2022
-          - os: ubuntu-22.04
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-latest
+          - os: ubuntu-latest-arm
             arch: arm64
           - os: macos-14
 
@@ -516,7 +516,7 @@ jobs:
 
   publish-release:
     name: Publish GitHub Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: release
     permissions:
       contents: write
@@ -564,7 +564,7 @@ jobs:
 
   assemble-latest-json:
     name: Assemble latest.json
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: publish-release
     permissions:
       contents: write


### PR DESCRIPTION
## Problem
Ubuntu 22.04 runners were queuing for 8+ minutes, causing build delays.

## Solution
Switched all  references to  in both workflow files:
-  (4 occurrences)
-  (1 occurrence)

This gives access to a larger GitHub-hosted runner pool and should significantly reduce queue times.