### PR TITLE
fix: OpenClaw cron jobs fail with 401 after provider rotation

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -12,6 +12,7 @@ use crate::codex_config::{get_codex_auth_path, get_codex_config_path};
 use crate::config::{delete_file, get_claude_settings_path, read_json_file, write_json_file};
 use crate::database::Database;
 use crate::error::AppError;
+use crate::openclaw_config;
 use crate::provider::Provider;
 use crate::services::mcp::McpService;
 use crate::store::AppState;

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1505,7 +1505,63 @@ pub fn import_openclaw_providers_from_live(state: &AppState) -> Result<usize, Ap
         log::info!("Imported OpenClaw provider '{id}' from live config");
     }
 
+    // Honor the user's live `agents.defaults.model.primary` by marking the
+    // matching provider as `is_current=1` in the database. Without this step
+    // every imported provider stays at `is_current=0`, so cc-switch cannot
+    // tell which one the gateway is actually using.
+    sync_openclaw_current_from_primary(state);
+
     Ok(imported)
+}
+
+/// Mark the OpenClaw provider matching `agents.defaults.model.primary`
+/// (`<provider>/<model>` form) as `is_current=1` in the database.
+///
+/// - If the primary points to a provider that isn't (yet) in the database,
+///   this is a no-op.
+/// - If `primary` is missing or malformed, every imported provider remains
+///   `is_current=0` (the previous, broken behavior).
+fn sync_openclaw_current_from_primary(state: &AppState) {
+    let primary_provider_id = match openclaw_config::get_default_model() {
+        Ok(Some(model)) => model
+            .primary
+            .split('/')
+            .next()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
+        Ok(None) => None,
+        Err(e) => {
+            log::warn!("OpenClaw live primary: failed to read default model: {e}");
+            None
+        }
+    };
+
+    let Some(pid) = primary_provider_id else {
+        log::debug!(
+            "OpenClaw live primary: no agents.defaults.model.primary; skipping is_current sync"
+        );
+        return;
+    };
+
+    match state.db.get_provider_ids("openclaw") {
+        Ok(ids) if ids.contains(&pid) => {
+            if let Err(e) = state.db.set_current_provider("openclaw", &pid) {
+                log::warn!("OpenClaw live primary: failed to mark '{pid}' as current: {e}");
+            } else {
+                log::info!(
+                    "OpenClaw live primary: marked '{pid}' as current (matches live primary)"
+                );
+            }
+        }
+        Ok(_) => {
+            log::debug!(
+                "OpenClaw live primary: '{pid}' is not an imported provider; is_current left untouched"
+            );
+        }
+        Err(e) => {
+            log::warn!("OpenClaw live primary: failed to query provider ids: {e}");
+        }
+    }
 }
 
 /// Import all providers from Hermes live config to database

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -964,6 +964,44 @@ base_url = "http://localhost:8080"
 
     #[test]
     #[serial]
+    fn import_openclaw_providers_from_live_marks_primary_provider_as_current() {
+        with_test_home(|state, _| {
+            // Seed two OpenClaw live providers (minimax and deepseek), each with
+            // a single model so the importer keeps them.
+            for (id, model_id) in [("minimax", "minimax/MiniMax-M3"), ("deepseek", "deepseek/deepseek-v4-flash")] {
+                let mut p = openclaw_provider(id);
+                p.settings_config["models"] = json!([{ "id": model_id, "name": id }]);
+                crate::openclaw_config::set_provider(&p.id, p.settings_config.clone())
+                    .expect("seed openclaw live provider");
+            }
+
+            // Live config declares minimax as the active default.
+            crate::openclaw_config::set_default_model(&crate::openclaw_config::OpenClawDefaultModel {
+                primary: "minimax/MiniMax-M3".to_string(),
+                fallbacks: Vec::new(),
+                extra: std::collections::HashMap::new(),
+            })
+            .expect("seed openclaw default model");
+
+            let imported = import_openclaw_providers_from_live(state)
+                .expect("import openclaw providers from live");
+            assert_eq!(imported, 2);
+
+            let current = state
+                .db
+                .get_current_provider(AppType::OpenClaw.as_str())
+                .expect("query current provider");
+            assert_eq!(
+                current.as_deref(),
+                Some("minimax"),
+                "minimax should be marked current because it matches agents.defaults.model.primary"
+            );
+        });
+    }
+    }
+
+    #[test]
+    #[serial]
     fn update_persists_non_current_omo_variants_in_database() {
         with_test_home(|state, _| {
             for category in ["omo", "omo-slim"] {

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -968,7 +968,10 @@ base_url = "http://localhost:8080"
         with_test_home(|state, _| {
             // Seed two OpenClaw live providers (minimax and deepseek), each with
             // a single model so the importer keeps them.
-            for (id, model_id) in [("minimax", "minimax/MiniMax-M3"), ("deepseek", "deepseek/deepseek-v4-flash")] {
+            for (id, model_id) in [
+                ("minimax", "minimax/MiniMax-M3"),
+                ("deepseek", "deepseek/deepseek-v4-flash"),
+            ] {
                 let mut p = openclaw_provider(id);
                 p.settings_config["models"] = json!([{ "id": model_id, "name": id }]);
                 crate::openclaw_config::set_provider(&p.id, p.settings_config.clone())
@@ -976,11 +979,13 @@ base_url = "http://localhost:8080"
             }
 
             // Live config declares minimax as the active default.
-            crate::openclaw_config::set_default_model(&crate::openclaw_config::OpenClawDefaultModel {
-                primary: "minimax/MiniMax-M3".to_string(),
-                fallbacks: Vec::new(),
-                extra: std::collections::HashMap::new(),
-            })
+            crate::openclaw_config::set_default_model(
+                &crate::openclaw_config::OpenClawDefaultModel {
+                    primary: "minimax/MiniMax-M3".to_string(),
+                    fallbacks: Vec::new(),
+                    extra: std::collections::HashMap::new(),
+                },
+            )
             .expect("seed openclaw default model");
 
             let imported = import_openclaw_providers_from_live(state)
@@ -997,7 +1002,6 @@ base_url = "http://localhost:8080"
                 "minimax should be marked current because it matches agents.defaults.model.primary"
             );
         });
-    }
     }
 
     #[test]


### PR DESCRIPTION
When importing OpenClaw providers from the live openclaw.json into the cc-switch database, every provider was unconditionally written with is_current=0. This meant the database had no record of which provider the OpenClaw gateway was actually using, because that information lives in agents.defaults.model.primary on the live side, not in any per-provider field.

Concrete failure mode this caused:
  - User configures openclaw.json with primary pointing to provider A
  - User rotates out A's key, leaves B's key valid
  - cc-switch db shows both A and B as non-current
  - cc-switch UI / CLI picks a fallback (often first alphabetical, sometimes nothing) and writes the wrong config back, breaking the gateway

Fix: after the import loop, read agents.defaults.model.primary, parse the leading <provider>/<model> segment, and if a matching provider exists in the database call set_current_provider to mark it. Missing primary and primary pointing at a non-imported provider are no-ops; the previous behavior (all is_current=0) is preserved in those cases.

OpenCode and Hermes have an analogous bug but are out of scope here.

Test: new unit test seeds two OpenClaw live providers with one declared as the default, runs the importer, and asserts the matching provider is returned by get_current_provider.

## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
