### PR TITLE
fix: strip historical reasoning_content to prevent context overflow with DeepSeek

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -596,6 +596,7 @@ fn append_responses_input_as_chat_messages(
         &mut last_assistant_index,
     );
     backfill_tool_call_reasoning_placeholders(messages);
+    strip_historical_reasoning_content(messages);
     Ok(())
 }
 
@@ -854,6 +855,37 @@ fn attach_pending_reasoning_to_assistant(
 
     if let Some(obj) = message.as_object_mut() {
         append_reasoning_content(obj, &reasoning);
+    }
+}
+
+
+/// Strip `reasoning_content` from all assistant messages except the last one.
+///
+/// When converting Responses API input to Chat Completions messages, historical
+/// `reasoning` items are faithfully written into the corresponding assistant
+/// messages. The Responses API does not count reasoning against the context
+/// window, but Chat Completions providers (DeepSeek, kimi, etc.) do. For
+/// reasoning-heavy models such as DeepSeek-v4-pro, each turn can produce 30K-80K
+/// tokens of thinking, so preserving reasoning from every historical turn quickly
+/// exceeds the model's context limit (e.g. 1M tokens after just 2 turns).
+///
+/// This function keeps `reasoning_content` only on the *last* assistant message
+/// (the one that immediately precedes the current user input) and strips it from
+/// all earlier assistant messages. The historical reasoning is internal monologue
+/// that was already consumed and provides no additional value to the model.
+
+fn strip_historical_reasoning_content(messages: &mut [Value]) {
+    let last_assistant_index = messages
+        .iter()
+        .rposition(|msg| msg.get("role").and_then(|v| v.as_str()) == Some("assistant"));
+    let Some(last_idx) = last_assistant_index else { return; };
+
+    for (i, msg) in messages.iter_mut().enumerate() {
+        if i != last_idx {
+            if let Some(obj) = msg.as_object_mut() {
+                obj.remove("reasoning_content");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

When using CC Switch with Codex and a reasoning model like DeepSeek-v4-pro, the conversation hits the model's context limit after just 2-3 turns.

**Root cause**: The Responses API does not count reasoning (thinking content) against the context window. But when CC Switch converts Responses API input to Chat Completions messages, every historical turn's reasoning content is preserved in the `reasoning_content` field of each assistant message. For reasoning-heavy models (30K-80K tokens of thinking per turn), the accumulated `reasoning_content` quickly exceeds the 1M token limit.

See [detail analysis](https://github.com/farion1231/cc-switch/issues/3867#issuecomment-4645185366) by @Easyprogrammer.

## Fix

Added `strip_historical_reasoning_content()` function that:

- Keeps `reasoning_content` **only** on the last assistant message (the one immediately preceding the current user input)
- Strips `reasoning_content` from all earlier assistant messages

Historical reasoning is internal monologue that was already consumed by the model and provides no additional value — removing it is safe and brings the behavior in line with how the Responses API handles reasoning.

## Changes

- `src-tauri/src/proxy/providers/transform_codex_chat.rs`: 1 call site + 24-line new function

## Verification

All existing tests pass unchanged — they each have exactly one assistant message, so `strip_historical_reasoning_content` is a no-op on them.

Fixes #3867