### PR TITLE
fix(proxy): make synthetic thinking placeholder injection reactive

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -16,7 +16,9 @@ use super::{
     },
     thinking_budget_rectifier::{rectify_thinking_budget, should_rectify_thinking_budget},
     thinking_rectifier::{
-        normalize_thinking_type, rectify_anthropic_request, should_rectify_thinking_signature,
+        normalize_thinking_type, rectify_anthropic_request,
+        rectify_thinking_required, should_rectify_thinking_required,
+        should_rectify_thinking_signature,
     },
     types::{CopilotOptimizerConfig, OptimizerConfig, ProxyStatus, RectifierConfig},
     ProxyError,
@@ -951,6 +953,88 @@ impl RequestForwarder {
                                         return Err(err);
                                     }
                                     continue;
+                                }
+                            }
+                        }
+                    }
+
+                    // ━━━ 反应式 thinking 注入 ━━━
+                    // 仅在上游 API 要求回传 thinking 块时才触发（DeepSeek / Kimi /
+                    // Moonshot 等 vendor）。与 pre-normalize 不同，此处是错误驱动的按需修
+                    // 复：先让原始请求直发，上游拒绝 400 后再注入占位 thinking 块重试。
+                    // 避免了预注入在长上下文下的副作用（输出退化、正文折叠到 thinking 块）。
+                    if is_anthropic_provider {
+                        let error_message = extract_error_message(&e);
+                        if should_rectify_thinking_required(
+                            error_message.as_deref(),
+                            &self.rectifier_config,
+                        ) {
+                            if rectifier_retried {
+                                log::warn!(
+                                    "[{app_type_str}] [RECT-020] thinking 必须回传整流已尝试，跳过"
+                                );
+                            } else {
+                                let thinking_rectified =
+                                    rectify_thinking_required(&mut provider_body);
+                                if thinking_rectified.applied {
+                                    log::info!(
+                                        "[{app_type_str}] [RECT-021] 反应式 thinking 注入: {} 个占位块",
+                                        thinking_rectified.injected_thinking_blocks
+                                    );
+                                    let _ = std::mem::replace(&mut rectifier_retried, true);
+
+                                    match self
+                                        .forward(
+                                            app_type,
+                                            &method,
+                                            provider,
+                                            endpoint,
+                                            &provider_body,
+                                            &headers,
+                                            &extensions,
+                                            adapter.as_ref(),
+                                        )
+                                        .await
+                                    {
+                                        Ok((response, claude_api_format, outbound_model)) => {
+                                            log::info!(
+                                                "[{app_type_str}] [RECT-022] 反应式 thinking 注入重试成功"
+                                            );
+                                            self.record_success_result(
+                                                &provider.id,
+                                                app_type_str,
+                                                used_half_open_permit,
+                                            )
+                                            .await;
+                                            return Ok(ForwardResult {
+                                                response,
+                                                provider: provider.clone(),
+                                                claude_api_format,
+                                                outbound_model,
+                                                connection_guard: None,
+                                            });
+                                        }
+                                        Err(retry_err) => {
+                                            log::warn!(
+                                                "[{app_type_str}] [RECT-023] 反应式 thinking 注入重试仍失败: {retry_err}"
+                                            );
+                                            if let Some(err) = self
+                                                .handle_rectifier_retry_failure(
+                                                    retry_err,
+                                                    provider,
+                                                    app_type_str,
+                                                    used_half_open_permit,
+                                                    "thinking 必须回传整流",
+                                                    &mut last_error,
+                                                    &mut last_provider,
+                                                )
+                                                .await
+                                            {
+                                                return Err(err);
+                                            }
+                                            continue;
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1006,6 +1006,49 @@ impl RequestForwarder {
                                                 used_half_open_permit,
                                             )
                                             .await;
+
+                                            {
+                                                let mut current_providers =
+                                                    self.current_providers.write().await;
+                                                current_providers.insert(
+                                                    app_type_str.to_string(),
+                                                    (provider.id.clone(), provider.name.clone()),
+                                                );
+                                            }
+
+                                            {
+                                                let mut status = self.status.write().await;
+                                                status.success_requests += 1;
+                                                status.last_error = None;
+                                                let should_switch =
+                                                    self.current_provider_id_at_start.as_str()
+                                                        != provider.id.as_str();
+                                                if should_switch {
+                                                    status.failover_count += 1;
+                                                    let fm = self.failover_manager.clone();
+                                                    let ah = self.app_handle.clone();
+                                                    let pid = provider.id.clone();
+                                                    let pname = provider.name.clone();
+                                                    let at = app_type_str.to_string();
+                                                    tokio::spawn(async move {
+                                                        let _ = fm
+                                                            .try_switch(
+                                                                ah.as_ref(),
+                                                                &at,
+                                                                &pid,
+                                                                &pname,
+                                                            )
+                                                            .await;
+                                                    });
+                                                }
+                                                if status.total_requests > 0 {
+                                                    status.success_rate =
+                                                        (status.success_requests as f32
+                                                            / status.total_requests as f32)
+                                                            * 100.0;
+                                                }
+                                            }
+
                                             return Ok(ForwardResult {
                                                 response,
                                                 provider: provider.clone(),

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -19,7 +19,6 @@ use crate::provider::Provider;
 use crate::proxy::error::ProxyError;
 use serde_json::{json, Value};
 
-const ANTHROPIC_THINKING_PLACEHOLDER: &str = "tool call";
 const ANTHROPIC_REDACTED_THINKING_PLACEHOLDER: &str = "[redacted thinking]";
 // Keep hints lowercase; matching lowercases only the input value.
 const REASONING_VENDOR_HINTS: &[&str] = &["moonshot", "kimi", "deepseek", "mimo", "xiaomimimo"];
@@ -127,12 +126,16 @@ fn should_normalize_anthropic_tool_thinking_history(
     .any(is_reasoning_vendor_identifier)
 }
 
-/// DeepSeek's Anthropic-compatible endpoint requires thinking history to be
-/// replayed on every assistant turn that contains tool_use. Some Anthropic SDK
-/// clients keep the tool history but drop or redact the thinking block, which
-/// makes DeepSeek reject the next request with `content[].thinking ... must be
-/// passed back`. Normalize only the narrow tool-call history shape for
-/// providers known to require plain `thinking` blocks.
+/// Normalize the tool-call history for reasoning providers (DeepSeek, Kimi, etc.).
+///
+/// Performs only safe structural transforms:
+/// - Strips `signature` fields from thinking blocks (Anthropic-internal, rejected by third parties).
+/// - Converts `redacted_thinking` blocks to `thinking` with placeholder text.
+///
+/// **Does NOT inject placeholder thinking blocks.** Filling empty/missing thinking
+/// is handled reactively by `thinking_rectifier::rectify_thinking_required`
+/// — it fires *only* when the upstream API actually rejects the request,
+/// avoiding unnecessary injection that degrades output quality at long context.
 pub fn normalize_anthropic_tool_thinking_history_for_provider(
     body: &mut Value,
     provider: &Provider,
@@ -246,49 +249,24 @@ fn normalize_anthropic_tool_thinking_history(body: &mut Value) -> bool {
             continue;
         }
 
-        let mut has_thinking = false;
         for block in content.iter_mut() {
             match block.get("type").and_then(Value::as_str) {
                 Some("thinking") => {
-                    let has_non_empty_thinking = block
-                        .get("thinking")
-                        .and_then(Value::as_str)
-                        .is_some_and(|text| !text.trim().is_empty());
                     if let Some(obj) = block.as_object_mut() {
                         if obj.remove("signature").is_some() {
                             changed = true;
                         }
-                        if !has_non_empty_thinking {
-                            obj.insert(
-                                "thinking".to_string(),
-                                json!(ANTHROPIC_THINKING_PLACEHOLDER),
-                            );
-                            changed = true;
-                        }
                     }
-                    has_thinking = true;
                 }
                 Some("redacted_thinking") => {
                     *block = json!({
                         "type": "thinking",
                         "thinking": ANTHROPIC_REDACTED_THINKING_PLACEHOLDER
                     });
-                    has_thinking = true;
                     changed = true;
                 }
                 _ => {}
             }
-        }
-
-        if !has_thinking {
-            content.insert(
-                0,
-                json!({
-                    "type": "thinking",
-                    "thinking": ANTHROPIC_THINKING_PLACEHOLDER
-                }),
-            );
-            changed = true;
         }
     }
 
@@ -2084,7 +2062,10 @@ mod tests {
     }
 
     #[test]
-    fn test_deepseek_anthropic_tool_history_injects_missing_thinking() {
+    fn test_deepseek_anthropic_tool_history_preserves_structure_without_injection() {
+        // normalize_anthropic_tool_thinking_history now only does safe transforms
+        // (strip signature, convert redacted_thinking). It does NOT inject "tool call"
+        // placeholders — that is handled reactively by thinking_rectifier.
         let provider = create_provider(json!({
             "env": {
                 "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
@@ -2108,12 +2089,13 @@ mod tests {
             "anthropic",
         );
 
-        assert!(changed);
+        // No change: message has text + tool_use, no redacted_thinking to convert,
+        // no signature to strip. No placeholder thinking is injected.
+        assert!(!changed);
         let content = body["messages"][0]["content"].as_array().unwrap();
-        assert_eq!(content[0]["type"], "thinking");
-        assert_eq!(content[0]["thinking"], ANTHROPIC_THINKING_PLACEHOLDER);
-        assert_eq!(content[1]["type"], "text");
-        assert_eq!(content[2]["type"], "tool_use");
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "tool_use");
     }
 
     #[test]
@@ -2175,7 +2157,9 @@ mod tests {
     }
 
     #[test]
-    fn test_kimi_anthropic_tool_history_injects_missing_thinking() {
+    fn test_kimi_anthropic_tool_history_preserves_structure_without_injection() {
+        // Same as test_deepseek_anthropic_tool_history_preserves_structure_without_injection:
+        // normalize no longer injects placeholder thinking blocks.
         let provider = create_provider(json!({
             "env": {
                 "ANTHROPIC_BASE_URL": "https://api.kimi.com/coding",
@@ -2198,11 +2182,11 @@ mod tests {
             "anthropic",
         );
 
-        assert!(changed);
+        // No change: no redacted_thinking, no signature.
+        assert!(!changed);
         let content = body["messages"][0]["content"].as_array().unwrap();
-        assert_eq!(content[0]["type"], "thinking");
-        assert_eq!(content[0]["thinking"], ANTHROPIC_THINKING_PLACEHOLDER);
-        assert_eq!(content[1]["type"], "tool_use");
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "tool_use");
     }
 
     #[test]

--- a/src-tauri/src/proxy/thinking_rectifier.rs
+++ b/src-tauri/src/proxy/thinking_rectifier.rs
@@ -278,12 +278,12 @@ pub fn should_rectify_thinking_required(
     let lower = msg.to_lowercase();
 
     // "content[].thinking in the thinking mode must be passed back to the API"
-    // DeepSeek / Kimi / Moonshot 等 vendor 的典型错误消息。
-    // 与 CCH 对齐：只对精确的 thinking-backpass 错误触发,避免误扩。
-    lower.contains("thinking")
+    // DeepSeek / Kimi / Moonshot 等 vendor 的典型错误消息。兼容
+    // 以 "thinking" 或 "reasoning_content" 表述的回传错误 (两者语义等价)。
+    (lower.contains("thinking") || lower.contains("reasoning_content"))
         && (lower.contains("must be passed back")
             || lower.contains("must start with a thinking block")
-            || lower.contains("reasoning_content") && lower.contains("must be"))
+            || lower.contains("must be"))
 }
 
 /// 反应式注入 thinking 占位块
@@ -840,6 +840,15 @@ mod tests {
     fn test_detect_thinking_must_be_passed_back() {
         assert!(should_rectify_thinking_required(
             Some("content[0].thinking in the thinking mode must be passed back to the API"),
+            &enabled_config()
+        ));
+    }
+
+    #[test]
+    fn test_detect_reasoning_content_must_be_passed_back() {
+        // Some vendors phrase the error in terms of reasoning_content rather than thinking.
+        assert!(should_rectify_thinking_required(
+            Some("reasoning_content must be passed back to the API"),
             &enabled_config()
         ));
     }

--- a/src-tauri/src/proxy/thinking_rectifier.rs
+++ b/src-tauri/src/proxy/thinking_rectifier.rs
@@ -2,9 +2,16 @@
 //!
 //! 用于自动修复 Anthropic API 中因签名校验失败导致的请求错误。
 //! 当上游 API 返回签名相关错误时，系统会自动移除有问题的签名字段并重试请求。
+//!
+//! 同时提供 **反应式 thinking 注入**：上游 API 要求回传 thinking 块时
+//! (DeepSeek / Kimi / Moonshot 等),整流器仅在 API 实际拒绝后注入占位
+//! thinking 块并重试,而非预注入——避免长上下文下的输出退化。
 
 use super::types::RectifierConfig;
-use serde_json::Value;
+use serde_json::{json, Value};
+
+/// Thinking 占位文本,用于反应式注入(仅在上游 API 拒绝时)。
+pub const REACTIVE_THINKING_PLACEHOLDER: &str = "tool call";
 
 /// 整流结果
 #[derive(Debug, Clone, Default)]
@@ -17,6 +24,8 @@ pub struct RectifyResult {
     pub removed_redacted_thinking_blocks: usize,
     /// 移除的 signature 字段数量
     pub removed_signature_fields: usize,
+    /// 注入的 thinking 占位块数量 (反应式,仅在上游 API 拒绝后)
+    pub injected_thinking_blocks: usize,
 }
 
 /// 检测是否需要触发 thinking 签名整流器
@@ -239,6 +248,111 @@ fn should_remove_top_level_thinking(body: &Value, messages: &[Value]) -> bool {
 /// 与 CCH 对齐：请求前不做 thinking type 主动改写。
 pub fn normalize_thinking_type(body: Value) -> Value {
     body
+}
+
+// ============================================================================
+// 反应式 thinking 注入
+// ============================================================================
+// 当上游 API (DeepSeek / Kimi / Moonshot 等) 要求回传 thinking 块时触发。
+// 仅在上游实际拒绝后注入占位 thinking 块并重试——避免了预注入在长上下文下
+// 的副作用 (输出退化、正文折叠到 thinking 块)。
+
+/// 检测是否需要触发反应式 thinking 注入
+///
+/// 匹配 DeepSeek / Kimi / Moonshot 等厂商的 thinking 回传要求错误。
+pub fn should_rectify_thinking_required(
+    error_message: Option<&str>,
+    config: &RectifierConfig,
+) -> bool {
+    if !config.enabled {
+        return false;
+    }
+    // 复用 thinking_signature 子开关 — 语义上同属 thinking 兼容整流。
+    if !config.request_thinking_signature {
+        return false;
+    }
+
+    let Some(msg) = error_message else {
+        return false;
+    };
+    let lower = msg.to_lowercase();
+
+    // "content[].thinking in the thinking mode must be passed back to the API"
+    // DeepSeek / Kimi / Moonshot 等 vendor 的典型错误消息。
+    // 与 CCH 对齐：只对精确的 thinking-backpass 错误触发,避免误扩。
+    lower.contains("thinking")
+        && (lower.contains("must be passed back")
+            || lower.contains("must start with a thinking block")
+            || lower.contains("reasoning_content") && lower.contains("must be"))
+}
+
+/// 反应式注入 thinking 占位块
+///
+/// 给所有有 tool_use 但无 (或空) thinking 的 assistant 历史消息注入占位
+/// thinking 块。仅在 `should_rectify_thinking_required` 返回 true 时调用。
+///
+/// 注入逻辑与已被移除的 claude.rs 预注入完全一致,但执行时机从「每个请求
+/// 预先注入」改为「上游拒绝后按需注入」。
+pub fn rectify_thinking_required(body: &mut Value) -> RectifyResult {
+    let mut result = RectifyResult::default();
+
+    let messages = match body.get_mut("messages").and_then(|m| m.as_array_mut()) {
+        Some(m) => m,
+        None => return result,
+    };
+
+    for message in messages {
+        if message.get("role").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+
+        let content = match message.get_mut("content").and_then(|c| c.as_array_mut()) {
+            Some(c) => c,
+            None => continue,
+        };
+
+        if !content
+            .iter()
+            .any(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"))
+        {
+            continue;
+        }
+
+        let mut has_thinking = false;
+        for block in content.iter_mut() {
+            if block.get("type").and_then(Value::as_str) == Some("thinking") {
+                let is_empty = block
+                    .get("thinking")
+                    .and_then(Value::as_str)
+                    .is_none_or(|text| text.trim().is_empty());
+                if is_empty {
+                    if let Some(obj) = block.as_object_mut() {
+                        obj.insert(
+                            "thinking".to_string(),
+                            Value::String(REACTIVE_THINKING_PLACEHOLDER.to_string()),
+                        );
+                        result.injected_thinking_blocks += 1;
+                        result.applied = true;
+                    }
+                }
+                has_thinking = true;
+            }
+        }
+
+        if !has_thinking {
+            content.insert(
+                0,
+                json!({
+                    "type": "thinking",
+                    "thinking": REACTIVE_THINKING_PLACEHOLDER
+                }),
+            );
+            result.injected_thinking_blocks += 1;
+            result.applied = true;
+        }
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -718,5 +832,144 @@ mod tests {
 
         assert_eq!(result["thinking"]["type"], "unexpected");
         assert_eq!(result["thinking"]["budget_tokens"], 100);
+    }
+
+    // ==================== should_rectify_thinking_required 测试 ====================
+
+    #[test]
+    fn test_detect_thinking_must_be_passed_back() {
+        assert!(should_rectify_thinking_required(
+            Some("content[0].thinking in the thinking mode must be passed back to the API"),
+            &enabled_config()
+        ));
+    }
+
+    #[test]
+    fn test_detect_thinking_must_start_with_thinking_block() {
+        assert!(should_rectify_thinking_required(
+            Some("a final assistant message must start with a thinking block"),
+            &enabled_config()
+        ));
+    }
+
+    #[test]
+    fn test_thinking_required_no_trigger_for_unrelated_error() {
+        assert!(!should_rectify_thinking_required(
+            Some("Request timeout"),
+            &enabled_config()
+        ));
+        assert!(!should_rectify_thinking_required(None, &enabled_config()));
+    }
+
+    #[test]
+    fn test_disabled_config_should_not_rectify_thinking_required() {
+        assert!(!should_rectify_thinking_required(
+            Some("content[0].thinking in the thinking mode must be passed back to the API"),
+            &disabled_config()
+        ));
+    }
+
+    #[test]
+    fn test_master_disabled_config_should_not_rectify_thinking_required() {
+        assert!(!should_rectify_thinking_required(
+            Some("content[0].thinking in the thinking mode must be passed back to the API"),
+            &master_disabled_config()
+        ));
+    }
+
+    // ==================== rectify_thinking_required 测试 ====================
+
+    #[test]
+    fn test_rectify_thinking_required_injects_for_missing_thinking() {
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I will inspect."},
+                    {"type": "tool_use", "id": "t1", "name": "read_file", "input": {}}
+                ]
+            }]
+        });
+
+        let result = rectify_thinking_required(&mut body);
+
+        assert!(result.applied);
+        assert_eq!(result.injected_thinking_blocks, 1);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["thinking"], REACTIVE_THINKING_PLACEHOLDER);
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[2]["type"], "tool_use");
+    }
+
+    #[test]
+    fn test_rectify_thinking_required_fills_empty_thinking() {
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "", "signature": "sig"},
+                    {"type": "tool_use", "id": "t1", "name": "read_file", "input": {}}
+                ]
+            }]
+        });
+
+        let result = rectify_thinking_required(&mut body);
+
+        assert!(result.applied);
+        assert_eq!(result.injected_thinking_blocks, 1);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["thinking"], REACTIVE_THINKING_PLACEHOLDER);
+    }
+
+    #[test]
+    fn test_rectify_thinking_required_noop_when_thinking_exists() {
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Real reasoning here."},
+                    {"type": "tool_use", "id": "t1", "name": "read_file", "input": {}}
+                ]
+            }]
+        });
+
+        let original = body.clone();
+        let result = rectify_thinking_required(&mut body);
+
+        assert!(!result.applied);
+        assert_eq!(result.injected_thinking_blocks, 0);
+        assert_eq!(body, original);
+    }
+
+    #[test]
+    fn test_rectify_thinking_required_skips_non_assistant_messages() {
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+                {"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "t1", "name": "read_file", "input": {}}
+                ]}
+            ]
+        });
+
+        let result = rectify_thinking_required(&mut body);
+
+        assert!(result.applied);
+        // Only the assistant message gets injection, user message is untouched
+        let assistant_content = body["messages"][1]["content"].as_array().unwrap();
+        assert_eq!(assistant_content[0]["type"], "thinking");
+        assert_eq!(assistant_content[0]["thinking"], REACTIVE_THINKING_PLACEHOLDER);
+    }
+
+    #[test]
+    fn test_rectify_thinking_required_no_messages() {
+        let mut body = json!({"model": "deepseek-v4-pro"});
+        let result = rectify_thinking_required(&mut body);
+        assert!(!result.applied);
     }
 }


### PR DESCRIPTION
## Problem

`normalize_anthropic_tool_thinking_history` currently pre-injects synthetic thinking placeholders like `{"type":"thinking","thinking":"tool call"}` for providers matching `REASONING_VENDOR_HINTS`.

That behavior was introduced for older Anthropic-format reasoning-provider failures where tool-call history without a thinking block could return 400 (`thinking must be passed back`, #3233). However, it is a high-risk default for long sessions: it can accumulate many synthetic thinking blocks that were never produced by the upstream model.

This PR does not claim that every DeepSeek-compatible Anthropic endpoint has relaxed the backpass contract. The narrower claim is that pre-injection is risky and should become reactive: send the original request first, and only inject placeholders if the upstream actually returns the old backpass error.

## Change

Reactive rectification replaces proactive placeholder injection.

| File | Change |
|------|--------|
| `claude.rs` | Remove proactive placeholder insertion for missing / empty thinking blocks. Keep safe transforms only: strip `signature` fields and convert `redacted_thinking` to `thinking`. |
| `thinking_rectifier.rs` | Add detection for old thinking / reasoning_content backpass errors and inject placeholders only on that error path. Add focused unit tests. |
| `forwarder.rs` | Wire the reactive retry into the existing rectifier pipeline after signature and budget rectifiers, before the non-retryable check. On retry success, update provider status/bookkeeping the same way as the normal success path. |

## Why this is safer

- Providers that no longer require synthetic thinking placeholders receive the original request unchanged.
- Providers that still require the old backpass behavior still get compatibility: first request returns 400, rectifier injects placeholders, retry succeeds.
- The behavior stays behind the existing rectifier retry path instead of being applied to every request by default.

## Tests

```text
cargo test --lib thinking_rectifier        -> 42 passed, 0 failed
cargo test --lib proxy::providers::claude  -> 53 passed, 0 failed
cargo check --lib                          -> 3 existing warnings, 0 errors
```

Two pre-existing local failures were from `port binding os error 10048` because cc-switch was already running locally; they are unrelated to this PR.

## Compatibility

- Behavior changes for DeepSeek/Kimi/Moonshot/Mimo-style provider hints: requests no longer receive synthetic `"tool call"` thinking placeholders up front.
- If a vendor still requires those placeholders, the reactive retry path preserves compatibility with one extra round trip.
- The existing `rectifier_config.enabled` switch controls this fallback path.

## Related

- Addresses #4208
- Related: #3233, #3263, #3645, #3934
- Different from #3881: this PR does not strip historical reasoning unconditionally; it only adds a compatibility fallback when the upstream explicitly asks for thinking backpass.