### PR TITLE
fix(media-sanitizer): also detect and strip image_url blocks for text-only models

### DIFF
--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -113,7 +113,8 @@ fn content_has_image_blocks(content: &Value) -> bool {
     };
 
     blocks.iter().any(|block| {
-        block.get("type").and_then(Value::as_str) == Some("image")
+        let block_type = block.get("type").and_then(Value::as_str);
+        block_type == Some("image") || block_type == Some("image_url")
             || block.get("content").is_some_and(content_has_image_blocks)
     })
 }
@@ -137,7 +138,8 @@ fn replace_images_in_content(content: &mut Value) -> usize {
 
     let mut replaced = 0usize;
     for block in blocks {
-        if block.get("type").and_then(Value::as_str) == Some("image") {
+        let block_type = block.get("type").and_then(Value::as_str);
+        if block_type == Some("image") || block_type == Some("image_url") {
             let cache_control = block.get("cache_control").cloned();
             *block = json!({
                 "type": "text",


### PR DESCRIPTION
## Problem

When Codex sends a request with images through CC Switch to a **non-vision provider** (like DeepSeek), the proxy converts the Responses API format to Chat Completions format via `transform_codex_chat.rs`. This conversion emits image content as `{ type: "image_url" }` blocks (OpenAI Chat format).

However, `media_sanitizer.rs` only checked for `{ type: "image" }` (Anthropic format), so images in Chat-format requests were forwarded to providers that don't support vision, causing:

> `Failed to deserialize the JSON body into the target type: messages[194]: unknown variant `image_url`, expected `text``

## Fix

Updated two functions in `media_sanitizer.rs`:

1. `content_has_image_blocks()` — now also checks for `"image_url"` type
2. `replace_images_in_content()` — now also replaces `"image_url"` type blocks with the `[Unsupported Image]` marker

## Related

This complements the existing Anthropic-format (`{ type: "image" }`) sanitization that was already working correctly for the `transform.rs` (Anthropic→OpenAI) path.