### PR TITLE
fix(provider): show terminal launch feedback immediately

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -773,12 +773,19 @@ function App() {
   };
 
   const handleOpenTerminal = async (provider: Provider) => {
+    let openingToastId: string | number | undefined;
+
     try {
       const selectedDir = await settingsApi.pickDirectory();
       if (!selectedDir) {
         return;
       }
 
+      openingToastId = toast.info(
+        t("provider.terminalOpening", {
+          defaultValue: "正在打开终端...",
+        }),
+      );
       await providersApi.openTerminal(provider.id, activeApp, {
         cwd: selectedDir,
       });
@@ -786,9 +793,13 @@ function App() {
         t("provider.terminalOpened", {
           defaultValue: "终端已打开",
         }),
+        { id: openingToastId },
       );
     } catch (error) {
       console.error("[App] Failed to open terminal", error);
+      if (openingToastId !== undefined) {
+        toast.dismiss(openingToastId);
+      }
       const errorMessage = extractErrorMessage(error);
       toast.error(
         t("provider.terminalOpenFailed", {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -145,6 +145,7 @@
     "managedByHermes": "Hermes Managed",
     "managedByHermesHint": "Defined in Hermes' providers: dict. Edit or remove it via Hermes Web UI.",
     "openTerminal": "Open Terminal",
+    "terminalOpening": "Opening terminal...",
     "terminalOpened": "Terminal opened",
     "terminalOpenFailed": "Failed to open terminal",
     "name": "Provider Name",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -145,6 +145,7 @@
     "managedByHermes": "Hermes 管理",
     "managedByHermesHint": "Hermes の providers: dict で定義されています。Hermes Web UI で編集または削除してください。",
     "openTerminal": "ターミナルを開く",
+    "terminalOpening": "ターミナルを開いています...",
     "terminalOpened": "ターミナルを開きました",
     "terminalOpenFailed": "ターミナルを開けませんでした",
     "name": "プロバイダー名",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -145,6 +145,7 @@
     "managedByHermes": "Hermes 託管",
     "managedByHermesHint": "該專案定義於 Hermes 的 providers: dict，請在 Hermes Web UI 中編輯或刪除。",
     "openTerminal": "開啟終端機",
+    "terminalOpening": "正在開啟終端機...",
     "terminalOpened": "終端機已開啟",
     "terminalOpenFailed": "開啟終端機失敗",
     "name": "供應商名稱",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -145,6 +145,7 @@
     "managedByHermes": "Hermes 托管",
     "managedByHermesHint": "该条目定义在 Hermes 的 providers: dict，请在 Hermes Web UI 中编辑或删除。",
     "openTerminal": "打开终端",
+    "terminalOpening": "正在打开终端...",
     "terminalOpened": "终端已打开",
     "terminalOpenFailed": "打开终端失败",
     "name": "供应商名称",


### PR DESCRIPTION
## Summary

Show feedback as soon as the user picks a directory and cc-switch starts opening a provider terminal.

The first version left an `Opening terminal...` toast visible when `openTerminal` failed, so users could see both "Opening terminal..." and "Failed to open terminal" at the same time. This update tracks the toast id: success reuses that toast for `Terminal opened`, and failure dismisses it before showing the error.

This keeps the useful immediate feedback without changing the failure path into mixed messages.

## Related Issue

No linked issue.

## Screenshots

Not captured; this is toast behavior only.

## Checklist

- [x] Opening feedback appears right after directory selection
- [x] Success updates the same toast to `terminalOpened`
- [x] Failure dismisses the opening toast before `terminalOpenFailed`
- [x] Added i18n strings for the opening state

## Verification

- `node .\node_modules\typescript\bin\tsc --noEmit`
- `node .\node_modules\prettier\bin\prettier.cjs --check "src/**/*.{js,jsx,ts,tsx,css,json}"`
- `git diff --check`