### PR TITLE
fix(ui): 修复长下拉列表无法滚动的问题

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-[100] min-w-[8rem] overflow-hidden rounded-md border border-border-default bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-[100] max-h-[min(24rem,var(--radix-select-content-available-height))] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-border-default bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       position={position}

--- a/tests/components/SelectContentScroll.test.ts
+++ b/tests/components/SelectContentScroll.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SELECT_TSX = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "src",
+  "components",
+  "ui",
+  "select.tsx",
+);
+
+describe("SelectContent scroll bounds", () => {
+  const source = fs.readFileSync(SELECT_TSX, "utf8");
+
+  it("limits popper content to the available viewport height", () => {
+    expect(source).toContain("--radix-select-content-available-height");
+    expect(source).toContain(
+      "max-h-[min(24rem,var(--radix-select-content-available-height))]",
+    );
+  });
+
+  it("allows long option lists to scroll vertically", () => {
+    expect(source).toContain("overflow-y-auto");
+    expect(source).toContain("overflow-x-hidden");
+  });
+});


### PR DESCRIPTION
## Summary / 概述

本 PR 修复共享 Select 下拉弹层在选项较多时无法滚动的问题。

- 为 `SelectContent` 增加基于 Radix 可用视口高度的最大高度限制，避免长列表超出窗口可视区域
- 将下拉弹层从 `overflow-hidden` 调整为纵向可滚动、横向隐藏
- 补充回归测试，确保共享 Select 后续仍保留高度约束和滚动能力

## 问题原因

路由设置中的“选择供应商添加到队列”复用了共享 `SelectContent`。当供应商数量较多时，原组件没有最大高度限制，也没有纵向滚动能力，导致下拉列表超出窗口后无法继续选择下方供应商。由于 Radix Select 弹层打开后会优先接收滚轮事件，外部设置页面也无法继续滚动。

这不是路由队列单个页面的数据问题，而是共享 Select 组件缺少滚动边界导致的通用 UI 问题。

## Related Issue / 关联 Issue

暂无。

## Screenshots / 截图

问题截图：

![供应商较多时下拉列表超出窗口](https://raw.githubusercontent.com/xwil1/cc-switch/da3847598de824d1fa2b8b6a2ef4a172007aa5ac/select-dropdown-scroll.png)

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 未修改 Rust 代码，不适用
- [x] Updated i18n files if user-facing text changed / 未新增用户可见文本，不适用

## 验证

- `./node_modules/.bin/vitest.cmd run tests/components/SelectItemIndicator.test.ts tests/components/SelectContentScroll.test.ts`
- `./node_modules/.bin/tsc.cmd --noEmit`
- `./node_modules/.bin/vite.cmd build`
- `./node_modules/.bin/prettier.cmd --check "src/**/*.{js,jsx,ts,tsx,css,json}"`
