### PR TITLE
fix(subscription): codex official Keychain fallback + OAuth path routing

### DIFF
--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -49,7 +49,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 11;
+pub(crate) const SCHEMA_VERSION: i32 = 12;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -444,6 +444,13 @@ impl Database {
                         Self::migrate_v10_to_v11(conn)?;
                         Self::set_user_version(conn, 11)?;
                     }
+                    11 => {
+                        log::info!(
+                            "迁移数据库从 v11 到 v12（补齐 codex 官方供应商的 providerType）"
+                        );
+                        Self::migrate_v11_to_v12(conn)?;
+                        Self::set_user_version(conn, 12)?;
+                    }
                     _ => {
                         return Err(AppError::Database(format!(
                             "未知的数据库版本 {version}，无法迁移到 {SCHEMA_VERSION}"
@@ -1267,6 +1274,77 @@ impl Database {
         log::info!(
             "v10 -> v11 迁移完成：usage_daily_rollups 已保留 request_model/pricing_model 维度"
         );
+        Ok(())
+    }
+
+    /// v11 -> v12：补齐 codex 官方供应商的 `providerType: "codex_oauth"`
+    ///
+    /// 旧版本（v11 前）通过 codex 预设创建的 "OpenAI Official" 供应商缺少
+    /// `providerType`，导致 ProviderCard 走 CLI 凭据路径（SubscriptionQuotaFooter）
+    /// 而非 OAuth 路径（CodexOauthQuotaFooter），在 Keychain 条目过期或缺失时
+    /// 显示"会话已过期"且无法消除 (#2157)。
+    ///
+    /// 迁移仅对 `app_type = 'codex'`、`category = 'official'` 且 `providerType`
+    /// 缺失的行打补丁，不触碰 authBinding（用户可稍后在设置中绑定 ChatGPT 账户）。
+    fn migrate_v11_to_v12(conn: &Connection) -> Result<(), AppError> {
+        if !Self::table_exists(conn, "providers")? {
+            log::info!("v11 -> v12：providers 表不存在，跳过");
+            return Ok(());
+        }
+
+        // category 列在 v0→v1 添加；测试从 v4 直接迁移时可能不存在，此时回退到全表扫描
+        let has_category_col = Self::has_column(conn, "providers", "category").unwrap_or(false);
+
+        let mut stmt = if has_category_col {
+            conn.prepare(
+                "SELECT id, meta FROM providers WHERE app_type = 'codex' AND category = 'official'",
+            )
+        } else {
+            conn.prepare("SELECT id, meta FROM providers WHERE app_type = 'codex'")
+        }
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let mut updates = Vec::new();
+        for row in rows {
+            let (id, meta_str) = row.map_err(|e| AppError::Database(e.to_string()))?;
+
+            let Ok(mut meta) = serde_json::from_str::<serde_json::Value>(&meta_str) else {
+                continue;
+            };
+
+            // 仅补齐缺失的 providerType
+            if meta.get("providerType").is_some() {
+                continue;
+            }
+
+            // 当 category 列不存在时（测试从 v4 直迁），回退到 meta.category 检查
+            if !has_category_col
+                && meta.get("category").and_then(|v| v.as_str()) != Some("official")
+            {
+                continue;
+            }
+
+            meta["providerType"] = serde_json::json!("codex_oauth");
+            let new_meta =
+                serde_json::to_string(&meta).map_err(|e| AppError::Database(e.to_string()))?;
+            updates.push((id, new_meta));
+        }
+
+        for (id, new_meta) in updates {
+            conn.execute(
+                "UPDATE providers SET meta = ?1 WHERE id = ?2 AND app_type = 'codex'",
+                rusqlite::params![new_meta, id],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+
+        log::info!("v11 -> v12 迁移完成：已补齐 codex 官方供应商的 providerType");
         Ok(())
     }
 

--- a/src-tauri/src/services/subscription.rs
+++ b/src-tauri/src/services/subscription.rs
@@ -13,7 +13,7 @@ use crate::config;
 // ── 数据类型 ──────────────────────────────────────────────
 
 /// 凭据状态
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CredentialStatus {
     Valid,
@@ -475,7 +475,12 @@ fn read_codex_credentials() -> CodexCredentials {
     #[cfg(target_os = "macos")]
     {
         if let Some(result) = read_codex_credentials_from_keychain() {
-            return result;
+            // Only use Keychain result if credentials were actually found/parsed.
+            // A stale entry (e.g. missing auth_mode) returns NotFound — fall through
+            // to ~/.codex/auth.json so a valid file is not shadowed (#3479).
+            if result.2 != CredentialStatus::NotFound {
+                return result;
+            }
         }
     }
 
@@ -1254,7 +1259,10 @@ pub async fn get_subscription_quota(tool: &str) -> Result<SubscriptionQuota, Str
             let (token, account_id, status, message) = read_codex_credentials();
 
             match status {
-                CredentialStatus::NotFound => Ok(SubscriptionQuota::not_found("codex")),
+                CredentialStatus::NotFound => Ok(SubscriptionQuota {
+                    error: message,
+                    ..SubscriptionQuota::not_found("codex")
+                }),
                 CredentialStatus::ParseError => Ok(SubscriptionQuota::error(
                     "codex",
                     CredentialStatus::ParseError,

--- a/src-tauri/src/services/subscription.rs
+++ b/src-tauri/src/services/subscription.rs
@@ -475,10 +475,11 @@ fn read_codex_credentials() -> CodexCredentials {
     #[cfg(target_os = "macos")]
     {
         if let Some(result) = read_codex_credentials_from_keychain() {
-            // Only use Keychain result if credentials were actually found/parsed.
-            // A stale entry (e.g. missing auth_mode) returns NotFound — fall through
-            // to ~/.codex/auth.json so a valid file is not shadowed (#3479).
-            if result.2 != CredentialStatus::NotFound {
+            // Only use Keychain result when credentials are fully valid.
+            // Stale entries (missing auth_mode → NotFound, last_refresh >8d → Expired,
+            // malformed JSON → ParseError) must fall through to ~/.codex/auth.json
+            // so a valid file is not shadowed (#3479).
+            if result.2 == CredentialStatus::Valid {
                 return result;
             }
         }

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -32,6 +32,10 @@ export interface CodexProviderPreset {
   iconColor?: string; // 图标颜色
   // Codex API 格式
   apiFormat?: CodexApiFormat;
+  // OAuth / Copilot 类型标识，用于路由到对应的 QuotaFooter
+  providerType?: "github_copilot" | "codex_oauth";
+  // 是否需要 OAuth 登录（在表单中展示 CodexOAuthSection）
+  requiresOAuth?: boolean;
   // Codex Chat 本地路由模式下的模型目录
   modelCatalog?: CodexCatalogModel[];
   // Codex Responses -> Chat Completions reasoning capability defaults
@@ -91,6 +95,8 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     websiteUrl: "https://chatgpt.com/codex",
     isOfficial: true,
     category: "official",
+    providerType: "codex_oauth",
+    requiresOAuth: true,
     auth: {},
     config: ``,
     theme: {


### PR DESCRIPTION
## Summary

Three fixes for the Codex Official provider's subscription quota display:

### 1. Keychain stale-entry fallback (`subscription.rs`)

`read_codex_credentials()` always preferred macOS Keychain `"Codex Auth"` over
`~/.codex/auth.json`. A legacy entry missing `auth_mode` or with an expired token
(`last_refresh` >8 days) returned `NotFound`/`Expired`, and the valid file was never
consulted. Now only `CredentialStatus::Valid` Keychain results take priority; all
other statuses fall through to the file.

Also propagate the `credential_message` for `NotFound` so the frontend shows the
actual reason instead of the generic "No result returned".

### 2. Preset: route new providers through OAuth path (`codexProviderPresets.ts`)

Add `providerType: "codex_oauth"` and `requiresOAuth: true` to the "OpenAI Official"
codex preset. New providers created from this preset now render `CodexOauthQuotaFooter`
(OAuth path) instead of `SubscriptionQuotaFooter` (CLI credential path).

### 3. Database migration v11→v12 (`schema.rs`)

Patch existing codex providers with `category = "official"` and missing `providerType`
to `"codex_oauth"`. Does not touch `authBinding` — users can bind a ChatGPT account
later via Settings → Auth Center.

## Test plan

- [ ] `cargo build` + `tsc --noEmit` pass
- [ ] Stale Keychain entry (missing `auth_mode` or expired) + valid `~/.codex/auth.json`
      → quota displays correctly (file fallback works)
- [ ] Valid Keychain entry → still preferred over file
- [ ] New "OpenAI Official" provider created → `providerType: "codex_oauth"` in meta,
      renders `CodexOauthQuotaFooter`
- [ ] Existing codex official provider (pre-migration) → v11→v12 migration adds
      `providerType`, renders `CodexOauthQuotaFooter` after upgrade

Fixes #3479
Fixes #2157