### PR TITLE
feat(skills): add tag grouping and management UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **技能标签数据库操作原子性**: `set_skill_tags` 方法使用事务包裹 delete+insert，防止外键约束失败导致标签丢失
+- **技能标签分配保留**: 更新或重装已安装技能时不再因 SQLite `REPLACE` 语义清空已有标签分配
 - **技能标签 i18n key 修正**: TagAssignPopover 中的 i18n key 从 `skills.assignTags`/`skills.tagsFor`/`skills.noTags`/`skills.newTagPlaceholder` 修正为 `skills.tags.*` 命名空间下的正确 key
+- **未分组拖拽处理**: 将技能拖回未分组区域时正确清空标签分配，避免提交无效标签 ID
 - **分组视图空标签可见性**: 移除 `groupSkills.length > 0` 过滤条件，空标签现在作为有效的 drop target 显示在分组视图中
 - **Rust 编译警告修复**: 修复 3 个编译警告（`unused import`、`dead_code`），通过条件编译和移动 import 解决跨平台兼容性问题
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **技能标签分组功能**: 新增标签 CRUD 管理（创建/重命名/删除/拖拽排序）、标签分配 Popover、分组视图（支持拖拽技能到不同分组、分组排序、空标签保留作为 drop target）、内联编辑分组名称（双击重命名），数据库 v10→v11 自动迁移，4 种语言支持（en/zh/zh-TW/ja）
+- **在文件管理器中打开技能目录**: 每个技能行新增文件夹图标按钮，点击可直接在系统文件管理器中打开对应技能目录
+
+### Changed
+
+- **管理标签弹窗布局**: 优化管理标签弹窗的信息层级与操作布局，新增标签输入区前置，标签数量改为标题旁徽标，并使用更轻量的列表行样式
+
+### Fixed
+
+- **技能标签数据库操作原子性**: `set_skill_tags` 方法使用事务包裹 delete+insert，防止外键约束失败导致标签丢失
+- **技能标签 i18n key 修正**: TagAssignPopover 中的 i18n key 从 `skills.assignTags`/`skills.tagsFor`/`skills.noTags`/`skills.newTagPlaceholder` 修正为 `skills.tags.*` 命名空间下的正确 key
+- **分组视图空标签可见性**: 移除 `groupSkills.length > 0` 过滤条件，空标签现在作为有效的 drop target 显示在分组视图中
+- **Rust 编译警告修复**: 修复 3 个编译警告（`unused import`、`dead_code`），通过条件编译和移动 import 解决跨平台兼容性问题
+
 ## [3.16.0] - 2026-05-29
 
 Development since v3.15.0 focuses on making third-party Codex providers work like first-class citizens through Chat Completions routing, stabilizing Codex provider identity and history, adding an in-app managed CLI tool lifecycle, expanding the partner preset catalog, refreshing the default model / pricing matrix around GPT-5.5 and Claude Opus 4.8, and improving usage observability, localization, docs, and proxy robustness.

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2897,6 +2897,7 @@ del \"%~f0\" >nul 2>&1
     result
 }
 
+#[cfg(not(target_os = "windows"))]
 fn build_shell_cd_command(cwd: Option<&Path>) -> String {
     cwd.map(|dir| {
         format!(
@@ -2907,6 +2908,7 @@ fn build_shell_cd_command(cwd: Option<&Path>) -> String {
     .unwrap_or_default()
 }
 
+#[cfg(not(target_os = "windows"))]
 fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
@@ -4551,6 +4553,7 @@ mod tests {
         assert!(error.contains("目录不存在"));
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn build_shell_cd_command_quotes_spaces_and_single_quotes() {
         let command = build_shell_cd_command(Some(Path::new("/tmp/project O'Brien")));

--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -14,7 +14,9 @@ use crate::services::skill::{
 use crate::store::AppState;
 use std::str::FromStr;
 use std::sync::Arc;
+use tauri::AppHandle;
 use tauri::State;
+use tauri_plugin_opener::OpenerExt;
 
 /// SkillService 状态包装
 pub struct SkillServiceState(pub Arc<SkillService>);
@@ -373,10 +375,7 @@ pub fn update_skill_tag(
 /// 删除技能标签
 #[tauri::command]
 pub fn delete_skill_tag(id: i64, app_state: State<'_, AppState>) -> Result<bool, String> {
-    app_state
-        .db
-        .delete_skill_tag(id)
-        .map_err(|e| e.to_string())
+    app_state.db.delete_skill_tag(id).map_err(|e| e.to_string())
 }
 
 /// 批量更新标签排序
@@ -413,4 +412,18 @@ pub fn get_all_skill_tag_assignments(
         .db
         .get_all_skill_tag_assignments()
         .map_err(|e| e.to_string())
+}
+
+/// 在系统文件管理器中打开技能目录
+#[tauri::command]
+pub async fn open_skill_directory(handle: AppHandle, directory: String) -> Result<(), String> {
+    let ssot_dir = SkillService::get_ssot_dir().map_err(|e| e.to_string())?;
+    let dir = ssot_dir.join(&directory);
+    if !dir.exists() {
+        return Err(format!("目录不存在: {}", dir.display()));
+    }
+    handle
+        .opener()
+        .open_path(dir.to_string_lossy().to_string(), None::<String>)
+        .map_err(|e| format!("打开目录失败: {e}"))
 }

--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -334,3 +334,83 @@ pub fn install_skills_from_zip(
 
     SkillService::install_from_zip(&app_state.db, path, &app_type).map_err(|e| e.to_string())
 }
+
+// ========== 标签管理命令 ==========
+
+/// 获取所有技能标签
+#[tauri::command]
+pub fn get_skill_tags(
+    app_state: State<'_, AppState>,
+) -> Result<Vec<crate::database::SkillTag>, String> {
+    app_state.db.get_all_skill_tags().map_err(|e| e.to_string())
+}
+
+/// 创建技能标签
+#[tauri::command]
+pub fn create_skill_tag(
+    name: String,
+    app_state: State<'_, AppState>,
+) -> Result<crate::database::SkillTag, String> {
+    app_state
+        .db
+        .create_skill_tag(&name)
+        .map_err(|e| e.to_string())
+}
+
+/// 更新技能标签名称
+#[tauri::command]
+pub fn update_skill_tag(
+    id: i64,
+    name: String,
+    app_state: State<'_, AppState>,
+) -> Result<bool, String> {
+    app_state
+        .db
+        .update_skill_tag(id, &name)
+        .map_err(|e| e.to_string())
+}
+
+/// 删除技能标签
+#[tauri::command]
+pub fn delete_skill_tag(id: i64, app_state: State<'_, AppState>) -> Result<bool, String> {
+    app_state
+        .db
+        .delete_skill_tag(id)
+        .map_err(|e| e.to_string())
+}
+
+/// 批量更新标签排序
+#[tauri::command]
+pub fn reorder_skill_tags(
+    ordered_ids: Vec<i64>,
+    app_state: State<'_, AppState>,
+) -> Result<(), String> {
+    app_state
+        .db
+        .reorder_skill_tags(&ordered_ids)
+        .map_err(|e| e.to_string())
+}
+
+/// 设置技能的标签分配（替换现有分配）
+#[tauri::command]
+pub fn set_skill_tags(
+    skill_id: String,
+    tag_ids: Vec<i64>,
+    app_state: State<'_, AppState>,
+) -> Result<(), String> {
+    app_state
+        .db
+        .set_skill_tags(&skill_id, &tag_ids)
+        .map_err(|e| e.to_string())
+}
+
+/// 获取所有标签分配关系
+#[tauri::command]
+pub fn get_all_skill_tag_assignments(
+    app_state: State<'_, AppState>,
+) -> Result<Vec<(String, i64)>, String> {
+    app_state
+        .db
+        .get_all_skill_tag_assignments()
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -12,6 +12,7 @@ use crate::services::skill::{
     SkillsShSearchResult,
 };
 use crate::store::AppState;
+use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use tauri::AppHandle;
@@ -418,12 +419,71 @@ pub fn get_all_skill_tag_assignments(
 #[tauri::command]
 pub async fn open_skill_directory(handle: AppHandle, directory: String) -> Result<(), String> {
     let ssot_dir = SkillService::get_ssot_dir().map_err(|e| e.to_string())?;
-    let dir = ssot_dir.join(&directory);
-    if !dir.exists() {
-        return Err(format!("目录不存在: {}", dir.display()));
-    }
+    let dir = resolve_skill_directory(&ssot_dir, &directory)?;
+
     handle
         .opener()
         .open_path(dir.to_string_lossy().to_string(), None::<String>)
-        .map_err(|e| format!("打开目录失败: {e}"))
+        .map_err(|e| format!("Failed to open directory: {e}"))
+}
+
+fn resolve_skill_directory(ssot_dir: &Path, directory: &str) -> Result<PathBuf, String> {
+    let requested = Path::new(&directory);
+    if directory.trim().is_empty()
+        || requested.is_absolute()
+        || requested.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err("Invalid skill directory".to_string());
+    }
+
+    let ssot_dir = ssot_dir
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve skills directory: {e}"))?;
+    let dir = ssot_dir.join(requested);
+    let dir = dir
+        .canonicalize()
+        .map_err(|_| format!("Directory not found: {}", dir.display()))?;
+
+    if !dir.starts_with(&ssot_dir) || !dir.is_dir() {
+        return Err("Invalid skill directory".to_string());
+    }
+
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_skill_directory;
+
+    #[test]
+    fn resolve_skill_directory_rejects_escape_paths() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let ssot = temp.path().join("skills");
+        std::fs::create_dir(&ssot).expect("create ssot");
+        std::fs::create_dir(temp.path().join("outside")).expect("create outside");
+
+        assert!(resolve_skill_directory(&ssot, "").is_err());
+        assert!(resolve_skill_directory(&ssot, "../outside").is_err());
+        assert!(resolve_skill_directory(&ssot, temp.path().to_string_lossy().as_ref()).is_err());
+
+        #[cfg(windows)]
+        assert!(resolve_skill_directory(&ssot, r"C:\Users").is_err());
+    }
+
+    #[test]
+    fn resolve_skill_directory_accepts_existing_relative_directory() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let ssot = temp.path().join("skills");
+        let skill = ssot.join("my-skill");
+        std::fs::create_dir(&ssot).expect("create ssot");
+        std::fs::create_dir(&skill).expect("create skill");
+
+        let resolved = resolve_skill_directory(&ssot, "my-skill").expect("resolve skill");
+        assert_eq!(resolved, skill.canonicalize().expect("canonical skill"));
+    }
 }

--- a/src-tauri/src/database/dao/mod.rs
+++ b/src-tauri/src/database/dao/mod.rs
@@ -9,6 +9,7 @@ pub mod providers;
 pub mod providers_seed;
 pub mod proxy;
 pub mod settings;
+pub mod skill_tags;
 pub mod skills;
 pub mod stream_check;
 pub mod universal_providers;
@@ -17,3 +18,4 @@ pub mod usage_rollup;
 // 所有 DAO 方法都通过 Database impl 提供，无需单独导出
 // 导出 FailoverQueueItem 供外部使用
 pub use failover::FailoverQueueItem;
+pub use skill_tags::SkillTag;

--- a/src-tauri/src/database/dao/skill_tags.rs
+++ b/src-tauri/src/database/dao/skill_tags.rs
@@ -1,0 +1,225 @@
+//! Skill Tags 数据访问对象
+//!
+//! 提供技能标签和标签分配的 CRUD 操作。
+//! 标签用于在 UI 层对 Skills 进行分组管理，不影响底层文件存储和同步逻辑。
+
+use crate::database::{lock_conn, Database};
+use crate::error::AppError;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+/// 技能标签
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillTag {
+    pub id: i64,
+    pub name: String,
+    pub sort_index: i32,
+    pub created_at: i64,
+}
+
+impl Database {
+    // ========== SkillTag CRUD ==========
+
+    /// 获取所有标签（按 sort_index 排序）
+    pub fn get_all_skill_tags(&self) -> Result<Vec<SkillTag>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare("SELECT id, name, sort_index, created_at FROM skill_tags ORDER BY sort_index ASC, id ASC")
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let tags = stmt
+            .query_map([], |row| {
+                Ok(SkillTag {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    sort_index: row.get(2)?,
+                    created_at: row.get(3)?,
+                })
+            })
+            .map_err(|e| AppError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(tags)
+    }
+
+    /// 创建标签
+    pub fn create_skill_tag(&self, name: &str) -> Result<SkillTag, AppError> {
+        let conn = lock_conn!(self.conn);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        // 获取当前最大 sort_index
+        let max_index: i32 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(sort_index), -1) FROM skill_tags",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(-1);
+
+        conn.execute(
+            "INSERT INTO skill_tags (name, sort_index, created_at) VALUES (?1, ?2, ?3)",
+            params![name, max_index + 1, now],
+        )
+        .map_err(|e| {
+            if e.to_string().contains("UNIQUE") {
+                AppError::Database(format!("标签 \"{name}\" 已存在"))
+            } else {
+                AppError::Database(e.to_string())
+            }
+        })?;
+
+        let id = conn.last_insert_rowid();
+        Ok(SkillTag {
+            id,
+            name: name.to_string(),
+            sort_index: max_index + 1,
+            created_at: now,
+        })
+    }
+
+    /// 更新标签名称
+    pub fn update_skill_tag(&self, id: i64, name: &str) -> Result<bool, AppError> {
+        let conn = lock_conn!(self.conn);
+        let affected = conn
+            .execute(
+                "UPDATE skill_tags SET name = ?1 WHERE id = ?2",
+                params![name, id],
+            )
+            .map_err(|e| {
+                if e.to_string().contains("UNIQUE") {
+                    AppError::Database(format!("标签 \"{name}\" 已存在"))
+                } else {
+                    AppError::Database(e.to_string())
+                }
+            })?;
+        Ok(affected > 0)
+    }
+
+    /// 删除标签（关联的分配记录会通过 CASCADE 自动删除）
+    pub fn delete_skill_tag(&self, id: i64) -> Result<bool, AppError> {
+        let conn = lock_conn!(self.conn);
+        let affected = conn
+            .execute("DELETE FROM skill_tags WHERE id = ?1", params![id])
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(affected > 0)
+    }
+
+    /// 批量更新标签排序
+    pub fn reorder_skill_tags(&self, ordered_ids: &[i64]) -> Result<(), AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare("UPDATE skill_tags SET sort_index = ?1 WHERE id = ?2")
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        for (index, id) in ordered_ids.iter().enumerate() {
+            stmt.execute(params![index as i32, id])
+                .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    // ========== Tag Assignments ==========
+
+    /// 为 skill 分配标签（替换现有分配）
+    pub fn set_skill_tags(&self, skill_id: &str, tag_ids: &[i64]) -> Result<(), AppError> {
+        let conn = lock_conn!(self.conn);
+
+        // 先删除该 skill 的所有现有分配
+        conn.execute(
+            "DELETE FROM skill_tag_assignments WHERE skill_id = ?1",
+            params![skill_id],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // 插入新分配
+        let mut stmt = conn
+            .prepare("INSERT INTO skill_tag_assignments (skill_id, tag_id) VALUES (?1, ?2)")
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        for tag_id in tag_ids {
+            stmt.execute(params![skill_id, tag_id])
+                .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    /// 为 skill 添加单个标签
+    pub fn assign_skill_tag(&self, skill_id: &str, tag_id: i64) -> Result<(), AppError> {
+        let conn = lock_conn!(self.conn);
+        conn.execute(
+            "INSERT OR IGNORE INTO skill_tag_assignments (skill_id, tag_id) VALUES (?1, ?2)",
+            params![skill_id, tag_id],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    /// 移除 skill 的单个标签
+    pub fn unassign_skill_tag(&self, skill_id: &str, tag_id: i64) -> Result<bool, AppError> {
+        let conn = lock_conn!(self.conn);
+        let affected = conn
+            .execute(
+                "DELETE FROM skill_tag_assignments WHERE skill_id = ?1 AND tag_id = ?2",
+                params![skill_id, tag_id],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(affected > 0)
+    }
+
+    /// 获取单个 skill 的标签 ID 列表
+    pub fn get_skill_tag_ids(&self, skill_id: &str) -> Result<Vec<i64>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare(
+                "SELECT tag_id FROM skill_tag_assignments WHERE skill_id = ?1 ORDER BY tag_id ASC",
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let ids = stmt
+            .query_map([skill_id], |row| row.get::<_, i64>(0))
+            .map_err(|e| AppError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(ids)
+    }
+
+    /// 获取所有标签分配关系（用于前端批量加载）
+    pub fn get_all_skill_tag_assignments(&self) -> Result<Vec<(String, i64)>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare("SELECT skill_id, tag_id FROM skill_tag_assignments ORDER BY skill_id, tag_id")
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let assignments = stmt
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))
+            .map_err(|e| AppError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(assignments)
+    }
+
+    /// 获取指定标签下的所有 skill ID
+    pub fn get_skills_by_tag(&self, tag_id: i64) -> Result<Vec<String>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare(
+                "SELECT skill_id FROM skill_tag_assignments WHERE tag_id = ?1 ORDER BY skill_id ASC",
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let ids = stmt
+            .query_map([tag_id], |row| row.get::<_, String>(0))
+            .map_err(|e| AppError::Database(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(ids)
+    }
+}

--- a/src-tauri/src/database/dao/skill_tags.rs
+++ b/src-tauri/src/database/dao/skill_tags.rs
@@ -197,7 +197,9 @@ impl Database {
             .map_err(|e| AppError::Database(e.to_string()))?;
 
         let assignments = stmt
-            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
             .map_err(|e| AppError::Database(e.to_string()))?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| AppError::Database(e.to_string()))?;

--- a/src-tauri/src/database/dao/skill_tags.rs
+++ b/src-tauri/src/database/dao/skill_tags.rs
@@ -66,7 +66,7 @@ impl Database {
         )
         .map_err(|e| {
             if e.to_string().contains("UNIQUE") {
-                AppError::Database(format!("标签 \"{name}\" 已存在"))
+                AppError::Database(format!("Tag \"{name}\" already exists"))
             } else {
                 AppError::Database(e.to_string())
             }
@@ -91,7 +91,7 @@ impl Database {
             )
             .map_err(|e| {
                 if e.to_string().contains("UNIQUE") {
-                    AppError::Database(format!("标签 \"{name}\" 已存在"))
+                    AppError::Database(format!("Tag \"{name}\" already exists"))
                 } else {
                     AppError::Database(e.to_string())
                 }
@@ -124,26 +124,34 @@ impl Database {
 
     // ========== Tag Assignments ==========
 
-    /// 为 skill 分配标签（替换现有分配）
+    /// 为 skill 分配标签（替换现有分配，事务保证原子性）
     pub fn set_skill_tags(&self, skill_id: &str, tag_ids: &[i64]) -> Result<(), AppError> {
-        let conn = lock_conn!(self.conn);
+        let mut conn = lock_conn!(self.conn);
+
+        let tx = conn
+            .transaction()
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         // 先删除该 skill 的所有现有分配
-        conn.execute(
+        tx.execute(
             "DELETE FROM skill_tag_assignments WHERE skill_id = ?1",
             params![skill_id],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
 
         // 插入新分配
-        let mut stmt = conn
-            .prepare("INSERT INTO skill_tag_assignments (skill_id, tag_id) VALUES (?1, ?2)")
-            .map_err(|e| AppError::Database(e.to_string()))?;
-
-        for tag_id in tag_ids {
-            stmt.execute(params![skill_id, tag_id])
+        {
+            let mut stmt = tx
+                .prepare("INSERT INTO skill_tag_assignments (skill_id, tag_id) VALUES (?1, ?2)")
                 .map_err(|e| AppError::Database(e.to_string()))?;
+
+            for tag_id in tag_ids {
+                stmt.execute(params![skill_id, tag_id])
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+            }
         }
+
+        tx.commit().map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(())
     }

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -107,11 +107,27 @@ impl Database {
     pub fn save_skill(&self, skill: &InstalledSkill) -> Result<(), AppError> {
         let conn = lock_conn!(self.conn);
         conn.execute(
-            "INSERT OR REPLACE INTO skills
+            "INSERT INTO skills
              (id, name, description, directory, repo_owner, repo_name, repo_branch,
               readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_opencode, enabled_hermes,
               installed_at, content_hash, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+             ON CONFLICT(id) DO UPDATE SET
+               name = excluded.name,
+               description = excluded.description,
+               directory = excluded.directory,
+               repo_owner = excluded.repo_owner,
+               repo_name = excluded.repo_name,
+               repo_branch = excluded.repo_branch,
+               readme_url = excluded.readme_url,
+               enabled_claude = excluded.enabled_claude,
+               enabled_codex = excluded.enabled_codex,
+               enabled_gemini = excluded.enabled_gemini,
+               enabled_opencode = excluded.enabled_opencode,
+               enabled_hermes = excluded.enabled_hermes,
+               installed_at = excluded.installed_at,
+               content_hash = excluded.content_hash,
+               updated_at = excluded.updated_at",
             params![
                 skill.id,
                 skill.name,
@@ -259,5 +275,59 @@ impl Database {
             log::info!("补充默认 Skill 仓库完成，新增 {count} 个");
         }
         Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_config::{InstalledSkill, SkillApps};
+    use rusqlite::Connection;
+    use std::sync::Mutex;
+
+    fn test_db() -> Database {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute("PRAGMA foreign_keys = ON;", [])
+            .expect("enable foreign keys");
+        Database::create_tables_on_conn(&conn).expect("create tables");
+        Database {
+            conn: Mutex::new(conn),
+        }
+    }
+
+    fn skill(name: &str) -> InstalledSkill {
+        InstalledSkill {
+            id: "owner/repo:skill".to_string(),
+            name: name.to_string(),
+            description: Some("description".to_string()),
+            directory: "skill".to_string(),
+            repo_owner: Some("owner".to_string()),
+            repo_name: Some("repo".to_string()),
+            repo_branch: Some("main".to_string()),
+            readme_url: None,
+            apps: SkillApps::default(),
+            installed_at: 1,
+            content_hash: Some("hash".to_string()),
+            updated_at: 1,
+        }
+    }
+
+    #[test]
+    fn save_skill_update_preserves_tag_assignments() {
+        let db = test_db();
+        db.save_skill(&skill("Old Name")).expect("insert skill");
+        let tag = db.create_skill_tag("Work").expect("create tag");
+        db.set_skill_tags("owner/repo:skill", &[tag.id])
+            .expect("assign tag");
+
+        let mut updated = skill("New Name");
+        updated.updated_at = 2;
+        db.save_skill(&updated).expect("update skill");
+
+        let assigned = db
+            .get_skill_tag_ids("owner/repo:skill")
+            .expect("load assigned tags");
+        assert_eq!(assigned.len(), 1);
+        assert_eq!(assigned[0], tag.id);
     }
 }

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -38,6 +38,7 @@ pub(crate) use dao::proxy::{
     PRICING_SOURCE_RESPONSE,
 };
 pub use dao::FailoverQueueItem;
+pub use dao::SkillTag;
 
 use crate::config::get_app_config_dir;
 use crate::error::AppError;
@@ -49,7 +50,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 10;
+pub(crate) const SCHEMA_VERSION: i32 = 11;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -287,6 +287,31 @@ impl Database {
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
 
+        // 19. Skill Tags 表 (技能标签)
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS skill_tags (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                sort_index INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL DEFAULT 0
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // 20. Skill Tag Assignments 表 (技能标签关联，多对多)
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS skill_tag_assignments (
+                skill_id TEXT NOT NULL,
+                tag_id INTEGER NOT NULL,
+                PRIMARY KEY (skill_id, tag_id),
+                FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE,
+                FOREIGN KEY (tag_id) REFERENCES skill_tags(id) ON DELETE CASCADE
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
         // 尝试添加 live_takeover_active 列到 proxy_config 表
         let _ = conn.execute(
             "ALTER TABLE proxy_config ADD COLUMN live_takeover_active INTEGER NOT NULL DEFAULT 0",
@@ -430,6 +455,11 @@ impl Database {
                         log::info!("迁移数据库从 v9 到 v10（添加 Hermes Agent 支持）");
                         Self::migrate_v9_to_v10(conn)?;
                         Self::set_user_version(conn, 10)?;
+                    }
+                    10 => {
+                        log::info!("迁移数据库从 v10 到 v11（添加 Skills 标签分组支持）");
+                        Self::migrate_v10_to_v11(conn)?;
+                        Self::set_user_version(conn, 11)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -1197,6 +1227,37 @@ impl Database {
         }
 
         log::info!("v9 -> v10 迁移完成：已添加 Hermes Agent 支持");
+        Ok(())
+    }
+
+    /// v10 -> v11 迁移：添加 Skills 标签分组支持
+    fn migrate_v10_to_v11(conn: &Connection) -> Result<(), AppError> {
+        // 创建 skill_tags 表
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS skill_tags (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                sort_index INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL DEFAULT 0
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("创建 skill_tags 表失败: {e}")))?;
+
+        // 创建 skill_tag_assignments 表（多对多关联，级联删除）
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS skill_tag_assignments (
+                skill_id TEXT NOT NULL,
+                tag_id INTEGER NOT NULL,
+                PRIMARY KEY (skill_id, tag_id),
+                FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE,
+                FOREIGN KEY (tag_id) REFERENCES skill_tags(id) ON DELETE CASCADE
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("创建 skill_tag_assignments 表失败: {e}")))?;
+
+        log::info!("v10 -> v11 迁移完成：已添加 skill_tags 和 skill_tag_assignments 表");
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1242,6 +1242,14 @@ pub fn run() {
             commands::add_skill_repo,
             commands::remove_skill_repo,
             commands::install_skills_from_zip,
+            // Skill tag management
+            commands::get_skill_tags,
+            commands::create_skill_tag,
+            commands::update_skill_tag,
+            commands::delete_skill_tag,
+            commands::reorder_skill_tags,
+            commands::set_skill_tags,
+            commands::get_all_skill_tag_assignments,
             // Auto launch
             commands::set_auto_launch,
             commands::get_auto_launch_status,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1250,6 +1250,7 @@ pub fn run() {
             commands::reorder_skill_tags,
             commands::set_skill_tags,
             commands::get_all_skill_tag_assignments,
+            commands::open_skill_directory,
             // Auto launch
             commands::set_auto_launch,
             commands::get_auto_launch_status,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{OnceLock, RwLock};
 
@@ -505,6 +504,7 @@ fn save_settings_file(settings: &AppSettings) -> Result<(), AppError> {
     #[cfg(unix)]
     {
         use std::fs::OpenOptions;
+        use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
 
         let mut file = OpenOptions::new()

--- a/src/components/skills/TagAssignPopover.tsx
+++ b/src/components/skills/TagAssignPopover.tsx
@@ -1,0 +1,186 @@
+import { useState, useMemo, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Tag, Check, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  useSkillTags,
+  useAllTagAssignments,
+  useSetSkillTags,
+  useCreateTag,
+} from "@/hooks/useSkills";
+import { toast } from "sonner";
+
+interface TagAssignPopoverProps {
+  skillId: string;
+  skillName: string;
+}
+
+export function TagAssignPopover({
+  skillId,
+  skillName,
+}: TagAssignPopoverProps) {
+  const { t } = useTranslation();
+  const [newTagName, setNewTagName] = useState("");
+
+  const { data: allTags = [] } = useSkillTags();
+  const { data: rawAssignments = [] } = useAllTagAssignments();
+  const setSkillTagsMutation = useSetSkillTags();
+  const createTagMutation = useCreateTag();
+
+  // 将 [skillId, tagId][] 转换为 Record<skillId, tagId[]>
+  const assignmentsMap = useMemo(() => {
+    const map: Record<string, number[]> = {};
+    for (const [sid, tid] of rawAssignments) {
+      if (!map[sid]) map[sid] = [];
+      map[sid].push(tid);
+    }
+    return map;
+  }, [rawAssignments]);
+
+  // 当前技能已分配的标签 ID 集合
+  const assignedTagIds = useMemo(() => {
+    const ids = assignmentsMap[skillId] ?? [];
+    return new Set<number>(ids);
+  }, [assignmentsMap, skillId]);
+
+  // 切换标签分配
+  const handleToggleTag = useCallback(
+    async (tagId: number) => {
+      const isAssigned = assignedTagIds.has(tagId);
+      const idsArray = Array.from(assignedTagIds);
+      const newTagIds = isAssigned
+        ? idsArray.filter((id) => id !== tagId)
+        : [...idsArray, tagId];
+
+      try {
+        await setSkillTagsMutation.mutateAsync({
+          skillId,
+          tagIds: newTagIds,
+        });
+      } catch (error) {
+        toast.error(t("common.error"), { description: String(error) });
+      }
+    },
+    [assignedTagIds, skillId, setSkillTagsMutation, t],
+  );
+
+  // 创建新标签并分配
+  const handleCreateAndAssign = useCallback(async () => {
+    const name = newTagName.trim();
+    if (!name) return;
+
+    try {
+      const newTag = await createTagMutation.mutateAsync(name);
+      const newTagIds = [...Array.from(assignedTagIds), newTag.id];
+      await setSkillTagsMutation.mutateAsync({
+        skillId,
+        tagIds: newTagIds,
+      });
+      setNewTagName("");
+    } catch (error) {
+      toast.error(t("common.error"), { description: String(error) });
+    }
+  }, [
+    newTagName,
+    createTagMutation,
+    assignedTagIds,
+    setSkillTagsMutation,
+    skillId,
+    t,
+  ]);
+
+  const tagCount = assignedTagIds.size;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="relative text-muted-foreground/60 hover:text-foreground flex-shrink-0"
+          title={t("skills.assignTags")}
+        >
+          <Tag size={12} />
+          {tagCount > 0 && (
+            <Badge
+              variant="secondary"
+              className="absolute -top-1.5 -right-1.5 h-3.5 min-w-3.5 px-0.5 text-[9px] leading-none"
+            >
+              {tagCount}
+            </Badge>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56">
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-muted-foreground">
+            {t("skills.tagsFor", { name: skillName })}
+          </p>
+
+          {/* 标签列表 */}
+          <div className="max-h-48 overflow-y-auto space-y-1">
+            {allTags.map((tag) => {
+              const isChecked = assignedTagIds.has(tag.id);
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => handleToggleTag(tag.id)}
+                  className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-sm hover:bg-accent transition-colors text-left"
+                >
+                  <div
+                    className={`flex h-4 w-4 items-center justify-center rounded-sm border ${
+                      isChecked
+                        ? "bg-primary border-primary text-primary-foreground"
+                        : "border-muted-foreground/30"
+                    }`}
+                  >
+                    {isChecked && <Check className="h-3 w-3" />}
+                  </div>
+                  <span className="truncate">{tag.name}</span>
+                </button>
+              );
+            })}
+
+            {allTags.length === 0 && (
+              <p className="text-xs text-muted-foreground py-2 text-center">
+                {t("skills.noTags")}
+              </p>
+            )}
+          </div>
+
+          {/* 快速创建标签 */}
+          <div className="flex gap-1 pt-1 border-t">
+            <input
+              type="text"
+              value={newTagName}
+              onChange={(e) => setNewTagName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleCreateAndAssign();
+                }
+              }}
+              placeholder={t("skills.newTagPlaceholder")}
+              className="flex-1 h-7 text-xs px-2 rounded-sm border bg-transparent outline-none focus:ring-1 focus:ring-ring"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              onClick={handleCreateAndAssign}
+              disabled={!newTagName.trim()}
+            >
+              <Plus className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/skills/TagAssignPopover.tsx
+++ b/src/components/skills/TagAssignPopover.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Tag, Check, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import {
   Popover,
   PopoverContent,
@@ -49,14 +48,12 @@ export function TagAssignPopover({
     return new Set<number>(ids);
   }, [assignmentsMap, skillId]);
 
-  // 切换标签分配
+  // 切换标签分配（单选：每个技能只属于一个分组）
   const handleToggleTag = useCallback(
     async (tagId: number) => {
       const isAssigned = assignedTagIds.has(tagId);
-      const idsArray = Array.from(assignedTagIds);
-      const newTagIds = isAssigned
-        ? idsArray.filter((id) => id !== tagId)
-        : [...idsArray, tagId];
+      // 取消勾选 → 清空分组；勾选 → 替换为当前分组
+      const newTagIds = isAssigned ? [] : [tagId];
 
       try {
         await setSkillTagsMutation.mutateAsync({
@@ -70,32 +67,22 @@ export function TagAssignPopover({
     [assignedTagIds, skillId, setSkillTagsMutation, t],
   );
 
-  // 创建新标签并分配
+  // 创建新标签并分配（替换现有分组）
   const handleCreateAndAssign = useCallback(async () => {
     const name = newTagName.trim();
     if (!name) return;
 
     try {
       const newTag = await createTagMutation.mutateAsync(name);
-      const newTagIds = [...Array.from(assignedTagIds), newTag.id];
       await setSkillTagsMutation.mutateAsync({
         skillId,
-        tagIds: newTagIds,
+        tagIds: [newTag.id],
       });
       setNewTagName("");
     } catch (error) {
       toast.error(t("common.error"), { description: String(error) });
     }
-  }, [
-    newTagName,
-    createTagMutation,
-    assignedTagIds,
-    setSkillTagsMutation,
-    skillId,
-    t,
-  ]);
-
-  const tagCount = assignedTagIds.size;
+  }, [newTagName, createTagMutation, setSkillTagsMutation, skillId, t]);
 
   return (
     <Popover>
@@ -106,14 +93,6 @@ export function TagAssignPopover({
           title={t("skills.assignTags")}
         >
           <Tag size={12} />
-          {tagCount > 0 && (
-            <Badge
-              variant="secondary"
-              className="absolute -top-1.5 -right-1.5 h-3.5 min-w-3.5 px-0.5 text-[9px] leading-none"
-            >
-              {tagCount}
-            </Badge>
-          )}
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-56">

--- a/src/components/skills/TagAssignPopover.tsx
+++ b/src/components/skills/TagAssignPopover.tsx
@@ -17,13 +17,9 @@ import { toast } from "sonner";
 
 interface TagAssignPopoverProps {
   skillId: string;
-  skillName: string;
 }
 
-export function TagAssignPopover({
-  skillId,
-  skillName,
-}: TagAssignPopoverProps) {
+export function TagAssignPopover({ skillId }: TagAssignPopoverProps) {
   const { t } = useTranslation();
   const [newTagName, setNewTagName] = useState("");
 
@@ -90,19 +86,20 @@ export function TagAssignPopover({
         <button
           type="button"
           className="relative text-muted-foreground/60 hover:text-foreground flex-shrink-0"
-          title={t("skills.assignTags")}
+          title={t("skills.tags.assignTag")}
         >
           <Tag size={12} />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-56">
-        <div className="space-y-2">
+      <PopoverContent align="end" className="w-60 overflow-hidden p-0">
+        <div className="border-b border-border-default px-3 py-2">
           <p className="text-xs font-medium text-muted-foreground">
-            {t("skills.tagsFor", { name: skillName })}
+            {t("skills.tags.assignTag")}
           </p>
+        </div>
 
-          {/* 标签列表 */}
-          <div className="max-h-48 overflow-y-auto space-y-1">
+        <div className="max-h-52 overflow-y-auto p-1.5 [scrollbar-width:thin]">
+          <div className="space-y-0.5">
             {allTags.map((tag) => {
               const isChecked = assignedTagIds.has(tag.id);
               return (
@@ -110,12 +107,16 @@ export function TagAssignPopover({
                   key={tag.id}
                   type="button"
                   onClick={() => handleToggleTag(tag.id)}
-                  className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded-sm hover:bg-accent transition-colors text-left"
+                  className={`flex h-9 w-full items-center gap-2 rounded-md px-2.5 text-left text-sm transition-colors ${
+                    isChecked
+                      ? "bg-blue-500/10 text-foreground"
+                      : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                  }`}
                 >
                   <div
-                    className={`flex h-4 w-4 items-center justify-center rounded-sm border ${
+                    className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors ${
                       isChecked
-                        ? "bg-primary border-primary text-primary-foreground"
+                        ? "border-blue-500 bg-blue-500 text-white"
                         : "border-muted-foreground/30"
                     }`}
                   >
@@ -125,39 +126,40 @@ export function TagAssignPopover({
                 </button>
               );
             })}
-
-            {allTags.length === 0 && (
-              <p className="text-xs text-muted-foreground py-2 text-center">
-                {t("skills.noTags")}
-              </p>
-            )}
           </div>
 
-          {/* 快速创建标签 */}
-          <div className="flex gap-1 pt-1 border-t">
-            <input
-              type="text"
-              value={newTagName}
-              onChange={(e) => setNewTagName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleCreateAndAssign();
-                }
-              }}
-              placeholder={t("skills.newTagPlaceholder")}
-              className="flex-1 h-7 text-xs px-2 rounded-sm border bg-transparent outline-none focus:ring-1 focus:ring-ring"
-            />
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 w-7 p-0"
-              onClick={handleCreateAndAssign}
-              disabled={!newTagName.trim()}
-            >
-              <Plus className="h-3.5 w-3.5" />
-            </Button>
-          </div>
+          {allTags.length === 0 && (
+            <p className="py-6 text-center text-xs text-muted-foreground">
+              {t("skills.tags.noTags")}
+            </p>
+          )}
+        </div>
+
+        {/* 快速创建标签 */}
+        <div className="flex gap-1.5 border-t border-border-default bg-muted/10 p-2">
+          <input
+            type="text"
+            value={newTagName}
+            onChange={(e) => setNewTagName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleCreateAndAssign();
+              }
+            }}
+            placeholder={t("skills.tags.tagNamePlaceholder")}
+            className="h-8 min-w-0 flex-1 rounded-md border border-border-default bg-background px-2.5 text-xs text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20"
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 cursor-pointer"
+            onClick={handleCreateAndAssign}
+            disabled={!newTagName.trim()}
+            title={t("skills.tags.create")}
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </Button>
         </div>
       </PopoverContent>
     </Popover>

--- a/src/components/skills/TagManagerDialog.tsx
+++ b/src/components/skills/TagManagerDialog.tsx
@@ -24,9 +24,9 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogClose,
 } from "@/components/ui/dialog";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import {
@@ -85,15 +85,15 @@ function SortableTagRow({
     <div
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-2 rounded-md border border-border/40 bg-background px-3 py-2"
+      className="group flex min-h-12 items-center gap-3 rounded-md border border-transparent px-3 py-2 transition-colors hover:border-border-default hover:bg-muted/35"
     >
       {/* 拖拽手柄 */}
       <button
-        className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+        className="cursor-grab touch-none text-muted-foreground/70 transition-colors hover:text-foreground active:cursor-grabbing"
         {...attributes}
         {...listeners}
       >
-        <GripVertical className="h-4 w-4" />
+        <GripVertical className="h-4 w-4" aria-hidden="true" />
       </button>
 
       {/* 标签名 / 编辑输入框 */}
@@ -106,11 +106,11 @@ function SortableTagRow({
               if (e.key === "Enter") onSaveEdit();
               if (e.key === "Escape") onCancelEdit();
             }}
-            className="h-7 text-sm"
+            className="h-8 text-sm"
             autoFocus
           />
         ) : (
-          <span className="text-sm truncate block">{tag.name}</span>
+          <span className="block truncate text-sm font-medium">{tag.name}</span>
         )}
       </div>
 
@@ -121,7 +121,7 @@ function SortableTagRow({
             <Button
               variant="ghost"
               size="icon"
-              className="h-7 w-7"
+              className="h-8 w-8 cursor-pointer"
               onClick={onSaveEdit}
               title={t("common.save")}
             >
@@ -130,7 +130,7 @@ function SortableTagRow({
             <Button
               variant="ghost"
               size="icon"
-              className="h-7 w-7"
+              className="h-8 w-8 cursor-pointer"
               onClick={onCancelEdit}
               title={t("common.cancel")}
             >
@@ -142,7 +142,7 @@ function SortableTagRow({
             <Button
               variant="ghost"
               size="icon"
-              className="h-7 w-7"
+              className="h-8 w-8 cursor-pointer opacity-70 transition-opacity group-hover:opacity-100"
               onClick={() => onStartEdit(tag)}
               title={t("skills.tags.rename")}
             >
@@ -151,7 +151,7 @@ function SortableTagRow({
             <Button
               variant="ghost"
               size="icon"
-              className="h-7 w-7 text-destructive hover:text-destructive"
+              className="h-8 w-8 cursor-pointer opacity-70 transition-opacity hover:bg-red-500/10 hover:text-red-500 group-hover:opacity-100"
               onClick={() => onDelete(tag)}
               title={t("skills.tags.delete")}
             >
@@ -200,19 +200,10 @@ export function TagManagerDialog({ open, onClose }: TagManagerDialogProps) {
     try {
       await createTag.mutateAsync(name);
       setNewTagName("");
-      toast.success(
-        t("skills.tags.createSuccess", {
-          defaultValue: "标签创建成功",
-        }),
-        { closeButton: true },
-      );
+      toast.success(t("skills.tags.createSuccess"), { closeButton: true });
     } catch (error) {
       console.error("[TagManagerDialog] 创建标签失败", error);
-      toast.error(
-        t("skills.tags.createFailed", {
-          defaultValue: "标签创建失败",
-        }),
-      );
+      toast.error(t("skills.tags.createFailed"));
     }
   }, [newTagName, createTag, t]);
 
@@ -238,19 +229,10 @@ export function TagManagerDialog({ open, onClose }: TagManagerDialogProps) {
       await updateTag.mutateAsync({ id: editingId, name });
       setEditingId(null);
       setEditingName("");
-      toast.success(
-        t("skills.tags.renameSuccess", {
-          defaultValue: "标签重命名成功",
-        }),
-        { closeButton: true },
-      );
+      toast.success(t("skills.tags.renameSuccess"), { closeButton: true });
     } catch (error) {
       console.error("[TagManagerDialog] 重命名标签失败", error);
-      toast.error(
-        t("skills.tags.renameFailed", {
-          defaultValue: "标签重命名失败",
-        }),
-      );
+      toast.error(t("skills.tags.renameFailed"));
     }
   }, [editingId, editingName, updateTag, t]);
 
@@ -260,19 +242,10 @@ export function TagManagerDialog({ open, onClose }: TagManagerDialogProps) {
       try {
         await deleteTag.mutateAsync(tag.id);
         setDeleteTarget(null);
-        toast.success(
-          t("skills.tags.deleteSuccess", {
-            defaultValue: "标签删除成功",
-          }),
-          { closeButton: true },
-        );
+        toast.success(t("skills.tags.deleteSuccess"), { closeButton: true });
       } catch (error) {
         console.error("[TagManagerDialog] 删除标签失败", error);
-        toast.error(
-          t("skills.tags.deleteFailed", {
-            defaultValue: "标签删除失败",
-          }),
-        );
+        toast.error(t("skills.tags.deleteFailed"));
       }
     },
     [deleteTag, t],
@@ -293,19 +266,10 @@ export function TagManagerDialog({ open, onClose }: TagManagerDialogProps) {
 
       try {
         await reorderTags.mutateAsync(orderedIds);
-        toast.success(
-          t("skills.tags.reorderSuccess", {
-            defaultValue: "排序已更新",
-          }),
-          { closeButton: true },
-        );
+        toast.success(t("skills.tags.reorderSuccess"), { closeButton: true });
       } catch (error) {
         console.error("[TagManagerDialog] 标签排序失败", error);
-        toast.error(
-          t("skills.tags.reorderFailed", {
-            defaultValue: "排序更新失败",
-          }),
-        );
+        toast.error(t("skills.tags.reorderFailed"));
       }
     },
     [tags, reorderTags, t],
@@ -326,16 +290,57 @@ export function TagManagerDialog({ open, onClose }: TagManagerDialogProps) {
   return (
     <>
       <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-        <DialogContent className="sm:max-w-md" zIndex="alert">
-          <DialogHeader>
-            <DialogTitle>{t("skills.tags.manage")}</DialogTitle>
+        <DialogContent
+          className="gap-0 overflow-hidden p-0 sm:max-w-[520px]"
+          zIndex="alert"
+        >
+          <DialogHeader className="border-b border-border-default bg-background px-6 py-4">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex min-w-0 items-center gap-3">
+                <DialogTitle>{t("skills.tags.manage")}</DialogTitle>
+                <span className="rounded-full border border-border-default bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground">
+                  {t("skills.tags.count", { count: sortedTags.length })}
+                </span>
+              </div>
+              <DialogClose asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 shrink-0 cursor-pointer"
+                  title={t("common.close")}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </DialogClose>
+            </div>
             <DialogDescription className="sr-only">
               {t("skills.tags.manage")}
             </DialogDescription>
           </DialogHeader>
 
+          {/* 新建标签 */}
+          <div className="border-b border-border-default bg-muted/10 px-6 py-4">
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+              <Input
+                value={newTagName}
+                onChange={(e) => setNewTagName(e.target.value)}
+                onKeyDown={handleNewTagKeyDown}
+                placeholder={t("skills.tags.tagNamePlaceholder")}
+                className="h-10"
+              />
+              <Button
+                onClick={handleCreate}
+                disabled={!newTagName.trim() || createTag.isPending}
+                className="h-10 px-4"
+              >
+                <Plus className="h-4 w-4" />
+                {t("skills.tags.create")}
+              </Button>
+            </div>
+          </div>
+
           {/* 标签列表 */}
-          <div className="max-h-[50vh] overflow-y-auto [scrollbar-width:thin] space-y-2 py-2">
+          <div className="max-h-[52vh] overflow-y-auto p-3 [scrollbar-width:thin]">
             {sortedTags.length === 0 ? (
               <div className="py-8 text-center text-sm text-muted-foreground">
                 {t("skills.tags.noTags")}
@@ -350,7 +355,7 @@ export function TagManagerDialog({ open, onClose }: TagManagerDialogProps) {
                   items={sortedTags.map((tag) => tag.id)}
                   strategy={verticalListSortingStrategy}
                 >
-                  <div className="space-y-2">
+                  <div className="space-y-1">
                     {sortedTags.map((tag) => (
                       <SortableTagRow
                         key={tag.id}
@@ -369,31 +374,6 @@ export function TagManagerDialog({ open, onClose }: TagManagerDialogProps) {
               </DndContext>
             )}
           </div>
-
-          {/* 新建标签 */}
-          <div className="flex items-center gap-2 pt-2 border-t">
-            <Input
-              value={newTagName}
-              onChange={(e) => setNewTagName(e.target.value)}
-              onKeyDown={handleNewTagKeyDown}
-              placeholder={t("skills.tags.tagNamePlaceholder")}
-              className="flex-1"
-            />
-            <Button
-              onClick={handleCreate}
-              disabled={!newTagName.trim() || createTag.isPending}
-              size="sm"
-            >
-              <Plus className="h-4 w-4 mr-1" />
-              {t("skills.tags.create")}
-            </Button>
-          </div>
-
-          <DialogFooter>
-            <Button variant="outline" onClick={onClose}>
-              {t("common.close")}
-            </Button>
-          </DialogFooter>
         </DialogContent>
       </Dialog>
 

--- a/src/components/skills/TagManagerDialog.tsx
+++ b/src/components/skills/TagManagerDialog.tsx
@@ -1,0 +1,413 @@
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Plus, Pencil, Trash2, GripVertical, Check, X } from "lucide-react";
+import { toast } from "sonner";
+import { CSS } from "@dnd-kit/utilities";
+import { DndContext, closestCenter } from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import {
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import {
+  useSkillTags,
+  useCreateTag,
+  useUpdateTag,
+  useDeleteTag,
+  useReorderTags,
+} from "@/hooks/useSkills";
+import type { SkillTag } from "@/hooks/useSkills";
+
+interface TagManagerDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/** 可排序的标签行 */
+function SortableTagRow({
+  tag,
+  editingId,
+  editingName,
+  onStartEdit,
+  onCancelEdit,
+  onEditNameChange,
+  onSaveEdit,
+  onDelete,
+}: {
+  tag: SkillTag;
+  editingId: number | null;
+  editingName: string;
+  onStartEdit: (tag: SkillTag) => void;
+  onCancelEdit: () => void;
+  onEditNameChange: (name: string) => void;
+  onSaveEdit: () => void;
+  onDelete: (tag: SkillTag) => void;
+}) {
+  const { t } = useTranslation();
+  const {
+    setNodeRef,
+    attributes,
+    listeners,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: tag.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const isEditing = editingId === tag.id;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 rounded-md border border-border/40 bg-background px-3 py-2"
+    >
+      {/* 拖拽手柄 */}
+      <button
+        className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+
+      {/* 标签名 / 编辑输入框 */}
+      <div className="flex-1 min-w-0">
+        {isEditing ? (
+          <Input
+            value={editingName}
+            onChange={(e) => onEditNameChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onSaveEdit();
+              if (e.key === "Escape") onCancelEdit();
+            }}
+            className="h-7 text-sm"
+            autoFocus
+          />
+        ) : (
+          <span className="text-sm truncate block">{tag.name}</span>
+        )}
+      </div>
+
+      {/* 操作按钮 */}
+      <div className="flex items-center gap-1 shrink-0">
+        {isEditing ? (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onSaveEdit}
+              title={t("common.save")}
+            >
+              <Check className="h-3.5 w-3.5 text-green-500" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={onCancelEdit}
+              title={t("common.cancel")}
+            >
+              <X className="h-3.5 w-3.5 text-muted-foreground" />
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={() => onStartEdit(tag)}
+              title={t("skills.tags.rename")}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-destructive hover:text-destructive"
+              onClick={() => onDelete(tag)}
+              title={t("skills.tags.delete")}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TagManagerDialog({ open, onClose }: TagManagerDialogProps) {
+  const { t } = useTranslation();
+  const { data: tags } = useSkillTags();
+  const createTag = useCreateTag();
+  const updateTag = useUpdateTag();
+  const deleteTag = useDeleteTag();
+  const reorderTags = useReorderTags();
+
+  // 新建标签输入
+  const [newTagName, setNewTagName] = useState("");
+
+  // 内联编辑状态
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingName, setEditingName] = useState("");
+
+  // 删除确认
+  const [deleteTarget, setDeleteTarget] = useState<SkillTag | null>(null);
+
+  // dnd-kit 传感器
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  /** 创建标签 */
+  const handleCreate = useCallback(async () => {
+    const name = newTagName.trim();
+    if (!name) return;
+
+    try {
+      await createTag.mutateAsync(name);
+      setNewTagName("");
+      toast.success(
+        t("skills.tags.createSuccess", {
+          defaultValue: "标签创建成功",
+        }),
+        { closeButton: true },
+      );
+    } catch (error) {
+      console.error("[TagManagerDialog] 创建标签失败", error);
+      toast.error(
+        t("skills.tags.createFailed", {
+          defaultValue: "标签创建失败",
+        }),
+      );
+    }
+  }, [newTagName, createTag, t]);
+
+  /** 开始编辑 */
+  const handleStartEdit = useCallback((tag: SkillTag) => {
+    setEditingId(tag.id);
+    setEditingName(tag.name);
+  }, []);
+
+  /** 取消编辑 */
+  const handleCancelEdit = useCallback(() => {
+    setEditingId(null);
+    setEditingName("");
+  }, []);
+
+  /** 保存编辑 */
+  const handleSaveEdit = useCallback(async () => {
+    if (editingId === null) return;
+    const name = editingName.trim();
+    if (!name) return;
+
+    try {
+      await updateTag.mutateAsync({ id: editingId, name });
+      setEditingId(null);
+      setEditingName("");
+      toast.success(
+        t("skills.tags.renameSuccess", {
+          defaultValue: "标签重命名成功",
+        }),
+        { closeButton: true },
+      );
+    } catch (error) {
+      console.error("[TagManagerDialog] 重命名标签失败", error);
+      toast.error(
+        t("skills.tags.renameFailed", {
+          defaultValue: "标签重命名失败",
+        }),
+      );
+    }
+  }, [editingId, editingName, updateTag, t]);
+
+  /** 删除标签 */
+  const handleDelete = useCallback(
+    async (tag: SkillTag) => {
+      try {
+        await deleteTag.mutateAsync(tag.id);
+        setDeleteTarget(null);
+        toast.success(
+          t("skills.tags.deleteSuccess", {
+            defaultValue: "标签删除成功",
+          }),
+          { closeButton: true },
+        );
+      } catch (error) {
+        console.error("[TagManagerDialog] 删除标签失败", error);
+        toast.error(
+          t("skills.tags.deleteFailed", {
+            defaultValue: "标签删除失败",
+          }),
+        );
+      }
+    },
+    [deleteTag, t],
+  );
+
+  /** 拖拽排序结束 */
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id || !tags) return;
+
+      const oldIndex = tags.findIndex((tag) => tag.id === active.id);
+      const newIndex = tags.findIndex((tag) => tag.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const reordered = arrayMove(tags, oldIndex, newIndex);
+      const orderedIds = reordered.map((tag) => tag.id);
+
+      try {
+        await reorderTags.mutateAsync(orderedIds);
+        toast.success(
+          t("skills.tags.reorderSuccess", {
+            defaultValue: "排序已更新",
+          }),
+          { closeButton: true },
+        );
+      } catch (error) {
+        console.error("[TagManagerDialog] 标签排序失败", error);
+        toast.error(
+          t("skills.tags.reorderFailed", {
+            defaultValue: "排序更新失败",
+          }),
+        );
+      }
+    },
+    [tags, reorderTags, t],
+  );
+
+  /** 新建输入回车提交 */
+  const handleNewTagKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") handleCreate();
+    },
+    [handleCreate],
+  );
+
+  const sortedTags = tags
+    ? [...tags].sort((a, b) => a.sort_index - b.sort_index)
+    : [];
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+        <DialogContent className="sm:max-w-md" zIndex="alert">
+          <DialogHeader>
+            <DialogTitle>{t("skills.tags.manage")}</DialogTitle>
+            <DialogDescription className="sr-only">
+              {t("skills.tags.manage")}
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* 标签列表 */}
+          <div className="max-h-[50vh] overflow-y-auto [scrollbar-width:thin] space-y-2 py-2">
+            {sortedTags.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                {t("skills.tags.noTags")}
+              </div>
+            ) : (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={sortedTags.map((tag) => tag.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-2">
+                    {sortedTags.map((tag) => (
+                      <SortableTagRow
+                        key={tag.id}
+                        tag={tag}
+                        editingId={editingId}
+                        editingName={editingName}
+                        onStartEdit={handleStartEdit}
+                        onCancelEdit={handleCancelEdit}
+                        onEditNameChange={setEditingName}
+                        onSaveEdit={handleSaveEdit}
+                        onDelete={setDeleteTarget}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            )}
+          </div>
+
+          {/* 新建标签 */}
+          <div className="flex items-center gap-2 pt-2 border-t">
+            <Input
+              value={newTagName}
+              onChange={(e) => setNewTagName(e.target.value)}
+              onKeyDown={handleNewTagKeyDown}
+              placeholder={t("skills.tags.tagNamePlaceholder")}
+              className="flex-1"
+            />
+            <Button
+              onClick={handleCreate}
+              disabled={!newTagName.trim() || createTag.isPending}
+              size="sm"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              {t("skills.tags.create")}
+            </Button>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={onClose}>
+              {t("common.close")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 删除确认弹窗 */}
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title={t("skills.tags.delete")}
+        message={t("skills.tags.deleteConfirm", {
+          name: deleteTarget?.name ?? "",
+          defaultValue: `确定要删除标签「${deleteTarget?.name ?? ""}」吗？`,
+        })}
+        onConfirm={() => deleteTarget && void handleDelete(deleteTarget)}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </>
+  );
+}

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -28,6 +28,7 @@ import {
   DragOverlay,
   closestCenter,
   PointerSensor,
+  useDroppable,
   useSensor,
   useSensors,
   type DragStartEvent,
@@ -199,16 +200,25 @@ const UnifiedSkillsPanel = React.forwardRef<
     }[] = [];
     const assignedSkillIds = new Set<string>();
 
-    // 按 tag 分组
-    for (const tag of tags) {
-      const skillIds = tagAssignments
-        .filter(([, tid]) => tid === tag.id)
-        .map(([sid]) => sid);
-      const groupSkills = skills.filter((s) => skillIds.includes(s.id));
-      if (groupSkills.length > 0) {
-        groups.push({ tag, tagId: tag.id, skills: groupSkills });
-        groupSkills.forEach((s) => assignedSkillIds.add(s.id));
+    // 预构建 tagId -> Set<skillId> 映射，避免 O(n*m) 查找
+    const tagSkillMap = new Map<number, Set<string>>();
+    for (const [sid, tid] of tagAssignments) {
+      let set = tagSkillMap.get(tid);
+      if (!set) {
+        set = new Set();
+        tagSkillMap.set(tid, set);
       }
+      set.add(sid);
+    }
+
+    // 按 tag 分组（保留空 tag 作为 drop target）
+    for (const tag of tags) {
+      const skillIdSet = tagSkillMap.get(tag.id);
+      const groupSkills = skillIdSet
+        ? skills.filter((s) => skillIdSet.has(s.id))
+        : [];
+      groups.push({ tag, tagId: tag.id, skills: groupSkills });
+      groupSkills.forEach((s) => assignedSkillIds.add(s.id));
     }
 
     // 未分组
@@ -321,7 +331,9 @@ const UnifiedSkillsPanel = React.forwardRef<
         const skillId = activeId.replace("skill:", "");
         let targetTagId: number | null = null;
 
-        if (overId.startsWith("group:")) {
+        if (overId.startsWith("drop-group:")) {
+          targetTagId = parseInt(overId.replace("drop-group:", ""), 10);
+        } else if (overId.startsWith("group:")) {
           targetTagId = parseInt(overId.replace("group:", ""), 10);
         } else if (overId.startsWith("skill:")) {
           // 拖到另一个 skill 上，找到该 skill 所在的分组
@@ -704,28 +716,41 @@ const UnifiedSkillsPanel = React.forwardRef<
                           tagId={tagKey}
                           isUntagged={group.tagId === null}
                         >
-                          <SortableGroupHeader
-                            tag={group.tag}
-                            tagId={group.tagId}
-                            skillCount={group.skills.length}
-                            isCollapsed={isCollapsed}
-                            isEditing={
-                              editingTagId !== null &&
-                              editingTagId === group.tagId
-                            }
-                            editingName={editingTagName}
-                            editInputRef={editInputRef}
-                            onToggleCollapse={() =>
-                              group.tagId !== null &&
-                              toggleTagCollapse(group.tagId)
-                            }
-                            onStartEdit={() =>
-                              group.tag && handleStartEditTag(group.tag)
-                            }
-                            onEditingNameChange={setEditingTagName}
-                            onSaveEdit={handleSaveEditTag}
-                            onCancelEdit={handleCancelEditTag}
-                          />
+                          {group.tagId !== null ? (
+                            <SortableGroupHeader
+                              tag={group.tag}
+                              tagId={group.tagId}
+                              skillCount={group.skills.length}
+                              isCollapsed={isCollapsed}
+                              isEditing={editingTagId === group.tagId}
+                              editingName={editingTagName}
+                              editInputRef={editInputRef}
+                              onToggleCollapse={() =>
+                                toggleTagCollapse(group.tagId!)
+                              }
+                              onStartEdit={() =>
+                                group.tag && handleStartEditTag(group.tag)
+                              }
+                              onEditingNameChange={setEditingTagName}
+                              onSaveEdit={handleSaveEditTag}
+                              onCancelEdit={handleCancelEditTag}
+                            />
+                          ) : (
+                            <StaticGroupHeader
+                              tag={group.tag}
+                              tagId={group.tagId}
+                              skillCount={group.skills.length}
+                              isCollapsed={isCollapsed}
+                              isEditing={false}
+                              editingName={editingTagName}
+                              editInputRef={editInputRef}
+                              onToggleCollapse={() => {}}
+                              onStartEdit={() => {}}
+                              onEditingNameChange={setEditingTagName}
+                              onSaveEdit={handleSaveEditTag}
+                              onCancelEdit={handleCancelEditTag}
+                            />
+                          )}
                           {!isCollapsed && (
                             <div>
                               {group.skills.map((skill, index) => (
@@ -900,7 +925,7 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
           >
             <FolderOpen size={12} />
           </button>
-          <TagAssignPopover skillId={skill.id} skillName={skill.name} />
+          <TagAssignPopover skillId={skill.id} />
           <span className="text-xs text-muted-foreground/50 flex-shrink-0">
             {sourceLabel}
           </span>
@@ -1259,26 +1284,21 @@ const DroppableGroup: React.FC<{
   );
 };
 
-/** 可排序 + 可放置的分组容器 */
+/** 可放置的分组容器 */
 const SortableDroppableGroup: React.FC<{
   tagId: number;
   children: React.ReactNode;
 }> = ({ tagId, children }) => {
-  const { setNodeRef, transform, transition, isDragging } = useSortable({
-    id: `group:${tagId}`,
+  const { setNodeRef, isOver } = useDroppable({
+    id: `drop-group:${tagId}`,
   });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  };
 
   return (
     <div
       ref={setNodeRef}
-      style={style}
-      className="rounded-xl border border-border-default overflow-hidden"
+      className={`rounded-xl border overflow-hidden transition-colors ${
+        isOver ? "border-primary/60 bg-primary/5" : "border-border-default"
+      }`}
       data-group-id={tagId}
     >
       {children}
@@ -1286,8 +1306,8 @@ const SortableDroppableGroup: React.FC<{
   );
 };
 
-/** 可排序的分组头部（支持内联编辑名称） */
-const SortableGroupHeader: React.FC<{
+/** 分组头部 Props */
+interface GroupHeaderProps {
   tag: SkillTag | null;
   tagId: number | null;
   skillCount: number;
@@ -1300,7 +1320,10 @@ const SortableGroupHeader: React.FC<{
   onEditingNameChange: (name: string) => void;
   onSaveEdit: () => void;
   onCancelEdit: () => void;
-}> = ({
+}
+
+/** 分组头部内容（编辑/显示逻辑） */
+const GroupHeaderContent: React.FC<GroupHeaderProps> = ({
   tag,
   tagId,
   skillCount,
@@ -1315,42 +1338,37 @@ const SortableGroupHeader: React.FC<{
   onCancelEdit,
 }) => {
   const { t } = useTranslation();
-
-  // 可排序 hook（仅对有 tagId 的分组生效）
-  const sortable =
-    tagId !== null ? useSortable({ id: `group:${tagId}` }) : null;
+  const isCancellingRef = useRef(false);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") {
       e.preventDefault();
       onSaveEdit();
     } else if (e.key === "Escape") {
+      isCancellingRef.current = true;
       onCancelEdit();
     }
   };
 
-  return (
-    <div
-      className="flex items-center gap-2 px-4 py-2 bg-muted/50 hover:bg-muted/70 transition-colors"
-      ref={sortable?.setNodeRef}
-      style={{
-        transform: CSS.Transform.toString(sortable?.transform ?? null),
-        transition: sortable?.transition,
-        opacity: sortable?.isDragging ? 0.5 : 1,
-      }}
-    >
-      {/* 拖拽手柄（仅自定义分组） */}
-      {tagId !== null && (
-        <button
-          type="button"
-          className="cursor-grab active:cursor-grabbing text-muted-foreground/40 hover:text-muted-foreground flex-shrink-0"
-          {...sortable?.attributes}
-          {...sortable?.listeners}
-        >
-          <GripVertical size={14} />
-        </button>
-      )}
+  const handleBlur = () => {
+    // 延迟检查，让 mousedown 事件先触发
+    requestAnimationFrame(() => {
+      if (!isCancellingRef.current) {
+        onSaveEdit();
+      }
+      isCancellingRef.current = false;
+    });
+  };
 
+  const handleCancelMouseDown = (e: React.MouseEvent) => {
+    // 阻止 Input 失焦
+    e.preventDefault();
+    isCancellingRef.current = true;
+    onCancelEdit();
+  };
+
+  return (
+    <>
       {/* 展开/折叠 */}
       <button
         type="button"
@@ -1378,7 +1396,7 @@ const SortableGroupHeader: React.FC<{
             value={editingName}
             onChange={(e) => onEditingNameChange(e.target.value)}
             onKeyDown={handleKeyDown}
-            onBlur={onSaveEdit}
+            onBlur={handleBlur}
             className="h-6 text-sm py-0 px-1"
           />
           <button
@@ -1390,7 +1408,7 @@ const SortableGroupHeader: React.FC<{
           </button>
           <button
             type="button"
-            onClick={onCancelEdit}
+            onMouseDown={handleCancelMouseDown}
             className="text-muted-foreground hover:text-foreground flex-shrink-0"
           >
             <X size={14} />
@@ -1412,6 +1430,53 @@ const SortableGroupHeader: React.FC<{
       >
         {skillCount}
       </Badge>
+    </>
+  );
+};
+
+/** 可排序的分组头部（有 tagId，支持拖拽排序） */
+const SortableGroupHeader: React.FC<GroupHeaderProps> = ({
+  tagId,
+  ...props
+}) => {
+  const {
+    setNodeRef,
+    attributes,
+    listeners,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: `group:${tagId}` });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className="flex items-center gap-2 px-4 py-2 bg-muted/50 hover:bg-muted/70 transition-colors"
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+      }}
+    >
+      {/* 拖拽手柄 */}
+      <button
+        type="button"
+        className="cursor-grab active:cursor-grabbing text-muted-foreground/40 hover:text-muted-foreground flex-shrink-0"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical size={14} />
+      </button>
+      <GroupHeaderContent tagId={tagId} {...props} />
+    </div>
+  );
+};
+
+/** 不可排序的分组头部（未分组区域） */
+const StaticGroupHeader: React.FC<GroupHeaderProps> = ({ tagId, ...props }) => {
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 hover:bg-muted/70 transition-colors">
+      <GroupHeaderContent tagId={tagId} {...props} />
     </div>
   );
 };

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -21,6 +21,7 @@ import {
   GripVertical,
   Check,
   X,
+  FolderOpen,
 } from "lucide-react";
 import {
   DndContext,
@@ -860,6 +861,14 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
     }
   };
 
+  const openInExplorer = async () => {
+    try {
+      await skillsApi.openDirectory(skill.directory);
+    } catch (error) {
+      toast.error(t("common.error"), { description: String(error) });
+    }
+  };
+
   const sourceLabel = useMemo(() => {
     if (skill.repoOwner && skill.repoName) {
       return `${skill.repoOwner}/${skill.repoName}`;
@@ -883,6 +892,14 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
               <ExternalLink size={12} />
             </button>
           )}
+          <button
+            type="button"
+            onClick={openInExplorer}
+            className="text-muted-foreground/60 hover:text-foreground flex-shrink-0"
+            title={t("skills.openDirectory")}
+          >
+            <FolderOpen size={12} />
+          </button>
           <TagAssignPopover skillId={skill.id} skillName={skill.name} />
           <span className="text-xs text-muted-foreground/50 flex-shrink-0">
             {sourceLabel}

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -87,6 +87,45 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
+const UNTAGGED_GROUP_KEY = -1;
+const UNTAGGED_DROP_ID = "drop-untagged";
+
+export function getSkillDropTargetTagIds(
+  overId: string,
+  tagAssignments: [string, number][],
+): number[] | null {
+  if (overId === UNTAGGED_DROP_ID) {
+    return [];
+  }
+
+  if (overId.startsWith("drop-group:")) {
+    const tagId = parseInt(overId.replace("drop-group:", ""), 10);
+    if (isNaN(tagId)) return null;
+    return tagId === UNTAGGED_GROUP_KEY ? [] : [tagId];
+  }
+
+  if (overId.startsWith("group:")) {
+    const tagId = parseInt(overId.replace("group:", ""), 10);
+    if (isNaN(tagId)) return null;
+    return tagId === UNTAGGED_GROUP_KEY ? [] : [tagId];
+  }
+
+  if (overId.startsWith("skill:")) {
+    const overSkillId = overId.replace("skill:", "");
+    const assignment = tagAssignments.find(([sid]) => sid === overSkillId);
+    return assignment ? [assignment[1]] : [];
+  }
+
+  return null;
+}
+
+function hasSameTagAssignment(currentTagIds: number[], targetTagIds: number[]) {
+  return (
+    currentTagIds.length === targetTagIds.length &&
+    targetTagIds.every((tagId) => currentTagIds.includes(tagId))
+  );
+}
+
 interface UnifiedSkillsPanelProps {
   onOpenDiscovery: () => void;
   currentApp: AppId;
@@ -329,24 +368,8 @@ const UnifiedSkillsPanel = React.forwardRef<
       // 技能拖拽到不同分组
       if (activeId.startsWith("skill:")) {
         const skillId = activeId.replace("skill:", "");
-        let targetTagId: number | null = null;
-
-        if (overId.startsWith("drop-group:")) {
-          targetTagId = parseInt(overId.replace("drop-group:", ""), 10);
-        } else if (overId.startsWith("group:")) {
-          targetTagId = parseInt(overId.replace("group:", ""), 10);
-        } else if (overId.startsWith("skill:")) {
-          // 拖到另一个 skill 上，找到该 skill 所在的分组
-          const overSkillId = overId.replace("skill:", "");
-          for (const [sid, tid] of tagAssignments) {
-            if (sid === overSkillId) {
-              targetTagId = tid;
-              break;
-            }
-          }
-        }
-
-        if (targetTagId === null || isNaN(targetTagId)) return;
+        const targetTagIds = getSkillDropTargetTagIds(overId, tagAssignments);
+        if (targetTagIds === null) return;
 
         // 获取该 skill 当前的标签
         const currentTagIds = tagAssignments
@@ -354,13 +377,13 @@ const UnifiedSkillsPanel = React.forwardRef<
           .map(([, tid]) => tid);
 
         // 如果已经在目标分组中，不处理
-        if (currentTagIds.includes(targetTagId)) return;
+        if (hasSameTagAssignment(currentTagIds, targetTagIds)) return;
 
         // 分配新标签（替换现有分配）
         try {
           await setSkillTagsMutation.mutateAsync({
             skillId,
-            tagIds: [targetTagId],
+            tagIds: targetTagIds,
           });
           toast.success(t("skills.tags.moveSuccess"), { closeButton: true });
         } catch (error) {
@@ -708,12 +731,12 @@ const UnifiedSkillsPanel = React.forwardRef<
                 >
                   <div className="space-y-3">
                     {groupedSkills.map((group) => {
-                      const tagKey = group.tagId ?? -1;
+                      const tagKey = group.tagId ?? UNTAGGED_GROUP_KEY;
                       const isCollapsed = collapsedTags.has(tagKey);
                       return (
                         <DroppableGroup
                           key={tagKey}
-                          tagId={tagKey}
+                          tagId={group.tagId}
                           isUntagged={group.tagId === null}
                         >
                           {group.tagId !== null ? (
@@ -1266,21 +1289,37 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
 
 /** 可放置技能的分组容器 */
 const DroppableGroup: React.FC<{
-  tagId: number;
+  tagId: number | null;
   isUntagged: boolean;
   children: React.ReactNode;
 }> = ({ tagId, isUntagged, children }) => {
-  // 未分组区域不参与拖拽
   if (isUntagged) {
-    return (
-      <div className="rounded-xl border border-border-default overflow-hidden">
-        {children}
-      </div>
-    );
+    return <UntaggedDroppableGroup>{children}</UntaggedDroppableGroup>;
   }
 
   return (
-    <SortableDroppableGroup tagId={tagId}>{children}</SortableDroppableGroup>
+    <SortableDroppableGroup tagId={tagId!}>{children}</SortableDroppableGroup>
+  );
+};
+
+/** 可放置的未分组容器 */
+const UntaggedDroppableGroup: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const { setNodeRef, isOver } = useDroppable({
+    id: UNTAGGED_DROP_ID,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`rounded-xl border overflow-hidden transition-colors ${
+        isOver ? "border-primary/60 bg-primary/5" : "border-border-default"
+      }`}
+      data-group-id="untagged"
+    >
+      {children}
+    </div>
   );
 };
 

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -1,4 +1,10 @@
-import React, { useMemo, useState } from "react";
+import React, {
+  useMemo,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+} from "react";
 import { useTranslation } from "react-i18next";
 import {
   Sparkles,
@@ -6,10 +12,37 @@ import {
   ExternalLink,
   RefreshCw,
   Loader2,
+  Tag,
+  LayoutList,
+  Layers,
+  Settings2,
+  ChevronDown,
+  ChevronRight,
+  GripVertical,
+  Check,
+  X,
 } from "lucide-react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { Input } from "@/components/ui/input";
 import {
   type ImportSkillSelection,
   type SkillBackupEntry,
@@ -24,8 +57,14 @@ import {
   useInstallSkillsFromZip,
   useCheckSkillUpdates,
   useUpdateSkill,
+  useSkillTags,
+  useAllTagAssignments,
+  useSetSkillTags,
+  useUpdateTag,
+  useReorderTags,
   type InstalledSkill,
   type SkillUpdateInfo,
+  type SkillTag,
 } from "@/hooks/useSkills";
 import type { AppId } from "@/lib/api/types";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -35,6 +74,8 @@ import { SKILLS_APP_IDS } from "@/config/appConfig";
 import { AppCountBar } from "@/components/common/AppCountBar";
 import { AppToggleGroup } from "@/components/common/AppToggleGroup";
 import { ListItemRow } from "@/components/common/ListItemRow";
+import { TagManagerDialog } from "@/components/skills/TagManagerDialog";
+import { TagAssignPopover } from "@/components/skills/TagAssignPopover";
 import {
   Dialog,
   DialogContent,
@@ -79,8 +120,13 @@ const UnifiedSkillsPanel = React.forwardRef<
   } | null>(null);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<"list" | "grouped">("list");
+  const [tagManagerOpen, setTagManagerOpen] = useState(false);
+  const [collapsedTags, setCollapsedTags] = useState<Set<number>>(new Set());
 
   const { data: skills, isLoading } = useInstalledSkills();
+  const { data: tags = [] } = useSkillTags();
+  const { data: tagAssignments = [] } = useAllTagAssignments();
   const {
     data: skillBackups = [],
     refetch: refetchSkillBackups,
@@ -100,7 +146,18 @@ const UnifiedSkillsPanel = React.forwardRef<
     isFetching: isCheckingUpdates,
   } = useCheckSkillUpdates();
   const updateSkillMutation = useUpdateSkill();
+  const setSkillTagsMutation = useSetSkillTags();
+  const updateTagMutation = useUpdateTag();
+  const reorderTagsMutation = useReorderTags();
   const [isUpdatingAll, setIsUpdatingAll] = useState(false);
+
+  // 拖拽状态
+  const [activeDragSkill, setActiveDragSkill] = useState<InstalledSkill | null>(
+    null,
+  );
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
 
   const updatesMap = useMemo(() => {
     const map: Record<string, SkillUpdateInfo> = {};
@@ -130,6 +187,176 @@ const UnifiedSkillsPanel = React.forwardRef<
     });
     return counts;
   }, [skills]);
+
+  // 按标签分组的 skills
+  const groupedSkills = useMemo(() => {
+    if (!skills) return [];
+    const groups: {
+      tag: SkillTag | null;
+      tagId: number | null;
+      skills: InstalledSkill[];
+    }[] = [];
+    const assignedSkillIds = new Set<string>();
+
+    // 按 tag 分组
+    for (const tag of tags) {
+      const skillIds = tagAssignments
+        .filter(([, tid]) => tid === tag.id)
+        .map(([sid]) => sid);
+      const groupSkills = skills.filter((s) => skillIds.includes(s.id));
+      if (groupSkills.length > 0) {
+        groups.push({ tag, tagId: tag.id, skills: groupSkills });
+        groupSkills.forEach((s) => assignedSkillIds.add(s.id));
+      }
+    }
+
+    // 未分组
+    const ungrouped = skills.filter((s) => !assignedSkillIds.has(s.id));
+    if (ungrouped.length > 0) {
+      groups.push({ tag: null, tagId: null, skills: ungrouped });
+    }
+
+    return groups;
+  }, [skills, tags, tagAssignments]);
+
+  const toggleTagCollapse = useCallback((tagId: number) => {
+    setCollapsedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tagId)) {
+        next.delete(tagId);
+      } else {
+        next.add(tagId);
+      }
+      return next;
+    });
+  }, []);
+
+  // 分组名称内联编辑状态
+  const [editingTagId, setEditingTagId] = useState<number | null>(null);
+  const [editingTagName, setEditingTagName] = useState("");
+  const editInputRef = useRef<HTMLInputElement>(null!);
+
+  useEffect(() => {
+    if (editingTagId !== null && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingTagId]);
+
+  const handleStartEditTag = useCallback((tag: SkillTag) => {
+    setEditingTagId(tag.id);
+    setEditingTagName(tag.name);
+  }, []);
+
+  const handleSaveEditTag = useCallback(async () => {
+    if (editingTagId === null) return;
+    const trimmed = editingTagName.trim();
+    if (!trimmed) {
+      setEditingTagId(null);
+      return;
+    }
+    try {
+      await updateTagMutation.mutateAsync({ id: editingTagId, name: trimmed });
+      toast.success(t("skills.tags.renameSuccess"), { closeButton: true });
+    } catch (error) {
+      toast.error(t("common.error"), { description: String(error) });
+    }
+    setEditingTagId(null);
+  }, [editingTagId, editingTagName, updateTagMutation, t]);
+
+  const handleCancelEditTag = useCallback(() => {
+    setEditingTagId(null);
+  }, []);
+
+  // 拖拽开始
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const { active } = event;
+      const activeId = active.id as string;
+      // 判断是 skill 拖拽还是 group 拖拽
+      if (activeId.startsWith("skill:")) {
+        const skillId = activeId.replace("skill:", "");
+        const skill = skills?.find((s) => s.id === skillId);
+        if (skill) setActiveDragSkill(skill);
+      }
+    },
+    [skills],
+  );
+
+  // 拖拽结束
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event;
+      setActiveDragSkill(null);
+      if (!over) return;
+
+      const activeId = active.id as string;
+      const overId = over.id as string;
+
+      // 分组排序（group header 拖拽）
+      if (
+        activeId.startsWith("group:") &&
+        overId.startsWith("group:") &&
+        activeId !== overId
+      ) {
+        const activeTagId = parseInt(activeId.replace("group:", ""), 10);
+        const overTagId = parseInt(overId.replace("group:", ""), 10);
+        const tagIds = tags.map((t) => t.id);
+        const oldIndex = tagIds.indexOf(activeTagId);
+        const newIndex = tagIds.indexOf(overTagId);
+        if (oldIndex !== -1 && newIndex !== -1) {
+          const newOrder = arrayMove(tagIds, oldIndex, newIndex);
+          try {
+            await reorderTagsMutation.mutateAsync(newOrder);
+          } catch (error) {
+            toast.error(t("common.error"), { description: String(error) });
+          }
+        }
+        return;
+      }
+
+      // 技能拖拽到不同分组
+      if (activeId.startsWith("skill:")) {
+        const skillId = activeId.replace("skill:", "");
+        let targetTagId: number | null = null;
+
+        if (overId.startsWith("group:")) {
+          targetTagId = parseInt(overId.replace("group:", ""), 10);
+        } else if (overId.startsWith("skill:")) {
+          // 拖到另一个 skill 上，找到该 skill 所在的分组
+          const overSkillId = overId.replace("skill:", "");
+          for (const [sid, tid] of tagAssignments) {
+            if (sid === overSkillId) {
+              targetTagId = tid;
+              break;
+            }
+          }
+        }
+
+        if (targetTagId === null || isNaN(targetTagId)) return;
+
+        // 获取该 skill 当前的标签
+        const currentTagIds = tagAssignments
+          .filter(([sid]) => sid === skillId)
+          .map(([, tid]) => tid);
+
+        // 如果已经在目标分组中，不处理
+        if (currentTagIds.includes(targetTagId)) return;
+
+        // 分配新标签（替换现有分配）
+        try {
+          await setSkillTagsMutation.mutateAsync({
+            skillId,
+            tagIds: [targetTagId],
+          });
+          toast.success(t("skills.tags.moveSuccess"), { closeButton: true });
+        } catch (error) {
+          toast.error(t("common.error"), { description: String(error) });
+        }
+      }
+    },
+    [tags, tagAssignments, reorderTagsMutation, setSkillTagsMutation, t],
+  );
 
   const handleToggleApp = async (id: string, app: AppId, enabled: boolean) => {
     try {
@@ -353,6 +580,40 @@ const UnifiedSkillsPanel = React.forwardRef<
           appIds={SKILLS_APP_IDS}
         />
         <div className="flex items-center gap-1.5">
+          {/* 视图切换 */}
+          <div className="flex items-center rounded-md border border-border-default">
+            <Button
+              type="button"
+              variant={viewMode === "list" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 px-2 text-xs rounded-r-none"
+              onClick={() => setViewMode("list")}
+              title={t("skills.tags.listView")}
+            >
+              <LayoutList size={12} />
+            </Button>
+            <Button
+              type="button"
+              variant={viewMode === "grouped" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 px-2 text-xs rounded-l-none"
+              onClick={() => setViewMode("grouped")}
+              title={t("skills.tags.groupedView")}
+            >
+              <Layers size={12} />
+            </Button>
+          </div>
+          {/* 标签管理入口 */}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs gap-1"
+            onClick={() => setTagManagerOpen(true)}
+          >
+            <Tag size={12} />
+            <Settings2 size={10} />
+          </Button>
           <div
             className="transition-all duration-300 ease-out overflow-hidden"
             style={{
@@ -418,23 +679,107 @@ const UnifiedSkillsPanel = React.forwardRef<
           </div>
         ) : (
           <TooltipProvider delayDuration={300}>
-            <div className="rounded-xl border border-border-default overflow-hidden">
-              {skills.map((skill, index) => (
-                <InstalledSkillListItem
-                  key={skill.id}
-                  skill={skill}
-                  hasUpdate={!!updatesMap[skill.id]}
-                  isUpdating={
-                    updateSkillMutation.isPending &&
-                    updateSkillMutation.variables === skill.id
-                  }
-                  onToggleApp={handleToggleApp}
-                  onUninstall={() => handleUninstall(skill)}
-                  onUpdate={() => handleUpdateSkill(skill)}
-                  isLast={index === skills.length - 1}
-                />
-              ))}
-            </div>
+            {viewMode === "grouped" && groupedSkills.length > 0 ? (
+              /* 分组视图（支持拖拽排序 + 技能拖拽分组 + 内联编辑） */
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={groupedSkills
+                    .filter((g) => g.tagId !== null)
+                    .map((g) => `group:${g.tagId}`)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-3">
+                    {groupedSkills.map((group) => {
+                      const tagKey = group.tagId ?? -1;
+                      const isCollapsed = collapsedTags.has(tagKey);
+                      return (
+                        <DroppableGroup
+                          key={tagKey}
+                          tagId={tagKey}
+                          isUntagged={group.tagId === null}
+                        >
+                          <SortableGroupHeader
+                            tag={group.tag}
+                            tagId={group.tagId}
+                            skillCount={group.skills.length}
+                            isCollapsed={isCollapsed}
+                            isEditing={
+                              editingTagId !== null &&
+                              editingTagId === group.tagId
+                            }
+                            editingName={editingTagName}
+                            editInputRef={editInputRef}
+                            onToggleCollapse={() =>
+                              group.tagId !== null &&
+                              toggleTagCollapse(group.tagId)
+                            }
+                            onStartEdit={() =>
+                              group.tag && handleStartEditTag(group.tag)
+                            }
+                            onEditingNameChange={setEditingTagName}
+                            onSaveEdit={handleSaveEditTag}
+                            onCancelEdit={handleCancelEditTag}
+                          />
+                          {!isCollapsed && (
+                            <div>
+                              {group.skills.map((skill, index) => (
+                                <DraggableSkillRow key={skill.id} skill={skill}>
+                                  <InstalledSkillListItem
+                                    skill={skill}
+                                    hasUpdate={!!updatesMap[skill.id]}
+                                    isUpdating={
+                                      updateSkillMutation.isPending &&
+                                      updateSkillMutation.variables === skill.id
+                                    }
+                                    onToggleApp={handleToggleApp}
+                                    onUninstall={() => handleUninstall(skill)}
+                                    onUpdate={() => handleUpdateSkill(skill)}
+                                    isLast={index === group.skills.length - 1}
+                                  />
+                                </DraggableSkillRow>
+                              ))}
+                            </div>
+                          )}
+                        </DroppableGroup>
+                      );
+                    })}
+                  </div>
+                </SortableContext>
+                <DragOverlay>
+                  {activeDragSkill && (
+                    <div className="rounded-lg border border-primary bg-background px-4 py-2 shadow-lg opacity-90">
+                      <span className="text-sm font-medium">
+                        {activeDragSkill.name}
+                      </span>
+                    </div>
+                  )}
+                </DragOverlay>
+              </DndContext>
+            ) : (
+              /* 列表视图 */
+              <div className="rounded-xl border border-border-default overflow-hidden">
+                {skills.map((skill, index) => (
+                  <InstalledSkillListItem
+                    key={skill.id}
+                    skill={skill}
+                    hasUpdate={!!updatesMap[skill.id]}
+                    isUpdating={
+                      updateSkillMutation.isPending &&
+                      updateSkillMutation.variables === skill.id
+                    }
+                    onToggleApp={handleToggleApp}
+                    onUninstall={() => handleUninstall(skill)}
+                    onUpdate={() => handleUpdateSkill(skill)}
+                    isLast={index === skills.length - 1}
+                  />
+                ))}
+              </div>
+            )}
           </TooltipProvider>
         )}
       </div>
@@ -458,6 +803,14 @@ const UnifiedSkillsPanel = React.forwardRef<
           isImporting={importMutation.isPending}
           onImport={handleImport}
           onClose={() => setImportDialogOpen(false)}
+        />
+      )}
+
+      {/* 标签管理弹窗 */}
+      {tagManagerOpen && (
+        <TagManagerDialog
+          open={tagManagerOpen}
+          onClose={() => setTagManagerOpen(false)}
         />
       )}
 
@@ -530,6 +883,7 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
               <ExternalLink size={12} />
             </button>
           )}
+          <TagAssignPopover skillId={skill.id} skillName={skill.name} />
           <span className="text-xs text-muted-foreground/50 flex-shrink-0">
             {sourceLabel}
           </span>
@@ -863,6 +1217,213 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
         </div>
       </div>
     </TooltipProvider>
+  );
+};
+
+// ========== 分组视图辅助组件 ==========
+
+/** 可放置技能的分组容器 */
+const DroppableGroup: React.FC<{
+  tagId: number;
+  isUntagged: boolean;
+  children: React.ReactNode;
+}> = ({ tagId, isUntagged, children }) => {
+  // 未分组区域不参与拖拽
+  if (isUntagged) {
+    return (
+      <div className="rounded-xl border border-border-default overflow-hidden">
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <SortableDroppableGroup tagId={tagId}>{children}</SortableDroppableGroup>
+  );
+};
+
+/** 可排序 + 可放置的分组容器 */
+const SortableDroppableGroup: React.FC<{
+  tagId: number;
+  children: React.ReactNode;
+}> = ({ tagId, children }) => {
+  const { setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `group:${tagId}`,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="rounded-xl border border-border-default overflow-hidden"
+      data-group-id={tagId}
+    >
+      {children}
+    </div>
+  );
+};
+
+/** 可排序的分组头部（支持内联编辑名称） */
+const SortableGroupHeader: React.FC<{
+  tag: SkillTag | null;
+  tagId: number | null;
+  skillCount: number;
+  isCollapsed: boolean;
+  isEditing: boolean;
+  editingName: string;
+  editInputRef: React.RefObject<HTMLInputElement>;
+  onToggleCollapse: () => void;
+  onStartEdit: () => void;
+  onEditingNameChange: (name: string) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+}> = ({
+  tag,
+  tagId,
+  skillCount,
+  isCollapsed,
+  isEditing,
+  editingName,
+  editInputRef,
+  onToggleCollapse,
+  onStartEdit,
+  onEditingNameChange,
+  onSaveEdit,
+  onCancelEdit,
+}) => {
+  const { t } = useTranslation();
+
+  // 可排序 hook（仅对有 tagId 的分组生效）
+  const sortable =
+    tagId !== null ? useSortable({ id: `group:${tagId}` }) : null;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onSaveEdit();
+    } else if (e.key === "Escape") {
+      onCancelEdit();
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center gap-2 px-4 py-2 bg-muted/50 hover:bg-muted/70 transition-colors"
+      ref={sortable?.setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(sortable?.transform ?? null),
+        transition: sortable?.transition,
+        opacity: sortable?.isDragging ? 0.5 : 1,
+      }}
+    >
+      {/* 拖拽手柄（仅自定义分组） */}
+      {tagId !== null && (
+        <button
+          type="button"
+          className="cursor-grab active:cursor-grabbing text-muted-foreground/40 hover:text-muted-foreground flex-shrink-0"
+          {...sortable?.attributes}
+          {...sortable?.listeners}
+        >
+          <GripVertical size={14} />
+        </button>
+      )}
+
+      {/* 展开/折叠 */}
+      <button
+        type="button"
+        className="flex-shrink-0"
+        onClick={onToggleCollapse}
+      >
+        {tagId !== null ? (
+          isCollapsed ? (
+            <ChevronRight size={14} />
+          ) : (
+            <ChevronDown size={14} />
+          )
+        ) : (
+          <span className="w-[14px]" />
+        )}
+      </button>
+
+      <Tag size={14} className="text-muted-foreground flex-shrink-0" />
+
+      {/* 分组名称：显示态 vs 编辑态 */}
+      {isEditing ? (
+        <div className="flex items-center gap-1 flex-1 min-w-0">
+          <Input
+            ref={editInputRef}
+            value={editingName}
+            onChange={(e) => onEditingNameChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={onSaveEdit}
+            className="h-6 text-sm py-0 px-1"
+          />
+          <button
+            type="button"
+            onClick={onSaveEdit}
+            className="text-green-500 hover:text-green-600 flex-shrink-0"
+          >
+            <Check size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={onCancelEdit}
+            className="text-muted-foreground hover:text-foreground flex-shrink-0"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      ) : (
+        <span
+          className="text-sm font-medium truncate"
+          onDoubleClick={tagId !== null ? onStartEdit : undefined}
+          title={tag ? t("skills.tags.doubleClickToEdit") : undefined}
+        >
+          {tag ? tag.name : t("skills.tags.untagged")}
+        </span>
+      )}
+
+      <Badge
+        variant="secondary"
+        className="ml-auto text-[10px] px-1.5 py-0 h-4 flex-shrink-0"
+      >
+        {skillCount}
+      </Badge>
+    </div>
+  );
+};
+
+/** 可拖拽的技能行 */
+const DraggableSkillRow: React.FC<{
+  skill: InstalledSkill;
+  children: React.ReactNode;
+}> = ({ skill, children }) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useSortable({
+    id: `skill:${skill.id}`,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className="relative group"
+      style={{ opacity: isDragging ? 0.4 : 1 }}
+    >
+      {/* 拖拽手柄覆盖在技能行左侧 */}
+      <div
+        className="absolute left-0 top-0 bottom-0 w-6 flex items-center justify-center cursor-grab active:cursor-grabbing opacity-0 group-hover:opacity-100 transition-opacity z-10"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical size={12} className="text-muted-foreground/50" />
+      </div>
+      <div className="pl-5">{children}</div>
+    </div>
   );
 };
 

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -12,6 +12,7 @@ import {
   type InstalledSkill,
   type SkillUpdateInfo,
   type SkillsShSearchResult,
+  type SkillTag,
 } from "@/lib/api/skills";
 import type { AppId } from "@/lib/api/types";
 import { mergeImportedSkills } from "@/hooks/useSkills.helpers";
@@ -354,5 +355,117 @@ export type {
   SkillBackupEntry,
   SkillUpdateInfo,
   SkillsShSearchResult,
+  SkillTag,
   AppId,
 };
+
+// ========== 标签管理 Hooks ==========
+
+/**
+ * 查询所有技能标签
+ * 使用 staleTime: Infinity，仅在 mutation 后手动更新缓存
+ */
+export function useSkillTags() {
+  return useQuery({
+    queryKey: ["skills", "tags"],
+    queryFn: () => skillsApi.getTags(),
+    staleTime: Infinity,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/**
+ * 查询所有标签分配关系
+ * 返回 Record<skillId, tagId[]> 的映射
+ */
+export function useAllTagAssignments() {
+  return useQuery({
+    queryKey: ["skills", "tag-assignments"],
+    queryFn: () => skillsApi.getAllTagAssignments(),
+    staleTime: Infinity,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** 创建标签 */
+export function useCreateTag() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => skillsApi.createTag(name),
+    onSuccess: (newTag) => {
+      queryClient.setQueryData<SkillTag[]>(["skills", "tags"], (old) => {
+        if (!old) return [newTag];
+        return [...old, newTag];
+      });
+    },
+  });
+}
+
+/** 更新标签名称 */
+export function useUpdateTag() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, name }: { id: number; name: string }) =>
+      skillsApi.updateTag(id, name),
+    onSuccess: (_result, variables) => {
+      queryClient.setQueryData<SkillTag[]>(["skills", "tags"], (old) => {
+        if (!old) return old;
+        return old.map((tag) =>
+          tag.id === variables.id ? { ...tag, name: variables.name } : tag,
+        );
+      });
+    },
+  });
+}
+
+/** 删除标签 */
+export function useDeleteTag() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => skillsApi.deleteTag(id),
+    onSuccess: (_result, id) => {
+      queryClient.setQueryData<SkillTag[]>(["skills", "tags"], (old) => {
+        if (!old) return old;
+        return old.filter((tag) => tag.id !== id);
+      });
+      // 标签删除后，分配关系也变了，需要刷新
+      queryClient.invalidateQueries({
+        queryKey: ["skills", "tag-assignments"],
+      });
+    },
+  });
+}
+
+/** 批量更新标签排序 */
+export function useReorderTags() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (orderedIds: number[]) => skillsApi.reorderTags(orderedIds),
+    onSuccess: (_result, orderedIds) => {
+      queryClient.setQueryData<SkillTag[]>(["skills", "tags"], (old) => {
+        if (!old) return old;
+        const tagMap = new Map(old.map((t) => [t.id, t]));
+        return orderedIds
+          .map((id, index) => {
+            const tag = tagMap.get(id);
+            return tag ? { ...tag, sort_index: index } : null;
+          })
+          .filter(Boolean) as SkillTag[];
+      });
+    },
+  });
+}
+
+/** 设置技能的标签分配 */
+export function useSetSkillTags() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ skillId, tagIds }: { skillId: string; tagIds: number[] }) =>
+      skillsApi.setSkillTags(skillId, tagIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["skills", "tag-assignments"],
+      });
+    },
+  });
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2054,6 +2054,22 @@
       "successSingle": "Skill {{name}} installed",
       "successMultiple": "Successfully installed {{count}} skills",
       "noSkillsFound": "No skills found in ZIP file (requires SKILL.md file)"
+    },
+    "tags": {
+      "manage": "Manage Tags",
+      "create": "Create Tag",
+      "rename": "Rename Tag",
+      "delete": "Delete Tag",
+      "deleteConfirm": "Deleting tag \"{{name}}\" will remove it from all associated skills. Skills themselves will not be deleted.",
+      "untagged": "Default",
+      "assignTag": "Assign Tags",
+      "noTags": "No tags created yet",
+      "tagNamePlaceholder": "Tag name...",
+      "listView": "List View",
+      "groupedView": "Grouped View",
+      "doubleClickToEdit": "Double-click to rename",
+      "moveSuccess": "Skill moved to group",
+      "renameSuccess": "Tag renamed"
     }
   },
   "deeplink": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2069,7 +2069,15 @@
       "groupedView": "Grouped View",
       "doubleClickToEdit": "Double-click to rename",
       "moveSuccess": "Skill moved to group",
-      "renameSuccess": "Tag renamed"
+      "renameSuccess": "Tag renamed",
+      "createSuccess": "Tag created",
+      "createFailed": "Failed to create tag",
+      "renameFailed": "Failed to rename tag",
+      "deleteSuccess": "Tag deleted",
+      "deleteFailed": "Failed to delete tag",
+      "reorderSuccess": "Order updated",
+      "reorderFailed": "Failed to update order",
+      "count": "{{count}} tags"
     },
     "openDirectory": "Open in file manager"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2070,7 +2070,8 @@
       "doubleClickToEdit": "Double-click to rename",
       "moveSuccess": "Skill moved to group",
       "renameSuccess": "Tag renamed"
-    }
+    },
+    "openDirectory": "Open in file manager"
   },
   "deeplink": {
     "confirmImport": "Confirm Import Provider",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2070,7 +2070,8 @@
       "doubleClickToEdit": "ダブルクリックで名前変更",
       "moveSuccess": "スキルをグループに移動しました",
       "renameSuccess": "タグ名を変更しました"
-    }
+    },
+    "openDirectory": "ファイルマネージャーで開く"
   },
   "deeplink": {
     "confirmImport": "プロバイダーのインポートを確認",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2069,7 +2069,15 @@
       "groupedView": "グループ表示",
       "doubleClickToEdit": "ダブルクリックで名前変更",
       "moveSuccess": "スキルをグループに移動しました",
-      "renameSuccess": "タグ名を変更しました"
+      "renameSuccess": "タグ名を変更しました",
+      "createSuccess": "タグを作成しました",
+      "createFailed": "タグの作成に失敗しました",
+      "renameFailed": "タグ名の変更に失敗しました",
+      "deleteSuccess": "タグを削除しました",
+      "deleteFailed": "タグの削除に失敗しました",
+      "reorderSuccess": "並び順を更新しました",
+      "reorderFailed": "並び順の更新に失敗しました",
+      "count": "{{count}} 個のタグ"
     },
     "openDirectory": "ファイルマネージャーで開く"
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2054,6 +2054,22 @@
       "successSingle": "スキル {{name}} をインストールしました",
       "successMultiple": "{{count}} 件のスキルをインストールしました",
       "noSkillsFound": "ZIP ファイルにスキルが見つかりません（SKILL.md が必要です）"
+    },
+    "tags": {
+      "manage": "タグ管理",
+      "create": "タグ作成",
+      "rename": "タグ名変更",
+      "delete": "タグ削除",
+      "deleteConfirm": "タグ「{{name}}」を削除すると、関連するすべてのスキルからこのタグが解除されます。スキル自体は削除されません。",
+      "untagged": "デフォルト",
+      "assignTag": "タグ割り当て",
+      "noTags": "タグがまだ作成されていません",
+      "tagNamePlaceholder": "タグ名...",
+      "listView": "リスト表示",
+      "groupedView": "グループ表示",
+      "doubleClickToEdit": "ダブルクリックで名前変更",
+      "moveSuccess": "スキルをグループに移動しました",
+      "renameSuccess": "タグ名を変更しました"
     }
   },
   "deeplink": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2016,7 +2016,8 @@
       "doubleClickToEdit": "雙擊重新命名",
       "moveSuccess": "技能已移動到新分組",
       "renameSuccess": "標籤已重新命名"
-    }
+    },
+    "openDirectory": "在檔案管理員中開啟"
   },
   "deeplink": {
     "confirmImport": "確認匯入供應商設定",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2015,7 +2015,15 @@
       "groupedView": "分組視圖",
       "doubleClickToEdit": "雙擊重新命名",
       "moveSuccess": "技能已移動到新分組",
-      "renameSuccess": "標籤已重新命名"
+      "renameSuccess": "標籤已重新命名",
+      "createSuccess": "標籤建立成功",
+      "createFailed": "標籤建立失敗",
+      "renameFailed": "標籤重新命名失敗",
+      "deleteSuccess": "標籤刪除成功",
+      "deleteFailed": "標籤刪除失敗",
+      "reorderSuccess": "排序已更新",
+      "reorderFailed": "排序更新失敗",
+      "count": "{{count}} 個標籤"
     },
     "openDirectory": "在檔案管理員中開啟"
   },

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2000,6 +2000,22 @@
       "successSingle": "技能 {{name}} 已安裝",
       "successMultiple": "成功安裝 {{count}} 個技能",
       "noSkillsFound": "ZIP 檔案中未找到技能（需包含 SKILL.md 檔案）"
+    },
+    "tags": {
+      "manage": "管理標籤",
+      "create": "建立標籤",
+      "rename": "重新命名標籤",
+      "delete": "刪除標籤",
+      "deleteConfirm": "刪除標籤「{{name}}」將從所有關聯技能中移除該標籤，技能本身不會被刪除。",
+      "untagged": "預設",
+      "assignTag": "分配標籤",
+      "noTags": "還沒有建立標籤",
+      "tagNamePlaceholder": "標籤名稱...",
+      "listView": "列表視圖",
+      "groupedView": "分組視圖",
+      "doubleClickToEdit": "雙擊重新命名",
+      "moveSuccess": "技能已移動到新分組",
+      "renameSuccess": "標籤已重新命名"
     }
   },
   "deeplink": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2069,7 +2069,15 @@
       "groupedView": "分组视图",
       "doubleClickToEdit": "双击重命名",
       "moveSuccess": "技能已移动到新分组",
-      "renameSuccess": "标签已重命名"
+      "renameSuccess": "标签已重命名",
+      "createSuccess": "标签创建成功",
+      "createFailed": "标签创建失败",
+      "renameFailed": "标签重命名失败",
+      "deleteSuccess": "标签删除成功",
+      "deleteFailed": "标签删除失败",
+      "reorderSuccess": "排序已更新",
+      "reorderFailed": "排序更新失败",
+      "count": "{{count}} 个标签"
     },
     "openDirectory": "在文件管理器中打开"
   },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2054,6 +2054,22 @@
       "successSingle": "技能 {{name}} 已安装",
       "successMultiple": "成功安装 {{count}} 个技能",
       "noSkillsFound": "ZIP 文件中未找到技能（需包含 SKILL.md 文件）"
+    },
+    "tags": {
+      "manage": "管理标签",
+      "create": "创建标签",
+      "rename": "重命名标签",
+      "delete": "删除标签",
+      "deleteConfirm": "删除标签「{{name}}」将从所有关联技能中移除该标签，技能本身不会被删除。",
+      "untagged": "默认",
+      "assignTag": "分配标签",
+      "noTags": "还没有创建标签",
+      "tagNamePlaceholder": "标签名称...",
+      "listView": "列表视图",
+      "groupedView": "分组视图",
+      "doubleClickToEdit": "双击重命名",
+      "moveSuccess": "技能已移动到新分组",
+      "renameSuccess": "标签已重命名"
     }
   },
   "deeplink": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2070,7 +2070,8 @@
       "doubleClickToEdit": "双击重命名",
       "moveSuccess": "技能已移动到新分组",
       "renameSuccess": "标签已重命名"
-    }
+    },
+    "openDirectory": "在文件管理器中打开"
   },
   "deeplink": {
     "confirmImport": "确认导入供应商配置",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -49,6 +49,14 @@ export interface SkillBackupEntry {
   skill: InstalledSkill;
 }
 
+/** 技能标签 */
+export interface SkillTag {
+  id: number;
+  name: string;
+  sort_index: number;
+  created_at: number;
+}
+
 /** 可发现的 Skill（来自仓库） */
 export interface DiscoverableSkill {
   key: string;
@@ -279,5 +287,42 @@ export const skillsApi = {
     currentApp: AppId,
   ): Promise<InstalledSkill[]> {
     return await invoke("install_skills_from_zip", { filePath, currentApp });
+  },
+
+  // ========== 标签管理 ==========
+
+  /** 获取所有标签 */
+  async getTags(): Promise<SkillTag[]> {
+    return await invoke("get_skill_tags");
+  },
+
+  /** 创建标签 */
+  async createTag(name: string): Promise<SkillTag> {
+    return await invoke("create_skill_tag", { name });
+  },
+
+  /** 更新标签名称 */
+  async updateTag(id: number, name: string): Promise<boolean> {
+    return await invoke("update_skill_tag", { id, name });
+  },
+
+  /** 删除标签 */
+  async deleteTag(id: number): Promise<boolean> {
+    return await invoke("delete_skill_tag", { id });
+  },
+
+  /** 批量更新标签排序 */
+  async reorderTags(orderedIds: number[]): Promise<void> {
+    return await invoke("reorder_skill_tags", { orderedIds });
+  },
+
+  /** 设置技能的标签分配（替换现有分配） */
+  async setSkillTags(skillId: string, tagIds: number[]): Promise<void> {
+    return await invoke("set_skill_tags", { skillId, tagIds });
+  },
+
+  /** 获取所有标签分配关系 */
+  async getAllTagAssignments(): Promise<[string, number][]> {
+    return await invoke("get_all_skill_tag_assignments");
   },
 };

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -325,4 +325,9 @@ export const skillsApi = {
   async getAllTagAssignments(): Promise<[string, number][]> {
     return await invoke("get_all_skill_tag_assignments");
   },
+
+  /** 在系统文件管理器中打开技能目录 */
+  async openDirectory(directory: string): Promise<void> {
+    return await invoke("open_skill_directory", { directory });
+  },
 };

--- a/tests/components/TagAssignPopover.test.tsx
+++ b/tests/components/TagAssignPopover.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { TagAssignPopover } from "@/components/skills/TagAssignPopover";
+import type { SkillTag } from "@/hooks/useSkills";
+
+const setSkillTagsMock = vi.fn();
+const createTagMock = vi.fn();
+let skillTagsMock: SkillTag[] = [];
+let tagAssignmentsMock: [string, number][] = [];
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useSkills", () => ({
+  useSkillTags: () => ({
+    data: skillTagsMock,
+  }),
+  useAllTagAssignments: () => ({
+    data: tagAssignmentsMock,
+  }),
+  useSetSkillTags: () => ({
+    mutateAsync: setSkillTagsMock,
+  }),
+  useCreateTag: () => ({
+    mutateAsync: createTagMock,
+  }),
+}));
+
+describe("TagAssignPopover", () => {
+  beforeEach(() => {
+    skillTagsMock = [
+      { id: 1, name: "密码", sort_index: 0, created_at: 1 },
+      { id: 2, name: "写作", sort_index: 1, created_at: 1 },
+    ];
+    tagAssignmentsMock = [["skill-1", 1]];
+    setSkillTagsMock.mockReset();
+    createTagMock.mockReset();
+  });
+
+  it("renders the assigned tag as selected", () => {
+    render(<TagAssignPopover skillId="skill-1" />);
+
+    fireEvent.click(screen.getByTitle("skills.tags.assignTag"));
+
+    const selectedRow = screen.getByText("密码").closest("button");
+    expect(selectedRow).toHaveClass("bg-blue-500/10");
+  });
+
+  it("replaces the current tag when another tag is selected", async () => {
+    setSkillTagsMock.mockResolvedValue(undefined);
+    render(<TagAssignPopover skillId="skill-1" />);
+
+    fireEvent.click(screen.getByTitle("skills.tags.assignTag"));
+    fireEvent.click(screen.getByText("写作"));
+
+    await waitFor(() => {
+      expect(setSkillTagsMock).toHaveBeenCalledWith({
+        skillId: "skill-1",
+        tagIds: [2],
+      });
+    });
+  });
+
+  it("clears the assignment when the selected tag is clicked", async () => {
+    setSkillTagsMock.mockResolvedValue(undefined);
+    render(<TagAssignPopover skillId="skill-1" />);
+
+    fireEvent.click(screen.getByTitle("skills.tags.assignTag"));
+    fireEvent.click(screen.getByText("密码"));
+
+    await waitFor(() => {
+      expect(setSkillTagsMock).toHaveBeenCalledWith({
+        skillId: "skill-1",
+        tagIds: [],
+      });
+    });
+  });
+
+  it("creates a tag and assigns it to the skill", async () => {
+    createTagMock.mockResolvedValue({
+      id: 3,
+      name: "设计",
+      sort_index: 2,
+      created_at: 1,
+    });
+    setSkillTagsMock.mockResolvedValue(undefined);
+    render(<TagAssignPopover skillId="skill-1" />);
+
+    fireEvent.click(screen.getByTitle("skills.tags.assignTag"));
+    fireEvent.change(
+      screen.getByPlaceholderText("skills.tags.tagNamePlaceholder"),
+      {
+        target: { value: "设计" },
+      },
+    );
+    fireEvent.keyDown(
+      screen.getByPlaceholderText("skills.tags.tagNamePlaceholder"),
+      {
+        key: "Enter",
+      },
+    );
+
+    await waitFor(() => {
+      expect(createTagMock).toHaveBeenCalledWith("设计");
+      expect(setSkillTagsMock).toHaveBeenCalledWith({
+        skillId: "skill-1",
+        tagIds: [3],
+      });
+    });
+  });
+});

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import UnifiedSkillsPanel, {
+  getSkillDropTargetTagIds,
   type UnifiedSkillsPanelHandle,
 } from "@/components/skills/UnifiedSkillsPanel";
 import type { InstalledSkill, SkillTag } from "@/hooks/useSkills";
@@ -183,5 +184,19 @@ describe("UnifiedSkillsPanel", () => {
     expect(screen.getByText("空标签")).toBeInTheDocument();
     expect(screen.getByText("Grouped Skill")).toBeInTheDocument();
     expect(screen.getByText("Ungrouped Skill")).toBeInTheDocument();
+  });
+
+  it("resolves ungrouped drop targets to an empty tag assignment", () => {
+    const assignments: [string, number][] = [["grouped-skill", 1]];
+
+    expect(getSkillDropTargetTagIds("drop-untagged", assignments)).toEqual([]);
+    expect(getSkillDropTargetTagIds("drop-group:-1", assignments)).toEqual([]);
+    expect(
+      getSkillDropTargetTagIds("skill:ungrouped-skill", assignments),
+    ).toEqual([]);
+    expect(getSkillDropTargetTagIds("drop-group:2", assignments)).toEqual([2]);
+    expect(
+      getSkillDropTargetTagIds("skill:grouped-skill", assignments),
+    ).toEqual([1]);
   });
 });

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import UnifiedSkillsPanel, {
   type UnifiedSkillsPanelHandle,
 } from "@/components/skills/UnifiedSkillsPanel";
+import type { InstalledSkill, SkillTag } from "@/hooks/useSkills";
 
 const scanUnmanagedMock = vi.fn();
 const toggleSkillAppMock = vi.fn();
@@ -13,6 +14,26 @@ const importSkillsMock = vi.fn();
 const installFromZipMock = vi.fn();
 const deleteSkillBackupMock = vi.fn();
 const restoreSkillBackupMock = vi.fn();
+let installedSkillsMock: InstalledSkill[] = [];
+let skillTagsMock: SkillTag[] = [];
+let tagAssignmentsMock: [string, number][] = [];
+
+const createSkill = (overrides: Partial<InstalledSkill>): InstalledSkill => ({
+  id: "skill-1",
+  name: "Skill One",
+  directory: "skill-one",
+  apps: {
+    claude: false,
+    codex: false,
+    gemini: false,
+    opencode: false,
+    openclaw: false,
+    hermes: false,
+  },
+  installedAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
 
 vi.mock("sonner", () => ({
   toast: {
@@ -24,7 +45,7 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/hooks/useSkills", () => ({
   useInstalledSkills: () => ({
-    data: [],
+    data: installedSkillsMock,
     isLoading: false,
   }),
   useSkillBackups: () => ({
@@ -73,10 +94,31 @@ vi.mock("@/hooks/useSkills", () => ({
     mutateAsync: vi.fn(),
     isPending: false,
   }),
+  useSkillTags: () => ({
+    data: skillTagsMock,
+  }),
+  useAllTagAssignments: () => ({
+    data: tagAssignmentsMock,
+  }),
+  useSetSkillTags: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useUpdateTag: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useCreateTag: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useReorderTags: () => ({
+    mutateAsync: vi.fn(),
+  }),
 }));
 
 describe("UnifiedSkillsPanel", () => {
   beforeEach(() => {
+    installedSkillsMock = [];
+    skillTagsMock = [];
+    tagAssignmentsMock = [];
     scanUnmanagedMock.mockResolvedValue({
       data: [
         {
@@ -116,5 +158,30 @@ describe("UnifiedSkillsPanel", () => {
       expect(screen.getByText("Shared Skill")).toBeInTheDocument();
       expect(screen.getByText("/tmp/shared-skill")).toBeInTheDocument();
     });
+  });
+
+  it("keeps empty tags visible in grouped view", async () => {
+    installedSkillsMock = [
+      createSkill({ id: "skill-1", name: "Grouped Skill" }),
+      createSkill({ id: "skill-2", name: "Ungrouped Skill" }),
+    ];
+    skillTagsMock = [
+      { id: 1, name: "密码", sort_index: 0, created_at: 1 },
+      { id: 2, name: "空标签", sort_index: 1, created_at: 1 },
+    ];
+    tagAssignmentsMock = [["skill-1", 1]];
+
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    await act(async () => {
+      screen.getByTitle("skills.tags.groupedView").click();
+    });
+
+    expect(screen.getByText("密码")).toBeInTheDocument();
+    expect(screen.getByText("空标签")).toBeInTheDocument();
+    expect(screen.getByText("Grouped Skill")).toBeInTheDocument();
+    expect(screen.getByText("Ungrouped Skill")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add skill tag grouping, assignment, management, and grouped-view interactions
- add open-in-file-manager support for skill directories
- polish the tag manager dialog and tag assignment popover UX
- fix grouped-view drag/drop targets, empty tag visibility, single-group assignment, tag assignment atomicity, and skill directory path validation
- add i18n strings, changelog entries, and focused component/Rust tests

## Verification
- pnpm exec tsc --noEmit
- pnpm exec vitest run tests/components/TagAssignPopover.test.tsx tests/components/UnifiedSkillsPanel.test.tsx --reporter=basic
- cargo test -p cc-switch resolve_skill_directory --lib -- --nocapture
- cargo check -p cc-switch
- pnpm build:renderer