### PR TITLE
perf(sessions): virtualize session list

### DIFF
--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -34,7 +34,6 @@ import {
   SelectTrigger,
 } from "@/components/ui/select";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import {
   Tooltip,
@@ -76,6 +75,7 @@ export function SessionManagerPage({ appId }: { appId: string }) {
   const sessions = data ?? [];
   const detailRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const sessionListScrollRef = useRef<HTMLDivElement | null>(null);
   const [activeMessageIndex, setActiveMessageIndex] = useState<number | null>(
     null,
   );
@@ -146,6 +146,22 @@ export function SessionManagerPage({ appId }: { appId: string }) {
     overscan: 5,
     gap: 12,
   });
+
+  const sessionListVirtualizer = useVirtualizer({
+    count: filteredSessions.length,
+    getScrollElement: () => sessionListScrollRef.current,
+    estimateSize: () => (selectionMode ? 92 : 80),
+    getItemKey: (index) => getSessionKey(filteredSessions[index]),
+    overscan: 12,
+    gap: 4,
+    initialRect: { width: 320, height: 720 },
+  });
+
+  useEffect(() => {
+    if (sessionListScrollRef.current) {
+      sessionListScrollRef.current.scrollTop = 0;
+    }
+  }, [providerFilter, search]);
 
   useEffect(() => {
     if (scrollContainerRef.current) {
@@ -771,8 +787,11 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                 )}
               </CardHeader>
               <CardContent className="flex-1 min-h-0 p-0">
-                <ScrollArea className="h-full">
-                  <div className="p-2">
+                <div
+                  ref={sessionListScrollRef}
+                  className="h-full overflow-y-auto"
+                >
+                  <div className="p-2 min-w-0">
                     {isLoading ? (
                       <div className="flex items-center justify-center py-12">
                         <RefreshCw className="size-5 animate-spin text-muted-foreground" />
@@ -785,34 +804,49 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                         </p>
                       </div>
                     ) : (
-                      <div className="space-y-1">
-                        {filteredSessions.map((session) => {
+                      <div
+                        className="relative"
+                        style={{
+                          height: sessionListVirtualizer.getTotalSize(),
+                        }}
+                      >
+                        {sessionListVirtualizer.getVirtualItems().map((row) => {
+                          const session = filteredSessions[row.index];
                           const isSelected =
                             selectedKey !== null &&
                             getSessionKey(session) === selectedKey;
 
                           return (
-                            <SessionItem
-                              key={getSessionKey(session)}
-                              session={session}
-                              isSelected={isSelected}
-                              selectionMode={selectionMode}
-                              searchQuery={search}
-                              isChecked={selectedSessionKeys.has(
-                                getSessionKey(session),
-                              )}
-                              isCheckDisabled={!session.sourcePath}
-                              onSelect={setSelectedKey}
-                              onToggleChecked={(checked) =>
-                                toggleSessionChecked(session, checked)
-                              }
-                            />
+                            <div
+                              key={row.key}
+                              data-index={row.index}
+                              ref={sessionListVirtualizer.measureElement}
+                              className="absolute left-0 top-0 w-full"
+                              style={{
+                                transform: `translateY(${row.start}px)`,
+                              }}
+                            >
+                              <SessionItem
+                                session={session}
+                                isSelected={isSelected}
+                                selectionMode={selectionMode}
+                                searchQuery={search}
+                                isChecked={selectedSessionKeys.has(
+                                  getSessionKey(session),
+                                )}
+                                isCheckDisabled={!session.sourcePath}
+                                onSelect={setSelectedKey}
+                                onToggleChecked={(checked) =>
+                                  toggleSessionChecked(session, checked)
+                                }
+                              />
+                            </div>
                           );
                         })}
                       </div>
                     )}
                   </div>
-                </ScrollArea>
+                </div>
               </CardContent>
             </Card>
 

--- a/tests/components/SessionManagerPage.test.tsx
+++ b/tests/components/SessionManagerPage.test.tsx
@@ -330,4 +330,27 @@ describe("SessionManagerPage", () => {
     });
     invalidateSpy.mockRestore();
   });
+
+  it("virtualizes long session lists instead of rendering every row", async () => {
+    const sessions = Array.from({ length: 500 }, (_, index) => ({
+      providerId: "codex",
+      sessionId: `bulk-session-${index}`,
+      title: `Bulk Session ${index}`,
+      summary: `Bulk summary ${index}`,
+      projectDir: "/mock/codex",
+      createdAt: index,
+      lastActiveAt: index,
+      sourcePath: `/mock/codex/bulk-session-${index}.jsonl`,
+      resumeCommand: `codex resume bulk-session-${index}`,
+    })) satisfies SessionMeta[];
+
+    setSessionFixtures(sessions, {});
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("Bulk Session 499")).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByText("Bulk Session 0")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- Virtualize the Session Manager left-hand session list with `@tanstack/react-virtual` so large local histories no longer mount every row at once.
- Keep existing search, provider filter, selection mode, and delete flows intact.
- Add a regression test that confirms long lists render a window instead of every row.

## Demo

### Scrolling before

![Before: full session list renders many rows and scrolls poorly](https://github.com/Wangnov/cc-switch/releases/download/session-list-virtualization-demo-20260629/cc-switch-session-list-before.gif)

### Scrolling after

![After: virtualized session list scrolls smoothly](https://github.com/Wangnov/cc-switch/releases/download/session-list-virtualization-demo-20260629/cc-switch-session-list-after.gif)

## Resource usage

### Before

![Before resource usage: CPU 64.2%, memory 412.1 MB](https://github.com/Wangnov/cc-switch/releases/download/session-list-virtualization-demo-20260629/cc-switch-session-list-resource-before.png)

### After

![After resource usage: CPU 17.8%, memory 83.1 MB](https://github.com/Wangnov/cc-switch/releases/download/session-list-virtualization-demo-20260629/cc-switch-session-list-resource-after.png)

Local sample from a large session history:

- Before: CPU 64.2%, memory 412.1 MB.
- After: CPU 17.8%, memory 83.1 MB.

The original list mounted every filtered session row at once. With a 10k+ local history, that creates thousands of React components and DOM nodes, then forces the renderer to reconcile, lay out, paint, and keep the whole tree alive while opening or scrolling the manager. This PR keeps the underlying session collection unchanged, but virtualizes the left list so only the visible rows plus overscan are mounted. The DOM stays small even when the local history is large, which is why CPU and memory usage drop sharply. Disk I/O can vary between runs and cache state; this change mainly targets renderer work.

## Tests

```bash
./node_modules/.bin/vitest run tests/components/SessionManagerPage.test.tsx
./node_modules/.bin/tsc --noEmit
git diff --check
```
