### PR TITLE
feat: add Kimi / Kimi EN built-in balance query (Balance mode)

### DIFF
--- a/src-tauri/src/services/balance.rs
+++ b/src-tauri/src/services/balance.rs
@@ -421,7 +421,7 @@ async fn query_novita(api_key: &str) -> Result<UsageResult, String> {
 // Also: https://api.kimi.ai/v1/users/me/balance (EN alias)
 // Response: { code: 0, data: { available_balance, voucher_balance, cash_balance }, status: true }
 
-async fn query_kimi(api_key: &str, is_en: bool) -> UsageResult {
+async fn query_kimi(api_key: &str, is_en: bool) -> Result<UsageResult, String> {
     let client = crate::proxy::http_client::get();
 
     let domain = if is_en {
@@ -441,40 +441,48 @@ async fn query_kimi(api_key: &str, is_en: bool) -> UsageResult {
 
     let resp = match resp {
         Ok(r) => r,
-        Err(e) => return make_error(format!("Network error: {e}")),
+        Err(e) => return Err(format!("Network error: {e}")),
     };
 
     let status = resp.status();
     if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-        return make_auth_error(status);
+        return Ok(make_auth_error(status));
     }
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
-        return make_error(format!("API error (HTTP {status}): {body}"));
+        return Ok(make_error(format!("API error (HTTP {status}): {body}")));
     }
 
-    let body: serde_json::Value = match resp.json().await {
+    let raw = match resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => return Err(format!("Failed to read response: {e}")),
+    };
+    let body: serde_json::Value = match serde_json::from_slice(&raw) {
         Ok(v) => v,
-        Err(e) => return make_error(format!("Failed to parse response: {e}")),
+        Err(e) => return Ok(make_error(format!("Failed to parse response: {e}"))),
     };
 
     let data = match body.get("data") {
         Some(d) => d,
-        None => return make_error("Missing 'data' field in response".to_string()),
+        None => return Ok(make_error("Missing 'data' field in response".to_string())),
     };
 
     let available = parse_f64_field(data, "available_balance").unwrap_or(0.0);
     let cash = parse_f64_field(data, "cash_balance").unwrap_or(0.0);
     let voucher = parse_f64_field(data, "voucher_balance").unwrap_or(0.0);
 
-    let plan_name = if is_en { "Kimi (EN)" } else { "Kimi" };
+    let (plan_name, unit, symbol) = if is_en {
+        ("Kimi (EN)", "USD", "$")
+    } else {
+        ("Kimi", "CNY", "¥")
+    };
 
     let mut usage_data = vec![UsageData {
         plan_name: Some(plan_name.to_string()),
         remaining: Some(available),
         total: None,
         used: None,
-        unit: Some("CNY".to_string()),
+        unit: Some(unit.to_string()),
         is_valid: Some(available > 0.0),
         invalid_message: if available <= 0.0 {
             Some("Insufficient balance".to_string())
@@ -487,19 +495,19 @@ async fn query_kimi(api_key: &str, is_en: bool) -> UsageResult {
     if cash > 0.0 || voucher > 0.0 {
         let mut parts = Vec::new();
         if cash > 0.0 {
-            parts.push(format!("Cash: ¥{cash:.2}"));
+            parts.push(format!("Cash: {symbol}{cash:.2}"));
         }
         if voucher > 0.0 {
-            parts.push(format!("Voucher: ¥{voucher:.2}"));
+            parts.push(format!("Voucher: {symbol}{voucher:.2}"));
         }
         usage_data[0].extra = Some(parts.join(", "));
     }
 
-    UsageResult {
+    Ok(UsageResult {
         success: true,
         data: Some(usage_data),
         error: None,
-    }
+    })
 }
 
 // ── 工具函数 ────────────────────────────────────────────────

--- a/src-tauri/src/services/balance.rs
+++ b/src-tauri/src/services/balance.rs
@@ -1,6 +1,6 @@
 //! 供应商余额查询服务
 //!
-//! 支持 DeepSeek、StepFun、SiliconFlow、OpenRouter、Novita AI 的账户余额查询。
+//! 支持 DeepSeek、StepFun、SiliconFlow、OpenRouter、Novita AI、Kimi (Moonshot) 的账户余额查询。
 //! 返回 UsageResult 格式，与现有用量系统无缝对接。
 //!
 //! 错误通道语义（与 coding_plan / subscription 两个服务保持一致）：
@@ -21,6 +21,8 @@ enum BalanceProvider {
     SiliconFlowEn,
     OpenRouter,
     NovitaAI,
+    Kimi,
+    KimiEn,
 }
 
 fn detect_provider(base_url: &str) -> Option<BalanceProvider> {
@@ -37,6 +39,10 @@ fn detect_provider(base_url: &str) -> Option<BalanceProvider> {
         Some(BalanceProvider::OpenRouter)
     } else if url.contains("api.novita.ai") {
         Some(BalanceProvider::NovitaAI)
+    } else if url.contains("api.moonshot.cn") {
+        Some(BalanceProvider::Kimi)
+    } else if url.contains("api.moonshot.ai") || url.contains("api.kimi.ai") {
+        Some(BalanceProvider::KimiEn)
     } else {
         None
     }
@@ -409,6 +415,93 @@ async fn query_novita(api_key: &str) -> Result<UsageResult, String> {
     })
 }
 
+// ── Kimi (Moonshot) ────────────────────────────────────────
+// GET https://api.moonshot.cn/v1/users/me/balance (CN)
+// GET https://api.moonshot.ai/v1/users/me/balance (EN)
+// Also: https://api.kimi.ai/v1/users/me/balance (EN alias)
+// Response: { code: 0, data: { available_balance, voucher_balance, cash_balance }, status: true }
+
+async fn query_kimi(api_key: &str, is_en: bool) -> UsageResult {
+    let client = crate::proxy::http_client::get();
+
+    let domain = if is_en {
+        "api.moonshot.ai"
+    } else {
+        "api.moonshot.cn"
+    };
+    let url = format!("https://{domain}/v1/users/me/balance");
+
+    let resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("Accept", "application/json")
+        .timeout(Duration::from_secs(15))
+        .send()
+        .await;
+
+    let resp = match resp {
+        Ok(r) => r,
+        Err(e) => return make_error(format!("Network error: {e}")),
+    };
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return make_auth_error(status);
+    }
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return make_error(format!("API error (HTTP {status}): {body}"));
+    }
+
+    let body: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => return make_error(format!("Failed to parse response: {e}")),
+    };
+
+    let data = match body.get("data") {
+        Some(d) => d,
+        None => return make_error("Missing 'data' field in response".to_string()),
+    };
+
+    let available = parse_f64_field(data, "available_balance").unwrap_or(0.0);
+    let cash = parse_f64_field(data, "cash_balance").unwrap_or(0.0);
+    let voucher = parse_f64_field(data, "voucher_balance").unwrap_or(0.0);
+
+    let plan_name = if is_en { "Kimi (EN)" } else { "Kimi" };
+
+    let mut usage_data = vec![UsageData {
+        plan_name: Some(plan_name.to_string()),
+        remaining: Some(available),
+        total: None,
+        used: None,
+        unit: Some("CNY".to_string()),
+        is_valid: Some(available > 0.0),
+        invalid_message: if available <= 0.0 {
+            Some("Insufficient balance".to_string())
+        } else {
+            None
+        },
+        extra: None,
+    }];
+
+    if cash > 0.0 || voucher > 0.0 {
+        let mut parts = Vec::new();
+        if cash > 0.0 {
+            parts.push(format!("Cash: ¥{cash:.2}"));
+        }
+        if voucher > 0.0 {
+            parts.push(format!("Voucher: ¥{voucher:.2}"));
+        }
+        usage_data[0].extra = Some(parts.join(", "));
+    }
+
+    UsageResult {
+        success: true,
+        data: Some(usage_data),
+        error: None,
+    }
+}
+
 // ── 工具函数 ────────────────────────────────────────────────
 
 /// 解析 JSON 字段为 f64，兼容数字和字符串格式
@@ -450,5 +543,7 @@ pub async fn get_balance(base_url: &str, api_key: &str) -> Result<UsageResult, S
         BalanceProvider::SiliconFlowEn => query_siliconflow(api_key, false).await,
         BalanceProvider::OpenRouter => query_openrouter(api_key).await,
         BalanceProvider::NovitaAI => query_novita(api_key).await,
+        BalanceProvider::Kimi => query_kimi(api_key, false).await,
+        BalanceProvider::KimiEn => query_kimi(api_key, true).await,
     }
 }

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -150,6 +150,12 @@ const BALANCE_PROVIDERS = [
   },
   { id: "openrouter", label: "OpenRouter", pattern: /openrouter\.ai/i },
   { id: "novita", label: "Novita AI", pattern: /api\.novita\.ai/i },
+  { id: "kimi", label: "Kimi", pattern: /api\.moonshot\.cn/i },
+  {
+    id: "kimi_en",
+    label: "Kimi (EN)",
+    pattern: /api\.(moonshot\.ai|kimi\.ai)/i,
+  },
 ] as const;
 
 /** 根据 Base URL 自动检测余额查询供应商 */


### PR DESCRIPTION
## Summary

- Add native balance query support for Kimi (Moonshot) pay-as-you-go accounts
- Detect `api.moonshot.cn` (CN) and `api.moonshot.ai` / `api.kimi.ai` (EN) base URLs
- Call official `GET /v1/users/me/balance` endpoint and parse `available_balance`, `cash_balance`, `voucher_balance`
- Frontend auto-detects Kimi base URLs and recommends the Balance template

## Motivation

cc-switch currently only supports Kimi's **Token Plan (Coding Plan)** quota query via `api.kimi.com/coding`, but does not support balance query for **pay-as-you-go** accounts. Users with Kimi pay-as-you-go API accounts cannot see their balance natively.

Kimi officially provides public balance query APIs:

| Site | Endpoint |
|------|----------|
| Kimi CN | `GET https://api.moonshot.cn/v1/users/me/balance` |
| Kimi EN | `GET https://api.moonshot.ai/v1/users/me/balance` |

## Changes

**Backend (`src-tauri/src/services/balance.rs`):**
- Add `Kimi` and `KimiEn` variants to `BalanceProvider` enum
- Add detection rules in `detect_provider()` for `api.moonshot.cn`, `api.moonshot.ai`, `api.kimi.ai`
- Implement `query_kimi(api_key, is_en)` following the same pattern as existing providers
- Display cash/voucher breakdown in the `extra` field

**Frontend (`src/components/UsageScriptModal.tsx`):**
- Add Kimi and Kimi (EN) entries to `BALANCE_PROVIDERS` array
- Existing `detectBalanceProvider()` logic automatically picks up the new entries

## Test Plan

- [x] `cargo check` passes with no errors
- [x] Configure a Claude provider with `ANTHROPIC_BASE_URL=https://api.moonshot.cn/v1` and a valid Kimi API key
- [x] Open Usage Script Modal → verify "Balance" template is auto-selected and "Kimi" badge appears
- [x] Click "Test" → verify balance is displayed correctly (available_balance, cash/voucher breakdown)
- [x] Repeat with `api.moonshot.ai` base URL for EN variant

Closes #4455

Made with [Cursor](https://cursor.com)