### PR TITLE
fix(codex): preserve custom tool metadata in chat routing

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -40,9 +40,9 @@ const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
 const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
 const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
 const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
-const CUSTOM_TOOL_FALLBACK_DESCRIPTION: &str = "Custom Codex tool.";
-const CUSTOM_TOOL_INPUT_DESCRIPTION: &str = "Raw string input for the original Codex custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description.";
-const CUSTOM_TOOL_PRESERVED_METADATA_HEADING: &str = "Original Codex tool definition:";
+const CUSTOM_TOOL_FALLBACK_DESCRIPTION: &str = "Custom tool.";
+const CUSTOM_TOOL_INPUT_DESCRIPTION: &str = "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description.";
+const CUSTOM_TOOL_PRESERVED_METADATA_HEADING: &str = "Original tool definition:";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodexToolKind {
@@ -1017,27 +1017,23 @@ fn responses_tool_name(tool: &Value) -> Option<String> {
 }
 
 fn responses_custom_tool_description(tool: &Value) -> String {
-    let base = tool
+    let fallback = tool
         .get("description")
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(CUSTOM_TOOL_FALLBACK_DESCRIPTION);
-    let mut description = base.to_string();
-
-    description.push_str(
-        "\n\nThis tool originated as a Codex custom tool. When calling it through Chat Completions, pass the exact raw tool payload in the `input` string argument.",
-    );
 
     if let Some(serialized) = serialize_tool_definition_for_description(tool) {
-        description.push_str("\n\n");
+        let mut description = String::new();
         description.push_str(CUSTOM_TOOL_PRESERVED_METADATA_HEADING);
         description.push_str("\n```json\n");
         description.push_str(&serialized);
         description.push_str("\n```");
+        return description;
     }
 
-    description
+    fallback.to_string()
 }
 
 fn serialize_tool_definition_for_description(tool: &Value) -> Option<String> {
@@ -1902,7 +1898,8 @@ mod tests {
             .as_str()
             .unwrap();
 
-        assert!(description.contains("Original Codex tool definition"));
+        assert!(description.starts_with("Original tool definition:"));
+        assert!(!description.contains("Original Codex tool definition"));
         assert!(description.contains("\"type\": \"custom\""));
         assert!(description.contains("\"format\""));
         assert!(description.contains("\"syntax\": \"lark\""));

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -40,6 +40,9 @@ const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
 const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
 const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
 const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
+const CUSTOM_TOOL_FALLBACK_DESCRIPTION: &str = "Custom Codex tool.";
+const CUSTOM_TOOL_INPUT_DESCRIPTION: &str = "Raw string input for the original Codex custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description.";
+const CUSTOM_TOOL_PRESERVED_METADATA_HEADING: &str = "Original Codex tool definition:";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodexToolKind {
@@ -132,10 +135,7 @@ impl CodexToolContext {
         let Some(name) = responses_tool_name(tool) else {
             return;
         };
-        let description = tool
-            .get("description")
-            .cloned()
-            .unwrap_or_else(|| json!("Custom Codex tool."));
+        let description = json!(responses_custom_tool_description(tool));
         let chat_tool = json!({
             "type": "function",
             "function": {
@@ -146,7 +146,7 @@ impl CodexToolContext {
                     "properties": {
                         CUSTOM_TOOL_INPUT_FIELD: {
                             "type": "string",
-                            "description": "Input to pass to the custom Codex tool."
+                            "description": CUSTOM_TOOL_INPUT_DESCRIPTION
                         }
                     },
                     "required": [CUSTOM_TOOL_INPUT_FIELD]
@@ -1016,6 +1016,40 @@ fn responses_tool_name(tool: &Value) -> Option<String> {
         .map(ToString::to_string)
 }
 
+fn responses_custom_tool_description(tool: &Value) -> String {
+    let base = tool
+        .get("description")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(CUSTOM_TOOL_FALLBACK_DESCRIPTION);
+    let mut description = base.to_string();
+
+    description.push_str(
+        "\n\nThis tool originated as a Codex custom tool. When calling it through Chat Completions, pass the exact raw tool payload in the `input` string argument.",
+    );
+
+    if let Some(serialized) = serialize_tool_definition_for_description(tool) {
+        description.push_str("\n\n");
+        description.push_str(CUSTOM_TOOL_PRESERVED_METADATA_HEADING);
+        description.push_str("\n```json\n");
+        description.push_str(&serialized);
+        description.push_str("\n```");
+    }
+
+    description
+}
+
+fn serialize_tool_definition_for_description(tool: &Value) -> Option<String> {
+    if !tool.is_object() {
+        return None;
+    }
+
+    serde_json::to_string_pretty(tool)
+        .ok()
+        .or_else(|| Some(canonical_json_string(tool)))
+}
+
 fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option<Value> {
     if tool.get("type").and_then(|v| v.as_str()) != Some("function") {
         return None;
@@ -1845,6 +1879,33 @@ mod tests {
             result["messages"][0]["tool_calls"][0]["function"]["arguments"],
             r#"{"input":"*** Begin Patch\n*** End Patch"}"#
         );
+    }
+
+    #[test]
+    fn responses_request_to_chat_preserves_custom_tool_metadata_in_description() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "custom",
+                "name": "apply_patch",
+                "description": "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.",
+                "format": {
+                    "type": "grammar",
+                    "syntax": "lark",
+                    "definition": "start: begin_patch hunk+ end_patch"
+                }
+            }]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let description = result["tools"][0]["function"]["description"]
+            .as_str()
+            .unwrap();
+
+        assert!(description.contains("Original Codex tool definition"));
+        assert!(description.contains("\"type\": \"custom\""));
+        assert!(description.contains("\"format\""));
+        assert!(description.contains("\"syntax\": \"lark\""));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1041,9 +1041,10 @@ fn serialize_tool_definition_for_description(tool: &Value) -> Option<String> {
         return None;
     }
 
-    serde_json::to_string_pretty(tool)
-        .ok()
-        .or_else(|| Some(canonical_json_string(tool)))
+    // Keep the embedded definition compact to reduce tool-description token
+    // overhead for chat-only upstreams, while remaining stable across map
+    // storage order.
+    Some(canonical_json_string(tool))
 }
 
 fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option<Value> {
@@ -1900,9 +1901,9 @@ mod tests {
 
         assert!(description.starts_with("Original tool definition:"));
         assert!(!description.contains("Original Codex tool definition"));
-        assert!(description.contains("\"type\": \"custom\""));
-        assert!(description.contains("\"format\""));
-        assert!(description.contains("\"syntax\": \"lark\""));
+        assert!(description.contains("\"type\":\"custom\""));
+        assert!(description.contains("\"format\":"));
+        assert!(description.contains("\"syntax\":\"lark\""));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -40,7 +40,6 @@ const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
 const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
 const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
 const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
-const CUSTOM_TOOL_FALLBACK_DESCRIPTION: &str = "Custom tool.";
 const CUSTOM_TOOL_INPUT_DESCRIPTION: &str = "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description.";
 const CUSTOM_TOOL_PRESERVED_METADATA_HEADING: &str = "Original tool definition:";
 
@@ -1017,34 +1016,19 @@ fn responses_tool_name(tool: &Value) -> Option<String> {
 }
 
 fn responses_custom_tool_description(tool: &Value) -> String {
-    let fallback = tool
-        .get("description")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(CUSTOM_TOOL_FALLBACK_DESCRIPTION);
-
-    if let Some(serialized) = serialize_tool_definition_for_description(tool) {
-        let mut description = String::new();
-        description.push_str(CUSTOM_TOOL_PRESERVED_METADATA_HEADING);
-        description.push_str("\n```json\n");
-        description.push_str(&serialized);
-        description.push_str("\n```");
-        return description;
-    }
-
-    fallback.to_string()
+    let mut description = String::new();
+    description.push_str(CUSTOM_TOOL_PRESERVED_METADATA_HEADING);
+    description.push_str("\n```json\n");
+    description.push_str(&serialize_tool_definition_for_description(tool));
+    description.push_str("\n```");
+    description
 }
 
-fn serialize_tool_definition_for_description(tool: &Value) -> Option<String> {
-    if !tool.is_object() {
-        return None;
-    }
-
+fn serialize_tool_definition_for_description(tool: &Value) -> String {
     // Keep the embedded definition compact to reduce tool-description token
     // overhead for chat-only upstreams, while remaining stable across map
     // storage order.
-    Some(canonical_json_string(tool))
+    canonical_json_string(tool)
 }
 
 fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option<Value> {


### PR DESCRIPTION
## Summary / 概述

在 Codex 请求经由 chat 协议提供方转发时，保留自定义工具的完整元数据，避免协议转换后工具说明丢失。

以 Codex 的 `apply_patch` 为例：

原始 Responses 工具定义里会包含一些 Chat Completions 没有直接对应位置的字段，例如 freeform grammar 相关元数据：

```json
{
  "type": "custom",
  "name": "apply_patch",
  "description": "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.",
  "format": {
    "type": "grammar",
    "syntax": "lark",
    "definition": "start: begin_patch hunk+ end_patch"
  }
}
```

改动前，CC Switch 会把这个工具转换成普通的 Chat Completions function，只保留基础说明。像 `format` 这类 Responses 专用元数据会被丢弃，这会导致上游 llm 无法按照正常的格式进行 patch：

```json
{
  "type": "function",
  "function": {
    "name": "apply_patch",
    "description": "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.",
    "parameters": {
      "type": "object",
      "properties": {
        "input": {
          "type": "string",
          "description": "Raw string input for the original Codex custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description."
        }
      },
      "required": ["input"]
    }
  }
}
```

改动后，CC Switch 仍然把自定义工具暴露为 Chat Completions function，但会把原始工具定义嵌入到 function description 里。这样上游 chat 协议模型依然能看到原本会丢失的元数据：

```json
{
  "type": "function",
  "function": {
    "name": "apply_patch",
    "description": "Original tool definition:\n```json\n{\"description\":\"Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.\",\"format\":{\"definition\":\"start: begin_patch hunk+ end_patch\",\"syntax\":\"lark\",\"type\":\"grammar\"},\"name\":\"apply_patch\",\"type\":\"custom\"}\n```",
    "parameters": {
      "type": "object",
      "properties": {
        "input": {
          "type": "string",
          "description": "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description."
        }
      },
      "required": ["input"]
    }
  }
}
```

## Related Issue / 关联 Issue

Ref #2806
Ref #2553 

## Screenshots / 截图

改动前，接入 DeepSeek 无法正常 patch：

<img width="715" height="829" alt="image" src="https://github.com/user-attachments/assets/b7060f64-0a3d-44e9-9b4e-b2db238863b4" />

改动后 DeepSeek 能够正常 Patch 成功：

<img width="663" height="779" alt="image" src="https://github.com/user-attachments/assets/56f5c09a-7df6-4b81-a582-bc58f743a5a2" />

## Checklist / 检查清单

Clippy 的两条警告不是本次改动引入的

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
