### PR TITLE
fix(ui): reset provider scroll when switching apps

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -237,9 +237,25 @@ function App() {
   const effectiveUsageProvider = useLastValidValue(usageProvider);
 
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const mainScrollRef = useRef<HTMLElement>(null);
+  const providerScrollContainerRef = useRef<HTMLDivElement>(null);
   const isToolbarCompact = useAutoCompact(toolbarRef);
 
   useUsageCacheBridge();
+
+  useEffect(() => {
+    if (currentView !== "providers") return;
+
+    if (mainScrollRef.current) {
+      mainScrollRef.current.scrollTop = 0;
+      mainScrollRef.current.scrollLeft = 0;
+    }
+
+    if (providerScrollContainerRef.current) {
+      providerScrollContainerRef.current.scrollTop = 0;
+      providerScrollContainerRef.current.scrollLeft = 0;
+    }
+  }, [activeApp, currentView]);
 
   const promptPanelRef = useRef<any>(null);
   const mcpPanelRef = useRef<any>(null);
@@ -935,7 +951,10 @@ function App() {
         default:
           return (
             <div className="px-6 flex flex-col flex-1 min-h-0 overflow-hidden">
-              <div className="flex-1 overflow-y-auto overflow-x-hidden pb-12 px-1">
+              <div
+                ref={providerScrollContainerRef}
+                className="flex-1 overflow-y-auto overflow-x-hidden pb-12 px-1"
+              >
                 <AnimatePresence mode="wait">
                   <motion.div
                     key={activeApp}
@@ -1005,7 +1024,7 @@ function App() {
       <AnimatePresence mode="wait">
         <motion.div
           key={currentView}
-          className="flex-1 min-h-0"
+          className="flex flex-1 min-h-0 flex-col"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -1525,7 +1544,10 @@ function App() {
         </div>
       </header>
 
-      <main className="flex-1 min-h-0 flex flex-col overflow-y-auto animate-fade-in">
+      <main
+        ref={mainScrollRef}
+        className="flex-1 min-h-0 flex flex-col overflow-y-auto animate-fade-in"
+      >
         {isOpenClawView && openclawHealthWarnings.length > 0 && (
           <OpenClawHealthBanner warnings={openclawHealthWarnings} />
         )}

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -220,6 +220,48 @@ describe("App integration with MSW", () => {
     expect(toastSuccessMock).toHaveBeenCalled();
   });
 
+  it("resets provider view scroll when switching apps", async () => {
+    const { default: App } = await import("@/App");
+    const { container } = renderApp(App);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-list").textContent).toContain(
+        "claude-1",
+      ),
+    );
+
+    const mainScrollContainer = container.querySelector("main") as HTMLElement;
+    const providerScrollContainer = Array.from(
+      container.querySelectorAll<HTMLElement>(".overflow-y-auto"),
+    ).find(
+      (element) =>
+        element !== mainScrollContainer && element.className.includes("pb-12"),
+    );
+
+    expect(mainScrollContainer).not.toBeNull();
+    expect(providerScrollContainer).toBeDefined();
+
+    mainScrollContainer.scrollTop = 320;
+    mainScrollContainer.scrollLeft = 12;
+    providerScrollContainer!.scrollTop = 640;
+    providerScrollContainer!.scrollLeft = 24;
+
+    fireEvent.click(screen.getByText("switch-codex"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-list").textContent).toContain(
+        "codex-1",
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mainScrollContainer.scrollTop).toBe(0);
+      expect(mainScrollContainer.scrollLeft).toBe(0);
+      expect(providerScrollContainer!.scrollTop).toBe(0);
+      expect(providerScrollContainer!.scrollLeft).toBe(0);
+    });
+  });
+
   it("shows toast when auto sync fails in background", async () => {
     const { default: App } = await import("@/App");
     renderApp(App);


### PR DESCRIPTION
## Summary / 概述

Fix provider page content staying scrolled after switching between apps. The main page scroll container and provider list scroll container now reset to the top when the active app changes while the provider view is open.

Adds a regression test for the provider view scroll reset behavior.

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|   <img width="1217" height="1125" alt="image" src="https://github.com/user-attachments/assets/85c73376-518f-4efa-9991-0d67177684e7" />   |   <img width="1217" height="1125" alt="image" src="https://github.com/user-attachments/assets/abb0149e-fb11-4def-8e16-f0c33bbe18da" />    |
|某一个提供商翻到底部后，无法查看其他提供商|可以查看其他提供商|
## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `pnpm test:unit` passes / 通过单元测试
- [x] `cargo clippy` passes (if Rust code changed) / Not applicable: no Rust changes
- [x] Updated i18n files if user-facing text changed / Not applicable: no user-facing text changes
