### PR TITLE
fix(proxy): serve Codex /v1/models so the desktop app can list & switch custom models

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -675,12 +675,24 @@ fn codex_model_catalog_from_settings(
     Ok(Some(codex_model_catalog_from_specs(&specs, &template)))
 }
 
-/// Read the `models` array from the cc-switch–generated Codex catalog file
-/// (`~/.codex/cc-switch-model-catalog.json`). Best-effort: any failure (missing
-/// file, parse error, unexpected shape) yields an empty list.
-fn read_codex_catalog_file_models() -> Vec<Value> {
-    let path = get_codex_model_catalog_path();
-    let Ok(catalog) = read_json_file::<Value>(&path) else {
+/// Extract the `model_catalog_json` path declared in a Codex provider config.
+/// Returns `None` when the provider config does not reference a catalog file —
+/// which is the signal that the current provider has no custom model list.
+fn codex_model_catalog_json_path(config_text: &str) -> Option<PathBuf> {
+    config_text
+        .parse::<toml::Value>()
+        .ok()?
+        .get("model_catalog_json")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Read the `models` array from a Codex catalog JSON file at `path`. Best-effort:
+/// any failure (missing file, parse error, unexpected shape) yields an empty list.
+fn read_codex_catalog_models_from_file(path: &Path) -> Vec<Value> {
+    let Ok(catalog) = read_json_file::<Value>(path) else {
         return Vec::new();
     };
     catalog
@@ -699,10 +711,14 @@ fn read_codex_catalog_file_models() -> Vec<Value> {
 /// and cannot switch models.
 ///
 /// Source priority (most authoritative first):
-///   1. the cc-switch–generated catalog file (`cc-switch-model-catalog.json`,
-///      the exact file the CLI consumes) — the durable source of truth;
-///   2. the provider's `modelCatalog` in `settings` (present only right after a
+///   1. the provider's inline `modelCatalog` in `settings` (present right after a
 ///      form save; the field is stripped when persisted);
+///   2. the catalog file the **current provider's config actually references**
+///      via `model_catalog_json` — the file the Codex CLI consumes. Gating on
+///      the active provider's own config is important: switching to a provider
+///      without a catalog (e.g. OpenAI Official, whose config has no
+///      `model_catalog_json`) must NOT advertise a stale catalog file left on
+///      disk by a previously-active custom provider;
 ///   3. the single active `model` from the provider config text, so the picker
 ///      always lists at least the current model.
 ///
@@ -715,31 +731,34 @@ pub fn codex_models_list_response(settings: &Value) -> Result<Value, AppError> {
         .and_then(Value::as_str)
         .unwrap_or("");
 
-    // 1. The generated catalog file (rich entries: reasoning levels, context
-    //    window, …) — what cc-switch writes and the Codex CLI reads.
-    let mut entries: Vec<Value> = read_codex_catalog_file_models();
-
-    // 2. Regenerate from the provider's settings `modelCatalog` if the file is
-    //    unavailable/empty.
-    if entries.is_empty() {
-        entries = match codex_model_catalog_from_settings(settings, config_text) {
-            Ok(Some(catalog)) => catalog
-                .get("models")
-                .and_then(Value::as_array)
-                .cloned()
-                .unwrap_or_default(),
-            Ok(None) => Vec::new(),
-            Err(_) => codex_catalog_model_specs(settings, config_text)
-                .into_iter()
-                .map(|spec| {
-                    json!({
-                        "slug": spec.model,
-                        "display_name": spec.display_name,
-                        "context_window": spec.context_window,
-                    })
+    // 1. The provider's inline `modelCatalog` (rich entries: reasoning levels,
+    //    context window, …). Authoritative for THIS provider when present.
+    let mut entries: Vec<Value> = match codex_model_catalog_from_settings(settings, config_text) {
+        Ok(Some(catalog)) => catalog
+            .get("models")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        Ok(None) => Vec::new(),
+        Err(_) => codex_catalog_model_specs(settings, config_text)
+            .into_iter()
+            .map(|spec| {
+                json!({
+                    "slug": spec.model,
+                    "display_name": spec.display_name,
+                    "context_window": spec.context_window,
                 })
-                .collect(),
-        };
+            })
+            .collect(),
+    };
+
+    // 2. Otherwise, read only the catalog file the CURRENT provider's config
+    //    points to. If the provider declares no `model_catalog_json`, serve
+    //    nothing here so a leftover file from another provider is never exposed.
+    if entries.is_empty() {
+        if let Some(path) = codex_model_catalog_json_path(config_text) {
+            entries = read_codex_catalog_models_from_file(&path);
+        }
     }
 
     // 3. Last resort: the single active `model` from the config text, so the

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -675,6 +675,115 @@ fn codex_model_catalog_from_settings(
     Ok(Some(codex_model_catalog_from_specs(&specs, &template)))
 }
 
+/// Read the `models` array from the cc-switch–generated Codex catalog file
+/// (`~/.codex/cc-switch-model-catalog.json`). Best-effort: any failure (missing
+/// file, parse error, unexpected shape) yields an empty list.
+fn read_codex_catalog_file_models() -> Vec<Value> {
+    let path = get_codex_model_catalog_path();
+    let Ok(catalog) = read_json_file::<Value>(&path) else {
+        return Vec::new();
+    };
+    catalog
+        .get("models")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Build an OpenAI-style `/v1/models` list response so the Codex **desktop**
+/// app can list and switch the configured models.
+///
+/// The desktop refreshes its model picker via an online `GET {base_url}/models`
+/// request, unlike the CLI which reads `model_catalog_json` from disk. Without a
+/// proxy answer the desktop picker can only show the active model as "Custom"
+/// and cannot switch models.
+///
+/// Source priority (most authoritative first):
+///   1. the cc-switch–generated catalog file (`cc-switch-model-catalog.json`,
+///      the exact file the CLI consumes) — the durable source of truth;
+///   2. the provider's `modelCatalog` in `settings` (present only right after a
+///      form save; the field is stripped when persisted);
+///   3. the single active `model` from the provider config text, so the picker
+///      always lists at least the current model.
+///
+/// The response carries the entries under both `data` (OpenAI list shape) and
+/// `models` (Codex catalog shape), and each entry exposes both `id` and `slug`,
+/// so it parses regardless of which form the Codex client expects.
+pub fn codex_models_list_response(settings: &Value) -> Result<Value, AppError> {
+    let config_text = settings
+        .get("config")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    // 1. The generated catalog file (rich entries: reasoning levels, context
+    //    window, …) — what cc-switch writes and the Codex CLI reads.
+    let mut entries: Vec<Value> = read_codex_catalog_file_models();
+
+    // 2. Regenerate from the provider's settings `modelCatalog` if the file is
+    //    unavailable/empty.
+    if entries.is_empty() {
+        entries = match codex_model_catalog_from_settings(settings, config_text) {
+            Ok(Some(catalog)) => catalog
+                .get("models")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default(),
+            Ok(None) => Vec::new(),
+            Err(_) => codex_catalog_model_specs(settings, config_text)
+                .into_iter()
+                .map(|spec| {
+                    json!({
+                        "slug": spec.model,
+                        "display_name": spec.display_name,
+                        "context_window": spec.context_window,
+                    })
+                })
+                .collect(),
+        };
+    }
+
+    // 3. Last resort: the single active `model` from the config text, so the
+    //    picker always lists at least the currently selected model.
+    if entries.is_empty() {
+        if let Some(model) = config_text
+            .parse::<toml::Value>()
+            .ok()
+            .and_then(|doc| {
+                doc.get("model")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            })
+            .filter(|model| !model.is_empty())
+        {
+            entries.push(json!({ "slug": model.clone(), "display_name": model }));
+        }
+    }
+
+    let data: Vec<Value> = entries
+        .into_iter()
+        .map(|mut entry| {
+            if let Some(obj) = entry.as_object_mut() {
+                let slug = obj
+                    .get("slug")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                obj.entry("id".to_string()).or_insert_with(|| json!(slug));
+                obj.insert("object".to_string(), json!("model"));
+                obj.entry("owned_by".to_string())
+                    .or_insert_with(|| json!("cc-switch"));
+            }
+            entry
+        })
+        .collect();
+
+    Ok(json!({
+        "object": "list",
+        "data": data.clone(),
+        "models": data,
+    }))
+}
+
 fn set_codex_model_catalog_json_field(
     config_text: &str,
     catalog_path: Option<&Path>,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -110,6 +110,26 @@ pub async fn handle_claude_desktop_models(
     Ok(Json(response))
 }
 
+/// 处理 `GET /v1/models`（OpenAI Models 列表 - Codex 桌面端在线刷新模型列表）
+///
+/// Codex CLI 通过注入的 `model_catalog_json` 离线读取模型列表，但桌面端只会
+/// 在线请求 `{base_url}/models`。代理此前没有为 Codex 注册该路由，导致桌面端
+/// 收到 404、模型列表刷新失败，只能把当前模型显示为「自定义」且无法切换。
+/// 这里用 provider 的 `modelCatalog` 合成与 CLI 一致的模型列表返回。
+pub async fn handle_codex_models(
+    State(state): State<ProxyState>,
+) -> Result<Json<Value>, ProxyError> {
+    let providers = state
+        .provider_router
+        .select_providers("codex")
+        .await
+        .map_err(|e| ProxyError::DatabaseError(e.to_string()))?;
+    let provider = providers.first().ok_or(ProxyError::NoAvailableProvider)?;
+    let response = crate::codex_config::codex_models_list_response(&provider.settings_config)
+        .map_err(|e| ProxyError::ConfigError(e.to_string()))?;
+    Ok(Json(response))
+}
+
 async fn handle_messages_for_app(
     state: ProxyState,
     request: axum::extract::Request,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -337,6 +337,11 @@ impl ProxyServer {
                 "/codex/v1/responses/compact",
                 post(handlers::handle_responses_compact),
             )
+            // OpenAI Models 列表 (Codex 桌面端在线刷新模型列表用；CLI 走 model_catalog_json，
+            // 不经此端点)。这些是 GET 只读端点，缺失时会在路由层 404，导致桌面端无法切换模型。
+            .route("/v1/models", get(handlers::handle_codex_models))
+            .route("/v1/v1/models", get(handlers::handle_codex_models))
+            .route("/codex/v1/models", get(handlers::handle_codex_models))
             // Gemini API (支持带前缀和不带前缀)
             //
             // 用 `any(..)` 覆盖所有 HTTP 方法：除了 POST `:generateContent` /


### PR DESCRIPTION
## 背景 / 根因

本地代理为 Codex/OpenAI 路径只注册了 **POST** 路由（`/v1/chat/completions`、`/v1/responses`、`/responses/compact`），`build_router()` 末尾也没有 `.fallback()`。因此 Codex 发出的只读请求 `GET /v1/models` 在路由层直接落到 **404**。

- **Codex CLI 不受影响**：它读注入的 `model_catalog_json` 文件，离线拿模型列表。
- **Codex 桌面端受影响**：它通过在线 `GET {base_url}/models` 刷新模型选择器。拿到 404 后，桌面端只能把当前模型显示成「自定义/Custom」，且**无法切换**已配置的模型。

代码里其实已为 **Gemini**（`any(handle_gemini)` 通配，注释明确说明"只挂 POST 会让 GET 在路由层 404"）和 **Claude Desktop**（`/claude-desktop/v1/models`）处理了同类只读端点——唯独 Codex/OpenAI 这条漏了。

## 改动

新增 `GET /v1/models`（以及 `/v1/v1/models`、`/codex/v1/models`）→ 新的 `handle_codex_models`，用 cc-switch 维护的目录合成 OpenAI 风格的模型列表。数据源优先级：

1. 生成的 `cc-switch-model-catalog.json`（CLI 消费的同一份，权威来源）；
2. provider settings 里的 `modelCatalog`（仅在表单保存后短暂存在，持久化后会被剥离）；
3. provider 配置文本里的当前 `model`（兜底，至少列出当前模型）。

响应同时在 `data`（OpenAI 列表形态）和 `models`（Codex 目录形态）下携带条目，每条同时带 `id` 和 `slug`，以兼容客户端两种解析方式。

涉及文件：`src-tauri/src/proxy/server.rs`、`src-tauri/src/proxy/handlers.rs`、`src-tauri/src/codex_config.rs`。

## ⚠️ 重要前提（仅修这个还不够）

桌面端要真正列出自定义 provider 的模型，**还需要 Codex 桌面端处于 ChatGPT 账户（OAuth）登录态**。在纯 API-key 模式下，桌面端的"在线刷新模型目录"链路走不通（日志会出现 `chatgpt authentication required ... api key auth is not supported`），会退回内置的官方模型目录、忽略本端点。

实测结论：**本补丁（`/v1/models` 返回正确列表）+ 桌面端 OAuth 登录** 两者同时满足时，桌面端选择器才会正确列出并可切换自定义模型（例如 DeepSeek 的 Flash/Pro）。对 CLI 在线刷新、以及消除 404 错误，本补丁单独即有效。

## 验证

- `cargo check` 与 `pnpm tauri build` 均通过。
- `GET http://127.0.0.1:15721/v1/models` 由原来的 **404** → **200**，返回配置的模型（含 `display_name`、`supported_reasoning_levels`）。
- 桌面端登录 ChatGPT 账户后，模型选择器从只显示「自定义」变为列出 **Flash / Pro** 并可切换，chip 也按真实模型名显示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
