### PR TITLE
docs: remove deprecated Homebrew tap step

### DIFF
--- a/docs/user-manual/en/1-getting-started/1.2-installation.md
+++ b/docs/user-manual/en/1-getting-started/1.2-installation.md
@@ -122,9 +122,6 @@ npm install -g @google/gemini-cli
 ### Option 1: Homebrew (Recommended)
 
 ```bash
-# Add tap
-brew tap farion1231/ccswitch
-
 # Install
 brew install --cask cc-switch
 ```

--- a/docs/user-manual/ja/1-getting-started/1.2-installation.md
+++ b/docs/user-manual/ja/1-getting-started/1.2-installation.md
@@ -122,9 +122,6 @@ npm install -g @google/gemini-cli
 ### 方法 1：Homebrew（推奨）
 
 ```bash
-# tap を追加
-brew tap farion1231/ccswitch
-
 # インストール
 brew install --cask cc-switch
 ```

--- a/docs/user-manual/zh/1-getting-started/1.2-installation.md
+++ b/docs/user-manual/zh/1-getting-started/1.2-installation.md
@@ -138,9 +138,6 @@ npm install -g @google/gemini-cli --registry=https://registry.npmmirror.com
 ### 方式一：Homebrew（推荐）
 
 ```bash
-# 添加 tap
-brew tap farion1231/ccswitch
-
 # 安装
 brew install --cask cc-switch
 ```


### PR DESCRIPTION
## Summary
- remove the deprecated `brew tap farion1231/ccswitch` step from macOS Homebrew installation docs
- keep the direct `brew install --cask cc-switch` command in English, Chinese, and Japanese user manuals

## Why
`cc-switch` is available from the official Homebrew cask tap, so users no longer need to add the deprecated custom tap before installing.

## Checks
- [x] `rg -n "brew tap farion1231/ccswitch|farion1231/ccswitch" docs/user-manual/*/1-getting-started/1.2-installation.md || true`
- [x] `git diff --check`