### PR TITLE
fix(proxy): map Claude Fable 5 through sonnet route

### DIFF
--- a/src-tauri/src/proxy/model_mapper.rs
+++ b/src-tauri/src/proxy/model_mapper.rs
@@ -71,6 +71,17 @@ impl ModelMapping {
                 return m.clone();
             }
         }
+        // Fable currently behaves as the "main/sonnet-tier" Claude slot in the
+        // local Claude/cc-switch config surfaces, so it should not fall through
+        // to ANTHROPIC_MODEL and silently downgrade to an unrelated default.
+        if model_lower.contains("fable") {
+            if let Some(ref m) = self.sonnet_model {
+                return m.clone();
+            }
+            if let Some(ref m) = self.default_model {
+                return m.clone();
+            }
+        }
 
         // 2. 默认模型
         if let Some(ref m) = self.default_model {
@@ -259,6 +270,15 @@ mod tests {
         let (result, _, mapped) = apply_model_mapping(body, &provider);
         assert_eq!(result["model"], "default-model");
         assert_eq!(mapped, Some("default-model".to_string()));
+    }
+
+    #[test]
+    fn test_fable_mapping_uses_sonnet_slot() {
+        let provider = create_provider_with_mapping();
+        let body = json!({"model": "claude-fable-5"});
+        let (result, _, mapped) = apply_model_mapping(body, &provider);
+        assert_eq!(result["model"], "sonnet-mapped");
+        assert_eq!(mapped, Some("sonnet-mapped".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Partially addresses #3980.

`src-tauri/src/proxy/model_mapper.rs` currently recognizes Claude route families by name matching on `haiku`, `sonnet`, and `opus`. When a Claude client requests `claude-fable-5`, the request can therefore fall through to `ANTHROPIC_MODEL` instead of using the configured sonnet route in `ANTHROPIC_DEFAULT_SONNET_MODEL`.

In current Claude/cc-switch config surfaces, Fable behaves as a sonnet-tier route choice rather than a separate standalone route key. Falling back to `ANTHROPIC_MODEL` can silently remap the request to an unrelated default upstream model.

This PR keeps the fix intentionally small:

- if the requested model name contains `fable`, prefer `ANTHROPIC_DEFAULT_SONNET_MODEL`
- if the sonnet slot is not configured, keep the existing fallback to `ANTHROPIC_MODEL`
- add a focused unit test that pins the expected mapping behavior

This PR only fixes the proxy model-mapping slice of `claude-fable-5` support. It does not cover the broader Fable 5 adaptation work discussed in #3980, such as GUI model availability or pricing / usage support.

## Related Issue / 关联 Issue

Partially addresses #3980.

## Screenshots / 截图

Not applicable.

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| `claude-fable-5` could fall through to `ANTHROPIC_MODEL` | `claude-fable-5` resolves through the sonnet route first |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（not needed）

### Validation

Tested locally with:

- `cargo test test_fable_mapping_uses_sonnet_slot --lib`

### Review focus

The main question for review is whether `claude-fable-5` should be treated as a sonnet-tier Claude route in `ModelMapping`, using `ANTHROPIC_DEFAULT_SONNET_MODEL` before falling back to `ANTHROPIC_MODEL`.
