### PR TITLE
fix(misc): dedupe npm Windows shell siblings in tool install scan

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1824,6 +1824,40 @@ fn resolve_path_default(tool: &str) -> Option<std::path::PathBuf> {
     std::fs::canonicalize(first).ok()
 }
 
+/// npm on Windows emits multiple sibling launchers (`tool`, `tool.cmd`, `tool.exe`) for one
+/// global install. `canonicalize` dedup cannot merge them because they are distinct files.
+fn dedupe_same_directory_shell_siblings(installs: Vec<ToolInstallation>) -> Vec<ToolInstallation> {
+    use std::collections::HashMap;
+
+    let mut groups: HashMap<(std::path::PathBuf, std::ffi::OsString), ToolInstallation> =
+        HashMap::new();
+    for inst in installs {
+        let path = std::path::Path::new(&inst.path);
+        let key = (
+            path.parent()
+                .unwrap_or(std::path::Path::new(""))
+                .to_path_buf(),
+            path.file_stem().unwrap_or_default().to_os_string(),
+        );
+
+        match groups.get_mut(&key) {
+            None => {
+                groups.insert(key, inst);
+            }
+            Some(picked) => {
+                if (!picked.runnable && inst.runnable)
+                    || (picked.runnable == inst.runnable
+                        && !picked.is_path_default
+                        && inst.is_path_default)
+                {
+                    *picked = inst;
+                }
+            }
+        }
+    }
+    groups.into_values().collect()
+}
+
 /// 枚举工具在系统中的所有安装（不短路）。与 `scan_cli_version` 共用
 /// `build_tool_search_paths`，但不在首个命中处停止——而是对每个去重后的真实
 /// 可执行文件都跑一次 `--version`，从而能发现"升级写入 A 处、PATH 实际用 B 处"。
@@ -1904,6 +1938,8 @@ fn enumerate_tool_installations(tool: &str) -> Vec<ToolInstallation> {
             });
         }
     }
+
+    installs = dedupe_same_directory_shell_siblings(installs);
 
     // PATH 默认那处排最前，UI 一眼看到"命令行默认用的是哪处"。
     installs.sort_by_key(|i| std::cmp::Reverse(i.is_path_default));
@@ -5061,6 +5097,68 @@ mod tests {
                 PathBuf::from("C:\\tools\\opencode"),
             ]
         );
+    }
+
+    #[test]
+    fn dedupe_same_directory_shell_siblings_prefers_runnable_entry() {
+        let dir = PathBuf::from("D:\\nvm\\nodejs");
+        let sh_script = ToolInstallation {
+            path: dir.join("claude").display().to_string(),
+            version: None,
+            runnable: false,
+            error: Some("not runnable".to_string()),
+            source: "system".to_string(),
+            is_path_default: false,
+            real: dir.join("claude"),
+        };
+        let cmd = ToolInstallation {
+            path: dir.join("claude.cmd").display().to_string(),
+            version: Some("2.1.190".to_string()),
+            runnable: true,
+            error: None,
+            source: "system".to_string(),
+            is_path_default: true,
+            real: dir.join("claude.cmd"),
+        };
+        let exe = ToolInstallation {
+            path: dir.join("claude.exe").display().to_string(),
+            version: Some("2.1.190".to_string()),
+            runnable: true,
+            error: None,
+            source: "system".to_string(),
+            is_path_default: false,
+            real: dir.join("claude.exe"),
+        };
+
+        let result = dedupe_same_directory_shell_siblings(vec![sh_script, cmd, exe]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            Path::new(&result[0].path)
+                .file_name()
+                .and_then(|n| n.to_str()),
+            Some("claude.cmd")
+        );
+        assert!(result[0].runnable);
+        assert!(result[0].is_path_default);
+    }
+
+    #[test]
+    fn dedupe_same_directory_shell_siblings_keeps_distinct_directories() {
+        let make = |dir: &str| ToolInstallation {
+            path: format!("{dir}\\claude.cmd"),
+            version: Some("1.0.0".to_string()),
+            runnable: true,
+            error: None,
+            source: "system".to_string(),
+            is_path_default: false,
+            real: PathBuf::from(format!("{dir}\\claude.cmd")),
+        };
+
+        let result = dedupe_same_directory_shell_siblings(vec![
+            make("D:\\nvm\\nodejs"),
+            make("C:\\Program Files\\nodejs"),
+        ]);
+        assert_eq!(result.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Merge npm Windows launcher siblings (`tool`, `tool.cmd`, `tool.exe`) in the same directory into a single installation entry during tool install enumeration.

## Motivation

Fixes #4610. On Windows with npm global installs (e.g. nvm-windows + `npm install -g @anthropic-ai/claude-code`), `enumerate_tool_installations` reports `claude` and `claude.cmd` as separate installations because `canonicalize` dedup only handles symlinks, not npm's distinct shell launchers. This triggers false "multiple installations" warnings in About → Diagnostics.

## Changes

- Add `dedupe_same_directory_shell_siblings()` grouping by (parent directory, file stem)
- Prefer `runnable=true`, then `is_path_default=true` when picking the representative entry
- Call dedupe at the end of `enumerate_tool_installations` before sorting
- Add unit tests for sibling merge and distinct-directory preservation

## Tests

```bash
cd src-tauri
cargo fmt --check
cargo clippy --lib --tests -- -D warnings
cargo test dedupe_same_directory_shell_siblings --lib
# 2 passed
```

## Notes

- Logic runs on all platforms but only affects Windows-style multi-candidate enumeration; non-Windows `tool_executable_candidates` emits one entry per directory.
- Full Windows end-to-end validation requires manual check on nvm-windows + npm global install (Linux CI cannot reproduce the filesystem layout).

Fixes #4610