### PR TITLE
feat(routing): per-app local-routing auto-toggle on provider switch

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -241,6 +241,12 @@ pub struct AppSettings {
     /// 是否在主页面启用本地代理功能（默认关闭）
     #[serde(default)]
     pub enable_local_proxy: bool,
+    /// 切换到「需要路由」的 provider 且当前 app 未接管时，自动开启路由并切换（默认关闭，首次弹窗确认）
+    #[serde(default)]
+    pub auto_enable_for_needs_routing: bool,
+    /// 路由开启时切换到官方 provider 时，自动关闭路由并切换（默认关闭，opt-in）
+    #[serde(default)]
+    pub auto_disable_for_no_routing: bool,
     /// User has confirmed the local proxy first-run notice
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy_confirmed: Option<bool>,
@@ -366,6 +372,8 @@ impl Default for AppSettings {
             launch_on_startup: false,
             silent_startup: false,
             enable_local_proxy: false,
+            auto_enable_for_needs_routing: false,
+            auto_disable_for_no_routing: false,
             proxy_confirmed: None,
             usage_confirmed: None,
             stream_check_confirmed: None,
@@ -916,5 +924,42 @@ mod tests {
         .expect("visible apps");
 
         assert!(!visible.is_visible(&AppType::ClaudeDesktop));
+    }
+
+    #[test]
+    fn routing_auto_toggle_defaults_are_false() {
+        let settings = AppSettings::default();
+        assert!(!settings.auto_enable_for_needs_routing);
+        assert!(!settings.auto_disable_for_no_routing);
+    }
+
+    #[test]
+    fn routing_auto_toggle_deserializes_to_false_when_keys_omitted() {
+        // A settings JSON that omits both new keys must still deserialize
+        // successfully and yield false (proves `#[serde(default)]`).
+        let settings: AppSettings = serde_json::from_value(serde_json::json!({
+            "showInTray": true,
+            "enableLocalProxy": true
+        }))
+        .expect("settings without routing auto-toggle keys should deserialize");
+
+        assert!(!settings.auto_enable_for_needs_routing);
+        assert!(!settings.auto_disable_for_no_routing);
+    }
+
+    #[test]
+    fn routing_auto_toggle_round_trips_camel_case() {
+        let settings: AppSettings = serde_json::from_value(serde_json::json!({
+            "autoEnableForNeedsRouting": true,
+            "autoDisableForNoRouting": true
+        }))
+        .expect("camelCase routing auto-toggle keys should deserialize");
+
+        assert!(settings.auto_enable_for_needs_routing);
+        assert!(settings.auto_disable_for_no_routing);
+
+        let json = serde_json::to_value(&settings).expect("serialize settings");
+        assert_eq!(json["autoEnableForNeedsRouting"], serde_json::json!(true));
+        assert_eq!(json["autoDisableForNoRouting"], serde_json::json!(true));
     }
 }

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { AlertTriangle, Info } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -18,6 +19,11 @@ interface ConfirmDialogProps {
   cancelText?: string;
   variant?: "destructive" | "info";
   zIndex?: "base" | "nested" | "alert" | "top";
+  checkbox?: {
+    label: string;
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+  };
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -30,6 +36,7 @@ export function ConfirmDialog({
   cancelText,
   variant = "destructive",
   zIndex = "alert",
+  checkbox,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
@@ -58,6 +65,15 @@ export function ConfirmDialog({
             {message}
           </DialogDescription>
         </DialogHeader>
+        {checkbox && (
+          <label className="flex cursor-pointer select-none items-center gap-2 px-6 pt-3 text-sm">
+            <Checkbox
+              checked={checkbox.checked}
+              onCheckedChange={(v) => checkbox.onChange(v === true)}
+            />
+            {checkbox.label}
+          </label>
+        )}
         <DialogFooter className="flex gap-2 border-t-0 bg-transparent pt-2 sm:justify-end">
           <Button variant="outline" onClick={onCancel}>
             {cancelText || t("common.cancel")}

--- a/src/components/providers/ProviderActions.tsx
+++ b/src/components/providers/ProviderActions.tsx
@@ -7,7 +7,6 @@ import {
   Minus,
   Play,
   Plus,
-  ShieldAlert,
   Terminal,
   TestTube2,
   Trash2,
@@ -37,7 +36,8 @@ interface ProviderActionsProps {
   isAutoFailoverEnabled?: boolean;
   isInFailoverQueue?: boolean;
   onToggleFailover?: (enabled: boolean) => void;
-  isOfficialBlockedByProxy?: boolean;
+  // 路由接管切换进行中：禁用主切换按钮，防止重复点击重复触发 takeover 切换。
+  isRoutingSwitchPending?: boolean;
   // Hermes v12+ providers: dict overlay — edit/delete must go through Web UI
   isReadOnly?: boolean;
   // OpenClaw: default model
@@ -64,7 +64,7 @@ export function ProviderActions({
   isAutoFailoverEnabled = false,
   isInFailoverQueue = false,
   onToggleFailover,
-  isOfficialBlockedByProxy = false,
+  isRoutingSwitchPending = false,
   isReadOnly = false,
   // OpenClaw: default model
   isDefaultModel = false,
@@ -174,16 +174,6 @@ export function ProviderActions({
       };
     }
 
-    if (isOfficialBlockedByProxy) {
-      return {
-        disabled: true,
-        variant: "secondary" as const,
-        className: "opacity-40 cursor-not-allowed",
-        icon: <ShieldAlert className="h-4 w-4" />,
-        text: t("provider.blockedByProxy", { defaultValue: "已拦截" }),
-      };
-    }
-
     if (isCurrent) {
       return {
         disabled: true,
@@ -251,7 +241,7 @@ export function ProviderActions({
         size="sm"
         variant={buttonState.variant}
         onClick={handleMainButtonClick}
-        disabled={buttonState.disabled}
+        disabled={buttonState.disabled || isRoutingSwitchPending}
         className={cn("w-[4.5rem] px-2.5", buttonState.className)}
       >
         {buttonState.icon}

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -18,12 +18,11 @@ import { PROVIDER_TYPES } from "@/config/constants";
 import { isHermesReadOnlyProvider } from "@/config/hermesProviderPresets";
 import { ProviderHealthBadge } from "@/components/providers/ProviderHealthBadge";
 import { FailoverPriorityBadge } from "@/components/providers/FailoverPriorityBadge";
+import { extractCodexBaseUrl } from "@/utils/providerConfigUtils";
 import {
-  extractCodexBaseUrl,
-  extractCodexExperimentalBearerToken,
-  extractCodexWireApi,
-  isCodexChatWireApi,
-} from "@/utils/providerConfigUtils";
+  getProxyRequirement,
+  isOfficialProvider,
+} from "@/utils/providerRouting";
 import { useProviderHealth } from "@/lib/query/failover";
 import { useUsageQuery } from "@/lib/query/queries";
 
@@ -54,6 +53,7 @@ interface ProviderCardProps {
   isTesting?: boolean;
   isProxyRunning: boolean;
   isProxyTakeover?: boolean; // 代理接管模式（Live配置已被接管，切换为热切换）
+  isRoutingSwitchPending?: boolean; // 路由接管切换进行中（禁用主按钮防重复点击）
   dragHandleProps?: DragHandleProps;
   isAutoFailoverEnabled?: boolean; // 是否开启自动故障转移
   failoverPriority?: number; // 故障转移优先级（1 = P1, 2 = P2, ...）
@@ -63,41 +63,6 @@ interface ProviderCardProps {
   // OpenClaw: default model
   isDefaultModel?: boolean;
   onSetAsDefault?: () => void;
-}
-
-/** 判断是否为官方供应商（无自定义 base URL / API key，直连官方 API） */
-function isOfficialProvider(provider: Provider, appId: AppId): boolean {
-  if (provider.category === "official") {
-    return true;
-  }
-
-  const config = provider.settingsConfig as Record<string, any>;
-  if (appId === "claude") {
-    const baseUrl = config?.env?.ANTHROPIC_BASE_URL;
-    return !baseUrl || (typeof baseUrl === "string" && baseUrl.trim() === "");
-  }
-  if (appId === "codex") {
-    // 无 OPENAI_API_KEY → 使用 Codex CLI 内置 OAuth（官方）
-    const apiKey = config?.auth?.OPENAI_API_KEY;
-    const bearerToken =
-      typeof config?.config === "string"
-        ? extractCodexExperimentalBearerToken(config.config)
-        : undefined;
-    return (
-      !bearerToken &&
-      (!apiKey || (typeof apiKey === "string" && apiKey.trim() === ""))
-    );
-  }
-  if (appId === "gemini") {
-    // 无 GEMINI_API_KEY 且无 GOOGLE_GEMINI_BASE_URL → Google OAuth 官方模式
-    const apiKey = config?.env?.GEMINI_API_KEY;
-    const baseUrl = config?.env?.GOOGLE_GEMINI_BASE_URL;
-    return (
-      (!apiKey || (typeof apiKey === "string" && apiKey.trim() === "")) &&
-      (!baseUrl || (typeof baseUrl === "string" && baseUrl.trim() === ""))
-    );
-  }
-  return false;
 }
 
 const extractApiUrl = (provider: Provider, fallbackText: string) => {
@@ -153,6 +118,7 @@ export function ProviderCard({
   isTesting,
   isProxyRunning,
   isProxyTakeover = false,
+  isRoutingSwitchPending = false,
   dragHandleProps,
   isAutoFailoverEnabled = false,
   failoverPriority,
@@ -192,8 +158,7 @@ export function ProviderCard({
 
   const usageEnabled = provider.meta?.usage_script?.enabled ?? false;
   const isOfficial = isOfficialProvider(provider, appId);
-  const isOfficialBlockedByProxy =
-    isProxyTakeover && (provider.category === "official" || isOfficial);
+  // 注意：isOfficialBlockedByProxy 已去除（不再硬禁用「已拦截」按钮；守卫弹窗接管了这一职责）。
   const isCopilot =
     provider.meta?.providerType === PROVIDER_TYPES.GITHUB_COPILOT ||
     provider.meta?.usage_script?.templateType === "github_copilot";
@@ -203,20 +168,10 @@ export function ProviderCard({
     appId === "hermes" && isHermesReadOnlyProvider(provider.settingsConfig);
   const isCodexOauth =
     provider.meta?.providerType === PROVIDER_TYPES.CODEX_OAUTH;
-  const codexNeedsRouting = useMemo(() => {
-    if (appId !== "codex" || provider.category === "official") return false;
-    if (provider.meta?.apiFormat === "openai_chat") return true;
-    const config = (provider.settingsConfig as Record<string, any>)?.config;
-    return (
-      typeof config === "string" &&
-      isCodexChatWireApi(extractCodexWireApi(config))
-    );
-  }, [
-    appId,
-    provider.category,
-    provider.meta?.apiFormat,
-    (provider.settingsConfig as Record<string, any>)?.config,
-  ]);
+  // Whether this provider inherently requires the local proxy ("routing").
+  // Single source of truth shared with switchProvider's guard (getProxyRequirement),
+  // so the badge can never disagree with what the switch flow enforces.
+  const needsRouting = getProxyRequirement(provider, appId).required;
   const isClaudeThirdParty =
     appId === "claude" && provider.category === "third_party";
 
@@ -350,30 +305,9 @@ export function ProviderCard({
                 </span>
               )}
 
-              {appId === "claude-desktop" &&
-                provider.category !== "official" &&
-                provider.meta?.claudeDesktopMode === "proxy" && (
-                  <span className="inline-flex items-center rounded-md bg-sky-100 px-1.5 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
-                    {t("claudeDesktop.modeProxy", {
-                      defaultValue: "需要路由",
-                    })}
-                  </span>
-                )}
-
-              {appId === "claude" &&
-                provider.category !== "official" &&
-                provider.meta?.apiFormat &&
-                provider.meta.apiFormat !== "anthropic" && (
-                  <span className="inline-flex items-center rounded-md bg-sky-100 px-1.5 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
-                    {t("claudeCode.needsRouting", {
-                      defaultValue: "需要路由",
-                    })}
-                  </span>
-                )}
-
-              {codexNeedsRouting && (
+              {needsRouting && (
                 <span className="inline-flex items-center rounded-md bg-sky-100 px-1.5 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
-                  {t("codex.needsRouting", {
+                  {t("provider.needsRouting", {
                     defaultValue: "需要路由",
                   })}
                 </span>
@@ -524,7 +458,7 @@ export function ProviderCard({
               isInConfig={isInConfig}
               isTesting={isTesting}
               isProxyTakeover={isProxyTakeover}
-              isOfficialBlockedByProxy={isOfficialBlockedByProxy}
+              isRoutingSwitchPending={isRoutingSwitchPending}
               isReadOnly={isHermesReadOnly}
               isOmo={isAnyOmo}
               onSwitch={() => onSwitch(provider)}

--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -47,12 +47,21 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi } from "@/lib/api/settings";
+import { useSetProxyTakeoverForApp } from "@/lib/query/proxy";
+import {
+  getProxyRequirement,
+  isOfficialProvider,
+} from "@/utils/providerRouting";
+import { decideSwitchAction } from "@/utils/switchDecision";
 
 interface ProviderListProps {
   providers: Record<string, Provider>;
   currentProviderId: string;
   appId: AppId;
-  onSwitch: (provider: Provider) => void;
+  onSwitch: (
+    provider: Provider,
+    opts?: { fromRoutingGuard?: boolean },
+  ) => void | Promise<boolean>;
   onEdit: (provider: Provider) => void;
   onDelete: (provider: Provider) => void;
   onRemoveFromConfig?: (provider: Provider) => void;
@@ -195,6 +204,19 @@ export function ProviderList({
   const [showStreamCheckConfirm, setShowStreamCheckConfirm] = useState(false);
   const [pendingTestProvider, setPendingTestProvider] =
     useState<Provider | null>(null);
+
+  // 路由自动开关 guard 状态
+  const [showRoutingConfirm, setShowRoutingConfirm] = useState<
+    "enable" | "disable" | null
+  >(null);
+  const [pendingSwitchProvider, setPendingSwitchProvider] =
+    useState<Provider | null>(null);
+  const [rememberRouting, setRememberRouting] = useState(false);
+  // 覆盖整个 toggleTakeoverThenSwitch 流程（切换 + 接管开关）的「进行中」标记。
+  // 不能只依赖 setProxyTakeover.isPending——「先切后开」时切换在途、接管 mutation
+  // 还没开始的窗口里它仍是 false，按钮可点 + 守卫不拦 → 会重复触发。
+  const [routingSwitchInFlight, setRoutingSwitchInFlight] = useState(false);
+  const setProxyTakeover = useSetProxyTakeoverForApp();
   const { data: claudeDesktopStatus } = useQuery({
     queryKey: ["claudeDesktopStatus"],
     queryFn: () => providersApi.getClaudeDesktopStatus(),
@@ -235,6 +257,160 @@ export function ProviderList({
       checkProvider(pendingTestProvider.id, pendingTestProvider.name);
       setPendingTestProvider(null);
     }
+  };
+
+  // 写入「记住选择」到对应设置位（点确认即写，独立于后续 takeover 成败）。
+  const persistRoutingPreference = async (direction: "enable" | "disable") => {
+    if (!settings) return;
+    const { webdavSync: _webdavSync, ...rest } = settings;
+    await settingsApi.save({
+      ...rest,
+      ...(direction === "enable"
+        ? { autoEnableForNeedsRouting: true }
+        : { autoDisableForNoRouting: true }),
+    });
+    await queryClient.invalidateQueries({ queryKey: ["settings"] });
+  };
+
+  // 接管开关 + 切换。两个方向的顺序不同，都是为了「官方流量绝不在接管下」：
+  //
+  // - enable（切到需路由 provider）：**先切后开**。先 await onSwitch 把 live 切到
+  //   目标（非官方），**仅当切换成功**才开本 app 接管。这样开接管时「当前 provider」
+  //   已是非官方，后端不会发 proxy-official-warning，也不存在「官方被接管」窗口；
+  //   且切换失败时绝不开接管（否则可能让仍停留的官方 provider 走代理被封号）。
+  //   切换成功但开接管失败：provider 已切但未接管（不工作，非封号）→ 提示手动开路由。
+  // - disable（切到官方 provider）：**先关后切**。先关接管（后端恢复真实 Live
+  //   配置），再切到官方。任何时刻官方都不在接管下。开关失败 → 中止不切换。
+  //
+  // onSwitch(p, { fromRoutingGuard: true })：guard 已显式处理路由意图，让
+  // switchProvider 跳过基于闭包（可能滞后一帧）的「需路由提示」与「官方硬阻断」；
+  // 它返回是否切换成功（switchProvider 内部吞错误，靠返回值而非异常判定）。
+  const toggleTakeoverThenSwitch = async (
+    provider: Provider,
+    enabled: boolean,
+  ): Promise<void> => {
+    // 标记整个流程进行中（含切换在途窗口），防重复点击/重入；finally 必清。
+    setRoutingSwitchInFlight(true);
+    try {
+      if (enabled) {
+        // 先切；仅当切换成功（返回非 false）才开接管。失败则中止——switchProvider
+        // 的 mutation onError 已弹「切换失败」toast，且 live 仍停在原 provider。
+        const switched = await onSwitch(provider, { fromRoutingGuard: true });
+        if (switched === false) return;
+        try {
+          await setProxyTakeover.mutateAsync({ appType: appId, enabled: true });
+        } catch {
+          toast.error(
+            t("notifications.routingEnableFailed", {
+              defaultValue: "开启本地路由失败，请手动开启路由",
+            }),
+          );
+          return;
+        }
+        toast.success(
+          t("notifications.routingAutoEnabled", {
+            defaultValue: "当前应用本地路由已自动开启",
+          }),
+          { closeButton: true },
+        );
+        await queryClient.invalidateQueries({ queryKey: ["proxyStatus"] });
+        return;
+      }
+
+      // disable：先关接管（失败则中止不切换），再切到官方。
+      try {
+        await setProxyTakeover.mutateAsync({ appType: appId, enabled: false });
+      } catch {
+        toast.error(
+          t("notifications.routingDisableFailed", {
+            defaultValue: "关闭本地路由失败，已取消切换",
+          }),
+        );
+        return;
+      }
+      toast.success(
+        t("notifications.routingAutoDisabled", {
+          defaultValue: "当前应用本地路由已自动关闭",
+        }),
+        { closeButton: true },
+      );
+      await queryClient.invalidateQueries({ queryKey: ["proxyStatus"] });
+      onSwitch(provider, { fromRoutingGuard: true });
+    } finally {
+      setRoutingSwitchInFlight(false);
+    }
+  };
+
+  // 切换 guard：用 decideSwitchAction 分流为直接切 / 弹确认 / 静默切。
+  // claude-desktop 排除：其 proxy 模式需要代理服务运行（不是 per-app takeover，
+  // 后端仅支持 claude/codex/gemini）。ProviderCard 的「需要路由」徽章仍对 claude-
+  // desktop 显示（信息正确），switchProvider 的既有 proxyRequiredReason toast 会在
+  // 代理未运行时提醒用户——这两者不依赖 per-app takeover，故不受守卫排除影响。
+  const handleSwitchWithGuard = async (provider: Provider) => {
+    if (routingSwitchInFlight || setProxyTakeover.isPending) return;
+
+    if (appId === "claude-desktop") {
+      onSwitch(provider);
+      return;
+    }
+
+    const requirement = getProxyRequirement(provider, appId);
+    const action = decideSwitchAction({
+      needsRouting: requirement.required,
+      isProxyTakeover,
+      isOfficial: isOfficialProvider(provider, appId),
+      autoEnable: settings?.autoEnableForNeedsRouting ?? false,
+      autoDisable: settings?.autoDisableForNoRouting ?? false,
+    });
+
+    switch (action) {
+      case "confirmEnable":
+        setPendingSwitchProvider(provider);
+        setRememberRouting(false);
+        setShowRoutingConfirm("enable");
+        return;
+      case "confirmDisable":
+        setPendingSwitchProvider(provider);
+        setRememberRouting(false);
+        setShowRoutingConfirm("disable");
+        return;
+      case "directEnable":
+        await toggleTakeoverThenSwitch(provider, true);
+        return;
+      case "directDisable":
+        await toggleTakeoverThenSwitch(provider, false);
+        return;
+      case "direct":
+        onSwitch(provider);
+    }
+  };
+
+  const handleRoutingConfirm = async () => {
+    const direction = showRoutingConfirm;
+    const provider = pendingSwitchProvider;
+    setShowRoutingConfirm(null);
+    setPendingSwitchProvider(null);
+    if (!direction || !provider) {
+      setRememberRouting(false);
+      return;
+    }
+
+    if (rememberRouting) {
+      try {
+        await persistRoutingPreference(direction);
+      } catch (error) {
+        console.error("Failed to persist routing preference:", error);
+      }
+    }
+    setRememberRouting(false);
+
+    await toggleTakeoverThenSwitch(provider, direction === "enable");
+  };
+
+  const handleRoutingCancel = () => {
+    setShowRoutingConfirm(null);
+    setPendingSwitchProvider(null);
+    setRememberRouting(false);
   };
 
   // Import current live config as default provider
@@ -430,7 +606,7 @@ export function ProviderList({
                 isInConfig={isProviderInConfig(provider.id)}
                 isOmo={isOmo}
                 isOmoSlim={isOmoSlim}
-                onSwitch={onSwitch}
+                onSwitch={handleSwitchWithGuard}
                 onEdit={onEdit}
                 onDelete={onDelete}
                 onRemoveFromConfig={onRemoveFromConfig}
@@ -444,6 +620,9 @@ export function ProviderList({
                 isTesting={isChecking(provider.id)}
                 isProxyRunning={isProxyRunning}
                 isProxyTakeover={isProxyTakeover}
+                isRoutingSwitchPending={
+                  routingSwitchInFlight || setProxyTakeover.isPending
+                }
                 isAutoFailoverEnabled={isFailoverModeActive}
                 failoverPriority={getFailoverPriority(provider.id)}
                 isInFailoverQueue={isInFailoverQueue(provider.id)}
@@ -571,6 +750,54 @@ export function ProviderList({
           setPendingTestProvider(null);
         }}
       />
+
+      <ConfirmDialog
+        isOpen={showRoutingConfirm !== null}
+        variant={showRoutingConfirm === "disable" ? "destructive" : "info"}
+        title={
+          showRoutingConfirm === "disable"
+            ? t("confirm.routingDisable.title", {
+                defaultValue: "关闭本地路由并切换？",
+              })
+            : t("confirm.routingEnable.title", {
+                defaultValue: "开启本地路由并启用？",
+              })
+        }
+        message={
+          showRoutingConfirm === "disable"
+            ? t("confirm.routingDisable.message", {
+                defaultValue:
+                  "该供应商为官方直连，不能在本地路由接管下使用（可能导致账号被封禁）。\n将关闭当前应用的本地路由，然后切换到该供应商。",
+              })
+            : t("confirm.routingEnable.message", {
+                defaultValue:
+                  "该供应商需要本地路由才能正常工作。\n将开启当前应用的本地路由，然后启用该供应商。",
+              })
+        }
+        confirmText={
+          showRoutingConfirm === "disable"
+            ? t("confirm.routingDisable.confirm", {
+                defaultValue: "关闭路由并切换",
+              })
+            : t("confirm.routingEnable.confirm", {
+                defaultValue: "开启路由并启用",
+              })
+        }
+        checkbox={{
+          label:
+            showRoutingConfirm === "disable"
+              ? t("confirm.routing.rememberDisable", {
+                  defaultValue: "以后都自动关闭本地路由，不再询问",
+                })
+              : t("confirm.routing.rememberEnable", {
+                  defaultValue: "以后都自动开启本地路由，不再询问",
+                }),
+          checked: rememberRouting,
+          onChange: setRememberRouting,
+        }}
+        onConfirm={() => void handleRoutingConfirm()}
+        onCancel={handleRoutingCancel}
+      />
     </div>
   );
 }
@@ -596,6 +823,7 @@ interface SortableProviderCardProps {
   isTesting: boolean;
   isProxyRunning: boolean;
   isProxyTakeover: boolean;
+  isRoutingSwitchPending: boolean;
   isAutoFailoverEnabled: boolean;
   failoverPriority?: number;
   isInFailoverQueue: boolean;
@@ -627,6 +855,7 @@ function SortableProviderCard({
   isTesting,
   isProxyRunning,
   isProxyTakeover,
+  isRoutingSwitchPending,
   isAutoFailoverEnabled,
   failoverPriority,
   isInFailoverQueue,
@@ -674,6 +903,7 @@ function SortableProviderCard({
         isTesting={isTesting}
         isProxyRunning={isProxyRunning}
         isProxyTakeover={isProxyTakeover}
+        isRoutingSwitchPending={isRoutingSwitchPending}
         dragHandleProps={{
           attributes,
           listeners,

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -9,6 +9,8 @@ import {
   Loader2,
   Zap,
   Power,
+  Route,
+  ShieldAlert,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -33,6 +35,10 @@ import { AnimatePresence, motion } from "framer-motion";
 interface ProxyPanelProps {
   enableLocalProxy: boolean;
   onEnableLocalProxyChange: (checked: boolean) => void;
+  autoEnableForNeedsRouting: boolean;
+  onAutoEnableForNeedsRoutingChange: (checked: boolean) => void;
+  autoDisableForNoRouting: boolean;
+  onAutoDisableForNoRoutingChange: (checked: boolean) => void;
   onToggleProxy: (checked: boolean) => Promise<void>;
   isProxyPending: boolean;
 }
@@ -40,6 +46,10 @@ interface ProxyPanelProps {
 export function ProxyPanel({
   enableLocalProxy,
   onEnableLocalProxyChange,
+  autoEnableForNeedsRouting,
+  onAutoEnableForNeedsRoutingChange,
+  autoDisableForNoRouting,
+  onAutoDisableForNoRoutingChange,
   onToggleProxy,
   isProxyPending,
 }: ProxyPanelProps) {
@@ -221,6 +231,40 @@ export function ProxyPanel({
           description={t("settings.advanced.proxy.enableFeatureDescription")}
           checked={enableLocalProxy}
           onCheckedChange={onEnableLocalProxyChange}
+        />
+
+        {/* [1a] Auto-enable routing when switching to a routing-required provider */}
+        <ToggleRow
+          icon={<Route className="h-4 w-4 text-sky-500" />}
+          title={t("settings.advanced.proxy.autoEnableForNeedsRouting", {
+            defaultValue: "切换到需路由供应商时自动开启路由",
+          })}
+          description={t(
+            "settings.advanced.proxy.autoEnableForNeedsRoutingDescription",
+            {
+              defaultValue:
+                "启用「需要路由」的供应商时，自动开启本地路由并切换，不再每次弹窗确认。",
+            },
+          )}
+          checked={autoEnableForNeedsRouting}
+          onCheckedChange={onAutoEnableForNeedsRoutingChange}
+        />
+
+        {/* [1b] Auto-disable routing when switching to an official provider */}
+        <ToggleRow
+          icon={<ShieldAlert className="h-4 w-4 text-amber-500" />}
+          title={t("settings.advanced.proxy.autoDisableForNoRouting", {
+            defaultValue: "切换到官方供应商时自动关闭路由",
+          })}
+          description={t(
+            "settings.advanced.proxy.autoDisableForNoRoutingDescription",
+            {
+              defaultValue:
+                "开启后，路由模式下切换到官方供应商时自动关闭本地路由再切换，不再弹窗确认。",
+            },
+          )}
+          checked={autoDisableForNoRouting}
+          onCheckedChange={onAutoDisableForNoRoutingChange}
         />
 
         {/* [2] Proxy service toggle — always visible */}

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -125,6 +125,18 @@ export function ProxyTabContent({
               onEnableLocalProxyChange={(checked) =>
                 onAutoSave({ enableLocalProxy: checked })
               }
+              autoEnableForNeedsRouting={
+                settings?.autoEnableForNeedsRouting ?? false
+              }
+              onAutoEnableForNeedsRoutingChange={(checked) =>
+                onAutoSave({ autoEnableForNeedsRouting: checked })
+              }
+              autoDisableForNoRouting={
+                settings?.autoDisableForNoRouting ?? false
+              }
+              onAutoDisableForNoRoutingChange={(checked) =>
+                onAutoSave({ autoDisableForNoRouting: checked })
+              }
               onToggleProxy={handleToggleProxy}
               isProxyPending={isProxyPending}
             />

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -147,9 +147,18 @@ export function useProviderActions(
     [updateProviderMutation],
   );
 
-  // 切换供应商
+  // 切换供应商。返回是否切换成功（供路由 guard 据此决定是否开接管——切换失败时
+  // 绝不能开接管，否则可能让仍停留的官方 provider 走代理被封号）。
+  // opts.fromRoutingGuard: 调用方（ProviderList 的路由 guard）已经显式处理过
+  // 路由意图（弹窗确认 + 已 await per-app set_takeover_for_app），因此跳过此处
+  // 基于闭包内 isProxyTakeover/isProxyRunning 的「需路由提示」与「官方硬阻断」——
+  // 这两者读的是可能滞后一帧的闭包值，guard 路径用它们会误触发。其它调用方不传
+  // 该参数，硬阻断兜底保持不变（返回值被忽略）。
   const switchProvider = useCallback(
-    async (provider: Provider) => {
+    async (
+      provider: Provider,
+      opts?: { fromRoutingGuard?: boolean },
+    ): Promise<boolean> => {
       const isCopilotProvider =
         activeApp === "claude" &&
         provider.meta?.providerType === "github_copilot";
@@ -166,7 +175,11 @@ export function useProviderActions(
 
       // Determine why this provider requires the proxy
       let proxyRequiredReason: string | null = null;
-      if (!isProxyRunning && provider.category !== "official") {
+      if (
+        !opts?.fromRoutingGuard &&
+        !isProxyRunning &&
+        provider.category !== "official"
+      ) {
         if (isCopilotProvider) {
           proxyRequiredReason = t("notifications.proxyReasonCopilot", {
             defaultValue: "使用 GitHub Copilot 作为 Claude 供应商",
@@ -216,8 +229,15 @@ export function useProviderActions(
         );
       }
 
-      // Block official providers when proxy takeover is active
-      if (isProxyTakeover && provider.category === "official") {
+      // Block official providers when proxy takeover is active.
+      // Skipped on the routing-guard path: it has already disabled takeover for
+      // this app and obtained explicit confirmation, so this backstop (reading a
+      // possibly-stale closure value) would otherwise false-trigger.
+      if (
+        !opts?.fromRoutingGuard &&
+        isProxyTakeover &&
+        provider.category === "official"
+      ) {
         toast.error(
           t("notifications.officialBlockedByProxy", {
             defaultValue:
@@ -225,7 +245,7 @@ export function useProviderActions(
           }),
           { duration: 6000 },
         );
-        return;
+        return false;
       }
 
       try {
@@ -267,8 +287,10 @@ export function useProviderActions(
             closeButton: true,
           });
         }
+        return true;
       } catch {
         // 错误提示由 mutation 处理
+        return false;
       }
     },
     [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -109,7 +109,6 @@
     "currentlyUsing": "Currently Using",
     "enable": "Enable",
     "inUse": "In Use",
-    "blockedByProxy": "Blocked",
     "editProvider": "Edit Provider",
     "editProviderHint": "Configuration will be applied to the current provider immediately after update.",
     "deleteProvider": "Delete Provider",
@@ -171,21 +170,19 @@
         "oauthHint": "Google official uses OAuth personal authentication, no need to fill in API Key. The browser will automatically open for login on first use.",
         "apiKeyPlaceholder": "Enter Gemini API Key"
       }
-    }
+    },
+    "needsRouting": "Needs Routing"
   },
   "claudeCode": {
-    "needsRouting": "Needs Routing",
     "noRoutingSupport": "No Routing Support"
   },
   "codex": {
-    "needsRouting": "Needs Routing",
     "noRoutingSupport": "No Routing Support"
   },
   "claudeDesktop": {
     "officialNotice": "Claude Desktop official providers use the built-in 1P sign-in. No API key or endpoint URL is required.",
     "mode": "Model handling",
     "modeDirect": "Direct",
-    "modeProxy": "Requires routing",
     "modelMappingToggle": "Needs model mapping",
     "modelMappingOffHint": "Direct mode works only when the provider accepts Claude Desktop's three role IDs (claude-sonnet-* / claude-opus-* / claude-haiku-*); for any other model name (including legacy IDs like claude-3-5-sonnet-…), enable this switch to use mapping.",
     "modelMappingOnHint": "Claude Desktop only accepts the three role IDs claude-sonnet-* / claude-opus-* / claude-haiku-*. When enabled, CC Switch maps these three roles to your provider's actual models and keeps local routing running while in use.",
@@ -262,7 +259,12 @@
     "backfillWarning": "Switched successfully, but failed to save changes back to the previous provider",
     "windowControlFailed": "Window control failed: {{error}}",
     "officialBlockedByProxy": "Cannot switch to official provider while local routing is active. Using routing with official APIs may cause account bans.",
-    "proxyOfficialWarning": "Current provider {{name}} is official. Consider switching to a third-party provider before using local routing."
+    "proxyOfficialWarning": "Current provider {{name}} is official. Consider switching to a third-party provider before using local routing.",
+    "routingEnableFailed": "Failed to enable local routing — please enable it manually",
+    "routingDisableFailed": "Failed to disable local routing; switch canceled",
+    "proxyReasonGeminiNative": "Uses the Gemini Native API format",
+    "routingAutoEnabled": "Local routing has been automatically enabled for this app",
+    "routingAutoDisabled": "Local routing has been automatically disabled for this app"
   },
   "confirm": {
     "deleteProvider": "Delete Provider",
@@ -298,6 +300,20 @@
       "title": "About Common Config",
       "message": "The \"Common Config Snippet\" lets you share plugins, environment variables, and other settings across different providers — so they won't be lost when you switch.\n\nHow to use:\n① Edit a provider → click \"Edit Common Config\" → \"Extract from Editor\"\n② When creating a new provider, check \"Write Common Config\" (enabled by default)\n\nIf you've newly installed plugins or hooks, re-extract the common config to keep them in sync.",
       "confirm": "Got it"
+    },
+    "routingEnable": {
+      "title": "Enable local routing and switch?",
+      "message": "This provider needs local routing to work.\nLocal routing will be enabled for the current app, then this provider will be activated.",
+      "confirm": "Enable routing & switch"
+    },
+    "routingDisable": {
+      "title": "Disable local routing and switch?",
+      "message": "This is an official direct-connection provider and cannot be used while local routing is active (it may get your account banned).\nLocal routing will be disabled for the current app, then this provider will be activated.",
+      "confirm": "Disable routing & switch"
+    },
+    "routing": {
+      "rememberEnable": "Always enable routing automatically from now on",
+      "rememberDisable": "Always disable routing automatically from now on"
     }
   },
   "settings": {
@@ -327,7 +343,11 @@
         "enableFailoverToggle": "Show Failover Toggle on Main Page",
         "enableFailoverToggleDescription": "When enabled, the failover toggle will appear independently at the top of the main page",
         "running": "Running",
-        "stopped": "Stopped"
+        "stopped": "Stopped",
+        "autoEnableForNeedsRouting": "Auto-enable routing for routing-required providers",
+        "autoEnableForNeedsRoutingDescription": "When enabling a provider that needs routing, automatically turn on local routing and switch — without confirming each time.",
+        "autoDisableForNoRouting": "Auto-disable routing when switching to official providers",
+        "autoDisableForNoRoutingDescription": "When enabled, switching to an official provider while routing is on will automatically disable local routing and switch — without a confirmation dialog."
       },
       "modelTest": {
         "title": "Model Test Config",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -109,7 +109,6 @@
     "currentlyUsing": "現在使用中",
     "enable": "有効化",
     "inUse": "使用中",
-    "blockedByProxy": "ブロック",
     "editProvider": "プロバイダーを編集",
     "editProviderHint": "保存すると現在のプロバイダーにすぐ反映されます。",
     "deleteProvider": "プロバイダーを削除",
@@ -171,21 +170,19 @@
         "oauthHint": "Google 公式は OAuth 個人認証を使用するため API Key は不要です。初回利用時にブラウザが開きます。",
         "apiKeyPlaceholder": "Gemini API Key を入力"
       }
-    }
+    },
+    "needsRouting": "ルーティングが必要"
   },
   "claudeCode": {
-    "needsRouting": "ルーティングが必要",
     "noRoutingSupport": "ルーティング非対応"
   },
   "codex": {
-    "needsRouting": "ルーティングが必要",
     "noRoutingSupport": "ルーティング非対応"
   },
   "claudeDesktop": {
     "officialNotice": "Claude Desktop の公式プロバイダーは内蔵の 1P サインインを使用します。API キーやエンドポイントの設定は不要です。",
     "mode": "モデル処理方式",
     "modeDirect": "直結",
-    "modeProxy": "ルーティング必要",
     "modelMappingToggle": "モデルマッピングが必要",
     "modelMappingOffHint": "プロバイダーが Claude Desktop の三つの役割 ID（claude-sonnet-* / claude-opus-* / claude-haiku-*）を受け付ける場合のみ直結できます。それ以外のモデル名（claude-3-5-sonnet-… などの旧式 ID を含む）はこのスイッチを有効にしてマッピングを使ってください。",
     "modelMappingOnHint": "Claude Desktop は claude-sonnet-* / claude-opus-* / claude-haiku-* の三つの役割 ID のみ受け付けます。有効にすると CC Switch がこの三役割をプロバイダーの実モデルにマッピングし、使用中はローカルルーティングを起動したままにします。",
@@ -262,7 +259,12 @@
     "backfillWarning": "切り替え成功しましたが、前のプロバイダーへの設定保存に失敗しました",
     "windowControlFailed": "ウィンドウ操作に失敗しました: {{error}}",
     "officialBlockedByProxy": "ローカルルーティングモード中は公式プロバイダーに切り替えできません。ルーティング経由で公式 API にアクセスするとアカウントが停止される可能性があります。",
-    "proxyOfficialWarning": "現在のプロバイダー {{name}} は公式です。ローカルルーティングを使用する前にサードパーティプロバイダーに切り替えてください。"
+    "proxyOfficialWarning": "現在のプロバイダー {{name}} は公式です。ローカルルーティングを使用する前にサードパーティプロバイダーに切り替えてください。",
+    "routingEnableFailed": "ローカルルーティングの有効化に失敗しました。手動で有効にしてください",
+    "routingDisableFailed": "ローカルルーティングの無効化に失敗しました。切り替えをキャンセルしました",
+    "proxyReasonGeminiNative": "Gemini Native インターフェース形式を使用",
+    "routingAutoEnabled": "現在のアプリのローカルルーティングが自動で有効になりました",
+    "routingAutoDisabled": "現在のアプリのローカルルーティングが自動で無効になりました"
   },
   "confirm": {
     "deleteProvider": "プロバイダーを削除",
@@ -298,6 +300,20 @@
       "title": "共通設定について",
       "message": "「共通設定スニペット」を使うと、プラグインや環境変数などの設定を異なるプロバイダー間で共有でき、切り替え時に失われることがありません。\n\n使い方：\n① プロバイダーを編集 →「共通設定を編集」→「編集内容から抽出」\n② 新規プロバイダー作成時に「共通設定を書き込む」をチェック（デフォルトでオン）\n\n新しいプラグインや Hook をインストールした場合は、共通設定を再抽出してください。",
       "confirm": "わかりました"
+    },
+    "routingEnable": {
+      "title": "ローカルルーティングを有効にして切り替えますか？",
+      "message": "このプロバイダーはローカルルーティングが必要です。\n現在のアプリのローカルルーティングを有効にしてから、このプロバイダーに切り替えます。",
+      "confirm": "ルーティングを有効にして切り替え"
+    },
+    "routingDisable": {
+      "title": "ローカルルーティングを無効にして切り替えますか？",
+      "message": "これは公式の直接接続プロバイダーで、ローカルルーティング中は使用できません（アカウントが停止される可能性があります）。\n現在のアプリのローカルルーティングを無効にしてから、このプロバイダーに切り替えます。",
+      "confirm": "ルーティングを無効にして切り替え"
+    },
+    "routing": {
+      "rememberEnable": "今後はルーティングを自動で有効にする",
+      "rememberDisable": "今後はルーティングを自動で無効にする"
     }
   },
   "settings": {
@@ -327,7 +343,11 @@
         "enableFailoverToggle": "メインページにフェイルオーバー切り替えを表示",
         "enableFailoverToggleDescription": "有効にすると、メインページ上部にフェイルオーバー切り替えが独立して表示されます",
         "running": "実行中",
-        "stopped": "停止中"
+        "stopped": "停止中",
+        "autoEnableForNeedsRouting": "ルーティングが必要なプロバイダーへの切り替え時に自動でルーティングを有効化",
+        "autoEnableForNeedsRoutingDescription": "「ルーティングが必要」なプロバイダーを有効にする際、ローカルルーティングを自動的にオンにして切り替え、毎回の確認を省略します。",
+        "autoDisableForNoRouting": "公式プロバイダーへの切り替え時に自動でルーティングを無効化",
+        "autoDisableForNoRoutingDescription": "有効にすると、ルーティングが有効な状態で公式プロバイダーへ切り替えるとき、確認ダイアログなしで自動的にローカルルーティングを無効化してから切り替えます。"
       },
       "modelTest": {
         "title": "モデルテスト設定",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -109,7 +109,6 @@
     "currentlyUsing": "目前使用",
     "enable": "啟用",
     "inUse": "使用中",
-    "blockedByProxy": "已攔截",
     "editProvider": "編輯供應商",
     "editProviderHint": "更新設定後將立即套用至目前供應商。",
     "deleteProvider": "刪除供應商",
@@ -171,21 +170,19 @@
         "oauthHint": "Google 官方使用 OAuth 個人驗證，無需填寫 API Key。首次使用時會自動開啟瀏覽器進行登入。",
         "apiKeyPlaceholder": "請輸入 Gemini API Key"
       }
-    }
+    },
+    "needsRouting": "需要路由"
   },
   "claudeCode": {
-    "needsRouting": "需要路由",
     "noRoutingSupport": "不支援路由"
   },
   "codex": {
-    "needsRouting": "需要路由",
     "noRoutingSupport": "不支援路由"
   },
   "claudeDesktop": {
     "officialNotice": "Claude Desktop 官方供應商使用應用程式內建的 1P 登入，無需設定 API Key 和 API 位址。",
     "mode": "模型處理方式",
     "modeDirect": "直連",
-    "modeProxy": "需要路由",
     "modelMappingToggle": "需要模型對應",
     "modelMappingOffHint": "僅當供應商直接接受 Claude Desktop 可識別的三檔角色 ID（claude-sonnet-* / claude-opus-* / claude-haiku-*）時才適用直連；其他模型名（含 claude-3-5-sonnet-… 等舊式 ID）請開啟此開關走對應。",
     "modelMappingOnHint": "Claude Desktop 只接受 claude-sonnet-* / claude-opus-* / claude-haiku-* 三檔角色 ID。開啟後 CC Switch 會把這三檔對應到供應商的實際模型，並在使用期間保持本地路由開啟。",
@@ -262,7 +259,12 @@
     "backfillWarning": "切換成功，但舊供應商設定回填失敗，您手動修改的設定可能未儲存",
     "windowControlFailed": "視窗控制失敗：{{error}}",
     "officialBlockedByProxy": "本地路由模式下不能切換至官方供應商，使用路由存取官方 API 可能導致帳號被封鎖",
-    "proxyOfficialWarning": "目前供應商 {{name}} 是官方供應商，建議切換至第三方供應商後再使用本地路由"
+    "proxyOfficialWarning": "目前供應商 {{name}} 是官方供應商，建議切換至第三方供應商後再使用本地路由",
+    "routingEnableFailed": "開啟本機路由失敗，請手動開啟路由",
+    "routingDisableFailed": "關閉本機路由失敗，已取消切換",
+    "proxyReasonGeminiNative": "使用 Gemini Native 介面格式",
+    "routingAutoEnabled": "目前應用程式的本機路由已自動開啟",
+    "routingAutoDisabled": "目前應用程式的本機路由已自動關閉"
   },
   "confirm": {
     "deleteProvider": "刪除供應商",
@@ -298,6 +300,20 @@
       "title": "關於通用設定",
       "message": "「通用設定片段」可以在不同供應商之間共用外掛程式、環境變數等設定，避免切換供應商時遺失這些設定。\n\n使用方法：\n① 編輯供應商時點擊「編輯通用設定」→「從編輯內容擷取」\n② 新增供應商時勾選「寫入通用設定」（預設已勾選）\n\n如果您新安裝了外掛程式或 Hook，請重新擷取一次通用設定。",
       "confirm": "我了解了"
+    },
+    "routingEnable": {
+      "title": "開啟本機路由並啟用？",
+      "message": "此供應商需要本機路由才能正常運作。\n將開啟目前應用程式的本機路由，然後啟用此供應商。",
+      "confirm": "開啟路由並啟用"
+    },
+    "routingDisable": {
+      "title": "關閉本機路由並切換？",
+      "message": "此供應商為官方直連，無法在本機路由接管下使用（可能導致帳號被封鎖）。\n將關閉目前應用程式的本機路由，然後切換到此供應商。",
+      "confirm": "關閉路由並切換"
+    },
+    "routing": {
+      "rememberEnable": "以後都自動開啟本機路由，不再詢問",
+      "rememberDisable": "以後都自動關閉本機路由，不再詢問"
     }
   },
   "settings": {
@@ -327,7 +343,11 @@
         "enableFailoverToggle": "在主頁面顯示故障轉移開關",
         "enableFailoverToggleDescription": "開啟後，主頁面頂部將獨立顯示故障轉移開關",
         "running": "執行中",
-        "stopped": "已停止"
+        "stopped": "已停止",
+        "autoEnableForNeedsRouting": "切換到需路由供應商時自動開啟路由",
+        "autoEnableForNeedsRoutingDescription": "啟用「需要路由」的供應商時，自動開啟本機路由並切換，不再每次彈窗確認。",
+        "autoDisableForNoRouting": "切換到官方供應商時自動關閉路由",
+        "autoDisableForNoRoutingDescription": "開啟後，路由模式下切換到官方供應商時自動關閉本機路由再切換，不再彈窗確認。"
       },
       "modelTest": {
         "title": "模型測試設定",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -109,7 +109,6 @@
     "currentlyUsing": "当前使用",
     "enable": "启用",
     "inUse": "使用中",
-    "blockedByProxy": "已拦截",
     "editProvider": "编辑供应商",
     "editProviderHint": "更新配置后将立即应用到当前供应商。",
     "deleteProvider": "删除供应商",
@@ -171,21 +170,19 @@
         "oauthHint": "Google 官方使用 OAuth 个人认证，无需填写 API Key。首次使用时会自动打开浏览器进行登录。",
         "apiKeyPlaceholder": "请输入 Gemini API Key"
       }
-    }
+    },
+    "needsRouting": "需要路由"
   },
   "claudeCode": {
-    "needsRouting": "需要路由",
     "noRoutingSupport": "不支持路由"
   },
   "codex": {
-    "needsRouting": "需要路由",
     "noRoutingSupport": "不支持路由"
   },
   "claudeDesktop": {
     "officialNotice": "Claude Desktop 官方供应商使用应用内置的 1P 登录，无需配置 API Key 和接口地址。",
     "mode": "模型处理方式",
     "modeDirect": "直连",
-    "modeProxy": "需要路由",
     "modelMappingToggle": "需要模型映射",
     "modelMappingOffHint": "仅当供应商直接接受 Claude Desktop 可识别的三档角色 ID（claude-sonnet-* / claude-opus-* / claude-haiku-*）时才适用直连；其他模型名（含 claude-3-5-sonnet-… 等旧式 ID）请打开此开关走映射。",
     "modelMappingOnHint": "Claude Desktop 只接受 claude-sonnet-* / claude-opus-* / claude-haiku-* 三档角色 ID。开启后 CC Switch 会把这三档映射到供应商的实际模型，并在使用期间保持本地路由开启。",
@@ -262,7 +259,12 @@
     "backfillWarning": "切换成功，但旧供应商配置回填失败，您手动修改的配置可能未保存",
     "windowControlFailed": "窗口控制失败：{{error}}",
     "officialBlockedByProxy": "本地路由模式下不能切换到官方供应商，使用路由访问官方 API 可能导致账号被封禁",
-    "proxyOfficialWarning": "当前供应商 {{name}} 是官方供应商，建议切换到第三方供应商后再使用本地路由"
+    "proxyOfficialWarning": "当前供应商 {{name}} 是官方供应商，建议切换到第三方供应商后再使用本地路由",
+    "routingEnableFailed": "开启本地路由失败，请手动开启路由",
+    "routingDisableFailed": "关闭本地路由失败，已取消切换",
+    "proxyReasonGeminiNative": "使用 Gemini Native 接口格式",
+    "routingAutoEnabled": "当前应用本地路由已自动开启",
+    "routingAutoDisabled": "当前应用本地路由已自动关闭"
   },
   "confirm": {
     "deleteProvider": "删除供应商",
@@ -298,6 +300,20 @@
       "title": "关于通用配置",
       "message": "「通用配置片段」可以在不同供应商之间共享插件、环境变量等配置，避免切换供应商时丢失这些设置。\n\n使用方法：\n① 编辑供应商时点击「编辑通用配置」→「从编辑内容提取」\n② 新建供应商时勾选「写入通用配置」（默认已勾选）\n\n如果您新安装了插件或 Hook，请重新提取一次通用配置。",
       "confirm": "我知道了"
+    },
+    "routingEnable": {
+      "title": "开启本地路由并启用？",
+      "message": "该供应商需要本地路由才能正常工作。\n将开启当前应用的本地路由，然后启用该供应商。",
+      "confirm": "开启路由并启用"
+    },
+    "routingDisable": {
+      "title": "关闭本地路由并切换？",
+      "message": "该供应商为官方直连，不能在本地路由接管下使用（可能导致账号被封禁）。\n将关闭当前应用的本地路由，然后切换到该供应商。",
+      "confirm": "关闭路由并切换"
+    },
+    "routing": {
+      "rememberEnable": "以后都自动开启本地路由，不再询问",
+      "rememberDisable": "以后都自动关闭本地路由，不再询问"
     }
   },
   "settings": {
@@ -327,7 +343,11 @@
         "enableFailoverToggle": "在主页面显示故障转移开关",
         "enableFailoverToggleDescription": "开启后，主页面顶部将独立显示故障转移开关",
         "running": "运行中",
-        "stopped": "已停止"
+        "stopped": "已停止",
+        "autoEnableForNeedsRouting": "切换到需路由供应商时自动开启路由",
+        "autoEnableForNeedsRoutingDescription": "启用「需要路由」的供应商时，自动开启本地路由并切换，不再每次弹窗确认。",
+        "autoDisableForNoRouting": "切换到官方供应商时自动关闭路由",
+        "autoDisableForNoRoutingDescription": "开启后，路由模式下切换到官方供应商时自动关闭本地路由再切换，不再弹窗确认。"
       },
       "modelTest": {
         "title": "模型测试配置",

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -16,6 +16,8 @@ export const settingsSchema = z.object({
   launchOnStartup: z.boolean().optional(),
   enableLocalProxy: z.boolean().optional(),
   preserveCodexOfficialAuthOnSwitch: z.boolean().optional(),
+  autoEnableForNeedsRouting: z.boolean().optional(),
+  autoDisableForNoRouting: z.boolean().optional(),
   language: z.enum(["en", "zh", "zh-TW", "ja"]).optional(),
 
   // 设备级目录覆盖

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,6 +325,10 @@ export interface Settings {
   silentStartup?: boolean;
   // 是否启用主页面本地代理功能（默认关闭）
   enableLocalProxy?: boolean;
+  // 切换到「需要路由」的 provider 且当前 app 未接管时，自动开启路由并切换（默认关闭，首次弹窗确认）
+  autoEnableForNeedsRouting?: boolean;
+  // 路由开启时切换到官方 provider 时，自动关闭路由并切换（默认关闭，opt-in）
+  autoDisableForNoRouting?: boolean;
   // User has confirmed the local proxy first-run notice
   proxyConfirmed?: boolean;
   // User has confirmed the usage query first-run notice

--- a/src/utils/__tests__/providerRouting.test.ts
+++ b/src/utils/__tests__/providerRouting.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import type { Provider } from "@/types";
+import type { AppId } from "@/lib/api";
+import {
+  getProxyRequirement,
+  PROXY_REASON_KEYS,
+} from "@/utils/providerRouting";
+
+// Minimal Provider factory — only the fields read by getProxyRequirement
+// matter; the rest are filled with harmless defaults.
+const makeProvider = (overrides: Partial<Provider> = {}): Provider =>
+  ({
+    id: "test-id",
+    name: "Test Provider",
+    settingsConfig: {},
+    ...overrides,
+  }) as Provider;
+
+describe("getProxyRequirement", () => {
+  it("exposes stable i18n keys (not translated strings)", () => {
+    // Documents the contract: `reason` is a stable i18n key, never a
+    // localized message. Callers (badge / dialog) translate it.
+    expect(PROXY_REASON_KEYS).toEqual({
+      copilot: "notifications.proxyReasonCopilot",
+      openAIChat: "notifications.proxyReasonOpenAIChat",
+      openAIResponses: "notifications.proxyReasonOpenAIResponses",
+      geminiNative: "notifications.proxyReasonGeminiNative",
+      claudeDesktop: "notifications.proxyReasonClaudeDesktop",
+      fullUrl: "notifications.proxyReasonFullUrl",
+    });
+  });
+
+  describe("Codex chat wire protocol", () => {
+    it("requires routing when TOML wire_api is chat", () => {
+      const provider = makeProvider({
+        settingsConfig: {
+          config: [
+            'model_provider = "deepseek"',
+            "[model_providers.deepseek]",
+            'wire_api = "chat"',
+          ].join("\n"),
+        },
+      });
+      const result = getProxyRequirement(provider, "codex" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonOpenAIChat",
+      });
+    });
+
+    it("requires routing when meta.apiFormat is openai_chat (codex)", () => {
+      const provider = makeProvider({
+        meta: { apiFormat: "openai_chat" },
+      });
+      const result = getProxyRequirement(provider, "codex" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonOpenAIChat",
+      });
+    });
+
+    it("does NOT require routing when codex TOML wire_api is responses", () => {
+      const provider = makeProvider({
+        settingsConfig: {
+          config: [
+            'model_provider = "openai"',
+            "[model_providers.openai]",
+            'wire_api = "responses"',
+          ].join("\n"),
+        },
+      });
+      const result = getProxyRequirement(provider, "codex" as AppId);
+      expect(result).toEqual({ required: false, reason: null });
+    });
+  });
+
+  describe("Claude non-anthropic interface formats", () => {
+    it("requires routing for openai_chat", () => {
+      const provider = makeProvider({
+        meta: { apiFormat: "openai_chat" },
+      });
+      const result = getProxyRequirement(provider, "claude" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonOpenAIChat",
+      });
+    });
+
+    it("requires routing for openai_responses", () => {
+      const provider = makeProvider({
+        meta: { apiFormat: "openai_responses" },
+      });
+      const result = getProxyRequirement(provider, "claude" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonOpenAIResponses",
+      });
+    });
+
+    it("requires routing for gemini_native (proxy transforms anthropic↔gemini)", () => {
+      const provider = makeProvider({
+        meta: { apiFormat: "gemini_native" },
+      });
+      const result = getProxyRequirement(provider, "claude" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonGeminiNative",
+      });
+    });
+
+    it("does NOT require routing for plain anthropic Claude", () => {
+      const provider = makeProvider({
+        meta: { apiFormat: "anthropic" },
+        settingsConfig: {
+          env: { ANTHROPIC_AUTH_TOKEN: "sk-test" },
+        },
+      });
+      const result = getProxyRequirement(provider, "claude" as AppId);
+      expect(result).toEqual({ required: false, reason: null });
+    });
+  });
+
+  describe("Copilot-as-Claude", () => {
+    it("requires routing when providerType is github_copilot (claude)", () => {
+      const provider = makeProvider({
+        meta: { providerType: "github_copilot" },
+      });
+      const result = getProxyRequirement(provider, "claude" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonCopilot",
+      });
+    });
+
+    it("requires routing for Copilot-as-Claude via usage_script templateType", () => {
+      const provider = makeProvider({
+        meta: { usage_script: { templateType: "github_copilot" } },
+      } as Partial<Provider>);
+      const result = getProxyRequirement(provider, "claude" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonCopilot",
+      });
+    });
+
+    it("does NOT require routing for github_copilot on non-claude app", () => {
+      const provider = makeProvider({
+        meta: { providerType: "github_copilot" },
+      });
+      const result = getProxyRequirement(provider, "codex" as AppId);
+      expect(result).toEqual({ required: false, reason: null });
+    });
+  });
+
+  describe("Full URL mode", () => {
+    it("requires routing for claude with isFullUrl", () => {
+      const provider = makeProvider({ meta: { isFullUrl: true } });
+      const result = getProxyRequirement(provider, "claude" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonFullUrl",
+      });
+    });
+
+    it("requires routing for codex with isFullUrl", () => {
+      const provider = makeProvider({ meta: { isFullUrl: true } });
+      const result = getProxyRequirement(provider, "codex" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonFullUrl",
+      });
+    });
+
+    it("does NOT require routing for gemini with isFullUrl", () => {
+      const provider = makeProvider({ meta: { isFullUrl: true } });
+      const result = getProxyRequirement(provider, "gemini" as AppId);
+      expect(result).toEqual({ required: false, reason: null });
+    });
+  });
+
+  describe("Claude Desktop proxy mode", () => {
+    it("requires routing when claudeDesktopMode is proxy", () => {
+      const provider = makeProvider({
+        meta: { claudeDesktopMode: "proxy" },
+      });
+      const result = getProxyRequirement(provider, "claude-desktop" as AppId);
+      expect(result).toEqual({
+        required: true,
+        reason: "notifications.proxyReasonClaudeDesktop",
+      });
+    });
+
+    it("does NOT require routing when claudeDesktopMode is not proxy", () => {
+      const provider = makeProvider({
+        meta: { claudeDesktopMode: "direct" },
+      });
+      const result = getProxyRequirement(provider, "claude-desktop" as AppId);
+      expect(result).toEqual({ required: false, reason: null });
+    });
+  });
+
+  describe("Official providers never need routing", () => {
+    const apps: AppId[] = [
+      "claude" as AppId,
+      "codex" as AppId,
+      "gemini" as AppId,
+    ];
+
+    for (const appId of apps) {
+      it(`returns required:false for official provider on ${appId}`, () => {
+        // Even with routing-triggering meta, official short-circuits.
+        const provider = makeProvider({
+          category: "official",
+          meta: { apiFormat: "openai_chat", isFullUrl: true },
+        });
+        const result = getProxyRequirement(provider, appId);
+        expect(result).toEqual({ required: false, reason: null });
+      });
+    }
+  });
+
+  describe("Empty / undefined config", () => {
+    it("returns required:false for provider with no meta and empty config", () => {
+      const provider = makeProvider({ settingsConfig: {} });
+      const result = getProxyRequirement(provider, "claude" as AppId);
+      expect(result).toEqual({ required: false, reason: null });
+    });
+
+    it("returns required:false for codex provider with empty config string", () => {
+      const provider = makeProvider({ settingsConfig: { config: "" } });
+      const result = getProxyRequirement(provider, "codex" as AppId);
+      expect(result).toEqual({ required: false, reason: null });
+    });
+
+    it("returns required:false for codex provider with undefined config", () => {
+      const provider = makeProvider({ settingsConfig: {} });
+      const result = getProxyRequirement(provider, "codex" as AppId);
+      expect(result).toEqual({ required: false, reason: null });
+    });
+  });
+});

--- a/src/utils/__tests__/switchDecision.test.ts
+++ b/src/utils/__tests__/switchDecision.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideSwitchAction,
+  type SwitchAction,
+  type SwitchDecisionInput,
+} from "../switchDecision";
+
+/**
+ * Typed expectation helper: keeps the expected literal constrained to the
+ * SwitchAction union without relying on a (non-existent) type argument on
+ * vitest's `toBe`.
+ */
+function expectAction(actual: SwitchAction, expected: SwitchAction): void {
+  expect(actual).toBe(expected);
+}
+
+/**
+ * Helper to build a fully-specified input with sensible defaults so each
+ * test only states the fields it cares about.
+ */
+function makeInput(
+  overrides: Partial<SwitchDecisionInput> = {},
+): SwitchDecisionInput {
+  return {
+    needsRouting: false,
+    isProxyTakeover: false,
+    isOfficial: false,
+    autoEnable: false,
+    autoDisable: false,
+    ...overrides,
+  };
+}
+
+describe("decideSwitchAction — §4 state machine", () => {
+  it("official + takeover + autoDisable=false → confirmDisable", () => {
+    expectAction(
+      decideSwitchAction(
+        makeInput({
+          isOfficial: true,
+          isProxyTakeover: true,
+          autoDisable: false,
+        }),
+      ),
+      "confirmDisable",
+    );
+  });
+
+  it("official + takeover + autoDisable=true → directDisable (remembered)", () => {
+    expectAction(
+      decideSwitchAction(
+        makeInput({
+          isOfficial: true,
+          isProxyTakeover: true,
+          autoDisable: true,
+        }),
+      ),
+      "directDisable",
+    );
+  });
+
+  it("needsRouting + !takeover + autoEnable=false → confirmEnable", () => {
+    expectAction(
+      decideSwitchAction(
+        makeInput({
+          needsRouting: true,
+          isProxyTakeover: false,
+          autoEnable: false,
+        }),
+      ),
+      "confirmEnable",
+    );
+  });
+
+  it("needsRouting + !takeover + autoEnable=true → directEnable (remembered)", () => {
+    expectAction(
+      decideSwitchAction(
+        makeInput({
+          needsRouting: true,
+          isProxyTakeover: false,
+          autoEnable: true,
+        }),
+      ),
+      "directEnable",
+    );
+  });
+
+  it("needsRouting + takeover (already routed) → direct", () => {
+    // Routing is already active, so no enable confirmation is needed.
+    expectAction(
+      decideSwitchAction(
+        makeInput({
+          needsRouting: true,
+          isProxyTakeover: true,
+          // autoEnable value must not matter here.
+          autoEnable: false,
+        }),
+      ),
+      "direct",
+    );
+  });
+
+  it("!needsRouting + !official → direct", () => {
+    expectAction(
+      decideSwitchAction(
+        makeInput({
+          needsRouting: false,
+          isOfficial: false,
+        }),
+      ),
+      "direct",
+    );
+  });
+
+  it("official + !takeover → direct (not blocked when proxy not taking over)", () => {
+    expectAction(
+      decideSwitchAction(
+        makeInput({
+          isOfficial: true,
+          isProxyTakeover: false,
+          // Even with autoDisable=false, no block because no takeover.
+          autoDisable: false,
+        }),
+      ),
+      "direct",
+    );
+  });
+
+  describe("branch precedence: official+takeover wins over needsRouting", () => {
+    it("official + takeover + needsRouting + autoDisable=false → confirmDisable", () => {
+      expectAction(
+        decideSwitchAction(
+          makeInput({
+            isOfficial: true,
+            isProxyTakeover: true,
+            needsRouting: true,
+            autoDisable: false,
+            autoEnable: true,
+          }),
+        ),
+        "confirmDisable",
+      );
+    });
+
+    it("official + takeover + needsRouting + autoDisable=true → directDisable (remembered)", () => {
+      expectAction(
+        decideSwitchAction(
+          makeInput({
+            isOfficial: true,
+            isProxyTakeover: true,
+            needsRouting: true,
+            autoDisable: true,
+            autoEnable: true,
+          }),
+        ),
+        "directDisable",
+      );
+    });
+
+    it("official + !takeover + needsRouting → direct (official never enables routing)", () => {
+      // Safety invariant: an official-class provider is never routed. A
+      // contradictory config that is both official (broad) and needsRouting
+      // must NOT reach confirmEnable.
+      expectAction(
+        decideSwitchAction(
+          makeInput({
+            isOfficial: true,
+            isProxyTakeover: false,
+            needsRouting: true,
+            autoEnable: true,
+          }),
+        ),
+        "direct",
+      );
+    });
+  });
+
+  describe("exhaustive truth table (all 32 combinations)", () => {
+    const bools = [false, true] as const;
+
+    function expected(input: SwitchDecisionInput): SwitchAction {
+      // Independent reference implementation: isOfficial dominates needsRouting.
+      if (input.isOfficial) {
+        if (input.isProxyTakeover) {
+          return input.autoDisable ? "directDisable" : "confirmDisable";
+        }
+        return "direct";
+      }
+      if (input.needsRouting && !input.isProxyTakeover) {
+        return input.autoEnable ? "directEnable" : "confirmEnable";
+      }
+      return "direct";
+    }
+
+    for (const needsRouting of bools) {
+      for (const isProxyTakeover of bools) {
+        for (const isOfficial of bools) {
+          for (const autoEnable of bools) {
+            for (const autoDisable of bools) {
+              const input: SwitchDecisionInput = {
+                needsRouting,
+                isProxyTakeover,
+                isOfficial,
+                autoEnable,
+                autoDisable,
+              };
+              it(`matches reference for ${JSON.stringify(input)}`, () => {
+                expect(decideSwitchAction(input)).toBe(expected(input));
+              });
+            }
+          }
+        }
+      }
+    }
+  });
+});

--- a/src/utils/providerRouting.ts
+++ b/src/utils/providerRouting.ts
@@ -1,0 +1,171 @@
+// Pure helpers for deciding whether a provider inherently requires the local
+// proxy (a.k.a. "routing") to function correctly.
+//
+// This logic is extracted from `useProviderActions.switchProvider`'s
+// `proxyRequiredReason` decision set, with two intentional differences:
+//  1. The `!isProxyRunning` precondition is REMOVED — this function only
+//     answers whether a provider *inherently* needs routing, independent of
+//     whether the proxy happens to be running right now. Callers combine the
+//     result with live takeover state to decide what to do.
+//  2. The `provider.category !== "official"` guard is kept — official
+//     providers never "need routing".
+//
+// `reason` is a STABLE i18n key string (e.g. "notifications.proxyReasonOpenAIChat")
+// rather than a translated message. This keeps the function pure (no `t()`
+// dependency) and lets each caller (badge / dialog) translate it.
+
+import type { Provider } from "@/types";
+import type { AppId } from "@/lib/api";
+import {
+  extractCodexExperimentalBearerToken,
+  extractCodexWireApi,
+  isCodexChatWireApi,
+} from "@/utils/providerConfigUtils";
+
+export interface ProxyRequirement {
+  required: boolean;
+  reason: string | null;
+}
+
+/**
+ * Whether a provider is "official" (direct connection to the vendor's own API,
+ * no custom base URL / API key). Official providers must never be routed through
+ * the local proxy — doing so risks account bans.
+ *
+ * This is the single source of truth shared by the card badge, the switch guard,
+ * and the action button's disable logic, so they can never disagree about which
+ * providers count as official (which would let one path bypass confirmDisable).
+ * Uses the broad detection (empty/absent base url counts as official).
+ */
+export function isOfficialProvider(provider: Provider, appId: AppId): boolean {
+  if (provider.category === "official") {
+    return true;
+  }
+
+  const config = provider.settingsConfig as Record<string, any>;
+  if (appId === "claude") {
+    const baseUrl = config?.env?.ANTHROPIC_BASE_URL;
+    return !baseUrl || (typeof baseUrl === "string" && baseUrl.trim() === "");
+  }
+  if (appId === "codex") {
+    // 无 OPENAI_API_KEY → 使用 Codex CLI 内置 OAuth（官方）
+    const apiKey = config?.auth?.OPENAI_API_KEY;
+    const bearerToken =
+      typeof config?.config === "string"
+        ? extractCodexExperimentalBearerToken(config.config)
+        : undefined;
+    return (
+      !bearerToken &&
+      (!apiKey || (typeof apiKey === "string" && apiKey.trim() === ""))
+    );
+  }
+  if (appId === "gemini") {
+    // 无 GEMINI_API_KEY 且无 GOOGLE_GEMINI_BASE_URL → Google OAuth 官方模式
+    const apiKey = config?.env?.GEMINI_API_KEY;
+    const baseUrl = config?.env?.GOOGLE_GEMINI_BASE_URL;
+    return (
+      (!apiKey || (typeof apiKey === "string" && apiKey.trim() === "")) &&
+      (!baseUrl || (typeof baseUrl === "string" && baseUrl.trim() === ""))
+    );
+  }
+  return false;
+}
+
+// Stable i18n keys used as the `reason` payload. Callers translate these.
+// NOTE: `reason` is forward-looking API surface — current consumers (the
+// ProviderCard badge, the ProviderList guard) read only `.required`; the
+// confirm dialogs use fixed messages, so `reason` is not yet shown in the UI.
+export const PROXY_REASON_KEYS = {
+  copilot: "notifications.proxyReasonCopilot",
+  openAIChat: "notifications.proxyReasonOpenAIChat",
+  openAIResponses: "notifications.proxyReasonOpenAIResponses",
+  geminiNative: "notifications.proxyReasonGeminiNative",
+  claudeDesktop: "notifications.proxyReasonClaudeDesktop",
+  fullUrl: "notifications.proxyReasonFullUrl",
+} as const;
+
+// Whether the Codex provider uses the Chat Completions wire protocol, either
+// via the explicit `meta.apiFormat` flag or the `wire_api` field inside the
+// TOML config string.
+const isCodexChatFormat = (provider: Provider): boolean => {
+  if (provider.meta?.apiFormat === "openai_chat") {
+    return true;
+  }
+  const config = (provider.settingsConfig as Record<string, any> | undefined)
+    ?.config;
+  return (
+    typeof config === "string" &&
+    isCodexChatWireApi(extractCodexWireApi(config))
+  );
+};
+
+/**
+ * Decide whether a provider inherently requires the local proxy ("routing").
+ *
+ * @returns `{ required, reason }` where `reason` is a stable i18n key when
+ *          `required` is true, or `null` when routing is not required.
+ */
+export const getProxyRequirement = (
+  provider: Provider,
+  appId: AppId,
+): ProxyRequirement => {
+  // Category-official providers never need routing. This is intentionally the
+  // NARROW check (only the literal "official" category) — it answers "does this
+  // provider's wire protocol need the proxy to transform it", which depends on
+  // apiFormat, not on whether credentials happen to be empty. The BROAD
+  // account-ban safety ("never route an official-looking provider") is enforced
+  // separately by the switch guard via `isOfficialProvider` + `decideSwitchAction`
+  // (where `isOfficial` dominates `needsRouting`), so the two never disagree in a
+  // way that could route official traffic.
+  if (provider.category === "official") {
+    return { required: false, reason: null };
+  }
+
+  const meta = provider.meta;
+
+  // Copilot-as-Claude. Mirror ProviderCard's broader detection (providerType OR
+  // usage_script template) so this stays a superset once the badge unifies onto
+  // this function — otherwise a templateType-only Copilot provider would lose
+  // the badge and escape the routing guard.
+  if (
+    appId === "claude" &&
+    (meta?.providerType === "github_copilot" ||
+      meta?.usage_script?.templateType === "github_copilot")
+  ) {
+    return { required: true, reason: PROXY_REASON_KEYS.copilot };
+  }
+
+  // Claude using any non-anthropic API format requires the local proxy to
+  // transform the wire protocol. The closed apiFormat enum is
+  // {anthropic, openai_chat, openai_responses, gemini_native}; every
+  // non-anthropic value maps to a backend transform (the Rust adapter's
+  // claude_api_format_needs_transform enumerates the same three), so we treat
+  // "non-anthropic" as the single source of truth instead of enumerating a
+  // subset — which previously dropped gemini_native from the badge + guard.
+  if (appId === "claude" && meta?.apiFormat && meta.apiFormat !== "anthropic") {
+    const reason =
+      meta.apiFormat === "openai_chat"
+        ? PROXY_REASON_KEYS.openAIChat
+        : meta.apiFormat === "openai_responses"
+          ? PROXY_REASON_KEYS.openAIResponses
+          : PROXY_REASON_KEYS.geminiNative;
+    return { required: true, reason };
+  }
+
+  // Codex using Chat Completions wire protocol (meta flag or TOML wire_api)
+  if (appId === "codex" && isCodexChatFormat(provider)) {
+    return { required: true, reason: PROXY_REASON_KEYS.openAIChat };
+  }
+
+  // Claude Desktop in local-proxy mode
+  if (appId === "claude-desktop" && meta?.claudeDesktopMode === "proxy") {
+    return { required: true, reason: PROXY_REASON_KEYS.claudeDesktop };
+  }
+
+  // Full URL connection mode (claude / codex)
+  if (meta?.isFullUrl && (appId === "claude" || appId === "codex")) {
+    return { required: true, reason: PROXY_REASON_KEYS.fullUrl };
+  }
+
+  return { required: false, reason: null };
+};

--- a/src/utils/switchDecision.ts
+++ b/src/utils/switchDecision.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure decision logic for the routing auto-toggle feature.
+ *
+ * `decideSwitchAction` maps the current state (provider requirement, per-app
+ * proxy takeover, the two opt-in settings) to one of the `SwitchAction`s below.
+ * It is intentionally side-effect free so it can be unit tested exhaustively
+ * against the full truth table (see `switchDecision.test.ts`) and reused from
+ * UI code.
+ */
+
+/**
+ * The action the caller should take when the user attempts to switch
+ * to a provider.
+ *
+ * - "direct":         perform the switch immediately, no routing change.
+ * - "directEnable":   silently enable routing then switch (user already "remembered").
+ * - "directDisable":  silently disable routing then switch (user already "remembered").
+ * - "confirmEnable":  ask the user to confirm enabling routing first.
+ * - "confirmDisable": ask the user to confirm disabling proxy takeover first.
+ */
+export type SwitchAction =
+  | "direct"
+  | "directEnable"
+  | "directDisable"
+  | "confirmEnable"
+  | "confirmDisable";
+
+/**
+ * Inputs to the switch decision state machine.
+ *
+ * - needsRouting:    the target provider requires routing to be enabled.
+ * - isProxyTakeover: a proxy is currently taking over (routing is active).
+ * - isOfficial:      the target provider is the official provider.
+ * - autoEnable:      auto-enable routing without confirmation is allowed.
+ * - autoDisable:     auto-disable proxy takeover without a hard block is allowed.
+ */
+export interface SwitchDecisionInput {
+  needsRouting: boolean;
+  isProxyTakeover: boolean;
+  isOfficial: boolean;
+  autoEnable: boolean;
+  autoDisable: boolean;
+}
+
+/**
+ * Decide which action to take for a provider switch.
+ *
+ * `isOfficial` always dominates `needsRouting`: an official-class provider is
+ * never routed through the proxy (account-ban safety). Under takeover it goes
+ * to the disable path; otherwise it just switches directly — it never reaches
+ * the enable path, even if a contradictory config also looks "needs routing".
+ *
+ * The two confirm paths are symmetric: first encounter = confirm dialog (with a
+ * "remember" checkbox that sets the corresponding auto-* setting); after
+ * remember = silent direct switch.
+ */
+export function decideSwitchAction(input: SwitchDecisionInput): SwitchAction {
+  const { needsRouting, isProxyTakeover, isOfficial, autoEnable, autoDisable } =
+    input;
+
+  if (isOfficial) {
+    // Official under takeover → disable routing before switching; otherwise
+    // just switch. Either way, never enable routing for an official provider.
+    if (isProxyTakeover) {
+      return autoDisable ? "directDisable" : "confirmDisable";
+    }
+    return "direct";
+  }
+
+  if (needsRouting && !isProxyTakeover) {
+    return autoEnable ? "directEnable" : "confirmEnable";
+  }
+
+  return "direct";
+}

--- a/tests/components/ConfirmDialog.test.tsx
+++ b/tests/components/ConfirmDialog.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+
+// Return i18n keys as-is for stable assertions
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("ConfirmDialog", () => {
+  it("does not render a checkbox when the checkbox prop is omitted", () => {
+    render(
+      <ConfirmDialog
+        isOpen
+        title="Delete provider"
+        message="Are you sure?"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("renders the checkbox with its label and toggles via onChange", () => {
+    const onChange = vi.fn();
+
+    render(
+      <ConfirmDialog
+        isOpen
+        title="Enable routing"
+        message="Routing is required."
+        checkbox={{
+          label: "Remember my choice",
+          checked: false,
+          onChange,
+        }}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeInTheDocument();
+    expect(screen.getByText("Remember my choice")).toBeInTheDocument();
+
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/tests/hooks/useProviderActions.test.tsx
+++ b/tests/hooks/useProviderActions.test.tsx
@@ -351,11 +351,23 @@ describe("useProviderActions", () => {
       wrapper,
     });
 
-    await expect(
-      result.current.switchProvider(provider),
-    ).resolves.toBeUndefined();
+    // switchProvider swallows the mutation error and resolves to `false`
+    // (success flag the routing guard relies on to NOT enable takeover).
+    await expect(result.current.switchProvider(provider)).resolves.toBe(false);
     expect(settingsApiGetMock).not.toHaveBeenCalled();
     expect(settingsApiApplyMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves true on a successful switch (success flag for the routing guard)", async () => {
+    switchProviderMutateAsync.mockResolvedValueOnce(undefined);
+    const { wrapper } = createWrapper();
+    const provider = createProvider();
+
+    const { result } = renderHook(() => useProviderActions("codex"), {
+      wrapper,
+    });
+
+    await expect(result.current.switchProvider(provider)).resolves.toBe(true);
   });
 
   it("should call delete mutation when calling deleteProvider", async () => {


### PR DESCRIPTION
## Summary / 概述

Switching providers and the local-proxy "routing" (per-app takeover) were not wired together: enabling a provider that **needs** routing (Codex chat, Claude non-anthropic format, Copilot, full-URL, Claude Desktop proxy) while routing was off only showed a soft warning and silently failed; switching to an **official** provider while routing was on was hard-blocked with a disabled "已拦截" button, forcing the user into Settings to turn routing off manually.

This PR adds a small **switch guard** that bridges the two. When you switch a provider, it decides — via two pure functions — whether to switch directly, silently toggle this app's routing, or pop a confirmation dialog with a "remember my choice" checkbox. Two opt-in settings (`autoEnableForNeedsRouting`, `autoDisableForNoRouting`) control silent-vs-confirm. The official-provider account-ban protection is preserved (routing is always disabled **before** switching to an official provider; the proxy never carries official traffic).

切换供应商与本地路由（per-app 接管）此前没有衔接：路由关闭时启用「需要路由」的供应商只弹软提示并静默失败；路由开启时切到官方供应商则被硬禁用为「已拦截」，必须手动去设置关路由。本 PR 加了一个**切换守卫**把两者打通——切换时由两个纯函数决策：直接切 / 静默开关本 app 路由 / 弹带「记住选择」勾选框的确认对话框。两个 opt-in 开关控制静默或确认。官方供应商的封号保护保留（切到官方前**必先关闭**路由，代理不会携带官方流量）。

## Related Issue / 关联 Issue

Fixes #3436

## Screenshots / 截图

### Before / 修改前

<!-- The two images below are already uploaded on issue #3436 — reuse the same
     github user-attachments URLs here, no re-upload needed. -->

**Needs-routing provider + routing OFF → soft `toast.warning`, config silently broken / 需路由供应商 + 路由关 → 软 `toast.warning`，配置被静默写坏**

<img width="1343" height="490" alt="before-soft-warning" src="https://github.com/user-attachments/assets/38746dce-4dcc-42a0-80b2-a0d6dc98e6a3" />

**Official provider + routing ON → disabled "已拦截" button, no in-place path / 官方供应商 + 路由开 → 「已拦截」禁用按钮，原地无路可走**

<img width="1295" height="249" alt="before-blocked-button" src="https://github.com/user-attachments/assets/f71a45bb-4b51-42ac-8610-9d5ea163e37a" />

### After / 修改后

| Enable-routing confirm (blue) / 开启路由确认 | Disable-routing confirm (red) / 关闭路由确认 |
|---|---|
|<img width="825" height="534" alt="s2Proxy" src="https://github.com/user-attachments/assets/c32ba6bd-43b9-4515-85f3-01e5b1292a72" /> | <img width="751" height="528" alt="s2Official" src="https://github.com/user-attachments/assets/d218bd1c-2513-46bb-b7c0-c53251fb475e" /> |

| Auto-toggle toast / 路由状态 toast |
|---|
| <img width="663" height="269" alt="toast" src="https://github.com/user-attachments/assets/ee1c53cd-5685-4548-b634-adb22aaab442" /> |

| Settings toggles / 设置开关 |
|---|
|<img width="1270" height="629" alt="config" src="https://github.com/user-attachments/assets/868b4008-44b4-4fb3-aee3-9cea7467e797" /> |

## Approach

- **Two pure functions, one guard.** All decision logic lives in side-effect-free, unit-tested helpers:
  - `getProxyRequirement(provider, appId) -> { required, reason }` — whether a provider *inherently* needs the local proxy. Extracted from `switchProvider`'s existing `proxyRequiredReason` set (dropping the `!isProxyRunning` precondition). The Claude branch is generalized to "any non-anthropic `apiFormat`" so it matches the backend transform set exactly (`claude_api_format_needs_transform` = `openai_chat | openai_responses | gemini_native`).
  - `decideSwitchAction(input) -> "direct" | "directEnable" | "directDisable" | "confirmEnable" | "confirmDisable"` — a pure 5-action state machine.
  - `ProviderList.handleSwitchWithGuard` is the only side-effecting site; it maps each action 1:1 to behavior (no re-derivation).
- **Single source of truth for "official".** `isOfficialProvider` is hoisted into `providerRouting.ts` and shared by the badge, the guard, and the decision — so they can never disagree (which would let a provider bypass the disable-routing confirmation).
- **Decision table** (`isOfficial`/`needsRouting` from the pure helpers; `autoEnable`/`autoDisable` from settings). **`isOfficial` dominates `needsRouting`** — an official-class provider is never routed (it never reaches the enable path), even if a contradictory config also looks "needs routing":

  | condition | autoflag off | autoflag on (remembered) |
  |---|---|---|
  | `isOfficial && isProxyTakeover` | `confirmDisable` (dialog) | `directDisable` (silent) |
  | `isOfficial && !isProxyTakeover` | `direct` (never routed) | `direct` |
  | `needsRouting && !isProxyTakeover` (non-official) | `confirmEnable` (dialog) | `directEnable` (silent) |
  | otherwise | `direct` | `direct` |

- **Safety ordering — official traffic is never under takeover.** The two directions are sequenced deliberately:
  - **enable** (switching to a needs-routing provider): `await onSwitch(...)` **first**, and turn takeover on **only if the switch actually succeeded**. `switchProvider` returns a success boolean (it swallows mutation errors, so the guard checks the return, not an exception); on a failed switch the guard aborts and never enables takeover — so a failed switch can't leave the *current* (possibly official) provider under takeover. On success, takeover starts over the already-switched, non-official target (the backend never sees an official "current", so it never even raises its official warning). The only residual case — takeover-enable fails *after* a successful switch — leaves the provider switched but unrouted (a "doesn't work yet" state, **not** an account-ban risk; the user is told to enable routing manually).
  - **disable** (switching to an official provider): turn takeover **off first** (the backend restores the real Live config), then `onSwitch` to the official provider.
  - `switchProvider` gains an `opts.fromRoutingGuard` flag so the guard skips its closure-based "proxy required" warning + official hard-block (which read a possibly-stale `isProxyTakeover`); the backstop stays fully intact for every other caller.
- **Per-app only.** Uses `set_proxy_takeover_for_app` exclusively. Never touches the global proxy on/off switch or the tray.

**中文**

- **两个纯函数，一个守卫。** 所有决策逻辑都在无副作用、有单测的纯函数里：
  - `getProxyRequirement(provider, appId) -> { required, reason }` — 某供应商是否*天生*需要本地代理。从 `switchProvider` 既有的 `proxyRequiredReason` 集合抽出（剥掉 `!isProxyRunning` 前置）。Claude 分支泛化为「任意非 anthropic 的 `apiFormat`」，与后端转换集合精确对齐（`claude_api_format_needs_transform` = `openai_chat | openai_responses | gemini_native`）。
  - `decideSwitchAction(input) -> "direct" | "directEnable" | "directDisable" | "confirmEnable" | "confirmDisable"` — 纯粹的 5 动作状态机。
  - `ProviderList.handleSwitchWithGuard` 是唯一有副作用的落点；每个动作 1:1 映射到行为（不重新推导）。
- **「官方」判定单一真值源。** `isOfficialProvider` 上提到 `providerRouting.ts`，徽章 / 守卫 / 决策共用——三者永不矛盾（否则可能让某供应商绕过关路由确认）。
- **决策表**（见上表；`isOfficial`/`needsRouting` 来自纯函数，`autoEnable`/`autoDisable` 来自设置）。
- **安全顺序——官方流量绝不在接管下。** 两个方向的顺序刻意不同：
  - **enable**（切到需路由 provider）：**先 `await onSwitch`** 切到目标，**仅当切换成功**才开接管。`switchProvider` 返回是否成功（它吞掉 mutation 错误，所以守卫看返回值而非异常）；切换失败则中止、绝不开接管——失败的切换不会把**当前**（可能是官方）provider 留在接管下。成功时接管启动在切换后的非官方目标上（后端不会把官方当作 current，也不发官方报警）。唯一残留情形——切换成功后开接管失败——provider 已切但未接管（「暂时不工作」，**非封号风险**，并提示手动开启路由）。
  - **disable**（切到官方 provider）：**先关接管**（后端恢复真实 Live 配置），再 `onSwitch` 切到官方。
  - `switchProvider` 新增 `opts.fromRoutingGuard` 标记，守卫据此跳过其基于闭包（可能读到过期 `isProxyTakeover`）的「需路由提示」与「官方硬阻断」；对其它所有调用方该兜底完整保留。
- **仅 per-app。** 只用 `set_proxy_takeover_for_app`，绝不碰全局代理总开关或托盘。

## Scope

- **In:** per-app routing auto-toggle for the main-window provider switch (Claude / Codex / Gemini). Badge unified onto `getProxyRequirement` (Copilot / full-URL / `gemini_native` providers now show the "needs routing" badge). Two persisted settings + two settings toggles.
- **Out (intentional):**
  - **Tray switching** — backend bypass (`tray.rs`), native menu can't show a dialog.
  - **claude-desktop** — its proxy mode needs the proxy *service* running, not per-app takeover (backend takeover is claude/codex/gemini only). The guard short-circuits claude-desktop to the normal switch; its badge and the existing `switchProvider` proxy-required toast still apply.
  - **`switchProvider`'s own legacy `proxyRequiredReason` toast still omits `gemini_native`** — a pre-existing frontend/backend asymmetry. It's moot on every UI path because the guard wraps all card switches (and `fromRoutingGuard` skips that toast), so it's left for a separate small upstream fix rather than widening this PR's surface.
  - No new DB columns (settings via existing `AppSettings` serde). No `*_confirmed` third state — the two setting bools double as the "remembered" flags.

**中文**

- **范围内：** 主窗口供应商切换（Claude / Codex / Gemini）的 per-app 路由自动开关。徽章统一到 `getProxyRequirement`（Copilot / 完整URL / `gemini_native` 供应商现在也显示「需要路由」徽章）。两个持久化设置 + 两个设置开关。
- **有意排除：**
  - **托盘切换** — 后端旁路（`tray.rs`），原生菜单无法弹对话框。
  - **claude-desktop** — 其代理模式需要代理*服务*运行，而非 per-app 接管（后端接管仅支持 claude/codex/gemini）。守卫对 claude-desktop 短路为普通切换；其徽章与既有 `switchProvider` 需代理 toast 仍生效。
  - **`switchProvider` 自身遗留的 `proxyRequiredReason` toast 仍漏掉 `gemini_native`** — 一个既有的前后端不一致。在所有 UI 路径上都已 moot（守卫包住了全部卡片切换，且 `fromRoutingGuard` 会跳过该 toast），故留给单独的小型上游修复，不在本 PR 扩面。
  - 无新增 DB 列（设置走既有 `AppSettings` serde）。无 `*_confirmed` 第三态——两个设置 bool 同时充当「记住」标记。

## Tests

```
pnpm typecheck                                              -> pass (exit 0)
pnpm format:check                                           -> pass
pnpm test:unit                                              -> ~344 pass / App.test.tsx flakes only*
cargo fmt    --manifest-path src-tauri/Cargo.toml --check   -> clean
cargo clippy --manifest-path src-tauri/Cargo.toml --lib     -> clean for changed files**
cargo test   --manifest-path src-tauri/Cargo.toml --lib     -> pass (incl. 3 new settings tests)
```

New tests / 新增测试:
- `src/utils/__tests__/switchDecision.test.ts` — the 5-action state machine, incl. an **exhaustive 32-combination** truth table cross-checked against an independent reference impl. / 5 动作状态机，含一份**穷举 32 组合**真值表，与独立参考实现交叉校验。
- `src/utils/__tests__/providerRouting.test.ts` — `getProxyRequirement` across Codex chat (meta + TOML `wire_api`), Claude `openai_chat`/`openai_responses`/`gemini_native`, Copilot (providerType + usage_script), full-URL, claude-desktop proxy, official-per-app, empty config; reason-key contract. / 覆盖 Codex chat、Claude 三种非 anthropic 格式、Copilot、完整URL、claude-desktop 代理、各 app 官方、空配置；reason-key 契约。
- `tests/components/ConfirmDialog.test.tsx` — optional checkbox renders/controlled; omitted = unchanged. / 可选 checkbox 渲染/受控；不传时与原渲染一致。
- `src-tauri/src/settings.rs` — defaults are `false`, camelCase round-trip, missing-key deserialization. / 默认 `false`、camelCase 往返、缺字段反序列化。

\* The only failures are in `tests/integration/App.test.tsx` (`Test timed out in 5000ms`), a **pre-existing parallel-load flake** unrelated to this change — the count is non-deterministic (0–3 across runs); the file passes all its tests in isolation, and reproduces identically on a clean `main` checkout (verified via `git stash`). (Run the suite with `--exclude "**/.claude/**"` to avoid double-collecting unrelated worktree tests.)
<br>失败只出现在 `tests/integration/App.test.tsx`（`Test timed out in 5000ms`），是与本改动**无关的既有并行负载 flaky**——数量非确定（每次跑 0–3 个不等）；该文件单独跑全部通过，在干净 `main`（`git stash` 验证）上同样复现。（用 `--exclude "**/.claude/**"` 可避免重复收集无关 worktree 的测试。）

\*\* The 5 `cargo clippy` warnings are all pre-existing on `main` and untouched by this PR (e.g. `settings.rs:3` `unused import: std::io::Write` is already unused on `main`; our diff only adds two fields + three tests far from that line). No new warnings introduced.
<br>这 5 个 `cargo clippy` warning 全部是 `main` 上既有、本 PR 未触及（例如 `settings.rs:3` 的 `unused import: std::io::Write` 在 `main` 上就已 unused；我们的 diff 只在离它很远处加了两个字段 + 三个测试），未引入新 warning。

## Manual verification / 人工验证

Built a local Windows portable release and verified on Windows 11: / 在本地构建 Windows portable release，于 Windows 11 验证：

- **Forward (enable):** routing off → enable a needs-routing provider → blue confirm dialog ("以后都自动开启本地路由，不再询问") → confirm → routing enabled + green toast + switched. Check "remember" → subsequent needs-routing switches go silent. Setting toggle reflects the remembered choice; survives restart.
- **Reverse (disable):** routing on → official provider button is now clickable ("启用", no longer "已拦截") → red confirm dialog → confirm → routing disabled + green toast + switched; the misleading backend "official provider" warning no longer appears on this path. "remember" → subsequent official switches go silent.
- **Safety default:** with `autoDisableForNoRouting` off (default), switching to official under routing still requires explicit confirmation; routing is disabled before the switch.
- **Regressions:** non-routing apps (OpenCode/OpenClaw/Hermes "add to config", OMO enable), claude-desktop, plain third-party switches, and the delete-provider dialog all behave exactly as before.

**中文**

- **正向（开启）：** 路由关 → 启用需路由供应商 → 蓝色确认对话框（「以后都自动开启本地路由，不再询问」）→ 确认 → 路由开启 + 绿色 toast + 切换。勾「记住」→ 此后需路由切换静默进行。设置开关反映记住的选择；重启保持。
- **反向（关闭）：** 路由开 → 官方供应商按钮现在可点（「启用」，不再「已拦截」）→ 红色确认对话框 → 确认 → 路由关闭 + 绿色 toast + 切换；该路径不再出现误导的后端「官方供应商」警告。勾「记住」→ 此后官方切换静默进行。
- **默认安全：** `autoDisableForNoRouting` 关（默认）时，路由下切官方仍需显式确认；路由在切换前关闭。
- **回归：** 非路由应用（OpenCode/OpenClaw/Hermes「添加到配置」、OMO 启用）、claude-desktop、普通第三方切换、删除供应商对话框，行为均与改动前完全一致。

## Notes for review / 审阅说明

- **Account-ban safety (no official traffic under takeover):** ordered per direction — **enable** switches first (`await onSwitch`) then turns takeover on (target is non-official by then; the backend never raises its official warning); **disable** turns takeover off (backend restores the real Live config) then switches to official. The `switchProvider` backstop (`isProxyTakeover && official → return`) is retained for all non-guard callers and only skipped via `fromRoutingGuard`.
- **`isOfficial` dominates `needsRouting`:** `decideSwitchAction` treats an official-class provider (the broad `isOfficialProvider` — empty base-url / no key) as official **regardless** of `needsRouting`, so it is never routed (under takeover → disable; otherwise → just switch). The narrow `category` check in `getProxyRequirement` is intentionally separate (it answers "does the wire protocol need transforming"). The only case the dominance changes is a *contradictory* config that is both broad-official and needs-routing (no real account behind it) — it now switches directly instead of enabling routing. Verified that every real needs-routing provider (Copilot/openai_chat/responses/gemini_native/full-URL/Codex-chat) carries an endpoint or key, so none is broad-official and none loses routing.
- **Failure modes (commented in code):** `switchProvider` now returns a success boolean (it still swallows the mutation error internally, but reports success/failure to the guard). Enable path: **switch fails → guard aborts, takeover never enabled, live unchanged** (no ban risk; the mutation's `onError` toast already told the user). **Switch succeeds → takeover-enable fails →** provider switched but **unrouted** (doesn't work until routing is on; user told to enable manually) — **not** a ban state. So there is no path that enables takeover over an official current provider after a failed switch.
- **Double-click guard:** a `routingSwitchInFlight` flag wraps the **whole** switch+takeover flow (set at the start of `toggleTakeoverThenSwitch`, cleared in `finally`) — it gates both the guard's re-entry check and the main-button disable, covering the provider-switch window (not just the takeover mutation, which `setProxyTakeover.isPending` alone would miss).
- i18n: all **4** locales updated (`en/ja/zh/zh-TW`); the now-orphaned `provider.blockedByProxy` ("已拦截") key is removed along with the old hard-block button; no hardcoded user-facing strings.

**中文**

- **封号安全（官方流量绝不在接管下）：** 按方向分序——**enable** 先切（`await onSwitch`）后开接管（此时目标已是非官方，后端不会发官方报警）；**disable** 先关接管（后端恢复真实 Live 配置）后切到官方。`switchProvider` 兜底（`isProxyTakeover && official → return`）对所有非守卫调用方保留，仅经 `fromRoutingGuard` 跳过。
- **`isOfficial` 压过 `needsRouting`：** `decideSwitchAction` 把官方类 provider（broad `isOfficialProvider`——空 base_url / 无 key）**无视** `needsRouting` 一律按官方处理，绝不路由（takeover 下关、否则直切）。`getProxyRequirement` 里的窄 `category` 判定是有意分离的（它回答「线协议是否需要转换」）。压制唯一改变的情形是一个**自相矛盾**的「既 broad-official 又 needsRouting」配置（背后无真实账号）——它现在直接切而非开路由。已核实所有真实需路由 provider（Copilot/openai_chat/responses/gemini_native/完整URL/Codex-chat）都带 endpoint 或 key，故均非 broad-official、都不会丢路由。
- **失败模式（代码已注释）：** `switchProvider` 现在返回是否成功（内部仍吞 mutation 错误，但把成功/失败告诉守卫）。enable 路径：**切换失败 → 守卫中止、绝不开接管、live 不变**（无封号风险，mutation 的 onError 已弹「切换失败」）；**切换成功但开接管失败 →** provider 已切但**未接管**（路由开启前不工作，已提示手动开启）——**非封号态**。因此不存在「切换失败后官方 current 被接管」的路径。
- **防重复点击：** `routingSwitchInFlight` 标记**包住整个**切换+接管流程（`toggleTakeoverThenSwitch` 开头置位、`finally` 清除），同时驱动守卫的重入检查与主按钮禁用，覆盖「切换在途」窗口（不只是接管 mutation——只看 `setProxyTakeover.isPending` 会漏掉这段）。
- i18n：全 **4** 语言更新（`en/ja/zh/zh-TW`）；随旧硬阻断按钮一并删除已失效的 `provider.blockedByProxy`（「已拦截」）key；无硬编码用户可见字符串。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (changed files clean; pre-existing warnings untouched) / 通过 Clippy 检查
- [x] Updated i18n files if user-facing text changed / 已更新国际化文件（en/ja/zh/zh-TW）
