### PR TITLE
fix(codex): sanitize common config at every entry point

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -306,6 +306,34 @@ fn remove_toml_table_like(target: &mut dyn TableLike, source: &dyn TableLike) {
     }
 }
 
+/// 移除 Codex common config 中不属于“跨 provider 用户配置”的字段。
+///
+/// common config 可以保存 `[features]`、`[mcp_servers]`、`[projects]` 等全局偏好；
+/// 但不能保存当前 provider 的模型、base_url、catalog 指针或 provider 表，否则切换
+/// official/provider 时会把旧路由或本地代理地址重新注入 live config。
+fn strip_codex_common_config_provider_fields(doc: &mut DocumentMut) {
+    for key in [
+        "model",
+        "model_provider",
+        "model_context_window",
+        "model_catalog_json",
+        "openai_base_url",
+        "experimental_bearer_token",
+    ] {
+        doc.as_table_mut().remove(key);
+    }
+    doc.as_table_mut().remove("model_providers");
+}
+
+/// 解析 Codex common config 片段，并在参与检测、应用或移除前净化 provider 私有字段。
+fn parse_codex_common_config_snippet(snippet: &str) -> Result<DocumentMut, AppError> {
+    let mut doc = snippet
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex common config snippet: {e}")))?;
+    strip_codex_common_config_provider_fields(&mut doc);
+    Ok(doc)
+}
+
 fn settings_contain_common_config(app_type: &AppType, settings: &Value, snippet: &str) -> bool {
     let trimmed = snippet.trim();
     if trimmed.is_empty() {
@@ -328,7 +356,13 @@ fn settings_contain_common_config(app_type: &AppType, settings: &Value, snippet:
                 Err(_) => return false,
             };
             let source_doc = match trimmed.parse::<DocumentMut>() {
-                Ok(doc) => doc,
+                Ok(mut doc) => {
+                    strip_codex_common_config_provider_fields(&mut doc);
+                    if doc.as_table().is_empty() {
+                        return false;
+                    }
+                    doc
+                }
                 Err(_) => return false,
             };
 
@@ -398,9 +432,10 @@ pub(crate) fn remove_common_config_from_settings(
                     ))
                 })?
             };
-            let source_doc = trimmed.parse::<DocumentMut>().map_err(|e| {
-                AppError::Message(format!("Invalid Codex common config snippet: {e}"))
-            })?;
+            let source_doc = parse_codex_common_config_snippet(trimmed)?;
+            if source_doc.as_table().is_empty() {
+                return Ok(settings.clone());
+            }
 
             remove_toml_table_like(target_doc.as_table_mut(), source_doc.as_table());
             if let Some(obj) = result.as_object_mut() {
@@ -453,9 +488,10 @@ fn apply_common_config_to_settings(
                     ))
                 })?
             };
-            let source_doc = trimmed.parse::<DocumentMut>().map_err(|e| {
-                AppError::Message(format!("Invalid Codex common config snippet: {e}"))
-            })?;
+            let source_doc = parse_codex_common_config_snippet(trimmed)?;
+            if source_doc.as_table().is_empty() {
+                return Ok(settings.clone());
+            }
 
             merge_toml_table_like(target_doc.as_table_mut(), source_doc.as_table());
             if let Some(obj) = result.as_object_mut() {
@@ -1641,6 +1677,60 @@ mod tests {
 
         let stripped =
             remove_common_config_from_settings(&AppType::Codex, &applied, snippet).unwrap();
+        assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn codex_common_config_does_not_import_provider_owned_router_fields() {
+        let settings = json!({
+            "auth": {
+                "OPENAI_API_KEY": "sk-test"
+            },
+            "config": "model_provider = \"openai\"\n[model_providers.openai]\nbase_url = \"https://api.openai.com/v1\"\n"
+        });
+        let snippet = r#"model_provider = "router"
+model_catalog_json = "cc-switch-model-catalog.json"
+openai_base_url = "http://127.0.0.1:15721/v1"
+experimental_bearer_token = "sk-router"
+
+[model_providers.router]
+base_url = "http://127.0.0.1:15721/v1"
+
+[features]
+web_search = true
+"#;
+
+        let applied = apply_common_config_to_settings(&AppType::Codex, &settings, snippet).unwrap();
+        let applied_config = applied["config"].as_str().unwrap_or_default();
+
+        assert!(applied_config.contains("model_provider = \"openai\""));
+        assert!(applied_config.contains("https://api.openai.com/v1"));
+        assert!(applied_config.contains("[features]"));
+        assert!(applied_config.contains("web_search = true"));
+        assert!(!applied_config.contains("model_catalog_json"));
+        assert!(!applied_config.contains("openai_base_url"));
+        assert!(!applied_config.contains("experimental_bearer_token"));
+        assert!(!applied_config.contains("127.0.0.1:15721"));
+        assert!(!applied_config.contains("[model_providers.router]"));
+    }
+
+    #[test]
+    fn codex_common_config_provider_only_snippet_is_not_detected_or_removed() {
+        let settings = json!({
+            "auth": {
+                "OPENAI_API_KEY": "sk-test"
+            },
+            "config": "model_provider = \"router\"\nmodel_catalog_json = \"cc-switch-model-catalog.json\"\n[model_providers.router]\nbase_url = \"http://127.0.0.1:15721/v1\"\n"
+        });
+        let snippet = "model_provider = \"router\"\n[model_providers.router]\nbase_url = \"http://127.0.0.1:15721/v1\"\n";
+
+        assert!(!settings_contain_common_config(
+            &AppType::Codex,
+            &settings,
+            snippet
+        ));
+        let stripped =
+            remove_common_config_from_settings(&AppType::Codex, &settings, snippet).unwrap();
         assert_eq!(stripped, settings);
     }
 

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -451,6 +451,14 @@ fn remove_toml_table_like(target: &mut dyn TableLike, source: &dyn TableLike) {
     }
 }
 
+fn parse_codex_common_config_snippet(snippet: &str) -> Result<DocumentMut, AppError> {
+    let mut doc = snippet
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex common config snippet: {e}")))?;
+    super::sanitize_codex_common_config_doc(&mut doc);
+    Ok(doc)
+}
+
 /// 前端表单勾选/取消"使用通用配置"时，对编辑器里的 config.toml 文本做
 /// 结构化合并/剥离。必须在后端用 toml_edit 做：前端 smol-toml 只能
 /// parse → merge → 整文档重序列化，注释全丢、键序重排，还会生成多余的
@@ -472,9 +480,10 @@ pub fn update_toml_common_config_snippet(
             .parse::<DocumentMut>()
             .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?
     };
-    let source_doc = trimmed
-        .parse::<DocumentMut>()
-        .map_err(|e| AppError::Message(format!("Invalid Codex common config snippet: {e}")))?;
+    let source_doc = parse_codex_common_config_snippet(trimmed)?;
+    if source_doc.as_table().is_empty() {
+        return Ok(config_toml.to_string());
+    }
 
     if enabled {
         merge_toml_table_like(target_doc.as_table_mut(), source_doc.as_table());
@@ -506,7 +515,8 @@ fn settings_contain_common_config(app_type: &AppType, settings: &Value, snippet:
                 Ok(doc) => doc,
                 Err(_) => return false,
             };
-            let source_doc = match trimmed.parse::<DocumentMut>() {
+            let source_doc = match parse_codex_common_config_snippet(trimmed) {
+                Ok(doc) if doc.as_table().is_empty() => return false,
                 Ok(doc) => doc,
                 Err(_) => return false,
             };
@@ -582,9 +592,10 @@ pub(crate) fn remove_common_config_from_settings(
                     ))
                 })?
             };
-            let source_doc = trimmed.parse::<DocumentMut>().map_err(|e| {
-                AppError::Message(format!("Invalid Codex common config snippet: {e}"))
-            })?;
+            let source_doc = parse_codex_common_config_snippet(trimmed)?;
+            if source_doc.as_table().is_empty() {
+                return Ok(settings.clone());
+            }
 
             remove_toml_table_like(target_doc.as_table_mut(), source_doc.as_table());
             if let Some(obj) = result.as_object_mut() {
@@ -640,9 +651,10 @@ fn apply_common_config_to_settings(
                     ))
                 })?
             };
-            let source_doc = trimmed.parse::<DocumentMut>().map_err(|e| {
-                AppError::Message(format!("Invalid Codex common config snippet: {e}"))
-            })?;
+            let source_doc = parse_codex_common_config_snippet(trimmed)?;
+            if source_doc.as_table().is_empty() {
+                return Ok(settings.clone());
+            }
 
             merge_toml_table_like(target_doc.as_table_mut(), source_doc.as_table());
             if let Some(obj) = result.as_object_mut() {
@@ -2863,6 +2875,129 @@ base_url = "https://a.example/v1"
         let stripped =
             remove_common_config_from_settings(&AppType::Codex, &applied, snippet).unwrap();
         assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn codex_common_config_sanitizes_owned_fields_before_apply() {
+        let settings = json!({
+            "auth": {},
+            "config": r#"model = "current-model"
+model_provider = "current"
+base_url = "https://current.example/v1"
+wire_api = "responses"
+
+[model_providers.current]
+base_url = "https://current.example/v1"
+wire_api = "responses"
+"#
+        });
+        let snippet = r#"model = "stale-model"
+review_model = "stale-review-model"
+model_provider = "stale"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "chat"
+model_context_window = 262144
+openai_base_url = "http://127.0.0.1:15721/v1"
+model_catalog_json = "stale-catalog.json"
+experimental_bearer_token = "sk-stale"
+web_search = "disabled"
+
+[model_providers.stale]
+name = "Stale"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "chat"
+
+[mcp_servers.stale]
+command = "stale-command"
+
+[mcp.servers.legacy]
+command = "legacy-command"
+
+[features]
+shell_snapshot = false
+"#;
+
+        let applied = apply_common_config_to_settings(&AppType::Codex, &settings, snippet).unwrap();
+        let config = applied["config"]
+            .as_str()
+            .expect("applied Codex config should remain a TOML string");
+        let parsed = config
+            .parse::<DocumentMut>()
+            .expect("applied Codex config should remain valid TOML");
+
+        assert_eq!(parsed["model"].as_str(), Some("current-model"));
+        assert_eq!(parsed["model_provider"].as_str(), Some("current"));
+        assert_eq!(
+            parsed["base_url"].as_str(),
+            Some("https://current.example/v1")
+        );
+        assert_eq!(parsed["wire_api"].as_str(), Some("responses"));
+        assert!(parsed.get("model_providers").is_some());
+        assert!(
+            !config.contains("stale")
+                && !config.contains("127.0.0.1")
+                && !config.contains("262144")
+                && !config.contains("mcp_servers")
+                && !config.contains("[mcp")
+                && !config.contains("web_search"),
+            "owned fields and injected artifacts must not be merged, got: {config}"
+        );
+        assert_eq!(parsed["features"]["shell_snapshot"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn codex_common_config_editor_sanitizes_owned_fields_before_merge() {
+        let config = r#"model_provider = "current"
+base_url = "https://current.example/v1"
+wire_api = "responses"
+"#;
+        let snippet = r#"model_provider = "stale"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "chat"
+
+[features]
+shell_snapshot = false
+"#;
+
+        let merged = update_toml_common_config_snippet(config, snippet, true).unwrap();
+        let parsed = merged
+            .parse::<DocumentMut>()
+            .expect("merged editor config should remain valid TOML");
+
+        assert_eq!(parsed["model_provider"].as_str(), Some("current"));
+        assert_eq!(
+            parsed["base_url"].as_str(),
+            Some("https://current.example/v1")
+        );
+        assert_eq!(parsed["wire_api"].as_str(), Some("responses"));
+        assert_eq!(parsed["features"]["shell_snapshot"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn codex_common_config_owned_only_snippet_is_not_detected_or_removed() {
+        let settings = json!({
+            "auth": {},
+            "config": r#"model_provider = "router"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+
+[model_providers.router]
+base_url = "http://127.0.0.1:15721/v1"
+"#
+        });
+        let snippet = settings["config"]
+            .as_str()
+            .expect("fixture should contain a config string");
+
+        assert!(
+            !settings_contain_common_config(&AppType::Codex, &settings, snippet),
+            "provider-owned fields alone must not enable legacy common-config inference"
+        );
+        assert_eq!(
+            remove_common_config_from_settings(&AppType::Codex, &settings, snippet).unwrap(),
+            settings,
+            "removing an owned-only snippet must not delete the active provider route"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -100,6 +100,51 @@ pub fn reapply_current_codex_official_live(state: &AppState) -> Result<bool, App
     Ok(true)
 }
 
+/// Remove values that are owned by the selected Codex provider or another cc-switch store.
+///
+/// Common-config extraction and every later consumer must share this policy. Otherwise an old
+/// database row or manually edited snippet can bypass extraction and restore stale routing,
+/// credentials, generated catalog pointers, or DB-managed MCP servers.
+fn sanitize_codex_common_config_doc(doc: &mut toml_edit::DocumentMut) {
+    let root = doc.as_table_mut();
+    for key in [
+        "model",
+        "review_model",
+        "model_provider",
+        "base_url",
+        "wire_api",
+        "model_context_window",
+        "openai_base_url",
+        "experimental_bearer_token",
+        "model_catalog_json",
+    ] {
+        root.remove(key);
+    }
+
+    root.remove("model_providers");
+    root.remove("mcp_servers");
+
+    // Also remove the historical [mcp.servers] shape. The MCP database cannot reconcile it.
+    if let Some(mcp_table) = root
+        .get_mut("mcp")
+        .and_then(|item| item.as_table_like_mut())
+    {
+        mcp_table.remove("servers");
+        if mcp_table.is_empty() {
+            root.remove("mcp");
+        }
+    }
+
+    // Preserve explicit user choices, but never persist cc-switch's injected sentinel.
+    if root
+        .get(crate::codex_config::CODEX_WEB_SEARCH_FIELD)
+        .and_then(|item| item.as_str())
+        == Some(crate::codex_config::CODEX_WEB_SEARCH_DISABLED)
+    {
+        root.remove(crate::codex_config::CODEX_WEB_SEARCH_FIELD);
+    }
+}
+
 /// Provider business logic service
 pub struct ProviderService;
 
@@ -1660,6 +1705,9 @@ GEMINI_TIMEOUT_MS=30000
         // [mcp.servers] 是历史错误格式，sync_all_enabled 清不掉它。
         let config_toml = r#"model_provider = "azure"
 model = "gpt-4"
+review_model = "gpt-4-review"
+model_context_window = 262144
+openai_base_url = "https://legacy-router.example/v1"
 wire_api = "chat"
 disable_response_storage = true
 experimental_bearer_token = "sk-live-secret"
@@ -1693,6 +1741,12 @@ command = "legacy-cmd"
                 .lines()
                 .any(|line| line.trim_start().starts_with("model =")),
             "should remove top-level model"
+        );
+        assert!(
+            !extracted.contains("review_model")
+                && !extracted.contains("model_context_window")
+                && !extracted.contains("openai_base_url"),
+            "should remove alternate provider-owned routing and model fields, got: {extracted}"
         );
         assert!(
             !extracted.contains("[model_providers"),
@@ -5867,53 +5921,7 @@ impl ProviderService {
             .parse::<toml_edit::DocumentMut>()
             .map_err(|e| AppError::Message(format!("TOML parse error: {e}")))?;
 
-        // Remove provider-specific fields.
-        let root = doc.as_table_mut();
-        root.remove("model");
-        root.remove("model_provider");
-        // Legacy/alt formats might use a top-level base_url.
-        root.remove("base_url");
-        // wire_api 与 base_url 同属供应商路由语义：无 model_provider 时
-        // update_codex_toml_field / 前端 setCodexWireApi 都会把它落在顶层，
-        // 进了片段会改写其它供应商的协议选择（chat vs responses）。
-        root.remove("wire_api");
-
-        // Remove entire model_providers table (provider-specific configuration)
-        root.remove("model_providers");
-
-        // MCP 服务器归 DB mcp_servers 表所有：进了共享片段会绕过按应用的
-        // 启用状态被合并进所有勾选通用配置的供应商，且在通用配置编辑框里
-        // 显示为一份"重复"的 MCP 配置。
-        root.remove("mcp_servers");
-        // 历史错误格式 [mcp.servers] 一并剥离（与 strip_codex_mcp_servers_from_settings
-        // 一致）：sync_all_enabled 只管理 [mcp_servers.*]，legacy 形态一旦进了
-        // 片段就会被合并进所有供应商，且没有任何同步路径能清掉这个孤儿。
-        if let Some(mcp_tbl) = root
-            .get_mut("mcp")
-            .and_then(|item| item.as_table_like_mut())
-        {
-            mcp_tbl.remove("servers");
-            if mcp_tbl.is_empty() {
-                root.remove("mcp");
-            }
-        }
-
-        // cc-switch 写 live 时注入的产物一律不进共享片段：
-        // - experimental_bearer_token 正常写在 [model_providers.<id>] 内（上面
-        //   整表已剥），但无活跃路由 / 内建保留 id / 路由表缺失三种 fallback
-        //   会落在顶层——不剥等于把 API 密钥写进共享片段。
-        root.remove("experimental_bearer_token");
-        // - model_catalog_json 指向按供应商生成的 catalog 投影文件（DB 为 SSOT）。
-        root.remove("model_catalog_json");
-        // - web_search 只剥 cc-switch 注入的 "disabled" 哨兵；用户手设的其它值
-        //   属于可共享偏好，保留。
-        if root
-            .get(crate::codex_config::CODEX_WEB_SEARCH_FIELD)
-            .and_then(|item| item.as_str())
-            == Some(crate::codex_config::CODEX_WEB_SEARCH_DISABLED)
-        {
-            root.remove(crate::codex_config::CODEX_WEB_SEARCH_FIELD);
-        }
+        sanitize_codex_common_config_doc(&mut doc);
 
         // Clean up multiple empty lines (keep at most one blank line).
         let mut cleaned = String::new();


### PR DESCRIPTION
## Summary

Related to #4012, #3824, #2296, and the common-config extraction hardening in `473c2aaa`.

Codex common config already has an ownership policy at extraction time: provider routing, generated catalog fields, injected credentials, and DB-managed MCP entries must not enter the shared snippet. However, legacy rows and manually edited snippets bypassed extraction. Detection, editor merge, provider apply, and removal each parsed the raw TOML again.

That mismatch could:

- restore a stale `model_provider`, `base_url`, `wire_api`, token, or provider table while switching;
- reintroduce catalog/MCP artifacts owned by other cc-switch stores;
- infer common-config enablement from provider-only fields;
- delete the active route when removing a provider-only snippet.

This PR makes extraction and every consumer share one sanitizer. Provider-owned-only snippets become a no-op, while user-owned values such as `[features]` continue to merge normally. It also incorporates the previous review request to cover top-level `base_url`.

The branch was rebuilt as one commit on current `main` (`f3b18df1`).

## Validation

- `cargo test --manifest-path src-tauri\Cargo.toml codex_common_config --lib` — 8 passed
- `cargo check --manifest-path src-tauri\Cargo.toml`
- `cargo fmt --manifest-path src-tauri\Cargo.toml -- --check`
- `tsc --noEmit`
- `git diff --check`
- strict UTF-8 decode; no BOM or U+FFFD in changed files