### PR TITLE
fix(macos): eliminate duplicate terminal windows when opening provider terminal

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2622,34 +2622,18 @@ exec bash --norc --noprofile
 
 /// macOS: Terminal.app AppleScript
 ///
-/// 冷启动去重：Terminal 未运行时 `activate` 会自动创建一个默认窗口，若随后再无条件
-/// `do script` 会再开第二个窗口 → 出现一个多余的空 bash 窗口。
-/// 故按 `was_running` 分支（与 iTerm2 同源做法）：
-/// - 已运行：`do script` 直接开新窗口（不复用，避免劫持用户既有窗口）；
-/// - 未运行：`activate` 后轮询等待自动创建的默认窗口就绪（0.1s×30，规避窗口创建竞态），
-///   再 `do script … in window 1` 复用它，保证只开一个窗口。
+/// 直接使用未指定目标窗口的 `do script`，让 Terminal.app 为启动命令创建专用窗口：
+/// - 避免先 `activate` 冷启动时自动创建一个空默认窗口，随后 `do script` 再开第二个窗口；
+/// - 避免 `do script ... in window 1` 把启动命令注入 macOS 恢复出来的旧 Terminal 会话。
+///
+/// `activate` 放在 `do script` 之后，只负责把已创建的命令窗口带到前台。
 #[cfg(target_os = "macos")]
 fn build_macos_terminal_applescript(script_file: &std::path::Path) -> String {
     format!(
         r#"set launcher_script to "bash '{}'"
-set was_running to application "Terminal" is running
 tell application "Terminal"
+    do script launcher_script
     activate
-    if was_running then
-        do script launcher_script
-    else
-        set waited to 0
-        repeat while (count of windows) = 0
-            delay 0.1
-            set waited to waited + 1
-            if waited >= 30 then exit repeat
-        end repeat
-        if (count of windows) = 0 then
-            do script launcher_script
-        else
-            do script launcher_script in window 1
-        end if
-    end if
 end tell"#,
         script_file.display()
     )
@@ -4743,36 +4727,30 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn terminal_applescript_cold_start_reuses_auto_created_window() {
+    fn terminal_applescript_runs_script_before_activate() {
         let script = build_macos_terminal_applescript(Path::new("/tmp/cc_switch_launcher.sh"));
 
-        let cold_start_branch = script
-            .split("if was_running then")
-            .nth(1)
-            .expect("was_running branch should be present")
-            .splitn(2, "else")
-            .nth(1)
-            .expect("cold start branch should be present");
+        let do_script_pos = script
+            .find("do script launcher_script")
+            .expect("Terminal launcher should run the script");
+        let activate_pos = script
+            .find("activate")
+            .expect("Terminal launcher should activate Terminal after creating the command window");
 
-        assert!(cold_start_branch.contains("repeat while (count of windows) = 0"));
-        assert!(cold_start_branch.contains("do script launcher_script in window 1"));
+        assert!(do_script_pos < activate_pos);
     }
 
+    /// 回归：Codex review (PR #4054) 指出冷启动若遇 macOS「恢复窗口」会把启动脚本注入被
+    /// 还原的既有会话。不能用 `window 1` 或 `current window` 作为目标；未指定目标窗口的
+    /// `do script` 才会创建专用命令窗口。
     #[cfg(target_os = "macos")]
     #[test]
-    fn terminal_applescript_opens_new_window_when_already_running() {
+    fn terminal_applescript_does_not_target_existing_windows() {
         let script = build_macos_terminal_applescript(Path::new("/tmp/cc_switch_launcher.sh"));
 
-        let running_branch = script
-            .split("if was_running then")
-            .nth(1)
-            .expect("was_running branch should be present")
-            .splitn(2, "else")
-            .next()
-            .expect("already-running branch should end before cold start branch");
-
-        assert!(running_branch.contains("do script launcher_script"));
-        assert!(!running_branch.contains("in window"));
+        assert!(script.contains("do script launcher_script"));
+        assert!(!script.contains("in window"));
+        assert!(!script.contains("current window"));
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2620,18 +2620,47 @@ exec bash --norc --noprofile
     result
 }
 
+/// macOS: Terminal.app AppleScript
+///
+/// 冷启动去重：Terminal 未运行时 `activate` 会自动创建一个默认窗口，若随后再无条件
+/// `do script` 会再开第二个窗口 → 出现一个多余的空 bash 窗口。
+/// 故按 `was_running` 分支（与 iTerm2 同源做法）：
+/// - 已运行：`do script` 直接开新窗口（不复用，避免劫持用户既有窗口）；
+/// - 未运行：`activate` 后轮询等待自动创建的默认窗口就绪（0.1s×30，规避窗口创建竞态），
+///   再 `do script … in window 1` 复用它，保证只开一个窗口。
+#[cfg(target_os = "macos")]
+fn build_macos_terminal_applescript(script_file: &std::path::Path) -> String {
+    format!(
+        r#"set launcher_script to "bash '{}'"
+set was_running to application "Terminal" is running
+tell application "Terminal"
+    activate
+    if was_running then
+        do script launcher_script
+    else
+        set waited to 0
+        repeat while (count of windows) = 0
+            delay 0.1
+            set waited to waited + 1
+            if waited >= 30 then exit repeat
+        end repeat
+        if (count of windows) = 0 then
+            do script launcher_script
+        else
+            do script launcher_script in window 1
+        end if
+    end if
+end tell"#,
+        script_file.display()
+    )
+}
+
 /// macOS: Terminal.app
 #[cfg(target_os = "macos")]
 fn launch_macos_terminal_app(script_file: &std::path::Path) -> Result<(), String> {
     use std::process::Command;
 
-    let applescript = format!(
-        r#"tell application "Terminal"
-    activate
-    do script "bash '{}'"
-end tell"#,
-        script_file.display()
-    );
+    let applescript = build_macos_terminal_applescript(script_file);
 
     let output = Command::new("osascript")
         .arg("-e")
@@ -4691,6 +4720,40 @@ mod tests {
         assert!(running_branch.contains("if (count of windows) = 0 then"));
         assert!(running_branch.contains("create window with default profile"));
         assert!(running_branch.contains("create tab with default profile"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminal_applescript_cold_start_reuses_auto_created_window() {
+        let script = build_macos_terminal_applescript(Path::new("/tmp/cc_switch_launcher.sh"));
+
+        let cold_start_branch = script
+            .split("if was_running then")
+            .nth(1)
+            .expect("was_running branch should be present")
+            .splitn(2, "else")
+            .nth(1)
+            .expect("cold start branch should be present");
+
+        assert!(cold_start_branch.contains("repeat while (count of windows) = 0"));
+        assert!(cold_start_branch.contains("do script launcher_script in window 1"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminal_applescript_opens_new_window_when_already_running() {
+        let script = build_macos_terminal_applescript(Path::new("/tmp/cc_switch_launcher.sh"));
+
+        let running_branch = script
+            .split("if was_running then")
+            .nth(1)
+            .expect("was_running branch should be present")
+            .splitn(2, "else")
+            .next()
+            .expect("already-running branch should end before cold start branch");
+
+        assert!(running_branch.contains("do script launcher_script"));
+        assert!(!running_branch.contains("in window"));
     }
 
     #[test]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2741,6 +2741,21 @@ fn launch_macos_iterm2(script_file: &std::path::Path) -> Result<(), String> {
     Ok(())
 }
 
+/// 把启动脚本路径包进 `bash -c` 的字符串参数，供 `open -na <App> --args … bash -c <该串>` 使用。
+///
+/// `open -na <App> --args … -e bash <裸 .sh 路径>` 中，末尾的裸脚本路径会被当成
+/// 「待打开的文档」再打开一次（`.sh` 的默认处理器是登录 shell，会直接执行该文件）
+/// → 一次点击起两个终端窗口（实测 Ghostty 8 次中 6 次双开），且「文档方式」那次
+/// 直接执行脚本还会触发 macOS 的 "Allow … to execute" 弹窗。把路径包进 `-c`
+/// 字符串后它不再是独立 argv，也就不会再被当文档打开（实测 8/8 单窗口）。
+#[cfg(target_os = "macos")]
+fn build_macos_dash_c_command(script_file: &std::path::Path) -> String {
+    format!(
+        "exec bash {}",
+        shell_single_quote(&script_file.to_string_lossy())
+    )
+}
+
 /// macOS: Ghostty — use --quit-after-last-window-closed to avoid cloning existing tabs
 #[cfg(target_os = "macos")]
 fn launch_macos_ghostty(script_file: &std::path::Path) -> Result<(), String> {
@@ -2754,8 +2769,9 @@ fn launch_macos_ghostty(script_file: &std::path::Path) -> Result<(), String> {
             "--quit-after-last-window-closed=true",
             "-e",
             "bash",
+            "-c",
         ])
-        .arg(script_file)
+        .arg(build_macos_dash_c_command(script_file))
         .output()
         .map_err(|e| format!("启动 Ghostty 失败: {e}"))?;
 
@@ -2786,7 +2802,10 @@ fn launch_macos_open_app(
     if use_e_flag {
         cmd.arg("-e");
     }
-    cmd.arg("bash").arg(script_file);
+    // 同 Ghostty：脚本路径包进 `bash -c`，避免末尾裸 `.sh` 路径被 `open` 当文档再打开一次。
+    cmd.arg("bash")
+        .arg("-c")
+        .arg(build_macos_dash_c_command(script_file));
 
     let output = cmd
         .output()
@@ -4754,6 +4773,19 @@ mod tests {
 
         assert!(running_branch.contains("do script launcher_script"));
         assert!(!running_branch.contains("in window"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn dash_c_command_wraps_script_path_inside_quoted_arg() {
+        // 关键不变量:脚本路径必须出现在 `-c` 的字符串参数内部(单引号包裹),
+        // 而非作为独立的裸文件 argv —— 否则 `open` 会把它当文档再打开一次。
+        let s = build_macos_dash_c_command(Path::new("/tmp/cc_switch_launcher_1.sh"));
+        assert_eq!(s, "exec bash '/tmp/cc_switch_launcher_1.sh'");
+
+        // 含空格/单引号的路径也必须整体安全包裹。
+        let s2 = build_macos_dash_c_command(Path::new("/Users/me/it's dir/x.sh"));
+        assert_eq!(s2, r#"exec bash '/Users/me/it'"'"'s dir/x.sh'"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

修复 macOS 点击「打开终端」时出现**两个终端窗口**的两个独立根因:

### 根因 1:Terminal.app 冷启动双窗口(默认终端,必现)

Terminal.app **未运行**时,AppleScript 的 `activate` 会自动创建一个默认窗口,随后无条件的 `do script` 又会再开一个 → 必现一个多余的空 bash 窗口。

**修复**:沿用仓库内 iTerm2 启动器已有的 `was_running` 模式(`build_macos_iterm2_applescript` 即此做法):

- 已运行:`do script` 照旧开新窗口(不劫持用户已有窗口);
- 冷启动:轮询(0.1s×30)等 `activate` 自建的默认窗口就绪,再 `do script … in window 1` 复用它,保证只开一个窗口。

### 根因 2:`open -na` 家族裸脚本路径被二次打开(Ghostty/Alacritty/kitty/WezTerm/Kaku)

`open -na <App> --args … -e bash <裸 .sh 路径>` 末尾的裸路径除被 `-e bash` 执行外,还会被当成「文档」再打开一次(`.sh` 的默认处理器是登录 shell,会直接执行该文件)→ 一次点击双窗口,且「文档方式」那次还可能触发 macOS "Allow … to execute" 弹窗。

**修复**:路径包进 `bash -c "exec bash '<script>'"` 字符串(新 helper `build_macos_dash_c_command`,复用现有 `shell_single_quote`),不再是独立 argv。脚本侧语义完全不变(`$0`/tty/cwd 与原 `bash <script>` 形式一致)。

**载荷零改动**:`open_provider_terminal` → `extract_env_vars_from_config` → `write_claude_config` → `claude --settings "<config>"` 的供应商注入链路未动;iTerm2 / Warp / Linux / Windows 路径未动。

## Related Issue / 关联 Issue

无现有 issue。复现条件:macOS 上完全退出 Terminal.app 后点击「打开终端」(根因 1);或首选终端设为 Ghostty 等 `open -na` 系终端后点击(根因 2)。

## Screenshots / 截图

窗口数真机实测(文字版前后对比):

| 场景 | Before / 修改前 | After / 修改后 |
|------|-----------------|----------------|
| Terminal.app 冷启动 | 2 个窗口(1 个空 bash) | 1 个窗口 |
| Terminal.app 已运行 | 每次 +1 窗口 | 每次 +1 窗口(不变) |
| Ghostty | 8 次中 6 次双开 + 偶发执行确认弹窗 | 8/8 单窗口 |

## Test Plan / 验证

- 新增 3 个单元测试(结构对齐现有 `iterm2_applescript_*` 测试):冷启动分支必须复用 `window 1`、已运行分支不得带 `in window`、`dash_c` 包裹的引号不变量(含空格/单引号路径)。`cargo test` 1650 全部通过。
- 真机(macOS, Apple Silicon)实测上表全部场景;并用替身 claude 验证 `--settings <临时JSON>` 参数与注入内容原样到达,确认供应商注入功能不受影响。
- 新测试为 `#[cfg(target_os = "macos")]` 门控,与现有 iTerm2 测试同等地位(CI 的 ubuntu runner 上不参与编译)。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查(如修改了 Rust 代码)
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本,已更新国际化文件(N/A:无用户可见文本变更)
