### PR TITLE
feat(proxy): add GET /v1/models endpoint for Codex CLI reachability check

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -766,7 +766,10 @@ pub fn read_codex_model_catalog_simplified_from_live() -> Result<Option<Value>, 
 /// Given `config.toml` text, resolve the on-disk path of the cc-switch–owned
 /// catalog file (returns `None` if `model_catalog_json` is absent or points at
 /// a file we don't own). Relative paths fall back to `generated_path`.
-fn resolve_cc_switch_catalog_path(config_text: &str, generated_path: &Path) -> Option<PathBuf> {
+pub(crate) fn resolve_cc_switch_catalog_path(
+    config_text: &str,
+    generated_path: &Path,
+) -> Option<PathBuf> {
     if config_text.trim().is_empty() {
         return None;
     }

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -68,9 +68,23 @@ pub async fn get_status(State(state): State<ProxyState>) -> Result<Json<ProxySta
 /// catalog with a top-level `models` field.  Return the cc-switch–managed model
 /// catalog file directly so the format always matches what the current version
 /// of Codex expects.
+///
+/// Only serves the catalog when the live config.toml still references it via
+/// `model_catalog_json` — avoids advertising stale models after a provider
+/// switch removes the catalog entry.
 pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
     let catalog_path = crate::codex_config::get_codex_model_catalog_path();
-    let catalog = if catalog_path.exists() {
+
+    // Guard: don't serve a stale catalog if config.toml no longer references it
+    let catalog_still_active = match crate::codex_config::read_codex_config_text() {
+        Ok(config_text) => {
+            let catalog_str = catalog_path.to_string_lossy();
+            config_text.contains(&*catalog_str)
+        }
+        Err(_) => false,
+    };
+
+    let catalog = if catalog_still_active && catalog_path.exists() {
         let text = std::fs::read_to_string(&catalog_path).unwrap_or_default();
         serde_json::from_str(&text).unwrap_or(json!({"models": []}))
     } else {

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -70,17 +70,17 @@ pub async fn get_status(State(state): State<ProxyState>) -> Result<Json<ProxySta
 /// of Codex expects.
 ///
 /// Only serves the catalog when the live config.toml still references it via
-/// `model_catalog_json` — avoids advertising stale models after a provider
-/// switch removes the catalog entry.
+/// `model_catalog_json`.  cc-switch writes a relative path (just the filename)
+/// so we match on the filename rather than the full path.
 pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
+    use crate::codex_config::CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME;
+
     let catalog_path = crate::codex_config::get_codex_model_catalog_path();
 
-    // Guard: don't serve a stale catalog if config.toml no longer references it
+    // Guard: cc-switch writes model_catalog_json as a relative filename
+    // (e.g. "cc-switch-model-catalog.json"), so match on the filename.
     let catalog_still_active = match crate::codex_config::read_codex_config_text() {
-        Ok(config_text) => {
-            let catalog_str = catalog_path.to_string_lossy();
-            config_text.contains(&*catalog_str)
-        }
+        Ok(config_text) => config_text.contains(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME),
         Err(_) => false,
     };
 

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -62,41 +62,21 @@ pub async fn get_status(State(state): State<ProxyState>) -> Result<Json<ProxySta
     Ok(Json(status))
 }
 
-/// GET /v1/models — OpenAI-compatible model list (Codex CLI reachability check)
+/// GET /v1/models — Codex model list (reachability check)
 ///
-/// Codex CLI probes this endpoint at startup. Returns model entries derived
-/// from the cc-switch–managed model catalog file.
+/// Codex CLI probes this endpoint at startup and deserializes the response as a
+/// catalog with a top-level `models` field.  Return the cc-switch–managed model
+/// catalog file directly so the format always matches what the current version
+/// of Codex expects.
 pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
     let catalog_path = crate::codex_config::get_codex_model_catalog_path();
-    let models: Vec<Value> = if catalog_path.exists() {
+    let catalog = if catalog_path.exists() {
         let text = std::fs::read_to_string(&catalog_path).unwrap_or_default();
-        let catalog: Value = serde_json::from_str(&text).unwrap_or_default();
-        catalog
-            .get("models")
-            .and_then(|m| m.as_array())
-            .cloned()
-            .unwrap_or_default()
+        serde_json::from_str(&text).unwrap_or(json!({"models": []}))
     } else {
-        Vec::new()
+        json!({"models": []})
     };
-
-    let data: Vec<Value> = models
-        .iter()
-        .map(|m| {
-            let id = m
-                .get("slug")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            json!({
-                "id": id,
-                "object": "model",
-                "created": 1700000000,
-                "owned_by": "custom"
-            })
-        })
-        .collect();
-
-    Ok(Json(json!({"object": "list", "data": data})))
+    Ok(Json(catalog))
 }
 
 // ============================================================================

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -62,6 +62,43 @@ pub async fn get_status(State(state): State<ProxyState>) -> Result<Json<ProxySta
     Ok(Json(status))
 }
 
+/// GET /v1/models — OpenAI-compatible model list (Codex CLI reachability check)
+///
+/// Codex CLI probes this endpoint at startup. Returns model entries derived
+/// from the cc-switch–managed model catalog file.
+pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
+    let catalog_path = crate::codex_config::get_codex_model_catalog_path();
+    let models: Vec<Value> = if catalog_path.exists() {
+        let text = std::fs::read_to_string(&catalog_path).unwrap_or_default();
+        let catalog: Value = serde_json::from_str(&text).unwrap_or_default();
+        catalog
+            .get("models")
+            .and_then(|m| m.as_array())
+            .cloned()
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    let data: Vec<Value> = models
+        .iter()
+        .map(|m| {
+            let id = m
+                .get("slug")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            json!({
+                "id": id,
+                "object": "model",
+                "created": 1700000000,
+                "owned_by": "custom"
+            })
+        })
+        .collect();
+
+    Ok(Json(json!({"object": "list", "data": data})))
+}
+
 // ============================================================================
 // Claude API 处理器（包含格式转换逻辑）
 // ============================================================================

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -73,14 +73,25 @@ pub async fn get_status(State(state): State<ProxyState>) -> Result<Json<ProxySta
 /// `model_catalog_json`.  cc-switch writes a relative path (just the filename)
 /// so we match on the filename rather than the full path.
 pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
-    use crate::codex_config::CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME;
-
     let catalog_path = crate::codex_config::get_codex_model_catalog_path();
 
-    // Guard: cc-switch writes model_catalog_json as a relative filename
-    // (e.g. "cc-switch-model-catalog.json"), so match on the filename.
+    // Guard: parse config.toml and inspect the actual model_catalog_json
+    // field so a commented-out line or stray mention of the filename in
+    // another field does not trick the check.  Use exact filename match to
+    // stay consistent with resolve_cc_switch_catalog_path in codex_config.rs.
     let catalog_still_active = match crate::codex_config::read_codex_config_text() {
-        Ok(config_text) => config_text.contains(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME),
+        Ok(config_text) => match config_text.parse::<toml_edit::DocumentMut>() {
+            Ok(doc) => doc
+                .get("model_catalog_json")
+                .and_then(|item| item.as_str())
+                .is_some_and(|val| {
+                    std::path::Path::new(val).file_name()
+                        == Some(std::ffi::OsStr::new(
+                            crate::codex_config::CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME,
+                        ))
+                }),
+            Err(_) => false,
+        },
         Err(_) => false,
     };
 
@@ -88,6 +99,11 @@ pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
         let text = std::fs::read_to_string(&catalog_path).unwrap_or_default();
         serde_json::from_str(&text).unwrap_or(json!({"models": []}))
     } else {
+        if !catalog_still_active {
+            log::debug!(
+                "[models] stale guard: catalog not served (model_catalog_json not set to cc-switch catalog)"
+            );
+        }
         json!({"models": []})
     };
     Ok(Json(catalog))

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -69,37 +69,25 @@ pub async fn get_status(State(state): State<ProxyState>) -> Result<Json<ProxySta
 /// catalog file directly so the format always matches what the current version
 /// of Codex expects.
 ///
-/// Only serves the catalog when the live config.toml still references it via
-/// `model_catalog_json`.  cc-switch writes a relative path (just the filename)
-/// so we match on the filename rather than the full path.
+/// Only serves the catalog when the live config.toml still references the
+/// cc-switch–owned `model_catalog_json`, using the same path ownership rules as
+/// Codex live-setting import.
 pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
-    let catalog_path = crate::codex_config::get_codex_model_catalog_path();
-
-    // Guard: parse config.toml and inspect the actual model_catalog_json
-    // field so a commented-out line or stray mention of the filename in
-    // another field does not trick the check.  Use exact filename match to
-    // stay consistent with resolve_cc_switch_catalog_path in codex_config.rs.
-    let catalog_still_active = match crate::codex_config::read_codex_config_text() {
-        Ok(config_text) => match config_text.parse::<toml_edit::DocumentMut>() {
-            Ok(doc) => doc
-                .get("model_catalog_json")
-                .and_then(|item| item.as_str())
-                .is_some_and(|val| {
-                    std::path::Path::new(val).file_name()
-                        == Some(std::ffi::OsStr::new(
-                            crate::codex_config::CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME,
-                        ))
-                }),
-            Err(_) => false,
-        },
-        Err(_) => false,
+    let generated_path = crate::codex_config::get_codex_model_catalog_path();
+    let active_catalog_path = match crate::codex_config::read_codex_config_text() {
+        Ok(config_text) => {
+            crate::codex_config::resolve_cc_switch_catalog_path(&config_text, &generated_path)
+        }
+        Err(_) => None,
     };
 
-    let catalog = if catalog_still_active && catalog_path.exists() {
-        let text = std::fs::read_to_string(&catalog_path).unwrap_or_default();
+    let catalog = if let Some(catalog_path) =
+        active_catalog_path.as_ref().filter(|path| path.exists())
+    {
+        let text = std::fs::read_to_string(catalog_path).unwrap_or_default();
         serde_json::from_str(&text).unwrap_or(json!({"models": []}))
     } else {
-        if !catalog_still_active {
+        if active_catalog_path.is_none() {
             log::debug!(
                 "[models] stale guard: catalog not served (model_catalog_json not set to cc-switch catalog)"
             );

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -315,6 +315,9 @@ impl ProxyServer {
                 "/codex/v1/chat/completions",
                 post(handlers::handle_chat_completions),
             )
+            // OpenAI Models API (Codex CLI reachability check)
+            .route("/models", get(handlers::handle_models))
+            .route("/v1/models", get(handlers::handle_models))
             // OpenAI Responses API (Codex CLI，支持带前缀和不带前缀)
             .route("/responses", post(handlers::handle_responses))
             .route("/v1/responses", post(handlers::handle_responses))


### PR DESCRIPTION
## Summary

Add a `GET /v1/models` endpoint. Codex CLI probes this endpoint at startup — without it cc-switch returns 404, causing Codex to fail before any request reaches the upstream LLM.

The handler returns the cc-switch–managed model catalog file directly (`~/.codex/cc-switch-model-catalog.json`), gated on `config.toml` still referencing the catalog via `model_catalog_json`. This prevents serving stale models after switching to a provider without a custom catalog.

## Verification

Codex doctor sends exactly one request — `GET /v1/models` — and only checks the HTTP status code (200 vs 404). Response body format does not affect the reachability check.

| Setup | `/v1/models` | codex doctor |
|-------|-------------|-------------|
| cc-switch directly (127.0.0.1:15721) | 404 (route missing) | fail |
| With this PR | 200 + model catalog | pass |

## Related Issue

Fixes #3812

## Changes

- `src-tauri/src/proxy/server.rs`: register `GET /v1/models` and `GET /models` routes (+3 lines)
- `src-tauri/src/proxy/handlers.rs`: new `handle_models()` handler with stale-catalog guard (+20 lines)

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --no-deps` passes (zero warnings)
- [x] `cargo test -p cc-switch -- proxy` — 837 passed, 5 pre-existing failures (port 15721 in use by running cc-switch)
- [x] No frontend changes (`pnpm typecheck` / `pnpm format:check` not applicable)
- [x] No user-facing text changed (no i18n needed)