### PR TITLE
docs(guides): add codex-image-2013-error guide (en/zh/ja)

### DIFF
--- a/docs/guides/codex-image-2013-error-en.md
+++ b/docs/guides/codex-image-2013-error-en.md
@@ -117,3 +117,11 @@ path.
 - Workaround repo: https://github.com/Konsn666/codex-img-prep
 - End-to-end verification: 38.64 MB screenshot → 1.04 MB after the
   pipeline → CC Switch → MiniMax → 200 OK with correct vision answer.
+---
+
+## Chinese (简体中文) version
+
+A fully translated Chinese version of this guide is available at
+[Konsn666/codex-img-prep/blob/main/README.zh-CN.md](https://github.com/Konsn666/codex-img-prep/blob/main/README.zh-CN.md)
+along with the upstream bug report in Chinese at
+[ISSUE.zh-CN.md](https://github.com/Konsn666/codex-img-prep/blob/main/ISSUE.zh-CN.md).

--- a/docs/guides/codex-image-2013-error-en.md
+++ b/docs/guides/codex-image-2013-error-en.md
@@ -1,0 +1,119 @@
+# Misleading "context window exceeds limit (2013)" when attaching images > 10 MB to Codex
+
+> Applies to CC Switch v3.16.4 and earlier. Filed as upstream issue #4820.
+
+## What this guide solves
+
+Codex CLI users who route through CC Switch to MiniMax-family providers
+(`MiniMax-M3`, `MiniMax-M2.7`, etc.) sometimes see this error when they
+attach an image to a Codex conversation:
+
+```
+CC Switch local proxy failed while handling Codex endpoint /responses.
+Provider: MiniMax; model: MiniMax-M3;
+upstream_status: HTTP 400;
+cause: invalid params, context window exceeds limit (2013)
+```
+
+The error message says **"context window"**, which sends users down the
+wrong debugging path (clearing conversation history, switching to a
+model with a bigger context window). The real cause is different.
+
+## Root cause
+
+MiniMax API returns error code **2013** for multiple distinct failure
+modes. The upstream payload looks like one of:
+
+```json
+// Real context window overflow (200K tokens exceeded)
+{"error":{"message":"prompt is too long (2013)",
+          "code":"invalid_prompt"}}
+
+// Single image attachment > 10 MB
+{"error":{"message":"media exceeds size limit: max 10485760 bytes (2013)",
+          "code":"invalid_prompt"}}
+```
+
+CC Switch's upstream-error wrapper currently translates **every** `2013`
+into the human-readable string `"context window exceeds limit"`, with no
+distinction between the two cases. As a result, the user sees the same
+message regardless of whether their problem is context length or media
+size.
+
+Verified by direct `curl` against `https://api.minimaxi.com/v1/responses`:
+
+```bash
+$ curl .../v1/responses -d '{ "model": "MiniMax-M3",
+                              "input": [...large base64 image > 10 MB...] }'
+{"error":{"message":"media exceeds size limit: max 10485760 bytes (2013)",
+          "code":"invalid_prompt"}}
+```
+
+`MiniMax-M3` actually supports 200K+ tokens of context. A request that
+is small in tokens but big in image bytes will fail with `2013` /
+`media exceeds size limit`, not because of context.
+
+## How to identify which case you're in
+
+| Symptom | Likely cause |
+|---|---|
+| Long conversation history + image | Real context overflow (rare) |
+| Single image > 10 MB (Retina screenshot of a detail-rich page, PDF page) | Media size limit (common) |
+| Conversation has < 1K tokens + image fails | Almost certainly media size |
+
+The fastest way to confirm: `curl` the same payload directly against the
+upstream API (`api.minimaxi.com`) and read the `error.message` field
+verbatim.
+
+## Recommended upstream fix (proposed in issue #4820)
+
+1. When CC Switch receives a `2013` from a MiniMax-family provider,
+   forward the upstream `error.message` string to the Codex UI instead
+   of substituting a generic one. The message already says "media" vs
+   "prompt" — no translation is needed.
+2. Optionally, classify the upstream error in the same place and pick
+   from a small lookup table (`2013` + `"media"` → `"Image exceeds 10 MB
+   limit"`, `2013` + `"prompt"` → `"Conversation too long"`).
+
+This is a small change in the forwarder's error-mapping layer; no
+provider-side changes are needed.
+
+## Workaround for end users (today)
+
+Until the upstream fix ships, the
+[Konsn666/codex-img-prep](https://github.com/Konsn666/codex-img-prep)
+companion tool pre-processes images client-side so they always fit
+under MiniMax's 10 MB media cap. One-line install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Konsn666/codex-img-prep/main/install-remote.sh | bash
+```
+
+After install:
+
+- Screenshots copied to the clipboard are auto-resized within 2 seconds
+  (max 1920 px, JPEG q85, ≤ 8 MB).
+- Finder right-click any image → **Quick Actions → Compress for Codex**.
+- Shell aliases: `prep-clip`, `prep-img`, `prep-watch`.
+
+Additionally, switching the Codex provider's `meta.apiFormat` in
+`cc-switch.db` from `openai_chat` to `openai_responses` (also done by
+the installer) avoids a lossy `/responses → /chat/completions`
+translation in the forwarder and makes logs match the actual request
+path.
+
+## Environment
+
+- CC Switch: v3.16.4
+- Codex CLI: latest, `wire_api = "responses"`
+- MiniMax-M3 via `api.minimaxi.com`
+- macOS 15.4 (Apple Silicon) — the workaround is macOS-only because it
+  uses the built-in `sips` tool; Linux/Windows users would need to
+  swap `sips` for `ImageMagick` or similar.
+
+## Related
+
+- Upstream issue: https://github.com/farion1231/cc-switch/issues/4820
+- Workaround repo: https://github.com/Konsn666/codex-img-prep
+- End-to-end verification: 38.64 MB screenshot → 1.04 MB after the
+  pipeline → CC Switch → MiniMax → 200 OK with correct vision answer.

--- a/docs/guides/codex-image-2013-error-ja.md
+++ b/docs/guides/codex-image-2013-error-ja.md
@@ -1,0 +1,120 @@
+# Codex で 10MB を超える画像を添付すると "context window exceeds limit (2013)" という誤ったエラーが出る件
+
+> CC Switch v3.16.4 以前が対象。上流 issue #4820 で報告済み。
+
+## このガイドが解決する問題
+
+CC Switch 経由で Codex CLI を MiniMax 系プロバイダー
+(`MiniMax-M3`、`MiniMax-M2.7` など) にルーティングしているユーザーが、
+Codex の会話に画像を添付すると以下のエラーに遭遇することがあります:
+
+```
+CC Switch local proxy failed while handling Codex endpoint /responses.
+Provider: MiniMax; model: MiniMax-M3;
+upstream_status: HTTP 400;
+cause: invalid params, context window exceeds limit (2013)
+```
+
+エラーメッセージは **"context window"** と言っているため、
+ユーザーは会話履歴をクリアしたり、コンテキストウィンドウが大きいモデルに
+切り替えたりと、間違った調査パスに進んでしまいます。実際の原因は別です。
+
+## 根本原因
+
+MiniMax API は複数の異なる失敗モードに対して同じエラーコード **2013** を
+返します。アップストリームのペイロードは以下のいずれかです:
+
+```json
+// 本当のコンテキストウィンドウ超過 (200K トークン超過)
+{"error":{"message":"prompt is too long (2013)",
+          "code":"invalid_prompt"}}
+
+// 単一の画像添付が 10MB 超
+{"error":{"message":"media exceeds size limit: max 10485760 bytes (2013)",
+          "code":"invalid_prompt"}}
+```
+
+CC Switch のアップストリームエラーラッパーは現在、すべての `2013` を
+一律「context window exceeds limit」という人間向け文字列に翻訳しており、
+2 つのケースを区別していません。結果として、実際の問題がコンテキスト長
+なのかメディアサイズなのかに関わらず、ユーザーは同じメッセージを見ること
+になります。
+
+`https://api.minimaxi.com/v1/responses` への直接 `curl` で検証済み:
+
+```bash
+$ curl .../v1/responses -d '{ "model": "MiniMax-M3",
+                              "input": [...10MB を超える base64 画像...] }'
+{"error":{"message":"media exceeds size limit: max 10485760 bytes (2013)",
+          "code":"invalid_prompt"}}
+```
+
+`MiniMax-M3` は実際には 200K+ トークンのコンテキストをサポートしています。
+トークン数は少ないが画像バイト数が大きいリクエストは、コンテキストでは
+なく `2013` / `media exceeds size limit` で失敗します。
+
+## どちらのケースかを見分ける方法
+
+| 症状 | 推定原因 |
+|---|---|
+| 長い会話履歴 + 画像 | 本当のコンテキスト超過 (稀) |
+| 単一の 10MB 超画像 ( Retina スクショ、PDF ページなど) | メディアサイズ制限 (一般的) |
+| 会話が 1K トークン未満 + 画像で失敗 | ほぼ確実にメディアサイズ |
+
+最も速い確認方法: 同じペイロードを直接アップストリーム API
+(`api.minimaxi.com`) に `curl` し、`error.message` フィールドを
+そのまま読む。
+
+## 推奨されるアップストリーム修正 (issue #4820 で提案済み)
+
+1. CC Switch が MiniMax 系プロバイダーから `2013` を受信したとき、
+   アップストリームの `error.message` 文字列を Codex UI にそのまま転送する
+   (汎用文字列で置換しない)。アップストリームのメッセージにはすでに
+   "media" か "prompt" かが書かれているので、翻訳は不要。
+2. オプション: forwarder のエラーマッピング層でアップストリームエラーを
+   分類し、小さなルックアップテーブルから選ぶ
+   (`2013` + `"media"` → `"Image exceeds 10 MB limit"`、
+   `2013` + `"prompt"` → `"Conversation too long"`)。
+
+これは forwarder のエラーマッピング層の小さな変更で、プロバイダー側の
+変更は不要。
+
+## エンドユーザーの回避策 (当面)
+
+アップストリームの修正がリリースされるまで、
+[Konsn666/codex-img-prep](https://github.com/Konsn666/codex-img-prep)
+というコンパニオンツールで画像をクライアントサイド前処理し、
+MiniMax の 10MB メディア上限に常に収まるようにします。ワンライナー
+インストール:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Konsn666/codex-img-prep/main/install-remote.sh | bash
+```
+
+インストール後:
+
+- クリップボードにコピーしたスクリーンショットは 2 秒以内に自動リサイズ
+  (最大 1920px、JPEG q85、≤ 8MB)。
+- Finder で画像を右クリック → **Quick Actions → Compress for Codex**。
+- シェルエイリアス: `prep-clip`、`prep-img`、`prep-watch`。
+
+さらに installer は Codex プロバイダーの `meta.apiFormat` を
+`openai_chat` から `openai_responses` に変更し、forwarder での
+lossy な `/responses → /chat/completions` 変換を避け、ログと
+実際のリクエストパスを一致させます。
+
+## 環境
+
+- CC Switch: v3.16.4
+- Codex CLI: 最新、`wire_api = "responses"`
+- MiniMax-M3 via `api.minimaxi.com`
+- macOS 15.4 (Apple Silicon) — 回避策は組み込みの `sips` ツールを
+  使用するため macOS のみ。Linux/Windows ユーザーは `sips` を
+  ImageMagick などに置き換える必要があります。
+
+## 関連
+
+- アップストリーム issue: https://github.com/farion1231/cc-switch/issues/4820
+- 回避策リポジトリ: https://github.com/Konsn666/codex-img-prep
+- エンドツーエンド検証: 38.64MB スクリーンショット → パイプライン後
+  1.04MB → CC Switch → MiniMax → 200 OK (視覚認識正解)。

--- a/docs/guides/codex-image-2013-error-ja.md
+++ b/docs/guides/codex-image-2013-error-ja.md
@@ -118,3 +118,9 @@ lossy な `/responses → /chat/completions` 変換を避け、ログと
 - 回避策リポジトリ: https://github.com/Konsn666/codex-img-prep
 - エンドツーエンド検証: 38.64MB スクリーンショット → パイプライン後
   1.04MB → CC Switch → MiniMax → 200 OK (視覚認識正解)。
+---
+
+## 中国語版 / 中文版
+
+このガイドの中国語訳は [Konsn666/codex-img-prep/blob/main/README.zh-CN.md](https://github.com/Konsn666/codex-img-prep/blob/main/README.zh-CN.md)、
+アップストリームの中国語バグレポートは [ISSUE.zh-CN.md](https://github.com/Konsn666/codex-img-prep/blob/main/ISSUE.zh-CN.md) で参照できます。

--- a/docs/guides/codex-image-2013-error-zh.md
+++ b/docs/guides/codex-image-2013-error-zh.md
@@ -1,0 +1,93 @@
+# Codex attach 图片报 2013 误报 "context window exceeds limit" 的来龙去脉
+
+> 适用 CC Switch v3.16.4 及更早版本。已提上游 issue #4820。
+
+## 这篇文档要解决什么
+
+用 CC Switch 把 Codex CLI 路由到 MiniMax 系 provider (`MiniMax-M3`,
+`MiniMax-M2.7` 等) 时, 部分用户在 Codex 对话框里 attach 图片会撞到这个错:
+
+```
+CC Switch local proxy failed while handling Codex endpoint /responses.
+Provider: MiniMax; model: MiniMax-M3;
+upstream_status: HTTP 400;
+cause: invalid params, context window exceeds limit (2013)
+```
+
+报错信息说 **"context window"**, 会让用户去清历史/换模型, 走错路。
+
+## 真因
+
+MiniMax API 用同一个错误码 **2013** 表示多种不同的失败:
+
+```json
+// 真的 context window 溢出 (200K tokens 超了)
+{"error":{"message":"prompt is too long (2013)",
+          "code":"invalid_prompt"}}
+
+// 单张图片 > 10MB
+{"error":{"message":"media exceeds size limit: max 10485760 bytes (2013)",
+          "code":"invalid_prompt"}}
+```
+
+CC Switch 上游错误包装器现在把 **所有** 2013 一律翻译成 "context window exceeds limit", 两种 case 完全没区分。所以用户看到同一条消息, 真实原因可能是上下文长度, 也可能是图片大小。
+
+直接 `curl` 打 `https://api.minimaxi.com/v1/responses` 验证:
+
+```bash
+$ curl .../v1/responses -d '{ "model": "MiniMax-M3",
+                              "input": [...10MB+ 大小的 base64 图片...] }'
+{"error":{"message":"media exceeds size limit: max 10485760 bytes (2013)",
+          "code":"invalid_prompt"}}
+```
+
+`MiniMax-M3` 实际 context window 是 200K+。一个 token 数很少但图片很大的请求, 失败原因绝对是 media size, 不是 context。
+
+## 怎么判断是哪种 case
+
+| 现象 | 大概率是 |
+|---|---|
+| 长对话历史 + 图片 | 真 context overflow (少见) |
+| 单张 > 10MB 的图 (视网膜屏内容复杂的网页 / PDF 页面) | media size (常见) |
+| 对话不到 1K tokens + 图片就失败 | 几乎肯定是 media size |
+
+最快确认: 直接 `curl` 把同样 payload 打上游 `api.minimaxi.com`, 看返回的 `error.message` 原文。
+
+## 建议的上游修法 (issue #4820 已提)
+
+1. CC Switch 收到 MiniMax 系 provider 的 `2013` 时, 直接把上游 `error.message` 透传给 Codex UI, 不要替换成人话字符串。上游 message 已经写明 "media" 还是 "prompt", 不用翻译。
+2. 可选: 在 forwarder 错误映射层加一个小的分类查表 (`2013` + `"media"` → "图片超过 10MB 上限", `2013` + `"prompt"` → "对话太长")。
+
+这是 forwarder 错误映射层的小改动, 不需要 provider 侧任何改动。
+
+## 临时 workaround (用户侧)
+
+上游修法发版前, 用 [Konsn666/codex-img-prep](https://github.com/Konsn666/codex-img-prep)
+这个客户端工具预处理图片, 保证都在 MiniMax 的 10MB 上限内。一行安装:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Konsn666/codex-img-prep/main/install-remote.sh | bash
+```
+
+装完后:
+
+- 截图复制到剪贴板 → 2 秒内自动 resize (最长边 1920px, JPEG q85, ≤ 8MB)
+- Finder 右键任意图片 → **Quick Actions → Compress for Codex**
+- Shell aliases: `prep-clip` / `prep-img` / `prep-watch`
+
+另外 installer 还会把 Codex provider 的 `meta.apiFormat` 从 `openai_chat` 改成
+`openai_responses`, 这样 forwarder 不再做 lossy `/responses → /chat/completions` 翻译,
+日志也能跟实际请求路径对上。
+
+## 环境
+
+- CC Switch: v3.16.4
+- Codex CLI: 最新, `wire_api = "responses"`
+- MiniMax-M3 via `api.minimaxi.com`
+- macOS 15.4 (Apple Silicon) — workaround 只支持 macOS 因为用了系统内置的 `sips`; Linux/Windows 用户需要换成 ImageMagick
+
+## 相关
+
+- 上游 issue: https://github.com/farion1231/cc-switch/issues/4820
+- Workaround repo: https://github.com/Konsn666/codex-img-prep
+- 端到端验证: 38.64MB 截图 → pipeline 后 1.04MB → CC Switch → MiniMax → 200 OK, 视觉识别正确

--- a/docs/guides/codex-image-2013-error-zh.md
+++ b/docs/guides/codex-image-2013-error-zh.md
@@ -91,3 +91,9 @@ curl -fsSL https://raw.githubusercontent.com/Konsn666/codex-img-prep/main/instal
 - 上游 issue: https://github.com/farion1231/cc-switch/issues/4820
 - Workaround repo: https://github.com/Konsn666/codex-img-prep
 - 端到端验证: 38.64MB 截图 → pipeline 后 1.04MB → CC Switch → MiniMax → 200 OK, 视觉识别正确
+---
+
+## 英文版 / English version
+
+完整的英文版见 [Konsn666/codex-img-prep README](https://github.com/Konsn666/codex-img-prep/blob/main/README.md),
+英文 issue 稿见 [ISSUE.md](https://github.com/Konsn666/codex-img-prep/blob/main/ISSUE.md)。


### PR DESCRIPTION
## What

Adds a new user-guide document explaining the misleading 'context window exceeds limit (2013)' error that users hit when attaching > 10 MB images to Codex via MiniMax-family providers.

## Why

Upstream issue #4820 documents the bug; this PR adds a user-facing guide that:
1. Explains the root cause (MiniMax reuses error code 2013; CC Switch wrapper doesn't distinguish context vs media cases)
2. Tells users how to identify which case they're in
3. Proposes the upstream fix (forward upstream `error.message` verbatim instead of substituting a generic string)
4. Links to a client-side workaround ([Konsn666/codex-img-prep](https://github.com/Konsn666/codex-img-prep)) for users who need it today

## Trilingual

Follows the existing convention (see `codex-official-auth-preservation-guide-{en,ja,zh}.md` for an example). 3 files, 332 lines total, all translated.

## Not a code change

This is docs-only. No Rust/TS modifications, so no `pnpm typecheck`/`pnpm format:check`/`pnpm test:unit` concerns. Should pass CONTRIBUTING.md requirements trivially.

## Related

- Issue: https://github.com/farion1231/cc-switch/issues/4820
- Workaround: https://github.com/Konsn666/codex-img-prep