### PR TITLE
feat(provider): add fuzzy search and A-Z sort to ProviderPresetSelector

### DIFF
--- a/src/components/providers/forms/ProviderPresetSelector.tsx
+++ b/src/components/providers/forms/ProviderPresetSelector.tsx
@@ -1,7 +1,9 @@
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FormLabel } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import { ClaudeIcon, CodexIcon, GeminiIcon } from "@/components/BrandIcons";
-import { Zap, Star, Layers, Settings2 } from "lucide-react";
+import { Search, Zap, Star, Layers, Settings2 } from "lucide-react";
 import type { ProviderPreset } from "@/config/claudeProviderPresets";
 import type { CodexProviderPreset } from "@/config/codexProviderPresets";
 import type { GeminiProviderPreset } from "@/config/geminiProviderPresets";
@@ -50,6 +52,43 @@ export function ProviderPresetSelector({
   category,
 }: ProviderPresetSelectorProps) {
   const { t } = useTranslation();
+
+  const [presetSearchQuery, setPresetSearchQuery] = useState("");
+  const [isSortedByName, setIsSortedByName] = useState(false);
+
+  const filteredPresetEntries = useMemo(() => {
+    const trimmedQuery = presetSearchQuery.trim().toLowerCase();
+    let entries = [...presetEntries];
+
+    // AZ 排序
+    if (isSortedByName) {
+      entries.sort((a, b) => {
+        const labelA = (
+          a.preset.nameKey ? t(a.preset.nameKey) : a.preset.name
+        ).toLowerCase();
+        const labelB = (
+          b.preset.nameKey ? t(b.preset.nameKey) : b.preset.name
+        ).toLowerCase();
+        return labelA.localeCompare(labelB, undefined, { sensitivity: "base" });
+      });
+    }
+
+    if (!trimmedQuery) {
+      return entries;
+    }
+
+    const tokens = trimmedQuery.split(/\s+/).filter(Boolean);
+
+    return entries.filter((entry) => {
+      const label = (
+        entry.preset.nameKey ? t(entry.preset.nameKey) : entry.preset.name
+      ).toLowerCase();
+      const id = entry.id.toLowerCase();
+      return tokens.some(
+        (token) => label.includes(token) || id.includes(token),
+      );
+    });
+  }, [presetEntries, presetSearchQuery, t, isSortedByName]);
 
   const getCategoryHint = (): React.ReactNode => {
     switch (category) {
@@ -131,6 +170,38 @@ export function ProviderPresetSelector({
   return (
     <div className="space-y-3">
       <FormLabel>{t("providerPreset.label")}</FormLabel>
+      <div className="relative flex items-center gap-2">
+        <Search className="absolute w-4 h-4 -translate-y-1/2 pointer-events-none left-3 top-1/2 text-muted-foreground" />
+        <Input
+          type="search"
+          value={presetSearchQuery}
+          onChange={(event) => setPresetSearchQuery(event.target.value)}
+          placeholder={t("providerPreset.searchPlaceholder", {
+            defaultValue: "搜索预设供应商",
+          })}
+          className="flex-1 pl-9"
+          maxLength={100}
+          aria-label={t("providerPreset.searchAriaLabel", {
+            defaultValue: "搜索预设供应商",
+          })}
+        />
+        <button
+          type="button"
+          onClick={() => setIsSortedByName(!isSortedByName)}
+          className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors shrink-0 ${
+            isSortedByName
+              ? "bg-blue-500 text-white dark:bg-blue-600"
+              : "bg-accent text-muted-foreground hover:bg-accent/80"
+          }`}
+          title={t("providerPreset.sortByName", {
+            defaultValue: "按首字母 A-Z 排序",
+          })}
+        >
+          {t("providerPreset.sortByNameShort", {
+            defaultValue: "按首字母排序",
+          })}
+        </button>
+      </div>
       <div className="flex flex-wrap gap-2">
         <button
           type="button"
@@ -144,7 +215,7 @@ export function ProviderPresetSelector({
           {t("providerPreset.custom")}
         </button>
 
-        {presetEntries.map((entry) => {
+        {filteredPresetEntries.map((entry) => {
           const isSelected = selectedPresetId === entry.id;
           const isPartner = entry.preset.isPartner;
           const presetCategory = entry.preset.category ?? "others";

--- a/src/components/providers/forms/ProviderPresetSelector.tsx
+++ b/src/components/providers/forms/ProviderPresetSelector.tsx
@@ -198,7 +198,7 @@ export function ProviderPresetSelector({
           })}
         >
           {t("providerPreset.sortByNameShort", {
-            defaultValue: "按首字母排序",
+            defaultValue: "A-Z Sort",
           })}
         </button>
       </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1320,7 +1320,11 @@
     "label": "Provider Preset",
     "custom": "Custom Configuration",
     "other": "Other",
-    "hint": "You can continue to adjust the fields below after selecting a preset."
+    "hint": "You can continue to adjust the fields below after selecting a preset.",
+    "searchPlaceholder": "Search provider presets",
+    "searchAriaLabel": "Search provider presets",
+    "sortByName": "Sort by name A-Z",
+    "sortByNameShort": "A-Z Sort"
   },
   "usage": {
     "title": "Usage Statistics",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1320,7 +1320,11 @@
     "label": "プロバイダータイプ",
     "custom": "カスタム設定",
     "other": "その他",
-    "hint": "プリセットを選んだ後でも、下のフィールドで調整できます。"
+    "hint": "プリセットを選んだ後でも、下のフィールドで調整できます。",
+    "searchPlaceholder": "プロバイダープリセットを検索",
+    "searchAriaLabel": "プロバイダープリセットを検索",
+    "sortByName": "名前順 A-Z に並び替え",
+    "sortByNameShort": "名前順並び替え"
   },
   "usage": {
     "title": "利用統計",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1266,7 +1266,11 @@
     "label": "預設供應商",
     "custom": "自訂設定",
     "other": "其他",
-    "hint": "選擇預設後可繼續調整下方欄位。"
+    "hint": "選擇預設後可繼續調整下方欄位。",
+    "searchPlaceholder": "搜尋預設供應商",
+    "searchAriaLabel": "搜尋預設供應商",
+    "sortByName": "按首字母 A-Z 排序",
+    "sortByNameShort": "按首字母排序"
   },
   "usage": {
     "title": "使用統計",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1320,7 +1320,11 @@
     "label": "预设供应商",
     "custom": "自定义配置",
     "other": "其他",
-    "hint": "选择预设后可继续调整下方字段。"
+    "hint": "选择预设后可继续调整下方字段。",
+    "searchPlaceholder": "搜索预设供应商",
+    "searchAriaLabel": "搜索预设供应商",
+    "sortByName": "按首字母 A-Z 排序",
+    "sortByNameShort": "按首字母排序"
   },
   "usage": {
     "title": "使用统计",

--- a/tests/components/ProviderPresetSelector.test.tsx
+++ b/tests/components/ProviderPresetSelector.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { useForm } from "react-hook-form";
 import { Form } from "@/components/ui/form";
@@ -67,5 +68,287 @@ describe("ProviderPresetSelector", () => {
     expect(
       screen.getAllByRole("button").map((button) => button.textContent),
     ).toEqual(["providerPreset.custom", "First", "Second", "Third", "Fourth"]);
+  });
+
+  it("搜索 'max' 能匹配到 'MiniMax'（模糊匹配）", async () => {
+    const user = userEvent.setup();
+    const Wrapper = () => {
+      const form = useForm();
+      return (
+        <Form {...form}>
+          <ProviderPresetSelector
+            selectedPresetId="custom"
+            presetEntries={[
+              {
+                id: "minimax",
+                preset: {
+                  name: "MiniMax",
+                  websiteUrl: "https://minimax.example.com",
+                  settingsConfig: {},
+                  category: "third_party",
+                },
+              },
+              {
+                id: "openai",
+                preset: {
+                  name: "OpenAI",
+                  websiteUrl: "https://openai.example.com",
+                  settingsConfig: {},
+                  category: "official",
+                },
+              },
+            ]}
+            presetCategoryLabels={{}}
+            onPresetChange={vi.fn()}
+          />
+        </Form>
+      );
+    };
+    render(<Wrapper />);
+
+    const searchInput = screen.getByRole("searchbox");
+    await user.type(searchInput, "max");
+
+    expect(screen.getByText("MiniMax")).toBeInTheDocument();
+    expect(screen.queryByText("OpenAI")).not.toBeInTheDocument();
+  });
+
+  it("点击 Sort 按钮后，预设按首字母 A-Z 排序", async () => {
+    const user = userEvent.setup();
+    const Wrapper = () => {
+      const form = useForm();
+      return (
+        <Form {...form}>
+          <ProviderPresetSelector
+            selectedPresetId="custom"
+            presetEntries={[
+              {
+                id: "zhipu",
+                preset: {
+                  name: "Zhipu",
+                  websiteUrl: "https://zhipu.example.com",
+                  settingsConfig: {},
+                  category: "third_party",
+                },
+              },
+              {
+                id: "minimax",
+                preset: {
+                  name: "MiniMax",
+                  websiteUrl: "https://minimax.example.com",
+                  settingsConfig: {},
+                  category: "third_party",
+                },
+              },
+              {
+                id: "anthropic",
+                preset: {
+                  name: "Anthropic",
+                  websiteUrl: "https://anthropic.example.com",
+                  settingsConfig: {},
+                  category: "official",
+                },
+              },
+            ]}
+            presetCategoryLabels={{}}
+            onPresetChange={vi.fn()}
+          />
+        </Form>
+      );
+    };
+    render(<Wrapper />);
+
+    // 默认保持原顺序: Zhipu, MiniMax, Anthropic
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[1].textContent).toMatch(/Zhipu|MiniMax|Anthropic/);
+
+    // 点击 Sort 排序按钮
+    const sortButton = screen.getByRole("button", { name: /按首字母排序/i });
+    await user.click(sortButton);
+
+    // 排序后: Anthropic, MiniMax, Zhipu
+    const sortedButtons = screen.getAllByRole("button");
+    expect(sortedButtons[1].textContent).toMatch(/Anthropic/);
+    expect(sortedButtons[2].textContent).toMatch(/MiniMax/);
+    expect(sortedButtons[3].textContent).toMatch(/Zhipu/);
+  });
+
+  it("'自定义'按钮始终排在第一位，不受排序影响", async () => {
+    const user = userEvent.setup();
+    const Wrapper = () => {
+      const form = useForm();
+      return (
+        <Form {...form}>
+          <ProviderPresetSelector
+            selectedPresetId="custom"
+            presetEntries={[
+              {
+                id: "zhipu",
+                preset: {
+                  name: "Zhipu",
+                  websiteUrl: "https://zhipu.example.com",
+                  settingsConfig: {},
+                  category: "third_party",
+                },
+              },
+              {
+                id: "anthropic",
+                preset: {
+                  name: "Anthropic",
+                  websiteUrl: "https://anthropic.example.com",
+                  settingsConfig: {},
+                  category: "official",
+                },
+              },
+            ]}
+            presetCategoryLabels={{}}
+            onPresetChange={vi.fn()}
+          />
+        </Form>
+      );
+    };
+    render(<Wrapper />);
+
+    const sortButton = screen.getByRole("button", { name: /按首字母排序/i });
+    await user.click(sortButton); // 开启 A-Z 排序
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0].textContent).toBe("providerPreset.custom"); // 自定义始终第一
+    expect(buttons[1].textContent).toMatch(/Anthropic/); // A-Z 排序
+  });
+
+  it("多词 OR 搜索 'mini max' 能匹配到 'MiniMax'", async () => {
+    const user = userEvent.setup();
+    const Wrapper = () => {
+      const form = useForm();
+      return (
+        <Form {...form}>
+          <ProviderPresetSelector
+            selectedPresetId="custom"
+            presetEntries={[
+              {
+                id: "minimax",
+                preset: {
+                  name: "MiniMax",
+                  websiteUrl: "https://minimax.example.com",
+                  settingsConfig: {},
+                  category: "third_party",
+                },
+              },
+              {
+                id: "openai",
+                preset: {
+                  name: "OpenAI",
+                  websiteUrl: "https://openai.example.com",
+                  settingsConfig: {},
+                  category: "official",
+                },
+              },
+            ]}
+            presetCategoryLabels={{}}
+            onPresetChange={vi.fn()}
+          />
+        </Form>
+      );
+    };
+    render(<Wrapper />);
+
+    const searchInput = screen.getByRole("searchbox");
+    await user.type(searchInput, "mini max");
+
+    expect(screen.getByText("MiniMax")).toBeInTheDocument();
+    expect(screen.queryByText("OpenAI")).not.toBeInTheDocument();
+  });
+
+  it("大小写不敏感 'MINI' 能匹配到 'MiniMax'", async () => {
+    const user = userEvent.setup();
+    const Wrapper = () => {
+      const form = useForm();
+      return (
+        <Form {...form}>
+          <ProviderPresetSelector
+            selectedPresetId="custom"
+            presetEntries={[
+              {
+                id: "minimax",
+                preset: {
+                  name: "MiniMax",
+                  websiteUrl: "https://minimax.example.com",
+                  settingsConfig: {},
+                  category: "third_party",
+                },
+              },
+              {
+                id: "openai",
+                preset: {
+                  name: "OpenAI",
+                  websiteUrl: "https://openai.example.com",
+                  settingsConfig: {},
+                  category: "official",
+                },
+              },
+            ]}
+            presetCategoryLabels={{}}
+            onPresetChange={vi.fn()}
+          />
+        </Form>
+      );
+    };
+    render(<Wrapper />);
+
+    const searchInput = screen.getByRole("searchbox");
+    await user.type(searchInput, "MINI");
+
+    expect(screen.getByText("MiniMax")).toBeInTheDocument();
+    expect(screen.queryByText("OpenAI")).not.toBeInTheDocument();
+  });
+
+  it("取消排序恢复原顺序", async () => {
+    const user = userEvent.setup();
+    const Wrapper = () => {
+      const form = useForm();
+      return (
+        <Form {...form}>
+          <ProviderPresetSelector
+            selectedPresetId="custom"
+            presetEntries={[
+              {
+                id: "zhipu",
+                preset: {
+                  name: "Zhipu",
+                  websiteUrl: "https://zhipu.example.com",
+                  settingsConfig: {},
+                  category: "third_party",
+                },
+              },
+              {
+                id: "anthropic",
+                preset: {
+                  name: "Anthropic",
+                  websiteUrl: "https://anthropic.example.com",
+                  settingsConfig: {},
+                  category: "official",
+                },
+              },
+            ]}
+            presetCategoryLabels={{}}
+            onPresetChange={vi.fn()}
+          />
+        </Form>
+      );
+    };
+    render(<Wrapper />);
+
+    const sortButton = screen.getByRole("button", { name: /按首字母排序/i });
+
+    // 开启排序
+    await user.click(sortButton);
+    let buttons = screen.getAllByRole("button");
+    expect(buttons[1].textContent).toMatch(/Anthropic/); // 排序后
+
+    // 取消排序
+    await user.click(sortButton);
+    buttons = screen.getAllByRole("button");
+    expect(buttons[1].textContent).toMatch(/Zhipu/); // 恢复原顺序
   });
 });

--- a/tests/components/ProviderPresetSelector.test.tsx
+++ b/tests/components/ProviderPresetSelector.test.tsx
@@ -65,9 +65,10 @@ describe("ProviderPresetSelector", () => {
 
     render(<Wrapper />);
 
+    // Sort button at [0], 自定义 at [1], presets start at [2]
     expect(
       screen.getAllByRole("button").map((button) => button.textContent),
-    ).toEqual(["providerPreset.custom", "First", "Second", "Third", "Fourth"]);
+    ).toEqual(["A-Z Sort", "providerPreset.custom", "First", "Second", "Third", "Fourth"]);
   });
 
   it("搜索 'max' 能匹配到 'MiniMax'（模糊匹配）", async () => {
@@ -158,19 +159,21 @@ describe("ProviderPresetSelector", () => {
     };
     render(<Wrapper />);
 
-    // 默认保持原顺序: Zhipu, MiniMax, Anthropic
+    // Sort=0, 自定义=1, Zhipu=2, MiniMax=3, Anthropic=4
     const buttons = screen.getAllByRole("button");
-    expect(buttons[1].textContent).toMatch(/Zhipu|MiniMax|Anthropic/);
+    expect(buttons[2].textContent).toMatch(/Zhipu/);
+    expect(buttons[3].textContent).toMatch(/MiniMax/);
+    expect(buttons[4].textContent).toMatch(/Anthropic/);
 
     // 点击 Sort 排序按钮
-    const sortButton = screen.getByRole("button", { name: /按首字母排序/i });
+    const sortButton = screen.getByRole("button", { name: /A-Z Sort/i });
     await user.click(sortButton);
 
-    // 排序后: Anthropic, MiniMax, Zhipu
+    // 排序后: Sort=0, 自定义=1, Anthropic=2, MiniMax=3, Zhipu=4
     const sortedButtons = screen.getAllByRole("button");
-    expect(sortedButtons[1].textContent).toMatch(/Anthropic/);
-    expect(sortedButtons[2].textContent).toMatch(/MiniMax/);
-    expect(sortedButtons[3].textContent).toMatch(/Zhipu/);
+    expect(sortedButtons[2].textContent).toMatch(/Anthropic/);
+    expect(sortedButtons[3].textContent).toMatch(/MiniMax/);
+    expect(sortedButtons[4].textContent).toMatch(/Zhipu/);
   });
 
   it("'自定义'按钮始终排在第一位，不受排序影响", async () => {
@@ -209,12 +212,14 @@ describe("ProviderPresetSelector", () => {
     };
     render(<Wrapper />);
 
-    const sortButton = screen.getByRole("button", { name: /按首字母排序/i });
+    const sortButton = screen.getByRole("button", { name: /A-Z Sort/i });
     await user.click(sortButton); // 开启 A-Z 排序
 
+    // Sort=0, 自定义=1, Anthropic=2, Zhipu=3
     const buttons = screen.getAllByRole("button");
-    expect(buttons[0].textContent).toBe("providerPreset.custom"); // 自定义始终第一
-    expect(buttons[1].textContent).toMatch(/Anthropic/); // A-Z 排序
+    expect(buttons[0].textContent).toBe("A-Z Sort"); // Sort 始终第一
+    expect(buttons[1].textContent).toBe("providerPreset.custom"); // 自定义始终第二
+    expect(buttons[2].textContent).toMatch(/Anthropic/); // A-Z 排序
   });
 
   it("多词 OR 搜索 'mini max' 能匹配到 'MiniMax'", async () => {
@@ -339,16 +344,16 @@ describe("ProviderPresetSelector", () => {
     };
     render(<Wrapper />);
 
-    const sortButton = screen.getByRole("button", { name: /按首字母排序/i });
+    const sortButton = screen.getByRole("button", { name: /A-Z Sort/i });
 
-    // 开启排序
+    // 开启排序: Sort=0, 自定义=1, Anthropic=2, Zhipu=3
     await user.click(sortButton);
     let buttons = screen.getAllByRole("button");
-    expect(buttons[1].textContent).toMatch(/Anthropic/); // 排序后
+    expect(buttons[2].textContent).toMatch(/Anthropic/); // 排序后
 
-    // 取消排序
+    // 取消排序: Sort=0, 自定义=1, Zhipu=2, Anthropic=3
     await user.click(sortButton);
     buttons = screen.getAllByRole("button");
-    expect(buttons[1].textContent).toMatch(/Zhipu/); // 恢复原顺序
+    expect(buttons[2].textContent).toMatch(/Zhipu/); // 恢复原顺序
   });
 });


### PR DESCRIPTION
Add search input with fuzzy matching (OR logic for multi-word search)
Add Sort button to toggle A-Z alphabetical ordering
'Custom' button stays first regardless of sort state
Support zh, zh-TW, en, ja i18n
Add tests for multi-word search, case-insensitive, and sort toggle
## Summary / 概述

Add fuzzy search and A-Z sort functionality to ProviderPresetSelector component.

为 ProviderPresetSelector 组件添加模糊搜索和 A-Z 排序功能。

## Related Issue / 关联 Issue

None

Fixes #

## Screenshots / 截图



| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|         
<img width="1669" height="243" alt="image" src="https://github.com/user-attachments/assets/0b4f0af1-8428-4079-8d0e-b7312e584b8a" />
        |           
<img width="2019" height="187" alt="image" src="https://github.com/user-attachments/assets/dbb2da81-c6ca-40f6-afe7-e84a27055462" />
    |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
