### PR TITLE
fix(skills): report update check failures

### DIFF
--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -8,7 +8,7 @@ use crate::app_config::{AppType, InstalledSkill, UnmanagedSkill};
 use crate::error::format_skill_error;
 use crate::services::skill::{
     DiscoverableSkill, ImportSkillSelection, MigrationResult, Skill, SkillBackupEntry, SkillRepo,
-    SkillService, SkillStorageLocation, SkillUninstallResult, SkillUpdateInfo,
+    SkillService, SkillStorageLocation, SkillUninstallResult, SkillUpdateCheckResult,
     SkillsShSearchResult,
 };
 use crate::store::AppState;
@@ -135,7 +135,7 @@ pub async fn discover_available_skills(
 pub async fn check_skill_updates(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
-) -> Result<Vec<SkillUpdateInfo>, String> {
+) -> Result<SkillUpdateCheckResult, String> {
     service
         .0
         .check_updates(&app_state.db)

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -186,6 +186,24 @@ pub struct SkillUpdateInfo {
     pub remote_hash: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillRepoCheckFailure {
+    pub owner: String,
+    pub name: String,
+    pub branch: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill_id: Option<String>,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillUpdateCheckResult {
+    pub updates: Vec<SkillUpdateInfo>,
+    pub failures: Vec<SkillRepoCheckFailure>,
+}
+
 /// Skill 存储位置迁移结果
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -868,9 +886,10 @@ impl SkillService {
     ///
     /// 仅检查有 repo_owner 的 Skill（本地 Skill 跳过），
     /// 按仓库分组下载，避免重复下载同一仓库。
-    pub async fn check_updates(&self, db: &Arc<Database>) -> Result<Vec<SkillUpdateInfo>> {
+    pub async fn check_updates(&self, db: &Arc<Database>) -> Result<SkillUpdateCheckResult> {
         let skills = db.get_all_installed_skills()?;
         let mut updates = Vec::new();
+        let mut failures = Vec::new();
 
         // 按 (owner, name, branch) 分组
         let mut repo_groups: HashMap<(String, String, String), Vec<InstalledSkill>> =
@@ -909,17 +928,69 @@ impl SkillService {
                 Ok(Ok(result)) => result,
                 Ok(Err(e)) => {
                     log::warn!("检查更新时下载 {}/{} 失败: {e}", owner, name);
+                    failures.push(SkillRepoCheckFailure {
+                        owner: owner.clone(),
+                        name: name.clone(),
+                        branch: branch.clone(),
+                        skill_id: None,
+                        error: e.to_string(),
+                    });
                     continue;
                 }
                 Err(_) => {
                     log::warn!("检查更新时下载 {}/{} 超时", owner, name);
+                    failures.push(SkillRepoCheckFailure {
+                        owner: owner.clone(),
+                        name: name.clone(),
+                        branch: branch.clone(),
+                        skill_id: None,
+                        error: format_skill_error(
+                            "DOWNLOAD_TIMEOUT",
+                            &[("owner", owner), ("name", name), ("timeout", "60")],
+                            Some("checkNetwork"),
+                        ),
+                    });
                     continue;
                 }
             };
 
             // 扫描仓库中的所有 Skill 目录
             let mut remote_skills: Vec<DiscoverableSkill> = Vec::new();
-            let _ = self.scan_dir_recursive(&temp_dir, &temp_dir, &repo, &mut remote_skills);
+            if let Err(e) = self.scan_dir_recursive(&temp_dir, &temp_dir, &repo, &mut remote_skills)
+            {
+                failures.push(SkillRepoCheckFailure {
+                    owner: owner.clone(),
+                    name: name.clone(),
+                    branch: branch.clone(),
+                    skill_id: None,
+                    error: e.to_string(),
+                });
+                let _ = fs::remove_dir_all(&temp_dir);
+                continue;
+            }
+
+            if let Some(missing) = group_skills.iter().find(|skill| {
+                !remote_skills.iter().any(|remote| {
+                    remote
+                        .directory
+                        .rsplit('/')
+                        .next()
+                        .unwrap_or(&remote.directory)
+                        .eq_ignore_ascii_case(&skill.directory)
+                })
+            }) {
+                failures.push(SkillRepoCheckFailure {
+                    owner: owner.clone(),
+                    name: name.clone(),
+                    branch: branch.clone(),
+                    skill_id: Some(missing.id.clone()),
+                    error: format_skill_error(
+                        "SKILL_DIR_NOT_FOUND",
+                        &[("path", &missing.directory)],
+                        Some("checkRepoUrl"),
+                    ),
+                });
+            }
 
             for skill in group_skills {
                 // 在远程仓库中找到匹配的 Skill 目录
@@ -978,7 +1049,29 @@ impl SkillService {
             let _ = fs::remove_dir_all(&temp_dir);
         }
 
-        Ok(updates)
+        let current_skills = db.get_all_installed_skills()?;
+        failures.retain(|failure| {
+            if let Some(skill_id) = &failure.skill_id {
+                return current_skills.contains_key(skill_id);
+            }
+            current_skills.values().any(|skill| {
+                skill
+                    .repo_owner
+                    .as_deref()
+                    .is_some_and(|owner| owner.eq_ignore_ascii_case(&failure.owner))
+                    && skill
+                        .repo_name
+                        .as_deref()
+                        .is_some_and(|name| name.eq_ignore_ascii_case(&failure.name))
+                    && skill
+                        .repo_branch
+                        .as_deref()
+                        .unwrap_or("main")
+                        .eq_ignore_ascii_case(&failure.branch)
+            })
+        });
+
+        Ok(SkillUpdateCheckResult { updates, failures })
     }
 
     /// 更新单个 Skill（重新下载并替换本地文件）

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import {
   Sparkles,
   Trash2,
@@ -28,10 +29,12 @@ import {
   type SkillUpdateInfo,
 } from "@/hooks/useSkills";
 import type { AppId } from "@/lib/api/types";
+import type { SkillRepoCheckFailure } from "@/lib/api/skills";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi, skillsApi } from "@/lib/api";
 import { toast } from "sonner";
 import { SKILLS_APP_IDS } from "@/config/appConfig";
+import { formatSkillError } from "@/lib/errors/skillErrorParser";
 import { AppCountBar } from "@/components/common/AppCountBar";
 import { AppToggleGroup } from "@/components/common/AppToggleGroup";
 import { ListItemRow } from "@/components/common/ListItemRow";
@@ -62,6 +65,16 @@ function formatSkillBackupDate(unixSeconds: number): string {
   return Number.isNaN(date.getTime())
     ? String(unixSeconds)
     : date.toLocaleString();
+}
+
+function formatUpdateFailures(failures: SkillRepoCheckFailure[], t: TFunction) {
+  return failures
+    .slice(0, 3)
+    .map((failure) => {
+      const reason = formatSkillError(failure.error, t).description;
+      return `${failure.owner}/${failure.name}@${failure.branch}: ${reason}`;
+    })
+    .join("\n");
 }
 
 const UnifiedSkillsPanel = React.forwardRef<
@@ -96,19 +109,18 @@ const UnifiedSkillsPanel = React.forwardRef<
   const importMutation = useImportSkillsFromApps();
   const installFromZipMutation = useInstallSkillsFromZip();
   const {
-    data: skillUpdates,
+    data: updateCheckResult,
     refetch: checkUpdates,
     isFetching: isCheckingUpdates,
   } = useCheckSkillUpdates();
+  const skillUpdates = updateCheckResult?.updates ?? [];
   const updateSkillMutation = useUpdateSkill();
   const [isUpdatingAll, setIsUpdatingAll] = useState(false);
 
   const updatesMap = useMemo(() => {
     const map: Record<string, SkillUpdateInfo> = {};
-    if (skillUpdates) {
-      for (const u of skillUpdates) {
-        map[u.id] = u;
-      }
+    for (const update of skillUpdates) {
+      map[update.id] = update;
     }
     return map;
   }, [skillUpdates]);
@@ -231,11 +243,24 @@ const UnifiedSkillsPanel = React.forwardRef<
 
   const handleCheckUpdates = async () => {
     try {
-      const result = await checkUpdates();
-      const updates = result.data || [];
-      if (updates.length === 0) {
+      const result = await checkUpdates({ throwOnError: true });
+      const { updates, failures } = result.data ?? {
+        updates: [],
+        failures: [],
+      };
+      if (failures.length > 0) {
+        toast.error(
+          t("skills.updateCheckIncomplete", { count: failures.length }),
+          {
+            description: formatUpdateFailures(failures, t),
+            duration: Infinity,
+            closeButton: true,
+          },
+        );
+      }
+      if (updates.length === 0 && failures.length === 0) {
         toast.success(t("skills.noUpdates"), { closeButton: true });
-      } else {
+      } else if (updates.length > 0) {
         toast.info(t("skills.updatesFound", { count: updates.length }), {
           closeButton: true,
         });
@@ -257,7 +282,7 @@ const UnifiedSkillsPanel = React.forwardRef<
   };
 
   const handleUpdateAll = async () => {
-    if (!skillUpdates || skillUpdates.length === 0) return;
+    if (skillUpdates.length === 0) return;
     setIsUpdatingAll(true);
     let successCount = 0;
     for (const update of skillUpdates) {

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -11,6 +11,7 @@ import {
   type ImportSkillSelection,
   type InstalledSkill,
   type SkillUpdateInfo,
+  type SkillUpdateCheckResult,
   type SkillsShSearchResult,
 } from "@/lib/api/skills";
 import type { AppId } from "@/lib/api/types";
@@ -321,11 +322,14 @@ export function useUpdateSkill() {
           );
         },
       );
-      queryClient.setQueryData<SkillUpdateInfo[]>(
+      queryClient.setQueryData<SkillUpdateCheckResult>(
         ["skills", "updates"],
         (oldData) => {
           if (!oldData) return oldData;
-          return oldData.filter((u) => u.id !== updatedSkill.id);
+          return {
+            ...oldData,
+            updates: oldData.updates.filter((u) => u.id !== updatedSkill.id),
+          };
         },
       );
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2224,6 +2224,7 @@
     "checkUpdates": "Check Updates",
     "checkingUpdates": "Checking...",
     "noUpdates": "All skills are up to date",
+    "updateCheckIncomplete": "{{count}} repositories could not be checked",
     "updatesFound": "{{count}} skill(s) have updates available",
     "updateAll": "Update All ({{count}})",
     "updatingAll": "Updating...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2224,6 +2224,7 @@
     "checkUpdates": "更新を確認",
     "checkingUpdates": "確認中...",
     "noUpdates": "すべてのスキルは最新です",
+    "updateCheckIncomplete": "{{count}} 件のリポジトリを確認できませんでした",
     "updatesFound": "{{count}} 個のスキルに更新があります",
     "updateAll": "すべて更新 ({{count}})",
     "updatingAll": "更新中...",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2196,6 +2196,7 @@
     "checkUpdates": "檢查更新",
     "checkingUpdates": "檢查中...",
     "noUpdates": "所有技能已是最新版本",
+    "updateCheckIncomplete": "{{count}} 個倉庫未完成檢查",
     "updatesFound": "發現 {{count}} 個技能有可用更新",
     "updateAll": "全部更新 ({{count}})",
     "updatingAll": "更新中...",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2224,6 +2224,7 @@
     "checkUpdates": "检查更新",
     "checkingUpdates": "检查中...",
     "noUpdates": "所有技能已是最新版本",
+    "updateCheckIncomplete": "{{count}} 个仓库未完成检查",
     "updatesFound": "发现 {{count}} 个技能有可用更新",
     "updateAll": "全部更新 ({{count}})",
     "updatingAll": "更新中...",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -99,6 +99,19 @@ export interface SkillUpdateInfo {
   remoteHash: string;
 }
 
+export interface SkillRepoCheckFailure {
+  owner: string;
+  name: string;
+  branch: string;
+  skillId?: string;
+  error: string;
+}
+
+export interface SkillUpdateCheckResult {
+  updates: SkillUpdateInfo[];
+  failures: SkillRepoCheckFailure[];
+}
+
 /** 存储位置迁移结果 */
 export interface MigrationResult {
   migratedCount: number;
@@ -197,7 +210,7 @@ export const skillsApi = {
   },
 
   /** 检查 Skills 更新 */
-  async checkUpdates(): Promise<SkillUpdateInfo[]> {
+  async checkUpdates(): Promise<SkillUpdateCheckResult> {
     return await invoke("check_skill_updates");
   },
 

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -1,6 +1,7 @@
 import { createRef } from "react";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { toast } from "sonner";
 
 import UnifiedSkillsPanel, {
   type UnifiedSkillsPanelHandle,
@@ -13,6 +14,7 @@ const importSkillsMock = vi.fn();
 const installFromZipMock = vi.fn();
 const deleteSkillBackupMock = vi.fn();
 const restoreSkillBackupMock = vi.fn();
+const checkUpdatesMock = vi.fn();
 
 vi.mock("sonner", () => ({
   toast: {
@@ -65,8 +67,8 @@ vi.mock("@/hooks/useSkills", () => ({
     mutateAsync: installFromZipMock,
   }),
   useCheckSkillUpdates: () => ({
-    data: [],
-    refetch: vi.fn(),
+    data: { updates: [], failures: [] },
+    refetch: checkUpdatesMock,
     isFetching: false,
   }),
   useUpdateSkill: () => ({
@@ -77,6 +79,7 @@ vi.mock("@/hooks/useSkills", () => ({
 
 describe("UnifiedSkillsPanel", () => {
   beforeEach(() => {
+    vi.resetAllMocks();
     scanUnmanagedMock.mockResolvedValue({
       data: [
         {
@@ -88,12 +91,6 @@ describe("UnifiedSkillsPanel", () => {
         },
       ],
     });
-    toggleSkillAppMock.mockReset();
-    uninstallSkillMock.mockReset();
-    importSkillsMock.mockReset();
-    installFromZipMock.mockReset();
-    deleteSkillBackupMock.mockReset();
-    restoreSkillBackupMock.mockReset();
   });
 
   it("opens the import dialog without crashing when app toggles render", async () => {
@@ -129,5 +126,42 @@ describe("UnifiedSkillsPanel", () => {
         },
       ]);
     });
+  });
+
+  it("does not report all skills up to date when a repository check fails", async () => {
+    checkUpdatesMock.mockResolvedValue({
+      data: {
+        updates: [],
+        failures: [
+          {
+            owner: "owner",
+            name: "repo",
+            branch: "main",
+            error: '{"code":"DOWNLOAD_TIMEOUT","context":{"timeout":"60"}}',
+          },
+        ],
+      },
+    });
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp="claude"
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.checkUpdates();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "skills.updateCheckIncomplete",
+      expect.objectContaining({ duration: Infinity }),
+    );
+    expect(toast.success).not.toHaveBeenCalledWith(
+      "skills.noUpdates",
+      expect.anything(),
+    );
   });
 });


### PR DESCRIPTION
Part of #4248

## Summary

修复 Skills 管理页在仓库检查失败时仍提示“所有技能已是最新版本”的问题。

## Changes

- 更新检查返回成功的 `updates` 和未完成的 `failures`，下载、扫描或目标 Skill 缺失都不会再被当作“没有更新”。
- 成功仓库的更新结果正常保留；失败提示列出仓库、分支及原因，并保持显示直到用户关闭。
- 检查期间若相关 Skill 或仓库已被移除，会丢弃迟到的失败结果。
- 仅新增 1 个提示文案，错误详情复用现有 Skills 错误格式化逻辑。

本 PR 只修正结果语义和反馈，不调整仓库下载方式或并发策略。

## Screenshots

| Before | After |
|---|---|
| 断网后仍显示“所有技能已是最新版本”。<br><img width="500" alt="update check before network failure" src="https://github.com/user-attachments/assets/16eb9f68-cf47-45f3-835d-b751bff14e9d" /> | 明确显示未完成检查的仓库和失败原因。<br><img width="500" alt="update check failures reported" src="https://github.com/user-attachments/assets/24883750-b291-4c30-97d2-aa903d505c07" /> |

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `CI=true pnpm vitest run tests/components/UnifiedSkillsPanel.test.tsx`
- `CI=true pnpm typecheck`
- `CI=true pnpm format:check`
- `git diff --check`
