### PR TITLE
fix(codex): use relative filename for model_catalog_json

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2032,7 +2032,8 @@ model = "glm-5"
 "#;
         // Simulate a WSL UNC path as cc-switch would see it on Windows;
         // the function now writes just the relative filename.
-        let unc_path = Path::new(r"\\wsl.localhost\Ubuntu\home\user\.codex\cc-switch-model-catalog.json");
+        let unc_path =
+            Path::new(r"\\wsl.localhost\Ubuntu\home\user\.codex\cc-switch-model-catalog.json");
 
         let result = set_codex_model_catalog_json_field(input, Some(unc_path)).unwrap();
         let parsed: toml::Value = toml::from_str(&result).unwrap();
@@ -2128,5 +2129,4 @@ model_catalog_json = "cc-switch-model-catalog.json"
             "None arm should remove relative cc-switch-owned field"
         );
     }
-
 }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -682,20 +682,18 @@ fn set_codex_model_catalog_json_field(
     let mut doc = config_text
         .parse::<DocumentMut>()
         .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
-    let generated_path = get_codex_model_catalog_path();
 
     match catalog_path {
-        Some(path) => {
-            doc["model_catalog_json"] = toml_edit::value(path.to_string_lossy().as_ref());
+        Some(_) => {
+            doc["model_catalog_json"] = toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
         }
         None => {
             let should_remove = doc
                 .get("model_catalog_json")
                 .and_then(|item| item.as_str())
                 .map(|path| {
-                    path == generated_path.to_string_lossy().as_ref()
-                        || Path::new(path).file_name().and_then(|name| name.to_str())
-                            == Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME)
+                    Path::new(path).file_name().and_then(|name| name.to_str())
+                        == Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME)
                 })
                 .unwrap_or(false);
             if should_remove {
@@ -780,9 +778,8 @@ fn resolve_cc_switch_catalog_path(config_text: &str, generated_path: &Path) -> O
         .filter(|s| !s.is_empty())?;
 
     let referenced_path = Path::new(catalog_path_str);
-    let is_cc_switch_owned = catalog_path_str == generated_path.to_string_lossy().as_ref()
-        || referenced_path.file_name().and_then(|name| name.to_str())
-            == Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
+    let is_cc_switch_owned = referenced_path.file_name().and_then(|name| name.to_str())
+        == Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
     if !is_cc_switch_owned {
         return None;
     }
@@ -1791,7 +1788,7 @@ base_url = "https://production.api/v1"
     }
 
     #[test]
-    fn model_catalog_json_field_operates_on_top_level() {
+    fn model_catalog_json_field_writes_relative_filename() {
         let input = r#"model_provider = "any"
 
 [model_providers.any]
@@ -1805,7 +1802,7 @@ name = "any"
             parsed
                 .get("model_catalog_json")
                 .and_then(|value| value.as_str()),
-            Some("/tmp/cc-switch-model-catalog.json")
+            Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME)
         );
         assert!(
             parsed
@@ -2026,4 +2023,110 @@ name = "any"
             );
         }
     }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn set_catalog_json_field_writes_filename_ignoring_unc_path() {
+        let input = r#"model_provider = "custom"
+model = "glm-5"
+"#;
+        // Simulate a WSL UNC path as cc-switch would see it on Windows;
+        // the function now writes just the relative filename.
+        let unc_path = Path::new(r"\\wsl.localhost\Ubuntu\home\user\.codex\cc-switch-model-catalog.json");
+
+        let result = set_codex_model_catalog_json_field(input, Some(unc_path)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        let written_path = parsed
+            .get("model_catalog_json")
+            .and_then(|v| v.as_str())
+            .expect("model_catalog_json should be set");
+        assert_eq!(
+            written_path, CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME,
+            "should write only the relative filename, not the UNC path"
+        );
+    }
+
+    #[test]
+    fn set_catalog_json_field_writes_filename_for_any_path() {
+        let input = r#"model_provider = "custom"
+model = "glm-5"
+"#;
+        let regular_path = Path::new("/home/user/.codex/cc-switch-model-catalog.json");
+
+        let result = set_codex_model_catalog_json_field(input, Some(regular_path)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        assert_eq!(
+            parsed.get("model_catalog_json").and_then(|v| v.as_str()),
+            Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME),
+            "should write only the relative filename, not the full path"
+        );
+    }
+
+    #[test]
+    fn set_catalog_json_none_removes_cc_switch_owned_by_filename() {
+        // After the WSL fix, TOML may contain a Linux-style path.
+        // The None arm must still remove it (file_name match catches any format).
+        let input = r#"model_catalog_json = "/home/user/.codex/cc-switch-model-catalog.json"
+"#;
+        let result = set_codex_model_catalog_json_field(input, None).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        assert!(
+            parsed.get("model_catalog_json").is_none(),
+            "None arm should remove cc-switch-owned field regardless of path format"
+        );
+    }
+
+    #[test]
+    fn set_catalog_json_none_preserves_user_owned_catalog() {
+        let input = r#"model_catalog_json = "/Users/me/.codex/my-custom-catalog.json"
+"#;
+        let result = set_codex_model_catalog_json_field(input, None).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        assert_eq!(
+            parsed.get("model_catalog_json").and_then(|v| v.as_str()),
+            Some("/Users/me/.codex/my-custom-catalog.json"),
+            "None arm should NOT remove user-owned catalog"
+        );
+    }
+
+    #[test]
+    fn resolve_catalog_finds_relative_filename() {
+        let config_text = r#"model_provider = "custom"
+model_catalog_json = "cc-switch-model-catalog.json"
+"#;
+        let generated_path = PathBuf::from("/home/user/.codex/cc-switch-model-catalog.json");
+        let result = resolve_cc_switch_catalog_path(config_text, &generated_path);
+        assert_eq!(
+            result,
+            Some(generated_path),
+            "relative filename should resolve to generated_path for file I/O"
+        );
+    }
+
+    #[test]
+    fn resolve_catalog_ignores_user_owned_relative() {
+        let config_text = r#"model_catalog_json = "my-custom-catalog.json"
+"#;
+        let generated_path = PathBuf::from("/home/user/.codex/cc-switch-model-catalog.json");
+        let result = resolve_cc_switch_catalog_path(config_text, &generated_path);
+        assert_eq!(
+            result, None,
+            "user-owned catalog should not be claimed by cc-switch"
+        );
+    }
+
+    #[test]
+    fn set_catalog_json_none_removes_relative_path() {
+        let input = r#"model_catalog_json = "cc-switch-model-catalog.json"
+"#;
+        let result = set_codex_model_catalog_json_field(input, None).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        assert!(
+            parsed.get("model_catalog_json").is_none(),
+            "None arm should remove relative cc-switch-owned field"
+        );
+    }
+
 }


### PR DESCRIPTION
Closes #3573
Related: #3569

## Problem / 问题描述

When cc-switch runs on Windows and the Codex config directory is a WSL path (e.g. `\\wsl.localhost\Ubuntu\home\user\.codex`), the generated `config.toml` contains a Windows UNC path in `model_catalog_json`:

当 cc-switch 在 Windows 上运行，且 Codex 配置目录是 WSL 路径时，生成的 `config.toml` 中 `model_catalog_json` 字段包含 Windows UNC 路径：

```toml
model_catalog_json = '\\wsl.localhost\Ubuntu\home\user\.codex\cc-switch-model-catalog.json'
```

Codex CLI runs inside WSL and cannot resolve UNC paths. Additionally, users who symlink their `.codex` directory across Windows/WSL (e.g. `ln -s /mnt/c/Users/xxx/.codex ~/.codex`) will break with any absolute path format.

Codex CLI 在 WSL 中运行，无法解析 UNC 路径。此外，通过符号链接跨系统共享 `.codex` 目录的用户，无论使用 Linux 还是 Windows 绝对路径，都会在某一端失效。

## Summary / 方案概述

Write only the filename `cc-switch-model-catalog.json` (relative path) to `config.toml`. Since `config.toml` and the catalog file always reside in the same directory (`~/.codex/`), Codex CLI correctly resolves relative paths from the config directory.

仅写入文件名 `cc-switch-model-catalog.json`（相对路径）到 `config.toml`。由于 `config.toml` 和 catalog 文件始终在同一目录下，Codex CLI 会从配置目录解析相对路径。

This eliminates the need for platform-specific path translation and makes the config portable across Windows, WSL, and symlinked directories.

这消除了平台特定路径转换的需求，使配置在 Windows、WSL 和符号链接目录之间可移植。

## Key Changes / 主要变更

- `set_codex_model_catalog_json_field()`: `Some` arm writes only `CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME` instead of the full absolute path
- `resolve_cc_switch_catalog_path()`: Removed dead string-equality comparison that never matched on WSL
- `set_codex_model_catalog_json_field()` None arm: Ownership is now determined solely by filename match
- Deleted `wsl_unc_to_linux_path()` helper and all its tests (no longer needed)

- `set_codex_model_catalog_json_field()`：`Some` 分支仅写入 `CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME` 而非完整绝对路径
- `resolve_cc_switch_catalog_path()`：移除了在 WSL 上永远不匹配的字符串相等比较
- `set_codex_model_catalog_json_field()` None 分支：所有权判断仅通过文件名匹配
- 删除了 `wsl_unc_to_linux_path()` 辅助函数及其所有测试（不再需要）

## Test Plan / 测试计划

- [x] `model_catalog_json_field_writes_relative_filename` — verifies relative output / 验证相对路径输出
- [x] `set_catalog_json_field_writes_filename_for_any_path` — verifies any input path produces filename / 验证任意输入路径生成文件名
- [x] `set_catalog_json_field_writes_filename_ignoring_unc_path` — Windows-only, verifies UNC path input / 仅 Windows，验证 UNC 路径输入
- [x] `set_catalog_json_none_removes_cc_switch_owned_by_filename` — backward compat with absolute paths / 向后兼容绝对路径
- [x] `set_catalog_json_none_removes_relative_path` — verifies removal of new relative path format / 验证移除新的相对路径格式
- [x] `set_catalog_json_none_preserves_user_owned_catalog` — verifies user catalogs untouched / 验证用户自有 catalog 不受影响
- [x] `resolve_catalog_finds_relative_filename` — verifies read path handles relative / 验证读取路径处理相对路径
- [x] `resolve_catalog_ignores_user_owned_relative` — verifies user catalogs ignored / 验证用户自有 catalog 被忽略
- [x] All existing tests pass with no regressions / 所有现有测试通过，无回归
- [x] Manual verification on Windows+WSL / 在 Windows+WSL 环境手动验证

Supersedes #3574 (that approach used UNC-to-Linux path translation instead of relative paths)
取代 #3574（该方案使用 UNC 转 Linux 路径翻译，而非相对路径）