### PR TITLE
Add Hermes OpenAI Codex official support

### DIFF
--- a/src-tauri/src/services/subscription.rs
+++ b/src-tauri/src/services/subscription.rs
@@ -13,7 +13,7 @@ use crate::config;
 // ── 数据类型 ──────────────────────────────────────────────
 
 /// 凭据状态
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CredentialStatus {
     Valid,
@@ -574,6 +574,175 @@ fn parse_codex_credentials_json(content: &str) -> CodexCredentials {
     (
         Some(access_token),
         tokens.account_id,
+        CredentialStatus::Valid,
+        None,
+    )
+}
+
+fn read_hermes_codex_credentials() -> CodexCredentials {
+    let auth_path = crate::hermes_config::get_hermes_dir().join("auth.json");
+
+    if !auth_path.exists() {
+        return (None, None, CredentialStatus::NotFound, None);
+    }
+
+    let content = match std::fs::read_to_string(&auth_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                None,
+                None,
+                CredentialStatus::ParseError,
+                Some(format!("Failed to read Hermes auth file: {e}")),
+            );
+        }
+    };
+
+    parse_hermes_codex_credentials_json(&content)
+}
+
+fn parse_hermes_codex_credentials_json(content: &str) -> CodexCredentials {
+    let auth: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                None,
+                None,
+                CredentialStatus::ParseError,
+                Some(format!("Failed to parse Hermes auth JSON: {e}")),
+            );
+        }
+    };
+
+    let mut expired_candidate: Option<CodexCredentials> = None;
+
+    if let Some(state) = auth
+        .get("providers")
+        .and_then(|providers| providers.get("openai-codex"))
+    {
+        let candidate = parse_hermes_codex_singleton_state(state);
+        match candidate.2 {
+            CredentialStatus::Valid => return candidate,
+            CredentialStatus::Expired => expired_candidate = Some(candidate),
+            CredentialStatus::NotFound | CredentialStatus::ParseError => {}
+        }
+    }
+
+    if let Some(entries) = auth
+        .get("credential_pool")
+        .and_then(|pool| pool.get("openai-codex"))
+        .and_then(|entries| entries.as_array())
+    {
+        for entry in entries {
+            let candidate = parse_hermes_codex_token_entry(entry, entry);
+            match candidate.2 {
+                CredentialStatus::Valid => return candidate,
+                CredentialStatus::Expired if expired_candidate.is_none() => {
+                    expired_candidate = Some(candidate)
+                }
+                CredentialStatus::Expired
+                | CredentialStatus::NotFound
+                | CredentialStatus::ParseError => {}
+            }
+        }
+    }
+
+    if let Some(candidate) = expired_candidate {
+        return candidate;
+    }
+
+    (
+        None,
+        None,
+        CredentialStatus::NotFound,
+        Some("No usable Hermes openai-codex access token".to_string()),
+    )
+}
+
+fn parse_hermes_codex_singleton_state(state: &serde_json::Value) -> CodexCredentials {
+    let Some(tokens) = state.get("tokens").filter(|tokens| tokens.is_object()) else {
+        return (
+            None,
+            None,
+            CredentialStatus::NotFound,
+            Some("No Hermes openai-codex singleton tokens".to_string()),
+        );
+    };
+
+    parse_hermes_codex_token_entry(tokens, state)
+}
+
+fn parse_hermes_codex_token_entry(
+    token_entry: &serde_json::Value,
+    metadata: &serde_json::Value,
+) -> CodexCredentials {
+    let access_token = token_entry
+        .get("access_token")
+        .and_then(|token| token.as_str())
+        .filter(|token| !token.trim().is_empty())
+        .map(str::to_string);
+
+    let Some(access_token) = access_token else {
+        return (
+            None,
+            None,
+            CredentialStatus::NotFound,
+            Some("No usable Hermes openai-codex access token".to_string()),
+        );
+    };
+
+    let account_id = token_entry
+        .get("account_id")
+        .or_else(|| metadata.get("account_id"))
+        .and_then(|id| id.as_str())
+        .filter(|id| !id.trim().is_empty())
+        .map(str::to_string);
+
+    let expires_at_ms = token_entry
+        .get("expires_at_ms")
+        .or_else(|| metadata.get("expires_at_ms"))
+        .and_then(|value| value.as_i64())
+        .or_else(|| {
+            token_entry
+                .get("expires_at")
+                .or_else(|| metadata.get("expires_at"))
+                .and_then(|value| value.as_str())
+                .and_then(|raw| chrono::DateTime::parse_from_rfc3339(raw).ok())
+                .map(|dt| dt.timestamp_millis())
+        });
+
+    if let Some(expires_at_ms) = expires_at_ms {
+        if expires_at_ms <= now_millis() {
+            return (
+                Some(access_token),
+                account_id,
+                CredentialStatus::Expired,
+                Some("Hermes openai-codex token has expired".to_string()),
+            );
+        }
+    }
+
+    if let Some(last_refresh) = token_entry
+        .get("last_refresh")
+        .or_else(|| metadata.get("last_refresh"))
+        .and_then(|value| value.as_str())
+    {
+        if is_codex_token_stale(last_refresh) {
+            return (
+                Some(access_token),
+                account_id,
+                CredentialStatus::Expired,
+                Some(
+                    "Hermes openai-codex token may be stale (>8 days since last refresh)"
+                        .to_string(),
+                ),
+            );
+        }
+    }
+
+    (
+        Some(access_token),
+        account_id,
         CredentialStatus::Valid,
         None,
     )
@@ -1273,6 +1442,49 @@ pub async fn get_subscription_quota(tool: &str) -> Result<SubscriptionQuota, Str
                 }
             }
         }
+        "hermes_codex" => {
+            let (token, account_id, status, message) = read_hermes_codex_credentials();
+
+            match status {
+                CredentialStatus::NotFound => Ok(SubscriptionQuota::not_found("hermes_codex")),
+                CredentialStatus::ParseError => Ok(SubscriptionQuota::error(
+                    "hermes_codex",
+                    CredentialStatus::ParseError,
+                    message.unwrap_or_else(|| "Failed to parse Hermes credentials".to_string()),
+                )),
+                CredentialStatus::Expired => {
+                    if let Some(token) = token {
+                        let result = query_codex_quota(
+                            &token,
+                            account_id.as_deref(),
+                            "hermes_codex",
+                            "Authentication failed. Please re-login with Hermes openai-codex.",
+                        )
+                        .await;
+                        if result.success {
+                            return Ok(result);
+                        }
+                    }
+                    Ok(SubscriptionQuota::error(
+                        "hermes_codex",
+                        CredentialStatus::Expired,
+                        message.unwrap_or_else(|| {
+                            "Hermes openai-codex token may be stale".to_string()
+                        }),
+                    ))
+                }
+                CredentialStatus::Valid => {
+                    let token = token.expect("token must be Some when status is Valid");
+                    Ok(query_codex_quota(
+                        &token,
+                        account_id.as_deref(),
+                        "hermes_codex",
+                        "Authentication failed. Please re-login with Hermes openai-codex.",
+                    )
+                    .await)
+                }
+            }
+        }
         "gemini" => {
             let (token, refresh_token, status, message) = read_gemini_credentials();
 
@@ -1320,4 +1532,86 @@ fn now_millis() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_hermes_codex_credentials_json, CredentialStatus};
+
+    #[test]
+    fn parses_hermes_codex_credential_pool_entry() {
+        let json = r#"{
+          "version": 1,
+          "active_provider": "openai-codex",
+          "credential_pool": {
+            "openai-codex": [
+              {
+                "label": "plus-a",
+                "access_token": "access-token-a",
+                "refresh_token": "refresh-token-a",
+                "account_id": "acct_123",
+                "expires_at_ms": 4102444800000
+              }
+            ]
+          }
+        }"#;
+
+        let (token, account_id, status, message) = parse_hermes_codex_credentials_json(json);
+
+        assert_eq!(token.as_deref(), Some("access-token-a"));
+        assert_eq!(account_id.as_deref(), Some("acct_123"));
+        assert_eq!(status, CredentialStatus::Valid);
+        assert!(message.is_none());
+    }
+
+    #[test]
+    fn prefers_fresh_hermes_codex_singleton_over_stale_pool_entry() {
+        let json = r#"{
+          "version": 1,
+          "active_provider": "openai-codex",
+          "providers": {
+            "openai-codex": {
+              "auth_mode": "chatgpt",
+              "last_refresh": "2099-01-01T00:00:00Z",
+              "tokens": {
+                "access_token": "fresh-singleton-token",
+                "refresh_token": "fresh-refresh-token",
+                "account_id": "acct_fresh"
+              }
+            }
+          },
+          "credential_pool": {
+            "openai-codex": [
+              {
+                "label": "stale-pool",
+                "access_token": "stale-pool-token",
+                "refresh_token": "stale-refresh-token",
+                "account_id": "acct_stale",
+                "expires_at_ms": 1
+              }
+            ]
+          }
+        }"#;
+
+        let (token, account_id, status, message) = parse_hermes_codex_credentials_json(json);
+
+        assert_eq!(token.as_deref(), Some("fresh-singleton-token"));
+        assert_eq!(account_id.as_deref(), Some("acct_fresh"));
+        assert_eq!(status, CredentialStatus::Valid);
+        assert!(message.is_none());
+    }
+
+    #[test]
+    fn hermes_codex_missing_pool_is_not_found() {
+        let json = r#"{"version":1,"credential_pool":{}}"#;
+
+        let (token, account_id, status, message) = parse_hermes_codex_credentials_json(json);
+
+        assert!(token.is_none());
+        assert!(account_id.is_none());
+        assert_eq!(status, CredentialStatus::NotFound);
+        assert!(message
+            .as_deref()
+            .is_some_and(|message| message.contains("access token")));
+    }
 }

--- a/src/components/HermesCodexQuotaFooter.tsx
+++ b/src/components/HermesCodexQuotaFooter.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useHermesCodexQuota } from "@/lib/query/subscription";
+import { SubscriptionQuotaView } from "@/components/SubscriptionQuotaFooter";
+
+interface HermesCodexQuotaFooterProps {
+  inline?: boolean;
+  /** 是否为当前激活的供应商 */
+  isCurrent?: boolean;
+}
+
+const HermesCodexQuotaFooter: React.FC<HermesCodexQuotaFooterProps> = ({
+  inline = false,
+  isCurrent = false,
+}) => {
+  const {
+    data: quota,
+    isFetching: loading,
+    refetch,
+  } = useHermesCodexQuota(true, isCurrent);
+
+  return (
+    <SubscriptionQuotaView
+      quota={quota}
+      loading={loading}
+      refetch={refetch}
+      appIdForExpiredHint="hermes openai-codex"
+      inline={inline}
+    />
+  );
+};
+
+export default HermesCodexQuotaFooter;

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -14,6 +14,7 @@ import UsageFooter from "@/components/UsageFooter";
 import SubscriptionQuotaFooter from "@/components/SubscriptionQuotaFooter";
 import CopilotQuotaFooter from "@/components/CopilotQuotaFooter";
 import CodexOauthQuotaFooter from "@/components/CodexOauthQuotaFooter";
+import HermesCodexQuotaFooter from "@/components/HermesCodexQuotaFooter";
 import { PROVIDER_TYPES } from "@/config/constants";
 import { isHermesReadOnlyProvider } from "@/config/hermesProviderPresets";
 import { ProviderHealthBadge } from "@/components/providers/ProviderHealthBadge";
@@ -197,16 +198,21 @@ export function ProviderCard({
   const isCopilot =
     provider.meta?.providerType === PROVIDER_TYPES.GITHUB_COPILOT ||
     provider.meta?.usage_script?.templateType === "github_copilot";
+  const settingsConfig = provider.settingsConfig as Record<string, any>;
   // Hermes v12+ overlay entries live under the `providers:` dict and are
   // read-only here — writes have to go through Hermes Web UI.
   const isHermesReadOnly =
     appId === "hermes" && isHermesReadOnlyProvider(provider.settingsConfig);
   const isCodexOauth =
     provider.meta?.providerType === PROVIDER_TYPES.CODEX_OAUTH;
+  const isHermesCodexOfficial =
+    appId === "hermes" &&
+    settingsConfig?.name === "openai-codex" &&
+    settingsConfig?.api_mode === "codex_responses";
   const codexNeedsRouting = useMemo(() => {
     if (appId !== "codex" || provider.category === "official") return false;
     if (provider.meta?.apiFormat === "openai_chat") return true;
-    const config = (provider.settingsConfig as Record<string, any>)?.config;
+    const config = settingsConfig?.config;
     return (
       typeof config === "string" &&
       isCodexChatWireApi(extractCodexWireApi(config))
@@ -215,7 +221,7 @@ export function ProviderCard({
     appId,
     provider.category,
     provider.meta?.apiFormat,
-    (provider.settingsConfig as Record<string, any>)?.config,
+    settingsConfig?.config,
   ]);
   const isClaudeThirdParty =
     appId === "claude" && provider.category === "third_party";
@@ -468,6 +474,8 @@ export function ProviderCard({
                   inline={true}
                   isCurrent={isCurrent}
                 />
+              ) : isHermesCodexOfficial ? (
+                <HermesCodexQuotaFooter inline={true} isCurrent={isCurrent} />
               ) : isOfficial ? (
                 <SubscriptionQuotaFooter
                   appId={appId}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -1658,7 +1658,7 @@ function ProviderFormFull({
       const preset = entry.preset as HermesProviderPreset;
       const config = preset.settingsConfig;
 
-      hermesForm.resetHermesState(config);
+      hermesForm.resetHermesState(config, preset.providerKey);
 
       form.reset({
         name: preset.nameKey ? t(preset.nameKey) : preset.name,

--- a/src/components/providers/forms/hooks/useHermesFormState.ts
+++ b/src/components/providers/forms/hooks/useHermesFormState.ts
@@ -44,7 +44,10 @@ export interface HermesFormState {
   handleHermesApiModeChange: (mode: HermesApiMode) => void;
   handleHermesModelsChange: (models: HermesModel[]) => void;
   handleHermesRateLimitDelayChange: (delay: number | undefined) => void;
-  resetHermesState: (config?: Partial<HermesProviderSettingsConfig>) => void;
+  resetHermesState: (
+    config?: Partial<HermesProviderSettingsConfig>,
+    providerKey?: string,
+  ) => void;
 }
 
 function parseHermesField<T>(
@@ -195,8 +198,8 @@ export function useHermesFormState({
   );
 
   const resetHermesState = useCallback(
-    (config?: Partial<HermesProviderSettingsConfig>) => {
-      setHermesProviderKey("");
+    (config?: Partial<HermesProviderSettingsConfig>, providerKey?: string) => {
+      setHermesProviderKey(providerKey ?? "");
       setHermesBaseUrl(config?.base_url || "");
       setHermesApiKey(config?.api_key || "");
       setHermesApiMode(config?.api_mode ?? HERMES_DEFAULT_API_MODE);

--- a/src/components/providers/forms/hooks/useProviderCategory.ts
+++ b/src/components/providers/forms/hooks/useProviderCategory.ts
@@ -5,6 +5,8 @@ import { providerPresets } from "@/config/claudeProviderPresets";
 import { codexProviderPresets } from "@/config/codexProviderPresets";
 import { geminiProviderPresets } from "@/config/geminiProviderPresets";
 import { opencodeProviderPresets } from "@/config/opencodeProviderPresets";
+import { openclawProviderPresets } from "@/config/openclawProviderPresets";
+import { hermesProviderPresets } from "@/config/hermesProviderPresets";
 
 interface UseProviderCategoryProps {
   appId: AppId;
@@ -44,7 +46,7 @@ export function useProviderCategory({
 
     // 从预设 ID 提取索引
     const match = selectedPresetId.match(
-      /^(claude|codex|gemini|opencode)-(\d+)$/,
+      /^(claude|codex|gemini|opencode|openclaw|hermes)-(\d+)$/,
     );
     if (!match) return;
 
@@ -74,6 +76,18 @@ export function useProviderCategory({
       const preset = opencodeProviderPresets[index];
       if (preset) {
         setCategory(preset.category || undefined);
+      }
+    } else if (type === "openclaw" && appId === "openclaw") {
+      const preset = openclawProviderPresets[index];
+      if (preset) {
+        setCategory(preset.category || undefined);
+      }
+    } else if (type === "hermes" && appId === "hermes") {
+      const preset = hermesProviderPresets[index];
+      if (preset) {
+        setCategory(
+          preset.category || (preset.isOfficial ? "official" : undefined),
+        );
       }
     }
   }, [appId, selectedPresetId, isEditMode, initialCategory]);

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -101,6 +101,7 @@ export interface HermesProviderPreset {
   nameKey?: string;
   websiteUrl: string;
   apiKeyUrl?: string;
+  providerKey?: string;
   settingsConfig: HermesProviderSettingsConfig;
   isOfficial?: boolean;
   isPartner?: boolean;
@@ -128,6 +129,34 @@ export interface HermesProviderSettingsConfig {
 }
 
 export const hermesProviderPresets: HermesProviderPreset[] = [
+  {
+    name: "OpenAI Official",
+    websiteUrl: "https://chatgpt.com/codex",
+    providerKey: "openai-codex",
+    settingsConfig: {
+      name: "openai-codex",
+      base_url: "https://chatgpt.com/backend-api/codex",
+      api_key: "",
+      api_mode: "codex_responses",
+      models: [
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+        },
+        {
+          id: "gpt-5.4-mini",
+          name: "GPT-5.4 Mini",
+        },
+      ],
+    },
+    isOfficial: true,
+    category: "official",
+    icon: "openai",
+    iconColor: "#00A67E",
+    suggestedDefaults: {
+      model: { default: "gpt-5.5", provider: "openai-codex" },
+    },
+  },
   {
     name: "Shengsuanyun",
     nameKey: "providerForm.presets.shengsuanyun",

--- a/src/lib/query/subscription.ts
+++ b/src/lib/query/subscription.ts
@@ -29,6 +29,19 @@ export function useSubscriptionQuota(
   });
 }
 
+export function useHermesCodexQuota(enabled: boolean, autoQuery = false) {
+  return useQuery({
+    queryKey: [...subscriptionKeys.all, "quota", "hermes_codex"] as const,
+    queryFn: () => subscriptionApi.getQuota("hermes_codex"),
+    enabled,
+    refetchInterval: autoQuery ? REFETCH_INTERVAL : false,
+    refetchIntervalInBackground: autoQuery,
+    refetchOnWindowFocus: autoQuery,
+    staleTime: REFETCH_INTERVAL,
+    retry: 1,
+  });
+}
+
 export interface UseCodexOauthQuotaOptions {
   enabled?: boolean;
   /** 是否启用自动轮询（5 分钟）与窗口 focus 重取 */

--- a/tests/config/providerPresetOrder.test.ts
+++ b/tests/config/providerPresetOrder.test.ts
@@ -82,4 +82,20 @@ describe("provider preset order", () => {
       "DouBaoSeed",
     ]);
   });
+
+  it("Hermes 预设包含 OpenAI Official 并映射到 Hermes Codex OAuth", () => {
+    expect(hermesProviderPresets[0]).toMatchObject({
+      name: "OpenAI Official",
+      providerKey: "openai-codex",
+      category: "official",
+      settingsConfig: {
+        name: "openai-codex",
+        base_url: "https://chatgpt.com/backend-api/codex",
+        api_mode: "codex_responses",
+      },
+      suggestedDefaults: {
+        model: { default: "gpt-5.5", provider: "openai-codex" },
+      },
+    });
+  });
 });

--- a/tests/hooks/useProviderCategory.test.tsx
+++ b/tests/hooks/useProviderCategory.test.tsx
@@ -1,0 +1,43 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { hermesProviderPresets } from "@/config/hermesProviderPresets";
+import { openclawProviderPresets } from "@/config/openclawProviderPresets";
+import { useProviderCategory } from "@/components/providers/forms/hooks/useProviderCategory";
+
+describe("useProviderCategory", () => {
+  it("detects Hermes preset categories", async () => {
+    const index = hermesProviderPresets.findIndex(
+      (preset) => preset.name === "OpenAI Official",
+    );
+
+    expect(index).toBeGreaterThanOrEqual(0);
+
+    const { result } = renderHook(() =>
+      useProviderCategory({
+        appId: "hermes",
+        selectedPresetId: `hermes-${index}`,
+        isEditMode: false,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.category).toBe("official"));
+  });
+
+  it("detects OpenClaw preset categories", async () => {
+    const index = openclawProviderPresets.findIndex(
+      (preset) => preset.name === "Shengsuanyun",
+    );
+
+    expect(index).toBeGreaterThanOrEqual(0);
+
+    const { result } = renderHook(() =>
+      useProviderCategory({
+        appId: "openclaw",
+        selectedPresetId: `openclaw-${index}`,
+        isEditMode: false,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.category).toBe("aggregator"));
+  });
+});


### PR DESCRIPTION
Adds an OpenAI Official preset for Hermes openai-codex, applies Hermes model defaults, and shows Codex quota from Hermes' own openai-codex credential pool.

Validation:
- pnpm exec tsc --noEmit
- pnpm exec vitest run tests/config/providerPresetOrder.test.ts tests/hooks/useProviderCategory.test.tsx
- cargo test -p cc-switch --lib services::subscription::tests
- git diff --check
