### PR TITLE
feat: provider support Codex WebSocket

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1141,6 +1141,8 @@ pub fn restore_codex_settings_for_backfill(
 ///   otherwise falls back to top-level `base_url`.
 /// - `"wire_api"`: writes to `[model_providers.<current>].wire_api` if `model_provider` exists,
 ///   otherwise falls back to top-level `wire_api`.
+/// - `"supports_websockets"`: writes to `[model_providers.<current>].supports_websockets` as a
+///   TOML boolean if `model_provider` exists, otherwise falls back to top-level.
 /// - `"model"` / `"model_catalog_json"`: writes to top-level field.
 ///
 /// Empty value removes the field.
@@ -1152,7 +1154,7 @@ pub fn update_codex_toml_field(toml_str: &str, field: &str, value: &str) -> Resu
     let trimmed = value.trim();
 
     match field {
-        "base_url" | "wire_api" => {
+        "base_url" | "wire_api" | "supports_websockets" => {
             let model_provider = doc
                 .get("model_provider")
                 .and_then(|item| item.as_str())
@@ -1173,6 +1175,12 @@ pub fn update_codex_toml_field(toml_str: &str, field: &str, value: &str) -> Resu
                     if let Some(provider_table) = model_providers[&provider_key].as_table_mut() {
                         if trimmed.is_empty() {
                             provider_table.remove(field);
+                        } else if field == "supports_websockets" {
+                            let value = trimmed
+                                .parse::<bool>()
+                                .map_err(|_| format!("{field} must be true or false"))?;
+                            provider_table[field] = toml_edit::value(value);
+                            doc.as_table_mut().remove(field);
                         } else {
                             provider_table[field] = toml_edit::value(trimmed);
                         }
@@ -1184,6 +1192,11 @@ pub fn update_codex_toml_field(toml_str: &str, field: &str, value: &str) -> Resu
             // Fallback: no model_provider or structure mismatch → top-level field
             if trimmed.is_empty() {
                 doc.as_table_mut().remove(field);
+            } else if field == "supports_websockets" {
+                let value = trimmed
+                    .parse::<bool>()
+                    .map_err(|_| format!("{field} must be true or false"))?;
+                doc[field] = toml_edit::value(value);
             } else {
                 doc[field] = toml_edit::value(trimmed);
             }
@@ -1451,6 +1464,7 @@ wire_api = "responses"
     fn base_url_writes_into_correct_model_provider_section() {
         let input = r#"model_provider = "any"
 model = "gpt-5.1-codex"
+supports_websockets = false
 
 [model_providers.any]
 name = "any"
@@ -1458,6 +1472,7 @@ wire_api = "responses"
 "#;
 
         let result = update_codex_toml_field(input, "base_url", "https://example.com/v1").unwrap();
+        let result = update_codex_toml_field(&result, "supports_websockets", "true").unwrap();
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         let base_url = parsed
@@ -1468,8 +1483,17 @@ wire_api = "responses"
             .expect("base_url should be in model_providers.any");
         assert_eq!(base_url, "https://example.com/v1");
 
+        let supports_websockets = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("any"))
+            .and_then(|v| v.get("supports_websockets"))
+            .and_then(|v| v.as_bool())
+            .expect("supports_websockets should be in model_providers.any");
+        assert_eq!(supports_websockets, true);
+
         // Should NOT have top-level base_url
         assert!(parsed.get("base_url").is_none());
+        assert!(parsed.get("supports_websockets").is_none());
 
         // wire_api preserved
         let wire_api = parsed
@@ -1511,12 +1535,27 @@ wire_api = "chat"
     }
 
     #[test]
+    fn supports_websockets_rejects_non_boolean_values() {
+        let input = r#"model_provider = "custom"
+
+[model_providers.custom]
+name = "Custom"
+"#;
+
+        let error =
+            update_codex_toml_field(input, "supports_websockets", "yes").expect_err("should fail");
+
+        assert_eq!(error, "supports_websockets must be true or false");
+    }
+
+    #[test]
     fn base_url_creates_section_when_missing() {
         let input = r#"model_provider = "custom"
 model = "gpt-4"
 "#;
 
         let result = update_codex_toml_field(input, "base_url", "https://custom.api/v1").unwrap();
+        let result = update_codex_toml_field(&result, "supports_websockets", "true").unwrap();
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         let base_url = parsed
@@ -1526,6 +1565,15 @@ model = "gpt-4"
             .and_then(|v| v.as_str())
             .expect("should create section and set base_url");
         assert_eq!(base_url, "https://custom.api/v1");
+
+        let supports_websockets = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("custom"))
+            .and_then(|v| v.get("supports_websockets"))
+            .and_then(|v| v.as_bool())
+            .expect("should set supports_websockets");
+        assert_eq!(supports_websockets, true);
+        assert!(parsed.get("supports_websockets").is_none());
     }
 
     #[test]
@@ -1534,13 +1582,20 @@ model = "gpt-4"
 "#;
 
         let result = update_codex_toml_field(input, "base_url", "https://fallback.api/v1").unwrap();
+        let result = update_codex_toml_field(&result, "supports_websockets", "false").unwrap();
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         let base_url = parsed
             .get("base_url")
             .and_then(|v| v.as_str())
             .expect("should set top-level base_url");
+        let supports_websockets = parsed
+            .get("supports_websockets")
+            .and_then(|v| v.as_bool())
+            .expect("should set top-level supports_websockets");
         assert_eq!(base_url, "https://fallback.api/v1");
+        assert_eq!(supports_websockets, false);
+        assert!(parsed.get("model_providers").is_none());
     }
 
     #[test]
@@ -1550,6 +1605,7 @@ model = "gpt-4"
 [model_providers.any]
 name = "any"
 base_url = "https://old.api/v1"
+supports_websockets = true
 wire_api = "responses"
 
 [mcp_servers.context7]
@@ -1557,14 +1613,16 @@ command = "npx"
 "#;
 
         let result = update_codex_toml_field(input, "base_url", "").unwrap();
+        let result = update_codex_toml_field(&result, "supports_websockets", "").unwrap();
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
-        // base_url removed from model_providers.any
+        // base_url and supports_websockets removed from model_providers.any
         let any_section = parsed
             .get("model_providers")
             .and_then(|v| v.get("any"))
             .expect("model_providers.any should exist");
         assert!(any_section.get("base_url").is_none());
+        assert!(any_section.get("supports_websockets").is_none());
 
         // wire_api preserved
         assert_eq!(

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2270,6 +2270,9 @@ impl ProxyService {
         let mut updated =
             crate::codex_config::update_codex_toml_field(&updated, "wire_api", "responses")
                 .unwrap_or(updated);
+        updated =
+            crate::codex_config::update_codex_toml_field(&updated, "supports_websockets", "false")
+                .unwrap_or(updated);
 
         if let Some(upstream_model) =
             provider.and_then(crate::proxy::providers::codex_provider_upstream_model)
@@ -4051,6 +4054,16 @@ wire_api = "chat"
         assert_eq!(
             provider.get("wire_api").and_then(|v| v.as_str()),
             Some("responses")
+        );
+        assert_eq!(
+            provider
+                .get("supports_websockets")
+                .and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert!(
+            parsed.get("supports_websockets").is_none(),
+            "should not write top-level supports_websockets when model_provider exists"
         );
     }
 

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -63,6 +63,8 @@ interface CodexFormFieldsProps {
   // Note: wire_api is always "responses" for Codex; apiFormat controls proxy-layer conversion
   apiFormat: CodexApiFormat;
   onApiFormatChange: (format: CodexApiFormat) => void;
+  supportsWebSockets: boolean;
+  onSupportsWebSocketsChange: (enabled: boolean) => void;
   codexChatReasoning?: CodexChatReasoning;
   onCodexChatReasoningChange?: (value: CodexChatReasoning) => void;
 
@@ -123,6 +125,8 @@ export function CodexFormFields({
   onAutoSelectChange,
   apiFormat,
   onApiFormatChange,
+  supportsWebSockets,
+  onSupportsWebSocketsChange,
   codexChatReasoning = {},
   onCodexChatReasoningChange,
   catalogModels = [],
@@ -319,6 +323,33 @@ export function CodexFormFields({
           onFullUrlChange={onFullUrlChange}
           onManageClick={() => onEndpointModalToggle(true)}
         />
+      )}
+
+      {shouldShowSpeedTest && (
+        <div className="space-y-3 rounded-lg border border-border-default bg-muted/20 p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <FormLabel>
+                {t("codexConfig.websocketToggle", {
+                  defaultValue: "使用 WebSocket 接入",
+                })}
+              </FormLabel>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {t("codexConfig.websocketHint", {
+                  defaultValue:
+                    "开启后会在当前 model_providers 条目写入 supports_websockets = true；关闭则写入 false。",
+                })}
+              </p>
+            </div>
+            <Switch
+              checked={supportsWebSockets}
+              onCheckedChange={onSupportsWebSocketsChange}
+              aria-label={t("codexConfig.websocketToggle", {
+                defaultValue: "使用 WebSocket 接入",
+              })}
+            />
+          </div>
+        </div>
       )}
 
       {shouldShowSpeedTest && (

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -55,7 +55,9 @@ import {
 } from "@/utils/providerConfigUtils";
 import { mergeProviderMeta } from "@/utils/providerMetaUtils";
 import {
+  extractCodexSupportsWebSockets,
   extractCodexWireApi,
+  setCodexSupportsWebSockets as setCodexSupportsWebSocketsInConfig,
   setCodexWireApi,
   setCodexModelName as setCodexModelNameInConfig,
 } from "@/utils/providerConfigUtils";
@@ -355,6 +357,13 @@ function ProviderFormFull({
       ),
     });
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
+    setCodexSupportsWebSockets(
+      extractCodexSupportsWebSockets(
+        typeof initialData?.settingsConfig?.config === "string"
+          ? initialData.settingsConfig.config
+          : "",
+      ),
+    );
   }, [appId, initialData, supportsFullUrl]);
 
   const defaultValues: ProviderFormData = useMemo(
@@ -544,6 +553,14 @@ function ProviderFormFull({
         ) ?? "openai_responses"
       );
     });
+  const [codexSupportsWebSockets, setCodexSupportsWebSockets] =
+    useState<boolean>(() =>
+      extractCodexSupportsWebSockets(
+        typeof initialData?.settingsConfig?.config === "string"
+          ? initialData.settingsConfig.config
+          : "",
+      ),
+    );
 
   const { configError: codexConfigError, debouncedValidate } =
     useCodexTomlValidation();
@@ -551,9 +568,22 @@ function ProviderFormFull({
   const handleCodexConfigChange = useCallback(
     (value: string) => {
       originalHandleCodexConfigChange(value);
+      setCodexSupportsWebSockets(extractCodexSupportsWebSockets(value));
       debouncedValidate(value);
     },
     [originalHandleCodexConfigChange, debouncedValidate],
+  );
+
+  const handleCodexSupportsWebSocketsChange = useCallback(
+    (enabled: boolean) => {
+      setCodexSupportsWebSockets(enabled);
+      setCodexConfig((prev) => {
+        const updated = setCodexSupportsWebSocketsInConfig(prev, enabled);
+        debouncedValidate(updated);
+        return updated;
+      });
+    },
+    [setCodexConfig, debouncedValidate],
   );
 
   const handleCodexApiFormatChange = useCallback(
@@ -574,6 +604,9 @@ function ProviderFormFull({
       const template = getCodexCustomTemplate();
       resetCodexConfig(template.auth, template.config);
       setCodexChatReasoning({});
+      setCodexSupportsWebSockets(
+        extractCodexSupportsWebSockets(template.config),
+      );
     }
   }, [appId, initialData, selectedPresetId, resetCodexConfig]);
 
@@ -1186,6 +1219,12 @@ function ProviderFormFull({
           category !== "official" && (codexConfig ?? "").trim()
             ? setCodexWireApi(codexConfig ?? "", "responses")
             : (codexConfig ?? "");
+        if (category !== "official" && normalizedCodexConfig.trim()) {
+          normalizedCodexConfig = setCodexSupportsWebSocketsInConfig(
+            normalizedCodexConfig,
+            codexSupportsWebSockets,
+          );
+        }
         const normalizedCatalogModels =
           category !== "official" && localCodexApiFormat === "openai_chat"
             ? normalizeCodexCatalogModelsForSave(codexCatalogModels)
@@ -1524,6 +1563,9 @@ function ProviderFormFull({
         const template = getCodexCustomTemplate();
         resetCodexConfig(template.auth, template.config);
         setCodexChatReasoning({});
+        setCodexSupportsWebSockets(
+          extractCodexSupportsWebSockets(template.config),
+        );
         setLocalCodexApiFormat(
           codexApiFormatFromWireApi(extractCodexWireApi(template.config)) ??
             "openai_responses",
@@ -1565,6 +1607,7 @@ function ProviderFormFull({
 
       resetCodexConfig(auth, config, preset.modelCatalog ?? []);
       setCodexChatReasoning(preset.codexChatReasoning ?? {});
+      setCodexSupportsWebSockets(extractCodexSupportsWebSockets(config));
       setLocalCodexApiFormat(
         preset.apiFormat ??
           codexApiFormatFromWireApi(extractCodexWireApi(config)) ??
@@ -2036,6 +2079,8 @@ function ProviderFormFull({
               onAutoSelectChange={setEndpointAutoSelect}
               apiFormat={localCodexApiFormat}
               onApiFormatChange={handleCodexApiFormatChange}
+              supportsWebSockets={codexSupportsWebSockets}
+              onSupportsWebSocketsChange={handleCodexSupportsWebSocketsChange}
               codexChatReasoning={codexChatReasoning}
               onCodexChatReasoningChange={setCodexChatReasoning}
               catalogModels={codexCatalogModels}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1228,6 +1228,8 @@
     "saveFailed": "Save failed: {{error}}",
     "modelNameHint": "Specify the model to use, will be auto-updated in config.toml",
     "modelName": "Model Name",
+    "websocketToggle": "Use WebSocket access",
+    "websocketHint": "When enabled, writes supports_websockets = true to the active model_providers entry; when disabled, writes false.",
     "localRoutingToggle": "Needs Local Routing",
     "localRoutingOffHint": "If your provider is not native OpenAI Responses API, or the model name is not Codex's default GPT series, please enable this switch.",
     "localRoutingOnHint": "Codex currently only natively supports OpenAI Responses API and GPT series models. If your provider uses the Chat Completions protocol or non-GPT models (such as DeepSeek or Kimi), enable this switch and keep local routing running while in use.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1228,6 +1228,8 @@
     "saveFailed": "保存に失敗しました: {{error}}",
     "modelNameHint": "使用するモデルを指定します。config.toml に自動更新されます",
     "modelName": "モデル名",
+    "websocketToggle": "WebSocket 接続を使用",
+    "websocketHint": "有効にすると現在の model_providers エントリに supports_websockets = true を書き込み、無効にすると false を書き込みます。",
     "localRoutingToggle": "ローカルルーティングが必要",
     "localRoutingOffHint": "プロバイダーがネイティブの OpenAI Responses API でない場合、またはモデル名が Codex デフォルトの GPT 系列でない場合は、このスイッチを有効にしてください。",
     "localRoutingOnHint": "Codex は現在、OpenAI Responses API と GPT 系列モデルのみをネイティブにサポートしています。プロバイダーが Chat Completions プロトコルや非 GPT モデル（DeepSeek、Kimi など）を使用する場合は、このスイッチを有効にし、使用中はローカルルーティングを起動したままにしてください。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1200,6 +1200,8 @@
     "saveFailed": "儲存失敗：{{error}}",
     "modelNameHint": "指定使用的模型，將自動更新到 config.toml 中",
     "modelName": "模型名稱",
+    "websocketToggle": "使用 WebSocket 接入",
+    "websocketHint": "開啟後會在目前 model_providers 條目寫入 supports_websockets = true；關閉則寫入 false。",
     "modelNamePlaceholder": "例如: gpt-5-codex",
     "contextWindow1M": "1M 上下文視窗",
     "autoCompactLimit": "壓縮閾值",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1228,6 +1228,8 @@
     "saveFailed": "保存失败: {{error}}",
     "modelNameHint": "指定使用的模型，将自动更新到 config.toml 中",
     "modelName": "模型名称",
+    "websocketToggle": "使用 WebSocket 接入",
+    "websocketHint": "开启后会在当前 model_providers 条目写入 supports_websockets = true；关闭则写入 false。",
     "localRoutingToggle": "需要本地路由映射",
     "localRoutingOffHint": "如果您的供应商不是原生 OpenAI Responses API，或者模型名不是 Codex 默认的 GPT 系列，请打开此开关。",
     "localRoutingOnHint": "Codex 目前仅原生支持 OpenAI Responses API 与 GPT 系列模型；如果您的供应商使用 Chat Completions 协议或非 GPT 模型（如 DeepSeek、Kimi），则需要打开本开关，并在使用过程中保持本地路由开启。",

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -408,6 +408,8 @@ const TOML_EXPERIMENTAL_BEARER_TOKEN_REPLACE_PATTERN =
 const TOML_MODEL_PATTERN = /^\s*model\s*=\s*(["'])([^"'\r\n]+)\1\s*(?:#.*)?$/;
 const TOML_WIRE_API_PATTERN =
   /^\s*wire_api\s*=\s*(["'])([^"'\r\n]+)\1\s*(?:#.*)?$/;
+const TOML_SUPPORTS_WEBSOCKETS_PATTERN =
+  /^\s*supports_websockets\s*=\s*(true|false)\s*(?:#.*)?$/;
 const TOML_MODEL_PROVIDER_LINE_PATTERN =
   /^\s*model_provider\s*=\s*(["'])([^"'\r\n]+)\1\s*(?:#.*)?$/;
 const TOML_PROVIDER_NAME_PATTERN =
@@ -801,6 +803,150 @@ export const setCodexWireApi = (
   );
   if (topLevelMatch) {
     lines[topLevelMatch.index] = replacementLine;
+    return finalizeTomlText(lines);
+  }
+
+  const modelProviderIndex = getTopLevelModelProviderLineIndex(lines);
+  if (modelProviderIndex !== -1) {
+    lines.splice(modelProviderIndex + 1, 0, replacementLine);
+    return finalizeTomlText(lines);
+  }
+
+  if (lines.length === 0) {
+    return `${replacementLine}\n`;
+  }
+
+  lines.splice(topLevelEndIndex, 0, replacementLine);
+  return finalizeTomlText(lines);
+};
+
+export const extractCodexSupportsWebSockets = (
+  configText: string | undefined | null,
+): boolean => {
+  try {
+    const raw = typeof configText === "string" ? configText : "";
+    const text = normalizeTomlText(raw);
+    if (!text) return false;
+
+    try {
+      const parsed = parseToml(text) as Record<string, any>;
+      const providerId =
+        typeof parsed.model_provider === "string"
+          ? parsed.model_provider.trim()
+          : "";
+      if (providerId) {
+        const value =
+          parsed.model_providers?.[providerId]?.supports_websockets;
+        if (typeof value === "boolean") return value;
+      }
+      if (typeof parsed.supports_websockets === "boolean") {
+        return parsed.supports_websockets;
+      }
+    } catch {
+      // Fall back to line scanning while the user is editing invalid TOML.
+    }
+
+    const lines = text.split("\n");
+    const targetSectionName = getCodexProviderSectionName(text);
+
+    if (targetSectionName) {
+      const sectionRange = getTomlSectionRange(lines, targetSectionName);
+      if (sectionRange) {
+        const index = findTomlLineInRange(
+          lines,
+          TOML_SUPPORTS_WEBSOCKETS_PATTERN,
+          sectionRange.bodyStartIndex,
+          sectionRange.bodyEndIndex,
+        );
+        if (index !== -1) {
+          return (
+            lines[index].match(TOML_SUPPORTS_WEBSOCKETS_PATTERN)?.[1] ===
+            "true"
+          );
+        }
+      }
+    }
+
+    const topLevelIndex = findTomlLineInRange(
+      lines,
+      TOML_SUPPORTS_WEBSOCKETS_PATTERN,
+      0,
+      getTopLevelEndIndex(lines),
+    );
+    if (topLevelIndex !== -1) {
+      return (
+        lines[topLevelIndex].match(TOML_SUPPORTS_WEBSOCKETS_PATTERN)?.[1] ===
+        "true"
+      );
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+export const setCodexSupportsWebSockets = (
+  configText: string,
+  enabled: boolean,
+): string => {
+  const normalizedText = normalizeTomlText(configText);
+  const lines = normalizedText ? normalizedText.split("\n") : [];
+  const targetSectionName = getCodexProviderSectionName(normalizedText);
+  const replacementLine = `supports_websockets = ${enabled ? "true" : "false"}`;
+
+  if (targetSectionName) {
+    let targetSectionRange = getTomlSectionRange(lines, targetSectionName);
+    const targetLine =
+      targetSectionRange &&
+      findTomlLineInRange(
+        lines,
+        TOML_SUPPORTS_WEBSOCKETS_PATTERN,
+        targetSectionRange.bodyStartIndex,
+        targetSectionRange.bodyEndIndex,
+      );
+
+    if (typeof targetLine === "number" && targetLine !== -1) {
+      lines[targetLine] = replacementLine;
+      return finalizeTomlText(lines);
+    }
+
+    const topLevelIndex = findTomlLineInRange(
+      lines,
+      TOML_SUPPORTS_WEBSOCKETS_PATTERN,
+      0,
+      getTopLevelEndIndex(lines),
+    );
+    if (topLevelIndex !== -1) {
+      lines.splice(topLevelIndex, 1);
+      targetSectionRange = getTomlSectionRange(lines, targetSectionName);
+    }
+
+    if (targetSectionRange) {
+      lines.splice(
+        getTomlSectionInsertIndex(lines, targetSectionRange),
+        0,
+        replacementLine,
+      );
+      return finalizeTomlText(lines);
+    }
+
+    if (lines.length > 0 && lines[lines.length - 1].trim() !== "") {
+      lines.push("");
+    }
+    lines.push(`[${targetSectionName}]`, replacementLine);
+    return finalizeTomlText(lines);
+  }
+
+  const topLevelEndIndex = getTopLevelEndIndex(lines);
+  const topLevelIndex = findTomlLineInRange(
+    lines,
+    TOML_SUPPORTS_WEBSOCKETS_PATTERN,
+    0,
+    topLevelEndIndex,
+  );
+  if (topLevelIndex !== -1) {
+    lines[topLevelIndex] = replacementLine;
     return finalizeTomlText(lines);
   }
 

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -835,8 +835,7 @@ export const extractCodexSupportsWebSockets = (
           ? parsed.model_provider.trim()
           : "";
       if (providerId) {
-        const value =
-          parsed.model_providers?.[providerId]?.supports_websockets;
+        const value = parsed.model_providers?.[providerId]?.supports_websockets;
         if (typeof value === "boolean") return value;
       }
       if (typeof parsed.supports_websockets === "boolean") {
@@ -860,8 +859,7 @@ export const extractCodexSupportsWebSockets = (
         );
         if (index !== -1) {
           return (
-            lines[index].match(TOML_SUPPORTS_WEBSOCKETS_PATTERN)?.[1] ===
-            "true"
+            lines[index].match(TOML_SUPPORTS_WEBSOCKETS_PATTERN)?.[1] === "true"
           );
         }
       }

--- a/tests/utils/providerConfigUtils.codex.test.ts
+++ b/tests/utils/providerConfigUtils.codex.test.ts
@@ -3,12 +3,14 @@ import {
   extractCodexBaseUrl,
   extractCodexExperimentalBearerToken,
   extractCodexModelName,
+  extractCodexSupportsWebSockets,
   extractCodexTopLevelInt,
   isCodexGoalModeEnabled,
   removeCodexTopLevelField,
   setCodexBaseUrl,
   setCodexGoalMode,
   setCodexModelName,
+  setCodexSupportsWebSockets,
   setCodexTopLevelInt,
   updateCodexExperimentalBearerToken,
 } from "@/utils/providerConfigUtils";
@@ -83,6 +85,50 @@ describe("Codex TOML utils", () => {
       '[model_providers.custom]\nname = "custom"\nwire_api = "responses"\nbase_url = "https://api.example.com/v1"',
     );
     expect(extractCodexBaseUrl(output)).toBe("https://api.example.com/v1");
+  });
+
+  it("reads and writes supports_websockets in the active provider section", () => {
+    const input = [
+      'model_provider = "custom"',
+      'model = "gpt-5.4"',
+      "",
+      "[model_providers.custom]",
+      'name = "custom"',
+      'wire_api = "responses"',
+      "",
+    ].join("\n");
+
+    const enabled = setCodexSupportsWebSockets(input, true);
+
+    expect(enabled).toContain(
+      '[model_providers.custom]\nname = "custom"\nwire_api = "responses"\nsupports_websockets = true',
+    );
+    expect(extractCodexSupportsWebSockets(enabled)).toBe(true);
+
+    const disabled = setCodexSupportsWebSockets(enabled, false);
+    expect(disabled).toContain("supports_websockets = false");
+    expect(extractCodexSupportsWebSockets(disabled)).toBe(false);
+  });
+
+  it("moves a top-level supports_websockets value into the active provider section", () => {
+    const input = [
+      'model_provider = "custom"',
+      "supports_websockets = true",
+      "",
+      "[model_providers.custom]",
+      'name = "custom"',
+      "",
+    ].join("\n");
+
+    const output = setCodexSupportsWebSockets(input, false);
+
+    expect(output.split("[model_providers.custom]")[0]).not.toContain(
+      "supports_websockets",
+    );
+    expect(output).toContain(
+      '[model_providers.custom]\nname = "custom"\nsupports_websockets = false',
+    );
+    expect(extractCodexSupportsWebSockets(output)).toBe(false);
   });
 
   it("recovers a single misplaced base_url from another section", () => {


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->
支持设置 Codex 供应商是否启用 WebSocket 支持（`supports_websockets`），便于利用此更省流量更快速的通信方式。
特别的，让本地路由接管时手动设置为 false，以规避当前本地路由不支持 WebSocket 的问题。

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

相关 https://github.com/farion1231/cc-switch/issues/3694
缓解 https://github.com/farion1231/cc-switch/issues/1673

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

<img width="1938" height="1464" alt="CleanShot 2026-06-06 at 22 27 06@2x" src="https://github.com/user-attachments/assets/95c9967a-2372-429b-aab0-8bcd2d3752db" />

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
