### PR TITLE
Fix provider preset search popover placement

### DIFF
--- a/src/components/providers/forms/ProviderPresetSelector.tsx
+++ b/src/components/providers/forms/ProviderPresetSelector.tsx
@@ -290,8 +290,10 @@ export function ProviderPresetSelector({
                 </TooltipContent>
               </Tooltip>
               <PopoverContent
-                align="end"
-                className="w-72 p-2 border-border-default"
+                side="left"
+                align="center"
+                sideOffset={8}
+                className="z-[100] w-72 border-0 bg-transparent p-0 shadow-none"
               >
                 <Input
                   value={searchQuery}

--- a/tests/components/ProviderPresetSelector.test.tsx
+++ b/tests/components/ProviderPresetSelector.test.tsx
@@ -273,7 +273,11 @@ describe("ProviderPresetSelector", () => {
     renderSelector();
 
     await user.click(getSearchButton());
-    await user.type(getSearchInput(), "gateway");
+    const searchInput = getSearchInput();
+    expect(searchInput.parentElement).toHaveAttribute("data-side", "left");
+    expect(searchInput.parentElement).toHaveClass("z-[100]");
+    expect(searchInput.parentElement).toHaveClass("border-0", "shadow-none");
+    await user.type(searchInput, "gateway");
 
     expect(
       screen.getByRole("button", { name: "providerPreset.custom" }),


### PR DESCRIPTION
## Summary

- move the provider preset search popover to the left of the search trigger
- remove the extra popover panel chrome so the input does not cover the preset controls
- add a regression assertion for the popover placement and layering

Follow-up to #3975. Related to #3963 and #3296.

## Validation

- `pnpm --config.verify-deps-before-run=false run typecheck`
- `pnpm --config.verify-deps-before-run=false run format:check`
- `pnpm --config.verify-deps-before-run=false run test:unit`
