### PR TITLE
feat(claude): add 1M toggle to fallback model field

### DIFF
--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -920,12 +920,37 @@ export function ClaudeFormFields({
                   defaultValue: "默认兜底模型",
                 })}
               </FormLabel>
-              {renderModelInput(
-                "claudeModel",
-                claudeModel,
-                "ANTHROPIC_MODEL",
-                t("providerForm.modelPlaceholder", { defaultValue: "" }),
-              )}
+              {(() => {
+                const fallbackBase = stripClaudeOneMMarker(claudeModel);
+                const fallbackUsesOneM = hasClaudeOneMMarker(claudeModel);
+                return (
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_104px]">
+                    {renderModelInput(
+                      "claudeModel",
+                      fallbackBase,
+                      "ANTHROPIC_MODEL",
+                      t("providerForm.modelPlaceholder", { defaultValue: "" }),
+                      (value) =>
+                        onModelChange(
+                          "ANTHROPIC_MODEL",
+                          setClaudeOneMMarker(value, fallbackUsesOneM),
+                        ),
+                    )}
+                    <label className="flex h-9 items-center gap-2 text-sm text-muted-foreground">
+                      <Checkbox
+                        checked={fallbackUsesOneM}
+                        onCheckedChange={(checked) =>
+                          onModelChange(
+                            "ANTHROPIC_MODEL",
+                            setClaudeOneMMarker(fallbackBase, checked === true),
+                          )
+                        }
+                      />
+                      {t("providerForm.modelOneMLabel", { defaultValue: "1M" })}
+                    </label>
+                  </div>
+                );
+              })()}
               <p className="text-xs text-muted-foreground">
                 {t("providerForm.fallbackModelHint", {
                   defaultValue:


### PR DESCRIPTION
## Summary

Adds a 1M-context checkbox next to the Claude provider's fallback
model input (`ANTHROPIC_MODEL`), matching the existing toggle on the
Sonnet/Opus/Haiku alias rows.

Refs: #3679

## Why

Per @makoMakoGo's analysis in #3679 (cross-verified locally against
`@anthropic-ai/claude-code` cli.js):

Claude Code resolves the active model via `ANTHROPIC_MODEL` first; the
`_DEFAULT_*_MODEL` env vars only kick in for explicit `/model` switches.
When users check 1M on the alias rows but the fallback field stays
bare, the fallback overrides the aliases and 1M silently fails on the
main flow (`/context` shows 200K).

Today the Claude form has no fallback toggle, so users have to hand-edit
settings.json to declare 1M on `ANTHROPIC_MODEL`. This PR closes that gap.

## Changes

- `src/components/providers/forms/ClaudeFormFields.tsx`
  - Wrap fallback input in a 2-column grid matching the alias rows.
  - Add a `Checkbox` that toggles `[1m]` via existing
    `setClaudeOneMMarker` / `stripClaudeOneMMarker` /
    `hasClaudeOneMMarker` helpers.
  - Reuses i18n key `providerForm.modelOneMLabel`.

No prop/signature changes. No new dependencies.

## Notes

- Original Bug 1 ("uppercase `[1M]`") was rebased out — `cli.js`
  regex `/\[1m\]/i` is case-insensitive (per @makoMakoGo and confirmed
  locally on v2.1.109).
- Toggle is opt-in (default off). Users following #2337's local-routing
  recommendation (leave fallback empty) keep their existing flow
  unchanged.
- The "默认兜底模型 / fallback model" label is itself misleading
  (@makoMakoGo, #3679) — `ANTHROPIC_MODEL` is the *primary* model
  source in Claude Code, not a fallback. Renaming the i18n label is
  out of scope for this PR.

## Verification

- `tsc --noEmit` → 0 errors
- `vitest run` → 53 files / 286 tests pass
- Local manual: toggle flips `ANTHROPIC_MODEL` between bare and
  `[1m]`-suffixed in settings.json; restarting Claude Code matches
  expected `/context` output (200K vs 1M).
