### PR TITLE
feat(macos): add Dock icon setting and fix Hide behavior

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -763,6 +763,7 @@ dependencies = [
  "log",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "once_cell",
  "regex",
  "reqwest 0.12.28",
@@ -1278,6 +1279,12 @@ dependencies = [
  "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
@@ -3244,6 +3251,7 @@ checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
+ "dispatch",
  "libc",
  "objc2 0.5.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -93,7 +93,8 @@ windows-sys = { version = "0.61", features = ["Win32_Globalization", "Win32_UI_S
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"
-objc2-app-kit = { version = "0.2", features = ["NSColor"] }
+objc2-app-kit = { version = "0.2", features = ["NSApplication", "NSColor", "NSResponder", "NSWindow"] }
+objc2-foundation = { version = "0.2", features = ["dispatch", "NSThread"] }
 
 # Optimize release binary size to help reduce AppImage footprint
 [profile.release]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,7 +1,36 @@
 #![allow(non_snake_case)]
 
 use tauri::AppHandle;
+#[cfg(target_os = "macos")]
+use tauri::Manager;
 use tauri_plugin_updater::UpdaterExt;
+
+#[cfg(target_os = "macos")]
+fn main_window_is_visible(app: &AppHandle) -> bool {
+    app.get_webview_window("main")
+        .and_then(|window| window.is_visible().ok())
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main_window_is_visible(_app: &AppHandle) -> bool {
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn apply_dock_icon_setting_change(app: &AppHandle, main_window_was_visible: bool) {
+    crate::tray::apply_tray_policy(app, main_window_was_visible);
+    if main_window_was_visible {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.unminimize();
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apply_dock_icon_setting_change(_app: &AppHandle, _main_window_was_visible: bool) {}
 
 fn merge_settings_for_save(
     mut incoming: crate::settings::AppSettings,
@@ -65,10 +94,21 @@ pub async fn get_settings() -> Result<crate::settings::AppSettings, String> {
 
 /// 保存设置
 #[tauri::command]
-pub async fn save_settings(settings: crate::settings::AppSettings) -> Result<bool, String> {
+pub async fn save_settings(
+    app: AppHandle,
+    settings: crate::settings::AppSettings,
+) -> Result<bool, String> {
     let existing = crate::settings::get_settings();
     let merged = merge_settings_for_save(settings, &existing);
+    let keep_dock_icon_changed = existing.keep_dock_icon != merged.keep_dock_icon;
+    let main_window_was_visible = main_window_is_visible(&app);
+
     crate::settings::update_settings(merged).map_err(|e| e.to_string())?;
+
+    if keep_dock_icon_changed {
+        apply_dock_icon_setting_change(&app, main_window_was_visible);
+    }
+
     Ok(true)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -159,6 +159,10 @@ fn handle_deeplink_url(
                     {
                         linux_fix::nudge_main_window(window.clone());
                     }
+                    #[cfg(target_os = "macos")]
+                    {
+                        crate::tray::apply_tray_policy(app, true);
+                    }
                     log::info!("✓ Window shown and focused");
                 }
             }
@@ -259,6 +263,10 @@ pub fn run() {
                 #[cfg(target_os = "linux")]
                 {
                     linux_fix::nudge_main_window(window.clone());
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    crate::tray::apply_tray_policy(app, true);
                 }
             }
         }));
@@ -1108,6 +1116,8 @@ pub fn run() {
                 } else {
                     // 正常启动模式：显示窗口
                     let _ = window.show();
+                    #[cfg(target_os = "macos")]
+                    tray::apply_tray_policy(app.handle(), true);
                     log::info!("正常启动模式：主窗口已显示");
 
                     // Linux: 解决首次启动 UI 无响应问题（Tauri #10746 + wry #637）。
@@ -1575,6 +1585,7 @@ pub fn run() {
                                 let _ = window.unminimize();
                                 let _ = window.show();
                                 let _ = window.set_focus();
+                                tray::apply_tray_policy(app_handle, true);
                             }
                         }
                     }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -324,6 +324,9 @@ pub struct AppSettings {
     pub show_in_tray: bool,
     #[serde(default = "default_minimize_to_tray_on_close")]
     pub minimize_to_tray_on_close: bool,
+    /// 是否保留 macOS Dock 图标
+    #[serde(default)]
+    pub keep_dock_icon: bool,
     #[serde(default)]
     pub use_app_window_controls: bool,
     /// 是否启用 Claude 插件联动
@@ -464,6 +467,7 @@ impl Default for AppSettings {
         Self {
             show_in_tray: true,
             minimize_to_tray_on_close: true,
+            keep_dock_icon: false,
             use_app_window_controls: false,
             enable_claude_plugin_integration: false,
             skip_claude_onboarding: false,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -677,22 +677,42 @@ pub fn refresh_tray_menu(app: &tauri::AppHandle) {
 }
 
 #[cfg(target_os = "macos")]
-pub fn apply_tray_policy(app: &tauri::AppHandle, dock_visible: bool) {
+fn restore_window_hide_behavior() {
+    use objc2_app_kit::NSApplication;
+    use objc2_foundation::run_on_main;
+
+    run_on_main(|mtm| unsafe {
+        let app = NSApplication::sharedApplication(mtm);
+        let windows = app.windows();
+
+        for index in 0..windows.count() {
+            let window = windows.objectAtIndex(index);
+            window.setCanHide(true);
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+pub fn apply_tray_policy(app: &tauri::AppHandle, main_window_visible: bool) {
     use tauri::ActivationPolicy;
 
-    let desired_policy = if dock_visible {
+    let effective_dock_visible =
+        main_window_visible && crate::settings::get_settings().keep_dock_icon;
+    let desired_policy = if effective_dock_visible {
         ActivationPolicy::Regular
     } else {
         ActivationPolicy::Accessory
     };
 
-    if let Err(err) = app.set_dock_visibility(dock_visible) {
+    if let Err(err) = app.set_dock_visibility(effective_dock_visible) {
         log::warn!("设置 Dock 显示状态失败: {err}");
     }
 
     if let Err(err) = app.set_activation_policy(desired_policy) {
         log::warn!("设置激活策略失败: {err}");
     }
+
+    restore_window_hide_behavior();
 }
 
 /// 处理托盘菜单事件

--- a/src/components/settings/WindowSettings.tsx
+++ b/src/components/settings/WindowSettings.tsx
@@ -3,7 +3,7 @@ import type { SettingsFormState } from "@/hooks/useSettings";
 import { AppWindow, MonitorUp, Power, EyeOff } from "lucide-react";
 import { ToggleRow } from "@/components/ui/toggle-row";
 import { AnimatePresence, motion } from "framer-motion";
-import { isLinux } from "@/lib/platform";
+import { isLinux, isMac } from "@/lib/platform";
 
 interface WindowSettingsProps {
   settings: SettingsFormState;
@@ -76,6 +76,16 @@ export function WindowSettings({ settings, onChange }: WindowSettingsProps) {
             onChange({ minimizeToTrayOnClose: value })
           }
         />
+
+        {isMac() && (
+          <ToggleRow
+            icon={<AppWindow className="h-4 w-4 text-slate-500" />}
+            title={t("settings.keepDockIcon")}
+            description={t("settings.keepDockIconDescription")}
+            checked={!!settings.keepDockIcon}
+            onCheckedChange={(value) => onChange({ keepDockIcon: value })}
+          />
+        )}
 
         {isLinux() && (
           <ToggleRow

--- a/src/hooks/useSettingsForm.ts
+++ b/src/hooks/useSettingsForm.ts
@@ -111,6 +111,7 @@ export function useSettingsForm(): UseSettingsFormResult {
       ...data,
       showInTray: data.showInTray ?? true,
       minimizeToTrayOnClose: data.minimizeToTrayOnClose ?? true,
+      keepDockIcon: data.keepDockIcon ?? false,
       useAppWindowControls: data.useAppWindowControls ?? false,
       enableClaudePluginIntegration:
         data.enableClaudePluginIntegration ?? false,
@@ -139,6 +140,7 @@ export function useSettingsForm(): UseSettingsFormResult {
           ({
             showInTray: true,
             minimizeToTrayOnClose: true,
+            keepDockIcon: false,
             useAppWindowControls: false,
             enableClaudePluginIntegration: false,
             skipClaudeOnboarding: false,
@@ -175,6 +177,7 @@ export function useSettingsForm(): UseSettingsFormResult {
         ...serverData,
         showInTray: serverData.showInTray ?? true,
         minimizeToTrayOnClose: serverData.minimizeToTrayOnClose ?? true,
+        keepDockIcon: serverData.keepDockIcon ?? false,
         useAppWindowControls: serverData.useAppWindowControls ?? false,
         enableClaudePluginIntegration:
           serverData.enableClaudePluginIntegration ?? false,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -661,6 +661,8 @@
     "autoLaunchFailed": "Failed to set auto-launch",
     "minimizeToTray": "Minimize to tray on close",
     "minimizeToTrayDescription": "When checked, clicking the close button will hide to system tray, otherwise the app will exit directly.",
+    "keepDockIcon": "Keep Dock icon",
+    "keepDockIconDescription": "Show CC Switch in the Dock while the main window is open; turn off to run from the menu bar only.",
     "useAppWindowControls": "Enable app-level window controls",
     "useAppWindowControlsDescription": "Use built-in minimize, maximize/restore, and close buttons in the app header.",
     "enableClaudePluginIntegration": "Apply to Claude Code extension",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -661,6 +661,8 @@
     "autoLaunchFailed": "自動起動の設定に失敗しました",
     "minimizeToTray": "閉じるときトレイへ最小化",
     "minimizeToTrayDescription": "チェックすると閉じるボタンでトレイに隠し、オフならアプリを終了します。",
+    "keepDockIcon": "Dock アイコンを保持",
+    "keepDockIconDescription": "メインウィンドウを開いている間は Dock に CC Switch を表示します。オフにするとメニューバーのみで動作します。",
     "useAppWindowControls": "アプリ内ウィンドウボタンを有効化",
     "useAppWindowControlsDescription": "有効にすると、アプリヘッダーに最小化・最大化/復元・閉じるボタンを表示します。",
     "enableClaudePluginIntegration": "Claude Code 拡張に適用",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -661,6 +661,8 @@
     "autoLaunchFailed": "設定開機自動啟動失敗",
     "minimizeToTray": "關閉時最小化至系統匣",
     "minimizeToTrayDescription": "勾選後點擊關閉按鈕會隱藏至系統匣，取消則直接退出應用程式。",
+    "keepDockIcon": "保留 Dock 圖示",
+    "keepDockIconDescription": "開啟後主視窗開啟時會在 Dock 中顯示 CC Switch；關閉後僅在選單列執行。",
     "useAppWindowControls": "啟用應用程式等級視窗按鈕",
     "useAppWindowControlsDescription": "開啟後使用應用程式自建的最小化、最大化/還原、關閉按鈕；關閉後沿用系統視窗模式。",
     "enableClaudePluginIntegration": "套用至 Claude Code 外掛程式",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -661,6 +661,8 @@
     "autoLaunchFailed": "设置开机自启失败",
     "minimizeToTray": "关闭时最小化到托盘",
     "minimizeToTrayDescription": "勾选后点击关闭按钮会隐藏到系统托盘，取消则直接退出应用。",
+    "keepDockIcon": "保留 Dock 图标",
+    "keepDockIconDescription": "开启后主窗口打开时在 Dock 中显示 CC Switch；关闭后仅在菜单栏运行。",
     "useAppWindowControls": "启用应用级窗口按钮",
     "useAppWindowControlsDescription": "开启后使用应用自建的最小化、最大化/还原、关闭按钮；关闭后沿用系统窗口模式。",
     "enableClaudePluginIntegration": "应用到 Claude Code 插件",

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -11,6 +11,7 @@ export const settingsSchema = z.object({
   // 设备级 UI 设置
   showInTray: z.boolean(),
   minimizeToTrayOnClose: z.boolean(),
+  keepDockIcon: z.boolean().optional(),
   enableClaudePluginIntegration: z.boolean().optional(),
   skipClaudeOnboarding: z.boolean().optional(),
   launchOnStartup: z.boolean().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -329,6 +329,8 @@ export interface Settings {
   showInTray: boolean;
   // 点击关闭按钮时是否最小化到托盘而不是关闭应用
   minimizeToTrayOnClose: boolean;
+  // 是否保留 macOS Dock 图标
+  keepDockIcon?: boolean;
   // 是否启用应用级窗口控制按钮（最小化/最大化/关闭）
   useAppWindowControls?: boolean;
   // 启用 Claude 插件联动（写入 ~/.claude/config.json 的 primaryApiKey）


### PR DESCRIPTION
## Summary

Add a macOS-only `Keep Dock icon` setting and restore standard Hide behavior.

CC Switch remains tray-first by default: `Keep Dock icon` is off unless the user enables it. With either setting, `Command+H`, the app menu Hide command, and KeyClu-triggered Hide now hide the visible main window instead of only moving it behind other windows.

## Root Cause

On macOS, Tauri/Tao's `set_dock_visibility(false)` path sets `NSWindow.canHide = false`. That breaks AppKit's standard `NSApplication.hide(_:)` behavior while the app is in no-Dock/accessory mode.

## Changes

- Add `keepDockIcon` to settings and expose it as `Keep Dock icon` on macOS.
- Compute Dock visibility as `mainWindowVisible && keepDockIcon`, preserving the default no-Dock tray behavior in background, silent startup, and lightweight mode.
- Restore `NSWindow.canHide = true` after applying the Dock policy.
- Reapply the policy on startup, close-to-tray, reopen, deeplink, lightweight mode transitions, and setting changes.

## Related Issue

Fixes #316.

Related context: #67 documents the intentional no-Dock tray behavior.

## Screenshots

<img width="981" height="640" alt="image" src="https://github.com/user-attachments/assets/07e00897-d7fb-42a2-a276-1a1da64b3d8f" />

## Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --no-deps`
- [x] `TZ=UTC cargo test --lib`
- [x] `tsc --noEmit`
- [x] `prettier --check "src/**/*.{js,jsx,ts,tsx,css,json}"`
- [x] `vitest run`
- [x] `vite build`
- [x] User-facing text added to all locale files
- [x] Manual macOS check: `Command+H` hides the main window with `Keep Dock icon` off and on.
