### PR TITLE
feat(settings): add MCP live sync toggle to disable automatic config writes

### DIFF
--- a/src-tauri/src/mcp/claude.rs
+++ b/src-tauri/src/mcp/claude.rs
@@ -9,6 +9,9 @@ use crate::error::AppError;
 use super::validation::{extract_server_spec, validate_server_spec};
 
 fn should_sync_claude_mcp() -> bool {
+    if !crate::settings::mcp_live_sync_enabled() {
+        return false;
+    }
     // Claude 未安装/未初始化时：通常 ~/.claude 目录与 ~/.claude.json 都不存在。
     // 按用户偏好：此时跳过写入/删除，不创建任何文件或目录。
     crate::config::get_claude_config_dir().exists() || crate::config::get_claude_mcp_path().exists()

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -14,6 +14,9 @@ use crate::error::AppError;
 use super::validation::{extract_server_spec, validate_server_spec};
 
 fn should_sync_codex_mcp() -> bool {
+    if !crate::settings::mcp_live_sync_enabled() {
+        return false;
+    }
     // Codex 未安装/未初始化时：~/.codex 目录不存在。
     // 按用户偏好：目录缺失时跳过写入/删除，不创建任何文件或目录。
     crate::codex_config::get_codex_config_dir().exists()

--- a/src-tauri/src/mcp/gemini.rs
+++ b/src-tauri/src/mcp/gemini.rs
@@ -9,6 +9,9 @@ use crate::error::AppError;
 use super::validation::{extract_server_spec, validate_server_spec};
 
 fn should_sync_gemini_mcp() -> bool {
+    if !crate::settings::mcp_live_sync_enabled() {
+        return false;
+    }
     // Gemini 未安装/未初始化时：~/.gemini 目录不存在。
     // 按用户偏好：目录缺失时跳过写入/删除，不创建任何文件或目录。
     crate::gemini_config::get_gemini_dir().exists()

--- a/src-tauri/src/mcp/hermes.rs
+++ b/src-tauri/src/mcp/hermes.rs
@@ -45,6 +45,9 @@ const HERMES_EXTRA_FIELDS: &[&str] = &[
 
 /// Check if Hermes MCP sync should proceed
 fn should_sync_hermes_mcp() -> bool {
+    if !crate::settings::mcp_live_sync_enabled() {
+        return false;
+    }
     hermes_config::get_hermes_dir().exists()
 }
 

--- a/src-tauri/src/mcp/opencode.rs
+++ b/src-tauri/src/mcp/opencode.rs
@@ -27,6 +27,9 @@ use super::validation::validate_server_spec;
 
 /// Check if OpenCode MCP sync should proceed
 fn should_sync_opencode_mcp() -> bool {
+    if !crate::settings::mcp_live_sync_enabled() {
+        return false;
+    }
     // Skip if OpenCode config directory doesn't exist
     opencode_config::get_opencode_dir().exists()
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -376,6 +376,9 @@ pub struct AppSettings {
     /// Opt-in: defaults to false so third-party switches cleanly overwrite auth.json.
     #[serde(default)]
     pub preserve_codex_official_auth_on_switch: bool,
+    /// 是否同步 MCP 服务到各工具 live 配置文件（默认 true）
+    #[serde(default = "default_true")]
+    pub mcp_live_sync_enabled: bool,
     /// Run official Codex providers under the shared "custom" model_provider id
     /// so official sessions share one resume-history bucket with third-party
     /// providers. Opt-in: defaults to false.
@@ -504,6 +507,7 @@ impl Default for AppSettings {
             stream_check_confirmed: None,
             enable_failover_toggle: false,
             preserve_codex_official_auth_on_switch: false,
+            mcp_live_sync_enabled: true,
             unify_codex_session_history: false,
             unify_codex_migrate_existing: None,
             failover_confirmed: None,
@@ -908,6 +912,16 @@ pub fn preserve_codex_official_auth_on_switch() -> bool {
             e.into_inner()
         })
         .preserve_codex_official_auth_on_switch
+}
+
+pub fn mcp_live_sync_enabled() -> bool {
+    settings_store()
+        .read()
+        .unwrap_or_else(|e| {
+            log::warn!("设置锁已毒化，使用恢复值: {e}");
+            e.into_inner()
+        })
+        .mcp_live_sync_enabled
 }
 
 pub fn unify_codex_session_history() -> bool {

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -1036,3 +1036,102 @@ fn sync_all_enabled_removes_known_disabled_but_preserves_unknown_live_entries() 
         "live entries unknown to DB should be preserved"
     );
 }
+
+#[test]
+fn sync_all_enabled_skips_when_mcp_live_sync_disabled() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    // Seed a Claude MCP config with an existing server
+    let mcp_path = get_claude_mcp_path();
+    if let Some(parent) = mcp_path.parent() {
+        fs::create_dir_all(parent).expect("create claude mcp dir");
+    }
+    let original_config = json!({
+        "mcpServers": {
+            "user-managed": {
+                "type": "stdio",
+                "command": "user-tool"
+            }
+        }
+    });
+    fs::write(
+        &mcp_path,
+        serde_json::to_string_pretty(&original_config).expect("serialize"),
+    )
+    .expect("seed claude mcp");
+
+    // Disable MCP live sync
+    update_settings(AppSettings {
+        mcp_live_sync_enabled: false,
+        ..Default::default()
+    })
+    .expect("disable mcp live sync");
+
+    let state = create_test_state().expect("create test state");
+
+    // Save a server that is enabled for Claude — normally this would be written to live config
+    state
+        .db
+        .save_mcp_server(&McpServer {
+            id: "db-server".to_string(),
+            name: "DB Server".to_string(),
+            server: json!({
+                "type": "stdio",
+                "command": "db-tool"
+            }),
+            apps: McpApps {
+                claude: true,
+                codex: false,
+                gemini: false,
+                opencode: false,
+                hermes: false,
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        })
+        .expect("save enabled server");
+
+    // Sync — should be a no-op because mcp_live_sync_enabled is false
+    McpService::sync_all_enabled(&state).expect("sync mcp");
+
+    // Verify: live config should be unchanged
+    let text = fs::read_to_string(&mcp_path).expect("read claude mcp");
+    let value: serde_json::Value = serde_json::from_str(&text).expect("parse claude mcp");
+    let servers = value
+        .get("mcpServers")
+        .and_then(|entry| entry.as_object())
+        .expect("mcpServers object");
+
+    assert!(
+        servers.contains_key("user-managed"),
+        "user-managed server should still be present"
+    );
+    assert!(
+        !servers.contains_key("db-server"),
+        "db-server should NOT have been written because mcp live sync is disabled"
+    );
+}
+
+#[test]
+fn settings_without_mcp_live_sync_field_defaults_to_true() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    // Simulate old settings JSON without the field
+    let old_settings_json = json!({
+        "show_in_tray": true,
+        "minimize_to_tray_on_close": true
+    });
+    let parsed: AppSettings =
+        serde_json::from_value(old_settings_json).expect("deserialize old settings");
+
+    assert!(
+        parsed.mcp_live_sync_enabled,
+        "missing mcp_live_sync_enabled should default to true"
+    );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -16,6 +16,7 @@ import {
   ScrollText,
   HardDriveDownload,
   FlaskConical,
+  RefreshCcwDot,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -52,6 +53,7 @@ import { UsageDashboard } from "@/components/usage/UsageDashboard";
 import { LogConfigPanel } from "@/components/settings/LogConfigPanel";
 import { AuthCenterPanel } from "@/components/settings/AuthCenterPanel";
 import { CodexAuthSettings } from "@/components/settings/CodexAuthSettings";
+import { ToggleRow } from "@/components/ui/toggle-row";
 import { useInstalledSkills } from "@/hooks/useSkills";
 import { useSettings } from "@/hooks/useSettings";
 import { useImportExport } from "@/hooks/useImportExport";
@@ -274,6 +276,27 @@ export function SettingsPage({
                         handleAutoSave({ skillSyncMethod: method })
                       }
                     />
+                    <section className="space-y-4">
+                      <div className="flex items-center gap-2 pb-2 border-b border-border/40">
+                        <RefreshCcwDot className="h-4 w-4 text-primary" />
+                        <h3 className="text-sm font-medium">
+                          {t("settings.mcpLiveSync")}
+                        </h3>
+                      </div>
+                      <div className="space-y-3">
+                        <ToggleRow
+                          icon={
+                            <RefreshCcwDot className="h-4 w-4 text-emerald-500" />
+                          }
+                          title={t("settings.mcpLiveSync")}
+                          description={t("settings.mcpLiveSyncDescription")}
+                          checked={settings.mcpLiveSyncEnabled ?? true}
+                          onCheckedChange={(value) =>
+                            handleAutoSave({ mcpLiveSyncEnabled: value })
+                          }
+                        />
+                      </div>
+                    </section>
                     <CodexAuthSettings
                       settings={settings}
                       onChange={handleAutoSave}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -682,6 +682,8 @@
     "enableClaudePluginIntegrationDescription": "When enabled, the VS Code Claude Code extension provider will switch with this app",
     "skipClaudeOnboarding": "Skip Claude Code first-run confirmation",
     "skipClaudeOnboardingDescription": "When enabled, Claude Code will skip the first-run confirmation",
+    "mcpLiveSync": "MCP Live Sync",
+    "mcpLiveSyncDescription": "Automatically sync MCP server definitions to live tool configs. Disable if you manage MCP servers manually or with another sync tool.",
     "codexAuth": "Codex App Enhancements",
     "preserveCodexOfficialAuthOnSwitch": "Keep official login when switching third-party providers",
     "preserveCodexOfficialAuthOnSwitchDescription": "When enabled, you can use the Codex app's official plugins, mobile remote control, and other features while using third-party APIs.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -682,6 +682,8 @@
     "enableClaudePluginIntegrationDescription": "オンにすると VS Code の Claude Code 拡張のプロバイダーも同期します",
     "skipClaudeOnboarding": "Claude Code の初回確認をスキップ",
     "skipClaudeOnboardingDescription": "オンにすると Claude Code の初回インストール確認をスキップします",
+    "mcpLiveSync": "MCP ライブ同期",
+    "mcpLiveSyncDescription": "MCPサーバー定義を各ツールの設定ファイルに自動同期します。MCPを手動で管理している場合、または別のツールで同期している場合はオフにしてください。",
     "codexAuth": "Codex アプリ拡張",
     "preserveCodexOfficialAuthOnSwitch": "サードパーティ切替時に公式ログインを保持",
     "preserveCodexOfficialAuthOnSwitchDescription": "オンにすると、サードパーティ API を使用する際に Codex アプリの公式プラグインやスマホからのリモート操作などの機能を利用できます。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -682,6 +682,8 @@
     "enableClaudePluginIntegrationDescription": "開啟後 VS Code Claude Code 外掛程式的供應商將隨本軟體切換",
     "skipClaudeOnboarding": "跳過 Claude Code 初次安裝確認",
     "skipClaudeOnboardingDescription": "開啟後跳過 Claude Code 初次安裝確認",
+    "mcpLiveSync": "MCP 即時同步",
+    "mcpLiveSyncDescription": "自動同步 MCP 服務到各工具設定檔。如果你手動管理 MCP 或使用其他工具同步，請關閉此項。",
     "codexAuth": "Codex 應用增強",
     "preserveCodexOfficialAuthOnSwitch": "切換第三方時保留官方登入",
     "preserveCodexOfficialAuthOnSwitchDescription": "開啟後可以在使用第三方 API 的時候使用 Codex 應用的官方外掛、手機遠端操作等功能",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -682,6 +682,8 @@
     "enableClaudePluginIntegrationDescription": "开启后 VS Code Claude Code 插件的供应商将随本软件切换",
     "skipClaudeOnboarding": "跳过 Claude Code 初次安装确认",
     "skipClaudeOnboardingDescription": "开启后跳过 Claude Code 初次安装确认",
+    "mcpLiveSync": "MCP 实时同步",
+    "mcpLiveSyncDescription": "自动同步 MCP 服务到各工具配置文件。如果你手动管理 MCP 或使用其他工具同步，请关闭此项。",
     "codexAuth": "Codex 应用增强",
     "preserveCodexOfficialAuthOnSwitch": "切换第三方时保留官方登录",
     "preserveCodexOfficialAuthOnSwitchDescription": "开启后可以在使用第三方 API 的时候使用 Codex 应用的官方插件、手机远程操作等功能",

--- a/src/types.ts
+++ b/src/types.ts
@@ -354,6 +354,8 @@ export interface Settings {
   streamCheckConfirmed?: boolean;
   // Whether to show the failover toggle independently on the main page
   enableFailoverToggle?: boolean;
+  // Whether to sync MCP server definitions to live tool config files (default true)
+  mcpLiveSyncEnabled?: boolean;
   // Preserve Codex ChatGPT login in auth.json when switching third-party providers
   preserveCodexOfficialAuthOnSwitch?: boolean;
   // Run official Codex under the shared "custom" provider id so future

--- a/tests/components/SettingsDialog.test.tsx
+++ b/tests/components/SettingsDialog.test.tsx
@@ -450,6 +450,33 @@ describe("SettingsPage Component", () => {
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
 
+  it("renders MCP live sync toggle with default checked when mcpLiveSyncEnabled omitted", async () => {
+    settingsMock = createSettingsMock({
+      settings: {
+        showInTray: true,
+        minimizeToTrayOnClose: true,
+        enableClaudePluginIntegration: false,
+        language: "zh",
+        claudeConfigDir: "/claude",
+        codexConfigDir: "/codex",
+      },
+    });
+    renderSettingsPage();
+
+    const labelMatches = screen.getAllByText("settings.mcpLiveSync");
+    expect(labelMatches.length).toBeGreaterThanOrEqual(2);
+
+    expect(
+      screen.getByText("settings.mcpLiveSyncDescription"),
+    ).toBeInTheDocument();
+
+    const toggle = screen.getByRole("switch", {
+      name: "settings.mcpLiveSync",
+    });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
   it("should trigger directory management callbacks inside advanced tab", () => {
     renderSettingsPage();
 


### PR DESCRIPTION
## Summary

Add a global `mcp_live_sync_enabled` setting (default: `true`) that controls whether CC Switch writes MCP server definitions to live tool config files.

**Problem:** Some users manage MCP configs manually or use another sync tool (e.g. a dedicated MCP manager). CC Switch currently overwrites their live configs on every provider switch / server toggle, causing conflicts.

**Solution:** A single toggle in **Settings → General → MCP Live Sync** that, when disabled:
- Stops all writes/deletes to Claude, Codex, Gemini, OpenCode, and Hermes live MCP config files
- Keeps CC Switch's own database management working normally (add/remove/enable/disable servers in UI)
- Leaves existing live configs completely untouched
- Does not affect import-from-tool (read-only direction)

## Changes

| Area | Files | What |
|------|-------|------|
| Backend setting | `settings.rs` | `mcp_live_sync_enabled: bool` with `#[serde(default = "default_true")]`, helper function |
| Backend guard | `mcp/{claude,codex,gemini,hermes,opencode}.rs` | Early return `false` in each `should_sync_*_mcp()` when disabled |
| Frontend type | `types.ts` | `mcpLiveSyncEnabled?: boolean` on `Settings` interface |
| Frontend UI | `SettingsPage.tsx` | `ToggleRow` in General tab, autosave on change |
| i18n | `{en,zh,zh-TW,ja}.json` | Label + description in all 4 locales |
| Backend tests | `mcp_commands.rs` | `sync_all_enabled` no-op test + serde default test |
| Frontend test | `SettingsDialog.test.tsx` | Render + default checked assertion |

**+188 lines across 14 files, 0 deletions from existing code.**

## Backward Compatibility

- Default is `true` → existing users see zero behavior change
- Old settings JSON without the field deserializes to `true` via serde default
- No migration needed

## Test Plan

- [x] `cargo test --test mcp_commands` — 20 passed
- [x] `vitest run` — 370 passed, 0 failed
- [x] Manual: toggle visible in Settings → General, default checked, toggling persists immediately