### PR TITLE
fix(codex): repair history visibility for active sqlite DB

### DIFF
--- a/scripts/codex-history-tool/codex_history_tool.py
+++ b/scripts/codex-history-tool/codex_history_tool.py
@@ -1,0 +1,1155 @@
+#!/usr/bin/env python3
+"""
+Codex Desktop history visibility repair tool.
+
+This script intentionally uses only the Python standard library so it can run
+on Windows, macOS, and Linux without packaging a helper executable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import platform
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+import glob as glob_module
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SOURCE_PROVIDERS = [
+    "openai",
+    "custom",
+    "ccswitch",
+    "codex_model_router_v2",
+    "cc_switch_codex_router",
+    "codex_model_router",
+]
+DEFAULT_TARGET_PROVIDER = "custom"
+DEFAULT_INTERACTIVE_SOURCES = {"cli", "vscode"}
+VERSION = "0.1.0"
+
+
+@dataclass
+class ActiveStateDb:
+    """记录当前 Codex Desktop 实际使用的 SQLite 路径和来源类型。"""
+
+    path: Path
+    kind: str
+
+
+@dataclass
+class HistoryRow:
+    """承载一条 threads 表记录中修复与展示需要的字段。"""
+
+    id: str
+    title: str
+    cwd: str | None
+    rollout_path: str | None
+    model_provider: str | None
+    source: str | None
+    thread_source: str | None
+    archived: int
+    has_user_event: int
+    updated_at: int
+    updated_at_ms: int
+    preview: str | None = None
+    first_user_message: str | None = None
+
+
+@dataclass
+class FocusRow:
+    """记录需要推入 Desktop recent window 的会话及其新时间戳。"""
+
+    id: str
+    title: str
+    cwd: str | None
+    rollout_path: str | None
+    updated_at: int
+    updated_at_ms: int
+    updated_iso: str
+
+
+def strip_long_prefix(value: str | None) -> str | None:
+    """去掉 Windows long-path 前缀，避免路径比较和 pathlib 打开失败。"""
+
+    if not value:
+        return value
+    if value.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + value[8:]
+    if value.startswith("\\\\?\\"):
+        return value[4:]
+    return value
+
+
+def normalize_path(value: str | None) -> str | None:
+    """把 cwd 规范化为稳定的比较形式，不修改 SQLite 中的原始值。"""
+
+    text = strip_long_prefix(str(value).strip()) if value is not None else ""
+    if not text:
+        return None
+    text = text.replace("/", "\\").rstrip("\\")
+    if len(text) >= 2 and text[1] == ":":
+        text = text[0].upper() + text[1:]
+    return text
+
+
+def resolve_user_path(raw: str | None) -> Path | None:
+    """解析用户输入路径，支持 ~ 并去掉 Windows long-path 前缀。"""
+
+    if raw is None or not str(raw).strip():
+        return None
+    text = strip_long_prefix(str(raw).strip()) or ""
+    return Path(text).expanduser()
+
+
+def default_codex_home() -> Path:
+    """返回当前用户的默认 Codex home 目录。"""
+
+    return Path.home() / ".codex"
+
+
+def parse_top_level_model_provider(config_text: str) -> str | None:
+    """读取 config.toml 顶层 model_provider，遇到表头后停止。"""
+
+    for line in config_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            break
+        if not stripped.startswith("model_provider"):
+            continue
+        _, _, rhs = stripped.partition("=")
+        value = rhs.strip().strip("\"'")
+        return value or None
+    return None
+
+
+def parse_sqlite_home(config_text: str) -> Path | None:
+    """读取 config.toml 顶层 sqlite_home，用于兼容非默认 Codex SQLite 目录。"""
+
+    for line in config_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            break
+        if not stripped.startswith("sqlite_home"):
+            continue
+        _, _, rhs = stripped.partition("=")
+        value = rhs.strip().strip("\"'")
+        return resolve_user_path(value)
+    return None
+
+
+def resolve_active_state_db(
+    codex_home: Path,
+    config_text: str,
+    explicit_state_db: str | None,
+) -> ActiveStateDb:
+    """解析 active state_5.sqlite，优先使用 Codex Desktop 26.609 的 sqlite 子目录。"""
+
+    explicit = resolve_user_path(explicit_state_db)
+    if explicit is not None:
+        if not explicit.exists():
+            raise FileNotFoundError(f"state DB not found: {explicit}")
+        return ActiveStateDb(explicit, "explicit")
+
+    sqlite_default = codex_home / "sqlite" / "state_5.sqlite"
+    if sqlite_default.exists():
+        return ActiveStateDb(sqlite_default, "sqlite_subdir")
+
+    sqlite_home = parse_sqlite_home(config_text)
+    if sqlite_home is not None and (sqlite_home / "state_5.sqlite").exists():
+        return ActiveStateDb(sqlite_home / "state_5.sqlite", "configured_sqlite_home")
+
+    legacy = codex_home / "state_5.sqlite"
+    if legacy.exists():
+        return ActiveStateDb(legacy, "legacy_root")
+
+    raise FileNotFoundError(f"state_5.sqlite not found under {codex_home}")
+
+
+@dataclass
+class StoreReconRow:
+    """Discovered state_*.sqlite with per-provider row counts."""
+    path: Path
+    kind: str
+    total: int
+    provider_counts: dict[str, int]
+
+
+def scan_all_state_dbs(codex_home: Path, config_text: str) -> list[StoreReconRow]:
+    """Scan all discovered state_*.sqlite candidates, return per-store counts.
+
+    Searches codex_home, codex_home/sqlite/, and sqlite_home (from config.toml)
+    for state_*.sqlite files. Deduplicates by resolved absolute path.
+    """
+    dirs = []
+    dirs.append(("root", codex_home))
+    dirs.append(("sqlite_subdir", codex_home / "sqlite"))
+    sqlite_home = parse_sqlite_home(config_text)
+    if sqlite_home is not None:
+        dirs.append(("configured_sqlite_home", sqlite_home))
+
+    seen: set[str] = set()
+    results: list[StoreReconRow] = []
+
+    for kind, directory in dirs:
+        if not directory.is_dir():
+            continue
+        pattern = str(directory / "state_*.sqlite")
+        for db_path_str in sorted(glob_module.glob(pattern)):
+            db_path = Path(db_path_str)
+            abs_path = str(db_path.resolve())
+            if abs_path in seen:
+                continue
+            seen.add(abs_path)
+            try:
+                con = sqlite3.connect(str(db_path))
+                con.row_factory = sqlite3.Row
+                if "threads" not in {row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}:
+                    con.close()
+                    continue
+                total = 0
+                counts: dict[str, int] = {}
+                for row in con.execute("SELECT model_provider, COUNT(*) AS cnt FROM threads GROUP BY model_provider"):
+                    provider = str(row["model_provider"])
+                    cnt = int(row["cnt"])
+                    counts[provider] = counts.get(provider, 0) + cnt
+                    total += cnt
+                con.close()
+                results.append(StoreReconRow(path=db_path, kind=kind, total=total, provider_counts=counts))
+            except (sqlite3.Error, OSError):
+                continue
+
+    return results
+
+
+def scan_session_jsonl_providers(codex_home: Path) -> dict[str, int]:
+    """Scan sessions/ and archived_sessions/ JSONL, count sessions per provider.
+
+    Reads model_provider from the first line of each JSONL.
+    """
+    counts: dict[str, int] = {}
+    for parent_dir in ("sessions", "archived_sessions"):
+        target = codex_home / parent_dir
+        if not target.is_dir():
+            continue
+        for entry in target.rglob("*"):
+            if entry.is_file() and entry.suffix.lower() == ".jsonl":
+                try:
+                    lines = entry.read_text(encoding="utf-8", errors="replace").splitlines()
+                    if not lines:
+                        continue
+                    first = json.loads(lines[0])
+                    payload = first.get("payload") if isinstance(first, dict) else None
+                    provider = str(payload["model_provider"]) if isinstance(payload, dict) and "model_provider" in payload else None
+                    if provider:
+                        counts[provider] = counts.get(provider, 0) + 1
+                except (OSError, json.JSONDecodeError):
+                    continue
+    return counts
+
+
+def reconcile_history(args: argparse.Namespace) -> dict[str, Any]:
+    """Full reconciliation: scan all candidate state DBs + JSONL, report drift."""
+    codex_home = resolve_user_path(args.codex_home) or default_codex_home()
+    config_text = ""
+    config_path = codex_home / "config.toml"
+    if config_path.exists():
+        config_text = config_path.read_text(encoding="utf-8", errors="replace")
+    live_provider = parse_top_level_model_provider(config_text)
+
+    stores = scan_all_state_dbs(codex_home, config_text)
+    jsonl_providers = scan_session_jsonl_providers(codex_home)
+
+    rows: list[dict[str, Any]] = []
+    all_providers: set[str] = set()
+    for store in stores:
+        all_providers.update(store.provider_counts.keys())
+    all_providers.update(jsonl_providers.keys())
+    sorted_providers = sorted(p for p in all_providers if p)
+
+    for store in stores:
+        row: dict[str, Any] = {"path": str(store.path), "kind": store.kind, "total": store.total}
+        for provider in sorted_providers:
+            row[provider] = store.provider_counts.get(provider, 0)
+        rows.append(row)
+
+    jsonl_row: dict[str, Any] = {
+        "path": str(codex_home / "sessions"),
+        "kind": "jsonl (sessions + archived)",
+        "total": sum(jsonl_providers.values()),
+    }
+    for provider in sorted_providers:
+        jsonl_row[provider] = jsonl_providers.get(provider, 0)
+    rows.append(jsonl_row)
+
+    drift = live_provider is not None and (
+        any(
+            store.provider_counts.get(p, 0) > 0
+            for store in stores
+            for p in store.provider_counts
+            if p != live_provider
+        )
+        or any(p != live_provider for p in jsonl_providers)
+    )
+
+    return {
+        "codexHome": str(codex_home),
+        "liveConfigModelProvider": live_provider,
+        "providersFound": sorted_providers,
+        "stores": rows,
+        "driftDetected": drift,
+    }
+
+
+def table_columns(con: sqlite3.Connection, table: str) -> set[str]:
+    """读取 SQLite 表字段，用于兼容 Codex schema 演进。"""
+
+    return {row[1] for row in con.execute(f"PRAGMA table_info({table})")}
+
+
+def get_value(row: sqlite3.Row, key: str, default: Any = None) -> Any:
+    """安全读取 sqlite3.Row 字段，缺列时返回默认值。"""
+
+    return row[key] if key in row.keys() else default
+
+
+def row_title(row: sqlite3.Row) -> str:
+    """按 Codex 展示习惯从 title、preview、first_user_message 中提取标题。"""
+
+    for key in ("title", "preview", "first_user_message"):
+        value = get_value(row, key)
+        if value and str(value).strip():
+            return str(value).strip()
+    return "Untitled"
+
+
+def row_updated_ms(row: sqlite3.Row | HistoryRow) -> int:
+    """读取更新时间毫秒值，缺失时退回秒级字段。"""
+
+    if isinstance(row, HistoryRow):
+        return int(row.updated_at_ms or row.updated_at * 1000 or 0)
+    value = get_value(row, "updated_at_ms")
+    if value is not None:
+        return int(value)
+    return int(get_value(row, "updated_at", 0) or 0) * 1000
+
+
+def load_history_rows(con: sqlite3.Connection) -> list[HistoryRow]:
+    """从 threads 表读取历史记录，转换成稳定的 Python 数据结构。"""
+
+    if "threads" not in {
+        row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }:
+        raise RuntimeError("threads table not found")
+    columns = table_columns(con, "threads")
+    if not {"id", "model_provider"} <= columns:
+        raise RuntimeError("threads table missing required id/model_provider columns")
+    rows = []
+    for row in con.execute("SELECT * FROM threads"):
+        updated_ms = row_updated_ms(row)
+        rows.append(
+            HistoryRow(
+                id=str(get_value(row, "id", "")),
+                title=row_title(row),
+                cwd=get_value(row, "cwd"),
+                rollout_path=get_value(row, "rollout_path"),
+                model_provider=get_value(row, "model_provider"),
+                source=get_value(row, "source"),
+                thread_source=get_value(row, "thread_source"),
+                archived=int(get_value(row, "archived", 0) or 0),
+                has_user_event=int(get_value(row, "has_user_event", 0) or 0),
+                updated_at=int(get_value(row, "updated_at", updated_ms // 1000) or 0),
+                updated_at_ms=updated_ms,
+                preview=get_value(row, "preview"),
+                first_user_message=get_value(row, "first_user_message"),
+            )
+        )
+    return rows
+
+
+def iso_from_ms(ms: int) -> str:
+    """把 epoch milliseconds 转成 session_index.jsonl 使用的 UTC ISO 字符串。"""
+
+    return (
+        dt.datetime.fromtimestamp(ms / 1000, tz=dt.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def now_stamp() -> str:
+    """生成本地备份目录时间戳。"""
+
+    return dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """读取 JSONL；无法解析的行以 __raw_line__ 保留，避免写回时丢数据。"""
+
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            value = json.loads(line)
+            rows.append(value if isinstance(value, dict) else {"__raw_line__": line})
+        except Exception:
+            rows.append({"__raw_line__": line})
+    return rows
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    """写回 JSONL，同时保留此前无法解析的原始行。"""
+
+    lines = []
+    for row in rows:
+        raw = row.get("__raw_line__") if isinstance(row, dict) else None
+        lines.append(raw if raw is not None else json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8", newline="\n")
+
+
+def read_json_object(path: Path) -> dict[str, Any]:
+    """读取 JSON 对象；缺失或损坏时返回空对象以便继续修复其它项。"""
+
+    if not path.exists():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def write_json_object(path: Path, value: dict[str, Any]) -> None:
+    """以 UTF-8 pretty JSON 写回 Codex global state。"""
+
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8", newline="\n")
+
+
+def rollout_path(row: HistoryRow) -> Path | None:
+    """把一条历史记录的 rollout_path 转成可访问路径。"""
+
+    if not row.rollout_path:
+        return None
+    path = Path(strip_long_prefix(row.rollout_path) or "")
+    return path if path.exists() else None
+
+
+def rollout_has_user_event(path: Path | None) -> bool:
+    """扫描 rollout 是否包含真实用户消息，用于回填 has_user_event。"""
+
+    if path is None:
+        return False
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return (
+        '"type":"user_message"' in text
+        or '"role":"user"' in text
+        or '"user_input"' in text
+    )
+
+
+def rewrite_rollout_provider(path: Path, target_provider: str) -> tuple[bool, str, float]:
+    """重写 rollout 中所有 payload.model_provider，并返回是否变更、文本和旧 mtime。"""
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    old_mtime = path.stat().st_mtime
+    lines = []
+    changed = False
+    for line in text.splitlines():
+        try:
+            value = json.loads(line)
+        except Exception:
+            lines.append(line)
+            continue
+        payload = value.get("payload") if isinstance(value, dict) else None
+        if not isinstance(payload, dict) or "model_provider" not in payload:
+            lines.append(line)
+            continue
+        if payload.get("model_provider") != target_provider:
+            payload["model_provider"] = target_provider
+            changed = True
+        lines.append(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
+    return changed, "\n".join(lines) + ("\n" if text.endswith("\n") or lines else ""), old_mtime
+
+
+def is_user_thread(row: HistoryRow, include_subagents: bool) -> bool:
+    """判断 thread_source 是否属于用户主线程。"""
+
+    return include_subagents or row.thread_source in (None, "", "user")
+
+
+def source_matches(row: HistoryRow, source_filter: str | None) -> bool:
+    """判断 source 是否匹配筛选条件；未指定时使用 Codex 常规交互来源。"""
+
+    if source_filter:
+        return row.source == source_filter
+    return row.source in DEFAULT_INTERACTIVE_SOURCES
+
+
+def visible_text(row: HistoryRow) -> bool:
+    """判断一条历史记录是否有可显示文本。"""
+
+    return any((value or "").strip() for value in (row.title, row.preview, row.first_user_message))
+
+
+def filter_visible_rows(
+    rows: list[HistoryRow],
+    target_provider: str,
+    provider_update_ids: set[str],
+    include_archived: bool,
+    include_subagents: bool,
+    source_filter: str | None,
+) -> tuple[list[HistoryRow], list[str]]:
+    """计算修复后可见行，并找出需要回填 has_user_event 的行。"""
+
+    visible_rows: list[HistoryRow] = []
+    user_event_updates: list[str] = []
+    for row in rows:
+        provider_after = target_provider if row.id in provider_update_ids else row.model_provider
+        if provider_after != target_provider:
+            continue
+        if not include_archived and row.archived != 0:
+            continue
+        if not source_matches(row, source_filter):
+            continue
+        if not is_user_thread(row, include_subagents):
+            continue
+        has_user = row.has_user_event == 1 or rollout_has_user_event(rollout_path(row))
+        if row.has_user_event != 1 and has_user:
+            user_event_updates.append(row.id)
+        if has_user and visible_text(row):
+            visible_rows.append(row)
+    return visible_rows, user_event_updates
+
+
+def select_balanced_rows(
+    visible_rows: list[HistoryRow],
+    project_path: str | None,
+    focus_count: int,
+    max_per_project: int,
+    max_total: int,
+) -> list[FocusRow]:
+    """先保证当前项目数量，再按项目 round-robin 填充最近窗口。"""
+
+    sorted_rows = sorted(visible_rows, key=lambda row: (row_updated_ms(row), row.id), reverse=True)
+    selected: list[HistoryRow] = []
+    selected_ids: set[str] = set()
+    if project_path:
+        for row in sorted_rows:
+            if len(selected) >= focus_count or len(selected) >= max_total:
+                break
+            if normalize_path(row.cwd) == project_path:
+                selected.append(row)
+                selected_ids.add(row.id)
+
+    buckets: dict[str, deque[HistoryRow]] = defaultdict(deque)
+    for row in sorted_rows:
+        if row.id in selected_ids:
+            continue
+        key = normalize_path(row.cwd) or "(no cwd)"
+        if len(buckets[key]) < max_per_project:
+            buckets[key].append(row)
+
+    projects = sorted(
+        buckets.keys(),
+        key=lambda key: row_updated_ms(buckets[key][0]) if buckets[key] else 0,
+        reverse=True,
+    )
+    while len(selected) < max_total and any(buckets.values()):
+        progressed = False
+        for project in projects:
+            if len(selected) >= max_total:
+                break
+            if buckets[project]:
+                row = buckets[project].popleft()
+                if row.id not in selected_ids:
+                    selected.append(row)
+                    selected_ids.add(row.id)
+                progressed = True
+        if not progressed:
+            break
+    return [focus_from_row(row) for row in selected]
+
+
+def focus_from_row(row: HistoryRow) -> FocusRow:
+    """把历史行转换为可更新时间戳和 session_index 的 focus 行。"""
+
+    ms = row_updated_ms(row)
+    return FocusRow(
+        id=row.id,
+        title=row.title,
+        cwd=normalize_path(row.cwd),
+        rollout_path=row.rollout_path,
+        updated_at=ms // 1000,
+        updated_at_ms=ms,
+        updated_iso=iso_from_ms(ms),
+    )
+
+
+def assign_focus_times(rows: list[FocusRow]) -> None:
+    """给 focus 行分配新的递减时间戳，使其进入 Desktop 最近窗口。"""
+
+    if not rows:
+        return
+    base = max(int(time.time() * 1000), max(row.updated_at_ms for row in rows)) + 10_000
+    total = len(rows)
+    for index, row in enumerate(rows):
+        ms = base + (total - index) * 250
+        row.updated_at_ms = ms
+        row.updated_at = ms // 1000
+        row.updated_iso = iso_from_ms(ms)
+
+
+def choose_focus_rows(
+    visible_rows: list[HistoryRow],
+    session_ids: list[str],
+    project_path: str | None,
+    count: int,
+    balance_recent_window: bool,
+    max_per_project: int,
+    max_total: int,
+) -> list[FocusRow]:
+    """按 sessionIds、项目 focus 或 balanced recent window 选择待恢复会话。"""
+
+    by_id = {row.id: row for row in visible_rows}
+    if session_ids:
+        selected = [focus_from_row(by_id[thread_id]) for thread_id in session_ids if thread_id in by_id]
+        assign_focus_times(selected)
+        return selected
+    if balance_recent_window:
+        selected = select_balanced_rows(visible_rows, project_path, count, max_per_project, max_total)
+        assign_focus_times(selected)
+        return selected
+    project_rows = [
+        row for row in visible_rows if project_path and normalize_path(row.cwd) == project_path
+    ]
+    project_rows.sort(key=lambda row: (row_updated_ms(row), row.id), reverse=True)
+    selected = [focus_from_row(row) for row in project_rows[:count]]
+    assign_focus_times(selected)
+    return selected
+
+
+def backup_state(codex_home: Path, state_db: Path, backup_dir: Path, rollout_paths: list[Path]) -> None:
+    """备份 active SQLite、WAL/SHM、session_index、global state 和待写 rollout。"""
+
+    backup_dir.mkdir(parents=True, exist_ok=False)
+    db_dir = backup_dir / ("sqlite" if state_db.parent.name.lower() == "sqlite" else "legacy-root")
+    db_dir.mkdir(parents=True, exist_ok=True)
+    for suffix in ("", "-wal", "-shm"):
+        source = Path(str(state_db) + suffix)
+        if source.exists():
+            shutil.copy2(source, db_dir / source.name)
+    for name in ("session_index.jsonl", ".codex-global-state.json"):
+        source = codex_home / name
+        if source.exists():
+            shutil.copy2(source, backup_dir / name)
+    rollout_dir = backup_dir / "rollouts"
+    rollout_dir.mkdir(parents=True, exist_ok=True)
+    manifest = []
+    for index, source in enumerate(rollout_paths):
+        if source.exists():
+            target = rollout_dir / f"{index:04d}-{source.name}"
+            shutil.copy2(source, target)
+            manifest.append({"source": str(source), "backup": str(target)})
+    (backup_dir / "rollout-manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def existing_index_ids(index_path: Path) -> set[str]:
+    """读取 session_index 中已有 thread id。"""
+
+    return {row.get("id") for row in read_jsonl(index_path) if isinstance(row.get("id"), str)}
+
+
+def append_missing_index(index_path: Path, missing_rows: list[HistoryRow]) -> int:
+    """把缺失的可见会话追加到 session_index.jsonl。"""
+
+    if not missing_rows:
+        return 0
+    rows = read_jsonl(index_path)
+    ids = {row.get("id") for row in rows if isinstance(row.get("id"), str)}
+    appended = 0
+    for item in missing_rows:
+        if item.id in ids:
+            continue
+        rows.append({"id": item.id, "thread_name": item.title, "updated_at": iso_from_ms(row_updated_ms(item))})
+        ids.add(item.id)
+        appended += 1
+    write_jsonl(index_path, rows)
+    return appended
+
+
+def move_focus_index(index_path: Path, focus_rows: list[FocusRow]) -> tuple[int, int]:
+    """把选中的会话移到 session_index 尾部，并更新标题和时间。"""
+
+    if not focus_rows:
+        return 0, 0
+    rows = read_jsonl(index_path)
+    selected = {row.id: row for row in focus_rows}
+    seen: set[str] = set()
+    kept: list[dict[str, Any]] = []
+    moved_by_id: dict[str, dict[str, Any]] = {}
+    titles_updated = 0
+    for row in rows:
+        thread_id = row.get("id")
+        if isinstance(thread_id, str):
+            seen.add(thread_id)
+        if isinstance(thread_id, str) and thread_id in selected:
+            next_row = dict(row)
+            old_title = str(next_row.get("thread_name") or "").strip()
+            next_row["updated_at"] = selected[thread_id].updated_iso
+            if selected[thread_id].title.strip() and old_title != selected[thread_id].title.strip():
+                next_row["thread_name"] = selected[thread_id].title
+                titles_updated += 1
+            moved_by_id[thread_id] = next_row
+        else:
+            kept.append(row)
+    moved = []
+    for focus in focus_rows:
+        moved.append(
+            moved_by_id.get(
+                focus.id,
+                {"id": focus.id, "thread_name": focus.title, "updated_at": focus.updated_iso},
+            )
+        )
+    write_jsonl(index_path, kept + moved)
+    return len(moved), titles_updated
+
+
+def update_global_state(
+    path: Path,
+    visible_rows: list[HistoryRow],
+    focus_rows: list[FocusRow],
+    project_path: str | None,
+    apply: bool,
+) -> tuple[int, int, int]:
+    """修复 workspace hints、projectless ids 和 saved roots。"""
+
+    state = read_json_object(path)
+    hints = state.get("thread-workspace-root-hints")
+    if not isinstance(hints, dict):
+        hints = {}
+        state["thread-workspace-root-hints"] = hints
+    expected: dict[str, str] = {}
+    for row in visible_rows:
+        cwd = normalize_path(row.cwd)
+        if cwd:
+            expected[row.id] = cwd
+    for row in focus_rows:
+        cwd = project_path or row.cwd
+        if cwd:
+            expected[row.id] = cwd
+
+    hints_to_fix = sum(1 for key, value in expected.items() if hints.get(key) != value)
+    ids = set(expected.keys())
+    projectless = state.get("projectless-thread-ids")
+    projectless_remove = 0
+    if isinstance(projectless, list):
+        projectless_remove = sum(1 for item in projectless if item in ids)
+    roots_to_add = 0
+    if project_path:
+        roots = state.get("electron-saved-workspace-roots")
+        if not isinstance(roots, list) or project_path not in roots:
+            roots_to_add = 1
+
+    if not apply or not (hints_to_fix or projectless_remove or roots_to_add):
+        return hints_to_fix, projectless_remove, roots_to_add
+
+    for key, value in expected.items():
+        hints[key] = value
+    if isinstance(projectless, list):
+        state["projectless-thread-ids"] = [item for item in projectless if item not in ids]
+    if project_path:
+        roots = state.get("electron-saved-workspace-roots")
+        if not isinstance(roots, list):
+            roots = []
+        if project_path not in roots:
+            roots.append(project_path)
+        state["electron-saved-workspace-roots"] = roots
+    write_json_object(path, state)
+    return hints_to_fix, projectless_remove, roots_to_add
+
+
+def touch_rollout_mtimes(focus_rows: list[FocusRow]) -> int:
+    """把选中 rollout 的 mtime 对齐到新 updated_at_ms。"""
+
+    touched = 0
+    for row in focus_rows:
+        raw = strip_long_prefix(row.rollout_path)
+        if not raw:
+            continue
+        path = Path(raw)
+        if not path.exists():
+            continue
+        stat = path.stat()
+        os.utime(path, (stat.st_atime, row.updated_at_ms / 1000))
+        touched += 1
+    return touched
+
+
+def detect_running_codex_processes() -> list[str]:
+    """尽量检测正在运行的 Codex Desktop/app-server，写入前用于风险提示。"""
+
+    system = platform.system().lower()
+    try:
+        if system == "windows":
+            output = subprocess.check_output(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -and ($_.CommandLine -like '*OpenAI.Codex*' -or $_.CommandLine -like '*\\codex.exe*app-server*' -or $_.CommandLine -like '*\\Codex.exe*') } | Select-Object -First 8 | ForEach-Object { \"$($_.ProcessId) $($_.Name)\" }",
+                ],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            output = subprocess.check_output(["ps", "-eo", "pid=,comm=,args="], text=True)
+    except Exception:
+        return []
+    lines = []
+    for line in output.splitlines():
+        lower = line.lower()
+        if "codex" in lower and ("app-server" in lower or "openai.codex" in lower or "codex.exe" in lower):
+            lines.append(line.strip())
+    return lines[:8]
+
+
+def repair_history(args: argparse.Namespace) -> dict[str, Any]:
+    """执行或预览完整历史可见性修复。"""
+
+    codex_home = resolve_user_path(args.codex_home) or default_codex_home()
+    config_text = (codex_home / "config.toml").read_text(encoding="utf-8", errors="replace") if (codex_home / "config.toml").exists() else ""
+    live_provider = parse_top_level_model_provider(config_text)
+    target_provider = args.target_provider or live_provider or DEFAULT_TARGET_PROVIDER
+    source_providers = set(args.source_provider or DEFAULT_SOURCE_PROVIDERS)
+    source_providers.discard(target_provider)
+    active_db = resolve_active_state_db(codex_home, config_text, args.state_db)
+
+    if args.apply and not args.force:
+        running = detect_running_codex_processes()
+        if running:
+            raise RuntimeError("Codex Desktop/app-server is running; close it first or pass --force. " + "; ".join(running))
+
+    con = sqlite3.connect(active_db.path)
+    con.row_factory = sqlite3.Row
+    rows = load_history_rows(con)
+    provider_update_ids = {
+        row.id for row in rows if row.model_provider in source_providers and not args.skip_provider_bucket_sync
+    }
+    visible_rows, user_event_update_ids = filter_visible_rows(
+        rows,
+        target_provider,
+        provider_update_ids,
+        args.include_archived,
+        args.include_subagents,
+        args.source_filter,
+    )
+    session_ids = [item for value in args.session_id for item in value.split(",") if item.strip()]
+    session_ids = [item.strip() for item in session_ids]
+    project_path = normalize_path(args.project_path)
+    focus_rows = choose_focus_rows(
+        visible_rows,
+        session_ids,
+        project_path,
+        args.count,
+        args.balance_recent_window,
+        args.max_per_project,
+        args.max_total,
+    )
+    index_path = codex_home / "session_index.jsonl"
+    global_state_path = codex_home / ".codex-global-state.json"
+    existing_ids = existing_index_ids(index_path)
+    missing_index_rows = [row for row in visible_rows if row.id not in existing_ids]
+    hints_fix, projectless_remove, roots_add = update_global_state(
+        global_state_path, visible_rows, focus_rows, project_path, apply=False
+    )
+    rollout_updates: list[tuple[Path, str, float]] = []
+    for row in rows:
+        if row.id not in provider_update_ids:
+            continue
+        path = rollout_path(row)
+        if path is None:
+            continue
+        changed, text, old_mtime = rewrite_rollout_provider(path, target_provider)
+        if changed:
+            rollout_updates.append((path, text, old_mtime))
+
+    outcome = {
+        "dryRun": not args.apply,
+        "codexHome": str(codex_home),
+        "stateDbPath": str(active_db.path),
+        "activeDbKind": active_db.kind,
+        "liveConfigModelProvider": live_provider,
+        "targetProvider": target_provider,
+        "sourceProviderIds": sorted(source_providers),
+        "sqliteThreads": len(rows),
+        "providerRowsToUpdate": len(provider_update_ids),
+        "providerRowsUpdated": 0,
+        "rolloutProviderLinesToUpdate": len(rollout_updates),
+        "rolloutProviderLinesUpdated": 0,
+        "userEventRowsToUpdate": len(user_event_update_ids),
+        "userEventRowsUpdated": 0,
+        "visibleCandidateRows": len(visible_rows),
+        "sessionIndexMissingToAppend": len(missing_index_rows),
+        "sessionIndexAppended": 0,
+        "selectedSessionIds": session_ids,
+        "focusSelectedCount": len(focus_rows),
+        "balancedRecentWindowEnabled": args.balance_recent_window,
+        "balancedRecentWindowRows": len(focus_rows) if args.balance_recent_window and not session_ids else 0,
+        "maxPerProject": args.max_per_project,
+        "maxTotal": args.max_total,
+        "sourceFilter": args.source_filter,
+        "workspaceHintsToFix": hints_fix,
+        "workspaceHintsFixed": 0,
+        "projectlessIdsToRemove": projectless_remove,
+        "projectlessIdsRemoved": 0,
+        "savedWorkspaceRootsToAdd": roots_add,
+        "savedWorkspaceRootsAdded": 0,
+        "rolloutMtimesToTouch": len([row for row in focus_rows if row.rollout_path]),
+        "rolloutMtimesTouched": 0,
+        "backupDir": None,
+    }
+    if not args.apply:
+        con.close()
+        return outcome
+
+    backup_dir = codex_home / "backups_state" / f"codex-history-tool-{now_stamp()}"
+    rollout_paths = [path for path, _, _ in rollout_updates]
+    rollout_paths.extend(Path(strip_long_prefix(row.rollout_path) or "") for row in focus_rows if row.rollout_path)
+    backup_state(codex_home, active_db.path, backup_dir, [path for path in rollout_paths if path.exists()])
+    with con:
+        if provider_update_ids:
+            placeholders = ",".join("?" for _ in provider_update_ids)
+            outcome["providerRowsUpdated"] = con.execute(
+                f"UPDATE threads SET model_provider = ? WHERE id IN ({placeholders})",
+                [target_provider, *provider_update_ids],
+            ).rowcount
+        if user_event_update_ids:
+            placeholders = ",".join("?" for _ in user_event_update_ids)
+            outcome["userEventRowsUpdated"] = con.execute(
+                f"UPDATE threads SET has_user_event = 1 WHERE id IN ({placeholders})",
+                user_event_update_ids,
+            ).rowcount
+        for row in focus_rows:
+            con.execute(
+                "UPDATE threads SET updated_at = ?, updated_at_ms = ? WHERE id = ?",
+                (row.updated_at, row.updated_at_ms, row.id),
+            )
+    con.close()
+
+    updated_rollouts = 0
+    for path, text, old_mtime in rollout_updates:
+        path.write_text(text, encoding="utf-8", newline="\n")
+        os.utime(path, (old_mtime, old_mtime))
+        updated_rollouts += 1
+    outcome["rolloutProviderLinesUpdated"] = updated_rollouts
+    outcome["sessionIndexAppended"] = append_missing_index(index_path, missing_index_rows)
+    moved, titles = move_focus_index(index_path, focus_rows)
+    outcome["sessionIndexRowsMoved"] = moved
+    outcome["sessionIndexTitlesUpdated"] = titles
+    hints_fixed, projectless_removed, roots_added = update_global_state(
+        global_state_path, visible_rows, focus_rows, project_path, apply=True
+    )
+    outcome["workspaceHintsFixed"] = hints_fixed
+    outcome["projectlessIdsRemoved"] = projectless_removed
+    outcome["savedWorkspaceRootsAdded"] = roots_added
+    if args.sync_rollout_mtime:
+        outcome["rolloutMtimesTouched"] = touch_rollout_mtimes(focus_rows)
+    outcome["backupDir"] = str(backup_dir)
+    return outcome
+
+
+def list_history(args: argparse.Namespace) -> dict[str, Any]:
+    """列出 Codex 历史记录，供 UI 或人工选择 session 后定向修复。"""
+
+    codex_home = resolve_user_path(args.codex_home) or default_codex_home()
+    config_text = (codex_home / "config.toml").read_text(encoding="utf-8", errors="replace") if (codex_home / "config.toml").exists() else ""
+    active_db = resolve_active_state_db(codex_home, config_text, args.state_db)
+    con = sqlite3.connect(active_db.path)
+    con.row_factory = sqlite3.Row
+    rows = load_history_rows(con)
+    con.close()
+
+    project = normalize_path(args.project_path)
+    filtered = []
+    for row in rows:
+        if not args.include_archived and row.archived != 0:
+            continue
+        if not args.include_subagents and not is_user_thread(row, False):
+            continue
+        if args.source_filter and row.source != args.source_filter:
+            continue
+        if args.provider and row.model_provider != args.provider:
+            continue
+        if project and normalize_path(row.cwd) != project:
+            continue
+        if args.query:
+            query = args.query.lower()
+            haystack = " ".join([row.id, row.title, row.cwd or "", row.model_provider or ""]).lower()
+            if query not in haystack:
+                continue
+        filtered.append(row)
+    filtered.sort(key=lambda row: (row.updated_at_ms, row.id), reverse=True)
+    limited = filtered[: args.limit]
+    return {
+        "codexHome": str(codex_home),
+        "stateDbPath": str(active_db.path),
+        "activeDbKind": active_db.kind,
+        "totalMatched": len(filtered),
+        "items": [
+            {
+                "id": row.id,
+                "title": row.title,
+                "cwd": normalize_path(row.cwd),
+                "modelProvider": row.model_provider,
+                "source": row.source,
+                "threadSource": row.thread_source,
+                "archived": bool(row.archived),
+                "hasUserEvent": bool(row.has_user_event),
+                "updatedAtMs": row.updated_at_ms,
+                "updatedAt": iso_from_ms(row.updated_at_ms) if row.updated_at_ms else None,
+                "rolloutPath": strip_long_prefix(row.rollout_path),
+            }
+            for row in limited
+        ],
+    }
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    """注册 list 和 repair 共用的 Codex 路径参数。"""
+
+    parser.add_argument("--codex-home", default=str(default_codex_home()), help="Codex home directory")
+    parser.add_argument("--state-db", default="", help="Explicit state_5.sqlite path")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """构建命令行解析器。"""
+
+    parser = argparse.ArgumentParser(description="Repair and inspect Codex Desktop history visibility")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {VERSION}")
+    parser.add_argument("--json", action="store_true", help="Print JSON output")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List Codex history sessions")
+    add_common_args(list_parser)
+    list_parser.add_argument("--project-path", default="")
+    list_parser.add_argument("--provider", default="")
+    list_parser.add_argument("--source-filter", default="")
+    list_parser.add_argument("--query", default="")
+    list_parser.add_argument("--limit", type=int, default=80)
+    list_parser.add_argument("--include-archived", action="store_true")
+    list_parser.add_argument("--include-subagents", action="store_true")
+    list_parser.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
+
+    repair_parser = subparsers.add_parser("repair", help="Preview or apply history visibility repair")
+    add_common_args(repair_parser)
+    repair_parser.add_argument("--apply", action="store_true")
+    repair_parser.add_argument("--force", action="store_true")
+    repair_parser.add_argument("--project-path", default="")
+    repair_parser.add_argument("--session-id", action="append", default=[])
+    repair_parser.add_argument("--target-provider", default="")
+    repair_parser.add_argument("--source-provider", action="append")
+    repair_parser.add_argument("--count", type=int, default=30)
+    repair_parser.add_argument("--window-limit", type=int, default=80)
+    repair_parser.add_argument("--balance-recent-window", dest="balance_recent_window", action="store_true", default=True)
+    repair_parser.add_argument("--no-balance-recent-window", dest="balance_recent_window", action="store_false")
+    repair_parser.add_argument("--max-per-project", type=int, default=10)
+    repair_parser.add_argument("--max-total", type=int, default=300)
+    repair_parser.add_argument("--source-filter", default="vscode")
+    repair_parser.add_argument("--include-archived", action="store_true")
+    repair_parser.add_argument("--include-subagents", action="store_true")
+    repair_parser.add_argument("--skip-provider-bucket-sync", action="store_true")
+    repair_parser.add_argument("--sync-rollout-mtime", dest="sync_rollout_mtime", action="store_true", default=True)
+    repair_parser.add_argument("--no-sync-rollout-mtime", dest="sync_rollout_mtime", action="store_false")
+    repair_parser.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
+    reconcile_parser = subparsers.add_parser("reconcile", help="Scan all state DBs + JSONL and show per-store provider drift table")
+    add_common_args(reconcile_parser)
+    reconcile_parser.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+def print_human(payload: dict[str, Any]) -> None:
+    """打印便于 PowerShell/终端阅读的摘要，同时避免输出完整会话内容。"""
+
+    if "stores" in payload:
+        # reconciliation 输出：per-store 漂移表
+        print(f"codexHome={payload['codexHome']}")
+        print(f"liveConfigModelProvider={payload.get('liveConfigModelProvider', 'N/A')}")
+        print(f"driftDetected={payload.get('driftDetected', False)}")
+        print()
+        print("--- Store Reconciliation Table ---")
+        providers = payload.get("providersFound", [])
+        header = f"{'Store':<55} {'Kind':<24} {'Total':>8}"
+        for p in providers:
+            header += f" {p:>10}"
+        print(header)
+        print("-" * len(header))
+        for store in payload.get("stores", []):
+            path_str = str(store.get("path", ""))
+            if len(path_str) > 50:
+                path_str = "..." + path_str[-47:]
+            row_line = f"{path_str:<55} {store.get('kind', ''):<24} {store.get('total', 0):>8}"
+            for p in providers:
+                row_line += f" {store.get(p, 0):>10}"
+            print(row_line)
+        print()
+        return
+    if "items" in payload:
+        print(f"codex_home={payload['codexHome']}")
+        print(f"state_db={payload['stateDbPath']} ({payload['activeDbKind']})")
+        print(f"total_matched={payload['totalMatched']}")
+        for item in payload["items"]:
+            title = (item["title"] or "").replace("\n", " ")[:80]
+            print(f"{item['updatedAt'] or '-'}  {item['id']}  {item['modelProvider']}  {item['cwd']}  {title}")
+        return
+    for key, value in payload.items():
+        if isinstance(value, (dict, list)):
+            print(f"{key}={json.dumps(value, ensure_ascii=False)}")
+        else:
+            print(f"{key}={value}")
+
+
+def main() -> int:
+    """CLI 入口，所有输出均支持机器可读 JSON。"""
+
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        if args.command == "list":
+            payload = list_history(args)
+        elif args.command == "reconcile":
+            payload = reconcile_history(args)
+        else:
+            payload = repair_history(args)
+    except Exception as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        else:
+            print(f"error={exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print_human(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -1,7 +1,7 @@
-//! Codex 第三方历史会话归桶迁移。
+﻿//! Codex 绗笁鏂瑰巻鍙蹭細璇濆綊妗惰縼绉汇€?
 //!
-//! 只迁移本机 `~/.codex` 历史数据；完成标记写入设备级 `settings.json`，
-//! 失败时不写标记，下一次启动自动重试。
+//! 鍙縼绉绘湰鏈?`~/.codex` 鍘嗗彶鏁版嵁锛涘畬鎴愭爣璁板啓鍏ヨ澶囩骇 `settings.json`锛?
+//! 澶辫触鏃朵笉鍐欐爣璁帮紝涓嬩竴娆″惎鍔ㄨ嚜鍔ㄩ噸璇曘€?
 
 use crate::codex_config::{
     get_codex_config_dir, read_codex_config_text, CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
@@ -26,14 +26,14 @@ use toml_edit::DocumentMut;
 
 const MIGRATION_NAME: &str = "codex-history-provider-migration-v1";
 const OFFICIAL_UNIFY_MIGRATION_NAME: &str = "codex-official-history-unify-v1";
-/// 还原操作自身的备份目录（与迁移备份分开，保持迁移账本目录纯净）。
+/// 杩樺師鎿嶄綔鑷韩鐨勫浠界洰褰曪紙涓庤縼绉诲浠藉垎寮€锛屼繚鎸佽縼绉昏处鏈洰褰曠函鍑€锛夈€?
 const OFFICIAL_UNIFY_RESTORE_BACKUP_NAME: &str = "codex-official-history-unify-restore-v1";
 const CODEX_STATE_DB_FILENAME: &str = "state_5.sqlite";
-/// SQLite 变量上限保守值，IN 列表按此分块。
+/// SQLite 鍙橀噺涓婇檺淇濆畧鍊硷紝IN 鍒楄〃鎸夋鍒嗗潡銆?
 const STATE_DB_ID_CHUNK: usize = 500;
 
-/// 串行化官方历史的迁移与还原：开启迁移（启动重试 + 设置保存后台任务）和
-/// 关闭还原可能在毫秒级先后被触发，对同一批 jsonl / state DB 双向改写。
+/// 涓茶鍖栧畼鏂瑰巻鍙茬殑杩佺Щ涓庤繕鍘燂細寮€鍚縼绉伙紙鍚姩閲嶈瘯 + 璁剧疆淇濆瓨鍚庡彴浠诲姟锛夊拰
+/// 鍏抽棴杩樺師鍙兘鍦ㄦ绉掔骇鍏堝悗琚Е鍙戯紝瀵瑰悓涓€鎵?jsonl / state DB 鍙屽悜鏀瑰啓銆?
 static CODEX_OFFICIAL_HISTORY_OP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn lock_codex_official_history_op() -> std::sync::MutexGuard<'static, ()> {
@@ -41,8 +41,8 @@ fn lock_codex_official_history_op() -> std::sync::MutexGuard<'static, ()> {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
-/// Codex 内建默认 provider id：config.toml 没有 `model_provider` 键时会话归入此桶。
-/// 官方订阅（ChatGPT OAuth / OpenAI API key）的历史会话都记录这个 id。
+/// Codex 鍐呭缓榛樿 provider id锛歝onfig.toml 娌℃湁 `model_provider` 閿椂浼氳瘽褰掑叆姝ゆ《銆?
+/// 瀹樻柟璁㈤槄锛圕hatGPT OAuth / OpenAI API key锛夌殑鍘嗗彶浼氳瘽閮借褰曡繖涓?id銆?
 const OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID: &str = "openai";
 const LEGACY_CC_SWITCH_CODEX_MODEL_PROVIDER_ID: &str = "ccswitch";
 // If a Codex preset ever used a temporary routing key, keep that old key here
@@ -186,14 +186,14 @@ pub fn maybe_migrate_codex_provider_template_bucket(
     Ok(outcome)
 }
 
-/// 统一会话开关的存量迁移：把官方会话（内建 "openai" 桶）迁入共享 "custom" 桶。
+/// 缁熶竴浼氳瘽寮€鍏崇殑瀛橀噺杩佺Щ锛氭妸瀹樻柟浼氳瘽锛堝唴寤?"openai" 妗讹級杩佸叆鍏变韩 "custom" 妗躲€?
 ///
-/// 仅当用户在开启弹窗里勾选了"迁入既有官方会话"（`unify_codex_migrate_existing`）
-/// 且本轮未完成时执行；开关关闭时标记与勾选意愿都会被清除（见 `save_settings`），
-/// 重新开启并再次勾选即可补迁关闭期间产生的官方会话。
-/// custom 桶里官方与第三方会话无法区分，自动逻辑绝不反向搬回；
-/// 用户可在关闭开关时选择按备份账本精确还原（见 `restore_codex_official_history_from_backups`）。
-/// 迁移前 jsonl / state DB 均备份到 `~/.cc-switch/backups/codex-official-history-unify-v1/`。
+/// 浠呭綋鐢ㄦ埛鍦ㄥ紑鍚脊绐楅噷鍕鹃€変簡"杩佸叆鏃㈡湁瀹樻柟浼氳瘽"锛坄unify_codex_migrate_existing`锛?
+/// 涓旀湰杞湭瀹屾垚鏃舵墽琛岋紱寮€鍏冲叧闂椂鏍囪涓庡嬀閫夋剰鎰块兘浼氳娓呴櫎锛堣 `save_settings`锛夛紝
+/// 閲嶆柊寮€鍚苟鍐嶆鍕鹃€夊嵆鍙ˉ杩佸叧闂湡闂翠骇鐢熺殑瀹樻柟浼氳瘽銆?
+/// custom 妗堕噷瀹樻柟涓庣涓夋柟浼氳瘽鏃犳硶鍖哄垎锛岃嚜鍔ㄩ€昏緫缁濅笉鍙嶅悜鎼洖锛?
+/// 鐢ㄦ埛鍙湪鍏抽棴寮€鍏虫椂閫夋嫨鎸夊浠借处鏈簿纭繕鍘燂紙瑙?`restore_codex_official_history_from_backups`锛夈€?
+/// 杩佺Щ鍓?jsonl / state DB 鍧囧浠藉埌 `~/.cc-switch/backups/codex-official-history-unify-v1/`銆?
 pub fn maybe_migrate_codex_official_history_to_unified_bucket(
 ) -> Result<CodexHistoryProviderBucketMigrationOutcome, AppError> {
     if !crate::settings::unify_codex_session_history() {
@@ -210,8 +210,8 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
     }
     let _op_guard = lock_codex_official_history_op();
     let codex_dir = get_codex_config_dir();
-    // marker 绑定迁移时的 Codex 目录：切换 codex_config_dir 后旧 marker 不再
-    // 挡住新目录的迁移（迁移幂等，重跑无害）。
+    // marker 缁戝畾杩佺Щ鏃剁殑 Codex 鐩綍锛氬垏鎹?codex_config_dir 鍚庢棫 marker 涓嶅啀
+    // 鎸′綇鏂扮洰褰曠殑杩佺Щ锛堣縼绉诲箓绛夛紝閲嶈窇鏃犲锛夈€?
     let codex_dir_key = canonical_dir_string(&codex_dir);
     if crate::settings::is_codex_official_history_unify_migrated_for_dir(&codex_dir_key) {
         return Ok(CodexHistoryProviderBucketMigrationOutcome {
@@ -219,12 +219,12 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
             ..Default::default()
         });
     }
-    // live 必须已实际路由到共享 custom 桶才允许迁移：官方配置的注入可能被拒
-    // （已有显式 model_provider / 形态冲突的 custom 表，见
-    // `inject_codex_unified_session_bucket`），代理接管期间的 live 也不带统一
-    // 路由（注入只进备份）。这些状态下新会话仍落 "openai" 桶，迁移只会把
-    // 历史搬进当前 live 看不见的桶里。开关与迁移意愿保持不动，待 live 真正
-    // 统一后（下次切换 / 接管释放后的启动重试）再迁。
+    // live 蹇呴』宸插疄闄呰矾鐢卞埌鍏变韩 custom 妗舵墠鍏佽杩佺Щ锛氬畼鏂归厤缃殑娉ㄥ叆鍙兘琚嫆
+    // 锛堝凡鏈夋樉寮?model_provider / 褰㈡€佸啿绐佺殑 custom 琛紝瑙?
+    // `inject_codex_unified_session_bucket`锛夛紝浠ｇ悊鎺ョ鏈熼棿鐨?live 涔熶笉甯︾粺涓€
+    // 璺敱锛堟敞鍏ュ彧杩涘浠斤級銆傝繖浜涚姸鎬佷笅鏂颁細璇濅粛钀?"openai" 妗讹紝杩佺Щ鍙細鎶?
+    // 鍘嗗彶鎼繘褰撳墠 live 鐪嬩笉瑙佺殑妗堕噷銆傚紑鍏充笌杩佺Щ鎰忔効淇濇寔涓嶅姩锛屽緟 live 鐪熸
+    // 缁熶竴鍚庯紙涓嬫鍒囨崲 / 鎺ョ閲婃斁鍚庣殑鍚姩閲嶈瘯锛夊啀杩併€?
     if !codex_config_text_routes_custom(&read_codex_config_text().unwrap_or_default()) {
         return Ok(CodexHistoryProviderBucketMigrationOutcome {
             skipped_reason: Some("live_not_unified".to_string()),
@@ -239,7 +239,7 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
         migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root)?;
     let migrated_state_rows =
         migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root)?;
-    // 备份代际记录来源目录，restore 据此只取当前目录的账本。
+    // 澶囦唤浠ｉ檯璁板綍鏉ユ簮鐩綍锛宺estore 鎹鍙彇褰撳墠鐩綍鐨勮处鏈€?
     write_backup_generation_meta(&backup_root, &codex_dir_key)?;
 
     let outcome = CodexHistoryProviderBucketMigrationOutcome {
@@ -249,9 +249,9 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
         skipped_reason: None,
     };
 
-    // 条件写入在 settings 写锁内原子完成："迁移期间开关被关掉"时不写完成标记，
-    // 避免下一次开启被标记挡住而漏迁"关闭期间"新产生的 openai 桶会话。
-    // 与关闭路径（update_settings + 清标记）共用同一把锁，无检查-写入窗口。
+    // 鏉′欢鍐欏叆鍦?settings 鍐欓攣鍐呭師瀛愬畬鎴愶細"杩佺Щ鏈熼棿寮€鍏宠鍏虫帀"鏃朵笉鍐欏畬鎴愭爣璁帮紝
+    // 閬垮厤涓嬩竴娆″紑鍚鏍囪鎸′綇鑰屾紡杩?鍏抽棴鏈熼棿"鏂颁骇鐢熺殑 openai 妗朵細璇濄€?
+    // 涓庡叧闂矾寰勶紙update_settings + 娓呮爣璁帮級鍏辩敤鍚屼竴鎶婇攣锛屾棤妫€鏌?鍐欏叆绐楀彛銆?
     let marker_written = crate::settings::mark_codex_official_history_unify_migrated_if_enabled(
         CodexOfficialHistoryUnifyMigration {
             completed_at: Utc::now().to_rfc3339(),
@@ -271,8 +271,8 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
     Ok(outcome)
 }
 
-/// live config.toml 是否路由到共享 custom 桶（会话分桶只看这个实态：
-/// base_url / 接管与否都不影响 session_meta 记录的 model_provider）。
+/// live config.toml 鏄惁璺敱鍒板叡浜?custom 妗讹紙浼氳瘽鍒嗘《鍙湅杩欎釜瀹炴€侊細
+/// base_url / 鎺ョ涓庡惁閮戒笉褰卞搷 session_meta 璁板綍鐨?model_provider锛夈€?
 fn codex_config_text_routes_custom(config_text: &str) -> bool {
     config_text
         .parse::<DocumentMut>()
@@ -285,8 +285,8 @@ fn codex_config_text_routes_custom(config_text: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// 目录的规范化字符串形式，用作 marker / 备份代际的目录身份。
-/// canonicalize 失败（目录尚不存在等）时退回原始路径字符串。
+/// 鐩綍鐨勮鑼冨寲瀛楃涓插舰寮忥紝鐢ㄤ綔 marker / 澶囦唤浠ｉ檯鐨勭洰褰曡韩浠姐€?
+/// canonicalize 澶辫触锛堢洰褰曞皻涓嶅瓨鍦ㄧ瓑锛夋椂閫€鍥炲師濮嬭矾寰勫瓧绗︿覆銆?
 fn canonical_dir_string(dir: &Path) -> String {
     fs::canonicalize(dir)
         .unwrap_or_else(|_| dir.to_path_buf())
@@ -294,8 +294,8 @@ fn canonical_dir_string(dir: &Path) -> String {
         .to_string()
 }
 
-/// 在备份代际根目录写入 meta.json，记录这批备份来自哪个 Codex 目录。
-/// 代际目录不存在（本轮没有任何文件被迁移）时跳过。
+/// 鍦ㄥ浠戒唬闄呮牴鐩綍鍐欏叆 meta.json锛岃褰曡繖鎵瑰浠芥潵鑷摢涓?Codex 鐩綍銆?
+/// 浠ｉ檯鐩綍涓嶅瓨鍦紙鏈疆娌℃湁浠讳綍鏂囦欢琚縼绉伙級鏃惰烦杩囥€?
 fn write_backup_generation_meta(backup_root: &Path, codex_dir_key: &str) -> Result<(), AppError> {
     if !backup_root.exists() {
         return Ok(());
@@ -313,17 +313,17 @@ pub struct CodexOfficialHistoryRestoreOutcome {
     pub skipped_reason: Option<String>,
 }
 
-/// 统一会话开关迁移备份的父目录（其下每次迁移一个时间戳代际目录）。
+/// 缁熶竴浼氳瘽寮€鍏宠縼绉诲浠界殑鐖剁洰褰曪紙鍏朵笅姣忔杩佺Щ涓€涓椂闂存埑浠ｉ檯鐩綍锛夈€?
 fn official_history_unify_backup_parent() -> PathBuf {
     get_app_config_dir()
         .join("backups")
         .join(OFFICIAL_UNIFY_MIGRATION_NAME)
 }
 
-/// 是否存在可用于还原的迁移备份（给前端决定要不要显示"恢复备份"勾选）。
-/// 与 restore 的账本收集共用同一目录匹配口径：只认属于当前 Codex 目录的
-/// 代际，避免切换 codex_config_dir 后弹出注定空跑的勾选。
-/// 精确账本内容仍在真正还原时才解析。
+/// 鏄惁瀛樺湪鍙敤浜庤繕鍘熺殑杩佺Щ澶囦唤锛堢粰鍓嶇鍐冲畾瑕佷笉瑕佹樉绀?鎭㈠澶囦唤"鍕鹃€夛級銆?
+/// 涓?restore 鐨勮处鏈敹闆嗗叡鐢ㄥ悓涓€鐩綍鍖归厤鍙ｅ緞锛氬彧璁ゅ睘浜庡綋鍓?Codex 鐩綍鐨?
+/// 浠ｉ檯锛岄伩鍏嶅垏鎹?codex_config_dir 鍚庡脊鍑烘敞瀹氱┖璺戠殑鍕鹃€夈€?
+/// 绮剧‘璐︽湰鍐呭浠嶅湪鐪熸杩樺師鏃舵墠瑙ｆ瀽銆?
 pub fn has_codex_official_history_unify_backup() -> bool {
     has_official_history_unify_backup_for_dir(
         &official_history_unify_backup_parent(),
@@ -341,21 +341,21 @@ fn has_official_history_unify_backup_for_dir(ledger_parent: &Path, codex_dir_key
     })
 }
 
-/// 关闭统一会话开关时的可选还原：按迁移备份账本，把当时迁入共享 custom 桶的
-/// 官方会话精确翻回 "openai" 桶。
+/// 鍏抽棴缁熶竴浼氳瘽寮€鍏虫椂鐨勫彲閫夎繕鍘燂細鎸夎縼绉诲浠借处鏈紝鎶婂綋鏃惰縼鍏ュ叡浜?custom 妗剁殑
+/// 瀹樻柟浼氳瘽绮剧‘缈诲洖 "openai" 妗躲€?
 ///
-/// 备份是唯一可信的归属证据：备份里 model_provider=="openai" 的会话必定源自
-/// 官方桶。开启期间新产生的会话不在任何备份里，**永不触碰**——它们可能来自
-/// 第三方，方向无法判定（产品决策：宁可留在第三方历史）。
-/// 扫描全部备份代际取并集，多次开关循环后仍能还原早期迁入的会话；
-/// 还原前改动目标先备份到独立的 restore 目录（保持迁移账本目录纯净），
-/// 且只改写当前仍为 custom 的目标，重复执行无害。
+/// 澶囦唤鏄敮涓€鍙俊鐨勫綊灞炶瘉鎹細澶囦唤閲?model_provider=="openai" 鐨勪細璇濆繀瀹氭簮鑷?
+/// 瀹樻柟妗躲€傚紑鍚湡闂存柊浜х敓鐨勪細璇濅笉鍦ㄤ换浣曞浠介噷锛?*姘镐笉瑙︾**鈥斺€斿畠浠彲鑳芥潵鑷?
+/// 绗笁鏂癸紝鏂瑰悜鏃犳硶鍒ゅ畾锛堜骇鍝佸喅绛栵細瀹佸彲鐣欏湪绗笁鏂瑰巻鍙诧級銆?
+/// 鎵弿鍏ㄩ儴澶囦唤浠ｉ檯鍙栧苟闆嗭紝澶氭寮€鍏冲惊鐜悗浠嶈兘杩樺師鏃╂湡杩佸叆鐨勪細璇濓紱
+/// 杩樺師鍓嶆敼鍔ㄧ洰鏍囧厛澶囦唤鍒扮嫭绔嬬殑 restore 鐩綍锛堜繚鎸佽縼绉昏处鏈洰褰曠函鍑€锛夛紝
+/// 涓斿彧鏀瑰啓褰撳墠浠嶄负 custom 鐨勭洰鏍囷紝閲嶅鎵ц鏃犲銆?
 pub fn restore_codex_official_history_from_backups(
 ) -> Result<CodexOfficialHistoryRestoreOutcome, AppError> {
     let _op_guard = lock_codex_official_history_op();
-    // 开关已（重新）开启时拒绝还原：live 正路由 custom，把账本会话翻回
-    // openai 桶等于亲手制造分裂。覆盖"关闭保存成功后用户立刻重新开启，
-    // 还原排在重开迁移之后才拿到 op lock"的时序。
+    // 寮€鍏冲凡锛堥噸鏂帮級寮€鍚椂鎷掔粷杩樺師锛歭ive 姝ｈ矾鐢?custom锛屾妸璐︽湰浼氳瘽缈诲洖
+    // openai 妗剁瓑浜庝翰鎵嬪埗閫犲垎瑁傘€傝鐩?鍏抽棴淇濆瓨鎴愬姛鍚庣敤鎴风珛鍒婚噸鏂板紑鍚紝
+    // 杩樺師鎺掑湪閲嶅紑杩佺Щ涔嬪悗鎵嶆嬁鍒?op lock"鐨勬椂搴忋€?
     if crate::settings::unify_codex_session_history() {
         return Ok(CodexOfficialHistoryRestoreOutcome {
             skipped_reason: Some("unify_toggle_on".to_string()),
@@ -410,8 +410,8 @@ fn restore_codex_official_history_inner(
     }
 
     if restored_jsonl_files == 0 && restored_state_rows == 0 {
-        // 账本非空但没有任何"当前仍为 custom"的目标（如重复还原）：
-        // 以 reason 告知前端，避免误报"已还原 0 项"为成功。
+        // 璐︽湰闈炵┖浣嗘病鏈変换浣?褰撳墠浠嶄负 custom"鐨勭洰鏍囷紙濡傞噸澶嶈繕鍘燂級锛?
+        // 浠?reason 鍛婄煡鍓嶇锛岄伩鍏嶈鎶?宸茶繕鍘?0 椤?涓烘垚鍔熴€?
         return Ok(CodexOfficialHistoryRestoreOutcome {
             skipped_reason: Some("nothing_to_restore".to_string()),
             ..Default::default()
@@ -425,12 +425,12 @@ fn restore_codex_official_history_inner(
     })
 }
 
-/// 从备份代际收集官方会话账本：jsonl 备份里 session_meta 为 "openai" 的
-/// 会话 id + state DB 备份里 model_provider 为 "openai" 的 thread id。
-/// 只采纳 meta.json 目录与当前 Codex 目录一致的代际，避免切换
-/// codex_config_dir 后拿旧目录的账本作用到新目录。
-/// 还原操作自身的备份（restore 目录）天然不会混入：那些副本里的 id 都是
-/// custom，解析后贡献为空。
+/// 浠庡浠戒唬闄呮敹闆嗗畼鏂逛細璇濊处鏈細jsonl 澶囦唤閲?session_meta 涓?"openai" 鐨?
+/// 浼氳瘽 id + state DB 澶囦唤閲?model_provider 涓?"openai" 鐨?thread id銆?
+/// 鍙噰绾?meta.json 鐩綍涓庡綋鍓?Codex 鐩綍涓€鑷寸殑浠ｉ檯锛岄伩鍏嶅垏鎹?
+/// codex_config_dir 鍚庢嬁鏃х洰褰曠殑璐︽湰浣滅敤鍒版柊鐩綍銆?
+/// 杩樺師鎿嶄綔鑷韩鐨勫浠斤紙restore 鐩綍锛夊ぉ鐒朵笉浼氭贩鍏ワ細閭ｄ簺鍓湰閲岀殑 id 閮芥槸
+/// custom锛岃В鏋愬悗璐＄尞涓虹┖銆?
 fn collect_official_ledger(
     ledger_parent: &Path,
     codex_dir_key: &str,
@@ -463,9 +463,9 @@ fn collect_official_ledger(
     Ok((session_ids, thread_ids))
 }
 
-/// 备份代际是否属于指定 Codex 目录。无 meta.json 或解析失败时宽容接受：
-/// 早期版本的备份没有 meta，而那个时期不存在切目录场景；误纳的代价也被
-/// "按会话 id 精确匹配 + 仅改写 custom"双重条件兜底。
+/// 澶囦唤浠ｉ檯鏄惁灞炰簬鎸囧畾 Codex 鐩綍銆傛棤 meta.json 鎴栬В鏋愬け璐ユ椂瀹藉鎺ュ彈锛?
+/// 鏃╂湡鐗堟湰鐨勫浠芥病鏈?meta锛岃€岄偅涓椂鏈熶笉瀛樺湪鍒囩洰褰曞満鏅紱璇撼鐨勪唬浠蜂篃琚?
+/// "鎸変細璇?id 绮剧‘鍖归厤 + 浠呮敼鍐?custom"鍙岄噸鏉′欢鍏滃簳銆?
 fn backup_generation_matches_dir(generation: &Path, codex_dir_key: &str) -> bool {
     let Ok(text) = fs::read_to_string(generation.join("meta.json")) else {
         return true;
@@ -600,9 +600,9 @@ fn restore_codex_state_db_official_threads(
     }
 
     let mut conn = Connection::open(db_path)
-        .map_err(|e| AppError::Database(format!("打开 Codex state DB 失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("鎵撳紑 Codex state DB 澶辫触: {e}")))?;
     conn.busy_timeout(Duration::from_secs(5))
-        .map_err(|e| AppError::Database(format!("设置 Codex state DB busy_timeout 失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("璁剧疆 Codex state DB busy_timeout 澶辫触: {e}")))?;
 
     if !Database::table_exists(&conn, "threads")?
         || !Database::has_column(&conn, "threads", "model_provider")?
@@ -624,7 +624,7 @@ fn restore_codex_state_db_official_threads(
             .query_row(&count_sql, params_from_iter(values.iter()), |row| {
                 row.get(0)
             })
-            .map_err(|e| AppError::Database(format!("统计 Codex state DB 待还原行失败: {e}")))?;
+            .map_err(|e| AppError::Database(format!("缁熻 Codex state DB 寰呰繕鍘熻澶辫触: {e}")))?;
         matching_rows += count;
     }
     if matching_rows == 0 {
@@ -635,7 +635,7 @@ fn restore_codex_state_db_official_threads(
 
     let tx = conn
         .transaction()
-        .map_err(|e| AppError::Database(format!("开启 Codex state DB 还原事务失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("寮€鍚?Codex state DB 杩樺師浜嬪姟澶辫触: {e}")))?;
     let mut changed = 0;
     for chunk in ids.chunks(STATE_DB_ID_CHUNK) {
         let placeholders = placeholders(chunk.len());
@@ -648,10 +648,10 @@ fn restore_codex_state_db_official_threads(
         values.extend(chunk.iter().map(|id| (*id).clone()));
         changed += tx
             .execute(&update_sql, params_from_iter(values.iter()))
-            .map_err(|e| AppError::Database(format!("还原 Codex state DB provider 失败: {e}")))?;
+            .map_err(|e| AppError::Database(format!("杩樺師 Codex state DB provider 澶辫触: {e}")))?;
     }
     tx.commit()
-        .map_err(|e| AppError::Database(format!("提交 Codex state DB 还原事务失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("鎻愪氦 Codex state DB 杩樺師浜嬪姟澶辫触: {e}")))?;
     Ok(changed)
 }
 
@@ -1115,22 +1115,55 @@ fn migrate_codex_state_dbs(
     Ok(migrated)
 }
 
-fn codex_state_db_paths(codex_dir: &Path, config_text: &str) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    push_unique_path(&mut paths, codex_dir.join(CODEX_STATE_DB_FILENAME));
-    // Codex lets SQLite state move away from CODEX_HOME; config takes precedence.
-    if let Some(sqlite_home) = sqlite_home_from_codex_config(config_text) {
-        push_unique_path(&mut paths, sqlite_home.join(CODEX_STATE_DB_FILENAME));
-    } else if let Some(sqlite_home) = sqlite_home_from_env() {
-        push_unique_path(&mut paths, sqlite_home.join(CODEX_STATE_DB_FILENAME));
+
+/// Read a directory and return all state_*.sqlite file paths found inside.
+fn find_state_db_files_in(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut results = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("sqlite") {
+            continue;
+        }
+        let name = path.file_stem().and_then(|n| n.to_str()).unwrap_or("");
+        if name.starts_with("state_") {
+            results.push(path);
+        }
     }
-    paths
+    results.sort();
+    results
 }
 
-fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
-    if !paths.contains(&path) {
-        paths.push(path);
+/// Discover all state DB paths across all known Codex directories.
+///
+/// Scans codex_dir, codex_dir/sqlite, and sqlite_home (from config.toml or
+/// CODEX_SQLITE_HOME env var) for any state_*.sqlite files.
+fn codex_state_db_paths(codex_dir: &Path, config_text: &str) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for dir in [codex_dir, &codex_dir.join("sqlite")] {
+        for found in find_state_db_files_in(dir) {
+            if !paths.contains(&found) {
+                paths.push(found);
+            }
+        }
     }
+    // sqlite_home from config.toml takes precedence over CODEX_SQLITE_HOME env var
+    if let Some(sqlite_home) = sqlite_home_from_codex_config(config_text) {
+        for found in find_state_db_files_in(&sqlite_home) {
+            if !paths.contains(&found) {
+                paths.push(found);
+            }
+        }
+    } else if let Some(sqlite_home) = sqlite_home_from_env() {
+        for found in find_state_db_files_in(&sqlite_home) {
+            if !paths.contains(&found) {
+                paths.push(found);
+            }
+        }
+    }
+    paths
 }
 
 fn sqlite_home_from_codex_config(config_text: &str) -> Option<PathBuf> {
@@ -1175,9 +1208,9 @@ fn migrate_codex_state_db_provider_bucket(
     }
 
     let mut conn = Connection::open(db_path)
-        .map_err(|e| AppError::Database(format!("打开 Codex state DB 失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("鎵撳紑 Codex state DB 澶辫触: {e}")))?;
     conn.busy_timeout(Duration::from_secs(5))
-        .map_err(|e| AppError::Database(format!("设置 Codex state DB busy_timeout 失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("璁剧疆 Codex state DB busy_timeout 澶辫触: {e}")))?;
 
     if !Database::table_exists(&conn, "threads")?
         || !Database::has_column(&conn, "threads", "model_provider")?
@@ -1194,7 +1227,7 @@ fn migrate_codex_state_db_provider_bucket(
             params_from_iter(source_provider_ids.iter()),
             |row| row.get(0),
         )
-        .map_err(|e| AppError::Database(format!("统计 Codex state DB 待迁移行失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("缁熻 Codex state DB 寰呰縼绉昏澶辫触: {e}")))?;
     if matching_rows == 0 {
         return Ok(0);
     }
@@ -1208,12 +1241,12 @@ fn migrate_codex_state_db_provider_bucket(
     values.extend(source_provider_ids.iter().cloned());
     let tx = conn
         .transaction()
-        .map_err(|e| AppError::Database(format!("开启 Codex state DB 迁移事务失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("寮€鍚?Codex state DB 杩佺Щ浜嬪姟澶辫触: {e}")))?;
     let changed = tx
         .execute(&update_sql, params_from_iter(values.iter()))
-        .map_err(|e| AppError::Database(format!("迁移 Codex state DB provider 失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("杩佺Щ Codex state DB provider 澶辫触: {e}")))?;
     tx.commit()
-        .map_err(|e| AppError::Database(format!("提交 Codex state DB 迁移事务失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("鎻愪氦 Codex state DB 杩佺Щ浜嬪姟澶辫触: {e}")))?;
     Ok(changed)
 }
 
@@ -1248,12 +1281,12 @@ fn backup_codex_state_db(
     }
 
     let mut backup_conn = Connection::open(&backup_path)
-        .map_err(|e| AppError::Database(format!("创建 Codex state DB 备份失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("鍒涘缓 Codex state DB 澶囦唤澶辫触: {e}")))?;
     let backup = Backup::new(source_conn, &mut backup_conn)
-        .map_err(|e| AppError::Database(format!("初始化 Codex state DB 备份失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("鍒濆鍖?Codex state DB 澶囦唤澶辫触: {e}")))?;
     backup
         .run_to_completion(5, Duration::from_millis(25), None)
-        .map_err(|e| AppError::Database(format!("写入 Codex state DB 备份失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("鍐欏叆 Codex state DB 澶囦唤澶辫触: {e}")))?;
     Ok(())
 }
 
@@ -1362,7 +1395,7 @@ mod tests {
 
     #[test]
     fn detects_custom_routed_codex_config_for_unify_gate() {
-        // 注入产物（官方 + 统一开关）
+        // 娉ㄥ叆浜х墿锛堝畼鏂?+ 缁熶竴寮€鍏筹級
         assert!(codex_config_text_routes_custom(
             r#"model_provider = "custom"
 
@@ -1373,7 +1406,7 @@ supports_websockets = true
 wire_api = "responses"
 "#
         ));
-        // 第三方供应商的常规 custom 路由（带 base_url）同样算已统一
+        // 绗笁鏂逛緵搴斿晢鐨勫父瑙?custom 璺敱锛堝甫 base_url锛夊悓鏍风畻宸茬粺涓€
         assert!(codex_config_text_routes_custom(
             r#"model_provider = "custom"
 
@@ -1382,7 +1415,7 @@ name = "AIHubMix"
 base_url = "https://aihubmix.example/v1"
 "#
         ));
-        // 注入被拒的形态：显式 openai 路由 / 无 model_provider（接管期间、空配置）
+        // 娉ㄥ叆琚嫆鐨勫舰鎬侊細鏄惧紡 openai 璺敱 / 鏃?model_provider锛堟帴绠℃湡闂淬€佺┖閰嶇疆锛?
         assert!(!codex_config_text_routes_custom(
             "model_provider = \"openai\"\n"
         ));
@@ -1708,7 +1741,7 @@ base_url = "https://proxy.example/v1"
             .join("jsonl/sessions/2026/06/12/official-sim.jsonl")
             .exists());
 
-        // 第二次执行应当无事可做（幂等）
+        // 绗簩娆℃墽琛屽簲褰撴棤浜嬪彲鍋氾紙骞傜瓑锛?
         let rerun = migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root)
             .expect("rerun migrate jsonl");
         assert_eq!(rerun, 0);
@@ -1758,7 +1791,7 @@ base_url = "https://proxy.example/v1"
         let ledger_parent = dir.path().join("ledger");
         let restore_backup_root = dir.path().join("restore-backup");
 
-        // 备份账本：一个代际，jsonl 备份里 s1 是 openai；state 备份里 t1 是 openai
+        // 澶囦唤璐︽湰锛氫竴涓唬闄咃紝jsonl 澶囦唤閲?s1 鏄?openai锛泂tate 澶囦唤閲?t1 鏄?openai
         let generation = ledger_parent.join("20260612_010101");
         let backup_session_dir = generation.join("jsonl/sessions/2026/06/01");
         fs::create_dir_all(&backup_session_dir).expect("create backup session dir");
@@ -1779,8 +1812,8 @@ base_url = "https://proxy.example/v1"
             .expect("seed backup db");
         drop(backup_db);
 
-        // 当前数据：s1（账本内，custom）应还原；s2（开启期间新会话，不在账本）
-        // 与 s3（手工 relay）必须原样保留
+        // 褰撳墠鏁版嵁锛歴1锛堣处鏈唴锛宑ustom锛夊簲杩樺師锛泂2锛堝紑鍚湡闂存柊浼氳瘽锛屼笉鍦ㄨ处鏈級
+        // 涓?s3锛堟墜宸?relay锛夊繀椤诲師鏍蜂繚鐣?
         let session_dir = codex_dir.join("sessions/2026/06/01");
         fs::create_dir_all(&session_dir).expect("create session dir");
         let official_path = session_dir.join("official.jsonl");
@@ -1813,7 +1846,7 @@ base_url = "https://proxy.example/v1"
         .expect("seed state db");
         drop(conn);
 
-        // 代际 meta 指向当前 Codex 目录：精确匹配分支生效（而非无 meta 的宽容分支）
+        // 浠ｉ檯 meta 鎸囧悜褰撳墠 Codex 鐩綍锛氱簿纭尮閰嶅垎鏀敓鏁堬紙鑰岄潪鏃?meta 鐨勫瀹瑰垎鏀級
         fs::write(
             generation.join("meta.json"),
             serde_json::to_vec_pretty(&serde_json::json!({
@@ -1854,7 +1887,7 @@ base_url = "https://proxy.example/v1"
         assert_eq!(provider_of("t3"), "openai");
         drop(conn);
 
-        // 还原前的现场已备份到独立目录
+        // 杩樺師鍓嶇殑鐜板満宸插浠藉埌鐙珛鐩綍
         assert!(restore_backup_root
             .join("jsonl/sessions/2026/06/01/official.jsonl")
             .exists());
@@ -1863,7 +1896,7 @@ base_url = "https://proxy.example/v1"
             .join(CODEX_STATE_DB_FILENAME)
             .exists());
 
-        // 幂等：第二次还原无事可做
+        // 骞傜瓑锛氱浜屾杩樺師鏃犱簨鍙仛
         let rerun = restore_codex_official_history_inner(
             &codex_dir,
             &ledger_parent,
@@ -1882,7 +1915,7 @@ base_url = "https://proxy.example/v1"
         let codex_dir = dir.path().join(".codex");
         let ledger_parent = dir.path().join("ledger");
 
-        // 账本代际属于另一个 Codex 目录
+        // 璐︽湰浠ｉ檯灞炰簬鍙︿竴涓?Codex 鐩綍
         let generation = ledger_parent.join("20260612_010101");
         let backup_session_dir = generation.join("jsonl/sessions/2026/06/01");
         fs::create_dir_all(&backup_session_dir).expect("create backup session dir");
@@ -1924,13 +1957,13 @@ base_url = "https://proxy.example/v1"
         let ledger_parent = dir.path().join("ledger");
         let codex_dir_key = "/current/codex-dir";
 
-        // 空父目录 / 父目录不存在：无备份
+        // 绌虹埗鐩綍 / 鐖剁洰褰曚笉瀛樺湪锛氭棤澶囦唤
         assert!(!has_official_history_unify_backup_for_dir(
             &ledger_parent,
             codex_dir_key
         ));
 
-        // 只有其他目录的代际：不算有备份
+        // 鍙湁鍏朵粬鐩綍鐨勪唬闄咃細涓嶇畻鏈夊浠?
         let other = ledger_parent.join("20260612_010101");
         fs::create_dir_all(&other).expect("create generation");
         fs::write(
@@ -1943,14 +1976,14 @@ base_url = "https://proxy.example/v1"
             codex_dir_key
         ));
 
-        // 无 meta 的早期代际：宽容接受（与 restore 的账本口径一致）
+        // 鏃?meta 鐨勬棭鏈熶唬闄咃細瀹藉鎺ュ彈锛堜笌 restore 鐨勮处鏈彛寰勪竴鑷达級
         fs::create_dir_all(ledger_parent.join("20260612_020202")).expect("create legacy gen");
         assert!(has_official_history_unify_backup_for_dir(
             &ledger_parent,
             codex_dir_key
         ));
 
-        // 精确匹配当前目录的代际
+        // 绮剧‘鍖归厤褰撳墠鐩綍鐨勪唬闄?
         fs::remove_dir_all(ledger_parent.join("20260612_020202")).expect("remove legacy gen");
         let matched = ledger_parent.join("20260612_030303");
         fs::create_dir_all(&matched).expect("create matched gen");
@@ -2164,6 +2197,10 @@ base_url = "https://proxy.example/v1"
         let codex_dir = dir.path().join(".codex");
         let sqlite_home = dir.path().join("sqlite-home");
         let _guard = EnvVarGuard::set("CODEX_SQLITE_HOME", &sqlite_home);
+        std::fs::create_dir_all(&codex_dir).expect("create codex_dir");
+        std::fs::create_dir_all(&sqlite_home).expect("create sqlite_home");
+        let _ = std::fs::write(codex_dir.join(CODEX_STATE_DB_FILENAME), b"");
+        let _ = std::fs::write(sqlite_home.join(CODEX_STATE_DB_FILENAME), b"");
 
         let paths = codex_state_db_paths(&codex_dir, "");
 
@@ -2184,7 +2221,11 @@ base_url = "https://proxy.example/v1"
         let env_sqlite_home = dir.path().join("env-sqlite-home");
         let config_sqlite_home = dir.path().join("config-sqlite-home");
         let _guard = EnvVarGuard::set("CODEX_SQLITE_HOME", &env_sqlite_home);
-        let config_text = format!("sqlite_home = \"{}\"\n", config_sqlite_home.display());
+        let config_text = format!("sqlite_home = \"{}\"\n", config_sqlite_home.to_string_lossy().replace('\\', "/"));
+        std::fs::create_dir_all(&codex_dir).expect("create codex_dir");
+        std::fs::create_dir_all(&config_sqlite_home).expect("create config_sqlite_home");
+        let _ = std::fs::write(codex_dir.join(CODEX_STATE_DB_FILENAME), b"");
+        let _ = std::fs::write(config_sqlite_home.join(CODEX_STATE_DB_FILENAME), b"");
 
         let paths = codex_state_db_paths(&codex_dir, &config_text);
 


### PR DESCRIPTION
## Summary

This PR contributes the newer Codex history visibility repair work in an upstream-friendly shape:

- detect the active Codex Desktop SQLite DB under `~/.codex/sqlite/state_5.sqlite` even when `sqlite_home` is not present in `config.toml`;
- preserve rollout/session JSONL file access and modified times after provider-bucket rewrites, so `codex resume` ordering is not disturbed;
- add `scripts/codex-history-tool`, a standalone standard-library Python tool that can list, dry-run, and apply Codex history visibility repairs, plus a Windows PyInstaller build script for exe artifacts.

## Why

Recent Codex Desktop builds can keep the active state DB under:

```text
~/.codex/sqlite/state_5.sqlite
```

If CC Switch only migrates `~/.codex/state_5.sqlite` or an explicit `sqlite_home`, the live Desktop sidebar can still look empty after unified history is enabled. The JSONL rewrite path also needs to preserve the original file mtime, otherwise old sessions can jump to the top of `codex resume`.

## Standalone Tool

The Python tool is intentionally dependency-free and supports:

- `list --json` for active DB/session diagnostics;
- `repair --json` dry-run previews by default;
- `repair --apply` with backups under Codex home;
- explicit `--session-id` repair for selected sessions;
- active DB discovery including `~/.codex/sqlite/state_5.sqlite`;
- provider bucket repair, `has_user_event`, `session_index.jsonl`, `.codex-global-state.json` workspace hints, and balanced recent-window defaults.

The same JSON entry points are documented as the recommended future Session Manager integration surface, so the app can expose a repair panel without making users type paths/provider IDs manually.

## Related

- Fixes #4289
- Addresses #3866
- Related to #3510
- Related to #3793

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml codex_history_migration --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml --lib`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib`
- `pnpm history:tool:check`
- `python scripts/codex-history-tool/codex_history_tool.py --help`
- `python scripts/codex-history-tool/codex_history_tool.py list --limit 1 --json`
- `python scripts/codex-history-tool/codex_history_tool.py repair --project-path "C:\Users\sunda\Documents\LLMservice" --json` (dry run)
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/codex-history-tool/build-windows-exe.ps1`
- generated exe `--version` and `list --limit 1 --json`
- Prettier check for `package.json` and the tool README

`cargo check`/`cargo clippy` currently report pre-existing warnings in `settings.rs`, `commands/misc.rs`, and `commands/settings.rs`; this PR does not add those warnings.

## Checklist

- [x] `pnpm typecheck` passes (not required for this script-only PR; covered in the stacked UI PR)
- [x] `pnpm format:check` passes (targeted Prettier check for changed JS/JSON/Markdown files)
- [x] `cargo clippy` passes (Rust code changed)
- [x] Updated i18n files if user-facing text changed (not applicable; no frontend UI text changed)