### PR TITLE
fix(codex): add managed config instructions

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -13,6 +13,17 @@ use toml_edit::DocumentMut;
 
 pub const CC_SWITCH_CODEX_MODEL_PROVIDER_ID: &str = "custom";
 pub const CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME: &str = "cc-switch-model-catalog.json";
+const CC_SWITCH_CODEX_CONFIG_HEADER_START: &str = "# [CC Switch Codex Config Instructions]";
+const CC_SWITCH_CODEX_CONFIG_HEADER_END: &str = "# [End CC Switch Codex Config Instructions]";
+const CC_SWITCH_CODEX_CONFIG_HEADER_BODY: &str = r#"# This config file is managed by CC Switch.
+# When modifying existing settings, confirm whether the changes should also be synced to CC Switch Common Config.
+# When adding new settings, confirm whether they should also be added to CC Switch Common Config.
+# If you are an AI agent asked to modify this config, stop and ask the user before changing it.
+# Learn how CC Switch Common Config works:
+# https://github.com/farion1231/cc-switch/blob/main/docs/release-notes/v3.12.0-en.md#common-config-runtime-overlay
+# If the user allows you to modify CC Switch config, follow:
+# https://github.com/farion1231/cc-switch/blob/main/docs/user-manual/en/5-faq/5.1-config-files.md
+"#;
 
 /// Top-level `config.toml` key that controls Codex's built-in web-search tool.
 const CODEX_WEB_SEARCH_FIELD: &str = "web_search";
@@ -224,6 +235,7 @@ pub fn write_codex_live_atomic(
     write_json_file(&auth_path, auth)?;
 
     // 第二步：写 config.toml（失败则回滚 auth.json）
+    let cfg_text = with_codex_config_header(&cfg_text);
     if let Err(e) = write_text_file(&config_path, &cfg_text) {
         // 回滚 auth.json
         if let Some(bytes) = old_auth {
@@ -235,6 +247,49 @@ pub fn write_codex_live_atomic(
     }
 
     Ok(())
+}
+
+fn strip_codex_config_header(config_text: &str) -> String {
+    let Some(start) = config_text.find(CC_SWITCH_CODEX_CONFIG_HEADER_START) else {
+        return config_text.to_string();
+    };
+    let Some(end_offset) = config_text[start..].find(CC_SWITCH_CODEX_CONFIG_HEADER_END) else {
+        return config_text.to_string();
+    };
+
+    let mut end = start + end_offset + CC_SWITCH_CODEX_CONFIG_HEADER_END.len();
+    if config_text[end..].starts_with("\r\n") {
+        end += 2;
+    } else if config_text[end..].starts_with('\n') {
+        end += 1;
+    }
+
+    let before = config_text[..start].trim_end();
+    let after = config_text[end..].trim_start_matches(['\r', '\n']);
+
+    match (before.is_empty(), after.is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => after.to_string(),
+        (false, true) => format!("{before}\n"),
+        (false, false) => format!("{before}\n{after}"),
+    }
+}
+
+fn codex_config_header() -> String {
+    format!(
+        "{CC_SWITCH_CODEX_CONFIG_HEADER_START}\n{CC_SWITCH_CODEX_CONFIG_HEADER_BODY}{CC_SWITCH_CODEX_CONFIG_HEADER_END}\n"
+    )
+}
+
+fn with_codex_config_header(config_text: &str) -> String {
+    if config_text.trim().is_empty() {
+        return String::new();
+    }
+    let config_text = strip_codex_config_header(config_text);
+    if config_text.trim().is_empty() {
+        return String::new();
+    }
+    format!("{}\n{config_text}", codex_config_header())
 }
 
 /// 读取 `~/.codex/config.toml`，若不存在返回空字符串
@@ -259,7 +314,7 @@ pub fn validate_config_toml(text: &str) -> Result<(), AppError> {
 
 /// 读取并校验 `~/.codex/config.toml`，返回文本（可能为空）
 pub fn read_and_validate_codex_config_text() -> Result<String, AppError> {
-    let s = read_codex_config_text()?;
+    let s = strip_codex_config_header(&read_codex_config_text()?);
     validate_config_toml(&s)?;
     Ok(s)
 }
@@ -296,6 +351,7 @@ pub fn write_codex_live_config_atomic(config_text_opt: Option<&str>) -> Result<(
         toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;
     }
 
+    let cfg_text = with_codex_config_header(&cfg_text);
     write_text_file(&config_path, &cfg_text)
 }
 
@@ -2981,5 +3037,24 @@ model_catalog_json = "cc-switch-model-catalog.json"
             parsed.get("model_catalog_json").is_none(),
             "None arm should remove relative cc-switch-owned field"
         );
+    }
+
+    #[test]
+    fn codex_config_header_warns_about_common_config_sync_once() {
+        let input = "model = \"gpt-5\"\n";
+        let header = codex_config_header();
+        let once = with_codex_config_header(input);
+        let twice = with_codex_config_header(&once);
+        let edited_notice = format!(
+            "{CC_SWITCH_CODEX_CONFIG_HEADER_START}\n# user edited this notice\n{CC_SWITCH_CODEX_CONFIG_HEADER_END}\n\n{input}"
+        );
+
+        assert_eq!(once, twice);
+        assert!(once.starts_with(&header));
+        assert!(once.contains(CC_SWITCH_CODEX_CONFIG_HEADER_START));
+        assert!(once.contains(CC_SWITCH_CODEX_CONFIG_HEADER_END));
+        assert_eq!(once.matches(header.as_str()).count(), 1);
+        assert!(once.ends_with(input));
+        assert_eq!(strip_codex_config_header(&edited_notice), input);
     }
 }

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -338,8 +338,7 @@ pub fn sync_enabled_to_codex(config: &MultiAppConfig) -> Result<(), AppError> {
 
     // 6) 写回（仅改 TOML，不触碰 auth.json）；toml_edit 会尽量保留未改区域的注释/空白/顺序
     let new_text = doc.to_string();
-    let path = crate::codex_config::get_codex_config_path();
-    crate::config::write_text_file(&path, &new_text)?;
+    crate::codex_config::write_codex_live_config_atomic(Some(&new_text))?;
     Ok(())
 }
 
@@ -396,7 +395,7 @@ pub fn sync_single_server_to_codex(
 
     // 写回文件
     let new_text = doc.to_string();
-    crate::config::write_text_file(&config_path, &new_text)?;
+    crate::codex_config::write_codex_live_config_atomic(Some(&new_text))?;
 
     Ok(())
 }
@@ -441,7 +440,7 @@ pub fn remove_server_from_codex(id: &str) -> Result<(), AppError> {
 
     // 写回文件
     let new_text = doc.to_string();
-    crate::config::write_text_file(&config_path, &new_text)?;
+    crate::codex_config::write_codex_live_config_atomic(Some(&new_text))?;
 
     Ok(())
 }
@@ -677,4 +676,67 @@ fn json_server_to_toml_table(spec: &Value) -> Result<toml_edit::Table, AppError>
     }
 
     Ok(t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::collections::HashMap;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &std::path::Path) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn sync_enabled_to_codex_preserves_managed_header() {
+        let temp_home = tempfile::tempdir().expect("create temp home");
+        let _home = EnvVarGuard::set("CC_SWITCH_TEST_HOME", temp_home.path());
+        let codex_dir = crate::codex_config::get_codex_config_dir();
+        std::fs::create_dir_all(&codex_dir).expect("create codex dir");
+        crate::codex_config::write_codex_live_config_atomic(Some("model = \"gpt-5\"\n"))
+            .expect("write codex config");
+
+        let mut config = MultiAppConfig::default();
+        let mut servers = HashMap::new();
+        servers.insert(
+            "local".to_string(),
+            json!({
+                "enabled": true,
+                "server": {
+                    "type": "stdio",
+                    "command": "node"
+                }
+            }),
+        );
+        config.mcp.codex = McpConfig { servers };
+
+        sync_enabled_to_codex(&config).expect("sync codex mcp");
+
+        let text = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read codex config");
+        assert!(text.starts_with("# [CC Switch Codex Config Instructions]"));
+        assert!(text.contains("model = \"gpt-5\""));
+        assert!(text.contains("[mcp_servers.local]"));
+    }
 }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -701,7 +701,7 @@ impl LiveSnapshot {
                 }
 
                 if let Some(text) = config {
-                    crate::config::write_text_file(&config_path, text)?;
+                    crate::codex_config::write_codex_live_config_atomic(Some(text))?;
                 } else if config_path.exists() {
                     delete_file(&config_path)?;
                 }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2464,7 +2464,7 @@ impl ProxyService {
     }
 
     fn write_codex_live_verbatim(&self, config: &Value) -> Result<(), String> {
-        use crate::codex_config::{get_codex_auth_path, get_codex_config_path};
+        use crate::codex_config::get_codex_auth_path;
 
         let auth = config.get("auth");
         let config_str = config.get("config").and_then(|v| v.as_str());
@@ -2504,8 +2504,7 @@ impl ProxyService {
                 let auth_path = get_codex_auth_path();
                 if auth.as_object().is_some_and(|obj| obj.is_empty()) {
                     let _ = crate::config::delete_file(&auth_path);
-                    let config_path = get_codex_config_path();
-                    crate::config::write_text_file(&config_path, cfg)
+                    crate::codex_config::write_codex_live_config_atomic(Some(cfg))
                         .map_err(|e| format!("写入 Codex config 失败: {e}"))?;
                 } else {
                     crate::codex_config::write_codex_live_atomic(auth, Some(cfg))
@@ -2518,8 +2517,7 @@ impl ProxyService {
                     .map_err(|e| format!("写入 Codex auth 失败: {e}"))?;
             }
             (None, Some(cfg)) => {
-                let config_path = get_codex_config_path();
-                crate::config::write_text_file(&config_path, cfg)
+                crate::codex_config::write_codex_live_config_atomic(Some(cfg))
                     .map_err(|e| format!("写入 Codex config 失败: {e}"))?;
             }
             (None, None) => {}
@@ -5881,6 +5879,10 @@ requires_openai_auth = true
 
         let restored = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
             .expect("read restored config.toml");
+        assert!(
+            restored.starts_with("# [CC Switch Codex Config Instructions]"),
+            "empty-auth restore must preserve the managed config header"
+        );
         assert!(
             restored.contains("model_catalog_json"),
             "empty-auth restore must still project the inline catalog pointer, got:\n{restored}"


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

很多场景下用户会通过 Agent 修改 Codex 的配置文件，如果用户同时使用了 CC-Switch，那么 CC-Switch 的配置文件同步规则对 Agent 来说实际上是不可见的。

这就会导致：
1. Agent 修改了配置文件，但是没有同步修改 CC-Switch 维护的 Common Config。
2. Agent 添加了新的配置，但是因为配置没有添加到 CC-Switch 维护的 Common Config，在切换供应商时发生配置丢失。

这个 PR 提供了一个实验性的办法：在 CC-Switch 写入 Codex 配置的时候在配置文件头部加入一段注释：

```toml
# [CC Switch Codex Config Instructions]
# This config file is managed by CC Switch.
# When modifying existing settings, confirm whether the changes should also be synced to CC Switch Common Config.
# When adding new settings, confirm whether they should also be added to CC Switch Common Config.
# If you are an AI agent asked to modify this config, stop and ask the user before changing it.
# Learn how CC Switch Common Config works:
# https://github.com/farion1231/cc-switch/blob/main/docs/release-notes/v3.12.0-en.md#common-config-runtime-overlay
# If the user allows you to modify CC Switch config, follow:
# https://github.com/farion1231/cc-switch/blob/main/docs/user-manual/en/5-faq/5.1-config-files.md
# [End CC Switch Codex Config Instructions]
```

修改后的 `config.toml` 会变成：

```toml
# [CC Switch Codex Config Instructions]
# This config file is managed by CC Switch.
# When modifying existing settings, confirm whether the changes should also be synced to CC Switch Common Config.
# When adding new settings, confirm whether they should also be added to CC Switch Common Config.
# If you are an AI agent asked to modify this config, stop and ask the user before changing it.
# Learn how CC Switch Common Config works:
# https://github.com/farion1231/cc-switch/blob/main/docs/release-notes/v3.12.0-en.md#common-config-runtime-overlay
# If the user allows you to modify CC Switch config, follow:
# https://github.com/farion1231/cc-switch/blob/main/docs/user-manual/en/5-faq/5.1-config-files.md
# [End CC Switch Codex Config Instructions]

model_provider = "custom"
model = "gpt-5"
```

以此解决 CC-Switch 对 Agent 的可见性问题。

当然解决这个问题的方案还有很多，例如

1. 在 `config.toml` 里面维护一个 common config 区，在 CC-Switch 每次切换的时候都对修改或者新增的 common config 进行反向同步。
2. 在 `config.toml` 的同目录加入 `AGENTS.md`，在这个文件内写 Instruction。

这个方案则是选择了一个较为简单的方式。

另外因为注释是直接写到 `config.toml` 里面的，在这里做 i18n 会引入一些不必要的问题，因此没有实现。

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Ref #2296

## Screenshots / 截图

在 Harness 为 codex，LLM 选择 gpt-5.4(medium) 以及 deepseek-v4-pro 的测试环境中，Agent 均能正常注意到 cc-switch 对 `config.toml` 的管理：

### Deepseek V4 Pro

<img width="1024" height="532" alt="image" src="https://github.com/user-attachments/assets/cb54b3f1-1788-4054-a3a1-2def1c11eeae" />


### GPT-5.4 Medium

<img width="982" height="592" alt="image" src="https://github.com/user-attachments/assets/3ada7150-e69d-49f8-8982-82b623a0843a" />

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
