### PR TITLE
Fix WebDAV auto sync conflict handling

### DIFF
--- a/src-tauri/src/commands/s3_sync.rs
+++ b/src-tauri/src/commands/s3_sync.rs
@@ -13,6 +13,7 @@ use crate::store::AppState;
 
 fn persist_sync_error(settings: &mut S3SyncSettings, error: &AppError, source: &str) {
     settings.status.last_error = Some(error.to_string());
+    settings.status.last_error_key = error.localized_key().map(str::to_string);
     settings.status.last_error_source = Some(source.to_string());
     let _ = settings::update_s3_sync_status(settings.status.clone());
 }

--- a/src-tauri/src/commands/webdav_sync.rs
+++ b/src-tauri/src/commands/webdav_sync.rs
@@ -13,6 +13,7 @@ use crate::store::AppState;
 
 fn persist_sync_error(settings: &mut WebDavSyncSettings, error: &AppError, source: &str) {
     settings.status.last_error = Some(error.to_string());
+    settings.status.last_error_key = error.localized_key().map(str::to_string);
     settings.status.last_error_source = Some(source.to_string());
     let _ = settings::update_webdav_sync_status(settings.status.clone());
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -91,6 +91,13 @@ impl AppError {
             en: en.into(),
         }
     }
+
+    pub fn localized_key(&self) -> Option<&'static str> {
+        match self {
+            Self::Localized { key, .. } => Some(*key),
+            _ => None,
+        }
+    }
 }
 
 impl<T> From<PoisonError<T>> for AppError {

--- a/src-tauri/src/services/s3_auto_sync.rs
+++ b/src-tauri/src/services/s3_auto_sync.rs
@@ -81,16 +81,18 @@ fn should_run_auto_sync(settings: Option<&S3SyncSettings>) -> bool {
 
 fn persist_auto_sync_error(settings: &mut S3SyncSettings, error: &AppError) {
     settings.status.last_error = Some(error.to_string());
+    settings.status.last_error_key = error.localized_key().map(str::to_string);
     settings.status.last_error_source = Some("auto".to_string());
     let _ = settings::update_s3_sync_status(settings.status.clone());
 }
 
-fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&str>) {
+fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&AppError>) {
     let payload = match error {
-        Some(message) => json!({
+        Some(error) => json!({
             "source": "auto",
             "status": status,
-            "error": message,
+            "error": error.to_string(),
+            "errorKey": error.localized_key(),
         }),
         None => json!({
             "source": "auto",
@@ -117,7 +119,11 @@ async fn run_auto_sync_upload(
         None => return Ok(()),
     };
 
-    let result = s3_sync::run_with_sync_lock(s3_sync::upload(db, &mut sync_settings)).await;
+    let result = s3_sync::run_with_sync_lock(async {
+        s3_sync::ensure_remote_unchanged_since_last_sync(&sync_settings).await?;
+        s3_sync::upload(db, &mut sync_settings).await
+    })
+    .await;
     match result {
         Ok(_) => {
             emit_auto_sync_status_updated(app, "success", None);
@@ -125,7 +131,7 @@ async fn run_auto_sync_upload(
         }
         Err(err) => {
             persist_auto_sync_error(&mut sync_settings, &err);
-            emit_auto_sync_status_updated(app, "error", Some(&err.to_string()));
+            emit_auto_sync_status_updated(app, "error", Some(&err));
             Err(err)
         }
     }

--- a/src-tauri/src/services/s3_sync.rs
+++ b/src-tauri/src/services/s3_sync.rs
@@ -15,10 +15,12 @@ use crate::services::s3::{self, S3Credentials};
 use crate::settings::{update_s3_sync_status, S3SyncSettings, WebDavSyncStatus};
 
 use super::sync_protocol::{
-    apply_snapshot, build_local_snapshot, localized, persist_sync_success_best_effort, sha256_hex,
-    validate_artifact_size_limit, validate_manifest_compat, verify_artifact, ArtifactMeta,
-    RemoteLayout, SyncManifest, DB_COMPAT_VERSION, MAX_MANIFEST_BYTES, MAX_SYNC_ARTIFACT_BYTES,
-    PROTOCOL_VERSION, REMOTE_DB_SQL, REMOTE_MANIFEST, REMOTE_SKILLS_ZIP,
+    apply_snapshot, build_local_snapshot, ensure_remote_manifest_unchanged_since_last_sync,
+    has_remote_sync_baseline, localized, manual_resolution_required_error,
+    persist_sync_success_best_effort, sha256_hex, validate_artifact_size_limit,
+    validate_manifest_compat, verify_artifact, ArtifactMeta, RemoteLayout, SnapshotSyncState,
+    SyncManifest, DB_COMPAT_VERSION, MAX_MANIFEST_BYTES, MAX_SYNC_ARTIFACT_BYTES, PROTOCOL_VERSION,
+    REMOTE_DB_SQL, REMOTE_MANIFEST, REMOTE_SKILLS_ZIP,
 };
 
 // ─── Sync lock ───────────────────────────────────────────────
@@ -43,6 +45,37 @@ pub async fn check_connection(settings: &S3SyncSettings) -> Result<(), AppError>
     settings.validate()?;
     let creds = creds_for(settings);
     s3::test_connection(&creds).await
+}
+
+/// Guard automatic uploads from overwriting remote data changed by another device.
+pub async fn ensure_remote_unchanged_since_last_sync(
+    settings: &S3SyncSettings,
+) -> Result<(), AppError> {
+    settings.validate()?;
+    let creds = creds_for(settings);
+    let manifest_key = s3_key(settings, REMOTE_MANIFEST);
+    let Some((manifest_bytes, _)) =
+        s3::get_object(&creds, &manifest_key, MAX_MANIFEST_BYTES).await?
+    else {
+        if has_remote_sync_baseline(&settings.status) {
+            return Err(manual_resolution_required_error(
+                SnapshotSyncState::RemoteOnlyChanged,
+            ));
+        }
+        return Ok(());
+    };
+
+    let remote_manifest_hash = sha256_hex(&manifest_bytes);
+    let manifest: SyncManifest =
+        serde_json::from_slice(&manifest_bytes).map_err(|e| AppError::Json {
+            path: REMOTE_MANIFEST.to_string(),
+            source: e,
+        })?;
+    ensure_remote_manifest_unchanged_since_last_sync(
+        &settings.status,
+        &remote_manifest_hash,
+        &manifest.snapshot_id,
+    )
 }
 
 /// Upload local snapshot (db + skills) to remote S3.
@@ -83,6 +116,7 @@ pub async fn upload(
     let _persisted = persist_sync_success_best_effort(
         settings,
         snapshot.manifest_hash,
+        snapshot.snapshot_id,
         etag,
         persist_sync_success,
     );
@@ -125,8 +159,13 @@ pub async fn download(
     apply_snapshot(db, &db_sql, &skills_zip)?;
 
     let manifest_hash = sha256_hex(&manifest_bytes);
-    let _persisted =
-        persist_sync_success_best_effort(settings, manifest_hash, etag, persist_sync_success);
+    let _persisted = persist_sync_success_best_effort(
+        settings,
+        manifest_hash,
+        manifest.snapshot_id,
+        etag,
+        persist_sync_success,
+    );
     Ok(serde_json::json!({ "status": "downloaded" }))
 }
 
@@ -168,14 +207,18 @@ pub async fn fetch_remote_info(settings: &S3SyncSettings) -> Result<Option<Value
 fn persist_sync_success(
     settings: &mut S3SyncSettings,
     manifest_hash: String,
+    snapshot_id: String,
     etag: Option<String>,
 ) -> Result<(), AppError> {
     let status = WebDavSyncStatus {
         last_sync_at: Some(Utc::now().timestamp()),
         last_error: None,
+        last_error_key: None,
         last_error_source: None,
         last_local_manifest_hash: Some(manifest_hash.clone()),
         last_remote_manifest_hash: Some(manifest_hash),
+        last_local_snapshot_id: Some(snapshot_id.clone()),
+        last_remote_snapshot_id: Some(snapshot_id),
         last_remote_etag: etag,
     };
     settings.status = status.clone();

--- a/src-tauri/src/services/sync_protocol.rs
+++ b/src-tauri/src/services/sync_protocol.rs
@@ -12,6 +12,7 @@ use sha2::{Digest, Sha256};
 use tempfile::tempdir;
 
 use crate::error::AppError;
+use crate::settings::WebDavSyncStatus;
 
 // Re-export archive functions for use by transport layers.
 pub(crate) use super::webdav_sync::archive::{
@@ -32,6 +33,9 @@ pub(crate) const REMOTE_MANIFEST: &str = "manifest.json";
 pub(crate) const MAX_DEVICE_NAME_LEN: usize = 64;
 pub(crate) const MAX_MANIFEST_BYTES: usize = 1024 * 1024;
 pub(crate) const MAX_SYNC_ARTIFACT_BYTES: u64 = 512 * 1024 * 1024;
+pub(crate) const SYNC_CONFLICT_DETECTED_KEY: &str = "sync.conflict_detected";
+pub(crate) const SYNC_REMOTE_CHANGED_KEY: &str = "sync.remote_changed_since_last_sync";
+pub(crate) const SYNC_MANUAL_RESOLUTION_REQUIRED_KEY: &str = "sync.manual_resolution_required";
 
 // ─── Error helpers ───────────────────────────────────────────
 
@@ -83,6 +87,16 @@ pub(crate) struct LocalSnapshot {
     pub skills_zip: Vec<u8>,
     pub manifest_bytes: Vec<u8>,
     pub manifest_hash: String,
+    pub snapshot_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotSyncState {
+    RemoteMissing,
+    InSync,
+    LocalOnlyChanged,
+    RemoteOnlyChanged,
+    Conflict,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -147,7 +161,7 @@ pub(crate) fn build_local_snapshot(
         device_name: detect_system_device_name().unwrap_or_else(|| "Unknown Device".to_string()),
         created_at: Utc::now().to_rfc3339(),
         artifacts,
-        snapshot_id,
+        snapshot_id: snapshot_id.clone(),
     };
     let manifest_bytes =
         serde_json::to_vec_pretty(&manifest).map_err(|e| AppError::JsonSerialize { source: e })?;
@@ -158,6 +172,7 @@ pub(crate) fn build_local_snapshot(
         skills_zip,
         manifest_bytes,
         manifest_hash,
+        snapshot_id,
     })
 }
 
@@ -398,18 +413,128 @@ pub(crate) fn normalize_device_name(raw: &str) -> Option<String> {
 pub(crate) fn persist_sync_success_best_effort<S, F>(
     settings: &mut S,
     manifest_hash: String,
+    snapshot_id: String,
     etag: Option<String>,
     persist_fn: F,
 ) -> bool
 where
-    F: FnOnce(&mut S, String, Option<String>) -> Result<(), AppError>,
+    F: FnOnce(&mut S, String, String, Option<String>) -> Result<(), AppError>,
 {
-    match persist_fn(settings, manifest_hash, etag) {
+    match persist_fn(settings, manifest_hash, snapshot_id, etag) {
         Ok(()) => true,
         Err(err) => {
             log::warn!("[Sync] Persist sync status failed, keep operation success: {err}");
             false
         }
+    }
+}
+
+fn last_synced_snapshot_id(status: &WebDavSyncStatus) -> Option<&str> {
+    match (
+        status.last_local_snapshot_id.as_deref(),
+        status.last_remote_snapshot_id.as_deref(),
+    ) {
+        (Some(local), Some(remote)) if local == remote => Some(local),
+        (Some(snapshot_id), None) | (None, Some(snapshot_id)) => Some(snapshot_id),
+        _ => None,
+    }
+}
+
+fn remote_matches_legacy_manifest_baseline(
+    status: &WebDavSyncStatus,
+    remote_manifest_hash: Option<&str>,
+) -> bool {
+    matches!(
+        (
+            status.last_remote_manifest_hash.as_deref(),
+            remote_manifest_hash,
+        ),
+        (Some(last_hash), Some(remote_hash)) if last_hash == remote_hash
+    )
+}
+
+pub(crate) fn has_remote_sync_baseline(status: &WebDavSyncStatus) -> bool {
+    status.last_remote_snapshot_id.is_some()
+        || status.last_remote_manifest_hash.is_some()
+        || status.last_remote_etag.is_some()
+}
+
+pub(crate) fn assess_snapshot_sync_state(
+    status: &WebDavSyncStatus,
+    local_snapshot_id: &str,
+    remote_snapshot_id: Option<&str>,
+    remote_manifest_hash: Option<&str>,
+) -> SnapshotSyncState {
+    let Some(remote_snapshot_id) = remote_snapshot_id else {
+        if let Some(base_snapshot_id) = last_synced_snapshot_id(status) {
+            return if local_snapshot_id == base_snapshot_id {
+                SnapshotSyncState::RemoteOnlyChanged
+            } else {
+                SnapshotSyncState::Conflict
+            };
+        }
+        if has_remote_sync_baseline(status) {
+            return SnapshotSyncState::RemoteOnlyChanged;
+        }
+        return SnapshotSyncState::RemoteMissing;
+    };
+
+    if local_snapshot_id == remote_snapshot_id {
+        return SnapshotSyncState::InSync;
+    }
+
+    let Some(base_snapshot_id) = last_synced_snapshot_id(status) else {
+        if remote_matches_legacy_manifest_baseline(status, remote_manifest_hash) {
+            return SnapshotSyncState::LocalOnlyChanged;
+        }
+        return SnapshotSyncState::Conflict;
+    };
+
+    let local_changed = local_snapshot_id != base_snapshot_id;
+    let remote_changed = remote_snapshot_id != base_snapshot_id;
+
+    match (local_changed, remote_changed) {
+        (false, false) => SnapshotSyncState::InSync,
+        (true, false) => SnapshotSyncState::LocalOnlyChanged,
+        (false, true) => SnapshotSyncState::RemoteOnlyChanged,
+        (true, true) => SnapshotSyncState::Conflict,
+    }
+}
+
+pub(crate) fn manual_resolution_required_error(state: SnapshotSyncState) -> AppError {
+    match state {
+        SnapshotSyncState::RemoteOnlyChanged => localized(
+            SYNC_REMOTE_CHANGED_KEY,
+            "云端同步数据已更新，自动同步已暂停。请确认是下载云端版本，还是上传本机版本覆盖云端。",
+            "Remote sync data changed, so auto sync paused. Choose whether to download the cloud version or upload this device to overwrite the cloud data.",
+        ),
+        SnapshotSyncState::Conflict => localized(
+            SYNC_CONFLICT_DETECTED_KEY,
+            "本机和云端都有更改，自动同步已暂停。请手动选择保留本机版本或云端版本。",
+            "Both local and cloud sync data changed, so auto sync paused. Choose whether to keep the local version or the cloud version.",
+        ),
+        _ => localized(
+            SYNC_MANUAL_RESOLUTION_REQUIRED_KEY,
+            "自动同步需要手动选择同步方向。",
+            "Auto sync requires choosing a sync direction manually.",
+        ),
+    }
+}
+
+pub(crate) fn ensure_remote_manifest_unchanged_since_last_sync(
+    status: &WebDavSyncStatus,
+    remote_manifest_hash: &str,
+    remote_snapshot_id: &str,
+) -> Result<(), AppError> {
+    match (
+        status.last_remote_snapshot_id.as_deref(),
+        status.last_remote_manifest_hash.as_deref(),
+    ) {
+        (Some(last_snapshot_id), _) if last_snapshot_id == remote_snapshot_id => Ok(()),
+        (None, Some(last_hash)) if last_hash == remote_manifest_hash => Ok(()),
+        _ => Err(manual_resolution_required_error(
+            SnapshotSyncState::RemoteOnlyChanged,
+        )),
     }
 }
 
@@ -463,8 +588,9 @@ mod tests {
         let ok = persist_sync_success_best_effort(
             &mut dummy,
             "hash".to_string(),
+            "snapshot".to_string(),
             Some("etag".to_string()),
-            |_settings, _hash, _etag| Ok(()),
+            |_settings, _hash, _snapshot, _etag| Ok(()),
         );
         assert!(ok);
     }
@@ -475,10 +601,107 @@ mod tests {
         let ok = persist_sync_success_best_effort(
             &mut dummy,
             "hash".to_string(),
+            "snapshot".to_string(),
             None,
-            |_settings, _hash, _etag| Err(AppError::Config("boom".to_string())),
+            |_settings, _hash, _snapshot, _etag| Err(AppError::Config("boom".to_string())),
         );
         assert!(!ok);
+    }
+
+    fn synced_status() -> WebDavSyncStatus {
+        WebDavSyncStatus {
+            last_local_snapshot_id: Some("base".to_string()),
+            last_remote_snapshot_id: Some("base".to_string()),
+            ..WebDavSyncStatus::default()
+        }
+    }
+
+    #[test]
+    fn snapshot_sync_state_detects_local_only_change() {
+        assert_eq!(
+            assess_snapshot_sync_state(&synced_status(), "local-new", Some("base"), None),
+            SnapshotSyncState::LocalOnlyChanged
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_detects_remote_only_change() {
+        assert_eq!(
+            assess_snapshot_sync_state(&synced_status(), "base", Some("remote-new"), None),
+            SnapshotSyncState::RemoteOnlyChanged
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_detects_conflict_when_both_changed() {
+        assert_eq!(
+            assess_snapshot_sync_state(&synced_status(), "local-new", Some("remote-new"), None),
+            SnapshotSyncState::Conflict
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_treats_new_missing_remote_as_uploadable() {
+        assert_eq!(
+            assess_snapshot_sync_state(&WebDavSyncStatus::default(), "local-new", None, None),
+            SnapshotSyncState::RemoteMissing
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_detects_missing_remote_after_sync_as_remote_change() {
+        assert_eq!(
+            assess_snapshot_sync_state(&synced_status(), "base", None, None),
+            SnapshotSyncState::RemoteOnlyChanged
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_detects_missing_remote_with_local_change_as_conflict() {
+        assert_eq!(
+            assess_snapshot_sync_state(&synced_status(), "local-new", None, None),
+            SnapshotSyncState::Conflict
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_accepts_equal_content_without_baseline() {
+        assert_eq!(
+            assess_snapshot_sync_state(&WebDavSyncStatus::default(), "same", Some("same"), None),
+            SnapshotSyncState::InSync
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_requires_choice_without_baseline() {
+        assert_eq!(
+            assess_snapshot_sync_state(&WebDavSyncStatus::default(), "local", Some("remote"), None),
+            SnapshotSyncState::Conflict
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_uses_legacy_manifest_hash_for_local_only_change() {
+        let status = WebDavSyncStatus {
+            last_remote_manifest_hash: Some("remote-hash".to_string()),
+            ..WebDavSyncStatus::default()
+        };
+        assert_eq!(
+            assess_snapshot_sync_state(&status, "local", Some("remote"), Some("remote-hash")),
+            SnapshotSyncState::LocalOnlyChanged
+        );
+    }
+
+    #[test]
+    fn snapshot_sync_state_requires_choice_when_legacy_manifest_hash_changed() {
+        let status = WebDavSyncStatus {
+            last_remote_manifest_hash: Some("remote-hash".to_string()),
+            ..WebDavSyncStatus::default()
+        };
+        assert_eq!(
+            assess_snapshot_sync_state(&status, "local", Some("remote"), Some("new-remote-hash")),
+            SnapshotSyncState::Conflict
+        );
     }
 
     fn manifest_with(format: &str, version: u32, db_compat_version: Option<u32>) -> SyncManifest {

--- a/src-tauri/src/services/webdav.rs
+++ b/src-tauri/src/services/webdav.rs
@@ -17,6 +17,12 @@ const TRANSFER_TIMEOUT_SECS: u64 = 300;
 /// Auth pair: `(username, Some(password))`.
 pub type WebDavAuth = Option<(String, Option<String>)>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PutPrecondition {
+    IfMatch(String),
+    IfNoneMatchAny,
+}
+
 // ─── WebDAV extension methods ────────────────────────────────
 
 fn method_propfind() -> Method {
@@ -97,6 +103,17 @@ pub fn auth_from_credentials(username: &str, password: &str) -> WebDavAuth {
 fn apply_auth(builder: RequestBuilder, auth: &WebDavAuth) -> RequestBuilder {
     match auth {
         Some((user, pass)) => builder.basic_auth(user, pass.as_deref()),
+        None => builder,
+    }
+}
+
+fn apply_put_precondition(
+    builder: RequestBuilder,
+    precondition: Option<&PutPrecondition>,
+) -> RequestBuilder {
+    match precondition {
+        Some(PutPrecondition::IfMatch(etag)) => builder.header("If-Match", etag),
+        Some(PutPrecondition::IfNoneMatchAny) => builder.header("If-None-Match", "*"),
         None => builder,
     }
 }
@@ -228,21 +245,49 @@ pub async fn put_bytes(
     bytes: Vec<u8>,
     content_type: &str,
 ) -> Result<(), AppError> {
+    put_bytes_inner(url, auth, bytes, content_type, None).await
+}
+
+/// PUT bytes to a remote WebDAV URL with an HTTP conditional header.
+pub async fn put_bytes_with_precondition(
+    url: &str,
+    auth: &WebDavAuth,
+    bytes: Vec<u8>,
+    content_type: &str,
+    precondition: PutPrecondition,
+) -> Result<(), AppError> {
+    put_bytes_inner(url, auth, bytes, content_type, Some(&precondition)).await
+}
+
+async fn put_bytes_inner(
+    url: &str,
+    auth: &WebDavAuth,
+    bytes: Vec<u8>,
+    content_type: &str,
+    precondition: Option<&PutPrecondition>,
+) -> Result<(), AppError> {
     let client = http_client::get();
-    let resp = apply_auth(
+    let builder = apply_put_precondition(
         client
             .put(url)
             .header("Content-Type", content_type)
             .body(bytes)
             .timeout(Duration::from_secs(TRANSFER_TIMEOUT_SECS)),
-        auth,
-    )
-    .send()
-    .await
-    .map_err(|e| webdav_transport_error("webdav.put_failed", "PUT 请求", "PUT request", url, &e))?;
+        precondition,
+    );
+    let resp = apply_auth(builder, auth).send().await.map_err(|e| {
+        webdav_transport_error("webdav.put_failed", "PUT 请求", "PUT request", url, &e)
+    })?;
 
     if resp.status().is_success() {
         return Ok(());
+    }
+    if resp.status() == StatusCode::PRECONDITION_FAILED {
+        return Err(AppError::localized(
+            "webdav.put_precondition_failed",
+            "WebDAV 远端文件已变化，条件上传被拒绝",
+            "WebDAV remote file changed, so the conditional upload was rejected.",
+        ));
     }
     Err(webdav_status_error("PUT", resp.status(), url))
 }

--- a/src-tauri/src/services/webdav_auto_sync.rs
+++ b/src-tauri/src/services/webdav_auto_sync.rs
@@ -9,6 +9,9 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use crate::error::AppError;
+use crate::services::sync_protocol::{
+    SYNC_CONFLICT_DETECTED_KEY, SYNC_MANUAL_RESOLUTION_REQUIRED_KEY, SYNC_REMOTE_CHANGED_KEY,
+};
 use crate::services::webdav_sync as webdav_sync_service;
 use crate::settings::{self, WebDavSyncSettings};
 
@@ -81,16 +84,18 @@ fn should_run_auto_sync(settings: Option<&WebDavSyncSettings>) -> bool {
 
 fn persist_auto_sync_error(settings: &mut WebDavSyncSettings, error: &AppError) {
     settings.status.last_error = Some(error.to_string());
+    settings.status.last_error_key = error.localized_key().map(str::to_string);
     settings.status.last_error_source = Some("auto".to_string());
     let _ = settings::update_webdav_sync_status(settings.status.clone());
 }
 
-fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&str>) {
+fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&AppError>) {
     let payload = match error {
-        Some(message) => json!({
+        Some(error) => json!({
             "source": "auto",
             "status": status,
-            "error": message,
+            "error": error.to_string(),
+            "errorKey": error.localized_key(),
         }),
         None => json!({
             "source": "auto",
@@ -100,6 +105,16 @@ fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&s
 
     if let Err(err) = app.emit("webdav-sync-status-updated", payload) {
         log::debug!("[WebDAV] failed to emit sync status update event: {err}");
+    }
+}
+
+fn auto_sync_status_for_error(error: &AppError) -> &'static str {
+    match error.localized_key() {
+        Some(key) if key == SYNC_CONFLICT_DETECTED_KEY || key == SYNC_REMOTE_CHANGED_KEY => {
+            "conflict"
+        }
+        Some(key) if key == SYNC_MANUAL_RESOLUTION_REQUIRED_KEY => "conflict",
+        _ => "error",
     }
 }
 
@@ -117,10 +132,15 @@ async fn run_auto_sync_upload(
         None => return Ok(()),
     };
 
-    let result = webdav_sync_service::run_with_sync_lock(webdav_sync_service::upload(
-        db,
-        &mut sync_settings,
-    ))
+    let result = webdav_sync_service::run_with_sync_lock(async {
+        let snapshot =
+            webdav_sync_service::prepare_auto_sync_snapshot(db, &mut sync_settings).await?;
+        if let Some(snapshot) = snapshot {
+            webdav_sync_service::upload_prepared_auto_sync_snapshot(&mut sync_settings, snapshot)
+                .await?;
+        }
+        Ok(())
+    })
     .await;
     match result {
         Ok(_) => {
@@ -129,7 +149,7 @@ async fn run_auto_sync_upload(
         }
         Err(err) => {
             persist_auto_sync_error(&mut sync_settings, &err);
-            emit_auto_sync_status_updated(app, "error", Some(&err.to_string()));
+            emit_auto_sync_status_updated(app, auto_sync_status_for_error(&err), Some(&err));
             Err(err)
         }
     }

--- a/src-tauri/src/services/webdav_sync.rs
+++ b/src-tauri/src/services/webdav_sync.rs
@@ -13,16 +13,18 @@ use serde_json::Value;
 use crate::error::AppError;
 use crate::services::webdav::{
     auth_from_credentials, build_remote_url, ensure_remote_directories, get_bytes, head_etag,
-    path_segments, put_bytes, test_connection, WebDavAuth,
+    path_segments, put_bytes, put_bytes_with_precondition, test_connection, PutPrecondition,
+    WebDavAuth,
 };
 use crate::settings::{update_webdav_sync_status, WebDavSyncSettings, WebDavSyncStatus};
 
 use super::sync_protocol::{
-    apply_snapshot, build_local_snapshot, effective_db_compat_version, localized,
-    persist_sync_success_best_effort, sha256_hex, validate_artifact_size_limit,
-    validate_manifest_compat, verify_artifact, ArtifactMeta, RemoteLayout, SyncManifest,
-    DB_COMPAT_VERSION, MAX_MANIFEST_BYTES, MAX_SYNC_ARTIFACT_BYTES, PROTOCOL_VERSION,
-    REMOTE_DB_SQL, REMOTE_MANIFEST, REMOTE_SKILLS_ZIP,
+    apply_snapshot, assess_snapshot_sync_state, build_local_snapshot, effective_db_compat_version,
+    localized, manual_resolution_required_error, persist_sync_success_best_effort, sha256_hex,
+    validate_artifact_size_limit, validate_manifest_compat, verify_artifact, ArtifactMeta,
+    LocalSnapshot, RemoteLayout, SnapshotSyncState, SyncManifest, DB_COMPAT_VERSION,
+    MAX_MANIFEST_BYTES, MAX_SYNC_ARTIFACT_BYTES, PROTOCOL_VERSION, REMOTE_DB_SQL, REMOTE_MANIFEST,
+    REMOTE_SKILLS_ZIP, SYNC_MANUAL_RESOLUTION_REQUIRED_KEY,
 };
 
 pub(crate) mod archive;
@@ -42,7 +44,22 @@ where
     operation.await
 }
 
-struct RemoteSnapshot {
+pub(crate) struct PreparedAutoSyncUpload {
+    snapshot: LocalSnapshot,
+    guard: AutoSyncUploadGuard,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AutoSyncUploadGuard {
+    RemoteMissing,
+    CurrentRemote {
+        manifest_etag: String,
+        db_etag: String,
+        skills_etag: String,
+    },
+}
+
+pub(crate) struct RemoteSnapshot {
     layout: RemoteLayout,
     manifest: SyncManifest,
     manifest_bytes: Vec<u8>,
@@ -60,17 +77,73 @@ pub async fn check_connection(settings: &WebDavSyncSettings) -> Result<(), AppEr
     Ok(())
 }
 
+/// Prepare an automatic upload only when the three-way sync state is safe.
+pub async fn prepare_auto_sync_snapshot(
+    db: &crate::database::Database,
+    settings: &mut WebDavSyncSettings,
+) -> Result<Option<PreparedAutoSyncUpload>, AppError> {
+    settings.validate()?;
+    let auth = auth_for(settings);
+    let remote_snapshot = find_remote_snapshot(settings, &auth).await?;
+    let local_snapshot = build_local_snapshot(db)?;
+    let remote_manifest_hash = remote_snapshot
+        .as_ref()
+        .map(|snapshot| sha256_hex(&snapshot.manifest_bytes));
+    let state = assess_snapshot_sync_state(
+        &settings.status,
+        &local_snapshot.snapshot_id,
+        remote_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.manifest.snapshot_id.as_str()),
+        remote_manifest_hash.as_deref(),
+    );
+
+    match state {
+        SnapshotSyncState::RemoteMissing => Ok(Some(PreparedAutoSyncUpload {
+            snapshot: local_snapshot,
+            guard: AutoSyncUploadGuard::RemoteMissing,
+        })),
+        SnapshotSyncState::LocalOnlyChanged => Ok(Some(PreparedAutoSyncUpload {
+            snapshot: local_snapshot,
+            guard: guard_for_auto_upload(settings, &auth, remote_snapshot.as_ref()).await?,
+        })),
+        SnapshotSyncState::InSync => {
+            if let Some(remote_snapshot) = remote_snapshot {
+                let manifest_hash = sha256_hex(&remote_snapshot.manifest_bytes);
+                let _persisted = persist_sync_success_best_effort(
+                    settings,
+                    manifest_hash,
+                    remote_snapshot.manifest.snapshot_id.clone(),
+                    remote_snapshot.manifest_etag,
+                    persist_sync_success,
+                );
+            }
+            Ok(None)
+        }
+        SnapshotSyncState::RemoteOnlyChanged | SnapshotSyncState::Conflict => {
+            Err(manual_resolution_required_error(state))
+        }
+    }
+}
+
 /// Upload local snapshot (db + skills) to remote.
 pub async fn upload(
     db: &crate::database::Database,
     settings: &mut WebDavSyncSettings,
 ) -> Result<Value, AppError> {
+    let snapshot = build_local_snapshot(db)?;
+    upload_snapshot(settings, snapshot).await
+}
+
+/// Upload a prebuilt local snapshot to remote.
+pub async fn upload_snapshot(
+    settings: &mut WebDavSyncSettings,
+    snapshot: LocalSnapshot,
+) -> Result<Value, AppError> {
     settings.validate()?;
     let auth = auth_for(settings);
     let dir_segs = remote_dir_segments(settings, RemoteLayout::Current);
     ensure_remote_directories(&settings.base_url, &dir_segs, &auth).await?;
-
-    let snapshot = build_local_snapshot(db)?;
 
     // Upload order: artifacts first, manifest last (best-effort consistency)
     let db_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_DB_SQL)?;
@@ -100,10 +173,175 @@ pub async fn upload(
     let _persisted = persist_sync_success_best_effort(
         settings,
         snapshot.manifest_hash,
+        snapshot.snapshot_id,
         etag,
         persist_sync_success,
     );
     Ok(serde_json::json!({ "status": "uploaded" }))
+}
+
+/// Upload a prebuilt automatic-sync snapshot with conditional writes.
+///
+/// Manual uploads intentionally overwrite remote data. Automatic uploads use
+/// WebDAV preconditions so a remote change during the upload window is surfaced
+/// as a manual-resolution conflict instead of silently overwriting data.
+pub async fn upload_prepared_auto_sync_snapshot(
+    settings: &mut WebDavSyncSettings,
+    prepared: PreparedAutoSyncUpload,
+) -> Result<Value, AppError> {
+    settings.validate()?;
+    let auth = auth_for(settings);
+    let dir_segs = remote_dir_segments(settings, RemoteLayout::Current);
+    ensure_remote_directories(&settings.base_url, &dir_segs, &auth).await?;
+
+    let db_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_DB_SQL)?;
+    let skills_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_SKILLS_ZIP)?;
+    let manifest_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_MANIFEST)?;
+    let PreparedAutoSyncUpload { snapshot, guard } = prepared;
+
+    match guard {
+        AutoSyncUploadGuard::RemoteMissing => {
+            put_bytes_guarded(
+                &db_url,
+                &auth,
+                snapshot.db_sql,
+                "application/sql",
+                PutPrecondition::IfNoneMatchAny,
+            )
+            .await?;
+            put_bytes_guarded(
+                &skills_url,
+                &auth,
+                snapshot.skills_zip,
+                "application/zip",
+                PutPrecondition::IfNoneMatchAny,
+            )
+            .await?;
+            put_bytes_guarded(
+                &manifest_url,
+                &auth,
+                snapshot.manifest_bytes,
+                "application/json",
+                PutPrecondition::IfNoneMatchAny,
+            )
+            .await?;
+        }
+        AutoSyncUploadGuard::CurrentRemote {
+            manifest_etag,
+            db_etag,
+            skills_etag,
+        } => {
+            put_bytes_guarded(
+                &db_url,
+                &auth,
+                snapshot.db_sql,
+                "application/sql",
+                PutPrecondition::IfMatch(db_etag),
+            )
+            .await?;
+            put_bytes_guarded(
+                &skills_url,
+                &auth,
+                snapshot.skills_zip,
+                "application/zip",
+                PutPrecondition::IfMatch(skills_etag),
+            )
+            .await?;
+            put_bytes_guarded(
+                &manifest_url,
+                &auth,
+                snapshot.manifest_bytes,
+                "application/json",
+                PutPrecondition::IfMatch(manifest_etag),
+            )
+            .await?;
+        }
+    }
+
+    let etag = match head_etag(&manifest_url, &auth).await {
+        Ok(e) => e,
+        Err(e) => {
+            log::debug!("[WebDAV] Failed to fetch ETag after auto upload: {e}");
+            None
+        }
+    };
+
+    let _persisted = persist_sync_success_best_effort(
+        settings,
+        snapshot.manifest_hash,
+        snapshot.snapshot_id,
+        etag,
+        persist_sync_success,
+    );
+    Ok(serde_json::json!({ "status": "uploaded" }))
+}
+
+async fn guard_for_auto_upload(
+    settings: &WebDavSyncSettings,
+    auth: &WebDavAuth,
+    remote_snapshot: Option<&RemoteSnapshot>,
+) -> Result<AutoSyncUploadGuard, AppError> {
+    let Some(manifest_etag) = current_manifest_etag_for_auto_upload(remote_snapshot)? else {
+        return Ok(AutoSyncUploadGuard::RemoteMissing);
+    };
+
+    let db_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_DB_SQL)?;
+    let skills_url = remote_file_url(settings, RemoteLayout::Current, REMOTE_SKILLS_ZIP)?;
+    let db_etag = required_current_etag(&db_url, auth).await?;
+    let skills_etag = required_current_etag(&skills_url, auth).await?;
+
+    Ok(AutoSyncUploadGuard::CurrentRemote {
+        manifest_etag,
+        db_etag,
+        skills_etag,
+    })
+}
+
+fn current_manifest_etag_for_auto_upload(
+    remote_snapshot: Option<&RemoteSnapshot>,
+) -> Result<Option<String>, AppError> {
+    let Some(remote_snapshot) = remote_snapshot else {
+        return Ok(None);
+    };
+    if remote_snapshot.layout != RemoteLayout::Current {
+        return Ok(None);
+    }
+    let Some(manifest_etag) = remote_snapshot.manifest_etag.clone() else {
+        return Err(auto_sync_precondition_unavailable_error());
+    };
+    Ok(Some(manifest_etag))
+}
+
+async fn required_current_etag(url: &str, auth: &WebDavAuth) -> Result<String, AppError> {
+    head_etag(url, auth)
+        .await?
+        .ok_or_else(auto_sync_precondition_unavailable_error)
+}
+
+async fn put_bytes_guarded(
+    url: &str,
+    auth: &WebDavAuth,
+    bytes: Vec<u8>,
+    content_type: &str,
+    precondition: PutPrecondition,
+) -> Result<(), AppError> {
+    put_bytes_with_precondition(url, auth, bytes, content_type, precondition)
+        .await
+        .map_err(|err| {
+            if err.localized_key() == Some("webdav.put_precondition_failed") {
+                manual_resolution_required_error(SnapshotSyncState::RemoteOnlyChanged)
+            } else {
+                err
+            }
+        })
+}
+
+fn auto_sync_precondition_unavailable_error() -> AppError {
+    localized(
+        SYNC_MANUAL_RESOLUTION_REQUIRED_KEY,
+        "WebDAV 服务未返回可用于安全自动上传的 ETag，自动同步已暂停。请手动选择同步方向。",
+        "The WebDAV service did not return an ETag for safe automatic upload, so auto sync paused. Choose a sync direction manually.",
+    )
 }
 
 /// Download remote snapshot and apply to local database + skills.
@@ -150,6 +388,7 @@ pub async fn download(
     let _persisted = persist_sync_success_best_effort(
         settings,
         manifest_hash,
+        snapshot.manifest.snapshot_id.clone(),
         snapshot.manifest_etag,
         persist_sync_success,
     );
@@ -191,14 +430,18 @@ pub async fn fetch_remote_info(settings: &WebDavSyncSettings) -> Result<Option<V
 fn persist_sync_success(
     settings: &mut WebDavSyncSettings,
     manifest_hash: String,
+    snapshot_id: String,
     etag: Option<String>,
 ) -> Result<(), AppError> {
     let status = WebDavSyncStatus {
         last_sync_at: Some(Utc::now().timestamp()),
         last_error: None,
+        last_error_key: None,
         last_error_source: None,
         last_local_manifest_hash: Some(manifest_hash.clone()),
         last_remote_manifest_hash: Some(manifest_hash),
+        last_local_snapshot_id: Some(snapshot_id.clone()),
+        last_remote_snapshot_id: Some(snapshot_id),
         last_remote_etag: etag,
     };
     settings.status = status.clone();
@@ -310,6 +553,7 @@ fn auth_for(settings: &WebDavSyncSettings) -> WebDavAuth {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn remote_dir_segments_uses_current_layout() {
@@ -331,5 +575,61 @@ mod tests {
         };
         let segs = remote_dir_segments(&settings, RemoteLayout::Legacy);
         assert_eq!(segs, vec!["cc-switch-sync", "v2", "default"]);
+    }
+
+    fn remote_snapshot(layout: RemoteLayout, etag: Option<&str>) -> RemoteSnapshot {
+        RemoteSnapshot {
+            layout,
+            manifest: SyncManifest {
+                format: super::super::sync_protocol::PROTOCOL_FORMAT.to_string(),
+                version: PROTOCOL_VERSION,
+                db_compat_version: Some(DB_COMPAT_VERSION),
+                device_name: "test-device".to_string(),
+                created_at: "2026-06-10T00:00:00Z".to_string(),
+                artifacts: BTreeMap::new(),
+                snapshot_id: "base".to_string(),
+            },
+            manifest_bytes: Vec::new(),
+            manifest_etag: etag.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn auto_upload_guard_treats_missing_remote_as_create_only() {
+        assert_eq!(
+            current_manifest_etag_for_auto_upload(None).expect("missing remote should be guarded"),
+            None
+        );
+    }
+
+    #[test]
+    fn auto_upload_guard_treats_legacy_remote_as_current_create_only() {
+        let remote = remote_snapshot(RemoteLayout::Legacy, Some("\"etag\""));
+        assert_eq!(
+            current_manifest_etag_for_auto_upload(Some(&remote))
+                .expect("legacy remote should be guarded"),
+            None
+        );
+    }
+
+    #[test]
+    fn auto_upload_guard_requires_current_manifest_etag() {
+        let remote = remote_snapshot(RemoteLayout::Current, None);
+        let err = current_manifest_etag_for_auto_upload(Some(&remote))
+            .expect_err("missing etag should fail safe");
+        assert_eq!(
+            err.localized_key(),
+            Some(SYNC_MANUAL_RESOLUTION_REQUIRED_KEY)
+        );
+    }
+
+    #[test]
+    fn auto_upload_guard_uses_current_manifest_etag() {
+        let remote = remote_snapshot(RemoteLayout::Current, Some("\"etag\""));
+        assert_eq!(
+            current_manifest_etag_for_auto_upload(Some(&remote))
+                .expect("etag should create if-match guard"),
+            Some("\"etag\"".to_string())
+        );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -85,6 +85,8 @@ pub struct WebDavSyncStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_error_source: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_remote_etag: Option<String>,
@@ -92,6 +94,10 @@ pub struct WebDavSyncStatus {
     pub last_local_manifest_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_remote_manifest_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_local_snapshot_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_remote_snapshot_id: Option<String>,
 }
 
 fn default_remote_root() -> String {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,10 @@ import { SkillsPage } from "@/components/skills/SkillsPage";
 import UnifiedSkillsPanel from "@/components/skills/UnifiedSkillsPanel";
 import { DeepLinkImportDialog } from "@/components/DeepLinkImportDialog";
 import { FirstRunNoticeDialog } from "@/components/FirstRunNoticeDialog";
+import {
+  WebdavSyncConflictDialog,
+  type WebdavSyncResolutionAction,
+} from "@/components/WebdavSyncConflictDialog";
 import { AgentsPanel } from "@/components/agents/AgentsPanel";
 import { UniversalProviderPanel } from "@/components/universal";
 import { McpIcon } from "@/components/BrandIcons";
@@ -111,8 +115,17 @@ interface SyncStatusUpdatedPayload {
   source?: string;
   status?: string;
   error?: string;
+  errorKey?: string | null;
 }
 
+const CONFLICT_SYNC_ERROR_KEY = "sync.conflict_detected";
+const REMOTE_CHANGED_SYNC_ERROR_KEY = "sync.remote_changed_since_last_sync";
+const MANUAL_RESOLUTION_SYNC_ERROR_KEY = "sync.manual_resolution_required";
+const WEBDAV_MANUAL_RESOLUTION_ERROR_KEYS = new Set([
+  CONFLICT_SYNC_ERROR_KEY,
+  REMOTE_CHANGED_SYNC_ERROR_KEY,
+  MANUAL_RESOLUTION_SYNC_ERROR_KEY,
+]);
 const DEFAULT_DRAG_BAR_HEIGHT = isWindows() || isLinux() ? 0 : 28; // px
 const HEADER_HEIGHT = 64; // px
 
@@ -230,6 +243,9 @@ function App() {
     provider: Provider;
     action: "remove" | "delete";
   } | null>(null);
+  const [webdavConflictOpen, setWebdavConflictOpen] = useState(false);
+  const [webdavResolutionAction, setWebdavResolutionAction] =
+    useState<WebdavSyncResolutionAction | null>(null);
   const [envConflicts, setEnvConflicts] = useState<EnvConflict[]>([]);
   const [showEnvBanner, setShowEnvBanner] = useState(false);
 
@@ -376,7 +392,18 @@ function App() {
     async (payload) => {
       const statusPayload = payload ?? {};
       await queryClient.invalidateQueries({ queryKey: ["settings"] });
-      if (statusPayload.source !== "auto" || statusPayload.status !== "error") {
+      if (statusPayload.source !== "auto") {
+        return;
+      }
+      if (
+        statusPayload.status === "conflict" ||
+        (statusPayload.errorKey &&
+          WEBDAV_MANUAL_RESOLUTION_ERROR_KEYS.has(statusPayload.errorKey))
+      ) {
+        setWebdavConflictOpen(true);
+        return;
+      }
+      if (statusPayload.status !== "error") {
         return;
       }
       toast.error(
@@ -393,6 +420,10 @@ function App() {
       const statusPayload = payload ?? {};
       await queryClient.invalidateQueries({ queryKey: ["settings"] });
       if (statusPayload.source !== "auto" || statusPayload.status !== "error") {
+        return;
+      }
+      if (statusPayload.errorKey === REMOTE_CHANGED_SYNC_ERROR_KEY) {
+        toast.error(t("settings.s3Sync.autoSyncRemoteChangedToast"));
         return;
       }
       toast.error(
@@ -659,6 +690,35 @@ function App() {
       await deleteProvider(provider.id);
     }
     setConfirmAction(null);
+  };
+
+  const handleResolveWebdavConflict = async (
+    action: WebdavSyncResolutionAction,
+  ) => {
+    setWebdavResolutionAction(action);
+    try {
+      if (action === "upload") {
+        await settingsApi.webdavSyncUpload();
+        toast.success(t("settings.webdavSync.uploadSuccess"));
+      } else {
+        await settingsApi.webdavSyncDownload();
+        toast.success(t("settings.webdavSync.downloadSuccess"));
+      }
+      setWebdavConflictOpen(false);
+      await queryClient.invalidateQueries({ queryKey: ["settings"] });
+    } catch (error) {
+      const key =
+        action === "upload"
+          ? "settings.webdavSync.uploadFailed"
+          : "settings.webdavSync.downloadFailed";
+      toast.error(
+        t(key, {
+          error: (error as Error)?.message ?? String(error),
+        }),
+      );
+    } finally {
+      setWebdavResolutionAction(null);
+    }
   };
 
   const generateUniqueProviderCopyKey = (
@@ -1609,6 +1669,14 @@ function App() {
           })();
         }}
         onCancel={() => setLaunchDashboardOpen(false)}
+      />
+
+      <WebdavSyncConflictDialog
+        open={webdavConflictOpen}
+        resolvingAction={webdavResolutionAction}
+        onUseLocal={() => void handleResolveWebdavConflict("upload")}
+        onUseRemote={() => void handleResolveWebdavConflict("download")}
+        onCancel={() => setWebdavConflictOpen(false)}
       />
 
       <DeepLinkImportDialog />

--- a/src/components/WebdavSyncConflictDialog.tsx
+++ b/src/components/WebdavSyncConflictDialog.tsx
@@ -1,0 +1,94 @@
+import {
+  AlertTriangle,
+  DownloadCloud,
+  Loader2,
+  UploadCloud,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export type WebdavSyncResolutionAction = "upload" | "download";
+
+interface WebdavSyncConflictDialogProps {
+  open: boolean;
+  resolvingAction: WebdavSyncResolutionAction | null;
+  onUseLocal: () => void;
+  onUseRemote: () => void;
+  onCancel: () => void;
+}
+
+export function WebdavSyncConflictDialog({
+  open,
+  resolvingAction,
+  onUseLocal,
+  onUseRemote,
+  onCancel,
+}: WebdavSyncConflictDialogProps) {
+  const { t } = useTranslation();
+  const isResolving = resolvingAction !== null;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && !isResolving) {
+          onCancel();
+        }
+      }}
+    >
+      <DialogContent className="max-w-md" zIndex="alert">
+        <DialogHeader className="space-y-3 border-b-0 bg-transparent pb-0">
+          <DialogTitle className="flex items-center gap-2 text-lg font-semibold">
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+            {t("settings.webdavSync.conflictDialog.title")}
+          </DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-3 text-sm leading-relaxed">
+              <p>{t("settings.webdavSync.conflictDialog.message")}</p>
+              <div className="rounded-lg border border-border bg-muted/50 p-3 text-xs text-muted-foreground">
+                {t("settings.webdavSync.conflictDialog.warning")}
+              </div>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex gap-2 border-t-0 bg-transparent pt-2 sm:justify-end">
+          <Button variant="outline" onClick={onCancel} disabled={isResolving}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={onUseRemote}
+            disabled={isResolving}
+          >
+            {resolvingAction === "download" ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <DownloadCloud className="h-3.5 w-3.5" />
+            )}
+            {t("settings.webdavSync.conflictDialog.useRemote")}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onUseLocal}
+            disabled={isResolving}
+          >
+            {resolvingAction === "upload" ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <UploadCloud className="h-3.5 w-3.5" />
+            )}
+            {t("settings.webdavSync.conflictDialog.useLocal")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/WebdavSyncSection.tsx
+++ b/src/components/settings/WebdavSyncSection.tsx
@@ -147,6 +147,15 @@ const S3_PRESETS: S3Preset[] = [
   },
 ];
 
+const CONFLICT_SYNC_ERROR_KEY = "sync.conflict_detected";
+const REMOTE_CHANGED_SYNC_ERROR_KEY = "sync.remote_changed_since_last_sync";
+const MANUAL_RESOLUTION_SYNC_ERROR_KEY = "sync.manual_resolution_required";
+const MANUAL_RESOLUTION_SYNC_ERROR_KEYS = new Set([
+  CONFLICT_SYNC_ERROR_KEY,
+  REMOTE_CHANGED_SYNC_ERROR_KEY,
+  MANUAL_RESOLUTION_SYNC_ERROR_KEY,
+]);
+
 /** Format an RFC 3339 date string for display; falls back to raw string. */
 function formatDate(rfc3339: string): string {
   const d = new Date(rfc3339);
@@ -941,6 +950,18 @@ export function WebdavSyncSection({
   const lastError = config?.status?.lastError?.trim();
   const showAutoSyncError =
     !!lastError && config?.status?.lastErrorSource === "auto";
+  const isManualResolutionAutoSyncError =
+    !!config?.status?.lastErrorKey &&
+    MANUAL_RESOLUTION_SYNC_ERROR_KEYS.has(config.status.lastErrorKey);
+  const autoSyncErrorTitleKey = isManualResolutionAutoSyncError
+    ? "settings.webdavSync.autoSyncRemoteChangedTitle"
+    : "settings.webdavSync.autoSyncLastErrorTitle";
+  const autoSyncErrorMessage = isManualResolutionAutoSyncError
+    ? t("settings.webdavSync.autoSyncRemoteChangedMessage")
+    : lastError;
+  const autoSyncErrorHintKey = isManualResolutionAutoSyncError
+    ? "settings.webdavSync.autoSyncRemoteChangedHint"
+    : "settings.webdavSync.autoSyncLastErrorHint";
   const currentRemotePath = `/${form.remoteRoot.trim() || "cc-switch-sync"}/v2/db-v6/${form.profile.trim() || "default"}`;
   const currentS3RemotePath = `${s3Bucket.trim() || "bucket"}/${s3RemoteRoot.trim() || "cc-switch-sync"}/v2/db-v6/${s3Profile.trim() || "default"}`;
   const remoteDbCompatDisplay = formatDbCompatVersion(
@@ -955,6 +976,17 @@ export function WebdavSyncSection({
   const s3LastError = s3Config?.status?.lastError?.trim();
   const s3ShowAutoSyncError =
     !!s3LastError && s3Config?.status?.lastErrorSource === "auto";
+  const s3IsRemoteChangedAutoSyncError =
+    s3Config?.status?.lastErrorKey === REMOTE_CHANGED_SYNC_ERROR_KEY;
+  const s3AutoSyncErrorTitleKey = s3IsRemoteChangedAutoSyncError
+    ? "settings.s3Sync.autoSyncRemoteChangedTitle"
+    : "settings.s3Sync.autoSyncLastErrorTitle";
+  const s3AutoSyncErrorMessage = s3IsRemoteChangedAutoSyncError
+    ? t("settings.s3Sync.autoSyncRemoteChangedMessage")
+    : s3LastError;
+  const s3AutoSyncErrorHintKey = s3IsRemoteChangedAutoSyncError
+    ? "settings.s3Sync.autoSyncRemoteChangedHint"
+    : "settings.s3Sync.autoSyncLastErrorHint";
 
   // ─── Render ─────────────────────────────────────────────
 
@@ -1132,12 +1164,12 @@ export function WebdavSyncSection({
           )}
           {showAutoSyncError && (
             <div className="rounded-lg border border-red-300/70 bg-red-50/80 px-3 py-2 text-xs text-red-900 dark:border-red-500/50 dark:bg-red-950/30 dark:text-red-200">
-              <p className="font-medium">
-                {t("settings.webdavSync.autoSyncLastErrorTitle")}
+              <p className="font-medium">{t(autoSyncErrorTitleKey)}</p>
+              <p className="mt-1 break-all whitespace-pre-wrap">
+                {autoSyncErrorMessage}
               </p>
-              <p className="mt-1 break-all whitespace-pre-wrap">{lastError}</p>
               <p className="mt-1 text-[11px] text-red-700/90 dark:text-red-300/80">
-                {t("settings.webdavSync.autoSyncLastErrorHint")}
+                {t(autoSyncErrorHintKey)}
               </p>
             </div>
           )}
@@ -1443,14 +1475,12 @@ export function WebdavSyncSection({
           )}
           {s3ShowAutoSyncError && (
             <div className="rounded-lg border border-red-300/70 bg-red-50/80 px-3 py-2 text-xs text-red-900 dark:border-red-500/50 dark:bg-red-950/30 dark:text-red-200">
-              <p className="font-medium">
-                {t("settings.s3Sync.autoSyncLastErrorTitle")}
-              </p>
+              <p className="font-medium">{t(s3AutoSyncErrorTitleKey)}</p>
               <p className="mt-1 break-all whitespace-pre-wrap">
-                {s3LastError}
+                {s3AutoSyncErrorMessage}
               </p>
               <p className="mt-1 text-[11px] text-red-700/90 dark:text-red-300/80">
-                {t("settings.s3Sync.autoSyncLastErrorHint")}
+                {t(s3AutoSyncErrorHintKey)}
               </p>
             </div>
           )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -496,6 +496,9 @@
       "lastSync": "Last sync: {{time}}",
       "autoSyncLastErrorTitle": "Last auto sync failed",
       "autoSyncLastErrorHint": "Please check network or WebDAV settings. Auto sync will retry on future changes.",
+      "autoSyncRemoteChangedTitle": "Choose sync direction",
+      "autoSyncRemoteChangedMessage": "Cloud sync data changed, so auto sync paused.",
+      "autoSyncRemoteChangedHint": "Choose whether to overwrite the cloud with this device, or overwrite this device with the cloud version.",
       "missingUrl": "Please enter the WebDAV server URL",
       "presets": {
         "label": "Provider",
@@ -544,6 +547,13 @@
         "warning": "This will overwrite existing sync data on the remote server",
         "legacyNotice": "Legacy remote data was detected. This upload will write to the new v2/db-v6 path and will not overwrite the legacy path.",
         "confirm": "Confirm Upload"
+      },
+      "conflictDialog": {
+        "title": "WebDAV Sync Needs a Choice",
+        "message": "The local and cloud sync snapshots differ, so auto sync paused to avoid overwriting either side.",
+        "warning": "Using the local version overwrites the cloud. Using the cloud version overwrites the local database and skill configuration.",
+        "useLocal": "Use Local Version",
+        "useRemote": "Use Cloud Version"
       }
     },
     "syncType": {
@@ -608,6 +618,7 @@
       "uploadSuccess": "Uploaded to S3",
       "uploadFailed": "S3 upload failed: {{error}}",
       "autoSyncFailedToast": "S3 auto sync failed: {{error}}",
+      "autoSyncRemoteChangedToast": "S3 cloud data changed, so auto sync paused. Choose the sync direction manually.",
       "download": "Download from Cloud",
       "downloading": "Downloading...",
       "downloadSuccess": "Downloaded and restored from S3",
@@ -615,6 +626,9 @@
       "lastSync": "Last sync: {{time}}",
       "autoSyncLastErrorTitle": "Last S3 auto sync failed",
       "autoSyncLastErrorHint": "Please check network or S3 settings. Auto sync will retry on future changes.",
+      "autoSyncRemoteChangedTitle": "Choose S3 sync direction",
+      "autoSyncRemoteChangedMessage": "S3 cloud sync data changed, so auto sync paused.",
+      "autoSyncRemoteChangedHint": "Choose whether to overwrite the cloud with this device, or overwrite this device with the cloud version.",
       "missingBucket": "Please enter the S3 bucket",
       "noRemoteData": "No sync data found in the S3 bucket",
       "incompatibleVersion": "Remote data is incompatible (version {{version}}). This client supports protocol v2 / db-v6.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -496,6 +496,9 @@
       "lastSync": "前回の同期：{{time}}",
       "autoSyncLastErrorTitle": "前回の自動同期に失敗しました",
       "autoSyncLastErrorHint": "ネットワークまたは WebDAV 設定を確認してください。次回の変更時に自動再試行されます。",
+      "autoSyncRemoteChangedTitle": "同期方向を選択してください",
+      "autoSyncRemoteChangedMessage": "クラウド同期データが更新されたため、自動同期を一時停止しました。",
+      "autoSyncRemoteChangedHint": "このデバイスでクラウドを上書きするか、クラウド版でこのデバイスを上書きするかを選択してください。",
       "missingUrl": "WebDAV サーバー URL を入力してください",
       "presets": {
         "label": "サービス",
@@ -544,6 +547,13 @@
         "warning": "リモートの既存同期データが上書きされます",
         "legacyNotice": "旧レイアウトのリモートデータを検出しました。今回のアップロードは新しい v2/db-v6 パスに書き込み、旧パスは上書きしません。",
         "confirm": "アップロードを実行"
+      },
+      "conflictDialog": {
+        "title": "WebDAV 同期には選択が必要です",
+        "message": "ローカルとクラウドの同期スナップショットが異なるため、どちらも上書きしないよう自動同期を一時停止しました。",
+        "warning": "ローカル版を使うとクラウドを上書きします。クラウド版を使うとローカルのデータベースとスキル設定を上書きします。",
+        "useLocal": "ローカル版を使う",
+        "useRemote": "クラウド版を使う"
       }
     },
     "syncType": {
@@ -608,6 +618,7 @@
       "uploadSuccess": "S3 にアップロードしました",
       "uploadFailed": "S3 アップロードに失敗しました：{{error}}",
       "autoSyncFailedToast": "S3 自動同期に失敗しました：{{error}}",
+      "autoSyncRemoteChangedToast": "S3 クラウドデータが更新されているため、自動同期を一時停止しました。同期方向を手動で選択してください。",
       "download": "クラウドからダウンロード",
       "downloading": "ダウンロード中...",
       "downloadSuccess": "S3 からダウンロード・復元しました",
@@ -615,6 +626,9 @@
       "lastSync": "前回の同期：{{time}}",
       "autoSyncLastErrorTitle": "前回の S3 自動同期に失敗しました",
       "autoSyncLastErrorHint": "ネットワークまたは S3 設定を確認してください。次回の変更時に自動再試行されます。",
+      "autoSyncRemoteChangedTitle": "S3 同期方向を選択してください",
+      "autoSyncRemoteChangedMessage": "S3 クラウド同期データが更新されたため、自動同期を一時停止しました。",
+      "autoSyncRemoteChangedHint": "このデバイスでクラウドを上書きするか、クラウド版でこのデバイスを上書きするかを選択してください。",
       "missingBucket": "S3 バケットを入力してください",
       "noRemoteData": "S3 バケットに同期データが見つかりません",
       "incompatibleVersion": "リモートデータに互換性がありません（バージョン {{version}}）。このクライアントは protocol v2 / db-v6 をサポートしています。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -496,6 +496,9 @@
       "lastSync": "上次同步：{{time}}",
       "autoSyncLastErrorTitle": "上次自動同步失敗",
       "autoSyncLastErrorHint": "請檢查網路或 WebDAV 設定，系統會在後續變更時繼續自動重試。",
+      "autoSyncRemoteChangedTitle": "需要選擇同步方向",
+      "autoSyncRemoteChangedMessage": "雲端同步資料已更新，自動同步已暫停。",
+      "autoSyncRemoteChangedHint": "請確認使用本機版本覆蓋雲端，或使用雲端版本覆蓋本機。",
       "missingUrl": "請填寫 WebDAV 伺服器位址",
       "presets": {
         "label": "服務商",
@@ -544,6 +547,13 @@
         "warning": "將覆寫雲端已有的同步資料",
         "legacyNotice": "檢測到舊版雲端路徑資料。本次上傳將寫入新路徑 v2/db-v6，不會覆寫舊路徑。",
         "confirm": "確認上傳"
+      },
+      "conflictDialog": {
+        "title": "WebDAV 同步需要手動選擇",
+        "message": "本機和雲端的同步快照不一致，自動同步已暫停以避免覆蓋任一端資料。",
+        "warning": "使用本機版本會覆蓋雲端；使用雲端版本會覆蓋本機資料庫和技能設定。",
+        "useLocal": "使用本機版本",
+        "useRemote": "使用雲端版本"
       }
     },
     "syncType": {
@@ -608,6 +618,7 @@
       "uploadSuccess": "已上傳到 S3",
       "uploadFailed": "S3 上傳失敗：{{error}}",
       "autoSyncFailedToast": "S3 自動同步失敗：{{error}}",
+      "autoSyncRemoteChangedToast": "S3 雲端已有更新，自動同步已暫停。請手動選擇同步方向。",
       "download": "從雲端下載",
       "downloading": "下載中...",
       "downloadSuccess": "已從 S3 下載並還原",
@@ -615,6 +626,9 @@
       "lastSync": "上次同步：{{time}}",
       "autoSyncLastErrorTitle": "上次 S3 自動同步失敗",
       "autoSyncLastErrorHint": "請檢查網路或 S3 設定，系統會在後續變更時繼續自動重試。",
+      "autoSyncRemoteChangedTitle": "需要選擇 S3 同步方向",
+      "autoSyncRemoteChangedMessage": "S3 雲端同步資料已更新，自動同步已暫停。",
+      "autoSyncRemoteChangedHint": "請確認使用本機版本覆蓋雲端，或使用雲端版本覆蓋本機。",
       "missingBucket": "請填寫 S3 儲存桶",
       "noRemoteData": "S3 儲存桶中沒有找到同步資料",
       "incompatibleVersion": "遠端資料版本不相容（版本 {{version}}），目前支援協議 v2 / db-v6",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -496,6 +496,9 @@
       "lastSync": "上次同步：{{time}}",
       "autoSyncLastErrorTitle": "上次自动同步失败",
       "autoSyncLastErrorHint": "请检查网络或 WebDAV 配置，系统会在后续变更时继续自动重试。",
+      "autoSyncRemoteChangedTitle": "需要选择同步方向",
+      "autoSyncRemoteChangedMessage": "云端同步数据已更新，自动同步已暂停。",
+      "autoSyncRemoteChangedHint": "请确认使用本机版本覆盖云端，或使用云端版本覆盖本机。",
       "missingUrl": "请填写 WebDAV 服务器地址",
       "presets": {
         "label": "服务商",
@@ -544,6 +547,13 @@
         "warning": "将覆盖云端已有的同步数据",
         "legacyNotice": "检测到旧版云端路径数据。本次上传将写入新路径 v2/db-v6，不会覆盖旧路径。",
         "confirm": "确认上传"
+      },
+      "conflictDialog": {
+        "title": "WebDAV 同步需要手动选择",
+        "message": "本机和云端的同步快照不一致，自动同步已暂停以避免覆盖任一端数据。",
+        "warning": "使用本机版本会覆盖云端；使用云端版本会覆盖本机数据库和技能配置。",
+        "useLocal": "使用本机版本",
+        "useRemote": "使用云端版本"
       }
     },
     "syncType": {
@@ -608,6 +618,7 @@
       "uploadSuccess": "已上传到 S3",
       "uploadFailed": "S3 上传失败：{{error}}",
       "autoSyncFailedToast": "S3 自动同步失败：{{error}}",
+      "autoSyncRemoteChangedToast": "S3 云端已有更新，自动同步已暂停。请手动选择同步方向。",
       "download": "从云端下载",
       "downloading": "下载中...",
       "downloadSuccess": "已从 S3 下载并恢复",
@@ -615,6 +626,9 @@
       "lastSync": "上次同步：{{time}}",
       "autoSyncLastErrorTitle": "上次 S3 自动同步失败",
       "autoSyncLastErrorHint": "请检查网络或 S3 配置，系统会在后续变更时继续自动重试。",
+      "autoSyncRemoteChangedTitle": "需要选择 S3 同步方向",
+      "autoSyncRemoteChangedMessage": "S3 云端同步数据已更新，自动同步已暂停。",
+      "autoSyncRemoteChangedHint": "请确认使用本机版本覆盖云端，或使用云端版本覆盖本机。",
       "missingBucket": "请填写 S3 存储桶",
       "noRemoteData": "S3 存储桶中没有找到同步数据",
       "incompatibleVersion": "远端数据版本不兼容（版本 {{version}}），当前支持协议 v2 / db-v6",

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -49,10 +49,13 @@ export const settingsSchema = z.object({
         .object({
           lastSyncAt: z.number().nullable().optional(),
           lastError: z.string().nullable().optional(),
+          lastErrorKey: z.string().nullable().optional(),
           lastErrorSource: z.string().nullable().optional(),
           lastRemoteEtag: z.string().nullable().optional(),
           lastLocalManifestHash: z.string().nullable().optional(),
           lastRemoteManifestHash: z.string().nullable().optional(),
+          lastLocalSnapshotId: z.string().nullable().optional(),
+          lastRemoteSnapshotId: z.string().nullable().optional(),
         })
         .optional(),
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,10 +271,13 @@ export interface VisibleApps {
 export interface WebDavSyncStatus {
   lastSyncAt?: number | null;
   lastError?: string | null;
+  lastErrorKey?: string | null;
   lastErrorSource?: string | null;
   lastRemoteEtag?: string | null;
   lastLocalManifestHash?: string | null;
   lastRemoteManifestHash?: string | null;
+  lastLocalSnapshotId?: string | null;
+  lastRemoteSnapshotId?: string | null;
 }
 
 // WebDAV 同步配置

--- a/tests/components/WebdavSyncSection.test.tsx
+++ b/tests/components/WebdavSyncSection.test.tsx
@@ -27,7 +27,9 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Button: ({ children, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 vi.mock("@/components/ui/input", () => ({
@@ -138,7 +140,9 @@ describe("WebdavSyncSection", () => {
       artifacts: ["db.sql", "skills.zip"],
     });
     settingsApiMock.webdavSyncUpload.mockResolvedValue({ status: "uploaded" });
-    settingsApiMock.webdavSyncDownload.mockResolvedValue({ status: "downloaded" });
+    settingsApiMock.webdavSyncDownload.mockResolvedValue({
+      status: "downloaded",
+    });
   });
 
   it("shows auto sync error callout when last auto sync failed", () => {
@@ -154,6 +158,54 @@ describe("WebdavSyncSection", () => {
       screen.getByText("settings.webdavSync.autoSyncLastErrorTitle"),
     ).toBeInTheDocument();
     expect(screen.getByText("network timeout")).toBeInTheDocument();
+  });
+
+  it("shows remote-changed guidance for auto sync conflicts", () => {
+    renderSection({
+      ...baseConfig,
+      status: {
+        lastError: "backend remote changed error",
+        lastErrorKey: "sync.remote_changed_since_last_sync",
+        lastErrorSource: "auto",
+      },
+    });
+
+    expect(
+      screen.getByText("settings.webdavSync.autoSyncRemoteChangedTitle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("settings.webdavSync.autoSyncRemoteChangedMessage"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("settings.webdavSync.autoSyncRemoteChangedHint"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("settings.webdavSync.autoSyncLastErrorHint"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("backend remote changed error"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows manual-resolution guidance when auto sync cannot safely upload", () => {
+    renderSection({
+      ...baseConfig,
+      status: {
+        lastError: "backend manual resolution error",
+        lastErrorKey: "sync.manual_resolution_required",
+        lastErrorSource: "auto",
+      },
+    });
+
+    expect(
+      screen.getByText("settings.webdavSync.autoSyncRemoteChangedTitle"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("settings.webdavSync.autoSyncRemoteChangedMessage"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("backend manual resolution error"),
+    ).not.toBeInTheDocument();
   });
 
   it("does not show auto sync error callout for manual sync errors", () => {
@@ -187,16 +239,22 @@ describe("WebdavSyncSection", () => {
   it("shows validation error when saving without base url", async () => {
     renderSection({ ...baseConfig, baseUrl: "" });
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
-    expect(toastErrorMock).toHaveBeenCalledWith("settings.webdavSync.missingUrl");
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "settings.webdavSync.missingUrl",
+    );
     expect(settingsApiMock.webdavSyncSaveSettings).not.toHaveBeenCalled();
   });
 
   it("saves settings and auto tests connection", async () => {
     renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -226,7 +284,9 @@ describe("WebdavSyncSection", () => {
   it("preserves password only for the single post-save refresh", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -264,7 +324,9 @@ describe("WebdavSyncSection", () => {
   it("does not preserve password after a later external config refresh", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -304,7 +366,9 @@ describe("WebdavSyncSection", () => {
   it("does not submit a preserved password again when testing without touching it", async () => {
     const view = renderSection(baseConfig);
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledTimes(1);
@@ -316,7 +380,9 @@ describe("WebdavSyncSection", () => {
       </QueryClientProvider>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.test" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.test" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavTestConnection).toHaveBeenLastCalledWith(
@@ -342,7 +408,9 @@ describe("WebdavSyncSection", () => {
         screen.getByRole("switch", { name: "settings.webdavSync.autoSync" }),
       ).toHaveAttribute("aria-checked", "true");
     });
-    fireEvent.click(screen.getByRole("button", { name: "settings.webdavSync.save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.webdavSync.save" }),
+    );
 
     await waitFor(() => {
       expect(settingsApiMock.webdavSyncSaveSettings).toHaveBeenCalledWith(
@@ -394,7 +462,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(
@@ -418,7 +488,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.upload" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("cc-switch-sync"), {
@@ -446,7 +518,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(
@@ -470,7 +544,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.download" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("default"), {
@@ -491,7 +567,9 @@ describe("WebdavSyncSection", () => {
   });
 
   it("shows info when no remote snapshot is found for download", async () => {
-    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({ empty: true });
+    settingsApiMock.webdavSyncFetchRemoteInfo.mockResolvedValueOnce({
+      empty: true,
+    });
     renderSection(baseConfig);
 
     fireEvent.click(
@@ -499,7 +577,9 @@ describe("WebdavSyncSection", () => {
     );
 
     await waitFor(() => {
-      expect(toastInfoMock).toHaveBeenCalledWith("settings.webdavSync.noRemoteData");
+      expect(toastInfoMock).toHaveBeenCalledWith(
+        "settings.webdavSync.noRemoteData",
+      );
     });
     expect(settingsApiMock.webdavSyncDownload).not.toHaveBeenCalled();
   });
@@ -540,7 +620,9 @@ describe("WebdavSyncSection", () => {
       screen.getByRole("button", { name: "settings.webdavSync.download" }),
     );
     await waitFor(() => {
-      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(1);
+      expect(settingsApiMock.webdavSyncFetchRemoteInfo).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     fireEvent.click(

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -117,6 +117,43 @@ vi.mock("@/components/ConfirmDialog", () => ({
     ) : null,
 }));
 
+vi.mock("@/components/WebdavSyncConflictDialog", () => ({
+  WebdavSyncConflictDialog: ({
+    open,
+    resolvingAction,
+    onCancel,
+    onUseLocal,
+    onUseRemote,
+  }: any) =>
+    open ? (
+      <div data-testid="webdav-sync-conflict-dialog">
+        <button disabled={resolvingAction !== null} onClick={() => onCancel()}>
+          common.cancel
+        </button>
+        <button
+          disabled={resolvingAction !== null}
+          onClick={() => onUseLocal()}
+        >
+          settings.webdavSync.conflictDialog.useLocal
+        </button>
+        <button
+          disabled={resolvingAction !== null}
+          onClick={() => onUseRemote()}
+        >
+          settings.webdavSync.conflictDialog.useRemote
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/DeepLinkImportDialog", () => ({
+  DeepLinkImportDialog: () => null,
+}));
+
+vi.mock("@/components/FirstRunNoticeDialog", () => ({
+  FirstRunNoticeDialog: () => null,
+}));
+
 vi.mock("@/components/AppSwitcher", () => ({
   AppSwitcher: ({ activeApp, onSwitch }: any) => (
     <div data-testid="app-switcher">
@@ -158,6 +195,8 @@ const renderApp = (AppComponent: ComponentType) => {
 
 describe("App integration with MSW", () => {
   beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
     resetProviderState();
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
@@ -218,7 +257,7 @@ describe("App integration with MSW", () => {
 
     expect(toastErrorMock).not.toHaveBeenCalled();
     expect(toastSuccessMock).toHaveBeenCalled();
-  });
+  }, 30_000);
 
   it("shows toast when auto sync fails in background", async () => {
     const { default: App } = await import("@/App");
@@ -244,6 +283,70 @@ describe("App integration with MSW", () => {
     await waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalled();
     });
+
+    toastErrorMock.mockReset();
+    emitTauriEvent("webdav-sync-status-updated", {
+      source: "auto",
+      status: "conflict",
+      error: "backend remote changed error",
+      errorKey: "sync.remote_changed_since_last_sync",
+    });
+
+    const useLocalButton = await screen.findByRole("button", {
+      name: "settings.webdavSync.conflictDialog.useLocal",
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+
+    fireEvent.click(useLocalButton);
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "settings.webdavSync.uploadSuccess",
+      );
+    });
+    expect(
+      screen.queryByRole("button", {
+        name: "settings.webdavSync.conflictDialog.useLocal",
+      }),
+    ).not.toBeInTheDocument();
+
+    toastErrorMock.mockReset();
+    emitTauriEvent("webdav-sync-status-updated", {
+      source: "auto",
+      status: "error",
+      error: "backend conflict error",
+      errorKey: "sync.conflict_detected",
+    });
+
+    expect(
+      await screen.findByRole("button", {
+        name: "settings.webdavSync.conflictDialog.useRemote",
+      }),
+    ).toBeInTheDocument();
+    expect(toastErrorMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("backend conflict error"),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "common.cancel",
+      }),
+    );
+    toastErrorMock.mockReset();
+    emitTauriEvent("webdav-sync-status-updated", {
+      source: "auto",
+      status: "conflict",
+      error: "backend manual resolution error",
+      errorKey: "sync.manual_resolution_required",
+    });
+
+    expect(
+      await screen.findByRole("button", {
+        name: "settings.webdavSync.conflictDialog.useRemote",
+      }),
+    ).toBeInTheDocument();
+    expect(toastErrorMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("backend manual resolution error"),
+    );
 
     toastErrorMock.mockReset();
     expect(() => {

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -220,6 +220,14 @@ export const handlers = [
     return success(true);
   }),
 
+  http.post(`${TAURI_ENDPOINT}/webdav_sync_upload`, () =>
+    success({ status: "uploaded" }),
+  ),
+
+  http.post(`${TAURI_ENDPOINT}/webdav_sync_download`, () =>
+    success({ status: "downloaded" }),
+  ),
+
   http.post(
     `${TAURI_ENDPOINT}/set_app_config_dir_override`,
     async ({ request }) => {


### PR DESCRIPTION
## Summary

This PR improves WebDAV auto-sync conflict handling to avoid automatically overwriting remote changes.

## Changes

- Track snapshot IDs and localized error keys in sync status.
- Add three-way sync state detection for WebDAV auto sync:
  - local-only changes can auto upload
  - remote-only changes pause auto sync and require manual resolution
  - local and remote changes pause auto sync and require manual resolution
  - matching local and remote snapshots refresh sync status without re-uploading
- Use WebDAV ETag preconditions for automatic uploads to avoid overwriting remote updates during upload.
- Add a WebDAV conflict dialog that lets users choose between:
  - using the local version to overwrite the cloud
  - using the cloud version to overwrite local data
- Show clearer auto-sync paused guidance in settings.
- Add snapshot/error-key tracking and remote manifest checks for S3 auto sync.
- Add translations for zh/en/zh-TW/ja.
- Add frontend test coverage for the conflict dialog and auto-sync guidance.

## Scope

- Affects WebDAV/S3 cloud sync only.
- Manual upload and manual download keep their existing explicit overwrite behavior.
- Does not affect provider configuration writes, local routing, transformer routing, usage statistics, or session management.

## Tests

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm build:renderer`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`