### PR TITLE
修复 Windows 更新后任务栏图标丢失

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,7 +88,7 @@ webkit2gtk = { version = "2.0.1", features = ["v2_16"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
-windows-sys = { version = "0.61", features = ["Win32_Globalization"] }
+windows-sys = { version = "0.61", features = ["Win32_Globalization", "Win32_UI_Shell"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,22 @@ use tauri::RunEvent;
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
+#[cfg(target_os = "windows")]
+fn set_windows_app_user_model_id(app: &tauri::AppHandle) {
+    let app_id = app.config().identifier.clone();
+    let wide_app_id: Vec<u16> = app_id.encode_utf16().chain(std::iter::once(0)).collect();
+
+    let result = unsafe {
+        windows_sys::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID(wide_app_id.as_ptr())
+    };
+
+    if result < 0 {
+        log::warn!("设置 Windows AppUserModelID 失败: 0x{result:08X}");
+    } else {
+        log::debug!("Windows AppUserModelID 已设置为 {app_id}");
+    }
+}
+
 fn redact_url_for_log(url_str: &str) -> String {
     match url::Url::parse(url_str) {
         Ok(url) => {
@@ -288,6 +304,8 @@ pub fn run() {
             // 预先刷新 Store 覆盖配置，确保后续路径读取正确（日志/数据库等）
             app_store::refresh_app_config_dir_override(app.handle());
             panic_hook::init_app_config_dir(crate::config::get_app_config_dir());
+            #[cfg(target_os = "windows")]
+            set_windows_app_user_model_id(app.handle());
 
             // 注册 Updater 插件（桌面端）
             #[cfg(desktop)]

--- a/src-tauri/wix/per-user-main.wxs
+++ b/src-tauri/wix/per-user-main.wxs
@@ -110,7 +110,14 @@
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="DesktopFolder" Name="Desktop">
                 <Component Id="ApplicationShortcutDesktop" Guid="*">
-                    <Shortcut Id="ApplicationDesktopShortcut" Name="{{product_name}}" Description="Runs {{product_name}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
+                    <Shortcut Id="ApplicationDesktopShortcut"
+                        Name="{{product_name}}"
+                        Description="Runs {{product_name}}"
+                        Target="[!Path]"
+                        Icon="ProductIcon"
+                        WorkingDirectory="INSTALLDIR">
+                        <ShortcutProperty Key="System.AppUserModel.ID" Value="{{bundle_id}}"/>
+                    </Shortcut>
                     <RemoveFolder Id="DesktopFolder" On="uninstall" />
                     <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Desktop Shortcut" Type="integer" Value="1" KeyPath="yes" />
                 </Component>


### PR DESCRIPTION
## 变更内容
- 在 Windows 启动阶段显式设置 `AppUserModelID`
- 为桌面快捷方式补齐 `System.AppUserModel.ID`
- 为桌面快捷方式显式指定 `ProductIcon`
- 为 `windows-sys` 增加 `Win32_UI_Shell` 特性以支持相关 Win32 API

## 问题原因
Windows 任务栏固定项依赖稳定的应用身份和快捷方式元数据来关联图标与进程。当前实现里只有开始菜单快捷方式带有 `System.AppUserModel.ID`，桌面快捷方式没有，运行时也没有显式设置进程级 `AppUserModelID`。升级后旧安装被替换时，任务栏固定项可能失去原有身份映射，表现为图标变成“未知图标”，但仍可启动应用。

## 修复思路
统一运行中的应用、桌面快捷方式和开始菜单快捷方式的 Windows Shell 身份，降低升级后 pinned item 失去关联的概率。

## 影响
修复后，新版本安装并重新固定后的任务栏项在后续升级中应能更稳定地保留正确图标与应用关联。

## 验证
- `cargo fmt`
- `cargo check` 未能在当前环境完成：本地 Rust 依赖缓存存在 `rustc 1.95` 与 `rustc 1.94` 混用导致的不兼容错误，未发现与本次改动直接相关的编译错误信息
