### PR TITLE
fix(proxy): preserve Codex OAuth auth token on takeover

### DIFF
--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -184,8 +184,8 @@ impl ProxyService {
                 }
             }
             ClaudeTakeoverAuthPolicy::ManagedAccount => {
-                let should_preserve_auth_token = preserve_auth_token_for_codex
-                    && env.contains_key("ANTHROPIC_AUTH_TOKEN");
+                let should_preserve_auth_token =
+                    preserve_auth_token_for_codex && env.contains_key("ANTHROPIC_AUTH_TOKEN");
                 for key in token_keys {
                     if should_preserve_auth_token && key == "ANTHROPIC_AUTH_TOKEN" {
                         env.insert(key.to_string(), json!(PROXY_TOKEN_PLACEHOLDER));

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -106,6 +106,7 @@ impl ProxyService {
             proxy_url,
             auth_policy,
             takeover_model_fields,
+            provider.is_codex_oauth(),
         );
     }
 
@@ -122,6 +123,7 @@ impl ProxyService {
             proxy_url,
             auth_policy,
             takeover_model_fields,
+            false,
         );
     }
 
@@ -130,6 +132,7 @@ impl ProxyService {
         proxy_url: &str,
         auth_policy: ClaudeTakeoverAuthPolicy,
         takeover_model_fields: Vec<(&'static str, String)>,
+        preserve_auth_token_for_codex: bool,
     ) {
         if !config.is_object() {
             *config = json!({});
@@ -181,8 +184,14 @@ impl ProxyService {
                 }
             }
             ClaudeTakeoverAuthPolicy::ManagedAccount => {
+                let should_preserve_auth_token = preserve_auth_token_for_codex
+                    && env.contains_key("ANTHROPIC_AUTH_TOKEN");
                 for key in token_keys {
-                    env.remove(key);
+                    if should_preserve_auth_token && key == "ANTHROPIC_AUTH_TOKEN" {
+                        env.insert(key.to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
+                    } else {
+                        env.remove(key);
+                    }
                 }
                 env.insert(
                     "ANTHROPIC_API_KEY".to_string(),
@@ -2845,7 +2854,7 @@ mod tests {
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-4-8"));
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME", Some("gpt-5.4"));
         assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
-        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", None);
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
     }
 
     #[test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -48,7 +48,7 @@ const CLAUDE_ONE_M_MARKER_FOR_CLIENT: &str = "[1M]";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ClaudeTakeoverAuthPolicy {
     PreserveExistingOrAuthToken,
-    ManagedAccount,
+    ManagedAccount { keep_auth_token: bool },
 }
 
 #[derive(Clone)]
@@ -90,7 +90,12 @@ impl ProxyService {
         provider: &Provider,
     ) {
         let auth_policy = if provider.uses_managed_account_auth() {
-            ClaudeTakeoverAuthPolicy::ManagedAccount
+            // Codex 系（含仅凭 base_url 识别、无 provider_type meta 的）必须保留
+            // ANTHROPIC_AUTH_TOKEN 占位符：Claude Code 缺该键会弹登录提示（#3784）。
+            // Copilot 维持仅 API_KEY 占位，避免与 /login 管理的 key 冲突（#1049）。
+            ClaudeTakeoverAuthPolicy::ManagedAccount {
+                keep_auth_token: !provider.is_github_copilot(),
+            }
         } else {
             ClaudeTakeoverAuthPolicy::PreserveExistingOrAuthToken
         };
@@ -106,7 +111,6 @@ impl ProxyService {
             proxy_url,
             auth_policy,
             takeover_model_fields,
-            provider.is_codex_oauth(),
         );
     }
 
@@ -123,7 +127,6 @@ impl ProxyService {
             proxy_url,
             auth_policy,
             takeover_model_fields,
-            false,
         );
     }
 
@@ -132,7 +135,6 @@ impl ProxyService {
         proxy_url: &str,
         auth_policy: ClaudeTakeoverAuthPolicy,
         takeover_model_fields: Vec<(&'static str, String)>,
-        preserve_auth_token_for_codex: bool,
     ) {
         if !config.is_object() {
             *config = json!({});
@@ -183,20 +185,22 @@ impl ProxyService {
                     );
                 }
             }
-            ClaudeTakeoverAuthPolicy::ManagedAccount => {
-                let should_preserve_auth_token =
-                    preserve_auth_token_for_codex && env.contains_key("ANTHROPIC_AUTH_TOKEN");
+            ClaudeTakeoverAuthPolicy::ManagedAccount { keep_auth_token } => {
                 for key in token_keys {
-                    if should_preserve_auth_token && key == "ANTHROPIC_AUTH_TOKEN" {
-                        env.insert(key.to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
-                    } else {
-                        env.remove(key);
-                    }
+                    env.remove(key);
                 }
                 env.insert(
                     "ANTHROPIC_API_KEY".to_string(),
                     json!(PROXY_TOKEN_PLACEHOLDER),
                 );
+                if keep_auth_token {
+                    // 无条件注入而非"已存在才保留"：热切换路径传入的是 provider
+                    // settings（预设不含该键），且旧版接管已把存量用户 live 中的键删光。
+                    env.insert(
+                        "ANTHROPIC_AUTH_TOKEN".to_string(),
+                        json!(PROXY_TOKEN_PLACEHOLDER),
+                    );
+                }
             }
         }
     }
@@ -2855,6 +2859,108 @@ mod tests {
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME", Some("gpt-5.4"));
         assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
         assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+    }
+
+    #[test]
+    fn managed_account_claude_takeover_codex_injects_auth_token_without_preexisting_key() {
+        let mut provider = Provider::with_id(
+            "codex".to_string(),
+            "Codex".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://chatgpt.com/backend-api/codex"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            ..Default::default()
+        });
+
+        // 全新安装/热切换形态：传入的 env 没有任何 token 键。
+        let mut live_config = provider.settings_config.clone();
+        ProxyService::apply_claude_takeover_fields_for_provider(
+            &mut live_config,
+            "http://127.0.0.1:15721",
+            &provider,
+        );
+
+        let env = live_config
+            .get("env")
+            .and_then(|value| value.as_object())
+            .expect("env should exist");
+        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+    }
+
+    #[test]
+    fn managed_account_claude_takeover_codex_by_base_url_keeps_auth_token() {
+        // 无 provider_type meta、仅凭 base_url 识别为受管 codex 的供应商，
+        // 也必须保留 AUTH_TOKEN 占位符（与策略选择共用同一判定族）。
+        let provider = Provider::with_id(
+            "codex-url-only".to_string(),
+            "Codex (URL only)".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://chatgpt.com/backend-api/codex"
+                }
+            }),
+            None,
+        );
+        assert!(provider.uses_managed_account_auth());
+        assert!(!provider.is_codex_oauth());
+
+        let mut live_config = provider.settings_config.clone();
+        ProxyService::apply_claude_takeover_fields_for_provider(
+            &mut live_config,
+            "http://127.0.0.1:15721",
+            &provider,
+        );
+
+        let env = live_config
+            .get("env")
+            .and_then(|value| value.as_object())
+            .expect("env should exist");
+        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+    }
+
+    #[test]
+    fn managed_account_claude_takeover_copilot_removes_stale_auth_token() {
+        let mut provider = Provider::with_id(
+            "copilot".to_string(),
+            "GitHub Copilot".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.githubcopilot.com"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            provider_type: Some("github_copilot".to_string()),
+            ..Default::default()
+        });
+
+        let mut live_config = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://stale.example.com",
+                "ANTHROPIC_AUTH_TOKEN": "stale-token"
+            }
+        });
+        ProxyService::apply_claude_takeover_fields_for_provider(
+            &mut live_config,
+            "http://127.0.0.1:15721",
+            &provider,
+        );
+
+        let env = live_config
+            .get("env")
+            .and_then(|value| value.as_object())
+            .expect("env should exist");
+        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

修复 Claude Code + Codex OAuth + Claude takeover 场景下，`ANTHROPIC_AUTH_TOKEN` 被 managed account takeover 强制删除后导致 Claude Code 弹出登录提示的问题。

本 PR 保持现有 `ManagedAccount` / 非 `ManagedAccount` 两态分流不变，仅在 managed 分支内对 Codex OAuth 做最小特例处理：

- GitHub Copilot 行为不变：继续删除 `ANTHROPIC_AUTH_TOKEN`，并写入 `ANTHROPIC_API_KEY = PROXY_MANAGED`
- Codex OAuth 行为调整：如果 live config 已存在 `ANTHROPIC_AUTH_TOKEN`，则保留该字段并将值替换为 `PROXY_MANAGED`
- 非 managed provider 行为不变
- 更新 Codex OAuth takeover 测试断言，保留 Copilot 回归断言

## Related Issue / 关联 Issue

Fixes #3784

## Screenshots / 截图

- Step 1. 选择一个非codex账号（非ManagedAccount场景），开启takeover及本地路由，查看settings.json
<img width="1687" height="111" alt="image" src="https://github.com/user-attachments/assets/24cb839a-7dbb-41a5-b04d-f688b9642c82" />
<img width="827" height="639" alt="image" src="https://github.com/user-attachments/assets/d67d6326-7060-483e-b43d-d2bb37d82ad1" />

- Step 2. 更换选择为codex provider，保持takeover及本地路由，查看settings.json, 正确注入auth占位符
<img width="1710" height="1049" alt="image" src="https://github.com/user-attachments/assets/0d5dff64-9638-4112-bb70-cf12f601f4f7" />

<img width="772" height="578" alt="image" src="https://github.com/user-attachments/assets/d6908406-9fd2-4b96-87f2-c88657fec8ed" />

- Step3. 启动cc

<img width="595" height="377" alt="image" src="https://github.com/user-attachments/assets/6ec44f3b-261d-42ab-9dbc-f3dc99184788" />
<img width="1690" height="210" alt="image" src="https://github.com/user-attachments/assets/d252383e-3650-4082-98e3-97964bc4d7cc" />

日志如下
<img width="1659" height="611" alt="image" src="https://github.com/user-attachments/assets/6fb67ac7-2b22-47ac-8492-5cb7e986ccf9" />



## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

Additional verification / 额外验证：

- [x] `cargo test managed_account_claude_takeover --manifest-path src-tauri/Cargo.toml`
- [x] End-to-end Codex OAuth scenario tested manually
