### PR TITLE
feat(skill): Per-Agent Skill Isolation and Global Toggle

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -222,6 +222,9 @@ pub struct InstalledSkill {
     /// 最近更新时间（Unix 时间戳，0 = 从未更新）
     #[serde(default)]
     pub updated_at: i64,
+    /// 全局启用状态（CcSwitch 模式下写入 ~/.agents/skills/ 的开关）
+    #[serde(default)]
+    pub global_enabled: bool,
 }
 
 /// 未管理的 Skill（在应用目录中发现但未被 CC Switch 管理）
@@ -421,6 +424,17 @@ impl AppType {
             AppType::Hermes,
         ]
         .into_iter()
+    }
+
+    /// Check if this app natively scans ~/.agents/skills/
+    ///
+    /// These agents cannot be independently toggled in Unified mode because
+    /// they always load all skills from ~/.agents/skills/.
+    pub fn scans_agents_skills_dir(&self) -> bool {
+        matches!(
+            self,
+            AppType::OpenCode | AppType::Codex | AppType::Gemini | AppType::OpenClaw
+        )
     }
 }
 

--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -97,6 +97,17 @@ pub fn toggle_skill_app(
     Ok(true)
 }
 
+/// 切换 Skill 的全局启用状态（CcSwitch 模式）
+#[tauri::command]
+pub fn toggle_skill_global(
+    id: String,
+    enabled: bool,
+    app_state: State<'_, AppState>,
+) -> Result<bool, String> {
+    SkillService::toggle_global(&app_state.db, &id, enabled).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
 /// 扫描未管理的 Skills
 #[tauri::command]
 pub fn scan_unmanaged_skills(

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -188,7 +188,11 @@ impl Database {
     }
 
     /// 更新 Skill 的全局启用状态
-    pub fn update_skill_global_enabled(&self, id: &str, global_enabled: bool) -> Result<bool, AppError> {
+    pub fn update_skill_global_enabled(
+        &self,
+        id: &str,
+        global_enabled: bool,
+    ) -> Result<bool, AppError> {
         let conn = lock_conn!(self.conn);
         let affected = conn
             .execute(

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -23,7 +23,7 @@ impl Database {
             .prepare(
                 "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
                         readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild,
-                        enabled_opencode, enabled_hermes, installed_at, content_hash, updated_at
+                        enabled_opencode, enabled_hermes, installed_at, content_hash, updated_at, global_enabled
                  FROM skills ORDER BY name ASC",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -50,6 +50,7 @@ impl Database {
                     installed_at: row.get(14)?,
                     content_hash: row.get(15)?,
                     updated_at: row.get::<_, i64>(16).unwrap_or(0),
+                    global_enabled: row.get::<_, bool>(17).unwrap_or(false),
                 })
             })
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -69,7 +70,7 @@ impl Database {
             .prepare(
                 "SELECT id, name, description, directory, repo_owner, repo_name, repo_branch,
                         readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild,
-                        enabled_opencode, enabled_hermes, installed_at, content_hash, updated_at
+                        enabled_opencode, enabled_hermes, installed_at, content_hash, updated_at, global_enabled
                  FROM skills WHERE id = ?1",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -95,6 +96,7 @@ impl Database {
                 installed_at: row.get(14)?,
                 content_hash: row.get(15)?,
                 updated_at: row.get::<_, i64>(16).unwrap_or(0),
+                global_enabled: row.get::<_, bool>(17).unwrap_or(false),
             })
         });
 
@@ -112,8 +114,8 @@ impl Database {
             "INSERT OR REPLACE INTO skills
              (id, name, description, directory, repo_owner, repo_name, repo_branch,
               readme_url, enabled_claude, enabled_codex, enabled_gemini, enabled_grokbuild, enabled_opencode, enabled_hermes,
-              installed_at, content_hash, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+               installed_at, content_hash, updated_at, global_enabled)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
             params![
                 skill.id,
                 skill.name,
@@ -132,6 +134,7 @@ impl Database {
                 skill.installed_at,
                 skill.content_hash,
                 skill.updated_at,
+                skill.global_enabled,
             ],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -179,6 +182,18 @@ impl Database {
             .execute(
                 "UPDATE skills SET content_hash = ?1, updated_at = ?2 WHERE id = ?3",
                 params![content_hash, updated_at, id],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(affected > 0)
+    }
+
+    /// 更新 Skill 的全局启用状态
+    pub fn update_skill_global_enabled(&self, id: &str, global_enabled: bool) -> Result<bool, AppError> {
+        let conn = lock_conn!(self.conn);
+        let affected = conn
+            .execute(
+                "UPDATE skills SET global_enabled = ?1 WHERE id = ?2",
+                params![global_enabled, id],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(affected > 0)

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -99,7 +99,8 @@ impl Database {
             enabled_hermes BOOLEAN NOT NULL DEFAULT 0,
             installed_at INTEGER NOT NULL DEFAULT 0,
             content_hash TEXT,
-            updated_at INTEGER NOT NULL DEFAULT 0
+            updated_at INTEGER NOT NULL DEFAULT 0,
+            global_enabled BOOLEAN NOT NULL DEFAULT 0
         )",
             [],
         )
@@ -507,7 +508,9 @@ impl Database {
                         Self::set_user_version(conn, 15)?;
                     }
                     15 => {
-                        log::info!("迁移数据库从 v15 到 v16（重建 Codex 会话用量）");
+                        log::info!(
+                            "迁移数据库从 v15 到 v16（重建 Codex 会话用量并添加 Skills 全局开关）"
+                        );
                         Self::migrate_v15_to_v16(conn)?;
                         Self::set_user_version(conn, 16)?;
                     }
@@ -1041,7 +1044,8 @@ impl Database {
                 enabled_claude BOOLEAN NOT NULL DEFAULT 0,
                 enabled_codex BOOLEAN NOT NULL DEFAULT 0,
                 enabled_gemini BOOLEAN NOT NULL DEFAULT 0,
-                installed_at INTEGER NOT NULL DEFAULT 0
+                installed_at INTEGER NOT NULL DEFAULT 0,
+                global_enabled BOOLEAN NOT NULL DEFAULT 0
             )",
             [],
         )
@@ -1520,7 +1524,12 @@ impl Database {
     /// schema migration already owns the Database connection mutex.
     fn migrate_v15_to_v16(conn: &Connection) -> Result<(), AppError> {
         let codex_dir = crate::codex_config::get_codex_config_dir();
-        crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)
+        crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)?;
+        if Self::table_exists(conn, "skills")? {
+            Self::add_column_if_missing(conn, "skills", "global_enabled", "BOOLEAN NOT NULL DEFAULT 0")?;
+        }
+        log::info!("v15 -> v16 迁移完成：已添加 global_enabled 列");
+        Ok(())
     }
 
     /// 插入默认模型定价数据

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1526,7 +1526,12 @@ impl Database {
         let codex_dir = crate::codex_config::get_codex_config_dir();
         crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)?;
         if Self::table_exists(conn, "skills")? {
-            Self::add_column_if_missing(conn, "skills", "global_enabled", "BOOLEAN NOT NULL DEFAULT 0")?;
+            Self::add_column_if_missing(
+                conn,
+                "skills",
+                "global_enabled",
+                "BOOLEAN NOT NULL DEFAULT 0",
+            )?;
         }
         log::info!("v15 -> v16 迁移完成：已添加 global_enabled 列");
         Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -967,6 +967,18 @@ pub fn run() {
 
             // 启动阶段不再无条件保存,避免意外覆盖用户配置。
 
+            // 启动时自愈同步 Skills（全量重整两个候选 SSOT 目录）
+            {
+                let db = app_state.db.clone();
+                tauri::async_runtime::spawn_blocking(move || {
+                    if let Err(e) = crate::services::skill::SkillService::sync_to_agents_dir(&db) {
+                        log::warn!("启动时 Skill 自愈同步失败: {e}");
+                    } else {
+                        log::info!("✓ 启动时 Skill 自愈同步完成");
+                    }
+                });
+            }
+
             // 注册 deep-link URL 处理器（使用正确的 DeepLinkExt API）
             log::info!("=== Registering deep-link URL handler ===");
 
@@ -1468,6 +1480,7 @@ pub fn run() {
             commands::uninstall_skill_unified,
             commands::restore_skill_backup,
             commands::toggle_skill_app,
+            commands::toggle_skill_global,
             commands::scan_unmanaged_skills,
             commands::import_skills_from_apps,
             commands::discover_available_skills,

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -7,9 +7,9 @@
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use indexmap::IndexMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -1499,14 +1499,13 @@ impl SkillService {
             let ssot_dir = Self::get_ssot_dir()?;
             let source = ssot_dir.join(&skill.directory);
             if !source.exists() {
-                return Err(anyhow!("Skill source directory not found: {}", source.display()));
+                return Err(anyhow!(
+                    "Skill source directory not found: {}",
+                    source.display()
+                ));
             }
             Self::sync_skill_to_dir(&skill.directory, &dest)?;
-            log::info!(
-                "Skill {} 全局启用：同步到 {}",
-                skill.name,
-                dest.display()
-            );
+            log::info!("Skill {} 全局启用：同步到 {}", skill.name, dest.display());
         } else {
             if dest.exists() || Self::is_symlink(&dest) {
                 Self::remove_path(&dest)?;
@@ -1532,20 +1531,17 @@ impl SkillService {
     pub fn reconcile_ssot_directories(db: &Arc<Database>) -> Result<()> {
         let location = crate::settings::get_skill_storage_location();
         let ssot_dir = Self::get_ssot_dir()?;
-        
+
         let agents_dir = match dirs::home_dir() {
             Some(h) => h.join(".agents").join("skills"),
             None => return Ok(()),
         };
 
         let skills = db.get_all_installed_skills()?;
-        let managed_dirs: HashSet<String> = skills
-            .values()
-            .map(|s| s.directory.clone())
-            .collect();
+        let managed_dirs: HashSet<String> = skills.values().map(|s| s.directory.clone()).collect();
 
         let ccswitch_dir = get_app_config_dir().join("skills");
-        
+
         // 确保两个目录都存在
         fs::create_dir_all(&ccswitch_dir)?;
         fs::create_dir_all(&agents_dir)?;
@@ -1555,12 +1551,24 @@ impl SkillService {
             SkillStorageLocation::CcSwitch => {
                 // CcSwitch 模式：~/.cc-switch/skills/ 是 SSOT
                 // ~/.agents/skills/ 应该只保留 global_enabled=true 的 symlink
-                Self::reconcile_ccswitch_mode(&ccswitch_dir, &agents_dir, &ssot_dir, &skills, &managed_dirs)?;
+                Self::reconcile_ccswitch_mode(
+                    &ccswitch_dir,
+                    &agents_dir,
+                    &ssot_dir,
+                    &skills,
+                    &managed_dirs,
+                )?;
             }
             SkillStorageLocation::Unified => {
                 // Unified 模式：~/.agents/skills/ 是 SSOT
                 // ~/.cc-switch/skills/ 不应残留与当前状态冲突的 skill 目录或 symlink
-                Self::reconcile_unified_mode(&ccswitch_dir, &agents_dir, &ssot_dir, &skills, &managed_dirs)?;
+                Self::reconcile_unified_mode(
+                    &ccswitch_dir,
+                    &agents_dir,
+                    &ssot_dir,
+                    &skills,
+                    &managed_dirs,
+                )?;
             }
         }
 
@@ -1587,20 +1595,27 @@ impl SkillService {
                 if dir_name.starts_with('.') {
                     continue;
                 }
-                
+
                 let is_managed = managed_dirs.contains(&dir_name);
                 let has_skill_md = path.join("SKILL.md").exists();
                 let is_skill_dir = has_skill_md && path.is_dir();
-                let is_ssot_symlink = path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
+                let is_ssot_symlink =
+                    path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
 
                 // 如果是 skill 目录但不在数据库中，删除
                 if is_skill_dir && !is_managed {
-                    log::info!("reconcile: 删除 SSOT 中未管理的 skill 目录: {}", path.display());
+                    log::info!(
+                        "reconcile: 删除 SSOT 中未管理的 skill 目录: {}",
+                        path.display()
+                    );
                     let _ = Self::remove_path(&path);
                 }
                 // 如果是指向 SSOT 的 symlink 但不在数据库中，删除
                 else if is_ssot_symlink && !is_managed {
-                    log::info!("reconcile: 删除 SSOT 中未管理的 symlink: {}", path.display());
+                    log::info!(
+                        "reconcile: 删除 SSOT 中未管理的 symlink: {}",
+                        path.display()
+                    );
                     let _ = Self::remove_path(&path);
                 }
             }
@@ -1620,7 +1635,8 @@ impl SkillService {
                 let skill = skills.values().find(|s| s.directory == dir_name);
                 let is_global_enabled = skill.map(|s| s.global_enabled).unwrap_or(false);
                 let is_skill_dir = path.join("SKILL.md").exists() && path.is_dir();
-                let is_ssot_symlink = path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
+                let is_ssot_symlink =
+                    path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
 
                 // 真实 skill 目录：如果在 DB 中但 global_enabled=false，删除
                 // 不在 DB 中的不删除（可能是用户手动放置、尚未导入的 skill）
@@ -1633,11 +1649,13 @@ impl SkillService {
                     }
                 }
                 // SSOT symlink：如果 skill 不存在或 global_enabled=false，删除
-                else if is_ssot_symlink
-                    && !is_global_enabled {
-                        log::info!("reconcile: 删除 agents_dir 中 global_enabled=false 的 symlink: {}", path.display());
-                        let _ = Self::remove_path(&path);
-                    }
+                else if is_ssot_symlink && !is_global_enabled {
+                    log::info!(
+                        "reconcile: 删除 agents_dir 中 global_enabled=false 的 symlink: {}",
+                        path.display()
+                    );
+                    let _ = Self::remove_path(&path);
+                }
                 // 其他文件/symlink：不处理，避免误删用户文件
             }
         }
@@ -1677,18 +1695,24 @@ impl SkillService {
                 if dir_name.starts_with('.') {
                     continue;
                 }
-                
+
                 let is_managed = managed_dirs.contains(&dir_name);
                 let has_skill_md = path.join("SKILL.md").exists();
                 let is_skill_dir = has_skill_md && path.is_dir();
-                let is_ssot_symlink = path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
+                let is_ssot_symlink =
+                    path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
 
                 if is_skill_dir && !is_managed {
-                    log::info!("reconcile: 删除 SSOT 中未管理的 skill 目录: {}", path.display());
+                    log::info!(
+                        "reconcile: 删除 SSOT 中未管理的 skill 目录: {}",
+                        path.display()
+                    );
                     let _ = Self::remove_path(&path);
-                }
-                else if is_ssot_symlink && !is_managed {
-                    log::info!("reconcile: 删除 SSOT 中未管理的 symlink: {}", path.display());
+                } else if is_ssot_symlink && !is_managed {
+                    log::info!(
+                        "reconcile: 删除 SSOT 中未管理的 symlink: {}",
+                        path.display()
+                    );
                     let _ = Self::remove_path(&path);
                 }
             }
@@ -1703,17 +1727,19 @@ impl SkillService {
                 if dir_name.starts_with('.') {
                     continue;
                 }
-                
+
                 let has_skill_md = path.join("SKILL.md").exists();
                 let is_skill_dir = has_skill_md && path.is_dir();
-                let is_ssot_symlink = path.is_symlink() && (
-                    Self::is_symlink_to_ssot(&path, ccswitch_dir) ||
-                    Self::is_symlink_to_ssot(&path, agents_dir)
-                );
+                let is_ssot_symlink = path.is_symlink()
+                    && (Self::is_symlink_to_ssot(&path, ccswitch_dir)
+                        || Self::is_symlink_to_ssot(&path, agents_dir));
 
                 // 所有 skill 目录和指向 SSOT 的 symlink 都清理
                 if is_skill_dir || is_ssot_symlink {
-                    log::info!("reconcile: 删除 ccswitch_dir 中冲突的条目: {}", path.display());
+                    log::info!(
+                        "reconcile: 删除 ccswitch_dir 中冲突的条目: {}",
+                        path.display()
+                    );
                     let _ = Self::remove_path(&path);
                 }
             }
@@ -1764,7 +1790,9 @@ impl SkillService {
         }
         if let Ok(ssot_dir) = Self::get_ssot_dir() {
             // 去重：如果 SSOT 已存在于 scan_sources 中，跳过重复添加
-            let already_has_ssot = scan_sources.iter().any(|(d, _)| Self::same_path(d, &ssot_dir));
+            let already_has_ssot = scan_sources
+                .iter()
+                .any(|(d, _)| Self::same_path(d, &ssot_dir));
             if !already_has_ssot {
                 scan_sources.push((ssot_dir, "cc-switch".to_string()));
             }
@@ -1846,7 +1874,9 @@ impl SkillService {
             }
         }
         // 去重：如果 SSOT 已存在于 search_sources 中，跳过重复添加
-        let already_has_ssot = search_sources.iter().any(|(d, _)| Self::same_path(d, &ssot_dir));
+        let already_has_ssot = search_sources
+            .iter()
+            .any(|(d, _)| Self::same_path(d, &ssot_dir));
         if !already_has_ssot {
             search_sources.push((ssot_dir.clone(), "cc-switch".to_string()));
         }
@@ -1892,7 +1922,11 @@ impl SkillService {
             let dest = ssot_dir.join(&dir_name);
             let did_import = if !dest.exists() {
                 // 同文件系统尝试 rename（原子操作），否则 temp copy + rename
-                if source.parent().map(|p| p.starts_with(&ssot_dir)).unwrap_or(false) {
+                if source
+                    .parent()
+                    .map(|p| p.starts_with(&ssot_dir))
+                    .unwrap_or(false)
+                {
                     // 同一目录树：可直接 rename（原子操作）
                     let _ = Self::remove_path(&dest);
                     fs::rename(&source, &dest)?;

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -1622,11 +1622,14 @@ impl SkillService {
                 let is_skill_dir = path.join("SKILL.md").exists() && path.is_dir();
                 let is_ssot_symlink = path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
 
-                // 真实 skill 目录：如果不在数据库中或 global_enabled=false，删除
+                // 真实 skill 目录：如果在 DB 中但 global_enabled=false，删除
+                // 不在 DB 中的不删除（可能是用户手动放置、尚未导入的 skill）
                 if is_skill_dir {
-                    if !is_global_enabled {
-                        log::info!("reconcile: 删除 agents_dir 中不应存在的真实 skill 目录: {}", path.display());
-                        let _ = Self::remove_path(&path);
+                    if let Some(_s) = skill {
+                        if !is_global_enabled {
+                            log::info!("reconcile: 删除 agents_dir 中 global_enabled=false 的真实 skill 目录: {}", path.display());
+                            let _ = Self::remove_path(&path);
+                        }
                     }
                 }
                 // SSOT symlink：如果 skill 不存在或 global_enabled=false，删除
@@ -1887,7 +1890,7 @@ impl SkillService {
 
             // 原子导入到 SSOT：先写入临时目录，再 rename 到目标位置
             let dest = ssot_dir.join(&dir_name);
-            if !dest.exists() {
+            let did_import = if !dest.exists() {
                 // 同文件系统尝试 rename（原子操作），否则 temp copy + rename
                 if source.parent().map(|p| p.starts_with(&ssot_dir)).unwrap_or(false) {
                     // 同一目录树：可直接 rename（原子操作）
@@ -1912,7 +1915,10 @@ impl SkillService {
 
                 // 成功后清理原文件（与 rename 同文件系统时原文件已消失，此处只处理跨文件系统残留）
                 let _ = Self::remove_path(&source);
-            }
+                true
+            } else {
+                false
+            };
 
             // 解析元数据
             let skill_md = dest.join("SKILL.md");
@@ -1948,6 +1954,15 @@ impl SkillService {
 
             // 保存到数据库
             db.save_skill(&skill)?;
+
+            // 立即同步到 per-app 目录（跳过源所在目录，仅当本次真正写入 SSOT 时）
+            if did_import {
+                for app in AppType::all() {
+                    if skill.apps.is_enabled_for(&app) {
+                        let _ = Self::sync_to_app_dir(&skill.directory, &app);
+                    }
+                }
+            }
 
             imported.push(skill);
         }

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -9,6 +9,7 @@ use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use indexmap::IndexMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -786,6 +787,7 @@ impl SkillService {
             installed_at: chrono::Utc::now().timestamp(),
             content_hash,
             updated_at: 0,
+            global_enabled: false,
         };
 
         // 保存到数据库
@@ -1149,6 +1151,7 @@ impl SkillService {
             installed_at: skill.installed_at,
             content_hash: new_hash,
             updated_at: chrono::Utc::now().timestamp(),
+            global_enabled: skill.global_enabled,
         };
 
         db.save_skill(&updated_skill)?;
@@ -1199,9 +1202,10 @@ impl SkillService {
         Ok(count)
     }
 
-    /// 迁移 Skill 存储位置（在两个 SSOT 目录间移动文件）
+    /// 迁移 Skill 存储位置（在两个 SSOT 目录间移动文件并重整）
     ///
     /// 安全策略：先移文件，后改设置。中途崩溃时设置仍指向旧目录。
+    /// 迁移完成后执行全量重整，确保两个目录最终与数据库状态一致。
     pub fn migrate_storage(
         db: &Arc<Database>,
         target: SkillStorageLocation,
@@ -1225,7 +1229,7 @@ impl SkillService {
         };
         fs::create_dir_all(&new_dir)?;
 
-        // 2. 逐个移动 skill 目录
+        // 2. 迁移数据库中已知的 skill 目录
         let skills = db.get_all_installed_skills()?;
         let mut result = MigrationResult {
             migrated_count: 0,
@@ -1276,7 +1280,12 @@ impl SkillService {
         // 3. 文件移动完成后才持久化设置
         crate::settings::set_skill_storage_location(target)?;
 
-        // 4. 刷新所有应用目录的 symlink（指向新 SSOT）
+        // 4. 执行全量重整，清理旧 SSOT 中剩余的 stale 条目，刷新新模式需要的 symlink 布局
+        if let Err(e) = Self::reconcile_ssot_directories(db) {
+            result.errors.push(format!("reconcile failed: {e}"));
+        }
+
+        // 5. 刷新所有应用目录的 symlink（指向新 SSOT）
         for app in AppType::all() {
             let _ = Self::sync_to_app(db, &app);
         }
@@ -1424,6 +1433,18 @@ impl SkillService {
     /// 启用：复制到应用目录
     /// 禁用：从应用目录删除
     pub fn toggle_app(db: &Arc<Database>, id: &str, app: &AppType, enabled: bool) -> Result<()> {
+        let location = crate::settings::get_skill_storage_location();
+
+        // Unified 模式下，双扫描 Agent 无法独立控制
+        if location == SkillStorageLocation::Unified && app.scans_agents_skills_dir() {
+            return Err(anyhow::anyhow!(
+                "Unified 模式下，{} 原生扫描 ~/.agents/skills/，无法独立控制 Skill 开关 \
+                 (Cannot toggle {} individually in Unified mode)",
+                app.as_str(),
+                app.as_str()
+            ));
+        }
+
         // 获取当前 skill
         let mut skill = db
             .get_installed_skill(id)?
@@ -1447,6 +1468,270 @@ impl SkillService {
         Ok(())
     }
 
+    /// 切换 Skill 的全局启用状态（CcSwitch 模式）
+    ///
+    /// 启用时：根据 SyncMethod 配置将 skill 同步到 ~/.agents/skills/，
+    ///         使原生扫描该目录的 Agent 也能加载此 Skill
+    /// 禁用时：删除 ~/.agents/skills/ 下的对应条目
+    pub fn toggle_global(db: &Arc<Database>, id: &str, enabled: bool) -> Result<()> {
+        // Unified 模式下 SSOT 本身就是 ~/.agents/skills/，global 开关无意义；
+        // 若放行，sync 的 source 与 link_path 相同，会先删掉真实的 skill 目录。
+        let location = crate::settings::get_skill_storage_location();
+        if location == SkillStorageLocation::Unified {
+            return Err(anyhow!(
+                "Unified 模式下 ~/.agents/skills/ 本身即 SSOT，无需且不支持 global 开关"
+            ));
+        }
+
+        let skill = db
+            .get_installed_skill(id)?
+            .ok_or_else(|| anyhow!("Skill not found: {id}"))?;
+
+        let agents_dir = dirs::home_dir()
+            .map(|h| h.join(".agents").join("skills"))
+            .ok_or_else(|| anyhow!("无法获取 HOME 目录"))?;
+
+        fs::create_dir_all(&agents_dir)?;
+
+        let dest = agents_dir.join(&skill.directory);
+
+        if enabled {
+            let ssot_dir = Self::get_ssot_dir()?;
+            let source = ssot_dir.join(&skill.directory);
+            if !source.exists() {
+                return Err(anyhow!("Skill source directory not found: {}", source.display()));
+            }
+            Self::sync_skill_to_dir(&skill.directory, &dest)?;
+            log::info!(
+                "Skill {} 全局启用：同步到 {}",
+                skill.name,
+                dest.display()
+            );
+        } else {
+            if dest.exists() || Self::is_symlink(&dest) {
+                Self::remove_path(&dest)?;
+                log::info!("Skill {} 全局禁用：删除 {}", skill.name, dest.display());
+            }
+        }
+
+        db.update_skill_global_enabled(id, enabled)?;
+
+        Ok(())
+    }
+
+    /// 全量重整两个候选 SSOT 目录
+    ///
+    /// 该函数会对以下两个目录执行重整：
+    /// - ~/.cc-switch/skills/
+    /// - ~/.agents/skills/
+    ///
+    /// 重整逻辑：
+    /// 1. 扫描两个目录下的所有 skill 条目（包含 SKILL.md 的目录和指向 skill 的 symlink）
+    /// 2. 根据当前 SSOT 模式和数据库状态决定保留、删除、迁移或重建
+    /// 3. 重整完成后，对目标目录执行一次完整同步
+    pub fn reconcile_ssot_directories(db: &Arc<Database>) -> Result<()> {
+        let location = crate::settings::get_skill_storage_location();
+        let ssot_dir = Self::get_ssot_dir()?;
+        
+        let agents_dir = match dirs::home_dir() {
+            Some(h) => h.join(".agents").join("skills"),
+            None => return Ok(()),
+        };
+
+        let skills = db.get_all_installed_skills()?;
+        let managed_dirs: HashSet<String> = skills
+            .values()
+            .map(|s| s.directory.clone())
+            .collect();
+
+        let ccswitch_dir = get_app_config_dir().join("skills");
+        
+        // 确保两个目录都存在
+        fs::create_dir_all(&ccswitch_dir)?;
+        fs::create_dir_all(&agents_dir)?;
+
+        // 根据当前 SSOT 模式决定重整策略
+        match location {
+            SkillStorageLocation::CcSwitch => {
+                // CcSwitch 模式：~/.cc-switch/skills/ 是 SSOT
+                // ~/.agents/skills/ 应该只保留 global_enabled=true 的 symlink
+                Self::reconcile_ccswitch_mode(&ccswitch_dir, &agents_dir, &ssot_dir, &skills, &managed_dirs)?;
+            }
+            SkillStorageLocation::Unified => {
+                // Unified 模式：~/.agents/skills/ 是 SSOT
+                // ~/.cc-switch/skills/ 不应残留与当前状态冲突的 skill 目录或 symlink
+                Self::reconcile_unified_mode(&ccswitch_dir, &agents_dir, &ssot_dir, &skills, &managed_dirs)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// CcSwitch 模式下的重整
+    ///
+    /// - ~/.cc-switch/skills/ (SSOT): 保留所有数据库中的 skill 目录，清理不在数据库中的
+    /// - ~/.agents/skills/: 只保留 global_enabled=true 的 symlink 指向 SSOT
+    fn reconcile_ccswitch_mode(
+        ccswitch_dir: &Path,
+        agents_dir: &Path,
+        ssot_dir: &Path,
+        skills: &IndexMap<String, InstalledSkill>,
+        managed_dirs: &HashSet<String>,
+    ) -> Result<()> {
+        // 1. 重整 SSOT 目录 (~/.cc-switch/skills/)
+        // 删除不在数据库中的真实 skill 目录和指向 SSOT 的 symlink
+        if let Ok(entries) = fs::read_dir(ccswitch_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let dir_name = entry.file_name().to_string_lossy().to_string();
+                if dir_name.starts_with('.') {
+                    continue;
+                }
+                
+                let is_managed = managed_dirs.contains(&dir_name);
+                let has_skill_md = path.join("SKILL.md").exists();
+                let is_skill_dir = has_skill_md && path.is_dir();
+                let is_ssot_symlink = path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
+
+                // 如果是 skill 目录但不在数据库中，删除
+                if is_skill_dir && !is_managed {
+                    log::info!("reconcile: 删除 SSOT 中未管理的 skill 目录: {}", path.display());
+                    let _ = Self::remove_path(&path);
+                }
+                // 如果是指向 SSOT 的 symlink 但不在数据库中，删除
+                else if is_ssot_symlink && !is_managed {
+                    log::info!("reconcile: 删除 SSOT 中未管理的 symlink: {}", path.display());
+                    let _ = Self::remove_path(&path);
+                }
+            }
+        }
+
+        // 2. 重整 ~/.agents/skills/ 目录
+        // 只保留 global_enabled=true 的 symlink
+        // 清理真实目录、非 SSOT symlink、以及 global_enabled=false 的 symlink
+        if let Ok(entries) = fs::read_dir(agents_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let dir_name = entry.file_name().to_string_lossy().to_string();
+                if dir_name.starts_with('.') {
+                    continue;
+                }
+
+                let skill = skills.values().find(|s| s.directory == dir_name);
+                let is_global_enabled = skill.map(|s| s.global_enabled).unwrap_or(false);
+                let is_skill_dir = path.join("SKILL.md").exists() && path.is_dir();
+                let is_ssot_symlink = path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
+
+                // 真实 skill 目录：如果不在数据库中或 global_enabled=false，删除
+                if is_skill_dir {
+                    if !is_global_enabled {
+                        log::info!("reconcile: 删除 agents_dir 中不应存在的真实 skill 目录: {}", path.display());
+                        let _ = Self::remove_path(&path);
+                    }
+                }
+                // SSOT symlink：如果 skill 不存在或 global_enabled=false，删除
+                else if is_ssot_symlink
+                    && !is_global_enabled {
+                        log::info!("reconcile: 删除 agents_dir 中 global_enabled=false 的 symlink: {}", path.display());
+                        let _ = Self::remove_path(&path);
+                    }
+                // 其他文件/symlink：不处理，避免误删用户文件
+            }
+        }
+
+        // 3. 确保 global_enabled=true 的 skill 在 agents_dir 有正确的条目（按 SyncMethod）
+        for skill in skills.values() {
+            if !skill.global_enabled {
+                continue;
+            }
+            let dest = agents_dir.join(&skill.directory);
+            match Self::sync_skill_to_dir(&skill.directory, &dest) {
+                Ok(()) => log::info!("reconcile: 同步 global skill {}", dest.display()),
+                Err(e) => log::warn!("reconcile: 同步 global skill 失败 {}: {e}", dest.display()),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Unified 模式下的重整
+    ///
+    /// - ~/.agents/skills/ (SSOT): 保留所有数据库中的 skill 目录，清理不在数据库中的
+    /// - ~/.cc-switch/skills/: 不保留与当前状态冲突的 skill 目录或 symlink
+    fn reconcile_unified_mode(
+        ccswitch_dir: &Path,
+        agents_dir: &Path,
+        ssot_dir: &Path,
+        _skills: &IndexMap<String, InstalledSkill>,
+        managed_dirs: &HashSet<String>,
+    ) -> Result<()> {
+        // 1. 重整 SSOT 目录 (~/.agents/skills/)
+        // 删除不在数据库中的真实 skill 目录和指向 SSOT 的 symlink
+        if let Ok(entries) = fs::read_dir(agents_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let dir_name = entry.file_name().to_string_lossy().to_string();
+                if dir_name.starts_with('.') {
+                    continue;
+                }
+                
+                let is_managed = managed_dirs.contains(&dir_name);
+                let has_skill_md = path.join("SKILL.md").exists();
+                let is_skill_dir = has_skill_md && path.is_dir();
+                let is_ssot_symlink = path.is_symlink() && Self::is_symlink_to_ssot(&path, ssot_dir);
+
+                if is_skill_dir && !is_managed {
+                    log::info!("reconcile: 删除 SSOT 中未管理的 skill 目录: {}", path.display());
+                    let _ = Self::remove_path(&path);
+                }
+                else if is_ssot_symlink && !is_managed {
+                    log::info!("reconcile: 删除 SSOT 中未管理的 symlink: {}", path.display());
+                    let _ = Self::remove_path(&path);
+                }
+            }
+        }
+
+        // 2. 重整 ~/.cc-switch/skills/ 目录
+        // 清理所有 skill 目录和指向任一 SSOT 的 symlink（因为 Unified 模式下不应使用这里）
+        if let Ok(entries) = fs::read_dir(ccswitch_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let dir_name = entry.file_name().to_string_lossy().to_string();
+                if dir_name.starts_with('.') {
+                    continue;
+                }
+                
+                let has_skill_md = path.join("SKILL.md").exists();
+                let is_skill_dir = has_skill_md && path.is_dir();
+                let is_ssot_symlink = path.is_symlink() && (
+                    Self::is_symlink_to_ssot(&path, ccswitch_dir) ||
+                    Self::is_symlink_to_ssot(&path, agents_dir)
+                );
+
+                // 所有 skill 目录和指向 SSOT 的 symlink 都清理
+                if is_skill_dir || is_ssot_symlink {
+                    log::info!("reconcile: 删除 ccswitch_dir 中冲突的条目: {}", path.display());
+                    let _ = Self::remove_path(&path);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// 自愈同步到 ~/.agents/skills/（增强版：全量对账两个候选 SSOT 目录）
+    ///
+    /// 根据数据库状态，对以下两个目录执行全量重整：
+    /// - ~/.cc-switch/skills/
+    /// - ~/.agents/skills/
+    ///
+    /// 重整逻辑：
+    /// - CcSwitch 模式：SSOT=~/.cc-switch/skills/，~/.agents/skills/ 只保留 global_enabled 的 symlink
+    /// - Unified 模式：SSOT=~/.agents/skills/，~/.cc-switch/skills/ 清理冲突条目
+    pub fn sync_to_agents_dir(db: &Arc<Database>) -> Result<()> {
+        Self::reconcile_ssot_directories(db)
+    }
+
     /// 扫描未管理的 Skills
     ///
     /// 扫描各应用目录，找出未被 CC Switch 管理的 Skills
@@ -1465,10 +1750,21 @@ impl SkillService {
             }
         }
         if let Some(agents_dir) = get_agents_skills_dir() {
-            scan_sources.push((agents_dir, "agents".to_string()));
+            // 去重：如果 SSOT 就是 ~/.agents/skills/（Unified 模式），跳过单独扫描 agents 目录
+            if let Ok(ssot_dir) = Self::get_ssot_dir() {
+                if !Self::same_path(&ssot_dir, &agents_dir) {
+                    scan_sources.push((agents_dir, "agents".to_string()));
+                }
+            } else {
+                scan_sources.push((agents_dir, "agents".to_string()));
+            }
         }
         if let Ok(ssot_dir) = Self::get_ssot_dir() {
-            scan_sources.push((ssot_dir, "cc-switch".to_string()));
+            // 去重：如果 SSOT 已存在于 scan_sources 中，跳过重复添加
+            let already_has_ssot = scan_sources.iter().any(|(d, _)| Self::same_path(d, &ssot_dir));
+            if !already_has_ssot {
+                scan_sources.push((ssot_dir, "cc-switch".to_string()));
+            }
         }
 
         let mut unmanaged: HashMap<String, UnmanagedSkill> = HashMap::new();
@@ -1513,6 +1809,7 @@ impl SkillService {
     /// 从应用目录导入 Skills
     ///
     /// 将未管理的 Skills 导入到 CC Switch 统一管理
+    /// 导入完成后触发全量重整，确保两个候选 SSOT 目录与数据库状态一致
     pub fn import_from_apps(
         db: &Arc<Database>,
         imports: Vec<ImportSkillSelection>,
@@ -1536,9 +1833,20 @@ impl SkillService {
             }
         }
         if let Some(agents_dir) = get_agents_skills_dir() {
-            search_sources.push((agents_dir, "agents".to_string()));
+            // 去重：如果 SSOT 就是 ~/.agents/skills/（Unified 模式），跳过单独扫描 agents 目录
+            if let Ok(ssot_dir_ref) = Self::get_ssot_dir() {
+                if !Self::same_path(&ssot_dir_ref, &agents_dir) {
+                    search_sources.push((agents_dir, "agents".to_string()));
+                }
+            } else {
+                search_sources.push((agents_dir, "agents".to_string()));
+            }
         }
-        search_sources.push((ssot_dir.clone(), "cc-switch".to_string()));
+        // 去重：如果 SSOT 已存在于 search_sources 中，跳过重复添加
+        let already_has_ssot = search_sources.iter().any(|(d, _)| Self::same_path(d, &ssot_dir));
+        if !already_has_ssot {
+            search_sources.push((ssot_dir.clone(), "cc-switch".to_string()));
+        }
 
         for selection in imports {
             // selection.directory 由前端 IPC 直接传入、此前全程无校验，而它既被
@@ -1577,10 +1885,33 @@ impl SkillService {
                 continue;
             }
 
-            // 复制到 SSOT
+            // 原子导入到 SSOT：先写入临时目录，再 rename 到目标位置
             let dest = ssot_dir.join(&dir_name);
             if !dest.exists() {
-                Self::copy_dir_recursive(&source, &dest)?;
+                // 同文件系统尝试 rename（原子操作），否则 temp copy + rename
+                if source.parent().map(|p| p.starts_with(&ssot_dir)).unwrap_or(false) {
+                    // 同一目录树：可直接 rename（原子操作）
+                    let _ = Self::remove_path(&dest);
+                    fs::rename(&source, &dest)?;
+                } else {
+                    // 跨文件系统或不同目录：临时目录 + rename
+                    let nonce = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_nanos();
+                    let tmp = ssot_dir.join(format!(".{dir_name}.tmp-{}", nonce));
+                    if tmp.exists() || Self::is_symlink(&tmp) {
+                        Self::remove_path(&tmp)?;
+                    }
+                    if let Err(e) = Self::copy_dir_recursive(&source, &tmp) {
+                        let _ = Self::remove_path(&tmp);
+                        return Err(e);
+                    }
+                    fs::rename(&tmp, &dest)?;
+                }
+
+                // 成功后清理原文件（与 rename 同文件系统时原文件已消失，此处只处理跨文件系统残留）
+                let _ = Self::remove_path(&source);
             }
 
             // 解析元数据
@@ -1612,12 +1943,18 @@ impl SkillService {
                 installed_at: chrono::Utc::now().timestamp(),
                 content_hash,
                 updated_at: 0,
+                global_enabled: false,
             };
 
             // 保存到数据库
             db.save_skill(&skill)?;
 
             imported.push(skill);
+        }
+
+        // 导入完成后触发全量重整，确保两个候选 SSOT 目录与数据库状态一致
+        if let Err(e) = Self::reconcile_ssot_directories(db) {
+            log::warn!("导入后重整失败: {}", e);
         }
 
         log::info!("成功导入 {} 个 Skills", imported.len());
@@ -1668,35 +2005,37 @@ impl SkillService {
 
         // directory 可能来自被污染的 DB 行（如同步导入的远端快照），join 前必须校验。
         let directory = Self::require_valid_directory(directory)?;
-
-        let ssot_dir = Self::get_ssot_dir()?;
-        let source = ssot_dir.join(&directory);
-
-        Self::validate_sync_source_dir(&source, &directory)?;
-
         let app_dir = Self::get_app_skills_dir(app)?;
         fs::create_dir_all(&app_dir)?;
 
         let dest = app_dir.join(&directory);
+        Self::sync_skill_to_dir(&directory, &dest)
+    }
+
+    /// 将 SSOT 中的 skill 按当前 SyncMethod 写入到目标路径
+    fn sync_skill_to_dir(directory: &str, dest: &Path) -> Result<()> {
+        let ssot_dir = Self::get_ssot_dir()?;
+        let source = ssot_dir.join(directory);
+
+        Self::validate_sync_source_dir(&source, directory)?;
 
         let sync_method = Self::get_sync_method();
 
         match sync_method {
             SyncMethod::Auto => {
-                if dest.exists() && !Self::is_symlink(&dest) {
-                    Self::replace_dest_with_copy(&source, &dest, &directory)?;
-                    log::debug!("Skill {directory} 已通过复制同步到 {app:?}");
+                if dest.exists() && !Self::is_symlink(dest) {
+                    Self::replace_dest_with_copy(&source, dest, directory)?;
+                    log::debug!("Skill {directory} 已通过复制同步到 {}", dest.display());
                     return Ok(());
                 }
 
-                if Self::is_symlink(&dest) {
-                    Self::remove_path(&dest)?;
+                if Self::is_symlink(dest) {
+                    Self::remove_path(dest)?;
                 }
 
-                // 优先尝试 symlink
-                match Self::create_symlink(&source, &dest) {
+                match Self::create_symlink(&source, dest) {
                     Ok(()) => {
-                        log::debug!("Skill {directory} 已通过 symlink 同步到 {app:?}");
+                        log::debug!("Skill {directory} 已通过 symlink 同步到 {}", dest.display());
                         return Ok(());
                     }
                     Err(err) => {
@@ -1708,19 +2047,19 @@ impl SkillService {
                     }
                 }
                 // Fallback 到 copy
-                Self::replace_dest_with_copy(&source, &dest, &directory)?;
-                log::debug!("Skill {directory} 已通过复制同步到 {app:?}");
+                Self::replace_dest_with_copy(&source, dest, directory)?;
+                log::debug!("Skill {directory} 已通过复制同步到 {}", dest.display());
             }
             SyncMethod::Symlink => {
-                if dest.exists() || Self::is_symlink(&dest) {
-                    Self::remove_path(&dest)?;
+                if dest.exists() || Self::is_symlink(dest) {
+                    Self::remove_path(dest)?;
                 }
-                Self::create_symlink(&source, &dest)?;
-                log::debug!("Skill {directory} 已通过 symlink 同步到 {app:?}");
+                log::debug!("Skill {directory} 已通过 symlink 同步到 {}", dest.display());
+                Self::create_symlink(&source, dest)?;
             }
             SyncMethod::Copy => {
-                Self::replace_dest_with_copy(&source, &dest, &directory)?;
-                log::debug!("Skill {directory} 已通过复制同步到 {app:?}");
+                Self::replace_dest_with_copy(&source, dest, directory)?;
+                log::debug!("Skill {directory} 已通过复制同步到 {}", dest.display());
             }
         }
 
@@ -1808,6 +2147,13 @@ impl SkillService {
         Ok(())
     }
 
+    /// 比较两个路径是否指向同一个位置（规范化后比较）
+    fn same_path(a: &Path, b: &Path) -> bool {
+        let a_canonical = a.canonicalize().unwrap_or_else(|_| a.to_path_buf());
+        let b_canonical = b.canonicalize().unwrap_or_else(|_| b.to_path_buf());
+        a_canonical == b_canonical
+    }
+
     /// 判断路径是否为指向 SSOT 目录内的符号链接。
     fn is_symlink_to_ssot(path: &Path, ssot_dir: &Path) -> bool {
         if !Self::is_symlink(path) {
@@ -1859,6 +2205,12 @@ impl SkillService {
     /// 同步所有已启用的 Skills 到指定应用
     pub fn sync_to_app(db: &Arc<Database>, app: &AppType) -> Result<()> {
         if matches!(app, AppType::ClaudeDesktop) {
+            return Ok(());
+        }
+
+        let location = crate::settings::get_skill_storage_location();
+        // Unified 模式下跳过双扫描 Agent（它们直接读取 ~/.agents/skills/）
+        if location == SkillStorageLocation::Unified && app.scans_agents_skills_dir() {
             return Ok(());
         }
 
@@ -3095,6 +3447,7 @@ impl SkillService {
                 installed_at: chrono::Utc::now().timestamp(),
                 content_hash,
                 updated_at: 0,
+                global_enabled: false,
             };
 
             // 保存到数据库
@@ -3545,6 +3898,7 @@ pub fn migrate_skills_to_ssot(db: &Arc<Database>) -> Result<usize> {
             installed_at: chrono::Utc::now().timestamp(),
             content_hash,
             updated_at: 0,
+            global_enabled: false,
         };
 
         db.save_skill(&skill)?;
@@ -4156,6 +4510,7 @@ mod tests {
             installed_at: 0,
             content_hash: None,
             updated_at: 0,
+            global_enabled: false,
         }
     }
 

--- a/src-tauri/tests/profile_roundtrip.rs
+++ b/src-tauri/tests/profile_roundtrip.rs
@@ -83,6 +83,7 @@ fn installed_skill(id: &str, directory: &str, claude_enabled: bool) -> Installed
         installed_at: 1_000,
         content_hash: None,
         updated_at: 0,
+        global_enabled: false,
     }
 }
 

--- a/src-tauri/tests/skill_sync.rs
+++ b/src-tauri/tests/skill_sync.rs
@@ -152,6 +152,7 @@ fn sync_to_app_removes_disabled_and_orphaned_ssot_symlinks() {
             installed_at: 0,
             content_hash: None,
             updated_at: 0,
+            global_enabled: false,
         })
         .expect("save disabled skill");
 
@@ -196,6 +197,7 @@ fn uninstall_skill_creates_backup_before_removing_ssot() {
             installed_at: 123,
             content_hash: None,
             updated_at: 0,
+            global_enabled: false,
         })
         .expect("save skill");
 
@@ -264,6 +266,7 @@ fn restore_skill_backup_restores_files_to_ssot_and_current_app() {
             installed_at: 456,
             content_hash: None,
             updated_at: 0,
+            global_enabled: false,
         })
         .expect("save skill");
 
@@ -345,6 +348,7 @@ fn delete_skill_backup_removes_backup_directory() {
             installed_at: 789,
             content_hash: None,
             updated_at: 0,
+            global_enabled: false,
         })
         .expect("save skill");
 

--- a/src/components/common/AppToggleGroup.tsx
+++ b/src/components/common/AppToggleGroup.tsx
@@ -39,8 +39,8 @@ export const AppToggleGroup: React.FC<AppToggleGroupProps> = ({
                   isLocked
                     ? "cursor-not-allowed"
                     : isVisuallyEnabled
-                    ? activeClass
-                    : "opacity-35 hover:opacity-70"
+                      ? activeClass
+                      : "opacity-35 hover:opacity-70"
                 } ${isVisuallyEnabled ? activeClass : ""}`}
               >
                 {icon}

--- a/src/components/common/AppToggleGroup.tsx
+++ b/src/components/common/AppToggleGroup.tsx
@@ -6,40 +6,57 @@ import {
 } from "@/components/ui/tooltip";
 import type { AppId } from "@/lib/api/types";
 import { APP_IDS, APP_ICON_MAP } from "@/config/appConfig";
+import { Lock } from "lucide-react";
 
 interface AppToggleGroupProps {
   apps: Partial<Record<AppId, boolean>>;
   onToggle: (app: AppId, enabled: boolean) => void;
   appIds?: AppId[];
+  lockedApps?: AppId[];
 }
 
 export const AppToggleGroup: React.FC<AppToggleGroupProps> = ({
   apps,
   onToggle,
   appIds = APP_IDS,
+  lockedApps = [],
 }) => {
   return (
     <div className="flex items-center gap-1.5 flex-shrink-0">
       {appIds.map((app) => {
         const { label, icon, activeClass } = APP_ICON_MAP[app];
         const enabled = apps[app];
+        const isLocked = lockedApps.includes(app);
+        // Locked apps show as enabled (with background) + lock icon
+        const isVisuallyEnabled = enabled || isLocked;
         return (
           <Tooltip key={app}>
             <TooltipTrigger asChild>
               <button
                 type="button"
-                onClick={() => onToggle(app, !enabled)}
-                className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all ${
-                  enabled ? activeClass : "opacity-35 hover:opacity-70"
-                }`}
+                onClick={() => !isLocked && onToggle(app, !enabled)}
+                className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all relative ${
+                  isLocked
+                    ? "cursor-not-allowed"
+                    : isVisuallyEnabled
+                    ? activeClass
+                    : "opacity-35 hover:opacity-70"
+                } ${isVisuallyEnabled ? activeClass : ""}`}
               >
                 {icon}
+                {isLocked && (
+                  <Lock
+                    size={8}
+                    className="absolute -bottom-0.5 -right-0.5 text-muted-foreground"
+                  />
+                )}
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               <p>
                 {label}
                 {enabled ? " ✓" : ""}
+                {isLocked ? " (🔒)" : ""}
               </p>
             </TooltipContent>
           </Tooltip>

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -6,10 +6,16 @@ import {
   ExternalLink,
   RefreshCw,
   Loader2,
+  Globe,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   type ImportSkillSelection,
   type SkillBackupEntry,
@@ -26,6 +32,7 @@ import {
   useUpdateSkill,
   type InstalledSkill,
   type SkillUpdateInfo,
+  useToggleSkillGlobal,
 } from "@/hooks/useSkills";
 import type { AppId } from "@/lib/api/types";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -43,6 +50,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useSettings } from "@/hooks/useSettings";
 
 interface UnifiedSkillsPanelProps {
   onOpenDiscovery: () => void;
@@ -88,6 +96,7 @@ const UnifiedSkillsPanel = React.forwardRef<
   } = useSkillBackups();
   const deleteBackupMutation = useDeleteSkillBackup();
   const toggleAppMutation = useToggleSkillApp();
+  const toggleGlobalMutation = useToggleSkillGlobal();
   const uninstallMutation = useUninstallSkill();
   const restoreBackupMutation = useRestoreSkillBackup();
   // enabled: true —— 进入 Skill 页面时自动静默扫描一次（绿点提示来源）
@@ -102,6 +111,13 @@ const UnifiedSkillsPanel = React.forwardRef<
   } = useCheckSkillUpdates();
   const updateSkillMutation = useUpdateSkill();
   const [isUpdatingAll, setIsUpdatingAll] = useState(false);
+  const { settings } = useSettings();
+  const isCcSwitchMode = settings?.skillStorageLocation !== "unified";
+
+  const DUAL_SCAN_APPS: AppId[] = useMemo(
+    () => ["codex", "gemini", "opencode", "openclaw"],
+    [],
+  );
 
   const updatesMap = useMemo(() => {
     const map: Record<string, SkillUpdateInfo> = {};
@@ -136,6 +152,14 @@ const UnifiedSkillsPanel = React.forwardRef<
   const handleToggleApp = async (id: string, app: AppId, enabled: boolean) => {
     try {
       await toggleAppMutation.mutateAsync({ id, app, enabled });
+    } catch (error) {
+      toast.error(t("common.error"), { description: String(error) });
+    }
+  };
+
+  const handleToggleGlobal = async (id: string, enabled: boolean) => {
+    try {
+      await toggleGlobalMutation.mutateAsync({ id, enabled });
     } catch (error) {
       toast.error(t("common.error"), { description: String(error) });
     }
@@ -431,9 +455,12 @@ const UnifiedSkillsPanel = React.forwardRef<
                     updateSkillMutation.variables === skill.id
                   }
                   onToggleApp={handleToggleApp}
+                  onToggleGlobal={handleToggleGlobal}
                   onUninstall={() => handleUninstall(skill)}
                   onUpdate={() => handleUpdateSkill(skill)}
                   isLast={index === skills.length - 1}
+                  isCcSwitchMode={isCcSwitchMode}
+                  dualScanApps={DUAL_SCAN_APPS}
                 />
               ))}
             </div>
@@ -484,9 +511,12 @@ interface InstalledSkillListItemProps {
   hasUpdate?: boolean;
   isUpdating?: boolean;
   onToggleApp: (id: string, app: AppId, enabled: boolean) => void;
+  onToggleGlobal: (id: string, enabled: boolean) => void;
   onUninstall: () => void;
   onUpdate?: () => void;
   isLast?: boolean;
+  isCcSwitchMode?: boolean;
+  dualScanApps?: AppId[];
 }
 
 const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
@@ -494,9 +524,12 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
   hasUpdate,
   isUpdating,
   onToggleApp,
+  onToggleGlobal,
   onUninstall,
   onUpdate,
   isLast,
+  isCcSwitchMode = false,
+  dualScanApps = [],
 }) => {
   const { t } = useTranslation();
 
@@ -554,10 +587,59 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
         )}
       </div>
 
+      {isCcSwitchMode && (
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => onToggleGlobal(skill.id, !skill.globalEnabled)}
+                className={`w-7 h-7 rounded-lg flex items-center justify-center transition-all ${
+                  skill.globalEnabled
+                    ? "bg-blue-100 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400"
+                    : "opacity-35 hover:opacity-70 text-muted-foreground"
+                }`}
+              >
+                <Globe size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p>
+                {skill.globalEnabled
+                  ? t("skills.globalEnabled")
+                  : t("skills.globalDisabled")}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
+
       <AppToggleGroup
         apps={skill.apps}
-        onToggle={(app, enabled) => onToggleApp(skill.id, app, enabled)}
+        onToggle={(app, enabled) => {
+          const isLocked =
+            !isCcSwitchMode && dualScanApps.includes(app as AppId);
+          // In CcSwitch mode, dual-scan apps are locked if global is enabled
+          const isLockedInCcSwitch =
+            isCcSwitchMode &&
+            skill.globalEnabled &&
+            dualScanApps.includes(app as AppId);
+          if (isLocked || isLockedInCcSwitch) {
+            toast.info(
+              t("skills.lockedInUnified", { app: app.toUpperCase() }),
+            );
+            return;
+          }
+          onToggleApp(skill.id, app, enabled);
+        }}
         appIds={SKILLS_APP_IDS}
+        lockedApps={
+          isCcSwitchMode
+            ? skill.globalEnabled
+              ? dualScanApps
+              : []
+            : dualScanApps
+        }
       />
 
       <div

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -625,9 +625,7 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
             skill.globalEnabled &&
             dualScanApps.includes(app as AppId);
           if (isLocked || isLockedInCcSwitch) {
-            toast.info(
-              t("skills.lockedInUnified", { app: app.toUpperCase() }),
-            );
+            toast.info(t("skills.lockedInUnified", { app: app.toUpperCase() }));
             return;
           }
           onToggleApp(skill.id, app, enabled);

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -185,6 +185,17 @@ export function useToggleSkillApp() {
   });
 }
 
+export function useToggleSkillGlobal() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      skillsApi.toggleGlobal(id, enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["skills", "installed"] });
+    },
+  });
+}
+
 /**
  * 扫描未管理的 Skills
  *

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -708,7 +708,7 @@
       "ccSwitch": "CC Switch",
       "unified": "~/.agents/skills",
       "ccSwitchHint": "Skills are stored in ~/.cc-switch/skills/ and synced to each app via symlink or copy.",
-      "unifiedHint": "Skills are stored in ~/.agents/skills/, the Agent Skills open standard. Compatible tools (Claude Code, Codex, Gemini CLI, etc.) discover skills here natively.",
+      "unifiedHint": "Skills are stored in ~/.agents/skills/, the Agent Skills open standard. Compatible tools (OpenCode, Codex, Gemini CLI, OpenClaw, etc.) discover skills here natively.",
       "confirmTitle": "Migrate Skill Storage",
       "confirmMessage": "{{count}} skill(s) will be moved to the new location. Continue?",
       "migrationSuccess": "Successfully migrated {{count}} skill(s)",
@@ -2421,7 +2421,10 @@
       "successSingle": "Skill {{name}} installed",
       "successMultiple": "Successfully installed {{count}} skills",
       "noSkillsFound": "No skills found in ZIP file (requires SKILL.md file)"
-    }
+    },
+    "globalEnabled": "Global (visible to all agents via ~/.agents/skills/)",
+    "globalDisabled": "Not global (only visible to explicitly enabled agents)",
+    "lockedInUnified": "{{app}} natively scans ~/.agents/skills/ and cannot be independently controlled in Unified mode"
   },
   "deeplink": {
     "confirmImport": "Confirm Import Provider",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -708,7 +708,7 @@
       "ccSwitch": "CC Switch",
       "unified": "~/.agents/skills",
       "ccSwitchHint": "スキルは ~/.cc-switch/skills/ に保存され、シンボリックリンクまたはコピーで各アプリに同期されます。",
-      "unifiedHint": "スキルは ~/.agents/skills/ に保存されます（Agent Skills オープン標準）。対応ツール（Claude Code、Codex、Gemini CLI など）はこのディレクトリのスキルを直接検出します。",
+      "unifiedHint": "スキルは ~/.agents/skills/ に保存されます（Agent Skills オープン標準）。対応ツール（OpenCode、Codex、Gemini CLI、OpenClaw など）はこのディレクトリのスキルを直接検出します。",
       "confirmTitle": "スキル保存場所の移行",
       "confirmMessage": "{{count}} 個のスキルを新しい場所に移動します。続行しますか？",
       "migrationSuccess": "{{count}} 個のスキルを移行しました",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -708,7 +708,7 @@
       "ccSwitch": "CC Switch",
       "unified": "~/.agents/skills",
       "ccSwitchHint": "技能儲存在 ~/.cc-switch/skills/，由 CC Switch 統一管理並同步至各應用程式。",
-      "unifiedHint": "技能儲存在 ~/.agents/skills/，遵循 Agent Skills 開放標準。相容的工具（Claude Code、Codex、Gemini CLI 等）可直接發現此目錄中的技能。",
+      "unifiedHint": "技能儲存在 ~/.agents/skills/，遵循 Agent Skills 開放標準。相容的工具（OpenCode、Codex、Gemini CLI、OpenClaw 等）可直接發現此目錄中的技能。",
       "confirmTitle": "遷移技能儲存位置",
       "confirmMessage": "將移動 {{count}} 個技能至新位置，是否繼續？",
       "migrationSuccess": "已成功遷移 {{count}} 個技能",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -708,7 +708,7 @@
       "ccSwitch": "CC Switch",
       "unified": "~/.agents/skills",
       "ccSwitchHint": "技能存储在 ~/.cc-switch/skills/，由 CC Switch 统一管理并同步到各应用。",
-      "unifiedHint": "技能存储在 ~/.agents/skills/，遵循 Agent Skills 开放标准。兼容的工具（Claude Code、Codex、Gemini CLI 等）可直接发现此目录中的技能。",
+      "unifiedHint": "技能存储在 ~/.agents/skills/，遵循 Agent Skills 开放标准。兼容的工具（OpenCode、Codex、Gemini CLI、OpenClaw 等）可直接发现此目录中的技能。",
       "confirmTitle": "迁移技能存储",
       "confirmMessage": "将移动 {{count}} 个技能到新位置，是否继续？",
       "migrationSuccess": "已成功迁移 {{count}} 个技能",
@@ -2421,7 +2421,10 @@
       "successSingle": "技能 {{name}} 已安装",
       "successMultiple": "成功安装 {{count}} 个技能",
       "noSkillsFound": "ZIP 文件中未找到技能（需包含 SKILL.md 文件）"
-    }
+    },
+    "globalEnabled": "全局启用（通过 ~/.agents/skills/ 对所有 Agent 可见）",
+    "globalDisabled": "未全局启用（仅对显式启用的 Agent 可见）",
+    "lockedInUnified": "{{app}} 原生扫描 ~/.agents/skills/，在 Unified 模式下无法独立控制"
   },
   "deeplink": {
     "confirmImport": "确认导入供应商配置",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -38,6 +38,7 @@ export interface InstalledSkill {
   installedAt: number;
   contentHash?: string;
   updatedAt: number;
+  globalEnabled?: boolean;
 }
 
 export interface SkillUninstallResult {
@@ -177,6 +178,11 @@ export const skillsApi = {
   /** 切换 Skill 的应用启用状态 */
   async toggleApp(id: string, app: AppId, enabled: boolean): Promise<boolean> {
     return await invoke("toggle_skill_app", { id, app, enabled });
+  },
+
+  /** 切换 Skill 的全局启用状态（CcSwitch 模式） */
+  async toggleGlobal(id: string, enabled: boolean): Promise<boolean> {
+    return await invoke("toggle_skill_global", { id, enabled });
   },
 
   /** 扫描未管理的 Skills */

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -1,6 +1,8 @@
 import { createRef } from "react";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { createTestQueryClient } from "../utils/testQueryClient";
 
 import UnifiedSkillsPanel, {
   type UnifiedSkillsPanelHandle,
@@ -102,13 +104,16 @@ describe("UnifiedSkillsPanel", () => {
 
   it("opens the import dialog without crashing when app toggles render", async () => {
     const ref = createRef<UnifiedSkillsPanelHandle>();
+    const queryClient = createTestQueryClient();
 
     render(
-      <UnifiedSkillsPanel
-        ref={ref}
-        onOpenDiscovery={() => {}}
-        currentApp="claude"
-      />,
+      <QueryClientProvider client={queryClient}>
+        <UnifiedSkillsPanel
+          ref={ref}
+          onOpenDiscovery={() => {}}
+          currentApp="claude"
+        />
+      </QueryClientProvider>,
     );
 
     await act(async () => {

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -8,6 +8,7 @@ import UnifiedSkillsPanel, {
 
 const scanUnmanagedMock = vi.fn();
 const toggleSkillAppMock = vi.fn();
+const toggleSkillGlobalMock = vi.fn();
 const uninstallSkillMock = vi.fn();
 const importSkillsMock = vi.fn();
 const installFromZipMock = vi.fn();
@@ -38,6 +39,9 @@ vi.mock("@/hooks/useSkills", () => ({
   }),
   useToggleSkillApp: () => ({
     mutateAsync: toggleSkillAppMock,
+  }),
+  useToggleSkillGlobal: () => ({
+    mutateAsync: toggleSkillGlobalMock,
   }),
   useRestoreSkillBackup: () => ({
     mutateAsync: restoreSkillBackupMock,


### PR DESCRIPTION
## Summary / 概述

CC Switch 管理的 Skills 有两种存储模式：

- **CcSwitch 模式**（默认）：SSOT 在 `~/.cc-switch/skills/`，每个 Agent 的 skill 目录里只有它显式启用的 skill（symlink 或 copy）
- **Unified 模式**：SSOT 在 `~/.agents/skills/`，遵循 Agent Skills 开放标准

问题在于：OpenCode、Codex、Gemini CLI、OpenClaw 这四个 Agent 原生扫描 `~/.agents/skills/`（无需 CC Switch 干预就能加载其中的所有 skill）。在 Unified 模式下，四个 Agent 直接从 SSOT 读取，无法独立开关 skill——它们总是全量加载。

本特性新增 **~/.agents/skills/ 目录接管** 和 **全局开关** 机制来解决这一冲突。

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #4407 

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| CcSwitch mode | Unified mode |
|-----------------|---------------|
| <img width="1994" height="1298" alt="image" src="https://github.com/user-attachments/assets/fc53f23d-b704-40cc-8020-c4e57a0f4490" /> | <img width="1996" height="1296" alt="image" src="https://github.com/user-attachments/assets/d889090d-a255-4cfd-b487-866646be6564" /> |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
