### PR TITLE
feat(claude-config): add Enable Advisor Tool checkbox

### DIFF
--- a/src/components/providers/forms/CommonConfigEditor.tsx
+++ b/src/components/providers/forms/CommonConfigEditor.tsx
@@ -85,6 +85,9 @@ export function CommonConfigEditor({
         disableAutoUpgrade:
           config?.env?.DISABLE_AUTOUPDATER === "1" ||
           config?.env?.DISABLE_AUTOUPDATER === 1,
+        enableAdvisor:
+          config?.env?.CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL === "1" ||
+          config?.env?.CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL === 1,
       };
     } catch {
       return {
@@ -93,6 +96,7 @@ export function CommonConfigEditor({
         enableToolSearch: false,
         effortMax: false,
         disableAutoUpgrade: false,
+        enableAdvisor: false,
       };
     }
   }, [localValue]);
@@ -143,6 +147,15 @@ export function CommonConfigEditor({
               config.env.DISABLE_AUTOUPDATER = "1";
             } else {
               delete config.env.DISABLE_AUTOUPDATER;
+              if (Object.keys(config.env).length === 0) delete config.env;
+            }
+            break;
+          case "enableAdvisor":
+            if (!config.env) config.env = {};
+            if (checked) {
+              config.env.CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL = "1";
+            } else {
+              delete config.env.CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL;
               if (Object.keys(config.env).length === 0) delete config.env;
             }
             break;
@@ -245,6 +258,17 @@ export function CommonConfigEditor({
               className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
             />
             <span>{t("claudeConfig.disableAutoUpgrade")}</span>
+          </label>
+          <label className="inline-flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
+            <input
+              type="checkbox"
+              checked={toggleStates.enableAdvisor}
+              onChange={(e) =>
+                handleToggle("enableAdvisor", e.target.checked)
+              }
+              className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
+            />
+            <span>{t("claudeConfig.enableAdvisor")}</span>
           </label>
         </div>
         <JsonEditor

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -81,7 +81,8 @@
     "enableTeammates": "Teammates Mode",
     "enableToolSearch": "Enable Tool Search",
     "effortMax": "Max Effort Thinking",
-    "disableAutoUpgrade": "Disable Auto-Upgrade"
+    "disableAutoUpgrade": "Disable Auto-Upgrade",
+    "enableAdvisor": "Enable Advisor Tool"
   },
   "header": {
     "viewOnGithub": "View on GitHub",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -81,7 +81,8 @@
     "enableTeammates": "Teammates モード",
     "enableToolSearch": "Tool Search を有効化",
     "effortMax": "最大強度思考",
-    "disableAutoUpgrade": "自動アップグレードを無効化"
+    "disableAutoUpgrade": "自動アップグレードを無効化",
+    "enableAdvisor": "Advisor ツールを有効化"
   },
   "header": {
     "viewOnGithub": "GitHub で見る",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -81,7 +81,8 @@
     "enableTeammates": "Teammates 模式",
     "enableToolSearch": "啟用 Tool Search",
     "effortMax": "最大強度思考",
-    "disableAutoUpgrade": "停用自動升級"
+    "disableAutoUpgrade": "停用自動升級",
+    "enableAdvisor": "啟用 Advisor 工具"
   },
   "header": {
     "viewOnGithub": "在 GitHub 上檢視",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -81,7 +81,8 @@
     "enableTeammates": "Teammates 模式",
     "enableToolSearch": "启用 Tool Search",
     "effortMax": "最大强度思考",
-    "disableAutoUpgrade": "禁用自动升级"
+    "disableAutoUpgrade": "禁用自动升级",
+    "enableAdvisor": "启用 Advisor 工具"
   },
   "header": {
     "viewOnGithub": "在 GitHub 上查看",


### PR DESCRIPTION
- Add enableAdvisor toggle in CommonConfigEditor
- Add env field CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL
- Add translations for en, zh, ja, zh-TW
- Auto-manage env object when empty

  ## Summary / 概述

  为 Claude Code 配置添加 "Enable Advisor Tool" 勾选框，用于快速启用/禁用实验性的 Advisor 工具功能。

  此功能通过 UI 勾选框自动管理 `CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL` 环境变量，无需手动编辑 JSON 配置。

  ## Changes / 修改内容

  - Add enableAdvisor toggle in CommonConfigEditor
  - Add env field CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL
  - Add translations for en, zh, ja, zh-TW
  - Auto-manage env object when empty

  ## Related Issue / 关联 Issue

  Fixes #4137

  ## Implementation Details / 实现细节

  1. **UI 勾选框**：在 `CommonConfigEditor.tsx` 中添加 "Enable Advisor Tool" 复选框
  2. **状态管理**：在 `toggleStates` 中检测 `CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL` 字段（支持 "1" 和 1
  两种格式）
  3. **配置更新**：
     - 勾选时：添加 `env.CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL = "1"`
     - 取消勾选时：删除该字段
     - 智能管理：如果 `env` 对象为空则自动删除
  4. **国际化**：添加 4 种语言翻译
     - 🇺🇸 英文：Enable Advisor Tool
     - 🇨🇳 简中：启用 Advisor 工具
     - 🇯🇵 日文：Advisor ツールを有効化
     - 🇹🇼 繁中：啟用 Advisor 工具

  ## Modified Files / 修改的文件

  - `src/components/providers/forms/CommonConfigEditor.tsx`
  - `src/i18n/locales/en.json`
  - `src/i18n/locales/zh.json`
  - `src/i18n/locales/ja.json`
  - `src/i18n/locales/zh-TW.json`

  ## Testing / 测试

  已手动测试以下场景：
  - ✅ 从空配置启用功能，正确添加字段
  - ✅ 禁用功能时正确删除字段和空的 env 对象
  - ✅ 与其他 env 字段共存时只删除自己
  - ✅ 所有语言翻译显示正确

  ## Screenshots / 截图

  配置界面新增勾选框位置：
  Config JSON 区域
  ├─ [✓] Hide AI Attribution
  ├─ [✓] Teammates Mode
  ├─ [✓] Enable Tool Search
  ├─ [✓] Max Effort Thinking
  ├─ [✓] Disable Auto-Upgrade
  └─ [✓] 启用 Advisor 工具  ← 新增

  配置效果：
  ```json
  {
    "env": {
      "CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL": "1"
    }
  }

  Checklist / 检查清单

  - [x] pnpm typecheck passes / 通过 TypeScript 类型检查
  - [x] pnpm format:check passes / 通过代码格式检查
  - [ ] cargo clippy passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）— N/A，未修改 Rust 代码
  - [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件