### PR TITLE
fix(tray): release WebView memory while running in tray

### DIFF
--- a/src-tauri/src/commands/deeplink.rs
+++ b/src-tauri/src/commands/deeplink.rs
@@ -3,7 +3,29 @@ use crate::deeplink::{
     import_skill_from_deeplink, parse_deeplink_url, DeepLinkImportRequest,
 };
 use crate::store::AppState;
+use std::sync::{Mutex, OnceLock};
 use tauri::State;
+
+fn pending_deeplink() -> &'static Mutex<Option<DeepLinkImportRequest>> {
+    static PENDING_DEEPLINK: OnceLock<Mutex<Option<DeepLinkImportRequest>>> = OnceLock::new();
+    PENDING_DEEPLINK.get_or_init(|| Mutex::new(None))
+}
+
+fn with_pending_deeplink<R>(f: impl FnOnce(&mut Option<DeepLinkImportRequest>) -> R) -> R {
+    let mut guard = pending_deeplink()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    f(&mut guard)
+}
+
+pub fn cache_pending_deeplink(request: DeepLinkImportRequest) {
+    with_pending_deeplink(|pending| *pending = Some(request));
+}
+
+#[tauri::command]
+pub fn take_pending_deeplink() -> Option<DeepLinkImportRequest> {
+    with_pending_deeplink(Option::take)
+}
 
 /// Parse a deep link URL and return the parsed request for frontend confirmation
 #[tauri::command]
@@ -85,5 +107,55 @@ pub async fn import_from_deeplink_unified(
             }))
         }
         _ => Err(format!("Unsupported resource type: {}", request.resource)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn sample_request(name: &str) -> DeepLinkImportRequest {
+        DeepLinkImportRequest {
+            version: "v1".to_string(),
+            resource: "provider".to_string(),
+            name: Some(name.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn take_pending_deeplink_consumes_cached_request() {
+        let _guard = test_guard();
+        let _ = take_pending_deeplink();
+        let request = sample_request("cached");
+
+        cache_pending_deeplink(request.clone());
+
+        let consumed = take_pending_deeplink().expect("pending deeplink should be cached");
+        assert_eq!(consumed.name.as_deref(), Some("cached"));
+        assert!(take_pending_deeplink().is_none());
+    }
+
+    #[test]
+    fn cache_pending_deeplink_keeps_latest_request() {
+        let _guard = test_guard();
+        let _ = take_pending_deeplink();
+        let first = sample_request("first");
+        let latest = sample_request("latest");
+
+        cache_pending_deeplink(first);
+        cache_pending_deeplink(latest.clone());
+
+        assert_eq!(
+            take_pending_deeplink().and_then(|request| request.name),
+            Some("latest".to_string())
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -284,14 +284,17 @@ pub fn run() {
 
                 if settings.minimize_to_tray_on_close {
                     api.prevent_close();
-                    let _ = window.hide();
-                    #[cfg(target_os = "windows")]
-                    {
-                        let _ = window.set_skip_taskbar(true);
-                    }
-                    #[cfg(target_os = "macos")]
-                    {
-                        tray::apply_tray_policy(window.app_handle(), false);
+                    if let Err(e) = crate::lightweight::enter_lightweight_mode(window.app_handle()) {
+                        log::error!("进入轻量模式失败，回退到隐藏窗口: {e}");
+                        let _ = window.hide();
+                        #[cfg(target_os = "windows")]
+                        {
+                            let _ = window.set_skip_taskbar(true);
+                        }
+                        #[cfg(target_os = "macos")]
+                        {
+                            tray::apply_tray_policy(window.app_handle(), false);
+                        }
                     }
                 } else {
                     api.prevent_close();
@@ -1156,13 +1159,16 @@ pub fn run() {
                 #[cfg(target_os = "linux")]
                 let _ = window.set_decorations(!settings.use_app_window_controls);
                 if settings.silent_startup {
-                    // 静默启动模式：保持窗口隐藏
-                    let _ = window.hide();
-                    #[cfg(target_os = "windows")]
-                    let _ = window.set_skip_taskbar(true);
-                    #[cfg(target_os = "macos")]
-                    tray::apply_tray_policy(app.handle(), false);
-                    log::info!("静默启动模式：主窗口已隐藏");
+                    if let Err(e) = crate::lightweight::enter_lightweight_mode(app.handle()) {
+                        log::error!("静默启动进入轻量模式失败，回退到隐藏窗口: {e}");
+                        let _ = window.hide();
+                        #[cfg(target_os = "windows")]
+                        let _ = window.set_skip_taskbar(true);
+                        #[cfg(target_os = "macos")]
+                        tray::apply_tray_policy(app.handle(), false);
+                    } else {
+                        log::info!("静默启动模式：主窗口已销毁，保留托盘后台");
+                    }
                 } else {
                     // 正常启动模式：显示窗口
                     let _ = window.show();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,6 +144,8 @@ fn handle_deeplink_url(
                 request.name
             );
 
+            crate::commands::cache_pending_deeplink(request.clone());
+
             if let Err(e) = app.emit("deeplink-import", &request) {
                 log::error!("✗ Failed to emit deeplink-import event: {e}");
             } else {
@@ -1313,6 +1315,7 @@ pub fn run() {
             // Deep link import
             commands::parse_deeplink,
             commands::merge_deeplink_config,
+            commands::take_pending_deeplink,
             commands::import_from_deeplink,
             commands::import_from_deeplink_unified,
             update_tray_menu,
@@ -1595,47 +1598,19 @@ pub fn run() {
 
                         if url_str.starts_with("ccswitch://") {
                             if crate::lightweight::is_lightweight_mode() {
-                                if let Err(e) = crate::lightweight::exit_lightweight_mode(app_handle)
+                                if let Err(e) =
+                                    crate::lightweight::exit_lightweight_mode(app_handle)
                                 {
                                     log::error!("退出轻量模式重建窗口失败: {e}");
                                 }
                             }
 
-                            // 解析并广播深链接事件，复用与 single_instance 相同的逻辑
-                            match crate::deeplink::parse_deeplink_url(&url_str) {
-                                Ok(request) => {
-                                    log::info!(
-                                        "Successfully parsed deep link from RunEvent::Opened: resource={}, app={:?}",
-                                        request.resource,
-                                        request.app
-                                    );
-
-                                    if let Err(e) =
-                                        app_handle.emit("deeplink-import", &request)
-                                    {
-                                        log::error!(
-                                            "Failed to emit deep link event from RunEvent::Opened: {e}"
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    log::error!(
-                                        "Failed to parse deep link URL from RunEvent::Opened: {e}"
-                                    );
-
-                                    if let Err(emit_err) = app_handle.emit(
-                                        "deeplink-error",
-                                        serde_json::json!({
-                                            "url": url_str,
-                                            "error": e.to_string()
-                                        }),
-                                    ) {
-                                        log::error!(
-                                            "Failed to emit deep link error event from RunEvent::Opened: {emit_err}"
-                                        );
-                                    }
-                                }
-                            }
+                            let _ = handle_deeplink_url(
+                                app_handle,
+                                &url_str,
+                                false,
+                                "RunEvent::Opened",
+                            );
 
                             // 确保主窗口可见
                             if let Some(window) = app_handle.get_webview_window("main") {

--- a/src/components/DeepLinkImportDialog.tsx
+++ b/src/components/DeepLinkImportDialog.tsx
@@ -49,45 +49,90 @@ export function DeepLinkImportDialog() {
   };
 
   useEffect(() => {
-    // Listen for deep link import events
-    const unlistenImport = listen<DeepLinkImportRequest>(
-      "deeplink-import",
-      async (event) => {
+    let disposed = false;
+    let unlistenImport: (() => void) | undefined;
+    let unlistenError: (() => void) | undefined;
+    const activeRequestKeys = new Set<string>();
+
+    const openImportDialog = async (incomingRequest: DeepLinkImportRequest) => {
+      const requestKey = JSON.stringify(incomingRequest);
+      if (activeRequestKeys.has(requestKey)) return;
+
+      activeRequestKeys.add(requestKey);
+      try {
+        let nextRequest = incomingRequest;
+
         // If config is present, merge it to get the complete configuration
-        if (event.payload.config || event.payload.configUrl) {
+        if (incomingRequest.config || incomingRequest.configUrl) {
           try {
-            const mergedRequest = await deeplinkApi.mergeDeeplinkConfig(
-              event.payload,
-            );
-            setRequest(mergedRequest);
+            nextRequest =
+              await deeplinkApi.mergeDeeplinkConfig(incomingRequest);
           } catch (error) {
             console.error("Failed to merge config:", error);
-            toast.error(t("deeplink.configMergeError"), {
-              description:
-                error instanceof Error ? error.message : String(error),
-            });
-            // Fall back to original request
-            setRequest(event.payload);
+            if (!disposed) {
+              toast.error(t("deeplink.configMergeError"), {
+                description:
+                  error instanceof Error ? error.message : String(error),
+              });
+            }
           }
-        } else {
-          setRequest(event.payload);
         }
 
+        if (disposed) return;
+        setRequest(nextRequest);
         setIsOpen(true);
-      },
-    );
+      } finally {
+        activeRequestKeys.delete(requestKey);
+      }
+    };
 
-    // Listen for deep link error events
-    const unlistenError = listen<DeeplinkError>("deeplink-error", (event) => {
-      console.error("Deep link error:", event.payload);
-      toast.error(t("deeplink.parseError"), {
-        description: event.payload.error,
-      });
+    const openPendingImportDialog = async () => {
+      const pendingRequest = await deeplinkApi.takePendingDeeplink();
+      if (pendingRequest) {
+        await openImportDialog(pendingRequest);
+      }
+    };
+
+    void (async () => {
+      const importOff = await listen<DeepLinkImportRequest>(
+        "deeplink-import",
+        () => {
+          void openPendingImportDialog().catch((error) => {
+            console.error("Failed to handle deep link import event:", error);
+          });
+        },
+      );
+      if (disposed) {
+        importOff();
+        return;
+      }
+      unlistenImport = importOff;
+
+      const errorOff = await listen<DeeplinkError>(
+        "deeplink-error",
+        (event) => {
+          if (disposed) return;
+          console.error("Deep link error:", event.payload);
+          toast.error(t("deeplink.parseError"), {
+            description: event.payload.error,
+          });
+        },
+      );
+      if (disposed) {
+        errorOff();
+        return;
+      }
+      unlistenError = errorOff;
+
+      await openPendingImportDialog();
+    })().catch((error) => {
+      console.error("Failed to subscribe deep link events:", error);
     });
 
     return () => {
-      unlistenImport.then((fn) => fn());
-      unlistenError.then((fn) => fn());
+      disposed = true;
+      unlistenImport?.();
+      unlistenError?.();
     };
   }, [t]);
 

--- a/src/lib/api/deeplink.ts
+++ b/src/lib/api/deeplink.ts
@@ -92,6 +92,14 @@ export const deeplinkApi = {
   },
 
   /**
+   * Take the last deep link request cached by Rust before the frontend was ready
+   * @returns A pending deep link request, or null when none exists
+   */
+  takePendingDeeplink: async (): Promise<DeepLinkImportRequest | null> => {
+    return invoke("take_pending_deeplink");
+  },
+
+  /**
    * Import a resource from a deep link request (unified handler)
    * @param request The deep link import request
    * @returns Import result based on resource type

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -44,6 +44,7 @@ export const handlers = [
   http.post(`${TAURI_ENDPOINT}/get_skills_migration_result`, () =>
     success(null),
   ),
+  http.post(`${TAURI_ENDPOINT}/take_pending_deeplink`, () => success(null)),
   http.post(`${TAURI_ENDPOINT}/get_providers`, async ({ request }) => {
     const { app } = await withJson<{ app: AppId }>(request);
     return success(getProviders(app));


### PR DESCRIPTION
## Summary / 概述

Fix the WebView renderer memory leak when cc-switch runs in the tray background.

`minimize_to_tray_on_close` and `silent_startup` previously hid the main window with `window.hide()`. That left the front-end WebView process alive, including React state, query caches, timers, DOM objects, and WebKit layer backing stores. Long-running background sessions kept accumulating memory until the app was restarted.

This PR changes both background paths to use the existing `enter_lightweight_mode()` flow. The main window is destroyed when entering tray background, which releases the WebView renderer process. Restoring from tray or dock uses the existing `exit_lightweight_mode()` path to rebuild the window with `WebviewWindowBuilder::from_config`. If entering lightweight mode fails, the code falls back to the original `hide()` behavior.

Measured before the fix: one long-running macOS instance reached about **1.8 GB RSS / 2.6 GB physical footprint after 17 days of uptime**, with about **2.0 GB concentrated in `WebKit Malloc`**.

Runtime verification with this patch:

| State | Main process | WebContent |
|---|---:|---:|
| After launch | 164 MB, pid 94053 | 213 MB, pid 94190 |
| After close to tray | 175 MB, same pid | 0, destroyed |
| After restore from tray | 181 MB, same pid | 220 MB, new pid 97833 |

Log evidence:

```text
[INFO][cc_switch_lib::lightweight] 进入轻量模式   # close to tray, window.destroy()
[INFO][cc_switch_lib::lightweight] 退出轻量模式   # restore via tray, rebuild
```

The main process stays alive throughout, so background services and the local proxy are preserved. The WebContent PID changes after restore, proving the old renderer was destroyed and a new one was created.

Trade-off: restoring from tray reloads the front-end once. That is the cost of releasing WebView memory while the app is idle in the tray.

## Related Issue / 关联 Issue

Fixes #4581

Related to #3787 and #3997.

## Screenshots / 截图

Activity Monitor screenshots showing the WebContent process present, gone after close-to-tray, and recreated after restore.

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| <img width="1792" height="1212" alt="image" src="https://github.com/user-attachments/assets/8144123b-d512-4329-951a-fbb3b1abf9ed" />| <img width="2174" height="1212" alt="image" src="https://github.com/user-attachments/assets/615da587-c89c-44a7-b83f-e205d50b7056" /><img width="2174" height="1212" alt="image" src="https://github.com/user-attachments/assets/61c4fe10-5b35-4caa-8a2c-d162c9292071" /><img width="2174" height="1212" alt="image" src="https://github.com/user-attachments/assets/72d442e0-43c6-4f69-baab-4f42918b10c9" />|

In dev mode the WebContent process appears as the `localhost:3000` URL it loads. In a release build it appears as `CC Switch Web Content`. The `cc-switch Graphics and Media` and `cc-switch Networking` entries are the GPU and networking helpers.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

Notes:

- Front-end verification: `./node_modules/.bin/tsc --noEmit`, `./node_modules/.bin/prettier --check "src/**/*.{js,jsx,ts,tsx,css,json}"`, and `./node_modules/.bin/vitest run` all passed locally.
- Rust verification: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all-targets` all passed locally.
- No user-facing UI text changed, so i18n files are unchanged.
