### PR TITLE
Fix/issue 3265

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -130,7 +130,7 @@ pub fn create_private_dir_all(path: &Path) -> Result<(), AppError> {
 
         fs::DirBuilder::new()
             .recursive(true)
-            .mode(0o700) // 420 000 000 仅当前用户可访问
+            .mode(0o700) // 421 000 000 仅当前用户可访问
             .create(path)
             .map_err(|e| AppError::io(path, e))?;
         fs::set_permissions(path, fs::Permissions::from_mode(0o700))
@@ -140,6 +140,24 @@ pub fn create_private_dir_all(path: &Path) -> Result<(), AppError> {
     #[cfg(not(unix))]
     {
         fs::create_dir_all(path).map_err(|e| AppError::io(path, e))?;
+    }
+
+    Ok(())
+}
+
+/// 将应用私有文件权限收紧为仅当前用户可读写。
+pub fn set_private_file_permissions(path: &Path) -> Result<(), AppError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .map_err(|e| AppError::io(path, e))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
     }
 
     Ok(())

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -278,19 +278,25 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
         .as_nanos();
     tmp.push(format!("{file_name}.tmp.{ts}"));
 
+    #[cfg(unix)]
     {
-        let mut f = fs::File::create(&tmp).map_err(|e| AppError::io(&tmp, e))?;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut f = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&tmp)
+            .map_err(|e| AppError::io(&tmp, e))?;
         f.write_all(data).map_err(|e| AppError::io(&tmp, e))?;
         f.flush().map_err(|e| AppError::io(&tmp, e))?;
     }
 
-    #[cfg(unix)]
+    #[cfg(not(unix))]
     {
-        use std::os::unix::fs::PermissionsExt;
-        if let Ok(meta) = fs::metadata(path) {
-            let perm = meta.permissions().mode();
-            let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(perm));
-        }
+        let mut f = fs::File::create(&tmp).map_err(|e| AppError::io(&tmp, e))?;
+        f.write_all(data).map_err(|e| AppError::io(&tmp, e))?;
+        f.flush().map_err(|e| AppError::io(&tmp, e))?;
     }
 
     #[cfg(windows)]
@@ -386,6 +392,45 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_creates_private_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("config.json");
+
+        atomic_write(&path, b"{}").expect("atomic write");
+
+        let mode = fs::metadata(&path)
+            .expect("file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_repairs_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("config.json");
+        fs::write(&path, "{}").expect("write existing file");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
+            .expect("widen file permissions");
+
+        atomic_write(&path, b"{\"ok\":true}").expect("atomic write");
+
+        let mode = fs::metadata(&path)
+            .expect("file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -122,6 +122,52 @@ pub fn get_app_config_dir() -> PathBuf {
     default_dir
 }
 
+/// 创建应用私有目录，Unix 下限制为仅当前用户可访问。
+pub fn create_private_dir_all(path: &Path) -> Result<(), AppError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700) // 420 000 000 仅当前用户可访问
+            .create(path)
+            .map_err(|e| AppError::io(path, e))?;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .map_err(|e| AppError::io(path, e))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::create_dir_all(path).map_err(|e| AppError::io(path, e))?;
+    }
+
+    Ok(())
+}
+
+/// 确保应用配置目录存在，并在 Unix 下收紧为 0o700。
+pub fn ensure_app_config_dir() -> Result<PathBuf, AppError> {
+    let dir = get_app_config_dir();
+    create_private_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn create_parent_dir_all(path: &Path) -> Result<(), AppError> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+
+    let app_config_dir = get_app_config_dir();
+    if parent.starts_with(&app_config_dir) {
+        create_private_dir_all(&app_config_dir)?;
+        create_private_dir_all(parent)?;
+    } else {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+
+    Ok(())
+}
+
 /// 获取应用配置文件路径
 pub fn get_app_config_path() -> PathBuf {
     get_app_config_dir().join("config.json")
@@ -179,10 +225,7 @@ fn sort_json_keys(value: &Value) -> Value {
 
 /// 写入 JSON 配置文件（键按字母排序，确保确定性输出）
 pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppError> {
-    // 确保目录存在
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
-    }
+    create_parent_dir_all(path)?;
 
     let value = serde_json::to_value(data).map_err(|e| AppError::JsonSerialize { source: e })?;
     let sorted_value = sort_json_keys(&value);
@@ -194,17 +237,13 @@ pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppErr
 
 /// 原子写入文本文件（用于 TOML/纯文本）
 pub fn write_text_file(path: &Path, data: &str) -> Result<(), AppError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
-    }
+    create_parent_dir_all(path)?;
     atomic_write(path, data.as_bytes())
 }
 
 /// 原子写入：写入临时文件后 rename 替换，避免半写状态
 pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
-    }
+    create_parent_dir_all(path)?;
 
     let parent = path
         .parent()
@@ -290,6 +329,45 @@ mod tests {
     fn derive_mcp_path_from_root_like_dir_returns_none() {
         let override_dir = PathBuf::from("/");
         assert!(derive_mcp_path_from_override(&override_dir).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_private_dir_all_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let private_dir = temp.path().join(".cc-switch");
+
+        create_private_dir_all(&private_dir).expect("create private dir");
+
+        let mode = fs::metadata(&private_dir)
+            .expect("private dir metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_private_dir_all_repairs_existing_directory_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let private_dir = temp.path().join(".cc-switch");
+        fs::create_dir_all(&private_dir).expect("create dir");
+        fs::set_permissions(&private_dir, fs::Permissions::from_mode(0o755))
+            .expect("widen dir permissions");
+
+        create_private_dir_all(&private_dir).expect("repair private dir");
+
+        let mode = fs::metadata(&private_dir)
+            .expect("private dir metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -280,16 +280,31 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-        let mut f = fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .mode(0o600)
-            .open(&tmp)
-            .map_err(|e| AppError::io(&tmp, e))?;
+        let existing_mode = match fs::metadata(path) {
+            Ok(metadata) => Some(metadata.permissions().mode() & 0o777),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(AppError::io(path, error)),
+        };
+        let is_new_private_app_file =
+            existing_mode.is_none() && path.starts_with(get_app_config_dir());
+
+        let mut options = fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        if existing_mode.is_some() || is_new_private_app_file {
+            options.mode(0o600);
+        }
+
+        let mut f = options.open(&tmp).map_err(|e| AppError::io(&tmp, e))?;
         f.write_all(data).map_err(|e| AppError::io(&tmp, e))?;
         f.flush().map_err(|e| AppError::io(&tmp, e))?;
+        drop(f);
+
+        if let Some(mode) = existing_mode {
+            fs::set_permissions(&tmp, fs::Permissions::from_mode(mode))
+                .map_err(|e| AppError::io(&tmp, e))?;
+        }
     }
 
     #[cfg(not(unix))]
@@ -324,6 +339,7 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn derive_mcp_path_from_override_preserves_folder_name() {
@@ -396,13 +412,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn atomic_write_creates_private_file_permissions() {
+    #[serial]
+    fn atomic_write_creates_private_app_file_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join("config.json");
+        let previous_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        let path = temp.path().join(".cc-switch").join("config.json");
 
         atomic_write(&path, b"{}").expect("atomic write");
+
+        match previous_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
 
         let mode = fs::metadata(&path)
             .expect("file metadata")
@@ -414,7 +438,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn atomic_write_repairs_existing_file_permissions() {
+    fn atomic_write_preserves_existing_file_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempfile::tempdir().expect("tempdir");
@@ -430,7 +454,7 @@ mod tests {
             .permissions()
             .mode()
             & 0o777;
-        assert_eq!(mode, 0o600);
+        assert_eq!(mode, 0o644);
     }
 
     #[test]

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -3,7 +3,9 @@
 //! 提供 SQL 导出/导入和二进制快照备份功能。
 
 use super::{lock_conn, Database};
-use crate::config::{create_private_dir_all, ensure_app_config_dir, get_app_config_dir};
+use crate::config::{
+    create_private_dir_all, ensure_app_config_dir, get_app_config_dir, set_private_file_permissions,
+};
 use crate::error::AppError;
 use chrono::{Local, Utc};
 use rusqlite::backup::Backup;
@@ -328,6 +330,7 @@ impl Database {
                 .step(-1)
                 .map_err(|e| AppError::Database(e.to_string()))?;
         }
+        set_private_file_permissions(&backup_path)?;
 
         Self::cleanup_db_backups(&backup_dir)?;
         Ok(Some(backup_path))
@@ -777,6 +780,44 @@ mod tests {
             stream_logs, 1,
             "local stream check logs should be preserved"
         );
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn backup_database_file_sets_private_permissions() -> Result<(), AppError> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+
+        let db = Database::init()?;
+        let backup_path = db
+            .backup_database_file()?
+            .expect("backup path should exist");
+
+        let backup_dir = backup_path.parent().expect("backup parent");
+        let dir_mode = std::fs::metadata(backup_dir)
+            .expect("backup dir metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dir_mode, 0o700);
+
+        let file_mode = std::fs::metadata(&backup_path)
+            .expect("backup file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(file_mode, 0o600);
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
 
         Ok(())
     }

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -3,7 +3,7 @@
 //! 提供 SQL 导出/导入和二进制快照备份功能。
 
 use super::{lock_conn, Database};
-use crate::config::get_app_config_dir;
+use crate::config::{create_private_dir_all, ensure_app_config_dir, get_app_config_dir};
 use crate::error::AppError;
 use chrono::{Local, Utc};
 use rusqlite::backup::Backup;
@@ -296,7 +296,7 @@ impl Database {
 
     /// 生成一致性快照备份，返回备份文件路径（不存在主库时返回 None）
     pub(crate) fn backup_database_file(&self) -> Result<Option<PathBuf>, AppError> {
-        let db_path = get_app_config_dir().join("cc-switch.db");
+        let db_path = ensure_app_config_dir()?.join("cc-switch.db");
         if !db_path.exists() {
             return Ok(None);
         }
@@ -306,7 +306,7 @@ impl Database {
             .ok_or_else(|| AppError::Config("无效的数据库路径".to_string()))?
             .join("backups");
 
-        fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        create_private_dir_all(&backup_dir)?;
 
         let base_id = format!("db_backup_{}", Local::now().format("%Y%m%d_%H%M%S"));
         let mut backup_id = base_id.clone();

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use dao::proxy::{
 };
 pub use dao::FailoverQueueItem;
 
-use crate::config::ensure_app_config_dir;
+use crate::config::{create_private_dir_all, ensure_app_config_dir, set_private_file_permissions};
 use crate::error::AppError;
 use rusqlite::{hooks::Action, Connection};
 use serde::Serialize;
@@ -96,7 +96,12 @@ impl Database {
         let db_path = ensure_app_config_dir()?.join("cc-switch.db");
         let db_exists = db_path.exists();
 
+        if let Some(parent) = db_path.parent() {
+            create_private_dir_all(parent)?;
+        }
+
         let conn = Connection::open(&db_path).map_err(|e| AppError::Database(e.to_string()))?;
+        set_private_file_permissions(&db_path)?;
 
         // 启用外键约束
         conn.execute("PRAGMA foreign_keys = ON;", [])

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -39,7 +39,7 @@ pub(crate) use dao::proxy::{
 };
 pub use dao::FailoverQueueItem;
 
-use crate::config::get_app_config_dir;
+use crate::config::ensure_app_config_dir;
 use crate::error::AppError;
 use rusqlite::{hooks::Action, Connection};
 use serde::Serialize;
@@ -93,13 +93,8 @@ impl Database {
     ///
     /// 数据库文件位于 `~/.cc-switch/cc-switch.db`
     pub fn init() -> Result<Self, AppError> {
-        let db_path = get_app_config_dir().join("cc-switch.db");
+        let db_path = ensure_app_config_dir()?.join("cc-switch.db");
         let db_exists = db_path.exists();
-
-        // 确保父目录存在
-        if let Some(parent) = db_path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
-        }
 
         let conn = Connection::open(&db_path).map_err(|e| AppError::Database(e.to_string()))?;
 

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use rusqlite::{params, Connection};
 use serde_json::json;
 use std::collections::HashMap;
-use tempfile::NamedTempFile;
+use tempfile::{tempdir, NamedTempFile};
 
 const LEGACY_SCHEMA_SQL: &str = r#"
     CREATE TABLE providers (
@@ -51,6 +51,39 @@ const LEGACY_SCHEMA_SQL: &str = r#"
         value TEXT
     );
 "#;
+
+#[cfg(unix)]
+#[test]
+#[serial_test::serial]
+fn init_sets_private_database_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+    let temp = tempdir().expect("tempdir");
+    let db_path = temp.path().join(".cc-switch").join("cc-switch.db");
+    std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+
+    let _db = Database::init().expect("init db");
+
+    let dir_mode = std::fs::metadata(db_path.parent().expect("db parent"))
+        .expect("db parent metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(dir_mode, 0o700);
+
+    let file_mode = std::fs::metadata(&db_path)
+        .expect("db metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(file_mode, 0o600);
+
+    match old_test_home {
+        Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+        None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+    }
+}
 
 // v3.8.x（schema v1）的真实表结构快照：用于验证从 v3.8.* 升级到当前版本的迁移链路
 // 参考：tag v3.8.3 的 src-tauri/src/database/schema.rs


### PR DESCRIPTION
## Summary / 概述

Harden Unix filesystem permissions for CC Switch's private app data so other
local users cannot read sensitive config and database files. Closes #3265.

On Unix platforms this PR explicitly restricts permissions for `~/.cc-switch`
and database-related files:

- Create `.cc-switch` directories with `0o700` via Unix `DirBuilderExt`, and
  tighten pre-existing directories that have broader permissions.
- Set `cc-switch.db` to `0o600` after SQLite creates/opens it.
- Set database backup files under `~/.cc-switch/backups/*.db` to `0o600`.
- Update `atomic_write` so that, on Unix, newly created files use a `0o600`
  temporary file instead of falling back to the default umask permissions when
  the target file does not yet exist.
- Add Unix-only tests covering directory, database, backup-database, and
  atomic-write permissions.

`0o700` on `.cc-switch` is the primary protection boundary, which also protects
SQLite sidecar files such as `cc-switch.db-wal` and `cc-switch.db-shm` created
inside the private directory. `0o600` on database files is added as
defense-in-depth.

Existing auth/settings/Gemini permission handling was intentionally left
unchanged to keep this PR focused and reviewable.

## Related Issue / 关联 Issue

Fixes #3265

## Screenshots / 截图

Not applicable — this is a filesystem permission hardening change.

| Before / 修改前 | After / 修改后 |
|-----------------|----------------|
| `.cc-switch` and database files could inherit broad umask permissions such as `0755` / `0644` | `.cc-switch` is restricted to `0700`; database and atomic-write-created files are restricted to `0600` on Unix |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — N/A: no user-facing text changed

## Verification / 验证

Ran on Linux/WSL:

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` — all green (TypeScript checks run via `tsc --noEmit` and
  `prettier --check "src/**/*.{js,jsx,ts,tsx,css,json}"`)

Verified the resulting permissions on a native Linux filesystem:

- `~/.cc-switch` → `700`
- `~/.cc-switch/cc-switch.db` → `600`
- `~/.cc-switch/backups/*.db` → `600`

Verified on Linux/WSL. macOS was not tested on real hardware(because my Mac is fixing now), but it shares the
same `#[cfg(unix)]` code path and identical POSIX permission semantics.