### PR TITLE
fix: isolate Codex provider API keys

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -192,6 +192,44 @@ pub fn write_codex_live_config_atomic(config_text_opt: Option<&str>) -> Result<(
     write_text_file(&config_path, &cfg_text)
 }
 
+fn clear_codex_live_auth_api_key(preserve_login_material: bool) -> Result<(), AppError> {
+    let auth_path = get_codex_auth_path();
+    if !auth_path.exists() {
+        return Ok(());
+    }
+
+    if !preserve_login_material {
+        return delete_file(&auth_path).or_else(
+            |err| {
+                if auth_path.exists() {
+                    Err(err)
+                } else {
+                    Ok(())
+                }
+            },
+        );
+    }
+
+    let mut auth: Value = read_json_file(&auth_path)?;
+    let Some(obj) = auth.as_object_mut() else {
+        return Ok(());
+    };
+
+    let Some(api_key) = obj.get("OPENAI_API_KEY") else {
+        return Ok(());
+    };
+    if api_key.is_null() {
+        return Ok(());
+    }
+    obj.remove("OPENAI_API_KEY");
+
+    if codex_auth_has_login_material(&auth) {
+        write_json_file(&auth_path, &auth)
+    } else {
+        delete_file(&auth_path).or_else(|err| if auth_path.exists() { Err(err) } else { Ok(()) })
+    }
+}
+
 pub fn extract_codex_auth_api_key(auth: &Value) -> Option<String> {
     auth.get("OPENAI_API_KEY")
         .and_then(|value| value.as_str())
@@ -1019,34 +1057,34 @@ pub fn read_codex_live_settings() -> Result<Value, AppError> {
     Ok(json!({ "auth": auth, "config": cfg_text }))
 }
 
-/// Route a Codex live write between full auth+config or config-only.
+/// 根据服务商类型决定 Codex Live 写入范围。
 ///
-/// Official providers with usable login material own `auth.json`. Third-party
-/// providers only touch `config.toml` when the compatibility setting is enabled
-/// so the user's ChatGPT login cache survives provider switches.
+/// 官方服务商携带可用登录材料时写入 `auth.json`。第三方服务商的
+/// API Key 写入 `config.toml`，同时避免污染官方登录缓存。
 pub fn write_codex_live_for_provider(
     category: Option<&str>,
     auth: &Value,
     config_text: Option<&str>,
 ) -> Result<(), AppError> {
-    let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
-        || (category != Some("official")
-            && !crate::settings::preserve_codex_official_auth_on_switch());
-
-    if should_write_auth {
+    if category == Some("official") && codex_auth_has_login_material(auth) {
         write_codex_live_atomic(auth, config_text)
     } else {
         let live_config = prepare_codex_provider_live_config(auth, config_text.unwrap_or(""))?;
-        write_codex_live_config_atomic(Some(&live_config))
+        write_codex_live_config_atomic(Some(&live_config))?;
+        if category != Some("official") {
+            clear_codex_live_auth_api_key(
+                crate::settings::preserve_codex_official_auth_on_switch(),
+            )?;
+        }
+        Ok(())
     }
 }
 
-/// Build the live Codex config for provider switching.
+/// 构建服务商切换时使用的 Codex Live 配置。
 ///
-/// The stored provider keeps its API key in `auth.OPENAI_API_KEY`. Live Codex
-/// requests can use a provider-scoped `experimental_bearer_token`, so switching
-/// providers only needs to update `config.toml`; `auth.json` stays as the user's
-/// long-lived ChatGPT login cache.
+/// 存储态服务商仍把 API Key 放在 `auth.OPENAI_API_KEY`。Live Codex 请求
+/// 可使用服务商作用域的 `experimental_bearer_token`，因此切换服务商只需
+/// 更新 `config.toml`，`auth.json` 保留给用户的官方登录缓存。
 pub fn prepare_codex_provider_live_config(
     auth: &Value,
     config_text: &str,
@@ -1058,6 +1096,43 @@ pub fn prepare_codex_provider_live_config(
         Some(token) => set_codex_experimental_bearer_token(config_text, &token)?,
         None => config_text.to_string(),
     })
+}
+
+pub fn prepare_codex_provider_settings_for_live_snapshot(
+    category: Option<&str>,
+    settings: &Value,
+) -> Result<Value, AppError> {
+    if category == Some("official") {
+        return Ok(settings.clone());
+    }
+
+    let mut live_settings = settings.clone();
+    let Some(obj) = live_settings.as_object_mut() else {
+        return Ok(live_settings);
+    };
+
+    let auth_for_config = obj.get("auth").cloned();
+
+    if let Some(auth_obj) = obj.get_mut("auth").and_then(Value::as_object_mut) {
+        if auth_obj
+            .get("OPENAI_API_KEY")
+            .is_some_and(|value| !value.is_null())
+        {
+            auth_obj.remove("OPENAI_API_KEY");
+        }
+    }
+
+    let Some(auth) = auth_for_config else {
+        return Ok(live_settings);
+    };
+    let Some(config_text) = obj.get("config").and_then(Value::as_str) else {
+        return Ok(live_settings);
+    };
+
+    let prepared_config = prepare_codex_provider_live_config(&auth, config_text)?;
+    obj.insert("config".to_string(), Value::String(prepared_config));
+
+    Ok(live_settings)
 }
 
 /// During DB backfill, lift a live `experimental_bearer_token` back into

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1787,6 +1787,13 @@ impl ProxyService {
                     existing_value,
                 )?;
             }
+
+            effective_settings =
+                crate::codex_config::prepare_codex_provider_settings_for_live_snapshot(
+                    provider.category.as_deref(),
+                    &effective_settings,
+                )
+                .map_err(|e| format!("构建 Codex Live 备份失败: {e}"))?;
         }
 
         let backup_json = match app_type_enum {
@@ -2865,7 +2872,7 @@ experimental_bearer_token = "PROXY_MANAGED"
 
     #[test]
     #[serial]
-    fn codex_custom_provider_live_write_can_overwrite_auth_when_preserve_disabled() {
+    fn codex_custom_provider_live_write_clears_auth_when_preserve_disabled() {
         let _home = TempHome::new();
         crate::settings::reload_settings().expect("reload settings");
         crate::settings::update_settings(crate::settings::AppSettings {
@@ -2931,22 +2938,20 @@ wire_api = "responses"
             .write_codex_live_for_provider(&takeover_settings, Some(&provider))
             .expect("write provider-driven Codex live config");
 
-        let live_auth: Value =
-            crate::config::read_json_file(&crate::codex_config::get_codex_auth_path())
-                .expect("read live auth");
-        assert_eq!(
-            live_auth,
-            json!({
-                "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER
-            }),
-            "disabled preservation should let third-party switches overwrite auth.json"
+        assert!(
+            !crate::codex_config::get_codex_auth_path().exists(),
+            "关闭保留官方登录后，第三方 Codex 写入应清理 live auth.json"
         );
 
         let live_config = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
             .expect("read live config");
         assert!(
-            !live_config.contains("experimental_bearer_token"),
-            "provider token should stay in auth.json when preservation is disabled"
+            live_config.contains("experimental_bearer_token"),
+            "第三方服务商 API Key 应写入 config.toml 的 provider-scoped bearer token"
+        );
+        assert!(
+            live_config.contains(PROXY_TOKEN_PLACEHOLDER),
+            "代理占位 token 应写入 config.toml"
         );
 
         crate::settings::update_settings(crate::settings::AppSettings::default())
@@ -4008,11 +4013,19 @@ requires_openai_auth = true
             "restored Codex live config should preserve the provider's model_provider"
         );
         assert_eq!(
-            live.get("auth")
-                .and_then(|auth| auth.get("OPENAI_API_KEY"))
+            parsed_live
+                .get("model_providers")
+                .and_then(|v| v.get("aihubmix"))
+                .and_then(|v| v.get("experimental_bearer_token"))
                 .and_then(|v| v.as_str()),
             Some("aihubmix-key"),
-            "restore should still use the hot-switched provider auth"
+            "恢复时应从 config.toml 使用热切换服务商的 API Key"
+        );
+        assert!(
+            live.get("auth")
+                .and_then(|auth| auth.get("OPENAI_API_KEY"))
+                .is_none(),
+            "恢复时不应把服务商 API Key 写入 auth.json"
         );
     }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -253,8 +253,8 @@ pub struct AppSettings {
     /// Whether to show the failover toggle independently on the main page
     #[serde(default)]
     pub enable_failover_toggle: bool,
-    /// Keep Codex ChatGPT login material in auth.json when switching to third-party providers.
-    /// Opt-in: defaults to false so third-party switches cleanly overwrite auth.json.
+    /// Whether to retain the official login credentials in `auth.json` when switching to a third-party Codex service provider.
+    /// Disabled by default: switching to a third-party provider will clear `auth.json`, and the service provider's API Key will be written solely to `config.toml`.
     #[serde(default)]
     pub preserve_codex_official_auth_on_switch: bool,
     /// User has confirmed the failover toggle first-run notice

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -315,15 +315,9 @@ command = "say"
     switch_provider_test_hook(&app_state, AppType::Codex, "new-provider")
         .expect("switch provider should succeed");
 
-    let auth_value: serde_json::Value =
-        read_json_file(&get_codex_auth_path()).expect("read auth.json");
-    assert_eq!(
-        auth_value
-            .get("OPENAI_API_KEY")
-            .and_then(|v| v.as_str())
-            .unwrap_or(""),
-        "legacy-key",
-        "Codex provider switching should preserve the existing live auth.json"
+    assert!(
+        !get_codex_auth_path().exists(),
+        "After switching third-party Codex providers, the provider's API key should not be retained in the live `auth.json` file"
     );
 
     let config_text = std::fs::read_to_string(get_codex_config_path()).expect("read config.toml");

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -179,12 +179,10 @@ command = "say"
     ProviderService::switch(&state, AppType::Codex, "new-provider")
         .expect("switch provider should succeed");
 
-    let auth_value: serde_json::Value =
-        read_json_file(&cc_switch_lib::get_codex_auth_path()).expect("read auth.json");
-    assert_eq!(
-        auth_value.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
-        Some("legacy-key"),
-        "Codex provider switching should preserve the existing live auth.json"
+    let auth_path = cc_switch_lib::get_codex_auth_path();
+    assert!(
+        !auth_path.exists(),
+        "After switching third-party Codex providers, the provider's API key should not be retained in the live `auth.json` file"
     );
 
     let config_text =
@@ -524,6 +522,89 @@ requires_openai_auth = true
 }
 
 #[test]
+fn provider_service_switch_codex_third_party_clears_stale_live_auth_api_key() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    enable_codex_official_auth_preservation();
+    let _home = ensure_test_home();
+
+    let live_auth = json!({ "OPENAI_API_KEY": "provider-a-key" });
+    let provider_a_config = r#"model_provider = "provider_a"
+model = "gpt-5.4"
+
+[model_providers.provider_a]
+name = "Provider A"
+base_url = "https://provider-a.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+    write_codex_live_atomic(&live_auth, Some(provider_a_config))
+        .expect("seed provider A live config");
+
+    let mut initial_config = MultiAppConfig::default();
+    {
+        let manager = initial_config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "provider-a".to_string();
+        manager.providers.insert(
+            "provider-a".to_string(),
+            Provider::with_id(
+                "provider-a".to_string(),
+                "Provider A".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "provider-a-key"},
+                    "config": provider_a_config
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "provider-b".to_string(),
+            Provider::with_id(
+                "provider-b".to_string(),
+                "Provider B".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "provider-b-key"},
+                    "config": r#"model_provider = "provider_b"
+model = "gpt-5.4"
+
+[model_providers.provider_b]
+name = "Provider B"
+base_url = "https://provider-b.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = create_test_state_with_config(&initial_config).expect("create test state");
+
+    ProviderService::switch(&state, AppType::Codex, "provider-b").expect("switch to provider B");
+
+    assert!(
+        !cc_switch_lib::get_codex_auth_path().exists(),
+        "第三方服务商切换后 live auth.json 不应保留上一个服务商的 OPENAI_API_KEY"
+    );
+
+    let live_config =
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read config.toml");
+    let parsed_live: toml::Value = toml::from_str(&live_config).expect("parse live config");
+    assert_eq!(
+        parsed_live
+            .get("model_providers")
+            .and_then(|v| v.get("provider_b"))
+            .and_then(|v| v.get("experimental_bearer_token"))
+            .and_then(|v| v.as_str()),
+        Some("provider-b-key"),
+        "目标服务商的 API Key 应写入自己的 provider-scoped bearer token"
+    );
+}
+
+#[test]
 fn provider_service_switch_codex_default_overwrites_official_auth_when_preservation_off() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();
@@ -598,16 +679,21 @@ requires_openai_auth = true
     ProviderService::switch(&state, AppType::Codex, "third-party")
         .expect("switch to third-party provider should succeed");
 
-    let auth_value: serde_json::Value =
-        read_json_file(&cc_switch_lib::get_codex_auth_path()).expect("read auth.json");
-    assert_eq!(
-        auth_value.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
-        Some("third-party-key"),
-        "default (preservation off) should overwrite auth.json with the third-party API key"
-    );
     assert!(
-        auth_value.pointer("/tokens/access_token").is_none(),
-        "default switch must clear the official ChatGPT OAuth token from live auth.json"
+        !cc_switch_lib::get_codex_auth_path().exists(),
+        "关闭保留官方登录后，第三方切换应清理 live auth.json"
+    );
+    let live_config =
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read config.toml");
+    let parsed_live: toml::Value = toml::from_str(&live_config).expect("parse live config");
+    assert_eq!(
+        parsed_live
+            .get("model_providers")
+            .and_then(|v| v.get("aihubmix"))
+            .and_then(|v| v.get("experimental_bearer_token"))
+            .and_then(|v| v.as_str()),
+        Some("third-party-key"),
+        "第三方服务商 API Key 应写入目标 provider-scoped bearer token"
     );
 }
 


### PR DESCRIPTION
 ## Summary / 概述                                                                                                                                                                  

  Fix Codex provider switching overwriting auth.json OPENAI_API_KEY.                                                                                                                 
                                                                                                                                                                                     
  - Keep third-party Codex provider API keys isolated per provider.                                                                                                                  
  - Write third-party provider keys to provider-scoped experimental_bearer_token in config.toml instead of live auth.json.                                                           
  - Clear stale live auth.json API keys when switching third-party providers.
  - Apply the same behavior to proxy takeover backup/restore paths.                                                                                                                  
  - Add regression coverage for switching between Codex providers.                                                                                                                   
                                                                                                                                                                                     
  ## Related Issue / 关联 Issue                                                                                                                                                      

  Fixes #3491                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                     

  ## Checklist / 检查清单                                                                                                                                                            
                                                                                                                                                                                     
  - [ ] pnpm typecheck passes / 通过 TypeScript 类型检查                                                                                                                             
  - [ ] pnpm format:check passes / 通过代码格式检查                                                                                                                                  
  - [ ] cargo clippy passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
  - [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件                                                                                      
                                                                                                                                                                                     
  ## Validation / 验证                                                                                                                                                               
                                                                                                                                                                                     
  - [x] cargo fmt --check                                                                                                                                                            
  - [x] git diff --check                                                                                                                                                             
  - [x] cargo test --features test-hooks --test provider_service provider_service_switch_codex_ -- --nocapture                                                                       
  - [x] cargo test --features test-hooks --test provider_commands switch_provider_updates_codex_live_and_state -- --nocapture                                                        
  - [x] cargo test --features test-hooks --lib services::proxy::tests::codex_custom_provider_live_write_clears_auth_when_preserve_disabled -- --nocapture                            
  - [x] cargo test --features test-hooks --lib services::proxy::tests::hot_switch_codex_provider_preserves_provider_model_provider_in_backup_and_restore -- --nocapture           