### PR TITLE
[codex] skip hidden OpenClaw live sync

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -161,6 +161,8 @@ fn apply_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provi
             .unwrap_or_else(|| Value::String(KIMI_FOR_CODING_CONTEXT_TOKENS.to_string()));
         env.insert(key.to_string(), value);
     }
+fn openclaw_live_sync_hidden() -> bool {
+    !crate::settings::is_app_visible(&AppType::OpenClaw)
 }
 
 pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
@@ -700,6 +702,14 @@ pub(crate) fn write_live_with_common_config(
     app_type: &AppType,
     provider: &Provider,
 ) -> Result<(), AppError> {
+    if matches!(app_type, AppType::OpenClaw) && openclaw_live_sync_hidden() {
+        log::debug!(
+            "OpenClaw is hidden in visibleApps; skipping live config write for provider '{}'",
+            provider.id
+        );
+        return Ok(());
+    }
+
     let mut effective_provider = provider.clone();
     effective_provider.settings_config =
         build_effective_settings_with_common_config(db, app_type, provider)?;
@@ -1171,6 +1181,11 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
 /// Writes all providers from the database to the live configuration file.
 /// Used for OpenCode and other additive mode applications.
 fn sync_all_providers_to_live(state: &AppState, app_type: &AppType) -> Result<(), AppError> {
+    if matches!(app_type, AppType::OpenClaw) && openclaw_live_sync_hidden() {
+        log::debug!("OpenClaw is hidden in visibleApps; skipping live provider sync");
+        return Ok(());
+    }
+
     let providers = state.db.get_all_providers(app_type.as_str())?;
     let mut synced_count = 0usize;
 
@@ -1763,6 +1778,11 @@ pub fn import_opencode_providers_from_live(state: &AppState) -> Result<usize, Ap
 pub fn import_openclaw_providers_from_live(state: &AppState) -> Result<usize, AppError> {
     use crate::openclaw_config;
 
+    if openclaw_live_sync_hidden() {
+        log::debug!("OpenClaw is hidden in visibleApps; skipping live provider import");
+        return Ok(0);
+    }
+
     let providers = openclaw_config::get_typed_providers()?;
     if providers.is_empty() {
         return Ok(0);
@@ -1936,6 +1956,13 @@ pub fn remove_hermes_provider_from_live(provider_id: &str) -> Result<(), AppErro
 /// without affecting other providers in the file.
 pub fn remove_openclaw_provider_from_live(provider_id: &str) -> Result<(), AppError> {
     use crate::openclaw_config;
+
+    if openclaw_live_sync_hidden() {
+        log::debug!(
+            "OpenClaw is hidden in visibleApps; skipping live config removal for provider '{provider_id}'"
+        );
+        return Ok(());
+    }
 
     // Check if OpenClaw config directory exists
     if !openclaw_config::get_openclaw_dir().exists() {

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -230,6 +230,7 @@ mod tests {
         let old_home = std::env::var_os("HOME");
         std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
         std::env::set_var("HOME", temp.path());
+        crate::settings::reload_settings().expect("reload settings for test home");
 
         let db = Arc::new(Database::memory().expect("in-memory database"));
         let state = AppState::new(db);
@@ -243,6 +244,7 @@ mod tests {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
         }
+        crate::settings::reload_settings().expect("restore settings after test home");
 
         result
     }
@@ -309,6 +311,15 @@ mod tests {
             ..Default::default()
         });
         provider
+    }
+
+    fn hide_openclaw_app() {
+        let mut settings = crate::settings::AppSettings::default();
+        settings.visible_apps = Some(crate::settings::VisibleApps {
+            openclaw: false,
+            ..Default::default()
+        });
+        crate::settings::update_settings(settings).expect("hide openclaw");
     }
 
     fn openclaw_provider(id: &str) -> Provider {
@@ -1557,6 +1568,36 @@ requires_openai_auth = true
 
     #[test]
     #[serial]
+    fn sync_current_provider_for_app_skips_hidden_openclaw_live_sync() {
+        with_test_home(|state, _| {
+            hide_openclaw_app();
+
+            let mut provider = openclaw_provider("hidden-openclaw-reset");
+            provider.settings_config["models"] = json!([
+                {
+                    "id": "claude-sonnet-4",
+                    "name": "Claude Sonnet 4"
+                }
+            ]);
+            state
+                .db
+                .save_provider(AppType::OpenClaw.as_str(), &provider)
+                .expect("seed hidden openclaw provider in db");
+
+            ProviderService::sync_current_provider_for_app(state, AppType::OpenClaw)
+                .expect("sync hidden openclaw providers");
+
+            let live_providers =
+                crate::openclaw_config::get_providers().expect("read openclaw providers");
+            assert!(
+                !live_providers.contains_key(&provider.id),
+                "hidden OpenClaw should not restore database providers to live config"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
     fn import_opencode_providers_from_live_marks_provider_as_live_managed() {
         with_test_home(|state, _| {
             let provider = opencode_provider("imported-opencode");
@@ -1690,6 +1731,37 @@ requires_openai_auth = true
             assert_eq!(
                 saved.settings_config["models"][0]["name"],
                 json!("Claude Sonnet 4.1")
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn import_openclaw_providers_from_live_skips_hidden_openclaw() {
+        with_test_home(|state, _| {
+            let mut provider = openclaw_provider("hidden-imported-openclaw");
+            provider.settings_config["models"] = json!([
+                {
+                    "id": "claude-sonnet-4",
+                    "name": "Claude Sonnet 4"
+                }
+            ]);
+            crate::openclaw_config::set_provider(&provider.id, provider.settings_config.clone())
+                .expect("seed openclaw live provider");
+
+            hide_openclaw_app();
+
+            let imported = import_openclaw_providers_from_live(state)
+                .expect("import hidden openclaw providers from live");
+            assert_eq!(imported, 0);
+
+            let saved = state
+                .db
+                .get_provider_by_id(&provider.id, AppType::OpenClaw.as_str())
+                .expect("query hidden imported openclaw provider");
+            assert!(
+                saved.is_none(),
+                "hidden OpenClaw should not import live providers into the database"
             );
         });
     }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -733,6 +733,14 @@ pub fn get_settings() -> AppSettings {
         .clone()
 }
 
+pub fn is_app_visible(app_type: &AppType) -> bool {
+    let settings = get_settings();
+    settings.visible_apps.as_ref().map_or_else(
+        || VisibleApps::default().is_visible(app_type),
+        |visible| visible.is_visible(app_type),
+    )
+}
+
 pub fn get_settings_for_frontend() -> AppSettings {
     let mut settings = get_settings();
     if let Some(sync) = &mut settings.webdav_sync {


### PR DESCRIPTION
Fixes #4593.

## Summary
- Add a backend visible-app check that defaults to the existing VisibleApps defaults when no setting is saved.
- Skip OpenClaw live config writes, provider sync, provider import, and provider removal when visibleApps.openclaw is false.
- Add regression coverage for hidden OpenClaw not restoring DB providers into live config and not importing live providers into the database.

## Validation
- git diff --check

Not run locally: cargo fmt / cargo test, because this machine does not currently have cargo/rustc/rustup installed in PATH.