### PR TITLE
fix(detection): resolve Windows custom npm prefix tools via PATH

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -733,9 +733,15 @@ async fn get_single_tool_version_impl(
     } else {
         #[cfg(target_os = "windows")]
         {
-            // Windows 上只执行已经定位到的真实可执行文件，避免 `cmd /C tool`
-            // 误触发 App Execution Alias 或协议处理器。
-            scan_cli_version(tool)
+            // 先用 `where`（标准 PATH 解析）探测 PATH 默认命中的真实可执行文件，
+            // 找不到才 fallback 到 `scan_cli_version` 的常见目录扫描。
+            // 这一路径能覆盖用户改了 npm prefix 后目录不在 GUI 进程 PATH 中的场景；
+            // 仍只执行 `where` 定位到的真身，不直接 `cmd /C tool`，避免误触发 App
+            // Execution Alias / 协议处理器。
+            match try_get_version_windows(tool) {
+                ShellProbe::NotFound(_) => scan_cli_version(tool),
+                found => found,
+            }
         }
 
         #[cfg(not(target_os = "windows"))]
@@ -1025,6 +1031,54 @@ fn try_get_version(tool: &str) -> ShellProbe {
                 // = 命令存在但 --version 自身报错退出，须如实上报、不 fallback 掩盖。
                 let err = if stderr.is_empty() { stdout } else { stderr };
                 if out.status.code() == Some(127) || err.is_empty() {
+                    ShellProbe::NotFound(NOT_INSTALLED.to_string())
+                } else {
+                    ShellProbe::FoundButFailed(last_lines(err.trim(), 4))
+                }
+            }
+        }
+        Err(_) => ShellProbe::NotFound(NOT_INSTALLED.to_string()),
+    }
+}
+
+/// 在 Windows 平台通过 `where`（标准 PATH 解析）探测版本。
+///
+/// 与非 Windows 的 `try_get_version` 对称：先用 `resolve_path_default` 解析命令行
+/// 默认命中的真实可执行文件，找到后只对该真身跑 `--version`（不直接 `cmd /C {tool}`，
+/// 以免误触发 App Execution Alias / 协议处理器）；解析不到时返回 `NotFound`，由
+/// 调用方 fallback 到 `scan_cli_version` 的常见目录扫描。
+///
+/// 这一路径与 `scan_cli_version` 的关键差异：`scan_cli_version` 用的是**进程级**
+/// `std::env::var_os("PATH")`（GUI 进程的 PATH），用户改了 npm prefix 后，若新目录
+/// 仅由 shell profile / 系统环境注入而未进入 Tauri 进程 PATH，文件存在性检查就会
+/// 漏掉。`where` 走的是 shell 侧的标准 PATH 解析，能覆盖自定义 npm prefix 等场景。
+#[cfg(target_os = "windows")]
+fn try_get_version_windows(tool: &str) -> ShellProbe {
+    let tool_path = match resolve_path_default(tool) {
+        Some(p) => p,
+        None => return ShellProbe::NotFound(NOT_INSTALLED.to_string()),
+    };
+
+    let new_path = std::env::var_os("PATH")
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    match run_windows_tool_version_command(&tool_path, &new_path) {
+        Ok(out) => {
+            let stdout = decode_command_output(&out.stdout).trim().to_string();
+            let stderr = decode_command_output(&out.stderr).trim().to_string();
+            if out.status.success() {
+                let raw = if stdout.is_empty() { &stderr } else { &stdout };
+                if raw.is_empty() {
+                    ShellProbe::NotFound(NOT_INSTALLED.to_string())
+                } else {
+                    ShellProbe::Found(extract_version(raw))
+                }
+            } else {
+                // `where` 命中了真实可执行文件，但 `--version` 自身非零退出
+                // （如工具要求更高 Node 版本）——如实上报，不 fallback 掩盖。
+                let err = if stderr.is_empty() { stdout } else { stderr };
+                if err.is_empty() {
                     ShellProbe::NotFound(NOT_INSTALLED.to_string())
                 } else {
                     ShellProbe::FoundButFailed(last_lines(err.trim(), 4))


### PR DESCRIPTION
## Summary / 概述

修复 Windows 上「改了 npm prefix 后，`npm i -g` 安装的 CLI 工具（codex / opencode）在 设置 → 关于 显示为『未安装』，而默认 prefix 的 Claude Code 检测正常」的问题。

### 根因

`get_single_tool_version_impl`（`src-tauri/src/commands/misc.rs`）的 `else` 分支存在**平台不对称**：

- **非 Windows**：先用 `try_get_version` 通过登录 shell（`$SHELL -lic "tool --version"`）查询，会加载 `.zshrc`/`.bashrc`、获得完整用户 PATH；只有 `NotFound` 才 fallback 到 `scan_cli_version`。
- **Windows（修复前）**：直接跳过 PATH 解析，只走 `scan_cli_version`。而 `scan_cli_version` 用的是**进程级** `std::env::var_os("PATH")`（GUI/Tauri 进程的 PATH）+ 文件存在性检查。当自定义 npm prefix 目录仅由 shell profile / 系统环境注入、未进入 GUI 进程 PATH 时，就会漏检。

已有的修复 PR #2286（pnpm 全局安装检测）、PR #2822（mise 路径）**只对非 Windows 生效**，Windows 这条路径从未被修过。

### 修复

新增 `try_get_version_windows`，与非 Windows 的 `try_get_version` 结构对称：

1. 用 `resolve_path_default`（`cmd /C where`，shell 侧标准 PATH 解析）定位命令行默认命中的真实可执行文件；
2. 只对该真身跑 `--version`（复用既有 `run_windows_tool_version_command`，仍不直接 `cmd /C {tool}`，避免误触发 App Execution Alias / 协议处理器）；
3. `where` 找不到时返回 `NotFound`，由调用方 fallback 到 `scan_cli_version` 的常见目录扫描。

调用点（`misc.rs` Windows 分支）改为与非 Windows 一致的 `match … NotFound => scan_cli_version, found => found` 形态。复用既有且经测试的 `resolve_path_default` / `run_windows_tool_version_command` / `extract_version`，未引入重复实现。

## Related Issue / 关联 Issue

Fixes #4265

## Screenshots / 截图

N/A —— 纯后端检测逻辑变更，无 UI 文案改动。

## How verified / 验证方式

- `cargo fmt --check` ✅ 干净
- `cargo clippy` ✅ 无新增告警（仅有与本次改动无关的既有告警）
- `cargo test commands::misc::tests` ✅ **无新增失败**：53 通过；6 个失败全在 `anchored_upgrade_windows::*`（升级命令生成，非检测路径），在干净的 `main` 上同样复现，属既有问题、与本次改动无关。

手动验证场景（对应 issue）：
1. 默认 npm prefix（`%APPDATA%\npm`）—— 所有工具检测正常（回归，走 `scan_cli_version` fallback）。
2. 自定义 npm prefix + `npm i -g @openai/codex` / `opencode-ai` —— 现在可检测到（新增 `where` 路径）。
3. `where` 找不到工具 —— 仍 fallback 到 `scan_cli_version`（兜底保留）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（无前端改动）
- [x] `pnpm format:check` passes / 通过代码格式检查（无前端改动）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本改动，N/A）
