### PR TITLE
fix(macos): declare bundle localizations for WKWebView context menu i18n

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <!-- 声明本地化语言，使 WKWebView 右键菜单跟随系统语言 -->
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleLocalizations</key>
+  <array>
+    <string>en</string>
+    <string>ja</string>
+    <string>zh</string>
+    <string>zh-Hant</string>
+  </array>
   <!-- 注册 ccswitch:// 自定义 URL 协议，用于深链接导入 -->
   <key>CFBundleURLTypes</key>
   <array>
@@ -16,4 +26,3 @@
   </array>
 </dict>
 </plist>
-


### PR DESCRIPTION
## Summary / 概述

macOS 上 CC Switch 应用窗口内右键菜单（Copy / Paste / Search with Google / Look Up 等 WKWebView 原生项）始终显示英文，即使系统语言是中文。

### 根因

`src-tauri/Info.plist` 未声明应用本地化信息（`CFBundleDevelopmentRegion` / `CFBundleLocalizations`）。macOS 通过应用 bundle 的本地化声明决定 WKWebView 原生菜单语言，未声明时一律按英文处理。

### 影响范围

仅 macOS。Windows（WebView2）和 Linux（WebKitGTK）的原生右键菜单直接跟随系统语言，不受影响。

### 修复方案

在 `src-tauri/Info.plist` 中添加本地化声明：

```xml
<key>CFBundleDevelopmentRegion</key>
<string>en</string>
<key>CFBundleLocalizations</key>
<array>
  <string>en</string>
  <string>ja</string>
  <string>zh</string>
  <string>zh-Hant</string>
</array>
```

- `CFBundleDevelopmentRegion` 设为 `en`，作为非列表内语言的通用回退
- `CFBundleLocalizations` 按 Apple 规范使用语言/脚本设计符（`zh-Hant` 而非 `zh-TW`）

## Related Issue / 关联 Issue

已检索现有 issues，未发现匹配的 issue。

Fixes #

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| <img width="900" height="600" alt="image" src="https://github.com/user-attachments/assets/e983ed00-e3a2-4a54-9a42-b85c107ac8e8" />  | <img width="900" height="600" alt="image" src="https://github.com/user-attachments/assets/6835399c-8032-4cfb-acae-00a7e3c41093" /> |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（无 TS 改动）
- [x] `pnpm format:check` passes / 通过代码格式检查（无 JS/TS 改动）
- [x] `cargo clippy` passes (if Rust code changed) / 未修改 Rust 代码，N/A
- [x] Updated i18n files if user-facing text changed / 未新增用户可见文案，N/A