### PR TITLE
feat(proxy): 基于请求内容的智能模型降级（图片请求自动切换多模态模型）

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -476,6 +476,9 @@ pub struct ProviderMeta {
     /// 用于多账号支持，关联到特定的 GitHub 账号
     #[serde(rename = "githubAccountId", skip_serializing_if = "Option::is_none")]
     pub github_account_id: Option<String>,
+    /// 多模态降级模型：当请求包含图片且当前模型不支持多模态时，自动切换到此模型
+    #[serde(rename = "multimodalFallbackModel", skip_serializing_if = "Option::is_none")]
+    pub multimodal_fallback_model: Option<String>,
 }
 
 impl ProviderMeta {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -958,6 +958,26 @@ impl RequestForwarder {
         // 与 CCH 对齐：请求前不做 thinking 主动改写（仅保留兼容入口）
         let mut mapped_body = normalize_thinking_type(mapped_body);
 
+        // 多模态降级：检测请求中的图片内容，自动切换到预配置的多模态模型
+        // 适用于 MiMo-v2.5-pro → mimo-v2.5、DeepSeek-v4-pro → deepseek-v4 等场景
+        if super::model_mapper::request_contains_images(&mapped_body) {
+            if let Some(fallback_model) = provider
+                .meta
+                .as_ref()
+                .and_then(|m| m.multimodal_fallback_model.as_deref())
+            {
+                let original_model = mapped_body["model"].as_str().unwrap_or("?").to_string();
+                log::info!(
+                    "[ModelMapper] 检测到图片内容，降级模型: {} → {}",
+                    original_model,
+                    fallback_model
+                );
+                mapped_body["model"] = serde_json::json!(fallback_model);
+            }
+            // 未配置 fallback 时不干预：让请求正常发送到上游，
+            // 由上游 API 决定模型是否支持图片输入
+        }
+
         if is_copilot {
             mapped_body =
                 super::providers::copilot_model_map::apply_copilot_model_normalization(mapped_body);

--- a/src-tauri/src/proxy/model_mapper.rs
+++ b/src-tauri/src/proxy/model_mapper.rs
@@ -140,6 +140,62 @@ pub fn strip_one_m_suffix_for_upstream_from_body(mut body: Value) -> Value {
     body
 }
 
+/// 检测请求体中是否包含图片内容。
+///
+/// 支持两种 API 格式：
+/// - Anthropic Messages API: `messages[].content[].type == "image"`（需验证 source 字段）
+/// - OpenAI Responses API: `input[].type == "input_image"` 或 `input[].content[].type == "input_image"`
+///
+/// 用于多模态降级判断：当检测到图片且当前模型不支持多模态时，自动切换到预配置的降级模型。
+pub fn request_contains_images(body: &Value) -> bool {
+    // Anthropic Messages API 格式
+    if let Some(messages) = body.get("messages").and_then(|m| m.as_array()) {
+        for msg in messages {
+            if let Some(content) = msg.get("content").and_then(|c| c.as_array()) {
+                for block in content {
+                    if block.get("type").and_then(|t| t.as_str()) == Some("image") {
+                        // 验证 source 字段是否存在且有效
+                        if let Some(source) = block.get("source") {
+                            if let Some(source_type) = source.get("type").and_then(|t| t.as_str()) {
+                                if source_type == "base64" && source.get("data").is_some() {
+                                    return true;
+                                }
+                                if source_type == "url" && source.get("url").is_some() {
+                                    return true;
+                                }
+                            }
+                            // 兼容旧格式：直接检查 data 或 url
+                            if source.get("data").is_some() || source.get("url").is_some() {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // OpenAI Responses API 格式
+    if let Some(input) = body.get("input").and_then(|i| i.as_array()) {
+        for item in input {
+            // input item 直接是 content block
+            if item.get("type").and_then(|t| t.as_str()) == Some("input_image") {
+                return true;
+            }
+            // input item 是 message，内含 content 数组
+            if let Some(content) = item.get("content").and_then(|c| c.as_array()) {
+                for block in content {
+                    if block.get("type").and_then(|t| t.as_str()) == Some("input_image") {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -308,5 +364,88 @@ mod tests {
         let body = json!({"model": "deepseek-v4-pro"});
         let result = strip_one_m_suffix_for_upstream_from_body(body);
         assert_eq!(result["model"], "deepseek-v4-pro");
+    }
+
+    // ==================== request_contains_images 测试 ====================
+
+    #[test]
+    fn test_request_contains_images_anthropic_base64() {
+        let body = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBOR..."}}
+                ]
+            }]
+        });
+        assert!(request_contains_images(&body));
+    }
+
+    #[test]
+    fn test_request_contains_images_anthropic_url() {
+        let body = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {"type": "url", "url": "https://example.com/img.png"}}
+                ]
+            }]
+        });
+        assert!(request_contains_images(&body));
+    }
+
+    #[test]
+    fn test_request_contains_images_responses_format() {
+        let body = json!({
+            "input": [
+                {"type": "message", "role": "user", "content": [
+                    {"type": "input_text", "text": "what is this"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,abc123"}
+                ]}
+            ]
+        });
+        assert!(request_contains_images(&body));
+    }
+
+    #[test]
+    fn test_request_contains_images_responses_direct_input_image() {
+        let body = json!({
+            "input": [
+                {"type": "input_image", "image_url": "data:image/png;base64,abc123"}
+            ]
+        });
+        assert!(request_contains_images(&body));
+    }
+
+    #[test]
+    fn test_request_no_images_text_only() {
+        let body = json!({
+            "messages": [{
+                "role": "user",
+                "content": [{"type": "text", "text": "hello world"}]
+            }]
+        });
+        assert!(!request_contains_images(&body));
+    }
+
+    #[test]
+    fn test_request_no_images_responses_text_only() {
+        let body = json!({
+            "input": [
+                {"type": "message", "role": "user", "content": [
+                    {"type": "input_text", "text": "hello world"}
+                ]}
+            ]
+        });
+        assert!(!request_contains_images(&body));
+    }
+
+    #[test]
+    fn test_request_no_images_empty_content() {
+        let body = json!({
+            "messages": [{"role": "user", "content": []}]
+        });
+        assert!(!request_contains_images(&body));
     }
 }

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -509,6 +509,9 @@ function ProviderFormFull({
     useState<CodexChatReasoning>(
       () => initialData?.meta?.codexChatReasoning ?? {},
     );
+  const [multimodalFallbackModel, setMultimodalFallbackModel] = useState<
+    string | undefined
+  >(() => initialData?.meta?.multimodalFallbackModel);
 
   const {
     codexAuth,
@@ -1386,6 +1389,10 @@ function ProviderFormFull({
         localCodexApiFormat === "openai_chat"
           ? normalizeCodexChatReasoningForSave(codexChatReasoning)
           : undefined,
+      multimodalFallbackModel:
+        appId === "codex" && category !== "official"
+          ? multimodalFallbackModel
+          : undefined,
       testConfig: testConfig.enabled ? testConfig : undefined,
       costMultiplier: pricingConfig.enabled
         ? pricingConfig.costMultiplier
@@ -1524,6 +1531,7 @@ function ProviderFormFull({
         const template = getCodexCustomTemplate();
         resetCodexConfig(template.auth, template.config);
         setCodexChatReasoning({});
+        setMultimodalFallbackModel(undefined);
         setLocalCodexApiFormat(
           codexApiFormatFromWireApi(extractCodexWireApi(template.config)) ??
             "openai_responses",
@@ -1565,6 +1573,7 @@ function ProviderFormFull({
 
       resetCodexConfig(auth, config, preset.modelCatalog ?? []);
       setCodexChatReasoning(preset.codexChatReasoning ?? {});
+      setMultimodalFallbackModel(preset.multimodalFallbackModel);
       setLocalCodexApiFormat(
         preset.apiFormat ??
           codexApiFormatFromWireApi(extractCodexWireApi(config)) ??

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -33,6 +33,8 @@ export interface CodexProviderPreset {
   apiFormat?: CodexApiFormat;
   // Codex Chat 本地路由模式下的模型目录
   modelCatalog?: CodexCatalogModel[];
+  // 多模态降级模型：当请求包含图片且当前模型不支持多模态时，自动切换到此模型
+  multimodalFallbackModel?: string;
   // Codex Responses -> Chat Completions reasoning capability defaults
   codexChatReasoning?: CodexChatReasoning;
 }
@@ -70,7 +72,7 @@ requires_openai_auth = true`;
 
 function modelCatalog(
   models: Array<
-    string | { model: string; displayName?: string; contextWindow?: number }
+    string | { model: string; displayName?: string; contextWindow?: number; supportsMultimodal?: boolean }
   >,
 ): CodexCatalogModel[] {
   return models.map((entry) =>
@@ -80,6 +82,7 @@ function modelCatalog(
           model: entry.model,
           displayName: entry.displayName,
           contextWindow: entry.contextWindow,
+          supportsMultimodal: entry.supportsMultimodal,
         },
   );
 }
@@ -631,8 +634,16 @@ requires_openai_auth = true`,
         model: "mimo-v2.5-pro",
         displayName: "MiMo V2.5 Pro",
         contextWindow: 1048576,
+        supportsMultimodal: false,
+      },
+      {
+        model: "mimo-v2.5",
+        displayName: "MiMo V2.5 (Multimodal)",
+        contextWindow: 1048576,
+        supportsMultimodal: true,
       },
     ]),
+    multimodalFallbackModel: "mimo-v2.5",
     codexChatReasoning: {
       supportsThinking: true,
       supportsEffort: false,
@@ -661,8 +672,16 @@ requires_openai_auth = true`,
         model: "mimo-v2.5-pro",
         displayName: "MiMo V2.5 Pro",
         contextWindow: 1048576,
+        supportsMultimodal: false,
+      },
+      {
+        model: "mimo-v2.5",
+        displayName: "MiMo V2.5 (Multimodal)",
+        contextWindow: 1048576,
+        supportsMultimodal: true,
       },
     ]),
+    multimodalFallbackModel: "mimo-v2.5",
     codexChatReasoning: {
       supportsThinking: true,
       supportsEffort: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,8 @@ export interface ProviderMeta {
   promptCacheKey?: string;
   // Codex OAuth FAST mode: injects service_tier="priority" on ChatGPT Codex requests
   codexFastMode?: boolean;
+  // 多模态降级模型：当请求包含图片且当前模型不支持多模态时，自动切换到此模型
+  multimodalFallbackModel?: string;
   // Codex Responses -> Chat Completions reasoning capability metadata
   codexChatReasoning?: CodexChatReasoning;
   // 供应商类型（用于识别 Copilot 等特殊供应商）
@@ -251,6 +253,7 @@ export interface CodexCatalogModel {
   model: string;
   displayName?: string;
   contextWindow?: string | number;
+  supportsMultimodal?: boolean;
 }
 
 // Claude 认证字段类型

--- a/tests/config/codexChatProviderPresets.test.ts
+++ b/tests/config/codexChatProviderPresets.test.ts
@@ -138,14 +138,14 @@ const expectedChatPresets = new Map<
     "Xiaomi MiMo",
     {
       baseUrl: "https://api.xiaomimimo.com/v1",
-      contextWindows: { "mimo-v2.5-pro": 1048576 },
+      contextWindows: { "mimo-v2.5-pro": 1048576, "mimo-v2.5": 1048576 },
     },
   ],
   [
     "Xiaomi MiMo Token Plan (China)",
     {
       baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
-      contextWindows: { "mimo-v2.5-pro": 1048576 },
+      contextWindows: { "mimo-v2.5-pro": 1048576, "mimo-v2.5": 1048576 },
     },
   ],
   [


### PR DESCRIPTION
## 概述

当用户通过 CC Switch 代理使用纯文本模型（如 `mimo-v2.5-pro` `deepseek v4 `）时，如果请求中包含图片内容，上游 API 会返回 400/404 错误。

本 PR 在代理层新增**基于请求内容的智能模型降级**：自动检测请求中的图片内容，将模型切换为用户预配置的多模态降级模型。

该能力是通用的，不仅解决 MiMo 的问题，也适用于 DeepSeek、Qwen 等其他纯文本模型。

## 主要改动

- **图片检测函数 `request_contains_images()`** — 支持两种 API 格式：
  - Anthropic Messages API: `messages[].content[].type == "image"`（含 source 字段验证）
  - OpenAI Responses API: `input[].type == "input_image"`
- **新增 `multimodalFallbackModel` 字段** — Rust 端 `ProviderMeta` + TypeScript 端 `CodexProviderPreset`
- **Forwarder 集成** — 在模型映射之后注入降级逻辑；未配置 fallback 时不干预，让请求正常发送到上游
- **MiMo 预设更新** — modelCatalog 新增 `mimo-v2.5`（多模态），预设 `multimodalFallbackModel: "mimo-v2.5"`
- **`supportsMultimodal` 标志** — `CodexCatalogModel` 新增可选字段，标注模型是否支持多模态
- **7 个单元测试** — 覆盖 Anthropic base64/URL、Responses API、纯文本、空内容等场景
- **更新已有测试** — `codexChatProviderPresets.test.ts` 适配新增的 mimo-v2.5 模型

## 工作原理

降级发生在 Responses API → Chat Completions 格式转换**之前**，因此两种 API 格式都能正确处理。

## 设计决策

1. **优雅降级**：未配置 fallback 模型时，请求原样发送到上游，由上游决定是否支持图片（不主动拒绝）
2. **通用方案**：适用于 MiMo、DeepSeek、Qwen 等任何纯文本模型 + 多模态变体的组合
3. **预设自动配置**：MiMo 预设开箱即用，用户无需手动设置

## 已验证

- `mimo-v2.5-pro` + 图片 → 404 错误："No endpoints found that support image input"
- `mimo-v2.5` + 图片 → 成功识别图片内容
- 完整流程测试：Responses API → 图片检测 → 降级 → Chat Completions → 成功
- TypeScript 类型检查通过
- 74 个前端单元测试全部通过

## 关联 Issue

Fixes #3415, Fixes #3561, Fixes #3068

## 检查清单

- [x] `pnpm typecheck` 通过
- [x] `pnpm test:unit` 相关测试通过
- [x] 7 个新增单元测试通过
- [x] UTF-8 编码（无 BOM）
- [x] 向后兼容：`multimodal_fallback_model` 为 `Option<String>`，默认 `None`