### PR TITLE
Improve Codex custom/freeform tool Chat bridge

### DIFF
--- a/src-tauri/src/proxy/providers/codex_chat_history.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_history.rs
@@ -109,16 +109,12 @@ impl CodexChatHistoryStore {
 
         let output_call_ids = items
             .iter()
-            .filter(|item| {
-                item.get("type").and_then(|value| value.as_str()) == Some("function_call_output")
-            })
+            .filter(|item| is_tool_call_output_item(item))
             .filter_map(response_item_call_id)
             .collect::<HashSet<_>>();
         let existing_call_ids = items
             .iter()
-            .filter(|item| {
-                item.get("type").and_then(|value| value.as_str()) == Some("function_call")
-            })
+            .filter(|item| is_tool_call_item(item))
             .filter_map(response_item_call_id)
             .collect::<HashSet<_>>();
         let requested_call_ids = output_call_ids
@@ -143,7 +139,7 @@ impl CodexChatHistoryStore {
 
         for mut item in items {
             match item.get("type").and_then(|value| value.as_str()) {
-                Some("function_call") => {
+                Some("function_call") | Some("custom_tool_call") => {
                     if let Some(call_id) = response_item_call_id(&item) {
                         if let Some(cached) = lookup.call(&call_id) {
                             if enrich_function_call_reasoning(&mut item, cached) {
@@ -154,7 +150,7 @@ impl CodexChatHistoryStore {
                     }
                     new_items.push(item);
                 }
-                Some("function_call_output") => {
+                Some("function_call_output") | Some("custom_tool_call_output") => {
                     if let Some(group) = restore_group.take().filter(|group| !group.is_empty()) {
                         for (call_id, cached_item) in group {
                             seen_call_ids.insert(call_id);
@@ -360,6 +356,20 @@ fn append_restore_group(
     }
 }
 
+fn is_tool_call_item(item: &Value) -> bool {
+    matches!(
+        item.get("type").and_then(|value| value.as_str()),
+        Some("function_call" | "custom_tool_call")
+    )
+}
+
+fn is_tool_call_output_item(item: &Value) -> bool {
+    matches!(
+        item.get("type").and_then(|value| value.as_str()),
+        Some("function_call_output" | "custom_tool_call_output")
+    )
+}
+
 pub fn record_responses_sse_stream(
     stream: impl Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
     history: Arc<CodexChatHistoryStore>,
@@ -437,7 +447,7 @@ async fn inspect_sse_block(
 }
 
 fn cached_function_call(item: &Value) -> Option<(String, Value)> {
-    if item.get("type").and_then(|value| value.as_str()) != Some("function_call") {
+    if !is_tool_call_item(item) {
         return None;
     }
     let call_id = response_item_call_id(item)?;
@@ -501,6 +511,42 @@ mod tests {
         assert_eq!(input[0]["type"], "function_call");
         assert_eq!(input[0]["reasoning_content"], "Need to inspect the file.");
         assert_eq!(input[1]["type"], "function_call_output");
+    }
+
+    #[tokio::test]
+    async fn enriches_custom_tool_output_with_cached_custom_tool_call() {
+        let history = CodexChatHistoryStore::default();
+        history
+            .record_response(&json!({
+                "id": "resp_1",
+                "output": [
+                    {
+                        "type": "custom_tool_call",
+                        "call_id": "call_patch",
+                        "name": "apply_patch",
+                        "input": "*** Begin Patch\n*** Add File: hello.txt\n+hi\n*** End Patch",
+                        "reasoning_content": "Need to edit the file."
+                    }
+                ]
+            }))
+            .await;
+
+        let mut request = json!({
+            "previous_response_id": "resp_1",
+            "input": [
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_patch",
+                    "output": "Success. Updated the following files:\nA hello.txt\n"
+                }
+            ]
+        });
+
+        assert_eq!(history.enrich_request(&mut request).await, 1);
+        let input = request["input"].as_array().unwrap();
+        assert_eq!(input[0]["type"], "custom_tool_call");
+        assert_eq!(input[0]["reasoning_content"], "Need to edit the file.");
+        assert_eq!(input[1]["type"], "custom_tool_call_output");
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/codex_custom_tools.rs
+++ b/src-tauri/src/proxy/providers/codex_custom_tools.rs
@@ -248,11 +248,7 @@ fn apply_patch_candidate_from_command_array(value: &Value) -> Option<String> {
     let Value::Array(items) = value else {
         return None;
     };
-    if !items
-        .first()
-        .and_then(Value::as_str)
-        .is_some_and(|name| name == APPLY_PATCH_TOOL_NAME)
-    {
+    if items.first().and_then(Value::as_str) != Some(APPLY_PATCH_TOOL_NAME) {
         return None;
     }
 

--- a/src-tauri/src/proxy/providers/codex_custom_tools.rs
+++ b/src-tauri/src/proxy/providers/codex_custom_tools.rs
@@ -1,0 +1,386 @@
+//! Helpers for adapting Codex Responses custom/freeform tools to Chat function tools.
+
+use crate::proxy::json_canonical::{canonical_json_string, canonicalize_json_string_if_parseable};
+use serde_json::{json, Value};
+
+pub(crate) const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
+
+const APPLY_PATCH_TOOL_NAME: &str = "apply_patch";
+const EXEC_TOOL_NAME: &str = "exec";
+const APPLY_PATCH_BEGIN_MARKER: &str = "*** Begin Patch";
+const APPLY_PATCH_END_MARKER: &str = "*** End Patch";
+
+const CUSTOM_CHAT_DESCRIPTION: &str = r#"Codex custom/freeform tool adapted for Chat Completions.
+
+For this bridge, call the function with JSON arguments:
+{"input":"<raw tool input>"}
+
+The input string is forwarded as Responses custom_tool_call.input. Put only the
+raw string required by the tool in input; do not wrap it in a second JSON object,
+Markdown fences, prose, or a shell command unless the original tool description
+explicitly requires that."#;
+
+const CUSTOM_INPUT_DESCRIPTION: &str = r#"Raw string input for this Codex custom/freeform tool. This Chat function wrapper requires JSON arguments with an "input" string, and that string is forwarded to Responses custom_tool_call.input."#;
+
+const EXEC_CHAT_DESCRIPTION: &str = r#"Run Codex code-mode JavaScript through the raw exec custom tool.
+
+For this Chat Completions bridge, call the function with JSON arguments:
+{"input":"<raw JavaScript source>"}
+
+The input string must contain only JavaScript source text. Do not include
+Markdown fences, a JSON string literal, prose, or a shell command wrapper inside
+input. You may start with a first-line pragma such as:
+// @exec: {"yield_time_ms": 1000, "max_output_tokens": 2000}
+
+Examples:
+{"input":"const result = await tools.exec_command({cmd: \"pwd\"});\ntext(result.output);"}
+
+{"input":"// @exec: {\"yield_time_ms\": 1000, \"max_output_tokens\": 2000}\nconst result = await tools.list_mcp_resources({});\ntext(JSON.stringify(result));"}"#;
+
+const EXEC_INPUT_DESCRIPTION: &str = r#"Raw JavaScript source for Codex code-mode exec. Put JS source here as a plain string; do not wrap it in Markdown fences, prose, a shell command, or a second JSON object. An optional first-line // @exec: {...} pragma is allowed."#;
+
+const APPLY_PATCH_CHAT_DESCRIPTION: &str = r#"Apply file edits using Codex's raw apply_patch format.
+
+For this Chat Completions bridge you must call the function with JSON arguments:
+{"input":"<raw patch text>"}
+
+The input string itself must be only the raw patch. Do not include Markdown fences,
+shell heredocs, JSON, prose, or an apply_patch command wrapper inside input. The
+patch must start with "*** Begin Patch" and end with "*** End Patch".
+
+Supported operations:
+
+Add a file:
+*** Begin Patch
+*** Add File: path/to/new.txt
++first line
++second line
+*** End Patch
+
+Update a file:
+*** Begin Patch
+*** Update File: path/to/file.txt
+@@
+-old line
++new line
+*** End Patch
+
+Delete a file:
+*** Begin Patch
+*** Delete File: path/to/old.txt
+*** End Patch
+
+Move/update a file:
+*** Begin Patch
+*** Update File: old/path.txt
+*** Move to: new/path.txt
+@@
+-old content
++new content
+*** End Patch"#;
+
+const APPLY_PATCH_INPUT_DESCRIPTION: &str = r#"Raw apply_patch patch text. It must begin with "*** Begin Patch" and end with "*** End Patch". Put the patch here as a plain string; do not wrap it in Markdown code fences, prose, a shell command, or a second JSON object. Use "*** Add File:", "*** Update File:", "*** Delete File:", and optionally "*** Move to:" hunks."#;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CustomToolInputKind {
+    ApplyPatch,
+    Exec,
+    Generic,
+}
+
+impl CustomToolInputKind {
+    fn for_tool_name(tool_name: &str) -> Self {
+        match tool_name {
+            APPLY_PATCH_TOOL_NAME => Self::ApplyPatch,
+            EXEC_TOOL_NAME => Self::Exec,
+            _ => Self::Generic,
+        }
+    }
+
+    fn chat_description(self, tool: &Value) -> String {
+        match self {
+            Self::ApplyPatch => APPLY_PATCH_CHAT_DESCRIPTION.to_string(),
+            Self::Exec => with_original_tool_description(EXEC_CHAT_DESCRIPTION, tool),
+            Self::Generic => with_original_tool_description(CUSTOM_CHAT_DESCRIPTION, tool),
+        }
+    }
+
+    fn input_description(self) -> &'static str {
+        match self {
+            Self::ApplyPatch => APPLY_PATCH_INPUT_DESCRIPTION,
+            Self::Exec => EXEC_INPUT_DESCRIPTION,
+            Self::Generic => CUSTOM_INPUT_DESCRIPTION,
+        }
+    }
+
+    fn argument_keys(self) -> &'static [&'static str] {
+        match self {
+            Self::ApplyPatch => &[CUSTOM_TOOL_INPUT_FIELD, "patch", "command"],
+            Self::Exec => &[
+                CUSTOM_TOOL_INPUT_FIELD,
+                "code",
+                "source",
+                "script",
+                "javascript",
+                "js",
+                "command",
+            ],
+            Self::Generic => &[
+                CUSTOM_TOOL_INPUT_FIELD,
+                "text",
+                "content",
+                "payload",
+                "data",
+                "source",
+                "code",
+            ],
+        }
+    }
+
+    fn normalize_input(self, input: &str) -> String {
+        match self {
+            Self::ApplyPatch => normalize_apply_patch_input(input),
+            Self::Exec => normalize_exec_input(input),
+            Self::Generic => normalize_generic_input(input),
+        }
+    }
+}
+
+pub(crate) fn custom_tool_chat_description(tool_name: &str, tool: &Value) -> String {
+    CustomToolInputKind::for_tool_name(tool_name).chat_description(tool)
+}
+
+pub(crate) fn custom_tool_input_description(tool_name: &str) -> &'static str {
+    CustomToolInputKind::for_tool_name(tool_name).input_description()
+}
+
+pub(crate) fn custom_tool_arguments_from_response_input(input: Option<&Value>) -> String {
+    let input = response_custom_input_to_string(input);
+    canonical_json_string(&json!({ CUSTOM_TOOL_INPUT_FIELD: input }))
+}
+
+pub(crate) fn custom_tool_arguments_from_chat_value(arguments: Option<&Value>) -> String {
+    match arguments {
+        Some(Value::String(value)) => custom_tool_arguments_from_chat_str(value),
+        Some(value) => canonical_json_string(value),
+        None => String::new(),
+    }
+}
+
+pub(crate) fn custom_tool_arguments_from_chat_str(arguments: &str) -> String {
+    canonicalize_json_string_if_parseable(arguments)
+}
+
+pub(crate) fn custom_tool_input_from_chat_arguments(tool_name: &str, arguments: &str) -> String {
+    let kind = CustomToolInputKind::for_tool_name(tool_name);
+    let candidate = custom_tool_input_candidate_from_chat_arguments(kind, arguments)
+        .unwrap_or_else(|| arguments.to_string());
+    kind.normalize_input(&candidate)
+}
+
+fn response_custom_input_to_string(input: Option<&Value>) -> String {
+    match input {
+        Some(Value::String(value)) => value.clone(),
+        Some(value) => canonical_json_string(value),
+        None => String::new(),
+    }
+}
+
+fn custom_tool_input_candidate_from_chat_arguments(
+    kind: CustomToolInputKind,
+    arguments: &str,
+) -> Option<String> {
+    let trimmed = arguments.trim();
+    if trimmed.is_empty() {
+        return Some(String::new());
+    }
+
+    let value = serde_json::from_str::<Value>(trimmed).ok()?;
+    custom_tool_input_candidate_from_value(kind, &value)
+}
+
+fn custom_tool_input_candidate_from_value(
+    kind: CustomToolInputKind,
+    value: &Value,
+) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Object(obj) => {
+            for key in kind.argument_keys() {
+                if let Some(value) = obj.get(*key) {
+                    if let Some(candidate) =
+                        custom_tool_input_candidate_from_argument_value(kind, value)
+                    {
+                        return Some(candidate);
+                    }
+                }
+            }
+
+            if obj.len() == 1 {
+                return obj
+                    .values()
+                    .next()
+                    .map(|value| response_custom_input_to_string(Some(value)));
+            }
+
+            (kind == CustomToolInputKind::Generic).then(|| canonical_json_string(value))
+        }
+        _ => Some(response_custom_input_to_string(Some(value))),
+    }
+}
+
+fn custom_tool_input_candidate_from_argument_value(
+    kind: CustomToolInputKind,
+    value: &Value,
+) -> Option<String> {
+    if kind == CustomToolInputKind::ApplyPatch {
+        if let Some(candidate) = apply_patch_candidate_from_command_array(value) {
+            return Some(candidate);
+        }
+    }
+
+    Some(response_custom_input_to_string(Some(value)))
+}
+
+fn apply_patch_candidate_from_command_array(value: &Value) -> Option<String> {
+    let Value::Array(items) = value else {
+        return None;
+    };
+    if !items
+        .first()
+        .and_then(Value::as_str)
+        .is_some_and(|name| name == APPLY_PATCH_TOOL_NAME)
+    {
+        return None;
+    }
+
+    items
+        .iter()
+        .skip(1)
+        .filter_map(Value::as_str)
+        .find(|text| text.contains(APPLY_PATCH_BEGIN_MARKER))
+        .map(ToString::to_string)
+}
+
+fn normalize_apply_patch_input(input: &str) -> String {
+    let mut value = strip_markdown_fence(input)
+        .unwrap_or(input)
+        .trim()
+        .to_string();
+    if let Some(extracted) = extract_apply_patch_body(&value) {
+        value = extracted;
+    }
+    strip_markdown_fence(&value)
+        .unwrap_or(&value)
+        .trim()
+        .to_string()
+}
+
+fn normalize_exec_input(input: &str) -> String {
+    strip_markdown_fence(input)
+        .unwrap_or(input)
+        .trim()
+        .to_string()
+}
+
+fn normalize_generic_input(input: &str) -> String {
+    strip_markdown_fence(input)
+        .map(|value| value.trim().to_string())
+        .unwrap_or_else(|| input.to_string())
+}
+
+fn extract_apply_patch_body(input: &str) -> Option<String> {
+    let begin = input.find(APPLY_PATCH_BEGIN_MARKER)?;
+    let after_begin = &input[begin..];
+    let end_relative = after_begin.find(APPLY_PATCH_END_MARKER)?;
+    let end = begin + end_relative + APPLY_PATCH_END_MARKER.len();
+    Some(input[begin..end].to_string())
+}
+
+fn strip_markdown_fence(input: &str) -> Option<&str> {
+    let trimmed = input.trim();
+    let rest = trimmed.strip_prefix("```")?;
+    let first_newline = rest.find('\n')?;
+    let body = rest[first_newline + 1..].trim_end();
+    body.strip_suffix("```").map(str::trim_end)
+}
+
+fn with_original_tool_description(prefix: &str, tool: &Value) -> String {
+    let Some(description) = tool
+        .get("description")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return prefix.to_string();
+    };
+
+    format!("{prefix}\n\nOriginal Codex tool description:\n{description}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn custom_tool_arguments_from_response_input_always_uses_string_input() {
+        assert_eq!(
+            custom_tool_arguments_from_response_input(Some(&json!("hello"))),
+            r#"{"input":"hello"}"#
+        );
+        assert_eq!(
+            custom_tool_arguments_from_response_input(Some(&json!({"b": 2, "a": 1}))),
+            r#"{"input":"{\"a\":1,\"b\":2}"}"#
+        );
+    }
+
+    #[test]
+    fn generic_custom_input_accepts_string_aliases_and_structured_values() {
+        assert_eq!(
+            custom_tool_input_from_chat_arguments("custom", r#"{"content":"hello"}"#),
+            "hello"
+        );
+        assert_eq!(
+            custom_tool_input_from_chat_arguments("custom", r#"{"input":{"b":2,"a":1}}"#),
+            r#"{"a":1,"b":2}"#
+        );
+        assert_eq!(
+            custom_tool_input_from_chat_arguments("custom", r#""raw string""#),
+            "raw string"
+        );
+    }
+
+    #[test]
+    fn exec_input_accepts_code_alias_and_strips_fences() {
+        let input = custom_tool_input_from_chat_arguments(
+            "exec",
+            r#"{"code":"```js\nconst value = 1;\ntext(value);\n```"}"#,
+        );
+
+        assert_eq!(input, "const value = 1;\ntext(value);");
+    }
+
+    #[test]
+    fn apply_patch_input_extracts_command_array_and_patch_body() {
+        let input = custom_tool_input_from_chat_arguments(
+            "apply_patch",
+            r#"{"command":["apply_patch","prose\n*** Begin Patch\n*** Delete File: old.txt\n*** End Patch\nextra"]}"#,
+        );
+
+        assert_eq!(
+            input,
+            "*** Begin Patch\n*** Delete File: old.txt\n*** End Patch"
+        );
+    }
+
+    #[test]
+    fn custom_tool_chat_description_preserves_original_description() {
+        let description =
+            custom_tool_chat_description("exec", &json!({"description": "Original exec details."}));
+
+        assert!(description.contains(r#"{"input":"<raw JavaScript source>"}"#));
+        assert!(description.contains("Original Codex tool description:"));
+        assert!(description.contains("Original exec details."));
+    }
+}

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -17,6 +17,7 @@ mod claude;
 mod codex;
 pub(crate) mod codex_chat_common;
 pub mod codex_chat_history;
+pub(crate) mod codex_custom_tools;
 pub mod codex_oauth_auth;
 pub mod copilot_auth;
 pub mod copilot_model_map;

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -5,7 +5,7 @@ use super::{
         extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
     },
     transform_codex_chat::{
-        chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
+        chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments_for_tool,
         response_id_from_chat_id, response_status_from_finish_reason,
         response_tool_call_item_from_chat_name, response_tool_call_item_id_from_chat_name,
         CodexToolContext,
@@ -735,7 +735,7 @@ impl ChatToResponsesState {
             self.output_items.push((output_index, item.clone()));
 
             if is_custom_tool {
-                let input = custom_tool_input_from_chat_arguments(&arguments);
+                let input = custom_tool_input_from_chat_arguments_for_tool(&state.name, &arguments);
                 if !input.is_empty() {
                     events.push(sse_event(
                         "response.custom_tool_call_input.delta",

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -4,11 +4,13 @@ use super::{
     codex_chat_common::{
         extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
     },
+    codex_custom_tools::{
+        custom_tool_arguments_from_chat_str, custom_tool_input_from_chat_arguments,
+    },
     transform_codex_chat::{
-        chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments_for_tool,
-        response_id_from_chat_id, response_status_from_finish_reason,
-        response_tool_call_item_from_chat_name, response_tool_call_item_id_from_chat_name,
-        CodexToolContext,
+        chat_usage_to_responses_usage, response_id_from_chat_id,
+        response_status_from_finish_reason, response_tool_call_item_from_chat_name,
+        response_tool_call_item_id_from_chat_name, CodexToolContext,
     },
 };
 use crate::proxy::json_canonical::canonicalize_tool_arguments_str;
@@ -720,8 +722,12 @@ impl ChatToResponsesState {
                 continue;
             };
             let output_index = state.output_index.unwrap_or(0);
-            let arguments = canonicalize_tool_arguments_str(&state.arguments);
             let is_custom_tool = self.tool_context.is_custom_tool_chat_name(&state.name);
+            let arguments = if is_custom_tool {
+                custom_tool_arguments_from_chat_str(&state.arguments)
+            } else {
+                canonicalize_tool_arguments_str(&state.arguments)
+            };
             let item = response_tool_call_item_from_chat_name(
                 &state.item_id,
                 "completed",
@@ -735,7 +741,7 @@ impl ChatToResponsesState {
             self.output_items.push((output_index, item.clone()));
 
             if is_custom_tool {
-                let input = custom_tool_input_from_chat_arguments_for_tool(&state.name, &arguments);
+                let input = custom_tool_input_from_chat_arguments(&state.name, &arguments);
                 if !input.is_empty() {
                     events.push(sse_event(
                         "response.custom_tool_call_input.delta",
@@ -1104,6 +1110,30 @@ mod tests {
         assert!(output.contains("\"type\":\"custom_tool_call\""));
         assert!(output.contains("\"name\":\"exec\""));
         assert!(output.contains("\"input\":\"ls -la\""));
+    }
+
+    #[tokio::test]
+    async fn streamed_custom_tool_without_arguments_keeps_empty_input() {
+        let request = json!({
+            "model": "gpt-5.4",
+            "tools": [{ "type": "custom", "name": "exec" }]
+        });
+        let context =
+            super::super::transform_codex_chat::build_codex_tool_context_from_request(&request);
+        let output = collect_with_context(
+            vec![
+                "data: {\"id\":\"chatcmpl_custom_empty\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_custom\",\"type\":\"function\",\"function\":{\"name\":\"exec\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+                "data: [DONE]\n\n",
+            ],
+            context,
+        )
+        .await;
+
+        assert!(output.contains("event: response.custom_tool_call_input.done"));
+        assert!(output.contains("\"type\":\"custom_tool_call\""));
+        assert!(output.contains("\"name\":\"exec\""));
+        assert!(output.contains("\"input\":\"\""));
+        assert!(!output.contains("\"input\":\"{}\""));
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -39,7 +39,50 @@ const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
 
 const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
 const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
+const APPLY_PATCH_TOOL_NAME: &str = "apply_patch";
 const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
+const APPLY_PATCH_BEGIN_MARKER: &str = "*** Begin Patch";
+const APPLY_PATCH_END_MARKER: &str = "*** End Patch";
+const APPLY_PATCH_CHAT_DESCRIPTION: &str = r#"Apply file edits using Codex's raw apply_patch format.
+
+For this Chat Completions bridge you must call the function with JSON arguments:
+{"input":"<raw patch text>"}
+
+The input string itself must be only the raw patch. Do not include Markdown fences,
+shell heredocs, JSON, prose, or an apply_patch command wrapper inside input. The
+patch must start with "*** Begin Patch" and end with "*** End Patch".
+
+Supported operations:
+
+Add a file:
+*** Begin Patch
+*** Add File: path/to/new.txt
++first line
++second line
+*** End Patch
+
+Update a file:
+*** Begin Patch
+*** Update File: path/to/file.txt
+@@
+-old line
++new line
+*** End Patch
+
+Delete a file:
+*** Begin Patch
+*** Delete File: path/to/old.txt
+*** End Patch
+
+Move/update a file:
+*** Begin Patch
+*** Update File: old/path.txt
+*** Move to: new/path.txt
+@@
+-old content
++new content
+*** End Patch"#;
+const APPLY_PATCH_INPUT_DESCRIPTION: &str = r#"Raw apply_patch patch text. It must begin with "*** Begin Patch" and end with "*** End Patch". Put the patch here as a plain string; do not wrap it in Markdown code fences, prose, a shell command, or a second JSON object. Use "*** Add File:", "*** Update File:", "*** Delete File:", and optionally "*** Move to:" hunks."#;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodexToolKind {
@@ -132,10 +175,19 @@ impl CodexToolContext {
         let Some(name) = responses_tool_name(tool) else {
             return;
         };
-        let description = tool
-            .get("description")
-            .cloned()
-            .unwrap_or_else(|| json!("Custom Codex tool."));
+        let is_apply_patch = name == APPLY_PATCH_TOOL_NAME;
+        let description = if is_apply_patch {
+            json!(APPLY_PATCH_CHAT_DESCRIPTION)
+        } else {
+            tool.get("description")
+                .cloned()
+                .unwrap_or_else(|| json!("Custom Codex tool."))
+        };
+        let input_description = if is_apply_patch {
+            APPLY_PATCH_INPUT_DESCRIPTION
+        } else {
+            "Input to pass to the custom Codex tool."
+        };
         let chat_tool = json!({
             "type": "function",
             "function": {
@@ -146,7 +198,7 @@ impl CodexToolContext {
                     "properties": {
                         CUSTOM_TOOL_INPUT_FIELD: {
                             "type": "string",
-                            "description": "Input to pass to the custom Codex tool."
+                            "description": input_description
                         }
                     },
                     "required": [CUSTOM_TOOL_INPUT_FIELD]
@@ -620,18 +672,29 @@ fn append_responses_item_as_chat_message(
                 last_assistant_index,
             );
             let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
-            let output = match item.get("output") {
-                Some(Value::String(s)) => canonicalize_json_string_if_parseable(s),
-                Some(v) => canonical_json_string(v),
-                None => String::new(),
-            };
+            let output = tool_output_content_for_chat(item);
             messages.push(json!({
                 "role": "tool",
                 "tool_call_id": call_id,
                 "content": output
             }));
         }
-        Some("custom_tool_call_output") | Some("tool_search_output") => {
+        Some("custom_tool_call_output") => {
+            flush_pending_tool_calls(
+                messages,
+                pending_tool_calls,
+                pending_reasoning,
+                last_assistant_index,
+            );
+            let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
+            let output = tool_output_content_for_chat(item);
+            messages.push(json!({
+                "role": "tool",
+                "tool_call_id": call_id,
+                "content": output
+            }));
+        }
+        Some("tool_search_output") => {
             flush_pending_tool_calls(
                 messages,
                 pending_tool_calls,
@@ -683,6 +746,14 @@ fn append_responses_item_as_chat_message(
     }
 
     Ok(())
+}
+
+fn tool_output_content_for_chat(item: &Value) -> String {
+    match item.get("output") {
+        Some(Value::String(s)) => canonicalize_json_string_if_parseable(s),
+        Some(v) => canonical_json_string(v),
+        None => String::new(),
+    }
 }
 
 fn flush_pending_tool_calls(
@@ -1465,7 +1536,7 @@ fn response_custom_tool_call_item(
     arguments: &str,
     reasoning: Option<&str>,
 ) -> Value {
-    let input = custom_tool_input_from_chat_arguments(arguments);
+    let input = custom_tool_input_from_chat_arguments_for_tool(name, arguments);
     let mut item = json!({
         "id": item_id,
         "type": "custom_tool_call",
@@ -1488,7 +1559,14 @@ fn parse_tool_arguments_object(arguments: &str) -> Value {
         .unwrap_or_else(|| json!({ "query": arguments }))
 }
 
-pub(crate) fn custom_tool_input_from_chat_arguments(arguments: &str) -> String {
+pub(crate) fn custom_tool_input_from_chat_arguments_for_tool(
+    tool_name: &str,
+    arguments: &str,
+) -> String {
+    if tool_name == APPLY_PATCH_TOOL_NAME {
+        return apply_patch_input_from_chat_arguments(arguments);
+    }
+
     if arguments.trim().is_empty() {
         return String::new();
     }
@@ -1499,6 +1577,91 @@ pub(crate) fn custom_tool_input_from_chat_arguments(arguments: &str) -> String {
             .unwrap_or(arguments)
             .to_string(),
         _ => arguments.to_string(),
+    }
+}
+
+fn apply_patch_input_from_chat_arguments(arguments: &str) -> String {
+    let Some(candidate) = apply_patch_candidate_from_chat_arguments(arguments) else {
+        return normalize_apply_patch_input(arguments);
+    };
+    normalize_apply_patch_input(&candidate)
+}
+
+fn apply_patch_candidate_from_chat_arguments(arguments: &str) -> Option<String> {
+    let trimmed = arguments.trim();
+    if trimmed.is_empty() {
+        return Some(String::new());
+    }
+
+    let value = serde_json::from_str::<Value>(trimmed).ok()?;
+    match value {
+        Value::String(text) => Some(text),
+        Value::Object(obj) => {
+            for key in [CUSTOM_TOOL_INPUT_FIELD, "patch", "command"] {
+                if let Some(value) = obj.get(key) {
+                    if let Some(candidate) = apply_patch_candidate_from_value(value) {
+                        return Some(candidate);
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn apply_patch_candidate_from_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(items) => {
+            if items
+                .first()
+                .and_then(|value| value.as_str())
+                .is_some_and(|name| name == APPLY_PATCH_TOOL_NAME)
+            {
+                return items
+                    .iter()
+                    .skip(1)
+                    .filter_map(|value| value.as_str())
+                    .find(|text| text.contains(APPLY_PATCH_BEGIN_MARKER))
+                    .map(ToString::to_string);
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn normalize_apply_patch_input(input: &str) -> String {
+    let mut value = strip_markdown_fence(input.trim()).trim().to_string();
+    if let Some(extracted) = extract_apply_patch_body(&value) {
+        value = extracted;
+    }
+    strip_markdown_fence(value.trim()).trim().to_string()
+}
+
+fn extract_apply_patch_body(input: &str) -> Option<String> {
+    let begin = input.find(APPLY_PATCH_BEGIN_MARKER)?;
+    let after_begin = &input[begin..];
+    let end_relative = after_begin.find(APPLY_PATCH_END_MARKER)?;
+    let end = begin + end_relative + APPLY_PATCH_END_MARKER.len();
+    Some(input[begin..end].to_string())
+}
+
+fn strip_markdown_fence(input: &str) -> &str {
+    let trimmed = input.trim();
+    let Some(rest) = trimmed.strip_prefix("```") else {
+        return input;
+    };
+    let Some(first_newline) = rest.find('\n') else {
+        return input;
+    };
+    let body = &rest[first_newline + 1..];
+    let body = body.trim_end();
+    if let Some(body) = body.strip_suffix("```") {
+        body.trim_end()
+    } else {
+        input
     }
 }
 
@@ -1854,6 +2017,125 @@ mod tests {
         assert_eq!(
             result["messages"][0]["tool_calls"][0]["function"]["arguments"],
             r#"{"input":"*** Begin Patch\n*** End Patch"}"#
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_enriches_apply_patch_description() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "custom",
+                "name": "apply_patch",
+                "description": "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.",
+                "format": {
+                    "type": "grammar",
+                    "syntax": "lark",
+                    "definition": "start: begin_patch hunk+ end_patch"
+                }
+            }],
+            "input": "Patch it."
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let description = result["tools"][0]["function"]["description"]
+            .as_str()
+            .unwrap();
+        let input_description = result["tools"][0]["function"]["parameters"]["properties"]["input"]
+            ["description"]
+            .as_str()
+            .unwrap();
+
+        assert!(description.contains(r#"{"input":"<raw patch text>"}"#));
+        assert!(description.contains("*** Add File: path/to/new.txt"));
+        assert!(description.contains("*** Update File: path/to/file.txt"));
+        assert!(description.contains("*** Delete File: path/to/old.txt"));
+        assert!(description.contains("*** Move to: new/path.txt"));
+        assert!(input_description.contains("*** Begin Patch"));
+        assert!(input_description.contains("Markdown code fences"));
+    }
+
+    #[test]
+    fn chat_response_to_responses_extracts_apply_patch_from_patch_alias_and_fence() {
+        let request = json!({
+            "model": "gpt-5.4",
+            "tools": [{"type": "custom", "name": "apply_patch"}],
+            "input": "Patch it."
+        });
+        let context = build_codex_tool_context_from_request(&request);
+        let chat = json!({
+            "id": "chatcmpl_custom",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-5.4",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "call_patch",
+                        "type": "function",
+                        "function": {
+                            "name": "apply_patch",
+                            "arguments": "{\"patch\":\"```patch\\n*** Begin Patch\\n*** Update File: hello.txt\\n@@\\n-old\\n+new\\n*** End Patch\\n```\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let result = chat_completion_to_response_with_context(chat, &context).unwrap();
+
+        assert_eq!(
+            result["output"][0]["input"],
+            "*** Begin Patch\n*** Update File: hello.txt\n@@\n-old\n+new\n*** End Patch"
+        );
+    }
+
+    #[test]
+    fn apply_patch_input_extraction_accepts_command_array_wrappers() {
+        let input = custom_tool_input_from_chat_arguments_for_tool(
+            "apply_patch",
+            r#"{"command":["apply_patch","*** Begin Patch\n*** Delete File: old.txt\n*** End Patch"]}"#,
+        );
+
+        assert_eq!(
+            input,
+            "*** Begin Patch\n*** Delete File: old.txt\n*** End Patch"
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_maps_custom_tool_output_as_plain_output() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "call_id": "call_patch",
+                    "name": "apply_patch",
+                    "input": "*** Begin Patch\n*** Add File: hello.txt\n+hi\n*** End Patch"
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_patch",
+                    "output": "Success. Updated the following files:\nA hello.txt\n"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(
+            messages[0]["tool_calls"][0]["function"]["name"],
+            "apply_patch"
+        );
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(
+            messages[1]["content"],
+            "Success. Updated the following files:\nA hello.txt\n"
         );
     }
 

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -9,6 +9,11 @@ use super::codex_chat_common::{
     response_function_call_item, response_function_call_item_with_namespace,
     split_leading_think_block,
 };
+use super::codex_custom_tools::{
+    custom_tool_arguments_from_chat_value, custom_tool_arguments_from_response_input,
+    custom_tool_chat_description, custom_tool_input_description,
+    custom_tool_input_from_chat_arguments, CUSTOM_TOOL_INPUT_FIELD,
+};
 use crate::provider::CodexChatReasoningConfig;
 use crate::proxy::{
     error::ProxyError,
@@ -38,51 +43,7 @@ const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
 ];
 
 const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
-const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
-const APPLY_PATCH_TOOL_NAME: &str = "apply_patch";
 const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
-const APPLY_PATCH_BEGIN_MARKER: &str = "*** Begin Patch";
-const APPLY_PATCH_END_MARKER: &str = "*** End Patch";
-const APPLY_PATCH_CHAT_DESCRIPTION: &str = r#"Apply file edits using Codex's raw apply_patch format.
-
-For this Chat Completions bridge you must call the function with JSON arguments:
-{"input":"<raw patch text>"}
-
-The input string itself must be only the raw patch. Do not include Markdown fences,
-shell heredocs, JSON, prose, or an apply_patch command wrapper inside input. The
-patch must start with "*** Begin Patch" and end with "*** End Patch".
-
-Supported operations:
-
-Add a file:
-*** Begin Patch
-*** Add File: path/to/new.txt
-+first line
-+second line
-*** End Patch
-
-Update a file:
-*** Begin Patch
-*** Update File: path/to/file.txt
-@@
--old line
-+new line
-*** End Patch
-
-Delete a file:
-*** Begin Patch
-*** Delete File: path/to/old.txt
-*** End Patch
-
-Move/update a file:
-*** Begin Patch
-*** Update File: old/path.txt
-*** Move to: new/path.txt
-@@
--old content
-+new content
-*** End Patch"#;
-const APPLY_PATCH_INPUT_DESCRIPTION: &str = r#"Raw apply_patch patch text. It must begin with "*** Begin Patch" and end with "*** End Patch". Put the patch here as a plain string; do not wrap it in Markdown code fences, prose, a shell command, or a second JSON object. Use "*** Add File:", "*** Update File:", "*** Delete File:", and optionally "*** Move to:" hunks."#;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodexToolKind {
@@ -175,19 +136,8 @@ impl CodexToolContext {
         let Some(name) = responses_tool_name(tool) else {
             return;
         };
-        let is_apply_patch = name == APPLY_PATCH_TOOL_NAME;
-        let description = if is_apply_patch {
-            json!(APPLY_PATCH_CHAT_DESCRIPTION)
-        } else {
-            tool.get("description")
-                .cloned()
-                .unwrap_or_else(|| json!("Custom Codex tool."))
-        };
-        let input_description = if is_apply_patch {
-            APPLY_PATCH_INPUT_DESCRIPTION
-        } else {
-            "Input to pass to the custom Codex tool."
-        };
+        let description = custom_tool_chat_description(&name, tool);
+        let input_description = custom_tool_input_description(&name);
         let chat_tool = json!({
             "type": "function",
             "function": {
@@ -201,7 +151,8 @@ impl CodexToolContext {
                             "description": input_description
                         }
                     },
-                    "required": [CUSTOM_TOOL_INPUT_FIELD]
+                    "required": [CUSTOM_TOOL_INPUT_FIELD],
+                    "additionalProperties": false
                 }
             }
         });
@@ -1155,14 +1106,14 @@ fn responses_custom_tool_call_to_chat_tool_call(item: &Value) -> Value {
         .and_then(|v| v.as_str())
         .unwrap_or("");
     let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
-    let input = item.get("input").cloned().unwrap_or_else(|| json!(""));
+    let arguments = custom_tool_arguments_from_response_input(item.get("input"));
 
     json!({
         "id": call_id,
         "type": "function",
         "function": {
             "name": name,
-            "arguments": canonical_json_string(&json!({ CUSTOM_TOOL_INPUT_FIELD: input }))
+            "arguments": arguments
         }
     })
 }
@@ -1425,7 +1376,8 @@ fn chat_tool_call_to_response_item(
         .unwrap_or_else(|| format!("call_{index}"));
     let function = tool_call.get("function").unwrap_or(&Value::Null);
     let name = function.get("name").and_then(|v| v.as_str()).unwrap_or("");
-    let arguments = canonicalize_tool_arguments(function.get("arguments"));
+    let arguments =
+        canonicalize_chat_arguments_for_tool(name, function.get("arguments"), tool_context);
 
     let item_id = response_tool_call_item_id_from_chat_name(&call_id, name, tool_context);
     response_tool_call_item_from_chat_name(
@@ -1453,7 +1405,8 @@ fn chat_legacy_function_call_to_response_item(
         .get("name")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    let arguments = canonicalize_tool_arguments(function_call.get("arguments"));
+    let arguments =
+        canonicalize_chat_arguments_for_tool(name, function_call.get("arguments"), tool_context);
 
     let item_id = response_tool_call_item_id_from_chat_name(call_id, name, tool_context);
     response_tool_call_item_from_chat_name(
@@ -1465,6 +1418,18 @@ fn chat_legacy_function_call_to_response_item(
         reasoning,
         tool_context,
     )
+}
+
+fn canonicalize_chat_arguments_for_tool(
+    chat_name: &str,
+    arguments: Option<&Value>,
+    tool_context: &CodexToolContext,
+) -> String {
+    if tool_context.is_custom_tool_chat_name(chat_name) {
+        custom_tool_arguments_from_chat_value(arguments)
+    } else {
+        canonicalize_tool_arguments(arguments)
+    }
 }
 
 pub(crate) fn response_tool_call_item_id_from_chat_name(
@@ -1536,7 +1501,7 @@ fn response_custom_tool_call_item(
     arguments: &str,
     reasoning: Option<&str>,
 ) -> Value {
-    let input = custom_tool_input_from_chat_arguments_for_tool(name, arguments);
+    let input = custom_tool_input_from_chat_arguments(name, arguments);
     let mut item = json!({
         "id": item_id,
         "type": "custom_tool_call",
@@ -1557,112 +1522,6 @@ fn parse_tool_arguments_object(arguments: &str) -> Value {
         .ok()
         .filter(|value| value.is_object())
         .unwrap_or_else(|| json!({ "query": arguments }))
-}
-
-pub(crate) fn custom_tool_input_from_chat_arguments_for_tool(
-    tool_name: &str,
-    arguments: &str,
-) -> String {
-    if tool_name == APPLY_PATCH_TOOL_NAME {
-        return apply_patch_input_from_chat_arguments(arguments);
-    }
-
-    if arguments.trim().is_empty() {
-        return String::new();
-    }
-    match serde_json::from_str::<Value>(arguments) {
-        Ok(Value::Object(obj)) => obj
-            .get(CUSTOM_TOOL_INPUT_FIELD)
-            .and_then(|value| value.as_str())
-            .unwrap_or(arguments)
-            .to_string(),
-        _ => arguments.to_string(),
-    }
-}
-
-fn apply_patch_input_from_chat_arguments(arguments: &str) -> String {
-    let Some(candidate) = apply_patch_candidate_from_chat_arguments(arguments) else {
-        return normalize_apply_patch_input(arguments);
-    };
-    normalize_apply_patch_input(&candidate)
-}
-
-fn apply_patch_candidate_from_chat_arguments(arguments: &str) -> Option<String> {
-    let trimmed = arguments.trim();
-    if trimmed.is_empty() {
-        return Some(String::new());
-    }
-
-    let value = serde_json::from_str::<Value>(trimmed).ok()?;
-    match value {
-        Value::String(text) => Some(text),
-        Value::Object(obj) => {
-            for key in [CUSTOM_TOOL_INPUT_FIELD, "patch", "command"] {
-                if let Some(value) = obj.get(key) {
-                    if let Some(candidate) = apply_patch_candidate_from_value(value) {
-                        return Some(candidate);
-                    }
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-fn apply_patch_candidate_from_value(value: &Value) -> Option<String> {
-    match value {
-        Value::String(text) => Some(text.clone()),
-        Value::Array(items) => {
-            if items
-                .first()
-                .and_then(|value| value.as_str())
-                .is_some_and(|name| name == APPLY_PATCH_TOOL_NAME)
-            {
-                return items
-                    .iter()
-                    .skip(1)
-                    .filter_map(|value| value.as_str())
-                    .find(|text| text.contains(APPLY_PATCH_BEGIN_MARKER))
-                    .map(ToString::to_string);
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-fn normalize_apply_patch_input(input: &str) -> String {
-    let mut value = strip_markdown_fence(input.trim()).trim().to_string();
-    if let Some(extracted) = extract_apply_patch_body(&value) {
-        value = extracted;
-    }
-    strip_markdown_fence(value.trim()).trim().to_string()
-}
-
-fn extract_apply_patch_body(input: &str) -> Option<String> {
-    let begin = input.find(APPLY_PATCH_BEGIN_MARKER)?;
-    let after_begin = &input[begin..];
-    let end_relative = after_begin.find(APPLY_PATCH_END_MARKER)?;
-    let end = begin + end_relative + APPLY_PATCH_END_MARKER.len();
-    Some(input[begin..end].to_string())
-}
-
-fn strip_markdown_fence(input: &str) -> &str {
-    let trimmed = input.trim();
-    let Some(rest) = trimmed.strip_prefix("```") else {
-        return input;
-    };
-    let Some(first_newline) = rest.find('\n') else {
-        return input;
-    };
-    let body = &rest[first_newline + 1..];
-    let body = body.trim_end();
-    if let Some(body) = body.strip_suffix("```") {
-        body.trim_end()
-    } else {
-        input
-    }
 }
 
 pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
@@ -2056,6 +1915,40 @@ mod tests {
     }
 
     #[test]
+    fn responses_request_to_chat_enriches_exec_description() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "custom",
+                "name": "exec",
+                "description": "Accepts raw JavaScript source text, not JSON.",
+                "format": {
+                    "type": "grammar",
+                    "syntax": "lark",
+                    "definition": "start: SOURCE"
+                }
+            }],
+            "input": "Run code."
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let description = result["tools"][0]["function"]["description"]
+            .as_str()
+            .unwrap();
+        let input_description = result["tools"][0]["function"]["parameters"]["properties"]["input"]
+            ["description"]
+            .as_str()
+            .unwrap();
+
+        assert!(description.contains(r#"{"input":"<raw JavaScript source>"}"#));
+        assert!(description.contains("const result = await tools.exec_command"));
+        assert!(description.contains("Original Codex tool description:"));
+        assert!(description.contains("Accepts raw JavaScript source text"));
+        assert!(input_description.contains("Raw JavaScript source"));
+        assert!(input_description.contains("// @exec"));
+    }
+
+    #[test]
     fn chat_response_to_responses_extracts_apply_patch_from_patch_alias_and_fence() {
         let request = json!({
             "model": "gpt-5.4",
@@ -2094,7 +1987,7 @@ mod tests {
 
     #[test]
     fn apply_patch_input_extraction_accepts_command_array_wrappers() {
-        let input = custom_tool_input_from_chat_arguments_for_tool(
+        let input = custom_tool_input_from_chat_arguments(
             "apply_patch",
             r#"{"command":["apply_patch","*** Begin Patch\n*** Delete File: old.txt\n*** End Patch"]}"#,
         );
@@ -2102,6 +1995,45 @@ mod tests {
         assert_eq!(
             input,
             "*** Begin Patch\n*** Delete File: old.txt\n*** End Patch"
+        );
+    }
+
+    #[test]
+    fn chat_response_to_responses_extracts_exec_from_code_alias_and_fence() {
+        let request = json!({
+            "model": "gpt-5.4",
+            "tools": [{"type": "custom", "name": "exec"}],
+            "input": "Run JS."
+        });
+        let context = build_codex_tool_context_from_request(&request);
+        let chat = json!({
+            "id": "chatcmpl_exec",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-5.4",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "call_exec",
+                        "type": "function",
+                        "function": {
+                            "name": "exec",
+                            "arguments": "{\"code\":\"```js\\nconst result = await tools.exec_command({cmd: \\\"pwd\\\"});\\ntext(result.output);\\n```\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let result = chat_completion_to_response_with_context(chat, &context).unwrap();
+
+        assert_eq!(result["output"][0]["type"], "custom_tool_call");
+        assert_eq!(result["output"][0]["name"], "exec");
+        assert_eq!(
+            result["output"][0]["input"],
+            "const result = await tools.exec_command({cmd: \"pwd\"});\ntext(result.output);"
         );
     }
 


### PR DESCRIPTION
## Summary / 概述

This PR improves the Codex Responses API to Chat Completions bridge for custom/freeform tools.

本 PR 优化了 Codex Responses API 到 Chat Completions 的 custom/freeform tool 转换链路。

Changes include:

- Adds dedicated Chat-facing guidance and examples for the raw `apply_patch` custom tool so upstream Chat models are more likely to emit valid patch input.
- Adds tolerant `apply_patch` input recovery for common wrappers such as `{ "input": ... }`, `{ "patch": ... }`, `{ "command": ["apply_patch", ...] }`, Markdown fences, heredoc/prose wrappers, and extra text around the patch body.
- Introduces a shared custom/freeform tool adapter for Codex Chat bridging, covering generic custom tools plus the code-mode `exec` freeform tool.
- Adds `exec`-specific guidance and recovery for `input`, `code`, `source`, `script`, `javascript`, `js`, and fenced JavaScript snippets.
- Preserves custom tool history and output handling across non-streaming and streaming conversions, including empty custom inputs.

Why:

Codex native custom/freeform tools use raw string input in Responses API, but Chat Completions function calls require JSON arguments. Without explicit guidance and centralized conversion, upstream Chat models often wrap or reshape raw tool input, which lowers success rates for tools like `apply_patch` and `exec`.

原因：

Codex 原生 custom/freeform tool 在 Responses API 中使用 raw string input，但 Chat Completions 的 function call 必须使用 JSON arguments。如果没有清晰指引和统一转换，上游 Chat 模型很容易把 raw input 包装成 Markdown、命令、二层 JSON 或其它形态，从而降低 `apply_patch`、`exec` 等工具的调用成功率。

## Process / 过程

- Added `upstream` remote for `farion1231/cc-switch`.
- Rebasing the branch onto `upstream/main` completed without conflicts.
- Force-pushed the rebased branch with `--force-with-lease`.
- Verified the Codex-related Rust tests after the rebase.

Validation run:

- `cargo fmt`
- `cargo test transform_codex_chat`
- `cargo test streaming_codex_chat`
- `cargo test codex_chat_history`
- `cargo test codex_custom_tools`
- `cargo test codex_`
- `git diff --check`

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| N/A             | N/A           |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
