### PR TITLE
fix(provider): stop API Key field flicker when opening edit dialog (#4110)

### DIFF
--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -104,8 +104,11 @@ export function EditProviderDialog({
             const live = (await vscodeApi.getLiveProviderSettings(
               appId,
             )) as Record<string, unknown>;
-            if (!cancelled && live && typeof live === "object") {
-              setLiveSettings(live);
+            // live 可能为 null 或非对象（例如 settings 文件内容是合法的 JSON null）。
+            // 这种情况下回退到数据库 SSOT，但仍必须置位 hasLoadedLive——否则表单会
+            // 永远卡在加载态，无法编辑/保存该供应商。
+            if (!cancelled) {
+              setLiveSettings(live && typeof live === "object" ? live : null);
               setHasLoadedLive(true);
             }
           } catch {

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Save } from "lucide-react";
+import { Loader2, Save } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { FullScreenPanel } from "@/components/common/FullScreenPanel";
 import type { Provider } from "@/types";
@@ -230,7 +230,7 @@ export function EditProviderDialog({
         <Button
           type="submit"
           form="provider-form"
-          disabled={isFormSubmitting}
+          disabled={isFormSubmitting || !hasLoadedLive}
           className="bg-primary text-primary-foreground hover:bg-primary/90"
         >
           <Save className="h-4 w-4 mr-2" />
@@ -238,17 +238,28 @@ export function EditProviderDialog({
         </Button>
       }
     >
-      <ProviderForm
-        appId={appId}
-        providerId={provider.id}
-        submitLabel={t("common.save")}
-        onSubmit={handleSubmit}
-        onCancel={() => onOpenChange(false)}
-        onSubmittingChange={setIsFormSubmitting}
-        initialData={initialData}
-        showButtons={false}
-        isProxyTakeover={isProxyTakeover}
-      />
+      {/*
+        只在实时配置（live settings）解析完成后再挂载表单。
+        否则表单会先用数据库配置初始化，待 live 异步到达后再次触发 form.reset，
+        导致 API Key 等字段在打开瞬间闪烁/跳变（#4110）。
+      */}
+      {hasLoadedLive ? (
+        <ProviderForm
+          appId={appId}
+          providerId={provider.id}
+          submitLabel={t("common.save")}
+          onSubmit={handleSubmit}
+          onCancel={() => onOpenChange(false)}
+          onSubmittingChange={setIsFormSubmitting}
+          initialData={initialData}
+          showButtons={false}
+          isProxyTakeover={isProxyTakeover}
+        />
+      ) : (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
     </FullScreenPanel>
   );
 }

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -257,4 +257,39 @@ describe("EditProviderDialog", () => {
       JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
     ).toEqual(liveSettings);
   });
+
+  it("当前供应商 live 配置为 null 时回退到数据库配置并挂载表单，不会卡在加载态 (#4277 review)", async () => {
+    const provider: Provider = {
+      id: "deepseek",
+      name: "Deepseek",
+      category: "aggregator",
+      settingsConfig: {
+        env: { ANTHROPIC_AUTH_TOKEN: "db-key" },
+      },
+    };
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    // live 读取成功但返回非对象（settings 文件是 JSON null）
+    apiMocks.getLiveProviderSettings.mockResolvedValue(
+      null as unknown as Record<string, unknown>,
+    );
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="claude"
+      />,
+    );
+
+    // 表单仍会挂载（hasLoadedLive 置位），且使用数据库配置回退
+    await waitFor(() =>
+      expect(screen.getByTestId("settings-config")).toBeTruthy(),
+    );
+    expect(
+      JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+    ).toEqual(provider.settingsConfig);
+  });
 });

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -202,4 +202,59 @@ describe("EditProviderDialog", () => {
       JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
     ).toEqual(provider.settingsConfig);
   });
+
+  it("延迟挂载表单直到 live 配置解析完成，避免 API Key 字段在打开瞬间用数据库值闪烁 (#4110)", async () => {
+    const provider: Provider = {
+      id: "deepseek",
+      name: "Deepseek",
+      category: "aggregator",
+      settingsConfig: {
+        env: {
+          ANTHROPIC_AUTH_TOKEN: "db-key",
+          ANTHROPIC_BASE_URL: "https://api.deepseek.com/anthropic",
+        },
+      },
+    };
+    // 用户手动改过 ~/.claude/settings.json，live 里的 key 与数据库不同
+    const liveSettings = {
+      env: {
+        ANTHROPIC_AUTH_TOKEN: "live-key",
+        ANTHROPIC_BASE_URL: "https://api.deepseek.com/anthropic",
+      },
+    };
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    // 受控的 live 读取，手动决定何时解析
+    let resolveLive: (value: typeof liveSettings) => void = () => {};
+    apiMocks.getLiveProviderSettings.mockReturnValue(
+      new Promise<typeof liveSettings>((resolve) => {
+        resolveLive = resolve;
+      }),
+    );
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="claude"
+      />,
+    );
+
+    // live 解析前：表单尚未挂载，绝不会先用数据库配置初始化（否则就会闪一下 db-key）
+    await waitFor(() =>
+      expect(apiMocks.getLiveProviderSettings).toHaveBeenCalled(),
+    );
+    expect(screen.queryByTestId("settings-config")).toBeNull();
+
+    // 解析 live 后：表单挂载，且直接使用 live 配置（从未出现过 db-key）
+    resolveLive(liveSettings);
+    await waitFor(() =>
+      expect(screen.getByTestId("settings-config")).toBeTruthy(),
+    );
+    expect(
+      JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+    ).toEqual(liveSettings);
+  });
 });


### PR DESCRIPTION
## Summary / 概述

Opening the edit dialog for the **currently-active** provider made the API Key field (and the rest of the form) flicker/jump on open. `EditProviderDialog` mounted `ProviderForm` immediately with the **database** config, then read the live `~/.claude/settings.json` asynchronously and swapped it in. That late swap changed `initialData` → `defaultValues`, re-firing `ProviderForm`'s `form.reset(defaultValues)` effect after the first paint and re-initializing the fields. It is most visible when the live config was edited externally and differs from the stored one.

Fix: gate `ProviderForm` behind `hasLoadedLive` so it mounts **once** with the final (live) config. A spinner shows while live config loads, and Save is disabled until then. No behavior change for non-current providers / proxy-takeover / OpenCode (those already resolve `hasLoadedLive` synchronously).

打开**当前生效**供应商的编辑界面时，API Key 字段（及整个表单）会在打开瞬间闪烁/跳变。`EditProviderDialog` 先用**数据库**配置挂载 `ProviderForm`，随后异步读取 live 的 `~/.claude/settings.json` 再替换进去；这次迟到的替换改变了 `initialData` → `defaultValues`，在首屏绘制后再次触发 `form.reset`，导致字段被重新初始化。当用户手动改过 settings.json、live 与数据库不一致时尤其明显。

修复：用 `hasLoadedLive` 把 `ProviderForm` 挡住，等 live 配置解析完成后只挂载**一次**并使用最终（live）配置。加载期间显示 spinner，并禁用保存按钮。对非当前供应商 / 代理接管 / OpenCode 无行为变化（这些场景本就同步置位 `hasLoadedLive`）。

## Related Issue / 关联 Issue

Fixes #4110

## Screenshots / 截图

The bug is a flicker on open (hard to capture as a still image). Repro: edit the API key in `~/.claude/settings.json`, then open that provider in CC Switch — the API Key field re-initializes/jumps. After the fix the field renders once and stays stable.

该问题是打开瞬间的闪烁（静态图难以呈现）。复现：手动修改 `~/.claude/settings.json` 里的 API key，再在 CC Switch 中打开该供应商，API Key 字段会重新初始化/跳变；修复后字段只渲染一次、保持稳定。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) — N/A, no Rust changes / 无 Rust 改动
- [x] Updated i18n files if user-facing text changed — N/A, no new user-facing strings (spinner only) / 无新增用户可见文案

Added a regression test in `tests/components/EditProviderDialog.test.tsx` asserting the form is not mounted (API Key never shows the DB value) until live settings resolve. Full unit suite passes (320 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)