### PR TITLE
Fix Claude Official auth cleanup

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -18,6 +18,12 @@ use std::os::windows::process::CommandExt;
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+const CLAUDE_API_AUTH_ENV_KEYS: [&str; 3] = [
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+];
+
 /// 打开外部链接
 #[tauri::command]
 pub async fn open_external(app: AppHandle, url: String) -> Result<bool, String> {
@@ -2403,6 +2409,12 @@ pub async fn open_provider_terminal(
         .get(&providerId)
         .ok_or_else(|| format!("提供商 {providerId} 不存在"))?;
 
+    if is_claude_official_provider(&app_type, provider) {
+        launch_official_claude_terminal(launch_cwd.as_deref())
+            .map_err(|e| format!("启动终端失败: {e}"))?;
+        return Ok(true);
+    }
+
     // 从提供商配置中提取环境变量
     let config = &provider.settings_config;
     let env_vars = extract_env_vars_from_config(config, &app_type);
@@ -2412,6 +2424,10 @@ pub async fn open_provider_terminal(
         .map_err(|e| format!("启动终端失败: {e}"))?;
 
     Ok(true)
+}
+
+fn is_claude_official_provider(app_type: &AppType, provider: &crate::provider::Provider) -> bool {
+    *app_type == AppType::Claude && provider.category.as_deref() == Some("official")
 }
 
 /// 从提供商配置中提取环境变量
@@ -2520,19 +2536,43 @@ fn launch_terminal_with_env(
 
     #[cfg(target_os = "macos")]
     {
-        launch_macos_terminal(&config_file, cwd)?;
+        launch_macos_terminal(Some(&config_file), cwd)?;
         Ok(())
     }
 
     #[cfg(target_os = "linux")]
     {
-        launch_linux_terminal(&config_file, cwd)?;
+        launch_linux_terminal(Some(&config_file), cwd)?;
         Ok(())
     }
 
     #[cfg(target_os = "windows")]
     {
-        launch_windows_terminal(&temp_dir, &config_file, cwd)?;
+        launch_windows_terminal(&temp_dir, Some(&config_file), cwd)?;
+        return Ok(());
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    Err("不支持的操作系统".to_string())
+}
+
+fn launch_official_claude_terminal(cwd: Option<&Path>) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        launch_macos_terminal(None, cwd)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        launch_linux_terminal(None, cwd)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let temp_dir = std::env::temp_dir();
+        launch_windows_terminal(&temp_dir, None, cwd)?;
         return Ok(());
     }
 
@@ -2560,9 +2600,75 @@ fn write_claude_config(
     std::fs::write(config_file, config_json).map_err(|e| format!("写入配置文件失败: {e}"))
 }
 
+#[cfg(not(target_os = "windows"))]
+fn build_claude_terminal_invocation(config_file: Option<&std::path::Path>) -> String {
+    if let Some(config_file) = config_file {
+        return format!(
+            "claude --settings {}",
+            shell_single_quote(&config_file.to_string_lossy())
+        );
+    }
+
+    format!("unset {}\nclaude", CLAUDE_API_AUTH_ENV_KEYS.join(" "))
+}
+
+#[cfg(target_os = "windows")]
+fn build_claude_terminal_invocation(config_file: Option<&std::path::Path>) -> String {
+    if let Some(config_file) = config_file {
+        return format!(
+            "claude --settings \"{}\"",
+            escape_windows_batch_value(&config_file.to_string_lossy())
+        );
+    }
+
+    let mut lines: Vec<String> = CLAUDE_API_AUTH_ENV_KEYS
+        .iter()
+        .map(|key| format!("set {key}="))
+        .collect();
+    lines.push("claude".to_string());
+    lines.join("\r\n")
+}
+
+#[cfg(not(target_os = "windows"))]
+fn build_claude_terminal_intro(config_file: Option<&std::path::Path>) -> String {
+    if let Some(config_file) = config_file {
+        return format!(
+            "echo \"Using provider-specific claude config:\"\necho \"{}\"",
+            config_file.display()
+        );
+    }
+
+    "echo \"Using Claude official auth\"".to_string()
+}
+
+#[cfg(target_os = "windows")]
+fn build_claude_terminal_intro(config_file: Option<&std::path::Path>) -> String {
+    if let Some(config_file) = config_file {
+        let config_path = escape_windows_batch_value(&config_file.to_string_lossy());
+        return format!("echo Using provider-specific claude config:\r\necho {config_path}");
+    }
+
+    "echo Using Claude official auth".to_string()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn build_claude_terminal_cleanup(
+    script_file: &std::path::Path,
+    config_file: Option<&std::path::Path>,
+) -> String {
+    let mut cleanup = format!("\"{}\"", script_file.display());
+    if let Some(config_file) = config_file {
+        cleanup.push_str(&format!(" \"{}\"", config_file.display()));
+    }
+    cleanup
+}
+
 /// macOS: 根据用户首选终端启动
 #[cfg(target_os = "macos")]
-fn launch_macos_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> Result<(), String> {
+fn launch_macos_terminal(
+    config_file: Option<&std::path::Path>,
+    cwd: Option<&Path>,
+) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
 
     let preferred = crate::settings::get_preferred_terminal();
@@ -2570,22 +2676,18 @@ fn launch_macos_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> R
 
     let temp_dir = std::env::temp_dir();
     let script_file = temp_dir.join(format!("cc_switch_launcher_{}.sh", std::process::id()));
-    let config_path = config_file.to_string_lossy();
     let cd_command = build_shell_cd_command(cwd);
+    let cleanup_paths = build_claude_terminal_cleanup(&script_file, config_file);
+    let intro = build_claude_terminal_intro(config_file);
+    let claude_command = build_claude_terminal_invocation(config_file);
 
     // Write the shell script to a temp file
     let script_content = format!(
-        r#"#!/bin/bash
-trap 'rm -f "{config_path}" "{script_file}"' EXIT
-{cd_command}
-echo "Using provider-specific claude config:"
-echo "{config_path}"
-claude --settings "{config_path}"
-exec bash --norc --noprofile
-"#,
-        config_path = config_path,
-        script_file = script_file.display(),
+        "#!/bin/bash\ntrap 'rm -f {cleanup_paths}' EXIT\n{cd_command}{intro}\n{claude_command}\nexec bash --norc --noprofile\n",
+        cleanup_paths = cleanup_paths,
         cd_command = cd_command,
+        intro = intro,
+        claude_command = claude_command,
     );
 
     std::fs::write(&script_file, &script_content).map_err(|e| format!("写入启动脚本失败: {e}"))?;
@@ -2866,7 +2968,10 @@ fn launch_macos_warp(script_file: &std::path::Path) -> Result<(), String> {
 
 /// Linux: 根据用户首选终端启动
 #[cfg(target_os = "linux")]
-fn launch_linux_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> Result<(), String> {
+fn launch_linux_terminal(
+    config_file: Option<&std::path::Path>,
+    cwd: Option<&Path>,
+) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
 
@@ -2887,21 +2992,17 @@ fn launch_linux_terminal(config_file: &std::path::Path, cwd: Option<&Path>) -> R
     // Create temp script file
     let temp_dir = std::env::temp_dir();
     let script_file = temp_dir.join(format!("cc_switch_launcher_{}.sh", std::process::id()));
-    let config_path = config_file.to_string_lossy();
     let cd_command = build_shell_cd_command(cwd);
+    let cleanup_paths = build_claude_terminal_cleanup(&script_file, config_file);
+    let intro = build_claude_terminal_intro(config_file);
+    let claude_command = build_claude_terminal_invocation(config_file);
 
     let script_content = format!(
-        r#"#!/bin/bash
-trap 'rm -f "{config_path}" "{script_file}"' EXIT
-{cd_command}
-echo "Using provider-specific claude config:"
-echo "{config_path}"
-claude --settings "{config_path}"
-exec bash --norc --noprofile
-"#,
-        config_path = config_path,
-        script_file = script_file.display(),
+        "#!/bin/bash\ntrap 'rm -f {cleanup_paths}' EXIT\n{cd_command}{intro}\n{claude_command}\nexec bash --norc --noprofile\n",
+        cleanup_paths = cleanup_paths,
         cd_command = cd_command,
+        intro = intro,
+        claude_command = claude_command,
     );
 
     std::fs::write(&script_file, &script_content).map_err(|e| format!("写入启动脚本失败: {e}"))?;
@@ -2979,29 +3080,31 @@ fn which_command(cmd: &str) -> bool {
 #[cfg(target_os = "windows")]
 fn launch_windows_terminal(
     temp_dir: &std::path::Path,
-    config_file: &std::path::Path,
+    config_file: Option<&std::path::Path>,
     cwd: Option<&Path>,
 ) -> Result<(), String> {
     let preferred = crate::settings::get_preferred_terminal();
     let terminal = preferred.as_deref().unwrap_or("cmd");
 
     let bat_file = temp_dir.join(format!("cc_switch_claude_{}.bat", std::process::id()));
-    let config_path_for_batch = escape_windows_batch_value(&config_file.to_string_lossy());
     let cwd_command = build_windows_cwd_command(cwd);
+    let intro = build_claude_terminal_intro(config_file);
+    let claude_command = build_claude_terminal_invocation(config_file);
+    let cleanup_config = config_file
+        .map(|path| {
+            format!(
+                "del \"{}\" >nul 2>&1\r\n",
+                escape_windows_batch_value(&path.to_string_lossy())
+            )
+        })
+        .unwrap_or_default();
 
     let content = format!(
-        "@echo off
-{cwd_command}
-echo Using provider-specific claude config:
-echo {}
-claude --settings \"{}\"
-del \"{}\" >nul 2>&1
-del \"%~f0\" >nul 2>&1
-",
-        config_path_for_batch,
-        config_path_for_batch,
-        config_path_for_batch,
+        "@echo off\r\n{cwd_command}{intro}\r\n{claude_command}\r\n{cleanup_config}del \"%~f0\" >nul 2>&1\r\n",
         cwd_command = cwd_command,
+        intro = intro,
+        claude_command = claude_command,
+        cleanup_config = cleanup_config,
     );
 
     std::fs::write(&bat_file, &content).map_err(|e| format!("写入批处理文件失败: {e}"))?;
@@ -4691,6 +4794,34 @@ mod tests {
         let command = build_shell_cd_command(Some(Path::new("/tmp/project O'Brien")));
 
         assert_eq!(command, "cd '/tmp/project O'\"'\"'Brien' || exit 1\n");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn official_claude_terminal_invocation_clears_api_env_and_uses_default_settings() {
+        let command = build_claude_terminal_invocation(None);
+
+        assert!(
+            command.contains("unset ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL"),
+            "official Claude launch must clear API auth env: {command}"
+        );
+        assert!(
+            command.lines().any(|line| line == "claude"),
+            "official Claude launch should run the default claude command: {command}"
+        );
+        assert!(
+            !command.contains("--settings"),
+            "official Claude launch must not inject provider-specific settings: {command}"
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn provider_claude_terminal_invocation_uses_provider_settings() {
+        let command = build_claude_terminal_invocation(Some(Path::new("/tmp/cc switch.json")));
+
+        assert!(command.contains("claude --settings '/tmp/cc switch.json'"));
+        assert!(!command.contains("unset ANTHROPIC_AUTH_TOKEN"));
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2410,7 +2410,7 @@ pub async fn open_provider_terminal(
         .ok_or_else(|| format!("提供商 {providerId} 不存在"))?;
 
     if is_claude_official_provider(&app_type, provider) {
-        prepare_official_claude_terminal_launch(&app_type, provider)?;
+        prepare_official_claude_terminal_launch(state.inner(), &app_type, provider)?;
         launch_official_claude_terminal(launch_cwd.as_deref())
             .map_err(|e| format!("启动终端失败: {e}"))?;
         return Ok(true);
@@ -2432,9 +2432,23 @@ fn is_claude_official_provider(app_type: &AppType, provider: &crate::provider::P
 }
 
 fn prepare_official_claude_terminal_launch(
+    state: &crate::store::AppState,
     app_type: &AppType,
     provider: &crate::provider::Provider,
 ) -> Result<(), String> {
+    let _switch_guard =
+        futures::executor::block_on(state.proxy_service.lock_switch_for_app(app_type.as_str()));
+    let has_live_backup = futures::executor::block_on(state.db.get_live_backup(app_type.as_str()))
+        .map_err(|e| format!("读取 Live 备份失败: {e}"))?
+        .is_some();
+    let live_taken_over = state
+        .proxy_service
+        .detect_takeover_in_live_config_for_app(app_type);
+
+    if has_live_backup || live_taken_over {
+        return Err("代理接管模式下不能打开 Claude 官方终端，请先关闭代理接管。".to_string());
+    }
+
     crate::services::provider::write_live_snapshot(app_type, provider)
         .map_err(|e| format!("更新 Claude 官方配置失败: {e}"))
 }
@@ -2642,12 +2656,16 @@ fn build_claude_terminal_invocation(config_file: Option<&std::path::Path>) -> St
 fn build_claude_terminal_intro(config_file: Option<&std::path::Path>) -> String {
     if let Some(config_file) = config_file {
         return format!(
-            "echo \"Using provider-specific claude config:\"\necho \"{}\"",
-            config_file.display()
+            "printf '%s\\n' {}\nprintf '%s\\n' {}",
+            shell_single_quote("Using provider-specific claude config:"),
+            shell_single_quote(&config_file.to_string_lossy())
         );
     }
 
-    "echo \"Using Claude official auth\"".to_string()
+    format!(
+        "printf '%s\\n' {}",
+        shell_single_quote("Using Claude official auth")
+    )
 }
 
 #[cfg(target_os = "windows")]
@@ -2665,11 +2683,11 @@ fn build_claude_terminal_cleanup(
     script_file: &std::path::Path,
     config_file: Option<&std::path::Path>,
 ) -> String {
-    let mut cleanup = format!("\"{}\"", script_file.display());
+    let mut paths = vec![shell_single_quote(&script_file.to_string_lossy())];
     if let Some(config_file) = config_file {
-        cleanup.push_str(&format!(" \"{}\"", config_file.display()));
+        paths.push(shell_single_quote(&config_file.to_string_lossy()));
     }
-    cleanup
+    shell_single_quote(&format!("rm -f {}", paths.join(" ")))
 }
 
 /// macOS: 根据用户首选终端启动
@@ -2686,14 +2704,14 @@ fn launch_macos_terminal(
     let temp_dir = std::env::temp_dir();
     let script_file = temp_dir.join(format!("cc_switch_launcher_{}.sh", std::process::id()));
     let cd_command = build_shell_cd_command(cwd);
-    let cleanup_paths = build_claude_terminal_cleanup(&script_file, config_file);
+    let cleanup_trap = build_claude_terminal_cleanup(&script_file, config_file);
     let intro = build_claude_terminal_intro(config_file);
     let claude_command = build_claude_terminal_invocation(config_file);
 
     // Write the shell script to a temp file
     let script_content = format!(
-        "#!/bin/bash\ntrap 'rm -f {cleanup_paths}' EXIT\n{cd_command}{intro}\n{claude_command}\nexec bash --norc --noprofile\n",
-        cleanup_paths = cleanup_paths,
+        "#!/bin/bash\ntrap {cleanup_trap} EXIT\n{cd_command}{intro}\n{claude_command}\nexec bash --norc --noprofile\n",
+        cleanup_trap = cleanup_trap,
         cd_command = cd_command,
         intro = intro,
         claude_command = claude_command,
@@ -3002,13 +3020,13 @@ fn launch_linux_terminal(
     let temp_dir = std::env::temp_dir();
     let script_file = temp_dir.join(format!("cc_switch_launcher_{}.sh", std::process::id()));
     let cd_command = build_shell_cd_command(cwd);
-    let cleanup_paths = build_claude_terminal_cleanup(&script_file, config_file);
+    let cleanup_trap = build_claude_terminal_cleanup(&script_file, config_file);
     let intro = build_claude_terminal_intro(config_file);
     let claude_command = build_claude_terminal_invocation(config_file);
 
     let script_content = format!(
-        "#!/bin/bash\ntrap 'rm -f {cleanup_paths}' EXIT\n{cd_command}{intro}\n{claude_command}\nexec bash --norc --noprofile\n",
-        cleanup_paths = cleanup_paths,
+        "#!/bin/bash\ntrap {cleanup_trap} EXIT\n{cd_command}{intro}\n{claude_command}\nexec bash --norc --noprofile\n",
+        cleanup_trap = cleanup_trap,
         cd_command = cd_command,
         intro = intro,
         claude_command = claude_command,
@@ -3429,6 +3447,7 @@ mod tests {
     use serde_json::{json, Value};
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
     struct TempHome {
         _dir: tempfile::TempDir,
@@ -4867,10 +4886,52 @@ mod tests {
         assert!(!command.contains("unset ANTHROPIC_AUTH_TOKEN"));
     }
 
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn claude_terminal_script_fragments_quote_special_paths() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let config_path = temp_dir.path().join("cc switch O'Brien.json");
+        let script_path = temp_dir.path().join("cc switch launcher O'Brien.sh");
+        let command = build_claude_terminal_invocation(Some(&config_path));
+        let intro = build_claude_terminal_intro(Some(&config_path));
+        let cleanup_trap = build_claude_terminal_cleanup(&script_path, Some(&config_path));
+        let script = format!("#!/bin/bash\ntrap {cleanup_trap} EXIT\n{intro}\n{command}\n");
+
+        assert!(command.contains("cc switch O'\"'\"'Brien.json'"));
+        assert!(intro.contains("cc switch O'\"'\"'Brien.json'"));
+
+        let status = std::process::Command::new("bash")
+            .arg("-n")
+            .arg("-c")
+            .arg(&script)
+            .status()
+            .expect("bash should parse launcher fragment");
+        assert!(
+            status.success(),
+            "launcher fragment should parse:\n{script}"
+        );
+
+        std::fs::write(
+            &script_path,
+            format!("#!/bin/bash\ntrap {cleanup_trap} EXIT\n"),
+        )
+        .expect("write cleanup script");
+        std::fs::write(&config_path, "{}").expect("write cleanup config");
+        let status = std::process::Command::new("bash")
+            .arg(&script_path)
+            .status()
+            .expect("bash should run cleanup script");
+        assert!(status.success(), "cleanup script should exit successfully");
+        assert!(!script_path.exists(), "launcher script should be removed");
+        assert!(!config_path.exists(), "config file should be removed");
+    }
+
     #[test]
     #[serial_test::serial]
     fn official_claude_terminal_launch_prepares_clean_live_settings() {
         let _home = TempHome::new();
+        let db = Arc::new(crate::database::Database::memory().expect("init db"));
+        let state = crate::store::AppState::new(db);
         let mut provider = Provider::with_id(
             "claude-official".to_string(),
             "Claude Official".to_string(),
@@ -4890,7 +4951,7 @@ mod tests {
         );
         provider.category = Some("official".to_string());
 
-        prepare_official_claude_terminal_launch(&AppType::Claude, &provider)
+        prepare_official_claude_terminal_launch(&state, &AppType::Claude, &provider)
             .expect("prepare official Claude terminal launch");
 
         let written: Value =
@@ -4914,6 +4975,46 @@ mod tests {
             written.pointer("/permissions/allow/0"),
             Some(&json!("Bash"))
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn official_claude_terminal_launch_rejects_proxy_takeover() {
+        let _home = TempHome::new();
+        let db = Arc::new(crate::database::Database::memory().expect("init db"));
+        let state = crate::store::AppState::new(db.clone());
+        let existing_live = json!({
+            "env": {
+                "ANTHROPIC_API_KEY": "PROXY_MANAGED",
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721"
+            }
+        });
+        crate::config::write_json_file(&crate::config::get_claude_settings_path(), &existing_live)
+            .expect("write proxy live config");
+        futures::executor::block_on(db.save_live_backup("claude", "{\"env\":{}}"))
+            .expect("save live backup");
+
+        let mut provider = Provider::with_id(
+            "claude-official".to_string(),
+            "Claude Official".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "stale-auth-token",
+                    "ANTHROPIC_BASE_URL": "https://api.example.com"
+                }
+            }),
+            None,
+        );
+        provider.category = Some("official".to_string());
+
+        let err = prepare_official_claude_terminal_launch(&state, &AppType::Claude, &provider)
+            .expect_err("official launch should be blocked during proxy takeover");
+        assert!(err.contains("代理接管模式"));
+
+        let written: Value =
+            crate::config::read_json_file(&crate::config::get_claude_settings_path())
+                .expect("read live config");
+        assert_eq!(written, existing_live);
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2410,6 +2410,7 @@ pub async fn open_provider_terminal(
         .ok_or_else(|| format!("提供商 {providerId} 不存在"))?;
 
     if is_claude_official_provider(&app_type, provider) {
+        prepare_official_claude_terminal_launch(&app_type, provider)?;
         launch_official_claude_terminal(launch_cwd.as_deref())
             .map_err(|e| format!("启动终端失败: {e}"))?;
         return Ok(true);
@@ -2428,6 +2429,14 @@ pub async fn open_provider_terminal(
 
 fn is_claude_official_provider(app_type: &AppType, provider: &crate::provider::Provider) -> bool {
     *app_type == AppType::Claude && provider.category.as_deref() == Some("official")
+}
+
+fn prepare_official_claude_terminal_launch(
+    app_type: &AppType,
+    provider: &crate::provider::Provider,
+) -> Result<(), String> {
+    crate::services::provider::write_live_snapshot(app_type, provider)
+        .map_err(|e| format!("更新 Claude 官方配置失败: {e}"))
 }
 
 /// 从提供商配置中提取环境变量
@@ -3061,7 +3070,9 @@ fn launch_linux_terminal(
 
     // Clean up on failure
     let _ = std::fs::remove_file(&script_file);
-    let _ = std::fs::remove_file(config_file);
+    if let Some(config_file) = config_file {
+        let _ = std::fs::remove_file(config_file);
+    }
     Err(last_error)
 }
 
@@ -3414,7 +3425,39 @@ pub async fn set_window_theme(window: tauri::Window, theme: String) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::Provider;
+    use serde_json::{json, Value};
+    use std::ffi::OsString;
     use std::path::{Path, PathBuf};
+
+    struct TempHome {
+        _dir: tempfile::TempDir,
+        original_test_home: Option<OsString>,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let dir = tempfile::TempDir::new().expect("create temp home");
+            let original_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+            std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            crate::settings::reload_settings().expect("reload settings");
+
+            Self {
+                _dir: dir,
+                original_test_home,
+            }
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            match &self.original_test_home {
+                Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+            crate::settings::reload_settings().expect("reload settings");
+        }
+    }
 
     #[test]
     fn test_extract_version() {
@@ -4822,6 +4865,55 @@ mod tests {
 
         assert!(command.contains("claude --settings '/tmp/cc switch.json'"));
         assert!(!command.contains("unset ANTHROPIC_AUTH_TOKEN"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn official_claude_terminal_launch_prepares_clean_live_settings() {
+        let _home = TempHome::new();
+        let mut provider = Provider::with_id(
+            "claude-official".to_string(),
+            "Claude Official".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "stale-auth-token",
+                    "ANTHROPIC_API_KEY": "stale-api-key",
+                    "ANTHROPIC_BASE_URL": "https://api.example.com",
+                    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+                },
+                "apiBaseUrl": "https://api.example.com",
+                "primaryModel": "stale-primary",
+                "smallFastModel": "stale-small",
+                "permissions": { "allow": ["Bash"] }
+            }),
+            None,
+        );
+        provider.category = Some("official".to_string());
+
+        prepare_official_claude_terminal_launch(&AppType::Claude, &provider)
+            .expect("prepare official Claude terminal launch");
+
+        let written: Value =
+            crate::config::read_json_file(&crate::config::get_claude_settings_path())
+                .expect("read live config");
+        let env = written.get("env").and_then(Value::as_object);
+        assert!(
+            env.is_none_or(|env| !env.keys().any(|key| key.starts_with("ANTHROPIC_"))),
+            "official Claude terminal launch must clear live ANTHROPIC_* env: {written}"
+        );
+        assert!(written.get("apiBaseUrl").is_none());
+        assert!(written.get("primaryModel").is_none());
+        assert!(written.get("smallFastModel").is_none());
+        assert_eq!(
+            written
+                .pointer("/env/CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")
+                .and_then(Value::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            written.pointer("/permissions/allow/0"),
+            Some(&json!("Bash"))
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -21,6 +21,9 @@ use super::gemini_auth::{
 };
 use super::normalize_claude_models_in_value;
 
+const CLAUDE_OFFICIAL_TOP_LEVEL_API_KEYS: [&str; 3] =
+    ["apiBaseUrl", "primaryModel", "smallFastModel"];
+
 pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
     let mut v = settings.clone();
     if let Some(obj) = v.as_object_mut() {
@@ -31,6 +34,31 @@ pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
         obj.remove("openrouterCompatMode");
     }
     v
+}
+
+fn sanitize_claude_provider_settings_for_live(provider: &Provider) -> Value {
+    let mut settings = sanitize_claude_settings_for_live(&provider.settings_config);
+    if provider.category.as_deref() == Some("official") {
+        remove_claude_api_overrides(&mut settings);
+    }
+    settings
+}
+
+fn remove_claude_api_overrides(settings: &mut Value) {
+    let Some(obj) = settings.as_object_mut() else {
+        return;
+    };
+
+    for key in CLAUDE_OFFICIAL_TOP_LEVEL_API_KEYS {
+        obj.remove(key);
+    }
+
+    if let Some(env) = obj.get_mut("env").and_then(Value::as_object_mut) {
+        env.retain(|key, _| !key.starts_with("ANTHROPIC_"));
+        if env.is_empty() {
+            obj.remove("env");
+        }
+    }
 }
 
 pub(crate) fn provider_exists_in_live_config(
@@ -740,7 +768,7 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
     match app_type {
         AppType::Claude => {
             let path = get_claude_settings_path();
-            let settings = sanitize_claude_settings_for_live(&provider.settings_config);
+            let settings = sanitize_claude_provider_settings_for_live(provider);
             write_json_file(&path, &settings)?;
         }
         AppType::ClaudeDesktop => {
@@ -1599,6 +1627,36 @@ pub fn remove_openclaw_provider_from_live(provider_id: &str) -> Result<(), AppEr
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::ffi::OsString;
+
+    struct TempHome {
+        _dir: tempfile::TempDir,
+        original_test_home: Option<OsString>,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let dir = tempfile::TempDir::new().expect("create temp home");
+            let original_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+            std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            crate::settings::reload_settings().expect("reload settings");
+
+            Self {
+                _dir: dir,
+                original_test_home,
+            }
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            match &self.original_test_home {
+                Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+            crate::settings::reload_settings().expect("reload settings");
+        }
+    }
 
     #[test]
     fn claude_common_config_apply_and_remove_roundtrip_for_non_overlapping_fields() {
@@ -1622,6 +1680,54 @@ mod tests {
         let stripped =
             remove_common_config_from_settings(&AppType::Claude, &applied, snippet).unwrap();
         assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn official_claude_live_write_removes_api_auth_env() {
+        let _home = TempHome::new();
+        let mut provider = Provider::with_id(
+            "claude-official".to_string(),
+            "Claude Official".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "stale-auth-token",
+                    "ANTHROPIC_API_KEY": "stale-api-key",
+                    "ANTHROPIC_BASE_URL": "https://api.example.com",
+                    "ANTHROPIC_MODEL": "stale-model",
+                    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+                },
+                "apiBaseUrl": "https://api.example.com",
+                "primaryModel": "stale-primary",
+                "smallFastModel": "stale-small",
+                "permissions": { "allow": ["Bash"] }
+            }),
+            None,
+        );
+        provider.category = Some("official".to_string());
+
+        write_live_snapshot(&AppType::Claude, &provider)
+            .expect("write official Claude live config");
+
+        let written: Value = read_json_file(&get_claude_settings_path()).expect("read live config");
+        let env = written.get("env").and_then(Value::as_object);
+        assert!(
+            env.is_none_or(|env| !env.keys().any(|key| key.starts_with("ANTHROPIC_"))),
+            "official Claude live config must not keep ANTHROPIC_* env: {written}"
+        );
+        assert!(written.get("apiBaseUrl").is_none());
+        assert!(written.get("primaryModel").is_none());
+        assert!(written.get("smallFastModel").is_none());
+        assert_eq!(
+            written
+                .pointer("/env/CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")
+                .and_then(Value::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            written.pointer("/permissions/allow/0"),
+            Some(&json!("Bash"))
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -32,7 +32,7 @@ pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
     provider_exists_in_live_config, strip_common_config_from_live_settings,
-    sync_current_provider_for_app_to_live, write_live_with_common_config,
+    sync_current_provider_for_app_to_live, write_live_snapshot, write_live_with_common_config,
 };
 
 // Internal re-exports


### PR DESCRIPTION
## Summary

Fixes #4200.

Selecting `Claude Official` should restore Claude Code's first-party auth path instead of leaving stale API-key settings active.

<img width="422" height="253" alt="image" src="https://github.com/user-attachments/assets/3d3134d7-7a0e-4e7c-832d-f34efc261245" />

## Root Cause

`Claude Official` was treated like a normal Claude API provider in two places:

- the provider terminal launcher still generated provider-specific `claude --settings <temp-config>` invocations;
- Claude live settings writes could preserve stale API overrides from the provider record.

Those stale values can keep Claude Code in `API Usage Billing` mode even after `/login` succeeds.

## Changes

- Skip provider-specific `--settings` injection for `Claude Official` terminal launches.
- Clear `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, and `ANTHROPIC_BASE_URL` before launching official Claude from cc-switch.
- Remove stale `ANTHROPIC_*`, `apiBaseUrl`, `primaryModel`, and `smallFastModel` values when writing official Claude live settings.
- Preserve non-API official settings such as permissions and non-Anthropic env values.
- Keep non-official Claude providers on the existing provider-specific settings path.

## Verification

- `git diff --check upstream/main...HEAD`
- `cargo test --manifest-path src-tauri/Cargo.toml`