### PR TITLE
fix(codex): clear stale official auth API key

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2124,16 +2124,37 @@ pub fn write_codex_live_for_provider(
         };
     let config_text = unified_official_config.as_deref().or(config_text);
 
-    let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
-        || (category != Some("official")
-            && !crate::settings::preserve_codex_official_auth_on_switch());
+    if category == Some("official") {
+        return write_codex_official_live_for_provider(auth, config_text);
+    }
 
-    if should_write_auth {
+    if !crate::settings::preserve_codex_official_auth_on_switch() {
         write_codex_live_atomic(auth, config_text)
     } else {
         let live_config = prepare_codex_provider_live_config(auth, config_text.unwrap_or(""))?;
         write_codex_live_config_atomic(Some(&live_config))
     }
+}
+
+fn write_codex_official_live_for_provider(
+    auth: &Value,
+    config_text: Option<&str>,
+) -> Result<(), AppError> {
+    if codex_auth_has_login_material(auth) {
+        return write_codex_live_atomic(auth, config_text);
+    }
+
+    let auth_path = get_codex_auth_path();
+    if auth_path.exists() {
+        let mut live_auth: Value = read_json_file(&auth_path)?;
+        if let Some(live_auth_obj) = live_auth.as_object_mut() {
+            if live_auth_obj.remove("OPENAI_API_KEY").is_some() {
+                return write_codex_live_atomic(&live_auth, config_text);
+            }
+        }
+    }
+
+    write_codex_live_config_atomic(config_text)
 }
 
 /// Build the live Codex config for provider switching.

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2148,7 +2148,11 @@ fn write_codex_official_live_for_provider(
     if auth_path.exists() {
         let mut live_auth: Value = read_json_file(&auth_path)?;
         if let Some(live_auth_obj) = live_auth.as_object_mut() {
-            if live_auth_obj.remove("OPENAI_API_KEY").is_some() {
+            let has_stale_api_key = live_auth_obj
+                .get("OPENAI_API_KEY")
+                .is_some_and(|value| !value.is_null());
+            if has_stale_api_key {
+                live_auth_obj.remove("OPENAI_API_KEY");
                 return write_codex_live_atomic(&live_auth, config_text);
             }
         }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2106,6 +2106,8 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
 /// Official providers with usable login material own `auth.json`. Third-party
 /// providers only touch `config.toml` when the compatibility setting is enabled
 /// so the user's ChatGPT login cache survives provider switches.
+/// A material-less official write may also remove a non-null stale API key from
+/// an existing credential-bearing auth file while preserving those credentials.
 ///
 /// 统一会话开关开启时，官方配置在落盘前注入共享的 `custom` 路由
 /// （见 `inject_codex_unified_session_bucket`）。
@@ -2147,14 +2149,20 @@ fn write_codex_official_live_for_provider(
     let auth_path = get_codex_auth_path();
     if auth_path.exists() {
         let mut live_auth: Value = read_json_file(&auth_path)?;
-        if let Some(live_auth_obj) = live_auth.as_object_mut() {
-            let has_stale_api_key = live_auth_obj
-                .get("OPENAI_API_KEY")
-                .is_some_and(|value| !value.is_null());
-            if has_stale_api_key {
-                live_auth_obj.remove("OPENAI_API_KEY");
-                return write_codex_live_atomic(&live_auth, config_text);
-            }
+        let has_stale_api_key = live_auth
+            .get("OPENAI_API_KEY")
+            .is_some_and(|value| !value.is_null());
+
+        // Keep pure third-party residue intact here. The normal switch flow
+        // deletes that file only after safely backfilling its key to the
+        // outgoing provider. Rewriting it as `{}` here would suppress that
+        // post-backfill cleanup and leave Codex in a broken empty-auth state.
+        if has_stale_api_key && codex_auth_has_credential_login_material(&live_auth) {
+            live_auth
+                .as_object_mut()
+                .expect("credential-bearing Codex auth must be an object")
+                .remove("OPENAI_API_KEY");
+            return write_codex_live_atomic(&live_auth, config_text);
         }
     }
 

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -883,6 +883,127 @@ requires_openai_auth = true
 }
 
 #[test]
+fn provider_service_update_current_codex_official_clears_only_stale_api_key() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let live_auth = json!({
+        "auth_mode": "chatgpt",
+        "OPENAI_API_KEY": "sk-stale",
+        "tokens": {
+            "access_token": "oauth-access",
+            "refresh_token": "oauth-refresh",
+            "account_id": "acct-official"
+        },
+        "last_refresh": "2026-08-10T00:00:00Z"
+    });
+    write_codex_live_atomic(&live_auth, Some("model = \"old-model\"\n"))
+        .expect("seed official auth with stale API key");
+
+    let mut initial_config = MultiAppConfig::default();
+    {
+        let manager = initial_config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "official-provider".to_string();
+        let mut official_provider = Provider::with_id(
+            "official-provider".to_string(),
+            "OpenAI Official".to_string(),
+            json!({
+                "auth": live_auth,
+                "config": "model = \"old-model\"\n"
+            }),
+            None,
+        );
+        official_provider.category = Some("official".to_string());
+        manager
+            .providers
+            .insert("official-provider".to_string(), official_provider);
+    }
+
+    let state = create_test_state_with_config(&initial_config).expect("create test state");
+    let mut updated_provider = Provider::with_id(
+        "official-provider".to_string(),
+        "OpenAI Official".to_string(),
+        json!({
+            "auth": {},
+            "config": "model = \"gpt-5.4\"\n"
+        }),
+        None,
+    );
+    updated_provider.category = Some("official".to_string());
+
+    ProviderService::update(&state, AppType::Codex, None, updated_provider)
+        .expect("save current official provider with cleared API key");
+
+    let saved_auth: serde_json::Value =
+        read_json_file(&cc_switch_lib::get_codex_auth_path()).expect("read preserved OAuth auth");
+    assert!(
+        saved_auth.get("OPENAI_API_KEY").is_none(),
+        "saving empty official auth should remove only the stale API key"
+    );
+    assert_eq!(
+        saved_auth
+            .pointer("/tokens/access_token")
+            .and_then(|value| value.as_str()),
+        Some("oauth-access"),
+        "the existing OAuth access token must survive"
+    );
+    assert_eq!(
+        saved_auth
+            .pointer("/tokens/refresh_token")
+            .and_then(|value| value.as_str()),
+        Some("oauth-refresh"),
+        "the existing OAuth refresh token must survive"
+    );
+    assert_eq!(
+        saved_auth
+            .get("last_refresh")
+            .and_then(|value| value.as_str()),
+        Some("2026-08-10T00:00:00Z"),
+        "unrelated auth metadata must survive"
+    );
+    assert_eq!(
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path())
+            .expect("read updated config.toml"),
+        "model = \"gpt-5.4\"\n"
+    );
+}
+
+#[test]
+fn provider_service_add_empty_codex_official_auth_writes_only_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+    let state = create_test_state().expect("create test state");
+
+    let mut official_provider = Provider::with_id(
+        "official-provider".to_string(),
+        "OpenAI Official".to_string(),
+        json!({
+            "auth": {},
+            "config": "model = \"gpt-5.4\"\n"
+        }),
+        None,
+    );
+    official_provider.category = Some("official".to_string());
+
+    ProviderService::add(&state, AppType::Codex, official_provider, false)
+        .expect("add first official provider");
+
+    assert!(
+        !cc_switch_lib::get_codex_auth_path().exists(),
+        "empty official auth must not create auth.json"
+    );
+    assert_eq!(
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path())
+            .expect("read config-only official write"),
+        "model = \"gpt-5.4\"\n"
+    );
+}
+
+#[test]
 fn provider_service_switch_codex_official_clears_stale_third_party_auth() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();
@@ -1432,7 +1553,7 @@ fn provider_service_switch_codex_official_accounts_write_auth_json() {
                     "account_id": "acct-b"
                 }
             },
-            "config": ""
+            "config": "model = \"gpt-5.4\"\n"
         }),
         None,
     );
@@ -1464,6 +1585,12 @@ fn provider_service_switch_codex_official_accounts_write_auth_json() {
             .and_then(|v| v.as_str()),
         Some("official-b-token"),
         "switching official accounts must replace auth.json with the selected account"
+    );
+    assert_eq!(
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path())
+            .expect("read official account B config"),
+        "model = \"gpt-5.4\"\n",
+        "switching official accounts must write the selected config"
     );
 
     ProviderService::switch(&state, AppType::Codex, "official-a")


### PR DESCRIPTION
## Summary / 概述

Fixes a Codex OpenAI Official provider save path where clearing `OPENAI_API_KEY` from the auth JSON editor did not remove the stale key from live `~/.codex/auth.json`.

The official-provider branch previously skipped writing `auth.json` when the submitted auth had no login material. That made an intentional clear a no-op for the live auth file, so reopening the active provider read the old key back from live settings.

This change handles official providers separately:

- If the submitted official auth has login material, keep the existing full auth write behavior.
- If it has no login material, read the existing live auth and remove only a non-null `OPENAI_API_KEY`.
- Preserve existing OAuth token material while still writing the updated config.
- Keep third-party provider behavior unchanged.

## Related Issue / 关联 Issue

Fixes #3903

## Screenshots / 截图

N/A; backend persistence fix.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查 — N/A (Rust-only change; frontend untouched)
- [x] `pnpm format:check` passes / 通过代码格式检查 — N/A (Rust-only change; frontend untouched)
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 (not needed; no user-facing text changed)

## Validation

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml official_provider_empty_auth_clears_stale_live_api_key_without_dropping_oauth`
- `cargo test --manifest-path src-tauri/Cargo.toml codex_config::tests`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`

After rebasing onto the latest `main`, the conflict resolution keeps the unified-session config injection path and then applies the official-auth cleanup path.

Note on one narrow edge case: the empty-auth official path now reads `auth.json` to strip a stale key, so if that file is malformed JSON the save errors out instead of falling back to a config-only write (the previous code never read the file). This fails loudly on a corrupt auth file by design — happy to soften it to a config-only fallthrough if you'd prefer.
