### PR TITLE
fix(settings): reset scroll when switching tabs

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { motion } from "framer-motion";
 import {
   Loader2,
@@ -102,6 +109,7 @@ export function SettingsPage({
 
   const [activeTab, setActiveTab] = useState<string>("general");
   const [showRestartPrompt, setShowRestartPrompt] = useState(false);
+  const tabScrollContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (open) {
@@ -115,6 +123,12 @@ export function SettingsPage({
       setShowRestartPrompt(true);
     }
   }, [requiresRestart]);
+
+  useLayoutEffect(() => {
+    if (tabScrollContainerRef.current) {
+      tabScrollContainerRef.current.scrollTop = 0;
+    }
+  }, [activeTab]);
 
   const closeAfterSave = useCallback(() => {
     // 保存成功后关闭：不再重置语言，避免需要“保存两次”才生效
@@ -211,7 +225,10 @@ export function SettingsPage({
           </TabsList>
 
           <div className="flex-1 min-h-0 flex flex-col">
-            <div className="flex-1 overflow-y-auto overflow-x-hidden pr-2">
+            <div
+              ref={tabScrollContainerRef}
+              className="flex-1 overflow-y-auto overflow-x-hidden pr-2"
+            >
               <TabsContent value="general" className="space-y-6 mt-0">
                 {settings ? (
                   <motion.div

--- a/tests/components/SettingsDialog.test.tsx
+++ b/tests/components/SettingsDialog.test.tsx
@@ -344,9 +344,7 @@ describe("SettingsPage Component", () => {
     fireEvent.click(screen.getByText("settings.advanced.data.title"));
 
     // 有文件时，点击导入按钮执行 importConfig
-    fireEvent.click(
-      screen.getByRole("button", { name: /settings\.import/ }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /settings\.import/ }));
     expect(importExportMock.importConfig).toHaveBeenCalled();
 
     fireEvent.click(
@@ -357,6 +355,20 @@ describe("SettingsPage Component", () => {
     // 清除选择按钮
     fireEvent.click(screen.getByRole("button", { name: "common.clear" }));
     expect(importExportMock.clearSelection).toHaveBeenCalled();
+  });
+
+  it("should reset tab content scroll position when switching settings tabs", () => {
+    const { container } = renderSettingsPage();
+    const scrollContainer = container.querySelector(
+      ".overflow-y-auto",
+    ) as HTMLDivElement | null;
+
+    expect(scrollContainer).not.toBeNull();
+
+    scrollContainer!.scrollTop = 640;
+    fireEvent.click(screen.getByText("settings.tabAdvanced"));
+
+    expect(scrollContainer!.scrollTop).toBe(0);
   });
 
   it("should pass onImportSuccess callback to useImportExport hook", async () => {


### PR DESCRIPTION
## Summary / 概述

Fix Settings page tab content appearing blank after scrolling the General tab to the bottom. The shared tab scroll container now resets to the top when switching settings tabs.

Adds a regression test for the tab scroll reset behavior.

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|       <img width="3194" height="2448" alt="image" src="https://github.com/user-attachments/assets/9846b856-dab4-4bfb-ab58-eac4c5cd3d2d" /> |     <img width="3194" height="2448" alt="image" src="https://github.com/user-attachments/assets/7683a6fa-05f9-495e-b8d9-6ff8fff5684c" />          |
|第一页翻到底部后，无法查看其他页面|第一页翻到底部后，可以查看其他页面|

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / Not applicable: no Rust changes
- [x] Updated i18n files if user-facing text changed / Not applicable: no user-facing text changes
