### PR TITLE
fix: use ANTHROPIC_AUTH_TOKEN for managed account providers (Copilot/Codex)

### DIFF
--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -185,7 +185,7 @@ impl ProxyService {
                     env.remove(key);
                 }
                 env.insert(
-                    "ANTHROPIC_API_KEY".to_string(),
+                    "ANTHROPIC_AUTH_TOKEN".to_string(),
                     json!(PROXY_TOKEN_PLACEHOLDER),
                 );
             }
@@ -2757,7 +2757,7 @@ mod tests {
     }
 
     #[test]
-    fn managed_account_claude_takeover_uses_api_key_placeholder() {
+    fn managed_account_claude_takeover_uses_auth_token_placeholder() {
         let mut provider = Provider::with_id(
             "copilot".to_string(),
             "GitHub Copilot".to_string(),
@@ -2786,13 +2786,13 @@ mod tests {
             .and_then(|value| value.as_object())
             .expect("env should exist");
         assert_eq!(
-            env.get("ANTHROPIC_API_KEY")
+            env.get("ANTHROPIC_AUTH_TOKEN")
                 .and_then(|value| value.as_str()),
             Some(PROXY_TOKEN_PLACEHOLDER)
         );
         assert!(
-            env.get("ANTHROPIC_AUTH_TOKEN").is_none(),
-            "managed OAuth providers should avoid Claude Auth Token login semantics"
+            env.get("ANTHROPIC_API_KEY").is_none(),
+            "managed OAuth providers should not set ANTHROPIC_API_KEY"
         );
     }
 
@@ -2867,8 +2867,8 @@ mod tests {
             "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
             Some("claude-sonnet-4.6"),
         );
-        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
-        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", None);
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_API_KEY", None);
     }
 
     #[test]
@@ -2934,8 +2934,8 @@ mod tests {
         assert_env_str(env, "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME", Some("gpt-5.4"));
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-4-8"));
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME", Some("gpt-5.4"));
-        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
-        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", None);
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_API_KEY", None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When GitHub Copilot or Codex OAuth is set as the active provider, the `ManagedAccount` auth policy writes `ANTHROPIC_API_KEY=PROXY_MANAGED` into `~/.claude/settings.json`.

Claude Code CLI's login check recognises `ANTHROPIC_AUTH_TOKEN` as the session credential. When only `ANTHROPIC_API_KEY` is present with a placeholder value, the CLI shows:

```
Not logged in · Please run /login
```

on every new terminal session, even though the proxy is running and requests are succeeding.

Users on `PreserveExistingOrAuthToken` providers (e.g. direct Anthropic API) don't hit this because that policy defaults to writing `ANTHROPIC_AUTH_TOKEN` when no pre-existing key is found.

## Fix

Change `ManagedAccount` policy to write `ANTHROPIC_AUTH_TOKEN=PROXY_MANAGED` instead of `ANTHROPIC_API_KEY=PROXY_MANAGED`, consistent with what Claude Code expects for session auth.

## Test plan

- [x] Updated 3 existing tests to assert `ANTHROPIC_AUTH_TOKEN` is set and `ANTHROPIC_API_KEY` is absent after takeover (Copilot and Codex cases)
- [ ] Open CC Switch with Copilot as active provider → new terminal `claude` should not show "Not logged in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)