### PR TITLE
feat(pricing): add Claude Fable 5 model pricing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ release/
 *.tsbuildinfo
 .npmrc
 CLAUDE.md
-# AGENTS.md
+AGENTS.md
 GEMINI.md
 /.claude
 /.codex

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1205,6 +1205,15 @@ impl Database {
     /// 注意: model_id 使用短横线格式（如 claude-haiku-4-5），与 API 返回的模型名称标准化后一致
     fn seed_model_pricing(conn: &Connection) -> Result<(), AppError> {
         let pricing_data = [
+            // Claude Fable 5 系列
+            (
+                "claude-fable-5",
+                "Claude Fable 5",
+                "10",
+                "50",
+                "1",
+                "12.50",
+            ),
             // Claude 4.8 系列
             (
                 "claude-opus-4-8",


### PR DESCRIPTION
## Summary

- Add `claude-fable-5` pricing entry to `seed_model_pricing()` in `src-tauri/src/database/schema.rs`
- Uses `INSERT OR IGNORE` — safe for existing users with custom pricing, only seeds on fresh install
- Also uncomment `AGENTS.md` in `.gitignore` (consistent with existing `CLAUDE.md` entry)

## Pricing (source: [Anthropic official docs](https://platform.claude.com/docs/en/about-claude/models/overview))

| Model | Input | Output | Cache Read | Cache Creation |
|---|---|---|---|---|
| `claude-fable-5` | $10/MTok | $50/MTok | $1/MTok | $12.50/MTok |

Cache pricing follows the standard formula: cache read = 0.1× input, cache creation = 1.25× input (5-min TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)