### PR TITLE
fix(proxy): stop sorting JSON keys in outgoing request body

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -7,7 +7,7 @@ use super::{
     body_filter::filter_private_params_with_whitelist,
     error::*,
     failover_switch::FailoverSwitchManager,
-    json_canonical::{canonicalize_value, short_value_hash},
+    json_canonical::short_value_hash,
     log_codes::fwd as log_fwd,
     provider_router::ProviderRouter,
     providers::{
@@ -2545,7 +2545,7 @@ fn summarize_text_for_log(text: &str, max_chars: usize) -> String {
 }
 
 fn prepare_upstream_request_body(request_body: Value) -> Value {
-    canonicalize_value(filter_private_params_with_whitelist(request_body, &[]))
+    filter_private_params_with_whitelist(request_body, &[])
 }
 
 fn log_prompt_cache_trace(
@@ -2793,6 +2793,7 @@ mod tests {
 
         let prepared = prepare_upstream_request_body(body);
 
+        // Private fields are stripped
         assert!(prepared.get("_internal").is_none());
         assert!(prepared["tools"][0]["parameters"]["properties"]
             .get("_id")
@@ -2800,10 +2801,10 @@ mod tests {
         assert!(prepared["tools"][0]["parameters"]["properties"]["_id"]
             .get("_private_note")
             .is_none());
-        assert_eq!(
-            serde_json::to_string(&prepared).unwrap(),
-            r#"{"a":2,"tools":[{"name":"lookup","parameters":{"properties":{"_id":{"type":"string"},"a":{"type":"string"},"b":{"type":"number"}},"type":"object"}}],"z":1}"#
-        );
+        // Public fields are preserved (insertion order, not alphabetically sorted)
+        assert!(prepared.get("z").is_some());
+        assert!(prepared.get("a").is_some());
+        assert!(prepared.get("tools").is_some());
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/json_canonical.rs
+++ b/src-tauri/src/proxy/json_canonical.rs
@@ -3,23 +3,6 @@
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-pub(crate) fn canonicalize_value(value: Value) -> Value {
-    match value {
-        Value::Array(values) => Value::Array(values.into_iter().map(canonicalize_value).collect()),
-        Value::Object(map) => {
-            let mut entries = map.into_iter().collect::<Vec<_>>();
-            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
-
-            let mut sorted = serde_json::Map::new();
-            for (key, value) in entries {
-                sorted.insert(key, canonicalize_value(value));
-            }
-            Value::Object(sorted)
-        }
-        other => other,
-    }
-}
-
 pub(crate) fn canonical_json_string(value: &Value) -> String {
     match value {
         Value::Null => "null".to_string(),
@@ -130,13 +113,6 @@ mod tests {
             short_value_hash(Some(&left)),
             short_value_hash(Some(&right))
         );
-    }
-
-    #[test]
-    fn canonicalize_value_sorts_map_storage_order() {
-        let value = canonicalize_value(json!({"b": 2, "a": 1}));
-
-        assert_eq!(serde_json::to_string(&value).unwrap(), r#"{"a":1,"b":2}"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

`prepare_upstream_request_body` called `canonicalize_value` after filtering private fields. That function **recursively** sorts all JSON object keys alphabetically. Because of alphabetical ordering, fields throughout the request body were reordered in counter-intuitive ways — producing wrong field ordering in both the outgoing upstream request body and the exported full-log JSONL records.

Remove the `canonicalize_value` call from `prepare_upstream_request_body`; filtering private fields is sufficient. `canonicalize_value` becomes dead code after this and is deleted along with its test.


## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

Affected field orderings / 受影响的字段顺序

| Field | Before / 修改前 | After / 修改后 |
|---|---|---|
| message | `{"content": "...", "role": "..."}` | `{"role": "...", "content": "..."}` |
| content block | `{"text": "...", "type": "..."}` | `{"type": "...", "text": "..."}` |
| tool | `{"function": {...}, "type": "..."}` | `{"type": "...", "function": {...}}` |

In all cases the canonical (sorted) form pushed the semantically primary key (`role`, `type`) *after* its payload, which is the opposite of the conventional ordering emitted by the transform layer.



## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
