### PR TITLE
feat: add --dangerously-skip-permissions toggle for Claude Code terminals

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2407,9 +2407,20 @@ pub async fn open_provider_terminal(
     let config = &provider.settings_config;
     let env_vars = extract_env_vars_from_config(config, &app_type);
 
+    // 仅对 Claude Code 终端（运行 `claude` CLI）启用
+    // `--dangerously-skip-permissions`，且需用户在设置中显式开启。
+    // Claude Desktop 不走 `claude` CLI，因此不适用。
+    let dangerous_skip_permissions = matches!(app_type, AppType::Claude)
+        && crate::settings::get_claude_dangerous_skip_permissions();
+
     // 根据平台启动终端，传入提供商ID用于生成唯一的配置文件名
-    launch_terminal_with_env(env_vars, &providerId, launch_cwd.as_deref())
-        .map_err(|e| format!("启动终端失败: {e}"))?;
+    launch_terminal_with_env(
+        env_vars,
+        &providerId,
+        launch_cwd.as_deref(),
+        dangerous_skip_permissions,
+    )
+    .map_err(|e| format!("启动终端失败: {e}"))?;
 
     Ok(true)
 }
@@ -2507,6 +2518,7 @@ fn launch_terminal_with_env(
     env_vars: Vec<(String, String)>,
     provider_id: &str,
     cwd: Option<&Path>,
+    dangerous_skip_permissions: bool,
 ) -> Result<(), String> {
     let temp_dir = std::env::temp_dir();
     let config_file = temp_dir.join(format!(
@@ -2520,24 +2532,27 @@ fn launch_terminal_with_env(
 
     #[cfg(target_os = "macos")]
     {
-        launch_macos_terminal(&config_file, cwd)?;
+        launch_macos_terminal(&config_file, cwd, dangerous_skip_permissions)?;
         Ok(())
     }
 
     #[cfg(target_os = "linux")]
     {
-        launch_linux_terminal(&config_file, cwd)?;
+        launch_linux_terminal(&config_file, cwd, dangerous_skip_permissions)?;
         Ok(())
     }
 
     #[cfg(target_os = "windows")]
     {
-        launch_windows_terminal(&temp_dir, &config_file, cwd)?;
+        launch_windows_terminal(&temp_dir, &config_file, cwd, dangerous_skip_permissions)?;
         return Ok(());
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    Err("不支持的操作系统".to_string())
+    {
+        let _ = dangerous_skip_permissions;
+        Err("不支持的操作系统".to_string())
+    }
 }
 
 /// 写入 claude 配置文件
@@ -2562,7 +2577,11 @@ fn write_claude_config(
 
 /// macOS: 根据用户首选终端启动
 #[cfg(target_os = "macos")]
-fn launch_macos_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> Result<(), String> {
+fn launch_macos_terminal(
+    config_file: &std::path::Path,
+    cwd: Option<&Path>,
+    dangerous_skip_permissions: bool,
+) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
 
     let preferred = crate::settings::get_preferred_terminal();
@@ -2572,6 +2591,7 @@ fn launch_macos_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> R
     let script_file = temp_dir.join(format!("cc_switch_launcher_{}.sh", std::process::id()));
     let config_path = config_file.to_string_lossy();
     let cd_command = build_shell_cd_command(cwd);
+    let dangerous_flag = claude_dangerous_flag(dangerous_skip_permissions);
 
     // Write the shell script to a temp file
     let script_content = format!(
@@ -2580,12 +2600,13 @@ trap 'rm -f "{config_path}" "{script_file}"' EXIT
 {cd_command}
 echo "Using provider-specific claude config:"
 echo "{config_path}"
-claude --settings "{config_path}"
+claude --settings "{config_path}"{dangerous_flag}
 exec bash --norc --noprofile
 "#,
         config_path = config_path,
         script_file = script_file.display(),
         cd_command = cd_command,
+        dangerous_flag = dangerous_flag,
     );
 
     std::fs::write(&script_file, &script_content).map_err(|e| format!("写入启动脚本失败: {e}"))?;
@@ -2829,7 +2850,11 @@ fn launch_macos_warp(script_file: &std::path::Path) -> Result<(), String> {
 
 /// Linux: 根据用户首选终端启动
 #[cfg(target_os = "linux")]
-fn launch_linux_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> Result<(), String> {
+fn launch_linux_terminal(
+    config_file: &std::path::Path,
+    cwd: Option<&Path>,
+    dangerous_skip_permissions: bool,
+) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
 
@@ -2852,6 +2877,7 @@ fn launch_linux_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> R
     let script_file = temp_dir.join(format!("cc_switch_launcher_{}.sh", std::process::id()));
     let config_path = config_file.to_string_lossy();
     let cd_command = build_shell_cd_command(cwd);
+    let dangerous_flag = claude_dangerous_flag(dangerous_skip_permissions);
 
     let script_content = format!(
         r#"#!/bin/bash
@@ -2859,12 +2885,13 @@ trap 'rm -f "{config_path}" "{script_file}"' EXIT
 {cd_command}
 echo "Using provider-specific claude config:"
 echo "{config_path}"
-claude --settings "{config_path}"
+claude --settings "{config_path}"{dangerous_flag}
 exec bash --norc --noprofile
 "#,
         config_path = config_path,
         script_file = script_file.display(),
         cd_command = cd_command,
+        dangerous_flag = dangerous_flag,
     );
 
     std::fs::write(&script_file, &script_content).map_err(|e| format!("写入启动脚本失败: {e}"))?;
@@ -2944,6 +2971,7 @@ fn launch_windows_terminal(
     temp_dir: &std::path::Path,
     config_file: &std::path::Path,
     cwd: Option<&Path>,
+    dangerous_skip_permissions: bool,
 ) -> Result<(), String> {
     let preferred = crate::settings::get_preferred_terminal();
     let terminal = preferred.as_deref().unwrap_or("cmd");
@@ -2951,13 +2979,14 @@ fn launch_windows_terminal(
     let bat_file = temp_dir.join(format!("cc_switch_claude_{}.bat", std::process::id()));
     let config_path_for_batch = escape_windows_batch_value(&config_file.to_string_lossy());
     let cwd_command = build_windows_cwd_command(cwd);
+    let dangerous_flag = claude_dangerous_flag(dangerous_skip_permissions);
 
     let content = format!(
         "@echo off
 {cwd_command}
 echo Using provider-specific claude config:
 echo {}
-claude --settings \"{}\"
+claude --settings \"{}\"{dangerous_flag}
 del \"{}\" >nul 2>&1
 del \"%~f0\" >nul 2>&1
 ",
@@ -2965,6 +2994,7 @@ del \"%~f0\" >nul 2>&1
         config_path_for_batch,
         config_path_for_batch,
         cwd_command = cwd_command,
+        dangerous_flag = dangerous_flag,
     );
 
     std::fs::write(&bat_file, &content).map_err(|e| format!("写入批处理文件失败: {e}"))?;
@@ -2993,6 +3023,21 @@ del \"%~f0\" >nul 2>&1
     }
 
     result
+}
+
+/// 当开关开启时返回 ` --dangerously-skip-permissions`（含前导空格，直接拼到
+/// `claude --settings "..."` 之后）；关闭时返回空串。flag 为静态字面量，不含
+/// 用户输入，可安全拼入 shell/batch 脚本。
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "linux", target_os = "windows")),
+    allow(dead_code)
+)]
+fn claude_dangerous_flag(enabled: bool) -> &'static str {
+    if enabled {
+        " --dangerously-skip-permissions"
+    } else {
+        ""
+    }
 }
 
 fn build_shell_cd_command(cwd: Option<&Path>) -> String {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -446,6 +446,11 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preferred_terminal: Option<String>,
 
+    /// 在 Claude Code 终端中追加 `--dangerously-skip-permissions`（默认关闭）
+    /// 仅作用于 Claude / Claude Desktop 的"打开终端"，是设备级开关。
+    #[serde(default)]
+    pub claude_dangerous_skip_permissions: bool,
+
     // ===== 本机自动迁移状态 =====
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub local_migrations: Option<LocalMigrations>,
@@ -501,6 +506,7 @@ impl Default for AppSettings {
             backup_interval_hours: None,
             backup_retain_count: None,
             preferred_terminal: None,
+            claude_dangerous_skip_permissions: false,
             local_migrations: None,
         }
     }
@@ -972,6 +978,17 @@ pub fn get_preferred_terminal() -> Option<String> {
         })
         .preferred_terminal
         .clone()
+}
+
+/// 是否在 Claude Code 终端中追加 `--dangerously-skip-permissions`
+pub fn get_claude_dangerous_skip_permissions() -> bool {
+    settings_store()
+        .read()
+        .unwrap_or_else(|e| {
+            log::warn!("设置锁已毒化，使用恢复值: {e}");
+            e.into_inner()
+        })
+        .claude_dangerous_skip_permissions
 }
 
 // ===== WebDAV 同步设置管理函数 =====

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -255,6 +255,14 @@ export function SettingsPage({
                       onChange={(terminal) =>
                         handleAutoSave({ preferredTerminal: terminal })
                       }
+                      dangerousSkipPermissions={
+                        settings.claudeDangerousSkipPermissions
+                      }
+                      onDangerousSkipPermissionsChange={(value) =>
+                        handleAutoSave({
+                          claudeDangerousSkipPermissions: value,
+                        })
+                      }
                     />
                   </motion.div>
                 ) : null}

--- a/src/components/settings/TerminalSettings.tsx
+++ b/src/components/settings/TerminalSettings.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { ShieldAlert } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -6,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ToggleRow } from "@/components/ui/toggle-row";
 import { isMac, isWindows, isLinux } from "@/lib/platform";
 
 // Terminal options per platform
@@ -76,9 +78,16 @@ function getDefaultTerminal(): string {
 export interface TerminalSettingsProps {
   value?: string;
   onChange: (value: string) => void;
+  dangerousSkipPermissions?: boolean;
+  onDangerousSkipPermissionsChange: (value: boolean) => void;
 }
 
-export function TerminalSettings({ value, onChange }: TerminalSettingsProps) {
+export function TerminalSettings({
+  value,
+  onChange,
+  dangerousSkipPermissions,
+  onDangerousSkipPermissionsChange,
+}: TerminalSettingsProps) {
   const { t } = useTranslation();
   const terminals = getTerminalOptions();
   const defaultTerminal = getDefaultTerminal();
@@ -87,7 +96,7 @@ export function TerminalSettings({ value, onChange }: TerminalSettingsProps) {
   const currentValue = value || defaultTerminal;
 
   return (
-    <section className="space-y-2">
+    <section className="space-y-3">
       <header className="space-y-1">
         <h3 className="text-sm font-medium">{t("settings.terminal.title")}</h3>
         <p className="text-xs text-muted-foreground">
@@ -109,6 +118,14 @@ export function TerminalSettings({ value, onChange }: TerminalSettingsProps) {
       <p className="text-xs text-muted-foreground">
         {t("settings.terminal.fallbackHint")}
       </p>
+
+      <ToggleRow
+        icon={<ShieldAlert className="h-4 w-4 text-red-500" />}
+        title={t("settings.terminal.dangerousSkipPermissions")}
+        description={t("settings.terminal.dangerousSkipPermissionsDescription")}
+        checked={!!dangerousSkipPermissions}
+        onCheckedChange={onDangerousSkipPermissionsChange}
+      />
     </section>
   );
 }

--- a/src/hooks/useSettingsForm.ts
+++ b/src/hooks/useSettingsForm.ts
@@ -118,6 +118,8 @@ export function useSettingsForm(): UseSettingsFormResult {
       skipClaudeOnboarding: data.skipClaudeOnboarding ?? false,
       preserveCodexOfficialAuthOnSwitch:
         data.preserveCodexOfficialAuthOnSwitch ?? false,
+      claudeDangerousSkipPermissions:
+        data.claudeDangerousSkipPermissions ?? false,
       claudeConfigDir: sanitizeDir(data.claudeConfigDir),
       codexConfigDir: sanitizeDir(data.codexConfigDir),
       geminiConfigDir: sanitizeDir(data.geminiConfigDir),
@@ -182,6 +184,8 @@ export function useSettingsForm(): UseSettingsFormResult {
         skipClaudeOnboarding: serverData.skipClaudeOnboarding ?? false,
         preserveCodexOfficialAuthOnSwitch:
           serverData.preserveCodexOfficialAuthOnSwitch ?? false,
+        claudeDangerousSkipPermissions:
+          serverData.claudeDangerousSkipPermissions ?? false,
         claudeConfigDir: sanitizeDir(serverData.claudeConfigDir),
         codexConfigDir: sanitizeDir(serverData.codexConfigDir),
         geminiConfigDir: sanitizeDir(serverData.geminiConfigDir),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -701,6 +701,8 @@
       "title": "Preferred Terminal",
       "description": "Choose which terminal app to use when clicking the terminal button",
       "fallbackHint": "If the selected terminal is unavailable, the system default will be used",
+      "dangerousSkipPermissions": "Skip permission prompts (Claude Code)",
+      "dangerousSkipPermissionsDescription": "When enabled, opening a Claude Code terminal runs claude with --dangerously-skip-permissions. Use with caution: it bypasses Claude Code's permission confirmations.",
       "options": {
         "macos": {
           "terminal": "Terminal.app",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -701,6 +701,8 @@
       "title": "優先ターミナル",
       "description": "ターミナルボタンをクリックした時に使用するターミナルアプリを選択",
       "fallbackHint": "選択したターミナルが利用できない場合、システムのデフォルトが使用されます",
+      "dangerousSkipPermissions": "Claude Code で権限確認をスキップ",
+      "dangerousSkipPermissionsDescription": "有効にすると、Claude Code ターミナルを開く際に --dangerously-skip-permissions を付けて起動します。Claude はファイルの編集やコマンドの実行時に確認を求めなくなります。信頼できるディレクトリでのみ使用してください。",
       "options": {
         "macos": {
           "terminal": "Terminal.app",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -701,6 +701,8 @@
       "title": "首選終端機",
       "description": "選擇點擊終端機按鈕時使用的終端機應用程式",
       "fallbackHint": "如果選擇的終端機不可用，將自動使用系統預設終端機",
+      "dangerousSkipPermissions": "Claude Code 跳過權限確認",
+      "dangerousSkipPermissionsDescription": "啟用後，從 Claude 供應商打開終端機時會以 --dangerously-skip-permissions 啟動 Claude Code，跳過操作確認。請謹慎使用。",
       "options": {
         "macos": {
           "terminal": "Terminal.app",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -701,6 +701,8 @@
       "title": "首选终端",
       "description": "选择点击终端按钮时使用的终端应用",
       "fallbackHint": "如果选择的终端不可用，将自动使用系统默认终端",
+      "dangerousSkipPermissions": "跳过 Claude Code 权限确认",
+      "dangerousSkipPermissionsDescription": "开启后，从 Claude Code 终端打开时会附加 --dangerously-skip-permissions，跳过所有操作的权限确认。请谨慎使用。",
       "options": {
         "macos": {
           "terminal": "Terminal.app",

--- a/src/types.ts
+++ b/src/types.ts
@@ -411,6 +411,9 @@ export interface Settings {
   // Windows: "cmd" | "powershell" | "wt"
   // Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
   preferredTerminal?: string;
+  // 在 Claude Code 终端中追加 --dangerously-skip-permissions（默认关闭）
+  // 仅作用于 Claude / Claude Desktop 的"打开终端"
+  claudeDangerousSkipPermissions?: boolean;
 
   // ===== 本机自动迁移状态 =====
   localMigrations?: {


### PR DESCRIPTION
## Summary
Add a device-level setting in **Settings → General → Preferred Terminal** that appends `--dangerously-skip-permissions` when launching Claude Code terminals via the "Open Terminal" button.

- **Default:** OFF (safe by default)
- **Scope:** Claude Code only (not Claude Desktop, not Codex)
- **UI:** Toggle with red shield icon below the terminal selector

## Changes

### Backend (Rust)
- `settings.rs`: new `claude_dangerous_skip_permissions: bool` field + getter
- `misc.rs`: gate flag to `AppType::Claude`, thread through all platform terminal launchers (macOS/Linux/Windows)

### Frontend (TS/React)
- `TerminalSettings.tsx`: `ToggleRow` with `ShieldAlert` icon
- `SettingsPage.tsx`: wire value + auto-save handler
- `useSettingsForm.ts`: default `false` in init + reset
- `types.ts`: `claudeDangerousSkipPermissions?: boolean`
- `i18n`: keys in `en/zh/zh-TW/ja`

## Verification
- ✅ `cargo check` — clean compile (3 pre-existing warnings, unrelated)
- ✅ `tsc --noEmit` — exit 0
- ✅ `vitest run` — 287/287 pass
- ✅ Manual test in dev build — toggle saves, terminal launches with flag when enabled

## Testing
1. Enable toggle in Settings → General → Preferred Terminal
2. Click "Open Terminal" on a Claude Code provider
3. Verify launched terminal runs `claude --settings "..." --dangerously-skip-permissions`