### PR TITLE
fix(codex): fall back to live model for models endpoint

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -303,12 +303,37 @@ fn parse_codex_positive_u64(value: Option<&Value>) -> Option<u64> {
     }
 }
 
-fn extract_codex_top_level_u64(config_text: &str, field: &str) -> Option<u64> {
+fn extract_codex_positive_u64_from_toml(value: Option<&toml::Value>) -> Option<u64> {
+    match value {
+        Some(toml::Value::Integer(value)) => u64::try_from(*value).ok().filter(|value| *value > 0),
+        Some(toml::Value::String(value)) => {
+            value.trim().parse::<u64>().ok().filter(|value| *value > 0)
+        }
+        _ => None,
+    }
+}
+
+fn extract_codex_config_u64(config_text: &str, field: &str) -> Option<u64> {
     let doc = config_text.parse::<toml::Value>().ok()?;
-    doc.get(field)
-        .and_then(|value| value.as_integer())
-        .and_then(|value| u64::try_from(value).ok())
-        .filter(|value| *value > 0)
+    let active_provider = doc
+        .get("model_provider")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    if let Some(active_provider) = active_provider {
+        if let Some(provider_value) = doc
+            .get("model_providers")
+            .and_then(|providers| providers.get(active_provider))
+            .and_then(|provider| provider.get(field))
+        {
+            if let Some(value) = extract_codex_positive_u64_from_toml(Some(provider_value)) {
+                return Some(value);
+            }
+        }
+    }
+
+    extract_codex_positive_u64_from_toml(doc.get(field))
 }
 
 fn extract_codex_top_level_string(config_text: &str, field: &str) -> Option<String> {
@@ -363,7 +388,7 @@ fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCa
     };
 
     let default_context_window =
-        extract_codex_top_level_u64(config_text, "model_context_window").unwrap_or(128_000);
+        extract_codex_config_u64(config_text, "model_context_window").unwrap_or(128_000);
     let mut seen = std::collections::HashSet::new();
     let mut specs = Vec::new();
 
@@ -695,7 +720,7 @@ pub fn codex_model_catalog_from_live_config_model(
         return Ok(None);
     };
     let context_window =
-        extract_codex_top_level_u64(config_text, "model_context_window").unwrap_or(128_000);
+        extract_codex_config_u64(config_text, "model_context_window").unwrap_or(128_000);
     let specs = [CodexCatalogModelSpec {
         model: model.clone(),
         display_name: model,
@@ -833,7 +858,7 @@ fn build_simplified_catalog_from_texts(config_text: &str, catalog_text: &str) ->
     let models = catalog.get("models").and_then(|m| m.as_array())?;
 
     let default_context_window =
-        extract_codex_top_level_u64(config_text, "model_context_window").unwrap_or(128_000);
+        extract_codex_config_u64(config_text, "model_context_window").unwrap_or(128_000);
 
     let mut entries = Vec::with_capacity(models.len());
     for entry in models {
@@ -2172,6 +2197,36 @@ model_context_window = 1000000
                 .get("context_window")
                 .and_then(|value| value.as_u64()),
             Some(1_000_000)
+        );
+    }
+
+    #[test]
+    fn codex_model_catalog_fallback_uses_active_provider_context_window() {
+        let config = r#"
+model_provider = "eflowcode"
+model = "gpt-5.5"
+model_context_window = 128000
+
+[model_providers.eflowcode]
+model_context_window = 1000000
+
+[model_providers.other]
+model_context_window = 64000
+"#;
+        let catalog = codex_model_catalog_from_live_config_model(config)
+            .expect("fallback catalog should build")
+            .expect("top-level model should produce a catalog");
+        let models = catalog
+            .get("models")
+            .and_then(|value| value.as_array())
+            .expect("models should be an array");
+
+        assert_eq!(
+            models[0]
+                .get("context_window")
+                .and_then(|value| value.as_u64()),
+            Some(1_000_000),
+            "active provider context should override top-level fallback"
         );
     }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -311,6 +311,15 @@ fn extract_codex_top_level_u64(config_text: &str, field: &str) -> Option<u64> {
         .filter(|value| *value > 0)
 }
 
+fn extract_codex_top_level_string(config_text: &str, field: &str) -> Option<String> {
+    let doc = config_text.parse::<toml::Value>().ok()?;
+    doc.get(field)
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn codex_catalog_model_entry(
     template: &Value,
     model: &str,
@@ -674,6 +683,24 @@ fn codex_model_catalog_from_settings(
         return Ok(None);
     }
 
+    let template = load_codex_model_catalog_template()?;
+    Ok(Some(codex_model_catalog_from_specs(&specs, &template)))
+}
+
+/// 当 live config 缺少 cc-switch catalog 指针时，用当前模型生成最小 catalog，避免 `/v1/models` 返回空列表。
+pub fn codex_model_catalog_from_live_config_model(
+    config_text: &str,
+) -> Result<Option<Value>, AppError> {
+    let Some(model) = extract_codex_top_level_string(config_text, "model") else {
+        return Ok(None);
+    };
+    let context_window =
+        extract_codex_top_level_u64(config_text, "model_context_window").unwrap_or(128_000);
+    let specs = [CodexCatalogModelSpec {
+        model: model.clone(),
+        display_name: model,
+        context_window,
+    }];
     let template = load_codex_model_catalog_template()?;
     Ok(Some(codex_model_catalog_from_specs(&specs, &template)))
 }
@@ -2118,6 +2145,44 @@ base_url = "https://production.api/v1"
                 .get("availability_nux")
                 .is_some_and(|value| value.is_null()),
             "generated third-party entries should not inherit GPT-5.5 launch messaging"
+        );
+    }
+
+    #[test]
+    fn codex_model_catalog_can_fall_back_to_live_config_model() {
+        let config = r#"
+model = "gpt-5.5"
+model_context_window = 1000000
+"#;
+        let catalog = codex_model_catalog_from_live_config_model(config)
+            .expect("fallback catalog should build")
+            .expect("top-level model should produce a catalog");
+        let models = catalog
+            .get("models")
+            .and_then(|value| value.as_array())
+            .expect("models should be an array");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0].get("slug").and_then(|value| value.as_str()),
+            Some("gpt-5.5")
+        );
+        assert_eq!(
+            models[0]
+                .get("context_window")
+                .and_then(|value| value.as_u64()),
+            Some(1_000_000)
+        );
+    }
+
+    #[test]
+    fn codex_model_catalog_fallback_ignores_missing_live_model() {
+        let catalog = codex_model_catalog_from_live_config_model("model_context_window = 1000000")
+            .expect("fallback catalog lookup should not fail");
+
+        assert!(
+            catalog.is_none(),
+            "missing top-level model should not produce a fallback catalog"
         );
     }
 

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -75,12 +75,10 @@ pub async fn get_status(State(state): State<ProxyState>) -> Result<Json<ProxySta
 /// Codex live-setting import.
 pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
     let generated_path = crate::codex_config::get_codex_model_catalog_path();
-    let active_catalog_path = match crate::codex_config::read_codex_config_text() {
-        Ok(config_text) => {
-            crate::codex_config::resolve_cc_switch_catalog_path(&config_text, &generated_path)
-        }
-        Err(_) => None,
-    };
+    let config_text = crate::codex_config::read_codex_config_text().ok();
+    let active_catalog_path = config_text.as_ref().and_then(|config_text| {
+        crate::codex_config::resolve_cc_switch_catalog_path(config_text, &generated_path)
+    });
 
     let catalog = if let Some(catalog_path) =
         active_catalog_path.as_ref().filter(|path| path.exists())
@@ -88,6 +86,27 @@ pub async fn handle_models() -> Result<Json<Value>, ProxyError> {
         let text = std::fs::read_to_string(catalog_path).unwrap_or_default();
         serde_json::from_str(&text).unwrap_or(json!({"models": []}))
     } else {
+        if let Some(config_text) = config_text.as_deref() {
+            match crate::codex_config::codex_model_catalog_from_live_config_model(config_text) {
+                Ok(Some(catalog)) => {
+                    if active_catalog_path.is_none() {
+                        log::debug!(
+                            "[models] serving live-config fallback catalog (model_catalog_json not set to cc-switch catalog)"
+                        );
+                    } else {
+                        log::debug!(
+                            "[models] serving live-config fallback catalog (cc-switch catalog file missing)"
+                        );
+                    }
+                    return Ok(Json(catalog));
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    log::debug!("[models] live-config fallback catalog unavailable: {err}");
+                }
+            }
+        }
+
         if active_catalog_path.is_none() {
             log::debug!(
                 "[models] stale guard: catalog not served (model_catalog_json not set to cc-switch catalog)"


### PR DESCRIPTION
## Summary / 概述

当 Codex live config 已经被 CC Switch 本地代理接管，但 `config.toml` 里没有指向 CC Switch 生成目录的 `model_catalog_json` 时，当前 `GET /v1/models` 会返回空模型目录：

```json
{"models":[]}
```

Codex Desktop / CLI 在启动、恢复会话、或 pre-sampling compact 前可能会请求 `/v1/models`。即使 `/v1/responses` 实际可以正常转发，空模型列表也会让这些启动/恢复路径变得不稳定，表现为模型列表为空、启动/恢复超时或预采样阶段失败。

本 PR 增加一个很小的 fallback：

- 如果 `model_catalog_json` 指向 CC Switch 自己的 catalog，且文件存在，继续返回该 catalog；
- 否则读取 live `config.toml` 顶层的 `model` 和 `model_context_window`；
- 用现有 Codex catalog 模板生成一个单模型 catalog 返回；
- 只有在 live config 里也无法确定当前模型时，才继续返回空列表。

这个 PR 不尝试一次性修完整个 Codex Desktop 模型选择器 / catalog projection 问题，只解决 `/v1/models` 在 live config 仍有可用模型时不应返回空 `models` 的问题。

## Related Issue / 关联 Issue

Refs #3692

相关：#3818、#4420、#4453、#4461。

## Screenshots / 截图

不适用。该改动仅影响后端本地代理行为。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

额外验证：

- [x] `cargo fmt --check`
- [x] `cargo test -p cc-switch --lib codex_model_catalog`

说明：

- 没有修改前端或用户可见文案，因此没有改 i18n 文件。
- 本地只重跑了相关 Rust 单元测试。
