### PR TITLE
fix: prevent deadlock when relaunching after in-app update

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1443,14 +1443,37 @@ pub fn run() {
     app.run(|app_handle, event| {
         // 处理退出请求（所有平台）
         if let RunEvent::ExitRequested { api, code, .. } = &event {
-            // code 为 None 表示运行时自动触发（如隐藏窗口的 WebView 被回收导致无存活窗口），
-            // 此时应仅阻止退出、保持托盘后台运行；
-            // code 为 Some(_) 表示用户主动调用 app.exit() 退出（如托盘菜单"退出"），
-            // 此时执行清理后退出。
-            if code.is_none() {
-                log::info!("运行时触发退出请求（无存活窗口），阻止退出以保持托盘后台运行");
-                api.prevent_exit();
-                return;
+            match classify_exit_request(*code) {
+                // code 为 None 表示运行时自动触发（如隐藏窗口的 WebView 被回收导致无存活窗口），
+                // 此时应仅阻止退出、保持托盘后台运行。
+                ExitRequestAction::StayInTray => {
+                    log::info!("运行时触发退出请求（无存活窗口），阻止退出以保持托盘后台运行");
+                    api.prevent_exit();
+                    return;
+                }
+                // code 为 RESTART_EXIT_CODE：app.restart() / 自更新 relaunch 发起的重启。
+                // 这条路径上 prevent_exit() 会被 Tauri 忽略，事件循环必定退出，随后由
+                // Tauri 在 RunEvent::Exit 后用新二进制 re-exec（macOS 会按更新后的
+                // Info.plist 解析可执行名）。
+                //
+                // 绝不能复用下面的异步清理任务：该任务在 tokio 线程调 save_window_state，
+                // 持有 window-state 插件锁的同时向主线程查询窗口几何；而主线程此刻正在
+                // 退出事件循环，并在插件自带的 RunEvent::Exit 钩子里等待同一把锁——双方
+                // 互等造成进程永久卡死（更新已安装但应用冻结、不再重启，见 #3998）。
+                //
+                // 重启路径交还 Tauri 默认流程即可：
+                //   - 窗口状态：插件 Exit 钩子在主线程保存（同线程读取窗口几何，无死锁）
+                //   - 托盘图标：Tauri 内部 cleanup_before_exit 清理，正常走 Drop
+                //   - 代理/Live 配置：无需恢复，重启后新实例立即接管并恢复代理状态
+                //   - 100ms 落盘等待：重启前的 DB 写入均为命令驱动、此刻已完成，
+                //     与所有 Tauri 应用默认重启路径的行为一致，无需额外等待
+                ExitRequestAction::DeferToTauriRestart => {
+                    log::info!("收到重启请求 (code={code:?})，交由 Tauri 默认重启流程 re-exec");
+                    return;
+                }
+                // 其它 Some(_)：用户主动调用 app.exit() 退出（如托盘菜单"退出"），
+                // 此时执行清理后退出。
+                ExitRequestAction::CleanupAndExit => {}
             }
 
             log::info!("收到用户主动退出请求 (code={code:?})，开始清理...");
@@ -1892,6 +1915,36 @@ fn show_database_init_error_dialog(
 }
 
 // ============================================================
+// 退出请求分类
+// ============================================================
+
+/// `RunEvent::ExitRequested` 的三类来源，处理方式必须区分。
+///
+/// 关键约束：重启请求（`code == RESTART_EXIT_CODE`）上 `prevent_exit()` 会被
+/// Tauri 静默忽略（见 `ExitRequestApi::prevent_exit` 文档），事件循环必定继续
+/// 退出并触发各插件的 `RunEvent::Exit` 钩子；任何与之并发的自定义清理任务都
+/// 可能与插件退出钩子争用同一状态而死锁。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExitRequestAction {
+    /// `code` 为 `None`：运行时自动触发（如隐藏窗口的 WebView 被回收导致无存活
+    /// 窗口），阻止退出、保持托盘后台运行。
+    StayInTray,
+    /// `code` 为 `RESTART_EXIT_CODE`：`app.restart()` / 自更新 relaunch 发起的
+    /// 重启，不拦截、不做自定义清理，交还 Tauri 默认 re-exec 流程。
+    DeferToTauriRestart,
+    /// 其它 `Some(_)`：用户主动退出（托盘「退出」等），执行完整异步清理后结束进程。
+    CleanupAndExit,
+}
+
+fn classify_exit_request(code: Option<i32>) -> ExitRequestAction {
+    match code {
+        None => ExitRequestAction::StayInTray,
+        Some(tauri::RESTART_EXIT_CODE) => ExitRequestAction::DeferToTauriRestart,
+        Some(_) => ExitRequestAction::CleanupAndExit,
+    }
+}
+
+// ============================================================
 // 在应用主动退出前显式持久化窗口状态
 // ============================================================
 
@@ -1906,5 +1959,35 @@ pub fn save_window_state_before_exit(app_handle: &tauri::AppHandle) {
         log::error!("退出前保存窗口状态失败: {err}");
     } else {
         log::info!("已在退出前保存窗口状态");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_exit_request, ExitRequestAction};
+
+    #[test]
+    fn no_code_keeps_app_alive_in_tray() {
+        assert_eq!(classify_exit_request(None), ExitRequestAction::StayInTray);
+    }
+
+    #[test]
+    fn restart_exit_code_defers_to_tauri_default_restart() {
+        assert_eq!(
+            classify_exit_request(Some(tauri::RESTART_EXIT_CODE)),
+            ExitRequestAction::DeferToTauriRestart
+        );
+    }
+
+    #[test]
+    fn user_exit_codes_run_cleanup_then_exit() {
+        assert_eq!(
+            classify_exit_request(Some(0)),
+            ExitRequestAction::CleanupAndExit
+        );
+        assert_eq!(
+            classify_exit_request(Some(1)),
+            ExitRequestAction::CleanupAndExit
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes a macOS deadlock where the app **freezes forever on the "restarting" screen** after an in-app update finishes downloading. Because the update is already installed by then, force-quitting and reopening shows the new version — exactly the symptom reported in #3998 ("点击更新之后直接卡住 / 更新后不会自动重启，卡死无响应").

## Root cause

`relaunch()` (and `app.restart()`) triggers `RunEvent::ExitRequested` with code `RESTART_EXIT_CODE` (`i32::MAX`). The handler treated every `Some(code)` as a user-initiated exit: it called `api.prevent_exit()` and spawned an async cleanup task that ends in `std::process::exit(0)`.

Two facts combine into a deadlock:

1. **`prevent_exit()` is silently ignored for `RESTART_EXIT_CODE`** (documented on `ExitRequestApi::prevent_exit`). So the event loop shuts down regardless and fires every plugin's `RunEvent::Exit` hook on the **main thread**.
2. The spawned cleanup runs `save_window_state` on a **Tokio worker**, which holds `tauri-plugin-window-state`'s internal mutex while reading window geometry (`is_maximized()` → cross-thread dispatch to the main thread). Meanwhile the main thread is already inside that same plugin's `RunEvent::Exit` hook, blocked on the **same mutex**.

Circular wait → the process hangs forever.

Confirmed by sampling the frozen process on macOS:
- main thread parked in `tauri_plugin_window_state::save_window_state` → mutex lock;
- Tokio worker parked in `WebviewWindow::is_maximized()` → `mpsc::Receiver::recv`.

Deterministic A/B reproduction:
- **before**: a restart request logs *"received user-initiated exit (code=2147483647)"* and then never completes (no "cleanup done" line) → frozen;
- **after**: the same request logs *"restart request → defer to Tauri's default restart"* and the re-exec'd process comes up within the same second.

## Fix

Classify the exit request into three actions and let restart requests fall through **untouched** to Tauri's default restart flow (`RunEvent::Exit` → internal `cleanup_before_exit` → `process::restart` re-exec):

- **window state** is saved by the plugin's own `Exit` hook on the main thread (same-thread getters, no cross-thread dispatch → no deadlock);
- **tray icon** is cleaned up by Tauri's internal `cleanup_before_exit`;
- **proxy / live-config restore** is intentionally skipped on this path because the freshly relaunched instance takes over immediately (startup already restores takeover residue).

The normal exit path (tray "Quit", `app.exit(0)`) is unchanged.

## Related issue

Closes #3998

## Testing

- New unit tests for the exit-request classifier (`None` → stay in tray, `RESTART_EXIT_CODE` → defer to default restart, other `Some(_)` → cleanup-and-exit).
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and full `cargo test` pass.
- Manual A/B on macOS: pre-fix handler freezes on relaunch (had to force-quit); fixed handler relaunches cleanly with the new process up immediately.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] No new compiler/clippy warnings
