### PR TITLE
feat(skills): add global skill env management

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use tauri::{AppHandle, Emitter};
+use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_updater::UpdaterExt;
 
 /// 应用更新下载进度（通过 `update-download-progress` 事件发给前端）。
@@ -124,6 +125,59 @@ pub async fn save_settings(
         }
     }
     Ok(true)
+}
+
+#[tauri::command]
+pub async fn get_default_skill_env_output_path() -> Result<String, String> {
+    Ok(crate::skill_env::default_output_path()
+        .display()
+        .to_string())
+}
+
+#[tauri::command]
+pub async fn pick_skill_env_output_file<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    #[allow(non_snake_case)] currentPath: Option<String>,
+) -> Result<Option<String>, String> {
+    let fallback = crate::skill_env::default_output_path();
+    let current = currentPath
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(crate::skill_env::resolve_path)
+        .unwrap_or(fallback);
+    let default_name = current
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(if cfg!(target_os = "windows") {
+            "env.ps1"
+        } else {
+            "env.sh"
+        });
+
+    let mut dialog = app.dialog().file().set_file_name(default_name);
+    if let Some(parent) = current.parent() {
+        dialog = dialog.set_directory(parent);
+    }
+    let result = dialog.blocking_save_file();
+    Ok(result.map(|p| p.to_string()))
+}
+
+#[tauri::command]
+pub async fn get_skill_env_state() -> Result<crate::skill_env::SkillEnvState, String> {
+    crate::skill_env::read_state().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn save_skill_env(
+    #[allow(non_snake_case)] content: String,
+) -> Result<crate::skill_env::SkillEnvSaveResult, String> {
+    crate::skill_env::save_and_refresh(&content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn refresh_skill_env() -> Result<crate::skill_env::SkillEnvSaveResult, String> {
+    crate::skill_env::refresh_from_source().map_err(|e| e.to_string())
 }
 
 #[derive(serde::Serialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -479,6 +479,14 @@ pub fn run() {
                 }
             }
 
+            match crate::skill_env::apply_saved_to_current_process() {
+                Ok(count) if count > 0 => {
+                    log::info!("✓ Applied {count} saved Skill env variable(s) to current process");
+                }
+                Ok(_) => {}
+                Err(e) => log::warn!("✗ Failed to apply saved Skill env variables: {e}"),
+            }
+
             // 注入 AppHandle 给 usage_events，让无 AppHandle 持有的写日志路径
             // 也能向前端推送 `usage-log-recorded`。
             // 放在日志系统初始化之后，确保 init 的日志能正常输出。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ mod proxy;
 mod services;
 mod session_manager;
 mod settings;
+mod skill_env;
 mod store;
 
 mod tray;
@@ -1350,6 +1351,11 @@ pub fn run() {
             commands::read_live_provider_settings,
             commands::get_settings,
             commands::save_settings,
+            commands::get_skill_env_state,
+            commands::save_skill_env,
+            commands::refresh_skill_env,
+            commands::get_default_skill_env_output_path,
+            commands::pick_skill_env_output_file,
             commands::has_codex_unify_history_backup,
             commands::restore_codex_unified_history,
             commands::get_rectifier_config,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -456,6 +456,9 @@ pub struct AppSettings {
     /// Skill 存储位置：cc_switch（默认）或 unified（~/.agents/skills/）
     #[serde(default)]
     pub skill_storage_location: SkillStorageLocation,
+    /// Skill 环境变量生成文件路径（源文件固定为 ~/.cc-switch/skill-env.env）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill_env_output_path: Option<String>,
 
     // ===== WebDAV 同步设置 =====
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -543,6 +546,7 @@ impl Default for AppSettings {
             current_provider_hermes: None,
             skill_sync_method: SyncMethod::default(),
             skill_storage_location: SkillStorageLocation::default(),
+            skill_env_output_path: None,
             webdav_sync: None,
             s3_sync: None,
             webdav_backup: None,
@@ -619,6 +623,13 @@ impl AppSettings {
             .as_ref()
             .map(|s| s.trim())
             .filter(|s| matches!(*s, "en" | "zh" | "zh-TW" | "ja"))
+            .map(|s| s.to_string());
+
+        self.skill_env_output_path = self
+            .skill_env_output_path
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
 
         if let Some(sync) = &mut self.webdav_sync {

--- a/src-tauri/src/skill_env.rs
+++ b/src-tauri/src/skill_env.rs
@@ -119,6 +119,13 @@ pub fn refresh_from_source() -> Result<SkillEnvSaveResult, AppError> {
     save_and_refresh(&state.content)
 }
 
+pub fn apply_saved_to_current_process() -> Result<usize, AppError> {
+    let state = read_state()?;
+    let env = parse_dotenv(&state.content)?;
+    apply_to_current_process(&env, std::iter::empty::<&String>());
+    Ok(env.len())
+}
+
 fn normalize_source_content(content: &str) -> Result<String, AppError> {
     parse_dotenv(content)?;
     let trimmed = content.trim_end();
@@ -176,7 +183,7 @@ fn parse_generated_env(content: &str) -> BTreeMap<String, String> {
             if let Some((key, value)) = rest.trim().split_once('=') {
                 let key = key.trim();
                 if is_valid_key(key) {
-                    env.insert(key.to_string(), unquote_value(value.trim()));
+                    env.insert(key.to_string(), unquote_powershell_value(value.trim()));
                 }
             }
         }
@@ -300,7 +307,7 @@ fn quote_shell(value: &str) -> String {
 
 #[cfg(target_os = "windows")]
 fn quote_powershell(value: &str) -> String {
-    format!("\"{}\"", value.replace('`', "``").replace('"', "`\""))
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 fn escape_double_quoted(value: &str) -> String {
@@ -311,6 +318,41 @@ fn escape_double_quoted(value: &str) -> String {
         .replace('`', "\\`")
 }
 
+fn unquote_powershell_value(value: &str) -> String {
+    if value.len() >= 2 {
+        let bytes = value.as_bytes();
+        if bytes[0] == b'\'' && bytes[value.len() - 1] == b'\'' {
+            return value[1..value.len() - 1].replace("''", "'");
+        }
+        if bytes[0] == b'"' && bytes[value.len() - 1] == b'"' {
+            return unescape_powershell_double_quoted(&value[1..value.len() - 1]);
+        }
+    }
+    value.to_string()
+}
+
+fn unescape_powershell_double_quoted(value: &str) -> String {
+    let mut output = String::new();
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '`' {
+            if let Some(next) = chars.next() {
+                output.push(match next {
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    other => other,
+                });
+            } else {
+                output.push(ch);
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
 fn write_secure(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
@@ -319,13 +361,15 @@ fn write_secure(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
     #[cfg(unix)]
     {
         use std::fs::OpenOptions;
-        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
         let mut file = OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(true)
             .mode(0o600)
             .open(path)
+            .map_err(|e| AppError::io(path, e))?;
+        file.set_permissions(fs::Permissions::from_mode(0o600))
             .map_err(|e| AppError::io(path, e))?;
         file.write_all(bytes).map_err(|e| AppError::io(path, e))?;
         Ok(())
@@ -350,7 +394,7 @@ mod tests {
         assert_eq!(env.get("ENABLED").unwrap(), "true");
         let generated = render_generated_env(&env, Path::new("/tmp/source.env"));
         #[cfg(target_os = "windows")]
-        assert!(generated.contains("$env:TOKEN = \"a b$c\""));
+        assert!(generated.contains("$env:TOKEN = 'a b$c'"));
         #[cfg(not(target_os = "windows"))]
         assert!(generated.contains("export TOKEN=\"a b\\$c\""));
     }
@@ -360,5 +404,78 @@ mod tests {
         let env = parse_generated_env("export OT_BASE_DIR=\"/tmp/ot\"\n# comment\nBAD-LINE=x\n");
         assert_eq!(env.get("OT_BASE_DIR").unwrap(), "/tmp/ot");
         assert!(!env.contains_key("BAD-LINE"));
+    }
+
+    #[test]
+    fn parses_existing_powershell_exports_without_expanding_literals() {
+        let env = parse_generated_env(
+            "$env:TOKEN = 'abc$def'\n$env:QUOTE = 'it''s'\n$env:PATH = \"a`$b\"\n",
+        );
+        assert_eq!(env.get("TOKEN").unwrap(), "abc$def");
+        assert_eq!(env.get("QUOTE").unwrap(), "it's");
+        assert_eq!(env.get("PATH").unwrap(), "a$b");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn write_secure_tightens_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skill-env.env");
+        fs::write(&path, b"old").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_secure(&path, b"SECRET=value\n").unwrap();
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "SECRET=value\n");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn applies_saved_source_env_on_startup_without_clearing_inherited_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_dir = dir.path().join(".cc-switch");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::write(
+            source_dir.join(SOURCE_FILE_NAME),
+            "CC_SWITCH_SKILL_ENV_STARTUP_TEST=loaded\n",
+        )
+        .unwrap();
+
+        let previous_home = std::env::var("CC_SWITCH_TEST_HOME").ok();
+        let previous_loaded = std::env::var("CC_SWITCH_SKILL_ENV_STARTUP_TEST").ok();
+        let previous_inherited = std::env::var("CC_SWITCH_SKILL_ENV_INHERITED_TEST").ok();
+
+        std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+        std::env::remove_var("CC_SWITCH_SKILL_ENV_STARTUP_TEST");
+        std::env::set_var("CC_SWITCH_SKILL_ENV_INHERITED_TEST", "keep");
+
+        let applied = apply_saved_to_current_process().unwrap();
+
+        assert_eq!(applied, 1);
+        assert_eq!(
+            std::env::var("CC_SWITCH_SKILL_ENV_STARTUP_TEST").unwrap(),
+            "loaded"
+        );
+        assert_eq!(
+            std::env::var("CC_SWITCH_SKILL_ENV_INHERITED_TEST").unwrap(),
+            "keep"
+        );
+
+        match previous_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+        match previous_loaded {
+            Some(value) => std::env::set_var("CC_SWITCH_SKILL_ENV_STARTUP_TEST", value),
+            None => std::env::remove_var("CC_SWITCH_SKILL_ENV_STARTUP_TEST"),
+        }
+        match previous_inherited {
+            Some(value) => std::env::set_var("CC_SWITCH_SKILL_ENV_INHERITED_TEST", value),
+            None => std::env::remove_var("CC_SWITCH_SKILL_ENV_INHERITED_TEST"),
+        }
     }
 }

--- a/src-tauri/src/skill_env.rs
+++ b/src-tauri/src/skill_env.rs
@@ -1,0 +1,364 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::error::AppError;
+
+const SOURCE_FILE_NAME: &str = "skill-env.env";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillEnvState {
+    pub source_path: String,
+    pub output_path: String,
+    pub content: String,
+    pub parsed_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillEnvSaveResult {
+    pub source_path: String,
+    pub output_path: String,
+    pub parsed_count: usize,
+}
+
+pub fn default_output_path() -> PathBuf {
+    let home = crate::config::get_home_dir();
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            return PathBuf::from(appdata).join("skills").join("env.ps1");
+        }
+        return home
+            .join("AppData")
+            .join("Roaming")
+            .join("skills")
+            .join("env.ps1");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        home.join(".config").join("skills").join("env.sh")
+    }
+}
+
+pub fn source_path() -> PathBuf {
+    crate::config::get_home_dir()
+        .join(".cc-switch")
+        .join(SOURCE_FILE_NAME)
+}
+
+pub fn resolve_path(raw: &str) -> PathBuf {
+    let trimmed = raw.trim();
+    if trimmed == "~" {
+        return crate::config::get_home_dir();
+    }
+    if let Some(stripped) = trimmed.strip_prefix("~/") {
+        return crate::config::get_home_dir().join(stripped);
+    }
+    if let Some(stripped) = trimmed.strip_prefix("~\\") {
+        return crate::config::get_home_dir().join(stripped);
+    }
+    PathBuf::from(trimmed)
+}
+
+pub fn output_path_from_settings() -> PathBuf {
+    crate::settings::get_settings()
+        .skill_env_output_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(resolve_path)
+        .unwrap_or_else(default_output_path)
+}
+
+pub fn read_state() -> Result<SkillEnvState, AppError> {
+    let source = source_path();
+    let output = output_path_from_settings();
+    let content = if source.exists() {
+        fs::read_to_string(&source).map_err(|e| AppError::io(&source, e))?
+    } else if output.exists() {
+        let generated = fs::read_to_string(&output).map_err(|e| AppError::io(&output, e))?;
+        env_map_to_dotenv(&parse_generated_env(&generated))
+    } else {
+        String::new()
+    };
+    let parsed_count = parse_dotenv(&content)?.len();
+    Ok(SkillEnvState {
+        source_path: source.display().to_string(),
+        output_path: output.display().to_string(),
+        content,
+        parsed_count,
+    })
+}
+
+pub fn save_and_refresh(content: &str) -> Result<SkillEnvSaveResult, AppError> {
+    let previous_env = read_existing_env_for_refresh();
+    let env = parse_dotenv(content)?;
+    let source = source_path();
+    write_secure(&source, normalize_source_content(content)?.as_bytes())?;
+
+    let output = output_path_from_settings();
+    let generated = render_generated_env(&env, &source);
+    write_secure(&output, generated.as_bytes())?;
+
+    apply_to_current_process(&env, previous_env.keys());
+
+    Ok(SkillEnvSaveResult {
+        source_path: source.display().to_string(),
+        output_path: output.display().to_string(),
+        parsed_count: env.len(),
+    })
+}
+
+pub fn refresh_from_source() -> Result<SkillEnvSaveResult, AppError> {
+    let state = read_state()?;
+    save_and_refresh(&state.content)
+}
+
+fn normalize_source_content(content: &str) -> Result<String, AppError> {
+    parse_dotenv(content)?;
+    let trimmed = content.trim_end();
+    if trimmed.is_empty() {
+        Ok(String::new())
+    } else {
+        Ok(format!("{trimmed}\n"))
+    }
+}
+
+fn parse_dotenv(content: &str) -> Result<BTreeMap<String, String>, AppError> {
+    let mut env = BTreeMap::new();
+    for (index, raw_line) in content.lines().enumerate() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let assignment = line.strip_prefix("export ").unwrap_or(line).trim();
+        let Some((key, value)) = assignment.split_once('=') else {
+            return Err(AppError::InvalidInput(format!(
+                "第 {} 行不是 KEY=value 格式",
+                index + 1
+            )));
+        };
+        let key = key.trim();
+        if !is_valid_key(key) {
+            return Err(AppError::InvalidInput(format!(
+                "第 {} 行变量名无效: {}",
+                index + 1,
+                key
+            )));
+        }
+        env.insert(key.to_string(), unquote_value(value.trim()));
+    }
+    Ok(env)
+}
+
+fn parse_generated_env(content: &str) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    for raw_line in content.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("export ") {
+            if let Some((key, value)) = rest.trim().split_once('=') {
+                let key = key.trim();
+                if is_valid_key(key) {
+                    env.insert(key.to_string(), unquote_value(value.trim()));
+                }
+            }
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("$env:") {
+            if let Some((key, value)) = rest.trim().split_once('=') {
+                let key = key.trim();
+                if is_valid_key(key) {
+                    env.insert(key.to_string(), unquote_value(value.trim()));
+                }
+            }
+        }
+    }
+    env
+}
+
+fn env_map_to_dotenv(env: &BTreeMap<String, String>) -> String {
+    env.iter()
+        .map(|(key, value)| format!("{key}={}", quote_dotenv_value(value)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_generated_env(env: &BTreeMap<String, String>, source: &Path) -> String {
+    let header = format!(
+        "# Generated by CC Switch from {}\n# Edit variables in CC Switch instead of modifying this file directly.\n",
+        source.display()
+    );
+    #[cfg(target_os = "windows")]
+    {
+        let mut output = header;
+        for (key, value) in env {
+            output.push_str(&format!("$env:{key} = {}\n", quote_powershell(value)));
+        }
+        return output;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let mut output = header;
+        for (key, value) in env {
+            output.push_str(&format!("export {key}={}\n", quote_shell(value)));
+        }
+        output
+    }
+}
+
+fn read_existing_env_for_refresh() -> BTreeMap<String, String> {
+    let source = source_path();
+    if let Ok(content) = fs::read_to_string(&source) {
+        return parse_dotenv(&content).unwrap_or_default();
+    }
+    let output = output_path_from_settings();
+    if let Ok(content) = fs::read_to_string(&output) {
+        return parse_generated_env(&content);
+    }
+    BTreeMap::new()
+}
+
+fn apply_to_current_process<'a, I>(env: &BTreeMap<String, String>, previous_keys: I)
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    for key in previous_keys {
+        if !env.contains_key(key) {
+            std::env::remove_var(key);
+        }
+    }
+    for (key, value) in env {
+        std::env::set_var(key, value);
+    }
+}
+
+fn is_valid_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+fn unquote_value(value: &str) -> String {
+    if value.len() >= 2 {
+        let bytes = value.as_bytes();
+        if (bytes[0] == b'"' && bytes[value.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[value.len() - 1] == b'\'')
+        {
+            return unescape_basic(&value[1..value.len() - 1]);
+        }
+    }
+    value.to_string()
+}
+
+fn unescape_basic(value: &str) -> String {
+    let mut output = String::new();
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            if let Some(next) = chars.next() {
+                output.push(match next {
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    other => other,
+                });
+            } else {
+                output.push(ch);
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
+fn quote_dotenv_value(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '@'))
+    {
+        return value.to_string();
+    }
+    format!("\"{}\"", escape_double_quoted(value))
+}
+
+fn quote_shell(value: &str) -> String {
+    format!("\"{}\"", escape_double_quoted(value))
+}
+
+#[cfg(target_os = "windows")]
+fn quote_powershell(value: &str) -> String {
+    format!("\"{}\"", value.replace('`', "``").replace('"', "`\""))
+}
+
+fn escape_double_quoted(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "\\$")
+        .replace('`', "\\`")
+}
+
+fn write_secure(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| AppError::io(path, e))?;
+        file.write_all(bytes).map_err(|e| AppError::io(path, e))?;
+        return Ok(());
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(path, bytes).map_err(|e| AppError::io(path, e))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_dotenv_and_quotes_shell_output() {
+        let env = parse_dotenv("FOO=bar\nTOKEN=\"a b$c\"\nexport ENABLED=true\n").unwrap();
+        assert_eq!(env.get("FOO").unwrap(), "bar");
+        assert_eq!(env.get("TOKEN").unwrap(), "a b$c");
+        assert_eq!(env.get("ENABLED").unwrap(), "true");
+        let generated = render_generated_env(&env, Path::new("/tmp/source.env"));
+        #[cfg(target_os = "windows")]
+        assert!(generated.contains("$env:TOKEN = \"a b$c\""));
+        #[cfg(not(target_os = "windows"))]
+        assert!(generated.contains("export TOKEN=\"a b\\$c\""));
+    }
+
+    #[test]
+    fn parses_existing_shell_exports() {
+        let env = parse_generated_env("export OT_BASE_DIR=\"/tmp/ot\"\n# comment\nBAD-LINE=x\n");
+        assert_eq!(env.get("OT_BASE_DIR").unwrap(), "/tmp/ot");
+        assert!(!env.contains_key("BAD-LINE"));
+    }
+}

--- a/src-tauri/src/skill_env.rs
+++ b/src-tauri/src/skill_env.rs
@@ -328,7 +328,7 @@ fn write_secure(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
             .open(path)
             .map_err(|e| AppError::io(path, e))?;
         file.write_all(bytes).map_err(|e| AppError::io(path, e))?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]

--- a/src-tauri/src/skill_env.rs
+++ b/src-tauri/src/skill_env.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
+#[cfg(unix)]
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -32,11 +33,10 @@ pub fn default_output_path() -> PathBuf {
         if let Ok(appdata) = std::env::var("APPDATA") {
             return PathBuf::from(appdata).join("skills").join("env.ps1");
         }
-        return home
-            .join("AppData")
+        home.join("AppData")
             .join("Roaming")
             .join("skills")
-            .join("env.ps1");
+            .join("env.ps1")
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -209,7 +209,7 @@ fn render_generated_env(env: &BTreeMap<String, String>, source: &Path) -> String
         for (key, value) in env {
             output.push_str(&format!("$env:{key} = {}\n", quote_powershell(value)));
         }
-        return output;
+        output
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -301,6 +301,7 @@ fn quote_dotenv_value(value: &str) -> String {
     format!("\"{}\"", escape_double_quoted(value))
 }
 
+#[cfg(not(target_os = "windows"))]
 fn quote_shell(value: &str) -> String {
     format!("\"{}\"", escape_double_quoted(value))
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Shield,
   Cpu,
   LayoutDashboard,
+  SquareTerminal,
 } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { Provider, VisibleApps } from "@/types";
@@ -94,6 +95,7 @@ import ToolsPanel from "@/components/openclaw/ToolsPanel";
 import AgentsDefaultsPanel from "@/components/openclaw/AgentsDefaultsPanel";
 import OpenClawHealthBanner from "@/components/openclaw/OpenClawHealthBanner";
 import HermesMemoryPanel from "@/components/hermes/HermesMemoryPanel";
+import { SkillEnvEditorDialog } from "@/components/SkillEnvEditorDialog";
 
 type View =
   | "providers"
@@ -178,6 +180,7 @@ function App() {
     useState<SkillsPageSource>("repos");
   const [settingsDefaultTab, setSettingsDefaultTab] = useState("general");
   const [isAddOpen, setIsAddOpen] = useState(false);
+  const [isSkillEnvOpen, setIsSkillEnvOpen] = useState(false);
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
 
   useEffect(() => {
@@ -1395,6 +1398,17 @@ function App() {
                     />
 
                     <div className="flex items-center gap-1 p-1 bg-muted rounded-xl">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setIsSkillEnvOpen(true)}
+                        className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                        title={t("skillEnv.title", {
+                          defaultValue: "Skill 环境变量",
+                        })}
+                      >
+                        <SquareTerminal className="w-4 h-4" />
+                      </Button>
                       <AnimatePresence mode="wait">
                         <motion.div
                           key={
@@ -1657,6 +1671,10 @@ function App() {
       />
 
       <DeepLinkImportDialog />
+      <SkillEnvEditorDialog
+        open={isSkillEnvOpen}
+        onOpenChange={setIsSkillEnvOpen}
+      />
       <FirstRunNoticeDialog />
     </div>
   );

--- a/src/components/SkillEnvEditorDialog.tsx
+++ b/src/components/SkillEnvEditorDialog.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2, RefreshCw, Save, X } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { settingsApi } from "@/lib/api";
+import type { SkillEnvState } from "@/lib/api/settings";
+import { extractErrorMessage } from "@/utils/errorUtils";
+
+export interface SkillEnvEditorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function SkillEnvEditorDialog({
+  open,
+  onOpenChange,
+}: SkillEnvEditorDialogProps) {
+  const { t } = useTranslation();
+  const [state, setState] = useState<SkillEnvState | null>(null);
+  const [content, setContent] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const load = async () => {
+    setIsLoading(true);
+    try {
+      const next = await settingsApi.getSkillEnvState();
+      setState(next);
+      setContent(next.content);
+    } catch (error) {
+      toast.error(
+        t("skillEnv.loadFailed", {
+          defaultValue: "读取环境变量失败",
+        }),
+        { description: extractErrorMessage(error) || undefined },
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      void load();
+    }
+  }, [open]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const result = await settingsApi.saveSkillEnv(content);
+      toast.success(
+        t("skillEnv.saveSuccess", {
+          defaultValue: "环境变量已保存并应用",
+        }),
+      );
+      setState((prev: SkillEnvState | null) =>
+        prev
+          ? {
+              ...prev,
+              sourcePath: result.sourcePath,
+              outputPath: result.outputPath,
+              parsedCount: result.parsedCount,
+              content,
+            }
+          : {
+              sourcePath: result.sourcePath,
+              outputPath: result.outputPath,
+              parsedCount: result.parsedCount,
+              content,
+            },
+      );
+    } catch (error) {
+      toast.error(
+        t("skillEnv.saveFailed", {
+          defaultValue: "保存环境变量失败",
+        }),
+        { description: extractErrorMessage(error) || undefined },
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    try {
+      const result = await settingsApi.refreshSkillEnv();
+      const next = await settingsApi.getSkillEnvState();
+      setState(next);
+      setContent(next.content);
+      toast.success(
+        t("skillEnv.refreshSuccess", {
+          defaultValue: "环境变量已重新加载并应用",
+        }),
+        {
+          description: t("skillEnv.refreshCount", {
+            defaultValue: "已重新加载 {{count}} 个变量",
+            count: result.parsedCount,
+          }),
+        },
+      );
+    } catch (error) {
+      toast.error(
+        t("skillEnv.refreshFailed", {
+          defaultValue: "重新加载环境变量失败",
+        }),
+        { description: extractErrorMessage(error) || undefined },
+      );
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const busy = isLoading || isSaving || isRefreshing;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl" zIndex="top">
+        <DialogHeader>
+          <DialogTitle>
+            {t("skillEnv.title", { defaultValue: "Skill 环境变量" })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("skillEnv.description", {
+              defaultValue:
+                "使用 .env 格式配置全局 Skill 环境变量。保存后会写入源文件并生成当前系统的环境变量文件。",
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Textarea
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            disabled={isLoading}
+            className="min-h-[360px] resize-none font-mono text-xs leading-5"
+            placeholder={
+              "# zhangtian-platform\nZHANGTIAN_USER_ID=your-user-id\nZHANGTIAN_VPN=true"
+            }
+          />
+          <div className="space-y-1 rounded-md border border-border-default bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+            <div>
+              {t("skillEnv.sourcePath", {
+                defaultValue: "源文件：{{path}}",
+                path: state?.sourcePath || "-",
+              })}
+            </div>
+            <div>
+              {t("skillEnv.outputPath", {
+                defaultValue: "生成文件：{{path}}",
+                path: state?.outputPath || "-",
+              })}
+            </div>
+            <div>
+              {t("skillEnv.parsedCount", {
+                defaultValue: "变量数量：{{count}}",
+                count: state?.parsedCount ?? 0,
+              })}
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t("skillEnv.restartHint", {
+              defaultValue:
+                "保存/刷新后，CC Switch 后续启动的进程会使用新变量；已运行的客户端需要重启。",
+            })}
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={busy}
+            onClick={() => onOpenChange(false)}
+          >
+            <X className="mr-2 h-4 w-4" />
+            {t("common.close", { defaultValue: "关闭" })}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={busy}
+            onClick={() => void handleRefresh()}
+          >
+            {isRefreshing ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            {t("skillEnv.reloadApply", { defaultValue: "重新加载并应用" })}
+          </Button>
+          <Button
+            type="button"
+            disabled={busy}
+            onClick={() => void handleSave()}
+          >
+            {isSaving ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
+            {t("common.save", { defaultValue: "保存" })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -40,6 +40,7 @@ import { WindowSettings } from "@/components/settings/WindowSettings";
 import { AppVisibilitySettings } from "@/components/settings/AppVisibilitySettings";
 import { SkillStorageLocationSettings } from "@/components/settings/SkillStorageLocationSettings";
 import { SkillSyncMethodSettings } from "@/components/settings/SkillSyncMethodSettings";
+import { SkillEnvPathSettings } from "@/components/settings/SkillEnvPathSettings";
 import { TerminalSettings } from "@/components/settings/TerminalSettings";
 import { DirectorySettings } from "@/components/settings/DirectorySettings";
 import { ImportExportSection } from "@/components/settings/ImportExportSection";
@@ -272,6 +273,12 @@ export function SettingsPage({
                       value={settings.skillSyncMethod ?? "auto"}
                       onChange={(method) =>
                         handleAutoSave({ skillSyncMethod: method })
+                      }
+                    />
+                    <SkillEnvPathSettings
+                      value={settings.skillEnvOutputPath}
+                      onChange={(path) =>
+                        handleAutoSave({ skillEnvOutputPath: path })
                       }
                     />
                     <CodexAuthSettings

--- a/src/components/settings/SkillEnvPathSettings.tsx
+++ b/src/components/settings/SkillEnvPathSettings.tsx
@@ -32,7 +32,10 @@ export function SkillEnvPathSettings({
         if (active) setDefaultPath(path);
       })
       .catch((error) => {
-        console.warn("[SkillEnvPathSettings] Failed to load default path", error);
+        console.warn(
+          "[SkillEnvPathSettings] Failed to load default path",
+          error,
+        );
       });
     return () => {
       active = false;

--- a/src/components/settings/SkillEnvPathSettings.tsx
+++ b/src/components/settings/SkillEnvPathSettings.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { FolderSearch, RotateCcw } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { settingsApi } from "@/lib/api";
+
+export interface SkillEnvPathSettingsProps {
+  value?: string;
+  onChange: (path?: string) => Promise<boolean>;
+}
+
+export function SkillEnvPathSettings({
+  value,
+  onChange,
+}: SkillEnvPathSettingsProps) {
+  const { t } = useTranslation();
+  const [defaultPath, setDefaultPath] = useState("");
+  const [draft, setDraft] = useState(value ?? "");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setDraft(value ?? "");
+  }, [value]);
+
+  useEffect(() => {
+    let active = true;
+    settingsApi
+      .getDefaultSkillEnvOutputPath()
+      .then((path) => {
+        if (active) setDefaultPath(path);
+      })
+      .catch((error) => {
+        console.warn("[SkillEnvPathSettings] Failed to load default path", error);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const currentPath = draft || defaultPath;
+
+  const savePath = async (nextPath?: string) => {
+    const normalized = nextPath?.trim() ? nextPath.trim() : undefined;
+    const previous = value?.trim() ? value.trim() : undefined;
+    if (normalized === previous) return;
+    setIsSaving(true);
+    try {
+      const ok = await onChange(normalized);
+      if (ok) {
+        toast.success(
+          t("settings.skillEnv.pathSaved", {
+            defaultValue: "Skill 环境变量存储位置已保存",
+          }),
+        );
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleBrowse = async () => {
+    const selected = await settingsApi.pickSkillEnvOutputFile(currentPath);
+    if (!selected) return;
+    setDraft(selected);
+    await savePath(selected);
+  };
+
+  return (
+    <section className="space-y-2">
+      <header className="space-y-1">
+        <h3 className="text-sm font-medium">
+          {t("settings.skillEnv.pathTitle", {
+            defaultValue: "Skill 环境变量存储位置",
+          })}
+        </h3>
+        <p className="text-xs text-muted-foreground">
+          {t("settings.skillEnv.pathDescription", {
+            defaultValue:
+              "配置 CC Switch 生成的系统环境变量文件路径。变量内容通过主页面环境变量按钮编辑。",
+          })}
+        </p>
+      </header>
+      <div className="flex max-w-2xl items-center gap-2">
+        <Input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={() => void savePath(draft)}
+          placeholder={defaultPath}
+          className="font-mono text-xs"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          disabled={isSaving}
+          onClick={() => void handleBrowse()}
+          title={t("common.browse", { defaultValue: "浏览" })}
+        >
+          <FolderSearch className="h-4 w-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={isSaving || !draft}
+          onClick={() => {
+            setDraft("");
+            void savePath(undefined);
+          }}
+          title={t("settings.skillEnv.resetDefault", {
+            defaultValue: "恢复默认路径",
+          })}
+        >
+          <RotateCcw className="mr-2 h-4 w-4" />
+          {t("settings.skillEnv.resetDefault", {
+            defaultValue: "恢复默认路径",
+          })}
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {t("settings.skillEnv.effectivePath", {
+          defaultValue: "当前生效路径：{{path}}",
+          path: currentPath,
+        })}
+      </p>
+    </section>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -30,6 +30,7 @@
     "copy": "Copy",
     "view": "View",
     "back": "Back",
+    "close": "Close",
     "refresh": "Refresh",
     "refreshing": "Refreshing...",
     "import": "Import",
@@ -41,6 +42,21 @@
     "auto": "Auto",
     "enabled": "Enabled",
     "notSet": "Not Set"
+  },
+  "skillEnv": {
+    "title": "Skill Environment Variables",
+    "description": "Configure global Skill environment variables using .env format. Saving writes the source file and generates the environment file for this system.",
+    "loadFailed": "Failed to load environment variables",
+    "saveSuccess": "Environment variables saved and applied",
+    "saveFailed": "Failed to save environment variables",
+    "reloadApply": "Reload and Apply",
+    "refreshSuccess": "Environment variables reloaded and applied",
+    "refreshFailed": "Failed to reload environment variables",
+    "refreshCount": "Reloaded {{count}} variable(s)",
+    "sourcePath": "Source file: {{path}}",
+    "outputPath": "Generated file: {{path}}",
+    "parsedCount": "Variables: {{count}}",
+    "restartHint": "After saving/reloading, new processes launched by CC Switch will use these variables. Already running clients need a restart."
   },
   "firstRunNotice": {
     "title": "Welcome to CC Switch",
@@ -718,6 +734,13 @@
       "symlink": "Symlink",
       "copy": "Copy Files",
       "symlinkHint": "Symlinks save disk space and enable real-time sync. Note: May require admin privileges or Developer Mode on Windows"
+    },
+    "skillEnv": {
+      "pathTitle": "Skill Environment Variables File",
+      "pathDescription": "Configure the generated system environment file path. Edit variables from the environment button on the main page.",
+      "pathSaved": "Skill environment variables file path saved",
+      "resetDefault": "Restore Default Path",
+      "effectivePath": "Effective path: {{path}}"
     },
     "terminal": {
       "title": "Preferred Terminal",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -30,6 +30,7 @@
     "copy": "コピー",
     "view": "表示",
     "back": "戻る",
+    "close": "閉じる",
     "refresh": "更新",
     "refreshing": "更新中...",
     "import": "インポート",
@@ -41,6 +42,21 @@
     "auto": "自動",
     "enabled": "有効",
     "notSet": "未設定"
+  },
+  "skillEnv": {
+    "title": "Skill 環境変数",
+    "description": ".env 形式でグローバル Skill 環境変数を設定します。保存するとソースファイルを書き込み、このシステム用の環境変数ファイルを生成します。",
+    "loadFailed": "環境変数の読み込みに失敗しました",
+    "saveSuccess": "環境変数を保存して適用しました",
+    "saveFailed": "環境変数の保存に失敗しました",
+    "reloadApply": "再読み込みして適用",
+    "refreshSuccess": "環境変数を再読み込みして適用しました",
+    "refreshFailed": "環境変数の再読み込みに失敗しました",
+    "refreshCount": "{{count}} 個の変数を再読み込みしました",
+    "sourcePath": "ソースファイル：{{path}}",
+    "outputPath": "生成ファイル：{{path}}",
+    "parsedCount": "変数数：{{count}}",
+    "restartHint": "保存/再読み込み後、CC Switch が新しく起動するプロセスでは新しい変数が使われます。既に実行中のクライアントは再起動が必要です。"
   },
   "firstRunNotice": {
     "title": "CC Switch へようこそ",
@@ -718,6 +734,13 @@
       "symlink": "シンボリックリンク",
       "copy": "ファイルコピー",
       "symlinkHint": "シンボリックリンクはディスク容量を節約し、リアルタイム同期を有効にします。注意：Windowsでは管理者権限または開発者モードが必要な場合があります"
+    },
+    "skillEnv": {
+      "pathTitle": "Skill 環境変数ファイル",
+      "pathDescription": "CC Switch が生成するシステム環境変数ファイルのパスを設定します。変数はメイン画面の環境変数ボタンから編集します。",
+      "pathSaved": "Skill 環境変数ファイルのパスを保存しました",
+      "resetDefault": "既定のパスに戻す",
+      "effectivePath": "有効なパス：{{path}}"
     },
     "terminal": {
       "title": "優先ターミナル",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -30,6 +30,7 @@
     "copy": "複製",
     "view": "檢視",
     "back": "返回",
+    "close": "關閉",
     "refresh": "重新整理",
     "refreshing": "重新整理中...",
     "import": "匯入",
@@ -41,6 +42,21 @@
     "auto": "自動",
     "enabled": "已啟用",
     "notSet": "未設定"
+  },
+  "skillEnv": {
+    "title": "Skill 環境變數",
+    "description": "使用 .env 格式設定全域 Skill 環境變數。儲存後會寫入來源檔案並產生目前系統的環境變數檔案。",
+    "loadFailed": "讀取環境變數失敗",
+    "saveSuccess": "環境變數已儲存並套用",
+    "saveFailed": "儲存環境變數失敗",
+    "reloadApply": "重新載入並套用",
+    "refreshSuccess": "環境變數已重新載入並套用",
+    "refreshFailed": "重新載入環境變數失敗",
+    "refreshCount": "已重新載入 {{count}} 個變數",
+    "sourcePath": "來源檔案：{{path}}",
+    "outputPath": "產生檔案：{{path}}",
+    "parsedCount": "變數數量：{{count}}",
+    "restartHint": "儲存/重新載入後，CC Switch 後續啟動的行程會使用新變數；已執行中的客戶端需要重新啟動。"
   },
   "firstRunNotice": {
     "title": "歡迎使用 CC Switch",
@@ -718,6 +734,13 @@
       "symlink": "軟連結",
       "copy": "檔案複製",
       "symlinkHint": "軟連結節省磁碟空間並支援即時同步。注意：Windows 可能需要管理員權限或開啟開發者模式"
+    },
+    "skillEnv": {
+      "pathTitle": "Skill 環境變數儲存位置",
+      "pathDescription": "設定 CC Switch 產生的系統環境變數檔案路徑。變數內容可從主頁面的環境變數按鈕編輯。",
+      "pathSaved": "Skill 環境變數儲存位置已儲存",
+      "resetDefault": "還原預設路徑",
+      "effectivePath": "目前生效路徑：{{path}}"
     },
     "terminal": {
       "title": "首選終端機",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -30,6 +30,7 @@
     "copy": "复制",
     "view": "查看",
     "back": "返回",
+    "close": "关闭",
     "refresh": "刷新",
     "refreshing": "刷新中...",
     "import": "导入",
@@ -41,6 +42,21 @@
     "auto": "自动",
     "enabled": "已开启",
     "notSet": "未设置"
+  },
+  "skillEnv": {
+    "title": "Skill 环境变量",
+    "description": "使用 .env 格式配置全局 Skill 环境变量。保存后会写入源文件并生成当前系统的环境变量文件。",
+    "loadFailed": "读取环境变量失败",
+    "saveSuccess": "环境变量已保存并应用",
+    "saveFailed": "保存环境变量失败",
+    "reloadApply": "重新加载并应用",
+    "refreshSuccess": "环境变量已重新加载并应用",
+    "refreshFailed": "重新加载环境变量失败",
+    "refreshCount": "已重新加载 {{count}} 个变量",
+    "sourcePath": "源文件：{{path}}",
+    "outputPath": "生成文件：{{path}}",
+    "parsedCount": "变量数量：{{count}}",
+    "restartHint": "保存/重新加载后，CC Switch 后续启动的进程会使用新变量；已运行的客户端需要重启。"
   },
   "firstRunNotice": {
     "title": "欢迎使用 CC Switch",
@@ -718,6 +734,13 @@
       "symlink": "软连接",
       "copy": "文件复制",
       "symlinkHint": "软连接节省磁盘空间并支持实时同步。注意：Windows 可能需要管理员权限或开启开发者模式"
+    },
+    "skillEnv": {
+      "pathTitle": "Skill 环境变量存储位置",
+      "pathDescription": "配置 CC Switch 生成的系统环境变量文件路径。变量内容通过主页面环境变量按钮编辑。",
+      "pathSaved": "Skill 环境变量存储位置已保存",
+      "resetDefault": "恢复默认路径",
+      "effectivePath": "当前生效路径：{{path}}"
     },
     "terminal": {
       "title": "首选终端",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -26,6 +26,19 @@ export interface CodexUnifyHistoryRestoreResult {
   skippedReason?: string;
 }
 
+export interface SkillEnvState {
+  sourcePath: string;
+  outputPath: string;
+  content: string;
+  parsedCount: number;
+}
+
+export interface SkillEnvSaveResult {
+  sourcePath: string;
+  outputPath: string;
+  parsedCount: number;
+}
+
 export interface WebDavSyncResult {
   status: string;
 }
@@ -37,6 +50,28 @@ export const settingsApi = {
 
   async save(settings: Settings): Promise<boolean> {
     return await invoke("save_settings", { settings });
+  },
+
+  async getDefaultSkillEnvOutputPath(): Promise<string> {
+    return await invoke("get_default_skill_env_output_path");
+  },
+
+  async pickSkillEnvOutputFile(
+    currentPath?: string | null,
+  ): Promise<string | null> {
+    return await invoke("pick_skill_env_output_file", { currentPath });
+  },
+
+  async getSkillEnvState(): Promise<SkillEnvState> {
+    return await invoke("get_skill_env_state");
+  },
+
+  async saveSkillEnv(content: string): Promise<SkillEnvSaveResult> {
+    return await invoke("save_skill_env", { content });
+  },
+
+  async refreshSkillEnv(): Promise<SkillEnvSaveResult> {
+    return await invoke("refresh_skill_env");
   },
 
   /** 是否存在统一 Codex 会话历史的迁移备份（关闭弹窗据此显示"恢复备份"勾选） */

--- a/src/types.ts
+++ b/src/types.ts
@@ -419,6 +419,8 @@ export interface Settings {
   skillSyncMethod?: SkillSyncMethod;
   // Skill 存储位置：cc_switch（默认）或 unified（~/.agents/skills/）
   skillStorageLocation?: SkillStorageLocation;
+  // Skill 环境变量生成文件路径（源文件固定为 ~/.cc-switch/skill-env.env）
+  skillEnvOutputPath?: string;
 
   // ===== WebDAV v2 同步设置 =====
   webdavSync?: WebDavSyncSettings;

--- a/tests/components/SettingsDialog.test.tsx
+++ b/tests/components/SettingsDialog.test.tsx
@@ -140,6 +140,10 @@ vi.mock("@/hooks/useImportExport", () => ({
 vi.mock("@/lib/api", () => ({
   settingsApi: {
     restart: vi.fn().mockResolvedValue(true),
+    getDefaultSkillEnvOutputPath: vi
+      .fn()
+      .mockResolvedValue("/tmp/skill-env.env"),
+    pickSkillEnvOutputFile: vi.fn().mockResolvedValue(null),
   },
 }));
 
@@ -277,6 +281,8 @@ describe("SettingsPage Component", () => {
     toastErrorMock.mockReset();
     settingsApi = (await import("@/lib/api")).settingsApi;
     settingsApi.restart.mockClear();
+    settingsApi.getDefaultSkillEnvOutputPath.mockClear();
+    settingsApi.pickSkillEnvOutputFile.mockClear();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- add a global Skill environment variable editor on the main toolbar
- store source variables as .env and generate OS-specific env files
- add a general setting for the generated env file path

## Verification
- pnpm typecheck
- cargo test skill_env

Note: `pnpm build` generates the macOS app and dmg locally, then exits non-zero at updater signing because `TAURI_SIGNING_PRIVATE_KEY` is not configured.