### PR TITLE
fix(claude): preserve live common config on provider switch & fix auto-inference default

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -548,6 +548,12 @@ pub(crate) fn sync_common_config_from_live(
     db: &Database,
     app_type: &AppType,
 ) -> Result<(), AppError> {
+    // Skip sync if the user explicitly cleared common config — don't
+    // re-enable it automatically from stale live fields.
+    if db.is_config_snippet_cleared(app_type.as_str())? {
+        return Ok(());
+    }
+
     let live_settings = read_live_settings(app_type.clone())?;
 
     let snippet =

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -362,9 +362,22 @@ pub(crate) fn provider_uses_common_config(
         .and_then(|meta| meta.common_config_enabled)
     {
         Some(explicit) => explicit && snippet.is_some_and(|value| !value.trim().is_empty()),
-        None => snippet.is_some_and(|value| {
-            settings_contain_common_config(app_type, &provider.settings_config, value)
-        }),
+        None => {
+            // For exclusive-mode apps (Claude/Codex/Gemini), settings.json is fully
+            // overwritten on provider switch. Not merging common config means all
+            // common fields (statusLine, enabledPlugins, model, etc.) are lost.
+            // Default to applying common config as long as a non-empty snippet exists.
+            //
+            // For additive-mode apps (Hermes/OpenClaw), multiple providers coexist
+            // in the same config file — keep the existing subset heuristic.
+            if !app_type.is_additive_mode() {
+                snippet.is_some_and(|v| !v.trim().is_empty())
+            } else {
+                snippet.is_some_and(|value| {
+                    settings_contain_common_config(app_type, &provider.settings_config, value)
+                })
+            }
+        }
     }
 }
 
@@ -526,6 +539,31 @@ pub(crate) fn write_live_with_common_config(
     }
 
     write_live_snapshot(app_type, &effective_provider)
+}
+
+/// Re-extract common config from the current live settings and persist it to the database.
+/// This ensures the common config snippet stays up-to-date (e.g. when plugins like
+/// claude-hud update their cache paths between versions).
+pub(crate) fn sync_common_config_from_live(
+    db: &Database,
+    app_type: &AppType,
+) -> Result<(), AppError> {
+    let live_settings = read_live_settings(app_type.clone())?;
+
+    let snippet = crate::services::provider::ProviderService::extract_common_config_snippet_from_settings(
+        app_type.clone(),
+        &live_settings,
+    )?;
+
+    if !snippet.is_empty() && snippet != "{}" {
+        db.set_config_snippet(app_type.as_str(), Some(snippet))?;
+        log::info!(
+            "✓ Synced common config snippet for {} from live settings",
+            app_type.as_str()
+        );
+    }
+
+    Ok(())
 }
 
 pub(crate) fn strip_common_config_from_live_settings(

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -541,6 +541,32 @@ pub(crate) fn write_live_with_common_config(
     write_live_snapshot(app_type, &effective_provider)
 }
 
+/// Refresh the common-config snippet from the current live settings, then write
+/// the provider to live.
+///
+/// Use this for write paths that must preserve whatever was most recently written
+/// to the live config by the user or Claude Code (e.g. `update`/`add` of the
+/// current provider, and startup/restore sync). The provider-switch flow syncs
+/// the *outgoing* provider's live state itself and keeps calling
+/// [`write_live_with_common_config`] directly.
+///
+/// Additive-mode apps coexist in one file and do not use the snippet sync.
+pub(crate) fn write_live_with_common_config_synced(
+    db: &Database,
+    app_type: &AppType,
+    provider: &Provider,
+) -> Result<(), AppError> {
+    if !app_type.is_additive_mode() {
+        if let Err(err) = sync_common_config_from_live(db, app_type) {
+            log::warn!(
+                "Failed to sync common config from live before writing {}: {err}",
+                app_type.as_str()
+            );
+        }
+    }
+    write_live_with_common_config(db, app_type, provider)
+}
+
 /// Re-extract common config from the current live settings and persist it to the database.
 /// This ensures the common config snippet stays up-to-date (e.g. when plugins like
 /// claude-hud update their cache paths between versions).
@@ -969,7 +995,7 @@ pub(crate) fn sync_current_provider_for_app_to_live(
 
         let providers = state.db.get_all_providers(app_type.as_str())?;
         if let Some(provider) = providers.get(&current_id) {
-            write_live_with_common_config(state.db.as_ref(), app_type, provider)?;
+            write_live_with_common_config_synced(state.db.as_ref(), app_type, provider)?;
         }
     }
 

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -550,15 +550,26 @@ pub(crate) fn sync_common_config_from_live(
 ) -> Result<(), AppError> {
     let live_settings = read_live_settings(app_type.clone())?;
 
-    let snippet = crate::services::provider::ProviderService::extract_common_config_snippet_from_settings(
-        app_type.clone(),
-        &live_settings,
-    )?;
+    let snippet =
+        crate::services::provider::ProviderService::extract_common_config_snippet_from_settings(
+            app_type.clone(),
+            &live_settings,
+        )?;
 
     if !snippet.is_empty() && snippet != "{}" {
         db.set_config_snippet(app_type.as_str(), Some(snippet))?;
         log::info!(
             "✓ Synced common config snippet for {} from live settings",
+            app_type.as_str()
+        );
+    } else {
+        // Live settings had no extractable common fields — clear the stale
+        // snippet so that provider_uses_common_config won't write back
+        // removed fields on the next switch.
+        db.set_config_snippet(app_type.as_str(), None)?;
+        let _ = db.set_config_snippet_cleared(app_type.as_str(), true);
+        log::info!(
+            "✓ Cleared stale common config snippet for {} (live has no common fields)",
             app_type.as_str()
         );
     }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1726,10 +1726,7 @@ impl ProviderService {
         // This ensures the common config snippet in the DB stays up-to-date
         // (e.g. when plugins like claude-hud update their cache paths).
         if !app_type.is_additive_mode() {
-            if let Err(e) = sync_common_config_from_live(
-                state.db.as_ref(),
-                &app_type,
-            ) {
+            if let Err(e) = sync_common_config_from_live(state.db.as_ref(), &app_type) {
                 log::warn!("Failed to sync common config from live: {e}");
             }
         }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -32,7 +32,8 @@ pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
     provider_exists_in_live_config, strip_common_config_from_live_settings,
-    sync_current_provider_for_app_to_live, write_live_with_common_config,
+    sync_common_config_from_live, sync_current_provider_for_app_to_live,
+    write_live_with_common_config,
 };
 
 // Internal re-exports
@@ -1718,6 +1719,18 @@ impl ProviderService {
                         }
                     }
                 }
+            }
+        }
+
+        // Sync common config from live settings before switching.
+        // This ensures the common config snippet in the DB stays up-to-date
+        // (e.g. when plugins like claude-hud update their cache paths).
+        if !app_type.is_additive_mode() {
+            if let Err(e) = sync_common_config_from_live(
+                state.db.as_ref(),
+                &app_type,
+            ) {
+                log::warn!("Failed to sync common config from live: {e}");
             }
         }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -33,7 +33,7 @@ pub(crate) use live::{
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
     provider_exists_in_live_config, strip_common_config_from_live_settings,
     sync_common_config_from_live, sync_current_provider_for_app_to_live,
-    write_live_with_common_config,
+    write_live_with_common_config, write_live_with_common_config_synced,
 };
 
 // Internal re-exports
@@ -1221,7 +1221,7 @@ impl ProviderService {
             state
                 .db
                 .set_current_provider(app_type.as_str(), &provider.id)?;
-            write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
+            write_live_with_common_config_synced(state.db.as_ref(), &app_type, &provider)?;
         }
 
         Ok(true)
@@ -1423,7 +1423,7 @@ impl ProviderService {
                     .map_err(|e| AppError::Message(format!("同步 Claude Live 配置失败: {e}")))?;
                 }
             } else {
-                write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
+                write_live_with_common_config_synced(state.db.as_ref(), &app_type, &provider)?;
                 // Sync MCP
                 McpService::sync_all_enabled(state)?;
             }

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -2040,3 +2040,245 @@ fn update_current_claude_provider_preserves_live_common_config() {
         "statusLine should be preserved"
     );
 }
+
+/// Regression test for the provider-switch path of the "preserve live common
+/// config" fix (see PR #3728). When switching between two providers that do not
+/// set `commonConfigEnabled` (relying on auto-inference), the common fields
+/// present in the live `settings.json` (statusLine, enabledPlugins, model) must
+/// survive the switch while the provider-specific env fields are updated.
+#[test]
+fn provider_service_switch_claude_preserves_common_config_fields() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let settings_path = get_claude_settings_path();
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent).expect("create claude settings dir");
+    }
+
+    // Live settings.json holds the common fields the user configured in Claude
+    // Code while provider A is active. Neither provider sets commonConfigEnabled,
+    // so common config is applied via auto-inference from the synced snippet.
+    let live = json!({
+        "env": {
+            "ANTHROPIC_API_KEY": "key-a",
+            "ANTHROPIC_BASE_URL": "https://a.example.com"
+        },
+        "enabledPlugins": {
+            "plugin-a@market": true
+        },
+        "statusLine": {
+            "type": "command",
+            "command": "node /home/u/.claude/plugins/cache/hud/dist/index.js"
+        },
+        "model": "claude-sonnet-4-5"
+    });
+    std::fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&live).expect("serialize live"),
+    )
+    .expect("seed claude live config");
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "provider-a".to_string();
+        manager.providers.insert(
+            "provider-a".to_string(),
+            Provider::with_id(
+                "provider-a".to_string(),
+                "Provider A".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_API_KEY": "key-a",
+                        "ANTHROPIC_BASE_URL": "https://a.example.com"
+                    }
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "provider-b".to_string(),
+            Provider::with_id(
+                "provider-b".to_string(),
+                "Provider B".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_API_KEY": "key-b",
+                        "ANTHROPIC_BASE_URL": "https://b.example.com"
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = create_test_state_with_config(&config).expect("create test state");
+    // No pre-existing snippet and not cleared: the switch-time sync must
+    // extract the common config from live and merge it into the target provider.
+    state
+        .db
+        .set_config_snippet_cleared(AppType::Claude.as_str(), false)
+        .expect("snippet not cleared");
+
+    ProviderService::switch(&state, AppType::Claude, "provider-b")
+        .expect("switch provider should succeed");
+
+    let live_after: serde_json::Value =
+        read_json_file(&settings_path).expect("read claude live settings");
+
+    // Provider-specific fields are updated to provider B.
+    assert_eq!(
+        live_after
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+            .and_then(|key| key.as_str()),
+        Some("key-b"),
+        "live settings.json should reflect provider B auth"
+    );
+    assert_eq!(
+        live_after
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_BASE_URL"))
+            .and_then(|url| url.as_str()),
+        Some("https://b.example.com"),
+        "live settings.json should reflect provider B base url"
+    );
+
+    // Common fields are preserved across the switch.
+    assert_eq!(
+        live_after
+            .get("enabledPlugins")
+            .and_then(|p| p.get("plugin-a@market"))
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "enabledPlugins should be preserved when switching providers"
+    );
+    assert_eq!(
+        live_after
+            .get("statusLine")
+            .and_then(|s| s.get("command"))
+            .and_then(|c| c.as_str()),
+        Some("node /home/u/.claude/plugins/cache/hud/dist/index.js"),
+        "statusLine should be preserved when switching providers"
+    );
+    assert_eq!(
+        live_after.get("model").and_then(|m| m.as_str()),
+        Some("claude-sonnet-4-5"),
+        "model should be preserved when switching providers"
+    );
+}
+
+/// Regression test for the switch-time snippet re-sync (see PR #3728). When the
+/// live `settings.json` holds an up-to-date claude-hud path (with a version
+/// directory) but the DB `common_config_claude` snippet is stale (without the
+/// version directory), switching providers must re-sync the snippet from live so
+/// the DB no longer carries the stale path.
+#[test]
+fn provider_service_switch_claude_syncs_common_config_snippet() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let settings_path = get_claude_settings_path();
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent).expect("create claude settings dir");
+    }
+
+    let live_new_path = "node /home/u/.claude/plugins/cache/claude-hud/0.1.0/dist/index.js";
+    let live = json!({
+        "env": {
+            "ANTHROPIC_API_KEY": "key-a",
+            "ANTHROPIC_BASE_URL": "https://a.example.com"
+        },
+        "statusLine": {
+            "type": "command",
+            "command": live_new_path
+        }
+    });
+    std::fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&live).expect("serialize live"),
+    )
+    .expect("seed claude live config");
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "provider-a".to_string();
+        manager.providers.insert(
+            "provider-a".to_string(),
+            Provider::with_id(
+                "provider-a".to_string(),
+                "Provider A".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_API_KEY": "key-a",
+                        "ANTHROPIC_BASE_URL": "https://a.example.com"
+                    }
+                }),
+                None,
+            ),
+        );
+        manager.providers.insert(
+            "provider-b".to_string(),
+            Provider::with_id(
+                "provider-b".to_string(),
+                "Provider B".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_API_KEY": "key-b",
+                        "ANTHROPIC_BASE_URL": "https://b.example.com"
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    // STALE snippet: claude-hud path without the version directory (from before
+    // the plugin upgrade). The DB is out of date relative to the live settings.
+    let stale_path = "node /home/u/.claude/plugins/cache/claude-hud/dist/index.js";
+    let stale_snippet = serde_json::to_string(&json!({
+        "statusLine": {
+            "type": "command",
+            "command": stale_path
+        }
+    }))
+    .expect("serialize stale snippet");
+    state
+        .db
+        .set_config_snippet(AppType::Claude.as_str(), Some(stale_snippet))
+        .expect("set stale snippet");
+    state
+        .db
+        .set_config_snippet_cleared(AppType::Claude.as_str(), false)
+        .expect("snippet not cleared");
+
+    ProviderService::switch(&state, AppType::Claude, "provider-b")
+        .expect("switch provider should succeed");
+
+    // After switch, the DB snippet should have been re-synced from live, so it
+    // reflects the up-to-date (versioned) claude-hud path and no longer carries
+    // the stale path.
+    let snippet = state
+        .db
+        .get_config_snippet(AppType::Claude.as_str())
+        .expect("get config snippet")
+        .unwrap_or_default();
+    assert!(
+        snippet.contains(live_new_path),
+        "DB common_config_claude should be re-synced to the live (versioned) path, got: {snippet}"
+    );
+    assert!(
+        !snippet.contains(stale_path),
+        "DB common_config_claude should no longer carry the stale path, got: {snippet}"
+    );
+}

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -1911,3 +1911,132 @@ fn provider_service_delete_current_provider_returns_error() {
         other => panic!("expected Config/Message error, got {other:?}"),
     }
 }
+
+#[test]
+fn update_current_claude_provider_preserves_live_common_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let settings_path = get_claude_settings_path();
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent).expect("create claude settings dir");
+    }
+
+    // Live settings.json holds the *current* state, including a plugin the user
+    // just enabled in Claude Code ("plugin-b") that the DB snippet does not yet know about.
+    let live = json!({
+        "env": {
+            "ANTHROPIC_API_KEY": "old-key",
+            "ANTHROPIC_BASE_URL": "https://old.example.com"
+        },
+        "enabledPlugins": {
+            "plugin-a@market": true,
+            "plugin-b@market": true
+        },
+        "statusLine": {
+            "type": "command",
+            "command": "node /home/u/.claude/plugins/cache/hud/dist/index.js"
+        }
+    });
+    std::fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&live).expect("serialize live"),
+    )
+    .expect("seed claude live config");
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "wiki".to_string();
+        manager.providers.insert(
+            "wiki".to_string(),
+            Provider::with_id(
+                "wiki".to_string(),
+                "Wiki".to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_API_KEY": "old-key",
+                        "ANTHROPIC_BASE_URL": "https://old.example.com"
+                    }
+                }),
+                None,
+            ),
+        );
+    }
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    // STALE snippet: only knows about plugin-a, not the newly-enabled plugin-b.
+    state
+        .db
+        .set_config_snippet(
+            AppType::Claude.as_str(),
+            Some(
+                r#"{
+                    "enabledPlugins": { "plugin-a@market": true },
+                    "statusLine": {
+                        "type": "command",
+                        "command": "node /home/u/.claude/plugins/cache/hud/dist/index.js"
+                    }
+                }"#
+                .to_string(),
+            ),
+        )
+        .expect("set stale snippet");
+    state
+        .db
+        .set_config_snippet_cleared(AppType::Claude.as_str(), false)
+        .expect("snippet not cleared");
+
+    // User edits the current provider in cc-switch (e.g. rotates the API key).
+    let updated = Provider::with_id(
+        "wiki".to_string(),
+        "Wiki".to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_API_KEY": "new-key",
+                "ANTHROPIC_BASE_URL": "https://old.example.com"
+            }
+        }),
+        None,
+    );
+    ProviderService::update(&state, AppType::Claude, None, updated).expect("update provider");
+
+    let live_after: serde_json::Value =
+        read_json_file(&settings_path).expect("read claude live settings");
+
+    assert_eq!(
+        live_after
+            .get("env")
+            .and_then(|env| env.get("ANTHROPIC_API_KEY"))
+            .and_then(|key| key.as_str()),
+        Some("new-key"),
+        "update should apply the new provider auth"
+    );
+    assert_eq!(
+        live_after
+            .get("enabledPlugins")
+            .and_then(|p| p.get("plugin-b@market"))
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "update must not clobber a plugin enabled in Claude Code after the snippet was last synced"
+    );
+    assert_eq!(
+        live_after
+            .get("enabledPlugins")
+            .and_then(|p| p.get("plugin-a@market"))
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "previously-known plugin should also be preserved"
+    );
+    assert_eq!(
+        live_after
+            .get("statusLine")
+            .and_then(|s| s.get("command"))
+            .and_then(|c| c.as_str()),
+        Some("node /home/u/.claude/plugins/cache/hud/dist/index.js"),
+        "statusLine should be preserved"
+    );
+}

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -2165,6 +2165,10 @@ fn provider_service_switch_claude_preserves_common_config_fields() {
         Some("node /home/u/.claude/plugins/cache/hud/dist/index.js"),
         "statusLine should be preserved when switching providers"
     );
+    // `model` (the top-level field, not env.ANTHROPIC_MODEL) is treated as
+    // common config because it is absent from both ENV_EXCLUDES and
+    // TOP_LEVEL_EXCLUDES in `extract_claude_common_config`. If #1682
+    // reclassifies model as provider-specific, this assertion must change.
     assert_eq!(
         live_after.get("model").and_then(|m| m.as_str()),
         Some("claude-sonnet-4-5"),
@@ -2265,20 +2269,22 @@ fn provider_service_switch_claude_syncs_common_config_snippet() {
     ProviderService::switch(&state, AppType::Claude, "provider-b")
         .expect("switch provider should succeed");
 
-    // After switch, the DB snippet should have been re-synced from live, so it
-    // reflects the up-to-date (versioned) claude-hud path and no longer carries
-    // the stale path.
+    // After switch, the DB snippet should have been re-synced from live: the
+    // statusLine command must equal the up-to-date (versioned) path, which also
+    // rules out the stale path lingering anywhere in the snippet.
     let snippet = state
         .db
         .get_config_snippet(AppType::Claude.as_str())
         .expect("get config snippet")
         .unwrap_or_default();
-    assert!(
-        snippet.contains(live_new_path),
-        "DB common_config_claude should be re-synced to the live (versioned) path, got: {snippet}"
-    );
-    assert!(
-        !snippet.contains(stale_path),
-        "DB common_config_claude should no longer carry the stale path, got: {snippet}"
+    let snippet_json: serde_json::Value =
+        serde_json::from_str(&snippet).expect("DB snippet should be valid JSON");
+    assert_eq!(
+        snippet_json
+            .get("statusLine")
+            .and_then(|s| s.get("command"))
+            .and_then(|c| c.as_str()),
+        Some(live_new_path),
+        "DB common_config_claude statusLine should be re-synced to the live (versioned) path, got: {snippet}"
     );
 }


### PR DESCRIPTION
Closes #3631

## Summary / 概述

Three overlapping bugs cause `statusLine`, `enabledPlugins`, `model`, and other common fields to be lost or overwritten with stale values when switching Claude Code providers.

本 PR 修复了三个叠加的 Bug，这些 Bug 会导致切换 Claude Code Provider 时 `statusLine`（claude-hud 状态栏）、`enabledPlugins`（插件列表）、`model` 等通用配置字段丢失或被旧值覆盖。

> **Note**: Codex 端的同类问题已在 #3700 中记录，PR #3697 正在处理。本 PR 解决 Claude Code 端的同类问题，采用类似的修复思路。

### Bug 1: `provider_uses_common_config()` 自动推断逻辑失效（`live.rs:354`）

对于未显式设置 `meta.commonConfigEnabled` 的 provider（如内置的 `claude-official`），`None` 分支使用 `json_is_subset` 检查 provider 的 `settings_config` 是否包含 common config 的所有 key。但 provider 的 `settings_config` 只存储供应商专属字段（`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_BASE_URL` 等），永远不包含 `statusLine`、`enabledPlugins`、`model` 这些通用字段。子集检查始终失败，common config 永远不会被合并。

结果：切换到 `claude-official` 时，`settings.json` 只写入了 `{"env": {}}`，所有通用配置丢失。

### Bug 2: Common config 永远不会重新同步（`lib.rs:1626`）

`initialize_common_config_snippets()` 仅在**首次启动时**自动抽取 common config。一旦 `common_config_claude` 写入数据库，`should_auto_extract_config_snippet()` 返回 `false`，snippet 永远不会更新。当插件（如 claude-hud）更新导致缓存路径变化（如 `claude-hud/dist/` → `claude-hud/0.1.0/dist/`），数据库中的旧路径在每次切换时都会被写回 `settings.json`。

### Bug 3: 切换流程不回写 common config（`mod.rs:1660`）

`switch_normal()` 从数据库读取 common config 合并到 `settings.json`，但**不会**将最新的 live settings 同步回数据库。回填步骤（backfill）从 live settings 中剥离了 common config 后直接丢弃——只有供应商专属部分被存回了数据库。

### 修复内容

1. **修复 `provider_uses_common_config` 默认推断**（`live.rs`）：排他模式应用（Claude/Codex/Gemini）只要存在非空 snippet 就默认合并 common config；additive 模式应用（Hermes/OpenClaw）保留原有 `json_is_subset` 推断逻辑。

2. **新增 `sync_common_config_from_live()`**（`live.rs`）：从当前 live `settings.json` 重新抽取 common config 并持久化到数据库，确保 snippet 始终是最新的。

3. **在 `switch_normal()` 中调用 `sync_common_config_from_live()`**（`mod.rs`）：回填完成后、写入目标 provider 之前，同步最新的 common config 到数据库。

## Related Issue / 关联 Issue

Fixes #3631

Related: #3700, #3697 (Codex 同类问题及修复 PR)

## Screenshots / 截图

不适用（Rust 后端逻辑修复，无 UI 变化）

## Checklist / 检查清单

- [x] 无前端 TypeScript 修改，`pnpm typecheck` 不适用
- [x] 无前端代码修改，`pnpm format:check` 不适用
- [ ] `cargo clippy` passes（本地无 Rust 工具链，已通过静态分析验证类型、import 和函数签名）
- [x] 无用户可见文本修改，国际化文件无需更新

## Note on Tests / 测试说明

This PR does not include regression tests due to the lack of a local Rust toolchain. Below are the intended test cases for a contributor with a Rust environment to implement:

本 PR 因本地缺少 Rust 工具链未能附带回归测试。以下为设计的测试用例，供有 Rust 环境的 contributor 实现：

### Test 1: `provider_service_switch_claude_preserves_common_config_fields`
- Seed live `settings.json` with `statusLine`, `enabledPlugins`, `model`
- Create two providers without `commonConfigEnabled` set (relying on auto-inference)
- Switch from provider A to provider B
- Assert: provider-specific fields (`ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`) are updated
- Assert: common fields (`statusLine`, `enabledPlugins`, `model`) are preserved

### Test 2: `provider_service_switch_claude_syncs_common_config_snippet`
- Seed live `settings.json` with an updated claude-hud path (with version directory)
- Pre-seed DB `common_config_claude` with a stale path (without version directory)
- Switch provider
- Assert: `common_config_claude` in DB is updated to reflect the live path

These tests should follow the existing patterns in `src-tauri/tests/provider_service.rs` (see `provider_service_switch_claude_updates_live_and_state` at line 1592 for reference).

## Reproduction Verification / 复现验证

Before fix / 修复前:

```bash
$ sqlite3 ~/.cc-switch/cc-switch.db "SELECT meta FROM providers WHERE id = 'claude-official'"
{}   # ← no commonConfigEnabled → auto-inference fails → common config not merged

$ ls ~/.claude/plugins/cache/claude-hud/claude-hud/dist/index.js
No such file or directory   # ← stale path from DB, file doesn't exist
```

After fix / 修复后: common config is always merged for exclusive-mode apps, and the snippet is re-synced from live settings on every switch.

Co-authored-by: GLM 5.1

---

## 代码 Diff（供参考，已提交到分支）

```diff
diff --git a/src-tauri/src/services/provider/live.rs b/src-tauri/src/services/provider/live.rs
index 8a6b538..21ee83f 100644
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -362,9 +362,22 @@ pub(crate) fn provider_uses_common_config(
         .and_then(|meta| meta.common_config_enabled)
     {
         Some(explicit) => explicit && snippet.is_some_and(|value| !value.trim().is_empty()),
-        None => snippet.is_some_and(|value| {
-            settings_contain_common_config(app_type, &provider.settings_config, value)
-        }),
+        None => {
+            // For exclusive-mode apps (Claude/Codex/Gemini), settings.json is fully
+            // overwritten on provider switch. Not merging common config means all
+            // common fields (statusLine, enabledPlugins, model, etc.) are lost.
+            // Default to applying common config as long as a non-empty snippet exists.
+            //
+            // For additive-mode apps (Hermes/OpenClaw), multiple providers coexist
+            // in the same config file — keep the existing subset heuristic.
+            if !app_type.is_additive_mode() {
+                snippet.is_some_and(|v| !v.trim().is_empty())
+            } else {
+                snippet.is_some_and(|value| {
+                    settings_contain_common_config(app_type, &provider.settings_config, value)
+                })
+            }
+        }
     }
 }
 
@@ -528,6 +541,31 @@ pub(crate) fn write_live_with_common_config(
     write_live_snapshot(app_type, &effective_provider)
 }
 
+/// Re-extract common config from the current live settings and persist it to the database.
+/// This ensures the common config snippet stays up-to-date (e.g. when plugins like
+/// claude-hud update their cache paths between versions).
+pub(crate) fn sync_common_config_from_live(
+    db: &Database,
+    app_type: &AppType,
+) -> Result<(), AppError> {
+    let live_settings = read_live_settings(app_type.clone())?;
+
+    let snippet = crate::services::provider::ProviderService::extract_common_config_snippet_from_settings(
+        app_type.clone(),
+        &live_settings,
+    )?;
+
+    if !snippet.is_empty() && snippet != "{}" {
+        db.set_config_snippet(app_type.as_str(), Some(snippet))?;
+        log::info!(
+            "✓ Synced common config snippet for {} from live settings",
+            app_type.as_str()
+        );
+    }
+
+    Ok(())
+}
+
 pub(crate) fn strip_common_config_from_live_settings(
     db: &Database,
     app_type: &AppType,
diff --git a/src-tauri/src/services/provider/mod.rs b/src-tauri/src/services/provider/mod.rs
index f41fb78..e00d821 100644
--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -32,7 +32,8 @@ pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
     provider_exists_in_live_config, strip_common_config_from_live_settings,
-    sync_current_provider_for_app_to_live, write_live_with_common_config,
+    sync_common_config_from_live, sync_current_provider_for_app_to_live,
+    write_live_with_common_config,
 };
 
 // Internal re-exports
@@ -1721,6 +1722,18 @@ impl ProviderService {
             }
         }
 
+        // Sync common config from live settings before switching.
+        // This ensures the common config snippet in the DB stays up-to-date
+        // (e.g. when plugins like claude-hud update their cache paths).
+        if !app_type.is_additive_mode() {
+            if let Err(e) = sync_common_config_from_live(
+                state.db.as_ref(),
+                &app_type,
+            ) {
+                log::warn!("Failed to sync common config from live: {e}");
+            }
+        }
+
         // Additive mode apps skip setting is_current (no such concept)
         if !app_type.is_additive_mode() {
             // Update local settings (device-level, takes priority)
```

---

## 改动文件清单

| 文件 | 改动 | 行数 |
|------|------|------|
| `src-tauri/src/services/provider/live.rs` | 修复 `provider_uses_common_config` 推断默认值 + 新增 `sync_common_config_from_live` | +44 -3 |
| `src-tauri/src/services/provider/mod.rs` | re-export 新函数 + 在 `switch_normal` 中调用 `sync_common_config_from_live` | +15 -1 |
| `src-tauri/tests/provider_service.rs` | ⏳ 待补充（需 Rust 环境） | — |

**总计**: 2 files changed, 55 insertions(+), 4 deletions(-)