### PR TITLE
fix(proxy): attribute streamed usage model

### DIFF
--- a/src-tauri/src/proxy/handler_config.rs
+++ b/src-tauri/src/proxy/handler_config.rs
@@ -44,11 +44,13 @@ pub fn claude_stream_usage_event_filter(data: &str) -> bool {
 }
 
 fn openai_stream_usage_event_filter(data: &str) -> bool {
-    data.contains("\"usage\"")
+    data.contains("\"usage\"") || data.contains("\"model\"")
 }
 
 pub fn codex_stream_usage_event_filter(data: &str) -> bool {
-    data.contains("\"response.completed\"") || data.contains("\"usage\"")
+    data.contains("\"response.created\"")
+        || data.contains("\"response.completed\"")
+        || data.contains("\"usage\"")
 }
 
 fn gemini_stream_usage_event_filter(data: &str) -> bool {
@@ -94,15 +96,12 @@ fn codex_auto_model_extractor(events: &[Value], request_model: &str) -> String {
             return model;
         }
     }
-    // 回退：从 response.completed 事件中提取
+    // 回退：从 Responses 事件中提取
     events
         .iter()
-        .find_map(|e| {
-            if e.get("type")?.as_str()? == "response.completed" {
-                e.get("response")?.get("model")?.as_str()
-            } else {
-                None
-            }
+        .find_map(|e| match e.get("type")?.as_str()? {
+            "response.created" | "response.completed" => e.get("response")?.get("model")?.as_str(),
+            _ => None,
         })
         .or_else(|| {
             // 再回退：从 OpenAI 格式事件中提取

--- a/src-tauri/src/proxy/handler_config.rs
+++ b/src-tauri/src/proxy/handler_config.rs
@@ -44,13 +44,11 @@ pub fn claude_stream_usage_event_filter(data: &str) -> bool {
 }
 
 fn openai_stream_usage_event_filter(data: &str) -> bool {
-    data.contains("\"usage\"") || data.contains("\"model\"")
+    data.contains("\"usage\"")
 }
 
 pub fn codex_stream_usage_event_filter(data: &str) -> bool {
-    data.contains("\"response.created\"")
-        || data.contains("\"response.completed\"")
-        || data.contains("\"usage\"")
+    data.contains("\"response.completed\"") || data.contains("\"usage\"")
 }
 
 fn gemini_stream_usage_event_filter(data: &str) -> bool {
@@ -96,12 +94,15 @@ fn codex_auto_model_extractor(events: &[Value], request_model: &str) -> String {
             return model;
         }
     }
-    // 回退：从 Responses 事件中提取
+    // 回退：从 response.completed 事件中提取
     events
         .iter()
-        .find_map(|e| match e.get("type")?.as_str()? {
-            "response.created" | "response.completed" => e.get("response")?.get("model")?.as_str(),
-            _ => None,
+        .find_map(|e| {
+            if e.get("type")?.as_str()? == "response.completed" {
+                e.get("response")?.get("model")?.as_str()
+            } else {
+                None
+            }
         })
         .or_else(|| {
             // 再回退：从 OpenAI 格式事件中提取

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -298,7 +298,7 @@ async fn handle_claude_transform(
         let usage_collector = if usage_logging_enabled(state) {
             let state = state.clone();
             let provider_id = ctx.provider.id.clone();
-            let model = ctx.request_model.clone();
+            let request_model = ctx.request_model.clone();
             let status_code = status.as_u16();
             let start_time = ctx.start_time;
             let session_id = ctx.session_id.clone();
@@ -308,10 +308,11 @@ async fn handle_claude_transform(
                 Some(claude_stream_usage_event_filter),
                 move |events, first_token_ms| {
                     if let Some(usage) = TokenUsage::from_claude_stream_events(&events) {
+                        let model = usage.model.clone().unwrap_or_else(|| request_model.clone());
                         let latency_ms = start_time.elapsed().as_millis() as u64;
                         let state = state.clone();
                         let provider_id = provider_id.clone();
-                        let model = model.clone();
+                        let request_model = request_model.clone();
                         let session_id = session_id.clone();
 
                         tokio::spawn(async move {
@@ -320,7 +321,7 @@ async fn handle_claude_transform(
                                 &provider_id,
                                 "claude",
                                 &model,
-                                &model,
+                                &request_model,
                                 usage,
                                 latency_ms,
                                 first_token_ms,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -308,7 +308,11 @@ async fn handle_claude_transform(
                 Some(claude_stream_usage_event_filter),
                 move |events, first_token_ms| {
                     if let Some(usage) = TokenUsage::from_claude_stream_events(&events) {
-                        let model = usage.model.clone().unwrap_or_else(|| request_model.clone());
+                        let model = usage
+                            .model
+                            .clone()
+                            .filter(|model| !model.trim().is_empty())
+                            .unwrap_or_else(|| request_model.clone());
                         let latency_ms = start_time.elapsed().as_millis() as u64;
                         let state = state.clone();
                         let provider_id = provider_id.clone();


### PR DESCRIPTION
## Summary

- Fix routing-mode usage attribution for streamed responses.
- Prefer the model reported in the streamed usage payload when available.
- Keep the original request model available separately for fallback/pricing behavior.

## Background

In routing mode, streamed usage logging could record the request/default Claude model as the attributed model even when the transformed stream usage payload already included the actual upstream model.

For example, usage statistics could be attributed to a default model name such as `claude-opus-4-8` instead of the provider model that actually handled the request.

The fix keeps the existing stream event filtering and extraction behavior unchanged, and only adjusts the usage logging path to prefer `usage.model` when it is present.

<img width="1894" height="482" alt="260601_013350_cc-switch" src="https://github.com/user-attachments/assets/27e0202a-44ea-4e2a-ab8d-7552196e85ee" />

## Changes

- Use `usage.model` as the logged attribution model when the streamed usage payload includes it.
- Fall back to the original request model when the streamed usage payload has no model.
- Continue passing the original request model to `log_usage` separately so fallback/pricing logic remains intact.
- Keep the change scoped to proxy stream usage/model attribution.

## Test plan

- [x] Verify routing-mode usage statistics with DeepSeek OpenAI Chat Completions.
- [x] Verify routing-mode usage statistics with sub2api OpenAI Responses.
- [x] Verify routing-mode usage statistics with sub2api OpenAI Chat Completions.

## Screenshots

<img width="1883" height="496" alt="260601_013619_cc-switch" src="https://github.com/user-attachments/assets/68fb5ee9-d94f-444d-b23d-de1abfe92cdc" />
