### PR TITLE
fix(codex): preserve live settings on backup restore

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -9,7 +9,7 @@ use crate::error::AppError;
 use serde_json::{json, Value};
 use std::fs;
 use std::process::Command;
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, Item, TableLike};
 
 pub const CC_SWITCH_CODEX_MODEL_PROVIDER_ID: &str = "custom";
 pub const CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME: &str = "cc-switch-model-catalog.json";
@@ -882,6 +882,210 @@ pub fn prepare_codex_live_config_text_with_optional_catalog(
     } else {
         Ok(config_text.to_string())
     }
+}
+
+/// 判断 TOML 节点是否是用户自有的表结构。
+///
+/// Codex 的 provider 快照通常只应该接管顶层路由字段和当前 provider 表；
+/// `[desktop]`、`[features]`、`[memories]`、`[projects]`、`[mcp_servers]`
+/// 等表由 Codex Desktop 或用户维护，恢复旧备份时不能整表回滚。
+fn codex_toml_item_is_table_like(item: &Item) -> bool {
+    item.as_table().is_some() || item.as_array_of_tables().is_some()
+}
+
+/// 将 provider 需要的配置叠加到 live 表里，冲突时保留 provider。
+///
+/// 这个方向只用于真正由 provider 管理的字段；用户自有表结构通过
+/// `merge_missing_codex_toml_item` 只补缺失值，避免旧备份覆盖新设置。
+fn merge_codex_toml_item_prefer_provider(target: &mut Item, source: &Item) {
+    if let Some(source_table) = source.as_table_like() {
+        if let Some(target_table) = target.as_table_like_mut() {
+            merge_codex_toml_table_like_prefer_provider(target_table, source_table);
+            return;
+        }
+    }
+
+    *target = source.clone();
+}
+
+/// 递归合并 TOML 表，provider 侧同名键优先。
+fn merge_codex_toml_table_like_prefer_provider(target: &mut dyn TableLike, source: &dyn TableLike) {
+    for (key, source_item) in source.iter() {
+        match target.get_mut(key) {
+            Some(target_item) => merge_codex_toml_item_prefer_provider(target_item, source_item),
+            None => {
+                target.insert(key, source_item.clone());
+            }
+        }
+    }
+}
+
+/// 将 provider 表结构里 live 缺失的子项补进 live 配置，已有项一律保留 live。
+///
+/// 这用于兼容 common config 或新版本 Codex 写入的用户表；如果 live 已有同名项，
+/// 历史备份不能覆盖用户当前值。
+fn merge_missing_codex_toml_item(target: &mut Item, source: &Item) {
+    if let Some(source_table) = source.as_table_like() {
+        if let Some(target_table) = target.as_table_like_mut() {
+            merge_missing_codex_toml_table_like(target_table, source_table);
+            return;
+        }
+    }
+
+    if target.is_none() {
+        *target = source.clone();
+    }
+}
+
+/// 递归补齐 TOML 表中缺失的键，冲突时保留 target。
+fn merge_missing_codex_toml_table_like(target: &mut dyn TableLike, source: &dyn TableLike) {
+    for (key, source_item) in source.iter() {
+        match target.get_mut(key) {
+            Some(target_item) => merge_missing_codex_toml_item(target_item, source_item),
+            None => {
+                target.insert(key, source_item.clone());
+            }
+        }
+    }
+}
+
+/// 退出接管或恢复旧备份时清掉 live 当前的自定义 provider 表。
+///
+/// 这些表通常保存本地代理地址；如果备份已经切回官方 provider，继续保留它们会
+/// 让 Codex 后续仍可能读到旧的本地代理配置。
+fn remove_active_custom_codex_model_provider_section(doc: &mut DocumentMut) {
+    let Some(provider_id) = active_codex_model_provider_id(doc) else {
+        return;
+    };
+    if !is_custom_codex_model_provider_id(&provider_id) {
+        return;
+    }
+
+    let should_remove_container = doc
+        .get_mut("model_providers")
+        .and_then(|item| item.as_table_like_mut())
+        .map(|table| {
+            table.remove(&provider_id);
+            table.is_empty()
+        })
+        .unwrap_or(false);
+
+    if should_remove_container {
+        doc.as_table_mut().remove("model_providers");
+    }
+}
+
+/// 清理 live 中那些 provider 已不再声明的旧路由字段。
+///
+/// 先清理再叠加备份/provider，可以防止 `PROXY_MANAGED` token、旧 catalog 指针
+/// 或本地 router 表从接管态泄漏到恢复后的官方配置里。
+fn remove_codex_provider_owned_fields_missing_from_provider(
+    live_doc: &mut DocumentMut,
+    provider_doc: &DocumentMut,
+) {
+    if provider_doc
+        .get("model_provider")
+        .and_then(|item| item.as_str())
+        .map(is_custom_codex_model_provider_id)
+        != Some(true)
+    {
+        remove_active_custom_codex_model_provider_section(live_doc);
+    }
+
+    for key in ["model", "model_provider", "model_context_window"] {
+        if provider_doc.get(key).is_none() {
+            live_doc.as_table_mut().remove(key);
+        }
+    }
+
+    if provider_doc.get("openai_base_url").is_none() {
+        live_doc.as_table_mut().remove("openai_base_url");
+    }
+    if provider_doc.get("model_catalog_json").is_none() {
+        live_doc.as_table_mut().remove("model_catalog_json");
+    }
+    if provider_doc.get("experimental_bearer_token").is_none() {
+        live_doc.as_table_mut().remove("experimental_bearer_token");
+    }
+}
+
+/// 将待恢复的 provider 配置叠加到当前 live `config.toml`。
+///
+/// 重启或关闭接管时，备份里的 `config.toml` 可能比当前 live 文件旧。如果直接
+/// 原样写回，会回滚 Codex Desktop 后来写入的桌面偏好、记忆、项目和 MCP 配置。
+/// 因此这里以当前 live 为底，只让备份/provider 拥有路由相关字段和当前
+/// `[model_providers.<id>]`，其它表结构只补缺失值。
+pub(crate) fn merge_codex_provider_config_texts(
+    live_config_text: &str,
+    provider_config_text: &str,
+) -> Result<String, AppError> {
+    if provider_config_text.trim().is_empty() || live_config_text.trim().is_empty() {
+        return Ok(provider_config_text.to_string());
+    }
+
+    let mut live_doc = live_config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid live Codex config.toml: {e}")))?;
+    let provider_doc = provider_config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid provider Codex config.toml: {e}")))?;
+
+    remove_codex_provider_owned_fields_missing_from_provider(&mut live_doc, &provider_doc);
+
+    for (key, item) in provider_doc.as_table().iter() {
+        if key == "model_providers" || codex_toml_item_is_table_like(item) {
+            continue;
+        }
+        live_doc[key] = item.clone();
+    }
+
+    for (key, item) in provider_doc.as_table().iter() {
+        if key == "model_providers" || !codex_toml_item_is_table_like(item) {
+            continue;
+        }
+
+        match live_doc.as_table_mut().get_mut(key) {
+            Some(live_item) => merge_missing_codex_toml_item(live_item, item),
+            None => {
+                live_doc.as_table_mut().insert(key, item.clone());
+            }
+        }
+    }
+
+    let provider_id = active_codex_model_provider_id(&provider_doc);
+    if let Some(provider_id) = provider_id.as_deref() {
+        if let Some(provider_item) = provider_doc
+            .get("model_providers")
+            .and_then(|item| item.as_table())
+            .and_then(|table| table.get(provider_id))
+            .cloned()
+        {
+            if live_doc.get("model_providers").is_none() {
+                live_doc["model_providers"] = toml_edit::table();
+            }
+            if let Some(live_providers) = live_doc
+                .get_mut("model_providers")
+                .and_then(|item| item.as_table_mut())
+            {
+                match live_providers.get_mut(provider_id) {
+                    Some(live_item) => {
+                        merge_codex_toml_item_prefer_provider(live_item, &provider_item)
+                    }
+                    None => {
+                        live_providers.insert(provider_id, provider_item);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(live_doc.to_string())
+}
+
+/// 读取当前 live 配置，并把 provider/backup 配置叠加进去。
+pub(crate) fn merge_codex_provider_config_with_live(config_text: &str) -> Result<String, AppError> {
+    let live_config = read_codex_config_text()?;
+    merge_codex_provider_config_texts(&live_config, config_text)
 }
 
 pub fn write_codex_provider_live_with_catalog(

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -893,33 +893,6 @@ fn codex_toml_item_is_table_like(item: &Item) -> bool {
     item.as_table().is_some() || item.as_array_of_tables().is_some()
 }
 
-/// 将 provider 需要的配置叠加到 live 表里，冲突时保留 provider。
-///
-/// 这个方向只用于真正由 provider 管理的字段；用户自有表结构通过
-/// `merge_missing_codex_toml_item` 只补缺失值，避免旧备份覆盖新设置。
-fn merge_codex_toml_item_prefer_provider(target: &mut Item, source: &Item) {
-    if let Some(source_table) = source.as_table_like() {
-        if let Some(target_table) = target.as_table_like_mut() {
-            merge_codex_toml_table_like_prefer_provider(target_table, source_table);
-            return;
-        }
-    }
-
-    *target = source.clone();
-}
-
-/// 递归合并 TOML 表，provider 侧同名键优先。
-fn merge_codex_toml_table_like_prefer_provider(target: &mut dyn TableLike, source: &dyn TableLike) {
-    for (key, source_item) in source.iter() {
-        match target.get_mut(key) {
-            Some(target_item) => merge_codex_toml_item_prefer_provider(target_item, source_item),
-            None => {
-                target.insert(key, source_item.clone());
-            }
-        }
-    }
-}
-
 /// 将 provider 表结构里 live 缺失的子项补进 live 配置，已有项一律保留 live。
 ///
 /// 这用于兼容 common config 或新版本 Codex 写入的用户表；如果 live 已有同名项，
@@ -1067,14 +1040,10 @@ pub(crate) fn merge_codex_provider_config_texts(
                 .get_mut("model_providers")
                 .and_then(|item| item.as_table_mut())
             {
-                match live_providers.get_mut(provider_id) {
-                    Some(live_item) => {
-                        merge_codex_toml_item_prefer_provider(live_item, &provider_item)
-                    }
-                    None => {
-                        live_providers.insert(provider_id, provider_item);
-                    }
-                }
+                // 当前 active provider 表是路由归属字段，恢复时必须以备份/provider 为准整表替换。
+                // 如果只递归覆盖已有键，同名自定义 provider 在接管态写入的本地 base_url
+                // 或 PROXY_MANAGED token 会因为备份里缺少这些键而残留。
+                live_providers.insert(provider_id, provider_item);
             }
         }
     }
@@ -1743,6 +1712,58 @@ requires_openai_auth = true
             Some("")
         );
         assert!(settings.pointer("/auth/tokens/access_token").is_some());
+    }
+
+    #[test]
+    fn merge_provider_config_replaces_same_custom_provider_table() {
+        // 同名自定义 provider 恢复时，live 表可能来自接管态并带本地代理字段；
+        // 备份/provider 表缺少这些字段时，必须整表替换而不是只覆盖已有键。
+        let live_config = r#"model_provider = "custom"
+model = "gpt-5"
+
+[model_providers.custom]
+name = "OpenAI Router"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+experimental_bearer_token = "PROXY_MANAGED"
+
+[desktop]
+notifications-turn-mode = "always"
+"#;
+        let provider_config = r#"model_provider = "custom"
+model = "gpt-5"
+
+[model_providers.custom]
+name = "OpenAI"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+
+        let merged =
+            merge_codex_provider_config_texts(live_config, provider_config).expect("merge config");
+        let parsed: toml::Value = toml::from_str(&merged).expect("parse merged config");
+        let custom = parsed
+            .get("model_providers")
+            .and_then(|v| v.get("custom"))
+            .expect("custom provider table");
+
+        assert_eq!(custom.get("name").and_then(|v| v.as_str()), Some("OpenAI"));
+        assert!(
+            custom.get("base_url").is_none(),
+            "restored provider table must drop takeover proxy base_url"
+        );
+        assert!(
+            custom.get("experimental_bearer_token").is_none(),
+            "restored provider table must drop takeover proxy token"
+        );
+        assert_eq!(
+            parsed
+                .get("desktop")
+                .and_then(|v| v.get("notifications-turn-mode"))
+                .and_then(|v| v.as_str()),
+            Some("always"),
+            "user-owned desktop settings should still be preserved"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2479,6 +2479,10 @@ impl ProxyService {
             })
             .transpose()
             .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
+        let prepared_cfg = prepared_cfg
+            .map(|cfg| crate::codex_config::merge_codex_provider_config_with_live(&cfg))
+            .transpose()
+            .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
 
         match (auth, prepared_cfg.as_deref()) {
             (Some(auth), Some(cfg)) => {
@@ -5869,6 +5873,77 @@ requires_openai_auth = true
         assert!(
             !crate::codex_config::get_codex_auth_path().exists(),
             "empty-auth restore must delete auth.json rather than write an empty one"
+        );
+    }
+
+    /// 回归：Codex Desktop 会把编辑器和通知偏好写进用户自有 TOML 表。
+    ///
+    /// 恢复旧接管备份时只能替换 provider 字段，不能回滚 live 文件里较新的
+    /// `[desktop]` 设置。
+    #[tokio::test]
+    #[serial]
+    async fn codex_restore_from_backup_preserves_live_desktop_settings() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let codex_dir = crate::codex_config::get_codex_config_dir();
+        std::fs::create_dir_all(&codex_dir).expect("create codex dir");
+        std::fs::write(
+            crate::codex_config::get_codex_config_path(),
+            r#"model_provider = "codex_model_router_v2"
+model_catalog_json = "cc-switch-model-catalog.json"
+experimental_bearer_token = "PROXY_MANAGED"
+
+[model_providers.codex_model_router_v2]
+name = "OpenAI Multi-Model Router"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+
+[desktop]
+notifications-turn-mode = "always"
+reviewDelivery = "detached"
+"#,
+        )
+        .expect("seed taken-over live config with desktop settings");
+
+        let backup_json = serde_json::to_string(&json!({
+            "auth": { "OPENAI_API_KEY": "real-token" },
+            "config": "model = \"gpt-5.5\"\nmodel_provider = \"openai\"\n"
+        }))
+        .expect("serialize backup");
+        db.save_live_backup("codex", &backup_json)
+            .await
+            .expect("seed old live backup");
+
+        service
+            .restore_live_config_for_app_with_fallback(&AppType::Codex)
+            .await
+            .expect("restore codex live from backup");
+
+        let restored = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read restored config.toml");
+        assert!(
+            restored.contains("[desktop]"),
+            "restore must keep current live desktop table, got:\n{restored}"
+        );
+        assert!(
+            restored.contains("notifications-turn-mode = \"always\""),
+            "restore must keep Codex Desktop notification preference, got:\n{restored}"
+        );
+        assert!(
+            restored.contains("reviewDelivery = \"detached\""),
+            "restore must keep Codex Desktop review delivery preference, got:\n{restored}"
+        );
+        assert!(
+            restored.contains("model_provider = \"openai\""),
+            "restore must still apply the backup/provider route, got:\n{restored}"
+        );
+        assert!(
+            !restored.contains("http://127.0.0.1:15721"),
+            "restore must remove the takeover proxy endpoint, got:\n{restored}"
         );
     }
 


### PR DESCRIPTION
﻿## Summary

Closes #4254.

Codex takeover restore currently writes the stored backup `config.toml` verbatim. If the backup was captured before Codex Desktop wrote newer user-owned tables, a restart / takeover-off restore can silently roll back settings such as `[desktop]`, `[features]`, `[memories]`, `[projects]`, and `[mcp_servers]`.

This PR changes the restore write path to merge the prepared backup/provider config into the current live config before writing:

- provider-owned route fields and the active `[model_providers.<id>]` table are restored from the backup
- stale takeover router fields are removed when restoring to a non-custom provider
- user-owned TOML tables from the current live file are preserved

## Root Cause

`restore_live_config_for_app_with_fallback_inner` restores Codex through `write_codex_live`, which reaches `write_codex_live_verbatim`. That function prepared the backup config for optional catalog projection, then wrote it directly. The restore code had no live merge step, so an older backup became the whole live `config.toml`.

## Tests

- `cargo fmt --manifest-path src-tauri\Cargo.toml --check`
- `cargo test --manifest-path src-tauri\Cargo.toml codex_restore_from_backup --lib -- --nocapture`
- `cargo test --manifest-path src-tauri\Cargo.toml codex_restore_empty_auth_backup_still_projects_inline_catalog --lib -- --nocapture`
- `cargo check --manifest-path src-tauri\Cargo.toml --lib`

`cargo check` still reports existing warnings in `src/settings.rs` and `src/commands/misc.rs`; this PR does not touch those files.
