### PR TITLE
fix(proxy): convert function_call_output image arrays to image_url instead of base64 text

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -586,6 +586,20 @@ fn append_responses_input_as_chat_messages(
     Ok(())
 }
 
+/// Whether a Responses content array carries any multimodal parts
+/// (image / file / audio). Used to decide whether a `function_call_output`
+/// array should be converted via the content transformer (so images become
+/// `image_url` blocks) or serialized as a canonical JSON string (the
+/// legacy behavior for plain string arrays like `["main.rs","lib.rs"]`).
+fn array_has_multimodal_parts(parts: &[Value]) -> bool {
+    parts.iter().any(|part| {
+        matches!(
+            part.get("type").and_then(|v| v.as_str()),
+            Some("input_image" | "input_file" | "input_audio" | "image" | "image_url")
+        )
+    })
+}
+
 fn append_responses_item_as_chat_message(
     item: &Value,
     messages: &mut Vec<Value>,
@@ -619,10 +633,23 @@ fn append_responses_item_as_chat_message(
                 last_assistant_index,
             );
             let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
-            let output = match item.get("output") {
-                Some(Value::String(s)) => canonicalize_json_string_if_parseable(s),
-                Some(v) => canonical_json_string(v),
-                None => String::new(),
+            // A function_call_output `output` may be a structured array
+            // carrying multimodal parts (e.g. Codex `view_image` returns
+            // `input_image`). Serializing such an array to a JSON string
+            // would inline the base64 data as plain text, inflating token
+            // usage ~9000x per image and tripping context-length 400s on
+            // vision-capable upstreams (#4465). When the array contains
+            // multimodal parts, route it through the shared content
+            // transformer so `input_image` becomes a proper `image_url`
+            // block; plain string arrays keep the canonical-JSON-string
+            // behavior for backwards compatibility.
+            let output: Value = match item.get("output") {
+                Some(Value::String(s)) => Value::String(canonicalize_json_string_if_parseable(s)),
+                Some(Value::Array(parts)) if array_has_multimodal_parts(parts) => {
+                    responses_content_to_chat_content("tool", item.get("output").unwrap_or(&Value::Null))
+                }
+                Some(v) => Value::String(canonical_json_string(v)),
+                None => Value::String(String::new()),
             };
             messages.push(json!({
                 "role": "tool",
@@ -1827,6 +1854,46 @@ mod tests {
         assert_eq!(content[1]["file"]["filename"], "spec.pdf");
         assert_eq!(content[2]["type"], "input_audio");
         assert_eq!(content[2]["input_audio"]["format"], "wav");
+    }
+
+    #[test]
+    fn function_call_output_with_image_array_becomes_image_url_not_text() {
+        // Regression test for #4465: a function_call_output whose `output`
+        // is a structured array carrying an `input_image` part must be
+        // converted to a proper `image_url` content block, not serialized
+        // to a base64-laden JSON string (which inflates token usage ~9000x).
+        let input = json!({
+            "model": "kimi-k2.7-code",
+            "input": [
+                {"type": "function_call", "name": "view_image", "arguments": "{}", "call_id": "c1"},
+                {"type": "function_call_output", "call_id": "c1", "output": [
+                    {"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="},
+                    {"type": "input_text", "text": "screenshot"}
+                ]},
+                {"role": "user", "content": [{"type": "input_text", "text": "what is it?"}]}
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        // The tool message must carry multimodal content (array), not a
+        // JSON-serialized string that inlines the base64 data.
+        let tool_msg = messages
+            .iter()
+            .find(|m| m["role"] == "tool")
+            .expect("tool message should exist");
+        let content = tool_msg["content"].as_array()
+            .expect("tool content should be a multimodal array, not a string");
+
+        let image_part = content
+            .iter()
+            .find(|p| p["type"] == "image_url")
+            .expect("an image_url block should be present");
+        assert_eq!(
+            image_part["image_url"]["url"],
+            "data:image/png;base64,iVBORw0KGgo="
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When a Codex Responses API request contains a `function_call_output` whose `output` is a structured array carrying multimodal parts (e.g. the built-in `view_image` tool returns an `input_image` part), the Responses→ChatCompletions translator serialized the entire array to a canonical JSON **string**.

This inlined the image base64 data as plain text, inflating token usage ~9000x per image and tripping context-length `400` errors (`Range of input length should be [1, 262144]`) on vision-capable upstreams like Kimi-K2.7-Code. The error looks unrelated to images because the upstream rejects on token count, not on content type.

Closes #4465

## Root cause

`append_responses_item_as_chat_message` in `transform_codex_chat.rs` handled `function_call_output` like this:

```rust
let output = match item.get("output") {
    Some(Value::String(s)) => canonicalize_json_string_if_parseable(s),
    Some(v) => canonical_json_string(v),   // ← arrays serialized to JSON string
    None => String::new(),
};
```

When `output` is an array like `[{"type":"input_image","image_url":"data:image/png;base64,..."}]`, `canonical_json_string` turns the whole thing (including the base64 payload) into a plain text string. The upstream tokenizer then counts every byte of base64 as text tokens.

Notably, top-level user `input_image` parts were already handled correctly by `responses_content_to_chat_content` — the bug only affected images nested inside `function_call_output.output`.

## Fix

When the `output` array contains multimodal parts (`input_image` / `input_file` / `input_audio` / `image` / `image_url`), route it through the existing `responses_content_to_chat_content` transformer so `input_image` parts become proper `image_url` blocks — the same path already used for top-level user content.

Plain string-array outputs (e.g. `["main.rs","lib.rs"]`) keep the original canonical-JSON-string behavior for backwards compatibility, guarded by a new `array_has_multimodal_parts` helper.

The downstream `media_sanitizer` already handles `image_url` blocks (`is_image_block_type` matches `image_url`), so text-only models still get images stripped as before — no change to that path.

## Verification

### Unit test
New regression test `function_call_output_with_image_array_becomes_image_url_not_text` verifies that a `function_call_output` with an `input_image` part produces a tool message whose `content` is a multimodal array containing an `image_url` block (not a base64 string).

All 53 existing `transform_codex_chat` tests still pass, including `responses_request_to_chat_keeps_multiple_tool_calls_adjacent_to_outputs` (which covers plain string-array outputs).

### End-to-end measurement (upstream: scnet / Kimi-K2.7-Code)

| | Before fix | After fix |
|---|---|---|
| `function_call_output` with 1080p image | HTTP 400 `Range of input length should be [1, 262144]` | HTTP 200, `prompt_tokens=47`, model describes image |
| Plain string array `["main.rs","lib.rs"]` | HTTP 200 (serialized as JSON string) | HTTP 200 (unchanged) |

`cargo clippy` — no new warnings on the changed file.

## Checklist

- [x] `cargo test --lib transform_codex_chat` passes (53/53)
- [x] `cargo clippy --lib` — no new warnings
- [x] Backwards compatible: plain string-array tool outputs unchanged
- [x] media_sanitizer path unaffected (text-only models still stripped)
