### PR TITLE
fix(codex): preserve per-tool approval permissions across provider switch and MCP sync

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1518,6 +1518,10 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
 ///
 /// 最佳努力（best-effort）：旧文件不存在时按空 live 处理，读失败时返回
 /// `new_text` 的拷贝，绝不阻断底层写入。
+///
+/// 注意：read-then-write 不是原子的。若 Codex CLI 在本函数读取旧 live 之后、
+/// 底层 atomic 写入之前并发写入 `config.toml`，那次写入的 runtime 变更会被本次
+/// 覆盖丢失。对单用户桌面场景可接受，故不额外加锁。
 fn preserve_runtime_codex_mcp_state(new_text: &str) -> String {
     let live_path = get_codex_config_path();
     let old_text = if live_path.exists() {

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1516,18 +1516,22 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
 /// 运行时子表（典型为 `[mcp_servers.<id>.tools.<tool>]`），把它们合并进即将写入的
 /// 新文本。详细语义见 `mcp::codex::merge_codex_runtime_subtables`。
 ///
-/// 最佳努力（best-effort）：旧文件不存在时按空 live 处理，读失败时返回
-/// `new_text` 的拷贝，绝不阻断底层写入。
+/// 最佳努力（best-effort）：旧文件不存在时按空 live 处理，读失败时记 warning 并
+/// 返回 `new_text` 的拷贝（此时 runtime 子表无法抢救，等价于本保护引入前的行为），
+/// 绝不阻断底层写入。
 ///
 /// 注意：read-then-write 不是原子的。若 Codex CLI 在本函数读取旧 live 之后、
 /// 底层 atomic 写入之前并发写入 `config.toml`，那次写入的 runtime 变更会被本次
 /// 覆盖丢失。对单用户桌面场景可接受，故不额外加锁。
-fn preserve_runtime_codex_mcp_state(new_text: &str) -> String {
+pub(crate) fn preserve_runtime_codex_mcp_state(new_text: &str) -> String {
     let live_path = get_codex_config_path();
     let old_text = if live_path.exists() {
         match std::fs::read_to_string(&live_path) {
             Ok(text) => text,
-            Err(_) => return new_text.to_string(),
+            Err(err) => {
+                log::warn!("读取 Codex live 配置失败，本次写入无法保留 runtime 子表: {err}");
+                return new_text.to_string();
+            }
         }
     } else {
         String::new()
@@ -1560,8 +1564,12 @@ pub fn write_codex_live_for_provider(
     let config_text = unified_official_config.as_deref().or(config_text);
 
     // Layer 2：provider 驱动的 live 写入前，把旧 live 中 cc-switch 不管辖的 runtime
-    // 子表（典型 [mcp_servers.<id>.tools.<tool>]）合并进新文本。仅作用于 provider
-    // 写入路径；byte-for-byte restore 走裸 write_codex_live_atomic，不受影响。
+    // 子表（典型 [mcp_servers.<id>.tools.<tool>]）合并进新文本。下方 auth 路由的两个
+    // 分支都在合并之后写盘；接管期热切换绕开本函数的占位符分支在
+    // `ProxyService::write_codex_takeover_live_for_provider` 里做同一步合并。
+    // byte-for-byte restore 走裸 write_codex_live_atomic / write_codex_live_verbatim，
+    // 保持精确还原语义，不在写盘时合并——接管备份已在重建时合并过 runtime 子表
+    // （见 `ProxyService::update_live_backup_from_provider_inner`）。
     // 作用在 Layer 1 注入后的文本上，确保两层变换都落到最终写盘内容。
     let preserved = config_text.map(preserve_runtime_codex_mcp_state);
     let config_text = preserved.as_deref();

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1512,6 +1512,23 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
     Ok(())
 }
 
+/// 在 Codex live 写入之前从现有 `~/.codex/config.toml` 中抢救出 cc-switch 不知道的
+/// 运行时子表（典型为 `[mcp_servers.<id>.tools.<tool>]`），把它们合并进即将写入的
+/// 新文本。详细语义见 `mcp::codex::merge_codex_runtime_subtables`。
+///
+/// 最佳努力（best-effort）：旧文件不存在 / 读失败 / 没有可保留的子表时返回
+/// `new_text` 的拷贝，绝不阻断底层写入。
+fn preserve_runtime_codex_mcp_state(new_text: &str) -> String {
+    let live_path = get_codex_config_path();
+    if !live_path.exists() {
+        return new_text.to_string();
+    }
+    let Ok(old_text) = std::fs::read_to_string(&live_path) else {
+        return new_text.to_string();
+    };
+    crate::mcp::merge_codex_runtime_subtables(new_text, &old_text)
+}
+
 /// Route a Codex live write between full auth+config or config-only.
 ///
 /// Official providers with usable login material own `auth.json`. Third-party
@@ -1525,6 +1542,7 @@ pub fn write_codex_live_for_provider(
     auth: &Value,
     config_text: Option<&str>,
 ) -> Result<(), AppError> {
+    // Layer 1：统一会话开关开启时，官方配置在落盘前注入共享的 custom 路由。
     let unified_official_config =
         if category == Some("official") && crate::settings::unify_codex_session_history() {
             Some(inject_codex_unified_session_bucket(
@@ -1534,6 +1552,13 @@ pub fn write_codex_live_for_provider(
             None
         };
     let config_text = unified_official_config.as_deref().or(config_text);
+
+    // Layer 2：provider 驱动的 live 写入前，把旧 live 中 cc-switch 不管辖的 runtime
+    // 子表（典型 [mcp_servers.<id>.tools.<tool>]）合并进新文本。仅作用于 provider
+    // 写入路径；byte-for-byte restore 走裸 write_codex_live_atomic，不受影响。
+    // 作用在 Layer 1 注入后的文本上，确保两层变换都落到最终写盘内容。
+    let preserved = config_text.map(preserve_runtime_codex_mcp_state);
+    let config_text = preserved.as_deref();
 
     let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
         || (category != Some("official")

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1516,15 +1516,17 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
 /// 运行时子表（典型为 `[mcp_servers.<id>.tools.<tool>]`），把它们合并进即将写入的
 /// 新文本。详细语义见 `mcp::codex::merge_codex_runtime_subtables`。
 ///
-/// 最佳努力（best-effort）：旧文件不存在 / 读失败 / 没有可保留的子表时返回
+/// 最佳努力（best-effort）：旧文件不存在时按空 live 处理，读失败时返回
 /// `new_text` 的拷贝，绝不阻断底层写入。
 fn preserve_runtime_codex_mcp_state(new_text: &str) -> String {
     let live_path = get_codex_config_path();
-    if !live_path.exists() {
-        return new_text.to_string();
-    }
-    let Ok(old_text) = std::fs::read_to_string(&live_path) else {
-        return new_text.to_string();
+    let old_text = if live_path.exists() {
+        match std::fs::read_to_string(&live_path) {
+            Ok(text) => text,
+            Err(_) => return new_text.to_string(),
+        }
+    } else {
+        String::new()
     };
     crate::mcp::merge_codex_runtime_subtables(new_text, &old_text)
 }

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -272,27 +272,22 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
     Ok(changed_total)
 }
 
-/// 将 config.json 中 Codex 的 enabled==true 项以 TOML 形式写入 ~/.codex/config.toml
+/// 将 config.json 中 Codex 启用的项以 TOML 形式写入 ~/.codex/config.toml。
 ///
 /// 格式策略：
 /// - 唯一正确格式：[mcp_servers] 顶层表（Codex 官方标准）
 /// - 自动清理错误格式：[mcp.servers]（如果存在）
 /// - 读取现有 config.toml；若语法无效则报错，不尝试覆盖
-/// - 仅更新 `mcp_servers` 表，保留其它键
-/// - 仅写入启用项；无启用项时清理 mcp_servers 表
+/// - 重写每个 enabled server 的子表时保留其非 cc-switch 管辖的子表
+/// - 无启用项时清理 mcp_servers 表（pre-existing 行为）
 pub fn sync_enabled_to_codex(config: &MultiAppConfig) -> Result<(), AppError> {
     if !should_sync_codex_mcp() {
         return Ok(());
     }
-    use toml_edit::{Item, Table};
 
-    // 1) 收集启用项（Codex 维度）
     let enabled = collect_enabled_servers(&config.mcp.codex);
-
-    // 2) 读取现有 config.toml 文本；保持无效 TOML 的错误返回（不覆盖文件）
     let base_text = crate::codex_config::read_and_validate_codex_config_text()?;
 
-    // 3) 使用 toml_edit 解析（允许空文件）
     let mut doc = if base_text.trim().is_empty() {
         toml_edit::DocumentMut::default()
     } else {
@@ -301,50 +296,17 @@ pub fn sync_enabled_to_codex(config: &MultiAppConfig) -> Result<(), AppError> {
             .map_err(|e| AppError::McpValidation(format!("解析 config.toml 失败: {e}")))?
     };
 
-    // 4) 清理可能存在的错误格式 [mcp.servers]
-    if let Some(mcp_item) = doc.get_mut("mcp") {
-        if let Some(tbl) = mcp_item.as_table_like_mut() {
-            if tbl.contains_key("servers") {
-                log::warn!("检测到错误的 MCP 格式 [mcp.servers]，正在清理并迁移到 [mcp_servers]");
-                tbl.remove("servers");
-            }
-        }
-    }
+    apply_enabled_servers_to_doc(&mut doc, &enabled);
 
-    // 5) 构造目标 servers 表（稳定的键顺序）
-    if enabled.is_empty() {
-        // 无启用项：移除 mcp_servers 表
-        doc.as_table_mut().remove("mcp_servers");
-    } else {
-        // 构建 servers 表
-        let mut servers_tbl = Table::new();
-        let mut ids: Vec<_> = enabled.keys().cloned().collect();
-        ids.sort();
-        for id in ids {
-            let spec = enabled.get(&id).expect("spec must exist");
-            // 复用通用转换函数（已包含扩展字段支持）
-            match json_server_to_toml_table(spec) {
-                Ok(table) => {
-                    servers_tbl[&id[..]] = Item::Table(table);
-                }
-                Err(err) => {
-                    log::error!("跳过无效的 MCP 服务器 '{id}': {err}");
-                }
-            }
-        }
-        // 使用唯一正确的格式：[mcp_servers]
-        doc["mcp_servers"] = Item::Table(servers_tbl);
-    }
-
-    // 6) 写回（仅改 TOML，不触碰 auth.json）；toml_edit 会尽量保留未改区域的注释/空白/顺序
     let new_text = doc.to_string();
     let path = crate::codex_config::get_codex_config_path();
     crate::config::write_text_file(&path, &new_text)?;
     Ok(())
 }
 
-/// 将单个 MCP 服务器同步到 Codex live 配置
-/// 始终使用 Codex 官方格式 [mcp_servers]，并清理可能存在的错误格式 [mcp.servers]
+/// 将单个 MCP 服务器同步到 Codex live 配置。
+/// 始终使用 Codex 官方格式 [mcp_servers]，并清理可能存在的错误格式 [mcp.servers]。
+/// 重写 [mcp_servers.<id>] 时保留非 cc-switch 管辖的子表（典型为 Codex CLI 写入的 tools.*）。
 pub fn sync_single_server_to_codex(
     _config: &MultiAppConfig,
     id: &str,
@@ -353,9 +315,7 @@ pub fn sync_single_server_to_codex(
     if !should_sync_codex_mcp() {
         return Ok(());
     }
-    use toml_edit::Item;
 
-    // 读取现有的 config.toml
     let config_path = crate::codex_config::get_codex_config_path();
 
     let mut doc = if config_path.exists() {
@@ -370,28 +330,8 @@ pub fn sync_single_server_to_codex(
         toml_edit::DocumentMut::new()
     };
 
-    // 清理可能存在的错误格式 [mcp.servers]
-    if let Some(mcp_item) = doc.get_mut("mcp") {
-        if let Some(tbl) = mcp_item.as_table_like_mut() {
-            if tbl.contains_key("servers") {
-                log::warn!("检测到错误的 MCP 格式 [mcp.servers]，正在清理并迁移到 [mcp_servers]");
-                tbl.remove("servers");
-            }
-        }
-    }
+    apply_single_server_to_doc(&mut doc, id, server_spec)?;
 
-    // 确保 [mcp_servers] 表存在
-    if !doc.contains_key("mcp_servers") {
-        doc["mcp_servers"] = toml_edit::table();
-    }
-
-    // 将 JSON 服务器规范转换为 TOML 表
-    let toml_table = json_server_to_toml_table(server_spec)?;
-
-    // 使用唯一正确的格式：[mcp_servers]
-    doc["mcp_servers"][id] = Item::Table(toml_table);
-
-    // 写回文件
     let new_text = doc.to_string();
     crate::config::write_text_file(&config_path, &new_text)?;
 
@@ -674,4 +614,666 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
     }
 
     Ok(t)
+}
+
+/// `[mcp_servers.<id>]` 下 cc-switch 当前 / 曾经会写入为子表（toml_edit::Item::Table）的键名。
+/// 不在此列表里、但以子表形式存在的键（典型为 Codex CLI 运行时写入的
+/// `tools.<tool_name>` 权限声明）一律视为非 cc-switch 管辖，sync / live 写入时必须保留。
+///
+/// `"headers"` 是 compat 读取名：write 路径已切换到 `http_headers`，但 import
+/// 仍会读取旧文件里残留的 `headers`（见 `import_from_codex`），所以这里把它
+/// 视为受管，允许在重写时被清理，避免与新写入的 `http_headers` 共存。
+const CC_SWITCH_MANAGED_SUBTABLE_KEYS: &[&str] = &["env", "http_headers", "headers"];
+
+/// 抓取 `[mcp_servers.<server_id>]` 下所有非 cc-switch 管辖的子表，
+/// 用于在 sync 重写前快照、重写后再 restore。
+fn snapshot_unmanaged_subtables(
+    doc: &toml_edit::DocumentMut,
+    server_id: &str,
+) -> Vec<(String, toml_edit::Table)> {
+    let Some(server_tbl) = doc
+        .get("mcp_servers")
+        .and_then(|item| item.as_table())
+        .and_then(|t| t.get(server_id))
+        .and_then(|item| item.as_table())
+    else {
+        return Vec::new();
+    };
+
+    server_tbl
+        .iter()
+        .filter_map(|(k, v)| {
+            if CC_SWITCH_MANAGED_SUBTABLE_KEYS.contains(&k) {
+                return None;
+            }
+            v.as_table().map(|tbl| (k.to_string(), tbl.clone()))
+        })
+        .collect()
+}
+
+/// 把 snapshot_unmanaged_subtables 抓到的子表写回 `[mcp_servers.<server_id>]`。
+/// 在 sync 函数把 server 子表整体重写之后调用。
+fn restore_unmanaged_subtables(
+    doc: &mut toml_edit::DocumentMut,
+    server_id: &str,
+    preserved: Vec<(String, toml_edit::Table)>,
+) {
+    if preserved.is_empty() {
+        return;
+    }
+    let Some(server_tbl) = doc
+        .get_mut("mcp_servers")
+        .and_then(|item| item.as_table_mut())
+        .and_then(|t| t.get_mut(server_id))
+        .and_then(|item| item.as_table_mut())
+    else {
+        return;
+    };
+    for (k, tbl) in preserved {
+        server_tbl.insert(&k, toml_edit::Item::Table(tbl));
+    }
+}
+
+/// **Layer 2 纯函数**：把 `old_text` 中所有非 cc-switch 管辖的子表
+/// （典型为 Codex CLI 运行时写入的 `[mcp_servers.<id>.tools.<tool>]`）
+/// 合并进 `new_text`，返回合并后的 TOML 文本。
+///
+/// 用于 Codex live 写入边界：provider switch / common-config save 会用新 provider
+/// 的 stored config 整张覆盖 `~/.codex/config.toml`，但 stored config 不带 runtime
+/// 子表，本函数在写入前把旧 live 中的 runtime 子表抢救出来合并进去。
+///
+/// 语义：
+/// - "受管子表"（`CC_SWITCH_MANAGED_SUBTABLE_KEYS`）跳过——它们由 cc-switch 自己负责。
+/// - **逐子键深度合并**：旧 live 与新文本同时存在某子表（如 `tools`）时，按叶子键
+///   合并而非整体取舍——旧 `tools.search` 与新 `tools.read` 都保留；同名叶子键冲突
+///   时新文本优先（处理用户在 provider config 中显式改写 `tools.*` 的少见情况）。
+/// - **不为新文本中不存在的 server 凭空建父表**：新文本没有的 server 说明切换后的
+///   provider 配置不含它，且 provider 切换路径之后不会再跑 MCP sync 补全 command/url，
+///   建一个只有 `tools.*` 的残缺 server 会让 Codex 无法加载——这类孤儿 runtime 子表直接丢弃。
+/// - 解析失败 / 旧文件不可读 / 新旧任一方没有 `[mcp_servers]` 时退回原文本，
+///   best-effort 不阻塞底层写入。
+pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> String {
+    use toml_edit::DocumentMut;
+
+    let Ok(old_doc) = old_text.parse::<DocumentMut>() else {
+        return new_text.to_string();
+    };
+    let Some(old_mcp_servers) = old_doc
+        .get("mcp_servers")
+        .and_then(|item| item.as_table())
+    else {
+        return new_text.to_string();
+    };
+
+    // server_id, subtable_key, table
+    let mut preserved: Vec<(String, String, toml_edit::Table)> = Vec::new();
+    for (server_id, server_item) in old_mcp_servers.iter() {
+        let Some(server_tbl) = server_item.as_table() else {
+            continue;
+        };
+        for (k, v) in server_tbl.iter() {
+            if CC_SWITCH_MANAGED_SUBTABLE_KEYS.contains(&k) {
+                continue;
+            }
+            if let Some(tbl) = v.as_table() {
+                preserved.push((server_id.to_string(), k.to_string(), tbl.clone()));
+            }
+        }
+    }
+
+    if preserved.is_empty() {
+        return new_text.to_string();
+    }
+
+    let mut new_doc = if new_text.trim().is_empty() {
+        DocumentMut::default()
+    } else {
+        match new_text.parse::<DocumentMut>() {
+            Ok(doc) => doc,
+            Err(_) => return new_text.to_string(),
+        }
+    };
+
+    // P1：只把 runtime 子表回写到新文本中已存在的 server，不凭空创建残缺父表。
+    let Some(mcp_servers) = new_doc
+        .get_mut("mcp_servers")
+        .and_then(|item| item.as_table_mut())
+    else {
+        return new_text.to_string();
+    };
+
+    for (server_id, key, tbl) in preserved {
+        let Some(server_tbl) = mcp_servers
+            .get_mut(&server_id)
+            .and_then(|item| item.as_table_mut())
+        else {
+            continue;
+        };
+        // P2：逐子键合并——新文本已有同名子表（如 `tools`）时深度合并（新文本优先），
+        //     而非整体跳过，从而保住旧 live 中新文本未声明的 per-tool 授权。
+        match server_tbl.get_mut(&key) {
+            None => {
+                server_tbl.insert(&key, toml_edit::Item::Table(tbl));
+            }
+            Some(existing) => {
+                if let Some(existing_tbl) = existing.as_table_mut() {
+                    merge_table_preserving_new(existing_tbl, &tbl);
+                }
+            }
+        }
+    }
+
+    new_doc.to_string()
+}
+
+/// 深度合并：把 `old` 的键并入 `target`，target（新文本）已有的叶子键优先保留，
+/// 仅补齐缺失键；两边同名且皆为子表时递归合并。用于在 `tools` 等子表层面做到
+/// 逐工具粒度的保留。
+fn merge_table_preserving_new(target: &mut toml_edit::Table, old: &toml_edit::Table) {
+    for (k, v) in old.iter() {
+        match target.get_mut(k) {
+            None => {
+                target.insert(k, v.clone());
+            }
+            Some(existing) => {
+                if let (Some(existing_tbl), Some(old_tbl)) =
+                    (existing.as_table_mut(), v.as_table())
+                {
+                    merge_table_preserving_new(existing_tbl, old_tbl);
+                }
+            }
+        }
+    }
+}
+
+/// 纯逻辑：把单个 server 的 spec 应用到 DocumentMut，保留非 cc-switch 管辖的子表。
+/// `sync_single_server_to_codex` 的可单测内核。
+fn apply_single_server_to_doc(
+    doc: &mut toml_edit::DocumentMut,
+    id: &str,
+    server_spec: &Value,
+) -> Result<(), AppError> {
+    use toml_edit::Item;
+
+    let preserved = snapshot_unmanaged_subtables(doc, id);
+
+    // 清理可能存在的错误格式 [mcp.servers]
+    if let Some(mcp_item) = doc.get_mut("mcp") {
+        if let Some(tbl) = mcp_item.as_table_like_mut() {
+            if tbl.contains_key("servers") {
+                log::warn!("检测到错误的 MCP 格式 [mcp.servers]，正在清理并迁移到 [mcp_servers]");
+                tbl.remove("servers");
+            }
+        }
+    }
+
+    if !doc.contains_key("mcp_servers") {
+        doc["mcp_servers"] = toml_edit::table();
+    }
+
+    let toml_table = json_server_to_toml_table(server_spec)?;
+    doc["mcp_servers"][id] = Item::Table(toml_table);
+
+    restore_unmanaged_subtables(doc, id, preserved);
+
+    Ok(())
+}
+
+/// 纯逻辑：把 enabled servers 批量应用到 DocumentMut，保留 enabled server 自己的非托管子表。
+/// 未在 enabled 中的 server 沿用原有"整体抹除"行为（pre-existing），本 PR 不调整这一语义。
+/// `sync_enabled_to_codex` 的可单测内核。
+fn apply_enabled_servers_to_doc(
+    doc: &mut toml_edit::DocumentMut,
+    enabled: &HashMap<String, Value>,
+) {
+    use toml_edit::{Item, Table};
+
+    // 仅为 enabled 中的 server 快照非托管子表
+    let preserved_per_server: HashMap<String, Vec<(String, toml_edit::Table)>> = enabled
+        .keys()
+        .filter_map(|id| {
+            let preserved = snapshot_unmanaged_subtables(doc, id);
+            (!preserved.is_empty()).then(|| (id.clone(), preserved))
+        })
+        .collect();
+
+    // 清理可能存在的错误格式 [mcp.servers]
+    if let Some(mcp_item) = doc.get_mut("mcp") {
+        if let Some(tbl) = mcp_item.as_table_like_mut() {
+            if tbl.contains_key("servers") {
+                log::warn!("检测到错误的 MCP 格式 [mcp.servers]，正在清理并迁移到 [mcp_servers]");
+                tbl.remove("servers");
+            }
+        }
+    }
+
+    if enabled.is_empty() {
+        // pre-existing behavior：无 enabled 时整体移除 [mcp_servers]。
+        // preserved_per_server 在此分支必为空。
+        doc.as_table_mut().remove("mcp_servers");
+        return;
+    }
+
+    let mut servers_tbl = Table::new();
+    let mut ids: Vec<_> = enabled.keys().cloned().collect();
+    ids.sort();
+    for id in ids {
+        let spec = enabled.get(&id).expect("spec must exist");
+        match json_server_to_toml_table(spec) {
+            Ok(table) => {
+                servers_tbl[&id[..]] = Item::Table(table);
+            }
+            Err(err) => {
+                log::error!("跳过无效的 MCP 服务器 '{id}': {err}");
+            }
+        }
+    }
+    doc["mcp_servers"] = Item::Table(servers_tbl);
+
+    for (server_id, preserved) in preserved_per_server {
+        restore_unmanaged_subtables(doc, &server_id, preserved);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use toml_edit::DocumentMut;
+
+    fn parse(text: &str) -> DocumentMut {
+        text.parse::<DocumentMut>().expect("valid toml")
+    }
+
+    fn parse_value(doc: &DocumentMut) -> toml::Value {
+        toml::from_str(&doc.to_string()).expect("valid toml round-trip")
+    }
+
+    #[test]
+    fn sync_single_preserves_tools_permission_subtable() {
+        let mut doc = parse(
+            r#"
+[mcp_servers.ace-tool-rs]
+type = "stdio"
+command = "old-cmd"
+
+[mcp_servers.ace-tool-rs.tools.search_context]
+approval_mode = "approve"
+"#,
+        );
+
+        let new_spec = json!({
+            "type": "stdio",
+            "command": "new-cmd",
+            "args": ["--foo"]
+        });
+
+        apply_single_server_to_doc(&mut doc, "ace-tool-rs", &new_spec).unwrap();
+        let v = parse_value(&doc);
+
+        // 管辖字段已覆盖
+        assert_eq!(
+            v["mcp_servers"]["ace-tool-rs"]["command"].as_str(),
+            Some("new-cmd")
+        );
+        let args = v["mcp_servers"]["ace-tool-rs"]["args"]
+            .as_array()
+            .expect("args is array");
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_str(), Some("--foo"));
+
+        // 非托管子表必须保留
+        assert_eq!(
+            v["mcp_servers"]["ace-tool-rs"]["tools"]["search_context"]["approval_mode"].as_str(),
+            Some("approve"),
+            "Codex CLI 运行时写入的 tools.* 权限必须在 sync 后保留"
+        );
+    }
+
+    #[test]
+    fn sync_single_overwrites_managed_env_subtable() {
+        // env 是 cc-switch 管辖的子表——spec 中没有 env 时，旧 env 必须被清掉
+        let mut doc = parse(
+            r#"
+[mcp_servers.x]
+type = "stdio"
+command = "old"
+
+[mcp_servers.x.env]
+OLD_VAR = "1"
+"#,
+        );
+
+        let new_spec = json!({
+            "type": "stdio",
+            "command": "new"
+        });
+
+        apply_single_server_to_doc(&mut doc, "x", &new_spec).unwrap();
+        let v = parse_value(&doc);
+
+        assert_eq!(v["mcp_servers"]["x"]["command"].as_str(), Some("new"));
+        assert!(
+            v.get("mcp_servers")
+                .and_then(|m| m.get("x"))
+                .and_then(|x| x.get("env"))
+                .is_none(),
+            "env 是 cc-switch 管辖子表，spec 无 env 时必须清除"
+        );
+    }
+
+    #[test]
+    fn sync_single_overwrites_managed_http_headers_subtable() {
+        // http_headers 同样是 cc-switch 管辖的子表
+        let mut doc = parse(
+            r#"
+[mcp_servers.h]
+type = "http"
+url = "https://old.example/"
+
+[mcp_servers.h.http_headers]
+X-Old = "1"
+"#,
+        );
+
+        let new_spec = json!({
+            "type": "http",
+            "url": "https://new.example/",
+            "headers": { "X-New": "2" }
+        });
+
+        apply_single_server_to_doc(&mut doc, "h", &new_spec).unwrap();
+        let v = parse_value(&doc);
+
+        assert_eq!(
+            v["mcp_servers"]["h"]["url"].as_str(),
+            Some("https://new.example/")
+        );
+        assert_eq!(
+            v["mcp_servers"]["h"]["http_headers"]["X-New"].as_str(),
+            Some("2")
+        );
+        assert!(
+            v["mcp_servers"]["h"]["http_headers"]
+                .as_table()
+                .map(|t| !t.contains_key("X-Old"))
+                .unwrap_or(false),
+            "旧 header 应被新 spec 覆盖"
+        );
+    }
+
+    #[test]
+    fn sync_enabled_preserves_tools_for_enabled_server() {
+        let mut doc = parse(
+            r#"
+[mcp_servers.x]
+type = "stdio"
+command = "old"
+
+[mcp_servers.x.tools.t1]
+approval_mode = "deny"
+"#,
+        );
+
+        let mut enabled = HashMap::new();
+        enabled.insert(
+            "x".to_string(),
+            json!({
+                "type": "stdio",
+                "command": "new"
+            }),
+        );
+
+        apply_enabled_servers_to_doc(&mut doc, &enabled);
+        let v = parse_value(&doc);
+
+        assert_eq!(v["mcp_servers"]["x"]["command"].as_str(), Some("new"));
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["t1"]["approval_mode"].as_str(),
+            Some("deny"),
+            "enabled server 的 tools.* 必须保留"
+        );
+    }
+
+    #[test]
+    fn sync_enabled_drops_mcp_servers_when_empty() {
+        let mut doc = parse(
+            r#"
+[mcp_servers.x]
+type = "stdio"
+command = "x"
+
+[mcp_servers.x.tools.t1]
+approval_mode = "approve"
+"#,
+        );
+
+        let enabled: HashMap<String, Value> = HashMap::new();
+        apply_enabled_servers_to_doc(&mut doc, &enabled);
+
+        let text = doc.to_string();
+        assert!(
+            !text.contains("mcp_servers"),
+            "enabled 为空时整体移除 [mcp_servers]（pre-existing 行为）"
+        );
+    }
+
+    #[test]
+    fn sync_enabled_drops_unmentioned_server_including_its_tools() {
+        // 不在 enabled 中的 server 沿用原有"整体移除"行为
+        let mut doc = parse(
+            r#"
+[mcp_servers.x]
+type = "stdio"
+command = "x"
+
+[mcp_servers.x.tools.t1]
+approval_mode = "approve"
+
+[mcp_servers.y]
+type = "stdio"
+command = "y"
+"#,
+        );
+
+        let mut enabled = HashMap::new();
+        enabled.insert(
+            "y".to_string(),
+            json!({ "type": "stdio", "command": "y2" }),
+        );
+
+        apply_enabled_servers_to_doc(&mut doc, &enabled);
+        let v = parse_value(&doc);
+
+        assert!(
+            v.get("mcp_servers")
+                .and_then(|m| m.get("x"))
+                .is_none(),
+            "未在 enabled 中的 server 应被整体移除（pre-existing 行为）"
+        );
+        assert_eq!(v["mcp_servers"]["y"]["command"].as_str(), Some("y2"));
+    }
+
+    #[test]
+    fn sync_single_handles_empty_doc() {
+        let mut doc = DocumentMut::new();
+        let spec = json!({ "type": "stdio", "command": "c" });
+        apply_single_server_to_doc(&mut doc, "x", &spec).unwrap();
+        let v = parse_value(&doc);
+        assert_eq!(v["mcp_servers"]["x"]["command"].as_str(), Some("c"));
+    }
+
+    // ====== Layer 2: merge_codex_runtime_subtables ======
+
+    #[test]
+    fn merge_runtime_preserves_tools_when_new_text_has_server_without_tools() {
+        // 主复现路径：tools.* 由 Codex CLI 在 provider 保存之后才追加，所以切换回来的
+        // provider stored config 带 [mcp_servers.ace-tool-rs]（含 command）但不含 tools.*。
+        let old = r#"
+model_provider = "openai"
+
+[mcp_servers.ace-tool-rs]
+type = "stdio"
+command = "ace"
+
+[mcp_servers.ace-tool-rs.tools.search_context]
+approval_mode = "approve"
+"#;
+        let new = r#"
+model_provider = "anthropic"
+
+[mcp_servers.ace-tool-rs]
+type = "stdio"
+command = "ace"
+"#;
+        let merged = merge_codex_runtime_subtables(new, old);
+        let v: toml::Value = toml::from_str(&merged).expect("merged is valid toml");
+
+        // 新文本的字段保留
+        assert_eq!(v["model_provider"].as_str(), Some("anthropic"));
+        assert_eq!(v["mcp_servers"]["ace-tool-rs"]["command"].as_str(), Some("ace"));
+        // 旧 tools.* 必须保留
+        assert_eq!(
+            v["mcp_servers"]["ace-tool-rs"]["tools"]["search_context"]["approval_mode"].as_str(),
+            Some("approve"),
+            "Layer 2 必须把 Codex CLI runtime 写入的 tools.* 从旧 live 抢救到新文本"
+        );
+    }
+
+    #[test]
+    fn merge_runtime_skips_managed_subtables() {
+        // env / http_headers / headers 是受管子表，不应被 Layer 2 保留
+        let old = r#"
+[mcp_servers.x]
+command = "old"
+
+[mcp_servers.x.env]
+OLD = "1"
+
+[mcp_servers.x.http_headers]
+X-Old = "1"
+
+[mcp_servers.x.headers]
+X-Compat = "1"
+
+[mcp_servers.x.tools.t1]
+approval_mode = "approve"
+"#;
+        let new = r#"
+[mcp_servers.x]
+command = "new"
+"#;
+        let merged = merge_codex_runtime_subtables(new, old);
+        let v: toml::Value = toml::from_str(&merged).expect("merged is valid toml");
+
+        assert_eq!(v["mcp_servers"]["x"]["command"].as_str(), Some("new"));
+        // 受管子表都不应该被保留进来
+        assert!(v["mcp_servers"]["x"].get("env").is_none(), "env 受管，不应被 Layer 2 保留");
+        assert!(
+            v["mcp_servers"]["x"].get("http_headers").is_none(),
+            "http_headers 受管，不应被 Layer 2 保留"
+        );
+        assert!(
+            v["mcp_servers"]["x"].get("headers").is_none(),
+            "compat headers 受管，不应被 Layer 2 保留"
+        );
+        // 未知子表必须保留
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["t1"]["approval_mode"].as_str(),
+            Some("approve"),
+        );
+    }
+
+    #[test]
+    fn merge_runtime_new_wins_when_key_collides() {
+        // 用户在 provider config 中显式声明了 tools.*——新文本优先
+        let old = r#"
+[mcp_servers.x.tools.t1]
+approval_mode = "approve"
+"#;
+        let new = r#"
+[mcp_servers.x.tools.t1]
+approval_mode = "deny"
+"#;
+        let merged = merge_codex_runtime_subtables(new, old);
+        let v: toml::Value = toml::from_str(&merged).expect("merged is valid toml");
+
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["t1"]["approval_mode"].as_str(),
+            Some("deny"),
+            "新文本显式声明同名子表时应保留新值"
+        );
+    }
+
+    #[test]
+    fn merge_runtime_returns_unchanged_when_old_has_no_mcp_servers() {
+        let old = r#"model_provider = "openai""#;
+        let new = r#"model_provider = "anthropic""#;
+        let merged = merge_codex_runtime_subtables(new, old);
+        // best-effort：原样返回新文本（不要求字符串完全相等，只要语义等价）
+        let v: toml::Value = toml::from_str(&merged).unwrap();
+        assert_eq!(v["model_provider"].as_str(), Some("anthropic"));
+        assert!(v.get("mcp_servers").is_none());
+    }
+
+    #[test]
+    fn merge_runtime_returns_unchanged_when_old_unparseable() {
+        let old = "this is :: not toml";
+        let new = r#"model_provider = "anthropic""#;
+        let merged = merge_codex_runtime_subtables(new, old);
+        assert_eq!(merged, new, "旧文本无法解析时退回原新文本，不应阻断写入");
+    }
+
+    #[test]
+    fn merge_runtime_merges_tools_per_tool_not_per_parent() {
+        // P2：旧 live 有 tools.search、新文本（用户在 provider config 里）声明了 tools.read，
+        // 两者无键冲突，必须都保留——不能因为新文本已有 `tools` 父表就整体跳过旧表。
+        let old = r#"
+[mcp_servers.x]
+command = "x"
+
+[mcp_servers.x.tools.search]
+approval_mode = "approve"
+"#;
+        let new = r#"
+[mcp_servers.x]
+command = "x"
+
+[mcp_servers.x.tools.read]
+approval_mode = "approve"
+"#;
+        let merged = merge_codex_runtime_subtables(new, old);
+        let v: toml::Value = toml::from_str(&merged).expect("merged is valid toml");
+
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["search"]["approval_mode"].as_str(),
+            Some("approve"),
+            "新文本声明了其它工具时，旧 live 的 per-tool 授权仍须逐工具保留"
+        );
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["read"]["approval_mode"].as_str(),
+            Some("approve"),
+            "新文本声明的工具同样保留"
+        );
+    }
+
+    #[test]
+    fn merge_runtime_drops_orphan_tools_when_new_lacks_server() {
+        // P1：新文本里没有该 server（切换后的 provider 不含它，且之后不会再跑 MCP sync）。
+        // 不能为了塞 tools.* 而凭空建一个没有 command/url 的残缺 server——Codex 无法加载它。
+        let old = r#"
+[mcp_servers.x.tools.t1]
+approval_mode = "approve"
+"#;
+        let new = r#"
+model_provider = "anthropic"
+"#;
+        let merged = merge_codex_runtime_subtables(new, old);
+        let v: toml::Value = toml::from_str(&merged).expect("merged is valid toml");
+        assert_eq!(v["model_provider"].as_str(), Some("anthropic"));
+        assert!(
+            v.get("mcp_servers").is_none(),
+            "新文本不含该 server 时，不得为孤儿 tools.* 创建残缺父表"
+        );
+    }
 }

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -670,7 +670,14 @@ fn restore_unmanaged_subtables(
         return;
     };
     for (k, tbl) in preserved {
-        server_tbl.insert(&k, toml_edit::Item::Table(tbl));
+        match server_tbl.get_mut(&k).and_then(|item| item.as_table_mut()) {
+            Some(existing_tbl) => {
+                merge_table_preserving_old(existing_tbl, &tbl);
+            }
+            None => {
+                server_tbl.insert(&k, toml_edit::Item::Table(tbl));
+            }
+        }
     }
 }
 
@@ -685,8 +692,8 @@ fn restore_unmanaged_subtables(
 /// 语义：
 /// - "受管子表"（`CC_SWITCH_MANAGED_SUBTABLE_KEYS`）跳过——它们由 cc-switch 自己负责。
 /// - **逐子键深度合并**：旧 live 与新文本同时存在某子表（如 `tools`）时，按叶子键
-///   合并而非整体取舍——旧 `tools.search` 与新 `tools.read` 都保留；同名叶子键冲突
-///   时新文本优先（处理用户在 provider config 中显式改写 `tools.*` 的少见情况）。
+///   合并而非整体取舍——旧 `tools.search` 与新 `tools.read` 都保留；同名叶子键冲突时
+///   旧 live 优先，避免 provider 中被 backfill 的 stale runtime 副本覆盖 Codex CLI 最新权限。
 /// - **不为新文本中不存在的 server 凭空建父表**：新文本没有的 server 说明切换后的
 ///   provider 配置不含它，且 provider 切换路径之后不会再跑 MCP sync 补全 command/url，
 ///   建一个只有 `tools.*` 的残缺 server 会让 Codex 无法加载——这类孤儿 runtime 子表直接丢弃。
@@ -698,10 +705,7 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
     let Ok(old_doc) = old_text.parse::<DocumentMut>() else {
         return new_text.to_string();
     };
-    let Some(old_mcp_servers) = old_doc
-        .get("mcp_servers")
-        .and_then(|item| item.as_table())
-    else {
+    let Some(old_mcp_servers) = old_doc.get("mcp_servers").and_then(|item| item.as_table()) else {
         return new_text.to_string();
     };
 
@@ -749,16 +753,17 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
         else {
             continue;
         };
-        // P2：逐子键合并——新文本已有同名子表（如 `tools`）时深度合并（新文本优先），
-        //     而非整体跳过，从而保住旧 live 中新文本未声明的 per-tool 授权。
-        match server_tbl.get_mut(&key) {
+        // P2：逐子键合并——新文本已有同名子表（如 `tools`）时深度合并（旧 live 优先），
+        //     而非整体跳过，从而保住 Codex CLI 最新写入的 per-tool 授权。
+        match server_tbl
+            .get_mut(&key)
+            .and_then(|item| item.as_table_mut())
+        {
+            Some(existing_tbl) => {
+                merge_table_preserving_old(existing_tbl, &tbl);
+            }
             None => {
                 server_tbl.insert(&key, toml_edit::Item::Table(tbl));
-            }
-            Some(existing) => {
-                if let Some(existing_tbl) = existing.as_table_mut() {
-                    merge_table_preserving_new(existing_tbl, &tbl);
-                }
             }
         }
     }
@@ -766,20 +771,20 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
     new_doc.to_string()
 }
 
-/// 深度合并：把 `old` 的键并入 `target`，target（新文本）已有的叶子键优先保留，
-/// 仅补齐缺失键；两边同名且皆为子表时递归合并。用于在 `tools` 等子表层面做到
-/// 逐工具粒度的保留。
-fn merge_table_preserving_new(target: &mut toml_edit::Table, old: &toml_edit::Table) {
+/// 深度合并：把 `old` 的键并入 `target`，同名叶子键以 `old`（旧 live/runtime）优先；
+/// 两边同名且皆为子表时递归合并。用于在 `tools` 等子表层面做到逐工具粒度的保留。
+fn merge_table_preserving_old(target: &mut toml_edit::Table, old: &toml_edit::Table) {
     for (k, v) in old.iter() {
         match target.get_mut(k) {
             None => {
                 target.insert(k, v.clone());
             }
             Some(existing) => {
-                if let (Some(existing_tbl), Some(old_tbl)) =
-                    (existing.as_table_mut(), v.as_table())
+                if let (Some(existing_tbl), Some(old_tbl)) = (existing.as_table_mut(), v.as_table())
                 {
-                    merge_table_preserving_new(existing_tbl, old_tbl);
+                    merge_table_preserving_old(existing_tbl, old_tbl);
+                } else {
+                    *existing = v.clone();
                 }
             }
         }
@@ -1077,18 +1082,13 @@ command = "y"
         );
 
         let mut enabled = HashMap::new();
-        enabled.insert(
-            "y".to_string(),
-            json!({ "type": "stdio", "command": "y2" }),
-        );
+        enabled.insert("y".to_string(), json!({ "type": "stdio", "command": "y2" }));
 
         apply_enabled_servers_to_doc(&mut doc, &enabled);
         let v = parse_value(&doc);
 
         assert!(
-            v.get("mcp_servers")
-                .and_then(|m| m.get("x"))
-                .is_none(),
+            v.get("mcp_servers").and_then(|m| m.get("x")).is_none(),
             "未在 enabled 中的 server 应被整体移除（pre-existing 行为）"
         );
         assert_eq!(v["mcp_servers"]["y"]["command"].as_str(), Some("y2"));
@@ -1131,7 +1131,10 @@ command = "ace"
 
         // 新文本的字段保留
         assert_eq!(v["model_provider"].as_str(), Some("anthropic"));
-        assert_eq!(v["mcp_servers"]["ace-tool-rs"]["command"].as_str(), Some("ace"));
+        assert_eq!(
+            v["mcp_servers"]["ace-tool-rs"]["command"].as_str(),
+            Some("ace")
+        );
         // 旧 tools.* 必须保留
         assert_eq!(
             v["mcp_servers"]["ace-tool-rs"]["tools"]["search_context"]["approval_mode"].as_str(),
@@ -1168,7 +1171,10 @@ command = "new"
 
         assert_eq!(v["mcp_servers"]["x"]["command"].as_str(), Some("new"));
         // 受管子表都不应该被保留进来
-        assert!(v["mcp_servers"]["x"].get("env").is_none(), "env 受管，不应被 Layer 2 保留");
+        assert!(
+            v["mcp_servers"]["x"].get("env").is_none(),
+            "env 受管，不应被 Layer 2 保留"
+        );
         assert!(
             v["mcp_servers"]["x"].get("http_headers").is_none(),
             "http_headers 受管，不应被 Layer 2 保留"
@@ -1185,8 +1191,9 @@ command = "new"
     }
 
     #[test]
-    fn merge_runtime_new_wins_when_key_collides() {
-        // 用户在 provider config 中显式声明了 tools.*——新文本优先
+    fn merge_runtime_live_wins_when_key_collides() {
+        // provider config 可能是之前从 live backfill 的 stale runtime 副本；
+        // 发生冲突时应保留当前 live 中 Codex CLI 最新写入的权限。
         let old = r#"
 [mcp_servers.x.tools.t1]
 approval_mode = "approve"
@@ -1200,8 +1207,8 @@ approval_mode = "deny"
 
         assert_eq!(
             v["mcp_servers"]["x"]["tools"]["t1"]["approval_mode"].as_str(),
-            Some("deny"),
-            "新文本显式声明同名子表时应保留新值"
+            Some("approve"),
+            "同名 runtime 子表冲突时应保留旧 live 中的最新权限"
         );
     }
 

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -651,6 +651,10 @@ fn snapshot_unmanaged_subtables(
         .collect()
 }
 
+/// 分类只认标准子表（`v.as_table()`）。Codex CLI 始终以
+/// `[mcp_servers.<id>.tools.<tool>]` 标准表写入 runtime 权限，所以这个判定足够。
+/// 内联表形式（`tools = { ... }`）不在覆盖范围：遇到时既不剥离也不保留，按原样
+/// 透传——`snapshot_unmanaged_subtables` 与 Layer 2 的 new/old 遍历同此约定。
 fn remove_unmanaged_subtables(server_tbl: &mut toml_edit::Table) -> bool {
     let keys: Vec<String> = server_tbl
         .iter()
@@ -683,15 +687,13 @@ fn restore_unmanaged_subtables(
     else {
         return;
     };
+    // 调用方此前已用 json spec 把该 server 子表整张重写。`json_server_to_toml_table`
+    // 写出的标准子表（Item::Table）只有受管的 env/http_headers；其余未知对象字段一律
+    // 渲染为内联表（Item::Value），而快照只收集标准子表（`v.as_table()`）。因此快照里的
+    // 非管辖子表绝不会与重写结果中的同名标准子表冲突，整表写入即可。语义与 Layer 2
+    // `merge_codex_runtime_subtables` 的恢复步骤一致：旧 live 是 runtime 子表的唯一权威。
     for (k, tbl) in preserved {
-        match server_tbl.get_mut(&k).and_then(|item| item.as_table_mut()) {
-            Some(existing_tbl) => {
-                merge_table_preserving_old(existing_tbl, &tbl);
-            }
-            None => {
-                server_tbl.insert(&k, toml_edit::Item::Table(tbl));
-            }
-        }
+        server_tbl.insert(&k, toml_edit::Item::Table(tbl));
     }
 }
 
@@ -710,7 +712,9 @@ fn restore_unmanaged_subtables(
 ///   恢复时整表写入旧 live 的子表——new 侧同名子表已在上一步清空，旧 live 即唯一
 ///   权威，从而避免 provider 中被 backfill 的 stale runtime 副本覆盖 Codex CLI 最新权限。
 /// - **不为新文本中不存在的 server 凭空建父表**：新文本没有的 server 说明切换后的
-///   provider 配置不含它，且 provider 切换路径之后不会再跑 MCP sync 补全 command/url，
+///   provider 配置不含它。切换后确实仍会跑 MCP sync（`McpService::sync_all_enabled`
+///   → `sync_single_server_to_codex`），但它只为 cc-switch enabled 列表中的 server
+///   补全 command/url；新文本不含的 server 同样不在该列表，sync 不会重建它。为它
 ///   建一个只有 `tools.*` 的残缺 server 会让 Codex 无法加载——这类孤儿 runtime 子表直接丢弃。
 /// - 解析失败 / 旧文件不可读时退回原文本；新文本没有 `[mcp_servers]` 时不创建父表，
 ///   best-effort 不阻塞底层写入。
@@ -789,9 +793,12 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
 /// 剥离 `[mcp_servers.<id>]` 下所有非 cc-switch 管辖的子表（典型为 Codex CLI
 /// 运行时写入的 `tools.*`），返回处理后的 TOML 文本。
 ///
-/// 用于 backfill 边界：provider switch 后会把 live config 文本回填进 provider 的
-/// stored config，但 cc-switch 数据库不应持有 Codex runtime 状态。先剥离再回填，
-/// 可确保 stored config 不会种下 stale `tools.*`——live 才是 runtime 子表的唯一权威。
+/// 用于 backfill 边界（两个入口都接：`ConfigService::sync_codex_live` 的
+/// common-config save，以及 `ProviderService::switch_provider` 经
+/// `restore_live_settings_for_provider_backfill` 的 provider 切换）：回填会把
+/// live config 文本写进 provider 的 stored config，但 cc-switch 数据库不应持有
+/// Codex runtime 状态。先剥离再回填，可确保 stored config 不会种下 stale
+/// `tools.*`——live 才是 runtime 子表的唯一权威。
 ///
 /// 受管子表（`CC_SWITCH_MANAGED_SUBTABLE_KEYS`，即 `env`/`http_headers`/`headers`）保留。
 /// 空文本 / 解析失败 / 无 `[mcp_servers]` 时原样返回，best-effort 不阻塞回填。
@@ -824,26 +831,6 @@ pub(crate) fn strip_codex_runtime_subtables(config_text: &str) -> String {
         doc.to_string()
     } else {
         config_text.to_string()
-    }
-}
-
-/// 深度合并：把 `old` 的键并入 `target`，同名叶子键以 `old`（旧 live/runtime）优先；
-/// 两边同名且皆为子表时递归合并。用于在 `tools` 等子表层面做到逐工具粒度的保留。
-fn merge_table_preserving_old(target: &mut toml_edit::Table, old: &toml_edit::Table) {
-    for (k, v) in old.iter() {
-        match target.get_mut(k) {
-            None => {
-                target.insert(k, v.clone());
-            }
-            Some(existing) => {
-                if let (Some(existing_tbl), Some(old_tbl)) = (existing.as_table_mut(), v.as_table())
-                {
-                    merge_table_preserving_old(existing_tbl, old_tbl);
-                } else {
-                    *existing = v.clone();
-                }
-            }
-        }
     }
 }
 
@@ -1394,6 +1381,86 @@ approval_mode = "approve"
         assert!(
             server.get("tools").is_none(),
             "backfill 写回 provider 存储前应剥离 Codex runtime tools.*"
+        );
+    }
+
+    #[test]
+    fn merge_runtime_handles_multiple_servers_and_drops_orphan() {
+        // 一次 merge 覆盖多 server：live 权威保留、清掉 new 侧 stale、恢复缺失子表、
+        // 丢弃新文本不含的孤儿 server。
+        let old = r#"
+[mcp_servers.x]
+command = "x"
+
+[mcp_servers.x.tools.search]
+approval_mode = "approve"
+
+[mcp_servers.y]
+command = "y"
+
+[mcp_servers.y.tools.read]
+approval_mode = "approve"
+
+[mcp_servers.z.tools.gone]
+approval_mode = "approve"
+"#;
+        let new = r#"
+[mcp_servers.x]
+command = "x"
+
+[mcp_servers.x.tools.stale]
+approval_mode = "approve"
+
+[mcp_servers.y]
+command = "y"
+"#;
+        let merged = merge_codex_runtime_subtables(new, old);
+        let v: toml::Value = toml::from_str(&merged).expect("merged is valid toml");
+
+        // x：以 old live 为权威保留 search，清掉 new 侧 stale
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["search"]["approval_mode"].as_str(),
+            Some("approve")
+        );
+        assert!(
+            v["mcp_servers"]["x"]["tools"].get("stale").is_none(),
+            "new 侧 stale tool 应被清除"
+        );
+        // y：从 old live 恢复 read（new 侧本无 tools）
+        assert_eq!(
+            v["mcp_servers"]["y"]["tools"]["read"]["approval_mode"].as_str(),
+            Some("approve")
+        );
+        // z：新文本不含该 server，孤儿 runtime 子表整体丢弃
+        assert!(
+            v["mcp_servers"].get("z").is_none(),
+            "新文本不含的 server 不得为其孤儿 tools.* 建残缺父表"
+        );
+    }
+
+    #[test]
+    fn merge_runtime_returns_new_verbatim_when_nothing_to_change() {
+        // old/new 都没有非管辖 runtime 子表 → changed=false，原样返回 new，不 reserialize。
+        let old = r#"
+[mcp_servers.x]
+command = "x"
+"#;
+        let new = "model_provider = \"anthropic\"\n\n[mcp_servers.x]\ncommand = \"x\"\n";
+        let merged = merge_codex_runtime_subtables(new, old);
+        assert_eq!(
+            merged, new,
+            "无 runtime 子表可处理时应原样返回新文本，不引入无谓 reformat"
+        );
+    }
+
+    #[test]
+    fn strip_runtime_returns_verbatim_when_no_runtime_subtables() {
+        // 只有受管子表（env）时 changed=false，应原样返回，不 reformat。
+        let config = "[mcp_servers.x]\ncommand = \"x\"\n\n[mcp_servers.x.env]\nTOKEN = \"1\"\n";
+        let stripped = strip_codex_runtime_subtables(config);
+        assert_eq!(
+            stripped, config,
+            "只有受管子表时应原样返回，不引入无谓 reformat"
         );
     }
 }

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -625,21 +625,8 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
 /// 视为受管，允许在重写时被清理，避免与新写入的 `http_headers` 共存。
 const CC_SWITCH_MANAGED_SUBTABLE_KEYS: &[&str] = &["env", "http_headers", "headers"];
 
-/// 抓取 `[mcp_servers.<server_id>]` 下所有非 cc-switch 管辖的子表，
-/// 用于在 sync 重写前快照、重写后再 restore。
-fn snapshot_unmanaged_subtables(
-    doc: &toml_edit::DocumentMut,
-    server_id: &str,
-) -> Vec<(String, toml_edit::Table)> {
-    let Some(server_tbl) = doc
-        .get("mcp_servers")
-        .and_then(|item| item.as_table())
-        .and_then(|t| t.get(server_id))
-        .and_then(|item| item.as_table())
-    else {
-        return Vec::new();
-    };
-
+/// 列出单个 server 表下所有非 cc-switch 管辖的子表（克隆返回）。
+fn unmanaged_subtables_of(server_tbl: &toml_edit::Table) -> Vec<(String, toml_edit::Table)> {
     server_tbl
         .iter()
         .filter_map(|(k, v)| {
@@ -651,10 +638,26 @@ fn snapshot_unmanaged_subtables(
         .collect()
 }
 
+/// 抓取 `[mcp_servers.<server_id>]` 下所有非 cc-switch 管辖的子表，
+/// 用于在 sync 重写前快照、重写后再 restore。
+fn snapshot_unmanaged_subtables(
+    doc: &toml_edit::DocumentMut,
+    server_id: &str,
+) -> Vec<(String, toml_edit::Table)> {
+    doc.get("mcp_servers")
+        .and_then(|item| item.as_table())
+        .and_then(|t| t.get(server_id))
+        .and_then(|item| item.as_table())
+        .map(unmanaged_subtables_of)
+        .unwrap_or_default()
+}
+
 /// 分类只认标准子表（`v.as_table()`）。Codex CLI 始终以
 /// `[mcp_servers.<id>.tools.<tool>]` 标准表写入 runtime 权限，所以这个判定足够。
-/// 内联表形式（`tools = { ... }`）不在覆盖范围：遇到时既不剥离也不保留，按原样
-/// 透传——`snapshot_unmanaged_subtables` 与 Layer 2 的 new/old 遍历同此约定。
+/// 内联表形式（`tools = { ... }`）不在覆盖范围：既不剥离、也不快照。唯一的边角是
+/// 恢复步骤的整表写入：若旧 live 有同名标准子表，new 侧同名的内联值会被它替换——
+/// 这是「旧 live 是 runtime 子表唯一权威」主契约的自然结果，不属于透传的例外。
+/// `snapshot_unmanaged_subtables` 与 Layer 2 的 new/old 遍历同此约定。
 fn remove_unmanaged_subtables(server_tbl: &mut toml_edit::Table) -> bool {
     let keys: Vec<String> = server_tbl
         .iter()
@@ -667,6 +670,30 @@ fn remove_unmanaged_subtables(server_tbl: &mut toml_edit::Table) -> bool {
         server_tbl.remove(&key);
     }
     removed_any
+}
+
+/// 对 `[mcp_servers]` 下每个 server 执行 `remove_unmanaged_subtables`，
+/// 返回是否有任何改动。merge / strip 的公共清理步骤。
+fn remove_unmanaged_subtables_from_servers(mcp_servers: &mut toml_edit::Table) -> bool {
+    let mut changed = false;
+    for (_, server_item) in mcp_servers.iter_mut() {
+        if let Some(server_tbl) = server_item.as_table_mut() {
+            changed |= remove_unmanaged_subtables(server_tbl);
+        }
+    }
+    changed
+}
+
+/// 清理历史版本误写的 `[mcp.servers]` 格式（正确格式为顶层 `[mcp_servers]`）。
+fn remove_legacy_mcp_dot_servers(doc: &mut toml_edit::DocumentMut) {
+    if let Some(mcp_item) = doc.get_mut("mcp") {
+        if let Some(tbl) = mcp_item.as_table_like_mut() {
+            if tbl.contains_key("servers") {
+                log::warn!("检测到错误的 MCP 格式 [mcp.servers]，正在清理并迁移到 [mcp_servers]");
+                tbl.remove("servers");
+            }
+        }
+    }
 }
 
 /// 把 snapshot_unmanaged_subtables 抓到的子表写回 `[mcp_servers.<server_id>]`。
@@ -697,13 +724,13 @@ fn restore_unmanaged_subtables(
     }
 }
 
-/// **Layer 2 纯函数**：把 `old_text` 中所有非 cc-switch 管辖的子表
+/// **Layer 2 纯函数**：把 `old_text`（旧 live）中所有非 cc-switch 管辖的子表
 /// （典型为 Codex CLI 运行时写入的 `[mcp_servers.<id>.tools.<tool>]`）
 /// 合并进 `new_text`，返回合并后的 TOML 文本。
 ///
-/// 用于 Codex live 写入边界：provider switch / common-config save 会用新 provider
-/// 的 stored config 整张覆盖 `~/.codex/config.toml`，但 stored config 不带 runtime
-/// 子表，本函数在写入前把旧 live 中的 runtime 子表抢救出来合并进去。
+/// 用于 Codex live 写入边界：provider 驱动的写入会用新 provider 的 stored config
+/// 整张覆盖 `~/.codex/config.toml`，但 stored config 不带 runtime 子表，本函数在
+/// 写入前把旧 live 中的 runtime 子表抢救出来合并进去。
 ///
 /// 语义：
 /// - "受管子表"（`CC_SWITCH_MANAGED_SUBTABLE_KEYS`）跳过——它们由 cc-switch 自己负责。
@@ -711,11 +738,14 @@ fn restore_unmanaged_subtables(
 ///   当前仍存在的子表作为唯一权威恢复；live 中已删除的 `tools.*` 不会被 provider 重新带回。
 ///   恢复时整表写入旧 live 的子表——new 侧同名子表已在上一步清空，旧 live 即唯一
 ///   权威，从而避免 provider 中被 backfill 的 stale runtime 副本覆盖 Codex CLI 最新权限。
-/// - **不为新文本中不存在的 server 凭空建父表**：新文本没有的 server 说明切换后的
-///   provider 配置不含它。切换后确实仍会跑 MCP sync（`McpService::sync_all_enabled`
-///   → `sync_single_server_to_codex`），但它只为 cc-switch enabled 列表中的 server
-///   补全 command/url；新文本不含的 server 同样不在该列表，sync 不会重建它。为它
-///   建一个只有 `tools.*` 的残缺 server 会让 Codex 无法加载——这类孤儿 runtime 子表直接丢弃。
+/// - **不为新文本中不存在的 server 凭空建父表**：只有 `tools.*`、没有 command/url
+///   的残缺 server 会让 Codex 无法加载。cc-switch enabled 的 server 由各写入路径在
+///   进入本函数前整表带入新文本（普通切换/保存见 `services::provider::live::
+///   preserve_enabled_codex_mcp_servers_from_live`，接管路径见 `ProxyService::
+///   preserve_codex_mcp_servers_from_existing_config`），其 runtime 子表随父表就位
+///   后再由本步骤以旧 live 为权威刷新。因此走到这里仍缺父表的 server 均非
+///   cc-switch 管辖，其孤儿子表随「provider 文本决定这类 server 存在性」的既有
+///   语义一并丢弃。
 /// - 解析失败 / 旧文件不可读时退回原文本；新文本没有 `[mcp_servers]` 时不创建父表，
 ///   best-effort 不阻塞底层写入。
 pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> String {
@@ -724,34 +754,27 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
     let Ok(old_doc) = old_text.parse::<DocumentMut>() else {
         return new_text.to_string();
     };
-    // server_id, subtable_key, table
-    let mut preserved: Vec<(String, String, toml_edit::Table)> = Vec::new();
+    // 旧 live 的非管辖子表，按 server 分组快照。
+    let mut preserved: Vec<(String, Vec<(String, toml_edit::Table)>)> = Vec::new();
     if let Some(old_mcp_servers) = old_doc.get("mcp_servers").and_then(|item| item.as_table()) {
         for (server_id, server_item) in old_mcp_servers.iter() {
             let Some(server_tbl) = server_item.as_table() else {
                 continue;
             };
-            for (k, v) in server_tbl.iter() {
-                if CC_SWITCH_MANAGED_SUBTABLE_KEYS.contains(&k) {
-                    continue;
-                }
-                if let Some(tbl) = v.as_table() {
-                    preserved.push((server_id.to_string(), k.to_string(), tbl.clone()));
-                }
+            let subtables = unmanaged_subtables_of(server_tbl);
+            if !subtables.is_empty() {
+                preserved.push((server_id.to_string(), subtables));
             }
         }
     }
 
-    let mut new_doc = if new_text.trim().is_empty() {
-        DocumentMut::default()
-    } else {
-        match new_text.parse::<DocumentMut>() {
-            Ok(doc) => doc,
-            Err(_) => return new_text.to_string(),
-        }
+    let mut new_doc = match new_text.parse::<DocumentMut>() {
+        Ok(doc) => doc,
+        Err(_) => return new_text.to_string(),
     };
 
-    // P1：只把 runtime 子表回写到新文本中已存在的 server，不凭空创建残缺父表。
+    // 只把 runtime 子表回写到新文本中已存在的 server，不凭空创建残缺父表
+    // （enabled server 的父表已由调用路径在写入前整表带入，见函数文档）。
     let Some(mcp_servers) = new_doc
         .get_mut("mcp_servers")
         .and_then(|item| item.as_table_mut())
@@ -762,14 +785,9 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
     // provider 存储可能已经被旧 backfill 种下 stale runtime 子表。先清掉 new 侧所有
     // 非管辖子表，再恢复 old live 当前仍存在的 runtime 状态；这样 live 删除的 tools.*
     // 不会被 stale provider config 重新带回。
-    let mut changed = false;
-    for (_, server_item) in mcp_servers.iter_mut() {
-        if let Some(server_tbl) = server_item.as_table_mut() {
-            changed |= remove_unmanaged_subtables(server_tbl);
-        }
-    }
+    let mut changed = remove_unmanaged_subtables_from_servers(mcp_servers);
 
-    for (server_id, key, tbl) in preserved {
+    for (server_id, subtables) in preserved {
         let Some(server_tbl) = mcp_servers
             .get_mut(&server_id)
             .and_then(|item| item.as_table_mut())
@@ -779,8 +797,10 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
         // new 侧的非管辖子表已在上面整体清空，old live 是 runtime 子表的唯一权威，
         // 直接写入即可：既保住 Codex CLI 最新写入的 per-tool 授权，又不会复活 live
         // 中已删除、仅残留于 provider stored config 的 stale tools.*。
-        server_tbl.insert(&key, toml_edit::Item::Table(tbl));
-        changed = true;
+        for (key, tbl) in subtables {
+            server_tbl.insert(&key, toml_edit::Item::Table(tbl));
+            changed = true;
+        }
     }
 
     if changed {
@@ -793,21 +813,16 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
 /// 剥离 `[mcp_servers.<id>]` 下所有非 cc-switch 管辖的子表（典型为 Codex CLI
 /// 运行时写入的 `tools.*`），返回处理后的 TOML 文本。
 ///
-/// 用于 backfill 边界（两个入口都接：`ConfigService::sync_codex_live` 的
-/// common-config save，以及 `ProviderService::switch_provider` 经
-/// `restore_live_settings_for_provider_backfill` 的 provider 切换）：回填会把
-/// live config 文本写进 provider 的 stored config，但 cc-switch 数据库不应持有
-/// Codex runtime 状态。先剥离再回填，可确保 stored config 不会种下 stale
-/// `tools.*`——live 才是 runtime 子表的唯一权威。
+/// 用于 backfill 边界（`restore_live_settings_for_provider_backfill`，
+/// provider 切换回填的必经之路）：回填会把 live config 文本写进 provider 的
+/// stored config，但 cc-switch 数据库不应持有 Codex runtime 状态。先剥离再回填，
+/// 可确保 stored config 不会种下 stale `tools.*`——live 才是 runtime 子表的唯一权威。
 ///
 /// 受管子表（`CC_SWITCH_MANAGED_SUBTABLE_KEYS`，即 `env`/`http_headers`/`headers`）保留。
 /// 空文本 / 解析失败 / 无 `[mcp_servers]` 时原样返回，best-effort 不阻塞回填。
 pub(crate) fn strip_codex_runtime_subtables(config_text: &str) -> String {
     use toml_edit::DocumentMut;
 
-    if config_text.trim().is_empty() {
-        return config_text.to_string();
-    }
     let mut doc = match config_text.parse::<DocumentMut>() {
         Ok(doc) => doc,
         Err(_) => return config_text.to_string(),
@@ -820,14 +835,7 @@ pub(crate) fn strip_codex_runtime_subtables(config_text: &str) -> String {
         return config_text.to_string();
     };
 
-    let mut changed = false;
-    for (_, server_item) in mcp_servers.iter_mut() {
-        if let Some(server_tbl) = server_item.as_table_mut() {
-            changed |= remove_unmanaged_subtables(server_tbl);
-        }
-    }
-
-    if changed {
+    if remove_unmanaged_subtables_from_servers(mcp_servers) {
         doc.to_string()
     } else {
         config_text.to_string()
@@ -845,15 +853,7 @@ fn apply_single_server_to_doc(
 
     let preserved = snapshot_unmanaged_subtables(doc, id);
 
-    // 清理可能存在的错误格式 [mcp.servers]
-    if let Some(mcp_item) = doc.get_mut("mcp") {
-        if let Some(tbl) = mcp_item.as_table_like_mut() {
-            if tbl.contains_key("servers") {
-                log::warn!("检测到错误的 MCP 格式 [mcp.servers]，正在清理并迁移到 [mcp_servers]");
-                tbl.remove("servers");
-            }
-        }
-    }
+    remove_legacy_mcp_dot_servers(doc);
 
     if !doc.contains_key("mcp_servers") {
         doc["mcp_servers"] = toml_edit::table();
@@ -868,7 +868,8 @@ fn apply_single_server_to_doc(
 }
 
 /// 纯逻辑：把 enabled servers 批量应用到 DocumentMut，保留 enabled server 自己的非托管子表。
-/// 未在 enabled 中的 server 沿用原有"整体抹除"行为（pre-existing），本 PR 不调整这一语义。
+/// 未在 enabled 中的 server 沿用原有「整体抹除」语义
+/// （见 `sync_enabled_drops_unmentioned_server_including_its_tools` 测试）。
 /// `sync_enabled_to_codex` 的可单测内核。
 fn apply_enabled_servers_to_doc(
     doc: &mut toml_edit::DocumentMut,
@@ -885,15 +886,7 @@ fn apply_enabled_servers_to_doc(
         })
         .collect();
 
-    // 清理可能存在的错误格式 [mcp.servers]
-    if let Some(mcp_item) = doc.get_mut("mcp") {
-        if let Some(tbl) = mcp_item.as_table_like_mut() {
-            if tbl.contains_key("servers") {
-                log::warn!("检测到错误的 MCP 格式 [mcp.servers]，正在清理并迁移到 [mcp_servers]");
-                tbl.remove("servers");
-            }
-        }
-    }
+    remove_legacy_mcp_dot_servers(doc);
 
     if enabled.is_empty() {
         // pre-existing behavior：无 enabled 时整体移除 [mcp_servers]。
@@ -1331,8 +1324,9 @@ approval_mode = "approve"
 
     #[test]
     fn merge_runtime_drops_orphan_tools_when_new_lacks_server() {
-        // P1：新文本里没有该 server（切换后的 provider 不含它，且之后不会再跑 MCP sync）。
-        // 不能为了塞 tools.* 而凭空建一个没有 command/url 的残缺 server——Codex 无法加载它。
+        // 新文本里没有该 server，且它不属于写入路径预先整表带入的 cc-switch enabled
+        // server（例如非 cc-switch 管理的手工条目，见 merge 函数文档）。不能为了塞
+        // tools.* 而凭空建一个没有 command/url 的残缺 server——Codex 无法加载它。
         let old = r#"
 [mcp_servers.x.tools.t1]
 approval_mode = "approve"
@@ -1462,5 +1456,55 @@ command = "x"
             stripped, config,
             "只有受管子表时应原样返回，不引入无谓 reformat"
         );
+    }
+
+    #[test]
+    fn merge_runtime_returns_new_verbatim_when_new_unparseable() {
+        // 与 old 侧解析失败对称：新文本无法解析时原样返回，
+        // 交给底层写入路径的 TOML 校验报错，不在这里吞掉或改写。
+        let old = "[mcp_servers.x.tools.t1]\napproval_mode = \"approve\"\n";
+        let new = "this is :: not toml";
+        let merged = merge_codex_runtime_subtables(new, old);
+        assert_eq!(merged, new, "新文本无法解析时应原样返回");
+    }
+
+    #[test]
+    fn strip_runtime_returns_verbatim_when_unparseable() {
+        let config = "this is :: not toml";
+        assert_eq!(
+            strip_codex_runtime_subtables(config),
+            config,
+            "无法解析时应原样返回，best-effort 不阻塞回填"
+        );
+    }
+
+    #[test]
+    fn strip_then_merge_round_trips_runtime_subtables() {
+        // 完整生命周期：切走时 backfill 剥离（strip），切回时以 live 为权威恢复（merge）。
+        // 保证 2a/2b 两个半边互为逆变换，DB 不持有 runtime 状态也不会造成授权丢失。
+        let live = r#"
+model_provider = "openai"
+
+[mcp_servers.x]
+type = "stdio"
+command = "x"
+
+[mcp_servers.x.env]
+TOKEN = "1"
+
+[mcp_servers.x.tools.search]
+approval_mode = "approve"
+"#;
+        let stored = strip_codex_runtime_subtables(live);
+        let stored_v: toml::Value = toml::from_str(&stored).expect("stored is valid toml");
+        assert!(
+            stored_v["mcp_servers"]["x"].get("tools").is_none(),
+            "backfill 副本不应含 runtime 子表"
+        );
+
+        let restored = merge_codex_runtime_subtables(&stored, live);
+        let live_v: toml::Value = toml::from_str(live).expect("live is valid toml");
+        let restored_v: toml::Value = toml::from_str(&restored).expect("restored is valid toml");
+        assert_eq!(restored_v, live_v, "strip→merge 往返后应与原 live 语义等价");
     }
 }

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -651,6 +651,20 @@ fn snapshot_unmanaged_subtables(
         .collect()
 }
 
+fn remove_unmanaged_subtables(server_tbl: &mut toml_edit::Table) -> bool {
+    let keys: Vec<String> = server_tbl
+        .iter()
+        .filter(|(k, v)| !CC_SWITCH_MANAGED_SUBTABLE_KEYS.contains(k) && v.as_table().is_some())
+        .map(|(k, _)| k.to_string())
+        .collect();
+
+    let removed_any = !keys.is_empty();
+    for key in keys {
+        server_tbl.remove(&key);
+    }
+    removed_any
+}
+
 /// 把 snapshot_unmanaged_subtables 抓到的子表写回 `[mcp_servers.<server_id>]`。
 /// 在 sync 函数把 server 子表整体重写之后调用。
 fn restore_unmanaged_subtables(
@@ -691,13 +705,14 @@ fn restore_unmanaged_subtables(
 ///
 /// 语义：
 /// - "受管子表"（`CC_SWITCH_MANAGED_SUBTABLE_KEYS`）跳过——它们由 cc-switch 自己负责。
-/// - **逐子键深度合并**：旧 live 与新文本同时存在某子表（如 `tools`）时，按叶子键
-///   合并而非整体取舍——旧 `tools.search` 与新 `tools.read` 都保留；同名叶子键冲突时
-///   旧 live 优先，避免 provider 中被 backfill 的 stale runtime 副本覆盖 Codex CLI 最新权限。
+/// - new/provider 文本中已有的非管辖子表视为 stale runtime 副本，先清掉，再以旧 live
+///   当前仍存在的子表作为唯一权威恢复；live 中已删除的 `tools.*` 不会被 provider 重新带回。
+///   恢复时整表写入旧 live 的子表——new 侧同名子表已在上一步清空，旧 live 即唯一
+///   权威，从而避免 provider 中被 backfill 的 stale runtime 副本覆盖 Codex CLI 最新权限。
 /// - **不为新文本中不存在的 server 凭空建父表**：新文本没有的 server 说明切换后的
 ///   provider 配置不含它，且 provider 切换路径之后不会再跑 MCP sync 补全 command/url，
 ///   建一个只有 `tools.*` 的残缺 server 会让 Codex 无法加载——这类孤儿 runtime 子表直接丢弃。
-/// - 解析失败 / 旧文件不可读 / 新旧任一方没有 `[mcp_servers]` 时退回原文本，
+/// - 解析失败 / 旧文件不可读时退回原文本；新文本没有 `[mcp_servers]` 时不创建父表，
 ///   best-effort 不阻塞底层写入。
 pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> String {
     use toml_edit::DocumentMut;
@@ -705,28 +720,22 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
     let Ok(old_doc) = old_text.parse::<DocumentMut>() else {
         return new_text.to_string();
     };
-    let Some(old_mcp_servers) = old_doc.get("mcp_servers").and_then(|item| item.as_table()) else {
-        return new_text.to_string();
-    };
-
     // server_id, subtable_key, table
     let mut preserved: Vec<(String, String, toml_edit::Table)> = Vec::new();
-    for (server_id, server_item) in old_mcp_servers.iter() {
-        let Some(server_tbl) = server_item.as_table() else {
-            continue;
-        };
-        for (k, v) in server_tbl.iter() {
-            if CC_SWITCH_MANAGED_SUBTABLE_KEYS.contains(&k) {
+    if let Some(old_mcp_servers) = old_doc.get("mcp_servers").and_then(|item| item.as_table()) {
+        for (server_id, server_item) in old_mcp_servers.iter() {
+            let Some(server_tbl) = server_item.as_table() else {
                 continue;
-            }
-            if let Some(tbl) = v.as_table() {
-                preserved.push((server_id.to_string(), k.to_string(), tbl.clone()));
+            };
+            for (k, v) in server_tbl.iter() {
+                if CC_SWITCH_MANAGED_SUBTABLE_KEYS.contains(&k) {
+                    continue;
+                }
+                if let Some(tbl) = v.as_table() {
+                    preserved.push((server_id.to_string(), k.to_string(), tbl.clone()));
+                }
             }
         }
-    }
-
-    if preserved.is_empty() {
-        return new_text.to_string();
     }
 
     let mut new_doc = if new_text.trim().is_empty() {
@@ -746,6 +755,16 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
         return new_text.to_string();
     };
 
+    // provider 存储可能已经被旧 backfill 种下 stale runtime 子表。先清掉 new 侧所有
+    // 非管辖子表，再恢复 old live 当前仍存在的 runtime 状态；这样 live 删除的 tools.*
+    // 不会被 stale provider config 重新带回。
+    let mut changed = false;
+    for (_, server_item) in mcp_servers.iter_mut() {
+        if let Some(server_tbl) = server_item.as_table_mut() {
+            changed |= remove_unmanaged_subtables(server_tbl);
+        }
+    }
+
     for (server_id, key, tbl) in preserved {
         let Some(server_tbl) = mcp_servers
             .get_mut(&server_id)
@@ -753,22 +772,59 @@ pub(crate) fn merge_codex_runtime_subtables(new_text: &str, old_text: &str) -> S
         else {
             continue;
         };
-        // P2：逐子键合并——新文本已有同名子表（如 `tools`）时深度合并（旧 live 优先），
-        //     而非整体跳过，从而保住 Codex CLI 最新写入的 per-tool 授权。
-        match server_tbl
-            .get_mut(&key)
-            .and_then(|item| item.as_table_mut())
-        {
-            Some(existing_tbl) => {
-                merge_table_preserving_old(existing_tbl, &tbl);
-            }
-            None => {
-                server_tbl.insert(&key, toml_edit::Item::Table(tbl));
-            }
+        // new 侧的非管辖子表已在上面整体清空，old live 是 runtime 子表的唯一权威，
+        // 直接写入即可：既保住 Codex CLI 最新写入的 per-tool 授权，又不会复活 live
+        // 中已删除、仅残留于 provider stored config 的 stale tools.*。
+        server_tbl.insert(&key, toml_edit::Item::Table(tbl));
+        changed = true;
+    }
+
+    if changed {
+        new_doc.to_string()
+    } else {
+        new_text.to_string()
+    }
+}
+
+/// 剥离 `[mcp_servers.<id>]` 下所有非 cc-switch 管辖的子表（典型为 Codex CLI
+/// 运行时写入的 `tools.*`），返回处理后的 TOML 文本。
+///
+/// 用于 backfill 边界：provider switch 后会把 live config 文本回填进 provider 的
+/// stored config，但 cc-switch 数据库不应持有 Codex runtime 状态。先剥离再回填，
+/// 可确保 stored config 不会种下 stale `tools.*`——live 才是 runtime 子表的唯一权威。
+///
+/// 受管子表（`CC_SWITCH_MANAGED_SUBTABLE_KEYS`，即 `env`/`http_headers`/`headers`）保留。
+/// 空文本 / 解析失败 / 无 `[mcp_servers]` 时原样返回，best-effort 不阻塞回填。
+pub(crate) fn strip_codex_runtime_subtables(config_text: &str) -> String {
+    use toml_edit::DocumentMut;
+
+    if config_text.trim().is_empty() {
+        return config_text.to_string();
+    }
+    let mut doc = match config_text.parse::<DocumentMut>() {
+        Ok(doc) => doc,
+        Err(_) => return config_text.to_string(),
+    };
+
+    let Some(mcp_servers) = doc
+        .get_mut("mcp_servers")
+        .and_then(|item| item.as_table_mut())
+    else {
+        return config_text.to_string();
+    };
+
+    let mut changed = false;
+    for (_, server_item) in mcp_servers.iter_mut() {
+        if let Some(server_tbl) = server_item.as_table_mut() {
+            changed |= remove_unmanaged_subtables(server_tbl);
         }
     }
 
-    new_doc.to_string()
+    if changed {
+        doc.to_string()
+    } else {
+        config_text.to_string()
+    }
 }
 
 /// 深度合并：把 `old` 的键并入 `target`，同名叶子键以 `old`（旧 live/runtime）优先；
@@ -1224,6 +1280,29 @@ approval_mode = "deny"
     }
 
     #[test]
+    fn merge_runtime_strips_provider_stale_tools_when_live_has_no_mcp_servers() {
+        // old live 为空（例如 live 文件不存在）时，provider 存储里残留的 tools.*
+        // 也不能成为新的 authority。
+        let old = "";
+        let new = r#"
+[mcp_servers.x]
+command = "x"
+
+[mcp_servers.x.tools.search]
+approval_mode = "approve"
+"#;
+
+        let merged = merge_codex_runtime_subtables(new, old);
+        let v: toml::Value = toml::from_str(&merged).unwrap();
+
+        assert_eq!(v["mcp_servers"]["x"]["command"].as_str(), Some("x"));
+        assert!(
+            v["mcp_servers"]["x"].get("tools").is_none(),
+            "live 没有 runtime authority 时，应清掉 provider 中残留的 stale tools.*"
+        );
+    }
+
+    #[test]
     fn merge_runtime_returns_unchanged_when_old_unparseable() {
         let old = "this is :: not toml";
         let new = r#"model_provider = "anthropic""#;
@@ -1232,9 +1311,9 @@ approval_mode = "deny"
     }
 
     #[test]
-    fn merge_runtime_merges_tools_per_tool_not_per_parent() {
-        // P2：旧 live 有 tools.search、新文本（用户在 provider config 里）声明了 tools.read，
-        // 两者无键冲突，必须都保留——不能因为新文本已有 `tools` 父表就整体跳过旧表。
+    fn merge_runtime_removes_provider_stale_tool_missing_from_live() {
+        // provider config 可能已经被旧 backfill 种下 stale tools.*。如果用户随后在
+        // Codex live 里撤销某个 tool approval，切回该 provider 时不能把它复活。
         let old = r#"
 [mcp_servers.x]
 command = "x"
@@ -1255,12 +1334,11 @@ approval_mode = "approve"
         assert_eq!(
             v["mcp_servers"]["x"]["tools"]["search"]["approval_mode"].as_str(),
             Some("approve"),
-            "新文本声明了其它工具时，旧 live 的 per-tool 授权仍须逐工具保留"
+            "旧 live 中仍存在的 per-tool 授权必须恢复"
         );
-        assert_eq!(
-            v["mcp_servers"]["x"]["tools"]["read"]["approval_mode"].as_str(),
-            Some("approve"),
-            "新文本声明的工具同样保留"
+        assert!(
+            v["mcp_servers"]["x"]["tools"].get("read").is_none(),
+            "new/provider 中存在但 live 中已删除的 stale tool 不得被带回"
         );
     }
 
@@ -1281,6 +1359,41 @@ model_provider = "anthropic"
         assert!(
             v.get("mcp_servers").is_none(),
             "新文本不含该 server 时，不得为孤儿 tools.* 创建残缺父表"
+        );
+    }
+
+    #[test]
+    fn strip_runtime_subtables_removes_tools_but_keeps_managed_subtables() {
+        let config = r#"
+[mcp_servers.x]
+command = "x"
+
+[mcp_servers.x.env]
+TOKEN = "1"
+
+[mcp_servers.x.http_headers]
+Authorization = "Bearer token"
+
+[mcp_servers.x.headers]
+X-Compat = "1"
+
+[mcp_servers.x.tools.search]
+approval_mode = "approve"
+"#;
+        let stripped = strip_codex_runtime_subtables(config);
+        let v: toml::Value = toml::from_str(&stripped).expect("stripped is valid toml");
+
+        let server = &v["mcp_servers"]["x"];
+        assert_eq!(server["command"].as_str(), Some("x"));
+        assert_eq!(server["env"]["TOKEN"].as_str(), Some("1"));
+        assert_eq!(
+            server["http_headers"]["Authorization"].as_str(),
+            Some("Bearer token")
+        );
+        assert_eq!(server["headers"]["X-Compat"].as_str(), Some("1"));
+        assert!(
+            server.get("tools").is_none(),
+            "backfill 写回 provider 存储前应剥离 Codex runtime tools.*"
         );
     }
 }

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -23,10 +23,10 @@ pub use claude::{
     import_from_claude, remove_server_from_claude, sync_enabled_to_claude,
     sync_single_server_to_claude,
 };
+pub(crate) use codex::merge_codex_runtime_subtables;
 pub use codex::{
     import_from_codex, remove_server_from_codex, sync_enabled_to_codex, sync_single_server_to_codex,
 };
-pub(crate) use codex::merge_codex_runtime_subtables;
 pub use gemini::{
     import_from_gemini, remove_server_from_gemini, sync_enabled_to_gemini,
     sync_single_server_to_gemini,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -26,6 +26,7 @@ pub use claude::{
 pub use codex::{
     import_from_codex, remove_server_from_codex, sync_enabled_to_codex, sync_single_server_to_codex,
 };
+pub(crate) use codex::merge_codex_runtime_subtables;
 pub use gemini::{
     import_from_gemini, remove_server_from_gemini, sync_enabled_to_gemini,
     sync_single_server_to_gemini,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -23,10 +23,10 @@ pub use claude::{
     import_from_claude, remove_server_from_claude, sync_enabled_to_claude,
     sync_single_server_to_claude,
 };
-pub(crate) use codex::merge_codex_runtime_subtables;
 pub use codex::{
     import_from_codex, remove_server_from_codex, sync_enabled_to_codex, sync_single_server_to_codex,
 };
+pub(crate) use codex::{merge_codex_runtime_subtables, strip_codex_runtime_subtables};
 pub use gemini::{
     import_from_gemini, remove_server_from_gemini, sync_enabled_to_gemini,
     sync_single_server_to_gemini,

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -175,12 +175,13 @@ impl ConfigService {
         // MCP 的启用/禁用应通过 McpService::toggle_app 进行
 
         let cfg_text_after = crate::codex_config::read_and_validate_codex_config_text()?;
+        let cfg_text_for_backfill = crate::mcp::strip_codex_runtime_subtables(&cfg_text_after);
         if let Some(manager) = config.get_manager_mut(&AppType::Codex) {
             if let Some(target) = manager.providers.get_mut(provider_id) {
                 if let Some(obj) = target.settings_config.as_object_mut() {
                     let mut restored = serde_json::json!({
                         "auth": auth.clone(),
-                        "config": cfg_text_after,
+                        "config": cfg_text_for_backfill,
                     });
                     let restore_provider_token =
                         crate::codex_config::should_restore_codex_provider_token_for_backfill(

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles reading and writing live configuration files for Claude, Codex, and Gemini.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde_json::{json, Value};
 use toml_edit::{DocumentMut, Item, TableLike};
@@ -549,6 +549,10 @@ pub(crate) fn write_live_with_common_config(
     effective_provider.settings_config =
         build_effective_settings_with_common_config(db, app_type, provider)?;
 
+    if matches!(app_type, AppType::Codex) {
+        preserve_enabled_codex_mcp_servers_from_live(db, &mut effective_provider.settings_config);
+    }
+
     if matches!(app_type, AppType::ClaudeDesktop) {
         crate::claude_desktop_config::apply_provider(db, &effective_provider)?;
         log::info!(
@@ -560,6 +564,115 @@ pub(crate) fn write_live_with_common_config(
     }
 
     write_live_snapshot(app_type, &effective_provider)
+}
+
+/// Codex live 写入前置步骤：把旧 live 中「MCP DB 里启用了 Codex、但新 effective
+/// 配置文本缺失」的 server **整表**带进新文本。与接管路径的
+/// `ProxyService::preserve_codex_mcp_servers_from_existing_config` 同型，但只限
+/// cc-switch enabled 的 server——不复活非 cc-switch 管辖的手工条目。
+///
+/// 这些 server 的存在性由 MCP DB 管辖：provider stored config 在 backfill 时会主动
+/// 剥离 `[mcp_servers]`，新建 provider 也天然没有它们；切换尾部再由
+/// `McpService::sync_all_enabled` 按 DB spec 重建/移除。若不在写入前带上它们，
+/// Layer 2（`merge_codex_runtime_subtables`）就没有父表可挂 runtime 子表，
+/// per-tool 授权会在「切到从未持有该 server 的 provider」时永久丢失。整表拷贝
+/// 绝不产生残缺条目：即使后续 MCP sync 因故未跑，live 里仍是完整可加载的定义。
+///
+/// best-effort：任何一步失败只记日志返回，不阻断底层写入；新文本无 `config`
+/// 字段（该写入不会重写 config.toml）或无法解析（交给底层写入校验报错）时跳过。
+fn preserve_enabled_codex_mcp_servers_from_live(db: &Database, settings: &mut Value) {
+    let Some(config_text) = settings.get("config").and_then(Value::as_str) else {
+        return;
+    };
+
+    let live_path = get_codex_config_path();
+    let live_text = match std::fs::read_to_string(&live_path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+        Err(err) => {
+            log::warn!("读取 Codex live 配置失败，跳过 enabled MCP server 保留: {err}");
+            return;
+        }
+    };
+
+    let enabled_ids: HashSet<String> = match db.get_all_mcp_servers() {
+        Ok(servers) => servers
+            .values()
+            .filter(|server| server.apps.is_enabled_for(&AppType::Codex))
+            .map(|server| server.id.clone())
+            .collect(),
+        Err(err) => {
+            log::warn!("读取 MCP 服务器列表失败，跳过 enabled MCP server 保留: {err}");
+            return;
+        }
+    };
+
+    if let Some(updated) =
+        merge_enabled_live_servers_into_config(config_text, &live_text, &enabled_ids)
+    {
+        if let Some(obj) = settings.as_object_mut() {
+            obj.insert("config".to_string(), Value::String(updated));
+        }
+    }
+}
+
+/// `preserve_enabled_codex_mcp_servers_from_live` 的可单测内核：把 `live_text` 中
+/// enabled 且 `config_text` 缺失的 server 整表并入，返回并入后的文本；
+/// 无可并入（或 live/新文本形态不满足前提）时返回 `None`，调用方保持原文本字节不变。
+fn merge_enabled_live_servers_into_config(
+    config_text: &str,
+    live_text: &str,
+    enabled_ids: &HashSet<String>,
+) -> Option<String> {
+    if enabled_ids.is_empty() {
+        return None;
+    }
+    let live_doc = match live_text.parse::<DocumentMut>() {
+        Ok(doc) => doc,
+        Err(_) => {
+            log::warn!("Codex live 配置无法解析，跳过 enabled MCP server 保留");
+            return None;
+        }
+    };
+    let live_servers = live_doc
+        .get("mcp_servers")
+        .and_then(|item| item.as_table())?;
+
+    let mut target_doc = config_text.parse::<DocumentMut>().ok()?;
+
+    let mut copied = false;
+    for (server_id, server_item) in live_servers.iter() {
+        if !enabled_ids.contains(server_id) {
+            continue;
+        }
+        // 内联形式（x = { ... }）不在覆盖范围，按既有约定透传给现有语义处理。
+        let Some(server_tbl) = server_item.as_table() else {
+            continue;
+        };
+        let exists_in_target = target_doc
+            .get("mcp_servers")
+            .and_then(|item| item.as_table_like())
+            .map(|t| t.get(server_id).is_some())
+            .unwrap_or(false);
+        if exists_in_target {
+            continue;
+        }
+
+        if !target_doc.contains_key("mcp_servers") {
+            let mut parent = toml_edit::Table::new();
+            parent.set_implicit(true);
+            target_doc.insert("mcp_servers", Item::Table(parent));
+        }
+        if let Some(servers_tbl) = target_doc
+            .get_mut("mcp_servers")
+            .and_then(|item| item.as_table_mut())
+        {
+            servers_tbl.insert(server_id, Item::Table(server_tbl.clone()));
+            copied = true;
+        }
+    }
+
+    copied.then(|| target_doc.to_string())
 }
 
 pub(crate) fn strip_common_config_from_live_settings(
@@ -649,19 +762,6 @@ fn restore_live_settings_for_provider_backfill(
                 "Failed to strip unified session bucket while backfilling '{}': {err}",
                 provider.id
             );
-        }
-    }
-
-    // Codex CLI 运行时写入的 `[mcp_servers.<id>.tools.<tool>]` 授权只属于 live，
-    // backfill 进 DB 前必须剥离，否则 provider stored config 会积累 stale runtime
-    // 状态（让“编辑通用配置”冒出 runtime `tools.*`，也给 live 写入埋下脏 DB）。
-    // 这与 `ConfigService::sync_codex_live` 的 backfill 剥离保持一致，确保
-    // provider switch 与 common-config save 两个 backfill 入口都不把 runtime
-    // 子表写进 DB——live 才是 runtime 子表的唯一权威。
-    if let Some(config_text) = settings.get("config").and_then(Value::as_str) {
-        let stripped = crate::mcp::strip_codex_runtime_subtables(config_text);
-        if let Some(obj) = settings.as_object_mut() {
-            obj.insert("config".to_string(), Value::String(stripped));
         }
     }
 
@@ -2020,6 +2120,107 @@ base_url = "https://a.example/v1"
         assert!(
             config_text.contains("model = \"gpt-5.5\""),
             "non-MCP content must survive the strip"
+        );
+    }
+
+    // ====== preserve_enabled_codex_mcp_servers_from_live 内核 ======
+
+    fn enabled_ids(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn preserve_enabled_servers_copies_missing_server_with_runtime_subtables() {
+        // 切到「从未持有该 server」的 provider（典型：新建 provider）：enabled server
+        // 必须整表带进新文本，per-tool 授权随之保留，Layer 2 再以 live 为权威刷新。
+        let live = r#"
+[mcp_servers.x]
+type = "stdio"
+command = "x"
+
+[mcp_servers.x.env]
+TOKEN = "1"
+
+[mcp_servers.x.tools.search]
+approval_mode = "approve"
+"#;
+        let target = "model_provider = \"b\"\n";
+
+        let merged = merge_enabled_live_servers_into_config(target, live, &enabled_ids(&["x"]))
+            .expect("enabled server should be copied");
+        let v: toml::Value = toml::from_str(&merged).expect("merged is valid toml");
+
+        assert_eq!(v["model_provider"].as_str(), Some("b"));
+        assert_eq!(
+            v["mcp_servers"]["x"]["command"].as_str(),
+            Some("x"),
+            "整表拷贝必须带上 command，绝不产生残缺条目"
+        );
+        assert_eq!(v["mcp_servers"]["x"]["env"]["TOKEN"].as_str(), Some("1"));
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["search"]["approval_mode"].as_str(),
+            Some("approve"),
+            "per-tool 授权必须随整表拷贝保留"
+        );
+    }
+
+    #[test]
+    fn preserve_enabled_servers_skips_non_enabled_and_existing_servers() {
+        let live = r#"
+[mcp_servers.mine]
+command = "mine"
+
+[mcp_servers.mine.tools.t]
+approval_mode = "approve"
+
+[mcp_servers.manual]
+command = "manual"
+
+[mcp_servers.present]
+command = "live-version"
+"#;
+        // target 已含 present（stored 投影），manual 非 enabled（非 cc-switch 管辖）。
+        let target = "[mcp_servers.present]\ncommand = \"stored-version\"\n";
+
+        let merged = merge_enabled_live_servers_into_config(
+            target,
+            live,
+            &enabled_ids(&["mine", "present"]),
+        )
+        .expect("mine should be copied");
+        let v: toml::Value = toml::from_str(&merged).expect("merged is valid toml");
+
+        assert_eq!(
+            v["mcp_servers"]["mine"]["tools"]["t"]["approval_mode"].as_str(),
+            Some("approve")
+        );
+        assert!(
+            v["mcp_servers"].get("manual").is_none(),
+            "非 enabled 的 server 维持 provider 文本语义，不得复活"
+        );
+        assert_eq!(
+            v["mcp_servers"]["present"]["command"].as_str(),
+            Some("stored-version"),
+            "target 已含的 server 不得被 live 版本覆盖（子表交给 Layer 2 处理）"
+        );
+    }
+
+    #[test]
+    fn preserve_enabled_servers_returns_none_when_nothing_to_copy() {
+        // 无可并入时返回 None，调用方保持原文本字节不变（不引入无谓 reformat）。
+        let live = "[mcp_servers.x]\ncommand = \"x\"\n";
+        let target = "[mcp_servers.x]\ncommand = \"stored\"\n";
+        assert!(
+            merge_enabled_live_servers_into_config(target, live, &enabled_ids(&["x"])).is_none()
+        );
+        assert!(
+            merge_enabled_live_servers_into_config(target, live, &HashSet::new()).is_none(),
+            "enabled 集合为空时不做任何事"
+        );
+        assert!(
+            merge_enabled_live_servers_into_config(target, "not :: toml", &enabled_ids(&["x"]))
+                .is_none(),
+            "live 无法解析时跳过，best-effort 不阻断写入"
         );
     }
 }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -652,6 +652,19 @@ fn restore_live_settings_for_provider_backfill(
         }
     }
 
+    // Codex CLI 运行时写入的 `[mcp_servers.<id>.tools.<tool>]` 授权只属于 live，
+    // backfill 进 DB 前必须剥离，否则 provider stored config 会积累 stale runtime
+    // 状态（让“编辑通用配置”冒出 runtime `tools.*`，也给 live 写入埋下脏 DB）。
+    // 这与 `ConfigService::sync_codex_live` 的 backfill 剥离保持一致，确保
+    // provider switch 与 common-config save 两个 backfill 入口都不把 runtime
+    // 子表写进 DB——live 才是 runtime 子表的唯一权威。
+    if let Some(config_text) = settings.get("config").and_then(Value::as_str) {
+        let stripped = crate::mcp::strip_codex_runtime_subtables(config_text);
+        if let Some(obj) = settings.as_object_mut() {
+            obj.insert("config".to_string(), Value::String(stripped));
+        }
+    }
+
     // `modelCatalog` is a cc-switch–private field whose SSOT is the DB. Live's
     // `config.toml` only carries a lossy projection (`model_catalog_json` →
     // generated catalog file) that proxy takeover/restore cycles and Codex.app

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2076,6 +2076,15 @@ impl ProxyService {
                     &mut effective_settings,
                     existing_value,
                 )?;
+                // preserve_codex_mcp_servers_… 只整表拷贝目标缺失的 server；两边都有
+                // 的 server 用的是 provider stored config 版本，而 backfill 剥离保证
+                // 了它不含 runtime 子表（tools.*）。备份是接管释放时 byte-for-byte
+                // 恢复 live 的来源——这里不合并的话，热切换过一次的接管周期结束后，
+                // per-tool 授权会随恢复被确定性抹掉。
+                Self::merge_codex_runtime_subtables_into_backup(
+                    &mut effective_settings,
+                    existing_value,
+                );
                 Self::preserve_codex_oauth_auth_in_backup(&mut effective_settings, existing_value)?;
             }
 
@@ -2279,6 +2288,33 @@ impl ProxyService {
 
         target_obj.insert("config".to_string(), json!(target_doc.to_string()));
         Ok(())
+    }
+
+    /// 把旧备份 config 文本中的 Codex runtime 子表（如 `tools.*`）合并进重建后的
+    /// 备份 config 文本。语义同 live 写入边界的 Layer 2
+    /// （`mcp::merge_codex_runtime_subtables`），old 侧换成旧备份——接管期间
+    /// 旧备份是「释放接管时应恢复的 runtime 状态」的唯一持有者。
+    /// best-effort：任一侧缺 `config` 文本时不动 target。
+    fn merge_codex_runtime_subtables_into_backup(
+        target_settings: &mut Value,
+        existing_config: &Value,
+    ) {
+        let Some(new_cfg) = target_settings
+            .get("config")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+        else {
+            return;
+        };
+        let Some(old_cfg) = existing_config.get("config").and_then(|v| v.as_str()) else {
+            return;
+        };
+        let merged = crate::mcp::merge_codex_runtime_subtables(&new_cfg, old_cfg);
+        if merged != new_cfg {
+            if let Some(obj) = target_settings.as_object_mut() {
+                obj.insert("config".to_string(), json!(merged));
+            }
+        }
     }
 
     fn preserve_codex_oauth_auth_in_backup(
@@ -2496,6 +2532,13 @@ impl ProxyService {
                         config, config_str, profile,
                     )
                     .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
+                // 与下方 else 分支对齐：else 走 codex_config::write_codex_live_for_provider，
+                // 其 Layer 2 会以旧 live 为权威恢复 runtime 子表（tools.*）；本分支绕过
+                // 该函数直接原子写盘，必须显式做同一步合并，否则接管期热切换会把
+                // live 中的 per-tool 授权覆盖丢失，且同一操作的行为会随
+                // preserve_codex_official_auth_on_switch 开关分裂。
+                let prepared_config =
+                    crate::codex_config::preserve_runtime_codex_mcp_state(&prepared_config);
                 let live_config =
                     crate::codex_config::prepare_codex_provider_live_config(auth, &prepared_config)
                         .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
@@ -3357,6 +3400,131 @@ wire_api = "responses"
         assert!(
             live_config.contains(PROXY_TOKEN_PLACEHOLDER),
             "live config should carry the proxy placeholder token"
+        );
+
+        crate::settings::update_settings(crate::settings::AppSettings::default())
+            .expect("reset settings");
+    }
+
+    #[test]
+    fn backup_rebuild_merges_runtime_tools_from_existing_backup() {
+        // 热切换重建备份：两边都有的 server 取 provider stored config 版本（已被
+        // backfill 剥离 tools.*），必须从旧备份把 runtime 子表合并回来，否则释放
+        // 接管时 byte-for-byte 恢复的备份会确定性抹掉 per-tool 授权。
+        let mut target = json!({
+            "auth": {},
+            "config": "[mcp_servers.x]\ncommand = \"x\"\n"
+        });
+        let existing = json!({
+            "auth": {},
+            "config": "[mcp_servers.x]\ncommand = \"x\"\n\n[mcp_servers.x.tools.search]\napproval_mode = \"approve\"\n"
+        });
+
+        ProxyService::merge_codex_runtime_subtables_into_backup(&mut target, &existing);
+
+        let config = target["config"].as_str().expect("backup config text");
+        let v: toml::Value = toml::from_str(config).expect("backup config is valid toml");
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["search"]["approval_mode"].as_str(),
+            Some("approve"),
+            "重建后的备份必须保留旧备份中的 runtime 子表"
+        );
+
+        // 任一侧缺 config 文本时不动 target（best-effort）。
+        let mut no_config = json!({ "auth": {} });
+        ProxyService::merge_codex_runtime_subtables_into_backup(&mut no_config, &existing);
+        assert!(no_config.get("config").is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn codex_provider_live_write_rescues_runtime_tools_before_overwrite() {
+        // Layer 2 接线验证（codex_config::write_codex_live_for_provider）：
+        // provider 驱动的 live 写入必须以旧 live 为权威——保住 CLI 新授予的
+        // tools.*，同时不让 stored config 中的 stale 副本复活已撤销授权。
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        crate::codex_config::write_codex_live_atomic(
+            &json!({ "OPENAI_API_KEY": "old-key" }),
+            Some("[mcp_servers.x]\ncommand = \"x\"\n\n[mcp_servers.x.tools.search]\napproval_mode = \"approve\"\n"),
+        )
+        .expect("seed live config with runtime tools");
+
+        crate::codex_config::write_codex_live_for_provider(
+            Some("custom"),
+            &json!({ "OPENAI_API_KEY": "new-key" }),
+            Some("model_provider = \"b\"\n\n[mcp_servers.x]\ncommand = \"x\"\n\n[mcp_servers.x.tools.stale]\napproval_mode = \"approve\"\n"),
+        )
+        .expect("provider-driven live write");
+
+        let live_config = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read live config");
+        let v: toml::Value = toml::from_str(&live_config).expect("live config is valid toml");
+        assert_eq!(v["model_provider"].as_str(), Some("b"));
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["search"]["approval_mode"].as_str(),
+            Some("approve"),
+            "live 中的 per-tool 授权必须在 provider 写入后保留"
+        );
+        assert!(
+            v["mcp_servers"]["x"]["tools"].get("stale").is_none(),
+            "stored config 中 live 已不存在的 stale tool 不得复活"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn codex_takeover_placeholder_write_preserves_runtime_tools_from_live() {
+        // preserve_codex_official_auth_on_switch=true 时，接管写入走占位符分支
+        // （绕过 codex_config::write_codex_live_for_provider 直接原子写盘）；
+        // 该分支必须与 else 分支一样保留 live 中的 per-tool 授权，
+        // 行为不得随这个 auth 兼容开关分裂。
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        crate::settings::update_settings(crate::settings::AppSettings {
+            preserve_codex_official_auth_on_switch: true,
+            ..Default::default()
+        })
+        .expect("enable Codex official auth preservation");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db);
+
+        crate::codex_config::write_codex_live_atomic(
+            &json!({ "tokens": { "id_token": "id", "access_token": "at" } }),
+            Some("[mcp_servers.x]\ncommand = \"x\"\n\n[mcp_servers.x.tools.search]\napproval_mode = \"approve\"\n"),
+        )
+        .expect("seed live config with runtime tools");
+
+        let mut provider = Provider::with_id(
+            "b".to_string(),
+            "ProviderB".to_string(),
+            json!({
+                "auth": { "OPENAI_API_KEY": "key-b" },
+                "config": "model_provider = \"b\"\n"
+            }),
+            None,
+        );
+        provider.category = Some("custom".to_string());
+        // 模拟接管期热切换的写入形态：占位符 auth + 已被 backfill 剥离 tools.* 的
+        // provider stored config（含同名 server）。
+        let takeover_settings = json!({
+            "auth": { "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER },
+            "config": "model_provider = \"b\"\n\n[mcp_servers.x]\ncommand = \"x\"\n"
+        });
+
+        service
+            .write_codex_takeover_live_for_provider(&takeover_settings, Some(&provider))
+            .expect("takeover placeholder-branch write");
+
+        let live_config = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read live config");
+        let v: toml::Value = toml::from_str(&live_config).expect("live config is valid toml");
+        assert_eq!(
+            v["mcp_servers"]["x"]["tools"]["search"]["approval_mode"].as_str(),
+            Some("approve"),
+            "占位符分支必须保留 live 中的 per-tool 授权"
         );
 
         crate::settings::update_settings(crate::settings::AppSettings::default())


### PR DESCRIPTION
> Replaces #3251 — 旧 PR 因与最新 `main` 冲突已关闭，本 PR 为 rebase 后的版本。

Preserves Codex CLI runtime `[mcp_servers.<id>.tools.*]` permissions across provider switches and MCP sync.

---

## 问题

当用户在 Codex CLI 中对某个 MCP 工具点击“始终允许”时，Codex 会向 `~/.codex/config.toml` 写入：

```toml
[mcp_servers.<server_id>.tools.<tool_name>]
approval_mode = "approve"
```

cc-switch 在切换供应商（或保存通用配置）后会破坏这条权限，存在两种症状：

1. **权限丢失**：切换后 `tools.*` 被整张覆盖删除。即使放进“编辑通用配置”也无济于事——下一次同步仍会清掉。
2. **已撤销权限被复活**（review 阶段发现的 [P2]）：用户在 Codex CLI 里撤销某个工具授权后，切回某个供应商时，该工具的旧授权又被带了回来。

## 根因

**症状 1（权限丢失）** 源于切换供应商触发的**两步连续覆盖**，两步都会抹掉 `tools.*`：

1. **Provider live 写入**：provider 的 stored config 整张覆盖 `~/.codex/config.toml`，而 stored config 不带 runtime 字段，这一步先抹掉。
2. **MCP sync**：`McpService` 用 cc-switch 构造的服务器规范表整张替换 `[mcp_servers.<id>]`，再次抹除任何嵌套子表。

**症状 2（复活）** 源于 backfill：provider 切换后会把 live config 文本（含 Codex 刚写入的 `tools.*`）回填进 provider stored config（`services/config.rs`），于是 DB 里积累了 stale `tools.*`。一旦用户随后在 live 里撤销该授权，再切回这个 provider 时，新文本里的 stale `tools.<tool>` 在 live 中已无对应项可压制——若合并逻辑只“补”不“清”，就会被原样保留，等于把已撤销的权限复活。

## 修复

确立契约：**cc-switch 只管它自己写入的字段；runtime 子表（典型为 `tools.*`）的唯一权威是 live，provider stored config（DB）不应持有 runtime 状态。** cc-switch 在 `[mcp_servers.<id>]` 下唯一会写为子表的键只有 `env`、`http_headers` 及 compat 读取名 `headers`，其余子表一律视为非 cc-switch 管辖。

### Layer 1（`mcp/codex.rs`，MCP sync 边界）

sync 重写 `[mcp_servers.<id>]` 前快照非管辖子表，重写后写回。抽出 `apply_single_server_to_doc` / `apply_enabled_servers_to_doc` 两个纯函数便于单测。

### Layer 2（provider 驱动的 live 写入 + backfill 收口）

落在 provider 切换 / 保存通用配置路径，由两个互补的半边组成：

- **2a 前置 · enabled server 整表保留（`preserve_enabled_codex_mcp_servers_from_live`）**：enabled server 的存在性由 MCP DB 管辖、与 provider 文本解耦——切到从未持有该 server 的 provider（典型：新建 provider）时，新文本里根本没有父表可挂 runtime 子表。因此普通切换/保存写 live 前，先把「MCP DB 中启用了 Codex、但新文本缺失」的 server 从旧 live **整表**带入（含 `command`/`url`，绝不产生残缺条目），2a 再以旧 live 为权威刷新其子表，切换尾部的 MCP sync 最后用 DB spec 重建核心字段。非 cc-switch 管辖的 server 不带入，维持「provider 文本决定其存在性」的既有语义。
- **2a · 写 live（`merge_codex_runtime_subtables`）**：在 live 写入收口点 `write_codex_live_for_provider` 中，写入前先清掉新文本（来自 provider stored config）中所有非管辖子表（视为可能 stale 的 runtime 副本），再以**旧 live 当前仍存在的子表为唯一权威**恢复。这样既保住 Codex CLI 最新授权，又保证 live 中已撤销的 `tools.*` 不会被 stale provider config 带回（治症状 2，含存量脏 DB）。官方/三方两个写入分支都在合并后落盘；走裸 `write_codex_live_atomic` 的 byte-for-byte restore 路径不接入，保持精确还原语义。
- **2b · 回填 DB（`strip_codex_runtime_subtables`）**：把 live 文本回填进 provider stored config 前剥离全部 runtime 子表，使 DB 不再持有 Codex runtime 状态，从源头杜绝再种 stale 副本（让 2a 今后无需面对脏 DB，并让“编辑通用配置”不再冒出 runtime `tools.*`）。

**为何缺一不可**：

- Layer 1 vs Layer 2 对症状 1：只补 Layer 1 挡不住第 1 步 provider live 覆盖；只补 Layer 2 挡不住后续 MCP sync。
- 2a vs 2b 对症状 2：2a 兜正确性（每次写 live 都以 live 为权威，存量 + 新增都不复活）；2b 管干净（DB 不再积累 runtime 状态）。单留 2a，DB 表示仍脏；单留 2b，挡不住已被污染的存量 DB。

### 合并语义（细节）

- **live 为唯一权威，先清后恢复**：旧 live 与新文本同一 server 都有某子表（如 `tools`）时，**不做逐键合并**——先整体清掉新文本侧，再恢复旧 live 当前仍存在的子表。后果：旧 live 有、新文本无的工具保留；新文本有、旧 live 已删除的工具丢弃（即 [P2]）。
- **不为新文本中不存在的 server 凭空建父表**：只有 `tools.*`、没有 `command`/`url` 的残缺 server 会让 Codex 无法加载。enabled server 的父表已由写入前置步骤整表带入（普通路径见 2a 前置，接管路径由既有的 `preserve_codex_mcp_servers_from_existing_config` 承担同一职责），走到合并这一步仍缺父表的 server 均非 cc-switch 管辖，其孤儿子表随「provider 文本决定这类 server 存在性」的既有语义丢弃。
- best-effort：解析失败 / 旧文件不可读时退回原文本（读失败记 warning）；无可改动时按字节原样返回，不引入无谓 reformat。

### 代理接管路径（`services/proxy.rs`）

接管期间的 Codex 写入不全经过 `write_codex_live_for_provider` 收口点，需单独接入同一契约：

- **接管期热切换的占位符分支**：`preserve_codex_official_auth_on_switch` 开启时，`write_codex_takeover_live_for_provider` 直接原子写盘、绕过 2a（else 分支则经收口点走到 2a）。该分支现在落盘前显式执行同一步合并，两个开关取值下行为一致，接管期热切换不再丢失 live 中的 `tools.*`。
- **接管备份重建**：接管期热切换会用 provider stored config 重建接管备份，而 2b 恰好保证 stored config 不含 `tools.*`——不处理的话，释放接管时 byte-for-byte 恢复的备份会确定性抹掉授权。现在重建备份时把旧备份中的 runtime 子表合并进新备份（`merge_codex_runtime_subtables_into_backup`），恢复语义保持逐字不变，但备份内容本身携带正确的 runtime 状态。

## 不在本 PR 范围

- **`remove_server_from_codex`**：remove 语义为“该 server 不再存在”，权限随之失效符合直觉。
- **非 cc-switch 管理的 MCP 服务器**：`sync_enabled_to_codex` 会清掉不在 enabled 列表中的 server——pre-existing 行为，本 PR 不调整；同理，写入前置步骤只整表带入 MCP DB 中 enabled 的 server，不复活手工条目。
- **byte-for-byte restore 路径**：裸 `write_codex_live_atomic` / `LiveSnapshot::restore` 保持原样，确保备份/回滚精确还原。接管备份已在重建时合并 runtime 子表（见上），恢复的备份自带正确状态；接管期间新授予、且此后未发生热切换刷新备份的授权，释放接管时仍以备份为准——这是 restore 语义的固有取舍。
- **import / 编辑供应商（`read_codex_live_settings` 底稿）**：导入当前 live 为新供应商、或以 live 为底稿编辑保存时，会把 live 的 `tools.*` 一并带进 provider stored config；该副本在下次切换时被 Layer 2 自愈（2a 以 live 为权威、2b 回填前剥离），非本 issue 复现路径，故本 PR 不额外处理。

## 测试

`mcp::codex::tests` 共 22 个纯函数用例（不碰文件系统）：

**Layer 1（MCP sync 边界）**

- `sync_single_preserves_tools_permission_subtable`
- `sync_single_overwrites_managed_env_subtable`
- `sync_single_overwrites_managed_http_headers_subtable`
- `sync_enabled_preserves_tools_for_enabled_server`
- `sync_enabled_drops_mcp_servers_when_empty`（pre-existing 行为）
- `sync_enabled_drops_unmentioned_server_including_its_tools`（pre-existing 行为）
- `sync_single_handles_empty_doc`

**Layer 2 — 2a 写 live（`merge_codex_runtime_subtables`）**

- `merge_runtime_preserves_tools_when_new_text_has_server_without_tools`（症状 1 主复现路径）
- `merge_runtime_removes_provider_stale_tool_missing_from_live`（**[P2] 主复现：live 已删除、provider 残留的 stale tool 不得复活**）
- `merge_runtime_strips_provider_stale_tools_when_live_has_no_mcp_servers`（live 无 runtime authority 时也清掉 provider 残留）
- `merge_runtime_live_wins_when_key_collides`
- `merge_runtime_drops_orphan_tools_when_new_lacks_server`（不建残缺父表）
- `merge_runtime_handles_multiple_servers_and_drops_orphan`
- `merge_runtime_skips_managed_subtables`（覆盖 `env` / `http_headers` / compat `headers`）
- `merge_runtime_returns_unchanged_when_old_has_no_mcp_servers`
- `merge_runtime_returns_unchanged_when_old_unparseable`
- `merge_runtime_returns_new_verbatim_when_new_unparseable`（与 old 侧对称的回退）
- `merge_runtime_returns_new_verbatim_when_nothing_to_change`（字节保真短路）

**Layer 2 — 2b 回填 DB（`strip_codex_runtime_subtables`）**

- `strip_runtime_subtables_removes_tools_but_keeps_managed_subtables`
- `strip_runtime_returns_verbatim_when_no_runtime_subtables` / `strip_runtime_returns_verbatim_when_unparseable`
- `strip_then_merge_round_trips_runtime_subtables`（**2a/2b 互为逆变换的往返不变量**）

**接线与前置步骤（`services::provider::live::tests` / `services::proxy::tests`）**

- `codex_switch_backfill_strips_runtime_tools_subtables`（2b 在切换回填入口的接线）
- `preserve_enabled_servers_copies_missing_server_with_runtime_subtables` /
  `preserve_enabled_servers_skips_non_enabled_and_existing_servers` /
  `preserve_enabled_servers_returns_none_when_nothing_to_copy`（2a 前置内核）
- `codex_provider_live_write_rescues_runtime_tools_before_overwrite`（2a 在 `write_codex_live_for_provider` 的接线，TempHome 集成）
- `codex_takeover_placeholder_write_preserves_runtime_tools_from_live`（接管占位符分支）
- `backup_rebuild_merges_runtime_tools_from_existing_backup`（接管备份重建合并）

## 复现

### 症状 1（权限丢失）

1. 在 cc-switch 注册 MCP server `ace-tool-rs`，启用 Codex
2. 切换 Codex 供应商，确认 `~/.codex/config.toml` 写入 `[mcp_servers.ace-tool-rs]`
3. 启动 Codex，对某个工具点击“始终允许”
4. 确认 `[mcp_servers.ace-tool-rs.tools.<name>] approval_mode = "approve"` 写入文件
5. 在 cc-switch 中切换供应商
6. 旧行为：`tools.*` 消失；新行为：保留

### 症状 1 变体（切到从未持有该 server 的 provider）

1. 在 provider A 下启用 MCP server 并在 Codex CLI 中授权工具
2. **新建** provider B（模板配置没有 `[mcp_servers]`）并切换过去
3. 无前置步骤的行为：合并层因新文本无父表而丢弃授权，随后 MCP sync 重建出不带 `tools.*` 的 server → 授权永久丢失
4. 新行为：写入前置步骤把该 server 从旧 live 整表带入，授权保留

### 接管期热切换（`preserve_codex_official_auth_on_switch` 开启）

1. 开启代理接管，Codex CLI 在接管期间已有工具授权在 live 中
2. 接管态下热切换到另一第三方供应商
3. 无修复的行为：占位符分支直写 live，`tools.*` 丢失（且关掉该开关做同样操作则不丢——行为随无关开关分裂）；释放接管时，被 stored config 重建过的备份进一步固化丢失
4. 新行为：占位符分支落盘前合并 live 的 runtime 子表；备份重建时从旧备份合并，释放接管后授权仍在

### 症状 2（复活，[P2]）

前置：provider B 的 stored config 中已存在 stale `tools.<name>`（旧版本 backfill 所致——切换到 B 时把含 `tools.*` 的 live 文本回填进了 B）。

1. 在 Codex CLI 里撤销该工具授权（live 不再有该 `tools.<name>`）
2. 切回 provider B
3. 旧行为：新文本（B stored config）里的 stale `tools.<name>` 因 live 无对应项压制而被原样保留 → 已撤销的授权复活
4. 新行为：写 live 前先清掉 B 侧 stale 子表、以 live 为权威 → 保持已撤销；同时回填前剥离，B 的 DB 不再残留
