### PR TITLE
Fix deeplink prompt import test home isolation

### DIFF
--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -9,7 +9,51 @@ use super::DeepLinkImportRequest;
 use crate::AppType;
 use crate::{store::AppState, Database};
 use base64::prelude::*;
-use std::sync::Arc;
+use std::{env, ffi::OsString, sync::Arc};
+
+struct TestHomeGuard {
+    _dir: tempfile::TempDir,
+    original_home: Option<OsString>,
+    original_userprofile: Option<OsString>,
+    original_test_home: Option<OsString>,
+}
+
+impl TestHomeGuard {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("create isolated test home");
+        let original_home = env::var_os("HOME");
+        let original_userprofile = env::var_os("USERPROFILE");
+        let original_test_home = env::var_os("CC_SWITCH_TEST_HOME");
+
+        env::set_var("HOME", dir.path());
+        env::set_var("USERPROFILE", dir.path());
+        env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+
+        Self {
+            _dir: dir,
+            original_home,
+            original_userprofile,
+            original_test_home,
+        }
+    }
+}
+
+impl Drop for TestHomeGuard {
+    fn drop(&mut self) {
+        match &self.original_test_home {
+            Some(value) => env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+        match &self.original_userprofile {
+            Some(value) => env::set_var("USERPROFILE", value),
+            None => env::remove_var("USERPROFILE"),
+        }
+        match &self.original_home {
+            Some(value) => env::set_var("HOME", value),
+            None => env::remove_var("HOME"),
+        }
+    }
+}
 
 // =============================================================================
 // Parser Tests
@@ -477,8 +521,12 @@ fn test_build_claude_provider_without_config_unchanged() {
 // Prompt Tests
 // =============================================================================
 
+// Integration-style unit test: prompt import reaches PromptService and resolves
+// live config file paths, so HOME must be isolated before it runs.
 #[test]
+#[serial_test::serial]
 fn test_import_prompt_allows_space_in_base64_content() {
+    let _test_home = TestHomeGuard::new();
     let url = "ccswitch://v1/import?resource=prompt&app=codex&name=PromptPlus&content=Pj4+";
     let request = parse_deeplink_url(url).unwrap();
 


### PR DESCRIPTION
## 背景

这次修复来自一次真实事故：在本地运行 deeplink prompt 导入相关单测时，测试没有隔离 HOME，结果走到了真实 Codex 配置目录，并把真实 `~/.codex/AGENTS.md` 清空了。

根因是这个测试看起来只是验证 deeplink/base64 解析，但实际调用了 `import_prompt_from_deeplink`，会继续进入 `PromptService` 并解析 live prompt 文件路径。仅使用内存数据库不能隔离文件系统副作用。

## 变更内容

- 为 deeplink prompt 导入单测增加临时 HOME 隔离。
- 在测试期间设置并恢复 `HOME`、`USERPROFILE` 和 `CC_SWITCH_TEST_HOME`。
- 将该测试标记为串行执行，避免进程级环境变量与并发测试互相影响。
- 补充注释说明该单测会走到 `PromptService` 并解析 live config 文件路径，因此必须隔离 HOME。

## 验证

- `cargo test --lib deeplink::tests::test_import_prompt_allows_space_in_base64_content -- --exact`
- `cargo fmt --check`