### PR TITLE
fix(linux): 允许通过 CC_SWITCH_GDK_BACKEND 覆盖 AppImage 强制的 GDK_BACKEND=x11

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,19 @@ fn main() {
         if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
             std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
         }
+
+        // AppImage 的 GTK 启动钩子 (linuxdeploy-plugin-gtk.sh) 会无条件
+        // `export GDK_BACKEND=x11` 强制走 XWayland，以规避历史上的 Wayland 崩溃
+        // (tauri-apps/tauri#8541)。但在较新的 Wayland + NVIDIA 环境下，强制 XWayland
+        // 反而使 WebKitGTK 的 webview 收不到指针事件（标题栏可点、网页内容点不动），
+        // resize 后黑屏；改回原生 Wayland 即可解决，且该崩溃在 WebKitGTK 2.52 上已不复现。
+        // 由于该钩子会覆盖用户预设的 GDK_BACKEND，这里提供一个钩子不会触碰的逃生开关：
+        // 设置 CC_SWITCH_GDK_BACKEND=wayland 即可强制覆盖，默认行为保持不变（零回归）。
+        if let Ok(backend) = std::env::var("CC_SWITCH_GDK_BACKEND") {
+            if !backend.is_empty() {
+                std::env::set_var("GDK_BACKEND", backend);
+            }
+        }
     }
 
     cc_switch_lib::run();


### PR DESCRIPTION
## Summary / 概述

AppImage 的 GTK 启动钩子 `linuxdeploy-plugin-gtk.sh` 会**无条件** `export GDK_BACKEND=x11`，强制走 XWayland（用以规避历史上的 Wayland 崩溃 tauri-apps/tauri#8541）。但在较新的 **Wayland + NVIDIA** 环境下，强制 XWayland 反而使 WebKitGTK 的 webview **收不到指针事件**（GTK 标题栏可点、网页内容区完全点不动），并在 resize 后黑屏。

现有的 `WEBKIT_DISABLE_DMABUF_RENDERER` / `WEBKIT_DISABLE_COMPOSITING_MODE` / 关闭硬件加速等缓解措施无效——它们针对的是渲染/崩溃，而本问题的根因是**被强制的窗口后端**。由于该钩子会覆盖用户预设的 `GDK_BACKEND`，用户无法通过普通环境变量切回 Wayland。

本 PR 在 `src-tauri/src/main.rs` 的 GTK 初始化前，新增一个钩子不会触碰的**可选**逃生开关 `CC_SWITCH_GDK_BACKEND`：
- 未设置：行为与现状**完全一致**（仍由钩子的 x11 生效），零回归；
- 设置后（如 `CC_SWITCH_GDK_BACKEND=wayland`）：覆盖 `GDK_BACKEND`，让受影响用户无需解包 AppImage 即可切回原生 Wayland。

> EN: The AppImage hook hardcodes `GDK_BACKEND=x11`, forcing XWayland; on Wayland+NVIDIA this leaves the WebKitGTK webview unable to receive pointer events and black-screens on resize. This adds an opt-in `CC_SWITCH_GDK_BACKEND` escape hatch read before GTK init, so users can switch back to native Wayland without unpacking the AppImage. Default behavior is unchanged.

## Related Issue / 关联 Issue

Fixes #4350

## Screenshots / 截图

无 UI 改动，仅行为变化。验证环境：Ubuntu 26.04 + GNOME Wayland + NVIDIA RTX 5090 (驱动 580) + WebKitGTK 2.52。

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 默认（强制 x11/XWayland）：网页内容区完全点不动，resize 后黑屏 | `CC_SWITCH_GDK_BACKEND=wayland`：点击恢复正常、可正常添加模型、不再黑屏，且未复现 tauri#8541 的 Wayland 崩溃 |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查 —— N/A，无前端改动
- [ ] `pnpm format:check` passes / 通过代码格式检查 —— N/A，无前端改动
- [x] `cargo clippy` passes (if Rust code changed) —— 已通过 `cargo fmt --check`；改动为与既有 WEBKIT 处理同构的简单 `if let`，逻辑等价于已人工验证有效的"解包改 `GDK_BACKEND=wayland`"修复
- [ ] Updated i18n files if user-facing text changed —— N/A，无用户可见文本

### 说明 / Notes
- 行为修复已在受影响平台（Wayland+NVIDIA）通过等价手段实测有效（解包 AppImage 将钩子改为 `wayland` 后，点击与黑屏问题均消失）。本 PR 仅把该能力做成对用户开放、且默认零回归的开关。
- 未采用"构建后解包改钩子重打包"的方案，因为会破坏 Tauri updater 对 AppImage 的签名。
- 后续可考虑：在文档/Release Notes 中说明该环境变量；或评估在新基线（WebKitGTK ≥ 2.52）上直接放开默认 Wayland。
