### PR TITLE
fix(codex): preserve live UI settings / 保留 Codex UI 设置

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -592,6 +592,7 @@ fn extract_codex_live_common_config(config_toml: &str) -> Result<String, AppErro
         "model",
         "model_provider",
         "base_url",
+        "experimental_bearer_token",
         "model_catalog_json",
     ] {
         root.remove(key);

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -514,6 +514,7 @@ pub(crate) fn write_live_with_common_config(
     let mut effective_provider = provider.clone();
     effective_provider.settings_config =
         build_effective_settings_with_common_config(db, app_type, provider)?;
+    preserve_live_codex_common_config(app_type, &mut effective_provider.settings_config)?;
 
     if matches!(app_type, AppType::ClaudeDesktop) {
         crate::claude_desktop_config::apply_provider(db, &effective_provider)?;
@@ -526,6 +527,77 @@ pub(crate) fn write_live_with_common_config(
     }
 
     write_live_snapshot(app_type, &effective_provider)
+}
+
+fn preserve_live_codex_common_config(
+    app_type: &AppType,
+    settings: &mut Value,
+) -> Result<(), AppError> {
+    if !matches!(app_type, AppType::Codex) {
+        return Ok(());
+    }
+
+    let live_settings = match crate::codex_config::read_codex_live_settings() {
+        Ok(settings) => settings,
+        Err(err) => {
+            log::debug!("Skipping live Codex common config preservation: {err}");
+            return Ok(());
+        }
+    };
+    let Some(live_config) = live_settings.get("config").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let live_common = extract_codex_live_common_config(live_config)?;
+    if live_common.trim().is_empty() {
+        return Ok(());
+    }
+
+    let Some(obj) = settings.as_object_mut() else {
+        return Ok(());
+    };
+    let target_config = obj.get("config").and_then(Value::as_str).unwrap_or("");
+    let mut target_doc = if target_config.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        target_config.parse::<DocumentMut>().map_err(|e| {
+            AppError::Message(format!(
+                "Invalid Codex config.toml while preserving live common config: {e}"
+            ))
+        })?
+    };
+    let source_doc = live_common.parse::<DocumentMut>().map_err(|e| {
+        AppError::Message(format!(
+            "Invalid Codex live common config while preserving provider write: {e}"
+        ))
+    })?;
+
+    merge_toml_table_like(target_doc.as_table_mut(), source_doc.as_table());
+    obj.insert("config".to_string(), Value::String(target_doc.to_string()));
+    Ok(())
+}
+
+fn extract_codex_live_common_config(config_toml: &str) -> Result<String, AppError> {
+    if config_toml.trim().is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut doc = config_toml.parse::<DocumentMut>().map_err(|e| {
+        AppError::Message(format!(
+            "Invalid Codex config.toml while extracting live common config: {e}"
+        ))
+    })?;
+    let root = doc.as_table_mut();
+    for key in [
+        "OPENAI_API_KEY",
+        "model",
+        "model_provider",
+        "base_url",
+        "model_catalog_json",
+    ] {
+        root.remove(key);
+    }
+    root.remove("model_providers");
+    Ok(doc.to_string())
 }
 
 pub(crate) fn strip_common_config_from_live_settings(

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -246,6 +246,120 @@ command = "say"
 }
 
 #[test]
+fn provider_service_switch_codex_preserves_live_ui_settings() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    enable_codex_official_auth_preservation();
+    let _home = ensure_test_home();
+
+    let legacy_auth = json!({ "OPENAI_API_KEY": "legacy-key" });
+    let legacy_config = r##"model_provider = "legacy"
+model = "gpt-5.4"
+personality = "pragmatic"
+
+[desktop]
+appearanceLightCodeThemeId = "raycast"
+accentColor = "#ff6363"
+
+[mcp_servers.codegraph]
+type = "stdio"
+command = "codegraph"
+
+[model_providers.legacy]
+name = "legacy"
+base_url = "https://legacy.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"##;
+    write_codex_live_atomic(&legacy_auth, Some(legacy_config))
+        .expect("seed existing codex live config");
+
+    let mut initial_config = MultiAppConfig::default();
+    {
+        let manager = initial_config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "old-provider".to_string();
+        manager.providers.insert(
+            "old-provider".to_string(),
+            Provider::with_id(
+                "old-provider".to_string(),
+                "Legacy".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "legacy-key"},
+                    "config": legacy_config
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "new-provider".to_string(),
+            Provider::with_id(
+                "new-provider".to_string(),
+                "Latest".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "fresh-key"},
+                    "config": r#"model_provider = "latest"
+model = "gpt-5.5"
+
+[model_providers.latest]
+name = "latest"
+base_url = "https://latest.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = create_test_state_with_config(&initial_config).expect("create test state");
+
+    ProviderService::switch(&state, AppType::Codex, "new-provider")
+        .expect("switch provider should succeed");
+
+    let config_text =
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read config.toml");
+    let parsed: toml::Value = toml::from_str(&config_text).expect("parse config.toml");
+
+    assert_eq!(
+        parsed.get("model_provider").and_then(|v| v.as_str()),
+        Some("latest"),
+        "provider-specific routing should still switch to the selected provider"
+    );
+    assert_eq!(
+        parsed.get("personality").and_then(|v| v.as_str()),
+        Some("pragmatic"),
+        "live Codex UI personality should survive provider writes"
+    );
+    assert_eq!(
+        parsed
+            .get("desktop")
+            .and_then(|v| v.get("appearanceLightCodeThemeId"))
+            .and_then(|v| v.as_str()),
+        Some("raycast"),
+        "live Codex desktop theme should survive provider writes"
+    );
+    assert!(
+        parsed
+            .get("mcp_servers")
+            .and_then(|v| v.get("codegraph"))
+            .is_some(),
+        "live Codex MCP entries should survive provider writes"
+    );
+    assert_eq!(
+        parsed
+            .get("model_providers")
+            .and_then(|v| v.get("latest"))
+            .and_then(|v| v.get("base_url"))
+            .and_then(|v| v.as_str()),
+        Some("https://latest.example/v1"),
+        "provider-specific endpoint should come from the selected provider"
+    );
+}
+
+#[test]
 fn provider_service_switch_codex_preserves_user_model_provider_id_after_migration() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -256,6 +256,7 @@ fn provider_service_switch_codex_preserves_live_ui_settings() {
     let legacy_config = r##"model_provider = "legacy"
 model = "gpt-5.4"
 personality = "pragmatic"
+experimental_bearer_token = "stale-live-token"
 
 [desktop]
 appearanceLightCodeThemeId = "raycast"
@@ -292,14 +293,12 @@ requires_openai_auth = true
                 None,
             ),
         );
-        manager.providers.insert(
+        let mut new_provider = Provider::with_id(
             "new-provider".to_string(),
-            Provider::with_id(
-                "new-provider".to_string(),
-                "Latest".to_string(),
-                json!({
-                    "auth": {"OPENAI_API_KEY": "fresh-key"},
-                    "config": r#"model_provider = "latest"
+            "Latest".to_string(),
+            json!({
+                "auth": {},
+                "config": r#"model_provider = "latest"
 model = "gpt-5.5"
 
 [model_providers.latest]
@@ -308,10 +307,13 @@ base_url = "https://latest.example/v1"
 wire_api = "responses"
 requires_openai_auth = true
 "#
-                }),
-                None,
-            ),
+            }),
+            None,
         );
+        new_provider.category = Some("official".to_string());
+        manager
+            .providers
+            .insert("new-provider".to_string(), new_provider);
     }
 
     let state = create_test_state_with_config(&initial_config).expect("create test state");
@@ -356,6 +358,14 @@ requires_openai_auth = true
             .and_then(|v| v.as_str()),
         Some("https://latest.example/v1"),
         "provider-specific endpoint should come from the selected provider"
+    );
+    assert!(
+        !config_text.contains("stale-live-token"),
+        "stale top-level bearer tokens from live config should not be preserved as common config"
+    );
+    assert!(
+        !config_text.contains("experimental_bearer_token"),
+        "official provider writes without auth material should not inherit stale live bearer tokens"
     );
 }
 


### PR DESCRIPTION
## Summary / 摘要

- Closes #3700
- 在写入选中的 Codex provider 前，保留 live `config.toml` 里的非 provider 配置
- 排除 provider-owned keys：`model`、`model_provider`、`base_url`、`experimental_bearer_token`、`model_catalog_json`、`model_providers`
- 新增 regression test，覆盖 `personality`、`[desktop]`、`[mcp_servers]`、stale live bearer token，同时确认 endpoint 仍会切到目标 provider

## Root Cause / 根因

Codex provider writes 是从 cc-switch DB 里的 provider snapshot 加 common snippet 组装出来的。

如果用户后来直接在 Codex 里改了主题、personality、MCP 等 live settings，而这些改动还没有回写到 provider snapshot，那么下一次 provider write 就可能用旧 snapshot 覆盖 live `config.toml`。

这次改动让 provider 继续拥有 provider-specific routing，同时把 live config 里的 UI/context settings 保留下来。

## Verification / 验证

已通过：

- `cargo fmt --check`
- `pnpm typecheck`
- `pnpm format:check`
- `git diff --check`

本地受限 / Blocked locally:

- `cargo clippy` 和 targeted Rust test 被 Windows 本机缺少 MSVC `link.exe` 阻塞
- `pnpm test:unit` 在既有 `tests/integration/App.test.tsx` 失败：一个 timeout，一个 duplicate `provider-list` query；这两个失败和本次 Rust-only change 无直接关系
