### PR TITLE
fix(skills): preserve deleted default repositories

### DIFF
--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -7,7 +7,7 @@
 //! - 实际文件存储在 ~/.cc-switch/skills/，同步到各应用目录
 
 use crate::app_config::{InstalledSkill, SkillApps};
-use crate::database::{lock_conn, Database};
+use crate::database::{lock_conn, Database, DEFAULT_SKILL_REPOS_INITIALIZED_KEY};
 use crate::error::AppError;
 use crate::services::skill::SkillRepo;
 use indexmap::IndexMap;
@@ -232,32 +232,113 @@ impl Database {
         Ok(())
     }
 
-    /// 初始化默认的 Skill 仓库（启动时调用，补充缺失的默认仓库）
-    pub fn init_default_skill_repos(&self) -> Result<usize, AppError> {
-        // 获取已有仓库列表
-        let existing = self.get_skill_repos()?;
-        let existing_keys: std::collections::HashSet<(String, String)> = existing
-            .iter()
-            .map(|r| (r.owner.clone(), r.name.clone()))
-            .collect();
+    /// 一次性初始化默认的 Skill 仓库。
+    ///
+    /// 全新安装写入默认仓库；已有安装或 JSON 迁移只记录标记，不补回缺失仓库。
+    pub fn init_default_skill_repos(&self, seed_defaults: bool) -> Result<usize, AppError> {
+        let mut conn = lock_conn!(self.conn);
+        let tx = conn
+            .transaction()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let initialized: bool = tx
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM settings
+                    WHERE key = ?1 AND value IN ('true', '1')
+                )",
+                params![DEFAULT_SKILL_REPOS_INITIALIZED_KEY],
+                |row| row.get(0),
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        if initialized {
+            return Ok(0);
+        }
 
-        // 获取默认仓库列表
-        let default_store = crate::services::skill::SkillStore::default();
         let mut count = 0;
-
-        // 仅插入缺失的默认仓库
-        for repo in &default_store.repos {
-            let key = (repo.owner.clone(), repo.name.clone());
-            if !existing_keys.contains(&key) {
-                self.save_skill_repo(repo)?;
-                count += 1;
-                log::info!("补充默认 Skill 仓库: {}/{}", repo.owner, repo.name);
+        if seed_defaults {
+            for repo in &crate::services::skill::SkillStore::default().repos {
+                let inserted = tx
+                    .execute(
+                        "INSERT OR IGNORE INTO skill_repos
+                         (owner, name, branch, enabled) VALUES (?1, ?2, ?3, ?4)",
+                        params![repo.owner, repo.name, repo.branch, repo.enabled],
+                    )
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+                count += inserted;
+                if inserted > 0 {
+                    log::info!("初始化默认 Skill 仓库: {}/{}", repo.owner, repo.name);
+                }
             }
         }
 
-        if count > 0 {
-            log::info!("补充默认 Skill 仓库完成，新增 {count} 个");
-        }
+        tx.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES (?1, 'true')",
+            params![DEFAULT_SKILL_REPOS_INITIALIZED_KEY],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        tx.commit().map_err(|e| AppError::Database(e.to_string()))?;
+
+        log::info!("默认 Skill 仓库初始化状态已记录，新增 {count} 个仓库");
         Ok(count)
+    }
+
+    pub fn default_skill_repos_initialized(&self) -> Result<bool, AppError> {
+        Ok(matches!(
+            self.get_setting(DEFAULT_SKILL_REPOS_INITIALIZED_KEY)?
+                .as_deref(),
+            Some("true" | "1")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod default_skill_repo_tests {
+    use crate::database::Database;
+    use crate::services::skill::SkillStore;
+
+    #[test]
+    fn deleted_default_repository_is_not_restored_on_later_startup() {
+        let db = Database::memory().expect("memory db");
+        let default_repo = SkillStore::default()
+            .repos
+            .into_iter()
+            .next()
+            .expect("default repository");
+
+        db.init_default_skill_repos(true)
+            .expect("initialize default repositories");
+        db.delete_skill_repo(&default_repo.owner, &default_repo.name)
+            .expect("delete default repository");
+
+        let inserted = db
+            .init_default_skill_repos(true)
+            .expect("repeat startup initialization");
+        let repositories = db.get_skill_repos().expect("list repositories");
+
+        assert_eq!(inserted, 0);
+        assert!(
+            repositories.iter().all(|repo| {
+                !(repo.owner == default_repo.owner && repo.name == default_repo.name)
+            }),
+            "a repository explicitly deleted by the user must stay deleted"
+        );
+    }
+
+    #[test]
+    fn existing_installation_is_marked_without_injecting_default_repositories() {
+        let db = Database::memory().expect("memory db");
+
+        let inserted = db
+            .init_default_skill_repos(false)
+            .expect("mark existing installation");
+
+        assert_eq!(inserted, 0);
+        assert!(db
+            .get_skill_repos()
+            .expect("list existing repositories")
+            .is_empty());
+        assert!(db
+            .default_skill_repos_initialized()
+            .expect("read initialization marker"));
     }
 }

--- a/src-tauri/src/database/migration.rs
+++ b/src-tauri/src/database/migration.rs
@@ -2,7 +2,7 @@
 //!
 //! 将旧版 config.json (MultiAppConfig) 数据迁移到 SQLite 数据库。
 
-use super::{lock_conn, to_json_string, Database};
+use super::{lock_conn, to_json_string, Database, DEFAULT_SKILL_REPOS_INITIALIZED_KEY};
 use crate::app_config::MultiAppConfig;
 use crate::error::AppError;
 use rusqlite::{params, Connection};
@@ -16,6 +16,15 @@ impl Database {
             .map_err(|e| AppError::Database(e.to_string()))?;
 
         Self::migrate_from_json_tx(&tx, config)?;
+        tx.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES (?1, 'true')",
+            params![DEFAULT_SKILL_REPOS_INITIALIZED_KEY],
+        )
+        .map_err(|e| {
+            AppError::Database(format!(
+                "Mark default Skill repositories initialized failed: {e}"
+            ))
+        })?;
 
         tx.commit()
             .map_err(|e| AppError::Database(format!("Commit migration failed: {e}")))?;
@@ -241,5 +250,35 @@ impl Database {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::skill::SkillRepo;
+
+    fn config_with_repository() -> MultiAppConfig {
+        let mut config = MultiAppConfig::default();
+        config.skills.repos = vec![SkillRepo {
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+            branch: "main".to_string(),
+            enabled: true,
+        }];
+        config
+    }
+
+    #[test]
+    fn migration_and_repository_initialization_marker_commit_together() {
+        let db = Database::memory().expect("memory database");
+
+        db.migrate_from_json(&config_with_repository())
+            .expect("migrate configuration");
+
+        assert_eq!(db.get_skill_repos().expect("read repositories").len(), 1);
+        assert!(db
+            .default_skill_repos_initialized()
+            .expect("read initialization marker"));
     }
 }

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -53,6 +53,7 @@ use std::sync::Mutex;
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
 pub(crate) const SCHEMA_VERSION: i32 = 13;
+pub(crate) const DEFAULT_SKILL_REPOS_INITIALIZED_KEY: &str = "skills_default_repos_initialized";
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,103 @@ use tauri::RunEvent;
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
+const SKILL_REPO_INITIALIZATION_PENDING_FILE: &str = "skills-default-repos.pending";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillRepoInitializationPending {
+    None,
+    FreshInstall,
+    JsonMigration,
+}
+
+impl SkillRepoInitializationPending {
+    fn as_str(self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::FreshInstall => Some("fresh-install"),
+            Self::JsonMigration => Some("json-migration"),
+        }
+    }
+
+    fn parse(value: &str) -> Self {
+        match value.trim() {
+            "fresh-install" => Self::FreshInstall,
+            "json-migration" => Self::JsonMigration,
+            _ => Self::None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillRepoStartupAction {
+    SeedDefaults,
+    MarkExisting,
+    MigrateJson,
+    Skip,
+}
+
+fn decide_skill_repo_startup(
+    database_existed: bool,
+    has_json: bool,
+    pending: SkillRepoInitializationPending,
+    initialized: bool,
+) -> SkillRepoStartupAction {
+    if initialized {
+        return SkillRepoStartupAction::Skip;
+    }
+
+    match pending {
+        SkillRepoInitializationPending::FreshInstall => SkillRepoStartupAction::SeedDefaults,
+        SkillRepoInitializationPending::JsonMigration if has_json => {
+            SkillRepoStartupAction::MigrateJson
+        }
+        SkillRepoInitializationPending::JsonMigration => SkillRepoStartupAction::MarkExisting,
+        SkillRepoInitializationPending::None if !database_existed && has_json => {
+            SkillRepoStartupAction::MigrateJson
+        }
+        SkillRepoInitializationPending::None if !database_existed => {
+            SkillRepoStartupAction::SeedDefaults
+        }
+        SkillRepoInitializationPending::None => SkillRepoStartupAction::MarkExisting,
+    }
+}
+
+fn load_skill_repo_initialization_pending(
+    path: &std::path::Path,
+) -> Result<SkillRepoInitializationPending, AppError> {
+    match std::fs::read_to_string(path) {
+        Ok(value) => Ok(SkillRepoInitializationPending::parse(&value)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(SkillRepoInitializationPending::None)
+        }
+        Err(error) => Err(AppError::io(path, error)),
+    }
+}
+
+fn persist_skill_repo_initialization_pending(
+    path: &std::path::Path,
+    pending: SkillRepoInitializationPending,
+) -> Result<(), AppError> {
+    let value = pending
+        .as_str()
+        .ok_or_else(|| AppError::Config("Cannot persist an empty pending state".to_string()))?;
+    crate::config::atomic_write(path, value.as_bytes())
+}
+
+fn clear_skill_repo_initialization_pending(path: &std::path::Path) -> Result<(), AppError> {
+    match std::fs::remove_file(path) {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(AppError::io(path, error)),
+    }
+}
+
+fn clear_skill_repo_initialization_pending_or_warn(path: &std::path::Path) {
+    if let Err(error) = clear_skill_repo_initialization_pending(path) {
+        log::warn!("Failed to clear Skill repository pending marker: {error}");
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn set_windows_app_user_model_id(app: &tauri::AppHandle) {
     let app_id = app.config().identifier.clone();
@@ -379,14 +476,32 @@ pub fn run() {
             let app_config_dir = crate::config::get_app_config_dir();
             let db_path = app_config_dir.join("cc-switch.db");
             let json_path = app_config_dir.join("config.json");
+            let skill_repo_pending_path =
+                app_config_dir.join(SKILL_REPO_INITIALIZATION_PENDING_FILE);
 
             // 检查是否需要从 config.json 迁移到 SQLite
             let has_json = json_path.exists();
             let has_db = db_path.exists();
+            let mut skill_repo_pending =
+                load_skill_repo_initialization_pending(&skill_repo_pending_path)?;
+            if !has_db && skill_repo_pending == SkillRepoInitializationPending::None {
+                skill_repo_pending = if has_json {
+                    SkillRepoInitializationPending::JsonMigration
+                } else {
+                    SkillRepoInitializationPending::FreshInstall
+                };
+                // 数据库创建前落盘，避免首次启动中断后误判为已有安装。
+                persist_skill_repo_initialization_pending(
+                    &skill_repo_pending_path,
+                    skill_repo_pending,
+                )?;
+            }
 
-            // 如果需要迁移，先验证 config.json 是否可以加载（在创建数据库之前）
-            // 这样如果加载失败用户选择退出，数据库文件还没被创建，下次可以正常重试
-            let migration_config = if !has_db && has_json {
+            // 迁移 pending 跨启动保留，数据库已创建时也继续迁移旧配置。
+            let migration_config = if skill_repo_pending
+                == SkillRepoInitializationPending::JsonMigration
+                && has_json
+            {
                 log::info!("检测到旧版配置文件，验证配置文件...");
 
                 // 循环：支持用户重试加载配置文件
@@ -400,7 +515,6 @@ pub fn run() {
                             log::error!("加载旧配置文件失败: {e}");
                             // 弹出系统对话框让用户选择
                             if !show_migration_error_dialog(app.handle(), &e.to_string()) {
-                                // 用户选择退出（此时数据库还没创建，下次启动可以重试）
                                 log::info!("用户选择退出程序");
                                 std::process::exit(1);
                             }
@@ -464,26 +578,72 @@ pub fn run() {
                 }
             };
 
-            // 如果有预加载的配置，执行迁移
-            if let Some(config) = migration_config {
-                log::info!("开始执行数据迁移...");
+            let skill_repo_initialized = db.default_skill_repos_initialized()?;
+            let skill_repo_action = decide_skill_repo_startup(
+                has_db,
+                has_json,
+                skill_repo_pending,
+                skill_repo_initialized,
+            );
 
-                match db.migrate_from_json(&config) {
-                    Ok(_) => {
-                        log::info!("✓ 配置迁移成功");
-                        // 标记迁移成功，供前端显示 Toast
-                        crate::init_status::set_migration_success();
-                        // 归档旧配置文件（重命名而非删除，便于用户恢复）
-                        let archive_path = json_path.with_extension("json.migrated");
-                        if let Err(e) = std::fs::rename(&json_path, &archive_path) {
-                            log::warn!("归档旧配置文件失败: {e}");
-                        } else {
-                            log::info!("✓ 旧配置已归档为 config.json.migrated");
+            match skill_repo_action {
+                SkillRepoStartupAction::SeedDefaults => {
+                    match db.init_default_skill_repos(true) {
+                        Ok(count) => {
+                            if count > 0 {
+                                log::info!("✓ Initialized {count} default skill repositories");
+                            }
+                            clear_skill_repo_initialization_pending_or_warn(
+                                &skill_repo_pending_path,
+                            );
+                        }
+                        Err(error) => {
+                            log::warn!("✗ Failed to initialize default skill repos: {error}");
                         }
                     }
-                    Err(e) => {
-                        // 配置加载成功但迁移失败的情况极少（磁盘满等），仅记录日志
-                        log::error!("配置迁移失败: {e}，将从现有配置导入");
+                }
+                SkillRepoStartupAction::MigrateJson => {
+                    if let Some(config) = migration_config {
+                        log::info!("开始执行数据迁移...");
+                        match db.migrate_from_json(&config) {
+                            Ok(_) => {
+                                log::info!("✓ 配置迁移成功");
+                                crate::init_status::set_migration_success();
+                                clear_skill_repo_initialization_pending_or_warn(
+                                    &skill_repo_pending_path,
+                                );
+                                let archive_path = json_path.with_extension("json.migrated");
+                                if let Err(error) = std::fs::rename(&json_path, &archive_path) {
+                                    // marker 已提交，归档失败也不重复迁移。
+                                    log::warn!("归档旧配置文件失败: {error}");
+                                } else {
+                                    log::info!("✓ 旧配置已归档为 config.json.migrated");
+                                }
+                            }
+                            Err(error) => {
+                                // 保留 JSON 与 pending 文件，下次启动重试。
+                                log::error!("配置迁移失败: {error}；下次启动将重试");
+                            }
+                        }
+                    }
+                }
+                SkillRepoStartupAction::MarkExisting => {
+                    match db.init_default_skill_repos(false) {
+                        Ok(_) => {
+                            if skill_repo_pending != SkillRepoInitializationPending::None {
+                                clear_skill_repo_initialization_pending_or_warn(
+                                    &skill_repo_pending_path,
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            log::warn!("✗ Failed to mark default skill repos initialized: {error}");
+                        }
+                    }
+                }
+                SkillRepoStartupAction::Skip => {
+                    if skill_repo_pending != SkillRepoInitializationPending::None {
+                        clear_skill_repo_initialization_pending_or_warn(&skill_repo_pending_path);
                     }
                 }
             }
@@ -497,16 +657,7 @@ pub fn run() {
             // 按表独立判断的导入逻辑（各类数据独立检查，互不影响）
             // ============================================================
 
-            // 1. 初始化默认 Skills 仓库（已有内置检查：表非空则跳过）
-            match app_state.db.init_default_skill_repos() {
-                Ok(count) if count > 0 => {
-                    log::info!("✓ Initialized {count} default skill repositories");
-                }
-                Ok(_) => {} // 表非空，静默跳过
-                Err(e) => log::warn!("✗ Failed to initialize default skill repos: {e}"),
-            }
-
-            // 1.1. Skills 统一管理迁移：当数据库迁移到 v3 结构后，自动从各应用目录导入到 SSOT
+            // 1. Skills 统一管理迁移：当数据库迁移到 v3 结构后，自动从各应用目录导入到 SSOT
             // 触发条件由 schema 迁移设置 settings.skills_ssot_migration_pending = true 控制。
             match app_state.db.get_setting("skills_ssot_migration_pending") {
                 Ok(Some(flag)) if flag == "true" || flag == "1" => {
@@ -2067,7 +2218,41 @@ pub fn restart_process(app_handle: &tauri::AppHandle) -> ! {
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_exit_request, ExitRequestAction};
+    use super::{
+        classify_exit_request, decide_skill_repo_startup, ExitRequestAction,
+        SkillRepoInitializationPending, SkillRepoStartupAction,
+    };
+
+    #[test]
+    fn pending_repository_initialization_resumes_safely() {
+        let cases = [
+            (
+                true,
+                false,
+                SkillRepoInitializationPending::FreshInstall,
+                SkillRepoStartupAction::SeedDefaults,
+            ),
+            (
+                true,
+                true,
+                SkillRepoInitializationPending::JsonMigration,
+                SkillRepoStartupAction::MigrateJson,
+            ),
+            (
+                true,
+                false,
+                SkillRepoInitializationPending::JsonMigration,
+                SkillRepoStartupAction::MarkExisting,
+            ),
+        ];
+
+        for (database_existed, has_json, pending, expected) in cases {
+            assert_eq!(
+                decide_skill_repo_startup(database_existed, has_json, pending, false),
+                expected
+            );
+        }
+    }
 
     #[test]
     fn no_code_keeps_app_alive_in_tray() {


### PR DESCRIPTION
> **Skills 仓库生命周期修复（从 #4256 拆分）**
>
> 建议合并顺序：#4658 → #4659 → #4660。三个 PR 分别处理初始化、更新检查、发现缓存；后两个会触及同一条 update/discovery 路径，前序合并后我会及时 rebase 后续 PR。

Fixes #4677  
Part of #4248  
Split from #4256

## Summary

修复用户删除内置 Skills 仓库后，重启应用又被自动恢复的问题。

## Changes

- 为默认仓库增加一次性初始化标记：仅全新安装写入默认仓库，后续启动不再“补齐”用户删除的仓库。
- 已有 SQLite 数据库只补初始化标记，不注入默认仓库；旧 `config.json` 迁移与标记在同一事务提交。
- 在数据库首次创建前写入一个很小的 pending marker，避免首次启动在“数据库已创建、默认仓库尚未写入”之间中断后永久丢失默认仓库；完成后立即清理。
- 初始化、迁移和标记写入均保持幂等，重复启动不会改变用户仓库列表。

## Screenshots

| Before | After |
|---|---|
| 删除前包含默认仓库。<br><img width="500" alt="default repos before delete" src="https://github.com/user-attachments/assets/55b2a638-33cf-4558-862c-19cdef8b5a13" /> | 完全退出并重启后，被删除仓库仍保持删除。<br><img width="500" alt="default repo after restart stays deleted" src="https://github.com/user-attachments/assets/21f2e251-ab31-45bd-b5b5-65529ac0f310" /> |

| Delete confirmation |
|---|
| <img width="500" alt="default repo delete confirmed" src="https://github.com/user-attachments/assets/52dcc383-27e1-49d3-be09-3cf280bce24a" /> |

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --lib default_skill_repo_tests`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib migration_and_repository_initialization_marker_commit_together`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib pending_repository_initialization_resumes_safely`
- `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `git diff --check`
