### PR TITLE
fix(skills): cache verified discovery results

### DIFF
--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -130,6 +130,15 @@ pub async fn discover_available_skills(
         .map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub fn load_cached_discoverable_skills(
+    service: State<'_, SkillServiceState>,
+    app_state: State<'_, AppState>,
+) -> Result<Vec<DiscoverableSkill>, String> {
+    let repos = app_state.db.get_skill_repos().map_err(|e| e.to_string())?;
+    Ok(service.0.load_cached_discovery(&repos))
+}
+
 /// 检查 Skills 更新
 #[tauri::command]
 pub async fn check_skill_updates(
@@ -323,6 +332,9 @@ pub fn remove_skill_repo(
         .db
         .delete_skill_repo(&owner, &name)
         .map_err(|e| e.to_string())?;
+    if let Err(error) = SkillService::remove_discovery_cache(&owner, &name) {
+        log::warn!("删除仓库发现缓存失败 {owner}/{name}: {error}");
+    }
     Ok(true)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1470,6 +1470,7 @@ pub fn run() {
             commands::scan_unmanaged_skills,
             commands::import_skills_from_apps,
             commands::discover_available_skills,
+            commands::load_cached_discoverable_skills,
             commands::check_skill_updates,
             commands::update_skill,
             commands::migrate_skill_storage,

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -186,6 +186,19 @@ pub struct SkillUpdateInfo {
     pub remote_hash: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SkillDiscoveryCache {
+    #[serde(default)]
+    schema_version: u32,
+    configured_branch: String,
+    resolved_branch: String,
+    commit_sha: String,
+    skills: Vec<DiscoverableSkill>,
+}
+
+const DISCOVERY_CACHE_SCHEMA_VERSION: u32 = 1;
+
 /// Skill 存储位置迁移结果
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1913,6 +1926,208 @@ impl SkillService {
 
     // ========== 发现功能（保留原有逻辑）==========
 
+    fn discovery_cache_path_from(base: &Path, owner: &str, name: &str) -> PathBuf {
+        use sha2::{Digest, Sha256};
+
+        let mut hasher = Sha256::new();
+        hasher.update(owner.to_lowercase());
+        hasher.update(b"/");
+        hasher.update(name.to_lowercase());
+        base.join("skill-discovery-cache")
+            .join(format!("{:x}.json", hasher.finalize()))
+    }
+
+    fn remove_discovery_cache_from(base: &Path, owner: &str, name: &str) -> Result<()> {
+        match fs::remove_file(Self::discovery_cache_path_from(base, owner, name)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub fn remove_discovery_cache(owner: &str, name: &str) -> Result<()> {
+        Self::remove_discovery_cache_from(&get_app_config_dir(), owner, name)
+    }
+
+    fn load_discovery_cache_from(
+        base: &Path,
+        repo: &SkillRepo,
+    ) -> Result<Option<SkillDiscoveryCache>> {
+        let path = Self::discovery_cache_path_from(base, &repo.owner, &repo.name);
+        if !path.is_file() {
+            return Ok(None);
+        }
+        let cache: SkillDiscoveryCache = serde_json::from_slice(&fs::read(&path)?)?;
+        if cache.schema_version != DISCOVERY_CACHE_SCHEMA_VERSION {
+            Self::remove_discovery_cache_from(base, &repo.owner, &repo.name)?;
+            return Ok(None);
+        }
+        if cache.configured_branch != repo.branch {
+            return Ok(None);
+        }
+        Ok(Some(cache))
+    }
+
+    fn load_discovery_cache(repo: &SkillRepo) -> Result<Option<SkillDiscoveryCache>> {
+        Self::load_discovery_cache_from(&get_app_config_dir(), repo)
+    }
+
+    fn save_discovery_cache_to(
+        base: &Path,
+        repo: &SkillRepo,
+        cache: &SkillDiscoveryCache,
+    ) -> Result<()> {
+        let data = serde_json::to_vec(cache)?;
+        crate::config::atomic_write(
+            &Self::discovery_cache_path_from(base, &repo.owner, &repo.name),
+            &data,
+        )?;
+        Ok(())
+    }
+
+    fn save_discovery_cache(repo: &SkillRepo, cache: &SkillDiscoveryCache) -> Result<()> {
+        Self::save_discovery_cache_to(&get_app_config_dir(), repo, cache)
+    }
+
+    pub fn load_cached_discovery(&self, repos: &[SkillRepo]) -> Vec<DiscoverableSkill> {
+        let mut skills = Vec::new();
+        for repo in repos.iter().filter(|repo| repo.enabled) {
+            match Self::load_discovery_cache(repo) {
+                Ok(Some(cache)) => skills.extend(cache.skills),
+                Ok(None) => {}
+                Err(error) => {
+                    log::warn!("读取仓库发现缓存失败 {}/{}: {error}", repo.owner, repo.name)
+                }
+            }
+        }
+        Self::deduplicate_discoverable_skills(&mut skills);
+        skills.sort_by_key(|skill| skill.name.to_lowercase());
+        skills
+    }
+
+    fn candidate_repo_branches(configured_branch: &str) -> Vec<String> {
+        let configured = configured_branch.trim();
+        let mut branches = Vec::new();
+        if !configured.is_empty() && !configured.eq_ignore_ascii_case("HEAD") {
+            branches.push(configured.to_string());
+            if configured.eq_ignore_ascii_case("main") && configured != "main" {
+                branches.push("main".to_string());
+            } else if configured.eq_ignore_ascii_case("master") && configured != "master" {
+                branches.push("master".to_string());
+            }
+        }
+        for fallback in ["main", "master"] {
+            if !branches.iter().any(|branch| branch == fallback) {
+                branches.push(fallback.to_string());
+            }
+        }
+        branches
+    }
+
+    fn is_missing_commit_ref(status: u16, message: Option<&str>) -> bool {
+        status == 404
+            || (status == 422
+                && message.is_some_and(|message| message.starts_with("No commit found for SHA:")))
+    }
+
+    async fn fetch_repo_commit_sha(&self, repo: &SkillRepo) -> Result<(String, String)> {
+        Self::validate_repo_ref(&repo.owner, &repo.name, &repo.branch)?;
+
+        #[derive(Deserialize)]
+        struct CommitResponse {
+            sha: String,
+        }
+
+        #[derive(Deserialize)]
+        struct ErrorResponse {
+            message: String,
+        }
+
+        for branch in Self::candidate_repo_branches(&repo.branch) {
+            let mut url = url::Url::parse("https://api.github.com")?;
+            url.path_segments_mut()
+                .map_err(|_| anyhow!("无法构造 GitHub API 地址"))?
+                .extend([
+                    "repos",
+                    repo.owner.as_str(),
+                    repo.name.as_str(),
+                    "commits",
+                    branch.as_str(),
+                ]);
+            let response = crate::proxy::http_client::get()
+                .get(url)
+                .header("Accept", "application/vnd.github+json")
+                .header("User-Agent", "cc-switch")
+                .timeout(std::time::Duration::from_secs(15))
+                .send()
+                .await?;
+            if response.status().is_success() {
+                return Ok((response.json::<CommitResponse>().await?.sha, branch));
+            }
+            let status = response.status().as_u16();
+            let message = if status == 422 {
+                response
+                    .json::<ErrorResponse>()
+                    .await
+                    .ok()
+                    .map(|error| error.message)
+            } else {
+                None
+            };
+            if Self::is_missing_commit_ref(status, message.as_deref()) {
+                continue;
+            }
+            let status = status.to_string();
+            return Err(anyhow!(format_skill_error(
+                "DOWNLOAD_FAILED",
+                &[("status", &status)],
+                match status.as_str() {
+                    "403" => Some("http403"),
+                    "429" => Some("http429"),
+                    _ => Some("checkNetwork"),
+                },
+            )));
+        }
+        Err(anyhow!(format_skill_error(
+            "DOWNLOAD_FAILED",
+            &[("status", "404")],
+            Some("http404"),
+        )))
+    }
+
+    fn cached_or_error(
+        repo: &SkillRepo,
+        cache: Option<SkillDiscoveryCache>,
+        error: anyhow::Error,
+    ) -> Result<Vec<DiscoverableSkill>> {
+        if let Some(cache) = cache {
+            log::warn!(
+                "刷新仓库 {}/{} 失败，继续使用发现缓存: {error}",
+                repo.owner,
+                repo.name
+            );
+            Ok(cache.skills)
+        } else {
+            Err(error)
+        }
+    }
+
+    fn scan_downloaded_repo(
+        &self,
+        temp_guard: tempfile::TempDir,
+        repo: &SkillRepo,
+        resolved_branch: String,
+    ) -> Result<Vec<DiscoverableSkill>> {
+        let resolved_repo = SkillRepo {
+            branch: resolved_branch,
+            ..repo.clone()
+        };
+        let mut skills = Vec::new();
+        let temp_dir = temp_guard.path();
+        self.scan_dir_recursive(temp_dir, temp_dir, &resolved_repo, &mut skills)?;
+        Ok(skills)
+    }
+
     /// 列出所有可发现的技能（从仓库获取）
     pub async fn discover_available(
         &self,
@@ -2013,10 +2228,57 @@ impl SkillService {
 
     /// 从仓库获取技能列表
     async fn fetch_repo_skills(&self, repo: &SkillRepo) -> Result<Vec<DiscoverableSkill>> {
-        let (temp_guard, resolved_branch) =
-            timeout(std::time::Duration::from_secs(60), self.download_repo(repo))
-                .await
-                .map_err(|_| {
+        let cache = Self::load_discovery_cache(repo).unwrap_or_else(|error| {
+            log::warn!("读取仓库发现缓存失败 {}/{}: {error}", repo.owner, repo.name);
+            None
+        });
+        let (commit_sha, resolved_branch) = match self.fetch_repo_commit_sha(repo).await {
+            Ok(result) => result,
+            Err(error) if cache.is_some() => {
+                return Self::cached_or_error(repo, cache, error);
+            }
+            Err(error) => {
+                log::warn!(
+                    "查询仓库 commit SHA 失败，回退分支下载 {}/{}: {error}",
+                    repo.owner,
+                    repo.name
+                );
+                let (temp_dir, resolved_branch) =
+                    timeout(std::time::Duration::from_secs(60), self.download_repo(repo))
+                        .await
+                        .map_err(|_| {
+                            anyhow!(format_skill_error(
+                                "DOWNLOAD_TIMEOUT",
+                                &[
+                                    ("owner", &repo.owner),
+                                    ("name", &repo.name),
+                                    ("timeout", "60")
+                                ],
+                                Some("checkNetwork"),
+                            ))
+                        })??;
+                return self.scan_downloaded_repo(temp_dir, repo, resolved_branch);
+            }
+        };
+
+        if let Some(cache) = cache.as_ref().filter(|cache| {
+            cache.commit_sha == commit_sha && cache.resolved_branch == resolved_branch
+        }) {
+            return Ok(cache.skills.clone());
+        }
+
+        let temp_dir = match timeout(
+            std::time::Duration::from_secs(60),
+            self.download_repo_at_commit(repo, &commit_sha),
+        )
+        .await
+        {
+            Ok(Ok(path)) => path,
+            Ok(Err(error)) => return Self::cached_or_error(repo, cache, error),
+            Err(_) => {
+                return Self::cached_or_error(
+                    repo,
+                    cache,
                     anyhow!(format_skill_error(
                         "DOWNLOAD_TIMEOUT",
                         &[
@@ -2025,14 +2287,28 @@ impl SkillService {
                             ("timeout", "60")
                         ],
                         Some("checkNetwork"),
-                    ))
-                })??;
+                    )),
+                );
+            }
+        };
 
-        let mut skills = Vec::new();
-        let scan_dir = temp_guard.path();
-        let mut resolved_repo = repo.clone();
-        resolved_repo.branch = resolved_branch;
-        self.scan_dir_recursive(scan_dir, scan_dir, &resolved_repo, &mut skills)?;
+        let skills = match self.scan_downloaded_repo(temp_dir, repo, resolved_branch.clone()) {
+            Ok(skills) => skills,
+            Err(error) => return Self::cached_or_error(repo, cache, error),
+        };
+
+        if let Err(error) = Self::save_discovery_cache(
+            repo,
+            &SkillDiscoveryCache {
+                schema_version: DISCOVERY_CACHE_SCHEMA_VERSION,
+                configured_branch: repo.branch.clone(),
+                resolved_branch,
+                commit_sha,
+                skills: skills.clone(),
+            },
+        ) {
+            log::warn!("保存仓库发现缓存失败 {}/{}: {error}", repo.owner, repo.name);
+        }
 
         Ok(skills)
     }
@@ -2422,11 +2698,32 @@ impl SkillService {
         });
     }
 
-    /// 下载仓库
+    async fn download_repo_at_commit(
+        &self,
+        repo: &SkillRepo,
+        sha: &str,
+    ) -> Result<tempfile::TempDir> {
+        Self::validate_repo_ref(&repo.owner, &repo.name, &repo.branch)?;
+
+        let temp_dir = tempfile::tempdir()?;
+        let temp_path = temp_dir.path().to_path_buf();
+        let archive = format!("{sha}.zip");
+        let mut url = url::Url::parse("https://github.com")?;
+        url.path_segments_mut()
+            .map_err(|_| anyhow!("无法构造 GitHub archive 地址"))?
+            .extend([
+                repo.owner.as_str(),
+                repo.name.as_str(),
+                "archive",
+                archive.as_str(),
+            ]);
+        self.download_and_extract(url.as_str(), &temp_path).await?;
+        Ok(temp_dir)
+    }
+
+    /// 按分支下载仓库。
     ///
-    /// 这里是仓库坐标进入 URL 的**唯一收敛点**——`fetch_repo_skills`、`install`、
-    /// `check_updates`、`update_skill` 四条路径都经过它，而 `skill_repos` / `skills`
-    /// 两张表都会被同步导入的远端快照整表覆盖，入库校验管不住它们。所以主防线放这里。
+    /// 此入口与 `download_repo_at_commit` 都会在构造 URL 前校验仓库坐标。
     async fn download_repo(&self, repo: &SkillRepo) -> Result<(tempfile::TempDir, String)> {
         Self::validate_repo_ref(&repo.owner, &repo.name, &repo.branch)?;
 
@@ -2436,19 +2733,8 @@ impl SkillService {
         let temp_dir = tempfile::tempdir()?;
         let temp_path = temp_dir.path().to_path_buf();
 
-        let mut branches = Vec::new();
-        if !repo.branch.is_empty() && !repo.branch.eq_ignore_ascii_case("HEAD") {
-            branches.push(repo.branch.as_str());
-        }
-        if !branches.contains(&"main") {
-            branches.push("main");
-        }
-        if !branches.contains(&"master") {
-            branches.push("master");
-        }
-
         let mut last_error = None;
-        for branch in branches {
+        for branch in Self::candidate_repo_branches(&repo.branch) {
             let url = format!(
                 "https://github.com/{}/{}/archive/refs/heads/{}.zip",
                 repo.owner, repo.name, branch
@@ -2456,7 +2742,7 @@ impl SkillService {
             Self::assert_github_archive_url(&url, &repo.owner, &repo.name)?;
 
             match self.download_and_extract(&url, &temp_path).await {
-                Ok(_) => return Ok((temp_dir, branch.to_string())),
+                Ok(_) => return Ok((temp_dir, branch)),
                 Err(e) => {
                     // 每个分支各自重算预算，所以失败后必须把上一轮的残留清掉——
                     // 否则 N 个候选分支等于 N 倍的落盘量堆在同一个目录里。
@@ -4451,5 +4737,72 @@ mod tests {
             dest.join("SKILL.md").is_file(),
             "existing destination skill should be preserved"
         );
+    }
+
+    #[test]
+    fn discovery_cache_is_scoped_to_the_configured_branch() {
+        let temp = tempdir().expect("tempdir");
+        let repo = SkillRepo {
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+            branch: "main".to_string(),
+            enabled: true,
+        };
+        let cache = SkillDiscoveryCache {
+            schema_version: DISCOVERY_CACHE_SCHEMA_VERSION,
+            configured_branch: "main".to_string(),
+            resolved_branch: "master".to_string(),
+            commit_sha: "abc123".to_string(),
+            skills: Vec::new(),
+        };
+
+        SkillService::save_discovery_cache_to(temp.path(), &repo, &cache).expect("save cache");
+        assert!(SkillService::load_discovery_cache_from(temp.path(), &repo)
+            .expect("load cache")
+            .is_some());
+        for branch in ["dev", "Main"] {
+            assert!(SkillService::load_discovery_cache_from(
+                temp.path(),
+                &SkillRepo {
+                    branch: branch.to_string(),
+                    ..repo.clone()
+                },
+            )
+            .expect("load changed branch")
+            .is_none());
+        }
+
+        let cache_path =
+            SkillService::discovery_cache_path_from(temp.path(), &repo.owner, &repo.name);
+        let mut stale_cache = cache.clone();
+        stale_cache.schema_version = 0;
+        SkillService::save_discovery_cache_to(temp.path(), &repo, &stale_cache)
+            .expect("save stale cache");
+        assert!(SkillService::load_discovery_cache_from(temp.path(), &repo)
+            .expect("reject stale cache")
+            .is_none());
+        assert!(!cache_path.exists());
+
+        SkillService::save_discovery_cache_to(temp.path(), &repo, &cache).expect("save cache");
+        SkillService::remove_discovery_cache_from(temp.path(), &repo.owner, &repo.name)
+            .expect("remove cache");
+        assert!(!cache_path.exists());
+        assert_eq!(
+            SkillService::candidate_repo_branches("Main"),
+            vec!["Main", "main", "master"]
+        );
+    }
+
+    #[test]
+    fn missing_commit_ref_status_is_classified_precisely() {
+        assert!(SkillService::is_missing_commit_ref(404, None));
+        assert!(SkillService::is_missing_commit_ref(
+            422,
+            Some("No commit found for SHA: missing")
+        ));
+        assert!(!SkillService::is_missing_commit_ref(
+            422,
+            Some("Validation Failed")
+        ));
     }
 }

--- a/src/components/skills/SkillsPage.tsx
+++ b/src/components/skills/SkillsPage.tsx
@@ -85,6 +85,7 @@ export const getSkillsPageHeaderActions = (source: SkillsPageSource) =>
   );
 
 const SKILLSSH_PAGE_SIZE = 20;
+const REPO_SKILL_BATCH_SIZE = 48;
 
 /**
  * Skills 发现面板
@@ -99,6 +100,7 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
     const [filterStatus, setFilterStatus] = useState<
       "all" | "installed" | "uninstalled"
     >("all");
+    const [repoSkillLimit, setRepoSkillLimit] = useState(REPO_SKILL_BATCH_SIZE);
 
     // skills.sh 搜索状态
     const [searchSource, setSearchSource] = useState<SkillsPageSource>("repos");
@@ -120,7 +122,11 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
       refetch: refetchDiscoverable,
     } = useDiscoverableSkills();
     const { data: installedSkills } = useInstalledSkills();
-    const { data: repos = [], refetch: refetchRepos } = useSkillRepos();
+    const {
+      data: repos = [],
+      isLoading: loadingRepos,
+      refetch: refetchRepos,
+    } = useSkillRepos();
 
     // skills.sh 搜索
     const {
@@ -208,12 +214,13 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
 
     const loading =
       searchSource === "repos"
-        ? loadingDiscoverable || fetchingDiscoverable
+        ? (loadingDiscoverable || fetchingDiscoverable) &&
+          !discoverableSkills?.length
         : false;
 
     useImperativeHandle(ref, () => ({
       refresh: () => {
-        refetchDiscoverable();
+        refetchDiscoverable({ cancelRefetch: false });
         refetchRepos();
       },
       openRepoManager: () => setRepoManagerOpen(true),
@@ -283,7 +290,9 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
       try {
         await addRepoMutation.mutateAsync(repo);
         // Await discovery so we can report the real count
-        const { data: freshSkills } = await refetchDiscoverable();
+        const { data: freshSkills } = await refetchDiscoverable({
+          cancelRefetch: false,
+        });
         const count =
           freshSkills?.filter(
             (s) =>
@@ -349,6 +358,17 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
         return name.includes(query) || repo.includes(query);
       });
     }, [skills, searchQuery, filterRepo, filterStatus]);
+    const displayedRepoSkills = filteredSkills.slice(0, repoSkillLimit);
+
+    useEffect(() => {
+      if (loading || repoSkillLimit >= filteredSkills.length) return;
+      const frame = requestAnimationFrame(() =>
+        setRepoSkillLimit((current) =>
+          Math.min(current + REPO_SKILL_BATCH_SIZE, filteredSkills.length),
+        ),
+      );
+      return () => cancelAnimationFrame(frame);
+    }, [filteredSkills.length, loading, repoSkillLimit]);
 
     // 是否有更多 skills.sh 结果
     const hasMoreSkillsSh =
@@ -358,7 +378,10 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
 
     // 无仓库配置时默认切换到 skills.sh；仓库发现结果为空时仍保留仓库视图，方便手动刷新重试。
     const effectiveSource =
-      searchSource === "repos" && repos.length === 0 && !loading
+      searchSource === "repos" &&
+      repos.length === 0 &&
+      !loadingRepos &&
+      !loading
         ? "skillssh"
         : searchSource;
 
@@ -412,13 +435,22 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
                       type="text"
                       placeholder={t("skills.searchPlaceholder")}
                       value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
+                      onChange={(e) => {
+                        setRepoSkillLimit(REPO_SKILL_BATCH_SIZE);
+                        setSearchQuery(e.target.value);
+                      }}
                       className="pl-9 pr-3"
                     />
                   </div>
                   {/* 仓库筛选 */}
                   <div className="w-full md:w-56">
-                    <Select value={filterRepo} onValueChange={setFilterRepo}>
+                    <Select
+                      value={filterRepo}
+                      onValueChange={(value) => {
+                        setRepoSkillLimit(REPO_SKILL_BATCH_SIZE);
+                        setFilterRepo(value);
+                      }}
+                    >
                       <SelectTrigger className="bg-card border shadow-sm text-foreground">
                         <SelectValue
                           placeholder={t("skills.filter.repo")}
@@ -451,11 +483,12 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
                   <div className="w-full md:w-36">
                     <Select
                       value={filterStatus}
-                      onValueChange={(val) =>
+                      onValueChange={(val) => {
+                        setRepoSkillLimit(REPO_SKILL_BATCH_SIZE);
                         setFilterStatus(
                           val as "all" | "installed" | "uninstalled",
-                        )
-                      }
+                        );
+                      }}
                     >
                       <SelectTrigger className="bg-card border shadow-sm text-foreground">
                         <SelectValue
@@ -560,7 +593,7 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
                 </div>
               ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {filteredSkills.map((skill) => (
+                  {displayedRepoSkills.map((skill) => (
                     <SkillCard
                       key={skill.key}
                       skill={skill}

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -4,6 +4,7 @@ import {
   useQueryClient,
   keepPreviousData,
 } from "@tanstack/react-query";
+import { useEffect } from "react";
 import {
   skillsApi,
   type SkillBackupEntry,
@@ -54,9 +55,43 @@ export function useDeleteSkillBackup() {
  * 实现首次进入使用缓存，只有刷新时才重新获取
  */
 export function useDiscoverableSkills() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    let cancelled = false;
+    skillsApi
+      .loadCachedDiscoverable()
+      .then((skills) => {
+        if (
+          !cancelled &&
+          skills.length > 0 &&
+          !queryClient.getQueryData(["skills", "discoverable"])
+        ) {
+          queryClient.setQueryData(["skills", "discoverable"], skills);
+        }
+      })
+      .catch((error) =>
+        console.warn("Failed to load cached discoverable skills", error),
+      );
+    return () => {
+      cancelled = true;
+    };
+  }, [queryClient]);
+
   return useQuery({
     queryKey: ["skills", "discoverable"],
-    queryFn: () => skillsApi.discoverAvailable(),
+    queryFn: async () => {
+      const skills = await skillsApi.discoverAvailable();
+      const repos = await skillsApi.getRepos();
+      const enabledRepos = new Set(
+        repos
+          .filter((repo) => repo.enabled)
+          .map((repo) => `${repo.owner}/${repo.name}`.toLowerCase()),
+      );
+      return skills.filter((skill) =>
+        enabledRepos.has(`${skill.repoOwner}/${skill.repoName}`.toLowerCase()),
+      );
+    },
     staleTime: Infinity,
     placeholderData: keepPreviousData,
   });

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -196,6 +196,10 @@ export const skillsApi = {
     return await invoke("discover_available_skills");
   },
 
+  async loadCachedDiscoverable(): Promise<DiscoverableSkill[]> {
+    return await invoke("load_cached_discoverable_skills");
+  },
+
   /** 检查 Skills 更新 */
   async checkUpdates(): Promise<SkillUpdateInfo[]> {
     return await invoke("check_skill_updates");

--- a/tests/components/SkillsPageInstall.test.tsx
+++ b/tests/components/SkillsPageInstall.test.tsx
@@ -18,6 +18,7 @@ import type {
 const installMutateAsyncMock = vi.fn();
 let discoverableSkillsMock: DiscoverableSkill[] = [];
 let skillReposMock: SkillRepo[] = [];
+let skillReposLoadingMock = false;
 const refetchDiscoverableMock = vi.fn();
 
 // Stable cache so repeated renders see referentially-equal data.
@@ -75,6 +76,7 @@ vi.mock("@/hooks/useSkills", () => ({
   }),
   useSkillRepos: () => ({
     data: skillReposMock,
+    isLoading: skillReposLoadingMock,
     refetch: vi.fn(),
   }),
   useAddSkillRepo: () => ({
@@ -132,6 +134,7 @@ describe("SkillsPage - skills.sh install (regression)", () => {
     installMutateAsyncMock.mockResolvedValue({});
     discoverableSkillsMock = [];
     skillReposMock = [];
+    skillReposLoadingMock = false;
     refetchDiscoverableMock.mockReset();
     searchCache.clear();
   });
@@ -301,6 +304,17 @@ describe("SkillsPage - skills.sh install (regression)", () => {
     ).toBeVisible();
   });
 
+  it("keeps cached repository results while repositories are loading", async () => {
+    discoverableSkillsMock = [makeDiscoverableSkill()];
+    skillReposLoadingMock = true;
+    const onSourceChange = vi.fn();
+
+    render(<SkillsPage initialApp="claude" onSourceChange={onSourceChange} />);
+
+    expect(screen.getByText("Repo Skill")).toBeInTheDocument();
+    await waitFor(() => expect(onSourceChange).toHaveBeenCalledWith("repos"));
+  });
+
   it("can switch back to repository results after discoverable skills refresh", async () => {
     const onSourceChange = vi.fn();
     const user = userEvent.setup();
@@ -335,5 +349,23 @@ describe("SkillsPage - skills.sh install (regression)", () => {
     expect(
       getSkillsPageHeaderActions("skillssh").map((action) => action.key),
     ).toEqual(["manage-repos"]);
+  });
+
+  it("renders large cached repository results in batches", async () => {
+    skillReposMock = [makeSkillRepo()];
+    discoverableSkillsMock = Array.from({ length: 60 }, (_, index) =>
+      makeDiscoverableSkill({
+        key: `skill-${index}:owner-a:repo-a`,
+        name: `Skill ${index}`,
+        directory: `skill-${index}`,
+      }),
+    );
+
+    render(<SkillsPage initialApp="claude" />);
+
+    expect(screen.getAllByText(/^Skill \d+$/)).toHaveLength(48);
+    await waitFor(() =>
+      expect(screen.getAllByText(/^Skill \d+$/)).toHaveLength(60),
+    );
   });
 });

--- a/tests/hooks/useDiscoverableSkills.test.tsx
+++ b/tests/hooks/useDiscoverableSkills.test.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { useDiscoverableSkills } from "@/hooks/useSkills";
+import type { DiscoverableSkill } from "@/lib/api/skills";
+
+const api = vi.hoisted(() => ({
+  loadCachedDiscoverable: vi.fn(),
+  discoverAvailable: vi.fn(),
+  getRepos: vi.fn(),
+}));
+
+vi.mock("@/lib/api/skills", () => ({ skillsApi: api }));
+
+const skill = (name: string): DiscoverableSkill => ({
+  key: `owner/repo:${name}`,
+  name,
+  description: name,
+  directory: name,
+  repoOwner: "owner",
+  repoName: "repo",
+  repoBranch: "main",
+});
+
+describe("useDiscoverableSkills", () => {
+  it("shows persisted results while the remote refresh is pending", async () => {
+    let resolveRemote!: (skills: DiscoverableSkill[]) => void;
+    api.loadCachedDiscoverable.mockResolvedValue([skill("cached")]);
+    api.discoverAvailable.mockReturnValue(
+      new Promise<DiscoverableSkill[]>((resolve) => {
+        resolveRemote = resolve;
+      }),
+    );
+    api.getRepos.mockResolvedValue([
+      { owner: "owner", name: "repo", branch: "main", enabled: true },
+    ]);
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useDiscoverableSkills(), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.[0].name).toBe("cached"));
+    resolveRemote([skill("fresh")]);
+    await waitFor(() => expect(result.current.data?.[0].name).toBe("fresh"));
+  });
+});


### PR DESCRIPTION
Fixes #3144  
Part of #4248

## Summary

修复应用重启后进入“发现技能”仍会重新下载所有启用仓库的问题：先展示上一次完整扫描成功的结果，再在后台校验远端 commit。

## Changes

- 持久化完整扫描成功的发现结果，缓存绑定 `owner/name + configured branch + resolved branch + commit SHA`，并使用原子写入。
- 后台先查询 GitHub commit SHA：未变化时直接复用缓存；变化后按该 commit 下载并重新扫描，避免分支在检查与下载之间变化。
- commit 查询、下载或扫描失败时继续使用已有缓存；首次无缓存且 SHA 查询失败时回退原有分支 ZIP 流程，不把未验证结果写入缓存。
- 远端查询先尝试配置分支；分支不存在时回退 `main/master`。对于 `Main/MASTER` 等默认分支大小写变体，会补试标准小写名称；缓存身份仍严格区分大小写。缓存文件名由仓库身份哈希生成，不信任外部路径。
- 页面启动读取持久缓存并继续后台刷新；同一轮发现请求不会因手动刷新或新增仓库后的再次 refetch 重复启动；迟到结果按当前启用仓库过滤，避免恢复已删除仓库。
- 默认仓库目前可产生 800+ 张卡片。缓存命中后先渲染 48 张，再按 animation frame 自动补齐；搜索和筛选始终使用完整结果，避免从其他页面切回时出现明显白屏。

## Screenshots

| Before | After |
|---|---|
| 重启后页面等待所有仓库重新下载。<br><img width="500" alt="discovery before restart downloads all" src="https://github.com/user-attachments/assets/87087e63-b983-467b-9945-22eab73936e4" /> | 缓存技能立即可见，同时后台校验仓库。<br><img width="500" alt="discovery after restart cache visible" src="https://github.com/user-attachments/assets/6b7d05ce-42c6-4623-8765-b5a0c94193cd" /> |

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `CI=true pnpm vitest run tests/components/SkillsPageInstall.test.tsx tests/hooks/useDiscoverableSkills.test.tsx`
- `CI=true pnpm typecheck`
- `CI=true pnpm format:check`
- `git diff --check`
