### PR TITLE
feat(terminal): add cmux as preferred terminal on macOS

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2408,8 +2408,14 @@ pub async fn open_provider_terminal(
     let env_vars = extract_env_vars_from_config(config, &app_type);
 
     // 根据平台启动终端，传入提供商ID用于生成唯一的配置文件名
-    launch_terminal_with_env(env_vars, &providerId, launch_cwd.as_deref())
-        .map_err(|e| format!("启动终端失败: {e}"))?;
+    launch_terminal_with_env(
+        env_vars,
+        &providerId,
+        &provider.name,
+        &app,
+        launch_cwd.as_deref(),
+    )
+    .map_err(|e| format!("启动终端失败: {e}"))?;
 
     Ok(true)
 }
@@ -2501,43 +2507,163 @@ fn resolve_launch_cwd(cwd: Option<String>) -> Result<Option<PathBuf>, String> {
     Ok(Some(resolved))
 }
 
+/// 创建 provider 临时 settings 文件（`tempfile`，与 Warp 启动脚本同一模式）。
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn create_provider_config_tempfile(
+    provider_id: &str,
+    env_vars: &[(String, String)],
+) -> Result<tempfile::NamedTempFile, String> {
+    let file = tempfile::Builder::new()
+        .prefix(&format!("claude_{provider_id}_"))
+        .suffix(".json")
+        .disable_cleanup(true)
+        .tempfile()
+        .map_err(|e| format!("写入配置文件失败: {e}"))?;
+    write_claude_config(file.path(), env_vars)?;
+    Ok(file)
+}
+
+/// 创建 provider 启动脚本；`cd_in_script=false` 时 cwd 由 cmux `--cwd` 承担。
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn create_provider_launcher_script(
+    config_file: &std::path::Path,
+    cwd: Option<&std::path::Path>,
+    cd_in_script: bool,
+) -> Result<tempfile::NamedTempFile, String> {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let cd_command = if cd_in_script {
+        build_shell_cd_command(cwd)
+    } else {
+        String::new()
+    };
+    let config_path = config_file.to_string_lossy();
+
+    let mut script = tempfile::Builder::new()
+        .prefix("cc_switch_launcher_")
+        .suffix(".sh")
+        .disable_cleanup(true)
+        .permissions(std::fs::Permissions::from_mode(0o755))
+        .tempfile()
+        .map_err(|e| format!("写入启动脚本失败: {e}"))?;
+
+    let script_path = script.path().display().to_string();
+    write!(
+        script,
+        r#"#!/bin/bash
+trap 'rm -f "{config_path}" "{script_path}"' EXIT
+{cd_command}echo "Using provider-specific claude config:"
+echo "{config_path}"
+claude --settings "{config_path}"
+exec bash --norc --noprofile
+"#,
+        config_path = config_path,
+        script_path = script_path,
+        cd_command = cd_command,
+    )
+    .map_err(|e| format!("写入启动脚本失败: {e}"))?;
+
+    Ok(script)
+}
+
+/// cmux 专用 launcher：显式 `--model` + 新 `--session-id`，避免 autoResume 复用已有 Claude session。
+#[cfg(target_os = "macos")]
+fn create_provider_cmux_launcher_script(
+    config_file: &std::path::Path,
+    anthropic_model: Option<&str>,
+) -> Result<tempfile::NamedTempFile, String> {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let config_path = config_file.to_string_lossy();
+    let model_flag = anthropic_model
+        .filter(|m| !m.is_empty())
+        .map(|m| format!(" --model {}", shell_single_quote(m)))
+        .unwrap_or_default();
+
+    let mut script = tempfile::Builder::new()
+        .prefix("cc_switch_launcher_")
+        .suffix(".sh")
+        .disable_cleanup(true)
+        .permissions(std::fs::Permissions::from_mode(0o755))
+        .tempfile()
+        .map_err(|e| format!("写入启动脚本失败: {e}"))?;
+
+    let script_path = script.path().display().to_string();
+    // `--session-id` 强制新会话，避免 cmux 在同 cwd 下 autoResume 旧 Claude session
+    write!(
+        script,
+        r#"#!/bin/bash
+trap 'rm -f "{config_path}" "{script_path}"' EXIT
+echo "Using provider-specific claude config:"
+echo "{config_path}"
+claude --settings "{config_path}"{model_flag} --session-id "$(uuidgen)"
+exec bash --norc --noprofile
+"#,
+        config_path = config_path,
+        script_path = script_path,
+        model_flag = model_flag,
+    )
+    .map_err(|e| format!("写入启动脚本失败: {e}"))?;
+
+    Ok(script)
+}
+
 /// 创建临时配置文件并启动 claude 终端
 /// 使用 --settings 参数传入提供商特定的 API 配置
 fn launch_terminal_with_env(
     env_vars: Vec<(String, String)>,
     provider_id: &str,
+    provider_name: &str,
+    app: &str,
     cwd: Option<&Path>,
 ) -> Result<(), String> {
-    let temp_dir = std::env::temp_dir();
-    let config_file = temp_dir.join(format!(
-        "claude_{}_{}.json",
-        provider_id,
-        std::process::id()
-    ));
-
-    // 创建并写入配置文件
-    write_claude_config(&config_file, &env_vars)?;
-
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
-        launch_macos_terminal(&config_file, cwd)?;
-        Ok(())
-    }
+        let _config_temp = create_provider_config_tempfile(provider_id, &env_vars)?;
+        let config_file = _config_temp.path();
 
-    #[cfg(target_os = "linux")]
-    {
-        launch_linux_terminal(&config_file, cwd)?;
-        Ok(())
+        #[cfg(target_os = "macos")]
+        {
+            // cmux launcher 需要显式 `--model`，从 env 里取 ANTHROPIC_MODEL
+            let anthropic_model = env_vars
+                .iter()
+                .find(|(key, _)| key == "ANTHROPIC_MODEL")
+                .map(|(_, value)| value.as_str());
+            launch_macos_terminal(
+                config_file,
+                provider_name,
+                app,
+                cwd,
+                anthropic_model,
+            )?;
+        }
+
+        #[cfg(target_os = "linux")]
+        launch_linux_terminal(config_file, cwd)?;
+
+        return Ok(());
     }
 
     #[cfg(target_os = "windows")]
     {
+        let temp_dir = std::env::temp_dir();
+        let config_file = temp_dir.join(format!(
+            "claude_{}_{}.json",
+            provider_id,
+            std::process::id()
+        ));
+        write_claude_config(&config_file, &env_vars)?;
         launch_windows_terminal(&temp_dir, &config_file, cwd)?;
         return Ok(());
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    Err("不支持的操作系统".to_string())
+    {
+        let _ = (env_vars, provider_id, provider_name, app, cwd);
+        Err("不支持的操作系统".to_string())
+    }
 }
 
 /// 写入 claude 配置文件
@@ -2562,62 +2688,86 @@ fn write_claude_config(
 
 /// macOS: 根据用户首选终端启动
 #[cfg(target_os = "macos")]
-fn launch_macos_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> Result<(), String> {
-    use std::os::unix::fs::PermissionsExt;
-
+fn launch_macos_terminal(
+    config_file: &std::path::Path,
+    provider_name: &str,
+    app: &str,
+    cwd: Option<&Path>,
+    anthropic_model: Option<&str>,
+) -> Result<(), String> {
     let preferred = crate::settings::get_preferred_terminal();
     let terminal = preferred.as_deref().unwrap_or("terminal");
+    let use_cmux = terminal == "cmux";
 
-    let temp_dir = std::env::temp_dir();
-    let script_file = temp_dir.join(format!("cc_switch_launcher_{}.sh", std::process::id()));
-    let config_path = config_file.to_string_lossy();
-    let cd_command = build_shell_cd_command(cwd);
+    // cmux 用专用脚本（含 --model / --session-id），且 cwd 交给 cmux `--cwd` 而非脚本内 cd
+    let _script_temp = if use_cmux {
+        create_provider_cmux_launcher_script(config_file, anthropic_model)?
+    } else {
+        create_provider_launcher_script(config_file, cwd, true)?
+    };
+    let script_file = _script_temp.path();
 
-    // Write the shell script to a temp file
-    let script_content = format!(
-        r#"#!/bin/bash
-trap 'rm -f "{config_path}" "{script_file}"' EXIT
-{cd_command}
-echo "Using provider-specific claude config:"
-echo "{config_path}"
-claude --settings "{config_path}"
-exec bash --norc --noprofile
-"#,
-        config_path = config_path,
-        script_file = script_file.display(),
-        cd_command = cd_command,
-    );
-
-    std::fs::write(&script_file, &script_content).map_err(|e| format!("写入启动脚本失败: {e}"))?;
-
-    // Make script executable
-    std::fs::set_permissions(&script_file, std::fs::Permissions::from_mode(0o755))
-        .map_err(|e| format!("设置脚本权限失败: {e}"))?;
-
-    // Try the preferred terminal first, fall back to Terminal.app if it fails
-    // Note: Kitty doesn't need the -e flag, others do
     let result = match terminal {
-        "iterm2" => launch_macos_iterm2(&script_file),
-        "warp" => launch_macos_warp(&script_file),
-        "alacritty" => launch_macos_open_app("Alacritty", &script_file, true),
-        "kitty" => launch_macos_open_app("kitty", &script_file, false),
-        "ghostty" => launch_macos_ghostty(&script_file),
-        "wezterm" => launch_macos_open_app("WezTerm", &script_file, true),
-        "kaku" => launch_macos_open_app("Kaku", &script_file, true),
-        _ => launch_macos_terminal_app(&script_file), // "terminal" or default
+        "iterm2" => launch_macos_iterm2(script_file),
+        "warp" => launch_macos_warp(script_file),
+        "alacritty" => launch_macos_open_app("Alacritty", script_file, true),
+        "kitty" => launch_macos_open_app("kitty", script_file, false),
+        "ghostty" => launch_macos_ghostty(script_file),
+        "wezterm" => launch_macos_open_app("WezTerm", script_file, true),
+        "kaku" => launch_macos_open_app("Kaku", script_file, true),
+        "cmux" => {
+            // 标题格式：供应商名 · Claude，显示在 cmux 侧边栏
+            let title =
+                crate::session_manager::terminal::cmux::format_cmux_workspace_title(
+                    provider_name, app,
+                );
+            launch_macos_cmux(config_file, script_file, cwd, &title)
+        }
+        _ => launch_macos_terminal_app(script_file),
     };
 
-    // If preferred terminal fails and it's not the default, try Terminal.app as fallback
-    if result.is_err() && terminal != "terminal" {
+    // cmux 失败时不回退 Terminal.app（与 Warp 行为一致，避免悄悄换终端）
+    if result.is_err() && terminal != "terminal" && terminal != "cmux" {
         log::warn!(
             "首选终端 {} 启动失败，回退到 Terminal.app: {:?}",
             terminal,
             result.as_ref().err()
         );
-        return launch_macos_terminal_app(&script_file);
+        return launch_macos_terminal_app(script_file);
     }
 
     result
+}
+
+#[cfg(target_os = "macos")]
+fn cleanup_launch_artifacts(config_file: &std::path::Path, script_file: &std::path::Path) {
+    let _ = std::fs::remove_file(config_file);
+    let _ = std::fs::remove_file(script_file);
+}
+
+/// macOS: cmux — 新建 workspace（标题 + cwd），再 send provider 启动脚本
+#[cfg(target_os = "macos")]
+fn launch_macos_cmux(
+    config_file: &std::path::Path,
+    script_file: &std::path::Path,
+    cwd: Option<&Path>,
+    workspace_title: &str,
+) -> Result<(), String> {
+    let command = format!(
+        "bash {}",
+        shell_single_quote(&script_file.to_string_lossy())
+    );
+    let launch = crate::session_manager::terminal::cmux::CmuxWorkspaceLaunch {
+        title: workspace_title.to_string(),
+        cwd: cwd.map(|p| p.to_path_buf()),
+        command,
+    };
+    if let Err(e) = crate::session_manager::terminal::cmux::run_cmux_workspace(&launch) {
+        // 启动失败时清理临时 settings / 脚本，避免 /tmp 堆积
+        cleanup_launch_artifacts(config_file, script_file);
+        return Err(e);
+    }
+    Ok(())
 }
 
 /// macOS: Terminal.app
@@ -2847,30 +2997,8 @@ fn launch_linux_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> R
         ("ghostty", vec!["-e"]),
     ];
 
-    // Create temp script file
-    let temp_dir = std::env::temp_dir();
-    let script_file = temp_dir.join(format!("cc_switch_launcher_{}.sh", std::process::id()));
-    let config_path = config_file.to_string_lossy();
-    let cd_command = build_shell_cd_command(cwd);
-
-    let script_content = format!(
-        r#"#!/bin/bash
-trap 'rm -f "{config_path}" "{script_file}"' EXIT
-{cd_command}
-echo "Using provider-specific claude config:"
-echo "{config_path}"
-claude --settings "{config_path}"
-exec bash --norc --noprofile
-"#,
-        config_path = config_path,
-        script_file = script_file.display(),
-        cd_command = cd_command,
-    );
-
-    std::fs::write(&script_file, &script_content).map_err(|e| format!("写入启动脚本失败: {e}"))?;
-
-    std::fs::set_permissions(&script_file, std::fs::Permissions::from_mode(0o755))
-        .map_err(|e| format!("设置脚本权限失败: {e}"))?;
+    let _script_temp = create_provider_launcher_script(config_file, cwd, true)?;
+    let script_file = _script_temp.path();
 
     // Build terminal list: preferred terminal first (if specified), then defaults
     let terminals_to_try: Vec<(&str, Vec<&str>)> = if let Some(ref pref) = preferred {
@@ -3121,10 +3249,27 @@ read -n 1 -s
             "ghostty" => launch_macos_ghostty(&script_file),
             "wezterm" => launch_macos_open_app("WezTerm", &script_file, true),
             "kaku" => launch_macos_open_app("Kaku", &script_file, true),
+            "cmux" => {
+                // 工具栏「在终端中运行」路径：无 provider 名，用 label 拼 workspace 标题
+                let title = crate::session_manager::terminal::cmux::format_cmux_workspace_title(
+                    label, "claude",
+                );
+                let command = format!(
+                    "bash {}",
+                    shell_single_quote(&script_file.to_string_lossy())
+                );
+                crate::session_manager::terminal::cmux::run_cmux_workspace(
+                    &crate::session_manager::terminal::cmux::CmuxWorkspaceLaunch {
+                        title,
+                        cwd: None,
+                        command,
+                    },
+                )
+            }
             _ => launch_macos_terminal_app(&script_file),
         };
 
-        if result.is_err() && terminal != "terminal" {
+        if result.is_err() && terminal != "terminal" && terminal != "cmux" {
             log::warn!(
                 "首选终端 {} 启动失败，回退到 Terminal.app: {:?}",
                 terminal,
@@ -4654,6 +4799,52 @@ mod tests {
         let command = build_shell_cd_command(Some(Path::new("/tmp/project O'Brien")));
 
         assert_eq!(command, "cd '/tmp/project O'\"'\"'Brien' || exit 1\n");
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn provider_launcher_script_embeds_config_path_and_claude_settings() {
+        let config = create_provider_config_tempfile(
+            "demo",
+            &[("ANTHROPIC_BASE_URL".into(), "https://a.example".into())],
+        )
+        .expect("config tempfile");
+        let config_path = config.path().to_string_lossy().to_string();
+        let script = create_provider_launcher_script(config.path(), None, true)
+            .expect("launcher script tempfile");
+        let contents =
+            std::fs::read_to_string(script.path()).expect("read launcher script contents");
+        assert!(contents.contains(&config_path));
+        assert!(contents.contains("claude --settings"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn provider_cmux_launcher_script_uses_model_and_fresh_session() {
+        let config = create_provider_config_tempfile(
+            "demo",
+            &[("ANTHROPIC_MODEL".into(), "deepseek-v4-pro".into())],
+        )
+        .expect("config tempfile");
+        let script =
+            create_provider_cmux_launcher_script(config.path(), Some("deepseek-v4-pro"))
+                .expect("cmux launcher script");
+        let contents =
+            std::fs::read_to_string(script.path()).expect("read cmux launcher script contents");
+        assert!(contents.contains("--model 'deepseek-v4-pro'"));
+        assert!(contents.contains("--session-id \"$(uuidgen)\""));
+        assert!(!contents.contains("cd '"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn provider_launcher_script_omits_cd_when_cmux_uses_workspace_cwd() {
+        let config = create_provider_config_tempfile("demo", &[]).expect("config tempfile");
+        let script = create_provider_cmux_launcher_script(config.path(), None)
+            .expect("cmux launcher script");
+        let contents =
+            std::fs::read_to_string(script.path()).expect("read launcher script contents");
+        assert!(!contents.contains("cd '/tmp/project'"));
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/session_manager/terminal/cmux.rs
+++ b/src-tauri/src/session_manager/terminal/cmux.rs
@@ -1,0 +1,552 @@
+//! 从 CC Switch 等外部 GUI 应用通过 [cmux](https://cmux.com/) CLI 启动终端会话。
+//!
+//! 与 Ghostty/Warp 等不同，cmux 没有 URL scheme，必须调用 `Resources/bin/cmux` 并通过 Unix socket
+//! 控制 workspace。Tauri/Finder 进程的 `PATH` 通常很短，且 socket 默认可能拒绝外部客户端，
+//! 因此需要显式解析 CLI 路径、设置 `CMUX_SOCKET_MODE`，并在 cmux 未运行时冷启动 GUI 主程序。
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::Duration;
+
+/// cmux 侧边栏 workspace 标题：`{provider_name} · {app_short}`
+pub fn format_cmux_workspace_title(provider_name: &str, app: &str) -> String {
+    let app_short = match app {
+        "claude" => "Claude".to_string(),
+        "codex" => "Codex".to_string(),
+        "gemini" => "Gemini".to_string(),
+        other => {
+            let mut chars = other.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+            }
+        }
+    };
+    let mut name: String = provider_name
+        .replace(['\n', '\r'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    const MAX_CHARS: usize = 64;
+    if name.chars().count() > MAX_CHARS {
+        name = name.chars().take(MAX_CHARS - 1).collect::<String>() + "…";
+    }
+    format!("{name} · {app_short}")
+}
+
+pub struct CmuxWorkspaceLaunch {
+    pub title: String,
+    pub cwd: Option<PathBuf>,
+    /// 要在 workspace 里执行的 shell 命令行（如 `bash '/tmp/script.sh'`），send 时会自动补换行。
+    pub command: String,
+}
+
+/// 判断路径是否指向 cmux GUI 主二进制（`Contents/MacOS/cmux`），该路径不能当 CLI 用。
+pub fn is_macos_gui_cmux_binary(path: &Path) -> bool {
+    path.to_string_lossy().contains("Contents/MacOS/cmux")
+}
+
+/// 定位 cmux.app 的 GUI 主程序，用于冷启动时附带 `CMUX_SOCKET_MODE=allowAll`。
+pub fn find_cmux_bundle_main_executable() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join("Applications/cmux.app/Contents/MacOS/cmux"));
+    }
+    candidates.push(PathBuf::from("/Applications/cmux.app/Contents/MacOS/cmux"));
+    candidates.into_iter().find(|p| p.is_file())
+}
+
+fn spawn_cmux_main_with_allow_all() -> bool {
+    let Some(exe) = find_cmux_bundle_main_executable() else {
+        return false;
+    };
+    Command::new(&exe)
+        .env("CMUX_SOCKET_MODE", "allowAll")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .is_ok()
+}
+
+fn cmux_ping(exe: &Path) -> bool {
+    run_cmux_checked(exe, &["ping"], "ping", "automation").is_ok()
+        || run_cmux_checked(exe, &["ping"], "ping", "allowAll").is_ok()
+}
+
+fn wait_for_cmux_ping(exe: &Path, max_wait_ms: u64) -> bool {
+    let step = Duration::from_millis(150);
+    let mut waited = 0u64;
+    while waited < max_wait_ms {
+        if cmux_ping(exe) {
+            return true;
+        }
+        thread::sleep(step);
+        waited += step.as_millis() as u64;
+    }
+    false
+}
+
+/// 确保 cmux 已运行且 socket 可用。
+fn ensure_cmux_app_ready(exe: &Path) -> Result<(), String> {
+    if cmux_ping(exe) {
+        // 已在运行：激活窗口即可，不要再次 spawn（避免多实例或重复恢复 workspace）
+        let status = Command::new("open")
+            .args(["-a", "cmux"])
+            .status()
+            .map_err(|e| format!("Failed to run open -a cmux: {e}"))?;
+        if status.success() {
+            thread::sleep(Duration::from_millis(200));
+            return Ok(());
+        }
+        return Err(
+            "open -a cmux failed. Make sure cmux is installed in /Applications.".into(),
+        );
+    }
+
+    // cmux 未运行：必须用 GUI 主二进制 + allowAll 启动，单纯 `open -a` 不会写入 socket 策略
+    if !spawn_cmux_main_with_allow_all() {
+        return Err("Failed to launch cmux.app. Make sure cmux is installed.".into());
+    }
+    if !wait_for_cmux_ping(exe, 5000) {
+        return Err("Timed out waiting for cmux socket.".into());
+    }
+    thread::sleep(Duration::from_millis(400));
+    Ok(())
+}
+
+/// 解析 cmux CLI 路径（`Contents/Resources/bin/cmux`），禁止使用 GUI 主二进制。
+pub fn resolve_cmux_cli() -> Result<PathBuf, String> {
+    if let Ok(custom) = std::env::var("CMUX_CLI") {
+        let trimmed = custom.trim();
+        if !trimmed.is_empty() {
+            let p = PathBuf::from(trimmed);
+            if p.is_file() {
+                if is_macos_gui_cmux_binary(&p) {
+                    return Err(format!(
+                        "CMUX_CLI points to the GUI binary; use Resources/bin/cmux instead: {trimmed}"
+                    ));
+                }
+                return Ok(p);
+            }
+            return Err(format!("CMUX_CLI is set but is not a valid file: {trimmed}"));
+        }
+    }
+
+    // Tauri 进程 PATH 短，按常见安装位置依次探测；Ghostty/Warp 用 `open -a` 不需要这一步
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join("Applications/cmux.app/Contents/Resources/bin/cmux"));
+        candidates.push(home.join(".local/bin/cmux"));
+    }
+    candidates.extend([
+        PathBuf::from("/Applications/cmux.app/Contents/Resources/bin/cmux"),
+        PathBuf::from("/opt/homebrew/bin/cmux"),
+        PathBuf::from("/usr/local/bin/cmux"),
+    ]);
+
+    for p in candidates {
+        if p.is_file() && !is_macos_gui_cmux_binary(&p) {
+            return Ok(p);
+        }
+    }
+
+    // 兜底：模拟用户在 login shell 里 `command -v cmux`（覆盖自定义安装路径）
+    if let Some(p) = resolve_via_zsh_login_shell() {
+        if !is_macos_gui_cmux_binary(&p) {
+            return Ok(p);
+        }
+    }
+
+    Err("cmux CLI not found. Install cmux or set CMUX_CLI to \
+         /Applications/cmux.app/Contents/Resources/bin/cmux"
+        .into())
+}
+
+fn resolve_via_zsh_login_shell() -> Option<PathBuf> {
+    let output = Command::new("/bin/zsh")
+        .args(["-l", "-c", "command -v cmux"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if s.is_empty() {
+        return None;
+    }
+    let p = PathBuf::from(s);
+    if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+fn format_cmux_failure_hint() -> &'static str {
+    " | Fix: allow external socket access in cmux settings, or quit and reopen cmux; see https://cmux.com/docs/api"
+}
+
+fn format_cmux_failure(output: &Output, step: &str) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut msg = format!("cmux {step} failed (exit {:?})", output.status.code());
+    if !stderr.trim().is_empty() {
+        msg.push_str(": ");
+        msg.push_str(stderr.trim());
+    } else if !stdout.trim().is_empty() {
+        msg.push_str(": ");
+        msg.push_str(stdout.trim());
+    }
+    msg.push_str(format_cmux_failure_hint());
+    msg
+}
+
+fn run_cmux_checked(
+    exe: &Path,
+    args: &[&str],
+    step: &str,
+    socket_mode: &str,
+) -> Result<(), String> {
+    let output = Command::new(exe)
+        .env("CMUX_SOCKET_MODE", socket_mode)
+        .args(args)
+        .output()
+        .map_err(|e| format!("Failed to run cmux ({step}): {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format_cmux_failure(&output, step))
+    }
+}
+
+fn run_cmux_with_modes(exe: &Path, args: &[&str], step: &str) -> Result<(), String> {
+    // 优先 automation；外部 GUI 进程常被拒时再试 allowAll
+    if run_cmux_checked(exe, args, step, "automation").is_ok() {
+        return Ok(());
+    }
+    run_cmux_checked(exe, args, step, "allowAll")
+}
+
+fn parse_workspace_id(stdout: &str) -> Option<String> {
+    // cmux 不同版本/输出格式：`{"workspace_id":"..."}` 或 `OK workspace:4`
+    let trimmed = stdout.trim();
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if let Some(id) = v.get("workspace_id").and_then(|x| x.as_str()) {
+            return Some(id.to_string());
+        }
+    }
+    for line in trimmed.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("OK workspace:") {
+            let id = rest.trim();
+            if !id.is_empty() {
+                return Some(format!("workspace:{id}"));
+            }
+        }
+    }
+    for token in trimmed.split_whitespace() {
+        if token.starts_with("workspace:") {
+            return Some(token.to_string());
+        }
+    }
+    None
+}
+
+fn stderr_suggests_unknown_flag(stderr: &str, flag: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("unknown") && lower.contains(flag)
+}
+
+#[derive(Clone, Copy, Default)]
+struct NewWorkspaceOpts {
+    json: bool,
+    with_name: bool,
+    with_command: bool,
+    with_cwd: bool,
+    with_focus: bool,
+}
+
+fn build_new_workspace_argv(launch: &CmuxWorkspaceLaunch, opts: NewWorkspaceOpts) -> Vec<String> {
+    let mut args = vec!["new-workspace".into()];
+    if opts.json {
+        args.push("--json".into());
+    }
+    if opts.with_cwd {
+        if let Some(cwd) = &launch.cwd {
+            args.push("--cwd".into());
+            args.push(cwd.to_string_lossy().into_owned());
+        }
+    }
+    if opts.with_name {
+        args.push("--name".into());
+        args.push(launch.title.clone());
+    }
+    if opts.with_command {
+        args.push("--command".into());
+        args.push(launch.command.clone());
+    }
+    if opts.with_focus {
+        args.push("--focus".into());
+        args.push("true".into());
+    }
+    args
+}
+
+/// 先 automation，失败再 allowAll；失败时返回 **最后一次** 尝试的 Output。
+fn run_cmux_output_with_modes(exe: &Path, args: &[&str]) -> Result<Output, String> {
+    let run = |mode: &str| {
+        Command::new(exe)
+            .env("CMUX_SOCKET_MODE", mode)
+            .args(args)
+            .output()
+    };
+    let output = run("automation").map_err(|e| format!("Failed to run cmux: {e}"))?;
+    if output.status.success() {
+        return Ok(output);
+    }
+    let allow_output = run("allowAll").map_err(|e| format!("Failed to run cmux: {e}"))?;
+    Ok(allow_output)
+}
+
+/// 清除 workspace 上待恢复的 agent session，避免 autoResume 抢先于 CC Switch 注入的命令。
+fn clear_surface_resume(exe: &Path, workspace: &str) {
+    let _ = run_cmux_with_modes(
+        exe,
+        &["surface", "resume", "clear", "--workspace", workspace],
+        "surface resume clear",
+    );
+}
+
+fn send_command_to_workspace(
+    exe: &Path,
+    workspace: &str,
+    launch: &CmuxWorkspaceLaunch,
+) -> Result<(), String> {
+    clear_surface_resume(exe, workspace);
+    // send 需要 trailing newline 才会在 shell 里执行，而不是只粘贴到提示符
+    let send_body = format!("{}\n", launch.command);
+    run_cmux_with_modes(
+        exe,
+        &["send", "--workspace", workspace, &send_body],
+        "send",
+    )
+}
+
+fn new_workspace_with_title_and_command(
+    exe: &Path,
+    launch: &CmuxWorkspaceLaunch,
+) -> Result<(), String> {
+    new_workspace_create_then_send(exe, launch, true)
+}
+
+/// 先创建 workspace（不用 `--command`，避免与 autoResume 竞态），再 clear resume + send。
+fn new_workspace_create_then_send(
+    exe: &Path,
+    launch: &CmuxWorkspaceLaunch,
+    with_focus: bool,
+) -> Result<(), String> {
+    let args = build_new_workspace_argv(
+        launch,
+        NewWorkspaceOpts {
+            json: true,
+            with_name: true,
+            with_cwd: true,
+            with_focus,
+            ..Default::default()
+        },
+    );
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let output = run_cmux_output_with_modes(exe, &arg_refs)?;
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let ws = parse_workspace_id(&stdout)
+            .ok_or_else(|| {
+                format!("cmux new-workspace --json did not return a workspace id: {stdout}")
+            })?;
+        return send_command_to_workspace(exe, &ws, launch);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if with_focus && stderr_suggests_unknown_flag(&stderr, "focus") {
+        return new_workspace_create_then_send(exe, launch, false);
+    }
+    if stderr_suggests_unknown_flag(&stderr, "name") {
+        return new_workspace_rename_then_command(exe, launch, with_focus);
+    }
+    if stderr_suggests_unknown_flag(&stderr, "cwd") {
+        return new_workspace_send_fallback(exe, launch, with_focus);
+    }
+
+    Err(format_cmux_failure(&output, "new-workspace"))
+}
+
+fn new_workspace_rename_then_command(
+    exe: &Path,
+    launch: &CmuxWorkspaceLaunch,
+    with_focus: bool,
+) -> Result<(), String> {
+    // 旧版 cmux 不支持 `new-workspace --name`：先创建再 rename
+    let args = build_new_workspace_argv(
+        launch,
+        NewWorkspaceOpts {
+            json: true,
+            with_cwd: true,
+            with_focus,
+            ..Default::default()
+        },
+    );
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let output = run_cmux_output_with_modes(exe, &arg_refs)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if with_focus && stderr_suggests_unknown_flag(&stderr, "focus") {
+            return new_workspace_rename_then_command(exe, launch, false);
+        }
+        return Err(format_cmux_failure(&output, "new-workspace"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let ws = parse_workspace_id(&stdout)
+        .ok_or_else(|| format!("cmux new-workspace --json did not return a workspace id: {stdout}"))?;
+
+    run_cmux_with_modes(
+        exe,
+        &["rename-workspace", "--workspace", &ws, &launch.title],
+        "rename-workspace",
+    )?;
+
+    send_command_to_workspace(exe, &ws, launch)
+}
+
+fn new_workspace_send_fallback(
+    exe: &Path,
+    launch: &CmuxWorkspaceLaunch,
+    with_focus: bool,
+) -> Result<(), String> {
+    // 更旧版本不支持 `--cwd`：在 send 正文里手动 `cd`
+    let args = build_new_workspace_argv(
+        launch,
+        NewWorkspaceOpts {
+            json: true,
+            with_focus,
+            ..Default::default()
+        },
+    );
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let output = run_cmux_output_with_modes(exe, &arg_refs)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if with_focus && stderr_suggests_unknown_flag(&stderr, "focus") {
+            return new_workspace_send_fallback(exe, launch, false);
+        }
+        return Err(format_cmux_failure(&output, "new-workspace"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let ws = parse_workspace_id(&stdout)
+        .ok_or_else(|| format!("cmux new-workspace --json did not return a workspace id: {stdout}"))?;
+
+    let mut send_text = String::new();
+    if let Some(cwd) = &launch.cwd {
+        send_text.push_str(&format!(
+            "cd {} && ",
+            shell_single_quote(&cwd.to_string_lossy())
+        ));
+    }
+    send_text.push_str(&launch.command);
+    if !send_text.ends_with('\n') {
+        send_text.push('\n');
+    }
+
+    clear_surface_resume(exe, &ws);
+    run_cmux_with_modes(exe, &["send", "--workspace", &ws, &send_text], "send")?;
+
+    run_cmux_with_modes(
+        exe,
+        &["rename-workspace", "--workspace", &ws, &launch.title],
+        "rename-workspace",
+    )
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+/// 创建带标题的新 workspace 并在其中执行命令（Provider 打开终端 / Session 恢复共用入口）。
+pub fn run_cmux_workspace(launch: &CmuxWorkspaceLaunch) -> Result<(), String> {
+    let exe = resolve_cmux_cli()?;
+    ensure_cmux_app_ready(&exe)?;
+    new_workspace_with_title_and_command(&exe, launch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn title_claude() {
+        assert_eq!(
+            format_cmux_workspace_title("PackyCode", "claude"),
+            "PackyCode · Claude"
+        );
+    }
+
+    #[test]
+    fn title_strips_newlines() {
+        assert_eq!(
+            format_cmux_workspace_title("a\nb", "claude"),
+            "a b · Claude"
+        );
+    }
+
+    #[test]
+    fn title_truncates_long_name() {
+        let long = "x".repeat(80);
+        let title = format_cmux_workspace_title(&long, "claude");
+        assert!(title.chars().count() <= 64 + " · Claude".chars().count());
+        assert!(title.ends_with("· Claude"));
+    }
+
+    #[test]
+    fn rejects_macos_gui_path() {
+        let p = PathBuf::from("/Applications/cmux.app/Contents/MacOS/cmux");
+        assert!(is_macos_gui_cmux_binary(&p));
+    }
+
+    #[test]
+    fn accepts_resources_bin_path() {
+        let p = PathBuf::from("/Applications/cmux.app/Contents/Resources/bin/cmux");
+        assert!(!is_macos_gui_cmux_binary(&p));
+    }
+
+    #[test]
+    fn parse_workspace_id_from_ok_line() {
+        assert_eq!(
+            parse_workspace_id("OK workspace:4\n"),
+            Some("workspace:4".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_workspace_id_from_json() {
+        assert_eq!(
+            parse_workspace_id(r#"{"workspace_id":"workspace:2"}"#),
+            Some("workspace:2".to_string())
+        );
+    }
+
+    #[test]
+    fn stderr_suggests_unknown_flag_matches() {
+        assert!(stderr_suggests_unknown_flag(
+            "Error: unknown flag: --focus",
+            "focus"
+        ));
+        assert!(!stderr_suggests_unknown_flag(
+            "socket connection refused",
+            "focus"
+        ));
+    }
+}

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -1,5 +1,9 @@
 use std::process::Command;
 
+// cmux 集成逻辑较长，单独成模块；
+#[cfg(target_os = "macos")]
+pub mod cmux;
+
 pub fn launch_terminal(
     target: &str,
     command: &str,
@@ -22,6 +26,8 @@ pub fn launch_terminal(
         "wezterm" => launch_wezterm(command, cwd),
         "kaku" => launch_kaku(command, cwd),
         "alacritty" => launch_alacritty(command, cwd),
+        #[cfg(target_os = "macos")]
+        "cmux" => launch_cmux(command, cwd),
         #[cfg(unix)]
         "warp" => launch_warp(command, cwd),
         "custom" => launch_custom(command, cwd, custom_config),
@@ -243,6 +249,18 @@ fn launch_warp(command: &str, cwd: Option<&str>) -> Result<(), String> {
     } else {
         Err("Failed to launch Warp.".to_string())
     }
+}
+
+#[cfg(target_os = "macos")]
+fn launch_cmux(command: &str, cwd: Option<&str>) -> Result<(), String> {
+    // Session 恢复：每次新建 workspace；cwd 由 cmux `--cwd` 承担（与 Provider 路径一致）
+    let full_command = build_shell_command(command, cwd);
+    let launch = cmux::CmuxWorkspaceLaunch {
+        title: "Claude Session · Claude".to_string(),
+        cwd: cwd.map(std::path::PathBuf::from),
+        command: format!("{full_command}\n"),
+    };
+    cmux::run_cmux_workspace(&launch)
 }
 
 fn launch_alacritty(command: &str, cwd: Option<&str>) -> Result<(), String> {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -336,7 +336,7 @@ pub struct AppSettings {
 
     // ===== 终端设置 =====
     /// 首选终端应用（可选，默认使用系统默认终端）
-    /// - macOS: "terminal" | "iterm2" | "warp" | "alacritty" | "kitty" | "ghostty" | "wezterm" | "kaku"
+    /// - macOS: "terminal" | "iterm2" | "warp" | "alacritty" | "kitty" | "ghostty" | "wezterm" | "kaku" | "cmux"
     /// - Windows: "cmd" | "powershell" | "wt" (Windows Terminal)
     /// - Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/components/settings/TerminalSettings.tsx
+++ b/src/components/settings/TerminalSettings.tsx
@@ -18,6 +18,7 @@ const MACOS_TERMINALS = [
   { value: "wezterm", labelKey: "settings.terminal.options.macos.wezterm" },
   { value: "kaku", labelKey: "settings.terminal.options.macos.kaku" },
   { value: "warp", labelKey: "settings.terminal.options.macos.warp" },
+  { value: "cmux", labelKey: "settings.terminal.options.macos.cmux" },
 ] as const;
 
 const WINDOWS_TERMINALS = [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -605,7 +605,8 @@
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
           "kaku": "Kaku",
-          "warp": "Warp"
+          "warp": "Warp",
+          "cmux": "cmux"
         },
         "windows": {
           "cmd": "Command Prompt",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -605,7 +605,8 @@
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
           "kaku": "Kaku",
-          "warp": "Warp"
+          "warp": "Warp",
+          "cmux": "cmux"
         },
         "windows": {
           "cmd": "コマンドプロンプト",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -605,7 +605,8 @@
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
           "kaku": "Kaku",
-          "warp": "Warp"
+          "warp": "Warp",
+          "cmux": "cmux"
         },
         "windows": {
           "cmd": "命令提示字元",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -605,7 +605,8 @@
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
           "kaku": "Kaku",
-          "warp": "Warp"
+          "warp": "Warp",
+          "cmux": "cmux"
         },
         "windows": {
           "cmd": "命令提示符",

--- a/src/types.ts
+++ b/src/types.ts
@@ -390,7 +390,7 @@ export interface Settings {
 
   // ===== 终端设置 =====
   // 首选终端应用（可选，默认使用系统默认终端）
-  // macOS: "terminal" | "iterm2" | "warp" | "alacritty" | "kitty" | "ghostty" | "wezterm" | "kaku"
+  // macOS: "terminal" | "iterm2" | "warp" | "alacritty" | "kitty" | "ghostty" | "wezterm" | "kaku" | "cmux"
   // Windows: "cmd" | "powershell" | "wt"
   // Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
   preferredTerminal?: string;


### PR DESCRIPTION
## Summary

- macOS 设置页「首选终端」新增 **cmux** 选项
- Provider 卡片「打开终端」：每次新建 cmux workspace，标题为 `Provider名 · Claude`，并用该 Provider 的 `claude --settings` 启动（不要求当前激活 Provider）
- Session Manager 恢复会话同样走 cmux
- 新增 `src-tauri/src/session_manager/terminal/cmux.rs`，集中处理 cmux CLI / socket 交互

## 实现要点

- 规避 cmux `autoResumeAgentSessions` 与 `new-workspace --command` 的竞态：改为 `new-workspace --json` → `surface resume clear` → `send`
- launcher 使用 `claude --settings` + `--model` + `--session-id "$(uuidgen)"`，避免同 cwd 下误 resume 旧 session
- cmux 启动失败不回退 Terminal.app（与 Warp 行为一致）

Related to #1949

相对 #1947 的改进：
- 将 cmux 逻辑迁入 `session_manager/terminal/cmux.rs`，与现有终端架构对齐
- 修复多 Provider 连续打开时模型相同的问题（autoResume 竞态 + session resume）
- 不包含「重启 cmux（允许外部控制）」设置 UI

## Test plan

- [x] `cargo test -p cc-switch --lib cmux`（10 passed）
- [x] 手动验证：连续打开两个不同 Provider，cmux 窗口模型正确区分
- [ ] 维护者 review

## 未包含

- CHANGELOG.md
- docs/user-manual
- 本地 dev 脚本变更