### PR TITLE
feat(skills): support GitLab skill repositories

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -200,7 +200,13 @@ pub struct InstalledSkill {
     pub description: Option<String>,
     /// 安装目录名（在 SSOT 目录中的子目录名）
     pub directory: String,
-    /// 仓库所有者（GitHub 用户/组织）
+    /// 仓库来源类型（github / gitlab）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_source_type: Option<String>,
+    /// 仓库来源域名
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_source_host: Option<String>,
+    /// 仓库所有者（用户/组织）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_owner: Option<String>,
     /// 仓库名称

--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -315,13 +315,30 @@ pub fn add_skill_repo(repo: SkillRepo, app_state: State<'_, AppState>) -> Result
 /// 删除技能仓库
 #[tauri::command]
 pub fn remove_skill_repo(
+    source_type: Option<String>,
+    source_host: Option<String>,
     owner: String,
     name: String,
     app_state: State<'_, AppState>,
 ) -> Result<bool, String> {
+    let repo_for_source = SkillRepo {
+        source_type: source_type.unwrap_or_else(|| "github".to_string()),
+        source_host: source_host.unwrap_or_else(|| "github.com".to_string()),
+        owner: owner.clone(),
+        name: name.clone(),
+        branch: "main".to_string(),
+        enabled: true,
+    };
+    let normalized_source_type = repo_for_source.normalized_source_type();
+    let normalized_source_host = repo_for_source.normalized_source_host();
     app_state
         .db
-        .delete_skill_repo(&owner, &name)
+        .delete_skill_repo(
+            &normalized_source_type,
+            &normalized_source_host,
+            &owner,
+            &name,
+        )
         .map_err(|e| e.to_string())?;
     Ok(true)
 }

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -21,9 +21,10 @@ impl Database {
         let conn = lock_conn!(self.conn);
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
-                        readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild,
-                        enabled_opencode, enabled_hermes, installed_at, content_hash, updated_at
+                "SELECT id, name, description, directory, repo_source_type, repo_source_host,
+                        repo_owner, repo_name, repo_branch, readme_url,
+                        enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild, enabled_opencode,
+                        enabled_hermes, installed_at, content_hash, updated_at
                  FROM skills ORDER BY name ASC",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -35,21 +36,23 @@ impl Database {
                     name: row.get(1)?,
                     description: row.get(2)?,
                     directory: row.get(3)?,
-                    repo_owner: row.get(4)?,
-                    repo_name: row.get(5)?,
-                    repo_branch: row.get(6)?,
-                    readme_url: row.get(7)?,
+                    repo_source_type: row.get(4)?,
+                    repo_source_host: row.get(5)?,
+                    repo_owner: row.get(6)?,
+                    repo_name: row.get(7)?,
+                    repo_branch: row.get(8)?,
+                    readme_url: row.get(9)?,
                     apps: SkillApps {
-                        claude: row.get(8)?,
-                        codex: row.get(9)?,
-                        gemini: row.get(10)?,
-                        grokbuild: row.get(11)?,
-                        opencode: row.get(12)?,
-                        hermes: row.get(13)?,
+                        claude: row.get(10)?,
+                        codex: row.get(11)?,
+                        gemini: row.get(12)?,
+                        grokbuild: row.get(13)?,
+                        opencode: row.get(14)?,
+                        hermes: row.get(15)?,
                     },
-                    installed_at: row.get(14)?,
-                    content_hash: row.get(15)?,
-                    updated_at: row.get::<_, i64>(16).unwrap_or(0),
+                    installed_at: row.get(16)?,
+                    content_hash: row.get(17)?,
+                    updated_at: row.get::<_, i64>(18).unwrap_or(0),
                 })
             })
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -67,9 +70,10 @@ impl Database {
         let conn = lock_conn!(self.conn);
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
-                        readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild,
-                        enabled_opencode, enabled_hermes, installed_at, content_hash, updated_at
+                "SELECT id, name, description, directory, repo_source_type, repo_source_host,
+                        repo_owner, repo_name, repo_branch, readme_url,
+                        enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild, enabled_opencode,
+                        enabled_hermes, installed_at, content_hash, updated_at
                  FROM skills WHERE id = ?1",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -80,21 +84,23 @@ impl Database {
                 name: row.get(1)?,
                 description: row.get(2)?,
                 directory: row.get(3)?,
-                repo_owner: row.get(4)?,
-                repo_name: row.get(5)?,
-                repo_branch: row.get(6)?,
-                readme_url: row.get(7)?,
+                repo_source_type: row.get(4)?,
+                repo_source_host: row.get(5)?,
+                repo_owner: row.get(6)?,
+                repo_name: row.get(7)?,
+                repo_branch: row.get(8)?,
+                readme_url: row.get(9)?,
                 apps: SkillApps {
-                    claude: row.get(8)?,
-                    codex: row.get(9)?,
-                    gemini: row.get(10)?,
-                    grokbuild: row.get(11)?,
-                    opencode: row.get(12)?,
-                    hermes: row.get(13)?,
+                    claude: row.get(10)?,
+                    codex: row.get(11)?,
+                    gemini: row.get(12)?,
+                    grokbuild: row.get(13)?,
+                    opencode: row.get(14)?,
+                    hermes: row.get(15)?,
                 },
-                installed_at: row.get(14)?,
-                content_hash: row.get(15)?,
-                updated_at: row.get::<_, i64>(16).unwrap_or(0),
+                installed_at: row.get(16)?,
+                content_hash: row.get(17)?,
+                updated_at: row.get::<_, i64>(18).unwrap_or(0),
             })
         });
 
@@ -110,15 +116,18 @@ impl Database {
         let conn = lock_conn!(self.conn);
         conn.execute(
             "INSERT OR REPLACE INTO skills
-             (id, name, description, directory, repo_owner, repo_name, repo_branch,
-              readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild, enabled_opencode, enabled_hermes,
+             (id, name, description, directory, repo_source_type, repo_source_host,
+              repo_owner, repo_name, repo_branch, readme_url,
+              enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild, enabled_opencode, enabled_hermes,
               installed_at, content_hash, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
             params![
                 skill.id,
                 skill.name,
                 skill.description,
                 skill.directory,
+                skill.repo_source_type,
+                skill.repo_source_host,
                 skill.repo_owner,
                 skill.repo_name,
                 skill.repo_branch,
@@ -191,17 +200,21 @@ impl Database {
         let conn = lock_conn!(self.conn);
         let mut stmt = conn
             .prepare(
-                "SELECT owner, name, branch, enabled FROM skill_repos ORDER BY owner ASC, name ASC",
+                "SELECT source_type, source_host, owner, name, branch, enabled
+                 FROM skill_repos
+                 ORDER BY source_type ASC, source_host ASC, owner ASC, name ASC",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
 
         let repo_iter = stmt
             .query_map([], |row| {
                 Ok(SkillRepo {
-                    owner: row.get(0)?,
-                    name: row.get(1)?,
-                    branch: row.get(2)?,
-                    enabled: row.get(3)?,
+                    source_type: row.get(0)?,
+                    source_host: row.get(1)?,
+                    owner: row.get(2)?,
+                    name: row.get(3)?,
+                    branch: row.get(4)?,
+                    enabled: row.get(5)?,
                 })
             })
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -217,19 +230,35 @@ impl Database {
     pub fn save_skill_repo(&self, repo: &SkillRepo) -> Result<(), AppError> {
         let conn = lock_conn!(self.conn);
         conn.execute(
-            "INSERT OR REPLACE INTO skill_repos (owner, name, branch, enabled) VALUES (?1, ?2, ?3, ?4)",
-            params![repo.owner, repo.name, repo.branch, repo.enabled],
+            "INSERT OR REPLACE INTO skill_repos
+             (source_type, source_host, owner, name, branch, enabled)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                repo.normalized_source_type(),
+                repo.normalized_source_host(),
+                repo.owner,
+                repo.name,
+                repo.branch,
+                repo.enabled
+            ],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(())
     }
 
     /// 删除 Skill 仓库
-    pub fn delete_skill_repo(&self, owner: &str, name: &str) -> Result<(), AppError> {
+    pub fn delete_skill_repo(
+        &self,
+        source_type: &str,
+        source_host: &str,
+        owner: &str,
+        name: &str,
+    ) -> Result<(), AppError> {
         let conn = lock_conn!(self.conn);
         conn.execute(
-            "DELETE FROM skill_repos WHERE owner = ?1 AND name = ?2",
-            params![owner, name],
+            "DELETE FROM skill_repos
+             WHERE source_type = ?1 AND source_host = ?2 AND owner = ?3 AND name = ?4",
+            params![source_type, source_host, owner, name],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(())

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -291,3 +291,45 @@ impl Database {
         Ok(count)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::skill::SkillStore;
+
+    #[test]
+    fn default_repo_init_preserves_existing_custom_branch() {
+        let db = Database::memory().expect("memory db");
+        let default_repo = SkillStore::default()
+            .repos
+            .into_iter()
+            .next()
+            .expect("default repo");
+        let custom_branch = "custom-branch".to_string();
+
+        db.save_skill_repo(&SkillRepo {
+            source_type: "github".to_string(),
+            source_host: "github.com".to_string(),
+            owner: default_repo.owner.clone(),
+            name: default_repo.name.clone(),
+            branch: custom_branch.clone(),
+            enabled: true,
+        })
+        .expect("save custom branch repo");
+
+        let inserted = db.init_default_skill_repos().expect("init default repos");
+        let repos = db.get_skill_repos().expect("get repos");
+        let matching_repo = repos
+            .iter()
+            .find(|repo| {
+                repo.normalized_source_type() == default_repo.normalized_source_type()
+                    && repo.normalized_source_host() == default_repo.normalized_source_host()
+                    && repo.owner == default_repo.owner
+                    && repo.name == default_repo.name
+            })
+            .expect("existing default repo identity");
+
+        assert_eq!(inserted, 0);
+        assert_eq!(matching_repo.branch, custom_branch);
+    }
+}

--- a/src-tauri/src/database/migration.rs
+++ b/src-tauri/src/database/migration.rs
@@ -205,9 +205,19 @@ impl Database {
 
         for repo in &config.skills.repos {
             tx.execute(
-                "INSERT OR REPLACE INTO skill_repos (owner, name, branch, enabled) VALUES (?1, ?2, ?3, ?4)",
-                params![repo.owner, repo.name, repo.branch, repo.enabled],
-            ).map_err(|e| AppError::Database(format!("Migrate skill repo failed: {e}")))?;
+                "INSERT OR REPLACE INTO skill_repos
+                 (source_type, source_host, owner, name, branch, enabled)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    "github",
+                    "github.com",
+                    repo.owner,
+                    repo.name,
+                    repo.branch,
+                    repo.enabled
+                ],
+            )
+            .map_err(|e| AppError::Database(format!("Migrate skill repo failed: {e}")))?;
         }
 
         Ok(())

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -53,7 +53,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 16;
+pub(crate) const SCHEMA_VERSION: i32 = 17;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1542,24 +1542,32 @@ impl Database {
         if Self::table_exists(conn, "skills")? {
             Self::add_column_if_missing(conn, "skills", "repo_source_type", "TEXT")?;
             Self::add_column_if_missing(conn, "skills", "repo_source_host", "TEXT")?;
-            conn.execute(
-                "UPDATE skills
-                 SET repo_source_type = 'github'
-                 WHERE repo_owner IS NOT NULL
-                   AND repo_name IS NOT NULL
-                   AND (repo_source_type IS NULL OR repo_source_type = '')",
-                [],
-            )
-            .map_err(|e| AppError::Database(format!("回填 skills.repo_source_type 失败: {e}")))?;
-            conn.execute(
-                "UPDATE skills
-                 SET repo_source_host = 'github.com'
-                 WHERE repo_owner IS NOT NULL
-                   AND repo_name IS NOT NULL
-                   AND (repo_source_host IS NULL OR repo_source_host = '')",
-                [],
-            )
-            .map_err(|e| AppError::Database(format!("回填 skills.repo_source_host 失败: {e}")))?;
+            if Self::has_column(conn, "skills", "repo_owner")?
+                && Self::has_column(conn, "skills", "repo_name")?
+            {
+                conn.execute(
+                    "UPDATE skills
+                     SET repo_source_type = 'github'
+                     WHERE repo_owner IS NOT NULL
+                       AND repo_name IS NOT NULL
+                       AND (repo_source_type IS NULL OR repo_source_type = '')",
+                    [],
+                )
+                .map_err(|e| {
+                    AppError::Database(format!("回填 skills.repo_source_type 失败: {e}"))
+                })?;
+                conn.execute(
+                    "UPDATE skills
+                     SET repo_source_host = 'github.com'
+                     WHERE repo_owner IS NOT NULL
+                       AND repo_name IS NOT NULL
+                       AND (repo_source_host IS NULL OR repo_source_host = '')",
+                    [],
+                )
+                .map_err(|e| {
+                    AppError::Database(format!("回填 skills.repo_source_host 失败: {e}"))
+                })?;
+            }
         }
 
         if !Self::table_exists(conn, "skill_repos")? {
@@ -3156,7 +3164,7 @@ mod tests {
 
         Database::apply_schema_migrations_on_conn(&conn)?;
 
-        assert_eq!(Database::get_user_version(&conn)?, 16);
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
         let counts: (i64, i64, i64, i64) = conn.query_row(
             "SELECT
                 (SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'),

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -87,6 +87,8 @@ impl Database {
             name TEXT NOT NULL,
             description TEXT,
             directory TEXT NOT NULL,
+            repo_source_type TEXT,
+            repo_source_host TEXT,
             repo_owner TEXT,
             repo_name TEXT,
             repo_branch TEXT DEFAULT 'main',
@@ -108,8 +110,13 @@ impl Database {
         // 6. Skill Repos 表
         conn.execute(
             "CREATE TABLE IF NOT EXISTS skill_repos (
-            owner TEXT NOT NULL, name TEXT NOT NULL, branch TEXT NOT NULL DEFAULT 'main',
-            enabled BOOLEAN NOT NULL DEFAULT 1, PRIMARY KEY (owner, name)
+            source_type TEXT NOT NULL DEFAULT 'github',
+            source_host TEXT NOT NULL DEFAULT 'github.com',
+            owner TEXT NOT NULL,
+            name TEXT NOT NULL,
+            branch TEXT NOT NULL DEFAULT 'main',
+            enabled BOOLEAN NOT NULL DEFAULT 1,
+            PRIMARY KEY (source_type, source_host, owner, name)
         )",
             [],
         )
@@ -510,6 +517,11 @@ impl Database {
                         log::info!("迁移数据库从 v15 到 v16（重建 Codex 会话用量）");
                         Self::migrate_v15_to_v16(conn)?;
                         Self::set_user_version(conn, 16)?;
+                    }
+                    16 => {
+                        log::info!("迁移数据库从 v16 到 v17（Skill 仓库来源支持）");
+                        Self::migrate_v16_to_v17(conn)?;
+                        Self::set_user_version(conn, 17)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -1521,6 +1533,70 @@ impl Database {
     fn migrate_v15_to_v16(conn: &Connection) -> Result<(), AppError> {
         let codex_dir = crate::codex_config::get_codex_config_dir();
         crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)
+    }
+
+    /// v16 -> v17：Skill 仓库支持 GitHub/GitLab 来源。
+    ///
+    /// 该迁移保持幂等，以兼容曾运行过本地开发版（其 v12 已包含这些字段）的数据库。
+    fn migrate_v16_to_v17(conn: &Connection) -> Result<(), AppError> {
+        if Self::table_exists(conn, "skills")? {
+            Self::add_column_if_missing(conn, "skills", "repo_source_type", "TEXT")?;
+            Self::add_column_if_missing(conn, "skills", "repo_source_host", "TEXT")?;
+            conn.execute(
+                "UPDATE skills
+                 SET repo_source_type = 'github'
+                 WHERE repo_owner IS NOT NULL
+                   AND repo_name IS NOT NULL
+                   AND (repo_source_type IS NULL OR repo_source_type = '')",
+                [],
+            )
+            .map_err(|e| AppError::Database(format!("回填 skills.repo_source_type 失败: {e}")))?;
+            conn.execute(
+                "UPDATE skills
+                 SET repo_source_host = 'github.com'
+                 WHERE repo_owner IS NOT NULL
+                   AND repo_name IS NOT NULL
+                   AND (repo_source_host IS NULL OR repo_source_host = '')",
+                [],
+            )
+            .map_err(|e| AppError::Database(format!("回填 skills.repo_source_host 失败: {e}")))?;
+        }
+
+        if !Self::table_exists(conn, "skill_repos")? {
+            return Ok(());
+        }
+
+        if Self::has_column(conn, "skill_repos", "source_type")?
+            && Self::has_column(conn, "skill_repos", "source_host")?
+        {
+            log::info!("v16 -> v17：skill_repos 已包含来源字段，跳过重建");
+            return Ok(());
+        }
+
+        conn.execute_batch(
+            "DROP TABLE IF EXISTS skill_repos_v17;
+             ALTER TABLE skill_repos RENAME TO skill_repos_v17;
+             CREATE TABLE skill_repos (
+                 source_type TEXT NOT NULL DEFAULT 'github',
+                 source_host TEXT NOT NULL DEFAULT 'github.com',
+                 owner TEXT NOT NULL,
+                 name TEXT NOT NULL,
+                 branch TEXT NOT NULL DEFAULT 'main',
+                 enabled BOOLEAN NOT NULL DEFAULT 1,
+                 PRIMARY KEY (source_type, source_host, owner, name)
+             );
+             INSERT OR REPLACE INTO skill_repos
+                 (source_type, source_host, owner, name, branch, enabled)
+             SELECT 'github', 'github.com', owner, name,
+                    COALESCE(NULLIF(branch, ''), 'main'),
+                    COALESCE(enabled, 1)
+             FROM skill_repos_v17;
+             DROP TABLE skill_repos_v17;",
+        )
+        .map_err(|e| AppError::Database(format!("v16 -> v17 重建 skill_repos 失败: {e}")))?;
+
+        log::info!("v16 -> v17 迁移完成：Skill 仓库已支持来源类型和域名");
+        Ok(())
     }
 
     /// 插入默认模型定价数据

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -157,8 +157,13 @@ fn deleted_default_skill_repo_is_not_restored() {
 
     assert_eq!(db.init_default_skill_repos().expect("initialize repos"), 4);
     for repo in db.get_skill_repos().expect("get initialized repos") {
-        db.delete_skill_repo(&repo.owner, &repo.name)
-            .expect("delete repo");
+        db.delete_skill_repo(
+            &repo.normalized_source_type(),
+            &repo.normalized_source_host(),
+            &repo.owner,
+            &repo.name,
+        )
+        .expect("delete repo");
     }
     assert!(db.get_skill_repos().expect("get deleted repos").is_empty());
 
@@ -527,8 +532,8 @@ fn schema_create_tables_repairs_dev_global_profile_marker() {
             "SELECT value FROM settings WHERE key = 'current_profile_id_claude'",
             [],
             |row| row.get(0),
-    )
-    .expect("scoped current marker survives");
+        )
+        .expect("scoped current marker survives");
     assert_eq!(claude_marker, "p1");
 }
 
@@ -606,6 +611,69 @@ fn migration_v16_to_v17_adds_skill_repo_sources() {
     assert_eq!(
         Database::get_user_version(&conn).expect("version after migration"),
         SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn migration_from_local_skill_source_v12_remains_compatible() {
+    let conn = Connection::open_in_memory().expect("open memory db");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE skills (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            directory TEXT NOT NULL,
+            repo_source_type TEXT,
+            repo_source_host TEXT,
+            repo_owner TEXT,
+            repo_name TEXT,
+            repo_branch TEXT DEFAULT 'main',
+            readme_url TEXT,
+            enabled_claude BOOLEAN NOT NULL DEFAULT 0,
+            enabled_codex BOOLEAN NOT NULL DEFAULT 0,
+            enabled_gemini BOOLEAN NOT NULL DEFAULT 0,
+            enabled_opencode BOOLEAN NOT NULL DEFAULT 0,
+            enabled_hermes BOOLEAN NOT NULL DEFAULT 0,
+            installed_at INTEGER NOT NULL DEFAULT 0,
+            content_hash TEXT,
+            updated_at INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE skill_repos (
+            source_type TEXT NOT NULL DEFAULT 'github',
+            source_host TEXT NOT NULL DEFAULT 'github.com',
+            owner TEXT NOT NULL,
+            name TEXT NOT NULL,
+            branch TEXT NOT NULL DEFAULT 'main',
+            enabled BOOLEAN NOT NULL DEFAULT 1,
+            PRIMARY KEY (source_type, source_host, owner, name)
+        );
+        INSERT INTO skill_repos
+            (source_type, source_host, owner, name, branch, enabled)
+        VALUES ('gitlab', 'gitlab.example.com', 'group', 'skills', 'develop', 1);
+        "#,
+    )
+    .expect("seed local v12 skill tables");
+    Database::set_user_version(&conn, 12).expect("set user_version=12");
+
+    Database::create_tables_on_conn(&conn).expect("create current tables");
+    Database::apply_schema_migrations_on_conn(&conn).expect("apply migrations");
+
+    assert_eq!(
+        Database::get_user_version(&conn).expect("version after migration"),
+        SCHEMA_VERSION
+    );
+    assert!(Database::has_column(&conn, "skills", "enabled_grokbuild").unwrap());
+    let (source_type, source_host, branch): (String, String, String) = conn
+        .query_row(
+            "SELECT source_type, source_host, branch FROM skill_repos",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("preserved GitLab repo");
+    assert_eq!(
+        (source_type.as_str(), source_host.as_str(), branch.as_str()),
+        ("gitlab", "gitlab.example.com", "develop")
     );
 }
 

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -233,6 +233,10 @@ fn schema_migration_adds_missing_columns_for_providers() {
         ("mcp_servers", "enabled_gemini"),
         ("prompts", "updated_at"),
         ("skills", "installed_at"),
+        ("skills", "repo_source_type"),
+        ("skills", "repo_source_host"),
+        ("skill_repos", "source_type"),
+        ("skill_repos", "source_host"),
         ("skill_repos", "enabled"),
     ] {
         assert!(
@@ -297,6 +301,20 @@ fn schema_migration_aligns_column_defaults_and_types() {
     assert_eq!(
         normalize_default(&skill_repo_enabled.default).as_deref(),
         Some("1")
+    );
+
+    let source_type = get_column_info(&conn, "skill_repos", "source_type");
+    assert_eq!(source_type.r#type, "TEXT");
+    assert_eq!(
+        normalize_default(&source_type.default).as_deref(),
+        Some("github")
+    );
+
+    let source_host = get_column_info(&conn, "skill_repos", "source_host");
+    assert_eq!(source_host.r#type, "TEXT");
+    assert_eq!(
+        normalize_default(&source_host.default).as_deref(),
+        Some("github.com")
     );
 }
 
@@ -509,9 +527,86 @@ fn schema_create_tables_repairs_dev_global_profile_marker() {
             "SELECT value FROM settings WHERE key = 'current_profile_id_claude'",
             [],
             |row| row.get(0),
-        )
-        .expect("scoped current marker survives");
+    )
+    .expect("scoped current marker survives");
     assert_eq!(claude_marker, "p1");
+}
+
+#[test]
+fn migration_v16_to_v17_adds_skill_repo_sources() {
+    let conn = Connection::open_in_memory().expect("open memory db");
+
+    conn.execute_batch(
+        r#"
+        CREATE TABLE skills (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            directory TEXT NOT NULL,
+            repo_owner TEXT,
+            repo_name TEXT,
+            repo_branch TEXT DEFAULT 'main',
+            readme_url TEXT,
+            enabled_claude BOOLEAN NOT NULL DEFAULT 0,
+            enabled_codex BOOLEAN NOT NULL DEFAULT 0,
+            enabled_gemini BOOLEAN NOT NULL DEFAULT 0,
+            enabled_opencode BOOLEAN NOT NULL DEFAULT 0,
+            enabled_hermes BOOLEAN NOT NULL DEFAULT 0,
+            installed_at INTEGER NOT NULL DEFAULT 0,
+            content_hash TEXT,
+            updated_at INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO skills
+            (id, name, directory, repo_owner, repo_name, repo_branch)
+        VALUES ('owner/repo:demo', 'Demo', 'demo', 'owner', 'repo', 'main');
+
+        CREATE TABLE skill_repos (
+            owner TEXT NOT NULL,
+            name TEXT NOT NULL,
+            branch TEXT NOT NULL DEFAULT 'main',
+            enabled BOOLEAN NOT NULL DEFAULT 1,
+            PRIMARY KEY (owner, name)
+        );
+        INSERT INTO skill_repos (owner, name, branch, enabled)
+        VALUES ('owner', 'repo', 'main', 1);
+        "#,
+    )
+    .expect("seed v16 skill tables");
+
+    Database::set_user_version(&conn, 16).expect("set user_version=16");
+    Database::apply_schema_migrations_on_conn(&conn).expect("apply migrations");
+
+    assert!(Database::has_column(&conn, "skills", "repo_source_type").unwrap());
+    assert!(Database::has_column(&conn, "skills", "repo_source_host").unwrap());
+    assert!(Database::has_column(&conn, "skill_repos", "source_type").unwrap());
+    assert!(Database::has_column(&conn, "skill_repos", "source_host").unwrap());
+
+    let (skill_source_type, skill_source_host): (String, String) = conn
+        .query_row(
+            "SELECT repo_source_type, repo_source_host FROM skills WHERE id = 'owner/repo:demo'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("migrated skill source");
+    assert_eq!(skill_source_type, "github");
+    assert_eq!(skill_source_host, "github.com");
+
+    let (repo_source_type, repo_source_host, owner, name): (String, String, String, String) = conn
+        .query_row(
+            "SELECT source_type, source_host, owner, name FROM skill_repos",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("migrated repo source");
+    assert_eq!(repo_source_type, "github");
+    assert_eq!(repo_source_host, "github.com");
+    assert_eq!(owner, "owner");
+    assert_eq!(name, "repo");
+
+    assert_eq!(
+        Database::get_user_version(&conn).expect("version after migration"),
+        SCHEMA_VERSION
+    );
 }
 
 #[test]

--- a/src-tauri/src/deeplink/skill.rs
+++ b/src-tauri/src/deeplink/skill.rs
@@ -49,6 +49,8 @@ pub fn import_skill_from_deeplink(
 
     // Create SkillRepo
     let repo = SkillRepo {
+        source_type: "github".to_string(),
+        source_host: "github.com".to_string(),
         owner: owner.clone(),
         name: name.clone(),
         branch,

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -548,10 +548,7 @@ impl SkillService {
     /// `openExternal` 直接打开，恶意仓库坐标可能把它指向非预期位置。
     fn build_skill_doc_url(repo: &SkillRepo, branch: &str, doc_path: &str) -> Option<String> {
         if Self::validate_skill_repo(repo, branch).is_err() {
-            log::warn!(
-                "跳过非法仓库坐标的文档链接: {}@{branch}",
-                repo.repo_key()
-            );
+            log::warn!("跳过非法仓库坐标的文档链接: {}@{branch}", repo.repo_key());
             return None;
         }
 
@@ -2604,11 +2601,8 @@ impl SkillService {
 
     fn assert_gitlab_archive_url(url: &str, repo: &SkillRepo) -> Result<()> {
         let parsed = url::Url::parse(url).map_err(|e| anyhow!("Invalid archive URL: {e}"))?;
-        let expected = url::Url::parse(&format!(
-            "https://{}/",
-            repo.normalized_source_host()
-        ))
-        .map_err(|e| anyhow!("Invalid GitLab host: {e}"))?;
+        let expected = url::Url::parse(&format!("https://{}/", repo.normalized_source_host()))
+            .map_err(|e| anyhow!("Invalid GitLab host: {e}"))?;
         let expected_prefix = format!("/{}/{}/-/archive/", repo.owner, repo.name);
         if parsed.scheme() != "https"
             || parsed.host_str() != expected.host_str()
@@ -4095,15 +4089,64 @@ mod tests {
     }
 
     #[test]
-    fn build_skill_doc_url_drops_illegal_coordinates() {
+    fn gitlab_archive_and_doc_urls_keep_the_configured_host() {
+        let repo = SkillRepo {
+            source_type: "gitlab".to_string(),
+            source_host: "gitlab.example.com".to_string(),
+            owner: "group/subgroup".to_string(),
+            name: "skills".to_string(),
+            branch: "feature/env".to_string(),
+            enabled: true,
+        };
+
         assert_eq!(
-            SkillService::build_skill_doc_url("owner", "repo", "main", "a/SKILL.md").as_deref(),
+            SkillService::build_repo_archive_url(&repo, "feature/env").unwrap(),
+            "https://gitlab.example.com/group/subgroup/skills/-/archive/feature/env/skills-feature/env.zip"
+        );
+        assert_eq!(
+            SkillService::build_skill_doc_url(&repo, "feature/env", "demo/SKILL.md").as_deref(),
+            Some(
+                "https://gitlab.example.com/group/subgroup/skills/-/blob/feature/env/demo/SKILL.md"
+            )
+        );
+    }
+
+    #[test]
+    fn gitlab_repo_validation_rejects_host_and_path_injection() {
+        for (host, owner, branch) in [
+            ("gitlab.example.com/evil", "group", "main"),
+            ("user@gitlab.example.com", "group", "main"),
+            ("gitlab.example.com", "../group", "main"),
+            ("gitlab.example.com", "group", "../../../issues"),
+        ] {
+            let repo = SkillRepo {
+                source_type: "gitlab".to_string(),
+                source_host: host.to_string(),
+                owner: owner.to_string(),
+                name: "skills".to_string(),
+                branch: branch.to_string(),
+                enabled: true,
+            };
+            assert!(SkillService::validate_skill_repo(&repo, branch).is_err());
+        }
+    }
+
+    #[test]
+    fn build_skill_doc_url_drops_illegal_coordinates() {
+        let repo = SkillRepo {
+            source_type: "github".to_string(),
+            source_host: "github.com".to_string(),
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+            branch: "main".to_string(),
+            enabled: true,
+        };
+        assert_eq!(
+            SkillService::build_skill_doc_url(&repo, "main", "a/SKILL.md").as_deref(),
             Some("https://github.com/owner/repo/blob/main/a/SKILL.md")
         );
         // readme_url 会被前端 openExternal 直接打开，非法坐标不得产出链接
-        assert!(
-            SkillService::build_skill_doc_url("owner", "repo", "../../../issues", "x").is_none()
-        );
+        assert!(SkillService::build_skill_doc_url(&repo, "../../../issues", "x").is_none());
     }
 
     #[test]
@@ -4551,6 +4594,8 @@ mod tests {
             name: "poisoned".to_string(),
             description: None,
             directory: directory.to_string(),
+            repo_source_type: None,
+            repo_source_host: None,
             repo_owner: None,
             repo_name: None,
             repo_branch: None,

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -3704,13 +3704,7 @@ impl SkillService {
 
 // ========== 迁移支持 ==========
 
-/// 从 lock 文件信息构建 skill 的 ID、仓库字段和 readme URL
-///
-/// 返回 (id, repo_owner, repo_name, repo_branch, readme_url)
-fn build_repo_info_from_lock(
-    lock: &HashMap<String, LockRepoInfo>,
-    dir_name: &str,
-) -> (
+type LockRepoInfoParts = (
     String,
     Option<String>,
     Option<String>,
@@ -3718,7 +3712,15 @@ fn build_repo_info_from_lock(
     Option<String>,
     Option<String>,
     Option<String>,
-) {
+);
+
+/// 从 lock 文件信息构建 skill 的 ID、仓库字段和 readme URL
+///
+/// 返回 (id, repo_source_type, repo_source_host, repo_owner, repo_name, repo_branch, readme_url)
+fn build_repo_info_from_lock(
+    lock: &HashMap<String, LockRepoInfo>,
+    dir_name: &str,
+) -> LockRepoInfoParts {
     match lock.get(dir_name) {
         Some(info) => {
             let branch = info.branch.clone();

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -49,7 +49,7 @@ pub enum SkillStorageLocation {
 /// 可发现的技能（来自仓库）
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiscoverableSkill {
-    /// 唯一标识: "owner/name:directory"
+    /// 唯一标识: "owner/name:directory" 或 "source_host/owner/name:directory"
     pub key: String,
     /// 显示名称 (从 SKILL.md 解析)
     pub name: String,
@@ -57,9 +57,15 @@ pub struct DiscoverableSkill {
     pub description: String,
     /// 目录名称 (安装路径的最后一段)
     pub directory: String,
-    /// GitHub README URL
+    /// README URL
     #[serde(rename = "readmeUrl")]
     pub readme_url: Option<String>,
+    /// 仓库来源类型（github / gitlab）
+    #[serde(rename = "repoSourceType")]
+    pub repo_source_type: String,
+    /// 仓库来源域名
+    #[serde(rename = "repoSourceHost")]
+    pub repo_source_host: String,
     /// 仓库所有者
     #[serde(rename = "repoOwner")]
     pub repo_owner: String,
@@ -101,7 +107,13 @@ pub struct Skill {
 /// 仓库配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillRepo {
-    /// GitHub 用户/组织名
+    /// 仓库来源类型（github / gitlab）
+    #[serde(rename = "sourceType", default = "default_repo_source_type")]
+    pub source_type: String,
+    /// 仓库来源域名
+    #[serde(rename = "sourceHost", default = "default_repo_source_host")]
+    pub source_host: String,
+    /// 仓库用户/组织名
     pub owner: String,
     /// 仓库名称
     pub name: String,
@@ -109,6 +121,62 @@ pub struct SkillRepo {
     pub branch: String,
     /// 是否启用
     pub enabled: bool,
+}
+
+fn default_repo_source_type() -> String {
+    "github".to_string()
+}
+
+fn default_repo_source_host() -> String {
+    "github.com".to_string()
+}
+
+impl SkillRepo {
+    pub fn normalized_source_type(&self) -> String {
+        let source_type = self.source_type.trim().to_lowercase();
+        if source_type.is_empty() {
+            default_repo_source_type()
+        } else {
+            source_type
+        }
+    }
+
+    pub fn normalized_source_host(&self) -> String {
+        let source_host = self
+            .source_host
+            .trim()
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .trim_end_matches('/')
+            .to_lowercase();
+        if source_host.is_empty() {
+            match self.normalized_source_type().as_str() {
+                "gitlab" => "gitlab.com".to_string(),
+                _ => default_repo_source_host(),
+            }
+        } else {
+            source_host
+        }
+    }
+
+    pub fn repo_key(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.normalized_source_host(),
+            self.owner,
+            self.name
+        )
+    }
+
+    pub fn skill_id_prefix(&self) -> String {
+        if self.normalized_source_type() == "github"
+            && self.normalized_source_host() == default_repo_source_host()
+        {
+            format!("{}/{}", self.owner, self.name)
+        } else {
+            self.repo_key()
+        }
+    }
 }
 
 /// 技能安装状态（旧版兼容）
@@ -136,24 +204,32 @@ impl Default for SkillStore {
             skills: HashMap::new(),
             repos: vec![
                 SkillRepo {
+                    source_type: default_repo_source_type(),
+                    source_host: default_repo_source_host(),
                     owner: "anthropics".to_string(),
                     name: "skills".to_string(),
                     branch: "main".to_string(),
                     enabled: true,
                 },
                 SkillRepo {
+                    source_type: default_repo_source_type(),
+                    source_host: default_repo_source_host(),
                     owner: "ComposioHQ".to_string(),
                     name: "awesome-claude-skills".to_string(),
                     branch: "master".to_string(),
                     enabled: true,
                 },
                 SkillRepo {
+                    source_type: default_repo_source_type(),
+                    source_host: default_repo_source_host(),
                     owner: "cexll".to_string(),
                     name: "myclaude".to_string(),
                     branch: "master".to_string(),
                     enabled: true,
                 },
                 SkillRepo {
+                    source_type: default_repo_source_type(),
+                    source_host: default_repo_source_host(),
                     owner: "JimLiu".to_string(),
                     name: "baoyu-skills".to_string(),
                     branch: "main".to_string(),
@@ -469,20 +545,83 @@ impl SkillService {
     /// 构建 Skill 文档 URL（指向仓库中的 SKILL.md 文件）
     ///
     /// 坐标不合法时返回 None：这个值会存进 `readme_url`，前端「查看文档」用
-    /// `openExternal` 直接打开，恶意 branch 能把它指到 github.com 上的任意路径。
-    fn build_skill_doc_url(
-        owner: &str,
-        repo: &str,
-        branch: &str,
-        doc_path: &str,
-    ) -> Option<String> {
-        if Self::validate_repo_ref(owner, repo, branch).is_err() {
-            log::warn!("跳过非法仓库坐标的文档链接: {owner}/{repo}@{branch}");
+    /// `openExternal` 直接打开，恶意仓库坐标可能把它指向非预期位置。
+    fn build_skill_doc_url(repo: &SkillRepo, branch: &str, doc_path: &str) -> Option<String> {
+        if Self::validate_skill_repo(repo, branch).is_err() {
+            log::warn!(
+                "跳过非法仓库坐标的文档链接: {}@{branch}",
+                repo.repo_key()
+            );
             return None;
         }
-        Some(format!(
-            "https://github.com/{owner}/{repo}/blob/{branch}/{doc_path}"
-        ))
+
+        Some(match repo.normalized_source_type().as_str() {
+            "gitlab" => format!(
+                "https://{}/{}/{}/-/blob/{}/{}",
+                repo.normalized_source_host(),
+                repo.owner,
+                repo.name,
+                branch,
+                doc_path
+            ),
+            "github" => format!(
+                "https://github.com/{}/{}/blob/{}/{}",
+                repo.owner, repo.name, branch, doc_path
+            ),
+            _ => return None,
+        })
+    }
+
+    fn build_repo_archive_url(repo: &SkillRepo, branch: &str) -> Result<String> {
+        Self::validate_skill_repo(repo, branch)?;
+        let url = match repo.normalized_source_type().as_str() {
+            "github" => {
+                let url = format!(
+                    "https://github.com/{}/{}/archive/refs/heads/{}.zip",
+                    repo.owner, repo.name, branch
+                );
+                Self::assert_github_archive_url(&url, &repo.owner, &repo.name)?;
+                url
+            }
+            "gitlab" => {
+                let url = format!(
+                    "https://{}/{}/{}/-/archive/{}/{}-{}.zip",
+                    repo.normalized_source_host(),
+                    repo.owner,
+                    repo.name,
+                    branch,
+                    repo.name,
+                    branch
+                );
+                Self::assert_gitlab_archive_url(&url, repo)?;
+                url
+            }
+            source_type => Err(anyhow!(
+                "Unsupported skill repository source: {source_type}"
+            ))?,
+        };
+        Ok(url)
+    }
+
+    fn build_repo_git_urls(repo: &SkillRepo) -> Result<Vec<String>> {
+        Self::validate_skill_repo(repo, &repo.branch)?;
+        match repo.normalized_source_type().as_str() {
+            "github" => Ok(vec![format!(
+                "https://github.com/{}/{}.git",
+                repo.owner, repo.name
+            )]),
+            "gitlab" => {
+                let host = repo.normalized_source_host();
+                let path = format!("{}/{}.git", repo.owner, repo.name);
+                Ok(vec![
+                    format!("https://{host}/{path}"),
+                    format!("http://{host}/{path}"),
+                ])
+            }
+            source_type => Err(anyhow!(
+                "Unsupported skill repository source: {source_type}"
+            )),
+        }
     }
 
     /// 从旧 readme_url 中提取仓库内文档路径，兼容 `blob`/`tree` 两种格式
@@ -632,7 +771,17 @@ impl SkillService {
             if existing.directory.eq_ignore_ascii_case(&install_name) {
                 // 检查是否来自同一仓库
                 let same_repo = existing.repo_owner.as_deref() == Some(&skill.repo_owner)
-                    && existing.repo_name.as_deref() == Some(&skill.repo_name);
+                    && existing.repo_name.as_deref() == Some(&skill.repo_name)
+                    && existing
+                        .repo_source_type
+                        .as_deref()
+                        .unwrap_or("github")
+                        .eq_ignore_ascii_case(&skill.repo_source_type)
+                    && existing
+                        .repo_source_host
+                        .as_deref()
+                        .unwrap_or("github.com")
+                        .eq_ignore_ascii_case(&skill.repo_source_host);
                 if same_repo {
                     // 同一仓库的同名 skill，返回现有记录（可能需要更新启用状态）
                     let mut updated = existing.clone();
@@ -677,6 +826,8 @@ impl SkillService {
         // 如果已存在则跳过下载
         if !dest.exists() {
             let repo = SkillRepo {
+                source_type: skill.repo_source_type.clone(),
+                source_host: skill.repo_source_host.clone(),
                 owner: skill.repo_owner.clone(),
                 name: skill.repo_name.clone(),
                 branch: skill.repo_branch.clone(),
@@ -759,8 +910,15 @@ impl SkillService {
             })
             .unwrap_or_else(|| format!("{}/SKILL.md", skill.directory.trim_end_matches('/')));
 
-        let readme_url =
-            Self::build_skill_doc_url(&skill.repo_owner, &skill.repo_name, &repo_branch, &doc_path);
+        let readme_repo = SkillRepo {
+            source_type: skill.repo_source_type.clone(),
+            source_host: skill.repo_source_host.clone(),
+            owner: skill.repo_owner.clone(),
+            name: skill.repo_name.clone(),
+            branch: repo_branch.clone(),
+            enabled: true,
+        };
+        let readme_url = Self::build_skill_doc_url(&readme_repo, &repo_branch, &doc_path);
 
         // 创建 InstalledSkill 记录
         // 计算内容哈希
@@ -778,6 +936,8 @@ impl SkillService {
                 Some(skill.description.clone())
             },
             directory: install_name.clone(),
+            repo_source_type: Some(skill.repo_source_type.clone()),
+            repo_source_host: Some(skill.repo_source_host.clone()),
             repo_owner: Some(skill.repo_owner.clone()),
             repo_name: Some(skill.repo_name.clone()),
             repo_branch: Some(repo_branch),
@@ -922,27 +1082,41 @@ impl SkillService {
         let skills = db.get_all_installed_skills()?;
         let mut updates = Vec::new();
 
-        // 按 (owner, name, branch) 分组
-        let mut repo_groups: HashMap<(String, String, String), Vec<InstalledSkill>> =
-            HashMap::new();
+        // 按 (source_type, source_host, owner, name, branch) 分组
+        let mut repo_groups: HashMap<
+            (String, String, String, String, String),
+            Vec<InstalledSkill>,
+        > = HashMap::new();
 
         for skill in skills.into_values() {
-            let (owner, name, branch) =
-                match (&skill.repo_owner, &skill.repo_name, &skill.repo_branch) {
-                    (Some(o), Some(n), Some(b)) => (o.clone(), n.clone(), b.clone()),
-                    (Some(o), Some(n), None) => (o.clone(), n.clone(), "main".to_string()),
-                    _ => continue,
-                };
+            let (owner, name) = match (&skill.repo_owner, &skill.repo_name) {
+                (Some(o), Some(n)) => (o.clone(), n.clone()),
+                _ => continue,
+            };
+            let source_type = skill
+                .repo_source_type
+                .clone()
+                .unwrap_or_else(default_repo_source_type);
+            let source_host = skill
+                .repo_source_host
+                .clone()
+                .unwrap_or_else(default_repo_source_host);
+            let branch = skill
+                .repo_branch
+                .clone()
+                .unwrap_or_else(|| "main".to_string());
             repo_groups
-                .entry((owner, name, branch))
+                .entry((source_type, source_host, owner, name, branch))
                 .or_default()
                 .push(skill);
         }
 
         let ssot_dir = Self::get_ssot_dir()?;
 
-        for ((owner, name, branch), group_skills) in &repo_groups {
+        for ((source_type, source_host, owner, name, branch), group_skills) in &repo_groups {
             let repo = SkillRepo {
+                source_type: source_type.clone(),
+                source_host: source_host.clone(),
                 owner: owner.clone(),
                 name: name.clone(),
                 branch: branch.clone(),
@@ -1062,6 +1236,14 @@ impl SkillService {
         };
 
         let repo = SkillRepo {
+            source_type: skill
+                .repo_source_type
+                .clone()
+                .unwrap_or_else(default_repo_source_type),
+            source_host: skill
+                .repo_source_host
+                .clone()
+                .unwrap_or_else(default_repo_source_host),
             owner: owner.clone(),
             name: name.clone(),
             branch: branch.clone(),
@@ -1134,7 +1316,7 @@ impl SkillService {
             .as_deref()
             .and_then(Self::extract_doc_path_from_url)
             .unwrap_or_else(|| format!("{}/SKILL.md", skill.directory.trim_end_matches('/')));
-        let readme_url = Self::build_skill_doc_url(&owner, &name, &used_branch, &doc_path);
+        let readme_url = Self::build_skill_doc_url(&repo, &used_branch, &doc_path);
 
         let updated_skill = InstalledSkill {
             id: skill.id.clone(),
@@ -1144,6 +1326,8 @@ impl SkillService {
             repo_owner: skill.repo_owner.clone(),
             repo_name: skill.repo_name.clone(),
             repo_branch: Some(used_branch),
+            repo_source_type: skill.repo_source_type.clone(),
+            repo_source_host: skill.repo_source_host.clone(),
             readme_url,
             apps: skill.apps.clone(),
             installed_at: skill.installed_at,
@@ -1591,8 +1775,15 @@ impl SkillService {
             let apps = selection.apps;
 
             // 从 lock 文件提取仓库信息
-            let (id, repo_owner, repo_name, repo_branch, readme_url) =
-                build_repo_info_from_lock(&agents_lock, &dir_name);
+            let (
+                id,
+                repo_source_type,
+                repo_source_host,
+                repo_owner,
+                repo_name,
+                repo_branch,
+                readme_url,
+            ) = build_repo_info_from_lock(&agents_lock, &dir_name);
 
             // 计算内容哈希
             let ssot_skill_dir = ssot_dir.join(&dir_name);
@@ -1604,6 +1795,8 @@ impl SkillService {
                 name,
                 description,
                 directory: dir_name,
+                repo_source_type,
+                repo_source_host,
                 repo_owner,
                 repo_name,
                 repo_branch,
@@ -2096,11 +2289,13 @@ impl SkillService {
         let meta = self.parse_skill_metadata(skill_md)?;
 
         Ok(DiscoverableSkill {
-            key: format!("{}/{}:{}", repo.owner, repo.name, directory),
+            key: format!("{}:{}", repo.skill_id_prefix(), directory),
             name: meta.name.unwrap_or_else(|| directory.to_string()),
             description: meta.description.unwrap_or_default(),
             directory: directory.to_string(),
-            readme_url: Self::build_skill_doc_url(&repo.owner, &repo.name, &repo.branch, doc_path),
+            readme_url: Self::build_skill_doc_url(repo, &repo.branch, doc_path),
+            repo_source_type: repo.normalized_source_type(),
+            repo_source_host: repo.normalized_source_host(),
             repo_owner: repo.owner.clone(),
             repo_name: repo.name.clone(),
             repo_branch: repo.branch.clone(),
@@ -2320,6 +2515,73 @@ impl SkillService {
         Ok(())
     }
 
+    fn is_valid_gitlab_namespace(namespace: &str) -> bool {
+        !namespace.is_empty()
+            && namespace.len() <= 512
+            && namespace.split('/').all(|segment| {
+                !segment.is_empty()
+                    && segment != "."
+                    && segment != ".."
+                    && segment.len() <= 255
+                    && segment
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+            })
+    }
+
+    fn is_valid_gitlab_host(host: &str) -> bool {
+        if host.is_empty() {
+            return false;
+        }
+        let Ok(parsed) = url::Url::parse(&format!("https://{host}/")) else {
+            return false;
+        };
+        parsed.scheme() == "https"
+            && parsed.host_str().is_some()
+            && parsed.username().is_empty()
+            && parsed.password().is_none()
+            && parsed.path() == "/"
+            && parsed.query().is_none()
+            && parsed.fragment().is_none()
+    }
+
+    fn validate_skill_repo(repo: &SkillRepo, branch: &str) -> Result<()> {
+        match repo.normalized_source_type().as_str() {
+            "github" => {
+                if repo.normalized_source_host() != default_repo_source_host() {
+                    return Err(anyhow!(format_skill_error(
+                        "INVALID_REPO_REF",
+                        &[("owner", &repo.owner), ("name", &repo.name)],
+                        Some("checkRepoUrl"),
+                    )));
+                }
+                Self::validate_repo_ref(&repo.owner, &repo.name, branch)
+            }
+            "gitlab" => {
+                let host = repo.normalized_source_host();
+                if !Self::is_valid_gitlab_host(&host)
+                    || !Self::is_valid_gitlab_namespace(&repo.owner)
+                    || !Self::is_valid_github_repo_name(&repo.name)
+                    || !Self::is_valid_git_branch(branch)
+                {
+                    return Err(anyhow!(format_skill_error(
+                        "INVALID_REPO_REF",
+                        &[
+                            ("owner", &repo.owner),
+                            ("name", &repo.name),
+                            ("branch", branch),
+                        ],
+                        Some("checkRepoUrl"),
+                    )));
+                }
+                Ok(())
+            }
+            source_type => Err(anyhow!(
+                "Unsupported skill repository source: {source_type}"
+            )),
+        }
+    }
+
     /// 出口断言：URL 拼好后再确认它确实指向预期的 github.com 路径。
     ///
     /// 这是纵深防御——即便上面的字符集校验将来漏了某种变形（百分号编码、新的
@@ -2334,6 +2596,28 @@ impl SkillService {
             return Err(anyhow!(format_skill_error(
                 "INVALID_REPO_REF",
                 &[("owner", owner), ("name", name)],
+                Some("checkRepoUrl"),
+            )));
+        }
+        Ok(())
+    }
+
+    fn assert_gitlab_archive_url(url: &str, repo: &SkillRepo) -> Result<()> {
+        let parsed = url::Url::parse(url).map_err(|e| anyhow!("Invalid archive URL: {e}"))?;
+        let expected = url::Url::parse(&format!(
+            "https://{}/",
+            repo.normalized_source_host()
+        ))
+        .map_err(|e| anyhow!("Invalid GitLab host: {e}"))?;
+        let expected_prefix = format!("/{}/{}/-/archive/", repo.owner, repo.name);
+        if parsed.scheme() != "https"
+            || parsed.host_str() != expected.host_str()
+            || parsed.port() != expected.port()
+            || !parsed.path().starts_with(&expected_prefix)
+        {
+            return Err(anyhow!(format_skill_error(
+                "INVALID_REPO_REF",
+                &[("owner", &repo.owner), ("name", &repo.name)],
                 Some("checkRepoUrl"),
             )));
         }
@@ -2428,7 +2712,7 @@ impl SkillService {
     /// `check_updates`、`update_skill` 四条路径都经过它，而 `skill_repos` / `skills`
     /// 两张表都会被同步导入的远端快照整表覆盖，入库校验管不住它们。所以主防线放这里。
     async fn download_repo(&self, repo: &SkillRepo) -> Result<(tempfile::TempDir, String)> {
-        Self::validate_repo_ref(&repo.owner, &repo.name, &repo.branch)?;
+        Self::validate_skill_repo(repo, &repo.branch)?;
 
         // 守卫全程持有，成功后连同目录一起交给调用方（见 `extract_local_zip` 的说明）。
         // 原来这里立刻 keep()，任何一步失败——下载超时、ARCHIVE_TOO_LARGE、解压出错
@@ -2449,11 +2733,7 @@ impl SkillService {
 
         let mut last_error = None;
         for branch in branches {
-            let url = format!(
-                "https://github.com/{}/{}/archive/refs/heads/{}.zip",
-                repo.owner, repo.name, branch
-            );
-            Self::assert_github_archive_url(&url, &repo.owner, &repo.name)?;
+            let url = Self::build_repo_archive_url(repo, branch)?;
 
             match self.download_and_extract(&url, &temp_path).await {
                 Ok(_) => return Ok((temp_dir, branch.to_string())),
@@ -2463,12 +2743,92 @@ impl SkillService {
                     let _ = fs::remove_dir_all(&temp_path);
                     let _ = fs::create_dir_all(&temp_path);
                     last_error = Some(e);
+                    if repo.normalized_source_type() == "gitlab" {
+                        Self::clear_dir_contents(&temp_path)?;
+                        match self.clone_repo_with_git(repo, branch, &temp_path).await {
+                            Ok(_) => {
+                                return Ok((temp_dir, branch.to_string()));
+                            }
+                            Err(e) => {
+                                last_error = Some(e);
+                            }
+                        }
+                    }
                     continue;
                 }
             }
         }
 
         Err(last_error.unwrap_or_else(|| anyhow::anyhow!("所有分支下载失败")))
+    }
+
+    fn clear_dir_contents(dir: &Path) -> Result<()> {
+        fs::create_dir_all(dir)?;
+        for entry in fs::read_dir(dir)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                fs::remove_dir_all(&path)?;
+            } else {
+                fs::remove_file(&path)?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn clone_repo_with_git(&self, repo: &SkillRepo, branch: &str, dest: &Path) -> Result<()> {
+        let urls = Self::build_repo_git_urls(repo)?;
+        let mut last_error = None;
+
+        for url in urls {
+            let dest = dest.to_path_buf();
+            let dest_for_cleanup = dest.clone();
+            let branch = branch.to_string();
+            let url_for_error = url.clone();
+
+            let result = timeout(
+                std::time::Duration::from_secs(60),
+                tokio::task::spawn_blocking(move || {
+                    let output = std::process::Command::new("git")
+                        .args([
+                            "clone",
+                            "--depth",
+                            "1",
+                            "--branch",
+                            &branch,
+                            "--single-branch",
+                            &url,
+                        ])
+                        .arg(&dest)
+                        .output()
+                        .with_context(|| "Failed to run git clone")?;
+
+                    if output.status.success() {
+                        Ok(())
+                    } else {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        Err(anyhow!("git clone failed for {url}: {}", stderr.trim()))
+                    }
+                }),
+            )
+            .await;
+
+            match result {
+                Ok(Ok(Ok(()))) => return Ok(()),
+                Ok(Ok(Err(e))) => {
+                    last_error = Some(e);
+                }
+                Ok(Err(e)) => {
+                    last_error = Some(anyhow!("git clone task failed for {url_for_error}: {e}"));
+                }
+                Err(_) => {
+                    last_error = Some(anyhow!("git clone timed out for {url_for_error}"));
+                }
+            }
+
+            Self::clear_dir_contents(&dest_for_cleanup)?;
+        }
+
+        Err(last_error.unwrap_or_else(|| anyhow!("git clone failed")))
     }
 
     /// 下载并解压 ZIP
@@ -3087,6 +3447,8 @@ impl SkillService {
                 name,
                 description,
                 directory: install_name.clone(),
+                repo_source_type: None,
+                repo_source_host: None,
                 repo_owner: None,
                 repo_name: None,
                 repo_branch: None,
@@ -3354,6 +3716,8 @@ fn build_repo_info_from_lock(
     Option<String>,
     Option<String>,
     Option<String>,
+    Option<String>,
+    Option<String>,
 ) {
     match lock.get(dir_name) {
         Some(info) => {
@@ -3362,17 +3726,34 @@ fn build_repo_info_from_lock(
             // 优先使用 lock 文件中的 skillPath，否则回退到 dir_name/SKILL.md
             let fallback = format!("{dir_name}/SKILL.md");
             let doc_path = info.skill_path.as_deref().unwrap_or(&fallback);
-            let url =
-                SkillService::build_skill_doc_url(&info.owner, &info.repo, &url_branch, doc_path);
+            let repo = SkillRepo {
+                source_type: default_repo_source_type(),
+                source_host: default_repo_source_host(),
+                owner: info.owner.clone(),
+                name: info.repo.clone(),
+                branch: url_branch.clone(),
+                enabled: true,
+            };
+            let url = SkillService::build_skill_doc_url(&repo, &url_branch, doc_path);
             (
                 format!("{}/{}:{dir_name}", info.owner, info.repo),
+                Some(default_repo_source_type()),
+                Some(default_repo_source_host()),
                 Some(info.owner.clone()),
                 Some(info.repo.clone()),
                 branch,
                 url,
             )
         }
-        None => (format!("local:{dir_name}"), None, None, None, None),
+        None => (
+            format!("local:{dir_name}"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
     }
 }
 
@@ -3386,19 +3767,30 @@ fn save_repos_from_lock(
         .get_skill_repos()
         .unwrap_or_default()
         .into_iter()
-        .map(|r| (r.owner, r.name))
+        .map(|r| (r.repo_key(), r.branch))
         .collect();
     let mut added = HashSet::new();
 
     for dir_name in directories {
         if let Some(info) = lock.get(dir_name.as_ref()) {
-            let key = (info.owner.clone(), info.repo.clone());
+            let branch = info.branch.clone().unwrap_or_else(|| "HEAD".to_string());
+            let key = (
+                format!(
+                    "{}/{}/{}",
+                    default_repo_source_host(),
+                    info.owner,
+                    info.repo
+                ),
+                branch.clone(),
+            );
             if !existing_repos.contains(&key) && added.insert(key) {
                 let skill_repo = SkillRepo {
+                    source_type: default_repo_source_type(),
+                    source_host: default_repo_source_host(),
                     owner: info.owner.clone(),
                     name: info.repo.clone(),
                     // 未知分支时使用 HEAD 语义，后续下载会回退到 main/master。
-                    branch: info.branch.clone().unwrap_or_else(|| "HEAD".to_string()),
+                    branch,
                     enabled: true,
                 };
                 // lock 文件由外部 agents CLI 写入，owner/repo/branch 均未经校验，
@@ -3527,8 +3919,15 @@ pub fn migrate_skills_to_ssot(db: &Arc<Database>) -> Result<usize> {
 
         let (name, description) = SkillService::read_skill_name_desc(&skill_md, &directory);
 
-        let (id, repo_owner, repo_name, repo_branch, readme_url) =
-            build_repo_info_from_lock(&agents_lock, &directory);
+        let (
+            id,
+            repo_source_type,
+            repo_source_host,
+            repo_owner,
+            repo_name,
+            repo_branch,
+            readme_url,
+        ) = build_repo_info_from_lock(&agents_lock, &directory);
 
         let content_hash = SkillService::compute_dir_hash(&ssot_path).ok();
 
@@ -3537,6 +3936,8 @@ pub fn migrate_skills_to_ssot(db: &Arc<Database>) -> Result<usize> {
             name,
             description,
             directory,
+            repo_source_type,
+            repo_source_host,
             repo_owner,
             repo_name,
             repo_branch,

--- a/src-tauri/tests/profile_roundtrip.rs
+++ b/src-tauri/tests/profile_roundtrip.rs
@@ -72,6 +72,8 @@ fn installed_skill(id: &str, directory: &str, claude_enabled: bool) -> Installed
         name: id.to_string(),
         description: None,
         directory: directory.to_string(),
+        repo_source_type: None,
+        repo_source_host: None,
         repo_owner: None,
         repo_name: None,
         repo_branch: None,

--- a/src-tauri/tests/skill_sync.rs
+++ b/src-tauri/tests/skill_sync.rs
@@ -147,6 +147,8 @@ fn sync_to_app_removes_disabled_and_orphaned_ssot_symlinks() {
             repo_owner: None,
             repo_name: None,
             repo_branch: None,
+            repo_source_type: None,
+            repo_source_host: None,
             readme_url: None,
             apps: SkillApps::default(),
             installed_at: 0,
@@ -188,6 +190,8 @@ fn uninstall_skill_creates_backup_before_removing_ssot() {
             repo_owner: None,
             repo_name: None,
             repo_branch: None,
+            repo_source_type: None,
+            repo_source_host: None,
             readme_url: None,
             apps: SkillApps {
                 claude: true,
@@ -256,6 +260,8 @@ fn restore_skill_backup_restores_files_to_ssot_and_current_app() {
             repo_owner: None,
             repo_name: None,
             repo_branch: None,
+            repo_source_type: None,
+            repo_source_host: None,
             readme_url: None,
             apps: SkillApps {
                 claude: true,
@@ -337,6 +343,8 @@ fn delete_skill_backup_removes_backup_directory() {
             repo_owner: None,
             repo_name: None,
             repo_branch: None,
+            repo_source_type: None,
+            repo_source_host: None,
             readme_url: None,
             apps: SkillApps {
                 claude: true,

--- a/src/components/skills/RepoManager.tsx
+++ b/src/components/skills/RepoManager.tsx
@@ -13,6 +13,12 @@ import { Label } from "@/components/ui/label";
 import { Trash2, ExternalLink, Plus } from "lucide-react";
 import { settingsApi } from "@/lib/api";
 import type { DiscoverableSkill, SkillRepo } from "@/lib/api/skills";
+import {
+  parseRepoUrl,
+  repoDisplayName,
+  repoExternalUrl,
+  skillMatchesRepo,
+} from "./repoUtils";
 
 interface RepoManagerProps {
   open: boolean;
@@ -20,7 +26,7 @@ interface RepoManagerProps {
   repos: SkillRepo[];
   skills: DiscoverableSkill[];
   onAdd: (repo: SkillRepo) => Promise<void>;
-  onRemove: (owner: string, name: string) => Promise<void>;
+  onRemove: (repo: SkillRepo) => Promise<void>;
 }
 
 export function RepoManager({
@@ -37,32 +43,7 @@ export function RepoManager({
   const [error, setError] = useState("");
 
   const getSkillCount = (repo: SkillRepo) =>
-    skills.filter(
-      (skill) =>
-        skill.repoOwner === repo.owner &&
-        skill.repoName === repo.name &&
-        (skill.repoBranch || "main") === (repo.branch || "main"),
-    ).length;
-
-  const parseRepoUrl = (
-    url: string,
-  ): { owner: string; name: string } | null => {
-    // 支持格式:
-    // - https://github.com/owner/name
-    // - owner/name
-    // - https://github.com/owner/name.git
-
-    let cleaned = url.trim();
-    cleaned = cleaned.replace(/^https?:\/\/github\.com\//, "");
-    cleaned = cleaned.replace(/\.git$/, "");
-
-    const parts = cleaned.split("/");
-    if (parts.length === 2 && parts[0] && parts[1]) {
-      return { owner: parts[0], name: parts[1] };
-    }
-
-    return null;
-  };
+    skills.filter((skill) => skillMatchesRepo(skill, repo)).length;
 
   const handleAdd = async () => {
     setError("");
@@ -75,8 +56,7 @@ export function RepoManager({
 
     try {
       await onAdd({
-        owner: parsed.owner,
-        name: parsed.name,
+        ...parsed,
         branch: branch || "main",
         enabled: true,
       });
@@ -88,9 +68,9 @@ export function RepoManager({
     }
   };
 
-  const handleOpenRepo = async (owner: string, name: string) => {
+  const handleOpenRepo = async (repo: SkillRepo) => {
     try {
-      await settingsApi.openExternal(`https://github.com/${owner}/${name}`);
+      await settingsApi.openExternal(repoExternalUrl(repo));
     } catch (error) {
       console.error("Failed to open URL:", error);
     }
@@ -152,12 +132,12 @@ export function RepoManager({
                 <div className="space-y-3">
                   {repos.map((repo) => (
                     <div
-                      key={`${repo.owner}/${repo.name}`}
+                      key={repoDisplayName(repo)}
                       className="flex items-center justify-between rounded-xl border border-border-default bg-card px-4 py-3"
                     >
                       <div>
                         <div className="text-sm font-medium text-foreground">
-                          {repo.owner}/{repo.name}
+                          {repoDisplayName(repo)}
                         </div>
                         <div className="mt-1 text-xs text-muted-foreground">
                           {t("skills.repo.branch")}: {repo.branch || "main"}
@@ -173,7 +153,7 @@ export function RepoManager({
                           variant="ghost"
                           size="icon"
                           type="button"
-                          onClick={() => handleOpenRepo(repo.owner, repo.name)}
+                          onClick={() => handleOpenRepo(repo)}
                           title={t("common.view", { defaultValue: "查看" })}
                         >
                           <ExternalLink className="h-4 w-4" />
@@ -182,7 +162,7 @@ export function RepoManager({
                           variant="ghost"
                           size="icon"
                           type="button"
-                          onClick={() => onRemove(repo.owner, repo.name)}
+                          onClick={() => onRemove(repo)}
                           title={t("common.delete")}
                           className="hover:text-red-500 hover:bg-red-100 dark:hover:text-red-400 dark:hover:bg-red-500/10"
                         >

--- a/src/components/skills/RepoManagerPanel.tsx
+++ b/src/components/skills/RepoManagerPanel.tsx
@@ -7,12 +7,18 @@ import { Trash2, ExternalLink, Plus } from "lucide-react";
 import { settingsApi } from "@/lib/api";
 import { FullScreenPanel } from "@/components/common/FullScreenPanel";
 import type { DiscoverableSkill, SkillRepo } from "@/lib/api/skills";
+import {
+  parseRepoUrl,
+  repoDisplayName,
+  repoExternalUrl,
+  skillMatchesRepo,
+} from "./repoUtils";
 
 interface RepoManagerPanelProps {
   repos: SkillRepo[];
   skills: DiscoverableSkill[];
   onAdd: (repo: SkillRepo) => Promise<void>;
-  onRemove: (owner: string, name: string) => Promise<void>;
+  onRemove: (repo: SkillRepo) => Promise<void>;
   onClose: () => void;
 }
 
@@ -29,27 +35,7 @@ export function RepoManagerPanel({
   const [error, setError] = useState("");
 
   const getSkillCount = (repo: SkillRepo) =>
-    skills.filter(
-      (skill) =>
-        skill.repoOwner === repo.owner &&
-        skill.repoName === repo.name &&
-        (skill.repoBranch || "main") === (repo.branch || "main"),
-    ).length;
-
-  const parseRepoUrl = (
-    url: string,
-  ): { owner: string; name: string } | null => {
-    let cleaned = url.trim();
-    cleaned = cleaned.replace(/^https?:\/\/github\.com\//, "");
-    cleaned = cleaned.replace(/\.git$/, "");
-
-    const parts = cleaned.split("/");
-    if (parts.length === 2 && parts[0] && parts[1]) {
-      return { owner: parts[0], name: parts[1] };
-    }
-
-    return null;
-  };
+    skills.filter((skill) => skillMatchesRepo(skill, repo)).length;
 
   const handleAdd = async () => {
     setError("");
@@ -62,8 +48,7 @@ export function RepoManagerPanel({
 
     try {
       await onAdd({
-        owner: parsed.owner,
-        name: parsed.name,
+        ...parsed,
         branch: branch || "main",
         enabled: true,
       });
@@ -75,9 +60,9 @@ export function RepoManagerPanel({
     }
   };
 
-  const handleOpenRepo = async (owner: string, name: string) => {
+  const handleOpenRepo = async (repo: SkillRepo) => {
     try {
-      await settingsApi.openExternal(`https://github.com/${owner}/${name}`);
+      await settingsApi.openExternal(repoExternalUrl(repo));
     } catch (error) {
       console.error("Failed to open URL:", error);
     }
@@ -148,12 +133,12 @@ export function RepoManagerPanel({
           <div className="space-y-3">
             {repos.map((repo) => (
               <div
-                key={`${repo.owner}/${repo.name}`}
+                key={repoDisplayName(repo)}
                 className="flex items-center justify-between glass-card rounded-xl px-4 py-3"
               >
                 <div>
                   <div className="text-sm font-medium text-foreground">
-                    {repo.owner}/{repo.name}
+                    {repoDisplayName(repo)}
                   </div>
                   <div className="mt-1 text-xs text-muted-foreground">
                     {t("skills.repo.branch")}: {repo.branch || "main"}
@@ -169,7 +154,7 @@ export function RepoManagerPanel({
                     variant="ghost"
                     size="icon"
                     type="button"
-                    onClick={() => handleOpenRepo(repo.owner, repo.name)}
+                    onClick={() => handleOpenRepo(repo)}
                     title={t("common.view", { defaultValue: "查看" })}
                     className="hover:bg-black/5 dark:hover:bg-white/5"
                   >
@@ -179,7 +164,7 @@ export function RepoManagerPanel({
                     variant="ghost"
                     size="icon"
                     type="button"
-                    onClick={() => onRemove(repo.owner, repo.name)}
+                    onClick={() => onRemove(repo)}
                     title={t("common.delete")}
                     className="hover:text-red-500 hover:bg-red-100 dark:hover:text-red-400 dark:hover:bg-red-500/10"
                   >

--- a/src/components/skills/SkillCard.tsx
+++ b/src/components/skills/SkillCard.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { ExternalLink, Download, Trash2, Loader2 } from "lucide-react";
 import { settingsApi } from "@/lib/api";
 import type { DiscoverableSkill } from "@/lib/api/skills";
+import { repoDisplayName } from "./repoUtils";
 
 type SkillCardSkill = DiscoverableSkill & { installed: boolean };
 
@@ -84,7 +85,14 @@ export function SkillCard({
                   variant="outline"
                   className="shrink-0 text-[10px] px-1.5 py-0 h-4 border-border-default"
                 >
-                  {skill.repoOwner}/{skill.repoName}
+                  {repoDisplayName({
+                    sourceType: skill.repoSourceType,
+                    sourceHost: skill.repoSourceHost,
+                    owner: skill.repoOwner,
+                    name: skill.repoName,
+                    branch: skill.repoBranch,
+                    enabled: true,
+                  })}
                 </Badge>
               )}
               {typeof installs === "number" && (

--- a/src/components/skills/SkillsPage.tsx
+++ b/src/components/skills/SkillsPage.tsx
@@ -41,6 +41,12 @@ import type {
   SkillsShDiscoverableSkill,
 } from "@/lib/api/skills";
 import { formatSkillError } from "@/lib/errors/skillErrorParser";
+import {
+  normalizeRepoSourceHost,
+  normalizeRepoSourceType,
+  repoDisplayName,
+  skillMatchesRepo,
+} from "./repoUtils";
 
 export type SkillsPageSource = "repos" | "skillssh";
 
@@ -83,6 +89,23 @@ export const getSkillsPageHeaderActions = (source: SkillsPageSource) =>
   SKILLS_PAGE_HEADER_ACTIONS.filter((action) =>
     action.sources.includes(source),
   );
+
+function skillInstallKey(skill: {
+  directory: string;
+  repoSourceType?: string;
+  repoSourceHost?: string;
+  repoOwner?: string;
+  repoName?: string;
+}): string {
+  const installName =
+    skill.directory.split(/[/\\]/).pop()?.toLowerCase() ||
+    skill.directory.toLowerCase();
+  const sourceType = normalizeRepoSourceType(skill.repoSourceType);
+  const sourceHost = normalizeRepoSourceHost(skill.repoSourceHost, sourceType);
+  const owner = skill.repoOwner?.toLowerCase() || "";
+  const name = skill.repoName?.toLowerCase() || "";
+  return `${installName}:${sourceType}:${sourceHost}:${owner}:${name}`;
+}
 
 const SKILLSSH_PAGE_SIZE = 20;
 
@@ -156,17 +179,10 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
     const addRepoMutation = useAddSkillRepo();
     const removeRepoMutation = useRemoveSkillRepo();
 
-    // 已安装的 skill key 集合（使用 directory + repoOwner + repoName 组合判断）
+    // 已安装的 skill key 集合（使用 directory + source + repo 组合判断）
     const installedKeys = useMemo(() => {
       if (!installedSkills) return new Set<string>();
-      return new Set(
-        installedSkills.map((s) => {
-          // 构建唯一 key：directory + repoOwner + repoName
-          const owner = s.repoOwner?.toLowerCase() || "";
-          const name = s.repoName?.toLowerCase() || "";
-          return `${s.directory.toLowerCase()}:${owner}:${name}`;
-        }),
-      );
+      return new Set(installedSkills.map(skillInstallKey));
     }, [installedSkills]);
 
     type DiscoverableSkillItem = DiscoverableSkill & { installed: boolean };
@@ -177,7 +193,16 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
       const repoSet = new Set<string>();
       discoverableSkills.forEach((s) => {
         if (s.repoOwner && s.repoName) {
-          repoSet.add(`${s.repoOwner}/${s.repoName}`);
+          repoSet.add(
+            repoDisplayName({
+              sourceType: s.repoSourceType,
+              sourceHost: s.repoSourceHost,
+              owner: s.repoOwner,
+              name: s.repoName,
+              branch: s.repoBranch,
+              enabled: true,
+            }),
+          );
         }
       });
       return Array.from(repoSet).sort();
@@ -187,23 +212,16 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
     const skills: DiscoverableSkillItem[] = useMemo(() => {
       if (!discoverableSkills) return [];
       return discoverableSkills.map((d) => {
-        // 同时处理 / 和 \ 路径分隔符（兼容 Windows 和 Unix）
-        const installName =
-          d.directory.split(/[/\\]/).pop()?.toLowerCase() ||
-          d.directory.toLowerCase();
-        // 使用 directory + repoOwner + repoName 组合判断是否已安装
-        const key = `${installName}:${d.repoOwner.toLowerCase()}:${d.repoName.toLowerCase()}`;
         return {
           ...d,
-          installed: installedKeys.has(key),
+          installed: installedKeys.has(skillInstallKey(d)),
         };
       });
     }, [discoverableSkills, installedKeys]);
 
     // 检查 skills.sh 结果的安装状态
     const isSkillsShInstalled = (skill: SkillsShDiscoverableSkill): boolean => {
-      const key = `${skill.directory.toLowerCase()}:${skill.repoOwner.toLowerCase()}:${skill.repoName.toLowerCase()}`;
-      return installedKeys.has(key);
+      return installedKeys.has(skillInstallKey(skill));
     };
 
     const loading =
@@ -227,6 +245,8 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
       name: s.name,
       description: "",
       directory: s.directory,
+      repoSourceType: "github",
+      repoSourceHost: "github.com",
       repoOwner: s.repoOwner,
       repoName: s.repoName,
       repoBranch: s.repoBranch,
@@ -285,12 +305,8 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
         // Await discovery so we can report the real count
         const { data: freshSkills } = await refetchDiscoverable();
         const count =
-          freshSkills?.filter(
-            (s) =>
-              s.repoOwner === repo.owner &&
-              s.repoName === repo.name &&
-              (s.repoBranch || "main") === (repo.branch || "main"),
-          ).length ?? 0;
+          freshSkills?.filter((skill) => skillMatchesRepo(skill, repo))
+            .length ?? 0;
         toast.success(
           t("skills.repo.addSuccess", {
             owner: repo.owner,
@@ -306,12 +322,16 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
       }
     };
 
-    const handleRemoveRepo = async (owner: string, name: string) => {
+    const handleRemoveRepo = async (repo: SkillRepo) => {
       try {
-        await removeRepoMutation.mutateAsync({ owner, name });
-        toast.success(t("skills.repo.removeSuccess", { owner, name }), {
-          closeButton: true,
-        });
+        await removeRepoMutation.mutateAsync(repo);
+        toast.success(
+          t("skills.repo.removeSuccess", {
+            owner: repo.owner,
+            name: repo.name,
+          }),
+          { closeButton: true },
+        );
       } catch (error) {
         toast.error(t("common.error"), {
           description: String(error),
@@ -324,7 +344,14 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
       // 按仓库筛选
       const byRepo = skills.filter((skill) => {
         if (filterRepo === "all") return true;
-        const skillRepo = `${skill.repoOwner}/${skill.repoName}`;
+        const skillRepo = repoDisplayName({
+          sourceType: skill.repoSourceType,
+          sourceHost: skill.repoSourceHost,
+          owner: skill.repoOwner,
+          name: skill.repoName,
+          branch: skill.repoBranch,
+          enabled: true,
+        });
         return skillRepo === filterRepo;
       });
 
@@ -343,7 +370,14 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
         const name = skill.name?.toLowerCase() || "";
         const repo =
           skill.repoOwner && skill.repoName
-            ? `${skill.repoOwner}/${skill.repoName}`.toLowerCase()
+            ? repoDisplayName({
+                sourceType: skill.repoSourceType,
+                sourceHost: skill.repoSourceHost,
+                owner: skill.repoOwner,
+                name: skill.repoName,
+                branch: skill.repoBranch,
+                enabled: true,
+              }).toLowerCase()
             : "";
 
         return name.includes(query) || repo.includes(query);

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -43,6 +43,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  normalizeRepoSourceHost,
+  normalizeRepoSourceType,
+  repoDisplayName,
+} from "./repoUtils";
 
 interface UnifiedSkillsPanelProps {
   onOpenDiscovery: () => void;
@@ -152,7 +157,14 @@ const UnifiedSkillsPanel = React.forwardRef<
           const installName =
             skill.directory.split(/[/\\]/).pop()?.toLowerCase() ||
             skill.directory.toLowerCase();
-          const skillKey = `${installName}:${skill.repoOwner?.toLowerCase() || ""}:${skill.repoName?.toLowerCase() || ""}`;
+          const sourceType = normalizeRepoSourceType(skill.repoSourceType);
+          const sourceHost = normalizeRepoSourceHost(
+            skill.repoSourceHost,
+            sourceType,
+          );
+          const owner = skill.repoOwner?.toLowerCase() || "";
+          const name = skill.repoName?.toLowerCase() || "";
+          const skillKey = `${installName}:${sourceType}:${sourceHost}:${owner}:${name}`;
 
           const result = await uninstallMutation.mutateAsync({
             id: skill.id,
@@ -511,10 +523,24 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
 
   const sourceLabel = useMemo(() => {
     if (skill.repoOwner && skill.repoName) {
-      return `${skill.repoOwner}/${skill.repoName}`;
+      return repoDisplayName({
+        sourceType: skill.repoSourceType || "github",
+        sourceHost: skill.repoSourceHost || "github.com",
+        owner: skill.repoOwner,
+        name: skill.repoName,
+        branch: skill.repoBranch || "main",
+        enabled: true,
+      });
     }
     return t("skills.local");
-  }, [skill.repoOwner, skill.repoName, t]);
+  }, [
+    skill.repoSourceType,
+    skill.repoSourceHost,
+    skill.repoOwner,
+    skill.repoName,
+    skill.repoBranch,
+    t,
+  ]);
 
   return (
     <ListItemRow isLast={isLast}>

--- a/src/components/skills/repoUtils.ts
+++ b/src/components/skills/repoUtils.ts
@@ -1,0 +1,116 @@
+import type { DiscoverableSkill, SkillRepo } from "@/lib/api/skills";
+
+export function normalizeRepoSourceType(sourceType?: string): string {
+  return (sourceType || "github").trim().toLowerCase() || "github";
+}
+
+export function normalizeRepoSourceHost(
+  sourceHost?: string,
+  sourceType?: string,
+): string {
+  const cleaned = (sourceHost || "")
+    .trim()
+    .replace(/^https?:\/\//, "")
+    .replace(/\/$/, "")
+    .toLowerCase();
+
+  if (cleaned) return cleaned;
+  return normalizeRepoSourceType(sourceType) === "gitlab"
+    ? "gitlab.com"
+    : "github.com";
+}
+
+export function repoDisplayName(repo: SkillRepo): string {
+  const sourceHost = normalizeRepoSourceHost(repo.sourceHost, repo.sourceType);
+  if (
+    normalizeRepoSourceType(repo.sourceType) === "github" &&
+    sourceHost === "github.com"
+  ) {
+    return `${repo.owner}/${repo.name}`;
+  }
+  return `${sourceHost}/${repo.owner}/${repo.name}`;
+}
+
+export function repoExternalUrl(repo: SkillRepo): string {
+  const sourceHost = normalizeRepoSourceHost(repo.sourceHost, repo.sourceType);
+  return `https://${sourceHost}/${repo.owner}/${repo.name}`;
+}
+
+export function skillMatchesRepo(
+  skill: DiscoverableSkill,
+  repo: SkillRepo,
+): boolean {
+  return (
+    normalizeRepoSourceType(skill.repoSourceType) ===
+      normalizeRepoSourceType(repo.sourceType) &&
+    normalizeRepoSourceHost(skill.repoSourceHost, skill.repoSourceType) ===
+      normalizeRepoSourceHost(repo.sourceHost, repo.sourceType) &&
+    skill.repoOwner === repo.owner &&
+    skill.repoName === repo.name &&
+    (skill.repoBranch || "main") === (repo.branch || "main")
+  );
+}
+
+export function parseRepoUrl(input: string): SkillRepo | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const sshMatch = trimmed.match(/^(?:ssh:\/\/)?git@([^:/]+)[:/](.+)$/);
+  if (sshMatch) {
+    return parsePathRepo(sshMatch[2], sshMatch[1]);
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      return parsePathRepo(url.pathname, url.hostname);
+    } catch {
+      return null;
+    }
+  }
+
+  const cleaned = trimmed.replace(/\.git$/, "").replace(/^\/+|\/+$/g, "");
+  const parts = cleaned.split("/").filter(Boolean);
+  if (parts.length === 2) {
+    return {
+      sourceType: "github",
+      sourceHost: "github.com",
+      owner: parts[0],
+      name: parts[1],
+      branch: "main",
+      enabled: true,
+    };
+  }
+
+  return null;
+}
+
+function parsePathRepo(path: string, host: string): SkillRepo | null {
+  const sourceHost = normalizeRepoSourceHost(host);
+  const sourceType = sourceHost === "github.com" ? "github" : "gitlab";
+  const markerIndex = path.indexOf("/-/");
+  const repoPath = (markerIndex >= 0 ? path.slice(0, markerIndex) : path)
+    .replace(/\.git$/, "")
+    .replace(/^\/+|\/+$/g, "");
+  const parts = repoPath.split("/").filter(Boolean);
+
+  if (sourceType === "github" && parts.length !== 2) {
+    return null;
+  }
+  if (sourceType === "gitlab" && parts.length < 2) {
+    return null;
+  }
+
+  const name = parts[parts.length - 1];
+  const owner = parts.slice(0, -1).join("/");
+  if (!owner || !name) return null;
+
+  return {
+    sourceType,
+    sourceHost,
+    owner,
+    name,
+    branch: "main",
+    enabled: true,
+  };
+}

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -254,8 +254,7 @@ export function useAddSkillRepo() {
 export function useRemoveSkillRepo() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ owner, name }: { owner: string; name: string }) =>
-      skillsApi.removeRepo(owner, name),
+    mutationFn: skillsApi.removeRepo,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["skills", "repos"] });
       queryClient.invalidateQueries({ queryKey: ["skills", "discoverable"] });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2346,9 +2346,9 @@
     },
     "repo": {
       "title": "Manage Skill Repositories",
-      "description": "Add or remove GitHub skill repository sources",
+      "description": "Add or remove GitHub / GitLab skill repository sources",
       "url": "Repository URL",
-      "urlPlaceholder": "owner/name or https://github.com/owner/name",
+      "urlPlaceholder": "owner/name, https://github.com/owner/name, or https://gitlab.com/group/project",
       "branch": "Branch",
       "branchPlaceholder": "main",
       "path": "Skills Path",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2346,9 +2346,9 @@
     },
     "repo": {
       "title": "スキルリポジトリを管理",
-      "description": "GitHub のスキルリポジトリソースを追加または削除します",
+      "description": "GitHub / GitLab のスキルリポジトリソースを追加または削除します",
       "url": "リポジトリ URL",
-      "urlPlaceholder": "owner/name または https://github.com/owner/name",
+      "urlPlaceholder": "owner/name、https://github.com/owner/name、または https://gitlab.com/group/project",
       "branch": "ブランチ",
       "branchPlaceholder": "main",
       "path": "スキルパス",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2317,9 +2317,9 @@
     },
     "repo": {
       "title": "管理技能儲存庫",
-      "description": "新增或刪除 GitHub 技能儲存庫來源",
+      "description": "新增或刪除 GitHub / GitLab 技能儲存庫來源",
       "url": "儲存庫 URL",
-      "urlPlaceholder": "owner/name 或 https://github.com/owner/name",
+      "urlPlaceholder": "owner/name、https://github.com/owner/name 或 https://gitlab.com/group/project",
       "branch": "分支",
       "branchPlaceholder": "main",
       "path": "技能路徑",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2346,9 +2346,9 @@
     },
     "repo": {
       "title": "管理技能仓库",
-      "description": "添加或删除 GitHub 技能仓库源",
+      "description": "添加或删除 GitHub / GitLab 技能仓库源",
       "url": "仓库 URL",
-      "urlPlaceholder": "owner/name 或 https://github.com/owner/name",
+      "urlPlaceholder": "owner/name、https://github.com/owner/name 或 https://gitlab.com/group/project",
       "branch": "分支",
       "branchPlaceholder": "main",
       "path": "技能路径",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -30,6 +30,8 @@ export interface InstalledSkill {
   name: string;
   description?: string;
   directory: string;
+  repoSourceType?: string;
+  repoSourceHost?: string;
   repoOwner?: string;
   repoName?: string;
   repoBranch?: string;
@@ -58,6 +60,8 @@ export interface DiscoverableSkill {
   description: string;
   directory: string;
   readmeUrl?: string;
+  repoSourceType: string;
+  repoSourceHost: string;
   repoOwner: string;
   repoName: string;
   repoBranch: string;
@@ -127,6 +131,8 @@ export interface SkillsShSearchResult {
 
 /** 仓库配置 */
 export interface SkillRepo {
+  sourceType: string;
+  sourceHost: string;
   owner: string;
   name: string;
   branch: string;
@@ -264,8 +270,13 @@ export const skillsApi = {
   },
 
   /** 删除仓库 */
-  async removeRepo(owner: string, name: string): Promise<boolean> {
-    return await invoke("remove_skill_repo", { owner, name });
+  async removeRepo(repo: SkillRepo): Promise<boolean> {
+    return await invoke("remove_skill_repo", {
+      sourceType: repo.sourceType || "github",
+      sourceHost: repo.sourceHost || "github.com",
+      owner: repo.owner,
+      name: repo.name,
+    });
   },
 
   // ========== ZIP 安装 ==========

--- a/tests/components/SkillsPageInstall.test.tsx
+++ b/tests/components/SkillsPageInstall.test.tsx
@@ -112,6 +112,8 @@ const makeDiscoverableSkill = (
   description: "Skill from a configured repository",
   directory: "repo-skill",
   readmeUrl: "https://example.com/repo-skill",
+  repoSourceType: "github",
+  repoSourceHost: "github.com",
   repoOwner: "owner-a",
   repoName: "repo-a",
   repoBranch: "main",
@@ -119,6 +121,8 @@ const makeDiscoverableSkill = (
 });
 
 const makeSkillRepo = (overrides: Partial<SkillRepo> = {}): SkillRepo => ({
+  sourceType: "github",
+  sourceHost: "github.com",
   owner: "owner-a",
   name: "repo-a",
   branch: "main",


### PR DESCRIPTION
## Summary
- add GitLab/custom-host metadata for skill repositories alongside existing GitHub defaults
- support parsing GitLab URLs and nested repository paths in the skill repository UI
- persist source type/host in the skill database and sync/install flows
- update skill matching, deeplink import, localization, and tests for non-GitHub sources

## Verification
- pnpm typecheck
- cargo test
- pnpm tauri build (generated app/dmg successfully; updater signing failed locally because TAURI_SIGNING_PRIVATE_KEY is not configured)