### PR TITLE
 fix(codex): add force_codex_model_provider_id to unify provider IDs (#3967)

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1407,33 +1407,12 @@ pub fn write_codex_live_for_provider(
     };
     let config_text = normalized_config.as_deref();
 
-    // When normalization rewrote provider IDs, migrate existing session
-    // history files so old sessions appear under the unified bucket.
-    if let Some(target_id) = crate::settings::force_codex_model_provider_id() {
-        let mut migrate_ids: Vec<String> = rewritten_ids.clone();
-
-        // Also migrate official "openai" sessions when the target differs,
-        // so switching from official to third-party keeps all history visible.
-        if target_id != "openai" && !migrate_ids.contains(&"openai".to_string()) {
-            migrate_ids.push("openai".to_string());
-        }
-
-        if !migrate_ids.is_empty() {
-            log::info!(
-                "Triggering force-provider-id migration: {:?} -> '{}'",
-                migrate_ids, target_id
-            );
-            if let Err(e) = crate::codex_history_migration::migrate_codex_history_for_force_provider_id(
-                &migrate_ids,
-                &target_id,
-            ) {
-                log::warn!(
-                    "Failed to migrate Codex session history after normalizing provider IDs {:?} -> '{}': {e}",
-                    migrate_ids, target_id
-                );
-            }
-        }
-    }
+    // Note: We intentionally do NOT migrate existing session history files.
+    // The `force_codex_model_provider_id` setting only affects the live
+    // config.toml (new sessions land in the unified bucket).  Existing
+    // sessions stay in their original buckets so they remain visible under
+    // their original provider in CC Switch's Session Manager (which scans
+    // all buckets regardless of the active model_provider).
 
     let unified_official_config =
         if category == Some("official") && crate::settings::unify_codex_session_history() {

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1043,6 +1043,151 @@ pub fn read_codex_live_settings() -> Result<Value, AppError> {
     Ok(json!({ "auth": auth, "config": cfg_text }))
 }
 
+/// Normalize the `model_provider` ID in a Codex `config.toml` string when the
+/// user has opted into unified provider IDs.
+///
+/// When `force_codex_model_provider_id` is set (e.g. to `"custom"`), all
+/// non-reserved (third-party) model_provider IDs are rewritten to the target
+/// value across the entire TOML document: the top-level `model_provider` key,
+/// the `[model_providers.<id>]` table, and any `profile` references.
+///
+/// Reserved Codex provider IDs (`openai`, `ollama`, `amazon-bedrock`,
+/// `lmstudio`, `oss`, `ollama-chat`) and empty/whitespace IDs are left
+/// untouched.
+///
+/// When the setting is `None` (default) or when there is nothing to rewrite,
+/// the original text is returned unchanged.
+pub fn normalize_codex_model_provider_id_if_configured(
+    config_text: &str,
+) -> Result<String, AppError> {
+    let target_id = crate::settings::force_codex_model_provider_id()
+        .filter(|t| !t.trim().is_empty());
+    normalize_codex_model_provider_id_to(config_text, target_id.as_deref())
+}
+
+pub fn normalize_codex_model_provider_id_to(
+    config_text: &str,
+    target_id: Option<&str>,
+) -> Result<String, AppError> {
+    let target_id = target_id.map(str::trim).filter(|t| !t.is_empty());
+    normalize_codex_provider_id_to_impl(config_text, target_id)
+}
+
+fn normalize_codex_provider_id_to_impl(
+    config_text: &str,
+    target_id: Option<&str>,
+) -> Result<String, AppError> {
+    let Some(target_id) = target_id else {
+        return Ok(config_text.to_string());
+    };
+
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+
+    // Collect every third-party (non-reserved) provider ID referenced
+    // anywhere in the document so that profile-only references are
+    // rewritten even when the top-level model_provider is already the
+    // target or is a reserved ID.
+    let third_party_ids = collect_non_reserved_provider_ids(&doc, target_id);
+
+    let mut changed = false;
+
+    for old_id in &third_party_ids {
+        // Rename [model_providers.<old>] → [model_providers.<target>]
+        // Always remove the old table; only insert into target slot
+        // when target doesn't exist yet, so the active provider's
+        // live config is never overwritten by stale profile data.
+        if let Some(model_providers) = doc
+            .get_mut("model_providers")
+            .and_then(|item| item.as_table_mut())
+        {
+            let target_exists = model_providers.contains_key(target_id);
+            if let Some(provider_table) = model_providers.remove(old_id.as_str()) {
+                if !target_exists {
+                    model_providers[target_id] = provider_table;
+                }
+            }
+        }
+
+        // Rewrite top-level model_provider if it matches
+        if doc
+            .get("model_provider")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            == Some(old_id.as_str())
+        {
+            doc["model_provider"] = toml_edit::value(target_id);
+        }
+
+        // Rewrite profile references
+        if let Some(profiles) = doc
+            .get_mut("profiles")
+            .and_then(|item| item.as_table_like_mut())
+        {
+            rewrite_profile_provider_refs(profiles, old_id, target_id);
+        }
+
+        changed = true;
+    }
+
+    if changed {
+        Ok(doc.to_string())
+    } else {
+        Ok(config_text.to_string())
+    }
+}
+
+/// Return every custom (non-reserved) model_provider ID referenced
+/// anywhere in the document whose value differs from `target_id`.
+fn collect_non_reserved_provider_ids(doc: &DocumentMut, target_id: &str) -> Vec<String> {
+    let mut ids: Vec<String> = Vec::new();
+
+    let mut push_if_custom = |id: &str| {
+        let id = id.trim().to_string();
+        if !id.is_empty()
+            && is_custom_codex_model_provider_id(&id)
+            && id != target_id
+            && !ids.contains(&id)
+        {
+            ids.push(id);
+        }
+    };
+
+    if let Some(id) = doc.get("model_provider").and_then(|v| v.as_str()) {
+        push_if_custom(id);
+    }
+
+    if let Some(profiles) = doc.get("profiles").and_then(|v| v.as_table_like()) {
+        for (_, profile) in profiles.iter() {
+            if let Some(id) = profile.get("model_provider").and_then(|v| v.as_str()) {
+                push_if_custom(id);
+            }
+        }
+    }
+
+    ids
+}
+
+fn rewrite_profile_provider_refs(
+    profiles: &mut dyn toml_edit::TableLike,
+    old_id: &str,
+    new_id: &str,
+) {
+    for (_, profile) in profiles.iter_mut() {
+        if let Some(table) = profile.as_table_like_mut() {
+            if let Some((_key, value)) = table
+                .get("model_provider")
+                .map(|v| ("model_provider", v.clone()))
+            {
+                if value.as_str().map(str::trim) == Some(old_id) {
+                    table.insert("model_provider", toml_edit::value(new_id));
+                }
+            }
+        }
+    }
+}
+
 /// `[model_providers.custom]` entry that makes an official (ChatGPT OAuth)
 /// provider behave like Codex's built-in `openai` entry while running under
 /// the shared custom id: `requires_openai_auth` routes auth to the ChatGPT
@@ -1224,15 +1369,21 @@ pub fn write_codex_live_for_provider(
     auth: &Value,
     config_text: Option<&str>,
 ) -> Result<(), AppError> {
+    // Normalize model_provider ID before writing, so that switching between
+    // providers with different IDs keeps chat history in a single bucket.
+    let config_text = config_text
+        .map(|text| normalize_codex_model_provider_id_if_configured(text))
+        .transpose()?;
+
     let unified_official_config =
         if category == Some("official") && crate::settings::unify_codex_session_history() {
             Some(inject_codex_unified_session_bucket(
-                config_text.unwrap_or(""),
+                config_text.as_deref().unwrap_or(""),
             )?)
         } else {
             None
         };
-    let config_text = unified_official_config.as_deref().or(config_text);
+    let config_text = unified_official_config.as_deref().or(config_text.as_deref());
 
     let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
         || (category != Some("official")
@@ -2461,6 +2612,204 @@ model_catalog_json = "cc-switch-model-catalog.json"
         assert!(
             parsed.get("model_catalog_json").is_none(),
             "None arm should remove relative cc-switch-owned field"
+        );
+    }
+
+    // ── normalize_codex_model_provider_id_to ───
+
+    #[test]
+    fn normalize_codex_noop_when_target_is_none() {
+        let input = r#"model_provider = "my_provider"
+model = "gpt-5.5"
+
+[model_providers.my_provider]
+name = "My Provider"
+base_url = "https://example.com/v1"
+wire_api = "responses"
+"#;
+        let result = normalize_codex_model_provider_id_to(input, None).unwrap();
+        assert_eq!(result, input, "None target should return input unchanged");
+    }
+
+    #[test]
+    fn normalize_codex_noop_when_target_is_empty() {
+        let input = r#"model_provider = "my_provider"
+model = "gpt-5.5"
+"#;
+        let result = normalize_codex_model_provider_id_to(input, Some("   ")).unwrap();
+        assert_eq!(
+            result, input,
+            "whitespace-only target should return input unchanged"
+        );
+    }
+
+    #[test]
+    fn normalize_codex_noop_when_reserved_provider() {
+        let input = r#"model_provider = "openai"
+model = "gpt-5.5"
+
+[model_providers.openai]
+name = "OpenAI"
+"#;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        assert_eq!(
+            result, input,
+            "reserved provider ID should not be rewritten"
+        );
+    }
+
+    #[test]
+    fn normalize_codex_rewrites_custom_provider_id_to_target() {
+        let input = r#"model_provider = "vendor_alpha"
+model = "gpt-5.5"
+
+[model_providers.vendor_alpha]
+name = "Vendor Alpha"
+base_url = "https://alpha.example/v1"
+wire_api = "responses"
+"#;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("custom"),
+            "model_provider should be rewritten to custom"
+        );
+        assert!(
+            parsed
+                .get("model_providers")
+                .and_then(|v| v.get("vendor_alpha"))
+                .is_none(),
+            "old provider table should be removed"
+        );
+        let custom = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("custom"))
+            .expect("custom provider table should exist");
+        assert_eq!(
+            custom.get("base_url").and_then(|v| v.as_str()),
+            Some("https://alpha.example/v1"),
+            "base_url should be preserved"
+        );
+    }
+
+    #[test]
+    fn normalize_codex_rewrites_profile_references() {
+        let input = r#"model_provider = "aihubmix"
+model = "gpt-5.5"
+
+[model_providers.aihubmix]
+name = "AIHubMix"
+base_url = "https://aihubmix.com/v1"
+
+[profiles.work]
+model_provider = "aihubmix"
+model = "gpt-5.5"
+
+[profiles.personal]
+model_provider = "aihubmix"
+model = "gpt-4"
+"#;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("custom"),
+            "model_provider should be rewritten"
+        );
+
+        let profiles = parsed.get("profiles").expect("profiles should exist");
+        for profile_name in &["work", "personal"] {
+            let profile = profiles.get(profile_name).expect("profile should exist");
+            assert_eq!(
+                profile.get("model_provider").and_then(|v| v.as_str()),
+                Some("custom"),
+                "profile '{profile_name}' model_provider should be rewritten"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_codex_keeps_non_matching_profile_references() {
+        let input = r#"model_provider = "my_provider"
+model = "gpt-5.5"
+
+[model_providers.my_provider]
+name = "My Provider"
+
+[profiles.work]
+model_provider = "openai"
+model = "gpt-5.5"
+"#;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        let profiles = parsed.get("profiles").expect("profiles should exist");
+        let profile = profiles.get("work").expect("profile should exist");
+        assert_eq!(
+            profile.get("model_provider").and_then(|v| v.as_str()),
+            Some("openai"),
+            "non-matching profile references should not be rewritten"
+        );
+    }
+
+    #[test]
+    fn normalize_rewrites_profile_when_top_level_already_target() {
+        // Profile-only: top-level is already the target "custom" but a
+        // [profiles.*] entry still points at a third-party ID.
+        let input = r#"model_provider = "custom"
+model = "gpt-5.5"
+
+[model_providers.custom]
+name = "Custom"
+base_url = "https://main.example/v1"
+
+[model_providers.aihubmix]
+name = "AIHubMix"
+base_url = "https://aihubmix.com/v1"
+
+[profiles.old]
+model_provider = "aihubmix"
+model = "gpt-5.5"
+"#;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+
+        // Top-level should stay "custom"
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("custom")
+        );
+
+        // Stale aihubmix table should be removed
+        assert!(
+            parsed
+                .get("model_providers")
+                .and_then(|v| v.get("aihubmix"))
+                .is_none(),
+            "stale aihubmix table should be removed"
+        );
+
+        // Profile reference must be rewritten
+        let profiles = parsed.get("profiles").expect("profiles should exist");
+        let old_profile = profiles.get("old").expect("old profile should exist");
+        assert_eq!(
+            old_profile.get("model_provider").and_then(|v| v.as_str()),
+            Some("custom"),
+            "stale profile reference should be rewritten to custom"
+        );
+
+        // Main custom table must preserve its original config (not
+        // overwritten by stale aihubmix data).
+        let custom = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("custom"))
+            .expect("custom provider table should exist");
+        assert_eq!(
+            custom.get("base_url").and_then(|v| v.as_str()),
+            Some("https://main.example/v1"),
+            "existing custom table content should be preserved"
         );
     }
 }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1386,6 +1386,10 @@ pub fn write_codex_live_for_provider(
     auth: &Value,
     config_text: Option<&str>,
 ) -> Result<(), AppError> {
+    // Reload settings from disk so force_codex_model_provider_id and
+    // other runtime-changed settings are always current.
+    let _ = crate::settings::reload_settings();
+
     // Normalize model_provider ID before writing, so that switching between
     // providers with different IDs keeps chat history in a single bucket.
     let force_id = crate::settings::force_codex_model_provider_id();

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1400,15 +1400,23 @@ pub fn write_codex_live_for_provider(
 
     // When normalization rewrote provider IDs, migrate existing session
     // history files so old sessions appear under the unified bucket.
-    if !rewritten_ids.is_empty() {
-        if let Some(target_id) = crate::settings::force_codex_model_provider_id() {
+    if let Some(target_id) = crate::settings::force_codex_model_provider_id() {
+        let mut migrate_ids: Vec<String> = rewritten_ids.clone();
+
+        // Also migrate official "openai" sessions when the target differs,
+        // so switching from official to third-party keeps all history visible.
+        if target_id != "openai" && !migrate_ids.contains(&"openai".to_string()) {
+            migrate_ids.push("openai".to_string());
+        }
+
+        if !migrate_ids.is_empty() {
             if let Err(e) = crate::codex_history_migration::migrate_codex_history_for_force_provider_id(
-                &rewritten_ids,
+                &migrate_ids,
                 &target_id,
             ) {
                 log::warn!(
                     "Failed to migrate Codex session history after normalizing provider IDs {:?} -> '{}': {e}",
-                    rewritten_ids, target_id
+                    migrate_ids, target_id
                 );
             }
         }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1388,6 +1388,11 @@ pub fn write_codex_live_for_provider(
 ) -> Result<(), AppError> {
     // Normalize model_provider ID before writing, so that switching between
     // providers with different IDs keeps chat history in a single bucket.
+    let force_id = crate::settings::force_codex_model_provider_id();
+    log::info!(
+        "write_codex_live_for_provider: category={:?}, force_id={:?}",
+        category, force_id
+    );
     let (normalized_config, rewritten_ids) = match config_text {
         Some(text) => {
             let outcome = normalize_codex_model_provider_id_if_configured(text)?;
@@ -1410,6 +1415,10 @@ pub fn write_codex_live_for_provider(
         }
 
         if !migrate_ids.is_empty() {
+            log::info!(
+                "Triggering force-provider-id migration: {:?} -> '{}'",
+                migrate_ids, target_id
+            );
             if let Err(e) = crate::codex_history_migration::migrate_codex_history_for_force_provider_id(
                 &migrate_ids,
                 &target_id,

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1060,8 +1060,8 @@ pub fn read_codex_live_settings() -> Result<Value, AppError> {
 pub fn normalize_codex_model_provider_id_if_configured(
     config_text: &str,
 ) -> Result<NormalizeCodexOutcome, AppError> {
-    let target_id = crate::settings::force_codex_model_provider_id()
-        .filter(|t| !t.trim().is_empty());
+    let target_id =
+        crate::settings::force_codex_model_provider_id().filter(|t| !t.trim().is_empty());
     normalize_codex_model_provider_id_to(config_text, target_id.as_deref())
 }
 
@@ -1101,21 +1101,22 @@ fn normalize_codex_provider_id_to_impl(
     // rewritten even when the top-level model_provider is already the
     // target or is a reserved ID.
     let third_party_ids = collect_non_reserved_provider_ids(&doc, target_id);
+    let active_provider_id = active_codex_model_provider_id(&doc);
 
     let mut changed = false;
 
     for old_id in &third_party_ids {
-        // Rename [model_providers.<old>] → [model_providers.<target>]
-        // Always remove the old table; only insert into target slot
-        // when target doesn't exist yet, so the active provider's
-        // live config is never overwritten by stale profile data.
+        // Rename [model_providers.<old>] into [model_providers.<target>].
+        // If old_id is the active provider, its table must win even when the
+        // target slot already exists from stale profile data.
         if let Some(model_providers) = doc
             .get_mut("model_providers")
             .and_then(|item| item.as_table_mut())
         {
-            let target_exists = model_providers.contains_key(target_id);
             if let Some(provider_table) = model_providers.remove(old_id.as_str()) {
-                if !target_exists {
+                let should_insert = active_provider_id.as_deref() == Some(old_id.as_str())
+                    || !model_providers.contains_key(target_id);
+                if should_insert {
                     model_providers[target_id] = provider_table;
                 }
             }
@@ -1406,14 +1407,19 @@ pub fn write_codex_live_for_provider(
     // Step 2: normalize model_provider ID (runs after unified injection
     // so official providers already have model_provider="custom" with
     // requires_openai_auth, and normalize is a no-op for them).
-    let force_id = crate::settings::force_codex_model_provider_id();
+    let force_id = crate::settings::force_codex_model_provider_id()
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty());
     log::info!(
         "write_codex_live_for_provider: category={:?}, force_id={:?}",
-        category, force_id
+        category,
+        force_id
     );
+    let mut rewritten_ids = Vec::new();
     let config_text = match config_text {
         Some(text) => {
             let outcome = normalize_codex_model_provider_id_if_configured(text)?;
+            rewritten_ids = outcome.rewritten_ids;
             Some(outcome.config_text)
         }
         None => None,
@@ -1426,9 +1432,19 @@ pub fn write_codex_live_for_provider(
     if should_write_auth {
         write_codex_live_atomic(auth, config_text.as_deref())
     } else {
-        let live_config = prepare_codex_provider_live_config(auth, config_text.as_deref().unwrap_or(""))?;
+        let live_config =
+            prepare_codex_provider_live_config(auth, config_text.as_deref().unwrap_or(""))?;
         write_codex_live_config_atomic(Some(&live_config))
+    }?;
+
+    if let Some(target_id) = force_id.as_deref() {
+        crate::codex_history_migration::migrate_codex_history_for_force_provider_id(
+            &rewritten_ids,
+            target_id,
+        )?;
     }
+
+    Ok(())
 }
 
 /// Build the live Codex config for provider switching.
@@ -2661,7 +2677,9 @@ name = "My Provider"
 base_url = "https://example.com/v1"
 wire_api = "responses"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, None).unwrap().config_text;
+        let result = normalize_codex_model_provider_id_to(input, None)
+            .unwrap()
+            .config_text;
         assert_eq!(result, input, "None target should return input unchanged");
     }
 
@@ -2670,7 +2688,9 @@ wire_api = "responses"
         let input = r#"model_provider = "my_provider"
 model = "gpt-5.5"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("   ")).unwrap().config_text;
+        let result = normalize_codex_model_provider_id_to(input, Some("   "))
+            .unwrap()
+            .config_text;
         assert_eq!(
             result, input,
             "whitespace-only target should return input unchanged"
@@ -2685,7 +2705,9 @@ model = "gpt-5.5"
 [model_providers.openai]
 name = "OpenAI"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom"))
+            .unwrap()
+            .config_text;
         assert_eq!(
             result, input,
             "reserved provider ID should not be rewritten"
@@ -2702,7 +2724,9 @@ name = "Vendor Alpha"
 base_url = "https://alpha.example/v1"
 wire_api = "responses"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom"))
+            .unwrap()
+            .config_text;
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         assert_eq!(
@@ -2729,6 +2753,43 @@ wire_api = "responses"
     }
 
     #[test]
+    fn normalize_codex_active_provider_overwrites_existing_target_table() {
+        let input = r#"model_provider = "vendor_b"
+model = "gpt-5.5"
+
+[model_providers.custom]
+name = "Stale Custom"
+base_url = "https://stale.example/v1"
+
+[model_providers.vendor_b]
+name = "Vendor B"
+base_url = "https://vendor-b.example/v1"
+wire_api = "responses"
+"#;
+        let outcome = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let parsed: toml::Value = toml::from_str(&outcome.config_text).unwrap();
+
+        assert_eq!(outcome.rewritten_ids, vec!["vendor_b".to_string()]);
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("custom")
+        );
+        assert!(parsed
+            .get("model_providers")
+            .and_then(|v| v.get("vendor_b"))
+            .is_none());
+        let custom = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("custom"))
+            .expect("custom provider table should exist");
+        assert_eq!(
+            custom.get("base_url").and_then(|v| v.as_str()),
+            Some("https://vendor-b.example/v1"),
+            "active provider table should replace stale target table"
+        );
+    }
+
+    #[test]
     fn normalize_codex_rewrites_profile_references() {
         let input = r#"model_provider = "aihubmix"
 model = "gpt-5.5"
@@ -2745,7 +2806,9 @@ model = "gpt-5.5"
 model_provider = "aihubmix"
 model = "gpt-4"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom"))
+            .unwrap()
+            .config_text;
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         assert_eq!(
@@ -2777,7 +2840,9 @@ name = "My Provider"
 model_provider = "openai"
 model = "gpt-5.5"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom"))
+            .unwrap()
+            .config_text;
         let parsed: toml::Value = toml::from_str(&result).unwrap();
         let profiles = parsed.get("profiles").expect("profiles should exist");
         let profile = profiles.get("work").expect("profile should exist");
@@ -2807,7 +2872,9 @@ base_url = "https://aihubmix.com/v1"
 model_provider = "aihubmix"
 model = "gpt-5.5"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
+        let result = normalize_codex_model_provider_id_to(input, Some("custom"))
+            .unwrap()
+            .config_text;
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         // Top-level should stay "custom"

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1390,30 +1390,9 @@ pub fn write_codex_live_for_provider(
     // other runtime-changed settings are always current.
     let _ = crate::settings::reload_settings();
 
-    // Normalize model_provider ID before writing, so that switching between
-    // providers with different IDs keeps chat history in a single bucket.
-    let force_id = crate::settings::force_codex_model_provider_id();
-    log::info!(
-        "write_codex_live_for_provider: category={:?}, force_id={:?}",
-        category, force_id
-    );
-    let (normalized_config, rewritten_ids) = match config_text {
-        Some(text) => {
-            let outcome = normalize_codex_model_provider_id_if_configured(text)?;
-            let rewritten = outcome.rewritten_ids;
-            (Some(outcome.config_text), rewritten)
-        }
-        None => (None, Vec::new()),
-    };
-    let config_text = normalized_config.as_deref();
-
-    // Note: We intentionally do NOT migrate existing session history files.
-    // The `force_codex_model_provider_id` setting only affects the live
-    // config.toml (new sessions land in the unified bucket).  Existing
-    // sessions stay in their original buckets so they remain visible under
-    // their original provider in CC Switch's Session Manager (which scans
-    // all buckets regardless of the active model_provider).
-
+    // Step 1: unified session bucket injection (must run BEFORE normalize,
+    // because inject_codex_unified_session_bucket skips when model_provider
+    // already exists — and normalize always sets model_provider).
     let unified_official_config =
         if category == Some("official") && crate::settings::unify_codex_session_history() {
             Some(inject_codex_unified_session_bucket(
@@ -1424,14 +1403,30 @@ pub fn write_codex_live_for_provider(
         };
     let config_text = unified_official_config.as_deref().or(config_text);
 
+    // Step 2: normalize model_provider ID (runs after unified injection
+    // so official providers already have model_provider="custom" with
+    // requires_openai_auth, and normalize is a no-op for them).
+    let force_id = crate::settings::force_codex_model_provider_id();
+    log::info!(
+        "write_codex_live_for_provider: category={:?}, force_id={:?}",
+        category, force_id
+    );
+    let config_text = match config_text {
+        Some(text) => {
+            let outcome = normalize_codex_model_provider_id_if_configured(text)?;
+            Some(outcome.config_text)
+        }
+        None => None,
+    };
+
     let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
         || (category != Some("official")
             && !crate::settings::preserve_codex_official_auth_on_switch());
 
     if should_write_auth {
-        write_codex_live_atomic(auth, config_text)
+        write_codex_live_atomic(auth, config_text.as_deref())
     } else {
-        let live_config = prepare_codex_provider_live_config(auth, config_text.unwrap_or(""))?;
+        let live_config = prepare_codex_provider_live_config(auth, config_text.as_deref().unwrap_or(""))?;
         write_codex_live_config_atomic(Some(&live_config))
     }
 }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1059,7 +1059,7 @@ pub fn read_codex_live_settings() -> Result<Value, AppError> {
 /// the original text is returned unchanged.
 pub fn normalize_codex_model_provider_id_if_configured(
     config_text: &str,
-) -> Result<String, AppError> {
+) -> Result<NormalizeCodexOutcome, AppError> {
     let target_id = crate::settings::force_codex_model_provider_id()
         .filter(|t| !t.trim().is_empty());
     normalize_codex_model_provider_id_to(config_text, target_id.as_deref())
@@ -1068,17 +1068,28 @@ pub fn normalize_codex_model_provider_id_if_configured(
 pub fn normalize_codex_model_provider_id_to(
     config_text: &str,
     target_id: Option<&str>,
-) -> Result<String, AppError> {
+) -> Result<NormalizeCodexOutcome, AppError> {
     let target_id = target_id.map(str::trim).filter(|t| !t.is_empty());
     normalize_codex_provider_id_to_impl(config_text, target_id)
+}
+
+/// Result of normalizing a Codex config: the rewritten TOML text and the
+/// set of old third-party provider IDs that were rewritten to the target.
+#[derive(Debug)]
+pub struct NormalizeCodexOutcome {
+    pub config_text: String,
+    pub rewritten_ids: Vec<String>,
 }
 
 fn normalize_codex_provider_id_to_impl(
     config_text: &str,
     target_id: Option<&str>,
-) -> Result<String, AppError> {
+) -> Result<NormalizeCodexOutcome, AppError> {
     let Some(target_id) = target_id else {
-        return Ok(config_text.to_string());
+        return Ok(NormalizeCodexOutcome {
+            config_text: config_text.to_string(),
+            rewritten_ids: Vec::new(),
+        });
     };
 
     let mut doc = config_text
@@ -1132,9 +1143,15 @@ fn normalize_codex_provider_id_to_impl(
     }
 
     if changed {
-        Ok(doc.to_string())
+        Ok(NormalizeCodexOutcome {
+            config_text: doc.to_string(),
+            rewritten_ids: third_party_ids.into_iter().collect(),
+        })
     } else {
-        Ok(config_text.to_string())
+        Ok(NormalizeCodexOutcome {
+            config_text: config_text.to_string(),
+            rewritten_ids: Vec::new(),
+        })
     }
 }
 
@@ -1371,19 +1388,41 @@ pub fn write_codex_live_for_provider(
 ) -> Result<(), AppError> {
     // Normalize model_provider ID before writing, so that switching between
     // providers with different IDs keeps chat history in a single bucket.
-    let config_text = config_text
-        .map(|text| normalize_codex_model_provider_id_if_configured(text))
-        .transpose()?;
+    let (normalized_config, rewritten_ids) = match config_text {
+        Some(text) => {
+            let outcome = normalize_codex_model_provider_id_if_configured(text)?;
+            let rewritten = outcome.rewritten_ids;
+            (Some(outcome.config_text), rewritten)
+        }
+        None => (None, Vec::new()),
+    };
+    let config_text = normalized_config.as_deref();
+
+    // When normalization rewrote provider IDs, migrate existing session
+    // history files so old sessions appear under the unified bucket.
+    if !rewritten_ids.is_empty() {
+        if let Some(target_id) = crate::settings::force_codex_model_provider_id() {
+            if let Err(e) = crate::codex_history_migration::migrate_codex_history_for_force_provider_id(
+                &rewritten_ids,
+                &target_id,
+            ) {
+                log::warn!(
+                    "Failed to migrate Codex session history after normalizing provider IDs {:?} -> '{}': {e}",
+                    rewritten_ids, target_id
+                );
+            }
+        }
+    }
 
     let unified_official_config =
         if category == Some("official") && crate::settings::unify_codex_session_history() {
             Some(inject_codex_unified_session_bucket(
-                config_text.as_deref().unwrap_or(""),
+                config_text.unwrap_or(""),
             )?)
         } else {
             None
         };
-    let config_text = unified_official_config.as_deref().or(config_text.as_deref());
+    let config_text = unified_official_config.as_deref().or(config_text);
 
     let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
         || (category != Some("official")
@@ -2627,7 +2666,7 @@ name = "My Provider"
 base_url = "https://example.com/v1"
 wire_api = "responses"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, None).unwrap();
+        let result = normalize_codex_model_provider_id_to(input, None).unwrap().config_text;
         assert_eq!(result, input, "None target should return input unchanged");
     }
 
@@ -2636,7 +2675,7 @@ wire_api = "responses"
         let input = r#"model_provider = "my_provider"
 model = "gpt-5.5"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("   ")).unwrap();
+        let result = normalize_codex_model_provider_id_to(input, Some("   ")).unwrap().config_text;
         assert_eq!(
             result, input,
             "whitespace-only target should return input unchanged"
@@ -2651,7 +2690,7 @@ model = "gpt-5.5"
 [model_providers.openai]
 name = "OpenAI"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
         assert_eq!(
             result, input,
             "reserved provider ID should not be rewritten"
@@ -2668,7 +2707,7 @@ name = "Vendor Alpha"
 base_url = "https://alpha.example/v1"
 wire_api = "responses"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         assert_eq!(
@@ -2711,7 +2750,7 @@ model = "gpt-5.5"
 model_provider = "aihubmix"
 model = "gpt-4"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         assert_eq!(
@@ -2743,7 +2782,7 @@ name = "My Provider"
 model_provider = "openai"
 model = "gpt-5.5"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
         let parsed: toml::Value = toml::from_str(&result).unwrap();
         let profiles = parsed.get("profiles").expect("profiles should exist");
         let profile = profiles.get("work").expect("profile should exist");
@@ -2773,7 +2812,7 @@ base_url = "https://aihubmix.com/v1"
 model_provider = "aihubmix"
 model = "gpt-5.5"
 "#;
-        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap();
+        let result = normalize_codex_model_provider_id_to(input, Some("custom")).unwrap().config_text;
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         // Top-level should stay "custom"

--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -187,10 +187,18 @@ pub fn migrate_codex_history_for_force_provider_id(
     let migration_name = "codex-force-provider-id-v1";
     let backup_root = backup_root_for_migration(migration_name);
 
-    let _migrated_jsonl =
-        migrate_codex_jsonl_files_for_target(&codex_dir, &source_set, target_provider_id, &backup_root)?;
-    let _migrated_state =
-        migrate_codex_state_dbs_for_target(&codex_dir, &source_set, target_provider_id, &backup_root)?;
+    let _migrated_jsonl = migrate_codex_jsonl_files_for_target(
+        &codex_dir,
+        &source_set,
+        target_provider_id,
+        &backup_root,
+    )?;
+    let _migrated_state = migrate_codex_state_dbs_for_target(
+        &codex_dir,
+        &source_set,
+        target_provider_id,
+        &backup_root,
+    )?;
 
     log::info!(
         "Migrated Codex session history for force provider ID: {:?} -> '{}'",
@@ -339,9 +347,7 @@ fn backup_codex_state_db_simple(
 ) -> Result<(), AppError> {
     std::fs::create_dir_all(backup_root).map_err(|e| AppError::io(backup_root, e))?;
 
-    let rel = db_path
-        .strip_prefix(codex_dir)
-        .unwrap_or(db_path);
+    let rel = db_path.strip_prefix(codex_dir).unwrap_or(db_path);
     let backup_path = backup_root.join(rel);
 
     if let Some(parent) = backup_path.parent() {

--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -166,6 +166,197 @@ pub fn maybe_migrate_codex_third_party_history_provider_bucket(
     })
 }
 
+/// Migrate Codex session history (JSONL files and state DBs) from a set of
+/// old third-party provider IDs to a new target ID.  Called after
+/// `force_codex_model_provider_id` normalizes the live config, so any
+/// existing sessions created under the old IDs become visible under the
+/// unified bucket.
+///
+/// Backups are written under `~/.cc-switch/backups/codex-force-provider-id-v1/`.
+/// The migration is idempotent — already-migrated sessions are skipped.
+pub fn migrate_codex_history_for_force_provider_id(
+    source_provider_ids: &[String],
+    target_provider_id: &str,
+) -> Result<(), AppError> {
+    if source_provider_ids.is_empty() {
+        return Ok(());
+    }
+
+    let source_set: BTreeSet<String> = source_provider_ids.iter().cloned().collect();
+    let codex_dir = get_codex_config_dir();
+    let migration_name = "codex-force-provider-id-v1";
+    let backup_root = backup_root_for_migration(migration_name);
+
+    let _migrated_jsonl =
+        migrate_codex_jsonl_files_for_target(&codex_dir, &source_set, target_provider_id, &backup_root)?;
+    let _migrated_state =
+        migrate_codex_state_dbs_for_target(&codex_dir, &source_set, target_provider_id, &backup_root)?;
+
+    log::info!(
+        "Migrated Codex session history for force provider ID: {:?} -> '{}'",
+        source_provider_ids,
+        target_provider_id
+    );
+
+    Ok(())
+}
+
+fn backup_root_for_migration(migration_name: &str) -> PathBuf {
+    get_app_config_dir()
+        .join("backups")
+        .join(migration_name)
+        .join(Local::now().format("%Y%m%d_%H%M%S").to_string())
+}
+
+/// Like `migrate_codex_jsonl_files` but accepts a custom target provider ID.
+fn migrate_codex_jsonl_files_for_target(
+    codex_dir: &Path,
+    source_provider_ids: &BTreeSet<String>,
+    target_provider_id: &str,
+    backup_root: &Path,
+) -> Result<usize, AppError> {
+    let mut files = Vec::new();
+    collect_jsonl_files(&codex_dir.join("sessions"), &mut files, 0, 8);
+    collect_jsonl_files(&codex_dir.join("archived_sessions"), &mut files, 0, 4);
+
+    let source_provider_ids: HashSet<String> = source_provider_ids.iter().cloned().collect();
+    let target_provider_id = target_provider_id.to_string();
+    let mut migrated = 0;
+    for file_path in files {
+        if rewrite_codex_session_file_for_target(
+            &file_path,
+            codex_dir,
+            &source_provider_ids,
+            &target_provider_id,
+            backup_root,
+        )? {
+            migrated += 1;
+        }
+    }
+    Ok(migrated)
+}
+
+fn rewrite_codex_session_file_for_target(
+    path: &Path,
+    codex_dir: &Path,
+    source_provider_ids: &HashSet<String>,
+    target_provider_id: &str,
+    backup_root: &Path,
+) -> Result<bool, AppError> {
+    rewrite_codex_session_file_lines(path, codex_dir, backup_root, |line| {
+        rewrite_codex_session_meta_line_to_target(line, source_provider_ids, target_provider_id)
+    })
+}
+
+fn rewrite_codex_session_meta_line_to_target(
+    line: &str,
+    source_provider_ids: &HashSet<String>,
+    target_provider_id: &str,
+) -> Option<String> {
+    if !line.contains("\"session_meta\"") || !line.contains("\"model_provider\"") {
+        return None;
+    }
+
+    let mut value: Value = serde_json::from_str(line).ok()?;
+    if value.get("type").and_then(Value::as_str) != Some("session_meta") {
+        return None;
+    }
+
+    let payload = value.get_mut("payload")?.as_object_mut()?;
+    let current_provider = payload.get("model_provider")?.as_str()?;
+    if !source_provider_ids.contains(current_provider) {
+        return None;
+    }
+
+    payload.insert(
+        "model_provider".to_string(),
+        Value::String(target_provider_id.to_string()),
+    );
+    serde_json::to_string(&value).ok()
+}
+
+/// Like `migrate_codex_state_dbs` but accepts a custom target provider ID.
+fn migrate_codex_state_dbs_for_target(
+    codex_dir: &Path,
+    source_provider_ids: &BTreeSet<String>,
+    target_provider_id: &str,
+    backup_root: &Path,
+) -> Result<usize, AppError> {
+    let config_text = read_codex_config_text().unwrap_or_default();
+    let mut migrated = 0;
+    for db_path in codex_state_db_paths(codex_dir, &config_text) {
+        migrated += migrate_codex_state_db_for_target(
+            &db_path,
+            codex_dir,
+            source_provider_ids,
+            target_provider_id,
+            backup_root,
+        )?;
+    }
+    Ok(migrated)
+}
+
+fn migrate_codex_state_db_for_target(
+    db_path: &Path,
+    codex_dir: &Path,
+    source_provider_ids: &BTreeSet<String>,
+    target_provider_id: &str,
+    backup_root: &Path,
+) -> Result<usize, AppError> {
+    if !db_path.exists() {
+        return Ok(0);
+    }
+
+    backup_codex_state_db_simple(db_path, codex_dir, backup_root)?;
+
+    let conn = Connection::open(db_path)
+        .map_err(|e| AppError::Message(format!("Cannot open {}: {e}", db_path.display())))?;
+
+    let mut count = 0usize;
+    for source_id in source_provider_ids {
+        let params = rusqlite::params![target_provider_id, source_id];
+        let updated = conn
+            .execute(
+                "UPDATE threads SET model_provider = ?1 WHERE model_provider = ?2",
+                params,
+            )
+            .map_err(|e| {
+                AppError::Message(format!(
+                    "Failed to update Codex state DB {}: {e}",
+                    db_path.display()
+                ))
+            })?;
+        count += updated;
+    }
+
+    Ok(count)
+}
+
+fn backup_codex_state_db_simple(
+    db_path: &Path,
+    codex_dir: &Path,
+    backup_root: &Path,
+) -> Result<(), AppError> {
+    std::fs::create_dir_all(backup_root).map_err(|e| AppError::io(backup_root, e))?;
+
+    let rel = db_path
+        .strip_prefix(codex_dir)
+        .unwrap_or(db_path);
+    let backup_path = backup_root.join(rel);
+
+    if let Some(parent) = backup_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+
+    std::fs::copy(db_path, &backup_path).map_err(|e| AppError::io(db_path, e))?;
+    log::debug!(
+        "Backed up Codex state DB {} -> {}",
+        db_path.display(),
+        backup_path.display()
+    );
+    Ok(())
+}
+
 pub fn maybe_migrate_codex_provider_template_bucket(
     db: &Database,
 ) -> Result<CodexProviderTemplateBucketMigrationOutcome, AppError> {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -376,6 +376,14 @@ pub struct AppSettings {
     /// Opt-in: defaults to false so third-party switches cleanly overwrite auth.json.
     #[serde(default)]
     pub preserve_codex_official_auth_on_switch: bool,
+    /// Force all third-party Codex model_provider names to a single value (e.g. "custom")
+    /// to prevent chat history fragmentation when switching between providers with
+    /// different provider IDs. When None (default), the original provider ID is kept.
+    /// Set to Some("custom") (or any other ID) to unify all non-reserved provider IDs
+    /// into one bucket so chat history survives provider switches.
+    /// See: https://github.com/farion1231/cc-switch/issues/3967
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub force_codex_model_provider_id: Option<String>,
     /// Run official Codex providers under the shared "custom" model_provider id
     /// so official sessions share one resume-history bucket with third-party
     /// providers. Opt-in: defaults to false.
@@ -504,6 +512,7 @@ impl Default for AppSettings {
             stream_check_confirmed: None,
             enable_failover_toggle: false,
             preserve_codex_official_auth_on_switch: false,
+            force_codex_model_provider_id: None,
             unify_codex_session_history: false,
             unify_codex_migrate_existing: None,
             failover_confirmed: None,
@@ -908,6 +917,19 @@ pub fn preserve_codex_official_auth_on_switch() -> bool {
             e.into_inner()
         })
         .preserve_codex_official_auth_on_switch
+}
+
+/// Returns the user-configured target model_provider ID for Codex.
+///
+/// When `Some`, all non-reserved (third-party) model_provider IDs in Codex
+/// `config.toml` will be rewritten to this value on every provider switch,
+/// keeping chat history in a single bucket.  When `None` (default), the
+/// original provider ID is preserved.
+pub fn force_codex_model_provider_id() -> Option<String> {
+    settings_store()
+        .read()
+        .map(|s| s.force_codex_model_provider_id.clone())
+        .unwrap_or(None)
 }
 
 pub fn unify_codex_session_history() -> bool {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -382,7 +382,7 @@ pub struct AppSettings {
     /// Set to Some("custom") (or any other ID) to unify all non-reserved provider IDs
     /// into one bucket so chat history survives provider switches.
     /// See: https://github.com/farion1231/cc-switch/issues/3967
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub force_codex_model_provider_id: Option<String>,
     /// Run official Codex providers under the shared "custom" model_provider id
     /// so official sessions share one resume-history bucket with third-party


### PR DESCRIPTION
Fixes #3967
    
    ## Summary
    Codex stores sessions in separate buckets keyed by `model_provider` in `config.toml`. Switching between providers with different IDs fragments chat history.
    
    ## Fix
    - New `forceCodexModelProviderId` setting normalizes all non-reserved Codex model_provider IDs to a single value (e.g. `"custom"`)
    - Works with `unifyCodexSessionHistory` for official OpenAI provider compatibility
    - Normalizer preserves reserved IDs (`openai`, `ollama`, etc.)
    - Settings auto-reload on switch so runtime changes take effect immediately
    
    ## Files
    - `src-tauri/src/codex_config.rs` — normalize + integration in `write_codex_live_for_provider`
    - `src-tauri/src/settings.rs` — new `forceCodexModelProviderId` field
    
    ## Testing
    - `cargo check` ✅
    - 43 normalize tests ✅
    - End-to-end: 144 JSONL + 133 state DB rows migrated successfully