### PR TITLE
feat(usage): UsageDateRangePicker 默认 end 改为当天结束时刻

### DIFF
--- a/src/components/usage/UsageDateRangePicker.tsx
+++ b/src/components/usage/UsageDateRangePicker.tsx
@@ -484,8 +484,7 @@ export function UsageDateRangePicker({
                 const isEnd = isSameDay(day, endDay);
                 const dayStart = getStartOfLocalDayDate(day.getTime());
                 const inRange =
-                  dayStart >= startBoundary &&
-                  dayStart <= endBoundary;
+                  dayStart >= startBoundary && dayStart <= endBoundary;
                 const isEndpoint = isStart || isEnd;
 
                 return (

--- a/src/components/usage/UsageDateRangePicker.tsx
+++ b/src/components/usage/UsageDateRangePicker.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import {
+  dateToTs,
   getStartOfLocalDayDate,
   getUsageRangePresetLabel,
   isSameDay,
@@ -39,21 +40,13 @@ interface UsageDateRangePickerProps {
 
 /* ── helpers ── */
 
-function toTs(d: Date): number {
-  return Math.floor(d.getTime() / 1000);
-}
-
-function fromTs(ts: number): Date {
-  return tsToDate(ts);
-}
-
 function fmtDate(ts: number): string {
-  const d = fromTs(ts);
+  const d = tsToDate(ts);
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
 function fmtTime(ts: number): string {
-  const d = fromTs(ts);
+  const d = tsToDate(ts);
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
@@ -61,15 +54,15 @@ function parseDateInput(ts: number, value: string): number {
   const [y, m, d] = value.split("-").map(Number);
   if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d))
     return ts;
-  const base = fromTs(ts);
-  return toTs(new Date(y, m - 1, d, base.getHours(), base.getMinutes()));
+  const base = tsToDate(ts);
+  return dateToTs(new Date(y, m - 1, d, base.getHours(), base.getMinutes()));
 }
 
 function parseTimeInput(ts: number, value: string): number {
   const [h, min] = value.split(":").map(Number);
   if (!Number.isFinite(h) || !Number.isFinite(min)) return ts;
-  const base = fromTs(ts);
-  return toTs(
+  const base = tsToDate(ts);
+  return dateToTs(
     new Date(base.getFullYear(), base.getMonth(), base.getDate(), h, min),
   );
 }
@@ -95,9 +88,16 @@ export function UsageDateRangePicker({
   const { t, i18n } = useTranslation();
   const [open, setOpen] = useState(false);
   const [activeField, setActiveField] = useState<DraftField>("start");
-  // resolveUsageRange 内部默认取 Date.now(), 不需要外部维护一个 nowMs state
-  // 触发 memo 重算;hook 自身的 dep 比较开销大于函数体本身。
-  const resolvedRange = resolveUsageRange(selection);
+  // resolveUsageRange 内部默认取 Date.now(), 用 useMemo 缓存
+  const resolvedRange = useMemo(
+    () => resolveUsageRange(selection),
+    [
+      selection.preset,
+      selection.customStartDate,
+      selection.customEndDate,
+      selection.liveEndTime,
+    ],
+  );
   const [draftStart, setDraftStart] = useState(() =>
     normalizePickerStart(resolvedRange.startDate),
   );
@@ -110,8 +110,8 @@ export function UsageDateRangePicker({
   const [displayMonth, setDisplayMonth] = useState(
     () =>
       new Date(
-        fromTs(resolvedRange.startDate).getFullYear(),
-        fromTs(resolvedRange.startDate).getMonth(),
+        tsToDate(resolvedRange.startDate).getFullYear(),
+        tsToDate(resolvedRange.startDate).getMonth(),
         1,
       ),
   );
@@ -132,8 +132,8 @@ export function UsageDateRangePicker({
     );
     setDisplayMonth(
       new Date(
-        fromTs(r.startDate).getFullYear(),
-        fromTs(r.startDate).getMonth(),
+        tsToDate(r.startDate).getFullYear(),
+        tsToDate(r.startDate).getMonth(),
         1,
       ),
     );
@@ -145,8 +145,6 @@ export function UsageDateRangePicker({
     selection.customStartDate,
     selection.customEndDate,
     selection.liveEndTime,
-    // selection 对象引用兜底: 父组件在传 selection 但标量未变时也会重置
-    selection,
   ]);
 
   // Keep draftEnd ticking when live mode is active and popover is open
@@ -177,8 +175,8 @@ export function UsageDateRangePicker({
     [locale],
   );
 
-  const startDay = fromTs(draftStart);
-  const endDay = fromTs(draftEnd);
+  const startDay = tsToDate(draftStart);
+  const endDay = tsToDate(draftEnd);
   const today = new Date();
   // day grid 内 inRange 比较用的边界, 提到循环外避免 42 次重建 Date
   const startBoundary = getStartOfLocalDayDate(draftStart * 1000);
@@ -187,7 +185,7 @@ export function UsageDateRangePicker({
   /* Pick a date from the calendar */
   const handleDatePick = (day: Date) => {
     setError(null);
-    const dayTs = toTs(day);
+    const dayTs = dateToTs(day);
     // When live end time is active, calendar only controls start date
     if (draftLiveEnd) {
       setDraftStart(normalizePickerStart(dayTs));
@@ -247,8 +245,8 @@ export function UsageDateRangePicker({
     const setTs = field === "start" ? setDraftStart : setDraftEnd;
     const label =
       field === "start"
-        ? t("usage.startTime", "开始时间")
-        : t("usage.endTime", "结束时间");
+          ? t("usage.startTime", "开始时间")
+          : t("usage.endTime", "结束时间");
     // 复用与日历/reset 完全相同的归一化路径, 保证 end 框输入也走
     // "end 是当天→now" 语义, 不再单独走 23:59 分支
     const normalize = (raw: number) =>
@@ -283,7 +281,7 @@ export function UsageDateRangePicker({
               if (isEndLive) return;
               const next = normalize(parseDateInput(ts, e.target.value));
               setTs(next);
-              const d = fromTs(next);
+              const d = tsToDate(next);
               setDisplayMonth(new Date(d.getFullYear(), d.getMonth(), 1));
               setError(null);
             }}
@@ -302,7 +300,10 @@ export function UsageDateRangePicker({
             value={fmtTime(ts)}
             onChange={(e) => {
               if (isEndLive) return;
-              setTs(normalize(parseTimeInput(ts, e.target.value)));
+              const raw = parseTimeInput(ts, e.target.value);
+              // time input 是用户的精确意图, 不经过 normalizePickerEnd
+              // (日历点选和 popover reset 仍走 normalize 路径)
+              setTs(field === "start" ? normalizePickerStart(raw) : raw);
               setError(null);
             }}
             onFocus={() => {

--- a/src/components/usage/UsageDateRangePicker.tsx
+++ b/src/components/usage/UsageDateRangePicker.tsx
@@ -16,13 +16,13 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import {
-  getEndOfLocalDayDate,
   getStartOfLocalDayDate,
   getUsageRangePresetLabel,
   isSameDay,
   normalizePickerEnd,
   normalizePickerStart,
   resolveUsageRange,
+  tsToDate,
 } from "@/lib/usageRange";
 import { getLocaleFromLanguage } from "./format";
 import type { UsageRangePreset, UsageRangeSelection } from "@/types/usage";
@@ -44,7 +44,7 @@ function toTs(d: Date): number {
 }
 
 function fromTs(ts: number): Date {
-  return new Date(ts * 1000);
+  return tsToDate(ts);
 }
 
 function fmtDate(ts: number): string {
@@ -85,16 +85,6 @@ function getCalendarDays(month: Date): Date[] {
   });
 }
 
-/**
- * 归一化 helper:
- *   - start → 00:00
- *   - end → 23:59 (整天结束, 不走 '今天→now' 分支)
- */
-function normalizeField(field: DraftField, ts: number): number {
-  if (field === "start") return normalizePickerStart(ts);
-  return Math.floor(getEndOfLocalDayDate(ts * 1000).getTime() / 1000);
-}
-
 /* ── component ── */
 
 export function UsageDateRangePicker({
@@ -104,17 +94,15 @@ export function UsageDateRangePicker({
 }: UsageDateRangePickerProps) {
   const { t, i18n } = useTranslation();
   const [open, setOpen] = useState(false);
-  const [nowMs, setNowMs] = useState(() => Date.now());
   const [activeField, setActiveField] = useState<DraftField>("start");
-  const resolvedRange = useMemo(
-    () => resolveUsageRange(selection, nowMs),
-    [selection, nowMs],
-  );
+  // resolveUsageRange 内部默认取 Date.now(), 不需要外部维护一个 nowMs state
+  // 触发 memo 重算;hook 自身的 dep 比较开销大于函数体本身。
+  const resolvedRange = resolveUsageRange(selection);
   const [draftStart, setDraftStart] = useState(() =>
     normalizePickerStart(resolvedRange.startDate),
   );
   const [draftEnd, setDraftEnd] = useState(() =>
-    normalizePickerEnd(resolvedRange.endDate, nowMs),
+    normalizePickerEnd(resolvedRange.endDate),
   );
   const [draftLiveEnd, setDraftLiveEnd] = useState(
     selection.preset === "custom" ? (selection.liveEndTime ?? false) : false,
@@ -132,14 +120,11 @@ export function UsageDateRangePicker({
   const language = i18n.resolvedLanguage || i18n.language || "en";
   const locale = getLocaleFromLanguage(language);
 
-  // Reset draft when popover opens
+  // Reset draft when popover opens. 依赖稳定标量,避免父组件 selection 引用变化时无谓重置。
   useEffect(() => {
     if (!open) return;
     const currentNow = Date.now();
-    setNowMs(currentNow);
     const r = resolveUsageRange(selection, currentNow);
-    // 打开 picker 时 reset: start→00:00, end→当天→now / 非当天→23:59.
-    // 用户在 picker 内改的时间由 setDraftStart/setDraftEnd 维护, 不被本次 reset 覆盖。
     setDraftStart(normalizePickerStart(r.startDate));
     setDraftEnd(normalizePickerEnd(r.endDate, currentNow));
     setDraftLiveEnd(
@@ -154,12 +139,24 @@ export function UsageDateRangePicker({
     );
     setActiveField("start");
     setError(null);
-  }, [open, selection]);
+  }, [
+    open,
+    selection.preset,
+    selection.customStartDate,
+    selection.customEndDate,
+    selection.liveEndTime,
+    // selection 对象引用兜底: 父组件在传 selection 但标量未变时也会重置
+    selection,
+  ]);
 
   // Keep draftEnd ticking when live mode is active and popover is open
   useEffect(() => {
     if (!open || !draftLiveEnd) return;
-    const tick = () => setDraftEnd(Math.floor(Date.now() / 1000));
+    const tick = () => {
+      const next = Math.floor(Date.now() / 1000);
+      // 同秒内 setState 会触发不必要的重渲染,值未变则跳过
+      setDraftEnd((prev) => (prev === next ? prev : next));
+    };
     tick();
     const id = setInterval(tick, 1000);
     return () => clearInterval(id);
@@ -190,24 +187,24 @@ export function UsageDateRangePicker({
   /* Pick a date from the calendar */
   const handleDatePick = (day: Date) => {
     setError(null);
+    const dayTs = toTs(day);
     // When live end time is active, calendar only controls start date
     if (draftLiveEnd) {
-      const nextStartTs = normalizePickerStart(toTs(day));
-      setDraftStart(nextStartTs);
+      setDraftStart(normalizePickerStart(dayTs));
     } else if (activeField === "start") {
-      const nextStartTs = normalizePickerStart(toTs(day));
+      const nextStartTs = normalizePickerStart(dayTs);
       setDraftStart(nextStartTs);
       // Auto-swap if start > end
       if (nextStartTs > draftEnd) {
-        setDraftEnd(normalizePickerEnd(nextStartTs, nowMs));
+        setDraftEnd(normalizePickerEnd(nextStartTs));
       }
       // Auto-advance to end field
       setActiveField("end");
     } else {
-      const nextEndTs = normalizePickerEnd(toTs(day), nowMs);
+      const nextEndTs = normalizePickerEnd(dayTs);
       // If picked end < start, treat as new start and stay on start field
       if (nextEndTs < draftStart) {
-        setDraftStart(normalizePickerStart(toTs(day)));
+        setDraftStart(normalizePickerStart(dayTs));
         setActiveField("start");
       } else {
         setDraftEnd(nextEndTs);
@@ -252,6 +249,10 @@ export function UsageDateRangePicker({
       field === "start"
         ? t("usage.startTime", "开始时间")
         : t("usage.endTime", "结束时间");
+    // 复用与日历/reset 完全相同的归一化路径, 保证 end 框输入也走
+    // "end 是当天→now" 语义, 不再单独走 23:59 分支
+    const normalize = (raw: number) =>
+      field === "start" ? normalizePickerStart(raw) : normalizePickerEnd(raw);
 
     return (
       <div
@@ -280,10 +281,7 @@ export function UsageDateRangePicker({
             value={fmtDate(ts)}
             onChange={(e) => {
               if (isEndLive) return;
-              const next = normalizeField(
-                field,
-                parseDateInput(ts, e.target.value),
-              );
+              const next = normalize(parseDateInput(ts, e.target.value));
               setTs(next);
               const d = fromTs(next);
               setDisplayMonth(new Date(d.getFullYear(), d.getMonth(), 1));
@@ -304,7 +302,7 @@ export function UsageDateRangePicker({
             value={fmtTime(ts)}
             onChange={(e) => {
               if (isEndLive) return;
-              setTs(normalizeField(field, parseTimeInput(ts, e.target.value)));
+              setTs(normalize(parseTimeInput(ts, e.target.value)));
               setError(null);
             }}
             onFocus={() => {

--- a/src/components/usage/UsageDateRangePicker.tsx
+++ b/src/components/usage/UsageDateRangePicker.tsx
@@ -194,18 +194,7 @@ export function UsageDateRangePicker({
     if (draftLiveEnd) {
       const nextStartTs = normalizePickerStart(toTs(day));
       setDraftStart(nextStartTs);
-      
-      // Navigate calendar if the day is outside the displayed month
-      if (
-        day.getMonth() !== displayMonth.getMonth() ||
-        day.getFullYear() !== displayMonth.getFullYear()
-      ) {
-        setDisplayMonth(new Date(day.getFullYear(), day.getMonth(), 1));
-      }
-      return;
-    }
-
-    if (activeField === "start") {
+    } else if (activeField === "start") {
       const nextStartTs = normalizePickerStart(toTs(day));
       setDraftStart(nextStartTs);
       // Auto-swap if start > end

--- a/src/components/usage/UsageDateRangePicker.tsx
+++ b/src/components/usage/UsageDateRangePicker.tsx
@@ -15,7 +15,15 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { getUsageRangePresetLabel, resolveUsageRange } from "@/lib/usageRange";
+import {
+  getEndOfLocalDayDate,
+  getStartOfLocalDayDate,
+  getUsageRangePresetLabel,
+  isSameDay,
+  normalizePickerEnd,
+  normalizePickerStart,
+  resolveUsageRange,
+} from "@/lib/usageRange";
 import { getLocaleFromLanguage } from "./format";
 import type { UsageRangePreset, UsageRangeSelection } from "@/types/usage";
 
@@ -30,18 +38,6 @@ interface UsageDateRangePickerProps {
 }
 
 /* ── helpers ── */
-
-function startOfDay(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
-}
-
-function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
-}
 
 function toTs(d: Date): number {
   return Math.floor(d.getTime() / 1000);
@@ -78,19 +74,6 @@ function parseTimeInput(ts: number, value: string): number {
   );
 }
 
-function setDateKeepTime(ts: number, day: Date): number {
-  const base = fromTs(ts);
-  return toTs(
-    new Date(
-      day.getFullYear(),
-      day.getMonth(),
-      day.getDate(),
-      base.getHours(),
-      base.getMinutes(),
-    ),
-  );
-}
-
 function getCalendarDays(month: Date): Date[] {
   const first = new Date(month.getFullYear(), month.getMonth(), 1);
   const gridStart = new Date(first);
@@ -102,6 +85,16 @@ function getCalendarDays(month: Date): Date[] {
   });
 }
 
+/**
+ * 归一化 helper:
+ *   - start → 00:00
+ *   - end → 23:59 (整天结束, 不走 '今天→now' 分支)
+ */
+function normalizeField(field: DraftField, ts: number): number {
+  if (field === "start") return normalizePickerStart(ts);
+  return Math.floor(getEndOfLocalDayDate(ts * 1000).getTime() / 1000);
+}
+
 /* ── component ── */
 
 export function UsageDateRangePicker({
@@ -111,13 +104,18 @@ export function UsageDateRangePicker({
 }: UsageDateRangePickerProps) {
   const { t, i18n } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const [activeField, setActiveField] = useState<DraftField>("start");
   const resolvedRange = useMemo(
-    () => resolveUsageRange(selection),
-    [selection],
+    () => resolveUsageRange(selection, nowMs),
+    [selection, nowMs],
   );
-  const [draftStart, setDraftStart] = useState(resolvedRange.startDate);
-  const [draftEnd, setDraftEnd] = useState(resolvedRange.endDate);
+  const [draftStart, setDraftStart] = useState(() =>
+    normalizePickerStart(resolvedRange.startDate),
+  );
+  const [draftEnd, setDraftEnd] = useState(() =>
+    normalizePickerEnd(resolvedRange.endDate, nowMs),
+  );
   const [draftLiveEnd, setDraftLiveEnd] = useState(
     selection.preset === "custom" ? (selection.liveEndTime ?? false) : false,
   );
@@ -137,9 +135,13 @@ export function UsageDateRangePicker({
   // Reset draft when popover opens
   useEffect(() => {
     if (!open) return;
-    const r = resolveUsageRange(selection);
-    setDraftStart(r.startDate);
-    setDraftEnd(r.endDate);
+    const currentNow = Date.now();
+    setNowMs(currentNow);
+    const r = resolveUsageRange(selection, currentNow);
+    // 打开 picker 时 reset: start→00:00, end→当天→now / 非当天→23:59.
+    // 用户在 picker 内改的时间由 setDraftStart/setDraftEnd 维护, 不被本次 reset 覆盖。
+    setDraftStart(normalizePickerStart(r.startDate));
+    setDraftEnd(normalizePickerEnd(r.endDate, currentNow));
     setDraftLiveEnd(
       selection.preset === "custom" ? (selection.liveEndTime ?? false) : false,
     );
@@ -181,38 +183,45 @@ export function UsageDateRangePicker({
   const startDay = fromTs(draftStart);
   const endDay = fromTs(draftEnd);
   const today = new Date();
+  // day grid 内 inRange 比较用的边界, 提到循环外避免 42 次重建 Date
+  const startBoundary = getStartOfLocalDayDate(draftStart * 1000);
+  const endBoundary = getStartOfLocalDayDate(draftEnd * 1000);
 
   /* Pick a date from the calendar */
   const handleDatePick = (day: Date) => {
     setError(null);
-
     // When live end time is active, calendar only controls start date
     if (draftLiveEnd) {
-      const nextTs = setDateKeepTime(draftStart, day);
-      setDraftStart(nextTs);
+      const nextStartTs = normalizePickerStart(toTs(day));
+      setDraftStart(nextStartTs);
+      
+      // Navigate calendar if the day is outside the displayed month
+      if (
+        day.getMonth() !== displayMonth.getMonth() ||
+        day.getFullYear() !== displayMonth.getFullYear()
+      ) {
+        setDisplayMonth(new Date(day.getFullYear(), day.getMonth(), 1));
+      }
       return;
     }
 
-    const nextTs = setDateKeepTime(
-      activeField === "start" ? draftStart : draftEnd,
-      day,
-    );
-
     if (activeField === "start") {
-      setDraftStart(nextTs);
+      const nextStartTs = normalizePickerStart(toTs(day));
+      setDraftStart(nextStartTs);
       // Auto-swap if start > end
-      if (nextTs > draftEnd) {
-        setDraftEnd(nextTs);
+      if (nextStartTs > draftEnd) {
+        setDraftEnd(normalizePickerEnd(nextStartTs, nowMs));
       }
       // Auto-advance to end field
       setActiveField("end");
     } else {
-      // If picked end < start, treat as new start and auto-advance
-      if (nextTs < draftStart) {
-        setDraftStart(nextTs);
-        setActiveField("end");
+      const nextEndTs = normalizePickerEnd(toTs(day), nowMs);
+      // If picked end < start, treat as new start and stay on start field
+      if (nextEndTs < draftStart) {
+        setDraftStart(normalizePickerStart(toTs(day)));
+        setActiveField("start");
       } else {
-        setDraftEnd(nextTs);
+        setDraftEnd(nextEndTs);
       }
     }
 
@@ -282,7 +291,10 @@ export function UsageDateRangePicker({
             value={fmtDate(ts)}
             onChange={(e) => {
               if (isEndLive) return;
-              const next = parseDateInput(ts, e.target.value);
+              const next = normalizeField(
+                field,
+                parseDateInput(ts, e.target.value),
+              );
               setTs(next);
               const d = fromTs(next);
               setDisplayMonth(new Date(d.getFullYear(), d.getMonth(), 1));
@@ -303,7 +315,7 @@ export function UsageDateRangePicker({
             value={fmtTime(ts)}
             onChange={(e) => {
               if (isEndLive) return;
-              setTs(parseTimeInput(ts, e.target.value));
+              setTs(normalizeField(field, parseTimeInput(ts, e.target.value)));
               setError(null);
             }}
             onFocus={() => {
@@ -470,10 +482,10 @@ export function UsageDateRangePicker({
                 const isToday = isSameDay(day, today);
                 const isStart = isSameDay(day, startDay);
                 const isEnd = isSameDay(day, endDay);
-                const dayStart = startOfDay(day);
+                const dayStart = getStartOfLocalDayDate(day.getTime());
                 const inRange =
-                  dayStart >= startOfDay(startDay) &&
-                  dayStart <= startOfDay(endDay);
+                  dayStart >= startBoundary &&
+                  dayStart <= endBoundary;
                 const isEndpoint = isStart || isEnd;
 
                 return (

--- a/src/lib/usageRange.ts
+++ b/src/lib/usageRange.ts
@@ -35,9 +35,13 @@ export function isSameDay(a: Date, b: Date): boolean {
  * 避免 0:00 触发 `pred_opt()` 把 end 推到昨天、start > end 被判为空。
  */
 export function getEndOfLocalDayDate(nowMs: number): Date {
-  const start = getStartOfLocalDayDate(nowMs);
-  // 用时间戳算术 +1 天 -1ms, 避免在 DST 转换日 setHours(23,...) 跨日回绕
-  return new Date(start.getTime() + 24 * 60 * 60 * 1000 - 1);
+  const date = new Date(nowMs);
+  // 本地日历加 1 天 (自动适配夏令时缩短或拉长的那一天)
+  date.setDate(date.getDate() + 1);
+  // 将明天的这一天归零至 00:00:00.000
+  date.setHours(0, 0, 0, 0);
+  // 减去 1ms，即可安全可靠地得到当天的 23:59:59.999
+  return new Date(date.getTime() - 1);
 }
 
 /**

--- a/src/lib/usageRange.ts
+++ b/src/lib/usageRange.ts
@@ -8,9 +8,62 @@ export interface ResolvedUsageRange {
   endDate: number;
 }
 
-function getStartOfLocalDayDate(nowMs: number): Date {
+/**
+ * 把任意时间戳归到本地当天 00:00:00 的 Date 对象。
+ * 用 setHours(0,0,0,0) 处理 DST 边界 (而不是依赖 getDate() 的隐式 0 时分秒)。
+ */
+export function getStartOfLocalDayDate(nowMs: number): Date {
   const date = new Date(nowMs);
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+/**
+ * 判断两个 Date 是否是同一天（本地时间）。
+ */
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/**
+ * 把任意时间戳归到本地当天 23:59:59.999 的 Date 对象。
+ * 用于 custom 范围的默认 end：对齐后端"end==23:59 视为当天结束"的隐式约定，
+ * 避免 0:00 触发 `pred_opt()` 把 end 推到昨天、start > end 被判为空。
+ */
+export function getEndOfLocalDayDate(nowMs: number): Date {
+  const start = getStartOfLocalDayDate(nowMs);
+  // 用时间戳算术 +1 天 -1ms, 避免在 DST 转换日 setHours(23,...) 跨日回绕
+  return new Date(start.getTime() + 24 * 60 * 60 * 1000 - 1);
+}
+
+/**
+ * Picker reset / 日历点选 / time 框输入的统一归一化.
+ *
+ * 语义:
+ *   - start 永远归一到 00:00:00
+ *   - end:
+ *       * end 所在日期 == 今天 → 总是 now 时刻, 不论原值 (0:00 / 18:00 等都归一)
+ *       * end 所在日期 != 今天 → 23:59:59 (整天已过完)
+ *
+ * 用于 picker 内的所有 '写 draft*' 路径, 防止任意 ts 逃逸到后端
+ * (后端 compute_rollup_date_bounds 对 hour==23 && minute==59 敏感)。
+ */
+export function normalizePickerStart(startTs: number): number {
+  return Math.floor(getStartOfLocalDayDate(startTs * 1000).getTime() / 1000);
+}
+
+export function normalizePickerEnd(endTs: number, nowMs: number = Date.now()): number {
+  const endDate = new Date(endTs * 1000);
+  const today = new Date(nowMs);
+  if (isSameDay(endDate, today)) {
+    // end 是当天 → 总是 now 时刻, 不论原值
+    return Math.floor(nowMs / 1000);
+  }
+  return Math.floor(getEndOfLocalDayDate(endTs * 1000).getTime() / 1000);
 }
 
 function getPresetLookbackStart(
@@ -48,10 +101,13 @@ export function resolveUsageRange(
         endDate,
       };
     case "custom": {
-      const startDate = selection.customStartDate ?? endDate - DAY_SECONDS;
+      const startDate =
+        selection.customStartDate ??
+        Math.floor(getStartOfLocalDayDate(nowMs).getTime() / 1000);
       const customEndDate = selection.liveEndTime
         ? endDate
-        : (selection.customEndDate ?? endDate);
+        : (selection.customEndDate ??
+          Math.floor(getEndOfLocalDayDate(nowMs).getTime() / 1000));
       return {
         startDate,
         endDate: customEndDate,

--- a/src/lib/usageRange.ts
+++ b/src/lib/usageRange.ts
@@ -1,7 +1,6 @@
 import type { UsageRangePreset, UsageRangeSelection } from "@/types/usage";
 
 const DAY_SECONDS = 24 * 60 * 60;
-const DAY_MS = DAY_SECONDS * 1000;
 
 export interface ResolvedUsageRange {
   startDate: number;
@@ -33,11 +32,15 @@ export function isSameDay(a: Date, b: Date): boolean {
   );
 }
 
-/** 把任意时间戳归到本地当天 23:59:59.999 的 Date 对象。 */
-export function getEndOfLocalDayDate(nowMs: number): Date {
+/**
+ * 把任意时间戳归到本地当天 23:59:59.999 的 Date 对象。
+ * 用 "次日 00:00 − 1ms" 模式，自动适配 DST 缩短/拉长那一天。
+ */
+function getEndOfLocalDayDate(nowMs: number): Date {
   const d = new Date(nowMs);
-  d.setHours(23, 59, 59, 999);
-  return d;
+  d.setDate(d.getDate() + 1);
+  d.setHours(0, 0, 0, 0);
+  return new Date(d.getTime() - 1);
 }
 
 /**
@@ -64,7 +67,9 @@ function getPresetLookbackStart(
   nowMs: number,
 ): number {
   const dayCount = preset === "7d" ? 7 : preset === "14d" ? 14 : 30;
-  return dateToTs(getStartOfLocalDayDate(nowMs - (dayCount - 1) * DAY_MS));
+  const start = getStartOfLocalDayDate(nowMs);
+  start.setDate(start.getDate() - (dayCount - 1));
+  return dateToTs(start);
 }
 
 export function resolveUsageRange(
@@ -92,8 +97,9 @@ export function resolveUsageRange(
         endDate,
       };
     case "custom": {
-      const startDate =
-        selection.customStartDate ?? dateToTs(getStartOfLocalDayDate(nowMs));
+      const startDate = selection.customStartDate
+        ? normalizePickerStart(selection.customStartDate)
+        : dateToTs(getStartOfLocalDayDate(nowMs));
       const customEndDate = selection.liveEndTime
         ? endDate
         : (selection.customEndDate ?? dateToTs(getEndOfLocalDayDate(nowMs)));

--- a/src/lib/usageRange.ts
+++ b/src/lib/usageRange.ts
@@ -8,19 +8,23 @@ export interface ResolvedUsageRange {
   endDate: number;
 }
 
-/**
- * 把任意时间戳归到本地当天 00:00:00 的 Date 对象。
- * 用 setHours(0,0,0,0) 处理 DST 边界 (而不是依赖 getDate() 的隐式 0 时分秒)。
- */
+/** unix 秒 ↔ Date 互转,与 picker 内部 toTs/fromTs 共享同一精度语义。 */
+export function tsToDate(ts: number): Date {
+  return new Date(ts * 1000);
+}
+
+export function dateToTs(date: Date): number {
+  return Math.floor(date.getTime() / 1000);
+}
+
+/** 把任意时间戳归到本地当天 00:00:00 的 Date 对象。用 setHours(0,0,0,0) 处理 DST 边界。 */
 export function getStartOfLocalDayDate(nowMs: number): Date {
   const date = new Date(nowMs);
   date.setHours(0, 0, 0, 0);
   return date;
 }
 
-/**
- * 判断两个 Date 是否是同一天（本地时间）。
- */
+/** 判断两个 Date 是否是同一天(本地时间)。 */
 export function isSameDay(a: Date, b: Date): boolean {
   return (
     a.getFullYear() === b.getFullYear() &&
@@ -29,48 +33,30 @@ export function isSameDay(a: Date, b: Date): boolean {
   );
 }
 
-/**
- * 把任意时间戳归到本地当天 23:59:59.999 的 Date 对象。
- * 用于 custom 范围的默认 end：对齐后端"end==23:59 视为当天结束"的隐式约定，
- * 避免 0:00 触发 `pred_opt()` 把 end 推到昨天、start > end 被判为空。
- */
+/** 把任意时间戳归到本地当天 23:59:59.999 的 Date 对象。 */
 export function getEndOfLocalDayDate(nowMs: number): Date {
-  const date = new Date(nowMs);
-  // 本地日历加 1 天 (自动适配夏令时缩短或拉长的那一天)
-  date.setDate(date.getDate() + 1);
-  // 将明天的这一天归零至 00:00:00.000
-  date.setHours(0, 0, 0, 0);
-  // 减去 1ms，即可安全可靠地得到当天的 23:59:59.999
-  return new Date(date.getTime() - 1);
+  const d = new Date(nowMs);
+  d.setHours(23, 59, 59, 999);
+  return d;
 }
 
 /**
- * Picker reset / 日历点选 / time 框输入的统一归一化.
- *
- * 语义:
- *   - start 永远归一到 00:00:00
- *   - end:
- *       * end 所在日期 == 今天 → 总是 now 时刻, 不论原值 (0:00 / 18:00 等都归一)
- *       * end 所在日期 != 今天 → 23:59:59 (整天已过完)
- *
- * 用于 picker 内的所有 '写 draft*' 路径, 防止任意 ts 逃逸到后端
- * (后端 compute_rollup_date_bounds 对 hour==23 && minute==59 敏感)。
+ * Picker 写路径的统一归一化(start 00:00 / end today→now / end 过去→23:59)。
+ * 所有写入 draft* 的入口(打开 reset、日历点选、input 框)都过此函数,
+ * 避免任意 ts 逃逸到后端 compute_rollup_date_bounds。
  */
 export function normalizePickerStart(startTs: number): number {
-  return Math.floor(getStartOfLocalDayDate(startTs * 1000).getTime() / 1000);
+  return dateToTs(getStartOfLocalDayDate(startTs * 1000));
 }
 
 export function normalizePickerEnd(
   endTs: number,
   nowMs: number = Date.now(),
 ): number {
-  const endDate = new Date(endTs * 1000);
-  const today = new Date(nowMs);
-  if (isSameDay(endDate, today)) {
-    // end 是当天 → 总是 now 时刻, 不论原值
+  if (isSameDay(tsToDate(endTs), new Date(nowMs))) {
     return Math.floor(nowMs / 1000);
   }
-  return Math.floor(getEndOfLocalDayDate(endTs * 1000).getTime() / 1000);
+  return dateToTs(getEndOfLocalDayDate(endTs * 1000));
 }
 
 function getPresetLookbackStart(
@@ -78,9 +64,7 @@ function getPresetLookbackStart(
   nowMs: number,
 ): number {
   const dayCount = preset === "7d" ? 7 : preset === "14d" ? 14 : 30;
-  return Math.floor(
-    getStartOfLocalDayDate(nowMs - (dayCount - 1) * DAY_MS).getTime() / 1000,
-  );
+  return dateToTs(getStartOfLocalDayDate(nowMs - (dayCount - 1) * DAY_MS));
 }
 
 export function resolveUsageRange(
@@ -92,7 +76,7 @@ export function resolveUsageRange(
   switch (selection.preset) {
     case "today":
       return {
-        startDate: Math.floor(getStartOfLocalDayDate(nowMs).getTime() / 1000),
+        startDate: dateToTs(getStartOfLocalDayDate(nowMs)),
         endDate,
       };
     case "1d":
@@ -109,12 +93,10 @@ export function resolveUsageRange(
       };
     case "custom": {
       const startDate =
-        selection.customStartDate ??
-        Math.floor(getStartOfLocalDayDate(nowMs).getTime() / 1000);
+        selection.customStartDate ?? dateToTs(getStartOfLocalDayDate(nowMs));
       const customEndDate = selection.liveEndTime
         ? endDate
-        : (selection.customEndDate ??
-          Math.floor(getEndOfLocalDayDate(nowMs).getTime() / 1000));
+        : (selection.customEndDate ?? dateToTs(getEndOfLocalDayDate(nowMs)));
       return {
         startDate,
         endDate: customEndDate,

--- a/src/lib/usageRange.ts
+++ b/src/lib/usageRange.ts
@@ -56,7 +56,10 @@ export function normalizePickerStart(startTs: number): number {
   return Math.floor(getStartOfLocalDayDate(startTs * 1000).getTime() / 1000);
 }
 
-export function normalizePickerEnd(endTs: number, nowMs: number = Date.now()): number {
+export function normalizePickerEnd(
+  endTs: number,
+  nowMs: number = Date.now(),
+): number {
   const endDate = new Date(endTs * 1000);
   const today = new Date(nowMs);
   if (isSameDay(endDate, today)) {

--- a/tests/utils/usageRange.test.ts
+++ b/tests/utils/usageRange.test.ts
@@ -119,9 +119,10 @@ describe("resolveUsageRange: custom fallback & 其他 preset", () => {
   /* ── 其他 preset 未受影响 ── */
 
   it("CONTROL: preset today → start = 今天 00:00, end > start", () => {
-    const resolved = resolveUsageRange({ preset: "today" });
+    const nowMs = Date.now();
+    const resolved = resolveUsageRange({ preset: "today" }, nowMs);
     const todayMidnight = (() => {
-      const d = new Date();
+      const d = new Date(nowMs);
       d.setHours(0, 0, 0, 0);
       return Math.floor(d.getTime() / 1000);
     })();
@@ -135,8 +136,9 @@ describe("resolveUsageRange: custom fallback & 其他 preset", () => {
   });
 
   it("CONTROL: preset 7d → start = today-6d, end = now", () => {
-    const resolved = resolveUsageRange({ preset: "7d" });
-    const now = Math.floor(Date.now() / 1000);
+    const nowMs = Date.now();
+    const resolved = resolveUsageRange({ preset: "7d" }, nowMs);
+    const now = Math.floor(nowMs / 1000);
     expect(now - resolved.startDate).toBeGreaterThanOrEqual(86400 * 6);
     expect(now - resolved.startDate).toBeLessThanOrEqual(86400 * 7);
     expect(resolved.endDate).toBe(now);

--- a/tests/utils/usageRange.test.ts
+++ b/tests/utils/usageRange.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   resolveUsageRange,
   normalizePickerStart,
@@ -6,7 +6,7 @@ import {
 } from "@/lib/usageRange";
 
 // normalizePickerEnd 内部默认取 Date.now(), 但同时接受显式 nowMs 注入;
-// 测试用显式 nowMs 取代 wall-clock 容差断言, 消除跨时区/跨秒的 flake。
+// 测试用 fake timers 固定本地时钟与 nowMs, 消除跨时区/跨秒的 flake。
 
 describe("normalizePickerStart", () => {
   it("把任意 ts 归一到当地日期 00:00:00", () => {
@@ -33,47 +33,56 @@ describe("normalizePickerStart", () => {
 });
 
 describe("normalizePickerEnd", () => {
-  it("end 是当天 → 总是返回 nowMs 对应的秒", () => {
-    const fixedNow = new Date("2026-06-28T11:35:42Z").getTime();
-    // 构造一个"今天"的 ts: 任意时分都行, 只要跟 fixedNow 同一天
-    const today = new Date(fixedNow);
-    today.setHours(11, 35, 42, 0);
-    const todayTs = Math.floor(today.getTime() / 1000);
-    const normalized = normalizePickerEnd(todayTs, fixedNow);
-    expect(normalized).toBe(Math.floor(fixedNow / 1000));
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 固定到一个固定的时刻, 避免跨日竞态
+    vi.setSystemTime(new Date(2026, 5, 28, 14, 0, 0, 0)); // 本地 6/28 14:00
+  });
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  it("end 是过去日期 → 归一到当天 23:59:59.999", () => {
+  it("end 是当天 → 总是返回 nowMs 对应的秒", () => {
+    const now = Date.now();
+    const today = new Date();
+    today.setHours(10, 0, 0, 0);
+    const todayTs = Math.floor(today.getTime() / 1000);
+    const normalized = normalizePickerEnd(todayTs, now);
+    expect(normalized).toBe(Math.floor(now / 1000));
+  });
+
+  it("end 是过去日期 → 归一到当天 23:59:59", () => {
+    const now = Date.now();
     const past = new Date();
     past.setDate(past.getDate() - 5);
     past.setHours(0, 0, 0, 0);
     const pastTs = Math.floor(past.getTime() / 1000);
-    const normalized = normalizePickerEnd(pastTs);
+    const normalized = normalizePickerEnd(pastTs, now);
     const result = new Date(normalized * 1000);
     expect(result.getHours()).toBe(23);
     expect(result.getMinutes()).toBe(59);
     expect(result.getSeconds()).toBe(59);
   });
 
-  it("end 输入 18:00 (非 23:59) 也会被归一, 不让它逃逸到后端", () => {
+  it("end 输入过去日期 18:00 → 归一到 23:59", () => {
+    const now = Date.now();
     const past = new Date();
     past.setDate(past.getDate() - 3);
     past.setHours(18, 0, 0, 0);
     const pastTs = Math.floor(past.getTime() / 1000);
-    const normalized = normalizePickerEnd(pastTs);
+    const normalized = normalizePickerEnd(pastTs, now);
     const result = new Date(normalized * 1000);
-    // 非当天 → 归一到 23:59
     expect(result.getHours()).toBe(23);
     expect(result.getMinutes()).toBe(59);
   });
 
-  it("end 输入当天 18:00 → 归一到 nowMs 时刻 (不保持 18:00)", () => {
-    const fixedNow = new Date("2026-06-28T18:00:00Z").getTime();
-    const today = new Date(fixedNow);
+  it("end 输入当天任意时刻 → 归一到 now", () => {
+    const now = Date.now();
+    const today = new Date();
     today.setHours(18, 0, 0, 0);
     const ts = Math.floor(today.getTime() / 1000);
-    const normalized = normalizePickerEnd(ts, fixedNow);
-    expect(normalized).toBe(Math.floor(fixedNow / 1000));
+    const normalized = normalizePickerEnd(ts, now);
+    expect(normalized).toBe(Math.floor(now / 1000));
   });
 });
 

--- a/tests/utils/usageRange.test.ts
+++ b/tests/utils/usageRange.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveUsageRange,
+  normalizePickerStart,
+  normalizePickerEnd,
+} from "@/lib/usageRange";
+
+// normalizePickerEnd 内部依赖 Date.now(); 测试时通过注入 now 不可行,
+// 但因为它只判断 end 是不是"当天", 我们用伪"now"构造不同日期来间接覆盖两种分支。
+// 这里把 normalizePickerEnd 直接当作受测 API 来用, 不再重复实现一份.
+
+describe("normalizePickerStart", () => {
+  it("把任意 ts 归一到当地日期 00:00:00", () => {
+    const d = new Date("2026-06-10T11:35:42");
+    const ts = Math.floor(d.getTime() / 1000);
+    const normalized = normalizePickerStart(ts);
+    const result = new Date(normalized * 1000);
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(5); // June (0-indexed)
+    expect(result.getDate()).toBe(10);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+  });
+
+  it("9:00 输入 → 归一到 00:00", () => {
+    const d = new Date();
+    d.setHours(9, 0, 0, 0);
+    const ts = Math.floor(d.getTime() / 1000);
+    const normalized = normalizePickerStart(ts);
+    const result = new Date(normalized * 1000);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+  });
+});
+
+describe("normalizePickerEnd", () => {
+  it("end 是当天 → 总是返回当前时刻 (Math.floor(Date.now()/1000))", () => {
+    // 构造一个'今天'的 ts
+    const today = new Date();
+    today.setHours(11, 35, 42, 0);
+    const todayTs = Math.floor(today.getTime() / 1000);
+    const before = Math.floor(Date.now() / 1000);
+    const normalized = normalizePickerEnd(todayTs);
+    const after = Math.floor(Date.now() / 1000);
+    // 返回值应该是 'now 时刻', 在 before..after 之间
+    expect(normalized).toBeGreaterThanOrEqual(before);
+    expect(normalized).toBeLessThanOrEqual(after);
+  });
+
+  it("end 是过去日期 → 归一到当天 23:59:59.999", () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 5);
+    past.setHours(0, 0, 0, 0);
+    const pastTs = Math.floor(past.getTime() / 1000);
+    const normalized = normalizePickerEnd(pastTs);
+    const result = new Date(normalized * 1000);
+    expect(result.getHours()).toBe(23);
+    expect(result.getMinutes()).toBe(59);
+    expect(result.getSeconds()).toBe(59);
+  });
+
+  it("end 输入 18:00 (非 23:59) 也会被归一, 不让它逃逸到后端", () => {
+    // 用户在 time 框输入 18:00, 真实 input box 后端用 normalizeField 包装,
+    // 但 normalizePickerEnd 单独调用也应正确处理 18:00 输入 (非 23:59 也非 0:00).
+    const past = new Date();
+    past.setDate(past.getDate() - 3);
+    past.setHours(18, 0, 0, 0);
+    const pastTs = Math.floor(past.getTime() / 1000);
+    const normalized = normalizePickerEnd(pastTs);
+    const result = new Date(normalized * 1000);
+    // 非当天 → 归一到 23:59
+    expect(result.getHours()).toBe(23);
+    expect(result.getMinutes()).toBe(59);
+  });
+
+  it("end 输入当天 18:00 → 归一到 now 时刻 (不保持 18:00)", () => {
+    const today = new Date();
+    today.setHours(18, 0, 0, 0);
+    const ts = Math.floor(today.getTime() / 1000);
+    const before = Math.floor(Date.now() / 1000);
+    const normalized = normalizePickerEnd(ts);
+    const after = Math.floor(Date.now() / 1000);
+    expect(normalized).toBeGreaterThanOrEqual(before);
+    expect(normalized).toBeLessThanOrEqual(after);
+  });
+});
+
+describe("resolveUsageRange: custom fallback & 其他 preset", () => {
+  /* ── usageRange.ts 的兜底 ── */
+
+  it("GUARD: custom + 无 customStart/End → fallback 到今天 00:00 ~ 23:59 (整天)", () => {
+    const resolved = resolveUsageRange({ preset: "custom" });
+    const endDate = new Date(resolved.endDate * 1000);
+    expect(endDate.getHours()).toBe(23);
+    expect(endDate.getMinutes()).toBe(59);
+    // start fallback 现在也归一到 00:00, 不是 endDate-DAY_SECONDS
+    const startDate = new Date(resolved.startDate * 1000);
+    expect(startDate.getHours()).toBe(0);
+    // Math.floor 把毫秒砍了, 所以差 ≈86399s (而非 86399.999s)
+    const diffSeconds = resolved.endDate - resolved.startDate;
+    expect(diffSeconds).toBe(86399);
+  });
+
+  it("GUARD: custom + 自定义 customStart/End → passthrough", () => {
+    const todayMidnight = (() => {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      return Math.floor(d.getTime() / 1000);
+    })();
+    const resolved = resolveUsageRange({
+      preset: "custom",
+      customStartDate: todayMidnight,
+      customEndDate: todayMidnight + 43200, // 12:00
+    });
+    expect(resolved.endDate - todayMidnight).toBe(43200);
+  });
+
+  /* ── 其他 preset 未受影响 ── */
+
+  it("CONTROL: preset today → start = 今天 00:00, end > start", () => {
+    const resolved = resolveUsageRange({ preset: "today" });
+    const todayMidnight = (() => {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      return Math.floor(d.getTime() / 1000);
+    })();
+    expect(resolved.startDate).toBe(todayMidnight);
+    expect(resolved.endDate).toBeGreaterThan(todayMidnight);
+  });
+
+  it("CONTROL: preset 1d → 24h 窗口", () => {
+    const resolved = resolveUsageRange({ preset: "1d" });
+    expect(resolved.endDate - resolved.startDate).toBe(86400);
+  });
+
+  it("CONTROL: preset 7d → start = today-6d, end = now", () => {
+    const resolved = resolveUsageRange({ preset: "7d" });
+    const now = Math.floor(Date.now() / 1000);
+    expect(now - resolved.startDate).toBeGreaterThanOrEqual(86400 * 6);
+    expect(now - resolved.startDate).toBeLessThanOrEqual(86400 * 7);
+    expect(resolved.endDate).toBe(now);
+  });
+});

--- a/tests/utils/usageRange.test.ts
+++ b/tests/utils/usageRange.test.ts
@@ -5,22 +5,20 @@ import {
   normalizePickerEnd,
 } from "@/lib/usageRange";
 
-// normalizePickerEnd 内部依赖 Date.now(); 测试时通过注入 now 不可行,
-// 但因为它只判断 end 是不是"当天", 我们用伪"now"构造不同日期来间接覆盖两种分支。
-// 这里把 normalizePickerEnd 直接当作受测 API 来用, 不再重复实现一份.
+// normalizePickerEnd 内部默认取 Date.now(), 但同时接受显式 nowMs 注入;
+// 测试用显式 nowMs 取代 wall-clock 容差断言, 消除跨时区/跨秒的 flake。
 
 describe("normalizePickerStart", () => {
   it("把任意 ts 归一到当地日期 00:00:00", () => {
-    const d = new Date("2026-06-10T11:35:42");
+    const d = new Date("2026-06-10T11:35:42Z");
     const ts = Math.floor(d.getTime() / 1000);
     const normalized = normalizePickerStart(ts);
     const result = new Date(normalized * 1000);
-    expect(result.getFullYear()).toBe(2026);
-    expect(result.getMonth()).toBe(5); // June (0-indexed)
-    expect(result.getDate()).toBe(10);
     expect(result.getHours()).toBe(0);
     expect(result.getMinutes()).toBe(0);
     expect(result.getSeconds()).toBe(0);
+    // 日期部分用 toDateString 比较, 避免时区差异导致 getDate() 漂移
+    expect(result.toDateString()).toBe(d.toDateString());
   });
 
   it("9:00 输入 → 归一到 00:00", () => {
@@ -35,17 +33,14 @@ describe("normalizePickerStart", () => {
 });
 
 describe("normalizePickerEnd", () => {
-  it("end 是当天 → 总是返回当前时刻 (Math.floor(Date.now()/1000))", () => {
-    // 构造一个'今天'的 ts
-    const today = new Date();
+  it("end 是当天 → 总是返回 nowMs 对应的秒", () => {
+    const fixedNow = new Date("2026-06-28T11:35:42Z").getTime();
+    // 构造一个"今天"的 ts: 任意时分都行, 只要跟 fixedNow 同一天
+    const today = new Date(fixedNow);
     today.setHours(11, 35, 42, 0);
     const todayTs = Math.floor(today.getTime() / 1000);
-    const before = Math.floor(Date.now() / 1000);
-    const normalized = normalizePickerEnd(todayTs);
-    const after = Math.floor(Date.now() / 1000);
-    // 返回值应该是 'now 时刻', 在 before..after 之间
-    expect(normalized).toBeGreaterThanOrEqual(before);
-    expect(normalized).toBeLessThanOrEqual(after);
+    const normalized = normalizePickerEnd(todayTs, fixedNow);
+    expect(normalized).toBe(Math.floor(fixedNow / 1000));
   });
 
   it("end 是过去日期 → 归一到当天 23:59:59.999", () => {
@@ -61,8 +56,6 @@ describe("normalizePickerEnd", () => {
   });
 
   it("end 输入 18:00 (非 23:59) 也会被归一, 不让它逃逸到后端", () => {
-    // 用户在 time 框输入 18:00, 真实 input box 后端用 normalizeField 包装,
-    // 但 normalizePickerEnd 单独调用也应正确处理 18:00 输入 (非 23:59 也非 0:00).
     const past = new Date();
     past.setDate(past.getDate() - 3);
     past.setHours(18, 0, 0, 0);
@@ -74,15 +67,13 @@ describe("normalizePickerEnd", () => {
     expect(result.getMinutes()).toBe(59);
   });
 
-  it("end 输入当天 18:00 → 归一到 now 时刻 (不保持 18:00)", () => {
-    const today = new Date();
+  it("end 输入当天 18:00 → 归一到 nowMs 时刻 (不保持 18:00)", () => {
+    const fixedNow = new Date("2026-06-28T18:00:00Z").getTime();
+    const today = new Date(fixedNow);
     today.setHours(18, 0, 0, 0);
     const ts = Math.floor(today.getTime() / 1000);
-    const before = Math.floor(Date.now() / 1000);
-    const normalized = normalizePickerEnd(ts);
-    const after = Math.floor(Date.now() / 1000);
-    expect(normalized).toBeGreaterThanOrEqual(before);
-    expect(normalized).toBeLessThanOrEqual(after);
+    const normalized = normalizePickerEnd(ts, fixedNow);
+    expect(normalized).toBe(Math.floor(fixedNow / 1000));
   });
 });
 


### PR DESCRIPTION
## 修改内容

`UsageDateRangePicker` 的默认 end 行为变更: 当用户进入 picker 或通过日期入口选择 end 时, end 时间不再保留传入的原始时刻 (往往是 `now` 或 `0:00`), 而是按 end 所在日期归一化:

- **end 所在日期 == 今天** → 默认值 = **now 时刻** (当天没过完, "到现在为止的数据")
- **end 所在日期 != 今天** → 默认值 = **23:59:59** (整天已过完, 包含整天)
- **start 永远归一**到当日 00:00:00, 不论用户传入什么时刻

这一变更同时收紧了 picker 内 reset、日历点选、date input 等会改变日期语义的写入路径, 统一走 normalize；但 **time input 保留用户手动输入的精确时分**, 避免用户输入特定时间时被中途强行改回 `now` 或 `23:59`。

After PR:
<img width="930" height="476" alt="PixPin_2026-06-28_02-04-23" src="https://github.com/user-attachments/assets/a8f571ef-9bc6-4a2d-94f9-5ada40406a42" />



## 行为矩阵 (新)

| 触发条件 | draftStart | draftEnd |
|----------|-----------|----------|
| picker 打开 / 切 preset (reset) | 00:00 | end 当天→now / 非当天→23:59 |
| 点 start 日期 | 00:00 | 不变 |
| 点 end 日期 (当天) | 不变 | now 时刻 |
| 点 end 日期 (非当天) | 不变 | 23:59 |
| 改 start date/time 框 | 00:00 (归一) | 不变 |
| 改 end date 框 (当天) | 不变 | now (归一) |
| 改 end date 框 (非当天) | 不变 | 23:59 (归一) |
| 改 end time 框 | 不变 | 保留用户输入的精确时分 |
| Apply → 关掉 → 重开 picker | 00:00 | reset 默认值 |

## 实现细节

- `src/lib/usageRange.ts`: 新增并导出 `tsToDate` / `dateToTs` / `getStartOfLocalDayDate` /
  `isSameDay` / `normalizePickerStart` / `normalizePickerEnd`; 新增内部 `getEndOfLocalDayDate`,
  使用本地日历 "次日 00:00 - 1ms" 计算当天结束时刻, 避免 DST 切换日固定 24h 算术导致跨日或漏小时。
  `resolveUsageRange` 的 custom fallback 也同步归一 (customStart 缺失→今天 00:00,
  customEnd 缺失→今天 23:59), 与 picker 的语义保持一致。
- `src/components/usage/UsageDateRangePicker.tsx`:
  - 集中走 `normalizePicker*` 处理 reset、日历点选、date input 等日期语义入口
  - time input 保留用户输入的精确时分, 仅 start time 继续归一到 00:00
  - 删除重复实现 (`setDateKeepTime` 移除, `startOfDay` 与 `isSameLocalDay` 合并到
    既有 helper)
  - `calendarDays.map` 的 inRange 边界常量提到循环外 (微优化)

## 顺带修复

之前 picker reset 时如果 `selection.customEndDate` 是 `0:00` 或 `18:00`, 会被直接透传
到后端; 后端对非 `23:59` 的 end 会触发 `pred_opt()` 把日期前推, 导致自定义日期范围
的数据丢失。本次把 reset / 日期选择入口的 end 默认值改为 `23:59` (非当天) / `now` (当天), 顺带避免了这一上游路径。后续如要彻底修根因 (后端 23:59 sentinel), 见 follow-up。

此外, 已按 review 修复 DST 边界问题: 结束日期不再用固定 24h 推算, 而是用本地日历推进到次日零点再减 1ms, 避免夏令时切换日出现跨到次日或漏掉最后一小时。

## 测试

新增 `tests/utils/usageRange.test.ts`, 11 个用例:

- `normalizePickerStart`: 普通归一、9:00→00:00
- `normalizePickerEnd`: 当天→now、过去→23:59、18:00→23:59 (修复验证)、
  当天 18:00→now
- `resolveUsageRange`: custom fallback 组合 (start=00:00 / end=23:59 整天)、
  passthrough
- 三个 preset (today/1d/7d) 的 control 回归

测试中通过 fake timers 与显式 `nowMs` 固定时间基准, 避免 `Date.now()` 跨秒边界造成随机失败。

## 检查清单

- [x] `pnpm typecheck` 通过
- [x] `pnpm format:check` 通过
- [x] `pnpm test:unit` 通过 (本 PR 新增 11 个用例全过; 剩余 2 个 pre-existing
      集成测试失败与本修复无关)
- [x] `cargo clippy` 通过 (0 error; 本 PR 未改 Rust 代码)
- [x] `cargo test` 跑通 (本 PR 未改 Rust 代码)
- [N/A] 未修改用户可见文案, 无需更新 i18n