### PR TITLE
feat(proxy): add response health checks for failover

### DIFF
--- a/src-tauri/src/proxy/content_health.rs
+++ b/src-tauri/src/proxy/content_health.rs
@@ -1,0 +1,515 @@
+use http::HeaderMap;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentHealth {
+    Healthy,
+    Inconclusive,
+    Unhealthy(ContentHealthViolation),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentHealthViolation {
+    pub reason: ContentHealthReason,
+    pub body_hash: String,
+    pub sample_len: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentHealthReason {
+    KnownSignatureHit,
+    AdOrPromoText,
+    UnrelatedChatRoomOrInvite,
+    HtmlLoginOrCaptcha,
+    QuotaSalesOrProviderNotice,
+    SchemaMismatch,
+    MalformedToolCall,
+    RepeatedUnrelatedStreamFragment,
+    ZeroUsageZeroCostInvalidResponse,
+}
+
+impl ContentHealthReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::KnownSignatureHit => "known_signature_hit",
+            Self::AdOrPromoText => "ad_or_promo_text",
+            Self::UnrelatedChatRoomOrInvite => "unrelated_chat_room_or_invite",
+            Self::HtmlLoginOrCaptcha => "html_login_or_captcha",
+            Self::QuotaSalesOrProviderNotice => "quota_sales_or_provider_notice",
+            Self::SchemaMismatch => "schema_mismatch",
+            Self::MalformedToolCall => "malformed_tool_call",
+            Self::RepeatedUnrelatedStreamFragment => "repeated_unrelated_stream_fragment",
+            Self::ZeroUsageZeroCostInvalidResponse => "zero_usage_zero_cost_invalid_response",
+        }
+    }
+}
+
+impl ContentHealthViolation {
+    pub fn provider_unhealthy_message(&self) -> String {
+        format!(
+            "content_unhealthy:{} hash={} sample_len={}",
+            self.reason.as_str(),
+            self.body_hash,
+            self.sample_len
+        )
+    }
+}
+
+pub fn classify_non_stream_response(
+    headers: &HeaderMap,
+    body: &[u8],
+    request_is_generation: bool,
+) -> ContentHealth {
+    let sample = String::from_utf8_lossy(body);
+    let lower = sample.to_ascii_lowercase();
+
+    if sample.trim().is_empty() {
+        return ContentHealth::Healthy;
+    }
+
+    if looks_like_html_or_captcha(headers, &lower) {
+        return unhealthy(ContentHealthReason::HtmlLoginOrCaptcha, body);
+    }
+
+    if let Some(reason) = synthetic_or_general_unhealthy_signal(&lower) {
+        return unhealthy(reason, body);
+    }
+
+    if let Some(reason) = malformed_tool_call_reason(&sample) {
+        return unhealthy(reason, body);
+    }
+
+    if request_is_generation && zero_usage_invalid_response(&sample) {
+        return unhealthy(ContentHealthReason::ZeroUsageZeroCostInvalidResponse, body);
+    }
+
+    if request_is_generation && expects_json(headers) && !looks_like_valid_protocol_json(&sample) {
+        return unhealthy(ContentHealthReason::SchemaMismatch, body);
+    }
+
+    ContentHealth::Healthy
+}
+
+pub fn classify_sse_prime_window(
+    event_data: &[String],
+    raw_sample: &[u8],
+    request_is_generation: bool,
+) -> ContentHealth {
+    if event_data.is_empty() && raw_sample.is_empty() {
+        return ContentHealth::Inconclusive;
+    }
+
+    let joined = event_data.join("\n");
+    let lower = joined.to_ascii_lowercase();
+
+    if let Some(reason) = synthetic_or_general_unhealthy_signal(&lower) {
+        return unhealthy(reason, raw_sample);
+    }
+
+    if repeated_fragment(event_data) {
+        return unhealthy(
+            ContentHealthReason::RepeatedUnrelatedStreamFragment,
+            raw_sample,
+        );
+    }
+
+    if event_data
+        .iter()
+        .any(|data| malformed_tool_call_reason(data).is_some())
+    {
+        return unhealthy(ContentHealthReason::MalformedToolCall, raw_sample);
+    }
+
+    if request_is_generation
+        && event_data
+            .iter()
+            .any(|data| zero_usage_invalid_response(data))
+    {
+        return unhealthy(
+            ContentHealthReason::ZeroUsageZeroCostInvalidResponse,
+            raw_sample,
+        );
+    }
+
+    if request_is_generation
+        && event_data
+            .iter()
+            .any(|data| !sse_event_data_has_protocol_shape(data))
+    {
+        return unhealthy(ContentHealthReason::SchemaMismatch, raw_sample);
+    }
+
+    ContentHealth::Healthy
+}
+
+fn unhealthy(reason: ContentHealthReason, sample: &[u8]) -> ContentHealth {
+    ContentHealth::Unhealthy(ContentHealthViolation {
+        reason,
+        body_hash: super::json_canonical::short_sha256_hex(sample),
+        sample_len: sample.len(),
+    })
+}
+
+fn looks_like_html_or_captcha(headers: &HeaderMap, lower: &str) -> bool {
+    let content_type = headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let trimmed = lower.trim_start();
+
+    content_type.contains("html")
+        || trimmed.starts_with("<!doctype html")
+        || trimmed.starts_with("<html")
+        || lower.contains("<body")
+        || lower.contains("<form")
+        || lower.contains("</html>")
+}
+
+fn synthetic_or_general_unhealthy_signal(lower: &str) -> Option<ContentHealthReason> {
+    if lower.contains("synthetic_unhealthy_marker") {
+        return Some(ContentHealthReason::KnownSignatureHit);
+    }
+    if lower.contains("synthetic_ad_promo_marker") {
+        return Some(ContentHealthReason::AdOrPromoText);
+    }
+    if lower.contains("provider_notice_unhealthy") {
+        return Some(ContentHealthReason::QuotaSalesOrProviderNotice);
+    }
+    if lower.contains("unrelated_invite_marker") {
+        return Some(ContentHealthReason::UnrelatedChatRoomOrInvite);
+    }
+    None
+}
+
+fn expects_json(headers: &HeaderMap) -> bool {
+    headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_ascii_lowercase().contains("json"))
+        .unwrap_or(true)
+}
+
+fn looks_like_valid_protocol_json(sample: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(sample) else {
+        return false;
+    };
+
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+
+    object.contains_key("content")
+        || object.contains_key("output")
+        || object.contains_key("choices")
+        || object
+            .get("message")
+            .and_then(|message| message.as_object())
+            .and_then(|message| message.get("content"))
+            .is_some()
+        || valid_tool_calls(object)
+}
+
+fn sse_event_data_has_protocol_shape(data: &str) -> bool {
+    let trimmed = data.trim();
+    if trimmed.is_empty() || trimmed == "[DONE]" {
+        return true;
+    }
+
+    let Ok(value) = serde_json::from_str::<Value>(trimmed) else {
+        return false;
+    };
+
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+
+    object.contains_key("type")
+        || object.contains_key("delta")
+        || object.contains_key("choices")
+        || object.contains_key("content")
+        || object.contains_key("message")
+        || object.contains_key("output")
+        || object.contains_key("response")
+        || object.contains_key("usage")
+        || object.contains_key("candidate")
+        || object.contains_key("candidates")
+        || object.contains_key("error")
+        || valid_tool_calls(object)
+}
+
+fn malformed_tool_call_reason(sample: &str) -> Option<ContentHealthReason> {
+    let lower = sample.to_ascii_lowercase();
+    if !lower.contains("tool_call") && !lower.contains("tool call") {
+        return None;
+    }
+
+    let Ok(value) = serde_json::from_str::<Value>(sample) else {
+        return Some(ContentHealthReason::MalformedToolCall);
+    };
+
+    let Some(object) = value.as_object() else {
+        return Some(ContentHealthReason::MalformedToolCall);
+    };
+
+    if valid_tool_calls(object) {
+        None
+    } else {
+        Some(ContentHealthReason::MalformedToolCall)
+    }
+}
+
+fn valid_tool_calls(object: &serde_json::Map<String, Value>) -> bool {
+    let Some(calls) = object.get("tool_calls").and_then(|value| value.as_array()) else {
+        return false;
+    };
+    if calls.is_empty() {
+        return false;
+    }
+
+    calls.iter().all(|call| {
+        let Some(call) = call.as_object() else {
+            return false;
+        };
+
+        if let Some(function) = call.get("function").and_then(|value| value.as_object()) {
+            return function
+                .get("name")
+                .and_then(|value| value.as_str())
+                .is_some_and(|name| !name.is_empty())
+                && function
+                    .get("arguments")
+                    .and_then(|value| value.as_str())
+                    .is_some();
+        }
+
+        call.get("name")
+            .and_then(|value| value.as_str())
+            .is_some_and(|name| !name.is_empty())
+            && (call.contains_key("arguments") || call.contains_key("input"))
+    })
+}
+
+fn zero_usage_invalid_response(sample: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(sample) else {
+        return false;
+    };
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    let Some(usage) = object.get("usage").and_then(|value| value.as_object()) else {
+        return false;
+    };
+
+    let input_zero = number_is_zero(usage.get("input_tokens").or_else(|| usage.get("input")));
+    let output_zero = number_is_zero(usage.get("output_tokens").or_else(|| usage.get("output")));
+    let cost_zero = number_is_zero(usage.get("total_cost").or_else(|| usage.get("cost")));
+
+    input_zero && output_zero && cost_zero && !looks_like_valid_protocol_json(sample)
+}
+
+fn number_is_zero(value: Option<&Value>) -> bool {
+    value
+        .and_then(|value| value.as_f64())
+        .is_some_and(|number| number.abs() < f64::EPSILON)
+}
+
+fn repeated_fragment(event_data: &[String]) -> bool {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for data in event_data {
+        let trimmed = data.trim();
+        if trimmed.len() < 20 {
+            continue;
+        }
+        let count = counts.entry(trimmed).or_insert(0);
+        *count += 1;
+        if *count >= 3 {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::header::CONTENT_TYPE;
+    use http::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn allows_clean_openai_response_json() {
+        let body =
+            br#"{"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}"#;
+
+        assert_eq!(
+            classify_non_stream_response(&HeaderMap::new(), body, true),
+            ContentHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn allows_clean_anthropic_message_json() {
+        let body = br#"{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}"#;
+
+        assert_eq!(
+            classify_non_stream_response(&HeaderMap::new(), body, true),
+            ContentHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn blocks_synthetic_unhealthy_non_stream_json_with_redacted_message() {
+        let body = b"SYNTHETIC_UNHEALTHY_MARKER should not be copied";
+        let ContentHealth::Unhealthy(violation) =
+            classify_non_stream_response(&HeaderMap::new(), body, true)
+        else {
+            panic!("expected unhealthy");
+        };
+
+        let message = violation.provider_unhealthy_message();
+        assert!(message.contains("content_unhealthy:known_signature_hit"));
+        assert!(message.contains("hash="));
+        assert!(message.contains("sample_len="));
+        assert!(!message.contains("SYNTHETIC_UNHEALTHY_MARKER"));
+        assert!(!message.contains("should not be copied"));
+    }
+
+    #[test]
+    fn blocks_html_login_or_captcha_200() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/html"));
+        let body = b"<html><body><form>login captcha</form></body></html>";
+
+        let result = classify_non_stream_response(&headers, body, true);
+
+        assert!(matches!(
+            result,
+            ContentHealth::Unhealthy(ContentHealthViolation {
+                reason: ContentHealthReason::HtmlLoginOrCaptcha,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn allows_clean_json_text_that_mentions_login() {
+        let body = br#"{"output":[{"type":"message","content":[{"type":"output_text","text":"Please login with the documented command."}]}]}"#;
+
+        assert_eq!(
+            classify_non_stream_response(&HeaderMap::new(), body, true),
+            ContentHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn blocks_schema_mismatch_for_generation_json_response() {
+        let body = br#"{"ok":true}"#;
+
+        let result = classify_non_stream_response(&HeaderMap::new(), body, true);
+
+        assert!(matches!(
+            result,
+            ContentHealth::Unhealthy(ContentHealthViolation {
+                reason: ContentHealthReason::SchemaMismatch,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn allows_non_generation_json_without_protocol_shape() {
+        let body = br#"{"ok":true}"#;
+
+        assert_eq!(
+            classify_non_stream_response(&HeaderMap::new(), body, false),
+            ContentHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn blocks_malformed_tool_call_delta() {
+        let body = br#"{"tool_calls":[{"function":{"arguments":"{}"}}]}"#;
+
+        let result = classify_non_stream_response(&HeaderMap::new(), body, true);
+
+        assert!(matches!(
+            result,
+            ContentHealth::Unhealthy(ContentHealthViolation {
+                reason: ContentHealthReason::MalformedToolCall,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn zero_usage_valid_response_is_not_unhealthy() {
+        let body = br#"{"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":0,"output_tokens":0,"total_cost":0}}"#;
+
+        assert_eq!(
+            classify_non_stream_response(&HeaderMap::new(), body, true),
+            ContentHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn zero_usage_invalid_response_is_unhealthy() {
+        let body =
+            br#"{"usage":{"input_tokens":0,"output_tokens":0,"total_cost":0},"note":"invalid"}"#;
+
+        let result = classify_non_stream_response(&HeaderMap::new(), body, true);
+
+        assert!(matches!(
+            result,
+            ContentHealth::Unhealthy(ContentHealthViolation {
+                reason: ContentHealthReason::ZeroUsageZeroCostInvalidResponse,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn blocks_repeated_unrelated_stream_fragments() {
+        let repeated = "repeated synthetic unrelated fragment";
+        let event_data = vec![
+            repeated.to_string(),
+            repeated.to_string(),
+            repeated.to_string(),
+        ];
+
+        let result = classify_sse_prime_window(&event_data, repeated.as_bytes(), true);
+
+        assert!(matches!(
+            result,
+            ContentHealth::Unhealthy(ContentHealthViolation {
+                reason: ContentHealthReason::RepeatedUnrelatedStreamFragment,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn allows_clean_openai_sse_json_event() {
+        let event_data = vec![r#"{"type":"response.output_text.delta","delta":"ok"}"#.to_string()];
+
+        assert_eq!(
+            classify_sse_prime_window(&event_data, event_data[0].as_bytes(), true),
+            ContentHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn blocks_non_protocol_sse_data_for_generation_request() {
+        let event_data = vec!["plain provider notice instead of protocol JSON".to_string()];
+
+        let result = classify_sse_prime_window(&event_data, event_data[0].as_bytes(), true);
+
+        assert!(matches!(
+            result,
+            ContentHealth::Unhealthy(ContentHealthViolation {
+                reason: ContentHealthReason::SchemaMismatch,
+                ..
+            })
+        ));
+    }
+}

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -33,6 +33,7 @@ use tauri::Manager;
 use tokio::sync::RwLock;
 
 const PROXY_AUTH_PLACEHOLDER: &str = "PROXY_MANAGED";
+const CONTENT_HEALTH_PRIME_MAX_BYTES: usize = 16 * 1024;
 
 pub struct ForwardResult {
     pub response: ProxyResponse,
@@ -1707,8 +1708,14 @@ impl RequestForwarder {
         let status = response.status();
 
         if status.is_success() {
+            let request_is_generation =
+                content_health_request_is_generation(method, &effective_endpoint, &filtered_body);
             let response = self
-                .prepare_success_response_for_failover(response, request_is_streaming)
+                .prepare_success_response_for_failover(
+                    response,
+                    request_is_streaming,
+                    request_is_generation,
+                )
                 .await?;
             Ok((response, resolved_claude_api_format))
         } else {
@@ -1730,9 +1737,12 @@ impl RequestForwarder {
         &self,
         response: ProxyResponse,
         request_is_streaming: bool,
+        request_is_generation: bool,
     ) -> Result<ProxyResponse, ProxyError> {
         if request_is_streaming {
-            return self.prime_streaming_response(response).await;
+            return self
+                .prime_streaming_response(response, request_is_generation)
+                .await;
         }
 
         if self.non_streaming_timeout.is_zero() {
@@ -1751,12 +1761,29 @@ impl RequestForwarder {
                 ))
             })??;
 
+        if let super::content_health::ContentHealth::Unhealthy(violation) =
+            super::content_health::classify_non_stream_response(
+                &headers,
+                &body,
+                request_is_generation,
+            )
+        {
+            let message = violation.provider_unhealthy_message();
+            log::warn!(
+                "[{}] content-health blocked successful non-stream response: {}",
+                super::log_codes::ch::UNHEALTHY_BLOCKED,
+                message
+            );
+            return Err(ProxyError::ProviderUnhealthy(message));
+        }
+
         Ok(ProxyResponse::buffered(status, headers, body))
     }
 
     async fn prime_streaming_response(
         &self,
         response: ProxyResponse,
+        request_is_generation: bool,
     ) -> Result<ProxyResponse, ProxyError> {
         if self.streaming_first_byte_timeout.is_zero() {
             return Ok(response);
@@ -1766,6 +1793,11 @@ impl RequestForwarder {
         let headers = response.headers().clone();
         let timeout = self.streaming_first_byte_timeout;
         let mut stream = Box::pin(response.bytes_stream());
+        let mut buffered_chunks: Vec<bytes::Bytes> = Vec::new();
+        let mut raw_sample: Vec<u8> = Vec::new();
+        let mut text_buffer = String::new();
+        let mut utf8_remainder: Vec<u8> = Vec::new();
+        let mut event_data: Vec<String> = Vec::new();
 
         let first = tokio::time::timeout(timeout, stream.next())
             .await
@@ -1785,7 +1817,70 @@ impl RequestForwarder {
         let first =
             first.map_err(|e| ProxyError::ForwardFailed(format!("读取流式响应首包失败: {e}")))?;
 
-        let replay = futures::stream::once(async move { Ok(first) }).chain(stream);
+        raw_sample.extend_from_slice(&first);
+        crate::proxy::sse::append_utf8_safe(&mut text_buffer, &mut utf8_remainder, &first);
+        buffered_chunks.push(first);
+
+        loop {
+            while let Some(event_text) = crate::proxy::sse::take_sse_block(&mut text_buffer) {
+                for line in event_text.lines() {
+                    if let Some(data) = crate::proxy::sse::strip_sse_field(line, "data") {
+                        if data.trim() != "[DONE]" {
+                            event_data.push(data.to_string());
+                        }
+                    }
+                }
+            }
+
+            if let super::content_health::ContentHealth::Unhealthy(violation) =
+                super::content_health::classify_sse_prime_window(
+                    &event_data,
+                    &raw_sample,
+                    request_is_generation,
+                )
+            {
+                let message = violation.provider_unhealthy_message();
+                log::warn!(
+                    "[{}] content-health blocked successful stream prime: {}",
+                    super::log_codes::ch::UNHEALTHY_BLOCKED,
+                    message
+                );
+                return Err(ProxyError::ProviderUnhealthy(message));
+            }
+
+            if !event_data.is_empty() || !response_looks_like_sse(&headers, &text_buffer) {
+                break;
+            }
+
+            if raw_sample.len() >= CONTENT_HEALTH_PRIME_MAX_BYTES {
+                break;
+            }
+
+            match tokio::time::timeout(timeout, stream.next()).await {
+                Ok(Some(Ok(bytes))) => {
+                    raw_sample.extend_from_slice(&bytes);
+                    crate::proxy::sse::append_utf8_safe(
+                        &mut text_buffer,
+                        &mut utf8_remainder,
+                        &bytes,
+                    );
+                    buffered_chunks.push(bytes);
+                }
+                Ok(Some(Err(e))) => {
+                    return Err(ProxyError::ForwardFailed(format!(
+                        "读取流式响应 prime 窗口失败: {e}"
+                    )));
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        let replay = futures::stream::iter(
+            buffered_chunks
+                .into_iter()
+                .map(Ok::<bytes::Bytes, std::io::Error>),
+        )
+        .chain(stream);
         Ok(ProxyResponse::streamed(status, headers, replay))
     }
 
@@ -2283,6 +2378,43 @@ fn is_streaming_request(endpoint: &str, body: &Value, headers: &axum::http::Head
         .unwrap_or(false)
 }
 
+fn content_health_request_is_generation(
+    method: &http::Method,
+    endpoint: &str,
+    body: &Value,
+) -> bool {
+    if matches!(method, &http::Method::GET | &http::Method::HEAD) {
+        return false;
+    }
+
+    if body.get("model").is_some() {
+        return true;
+    }
+
+    endpoint.contains("/responses")
+        || endpoint.contains("/messages")
+        || endpoint.contains("/chat/completions")
+        || endpoint.contains(":generateContent")
+        || endpoint.contains(":streamGenerateContent")
+}
+
+fn response_looks_like_sse(headers: &http::HeaderMap, text_buffer: &str) -> bool {
+    let content_type = headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    if content_type.contains("text/event-stream") {
+        return true;
+    }
+
+    text_buffer.lines().any(|line| {
+        crate::proxy::sse::strip_sse_field(line, "data").is_some()
+            || crate::proxy::sse::strip_sse_field(line, "event").is_some()
+    })
+}
+
 #[cfg(test)]
 fn should_force_identity_encoding(
     endpoint: &str,
@@ -2378,7 +2510,7 @@ fn value_for_log(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::database::Database;
-    use axum::http::header::{HeaderValue, ACCEPT};
+    use axum::http::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
     use axum::http::HeaderMap;
     use bytes::Bytes;
     use http::StatusCode;
@@ -2590,7 +2722,7 @@ mod tests {
         );
 
         let prepared = forwarder
-            .prepare_success_response_for_failover(response, false)
+            .prepare_success_response_for_failover(response, false, false)
             .await
             .expect("response should be buffered");
 
@@ -2612,7 +2744,7 @@ mod tests {
         );
 
         let err = match forwarder
-            .prepare_success_response_for_failover(response, false)
+            .prepare_success_response_for_failover(response, false, false)
             .await
         {
             Ok(_) => panic!("body read errors should fail the attempt"),
@@ -2620,6 +2752,47 @@ mod tests {
         };
 
         assert!(matches!(err, ProxyError::ForwardFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn non_streaming_content_unhealthy_returns_provider_unhealthy_before_success_response() {
+        let forwarder = test_forwarder(Duration::from_secs(1), Duration::from_secs(1));
+        let response = ProxyResponse::streamed(
+            StatusCode::OK,
+            HeaderMap::new(),
+            futures::stream::once(async {
+                Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                    b"SYNTHETIC_UNHEALTHY_MARKER should not be copied",
+                ))
+            }),
+        );
+
+        let err = match forwarder
+            .prepare_success_response_for_failover(response, false, true)
+            .await
+        {
+            Ok(_) => panic!("content-unhealthy body should fail the attempt"),
+            Err(err) => err,
+        };
+
+        let ProxyError::ProviderUnhealthy(message) = err else {
+            panic!("expected ProviderUnhealthy");
+        };
+        assert!(message.contains("content_unhealthy:known_signature_hit"));
+        assert!(!message.contains("SYNTHETIC_UNHEALTHY_MARKER"));
+        assert!(!message.contains("should not be copied"));
+    }
+
+    #[test]
+    fn provider_unhealthy_is_retryable_for_failover() {
+        let forwarder = test_forwarder(Duration::from_secs(1), Duration::from_secs(1));
+
+        assert_eq!(
+            forwarder.categorize_proxy_error(&ProxyError::ProviderUnhealthy(
+                "content_unhealthy:known_signature_hit hash=abc sample_len=1".to_string()
+            )),
+            ErrorCategory::Retryable
+        );
     }
 
     #[tokio::test]
@@ -2635,7 +2808,7 @@ mod tests {
         );
 
         let prepared = forwarder
-            .prepare_success_response_for_failover(response, true)
+            .prepare_success_response_for_failover(response, true, false)
             .await
             .expect("stream should be primed");
 
@@ -2657,7 +2830,7 @@ mod tests {
         );
 
         let err = match forwarder
-            .prepare_success_response_for_failover(response, true)
+            .prepare_success_response_for_failover(response, true, false)
             .await
         {
             Ok(_) => panic!("first chunk errors should fail the attempt"),
@@ -2665,6 +2838,98 @@ mod tests {
         };
 
         assert!(matches!(err, ProxyError::ForwardFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn streaming_prime_blocks_split_unhealthy_sse_before_replay() {
+        let forwarder = test_forwarder(Duration::from_secs(1), Duration::from_secs(1));
+        let response = ProxyResponse::streamed(
+            StatusCode::OK,
+            HeaderMap::new(),
+            futures::stream::iter(vec![
+                Ok::<Bytes, std::io::Error>(Bytes::from_static(b"data: SYNTHETIC_")),
+                Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                    b"UNHEALTHY_MARKER should not be copied\n\n",
+                )),
+            ]),
+        );
+
+        let err = match forwarder
+            .prepare_success_response_for_failover(response, true, true)
+            .await
+        {
+            Ok(_) => panic!("split unhealthy SSE should fail before replay"),
+            Err(err) => err,
+        };
+
+        let ProxyError::ProviderUnhealthy(message) = err else {
+            panic!("expected ProviderUnhealthy");
+        };
+        assert!(message.contains("content_unhealthy:known_signature_hit"));
+        assert!(!message.contains("SYNTHETIC_UNHEALTHY_MARKER"));
+        assert!(!message.contains("should not be copied"));
+    }
+
+    #[tokio::test]
+    async fn streaming_prime_blocks_unhealthy_sse_when_field_name_is_split() {
+        let forwarder = test_forwarder(Duration::from_secs(1), Duration::from_secs(1));
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+        let response = ProxyResponse::streamed(
+            StatusCode::OK,
+            headers,
+            futures::stream::iter(vec![
+                Ok::<Bytes, std::io::Error>(Bytes::from_static(b"da")),
+                Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                    b"ta: SYNTHETIC_UNHEALTHY_MARKER should not be copied\n\n",
+                )),
+            ]),
+        );
+
+        let err = match forwarder
+            .prepare_success_response_for_failover(response, true, true)
+            .await
+        {
+            Ok(_) => panic!("field-name split unhealthy SSE should fail before replay"),
+            Err(err) => err,
+        };
+
+        let ProxyError::ProviderUnhealthy(message) = err else {
+            panic!("expected ProviderUnhealthy");
+        };
+        assert!(message.contains("content_unhealthy:known_signature_hit"));
+        assert!(!message.contains("SYNTHETIC_UNHEALTHY_MARKER"));
+        assert!(!message.contains("should not be copied"));
+    }
+
+    #[tokio::test]
+    async fn streaming_prime_blocks_non_protocol_sse_for_generation_request() {
+        let forwarder = test_forwarder(Duration::from_secs(1), Duration::from_secs(1));
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+        let response = ProxyResponse::streamed(
+            StatusCode::OK,
+            headers,
+            futures::stream::once(async {
+                Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                    b"data: plain provider notice instead of protocol JSON\n\n",
+                ))
+            }),
+        );
+
+        let err = match forwarder
+            .prepare_success_response_for_failover(response, true, true)
+            .await
+        {
+            Ok(_) => panic!("non-protocol SSE data should fail before replay"),
+            Err(err) => err,
+        };
+
+        let ProxyError::ProviderUnhealthy(message) = err else {
+            panic!("expected ProviderUnhealthy");
+        };
+        assert!(message.contains("content_unhealthy:schema_mismatch"));
+        assert!(!message.contains("plain provider notice"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/log_codes.rs
+++ b/src-tauri/src/proxy/log_codes.rs
@@ -6,6 +6,7 @@
 //! - FWD: Forwarder (转发器)
 //! - FO: Failover (故障转移)
 //! - RSP: Response (响应处理)
+//! - CH: Content Health (内容健康)
 //! - USG: Usage (使用量)
 
 #![allow(dead_code)]
@@ -53,6 +54,13 @@ pub mod rsp {
     pub const BUILD_RESPONSE_ERROR: &str = "RSP-003";
     pub const STREAM_TIMEOUT: &str = "RSP-004";
     pub const STREAM_ERROR: &str = "RSP-005";
+}
+
+/// 内容健康日志码
+pub mod ch {
+    pub const UNHEALTHY_BLOCKED: &str = "CH-001";
+    pub const PRIME_INCONCLUSIVE: &str = "CH-002";
+    pub const PRIME_CLEAN: &str = "CH-003";
 }
 
 /// 使用量日志码

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -5,6 +5,7 @@
 pub mod body_filter;
 pub mod cache_injector;
 pub mod circuit_breaker;
+pub(crate) mod content_health;
 pub mod copilot_optimizer;
 pub mod error;
 pub mod error_mapper;


### PR DESCRIPTION
# Stage C PR Body Submission - 2026-06-01

Target upstream: `farion1231/cc-switch`

Status: submitted. The branch has been pushed and this PR is linked to the feature issue.

Safety label: `[AD_REDACTED: provider_content_poisoned]`

## PR Title

```text
feat(proxy): add response health checks for failover
```

## Body

### Summary

Classifies HTTP/SSE successful but unhealthy provider responses as retryable provider failures, so existing failover and circuit-breaker logic can recover instead of recording unusable content as provider success.

The patch is backend-only and keeps content-health errors redacted to reason, hash, and sample length.

### Related Issue

```text
Fixes #3488
```

Replace `#TODO` after opening the feature issue required by `CONTRIBUTING.md`.

Branch:

```text
https://github.com/zbeginner19-coder/cc-switch/tree/feat/proxy-content-health-failover-upstream
```

### Screenshots

Not applicable. This is a backend proxy change with no UI changes.

| Before | After |
|---|---|
| N/A | N/A |

### What Changed

- Added a proxy-layer content-health classifier for successful response bodies and early SSE data.
- Checks non-streaming successful responses before `record_success_result`.
- Checks a bounded early SSE prime window before buffered chunks are replayed.
- Maps unhealthy content to `ProxyError::ProviderUnhealthy` so existing retry/failover behavior applies.
- Adds redacted content-health log codes and tests.

Changed files:

```text
src-tauri/src/proxy/content_health.rs
src-tauri/src/proxy/forwarder.rs
src-tauri/src/proxy/log_codes.rs
src-tauri/src/proxy/mod.rs
```

### Motivation

Some providers or relays can return HTTP 200 or SSE-successful responses whose body is not valid model output, such as HTML login/captcha pages, provider notices, schema-mismatched JSON, malformed tool-call payloads, repeated unrelated stream fragments, or non-protocol SSE data.

Transport-level success should not be recorded as provider success when the response cannot be consumed safely as model output.

### Design

- Non-streaming responses are buffered and classified before provider success is recorded.
- Streaming responses use a bounded prime window before replaying buffered chunks to the client.
- Generation SSE `data:` entries are checked for protocol JSON shape before replay.
- Clean responses replay unchanged.
- Unhealthy responses return `ProxyError::ProviderUnhealthy(...)`.
- Error text and logs include only redacted metadata.

### Safety

- Does not store raw unhealthy provider content.
- Does not hardcode a single real-world domain as the detection rule.
- Does not add a new provider switching system.
- Does not change authentication, 429, timeout, or quota-failure retry semantics.
- Treats zero usage/cost as a failure only when combined with invalid or unhealthy content.
- Applies non-protocol SSE blocking only to generation requests.

### Test Plan

Verified locally:

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`: pass
- `git diff --check`: pass
- `git show --check --format= HEAD`: pass
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`: pass with warnings outside this patch
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::content_health`: `13 passed`
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::forwarder`: `45 passed`
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::sse`: `14 passed`
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::provider_router`: `6 passed`
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::circuit_breaker`: `4 passed`
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::`: `780 passed`

Known local limitations:

- Strict `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` fails locally on pre-existing warnings outside this patch (`src/settings.rs`, `src/commands/misc.rs`).
- Full `cargo test --manifest-path src-tauri/Cargo.toml` is not claimed as passing here; the focused proxy tests above are the local evidence for this patch.
- Frontend checks were not run locally because `pnpm` and `node_modules` are not available in the current environment.

### Checklist

- [ ] `pnpm typecheck` passes (not run locally; frontend dependencies are not available in this environment)
- [ ] `pnpm format:check` passes (not run locally; frontend dependencies are not available in this environment)
- [x] `cargo clippy` passes (Rust code changed; see command above)
- [x] Updated i18n files if user-facing text changed (not applicable; no user-facing UI text changed)

### AI-Assisted Disclosure

AI assistance was used to draft and iterate the patch, tests, and PR text. The final local diff was reviewed against the project goal, `CONTRIBUTING.md`, and local test evidence.

I can walk through the design and each changed function. The PR is scoped to one backend proxy behavior: classifying successful-but-unhealthy provider responses as retryable provider failures.

### Notes

Late-stream unhealthy content after buffered chunks have already been replayed is intentionally out of scope for the first patch. Handling that safely would require a larger streaming architecture change.
