### PR TITLE
feat(providers): add Suanni API presets

### DIFF
--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -134,6 +134,35 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     icon: "pateway",
   },
   {
+    name: "狻猊api",
+    websiteUrl: "https://suanni2028.com",
+    apiKeyUrl: "https://suanni2028.com/dashboard",
+    category: "third_party",
+    auth: generateThirdPartyAuth(""),
+    config: `model_provider = "custom"
+model = "gpt-5.5"
+review_model = "gpt-5.5"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.custom]
+name = "狻猊api"
+base_url = "https://api.suanni2028.com/v1"
+wire_api = "responses"
+requires_openai_auth = true`,
+    endpointCandidates: ["https://api.suanni2028.com/v1"],
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      {
+        model: "gpt-5.5",
+        displayName: "GPT-5.5",
+        contextWindow: 400000,
+      },
+    ]),
+    icon: "lioncc",
+    iconColor: "#D99A20",
+  },
+  {
     name: "火山Agentplan",
     websiteUrl:
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -310,6 +310,33 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     },
   },
   {
+    name: "狻猊api",
+    websiteUrl: "https://suanni2028.com",
+    apiKeyUrl: "https://suanni2028.com/dashboard",
+    settingsConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "狻猊api",
+      options: {
+        baseURL: "https://api.suanni2028.com/v1",
+        apiKey: "",
+        setCacheKey: true,
+      },
+      models: {
+        "gpt-5.5": { name: "GPT-5.5" },
+      },
+    },
+    category: "third_party",
+    icon: "lioncc",
+    iconColor: "#D99A20",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "",
+        editorValue: "",
+      },
+    },
+  },
+  {
     name: "火山Agentplan",
     websiteUrl:
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",


### PR DESCRIPTION
## Summary
- add 狻猊api as a Codex third-party provider preset
- add 狻猊api as an OpenCode openai-compatible provider preset
- use the existing lioncc icon for the provider mark

## Verification
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/prettier --check "src/**/*.{js,jsx,ts,tsx,css,json}"
- git diff --check