### PR TITLE
fix(codex): add use_responses_lite and remove model_messages in catalog entries

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -334,6 +334,17 @@ fn codex_catalog_model_entry(
     entry_obj.insert("availability_nux".to_string(), Value::Null);
     entry_obj.insert("upgrade".to_string(), Value::Null);
 
+    // Codex desktop app expects this field on every catalog entry; its absence
+    // causes the app to treat the entry as unknown and fall back to a generic
+    // "custom" model with a hardcoded 6-tier reasoning picker.
+    entry_obj.insert("use_responses_lite".to_string(), json!(false));
+
+    // model_messages carries GPT-5.5 personality/instruction templates that are
+    // irrelevant to third-party models. The built-in catalog entries for
+    // non-GPT models do not include this field; keeping it causes the desktop
+    // app to reject the entry during model-list construction.
+    entry_obj.remove("model_messages");
+
     entry
 }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2105,8 +2105,8 @@ base_url = "https://production.api/v1"
             Some(128_000)
         );
         assert!(
-            models[0].get("model_messages").is_some(),
-            "Codex requires model_messages in custom catalogs"
+            models[0].get("model_messages").is_none(),
+            "third-party catalog entries should not carry the gpt-5.5 agent template"
         );
         assert_eq!(
             models[0]
@@ -2115,9 +2115,9 @@ base_url = "https://production.api/v1"
             Some("gpt-5.5 base instructions")
         );
         assert_eq!(
-            models[0].get("model_messages"),
-            template.get("model_messages"),
-            "custom catalog entries should keep the gpt-5.5 agent template"
+            models[0].get("use_responses_lite"),
+            Some(&json!(false)),
+            "third-party catalog entries should declare use_responses_lite for desktop app compatibility"
         );
         assert_eq!(
             models[0].get("additional_speed_tiers"),


### PR DESCRIPTION
﻿## Problem

Fixes #4453

When CC Switch generates `~/.codex/cc-switch-model-catalog.json` for third-party Codex providers, the Codex **desktop app** (26.x) fails to list the configured models in its model picker. Instead, the model name shows as "custom" (自定义) and the picker degrades to a hardcoded 6-tier reasoning effort selector (极低/低/中/高/超高/最高), making it impossible to switch between configured models from the UI.

## Root Cause

The `codex_catalog_model_entry` function in `src-tauri/src/codex_config.rs` clones the bundled `gpt-5.5` template and overrides a handful of fields. Comparing the generated catalog entries against the Codex app's built-in `codex debug models --bundled` output reveals two field-level mismatches:

1. **Missing `use_responses_lite`**: Every built-in catalog entry includes `"use_responses_lite": false`. The cc-switch generated entries omit this field entirely (the static `gpt5_5_template.json` fallback does not contain it). Its absence causes the desktop app to treat the entry as unknown and fall back to a generic "custom" model.

2. **Stray `model_messages`**: The `gpt-5.5` template carries a `model_messages` field with personality/instruction templates. Built-in catalog entries for non-GPT models do **not** include this field. cc-switch inherits it from the template without removing it, which causes the desktop app to reject the entry during model-list construction.

## Fix

In `codex_catalog_model_entry`, after the existing field overrides:

- Insert `"use_responses_lite": false` to match the built-in catalog schema.
- Remove the `model_messages` field inherited from the GPT-5.5 template, since it is irrelevant to third-party models and not present in built-in non-GPT entries.

## Verification

Before the fix, `~/.codex/cc-switch-model-catalog.json` entries were missing `use_responses_lite` and included `model_messages`. After the fix, generated entries match the structural contract of built-in catalog entries (e.g. `gpt-5.2`), which also has empty `additional_speed_tiers` and no `model_messages` but does include `use_responses_lite: false`.

Built-in model field comparison (via `codex debug models --bundled`):

| Field | Built-in `gpt-5.2` | cc-switch (before) | cc-switch (after) |
|---|---|---|---|
| `use_responses_lite` | `false` | **missing** | `false` |
| `model_messages` | absent | **present** | absent |
| `additional_speed_tiers` | `[]` | `[]` | `[]` (unchanged) |
| `supported_reasoning_levels` | 4 levels | 4 levels | 4 levels (unchanged) |

## Notes

- This is a minimal, surgical fix targeting the two fields confirmed to differ from the built-in schema.
- The 6-tier reasoning picker shown in the desktop app is the app's hardcoded fallback for unrecognized `custom` provider entries — it is not driven by `supported_reasoning_levels` in the catalog (all built-in models use 4 tiers).