### PR TITLE
Codex/sanitize chat tool history

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ pnpm test:unit
 # Run tests in watch mode (recommended for development)
 pnpm test:unit:watch
 
+# Run Codex Chat tool-call sequence regression tests
+pnpm test:codex-chat-tools
+
 # Build application
 pnpm build
 
@@ -469,6 +472,9 @@ pnpm test:unit:watch
 
 # With coverage report
 pnpm test:unit --coverage
+
+# Codex Chat tool-call sequence regression tests
+pnpm test:codex-chat-tools
 ```
 
 ### Tech Stack

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -424,6 +424,9 @@ pnpm test:unit
 # 监听模式运行测试（推荐开发时使用）
 pnpm test:unit:watch
 
+# 运行 Codex Chat 工具调用序列回归测试
+pnpm test:codex-chat-tools
+
 # 构建应用
 pnpm build
 
@@ -471,6 +474,9 @@ pnpm test:unit:watch
 
 # 带覆盖率报告
 pnpm test:unit --coverage
+
+# Codex Chat 工具调用序列回归测试
+pnpm test:codex-chat-tools
 ```
 
 ### 技术栈

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -434,6 +434,27 @@ pnpm build
 pnpm tauri build --debug
 ```
 
+### 使用构建脚本（推荐）
+
+本项目提供了 `scripts\build.ps1` 一键打包脚本，可自动检测环境依赖并生成安装包（MSI/EXE/DMG/AppImage）。
+
+```bash
+# 标准发布构建
+.\scripts\build.ps1
+
+# 构建调试版本
+.\scripts\build.ps1 -Debug
+
+# 跳过依赖安装（已安装过依赖时）
+.\scripts\build.ps1 -SkipInstall
+
+# 指定代理地址（国内网络环境需要代理访问 GitHub 时）
+.\scripts\build.ps1 -Proxy "http://localhost:7890"
+```
+
+> **网络代理说明**：脚本启动时会自动检测 `https://github.com` 连通性，若无法直接访问则尝试使用代理。
+> 默认代理地址为 `http://localhost:7890`，可通过 `-Proxy` 参数自定义，传空字符串 `""` 则跳过代理配置。
+
 ### Rust 后端开发
 
 ```bash

--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -1,0 +1,110 @@
+# CC Switch 构建打包指南
+
+## 概述
+
+CC Switch 是一个基于 [Tauri v2](https://v2.tauri.app/) 的跨平台桌面应用，使用 React 前端 + Rust 后端架构。本文档说明如何将源代码打包为可执行安装包。
+
+## 环境要求
+
+| 工具 | 版本要求 | 检查命令 | 安装方式 |
+|------|---------|---------|---------|
+| **Node.js** | >= 18 | `node --version` | [nodejs.org](https://nodejs.org/) |
+| **pnpm** | >= 9 | `pnpm --version` | `npm install -g pnpm` |
+| **Rust** | >= 1.85.0 | `rustc --version` | [rustup.rs](https://rustup.rs/) |
+| **Tauri CLI** | ^2.8.0 | 由 pnpm 管理 | 含在 devDependencies 中 |
+
+### Windows 额外要求
+
+- **WebView2**: Windows 10 (1803+) 已内置；旧系统需手动安装 [WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/)
+- **Visual Studio Build Tools**: 需要安装 "Desktop development with C++" 工作负载
+  - 推荐安装 [Visual Studio 2022 Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
+
+## 一键打包
+
+在项目根目录执行：
+
+```powershell
+.\scripts\build.ps1
+```
+
+脚本将自动完成：
+1. 检查环境依赖（Node.js、pnpm、Rust、Tauri CLI）
+2. 安装 `pnpm install`
+3. 执行 `pnpm tauri build`（release 模式）
+4. 输出构建产物路径
+
+### 脚本参数
+
+| 参数 | 说明 | 示例 |
+|------|------|------|
+| `-SkipInstall` | 跳过依赖安装（已安装时用） | `.\scripts\build.ps1 -SkipInstall` |
+| `-Debug` | 构建 debug 版本（默认 release） | `.\scripts\build.ps1 -Debug` |
+| `-Target <triple>` | 交叉编译目标平台 | `.\scripts\build.ps1 -Target x86_64-pc-windows-msvc` |
+
+## 构建产物
+
+构建成功后，产物位于：
+
+| 平台 | 输出路径 | 格式 |
+|------|---------|------|
+| **Windows** | `src-tauri/target/release/bundle/msi/` | `.msi` 安装包 |
+| **Windows** | `src-tauri/target/release/bundle/wix/` | 若启用 WiX 则会生成 |
+| **Windows** | `src-tauri/target/release/cc-switch.exe` | 便携 exe（需配合资源文件） |
+| **macOS** | `src-tauri/target/release/bundle/dmg/` | `.dmg` 镜像 |
+| **Linux** | `src-tauri/target/release/bundle/appimage/` | `.AppImage` |
+| **Linux** | `src-tauri/target/release/bundle/deb/` | `.deb` 包 |
+
+> 默认 `bundle.targets` 为 `"all"`，会生成当前平台支持的所有格式。如需限制，可修改 `tauri.conf.json`。
+
+## 手动构建流程
+
+如果希望逐步执行：
+
+```powershell
+# 1. 安装依赖
+pnpm install
+
+# 2. 构建前端（会被 tauri build 自动触发，也可单独执行）
+pnpm run build:renderer
+
+# 3. 执行 Tauri 构建
+pnpm tauri build
+
+# 4. （可选）仅构建 debug 版本
+pnpm tauri build --profile debug
+```
+
+## 常见问题
+
+### Q: 构建失败提示 "Could not find any targets"
+
+确保安装 Rust 时勾选了目标工具链。Windows 平台：
+```powershell
+rustup target add x86_64-pc-windows-msvc
+```
+
+### Q: 构建时提示 "linker `link.exe` not found"
+
+需要 Visual Studio Build Tools 或 Visual Studio 的 "Desktop development with C++" 工作负载。
+
+### Q: 如何修改版本号？
+
+版本号在 `tauri.conf.json` 的 `version` 字段中定义，与 `package.json` 保持一致即可。
+
+### Q: 构建产物体积偏大
+
+`Cargo.toml` 中已有优化配置（`lto = "thin"`, `opt-level = "s"`, `strip = "symbols"`），能有效减小体积。
+
+### Q: 签名错误: "A public key has been found, but no private key"
+
+此提示表示 `TAURI_SIGNING_PRIVATE_KEY` 环境变量未设置。如需生成正式签名更新包：
+
+1. 按照 [Tauri 更新文档](https://v2.tauri.app/plugin/updater/) 生成签名密钥对
+2. 将私钥设置为环境变量 `TAURI_SIGNING_PRIVATE_KEY`
+3. 将公钥更新到 `tauri.conf.json` 中 `plugins.updater.pubkey` 字段
+
+如果仅做本地测试构建、不需要更新签名，可将 `TAURI_SIGNING_PRIVATE_KEY` 设为任意占位值，或临时将 `tauri.conf.json` 中 `plugins.updater.createUpdaterArtifacts` 设为 `false`。
+
+### Q: 如何排查构建失败？
+
+查看 `src-tauri/target/release/` 下的 Cargo 构建日志，或添加 `RUST_LOG=cc_switch=debug` 环境变量重试。

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,json}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,css,json}\"",
     "test:unit": "vitest run",
-    "test:unit:watch": "vitest watch"
+    "test:unit:watch": "vitest watch",
+    "test:codex-chat-tools": "node scripts/test-codex-chat-tool-sequence.cjs"
   },
   "keywords": [],
   "author": "Jason Young",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages: []
 
+allowBuilds:
+  esbuild: true
+  msw: true
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,214 @@
+<#
+.SYNOPSIS
+    一键打包 cc-switch Tauri 桌面应用为可执行安装包。
+.DESCRIPTION
+    该脚本会检查构建环境依赖，安装 Node.js 依赖，然后执行 Tauri 构建，
+    最终在 src-tauri/target/release/bundle 下生成安装包（MSI/EXE/DMG/AppImage）。
+.PARAMETER SkipInstall
+    跳过 pnpm install 步骤（已安装依赖时使用）。
+.PARAMETER Debug
+    构建 debug 版本（默认是 release）。
+.PARAMETER Target
+    指定构建目标（如 "x86_64-pc-windows-msvc"），留空则使用默认目标。
+.PARAMETER Proxy
+    指定网络代理地址（如 "http://localhost:7890"），留空则不配置代理。
+.EXAMPLE
+    .\scripts\build.ps1
+    标准发布构建（推荐）。
+.EXAMPLE
+    .\scripts\build.ps1 -SkipInstall
+    跳过依赖安装，直接构建。
+.EXAMPLE
+    .\scripts\build.ps1 -Debug
+    构建 debug 版本。
+#>
+
+param(
+    [switch]$SkipInstall,
+    [switch]$Debug,
+    [string]$Target = "",
+    [string]$Proxy = "http://localhost:7890"
+)
+
+$ErrorActionPreference = "Stop"
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+
+$profileLabel = if ($Debug) { "debug" } else { "release" }
+
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "  CC Switch 一键打包脚本" -ForegroundColor Cyan
+Write-Host "  版本: 3.16.2" -ForegroundColor Cyan
+Write-Host "  配置: $profileLabel" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+# ---------- 自动检测并配置网络代理 ----------
+Write-Host "[1/5] 检测网络环境..." -ForegroundColor Yellow
+
+function Test-GitHubAccess {
+    try {
+        $request = [System.Net.HttpWebRequest]::Create("https://github.com")
+        $request.Timeout = 5000
+        $request.Method = "HEAD"
+        $response = $request.GetResponse()
+        $response.Close()
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Test-ProxyAvailable {
+    param([string]$ProxyUrl)
+    try {
+        $request = [System.Net.HttpWebRequest]::Create("https://github.com")
+        $request.Timeout = 5000
+        $request.Method = "HEAD"
+        $request.Proxy = New-Object System.Net.WebProxy($ProxyUrl)
+        $response = $request.GetResponse()
+        $response.Close()
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+$hasDirectAccess = Test-GitHubAccess
+if (-not $hasDirectAccess -and $Proxy -ne "") {
+    Write-Host "  检测到 GitHub 无法直接访问，尝试使用代理: $Proxy" -ForegroundColor Yellow
+    if (Test-ProxyAvailable -ProxyUrl $Proxy) {
+        Write-Host "  [OK] 代理可用: $Proxy" -ForegroundColor Green
+        # 设置环境变量代理（Cargo、rustc、Node.js 等均会读取）
+        $env:HTTP_PROXY = $Proxy
+        $env:HTTPS_PROXY = $Proxy
+        $env:http_proxy = $Proxy
+        $env:https_proxy = $Proxy
+
+        # 配置 git 代理（用于 Cargo 拉取 git 依赖）
+        $hasGitLocalProxy = git config --local http.proxy 2>$null
+        if (-not $hasGitLocalProxy) {
+            git config --local http.proxy $Proxy
+            Write-Host "  [OK] 已配置 git local proxy" -ForegroundColor Green
+        }
+        Write-Host "  [提示] 代理仅在此脚本会话中生效，不影响系统设置" -ForegroundColor DarkYellow
+    } else {
+        Write-Host "  [警告] 指定的代理不可用: $Proxy，将尝试直接连接" -ForegroundColor Yellow
+    }
+} elseif ($hasDirectAccess) {
+    Write-Host "  [OK] GitHub 可直接访问" -ForegroundColor Green
+} else {
+    Write-Host "  [警告] 无法访问 GitHub 且未指定代理，构建可能失败" -ForegroundColor Yellow
+}
+
+Write-Host ""
+
+# ---------- 检查环境依赖 ----------
+Write-Host "[2/5] 检查环境依赖..." -ForegroundColor Yellow
+
+# 检查 Node.js
+$nodeVersion = node --version 2>$null
+if (-not $nodeVersion) {
+    Write-Host "  [错误] 未找到 Node.js，请先安装: https://nodejs.org/" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  [OK] Node.js $nodeVersion"
+
+# 检查 pnpm
+$pnpmVersion = pnpm --version 2>$null
+if (-not $pnpmVersion) {
+    Write-Host "  [错误] 未找到 pnpm，请执行: npm install -g pnpm" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  [OK] pnpm $pnpmVersion"
+
+# 检查 Rust / cargo
+$cargoVersion = cargo --version 2>$null
+if (-not $cargoVersion) {
+    Write-Host "  [错误] 未找到 Rust/Cargo，请先安装: https://rustup.rs/" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  [OK] $cargoVersion"
+
+# 检查 Tauri CLI
+$tauriVersion = pnpm tauri --version 2>$null
+if (-not $tauriVersion) {
+    Write-Host "  [警告] Tauri CLI 未安装，将使用 pnpm 自动安装" -ForegroundColor Yellow
+} else {
+    Write-Host "  [OK] Tauri CLI $tauriVersion"
+}
+
+Write-Host ""
+
+# ---------- 安装依赖 ----------
+if (-not $SkipInstall) {
+    Write-Host "[3/5] 安装 Node.js 依赖..." -ForegroundColor Yellow
+    Set-Location $ProjectRoot
+    pnpm install
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  [错误] pnpm install 失败" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "  [OK] 依赖安装完成"
+} else {
+    Write-Host "[3/5] 跳过依赖安装 (-SkipInstall)" -ForegroundColor DarkYellow
+}
+Write-Host ""
+
+# ---------- 执行构建 ----------
+Write-Host "[4/5] 开始 Tauri 构建 ($profileLabel)..." -ForegroundColor Yellow
+Set-Location $ProjectRoot
+
+$buildArgs = @("tauri", "build")
+if ($Debug) {$buildArgs += "--debug" }
+if ($Target -ne "") {$buildArgs += "--target"; $buildArgs +=$Target }
+
+pnpm exec @buildArgs
+
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "  [错误] Tauri 构建失败" -ForegroundColor Red
+    exit 1
+}
+Write-Host ""
+
+# ---------- 输出结果 ----------
+Write-Host "[5/5] 构建完成!" -ForegroundColor Green
+
+# 清理：移除临时配置的本地 git 代理
+if (-not $hasDirectAccess -and $Proxy -ne "" -and (-not $hasGitLocalProxy)) {
+    git config --local --unset http.proxy 2>$null
+    Write-Host "  [OK] 已清理 git local proxy 配置" -ForegroundColor Green
+}
+
+# 确定产物目录
+if ($Debug) {
+    $bundleDir = Join-Path $ProjectRoot "src-tauri\target\debug\bundle"
+} else {
+    $bundleDir = Join-Path $ProjectRoot "src-tauri\target\release\bundle"
+}
+
+if (Test-Path $bundleDir) {
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "  构建产物位于:" -ForegroundColor Cyan
+    Write-Host "  $bundleDir" -ForegroundColor White
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host ""
+
+    $installers = Get-ChildItem -Recurse -File $bundleDir | Where-Object {
+        $_.Extension -match '\.(msi|exe|dmg|AppImage|deb|rpm|apk)$'
+    }
+    if ($installers) {
+        Write-Host "生成的安装包:" -ForegroundColor Green
+        foreach ($installer in $installers) {
+            $sizeInMB = [math]::Round($installer.Length / 1MB, 2)
+            Write-Host "  - $($installer.FullName)  ($sizeInMB MB)" -ForegroundColor White
+        }
+    }
+} else {
+    Write-Host "  [提示] 未能找到 bundle 目录，请检查构建日志。" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "提示: 构建产物默认使用 'all' 目标，会生成当前平台所有可用的安装包格式。" -ForegroundColor Gray
+Write-Host "      如需修改打包目标，请编辑 tauri.conf.json 中的 bundle.targets 字段。" -ForegroundColor Gray

--- a/scripts/test-codex-chat-tool-sequence.cjs
+++ b/scripts/test-codex-chat-tool-sequence.cjs
@@ -1,0 +1,28 @@
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const tauriDir = path.join(repoRoot, "src-tauri");
+
+const tests = [
+  "responses_request_to_chat_does_not_emit_unanswered_tool_calls",
+  "responses_request_to_chat_keeps_multiple_tool_calls_adjacent_to_outputs",
+  "codex_chat_history::tests",
+];
+
+for (const testName of tests) {
+  const result = spawnSync("cargo", ["test", testName], {
+    cwd: tauriDir,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/scripts/test-codex-chat-tool-sequence.cjs
+++ b/scripts/test-codex-chat-tool-sequence.cjs
@@ -7,6 +7,7 @@ const tauriDir = path.join(repoRoot, "src-tauri");
 const tests = [
   "responses_request_to_chat_does_not_emit_unanswered_tool_calls",
   "responses_request_to_chat_keeps_multiple_tool_calls_adjacent_to_outputs",
+  "responses_request_to_chat_keeps_trailing_unanswered_tool_call_after_unmatched_tool_output",
   "codex_chat_history::tests",
 ];
 

--- a/scripts/test-codex-chat-tool-sequence.cjs
+++ b/scripts/test-codex-chat-tool-sequence.cjs
@@ -8,7 +8,14 @@ const tests = [
   "responses_request_to_chat_does_not_emit_unanswered_tool_calls",
   "responses_request_to_chat_keeps_multiple_tool_calls_adjacent_to_outputs",
   "responses_request_to_chat_keeps_trailing_unanswered_tool_call_after_unmatched_tool_output",
+  "test_anthropic_to_openai_drops_unanswered_parallel_tool_calls",
+  "test_anthropic_to_openai_drops_orphan_tool_result",
+  "test_anthropic_to_openai_keeps_trailing_pending_tool_use",
+  "test_anthropic_to_openai_drops_tool_use_from_non_assistant_message",
   "codex_chat_history::tests",
+  "transform_gemini::tests::anthropic_to_gemini_rejects_tool_result_without_resolvable_name",
+  "streaming_gemini::tests::parallel_empty_string_id_calls_are_treated_as_missing_and_preserved",
+  "streaming_responses::tests::test_streaming_conversion_interleaved_tool_deltas_by_item_id",
 ];
 
 for (const testName of tests) {

--- a/src-tauri/src/database/dao/usage_rollup.rs
+++ b/src-tauri/src/database/dao/usage_rollup.rs
@@ -493,7 +493,9 @@ mod tests {
 
         {
             let conn = crate::database::lock_conn!(db.conn);
-            let date_str = chrono::DateTime::from_timestamp(old_ts, 0)
+            let date_str = Local
+                .timestamp_opt(old_ts, 0)
+                .single()
                 .unwrap()
                 .format("%Y-%m-%d")
                 .to_string();

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -5,6 +5,7 @@
 
 use crate::proxy::{error::ProxyError, json_canonical::canonical_json_string};
 use serde_json::{json, Value};
+use std::collections::HashSet;
 
 const ANTHROPIC_BILLING_HEADER_PREFIX: &str = "x-anthropic-billing-header:";
 
@@ -165,6 +166,7 @@ pub fn anthropic_to_openai_with_reasoning_content(
     }
 
     normalize_openai_system_messages(&mut messages);
+    let messages = sanitize_openai_chat_tool_message_sequence(messages);
     result["messages"] = json!(messages);
 
     // 转换参数 — o-series 模型需要 max_completion_tokens
@@ -392,7 +394,7 @@ fn convert_message_to_openai(
                         }));
                     }
                 }
-                "tool_use" => {
+                "tool_use" if role == "assistant" => {
                     let id = block.get("id").and_then(|i| i.as_str()).unwrap_or("");
                     let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("");
                     let input = block.get("input").cloned().unwrap_or(json!({}));
@@ -405,6 +407,7 @@ fn convert_message_to_openai(
                         }
                     }));
                 }
+                "tool_use" => {}
                 "tool_result" => {
                     // tool_result 变成单独的 tool role 消息
                     let tool_use_id = block
@@ -484,6 +487,121 @@ fn convert_message_to_openai(
     // 其他情况直接透传
     result.push(json!({"role": role, "content": content}));
     Ok(result)
+}
+
+/// Chat Completions requires every assistant `tool_calls` entry to be followed
+/// by matching `role=tool` messages. Anthropic histories can contain abandoned
+/// parallel tool uses, so strip unanswered calls and orphan tool results before
+/// forwarding to strict OpenAI-compatible upstreams.
+fn sanitize_openai_chat_tool_message_sequence(messages: Vec<Value>) -> Vec<Value> {
+    let mut sanitized = Vec::with_capacity(messages.len());
+    let mut index = 0usize;
+
+    while index < messages.len() {
+        let mut message = messages[index].clone();
+        if message.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+            if message.get("role").and_then(|v| v.as_str()) != Some("tool") {
+                sanitized.push(message);
+            }
+            index += 1;
+            continue;
+        }
+
+        let Some(tool_calls) = message
+            .get("tool_calls")
+            .and_then(|value| value.as_array())
+            .filter(|calls| !calls.is_empty())
+        else {
+            sanitized.push(message);
+            index += 1;
+            continue;
+        };
+
+        let mut tool_block_end = index + 1;
+        let mut answered_call_ids = HashSet::new();
+        while tool_block_end < messages.len()
+            && messages[tool_block_end]
+                .get("role")
+                .and_then(|value| value.as_str())
+                == Some("tool")
+        {
+            if let Some(call_id) = messages[tool_block_end]
+                .get("tool_call_id")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.is_empty())
+            {
+                answered_call_ids.insert(call_id.to_string());
+            }
+            tool_block_end += 1;
+        }
+
+        let filtered_calls = tool_calls
+            .iter()
+            .filter(|call| {
+                call.get("id")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|call_id| answered_call_ids.contains(call_id))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if filtered_calls.is_empty() && tool_block_end == messages.len() {
+            sanitized.push(message);
+            index = tool_block_end;
+            continue;
+        }
+
+        if filtered_calls.is_empty() {
+            remove_openai_chat_tool_calls(&mut message);
+            if openai_chat_message_has_content(&message) {
+                sanitized.push(message);
+            }
+            index = tool_block_end;
+            continue;
+        }
+
+        let kept_call_ids = filtered_calls
+            .iter()
+            .filter_map(|call| call.get("id").and_then(|value| value.as_str()))
+            .map(ToString::to_string)
+            .collect::<HashSet<_>>();
+
+        if let Some(object) = message.as_object_mut() {
+            object.insert("tool_calls".to_string(), Value::Array(filtered_calls));
+        }
+        sanitized.push(message);
+
+        while index + 1 < tool_block_end {
+            index += 1;
+            let tool_message = &messages[index];
+            if tool_message
+                .get("tool_call_id")
+                .and_then(|value| value.as_str())
+                .is_some_and(|call_id| kept_call_ids.contains(call_id))
+            {
+                sanitized.push(tool_message.clone());
+            }
+        }
+        index = tool_block_end;
+    }
+
+    sanitized
+}
+
+fn remove_openai_chat_tool_calls(message: &mut Value) {
+    if let Some(object) = message.as_object_mut() {
+        object.remove("tool_calls");
+    }
+}
+
+fn openai_chat_message_has_content(message: &Value) -> bool {
+    match message.get("content") {
+        Some(Value::String(text)) => !text.trim().is_empty(),
+        Some(Value::Array(parts)) => !parts.is_empty(),
+        Some(Value::Object(obj)) => !obj.is_empty(),
+        Some(value) => !value.is_null(),
+        None => false,
+    }
 }
 
 /// 清理 JSON schema（移除不支持的 format）
@@ -1018,7 +1136,7 @@ mod tests {
     }
 
     #[test]
-    fn test_anthropic_to_openai_tool_result() {
+    fn test_anthropic_to_openai_drops_orphan_tool_result() {
         let input = json!({
             "model": "claude-3-opus",
             "max_tokens": 1024,
@@ -1031,10 +1149,83 @@ mod tests {
         });
 
         let result = anthropic_to_openai(input).unwrap();
-        let msg = &result["messages"][0];
-        assert_eq!(msg["role"], "tool");
-        assert_eq!(msg["tool_call_id"], "call_123");
-        assert_eq!(msg["content"], "Sunny, 25°C");
+        assert_eq!(result["messages"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_keeps_trailing_pending_tool_use() {
+        let input = json!({
+            "model": "claude-3-opus",
+            "max_tokens": 1024,
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "call_123", "name": "get_weather", "input": {"location": "Tokyo"}}
+                ]
+            }]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["tool_calls"][0]["id"], "call_123");
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_drops_tool_use_from_non_assistant_message() {
+        let input = json!({
+            "model": "claude-3-opus",
+            "max_tokens": 1024,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "tool_use", "id": "call_123", "name": "get_weather", "input": {"location": "Tokyo"}}
+                ]
+            }]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        assert_eq!(result["messages"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_drops_unanswered_parallel_tool_calls() {
+        let input = json!({
+            "model": "claude-3-opus",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "call_1", "name": "read_file", "input": {"path": "README.md"}},
+                        {"type": "tool_use", "id": "call_2", "name": "list_files", "input": {"path": "src"}}
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "call_1", "content": "Readme content"}
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": "Continue"
+                }
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages[0]["role"], "assistant");
+        let tool_calls = messages[0]["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["id"], "call_1");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
+        assert_eq!(messages[2]["role"], "user");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -574,9 +574,9 @@ fn sanitize_chat_tool_message_sequence(messages: Vec<Value>) -> Vec<Value> {
             .cloned()
             .collect::<Vec<_>>();
 
-        if answered_call_ids.is_empty() && tool_block_end == messages.len() {
+        if filtered_calls.is_empty() && tool_block_end == messages.len() {
             sanitized.push(message);
-            index += 1;
+            index = tool_block_end;
             continue;
         }
 
@@ -2783,6 +2783,33 @@ mod tests {
         assert_eq!(tool_calls[0]["id"], "call_1");
         assert_eq!(messages[1]["role"], "tool");
         assert_eq!(messages[1]["tool_call_id"], "call_1");
+    }
+
+    #[test]
+    fn responses_request_to_chat_keeps_trailing_unanswered_tool_call_after_unmatched_tool_output() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{\"path\":\"README.md\"}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "stale_call",
+                    "output": "stale output"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["tool_calls"][0]["id"], "call_1");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -278,7 +278,7 @@ pub fn responses_to_chat_completions_with_reasoning(
     if let Some(input) = body.get("input") {
         append_responses_input_as_chat_messages(input, &mut messages, &tool_context)?;
     }
-    let messages = collapse_system_messages_to_head(messages);
+    let messages = sanitize_chat_tool_message_sequence(collapse_system_messages_to_head(messages));
     result["messages"] = json!(messages);
 
     let model = body.get("model").and_then(|v| v.as_str()).unwrap_or("");
@@ -516,6 +516,121 @@ fn collapse_system_messages_to_head(messages: Vec<Value>) -> Vec<Value> {
     }
     out.extend(rest);
     out
+}
+
+/// Chat Completions requires every assistant `tool_calls` entry to be followed
+/// by tool messages for those exact call ids. Codex Responses history can carry
+/// abandoned or partially completed parallel calls, so drop unanswered calls
+/// before forwarding to strict Chat-compatible upstreams.
+fn sanitize_chat_tool_message_sequence(messages: Vec<Value>) -> Vec<Value> {
+    let mut sanitized = Vec::with_capacity(messages.len());
+    let mut index = 0usize;
+
+    while index < messages.len() {
+        let mut message = messages[index].clone();
+        if message.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+            if message.get("role").and_then(|v| v.as_str()) != Some("tool") {
+                sanitized.push(message);
+            }
+            index += 1;
+            continue;
+        }
+
+        let Some(tool_calls) = message
+            .get("tool_calls")
+            .and_then(|value| value.as_array())
+            .filter(|calls| !calls.is_empty())
+        else {
+            sanitized.push(message);
+            index += 1;
+            continue;
+        };
+
+        let mut tool_block_end = index + 1;
+        let mut answered_call_ids = HashSet::new();
+        while tool_block_end < messages.len()
+            && messages[tool_block_end]
+                .get("role")
+                .and_then(|value| value.as_str())
+                == Some("tool")
+        {
+            if let Some(call_id) = messages[tool_block_end]
+                .get("tool_call_id")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.is_empty())
+            {
+                answered_call_ids.insert(call_id.to_string());
+            }
+            tool_block_end += 1;
+        }
+
+        let filtered_calls = tool_calls
+            .iter()
+            .filter(|call| {
+                call.get("id")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|call_id| answered_call_ids.contains(call_id))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if answered_call_ids.is_empty() && tool_block_end == messages.len() {
+            sanitized.push(message);
+            index += 1;
+            continue;
+        }
+
+        if filtered_calls.is_empty() {
+            remove_tool_calls(&mut message);
+            if chat_message_has_content(&message) {
+                sanitized.push(message);
+            }
+            index = tool_block_end;
+            continue;
+        }
+
+        let kept_call_ids = filtered_calls
+            .iter()
+            .filter_map(|call| call.get("id").and_then(|value| value.as_str()))
+            .map(ToString::to_string)
+            .collect::<HashSet<_>>();
+
+        if let Some(object) = message.as_object_mut() {
+            object.insert("tool_calls".to_string(), Value::Array(filtered_calls));
+        }
+        sanitized.push(message);
+
+        while index + 1 < tool_block_end {
+            index += 1;
+            let tool_message = &messages[index];
+            if tool_message
+                .get("tool_call_id")
+                .and_then(|value| value.as_str())
+                .is_some_and(|call_id| kept_call_ids.contains(call_id))
+            {
+                sanitized.push(tool_message.clone());
+            }
+        }
+        index = tool_block_end;
+    }
+
+    sanitized
+}
+
+fn remove_tool_calls(message: &mut Value) {
+    if let Some(object) = message.as_object_mut() {
+        object.remove("tool_calls");
+    }
+}
+
+fn chat_message_has_content(message: &Value) -> bool {
+    match message.get("content") {
+        Some(Value::String(text)) => !text.trim().is_empty(),
+        Some(Value::Array(parts)) => !parts.is_empty(),
+        Some(Value::Object(obj)) => !obj.is_empty(),
+        Some(value) => !value.is_null(),
+        None => false,
+    }
 }
 
 fn instruction_text(value: &Value) -> String {
@@ -2628,6 +2743,46 @@ mod tests {
         assert_eq!(messages[2]["tool_call_id"], "call_2");
         assert_eq!(messages[2]["content"], "[\"main.rs\",\"lib.rs\"]");
         assert_eq!(messages[3]["role"], "user");
+    }
+
+    #[test]
+    fn responses_request_to_chat_does_not_emit_unanswered_tool_calls() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{\"path\":\"README.md\"}"
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_2",
+                    "name": "list_files",
+                    "arguments": "{\"path\":\"src\"}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "Readme content"
+                },
+                {
+                    "role": "user",
+                    "content": "Continue"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages[0]["role"], "assistant");
+        let tool_calls = messages[0]["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["id"], "call_1");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
     }
 
     #[test]


### PR DESCRIPTION
 ### Summary

  This PR contains two changes on the codex/sanitize-chat-tool-history branch:

  1. Fix: Sanitize Codex Chat tool call history to prevent stale tool call data from leaking across conversation turns.
  2. Docs: Add a one-click PowerShell build script (scripts/build.ps1) and a comprehensive build & packaging guide (docs/build-guide.md), along with usage instructions in README_ZH.md.

  ### Changes

  #### Commit 1b6e9cbd — fix: sanitize Codex chat tool call history

   File                                                     Change       Description
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   src-tauri/src/proxy/providers/transform_codex_chat.rs    +157 / -1    Core fix: sanitize tool call history in Codex Chat proxy transformation
  ───────────────────────────────────────────────────────  ───────────  ─────────────────────────────────────────────────────────────────────────
   scripts/test-codex-chat-tool-sequence.cjs                +28          New test script for tool call sequence validation
  ───────────────────────────────────────────────────────  ───────────  ─────────────────────────────────────────────────────────────────────────
   package.json                                             +3 / -1      Add test:codex-chat-tools npm script
  ───────────────────────────────────────────────────────  ───────────  ─────────────────────────────────────────────────────────────────────────
   README.md                                                +6           Document the fix
  ───────────────────────────────────────────────────────  ───────────  ─────────────────────────────────────────────────────────────────────────
   README_ZH.md                                             +6           Document the fix (Chinese)

  #### Commit a32751db — docs: add build script usage guide and packaging documentation

   File                   Change    Description
  ━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   scripts/build.ps1      +214      New one-click build script with auto proxy detection for GitHub access
  ─────────────────────  ────────  ──────────────────────────────────────────────────────────────────────────────
   docs/build-guide.md    +110      New build & packaging guide covering environment setup, build steps, and FAQ
  ─────────────────────  ────────  ──────────────────────────────────────────────────────────────────────────────
   README_ZH.md           +21       Add build script usage section with parameter examples

  ### Motivation

  - Tool call sanitization: Without this fix, Codex Chat could carry over stale tool call history between turns, causing incorrect tool invocation or unexpected behavior in the proxy layer.
  - Build automation: Previously there was no automated build script. The new build.ps1 handles dependency checking, proxy configuration for restricted networks, and produces platform-specific installers (MSI, DMG, AppImage, deb).

  ### How to Test

  # Test tool call sanitization
  pnpm test:codex-chat-tools

  # One-click build (Windows)
  .\scripts\build.ps1

  # Build with debug profile
  .\scripts\build.ps1 -Debug

  # Build with custom proxy
  .\scripts\build.ps1 -Proxy "http://localhost:7890"

  ### Related

  - No related issues.
