### PR TITLE
fix(proxy): add provider-aware Anthropic thinking policy

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -340,6 +340,18 @@ pub enum ClaudeDesktopMode {
     Proxy,
 }
 
+/// Anthropic-format assistant tool-use history handling for reasoning vendors.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AnthropicToolThinkingPolicy {
+    /// Historical default: synthesize placeholder thinking blocks for reasoning vendors.
+    Auto,
+    /// Preserve real thinking and safe structural cleanup only; do not synthesize.
+    PreserveOnly,
+    /// Explicitly opt into placeholder synthesis for vendors that require it.
+    PlaceholderAlways,
+}
+
 /// Claude Desktop 本地路由模式下暴露给 Desktop 的安全模型路由。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -432,6 +444,16 @@ pub struct ProviderMeta {
     /// - "openai_responses": OpenAI Responses API 格式，需要转换
     #[serde(rename = "apiFormat", skip_serializing_if = "Option::is_none")]
     pub api_format: Option<String>,
+    /// Anthropic-format reasoning tool-use history policy.
+    ///
+    /// Unset / `auto` keeps the historical behavior for compatibility.
+    /// `preserve_only` keeps real thinking blocks and safe cleanup, without
+    /// synthesizing `"tool call"` thinking placeholders.
+    #[serde(
+        rename = "anthropicToolThinkingPolicy",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub anthropic_tool_thinking_policy: Option<AnthropicToolThinkingPolicy>,
     /// 通用认证绑定（provider_config / managed_account）
     ///
     /// 新代码应只写入该字段；githubAccountId 仅保留兼容读取。

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -136,12 +136,16 @@ fn should_normalize_anthropic_tool_thinking_history(
     .any(is_reasoning_vendor_identifier)
 }
 
-/// DeepSeek's Anthropic-compatible endpoint requires thinking history to be
-/// replayed on every assistant turn that contains tool_use. Some Anthropic SDK
-/// clients keep the tool history but drop or redact the thinking block, which
-/// makes DeepSeek reject the next request with `content[].thinking ... must be
-/// passed back`. Normalize only the narrow tool-call history shape for
-/// providers known to require plain `thinking` blocks.
+/// Some Anthropic-compatible reasoning providers historically required
+/// thinking history to be replayed on assistant turns that contain `tool_use`.
+/// Some clients keep the tool history but drop or redact the thinking block,
+/// which made those providers reject the next request with errors such as
+/// `content[].thinking ... must be passed back`.
+///
+/// Keep the legacy placeholder behavior configurable and scoped to the narrow
+/// tool-call history shape. Providers that no longer need synthetic replay can
+/// use `preserve_only` to keep real thinking blocks and safe cleanup without
+/// inserting `"tool call"` placeholders.
 pub fn normalize_anthropic_tool_thinking_history_for_provider(
     body: &mut Value,
     provider: &Provider,

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -15,7 +15,7 @@
 //! - **GitHubCopilot**: GitHub Copilot (OAuth + Copilot Token)
 
 use super::{AuthInfo, AuthStrategy, ProviderAdapter, ProviderType};
-use crate::provider::Provider;
+use crate::provider::{AnthropicToolThinkingPolicy, Provider};
 use crate::proxy::error::ProxyError;
 use serde_json::{json, Value};
 
@@ -104,6 +104,15 @@ fn should_normalize_anthropic_tool_thinking_history(
         return false;
     }
 
+    if provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.anthropic_tool_thinking_policy.as_ref())
+        == Some(&AnthropicToolThinkingPolicy::PlaceholderAlways)
+    {
+        return true;
+    }
+
     if body
         .get("model")
         .and_then(|m| m.as_str())
@@ -142,7 +151,19 @@ pub fn normalize_anthropic_tool_thinking_history_for_provider(
         return false;
     }
 
-    normalize_anthropic_tool_thinking_history(body)
+    let inject_missing_thinking = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.anthropic_tool_thinking_policy.as_ref())
+        .map(|policy| match policy {
+            AnthropicToolThinkingPolicy::PreserveOnly => false,
+            AnthropicToolThinkingPolicy::Auto | AnthropicToolThinkingPolicy::PlaceholderAlways => {
+                true
+            }
+        })
+        .unwrap_or(true);
+
+    normalize_anthropic_tool_thinking_history(body, inject_missing_thinking)
 }
 
 /// DeepSeek official Anthropic-compatible endpoint URL
@@ -231,7 +252,10 @@ pub fn normalize_anthropic_messages_for_provider(
     changed
 }
 
-fn normalize_anthropic_tool_thinking_history(body: &mut Value) -> bool {
+fn normalize_anthropic_tool_thinking_history(
+    body: &mut Value,
+    inject_missing_thinking: bool,
+) -> bool {
     let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
         return false;
     };
@@ -264,7 +288,7 @@ fn normalize_anthropic_tool_thinking_history(body: &mut Value) -> bool {
                         if obj.remove("signature").is_some() {
                             changed = true;
                         }
-                        if !has_non_empty_thinking {
+                        if inject_missing_thinking && !has_non_empty_thinking {
                             obj.insert(
                                 "thinking".to_string(),
                                 json!(ANTHROPIC_THINKING_PLACEHOLDER),
@@ -286,7 +310,7 @@ fn normalize_anthropic_tool_thinking_history(body: &mut Value) -> bool {
             }
         }
 
-        if !has_thinking {
+        if inject_missing_thinking && !has_thinking {
             content.insert(
                 0,
                 json!({
@@ -2120,6 +2144,123 @@ mod tests {
         assert_eq!(content[0]["thinking"], ANTHROPIC_THINKING_PLACEHOLDER);
         assert_eq!(content[1]["type"], "text");
         assert_eq!(content[2]["type"], "tool_use");
+    }
+
+    #[test]
+    fn test_anthropic_tool_history_preserve_only_policy_skips_placeholder_injection() {
+        let provider = create_provider_with_meta(
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+                    "ANTHROPIC_API_KEY": "test-key"
+                }
+            }),
+            ProviderMeta {
+                anthropic_tool_thinking_policy: Some(
+                    crate::provider::AnthropicToolThinkingPolicy::PreserveOnly,
+                ),
+                ..Default::default()
+            },
+        );
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I will inspect the repo."},
+                    {"type": "tool_use", "id": "call_123", "name": "read_file", "input": {"path": "README.md"}}
+                ]
+            }]
+        });
+        let original = body.clone();
+
+        let changed = normalize_anthropic_tool_thinking_history_for_provider(
+            &mut body,
+            &provider,
+            "anthropic",
+        );
+
+        assert!(!changed);
+        assert_eq!(body, original);
+    }
+
+    #[test]
+    fn test_anthropic_tool_history_preserve_only_policy_keeps_safe_transforms() {
+        let provider = create_provider_with_meta(
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+                    "ANTHROPIC_API_KEY": "test-key"
+                }
+            }),
+            ProviderMeta {
+                anthropic_tool_thinking_policy: Some(
+                    crate::provider::AnthropicToolThinkingPolicy::PreserveOnly,
+                ),
+                ..Default::default()
+            },
+        );
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Need to inspect the file.", "signature": "anthropic-signature"},
+                    {"type": "tool_use", "id": "call_123", "name": "read_file", "input": {"path": "README.md"}}
+                ]
+            }]
+        });
+
+        let changed = normalize_anthropic_tool_thinking_history_for_provider(
+            &mut body,
+            &provider,
+            "anthropic",
+        );
+
+        assert!(changed);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["thinking"], "Need to inspect the file.");
+        assert!(content[0].get("signature").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_tool_history_placeholder_always_policy_injects_placeholder() {
+        let provider = create_provider_with_meta(
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.example.com/anthropic",
+                    "ANTHROPIC_API_KEY": "test-key"
+                }
+            }),
+            ProviderMeta {
+                anthropic_tool_thinking_policy: Some(
+                    crate::provider::AnthropicToolThinkingPolicy::PlaceholderAlways,
+                ),
+                ..Default::default()
+            },
+        );
+        let mut body = json!({
+            "model": "example-model",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "call_123", "name": "read_file", "input": {"path": "README.md"}}
+                ]
+            }]
+        });
+
+        let changed = normalize_anthropic_tool_thinking_history_for_provider(
+            &mut body,
+            &provider,
+            "anthropic",
+        );
+
+        assert!(changed);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["thinking"], ANTHROPIC_THINKING_PLACEHOLDER);
+        assert_eq!(content[1]["type"], "tool_use");
     }
 
     #[test]

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,11 @@ export type CodexChatReasoningOutputFormat =
   | "reasoning_details"
   | "think_tags";
 
+export type AnthropicToolThinkingPolicy =
+  | "auto"
+  | "preserve_only"
+  | "placeholder_always";
+
 export interface CodexChatReasoning {
   supportsThinking?: boolean;
   supportsEffort?: boolean;
@@ -203,6 +208,9 @@ export interface ProviderMeta {
     | "openai_chat"
     | "openai_responses"
     | "gemini_native";
+  // Anthropic-format reasoning tool-use history policy.
+  // Defaults to auto. preserve_only keeps real thinking and safe cleanup only.
+  anthropicToolThinkingPolicy?: AnthropicToolThinkingPolicy;
   // 通用认证绑定
   authBinding?: AuthBinding;
   // Claude 认证字段名


### PR DESCRIPTION
## Summary

This is a smaller provider-aware alternative to #4210.

Instead of replacing proactive placeholder injection with a reactive retry path, this PR keeps the current default behavior for compatibility and adds an explicit provider metadata policy for Anthropic-format tool-use thinking history:

- `auto` / unset: keep historical behavior for reasoning-vendor hints.
- `preserve_only`: preserve real `thinking` blocks and safe structural cleanup only; do not synthesize `{"type":"thinking","thinking":"tool call"}`.
- `placeholder_always`: explicitly opt a provider into placeholder synthesis, even without a vendor hint.

The intent is to stop treating synthetic thinking placeholders as a hardcoded behavior for every reasoning-vendor Anthropic path. They become a provider capability / compatibility choice.

## Context collected

- #3203 introduced DeepSeek/MiMo Anthropic tool-thinking history normalization so assistant `tool_use` turns always include a plain `thinking` block.
- #4208 reports long DeepSeek-compatible Anthropic sessions where synthetic `"tool call"` thinking placeholders may correlate with visible text being emitted inside `thinking` blocks and session freezes.
- #3645 reports thinking-only responses with no visible text blocks in DeepSeek Anthropic protocol sessions.
- #3934 reports request transformations affecting DeepSeek prefix-cache behavior; #3775 was later reverted in main, reinforcing that Anthropic-format proxy transforms should be minimal and provider-aware.
- #3930 covers a nearby but different replay problem: invalid signed historical thinking blocks.
- #4239 recently added a very targeted DeepSeek official endpoint transform for `thinking: disabled` + effort conflicts. That is a separate issue, but it follows the same direction: precise provider-scoped behavior instead of broad request rewriting.

## Why this shape

A pure reactive retry path is useful as a compatibility fallback, but it has drawbacks:

- it depends on upstream error text staying stable;
- it adds a failed round trip for vendors that still require backpass;
- some relays wrap or normalize errors before cc-switch can match them;
- it still treats placeholder synthesis as an error-path repair rather than an explicit provider capability.

This PR does not claim that every DeepSeek-compatible Anthropic endpoint has relaxed thinking backpass requirements. It only makes the existing synthetic placeholder behavior configurable and safe to disable for providers where it is harmful.

## Private A/B validation

I also ran a sanitized private A/B against a DeepSeek-compatible Anthropic relay. No private endpoint names, machine names, or credentials are included here.

- Auth/model probe: bearer auth worked for the test model; `x-api-key` was rejected by that relay.
- Anthropic `/v1/messages`, small tool-use history:
  - no synthetic placeholder: HTTP 200, response contained `thinking` + `text` blocks.
  - with synthetic `"tool call"` placeholder: HTTP 200, response contained `thinking` + `text` blocks.
- Anthropic `/v1/messages`, non-streaming long-history fixture (~63 KB request, 12 tool turns, ~21.9k input tokens):
  - no synthetic placeholder: HTTP 200, `thinking` + `text`, `stop_reason=end_turn`.
  - with synthetic placeholder: HTTP 200, but one run emitted only `thinking` before `max_tokens`.
- Anthropic `/v1/messages`, streaming stress fixture (~304 KB request, 18 tool turns, ~107k input tokens):
  - no synthetic placeholder: HTTP 200, `thinking` + `text`, `stop_reason=end_turn`.
  - with synthetic placeholder: HTTP 200, `thinking` + `text`, `stop_reason=end_turn`.

Interpretation: this is not proof that disabling placeholders fixes every long-context freeze. It does confirm that this tested DeepSeek-compatible Anthropic path accepts tool-use history without synthetic placeholders, and that synthetic placeholders can still affect the output block mix / budget under longer histories. That is why this PR exposes a provider-scoped policy instead of changing the global default.

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/provider.rs` | Add `AnthropicToolThinkingPolicy` and `ProviderMeta.anthropicToolThinkingPolicy`. |
| `src-tauri/src/proxy/providers/claude.rs` | Parameterize placeholder synthesis while keeping signature stripping and `redacted_thinking` conversion; soften outdated comments that implied all DeepSeek-compatible endpoints still require placeholder replay. |
| `src/types.ts` | Add frontend TypeScript metadata type for the new policy. |

## Behavior

- Existing providers are unchanged because unset policy maps to historical `auto` behavior.
- `preserve_only` prevents missing / empty thinking blocks from being filled with synthetic `"tool call"`, but still strips invalid `signature` fields from real thinking blocks.
- `placeholder_always` allows explicit opt-in for a provider that requires synthetic placeholders even when it does not match the built-in vendor hints.

## Verification

Passed:

```text
cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::providers::claude -- --nocapture
# 66 passed

cargo fmt --manifest-path src-tauri/Cargo.toml --check
cargo check --manifest-path src-tauri/Cargo.toml --lib
pnpm typecheck
pnpm format:check
```

Also ran:

```text
cargo test --manifest-path src-tauri/Cargo.toml --lib
```

Result: 1654 passed, 8 failed, 2 ignored. The failures are outside this PR's touched area (`codex_history_migration`, `commands::misc::anchored_upgrade_windows`, `database::dao::usage_rollup`) and appear unrelated to Anthropic provider normalization.

## Draft notes

This is intentionally draft because the maintainer may prefer one of two follow-ups:

1. expose `anthropicToolThinkingPolicy` in the provider UI, or
2. seed `preserve_only` / `placeholder_always` on specific presets after more provider verification.

I kept this PR backend-focused to separate the protocol behavior from UI/preset policy decisions.
