### PR TITLE
fix(mcp): add streamable-http transport type support

### DIFF
--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -84,7 +84,7 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
             // 核心字段（需要手动处理的字段）
             let core_fields = match typ {
                 "stdio" => vec!["type", "command", "args", "env", "cwd"],
-                "http" | "sse" => vec!["type", "url", "http_headers"],
+                "http" | "sse" | "streamable-http" => vec!["type", "url", "http_headers"],
                 _ => vec!["type"],
             };
 
@@ -121,7 +121,7 @@ pub fn import_from_codex(config: &mut MultiAppConfig) -> Result<usize, AppError>
                         }
                     }
                 }
-                "http" | "sse" => {
+                "http" | "sse" | "streamable-http" => {
                     if let Some(url) = entry_tbl.get("url").and_then(|v| v.as_str()) {
                         spec.insert("url".into(), json!(url));
                     }
@@ -569,7 +569,7 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
     // 定义核心字段（已在下方处理，跳过通用转换）
     let core_fields = match typ {
         "stdio" => vec!["type", "command", "args", "env", "cwd"],
-        "http" | "sse" => vec!["type", "url", "http_headers"],
+        "http" | "sse" | "streamable-http" => vec!["type", "url", "http_headers"],
         _ => vec!["type"],
     };
 
@@ -635,7 +635,7 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
                 }
             }
         }
-        "http" | "sse" => {
+        "http" | "sse" | "streamable-http" => {
             let url = spec.get("url").and_then(|v| v.as_str()).unwrap_or("");
             t["url"] = toml_edit::value(url);
 

--- a/src-tauri/src/mcp/validation.rs
+++ b/src-tauri/src/mcp/validation.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::error::AppError;
 
-/// 基础校验：允许 stdio/http/sse；或省略 type（视为 stdio）。对应必填字段存在
+/// 基础校验：允许 stdio/http/sse/streamable-http；或省略 type（视为 stdio）。对应必填字段存在
 pub fn validate_server_spec(spec: &Value) -> Result<(), AppError> {
     if !spec.is_object() {
         return Err(AppError::McpValidation(
@@ -12,14 +12,14 @@ pub fn validate_server_spec(spec: &Value) -> Result<(), AppError> {
         ));
     }
     let t_opt = spec.get("type").and_then(|x| x.as_str());
-    // 支持三种：stdio/http/sse；若缺省 type 则按 stdio 处理（与社区常见 .mcp.json 一致）
+    // 支持四种：stdio/http/sse/streamable-http；若缺省 type 则按 stdio 处理（与社区常见 .mcp.json 一致）
     let is_stdio = t_opt.map(|t| t == "stdio").unwrap_or(true);
-    let is_http = t_opt.map(|t| t == "http").unwrap_or(false);
+    let is_http = t_opt.map(|t| t == "http" || t == "streamable-http").unwrap_or(false);
     let is_sse = t_opt.map(|t| t == "sse").unwrap_or(false);
 
     if !(is_stdio || is_http || is_sse) {
         return Err(AppError::McpValidation(
-            "MCP 服务器 type 必须是 'stdio'、'http' 或 'sse'（或省略表示 stdio）".into(),
+            "MCP 服务器 type 必须是 'stdio'、'http'、'sse' 或 'streamable-http'（或省略表示 stdio）".into(),
         ));
     }
 
@@ -35,7 +35,7 @@ pub fn validate_server_spec(spec: &Value) -> Result<(), AppError> {
         let url = spec.get("url").and_then(|x| x.as_str()).unwrap_or("");
         if url.trim().is_empty() {
             return Err(AppError::McpValidation(
-                "http 类型的 MCP 服务器缺少 url 字段".into(),
+                "http/streamable-http 类型的 MCP 服务器缺少 url 字段".into(),
             ));
         }
     }

--- a/src/components/mcp/McpFormModal.tsx
+++ b/src/components/mcp/McpFormModal.tsx
@@ -345,7 +345,7 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
       return;
     }
     if (
-      (serverSpec?.type === "http" || serverSpec?.type === "sse") &&
+      (serverSpec?.type === "http" || serverSpec?.type === "sse" || serverSpec?.type === "streamable-http") &&
       !serverSpec?.url?.trim()
     ) {
       toast.error(t("mcp.wizard.urlRequired"), { duration: 3000 });

--- a/src/components/mcp/McpWizardModal.tsx
+++ b/src/components/mcp/McpWizardModal.tsx
@@ -81,7 +81,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
   initialServer,
 }) => {
   const { t } = useTranslation();
-  const [wizardType, setWizardType] = useState<"stdio" | "http" | "sse">(
+  const [wizardType, setWizardType] = useState<"stdio" | "http" | "sse" | "streamable-http" | "streamable-http">(
     "stdio",
   );
   const [wizardTitle, setWizardTitle] = useState("");
@@ -142,7 +142,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
       toast.error(t("mcp.error.commandRequired"), { duration: 3000 });
       return;
     }
-    if ((wizardType === "http" || wizardType === "sse") && !wizardUrl.trim()) {
+    if ((wizardType === "http" || wizardType === "sse" || wizardType === "streamable-http") && !wizardUrl.trim()) {
       toast.error(t("mcp.wizard.urlRequired"), { duration: 3000 });
       return;
     }
@@ -182,7 +182,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
 
     setWizardType(resolvedType);
 
-    if (resolvedType === "http" || resolvedType === "sse") {
+    if (resolvedType === "http" || resolvedType === "sse" || resolvedType === "streamable-http") {
       setWizardUrl(initialServer?.url ?? "");
       const headersCandidate = initialServer?.headers;
       const headers =
@@ -258,7 +258,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
                     value="stdio"
                     checked={wizardType === "stdio"}
                     onChange={(e) =>
-                      setWizardType(e.target.value as "stdio" | "http" | "sse")
+                      setWizardType(e.target.value as "stdio" | "http" | "sse" | "streamable-http")
                     }
                     className="w-4 h-4 accent-blue-500"
                   />
@@ -272,7 +272,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
                     value="http"
                     checked={wizardType === "http"}
                     onChange={(e) =>
-                      setWizardType(e.target.value as "stdio" | "http" | "sse")
+                      setWizardType(e.target.value as "stdio" | "http" | "sse" | "streamable-http")
                     }
                     className="w-4 h-4 accent-blue-500"
                   />
@@ -286,12 +286,26 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
                     value="sse"
                     checked={wizardType === "sse"}
                     onChange={(e) =>
-                      setWizardType(e.target.value as "stdio" | "http" | "sse")
+                      setWizardType(e.target.value as "stdio" | "http" | "sse" | "streamable-http")
                     }
                     className="w-4 h-4 accent-blue-500"
                   />
                   <span className="text-sm text-foreground">
                     {t("mcp.wizard.typeSse")}
+                  </span>
+                </label>
+                <label className="inline-flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    value="streamable-http"
+                    checked={wizardType === "streamable-http"}
+                    onChange={(e) =>
+                      setWizardType(e.target.value as "stdio" | "http" | "sse" | "streamable-http")
+                    }
+                    className="w-4 h-4 accent-blue-500"
+                  />
+                  <span className="text-sm text-foreground">
+                    Streamable HTTP
                   </span>
                 </label>
               </div>
@@ -362,7 +376,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
             )}
 
             {/* HTTP 和 SSE 类型字段 */}
-            {(wizardType === "http" || wizardType === "sse") && (
+            {(wizardType === "http" || wizardType === "sse" || wizardType === "streamable-http") && (
               <>
                 {/* URL */}
                 <div>

--- a/src/components/mcp/McpWizardModal.tsx
+++ b/src/components/mcp/McpWizardModal.tsx
@@ -81,7 +81,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
   initialServer,
 }) => {
   const { t } = useTranslation();
-  const [wizardType, setWizardType] = useState<"stdio" | "http" | "sse" | "streamable-http" | "streamable-http">(
+  const [wizardType, setWizardType] = useState<"stdio" | "http" | "sse" | "streamable-http">(
     "stdio",
   );
   const [wizardTitle, setWizardTitle] = useState("");
@@ -305,7 +305,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
                     className="w-4 h-4 accent-blue-500"
                   />
                   <span className="text-sm text-foreground">
-                    Streamable HTTP
+                    {t("mcp.wizard.typeStreamableHttp")}
                   </span>
                 </label>
               </div>

--- a/src/components/mcp/useMcpValidation.ts
+++ b/src/components/mcp/useMcpValidation.ts
@@ -42,7 +42,7 @@ export function useMcpValidation() {
           return t("mcp.error.commandRequired");
         }
         if (
-          (server.type === "http" || server.type === "sse") &&
+          (server.type === "http" || server.type === "sse" || server.type === "streamable-http") &&
           !server.url?.trim()
         ) {
           return t("mcp.wizard.urlRequired");
@@ -76,7 +76,7 @@ export function useMcpValidation() {
           if (typ === "stdio" && !(obj as any)?.command?.trim()) {
             return t("mcp.error.commandRequired");
           }
-          if ((typ === "http" || typ === "sse") && !(obj as any)?.url?.trim()) {
+          if ((typ === "http" || typ === "sse" || typ === "streamable-http") && !(obj as any)?.url?.trim()) {
             return t("mcp.wizard.urlRequired");
           }
         }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1645,6 +1645,7 @@
       "typeHttp": "http",
       "typeSse": "sse",
       "typeStreamableHttp": "streamable-http",
+      "command": "Command",
       "commandPlaceholder": "npx or uvx",
       "args": "Arguments",
       "argsPlaceholder": "arg1\narg2",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1644,7 +1644,7 @@
       "typeStdio": "stdio",
       "typeHttp": "http",
       "typeSse": "sse",
-      "command": "Command",
+      "typeStreamableHttp": "streamable-http",
       "commandPlaceholder": "npx or uvx",
       "args": "Arguments",
       "argsPlaceholder": "arg1\narg2",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1645,6 +1645,7 @@
       "typeHttp": "http",
       "typeSse": "sse",
       "typeStreamableHttp": "streamable-http",
+      "command": "コマンド",
       "commandPlaceholder": "npx または uvx",
       "args": "引数",
       "argsPlaceholder": "arg1\narg2",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1644,7 +1644,7 @@
       "typeStdio": "stdio",
       "typeHttp": "http",
       "typeSse": "sse",
-      "command": "コマンド",
+      "typeStreamableHttp": "streamable-http",
       "commandPlaceholder": "npx または uvx",
       "args": "引数",
       "argsPlaceholder": "arg1\narg2",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1590,7 +1590,7 @@
       "typeStdio": "stdio",
       "typeHttp": "http",
       "typeSse": "sse",
-      "command": "命令",
+      "typeStreamableHttp": "streamable-http",
       "commandPlaceholder": "npx 或 uvx",
       "args": "參數",
       "argsPlaceholder": "arg1\narg2",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1591,6 +1591,7 @@
       "typeHttp": "http",
       "typeSse": "sse",
       "typeStreamableHttp": "streamable-http",
+      "command": "命令",
       "commandPlaceholder": "npx 或 uvx",
       "args": "參數",
       "argsPlaceholder": "arg1\narg2",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1644,7 +1644,7 @@
       "typeStdio": "stdio",
       "typeHttp": "http",
       "typeSse": "sse",
-      "command": "命令",
+      "typeStreamableHttp": "streamable-http",
       "commandPlaceholder": "npx 或 uvx",
       "args": "参数",
       "argsPlaceholder": "arg1\narg2",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1645,6 +1645,7 @@
       "typeHttp": "http",
       "typeSse": "sse",
       "typeStreamableHttp": "streamable-http",
+      "command": "命令",
       "commandPlaceholder": "npx 或 uvx",
       "args": "参数",
       "argsPlaceholder": "arg1\narg2",

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -81,7 +81,7 @@ export const tomlConfigSchema = z.string().superRefine((value, ctx) => {
       });
     }
     if (
-      (server.type === "http" || server.type === "sse") &&
+      (server.type === "http" || server.type === "sse" || server.type === "streamable-http") &&
       !server.url?.trim()
     ) {
       ctx.addIssue({

--- a/src/lib/schemas/mcp.ts
+++ b/src/lib/schemas/mcp.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 const mcpServerSpecSchema = z
   .object({
-    type: z.enum(["stdio", "http", "sse"]).optional(),
+    type: z.enum(["stdio", "http", "sse", "streamable-http"]).optional(),
     command: z.string().trim().optional(),
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
@@ -19,7 +19,7 @@ const mcpServerSpecSchema = z
         path: ["command"],
       });
     }
-    if ((type === "http" || type === "sse") && !server.url?.trim()) {
+    if ((type === "http" || type === "sse" || type === "streamable-http") && !server.url?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `${type} 类型需填写 url`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -445,7 +445,7 @@ export interface SessionMessage {
 // MCP 服务器连接参数（宽松：允许扩展字段）
 export interface McpServerSpec {
   // 可选：社区常见 .mcp.json 中 stdio 配置可不写 type
-  type?: "stdio" | "http" | "sse";
+  type?: "stdio" | "http" | "sse" | "streamable-http";
   // stdio 字段
   command?: string;
   args?: string[];

--- a/src/utils/tomlUtils.ts
+++ b/src/utils/tomlUtils.ts
@@ -146,13 +146,13 @@ function normalizeServerConfig(config: any): McpServerSpec {
     }
 
     return server;
-  } else if (type === "http" || type === "sse") {
+  } else if (type === "http" || type === "sse" || type === "streamable-http") {
     if (!config.url || typeof config.url !== "string") {
       throw new Error(`${type} 类型的 MCP 服务器必须包含 url 字段`);
     }
 
     const server: McpServerSpec = {
-      type: type as "http" | "sse",
+      type: type as "http" | "sse" | "streamable-http",
       url: config.url,
     };
     knownFields.add("type");


### PR DESCRIPTION
## Summary

Closes #3824

CC Switch's MCP validation only accepted `stdio`/`http`/`sse` types, causing `streamable-http` MCP servers to be skipped during import (`import_from_codex` hits the `_ => warn + return` branch), leaving `enabled_codex` permanently at 0. This triggered the following cascade:

```
provider live sync → config.toml full rewrite (no [mcp_servers])
  → McpService::sync_all_enabled() removes servers with enabled_codex=0
  → [mcp_servers] section cleared
  → Codex App auto-migration → npx mcp-remote format → zombie process accumulation
```

**Fix**: Add `streamable-http` as a recognized MCP transport type alongside `http` and `sse` across the full stack.

## Changes

### Backend (Rust)
- **`src-tauri/src/mcp/validation.rs`**: `validate_server_spec()` now accepts `streamable-http`; shares URL-required validation with `http`
- **`src-tauri/src/mcp/codex.rs`**:
  - `import_from_codex()`: `streamable-http` hits the `http | sse | streamable-http` branch, correctly importing `url` + `http_headers`
  - `json_server_to_toml_table()`: correctly converts `streamable-http` type to TOML (`type`, `url`, `http_headers`)

### Frontend (TypeScript/React)
- **`src/types.ts`**: Added `"streamable-http"` to `McpServerSpec.type` union type
- **`src/lib/schemas/mcp.ts`**: Added `"streamable-http"` to Zod enum
- **`src/lib/schemas/common.ts`**: Added `streamable-http` URL-required validation
- **`src/utils/tomlUtils.ts`**: TOML parser handles `streamable-http` with same logic as `http`/`sse`
- **`src/components/mcp/McpWizardModal.tsx`**: Added "Streamable HTTP" radio button option
- **`src/components/mcp/McpFormModal.tsx`**: Added `streamable-http` to form validation
- **`src/components/mcp/useMcpValidation.ts`**: Added `streamable-http` to validation hooks

## Test Plan

- [ ] Configure a `type = "streamable-http"` MCP server in Codex config.toml; after CC Switch import, `enabled_codex` should be `1`
- [ ] After provider switch, `streamable-http` MCP servers should be preserved in config.toml (as `type = "streamable-http"` + `url`)
- [ ] Select "Streamable HTTP" type in MCP Wizard UI, fill in URL, and verify it saves correctly
- [ ] No more `npx mcp-remote` zombie processes