### PR TITLE
fix(provider): send standard headers when fetching models

### DIFF
--- a/src-tauri/src/services/model_fetch.rs
+++ b/src-tauri/src/services/model_fetch.rs
@@ -30,6 +30,8 @@ struct ModelEntry {
 
 const FETCH_TIMEOUT_SECS: u64 = 15;
 
+const MODEL_FETCH_USER_AGENT: &str = concat!("cc-switch/", env!("CARGO_PKG_VERSION"));
+
 /// 404/405 响应体截断长度：避免把几十 KB HTML 404 页整页保留到错误串里。
 const ERROR_BODY_MAX_CHARS: usize = 512;
 
@@ -66,10 +68,7 @@ pub async fn fetch_models(
 
     for url in &candidates {
         log::debug!("[ModelFetch] Trying endpoint: {url}");
-        let response = match client
-            .get(url)
-            .header("Authorization", format!("Bearer {api_key}"))
-            .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
+        let response = match build_model_fetch_request(&client, url, api_key)
             .send()
             .await
         {
@@ -115,6 +114,19 @@ pub async fn fetch_models(
         "All candidates failed: {}",
         last_err.unwrap_or_else(|| "no candidates".to_string())
     ))
+}
+
+fn build_model_fetch_request(
+    client: &reqwest::Client,
+    url: &str,
+    api_key: &str,
+) -> reqwest::RequestBuilder {
+    client
+        .get(url)
+        .header(reqwest::header::AUTHORIZATION, format!("Bearer {api_key}"))
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::USER_AGENT, MODEL_FETCH_USER_AGENT)
+        .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
 }
 
 /// 构造「模型列表端点」的候选 URL 列表
@@ -229,6 +241,34 @@ fn ends_with_version_segment(url: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_model_fetch_request_headers_include_json_accept_and_user_agent() {
+        let client = reqwest::Client::new();
+        let request =
+            build_model_fetch_request(&client, "https://api.example.com/v1/models", "test-key")
+                .build()
+                .unwrap();
+
+        assert_eq!(
+            request
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer test-key")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get(reqwest::header::ACCEPT)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json")
+        );
+        assert!(
+            request.headers().contains_key(reqwest::header::USER_AGENT),
+            "model fetch requests should include a User-Agent so CDN/WAF layers do not reject bare requests"
+        );
+    }
 
     #[test]
     fn test_candidates_plain_root() {


### PR DESCRIPTION
## Summary / 概述

`fetch_models` now sends standard HTTP headers when calling OpenAI-compatible model list endpoints:

- `Authorization: Bearer <key>`
- `Accept: application/json`
- `User-Agent: cc-switch/<version>`

Some CDN/WAF-protected providers reject bare requests without a `User-Agent`, returning HTTP 403 HTML pages. CC Switch currently surfaces those responses as invalid API key errors, even when the API key is valid.

This change makes the model-fetch request look like a normal API client request without changing URL candidate logic or response parsing.

## Related Issue / 关联 Issue

Fixes #3914

## Screenshots / 截图

Backend-only behavior change.

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| `Fetch Models` may show `API Key is invalid or lacks permission` when the upstream returns a CDN/WAF 403 HTML page | `Fetch Models` sends standard request headers and can fetch model lists from CDN/WAF-protected OpenAI-compatible endpoints |

<img width="420" height="159" alt="Screenshot 2026-06-08 at 22 17 55" src="https://github.com/user-attachments/assets/9ca07d42-892d-4e62-b316-5ff26878172c" />


## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

Additional verification run locally:

- [x] `cargo test model_fetch`
- [x] `pnpm run build:renderer`
- [x] `git diff --check`

No user-facing text changed, so i18n updates are not required.