### PR TITLE
feat(providers): add Bailian Token Plan preset across all clients

### DIFF
--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -414,6 +414,18 @@ export const claudeDesktopProviderPresets: ClaudeDesktopProviderPreset[] = [
     iconColor: "#624AFF",
   },
   {
+    name: "Bailian Token Plan",
+    websiteUrl: "https://bailian.console.aliyun.com",
+    category: "cn_official",
+    baseUrl:
+      "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+    mode: "proxy",
+    apiFormat: "anthropic",
+    modelRoutes: passthroughRoutes(),
+    icon: "bailian",
+    iconColor: "#624AFF",
+  },
+  {
     name: "Kimi",
     primePartner: true,
     websiteUrl: "https://platform.moonshot.cn/console?aff=cc-switch",

--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -417,8 +417,7 @@ export const claudeDesktopProviderPresets: ClaudeDesktopProviderPreset[] = [
     name: "Bailian Token Plan",
     websiteUrl: "https://bailian.console.aliyun.com",
     category: "cn_official",
-    baseUrl:
-      "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+    baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
     mode: "proxy",
     apiFormat: "anthropic",
     modelRoutes: passthroughRoutes(),

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -367,6 +367,20 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#624AFF",
   },
   {
+    name: "Bailian Token Plan",
+    websiteUrl: "https://bailian.console.aliyun.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL:
+          "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+        ANTHROPIC_AUTH_TOKEN: "",
+      },
+    },
+    category: "cn_official",
+    icon: "bailian",
+    iconColor: "#624AFF",
+  },
+  {
     name: "Kimi",
     primePartner: true,
     websiteUrl: "https://platform.moonshot.cn/console?aff=cc-switch",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -420,6 +420,53 @@ requires_openai_auth = true`,
     iconColor: "#624AFF",
   },
   {
+    name: "Bailian Token Plan",
+    websiteUrl: "https://bailian.console.aliyun.com",
+    apiKeyUrl: "https://bailian.console.aliyun.com/#/api-key",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "bailian-token-plan",
+      "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+      "qwen3.7-max",
+    ),
+    endpointCandidates: [
+      "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    ],
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      {
+        model: "qwen3.7-max",
+        displayName: "Qwen3.7 Max",
+        contextWindow: 262144,
+      },
+      {
+        model: "deepseek-v4-pro",
+        displayName: "DeepSeek V4 Pro",
+        contextWindow: 1000000,
+      },
+      {
+        model: "kimi-k2.7-code",
+        displayName: "Kimi K2.7 Code",
+        contextWindow: 262144,
+      },
+      {
+        model: "glm-5.2",
+        displayName: "GLM-5.2",
+        contextWindow: 128000,
+      },
+    ]),
+    codexChatReasoning: {
+      supportsThinking: true,
+      supportsEffort: false,
+      thinkingParam: "enable_thinking",
+      effortParam: "none",
+      outputFormat: "reasoning_content",
+    },
+    category: "cn_official",
+    icon: "bailian",
+    iconColor: "#624AFF",
+  },
+  {
     name: "Kimi",
     primePartner: true,
     websiteUrl: "https://platform.moonshot.cn/console?aff=cc-switch",

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -515,6 +515,29 @@ export const hermesProviderPresets: HermesProviderPreset[] = [
     },
   },
   {
+    name: "Bailian Token Plan",
+    websiteUrl: "https://bailian.console.aliyun.com",
+    settingsConfig: {
+      name: "bailian_token_plan",
+      base_url:
+        "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+      api_key: "",
+      api_mode: "chat_completions",
+      models: [
+        { id: "qwen3.7-max", name: "Qwen3.7 Max" },
+        { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
+        { id: "kimi-k2.7-code", name: "Kimi K2.7 Code" },
+        { id: "glm-5.2", name: "GLM-5.2" },
+      ],
+    },
+    category: "cn_official",
+    icon: "bailian",
+    iconColor: "#624AFF",
+    suggestedDefaults: {
+      model: { default: "qwen3.7-max", provider: "bailian_token_plan" },
+    },
+  },
+  {
     name: "Kimi",
     primePartner: true,
     websiteUrl: "https://platform.moonshot.cn/console?aff=cc-switch",

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -491,6 +491,61 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     },
   },
   {
+    name: "Bailian Token Plan",
+    websiteUrl: "https://bailian.console.aliyun.com",
+    apiKeyUrl: "https://bailian.console.aliyun.com/#/api-key",
+    settingsConfig: {
+      baseUrl:
+        "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+      apiKey: "",
+      api: "openai-completions",
+      models: [
+        {
+          id: "qwen3.7-max",
+          name: "Qwen3.7 Max",
+          contextWindow: 262144,
+        },
+        {
+          id: "deepseek-v4-pro",
+          name: "DeepSeek V4 Pro",
+          contextWindow: 1000000,
+        },
+        {
+          id: "kimi-k2.7-code",
+          name: "Kimi K2.7 Code",
+          contextWindow: 262144,
+        },
+        {
+          id: "glm-5.2",
+          name: "GLM-5.2",
+          contextWindow: 128000,
+        },
+      ],
+    },
+    category: "cn_official",
+    icon: "bailian",
+    iconColor: "#624AFF",
+    templateValues: {
+      baseUrl: {
+        label: "Base URL",
+        placeholder:
+          "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        defaultValue:
+          "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        editorValue: "",
+      },
+      apiKey: {
+        label: "API Key",
+        placeholder: "sk-...",
+        editorValue: "",
+      },
+    },
+    suggestedDefaults: {
+      model: { primary: "qwen/qwen3.7-max" },
+      modelCatalog: { "qwen/qwen3.7-max": { alias: "Qwen" } },
+    },
+  },
+  {
     name: "Kimi K2.7 Code",
     primePartner: true,
     websiteUrl: "https://platform.moonshot.cn/console?aff=cc-switch",

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -589,6 +589,45 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     },
   },
   {
+    name: "Bailian Token Plan",
+    websiteUrl: "https://bailian.console.aliyun.com",
+    apiKeyUrl: "https://bailian.console.aliyun.com/#/api-key",
+    settingsConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "Bailian Token Plan",
+      options: {
+        baseURL:
+          "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        apiKey: "",
+        setCacheKey: true,
+      },
+      models: {
+        "qwen3.7-max": { name: "Qwen3.7 Max" },
+        "deepseek-v4-pro": { name: "DeepSeek V4 Pro" },
+        "kimi-k2.7-code": { name: "Kimi K2.7 Code" },
+        "glm-5.2": { name: "GLM-5.2" },
+      },
+    },
+    category: "cn_official",
+    icon: "bailian",
+    iconColor: "#624AFF",
+    templateValues: {
+      baseURL: {
+        label: "Base URL",
+        placeholder:
+          "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        defaultValue:
+          "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        editorValue: "",
+      },
+      apiKey: {
+        label: "API Key",
+        placeholder: "sk-...",
+        editorValue: "",
+      },
+    },
+  },
+  {
     name: "Kimi K2.7 Code",
     primePartner: true,
     websiteUrl: "https://platform.moonshot.cn/console?aff=cc-switch",


### PR DESCRIPTION
## Summary

Adds a new **Bailian Token Plan** provider preset for Alibaba Cloud Model Studio (百炼 / DashScope) **Token Plan 团队版** subscription, covering all six supported clients.

This complements the existing `Bailian` (pay-as-you-go via dashscope) and `Bailian For Coding` presets with the new seat-based **Token Plan** product line (cn-beijing region, Credits-based metering).

## Changes

Preset added to all six config files:
- `claudeProviderPresets.ts` (Claude Code)
- `claudeDesktopProviderPresets.ts` (Claude Desktop)
- `codexProviderPresets.ts` (Codex)
- `hermesProviderPresets.ts` (Hermes Agent)
- `openclawProviderPresets.ts` (OpenClaw)
- `opencodeProviderPresets.ts` (OpenCode)

## Details

**Endpoints** (per official docs — Token Plan is currently Beijing-region only):
- Anthropic-compatible: `https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic`
- OpenAI-compatible: `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`

**Models** (verified against the Token Plan supported-model whitelist — exact string match): `qwen3.7-max` (default), `deepseek-v4-pro`, `kimi-k2.7-code`, `glm-5.2`.

- The two Anthropic-format clients (Claude Code / Claude Desktop) route through `/apps/anthropic` as passthrough (no model list, matching existing Bailian presets).
- The four OpenAI-compatible clients (Codex / Hermes / OpenClaw / OpenCode) expose the four models above.

## Verification

- `npx tsc --noEmit` ✅
- Full unit suite ✅ (56 files / 338 tests)
- Manual UI check: preset appears and shows correct default + model list across all six clients.

## Reference

- Quickstart: https://help.aliyun.com/zh/model-studio/token-plan-quickstart
- Supported models: https://help.aliyun.com/zh/model-studio/token-plan-team

🤖 Generated with [Claude Code](https://claude.com/claude-code)