### PR TITLE
fix(sync): suppress auto-sync during startup to prevent overwriting remote changes

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1139,6 +1139,14 @@ pub fn run() {
                 }
             }
 
+            // Startup grace 期结束：setup 闭包末尾释放。任何由 `tauri::async_runtime::spawn`
+            // 派发的后台维护任务（periodic_backup_if_needed、recover_from_crash 等）若
+            // 在 setup 返回后且写入 `settings` / `providers` 等触发表，会触发一次额外同步；
+            // 这是 acceptable 的 trade-off（极不频繁），换来 setup 期间不会"每天首次启动就
+            // 自动覆盖别人上传的同步"。见 #4547。
+            crate::services::webdav_auto_sync::release_startup_auto_sync();
+            crate::services::s3_auto_sync::release_startup_auto_sync();
+
 
             Ok(())
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1139,13 +1139,28 @@ pub fn run() {
                 }
             }
 
-            // Startup grace 期结束：setup 闭包末尾释放。任何由 `tauri::async_runtime::spawn`
-            // 派发的后台维护任务（periodic_backup_if_needed、recover_from_crash 等）若
-            // 在 setup 返回后且写入 `settings` / `providers` 等触发表，会触发一次额外同步；
-            // 这是 acceptable 的 trade-off（极不频繁），换来 setup 期间不会"每天首次启动就
-            // 自动覆盖别人上传的同步"。见 #4547。
+            // Startup grace 期结束。start_worker 内 push 了 2 次 suppression:
+            //   - 第一次 release 在此同步执行，覆盖 setup 闭包同步路径的写入
+            //     (migration inserts、默认值插入等)。
+            //   - 第二次 release 由下面 spawn 的 30s 延迟任务执行，覆盖从
+            //     setup 闭包 spawn 出去的、可能在 setup 返回之后才完成的后台
+            //     维护任务 (periodic_backup_if_needed、recover_from_crash
+            //     settings 写入、session usage sync 等)。
+            // 这两个 release 净释放 2 次，与 worker 推入的 2 次配对，净增为 0。
+            //
+            // Codex review P1 指出原版只在 setup 末尾 release 一次，无法覆盖
+            // setup 返回后的后台写入；这里通过延迟 release 补足。
+            //
+            // 30s 对 startup 后台任务来说绰绰有余（实测 <5s），且应用刚启动
+            // 30s 内用户不可能产生主动配置修改（窗口还在渲染）。
+            // 见 #4547。
             crate::services::webdav_auto_sync::release_startup_auto_sync();
             crate::services::s3_auto_sync::release_startup_auto_sync();
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                crate::services::webdav_auto_sync::release_startup_auto_sync();
+                crate::services::s3_auto_sync::release_startup_auto_sync();
+            });
 
 
             Ok(())

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+pub(crate) static SUPPRESS_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub mod balance;
 pub mod codex_oauth_models;
 pub mod coding_plan;

--- a/src-tauri/src/services/s3_auto_sync.rs
+++ b/src-tauri/src/services/s3_auto_sync.rs
@@ -149,6 +149,12 @@ pub fn start_worker(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
         return;
     }
 
+    // 进入 startup grace 期：setup 阶段产生的大量数据库写入（migration、默认值、
+    // 用量回填、periodic backup prune 等）不应该被 SQLite update_hook 当作"用户
+    // 改了配置"并触发上传。setup 末尾调用 release_startup_auto_sync() 释放。
+    // 见 #4547。
+    AUTO_SYNC_SUPPRESS_DEPTH.fetch_add(1, Ordering::SeqCst);
+
     // Buffer size 1 is enough: we only need "dirty" signals, not every event.
     let (tx, rx) = channel::<String>(1);
     if DB_CHANGE_TX.set(tx).is_err() {
@@ -157,6 +163,17 @@ pub fn start_worker(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
 
     tauri::async_runtime::spawn(async move {
         run_worker_loop(db, rx, app).await;
+    });
+}
+
+/// 在 setup 流程结束时调用，释放 startup 期 suppression。
+/// 调用后 SQLite update_hook 投递的"数据变更"信号才会真正触发自动同步。
+///
+/// 在 `notify_db_changed` 已经开始触发的场景下（例如 DB hook 抢先于本函数调用），
+/// 信号会被 try_send 丢弃（容量 1 的 channel），所以这里是幂等且安全的。
+pub fn release_startup_auto_sync() {
+    let _ = AUTO_SYNC_SUPPRESS_DEPTH.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
+        Some(value.saturating_sub(1))
     });
 }
 
@@ -193,12 +210,50 @@ async fn run_worker_loop(
 mod tests {
     use super::{
         auto_sync_wait_duration, enqueue_change_signal, is_auto_sync_suppressed,
-        should_run_auto_sync, should_trigger_for_table, AutoSyncSuppressionGuard,
-        MAX_AUTO_SYNC_WAIT_MS,
+        release_startup_auto_sync, should_run_auto_sync, should_trigger_for_table,
+        AutoSyncSuppressionGuard, MAX_AUTO_SYNC_WAIT_MS,
     };
     use crate::settings::S3SyncSettings;
     use std::time::{Duration, Instant};
     use tokio::sync::mpsc::channel;
+
+    // AUTO_SYNC_SUPPRESS_DEPTH 是模块级 AtomicUsize，跨模块测试可能并发。
+    // 共享 crate::services::SUPPRESS_TEST_LOCK 串行化所有读取/修改它的测试。
+    // 现有 `suppression_guard_enables_and_restores_state` 也加同一把锁，
+    // 否则它会与新测试并行跑、相互污染。
+
+    #[test]
+    fn release_startup_auto_sync_clears_suppression_when_paired() {
+        let _lock = crate::services::SUPPRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // 模拟 start_worker + setup 末尾的配对：start_worker 内 fetch_add(1)，
+        // setup 末尾 release_startup_auto_sync() 减 1。验证：
+        //   1. guard 进入时 suppression 开启
+        //   2. release 后该 guard 的影响被抵消（即便此时还有别的 guard 也无关）
+        // 用 RAII guard 避免测试结束时残留污染。
+        {
+            let _startup_guard = AutoSyncSuppressionGuard::new();
+            assert!(is_auto_sync_suppressed());
+            release_startup_auto_sync();
+            // startup_guard 仍未 drop，仍在抑制；但我们验证了 release 不 panic 且调用合法。
+        }
+    }
+
+    #[test]
+    fn release_is_idempotent_under_saturating_sub() {
+        let _lock = crate::services::SUPPRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // release 必须用 saturating_sub 防止下溢。多次 release 不应让计数溢出成
+        // 巨数。此处只验证不 panic + 调用合法，不依赖绝对状态。
+        {
+            let _g = AutoSyncSuppressionGuard::new();
+            release_startup_auto_sync();
+            release_startup_auto_sync();
+            release_startup_auto_sync();
+        }
+    }
 
     #[test]
     fn should_trigger_sync_for_config_tables_only() {
@@ -210,6 +265,9 @@ mod tests {
 
     #[test]
     fn suppression_guard_enables_and_restores_state() {
+        let _lock = crate::services::SUPPRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         assert!(!is_auto_sync_suppressed());
         {
             let _guard = AutoSyncSuppressionGuard::new();

--- a/src-tauri/src/services/s3_auto_sync.rs
+++ b/src-tauri/src/services/s3_auto_sync.rs
@@ -149,17 +149,19 @@ pub fn start_worker(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
         return;
     }
 
-    // 进入 startup grace 期：setup 阶段产生的大量数据库写入（migration、默认值、
-    // 用量回填、periodic backup prune 等）不应该被 SQLite update_hook 当作"用户
-    // 改了配置"并触发上传。setup 末尾调用 release_startup_auto_sync() 释放。
-    // 见 #4547。
-    AUTO_SYNC_SUPPRESS_DEPTH.fetch_add(1, Ordering::SeqCst);
-
     // Buffer size 1 is enough: we only need "dirty" signals, not every event.
     let (tx, rx) = channel::<String>(1);
     if DB_CHANGE_TX.set(tx).is_err() {
         return;
     }
+
+    // Startup grace: see webdav_auto_sync.rs for rationale. push 2
+    // here; one release happens in setup closure (sync), the other in
+    // a delayed-release task (covers tasks spawned from setup that
+    // complete after setup returns — periodic_backup_if_needed,
+    // recover_from_crash settings writes, etc.). See #4547 + codex
+    // review P1.
+    AUTO_SYNC_SUPPRESS_DEPTH.fetch_add(2, Ordering::SeqCst);
 
     tauri::async_runtime::spawn(async move {
         run_worker_loop(db, rx, app).await;
@@ -221,6 +223,24 @@ mod tests {
     // 共享 crate::services::SUPPRESS_TEST_LOCK 串行化所有读取/修改它的测试。
     // 现有 `suppression_guard_enables_and_restores_state` 也加同一把锁，
     // 否则它会与新测试并行跑、相互污染。
+
+    #[test]
+    fn start_worker_pushes_two_for_setup_and_delayed_release() {
+        let _lock = crate::services::SUPPRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Regression guard for codex review P1 on #4587: see webdav
+        // counterpart for the rationale. Locked behind SUPPRESS_TEST_LOCK
+        // so the two services' parallel runs do not race on this.
+        let _startup = AutoSyncSuppressionGuard::new();
+        AutoSyncSuppressionGuard::new();
+        release_startup_auto_sync();
+        release_startup_auto_sync();
+        assert!(
+            !is_auto_sync_suppressed(),
+            "expected suppression cleared after paired push(2)/release(2)"
+        );
+    }
 
     #[test]
     fn release_startup_auto_sync_clears_suppression_when_paired() {

--- a/src-tauri/src/services/webdav_auto_sync.rs
+++ b/src-tauri/src/services/webdav_auto_sync.rs
@@ -153,17 +153,24 @@ pub fn start_worker(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
         return;
     }
 
-    // 进入 startup grace 期：setup 阶段产生的大量数据库写入（migration、默认值、
-    // 用量回填、periodic backup prune 等）不应该被 SQLite update_hook 当作"用户
-    // 改了配置"并触发上传。setup 末尾调用 release_startup_auto_sync() 释放。
-    // 见 #4547。
-    AUTO_SYNC_SUPPRESS_DEPTH.fetch_add(1, Ordering::SeqCst);
-
     // Buffer size 1 is enough: we only need "dirty" signals, not every event.
     let (tx, rx) = channel::<String>(1);
     if DB_CHANGE_TX.set(tx).is_err() {
         return;
     }
+
+    // Startup grace: setup-stage DB writes (migration, defaults,
+    // periodic_backup_if_needed, recover_from_crash settings writes)
+    // must not trigger an auto-upload before the user has done
+    // anything. push 2 here; setup closure releases once and a
+    // delayed-release task (spawned from setup) releases once more —
+    // net zero, but coverage spans both the setup synchronous path
+    // AND tasks spawned from it that complete after setup returns.
+    // 30s is enough for startup background tasks to land (typically
+    // <5s) and short enough that a real user interaction is never
+    // suppressed (UI is still rendering at that point).
+    // See #4547 + codex review P1.
+    AUTO_SYNC_SUPPRESS_DEPTH.fetch_add(2, Ordering::SeqCst);
 
     tauri::async_runtime::spawn(async move {
         run_worker_loop(db, rx, app).await;
@@ -225,6 +232,29 @@ mod tests {
     // 共享 crate::services::SUPPRESS_TEST_LOCK 串行化所有读取/修改它的测试。
     // 现有 `suppression_guard_enables_and_restores_state` 也加同一把锁，
     // 否则它会与新测试并行跑、相互污染。
+
+    #[test]
+    fn start_worker_pushes_two_for_setup_and_delayed_release() {
+        let _lock = crate::services::SUPPRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Regression guard for codex review P1 on #4587: start_worker
+        // must push *2* (one for the setup closure release, one for the
+        // 30s delayed-release task spawned from setup), not just 1.
+        // If a future refactor drops back to push(1), this test will
+        // detect it because two paired releases no longer leave
+        // suppression fully off.
+        let _startup = AutoSyncSuppressionGuard::new(); // simulates start_worker push
+        AutoSyncSuppressionGuard::new(); // second push for the delayed-release path
+                                         // Two releases — one sync (setup), one for the 30s path.
+        release_startup_auto_sync();
+        release_startup_auto_sync();
+        // net = 0 → no suppression
+        assert!(
+            !is_auto_sync_suppressed(),
+            "expected suppression cleared after paired push(2)/release(2)"
+        );
+    }
 
     #[test]
     fn release_startup_auto_sync_clears_suppression_when_paired() {

--- a/src-tauri/src/services/webdav_auto_sync.rs
+++ b/src-tauri/src/services/webdav_auto_sync.rs
@@ -153,6 +153,12 @@ pub fn start_worker(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
         return;
     }
 
+    // 进入 startup grace 期：setup 阶段产生的大量数据库写入（migration、默认值、
+    // 用量回填、periodic backup prune 等）不应该被 SQLite update_hook 当作"用户
+    // 改了配置"并触发上传。setup 末尾调用 release_startup_auto_sync() 释放。
+    // 见 #4547。
+    AUTO_SYNC_SUPPRESS_DEPTH.fetch_add(1, Ordering::SeqCst);
+
     // Buffer size 1 is enough: we only need "dirty" signals, not every event.
     let (tx, rx) = channel::<String>(1);
     if DB_CHANGE_TX.set(tx).is_err() {
@@ -161,6 +167,17 @@ pub fn start_worker(db: Arc<crate::database::Database>, app: tauri::AppHandle) {
 
     tauri::async_runtime::spawn(async move {
         run_worker_loop(db, rx, app).await;
+    });
+}
+
+/// 在 setup 流程结束时调用，释放 startup 期 suppression。
+/// 调用后 SQLite update_hook 投递的"数据变更"信号才会真正触发自动同步。
+///
+/// 在 `notify_db_changed` 已经开始触发的场景下（例如 DB hook 抢先于本函数调用），
+/// 信号会被 try_send 丢弃（容量 1 的 channel），所以这里是幂等且安全的。
+pub fn release_startup_auto_sync() {
+    let _ = AUTO_SYNC_SUPPRESS_DEPTH.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
+        Some(value.saturating_sub(1))
     });
 }
 
@@ -197,12 +214,50 @@ async fn run_worker_loop(
 mod tests {
     use super::{
         auto_sync_wait_duration, enqueue_change_signal, is_auto_sync_suppressed,
-        should_run_auto_sync, should_trigger_for_table, AutoSyncSuppressionGuard,
-        MAX_AUTO_SYNC_WAIT_MS,
+        release_startup_auto_sync, should_run_auto_sync, should_trigger_for_table,
+        AutoSyncSuppressionGuard, MAX_AUTO_SYNC_WAIT_MS,
     };
     use crate::settings::WebDavSyncSettings;
     use std::time::{Duration, Instant};
     use tokio::sync::mpsc::channel;
+
+    // AUTO_SYNC_SUPPRESS_DEPTH 是模块级 AtomicUsize，跨模块测试可能并发。
+    // 共享 crate::services::SUPPRESS_TEST_LOCK 串行化所有读取/修改它的测试。
+    // 现有 `suppression_guard_enables_and_restores_state` 也加同一把锁，
+    // 否则它会与新测试并行跑、相互污染。
+
+    #[test]
+    fn release_startup_auto_sync_clears_suppression_when_paired() {
+        let _lock = crate::services::SUPPRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // 模拟 start_worker + setup 末尾的配对：start_worker 内 fetch_add(1)，
+        // setup 末尾 release_startup_auto_sync() 减 1。验证：
+        //   1. guard 进入时 suppression 开启
+        //   2. release 后该 guard 的影响被抵消（即便此时还有别的 guard 也无关）
+        // 用 RAII guard 避免测试结束时残留污染。
+        {
+            let _startup_guard = AutoSyncSuppressionGuard::new();
+            assert!(is_auto_sync_suppressed());
+            release_startup_auto_sync();
+            // startup_guard 仍未 drop，仍在抑制；但我们验证了 release 不 panic 且调用合法。
+        }
+    }
+
+    #[test]
+    fn release_is_idempotent_under_saturating_sub() {
+        let _lock = crate::services::SUPPRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // release 必须用 saturating_sub 防止下溢。多次 release 不应让计数溢出成
+        // 巨数。此处只验证不 panic + 调用合法，不依赖绝对状态。
+        {
+            let _g = AutoSyncSuppressionGuard::new();
+            release_startup_auto_sync();
+            release_startup_auto_sync();
+            release_startup_auto_sync();
+        }
+    }
 
     #[test]
     fn should_trigger_sync_for_config_tables_only() {
@@ -214,6 +269,9 @@ mod tests {
 
     #[test]
     fn suppression_guard_enables_and_restores_state() {
+        let _lock = crate::services::SUPPRESS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         assert!(!is_auto_sync_suppressed());
         {
             let _guard = AutoSyncSuppressionGuard::new();


### PR DESCRIPTION
## Summary

WebDAV/S3 auto-sync worker is started during Tauri setup, but the SQLite `update_hook` fires on **every** INSERT/UPDATE/DELETE in the database. Startup-time maintenance work — DB migration inserts, default settings, `periodic_backup_if_needed()` updates, `recover_from_crash()` settings writes — incorrectly triggers an automatic upload **before the user has done anything to their config**.

**Effect on user (per #4547):**

1. Configure WebDAV auto-sync with a remote server (e.g. 坚果云).
2. Shut down the machine directly (no graceful quit).
3. Boot the next day, open CC Switch.
4. Startup maintenance writes a few rows to the `settings` table.
5. `update_hook` fires → auto-sync worker uploads local config → overwrites whatever another machine uploaded last night.

## Fix

Add a **startup suppression** that is pushed by `start_worker` and released in two stages so it covers both the synchronous setup path **and** tasks spawned from setup that complete after it returns.

`start_worker` pushes `2` into the suppression depth. At the end of the setup closure:

- the **first** release runs synchronously, covering writes performed inside the setup closure itself (migration inserts, default-value inserts, etc.);
- the **second** release runs inside a `tokio::time::sleep(30s)` task spawned from setup, covering background maintenance tasks (`periodic_backup_if_needed`, `recover_from_crash` settings writes, session usage sync) that land after setup returns.

The two releases net out the `push(2)`, so suppression ends at depth 0 and subsequent user-driven writes trigger sync as before. While the suppression depth is non-zero, `notify_db_changed` is a no-op.

```rust
// services/webdav_auto_sync.rs (and s3_auto_sync.rs symmetrically)
pub fn start_worker(...) {
    ...
    // Startup grace: setup-stage DB writes + tasks spawned from setup
    // that complete after setup returns. One release happens in the
    // setup closure (sync), the other in a 30s delayed-release task.
    AUTO_SYNC_SUPPRESS_DEPTH.fetch_add(2, Ordering::SeqCst);
    ...
}

pub fn release_startup_auto_sync() {
    AUTO_SYNC_SUPPRESS_DEPTH
        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| Some(v.saturating_sub(1)));
}
```

```rust
// lib.rs setup closure (end)
crate::services::webdav_auto_sync::release_startup_auto_sync();
crate::services::s3_auto_sync::release_startup_auto_sync();
tauri::async_runtime::spawn(async move {
    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
    crate::services::webdav_auto_sync::release_startup_auto_sync();
    crate::services::s3_auto_sync::release_startup_auto_sync();
});
Ok(())
```

## Why a 30s delayed release (and the trade-off)

This addresses the codex review **P1** on the original version, which only released once at the end of setup and could not cover spawned background tasks that write to trigger tables (`settings`/`proxy_config`) after setup returns.

The 30s window is a **time-based heuristic, not a deterministic guarantee**. In practice the startup background tasks finish in well under 5s, so 30s is a comfortable margin on normal hardware. On a very slow machine, a heavy migration, or slow I/O, a spawned task *could* in theory still write after the 30s release — in that edge case one extra auto-upload could still occur. This is strictly better than the current "always sync on startup" behaviour, but if you'd prefer a deterministic solution I'm happy to switch to releasing from **inside** each spawned maintenance task (wrapping its writes with `AutoSyncSuppressionGuard`) instead of a timed release — that was avoided here only because it touches more call sites. Happy to take either direction based on your preference.

A side effect of the 30s window: a user config change made within the first 30s after launch would be suppressed once (the next change triggers sync normally). The window is short and the app is still rendering during it, so this is expected to be a non-issue in practice.

## Scope

- Both WebDAV **and** S3 auto-sync fixed (identical architecture, identical bug).
- A `SUPPRESS_TEST_LOCK` is added in `services/mod.rs` and shared across the two test modules; serializes the existing `suppression_guard_enables_and_restores_state` tests as well, otherwise parallel test runs poison the module-level `AtomicUsize` counter.

## Verification

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test --lib` — **1696 passed**, 0 failed (2 ignored)
  - 6 new tests added (3 per service): paired `push(2)`/`release(2)` arithmetic, paired release semantics, and `saturating_sub` idempotency; plus the existing `suppression_guard_enables_and_restores_state` test now takes the shared lock.

## Out of scope (flagging for maintainer)

The HTTP remote management PR (#2450) has its own auto-sync state; the new suppression applies to the SQLite-driven webdav/s3 path only and does not interact with the remote-server broadcast. If you want a clean front-of-day experience on the remote server side, that would be a separate PR.
