### PR TITLE
fix(provider): correct [1m] marker case and add 1M toggle to fallback…

### DIFF
--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -957,12 +957,38 @@ export function ClaudeFormFields({
                   defaultValue: "默认兜底模型",
                 })}
               </FormLabel>
-              {renderModelInput(
-                "claudeModel",
-                claudeModel,
-                "ANTHROPIC_MODEL",
-                t("providerForm.modelPlaceholder", { defaultValue: "" }),
-              )}
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_104px]">
+                {renderModelInput(
+                  "claudeModel",
+                  stripClaudeOneMMarker(claudeModel),
+                  "ANTHROPIC_MODEL",
+                  t("providerForm.modelPlaceholder", { defaultValue: "" }),
+                  (value) => {
+                    const fallbackUsesOneM = hasClaudeOneMMarker(claudeModel);
+                    onModelChange(
+                      "ANTHROPIC_MODEL",
+                      fallbackUsesOneM
+                        ? setClaudeOneMMarker(value, true)
+                        : value,
+                    );
+                  },
+                )}
+                <label className="flex h-9 items-center gap-2 text-sm text-muted-foreground">
+                  <Checkbox
+                    checked={hasClaudeOneMMarker(claudeModel)}
+                    onCheckedChange={(checked) => {
+                      const enabled = checked === true;
+                      onModelChange(
+                        "ANTHROPIC_MODEL",
+                        setClaudeOneMMarker(claudeModel, enabled),
+                      );
+                    }}
+                  />
+                  {t("providerForm.modelOneMLabel", {
+                    defaultValue: "1M",
+                  })}
+                </label>
+              </div>
               <p className="text-xs text-muted-foreground">
                 {t("providerForm.fallbackModelHint", {
                   defaultValue:

--- a/src/components/providers/forms/hooks/useModelState.ts
+++ b/src/components/providers/forms/hooks/useModelState.ts
@@ -16,7 +16,7 @@ export type ClaudeModelEnvField =
   | "ANTHROPIC_DEFAULT_FABLE_MODEL"
   | "ANTHROPIC_DEFAULT_FABLE_MODEL_NAME";
 
-export const CLAUDE_ONE_M_MARKER = "[1M]";
+export const CLAUDE_ONE_M_MARKER = "[1m]";
 
 export function hasClaudeOneMMarker(model: string): boolean {
   return model.trimEnd().toLowerCase().endsWith("[1m]");

--- a/tests/hooks/useModelState.test.tsx
+++ b/tests/hooks/useModelState.test.tsx
@@ -104,7 +104,7 @@ describe("useModelState", () => {
       "deepseek-v4-pro",
     );
     expect(setClaudeOneMMarker("deepseek-v4-pro", true)).toBe(
-      "deepseek-v4-pro[1M]",
+      "deepseek-v4-pro[1m]",
     );
   });
 });


### PR DESCRIPTION
---
  Title

  fix(provider): correct [1m] marker case and add 1M toggle to fallback model

  Description

  Fixes #3679 — two related bugs that prevent Claude 1M context window from working correctly.

  ## Bug 1: Uppercase marker not recognized
  `CLAUDE_ONE_M_MARKER` was `[1M]` (uppercase) but Claude Code only recognizes lowercase `[1m]`. The `hasClaudeOneMMarker`/`stripClaudeOneMMarker` functions use   
  `.toLowerCase()` so they hid the problem silently, but `setClaudeOneMMarker` wrote the uppercase form into config — which Claude Code ignores.

  **Fix**: Change the constant from `"[1M]"` to `"[1m]"`.

  ## Bug 2: Fallback model missing 1M toggle
  The fallback model (`ANTHROPIC_MODEL`) field had no checkbox to declare 1M support, unlike the Sonnet/Opus/Fable role fields. Since `ANTHROPIC_MODEL` overrides  
  role-specific models, users who correctly configured 1M on role models would still lose it via the fallback.

  **Fix**: Added 1M checkbox to the fallback model section, following the same pattern as role model rows — `stripClaudeOneMMarker` for display value,
  `hasClaudeOneMMarker` for checkbox state, `setClaudeOneMMarker` on toggle.

  ## Changes
  | File | Change |
  |------|--------|
  | `src/components/providers/forms/hooks/useModelState.ts` | `[1M]` → `[1m]` (1 char) |
  | `src/components/providers/forms/ClaudeFormFields.tsx` | Add 1M checkbox grid to fallback model (+30 lines) |
  | `tests/hooks/useModelState.test.tsx` | Update test expectation to match corrected marker case |

  ## Verification
  - [x] `pnpm typecheck` passes
  - [x] `pnpm format:check` passes
  - [x] `useModelState` unit tests (4/4) pass
  - [x] Backward compatible — existing uppercase `[1M]` in user configs is still correctly detected/stripped via `.toLowerCase()`

  ---