### PR TITLE
fix(sessions): adjust provider filter trigger spacing

### DIFF
--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -600,7 +600,7 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                         >
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <SelectTrigger className="size-7 p-0 justify-center border-0 bg-transparent hover:bg-muted">
+                              <SelectTrigger className="h-7 w-10 justify-center gap-0.5 border-0 bg-transparent px-1 py-0 shadow-none hover:bg-muted">
                                 <ProviderIcon
                                   icon={
                                     providerFilter === "all"


### PR DESCRIPTION
## Summary / 概述

- Adjust the Session Manager provider filter trigger from a square icon button footprint to a compact selector width.
- Preserve the chevron affordance while keeping the control height aligned with adjacent toolbar icon buttons.

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| ![Before](https://raw.githubusercontent.com/Wangnov/cc-switch/refs/heads/codex/pr-assets-session-provider-filter/screenshots/session-provider-filter-before.png) | ![After](https://raw.githubusercontent.com/Wangnov/cc-switch/refs/heads/codex/pr-assets-session-provider-filter/screenshots/session-provider-filter-after.png) |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] Rust code not changed; `cargo clippy` not required / 未修改 Rust 代码，无需运行 Clippy
- [x] User-facing text not changed; i18n updates not required / 未修改用户可见文本，无需更新国际化文件
