### PR TITLE
fix(updater): resolve macOS update deadlock (#4206)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 use tauri_plugin_updater::UpdaterExt;
 
 fn merge_settings_for_save(
@@ -189,23 +189,43 @@ pub async fn restart_app(app: AppHandle) -> Result<bool, String> {
 /// 这里把退出清理、安装和重启串在同一个后端流程中，避免依赖旧前端继续执行。
 #[tauri::command]
 pub async fn install_update_and_restart(app: AppHandle) -> Result<bool, String> {
+    use std::time::Duration;
+
     let updater = app
         .updater_builder()
+        // 不在 builder 上设置 timeout：tauri-plugin-updater 曾有 check() timeout 泄漏到
+        // download() 的 bug（#2372），即使已修复也不确定当前版本是否包含。改用
+        // tokio::time::timeout 分别为 check 和 download 设置不同的超时。
         .build()
         .map_err(|e| format!("初始化更新器失败: {e}"))?;
 
-    let Some(update) = updater
-        .check()
+    let Some(update) = tokio::time::timeout(Duration::from_secs(35), updater.check())
         .await
+        .map_err(|_| "检查更新超时，请检查网络连接后重试".to_string())?
         .map_err(|e| format!("检查更新失败: {e}"))?
     else {
         return Ok(false);
     };
 
     log::info!("开始下载应用更新: {}", update.version);
-    let bytes = update
-        .download(|_, _| {}, || {})
+
+    let app_handle = app.clone();
+    let download_future = update.download(
+        move |chunk_length, content_length| {
+            let _ = app_handle.emit(
+                "update-download-progress",
+                serde_json::json!({
+                    "chunkLength": chunk_length,
+                    "contentLength": content_length,
+                }),
+            );
+        },
+        || {},
+    );
+
+    let bytes = tokio::time::timeout(Duration::from_secs(300), download_future)
         .await
+        .map_err(|_| "下载更新超时（5分钟），请检查网络连接后重试".to_string())?
         .map_err(|e| format!("下载更新失败: {e}"))?;
 
     log::info!("开始安装应用更新: {}", update.version);
@@ -236,11 +256,17 @@ pub async fn install_update_and_restart(app: AppHandle) -> Result<bool, String> 
             .install(bytes)
             .map_err(|e| format!("安装更新失败: {e}"))?;
 
-        crate::save_window_state_before_exit(&app);
-        crate::cleanup_before_exit(&app).await;
-
         log::info!("应用更新安装完成，正在重启应用");
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // 绝不能在此调用 save_window_state_before_exit / cleanup_before_exit：
+        // 当前函数作为 #[tauri::command] 运行在 tokio worker 线程，
+        // save_window_state 会持有 window-state 插件锁并向主线程查询窗口几何；
+        // 而 restart_process 触发 ExitRequested(RESTART_EXIT_CODE) 后，主线程
+        // 在 RunEvent::Exit 钩子中等待同一把锁——双方互等造成进程永久卡死（#3998 / #4206）。
+        //
+        // 正确做法与 lib.rs 中 DeferToTauriRestart 路径一致：
+        //   - 窗口状态：Tauri 的 Exit 钩子在主线程保存（同线程读取几何，无死锁）
+        //   - 代理/Live 配置：重启后新实例立即接管并恢复代理状态，无需手动清理
         crate::restart_process(&app);
     }
 }

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Download,
   Copy,
@@ -216,6 +216,8 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
     () => appVersionCache === null,
   );
   const [isDownloading, setIsDownloading] = useState(false);
+  const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
+  const downloadBytesRef = useRef(0);
   const [toolVersions, setToolVersions] = useState<ToolVersion[]>(
     () => toolVersionsCache?.data ?? [],
   );
@@ -381,6 +383,40 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
     await refreshToolVersions([toolName], { [toolName]: nextPref });
   };
 
+  // 监听后端下载进度事件，实时更新百分比
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    import("@tauri-apps/api/event").then(({ listen }) => {
+      if (disposed) return;
+      listen<{ chunkLength: number; contentLength: number | null }>(
+        "update-download-progress",
+        (event) => {
+          downloadBytesRef.current += event.payload.chunkLength;
+          const total = event.payload.contentLength;
+          if (total && total > 0) {
+            setDownloadProgress(
+              Math.min(
+                99,
+                Math.round((downloadBytesRef.current / total) * 100),
+              ),
+            );
+          }
+        },
+      ).then((fn) => {
+        if (disposed) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      });
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+
   useEffect(() => {
     let active = true;
 
@@ -457,6 +493,8 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
       }
 
       setIsDownloading(true);
+      setDownloadProgress(null);
+      downloadBytesRef.current = 0;
       try {
         resetDismiss();
         const installed = await settingsApi.installUpdateAndRestart();
@@ -479,6 +517,8 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
         }
       } finally {
         setIsDownloading(false);
+        setDownloadProgress(null);
+        downloadBytesRef.current = 0;
       }
       return;
     }
@@ -907,7 +947,9 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
               {isDownloading ? (
                 <>
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  {t("settings.updating")}
+                  {downloadProgress !== null
+                    ? `${t("settings.updating")} ${downloadProgress}%`
+                    : t("settings.updating")}
                 </>
               ) : hasUpdate ? (
                 <>


### PR DESCRIPTION
## Summary

Fixes the app freeze / permanent hang when clicking "Update" on macOS (Apple Silicon), as reported in #4206.

**Root cause**: `install_update_and_restart` runs on a tokio worker thread. Before restarting, it called `save_window_state_before_exit`, which acquires the window-state plugin lock and queries the main thread for window geometry. When `restart_process` then triggers `ExitRequested(RESTART_EXIT_CODE)`, the main thread enters the exit event loop and its window-state Exit hook tries to acquire the same lock — **mutual deadlock** (`_pthread_mutex_firstfit_lock_slow` / `__psynch_mutexwait`).

**Fix**: Remove the manual `save_window_state_before_exit` / `cleanup_before_exit` calls from the macOS/Linux update path, aligning it with the `DeferToTauriRestart` handler in `lib.rs` (which was already corrected for the identical deadlock in #3998):
- Window state is saved by the plugin's own Exit hook on the main thread (no cross-thread lock contention)
- Proxy/Live config is restored automatically by the new instance on startup

**Additional defensive improvements** (not the core fix, but prevent related hangs):
- Wrap `updater.check()` with `tokio::time::timeout(35s)` and `update.download()` with `tokio::time::timeout(300s)`
- Emit `update-download-progress` events during download; frontend shows real-time percentage on the update button
- Avoid `UpdaterBuilder::timeout()` to sidestep the timeout-leaking-to-download bug (tauri-apps/plugins-workspace#2372)

## Related Issue

Closes #4206

## Changed Files

| File | Change |
|------|--------|
| `src-tauri/src/commands/settings.rs` | Remove deadlock-causing cleanup calls on macOS/Linux; add timeouts and progress events |
| `src/components/settings/AboutSection.tsx` | Listen to download progress events; display percentage on update button |

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `pnpm test:unit` passes (338/338)
- [ ] `cargo clippy` passes (Rust toolchain not available in current env — needs CI verification)
- [ ] Manual test: click "Update" on macOS Apple Silicon — app should download, install, and restart without freezing
- [ ] Manual test: disconnect network, click "Update" — should show timeout error after 35s instead of hanging