### PR TITLE
fix(provider): improve drag cursor contrast on light backgrounds

### DIFF
--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -305,7 +305,7 @@ export function ProviderCard({
         !(isActiveProvider || hasPersistentConfigHighlight) &&
           "hover:shadow-sm",
         dragHandleProps?.isDragging &&
-          "cursor-grabbing border-primary shadow-lg scale-105 z-10",
+          "provider-card-grabbing-cursor cursor-grabbing border-primary shadow-lg scale-105 z-10",
       )}
     >
       <div
@@ -324,9 +324,10 @@ export function ProviderCard({
           <button
             type="button"
             className={cn(
-              "-ml-1.5 flex-shrink-0 cursor-grab active:cursor-grabbing p-1.5",
+              "-ml-1.5 flex-shrink-0 provider-card-grab-cursor cursor-grab active:cursor-grabbing p-1.5",
               "text-muted-foreground/50 hover:text-muted-foreground transition-colors",
-              dragHandleProps?.isDragging && "cursor-grabbing",
+              dragHandleProps?.isDragging &&
+                "provider-card-grabbing-cursor cursor-grabbing",
             )}
             aria-label={t("provider.dragHandle")}
             {...(dragHandleProps?.attributes ?? {})}

--- a/src/index.css
+++ b/src/index.css
@@ -191,3 +191,18 @@ input[type="password"]::-ms-reveal,
 input[type="password"]::-ms-clear {
   display: none;
 }
+
+.provider-card-grab-cursor {
+  cursor:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='%23fff' stroke='%2318171f' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M11 13V7a2 2 0 0 1 4 0v6V5a2 2 0 0 1 4 0v8V7a2 2 0 0 1 4 0v9-4a2 2 0 0 1 4 0v7c0 5-4 9-9 9h-2c-3 0-5-1-7-4l-4-6a2 2 0 0 1 3-2l3 3z'/%3E%3C/svg%3E")
+      14 14,
+    grab;
+}
+
+.provider-card-grabbing-cursor,
+.provider-card-grab-cursor:active {
+  cursor:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='%23fff' stroke='%2318171f' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M10 14V9a2 2 0 0 1 4 0v5V7a2 2 0 0 1 4 0v7V9a2 2 0 0 1 4 0v7-3a2 2 0 0 1 4 0v6c0 5-4 9-9 9h-1c-3 0-5-1-7-4l-4-5a2 2 0 0 1 3-3l2 2z'/%3E%3C/svg%3E")
+      14 14,
+    grabbing;
+}

--- a/tests/components/ProviderCardLayout.test.ts
+++ b/tests/components/ProviderCardLayout.test.ts
@@ -11,9 +11,11 @@ const PROVIDER_CARD_TSX = path.resolve(
   "providers",
   "ProviderCard.tsx",
 );
+const INDEX_CSS = path.resolve(__dirname, "..", "..", "src", "index.css");
 
 describe("ProviderCard layout", () => {
   const source = fs.readFileSync(PROVIDER_CARD_TSX, "utf8");
+  const indexCss = fs.readFileSync(INDEX_CSS, "utf8");
 
   it("lets website links use available card width before truncating", () => {
     expect(source).not.toContain("max-w-[280px]");
@@ -22,5 +24,15 @@ describe("ProviderCard layout", () => {
     expect(source).toContain(
       "inline-flex max-w-full items-center overflow-hidden text-left text-sm",
     );
+  });
+
+  it("uses outlined grab cursors for provider drag sorting", () => {
+    expect(source).toContain("provider-card-grab-cursor");
+    expect(source).toContain("provider-card-grabbing-cursor");
+    expect(indexCss).toContain(".provider-card-grab-cursor");
+    expect(indexCss).toContain(".provider-card-grabbing-cursor");
+    expect(indexCss).toContain("stroke='%2318171f'");
+    expect(indexCss).toMatch(/,\s*grab/);
+    expect(indexCss).toMatch(/,\s*grabbing/);
   });
 });


### PR DESCRIPTION
### Summary / 摘要
This PR makes the provider drag cursor visible on light backgrounds.
这个 PR 修复了浅色背景下 provider 拖动光标不易看见的问题。

Previously, provider drag sorting used the native `grab` / `grabbing` hand cursor. On some Windows environments, that cursor can appear as a pure white hand.
之前 provider 拖动排序使用系统原生的 `grab` / `grabbing` 手型光标。在部分 Windows 环境中，该光标会显示为纯白色手型。

On white or very light provider card backgrounds, the cursor becomes hard to see while dragging providers up and down.
在白色或很浅的 provider 卡片背景上，上下拖动 provider 时光标会变得难以识别。

### Changes / 修改
Add custom outlined grab and grabbing cursors for provider drag sorting.
为 provider 拖动排序新增带描边的 grab / grabbing 手型光标。

Apply the custom cursor only to the provider drag handle and active dragging state.
仅在 provider 拖动手柄和正在拖动状态下使用自定义光标。

Keep the native `grab` / `grabbing` cursor as fallback.
保留系统原生 `grab` / `grabbing` 光标作为回退。

Add a regression test to ensure provider drag sorting uses outlined cursors.
新增回归测试，确保 provider 拖动排序使用带描边的光标。

### Behavior / 行为
Provider drag sorting still uses a hand-shaped cursor.
provider 拖动排序仍然使用手型光标。

The cursor now has a dark outline, so it remains visible on white backgrounds.
光标现在带有深色描边，因此在白色背景上仍然可见。

Other clickable areas and regular pointer cursors are unchanged.
其他可点击区域和普通 pointer 光标行为保持不变。

### Why / 原因
This fixes a visibility bug without changing the drag behavior or provider ordering logic.
这个修改修复了可见性问题，不改变拖动行为和 provider 排序逻辑。

The change is intentionally scoped to the provider drag handle so the rest of the app continues to use existing cursor behavior.
修改范围刻意限制在 provider 拖动手柄内，应用其他区域继续使用现有光标行为。

### Verification / 验证
pnpm vitest run tests/components/ProviderCardLayout.test.ts
pnpm typecheck
pnpm exec prettier --check src/components/providers/ProviderCard.tsx src/index.css tests/components/ProviderCardLayout.test.ts
pnpm build:renderer