### PR TITLE
fix(windows): inject chcp 65001 into launcher .bat to fix CJK path (#3150)

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -231,7 +231,8 @@ fn run_tool_lifecycle_silently(command_line: &str, label: &str) -> Result<(), St
 
     let bat_file =
         std::env::temp_dir().join(format!("cc_switch_{}_{}.bat", label, std::process::id()));
-    std::fs::write(&bat_file, command_line).map_err(|e| format!("写入批处理文件失败: {e}"))?;
+    // 切到 UTF-8 代码页，避免 .bat 按 UTF-8 写入、cmd 按 GBK 读取导致中文路径乱码（#3150）
+    std::fs::write(&bat_file, format!("chcp 65001 >nul\r\n{command_line}")).map_err(|e| format!("写入批处理文件失败: {e}"))?;
 
     let output = Command::new("cmd")
         .arg("/C")
@@ -2954,6 +2955,7 @@ fn launch_windows_terminal(
 
     let content = format!(
         "@echo off
+chcp 65001 >nul
 {cwd_command}
 echo Using provider-specific claude config:
 echo {}
@@ -3211,7 +3213,7 @@ read -n 1 -s
 
         let bat_file = temp_dir.join(format!("cc_switch_{}_{}.bat", label, pid));
         let content = format!(
-            "@echo off\r\necho [cc-switch] Starting: {label}\r\necho.\r\n{cmd}\r\necho.\r\necho [cc-switch] Command exited. Press any key to close.\r\npause >nul\r\ndel \"%~f0\" >nul 2>&1\r\n",
+            "@echo off\r\nchcp 65001 >nul\r\necho [cc-switch] Starting: {label}\r\necho.\r\n{cmd}\r\necho.\r\necho [cc-switch] Command exited. Press any key to close.\r\npause >nul\r\ndel \"%~f0\" >nul 2>&1\r\n",
             label = label,
             cmd = command_line,
         );


### PR DESCRIPTION
## Summary / 概述

修复 Windows 下、工作目录含中文（CJK）字符时打开终端失败、提示找不到目录的问题（#3150）。

cc-switch 生成的 `.bat` 用 UTF-8 写入（Rust `String` → `std::fs::write`），但 cmd 默认按 GBK/ANSI 读取，`.bat` 里的中文工作目录路径乱码、`cd` 失败。本 PR 在三处 `.bat` 生成逻辑开头注入 `chcp 65001 >nul`，把 cmd 代码页切到 UTF-8，读写编码一致：

- `run_tool_lifecycle_silently`（静默安装 / tool lifecycle）
- `launch_windows_terminal`（openTerminal）
- 通用 launch（label / cmd 启动）

## Related Issue / 关联 Issue

Fixes #3150

重复 issue：#2305（.bat 编码 + 中文路径）、#3852（中文路径打开异常）——同源，合并时一并关闭。

## 根因

`std::fs::write` 按 UTF-8 落盘，cmd 默认按系统 ANSI（中文 Windows 为 GBK）读取 `.bat`。`.bat` 未设 `chcp`，中文路径被按 GBK 解析 UTF-8 字节 → 乱码 → 找不到目录。注入 `chcp 65001 >nul` 后 cmd 切到 UTF-8 代码页，读写一致。

## 验证

- `cargo check --manifest-path src-tauri/Cargo.toml` ✅（Linux 侧；`.bat` 逻辑在 `#[cfg(target_os = "windows")]` 块，需在 Windows 实测）
- 待补：Windows 含中文路径目录（如 `E:\测试\目录`）打开终端实测 + 回归测试

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未改前端）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未改前端）
- [ ] `cargo clippy` passes / 通过 Clippy 检查
- [x] `cargo check` passes（Linux 侧）
- [ ] Windows 实测中文路径打开终端（draft → ready 前补）

> Draft：核心修复（3 处 `chcp` 注入）已就位，Windows 实测 + 回归测试待补后转 ready。
