### PR TITLE
fix(codex): prefer provider bearer token in form

### DIFF
--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -11,20 +11,56 @@ import type { CodexCatalogModel } from "@/types";
 interface UseCodexConfigStateProps {
   initialData?: {
     settingsConfig?: Record<string, unknown>;
+    category?: string;
   };
 }
 
-// auth.json 缺 OPENAI_API_KEY 时回退到 config.toml 的 experimental_bearer_token
-// (Mobile 兼容形态：保留 ChatGPT 登录态但用第三方 token)
-function pickCodexApiKey(
+// 第三方 Codex 在保留官方登录态时，真实 provider token 会落在 config.toml 的
+// experimental_bearer_token；官方 provider 仍以 auth.json 为准。
+function codexAuthApiKey(
   authObj: { OPENAI_API_KEY?: unknown } | null | undefined,
-  configText: string,
 ): string {
   if (authObj && typeof authObj.OPENAI_API_KEY === "string") {
-    const key = authObj.OPENAI_API_KEY;
-    if (key) return key;
+    return authObj.OPENAI_API_KEY;
   }
-  return extractCodexExperimentalBearerToken(configText) || "";
+  return "";
+}
+
+function shouldPreferCodexBearerToken(
+  category: string | undefined,
+  bearerToken: string | undefined,
+): bearerToken is string {
+  return category !== "official" && !!bearerToken;
+}
+
+export function pickCodexApiKey(
+  authObj: { OPENAI_API_KEY?: unknown } | null | undefined,
+  configText: string,
+  category?: string,
+): string {
+  const bearerToken = extractCodexExperimentalBearerToken(configText);
+  if (shouldPreferCodexBearerToken(category, bearerToken)) {
+    return bearerToken;
+  }
+  return codexAuthApiKey(authObj) || bearerToken || "";
+}
+
+export function normalizeCodexAuthForSave(
+  authObj: Record<string, unknown>,
+  configText: string,
+  category?: string,
+): Record<string, unknown> {
+  const bearerToken = extractCodexExperimentalBearerToken(configText);
+  if (!shouldPreferCodexBearerToken(category, bearerToken)) {
+    return authObj;
+  }
+  if (authObj.OPENAI_API_KEY === bearerToken) {
+    return authObj;
+  }
+  return {
+    ...authObj,
+    OPENAI_API_KEY: bearerToken,
+  };
 }
 
 /**
@@ -50,7 +86,17 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
     const config = initialData.settingsConfig;
     if (typeof config === "object" && config !== null) {
       // 设置 auth.json
-      const auth = (config as any).auth || {};
+      const rawAuth = (config as any).auth || {};
+      const auth =
+        rawAuth && typeof rawAuth === "object" && !Array.isArray(rawAuth)
+          ? normalizeCodexAuthForSave(
+              rawAuth as Record<string, unknown>,
+              typeof (config as any).config === "string"
+                ? (config as any).config
+                : "",
+              initialData.category,
+            )
+          : {};
       setCodexAuthState(JSON.stringify(auth, null, 2));
 
       // 设置 config.toml
@@ -92,7 +138,7 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
         setCodexBaseUrl(initialBaseUrl);
       }
 
-      setCodexApiKey(pickCodexApiKey(auth, configStr));
+      setCodexApiKey(pickCodexApiKey(auth, configStr, initialData.category));
     }
   }, [initialData]);
 
@@ -123,9 +169,24 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
     } catch {
       parsed = null;
     }
-    const extractedKey = pickCodexApiKey(parsed, codexConfig);
+    const extractedKey = pickCodexApiKey(
+      parsed,
+      codexConfig,
+      initialData?.category,
+    );
     setCodexApiKey((prev) => (prev === extractedKey ? prev : extractedKey));
-  }, [codexAuth, codexConfig]);
+
+    if (parsed) {
+      const normalized = normalizeCodexAuthForSave(
+        parsed as Record<string, unknown>,
+        codexConfig,
+        initialData?.category,
+      );
+      if (normalized !== parsed) {
+        setCodexAuthState(JSON.stringify(normalized, null, 2));
+      }
+    }
+  }, [codexAuth, codexConfig, initialData?.category]);
 
   // 验证 Codex Auth JSON
   const validateCodexAuth = useCallback((value: string): string => {
@@ -222,7 +283,12 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       config: string,
       modelCatalogModels: CodexCatalogModel[] = [],
     ) => {
-      const authString = JSON.stringify(auth, null, 2);
+      const normalizedAuth = normalizeCodexAuthForSave(
+        auth,
+        config,
+        initialData?.category,
+      );
+      const authString = JSON.stringify(normalizedAuth, null, 2);
       setCodexAuth(authString);
       setCodexConfig(config);
       setCodexCatalogModels(modelCatalogModels);
@@ -230,9 +296,16 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       const baseUrl = extractCodexBaseUrl(config);
       setCodexBaseUrl(baseUrl || "");
 
-      setCodexApiKey(pickCodexApiKey(auth, config));
+      setCodexApiKey(
+        pickCodexApiKey(normalizedAuth, config, initialData?.category),
+      );
     },
-    [setCodexAuth, setCodexConfig, setCodexCatalogModels],
+    [
+      setCodexAuth,
+      setCodexConfig,
+      setCodexCatalogModels,
+      initialData?.category,
+    ],
   );
 
   return {

--- a/tests/hooks/useCodexConfigState.test.tsx
+++ b/tests/hooks/useCodexConfigState.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeCodexAuthForSave,
+  pickCodexApiKey,
+} from "@/components/providers/forms/hooks/useCodexConfigState";
+
+const codexConfigWithBearerToken = (token: string) =>
+  [
+    'model_provider = "thirdparty"',
+    "",
+    "[model_providers.thirdparty]",
+    'name = "Thirdparty"',
+    'base_url = "https://api.example.com/v1"',
+    `experimental_bearer_token = "${token}"`,
+    "",
+  ].join("\n");
+
+describe("useCodexConfigState", () => {
+  it("prefers the provider bearer token for third-party Codex configs", () => {
+    const config = codexConfigWithBearerToken("sk-provider-token");
+
+    expect(
+      pickCodexApiKey({ OPENAI_API_KEY: "sk-old-auth" }, config, "aggregator"),
+    ).toBe("sk-provider-token");
+
+    expect(
+      normalizeCodexAuthForSave(
+        { OPENAI_API_KEY: "sk-old-auth" },
+        config,
+        "aggregator",
+      ),
+    ).toEqual({
+      OPENAI_API_KEY: "sk-provider-token",
+    });
+  });
+
+  it("keeps auth.json as the source of truth for official Codex configs", () => {
+    const config = codexConfigWithBearerToken("sk-third-party-token");
+
+    expect(
+      pickCodexApiKey({ OPENAI_API_KEY: "sk-official-auth" }, config, "official"),
+    ).toBe("sk-official-auth");
+
+    expect(
+      normalizeCodexAuthForSave(
+        { OPENAI_API_KEY: "sk-official-auth" },
+        config,
+        "official",
+      ),
+    ).toEqual({
+      OPENAI_API_KEY: "sk-official-auth",
+    });
+  });
+
+  it("falls back to bearer token when auth is empty", () => {
+    const config = codexConfigWithBearerToken("sk-provider-token");
+
+    expect(pickCodexApiKey({}, config, "third_party")).toBe(
+      "sk-provider-token",
+    );
+  });
+});


### PR DESCRIPTION
## Summary / 概述

- Fix Codex provider form state when official-auth preservation leaves a stale `auth.json` `OPENAI_API_KEY` while the active third-party token is stored in `config.toml` as `experimental_bearer_token`.
- Third-party Codex configs now prefer the provider bearer token and normalize auth JSON before saving, so stale auth values are not written back over provider edits.
- Official Codex configs continue to use `auth.json` as the source of truth.
- Add regression tests for third-party bearer-token priority, official auth priority, and empty-auth fallback.

## Related Issue / 关联 Issue

Fixes #4108

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|  <img width="903" height="757" alt="pre" src="https://github.com/user-attachments/assets/1ebd7aab-27fe-46a4-8ebd-d4c0946171ba" /> |  <img width="1448" height="1044" alt="PixPin_2026-06-27_15-08-22" src="https://github.com/user-attachments/assets/6d4fd246-7e9d-4908-97de-744fd6e93f71" />  |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

## Test Notes / 测试说明

- Passed: `pnpm --config.allowBuilds.esbuild=true --config.allowBuilds.msw=true vitest run tests/hooks/useCodexConfigState.test.tsx tests/utils/providerConfigUtils.codex.test.ts --reporter=verbose` (26 tests).
- Passed: `pnpm --config.allowBuilds.esbuild=true --config.allowBuilds.msw=true typecheck`.
- Passed: `pnpm --config.allowBuilds.esbuild=true --config.allowBuilds.msw=true format:check`.
- Passed: `git diff --check HEAD^ HEAD`.
- `pnpm --config.allowBuilds.esbuild=true --config.allowBuilds.msw=true test:unit` currently fails in existing `tests/integration/App.test.tsx` coverage: `covers basic provider flows via real hooks` times out at 5000ms, and `shows toast when auto sync fails in background` sees duplicate `provider-list` DOM nodes after the prior timeout. The targeted Codex regression tests pass, and the failing integration file is unrelated to this form-state change.
- No Rust code or user-facing text changed, so cargo clippy and i18n updates are not applicable.