### PR TITLE
fix(claude): write 1M context marker as lowercase [1m]

### DIFF
--- a/src/components/providers/forms/hooks/useModelState.ts
+++ b/src/components/providers/forms/hooks/useModelState.ts
@@ -16,7 +16,9 @@ export type ClaudeModelEnvField =
   | "ANTHROPIC_DEFAULT_FABLE_MODEL"
   | "ANTHROPIC_DEFAULT_FABLE_MODEL_NAME";
 
-export const CLAUDE_ONE_M_MARKER = "[1M]";
+// Claude Code 只识别小写 `[1m]` 后缀（见官方文档 model-config）。
+// 读取侧虽用 toLowerCase() 容错，但写入侧必须用小写，否则 /context 不会启用 1M 上下文。
+export const CLAUDE_ONE_M_MARKER = "[1m]";
 
 export function hasClaudeOneMMarker(model: string): boolean {
   return model.trimEnd().toLowerCase().endsWith("[1m]");

--- a/tests/hooks/useModelState.test.tsx
+++ b/tests/hooks/useModelState.test.tsx
@@ -104,7 +104,7 @@ describe("useModelState", () => {
       "deepseek-v4-pro",
     );
     expect(setClaudeOneMMarker("deepseek-v4-pro", true)).toBe(
-      "deepseek-v4-pro[1M]",
+      "deepseek-v4-pro[1m]",
     );
   });
 });


### PR DESCRIPTION
## Summary

Claude Code only recognizes the lowercase `[1m]` suffix to enable the 1M context window. The writer path was emitting uppercase `[1M]`, so toggling "declare 1M support" in the UI wrote a value that silently failed to enable 1M context (`/context` kept showing 200K).

Fixes the **Bug 1** portion of #3679.

> Note: this is complementary to #3680, which addresses **Bug 2** (adding the 1M toggle to the fallback model field in `ClaudeFormFields.tsx`). The two fixes are independent — this PR only touches the marker constant and its writer-path test.

## Root cause

`src/components/providers/forms/hooks/useModelState.ts`:

```ts
export const CLAUDE_ONE_M_MARKER = "[1M]";   // ← write path, uppercase

// read-side helpers were already case-insensitive, masking the bug:
hasClaudeOneMMarker(model)  → model.toLowerCase().endsWith("[1m]")
stripClaudeOneMMarker(model) → toLowerCase().endsWith("[1m]")
setClaudeOneMMarker(model, true) → `${base}[1M]`  // ← emits uppercase
```

Per the [official model-config docs](https://docs.claude.com/en/docs/claude-code/model-config):

> Append `[1m]` to the model ID to enable the 1M context window for a pinned model.

Because the read-side normalized via `toLowerCase()`, already-stored uppercase values were detected/stripped correctly — but anything freshly written by the UI came back uppercase and was silently ignored by Claude Code.

## Changes

- `src/components/providers/forms/hooks/useModelState.ts`: `CLAUDE_ONE_M_MARKER` → `"[1m]"`.
- `tests/hooks/useModelState.test.tsx`: updated the writer-path assertion (`setClaudeOneMMarker(..., true)`) to expect `[1m]`. Read-side assertions that feed uppercase input are intentionally kept as-is, since they verify case-insensitive normalization.

## Verification

- [x] `tsc --noEmit` — no type errors
- [x] `prettier --check` — passes on both files
- [x] `vitest run` — 351 tests passed (58 files), including all 4 cases in `useModelState.test.tsx`

## Out of scope (flagging for maintainer)

There is a **second** uppercase marker in the Rust backend that I did **not** touch, because its comment indicates an intentional choice and it's on a separate code path (proxy takeover mode), which is outside this issue's scope:

- `src-tauri/src/services/proxy.rs:46` — `CLAUDE_ONE_M_MARKER_FOR_CLIENT: &str = "[1M]"` (comment: "写给 Claude Code 时沿用文档示例的大写形式；解析侧大小写不敏感"), pushed onto `client_model` at `proxy.rs:271`.

If the lowercase fix is the intended direction here, the backend constant likely wants the same treatment for consistency, but I'll defer that to the maintainer's call since it has an explicit design comment.