### PR TITLE
fix(sessions): update OpenCode resume command to new -s flag

### DIFF
--- a/src-tauri/src/session_manager/providers/opencode.rs
+++ b/src-tauri/src/session_manager/providers/opencode.rs
@@ -149,7 +149,7 @@ fn scan_sessions_sqlite() -> Vec<SessionMeta> {
             created_at: Some(created),
             last_active_at: Some(updated),
             source_path: Some(format!("sqlite:{db_display}:{session_id}")),
-            resume_command: Some(format!("opencode session resume {session_id}")),
+            resume_command: Some(format!("opencode -s {session_id}")),
         });
     }
     sessions
@@ -473,7 +473,7 @@ fn parse_session(storage: &Path, path: &Path) -> Option<SessionMeta> {
         created_at,
         last_active_at: updated_at.or(created_at),
         source_path: Some(source_path),
-        resume_command: Some(format!("opencode session resume {session_id}")),
+        resume_command: Some(format!("opencode -s {session_id}")),
     })
 }
 


### PR DESCRIPTION
## Summary / 概述

Update the OpenCode session resume command from the removed `opencode session resume <id>` subcommand to the new top-level `opencode -s <id>` flag, so the Session Manager's "Resume" button works again with current OpenCode CLI.

Upstream opencode CLI (commit `2324a63fc` — "feat(cli): add session resume flags") promoted `-s`/`--session` and `-c`/`--continue` from the `run` subcommand to top-level flags. The old `opencode session resume <id>` / `opencode run -s <id>` forms no longer work.

Two identical `resume_command` builders in `src-tauri/src/session_manager/providers/opencode.rs` (SQLite backend + JSON backend) are updated. The frontend renders and executes `resumeCommand` as-is, so no frontend change is needed.

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

N/A — backend string change, no visual diff. Resume command preview in Session Manager now shows `opencode -s ses_xxx` instead of the broken `opencode session resume ses_xxx`.

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| `opencode session resume ses_xxx` (fails: unknown subcommand) | `opencode -s ses_xxx` (works) |

## Checklist / 检查清单
- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查 (no frontend change)
- [x] `pnpm format:check` passes / 通过代码格式检查 (no frontend change)
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）(no new warnings in touched file)
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 (no text change, command is generated)

## Reference / 参考

Upstream change: `2324a63fc` — feat(cli): add session resume flags

| Before (old CLI) | Now (new CLI v2) |
|---|---|
| `opencode run -s <id>` | `opencode -s <id>` |
| `opencode run --continue` | `opencode -c` |
| `opencode run --fork` | `opencode --fork` |
