### PR TITLE
feat(claude-desktop): 增加关闭自动更新设置

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -19,6 +19,7 @@ const CONFIG_FILE: &str = "claude_desktop_config.json";
 #[cfg(any(target_os = "macos", windows, test))]
 const CONFIG_LIBRARY_DIR: &str = "configLibrary";
 const GATEWAY_TOKEN_SETTING_KEY: &str = "claude_desktop_gateway_token";
+const DISABLE_AUTO_UPDATES_SETTING_KEY: &str = "claude_desktop_disable_auto_updates";
 const CLAUDE_DESKTOP_PROXY_PREFIX: &str = "/claude-desktop";
 const DEFAULT_CREATED_AT: &str = "2024-01-01T00:00:00Z";
 const MIMO_REDACTED_THINKING_PLACEHOLDER: &str = "[redacted thinking]";
@@ -108,6 +109,7 @@ pub struct ClaudeDesktopStatus {
     pub stale_raw_models: bool,
     pub missing_route_mappings: bool,
     pub gateway_token_configured: bool,
+    pub disable_auto_updates: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -145,6 +147,7 @@ pub fn get_status(db: &Database, proxy_running: bool) -> Result<ClaudeDesktopSta
             stale_raw_models: false,
             missing_route_mappings: false,
             gateway_token_configured: false,
+            disable_auto_updates: false,
         });
     }
 
@@ -172,6 +175,7 @@ pub fn get_status(db: &Database, proxy_running: bool) -> Result<ClaudeDesktopSta
         .ok()
         .flatten()
         .is_some_and(|token| !token.trim().is_empty());
+    let disable_auto_updates = configured_disable_auto_updates(db, &paths);
     let current_provider = crate::settings::get_effective_current_provider(
         db,
         &crate::app_config::AppType::ClaudeDesktop,
@@ -206,11 +210,30 @@ pub fn get_status(db: &Database, proxy_running: bool) -> Result<ClaudeDesktopSta
         stale_raw_models,
         missing_route_mappings,
         gateway_token_configured,
+        disable_auto_updates,
     })
 }
 
 pub fn get_config_library_path() -> Result<PathBuf, AppError> {
     Ok(current_platform_paths()?.config_library_path)
+}
+
+pub fn set_disable_auto_updates(db: &Database, enabled: bool) -> Result<(), AppError> {
+    db.set_setting(
+        DISABLE_AUTO_UPDATES_SETTING_KEY,
+        if enabled { "true" } else { "false" },
+    )?;
+
+    if !is_supported_platform() {
+        return Err(AppError::localized(
+            "claude_desktop.unsupported_platform",
+            "当前平台不支持 Claude Desktop 配置",
+            "Claude Desktop configuration is not supported on this platform",
+        ));
+    }
+
+    let paths = current_platform_paths()?;
+    write_disable_auto_updates_to_active_profile(&paths, enabled)
 }
 
 pub fn default_proxy_routes() -> Vec<ClaudeDesktopDefaultRoute> {
@@ -231,6 +254,55 @@ pub fn provider_mode(provider: &Provider) -> ClaudeDesktopMode {
         .as_ref()
         .and_then(|meta| meta.claude_desktop_mode.clone())
         .unwrap_or(ClaudeDesktopMode::Direct)
+}
+
+fn stored_disable_auto_updates(db: &Database) -> bool {
+    db.get_setting(DISABLE_AUTO_UPDATES_SETTING_KEY)
+        .ok()
+        .flatten()
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("true"))
+}
+
+fn configured_disable_auto_updates(db: &Database, paths: &ClaudeDesktopPaths) -> bool {
+    active_profile_disable_auto_updates(paths).unwrap_or_else(|| stored_disable_auto_updates(db))
+}
+
+fn active_profile_disable_auto_updates(paths: &ClaudeDesktopPaths) -> Option<bool> {
+    let profile_path = active_profile_path(paths);
+    read_json_or_empty(&profile_path)
+        .ok()
+        .and_then(|profile| profile.get("disableAutoUpdates").and_then(Value::as_bool))
+}
+
+fn write_disable_auto_updates_to_active_profile(
+    paths: &ClaudeDesktopPaths,
+    enabled: bool,
+) -> Result<(), AppError> {
+    let profile_path = active_profile_path(paths);
+    let mut profile = read_json_or_empty(&profile_path)?;
+    if !profile.is_object() {
+        profile = json!({});
+    }
+
+    let obj = profile.as_object_mut().expect("just normalized to object");
+    obj.insert("disableAutoUpdates".to_string(), json!(enabled));
+    write_json_file(&profile_path, &profile)
+}
+
+fn active_profile_path(paths: &ClaudeDesktopPaths) -> PathBuf {
+    read_applied_id(&paths.meta_path)
+        .as_deref()
+        .and_then(|id| profile_path_for_id(&paths.config_library_path, id))
+        .unwrap_or_else(|| paths.profile_path.clone())
+}
+
+fn profile_path_for_id(config_library_path: &Path, profile_id: &str) -> Option<PathBuf> {
+    let trimmed = profile_id.trim();
+    if trimmed.is_empty() || trimmed.contains('/') || trimmed.contains('\\') {
+        return None;
+    }
+
+    Some(config_library_path.join(format!("{trimmed}.json")))
 }
 
 pub fn is_claude_safe_model_id(model: &str) -> bool {
@@ -971,6 +1043,7 @@ fn apply_provider_to_paths_inner(
     provider: &Provider,
     paths: &ClaudeDesktopPaths,
 ) -> Result<(), AppError> {
+    let disable_auto_updates = configured_disable_auto_updates(db, paths);
     let profile = match provider_mode(provider) {
         ClaudeDesktopMode::Direct => {
             let credentials = direct_gateway_credentials(provider)?;
@@ -978,6 +1051,7 @@ fn apply_provider_to_paths_inner(
             build_gateway_profile(
                 &credentials.base_url,
                 &credentials.api_key,
+                disable_auto_updates,
                 (!model_specs.is_empty()).then_some(model_specs.as_slice()),
             )
         }
@@ -993,7 +1067,12 @@ fn apply_provider_to_paths_inner(
                     supports_1m: route.supports_1m,
                 })
                 .collect::<Vec<_>>();
-            build_gateway_profile(&base_url, &api_key, Some(model_specs.as_slice()))
+            build_gateway_profile(
+                &base_url,
+                &api_key,
+                disable_auto_updates,
+                Some(model_specs.as_slice()),
+            )
         }
     };
 
@@ -1021,10 +1100,12 @@ fn restore_official_at_paths_inner(paths: &ClaudeDesktopPaths) -> Result<(), App
 fn build_gateway_profile(
     base_url: &str,
     api_key: &str,
+    disable_auto_updates: bool,
     model_specs: Option<&[InferenceModelSpec]>,
 ) -> Value {
     let mut profile = json!({
         "coworkEgressAllowedHosts": ["*"],
+        "disableAutoUpdates": disable_auto_updates,
         "disableDeploymentModeChooser": true,
         "inferenceGatewayApiKey": api_key,
         "inferenceGatewayAuthScheme": "bearer",
@@ -1501,6 +1582,7 @@ mod tests {
         );
         assert_eq!(profile["inferenceGatewayApiKey"], json!("test-token"));
         assert_eq!(profile["inferenceGatewayAuthScheme"], json!("bearer"));
+        assert_eq!(profile["disableAutoUpdates"], json!(false));
         assert_eq!(profile["disableDeploymentModeChooser"], json!(true));
         assert_eq!(profile["coworkEgressAllowedHosts"], json!(["*"]));
         assert!(profile.get("inferenceModels").is_none());
@@ -1510,6 +1592,64 @@ mod tests {
             .expect("entries")
             .iter()
             .any(|entry| entry["id"] == json!(PROFILE_ID) && entry["name"] == json!(PROFILE_NAME)));
+    }
+
+    #[test]
+    fn claude_desktop_apply_writes_stored_disable_auto_updates_flag() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+        let provider = direct_provider("direct-no-updates");
+        let db = test_db();
+        db.set_setting(DISABLE_AUTO_UPDATES_SETTING_KEY, "true")
+            .expect("store setting");
+
+        apply_provider_to_paths(&db, &provider, &paths).expect("apply provider");
+
+        let profile: Value = read_json_file(&paths.profile_path).expect("read profile");
+        assert_eq!(profile["disableAutoUpdates"], json!(true));
+    }
+
+    #[test]
+    fn claude_desktop_apply_preserves_existing_profile_disable_auto_updates_flag() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+        let provider = direct_provider("direct-preserve-no-updates");
+        let db = test_db();
+        write_json_file(&paths.profile_path, &json!({ "disableAutoUpdates": true }))
+            .expect("seed profile");
+
+        apply_provider_to_paths(&db, &provider, &paths).expect("apply provider");
+
+        let profile: Value = read_json_file(&paths.profile_path).expect("read profile");
+        assert_eq!(profile["disableAutoUpdates"], json!(true));
+    }
+
+    #[test]
+    fn claude_desktop_disable_auto_updates_updates_active_profile() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+        let external_id = "external-profile";
+        let external_profile_path = paths
+            .config_library_path
+            .join(format!("{external_id}.json"));
+        write_json_file(
+            &paths.meta_path,
+            &json!({
+                "appliedId": external_id,
+                "entries": [{ "id": external_id, "name": "External" }]
+            }),
+        )
+        .expect("seed meta");
+        write_json_file(&external_profile_path, &json!({ "name": "External" }))
+            .expect("seed profile");
+
+        write_disable_auto_updates_to_active_profile(&paths, true).expect("write true");
+        let profile: Value = read_json_file(&external_profile_path).expect("read profile");
+        assert_eq!(profile["disableAutoUpdates"], json!(true));
+
+        write_disable_auto_updates_to_active_profile(&paths, false).expect("write false");
+        let profile: Value = read_json_file(&external_profile_path).expect("read profile");
+        assert_eq!(profile["disableAutoUpdates"], json!(false));
     }
 
     #[test]

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -219,11 +219,6 @@ pub fn get_config_library_path() -> Result<PathBuf, AppError> {
 }
 
 pub fn set_disable_auto_updates(db: &Database, enabled: bool) -> Result<(), AppError> {
-    db.set_setting(
-        DISABLE_AUTO_UPDATES_SETTING_KEY,
-        if enabled { "true" } else { "false" },
-    )?;
-
     if !is_supported_platform() {
         return Err(AppError::localized(
             "claude_desktop.unsupported_platform",
@@ -233,7 +228,19 @@ pub fn set_disable_auto_updates(db: &Database, enabled: bool) -> Result<(), AppE
     }
 
     let paths = current_platform_paths()?;
-    write_disable_auto_updates_to_active_profile(&paths, enabled)
+    set_disable_auto_updates_at_paths(db, &paths, enabled)
+}
+
+fn set_disable_auto_updates_at_paths(
+    db: &Database,
+    paths: &ClaudeDesktopPaths,
+    enabled: bool,
+) -> Result<(), AppError> {
+    write_disable_auto_updates_to_active_profile(paths, enabled)?;
+    db.set_setting(
+        DISABLE_AUTO_UPDATES_SETTING_KEY,
+        if enabled { "true" } else { "false" },
+    )
 }
 
 pub fn default_proxy_routes() -> Vec<ClaudeDesktopDefaultRoute> {
@@ -1650,6 +1657,37 @@ mod tests {
         write_disable_auto_updates_to_active_profile(&paths, false).expect("write false");
         let profile: Value = read_json_file(&external_profile_path).expect("read profile");
         assert_eq!(profile["disableAutoUpdates"], json!(false));
+    }
+
+    #[test]
+    fn claude_desktop_disable_auto_updates_persists_after_profile_write() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+        let db = test_db();
+        write_json_file(&paths.profile_path, &json!({ "name": "CC Switch" }))
+            .expect("seed profile");
+
+        set_disable_auto_updates_at_paths(&db, &paths, true).expect("set disable updates");
+
+        let profile: Value = read_json_file(&paths.profile_path).expect("read profile");
+        assert_eq!(profile["disableAutoUpdates"], json!(true));
+        assert!(stored_disable_auto_updates(&db));
+    }
+
+    #[test]
+    fn claude_desktop_disable_auto_updates_does_not_persist_when_profile_write_fails() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+        let db = test_db();
+        fs::create_dir_all(paths.profile_path.parent().expect("profile parent"))
+            .expect("create profile dir");
+        fs::write(&paths.profile_path, "{ invalid json").expect("seed broken profile");
+
+        let err = set_disable_auto_updates_at_paths(&db, &paths, true)
+            .expect_err("broken profile should fail");
+
+        assert!(err.to_string().contains("JSON"), "unexpected error: {err}");
+        assert!(!stored_disable_auto_updates(&db));
     }
 
     #[test]

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -161,6 +161,16 @@ pub async fn get_claude_desktop_status(
 }
 
 #[tauri::command]
+pub fn set_claude_desktop_disable_auto_updates(
+    state: State<'_, AppState>,
+    enabled: bool,
+) -> Result<bool, String> {
+    crate::claude_desktop_config::set_disable_auto_updates(state.db.as_ref(), enabled)
+        .map(|_| true)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub fn get_claude_desktop_default_routes(
 ) -> Vec<crate::claude_desktop_config::ClaudeDesktopDefaultRoute> {
     crate::claude_desktop_config::default_proxy_routes()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1152,6 +1152,7 @@ pub fn run() {
             commands::switch_provider,
             commands::import_default_config,
             commands::get_claude_desktop_status,
+            commands::set_claude_desktop_disable_auto_updates,
             commands::get_claude_desktop_default_routes,
             commands::import_claude_desktop_providers_from_claude,
             commands::ensure_claude_desktop_official_provider,

--- a/src/components/settings/ClaudeDesktopSettings.tsx
+++ b/src/components/settings/ClaudeDesktopSettings.tsx
@@ -63,7 +63,9 @@ export function ClaudeDesktopSettings() {
   });
 
   const supported = status?.supported !== false;
-  const disabled = isLoading || mutation.isPending || !status || !supported;
+  const configured = status?.configured === true;
+  const disabled =
+    isLoading || mutation.isPending || !status || !supported || !configured;
   const description = supported
     ? t("settings.disableClaudeDesktopAutoUpdatesDescription", {
         defaultValue:

--- a/src/components/settings/ClaudeDesktopSettings.tsx
+++ b/src/components/settings/ClaudeDesktopSettings.tsx
@@ -1,0 +1,101 @@
+import { MonitorUp, Shield } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { ToggleRow } from "@/components/ui/toggle-row";
+import { providersApi, type ClaudeDesktopStatus } from "@/lib/api/providers";
+import { extractErrorMessage } from "@/utils/errorUtils";
+
+export function ClaudeDesktopSettings() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const { data: status, isLoading } = useQuery({
+    queryKey: ["claudeDesktopStatus"],
+    queryFn: () => providersApi.getClaudeDesktopStatus(),
+    refetchInterval: 5000,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (enabled: boolean) =>
+      providersApi.setClaudeDesktopDisableAutoUpdates(enabled),
+    onMutate: async (enabled) => {
+      await queryClient.cancelQueries({ queryKey: ["claudeDesktopStatus"] });
+      const previous = queryClient.getQueryData<ClaudeDesktopStatus>([
+        "claudeDesktopStatus",
+      ]);
+
+      queryClient.setQueryData<ClaudeDesktopStatus>(
+        ["claudeDesktopStatus"],
+        (current) =>
+          current ? { ...current, disableAutoUpdates: enabled } : current,
+      );
+
+      return { previous };
+    },
+    onError: (error, _enabled, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["claudeDesktopStatus"], context.previous);
+      }
+      toast.error(
+        t("claudeDesktop.autoUpdates.failed", {
+          error: extractErrorMessage(error),
+          defaultValue: "更新 Claude Desktop 自动更新设置失败: {{error}}",
+        }),
+      );
+    },
+    onSuccess: (_result, enabled) => {
+      toast.success(
+        enabled
+          ? t("claudeDesktop.autoUpdates.blocked", {
+              defaultValue: "已关闭 Claude Desktop 自动更新",
+            })
+          : t("claudeDesktop.autoUpdates.allowed", {
+              defaultValue: "已允许 Claude Desktop 自动更新",
+            }),
+      );
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["claudeDesktopStatus"],
+      });
+    },
+  });
+
+  const supported = status?.supported !== false;
+  const disabled = isLoading || mutation.isPending || !status || !supported;
+  const description = supported
+    ? t("settings.disableClaudeDesktopAutoUpdatesDescription", {
+        defaultValue:
+          "开启后，Claude Desktop 不会自动下载和安装新版本；关闭后恢复默认自动更新。",
+      })
+    : t("settings.claudeDesktopUnsupportedDescription", {
+        defaultValue: "当前平台暂不支持 Claude Desktop 3P 配置写入。",
+      });
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-2 border-b border-border/40 pb-2">
+        <MonitorUp className="h-4 w-4 text-primary" />
+        <h3 className="text-sm font-medium">
+          {t("settings.claudeDesktopSettings", {
+            defaultValue: "Claude Desktop 设置",
+          })}
+        </h3>
+      </div>
+
+      <div className="space-y-3">
+        <ToggleRow
+          icon={<Shield className="h-4 w-4 text-blue-500" />}
+          title={t("settings.disableClaudeDesktopAutoUpdates", {
+            defaultValue: "关闭 Claude Desktop 自动更新",
+          })}
+          description={description}
+          checked={status?.disableAutoUpdates ?? false}
+          onCheckedChange={(value) => mutation.mutate(value)}
+          disabled={disabled}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -52,6 +52,7 @@ import { UsageDashboard } from "@/components/usage/UsageDashboard";
 import { LogConfigPanel } from "@/components/settings/LogConfigPanel";
 import { AuthCenterPanel } from "@/components/settings/AuthCenterPanel";
 import { CodexAuthSettings } from "@/components/settings/CodexAuthSettings";
+import { ClaudeDesktopSettings } from "@/components/settings/ClaudeDesktopSettings";
 import { useInstalledSkills } from "@/hooks/useSkills";
 import { useSettings } from "@/hooks/useSettings";
 import { useImportExport } from "@/hooks/useImportExport";
@@ -278,6 +279,7 @@ export function SettingsPage({
                       settings={settings}
                       onChange={handleAutoSave}
                     />
+                    <ClaudeDesktopSettings />
                     <WindowSettings
                       settings={settings}
                       onChange={handleAutoSave}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -215,6 +215,15 @@
     "statusMissingRouteMappings": "The current provider has model mapping enabled but no valid routes. Edit the provider and add at least one mapping.",
     "statusGatewayTokenMissing": "The local routing token has not been generated yet. Switching to this provider again will write a new local token.",
     "statusBaseUrlMismatch": "The Claude Desktop profile points to a different URL than the current provider. Current: {{actual}}; expected: {{expected}}. Switch to the current provider again to repair it.",
+    "autoUpdates": {
+      "label": "Turn off Claude Desktop auto-updates",
+      "blocked": "Claude Desktop auto-updates are off",
+      "allowed": "Claude Desktop auto-updates are allowed",
+      "failed": "Failed to update Claude Desktop auto-update setting: {{error}}",
+      "unsupported": "This platform does not support writing Claude Desktop 3P configuration yet",
+      "tooltipBlocked": "Claude Desktop auto-updates are off",
+      "tooltipAllowed": "Claude Desktop auto-updates are allowed"
+    },
     "route": {
       "tooltip": {
         "active": "Claude Desktop local routing is running - {{address}}:{{port}}",
@@ -682,6 +691,10 @@
     "skipClaudeOnboarding": "Skip Claude Code first-run confirmation",
     "skipClaudeOnboardingDescription": "When enabled, Claude Code will skip the first-run confirmation",
     "codexAuth": "Codex App Enhancements",
+    "claudeDesktopSettings": "Claude Desktop Settings",
+    "disableClaudeDesktopAutoUpdates": "Turn off Claude Desktop auto-updates",
+    "disableClaudeDesktopAutoUpdatesDescription": "When enabled, Claude Desktop will not download and install new versions automatically. Turn it off to restore the default auto-update behavior.",
+    "claudeDesktopUnsupportedDescription": "This platform does not support writing Claude Desktop 3P configuration yet.",
     "preserveCodexOfficialAuthOnSwitch": "Keep official login when switching third-party providers",
     "preserveCodexOfficialAuthOnSwitchDescription": "When enabled, you can use the Codex app's official plugins, mobile remote control, and other features while using third-party APIs.",
     "unifyCodexSessionHistory": "Unified Codex session history",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -215,6 +215,15 @@
     "statusMissingRouteMappings": "現在のプロバイダーはモデルマッピングを有効にしていますが、有効なルートがありません。プロバイダーを編集し、少なくとも 1 つのマッピングを追加してください。",
     "statusGatewayTokenMissing": "ローカルルーティング token がまだ生成されていません。このプロバイダーへ再度切り替えると新しい token が書き込まれます。",
     "statusBaseUrlMismatch": "Claude Desktop profile の URL が現在のプロバイダーと一致しません。現在: {{actual}}、期待値: {{expected}}。現在のプロバイダーへ再度切り替えると修復できます。",
+    "autoUpdates": {
+      "label": "Claude Desktop の自動更新をオフにする",
+      "blocked": "Claude Desktop の自動更新をオフにしました",
+      "allowed": "Claude Desktop の自動更新を許可しました",
+      "failed": "Claude Desktop の自動更新設定の更新に失敗しました: {{error}}",
+      "unsupported": "このプラットフォームでは Claude Desktop 3P 設定の書き込みはまだサポートされていません",
+      "tooltipBlocked": "Claude Desktop の自動更新はオフです",
+      "tooltipAllowed": "Claude Desktop の自動更新を許可しています"
+    },
     "route": {
       "tooltip": {
         "active": "Claude Desktop ローカルルーティングは起動中です - {{address}}:{{port}}",
@@ -682,6 +691,10 @@
     "skipClaudeOnboarding": "Claude Code の初回確認をスキップ",
     "skipClaudeOnboardingDescription": "オンにすると Claude Code の初回インストール確認をスキップします",
     "codexAuth": "Codex アプリ拡張",
+    "claudeDesktopSettings": "Claude Desktop 設定",
+    "disableClaudeDesktopAutoUpdates": "Claude Desktop の自動更新をオフにする",
+    "disableClaudeDesktopAutoUpdatesDescription": "オンにすると、Claude Desktop は新しいバージョンを自動でダウンロード・インストールしません。オフにすると既定の自動更新に戻ります。",
+    "claudeDesktopUnsupportedDescription": "このプラットフォームでは Claude Desktop 3P 設定の書き込みはまだサポートされていません。",
     "preserveCodexOfficialAuthOnSwitch": "サードパーティ切替時に公式ログインを保持",
     "preserveCodexOfficialAuthOnSwitchDescription": "オンにすると、サードパーティ API を使用する際に Codex アプリの公式プラグインやスマホからのリモート操作などの機能を利用できます。",
     "unifyCodexSessionHistory": "Codex セッション履歴を統一",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -215,6 +215,15 @@
     "statusMissingRouteMappings": "目前供應商啟用了模型對應，但沒有有效路由；請編輯供應商並補全至少一個模型對應。",
     "statusGatewayTokenMissing": "目前本地路由 token 尚未產生；重新切換該供應商會寫入新的本地 token。",
     "statusBaseUrlMismatch": "Claude Desktop profile 指向的位址與目前供應商不一致；目前為 {{actual}}，應為 {{expected}}。重新切換目前供應商可修復。",
+    "autoUpdates": {
+      "label": "關閉 Claude Desktop 自動更新",
+      "blocked": "已關閉 Claude Desktop 自動更新",
+      "allowed": "已允許 Claude Desktop 自動更新",
+      "failed": "更新 Claude Desktop 自動更新設定失敗: {{error}}",
+      "unsupported": "目前平台暫不支援 Claude Desktop 3P 設定寫入",
+      "tooltipBlocked": "Claude Desktop 自動更新已關閉",
+      "tooltipAllowed": "允許 Claude Desktop 自動更新"
+    },
     "route": {
       "tooltip": {
         "active": "Claude Desktop 本地路由已開啟 - {{address}}:{{port}}",
@@ -682,6 +691,10 @@
     "skipClaudeOnboarding": "跳過 Claude Code 初次安裝確認",
     "skipClaudeOnboardingDescription": "開啟後跳過 Claude Code 初次安裝確認",
     "codexAuth": "Codex 應用增強",
+    "claudeDesktopSettings": "Claude Desktop 設定",
+    "disableClaudeDesktopAutoUpdates": "關閉 Claude Desktop 自動更新",
+    "disableClaudeDesktopAutoUpdatesDescription": "開啟後，Claude Desktop 不會自動下載和安裝新版本；關閉後恢復預設自動更新。",
+    "claudeDesktopUnsupportedDescription": "目前平台暫不支援 Claude Desktop 3P 設定寫入。",
     "preserveCodexOfficialAuthOnSwitch": "切換第三方時保留官方登入",
     "preserveCodexOfficialAuthOnSwitchDescription": "開啟後可以在使用第三方 API 的時候使用 Codex 應用的官方外掛、手機遠端操作等功能",
     "unifyCodexSessionHistory": "統一 Codex 會話歷史",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -215,6 +215,15 @@
     "statusMissingRouteMappings": "当前供应商启用了模型映射，但没有有效路由；请编辑供应商并补全至少一个模型映射。",
     "statusGatewayTokenMissing": "当前本地路由 token 尚未生成；重新切换该供应商会写入新的本地 token。",
     "statusBaseUrlMismatch": "Claude Desktop profile 指向的地址与当前供应商不一致；当前为 {{actual}}，应为 {{expected}}。重新切换当前供应商可修复。",
+    "autoUpdates": {
+      "label": "关闭 Claude Desktop 自动更新",
+      "blocked": "已关闭 Claude Desktop 自动更新",
+      "allowed": "已允许 Claude Desktop 自动更新",
+      "failed": "更新 Claude Desktop 自动更新设置失败: {{error}}",
+      "unsupported": "当前平台暂不支持 Claude Desktop 3P 配置写入",
+      "tooltipBlocked": "Claude Desktop 自动更新已关闭",
+      "tooltipAllowed": "允许 Claude Desktop 自动更新"
+    },
     "route": {
       "tooltip": {
         "active": "Claude Desktop 本地路由已开启 - {{address}}:{{port}}",
@@ -682,6 +691,10 @@
     "skipClaudeOnboarding": "跳过 Claude Code 初次安装确认",
     "skipClaudeOnboardingDescription": "开启后跳过 Claude Code 初次安装确认",
     "codexAuth": "Codex 应用增强",
+    "claudeDesktopSettings": "Claude Desktop 设置",
+    "disableClaudeDesktopAutoUpdates": "关闭 Claude Desktop 自动更新",
+    "disableClaudeDesktopAutoUpdatesDescription": "开启后，Claude Desktop 不会自动下载和安装新版本；关闭后恢复默认自动更新。",
+    "claudeDesktopUnsupportedDescription": "当前平台暂不支持 Claude Desktop 3P 配置写入。",
     "preserveCodexOfficialAuthOnSwitch": "切换第三方时保留官方登录",
     "preserveCodexOfficialAuthOnSwitchDescription": "开启后可以在使用第三方 API 的时候使用 Codex 应用的官方插件、手机远程操作等功能",
     "unifyCodexSessionHistory": "统一 Codex 会话历史",

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -38,6 +38,7 @@ export interface ClaudeDesktopStatus {
   staleRawModels: boolean;
   missingRouteMappings: boolean;
   gatewayTokenConfigured: boolean;
+  disableAutoUpdates: boolean;
 }
 
 export interface ClaudeDesktopDefaultRoute {
@@ -105,6 +106,10 @@ export const providersApi = {
 
   async getClaudeDesktopStatus(): Promise<ClaudeDesktopStatus> {
     return await invoke("get_claude_desktop_status");
+  },
+
+  async setClaudeDesktopDisableAutoUpdates(enabled: boolean): Promise<boolean> {
+    return await invoke("set_claude_desktop_disable_auto_updates", { enabled });
   },
 
   async getClaudeDesktopDefaultRoutes(): Promise<ClaudeDesktopDefaultRoute[]> {

--- a/tests/components/ClaudeDesktopSettings.test.tsx
+++ b/tests/components/ClaudeDesktopSettings.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import type { ReactElement } from "react";
+import { server } from "../msw/server";
+import { ClaudeDesktopSettings } from "@/components/settings/ClaudeDesktopSettings";
+
+const TAURI_ENDPOINT = "http://tauri.local";
+
+function renderWithQueryClient(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+function claudeDesktopStatus(disableAutoUpdates: boolean) {
+  return {
+    supported: true,
+    configured: true,
+    appliedId: "00000000-0000-4000-8000-000000157210",
+    profilePath: null,
+    configLibraryPath: null,
+    mode: "direct",
+    expectedBaseUrl: null,
+    actualBaseUrl: null,
+    proxyRunning: false,
+    staleRawModels: false,
+    missingRouteMappings: false,
+    gatewayTokenConfigured: true,
+    disableAutoUpdates,
+  };
+}
+
+describe("ClaudeDesktopSettings", () => {
+  it("renders in settings and writes the toggled auto-update setting", async () => {
+    const writes: boolean[] = [];
+
+    server.use(
+      http.post(`${TAURI_ENDPOINT}/get_claude_desktop_status`, () =>
+        HttpResponse.json(claudeDesktopStatus(true)),
+      ),
+      http.post(
+        `${TAURI_ENDPOINT}/set_claude_desktop_disable_auto_updates`,
+        async ({ request }) => {
+          const body = (await request.json()) as { enabled: boolean };
+          writes.push(body.enabled);
+          return HttpResponse.json(true);
+        },
+      ),
+    );
+
+    renderWithQueryClient(<ClaudeDesktopSettings />);
+
+    expect(await screen.findByText("Claude Desktop 设置")).toBeInTheDocument();
+
+    const toggle = await screen.findByRole("switch", {
+      name: "关闭 Claude Desktop 自动更新",
+    });
+    await waitFor(() => {
+      expect(toggle).toBeChecked();
+    });
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(writes).toEqual([false]);
+    });
+  });
+});

--- a/tests/components/ClaudeDesktopSettings.test.tsx
+++ b/tests/components/ClaudeDesktopSettings.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import type { ReactElement } from "react";
 import { server } from "../msw/server";
 import { ClaudeDesktopSettings } from "@/components/settings/ClaudeDesktopSettings";
+import type { ClaudeDesktopStatus } from "@/lib/api/providers";
 
 const TAURI_ENDPOINT = "http://tauri.local";
 
@@ -18,7 +19,10 @@ function renderWithQueryClient(ui: ReactElement) {
   );
 }
 
-function claudeDesktopStatus(disableAutoUpdates: boolean) {
+function claudeDesktopStatus(
+  disableAutoUpdates: boolean,
+  overrides: Partial<ClaudeDesktopStatus> = {},
+): ClaudeDesktopStatus {
   return {
     supported: true,
     configured: true,
@@ -33,6 +37,7 @@ function claudeDesktopStatus(disableAutoUpdates: boolean) {
     missingRouteMappings: false,
     gatewayTokenConfigured: true,
     disableAutoUpdates,
+    ...overrides,
   };
 }
 
@@ -70,5 +75,36 @@ describe("ClaudeDesktopSettings", () => {
     await waitFor(() => {
       expect(writes).toEqual([false]);
     });
+  });
+
+  it("disables the switch when Claude Desktop is not configured", async () => {
+    const writes: boolean[] = [];
+
+    server.use(
+      http.post(`${TAURI_ENDPOINT}/get_claude_desktop_status`, () =>
+        HttpResponse.json(claudeDesktopStatus(false, { configured: false })),
+      ),
+      http.post(
+        `${TAURI_ENDPOINT}/set_claude_desktop_disable_auto_updates`,
+        async ({ request }) => {
+          const body = (await request.json()) as { enabled: boolean };
+          writes.push(body.enabled);
+          return HttpResponse.json(true);
+        },
+      ),
+    );
+
+    renderWithQueryClient(<ClaudeDesktopSettings />);
+
+    const toggle = await screen.findByRole("switch", {
+      name: "关闭 Claude Desktop 自动更新",
+    });
+
+    await waitFor(() => {
+      expect(toggle).toBeDisabled();
+    });
+    fireEvent.click(toggle);
+
+    expect(writes).toEqual([]);
   });
 });

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -311,6 +311,28 @@ export const handlers = [
     success({ success: true }),
   ),
 
+  http.post(`${TAURI_ENDPOINT}/get_claude_desktop_status`, () =>
+    success({
+      supported: true,
+      configured: true,
+      appliedId: "00000000-0000-4000-8000-000000157210",
+      profilePath: null,
+      configLibraryPath: null,
+      mode: "direct",
+      expectedBaseUrl: null,
+      actualBaseUrl: null,
+      proxyRunning: false,
+      staleRawModels: false,
+      missingRouteMappings: false,
+      gatewayTokenConfigured: true,
+      disableAutoUpdates: false,
+    }),
+  ),
+
+  http.post(`${TAURI_ENDPOINT}/set_claude_desktop_disable_auto_updates`, () =>
+    success(true),
+  ),
+
   // Proxy status (for SettingsPage / ProxyPanel hooks)
   http.post(`${TAURI_ENDPOINT}/get_proxy_status`, () =>
     success({


### PR DESCRIPTION
## Summary / 概述

为 Claude Desktop 3P 配置增加「关闭 Claude Desktop 自动更新」设置入口。

## 为什么需要

有些用户希望固定 Claude Desktop 版本，避免 Claude Desktop 自动升级后改变 3P 配置相关行为，进而影响第三方推理、gateway、本地模型映射、1M context 等已经调好的使用方式。

这个开关让用户可以在 CC Switch 里明确控制 Claude Desktop 的自动更新状态：需要稳定环境时关闭自动更新，需要恢复默认行为时再打开自动更新。

这次改动包含：

- 在设置页「通用」中新增「Claude Desktop 设置」分组。
- 增加「关闭 Claude Desktop 自动更新」开关，并使用面向用户的说明文案。
- 开关切换时写入当前生效 Claude Desktop 3P profile 的 `disableAutoUpdates` 值。
- 后续 CC Switch 重写 3P profile 时会继续保留该自动更新偏好，避免切换供应商后丢失设置。
- 更新中英日繁四套 i18n 文案，并补充前端和 Rust 单测。

## Related Issue / 关联 Issue

Fixes #4373

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 设置页通用中没有 Claude Desktop 自动更新控制项 | ![Claude Desktop 设置](https://raw.githubusercontent.com/qwq202/cc-switch/pr-assets-claude-desktop-auto-updates/docs/pr-assets/claude-desktop-auto-update-setting.png) |

## 验证

已在本地验证该开关可以正常使用：开启后关闭 Claude Desktop 自动更新，关闭后恢复默认自动更新。

已运行：

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit tests/components/ProviderList.test.tsx tests/components/ClaudeDesktopSettings.test.tsx`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml disable_auto_updates --lib`

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件