### PR TITLE
fix(hermes): update settings.json and DB is_current on provider switch

### DIFF
--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2231,8 +2231,17 @@ impl ProviderService {
             }
         }
 
-        // Additive mode apps skip setting is_current (no such concept)
-        if !app_type.is_additive_mode() {
+        // Additive mode apps skip setting is_current (no such concept).
+        // Hermes is additive for *live config* purposes (all providers coexist
+        // in custom_providers[]), but CCSwitch still needs to track which provider
+        // the user selected in the UI via settings.json + DB is_current so that
+        // the UI correctly highlights the active provider on next launch.
+        // Without this, switching between same-backend Hermes providers (e.g.
+        // deepseek flash → deepseek pro) updates config.yaml but leaves
+        // settings.currentProviderHermes and DB.is_current stale, causing a
+        // flip-flop loop where the UI reads the stale value and re-triggers the
+        // switch on the next interaction.
+        if !app_type.is_additive_mode() || matches!(app_type, AppType::Hermes) {
             // Update local settings (device-level, takes priority)
             crate::settings::set_current_provider(&app_type, Some(id))?;
 


### PR DESCRIPTION
## Problem

When switching Hermes providers in CCSwitch UI (e.g., `hermes-deepseek-v4-flash` → `hermes-deepseek-v4-pro`), the `config.yaml` is correctly updated via `apply_switch_defaults()`, but CCSwitch's own state tracking is NOT updated:

- `settings.json currentProviderHermes` remains stale
- DB `providers.is_current` remains stale

## Root Cause

In `ProviderService::switch_normal()` (services/provider/mod.rs:2235), the `is_current` update is guarded by:

```rust
if !app_type.is_additive_mode() {
    crate::settings::set_current_provider(...)?;
    state.db.set_current_provider(...)?;
}
```

Hermes is defined as additive mode (`AppType::Hermes` in `is_additive_mode()`), so this block is skipped. However, Hermes IS additive for *live config* purposes (all providers coexist in `custom_providers[]`), but CCSwitch still needs to track the user's selected provider for UI highlighting.

## Fix

Add `AppType::Hermes` exception to the guard:

```rust
if !app_type.is_additive_mode() || matches!(app_type, AppType::Hermes) {
```

This ensures Hermes switches update `settings.json` and DB `is_current`, while OpenCode and OpenClaw remain unchanged (they don't use CCSwitch current tracking).

## Verification

- [x] Flash → Pro switch: all 8 checkpoints verified correct
- [x] Pro → Flash switch: all 8 checkpoints verified correct
- [x] No hardcoded model names
- [x] No changes to API keys, provider content, or custom_providers