### PR TITLE
fix(misc): avoid interactive shell probes in WSL

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1699,7 +1699,10 @@ fn infer_install_source(path: &Path) -> &'static str {
     // Windows 的 `%LOCALAPPDATA%\Volta\bin` / `%VOLTA_HOME%\bin`(无前导点)。
     } else if s.contains("/.volta/") || s.contains("/volta/") {
         "volta"
-    } else if s.contains("fnm_multishells") {
+    } else if s.contains("fnm_multishells")
+        || s.contains("/.local/share/fnm/node-versions/")
+        || s.contains("/.fnm/node-versions/")
+    {
         "fnm"
     } else if s.contains("/mise/") {
         "mise"
@@ -3976,6 +3979,22 @@ mod tests {
                 "scoop"
             );
         }
+
+        #[test]
+        fn fnm_node_versions_are_identified() {
+            assert_eq!(
+                infer_install_source(Path::new(
+                    "/Users/me/.local/share/fnm/node-versions/v25.8.0/installation/bin/gemini"
+                )),
+                "fnm"
+            );
+            assert_eq!(
+                infer_install_source(Path::new(
+                    "/Users/me/.fnm/node-versions/v25.8.0/installation/bin/gemini"
+                )),
+                "fnm"
+            );
+        }
     }
 
     /// 锚定升级命令生成：用真实勘察到的安装路径固化为回归断言——
@@ -4199,6 +4218,21 @@ mod tests {
                 cmd.as_deref(),
                 Some(
                     "/Users/me/.local/share/fnm_multishells/12345_abc/bin/codex update || /Users/me/.local/share/fnm_multishells/12345_abc/bin/npm i -g @openai/codex@latest"
+                )
+            );
+        }
+
+        #[test]
+        fn fnm_node_version_install_anchors_npm_only_tools_to_that_npm() {
+            let cmd = anchored_command_from_paths(
+                "gemini",
+                "/Users/me/.local/share/fnm/node-versions/v25.8.0/installation/bin/gemini",
+                "/Users/me/.local/share/fnm/node-versions/v25.8.0/installation/lib/node_modules/@google/gemini-cli/dist/index.js",
+            );
+            assert_eq!(
+                cmd.as_deref(),
+                Some(
+                    "/Users/me/.local/share/fnm/node-versions/v25.8.0/installation/bin/npm i -g @google/gemini-cli@latest"
                 )
             );
         }

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1002,7 +1002,7 @@ fn try_get_version(tool: &str) -> ShellProbe {
             .ok()
             .filter(|s| is_valid_shell(s))
             .unwrap_or_else(|| "sh".to_string());
-        let flag = default_flag_for_shell(&shell);
+        let flag = shell_flag_for_version_probe(&shell);
         Command::new(shell)
             .arg(flag)
             .arg(format!("{tool} --version"))
@@ -1067,6 +1067,45 @@ fn default_flag_for_shell(shell: &str) -> &'static str {
         "fish" => "-lc",
         _ => "-lic",
     }
+}
+
+/// Return the shell flag used by non-Windows CLI version/path probes.
+///
+/// Keep the existing interactive login shell behavior for ordinary desktop
+/// sessions, but avoid `-i` inside WSL. A GUI app launched from a WSL terminal
+/// can otherwise hit shell job-control paths and get stopped by SIGTTIN.
+#[cfg(not(target_os = "windows"))]
+fn shell_flag_for_version_probe(shell: &str) -> &'static str {
+    shell_flag_for_version_probe_with_env(shell, is_wsl_environment())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn shell_flag_for_version_probe_with_env(shell: &str, is_wsl: bool) -> &'static str {
+    if !is_wsl {
+        return default_flag_for_shell(shell);
+    }
+
+    match shell.rsplit('/').next().unwrap_or(shell) {
+        "dash" | "sh" => "-c",
+        _ => "-lc",
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn is_wsl_environment() -> bool {
+    std::env::var_os("WSL_INTEROP").is_some()
+        || std::env::var_os("WSL_DISTRO_NAME").is_some()
+        || std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|s| {
+                let s = s.to_ascii_lowercase();
+                s.contains("microsoft") || s.contains("wsl")
+            })
+            .unwrap_or(false)
+}
+
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
+fn is_wsl_environment() -> bool {
+    false
 }
 
 #[cfg(target_os = "windows")]
@@ -1667,14 +1706,14 @@ fn infer_install_source(path: &Path) -> &'static str {
     }
 }
 
-/// 从 shell 输出里挑出第一个绝对路径行（trim 后以 `/` 开头），跳过交互式登录 shell
-/// （`-lic`）里 .zshrc 打印的欢迎语/提示符等噪音。canonicalize 由调用方做（碰 FS）。
+/// 从 shell 输出里挑出第一个绝对路径行（trim 后以 `/` 开头），跳过登录/交互式 shell
+/// 里 .zshrc 打印的欢迎语/提示符等噪音。canonicalize 由调用方做（碰 FS）。
 #[cfg(not(target_os = "windows"))]
 fn first_abs_path_line(raw: &str) -> Option<&str> {
     raw.lines().map(str::trim).find(|l| l.starts_with('/'))
 }
 
-/// 用与 `try_get_version` 相同的登录 shell 解析 PATH 默认命中的可执行文件路径，
+/// 用与 `try_get_version` 相同的 shell 探测方式解析 PATH 默认命中的可执行文件路径，
 /// canonicalize 后作为"命令行默认 / 升级目标"的锚点（与升级会作用的那处对齐）。
 #[cfg(not(target_os = "windows"))]
 fn resolve_path_default(tool: &str) -> Option<std::path::PathBuf> {
@@ -1683,7 +1722,7 @@ fn resolve_path_default(tool: &str) -> Option<std::path::PathBuf> {
         .ok()
         .filter(|s| is_valid_shell(s))
         .unwrap_or_else(|| "sh".to_string());
-    let flag = default_flag_for_shell(&shell);
+    let flag = shell_flag_for_version_probe(&shell);
     let out = Command::new(shell)
         .arg(flag)
         .arg(format!("command -v {tool}"))
@@ -4433,6 +4472,42 @@ mod tests {
                 "should not depend on pipefail or system Python/pip: {cmd}"
             );
         }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn version_probe_shell_flag_keeps_default_behavior_outside_wsl() {
+        assert_eq!(shell_flag_for_version_probe_with_env("sh", false), "-c");
+        assert_eq!(shell_flag_for_version_probe_with_env("dash", false), "-c");
+        assert_eq!(
+            shell_flag_for_version_probe_with_env("/bin/dash", false),
+            "-c"
+        );
+        assert_eq!(shell_flag_for_version_probe_with_env("fish", false), "-lc");
+        assert_eq!(shell_flag_for_version_probe_with_env("bash", false), "-lic");
+        assert_eq!(shell_flag_for_version_probe_with_env("zsh", false), "-lic");
+        assert_eq!(
+            shell_flag_for_version_probe_with_env("/usr/bin/zsh", false),
+            "-lic"
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn version_probe_shell_flag_avoids_interactive_shell_in_wsl() {
+        assert_eq!(shell_flag_for_version_probe_with_env("sh", true), "-c");
+        assert_eq!(shell_flag_for_version_probe_with_env("dash", true), "-c");
+        assert_eq!(
+            shell_flag_for_version_probe_with_env("/bin/dash", true),
+            "-c"
+        );
+        assert_eq!(shell_flag_for_version_probe_with_env("fish", true), "-lc");
+        assert_eq!(shell_flag_for_version_probe_with_env("bash", true), "-lc");
+        assert_eq!(shell_flag_for_version_probe_with_env("zsh", true), "-lc");
+        assert_eq!(
+            shell_flag_for_version_probe_with_env("/usr/bin/zsh", true),
+            "-lc"
+        );
     }
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1413,6 +1413,42 @@ fn extend_mise_node_search_paths(paths: &mut Vec<std::path::PathBuf>, home: &Pat
     }
 }
 
+fn extend_rc_managed_node_search_paths(paths: &mut Vec<std::path::PathBuf>, home: &Path) {
+    if home.as_os_str().is_empty() {
+        return;
+    }
+
+    push_unique_path(paths, home.join(".local/share/pnpm"));
+    push_unique_path(paths, home.join(".bun").join("bin"));
+    push_unique_path(paths, home.join(".asdf").join("shims"));
+
+    let fnm_bases = [
+        home.join(".local/share/fnm").join("node-versions"),
+        home.join(".fnm").join("node-versions"),
+    ];
+    for base in fnm_bases {
+        extend_existing_child_search_paths(paths, &base, Some("installation/bin"));
+    }
+}
+
+fn extend_fnm_multishell_search_paths(paths: &mut Vec<std::path::PathBuf>, home: &Path) {
+    if home.as_os_str().is_empty() {
+        return;
+    }
+
+    let fnm_base = home.join(".local/state/fnm_multishells");
+    extend_existing_child_search_paths(paths, &fnm_base, Some("bin"));
+}
+
+fn extend_nvm_node_search_paths(paths: &mut Vec<std::path::PathBuf>, home: &Path) {
+    if home.as_os_str().is_empty() {
+        return;
+    }
+
+    let nvm_base = home.join(".nvm/versions/node");
+    extend_existing_child_search_paths(paths, &nvm_base, Some("bin"));
+}
+
 /// 构建某工具的候选搜索目录（原生安装优先，PATH 兜底）。
 /// 单探兜底 (`scan_cli_version`) 与全量枚举 (`enumerate_tool_installations`) 共用，
 /// 确保两条路径看到的是同一组安装位置。
@@ -1427,6 +1463,9 @@ fn build_tool_search_paths(tool: &str) -> Vec<std::path::PathBuf> {
         push_unique_path(&mut search_paths, home.join("n/bin"));
         push_unique_path(&mut search_paths, home.join(".volta/bin"));
         extend_mise_node_search_paths(&mut search_paths, &home);
+        extend_rc_managed_node_search_paths(&mut search_paths, &home);
+        extend_fnm_multishell_search_paths(&mut search_paths, &home);
+        extend_nvm_node_search_paths(&mut search_paths, &home);
     }
 
     #[cfg(target_os = "macos")]
@@ -1501,30 +1540,6 @@ fn build_tool_search_paths(tool: &str) -> Vec<std::path::PathBuf> {
             std::path::PathBuf::from("C:\\Program Files\\nodejs"),
         );
         extend_windows_cli_manager_search_paths(&mut search_paths, &home);
-    }
-
-    let fnm_base = home.join(".local/state/fnm_multishells");
-    if fnm_base.exists() {
-        if let Ok(entries) = std::fs::read_dir(&fnm_base) {
-            for entry in entries.flatten() {
-                let bin_path = entry.path().join("bin");
-                if bin_path.exists() {
-                    push_unique_path(&mut search_paths, bin_path);
-                }
-            }
-        }
-    }
-
-    let nvm_base = home.join(".nvm/versions/node");
-    if nvm_base.exists() {
-        if let Ok(entries) = std::fs::read_dir(&nvm_base) {
-            for entry in entries.flatten() {
-                let bin_path = entry.path().join("bin");
-                if bin_path.exists() {
-                    push_unique_path(&mut search_paths, bin_path);
-                }
-            }
-        }
     }
 
     if tool == "opencode" {
@@ -4673,6 +4688,41 @@ mod tests {
 
         assert!(paths.contains(&home.join(".local/share/mise/shims")));
         assert!(paths.contains(&node_bin));
+    }
+
+    #[test]
+    fn rc_managed_node_search_paths_include_common_shell_initialized_bins() {
+        let temp = tempfile::tempdir().expect("temp dir should be created");
+        let home = temp.path();
+        let fnm_bin = home
+            .join(".local/share/fnm/node-versions/v25.8.0")
+            .join("installation/bin");
+        std::fs::create_dir_all(&fnm_bin).expect("fnm node bin should be created");
+
+        let mut paths = Vec::new();
+        extend_rc_managed_node_search_paths(&mut paths, home);
+
+        assert!(paths.contains(&home.join(".local/share/pnpm")));
+        assert!(paths.contains(&home.join(".bun/bin")));
+        assert!(paths.contains(&home.join(".asdf/shims")));
+        assert!(paths.contains(&fnm_bin));
+    }
+
+    #[test]
+    fn node_manager_search_paths_include_nvm_and_fnm_multishell_bins() {
+        let temp = tempfile::tempdir().expect("temp dir should be created");
+        let home = temp.path();
+        let nvm_bin = home.join(".nvm/versions/node/v25.8.0").join("bin");
+        let fnm_bin = home.join(".local/state/fnm_multishells/12345").join("bin");
+        std::fs::create_dir_all(&nvm_bin).expect("nvm node bin should be created");
+        std::fs::create_dir_all(&fnm_bin).expect("fnm multishell bin should be created");
+
+        let mut paths = Vec::new();
+        extend_nvm_node_search_paths(&mut paths, home);
+        extend_fnm_multishell_search_paths(&mut paths, home);
+
+        assert!(paths.contains(&nvm_bin));
+        assert!(paths.contains(&fnm_bin));
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary
- Avoid using interactive shell flags for Linux WSL CLI version/path probes.
- Keep the existing default shell behavior outside WSL, including `bash`/`zsh` using `-lic`.
- Use `-lc` in WSL for non-`sh`/`dash` shells so About-page probes still get login-shell PATH setup without triggering interactive job-control TTY reads.

## Context
Fixes #3291

When CC Switch is installed as the Linux build inside WSLg and launched from a terminal, opening Settings -> About can spawn commands such as `/bin/bash -lic codex --version`. The `-i` flag makes bash enter interactive job-control initialization and touch `/dev/tty`; in this WSLg/terminal process-group setup that can lead to `SIGTTIN` and stop the whole CC Switch process group (`Stopped (tty input)`).

This change keeps the fix narrow: only Linux WSL version/path probes avoid `-i`; ordinary Linux/macOS behavior is unchanged.

## Verification
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml version_probe_shell_flag --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- Built and installed a debug `.deb` locally, then verified `GDK_BACKEND=x11 cc-switch` no longer freezes on Settings -> About in WSL2 Debian 13 + WSLg.