### PR TITLE
fix(proxy):修复开启本地路由时报错unsupported call的问题。

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -430,7 +430,9 @@ impl ChatToResponsesState {
                 state.call_id = id;
             }
             if let Some(name) = name_delta {
-                state.name = name;
+                if !name.is_empty() {
+                    state.name = name;
+                }
             }
             if !args_delta.is_empty() {
                 state.arguments.push_str(&args_delta);


### PR DESCRIPTION
## Summary / 概述
修复了 Codex 客户端报告的 “不支持调用” 错误。

当流式传输 Codex 聊天响应时，streaming_codex_chat.rs 会在 state.name 存在时将 name_delta 值赋值给 state.name。然而，流可能会发出 name_delta，这是一个空字符串，它会覆盖已知的工具名称，并导致 Codex 客户端报告不支持的调用。

修复程序会跳过空的 name_delta 值，以保留现有的工具名称。
-----------------------------------------------------------------------
Fixed an `unsupported call` error reported by the Codex client.

When streaming a Codex chat response, `streaming_codex_chat.rs` assigns the `name_delta` value to `state.name` whenever it is present. However, the stream can emit a `name_delta` that is an empty string, which overwrites the already-known tool name and causes the Codex client to report `unsupported call`.

The fix skips empty `name_delta` values so the existing tool name is preserved.

## Related Issue / 关联 Issue

Fixes #3755
https://github.com/farion1231/cc-switch/issues/3755#issuecomment-4648725615

## Screenshots / 截图

N/A

## Manual Verification / 手动验证

I built `cc-switch.exe` locally with this change and verified that the Codex client no longer reports the `unsupported call` error.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
  - No user-facing text changed in this PR. / 本 PR 未修改用户可见文本。

## Notes / 备注

Local Rust checks (`cargo fmt --check`, `cargo clippy`, `cargo test`) could not be run because the local Rust toolchain (`1.95-x86_64-pc-windows-msvc`) is currently broken and fails to sync components. I am relying on CI to validate the Rust side of this change.

`pnpm test:unit` also reports 2 pre-existing failures in `tests/integration/App.test.tsx` that are unrelated to this Rust-only change.