### PR TITLE
feat(session): include tool_use input in extracted text

### DIFF
--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -85,13 +85,20 @@ pub fn extract_text(content: &Value) -> String {
 fn extract_text_from_item(item: &Value) -> Option<String> {
     let item_type = item.get("type").and_then(Value::as_str).unwrap_or("");
 
-    // tool_use: show tool name
+    // tool_use: show tool name and input
     if item_type == "tool_use" {
         let name = item
             .get("name")
             .and_then(Value::as_str)
             .unwrap_or("unknown");
-        return Some(format!("[Tool: {name}]"));
+        match item.get("input") {
+            Some(input) if !input.is_null() => {
+                let rendered =
+                    serde_json::to_string_pretty(input).unwrap_or_else(|_| input.to_string());
+                return Some(format!("[Tool: {name}]\n{rendered}"));
+            }
+            _ => return Some(format!("[Tool: {name}]")),
+        }
     }
 
     // tool_result: extract nested content


### PR DESCRIPTION
## Summary

Render `tool_use` content blocks with their `input` payload alongside the tool name when extracting text from session messages. Previously summaries only showed `[Tool: name]`, making it impossible to tell what a tool was invoked with.

After:

```
[Tool: Edit]
{
  "file_path": "src/foo.ts",
  ...
}
```

If `input` is missing or `null`, behavior is unchanged.

## Related Issue


## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|      <img width="394" height="128" alt="image" src="https://github.com/user-attachments/assets/40016f78-1431-440f-bc60-7bdd83f63eb6" />    |       <img width="662" height="346" alt="image" src="https://github.com/user-attachments/assets/da927ae6-5385-4a6b-bf44-fa37a4f05723" />        |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
