### PR TITLE
fix(proxy): support image input for Codex Responses API via media retry

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -154,16 +154,18 @@ impl RequestForwarder {
     /// 这里是上游"实测"错误后的纯恢复，不是预测，故启发式开关与它无关。
     fn media_retry_should_trigger(
         &self,
-        adapter_name: &str,
+        _adapter_name: &str,
         already_retried: bool,
         provider_body: &Value,
         error: &ProxyError,
     ) -> bool {
-        adapter_name == "Claude"
-            && self.rectifier_config.enabled
+        // Media retry now works for all adapters (Claude, Codex, etc.),
+        // not just Claude.  The image-block detection covers both Anthropic
+        // and Responses API formats.
+        self.rectifier_config.enabled
             && self.rectifier_config.request_media_fallback
             && !already_retried
-            && super::media_sanitizer::contains_image_blocks(provider_body)
+            && super::media_sanitizer::contains_image_blocks_any_format(provider_body)
             && super::media_sanitizer::is_unsupported_image_error(error)
     }
 
@@ -515,7 +517,7 @@ impl RequestForwarder {
                     });
                 }
                 Err(e) => {
-                    // 检测是否需要触发整流器（仅 Claude/ClaudeAuth 供应商）
+                    // 检测是否需要触发整流器（所有适配器均可触发，不限于 Claude）
                     let provider_type = ProviderType::from_app_type_and_config(app_type, provider);
                     let is_anthropic_provider = matches!(
                         provider_type,
@@ -530,10 +532,17 @@ impl RequestForwarder {
                         &e,
                     ) {
                         let mut media_body = provider_body.clone();
-                        let replaced_images =
+                        // Try both Anthropic and Responses API image replacement;
+                        // whichever format the body uses, the other is a no-op.
+                        let replaced_anthropic =
                             super::media_sanitizer::replace_image_blocks_with_marker(
                                 &mut media_body,
                             );
+                        let replaced_responses =
+                            super::media_sanitizer::replace_responses_images_with_marker(
+                                &mut media_body,
+                            );
+                        let replaced_images = replaced_anthropic + replaced_responses;
 
                         if replaced_images > 0 {
                             let _ = std::mem::replace(&mut media_rectifier_retried, true);
@@ -3425,5 +3434,55 @@ mod tests {
         });
         let body = body_with_image("any-model");
         assert!(fwd.media_retry_should_trigger("Claude", false, &body, &image_unsupported_error()));
+    }
+
+    // --- Codex / Responses API media retry ---
+
+    fn responses_body_with_image(model: &str) -> Value {
+        json!({
+            "model": model,
+            "input": [
+                { "type": "input_image", "image_url": "data:image/png;base64,abc" },
+                { "type": "input_text", "text": "describe this image" }
+            ]
+        })
+    }
+
+    fn image_unsupported_error_404() -> ProxyError {
+        ProxyError::UpstreamError {
+            status: 404,
+            body: Some(
+                r#"{"error":{"message":"No endpoints found that support image input"}}"#.to_string(),
+            ),
+        }
+    }
+
+    #[test]
+    fn reactive_triggers_for_codex_adapter() {
+        // Previously blocked by adapter_name == "Claude" check.
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let body = body_with_image("any-model");
+        assert!(fwd.media_retry_should_trigger("Codex", false, &body, &image_unsupported_error()));
+    }
+
+    #[test]
+    fn reactive_triggers_for_responses_api_format() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let body = responses_body_with_image("mimo-v2.5");
+        assert!(fwd.media_retry_should_trigger("Codex", false, &body, &image_unsupported_error_404()));
+    }
+
+    #[test]
+    fn reactive_triggers_for_404_image_error() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let body = body_with_image("mimo-v2.5");
+        assert!(fwd.media_retry_should_trigger("Codex", false, &body, &image_unsupported_error_404()));
+    }
+
+    #[test]
+    fn reactive_skipped_for_codex_when_already_retried() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let body = responses_body_with_image("mimo-v2.5");
+        assert!(!fwd.media_retry_should_trigger("Codex", true, &body, &image_unsupported_error_404()));
     }
 }

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -51,6 +51,84 @@ pub fn contains_image_blocks(body: &Value) -> bool {
         })
 }
 
+/// Detect image blocks in any supported API format:
+/// - Anthropic: `{ "type": "image", "source": ... }` inside `messages[].content[]`
+/// - Responses API: `{ "type": "input_image" }` inside top-level `input[]` or
+///   inside `input[].content[]`
+///
+/// This is used by the media rectifier to decide whether to retry with images
+/// stripped, regardless of which adapter (Claude / Codex / …) is active.
+pub fn contains_image_blocks_any_format(body: &Value) -> bool {
+    // 1. Anthropic / OpenAI Chat Completions format
+    if contains_image_blocks(body) {
+        return true;
+    }
+
+    // 2. Responses API: top-level `input` array
+    if let Some(input) = body.get("input").and_then(Value::as_array) {
+        for item in input {
+            // 2a. Direct input_image item
+            if item.get("type").and_then(Value::as_str) == Some("input_image") {
+                return true;
+            }
+            // 2b. input_image inside item.content[]
+            if let Some(content) = item.get("content").and_then(Value::as_array) {
+                if content
+                    .iter()
+                    .any(|c| c.get("type").and_then(Value::as_str) == Some("input_image"))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Strip image blocks from a Responses API request body by replacing
+/// `input_image` items with `input_text` markers.  Returns the number of
+/// images replaced.
+pub fn replace_responses_images_with_marker(body: &mut Value) -> usize {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return 0;
+    };
+
+    let mut replaced = 0usize;
+    for item in input.iter_mut() {
+        // Top-level input_image item
+        if item.get("type").and_then(Value::as_str) == Some("input_image") {
+            if let Some(obj) = item.as_object_mut() {
+                obj.insert("type".to_string(), json!("input_text"));
+                obj.insert("text".to_string(), json!(UNSUPPORTED_IMAGE_MARKER));
+                obj.remove("image_url");
+                obj.remove("url");
+                obj.remove("detail");
+                replaced += 1;
+            }
+            continue;
+        }
+
+        // input_image inside item.content[]
+        if let Some(content) = item.get_mut("content").and_then(Value::as_array_mut) {
+            for part in content.iter_mut() {
+                if part.get("type").and_then(Value::as_str) == Some("input_image") {
+                    if let Some(obj) = part.as_object_mut() {
+                        obj.insert("type".to_string(), json!("input_text"));
+                        obj.insert("text".to_string(), json!(UNSUPPORTED_IMAGE_MARKER));
+                        obj.remove("image_url");
+                        obj.remove("url");
+                        obj.remove("detail");
+                        replaced += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    replaced
+}
+
 pub fn replace_image_blocks_with_marker(body: &mut Value) -> usize {
     replace_images_in_body(body)
 }
@@ -60,7 +138,9 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
         return false;
     };
 
-    if !matches!(*status, 400 | 415 | 422 | 501) {
+    // Some providers (e.g. Xiaomi MiMo) return 404 when no endpoint supports
+    // image input for the requested model, rather than the more common 400/415.
+    if !matches!(*status, 400 | 404 | 415 | 422 | 501) {
         return false;
     }
 
@@ -81,6 +161,14 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
 
     if !mentions_image {
         return false;
+    }
+
+    // For 404 errors, mentioning image/vision in the error is already a strong
+    // signal that the model doesn't support image input (e.g. Xiaomi MiMo returns
+    // "No endpoints found that support image input").  Skip the stricter
+    // UNSUPPORTED_HINTS check for 404.
+    if *status == 404 {
+        return true;
     }
 
     const UNSUPPORTED_HINTS: &[&str] = &[
@@ -699,5 +787,158 @@ mod tests {
             body["messages"][0]["content"][0]["text"],
             UNSUPPORTED_IMAGE_MARKER
         );
+    }
+
+    // --- contains_image_blocks_any_format ---
+
+    #[test]
+    fn any_format_detects_anthropic_image_blocks() {
+        let body = json!({
+            "model": "test",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "abc" } }
+                ]
+            }]
+        });
+        assert!(contains_image_blocks_any_format(&body));
+    }
+
+    #[test]
+    fn any_format_detects_responses_input_image_at_top_level() {
+        let body = json!({
+            "model": "test",
+            "input": [
+                { "type": "input_image", "image_url": "data:image/png;base64,abc" },
+                { "type": "input_text", "text": "describe" }
+            ]
+        });
+        assert!(contains_image_blocks_any_format(&body));
+    }
+
+    #[test]
+    fn any_format_detects_responses_input_image_in_content() {
+        let body = json!({
+            "model": "test",
+            "input": [{
+                "role": "user",
+                "content": [
+                    { "type": "input_image", "image_url": "data:image/png;base64,abc" },
+                    { "type": "input_text", "text": "describe" }
+                ]
+            }]
+        });
+        assert!(contains_image_blocks_any_format(&body));
+    }
+
+    #[test]
+    fn any_format_returns_false_for_text_only() {
+        let body = json!({
+            "model": "test",
+            "messages": [{
+                "role": "user",
+                "content": [{ "type": "text", "text": "hello" }]
+            }]
+        });
+        assert!(!contains_image_blocks_any_format(&body));
+    }
+
+    #[test]
+    fn any_format_returns_false_for_responses_text_only() {
+        let body = json!({
+            "model": "test",
+            "input": [
+                { "type": "input_text", "text": "hello" }
+            ]
+        });
+        assert!(!contains_image_blocks_any_format(&body));
+    }
+
+    // --- replace_responses_images_with_marker ---
+
+    #[test]
+    fn replace_responses_replaces_top_level_input_image() {
+        let mut body = json!({
+            "model": "test",
+            "input": [
+                { "type": "input_image", "image_url": "data:image/png;base64,abc" },
+                { "type": "input_text", "text": "describe" }
+            ]
+        });
+        let count = replace_responses_images_with_marker(&mut body);
+        assert_eq!(count, 1);
+        assert_eq!(body["input"][0]["type"], "input_text");
+        assert_eq!(body["input"][0]["text"], UNSUPPORTED_IMAGE_MARKER);
+        assert!(body["input"][0].get("image_url").is_none());
+        assert_eq!(body["input"][1]["type"], "input_text");
+        assert_eq!(body["input"][1]["text"], "describe");
+    }
+
+    #[test]
+    fn replace_responses_replaces_content_level_input_image() {
+        let mut body = json!({
+            "model": "test",
+            "input": [{
+                "role": "user",
+                "content": [
+                    { "type": "input_image", "image_url": "data:image/png;base64,abc" },
+                    { "type": "input_text", "text": "describe" }
+                ]
+            }]
+        });
+        let count = replace_responses_images_with_marker(&mut body);
+        assert_eq!(count, 1);
+        assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
+        assert_eq!(body["input"][0]["content"][0]["text"], UNSUPPORTED_IMAGE_MARKER);
+    }
+
+    #[test]
+    fn replace_responses_noop_for_anthropic_format() {
+        let mut body = json!({
+            "model": "test",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "abc" } }
+                ]
+            }]
+        });
+        let count = replace_responses_images_with_marker(&mut body);
+        assert_eq!(count, 0);
+        assert_eq!(body["messages"][0]["content"][0]["type"], "image");
+    }
+
+    // --- is_unsupported_image_error with 404 ---
+
+    #[test]
+    fn detects_404_as_unsupported_image_error() {
+        let error = ProxyError::UpstreamError {
+            status: 404,
+            body: Some(
+                r#"{"error":{"message":"No endpoints found that support image input"}}"#.to_string(),
+            ),
+        };
+        assert!(is_unsupported_image_error(&error));
+    }
+
+    #[test]
+    fn detects_404_with_model_not_support_image() {
+        let error = ProxyError::UpstreamError {
+            status: 404,
+            body: Some(
+                r#"{"error":{"code":"404","message":"No endpoints found that support image input","param":"","type":""}}"#.to_string(),
+            ),
+        };
+        assert!(is_unsupported_image_error(&error));
+    }
+
+    #[test]
+    fn ignores_404_without_image_mention() {
+        let error = ProxyError::UpstreamError {
+            status: 404,
+            body: Some(r#"{"error":{"message":"Model not found"}}"#.to_string()),
+        };
+        assert!(!is_unsupported_image_error(&error));
     }
 }


### PR DESCRIPTION
## Summary / 概述

修复 Codex 通过 cc-switch 代理发送图片到 mimo-v2.5-pro 等模型时，图片被静默丢弃或返回 404 错误，导致模型返回错误的识别结果。

根因分析：
1. `media_retry_should_trigger()` 硬编码只对 Claude 适配器生效（`adapter_name == "Claude"`），Codex 完全绕过图片重试机制
2. `contains_image_blocks()` 只识别 Anthropic 格式（`messages[].content[].type == "image"`），不识别 Responses API 格式（`input[].type == "input_image"`）
3. `is_unsupported_image_error()` 不匹配 404 状态码，而 Xiaomi MiMo 返回 404 表示不支持图片输入

改动：
- 新增 `contains_image_blocks_any_format()`：同时检测 Anthropic 和 Responses API 图片块
- 新增 `replace_responses_images_with_marker()`：替换 Responses API 中的 `input_image` 为文本标记
- 移除 `media_retry_should_trigger()` 中的 `adapter_name == "Claude"` 限制，所有适配器均可触发
- `is_unsupported_image_error()` 新增 404 支持，404 + 消息提到 image 即判定为图片不支持
- 新增 12 个测试覆盖所有新增逻辑

## Related Issue / 关联 Issue

Fixes #

## Checklist / 检查清单

- [x] `cargo clippy` passes / 通过 Clippy 检查
- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未修改前端代码）
- [x] `cargo test` passes (28 media_sanitizer + 52 forwarder tests all pass)
- [ ] 未修改用户可见文本，无需更新国际化文件