### PR TITLE
Fix Codex editor showing stale auth key for active third-party providers

### DIFF
--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -9,6 +9,10 @@ import {
   type ProviderFormValues,
 } from "@/components/providers/forms/ProviderForm";
 import { openclawApi, providersApi, vscodeApi, type AppId } from "@/lib/api";
+import {
+  extractCodexExperimentalBearerToken,
+  updateCodexExperimentalBearerToken,
+} from "@/utils/providerConfigUtils";
 
 interface EditProviderDialogProps {
   open: boolean;
@@ -20,6 +24,33 @@ interface EditProviderDialogProps {
   }) => Promise<void> | void;
   appId: AppId;
   isProxyTakeover?: boolean; // 代理接管模式下不读取 live（避免显示被接管后的代理配置）
+}
+
+function restoreCodexLiveProviderSettingsForEdit(
+  liveSettings: Record<string, unknown>,
+  dbSettings?: Record<string, unknown>,
+): Record<string, unknown> {
+  const configText =
+    typeof liveSettings.config === "string" ? liveSettings.config : "";
+  const providerToken = extractCodexExperimentalBearerToken(configText);
+  if (!providerToken) {
+    return liveSettings;
+  }
+
+  const auth =
+    dbSettings?.auth &&
+    typeof dbSettings.auth === "object" &&
+    !Array.isArray(dbSettings.auth)
+      ? { ...(dbSettings.auth as Record<string, unknown>) }
+      : {};
+
+  auth.OPENAI_API_KEY = providerToken;
+
+  return {
+    ...liveSettings,
+    auth,
+    config: updateCodexExperimentalBearerToken(configText, ""),
+  };
 }
 
 export function EditProviderDialog({
@@ -132,10 +163,14 @@ export function EditProviderDialog({
   }, [open, provider?.id, appId, hasLoadedLive, isProxyTakeover]); // 只依赖 provider.id，不依赖整个 provider 对象
 
   const initialSettingsConfig = useMemo(() => {
-    const base = (liveSettings ?? provider?.settingsConfig ?? {}) as Record<
-      string,
-      unknown
-    >;
+    const dbSettings =
+      provider?.settingsConfig && typeof provider.settingsConfig === "object"
+        ? (provider.settingsConfig as Record<string, unknown>)
+        : undefined;
+    const base =
+      appId === "codex" && liveSettings
+        ? restoreCodexLiveProviderSettingsForEdit(liveSettings, dbSettings)
+        : ((liveSettings ?? dbSettings ?? {}) as Record<string, unknown>);
 
     // Codex 的 modelCatalog 是 cc-switch 私有字段，SSOT 在数据库。Live 的 config.toml
     // 仅在写入时投影出 model_catalog_json 指针；Codex.app 改写配置、代理接管/恢复周期、
@@ -145,11 +180,9 @@ export function EditProviderDialog({
     if (
       appId === "codex" &&
       liveSettings &&
-      provider?.settingsConfig &&
-      typeof provider.settingsConfig === "object"
+      dbSettings
     ) {
-      const dbCatalog = (provider.settingsConfig as Record<string, unknown>)
-        .modelCatalog;
+      const dbCatalog = dbSettings.modelCatalog;
       if (dbCatalog !== undefined) {
         return { ...base, modelCatalog: dbCatalog };
       }

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -177,11 +177,7 @@ export function EditProviderDialog({
     // 来回切换供应商都可能让 Live 丢失该投影，从而 read_live_settings 反解为空。
     // 若放任 Live 覆盖，编辑界面会显示空映射表，保存后连同数据库里的映射一起清空（数据丢失）。
     // 因此始终以数据库 SSOT 的 modelCatalog 为准，仅在数据库确实没有时才回退到 Live 反解结果。
-    if (
-      appId === "codex" &&
-      liveSettings &&
-      dbSettings
-    ) {
+    if (appId === "codex" && liveSettings && dbSettings) {
       const dbCatalog = dbSettings.modelCatalog;
       if (dbCatalog !== undefined) {
         return { ...base, modelCatalog: dbCatalog };

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -159,6 +159,65 @@ describe("EditProviderDialog", () => {
     });
   });
 
+  it("编辑当前 Codex 供应商时从 live experimental_bearer_token 还原真实 API Key", async () => {
+    const provider: Provider = {
+      id: "katixiya",
+      name: "Katixiya",
+      category: "custom",
+      settingsConfig: {
+        auth: {
+          OPENAI_API_KEY: "db-key",
+        },
+        config:
+          'model_provider = "katixiya"\n[model_providers.katixiya]\nbase_url = "https://new.sharedchat.cc/codex"\n',
+      },
+    };
+    const liveSettings = {
+      auth: {
+        OPENAI_API_KEY: "old-live-auth-key",
+      },
+      config:
+        'model_provider = "katixiya"\n[model_providers.katixiya]\nbase_url = "https://new.sharedchat.cc/codex"\nexperimental_bearer_token = "real-provider-key"\n',
+    };
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockResolvedValue(liveSettings);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={handleSubmit}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual({
+        auth: {
+          OPENAI_API_KEY: "real-provider-key",
+        },
+        config:
+          'model_provider = "katixiya"\n[model_providers.katixiya]\nbase_url = "https://new.sharedchat.cc/codex"\n',
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+    expect(handleSubmit.mock.calls[0][0].provider.settingsConfig).toEqual({
+      auth: {
+        OPENAI_API_KEY: "real-provider-key",
+      },
+      config:
+        'model_provider = "katixiya"\n[model_providers.katixiya]\nbase_url = "https://new.sharedchat.cc/codex"\n',
+    });
+  });
+
   it("代理接管中编辑 Codex 供应商时展示数据库配置而不是读取 live 代理配置", async () => {
     const provider: Provider = {
       id: "deepseek",


### PR DESCRIPTION
  ## Summary

  Fixes a Codex provider editor mismatch when editing the currently active third-party provider.

  When CC Switch preserves the Codex official auth file, the live `~/.codex/auth.json` may remain unchanged while the
  active third-party provider token is projected into `config.toml` as `experimental_bearer_token`.

  Previously, the editor initialized the form from live settings directly, so it could show a stale
  `auth.OPENAI_API_KEY` from `auth.json` even though Codex was actually using the correct provider token from
  `config.toml`.

  This change restores the live projected token back into the provider auth shape when initializing the editor.

  ## Changes

  - Extract `experimental_bearer_token` from live Codex `config.toml` when editing the active provider.
  - Restore that token into `auth.OPENAI_API_KEY` for the editor form.
  - Remove the runtime-projected `experimental_bearer_token` from the editable TOML to avoid saving live projection
  details back into provider storage.
  - Keep the existing `modelCatalog` database SSOT behavior.
  - Add a regression test for the stale live auth case.

  ## Why

  For third-party Codex providers, `auth.json` may intentionally stay unchanged to preserve official Codex auth/login
  state. In that mode, the provider token lives in `config.toml` at runtime. The editor should show the effective
  provider token, not the stale preserved `auth.json` key.