### PR TITLE
feat: add Rio terminal support in terminal settings dropdown

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2790,6 +2790,7 @@ echo "{config_path}"
         "ghostty" => launch_macos_ghostty(&script_file),
         "wezterm" => launch_macos_open_app("WezTerm", &script_file, true),
         "kaku" => launch_macos_open_app("Kaku", &script_file, true),
+        "rio" => launch_macos_rio(&script_file),
         _ => launch_macos_terminal_app(&script_file),
     };
 
@@ -3051,6 +3052,30 @@ fn launch_macos_warp(script_file: &std::path::Path) -> Result<(), String> {
         let stderr = decode_command_output(&output.stderr);
         return Err(format!(
             "Warp 启动失败 (exit code: {:?}): {}",
+            output.status.code(),
+            stderr
+        ));
+    }
+
+    Ok(())
+}
+
+/// macOS: Rio.  Rio's `-e` consumes all remaining args as the command, so we
+/// pass the script file directly without a `sh -c` wrapper.
+#[cfg(target_os = "macos")]
+fn launch_macos_rio(script_file: &std::path::Path) -> Result<(), String> {
+    use std::process::Command;
+
+    let output = Command::new("open")
+        .args(["-na", "Rio", "--args", "-e"])
+        .arg(script_file)
+        .output()
+        .map_err(|e| format!("启动 Rio 失败: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = decode_command_output(&output.stderr);
+        return Err(format!(
+            "Rio 启动失败 (exit code: {:?}): {}",
             output.status.code(),
             stderr
         ));
@@ -3349,6 +3374,7 @@ read -r _
             "ghostty" => launch_macos_ghostty(&script_file),
             "wezterm" => launch_macos_open_app("WezTerm", &script_file, true),
             "kaku" => launch_macos_open_app("Kaku", &script_file, true),
+            "rio" => launch_macos_rio(&script_file),
             _ => launch_macos_terminal_app(&script_file),
         };
 

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1414,11 +1414,9 @@ fn chat_tool_calls_to_response_output_items(
             ));
         }
     } else if let Some(function_call) = message.get("function_call") {
-        if let Some(item) = chat_legacy_function_call_to_response_item(
-            function_call,
-            reasoning,
-            tool_context,
-        ) {
+        if let Some(item) =
+            chat_legacy_function_call_to_response_item(function_call, reasoning, tool_context)
+        {
             output.push(item);
         }
     }

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -22,6 +22,7 @@ pub fn launch_terminal(
         "wezterm" => launch_wezterm(command, cwd),
         "kaku" => launch_kaku(command, cwd),
         "alacritty" => launch_alacritty(command, cwd),
+        "rio" => launch_rio(command, cwd),
         #[cfg(unix)]
         "warp" => launch_warp(command, cwd),
         "custom" => launch_custom(command, cwd, custom_config),
@@ -272,6 +273,50 @@ fn launch_alacritty(command: &str, cwd: Option<&str>) -> Result<(), String> {
     } else {
         Err("Failed to launch Alacritty.".to_string())
     }
+}
+
+fn launch_rio(command: &str, cwd: Option<&str>) -> Result<(), String> {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    // Rio's -e consumes all remaining args as the command, so we write the
+    // command into a temp script and have Rio invoke it directly.
+    let mut script_file = tempfile::Builder::new()
+        .prefix("cc_switch_rio_")
+        .suffix(".sh")
+        .permissions(std::fs::Permissions::from_mode(0o755))
+        .tempfile()
+        .map_err(|e| format!("Failed to create temporary script for Rio: {e}"))?;
+
+    writeln!(
+        &mut script_file,
+        r#"#!/usr/bin/env sh
+rm -- "$0"
+"#,
+    )
+    .map_err(|e| format!("Failed to write temp script for Rio: {e}"))?;
+
+    if let Some(dir) = cwd {
+        if !dir.trim().is_empty() {
+            writeln!(&mut script_file, "cd {}", shell_escape(dir))
+                .map_err(|e| format!("Failed to write temp script for Rio: {e}"))?;
+        }
+    }
+    writeln!(&mut script_file, "exec {command}")
+        .map_err(|e| format!("Failed to write temp script for Rio: {e}"))?;
+
+    // Important: drop the file handle so Rio can read it,
+    // and keep the temp file around (self-deletes via `rm -- "$0"` above).
+    let (_file, path) = script_file.keep().map_err(|e| format!("Failed to persist temp script for Rio: {e}"))?;
+    drop(_file);
+
+    Command::new("open")
+        .args(["-na", "Rio", "--args", "-e"])
+        .arg(&path)
+        .status()
+        .map_err(|e| format!("Failed to launch Rio: {e}"))?;
+
+    Ok(())
 }
 
 fn launch_custom(

--- a/src-tauri/src/session_manager/terminal/mod.rs
+++ b/src-tauri/src/session_manager/terminal/mod.rs
@@ -22,6 +22,7 @@ pub fn launch_terminal(
         "wezterm" => launch_wezterm(command, cwd),
         "kaku" => launch_kaku(command, cwd),
         "alacritty" => launch_alacritty(command, cwd),
+        #[cfg(target_os = "macos")]
         "rio" => launch_rio(command, cwd),
         #[cfg(unix)]
         "warp" => launch_warp(command, cwd),
@@ -275,6 +276,7 @@ fn launch_alacritty(command: &str, cwd: Option<&str>) -> Result<(), String> {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn launch_rio(command: &str, cwd: Option<&str>) -> Result<(), String> {
     use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
@@ -307,16 +309,22 @@ rm -- "$0"
 
     // Important: drop the file handle so Rio can read it,
     // and keep the temp file around (self-deletes via `rm -- "$0"` above).
-    let (_file, path) = script_file.keep().map_err(|e| format!("Failed to persist temp script for Rio: {e}"))?;
+    let (_file, path) = script_file
+        .keep()
+        .map_err(|e| format!("Failed to persist temp script for Rio: {e}"))?;
     drop(_file);
 
-    Command::new("open")
+    let status = Command::new("open")
         .args(["-na", "Rio", "--args", "-e"])
         .arg(&path)
         .status()
         .map_err(|e| format!("Failed to launch Rio: {e}"))?;
 
-    Ok(())
+    if status.success() {
+        Ok(())
+    } else {
+        Err("Failed to launch Rio.".to_string())
+    }
 }
 
 fn launch_custom(

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -469,7 +469,7 @@ pub struct AppSettings {
 
     // ===== 终端设置 =====
     /// 首选终端应用（可选，默认使用系统默认终端）
-    /// - macOS: "terminal" | "iterm2" | "warp" | "alacritty" | "kitty" | "ghostty" | "wezterm" | "kaku"
+    /// - macOS: "terminal" | "iterm2" | "warp" | "alacritty" | "kitty" | "ghostty" | "wezterm" | "kaku" | "rio"
     /// - Windows: "cmd" | "powershell" | "wt" (Windows Terminal)
     /// - Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/components/settings/TerminalSettings.tsx
+++ b/src/components/settings/TerminalSettings.tsx
@@ -18,6 +18,7 @@ const MACOS_TERMINALS = [
   { value: "wezterm", labelKey: "settings.terminal.options.macos.wezterm" },
   { value: "kaku", labelKey: "settings.terminal.options.macos.kaku" },
   { value: "warp", labelKey: "settings.terminal.options.macos.warp" },
+  { value: "rio", labelKey: "settings.terminal.options.macos.rio" },
 ] as const;
 
 const WINDOWS_TERMINALS = [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -730,7 +730,8 @@
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
           "kaku": "Kaku",
-          "warp": "Warp"
+          "warp": "Warp",
+          "rio": "Rio"
         },
         "windows": {
           "cmd": "Command Prompt",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -730,7 +730,8 @@
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
           "kaku": "Kaku",
-          "warp": "Warp"
+          "warp": "Warp",
+          "rio": "Rio"
         },
         "windows": {
           "cmd": "コマンドプロンプト",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -730,7 +730,8 @@
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
           "kaku": "Kaku",
-          "warp": "Warp"
+          "warp": "Warp",
+          "rio": "Rio"
         },
         "windows": {
           "cmd": "命令提示字元",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -730,7 +730,8 @@
           "ghostty": "Ghostty",
           "wezterm": "WezTerm",
           "kaku": "Kaku",
-          "warp": "Warp"
+          "warp": "Warp",
+          "rio": "Rio"
         },
         "windows": {
           "cmd": "命令提示符",

--- a/src/types.ts
+++ b/src/types.ts
@@ -410,7 +410,7 @@ export interface Settings {
 
   // ===== 终端设置 =====
   // 首选终端应用（可选，默认使用系统默认终端）
-  // macOS: "terminal" | "iterm2" | "warp" | "alacritty" | "kitty" | "ghostty" | "wezterm" | "kaku"
+  // macOS: "terminal" | "iterm2" | "warp" | "alacritty" | "kitty" | "ghostty" | "wezterm" | "kaku" | "rio"
   // Windows: "cmd" | "powershell" | "wt"
   // Linux: "gnome-terminal" | "konsole" | "xfce4-terminal" | "alacritty" | "kitty" | "ghostty"
   preferredTerminal?: string;


### PR DESCRIPTION
Related issue: #4440

Adds [Rio](https://raphamorim.io/rio/) ([GitHub](https://github.com/raphamorim/rio)), a GPU-accelerated terminal emulator, as a selectable option in the macOS Preferred Terminal dropdown.

## Changes

- `TerminalSettings.tsx`: add `"rio"` to the `MACOS_TERMINALS` dropdown array
- i18n (en/zh/zh-TW/ja): add `"rio": "Rio"` label to each locale
- `types.ts` + `settings.rs`: update valid-terminal doc comments
- `commands/misc.rs`: add `launch_macos_rio()` helper + match arms in both `launch_macos_terminal()` and `launch_terminal_running()`
- `session_manager/terminal/mod.rs`: add `launch_rio()` + match arm in `launch_terminal()`

## Design decision

Rio's `-e` / `--command` flag **consumes all remaining args as a single command string**, unlike Alacritty/WezTerm which accept a program name + separate args. This means the existing `launch_macos_open_app()` helper (which passes `-e sh -c "exec sh script\"`) does not work with Rio — the `sh -c` wrapper breaks because `-c` and the script path arrive as separate argv elements rather than one combined string.

Instead, we pass the script file **directly** via `-e /path/to/script`, letting it execute via its `#!/bin/sh` shebang. For the session resume path, we write a self-deleting temp script that `cd`s into the target directory before `exec`-ing the command.

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `pnpm test:unit` passes (338 tests)
- [x] `cargo fmt --check` passes (changed files only)
- [x] `cargo clippy` passes (zero warnings)
- [x] `cargo test` passes (1680 tests)
- [x] Manually tested: selecting Rio in Settings → Preferred Terminal launches Rio correctly for both provider-level and terminal button scenarios

---

Authored with Claude Code.