### PR TITLE
fix(skills): discover nested SKILL.md directories under skill parents

### DIFF
--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -1978,8 +1978,6 @@ impl SkillService {
             {
                 skills.push(skill);
             }
-
-            return Ok(());
         }
 
         for entry in fs::read_dir(current_dir)? {
@@ -1987,6 +1985,8 @@ impl SkillService {
             let path = entry.path();
 
             if path.is_dir() {
+                // 当前目录即使已经命中 SKILL.md，也仍需继续递归，
+                // 否则父 skill 会把其子目录中的嵌套 skill 截断掉。
                 self.scan_dir_recursive(&path, base_dir, repo, skills)?;
             }
         }
@@ -3102,6 +3102,43 @@ mod tests {
             .expect("install name should fall back to the matching discovered skill directory");
 
         assert_eq!(resolved, nested);
+    }
+
+    #[test]
+    fn scan_dir_recursive_discovers_parent_and_nested_child_skills() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path();
+        let child = root.join("child");
+        write_skill(root, "Root Skill");
+        write_skill(&child, "Child Skill");
+
+        let repo = SkillRepo {
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+            branch: "main".to_string(),
+            enabled: true,
+        };
+        let service = SkillService::new();
+        let mut skills = Vec::new();
+
+        service
+            .scan_dir_recursive(root, root, &repo, &mut skills)
+            .expect("scan should succeed");
+
+        skills.sort_by(|a, b| a.directory.cmp(&b.directory));
+
+        let discovered: Vec<(String, String)> = skills
+            .into_iter()
+            .map(|skill| (skill.directory, skill.name))
+            .collect();
+
+        assert_eq!(
+            discovered,
+            vec![
+                ("child".to_string(), "Child Skill".to_string()),
+                ("repo".to_string(), "Root Skill".to_string()),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

修复 GitHub skill 仓库的嵌套 skill discover 问题。

此前 `scan_dir_recursive` 在当前目录发现 `SKILL.md` 后会提前返回，不再继续扫描子目录，导致“父目录有 `SKILL.md`，子目录也有 `SKILL.md`”的场景下，子目录 skill 不会被识别。

本次修改保持当前目录 skill 的发现逻辑不变，但去掉提前返回，使其在记录当前 skill 后继续递归扫描子目录。同时补充了一条最小回归测试，覆盖父子目录同时包含 `SKILL.md` 时两个 skill 都应被 discover 的情况。

本 PR 有意保持最小范围：
- 只修改 `src-tauri/src/services/skill.rs`
- 只处理 nested skill discovery
- 不涉及 install / update / legacy 兼容 / source id 语义调整

## Related Issue / 关联 Issue

Fixes #4664

## Screenshots / 截图

本次修改为后端 discover 逻辑修复。修复后，技能数量可以正确反映父子目录中的嵌套 skill 发现结果。

### Before / 修改前

![Before](https://github.com/user-attachments/assets/01b90baf-7bb1-4508-95a7-f7c59a5c4400)

### After / 修改后

![After](https://github.com/user-attachments/assets/3bb4b3ac-d322-47d1-afe4-c7137039c092)

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件