### PR TITLE
fix(updater): use login shell for tool lifecycle commands

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -214,8 +214,10 @@ fn run_tool_lifecycle_silently(command_line: &str, _label: &str) -> Result<(), S
     use std::process::Command;
     // command_line 是 bash 风格脚本（含 `set -e` 与多行命令）；强制用 bash 执行，
     // 避免用户默认 shell 为 fish/zsh 时 `set -e` 等语义不一致。
+    // 使用登录 shell (`-l`) 以确保 `/etc/profile` 中的 `path_helper` 被调用，
+    // 使得 GUI 应用启动的非登录 shell 也能获取完整 PATH（如 /usr/local/bin 中的 npm）。
     let output = Command::new("bash")
-        .arg("-c")
+        .arg("-lc")
         .arg(command_line)
         .output()
         .map_err(|e| format!("启动安装进程失败: {e}"))?;


### PR DESCRIPTION
---

## Summary / 概述

```markdown
修复 macOS 上 CC Switch GUI 执行工具安装/升级时因非登录 shell 导致 `npm: command not found` 的问题。

将 `run_tool_lifecycle_silently` 中的 `bash -c` 改为 `bash -lc`，使 `/etc/profile` 中的 `path_helper` 能被加载，
补全 GUI 应用缺失的 PATH（如 `/usr/local/bin`、`/opt/homebrew/bin`），从而找到 `npm`、`node` 等命令。

影响范围：macOS 上所有工具的 install 和 update 生命周期操作。
改动量：一个字符（`-c` → `-lc`）。
```

## Related Issue / 关联 Issue

没有现成 issue，留空或填 `N/A`。

## Screenshots / 截图
<img width="1998" height="1298" alt="image" src="https://github.com/user-attachments/assets/ef761309-7f37-4bbf-8b64-14656a3ca3ec" />

```markdown
| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 安装 Codex 报错 "bash: line 3: npm: command not found" | 安装成功 |
```

没有实际截图的话删掉这个表格也行。

## Checklist / 检查清单

```markdown
- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查 
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) 
- [ ] Updated i18n files if user-facing text changed
```

---

