### PR TITLE
fix(linux): stabilize window after resize and scale changes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -772,6 +772,7 @@ dependencies = [
  "dirs 5.0.1",
  "flate2",
  "futures",
+ "gtk",
  "hmac",
  "http",
  "http-body",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "dirs 5.0.1",
  "flate2",
  "futures",
+ "gtk",
  "hmac",
  "http",
  "http-body",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -85,6 +85,7 @@ json-five = "0.3.1"
 tauri-plugin-single-instance = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18"
 webkit2gtk = { version = "2.0.1", features = ["v2_16"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -87,6 +87,7 @@ sys-locale = "0.3"
 tauri-plugin-single-instance = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18"
 webkit2gtk = { version = "2.0.1", features = ["v2_16"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -269,6 +269,23 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         // 拦截窗口关闭：根据设置决定是否最小化到托盘
         .on_window_event(|window, event| {
+            #[cfg(target_os = "linux")]
+            {
+                if window.label() == "main"
+                    && matches!(
+                        event,
+                        tauri::WindowEvent::Resized(_)
+                            | tauri::WindowEvent::ScaleFactorChanged { .. }
+                    )
+                {
+                    if let Some(webview_window) =
+                        window.app_handle().get_webview_window("main")
+                    {
+                        linux_fix::repaint_main_window_after_resize(webview_window);
+                    }
+                }
+            }
+
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 let settings = crate::settings::get_settings();
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -408,6 +408,23 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         // 拦截窗口关闭：根据设置决定是否最小化到托盘
         .on_window_event(|window, event| {
+            #[cfg(target_os = "linux")]
+            {
+                if window.label() == "main"
+                    && matches!(
+                        event,
+                        tauri::WindowEvent::Resized(_)
+                            | tauri::WindowEvent::ScaleFactorChanged { .. }
+                    )
+                {
+                    if let Some(webview_window) =
+                        window.app_handle().get_webview_window("main")
+                    {
+                        linux_fix::repaint_main_window_after_resize(webview_window);
+                    }
+                }
+            }
+
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 // 数据库版本过新的恢复模式下没有托盘可唤回，关闭即退出，避免应用隐身后台
                 let in_db_recovery = crate::init_status::get_init_error()

--- a/src-tauri/src/linux_fix.rs
+++ b/src-tauri/src/linux_fix.rs
@@ -81,10 +81,29 @@ fn queue_webview_repaint(window: &WebviewWindow) {
     }
 }
 
-fn active_gdk_backend_is_wayland() -> Option<bool> {
+fn active_gdk_backend_is_wayland_on_current_thread() -> Option<bool> {
     use gtk::gdk::prelude::DisplayExtManual;
 
     gtk::gdk::Display::default().map(|display| display.backend().is_wayland())
+}
+
+async fn active_gdk_backend_is_wayland(window: &WebviewWindow) -> Option<bool> {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+
+    if let Err(err) = window.run_on_main_thread(move || {
+        let _ = sender.send(active_gdk_backend_is_wayland_on_current_thread());
+    }) {
+        log::debug!("Linux nudge: 无法在主线程查询 GDK backend: {err}");
+        return None;
+    }
+
+    match receiver.await {
+        Ok(value) => value,
+        Err(err) => {
+            log::debug!("Linux nudge: 主线程 GDK backend 查询被取消: {err}");
+            None
+        }
+    }
 }
 
 fn should_skip_pseudo_resize_for_backend(
@@ -112,7 +131,7 @@ pub(crate) fn nudge_main_window(window: WebviewWindow) {
         queue_webview_repaint(&window);
 
         let is_wayland = should_skip_pseudo_resize_for_backend(
-            active_gdk_backend_is_wayland(),
+            active_gdk_backend_is_wayland(&window).await,
             std::env::var_os("WAYLAND_DISPLAY").is_some(),
         );
         let skip_pseudo_resize = is_wayland

--- a/src-tauri/src/linux_fix.rs
+++ b/src-tauri/src/linux_fix.rs
@@ -16,7 +16,10 @@
 //! deeplink 唤起、single_instance 回调、托盘 show_main、lightweight
 //! 退出）都应在现有 `set_focus()` 之后追加一次调用。
 
-use std::time::Duration;
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 
 use tauri::{PhysicalSize, WebviewWindow};
 
@@ -36,6 +39,48 @@ const RESIZE_GAP: Duration = Duration::from_millis(100);
 /// resize 消息队列。
 const RECONCILE_WAIT: Duration = Duration::from_millis(500);
 
+/// Resize events arrive in bursts while dragging a border or moving between
+/// monitors. Only repaint once after the burst settles.
+const RESIZE_REPAINT_WAIT: Duration = Duration::from_millis(180);
+
+static RESIZE_REPAINT_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+const RESIZE_REPAINT_SCRIPT: &str = r#"
+(() => {
+  const body = document.body;
+  if (!body) return;
+
+  const previousTransform = body.style.transform;
+  const previousBackfaceVisibility = body.style.backfaceVisibility;
+
+  body.style.transform = previousTransform
+    ? `${previousTransform} translateZ(0)`
+    : "translateZ(0)";
+  body.style.backfaceVisibility = "hidden";
+  void body.offsetHeight;
+
+  window.dispatchEvent(new Event("resize"));
+
+  requestAnimationFrame(() => {
+    body.style.transform = previousTransform;
+    body.style.backfaceVisibility = previousBackfaceVisibility;
+    void body.offsetHeight;
+  });
+})();
+"#;
+
+fn queue_webview_repaint(window: &WebviewWindow) {
+    let _ = window.with_webview(|webview| {
+        use gtk::prelude::WidgetExt;
+
+        webview.inner().queue_draw();
+    });
+
+    if let Err(err) = window.eval(RESIZE_REPAINT_SCRIPT) {
+        log::debug!("Linux repaint: 前端重绘脚本执行失败: {err}");
+    }
+}
+
 /// 对主窗口执行 Linux 专用的「focus + surface 重激活」序列。
 ///
 /// 调用是 fire-and-forget：内部 spawn 一个异步任务在 ~250ms 后完成。
@@ -51,6 +96,16 @@ pub(crate) fn nudge_main_window(window: WebviewWindow) {
         // 第二次 set_focus：此时 webview realize 已完成，在绝大多数
         // 发行版上这一次会真的生效，消除失效模式 A。
         let _ = window.set_focus();
+        queue_webview_repaint(&window);
+
+        let is_wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+        let skip_pseudo_resize = is_wayland
+            || matches!(window.is_maximized(), Ok(true))
+            || matches!(window.is_fullscreen(), Ok(true));
+        if skip_pseudo_resize {
+            log::info!("Linux: 已对主窗口执行 focus + repaint，跳过 Wayland/最大化/全屏伪 resize");
+            return;
+        }
 
         // 伪 resize：读取当前 inner_size，先加 1px 再还原。这会触发
         // GTK 的 size-allocate → WebKitWebViewBase::size_allocate →
@@ -117,5 +172,28 @@ pub(crate) fn nudge_main_window(window: WebviewWindow) {
                 log::warn!("Linux nudge: 读取 inner_size 失败，跳过伪 resize: {e}");
             }
         }
+    });
+}
+
+/// Linux WebKitGTK can keep a stale/black backing surface after manual resize,
+/// monitor moves, or scale-factor changes. This is a lighter repaint than
+/// `nudge_main_window`: it does not call `set_size`, so it is safe to trigger
+/// from resize events without creating a resize loop.
+pub(crate) fn repaint_main_window_after_resize(window: WebviewWindow) {
+    let generation = RESIZE_REPAINT_GENERATION.fetch_add(1, Ordering::AcqRel) + 1;
+
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(RESIZE_REPAINT_WAIT).await;
+        if RESIZE_REPAINT_GENERATION.load(Ordering::Acquire) != generation {
+            return;
+        }
+
+        if matches!(window.is_visible(), Ok(false)) {
+            return;
+        }
+
+        let _ = window.set_focus();
+        queue_webview_repaint(&window);
+        log::debug!("Linux: 已请求 resize 后 WebView 重绘");
     });
 }

--- a/src-tauri/src/linux_fix.rs
+++ b/src-tauri/src/linux_fix.rs
@@ -81,6 +81,18 @@ fn queue_webview_repaint(window: &WebviewWindow) {
     }
 }
 
+fn is_effective_wayland_backend(gdk_backend: Option<&str>, has_wayland_display: bool) -> bool {
+    let requested_backend = gdk_backend
+        .and_then(|value| value.split(',').find(|part| !part.trim().is_empty()))
+        .map(|value| value.trim().to_ascii_lowercase());
+
+    match requested_backend.as_deref() {
+        Some("x11") => false,
+        Some("wayland") => true,
+        _ => has_wayland_display,
+    }
+}
+
 /// 对主窗口执行 Linux 专用的「focus + surface 重激活」序列。
 ///
 /// 调用是 fire-and-forget：内部 spawn 一个异步任务在 ~250ms 后完成。
@@ -98,7 +110,10 @@ pub(crate) fn nudge_main_window(window: WebviewWindow) {
         let _ = window.set_focus();
         queue_webview_repaint(&window);
 
-        let is_wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+        let is_wayland = is_effective_wayland_backend(
+            std::env::var("GDK_BACKEND").ok().as_deref(),
+            std::env::var_os("WAYLAND_DISPLAY").is_some(),
+        );
         let skip_pseudo_resize = is_wayland
             || matches!(window.is_maximized(), Ok(true))
             || matches!(window.is_fullscreen(), Ok(true));
@@ -196,4 +211,32 @@ pub(crate) fn repaint_main_window_after_resize(window: WebviewWindow) {
         queue_webview_repaint(&window);
         log::debug!("Linux: 已请求 resize 后 WebView 重绘");
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_effective_wayland_backend;
+
+    #[test]
+    fn gdk_backend_x11_overrides_wayland_session() {
+        assert!(!is_effective_wayland_backend(Some("x11"), true));
+    }
+
+    #[test]
+    fn gdk_backend_first_entry_controls_backend() {
+        assert!(!is_effective_wayland_backend(Some("x11,wayland"), true));
+        assert!(is_effective_wayland_backend(Some("wayland,x11"), false));
+    }
+
+    #[test]
+    fn wayland_display_is_used_when_backend_is_unset() {
+        assert!(is_effective_wayland_backend(None, true));
+        assert!(!is_effective_wayland_backend(None, false));
+    }
+
+    #[test]
+    fn unknown_backend_falls_back_to_session_probe() {
+        assert!(is_effective_wayland_backend(Some("broadway"), true));
+        assert!(!is_effective_wayland_backend(Some("broadway"), false));
+    }
 }

--- a/src-tauri/src/linux_fix.rs
+++ b/src-tauri/src/linux_fix.rs
@@ -81,16 +81,17 @@ fn queue_webview_repaint(window: &WebviewWindow) {
     }
 }
 
-fn is_effective_wayland_backend(gdk_backend: Option<&str>, has_wayland_display: bool) -> bool {
-    let requested_backend = gdk_backend
-        .and_then(|value| value.split(',').find(|part| !part.trim().is_empty()))
-        .map(|value| value.trim().to_ascii_lowercase());
+fn active_gdk_backend_is_wayland() -> Option<bool> {
+    use gtk::gdk::prelude::DisplayExtManual;
 
-    match requested_backend.as_deref() {
-        Some("x11") => false,
-        Some("wayland") => true,
-        _ => has_wayland_display,
-    }
+    gtk::gdk::Display::default().map(|display| display.backend().is_wayland())
+}
+
+fn should_skip_pseudo_resize_for_backend(
+    active_gdk_is_wayland: Option<bool>,
+    has_wayland_display: bool,
+) -> bool {
+    active_gdk_is_wayland.unwrap_or(has_wayland_display)
 }
 
 /// 对主窗口执行 Linux 专用的「focus + surface 重激活」序列。
@@ -110,8 +111,8 @@ pub(crate) fn nudge_main_window(window: WebviewWindow) {
         let _ = window.set_focus();
         queue_webview_repaint(&window);
 
-        let is_wayland = is_effective_wayland_backend(
-            std::env::var("GDK_BACKEND").ok().as_deref(),
+        let is_wayland = should_skip_pseudo_resize_for_backend(
+            active_gdk_backend_is_wayland(),
             std::env::var_os("WAYLAND_DISPLAY").is_some(),
         );
         let skip_pseudo_resize = is_wayland
@@ -215,28 +216,21 @@ pub(crate) fn repaint_main_window_after_resize(window: WebviewWindow) {
 
 #[cfg(test)]
 mod tests {
-    use super::is_effective_wayland_backend;
+    use super::should_skip_pseudo_resize_for_backend;
 
     #[test]
-    fn gdk_backend_x11_overrides_wayland_session() {
-        assert!(!is_effective_wayland_backend(Some("x11"), true));
+    fn active_gdk_x11_keeps_pseudo_resize_even_in_wayland_session() {
+        assert!(!should_skip_pseudo_resize_for_backend(Some(false), true));
     }
 
     #[test]
-    fn gdk_backend_first_entry_controls_backend() {
-        assert!(!is_effective_wayland_backend(Some("x11,wayland"), true));
-        assert!(is_effective_wayland_backend(Some("wayland,x11"), false));
+    fn active_gdk_wayland_skips_pseudo_resize() {
+        assert!(should_skip_pseudo_resize_for_backend(Some(true), false));
     }
 
     #[test]
-    fn wayland_display_is_used_when_backend_is_unset() {
-        assert!(is_effective_wayland_backend(None, true));
-        assert!(!is_effective_wayland_backend(None, false));
-    }
-
-    #[test]
-    fn unknown_backend_falls_back_to_session_probe() {
-        assert!(is_effective_wayland_backend(Some("broadway"), true));
-        assert!(!is_effective_wayland_backend(Some("broadway"), false));
+    fn wayland_display_is_used_when_gdk_display_is_unavailable() {
+        assert!(should_skip_pseudo_resize_for_backend(None, true));
+        assert!(!should_skip_pseudo_resize_for_backend(None, false));
     }
 }

--- a/src-tauri/src/linux_fix.rs
+++ b/src-tauri/src/linux_fix.rs
@@ -10,13 +10,14 @@
 //!   协商在 `visible:false` → `show()` 的路径上失败，整窗永远不响应
 //!   点击，只有重新 `size_allocate`（例如最大化-还原）才能恢复。
 //!
-//! 本模块导出 [`nudge_main_window`]，它通过「显式 set_focus + 无视觉
-//! 版本的 ±1px 伪 resize」精确模拟用户手动最大化再还原的 workaround，
-//! 但肉眼无法察觉。所有"让主窗口出现在用户面前"的路径（正常启动、
-//! deeplink 唤起、single_instance 回调、托盘 show_main、lightweight
-//! 退出）都应在现有 `set_focus()` 之后追加一次调用。
+//! 本模块导出 [`nudge_main_window`]，它通过显式 focus、WebView 重绘以及
+//! X11 下的无视觉 ±1px 伪 resize 恢复窗口。Wayland、最大化和全屏窗口
+//! 跳过伪 resize，避免合成器协商导致窗口尺寸漂移。
 
-use std::time::Duration;
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 
 use tauri::{PhysicalSize, WebviewWindow};
 
@@ -36,6 +37,80 @@ const RESIZE_GAP: Duration = Duration::from_millis(100);
 /// resize 消息队列。
 const RECONCILE_WAIT: Duration = Duration::from_millis(500);
 
+/// Resize events arrive in bursts while dragging a border or moving between
+/// monitors. Only repaint once after the burst settles.
+const RESIZE_REPAINT_WAIT: Duration = Duration::from_millis(180);
+
+static RESIZE_REPAINT_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+const RESIZE_REPAINT_SCRIPT: &str = r#"
+(() => {
+  const body = document.body;
+  if (!body) return;
+
+  const previousTransform = body.style.transform;
+  const previousBackfaceVisibility = body.style.backfaceVisibility;
+
+  body.style.transform = previousTransform
+    ? `${previousTransform} translateZ(0)`
+    : "translateZ(0)";
+  body.style.backfaceVisibility = "hidden";
+  void body.offsetHeight;
+
+  window.dispatchEvent(new Event("resize"));
+
+  requestAnimationFrame(() => {
+    body.style.transform = previousTransform;
+    body.style.backfaceVisibility = previousBackfaceVisibility;
+    void body.offsetHeight;
+  });
+})();
+"#;
+
+fn queue_webview_repaint(window: &WebviewWindow) {
+    let _ = window.with_webview(|webview| {
+        use gtk::prelude::WidgetExt;
+
+        webview.inner().queue_draw();
+    });
+
+    if let Err(err) = window.eval(RESIZE_REPAINT_SCRIPT) {
+        log::debug!("Linux repaint: 前端重绘脚本执行失败: {err}");
+    }
+}
+
+fn active_gdk_backend_is_wayland_on_current_thread() -> Option<bool> {
+    use gtk::gdk::prelude::DisplayExtManual;
+
+    gtk::gdk::Display::default().map(|display| display.backend().is_wayland())
+}
+
+async fn active_gdk_backend_is_wayland(window: &WebviewWindow) -> Option<bool> {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+
+    if let Err(err) = window.run_on_main_thread(move || {
+        let _ = sender.send(active_gdk_backend_is_wayland_on_current_thread());
+    }) {
+        log::debug!("Linux nudge: 无法在主线程查询 GDK backend: {err}");
+        return None;
+    }
+
+    match receiver.await {
+        Ok(value) => value,
+        Err(err) => {
+            log::debug!("Linux nudge: 主线程 GDK backend 查询被取消: {err}");
+            None
+        }
+    }
+}
+
+fn should_skip_pseudo_resize_for_backend(
+    active_gdk_is_wayland: Option<bool>,
+    has_wayland_display: bool,
+) -> bool {
+    active_gdk_is_wayland.unwrap_or(has_wayland_display)
+}
+
 /// 对主窗口执行 Linux 专用的「focus + surface 重激活」序列。
 ///
 /// 调用是 fire-and-forget：内部 spawn 一个异步任务在 ~250ms 后完成。
@@ -51,6 +126,19 @@ pub(crate) fn nudge_main_window(window: WebviewWindow) {
         // 第二次 set_focus：此时 webview realize 已完成，在绝大多数
         // 发行版上这一次会真的生效，消除失效模式 A。
         let _ = window.set_focus();
+        queue_webview_repaint(&window);
+
+        let is_wayland = should_skip_pseudo_resize_for_backend(
+            active_gdk_backend_is_wayland(&window).await,
+            std::env::var_os("WAYLAND_DISPLAY").is_some(),
+        );
+        let skip_pseudo_resize = is_wayland
+            || matches!(window.is_maximized(), Ok(true))
+            || matches!(window.is_fullscreen(), Ok(true));
+        if skip_pseudo_resize {
+            log::info!("Linux: 已对主窗口执行 focus + repaint，跳过 Wayland/最大化/全屏伪 resize");
+            return;
+        }
 
         // 伪 resize：读取当前 inner_size，先加 1px 再还原。这会触发
         // GTK 的 size-allocate → WebKitWebViewBase::size_allocate →
@@ -118,4 +206,48 @@ pub(crate) fn nudge_main_window(window: WebviewWindow) {
             }
         }
     });
+}
+
+/// Linux WebKitGTK can keep a stale or black backing surface after manual
+/// resize, monitor moves, or scale-factor changes. This is a lighter repaint
+/// than [`nudge_main_window`]: it never changes the window size, so calling it
+/// from resize events cannot create a resize loop.
+pub(crate) fn repaint_main_window_after_resize(window: WebviewWindow) {
+    let generation = RESIZE_REPAINT_GENERATION.fetch_add(1, Ordering::AcqRel) + 1;
+
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(RESIZE_REPAINT_WAIT).await;
+        if RESIZE_REPAINT_GENERATION.load(Ordering::Acquire) != generation {
+            return;
+        }
+
+        if matches!(window.is_visible(), Ok(false)) {
+            return;
+        }
+
+        let _ = window.set_focus();
+        queue_webview_repaint(&window);
+        log::debug!("Linux: 已请求 resize 后 WebView 重绘");
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_skip_pseudo_resize_for_backend;
+
+    #[test]
+    fn active_gdk_x11_keeps_pseudo_resize_even_in_wayland_session() {
+        assert!(!should_skip_pseudo_resize_for_backend(Some(false), true));
+    }
+
+    #[test]
+    fn active_gdk_wayland_skips_pseudo_resize() {
+        assert!(should_skip_pseudo_resize_for_backend(Some(true), false));
+    }
+
+    #[test]
+    fn wayland_display_is_used_when_gdk_display_is_unavailable() {
+        assert!(should_skip_pseudo_resize_for_backend(None, true));
+        assert!(!should_skip_pseudo_resize_for_backend(None, false));
+    }
 }


### PR DESCRIPTION
## Summary / 概述

Fix Linux WebKitGTK windows drifting or repainting incorrectly after resize, monitor, or scale-factor changes.

- Query the active GDK backend on the GTK main thread and skip the `+1px` pseudo-resize on Wayland, maximized, and fullscreen windows.
- Keep the existing X11 surface workaround while adding a size-neutral GTK/WebView repaint path.
- Debounce repaint requests after `Resized` and `ScaleFactorChanged` events so resize bursts trigger only one repaint.
- Add Linux-only GTK access and focused unit tests for backend selection.

## Root cause / 根因

The existing Linux window recovery path always changes the physical window width by one pixel and then restores it. Under Wayland, size requests are advisory and may be ignored or coalesced by the compositor, so the workaround itself can perturb geometry. Resize and scale-factor changes also had no size-neutral WebView repaint path, allowing stale or black backing surfaces to persist.

## Related issues / 关联 Issue

Related to #1111, #1667, #4010, and #2839.

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| <img width="1217" height="1125" alt="image" src="https://github.com/user-attachments/assets/08d2d0d7-2069-4e93-bb8e-89b93cf1dd57" /> | <img width="1217" height="1125" alt="image" src="https://github.com/user-attachments/assets/abb0149e-fb11-4def-8e16-f0c33bbe18da" /> |
| 拉动窗口到另一个屏幕时可能触发渲染错误 | 无问题 |

## Local verification / 本地验证

The latest `main` was checked in a Wayland session (`XDG_SESSION_TYPE=wayland`, `WAYLAND_DISPLAY=wayland-0`). Its existing `nudge_main_window` path still called `set_size` unconditionally and did not handle resize or scale-factor repaint events, confirming that the risky path remained active before this change.

## Checklist / 检查清单

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] Focused Linux backend-selection tests: 3/3 passed
- [x] Full Rust suite: 2887 passed, 5 ignored, 0 failed
- [x] Frontend checks not applicable; no frontend changes
- [x] i18n updates not applicable; no user-facing text changes
