### PR TITLE
fix(coding-plan): 修复 MiniMax的Token Plan boost后额度不为100%时的用量计算

### DIFF
--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -571,7 +571,7 @@ fn parse_minimax_tiers(body: &serde_json::Value) -> Vec<QuotaTier> {
         return tiers;
     };
 
-    // 5h 桶:用剩余额度 / 桶总量反推已用率。
+    // 5h 桶:用剩余比例和 boost 后的桶总量反推已用百分比点数。
     if let Some(utilization) = minimax_bucket_utilization(
         item,
         "current_interval_remaining_percent",
@@ -621,7 +621,7 @@ fn minimax_bucket_utilization(
 ) -> Option<f64> {
     let remaining = item.get(remaining_percent_key).and_then(parse_f64)?;
     let total = minimax_bucket_total_percent(item, boost_permille_key);
-    Some(((total - remaining) / total) * 100.0)
+    Some((100.0 - remaining) * total / 100.0)
 }
 
 fn minimax_bucket_total_percent(item: &serde_json::Value, boost_permille_key: &str) -> f64 {
@@ -870,13 +870,9 @@ mod tests {
         let tiers = parse_minimax_tiers(&body);
         assert_eq!(tiers.len(), 2);
         assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
-        assert!(
-            (tiers[0].utilization - 65.333_333_333_333_33).abs() < 1e-9
-        );
+        assert_eq!(tiers[0].utilization, 72.0);
         assert_eq!(tiers[1].name, TIER_WEEKLY_LIMIT);
-        assert!(
-            (tiers[1].utilization - 38.666_666_666_666_664).abs() < 1e-9
-        );
+        assert_eq!(tiers[1].utilization, 12.0);
     }
 
     #[test]

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -547,7 +547,8 @@ async fn query_zenmux(base_url: &str, api_key: &str) -> SubscriptionQuota {
 
 /// 从 `/coding_plan/remains` 响应中解析 MiniMax 编程套餐的额度 tier。
 ///
-/// 新接口语义:`current_*_remaining_percent` 是"剩余百分比"(0-100),
+/// 新接口语义:`current_*_remaining_percent` 是剩余额度的百分比点数,
+/// 但桶总量不一定是 100;接口可通过对应 boost permille 字段放大,
 /// `model_remains` 数组里有 `general`(编程套餐)和 `video` 等其他模型,
 /// 这里只取 `general`,跳过 video。
 ///
@@ -570,18 +571,19 @@ fn parse_minimax_tiers(body: &serde_json::Value) -> Vec<QuotaTier> {
         return tiers;
     };
 
-    // 5h 桶:剩余百分比 → 已用百分比
-    if let Some(remain_pct) = item
-        .get("current_interval_remaining_percent")
-        .and_then(|v| v.as_f64())
-    {
+    // 5h 桶:用剩余额度 / 桶总量反推已用率。
+    if let Some(utilization) = minimax_bucket_utilization(
+        item,
+        "current_interval_remaining_percent",
+        "current_interval_boost_permille",
+    ) {
         let resets_at = item
             .get("end_time")
             .and_then(|v| v.as_i64())
             .and_then(millis_to_iso8601);
         tiers.push(QuotaTier {
             name: TIER_FIVE_HOUR.to_string(),
-            utilization: 100.0 - remain_pct,
+            utilization,
             resets_at,
             used_value_usd: None,
             max_value_usd: None,
@@ -590,17 +592,18 @@ fn parse_minimax_tiers(body: &serde_json::Value) -> Vec<QuotaTier> {
 
     // 周桶:仅当 status=1 时激活;status=3 等表示该套餐无周限额,跳过
     if item.get("current_weekly_status").and_then(|v| v.as_i64()) == Some(1) {
-        if let Some(remain_pct) = item
-            .get("current_weekly_remaining_percent")
-            .and_then(|v| v.as_f64())
-        {
+        if let Some(utilization) = minimax_bucket_utilization(
+            item,
+            "current_weekly_remaining_percent",
+            "weekly_boost_permille",
+        ) {
             let resets_at = item
                 .get("weekly_end_time")
                 .and_then(|v| v.as_i64())
                 .and_then(millis_to_iso8601);
             tiers.push(QuotaTier {
                 name: TIER_WEEKLY_LIMIT.to_string(),
-                utilization: 100.0 - remain_pct,
+                utilization,
                 resets_at,
                 used_value_usd: None,
                 max_value_usd: None,
@@ -609,6 +612,24 @@ fn parse_minimax_tiers(body: &serde_json::Value) -> Vec<QuotaTier> {
     }
 
     tiers
+}
+
+fn minimax_bucket_utilization(
+    item: &serde_json::Value,
+    remaining_percent_key: &str,
+    boost_permille_key: &str,
+) -> Option<f64> {
+    let remaining = item.get(remaining_percent_key).and_then(parse_f64)?;
+    let total = minimax_bucket_total_percent(item, boost_permille_key);
+    Some(((total - remaining) / total) * 100.0)
+}
+
+fn minimax_bucket_total_percent(item: &serde_json::Value, boost_permille_key: &str) -> f64 {
+    item.get(boost_permille_key)
+        .and_then(parse_f64)
+        .filter(|permille| *permille > 0.0)
+        .map(|permille| permille / 10.0)
+        .unwrap_or(100.0)
 }
 
 // ── 公开入口 ────────────────────────────────────────────────
@@ -827,6 +848,55 @@ mod tests {
         assert_eq!(tiers[1].name, TIER_WEEKLY_LIMIT);
         assert_eq!(tiers[1].utilization, 5.0);
         assert!(tiers[1].resets_at.is_some());
+    }
+
+    #[test]
+    fn minimax_boost_permille_changes_bucket_totals() {
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_remaining_percent": 52,
+                "current_weekly_remaining_percent": 92,
+                "current_interval_status": 1,
+                "current_weekly_status": 1,
+                "current_interval_total_count": 0,
+                "current_interval_usage_count": 0,
+                "current_weekly_total_count": 0,
+                "current_weekly_usage_count": 0,
+                "current_interval_boost_permille": 1500,
+                "weekly_boost_permille": 1500
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
+        assert!(
+            (tiers[0].utilization - 65.333_333_333_333_33).abs() < 1e-9
+        );
+        assert_eq!(tiers[1].name, TIER_WEEKLY_LIMIT);
+        assert!(
+            (tiers[1].utilization - 38.666_666_666_666_664).abs() < 1e-9
+        );
+    }
+
+    #[test]
+    fn minimax_count_fields_do_not_override_remaining_percent() {
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 3,
+                "current_interval_usage_count": 3,
+                "current_interval_remaining_percent": 80,
+                "current_weekly_total_count": 21,
+                "current_weekly_usage_count": 7,
+                "current_weekly_remaining_percent": 70,
+                "current_weekly_status": 1
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        assert_eq!(tiers[0].utilization, 20.0);
+        assert_eq!(tiers[1].utilization, 30.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

  - 修复 MiniMax Coding Plan 在 5h / 周桶总额度被 boost 后不再等于 100 时的用量计算。
  - 只读取精确 boost 字段：
      - 5h 桶：current_interval_boost_permille
      - 周桶：weekly_boost_permille

  - 使用正确的 boost 用量公式：
      - 总配额 = boost_permille / 10
      - 已用 = (100 - remaining_percent) * boost_permille / 1000

  - MiniMax 用量计算不使用 count 字段，current_*_total_count 和 current_*_usage_count 不会覆盖
    remaining percent。

  - 新增回归测试，覆盖 boost 桶计算和 count 字段不覆盖百分比的行为。

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->
Fixes #
pr: https://github.com/farion1231/cc-switch/pull/3518

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->


| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|    MiniMax 周桶 boost 会被错误归一化，例如remaining=92、weekly_boost_permille=1500 时显示8%。<img width="786" height="111" alt="image" src="https://github.com/user-attachments/assets/5b3fba79-69eb-471b-8ee3-f15e9c8068d3" />  |        按 boost 用量公式计算，例如 remaining=92，weekly_boost_permille=1500 时显示 12%。<img width="878" height="120" alt="image" src="https://github.com/user-attachments/assets/47be0446-4b3c-418a-ac57-9a4ff3c92f3a" />  |

真实用量：
<img width="2174" height="195" alt="image" src="https://github.com/user-attachments/assets/6779d8a8-9629-4599-b595-6dc68cc6e871" />

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
  额外验证：
- [x] cargo test --manifest-path src-tauri/Cargo.toml minimax passes