### PR TITLE
fix(opencode): 补充 SiliconFlow 供应商渠道

### DIFF
--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -1191,6 +1191,64 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     },
   },
   {
+    name: "SiliconFlow",
+    websiteUrl: "https://siliconflow.cn",
+    apiKeyUrl: "https://cloud.siliconflow.cn/i/YflgU2Ve",
+    settingsConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "SiliconFlow",
+      options: {
+        baseURL: "https://api.siliconflow.cn/v1",
+        apiKey: "",
+        setCacheKey: true,
+      },
+      models: {
+        "Pro/MiniMaxAI/MiniMax-M2.7": { name: "Pro / MiniMax M2.7" },
+      },
+    },
+    category: "aggregator",
+    isPartner: true,
+    partnerPromotionKey: "siliconflow",
+    icon: "siliconflow",
+    iconColor: "#6E29F6",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "sk-...",
+        editorValue: "",
+      },
+    },
+  },
+  {
+    name: "SiliconFlow en",
+    websiteUrl: "https://siliconflow.com",
+    apiKeyUrl: "https://cloud.siliconflow.cn/i/YflgU2Ve",
+    settingsConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "SiliconFlow en",
+      options: {
+        baseURL: "https://api.siliconflow.com/v1",
+        apiKey: "",
+        setCacheKey: true,
+      },
+      models: {
+        "MiniMaxAI/MiniMax-M2.7": { name: "MiniMax M2.7" },
+      },
+    },
+    category: "aggregator",
+    isPartner: true,
+    partnerPromotionKey: "siliconflow",
+    icon: "siliconflow",
+    iconColor: "#000000",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "sk-...",
+        editorValue: "",
+      },
+    },
+  },
+  {
     name: "AiHubMix",
     websiteUrl: "https://aihubmix.com",
     apiKeyUrl: "https://aihubmix.com",

--- a/tests/config/opencodeProviderPresets.test.ts
+++ b/tests/config/opencodeProviderPresets.test.ts
@@ -92,4 +92,33 @@ describe("AWS Bedrock OpenCode Provider Presets", () => {
       });
     }
   });
+
+  it("SiliconFlow presets should be available for OpenCode", () => {
+    const expectedPresets = [
+      {
+        name: "SiliconFlow",
+        baseURL: "https://api.siliconflow.cn/v1",
+        modelId: "Pro/MiniMaxAI/MiniMax-M2.7",
+      },
+      {
+        name: "SiliconFlow en",
+        baseURL: "https://api.siliconflow.com/v1",
+        modelId: "MiniMaxAI/MiniMax-M2.7",
+      },
+    ];
+
+    for (const expected of expectedPresets) {
+      const preset = opencodeProviderPresets.find(
+        (candidate) => candidate.name === expected.name,
+      );
+
+      expect(preset).toBeDefined();
+      expect(preset!.settingsConfig.npm).toBe("@ai-sdk/openai-compatible");
+      expect(preset!.settingsConfig.options.baseURL).toBe(expected.baseURL);
+      expect(preset!.settingsConfig.models).toHaveProperty(expected.modelId);
+      expect(preset!.category).toBe("aggregator");
+      expect(preset!.partnerPromotionKey).toBe("siliconflow");
+      expect(preset!.icon).toBe("siliconflow");
+    }
+  });
 });


### PR DESCRIPTION
## Summary / 概述

补充 OpenCode 的 SiliconFlow / SiliconFlow en 供应商预设。

当前 Claude Code、Claude Desktop、Codex、OpenClaw 和 Hermes 已经提供 SiliconFlow 预设，但 OpenCode 的新建供应商列表中缺少对应项。OpenCode 支持 OpenAI-compatible provider，因此本 PR 按 OpenCode 的 provider schema 增加两条预设，避免用户手动填写 baseURL、模型 ID 和 API Key 字段。

本次改动仅影响 OpenCode 新建供应商时的预设列表，不涉及路由、后端代理或其他客户端的配置逻辑。

## Related Issue / 关联 Issue

Fixes #4500

## Screenshots / 截图

可见缺失SiliconFlow供应商
<img width="980" height="697" alt="1782917454170_d" src="https://github.com/user-attachments/assets/dbc5539f-6a14-478e-a197-8eed707015c1" />

## Verification / 验证

- `pnpm exec vitest run tests/config/opencodeProviderPresets.test.ts`
- `pnpm typecheck`
- `pnpm format:check`
- `git diff --check`

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] 未修改 Rust 代码，`cargo clippy` 不适用
- [x] 未新增需要翻译的界面文案