### PR TITLE
fix(proxy): skip empty reasoning_content to prevent per-token block switching (逐字换行)

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -264,47 +264,52 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                             has_sent_message_start = true;
                                         }
 
-                                        // 处理 reasoning（thinking）
-                                        if let Some(reasoning) = &choice.delta.reasoning {
-                                            if current_non_tool_block_type != Some("thinking") {
-                                                if let Some(index) = current_non_tool_block_index.take() {
+                                       // 处理 reasoning（thinking）
+                                       if let Some(reasoning) = &choice.delta.reasoning {
+                                           // 跳过空字符串 reasoning_content：部分 Provider（如 ModelScope
+                                           // DeepSeek-V4-Pro）在正文阶段每个 chunk 仍带 "reasoning_content": ""
+                                           // 空字符串，若不判空会反复触发 thinking/text block 切换，导致逐字换行。
+                                           if !reasoning.is_empty() {
+                                                if current_non_tool_block_type != Some("thinking") {
+                                                    if let Some(index) = current_non_tool_block_index.take() {
+                                                        let event = json!({
+                                                            "type": "content_block_stop",
+                                                            "index": index
+                                                        });
+                                                        let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                                            serde_json::to_string(&event).unwrap_or_default());
+                                                        yield Ok(Bytes::from(sse_data));
+                                                    }
+                                                    let index = next_content_index;
+                                                    next_content_index += 1;
                                                     let event = json!({
-                                                        "type": "content_block_stop",
-                                                        "index": index
+                                                        "type": "content_block_start",
+                                                        "index": index,
+                                                        "content_block": {
+                                                            "type": "thinking",
+                                                            "thinking": ""
+                                                        }
                                                     });
-                                                    let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                                    let sse_data = format!("event: content_block_start\ndata: {}\n\n",
+                                                        serde_json::to_string(&event).unwrap_or_default());
+                                                    yield Ok(Bytes::from(sse_data));
+                                                    current_non_tool_block_type = Some("thinking");
+                                                    current_non_tool_block_index = Some(index);
+                                                }
+
+                                                if let Some(index) = current_non_tool_block_index {
+                                                    let event = json!({
+                                                        "type": "content_block_delta",
+                                                        "index": index,
+                                                        "delta": {
+                                                            "type": "thinking_delta",
+                                                            "thinking": reasoning
+                                                        }
+                                                    });
+                                                    let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
                                                         serde_json::to_string(&event).unwrap_or_default());
                                                     yield Ok(Bytes::from(sse_data));
                                                 }
-                                                let index = next_content_index;
-                                                next_content_index += 1;
-                                                let event = json!({
-                                                    "type": "content_block_start",
-                                                    "index": index,
-                                                    "content_block": {
-                                                        "type": "thinking",
-                                                        "thinking": ""
-                                                    }
-                                                });
-                                                let sse_data = format!("event: content_block_start\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
-                                                current_non_tool_block_type = Some("thinking");
-                                                current_non_tool_block_index = Some(index);
-                                            }
-
-                                            if let Some(index) = current_non_tool_block_index {
-                                                let event = json!({
-                                                    "type": "content_block_delta",
-                                                    "index": index,
-                                                    "delta": {
-                                                        "type": "thinking_delta",
-                                                        "thinking": reasoning
-                                                    }
-                                                });
-                                                let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
                                             }
                                         }
 
@@ -1226,9 +1231,50 @@ mod tests {
             .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("error")));
         assert!(!events
             .iter()
-            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_delta")));
-        assert!(!events
+           .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_delta")));
+       assert!(!events
+           .iter()
+           .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+   }
+
+    /// 回归测试：DeepSeek-V4-Pro（ModelScope）等 Provider 在正文阶段每个 chunk 仍带
+    /// `"reasoning_content": ""`（空字符串，非 null）。修复前 reasoning 分支不判空，会在每个
+    /// 正文 token 上反复 stop text block / start thinking block / stop / start text block，
+    /// 导致 Claude Code/Desktop 逐字换行。修复后空字符串 reasoning_content 应被跳过。
+    #[tokio::test]
+    async fn test_empty_reasoning_content_does_not_cause_per_token_block_switching() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"deepseek-ai/DeepSeek-V4-Pro\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"reasoning_content\":\"嗯\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"deepseek-ai/DeepSeek-V4-Pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"reasoning_content\":\"，用户只发了你好\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"deepseek-ai/DeepSeek-V4-Pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"你好！\",\"reasoning_content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"deepseek-ai/DeepSeek-V4-Pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"很高兴见到你\",\"reasoning_content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"deepseek-ai/DeepSeek-V4-Pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"，有什么可以帮你的吗？\",\"reasoning_content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"model\":\"deepseek-ai/DeepSeek-V4-Pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"reasoning_content\":\"\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":10,\"total_tokens\":15}}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let events = collect_anthropic_events(input).await;
+        let content_block_starts: Vec<&Value> = events
             .iter()
-            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+            .filter(|e| event_type(e) == Some("content_block_start"))
+            .collect();
+       let text_block_starts: Vec<&Value> = content_block_starts
+            .iter().copied()
+           .filter(|e| e.get("content_block").and_then(|c| c.get("type")).and_then(|t| t.as_str()) == Some("text"))
+           .collect();
+       assert_eq!(text_block_starts.len(), 1, "正文阶段应只启动一个 text block，实际 {} 个 —— 空 reasoning_content 仍在触发逐字 block 切换", text_block_starts.len());
+       let thinking_block_starts: Vec<&Value> = content_block_starts
+            .iter().copied()
+           .filter(|e| e.get("content_block").and_then(|c| c.get("type")).and_then(|t| t.as_str()) == Some("thinking"))
+           .collect();
+        assert_eq!(thinking_block_starts.len(), 1, "思考阶段应只启动一个 thinking block，实际 {} 个", thinking_block_starts.len());
+        let merged: String = events
+            .iter()
+            .filter_map(|e| {
+                if event_type(e) == Some("content_block_delta") {
+                    e.get("delta").and_then(|d| d.get("text")).and_then(|t| t.as_str()).map(|s| s.to_string())
+                } else { None }
+            })
+            .collect();
+        assert!(merged.contains("你好！很高兴见到你，有什么可以帮你的吗？"), "正文应完整拼接，实际得到: {merged}");
     }
 }

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -1231,11 +1231,11 @@ mod tests {
             .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("error")));
         assert!(!events
             .iter()
-           .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_delta")));
-       assert!(!events
-           .iter()
-           .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
-   }
+            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_delta")));
+        assert!(!events
+            .iter()
+            .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+    }
 
     /// 回归测试：DeepSeek-V4-Pro（ModelScope）等 Provider 在正文阶段每个 chunk 仍带
     /// `"reasoning_content": ""`（空字符串，非 null）。修复前 reasoning 分支不判空，会在每个
@@ -1257,24 +1257,49 @@ mod tests {
             .iter()
             .filter(|e| event_type(e) == Some("content_block_start"))
             .collect();
-       let text_block_starts: Vec<&Value> = content_block_starts
-            .iter().copied()
-           .filter(|e| e.get("content_block").and_then(|c| c.get("type")).and_then(|t| t.as_str()) == Some("text"))
-           .collect();
-       assert_eq!(text_block_starts.len(), 1, "正文阶段应只启动一个 text block，实际 {} 个 —— 空 reasoning_content 仍在触发逐字 block 切换", text_block_starts.len());
-       let thinking_block_starts: Vec<&Value> = content_block_starts
-            .iter().copied()
-           .filter(|e| e.get("content_block").and_then(|c| c.get("type")).and_then(|t| t.as_str()) == Some("thinking"))
-           .collect();
-        assert_eq!(thinking_block_starts.len(), 1, "思考阶段应只启动一个 thinking block，实际 {} 个", thinking_block_starts.len());
+        let text_block_starts: Vec<&Value> = content_block_starts
+            .iter()
+            .copied()
+            .filter(|e| {
+                e.get("content_block")
+                    .and_then(|c| c.get("type"))
+                    .and_then(|t| t.as_str())
+                    == Some("text")
+            })
+            .collect();
+        assert_eq!(text_block_starts.len(), 1, "正文阶段应只启动一个 text block，实际 {} 个 —— 空 reasoning_content 仍在触发逐字 block 切换", text_block_starts.len());
+        let thinking_block_starts: Vec<&Value> = content_block_starts
+            .iter()
+            .copied()
+            .filter(|e| {
+                e.get("content_block")
+                    .and_then(|c| c.get("type"))
+                    .and_then(|t| t.as_str())
+                    == Some("thinking")
+            })
+            .collect();
+        assert_eq!(
+            thinking_block_starts.len(),
+            1,
+            "思考阶段应只启动一个 thinking block，实际 {} 个",
+            thinking_block_starts.len()
+        );
         let merged: String = events
             .iter()
             .filter_map(|e| {
                 if event_type(e) == Some("content_block_delta") {
-                    e.get("delta").and_then(|d| d.get("text")).and_then(|t| t.as_str()).map(|s| s.to_string())
-                } else { None }
+                    e.get("delta")
+                        .and_then(|d| d.get("text"))
+                        .and_then(|t| t.as_str())
+                        .map(|s| s.to_string())
+                } else {
+                    None
+                }
             })
             .collect();
-        assert!(merged.contains("你好！很高兴见到你，有什么可以帮你的吗？"), "正文应完整拼接，实际得到: {merged}");
+        assert!(
+            merged.contains("你好！很高兴见到你，有什么可以帮你的吗？"),
+            "正文应完整拼接，实际得到: {merged}"
+        );
     }
 }


### PR DESCRIPTION
## 修复：空字符串 `reasoning_content` 导致 Claude Code/Desktop 逐字换行

### 问题现象

使用 cc-switch 接入部分 Provider（如 ModelScope 的 `deepseek-ai/DeepSeek-V4-Pro`、GLM 5.1/5.2、千问 3.7max 等）时，Claude Code / Claude Desktop 的输出出现**逐字换行**——每个 token 单独成行，几乎无法阅读。任务本身能执行成功，但回答被换行符切碎。

相关 issue：#2200 #2195 #3092

### 根因分析

问题出在 OpenAI Chat Completions SSE → Anthropic SSE 的流式转换逻辑（`src-tauri/src/proxy/providers/streaming.rs`）。

转换器根据当前 chunk 携带的内容类型，在 `thinking` block 和 `text` block 之间切换——切换时先发 `content_block_stop` 关闭旧 block，再发 `content_block_start` 开新 block。三个分支的判空守卫不一致：

| 分支 | 守卫 | 状态 |
|------|------|------|
| `content` | `if !content.is_empty()` | ✅ 有 |
| `tool_calls` | `if !tool_calls.is_empty()` | ✅ 有（v3.16.0 #2915 加的） |
| `reasoning` | `if let Some(reasoning)` | ❌ 缺失 |

DeepSeek-V4-Pro 等 Provider 在**正文阶段**的每个流式 chunk 里仍带一个 `reasoning_content` 字段，值为空字符串 `""`（非 null、非缺失）。`#[serde(default, alias = "reasoning_content")]` 会把空字符串反序列化为 `Some("")`，于是 reasoning 分支在每个正文 chunk 上都会触发：

1. reasoning 分支进入 → 发现当前 block 是 text 而非 thinking → **stop 掉 text block**
2. 开一个 thinking block → 发一个空的 `thinking_delta`
3. 紧接着 content 分支进入 → 发现当前 block 是 thinking 而非 text → **stop 掉 thinking block**
4. 重新开一个 text block → 发出真正的正文 delta

结果每个正文 token 都被一对 `content_block_stop` / `content_block_start` 包裹。Claude Code/Desktop 收到这种流，把每个 token 当成独立 block 渲染，于是逐字换行。

这与 v3.16.0 修复的空 `tool_calls: []` 问题（#2915）是**同一类 bug**——那次只堵了 `tool_calls` 一个口子，`reasoning` 这条路径漏了。Issue #2200 评论中 `@SimonWicre` 在 v3.16.3 上仍然复现，正是因为这次走的是 `reasoning_content` 路径而非 `tool_calls` 路径。

### 修复方案

给 reasoning 分支补上和 content / tool_calls 分支对称的判空守卫：

```rust
if let Some(reasoning) = &choice.delta.reasoning {
    if !reasoning.is_empty() {   // ← 新增，与 content 分支对齐
        // ... 原有 block 切换 + thinking_delta 逻辑
    }
}
```

### 复现数据

来自 #2200 评论中 `@SimonWicre` 贴的 ModelScope DeepSeek-V4-Pro 流式原始返回（节选）：

思考阶段（`reasoning_content` 有值，`content` 为空）：
```json
{"delta":{"role":"assistant","content":"","reasoning_content":"嗯"}}
{"delta":{"content":"","reasoning_content":"，用户只发了你好"}}
```

正文阶段（`reasoning_content` 为空字符串，`content` 有值）——触发 bug：
```json
{"delta":{"content":"你好！","reasoning_content":""}}
{"delta":{"content":"很高兴见到你～","reasoning_content":""}}
```

### 测试

新增回归测试 `test_empty_reasoning_content_does_not_cause_per_token_block_switching`，用上述数据流特征构造输入，断言：
- 正文阶段只启动一个 text block（不被逐字切碎）
- 思考阶段只启动一个 thinking block
- 正文完整拼接 `你好！很高兴见到你，有什么可以帮你的吗？`

全部 63 个 streaming 测试通过。

### Checklist

- [x] `cargo test` passes
- [ ] `cargo clippy` passes
- [ ] `pnpm typecheck` passes
