### PR TITLE
feat(codex): add model mapping and Chat Completions transform (merged PR-916 + PR-2659)

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -382,6 +382,17 @@ pub struct CodexChatReasoningConfig {
     pub output_format: Option<String>,
 }
 
+/// 请求体重写器配置（用于过滤或覆盖 JSON 字段）
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RequestBodyRewriter {
+    /// 是否启用
+    #[serde(default)]
+    pub enabled: bool,
+    /// 重写规则：key 为字段路径（支持点分隔如 "text.verbosity"），value 为新值（null 表示删除）
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub rules: HashMap<String, Option<Value>>,
+}
+
 /// 供应商元数据
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProviderMeta {
@@ -478,6 +489,12 @@ pub struct ProviderMeta {
     /// 用于多账号支持，关联到特定的 GitHub 账号
     #[serde(rename = "githubAccountId", skip_serializing_if = "Option::is_none")]
     pub github_account_id: Option<String>,
+    /// Codex 模型映射配置（每个渠道独立配置）
+    #[serde(rename = "codexModelMapping", skip_serializing_if = "Option::is_none")]
+    pub codex_model_mapping: Option<crate::proxy::codex_model_mapper::CodexModelMappingConfig>,
+    /// 请求体重写器配置（用于过滤或覆盖 JSON 字段）
+    #[serde(rename = "requestBodyRewriter", skip_serializing_if = "Option::is_none")]
+    pub request_body_rewriter: Option<RequestBodyRewriter>,
 }
 
 /// 解析 Provider 级自定义 User-Agent 字符串（单一真理来源）。

--- a/src-tauri/src/proxy/codex_model_mapper.rs
+++ b/src-tauri/src/proxy/codex_model_mapper.rs
@@ -1,0 +1,284 @@
+//! Codex 模型映射模块
+//!
+//! 在请求转发前，根据 Provider 配置替换 Codex 请求中的模型名称
+//! 支持简单映射和 effort 组合映射
+
+use crate::provider::Provider;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Codex 模型映射配置
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CodexModelMappingConfig {
+    /// 是否启用模型映射
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// 简单模型映射：请求模型 → 目标模型
+    /// Key: 请求模型ID, Value: 目标模型ID
+    #[serde(default, rename = "modelMap")]
+    pub model_map: HashMap<String, String>,
+
+    /// Effort 组合映射：(模型, effort) → 目标模型
+    /// Key: "模型ID@effort", Value: 目标模型ID
+    /// 例: "gpt-5.2-codex@xhigh" → "gpt-5.2-codex-xhigh"
+    #[serde(default, rename = "effortMap")]
+    pub effort_map: HashMap<String, String>,
+}
+
+impl CodexModelMappingConfig {
+    /// 检查是否有任何映射规则
+    pub fn has_mapping(&self) -> bool {
+        self.enabled && (!self.model_map.is_empty() || !self.effort_map.is_empty())
+    }
+
+    /// 根据模型和effort查找映射
+    ///
+    /// 优先级：
+    /// 1. model_map (简单模型映射) - 匹配模型ID后直接映射，不管有没有 effort
+    /// 2. effort_map (模型+effort 组合) - 更细粒度的覆盖，仅当简单映射未匹配时使用
+    /// 3. 无映射，返回原模型
+    pub fn map_model(&self, original_model: &str, effort: Option<&str>) -> (String, bool) {
+        if !self.enabled {
+            return (original_model.to_string(), false);
+        }
+
+        // 1. 优先尝试简单模型映射
+        if let Some(mapped) = self.model_map.get(original_model) {
+            return (mapped.clone(), true);
+        }
+
+        // 2. 如果简单映射没匹配，尝试 effort 组合映射（更细粒度）
+        if let Some(eff) = effort {
+            let key = format!("{}@{}", original_model, eff);
+            if let Some(mapped) = self.effort_map.get(&key) {
+                return (mapped.clone(), true);
+            }
+        }
+
+        // 3. 无映射
+        (original_model.to_string(), false)
+    }
+}
+
+/// 从 Provider 提取 Codex 模型映射配置
+pub fn extract_mapping_config(provider: &Provider) -> CodexModelMappingConfig {
+    provider
+        .meta
+        .as_ref()
+        .and_then(|m| m.codex_model_mapping.as_ref())
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// 从请求体中提取 effort 值
+pub fn extract_effort(body: &Value) -> Option<String> {
+    body.get("reasoning")
+        .and_then(|r| r.get("effort"))
+        .and_then(|e| e.as_str())
+        .map(String::from)
+}
+
+/// 应用 Codex 模型映射
+///
+/// 返回 (映射后的请求体, 原始模型, 映射后模型)
+pub fn apply_codex_model_mapping(
+    mut body: Value,
+    provider: &Provider,
+) -> (Value, Option<String>, Option<String>) {
+    let mapping = extract_mapping_config(provider);
+
+    // 如果没有配置映射，直接返回
+    if !mapping.has_mapping() {
+        let original = body.get("model").and_then(|m| m.as_str()).map(String::from);
+        return (body, original, None);
+    }
+
+    // 提取原始模型名和 effort
+    let original_model = body.get("model").and_then(|m| m.as_str()).map(String::from);
+    let effort = extract_effort(&body);
+
+    if let Some(ref original) = original_model {
+        let (mapped, did_map) = mapping.map_model(original, effort.as_deref());
+
+        if did_map && mapped != *original {
+            log::debug!("[CodexModelMapper] 模型映射: {original} → {mapped}");
+            body["model"] = serde_json::json!(mapped);
+            return (body, Some(original.clone()), Some(mapped));
+        }
+    }
+
+    (body, original_model, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn create_provider_with_mapping(
+        model_map: HashMap<String, String>,
+        effort_map: HashMap<String, String>,
+    ) -> Provider {
+        use crate::provider::ProviderMeta;
+
+        Provider {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            settings_config: json!({}),
+            website_url: None,
+            category: None,
+            created_at: None,
+            sort_index: None,
+            notes: None,
+            meta: Some(ProviderMeta {
+                codex_model_mapping: Some(CodexModelMappingConfig {
+                    enabled: true,
+                    model_map,
+                    effort_map,
+                }),
+                ..Default::default()
+            }),
+            icon: None,
+            icon_color: None,
+            in_failover_queue: false,
+        }
+    }
+
+    fn create_provider_without_mapping() -> Provider {
+        Provider {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            settings_config: json!({}),
+            website_url: None,
+            category: None,
+            created_at: None,
+            sort_index: None,
+            notes: None,
+            meta: None,
+            icon: None,
+            icon_color: None,
+            in_failover_queue: false,
+        }
+    }
+
+    #[test]
+    fn test_simple_model_mapping() {
+        let mut model_map = HashMap::new();
+        model_map.insert("gpt-5.2-codex".to_string(), "gpt-5.2-custom".to_string());
+
+        let provider = create_provider_with_mapping(model_map, HashMap::new());
+        let body = json!({"model": "gpt-5.2-codex"});
+
+        let (result, original, mapped) = apply_codex_model_mapping(body, &provider);
+
+        assert_eq!(result["model"], "gpt-5.2-custom");
+        assert_eq!(original, Some("gpt-5.2-codex".to_string()));
+        assert_eq!(mapped, Some("gpt-5.2-custom".to_string()));
+    }
+
+    #[test]
+    fn test_effort_mapping() {
+        let mut effort_map = HashMap::new();
+        effort_map.insert(
+            "gpt-5.2-codex@xhigh".to_string(),
+            "gpt-5.2-codex-xhigh".to_string(),
+        );
+
+        let provider = create_provider_with_mapping(HashMap::new(), effort_map);
+        let body = json!({
+            "model": "gpt-5.2-codex",
+            "reasoning": {"effort": "xhigh", "summary": "auto"}
+        });
+
+        let (result, original, mapped) = apply_codex_model_mapping(body, &provider);
+
+        assert_eq!(result["model"], "gpt-5.2-codex-xhigh");
+        assert_eq!(original, Some("gpt-5.2-codex".to_string()));
+        assert_eq!(mapped, Some("gpt-5.2-codex-xhigh".to_string()));
+        // 验证 reasoning.effort 被保留
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+    }
+
+    #[test]
+    fn test_effort_mapping_priority_over_simple() {
+        let mut model_map = HashMap::new();
+        model_map.insert("gpt-5.2-codex".to_string(), "simple-mapped".to_string());
+
+        let mut effort_map = HashMap::new();
+        effort_map.insert("gpt-5.2-codex@xhigh".to_string(), "effort-mapped".to_string());
+
+        let provider = create_provider_with_mapping(model_map, effort_map);
+        let body = json!({
+            "model": "gpt-5.2-codex",
+            "reasoning": {"effort": "xhigh"}
+        });
+
+        let (result, _, mapped) = apply_codex_model_mapping(body, &provider);
+
+        // effort 映射应该优先
+        assert_eq!(result["model"], "effort-mapped");
+        assert_eq!(mapped, Some("effort-mapped".to_string()));
+    }
+
+    #[test]
+    fn test_fallback_to_simple_mapping_when_effort_not_matched() {
+        let mut model_map = HashMap::new();
+        model_map.insert("gpt-5.2-codex".to_string(), "simple-mapped".to_string());
+
+        let mut effort_map = HashMap::new();
+        effort_map.insert("gpt-5.2-codex@xhigh".to_string(), "effort-mapped".to_string());
+
+        let provider = create_provider_with_mapping(model_map, effort_map);
+        let body = json!({
+            "model": "gpt-5.2-codex",
+            "reasoning": {"effort": "high"}  // 不匹配 xhigh
+        });
+
+        let (result, _, mapped) = apply_codex_model_mapping(body, &provider);
+
+        // 应该 fallback 到简单映射
+        assert_eq!(result["model"], "simple-mapped");
+        assert_eq!(mapped, Some("simple-mapped".to_string()));
+    }
+
+    #[test]
+    fn test_no_mapping_configured() {
+        let provider = create_provider_without_mapping();
+        let body = json!({"model": "gpt-5.2-codex"});
+
+        let (result, original, mapped) = apply_codex_model_mapping(body, &provider);
+
+        assert_eq!(result["model"], "gpt-5.2-codex");
+        assert_eq!(original, Some("gpt-5.2-codex".to_string()));
+        assert!(mapped.is_none());
+    }
+
+    #[test]
+    fn test_disabled_mapping() {
+        let mut model_map = HashMap::new();
+        model_map.insert("gpt-5.2-codex".to_string(), "mapped".to_string());
+
+        let config = CodexModelMappingConfig {
+            enabled: false,
+            model_map,
+            effort_map: HashMap::new(),
+        };
+
+        let (mapped, did_map) = config.map_model("gpt-5.2-codex", None);
+        assert_eq!(mapped, "gpt-5.2-codex");
+        assert!(!did_map);
+    }
+
+    #[test]
+    fn test_extract_effort() {
+        let body = json!({
+            "reasoning": {"effort": "xhigh", "summary": "auto"}
+        });
+        assert_eq!(extract_effort(&body), Some("xhigh".to_string()));
+
+        let body_no_effort = json!({"model": "test"});
+        assert_eq!(extract_effort(&body_no_effort), None);
+    }
+}

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -34,6 +34,35 @@ use tokio::sync::RwLock;
 
 const PROXY_AUTH_PLACEHOLDER: &str = "PROXY_MANAGED";
 
+/// 应用重写规则到 JSON 对象
+/// path 支持点分隔（如 "text.verbosity"），value 为 None 表示删除该字段，Some(v) 表示覆盖
+fn apply_rewrite_rule(obj: &mut serde_json::Map<String, Value>, path: &str, value: Option<Value>) {
+    let parts: Vec<&str> = path.split('.').collect();
+    if parts.is_empty() {
+        return;
+    }
+
+    if parts.len() == 1 {
+        // 单层路径：直接删除或覆盖
+        let key = parts[0];
+        match value {
+            None => {
+                obj.remove(key);
+            }
+            Some(v) => {
+                obj.insert(key.to_string(), v);
+            }
+        }
+    } else {
+        // 嵌套路径：递归处理
+        let key = parts[0];
+        if let Some(Value::Object(inner)) = obj.get_mut(key) {
+            let remaining_path = parts[1..].join(".");
+            apply_rewrite_rule(inner, &remaining_path, value);
+        }
+    }
+}
+
 pub struct ForwardResult {
     pub response: ProxyResponse,
     pub provider: Provider,
@@ -1124,6 +1153,11 @@ impl RequestForwarder {
         let mapped_body = if matches!(app_type, AppType::ClaudeDesktop) {
             crate::claude_desktop_config::map_proxy_request_model(body.clone(), provider)
                 .map_err(|e| ProxyError::InvalidRequest(e.to_string()))?
+        } else if adapter.name() == "Codex" {
+            // Codex 使用专用映射器，支持 effort 组合映射
+            let (mapped_body, _original_model, _mapped_model) =
+                super::codex_model_mapper::apply_codex_model_mapping(body.clone(), provider);
+            mapped_body
         } else {
             let (mapped_body, _original_model, _mapped_model) =
                 super::model_mapper::apply_model_mapping(body.clone(), provider);
@@ -1386,7 +1420,19 @@ impl RequestForwarder {
 
         // 过滤私有参数（以 `_` 开头的字段），防止内部信息泄露到上游
         // 默认使用空白名单，过滤所有 _ 前缀字段
-        let filtered_body = prepare_upstream_request_body(request_body);
+        let mut filtered_body = prepare_upstream_request_body(request_body);
+
+        // 应用请求体重写器（用户自定义字段过滤/覆盖）
+        if let Some(rewriter) = provider.meta.as_ref().and_then(|m| m.request_body_rewriter.as_ref()) {
+            if rewriter.enabled {
+                if let Some(obj) = filtered_body.as_object_mut() {
+                    for (path, value) in &rewriter.rules {
+                        apply_rewrite_rule(obj, path, value.clone());
+                    }
+                }
+            }
+        }
+
         // 出站 body 定稿后刷新真值（覆盖 Codex chat 上游模型覆写、转换层模型改写）
         if let Some(m) = filtered_body
             .get("model")

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod json_canonical;
 pub mod log_codes;
 pub mod media_sanitizer;
 pub mod model_mapper;
+pub mod codex_model_mapper;
 pub mod provider_router;
 pub mod providers;
 pub mod response_handler;

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -9,7 +9,7 @@ use super::{AuthInfo, AuthStrategy, ProviderAdapter};
 use crate::provider::{CodexChatReasoningConfig, Provider};
 use crate::proxy::error::ProxyError;
 use regex::Regex;
-use serde_json::Value as JsonValue;
+use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::sync::LazyLock;
 use toml::Value as TomlValue;
@@ -124,7 +124,7 @@ fn codex_provider_catalog_model_ids(provider: &Provider) -> HashSet<String> {
 /// model before converting the request to Chat Completions.
 pub fn apply_codex_chat_upstream_model(
     provider: &Provider,
-    body: &mut JsonValue,
+    body: &mut Value,
 ) -> Option<String> {
     if !codex_provider_uses_chat_completions(provider) {
         return None;
@@ -143,13 +143,13 @@ pub fn apply_codex_chat_upstream_model(
     }
 
     let upstream_model = codex_provider_upstream_model(provider)?;
-    body["model"] = JsonValue::String(upstream_model.clone());
+    body["model"] = Value::String(upstream_model.clone());
     Some(upstream_model)
 }
 
 pub fn resolve_codex_chat_reasoning_config(
     provider: &Provider,
-    body: &JsonValue,
+    body: &Value,
 ) -> Option<CodexChatReasoningConfig> {
     if let Some(config) = provider
         .meta
@@ -173,7 +173,7 @@ fn normalize_codex_chat_reasoning_config(
 
 fn infer_codex_chat_reasoning_config(
     provider: &Provider,
-    body: &JsonValue,
+    body: &Value,
 ) -> Option<CodexChatReasoningConfig> {
     let model = body
         .get("model")
@@ -573,6 +573,101 @@ impl ProviderAdapter for CodexAdapter {
             http::HeaderName::from_static("authorization"),
             auth_header_value(&bearer)?,
         )])
+    }
+
+    /// Codex 适配器是否需要格式转换
+    ///
+    /// 当 provider 配置中设置了 `api_format = "chat_completions"` 时返回 true，
+    /// 表示上游不支持 Responses API，需要转换为 Chat Completions 格式。
+    fn needs_transform(&self, provider: &Provider) -> bool {
+        // 1. 检查 settings_config 顶层的 api_format
+        if let Some(fmt) = provider
+            .settings_config
+            .get("api_format")
+            .and_then(|v| v.as_str())
+        {
+            if fmt == "chat_completions" {
+                return true;
+            }
+        }
+
+        // 2. 检查 config TOML 字符串中的 api_format
+        if let Some(config) = provider.settings_config.get("config") {
+            if let Some(config_str) = config.as_str() {
+                for marker in &[
+                    "api_format = \"chat_completions\"",
+                    "api_format = 'chat_completions'",
+                ] {
+                    if config_str.contains(marker) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // 3. 检查 meta.apiFormat（从 Codex 供应商表单的 API 格式下拉框设置）
+        if let Some(fmt) = provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.api_format.as_deref())
+        {
+            if fmt == "chat_completions" {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// 转换请求：Responses API → Chat Completions，并重写 model 为上游支持的名称
+    fn transform_request(&self, body: Value, provider: &Provider) -> Result<Value, ProxyError> {
+        let mut body = body;
+
+        // 用 provider 配置中的 model 覆盖，确保上游模型名正确
+        if let Some(upstream_model) = CodexAdapter::extract_model(provider) {
+            log::info!("[Codex] 重写模型名: {} → {}", body.get("model").and_then(|m| m.as_str()).unwrap_or("?"), upstream_model);
+            body["model"] = json!(upstream_model);
+        }
+
+        super::transform_responses::responses_to_chat_completions(body)
+    }
+
+    /// 转换响应：Chat Completions → Responses API
+    fn transform_response(&self, body: Value) -> Result<Value, ProxyError> {
+        super::transform_responses::chat_completions_to_responses(body)
+    }
+}
+
+impl CodexAdapter {
+    /// 从 provider 配置中提取上游模型名
+    fn extract_model(provider: &Provider) -> Option<String> {
+        // 1. settings_config 顶层 model
+        if let Some(m) = provider.settings_config.get("model").and_then(|v| v.as_str()) {
+            return Some(m.to_string());
+        }
+        // 2. config TOML 字符串中的 model
+        if let Some(config) = provider.settings_config.get("config") {
+            if let Some(config_str) = config.as_str() {
+                if let Some(v) = Self::extract_toml_value(config_str, "model") {
+                    return Some(v);
+                }
+            }
+        }
+        None
+    }
+
+    /// 从 TOML 字符串中提取指定 key 的值
+    fn extract_toml_value(toml_str: &str, key: &str) -> Option<String> {
+        for pattern in [format!("{key} = \""), format!("{key} = '")] {
+            if let Some(start) = toml_str.find(&pattern) {
+                let rest = &toml_str[start + pattern.len()..];
+                let end_char = if pattern.contains('"') { '"' } else { '\'' };
+                if let Some(end) = rest.find(end_char) {
+                    return Some(rest[..end].to_string());
+                }
+            }
+        }
+        None
     }
 }
 

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -622,6 +622,677 @@ pub fn responses_to_anthropic(body: Value) -> Result<Value, ProxyError> {
 
     Ok(result)
 }
+    Ok(result)
+}
+/// Validate and fix the Chat Completions message sequence for DeepSeek compliance.
+///
+/// DeepSeek strictly requires every assistant message with tool_calls to be
+/// immediately followed by tool messages matching each tool_call_id — no other
+/// message types may appear between the assistant and its tool results.
+///
+/// This function:
+/// - Builds an index of all tool messages by tool_call_id.
+/// - For each assistant with tool_calls, collects matching tool messages and
+///   places them right after the assistant.
+/// - Strips orphan tool_calls that have no matching tool message anywhere.
+/// - Drops orphan tool messages that have no matching assistant tool_call.
+fn reorder_tool_messages(messages: Vec<Value>) -> Vec<Value> {
+    use std::collections::{HashMap, HashSet};
+
+    // Phase 0: Build index of tool messages by tool_call_id.
+    // Multi-map because a single tool_call_id may appear multiple times
+    // (e.g. across different conversation turns).
+    let mut tool_by_call_id: HashMap<String, Vec<Value>> = HashMap::new();
+    let mut tool_indices: Vec<usize> = Vec::new(); // positions of tool messages
+
+    for (idx, msg) in messages.iter().enumerate() {
+        if msg.get("role").and_then(|r| r.as_str()) == Some("tool") {
+            if let Some(call_id) = msg.get("tool_call_id").and_then(|i| i.as_str()) {
+                tool_by_call_id
+                    .entry(call_id.to_string())
+                    .or_default()
+                    .push(msg.clone());
+            }
+            tool_indices.push(idx);
+        }
+    }
+
+    // Phase 1: Identify which tool_call_ids exist (have at least one tool message).
+    let existing_tool_ids: HashSet<&str> = tool_by_call_id.keys().map(|s| s.as_str()).collect();
+
+    // Phase 2: For each assistant, collect all tool_calls that have matching
+    // tool messages, and record their positions.
+    struct AssistantInfo {
+        idx: usize,
+        tool_call_ids: Vec<String>, // only those with matching tool messages
+    }
+    let mut assistant_infos: Vec<AssistantInfo> = Vec::new();
+
+    for (idx, msg) in messages.iter().enumerate() {
+        if msg.get("role").and_then(|r| r.as_str()) == Some("assistant") {
+            if let Some(tool_calls) = msg.get("tool_calls").and_then(|t| t.as_array()) {
+                let matching_ids: Vec<String> = tool_calls
+                    .iter()
+                    .filter_map(|tc| {
+                        tc.get("id")
+                            .and_then(|id| id.as_str())
+                            .map(|id| id.to_string())
+                    })
+                    .filter(|id| existing_tool_ids.contains(&**id))
+                    .collect();
+
+                if !matching_ids.is_empty() {
+                    assistant_infos.push(AssistantInfo {
+                        idx,
+                        tool_call_ids: matching_ids,
+                    });
+                }
+            }
+        }
+    }
+
+    // Phase 3: Build output — copy messages, inserting tool messages after
+    // each assistant. Track which tool messages have been consumed.
+    let tool_indices_set: HashSet<usize> = tool_indices.into_iter().collect();
+    let mut consumed_tool_positions: HashSet<usize> = HashSet::new();
+    let mut result: Vec<Value> = Vec::new();
+
+    let mut assistant_iter = assistant_infos.iter().peekable();
+    let mut pending_orphan_tools: usize = 0;
+
+    for (idx, msg) in messages.iter().enumerate() {
+        let is_tool = tool_indices_set.contains(&idx);
+
+        if is_tool {
+            // Tool messages are handled when their matching assistant is processed
+            if !consumed_tool_positions.contains(&idx) {
+                consumed_tool_positions.insert(idx);
+                pending_orphan_tools += 1;
+            }
+            continue;
+        }
+
+        // Check if this is an assistant that needs tool messages inserted
+        if let Some(info) = assistant_iter.next_if(|a| a.idx == idx) {
+            // Clone and strip orphan tool_calls (no matching tool message)
+            let mut msg = msg.clone();
+            if let Some(tool_calls) = msg.get_mut("tool_calls").and_then(|t| t.as_array_mut()) {
+                let before = tool_calls.len();
+                tool_calls.retain(|tc| {
+                    tc.get("id")
+                        .and_then(|id| id.as_str())
+                        .map(|id| existing_tool_ids.contains(id))
+                        .unwrap_or(false)
+                });
+                let removed = before - tool_calls.len();
+                if removed > 0 {
+                    log::warn!(
+                        "[Codex] 移除了 {} 个孤儿 tool_calls（无对应 tool 消息）",
+                        removed
+                    );
+                }
+                if tool_calls.is_empty() {
+                    let content_is_null = msg.get("content").map_or(false, |c| c.is_null());
+                if let Some(obj) = msg.as_object_mut() {
+                    obj.remove("tool_calls");
+                    if content_is_null {
+                        obj.insert("content".to_string(), json!(""));
+                    }
+                }
+                }
+            }
+            result.push(msg);
+
+            // Insert matching tool messages immediately after
+            for call_id in &info.tool_call_ids {
+                if let Some(tool_msgs) = tool_by_call_id.get(call_id) {
+                    for t in tool_msgs {
+                        result.push(t.clone());
+                    }
+                }
+            }
+        } else {
+            // Regular message (user, system, assistant without tool_calls, etc.)
+            result.push(msg.clone());
+        }
+    }
+
+    if pending_orphan_tools > 0 {
+        log::warn!(
+            "[Codex] 丢弃 {} 个孤儿 tool 消息（无前置 assistant 的 tool_calls 匹配）",
+            pending_orphan_tools
+        );
+    }
+
+    if result.len() != messages.len() {
+        log::info!(
+            "[Codex] Tool 消息清理: {} → {} 条消息",
+            messages.len(),
+            result.len()
+        );
+    }
+
+    result
+}/// Recursively strip all image content blocks from a content value,
+/// replacing them with "[Image]" text placeholders. This is a safety net
+/// for text-only models (DeepSeek, etc.) that reject image_url blocks.
+fn sanitize_image_content(content: &Value) -> Value {
+    match content {
+        Value::Array(arr) => {
+            let sanitized: Vec<Value> = arr
+                .iter()
+                .map(|item| {
+                    if let Some(bt) = item.get("type").and_then(|t| t.as_str()) {
+                        match bt {
+                            // Chat Completions image format
+                            "image_url" => {
+                                json!({"type": "text", "text": "[Image]"})
+                            }
+                            // Responses API image format (should not appear here,
+                            // but handled defensively)
+                            "input_image" | "output_image" => {
+                                json!({"type": "text", "text": "[Image]"})
+                            }
+                            // Pass through non-image blocks unchanged
+                            _ => item.clone(),
+                        }
+                    } else {
+                        item.clone()
+                    }
+                })
+                .collect();
+            Value::Array(sanitized)
+        }
+        // String content is always safe
+        _ => content.clone(),
+    }
+}
+
+
+
+/// OpenAI Responses 请求 → Chat Completions 请求
+///
+/// 将 Codex CLI 发出的 Responses API 格式转换为 Chat Completions 格式，
+/// 用于连接不支持 Responses API 的上游（如 DeepSeek）。
+///
+/// 转换规则：
+/// - `instructions` → system message（插入 messages 数组首位）
+/// - `input[]` → `messages[]`
+///   - role=user + input_text → user message
+///   - role=assistant + output_text → assistant message
+///   - function_call item → assistant message with tool_calls
+///   - function_call_output item → tool message
+/// - `max_output_tokens` → `max_tokens`
+/// - `reasoning.effort` → `reasoning_effort` (DeepSeek 兼容)
+/// - `tools` → 透传（Responses API 的 function tool 格式与 Chat Completions 兼容）
+pub fn responses_to_chat_completions(body: Value) -> Result<Value, ProxyError> {
+    // If the request is already in Chat Completions format (has "messages" not "input"),
+    // Codex may have sent it directly for providers it knows support Chat Completions.
+    // In that case, pass through without double-transforming.
+    if body.get("messages").is_some() && body.get("input").is_none() {
+        log::info!("[Codex] 请求已是 Chat Completions 格式，跳过转换，执行图片安全检查");
+        let mut body = body;
+        // Safety net: strip image content for text-only models (DeepSeek)
+        if let Some(messages) = body.get_mut("messages").and_then(|m| m.as_array_mut()) {
+            for msg in messages.iter_mut() {
+                if let Some(msg_content) = msg.get("content").cloned() {
+                    msg["content"] = sanitize_image_content(&msg_content);
+                }
+            }
+        }
+        return Ok(body);
+    }
+
+    let mut result = json!({});
+
+    // model
+    if let Some(model) = body.get("model").and_then(|m| m.as_str()) {
+        result["model"] = json!(model);
+    }
+
+    // instructions → system message
+    let mut messages: Vec<Value> = Vec::new();
+    if let Some(instructions) = body.get("instructions").and_then(|i| i.as_str()) {
+        if !instructions.is_empty() {
+            messages.push(json!({
+                "role": "system",
+                "content": instructions
+            }));
+        }
+    }
+
+    // input[] → messages[]
+    // Accumulate reasoning text so it can be injected as `reasoning_content`
+    // in the next assistant message. DeepSeek requires this for multi-turn
+    // thinking mode — reasoning_content must be passed back to the API.
+    let mut pending_reasoning: Option<String> = None;
+
+    if let Some(input) = body.get("input").and_then(|i| i.as_array()) {
+        for item in input {
+            let item_type = item.get("type").and_then(|t| t.as_str());
+
+            match item_type {
+                // Reasoning items accumulate text for the next assistant message.
+                Some("reasoning") => {
+                    if let Some(summary) = item.get("summary").and_then(|s| s.as_array()) {
+                        let text: String = summary
+                            .iter()
+                            .filter_map(|s| {
+                                if s.get("type").and_then(|t| t.as_str()) == Some("summary_text") {
+                                    s.get("text").and_then(|t| t.as_str())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join("");
+                        if !text.is_empty() {
+                            pending_reasoning = Some(text);
+                        }
+                    }
+                }
+
+                Some("message") => {
+                    let raw_role = item.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+                    // Map Responses API roles to Chat Completions roles.
+                    // DeepSeek does not support "developer" — convert to "system".
+                    let role = match raw_role {
+                        "developer" => "system",
+                        other => other,
+                    };
+                    if let Some(content) = item.get("content").and_then(|c| c.as_array()) {
+                        let mut text_parts: Vec<String> = Vec::new();
+                                                for block in content {
+                            let bt = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                            match bt {
+                                "input_text" | "output_text" => {
+                                    if let Some(text) =
+                                        block.get("text").and_then(|t| t.as_str())
+                                    {
+                                        text_parts.push(text.to_string());
+                                    }
+                                }
+                                "input_image" => {
+                                    // DeepSeek and other text-only models don't support
+                                    // multimodal input. Replace image with a text
+                                    // placeholder so the request doesn't fail.
+                                    if let Some(img_url) = block.get("image_url") {
+                                        if let Some(url_str) = img_url.as_str() {
+                                            if url_str.len() <= 120 {
+                                                text_parts.push(format!("[Image: {}]", url_str));
+                                            } else {
+                                                // Truncate long data URIs to keep prompt size reasonable
+                                                text_parts.push(format!(
+                                                    "[Image: {}...]",
+                                                    &url_str[..117]
+                                                ));
+                                            }
+                                        } else {
+                                            text_parts.push("[Image]".to_string());
+                                        }
+                                    } else {
+                                        text_parts.push("[Image]".to_string());
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        // Build content: always text-only (multimodal images
+                        // are converted to [Image] placeholders above for
+                        // text-only model compatibility)
+                        if text_parts.len() <= 1 {
+                            let text = text_parts.first().cloned().unwrap_or_default();
+                            messages.push(json!({
+                                "role": role,
+                                "content": text
+                            }));
+                        } else {
+                            let parts: Vec<Value> = text_parts
+                                .iter()
+                                .map(|t| json!({"type": "text", "text": t}))
+                                .collect();
+                            messages.push(json!({
+                                "role": role,
+                                "content": parts
+                            }));
+                        }
+                    } else if let Some(text) = item.get("content").and_then(|c| c.as_str()) {
+                        messages.push(json!({
+                            "role": role,
+                            "content": text
+                        }));
+                    } else {
+                        messages.push(json!({"role": role, "content": ""}));
+                    }
+
+                    // Inject accumulated reasoning_content into assistant messages.
+                    // DeepSeek requires reasoning_content to be passed back on subsequent turns.
+                    if role == "assistant" {
+                        if let Some(reasoning) = pending_reasoning.take() {
+                            if let Some(last) = messages.last_mut() {
+                                last["reasoning_content"] = json!(reasoning);
+                            }
+                        }
+                    }
+                }
+
+                Some("function_call") => {
+                    let call_id = item.get("call_id").and_then(|i| i.as_str()).unwrap_or("");
+                    let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                    let arguments =
+                        item.get("arguments").and_then(|a| a.as_str()).unwrap_or("{}");
+                    // Validate arguments is parseable JSON; if not, use as-is
+                    let args_str = if serde_json::from_str::<Value>(arguments).is_ok() {
+                        arguments.to_string()
+                    } else {
+                        serde_json::to_string(arguments).unwrap_or_else(|_| "{}".to_string())
+                    };
+
+                    let tc = json!({
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": name,
+                            "arguments": args_str
+                        }
+                    });
+
+                    // Merge into the previous assistant message if one exists.
+                    // Responses API has function_call as a separate input item, but
+                    // Chat Completions requires tool_calls to be in the SAME assistant message.
+                    if let Some(last) = messages.last_mut() {
+                        if last.get("role").and_then(|r| r.as_str()) == Some("assistant") {
+                            // Merge tool_calls into the existing assistant message
+                            if let Some(existing_tcs) = last.get_mut("tool_calls") {
+                                if let Some(arr) = existing_tcs.as_array_mut() {
+                                    arr.push(tc);
+                                }
+                            } else {
+                                last["tool_calls"] = json!([tc]);
+                                // If content was a string, keep it; null means no text was sent
+                                if last.get("content").is_none() {
+                                    last["content"] = json!(null);
+                                }
+                            }
+                            continue;
+                        }
+                    }
+                    // No prior assistant message — create a new one
+                    let mut new_msg = json!({
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [tc]
+                    });
+                    if let Some(reasoning) = pending_reasoning.take() {
+                        new_msg["reasoning_content"] = json!(reasoning);
+                    }
+                    messages.push(new_msg);
+                }
+
+                Some("function_call_output") => {
+                    let call_id = item.get("call_id").and_then(|i| i.as_str()).unwrap_or("");
+                    // Output may be a string, object, or array — serialize non-string outputs
+                    let output = match item.get("output") {
+                        Some(Value::String(s)) => s.clone(),
+                        Some(v) => serde_json::to_string(v).unwrap_or_default(),
+                        None => String::new(),
+                    };
+                    messages.push(json!({
+                        "role": "tool",
+                        "tool_call_id": call_id,
+                        "content": output
+                    }));
+                }
+
+                _ => {
+                    // Unknown item type — determine proper role mapping.
+                    // Items with a call_id are tool outputs (e.g. web_search_call_output,
+                    // computer_call_output, etc.) and must be mapped to tool messages
+                    // so the Chat Completions tool_calls → tool sequence stays intact.
+                    if let Some(call_id) = item.get("call_id").and_then(|c| c.as_str()) {
+                        let output = item.get("output").and_then(|o| o.as_str()).unwrap_or("");
+                        messages.push(json!({
+                            "role": "tool",
+                            "tool_call_id": call_id,
+                            "content": output
+                        }));
+                    } else if let Some(role) = item.get("role").and_then(|r| r.as_str()) {
+                        let raw_content = item.get("content").cloned().unwrap_or(json!(""));
+                        let safe_content = sanitize_image_content(&raw_content);
+                        messages.push(json!({
+                            "role": role,
+                            "content": safe_content
+                        }));
+                    }
+                }
+            }
+        }
+    }
+    // Final safety net: strip any image content from all messages.
+    // Text-only models (DeepSeek, etc.) reject image_url / input_image blocks.
+    for msg in &mut messages {
+        if let Some(msg_content) = msg.get("content").cloned() {
+            msg["content"] = sanitize_image_content(&msg_content);
+        }
+    }
+
+    // Reorder tool messages to satisfy DeepSeek's strict validation:
+    // Every assistant message with tool_calls must be immediately followed
+    // by ALL matching tool messages (one per tool_call_id), with no
+    // non-tool messages in between.
+    messages = reorder_tool_messages(messages);
+
+    result["messages"] = json!(messages);
+
+    // max_output_tokens → max_tokens
+    if let Some(v) = body.get("max_output_tokens") {
+        result["max_tokens"] = v.clone();
+    }
+
+    // temperature
+    if let Some(v) = body.get("temperature") {
+        result["temperature"] = v.clone();
+    }
+
+    // top_p
+    if let Some(v) = body.get("top_p") {
+        result["top_p"] = v.clone();
+    }
+
+    // stream — force false for now (SSE streaming conversion not yet implemented)
+    // When stream is false, DeepSeek returns a single JSON response that we can transform
+    result["stream"] = json!(false);
+
+    // reasoning.effort → reasoning_effort (DeepSeek)
+    if let Some(effort) = body.pointer("/reasoning/effort").and_then(|e| e.as_str()) {
+        result["reasoning_effort"] = json!(effort);
+    }
+
+    // tools — Responses format → Chat Completions format
+    // Responses: {"type":"function","name":"...","parameters":{...}}
+    // Chat Completions: {"type":"function","function":{"name":"...","parameters":{...}}}
+    if let Some(tools) = body.get("tools").and_then(|t| t.as_array()) {
+        let cc_tools: Vec<Value> = tools
+            .iter()
+            .filter_map(|t| {
+                let name = t.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                // Skip tools with empty names (Chat Completions requirement)
+                if name.is_empty() {
+                    return None;
+                }
+                let desc_val = t.get("description").cloned().unwrap_or(json!(null));
+                // Ensure parameters is a valid JSON Schema object (Chat Completions requirement)
+                let params = match t.get("parameters") {
+                    Some(p) if p.is_object() && !p.as_object().map(|o| o.is_empty()).unwrap_or(true) => p.clone(),
+                    _ => json!({"type": "object", "properties": {}}),
+                };
+                let mut function_obj = json!({
+                    "name": name,
+                    "parameters": params,
+                });
+                // Only include description if it is a non-empty string
+                if let Some(d) = desc_val.as_str() {
+                    if !d.is_empty() {
+                        function_obj["description"] = json!(d);
+                    }
+                }
+                if let Some(req) = t.get("required") {
+                    if !req.is_null() {
+                        function_obj["required"] = req.clone();
+                    }
+                }
+                Some(json!({
+                    "type": "function",
+                    "function": function_obj
+                }))
+            })
+            .collect();
+        result["tools"] = json!(cc_tools);
+    }
+
+    // tool_choice
+    if let Some(v) = body.get("tool_choice") {
+        result["tool_choice"] = v.clone();
+    }
+
+    Ok(result)
+}
+
+/// Chat Completions 响应 → OpenAI Responses 响应
+///
+/// 将上游 Chat Completions API 的响应转换回 Responses API 格式，
+/// 使 Codex CLI 可以正常解析。
+pub fn chat_completions_to_responses(body: Value) -> Result<Value, ProxyError> {
+    let mut result = json!({
+        "object": "response"
+    });
+
+    // id
+    if let Some(id) = body.get("id").and_then(|i| i.as_str()) {
+        result["id"] = json!(id);
+    }
+
+    // model
+    if let Some(model) = body.get("model").and_then(|m| m.as_str()) {
+        result["model"] = json!(model);
+    }
+
+    // status — derive from finish_reason
+    let mut status = "completed";
+    let mut output: Vec<Value> = Vec::new();
+
+    if let Some(choices) = body.get("choices").and_then(|c| c.as_array()) {
+        for choice in choices {
+            if let Some(msg) = choice.get("message") {
+                let mut content: Vec<Value> = Vec::new();
+                let mut tool_calls_out: Vec<Value> = Vec::new();
+
+                // text content
+                if let Some(text) = msg.get("content").and_then(|c| c.as_str()) {
+                    if !text.is_empty() {
+                        content.push(json!({
+                            "type": "output_text",
+                            "text": text
+                        }));
+                    }
+                }
+
+                // reasoning_content (DeepSeek R1)
+                if let Some(reasoning) = msg.get("reasoning_content").and_then(|r| r.as_str()) {
+                    if !reasoning.is_empty() {
+                        output.push(json!({
+                            "type": "reasoning",
+                            "summary": [{"type": "summary_text", "text": reasoning}]
+                        }));
+                    }
+                }
+
+                // tool_calls → function_call items
+                if let Some(tool_calls) = msg.get("tool_calls").and_then(|t| t.as_array()) {
+                    for tc in tool_calls {
+                        let tc_id = tc.get("id").and_then(|i| i.as_str()).unwrap_or("");
+                        if let Some(func) = tc.get("function") {
+                            let name = func.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                            let args =
+                                func.get("arguments").and_then(|a| a.as_str()).unwrap_or("{}");
+                            tool_calls_out.push(json!({
+                                "type": "function_call",
+                                "call_id": tc_id,
+                                "name": name,
+                                "arguments": args
+                            }));
+                        }
+                    }
+                }
+
+                // Build message output item
+                if !content.is_empty() {
+                    output.push(json!({
+                        "type": "message",
+                        "role": "assistant",
+                        "content": content
+                    }));
+                }
+
+                // Append function_call items after the message
+                output.extend(tool_calls_out);
+            }
+
+            // finish_reason → status
+            if let Some(reason) = choice.get("finish_reason").and_then(|r| r.as_str()) {
+                match reason {
+                    "tool_calls" => status = "completed", // will be mapped via has_tool_use
+                    "length" => status = "incomplete",
+                    "content_filter" => status = "incomplete",
+                    "stop" => status = "completed",
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    // Detect if we have tool calls for proper status
+    let has_tool_use = output.iter().any(|o| {
+        o.get("type")
+            .and_then(|t| t.as_str())
+            .map(|t| t == "function_call")
+            .unwrap_or(false)
+    });
+
+    // Override status when tool calls present
+    if has_tool_use && status == "completed" {
+        // status stays "completed" — Codex uses stop_reason for tool_use
+    }
+
+    result["status"] = json!(status);
+    result["output"] = json!(output);
+
+    // usage: Chat Completions → Responses
+    if let Some(usage) = body.get("usage") {
+        let input_tokens = usage
+            .get("prompt_tokens")
+            .or_else(|| usage.get("input_tokens"))
+            .cloned()
+            .unwrap_or(json!(0));
+        let output_tokens = usage
+            .get("completion_tokens")
+            .or_else(|| usage.get("output_tokens"))
+            .cloned()
+            .unwrap_or(json!(0));
+        let total_tokens = usage.get("total_tokens").cloned().unwrap_or_else(|| {
+            json!(input_tokens.as_u64().unwrap_or(0) + output_tokens.as_u64().unwrap_or(0))
+        });
+
+        result["usage"] = json!({
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens
+        });
+    }
+
+    Ok(result)
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/components/providers/forms/CodexModelMappingConfig.tsx
+++ b/src/components/providers/forms/CodexModelMappingConfig.tsx
@@ -1,0 +1,499 @@
+import { useTranslation } from "react-i18next";
+import { useState, useEffect, useRef } from "react";
+import { ChevronDown, ChevronRight, ArrowRightLeft, Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+/** Codex 模型映射配置 */
+export interface CodexModelMappingConfig {
+  enabled: boolean;
+  /** 简单模型映射：请求模型 → 目标模型 */
+  modelMap: Record<string, string>;
+  /** Effort 组合映射：模型ID@effort → 目标模型 */
+  effortMap: Record<string, string>;
+}
+
+/** 默认配置 */
+export const defaultCodexModelMappingConfig: CodexModelMappingConfig = {
+  enabled: false,
+  modelMap: {},
+  effortMap: {},
+};
+
+interface CodexModelMappingConfigProps {
+  config: CodexModelMappingConfig;
+  onConfigChange: (config: CodexModelMappingConfig) => void;
+}
+
+/** effort 选项 */
+const EFFORT_OPTIONS = ["low", "medium", "high", "xhigh"];
+
+/** 简单映射行类型 */
+interface SimpleMappingRow {
+  id: string;
+  source: string;
+  target: string;
+  isNew: boolean;
+}
+
+/** Effort 映射行类型 */
+interface EffortMappingRow {
+  id: string;
+  model: string;
+  effort: string;
+  target: string;
+  isNew: boolean;
+}
+
+export function CodexModelMappingConfig({
+  config,
+  onConfigChange,
+}: CodexModelMappingConfigProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(config.enabled);
+
+  // 将 config 转换为行数据
+  const [simpleRows, setSimpleRows] = useState<SimpleMappingRow[]>([]);
+  const [effortRows, setEffortRows] = useState<EffortMappingRow[]>([]);
+
+  // Refs for auto-focus
+  const simpleInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+  const effortInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+
+  // Refs to track whether component has been initialized from config
+  const simpleInitialized = useRef(false);
+  const effortInitialized = useRef(false);
+
+  // 从 config 初始化 Simple 行数据
+  // 仅在首次加载或 config 从外部真正变化时同步（非本组件触发的变化）
+  useEffect(() => {
+    // 构建 config 对应的行数据
+    const existingSimple: SimpleMappingRow[] = Object.entries(config.modelMap).map(
+      ([source, target]) => ({
+        id: `simple-${source}`,
+        source,
+        target,
+        isNew: false,
+      })
+    );
+
+    // 首次初始化：直接设置
+    if (!simpleInitialized.current) {
+      simpleInitialized.current = true;
+      setSimpleRows(existingSimple);
+      return;
+    }
+
+    // 后续更新：仅当 config 来自外部（非本组件的 sync）时才覆盖
+    // 比较当前 rows 生成的 map 与 config.modelMap 是否相等
+    // 如果相等，说明是本组件的 sync 触发的，不需要覆盖
+    setSimpleRows((currentRows) => {
+      const currentMap: Record<string, string> = {};
+      currentRows.forEach((row) => {
+        if (row.source.trim() && row.target.trim()) {
+          currentMap[row.source.trim()] = row.target.trim();
+        }
+      });
+      // 如果当前行生成的 map 与 config 完全匹配，跳过覆盖
+      if (JSON.stringify(currentMap) === JSON.stringify(config.modelMap)) {
+        return currentRows;
+      }
+      // 否则，config 是从外部更新的，需要同步
+      return existingSimple;
+    });
+  }, [config.modelMap]);
+
+  // 从 config 初始化 Effort 行数据
+  useEffect(() => {
+    const existingEffort: EffortMappingRow[] = Object.entries(config.effortMap).map(
+      ([key, target]) => {
+        const [model, effort] = key.split("@");
+        return {
+          id: `effort-${key}`,
+          model,
+          effort: effort || "medium",
+          target,
+          isNew: false,
+        };
+      }
+    );
+
+    // 首次初始化：直接设置
+    if (!effortInitialized.current) {
+      effortInitialized.current = true;
+      setEffortRows(existingEffort);
+      return;
+    }
+
+    // 后续更新：仅当 config 来自外部时才覆盖
+    setEffortRows((currentRows) => {
+      const currentMap: Record<string, string> = {};
+      currentRows.forEach((row) => {
+        if (row.model.trim() && row.target.trim()) {
+          const key = `${row.model.trim()}@${row.effort}`;
+          currentMap[key] = row.target.trim();
+        }
+      });
+      if (JSON.stringify(currentMap) === JSON.stringify(config.effortMap)) {
+        return currentRows;
+      }
+      return existingEffort;
+    });
+  }, [config.effortMap]);
+
+  // 同步 enabled 状态
+  useEffect(() => {
+    setIsOpen(config.enabled);
+  }, [config.enabled]);
+
+  // 更新简单映射行
+  const handleSimpleRowChange = (
+    id: string,
+    field: "source" | "target",
+    value: string
+  ) => {
+    setSimpleRows((prev) => {
+      const updated = prev.map((row) =>
+        row.id === id ? { ...row, [field]: value } : row
+      );
+      // 同步到 config
+      syncSimpleToConfig(updated);
+      return updated;
+    });
+  };
+
+  // 同步简单映射到 config
+  const syncSimpleToConfig = (rows: SimpleMappingRow[]) => {
+    const newModelMap: Record<string, string> = {};
+    rows.forEach((row) => {
+      if (row.source.trim() && row.target.trim()) {
+        newModelMap[row.source.trim()] = row.target.trim();
+      }
+    });
+    if (JSON.stringify(newModelMap) !== JSON.stringify(config.modelMap)) {
+      onConfigChange({ ...config, modelMap: newModelMap });
+    }
+  };
+
+  // 添加简单映射新行
+  const handleAddSimpleRow = () => {
+    const newId = `simple-new-${Date.now()}`;
+    const newRow: SimpleMappingRow = {
+      id: newId,
+      source: "",
+      target: "",
+      isNew: true,
+    };
+    setSimpleRows((prev) => [...prev, newRow]);
+    // Auto-focus
+    setTimeout(() => {
+      simpleInputRefs.current.get(newId)?.focus();
+    }, 50);
+  };
+
+  // 删除简单映射行
+  const handleRemoveSimpleRow = (id: string) => {
+    setSimpleRows((prev) => {
+      const updated = prev.filter((row) => row.id !== id);
+      syncSimpleToConfig(updated);
+      return updated;
+    });
+  };
+
+  // 更新 effort 映射行
+  const handleEffortRowChange = (
+    id: string,
+    field: "model" | "effort" | "target",
+    value: string
+  ) => {
+    setEffortRows((prev) => {
+      const updated = prev.map((row) =>
+        row.id === id ? { ...row, [field]: value } : row
+      );
+      syncEffortToConfig(updated);
+      return updated;
+    });
+  };
+
+  // 同步 effort 映射到 config
+  const syncEffortToConfig = (rows: EffortMappingRow[]) => {
+    const newEffortMap: Record<string, string> = {};
+    rows.forEach((row) => {
+      if (row.model.trim() && row.target.trim()) {
+        const key = `${row.model.trim()}@${row.effort}`;
+        newEffortMap[key] = row.target.trim();
+      }
+    });
+    if (JSON.stringify(newEffortMap) !== JSON.stringify(config.effortMap)) {
+      onConfigChange({ ...config, effortMap: newEffortMap });
+    }
+  };
+
+  // 添加 effort 映射新行
+  const handleAddEffortRow = () => {
+    const newId = `effort-new-${Date.now()}`;
+    const newRow: EffortMappingRow = {
+      id: newId,
+      model: "",
+      effort: "medium",
+      target: "",
+      isNew: true,
+    };
+    setEffortRows((prev) => [...prev, newRow]);
+    setTimeout(() => {
+      effortInputRefs.current.get(newId)?.focus();
+    }, 50);
+  };
+
+  // 删除 effort 映射行
+  const handleRemoveEffortRow = (id: string) => {
+    setEffortRows((prev) => {
+      const updated = prev.filter((row) => row.id !== id);
+      syncEffortToConfig(updated);
+      return updated;
+    });
+  };
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-muted/20">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between p-4 hover:bg-muted/30 transition-colors"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex items-center gap-3">
+          <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium">
+            {t("providerAdvanced.codexModelMapping", {
+              defaultValue: "Codex 模型映射",
+            })}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <div
+            className="flex items-center gap-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Label
+              htmlFor="codex-mapping-enabled"
+              className="text-sm text-muted-foreground"
+            >
+              {t("providerAdvanced.enableMapping", {
+                defaultValue: "启用映射",
+              })}
+            </Label>
+            <Switch
+              id="codex-mapping-enabled"
+              checked={config.enabled}
+              onCheckedChange={(checked) => {
+                onConfigChange({ ...config, enabled: checked });
+                if (checked) setIsOpen(true);
+              }}
+            />
+          </div>
+          {isOpen ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-300 ease-in-out",
+          isOpen ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0"
+        )}
+      >
+        <div className="border-t border-border/50 p-4 space-y-6">
+          <p className="text-sm text-muted-foreground">
+            {t("providerAdvanced.codexModelMappingDesc", {
+              defaultValue:
+                "为 Codex 请求配置模型ID映射，支持简单映射和 effort 组合映射。",
+            })}
+          </p>
+
+          {/* 简单模型映射 */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">
+              {t("providerAdvanced.simpleModelMapping", {
+                defaultValue: "简单模型映射",
+              })}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t("providerAdvanced.simpleModelMappingHint", {
+                defaultValue: "将请求中的模型ID替换为目标模型ID（优先级最高）",
+              })}
+            </p>
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleAddSimpleRow}
+                disabled={!config.enabled}
+                className="h-8"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                {t("common.add", { defaultValue: "添加" })}
+              </Button>
+            </div>
+
+            {/* 映射行列表 */}
+            <div className="space-y-2">
+              {simpleRows.map((row) => (
+                <div
+                  key={row.id}
+                  className="flex items-center gap-2"
+                >
+                  <Input
+                    ref={(el) => {
+                      if (el) simpleInputRefs.current.set(row.id, el);
+                    }}
+                    placeholder={t("providerAdvanced.sourceModel", {
+                      defaultValue: "请求模型",
+                    })}
+                    value={row.source}
+                    onChange={(e) =>
+                      handleSimpleRowChange(row.id, "source", e.target.value)
+                    }
+                    className="flex-1 font-mono text-sm transition-colors duration-200"
+                    disabled={!config.enabled}
+                  />
+                  <span className="text-muted-foreground">→</span>
+                  <Input
+                    placeholder={t("providerAdvanced.targetModel", {
+                      defaultValue: "目标模型",
+                    })}
+                    value={row.target}
+                    onChange={(e) =>
+                      handleSimpleRowChange(row.id, "target", e.target.value)
+                    }
+                    className="flex-1 font-mono text-sm transition-colors duration-200"
+                    disabled={!config.enabled}
+                  />
+                  {/* 删除按钮 - 总是显示，除非只有一个空行（可选，但这里我们允许删除所有行，或者保持至少一行空的逻辑在 handleRemove 处理） */}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemoveSimpleRow(row.id)}
+                    disabled={!config.enabled}
+                    className="transition-opacity duration-200 hover:bg-destructive/10"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Effort 组合映射 */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">
+              {t("providerAdvanced.effortModelMapping", {
+                defaultValue: "Effort 组合映射",
+              })}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t("providerAdvanced.effortModelMappingHint", {
+                defaultValue:
+                  "当请求同时匹配模型ID和 reasoning.effort 时，替换为目标模型ID（仅当简单映射未匹配时生效）",
+              })}
+            </p>
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleAddEffortRow}
+                disabled={!config.enabled}
+                className="h-8"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                {t("common.add", { defaultValue: "添加" })}
+              </Button>
+            </div>
+
+            {/* 映射行列表 */}
+            <div className="space-y-2">
+              {effortRows.map((row) => (
+                <div
+                  key={row.id}
+                  className="flex items-center gap-2"
+                >
+                  <Input
+                    ref={(el) => {
+                      if (el) effortInputRefs.current.set(row.id, el);
+                    }}
+                    placeholder={t("providerAdvanced.sourceModel", {
+                      defaultValue: "请求模型",
+                    })}
+                    value={row.model}
+                    onChange={(e) =>
+                      handleEffortRowChange(row.id, "model", e.target.value)
+                    }
+                    className="flex-1 font-mono text-sm transition-colors duration-200"
+                    disabled={!config.enabled}
+                  />
+                  <span className="text-muted-foreground">@</span>
+                  <Select
+                    value={row.effort}
+                    onValueChange={(value) =>
+                      handleEffortRowChange(row.id, "effort", value)
+                    }
+                    disabled={!config.enabled}
+                  >
+                    <SelectTrigger className="w-24 transition-colors duration-200">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {EFFORT_OPTIONS.map((opt) => (
+                        <SelectItem key={opt} value={opt}>
+                          {opt}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <span className="text-muted-foreground">→</span>
+                  <Input
+                    placeholder={t("providerAdvanced.targetModel", {
+                      defaultValue: "目标模型",
+                    })}
+                    value={row.target}
+                    onChange={(e) =>
+                      handleEffortRowChange(row.id, "target", e.target.value)
+                    }
+                    className="flex-1 font-mono text-sm transition-colors duration-200"
+                    disabled={!config.enabled}
+                  />
+                  {/* 删除按钮 */}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemoveEffortRow(row.id)}
+                    disabled={!config.enabled}
+                    className="transition-opacity duration-200 hover:bg-destructive/10"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -80,6 +80,16 @@ import {
   type PricingModelSourceOption,
 } from "./ProviderAdvancedConfig";
 import {
+  CodexModelMappingConfig,
+  defaultCodexModelMappingConfig,
+  type CodexModelMappingConfig as CodexModelMappingConfigType,
+} from "./CodexModelMappingConfig";
+import {
+  RequestBodyRewriterConfig,
+  defaultRequestBodyRewriterConfig,
+  type RequestBodyRewriterConfig as RequestBodyRewriterConfigType,
+} from "./RequestBodyRewriterConfig";
+import {
   useProviderCategory,
   useApiKeyState,
   useBaseUrlState,
@@ -324,6 +334,20 @@ function ProviderFormFull({
       initialData?.meta?.pricingModelSource,
     ),
   }));
+
+  // Codex 模型映射配置状态
+  const [codexModelMapping, setCodexModelMapping] =
+    useState<CodexModelMappingConfigType>(() => {
+      if (appId !== "codex") return defaultCodexModelMappingConfig;
+      return initialData?.meta?.codexModelMapping ?? defaultCodexModelMappingConfig;
+    });
+
+  // 请求体重写器配置状态
+  const [requestBodyRewriter, setRequestBodyRewriter] =
+    useState<RequestBodyRewriterConfigType>(() => {
+      if (appId !== "codex") return defaultRequestBodyRewriterConfig;
+      return initialData?.meta?.requestBodyRewriter ?? defaultRequestBodyRewriterConfig;
+    });
 
   const { category } = useProviderCategory({
     appId,
@@ -1422,6 +1446,16 @@ function ProviderFormFull({
         supportsFullUrl && category !== "official" && localIsFullUrl
           ? true
           : undefined,
+      // Codex 模型映射配置（仅 Codex 供应商使用）
+      codexModelMapping:
+        appId === "codex" && codexModelMapping.enabled
+          ? codexModelMapping
+          : undefined,
+      // 请求体重写器配置（仅 Codex 供应商使用）
+      requestBodyRewriter:
+        appId === "codex" && requestBodyRewriter.enabled
+          ? requestBodyRewriter
+          : undefined,
     };
 
     if (!isCodexOauthProvider && "codexFastMode" in nextMeta) {
@@ -2335,6 +2369,22 @@ function ProviderFormFull({
                 onPricingConfigChange={setPricingConfig}
               />
             )}
+
+          {/* Codex 模型映射配置 */}
+          {appId === "codex" && (
+            <CodexModelMappingConfig
+              config={codexModelMapping}
+              onConfigChange={setCodexModelMapping}
+            />
+          )}
+
+          {/* 请求体字段重写器（仅 Codex） */}
+          {appId === "codex" && (
+            <RequestBodyRewriterConfig
+              config={requestBodyRewriter}
+              onConfigChange={setRequestBodyRewriter}
+            />
+          )}
 
           {showButtons && (
             <div className="flex justify-end gap-2">

--- a/src/components/providers/forms/RequestBodyRewriterConfig.tsx
+++ b/src/components/providers/forms/RequestBodyRewriterConfig.tsx
@@ -1,0 +1,256 @@
+import { useTranslation } from "react-i18next";
+import { useState, useRef } from "react";
+import { ChevronDown, ChevronRight, Filter, Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+
+/** 请求体重写器配置 */
+export interface RequestBodyRewriterConfig {
+    enabled: boolean;
+    /** 重写规则：key 为字段路径，value 为新值（null = 删除） */
+    rules: Record<string, any>;
+}
+
+/** 默认配置 */
+export const defaultRequestBodyRewriterConfig: RequestBodyRewriterConfig = {
+    enabled: false,
+    rules: {},
+};
+
+interface RequestBodyRewriterConfigProps {
+    config: RequestBodyRewriterConfig;
+    onConfigChange: (config: RequestBodyRewriterConfig) => void;
+}
+
+/** 规则行类型 */
+interface RuleRow {
+    id: string;
+    path: string;
+    value: string; // JSON 字符串，"null" 表示删除
+}
+
+/** 预设规则 */
+const PRESET_RULES = [
+    { label: "text (删除)", path: "text", value: "null" },
+    { label: "instructions (删除)", path: "instructions", value: "null" },
+    { label: "text.verbosity (删除)", path: "text.verbosity", value: "null" },
+];
+
+let rowIdCounter = 0;
+
+export function RequestBodyRewriterConfig({
+    config,
+    onConfigChange,
+}: RequestBodyRewriterConfigProps) {
+    const { t } = useTranslation();
+    const [isOpen, setIsOpen] = useState(config.enabled);
+    const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+
+    // 从 config 初始化行数据（仅在首次渲染时，无默认空行）
+    const [rows, setRows] = useState<RuleRow[]>(() => {
+        return Object.entries(config.rules || {}).map(
+            ([path, value], index) => ({
+                id: `initial-${index}`,
+                path,
+                value: value === null ? "null" : JSON.stringify(value),
+            })
+        );
+    });
+
+    // 同步到 config
+    const syncToConfig = (newRows: RuleRow[]) => {
+        const rules: Record<string, any> = {};
+        for (const row of newRows) {
+            if (row.path.trim()) {
+                try {
+                    rules[row.path.trim()] = JSON.parse(row.value);
+                } catch {
+                    // 无效 JSON，视为字符串
+                    rules[row.path.trim()] = row.value === "null" ? null : row.value;
+                }
+            }
+        }
+        onConfigChange({ ...config, rules });
+    };
+
+    // 更新行
+    const handleRowChange = (
+        id: string,
+        field: "path" | "value",
+        value: string
+    ) => {
+        setRows((prev) => {
+            const newRows = prev.map((row) =>
+                row.id === id ? { ...row, [field]: value } : row
+            );
+            // 延迟同步
+            setTimeout(() => syncToConfig(newRows), 0);
+            return newRows;
+        });
+    };
+
+    // 删除行
+    const handleRemoveRow = (id: string) => {
+        setRows((prev) => {
+            const newRows = prev.filter((row) => row.id !== id);
+            syncToConfig(newRows);
+            return newRows;
+        });
+    };
+
+    // 添加空行
+    const handleAddRow = () => {
+        const newRow: RuleRow = {
+            id: `row-${++rowIdCounter}`,
+            path: "",
+            value: "null",
+        };
+        setRows((prev) => [...prev, newRow]);
+        // 延迟聚焦到新行
+        setTimeout(() => {
+            const input = inputRefs.current.get(`${newRow.id}-path`);
+            input?.focus();
+        }, 50);
+    };
+
+    // 添加预设规则
+    const handleAddPreset = (preset: (typeof PRESET_RULES)[0]) => {
+        // 检查是否已存在
+        if (rows.some((r) => r.path === preset.path)) {
+            return;
+        }
+        const newRow: RuleRow = {
+            id: `row-${++rowIdCounter}`,
+            path: preset.path,
+            value: preset.value,
+        };
+        setRows((prev) => {
+            const newRows = [...prev, newRow];
+            syncToConfig(newRows);
+            return newRows;
+        });
+    };
+
+    return (
+        <div className="space-y-3">
+            {/* 标题栏 */}
+            <div
+                className="flex items-center gap-2 cursor-pointer select-none"
+                onClick={() => setIsOpen(!isOpen)}
+            >
+                {isOpen ? (
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                )}
+                <Filter className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">
+                    {t("provider.requestBodyRewriter", "请求体字段重写")}
+                </span>
+                <div className="ml-auto" onClick={(e) => e.stopPropagation()}>
+                    <Switch
+                        checked={config.enabled}
+                        onCheckedChange={(checked) =>
+                            onConfigChange({ ...config, enabled: checked })
+                        }
+                    />
+                </div>
+            </div>
+
+            {/* 配置内容 */}
+            {isOpen && config.enabled && (
+                <div className="pl-6 space-y-3">
+                    {/* 预设按钮和添加按钮 */}
+                    <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-xs text-muted-foreground">
+                            {t("provider.presets", "预设")}:
+                        </span>
+                        {PRESET_RULES.map((preset) => (
+                            <Button
+                                key={preset.path}
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-6 text-xs"
+                                onClick={() => handleAddPreset(preset)}
+                            >
+                                <Plus className="h-3 w-3 mr-1" />
+                                {preset.label}
+                            </Button>
+                        ))}
+                        <div className="ml-auto">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-6 text-xs"
+                                onClick={handleAddRow}
+                            >
+                                <Plus className="h-3 w-3 mr-1" />
+                                {t("common.add", "添加")}
+                            </Button>
+                        </div>
+                    </div>
+
+                    {/* 规则列表 */}
+                    {rows.length > 0 && (
+                        <div className="space-y-2">
+                            <div className="grid grid-cols-[1fr_1fr_32px] gap-2 text-xs text-muted-foreground">
+                                <span>{t("provider.fieldPath", "字段路径")}</span>
+                                <span>{t("provider.newValue", "新值 (null=删除)")}</span>
+                                <span></span>
+                            </div>
+
+                            {rows.map((row) => (
+                                <div
+                                    key={row.id}
+                                    className="grid grid-cols-[1fr_1fr_32px] gap-2 items-center"
+                                >
+                                    <Input
+                                        ref={(el) => {
+                                            if (el) inputRefs.current.set(`${row.id}-path`, el);
+                                        }}
+                                        placeholder="text.verbosity"
+                                        value={row.path}
+                                        onChange={(e) =>
+                                            handleRowChange(row.id, "path", e.target.value)
+                                        }
+                                        className="h-8 text-sm"
+                                    />
+                                    <Textarea
+                                        placeholder='null 或 {"key": "value"}'
+                                        value={row.value}
+                                        onChange={(e) =>
+                                            handleRowChange(row.id, "value", e.target.value)
+                                        }
+                                        className="min-h-[32px] h-8 text-sm font-mono resize-y"
+                                        rows={1}
+                                    />
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-destructive hover:text-destructive"
+                                        onClick={() => handleRemoveRow(row.id)}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* 说明 */}
+                    <p className="text-xs text-muted-foreground">
+                        {t(
+                            "provider.rewriterHelp",
+                            "使用点分隔路径（如 text.verbosity）访问嵌套字段。设为 null 删除字段，其他 JSON 值覆盖。"
+                        )}
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,17 @@ export interface ProviderMeta {
   providerType?: string;
   // GitHub Copilot 关联账号 ID（旧字段，保留兼容读取）
   githubAccountId?: string;
+  // Codex 模型映射配置（仅 Codex 供应商使用）
+  codexModelMapping?: {
+    enabled: boolean;
+    modelMap: Record<string, string>;
+    effortMap: Record<string, string>;
+  };
+  // 请求体重写器配置（用于过滤或覆盖 JSON 字段）
+  requestBodyRewriter?: {
+    enabled: boolean;
+    rules: Record<string, any>; // null = 删除, 其他值 = 覆盖
+  };
 }
 
 // Skill 同步方式

--- a/使用指南.md
+++ b/使用指南.md
@@ -1,0 +1,221 @@
+# CC Switch 构建和使用指南
+
+## 🎯 你需要什么
+
+### 环境要求
+1. **Node.js 18+** - https://nodejs.org/
+2. **pnpm 8+** - 安装命令: `npm install -g pnpm`
+3. **Rust 1.85+** - https://rustup.rs/
+4. **Tauri CLI 2.8+** - 安装命令: `cargo install tauri-cli`
+
+---
+
+## 🔨 构建步骤
+
+### 1. 进入项目目录
+```bash
+cd cc-switch
+```
+
+### 2. 安装依赖
+```bash
+pnpm install
+```
+
+### 3. 构建应用
+```bash
+# 构建正式版本
+pnpm build
+
+# 或者构建调试版本（推荐先用这个测试）
+pnpm tauri build --debug
+```
+
+### 4. 找到安装包
+
+构建完成后，安装包在这里：
+```
+src-tauri/target/release/bundle/
+```
+
+**Windows**:
+- `CC-Switch-v3.16.3-Windows.msi` - 安装版
+- `CC-Switch-v3.16.3-Windows-Portable.zip` - 绿色版（解压即用）
+
+**macOS**:
+- `CC-Switch-v3.16.3-macOS.dmg`
+
+**Linux**:
+- `CC-Switch-v3.16.3-Linux.deb`
+- `CC-Switch-v3.16.3-Linux.AppImage`
+
+---
+
+## 🚀 使用方法
+
+### 1. 安装并打开 CC Switch
+
+### 2. 添加 Codex 供应商
+
+1. 点击左侧菜单 **"供应商"**
+2. 点击右上角 **"+ 添加供应商"**
+3. 选择 **"Codex"** 类型
+4. 填写供应商信息：
+   - **名称**: 给供应商起个名字（如 "DeepSeek"）
+   - **API Key**: 你的 API Key
+   - **Base URL**: 供应商的 API 地址
+   - **API 格式**: 选择 **"openai_chat"**（重要！这是 Chat Completions 格式）
+
+### 3. 配置模型映射（可选但推荐）
+
+在供应商设置页面，找到 **"Codex 模型映射"** 部分：
+
+1. **启用**: ✓ 勾选
+2. **模型映射**: 添加映射规则
+   - 左边: Codex 发送的模型名（如 `gpt-4o`）
+   - 右边: 供应商支持的模型名（如 `deepseek-chat`）
+3. **Effort 映射**: （可选）映射推理强度参数
+
+**示例配置**:
+```
+模型映射:
+  gpt-4o → deepseek-chat
+  gpt-4o-mini → deepseek-chat
+
+Effort 映射:
+  high → max
+  medium → default
+  low → min
+```
+
+### 4. 配置请求体重写器（可选）
+
+在供应商设置页面，找到 **"请求体字段重写器"** 部分：
+
+1. **启用**: ✓ 勾选
+2. **规则**: 添加重写规则
+   - **路径**: 字段路径（支持点分隔，如 `text.verbosity`）
+   - **值**: 新值（留空 = 删除该字段）
+
+**示例配置**:
+```
+路径: text.verbosity
+值: （留空）  → 删除这个字段
+
+路径: model
+值: deepseek-chat  → 覆盖模型名
+```
+
+### 5. 测试连接
+
+1. 在供应商设置页面，点击 **"测试"** 按钮
+2. 等待测试完成
+3. 看到 ✅ 成功即可
+
+### 6. 激活供应商
+
+1. 回到供应商列表
+2. 点击你刚创建的供应商旁边的 **"激活"** 按钮
+3. 状态变为 **"已激活"** ✅
+
+---
+
+## 🧪 测试 Codex 客户端
+
+### 1. 打开 Codex 客户端
+
+### 2. 配置 API 地址
+
+在 Codex 设置中：
+- **API Base URL**: `http://localhost:PORT`（CC Switch 会显示具体端口）
+- **API Key**: 随意填写（CC Switch 会处理）
+
+### 3. 测试对话
+
+发送一条消息，例如：
+```
+你好，请帮我写一个 Hello World 程序
+```
+
+### 4. 检查日志
+
+在 CC Switch 中查看请求日志，确认：
+- ✅ 模型名已映射（如 `gpt-4o` → `deepseek-chat`）
+- ✅ API 格式已转换（Responses API → Chat Completions）
+- ✅ 请求成功发送到供应商
+
+---
+
+## ❓ 常见问题
+
+### Q1: 构建失败怎么办？
+
+**检查环境**:
+```bash
+node --version    # 应该 >= 18
+pnpm --version    # 应该 >= 8
+rustc --version   # 应该 >= 1.85
+cargo tauri --version  # 应该 >= 2.8
+```
+
+**常见错误**:
+- `pnpm: command not found` → 安装 pnpm: `npm install -g pnpm`
+- `cargo: command not found` → 安装 Rust: https://rustup.rs/
+- `tauri: command not found` → 安装 Tauri CLI: `cargo install tauri-cli`
+
+### Q2: 运行时端口被占用？
+
+CC Switch 默认使用随机端口。如果端口冲突：
+1. 关闭其他占用端口的程序
+2. 或者重启 CC Switch
+
+### Q3: 模型映射不生效？
+
+检查：
+1. 模型映射是否 **启用** ✓
+2. 映射规则是否正确（左边是 Codex 发送的，右边是供应商支持的）
+3. 查看日志确认映射是否生效
+
+### Q4: Chat Completions 转换失败？
+
+检查：
+1. API 格式是否选择 **"openai_chat"**
+2. 供应商是否真的支持 Chat Completions
+3. 查看日志确认转换是否成功
+
+### Q5: 请求体重写器不生效？
+
+检查：
+1. 重写器是否 **启用** ✓
+2. 路径是否正确（如 `text.verbosity`）
+3. 值是否正确（留空 = 删除，有值 = 覆盖）
+
+---
+
+## 📊 工作流程图
+
+```
+Codex 客户端
+    ↓ (发送请求)
+CC Switch 本地代理
+    ↓ (1. 模型映射)
+    ↓ (2. API 格式转换: Responses → Chat Completions)
+    ↓ (3. 请求体重写)
+供应商 API (如 DeepSeek)
+    ↑ (返回响应)
+CC Switch
+    ↑ (响应格式转换: Chat Completions → Responses)
+Codex 客户端
+```
+
+---
+
+## 🎉 完成！
+
+现在你可以：
+- ✅ 用 Codex 客户端连接任何供应商
+- ✅ 自动转换 API 格式
+- ✅ 自由映射模型名
+- ✅ 灵活控制请求体
+
+**享受使用 Codex 的乐趣！** 🚀

--- a/合并PR-916和PR-2659操作笔记.md
+++ b/合并PR-916和PR-2659操作笔记.md
@@ -1,0 +1,423 @@
+# 合并 PR-916 和 PR-2659 到 cc-switch 仓库
+
+## 📋 背景
+
+**仓库地址**: https://github.com/farion1231/cc-switch  
+**目的**: 让 Codex 客户端能够使用非 GPT 模型，支持切换服务商  
+**核心功能**:
+- PR-916: 模型映射功能（Codex 专用映射器）
+- PR-2659: Chat Completions 端点转换（Responses API ↔ Chat Completions）
+
+---
+
+## 🔧 操作步骤
+
+### 1. 克隆仓库
+```bash
+git clone https://github.com/farion1231/cc-switch.git
+cd cc-switch
+```
+
+### 2. 获取两个 PR 的代码
+```bash
+# 获取 PR-916（模型映射）
+git fetch origin pull/916/head:pr-916
+
+# 获取 PR-2659（端点转换）
+git fetch origin pull/2659/head:pr-2659
+```
+
+### 3. 分析 PR 改动范围
+```bash
+# 查看 PR-916 改动了哪些文件
+git diff main...pr-916 --stat
+
+# 查看 PR-2659 改动了哪些文件
+git diff main...pr-2659 --stat
+```
+
+**PR-916 改动**:
+- `src-tauri/src/provider.rs` - 添加字段到 ProviderMeta
+- `src-tauri/src/proxy/codex_model_mapper.rs` - **新文件** - Codex 模型映射器
+- `src-tauri/src/proxy/forwarder.rs` - 添加模型映射逻辑
+- `src-tauri/src/proxy/mod.rs` - 添加模块声明
+- `src/components/providers/forms/CodexModelMappingConfig.tsx` - **新文件** - UI 组件
+- `src/components/providers/forms/ProviderForm.tsx` - 添加状态变量
+- `src/components/providers/forms/RequestBodyRewriterConfig.tsx` - **新文件** - UI 组件
+- `src/types.ts` - 添加类型定义
+
+**PR-2659 改动**:
+- `src-tauri/src/proxy/providers/codex.rs` - 添加 Chat Completions 转换
+- `src-tauri/src/proxy/providers/transform_responses.rs` - 添加转换函数
+- `src-tauri/src/services/stream_check.rs` - 流式检查支持
+- 前端文件 - UI 改动
+
+---
+
+## ⚠️ 为什么不能直接 merge
+
+直接 `git merge pr-916` 和 `git merge pr-2659` 会产生大量冲突，因为：
+1. 两个 PR 基于旧版本的 main
+2. main 分支已经有很多新改动
+3. 代码结构变化较大
+
+---
+
+## ✅ 实际采用的策略：手动提取 + 精准应用
+
+### 策略 1: 提取全新文件（无冲突）
+
+```bash
+# 从 PR-916 提取 3 个新文件
+git show pr-916:src-tauri/src/proxy/codex_model_mapper.rs > src-tauri/src/proxy/codex_model_mapper.rs
+git show pr-916:src/components/providers/forms/CodexModelMappingConfig.tsx > src/components/providers/forms/CodexModelMappingConfig.tsx
+git show pr-916:src/components/providers/forms/RequestBodyRewriterConfig.tsx > src/components/providers/forms/RequestBodyRewriterConfig.tsx
+```
+
+### 策略 2: 查看 diff，手动应用改动
+
+```bash
+# 查看具体改动
+git diff main...pr-916 -- src-tauri/src/provider.rs
+```
+
+然后手动编辑文件，添加需要的代码。
+
+### 策略 3: 提取新增函数（避免冲突）
+
+```bash
+# 提取 PR-2659 的 transform_responses.rs
+git show pr-2659:src-tauri/src/proxy/providers/transform_responses.rs > /tmp/transform_responses_pr2659.rs
+
+# 提取新增的函数（第 576-1246 行）
+sed -n '576,1246p' /tmp/transform_responses_pr2659.rs > /tmp/new_functions.rs
+
+# 插入到当前文件的合适位置
+head -624 src-tauri/src/proxy/providers/transform_responses.rs > /tmp/transform_responses_new.rs
+cat /tmp/new_functions.rs >> /tmp/transform_responses_new.rs
+tail -n +625 src-tauri/src/proxy/providers/transform_responses.rs >> /tmp/transform_responses_new.rs
+cp /tmp/transform_responses_new.rs src-tauri/src/proxy/providers/transform_responses.rs
+```
+
+---
+
+## 📝 具体改动清单
+
+### 1. `src-tauri/src/provider.rs`
+
+**添加 RequestBodyRewriter 结构体**（在 ProviderMeta 之前）:
+```rust
+/// 请求体重写器配置（用于过滤或覆盖 JSON 字段）
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RequestBodyRewriter {
+    /// 是否启用
+    #[serde(default)]
+    pub enabled: bool,
+    /// 重写规则：key 为字段路径（支持点分隔如 "text.verbosity"），value 为新值（null 表示删除）
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub rules: HashMap<String, Option<Value>>,
+}
+```
+
+**添加 2 个字段到 ProviderMeta**:
+```rust
+/// Codex 模型映射配置（每个渠道独立配置）
+#[serde(rename = "codexModelMapping", skip_serializing_if = "Option::is_none")]
+pub codex_model_mapping: Option<crate::proxy::codex_model_mapper::CodexModelMappingConfig>,
+
+/// 请求体重写器配置（用于过滤或覆盖 JSON 字段）
+#[serde(rename = "requestBodyRewriter", skip_serializing_if = "Option::is_none")]
+pub request_body_rewriter: Option<RequestBodyRewriter>,
+```
+
+### 2. `src-tauri/src/proxy/mod.rs`
+
+**添加模块声明**:
+```rust
+pub mod codex_model_mapper;
+```
+
+### 3. `src-tauri/src/proxy/forwarder.rs`
+
+**添加 apply_rewrite_rule 函数**（在 ForwardResult 之前）:
+```rust
+/// 应用重写规则到 JSON 对象
+/// path 支持点分隔（如 "text.verbosity"），value 为 None 表示删除该字段，Some(v) 表示覆盖
+fn apply_rewrite_rule(obj: &mut serde_json::Map<String, Value>, path: &str, value: Option<Value>) {
+    let parts: Vec<&str> = path.split('.').collect();
+    if parts.is_empty() {
+        return;
+    }
+
+    if parts.len() == 1 {
+        let key = parts[0];
+        match value {
+            None => { obj.remove(key); }
+            Some(v) => { obj.insert(key.to_string(), v); }
+        }
+    } else {
+        let key = parts[0];
+        if let Some(Value::Object(inner)) = obj.get_mut(key) {
+            let remaining_path = parts[1..].join(".");
+            apply_rewrite_rule(inner, &remaining_path, value);
+        }
+    }
+}
+```
+
+**修改模型映射逻辑**（添加 Codex 分支）:
+```rust
+let mapped_body = if matches!(app_type, AppType::ClaudeDesktop) {
+    crate::claude_desktop_config::map_proxy_request_model(body.clone(), provider)
+        .map_err(|e| ProxyError::InvalidRequest(e.to_string()))?
+} else if adapter.name() == "Codex" {
+    // Codex 使用专用映射器，支持 effort 组合映射
+    let (mapped_body, _original_model, _mapped_model) =
+        super::codex_model_mapper::apply_codex_model_mapping(body.clone(), provider);
+    mapped_body
+} else {
+    let (mapped_body, _original_model, _mapped_model) =
+        super::model_mapper::apply_model_mapping(body.clone(), provider);
+    mapped_body
+};
+```
+
+**添加请求体重写器逻辑**（在 prepare_upstream_request_body 之后）:
+```rust
+let mut filtered_body = prepare_upstream_request_body(request_body);
+
+// 应用请求体重写器（用户自定义字段过滤/覆盖）
+if let Some(rewriter) = provider.meta.as_ref().and_then(|m| m.request_body_rewriter.as_ref()) {
+    if rewriter.enabled {
+        if let Some(obj) = filtered_body.as_object_mut() {
+            for (path, value) in &rewriter.rules {
+                apply_rewrite_rule(obj, path, value.clone());
+            }
+        }
+    }
+}
+```
+
+### 4. `src-tauri/src/proxy/providers/codex.rs`
+
+**添加 import**:
+```rust
+use serde_json::{json, Value};
+```
+
+**添加 3 个方法到 ProviderAdapter impl**:
+- `needs_transform()` - 检测是否需要 Chat Completions 转换
+- `transform_request()` - Responses API → Chat Completions
+- `transform_response()` - Chat Completions → Responses API
+
+**添加 CodexAdapter impl**:
+- `extract_model()` - 从 provider 配置提取上游模型名
+- `extract_toml_value()` - 从 TOML 字符串提取值
+
+### 5. `src-tauri/src/proxy/providers/transform_responses.rs`
+
+**添加 671 行新代码**，包含：
+- `reorder_tool_messages()` - DeepSeek 兼容性处理
+- `responses_to_chat_completions()` - Responses API → Chat Completions 转换
+- `chat_completions_to_responses()` - Chat Completions → Responses API 转换
+
+### 6. `src/components/providers/forms/ProviderForm.tsx`
+
+**添加 import**:
+```typescript
+import {
+  CodexModelMappingConfig,
+  defaultCodexModelMappingConfig,
+  type CodexModelMappingConfig as CodexModelMappingConfigType,
+} from "./CodexModelMappingConfig";
+import {
+  RequestBodyRewriterConfig,
+  defaultRequestBodyRewriterConfig,
+  type RequestBodyRewriterConfig as RequestBodyRewriterConfigType,
+} from "./RequestBodyRewriterConfig";
+```
+
+**添加状态变量**:
+```typescript
+const [codexModelMapping, setCodexModelMapping] =
+  useState<CodexModelMappingConfigType>(() => {
+    if (appId !== "codex") return defaultCodexModelMappingConfig;
+    return initialData?.meta?.codexModelMapping ?? defaultCodexModelMappingConfig;
+  });
+
+const [requestBodyRewriter, setRequestBodyRewriter] =
+  useState<RequestBodyRewriterConfigType>(() => {
+    if (appId !== "codex") return defaultRequestBodyRewriterConfig;
+    return initialData?.meta?.requestBodyRewriter ?? defaultRequestBodyRewriterConfig;
+  });
+```
+
+**添加到 payload**:
+```typescript
+codexModelMapping:
+  appId === "codex" && codexModelMapping.enabled
+    ? codexModelMapping
+    : undefined,
+requestBodyRewriter:
+  appId === "codex" && requestBodyRewriter.enabled
+    ? requestBodyRewriter
+    : undefined,
+```
+
+**添加 UI 组件**:
+```tsx
+{/* Codex 模型映射配置 */}
+{appId === "codex" && (
+  <CodexModelMappingConfig
+    config={codexModelMapping}
+    onConfigChange={setCodexModelMapping}
+  />
+)}
+
+{/* 请求体字段重写器（仅 Codex） */}
+{appId === "codex" && (
+  <RequestBodyRewriterConfig
+    config={requestBodyRewriter}
+    onConfigChange={setRequestBodyRewriter}
+  />
+)}
+```
+
+### 7. `src/types.ts`
+
+**添加类型定义**:
+```typescript
+codexModelMapping?: {
+  enabled: boolean;
+  modelMap: Record<string, string>;
+  effortMap: Record<string, string>;
+};
+requestBodyRewriter?: {
+  enabled: boolean;
+  rules: Record<string, any>; // null = 删除, 其他值 = 覆盖
+};
+```
+
+---
+
+## 🎯 核心功能说明
+
+### 1. 模型映射 (PR-916)
+
+**作用**: 将 Codex 客户端发送的模型名映射到供应商支持的模型名
+
+**示例**:
+- Codex 发送: `gpt-4o`
+- 供应商支持: `deepseek-chat`
+- 映射后: `deepseek-chat`
+
+**配置位置**: 供应商设置 → Codex 模型映射
+
+### 2. 请求体重写器 (PR-916)
+
+**作用**: 过滤或覆盖请求体中的特定字段
+
+**示例**:
+- 删除字段: `text.verbosity` → null
+- 覆盖字段: `model` → `deepseek-chat`
+
+### 3. Chat Completions 转换 (PR-2659)
+
+**作用**: 将 Responses API 格式转换为 Chat Completions 格式
+
+**为什么需要**:
+- Codex 客户端只支持 Responses API
+- 很多供应商（如 DeepSeek）只支持 Chat Completions
+- 需要在中间层做格式转换
+
+**转换内容**:
+- 请求: Responses API → Chat Completions
+- 响应: Chat Completions → Responses API
+
+---
+
+## 🧪 测试方法
+
+### 1. 构建项目
+```bash
+# 安装依赖
+pnpm install
+
+# 构建
+pnpm build
+```
+
+### 2. 配置 Codex 供应商
+
+1. 打开 cc-switch
+2. 添加新供应商 → 选择 Codex
+3. 填写供应商信息:
+   - API Key
+   - Base URL
+   - 选择 API 格式: `openai_chat`（如果供应商只支持 Chat Completions）
+
+### 3. 测试模型映射
+
+1. 在供应商设置中找到"Codex 模型映射"
+2. 添加映射规则:
+   - 启用: ✓
+   - 模型映射: `gpt-4o` → `deepseek-chat`
+3. 测试: Codex 客户端发送 `gpt-4o`，实际发送 `deepseek-chat`
+
+### 4. 测试请求体重写器
+
+1. 在供应商设置中找到"请求体字段重写器"
+2. 添加规则:
+   - 启用: ✓
+   - 路径: `text.verbosity`
+   - 值: null（删除该字段）
+3. 测试: 请求体中的 `text.verbosity` 字段被删除
+
+---
+
+## ❓ 常见问题
+
+### Q1: 为什么不直接 merge PR？
+
+A: 因为：
+1. PR 基于旧版本的 main
+2. main 已经有很多新改动
+3. 直接 merge 会产生大量冲突
+4. 手动应用更可控
+
+### Q2: 如何在新对话中复现？
+
+A: 按照上面的步骤操作：
+1. 克隆仓库
+2. 获取 PR 代码
+3. 查看 diff
+4. 手动应用改动
+5. 提交
+
+### Q3: 如果遇到编译错误怎么办？
+
+A: 检查：
+1. import 是否正确
+2. 类型是否匹配
+3. 函数签名是否一致
+4. 参考 PR 的 diff 逐个修复
+
+---
+
+## 📚 相关资源
+
+- **PR-916**: https://github.com/farion1231/cc-switch/pull/916
+- **PR-2659**: https://github.com/farion1231/cc-switch/pull/2659
+- **cc-switch 仓库**: https://github.com/farion1231/cc-switch
+
+---
+
+## 🎉 总结
+
+通过手动提取和精准应用，成功合并了两个 PR 的核心功能：
+
+✅ **模型映射** - Codex 可以使用非 GPT 模型  
+✅ **Chat Completions 转换** - 支持只提供 Chat Completions API 的供应商  
+✅ **请求体重写器** - 灵活控制请求体内容  
+
+现在 Codex 客户端可以随意切换服务商了！🚀


### PR DESCRIPTION
## 概述

本 PR 合并了 PR-916（模型映射）和 PR-2659（Chat Completions 转换）的核心功能，使 Codex 客户端能够使用非 GPT 模型连接任意供应商。

## 主要改动

### 来自 PR-916（模型映射）：
- 新增 codex_model_mapper.rs - Codex 专用模型映射器
- 新增 CodexModelMappingConfig.tsx - 模型映射 UI 组件
- 新增 RequestBodyRewriterConfig.tsx - 请求体重写器 UI
- 在 ProviderMeta 中添加 codexModelMapping 和 requestBodyRewriter 字段
- 在 forwarder.rs 中添加 Codex 模型映射逻辑和请求体重写器支持

### 来自 PR-2659（Chat Completions 转换）：
- 在 codex.rs 中添加 needs_transform()、transform_request()、transform_response() 方法
- 在 transform_responses.rs 中添加 responses_to_chat_completions() 和 chat_completions_to_responses() 函数
- 添加 DeepSeek 兼容性处理（reorder_tool_messages）

## 功能说明

1. **模型映射**: 将 Codex 发送的模型名（如 gpt-4o）映射到供应商支持的模型名（如 deepseek-chat）
2. **Chat Completions 转换**: 将 Responses API 格式转换为 Chat Completions 格式
3. **请求体重写器**: 支持删除或覆盖请求体中的特定字段

## 使用方法

详见 使用指南.md 文件。

---

🤖 Generated with [Claude Code](https://claude.ai/code)
Base repository: farion1231/cc-switch

Base branch: main

Head repository: Ezio1997-K/cc-switch

Head branch: feat/codex-model-mapping-and-chat-completions-transform

