### PR TITLE
fix(codex): restore cached tool call fields

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1350,7 +1350,7 @@ impl RequestForwarder {
                 .await;
             if restored > 0 {
                 log::debug!(
-                    "[Codex] Restored {restored} cached function call(s) for Chat upstream"
+                    "[Codex] Restored or enriched {restored} cached function call item(s) for Chat upstream"
                 );
             }
             super::providers::apply_codex_chat_upstream_model(provider, &mut mapped_body);

--- a/src-tauri/src/proxy/providers/codex_chat_history.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_history.rs
@@ -150,7 +150,7 @@ impl CodexChatHistoryStore {
                 Some(item_type) if is_call_item_type(item_type) => {
                     if let Some(call_id) = response_item_call_id(&item) {
                         if let Some(cached) = lookup.call(&call_id) {
-                            if enrich_call_item_reasoning(&mut item, cached) {
+                            if enrich_call_item_from_cache(&mut item, cached) {
                                 enriched += 1;
                             }
                         }
@@ -466,8 +466,27 @@ fn is_call_output_item_type(item_type: &str) -> bool {
     )
 }
 
-fn enrich_call_item_reasoning(item: &mut Value, cached: &Value) -> bool {
+fn enrich_call_item_from_cache(item: &mut Value, cached: &Value) -> bool {
     let mut changed = false;
+    for key in [
+        "name",
+        "namespace",
+        "arguments",
+        "input",
+        "status",
+        "execution",
+    ] {
+        if item.get(key).is_some_and(|value| !is_empty_value(value)) {
+            continue;
+        }
+        let Some(value) = cached.get(key).filter(|value| !is_empty_value(value)) else {
+            continue;
+        };
+        if let Some(object) = item.as_object_mut() {
+            object.insert(key.to_string(), value.clone());
+            changed = true;
+        }
+    }
     for key in ["reasoning_content", "reasoning"] {
         if item.get(key).is_some_and(|value| !is_empty_value(value)) {
             continue;
@@ -673,6 +692,48 @@ mod tests {
         let input = request["input"].as_array().unwrap();
         assert_eq!(input[0]["reasoning_content"], "Need to inspect the file.");
         assert_eq!(input.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn enriches_existing_function_call_missing_name_and_arguments() {
+        let history = CodexChatHistoryStore::default();
+        history
+            .record_response(&json!({
+                "id": "resp_1",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "read_file",
+                        "arguments": "{\"path\":\"README.md\"}",
+                        "reasoning_content": "Need to inspect the file."
+                    }
+                ]
+            }))
+            .await;
+
+        let mut request = json!({
+            "previous_response_id": "resp_1",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "ok"
+                }
+            ]
+        });
+
+        assert_eq!(history.enrich_request(&mut request).await, 1);
+        let input = request["input"].as_array().unwrap();
+        assert_eq!(input[0]["type"], "function_call");
+        assert_eq!(input[0]["name"], "read_file");
+        assert_eq!(input[0]["arguments"], "{\"path\":\"README.md\"}");
+        assert_eq!(input[0]["reasoning_content"], "Need to inspect the file.");
+        assert_eq!(input[1]["type"], "function_call_output");
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/codex_chat_history.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_history.rs
@@ -475,6 +475,8 @@ fn enrich_call_item_from_cache(item: &mut Value, cached: &Value) -> bool {
         "input",
         "status",
         "execution",
+        "reasoning_content",
+        "reasoning",
     ] {
         if item.get(key).is_some_and(|value| !is_empty_value(value)) {
             continue;
@@ -484,18 +486,6 @@ fn enrich_call_item_from_cache(item: &mut Value, cached: &Value) -> bool {
         };
         if let Some(object) = item.as_object_mut() {
             object.insert(key.to_string(), value.clone());
-            changed = true;
-        }
-    }
-    for key in ["reasoning_content", "reasoning"] {
-        if item.get(key).is_some_and(|value| !is_empty_value(value)) {
-            continue;
-        }
-        let Some(reasoning) = cached.get(key).filter(|value| !is_empty_value(value)) else {
-            continue;
-        };
-        if let Some(object) = item.as_object_mut() {
-            object.insert(key.to_string(), reasoning.clone());
             changed = true;
         }
     }


### PR DESCRIPTION
## Summary / 概述

- Restore missing cached Codex tool call fields before converting Responses history to Chat Completions.
- Preserve non-empty fields already present in the request, and only fill blank or missing fields from cached call history.
- Avoid sending an empty function name to strict Chat upstreams when a follow-up request contains a partial function call item.

## Related Issue / 关联 Issue

Fixes #4152

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| N/A - backend proxy change | N/A - backend proxy change |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（N/A - no user-facing text changed）

## Verification / 验证

- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --check`
- `cargo clippy`
- `cargo test codex_chat_history`
