### PR TITLE
fix: normalize function parameters type to "object" for strict OpenAI-compatible providers

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1092,6 +1092,24 @@ fn serialize_tool_definition_for_description(tool: &Value) -> String {
     canonical_json_string(tool)
 }
 
+
+/// Normalize a function's `parameters` JSON Schema so `type` is always `"object"`.
+///
+/// Some Responses tools carry `parameters: null` or `parameters: {"type": null}`,
+/// but OpenAI Chat Completions strictly requires `{"type": "object", "properties": {...}}`.
+fn normalize_function_parameters(params: Option<&Value>) -> Value {
+    let mut params = params.cloned().unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+    if let Some(obj) = params.as_object_mut() {
+        match obj.get("type").and_then(|v| v.as_str()) {
+            Some("object") => {}
+            _ => {
+                obj.insert("type".to_string(), json!("object"));
+            }
+        }
+    }
+    params
+}
+
 fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option<Value> {
     if tool.get("type").and_then(|v| v.as_str()) != Some("function") {
         return None;
@@ -1106,6 +1124,14 @@ fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option
             .get_mut("function")
             .and_then(|value| value.as_object_mut())
         {
+            // Ensure parameters.type is "object" for strict OpenAI-compatible providers
+            if let Some(params) = obj.get("parameters") {
+                let normalized = normalize_function_parameters(Some(params));
+                if normalized != *params {
+                    obj.insert("parameters".to_string(), normalized);
+                }
+            }
+
             obj.insert("name".to_string(), json!(chat_name));
             if let Some(strict) = tool.get("strict").cloned() {
                 obj.entry("strict".to_string()).or_insert(strict);
@@ -1117,7 +1143,7 @@ fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option
     let mut function = json!({
         "name": chat_name,
         "description": tool.get("description").cloned().unwrap_or(Value::Null),
-        "parameters": tool.get("parameters").cloned().unwrap_or_else(|| json!({}))
+        "parameters": normalize_function_parameters(tool.get("parameters"))
     });
     if let Some(strict) = tool.get("strict") {
         function["strict"] = strict.clone();

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1097,9 +1097,10 @@ fn serialize_tool_definition_for_description(tool: &Value) -> String {
 /// Some Responses tools carry `parameters: null` or `parameters: {"type": null}`,
 /// but OpenAI Chat Completions strictly requires `{"type": "object", "properties": {...}}`.
 fn normalize_function_parameters(params: Option<&Value>) -> Value {
-    let mut params = params
-        .cloned()
-        .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+    let mut params = match params {
+        Some(Value::Object(obj)) => Value::Object(obj.clone()),
+        _ => json!({"type": "object", "properties": {}}),
+    };
     if let Some(obj) = params.as_object_mut() {
         match obj.get("type").and_then(|v| v.as_str()) {
             Some("object") => {}

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1092,13 +1092,14 @@ fn serialize_tool_definition_for_description(tool: &Value) -> String {
     canonical_json_string(tool)
 }
 
-
 /// Normalize a function's `parameters` JSON Schema so `type` is always `"object"`.
 ///
 /// Some Responses tools carry `parameters: null` or `parameters: {"type": null}`,
 /// but OpenAI Chat Completions strictly requires `{"type": "object", "properties": {...}}`.
 fn normalize_function_parameters(params: Option<&Value>) -> Value {
-    let mut params = params.cloned().unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+    let mut params = params
+        .cloned()
+        .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
     if let Some(obj) = params.as_object_mut() {
         match obj.get("type").and_then(|v| v.as_str()) {
             Some("object") => {}


### PR DESCRIPTION
# CC Switch `type:null` 修复分析

Closes #4705 

## 问题

Codex 通过 CC Switch 接入 DeepSeek（apiFormat: openai_chat）时，`codex_app__automation_update` 这个 tool 的 parameters schema `type: null` 导致 DeepSeek 返回 HTTP 400：

```
Invalid schema for function 'codex_app__automation_update': 
schema must be a JSON Schema of 'type: "object"', got 'type: null'.
```

## 根因定位

问题代码在 `src-tauri/src/proxy/providers/transform_codex_chat.rs` 的 `responses_function_tool_to_chat_tool` 函数中，约第 1120 行：

```rust
"parameters": tool.get("parameters").cloned().unwrap_or_else(|| json!({}))
```

两个场景都会出问题：

1. **parameters 完全缺失或为 null**：`unwrap_or_else` 回退到 `json!({})`，结果 `"parameters": {}`——缺少必须的 `"type": "object"`。

2. **parameters 为 `{"type": null}`**：`cloned()` 直接复制原始值，`type: null` 未被修正。

两种情况都被 DeepSeek（及其他严格校验的 OpenAI 兼容 provider）以 400 拒绝。

## 修复方案

将上述一行改为对 parameters 做规范化：缺失 type 时补充 `"type": "object"`。

```rust
"parameters": normalize_function_parameters(tool.get("parameters"))
```

新增 helper 函数（放在同文件的 `responses_function_tool_to_chat_tool` 之前）：

```rust
/// Normalize a function's `parameters` JSON Schema so `type` is always `"object"`.
///
/// Some Responses tools carry `parameters: null` or `parameters: {"type": null}`,
/// but OpenAI Chat Completions strictly requires `{"type": "object", "properties": {...}}`.
fn normalize_function_parameters(params: Option<&Value>) -> Value {
    let mut params = params.cloned().unwrap_or_else(|| json!({"type": "object", "properties": {}}));
    if let Some(obj) = params.as_object_mut() {
        // Ensure type is "object" — fix null/missing/incorrect type values
        match obj.get("type").and_then(|v| v.as_str()) {
            Some("object") => {}  // already correct
            _ => {
                obj.insert("type".to_string(), json!("object"));
            }
        }
    }
    params
}
```

**修改文件**：[transform_codex_chat.rs](/Users/ryanzhao/Documents/Codex/2026-06-27/w/cc-switch/src-tauri/src/proxy/providers/transform_codex_chat.rs)

**修改行**：约第 1120 行，将：
```rust
"parameters": tool.get("parameters").cloned().unwrap_or_else(|| json!({}))
```
改为：
```rust
"parameters": normalize_function_parameters(tool.get("parameters"))
```

## 影响范围

只影响无参数或 type 不正确的 function tool 的 parameters schema 规范化，不改变有正确 `"type": "object"` 的 tool。所有使用 `apiFormat: "openai_chat"` 的 Codex provider 都会受益。