### PR TITLE
fix: align hermes_config_dir with Hermes platform defaults on Windows

### DIFF
--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -62,7 +62,7 @@ pub fn get_hermes_dir() -> PathBuf {
 #[cfg(target_os = "windows")]
 fn default_hermes_dir() -> PathBuf {
     dirs::data_local_dir()
-        .unwrap_or_else(crate::config::get_home_dir)
+        .unwrap_or_else(|| crate::config::get_home_dir().join("AppData").join("Local"))
         .join("hermes")
 }
 
@@ -250,7 +250,7 @@ fn replace_yaml_section(
 // ============================================================================
 
 fn create_hermes_backup(source: &str) -> Result<PathBuf, AppError> {
-    let backup_dir = get_app_config_dir().join("backups").join("hermes");
+    let backup_dir = get_app_config_dir().join("backups").join(".hermes");
     fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
 
     let base_id = format!("hermes_{}", Local::now().format("%Y%m%d_%H%M%S"));

--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -44,27 +44,37 @@ use std::sync::{Mutex, OnceLock};
 // Path Functions
 // ============================================================================
 
-/// 获取 Hermes 配置目录
+/// 获取 Hermes 配置目录路径
 ///
-/// 优先级：settings override > HERMES_HOME > ~/.hermes/
+/// 通过 CCS 设置中的 `hermes_config_dir` 覆盖
+/// 否则用默认路径（Windows: `%LOCALAPPDATA%\\hermes`，Mac/Linux: `~/.hermes`）
 pub fn get_hermes_dir() -> PathBuf {
     if let Some(override_dir) = get_hermes_override_dir() {
         return override_dir;
     }
 
-    if let Ok(hermes_home) = std::env::var("HERMES_HOME") {
-        let trimmed = hermes_home.trim();
-        if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
-        }
-    }
+    default_hermes_dir()
+}
 
+/// Windows 默认 Hermes 目录：`%LOCALAPPDATA%\\hermes`
+///
+/// 与 Hermes 自身 `get_hermes_home()` 默认值对齐
+#[cfg(target_os = "windows")]
+fn default_hermes_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(crate::config::get_home_dir)
+        .join("hermes")
+}
+
+/// Mac/Linux默认 Hermes 目录：`~/.hermes`
+#[cfg(not(target_os = "windows"))]
+fn default_hermes_dir() -> PathBuf {
     crate::config::get_home_dir().join(".hermes")
 }
 
 /// 获取 Hermes 配置文件路径
 ///
-/// 返回 `~/.hermes/config.yaml`
+/// 返回 `<hermes_dir>/config.yaml`
 pub fn get_hermes_config_path() -> PathBuf {
     get_hermes_dir().join("config.yaml")
 }
@@ -1951,69 +1961,37 @@ user_profile_enabled: false
         assert!(serde_json::from_str::<MemoryKind>("\"bogus\"").is_err());
     }
 
-    // ---- get_hermes_dir() path resolution ----
+    // ---- get_hermes_dir() 路径确认 ----
 
-    /// Helper: save and restore a single env var across a test.
-    struct EnvGuard {
-        key: &'static str,
-        old: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn new(key: &'static str) -> Self {
-            let old = std::env::var(key).ok();
-            Self { key, old }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.old {
-                Some(v) => std::env::set_var(self.key, v),
-                None => std::env::remove_var(self.key),
-            }
-        }
+    #[test]
+    #[serial]
+    fn hermes_fallback_uses_os_default() {
+        let _g = test_guard();
+        // 没有自定义目录走平台默认
+        // Windows：%LOCALAPPDATA%\hermes，Mac/Linux： ~/.hermes
+        let dir = get_hermes_dir();
+        #[cfg(target_os = "windows")]
+        assert!(
+            dir.ends_with("hermes"),
+            "Windows 上默认路径应为 %LOCALAPPDATA%\\hermes，实际为 {dir:?}"
+        );
+        #[cfg(not(target_os = "windows"))]
+        assert!(
+            dir.ends_with(".hermes"),
+            "Mac/Linux 上默认路径应为 ~/.hermes，实际为 {dir:?}"
+        );
     }
 
     #[test]
     #[serial]
-    fn uses_hermes_home_env() {
-        let _guard = EnvGuard::new("HERMES_HOME");
+    fn settings_override_wins_over_default() {
         let _g = test_guard();
-        let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HERMES_HOME", tmp.path());
-        assert_eq!(get_hermes_dir(), tmp.path());
-    }
-
-    #[test]
-    #[serial]
-    fn skips_empty_hermes_home() {
-        let _guard = EnvGuard::new("HERMES_HOME");
-        let _g = test_guard();
-        std::env::set_var("HERMES_HOME", "   ");
-        assert!(get_hermes_dir().ends_with(".hermes"));
-    }
-
-    #[test]
-    #[serial]
-    fn defaults_to_hermes_dir() {
-        let _guard = EnvGuard::new("HERMES_HOME");
-        let _g = test_guard();
-        std::env::remove_var("HERMES_HOME");
-        assert!(get_hermes_dir().ends_with(".hermes"));
-    }
-
-    #[test]
-    #[serial]
-    fn no_tilde_expansion() {
-        // ~/xxx 和 ~ 两种情况都不展开，与 Hermes 自身行为一致
-        let _guard = EnvGuard::new("HERMES_HOME");
-        let _g = test_guard();
-
-        std::env::set_var("HERMES_HOME", "~/custom");
-        assert_eq!(get_hermes_dir(), PathBuf::from("~/custom"));
-
-        std::env::set_var("HERMES_HOME", "~");
-        assert_eq!(get_hermes_dir(), PathBuf::from("~"));
+        // 自定义目录优先于平台默认路径
+        // 确认不会因默认值变更而崩溃
+        let dir = get_hermes_dir();
+        assert!(
+            dir.ends_with(".hermes") || dir.ends_with("hermes"),
+            "预期默认路径 ~/.hermes，实际路径：{dir:?}"
+        );
     }
 }

--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -46,21 +46,12 @@ use std::sync::{Mutex, OnceLock};
 
 /// 获取 Hermes 配置目录
 ///
-/// 优先级（与 Hermes 自身 `hermes_constants.get_hermes_home()` 对齐）：
-/// 1. CC Switch 设置覆盖 (`settings.hermes_config_dir`)
-/// 2. `HERMES_HOME` 环境变量（Hermes 自身的配置目录覆盖）
-/// 3. 默认路径: `~/.hermes/`
-///
-/// 参见 https://github.com/NousResearch/hermes-agent/blob/main/hermes_constants.py
+/// 优先级：settings override > HERMES_HOME > ~/.hermes/
 pub fn get_hermes_dir() -> PathBuf {
-    // 1. CC Switch 自身的 settings override（最高优先级）
     if let Some(override_dir) = get_hermes_override_dir() {
         return override_dir;
     }
 
-    // 2. HERMES_HOME 环境变量（与 Hermes 自身行为一致）
-    //    不做 ~ 展开：Hermes 的 get_hermes_home() 也是 trim() 后直接 Path(val)，
-    //    展开会导致 HERMES_HOME 含 ~ 时两边路径不一致。
     if let Ok(hermes_home) = std::env::var("HERMES_HOME") {
         let trimmed = hermes_home.trim();
         if !trimmed.is_empty() {
@@ -68,7 +59,6 @@ pub fn get_hermes_dir() -> PathBuf {
         }
     }
 
-    // 3. 默认路径
     crate::config::get_home_dir().join(".hermes")
 }
 
@@ -1963,136 +1953,67 @@ user_profile_enabled: false
 
     // ---- get_hermes_dir() path resolution ----
 
-    #[test]
-    #[serial]
-    fn hermes_dir_respects_hermes_home_env_var() {
-        // When HERMES_HOME is set, get_hermes_dir() must use it (matching
-        // Hermes' own hermes_constants.get_hermes_home() behaviour).
-        // This is the fix for cc-switch issue #3406.
-        let _guard = test_guard();
-        let tmp = tempfile::tempdir().unwrap();
-        let old_home = std::env::var_os("HERMES_HOME");
-        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+    /// Helper: save and restore a single env var across a test.
+    struct EnvGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
 
-        // Clear CC_SWITCH_TEST_HOME so get_home_dir() falls back to real
-        // dirs::home_dir(), and set HERMES_HOME to our temp dir.
-        std::env::remove_var("CC_SWITCH_TEST_HOME");
-        std::env::set_var("HERMES_HOME", tmp.path());
-
-        let hermes_dir = get_hermes_dir();
-        assert_eq!(hermes_dir, tmp.path());
-
-        // Cleanup
-        match old_home {
-            Some(value) => std::env::set_var("HERMES_HOME", value),
-            None => std::env::remove_var("HERMES_HOME"),
-        }
-        match old_test_home {
-            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
-            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+    impl EnvGuard {
+        fn new(key: &'static str) -> Self {
+            let old = std::env::var(key).ok();
+            Self { key, old }
         }
     }
 
-    #[test]
-    #[serial]
-    fn hermes_dir_ignores_empty_hermes_home() {
-        let _guard = test_guard();
-        let old = std::env::var_os("HERMES_HOME");
-
-        // Empty or whitespace-only HERMES_HOME should fall through to default
-        std::env::set_var("HERMES_HOME", "   ");
-        let dir = get_hermes_dir();
-        assert!(dir.ends_with(".hermes"));
-
-        match old {
-            Some(value) => std::env::set_var("HERMES_HOME", value),
-            None => std::env::remove_var("HERMES_HOME"),
-        }
-    }
-
-    #[test]
-    #[serial]
-    fn hermes_dir_with_test_home_falls_back_to_default() {
-        // When neither override nor HERMES_HOME is set, should use
-        // CC_SWITCH_TEST_HOME/.hermes (the test isolation default).
-        with_test_home(|| {
-            let old = std::env::var_os("HERMES_HOME");
-            std::env::remove_var("HERMES_HOME");
-
-            let dir = get_hermes_dir();
-            assert!(dir.ends_with(".hermes"));
-
-            match old {
-                Some(value) => std::env::set_var("HERMES_HOME", value),
-                None => {}
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.old {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
             }
-        });
-    }
-
-    #[test]
-    #[serial]
-    fn hermes_dir_does_not_expand_tilde_in_hermes_home() {
-        // HERMES_HOME with ~ prefix must NOT be expanded, matching Hermes'
-        // own get_hermes_home() which does Path(val) without expanduser.
-        // Expanding would cause a config split when the env var comes from
-        // .env files or GUI launchers that don't perform shell expansion.
-        let _guard = test_guard();
-        let old_home = std::env::var_os("HERMES_HOME");
-        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
-
-        std::env::remove_var("CC_SWITCH_TEST_HOME");
-
-        // ~/ prefix → used as-is (not expanded to home dir)
-        std::env::set_var("HERMES_HOME", "~/custom-hermes");
-        let dir = get_hermes_dir();
-        assert_eq!(dir, PathBuf::from("~/custom-hermes"));
-
-        // ~ alone → used as-is
-        std::env::set_var("HERMES_HOME", "~");
-        let dir = get_hermes_dir();
-        assert_eq!(dir, PathBuf::from("~"));
-
-        // Cleanup
-        match old_home {
-            Some(value) => std::env::set_var("HERMES_HOME", value),
-            None => std::env::remove_var("HERMES_HOME"),
-        }
-        match old_test_home {
-            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
-            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
         }
     }
 
     #[test]
     #[serial]
-    fn hermes_dir_settings_override_beats_hermes_home() {
-        // When both settings override and HERMES_HOME are set,
-        // settings override should win (highest priority).
-        // This test verifies priority order: settings > HERMES_HOME > default.
-        //
-        // Note: We can only test this indirectly since get_hermes_override_dir()
-        // reads from the global settings store which is hard to mock in unit tests.
-        // The key assertion is that HERMES_HOME works when no override is set.
-        // The override > HERMES_HOME priority is enforced by the code ordering
-        // (override check comes first in get_hermes_dir()).
-        let _guard = test_guard();
-        let old = std::env::var_os("HERMES_HOME");
-        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+    fn uses_hermes_home_env() {
+        let _guard = EnvGuard::new("HERMES_HOME");
+        let _g = test_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HERMES_HOME", tmp.path());
+        assert_eq!(get_hermes_dir(), tmp.path());
+    }
 
-        std::env::remove_var("CC_SWITCH_TEST_HOME");
+    #[test]
+    #[serial]
+    fn skips_empty_hermes_home() {
+        let _guard = EnvGuard::new("HERMES_HOME");
+        let _g = test_guard();
+        std::env::set_var("HERMES_HOME", "   ");
+        assert!(get_hermes_dir().ends_with(".hermes"));
+    }
+
+    #[test]
+    #[serial]
+    fn defaults_to_hermes_dir() {
+        let _guard = EnvGuard::new("HERMES_HOME");
+        let _g = test_guard();
         std::env::remove_var("HERMES_HOME");
+        assert!(get_hermes_dir().ends_with(".hermes"));
+    }
 
-        // Without any override or HERMES_HOME, falls back to default
-        let dir = get_hermes_dir();
-        assert!(dir.ends_with(".hermes"));
+    #[test]
+    #[serial]
+    fn no_tilde_expansion() {
+        // ~/xxx 和 ~ 两种情况都不展开，与 Hermes 自身行为一致
+        let _guard = EnvGuard::new("HERMES_HOME");
+        let _g = test_guard();
 
-        match old {
-            Some(value) => std::env::set_var("HERMES_HOME", value),
-            None => std::env::remove_var("HERMES_HOME"),
-        }
-        match old_test_home {
-            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
-            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
-        }
+        std::env::set_var("HERMES_HOME", "~/custom");
+        assert_eq!(get_hermes_dir(), PathBuf::from("~/custom"));
+
+        std::env::set_var("HERMES_HOME", "~");
+        assert_eq!(get_hermes_dir(), PathBuf::from("~"));
     }
 }

--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -59,21 +59,12 @@ pub fn get_hermes_dir() -> PathBuf {
     }
 
     // 2. HERMES_HOME 环境变量（与 Hermes 自身行为一致）
-    //    展开 ~ 前缀，与 settings::resolve_override_path 行为一致。
+    //    不做 ~ 展开：Hermes 的 get_hermes_home() 也是 trim() 后直接 Path(val)，
+    //    展开会导致 HERMES_HOME 含 ~ 时两边路径不一致。
     if let Ok(hermes_home) = std::env::var("HERMES_HOME") {
         let trimmed = hermes_home.trim();
         if !trimmed.is_empty() {
-            let path = if trimmed == "~" {
-                crate::config::get_home_dir()
-            } else if let Some(stripped) = trimmed
-                .strip_prefix("~/")
-                .or_else(|| trimmed.strip_prefix("~\\"))
-            {
-                crate::config::get_home_dir().join(stripped)
-            } else {
-                PathBuf::from(trimmed)
-            };
-            return path;
+            return PathBuf::from(trimmed);
         }
     }
 
@@ -2040,31 +2031,26 @@ user_profile_enabled: false
 
     #[test]
     #[serial]
-    fn hermes_dir_expands_tilde_in_hermes_home() {
-        // HERMES_HOME=~/custom should expand ~ to the actual home directory,
-        // matching settings::resolve_override_path behaviour.
+    fn hermes_dir_does_not_expand_tilde_in_hermes_home() {
+        // HERMES_HOME with ~ prefix must NOT be expanded, matching Hermes'
+        // own get_hermes_home() which does Path(val) without expanduser.
+        // Expanding would cause a config split when the env var comes from
+        // .env files or GUI launchers that don't perform shell expansion.
         let _guard = test_guard();
         let old_home = std::env::var_os("HERMES_HOME");
         let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
 
-        // Use a real home dir so ~ expansion is testable
         std::env::remove_var("CC_SWITCH_TEST_HOME");
-        let real_home = crate::config::get_home_dir();
 
-        // Test ~/ prefix
+        // ~/ prefix → used as-is (not expanded to home dir)
         std::env::set_var("HERMES_HOME", "~/custom-hermes");
         let dir = get_hermes_dir();
-        assert_eq!(dir, real_home.join("custom-hermes"));
+        assert_eq!(dir, PathBuf::from("~/custom-hermes"));
 
-        // Test ~ alone
+        // ~ alone → used as-is
         std::env::set_var("HERMES_HOME", "~");
         let dir = get_hermes_dir();
-        assert_eq!(dir, real_home);
-
-        // Test ~\ prefix (Windows-style backslash)
-        std::env::set_var("HERMES_HOME", "~\\hermes-win");
-        let dir = get_hermes_dir();
-        assert_eq!(dir, real_home.join("hermes-win"));
+        assert_eq!(dir, PathBuf::from("~"));
 
         // Cleanup
         match old_home {

--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -250,7 +250,7 @@ fn replace_yaml_section(
 // ============================================================================
 
 fn create_hermes_backup(source: &str) -> Result<PathBuf, AppError> {
-    let backup_dir = get_app_config_dir().join("backups").join(".hermes");
+    let backup_dir = get_app_config_dir().join("backups").join("hermes");
     fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
 
     let base_id = format!("hermes_{}", Local::now().format("%Y%m%d_%H%M%S"));
@@ -1961,14 +1961,10 @@ user_profile_enabled: false
         assert!(serde_json::from_str::<MemoryKind>("\"bogus\"").is_err());
     }
 
-    // ---- get_hermes_dir() 路径确认 ----
-
     #[test]
     #[serial]
-    fn hermes_fallback_uses_os_default() {
+    fn default_hermes_dir_without_override() {
         let _g = test_guard();
-        // 没有自定义目录走平台默认
-        // Windows：%LOCALAPPDATA%\hermes，Mac/Linux： ~/.hermes
         let dir = get_hermes_dir();
         #[cfg(target_os = "windows")]
         assert!(
@@ -1984,14 +1980,23 @@ user_profile_enabled: false
 
     #[test]
     #[serial]
-    fn settings_override_wins_over_default() {
+    fn settings_override_takes_precedence_over_default() {
         let _g = test_guard();
-        // 自定义目录优先于平台默认路径
-        // 确认不会因默认值变更而崩溃
+        let custom_dir = tempfile::tempdir().unwrap();
+        let custom_path = custom_dir.path().to_path_buf();
+
+        let mut settings = crate::settings::get_settings();
+        settings.hermes_config_dir = Some(custom_path.to_string_lossy().to_string());
+        crate::settings::update_settings(settings).unwrap();
+
         let dir = get_hermes_dir();
-        assert!(
-            dir.ends_with(".hermes") || dir.ends_with("hermes"),
-            "预期默认路径 ~/.hermes，实际路径：{dir:?}"
+        assert_eq!(
+            dir, custom_path,
+            "settings override 应优先于平台默认路径，实际为 {dir:?}"
         );
+
+        let mut settings = crate::settings::get_settings();
+        settings.hermes_config_dir = None;
+        crate::settings::update_settings(settings).unwrap();
     }
 }

--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -46,13 +46,38 @@ use std::sync::{Mutex, OnceLock};
 
 /// 获取 Hermes 配置目录
 ///
-/// 默认路径: `~/.hermes/`
-/// 可通过 settings.hermes_config_dir 覆盖
+/// 优先级（与 Hermes 自身 `hermes_constants.get_hermes_home()` 对齐）：
+/// 1. CC Switch 设置覆盖 (`settings.hermes_config_dir`)
+/// 2. `HERMES_HOME` 环境变量（Hermes 自身的配置目录覆盖）
+/// 3. 默认路径: `~/.hermes/`
+///
+/// 参见 https://github.com/NousResearch/hermes-agent/blob/main/hermes_constants.py
 pub fn get_hermes_dir() -> PathBuf {
+    // 1. CC Switch 自身的 settings override（最高优先级）
     if let Some(override_dir) = get_hermes_override_dir() {
         return override_dir;
     }
 
+    // 2. HERMES_HOME 环境变量（与 Hermes 自身行为一致）
+    //    展开 ~ 前缀，与 settings::resolve_override_path 行为一致。
+    if let Ok(hermes_home) = std::env::var("HERMES_HOME") {
+        let trimmed = hermes_home.trim();
+        if !trimmed.is_empty() {
+            let path = if trimmed == "~" {
+                crate::config::get_home_dir()
+            } else if let Some(stripped) = trimmed
+                .strip_prefix("~/")
+                .or_else(|| trimmed.strip_prefix("~\\"))
+            {
+                crate::config::get_home_dir().join(stripped)
+            } else {
+                PathBuf::from(trimmed)
+            };
+            return path;
+        }
+    }
+
+    // 3. 默认路径
     crate::config::get_home_dir().join(".hermes")
 }
 
@@ -1943,5 +1968,145 @@ user_profile_enabled: false
         assert_eq!(memory, MemoryKind::Memory);
         assert_eq!(user, MemoryKind::User);
         assert!(serde_json::from_str::<MemoryKind>("\"bogus\"").is_err());
+    }
+
+    // ---- get_hermes_dir() path resolution ----
+
+    #[test]
+    #[serial]
+    fn hermes_dir_respects_hermes_home_env_var() {
+        // When HERMES_HOME is set, get_hermes_dir() must use it (matching
+        // Hermes' own hermes_constants.get_hermes_home() behaviour).
+        // This is the fix for cc-switch issue #3406.
+        let _guard = test_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        let old_home = std::env::var_os("HERMES_HOME");
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+
+        // Clear CC_SWITCH_TEST_HOME so get_home_dir() falls back to real
+        // dirs::home_dir(), and set HERMES_HOME to our temp dir.
+        std::env::remove_var("CC_SWITCH_TEST_HOME");
+        std::env::set_var("HERMES_HOME", tmp.path());
+
+        let hermes_dir = get_hermes_dir();
+        assert_eq!(hermes_dir, tmp.path());
+
+        // Cleanup
+        match old_home {
+            Some(value) => std::env::set_var("HERMES_HOME", value),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn hermes_dir_ignores_empty_hermes_home() {
+        let _guard = test_guard();
+        let old = std::env::var_os("HERMES_HOME");
+
+        // Empty or whitespace-only HERMES_HOME should fall through to default
+        std::env::set_var("HERMES_HOME", "   ");
+        let dir = get_hermes_dir();
+        assert!(dir.ends_with(".hermes"));
+
+        match old {
+            Some(value) => std::env::set_var("HERMES_HOME", value),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn hermes_dir_with_test_home_falls_back_to_default() {
+        // When neither override nor HERMES_HOME is set, should use
+        // CC_SWITCH_TEST_HOME/.hermes (the test isolation default).
+        with_test_home(|| {
+            let old = std::env::var_os("HERMES_HOME");
+            std::env::remove_var("HERMES_HOME");
+
+            let dir = get_hermes_dir();
+            assert!(dir.ends_with(".hermes"));
+
+            match old {
+                Some(value) => std::env::set_var("HERMES_HOME", value),
+                None => {}
+            }
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn hermes_dir_expands_tilde_in_hermes_home() {
+        // HERMES_HOME=~/custom should expand ~ to the actual home directory,
+        // matching settings::resolve_override_path behaviour.
+        let _guard = test_guard();
+        let old_home = std::env::var_os("HERMES_HOME");
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+
+        // Use a real home dir so ~ expansion is testable
+        std::env::remove_var("CC_SWITCH_TEST_HOME");
+        let real_home = crate::config::get_home_dir();
+
+        // Test ~/ prefix
+        std::env::set_var("HERMES_HOME", "~/custom-hermes");
+        let dir = get_hermes_dir();
+        assert_eq!(dir, real_home.join("custom-hermes"));
+
+        // Test ~ alone
+        std::env::set_var("HERMES_HOME", "~");
+        let dir = get_hermes_dir();
+        assert_eq!(dir, real_home);
+
+        // Test ~\ prefix (Windows-style backslash)
+        std::env::set_var("HERMES_HOME", "~\\hermes-win");
+        let dir = get_hermes_dir();
+        assert_eq!(dir, real_home.join("hermes-win"));
+
+        // Cleanup
+        match old_home {
+            Some(value) => std::env::set_var("HERMES_HOME", value),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn hermes_dir_settings_override_beats_hermes_home() {
+        // When both settings override and HERMES_HOME are set,
+        // settings override should win (highest priority).
+        // This test verifies priority order: settings > HERMES_HOME > default.
+        //
+        // Note: We can only test this indirectly since get_hermes_override_dir()
+        // reads from the global settings store which is hard to mock in unit tests.
+        // The key assertion is that HERMES_HOME works when no override is set.
+        // The override > HERMES_HOME priority is enforced by the code ordering
+        // (override check comes first in get_hermes_dir()).
+        let _guard = test_guard();
+        let old = std::env::var_os("HERMES_HOME");
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+
+        std::env::remove_var("CC_SWITCH_TEST_HOME");
+        std::env::remove_var("HERMES_HOME");
+
+        // Without any override or HERMES_HOME, falls back to default
+        let dir = get_hermes_dir();
+        assert!(dir.ends_with(".hermes"));
+
+        match old {
+            Some(value) => std::env::set_var("HERMES_HOME", value),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
     }
 }


### PR DESCRIPTION
Fixes #3460, #3168, #3178

### Problem

On Windows, CC Switch hardcoded `~/.hermes` as the Hermes config directory, but Hermes itself defaults to `%LOCALAPPDATA%\hermes` (see [`_get_platform_default_hermes_home()`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_constants.py#L44-L52)). This caused CC Switch to write configs to the wrong location — changes made in CC Switch had no effect on Hermes.

### Solution

Extract a platform-aware `default_hermes_dir()` that matches Hermes' own path logic:

| Platform | Path |
|----------|------|
| Windows | `%LOCALAPPDATA%\hermes` (fallback: `%USERPROFILE%\AppData\Local\hermes`) |
| Mac/Linux | `~/.hermes` |

Priority: `settings.hermes_config_dir` > platform default.

### Alignment with CC Switch conventions

Codex (`get_codex_override_dir()`) and Claude (`get_claude_override_dir()`) also follow the "settings override > platform default" pattern without reading upstream env vars. This PR aligns Hermes with the same convention.

### Testing

Two new unit tests:

- `default_hermes_dir_without_override` — verifies platform-correct default path
- `settings_override_takes_precedence_over_default` — confirms override takes precedence
