### PR TITLE
fix(macos): inject Homebrew paths into run_tool_lifecycle_silently to resolve 'env: node: No such file or directory'

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -214,9 +214,20 @@ fn run_tool_lifecycle_silently(command_line: &str, _label: &str) -> Result<(), S
     use std::process::Command;
     // command_line 是 bash 风格脚本（含 `set -e` 与多行命令）；强制用 bash 执行，
     // 避免用户默认 shell 为 fish/zsh 时 `set -e` 等语义不一致。
+
+    // GUI App 启动的进程 PATH 由 launchd 提供，macOS 上通常仅含
+    // /usr/bin:/bin:/usr/sbin:/sbin，缺少 Homebrew / nvm / mise 等用户级 bin 目录。
+    // npm / codex / node 等 CLI 的 #!/usr/bin/env node shebang 依赖 PATH 定位 node，
+    // 因此在 bash -c 之前注入常见用户 bin 路径，确保 env 可找到 node。
+    let path = std::env::var("PATH").unwrap_or_default();
+    let enhanced_path = format!(
+        "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:{}",
+        path
+    );
     let output = Command::new("bash")
         .arg("-c")
         .arg(command_line)
+        .env("PATH", &enhanced_path)
         .output()
         .map_err(|e| format!("启动安装进程失败: {e}"))?;
     finish_lifecycle_output(&output)


### PR DESCRIPTION
## Problem

On macOS, GUI applications launched from the Dock/Finder inherit a minimal PATH from `launchd`:

```
/usr/bin:/bin:/usr/sbin:/sbin
```

This PATH lacks Homebrew binary directories (`/opt/homebrew/bin`, `/opt/homebrew/sbin`) and `/usr/local/bin`. When the codex update feature invokes a tool lifecycle command via `bash -c`, any binary that uses the `#!/usr/bin/env node` shebang — such as `npm`, `node`, and `codex` themselves — fails because `env(1)` cannot locate `node` in the sparse PATH.

**Error reported:**
```
env: node: No such file or directory
```

## Root Cause

The `run_tool_lifecycle_silently` function spawns `bash -c` to execute the update command. While the anchored upgrade commands use absolute paths to sibling binaries (e.g., `/opt/homebrew/bin/npm i -g @openai/codex@latest`), those binaries themselves carry a `#!/usr/bin/env node` shebang line that relies on `PATH` resolution — and the GUI process barely has any PATH set.

## Fix

Prepend common user-level binary directories (`/opt/homebrew/bin`, `/opt/homebrew/sbin`, `/usr/local/bin`) to the `PATH` environment variable before spawning the `bash -c` subprocess. This ensures `env(1)` can find `node` regardless of the sparse PATH inherited from `launchd`.

## Verification

- Running ccswitch process under GUI has [`PATH=/usr/bin:/bin:/usr/sbin:/sbin`](https://github.com/user-attachments/files/…)
- `launchctl print gui/$(id -u)` confirms no PATH variable is set in the launchd environment
- With the fix applied, `/opt/homebrew/bin/node` is discoverable and the update proceeds successfully