### PR TITLE
Filter unsupported Responses API tools for Codex

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages: []
 
+allowBuilds:
+  esbuild: true
+  msw: true
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -224,7 +224,7 @@ impl Database {
                 "SELECT app_type, enabled, auto_failover_enabled,
                         max_retries, streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
                         circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
-                        circuit_error_rate_threshold, circuit_min_requests
+                        circuit_error_rate_threshold, circuit_min_requests, filter_unsupported_response_tools
                  FROM proxy_config WHERE app_type = ?1",
                 [app_type],
                 |row| {
@@ -241,6 +241,7 @@ impl Database {
                         circuit_timeout_seconds: row.get::<_, i32>(9)? as u32,
                         circuit_error_rate_threshold: row.get(10)?,
                         circuit_min_requests: row.get::<_, i32>(11)? as u32,
+                        filter_unsupported_response_tools: row.get::<_, i32>(12)? != 0,
                     })
                 },
             )
@@ -265,6 +266,7 @@ impl Database {
                     circuit_timeout_seconds: 60,
                     circuit_error_rate_threshold: 0.6,
                     circuit_min_requests: 10,
+                    filter_unsupported_response_tools: true,
                 })
             }
             Err(e) => Err(AppError::Database(e.to_string())),
@@ -291,6 +293,7 @@ impl Database {
                 circuit_timeout_seconds = ?10,
                 circuit_error_rate_threshold = ?11,
                 circuit_min_requests = ?12,
+                filter_unsupported_response_tools = ?13,
                 updated_at = datetime('now')
              WHERE app_type = ?1",
             rusqlite::params![
@@ -306,6 +309,11 @@ impl Database {
                 config.circuit_timeout_seconds as i32,
                 config.circuit_error_rate_threshold,
                 config.circuit_min_requests as i32,
+                if config.filter_unsupported_response_tools {
+                    1
+                } else {
+                    0
+                },
             ],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -49,7 +49,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 10;
+pub(crate) const SCHEMA_VERSION: i32 = 11;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -131,6 +131,7 @@ impl Database {
             circuit_failure_threshold INTEGER NOT NULL DEFAULT 4, circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
             circuit_timeout_seconds INTEGER NOT NULL DEFAULT 60, circuit_error_rate_threshold REAL NOT NULL DEFAULT 0.6,
             circuit_min_requests INTEGER NOT NULL DEFAULT 10,
+            filter_unsupported_response_tools INTEGER NOT NULL DEFAULT 1,
             default_cost_multiplier TEXT NOT NULL DEFAULT '1',
             pricing_model_source TEXT NOT NULL DEFAULT 'response',
             created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -324,6 +325,10 @@ impl Database {
             "ALTER TABLE proxy_config ADD COLUMN non_streaming_timeout INTEGER NOT NULL DEFAULT 600",
             [],
         );
+        let _ = conn.execute(
+            "ALTER TABLE proxy_config ADD COLUMN filter_unsupported_response_tools INTEGER NOT NULL DEFAULT 1",
+            [],
+        );
 
         // 兼容：若旧版 proxy_config 仍为单例结构（无 app_type），则在启动时直接转换为三行结构
         // 说明：user_version=2 时不会再触发 v1->v2 迁移，但新代码查询依赖 app_type 列。
@@ -430,6 +435,11 @@ impl Database {
                         log::info!("迁移数据库从 v9 到 v10（添加 Hermes Agent 支持）");
                         Self::migrate_v9_to_v10(conn)?;
                         Self::set_user_version(conn, 10)?;
+                    }
+                    10 => {
+                        log::info!("迁移数据库从 v10 到 v11（Responses 工具过滤设置）");
+                        Self::migrate_v10_to_v11(conn)?;
+                        Self::set_user_version(conn, 11)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -757,6 +767,7 @@ impl Database {
             circuit_failure_threshold INTEGER NOT NULL DEFAULT 4, circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
             circuit_timeout_seconds INTEGER NOT NULL DEFAULT 60, circuit_error_rate_threshold REAL NOT NULL DEFAULT 0.6,
             circuit_min_requests INTEGER NOT NULL DEFAULT 10,
+            filter_unsupported_response_tools INTEGER NOT NULL DEFAULT 1,
             default_cost_multiplier TEXT NOT NULL DEFAULT '1',
             pricing_model_source TEXT NOT NULL DEFAULT 'response',
             created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -1197,6 +1208,21 @@ impl Database {
         }
 
         log::info!("v9 -> v10 迁移完成：已添加 Hermes Agent 支持");
+        Ok(())
+    }
+
+    /// v10 -> v11 迁移：添加 Codex Responses 工具过滤设置
+    fn migrate_v10_to_v11(conn: &Connection) -> Result<(), AppError> {
+        if Self::table_exists(conn, "proxy_config")? {
+            Self::add_column_if_missing(
+                conn,
+                "proxy_config",
+                "filter_unsupported_response_tools",
+                "INTEGER NOT NULL DEFAULT 1",
+            )?;
+        }
+
+        log::info!("v10 -> v11 迁移完成：已添加 Responses 工具过滤设置");
         Ok(())
     }
 

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -273,6 +273,14 @@ fn schema_create_tables_include_pricing_model_columns() {
     let conn = Connection::open_in_memory().expect("open memory db");
     Database::create_tables_on_conn(&conn).expect("create tables");
 
+    let tool_filter = get_column_info(&conn, "proxy_config", "filter_unsupported_response_tools");
+    assert_eq!(tool_filter.r#type, "INTEGER");
+    assert_eq!(tool_filter.notnull, 1);
+    assert_eq!(
+        normalize_default(&tool_filter.default).as_deref(),
+        Some("1")
+    );
+
     let multiplier = get_column_info(&conn, "proxy_config", "default_cost_multiplier");
     assert_eq!(multiplier.r#type, "TEXT");
     assert_eq!(multiplier.notnull, 1);
@@ -338,6 +346,39 @@ fn schema_migration_v4_adds_pricing_model_columns() {
     let request_model = get_column_info(&conn, "proxy_request_logs", "request_model");
     assert_eq!(request_model.r#type, "TEXT");
     assert_eq!(request_model.notnull, 0);
+
+    assert_eq!(
+        Database::get_user_version(&conn).expect("version after migration"),
+        SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn schema_migration_v10_adds_response_tool_filter_column() {
+    let conn = Connection::open_in_memory().expect("open memory db");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE proxy_config (app_type TEXT PRIMARY KEY);
+        CREATE TABLE mcp_servers (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            server_config TEXT NOT NULL,
+            enabled_hermes BOOLEAN NOT NULL DEFAULT 0
+        );
+        "#,
+    )
+    .expect("seed v10 schema");
+
+    Database::set_user_version(&conn, 10).expect("set user_version=10");
+    Database::apply_schema_migrations_on_conn(&conn).expect("apply migrations");
+
+    let tool_filter = get_column_info(&conn, "proxy_config", "filter_unsupported_response_tools");
+    assert_eq!(tool_filter.r#type, "INTEGER");
+    assert_eq!(tool_filter.notnull, 1);
+    assert_eq!(
+        normalize_default(&tool_filter.default).as_deref(),
+        Some("1")
+    );
 
     assert_eq!(
         Database::get_user_version(&conn).expect("version after migration"),

--- a/src-tauri/src/proxy/body_filter.rs
+++ b/src-tauri/src/proxy/body_filter.rs
@@ -18,6 +18,46 @@
 use serde_json::Value;
 use std::collections::HashSet;
 
+/// 过滤 Responses API 顶层 tools 数组中上游不支持的工具类型。
+///
+/// 只处理顶层 `tools`，避免误改 JSON Schema、MCP namespace 或业务自定义字段。
+pub fn filter_unsupported_response_tools(body: Value, unsupported_tool_types: &[&str]) -> Value {
+    let unsupported: HashSet<&str> = unsupported_tool_types.iter().copied().collect();
+    if unsupported.is_empty() {
+        return body;
+    }
+
+    let mut body = body;
+    let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
+        return body;
+    };
+
+    let original_len = tools.len();
+    let mut removed_types = Vec::new();
+    tools.retain(|tool| {
+        let Some(tool_type) = tool.get("type").and_then(Value::as_str) else {
+            return true;
+        };
+        if unsupported.contains(tool_type) {
+            removed_types.push(tool_type.to_string());
+            false
+        } else {
+            true
+        }
+    });
+
+    let removed_count = original_len.saturating_sub(tools.len());
+    if removed_count > 0 {
+        removed_types.sort();
+        removed_types.dedup();
+        log::debug!(
+            "[BodyFilter] filtered unsupported Responses tools: count={removed_count}, types={removed_types:?}"
+        );
+    }
+
+    body
+}
+
 /// 过滤私有参数（以 `_` 开头的字段）
 ///
 /// 递归遍历 JSON 结构，移除所有以下划线开头的字段。
@@ -335,5 +375,71 @@ mod tests {
         let output2 = filter_private_params_with_whitelist(input, &[]);
 
         assert_eq!(output1, output2);
+    }
+
+    #[test]
+    fn test_filter_unsupported_response_tools_removes_image_generation() {
+        let input = json!({
+            "model": "gpt-5",
+            "tools": [
+                {"type": "function", "name": "read_file"},
+                {"type": "image_generation", "output_format": "png"},
+                {"type": "web_search_preview"}
+            ]
+        });
+
+        let output = filter_unsupported_response_tools(input, &["image_generation"]);
+
+        assert_eq!(
+            output["tools"],
+            json!([
+                {"type": "function", "name": "read_file"},
+                {"type": "web_search_preview"}
+            ])
+        );
+    }
+
+    #[test]
+    fn test_filter_unsupported_response_tools_preserves_non_matching_shapes() {
+        let input = json!({
+            "tools": [
+                {"type": "function", "name": "read_file"},
+                {"name": "missing_type"},
+                "string-tool",
+                {"type": "unknown_native_tool"}
+            ]
+        });
+
+        let output = filter_unsupported_response_tools(input.clone(), &["image_generation"]);
+
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_filter_unsupported_response_tools_keeps_empty_tools_array() {
+        let input = json!({
+            "tools": [
+                {"type": "image_generation", "output_format": "png"}
+            ]
+        });
+
+        let output = filter_unsupported_response_tools(input, &["image_generation"]);
+
+        assert_eq!(output["tools"], json!([]));
+    }
+
+    #[test]
+    fn test_filter_unsupported_response_tools_ignores_missing_or_non_array_tools() {
+        let without_tools = json!({"model": "gpt-5"});
+        assert_eq!(
+            filter_unsupported_response_tools(without_tools.clone(), &["image_generation"]),
+            without_tools
+        );
+
+        let non_array_tools = json!({"tools": {"type": "image_generation"}});
+        assert_eq!(
+            filter_unsupported_response_tools(non_array_tools.clone(), &["image_generation"]),
+            non_array_tools
+        );
     }
 }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -4,7 +4,7 @@
 
 use super::hyper_client::ProxyResponse;
 use super::{
-    body_filter::filter_private_params_with_whitelist,
+    body_filter::{filter_private_params_with_whitelist, filter_unsupported_response_tools},
     error::*,
     failover_switch::FailoverSwitchManager,
     json_canonical::{canonicalize_value, short_value_hash},
@@ -119,6 +119,8 @@ pub struct RequestForwarder {
     /// `max_attempts = max_retries + 1`，所以 max_retries=0 表示仅尝试一家、
     /// max_retries=3（默认）表示最多 4 家。loop 同时受 providers.len() 自然限制。
     max_attempts: usize,
+    /// 是否过滤 Codex Responses 请求中上游不支持的原生工具
+    filter_unsupported_response_tools: bool,
 }
 
 impl RequestForwarder {
@@ -141,6 +143,7 @@ impl RequestForwarder {
         optimizer_config: OptimizerConfig,
         copilot_optimizer_config: CopilotOptimizerConfig,
         max_retries: u32,
+        filter_unsupported_response_tools: bool,
     ) -> Self {
         // max_retries 是「失败后重试次数」语义，attempt 上限 = retries + 1。
         // saturating_add 防止 u32::MAX + 1 溢出。
@@ -164,6 +167,7 @@ impl RequestForwarder {
                 streaming_first_byte_timeout,
             ),
             max_attempts,
+            filter_unsupported_response_tools,
         }
     }
 
@@ -1195,6 +1199,13 @@ impl RequestForwarder {
             mapped_body
         };
 
+        let request_body = filter_unsupported_response_tools_for_request(
+            request_body,
+            app_type,
+            endpoint,
+            self.filter_unsupported_response_tools,
+        );
+
         // 过滤私有参数（以 `_` 开头的字段），防止内部信息泄露到上游
         // 默认使用空白名单，过滤所有 _ 前缀字段
         let filtered_body = prepare_upstream_request_body(request_body);
@@ -2077,6 +2088,21 @@ fn is_claude_messages_path(path: &str) -> bool {
     matches!(path, "/v1/messages" | "/claude/v1/messages")
 }
 
+fn is_responses_endpoint(endpoint: &str) -> bool {
+    let (path, _) = split_endpoint_and_query(endpoint);
+    matches!(
+        path,
+        "/responses"
+            | "/v1/responses"
+            | "/v1/v1/responses"
+            | "/codex/v1/responses"
+            | "/responses/compact"
+            | "/v1/responses/compact"
+            | "/v1/v1/responses/compact"
+            | "/codex/v1/responses/compact"
+    )
+}
+
 fn rewrite_codex_responses_endpoint_to_chat(endpoint: &str) -> (String, Option<String>) {
     let (_path, query) = split_endpoint_and_query(endpoint);
     let passthrough_query = query.map(ToString::to_string);
@@ -2319,6 +2345,19 @@ fn prepare_upstream_request_body(request_body: Value) -> Value {
     canonicalize_value(filter_private_params_with_whitelist(request_body, &[]))
 }
 
+fn filter_unsupported_response_tools_for_request(
+    request_body: Value,
+    app_type: &AppType,
+    endpoint: &str,
+    enabled: bool,
+) -> Value {
+    if enabled && matches!(app_type, AppType::Codex) && is_responses_endpoint(endpoint) {
+        filter_unsupported_response_tools(request_body, &["image_generation"])
+    } else {
+        request_body
+    }
+}
+
 fn log_prompt_cache_trace(
     app_type: &AppType,
     provider: &Provider,
@@ -2429,6 +2468,7 @@ mod tests {
             non_streaming_timeout,
             streaming_first_byte_timeout,
             max_attempts: 1,
+            filter_unsupported_response_tools: true,
         }
     }
 
@@ -2575,6 +2615,51 @@ mod tests {
             serde_json::to_string(&prepared).unwrap(),
             r#"{"a":2,"tools":[{"name":"lookup","parameters":{"properties":{"_id":{"type":"string"},"a":{"type":"string"},"b":{"type":"number"}},"type":"object"}}],"z":1}"#
         );
+    }
+
+    #[test]
+    fn unsupported_response_tool_filter_only_applies_to_enabled_codex_responses() {
+        let body = json!({
+            "tools": [
+                {"type": "function", "name": "read_file"},
+                {"type": "image_generation", "output_format": "png"}
+            ]
+        });
+
+        let filtered = filter_unsupported_response_tools_for_request(
+            body.clone(),
+            &AppType::Codex,
+            "/v1/responses",
+            true,
+        );
+        assert_eq!(filtered["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(filtered["tools"][0]["type"], "function");
+
+        assert_eq!(
+            filter_unsupported_response_tools_for_request(
+                body.clone(),
+                &AppType::Codex,
+                "/v1/responses",
+                false,
+            ),
+            body
+        );
+
+        let non_codex = filter_unsupported_response_tools_for_request(
+            body.clone(),
+            &AppType::Claude,
+            "/v1/responses",
+            true,
+        );
+        assert_eq!(non_codex, body);
+
+        let non_responses = filter_unsupported_response_tools_for_request(
+            body.clone(),
+            &AppType::Codex,
+            "/v1/chat/completions",
+            true,
+        );
+        assert_eq!(non_responses, body);
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/handler_context.rs
+++ b/src-tauri/src/proxy/handler_context.rs
@@ -235,6 +235,7 @@ impl RequestContext {
             self.optimizer_config.clone(),
             self.copilot_optimizer_config.clone(),
             max_retries,
+            self.app_config.filter_unsupported_response_tools,
         )
     }
 

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -50,6 +50,147 @@ pub struct ProxyState {
     pub failover_manager: Arc<FailoverSwitchManager>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::Provider;
+    use serde_json::{json, Value};
+    use std::sync::Arc;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        sync::oneshot,
+    };
+
+    async fn run_single_capture_upstream() -> (String, oneshot::Receiver<Value>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock upstream");
+        let addr = listener.local_addr().expect("mock upstream addr");
+        let (tx, rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept mock request");
+            let mut buffer = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            let header_end;
+            loop {
+                let read = stream.read(&mut chunk).await.expect("read mock request");
+                assert!(read > 0, "mock upstream connection closed before headers");
+                buffer.extend_from_slice(&chunk[..read]);
+                if let Some(pos) = buffer.windows(4).position(|w| w == b"\r\n\r\n") {
+                    header_end = pos + 4;
+                    break;
+                }
+            }
+
+            let headers = String::from_utf8_lossy(&buffer[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+
+            while buffer.len() < header_end + content_length {
+                let read = stream.read(&mut chunk).await.expect("read mock body");
+                assert!(read > 0, "mock upstream connection closed before body");
+                buffer.extend_from_slice(&chunk[..read]);
+            }
+
+            let body = &buffer[header_end..header_end + content_length];
+            let body_json: Value = serde_json::from_slice(body).expect("parse upstream body");
+            let _ = tx.send(body_json);
+
+            let response = br#"{"id":"resp_mock","object":"response","output":[]}"#;
+            let header = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                response.len()
+            );
+            stream
+                .write_all(header.as_bytes())
+                .await
+                .expect("write mock response headers");
+            stream
+                .write_all(response)
+                .await
+                .expect("write mock response body");
+        });
+
+        (format!("http://{addr}/v1"), rx)
+    }
+
+    #[tokio::test]
+    async fn codex_responses_route_filters_unsupported_tools_before_upstream() {
+        let (base_url, received_body) = run_single_capture_upstream().await;
+        let proxy_port = {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("reserve proxy port");
+            let port = listener.local_addr().expect("reserved proxy addr").port();
+            drop(listener);
+            port
+        };
+
+        let db = Arc::new(Database::memory().expect("memory db"));
+        let provider = Provider::with_id(
+            "mock-codex".to_string(),
+            "Mock Codex".to_string(),
+            json!({
+                "base_url": base_url,
+                "api_key": "test-key"
+            }),
+            None,
+        );
+        db.save_provider("codex", &provider)
+            .expect("save mock provider");
+        db.set_current_provider("codex", "mock-codex")
+            .expect("select mock provider");
+
+        let proxy_config = ProxyConfig {
+            listen_address: "127.0.0.1".to_string(),
+            listen_port: proxy_port,
+            ..ProxyConfig::default()
+        };
+        let server = ProxyServer::new(proxy_config, db, None);
+        let proxy_info = server.start().await.expect("start proxy");
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!(
+                "http://{}:{}/v1/responses",
+                proxy_info.address, proxy_info.port
+            ))
+            .json(&json!({
+                "model": "gpt-5",
+                "input": "test",
+                "tools": [
+                    {"type": "image_generation", "output_format": "png"},
+                    {"type": "function", "name": "ok", "parameters": {"type": "object", "properties": {}}}
+                ]
+            }))
+            .send()
+            .await
+            .expect("send proxy request");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let _ = response.bytes().await.expect("read proxy response");
+        server.stop().await.expect("stop proxy");
+
+        let upstream_body = received_body.await.expect("mock received request");
+        let tools = upstream_body["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["type"], "function");
+        assert!(
+            !serde_json::to_string(&upstream_body)
+                .expect("serialize upstream body")
+                .contains("image_generation"),
+            "upstream body must not contain image_generation: {upstream_body}"
+        );
+    }
+}
+
 /// 代理HTTP服务器
 pub struct ProxyServer {
     config: ProxyConfig,

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -192,6 +192,9 @@ pub struct AppProxyConfig {
     pub circuit_error_rate_threshold: f64,
     /// 计算错误率的最小请求数
     pub circuit_min_requests: u32,
+    /// 是否过滤 Responses API 中上游不支持的工具
+    #[serde(default = "default_true")]
+    pub filter_unsupported_response_tools: bool,
 }
 
 /// 整流器配置

--- a/src/components/proxy/AutoFailoverConfigPanel.tsx
+++ b/src/components/proxy/AutoFailoverConfigPanel.tsx
@@ -172,6 +172,7 @@ export function AutoFailoverConfigPanel({
         circuitTimeoutSeconds: raw.circuitTimeoutSeconds,
         circuitErrorRateThreshold: raw.circuitErrorRateThreshold / 100,
         circuitMinRequests: raw.circuitMinRequests,
+        filterUnsupportedResponseTools: config.filterUnsupportedResponseTools,
       });
       toast.success(
         t("proxy.autoFailover.configSaved", "自动故障转移配置已保存"),

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -25,6 +25,8 @@ import {
   useSetProxyTakeoverForApp,
   useGlobalProxyConfig,
   useUpdateGlobalProxyConfig,
+  useAppProxyConfig,
+  useUpdateAppProxyConfig,
 } from "@/lib/query/proxy";
 import type { ProxyStatus } from "@/types/proxy";
 import { useTranslation } from "react-i18next";
@@ -53,6 +55,8 @@ export function ProxyPanel({
   // 获取全局代理配置
   const { data: globalConfig } = useGlobalProxyConfig();
   const updateGlobalConfig = useUpdateGlobalProxyConfig();
+  const { data: codexProxyConfig } = useAppProxyConfig("codex");
+  const updateAppProxyConfig = useUpdateAppProxyConfig();
 
   // 监听地址/端口的本地状态（端口用字符串以支持完全清空）
   const [listenAddress, setListenAddress] = useState("127.0.0.1");
@@ -112,6 +116,32 @@ export function ProxyPanel({
     } catch (error) {
       toast.error(
         t("proxy.logging.failed", { defaultValue: "切换日志状态失败" }),
+      );
+    }
+  };
+
+  const handleCodexToolFilterChange = async (enabled: boolean) => {
+    if (!codexProxyConfig) return;
+    try {
+      await updateAppProxyConfig.mutateAsync({
+        ...codexProxyConfig,
+        filterUnsupportedResponseTools: enabled,
+      });
+      toast.success(
+        enabled
+          ? t("proxy.settings.codexToolFilter.enabled", {
+              defaultValue: "Codex Responses 工具过滤已启用",
+            })
+          : t("proxy.settings.codexToolFilter.disabled", {
+              defaultValue: "Codex Responses 工具过滤已关闭",
+            }),
+        { closeButton: true },
+      );
+    } catch (error) {
+      toast.error(
+        t("proxy.settings.codexToolFilter.failed", {
+          defaultValue: "切换 Codex Responses 工具过滤失败",
+        }),
       );
     }
   };
@@ -300,6 +330,33 @@ export function ProxyPanel({
             </motion.div>
           )}
         </AnimatePresence>
+
+        <div className="rounded-xl border border-border bg-card/50 p-4 transition-colors hover:bg-muted/50">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <Label
+                htmlFor="codex-filter-unsupported-response-tools"
+                className="text-sm font-medium"
+              >
+                {t("proxy.settings.codexToolFilter.title", {
+                  defaultValue: "Codex: 过滤不支持的 Responses 工具",
+                })}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {t("proxy.settings.codexToolFilter.description", {
+                  defaultValue:
+                    "本地路由接管 Codex 后，从 Responses 请求中移除上游不支持的工具；默认移除 image_generation，避免 403/unsupported_value。",
+                })}
+              </p>
+            </div>
+            <Switch
+              id="codex-filter-unsupported-response-tools"
+              checked={codexProxyConfig?.filterUnsupportedResponseTools ?? true}
+              onCheckedChange={handleCodexToolFilterChange}
+              disabled={!codexProxyConfig || updateAppProxyConfig.isPending}
+            />
+          </div>
+        </div>
 
         {/* Running state: service info + stats */}
         {isRunning && status ? (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2285,7 +2285,14 @@
       "invalidAddress": "Invalid address. Enter an IPv4 (e.g. 127.0.0.1), IPv6 (e.g. ::1), or localhost",
       "configSaved": "Routing configuration saved",
       "configSaveFailed": "Failed to save configuration",
-      "restartRequired": "Restart routing service for address or port changes to take effect"
+      "restartRequired": "Restart routing service for address or port changes to take effect",
+      "codexToolFilter": {
+        "title": "Codex: Filter unsupported Responses tools",
+        "description": "When local routing takes over Codex, remove tools unsupported by the upstream from Responses requests. Defaults to removing image_generation to avoid 403/unsupported_value.",
+        "enabled": "Codex Responses tool filtering enabled",
+        "disabled": "Codex Responses tool filtering disabled",
+        "failed": "Failed to toggle Codex Responses tool filtering"
+      }
     },
     "switchFailed": "Switch failed: {{error}}",
     "takeover": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2285,7 +2285,14 @@
       "invalidAddress": "無効なアドレスです。IPv4（例: 127.0.0.1）、IPv6（例: ::1）、または localhost を入力してください",
       "configSaved": "ルーティング設定を保存しました",
       "configSaveFailed": "設定の保存に失敗しました",
-      "restartRequired": "アドレスまたはポートの変更を反映するにはルーティングサービスの再起動が必要です"
+      "restartRequired": "アドレスまたはポートの変更を反映するにはルーティングサービスの再起動が必要です",
+      "codexToolFilter": {
+        "title": "Codex: 未対応の Responses ツールをフィルター",
+        "description": "ローカルルーティングで Codex を接管したとき、上流が対応していないツールを Responses リクエストから削除します。デフォルトでは image_generation を削除し、403/unsupported_value を回避します。",
+        "enabled": "Codex Responses ツールフィルターを有効にしました",
+        "disabled": "Codex Responses ツールフィルターを無効にしました",
+        "failed": "Codex Responses ツールフィルターの切り替えに失敗しました"
+      }
     },
     "switchFailed": "切り替えに失敗しました: {{error}}",
     "takeover": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2231,7 +2231,14 @@
       "invalidAddress": "位址無效，請輸入 IPv4（如 127.0.0.1）、IPv6（如 ::1）或 localhost",
       "configSaved": "路由設定已儲存",
       "configSaveFailed": "儲存設定失敗",
-      "restartRequired": "修改位址或連接埠後需要重新啟動路由服務才能生效"
+      "restartRequired": "修改位址或連接埠後需要重新啟動路由服務才能生效",
+      "codexToolFilter": {
+        "title": "Codex: 過濾不支援的 Responses 工具",
+        "description": "本地路由接管 Codex 後，從 Responses 請求中移除上游不支援的工具；預設移除 image_generation，避免 403/unsupported_value。",
+        "enabled": "Codex Responses 工具過濾已啟用",
+        "disabled": "Codex Responses 工具過濾已關閉",
+        "failed": "切換 Codex Responses 工具過濾失敗"
+      }
     },
     "switchFailed": "切換失敗：{{error}}",
     "takeover": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2285,7 +2285,14 @@
       "invalidAddress": "地址无效，请输入 IPv4（如 127.0.0.1）、IPv6（如 ::1）或 localhost",
       "configSaved": "路由配置已保存",
       "configSaveFailed": "保存配置失败",
-      "restartRequired": "修改地址或端口后需要重启路由服务才能生效"
+      "restartRequired": "修改地址或端口后需要重启路由服务才能生效",
+      "codexToolFilter": {
+        "title": "Codex: 过滤不支持的 Responses 工具",
+        "description": "本地路由接管 Codex 后，从 Responses 请求中移除上游不支持的工具；默认移除 image_generation，避免 403/unsupported_value。",
+        "enabled": "Codex Responses 工具过滤已启用",
+        "disabled": "Codex Responses 工具过滤已关闭",
+        "failed": "切换 Codex Responses 工具过滤失败"
+      }
     },
     "switchFailed": "切换失败: {{error}}",
     "takeover": {

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -137,4 +137,5 @@ export interface AppProxyConfig {
   circuitTimeoutSeconds: number;
   circuitErrorRateThreshold: number;
   circuitMinRequests: number;
+  filterUnsupportedResponseTools: boolean;
 }


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

Add a Codex local-routing option to filter unsupported Responses API tools before forwarding requests upstream. The initial unsupported tool is `image_generation`.

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #3683

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |     
<img width="1088" height="832" alt="image" src="https://github.com/user-attachments/assets/7b401032-baac-4432-ab9c-bb7875a63968" />
          |

## Checklist / 检查清单

- [*] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [*] `pnpm format:check` passes / 通过代码格式检查
- [*] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [*] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
