### PR TITLE
fix(updater): pass GlobalProxy to updater plugin for check and download

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -189,8 +189,17 @@ pub async fn restart_app(app: AppHandle) -> Result<bool, String> {
 /// 这里把退出清理、安装和重启串在同一个后端流程中，避免依赖旧前端继续执行。
 #[tauri::command]
 pub async fn install_update_and_restart(app: AppHandle) -> Result<bool, String> {
-    let updater = app
-        .updater_builder()
+    let mut builder = app.updater_builder();
+
+    // 将 GlobalProxy 配置传递给 updater，使其在代理环境下也能正常访问 GitHub
+    if let Some(proxy_url) = crate::proxy::http_client::get_current_proxy_url() {
+        if let Ok(parsed) = url::Url::parse(&proxy_url) {
+            builder = builder.proxy(parsed);
+            log::info!("[Updater] Using global proxy: {}", crate::proxy::http_client::mask_url(&proxy_url));
+        }
+    }
+
+    let updater = builder
         .build()
         .map_err(|e| format!("初始化更新器失败: {e}"))?;
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -192,10 +192,18 @@ pub async fn install_update_and_restart(app: AppHandle) -> Result<bool, String> 
     let mut builder = app.updater_builder();
 
     // 将 GlobalProxy 配置传递给 updater，使其在代理环境下也能正常访问 GitHub
+    // 注意：tauri-plugin-updater 的 reqwest 未启用 socks feature，仅支持 http/https 代理
     if let Some(proxy_url) = crate::proxy::http_client::get_current_proxy_url() {
         if let Ok(parsed) = url::Url::parse(&proxy_url) {
-            builder = builder.proxy(parsed);
-            log::info!("[Updater] Using global proxy: {}", crate::proxy::http_client::mask_url(&proxy_url));
+            match parsed.scheme() {
+                "http" | "https" => {
+                    builder = builder.proxy(parsed);
+                    log::info!("[Updater] Using global proxy: {}", crate::proxy::http_client::mask_url(&proxy_url));
+                }
+                scheme => {
+                    log::warn!("[Updater] Unsupported proxy scheme '{}', falling back to direct connection", scheme);
+                }
+            }
         }
     }
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -34,9 +34,15 @@ export async function checkForUpdate(
   const currentVersion = await getCurrentVersion();
 
   // 读取全局代理配置，传递给 updater 插件
+  // 注意：tauri-plugin-updater 仅支持 http/https 代理，SOCKS 代理需跳过
   let proxyUrl: string | null = null;
   try {
-    proxyUrl = await getGlobalProxyUrl();
+    const raw = await getGlobalProxyUrl();
+    if (raw && /^https?:\/\//i.test(raw)) {
+      proxyUrl = raw;
+    } else if (raw) {
+      console.warn(`[Updater] Unsupported proxy scheme, falling back to direct: ${raw}`);
+    }
   } catch {
     // 获取代理失败时静默忽略，使用直连
   }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -29,9 +29,22 @@ export async function checkForUpdate(
 > {
   // 动态引入，避免在未安装插件时导致打包期问题
   const { check } = await import("@tauri-apps/plugin-updater");
+  const { getGlobalProxyUrl } = await import("./api/globalProxy");
 
   const currentVersion = await getCurrentVersion();
-  const update = await check({ timeout: opts.timeout ?? 30000 } as any);
+
+  // 读取全局代理配置，传递给 updater 插件
+  let proxyUrl: string | null = null;
+  try {
+    proxyUrl = await getGlobalProxyUrl();
+  } catch {
+    // 获取代理失败时静默忽略，使用直连
+  }
+
+  const update = await check({
+    timeout: opts.timeout ?? 30000,
+    ...(proxyUrl ? { proxy: proxyUrl } : {}),
+  } as any);
 
   if (!update) {
     return { status: "up-to-date" };


### PR DESCRIPTION
The tauri-plugin-updater uses its own reqwest client which does not inherit the app's GlobalProxy configuration. This causes update checks and downloads to fail in environments where GitHub access requires a proxy (e.g. mainland China).

Fix:
- Backend (settings.rs): Read GlobalProxy URL from http_client module and pass it to UpdaterBuilder::proxy() before building the updater.
- Frontend (updater.ts): Read GlobalProxy URL via getGlobalProxyUrl() and pass it as the 'proxy' option to the check() call.

Closes #4089

## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
