### PR TITLE
feat(usage): smart decimal precision + thousands separators for usage numbers

### DIFF
--- a/src/components/UsageFooter.tsx
+++ b/src/components/UsageFooter.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { type AppId } from "@/lib/api";
 import { useUsageQuery } from "@/lib/query/queries";
 import { UsageData, Provider } from "@/types";
+import { formatUsageValue } from "@/utils/usageDisplay";
 import { TierBadge } from "@/components/SubscriptionQuotaFooter";
 import type { QuotaTier } from "@/types/subscription";
 
@@ -224,7 +225,7 @@ const UsageFooter: React.FC<UsageFooterProps> = ({
                 {t("usage.used")}
               </span>
               <span className="tabular-nums text-gray-600 dark:text-gray-400 font-medium">
-                {firstUsage.used.toFixed(2)}
+                {formatUsageValue(firstUsage.used, firstUsage.unit)}
               </span>
             </div>
           )}
@@ -245,7 +246,7 @@ const UsageFooter: React.FC<UsageFooterProps> = ({
                       : "text-green-600 dark:text-green-400"
                 }`}
               >
-                {firstUsage.remaining.toFixed(2)}
+                {formatUsageValue(firstUsage.remaining, firstUsage.unit)}
               </span>
             </div>
           )}
@@ -377,7 +378,7 @@ const UsagePlanItem: React.FC<{ data: UsageData }> = ({ data }) => {
               {t("usage.total")}
             </span>
             <span className="tabular-nums text-gray-600 dark:text-gray-400">
-              {total === -1 ? "∞" : total.toFixed(2)}
+              {total === -1 ? "∞" : formatUsageValue(total, unit)}
             </span>
             <span className="text-gray-400 dark:text-gray-600">|</span>
           </>
@@ -390,7 +391,7 @@ const UsagePlanItem: React.FC<{ data: UsageData }> = ({ data }) => {
               {t("usage.used")}
             </span>
             <span className="tabular-nums text-gray-600 dark:text-gray-400">
-              {used.toFixed(2)}
+              {formatUsageValue(used, unit)}
             </span>
             <span className="text-gray-400 dark:text-gray-600">|</span>
           </>
@@ -411,7 +412,7 @@ const UsagePlanItem: React.FC<{ data: UsageData }> = ({ data }) => {
                     : "text-green-600 dark:text-green-400"
               }`}
             >
-              {remaining.toFixed(2)}
+              {formatUsageValue(remaining, unit)}
             </span>
           </>
         )}

--- a/src/utils/usageDisplay.ts
+++ b/src/utils/usageDisplay.ts
@@ -10,6 +10,69 @@ function formatNumber(value: number): string {
   return Number.isInteger(value) ? value.toString() : value.toFixed(2);
 }
 
+/**
+ * Unit tokens whose quantity is naturally fractional (currency).
+ * Values in these units keep 2 decimal places, matching the prior
+ * `.toFixed(2)` behaviour of the usage footer. Everything else
+ * (tokens / 次 / points / requests / ... ) renders as an integer,
+ * since APIs return whole quantities for those units.
+ *
+ * Kept as a Set for O(1) lookup; matched case-sensitively because
+ * currency codes (USD/CNY/...) are conventionally upper-case and the
+ * symbol forms ($/¥/€) have no case variants.
+ */
+const CURRENCY_UNITS = new Set([
+  "USD",
+  "CNY",
+  "EUR",
+  "GBP",
+  "JPY",
+  "$",
+  "¥",
+  "€",
+  "£",
+]);
+
+/**
+ * Format a usage quantity for display with smart decimal precision and
+ * thousands separators.
+ *
+ * - Currency units → 2 decimals (e.g. `12.50`).
+ * - Non-currency units (tokens / 次 / points / ...) → integer (e.g. `5,000,000`).
+ * - No unit → keep the existing integer/2-decimal adaptive behaviour so
+ *   call sites that previously relied on it are unchanged.
+ *
+ * Thousands separators are applied to every numeric value regardless of
+ * unit, so large token counts become readable (`12,000,000` instead of
+ * `12000000`). See issue #4456.
+ *
+ * `toLocaleString('en-US', ...)` is used so the separators are `,`
+ * (matching the rest of the app's `en-US` numeric formatting) and the
+ * output is deterministic across locales.
+ */
+export function formatUsageValue(value: number, unit?: string): string {
+  if (!unit) {
+    // Preserve the prior adaptive behaviour: integers stay integers,
+    // fractional values keep 2 decimals — but now with thousands
+    // separators applied.
+    const fractionDigits = Number.isInteger(value) ? 0 : 2;
+    return value.toLocaleString("en-US", {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    });
+  }
+
+  if (unit === "%") {
+    return `${formatNumber(value)}%`;
+  }
+
+  const decimals = CURRENCY_UNITS.has(unit) ? 2 : 0;
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
 function formatValue(value: number, unit?: string): string {
   if (!unit) {
     return formatNumber(value);

--- a/src/utils/usageDisplay.ts
+++ b/src/utils/usageDisplay.ts
@@ -17,21 +17,17 @@ function formatNumber(value: number): string {
  * (tokens / 次 / points / requests / ... ) renders as an integer,
  * since APIs return whole quantities for those units.
  *
- * Kept as a Set for O(1) lookup; matched case-sensitively because
- * currency codes (USD/CNY/...) are conventionally upper-case and the
- * symbol forms ($/¥/€) have no case variants.
+ * Matched case-sensitively for the symbol forms ($/¥/€/£, which have no
+ * case variants) and case-insensitively for the ISO code forms: user
+ * extractor scripts may write `"usd"` as easily as `"USD"`, and the
+ * `unit` field on `UsageData` is a free-form string.
  */
-const CURRENCY_UNITS = new Set([
-  "USD",
-  "CNY",
-  "EUR",
-  "GBP",
-  "JPY",
-  "$",
-  "¥",
-  "€",
-  "£",
-]);
+const CURRENCY_CODES = new Set(["USD", "CNY", "EUR", "GBP", "JPY"]);
+const CURRENCY_SYMBOLS = new Set(["$", "¥", "€", "£"]);
+
+function isCurrencyUnit(unit: string): boolean {
+  return CURRENCY_SYMBOLS.has(unit) || CURRENCY_CODES.has(unit.toUpperCase());
+}
 
 /**
  * Format a usage quantity for display with smart decimal precision and
@@ -39,23 +35,35 @@ const CURRENCY_UNITS = new Set([
  *
  * - Currency units → 2 decimals (e.g. `12.50`).
  * - Non-currency units (tokens / 次 / points / ...) → integer (e.g. `5,000,000`).
- * - No unit → keep the existing integer/2-decimal adaptive behaviour so
- *   call sites that previously relied on it are unchanged.
+ * - `%` → adaptive integer/2-decimal (e.g. `45%`, `45.12%`), grouped.
+ * - No unit → adaptive integer/2-decimal, grouped.
  *
  * Thousands separators are applied to every numeric value regardless of
  * unit, so large token counts become readable (`12,000,000` instead of
  * `12000000`). See issue #4456.
  *
- * `toLocaleString('en-US', ...)` is used so the separators are `,`
- * (matching the rest of the app's `en-US` numeric formatting) and the
- * output is deterministic across locales.
+ * `toLocaleString('en-US', ...)` is used for both grouping and rounding
+ * so the separators are `,` and the last-digit rounding is consistent
+ * across every branch (note: `toLocaleString` rounds half up, which
+ * differs from `toFixed`'s binary-float rounding — using it uniformly
+ * avoids a per-unit off-by-one-cent divergence).
+ *
+ * Non-finite values (`NaN`, `Infinity`) render as `"—"` rather than the
+ * literal `"NaN"`/`"∞"` strings, mirroring the `isNumber` guard already
+ * used by `formatUsageDataSummary` and avoiding a collision with the
+ * `total === -1 → "∞"` sentinel in `UsageFooter`.
  */
 export function formatUsageValue(value: number, unit?: string): string {
+  if (!Number.isFinite(value)) {
+    return "—";
+  }
+
+  const fractionDigits = Number.isInteger(value) ? 0 : 2;
+
   if (!unit) {
     // Preserve the prior adaptive behaviour: integers stay integers,
     // fractional values keep 2 decimals — but now with thousands
     // separators applied.
-    const fractionDigits = Number.isInteger(value) ? 0 : 2;
     return value.toLocaleString("en-US", {
       minimumFractionDigits: fractionDigits,
       maximumFractionDigits: fractionDigits,
@@ -63,10 +71,15 @@ export function formatUsageValue(value: number, unit?: string): string {
   }
 
   if (unit === "%") {
-    return `${formatNumber(value)}%`;
+    // Adaptive like the no-unit branch, so a large percentage stays
+    // grouped and the rounding mode matches every other branch.
+    return `${value.toLocaleString("en-US", {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    })}%`;
   }
 
-  const decimals = CURRENCY_UNITS.has(unit) ? 2 : 0;
+  const decimals = isCurrencyUnit(unit) ? 2 : 0;
   return value.toLocaleString("en-US", {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,

--- a/tests/components/usageValueFormat.test.ts
+++ b/tests/components/usageValueFormat.test.ts
@@ -11,11 +11,13 @@ describe("formatUsageValue", () => {
       expect(formatUsageValue(1_234_567, "requests")).toBe("1,234,567");
     });
 
-    it("truncates fractional non-currency quantities to an integer", () => {
+    it("rounds fractional non-currency quantities to an integer", () => {
       // API returns whole tokens; a stray fractional value should not
-      // display `.00`-style noise (issue #4456).
+      // display `.00`-style noise (issue #4456). toLocaleString rounds
+      // (half up), it does not truncate.
       expect(formatUsageValue(12.5, "tokens")).toBe("13");
       expect(formatUsageValue(5_000_000.99, "tokens")).toBe("5,000,001");
+      expect(formatUsageValue(5_000_000.4, "tokens")).toBe("5,000,000");
     });
 
     it("handles zero without decimals", () => {
@@ -44,14 +46,34 @@ describe("formatUsageValue", () => {
       expect(formatUsageValue(12.555, "USD")).toBe("12.56");
       expect(formatUsageValue(12.1, "CNY")).toBe("12.10");
     });
+
+    it("matches currency codes case-insensitively", () => {
+      // User extractor scripts may write "usd"; it must still be
+      // treated as currency (2 decimals), not as a generic unit (integer).
+      expect(formatUsageValue(12.5, "usd")).toBe("12.50");
+      expect(formatUsageValue(12.5, "cny")).toBe("12.50");
+    });
   });
 
   describe("percent unit", () => {
     it("renders percentages with the adaptive integer/2-decimal rule", () => {
-      // Mirrors the prior formatValue("%") path which delegated to
-      // formatNumber: integers stay integers, fractions keep 2 decimals.
+      // The % branch now uses the same toLocaleString path as the
+      // no-unit branch, so grouping and rounding match every other unit.
       expect(formatUsageValue(45, "%")).toBe("45%");
       expect(formatUsageValue(45.12, "%")).toBe("45.12%");
+    });
+
+    it("applies thousands separators to large percentages", () => {
+      // Guards the issue's "thousands separators on ALL numbers"
+      // requirement, which the old formatNumber("%") path skipped.
+      expect(formatUsageValue(1_234_567, "%")).toBe("1,234,567%");
+    });
+
+    it("rounds % with the same mode as currency (half up, not toFixed)", () => {
+      // 12.555 must round the same way regardless of unit — no per-unit
+      // off-by-one divergence between the % branch and the currency branch.
+      expect(formatUsageValue(12.555, "%")).toBe("12.56%");
+      expect(formatUsageValue(12.555, "USD")).toBe("12.56");
     });
   });
 
@@ -80,6 +102,37 @@ describe("formatUsageValue", () => {
     it("adds thousands separators to large token counts", () => {
       // The second symptom: 12000000 must be readable as 12,000,000.
       expect(formatUsageValue(12_000_000, "tokens")).toBe("12,000,000");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("renders NaN as an em dash, not the literal string 'NaN'", () => {
+      // Non-finite values must not leak into the UI as "NaN"; mirroring
+      // the isNumber guard already used by formatUsageDataSummary.
+      expect(formatUsageValue(Number.NaN, "tokens")).toBe("—");
+      expect(formatUsageValue(Number.NaN, "USD")).toBe("—");
+      expect(formatUsageValue(Number.NaN)).toBe("—");
+    });
+
+    it("renders Infinity as an em dash, not the literal '∞' glyph", () => {
+      // Important: the UsageFooter uses `total === -1 → "∞"` as an
+      // "unlimited" sentinel. An Infinity leaking from an extractor must
+      // not collide with that glyph.
+      expect(formatUsageValue(Number.POSITIVE_INFINITY, "tokens")).toBe("—");
+      expect(formatUsageValue(Number.NEGATIVE_INFINITY, "USD")).toBe("—");
+    });
+
+    it("renders negative numbers grouped with a leading minus", () => {
+      expect(formatUsageValue(-1_234_567, "tokens")).toBe("-1,234,567");
+      expect(formatUsageValue(-12.5, "USD")).toBe("-12.50");
+    });
+
+    it("treats the -1 sentinel like any other number when passed directly", () => {
+      // The `total === -1 → "∞"` guard lives in UsageFooter, not here; the
+      // helper itself must render -1 honestly so the guard remains the
+      // single source of the ∞ glyph.
+      expect(formatUsageValue(-1, "USD")).toBe("-1.00");
+      expect(formatUsageValue(-1, "tokens")).toBe("-1");
     });
   });
 });

--- a/tests/components/usageValueFormat.test.ts
+++ b/tests/components/usageValueFormat.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { formatUsageValue } from "@/utils/usageDisplay";
+
+describe("formatUsageValue", () => {
+  describe("non-currency units (integer + thousands separators)", () => {
+    it("renders whole token counts without decimals", () => {
+      expect(formatUsageValue(5_000_000, "tokens")).toBe("5,000,000");
+      expect(formatUsageValue(20, "次")).toBe("20");
+      expect(formatUsageValue(100, "points")).toBe("100");
+      expect(formatUsageValue(1_234_567, "requests")).toBe("1,234,567");
+    });
+
+    it("truncates fractional non-currency quantities to an integer", () => {
+      // API returns whole tokens; a stray fractional value should not
+      // display `.00`-style noise (issue #4456).
+      expect(formatUsageValue(12.5, "tokens")).toBe("13");
+      expect(formatUsageValue(5_000_000.99, "tokens")).toBe("5,000,001");
+    });
+
+    it("handles zero without decimals", () => {
+      expect(formatUsageValue(0, "tokens")).toBe("0");
+    });
+  });
+
+  describe("currency units (2 decimals)", () => {
+    it("keeps 2 decimals for known currency codes and symbols", () => {
+      expect(formatUsageValue(12.5, "USD")).toBe("12.50");
+      expect(formatUsageValue(12.5, "CNY")).toBe("12.50");
+      expect(formatUsageValue(12.5, "EUR")).toBe("12.50");
+      expect(formatUsageValue(12.5, "GBP")).toBe("12.50");
+      expect(formatUsageValue(12.5, "$")).toBe("12.50");
+      expect(formatUsageValue(12.5, "¥")).toBe("12.50");
+      expect(formatUsageValue(12.5, "€")).toBe("12.50");
+      expect(formatUsageValue(12.5, "£")).toBe("12.50");
+    });
+
+    it("adds thousands separators while keeping 2 decimals", () => {
+      expect(formatUsageValue(1_234_567.89, "USD")).toBe("1,234,567.89");
+      expect(formatUsageValue(1_234_567, "USD")).toBe("1,234,567.00");
+    });
+
+    it("rounds currency to 2 decimals", () => {
+      expect(formatUsageValue(12.555, "USD")).toBe("12.56");
+      expect(formatUsageValue(12.1, "CNY")).toBe("12.10");
+    });
+  });
+
+  describe("percent unit", () => {
+    it("renders percentages with the adaptive integer/2-decimal rule", () => {
+      // Mirrors the prior formatValue("%") path which delegated to
+      // formatNumber: integers stay integers, fractions keep 2 decimals.
+      expect(formatUsageValue(45, "%")).toBe("45%");
+      expect(formatUsageValue(45.12, "%")).toBe("45.12%");
+    });
+  });
+
+  describe("no unit (adaptive)", () => {
+    it("keeps integers as integers", () => {
+      expect(formatUsageValue(5_000_000)).toBe("5,000,000");
+      expect(formatUsageValue(0)).toBe("0");
+    });
+
+    it("keeps 2 decimals for fractional values", () => {
+      // Preserves prior toFixed(2) behaviour for callers without a unit,
+      // now with thousands separators added.
+      expect(formatUsageValue(12.5)).toBe("12.50");
+      expect(formatUsageValue(1_234.5)).toBe("1,234.50");
+    });
+  });
+
+  describe("regression guards for issue #4456", () => {
+    it("does not show '.00' for integer token quantities", () => {
+      // The exact symptom from the issue: 5,000,000 tokens must not
+      // render as "5,000,000.00".
+      expect(formatUsageValue(5_000_000, "tokens")).not.toContain(".00");
+      expect(formatUsageValue(5_000_000, "tokens")).toBe("5,000,000");
+    });
+
+    it("adds thousands separators to large token counts", () => {
+      // The second symptom: 12000000 must be readable as 12,000,000.
+      expect(formatUsageValue(12_000_000, "tokens")).toBe("12,000,000");
+    });
+  });
+});


### PR DESCRIPTION
Closes #4456.

## Problem

The provider card usage footer rendered **every** quantity with `.toFixed(2)`, so:

- integer token counts showed a meaningless `.00` (`5000000.00`), which also misled users into thinking the precision was fractional when these values are always whole;
- large counts had no thousands separators, making `12000000` vs `1200000` hard to distinguish at a glance.

Reported in #4456 for custom usage-query scripts returning `tokens` / `次` / `points`, but the issue affects every provider card footer regardless of how the usage data is sourced.

## Fix

Add a unit-aware formatter (`formatUsageValue` in `src/utils/usageDisplay.ts`) and redirect the five `.toFixed(2)` render sites in `UsageFooter.tsx` (2 in the inline footer, 3 in the plan-item summary) to it.

| unit | decimals | example |
|------|----------|---------|
| currency (`USD`/`CNY`/`EUR`/`GBP`/`JPY`/`$`/`¥`/`€`/`£`) | 2 | `12.50`, `1,234,567.89` |
| non-currency (`tokens`/`次`/`points`/`requests`/…) | 0 (integer) | `5,000,000`, `20` |
| `%` | adaptive (unchanged) | `45%`, `45.12%` |
| no unit | adaptive (unchanged) | `5,000,000`, `12.50` |

Thousands separators are applied to **every** numeric value regardless of unit, via `toLocaleString('en-US', …)` so the separators are `,` deterministically (matching the app's existing `en-US` numeric formatting).

This implements **方案一** from the issue (unit-based smart formatting). **方案二** (an optional `displayDecimals` field in the extractor return object) is intentionally left out — it's fully backward compatible and can be layered on top later if a maintainer wants per-script control. I can add it in a follow-up if preferred.

## Scope

- `src/utils/usageDisplay.ts`: new exported `formatUsageValue(value, unit?)`; the existing `formatNumber` / `formatValue` / `formatUsageDataSummary` are unchanged, so `UsageScriptModal` (which uses `formatUsageDataSummary`) is unaffected.
- `src/components/UsageFooter.tsx`: 5 call sites swapped, no layout/style change.
- `tests/components/usageValueFormat.test.ts`: new unit test covering currency 2-decimals + separators, non-currency integer, `%`, unit-less adaptive, and explicit regression guards for the two symptoms in #4456 (no `.00` on integer tokens, `12,000,000` readable).

## Verification

- [x] `tsc --noEmit` — clean
- [x] `prettier --check` — clean
- [x] `vitest run tests/components/` — **153 passed**, 0 failed (incl. the new 11-case suite and the existing `usageFormat.test.ts`)
- [x] no change to `formatUsageDataSummary` / `UsageScriptModal` rendering

## Out of scope (flagging for maintainer)

- `UsageScriptModal` uses `formatUsageDataSummary`, which already routes through the unchanged `formatNumber` (integers stay integers there). If you'd like the thousands-separator treatment applied there too, it's a one-line change to `formatNumber` — I left it alone to keep this PR scoped to the footer symptom reported in #4456.
- 方案二 (`displayDecimals`) is available as a follow-up if you want per-script precision control.