### PR TITLE
Fix select dropdown scrolling for long provider lists

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1414,11 +1414,9 @@ fn chat_tool_calls_to_response_output_items(
             ));
         }
     } else if let Some(function_call) = message.get("function_call") {
-        if let Some(item) = chat_legacy_function_call_to_response_item(
-            function_call,
-            reasoning,
-            tool_context,
-        ) {
+        if let Some(item) =
+            chat_legacy_function_call_to_response_item(function_call, reasoning, tool_context)
+        {
             output.push(item);
         }
     }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-[100] min-w-[8rem] overflow-hidden rounded-md border border-border-default bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-[100] max-h-[min(24rem,var(--radix-select-content-available-height))] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-border-default bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       position={position}


### PR DESCRIPTION
## Problem
When many providers are configured, the failover queue provider selector can extend beyond the visible app window. Options rendered below the screen edge are not reachable, so users cannot select some providers from the dropdown.

## Summary
- Constrain shared Select dropdown content to the available viewport height.
- Allow long option lists to scroll vertically while keeping horizontal overflow hidden.
- Fix long provider lists in the failover queue selector without changing provider routing behavior.

## Root cause
The shared `SelectContent` wrapper used `overflow-hidden` without a max height, so long option lists could grow past the app window and become difficult or impossible to scroll to.

## Tests
- `pnpm typecheck`
- `pnpm build:renderer`
- `./node_modules/.bin/vitest.cmd run tests/integration/App.test.tsx --testTimeout=15000`