### PR TITLE
[codex] Fix WebDAV saved password placeholder

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -22,6 +22,10 @@ fn default_true() -> bool {
     true
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 /// 主页面显示的应用配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -115,6 +119,8 @@ pub struct WebDavSyncSettings {
     pub username: String,
     #[serde(default)]
     pub password: String,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub password_configured: bool,
     #[serde(default = "default_remote_root")]
     pub remote_root: String,
     #[serde(default = "default_profile")]
@@ -131,6 +137,7 @@ impl Default for WebDavSyncSettings {
             base_url: String::new(),
             username: String::new(),
             password: String::new(),
+            password_configured: false,
             remote_root: default_remote_root(),
             profile: default_profile(),
             status: WebDavSyncStatus::default(),
@@ -160,6 +167,7 @@ impl WebDavSyncSettings {
     pub fn normalize(&mut self) {
         self.base_url = self.base_url.trim().to_string();
         self.username = self.username.trim().to_string();
+        self.password_configured = !self.password.is_empty();
         self.remote_root = self.remote_root.trim().to_string();
         self.profile = self.profile.trim().to_string();
         if self.remote_root.is_empty() {
@@ -680,6 +688,7 @@ pub fn get_settings() -> AppSettings {
 pub fn get_settings_for_frontend() -> AppSettings {
     let mut settings = get_settings();
     if let Some(sync) = &mut settings.webdav_sync {
+        sync.password_configured = !sync.password.is_empty();
         sync.password.clear();
     }
     if let Some(s3) = &mut settings.s3_sync {
@@ -1021,6 +1030,7 @@ pub fn update_s3_sync_status(status: WebDavSyncStatus) -> Result<(), AppError> {
 mod tests {
     use super::*;
     use crate::app_config::AppType;
+    use serial_test::serial;
 
     #[test]
     fn visible_apps_old_settings_default_claude_desktop_visible() {
@@ -1051,5 +1061,34 @@ mod tests {
         .expect("visible apps");
 
         assert!(!visible.is_visible(&AppType::ClaudeDesktop));
+    }
+
+    #[test]
+    #[serial]
+    fn frontend_settings_marks_webdav_password_configured_without_exposing_it() {
+        let test_home = std::env::temp_dir().join("cc-switch-webdav-password-redaction-test");
+        let _ = std::fs::remove_dir_all(&test_home);
+        std::fs::create_dir_all(&test_home).expect("create test home");
+        std::env::set_var("CC_SWITCH_TEST_HOME", &test_home);
+
+        update_settings(AppSettings {
+            webdav_sync: Some(WebDavSyncSettings {
+                enabled: true,
+                base_url: "https://dav.example.com/dav/".to_string(),
+                username: "alice".to_string(),
+                password: "secret".to_string(),
+                ..WebDavSyncSettings::default()
+            }),
+            ..AppSettings::default()
+        })
+        .expect("seed settings");
+
+        let frontend_settings = get_settings_for_frontend();
+        let sync = frontend_settings
+            .webdav_sync
+            .expect("frontend webdav settings");
+
+        assert!(sync.password.is_empty());
+        assert!(sync.password_configured);
     }
 }

--- a/src/components/settings/WebdavSyncSection.tsx
+++ b/src/components/settings/WebdavSyncSection.tsx
@@ -147,6 +147,8 @@ const S3_PRESETS: S3Preset[] = [
   },
 ];
 
+const SAVED_PASSWORD_PLACEHOLDER = "••••••••";
+
 /** Format an RFC 3339 date string for display; falls back to raw string. */
 function formatDate(rfc3339: string): string {
   const d = new Date(rfc3339);
@@ -155,20 +157,6 @@ function formatDate(rfc3339: string): string {
 
 function formatDbCompatVersion(version?: number | null): string | null {
   return typeof version === "number" ? `db-v${version}` : null;
-}
-
-function buildPasswordPreservationKey(values: {
-  baseUrl?: string | null;
-  username?: string | null;
-  remoteRoot?: string | null;
-  profile?: string | null;
-}) {
-  return JSON.stringify({
-    baseUrl: values.baseUrl ?? "",
-    username: values.username ?? "",
-    remoteRoot: values.remoteRoot ?? "cc-switch-sync",
-    profile: values.profile ?? "default",
-  });
 }
 
 // ─── Types ──────────────────────────────────────────────────
@@ -244,10 +232,6 @@ export function WebdavSyncSection({
   const [passwordTouched, setPasswordTouched] = useState(false);
   const [justSaved, setJustSaved] = useState(false);
   const justSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingPasswordPreservationRef = useRef<{
-    key: string;
-    password: string;
-  } | null>(null);
 
   // ─── Sync type selector ────────────────────────────────────
   const [syncType, setSyncType] = useState<SyncType>(() =>
@@ -309,6 +293,8 @@ export function WebdavSyncSection({
   );
 
   const activePreset = WEBDAV_PRESETS.find((p) => p.id === presetId);
+  const showSavedPasswordPlaceholder =
+    !!config?.passwordConfigured && !passwordTouched && !form.password;
 
   // Confirmation dialog state
   const [dialogType, setDialogType] = useState<DialogType>(null);
@@ -337,36 +323,13 @@ export function WebdavSyncSection({
   // Sync form when config is loaded/updated from backend, but not while user is editing
   useEffect(() => {
     if (!config || dirty) return;
-    setForm(() => {
-      const nextBaseUrl = config.baseUrl ?? "";
-      const nextUsername = config.username ?? "";
-      const nextRemoteRoot = config.remoteRoot ?? "cc-switch-sync";
-      const nextProfile = config.profile ?? "default";
-      const nextKey = buildPasswordPreservationKey({
-        baseUrl: nextBaseUrl,
-        username: nextUsername,
-        remoteRoot: nextRemoteRoot,
-        profile: nextProfile,
-      });
-      const shouldPreserveRedactedPassword =
-        !config.password &&
-        pendingPasswordPreservationRef.current?.key === nextKey &&
-        !!pendingPasswordPreservationRef.current.password;
-
-      const nextPassword = shouldPreserveRedactedPassword
-        ? pendingPasswordPreservationRef.current!.password
-        : (config.password ?? "");
-
-      pendingPasswordPreservationRef.current = null;
-
-      return {
-        baseUrl: nextBaseUrl,
-        username: nextUsername,
-        password: nextPassword,
-        remoteRoot: nextRemoteRoot,
-        profile: nextProfile,
-        autoSync: config.autoSync ?? false,
-      };
+    setForm({
+      baseUrl: config.baseUrl ?? "",
+      username: config.username ?? "",
+      password: config.password ?? "",
+      remoteRoot: config.remoteRoot ?? "cc-switch-sync",
+      profile: config.profile ?? "default",
+      autoSync: config.autoSync ?? false,
     });
     setPasswordTouched(false);
     setPresetId(detectPreset(config.baseUrl ?? ""));
@@ -497,12 +460,6 @@ export function WebdavSyncSection({
       return;
     }
     setActionState("saving");
-    pendingPasswordPreservationRef.current = form.password
-      ? {
-          key: buildPasswordPreservationKey(settings),
-          password: form.password,
-        }
-      : null;
     try {
       await settingsApi.webdavSyncSaveSettings(settings, passwordTouched);
       setDirty(false);
@@ -516,7 +473,6 @@ export function WebdavSyncSection({
       }, 2000);
       await queryClient.invalidateQueries();
     } catch (error) {
-      pendingPasswordPreservationRef.current = null;
       toast.error(
         t("settings.webdavSync.saveFailed", {
           error: (error as Error)?.message ?? String(error),
@@ -1057,7 +1013,11 @@ export function WebdavSyncSection({
                 type="password"
                 value={form.password}
                 onChange={(e) => updateField("password", e.target.value)}
-                placeholder={t("settings.webdavSync.passwordPlaceholder")}
+                placeholder={
+                  showSavedPasswordPlaceholder
+                    ? SAVED_PASSWORD_PLACEHOLDER
+                    : t("settings.webdavSync.passwordPlaceholder")
+                }
                 className="text-xs flex-1"
                 autoComplete="off"
                 disabled={isLoading}

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -43,6 +43,7 @@ export const settingsSchema = z.object({
       baseUrl: z.string().trim().optional().or(z.literal("")),
       username: z.string().trim().optional().or(z.literal("")),
       password: z.string().optional(),
+      passwordConfigured: z.boolean().optional(),
       remoteRoot: z.string().trim().optional().or(z.literal("")),
       profile: z.string().trim().optional().or(z.literal("")),
       status: z

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,7 @@ export interface WebDavSyncSettings {
   baseUrl?: string;
   username?: string;
   password?: string;
+  passwordConfigured?: boolean;
   remoteRoot?: string;
   profile?: string;
   status?: WebDavSyncStatus;

--- a/tests/components/WebdavSyncSection.test.tsx
+++ b/tests/components/WebdavSyncSection.test.tsx
@@ -27,7 +27,9 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Button: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 vi.mock("@/components/ui/input", () => ({
@@ -90,7 +92,8 @@ const baseConfig: WebDavSyncSettings = {
   enabled: true,
   baseUrl: "https://dav.example.com/dav/",
   username: "alice",
-  password: "secret",
+  password: "",
+  passwordConfigured: true,
   remoteRoot: "cc-switch-sync",
   profile: "default",
   autoSync: false,
@@ -138,7 +141,9 @@ describe("WebdavSyncSection", () => {
       artifacts: ["db.sql", "skills.zip"],
     });
     settingsApiMock.webdavSyncUpload.mockResolvedValue({ status: "uploaded" });
-    settingsApiMock.webdavSyncDownload.mockResolvedValue({ status: "downloaded" });
+    settingsApiMock.webdavSyncDownload.mockResolvedValue({
+      status: "downloaded",
+    });
   });
 
   it("shows auto sync error callout when last auto sync failed", () => {
@@ -187,16 +192,22 @@ describe("WebdavSyncSection", () => {
   it("shows validation error when saving without base url", async () => {
     renderSection({ ...baseConfig, baseUrl: "" });
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
-    expect(toastErrorMock).toHaveBeenCalledWith("settings.webdavSync.missingUrl");
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "settings.webdavSync.missingUrl",
+    );
     expect(settingsApiMock.webdavSyncSaveSettings).not.toHaveBeenCalled();
   });
 
   it("saves settings and auto tests connection", async () => {
     renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -223,105 +234,47 @@ describe("WebdavSyncSection", () => {
     );
   });
 
-  it("preserves password only for the single post-save refresh", async () => {
-    const view = renderSection(baseConfig);
+  it("shows a masked placeholder for a saved redacted password", () => {
+    renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    const passwordInput = screen.getByPlaceholderText(
+      "••••••••",
+    ) as HTMLInputElement;
 
-    await waitFor(() => {
-      expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
-    });
-
-    view.rerender(
-      <QueryClientProvider client={view.client}>
-        <WebdavSyncSection config={{ ...baseConfig, password: "" }} />
-      </QueryClientProvider>,
-    );
-
-    expect(
-      (
-        screen.getByPlaceholderText(
-          "settings.webdavSync.passwordPlaceholder",
-        ) as HTMLInputElement
-      ).value,
-    ).toBe("secret");
-
-    view.rerender(
-      <QueryClientProvider client={view.client}>
-        <WebdavSyncSection config={{ ...baseConfig, password: "" }} />
-      </QueryClientProvider>,
-    );
-
-    expect(
-      (
-        screen.getByPlaceholderText(
-          "settings.webdavSync.passwordPlaceholder",
-        ) as HTMLInputElement
-      ).value,
-    ).toBe("");
+    expect(passwordInput.value).toBe("");
   });
 
-  it("does not preserve password after a later external config refresh", async () => {
-    const view = renderSection(baseConfig);
+  it("keeps the redacted saved password when testing without touching it", async () => {
+    renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
-
-    await waitFor(() => {
-      expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
-    });
-
-    view.rerender(
-      <QueryClientProvider client={view.client}>
-        <WebdavSyncSection config={{ ...baseConfig, password: "" }} />
-      </QueryClientProvider>,
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.test" }),
     );
-
-    expect(
-      (
-        screen.getByPlaceholderText(
-          "settings.webdavSync.passwordPlaceholder",
-        ) as HTMLInputElement
-      ).value,
-    ).toBe("secret");
-
-    view.rerender(
-      <QueryClientProvider client={view.client}>
-        <WebdavSyncSection
-          config={{ ...baseConfig, username: "bob", password: "" }}
-        />
-      </QueryClientProvider>,
-    );
-
-    expect(
-      (
-        screen.getByPlaceholderText(
-          "settings.webdavSync.passwordPlaceholder",
-        ) as HTMLInputElement
-      ).value,
-    ).toBe("");
-  });
-
-  it("does not submit a preserved password again when testing without touching it", async () => {
-    const view = renderSection(baseConfig);
-
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
-
-    await waitFor(() => {
-      expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
-    });
-
-    view.rerender(
-      <QueryClientProvider client={view.client}>
-        <WebdavSyncSection config={{ ...baseConfig, password: "" }} />
-      </QueryClientProvider>,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.test" }));
 
     await waitFor(() => {
       expect(settingsApiMock.webdavTestConnection).toHaveBeenLastCalledWith(
         expect.objectContaining({
           password: "",
+        }),
+        true,
+      );
+    });
+  });
+
+  it("submits a replacement password only after the password field is edited", async () => {
+    renderSection(baseConfig);
+
+    fireEvent.change(screen.getByPlaceholderText("••••••••"), {
+      target: { value: "new-secret" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
+
+    await waitFor(() => {
+      expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          password: "new-secret",
         }),
         true,
       );
@@ -342,7 +295,9 @@ describe("WebdavSyncSection", () => {
         screen.getByRole("switch", { name: "settings.webdavSync.autoSync" }),
       ).toHaveAttribute("aria-checked", "true");
     });
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledWith(
@@ -394,7 +349,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(
@@ -418,7 +375,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.upload" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("cc-switch-sync"), {
@@ -446,7 +405,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(
@@ -470,7 +431,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.download" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("default"), {
@@ -491,7 +454,9 @@ describe("WebdavSyncSection", () => {
   });
 
   it("shows info when no remote snapshot is found for download", async () => {
-    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({ empty: true });
+    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({
+      empty: true,
+    });
     renderSection(baseConfig);
 
     fireEvent.click(
@@ -499,7 +464,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(toastInfoMock).toHaveBeenCalledWith("settings.webdavSync.noRemoteData");
+      expect(toastInfoMock).toHaveBeenCalledWith(
+        "settings.webdavSync.noRemoteData",
+      );
     });
     expect(settingsApiMock.webdavSyncDownload).not.toHaveBeenCalled();
   });
@@ -540,7 +507,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.download" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(


### PR DESCRIPTION
## Summary

This PR fixes the WebDAV sync settings password field when a password has already been saved.

Previously, the backend correctly redacted the saved WebDAV password before returning settings to the frontend, but the frontend could only see an empty `password` value. As a result, the password field looked blank even when a password was already configured.

This change adds a non-sensitive `passwordConfigured` flag so the frontend can show a masked placeholder (`••••••••`) without receiving or storing the real password.

## What changed

- Add `passwordConfigured` to WebDAV sync settings returned to the frontend.
- Keep the actual WebDAV password redacted before sending settings to the frontend.
- Show a masked placeholder for saved WebDAV passwords while keeping the input value empty.
- Remove the previous frontend-only password preservation logic that temporarily kept the typed password in the input after save.
- Update WebDAV sync settings tests for the redacted saved-password behavior.

## Behavior

- If a WebDAV password is already saved, the password field shows `••••••••` as a placeholder.
- If the user does not edit the password field, saves/tests continue to preserve the existing saved password.
- If the user enters a new password, the new password is submitted and replaces the saved one.

## Scope

This is scoped to the WebDAV sync settings form and settings payload only.

It does not change routing, provider configs, S3 sync, Claude Code, Codex, Gemini, or other client behavior. It also does not expose stored credentials to the frontend.

## Validation

- `pnpm test:unit tests/components/WebdavSyncSection.test.tsx`
- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`