### PR TITLE
fix(presets): fix Volcengine Ark Agent Plan default endpoint from /api/coding to /api/plan

### DIFF
--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -18,7 +18,7 @@ enum CodingPlanProvider {
     MiniMaxEn,
     ZenMux,
     /// 火山方舟 Agent Plan / Coding Plan（base_url 形如
-    /// `https://ark.cn-beijing.volces.com/api/coding[/v3]`）。
+    /// `https://ark.cn-beijing.volces.com/api/{coding,plan}[/v3]`）。
     Volcengine,
 }
 
@@ -36,7 +36,7 @@ fn detect_provider(base_url: &str) -> Option<CodingPlanProvider> {
         Some(CodingPlanProvider::MiniMaxEn)
     } else if url.contains("zenmux") {
         Some(CodingPlanProvider::ZenMux)
-    } else if url.contains("volces.com/api/coding") {
+    } else if url.contains("volces.com/api/coding") || url.contains("volces.com/api/plan") {
         // 仅匹配 Coding/Agent Plan 入口；DouBaoSeed 按量付费走 /api/v3 与
         // /api/compatible，没有套餐额度，不在此命中。
         Some(CodingPlanProvider::Volcengine)

--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -191,7 +191,7 @@ export const claudeDesktopProviderPresets: ClaudeDesktopProviderPreset[] = [
     apiKeyUrl:
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",
     category: "cn_official",
-    baseUrl: "https://ark.cn-beijing.volces.com/api/coding",
+    baseUrl: "https://ark.cn-beijing.volces.com/api/plan",
     mode: "proxy",
     apiFormat: "anthropic",
     modelRoutes: brandedRoutes(

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -134,7 +134,7 @@ export const providerPresets: ProviderPreset[] = [
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",
     settingsConfig: {
       env: {
-        ANTHROPIC_BASE_URL: "https://ark.cn-beijing.volces.com/api/coding",
+        ANTHROPIC_BASE_URL: "https://ark.cn-beijing.volces.com/api/plan",
         ANTHROPIC_AUTH_TOKEN: "",
         ANTHROPIC_MODEL: "ark-code-latest",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "ark-code-latest",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -142,10 +142,10 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     auth: generateThirdPartyAuth(""),
     config: generateThirdPartyConfig(
       "ark_agentplan",
-      "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "https://ark.cn-beijing.volces.com/api/plan/v3",
       "ark-code-latest",
     ),
-    endpointCandidates: ["https://ark.cn-beijing.volces.com/api/coding/v3"],
+    endpointCandidates: ["https://ark.cn-beijing.volces.com/api/plan/v3"],
     apiFormat: "openai_chat",
     modelCatalog: modelCatalog([
       {

--- a/src/config/codingPlanProviders.ts
+++ b/src/config/codingPlanProviders.ts
@@ -37,11 +37,11 @@ export const CODING_PLAN_PROVIDERS: readonly CodingPlanProviderEntry[] = [
   },
   {
     // 火山方舟 Agent Plan / Coding Plan。base_url 形如
-    // ark.cn-beijing.volces.com/api/coding[/v3]；与后端 detect_provider 的
-    // `volces.com/api/coding` 子串判断同效。
+    // ark.cn-beijing.volces.com/api/{coding,plan}[/v3]；与后端 detect_provider 的
+    // `volces.com/api/coding` 和 `volces.com/api/plan` 子串判断同效。
     id: "volcengine",
     label: "火山方舟 (Volcengine)",
-    pattern: /volces\.com\/api\/coding/i,
+    pattern: /volces\.com\/api\/(coding|plan)/i,
   },
 ] as const;
 

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -157,7 +157,7 @@ export const hermesProviderPresets: HermesProviderPreset[] = [
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",
     settingsConfig: {
       name: "ark_agentplan",
-      base_url: "https://ark.cn-beijing.volces.com/api/coding",
+      base_url: "https://ark.cn-beijing.volces.com/api/plan",
       api_key: "",
       api_mode: "anthropic_messages",
       models: [

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -152,7 +152,7 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     apiKeyUrl:
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",
     settingsConfig: {
-      baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+      baseUrl: "https://ark.cn-beijing.volces.com/api/plan/v3",
       apiKey: "",
       api: "openai-completions",
       models: [

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -319,7 +319,7 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
       npm: "@ai-sdk/openai-compatible",
       name: "火山Agentplan",
       options: {
-        baseURL: "https://ark.cn-beijing.volces.com/api/coding/v3",
+        baseURL: "https://ark.cn-beijing.volces.com/api/plan/v3",
         apiKey: "",
         setCacheKey: true,
       },

--- a/tests/config/codexChatProviderPresets.test.ts
+++ b/tests/config/codexChatProviderPresets.test.ts
@@ -13,7 +13,7 @@ const expectedChatPresets = new Map<
   [
     "火山Agentplan",
     {
-      baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+      baseUrl: "https://ark.cn-beijing.volces.com/api/plan/v3",
       contextWindows: { "ark-code-latest": 256000 },
     },
   ],


### PR DESCRIPTION
## Problem

The default API endpoint for the "火山Agentplan" (Volcengine Ark Agent Plan) preset is incorrectly set to `https://ark.cn-beijing.volces.com/api/coding`, which causes API errors when users use the default configuration.

The correct endpoint should be `https://ark.cn-beijing.volces.com/api/plan`.

## Changes

### 1. Updated default API endpoint for 火山Agentplan preset across all supported apps

| App | Field | Change |
|-----|-------|--------|
| Claude Code | `ANTHROPIC_BASE_URL` | `/api/coding` → `/api/plan` |
| Claude Desktop | `baseUrl` | `/api/coding` → `/api/plan` |
| Codex | `base_url` and `endpointCandidates` | `/api/coding/v3` → `/api/plan/v3` |
| OpenCode | `baseURL` | `/api/coding/v3` → `/api/plan/v3` |
| OpenClaw | `baseUrl` | `/api/coding/v3` → `/api/plan/v3` |
| Hermes | `base_url` | `/api/coding` → `/api/plan` |

### 2. Updated coding plan provider detection to accept the new `/api/plan` path

- `src/config/codingPlanProviders.ts`: Updated regex from `/volces\.com\/api\/coding/i` to `/volces\.com\/api\/(coding|plan)/i` so the frontend correctly identifies the new endpoint as a Volcengine coding plan provider and auto-injects the `token_plan` usage script.
- `src-tauri/src/services/coding_plan.rs`: Updated `detect_provider` to match both `volces.com/api/coding` and `volces.com/api/plan` so the Rust backend correctly routes usage queries to the Volcengine provider.

### 3. Updated test fixture

- `tests/config/codexChatProviderPresets.test.ts`: Updated expected baseUrl from `/api/coding/v3` to `/api/plan/v3` to match the corrected preset.

**Note**: The BytePlus international preset (`ark.ap-southeast.bytepluses.com/api/coding`) and the DouBaoSeed pay-as-you-go presets remain unchanged.