### PR TITLE
Fix custom usage date picker full-day selection

### DIFF
--- a/src/components/usage/UsageDateRangePicker.tsx
+++ b/src/components/usage/UsageDateRangePicker.tsx
@@ -35,6 +35,10 @@ function startOfDay(d: Date): Date {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate());
 }
 
+function endOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59);
+}
+
 function isSameDay(a: Date, b: Date): boolean {
   return (
     a.getFullYear() === b.getFullYear() &&
@@ -61,12 +65,15 @@ function fmtTime(ts: number): string {
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
-function parseDateInput(ts: number, value: string): number {
+function getDayBoundaryTs(day: Date, field: DraftField): number {
+  return toTs(field === "start" ? startOfDay(day) : endOfDay(day));
+}
+
+function parseDateInput(ts: number, value: string, field: DraftField): number {
   const [y, m, d] = value.split("-").map(Number);
   if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d))
     return ts;
-  const base = fromTs(ts);
-  return toTs(new Date(y, m - 1, d, base.getHours(), base.getMinutes()));
+  return getDayBoundaryTs(new Date(y, m - 1, d), field);
 }
 
 function parseTimeInput(ts: number, value: string): number {
@@ -121,6 +128,9 @@ export function UsageDateRangePicker({
   const [draftLiveEnd, setDraftLiveEnd] = useState(
     selection.preset === "custom" ? (selection.liveEndTime ?? false) : false,
   );
+  const [hasEditedCustomDraft, setHasEditedCustomDraft] = useState(
+    selection.preset === "custom",
+  );
   const [displayMonth, setDisplayMonth] = useState(
     () =>
       new Date(
@@ -143,6 +153,7 @@ export function UsageDateRangePicker({
     setDraftLiveEnd(
       selection.preset === "custom" ? (selection.liveEndTime ?? false) : false,
     );
+    setHasEditedCustomDraft(selection.preset === "custom");
     setDisplayMonth(
       new Date(
         fromTs(r.startDate).getFullYear(),
@@ -193,28 +204,30 @@ export function UsageDateRangePicker({
       return;
     }
 
-    const nextTs = setDateKeepTime(
-      activeField === "start" ? draftStart : draftEnd,
-      day,
-    );
+    const nextTs = getDayBoundaryTs(day, activeField);
 
     if (activeField === "start") {
       setDraftStart(nextTs);
-      // Auto-swap if start > end
-      if (nextTs > draftEnd) {
-        setDraftEnd(nextTs);
+      const shouldUseSingleDay =
+        !hasEditedCustomDraft ||
+        isSameDay(startDay, endDay) ||
+        nextTs > draftEnd;
+      if (shouldUseSingleDay) {
+        setDraftEnd(getDayBoundaryTs(day, "end"));
       }
       // Auto-advance to end field
       setActiveField("end");
     } else {
       // If picked end < start, treat as new start and auto-advance
       if (nextTs < draftStart) {
-        setDraftStart(nextTs);
+        setDraftStart(getDayBoundaryTs(day, "start"));
+        setDraftEnd(getDayBoundaryTs(day, "end"));
         setActiveField("end");
       } else {
         setDraftEnd(nextTs);
       }
     }
+    setHasEditedCustomDraft(true);
 
     // Navigate calendar if the day is outside the displayed month
     if (
@@ -249,11 +262,35 @@ export function UsageDateRangePicker({
     const isActive = activeField === field;
     const isEndLive = field === "end" && draftLiveEnd;
     const ts = field === "start" ? draftStart : draftEnd;
-    const setTs = field === "start" ? setDraftStart : setDraftEnd;
     const label =
       field === "start"
         ? t("usage.startTime", "开始时间")
         : t("usage.endTime", "结束时间");
+
+    const handleDateInputChange = (value: string) => {
+      const next = parseDateInput(ts, value, field);
+      const nextDay = fromTs(next);
+
+      if (field === "start") {
+        setDraftStart(next);
+        const shouldUseSingleDay =
+          !hasEditedCustomDraft ||
+          isSameDay(startDay, endDay) ||
+          next > draftEnd;
+        if (shouldUseSingleDay) {
+          setDraftEnd(getDayBoundaryTs(nextDay, "end"));
+        }
+      } else if (next < draftStart) {
+        setDraftStart(getDayBoundaryTs(nextDay, "start"));
+        setDraftEnd(next);
+      } else {
+        setDraftEnd(next);
+      }
+
+      setHasEditedCustomDraft(true);
+      setDisplayMonth(new Date(nextDay.getFullYear(), nextDay.getMonth(), 1));
+      setError(null);
+    };
 
     return (
       <div
@@ -282,11 +319,7 @@ export function UsageDateRangePicker({
             value={fmtDate(ts)}
             onChange={(e) => {
               if (isEndLive) return;
-              const next = parseDateInput(ts, e.target.value);
-              setTs(next);
-              const d = fromTs(next);
-              setDisplayMonth(new Date(d.getFullYear(), d.getMonth(), 1));
-              setError(null);
+              handleDateInputChange(e.target.value);
             }}
             onFocus={() => {
               if (!isEndLive) setActiveField(field);
@@ -303,7 +336,11 @@ export function UsageDateRangePicker({
             value={fmtTime(ts)}
             onChange={(e) => {
               if (isEndLive) return;
-              setTs(parseTimeInput(ts, e.target.value));
+              if (field === "start") {
+                setDraftStart(parseTimeInput(ts, e.target.value));
+              } else {
+                setDraftEnd(parseTimeInput(ts, e.target.value));
+              }
               setError(null);
             }}
             onFocus={() => {

--- a/tests/components/UsageDateRangePicker.test.tsx
+++ b/tests/components/UsageDateRangePicker.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UsageDateRangePicker } from "@/components/usage/UsageDateRangePicker";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      options?:
+        | string
+        | {
+            defaultValue?: string;
+          },
+    ) =>
+      typeof options === "string" ? options : (options?.defaultValue ?? key),
+    i18n: {
+      resolvedLanguage: "en",
+      language: "en",
+    },
+  }),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <>{children}</>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+function localTs(
+  year: number,
+  monthIndex: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+) {
+  return Math.floor(
+    new Date(year, monthIndex, day, hour, minute, second).getTime() / 1000,
+  );
+}
+
+describe("UsageDateRangePicker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 22, 11, 23, 45));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the full local day when a single calendar date is selected", () => {
+    const onApply = vi.fn();
+
+    render(
+      <UsageDateRangePicker
+        selection={{ preset: "1d" }}
+        triggerLabel="1d"
+        onApply={onApply}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "6/1/2026" }));
+    fireEvent.click(screen.getByRole("button", { name: "common.confirm" }));
+
+    expect(onApply).toHaveBeenCalledWith({
+      preset: "custom",
+      customStartDate: localTs(2026, 5, 1, 0, 0, 0),
+      customEndDate: localTs(2026, 5, 1, 23, 59, 59),
+      liveEndTime: false,
+    });
+  });
+
+  it("defaults an edited end date to the end of that local day", () => {
+    const onApply = vi.fn();
+    const start = localTs(2026, 5, 1, 0, 0, 0);
+
+    const { container } = render(
+      <UsageDateRangePicker
+        selection={{
+          preset: "custom",
+          customStartDate: start,
+          customEndDate: localTs(2026, 5, 1, 23, 59, 59),
+        }}
+        triggerLabel="Custom"
+        onApply={onApply}
+      />,
+    );
+
+    const dateInputs =
+      container.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    fireEvent.change(dateInputs[1], { target: { value: "2026-06-03" } });
+    fireEvent.click(screen.getByRole("button", { name: "common.confirm" }));
+
+    expect(onApply).toHaveBeenCalledWith({
+      preset: "custom",
+      customStartDate: start,
+      customEndDate: localTs(2026, 5, 3, 23, 59, 59),
+      liveEndTime: false,
+    });
+  });
+
+  it("preserves a drafted end date when refining the start date from a preset", () => {
+    const onApply = vi.fn();
+
+    const { container } = render(
+      <UsageDateRangePicker
+        selection={{ preset: "1d" }}
+        triggerLabel="1d"
+        onApply={onApply}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "6/1/2026" }));
+    fireEvent.click(screen.getByRole("button", { name: "6/3/2026" }));
+
+    const dateInputs =
+      container.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    fireEvent.focus(dateInputs[0]);
+    fireEvent.click(screen.getByRole("button", { name: "6/2/2026" }));
+    fireEvent.click(screen.getByRole("button", { name: "common.confirm" }));
+
+    expect(onApply).toHaveBeenCalledWith({
+      preset: "custom",
+      customStartDate: localTs(2026, 5, 2, 0, 0, 0),
+      customEndDate: localTs(2026, 5, 3, 23, 59, 59),
+      liveEndTime: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Default calendar/date-field selections in the usage date range picker to local day boundaries
- Selecting a single calendar date now applies 00:00:00 through 23:59:59 for that day
- Add regression coverage for single-day and edited end-date behavior

## Tests
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/prettier --check src/components/usage/UsageDateRangePicker.tsx tests/components/UsageDateRangePicker.test.tsx
- ./node_modules/.bin/vitest run tests/components/UsageDateRangePicker.test.tsx tests/components/RequestLogTable.test.tsx tests/components/usageFormat.test.tsx tests/utils/usageDisplay.test.ts tests/lib/keepLastGoodUsage.test.ts
- ./node_modules/.bin/vitest run tests/integration/App.test.tsx
- ./node_modules/.bin/vitest run --fileParallelism=false