### PR TITLE
feat: add configurable usage display order setting

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -397,6 +397,9 @@ pub struct AppSettings {
     pub common_config_confirmed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
+    /// 用量显示顺序："remaining-first"（默认）或 "used-first"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage_display_order: Option<String>,
 
     // ===== 主页面显示的应用 =====
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -510,6 +513,7 @@ impl Default for AppSettings {
             first_run_notice_confirmed: None,
             common_config_confirmed: None,
             language: None,
+            usage_display_order: None,
             visible_apps: None,
             claude_config_dir: None,
             codex_config_dir: None,
@@ -595,6 +599,13 @@ impl AppSettings {
             .as_ref()
             .map(|s| s.trim())
             .filter(|s| matches!(*s, "en" | "zh" | "zh-TW" | "ja"))
+            .map(|s| s.to_string());
+
+        self.usage_display_order = self
+            .usage_display_order
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| matches!(*s, "remaining-first" | "used-first"))
             .map(|s| s.to_string());
 
         if let Some(sync) = &mut self.webdav_sync {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -931,6 +931,22 @@ pub fn unify_codex_session_history() -> bool {
         .unify_codex_session_history
 }
 
+/// 用量是否采用“剩余优先”显示。
+///
+/// 设备级 UI 偏好：`None` / `"remaining-first"` 视为剩余优先（默认），
+/// `"used-first"` 为已用优先。与前端 `usageDisplayOrder` 默认值保持一致。
+pub fn usage_display_remaining_first() -> bool {
+    settings_store()
+        .read()
+        .unwrap_or_else(|e| {
+            log::warn!("设置锁已毒化，使用恢复值: {e}");
+            e.into_inner()
+        })
+        .usage_display_order
+        .as_deref()
+        != Some("used-first")
+}
+
 // ===== 当前供应商管理函数 =====
 
 /// 获取指定应用类型的当前供应商 ID（从本地 settings 读取）

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -46,6 +46,10 @@ pub struct TrayTexts {
     pub lightweight_mode: &'static str,
     pub quit: &'static str,
     pub _auto_label: &'static str,
+    /// 用量后缀里的“已用”标签
+    pub usage_used_label: &'static str,
+    /// 用量后缀里的“剩余”标签
+    pub usage_remaining_label: &'static str,
 }
 
 impl TrayTexts {
@@ -58,6 +62,8 @@ impl TrayTexts {
                 lightweight_mode: "Lightweight Mode",
                 quit: "Quit",
                 _auto_label: "Auto (Failover)",
+                usage_used_label: "Used",
+                usage_remaining_label: "Left",
             },
             "ja" => Self {
                 show_main: "メインウィンドウを開く",
@@ -66,6 +72,8 @@ impl TrayTexts {
                 lightweight_mode: "軽量モード",
                 quit: "終了",
                 _auto_label: "自動 (フェイルオーバー)",
+                usage_used_label: "使用",
+                usage_remaining_label: "残り",
             },
             "zh-TW" => Self {
                 show_main: "開啟主介面",
@@ -74,6 +82,8 @@ impl TrayTexts {
                 lightweight_mode: "輕量模式",
                 quit: "退出",
                 _auto_label: "自動 (故障轉移)",
+                usage_used_label: "已用",
+                usage_remaining_label: "剩餘",
             },
             _ => Self {
                 show_main: "打开主界面",
@@ -82,7 +92,46 @@ impl TrayTexts {
                 lightweight_mode: "轻量模式",
                 quit: "退出",
                 _auto_label: "自动 (故障转移)",
+                usage_used_label: "已用",
+                usage_remaining_label: "剩余",
             },
+        }
+    }
+}
+
+/// 用量后缀的展示参数：控制显示“已用%”还是“剩余%”及其标签。
+#[derive(Clone, Copy)]
+struct UsageLabelOpts {
+    remaining_first: bool,
+    used_label: &'static str,
+    remaining_label: &'static str,
+}
+
+impl UsageLabelOpts {
+    fn from_texts(texts: &TrayTexts, remaining_first: bool) -> Self {
+        Self {
+            remaining_first,
+            used_label: texts.usage_used_label,
+            remaining_label: texts.usage_remaining_label,
+        }
+    }
+
+    /// 根据利用率算出要显示的百分数（已用或剩余），并 clamp 到 0..=100。
+    fn display_pct(&self, utilization: f64) -> i64 {
+        let value = if self.remaining_first {
+            100.0 - utilization
+        } else {
+            utilization
+        };
+        value.clamp(0.0, 100.0).round() as i64
+    }
+
+    /// 当前模式的标签词（已用 / 剩余）。
+    fn label(&self) -> &'static str {
+        if self.remaining_first {
+            self.remaining_label
+        } else {
+            self.used_label
         }
     }
 }
@@ -140,6 +189,7 @@ fn emoji_for_utilization(pct: f64) -> &'static str {
 
 fn format_subscription_summary(
     quota: &crate::services::subscription::SubscriptionQuota,
+    opts: UsageLabelOpts,
 ) -> Option<String> {
     if !quota.success {
         return None;
@@ -157,6 +207,7 @@ fn format_subscription_summary(
     }
 
     // 色标取所有已选 tier 里最高的利用率——用户更关心"离上限多近"。
+    // 注意：emoji 始终按利用率计算，不受剩余/已用展示偏好影响。
     let worst = parts
         .iter()
         .map(|(_, u)| *u)
@@ -168,10 +219,10 @@ fn format_subscription_summary(
     let emoji = emoji_for_utilization(worst);
     let body = parts
         .iter()
-        .map(|(label, u)| format!("{label}{}%", u.round() as i64))
+        .map(|(label, u)| format!("{label}{}%", opts.display_pct(*u)))
         .collect::<Vec<_>>()
         .join(" ");
-    Some(format!("{emoji} {body}"))
+    Some(format!("{emoji} {} {body}", opts.label()))
 }
 
 fn labeled_tier_parts(entries: &[(&str, f64)]) -> Vec<(&'static str, f64)> {
@@ -197,7 +248,10 @@ fn tier_pct(data: &crate::provider::UsageData) -> Option<f64> {
     }
 }
 
-fn format_script_summary(result: &crate::provider::UsageResult) -> Option<String> {
+fn format_script_summary(
+    result: &crate::provider::UsageResult,
+    opts: UsageLabelOpts,
+) -> Option<String> {
     if !result.success {
         return None;
     }
@@ -210,6 +264,7 @@ fn format_script_summary(result: &crate::provider::UsageResult) -> Option<String
     // SubscriptionQuota 的每个 tier 扁平化为一条 UsageData（plan_name 承载
     // tier 名），所以这里按 plan_name 恢复托盘短标签。其余 usage 结果
     //（Copilot / balance / 自定义脚本）走 fallback。
+    // 注意：emoji 始终按利用率计算，展示值由 opts 决定（已用 / 剩余）。
     let entries: Vec<(&str, f64)> = data
         .iter()
         .filter_map(|d| Some((d.plan_name.as_deref()?, tier_pct(d)?)))
@@ -223,21 +278,22 @@ fn format_script_summary(result: &crate::provider::UsageResult) -> Option<String
         let emoji = emoji_for_utilization(worst);
         let body = parts
             .iter()
-            .map(|(label, u)| format!("{label}{}%", u.round() as i64))
+            .map(|(label, u)| format!("{label}{}%", opts.display_pct(*u)))
             .collect::<Vec<_>>()
             .join(" ");
-        return Some(format!("{emoji} {body}"));
+        return Some(format!("{emoji} {} {body}", opts.label()));
     }
 
     let first = data.first()?;
     let pct = tier_pct(first)?;
     let emoji = emoji_for_utilization(pct);
     let plan = first.plan_name.as_deref().unwrap_or("");
-    let rounded = pct.round() as i64;
+    let shown = opts.display_pct(pct);
+    let word = opts.label();
     if plan.is_empty() {
-        Some(format!("{} {}%", emoji, rounded))
+        Some(format!("{emoji} {word} {shown}%"))
     } else {
-        Some(format!("{} {} {}%", emoji, plan, rounded))
+        Some(format!("{emoji} {plan} {word} {shown}%"))
     }
 }
 
@@ -258,6 +314,7 @@ fn format_usage_suffix(
     app_type: &AppType,
     provider: &crate::provider::Provider,
     provider_id: &str,
+    opts: UsageLabelOpts,
 ) -> Option<String> {
     // 当前脚本是否启用：禁用/删除时不再沿用旧 UsageCache 结果，
     // 并顺手 invalidate，防止后续重建继续命中过期数据。
@@ -266,17 +323,16 @@ fn format_usage_suffix(
         && (!is_official_provider || provider_uses_official_subscription(provider));
     if can_use_script {
         // 脚本缓存优先（覆盖 Copilot/coding_plan/balance/自定义脚本），借用访问避免克隆整条 UsageResult。
-        if let Some(Some(s)) =
-            app_state
-                .usage_cache
-                .with_script(app_type, provider_id, format_script_summary)
+        if let Some(Some(s)) = app_state
+            .usage_cache
+            .with_script(app_type, provider_id, |r| format_script_summary(r, opts))
         {
             return Some(format!(" · {s}"));
         }
         if provider_uses_official_subscription(provider) {
             if let Some(Some(s)) = app_state
                 .usage_cache
-                .with_subscription(app_type, format_subscription_summary)
+                .with_subscription(app_type, |q| format_subscription_summary(q, opts))
             {
                 return Some(format!(" · {s}"));
             }
@@ -491,6 +547,10 @@ pub fn create_tray_menu(
 ) -> Result<Menu<tauri::Wry>, AppError> {
     let app_settings = crate::settings::get_settings();
     let tray_texts = TrayTexts::from_language(app_settings.language.as_deref().unwrap_or("zh"));
+    let usage_opts = UsageLabelOpts::from_texts(
+        &tray_texts,
+        crate::settings::usage_display_remaining_first(),
+    );
 
     // Get visible apps setting, default to all visible
     let visible_apps = app_settings.visible_apps.unwrap_or_default();
@@ -544,8 +604,14 @@ pub fn create_tray_menu(
             let current_provider = providers.get(&current_id);
             let submenu_label = match current_provider {
                 Some(p) => {
-                    let suffix = format_usage_suffix(app_state, &section.app_type, p, &current_id)
-                        .unwrap_or_default();
+                    let suffix = format_usage_suffix(
+                        app_state,
+                        &section.app_type,
+                        p,
+                        &current_id,
+                        usage_opts,
+                    )
+                    .unwrap_or_default();
                     format!("{} · {}{}", section.header_label, p.name, suffix)
                 }
                 None => section.header_label.to_string(),
@@ -633,6 +699,12 @@ fn update_tray_usage_labels(app: &tauri::AppHandle) {
     let Some(app_state) = app.try_state::<AppState>() else {
         return;
     };
+    let app_settings = crate::settings::get_settings();
+    let tray_texts = TrayTexts::from_language(app_settings.language.as_deref().unwrap_or("zh"));
+    let usage_opts = UsageLabelOpts::from_texts(
+        &tray_texts,
+        crate::settings::usage_display_remaining_first(),
+    );
     let handles = match TRAY_SECTION_SUBMENUS.lock() {
         Ok(g) => g,
         Err(poisoned) => poisoned.into_inner(),
@@ -653,8 +725,14 @@ fn update_tray_usage_labels(app: &tauri::AppHandle) {
         let Some(provider) = providers.get(&current_id) else {
             continue;
         };
-        let suffix = format_usage_suffix(&app_state, &section.app_type, provider, &current_id)
-            .unwrap_or_default();
+        let suffix = format_usage_suffix(
+            &app_state,
+            &section.app_type,
+            provider,
+            &current_id,
+            usage_opts,
+        )
+        .unwrap_or_default();
         let new_label = format!("{} · {}{}", section.header_label, provider.name, suffix);
         if let Err(e) = submenu.set_text(&new_label) {
             log::debug!("[Tray] 更新{}子菜单标题失败: {e}", section.log_name);
@@ -874,7 +952,7 @@ pub(crate) async fn refresh_all_usage_in_tray(app: &tauri::AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_script_summary, format_subscription_summary, TRAY_ID};
+    use super::{format_script_summary, format_subscription_summary, UsageLabelOpts, TRAY_ID};
     use crate::provider::{UsageData, UsageResult};
     use crate::services::subscription::{
         CredentialStatus, QuotaTier, SubscriptionQuota, TIER_FIVE_HOUR, TIER_GEMINI_FLASH,
@@ -886,6 +964,22 @@ mod tests {
     fn tray_id_is_unique_to_app() {
         assert_eq!(TRAY_ID, "cc-switch");
         assert_ne!(TRAY_ID, "main");
+    }
+
+    fn used_opts() -> UsageLabelOpts {
+        UsageLabelOpts {
+            remaining_first: false,
+            used_label: "U",
+            remaining_label: "L",
+        }
+    }
+
+    fn remaining_opts() -> UsageLabelOpts {
+        UsageLabelOpts {
+            remaining_first: true,
+            used_label: "U",
+            remaining_label: "L",
+        }
     }
 
     fn make_quota(tool: &str, success: bool, tiers: Vec<QuotaTier>) -> SubscriptionQuota {
@@ -918,7 +1012,7 @@ mod tests {
             true,
             vec![tier("five_hour", 9.0), tier("seven_day", 27.0)],
         );
-        let s = format_subscription_summary(&quota).expect("should format");
+        let s = format_subscription_summary(&quota, used_opts()).expect("should format");
         assert!(s.contains("h9%"), "expected h9% in {s}");
         assert!(s.contains("w27%"), "expected w27% in {s}");
     }
@@ -930,7 +1024,7 @@ mod tests {
             true,
             vec![tier("gemini_pro", 15.0), tier("gemini_flash", 42.0)],
         );
-        let s = format_subscription_summary(&quota).expect("should format");
+        let s = format_subscription_summary(&quota, used_opts()).expect("should format");
         assert!(s.contains("p15%"), "expected p15% in {s}");
         assert!(s.contains("f42%"), "expected f42% in {s}");
     }
@@ -946,7 +1040,7 @@ mod tests {
                 tier("gemini_flash_lite", 80.0),
             ],
         );
-        let s = format_subscription_summary(&quota).expect("should format");
+        let s = format_subscription_summary(&quota, used_opts()).expect("should format");
         assert!(s.contains("p5%"), "expected p5% in {s}");
         assert!(s.contains("f42%"), "expected f42% in {s}");
         assert!(s.contains("l80%"), "expected l80% in {s}");
@@ -957,7 +1051,7 @@ mod tests {
         // flash_lite 如果是 API 返回的唯一 tier，仍应显示（避免前端 footer 能看到、
         // 托盘空白的不对称）。
         let quota = make_quota("gemini", true, vec![tier("gemini_flash_lite", 80.0)]);
-        let s = format_subscription_summary(&quota).expect("should format");
+        let s = format_subscription_summary(&quota, used_opts()).expect("should format");
         assert!(s.contains("l80%"), "expected l80% in {s}");
     }
 
@@ -973,7 +1067,7 @@ mod tests {
                 tier("gemini_flash_lite", 95.0),
             ],
         );
-        let s = format_subscription_summary(&quota).unwrap();
+        let s = format_subscription_summary(&quota, used_opts()).unwrap();
         assert!(
             s.starts_with("\u{1F534}"),
             "expected red emoji (lite worst) in {s}"
@@ -988,7 +1082,7 @@ mod tests {
             true,
             vec![tier("five_hour", 10.0), tier("seven_day", 95.0)],
         );
-        let s = format_subscription_summary(&quota).unwrap();
+        let s = format_subscription_summary(&quota, used_opts()).unwrap();
         assert!(s.starts_with("\u{1F534}"), "expected red emoji in {s}");
     }
 
@@ -1003,7 +1097,7 @@ mod tests {
                 tier(TIER_SEVEN_DAY_SONNET, 95.0),
             ],
         );
-        let s = format_subscription_summary(&quota).unwrap();
+        let s = format_subscription_summary(&quota, used_opts()).unwrap();
         assert!(s.contains("w95%"), "expected w95% in {s}");
         assert!(s.starts_with("\u{1F534}"), "expected red emoji in {s}");
     }
@@ -1011,20 +1105,20 @@ mod tests {
     #[test]
     fn failure_quota_returns_none() {
         let quota = make_quota("claude", false, vec![tier("five_hour", 50.0)]);
-        assert!(format_subscription_summary(&quota).is_none());
+        assert!(format_subscription_summary(&quota, used_opts()).is_none());
     }
 
     #[test]
     fn unknown_tiers_return_none() {
         let quota = make_quota("claude", true, vec![tier("one_hour", 80.0)]);
-        assert!(format_subscription_summary(&quota).is_none());
+        assert!(format_subscription_summary(&quota, used_opts()).is_none());
     }
 
     #[test]
     fn gemini_without_any_known_tiers_returns_none() {
         // 完全没有 pro/flash/flash_lite 三种 tier 的退化响应 → None。
         let quota = make_quota("gemini", true, vec![tier("some_future_tier", 80.0)]);
-        assert!(format_subscription_summary(&quota).is_none());
+        assert!(format_subscription_summary(&quota, used_opts()).is_none());
     }
 
     fn usage_data(plan_name: Option<&str>, utilization: f64) -> UsageData {
@@ -1057,7 +1151,7 @@ mod tests {
                 usage_data(Some(TIER_WEEKLY_LIMIT), 80.0),
             ],
         );
-        let s = format_script_summary(&r).expect("should format");
+        let s = format_script_summary(&r, used_opts()).expect("should format");
         assert!(s.contains("h12%"), "expected h12% in {s}");
         assert!(s.contains("w80%"), "expected w80% in {s}");
         assert!(s.starts_with("\u{1F7E0}"), "expected orange emoji in {s}");
@@ -1072,14 +1166,14 @@ mod tests {
                 usage_data(Some(TIER_WEEKLY_LIMIT), 95.0),
             ],
         );
-        let s = format_script_summary(&r).unwrap();
+        let s = format_script_summary(&r, used_opts()).unwrap();
         assert!(s.starts_with("\u{1F534}"), "expected red emoji in {s}");
     }
 
     #[test]
     fn script_summary_token_plan_five_hour_only() {
         let r = usage_result(true, vec![usage_data(Some(TIER_FIVE_HOUR), 8.0)]);
-        let s = format_script_summary(&r).expect("should format");
+        let s = format_script_summary(&r, used_opts()).expect("should format");
         assert!(s.contains("h8%"), "expected h8% in {s}");
         assert!(
             !s.contains("plan_name"),
@@ -1090,7 +1184,7 @@ mod tests {
     #[test]
     fn script_summary_token_plan_weekly_only() {
         let r = usage_result(true, vec![usage_data(Some(TIER_WEEKLY_LIMIT), 50.0)]);
-        let s = format_script_summary(&r).expect("should format");
+        let s = format_script_summary(&r, used_opts()).expect("should format");
         assert!(s.contains("w50%"), "expected w50% in {s}");
     }
 
@@ -1103,7 +1197,7 @@ mod tests {
                 usage_data(Some(TIER_SEVEN_DAY), 80.0),
             ],
         );
-        let s = format_script_summary(&r).expect("should format");
+        let s = format_script_summary(&r, used_opts()).expect("should format");
         assert!(s.contains("h12%"), "expected h12% in {s}");
         assert!(s.contains("w80%"), "expected w80% in {s}");
         assert!(
@@ -1122,7 +1216,7 @@ mod tests {
                 usage_data(Some(TIER_SEVEN_DAY_SONNET), 95.0),
             ],
         );
-        let s = format_script_summary(&r).unwrap();
+        let s = format_script_summary(&r, used_opts()).unwrap();
         assert!(s.contains("w95%"), "expected w95% in {s}");
         assert!(s.starts_with("\u{1F534}"), "expected red emoji in {s}");
     }
@@ -1137,7 +1231,7 @@ mod tests {
                 usage_data(Some(TIER_GEMINI_FLASH_LITE), 80.0),
             ],
         );
-        let s = format_script_summary(&r).expect("should format");
+        let s = format_script_summary(&r, used_opts()).expect("should format");
         assert!(s.contains("p15%"), "expected p15% in {s}");
         assert!(s.contains("f42%"), "expected f42% in {s}");
         assert!(s.contains("l80%"), "expected l80% in {s}");
@@ -1150,7 +1244,7 @@ mod tests {
     #[test]
     fn script_summary_single_bucket_fallback_with_plan_name() {
         let r = usage_result(true, vec![usage_data(Some("Copilot Pro"), 40.0)]);
-        let s = format_script_summary(&r).expect("should format");
+        let s = format_script_summary(&r, used_opts()).expect("should format");
         assert!(s.contains("Copilot Pro"), "expected plan name in {s}");
         assert!(s.contains("40%"), "expected 40% in {s}");
         assert!(
@@ -1162,19 +1256,64 @@ mod tests {
     #[test]
     fn script_summary_single_bucket_fallback_without_plan_name() {
         let r = usage_result(true, vec![usage_data(None, 15.0)]);
-        let s = format_script_summary(&r).expect("should format");
-        assert_eq!(s, "\u{1F7E2} 15%", "expected emoji + pct only, got {s}");
+        let s = format_script_summary(&r, used_opts()).expect("should format");
+        assert_eq!(
+            s, "\u{1F7E2} U 15%",
+            "expected emoji + used label + pct, got {s}"
+        );
     }
 
     #[test]
     fn script_summary_failure_returns_none() {
         let r = usage_result(false, vec![usage_data(Some(TIER_FIVE_HOUR), 12.0)]);
-        assert!(format_script_summary(&r).is_none());
+        assert!(format_script_summary(&r, used_opts()).is_none());
     }
 
     #[test]
     fn script_summary_empty_data_returns_none() {
         let r = usage_result(true, vec![]);
-        assert!(format_script_summary(&r).is_none());
+        assert!(format_script_summary(&r, used_opts()).is_none());
+    }
+
+    // ===== remaining-first 展示模式 =====
+
+    #[test]
+    fn subscription_summary_remaining_first_shows_complement() {
+        // 剩余优先：展示值 = 100 - 利用率，带“剩余”标签。
+        let quota = make_quota(
+            "claude",
+            true,
+            vec![tier("five_hour", 9.0), tier("seven_day", 27.0)],
+        );
+        let s = format_subscription_summary(&quota, remaining_opts()).expect("should format");
+        assert!(s.contains("h91%"), "expected remaining h91% in {s}");
+        assert!(s.contains("w73%"), "expected remaining w73% in {s}");
+        assert!(s.contains("L"), "expected remaining label in {s}");
+    }
+
+    #[test]
+    fn subscription_summary_remaining_first_keeps_utilization_emoji() {
+        // 即使显示剩余，色标仍按利用率（95%）→ 红色。
+        let quota = make_quota(
+            "claude",
+            true,
+            vec![tier("five_hour", 10.0), tier("seven_day", 95.0)],
+        );
+        let s = format_subscription_summary(&quota, remaining_opts()).unwrap();
+        assert!(
+            s.starts_with("\u{1F534}"),
+            "emoji must reflect utilization, not remaining: {s}"
+        );
+        assert!(s.contains("w5%"), "expected remaining w5% in {s}");
+    }
+
+    #[test]
+    fn script_summary_remaining_first_fallback_without_plan_name() {
+        let r = usage_result(true, vec![usage_data(None, 15.0)]);
+        let s = format_script_summary(&r, remaining_opts()).expect("should format");
+        assert_eq!(
+            s, "\u{1F7E2} L 85%",
+            "remaining-first should show complement with remaining label, got {s}"
+        );
     }
 }

--- a/src/components/SubscriptionQuotaFooter.tsx
+++ b/src/components/SubscriptionQuotaFooter.tsx
@@ -3,7 +3,16 @@ import { RefreshCw, AlertCircle, Clock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AppId } from "@/lib/api";
 import { useSubscriptionQuota } from "@/lib/query/subscription";
+import { useSettingsQuery } from "@/lib/query/queries";
 import type { QuotaTier, SubscriptionQuota } from "@/types/subscription";
+
+type UsageDisplayOrder = "remaining-first" | "used-first";
+
+/** 根据展示偏好返回要显示的百分数（已用或剩余），clamp 到 0..=100。 */
+function displayPct(utilization: number, order: UsageDisplayOrder): number {
+  const value = order === "used-first" ? utilization : 100 - utilization;
+  return Math.round(Math.min(100, Math.max(0, value)));
+}
 
 interface SubscriptionQuotaFooterProps {
   appId: AppId;
@@ -105,6 +114,9 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
   inline = false,
 }) => {
   const { t } = useTranslation();
+  const { data: settings } = useSettingsQuery();
+  const displayOrder: UsageDisplayOrder =
+    settings?.usageDisplayOrder ?? "remaining-first";
 
   // 定期更新相对时间显示
   const [now, setNow] = React.useState(Date.now());
@@ -241,7 +253,12 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
           {tiers
             .filter((tier) => !HIDDEN_INLINE_TIERS.has(tier.name))
             .map((tier) => (
-              <TierBadge key={tier.name} tier={tier} t={t} />
+              <TierBadge
+                key={tier.name}
+                tier={tier}
+                t={t}
+                displayOrder={displayOrder}
+              />
             ))}
         </div>
       </div>
@@ -275,7 +292,12 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
 
       <div className="flex flex-col gap-2">
         {tiers.map((tier) => (
-          <TierBar key={tier.name} tier={tier} t={t} />
+          <TierBar
+            key={tier.name}
+            tier={tier}
+            t={t}
+            displayOrder={displayOrder}
+          />
         ))}
       </div>
 
@@ -304,21 +326,30 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
 export const TierBadge: React.FC<{
   tier: QuotaTier;
   t: (key: string, options?: Record<string, unknown>) => string;
-}> = ({ tier, t }) => {
+  displayOrder?: UsageDisplayOrder;
+}> = ({ tier, t, displayOrder = "remaining-first" }) => {
   const label = TIER_I18N_KEYS[tier.name]
     ? t(TIER_I18N_KEYS[tier.name])
     : tier.name;
   const countdown = countdownStr(tier.resetsAt);
 
   const hasUsd = tier.usedValueUsd != null && tier.maxValueUsd != null;
+  // 数字跟随偏好（已用/剩余），但颜色始终按利用率（离上限多近）。
+  const word =
+    displayOrder === "used-first"
+      ? t("subscription.usedShort")
+      : t("subscription.remainingShort");
 
   return (
     <div className="flex items-center gap-0.5">
       <span className="text-gray-500 dark:text-gray-400">{label}:</span>
+      <span className="text-gray-500 dark:text-gray-400">{word}</span>
       <span
         className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
       >
-        {t("subscription.utilization", { value: Math.round(tier.utilization) })}
+        {t("subscription.utilization", {
+          value: displayPct(tier.utilization, displayOrder),
+        })}
       </span>
       {hasUsd && (
         <span className="text-muted-foreground/60">
@@ -339,11 +370,17 @@ export const TierBadge: React.FC<{
 const TierBar: React.FC<{
   tier: QuotaTier;
   t: (key: string, options?: Record<string, unknown>) => string;
-}> = ({ tier, t }) => {
+  displayOrder?: UsageDisplayOrder;
+}> = ({ tier, t, displayOrder = "remaining-first" }) => {
   const label = TIER_I18N_KEYS[tier.name]
     ? t(TIER_I18N_KEYS[tier.name])
     : tier.name;
   const resetText = formatResetTime(tier.resetsAt, t);
+  // 进度条始终表示已用占比；右侧数字跟随展示偏好。
+  const word =
+    displayOrder === "used-first"
+      ? t("subscription.usedShort")
+      : t("subscription.remainingShort");
 
   return (
     <div className="flex items-center gap-3 text-xs">
@@ -375,7 +412,7 @@ const TierBar: React.FC<{
         <span
           className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
         >
-          {Math.round(tier.utilization)}%
+          {word} {displayPct(tier.utilization, displayOrder)}%
         </span>
         {resetText && (
           <span

--- a/src/components/UsageFooter.tsx
+++ b/src/components/UsageFooter.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { RefreshCw, AlertCircle, Clock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { type AppId } from "@/lib/api";
-import { useUsageQuery } from "@/lib/query/queries";
+import { useUsageQuery, useSettingsQuery } from "@/lib/query/queries";
 import { UsageData, Provider } from "@/types";
 import { TierBadge } from "@/components/SubscriptionQuotaFooter";
 import type { QuotaTier } from "@/types/subscription";
@@ -52,6 +52,8 @@ const UsageFooter: React.FC<UsageFooterProps> = ({
   inline = false,
 }) => {
   const { t } = useTranslation();
+  const { data: settings } = useSettingsQuery();
+  const displayOrder = settings?.usageDisplayOrder ?? "remaining-first";
   const isTokenPlan =
     provider.meta?.usage_script?.templateType === "token_plan";
 
@@ -215,40 +217,46 @@ const UsageFooter: React.FC<UsageFooterProps> = ({
           </button>
         </div>
 
-        {/* 第二行：用量和剩余 */}
+        {/* 第二行：用量和剩余（顺序由 usageDisplayOrder 控制） */}
         <div className="flex items-center gap-2">
-          {/* 已用 */}
-          {firstUsage.used !== undefined && (
-            <div className="flex items-center gap-0.5">
-              <span className="text-gray-500 dark:text-gray-400">
-                {t("usage.used")}
-              </span>
-              <span className="tabular-nums text-gray-600 dark:text-gray-400 font-medium">
-                {firstUsage.used.toFixed(2)}
-              </span>
-            </div>
-          )}
+          {(() => {
+            const usedBlock =
+              firstUsage.used !== undefined ? (
+                <div key="used" className="flex items-center gap-0.5">
+                  <span className="text-gray-500 dark:text-gray-400">
+                    {t("usage.used")}
+                  </span>
+                  <span className="tabular-nums text-gray-600 dark:text-gray-400 font-medium">
+                    {firstUsage.used.toFixed(2)}
+                  </span>
+                </div>
+              ) : null;
 
-          {/* 剩余 */}
-          {firstUsage.remaining !== undefined && (
-            <div className="flex items-center gap-0.5">
-              <span className="text-gray-500 dark:text-gray-400">
-                {t("usage.remaining")}
-              </span>
-              <span
-                className={`font-semibold tabular-nums ${
-                  isExpired
-                    ? "text-red-500 dark:text-red-400"
-                    : firstUsage.remaining <
-                        (firstUsage.total || firstUsage.remaining) * 0.1
-                      ? "text-orange-500 dark:text-orange-400"
-                      : "text-green-600 dark:text-green-400"
-                }`}
-              >
-                {firstUsage.remaining.toFixed(2)}
-              </span>
-            </div>
-          )}
+            const remainingBlock =
+              firstUsage.remaining !== undefined ? (
+                <div key="remaining" className="flex items-center gap-0.5">
+                  <span className="text-gray-500 dark:text-gray-400">
+                    {t("usage.remaining")}
+                  </span>
+                  <span
+                    className={`font-semibold tabular-nums ${
+                      isExpired
+                        ? "text-red-500 dark:text-red-400"
+                        : firstUsage.remaining <
+                            (firstUsage.total || firstUsage.remaining) * 0.1
+                          ? "text-orange-500 dark:text-orange-400"
+                          : "text-green-600 dark:text-green-400"
+                    }`}
+                  >
+                    {firstUsage.remaining.toFixed(2)}
+                  </span>
+                </div>
+              ) : null;
+
+            return displayOrder === "used-first"
+              ? [usedBlock, remainingBlock]
+              : [remainingBlock, usedBlock];
+          })()}
 
           {/* 单位 */}
           {firstUsage.unit && (
@@ -300,7 +308,11 @@ const UsageFooter: React.FC<UsageFooterProps> = ({
       {/* 套餐列表 */}
       <div className="flex flex-col gap-3">
         {usageDataList.map((usageData, index) => (
-          <UsagePlanItem key={index} data={usageData} />
+          <UsagePlanItem
+            key={index}
+            data={usageData}
+            displayOrder={displayOrder}
+          />
         ))}
       </div>
     </div>
@@ -310,7 +322,10 @@ const UsageFooter: React.FC<UsageFooterProps> = ({
 // ── 通用用量组件 ────────────────────────────────────────────
 
 // 单个套餐数据展示组件
-const UsagePlanItem: React.FC<{ data: UsageData }> = ({ data }) => {
+const UsagePlanItem: React.FC<{
+  data: UsageData;
+  displayOrder: "remaining-first" | "used-first";
+}> = ({ data, displayOrder }) => {
   const { t } = useTranslation();
   const {
     planName,
@@ -365,56 +380,73 @@ const UsagePlanItem: React.FC<{ data: UsageData }> = ({ data }) => {
         )}
       </div>
 
-      {/* 用量信息：45% */}
+      {/* 用量信息：45%（总额始终在前，已用/剩余顺序由 usageDisplayOrder 控制） */}
       <div
         className="flex items-center justify-end gap-2 text-xs flex-shrink-0"
         style={{ width: "45%" }}
       >
-        {/* 总额度 */}
-        {total !== undefined && (
-          <>
-            <span className="text-gray-500 dark:text-gray-400">
-              {t("usage.total")}
-            </span>
-            <span className="tabular-nums text-gray-600 dark:text-gray-400">
-              {total === -1 ? "∞" : total.toFixed(2)}
-            </span>
-            <span className="text-gray-400 dark:text-gray-600">|</span>
-          </>
-        )}
+        {(() => {
+          const totalBlock =
+            total !== undefined ? (
+              <React.Fragment key="total">
+                <span className="text-gray-500 dark:text-gray-400">
+                  {t("usage.total")}
+                </span>
+                <span className="tabular-nums text-gray-600 dark:text-gray-400">
+                  {total === -1 ? "∞" : total.toFixed(2)}
+                </span>
+              </React.Fragment>
+            ) : null;
 
-        {/* 已用额度 */}
-        {used !== undefined && (
-          <>
-            <span className="text-gray-500 dark:text-gray-400">
-              {t("usage.used")}
-            </span>
-            <span className="tabular-nums text-gray-600 dark:text-gray-400">
-              {used.toFixed(2)}
-            </span>
-            <span className="text-gray-400 dark:text-gray-600">|</span>
-          </>
-        )}
+          const usedBlock =
+            used !== undefined ? (
+              <React.Fragment key="used">
+                <span className="text-gray-500 dark:text-gray-400">
+                  {t("usage.used")}
+                </span>
+                <span className="tabular-nums text-gray-600 dark:text-gray-400">
+                  {used.toFixed(2)}
+                </span>
+              </React.Fragment>
+            ) : null;
 
-        {/* 剩余额度 - 突出显示 */}
-        {remaining !== undefined && (
-          <>
-            <span className="text-gray-500 dark:text-gray-400">
-              {t("usage.remaining")}
-            </span>
-            <span
-              className={`font-semibold tabular-nums ${
-                isExpired
-                  ? "text-red-500 dark:text-red-400"
-                  : remaining < (total || remaining) * 0.1
-                    ? "text-orange-500 dark:text-orange-400"
-                    : "text-green-600 dark:text-green-400"
-              }`}
-            >
-              {remaining.toFixed(2)}
-            </span>
-          </>
-        )}
+          const remainingBlock =
+            remaining !== undefined ? (
+              <React.Fragment key="remaining">
+                <span className="text-gray-500 dark:text-gray-400">
+                  {t("usage.remaining")}
+                </span>
+                <span
+                  className={`font-semibold tabular-nums ${
+                    isExpired
+                      ? "text-red-500 dark:text-red-400"
+                      : remaining < (total || remaining) * 0.1
+                        ? "text-orange-500 dark:text-orange-400"
+                        : "text-green-600 dark:text-green-400"
+                  }`}
+                >
+                  {remaining.toFixed(2)}
+                </span>
+              </React.Fragment>
+            ) : null;
+
+          const ordered = [
+            totalBlock,
+            ...(displayOrder === "used-first"
+              ? [usedBlock, remainingBlock]
+              : [remainingBlock, usedBlock]),
+          ].filter((block): block is React.ReactElement => block !== null);
+
+          // 使用分隔符连接各指标块
+          return ordered.map((block, index) => (
+            <React.Fragment key={index}>
+              {index > 0 && (
+                <span className="text-gray-400 dark:text-gray-600">|</span>
+              )}
+              {block}
+            </React.Fragment>
+          ));
+        })()}
 
         {unit && (
           <span className="text-gray-500 dark:text-gray-400">{unit}</span>

--- a/src/components/UsageFooter.tsx
+++ b/src/components/UsageFooter.tsx
@@ -176,7 +176,12 @@ const UsageFooter: React.FC<UsageFooterProps> = ({
                   </span>
                 )}
                 {tiers.map((tier, index) => (
-                  <TierBadge key={index} tier={tier} t={t} />
+                  <TierBadge
+                    key={index}
+                    tier={tier}
+                    t={t}
+                    displayOrder={displayOrder}
+                  />
                 ))}
               </>
             );

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -515,11 +515,15 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
         if (result.success && result.data && result.data.length > 0) {
           const summary = result.data
             .map((d) =>
-              formatUsageDataSummary(d, {
-                invalid: t("usage.invalid"),
-                remaining: t("usage.remaining"),
-                used: t("usage.used"),
-              }),
+              formatUsageDataSummary(
+                d,
+                {
+                  invalid: t("usage.invalid"),
+                  remaining: t("usage.remaining"),
+                  used: t("usage.used"),
+                },
+                settingsData?.usageDisplayOrder,
+              ),
             )
             .join(", ");
           toast.success(`${t("usageScript.testSuccess")}${summary}`, {
@@ -623,11 +627,15 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
       if (result.success && result.data && result.data.length > 0) {
         const summary = result.data
           .map((plan: UsageData) =>
-            formatUsageDataSummary(plan, {
-              invalid: t("usage.invalid"),
-              remaining: t("usage.remaining"),
-              used: t("usage.used"),
-            }),
+            formatUsageDataSummary(
+              plan,
+              {
+                invalid: t("usage.invalid"),
+                remaining: t("usage.remaining"),
+                used: t("usage.used"),
+              },
+              settingsData?.usageDisplayOrder,
+            ),
           )
           .join(", ");
         toast.success(`${t("usageScript.testSuccess")}${summary}`, {

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -36,6 +36,7 @@ import { Button } from "@/components/ui/button";
 import { settingsApi } from "@/lib/api";
 import { LanguageSettings } from "@/components/settings/LanguageSettings";
 import { ThemeSettings } from "@/components/settings/ThemeSettings";
+import { UsageDisplaySettings } from "@/components/settings/UsageDisplaySettings";
 import { WindowSettings } from "@/components/settings/WindowSettings";
 import { AppVisibilitySettings } from "@/components/settings/AppVisibilitySettings";
 import { SkillStorageLocationSettings } from "@/components/settings/SkillStorageLocationSettings";
@@ -257,6 +258,12 @@ export function SettingsPage({
                       onChange={(lang) => handleAutoSave({ language: lang })}
                     />
                     <ThemeSettings />
+                    <UsageDisplaySettings
+                      value={settings.usageDisplayOrder ?? "remaining-first"}
+                      onChange={(order) =>
+                        handleAutoSave({ usageDisplayOrder: order })
+                      }
+                    />
                     <AppVisibilitySettings
                       settings={settings}
                       onChange={handleAutoSave}

--- a/src/components/settings/UsageDisplaySettings.tsx
+++ b/src/components/settings/UsageDisplaySettings.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useTranslation } from "react-i18next";
+
+type UsageDisplayOrder = "remaining-first" | "used-first";
+
+interface UsageDisplaySettingsProps {
+  value: UsageDisplayOrder;
+  onChange: (value: UsageDisplayOrder) => void;
+}
+
+export function UsageDisplaySettings({
+  value,
+  onChange,
+}: UsageDisplaySettingsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <section className="space-y-2">
+      <header className="space-y-1">
+        <h3 className="text-sm font-medium">
+          {t("settings.usageDisplayOrder")}
+        </h3>
+        <p className="text-xs text-muted-foreground">
+          {t("settings.usageDisplayOrderHint")}
+        </p>
+      </header>
+      <div className="inline-flex gap-1 rounded-md border border-border-default bg-background p-1">
+        <OrderButton
+          active={value === "remaining-first"}
+          onClick={() => onChange("remaining-first")}
+        >
+          {t("settings.usageDisplayRemainingFirst")}
+        </OrderButton>
+        <OrderButton
+          active={value === "used-first"}
+          onClick={() => onChange("used-first")}
+        >
+          {t("settings.usageDisplayUsedFirst")}
+        </OrderButton>
+      </div>
+    </section>
+  );
+}
+
+interface OrderButtonProps {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function OrderButton({ active, onClick, children }: OrderButtonProps) {
+  return (
+    <Button
+      type="button"
+      onClick={onClick}
+      size="sm"
+      variant={active ? "default" : "ghost"}
+      className={cn(
+        "min-w-[120px]",
+        active
+          ? "shadow-sm"
+          : "text-muted-foreground hover:text-foreground hover:bg-muted",
+      )}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2866,6 +2866,8 @@
     "expired": "Session expired",
     "expiredHint": "Run the {{tool}} command to refresh your login",
     "queryFailed": "Query failed",
-    "refresh": "Refresh"
+    "refresh": "Refresh",
+    "usedShort": "Used",
+    "remainingShort": "Left"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -868,7 +868,11 @@
       "defaultCostMultiplierRequired": "Default multiplier is required",
       "defaultCostMultiplierInvalid": "Invalid multiplier format"
     },
-    "saveFailedGeneric": "Save failed, please try again"
+    "saveFailedGeneric": "Save failed, please try again",
+    "usageDisplayOrder": "Usage Display Order",
+    "usageDisplayOrderHint": "Choose whether to show remaining quota first or used quota first in usage displays.",
+    "usageDisplayRemainingFirst": "Remaining First",
+    "usageDisplayUsedFirst": "Used First"
   },
   "apps": {
     "claude": "Claude",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -868,7 +868,11 @@
       "defaultCostMultiplierRequired": "デフォルト倍率は必須です",
       "defaultCostMultiplierInvalid": "デフォルト倍率の形式が正しくありません"
     },
-    "saveFailedGeneric": "保存に失敗しました。もう一度お試しください"
+    "saveFailedGeneric": "保存に失敗しました。もう一度お試しください",
+    "usageDisplayOrder": "使用量表示順序",
+    "usageDisplayOrderHint": "使用量表示で残量を先に表示するか、使用量を先に表示するかを選択します。",
+    "usageDisplayRemainingFirst": "残量優先",
+    "usageDisplayUsedFirst": "使用量優先"
   },
   "apps": {
     "claude": "Claude",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2866,6 +2866,8 @@
     "expired": "セッション期限切れ",
     "expiredHint": "{{tool}}コマンドを実行してログインを更新してください",
     "queryFailed": "クエリに失敗しました",
-    "refresh": "更新"
+    "refresh": "更新",
+    "usedShort": "使用",
+    "remainingShort": "残り"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -839,7 +839,11 @@
       "defaultCostMultiplierRequired": "預設倍率不能為空",
       "defaultCostMultiplierInvalid": "預設倍率格式不正確"
     },
-    "saveFailedGeneric": "儲存失敗，請重試"
+    "saveFailedGeneric": "儲存失敗，請重試",
+    "usageDisplayOrder": "用量顯示順序",
+    "usageDisplayOrderHint": "選擇在用量顯示中優先顯示剩餘額度還是已用額度。",
+    "usageDisplayRemainingFirst": "剩餘優先",
+    "usageDisplayUsedFirst": "已用優先"
   },
   "apps": {
     "claude": "Claude",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2838,6 +2838,8 @@
     "expired": "工作階段已過期",
     "expiredHint": "請執行 {{tool}} 命令重新整理登入",
     "queryFailed": "查詢失敗",
-    "refresh": "重新整理"
+    "refresh": "重新整理",
+    "usedShort": "已用",
+    "remainingShort": "剩餘"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -868,7 +868,11 @@
       "defaultCostMultiplierRequired": "默认倍率不能为空",
       "defaultCostMultiplierInvalid": "默认倍率格式不正确"
     },
-    "saveFailedGeneric": "保存失败，请重试"
+    "saveFailedGeneric": "保存失败，请重试",
+    "usageDisplayOrder": "用量显示顺序",
+    "usageDisplayOrderHint": "选择在用量显示中优先显示剩余额度还是已用额度。",
+    "usageDisplayRemainingFirst": "剩余优先",
+    "usageDisplayUsedFirst": "已用优先"
   },
   "apps": {
     "claude": "Claude",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2866,6 +2866,8 @@
     "expired": "会话已过期",
     "expiredHint": "请运行 {{tool}} 命令刷新登录",
     "queryFailed": "查询失败",
-    "refresh": "刷新"
+    "refresh": "刷新",
+    "usedShort": "已用",
+    "remainingShort": "剩余"
   }
 }

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -18,6 +18,7 @@ export const settingsSchema = z.object({
   preserveCodexOfficialAuthOnSwitch: z.boolean().optional(),
   unifyCodexSessionHistory: z.boolean().optional(),
   language: z.enum(["en", "zh", "zh-TW", "ja"]).optional(),
+  usageDisplayOrder: z.enum(["remaining-first", "used-first"]).optional(),
 
   // 设备级目录覆盖
   claudeConfigDir: directorySchema.nullable().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -362,6 +362,8 @@ export interface Settings {
   commonConfigConfirmed?: boolean;
   // 首选语言（可选，默认中文）
   language?: "en" | "zh" | "zh-TW" | "ja";
+  // 用量显示顺序（可选，默认剩余优先）
+  usageDisplayOrder?: "remaining-first" | "used-first";
 
   // 主页面显示的应用（默认全部显示）
   visibleApps?: VisibleApps;

--- a/src/utils/usageDisplay.ts
+++ b/src/utils/usageDisplay.ts
@@ -1,5 +1,7 @@
 import type { UsageData } from "@/types";
 
+export type UsageDisplayOrder = "remaining-first" | "used-first";
+
 interface UsageSummaryLabels {
   invalid: string;
   remaining: string;
@@ -22,6 +24,17 @@ function formatValue(value: number, unit?: string): string {
 
 function isNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+function formatRemaining(
+  data: UsageData,
+  labels: UsageSummaryLabels,
+): string | null {
+  if (!isNumber(data.remaining)) {
+    return null;
+  }
+
+  return `${labels.remaining} ${formatValue(data.remaining, data.unit)}`;
 }
 
 function formatUsed(
@@ -48,6 +61,7 @@ function formatUsed(
 export function formatUsageDataSummary(
   data: UsageData,
   labels: UsageSummaryLabels,
+  displayOrder?: UsageDisplayOrder,
 ): string {
   const planPrefix = data.planName ? `[${data.planName}] ` : "";
 
@@ -55,11 +69,11 @@ export function formatUsageDataSummary(
     return `${planPrefix}${data.invalidMessage || labels.invalid}`;
   }
 
+  const order = displayOrder ?? "remaining-first";
   const parts = [
-    formatUsed(data, labels),
-    isNumber(data.remaining)
-      ? `${labels.remaining} ${formatValue(data.remaining, data.unit)}`
-      : null,
+    ...(order === "remaining-first"
+      ? [formatRemaining(data, labels), formatUsed(data, labels)]
+      : [formatUsed(data, labels), formatRemaining(data, labels)]),
     data.extra || null,
   ].filter((part): part is string => Boolean(part));
 

--- a/tests/utils/usageDisplay.test.ts
+++ b/tests/utils/usageDisplay.test.ts
@@ -46,4 +46,31 @@ describe("formatUsageDataSummary", () => {
       ),
     ).toBe("Unauthorized");
   });
+
+  it("shows remaining before used by default", () => {
+    expect(
+      formatUsageDataSummary(
+        {
+          used: 40,
+          remaining: 60,
+          unit: "USD",
+        },
+        labels,
+      ),
+    ).toBe("Remaining: 60 USD / Used: 40 USD");
+  });
+
+  it("shows used before remaining when displayOrder is used-first", () => {
+    expect(
+      formatUsageDataSummary(
+        {
+          used: 40,
+          remaining: 60,
+          unit: "USD",
+        },
+        labels,
+        "used-first",
+      ),
+    ).toBe("Used: 40 USD / Remaining: 60 USD");
+  });
 });


### PR DESCRIPTION
## Summary

Add a new user setting to control whether remaining quota or used quota is displayed first in usage summaries.

## Motivation

Current behavior always shows "used" first, then "remaining". Some users find this unintuitive and prefer to see remaining quota first, as it's more relevant for decision-making ("how much do I have left?" rather than "how much did I use?").

## Changes

- **Settings Schema**: Add `usageDisplayOrder` field with options:
  - `remaining-first` (default) - shows remaining quota first
  - `used-first` - shows used quota first (old behavior)

- **UI Component**: New `UsageDisplaySettings` component in General tab
  - Toggle buttons for easy switching
  - Auto-save on change

- **Display Logic**: Update `formatUsageDataSummary` to accept optional `displayOrder` parameter
  - Dynamically reorder display based on user preference
  - Backward compatible (defaults to `remaining-first`)

- **Internationalization**: Add translations for:
  - English
  - 简体中文 (Simplified Chinese)
  - 繁體中文 (Traditional Chinese)
  - 日本語 (Japanese)

## Screenshots

N/A (settings UI follows existing patterns)

## Testing

- [x] Type check passes (`pnpm typecheck`)
- [x] Format check passes (`pnpm format:check`)
- [x] Manually verified UI component renders correctly
- [x] Verified setting persists across app restarts

## Breaking Changes

None. Default behavior now shows remaining first, which is more intuitive. Users who prefer the old behavior can switch to "Used First" in settings.