### PR TITLE
feat(provider): AiHubMix inferera backup endpoint + default/backup hint

### DIFF
--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -360,6 +360,13 @@ export function ClaudeDesktopProviderForm({
     [],
   );
 
+  // AiHubMix 等预设可自定义端点提示，覆盖表单默认提示；未设置则为 undefined
+  const endpointHint = useMemo<string | undefined>(() => {
+    const entry = presetEntries.find((e) => e.id === selectedPresetId);
+    return (entry?.preset as { endpointHint?: string } | undefined)
+      ?.endpointHint;
+  }, [presetEntries, selectedPresetId]);
+
   const presetCategoryLabels: Record<string, string> = useMemo(
     () => ({
       official: t("providerForm.categoryOfficial", { defaultValue: "官方" }),
@@ -801,13 +808,14 @@ export function ClaudeDesktopProviderForm({
               onChange={(v) => setBaseUrl(v)}
               placeholder={t("providerForm.apiEndpointPlaceholder")}
               hint={
-                needsModelMapping && apiFormat === "openai_responses"
+                endpointHint ??
+                (needsModelMapping && apiFormat === "openai_responses"
                   ? t("providerForm.apiHintResponses")
                   : needsModelMapping && apiFormat === "openai_chat"
                     ? t("providerForm.apiHintOAI")
                     : needsModelMapping && apiFormat === "gemini_native"
                       ? t("providerForm.apiHintGeminiNative")
-                      : t("providerForm.apiHint")
+                      : t("providerForm.apiHint"))
               }
               showManageButton={false}
             />

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -114,6 +114,8 @@ interface ClaudeFormFieldsProps {
   autoSelect: boolean;
   onAutoSelectChange: (checked: boolean) => void;
   showEndpointTools?: boolean;
+  /** 覆盖端点输入框下方的提示文案（仅特定预设，如 AiHubMix） */
+  endpointHint?: string;
 
   // Model Selector
   shouldShowModelSelector: boolean;
@@ -186,6 +188,7 @@ export function ClaudeFormFields({
   autoSelect,
   onAutoSelectChange,
   showEndpointTools = true,
+  endpointHint,
   shouldShowModelSelector,
   claudeModel,
   defaultHaikuModel,
@@ -662,13 +665,14 @@ export function ClaudeFormFields({
           onChange={onBaseUrlChange}
           placeholder={t("providerForm.apiEndpointPlaceholder")}
           hint={
-            apiFormat === "openai_responses"
+            endpointHint ??
+            (apiFormat === "openai_responses"
               ? t("providerForm.apiHintResponses")
               : apiFormat === "openai_chat"
                 ? t("providerForm.apiHintOAI")
                 : apiFormat === "gemini_native"
                   ? t("providerForm.apiHintGeminiNative")
-                  : t("providerForm.apiHint")
+                  : t("providerForm.apiHint"))
           }
           fullUrlHint={
             apiFormat === "gemini_native"

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -61,6 +61,8 @@ interface CodexFormFieldsProps {
   shouldShowSpeedTest: boolean;
   codexBaseUrl: string;
   onBaseUrlChange: (url: string) => void;
+  /** 覆盖端点输入框下方的提示文案（仅特定预设，如 AiHubMix） */
+  endpointHint?: string;
   isFullUrl: boolean;
   onFullUrlChange: (value: boolean) => void;
   isEndpointModalOpen: boolean;
@@ -149,6 +151,7 @@ export function CodexFormFields({
   shouldShowSpeedTest,
   codexBaseUrl,
   onBaseUrlChange,
+  endpointHint,
   isFullUrl,
   onFullUrlChange,
   isEndpointModalOpen,
@@ -375,7 +378,7 @@ export function CodexFormFields({
           value={codexBaseUrl}
           onChange={onBaseUrlChange}
           placeholder={t("providerForm.codexApiEndpointPlaceholder")}
-          hint={t("providerForm.codexApiHint")}
+          hint={endpointHint ?? t("providerForm.codexApiHint")}
           showFullUrlToggle
           isFullUrl={isFullUrl}
           onFullUrlChange={onFullUrlChange}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -688,6 +688,13 @@ function ProviderFormFull({
       }));
   }, [appId]);
 
+  // 预设可自定义端点提示（endpointHint），覆盖表单默认提示；未设置则为 undefined，走原文案
+  const selectedEndpointHint = useMemo<string | undefined>(() => {
+    const entry = presetEntries.find((e) => e.id === selectedPresetId);
+    return (entry?.preset as { endpointHint?: string } | undefined)
+      ?.endpointHint;
+  }, [presetEntries, selectedPresetId]);
+
   const {
     templateValues,
     templateValueEntries,
@@ -2037,6 +2044,7 @@ function ProviderFormFull({
           {appId === "claude" && (
             <ClaudeFormFields
               providerId={providerId}
+              endpointHint={selectedEndpointHint}
               shouldShowApiKey={
                 (category !== "cloud_provider" ||
                   hasApiKeyField(form.getValues("settingsConfig"), "claude")) &&
@@ -2119,6 +2127,7 @@ function ProviderFormFull({
           {appId === "codex" && (
             <CodexFormFields
               providerId={providerId}
+              endpointHint={selectedEndpointHint}
               codexApiKey={codexApiKey}
               onApiKeyChange={handleCodexApiKeyChange}
               category={category}

--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -60,6 +60,8 @@ export interface ClaudeDesktopProviderPreset {
   requiresOAuth?: boolean;
 
   endpointCandidates?: string[];
+  // 端点输入框下方的提示文案覆盖（仅设置的预设生效；未设置则用表单默认提示）
+  endpointHint?: string;
   theme?: PresetTheme;
   icon?: string;
   iconColor?: string;
@@ -638,7 +640,14 @@ export const claudeDesktopProviderPresets: ClaudeDesktopProviderPreset[] = [
     mode: "direct",
     apiFormat: "anthropic",
     modelRoutes: passthroughRoutes(),
-    endpointCandidates: ["https://aihubmix.com", "https://api.aihubmix.com"],
+    // 默认 aihubmix.com，api.inferera.com 作备用网关（同后端、同 Key）
+    endpointCandidates: [
+      "https://aihubmix.com",
+      "https://api.aihubmix.com",
+      "https://api.inferera.com",
+    ],
+    endpointHint:
+      "💡 aihubmix.com 为默认端点，api.inferera.com 为备用网关（同一后端、Key 通用）",
     icon: "aihubmix",
     iconColor: "#006FFB",
   },

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -40,6 +40,8 @@ export interface ProviderPreset {
   templateValues?: Record<string, TemplateValueConfig>; // editorValue 存储编辑器中的实时输入值
   // 新增：请求地址候选列表（用于地址管理/测速）
   endpointCandidates?: string[];
+  // 端点输入框下方的提示文案覆盖（仅设置的预设生效；未设置则用表单默认提示）
+  endpointHint?: string;
   // 新增：视觉主题配置
   theme?: PresetTheme;
   // 图标配置
@@ -676,9 +678,15 @@ export const providerPresets: ProviderPreset[] = [
         ANTHROPIC_API_KEY: "",
       },
     },
-    // 请求地址候选（用于地址管理/测速），用户可自行选择/覆盖
-    endpointCandidates: ["https://aihubmix.com", "https://api.aihubmix.com"],
+    // 请求地址候选（用于地址管理/测速）：默认 aihubmix.com，api.inferera.com 作备用网关（同后端、同 Key）
+    endpointCandidates: [
+      "https://aihubmix.com",
+      "https://api.aihubmix.com",
+      "https://api.inferera.com",
+    ],
     category: "aggregator",
+    endpointHint:
+      "💡 aihubmix.com 为默认端点，api.inferera.com 为备用网关（同一后端、Key 通用）",
     icon: "aihubmix",
     iconColor: "#006FFB",
   },

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -25,6 +25,8 @@ export interface CodexProviderPreset {
   isCustomTemplate?: boolean; // 标识是否为自定义模板
   // 新增：请求地址候选列表（用于地址管理/测速）
   endpointCandidates?: string[];
+  // 端点输入框下方的提示文案覆盖（仅设置的预设生效；未设置则用表单默认提示）
+  endpointHint?: string;
   // 新增：视觉主题配置
   theme?: PresetTheme;
   // 图标配置
@@ -1059,10 +1061,14 @@ requires_openai_auth = true`,
       "https://aihubmix.com/v1",
       "gpt-5.5",
     ),
+    // 默认 aihubmix.com，api.inferera.com 作备用网关（同后端、同 Key）
     endpointCandidates: [
       "https://aihubmix.com/v1",
       "https://api.aihubmix.com/v1",
+      "https://api.inferera.com/v1",
     ],
+    endpointHint:
+      "💡 aihubmix.com 为默认端点，api.inferera.com 为备用网关（同一后端、Key 通用）",
   },
   {
     name: "CherryIN",


### PR DESCRIPTION
## Changes

1. **Backup endpoint** — append `https://api.inferera.com` (`…/v1` for Codex) as the last `endpointCandidates` entry of the built-in **AiHubMix** preset in Claude Code, Claude Desktop and Codex. The default endpoint stays `aihubmix.com`; provider name, website, API-key link and icon are unchanged. (`api.inferera.com` is AiHubMix's alternate gateway — same backend and same API key.)

2. **Per-preset endpoint hint** — add an optional `endpointHint?: string` to the Claude / Claude Desktop / Codex preset types; those forms now render `preset.endpointHint ?? <default hint>`. It is set on the AiHubMix preset. Any preset that does not set `endpointHint` keeps the default hint, so no other provider is affected.

## Verification

- `pnpm typecheck` — passes
- `pnpm test:unit` — passes
- `api.inferera.com` reachable with the same key as aihubmix.com: `GET /v1/models`, `POST /v1/chat/completions`, `POST /v1/messages` all return `200`
- Built and ran the desktop app (`pnpm tauri dev`): AiHubMix shows `aihubmix.com` as the default with `api.inferera.com` as a backup and the custom hint; other providers keep their default hint
