### PR TITLE
fix(codex): sync catalog truncation limit

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -434,6 +434,12 @@ fn codex_catalog_model_entry(
     entry_obj.insert("description".to_string(), json!(spec.display_name));
     entry_obj.insert("context_window".to_string(), json!(spec.context_window));
     entry_obj.insert("max_context_window".to_string(), json!(spec.context_window));
+    if let Some(truncation_policy) = entry_obj
+        .get_mut("truncation_policy")
+        .and_then(|value| value.as_object_mut())
+    {
+        truncation_policy.insert("limit".to_string(), json!(spec.context_window));
+    }
     entry_obj.insert("priority".to_string(), json!(1000 + priority));
     entry_obj.insert("additional_speed_tiers".to_string(), json!([]));
     entry_obj.insert("service_tiers".to_string(), json!([]));
@@ -2314,7 +2320,11 @@ base_url = "https://production.api/v1"
                 "target": "gpt-5.5"
             },
             "context_window": 272000,
-            "max_context_window": 272000
+            "max_context_window": 272000,
+            "truncation_policy": {
+                "mode": "tokens",
+                "limit": 10000
+            }
         });
         let settings = json!({
             "modelCatalog": {
@@ -2353,6 +2363,27 @@ base_url = "https://production.api/v1"
         assert_eq!(
             models[1]
                 .get("context_window")
+                .and_then(|value| value.as_u64()),
+            Some(128_000)
+        );
+        assert_eq!(
+            models[0]
+                .get("truncation_policy")
+                .and_then(|value| value.get("mode"))
+                .and_then(|value| value.as_str()),
+            Some("tokens")
+        );
+        assert_eq!(
+            models[0]
+                .get("truncation_policy")
+                .and_then(|value| value.get("limit"))
+                .and_then(|value| value.as_u64()),
+            Some(64_000)
+        );
+        assert_eq!(
+            models[1]
+                .get("truncation_policy")
+                .and_then(|value| value.get("limit"))
                 .and_then(|value| value.as_u64()),
             Some(128_000)
         );


### PR DESCRIPTION
## Summary / 概述

- Sync generated Codex model catalog `truncation_policy.limit` with each model entry's `context_window`.
- Preserve the template's existing truncation mode while replacing the stale hard-coded `10000` limit.
- Extend the catalog generation regression test to cover explicit per-model context windows and the `model_context_window` fallback.

## Related Issue / 关联 Issue

Fixes #4832

## Screenshots / 截图

N/A. Backend catalog generation fix only.

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / Rust-only change, not run
- [ ] `pnpm format:check` passes / Rust-only change, not run
- [x] `cargo clippy` passes (if Rust code changed) / passes with existing warnings
- [x] Updated i18n files if user-facing text changed / N/A, no user-facing text changed

## Validation / 验证

- `cargo test --manifest-path src-tauri/Cargo.toml codex_model_catalog_uses_provider_models_and_context`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml` passes with existing warnings
- `git diff --check`