### PR TITLE
fix(updater): drive download/install/restart from backend to avoid hang

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -115,10 +115,13 @@ pub async fn install_update_and_restart(app: AppHandle) -> Result<bool, String> 
 
     #[cfg(target_os = "windows")]
     {
-        // Windows updater 会在 install() 内启动安装器并直接退出当前进程。
-        // 因此清理只能放在 install 前执行。
+        // Windows updater 会在 install() 内启动安装器并直接退出当前进程
+        // （插件内部 std::process::exit(0)，绕过 TrayIcon::drop、不发
+        // NIM_DELETE，会残留死图标——与托盘"退出"路径相同的问题）。
+        // 因此清理只能放在 install 前执行，且必须显式移除托盘图标。
         crate::save_window_state_before_exit(&app);
         crate::cleanup_before_exit(&app).await;
+        crate::remove_tray_icon_before_exit(&app);
         crate::destroy_single_instance_lock(&app);
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         update.install(bytes).map_err(|e| {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use tauri::AppHandle;
+use tauri_plugin_updater::UpdaterExt;
 
 fn merge_settings_for_save(
     mut incoming: crate::settings::AppSettings,
@@ -82,6 +83,66 @@ pub async fn restart_app(app: AppHandle) -> Result<bool, String> {
         app.restart();
     });
     Ok(true)
+}
+
+/// 下载并安装应用更新，然后由后端直接重启应用。
+///
+/// macOS 更新会原地替换 `.app` bundle。如果先返回前端、再让旧 WebView 调
+/// `process.relaunch()`，旧进程可能已经处在 bundle 被替换后的不稳定窗口期。
+/// 这里把退出清理、安装和重启串在同一个后端流程中，避免依赖旧前端继续执行。
+#[tauri::command]
+pub async fn install_update_and_restart(app: AppHandle) -> Result<bool, String> {
+    let updater = app
+        .updater_builder()
+        .build()
+        .map_err(|e| format!("初始化更新器失败: {e}"))?;
+
+    let Some(update) = updater
+        .check()
+        .await
+        .map_err(|e| format!("检查更新失败: {e}"))?
+    else {
+        return Ok(false);
+    };
+
+    log::info!("开始下载应用更新: {}", update.version);
+    let bytes = update
+        .download(|_, _| {}, || {})
+        .await
+        .map_err(|e| format!("下载更新失败: {e}"))?;
+
+    log::info!("开始安装应用更新: {}", update.version);
+
+    #[cfg(target_os = "windows")]
+    {
+        // Windows updater 会在 install() 内启动安装器并直接退出当前进程。
+        // 因此清理只能放在 install 前执行。
+        crate::save_window_state_before_exit(&app);
+        crate::cleanup_before_exit(&app).await;
+        crate::destroy_single_instance_lock(&app);
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        update.install(bytes).map_err(|e| {
+            format!(
+                "Windows 更新安装失败: {e}。已执行退出前清理，代理或 Live 接管可能已暂停；请重启应用或重新开启代理后再试。"
+            )
+        })?;
+        return Ok(true);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        // macOS/Linux install() 会返回；先安装，避免安装失败时误停代理/撤回接管。
+        update
+            .install(bytes)
+            .map_err(|e| format!("安装更新失败: {e}"))?;
+
+        crate::save_window_state_before_exit(&app);
+        crate::cleanup_before_exit(&app).await;
+
+        log::info!("应用更新安装完成，正在重启应用");
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        crate::restart_process(&app);
+    }
 }
 
 /// 获取 app_config_dir 覆盖配置 (从 Store)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1646,7 +1646,7 @@ pub async fn cleanup_before_exit(app_handle: &tauri::AppHandle) {
 /// 触发 tray-icon 内部的 `remove_tray_icon` → `Shell_NotifyIconW(NIM_DELETE)`，
 /// 在进程结束前干净地把图标摘掉。其它平台 `set_visible(false)` 也是
 /// 正常的隐藏/移除语义，作为跨平台兜底也安全。
-fn remove_tray_icon_before_exit(app_handle: &tauri::AppHandle) {
+pub(crate) fn remove_tray_icon_before_exit(app_handle: &tauri::AppHandle) {
     if let Some(tray) = app_handle.tray_by_id(tray::TRAY_ID) {
         if let Err(e) = tray.set_visible(false) {
             log::warn!("退出时移除托盘图标失败: {e}");
@@ -1973,8 +1973,18 @@ pub fn destroy_single_instance_lock(app_handle: &tauri::AppHandle) {
     tauri_plugin_single_instance::destroy(app_handle);
 }
 
-/// 释放 single-instance 锁后重启当前应用。
+/// 清理托盘图标、释放 single-instance 锁后重启当前应用。
+///
+/// 直接走 `tauri::process::restart`（spawn 新进程 + `exit(0)`），不经过事件
+/// 循环退出，因此 Tauri 内部的 `cleanup_before_exit` 和各插件的
+/// `RunEvent::Exit` 钩子都不会执行。需要的清理由调用方与本函数显式补偿：
+/// 窗口状态、代理/Live 恢复（调用方）；托盘图标、single-instance 锁（本函数）。
+///
+/// 有意不调 `AppHandle::cleanup_before_exit()`：它会在调用线程上 Drop 托盘
+/// 图标，而 macOS 的 NSStatusItem 操作要求主线程；`set_visible(false)` 走
+/// `run_item_main_thread` 代理，跨线程安全（见 `remove_tray_icon_before_exit`）。
 pub fn restart_process(app_handle: &tauri::AppHandle) -> ! {
+    remove_tray_icon_before_exit(app_handle);
     destroy_single_instance_lock(app_handle);
     tauri::process::restart(&app_handle.env());
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1165,6 +1165,7 @@ pub fn run() {
             commands::get_log_config,
             commands::set_log_config,
             commands::restart_app,
+            commands::install_update_and_restart,
             commands::check_for_updates,
             commands::is_portable_mode,
             commands::copy_text_to_clipboard,
@@ -1960,6 +1961,22 @@ pub fn save_window_state_before_exit(app_handle: &tauri::AppHandle) {
     } else {
         log::info!("已在退出前保存窗口状态");
     }
+}
+
+/// 主动释放 single-instance 锁。
+///
+/// macOS single-instance 使用 `/tmp/{identifier}.sock`。我们有若干路径会直接
+/// `std::process::exit(0)`，不会触发插件挂在 `RunEvent::Exit` 上的清理钩子。
+/// 重启前主动 destroy 可以避免新进程误连旧 listener 后自行退出。
+pub fn destroy_single_instance_lock(app_handle: &tauri::AppHandle) {
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+    tauri_plugin_single_instance::destroy(app_handle);
+}
+
+/// 释放 single-instance 锁后重启当前应用。
+pub fn restart_process(app_handle: &tauri::AppHandle) -> ! {
+    destroy_single_instance_lock(app_handle);
+    tauri::process::restart(&app_handle.env());
 }
 
 #[cfg(test)]

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -32,7 +32,6 @@ import type {
   ToolInstallationReport,
 } from "@/lib/api/settings";
 import { useUpdate } from "@/contexts/UpdateContext";
-import { relaunchApp } from "@/lib/updater";
 import { Badge } from "@/components/ui/badge";
 import { motion } from "framer-motion";
 import appIcon from "@/assets/icons/app-icon.png";
@@ -195,14 +194,8 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
   );
   const [showInstallCommands, setShowInstallCommands] = useState(false);
 
-  const {
-    hasUpdate,
-    updateInfo,
-    updateHandle,
-    checkUpdate,
-    resetDismiss,
-    isChecking,
-  } = useUpdate();
+  const { hasUpdate, updateInfo, checkUpdate, resetDismiss, isChecking } =
+    useUpdate();
 
   const [wslShellByTool, setWslShellByTool] = useState<
     Record<string, WslShellPreference>
@@ -392,7 +385,7 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
   }, [t, updateInfo?.availableVersion, version]);
 
   const handleCheckUpdate = useCallback(async () => {
-    if (hasUpdate && updateHandle) {
+    if (hasUpdate) {
       if (isPortable) {
         try {
           await settingsApi.checkUpdates();
@@ -405,11 +398,16 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
       setIsDownloading(true);
       try {
         resetDismiss();
-        await updateHandle.downloadAndInstall();
-        await relaunchApp();
+        const installed = await settingsApi.installUpdateAndRestart();
+        if (!installed) {
+          toast.success(t("settings.upToDate"), { closeButton: true });
+        }
       } catch (error) {
         console.error("[AboutSection] Update failed", error);
-        toast.error(t("settings.updateFailed"));
+        toast.error(t("settings.updateFailed"), {
+          description: extractErrorMessage(error) || undefined,
+          closeButton: true,
+        });
         try {
           await settingsApi.checkUpdates();
         } catch (fallbackError) {
@@ -433,7 +431,7 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
       console.error("[AboutSection] Check update failed", error);
       toast.error(t("settings.checkUpdateFailed"));
     }
-  }, [checkUpdate, hasUpdate, isPortable, resetDismiss, t, updateHandle]);
+  }, [checkUpdate, hasUpdate, isPortable, resetDismiss, t]);
 
   const handleCopyInstallCommands = useCallback(async () => {
     try {

--- a/src/contexts/UpdateContext.tsx
+++ b/src/contexts/UpdateContext.tsx
@@ -6,14 +6,13 @@ import React, {
   useCallback,
   useRef,
 } from "react";
-import type { UpdateInfo, UpdateHandle } from "../lib/updater";
+import type { UpdateInfo } from "../lib/updater";
 import { checkForUpdate } from "../lib/updater";
 
 interface UpdateContextValue {
   // 更新状态
   hasUpdate: boolean;
   updateInfo: UpdateInfo | null;
-  updateHandle: UpdateHandle | null;
   isChecking: boolean;
   error: string | null;
 
@@ -34,7 +33,6 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
 
   const [hasUpdate, setHasUpdate] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
-  const [updateHandle, setUpdateHandle] = useState<UpdateHandle | null>(null);
   const [isChecking, setIsChecking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isDismissed, setIsDismissed] = useState(false);
@@ -72,7 +70,6 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
       if (result.status === "available") {
         setHasUpdate(true);
         setUpdateInfo(result.info);
-        setUpdateHandle(result.update);
 
         // 检查是否已经关闭过这个版本的提醒
         let dismissedVersion = localStorage.getItem(DISMISSED_VERSION_KEY);
@@ -89,7 +86,6 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
       } else {
         setHasUpdate(false);
         setUpdateInfo(null);
-        setUpdateHandle(null);
         setIsDismissed(false);
         return false; // 已是最新
       }
@@ -132,7 +128,6 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
   const value: UpdateContextValue = {
     hasUpdate,
     updateInfo,
-    updateHandle,
     isChecking,
     error,
     isDismissed,

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -36,6 +36,10 @@ export const settingsApi = {
     return await invoke("restart_app");
   },
 
+  async installUpdateAndRestart(): Promise<boolean> {
+    return await invoke("install_update_and_restart");
+  },
+
   async checkUpdates(): Promise<void> {
     await invoke("check_for_updates");
   },

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,21 +1,6 @@
 import { getVersion } from "@tauri-apps/api/app";
 
-// 可选导入：在未注册插件或非 Tauri 环境下，调用时会抛错，外层需做兜底
-// 我们按需加载并在运行时捕获错误，避免构建期类型问题
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import type { Update } from "@tauri-apps/plugin-updater";
-
 export type UpdateChannel = "stable" | "beta";
-
-export type UpdaterPhase =
-  | "idle"
-  | "checking"
-  | "available"
-  | "downloading"
-  | "installing"
-  | "restarting"
-  | "upToDate"
-  | "error";
 
 export interface UpdateInfo {
   currentVersion: string;
@@ -24,62 +9,9 @@ export interface UpdateInfo {
   pubDate?: string;
 }
 
-export interface UpdateProgressEvent {
-  event: "Started" | "Progress" | "Finished";
-  total?: number;
-  downloaded?: number;
-}
-
-export interface UpdateHandle {
-  version: string;
-  notes?: string;
-  date?: string;
-  downloadAndInstall: (
-    onProgress?: (e: UpdateProgressEvent) => void,
-  ) => Promise<void>;
-  download?: () => Promise<void>;
-  install?: () => Promise<void>;
-}
-
 export interface CheckOptions {
   timeout?: number;
   channel?: UpdateChannel;
-}
-
-function mapUpdateHandle(raw: Update): UpdateHandle {
-  return {
-    version: (raw as any).version ?? "",
-    notes: (raw as any).notes,
-    date: (raw as any).date,
-    async downloadAndInstall(onProgress?: (e: UpdateProgressEvent) => void) {
-      await (raw as any).downloadAndInstall((evt: any) => {
-        if (!onProgress) return;
-        const mapped: UpdateProgressEvent = {
-          event: evt?.event,
-        };
-        if (evt?.event === "Started") {
-          mapped.total = evt?.data?.contentLength ?? 0;
-          mapped.downloaded = 0;
-        } else if (evt?.event === "Progress") {
-          mapped.downloaded = evt?.data?.chunkLength ?? 0; // 累积由调用方完成
-        }
-        onProgress(mapped);
-      });
-    },
-    // 透传可选 API（若插件版本支持）
-    download: (raw as any).download
-      ? async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          await (raw as any).download();
-        }
-      : undefined,
-    install: (raw as any).install
-      ? async () => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          await (raw as any).install();
-        }
-      : undefined,
-  };
 }
 
 export async function getCurrentVersion(): Promise<string> {
@@ -93,8 +25,7 @@ export async function getCurrentVersion(): Promise<string> {
 export async function checkForUpdate(
   opts: CheckOptions = {},
 ): Promise<
-  | { status: "up-to-date" }
-  | { status: "available"; info: UpdateInfo; update: UpdateHandle }
+  { status: "up-to-date" } | { status: "available"; info: UpdateInfo }
 > {
   // 动态引入，避免在未安装插件时导致打包期问题
   const { check } = await import("@tauri-apps/plugin-updater");
@@ -106,21 +37,12 @@ export async function checkForUpdate(
     return { status: "up-to-date" };
   }
 
-  const mapped = mapUpdateHandle(update);
   const info: UpdateInfo = {
     currentVersion,
-    availableVersion: mapped.version,
-    notes: mapped.notes,
-    pubDate: mapped.date,
+    availableVersion: (update as any).version ?? "",
+    notes: (update as any).notes,
+    pubDate: (update as any).date,
   };
 
-  return { status: "available", info, update: mapped };
+  return { status: "available", info };
 }
-
-export async function relaunchApp(): Promise<void> {
-  const { relaunch } = await import("@tauri-apps/plugin-process");
-  await relaunch();
-}
-
-// 旧的聚合更新流程已由调用方直接使用 updateHandle 取代
-// 如需单函数封装，可在需要时基于 checkForUpdate + updateHandle 复合调用


### PR DESCRIPTION
## Summary

Revives the previously-lost backend-driven update fix (`af4271f4`, authored 2026-06-03). It was stacked on the `codex/fix-zhipu-coding-plan-presets` branch; the other two commits of that stack landed on main via separate PRs (#3524, `0512ee76`), but this updater fix was left behind — v3.16.2 still ships the frontend-driven flow from 2025-09.

## What this fixes (beyond #4069)

#4069 fixed the `ExitRequested` deadlock for all `app.restart()` paths. This PR fixes the remaining structural problems of the update flow itself:

- **Bundle-swap window**: the old flow returned to the frontend after `downloadAndInstall()` and relied on the old WebView to call `relaunch()` — i.e. running JS in a process whose `.app` bundle had already been replaced. The new backend command `install_update_and_restart` runs the whole download → install → cleanup → restart chain in Rust.
- **Windows install ordering**: `install()` launches the external installer and exits the process internally on Windows, so cleanup + single-instance destroy must run *before* install; on macOS/Linux `install()` returns, so install runs first and an install failure no longer wrongly stops the proxy or reverts takeover.
- **Restart vs single-instance race**: `restart_process()` destroys the single-instance lock (socket on macOS, mutex on Windows) before `tauri::process::restart()`, so the freshly spawned process can't connect to the old listener and exit itself.
- **Proper cleanup on the update path**: proxy/live-config restore and window-state save run synchronously in the command, while the event loop is still alive — no interleaving with loop teardown.

## Adaptation from the original commit

The original `af4271f4` also patched the `ExitRequested` handler (`should_restart` branch with `prevent_exit()` + async cleanup + `restart_process`). That part is **dropped**: `prevent_exit()` is silently ignored for `RESTART_EXIT_CODE`, so that branch would race the main thread's exit and reintroduce the window-state deadlock that #4069 fixed. With #4069's classifier in place the handler needs no restart awareness, and `install_update_and_restart` bypasses `ExitRequested` entirely — the two fixes compose cleanly.

## Testing

- `cargo fmt --check`, `cargo clippy`, `cargo test` pass
- `pnpm typecheck` passes
- Original commit was manually verified on macOS at the time (backend-driven update + relaunch came up cleanly)