### PR TITLE
fix: 修复Windows退出托盘图标残留问题

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1460,6 +1460,11 @@ pub fn run() {
             tauri::async_runtime::spawn(async move {
                 save_window_state_before_exit(&app_handle);
                 cleanup_before_exit(&app_handle).await;
+                // 先于 std::process::exit 显式移除托盘图标。
+                // 进程直接退出时 Tauri 运行时不走正常 Drop 流程，
+                // 不会向 Windows Shell 发送 NIM_DELETE，导致已退出的进程
+                // 注册的图标仍残留在系统托盘（鼠标悬停 Shell 才会重绘发现进程已死）。
+                remove_tray_icon_before_exit(&app_handle);
                 log::info!("清理完成，退出应用");
 
                 // 短暂等待确保所有 I/O 操作（如数据库写入）刷新到磁盘
@@ -1603,6 +1608,26 @@ pub async fn cleanup_before_exit(app_handle: &tauri::AppHandle) {
                 log::error!("退出时停止代理失败: {e}");
             }
             log::info!("代理服务器清理完成");
+        }
+    }
+}
+
+/// 主动从系统托盘移除托盘图标。
+///
+/// `std::process::exit` 会绕过 Tauri 运行时，触发不了 `TrayIcon::drop()`，
+/// 也就不会向 Windows Shell 发 `NIM_DELETE`。结果是进程退出后托盘里
+/// 仍保留一个死图标的缓存占位（Shell 不会主动重绘，需要鼠标悬停才刷新）。
+///
+/// 通过 `set_visible(false)` 走 `WM_USER_HIDE_TRAYICON` 消息路径，
+/// 触发 tray-icon 内部的 `remove_tray_icon` → `Shell_NotifyIconW(NIM_DELETE)`，
+/// 在进程结束前干净地把图标摘掉。其它平台 `set_visible(false)` 也是
+/// 正常的隐藏/移除语义，作为跨平台兜底也安全。
+fn remove_tray_icon_before_exit(app_handle: &tauri::AppHandle) {
+    if let Some(tray) = app_handle.tray_by_id(tray::TRAY_ID) {
+        if let Err(e) = tray.set_visible(false) {
+            log::warn!("退出时移除托盘图标失败: {e}");
+        } else {
+            log::info!("已显式从系统托盘移除图标");
         }
     }
 }


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

fix: 修复Windows退出托盘图标残留问题
进程退出后托盘里
仍保留一个死图标的缓存占位（Shell 不会主动重绘，需要鼠标悬停才刷新）。

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
