### PR TITLE
Avoid duplicate Claude calls from background session sync

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1043,29 +1043,44 @@ pub fn run() {
                         }
                     }
 
+                    fn should_skip_automatic_session_sync(phase: &str) -> bool {
+                        if crate::services::session_usage::is_claude_session_owner_running() {
+                            log::debug!(
+                                "[SESSION-SYNC] skipping {phase} automatic session usage sync while Claude is running"
+                            );
+                            return true;
+                        }
+
+                        false
+                    }
+
                     let db = &db_for_session_sync;
+                    let mut usage_cost_backfill_done = false;
 
                     // 首次同步
-                    run_step(
-                        "Usage cost startup backfill",
-                        db.backfill_missing_usage_costs(),
-                    );
-                    run_step(
-                        "Session usage initial sync",
-                        crate::services::session_usage::sync_claude_session_logs(db),
-                    );
-                    run_step(
-                        "Codex usage initial sync",
-                        crate::services::session_usage_codex::sync_codex_usage(db),
-                    );
-                    run_step(
-                        "Gemini usage initial sync",
-                        crate::services::session_usage_gemini::sync_gemini_usage(db),
-                    );
-                    run_step(
-                        "OpenCode usage initial sync",
-                        crate::services::session_usage_opencode::sync_opencode_usage(db),
-                    );
+                    if !should_skip_automatic_session_sync("initial") {
+                        usage_cost_backfill_done = true;
+                        run_step(
+                            "Usage cost startup backfill",
+                            db.backfill_missing_usage_costs(),
+                        );
+                        run_step(
+                            "Session usage initial sync",
+                            crate::services::session_usage::sync_claude_session_logs_auto(db),
+                        );
+                        run_step(
+                            "Codex usage initial sync",
+                            crate::services::session_usage_codex::sync_codex_usage_auto(db),
+                        );
+                        run_step(
+                            "Gemini usage initial sync",
+                            crate::services::session_usage_gemini::sync_gemini_usage_auto(db),
+                        );
+                        run_step(
+                            "OpenCode usage initial sync",
+                            crate::services::session_usage_opencode::sync_opencode_usage_auto(db),
+                        );
+                    }
 
                     // 定期同步
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
@@ -1074,21 +1089,33 @@ pub fn run() {
                     interval.tick().await; // skip immediate first tick
                     loop {
                         interval.tick().await;
+                        if should_skip_automatic_session_sync("periodic") {
+                            continue;
+                        }
+
+                        if !usage_cost_backfill_done {
+                            usage_cost_backfill_done = true;
+                            run_step(
+                                "Usage cost startup backfill",
+                                db.backfill_missing_usage_costs(),
+                            );
+                        }
+
                         run_step(
                             "Session usage periodic sync",
-                            crate::services::session_usage::sync_claude_session_logs(db),
+                            crate::services::session_usage::sync_claude_session_logs_auto(db),
                         );
                         run_step(
                             "Codex usage periodic sync",
-                            crate::services::session_usage_codex::sync_codex_usage(db),
+                            crate::services::session_usage_codex::sync_codex_usage_auto(db),
                         );
                         run_step(
                             "Gemini usage periodic sync",
-                            crate::services::session_usage_gemini::sync_gemini_usage(db),
+                            crate::services::session_usage_gemini::sync_gemini_usage_auto(db),
                         );
                         run_step(
                             "OpenCode usage periodic sync",
-                            crate::services::session_usage_opencode::sync_opencode_usage(db),
+                            crate::services::session_usage_opencode::sync_opencode_usage_auto(db),
                         );
                     }
                 });

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -22,7 +22,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::process::Command;
+use std::time::{Duration, SystemTime};
 
 /// 同步结果
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,6 +44,9 @@ pub struct DataSourceSummary {
     pub total_cost_usd: String,
 }
 
+/// Background sync should only import transcripts that have stopped changing.
+pub(crate) const DEFAULT_AUTO_SYNC_MIN_FILE_AGE: Duration = Duration::from_secs(300);
+
 /// 从 JSONL 中解析出的 assistant 消息使用数据
 #[derive(Debug)]
 struct ParsedAssistantUsage {
@@ -59,6 +63,29 @@ struct ParsedAssistantUsage {
 
 /// 同步 Claude Code 会话日志到使用统计数据库
 pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_claude_session_logs_with_min_file_age(db, None)
+}
+
+pub fn sync_claude_session_logs_auto(db: &Database) -> Result<SessionSyncResult, AppError> {
+    if is_claude_session_owner_running() {
+        log::debug!(
+            "[SESSION-SYNC] skipping automatic Claude session sync while Claude is running"
+        );
+        return Ok(SessionSyncResult {
+            imported: 0,
+            skipped: 0,
+            files_scanned: 0,
+            errors: vec![],
+        });
+    }
+
+    sync_claude_session_logs_with_min_file_age(db, Some(DEFAULT_AUTO_SYNC_MIN_FILE_AGE))
+}
+
+fn sync_claude_session_logs_with_min_file_age(
+    db: &Database,
+    min_file_age: Option<Duration>,
+) -> Result<SessionSyncResult, AppError> {
     let projects_dir = get_claude_config_dir().join("projects");
     if !projects_dir.exists() {
         return Ok(SessionSyncResult {
@@ -82,7 +109,7 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
     for file_path in &jsonl_files {
         result.files_scanned += 1;
 
-        match sync_single_file(db, file_path) {
+        match sync_single_file(db, file_path, min_file_age) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -179,13 +206,27 @@ fn push_jsonl_children(dir: &Path, files: &mut Vec<PathBuf>) {
 }
 
 /// 同步单个 JSONL 文件，返回 (imported, skipped)
-fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+fn sync_single_file(
+    db: &Database,
+    file_path: &Path,
+    min_file_age: Option<Duration>,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
     // 获取文件元数据
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
     let file_modified = metadata_modified_nanos(&metadata);
+
+    if let Some(min_age) = min_file_age {
+        if is_recently_modified(&metadata, min_age) {
+            log::debug!(
+                "[SESSION-SYNC] skipping active Claude transcript: {}",
+                file_path.display()
+            );
+            return Ok((0, 0));
+        }
+    }
 
     // 检查同步状态
     let (last_modified, last_offset) = get_sync_state(db, &file_path_str)?;
@@ -382,6 +423,95 @@ pub(crate) fn metadata_modified_nanos(metadata: &fs::Metadata) -> i64 {
         .unwrap_or(0)
 }
 
+/// Returns true when a file is too new for conservative background sync.
+pub(crate) fn is_recently_modified(metadata: &fs::Metadata, min_age: Duration) -> bool {
+    match metadata.modified() {
+        Ok(modified) => match SystemTime::now().duration_since(modified) {
+            Ok(age) => age < min_age,
+            Err(_) => true,
+        },
+        Err(_) => true,
+    }
+}
+
+pub(crate) fn is_claude_session_owner_running() -> bool {
+    process_snapshot()
+        .as_deref()
+        .map(contains_claude_process_marker)
+        .unwrap_or(false)
+}
+
+fn contains_claude_process_marker(snapshot: &str) -> bool {
+    snapshot.lines().any(process_line_matches_claude_owner)
+}
+
+fn process_line_matches_claude_owner(line: &str) -> bool {
+    let normalized = line.replace('\\', "/").to_ascii_lowercase();
+
+    if normalized.contains("claude desktop")
+        || normalized.contains("anthropicclaude")
+        || normalized.contains("@anthropic-ai/claude-code")
+        || normalized.contains("anthropic-ai/claude-code")
+        || normalized.contains("claude-code")
+    {
+        return true;
+    }
+
+    normalized
+        .split(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == ',' || c == ';')
+        .any(|token| {
+            token == "claude"
+                || token == "claude.exe"
+                || token.ends_with("/claude")
+                || token.ends_with("/claude.exe")
+        })
+}
+
+#[cfg(target_os = "windows")]
+fn process_snapshot() -> Option<String> {
+    command_output(
+        "powershell.exe",
+        &[
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "Get-CimInstance Win32_Process | Select-Object -ExpandProperty CommandLine",
+        ],
+    )
+    .or_else(|| command_output("tasklist.exe", &["/fo", "csv", "/nh"]))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn process_snapshot() -> Option<String> {
+    command_output("ps", &["-axo", "comm=,args="])
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let mut command = Command::new(program);
+    command.args(args);
+    hide_command_window(&mut command);
+
+    let output = command.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    Some(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn hide_command_window(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    command.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(target_os = "windows"))]
+fn hide_command_window(_command: &mut Command) {}
+
 /// 更新 session_log_sync 表中某条目的同步进度。
 ///
 /// Shared by all session_usage_* parsers.
@@ -564,6 +694,26 @@ pub fn get_data_source_breakdown(db: &Database) -> Result<Vec<DataSourceSummary>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn claude_process_marker_detects_desktop_and_cli() {
+        assert!(contains_claude_process_marker(
+            r#"C:\Users\alice\AppData\Local\AnthropicClaude\Claude.exe" --type=renderer"#
+        ));
+        assert!(contains_claude_process_marker(
+            r#"node.exe C:\Users\alice\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\cli.js"#
+        ));
+        assert!(contains_claude_process_marker(
+            "/usr/local/bin/claude --dangerously-skip-permissions"
+        ));
+    }
+
+    #[test]
+    fn claude_process_marker_ignores_unrelated_processes() {
+        assert!(!contains_claude_process_marker(
+            "cc-switch.exe\nnode.exe C:\\projects\\other-tool\\index.js"
+        ));
+    }
 
     #[test]
     fn test_parse_usage_from_jsonl_line() {
@@ -771,7 +921,7 @@ mod tests {
         let empty = r#"{"type":"assistant","message":{"id":"msg_empty","model":"claude-opus-4-8","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-06-07T13:01:24Z","sessionId":"session-wf"}"#;
         fs::write(&file, format!("{billable}\n{empty}\n")).unwrap();
 
-        let (imported, _skipped) = sync_single_file(&db, &file)?;
+        let (imported, _skipped) = sync_single_file(&db, &file, None)?;
         assert_eq!(
             imported, 1,
             "有 cache 成本但无 stop_reason 的 message 必须被导入"

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -19,14 +19,15 @@ use crate::error::AppError;
 use crate::proxy::usage::calculator::{CostCalculator, ModelPricing};
 use crate::proxy::usage::parser::TokenUsage;
 use crate::services::session_usage::{
-    get_sync_state, metadata_modified_nanos, update_sync_state, SessionSyncResult,
+    get_sync_state, is_recently_modified, metadata_modified_nanos, update_sync_state,
+    SessionSyncResult, DEFAULT_AUTO_SYNC_MIN_FILE_AGE,
 };
 use crate::services::usage_stats::{find_model_pricing, should_skip_session_insert, DedupKey};
 use rust_decimal::Decimal;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 /// 累计 token 用量（跟踪 total_token_usage 字段）
 #[derive(Debug, Clone, Default)]
@@ -144,6 +145,17 @@ fn parse_cumulative_tokens(total_usage: &serde_json::Value) -> Option<Cumulative
 
 /// 同步 Codex 使用数据（从 JSONL 会话日志）
 pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_codex_usage_with_min_file_age(db, None)
+}
+
+pub fn sync_codex_usage_auto(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_codex_usage_with_min_file_age(db, Some(DEFAULT_AUTO_SYNC_MIN_FILE_AGE))
+}
+
+fn sync_codex_usage_with_min_file_age(
+    db: &Database,
+    min_file_age: Option<Duration>,
+) -> Result<SessionSyncResult, AppError> {
     let codex_dir = get_codex_config_dir();
 
     let files = collect_codex_session_files(&codex_dir);
@@ -160,7 +172,7 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     }
 
     for file_path in &files {
-        match sync_single_codex_file(db, file_path) {
+        match sync_single_codex_file(db, file_path, min_file_age) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -229,13 +241,27 @@ fn collect_jsonl_recursive(dir: &Path, files: &mut Vec<PathBuf>, depth: u32, max
 }
 
 /// 同步单个 Codex JSONL 文件，返回 (imported, skipped)
-fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+fn sync_single_codex_file(
+    db: &Database,
+    file_path: &Path,
+    min_file_age: Option<Duration>,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
     // 获取文件元数据
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
     let file_modified = metadata_modified_nanos(&metadata);
+
+    if let Some(min_age) = min_file_age {
+        if is_recently_modified(&metadata, min_age) {
+            log::debug!(
+                "[CODEX-SYNC] skipping active Codex transcript: {}",
+                file_path.display()
+            );
+            return Ok((0, 0));
+        }
+    }
 
     // 检查同步状态
     let (last_modified, last_offset) = get_sync_state(db, &file_path_str)?;

--- a/src-tauri/src/services/session_usage_gemini.rs
+++ b/src-tauri/src/services/session_usage_gemini.rs
@@ -19,13 +19,14 @@ use crate::gemini_config::get_gemini_dir;
 use crate::proxy::usage::calculator::{CostCalculator, ModelPricing};
 use crate::proxy::usage::parser::TokenUsage;
 use crate::services::session_usage::{
-    get_sync_state, metadata_modified_nanos, update_sync_state, SessionSyncResult,
+    get_sync_state, is_recently_modified, metadata_modified_nanos, update_sync_state,
+    SessionSyncResult, DEFAULT_AUTO_SYNC_MIN_FILE_AGE,
 };
 use crate::services::usage_stats::{find_model_pricing, should_skip_session_insert, DedupKey};
 use rust_decimal::Decimal;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 /// 从 Gemini message 中提取的 token 数据
 #[derive(Debug)]
@@ -38,6 +39,17 @@ struct GeminiTokens {
 
 /// 同步 Gemini 使用数据（从 JSON 会话日志）
 pub fn sync_gemini_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_gemini_usage_with_min_file_age(db, None)
+}
+
+pub fn sync_gemini_usage_auto(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_gemini_usage_with_min_file_age(db, Some(DEFAULT_AUTO_SYNC_MIN_FILE_AGE))
+}
+
+fn sync_gemini_usage_with_min_file_age(
+    db: &Database,
+    min_file_age: Option<Duration>,
+) -> Result<SessionSyncResult, AppError> {
     let gemini_dir = get_gemini_dir();
 
     let files = collect_gemini_session_files(&gemini_dir);
@@ -54,7 +66,7 @@ pub fn sync_gemini_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     }
 
     for file_path in &files {
-        match sync_single_gemini_file(db, file_path) {
+        match sync_single_gemini_file(db, file_path, min_file_age) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -122,13 +134,27 @@ fn collect_gemini_session_files(gemini_dir: &Path) -> Vec<PathBuf> {
 }
 
 /// 同步单个 Gemini 会话 JSON 文件，返回 (imported, skipped)
-fn sync_single_gemini_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+fn sync_single_gemini_file(
+    db: &Database,
+    file_path: &Path,
+    min_file_age: Option<Duration>,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
     // 获取文件元数据
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
     let file_modified = metadata_modified_nanos(&metadata);
+
+    if let Some(min_age) = min_file_age {
+        if is_recently_modified(&metadata, min_age) {
+            log::debug!(
+                "[GEMINI-SYNC] skipping active Gemini transcript: {}",
+                file_path.display()
+            );
+            return Ok((0, 0));
+        }
+    }
 
     // 检查同步状态
     let (last_modified, _last_offset) = get_sync_state(db, &file_path_str)?;

--- a/src-tauri/src/services/session_usage_opencode.rs
+++ b/src-tauri/src/services/session_usage_opencode.rs
@@ -17,12 +17,13 @@ use crate::opencode_config::get_opencode_db_path;
 use crate::proxy::usage::calculator::CostCalculator;
 use crate::proxy::usage::parser::TokenUsage;
 use crate::services::session_usage::{
-    get_sync_state, metadata_modified_nanos, update_sync_state, SessionSyncResult,
+    get_sync_state, is_recently_modified, metadata_modified_nanos, update_sync_state,
+    SessionSyncResult, DEFAULT_AUTO_SYNC_MIN_FILE_AGE,
 };
 use crate::services::usage_stats::{find_model_pricing, should_skip_session_insert, DedupKey};
 use rust_decimal::Decimal;
 use std::fs;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 /// 从 opencode message.data JSON 中提取的 token 和费用数据
 struct OpenCodeMessageData {
@@ -43,6 +44,17 @@ struct OpenCodeMessageQueryResult {
 
 /// 同步 OpenCode 使用数据
 pub fn sync_opencode_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_opencode_usage_with_min_file_age(db, None)
+}
+
+pub fn sync_opencode_usage_auto(db: &Database) -> Result<SessionSyncResult, AppError> {
+    sync_opencode_usage_with_min_file_age(db, Some(DEFAULT_AUTO_SYNC_MIN_FILE_AGE))
+}
+
+fn sync_opencode_usage_with_min_file_age(
+    db: &Database,
+    min_file_age: Option<Duration>,
+) -> Result<SessionSyncResult, AppError> {
     let db_path = get_opencode_db_path();
 
     if !db_path.exists() {
@@ -63,10 +75,29 @@ pub fn sync_opencode_usage(db: &Database) -> Result<SessionSyncResult, AppError>
     let metadata = fs::metadata(&db_path)
         .map_err(|e| AppError::Config(format!("无法读取 opencode.db 元数据: {e}")))?;
     let mut file_modified = metadata_modified_nanos(&metadata);
+    let mut file_is_recent = min_file_age
+        .map(|min_age| is_recently_modified(&metadata, min_age))
+        .unwrap_or(false);
 
     let wal_path = db_path.with_extension("db-wal");
     if let Ok(wal_meta) = fs::metadata(&wal_path) {
         file_modified = file_modified.max(metadata_modified_nanos(&wal_meta));
+        if let Some(min_age) = min_file_age {
+            file_is_recent |= is_recently_modified(&wal_meta, min_age);
+        }
+    }
+
+    if file_is_recent {
+        log::debug!(
+            "[OPENCODE-SYNC] skipping active OpenCode database: {}",
+            db_path.display()
+        );
+        return Ok(SessionSyncResult {
+            imported: 0,
+            skipped: 0,
+            files_scanned: 1,
+            errors: vec![],
+        });
     }
 
     let (last_modified, _last_offset) = get_sync_state(db, &db_path_str)?;


### PR DESCRIPTION
## Summary 

This PR makes automatic Claude session usage sync more conservative.

Previously, the background session usage worker scanned `~/.claude/projects/**/*.jsonl` on startup and every 60 seconds. These transcript files can still be active runtime session state while Claude Desktop / Claude Code is running.

In that state, reading them from a background worker can interfere with Claude Desktop Code session restore / fork / replay behavior. In local testing, this manifested as a single Claude Desktop Code message causing multiple upstream API calls when CC Switch was running.

## Changes

- Add a separate automatic sync path for session usage.
- Skip automatic Claude transcript sync while Claude / Claude Desktop / Claude Code processes are running.
- Keep manual session usage sync unchanged.
- For automatic sync of session files, skip recently modified files as an additional guard.
- Hide Windows process snapshot commands to avoid flashing console windows.

## Behavior

- Claude usage stats may be delayed while Claude is open.
- Once Claude exits, automatic sync can import stable transcript files.
- Manual sync still performs a full import when explicitly requested by the user.

## Why

Claude transcript files are not purely historical logs while Claude is running. Treating them as live-readable log files from a background task can race with Desktop Code's own session lifecycle.

This PR avoids touching active Claude session transcripts from automatic background sync while preserving usage statistics.

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

Before
<img width="1154" height="619" alt="image" src="https://github.com/user-attachments/assets/c550732a-f2e8-4439-b911-139ce9add631" />