### PR TITLE
feat(session-manager): show source file name in session detail header

### DIFF
--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -912,7 +912,7 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                                   className="flex items-center gap-1 hover:text-foreground transition-colors"
                                 >
                                   <FileText className="size-3 shrink-0" />
-                                  <span className="font-mono">
+                                  <span className="font-mono truncate max-w-[200px]">
                                     {getBaseName(selectedSession.sourcePath)}
                                   </span>
                                 </button>

--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -13,6 +13,7 @@ import {
   MessageSquare,
   Clock,
   FolderOpen,
+  FileText,
   X,
   CheckSquare,
 } from "lucide-react";
@@ -890,6 +891,38 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                               >
                                 <p className="font-mono text-xs break-all">
                                   {selectedSession.projectDir}
+                                </p>
+                                <p className="text-muted-foreground mt-1">
+                                  {t("sessionManager.clickToCopyPath")}
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                          {selectedSession.sourcePath && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    void handleCopy(
+                                      selectedSession.sourcePath!,
+                                      t("sessionManager.sourcePathCopied"),
+                                    )
+                                  }
+                                  className="flex items-center gap-1 hover:text-foreground transition-colors"
+                                >
+                                  <FileText className="size-3 shrink-0" />
+                                  <span className="font-mono">
+                                    {getBaseName(selectedSession.sourcePath)}
+                                  </span>
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent
+                                side="bottom"
+                                className="max-w-xs"
+                              >
+                                <p className="font-mono text-xs break-all">
+                                  {selectedSession.sourcePath}
                                 </p>
                                 <p className="text-muted-foreground mt-1">
                                   {t("sessionManager.clickToCopyPath")}


### PR DESCRIPTION
Display the session log file name (with full path on hover) alongside the project directory, so users can locate and copy the underlying JSONL file directly from the UI.

## Summary / 概述

Show the session log file name in the Session Manager detail header. Hover reveals the full path; click copies it to the clipboard.

Makes it easy to locate the underlying JSONL file (e.g. for debugging or sharing) without leaving the app.

## Related Issue / 关联 Issue


## Screenshots / 截图


| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|     <img width="872" height="178" alt="image" src="https://github.com/user-attachments/assets/bd9cc9ad-5d63-4b17-b995-a8f8ec78739f" />            |  === no hover ===   <img width="844" height="148" alt="image" src="https://github.com/user-attachments/assets/0bf837e2-a92d-47a4-b6ac-e8c9fe7ad572" /> === full path on hover === <img width="742" height="299" alt="image" src="https://github.com/user-attachments/assets/9f051c62-55d8-4207-9233-d5b56cf0cc4c" />   |


## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
