### PR TITLE
fix(opencode): sync live-managed providers from config

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1370,12 +1370,6 @@ pub fn import_opencode_providers_from_live(state: &AppState) -> Result<usize, Ap
     let existing_ids = state.db.get_provider_ids("opencode")?;
 
     for (id, config) in providers {
-        // Skip if already exists in database
-        if existing_ids.contains(&id) {
-            log::debug!("OpenCode provider '{id}' already exists in database, skipping");
-            continue;
-        }
-
         // Convert to Value for settings_config
         let settings_config = match serde_json::to_value(&config) {
             Ok(v) => v,
@@ -1385,10 +1379,56 @@ pub fn import_opencode_providers_from_live(state: &AppState) -> Result<usize, Ap
             }
         };
 
+        let display_name = config.name.clone().unwrap_or_else(|| id.clone());
+
+        if existing_ids.contains(&id) {
+            let Some(existing_provider) = state.db.get_provider_by_id(&id, "opencode")? else {
+                log::debug!(
+                    "OpenCode provider '{id}' exists in id index but could not be loaded, skipping"
+                );
+                continue;
+            };
+
+            let live_managed = existing_provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.live_config_managed)
+                == Some(true);
+
+            if !live_managed {
+                log::debug!("OpenCode provider '{id}' already exists in database, skipping");
+                continue;
+            }
+
+            let needs_update = existing_provider.name != display_name
+                || existing_provider.settings_config != settings_config;
+            if !needs_update {
+                log::debug!("OpenCode provider '{id}' already exists in database and is up-to-date");
+                continue;
+            }
+
+            let mut provider = existing_provider.clone();
+            provider.name = display_name;
+            provider.settings_config = settings_config;
+            provider
+                .meta
+                .get_or_insert_with(Default::default)
+                .live_config_managed = Some(true);
+
+            if let Err(e) = state.db.save_provider("opencode", &provider) {
+                log::warn!("Failed to update OpenCode provider '{id}' from live config: {e}");
+                continue;
+            }
+
+            imported += 1;
+            log::info!("Updated OpenCode provider '{id}' from live config");
+            continue;
+        }
+
         // Create provider
         let mut provider = Provider::with_id(
             id.clone(),
-            config.name.clone().unwrap_or_else(|| id.clone()),
+            display_name,
             settings_config,
             None,
         );

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -861,6 +861,52 @@ base_url = "http://localhost:8080"
 
     #[test]
     #[serial]
+    fn import_opencode_providers_from_live_updates_existing_live_managed_provider() {
+        with_test_home(|state, _| {
+            let provider = opencode_provider("imported-opencode-update");
+            crate::opencode_config::set_provider(&provider.id, provider.settings_config.clone())
+                .expect("seed initial opencode live provider");
+
+            let imported = import_opencode_providers_from_live(state)
+                .expect("import initial opencode provider");
+            assert_eq!(imported, 1);
+
+            let mut updated_live = provider.settings_config.clone();
+            updated_live["options"]["apiKey"] = Value::String("updated-key".to_string());
+            updated_live["models"]["gpt-5.5"] = json!({ "name": "GPT-5.5" });
+            crate::opencode_config::set_provider(&provider.id, updated_live.clone())
+                .expect("update opencode live provider");
+
+            let imported = import_opencode_providers_from_live(state)
+                .expect("re-import updated opencode provider");
+            assert_eq!(imported, 1);
+
+            let saved = state
+                .db
+                .get_provider_by_id(&provider.id, AppType::OpenCode.as_str())
+                .expect("query updated opencode provider")
+                .expect("updated opencode provider should exist");
+
+            assert_eq!(
+                saved.settings_config["options"]["apiKey"],
+                Value::String("updated-key".to_string())
+            );
+            assert_eq!(
+                saved.settings_config["models"]["gpt-5.5"]["name"],
+                Value::String("GPT-5.5".to_string())
+            );
+            assert_eq!(
+                saved
+                    .meta
+                    .as_ref()
+                    .and_then(|meta| meta.live_config_managed),
+                Some(true)
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
     fn import_openclaw_providers_from_live_marks_provider_as_live_managed() {
         with_test_home(|state, _| {
             let mut provider = openclaw_provider("imported-openclaw");


### PR DESCRIPTION
## Summary
- update existing live-managed OpenCode providers from live config instead of always skipping when the provider id already exists in the database
- preserve the old skip behavior for DB-only additive providers
- add a regression test covering live-managed OpenCode provider re-import when models or options change

## Root cause
CC Switch imported OpenCode providers from the live OpenCode config only once. After the provider id already existed in the database, subsequent imports unconditionally skipped it. That left the DB with a stale snapshot even when the live OpenCode config had new models such as gpt-5.5.

## What changed
- in import_opencode_providers_from_live, if an existing provider is marked liveConfigManaged=true, compare the live config snapshot with the DB row and upsert when it changed
- if the provider is DB-only with liveConfigManaged=false, keep the old skip behavior
- add a test that proves a live-managed OpenCode provider is updated on re-import

## Validation
- manually reproduced the issue with onekeytest: live OpenCode config had gpt-5.5 while the CC Switch DB still only had gpt-5.4
- manually synced the stale DB row locally and confirmed the missing model discrepancy disappeared
- could not run Rust tests in this environment because cargo is not available in PATH on this machine
