### PR TITLE
fix: 无法打开 xfce4-terminal. feat: 新增 x-terminal-emulator (#3907)

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2839,12 +2839,13 @@ fn launch_linux_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> R
     let default_terminals = [
         ("gnome-terminal", vec!["--"]),
         ("konsole", vec!["-e"]),
-        ("xfce4-terminal", vec!["-e"]),
+        ("xfce4-terminal", vec!["-x"]),
         ("mate-terminal", vec!["--"]),
         ("lxterminal", vec!["-e"]),
         ("alacritty", vec!["-e"]),
         ("kitty", vec!["-e"]),
         ("ghostty", vec!["-e"]),
+        ("x-terminal-emulator", vec!["-e"]),
     ];
 
     // Create temp script file
@@ -2909,7 +2910,9 @@ exec bash --norc --noprofile
             let result = Command::new(terminal)
                 .args(&args)
                 .arg("bash")
+                .arg("-i")
                 .arg(script_file.to_string_lossy().as_ref())
+                .env_remove("PYTHONHOME")
                 .spawn();
 
             match result {

--- a/src/components/settings/TerminalSettings.tsx
+++ b/src/components/settings/TerminalSettings.tsx
@@ -42,6 +42,10 @@ const LINUX_TERMINALS = [
   { value: "alacritty", labelKey: "settings.terminal.options.linux.alacritty" },
   { value: "kitty", labelKey: "settings.terminal.options.linux.kitty" },
   { value: "ghostty", labelKey: "settings.terminal.options.linux.ghostty" },
+  {
+    value: "x-terminal-emulator",
+    labelKey: "settings.terminal.options.linux.xTerminalEmulator",
+  },
 ] as const;
 
 // Get terminals for the current platform

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -723,7 +723,8 @@
           "xfce4Terminal": "Xfce4 Terminal",
           "alacritty": "Alacritty",
           "kitty": "Kitty",
-          "ghostty": "Ghostty"
+          "ghostty": "Ghostty",
+          "xTerminalEmulator": "X Terminal"
         }
       }
     },


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

fix #3907
- xfce4 桌面中无法打开 xfce4-terminal 终端
```
运行报错：xfce4-terminal: 未知选项 “/tmp/cc_switch_launcher_1217885.sh”
```
- 新增 x-terminal-emulator：Debian 系都支持此命令，调用它会直接支持系统中默认配置的终端。

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

<img width="1395" height="654" alt="image" src="https://github.com/user-attachments/assets/bf54d01c-d405-4114-985d-bf0429514ccf" />
