### PR TITLE
fix: normalize path separators in scan_dir_recursive for Windows

### DIFF
--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -1964,7 +1964,7 @@ impl SkillService {
                     .strip_prefix(base_dir)
                     .unwrap_or(current_dir)
                     .to_string_lossy()
-                    .to_string()
+                    .replace('\\', "/")
             };
 
             let doc_path = skill_md


### PR DESCRIPTION
## Summary

- On Windows, `Path::strip_prefix` produces backslash-separated relative paths (e.g. `skills\my-skill`)
- The update-check matching logic in `check_updates` uses `rsplit('/')` to extract the install name, so subdirectory skills (e.g. `skills/<name>/SKILL.md`) never matched and updates were silently skipped
- Fix: call `.replace('\\', "/")` instead of `.to_string()` when building the `directory` string in `scan_dir_recursive`

## Testing

Ran `cargo test`: 1368 passed, 1 pre-existing failure (`session_manager::providers::openclaw::tests::delete_session_updates_index_and_removes_jsonl`) that reproduces on the unmodified `main` branch and is unrelated to this change.