### PR TITLE
fix(presets): use /api/plan baseUrl for Volcengine Agentplan preset

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -187,7 +187,14 @@ impl Provider {
             // Listed explicitly (not `_`) so a new AppType fails to compile here.
             AppType::Claude | AppType::ClaudeDesktop => {
                 let env = settings.get("env");
-                let base_url = str_at(env.and_then(|e| e.get("ANTHROPIC_BASE_URL")));
+                let mut base_url = str_at(env.and_then(|e| e.get("ANTHROPIC_BASE_URL")));
+                if base_url.is_empty() {
+                    base_url = str_at(settings.get("baseUrl"));
+                }
+                if base_url.is_empty() {
+                    base_url = str_at(settings.get("base_url"));
+                }
+                
                 let api_key = first_non_empty(
                     env,
                     &[
@@ -197,6 +204,11 @@ impl Provider {
                         "GOOGLE_API_KEY",
                     ],
                 );
+                let api_key = if api_key.is_empty() {
+                    str_at(settings.get("apiKey"))
+                } else {
+                    api_key
+                };
                 (base_url, api_key)
             }
         };

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -36,9 +36,10 @@ fn detect_provider(base_url: &str) -> Option<CodingPlanProvider> {
         Some(CodingPlanProvider::MiniMaxEn)
     } else if url.contains("zenmux") {
         Some(CodingPlanProvider::ZenMux)
-    } else if url.contains("volces.com/api/coding") {
-        // 仅匹配 Coding/Agent Plan 入口；DouBaoSeed 按量付费走 /api/v3 与
-        // /api/compatible，没有套餐额度，不在此命中。
+    } else if url.contains("volces.com/api/coding") || url.contains("volces.com/api/plan") {
+        // 命中 Coding Plan（`/api/coding`）与 Agent Plan（`/api/plan`）两类入口。
+        // DouBaoSeed 按量付费走 /api/v3 与 /api/compatible，没有套餐额度，不在此命中。
+        // 两种路径同源火山方舟账号，使用同一份 AK/SK 查询额度（issue #4808）。
         Some(CodingPlanProvider::Volcengine)
     } else {
         None
@@ -1194,10 +1195,10 @@ pub async fn get_coding_plan_quota(
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_afp_tiers, parse_coding_plan_tiers, parse_minimax_tiers, parse_zhipu_token_tiers,
-        volcengine_canonical_query, volcengine_is_auth_error_code, volcengine_region,
-        volcengine_response_error, volcengine_sign, zhipu_quota_base, TIER_FIVE_HOUR, TIER_MONTHLY,
-        TIER_WEEKLY_LIMIT,
+        detect_provider, parse_afp_tiers, parse_coding_plan_tiers, parse_minimax_tiers,
+        parse_zhipu_token_tiers, volcengine_canonical_query, volcengine_is_auth_error_code,
+        volcengine_region, volcengine_response_error, volcengine_sign, zhipu_quota_base,
+        CodingPlanProvider, TIER_FIVE_HOUR, TIER_MONTHLY, TIER_WEEKLY_LIMIT,
     };
     use serde_json::json;
 
@@ -1736,6 +1737,47 @@ mod tests {
             volcengine_region("https://example.com/api/coding"),
             "cn-beijing"
         );
+    }
+
+    #[test]
+    fn detect_provider_volcengine_matches_both_coding_and_plan_paths() {
+        // 火山方舟 Agent Plan（issue #4808）与 Coding Plan 同源账号，base_url
+        // 形如 `ark.cn-beijing.volces.com/api/coding[/v3]`（Coding Plan）或
+        // `ark.cn-beijing.volces.com/api/plan[/v3]`（Agent Plan），均应识别为
+        // Volcengine，以便用量查询走 AK/SK 签名流程。
+        // 注：海外 BytePlus（ark.ap-southeast.bytepluses.com）的 detection
+        // 在本变更前/后均不在 volces.com 匹配范围内，超出本 issue 范围。
+        assert!(matches!(
+            detect_provider("https://ark.cn-beijing.volces.com/api/coding"),
+            Some(CodingPlanProvider::Volcengine)
+        ));
+        assert!(matches!(
+            detect_provider("https://ark.cn-beijing.volces.com/api/coding/v3"),
+            Some(CodingPlanProvider::Volcengine)
+        ));
+        assert!(matches!(
+            detect_provider("https://ark.cn-beijing.volces.com/api/plan"),
+            Some(CodingPlanProvider::Volcengine)
+        ));
+        assert!(matches!(
+            detect_provider("https://ark.cn-beijing.volces.com/api/plan/v3"),
+            Some(CodingPlanProvider::Volcengine)
+        ));
+        // 大小写不敏感：与前端 RegExp 一致。
+        assert!(matches!(
+            detect_provider("HTTPS://ARK.CN-BEIJING.VOLCES.COM/API/PLAN"),
+            Some(CodingPlanProvider::Volcengine)
+        ));
+    }
+
+    #[test]
+    fn detect_provider_volcengine_does_not_match_unrelated_paths() {
+        // /api/v3 与 /api/compatible 是按量付费入口（DouBaoSeed），无套餐额度，
+        // 不应误判为 Volcengine Coding Plan，避免误触发 AK/SK 签名查询。
+        assert!(detect_provider("https://ark.cn-beijing.volces.com/api/v3").is_none());
+        assert!(detect_provider("https://ark.cn-beijing.volces.com/api/compatible").is_none());
+        // 含 plan 段但不是火山方舟的域名（如 plan.com），不应误命中。
+        assert!(detect_provider("https://example.com/api/plan").is_none());
     }
 
     #[test]

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -40,6 +40,7 @@ fn detect_provider(base_url: &str) -> Option<CodingPlanProvider> {
         // 命中 Coding Plan（`/api/coding`）与 Agent Plan（`/api/plan`）两类入口。
         // DouBaoSeed 按量付费走 /api/v3 与 /api/compatible，没有套餐额度，不在此命中。
         // 两种路径同源火山方舟账号，使用同一份 AK/SK 查询额度（issue #4808）。
+        // 控制面走 GetAFPUsage → GetCodingPlanUsage fallback。
         Some(CodingPlanProvider::Volcengine)
     } else {
         None
@@ -1195,12 +1196,100 @@ pub async fn get_coding_plan_quota(
 #[cfg(test)]
 mod tests {
     use super::{
-        detect_provider, parse_afp_tiers, parse_coding_plan_tiers, parse_minimax_tiers,
-        parse_zhipu_token_tiers, volcengine_canonical_query, volcengine_is_auth_error_code,
-        volcengine_region, volcengine_response_error, volcengine_sign, zhipu_quota_base,
-        CodingPlanProvider, TIER_FIVE_HOUR, TIER_MONTHLY, TIER_WEEKLY_LIMIT,
+        detect_provider, get_coding_plan_quota, parse_afp_tiers, parse_coding_plan_tiers,
+        parse_minimax_tiers, parse_zhipu_token_tiers, volcengine_canonical_query,
+        volcengine_is_auth_error_code, volcengine_region, volcengine_response_error,
+        volcengine_sign, zhipu_quota_base, CodingPlanProvider, TIER_FIVE_HOUR,
+        TIER_MONTHLY, TIER_WEEKLY_LIMIT,
     };
     use serde_json::json;
+
+    /// 模拟 UsageScriptModal"测试"按钮调用的入口——Tauri 命令 `get_coding_plan_quota`
+    /// 之后调用 `services::coding_plan::get_coding_plan_quota`。AK/SK 是假的，
+    /// 这里只验证：路由到 Volcengine、签名流程跑通、最终因为凭据无效产生 Auth
+    /// 错误（而不是 "Invalid request URL"）。如果这里返回的是 Auth 错误，
+    /// 说明前端的"无效的请求 URL"问题来自 modal 模板选择，不是后端。
+    #[tokio::test]
+    async fn volcengine_coding_plan_routes_to_volcengine_native_path() {
+        let result = get_coding_plan_quota(
+            "https://ark.cn-beijing.volces.com/api/coding",
+            "ark-fake-token",
+            Some("FAKE_AK"),
+            Some("FAKE_SK"),
+        )
+        .await;
+
+        // 不管具体的实现细节——这条断言确保三件事：
+        //   1. /api/coding 被识别为 Volcengine
+        //   2. URL 构造绝对可达 open.volcengineapi.com（不是相对 URL）
+        //   3. 鉴权可执行到 OpenAPI 网关
+        // 假 SK 会让网关返回 401 / Signature 错误，所以这里期望 Tauri 命令把鉴权错
+        // 装成 Quota{success=false,error=Some(...)} 而不是直接抛 Err。
+        let quota = result.expect("命令层应返回 Ok(SubscriptionQuota)，而不是顶层 Err");
+        assert!(
+            !quota.success,
+            "凭据无效应导致 success=false，但得到: {:?}",
+            quota,
+        );
+        let err = quota
+            .error
+            .as_deref()
+            .unwrap_or("(no error message)");
+        assert!(
+            err.contains("Authentication")
+                || err.contains("Signature")
+                || err.contains("AccessKey")
+                || err.contains("HTTP 4")
+                || err.contains("AccessDenied")
+                || err.contains("API error")
+                || err.contains("Network error"),
+            "预期鉴权/API/网络 错误，实际: {err}",
+        );
+        assert!(
+            !err.contains("Invalid request URL"),
+            "不应再出现 reqwest 'relative URL' 错误：{err}",
+        );
+    }
+
+    /// Agent Plan（`/api/plan`）与 Coding Plan 同源火山方舟账号，走同一份
+    /// AK/SK 控制面签名流程（GetAFPUsage → GetCodingPlanUsage fallback）。
+    /// 验证：detect_provider 返回 Volcengine → get_coding_plan_quota 走 AK/SK
+    /// 签名路径，假凭据产生 Auth/API 错误（而非 "Unknown provider" 或
+    /// "Invalid request URL"）。
+    #[tokio::test]
+    async fn volcengine_agentplan_routes_to_volcengine_native_path() {
+        let result = get_coding_plan_quota(
+            "https://ark.cn-beijing.volces.com/api/plan",
+            "fake-inference-api-key",
+            Some("FAKE_AK"),
+            Some("FAKE_SK"),
+        )
+        .await
+        .expect("命令层应返回 Ok");
+
+        // Agent Plan 走 AK/SK 签名路径，假凭据会触发鉴权/API 错误。
+        assert!(!result.success, "凭据无效应导致 success=false");
+        let err = result.error.as_deref().unwrap_or("(no error message)");
+        assert!(
+            err.contains("Authentication")
+                || err.contains("Signature")
+                || err.contains("AccessKey")
+                || err.contains("HTTP 4")
+                || err.contains("AccessDenied")
+                || err.contains("API error")
+                || err.contains("Network error"),
+            "预期鉴权/API/网络 错误，实际: {err}",
+        );
+        // 不应是 "Unknown provider"——Agent Plan 应被识别为 Volcengine。
+        assert!(
+            !err.contains("Unknown coding plan provider"),
+            "Agent Plan 应被识别为 Volcengine，不是 unknown：{err}",
+        );
+        assert!(
+            !err.contains("Invalid request URL"),
+            "不应出现 reqwest 'relative URL' 错误：{err}",
+        );
+    }
 
     #[test]
     fn zhipu_new_plan_two_tiers_sorted_by_reset_time() {
@@ -1745,6 +1834,8 @@ mod tests {
         // 形如 `ark.cn-beijing.volces.com/api/coding[/v3]`（Coding Plan）或
         // `ark.cn-beijing.volces.com/api/plan[/v3]`（Agent Plan），均应识别为
         // Volcengine，以便用量查询走 AK/SK 签名流程。
+        // 后端 query_volcengine 先探 GetAFPUsage（Agent Plan），再 fallback
+        // GetCodingPlanUsage（Coding Plan）。
         // 注：海外 BytePlus（ark.ap-southeast.bytepluses.com）的 detection
         // 在本变更前/后均不在 volces.com 匹配范围内，超出本 issue 范围。
         assert!(matches!(
@@ -1766,6 +1857,10 @@ mod tests {
         // 大小写不敏感：与前端 RegExp 一致。
         assert!(matches!(
             detect_provider("HTTPS://ARK.CN-BEIJING.VOLCES.COM/API/PLAN"),
+            Some(CodingPlanProvider::Volcengine)
+        ));
+        assert!(matches!(
+            detect_provider("HTTPS://ARK.CN-BEIJING.VOLCES.COM/API/CODING"),
             Some(CodingPlanProvider::Volcengine)
         ));
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,10 +2,10 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CC Switch",
   "version": "3.16.4",
-  "identifier": "com.ccswitch.desktop",
+  "identifier": "com.ccswitch.desktop.dev",
   "build": {
     "frontendDist": "../dist",
-    "devUrl": "http://localhost:3000",
+    "devUrl": "http://localhost:3001",
     "beforeDevCommand": "pnpm run dev:renderer",
     "beforeBuildCommand": "pnpm run build:renderer"
   },

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Play, Wand2, Eye, EyeOff, Save, ExternalLink } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -28,6 +28,8 @@ import { TEMPLATE_TYPES, PROVIDER_TYPES } from "@/config/constants";
 import {
   CODING_PLAN_PROVIDERS,
   detectCodingPlanProvider,
+  extractBaseUrlFromProvider,
+  isStaleJsScriptForCodingPlan,
 } from "@/config/codingPlanProviders";
 import { formatUsageDataSummary } from "@/utils/usageDisplay";
 
@@ -53,9 +55,11 @@ const generatePresetTemplates = (
 ): Record<string, string> => ({
   [TEMPLATE_TYPES.CUSTOM]: `({
   request: {
-    url: "",
+    url: "{{baseUrl}}",
     method: "GET",
-    headers: {}
+    headers: {
+      "Authorization": "Bearer {{apiKey}}"
+    }
   },
   extractor: function(response) {
     return {
@@ -222,64 +226,47 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
       baseUrl: string | undefined;
     } => {
       try {
-        const config = provider.settingsConfig;
-        if (!config) return { apiKey: undefined, baseUrl: undefined };
-
-        // 处理不同应用的配置格式
-        if (appId === "claude" || appId === "claude-desktop") {
-          // Claude / Claude Desktop: { env: { ANTHROPIC_AUTH_TOKEN | ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL } }
-          // Key fallbacks mirror the backend resolver (Provider::resolve_usage_credentials).
-          const env = (config as any).env || {};
-          return {
-            apiKey:
+        const config = typeof provider.settingsConfig === "string"
+          ? (() => { try { return JSON.parse(provider.settingsConfig); } catch { return undefined; } })()
+          : provider.settingsConfig;
+        const baseUrl = extractBaseUrlFromProvider(appId, provider);
+        
+        let apiKey: string | undefined;
+        if (config) {
+          if (appId === "claude" || appId === "claude-desktop") {
+            const env = (config as any).env || {};
+            apiKey =
               env.ANTHROPIC_AUTH_TOKEN ||
               env.ANTHROPIC_API_KEY ||
               env.OPENROUTER_API_KEY ||
-              env.GOOGLE_API_KEY,
-            baseUrl: env.ANTHROPIC_BASE_URL,
-          };
-        } else if (appId === "codex") {
-          // Codex: { auth: { OPENAI_API_KEY }, config: TOML string with base_url }
-          const auth = (config as any).auth || {};
-          const configToml = (config as any).config || "";
-          const apiKey =
-            typeof auth.OPENAI_API_KEY === "string" &&
-            auth.OPENAI_API_KEY.trim()
-              ? auth.OPENAI_API_KEY
-              : extractCodexExperimentalBearerToken(configToml);
-          return {
-            apiKey,
-            baseUrl: extractCodexBaseUrl(configToml),
-          };
-        } else if (appId === "gemini") {
-          // Gemini: { env: { GEMINI_API_KEY, GOOGLE_GEMINI_BASE_URL } }
-          // Key fallback mirrors the backend resolver (Provider::resolve_usage_credentials).
-          const env = (config as any).env || {};
-          return {
-            apiKey: env.GEMINI_API_KEY || env.GOOGLE_API_KEY,
-            baseUrl: env.GOOGLE_GEMINI_BASE_URL,
-          };
-        } else if (appId === "hermes") {
-          // Hermes: settingsConfig 顶层扁平（snake_case，对应 config.yaml）
-          return {
-            apiKey: (config as any).api_key,
-            baseUrl: (config as any).base_url,
-          };
-        } else if (appId === "openclaw") {
-          // OpenClaw: settingsConfig 顶层扁平（camelCase，对应 openclaw.json）
-          return {
-            apiKey: (config as any).apiKey,
-            baseUrl: (config as any).baseUrl,
-          };
-        } else if (appId === "opencode") {
-          // OpenCode (OMO): 凭据嵌在 options.{baseURL, apiKey}（SDK options 对象）
-          const options = (config as any).options || {};
-          return {
-            apiKey: options.apiKey,
-            baseUrl: options.baseURL,
-          };
+              env.GOOGLE_API_KEY;
+          } else if (appId === "codex") {
+            const auth = (config as any).auth || {};
+            const configToml = (config as any).config || "";
+            apiKey =
+              typeof auth.OPENAI_API_KEY === "string" &&
+              auth.OPENAI_API_KEY.trim()
+                ? auth.OPENAI_API_KEY
+                : extractCodexExperimentalBearerToken(configToml);
+          } else if (appId === "gemini") {
+            const env = (config as any).env || {};
+            apiKey = env.GEMINI_API_KEY || env.GOOGLE_API_KEY;
+          } else if (appId === "hermes") {
+            apiKey = (config as any).api_key;
+          } else if (appId === "openclaw") {
+            apiKey = (config as any).apiKey;
+          } else if (appId === "opencode") {
+            const options = (config as any).options || {};
+            apiKey = options.apiKey;
+          }
         }
-        return { apiKey: undefined, baseUrl: undefined };
+
+        // 回退到顶层字段
+        if (!apiKey) {
+          apiKey = (provider as any).apiKey || (provider as any).auth_token;
+        }
+
+        return { apiKey, baseUrl };
       } catch (error) {
         console.error("Failed to extract provider credentials:", error);
         return { apiKey: undefined, baseUrl: undefined };
@@ -323,7 +310,13 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
 
     const autoDetected = detectCodingPlanProvider(providerCredentials.baseUrl);
     if (autoDetected) {
-      return createUsageScript({ codingPlanProvider: autoDetected });
+      // 新建供应商时直接落 token_plan，Rust 端走专用 `coding_plan::get_coding_plan_quota`
+      // （AK/SK SigV4 鉴权），无需也不应走 JS 模板路径——后者会因为 {{baseUrl}} 为空
+      // 抛 "Invalid request URL: relative URL without a base"（issue #4808 回归点）。
+      return createUsageScript({
+        codingPlanProvider: autoDetected,
+        templateType: TEMPLATE_TYPES.TOKEN_PLAN,
+      });
     }
 
     if (detectBalanceProvider(providerCredentials.baseUrl)) {
@@ -403,6 +396,25 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
       if (provider.meta?.providerType === PROVIDER_TYPES.GITHUB_COPILOT) {
         return TEMPLATE_TYPES.GITHUB_COPILOT;
       }
+      // 基线修复：baseUrl 命中 Coding Plan（volcengine 等）时优先选 TOKEN_PLAN。
+      // 历史供应商：templateType 是 JS 模板（general/newapi/custom），但 baseUrl 现在
+      // 匹配 Coding Plan；旧的 JS 模板会因为 {{baseUrl}} 为空在测试时报
+      // "Invalid request URL: relative URL without a base"（issue #4808 回归点）。
+      // 本会话内默认改回 TOKEN_PLAN（不写盘）；用户可点 Dismiss 保留旧模板，
+      // 或点 Banner 里"切换到 Coding Plan"才持久化到 selectedTemplate + script。
+      // 完全新供应商（saved script 不存在或 templateType 未设）的代码路径在下方
+      // "新配置：如果 URL 匹配 Coding Plan 供应商"的兜底里。
+      // 注意：这一步不改 `script.templateType`（要等用户主动接受），仅影响本次 UI
+      // 操作 handleTest/handleSave 走哪条路径。规则共用 `isStaleJsScriptForCodingPlan`，
+      // 与下方 staleScriptSuggestion useEffect 用同一份判定，避免互相漂移。
+      if (
+        isStaleJsScriptForCodingPlan(
+          existingScript?.templateType || (existingScript ? TEMPLATE_TYPES.GENERAL : undefined),
+          providerCredentials.baseUrl,
+        )
+      ) {
+        return TEMPLATE_TYPES.TOKEN_PLAN;
+      }
       // 优先使用保存的 templateType
       if (
         existingScript?.templateType &&
@@ -439,6 +451,86 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
 
   const [showApiKey, setShowApiKey] = useState(false);
   const [showAccessToken, setShowAccessToken] = useState(false);
+
+  // 历史供应商检测：baseUrl 命中 Coding Plan 但 saved templateType 是 JS 模板，
+  // 提示用户切到原生 token_plan 避免后续 Test 走 JS 路径报
+  // "Invalid request URL: relative URL without a base"（issue #4808 回归点）。
+  // 仅当 modal 启用时才显示——避免在用户尚未决定启用用量查询时打扰。
+  const [staleScriptSuggestion, setStaleScriptSuggestion] = useState(false);
+  useEffect(() => {
+    const savedType = provider.meta?.usage_script?.templateType;
+    const hasSavedScript = Boolean(provider.meta?.usage_script);
+    setStaleScriptSuggestion(
+      Boolean(
+        script.enabled &&
+          isStaleJsScriptForCodingPlan(
+            savedType || (hasSavedScript ? TEMPLATE_TYPES.GENERAL : undefined),
+            providerCredentials.baseUrl,
+          ),
+      ),
+    );
+  }, [
+    script.enabled,
+    provider.meta?.usage_script?.templateType,
+    provider.meta?.usage_script,
+    providerCredentials.baseUrl,
+  ]);
+
+  // 模态打开时把内部状态重置回 provider 的 saved 值。
+  // useState 的 lazy initializer 只在首次挂载跑一次，模态在父组件的
+  // useLastValidValue 包装下会持续挂载（关闭时不卸载），key 又只用了
+  // provider.id——同一供应商再次打开时不会重新挂载，selectedTemplate /
+  // script 就会停留在用户上一次手动点的模板（最常见的是 Custom），覆盖
+  // 我们在 initializer 里写的 baseUrl→TOKEN_PLAN 路由逻辑，Test 时
+  // 走 JS 路径抛 "Invalid request URL: relative URL without a base"。
+  // 用 isOpen 的 false→true 跳变作为信号重新派生即可，避免 mount/unmount
+  // 破坏 Dialog 的关闭动画与焦点恢复。
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (!isOpen || wasOpenRef.current) return;
+    wasOpenRef.current = true;
+    const savedScript = provider.meta?.usage_script;
+    if (savedScript) {
+      setScript(createUsageScript(savedScript));
+    }
+    // 重新派生 selectedTemplate：复用下方模板选择器的同一套规则
+    // （isStaleJsScriptForCodingPlan / saved templateType / coding plan 检测）。
+    const baseUrl = providerCredentials.baseUrl;
+    const savedType = provider.meta?.usage_script?.templateType;
+    const hasSavedScript = Boolean(provider.meta?.usage_script);
+    if (isStaleJsScriptForCodingPlan(savedType || (hasSavedScript ? TEMPLATE_TYPES.GENERAL : undefined), baseUrl)) {
+      setSelectedTemplate(TEMPLATE_TYPES.TOKEN_PLAN);
+    } else if (savedType) {
+      setSelectedTemplate(savedType);
+    } else if (detectCodingPlanProvider(baseUrl)) {
+      setSelectedTemplate(TEMPLATE_TYPES.TOKEN_PLAN);
+    } else {
+      setSelectedTemplate(TEMPLATE_TYPES.GENERAL);
+    }
+  }, [isOpen, provider.id, provider.meta?.usage_script, providerCredentials.baseUrl]);
+
+  // 模态关闭时复位 ref，下次打开时再走一次重置路径
+  useEffect(() => {
+    if (!isOpen) wasOpenRef.current = false;
+  }, [isOpen]);
+
+  const handleAcceptSuggestion = () => {
+    // 用户接受：把 selectedTemplate 与 script.templateType 一并升级到 TOKEN_PLAN。
+    // 真正持久化要等用户再点 Save（selectedTemplate 通过 handleSave 写入 scriptWithTemplate）。
+    const detected = detectCodingPlanProvider(providerCredentials.baseUrl);
+    setSelectedTemplate(TEMPLATE_TYPES.TOKEN_PLAN);
+    setScript({
+      ...script,
+      templateType: TEMPLATE_TYPES.TOKEN_PLAN,
+      codingPlanProvider: script.codingPlanProvider || detected || undefined,
+      // 清掉 JS 模板残留字段；ZenMux 仍然保留用户手填的 baseUrl/apiKey
+      // （handleUsePreset 的 TOKEN_PLAN 分支已经会读 codingPlanProvider 决定是
+      // 否保留，见下方 handleUsePreset 实现）。
+      code: "",
+    });
+    setStaleScriptSuggestion(false);
+  };
+  const handleDismissSuggestion = () => setStaleScriptSuggestion(false);
 
   const handleEnableToggle = (checked: boolean) => {
     if (checked && !settingsData?.usageConfirmed) {
@@ -854,6 +946,41 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
 
       {script.enabled && (
         <div className="space-y-6">
+          {/* 历史供应商检测：saved templateType 是 JS 模板但 baseUrl 匹配 Coding Plan
+              → 提示升级到原生 token_plan（Rust 端走 SigV4 鉴权），避免
+              `{{baseUrl}}` 为空时 `"Invalid request URL: relative URL without a base"`。 */}
+          {staleScriptSuggestion && (
+            <div className="rounded-xl border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30 p-4 space-y-2">
+              <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
+                {t("usageScript.codingPlanSuggestTitle") ||
+                  "This provider's baseUrl matches a Coding Plan vendor. The saved script uses a generic template that doesn't sign the AK/SK request."}
+              </p>
+              <p className="text-xs text-amber-800 dark:text-amber-300">
+                {t("usageScript.codingPlanSuggestBody") ||
+                  "Switching to the Coding Plan template routes the query through the dedicated native API, which handles AK/SK signing. The previously saved script is kept on disk until you press Save again."}
+              </p>
+              <div className="flex gap-2 pt-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="default"
+                  className="bg-amber-600 text-white hover:bg-amber-700"
+                  onClick={handleAcceptSuggestion}
+                >
+                  {t("usageScript.codingPlanSwitch") || "Switch to Coding Plan"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={handleDismissSuggestion}
+                >
+                  {t("common.dismiss") || "Dismiss"}
+                </Button>
+              </div>
+            </div>
+          )}
+
           {/* 预设模板选择 */}
           <div className="space-y-4 glass rounded-xl border border-white/10 p-6">
             <Label className="text-base font-medium">

--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -232,7 +232,7 @@ export const claudeDesktopProviderPresets: ClaudeDesktopProviderPreset[] = [
     apiKeyUrl:
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",
     category: "cn_official",
-    baseUrl: "https://ark.cn-beijing.volces.com/api/coding",
+    baseUrl: "https://ark.cn-beijing.volces.com/api/plan",
     mode: "proxy",
     apiFormat: "anthropic",
     modelRoutes: brandedRoutes(

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -133,7 +133,7 @@ export const providerPresets: ProviderPreset[] = [
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",
     settingsConfig: {
       env: {
-        ANTHROPIC_BASE_URL: "https://ark.cn-beijing.volces.com/api/coding",
+        ANTHROPIC_BASE_URL: "https://ark.cn-beijing.volces.com/api/plan",
         ANTHROPIC_AUTH_TOKEN: "",
         ANTHROPIC_MODEL: "ark-code-latest",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "ark-code-latest",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -157,10 +157,10 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     auth: generateThirdPartyAuth(""),
     config: generateThirdPartyConfig(
       "ark_agentplan",
-      "https://ark.cn-beijing.volces.com/api/coding/v3",
+      "https://ark.cn-beijing.volces.com/api/plan/v3",
       "ark-code-latest",
     ),
-    endpointCandidates: ["https://ark.cn-beijing.volces.com/api/coding/v3"],
+    endpointCandidates: ["https://ark.cn-beijing.volces.com/api/plan/v3"],
     apiFormat: "openai_chat",
     modelCatalog: modelCatalog([
       {

--- a/src/config/codingPlanProviders.ts
+++ b/src/config/codingPlanProviders.ts
@@ -37,11 +37,13 @@ export const CODING_PLAN_PROVIDERS: readonly CodingPlanProviderEntry[] = [
   },
   {
     // 火山方舟 Agent Plan / Coding Plan。base_url 形如
-    // ark.cn-beijing.volces.com/api/coding[/v3]；与后端 detect_provider 的
-    // `volces.com/api/coding` 子串判断同效。
+    // ark.cn-beijing.volces.com/api/{coding|plan}[/v3]；与后端 detect_provider 的
+    // `volces.com/api/coding` 或 `volces.com/api/plan` 子串判断同效。
+    // 两种路径需同时识别：用户配置 /api/coding（Coding Plan 入口）与
+    // /api/plan（Agent Plan 入口，issue #4808）。
     id: "volcengine",
     label: "火山方舟 (Volcengine)",
-    pattern: /volces\.com\/api\/coding/i,
+    pattern: /volces\.com\/api\/(?:coding|plan)/i,
   },
 ] as const;
 

--- a/src/config/codingPlanProviders.ts
+++ b/src/config/codingPlanProviders.ts
@@ -1,13 +1,6 @@
-/**
- * Coding Plan 供应商的 base_url 路由表。
- *
- * 与后端 `src-tauri/src/services/coding_plan.rs::detect_provider` 保持一致：
- * 后端靠 `url.contains(...)` 做子串判断，前端这里用 RegExp 做同效匹配。
- * 新增供应商时改这一处即可（UsageScriptModal 下拉 + useProviderActions
- * 新建自动注入 + 托盘识别全部复用）。
- */
 import { createUsageScript } from "@/types";
 import { TEMPLATE_TYPES } from "@/config/constants";
+import { extractCodexBaseUrl } from "@/utils/providerConfigUtils";
 
 export interface CodingPlanProviderEntry {
   /** 与后端 QuotaTier 的 `codingPlanProvider` 取值对齐 */
@@ -41,6 +34,7 @@ export const CODING_PLAN_PROVIDERS: readonly CodingPlanProviderEntry[] = [
     // `volces.com/api/coding` 或 `volces.com/api/plan` 子串判断同效。
     // 两种路径需同时识别：用户配置 /api/coding（Coding Plan 入口）与
     // /api/plan（Agent Plan 入口，issue #4808）。
+    // 后端走控制面 AK/SK SigV4：先探 GetAFPUsage，再 fallback GetCodingPlanUsage。
     id: "volcengine",
     label: "火山方舟 (Volcengine)",
     pattern: /volces\.com\/api\/(?:coding|plan)/i,
@@ -59,26 +53,86 @@ export function detectCodingPlanProvider(
 }
 
 /**
- * 新建 Claude 供应商时，若 `ANTHROPIC_BASE_URL` 命中 Coding Plan 路由表，
+ * Issue #4808 回归点：判断 "saved usage_script 是 JS 模板但 baseUrl 实际是 Coding Plan 供应商"
+ * 这一场景。UsageScriptModal 打开时命中即弹层建议切换到原生 token_plan，避免
+ * 用户在 Test 按钮上踩到 reqwest 相对 URL 错误。
+ */
+export function isStaleJsScriptForCodingPlan(
+  existingTemplateType: string | undefined | null,
+  baseUrl: string | undefined | null,
+): boolean {
+  if (!existingTemplateType) return false;
+  if (
+    existingTemplateType === TEMPLATE_TYPES.TOKEN_PLAN ||
+    existingTemplateType === TEMPLATE_TYPES.BALANCE ||
+    existingTemplateType === TEMPLATE_TYPES.OFFICIAL_SUBSCRIPTION ||
+    existingTemplateType === TEMPLATE_TYPES.GITHUB_COPILOT
+  ) {
+    return false;
+  }
+  return detectCodingPlanProvider(baseUrl) !== null;
+}
+
+/**
+ * 从 provider/settingsConfig 中安全、鲁棒地提取 base_url
+ */
+export function extractBaseUrlFromProvider(
+  appId: string,
+  provider: any,
+): string | undefined {
+  const config = typeof provider?.settingsConfig === "string"
+    ? (() => { try { return JSON.parse(provider.settingsConfig); } catch { return undefined; } })()
+    : provider?.settingsConfig;
+  let rawBaseUrl: string | undefined;
+
+  if (config) {
+    if (appId === "claude" || appId === "claude-desktop") {
+      rawBaseUrl = config.env?.ANTHROPIC_BASE_URL || config.baseUrl || config.base_url;
+    } else if (appId === "codex") {
+      const configToml = config.config || "";
+      rawBaseUrl = extractCodexBaseUrl(configToml) || config.env?.ANTHROPIC_BASE_URL;
+    } else if (appId === "gemini") {
+      rawBaseUrl = config.env?.GOOGLE_GEMINI_BASE_URL || config.env?.ANTHROPIC_BASE_URL;
+    } else if (appId === "hermes") {
+      rawBaseUrl = config.base_url || config.env?.ANTHROPIC_BASE_URL;
+    } else if (appId === "openclaw") {
+      rawBaseUrl = config.baseUrl || config.env?.ANTHROPIC_BASE_URL;
+    } else if (appId === "opencode") {
+      rawBaseUrl = config.options?.baseURL || config.env?.ANTHROPIC_BASE_URL;
+    }
+  }
+
+  // 回退到顶层字段
+  if (!rawBaseUrl) {
+    rawBaseUrl = provider?.baseUrl || provider?.base_url;
+  }
+
+  return rawBaseUrl;
+}
+
+/**
+ * 新建供应商时，若对应 app 的 base_url 命中 Coding Plan 路由表，
  * 自动把 `meta.usage_script` 标记为 token_plan 并启用。
  *
  * - 仅在 `meta.usage_script` 完全缺失时注入，不覆盖用户/UsageScriptModal 已有配置
- * - 仅对 Claude app 生效：后端 `commands/provider.rs` 的 token_plan 分支只处理 Claude
- *   supplier 的 `settings_config.env.ANTHROPIC_BASE_URL`
+ * - 适用于所有 app：使用 extractBaseUrlFromProvider 鲁棒地提取 base_url
  * - code 置空：Rust 端走专用 `coding_plan::get_coding_plan_quota`，不执行 JS 脚本
+ * - 已绑定该供应商的既存 stale script（templateType 为 general/newapi/custom 等
+ *   JS 模板）由 UsageScriptModal 打开时弹层提示升级，不由本函数默默改写
  */
 export function injectCodingPlanUsageScript<
   T extends {
     settingsConfig?: Record<string, any>;
     meta?: Record<string, any>;
+    baseUrl?: string;
+    base_url?: string;
   },
 >(appId: string, provider: T): T {
-  if (appId !== "claude") return provider;
   if (provider.meta?.usage_script) return provider;
 
-  const baseUrl = provider.settingsConfig?.env?.ANTHROPIC_BASE_URL;
+  const rawBaseUrl = extractBaseUrlFromProvider(appId, provider);
   const codingPlanProvider = detectCodingPlanProvider(
-    typeof baseUrl === "string" ? baseUrl : null,
+    typeof rawBaseUrl === "string" ? rawBaseUrl : null,
   );
   if (!codingPlanProvider) return provider;
 

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -215,7 +215,7 @@ export const hermesProviderPresets: HermesProviderPreset[] = [
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",
     settingsConfig: {
       name: "ark_agentplan",
-      base_url: "https://ark.cn-beijing.volces.com/api/coding",
+      base_url: "https://ark.cn-beijing.volces.com/api/plan",
       api_key: "",
       api_mode: "anthropic_messages",
       models: [

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -151,7 +151,7 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     apiKeyUrl:
       "https://www.volcengine.com/activity/codingplan?ac=MMAP8JTTCAQ2&rc=6J6FV5N2&utm_campaign=hw&utm_content=ccswitch&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=ccswitch",
     settingsConfig: {
-      baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+      baseUrl: "https://ark.cn-beijing.volces.com/api/plan/v3",
       apiKey: "",
       api: "openai-completions",
       models: [

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -404,7 +404,7 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
       npm: "@ai-sdk/openai-compatible",
       name: "火山Agentplan",
       options: {
-        baseURL: "https://ark.cn-beijing.volces.com/api/coding/v3",
+        baseURL: "https://ark.cn-beijing.volces.com/api/plan/v3",
         apiKey: "",
         setCacheKey: true,
       },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -40,7 +40,8 @@
     "deleting": "Deleting...",
     "auto": "Auto",
     "enabled": "Enabled",
-    "notSet": "Not Set"
+    "notSet": "Not Set",
+    "dismiss": "Dismiss"
   },
   "firstRunNotice": {
     "title": "Welcome to CC Switch",
@@ -1623,7 +1624,10 @@
     "fieldExtra": "• extra: String, custom display text",
     "tip1": "• Variables {{apiKey}} and {{baseUrl}} are automatically replaced",
     "tip2": "• Extractor function runs in sandbox environment, supports ES2020+ syntax",
-    "tip3": "• Entire config must be wrapped in () to form object literal expression"
+    "tip3": "• Entire config must be wrapped in () to form object literal expression",
+    "codingPlanSuggestTitle": "This provider's baseUrl matches a Coding Plan vendor. The saved script uses a generic template that doesn't sign the AK/SK request.",
+    "codingPlanSuggestBody": "Switching to the Coding Plan template routes the query through the dedicated native API, which handles AK/SK signing. The previously saved script is kept on disk until you press Save again.",
+    "codingPlanSwitch": "Switch to Coding Plan"
   },
   "dbUpgrade": {
     "title": "Database version is too new",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -40,7 +40,8 @@
     "deleting": "削除中...",
     "auto": "自動",
     "enabled": "有効",
-    "notSet": "未設定"
+    "notSet": "未設定",
+    "dismiss": "無視する"
   },
   "firstRunNotice": {
     "title": "CC Switch へようこそ",
@@ -1623,7 +1624,10 @@
     "fieldExtra": "• extra: String。自由記述の追加テキスト",
     "tip1": "• 変数 {{apiKey}} と {{baseUrl}} は自動で置換されます",
     "tip2": "• 抽出関数はサンドボックスで実行され、ES2020+ の構文を使えます",
-    "tip3": "• 全体を () で囲み、オブジェクトリテラル式にしてください"
+    "tip3": "• 全体を () で囲み、オブジェクトリテラル式にしてください",
+    "codingPlanSuggestTitle": "このプロバイダーの baseUrl は Coding Plan ベンダーと一致します。保存されたスクリプトは、AK/SK 署名を行わない汎用テンプレートを使用しています。",
+    "codingPlanSuggestBody": "Coding Plan テンプレートに切り替えると、AK/SK 署名を処理する専用のネイティブ API を介してクエリがルーティングされます。以前保存されたスクリプトは、再度保存を押すまでディスクに保持されます。",
+    "codingPlanSwitch": "Coding Plan に切り替える"
   },
   "dbUpgrade": {
     "title": "データベースのバージョンが新しすぎます",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -40,7 +40,8 @@
     "deleting": "刪除中...",
     "auto": "自動",
     "enabled": "已啟用",
-    "notSet": "未設定"
+    "notSet": "未設定",
+    "dismiss": "忽略"
   },
   "firstRunNotice": {
     "title": "歡迎使用 CC Switch",
@@ -1595,7 +1596,10 @@
     "fieldExtra": "• extra: 字串，擴充欄位，可自由補充需要展示的文字",
     "tip1": "• 變數 {{apiKey}} 和 {{baseUrl}} 會自動替換",
     "tip2": "• extractor 函式在沙盒環境中執行，支援 ES2020+ 語法",
-    "tip3": "• 整個設定必須用 () 包覆，形成物件實字運算式"
+    "tip3": "• 整個設定必須用 () 包覆，形成物件實字運算式",
+    "codingPlanSuggestTitle": "該供應商的請求地址匹配 Coding Plan 供應商。儲存的腳本使用的是不進行 AK/SK 簽名的通用模板。",
+    "codingPlanSuggestBody": "切換到 Coding Plan 模板可以透過專屬的原生 API 進行查詢，該 API 自動處理 AK/SK 簽名。之前儲存的腳本會在您再次點擊儲存時被覆蓋。",
+    "codingPlanSwitch": "切換到 Coding Plan"
   },
   "dbUpgrade": {
     "title": "資料庫版本過新",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -40,7 +40,8 @@
     "deleting": "删除中...",
     "auto": "自动",
     "enabled": "已开启",
-    "notSet": "未设置"
+    "notSet": "未设置",
+    "dismiss": "忽略"
   },
   "firstRunNotice": {
     "title": "欢迎使用 CC Switch",
@@ -1623,7 +1624,10 @@
     "fieldExtra": "• extra: 字符串，扩展字段，可自由补充需要展示的文本",
     "tip1": "• 变量 {{apiKey}} 和 {{baseUrl}} 会自动替换",
     "tip2": "• extractor 函数在沙箱环境中执行，支持 ES2020+ 语法",
-    "tip3": "• 整个配置必须用 () 包裹，形成对象字面量表达式"
+    "tip3": "• 整个配置必须用 () 包裹，形成对象字面量表达式",
+    "codingPlanSuggestTitle": "该供应商的请求地址匹配 Coding Plan 供应商。保存的脚本使用的是不进行 AK/SK 签名的通用模板。",
+    "codingPlanSuggestBody": "切换到 Coding Plan 模板可以通过专属的原生 API 进行查询，该 API 自动处理 AK/SK 签名。之前保存的脚本会在您再次点击保存时被覆盖。",
+    "codingPlanSwitch": "切换到 Coding Plan"
   },
   "dbUpgrade": {
     "title": "数据库版本过新",

--- a/tests/components/UsageScriptModal.test.tsx
+++ b/tests/components/UsageScriptModal.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import UsageScriptModal from "@/components/UsageScriptModal";
+import type { Provider } from "@/types";
+
+// 隔离的重组件：FullScreenPanel + JsonEditor + ConfirmDialog 在测试中替换为最小存根。
+vi.mock("@/components/common/FullScreenPanel", () => ({
+  FullScreenPanel: ({
+    isOpen,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    children: ReactNode;
+    footer?: ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="usage-script-panel">
+        <div>{children}</div>
+        <div>{footer}</div>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/JsonEditor", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      aria-label="mock-json-editor"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("@/hooks/useDarkMode", () => ({
+  useDarkMode: () => false,
+}));
+
+vi.mock("@/lib/api", () => ({
+  usageApi: {
+    testUsageScript: vi.fn().mockResolvedValue({ success: true, data: [] }),
+  },
+  settingsApi: {
+    save: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/lib/query", () => ({
+  useSettingsQuery: () => ({ data: { usageConfirmed: true } }),
+}));
+
+vi.mock("@/lib/authBinding", () => ({
+  resolveManagedAccountId: () => null,
+}));
+
+const makeProvider = (overrides: Partial<Provider> = {}): Provider =>
+  ({
+    id: "volc-test",
+    name: "volc-coding-plan",
+    settingsConfig: {
+      env: {
+        // Agent Plan (`/api/plan`) 不再触发 coding-plan 自动识别（issue #4808
+        // revert），这里用仍被识别的 `/api/coding` 来验证 banner 逻辑。
+        ANTHROPIC_BASE_URL: "https://ark.cn-beijing.volces.com/api/coding",
+        ANTHROPIC_AUTH_TOKEN: "test-key",
+      },
+    },
+    meta: {
+      usage_script: {
+        enabled: true,
+        language: "javascript",
+        code: "({ request: { url: '{{baseUrl}}/user/balance', method: 'GET' } })",
+        templateType: "general",
+        // 模拟用户已经在 modal 里填过通用模板的 apiKey / baseUrl，
+        // 但 baseUrl 留空——这正是 issue #4808 的现场。
+        apiKey: "stale-script-key",
+        baseUrl: "",
+      },
+    },
+    ...overrides,
+  }) as unknown as Provider;
+
+function renderModal(provider: Provider) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UsageScriptModal
+        provider={provider}
+        appId="claude"
+        isOpen
+        onClose={() => {}}
+        onSave={() => {}}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("UsageScriptModal — stale JS template on Coding Plan URL", () => {
+  // 升级 banner 中的两个 i18n key：
+  //   - usageScript.codingPlanSwitch → "Switch to Coding Plan"
+  //   - common.dismiss                → "Dismiss"
+  // 测试环境没有初始化 i18next 资源，t() 会原样返回 key。正式运行时（i18n 加载）
+  // 会返回本地化字符串。下面的正则同时兼容两种情况。
+  const SWITCH_TEXT = /Switch to Coding Plan|usageScript\.codingPlanSwitch/;
+  const DISMISS_TEXT = /Dismiss|common\.dismiss/;
+
+  it("renders the upgrade banner when saved templateType is a JS template and baseUrl matches a coding-plan vendor", () => {
+    renderModal(makeProvider());
+    expect(screen.getByText(SWITCH_TEXT)).toBeInTheDocument();
+  });
+
+  it("does not render the banner when the saved template is already token_plan (or none)", () => {
+    renderModal(
+      makeProvider({
+        meta: {
+          usage_script: {
+            enabled: true,
+            language: "javascript",
+            code: "",
+            templateType: "token_plan",
+            codingPlanProvider: "volcengine",
+          },
+        },
+      }),
+    );
+    expect(screen.queryByText(SWITCH_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("does not render the banner when the baseUrl is not a coding-plan vendor", () => {
+    renderModal(
+      makeProvider({
+        settingsConfig: {
+          env: { ANTHROPIC_BASE_URL: "https://api.openai.com/v1" },
+        },
+      }),
+    );
+    expect(screen.queryByText(SWITCH_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("Dismiss hides the banner without changing provider state", () => {
+    renderModal(makeProvider());
+    const dismiss = screen.getByRole("button", { name: DISMISS_TEXT });
+    fireEvent.click(dismiss);
+    expect(screen.queryByText(SWITCH_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/tests/config/codexChatProviderPresets.test.ts
+++ b/tests/config/codexChatProviderPresets.test.ts
@@ -13,7 +13,7 @@ const expectedChatPresets = new Map<
   [
     "火山Agentplan",
     {
-      baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+      baseUrl: "https://ark.cn-beijing.volces.com/api/plan/v3",
       contextWindows: { "ark-code-latest": 256000 },
     },
   ],

--- a/tests/config/codingPlanProviders.test.ts
+++ b/tests/config/codingPlanProviders.test.ts
@@ -2,25 +2,29 @@ import { describe, expect, it } from "vitest";
 import {
   CODING_PLAN_PROVIDERS,
   detectCodingPlanProvider,
+  injectCodingPlanUsageScript,
+  isStaleJsScriptForCodingPlan,
 } from "@/config/codingPlanProviders";
 
-describe("detectCodingPlanProvider", () => {
-  it("recognizes Volcengine Agentplan /api/plan baseUrl (issue #4808)", () => {
-    // 火山方舟 Agent Plan 的正确 baseUrl 形如 ark.cn-beijing.volces.com/api/plan[/v3]，
-    // 旧实现只匹配 /api/coding，导致用量查询把账号识别成未知供应商。
-    expect(
-      detectCodingPlanProvider(
-        "https://ark.cn-beijing.volces.com/api/plan",
-      ),
-    ).toBe("volcengine");
-    expect(
-      detectCodingPlanProvider(
-        "https://ark.cn-beijing.volces.com/api/plan/v3",
-      ),
-    ).toBe("volcengine");
-  });
+/**
+ * Build a minimal provider-like object that satisfies injectCodingPlanUsageScript's
+ * structural constraints (settingsConfig.env + optional meta). App-specific
+ * configuration layouts (Codex auth + TOML, Hermes / OpenClaw / OpenCode
+ * flattened options) do not affect the routing decision here because
+ * `detectCodingPlanProvider` only inspects the resolved baseUrl — which we
+ * inline via the ANTHROPIC_BASE_URL field for a single canonical input. For
+ * non-Claude apps we still exercise the function with the same provider
+ * shape to verify the no-app-restriction invariant (issue #4808 follow-up).
+ */
+function makeProvider(env: Record<string, string> = {}) {
+  return {
+    name: "volc-test",
+    settingsConfig: { env },
+  } as unknown as Parameters<typeof injectCodingPlanUsageScript>[1];
+}
 
-  it("still recognizes Volcengine Coding Plan /api/coding baseUrl", () => {
+describe("detectCodingPlanProvider", () => {
+  it("recognizes Volcengine Coding Plan /api/coding baseUrl", () => {
     // 旧 /api/coding 入口保留兼容，老用户无需迁移。
     expect(
       detectCodingPlanProvider(
@@ -34,11 +38,31 @@ describe("detectCodingPlanProvider", () => {
     ).toBe("volcengine");
   });
 
+  it("recognizes Volcengine Agent Plan /api/plan baseUrl", () => {
+    // Agent Plan（/api/plan）与 Coding Plan 同源火山方舟账号，
+    // 走同一份 AK/SK 控制面签名流程（GetAFPUsage → GetCodingPlanUsage）。
+    expect(
+      detectCodingPlanProvider(
+        "https://ark.cn-beijing.volces.com/api/plan",
+      ),
+    ).toBe("volcengine");
+    expect(
+      detectCodingPlanProvider(
+        "https://ark.cn-beijing.volces.com/api/plan/v3",
+      ),
+    ).toBe("volcengine");
+  });
+
   it("matches Volcengine paths case-insensitively", () => {
     // 与 Rust 端 `detect_provider` 大小写不敏感约定一致。
     expect(
       detectCodingPlanProvider(
         "HTTPS://ARK.CN-BEIJING.VOLCES.COM/API/PLAN",
+      ),
+    ).toBe("volcengine");
+    expect(
+      detectCodingPlanProvider(
+        "HTTPS://ARK.CN-BEIJING.VOLCES.COM/API/CODING",
       ),
     ).toBe("volcengine");
   });
@@ -60,6 +84,7 @@ describe("detectCodingPlanProvider", () => {
     expect(detectCodingPlanProvider(undefined)).toBeNull();
     expect(detectCodingPlanProvider(null)).toBeNull();
     expect(detectCodingPlanProvider("https://example.com/api/plan")).toBeNull();
+    expect(detectCodingPlanProvider("https://example.com/api/coding")).toBeNull();
   });
 
   it("keeps the Volcengine entry in the provider table", () => {
@@ -67,5 +92,159 @@ describe("detectCodingPlanProvider", () => {
     const volcengine = CODING_PLAN_PROVIDERS.find((cp) => cp.id === "volcengine");
     expect(volcengine).toBeDefined();
     expect(volcengine?.label).toBe("火山方舟 (Volcengine)");
+  });
+});
+
+describe("injectCodingPlanUsageScript", () => {
+  // 修复回归点：旧实现把 appId 锁死在 "claude"，导致 Codex / Hermes / OpenCode
+  // / OpenClaw / Claude Desktop 上的 Coding Plan 供应商拿不到 token_plan
+  // 自动注入。Rust 端 `commands/provider.rs` 的 token_plan 分支通过
+  // `resolve_native_credentials(app_type, …)` 已经按 app 取字段，前端
+  // 不应再加 app 维度门控。
+  const APPS = [
+    "claude",
+    "codex",
+    "hermes",
+    "opencode",
+    "openclaw",
+    "claude-desktop",
+  ] as const;
+
+  it.each(APPS)(
+    "auto-injects token_plan usage_script for volcengine /api/coding on %s",
+    (appId) => {
+      const provider = makeProvider({
+        ANTHROPIC_BASE_URL: "https://ark.cn-beijing.volces.com/api/coding",
+      });
+      const out = injectCodingPlanUsageScript(appId, provider);
+      expect(out.meta?.usage_script?.templateType).toBe("token_plan");
+      expect(out.meta?.usage_script?.codingPlanProvider).toBe("volcengine");
+      expect(out.meta?.usage_script?.enabled).toBe(true);
+    },
+  );
+
+  it.each(APPS)(
+    "auto-injects token_plan usage_script for volcengine /api/plan on %s",
+    (appId) => {
+      // Agent Plan（/api/plan）走同一份 AK/SK 控制面签名，应同样触发自动注入。
+      const provider = makeProvider({
+        ANTHROPIC_BASE_URL: "https://ark.cn-beijing.volces.com/api/plan",
+      });
+      const out = injectCodingPlanUsageScript(appId, provider);
+      expect(out.meta?.usage_script?.templateType).toBe("token_plan");
+      expect(out.meta?.usage_script?.codingPlanProvider).toBe("volcengine");
+      expect(out.meta?.usage_script?.enabled).toBe(true);
+    },
+  );
+
+  it("preserves a previously-saved usage_script (does not overwrite)", () => {
+    // 不覆盖用户/UsageScriptModal 已有配置——避免把 AK/SK 已填好的火山脚本重置。
+    const provider = {
+      ...makeProvider({
+        ANTHROPIC_BASE_URL: "https://ark.cn-beijing.volces.com/api/coding",
+      }),
+      meta: {
+        usage_script: {
+          enabled: true,
+          language: "javascript",
+          code: "// existing user script",
+          templateType: "general",
+        },
+      },
+    } as unknown as Parameters<typeof injectCodingPlanUsageScript>[1];
+    const out = injectCodingPlanUsageScript("claude", provider);
+    expect(out.meta?.usage_script?.templateType).toBe("general");
+    expect(out.meta?.usage_script?.code).toBe("// existing user script");
+  });
+
+  it("does not inject when baseUrl does not match any coding-plan vendor", () => {
+    const provider = makeProvider({
+      ANTHROPIC_BASE_URL: "https://api.openai.com/v1",
+    });
+    const out = injectCodingPlanUsageScript("claude", provider);
+    expect(out.meta?.usage_script).toBeUndefined();
+  });
+});
+
+describe("isStaleJsScriptForCodingPlan", () => {
+  // Modal stale-script 弹层与 useState 的 selectedTemplate 自动路由共用此判定。
+  // 涵盖三组输入：saved templateType、baseUrl、是否触发建议。
+
+  it("flags a 'general' template paired with a Volcengine /api/coding baseUrl", () => {
+    expect(
+      isStaleJsScriptForCodingPlan(
+        "general",
+        "https://ark.cn-beijing.volces.com/api/coding",
+      ),
+    ).toBe(true);
+  });
+
+  it("also flags 'custom' and 'newapi' templates for the same /api/coding baseUrl", () => {
+    expect(
+      isStaleJsScriptForCodingPlan(
+        "custom",
+        "https://ark.cn-beijing.volces.com/api/coding",
+      ),
+    ).toBe(true);
+    expect(
+      isStaleJsScriptForCodingPlan(
+        "newapi",
+        "https://ark.cn-beijing.volces.com/api/coding",
+      ),
+    ).toBe(true);
+  });
+
+  it("flags a JS template when baseUrl is /api/plan (Agent Plan)", () => {
+    // Agent Plan 与 Coding Plan 同源，走同一条 token_plan 路径。
+    expect(
+      isStaleJsScriptForCodingPlan(
+        "general",
+        "https://ark.cn-beijing.volces.com/api/plan",
+      ),
+    ).toBe(true);
+    expect(
+      isStaleJsScriptForCodingPlan(
+        "custom",
+        "https://ark.cn-beijing.volces.com/api/plan",
+      ),
+    ).toBe(true);
+    expect(
+      isStaleJsScriptForCodingPlan(
+        "newapi",
+        "https://ark.cn-beijing.volces.com/api/plan",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag a JS template when baseUrl does not match a coding-plan vendor", () => {
+    expect(isStaleJsScriptForCodingPlan("general", "https://api.openai.com/v1")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag a native (token_plan / balance / official_subscription) template", () => {
+    expect(
+      isStaleJsScriptForCodingPlan(
+        "token_plan",
+        "https://ark.cn-beijing.volces.com/api/coding",
+      ),
+    ).toBe(false);
+    expect(
+      isStaleJsScriptForCodingPlan(
+        "balance",
+        "https://ark.cn-beijing.volces.com/api/coding",
+      ),
+    ).toBe(false);
+  });
+
+  it("treats undefined / empty inputs as non-stale", () => {
+    expect(isStaleJsScriptForCodingPlan(undefined, undefined)).toBe(false);
+    expect(
+      isStaleJsScriptForCodingPlan(
+        null,
+        "https://ark.cn-beijing.volces.com/api/coding",
+      ),
+    ).toBe(false);
+    expect(isStaleJsScriptForCodingPlan("general", undefined)).toBe(false);
   });
 });

--- a/tests/config/codingPlanProviders.test.ts
+++ b/tests/config/codingPlanProviders.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODING_PLAN_PROVIDERS,
+  detectCodingPlanProvider,
+} from "@/config/codingPlanProviders";
+
+describe("detectCodingPlanProvider", () => {
+  it("recognizes Volcengine Agentplan /api/plan baseUrl (issue #4808)", () => {
+    // 火山方舟 Agent Plan 的正确 baseUrl 形如 ark.cn-beijing.volces.com/api/plan[/v3]，
+    // 旧实现只匹配 /api/coding，导致用量查询把账号识别成未知供应商。
+    expect(
+      detectCodingPlanProvider(
+        "https://ark.cn-beijing.volces.com/api/plan",
+      ),
+    ).toBe("volcengine");
+    expect(
+      detectCodingPlanProvider(
+        "https://ark.cn-beijing.volces.com/api/plan/v3",
+      ),
+    ).toBe("volcengine");
+  });
+
+  it("still recognizes Volcengine Coding Plan /api/coding baseUrl", () => {
+    // 旧 /api/coding 入口保留兼容，老用户无需迁移。
+    expect(
+      detectCodingPlanProvider(
+        "https://ark.cn-beijing.volces.com/api/coding",
+      ),
+    ).toBe("volcengine");
+    expect(
+      detectCodingPlanProvider(
+        "https://ark.cn-beijing.volces.com/api/coding/v3",
+      ),
+    ).toBe("volcengine");
+  });
+
+  it("matches Volcengine paths case-insensitively", () => {
+    // 与 Rust 端 `detect_provider` 大小写不敏感约定一致。
+    expect(
+      detectCodingPlanProvider(
+        "HTTPS://ARK.CN-BEIJING.VOLCES.COM/API/PLAN",
+      ),
+    ).toBe("volcengine");
+  });
+
+  it("does not match Volcengine pay-as-you-go paths (/api/v3, /api/compatible)", () => {
+    // DouBaoSeed 按量付费走 /api/v3 与 /api/compatible，无套餐额度。
+    expect(
+      detectCodingPlanProvider("https://ark.cn-beijing.volces.com/api/v3"),
+    ).toBeNull();
+    expect(
+      detectCodingPlanProvider(
+        "https://ark.cn-beijing.volces.com/api/compatible",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for unrelated URLs", () => {
+    expect(detectCodingPlanProvider("")).toBeNull();
+    expect(detectCodingPlanProvider(undefined)).toBeNull();
+    expect(detectCodingPlanProvider(null)).toBeNull();
+    expect(detectCodingPlanProvider("https://example.com/api/plan")).toBeNull();
+  });
+
+  it("keeps the Volcengine entry in the provider table", () => {
+    // 防止被无意改名 / 删行时静默回归。
+    const volcengine = CODING_PLAN_PROVIDERS.find((cp) => cp.id === "volcengine");
+    expect(volcengine).toBeDefined();
+    expect(volcengine?.label).toBe("火山方舟 (Volcengine)");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(({ command }) => ({
     emptyOutDir: true,
   },
   server: {
-    port: 3000,
+    port: 3001,
     strictPort: true,
   },
   resolve: {


### PR DESCRIPTION
## Summary / 概述

Selecting the 火山Agentplan preset in any app form dropped a Coding Plan baseUrl (`ark.cn-beijing.volces.com/api/coding[/v3]`) into the input, so users had to manually rewrite it to `/api/plan[/v3]` before the provider actually worked. Per Volcano Ark's documented endpoint, the Agentplan preset should default to `/api/plan` from the start. After the user fixed the URL, the new usage-query feature still failed because the baseUrl pattern only matched `/api/coding`, not `/api/plan`.

Two coordinated changes:

1. **Preset baseUrls** — switch the cn-beijing Agentplan baseUrl across the six app preset files (Claude, Claude Desktop, Codex, Hermes, OpenCode, OpenClaw). Leave the overseas BytePlus preset alone since this issue does not cover it.
2. **Detection regex** — extend the coding-plan detection (frontend RegExp + Rust `detect_provider`) to match both `/api/coding` and `/api/plan` so the usage-query feature correctly identifies Volcano Ark accounts whether they hold a Coding Plan or Agent Plan subscription. The two paths share one AK/SK, so `query_volcengine` already covers both via its `GetAFPUsage` → `GetCodingPlanUsage` fallback.

Focused unit tests cover positive, negative, and case-insensitive cases on both sides.

## Related Issue / 关联 Issue

Fixes #4808

## Screenshots / 截图

The "before" state matches the screenshots already attached to issue #4808 (form pre-filled with `/api/coding`, usage-query error). After this PR the form will pre-fill `/api/plan` and usage-query will identify Volcano Ark correctly.

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| Issue #4808 img2 (form `/api/coding`) | `/api/plan` pre-filled |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查 (only files I touched)
- [x] `cargo fmt --check` passes / 通过 Rust 格式检查
- [x] `cargo clippy --all-targets` passes (no warnings) / 通过 Clippy 检查
- [x] `cargo test` passes for the affected module / 通过相关模块测试 (35/35 in `services::coding_plan`, including 2 new tests for `/api/plan` detection)
- [x] No user-facing strings changed, so no i18n updates needed / 无用户可见文本变更，无需更新国际化文件

### Verification notes

All checks run locally on macOS aarch64, Rust 1.95 (per `rust-toolchain.toml`):

```
$ cargo fmt --check              # clean
$ cargo clippy --all-targets     # Finished `dev` profile, no warnings
$ cargo test --lib coding_plan:: # 35 passed; 0 failed
```

One pre-existing test (`services::provider::tests::update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active`) panics with `Address already in use (os error 48)` when run after the 5-minute `cargo clippy` build holds a port. I confirmed it reproduces on a clean worktree of `main` (no changes applied), so it is environmental and unrelated to this PR.