### PR TITLE
Chat API: skip tool calls with missing function names

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -291,7 +291,7 @@ pub async fn set_common_config_snippet(
 
     let value = if is_cleared { None } else { Some(snippet) };
 
-    if matches!(app_type.as_str(), "claude" | "codex" | "gemini") {
+    if matches!(app_type.as_str(), "claude" | "codex" | "gemini" | "opencode") {
         if let Some(legacy_snippet) = old_snippet
             .as_deref()
             .filter(|value| !value.trim().is_empty())
@@ -315,7 +315,7 @@ pub async fn set_common_config_snippet(
         .set_config_snippet_cleared(&app_type, is_cleared)
         .map_err(|e| e.to_string())?;
 
-    if matches!(app_type.as_str(), "claude" | "codex" | "gemini") {
+    if matches!(app_type.as_str(), "claude" | "codex" | "gemini" | "opencode") {
         let app = AppType::from_str(&app_type).map_err(|e| e.to_string())?;
         crate::services::provider::ProviderService::sync_current_provider_for_app(
             state.inner(),

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -122,7 +122,7 @@ impl Database {
 
         // 8. Proxy Config 表（三行结构，app_type 主键）
         conn.execute("CREATE TABLE IF NOT EXISTS proxy_config (
-            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','gemini')),
+            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','gemini','opencode')),
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 15721, enable_logging INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
@@ -166,6 +166,15 @@ impl Database {
                 circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
                 circuit_error_rate_threshold, circuit_min_requests)
                 VALUES ('gemini', 5, 60, 120, 600, 4, 2, 60, 0.6, 10)",
+                [],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+            conn.execute(
+                "INSERT OR IGNORE INTO proxy_config (app_type, max_retries,
+                streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
+                circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
+                circuit_error_rate_threshold, circuit_min_requests)
+                VALUES ('opencode', 3, 60, 120, 600, 4, 2, 60, 0.6, 10)",
                 [],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -748,7 +757,7 @@ impl Database {
         // 创建新表
         conn.execute("DROP TABLE IF EXISTS proxy_config_new", [])?;
         conn.execute("CREATE TABLE proxy_config_new (
-            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','gemini')),
+            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','gemini','opencode')),
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 15721, enable_logging INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1618,7 +1618,7 @@ pub async fn cleanup_before_exit(app_handle: &tauri::AppHandle) {
 async fn restore_proxy_state_on_startup(state: &store::AppState) {
     // 收集需要恢复接管的应用列表（从 proxy_config.enabled 读取）
     let mut apps_to_restore = Vec::new();
-    for app_type in ["claude", "codex", "gemini"] {
+    for app_type in ["claude", "codex", "gemini", "opencode"] {
         if let Ok(config) = state.db.get_proxy_config_for_app(app_type).await {
             if config.enabled {
                 apps_to_restore.push(app_type);

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -21,6 +21,7 @@ pub mod codex_oauth_auth;
 pub mod copilot_auth;
 pub mod copilot_model_map;
 mod gemini;
+mod opencode;
 pub(crate) mod gemini_schema;
 pub mod gemini_shadow;
 pub mod models;
@@ -52,6 +53,7 @@ pub use codex::{
     should_convert_codex_responses_to_chat,
 };
 pub use gemini::GeminiAdapter;
+pub use opencode::OpenCodeAdapter;
 
 /// 供应商类型枚举
 ///
@@ -76,6 +78,8 @@ pub enum ProviderType {
     GitHubCopilot,
     /// OpenAI Codex (ChatGPT Plus/Pro OAuth，需要 Anthropic ↔ Responses API 转换)
     CodexOAuth,
+    /// OpenCode (OpenAI 兼容 API，如 OMO、DeepSeek 等)
+    OpenCode,
 }
 
 impl ProviderType {
@@ -106,6 +110,7 @@ impl ProviderType {
             ProviderType::OpenRouter => "https://openrouter.ai/api",
             ProviderType::GitHubCopilot => "https://api.githubcopilot.com",
             ProviderType::CodexOAuth => "https://chatgpt.com/backend-api/codex",
+            ProviderType::OpenCode => "",
         }
     }
 
@@ -185,7 +190,8 @@ impl ProviderType {
                 }
                 ProviderType::Gemini
             }
-            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => {
+            AppType::OpenCode => ProviderType::OpenCode,
+            AppType::OpenClaw | AppType::Hermes => {
                 // These apps don't support proxy, fallback to Codex-like type
                 ProviderType::Codex
             }
@@ -203,6 +209,7 @@ impl ProviderType {
             ProviderType::OpenRouter => "openrouter",
             ProviderType::GitHubCopilot => "github_copilot",
             ProviderType::CodexOAuth => "codex_oauth",
+            ProviderType::OpenCode => "opencode",
         }
     }
 }
@@ -228,6 +235,7 @@ impl std::str::FromStr for ProviderType {
                 Ok(ProviderType::GitHubCopilot)
             }
             "codex_oauth" | "codex-oauth" | "codexoauth" => Ok(ProviderType::CodexOAuth),
+            "opencode" | "open-code" => Ok(ProviderType::OpenCode),
             _ => Err(format!("Invalid provider type: {s}")),
         }
     }
@@ -239,7 +247,8 @@ pub fn get_adapter(app_type: &AppType) -> Box<dyn ProviderAdapter> {
         AppType::Claude | AppType::ClaudeDesktop => Box::new(ClaudeAdapter::new()),
         AppType::Codex => Box::new(CodexAdapter::new()),
         AppType::Gemini => Box::new(GeminiAdapter::new()),
-        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => {
+        AppType::OpenCode => Box::new(OpenCodeAdapter::new()),
+        AppType::OpenClaw | AppType::Hermes => {
             // These apps don't support proxy, fallback to Codex adapter
             Box::new(CodexAdapter::new())
         }
@@ -257,6 +266,7 @@ pub fn get_adapter_for_provider_type(provider_type: &ProviderType) -> Box<dyn Pr
         | ProviderType::CodexOAuth => Box::new(ClaudeAdapter::new()),
         ProviderType::Codex => Box::new(CodexAdapter::new()),
         ProviderType::Gemini | ProviderType::GeminiCli => Box::new(GeminiAdapter::new()),
+        ProviderType::OpenCode => Box::new(OpenCodeAdapter::new()),
     }
 }
 

--- a/src-tauri/src/proxy/providers/opencode.rs
+++ b/src-tauri/src/proxy/providers/opencode.rs
@@ -1,0 +1,181 @@
+//! OpenCode Provider Adapter
+//!
+//! 支持 OpenAI 兼容格式的 API（如 OMO、DeepSeek 等）
+//!
+//! ## 环境变量
+//! - `OPENAI_API_KEY`: API 密钥
+//! - `OPENAI_BASE_URL`: API 基础 URL
+//! - `OPENAI_MODEL`: 默认模型（可选）
+
+use super::{AuthInfo, AuthStrategy, ProviderAdapter};
+use crate::provider::Provider;
+use crate::proxy::error::ProxyError;
+use serde_json::Value;
+
+/// OpenCode 适配器
+pub struct OpenCodeAdapter;
+
+impl OpenCodeAdapter {
+    pub fn new() -> Self {
+        OpenCodeAdapter
+    }
+}
+
+impl ProviderAdapter for OpenCodeAdapter {
+    fn name(&self) -> &'static str {
+        "OpenCode"
+    }
+
+    fn extract_base_url(&self, provider: &Provider) -> Result<String, ProxyError> {
+        // 1. 尝试从 settings_config.base_url 获取
+        if let Some(url) = provider
+            .settings_config
+            .get("base_url")
+            .and_then(|v| v.as_str())
+        {
+            return Ok(url.trim_end_matches('/').to_string());
+        }
+
+        // 2. 尝试从 settings_config.baseURL 获取
+        if let Some(url) = provider
+            .settings_config
+            .get("baseURL")
+            .and_then(|v| v.as_str())
+        {
+            return Ok(url.trim_end_matches('/').to_string());
+        }
+
+        // 3. 尝试从 settings_config.apiEndpoint 获取
+        if let Some(url) = provider
+            .settings_config
+            .get("apiEndpoint")
+            .and_then(|v| v.as_str())
+        {
+            return Ok(url.trim_end_matches('/').to_string());
+        }
+
+        // 4. 尝试从 provider.baseUrl 获取
+        if let Some(provider_config) = provider.settings_config.get("provider") {
+            if let Some(url) = provider_config.get("baseUrl").and_then(|v| v.as_str()) {
+                return Ok(url.trim_end_matches('/').to_string());
+            }
+            if let Some(url) = provider_config.get("base_url").and_then(|v| v.as_str()) {
+                return Ok(url.trim_end_matches('/').to_string());
+            }
+        }
+
+        // 5. 尝试从 env 中获取
+        if let Some(env) = provider.settings_config.get("env") {
+            if let Some(url) = env.get("OPENAI_BASE_URL").and_then(|v| v.as_str()) {
+                return Ok(url.trim_end_matches('/').to_string());
+            }
+        }
+
+        Err(ProxyError::ConfigError(
+            "OpenCode Provider missing base_url configuration".to_string(),
+        ))
+    }
+
+    fn extract_auth(&self, provider: &Provider) -> Option<AuthInfo> {
+        // 1. 尝试从 settings_config.api_key 获取
+        if let Some(key) = provider
+            .settings_config
+            .get("api_key")
+            .and_then(|v| v.as_str())
+        {
+            if !key.is_empty() {
+                return Some(AuthInfo {
+                    api_key: key.to_string(),
+                    strategy: AuthStrategy::Bearer,
+                    access_token: None,
+                });
+            }
+        }
+
+        // 2. 尝试从 settings_config.apiKey 获取
+        if let Some(key) = provider
+            .settings_config
+            .get("apiKey")
+            .and_then(|v| v.as_str())
+        {
+            if !key.is_empty() {
+                return Some(AuthInfo {
+                    api_key: key.to_string(),
+                    strategy: AuthStrategy::Bearer,
+                    access_token: None,
+                });
+            }
+        }
+
+        // 3. 尝试从 provider.apiKey 获取
+        if let Some(provider_config) = provider.settings_config.get("provider") {
+            if let Some(key) = provider_config.get("apiKey").and_then(|v| v.as_str()) {
+                if !key.is_empty() {
+                    return Some(AuthInfo {
+                        api_key: key.to_string(),
+                        strategy: AuthStrategy::Bearer,
+                        access_token: None,
+                    });
+                }
+            }
+            if let Some(key) = provider_config.get("api_key").and_then(|v| v.as_str()) {
+                if !key.is_empty() {
+                    return Some(AuthInfo {
+                        api_key: key.to_string(),
+                        strategy: AuthStrategy::Bearer,
+                        access_token: None,
+                    });
+                }
+            }
+        }
+
+        // 4. 尝试从 env 中获取
+        if let Some(env) = provider.settings_config.get("env") {
+            if let Some(key) = env.get("OPENAI_API_KEY").and_then(|v| v.as_str()) {
+                if !key.is_empty() {
+                    return Some(AuthInfo {
+                        api_key: key.to_string(),
+                        strategy: AuthStrategy::Bearer,
+                        access_token: None,
+                    });
+                }
+            }
+        }
+
+        None
+    }
+
+    fn build_url(&self, base_url: &str, endpoint: &str) -> String {
+        let endpoint = if endpoint.is_empty() {
+            "/v1/chat/completions"
+        } else {
+            endpoint
+        };
+
+        if base_url.ends_with('/') {
+            format!("{}{}", base_url.trim_end_matches('/'), endpoint)
+        } else {
+            format!("{}{}", base_url, endpoint)
+        }
+    }
+
+    fn get_auth_headers(
+        &self,
+        auth: &AuthInfo,
+    ) -> Result<Vec<(http::HeaderName, http::HeaderValue)>, ProxyError> {
+        let value = super::adapter::auth_header_value(&format!("Bearer {}", auth.api_key))?;
+        Ok(vec![(http::header::AUTHORIZATION, value)])
+    }
+
+    fn needs_transform(&self, _provider: &Provider) -> bool {
+        false
+    }
+
+    fn transform_request(&self, body: Value, _provider: &Provider) -> Result<Value, ProxyError> {
+        Ok(body)
+    }
+
+    fn transform_response(&self, body: Value) -> Result<Value, ProxyError> {
+        Ok(body)
+    }
+}

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -428,8 +428,10 @@ impl ChatToResponsesState {
             if let Some(id) = id_delta {
                 state.call_id = id;
             }
-            if let Some(name) = name_delta {
-                state.name = name;
+            if let Some(ref name) = name_delta {
+                if !name.is_empty() {
+                    state.name.clone_from(name);
+                }
             }
             if !args_delta.is_empty() {
                 state.arguments.push_str(&args_delta);
@@ -464,7 +466,10 @@ impl ChatToResponsesState {
                 state.call_id = format!("call_{chat_index}");
             }
             if state.name.is_empty() {
-                state.name = "unknown_tool".to_string();
+                // Model never provided a valid name across all deltas — skip this tool call
+                log::warn!("[Codex] Skipping tool call with empty name (no delta provided a name)");
+                state.done = true;
+                return events;
             }
             state.output_index = Some(assigned);
             let is_custom_tool = self.tool_context.is_custom_tool_chat_name(&state.name);
@@ -667,6 +672,21 @@ impl ChatToResponsesState {
         for key in keys {
             let mut add_event: Option<Bytes> = None;
             if self.tools.get(&key).map(|state| state.done).unwrap_or(true) {
+                continue;
+            }
+
+            // Skip tool calls with missing names (defensive: some models generate
+            // tool call deltas without providing a valid function name)
+            let has_bad_name = self
+                .tools
+                .get(&key)
+                .map(|state| state.name.is_empty())
+                .unwrap_or(true);
+            if has_bad_name {
+                if let Some(state) = self.tools.get_mut(&key) {
+                    state.done = true;
+                }
+                log::warn!("[Codex] Skipping streaming tool call with missing name");
                 continue;
             }
 

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1350,6 +1350,14 @@ fn chat_tool_calls_to_response_output_items(
 
     if let Some(tool_calls) = message.get("tool_calls").and_then(|v| v.as_array()) {
         for (index, tool_call) in tool_calls.iter().enumerate() {
+            // Skip tool calls with missing function names (defensive: some models
+            // may generate tool calls without providing a valid name)
+            let function = tool_call.get("function").unwrap_or(&Value::Null);
+            let name = function.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            if name.is_empty() {
+                log::warn!("[Codex] Skipping tool call with missing name");
+                continue;
+            }
             output.push(chat_tool_call_to_response_item(
                 tool_call,
                 index,

--- a/src-tauri/src/proxy/usage/calculator.rs
+++ b/src-tauri/src/proxy/usage/calculator.rs
@@ -28,6 +28,67 @@ pub struct ModelPricing {
 /// 成本计算器
 pub struct CostCalculator;
 
+/// 从 Provider 配置中提取 API 格式
+///
+/// 支持的配置位置：
+/// 1. settings_config.api_format
+/// 2. settings_config.provider.api_format
+/// 3. 根据 URL 自动推断
+///
+/// 返回值：`"openai"`, `"anthropic"`, `"gemini"` 或默认 `"openai"`
+#[allow(dead_code)]
+pub fn extract_api_format(provider_config: &serde_json::Value) -> String {
+    // 1. 直接从 api_format 字段获取
+    if let Some(format) = provider_config
+        .get("api_format")
+        .and_then(|v| v.as_str())
+    {
+        return format.to_lowercase();
+    }
+
+    // 2. 从 provider 子对象获取
+    if let Some(provider) = provider_config.get("provider") {
+        if let Some(format) = provider.get("api_format").and_then(|v| v.as_str()) {
+            return format.to_lowercase();
+        }
+    }
+
+    // 3. 根据 URL 自动推断
+    if let Some(base_url) = provider_config
+        .get("base_url")
+        .or_else(|| provider_config.get("baseURL"))
+        .or_else(|| {
+            provider_config
+                .get("provider")
+                .and_then(|p| p.get("baseUrl").or_else(|| p.get("base_url")))
+        })
+        .and_then(|v| v.as_str())
+    {
+        let url_lower = base_url.to_lowercase();
+        if url_lower.contains("anthropic") || url_lower.contains("/v1/messages") {
+            return "anthropic".to_string();
+        }
+        if url_lower.contains("googleapis") || url_lower.contains("gemini") {
+            return "gemini".to_string();
+        }
+    }
+
+    // 4. 默认使用 OpenAI 兼容格式
+    "openai".to_string()
+}
+
+/// 判断 API 格式的 input_tokens 是否包含 cache_read_tokens
+///
+/// - OpenAI/Gemini: 包含（需要减去）
+/// - Anthropic: 不包含（直接使用）
+#[allow(dead_code)]
+pub fn input_includes_cache_read_for_api_format(api_format: &str) -> bool {
+    match api_format {
+        "anthropic" => false,
+        "openai" | "gemini" | _ => true,
+    }
+}
+
 impl CostCalculator {
     /// 计算请求成本
     ///
@@ -59,7 +120,33 @@ impl CostCalculator {
         pricing: &ModelPricing,
         cost_multiplier: Decimal,
     ) -> CostBreakdown {
-        let input_includes_cache_read = matches!(app_type, "codex" | "gemini");
+        let input_includes_cache_read = matches!(app_type, "codex" | "gemini" | "opencode");
+        Self::calculate_with_cache_semantics(
+            usage,
+            pricing,
+            cost_multiplier,
+            input_includes_cache_read,
+        )
+    }
+
+    /// 按 API 格式选择输入 token 语义后计算成本。
+    ///
+    /// 支持的 API 格式：
+    /// - `openai` / `gemini`: input_tokens 包含 cache_read_tokens
+    /// - `anthropic`: input_tokens 已经是 fresh input
+    ///
+    /// 默认使用 `openai` 格式（兼容性最好）
+    #[allow(dead_code)]
+    pub fn calculate_for_api_format(
+        api_format: &str,
+        usage: &TokenUsage,
+        pricing: &ModelPricing,
+        cost_multiplier: Decimal,
+    ) -> CostBreakdown {
+        let input_includes_cache_read = match api_format {
+            "anthropic" => false,
+            "openai" | "gemini" | _ => true,  // 默认假设包含缓存
+        };
         Self::calculate_with_cache_semantics(
             usage,
             pricing,

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1019,7 +1019,7 @@ impl ProxyService {
             .map_err(|e| format!("清除接管状态失败: {e}"))?;
 
         // 4. 清除所有应用的 enabled 状态（用户手动关闭，不需要下次自动恢复）
-        for app_type in ["claude", "codex", "gemini"] {
+        for app_type in ["claude", "codex", "gemini", "opencode"] {
             if let Ok(mut config) = self.db.get_proxy_config_for_app(app_type).await {
                 if config.enabled {
                     config.enabled = false;
@@ -1447,7 +1447,7 @@ impl ProxyService {
     async fn restore_live_configs(&self) -> Result<(), String> {
         let mut errors = Vec::new();
 
-        for app_type in [AppType::Claude, AppType::Codex, AppType::Gemini] {
+        for app_type in [AppType::Claude, AppType::Codex, AppType::Gemini, AppType::OpenCode] {
             if let Err(e) = self
                 .restore_live_config_for_app_with_fallback(&app_type)
                 .await
@@ -1776,7 +1776,7 @@ impl ProxyService {
     /// 检查是否处于 Live 接管模式
     pub async fn is_takeover_active(&self) -> Result<bool, String> {
         let status = self.get_takeover_status().await?;
-        Ok(status.claude || status.codex || status.gemini)
+        Ok(status.claude || status.codex || status.gemini || status.opencode)
     }
 
     /// 从异常退出中恢复（启动时调用）

--- a/src-tauri/src/services/sql_helpers.rs
+++ b/src-tauri/src/services/sql_helpers.rs
@@ -5,6 +5,12 @@
 //! `promptTokenCount` both include the cached portion. Any aggregation
 //! summing `input_tokens` across providers must route through
 //! [`fresh_input_sql`] to recover a consistent semantics.
+//!
+//! ## API 格式支持
+//!
+//! OpenCode 可能使用不同的 API 格式（OpenAI/Anthropic/Gemini），
+//! 默认假设使用 OpenAI 兼容格式。如果用户配置 OpenCode 使用 Anthropic API，
+//! 需要手动调整 `CACHE_INCLUSIVE_APP_TYPES` 或使用 `fresh_input_sql_for_api_format`。
 
 /// Set of `app_type` values whose stored `input_tokens` already includes
 /// `cache_read_tokens`. Aggregations subtract cache reads from these rows
@@ -16,7 +22,19 @@
 /// style provider not added here) shows up loudly as a too-low cache hit
 /// rate, which is easier to catch than the silent over-deduction that
 /// would happen with the opposite default.
-const CACHE_INCLUSIVE_APP_TYPES: &[&str] = &["codex", "gemini"];
+const CACHE_INCLUSIVE_APP_TYPES: &[&str] = &["codex", "gemini", "opencode"];
+
+/// 判断 API 格式的 input_tokens 是否包含 cache_read_tokens
+///
+/// - OpenAI/Gemini: 包含（需要减去）
+/// - Anthropic: 不包含（直接使用）
+#[allow(dead_code)]
+pub fn input_includes_cache_read_for_api_format(api_format: &str) -> bool {
+    match api_format {
+        "anthropic" => false,
+        "openai" | "gemini" | _ => true,
+    }
+}
 
 /// Build an SQL expression that returns the cache-normalized `input_tokens`
 /// for a single row in `proxy_request_logs` or `usage_daily_rollups`.
@@ -44,6 +62,29 @@ pub fn fresh_input_sql(alias: &str) -> String {
               THEN ({prefix}input_tokens - {prefix}cache_read_tokens) \
               ELSE {prefix}input_tokens END"
     )
+}
+
+/// Build an SQL expression for fresh input based on API format.
+///
+/// This is a more flexible version that supports different API formats.
+/// Use this when you have access to the API format information.
+#[allow(dead_code)]
+pub fn fresh_input_sql_for_api_format(alias: &str, api_format: &str) -> String {
+    let prefix = if alias.is_empty() {
+        String::new()
+    } else {
+        format!("{alias}.")
+    };
+
+    if input_includes_cache_read_for_api_format(api_format) {
+        format!(
+            "CASE WHEN {prefix}input_tokens >= {prefix}cache_read_tokens \
+                  THEN ({prefix}input_tokens - {prefix}cache_read_tokens) \
+                  ELSE {prefix}input_tokens END"
+        )
+    } else {
+        format!("{prefix}input_tokens")
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -432,6 +432,21 @@ fn local_day_start_rfc3339(day: NaiveDate) -> String {
 }
 
 impl Database {
+    /// 判断 app_type 的 input_tokens 是否包含 cache_read_tokens
+    ///
+    /// - OpenAI/Gemini 格式: 包含（需要减去）
+    /// - Anthropic 格式: 不包含（直接使用）
+    ///
+    /// 对于 OpenCode，默认假设使用 OpenAI 兼容格式（最常见）
+    /// 如果用户配置 OpenCode 使用 Anthropic API，需要手动调整
+    pub fn input_includes_cache_read_for_app(app_type: &str) -> bool {
+        match app_type {
+            "codex" | "gemini" | "opencode" => true,
+            "claude" | "claude-desktop" => false,
+            _ => true,  // 默认假设包含缓存（兼容性最好）
+        }
+    }
+
     /// 获取使用量汇总
     pub fn get_usage_summary(
         &self,
@@ -1562,10 +1577,14 @@ impl Database {
         let million = rust_decimal::Decimal::from(1_000_000u64);
 
         // 与 CostCalculator::calculate_for_app 保持一致的计算逻辑：
-        // 1. Codex/Gemini 的 input_tokens 包含 cache_read_tokens，需要扣除后按输入价计费
+        // 1. Codex/Gemini/OpenCode 的 input_tokens 包含 cache_read_tokens，需要扣除后按输入价计费
         // 2. Claude/Anthropic 的 input_tokens 已经是 fresh input，不能再次扣减
         // 3. 各项成本是基础成本（不含倍率），倍率只作用于最终总价
-        let input_includes_cache_read = matches!(log.app_type.as_str(), "codex" | "gemini");
+        //
+        // 注意：OpenCode 可能使用不同的 API 格式（OpenAI/Anthropic/Gemini）
+        // 这里使用 app_type 判断，因为历史日志中没有 API 格式信息
+        // 对于 OpenCode，默认假设使用 OpenAI 兼容格式（最常见）
+        let input_includes_cache_read = Self::input_includes_cache_read_for_app(&log.app_type);
         let billable_input_tokens = if input_includes_cache_read {
             (log.input_tokens as u64).saturating_sub(log.cache_read_tokens as u64)
         } else {

--- a/src/components/mcp/McpFormModal.tsx
+++ b/src/components/mcp/McpFormModal.tsx
@@ -42,7 +42,7 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
   onClose,
   existingIds = [],
   defaultFormat = "json",
-  defaultEnabledApps = ["claude", "codex", "gemini"],
+  defaultEnabledApps = ["claude", "codex", "gemini", "opencode"],
 }) => {
   const { t } = useTranslation();
   const { formatTomlError, validateTomlConfig, validateJsonConfig } =

--- a/src/components/providers/ProviderEmptyState.tsx
+++ b/src/components/providers/ProviderEmptyState.tsx
@@ -16,7 +16,7 @@ export function ProviderEmptyState({
 }: ProviderEmptyStateProps) {
   const { t } = useTranslation();
   const showSnippetHint =
-    appId === "claude" || appId === "codex" || appId === "gemini";
+    appId === "claude" || appId === "codex" || appId === "gemini" || appId === "opencode";
 
   return (
     <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border p-10 text-center">

--- a/src/components/proxy/ClaudeDesktopRouteToggle.tsx
+++ b/src/components/proxy/ClaudeDesktopRouteToggle.tsx
@@ -25,7 +25,7 @@ export function ClaudeDesktopRouteToggle({
 
   const isBusy = isStarting || isStoppingServer;
   const otherTakeoverActive = Boolean(
-    takeoverStatus?.claude || takeoverStatus?.codex || takeoverStatus?.gemini,
+    takeoverStatus?.claude || takeoverStatus?.codex || takeoverStatus?.gemini || takeoverStatus?.opencode,
   );
   const routeAddress = status?.address ?? "127.0.0.1";
   const routePort = status?.port ?? 15721;

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -67,11 +67,12 @@ export function ProxyPanel({
     }
   }, [globalConfig]);
 
-  // 获取所有三个应用类型的故障转移队列
+  // 获取所有应用类型的故障转移队列
   // 启用自动故障转移后，将按队列优先级（P1→P2→...）选择供应商
   const { data: claudeQueue = [] } = useFailoverQueue("claude");
   const { data: codexQueue = [] } = useFailoverQueue("codex");
   const { data: geminiQueue = [] } = useFailoverQueue("gemini");
+  const { data: opencodeQueue = [] } = useFailoverQueue("opencode");
 
   const handleTakeoverChange = async (appType: string, enabled: boolean) => {
     try {
@@ -413,7 +414,8 @@ export function ProxyPanel({
               {/* [6] Provider queues */}
               {(claudeQueue.length > 0 ||
                 codexQueue.length > 0 ||
-                geminiQueue.length > 0) && (
+                geminiQueue.length > 0 ||
+                opencodeQueue.length > 0) && (
                 <div className="pt-3 border-t border-border space-y-3">
                   <div className="flex items-center gap-2">
                     <ListOrdered className="h-3.5 w-3.5 text-muted-foreground" />
@@ -451,6 +453,18 @@ export function ProxyPanel({
                       appType="gemini"
                       appLabel="Gemini"
                       targets={geminiQueue.map((item) => ({
+                        id: item.providerId,
+                        name: item.providerName,
+                      }))}
+                      status={status}
+                    />
+                  )}
+
+                  {opencodeQueue.length > 0 && (
+                    <ProviderQueueGroup
+                      appType="opencode"
+                      appLabel="OpenCode"
+                      targets={opencodeQueue.map((item) => ({
                         id: item.providerId,
                         name: item.providerName,
                       }))}

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -172,12 +172,12 @@ export function ProxyTabContent({
               )}
 
               <Tabs defaultValue="claude" className="w-full">
-                <TabsList className="grid w-full grid-cols-3">
+                <TabsList className="grid w-full grid-cols-4">
                   <TabsTrigger value="claude">Claude</TabsTrigger>
                   <TabsTrigger value="codex">Codex</TabsTrigger>
                   <TabsTrigger value="gemini">Gemini</TabsTrigger>
-                </TabsList>
-                {(["claude", "codex", "gemini"] as const).map((appType) => {
+                  <TabsTrigger value="opencode">OpenCode</TabsTrigger>                </TabsList>
+                {(["claude", "codex", "gemini", "opencode"] as const).map((appType) => {
                   const failoverDisabled =
                     !isRunning || !(takeoverStatus?.[appType] ?? false);
                   return (

--- a/src/components/usage/PricingConfigPanel.tsx
+++ b/src/components/usage/PricingConfigPanel.tsx
@@ -33,7 +33,7 @@ import { Plus, Pencil, Trash2, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { proxyApi } from "@/lib/api/proxy";
 
-const PRICING_APPS = ["claude", "codex", "gemini"] as const;
+const PRICING_APPS = ["claude", "codex", "gemini", "opencode"] as const;
 type PricingApp = (typeof PRICING_APPS)[number];
 type PricingModelSource = "request" | "response";
 
@@ -52,11 +52,12 @@ export function PricingConfigPanel() {
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
 
-  // 三个应用的配置状态
+  // 四个应用的配置状态
   const [appConfigs, setAppConfigs] = useState<AppConfigState>({
     claude: { multiplier: "1", source: "response" },
     codex: { multiplier: "1", source: "response" },
     gemini: { multiplier: "1", source: "response" },
+    opencode: { multiplier: "1", source: "response" },
   });
   const [originalConfigs, setOriginalConfigs] = useState<AppConfigState | null>(
     null,
@@ -102,6 +103,7 @@ export function PricingConfigPanel() {
           claude: { multiplier: "1", source: "response" },
           codex: { multiplier: "1", source: "response" },
           gemini: { multiplier: "1", source: "response" },
+          opencode: { multiplier: "1", source: "response" },
         };
         for (const result of results) {
           newState[result.app] = {

--- a/src/lib/api/env.ts
+++ b/src/lib/api/env.ts
@@ -42,7 +42,7 @@ export async function restoreEnvBackup(backupPath: string): Promise<void> {
 export async function checkAllEnvConflicts(): Promise<
   Record<string, EnvConflict[]>
 > {
-  const apps = ["claude", "codex", "gemini"];
+  const apps = ["claude", "codex", "gemini", "opencode"];
   const results: Record<string, EnvConflict[]> = {};
 
   await Promise.all(


### PR DESCRIPTION
Some providers send empty or absent function names in streaming tool call deltas. Previously these produced invalid output items that could not be handled by downstream clients.

Changes:
- Don't overwrite accumulated state.name with empty deltas in streaming path
- Skip tool calls that never received a valid name (instead of falling back to 'unknown_tool')
- Apply the same defensive guard in finalize_tools and the non-streaming path