### PR TITLE
fix(proxy): 修复 Copilot/Codex OAuth 模块绕过全局代理导致 Claude 模型 400 错误

### DIFF
--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -16,7 +16,7 @@
 //! - 通过 JWT id_token 提取 chatgpt_account_id 作为账号唯一标识
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use reqwest::Client;
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -230,7 +230,6 @@ pub struct CodexOAuthManager {
     /// 进行中的 Device Code 流程：device_auth_id -> {user_code, expires_at_ms}
     /// 过期条目会在 start_device_flow 时被清理，防止放弃的登录流程导致无界增长
     pending_device_codes: Arc<RwLock<HashMap<String, PendingDeviceCode>>>,
-    http_client: Client,
     storage_path: PathBuf,
 }
 
@@ -244,7 +243,6 @@ impl CodexOAuthManager {
             access_tokens: Arc::new(RwLock::new(HashMap::new())),
             refresh_locks: Arc::new(RwLock::new(HashMap::new())),
             pending_device_codes: Arc::new(RwLock::new(HashMap::new())),
-            http_client: Client::new(),
             storage_path,
         };
 
@@ -266,8 +264,7 @@ impl CodexOAuthManager {
     pub async fn start_device_flow(&self) -> Result<GitHubDeviceCodeResponse, CodexOAuthError> {
         log::info!("[CodexOAuth] 启动 Device Code 流程");
 
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .post(DEVICE_AUTH_USERCODE_URL)
             .header("Content-Type", "application/json")
             .header("User-Agent", CODEX_USER_AGENT)
@@ -349,8 +346,7 @@ impl CodexOAuthManager {
 
         log::debug!("[CodexOAuth] 轮询 Device Code");
 
-        let poll_response = self
-            .http_client
+        let poll_response = crate::proxy::http_client::get()
             .post(DEVICE_AUTH_TOKEN_URL)
             .header("Content-Type", "application/json")
             .header("User-Agent", CODEX_USER_AGENT)
@@ -431,8 +427,7 @@ impl CodexOAuthManager {
         code: &str,
         code_verifier: &str,
     ) -> Result<OAuthTokenResponse, CodexOAuthError> {
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .post(OAUTH_TOKEN_URL)
             .header("Content-Type", "application/x-www-form-urlencoded")
             .header("User-Agent", CODEX_USER_AGENT)
@@ -465,8 +460,7 @@ impl CodexOAuthManager {
         &self,
         refresh_token: &str,
     ) -> Result<OAuthTokenResponse, CodexOAuthError> {
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .post(OAUTH_TOKEN_URL)
             .header("Content-Type", "application/x-www-form-urlencoded")
             .header("User-Agent", CODEX_USER_AGENT)

--- a/src-tauri/src/proxy/providers/copilot_auth.rs
+++ b/src-tauri/src/proxy/providers/copilot_auth.rs
@@ -15,7 +15,6 @@
 //! - Provider 通过 meta.authBinding 关联账号
 //! - 自动迁移 v1 单账号格式到 v3 多账号 + 默认账号格式
 
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -424,8 +423,6 @@ pub struct CopilotAuthManager {
     api_endpoints: Arc<RwLock<HashMap<String, String>>>,
     /// 每个账号的端点拉取锁，避免并发拉取重复打 GitHub API
     endpoint_locks: Arc<RwLock<HashMap<String, Arc<Mutex<()>>>>>,
-    /// HTTP 客户端
-    http_client: Client,
     /// 存储路径
     storage_path: PathBuf,
     /// 待迁移的旧格式 token
@@ -447,7 +444,6 @@ impl CopilotAuthManager {
             copilot_models: Arc::new(RwLock::new(HashMap::new())),
             api_endpoints: Arc::new(RwLock::new(HashMap::new())),
             endpoint_locks: Arc::new(RwLock::new(HashMap::new())),
-            http_client: Client::new(),
             storage_path,
             pending_migration: Arc::new(RwLock::new(None)),
             migration_error: Arc::new(RwLock::new(None)),
@@ -602,8 +598,7 @@ impl CopilotAuthManager {
         };
         log::info!("[CopilotAuth] 启动设备码流程 (domain: {domain})");
 
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .post(github_device_code_url(&domain))
             .header("Accept", "application/json")
             .header("User-Agent", COPILOT_USER_AGENT)
@@ -647,8 +642,7 @@ impl CopilotAuthManager {
         };
         log::debug!("[CopilotAuth] 轮询 OAuth Token (domain: {domain})");
 
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .post(github_oauth_token_url(&domain))
             .header("Accept", "application/json")
             .header("User-Agent", COPILOT_USER_AGENT)
@@ -831,8 +825,7 @@ impl CopilotAuthManager {
 
         log::info!("[CopilotAuth] 获取账号 {account_id} 的 Copilot 可用模型");
 
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .get(&models_url)
             .header("Authorization", format!("Bearer {copilot_token}"))
             .header("Content-Type", "application/json")
@@ -919,8 +912,7 @@ impl CopilotAuthManager {
 
         log::info!("[CopilotAuth] 获取账号 {account_id} 的 Copilot 使用量");
 
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .get(copilot_usage_url(&domain))
             .header("Authorization", format!("token {github_token}"))
             .header("Content-Type", "application/json")
@@ -1034,8 +1026,7 @@ impl CopilotAuthManager {
 
         log::debug!("[CopilotAuth] 为账号 {account_id} 惰性拉取动态 API 端点");
 
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .get(copilot_usage_url(&domain))
             .header("Authorization", format!("token {github_token}"))
             .header("Content-Type", "application/json")
@@ -1312,8 +1303,7 @@ impl CopilotAuthManager {
         github_token: &str,
         domain: &str,
     ) -> Result<GitHubUser, CopilotAuthError> {
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .get(github_user_url(domain))
             .header("Authorization", format!("token {github_token}"))
             .header("User-Agent", COPILOT_USER_AGENT)
@@ -1345,8 +1335,7 @@ impl CopilotAuthManager {
     ) -> Result<(), CopilotAuthError> {
         log::debug!("[CopilotAuth] 获取账号 {account_id} 的 Copilot Token (domain: {domain})");
 
-        let response = self
-            .http_client
+        let response = crate::proxy::http_client::get()
             .get(copilot_token_url(domain))
             .header("Authorization", format!("token {github_token}"))
             .header("User-Agent", COPILOT_USER_AGENT)


### PR DESCRIPTION
## Summary / 概述

修复 `CopilotAuthManager` 和 `CodexOAuthManager` 两个模块的 HTTP 客户端绕过全局代理配置的问题。

两个模块在构造时写死了 `Client::new()`（裸 reqwest 客户端，无代理），导致其内部的认证请求（token 获取、模型列表拉取等）完全无视全局代理配置，直连目标服务。当用户配置全局代理后，这些请求仍然直连，造成：

- 在某些网络环境下，直连 GitHub/Copilot API 失败或返回不完整的模型列表
- `/models` 列表为空时，模型 ID 归一化/匹配流程失效
- 最终导致上游 Copilot 返回 `400 model_not_supported`

改动将两个模块改为每次请求时从全局客户端现取（`crate::proxy::http_client::get()`），确保：
- 遵循用户的全局代理 URL 配置
- 支持代理设置的运行时热更新
- 符合代码库设计意图（`http_client.rs` 明确要求"所有 HTTP 请求都应使用全局模块"）

## Related Issue / 关联 Issue

Fixes #2016 #2931

## Changes / 改动

**copilot_auth.rs**（7 处调用）：
- 删除 `http_client: Client` 字段
- 7 处 `self.http_client` 改为 `crate::proxy::http_client::get()`
- 覆盖：token 获取、/models 列表拉取、model vendor 判断

**codex_oauth_auth.rs**（4 处调用）：
- 删除 `http_client: Client` 字段
- 4 处 `self.http_client` 改为 `crate::proxy::http_client::get()`
- 覆盖：device code 申请、token 轮询、OAuth token 刷新

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 无全局代理配置时：`/models` 列表为空 → 400 model_not_supported | 有全局代理配置时：`/models` 列表正确拉取 → 模型 ID 正确匹配 → 请求成功 |

## Checklist / 检查清单

- [x] `cargo clippy` passes (已修改 Rust 代码)
- [x] 编译通过且无 warning
- [x] 已构建并测试 deb 包

## Notes / 备注

这个修复解决了一个根本问题：全局代理配置只对转发路径（Claude Code → cc-switch 代理 → 上游）生效，但对代理本身内部的认证请求无效。修复后，认证和转发都走同一套全局代理管理，保证一致性。