### PR TITLE
feat(codex): add OpenCode Go preset and auto-populate its model catalog on fetch

### DIFF
--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -25,6 +25,10 @@ import {
   showFetchModelsError,
   type FetchedModel,
 } from "@/lib/api/model-fetch";
+import {
+  enrichOpencodeGoModels,
+  isOpencodeGoBaseUrl,
+} from "@/config/opencodeGoModelMeta";
 import { CustomUserAgentField } from "./CustomUserAgentField";
 import { cn } from "@/lib/utils";
 import type {
@@ -245,18 +249,36 @@ export function CodexFormFields({
         setFetchedModels(models);
         if (models.length === 0) {
           toast.info(t("providerForm.fetchModelsEmpty"));
-        } else {
-          toast.success(
-            t("providerForm.fetchModelsSuccess", { count: models.length }),
-          );
+          return;
         }
+        // OpenCode Go: directly enrich the fetched models into the full catalog
+        // (with per-model context windows, excluding messages-only models), so a
+        // single "Fetch Models" click auto-syncs any newly added upstream models.
+        if (isOpencodeGoBaseUrl(codexBaseUrl) && onCatalogModelsChange) {
+          const enriched = enrichOpencodeGoModels(models);
+          setCatalogRows(enriched.map((m) => createCatalogRow(m)));
+          toast.success(
+            t("providerForm.fetchModelsSuccess", { count: enriched.length }),
+          );
+          return;
+        }
+        toast.success(
+          t("providerForm.fetchModelsSuccess", { count: models.length }),
+        );
       })
       .catch((err) => {
         console.warn("[ModelFetch] Failed:", err);
         showFetchModelsError(err, t);
       })
       .finally(() => setIsFetchingModels(false));
-  }, [codexBaseUrl, codexApiKey, isFullUrl, customUserAgent, t]);
+  }, [
+    codexBaseUrl,
+    codexApiKey,
+    isFullUrl,
+    customUserAgent,
+    onCatalogModelsChange,
+    t,
+  ]);
 
   const handleAddCatalogRow = useCallback(() => {
     if (!onCatalogModelsChange) return;

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -102,6 +102,90 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     iconColor: "#00A67E",
   },
   {
+    name: "OpenCode Go",
+    websiteUrl: "https://opencode.ai/docs/go",
+    apiKeyUrl: "https://opencode.ai/auth",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "opencode_go",
+      "https://opencode.ai/zen/go/v1",
+      "deepseek-v4-flash",
+    ),
+    endpointCandidates: ["https://opencode.ai/zen/go/v1"],
+    apiFormat: "openai_chat",
+    // OpenCode Go 走 /chat/completions 通路、已实测可用的模型。
+    // 不写死 codexChatReasoning：让 cc-switch 按 model 名自动推断每个厂商的 reasoning
+    // 参数（deepseek/glm/kimi/mimo -> thinking、qwen -> enable_thinking、minimax -> reasoning_split）。
+    // 仅 /messages 的模型（如 qwen3.7-max）暂不纳入，留待 Responses->Messages 路由 PR。
+    modelCatalog: modelCatalog([
+      {
+        model: "deepseek-v4-flash",
+        displayName: "DeepSeek V4 Flash",
+        contextWindow: 1000000,
+      },
+      {
+        model: "deepseek-v4-pro",
+        displayName: "DeepSeek V4 Pro",
+        contextWindow: 1000000,
+      },
+      { model: "glm-5.2", displayName: "GLM-5.2", contextWindow: 1000000 },
+      { model: "glm-5.1", displayName: "GLM-5.1", contextWindow: 200000 },
+      { model: "glm-5", displayName: "GLM-5", contextWindow: 200000 },
+      {
+        model: "kimi-k2.7-code",
+        displayName: "Kimi K2.7 Code",
+        contextWindow: 262144,
+      },
+      { model: "kimi-k2.6", displayName: "Kimi K2.6", contextWindow: 262144 },
+      { model: "kimi-k2.5", displayName: "Kimi K2.5", contextWindow: 262144 },
+      {
+        model: "mimo-v2.5-pro",
+        displayName: "MiMo V2.5 Pro",
+        contextWindow: 1048576,
+      },
+      { model: "mimo-v2.5", displayName: "MiMo V2.5", contextWindow: 1000000 },
+      {
+        model: "mimo-v2-pro",
+        displayName: "MiMo V2 Pro",
+        contextWindow: 1048576,
+      },
+      {
+        model: "mimo-v2-omni",
+        displayName: "MiMo V2 Omni",
+        contextWindow: 262144,
+      },
+      {
+        model: "qwen3.7-plus",
+        displayName: "Qwen3.7 Plus",
+        contextWindow: 1000000,
+      },
+      {
+        model: "qwen3.6-plus",
+        displayName: "Qwen3.6 Plus",
+        contextWindow: 1000000,
+      },
+      {
+        model: "qwen3.5-plus",
+        displayName: "Qwen3.5 Plus",
+        contextWindow: 262144,
+      },
+      { model: "minimax-m3", displayName: "MiniMax M3", contextWindow: 512000 },
+      {
+        model: "minimax-m2.7",
+        displayName: "MiniMax M2.7",
+        contextWindow: 204800,
+      },
+      {
+        model: "minimax-m2.5",
+        displayName: "MiniMax M2.5",
+        contextWindow: 204800,
+      },
+    ]),
+    category: "aggregator",
+    icon: "opencode",
+    iconColor: "#211E1E",
+  },
+  {
     name: "Shengsuanyun",
     nameKey: "providerForm.presets.shengsuanyun",
     websiteUrl: "https://www.shengsuanyun.com/?from=CH_4HHXMRYF",

--- a/src/config/opencodeGoModelMeta.ts
+++ b/src/config/opencodeGoModelMeta.ts
@@ -1,0 +1,101 @@
+/**
+ * OpenCode Go 模型元数据辅助：用于在「获取模型」时把上游 /v1/models 返回的模型
+ * 富化为带正确上下文窗口的 Codex 模型目录条目，并排除仅 /messages 通路的模型。
+ *
+ * 这样当 OpenCode Go 上新增模型时，用户点一次「获取模型」即可自动拉取并套用上下文窗口，
+ * 无需手动逐个填写。
+ */
+import type { CodexCatalogModel } from "../types";
+
+/** OpenCode Go 的标准 base_url。 */
+export const OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go/v1";
+
+/** 判断某个 base_url 是否指向 OpenCode Go（容忍有无 /v1 与大小写）。 */
+export function isOpencodeGoBaseUrl(baseUrl?: string | null): boolean {
+  return !!baseUrl && baseUrl.toLowerCase().includes("opencode.ai/zen/go");
+}
+
+/**
+ * 仅在 Anthropic /messages 通路可用、无法走 Codex 的 openai_chat 通路的模型。
+ * 这些模型会从 chat 目录中排除（参见 docs：Go 的部分模型仅 /messages）。
+ */
+const MESSAGES_ONLY_MODELS = new Set<string>(["qwen3.7-max"]);
+
+/**
+ * 上下文窗口按模型 id 的有序前缀规则匹配；新加入的同系模型会自动继承同族窗口。
+ * 数据依据 models.dev 的 opencode-go provider 与实测。
+ */
+const CONTEXT_RULES: Array<[RegExp, number]> = [
+  [/^deepseek-v4/, 1_000_000],
+  [/^glm-5\.2/, 1_000_000],
+  [/^glm-5(\.1)?$/, 200_000],
+  [/^glm-/, 200_000],
+  [/^kimi-/, 262_144],
+  [/^mimo-v2\.5-pro/, 1_048_576],
+  [/^mimo-v2-pro/, 1_048_576],
+  [/^mimo-v2\.5/, 1_000_000],
+  [/^mimo-/, 262_144],
+  [/^qwen3\.[67]-plus/, 1_000_000],
+  [/^qwen3\.5-plus/, 262_144],
+  [/^qwen/, 262_144],
+  [/^minimax-m3/, 512_000],
+  [/^minimax-/, 204_800],
+];
+
+/** 未知模型的兜底上下文窗口（保守值）。 */
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+function contextWindowFor(id: string): number {
+  for (const [pattern, ctx] of CONTEXT_RULES) {
+    if (pattern.test(id)) return ctx;
+  }
+  return DEFAULT_CONTEXT_WINDOW;
+}
+
+/** 已知模型的友好显示名；未知模型回退到「按 - 分词 + 首字母大写」。 */
+const DISPLAY_NAME_OVERRIDES: Record<string, string> = {
+  "deepseek-v4-flash": "DeepSeek V4 Flash",
+  "deepseek-v4-pro": "DeepSeek V4 Pro",
+  "glm-5.2": "GLM-5.2",
+  "glm-5.1": "GLM-5.1",
+  "glm-5": "GLM-5",
+  "kimi-k2.7-code": "Kimi K2.7 Code",
+  "kimi-k2.6": "Kimi K2.6",
+  "kimi-k2.5": "Kimi K2.5",
+  "mimo-v2.5-pro": "MiMo V2.5 Pro",
+  "mimo-v2.5": "MiMo V2.5",
+  "mimo-v2-pro": "MiMo V2 Pro",
+  "mimo-v2-omni": "MiMo V2 Omni",
+  "qwen3.7-plus": "Qwen3.7 Plus",
+  "qwen3.6-plus": "Qwen3.6 Plus",
+  "qwen3.5-plus": "Qwen3.5 Plus",
+  "minimax-m3": "MiniMax M3",
+  "minimax-m2.7": "MiniMax M2.7",
+  "minimax-m2.5": "MiniMax M2.5",
+};
+
+function displayNameFor(id: string): string {
+  const override = DISPLAY_NAME_OVERRIDES[id];
+  if (override) return override;
+  return id
+    .split("-")
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ");
+}
+
+/**
+ * 把 /v1/models 返回的模型（结构上只需 `{ id }`）富化为 Codex 目录条目，
+ * 排除仅 /messages 的模型，并按族套用上下文窗口。
+ */
+export function enrichOpencodeGoModels(
+  models: ReadonlyArray<{ id: string }>,
+): CodexCatalogModel[] {
+  return models
+    .map((m) => m.id)
+    .filter((id) => !!id && !MESSAGES_ONLY_MODELS.has(id))
+    .map((id) => ({
+      model: id,
+      displayName: displayNameFor(id),
+      contextWindow: contextWindowFor(id),
+    }));
+}


### PR DESCRIPTION
## Summary

Adds native Codex support for **OpenCode Go** (opencode.ai/zen/go) in two parts:

1. **OpenCode Go preset** — a built-in Codex preset (`base_url https://opencode.ai/zen/go/v1`, `openai_chat` routing) covering the Go models verified to work on `/chat/completions`: DeepSeek V4 Flash/Pro, GLM-5/5.1/5.2, Kimi K2.5/2.6/2.7-code, MiMo V2/V2.5 family, Qwen3.5/3.6/3.7 Plus, and MiniMax M2.5/M2.7/M3 — each with its context window.

2. **Auto-populate model catalog on fetch** — for OpenCode Go providers, "Fetch Models" now enriches the upstream `/v1/models` result into the full Codex catalog: each model gets its per-model context window, messages-only models are excluded, and newly added upstream models are picked up automatically with a single click.

## Why

- New Codex speaks only the OpenAI Responses API; cc-switch's local proxy converts Responses → Chat Completions for `openai_chat` providers, which is how OpenCode Go's unified OpenAI-compatible endpoint is reached.
- There was no official OpenCode Go preset for Codex. This adds it, plus one-click sync as the upstream catalog grows.

## Design notes

- The preset intentionally **omits `codexChatReasoning`** so `resolve_codex_chat_reasoning_config` infers the correct per-model reasoning param (`deepseek/glm/kimi/mimo → thinking`, `qwen → enable_thinking`, `minimax → reasoning_split`). Hardcoding it was what caused MiniMax to 400 on `thinking.type "enabled"` and to "reply once and stop"; omitting it lets MiniMax use `reasoning_split` correctly.
- Model IDs are the exact API ids (e.g. `qwen3.7-plus`), not display names.
- **`qwen3.7-max` is excluded**: it is only available on the `/messages` route (reports `not supported for format oa-compat` on `/chat/completions`), so it can't go through Codex's `openai_chat` route. A follow-up could add a Responses→Messages route for it.

## Changes

- `src/config/codexProviderPresets.ts` — add the OpenCode Go preset (+84).
- `src/config/opencodeGoModelMeta.ts` — new: base-url detection, per-family context windows, messages-only exclusion, enrichment (+101).
- `src/components/providers/forms/CodexFormFields.tsx` — wire enrichment into the Codex fetch-success handler; other providers keep existing dropdown behavior (+28/−3).

No backend changes (reuses the existing `fetch_models_for_config` command).

## Verification

- `pnpm typecheck` (tsc --noEmit): **0 errors** (covers the `CodexFormFields.tsx` wiring).
- `prettier --check`: clean.
- Unit tests: **338/338 pass**.
- Enrichment runtime-checked: a simulated `/v1/models` of 14 entries → 12 catalog entries (`qwen3.7-max` and empty ids excluded), all context windows correct, unknown models fall back to a conservative 200000.
