### PR TITLE
feat(codex): add OpenCode Go provider preset

### DIFF
--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -280,6 +280,38 @@ requires_openai_auth = true`,
     iconColor: "#1E88E5",
   },
   {
+    name: "OpenCode Go",
+    websiteUrl: "https://opencode.ai",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "opencode_go",
+      "https://opencode.ai/zen/go/v1",
+      "deepseek-v4-flash",
+    ),
+    category: "third_party",
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      {
+        model: "deepseek-v4-flash",
+        displayName: "DeepSeek V4 Flash",
+        contextWindow: 1000000,
+      },
+      {
+        model: "deepseek-v4-pro",
+        displayName: "DeepSeek V4 Pro",
+        contextWindow: 1000000,
+      },
+    ]),
+    codexChatReasoning: {
+      supportsThinking: true,
+      thinkingParam: "thinking",
+      outputFormat: "reasoning_content",
+    },
+    endpointCandidates: ["https://opencode.ai/zen/go/v1"],
+    icon: "opencode",
+    iconColor: "#211E1E",
+  },
+  {
     name: "Zhipu GLM",
     websiteUrl: "https://open.bigmodel.cn",
     apiKeyUrl: "https://www.bigmodel.cn/claude-code?ic=RRVJPB5SII",


### PR DESCRIPTION
## Summary / 概述

Add **OpenCode Go** as a Codex provider preset to fix endpoint path resolution.

### Problem / 根因

When using the same base URL (`https://opencode.ai/zen/go`) as the OpenCode Go preset in Claude Code, requests work correctly in Claude Code but fail with upstream HTTP 404 in Codex.

The root cause is in [`forwarder.rs`](https://github.com/farion1231/cc-switch/blob/main/src-tauri/src/proxy/forwarder.rs): two endpoint rewrite functions output inconsistent paths for the same upstream target (Chat Completions API):

| Function | Returns `target_path` |
|---|---|
| [`rewrite_codex_responses_endpoint_to_chat`](https://github.com/farion1231/cc-switch/blob/main/src-tauri/src/proxy/forwarder.rs#L2083) | `/chat/completions` |
| [`rewrite_claude_transform_endpoint`](https://github.com/farion1231/cc-switch/blob/main/src-tauri/src/proxy/forwarder.rs#L2146) | `/v1/chat/completions` |

The Codex side is missing `/v1`, which causes [`CodexAdapter::build_url`](https://github.com/farion1231/cc-switch/blob/main/src-tauri/src/proxy/providers/codex.rs#L553-L555) to treat `https://opencode.ai/zen/go` as a custom prefix and not prepend `/v1`. The request ultimately lands on `/zen/go/chat/completions`. On the Claude side, the endpoint already carries `/v1`, so [`ClaudeAdapter::build_url`](https://github.com/farion1231/cc-switch/blob/main/src-tauri/src/proxy/providers/claude.rs#L703-L706) directly concatenates to produce the correct path `/zen/go/v1/chat/completions`.

```
Claude: https://opencode.ai/zen/go + /v1/chat/completions → OK ✅
Codex:  https://opencode.ai/zen/go + /chat/completions    → 404 ❌
```

Since fixing Codex-side path normalization globally could break other providers, a dedicated preset with the correct `/v1` suffix in the base URL is added instead.

### Changes / 变更

**`src/config/codexProviderPresets.ts`** — one new preset entry after DeepSeek:

| Field | Value |
|-------|-------|
| Provider | `opencode_go` |
| Base URL | `https://opencode.ai/zen/go/v1` |
| Default Model | `deepseek-v4-flash` |
| API Format | `openai_chat` |
| Model Catalog | `deepseek-v4-flash`, `deepseek-v4-pro` |
| Reasoning | thinking via `reasoning_content` |

## Related Issue / 关联 Issue

#3528

## Checklist / 检查清单

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
