### PR TITLE
feat(provider): add CLAUDE_CODE_AUTO_COMPACT_WINDOW for Kimi For Coding preset

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -389,6 +389,15 @@ export const providerPresets: ProviderPreset[] = [
       env: {
         ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
         ANTHROPIC_AUTH_TOKEN: "",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "${CLAUDE_CODE_AUTO_COMPACT_WINDOW}",
+      },
+    },
+    templateValues: {
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: {
+        label: "Auto Compact Window",
+        placeholder: "262144",
+        defaultValue: "262144",
+        editorValue: "262144",
       },
     },
     category: "cn_official",

--- a/tests/config/claudeProviderPresets.test.ts
+++ b/tests/config/claudeProviderPresets.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, it } from "vitest";
 import { providerPresets } from "@/config/claudeProviderPresets";
 
+describe("Kimi For Coding Provider Preset", () => {
+  const kimiForCoding = providerPresets.find(
+    (p) => p.name === "Kimi For Coding",
+  );
+
+  it("should include Kimi For Coding preset", () => {
+    expect(kimiForCoding).toBeDefined();
+  });
+
+  it("should use template placeholder for Claude Code auto-compact window", () => {
+    const env = (kimiForCoding!.settingsConfig as any).env;
+    expect(env).toHaveProperty(
+      "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+      "${CLAUDE_CODE_AUTO_COMPACT_WINDOW}",
+    );
+  });
+
+  it("should expose auto-compact window as editable template value with Kimi default", () => {
+    const values = (kimiForCoding!.templateValues as any)
+      ?.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+    expect(values).toBeDefined();
+    expect(values.defaultValue).toBe("262144");
+    expect(values.editorValue).toBe("262144");
+    expect(values.label).toBe("Auto Compact Window");
+  });
+});
+
 describe("AWS Bedrock Provider Presets", () => {
   const bedrockAksk = providerPresets.find(
     (p) => p.name === "AWS Bedrock (AKSK)",


### PR DESCRIPTION
## Summary

Add `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to the **Kimi For Coding** Claude Code provider preset, defaulting to `262144` as recommended by the official Kimi Code documentation for Claude Code integration:

https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html

To address the concern that this value may need to change for future models or user-tuned performance, the value is exposed as an editable `templateValues` field rather than a hard-coded constant. Users can keep the default or override it in the provider form.

Added unit tests to verify both the placeholder and the default template value.

## Related Issue

Fixes #

## Screenshots

N/A — configuration-only change.

| Before | After |
|--------|-------|
|        |       |

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [ ] `cargo clippy` passes (if Rust code changed)
- [ ] Updated i18n files if user-facing text changed

> Note: This change does not touch Rust code or user-facing UI strings, so `cargo clippy` and i18n updates are not applicable.