### PR TITLE
fix(providers): 修复部分工具在复制供应商时 供应商 Copy 出现在当前工具的最底部的问题

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -681,39 +681,23 @@ function App() {
   const handleDuplicateProvider = async (provider: Provider) => {
     // Fix #4234: Ensure duplicate appears next to original, even if original lacks sortIndex
     let newSortIndex: number;
-    let needUpdateOriginal = false;
-    // When the whole list lacks sortIndex, normalize all providers to contiguous
-    // indices so the duplicate (otherwise the only indexed item) isn't shoved to the top.
     let needNormalizeAll = false;
     let originalIdx = -1;
 
     if (provider.sortIndex !== undefined) {
-      // Original has sortIndex → insert right below it
+      // Original has sortIndex → insert duplicate right below it
       newSortIndex = provider.sortIndex + 1;
     } else {
-      // Original lacks sortIndex → assign sortIndex to both original and duplicate
-      // to ensure they appear adjacent (not scattered across the list)
+      // Original lacks sortIndex. Indexed items always sort ahead of unindexed ones
+      // (sortIndex ?? MAX_SAFE_INTEGER), so assigning sortIndex only to original+copy
+      // would lift them above the other unindexed providers. Normalize the whole list
+      // to contiguous indices by its current display order, then slot the duplicate
+      // right below the original — this preserves relative order for both the
+      // all-unindexed and the mixed indexed/unindexed cases.
       const allProviders = Object.values(providers); // already sorted by sortProviders
-      const indexedProviders = allProviders.filter(
-        (p) => p.sortIndex !== undefined,
-      );
-
-      if (indexedProviders.length === 0) {
-        // Whole list lacks sortIndex: assigning max+1/max+2 would make original+duplicate
-        // the only indexed items and shove them to the top. Normalize the entire list by
-        // display order, then slot the duplicate right below the original.
-        needNormalizeAll = true;
-        originalIdx = allProviders.findIndex((p) => p.id === provider.id);
-        newSortIndex = originalIdx + 1;
-      } else {
-        const maxSortIndex = indexedProviders.reduce(
-          (max, p) => Math.max(max, p.sortIndex!),
-          0,
-        );
-        // Original will get maxSortIndex + 1, duplicate gets maxSortIndex + 2
-        newSortIndex = maxSortIndex + 2;
-        needUpdateOriginal = true;
-      }
+      originalIdx = allProviders.findIndex((p) => p.id === provider.id);
+      needNormalizeAll = true;
+      newSortIndex = originalIdx + 1;
     }
 
     const duplicatedProvider: Omit<Provider, "id" | "createdAt"> & {
@@ -788,29 +772,19 @@ function App() {
         });
       });
     } else {
-      // If original lacked sortIndex, assign it one now (so it stays adjacent to duplicate)
-      if (needUpdateOriginal) {
-        updates.push({
-          id: provider.id,
-          sortIndex: newSortIndex - 1, // Original gets newSortIndex - 1, duplicate gets newSortIndex
-        });
-      }
-
-      // Update subsequent providers' sortIndex (shift them down by 1 or 2)
-      const shiftAmount = needUpdateOriginal ? 2 : 1;
-      const threshold = needUpdateOriginal ? newSortIndex - 1 : newSortIndex;
-
+      // Original already had sortIndex → shift subsequent indexed providers down by 1
+      // to make room for the duplicate slotted right below the original.
       Object.values(providers)
         .filter(
           (p) =>
             p.sortIndex !== undefined &&
-            p.sortIndex >= threshold &&
+            p.sortIndex >= newSortIndex &&
             p.id !== provider.id,
         )
         .forEach((p) => {
           updates.push({
             id: p.id,
-            sortIndex: p.sortIndex! + shiftAmount,
+            sortIndex: p.sortIndex! + 1,
           });
         });
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -679,20 +679,41 @@ function App() {
   };
 
   const handleDuplicateProvider = async (provider: Provider) => {
-    // Fix #4234: Always assign sortIndex to duplicate, even if original lacks it
+    // Fix #4234: Ensure duplicate appears next to original, even if original lacks sortIndex
     let newSortIndex: number;
+    let needUpdateOriginal = false;
+    // When the whole list lacks sortIndex, normalize all providers to contiguous
+    // indices so the duplicate (otherwise the only indexed item) isn't shoved to the top.
+    let needNormalizeAll = false;
+    let originalIdx = -1;
+
     if (provider.sortIndex !== undefined) {
       // Original has sortIndex → insert right below it
       newSortIndex = provider.sortIndex + 1;
     } else {
-      // Original lacks sortIndex → assign next available index
-      const maxSortIndex = Math.max(
-        0,
-        ...Object.values(providers)
-          .filter((p) => p.sortIndex !== undefined)
-          .map((p) => p.sortIndex!),
+      // Original lacks sortIndex → assign sortIndex to both original and duplicate
+      // to ensure they appear adjacent (not scattered across the list)
+      const allProviders = Object.values(providers); // already sorted by sortProviders
+      const indexedProviders = allProviders.filter(
+        (p) => p.sortIndex !== undefined,
       );
-      newSortIndex = maxSortIndex + 1;
+
+      if (indexedProviders.length === 0) {
+        // Whole list lacks sortIndex: assigning max+1/max+2 would make original+duplicate
+        // the only indexed items and shove them to the top. Normalize the entire list by
+        // display order, then slot the duplicate right below the original.
+        needNormalizeAll = true;
+        originalIdx = allProviders.findIndex((p) => p.id === provider.id);
+        newSortIndex = originalIdx + 1;
+      } else {
+        const maxSortIndex = indexedProviders.reduce(
+          (max, p) => Math.max(max, p.sortIndex!),
+          0,
+        );
+        // Original will get maxSortIndex + 1, duplicate gets maxSortIndex + 2
+        newSortIndex = maxSortIndex + 2;
+        needUpdateOriginal = true;
+      }
     }
 
     const duplicatedProvider: Omit<Provider, "id" | "createdAt"> & {
@@ -703,7 +724,7 @@ function App() {
       settingsConfig: deepClone(provider.settingsConfig),
       websiteUrl: provider.websiteUrl,
       category: provider.category,
-      sortIndex: newSortIndex, // Always has a value now
+      sortIndex: newSortIndex,
       meta: provider.meta ? deepClone(provider.meta) : undefined,
       icon: provider.icon,
       iconColor: provider.iconColor,
@@ -754,32 +775,57 @@ function App() {
       duplicatedProvider.addToLive = false;
     }
 
-    // Update subsequent providers' sortIndex (only if original had sortIndex and inserted in-between)
-    if (provider.sortIndex !== undefined) {
-      const updates = Object.values(providers)
+    // Update sortIndex for affected providers
+    const updates: Array<{ id: string; sortIndex: number }> = [];
+
+    if (needNormalizeAll) {
+      // Normalize the whole list to contiguous indices (0..N) by display order,
+      // reserving `newSortIndex` (= originalIdx + 1) for the duplicate.
+      Object.values(providers).forEach((p, idx) => {
+        updates.push({
+          id: p.id,
+          sortIndex: idx <= originalIdx ? idx : idx + 1,
+        });
+      });
+    } else {
+      // If original lacked sortIndex, assign it one now (so it stays adjacent to duplicate)
+      if (needUpdateOriginal) {
+        updates.push({
+          id: provider.id,
+          sortIndex: newSortIndex - 1, // Original gets newSortIndex - 1, duplicate gets newSortIndex
+        });
+      }
+
+      // Update subsequent providers' sortIndex (shift them down by 1 or 2)
+      const shiftAmount = needUpdateOriginal ? 2 : 1;
+      const threshold = needUpdateOriginal ? newSortIndex - 1 : newSortIndex;
+
+      Object.values(providers)
         .filter(
           (p) =>
             p.sortIndex !== undefined &&
-            p.sortIndex >= newSortIndex &&
+            p.sortIndex >= threshold &&
             p.id !== provider.id,
         )
-        .map((p) => ({
-          id: p.id,
-          sortIndex: p.sortIndex! + 1,
-        }));
+        .forEach((p) => {
+          updates.push({
+            id: p.id,
+            sortIndex: p.sortIndex! + shiftAmount,
+          });
+        });
+    }
 
-      if (updates.length > 0) {
-        try {
-          await providersApi.updateSortOrder(updates, activeApp);
-        } catch (error) {
-          console.error("[App] Failed to update sort order", error);
-          toast.error(
-            t("provider.sortUpdateFailed", {
-              defaultValue: "排序更新失败",
-            }),
-          );
-          return; // 如果排序更新失败，不继续添加
-        }
+    if (updates.length > 0) {
+      try {
+        await providersApi.updateSortOrder(updates, activeApp);
+      } catch (error) {
+        console.error("[App] Failed to update sort order", error);
+        toast.error(
+          t("provider.sortUpdateFailed", {
+            defaultValue: "排序更新失败",
+          }),
+        );
+        return; // 如果排序更新失败，不继续添加
       }
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -679,8 +679,21 @@ function App() {
   };
 
   const handleDuplicateProvider = async (provider: Provider) => {
-    const newSortIndex =
-      provider.sortIndex !== undefined ? provider.sortIndex + 1 : undefined;
+    // Fix #4234: Always assign sortIndex to duplicate, even if original lacks it
+    let newSortIndex: number;
+    if (provider.sortIndex !== undefined) {
+      // Original has sortIndex → insert right below it
+      newSortIndex = provider.sortIndex + 1;
+    } else {
+      // Original lacks sortIndex → assign next available index
+      const maxSortIndex = Math.max(
+        0,
+        ...Object.values(providers)
+          .filter((p) => p.sortIndex !== undefined)
+          .map((p) => p.sortIndex!),
+      );
+      newSortIndex = maxSortIndex + 1;
+    }
 
     const duplicatedProvider: Omit<Provider, "id" | "createdAt"> & {
       providerKey?: string;
@@ -690,7 +703,7 @@ function App() {
       settingsConfig: deepClone(provider.settingsConfig),
       websiteUrl: provider.websiteUrl,
       category: provider.category,
-      sortIndex: newSortIndex, // 复制原 sortIndex + 1
+      sortIndex: newSortIndex, // Always has a value now
       meta: provider.meta ? deepClone(provider.meta) : undefined,
       icon: provider.icon,
       iconColor: provider.iconColor,
@@ -741,12 +754,13 @@ function App() {
       duplicatedProvider.addToLive = false;
     }
 
+    // Update subsequent providers' sortIndex (only if original had sortIndex and inserted in-between)
     if (provider.sortIndex !== undefined) {
       const updates = Object.values(providers)
         .filter(
           (p) =>
             p.sortIndex !== undefined &&
-            p.sortIndex >= newSortIndex! &&
+            p.sortIndex >= newSortIndex &&
             p.id !== provider.id,
         )
         .map((p) => ({

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -305,6 +305,60 @@ describe("App integration with MSW", () => {
     );
   });
 
+  it("keeps duplicate next to original when original lacks sortIndex in a mixed list", async () => {
+    // Mixed indexed/unindexed list: A has sortIndex, B and C do not.
+    // Display order is A, B, C. Duplicating C must yield A, B, C, "C copy" — it must not
+    // lift C (and its copy) above the unindexed B. Regression test for the #4234 mixed case.
+    const base = Date.now();
+    setProviders("codex", {
+      "codex-a": {
+        id: "codex-a",
+        name: "A",
+        settingsConfig: {},
+        category: "custom",
+        sortIndex: 0,
+        createdAt: base,
+      },
+      "codex-b": {
+        id: "codex-b",
+        name: "B",
+        settingsConfig: {},
+        category: "custom",
+        createdAt: base + 1,
+      },
+      "codex-c": {
+        id: "codex-c",
+        name: "C",
+        settingsConfig: {},
+        category: "custom",
+        createdAt: base + 2,
+      },
+    });
+    setCurrentProviderId("codex", "codex-c");
+
+    const { default: App } = await import("@/App");
+    renderApp(App);
+
+    fireEvent.click(screen.getByText("switch-codex"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-list").textContent).toContain(
+        "codex-c",
+      ),
+    );
+
+    fireEvent.click(screen.getByText("duplicate"));
+
+    await waitFor(() => {
+      const list = screen.getByTestId("provider-list").textContent ?? "";
+      const parsed = JSON.parse(list) as Record<string, { name: string }>;
+      const names = Object.values(parsed).map((p) => p.name);
+      expect(names).toEqual(["A", "B", "C", "C copy"]);
+    });
+
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
   it("shows toast when duplicate cannot load live provider ids", async () => {
     setProviders("openclaw", {
       deepseek: {


### PR DESCRIPTION
## Summary / 概述

修复复制供应商（duplicate provider）时排序位置异常的问题。此前当 original 缺少 `sortIndex` 时，复制出的供应商可能脱离
  original、被挤到列表底部。

## Related Issue / 关联 Issue

Fixes #4234

## Screenshots / 截图

无

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
