### PR TITLE
fix(codex): always include output_tokens_details.reasoning_tokens in …

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -750,7 +750,8 @@ impl ChatToResponsesState {
                 json!({
                     "input_tokens": 0,
                     "output_tokens": 0,
-                    "total_tokens": 0
+                    "total_tokens": 0,
+                    "output_tokens_details": { "reasoning_tokens": 0 }
                 })
             })
         })

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1008,7 +1008,8 @@ pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
         return json!({
             "input_tokens": 0,
             "output_tokens": 0,
-            "total_tokens": 0
+            "total_tokens": 0,
+            "output_tokens_details": { "reasoning_tokens": 0 }
         });
     };
 
@@ -1042,7 +1043,13 @@ pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
     }
 
     if let Some(details) = usage.get("completion_tokens_details") {
-        result["output_tokens_details"] = details.clone();
+        let mut details = details.clone();
+        if details.get("reasoning_tokens").is_none() {
+            details["reasoning_tokens"] = json!(0);
+        }
+        result["output_tokens_details"] = details;
+    } else {
+        result["output_tokens_details"] = json!({ "reasoning_tokens": 0 });
     }
 
     if let Some(cache_read) = usage.get("cache_read_input_tokens") {

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1042,7 +1042,10 @@ pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
         result["input_tokens_details"] = json!({ "cached_tokens": cached });
     }
 
-    if let Some(details) = usage.get("completion_tokens_details") {
+    if let Some(details) = usage
+        .get("completion_tokens_details")
+        .filter(|v| v.is_object())
+    {
         let mut details = details.clone();
         if details.get("reasoning_tokens").is_none() {
             details["reasoning_tokens"] = json!(0);


### PR DESCRIPTION
fix(codex): always include output_tokens_details.reasoning_tokens in chat→responses transform

  Codex CLI/Codex Desktop strictly requires reasoning_tokens in the response.completed usage object. Custom providers using /chat/completions often omit completion_tokens_details, causing repeated parse failures and retries.

  ## Summary / 概述

  Codex CLI 在解析 responses API 的 usage 对象时，严格要求存在 `output_tokens_details.reasoning_tokens` 字段。当使用自定义 provider（走 /chat/completions 格式）时，上游往往不返回 `completion_tokens_details`，导致转换后的 usage 缺少该字段，Codex 解析失败并反复重试。

  本 PR 在 chat→responses 的 usage 转换逻辑中确保 `output_tokens_details.reasoning_tokens` 始终存在：
  - 上游无 usage 时，fallback 对象包含 `output_tokens_details: { reasoning_tokens: 0 }`
  - 上游有 `completion_tokens_details` 但缺少 `reasoning_tokens` 时，补零
  - 上游完全无 `completion_tokens_details` 时，插入默认值

  ## Related Issue / 关联 Issue

  Fixes #3081 

  ## Screenshots / 截图

  N/A（纯后端逻辑修改，无 UI 变动）

  ## Checklist / 检查清单

  - [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
  - [x] `pnpm format:check` passes / 通过代码格式检查
  - [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
  - [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件