### PR TITLE
fix: resolve issue #3454

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -330,6 +330,11 @@ fn decode_windows_command_output(bytes: &[u8]) -> String {
             Some(String::from_utf16_lossy(&wide[..written as usize]))
         }
     }
+    
+    // 尝试简体中文 GBK (936) 解码
+    if let Some(decoded) = decode_codepage(bytes, 936) {
+        return decoded;
+    }
 
     let oem_cp = unsafe { GetOEMCP() };
     if let Some(decoded) = decode_codepage(bytes, oem_cp) {


### PR DESCRIPTION
## Summary / 概述

解决了issue #3454 中提到的中文路径解析问题, 在decode_windows_command_output 里增加了一段优先用 GBK (936) 解码的逻辑，放在 UTF-8 检查之后、OEM CP 之前。
加上这段后，解码顺序变为：

UTF-8（如果本身就是 UTF-8 则立即返回）
GBK（新增，确保中文环境解析正确）
系统 OEM 代码页（兼容其他语言）
系统 ANSI 代码页
lossy UTF-8 兜底

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue
<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #3454
###  测试说明 (Testing Note):

- 执行 `cargo test` 后，除一个与本次无关的现有失败（`openclaw` 会话解析测试）外，其余全部通过
- 在执行本地 `pnpm test:unit` 时，发现 `App.test.tsx` 中存在 5000ms 的超时挂起错误（Infinite Retry Timeout）。经本地交叉验证，该错误在纯净的上游 `main` 分支中同样存在，确认为本地环境或上游现存的遗留问题，与本次 PR 的代码修改无关。
- 因此，本次核心功能的修复已通过 `pnpm dev` 进行了完整的本地交互测试与黑盒验证，确认 Bug 已解决且主流程运行正常。

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->


| Before / 修改前                                                                                                                      | After / 修改后 |
| ------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
| <img width="1354" height="947" alt="image" src="https://github.com/user-attachments/assets/423fc520-f48c-41ce-861d-8ba00bb218c3" />  |       <img width="1354" height="947" alt="修正后" src="https://github.com/user-attachments/assets/bb5bd946-72e1-40a1-80d8-cc3e25ae3146" />         |
       


## Checklist / 检查清单

- [X]  `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [X]  `pnpm format:check` passes / 通过代码格式检查
- [ ]  `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ]  Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
