### PR TITLE
fix: align Codex config with current schema

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -15,18 +15,6 @@ pub const CC_SWITCH_CODEX_MODEL_PROVIDER_ID: &str = "custom";
 pub const CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME: &str = "cc-switch-model-catalog.json";
 const CODEX_MODEL_CATALOG_TEMPLATE_SLUG: &str = "gpt-5.5";
 
-/// Reserved built-in provider IDs from OpenAI Codex's config/model-provider
-/// catalog. Keep in sync with Codex `RESERVED_MODEL_PROVIDER_IDS` and legacy
-/// removed provider aliases.
-const CODEX_RESERVED_MODEL_PROVIDER_IDS: &[&str] = &[
-    "amazon-bedrock",
-    "openai",
-    "ollama",
-    "lmstudio",
-    "oss",
-    "ollama-chat",
-];
-
 /// 获取 Codex 配置目录路径
 pub fn get_codex_config_dir() -> PathBuf {
     if let Some(custom) = crate::settings::get_codex_override_dir() {
@@ -163,14 +151,6 @@ fn active_codex_model_provider_id(doc: &DocumentMut) -> Option<String> {
         .map(str::trim)
         .filter(|id| !id.is_empty())
         .map(str::to_string)
-}
-
-pub(crate) fn is_custom_codex_model_provider_id(id: &str) -> bool {
-    let id = id.trim();
-    !id.is_empty()
-        && !CODEX_RESERVED_MODEL_PROVIDER_IDS
-            .iter()
-            .any(|reserved| reserved.eq_ignore_ascii_case(id))
 }
 
 /// Write only Codex `config.toml` for provider switching.
@@ -875,10 +855,9 @@ pub fn write_codex_provider_live_with_catalog(
 
 /// Extract a provider-scoped `experimental_bearer_token` from Codex `config.toml`.
 ///
-/// Mobile compat: third-party providers may store the API key inside
-/// `[model_providers.<id>].experimental_bearer_token` while keeping the
-/// user's ChatGPT login cache intact in `auth.json`. Falls back to the
-/// top-level `experimental_bearer_token` when no active model provider is set.
+/// Current Codex schema expects the token at
+/// `[model_providers.<id>].experimental_bearer_token`. The top-level field is
+/// still read for legacy config import and cleanup.
 pub fn extract_codex_experimental_bearer_token(config_text: &str) -> Option<String> {
     if !config_text.contains("experimental_bearer_token") {
         return None;
@@ -890,18 +869,16 @@ pub fn extract_codex_experimental_bearer_token(config_text: &str) -> Option<Stri
         doc.get("experimental_bearer_token")
             .and_then(|item| item.as_str())
     };
-    let token = match provider_id.as_deref() {
-        Some(id) if is_custom_codex_model_provider_id(id) => doc
-            .get("model_providers")
+
+    let provider_token = provider_id.as_deref().and_then(|id| {
+        doc.get("model_providers")
             .and_then(|item| item.as_table())
             .and_then(|table| table.get(id))
             .and_then(|item| item.as_table())
             .and_then(|table| table.get("experimental_bearer_token"))
             .and_then(|item| item.as_str())
-            .or_else(top_level_token),
-        Some(_) => top_level_token(),
-        None => top_level_token(),
-    };
+    });
+    let token = provider_token.or_else(top_level_token);
 
     token
         .map(str::trim)
@@ -922,32 +899,52 @@ fn set_codex_experimental_bearer_token(config_text: &str, token: &str) -> Result
         .parse::<DocumentMut>()
         .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
 
-    let Some(provider_id) = active_codex_model_provider_id(&doc) else {
-        doc["experimental_bearer_token"] = toml_edit::value(token);
-        return Ok(doc.to_string());
+    let provider_id = match active_codex_model_provider_id(&doc) {
+        Some(id) => id,
+        None => {
+            // 兼容旧式顶层 base_url 配置：缺少 model_provider 时迁移到 custom。
+            doc["model_provider"] = toml_edit::value(CC_SWITCH_CODEX_MODEL_PROVIDER_ID);
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string()
+        }
     };
 
-    if !is_custom_codex_model_provider_id(&provider_id) {
-        // Reserved Codex provider IDs are owned by the CLI. Keep third-party
-        // bearer tokens at the top level so we do not shadow built-in tables.
-        doc["experimental_bearer_token"] = toml_edit::value(token);
-        return Ok(doc.to_string());
+    if doc.get("model_providers").is_none() {
+        doc["model_providers"] = toml_edit::table();
     }
 
-    if let Some(model_providers) = doc
-        .get_mut("model_providers")
+    // 清理旧版顶层字段，避免继续生成不符合当前 Codex schema 的配置。
+    let mut legacy_provider_fields = Vec::new();
+    for field in ["base_url", "wire_api", "requires_openai_auth"] {
+        if let Some(item) = doc.as_table_mut().remove(field) {
+            legacy_provider_fields.push((field, item));
+        }
+    }
+    doc.as_table_mut().remove("experimental_bearer_token");
+
+    let model_providers = doc["model_providers"].as_table_mut().ok_or_else(|| {
+        AppError::Message("Invalid Codex config.toml: model_providers must be a table".into())
+    })?;
+
+    if !model_providers.contains_key(provider_id.as_str()) {
+        model_providers[provider_id.as_str()] = toml_edit::table();
+    }
+
+    let provider_table = model_providers
+        .get_mut(provider_id.as_str())
         .and_then(|item| item.as_table_mut())
-    {
-        if let Some(provider_table) = model_providers
-            .get_mut(provider_id.as_str())
-            .and_then(|item| item.as_table_mut())
-        {
-            provider_table["experimental_bearer_token"] = toml_edit::value(token);
-            return Ok(doc.to_string());
+        .ok_or_else(|| {
+            AppError::Message(format!(
+                "Invalid Codex config.toml: model_providers.{provider_id} must be a table"
+            ))
+        })?;
+
+    for (field, item) in legacy_provider_fields {
+        if !provider_table.contains_key(field) {
+            provider_table[field] = item;
         }
     }
 
-    doc["experimental_bearer_token"] = toml_edit::value(token);
+    provider_table["experimental_bearer_token"] = toml_edit::value(token);
     Ok(doc.to_string())
 }
 
@@ -1044,7 +1041,7 @@ pub fn write_codex_live_for_provider(
 /// Build the live Codex config for provider switching.
 ///
 /// The stored provider keeps its API key in `auth.OPENAI_API_KEY`. Live Codex
-/// requests can use a provider-scoped `experimental_bearer_token`, so switching
+/// requests use a provider-scoped `experimental_bearer_token`, so switching
 /// providers only needs to update `config.toml`; `auth.json` stays as the user's
 /// long-lived ChatGPT login cache.
 pub fn prepare_codex_provider_live_config(
@@ -1245,7 +1242,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_provider_live_config_uses_top_level_token_for_reserved_provider() {
+    fn prepare_provider_live_config_writes_provider_token_for_reserved_provider() {
         let input = r#"model_provider = "openai"
 model = "gpt-5"
 "#;
@@ -1257,28 +1254,30 @@ model = "gpt-5"
 
         assert_eq!(
             parsed
-                .get("experimental_bearer_token")
+                .get("model_providers")
+                .and_then(|v| v.get("openai"))
+                .and_then(|v| v.get("experimental_bearer_token"))
                 .and_then(|v| v.as_str()),
             Some("sk-test")
         );
         assert!(
-            parsed.get("model_providers").is_none(),
-            "reserved provider tables should not be synthesized"
+            parsed.get("experimental_bearer_token").is_none(),
+            "token should not be written at the top level"
         );
     }
 
     #[test]
-    fn extract_bearer_uses_top_level_token_for_reserved_provider() {
+    fn extract_bearer_prefers_active_provider_token() {
         let input = r#"model_provider = "openai"
 experimental_bearer_token = "top-level-key"
 
 [model_providers.openai]
-experimental_bearer_token = "stale-table-key"
+experimental_bearer_token = "provider-key"
 "#;
 
         assert_eq!(
             extract_codex_experimental_bearer_token(input).as_deref(),
-            Some("top-level-key")
+            Some("provider-key")
         );
     }
 
@@ -1313,7 +1312,7 @@ experimental_bearer_token = "stale-table-key"
     }
 
     #[test]
-    fn prepare_provider_live_config_does_not_create_incomplete_provider_table() {
+    fn prepare_provider_live_config_creates_missing_provider_table() {
         let input = r#"model_provider = "vendor_x"
 model = "gpt-5"
 "#;
@@ -1325,13 +1324,51 @@ model = "gpt-5"
 
         assert_eq!(
             parsed
+                .get("model_providers")
+                .and_then(|v| v.get("vendor_x"))
+                .and_then(|v| v.get("experimental_bearer_token"))
+                .and_then(|v| v.as_str()),
+            Some("sk-test")
+        );
+        assert!(
+            parsed.get("experimental_bearer_token").is_none(),
+            "token should not be written at the top level"
+        );
+    }
+
+    #[test]
+    fn prepare_provider_live_config_migrates_legacy_top_level_routing() {
+        let input = r#"base_url = "https://legacy.example/v1"
+wire_api = "responses"
+model = "gpt-5"
+"#;
+
+        let output =
+            prepare_codex_provider_live_config(&json!({"OPENAI_API_KEY": "sk-test"}), input)
+                .expect("prepare live config");
+        let parsed: toml::Value = toml::from_str(&output).expect("parse output");
+
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some(CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
+        );
+        let provider = parsed
+            .get("model_providers")
+            .and_then(|v| v.get(CC_SWITCH_CODEX_MODEL_PROVIDER_ID))
+            .expect("custom provider should be created");
+        assert_eq!(
+            provider.get("base_url").and_then(|v| v.as_str()),
+            Some("https://legacy.example/v1")
+        );
+        assert_eq!(
+            provider
                 .get("experimental_bearer_token")
                 .and_then(|v| v.as_str()),
             Some("sk-test")
         );
         assert!(
-            parsed.get("model_providers").is_none(),
-            "missing provider tables should not be synthesized without endpoint fields"
+            parsed.get("base_url").is_none() && parsed.get("experimental_bearer_token").is_none(),
+            "legacy top-level provider fields should be removed"
         );
     }
 

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -71,11 +71,17 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
                 continue;
             };
 
-            // type 缺省为 stdio
+            // Codex 当前 schema 不写 type：有 url 时按远程 HTTP 服务导入，否则按 stdio。
             let typ = entry_tbl
                 .get("type")
                 .and_then(|v| v.as_str())
-                .unwrap_or("stdio");
+                .unwrap_or_else(|| {
+                    if entry_tbl.get("url").is_some() {
+                        "http"
+                    } else {
+                        "stdio"
+                    }
+                });
 
             // 构建 JSON 规范
             let mut spec = serde_json::Map::new();
@@ -84,7 +90,7 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
             // 核心字段（需要手动处理的字段）
             let core_fields = match typ {
                 "stdio" => vec!["type", "command", "args", "env", "cwd"],
-                "http" | "sse" => vec!["type", "url", "http_headers"],
+                "http" | "sse" => vec!["type", "url", "headers", "http_headers"],
                 _ => vec!["type"],
             };
 
@@ -557,6 +563,7 @@ fn json_value_to_toml_item(value: &Value, field_name: &str) -> Option<toml_edit:
 ///
 /// 策略：
 /// 1. 核心字段（type, command, args, url, headers, env, cwd）使用强类型处理
+///    其中 type 只作为内部统一结构的类型标记，不写入 Codex TOML
 /// 2. 扩展字段（timeout、retry 等）通过白名单列表自动转换
 /// 3. 其他未知字段使用通用转换器尝试转换
 fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError> {
@@ -564,12 +571,11 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
 
     let mut t = Table::new();
     let typ = spec.get("type").and_then(|v| v.as_str()).unwrap_or("stdio");
-    t["type"] = toml_edit::value(typ);
 
     // 定义核心字段（已在下方处理，跳过通用转换）
     let core_fields = match typ {
         "stdio" => vec!["type", "command", "args", "env", "cwd"],
-        "http" | "sse" => vec!["type", "url", "http_headers"],
+        "http" | "sse" => vec!["type", "url", "headers", "http_headers"],
         _ => vec!["type"],
     };
 
@@ -639,7 +645,12 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
             let url = spec.get("url").and_then(|v| v.as_str()).unwrap_or("");
             t["url"] = toml_edit::value(url);
 
-            if let Some(headers) = spec.get("headers").and_then(|v| v.as_object()) {
+            let headers = spec
+                .get("http_headers")
+                .or_else(|| spec.get("headers"))
+                .and_then(|v| v.as_object());
+
+            if let Some(headers) = headers {
                 let mut h_tbl = Table::new();
                 for (k, v) in headers.iter() {
                     if let Some(s) = v.as_str() {

--- a/src-tauri/tests/import_export_sync.rs
+++ b/src-tauri/tests/import_export_sync.rs
@@ -118,13 +118,26 @@ fn sync_codex_provider_writes_config_without_touching_auth() {
     );
 
     let toml_text = fs::read_to_string(&config_path).expect("read config.toml");
-    assert!(
-        toml_text.contains("base_url"),
+    let parsed_live: toml::Value = toml::from_str(&toml_text).expect("parse live config");
+    let custom_provider = parsed_live
+        .get("model_providers")
+        .and_then(|v| v.get("custom"))
+        .expect("legacy top-level config should be migrated to model_providers.custom");
+    assert_eq!(
+        custom_provider.get("base_url").and_then(|v| v.as_str()),
+        Some("https://codex.test"),
         "config.toml should contain base_url from provider config"
     );
-    assert!(
-        toml_text.contains("experimental_bearer_token"),
+    assert_eq!(
+        custom_provider
+            .get("experimental_bearer_token")
+            .and_then(|v| v.as_str()),
+        Some("codex-key"),
         "config.toml should contain provider-scoped bearer token"
+    );
+    assert!(
+        parsed_live.get("experimental_bearer_token").is_none(),
+        "live config should not write bearer token at the top level"
     );
 
     let manager = config.get_manager(&AppType::Codex).expect("codex manager");
@@ -331,6 +344,10 @@ fn sync_enabled_to_codex_writes_enabled_servers() {
         text.contains("mcp_servers") && text.contains("stdio-enabled"),
         "enabled servers should be serialized"
     );
+    assert!(
+        !text.contains("type ="),
+        "Codex MCP export should not write a type field"
+    );
 }
 
 #[test]
@@ -389,6 +406,10 @@ mode = "dev"
     assert!(
         text.contains("echo") && text.contains("command = \"echo\""),
         "echo server should be serialized"
+    );
+    assert!(
+        !text.contains("type ="),
+        "Codex MCP export should omit type according to current schema"
     );
 }
 
@@ -631,12 +652,10 @@ fn import_from_codex_adds_servers_from_mcp_servers_table() {
     fs::write(
         &path,
         r#"[mcp_servers.echo_server]
-type = "stdio"
 command = "echo"
 args = ["hello"]
 
 [mcp_servers.http_server]
-type = "http"
 url = "https://example.com"
 "#,
     )
@@ -660,6 +679,10 @@ url = "https://example.com"
     );
     let server_spec = echo.server.as_object().expect("server spec");
     assert_eq!(
+        server_spec.get("type").and_then(|v| v.as_str()),
+        Some("stdio")
+    );
+    assert_eq!(
         server_spec
             .get("command")
             .and_then(|v| v.as_str())
@@ -673,6 +696,11 @@ url = "https://example.com"
         "Codex app should be enabled for http_server"
     );
     let http_spec = http.server.as_object().expect("http spec");
+    assert_eq!(
+        http_spec.get("type").and_then(|v| v.as_str()),
+        Some("http"),
+        "url-only Codex MCP entries should import as HTTP servers"
+    );
     assert_eq!(
         http_spec.get("url").and_then(|v| v.as_str()).unwrap_or(""),
         "https://example.com"

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -478,6 +478,10 @@ requires_openai_auth = true
         Some("bridge-key"),
         "third-party key should be injected into the selected live provider table"
     );
+    assert!(
+        parsed_live.get("experimental_bearer_token").is_none(),
+        "third-party key should not be written at the top level"
+    );
     assert_eq!(
         parsed_live
             .get("model_providers")

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -1082,7 +1082,6 @@ export const extractCodexExperimentalBearerToken = (
           : undefined;
       const providerToken =
         providerName &&
-        isCustomCodexModelProviderId(providerName) &&
         parsed.model_providers &&
         typeof parsed.model_providers === "object" &&
         typeof parsed.model_providers[providerName]
@@ -1102,7 +1101,7 @@ export const extractCodexExperimentalBearerToken = (
     }
 
     const lines = text.split("\n");
-    const targetSectionName = getCodexCustomProviderSectionName(text);
+    const targetSectionName = getCodexProviderSectionName(text);
 
     if (targetSectionName) {
       const sectionRange = getTomlSectionRange(lines, targetSectionName);
@@ -1148,7 +1147,7 @@ export const updateCodexExperimentalBearerToken = (
   }
 
   const lines = normalizedText.split("\n");
-  const targetSectionName = getCodexCustomProviderSectionName(normalizedText);
+  const targetSectionName = getCodexProviderSectionName(normalizedText);
 
   let tokenLineIndex = -1;
   if (targetSectionName) {

--- a/tests/utils/providerConfigUtils.codex.test.ts
+++ b/tests/utils/providerConfigUtils.codex.test.ts
@@ -377,17 +377,32 @@ describe("Codex TOML utils", () => {
     expect(extractCodexExperimentalBearerToken(updated)).toBe("new-key");
   });
 
-  it("extractCodexExperimentalBearerToken ignores reserved provider tables", () => {
+  it("extractCodexExperimentalBearerToken prefers the active provider table", () => {
     const input = [
       'model_provider = "openai"',
       'experimental_bearer_token = "top-level-key"',
       "",
       "[model_providers.openai]",
-      'experimental_bearer_token = "stale-table-key"',
+      'experimental_bearer_token = "provider-key"',
       "",
     ].join("\n");
 
-    expect(extractCodexExperimentalBearerToken(input)).toBe("top-level-key");
+    expect(extractCodexExperimentalBearerToken(input)).toBe("provider-key");
+  });
+
+  it("updateCodexExperimentalBearerToken can replace tokens in reserved provider tables", () => {
+    const input = [
+      'model_provider = "openai"',
+      "",
+      "[model_providers.openai]",
+      'experimental_bearer_token = "old-key"',
+      "",
+    ].join("\n");
+
+    const updated = updateCodexExperimentalBearerToken(input, "new-key");
+
+    expect(extractCodexExperimentalBearerToken(updated)).toBe("new-key");
+    expect(updated).not.toMatch(/old-key/);
   });
 
   it("extractCodexExperimentalBearerToken reads only top-level model_provider", () => {


### PR DESCRIPTION
## Summary / 概述

- Write Codex `experimental_bearer_token` under the active `[model_providers.<name>]` table.
- Migrate legacy top-level Codex routing fields into `[model_providers.custom]` when needed.
- Omit `type` when exporting Codex MCP config and infer HTTP servers from `url` on import.
- Update frontend Codex TOML token helpers and regression tests.

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

Not applicable; this is config serialization behavior.

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（not applicable: no user-facing text changed）

## Tests / 测试

- `corepack pnpm@10.12.3 typecheck`
- `corepack pnpm@10.12.3 format:check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `vitest run tests/utils/providerConfigUtils.codex.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml prepare_provider_live_config --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml extract_bearer --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml --test import_export_sync sync_codex_provider_writes_config_without_touching_auth -- --test-threads=1`
- `cargo test --manifest-path src-tauri/Cargo.toml --test import_export_sync sync_enabled_to_codex_writes_enabled_servers -- --test-threads=1`
- `cargo test --manifest-path src-tauri/Cargo.toml --test import_export_sync sync_enabled_to_codex_preserves_non_mcp_content_and_style -- --test-threads=1`
- `cargo test --manifest-path src-tauri/Cargo.toml --test import_export_sync import_from_codex_adds_servers_from_mcp_servers_table -- --test-threads=1`
- `cargo test --manifest-path src-tauri/Cargo.toml --test provider_service provider_service_switch_codex_preserves_oauth_and_backfills_api_key_from_live_token -- --test-threads=1`

## Notes / 备注

- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` was run locally, but it currently fails on pre-existing warnings outside this PR: `src/settings.rs` unused import and `src/commands/misc.rs` dead code / needless return warnings.
