### PR TITLE
fix: disable auto-capitalize on Input component for macOS

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,6 +12,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           "flex h-9 w-full rounded-md border border-border-default bg-background text-foreground px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:focus:ring-blue-400/20 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
macOS 下 Tauri WebView 输入框默认行为会自动将首字母转为大写，非常烦人。将大小写由用户自己决定
* <img width="300" alt="image" src="https://github.com/user-attachments/assets/4a943449-d95e-4bfa-8230-6e3a430758e5" />
* <img width="300" alt="image" src="https://github.com/user-attachments/assets/0eab9612-1ed4-4d5d-8bda-e43dcbef8804" />

修复方法：
https://github.com/orgs/tauri-apps/discussions/7635