### PR TITLE
fix(hermes): Windows 上 Hermes 供应商配置不生效

### DIFF
--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -1157,7 +1157,22 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
         std::env::set_var("CC_SWITCH_TEST_HOME", tmp.path());
+        // Neutralize the env vars get_hermes_dir() consults, so an ambient
+        // HERMES_HOME / LOCALAPPDATA (e.g. set by a Hermes install) can't make
+        // tests escape the temp home. Restored below.
+        let old_hermes_home = std::env::var_os("HERMES_HOME");
+        let old_local_appdata = std::env::var_os("LOCALAPPDATA");
+        std::env::remove_var("HERMES_HOME");
+        std::env::remove_var("LOCALAPPDATA");
         let result = test_fn();
+        match old_local_appdata {
+            Some(value) => std::env::set_var("LOCALAPPDATA", value),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
+        match old_hermes_home {
+            Some(value) => std::env::set_var("HERMES_HOME", value),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
         match old_test_home {
             Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
             None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
@@ -2367,6 +2382,43 @@ user_profile_enabled: false
         assert_eq!(
             windows_local_hermes_dir(Some(empty.as_os_str()), home),
             expected,
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn with_test_home_neutralizes_hermes_env_vars() {
+        // An ambient HERMES_HOME / LOCALAPPDATA (e.g. set by a Hermes install)
+        // must not leak into the test home — otherwise other tests in this
+        // module would read/write a real Hermes config via get_hermes_config_path().
+        let saved_hh = std::env::var_os("HERMES_HOME");
+        let saved_la = std::env::var_os("LOCALAPPDATA");
+        std::env::set_var("HERMES_HOME", "/ambient/hermes-home");
+        std::env::set_var("LOCALAPPDATA", "/ambient/local-appdata");
+
+        let inside = with_test_home(|| {
+            (
+                std::env::var_os("HERMES_HOME"),
+                std::env::var_os("LOCALAPPDATA"),
+            )
+        });
+
+        match saved_hh {
+            Some(v) => std::env::set_var("HERMES_HOME", v),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        match saved_la {
+            Some(v) => std::env::set_var("LOCALAPPDATA", v),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
+
+        assert_eq!(
+            inside.0, None,
+            "with_test_home must clear ambient HERMES_HOME"
+        );
+        assert_eq!(
+            inside.1, None,
+            "with_test_home must clear ambient LOCALAPPDATA"
         );
     }
 }

--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -83,10 +83,12 @@ fn default_hermes_dir() -> PathBuf {
 }
 
 /// Windows `%LOCALAPPDATA%\hermes` 路径计算(纯函数,便于跨平台单测)。
-/// `LOCALAPPDATA` 缺失或为空时回退 `<home>\AppData\Local\hermes`,与 Hermes 自身一致。
+/// 对齐 Hermes 的 `os.environ.get("LOCALAPPDATA", "").strip()`:trim 后为空
+/// (缺失/空/纯空白)则回退 `<home>\AppData\Local\hermes`。
 #[cfg(any(target_os = "windows", test))]
 fn windows_local_hermes_dir(localappdata: Option<&std::ffi::OsStr>, home: &Path) -> PathBuf {
     localappdata
+        .map(|value| value.to_string_lossy().trim().to_string())
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| home.join("AppData").join("Local"))
@@ -2382,6 +2384,24 @@ user_profile_enabled: false
         assert_eq!(
             windows_local_hermes_dir(Some(empty.as_os_str()), home),
             expected,
+        );
+    }
+
+    #[test]
+    fn windows_local_hermes_dir_trims_localappdata() {
+        // Mirror Hermes' `os.environ.get("LOCALAPPDATA", "").strip()`.
+        let home = Path::new("C:\\Users\\tester");
+        // Whitespace-only -> treated as unset, fall back to <home>\AppData\Local.
+        let blank = std::ffi::OsString::from("   ");
+        assert_eq!(
+            windows_local_hermes_dir(Some(blank.as_os_str()), home),
+            home.join("AppData").join("Local").join("hermes"),
+        );
+        // Padded value -> trimmed before use.
+        let padded = std::ffi::OsString::from("  C:\\Custom\\Local  ");
+        assert_eq!(
+            windows_local_hermes_dir(Some(padded.as_os_str()), home),
+            PathBuf::from("C:\\Custom\\Local").join("hermes"),
         );
     }
 

--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -46,14 +46,51 @@ use std::sync::{Mutex, OnceLock};
 
 /// 获取 Hermes 配置目录
 ///
-/// 默认路径: `~/.hermes/`
-/// 可通过 settings.hermes_config_dir 覆盖
+/// 解析顺序对齐 Hermes 自身的 `get_hermes_home()`:
+///   1. CCS 设置 `hermes_config_dir`(显式覆盖)
+///   2. `HERMES_HOME` 环境变量(trim 后非空;按原样,不展开 `~`,与 Hermes `Path(val)` 一致)
+///   3. 平台默认(Windows: `%LOCALAPPDATA%\hermes`,Mac/Linux: `~/.hermes`)
 pub fn get_hermes_dir() -> PathBuf {
     if let Some(override_dir) = get_hermes_override_dir() {
         return override_dir;
     }
 
+    if let Some(raw) = std::env::var_os("HERMES_HOME") {
+        let value = raw.to_string_lossy();
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+
+    default_hermes_dir()
+}
+
+/// 平台默认 Hermes 目录(Windows):对齐 Hermes `_get_platform_default_hermes_home()`——
+/// 读 `LOCALAPPDATA` 环境变量,缺失/空时回退 `~\AppData\Local`,再拼 `hermes`。
+#[cfg(target_os = "windows")]
+fn default_hermes_dir() -> PathBuf {
+    windows_local_hermes_dir(
+        std::env::var_os("LOCALAPPDATA").as_deref(),
+        &crate::config::get_home_dir(),
+    )
+}
+
+/// 平台默认 Hermes 目录(Mac/Linux):`~/.hermes`。
+#[cfg(not(target_os = "windows"))]
+fn default_hermes_dir() -> PathBuf {
     crate::config::get_home_dir().join(".hermes")
+}
+
+/// Windows `%LOCALAPPDATA%\hermes` 路径计算(纯函数,便于跨平台单测)。
+/// `LOCALAPPDATA` 缺失或为空时回退 `<home>\AppData\Local\hermes`,与 Hermes 自身一致。
+#[cfg(any(target_os = "windows", test))]
+fn windows_local_hermes_dir(localappdata: Option<&std::ffi::OsStr>, home: &Path) -> PathBuf {
+    localappdata
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join("AppData").join("Local"))
+        .join("hermes")
 }
 
 /// 获取 Hermes 配置文件路径
@@ -2192,5 +2229,144 @@ user_profile_enabled: false
         assert_eq!(memory, MemoryKind::Memory);
         assert_eq!(user, MemoryKind::User);
         assert!(serde_json::from_str::<MemoryKind>("\"bogus\"").is_err());
+    }
+
+    // ---- get_hermes_dir resolution (platform default + HERMES_HOME) ----
+
+    #[test]
+    #[serial]
+    fn hermes_home_env_takes_precedence_over_platform_default() {
+        with_test_home(|| {
+            // Clear any settings override so resolution reaches the HERMES_HOME branch.
+            let mut s = crate::settings::get_settings();
+            s.hermes_config_dir = None;
+            crate::settings::update_settings(s).unwrap();
+
+            let old = std::env::var_os("HERMES_HOME");
+            let custom = std::env::temp_dir().join("ccs-hermes-home-precedence");
+            std::env::set_var("HERMES_HOME", &custom);
+
+            let dir = get_hermes_dir();
+
+            match old {
+                Some(v) => std::env::set_var("HERMES_HOME", v),
+                None => std::env::remove_var("HERMES_HOME"),
+            }
+
+            assert_eq!(
+                dir, custom,
+                "HERMES_HOME should take precedence over the platform default, got {dir:?}"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn settings_override_takes_precedence_over_hermes_home() {
+        with_test_home(|| {
+            let custom = tempfile::tempdir().unwrap();
+            let custom_path = custom.path().to_path_buf();
+
+            let mut s = crate::settings::get_settings();
+            s.hermes_config_dir = Some(custom_path.to_string_lossy().to_string());
+            crate::settings::update_settings(s).unwrap();
+
+            let old = std::env::var_os("HERMES_HOME");
+            std::env::set_var("HERMES_HOME", "/tmp/should-be-ignored");
+
+            let dir = get_hermes_dir();
+
+            match old {
+                Some(v) => std::env::set_var("HERMES_HOME", v),
+                None => std::env::remove_var("HERMES_HOME"),
+            }
+            let mut s = crate::settings::get_settings();
+            s.hermes_config_dir = None;
+            crate::settings::update_settings(s).unwrap();
+
+            assert_eq!(
+                dir, custom_path,
+                "settings override should win over HERMES_HOME, got {dir:?}"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn blank_hermes_home_falls_through_to_platform_default() {
+        with_test_home(|| {
+            let mut s = crate::settings::get_settings();
+            s.hermes_config_dir = None;
+            crate::settings::update_settings(s).unwrap();
+
+            let old = std::env::var_os("HERMES_HOME");
+            std::env::set_var("HERMES_HOME", "   ");
+
+            let dir = get_hermes_dir();
+
+            match old {
+                Some(v) => std::env::set_var("HERMES_HOME", v),
+                None => std::env::remove_var("HERMES_HOME"),
+            }
+
+            // Blank HERMES_HOME is ignored (matches Hermes' `.strip()` non-empty check),
+            // so resolution must reach the platform default, never the literal blank path.
+            assert_ne!(dir, PathBuf::from("   "));
+            assert_eq!(dir, default_hermes_dir());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn default_hermes_dir_without_override_is_platform_correct() {
+        with_test_home(|| {
+            let mut s = crate::settings::get_settings();
+            s.hermes_config_dir = None;
+            crate::settings::update_settings(s).unwrap();
+
+            let old = std::env::var_os("HERMES_HOME");
+            std::env::remove_var("HERMES_HOME");
+
+            let dir = get_hermes_dir();
+
+            if let Some(v) = old {
+                std::env::set_var("HERMES_HOME", v);
+            }
+
+            #[cfg(target_os = "windows")]
+            assert!(
+                dir.ends_with("hermes") && dir.to_string_lossy().to_lowercase().contains("local"),
+                "Windows default should be %LOCALAPPDATA%\\hermes, got {dir:?}"
+            );
+            #[cfg(not(target_os = "windows"))]
+            assert!(
+                dir.ends_with(".hermes"),
+                "Unix default should be ~/.hermes, got {dir:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn windows_local_hermes_dir_uses_localappdata_when_set() {
+        let local = std::ffi::OsString::from("C:\\Users\\tester\\AppData\\Local");
+        let home = Path::new("C:\\Users\\tester");
+        // Uses LOCALAPPDATA (ignoring home) and appends `hermes`. Build the expected
+        // path with `join` so the separator matches the host OS.
+        assert_eq!(
+            windows_local_hermes_dir(Some(local.as_os_str()), home),
+            PathBuf::from(&local).join("hermes"),
+        );
+    }
+
+    #[test]
+    fn windows_local_hermes_dir_falls_back_to_home_when_localappdata_missing_or_empty() {
+        let home = Path::new("C:\\Users\\tester");
+        let expected = home.join("AppData").join("Local").join("hermes");
+        assert_eq!(windows_local_hermes_dir(None, home), expected);
+        let empty = std::ffi::OsString::from("");
+        assert_eq!(
+            windows_local_hermes_dir(Some(empty.as_os_str()), home),
+            expected,
+        );
     }
 }


### PR DESCRIPTION
## Summary / 概述

该 PR 修复 CC Switch 的 Hermes home/config directory 解析与 Hermes 自身行为不一致的问题。

Windows 上 Hermes 默认读取 `%LOCALAPPDATA%\hermes`，并且会优先读取非空 `HERMES_HOME`。此前 CC Switch 在未配置 `hermes_config_dir` override 时固定回落到 `~/.hermes`，导致 provider config、Hermes skills 等写入 CC Switch 认为的目录，但 Hermes 实际不会读取。

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| Windows 平台默认 Hermes home | CC Switch 默认使用 `~/.hermes` | 对齐 Hermes：默认使用 `%LOCALAPPDATA%\hermes`，缺失或为空时回退 `%USERPROFILE%\AppData\Local\hermes` |
| 用户或 Hermes 安装器设置了 `HERMES_HOME` | CC Switch 仍可能写入 `~/.hermes` | 在没有 CC Switch 显式 override 时，优先使用非空 `HERMES_HOME` |
| CC Switch 显式配置 `hermes_config_dir` | 作为覆盖路径 | 保持最高优先级，不改变现有用户配置 |
| Provider config / Hermes skills 等复用 `get_hermes_dir()` 的功能 | 可能写入 Hermes 不读取的位置 | 统一使用与 Hermes 一致的 home directory |
| macOS / Linux | Hermes 与 CC Switch 默认都使用 `~/.hermes` | 默认行为保持不变 |

## Root Cause / 根因

`get_hermes_dir()` 之前只处理 CC Switch 的 `settings.hermes_config_dir` override，否则直接返回 `~/.hermes`。

但 Hermes 自身的 [`get_hermes_home()`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_constants.py) 会按以下顺序解析 home directory：

1. in-process override；
2. 非空 `HERMES_HOME`；
3. 平台默认目录。

其中 Windows 平台默认目录来自 `LOCALAPPDATA`，不是 `~/.hermes`。因此在 Windows 上会出现：CC Switch 写入 `C:\Users\<user>\.hermes\config.yaml`，而 Hermes 实际读取 `C:\Users\<user>\AppData\Local\hermes\config.yaml`，表现为 CC Switch 中的 provider 编辑或 Hermes skills 同步不生效。

## Fix / 修复方式

`get_hermes_dir()` 现在按以下优先级解析：

1. `settings.hermes_config_dir`：CC Switch 显式 override，保持最高优先级；
2. `HERMES_HOME`：trim 后非空则使用，行为对齐 Hermes；
3. 平台默认目录：

| Platform | Default path |
| --- | --- |
| Windows | `%LOCALAPPDATA%\hermes`，缺失或为空时回退 `%USERPROFILE%\AppData\Local\hermes` |
| macOS / Linux | `~/.hermes` |

同时新增纯函数 `windows_local_hermes_dir()`，让 Windows `LOCALAPPDATA` 与 fallback 逻辑可以在非 Windows CI 上稳定覆盖。

两个实现选择是刻意保留的：

| 选择 | 原因 |
| --- | --- |
| 读取 `LOCALAPPDATA` 环境变量 | Hermes 自身读取的就是该环境变量；这样在 Known Folder 重定向或 launcher 覆盖环境变量时，CC Switch 与 Hermes 仍保持一致。 |
| 保留 `HERMES_HOME` | `HERMES_HOME` 是 Hermes 的一等 home directory 机制；忽略它会让 relocated / custom profile 安装重新写入错误目录。 |

## Relationship to #3470 / 与 #3470 的关系

#3470 也在修复 Windows 默认目录从 `~/.hermes` 到 `%LOCALAPPDATA%\hermes` 的问题。

本 PR 与 #3470 的主要差异：

| 差异 | 本 PR 的处理 |
| --- | --- |
| `HERMES_HOME` | 保留并按 Hermes 自身顺序优先于平台默认目录。Codex/Claude 没有同等语义的 home override，但 Hermes 有。 |
| Windows 默认目录来源 | 直接读取 `LOCALAPPDATA` 环境变量，而不是重新推导 Known Folder path，避免与 Hermes 实际读取值产生偏差。 |
| 测试覆盖 | 用纯函数覆盖 `LOCALAPPDATA` 存在、缺失、为空三类 Windows 路径分支，使该逻辑在非 Windows CI 上也能被测试。 |

## Related Issue / 关联 Issue

Fixes #3178
Fixes #3811
Related #3470

已检索 `HERMES_HOME`、`LOCALAPPDATA hermes`、`ccswitch hermes 模型` 等相关 issues。#2973 已由 #3267 处理；#4648 是 CN 版 Hermes `state.db` 路径探测问题，和本 PR 修复的 Hermes home/config/skills 目录解析不是同一范围。

## Screenshots / 截图

Real-machine verification on Windows. This PR only changes Rust-side path resolution (no UI changes); the screenshots below are end-to-end proof that the config now lands where Hermes actually reads it.

**Before — Hermes' model picker does not list the `baomiao-oneapi` provider.** CC Switch wrote `config.yaml` to `~/.hermes`, which Hermes on Windows never reads, so the provider configured in CC Switch was invisible to Hermes.

![Before: Hermes does not list the baomiao-oneapi provider](https://raw.githubusercontent.com/thisTom/cc-switch/pr-4680-assets/docs/pr-4680/hermes-win-before-fix.png)

**After — Hermes lists the `baomiao-oneapi` provider with its 4 models** (`deepseek-v4-flash`, `deepseek-v4-pro`, `kimi-k2.7`, `qwen3.7-plus`). CC Switch now writes to `%LOCALAPPDATA%\hermes`, where Hermes actually reads its config.

![After: Hermes lists the baomiao-oneapi provider and its 4 models](https://raw.githubusercontent.com/thisTom/cc-switch/pr-4680-assets/docs/pr-4680/hermes-win-after-fix.png)

> Windows 真机验证。本 PR 仅改 Rust 侧目录解析(无 UI 改动);上面两张图是端到端证据——修复前 Hermes 列表里没有 `baomiao-oneapi`(配置被写到 `~/.hermes`,Win 上 Hermes 不读);修复后写到 `%LOCALAPPDATA%\hermes`,Hermes 正常列出该供应商及其 4 个模型。

## Testing / 测试

新增/覆盖的关键测试：

- `hermes_home_env_takes_precedence_over_platform_default`
- `settings_override_takes_precedence_over_hermes_home`
- `blank_hermes_home_falls_through_to_platform_default`
- `default_hermes_dir_without_override_is_platform_correct`
- `windows_local_hermes_dir_uses_localappdata_when_set`
- `windows_local_hermes_dir_falls_back_to_home_when_localappdata_missing_or_empty`

| 检查项 | 结果 |
| --- | --- |
| `cargo fmt --check --manifest-path src-tauri/Cargo.toml` | 通过 |
| `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` | 通过 |
| `cargo test --manifest-path src-tauri/Cargo.toml` | 通过 |
| GitHub Actions / Backend Checks | 通过 |
| GitHub Actions / Frontend Checks | 通过，59 个测试文件 / 361 个测试 |

## Source References / 参考

- Hermes home resolution: https://github.com/NousResearch/hermes-agent/blob/main/hermes_constants.py
- Hermes config path usage: https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/config.py
- Hermes environment variables: https://github.com/NousResearch/hermes-agent/blob/main/website/docs/reference/environment-variables.md

## Out of Scope / 非本次范围

- 不做一次性迁移：已有 Windows 用户如果已经在 `~/.hermes/config.yaml` 中留下旧配置，升级后可能需要重新保存一次或手动迁移到 Hermes 实际 home directory。
- 不处理 CN 版 Hermes session database 的特殊路径探测；该问题属于 #4648。

## Checklist / 检查清单

- [x] 已搜索相关 open/closed issues，并只关联本 PR 实际覆盖的问题
- [x] 已补充 Hermes 目录解析优先级与 Windows fallback 的回归测试
- [x] PR 只包含上游仓库相关改动，无本地调试文件或内部上下文
- [x] 无 UI 变更，因此无需截图
- [x] GitHub Actions Backend / Frontend checks 均通过

