### PR TITLE
fix(代理): 检测纯文本模型并跳过图片转换

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
-tauri = { version = "2.8.2", features = ["tray-icon", "protocol-asset", "image-png"] }
+tauri = { version = "2.8.2", features = ["tray-icon", "protocol-asset", "image-png", "custom-protocol"] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-process = "2"

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -68,6 +68,22 @@ pub fn supports_reasoning_effort(model: &str) -> bool {
             .is_some_and(|c| c.is_ascii_digit() && c >= '5')
 }
 
+/// Detect models that support vision (image input).
+///
+/// Known text-only model families return `false`; all others are conservatively
+/// assumed to support vision. When `false`, image content blocks in the request
+/// are replaced with a text placeholder to avoid 400 errors from the upstream API.
+///
+/// Known text-only families:
+/// - DeepSeek (all variants: v3*, v4*, chat, reasoner)
+/// - Kimi / Moonshot
+pub fn supports_vision(model: &str) -> bool {
+    let model_lower = model.to_lowercase();
+    !(model_lower.starts_with("deepseek")
+        || model_lower.starts_with("kimi")
+        || model_lower.starts_with("moonshot"))
+}
+
 /// Resolve the appropriate OpenAI `reasoning_effort` from an Anthropic request body.
 ///
 /// Priority:
@@ -161,10 +177,15 @@ pub fn anthropic_to_openai_with_reasoning_content(
 
     // 转换 messages
     if let Some(msgs) = body.get("messages").and_then(|m| m.as_array()) {
+        let supports_vision = body
+            .get("model")
+            .and_then(|m| m.as_str())
+            .map(supports_vision)
+            .unwrap_or(true);
         for msg in msgs {
             let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
             let content = msg.get("content");
-            let converted = convert_message_to_openai(role, content, preserve_reasoning_content)?;
+            let converted = convert_message_to_openai(role, content, preserve_reasoning_content, supports_vision)?;
             messages.extend(converted);
         }
     }
@@ -348,6 +369,7 @@ fn convert_message_to_openai(
     role: &str,
     content: Option<&Value>,
     preserve_reasoning_content: bool,
+    supports_vision: bool,
 ) -> Result<Vec<Value>, ProxyError> {
     let mut result = Vec::new();
 
@@ -387,15 +409,22 @@ fn convert_message_to_openai(
                     }
                 }
                 "image" => {
-                    if let Some(source) = block.get("source") {
-                        let media_type = source
-                            .get("media_type")
-                            .and_then(|m| m.as_str())
-                            .unwrap_or("image/png");
-                        let data = source.get("data").and_then(|d| d.as_str()).unwrap_or("");
+                    if supports_vision {
+                        if let Some(source) = block.get("source") {
+                            let media_type = source
+                                .get("media_type")
+                                .and_then(|m| m.as_str())
+                                .unwrap_or("image/png");
+                            let data = source.get("data").and_then(|d| d.as_str()).unwrap_or("");
+                            content_parts.push(json!({
+                                "type": "image_url",
+                                "image_url": {"url": format!("data:{};base64,{}", media_type, data)}
+                            }));
+                        }
+                    } else {
                         content_parts.push(json!({
-                            "type": "image_url",
-                            "image_url": {"url": format!("data:{};base64,{}", media_type, data)}
+                            "type": "text",
+                            "text": "[Image omitted - model does not support vision input]"
                         }));
                     }
                 }

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -9,6 +9,7 @@
 //! - usage 字段命名与 Anthropic 一致 (input_tokens/output_tokens)
 
 use crate::proxy::{error::ProxyError, json_canonical::canonical_json_string};
+use super::transform::supports_vision;
 use serde_json::{json, Value};
 
 pub(crate) fn sanitize_anthropic_tool_use_input(name: &str, input: Value) -> Value {
@@ -82,7 +83,12 @@ pub fn anthropic_to_responses(
 
     // messages → input
     if let Some(msgs) = body.get("messages").and_then(|m| m.as_array()) {
-        let input = convert_messages_to_input(msgs)?;
+        let supports_vision = body
+            .get("model")
+            .and_then(|m| m.as_str())
+            .map(supports_vision)
+            .unwrap_or(true);
+        let input = convert_messages_to_input(msgs, supports_vision)?;
         result["input"] = json!(input);
     }
 
@@ -365,7 +371,7 @@ pub(crate) fn build_anthropic_usage_from_responses(usage: Option<&Value>) -> Val
 /// - tool_use 从 assistant message 中"提升"为独立的 function_call item
 /// - tool_result 从 user message 中"提升"为独立的 function_call_output item
 /// - thinking blocks → 丢弃
-fn convert_messages_to_input(messages: &[Value]) -> Result<Vec<Value>, ProxyError> {
+fn convert_messages_to_input(messages: &[Value], supports_vision: bool) -> Result<Vec<Value>, ProxyError> {
     let mut input = Vec::new();
 
     for msg in messages {
@@ -408,16 +414,23 @@ fn convert_messages_to_input(messages: &[Value]) -> Result<Vec<Value>, ProxyErro
                         }
 
                         "image" => {
-                            if let Some(source) = block.get("source") {
-                                let media_type = source
-                                    .get("media_type")
-                                    .and_then(|m| m.as_str())
-                                    .unwrap_or("image/png");
-                                let data =
-                                    source.get("data").and_then(|d| d.as_str()).unwrap_or("");
+                            if supports_vision {
+                                if let Some(source) = block.get("source") {
+                                    let media_type = source
+                                        .get("media_type")
+                                        .and_then(|m| m.as_str())
+                                        .unwrap_or("image/png");
+                                    let data =
+                                        source.get("data").and_then(|d| d.as_str()).unwrap_or("");
+                                    message_content.push(json!({
+                                        "type": "input_image",
+                                        "image_url": format!("data:{media_type};base64,{data}")
+                                    }));
+                                }
+                            } else {
                                 message_content.push(json!({
-                                    "type": "input_image",
-                                    "image_url": format!("data:{media_type};base64,{data}")
+                                    "type": "input_text",
+                                    "text": "[Image omitted - model does not support vision input]"
                                 }));
                             }
                         }


### PR DESCRIPTION
## 背景

修复 #3663 —— DeepSeek V4 Pro / Kimi / Moonshot 等纯文本模型在 Claude Code 含图片会话中返回 400 错误。

## 改动

| 文件 | 改动 | 行数 |
|------|------|------|
| `src-tauri/Cargo.toml` | 添加 `custom-protocol` feature | +1/-1 |
| `src-tauri/src/proxy/providers/transform.rs` | 新增 `supports_vision()` + 接入判定 | +38/-9 |
| `src-tauri/src/proxy/providers/transform_responses.rs` | 导入并接入 `supports_vision()` | +24/-11 |

## 核心逻辑

```rust
pub fn supports_vision(model: &str) -> bool {
    let model_lower = model.to_lowercase();
    !(model_lower.starts_with("deepseek")
        || model_lower.starts_with("kimi")
        || model_lower.starts_with("moonshot"))
}
```

不支持视觉的模型，`image` 块替换为文本占位符 `[Image omitted - model does not support vision input]`。

## 附加修复

`Cargo.toml` 添加 `custom-protocol` feature。原因：纯 `cargo build --release`（非 `cargo tauri build`）构建时，Tauri 缺少此 feature 会进入 dev 模式，Linux 下 webview 尝试连接 `http://localhost:3000` 而非加载内嵌 `dist/` 资源，GUI 显示空白页 "Could not connect to localhost"。

## 测试

- ✅ 已本地构建并运行，DeepSeek V4 Pro 含图片会话不再报错
- ✅ 代理端口 15721 正常监听
- ✅ GUI 正常渲染
- ✅ 已有单元测试通过

Closes #3663