### PR TITLE
fix(macos): prevent duplicate provider terminal sessions

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2620,29 +2620,58 @@ exec bash --norc --noprofile
     result
 }
 
-/// macOS: Terminal.app
+/// Escape a value as an AppleScript string literal.
 #[cfg(target_os = "macos")]
-fn launch_macos_terminal_app(script_file: &std::path::Path) -> Result<(), String> {
-    use std::process::Command;
+fn applescript_string_literal(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
 
-    let applescript = format!(
-        r#"tell application "Terminal"
-    activate
-    do script "bash '{}'"
+/// Build the launcher command literal used by AppleScript.
+#[cfg(target_os = "macos")]
+fn applescript_launcher_command(script_file: &std::path::Path) -> String {
+    applescript_string_literal(&format!(
+        "bash {}",
+        shell_single_quote(&script_file.to_string_lossy())
+    ))
+}
+
+/// macOS: Terminal.app AppleScript.
+/// A cold `activate` creates a default empty window before `do script` opens the command session.
+/// Use `launch` for cold starts so `do script` can create the only new session without reusing restored windows.
+#[cfg(target_os = "macos")]
+fn build_macos_terminal_applescript(script_file: &std::path::Path) -> String {
+    format!(
+        r#"set launcher_script to {launcher}
+set was_running to application "Terminal" is running
+tell application "Terminal"
+    if was_running then
+        activate
+        do script launcher_script
+    else
+        launch
+        do script launcher_script
+        activate
+    end if
 end tell"#,
-        script_file.display()
-    );
+        launcher = applescript_launcher_command(script_file)
+    )
+}
+
+/// Run AppleScript through `osascript -e` with shared error handling.
+#[cfg(target_os = "macos")]
+fn run_terminal_osascript(applescript: &str, terminal_label: &str) -> Result<(), String> {
+    use std::process::Command;
 
     let output = Command::new("osascript")
         .arg("-e")
-        .arg(&applescript)
+        .arg(applescript)
         .output()
         .map_err(|e| format!("执行 osascript 失败: {e}"))?;
 
     if !output.status.success() {
         let stderr = decode_command_output(&output.stderr);
         return Err(format!(
-            "Terminal.app 执行失败 (exit code: {:?}): {}",
+            "{terminal_label} 执行失败 (exit code: {:?}): {}",
             output.status.code(),
             stderr
         ));
@@ -2651,11 +2680,20 @@ end tell"#,
     Ok(())
 }
 
+/// macOS: Terminal.app
+#[cfg(target_os = "macos")]
+fn launch_macos_terminal_app(script_file: &std::path::Path) -> Result<(), String> {
+    run_terminal_osascript(
+        &build_macos_terminal_applescript(script_file),
+        "Terminal.app",
+    )
+}
+
 /// macOS: iTerm2
 #[cfg(target_os = "macos")]
 fn build_macos_iterm2_applescript(script_file: &std::path::Path) -> String {
     format!(
-        r#"set launcher_script to "bash '{}'"
+        r#"set launcher_script to {launcher}
 set was_running to application "iTerm" is running
 tell application "iTerm"
     if was_running then
@@ -2683,63 +2721,51 @@ tell application "iTerm"
         write text launcher_script
     end tell
 end tell"#,
-        script_file.display()
+        launcher = applescript_launcher_command(script_file)
     )
 }
 
 /// macOS: iTerm2
 #[cfg(target_os = "macos")]
 fn launch_macos_iterm2(script_file: &std::path::Path) -> Result<(), String> {
-    use std::process::Command;
-
-    let applescript = build_macos_iterm2_applescript(script_file);
-
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(&applescript)
-        .output()
-        .map_err(|e| format!("执行 osascript 失败: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = decode_command_output(&output.stderr);
-        return Err(format!(
-            "iTerm2 执行失败 (exit code: {:?}): {}",
-            output.status.code(),
-            stderr
-        ));
-    }
-
-    Ok(())
+    run_terminal_osascript(&build_macos_iterm2_applescript(script_file), "iTerm2")
 }
 
-/// macOS: Ghostty — use --quit-after-last-window-closed to avoid cloning existing tabs
+/// Keep the launcher path inside a `bash -c` string.
+/// A bare `.sh` passed through `open --args` may also be opened as a document.
+#[cfg(target_os = "macos")]
+fn build_macos_dash_c_command(script_file: &std::path::Path) -> String {
+    format!(
+        "exec bash {}",
+        shell_single_quote(&script_file.to_string_lossy())
+    )
+}
+
+/// macOS: Ghostty.
+/// Warm starts use AppleScript to create one command window.
+/// Cold starts use `initial-command` so the first default surface runs the launcher.
+/// Do not use `initial-window=false` plus `new window`: cold launch can still create the default window first.
+#[cfg(target_os = "macos")]
+fn build_macos_ghostty_applescript(script_file: &std::path::Path) -> String {
+    format!(
+        r#"set launcher_command to {launcher}
+set was_running to application "Ghostty" is running
+if was_running then
+    tell application "Ghostty"
+        new window with configuration {{command:launcher_command}}
+    end tell
+else
+    do shell script "open -na Ghostty --args --quit-after-last-window-closed=true " & quoted form of ("--initial-command=" & launcher_command)
+end if
+"#,
+        launcher = applescript_launcher_command(script_file)
+    )
+}
+
+/// macOS: Ghostty
 #[cfg(target_os = "macos")]
 fn launch_macos_ghostty(script_file: &std::path::Path) -> Result<(), String> {
-    use std::process::Command;
-
-    let output = Command::new("open")
-        .args([
-            "-na",
-            "Ghostty",
-            "--args",
-            "--quit-after-last-window-closed=true",
-            "-e",
-            "bash",
-        ])
-        .arg(script_file)
-        .output()
-        .map_err(|e| format!("启动 Ghostty 失败: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = decode_command_output(&output.stderr);
-        return Err(format!(
-            "Ghostty 启动失败 (exit code: {:?}): {}",
-            output.status.code(),
-            stderr
-        ));
-    }
-
-    Ok(())
+    run_terminal_osascript(&build_macos_ghostty_applescript(script_file), "Ghostty")
 }
 
 /// macOS: 使用 open -na 启动支持 --args 参数的终端（Alacritty/Kitty/WezTerm/Kaku）
@@ -2757,7 +2783,10 @@ fn launch_macos_open_app(
     if use_e_flag {
         cmd.arg("-e");
     }
-    cmd.arg("bash").arg(script_file);
+    // Keep the script path inside `bash -c`; a trailing bare `.sh` can be opened as a document.
+    cmd.arg("bash")
+        .arg("-c")
+        .arg(build_macos_dash_c_command(script_file));
 
     let output = cmd
         .output()
@@ -4691,6 +4720,124 @@ mod tests {
         assert!(running_branch.contains("if (count of windows) = 0 then"));
         assert!(running_branch.contains("create window with default profile"));
         assert!(running_branch.contains("create tab with default profile"));
+    }
+
+    /// Terminal `activate` creates a default empty window on cold start; `launch` does not.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminal_applescript_cold_start_uses_launch_before_do_script() {
+        let script = build_macos_terminal_applescript(Path::new("/tmp/cc_switch_launcher.sh"));
+
+        assert!(
+            script.contains(r#"set was_running to application "Terminal" is running"#),
+            "missing was_running detection:\n{script}"
+        );
+        // Cold launches avoid `activate` until after `do script`, so no default empty window is created first.
+        assert!(
+            script.contains(
+                "else\n        launch\n        do script launcher_script\n        activate"
+            ),
+            "cold start should launch before activating:\n{script}"
+        );
+        // Already-running launches should create a fresh session.
+        assert!(
+            script.contains(
+                "if was_running then\n        activate\n        do script launcher_script\n"
+            ),
+            "already-running branch should use bare do script:\n{script}"
+        );
+    }
+
+    /// Restored windows should not receive the launcher command.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminal_applescript_does_not_hijack_restored_windows() {
+        let script = build_macos_terminal_applescript(Path::new("/tmp/cc_switch_launcher.sh"));
+        assert!(
+            !script.contains(" in window 1"),
+            "should not inject into an existing/restored Terminal window:\n{script}"
+        );
+        assert!(
+            !script.contains("count of windows"),
+            "should not infer restored-window safety from window count:\n{script}"
+        );
+    }
+
+    /// Ghostty cold starts use `initial-command`; warm starts use the scripting dictionary.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ghostty_applescript_cold_start_uses_initial_command() {
+        let script = build_macos_ghostty_applescript(Path::new("/tmp/cc_switch_launcher.sh"));
+
+        // Warm launches execute through the AppleScript command property, not `open -na ... -e`.
+        assert!(
+            script.contains(r#"set launcher_command to "bash '/tmp/cc_switch_launcher.sh'""#),
+            "missing launcher_command:\n{script}"
+        );
+        assert!(script.contains("if was_running then"));
+        assert!(script.contains("new window with configuration {command:launcher_command}"));
+        assert!(
+            !script.contains(" --args -e"),
+            "should not execute through open -na -e:\n{script}"
+        );
+        // Cold launches make Ghostty's first default surface execute the launcher.
+        assert!(script.contains(r#"set was_running to application "Ghostty" is running"#));
+        assert!(
+            script.contains(
+                r#"do shell script "open -na Ghostty --args --quit-after-last-window-closed=true " & quoted form of ("--initial-command=" & launcher_command)"#
+            ),
+            "cold start should use initial-command:\n{script}"
+        );
+        assert!(
+            !script.contains("--initial-window=false"),
+            "should not rely on initial-window=false:\n{script}"
+        );
+        assert!(
+            !script.contains("delay 0.5"),
+            "should not rely on a fixed delay:\n{script}"
+        );
+        assert!(
+            !script.contains("old_ids"),
+            "should not track default windows for closing:\n{script}"
+        );
+        assert!(
+            !script.contains("close window"),
+            "should not close a default window:\n{script}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn dash_c_command_wraps_script_path_inside_quoted_arg() {
+        // The script path must stay inside the `-c` string, not as a bare argv.
+        let s = build_macos_dash_c_command(Path::new("/tmp/cc_switch_launcher_1.sh"));
+        assert_eq!(s, "exec bash '/tmp/cc_switch_launcher_1.sh'");
+
+        // Spaces and single quotes must stay shell-safe too.
+        let s2 = build_macos_dash_c_command(Path::new("/Users/me/it's dir/x.sh"));
+        assert_eq!(s2, r#"exec bash '/Users/me/it'"'"'s dir/x.sh'"#);
+    }
+
+    /// AppleScript launchers need both shell-path quoting and AppleScript string quoting.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn applescript_builders_safely_quote_special_paths() {
+        // First shell-quote the path, then wrap the whole command as an AppleScript string.
+        let expected = r#""bash '/Users/me/it'\"'\"'s dir/x.sh'""#;
+        let p = Path::new("/Users/me/it's dir/x.sh");
+        assert_eq!(applescript_launcher_command(p), expected);
+        assert!(
+            build_macos_terminal_applescript(p).contains(expected),
+            "Terminal did not quote safely"
+        );
+        assert!(
+            build_macos_iterm2_applescript(p).contains(expected),
+            "iTerm2 did not quote safely"
+        );
+        assert!(
+            build_macos_ghostty_applescript(p).contains(expected),
+            "Ghostty did not quote safely"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2765,7 +2765,15 @@ end if
 /// macOS: Ghostty
 #[cfg(target_os = "macos")]
 fn launch_macos_ghostty(script_file: &std::path::Path) -> Result<(), String> {
-    run_terminal_osascript(&build_macos_ghostty_applescript(script_file), "Ghostty")
+    match run_terminal_osascript(&build_macos_ghostty_applescript(script_file), "Ghostty") {
+        Ok(()) => Ok(()),
+        Err(applescript_error) => {
+            log::warn!(
+                "Ghostty AppleScript launch failed, falling back to open -na: {applescript_error}"
+            );
+            launch_macos_open_app("Ghostty", script_file, true)
+        }
+    }
 }
 
 /// macOS: 使用 open -na 启动支持 --args 参数的终端（Alacritty/Kitty/WezTerm/Kaku）


### PR DESCRIPTION
## 概要

修复 macOS 上打开 provider terminal 时，几条独立 launcher 路径可能导致重复终端 session / tab / window 的问题。

这个 PR 替代 #4054。#4054 里的 Terminal.app 方案在更多真机测试后发现还有两个风险：冷启动时 `activate` 会先创建一个默认空 session，后续 `do script` 仍可能再开一个 session；而直接复用 `window 1` 又可能把启动命令注入到 macOS 恢复出来的历史窗口里。这个版本重新调整了 Terminal.app 的冷启动逻辑，同时补上 Ghostty 和共用 `open -na ... --args` launcher 路径的问题。

本 PR 只处理 macOS provider terminal 重复打开的问题。#4140 关注 provider command 退出后回到用户 shell 的行为，两者互补；这个 PR 不改变 #4140 处理的那类行为。

## 修复前 / 修复后

| Terminal 路径 | 修复前 | 修复后 |
| --- | --- | --- |
| Terminal.app 冷启动 | `activate` 会先创建默认空 session，随后 `do script` 可能再打开第二个 session | 先 `launch`，再裸 `do script`，最后 `activate`；只得到一个 provider session，并且没有 `window 1` 注入路径 |
| Terminal.app 已运行 | 打开一个新的 provider session | 行为保持不变：打开一个新的 provider session |
| Ghostty 冷启动 | 默认 Ghostty surface 加上 `-e` command surface，可能留下额外空 tab/window | 通过 `--initial-command` 让第一个 Ghostty surface 直接运行 launcher |
| Ghostty 已运行 | `open -na Ghostty ... -e` 可能克隆已有 tabs，再追加 command tab | 通过 AppleScript `new window with configuration {command: ...}` 创建一个干净的 command window |
| Alacritty / kitty / WezTerm / Kaku | 末尾裸 `.sh` path 可能被 `open -na ... --args` 同时当成 document 打开 | script path 被包进 `bash -c "exec bash '<script>'"`，不再作为独立 argv 暴露 |
| iTerm2 | 既有 AppleScript 行为 | 行为保持不变；launcher quoting 改用共享 helper |
| Warp | 不受影响 | 不变 |

## 主要改动

### Terminal.app

Terminal.app 冷启动时，AppleScript `activate` 会自动创建一个默认空窗口 / session。如果紧接着无条件执行 `do script`，就容易出现“一个空 session + 一个 provider session”的重复打开。

这个 PR 先判断 Terminal.app 是否已经运行：

- 已运行：`activate` 后使用裸 `do script`，保持原本“新增一个 provider session”的行为，不复用已有用户窗口。
- 冷启动：使用 `launch` 启动应用，再执行裸 `do script`，最后 `activate` 到前台。

冷启动路径刻意不使用 `do script ... in window 1`。这样可以避免把 provider launcher 注入到 macOS 状态恢复出来的历史 Terminal 窗口中，也避免靠窗口数量猜测哪个窗口“可以安全复用”。

### `open -na` 系列 launcher

Alacritty、kitty、WezTerm 和 Kaku 都走 `open -na <App> --args ...` 这类路径。这里如果把 `.sh` 文件 path 作为末尾裸 argv 传进去，macOS 可能还会把它当成 document-open target 再打开一次。

这个 PR 将 script path 包进 `bash -c`：

```sh
bash -c "exec bash '<script>'"
```

这样 `.sh` path 不再是独立 argv，避免被 `open` 的 document handling 额外处理。

### Ghostty

Ghostty 的冷启动和已运行场景需要分开处理：

- 已运行：使用 Ghostty AppleScript dictionary，通过 `new window with configuration {command: ...}` 创建一个干净的 command window。
- 冷启动：使用 `--initial-command=<launcher command>`，让 Ghostty 启动时创建的第一个 surface 直接运行 launcher。

冷启动路径保留了之前 launcher 里的 `--quit-after-last-window-closed=true` 行为。

这里没有采用 `initial-window=false` 后再 AppleScript `new window` 的方案，因为真机测试里这个方案仍可能先创建一个默认空窗口，最后变成两个窗口。

### Quoting / Refactor

Terminal.app、iTerm2 和 Ghostty 现在共享 AppleScript launcher command 构造逻辑，统一处理 shell path quoting 和 AppleScript string quoting。

三个 AppleScript launcher 里重复的 `osascript -e` 调用与错误处理也抽成了共享 helper，减少后续维护时出现行为漂移的可能。

## 关联

- 替代 #4054
- 关联用户反馈 #1975：Ghostty 打开空 terminal，而不是运行 provider command
- 关联用户反馈 #2798：已运行的 Ghostty、Alacritty、WezTerm、Kaku 上 provider-terminal command 丢失；本 PR 保留 `open -na` 路径，同时修复裸 script argv 的边界问题
- 关联 Ghostty launcher 反馈 #2673：`open -na Ghostty` 会创建独立 Ghostty 进程 / Dock 图标

相邻 PR：#4140 关注 provider command 退出后是否尊重用户 shell。这个 PR 不改变该行为。

## 验证结果

真机 macOS 验证：

| Terminal | 验证结果 |
| --- | --- |
| Terminal.app | 冷启动只打开一个 provider session；已运行时只新增一个 provider session；不存在 `do script ... in window 1` 的恢复窗口注入路径 |
| Ghostty | 冷启动通过 `--initial-command` 打开一个 command window；重复冷启动检查为一个 Ghostty process/window，launcher command 正常执行；已运行时通过 AppleScript 新增一个干净 command window |
| iTerm2 | 行为保持不变；launcher command quoting 已验证 |
| Alacritty / kitty / WezTerm | script path 保持在 `bash -c` 内，没有裸 `.sh` argv path |
| Kaku | 覆盖在同一条共享 `open -na` / `bash -c` launcher 路径上 |
| Warp | 未改动 |

本地与 CI 检查：

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check -- src-tauri/src/commands/misc.rs`
- `osacompile` 验证生成的 Terminal.app 和 Ghostty AppleScript 形状
- `cargo test --manifest-path src-tauri/Cargo.toml commands::misc::tests`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- GitHub Frontend Checks passed：`pnpm typecheck`、`pnpm format:check`、`pnpm test:unit`
- GitHub Backend Checks passed：`cargo fmt --check`、`cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`、`cargo test`

额外执行过一个更严格的本地检查：

```sh
cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings
```

该检查目前会因为本 PR 未触及的既有代码诊断失败。我在干净的 `upstream/main` worktree（`2d64d8c6`）上复现了同样失败：

- `src/claude_desktop_config.rs:1314`
- `src/services/proxy.rs:5440`
- `src/services/proxy.rs:5578`

这些诊断都是 `clippy::field-reassign-with-default`，和本 PR 修改的 `src-tauri/src/commands/misc.rs` 无关。

## Checklist

- [x] `pnpm typecheck` / `pnpm format:check` via GitHub Frontend Checks
- [x] `cargo fmt`
- [x] `cargo clippy` via GitHub Backend Checks
- [x] `cargo test`
- [x] 真机 macOS terminal 验证
- [x] i18n N/A：没有新增用户可见文案
