### PR TITLE
feat(deeplink): support apiFormat param to set provider routing on import

### DIFF
--- a/docs/user-manual/en/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/en/5-faq/5.3-deeplink.md
@@ -53,6 +53,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `haikuModel` | No | Haiku model (Claude only) |
 | `sonnetModel` | No | Sonnet model (Claude only) |
 | `opusModel` | No | Opus model (Claude only) |
+| `apiFormat` | No | API format / local-route switch: `anthropic` / `openai_chat` / `openai_responses`. Any value other than `anthropic` makes the local proxy take over and convert the upstream protocol |
 | `notes` | No | Notes |
 | `icon` | No | Icon |
 | `config` | No | Base64-encoded configuration content |

--- a/docs/user-manual/ja/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/ja/5-faq/5.3-deeplink.md
@@ -53,6 +53,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `haikuModel` | いいえ | Haiku モデル（Claude のみ） |
 | `sonnetModel` | いいえ | Sonnet モデル（Claude のみ） |
 | `opusModel` | いいえ | Opus モデル（Claude のみ） |
+| `apiFormat` | いいえ | API フォーマット / ローカルルート切替：`anthropic` / `openai_chat` / `openai_responses`。`anthropic` 以外を指定するとローカルプロキシが上流プロトコルを変換します |
 | `notes` | いいえ | メモ |
 | `icon` | いいえ | アイコン |
 | `config` | いいえ | Base64 エンコードされた設定内容 |

--- a/docs/user-manual/zh/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/zh/5-faq/5.3-deeplink.md
@@ -53,6 +53,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `haikuModel` | 否 | Haiku 模型（仅 Claude） |
 | `sonnetModel` | 否 | Sonnet 模型（仅 Claude） |
 | `opusModel` | 否 | Opus 模型（仅 Claude） |
+| `apiFormat` | 否 | API 格式 / 本地路由开关：`anthropic` / `openai_chat` / `openai_responses`，非 `anthropic` 时由本地代理接管并转换上游协议 |
 | `notes` | 否 | 备注 |
 | `icon` | 否 | 图标 |
 | `config` | 否 | Base64 编码的配置内容 |

--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -78,6 +78,12 @@ pub struct DeepLinkImportRequest {
     /// Optional Opus model (Claude only, v3.7.1+)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub opus_model: Option<String>,
+    /// Optional API format / local-route switch (v3.16.5+)
+    /// One of: "anthropic" | "openai_chat" | "openai_responses".
+    /// Maps to `ProviderMeta.apiFormat`; any value other than "anthropic"
+    /// makes the local proxy take over and convert the upstream protocol.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_format: Option<String>,
 
     // ============ Prompt-specific fields ============
     /// Base64 encoded Markdown content

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -129,6 +129,22 @@ fn parse_provider_deeplink(
     let config_url = params.get("configUrl").cloned();
     let enabled = params.get("enabled").and_then(|v| v.parse::<bool>().ok());
 
+    // API format / local-route switch (v3.16.5+)
+    let api_format = params
+        .get("apiFormat")
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    if let Some(ref fmt) = api_format {
+        if !matches!(
+            fmt.as_str(),
+            "anthropic" | "openai_chat" | "openai_responses"
+        ) {
+            return Err(AppError::InvalidInput(format!(
+                "Invalid apiFormat: must be 'anthropic', 'openai_chat', or 'openai_responses', got '{fmt}'"
+            )));
+        }
+    }
+
     // Extract usage script fields (v3.9+)
     let usage_enabled = params
         .get("usageEnabled")
@@ -157,6 +173,7 @@ fn parse_provider_deeplink(
         haiku_model,
         sonnet_model,
         opus_model,
+        api_format,
         content: None,
         description: None,
         apps: None,
@@ -229,6 +246,7 @@ fn parse_prompt_deeplink(
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         apps: None,
         repo: None,
         directory: None,
@@ -295,6 +313,7 @@ fn parse_mcp_deeplink(
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         content: None,
         description: None,
         repo: None,
@@ -350,6 +369,7 @@ fn parse_skill_deeplink(
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         content: None,
         description: None,
         apps: None,

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -227,8 +227,25 @@ fn usage_base_url_override(request: &DeepLinkImportRequest) -> Option<String> {
     }
 }
 
-/// Build provider meta with usage script configuration
+/// Build provider meta with usage script and/or API format configuration
 fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<ProviderMeta>, AppError> {
+    let usage_script = build_usage_script(request)?;
+    let api_format = request.api_format.clone();
+
+    // Nothing to put in meta
+    if usage_script.is_none() && api_format.is_none() {
+        return Ok(None);
+    }
+
+    Ok(Some(ProviderMeta {
+        usage_script,
+        api_format,
+        ..Default::default()
+    }))
+}
+
+/// Build the usage query script from the deeplink request, if any usage field is set
+fn build_usage_script(request: &DeepLinkImportRequest) -> Result<Option<UsageScript>, AppError> {
     // Check if any usage script fields are provided
     if request.usage_script.is_none()
         && request.usage_enabled.is_none()
@@ -269,10 +286,7 @@ fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<Provide
         secret_access_key: None,
     };
 
-    Ok(Some(ProviderMeta {
-        usage_script: Some(usage_script),
-        ..Default::default()
-    }))
+    Ok(Some(usage_script))
 }
 
 /// Build Claude settings configuration

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -88,6 +88,47 @@ fn test_parse_deeplink_with_notes() {
 }
 
 #[test]
+fn test_parse_deeplink_with_api_format() {
+    let url = "ccswitch://v1/import?resource=provider&app=codex&name=DeepSeek&endpoint=https%3A%2F%2Fapi.deepseek.com&apiKey=key123&apiFormat=openai_chat";
+
+    let request = parse_deeplink_url(url).unwrap();
+
+    assert_eq!(request.api_format, Some("openai_chat".to_string()));
+}
+
+#[test]
+fn test_parse_deeplink_rejects_invalid_api_format() {
+    let url = "ccswitch://v1/import?resource=provider&app=codex&name=DeepSeek&endpoint=https%3A%2F%2Fapi.deepseek.com&apiKey=key123&apiFormat=bogus";
+
+    let result = parse_deeplink_url(url);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Invalid apiFormat"));
+}
+
+#[test]
+fn test_build_provider_sets_api_format_meta() {
+    use super::parser::parse_deeplink_url;
+    use super::provider::build_provider_from_request;
+    use crate::AppType;
+
+    let url = "ccswitch://v1/import?resource=provider&app=codex&name=DeepSeek&endpoint=https%3A%2F%2Fapi.deepseek.com&apiKey=key123&apiFormat=openai_chat";
+    let request = parse_deeplink_url(url).unwrap();
+
+    let provider = build_provider_from_request(&AppType::Codex, &request).unwrap();
+
+    assert_eq!(
+        provider
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.api_format.as_deref()),
+        Some("openai_chat")
+    );
+}
+
+#[test]
 fn test_parse_invalid_scheme() {
     let url = "https://v1/import?resource=provider&app=claude&name=Test";
 
@@ -179,6 +220,7 @@ fn test_build_gemini_provider_with_model() {
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: None,
         config_format: None,
         config_url: None,
@@ -232,6 +274,7 @@ fn test_build_gemini_provider_without_model() {
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: None,
         config_format: None,
         config_url: None,
@@ -278,6 +321,7 @@ fn test_deeplink_usage_script_does_not_copy_provider_credentials() {
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: None,
         config_format: None,
         config_url: None,
@@ -327,6 +371,7 @@ fn test_deeplink_usage_script_omits_explicit_credentials_that_match_provider() {
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: None,
         config_format: None,
         config_url: None,
@@ -375,6 +420,7 @@ fn test_deeplink_usage_script_preserves_distinct_usage_credentials() {
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: None,
         config_format: None,
         config_url: None,
@@ -428,6 +474,7 @@ fn test_parse_and_merge_config_claude() {
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: Some(config_b64),
         config_format: Some("json".to_string()),
         config_url: None,
@@ -519,6 +566,7 @@ fn test_parse_and_merge_config_url_override() {
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: Some(config_b64),
         config_format: Some("json".to_string()),
         config_url: None,
@@ -582,6 +630,7 @@ fn test_build_claude_provider_preserves_custom_env_fields() {
         haiku_model: Some("haiku-from-url".to_string()),
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: Some(config_b64),
         config_format: Some("json".to_string()),
         config_url: None,
@@ -637,6 +686,7 @@ fn test_build_claude_provider_without_config_unchanged() {
         haiku_model: None,
         sonnet_model: None,
         opus_model: None,
+        api_format: None,
         config: None,
         config_format: None,
         config_url: None,

--- a/src/components/DeepLinkImportDialog.tsx
+++ b/src/components/DeepLinkImportDialog.tsx
@@ -454,6 +454,16 @@ export function DeepLinkImportDialog() {
                           </div>
                         </div>
                       )}
+                      {request.apiFormat && (
+                        <div className="grid grid-cols-3 items-center gap-4">
+                          <div className="font-medium text-sm text-muted-foreground">
+                            {t("deeplink.apiFormat")}
+                          </div>
+                          <div className="col-span-2 text-sm font-mono">
+                            {request.apiFormat}
+                          </div>
+                        </div>
+                      )}
                       {request.model && (
                         <div className="grid grid-cols-3 items-center gap-4">
                           <div className="font-medium text-sm text-muted-foreground">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2288,6 +2288,7 @@
     "haikuModel": "Haiku Model",
     "sonnetModel": "Sonnet Model",
     "opusModel": "Opus Model",
+    "apiFormat": "API Format / Routing",
     "multiModel": "Multi-Modal Model",
     "notes": "Notes",
     "import": "Import",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2288,6 +2288,7 @@
     "haikuModel": "Haiku モデル",
     "sonnetModel": "Sonnet モデル",
     "opusModel": "Opus モデル",
+    "apiFormat": "API フォーマット / ルーティング",
     "multiModel": "マルチモーダルモデル",
     "notes": "メモ",
     "import": "インポート",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2260,6 +2260,7 @@
     "haikuModel": "Haiku 模型",
     "sonnetModel": "Sonnet 模型",
     "opusModel": "Opus 模型",
+    "apiFormat": "API 格式 / 路由",
     "multiModel": "多模態模型",
     "notes": "備註",
     "import": "匯入",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2288,6 +2288,7 @@
     "haikuModel": "Haiku 模型",
     "sonnetModel": "Sonnet 模型",
     "opusModel": "Opus 模型",
+    "apiFormat": "API 格式 / 路由",
     "multiModel": "多模态模型",
     "notes": "备注",
     "import": "导入",

--- a/src/lib/api/deeplink.ts
+++ b/src/lib/api/deeplink.ts
@@ -21,6 +21,7 @@ export interface DeepLinkImportRequest {
   haikuModel?: string;
   sonnetModel?: string;
   opusModel?: string;
+  apiFormat?: string;
 
   // Prompt fields
   content?: string;


### PR DESCRIPTION
## Summary

Deep link provider import 已经支持模型映射、用量查询脚本等字段，但唯独不能设置**本地路由开关**（`ProviderMeta.apiFormat`）。这导致导入 DeepSeek / Kimi / GLM 这类 Chat Completions 上游的供应商后，用户还得手动到表单里打开"需要本地路由映射"，一键导入并不完整。

本 PR 给 deeplink 增加一个可选 `apiFormat` 参数，导入时直接写入 `ProviderMeta.apiFormat`：

```
ccswitch://v1/import?resource=provider&app=codex&name=DeepSeek&endpoint=...&apiKey=...&apiFormat=openai_chat
```

## Changes

- **parser** (`deeplink/parser.rs`)：解析 `apiFormat`，校验取值 `anthropic` / `openai_chat` / `openai_responses`，非法值返回 `InvalidInput`
- **request model** (`deeplink/mod.rs`)：`DeepLinkImportRequest` 新增 `api_format` 字段
- **apply** (`deeplink/provider.rs`)：把 usage script 构建抽成 `build_usage_script`，`build_provider_meta` 现在在「有 usage 字段**或** apiFormat」时构建 meta 并写入 `api_format`
- **UI**：导入确认框展示该字段（`DeepLinkImportDialog.tsx` + 4 语言 i18n）
- **docs**：三语 deeplink 文档参数表补充 `apiFormat`
- **tests**：新增解析、非法值拒绝、meta 写入 3 个单测

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes（无新增告警）
- [x] `cargo test --lib deeplink::` passes（35 passed）
- [x] Updated i18n files（zh / en / ja / zh-TW）

## Notes

- 该参数对所有 app 类型通用，仅在提供时生效，默认行为不变（向后兼容）
- 与现有 `usageScript` 等参数风格保持一致，未引入新的编码方式

🤖 Generated with [Claude Code](https://claude.com/claude-code)