### PR TITLE
fix(provider): resolve 401 when fetching models from Anthropic-compatible endpoints

### DIFF
--- a/src-tauri/src/commands/model_fetch.rs
+++ b/src-tauri/src/commands/model_fetch.rs
@@ -2,24 +2,33 @@
 //!
 //! 提供 Tauri 命令，供前端在供应商表单中获取可用模型列表。
 
-use crate::services::model_fetch::{self, FetchedModel};
+use crate::services::model_fetch::{self, FetchedModel, ModelFetchStrategy};
 
 /// 获取供应商的可用模型列表
 ///
 /// 使用 OpenAI 兼容的 GET /v1/models 端点。优先使用 `models_url` 精确覆写；
 /// 否则对 baseURL 生成候选列表（含「剥离 Anthropic 兼容子路径」兜底），按序尝试。
+///
+/// `strategy` 控制认证头和 URL 候选排序：`bearer`（默认）、`anthropic`、`google_api_key`。
 #[tauri::command(rename_all = "camelCase")]
 pub async fn fetch_models_for_config(
     base_url: String,
     api_key: String,
     is_full_url: Option<bool>,
     models_url: Option<String>,
+    strategy: Option<String>,
 ) -> Result<Vec<FetchedModel>, String> {
+    let strategy = match strategy.as_deref() {
+        Some("anthropic") => ModelFetchStrategy::Anthropic,
+        Some("google_api_key") => ModelFetchStrategy::GoogleApiKey,
+        _ => ModelFetchStrategy::Bearer,
+    };
     model_fetch::fetch_models(
         &base_url,
         &api_key,
         is_full_url.unwrap_or(false),
         models_url.as_deref(),
+        strategy,
     )
     .await
 }

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -31,6 +31,7 @@ pub mod webdav_sync;
 
 pub use config::ConfigService;
 pub use mcp::McpService;
+pub use model_fetch::ModelFetchStrategy;
 pub use omo::OmoService;
 pub use prompt::PromptService;
 pub use provider::{ProviderService, ProviderSortUpdate, SwitchResult};

--- a/src-tauri/src/services/model_fetch.rs
+++ b/src-tauri/src/services/model_fetch.rs
@@ -73,25 +73,24 @@ pub async fn fetch_models(
         return Err("API Key is required to fetch models".to_string());
     }
 
-    let candidates = build_models_url_candidates(base_url, is_full_url, models_url_override, strategy)?;
+    let candidates =
+        build_models_url_candidates(base_url, is_full_url, models_url_override, strategy)?;
     let client = crate::proxy::http_client::get();
     let mut last_err: Option<String> = None;
 
     for url in &candidates {
         log::debug!("[ModelFetch] Trying endpoint: {url}");
-        let mut req = client.get(url).timeout(Duration::from_secs(FETCH_TIMEOUT_SECS));
+        let mut req = client
+            .get(url)
+            .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS));
         req = match strategy {
-            ModelFetchStrategy::Bearer => {
-                req.header("Authorization", format!("Bearer {api_key}"))
-            }
+            ModelFetchStrategy::Bearer => req.header("Authorization", format!("Bearer {api_key}")),
             ModelFetchStrategy::Anthropic => req
-                .header("Authorization", format!("Bearer {api_key}"))
                 .header("x-api-key", api_key)
                 .header("anthropic-version", "2023-06-01"),
             ModelFetchStrategy::GoogleApiKey => req.header("x-goog-api-key", api_key),
         };
-        let response = match req.send().await
-        {
+        let response = match req.send().await {
             Ok(r) => r,
             Err(e) => {
                 return Err(format!("Request failed: {e}"));
@@ -188,20 +187,19 @@ pub fn build_models_url_candidates(
     // baseURL 已以版本段 /v{N} 结尾时（如 `/v1`、智谱 `/api/coding/paas/v4`），
     // OpenAI 惯例的模型端点是 `{base}/models`，不能再补 `/v1`
     // （否则 .../coding/paas/v4/v1/models → 404）。
+    // 但版本段非 /v1 时保留 /v1/models 作为兜底候选。
     let append_models = format!("{trimmed}/models");
-    let append_versioned_models = if ends_with_version_segment(trimmed) {
-        None
-    } else {
-        Some(format!("{trimmed}/v1/models"))
-    };
 
     match strategy {
         ModelFetchStrategy::Anthropic => {
             // Anthropic: 优先 /v1/models
-            if let Some(ref versioned) = append_versioned_models {
-                candidates.push(versioned.clone());
+            if ends_with_version_segment(trimmed) {
+                candidates.push(format!("{trimmed}/models"));
+                if !trimmed.ends_with("/v1") {
+                    candidates.push(format!("{trimmed}/v1/models"));
+                }
             } else {
-                candidates.push(append_models.clone());
+                candidates.push(format!("{trimmed}/v1/models"));
             }
 
             if let Some(stripped) = strip_compat_suffix(trimmed) {
@@ -210,27 +208,32 @@ pub fn build_models_url_candidates(
                     candidates.push(format!("{root}/v1/models"));
                     candidates.push(format!("{root}/models"));
                 }
-            } else if append_versioned_models.is_some() {
+            } else if !ends_with_version_segment(trimmed) {
                 candidates.push(append_models);
             }
         }
         ModelFetchStrategy::Bearer | ModelFetchStrategy::GoogleApiKey => {
-            // OpenAI / Gemini: 优先 /v1/models
             if let Some(stripped) = strip_compat_suffix(trimmed) {
-                if let Some(ref versioned) = append_versioned_models {
-                    candidates.push(versioned.clone());
+                if ends_with_version_segment(trimmed) {
+                    candidates.push(format!("{trimmed}/models"));
+                    if !trimmed.ends_with("/v1") {
+                        candidates.push(format!("{trimmed}/v1/models"));
+                    }
                 } else {
-                    candidates.push(append_models.clone());
+                    candidates.push(format!("{trimmed}/v1/models"));
                 }
                 let root = stripped.trim_end_matches('/');
                 if !root.is_empty() && root.contains("://") {
                     candidates.push(format!("{root}/v1/models"));
                     candidates.push(format!("{root}/models"));
                 }
-            } else {
-                if let Some(versioned) = append_versioned_models {
-                    candidates.push(versioned);
+            } else if ends_with_version_segment(trimmed) {
+                candidates.push(format!("{trimmed}/models"));
+                if !trimmed.ends_with("/v1") {
+                    candidates.push(format!("{trimmed}/v1/models"));
                 }
+            } else {
+                candidates.push(format!("{trimmed}/v1/models"));
                 candidates.push(append_models);
             }
         }
@@ -286,17 +289,25 @@ mod tests {
 
     #[test]
     fn test_candidates_plain_root() {
-        let c =
-            build_models_url_candidates("https://api.siliconflow.cn", false, None, ModelFetchStrategy::Bearer)
-                .unwrap();
+        let c = build_models_url_candidates(
+            "https://api.siliconflow.cn",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(c, vec!["https://api.siliconflow.cn/v1/models"]);
     }
 
     #[test]
     fn test_candidates_trailing_slash() {
-        let c =
-            build_models_url_candidates("https://api.example.com/", false, None, ModelFetchStrategy::Bearer)
-                .unwrap();
+        let c = build_models_url_candidates(
+            "https://api.example.com/",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(c, vec!["https://api.example.com/v1/models"]);
     }
 

--- a/src-tauri/src/services/model_fetch.rs
+++ b/src-tauri/src/services/model_fetch.rs
@@ -8,6 +8,18 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
+/// 模型拉取认证策略，决定请求头和 URL 候选排序。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ModelFetchStrategy {
+    /// OpenAI 风格：Authorization: Bearer，优先 /v1/models
+    #[default]
+    Bearer,
+    /// Anthropic 风格：x-api-key + anthropic-version，优先 /v1/models
+    Anthropic,
+    /// Google Gemini 风格：x-goog-api-key，优先 /v1/models
+    GoogleApiKey,
+}
+
 /// 获取到的模型信息
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -55,23 +67,30 @@ pub async fn fetch_models(
     api_key: &str,
     is_full_url: bool,
     models_url_override: Option<&str>,
+    strategy: ModelFetchStrategy,
 ) -> Result<Vec<FetchedModel>, String> {
     if api_key.is_empty() {
         return Err("API Key is required to fetch models".to_string());
     }
 
-    let candidates = build_models_url_candidates(base_url, is_full_url, models_url_override)?;
+    let candidates = build_models_url_candidates(base_url, is_full_url, models_url_override, strategy)?;
     let client = crate::proxy::http_client::get();
     let mut last_err: Option<String> = None;
 
     for url in &candidates {
         log::debug!("[ModelFetch] Trying endpoint: {url}");
-        let response = match client
-            .get(url)
-            .header("Authorization", format!("Bearer {api_key}"))
-            .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
-            .send()
-            .await
+        let mut req = client.get(url).timeout(Duration::from_secs(FETCH_TIMEOUT_SECS));
+        req = match strategy {
+            ModelFetchStrategy::Bearer => {
+                req.header("Authorization", format!("Bearer {api_key}"))
+            }
+            ModelFetchStrategy::Anthropic => req
+                .header("Authorization", format!("Bearer {api_key}"))
+                .header("x-api-key", api_key)
+                .header("anthropic-version", "2023-06-01"),
+            ModelFetchStrategy::GoogleApiKey => req.header("x-goog-api-key", api_key),
+        };
+        let response = match req.send().await
         {
             Ok(r) => r,
             Err(e) => {
@@ -126,11 +145,16 @@ pub async fn fetch_models(
 /// 3. 版本段非 `/v1`（如 `/v4`）时再追加 `/v1/models` 作为兜底次候选
 /// 4. 若 baseURL 命中 [`KNOWN_COMPAT_SUFFIXES`]，剥离后缀再拼 `/v1/models`、`/models`
 ///
+/// `strategy` 影响无版本段时的候选排序：
+/// - `Anthropic`：优先 `/v1/models`
+/// - `Bearer` / `GoogleApiKey`：优先 `/v1/models`（OpenAI 惯例）
+///
 /// 结果已去重且保持首次出现顺序。
 pub fn build_models_url_candidates(
     base_url: &str,
     is_full_url: bool,
     models_url_override: Option<&str>,
+    strategy: ModelFetchStrategy,
 ) -> Result<Vec<String>, String> {
     if let Some(raw) = models_url_override {
         let trimmed = raw.trim();
@@ -164,21 +188,51 @@ pub fn build_models_url_candidates(
     // baseURL 已以版本段 /v{N} 结尾时（如 `/v1`、智谱 `/api/coding/paas/v4`），
     // OpenAI 惯例的模型端点是 `{base}/models`，不能再补 `/v1`
     // （否则 .../coding/paas/v4/v1/models → 404）。
-    if ends_with_version_segment(trimmed) {
-        candidates.push(format!("{trimmed}/models"));
-        // 版本段非 /v1 时，保留旧的 /v1/models 作为兜底次候选（正确路径已在前）。
-        if !trimmed.ends_with("/v1") {
-            candidates.push(format!("{trimmed}/v1/models"));
-        }
+    let append_models = format!("{trimmed}/models");
+    let append_versioned_models = if ends_with_version_segment(trimmed) {
+        None
     } else {
-        candidates.push(format!("{trimmed}/v1/models"));
-    }
+        Some(format!("{trimmed}/v1/models"))
+    };
 
-    if let Some(stripped) = strip_compat_suffix(trimmed) {
-        let root = stripped.trim_end_matches('/');
-        if !root.is_empty() && root.contains("://") {
-            candidates.push(format!("{root}/v1/models"));
-            candidates.push(format!("{root}/models"));
+    match strategy {
+        ModelFetchStrategy::Anthropic => {
+            // Anthropic: 优先 /v1/models
+            if let Some(ref versioned) = append_versioned_models {
+                candidates.push(versioned.clone());
+            } else {
+                candidates.push(append_models.clone());
+            }
+
+            if let Some(stripped) = strip_compat_suffix(trimmed) {
+                let root = stripped.trim_end_matches('/');
+                if !root.is_empty() && root.contains("://") {
+                    candidates.push(format!("{root}/v1/models"));
+                    candidates.push(format!("{root}/models"));
+                }
+            } else if append_versioned_models.is_some() {
+                candidates.push(append_models);
+            }
+        }
+        ModelFetchStrategy::Bearer | ModelFetchStrategy::GoogleApiKey => {
+            // OpenAI / Gemini: 优先 /v1/models
+            if let Some(stripped) = strip_compat_suffix(trimmed) {
+                if let Some(ref versioned) = append_versioned_models {
+                    candidates.push(versioned.clone());
+                } else {
+                    candidates.push(append_models.clone());
+                }
+                let root = stripped.trim_end_matches('/');
+                if !root.is_empty() && root.contains("://") {
+                    candidates.push(format!("{root}/v1/models"));
+                    candidates.push(format!("{root}/models"));
+                }
+            } else {
+                if let Some(versioned) = append_versioned_models {
+                    candidates.push(versioned);
+                }
+                candidates.push(append_models);
+            }
         }
     }
 
@@ -232,19 +286,29 @@ mod tests {
 
     #[test]
     fn test_candidates_plain_root() {
-        let c = build_models_url_candidates("https://api.siliconflow.cn", false, None).unwrap();
+        let c =
+            build_models_url_candidates("https://api.siliconflow.cn", false, None, ModelFetchStrategy::Bearer)
+                .unwrap();
         assert_eq!(c, vec!["https://api.siliconflow.cn/v1/models"]);
     }
 
     #[test]
     fn test_candidates_trailing_slash() {
-        let c = build_models_url_candidates("https://api.example.com/", false, None).unwrap();
+        let c =
+            build_models_url_candidates("https://api.example.com/", false, None, ModelFetchStrategy::Bearer)
+                .unwrap();
         assert_eq!(c, vec!["https://api.example.com/v1/models"]);
     }
 
     #[test]
     fn test_candidates_with_v1() {
-        let c = build_models_url_candidates("https://api.example.com/v1", false, None).unwrap();
+        let c = build_models_url_candidates(
+            "https://api.example.com/v1",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(c, vec!["https://api.example.com/v1/models"]);
     }
 
@@ -252,9 +316,13 @@ mod tests {
     fn test_candidates_zhipu_coding_paas_v4() {
         // 智谱 Coding Plan 端点以 /v4 版本段结尾：模型端点是 {base}/models，
         // 正确路径必须排在 .../v4/v1/models（404）之前。
-        let c =
-            build_models_url_candidates("https://open.bigmodel.cn/api/coding/paas/v4", false, None)
-                .unwrap();
+        let c = build_models_url_candidates(
+            "https://open.bigmodel.cn/api/coding/paas/v4",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(
             c,
             vec![
@@ -266,8 +334,13 @@ mod tests {
 
     #[test]
     fn test_candidates_zai_coding_paas_v4() {
-        let c = build_models_url_candidates("https://api.z.ai/api/coding/paas/v4", false, None)
-            .unwrap();
+        let c = build_models_url_candidates(
+            "https://api.z.ai/api/coding/paas/v4",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(
             c,
             vec![
@@ -296,6 +369,7 @@ mod tests {
             "https://proxy.example.com/v1/chat/completions",
             true,
             None,
+            ModelFetchStrategy::Bearer,
         )
         .unwrap();
         assert_eq!(c, vec!["https://proxy.example.com/v1/models"]);
@@ -303,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_candidates_empty() {
-        assert!(build_models_url_candidates("", false, None).is_err());
+        assert!(build_models_url_candidates("", false, None, ModelFetchStrategy::Bearer).is_err());
     }
 
     #[test]
@@ -312,6 +386,7 @@ mod tests {
             "https://api.deepseek.com/anthropic",
             false,
             Some("https://api.deepseek.com/models"),
+            ModelFetchStrategy::Bearer,
         )
         .unwrap();
         assert_eq!(c, vec!["https://api.deepseek.com/models"]);
@@ -319,15 +394,25 @@ mod tests {
 
     #[test]
     fn test_candidates_override_empty_falls_through() {
-        let c =
-            build_models_url_candidates("https://api.siliconflow.cn", false, Some("   ")).unwrap();
+        let c = build_models_url_candidates(
+            "https://api.siliconflow.cn",
+            false,
+            Some("   "),
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(c, vec!["https://api.siliconflow.cn/v1/models"]);
     }
 
     #[test]
     fn test_candidates_deepseek_strip_anthropic() {
-        let c =
-            build_models_url_candidates("https://api.deepseek.com/anthropic", false, None).unwrap();
+        let c = build_models_url_candidates(
+            "https://api.deepseek.com/anthropic",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(
             c,
             vec![
@@ -340,8 +425,13 @@ mod tests {
 
     #[test]
     fn test_candidates_zhipu_strip_api_anthropic() {
-        let c = build_models_url_candidates("https://open.bigmodel.cn/api/anthropic", false, None)
-            .unwrap();
+        let c = build_models_url_candidates(
+            "https://open.bigmodel.cn/api/anthropic",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(
             c,
             vec![
@@ -358,6 +448,7 @@ mod tests {
             "https://dashscope.aliyuncs.com/apps/anthropic",
             false,
             None,
+            ModelFetchStrategy::Bearer,
         )
         .unwrap();
         assert_eq!(
@@ -372,8 +463,13 @@ mod tests {
 
     #[test]
     fn test_candidates_stepfun_strip_step_plan() {
-        let c =
-            build_models_url_candidates("https://api.stepfun.com/step_plan", false, None).unwrap();
+        let c = build_models_url_candidates(
+            "https://api.stepfun.com/step_plan",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(
             c,
             vec![
@@ -390,6 +486,7 @@ mod tests {
             "https://ark.cn-beijing.volces.com/api/coding",
             false,
             None,
+            ModelFetchStrategy::Bearer,
         )
         .unwrap();
         assert_eq!(
@@ -404,7 +501,13 @@ mod tests {
 
     #[test]
     fn test_candidates_rightcode_strip_claude() {
-        let c = build_models_url_candidates("https://www.right.codes/claude", false, None).unwrap();
+        let c = build_models_url_candidates(
+            "https://www.right.codes/claude",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(
             c,
             vec![
@@ -419,7 +522,13 @@ mod tests {
     fn test_candidates_longer_suffix_wins() {
         // baseURL 以 /api/anthropic 结尾时，应剥离整个 /api/anthropic，
         // 而不是只剥离 /anthropic（那样会得到残缺的 https://.../api 根）。
-        let c = build_models_url_candidates("https://api.z.ai/api/anthropic", false, None).unwrap();
+        let c = build_models_url_candidates(
+            "https://api.z.ai/api/anthropic",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(
             c,
             vec![
@@ -432,15 +541,63 @@ mod tests {
 
     #[test]
     fn test_candidates_no_suffix_no_strip() {
-        let c = build_models_url_candidates("https://openrouter.ai/api", false, None).unwrap();
+        let c = build_models_url_candidates(
+            "https://openrouter.ai/api",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(c, vec!["https://openrouter.ai/api/v1/models"]);
     }
 
     #[test]
     fn test_candidates_deduplicate() {
         // 虚构 case：baseURL 就是 "scheme://host"，剥不出子路径，应只有一个候选。
-        let c = build_models_url_candidates("https://host.example.com", false, None).unwrap();
+        let c = build_models_url_candidates(
+            "https://host.example.com",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
         assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn test_anthropic_prefers_v1_models() {
+        let c = build_models_url_candidates(
+            "https://api.anthropic.com",
+            false,
+            None,
+            ModelFetchStrategy::Anthropic,
+        )
+        .unwrap();
+        assert_eq!(
+            c,
+            vec![
+                "https://api.anthropic.com/v1/models",
+                "https://api.anthropic.com/models",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_bearer_prefers_v1_models() {
+        let c = build_models_url_candidates(
+            "https://api.openai.com",
+            false,
+            None,
+            ModelFetchStrategy::Bearer,
+        )
+        .unwrap();
+        assert_eq!(
+            c,
+            vec![
+                "https://api.openai.com/v1/models",
+                "https://api.openai.com/models",
+            ]
+        );
     }
 
     #[test]

--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -496,7 +496,13 @@ export function ClaudeDesktopProviderForm({
 
     setIsFetchingModels(true);
     try {
-      const models = await fetchModelsForConfig(baseUrl.trim(), apiKey.trim(), undefined, undefined, "anthropic");
+      const models = await fetchModelsForConfig(
+        baseUrl.trim(),
+        apiKey.trim(),
+        undefined,
+        undefined,
+        "anthropic",
+      );
       setFetchedModels(models);
       toast.success(
         t("providerForm.fetchModelsSuccess", {

--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -496,7 +496,7 @@ export function ClaudeDesktopProviderForm({
 
     setIsFetchingModels(true);
     try {
-      const models = await fetchModelsForConfig(baseUrl.trim(), apiKey.trim());
+      const models = await fetchModelsForConfig(baseUrl.trim(), apiKey.trim(), undefined, undefined, "anthropic");
       setFetchedModels(models);
       toast.success(
         t("providerForm.fetchModelsSuccess", {

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -251,7 +251,7 @@ export function ClaudeFormFields({
     const modelsUrl = matchedPreset?.modelsUrl;
 
     setIsFetchingModels(true);
-    fetchModelsForConfig(baseUrl, apiKey, isFullUrl, modelsUrl)
+    fetchModelsForConfig(baseUrl, apiKey, isFullUrl, modelsUrl, "anthropic")
       .then((models) => {
         setFetchedModels(models);
         showModelFetchResult(models.length);

--- a/src/lib/api/model-fetch.ts
+++ b/src/lib/api/model-fetch.ts
@@ -8,22 +8,35 @@ export interface FetchedModel {
 }
 
 /**
+ * 模型拉取认证策略
+ *
+ * - `bearer`：OpenAI 风格，Authorization: Bearer
+ * - `anthropic`：Anthropic 风格，x-api-key + anthropic-version
+ * - `google_api_key`：Gemini 风格，x-goog-api-key
+ */
+export type ModelFetchStrategy = "bearer" | "anthropic" | "google_api_key";
+
+/**
  * 从供应商获取可用模型列表
  *
  * 使用 OpenAI 兼容的 GET /v1/models 端点。优先用 `modelsUrl` 精确覆写；
  * 否则后端会对 baseURL 生成候选列表并按序尝试（含"剥离 /anthropic 等兼容子路径"兜底）。
+ *
+ * @param strategy 认证策略，默认 `"bearer"`。Anthropic 端点应传 `"anthropic"`。
  */
 export async function fetchModelsForConfig(
   baseUrl: string,
   apiKey: string,
   isFullUrl?: boolean,
   modelsUrl?: string,
+  strategy?: ModelFetchStrategy,
 ): Promise<FetchedModel[]> {
   return invoke("fetch_models_for_config", {
     baseUrl,
     apiKey,
     isFullUrl,
     modelsUrl,
+    strategy,
   });
 }
 


### PR DESCRIPTION
## Problem

When configuring an Anthropic-compatible provider (e.g., `api.anthropic.com` or third-party providers using the Anthropic protocol), clicking "Fetch Models" returns **HTTP 401 Unauthorized**.

The `fetch_models` function only sends `Authorization: Bearer <key>`, but Anthropic's API requires:
- `x-api-key: <key>` (primary authentication)
- `anthropic-version: 2023-06-01` (required version header)

Fixes #3738

## Changes

### 1. Introduce `ModelFetchStrategy` enum (`src-tauri/src/services/model_fetch.rs`)

Three variants controlling auth headers and URL candidate ordering:
- **`Bearer`** (default) — OpenAI style: `Authorization: Bearer <key>`
- **`Anthropic`** — Anthropic style: `Authorization` + `x-api-key` + `anthropic-version`
- **`GoogleApiKey`** — Gemini style: `x-goog-api-key`

### 2. Strategy-aware auth headers

`fetch_models()` now sends provider-appropriate headers based on the strategy, instead of always sending only `Authorization: Bearer`.

### 3. Strategy-aware URL candidate ordering

`build_models_url_candidates()` now uses the strategy to determine URL ordering when the base URL doesn't contain a version segment.

### 4. Frontend integration

- Claude form (`ClaudeFormFields.tsx`) and Claude Desktop form (`ClaudeDesktopProviderForm.tsx`) now pass `"anthropic"` strategy
- TypeScript API wrapper (`model-fetch.ts`) exposes the `strategy` parameter
- Other forms (Codex, Gemini, OpenCode, etc.) continue using the default `"bearer"` strategy

### 5. New unit tests

- `test_anthropic_prefers_v1_models` — verifies Anthropic strategy URL ordering
- `test_bearer_prefers_v1_models` — verifies Bearer strategy URL ordering

## Reference

This issue was also fixed in the downstream fork:
- https://github.com/SaladDay/cc-switch-cli/pull/227