### PR TITLE
fix(usage): keep date-range picker calendar on-screen in narrow popovers

### DIFF
--- a/src/components/usage/UsageDateRangePicker.tsx
+++ b/src/components/usage/UsageDateRangePicker.tsx
@@ -331,7 +331,7 @@ export function UsageDateRangePicker({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[340px] max-w-[calc(100vw-2rem)] p-3 sm:w-[620px]"
+        className="usage-range-popover w-[620px] max-w-[calc(100vw-2rem)] p-3"
         align="end"
       >
         {/* Preset shortcuts */}
@@ -353,9 +353,9 @@ export function UsageDateRangePicker({
           ))}
         </div>
 
-        <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="usage-range-layout flex flex-col gap-3">
           {/* Left: date fields */}
-          <div className="space-y-2 sm:w-[250px] sm:flex-none">
+          <div className="usage-range-fields space-y-2">
             <p className="text-xs text-muted-foreground">
               {t("usage.customRangeHint", "支持日期与时间，最长 30 天")}
             </p>
@@ -403,7 +403,7 @@ export function UsageDateRangePicker({
           </div>
 
           {/* Right: calendar */}
-          <div className="rounded-lg border border-border/50 bg-muted/30 p-2.5 sm:min-w-0 sm:flex-1">
+          <div className="usage-range-calendar rounded-lg border border-border/50 bg-muted/30 p-2.5">
             {/* Month navigation */}
             <div className="flex items-center justify-between mb-1.5">
               <Button

--- a/src/index.css
+++ b/src/index.css
@@ -191,3 +191,36 @@ input[type="password"]::-ms-reveal,
 input[type="password"]::-ms-clear {
   display: none;
 }
+
+/*
+ * Usage date-range picker popover.
+ *
+ * The two-column layout (date fields | calendar) must depend on how much
+ * width the popover itself actually has — not on the viewport. The popover is
+ * clamped to `100vw - 2rem` and anchored to its trigger, so a viewport-based
+ * breakpoint (e.g. Tailwind `sm:`) could enable the wide layout while the
+ * popover only had room for one column, pushing the calendar off-screen.
+ *
+ * A container query keys the layout to the popover's own inline size. The base
+ * (stacked) layout is the safe fallback when container queries are
+ * unsupported, keeping the calendar fully visible at any width.
+ */
+.usage-range-popover {
+  container-type: inline-size;
+}
+
+@container (min-width: 500px) {
+  .usage-range-layout {
+    flex-direction: row;
+  }
+
+  .usage-range-fields {
+    width: 250px;
+    flex: none;
+  }
+
+  .usage-range-calendar {
+    min-width: 0;
+    flex: 1 1 0%;
+  }
+}


### PR DESCRIPTION
## Problem

Closes #4669

In **Settings → Usage Stats → time-range filter**, opening the custom date-range picker on a narrow window clips the **calendar** column off the right edge of the window — the month header shows only "2026" instead of "2026年6月", and only 3 of 7 weekday columns are visible. The calendar is effectively unusable.

<img width="426" alt="repro" src="https://github.com/user-attachments/assets/f06a34f7-525d-43f8-9874-94e190832bcf" />

## Root cause

`UsageDateRangePicker` switched to its two-column layout (date fields | calendar) based on the **viewport** width via Tailwind `sm:` (640px): `sm:flex-row`, fixed `sm:w-[250px] sm:flex-none` fields column, `sm:w-[620px]` popover.

But the popover is clamped to `max-w-[calc(100vw-2rem)]` and anchored to its trigger with `align="end"`, so how much width it actually has is **not** the viewport width. As a result the wide two-column layout could activate while the popover only had room for one column, pushing the calendar off-screen.

## Fix

Gate the two-column layout on the **popover's own inline size** via a CSS container query instead of the viewport, and let the popover width shrink to fit:

- Popover is now `w-[620px] max-w-[calc(100vw-2rem)]` (always ≤ viewport).
- The layout switches to two columns only when the popover itself is wide enough (`@container (min-width: 500px)`); otherwise it stacks vertically so the calendar is always fully visible.
- The base **stacked** layout is the safe fallback for engines without container-query support (progressive enhancement).

Only `src/components/usage/UsageDateRangePicker.tsx` (class names) and `src/index.css` (container-query rules) change.

## Verification

- `tsc --noEmit` — passes
- `tailwindcss` compiles `index.css` — container query emitted correctly
- `vitest run tests/components/RequestLogTable.test.tsx` — passes
- Wide desktop (min window 900px) unchanged: still the 620px two-column layout.
- Reviewed by GPT-5.5 (xhigh): no correctness issues; container-query approach confirmed as the cleanest option and the stacked fallback confirmed safe.
