### PR TITLE
fix(claude-desktop): 修复健康检查 400 和官方供应商复制报错

### DIFF
--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -1393,15 +1393,11 @@ impl StreamCheckService {
         config: &StreamCheckConfig,
     ) -> String {
         match app_type {
-            AppType::Claude => {
-                Self::extract_env_model(provider, "ANTHROPIC_MODEL")
-                    .unwrap_or_else(|| config.claude_model.clone())
-            }
-            AppType::ClaudeDesktop => {
-                Self::extract_env_model(provider, "ANTHROPIC_MODEL")
-                    .or_else(|| Self::extract_desktop_model_from_routes(provider))
-                    .unwrap_or_else(|| config.claude_model.clone())
-            }
+            AppType::Claude => Self::extract_env_model(provider, "ANTHROPIC_MODEL")
+                .unwrap_or_else(|| config.claude_model.clone()),
+            AppType::ClaudeDesktop => Self::extract_env_model(provider, "ANTHROPIC_MODEL")
+                .or_else(|| Self::extract_desktop_model_from_routes(provider))
+                .unwrap_or_else(|| config.claude_model.clone()),
             AppType::Codex => {
                 Self::extract_codex_model(provider).unwrap_or_else(|| config.codex_model.clone())
             }

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -1393,8 +1393,13 @@ impl StreamCheckService {
         config: &StreamCheckConfig,
     ) -> String {
         match app_type {
-            AppType::Claude | AppType::ClaudeDesktop => {
+            AppType::Claude => {
                 Self::extract_env_model(provider, "ANTHROPIC_MODEL")
+                    .unwrap_or_else(|| config.claude_model.clone())
+            }
+            AppType::ClaudeDesktop => {
+                Self::extract_env_model(provider, "ANTHROPIC_MODEL")
+                    .or_else(|| Self::extract_desktop_model_from_routes(provider))
                     .unwrap_or_else(|| config.claude_model.clone())
             }
             AppType::Codex => {
@@ -1448,6 +1453,21 @@ impl StreamCheckService {
             .and_then(|value| value.as_str())
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
+    }
+
+    /// Extract the first upstream model name from Claude Desktop's model route mapping.
+    ///
+    /// Claude Desktop presets store model info in `meta.claudeDesktopModelRoutes`
+    /// rather than `settings_config.env.ANTHROPIC_MODEL`, so this extra fallback is needed.
+    fn extract_desktop_model_from_routes(provider: &Provider) -> Option<String> {
+        provider
+            .meta
+            .as_ref()?
+            .claude_desktop_model_routes
+            .values()
+            .next()
+            .map(|route| route.model.trim().to_string())
+            .filter(|m| !m.is_empty())
     }
 
     fn extract_codex_model(provider: &Provider) -> Option<String> {

--- a/src/components/providers/ProviderActions.tsx
+++ b/src/components/providers/ProviderActions.tsx
@@ -27,7 +27,7 @@ interface ProviderActionsProps {
   isOmo?: boolean;
   onSwitch: () => void;
   onEdit: () => void;
-  onDuplicate: () => void;
+  onDuplicate?: () => void;
   onTest?: () => void;
   onConfigureUsage?: () => void;
   onDelete: () => void;
@@ -278,7 +278,10 @@ export function ProviderActions({
           variant="ghost"
           onClick={onDuplicate}
           title={t("provider.duplicate")}
-          className={iconButtonClass}
+          className={cn(
+            iconButtonClass,
+            !onDuplicate && "opacity-40 cursor-not-allowed text-muted-foreground",
+          )}
         >
           <Copy className="h-4 w-4" />
         </Button>

--- a/src/components/providers/ProviderActions.tsx
+++ b/src/components/providers/ProviderActions.tsx
@@ -280,7 +280,8 @@ export function ProviderActions({
           title={t("provider.duplicate")}
           className={cn(
             iconButtonClass,
-            !onDuplicate && "opacity-40 cursor-not-allowed text-muted-foreground",
+            !onDuplicate &&
+              "opacity-40 cursor-not-allowed text-muted-foreground",
           )}
         >
           <Copy className="h-4 w-4" />

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -48,7 +48,7 @@ interface ProviderCardProps {
   onDisableOmoSlim?: () => void;
   onConfigureUsage: (provider: Provider) => void;
   onOpenWebsite: (url: string) => void;
-  onDuplicate: (provider: Provider) => void;
+  onDuplicate?: (provider: Provider) => void;
   onTest?: (provider: Provider) => void;
   onOpenTerminal?: (provider: Provider) => void;
   isTesting?: boolean;
@@ -529,7 +529,13 @@ export function ProviderCard({
               isOmo={isAnyOmo}
               onSwitch={() => onSwitch(provider)}
               onEdit={() => onEdit(provider)}
-              onDuplicate={() => onDuplicate(provider)}
+              onDuplicate={
+                appId === "claude-desktop" && isOfficial
+                  ? undefined
+                  : onDuplicate
+                    ? () => onDuplicate(provider)
+                    : undefined
+              }
               onTest={
                 onTest &&
                 !isOfficial &&


### PR DESCRIPTION
## 概述

Claude Desktop 模块的两个关联修复：

### 1. 健康检查对第三方供应商返回 400
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/839fc3d8-32a8-4bd1-87b4-30d76ddb18c5" />

**根因**：`resolve_test_model()` 在 `settings_config.env.ANTHROPIC_MODEL` 未设置时，默认使用 `claude-haiku-4-5-20251001`。该模型仅官方 Anthropic API 支持，所有第三方供应商（MiMo、DeepSeek、OpenRouter 等）均返回 400。

**修复**：回退读取 `meta.claudeDesktopModelRoutes` 中的第一个上游模型，与 OpenCode、OpenClaw、Hermes 的处理模式一致。


### 2. 复制官方 Claude Desktop 供应商报错
<img width="400"   alt="image" src="https://github.com/user-attachments/assets/fd6cace6-d6e4-4ac0-917a-98789caddb62" />

**根因**：官方供应商的 `settingsConfig` 为空（设计如此——使用 Claude Desktop 内置 1P 模式）。复制时调用 `addProvider()` 触发 `validate_direct_provider()` 校验，因缺少 `ANTHROPIC_BASE_URL` 而失败。

**修复**：禁用官方 Claude Desktop 供应商的复制按钮。官方配置本身无实际凭据和设置，复制没有意义。

## 改动

- `src-tauri/src/services/stream_check.rs` — 新增 `extract_desktop_model_from_routes()` 回退方法
- `src/components/providers/ProviderActions.tsx` — `onDuplicate` 改为可选；未传时禁用按钮
- `src/components/providers/ProviderCard.tsx` — 官方 Claude Desktop 供应商不传 `onDuplicate`

## 验证

- [x] `pnpm typecheck` 通过
- [x] `cargo check` 通过
- [x] MiMo Token Plan 健康检查返回 200，使用 `mimo-v2.5-pro`
- [x] 官方 Claude Desktop 供应商复制按钮禁用
