### PR TITLE
fix(omo-slim): prevent infinite re-render when categories prop is undefined

### DIFF
--- a/src/components/providers/forms/OmoFormFields.tsx
+++ b/src/components/providers/forms/OmoFormFields.tsx
@@ -128,6 +128,12 @@ const BUILTIN_AGENT_KEYS_SLIM = new Set(
 const BUILTIN_CATEGORY_KEYS = new Set(OMO_BUILTIN_CATEGORIES.map((c) => c.key));
 const EMPTY_VARIANT_VALUE = "__cc_switch_omo_variant_empty__";
 
+// 模块级常量：作为 prop 默认值时使用稳定引用，避免每次渲染都生成新对象，
+// 否则会导致依赖该 prop 的 useEffect / useCallback 持续触发重渲染循环。
+// 详见: OMO Slim 传入 categories=undefined 时的无限循环问题。
+const EMPTY_OBJECT: Record<string, Record<string, unknown>> = {};
+const EMPTY_VARIANTS_MAP: Record<string, string[]> = {};
+
 function ModelCombobox({
   value,
   options,
@@ -303,11 +309,11 @@ export function mergeCustomModelsIntoStore(
 
 export function OmoFormFields({
   modelOptions,
-  modelVariantsMap = {},
-  presetMetaMap: _presetMetaMap = {},
+  modelVariantsMap = EMPTY_VARIANTS_MAP,
+  presetMetaMap: _presetMetaMap = EMPTY_OBJECT,
   agents,
   onAgentsChange,
-  categories = {},
+  categories = EMPTY_OBJECT,
   onCategoriesChange,
   otherFieldsStr,
   onOtherFieldsStrChange,

--- a/src/components/providers/forms/OmoFormFields.tsx
+++ b/src/components/providers/forms/OmoFormFields.tsx
@@ -128,11 +128,11 @@ const BUILTIN_AGENT_KEYS_SLIM = new Set(
 const BUILTIN_CATEGORY_KEYS = new Set(OMO_BUILTIN_CATEGORIES.map((c) => c.key));
 const EMPTY_VARIANT_VALUE = "__cc_switch_omo_variant_empty__";
 
-// 模块级常量：作为 prop 默认值时使用稳定引用，避免每次渲染都生成新对象，
-// 否则会导致依赖该 prop 的 useEffect / useCallback 持续触发重渲染循环。
-// 详见: OMO Slim 传入 categories=undefined 时的无限循环问题。
-const EMPTY_OBJECT: Record<string, Record<string, unknown>> = {};
-const EMPTY_VARIANTS_MAP: Record<string, string[]> = {};
+// 模块级稳定引用：仅用于 `categories` 的默认值。omo-slim 分类下调用点会传 undefined
+// （见 ProviderForm.tsx），若默认值写成 `= {}`，函数每次调用都会创建新对象，触发
+// 依赖 `categories` 的 useEffect 无限重渲染。modelVariantsMap / presetMetaMap 由
+// useOmoModelSource 的 useMemo 稳定，无需此保护。
+const EMPTY_CATEGORIES: Record<string, Record<string, unknown>> = {};
 
 function ModelCombobox({
   value,
@@ -309,11 +309,11 @@ export function mergeCustomModelsIntoStore(
 
 export function OmoFormFields({
   modelOptions,
-  modelVariantsMap = EMPTY_VARIANTS_MAP,
-  presetMetaMap: _presetMetaMap = EMPTY_OBJECT,
+  modelVariantsMap = {},
+  presetMetaMap: _presetMetaMap = {},
   agents,
   onAgentsChange,
-  categories = EMPTY_OBJECT,
+  categories = EMPTY_CATEGORIES,
   onCategoriesChange,
   otherFieldsStr,
   onOtherFieldsStrChange,


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

All interactive elements in OMO Slim form are unresponsive — section toggles, Custom buttons, and agent configuration controls. The bug does not affect standard OMO mode.

**Root Cause**: The `categories` prop in `OmoFormFields` defaults to `{}`. When `undefined` is passed from the parent (which happens in OMO Slim mode), a new empty object is created on every render. This unstable reference causes a `useEffect` depending on `categories` to continuously fire `setCustomCategories`, creating an infinite re-render loop that prevents click handlers from executing.

**Fix**: Extract empty object defaults to module-level constants (`EMPTY_OBJECT`, `EMPTY_VARIANTS_MAP`) to maintain stable references across renders.

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #2067 

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|      <img width="2707" height="1489" alt="image" src="https://github.com/user-attachments/assets/8a5bf909-4fc6-451b-b3f7-cba058f376ae" />         |        <img width="2707" height="1489" alt="image" src="https://github.com/user-attachments/assets/6a2cc231-aa63-4cc1-866b-2d57da6b8422" />   |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码） — N/A
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — N/A
