### PR TITLE
Add Codex image generation handling modes

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1147,6 +1147,7 @@ pub fn prepare_codex_live_config_text_with_optional_catalog(
 
 pub fn write_codex_provider_live_with_catalog(
     settings: &Value,
+    provider_meta: Option<&crate::provider::ProviderMeta>,
     category: Option<&str>,
     auth: &Value,
     config_text: Option<&str>,
@@ -1154,9 +1155,79 @@ pub fn write_codex_provider_live_with_catalog(
 ) -> Result<(), AppError> {
     let prepared_config = config_text
         .map(|text| prepare_codex_config_text_with_model_catalog(settings, text, profile))
+        .map(|result| {
+            result.and_then(|text| {
+                apply_codex_provider_feature_overrides(settings, provider_meta, &text)
+            })
+        })
         .transpose()?;
 
     write_codex_live_for_provider(category, auth, prepared_config.as_deref())
+}
+
+fn apply_codex_provider_feature_overrides(
+    settings: &Value,
+    provider_meta: Option<&crate::provider::ProviderMeta>,
+    config_text: &str,
+) -> Result<String, AppError> {
+    let image_generation_mode = provider_meta
+        .and_then(|meta| meta.codex_image_generation_mode.as_deref())
+        .or_else(|| {
+            settings
+                .get("meta")
+                .and_then(|meta| meta.get("codexImageGenerationMode"))
+                .and_then(Value::as_str)
+        })
+        .map(normalize_codex_image_generation_mode);
+    if let Some(mode) = image_generation_mode {
+        return set_codex_feature_bool(
+            config_text,
+            "image_generation",
+            !matches!(mode.as_str(), "disabled"),
+        );
+    }
+
+    let supports_image_generation = provider_meta
+        .and_then(|meta| meta.supports_image_generation)
+        .or_else(|| {
+            settings
+                .get("meta")
+                .and_then(|meta| meta.get("supportsImageGeneration"))
+                .and_then(Value::as_bool)
+        });
+    match supports_image_generation {
+        Some(enabled) => set_codex_feature_bool(config_text, "image_generation", enabled),
+        None => Ok(config_text.to_string()),
+    }
+}
+
+fn normalize_codex_image_generation_mode(value: &str) -> String {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "disabled" | "all" | "off" | "disable" => "disabled".to_string(),
+        "chat" | "chat_only" | "chat-only" => "chat".to_string(),
+        "passthrough" | "pass_through" | "pass-through" => "passthrough".to_string(),
+        _ => "enabled".to_string(),
+    }
+}
+
+fn set_codex_feature_bool(
+    config_text: &str,
+    feature: &str,
+    enabled: bool,
+) -> Result<String, AppError> {
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+
+    if doc
+        .get("features")
+        .and_then(|item| item.as_table())
+        .is_none()
+    {
+        doc["features"] = toml_edit::table();
+    }
+    doc["features"][feature] = toml_edit::value(enabled);
+    Ok(doc.to_string())
 }
 
 /// Extract a provider-scoped `experimental_bearer_token` from Codex `config.toml`.

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -478,6 +478,25 @@ pub struct ProviderMeta {
     /// Codex Responses -> Chat Completions reasoning capability metadata.
     #[serde(rename = "codexChatReasoning", skip_serializing_if = "Option::is_none")]
     pub codex_chat_reasoning: Option<CodexChatReasoningConfig>,
+    /// Legacy boolean for Codex image generation support.
+    #[serde(
+        rename = "supportsImageGeneration",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub supports_image_generation: Option<bool>,
+    /// Codex image generation handling mode.
+    ///
+    /// Values mirror CLIProxyAPI's disable-image-generation modes:
+    /// - enabled: enable image_generation everywhere
+    /// - disabled: disable image_generation everywhere
+    /// - chat: keep the Codex feature enabled, but strip image_generation from
+    ///   non-image chat endpoints
+    /// - passthrough: keep Codex feature enabled and never strip client payloads
+    #[serde(
+        rename = "codexImageGenerationMode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub codex_image_generation_mode: Option<String>,
     /// Custom User-Agent for local proxy routing.
     #[serde(rename = "customUserAgent", skip_serializing_if = "Option::is_none")]
     pub custom_user_agent: Option<String>,
@@ -983,6 +1002,42 @@ mod tests {
         let value = serde_json::to_value(&meta).expect("serialize ProviderMeta");
 
         assert!(value.get("pricingModelSource").is_none());
+    }
+
+    #[test]
+    fn provider_meta_serializes_codex_image_generation_support() {
+        let meta = ProviderMeta {
+            supports_image_generation: Some(false),
+            ..ProviderMeta::default()
+        };
+
+        let value = serde_json::to_value(&meta).expect("serialize ProviderMeta");
+
+        assert_eq!(
+            value
+                .get("supportsImageGeneration")
+                .and_then(|item| item.as_bool()),
+            Some(false)
+        );
+        assert!(value.get("supports_image_generation").is_none());
+    }
+
+    #[test]
+    fn provider_meta_serializes_codex_image_generation_mode() {
+        let meta = ProviderMeta {
+            codex_image_generation_mode: Some("chat".to_string()),
+            ..ProviderMeta::default()
+        };
+
+        let value = serde_json::to_value(&meta).expect("serialize ProviderMeta");
+
+        assert_eq!(
+            value
+                .get("codexImageGenerationMode")
+                .and_then(|item| item.as_str()),
+            Some("chat")
+        );
+        assert!(value.get("codex_image_generation_mode").is_none());
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1386,6 +1386,11 @@ impl RequestForwarder {
 
         if matches!(app_type, AppType::Codex) {
             self.apply_media_prevention(&mut request_body, provider);
+            suppress_codex_image_generation_for_provider(
+                provider,
+                &effective_endpoint,
+                &mut request_body,
+            );
         }
 
         // 过滤私有参数（以 `_` 开头的字段），防止内部信息泄露到上游
@@ -2733,6 +2738,128 @@ fn prepare_upstream_request_body(request_body: Value) -> Value {
     canonicalize_value(filter_private_params_with_whitelist(request_body, &[]))
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CodexImageGenerationMode {
+    Enabled,
+    Disabled,
+    Chat,
+    Passthrough,
+}
+
+fn codex_image_generation_mode_for_provider(provider: &Provider) -> CodexImageGenerationMode {
+    if let Some(mode) = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.codex_image_generation_mode.as_deref())
+    {
+        return match mode.trim().to_ascii_lowercase().as_str() {
+            "true" | "disabled" | "all" | "off" | "disable" => CodexImageGenerationMode::Disabled,
+            "chat" | "chat_only" | "chat-only" => CodexImageGenerationMode::Chat,
+            "passthrough" | "pass_through" | "pass-through" => {
+                CodexImageGenerationMode::Passthrough
+            }
+            _ => CodexImageGenerationMode::Enabled,
+        };
+    }
+
+    if provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.supports_image_generation)
+        == Some(false)
+    {
+        CodexImageGenerationMode::Disabled
+    } else {
+        CodexImageGenerationMode::Enabled
+    }
+}
+
+fn is_codex_images_endpoint(endpoint: &str) -> bool {
+    let path = endpoint.split('?').next().unwrap_or(endpoint).trim();
+    path.ends_with("/images/generations") || path.ends_with("/images/edits")
+}
+
+fn suppress_codex_image_generation_for_provider(
+    provider: &Provider,
+    endpoint: &str,
+    body: &mut Value,
+) {
+    match codex_image_generation_mode_for_provider(provider) {
+        CodexImageGenerationMode::Disabled => strip_codex_image_generation_tools(body),
+        CodexImageGenerationMode::Chat if !is_codex_images_endpoint(endpoint) => {
+            strip_codex_image_generation_tools(body);
+        }
+        CodexImageGenerationMode::Enabled
+        | CodexImageGenerationMode::Chat
+        | CodexImageGenerationMode::Passthrough => {}
+    }
+}
+
+fn strip_codex_image_generation_tools(body: &mut Value) {
+    strip_codex_image_generation_tool_array_field(body, "tools");
+    strip_codex_image_generation_tool_array_field(body, "allowed_tools");
+    strip_codex_image_generation_tool_array_field(body, "allowedTools");
+    strip_codex_image_generation_tool_choice_field(body, "tool_choice");
+    strip_codex_image_generation_tool_choice_field(body, "toolChoice");
+    strip_codex_image_generation_include_field(body);
+}
+
+fn strip_codex_image_generation_tool_array_field(body: &mut Value, field: &str) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    let Some(tools) = obj.get_mut(field).and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    tools.retain(|tool| !value_contains_codex_image_generation_identifier(tool));
+    if tools.is_empty() {
+        obj.remove(field);
+    }
+}
+
+fn strip_codex_image_generation_tool_choice_field(body: &mut Value, field: &str) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    if obj
+        .get(field)
+        .is_some_and(value_contains_codex_image_generation_identifier)
+    {
+        obj.remove(field);
+    }
+}
+
+fn strip_codex_image_generation_include_field(body: &mut Value) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    let Some(include) = obj.get_mut("include").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    include.retain(|item| !value_contains_codex_image_generation_identifier(item));
+    if include.is_empty() {
+        obj.remove("include");
+    }
+}
+
+fn value_contains_codex_image_generation_identifier(value: &Value) -> bool {
+    match value {
+        Value::String(s) => {
+            let normalized = s.trim().to_ascii_lowercase();
+            normalized.contains("image_generation") || normalized.contains("image-generation")
+        }
+        Value::Array(items) => items
+            .iter()
+            .any(value_contains_codex_image_generation_identifier),
+        Value::Object(map) => map
+            .values()
+            .any(value_contains_codex_image_generation_identifier),
+        _ => false,
+    }
+}
+
 fn log_prompt_cache_trace(
     app_type: &AppType,
     provider: &Provider,
@@ -2990,6 +3117,55 @@ mod tests {
             serde_json::to_string(&prepared).unwrap(),
             r#"{"a":2,"tools":[{"name":"lookup","parameters":{"properties":{"_id":{"type":"string"},"a":{"type":"string"},"b":{"type":"number"}},"type":"object"}}],"z":1}"#
         );
+    }
+
+    #[test]
+    fn codex_provider_chat_image_generation_mode_strips_only_chat_endpoints() {
+        let mut provider = test_provider_with_type(None);
+        provider.meta = Some(crate::provider::ProviderMeta {
+            codex_image_generation_mode: Some("chat".to_string()),
+            ..Default::default()
+        });
+        let mut chat_body = json!({
+            "tools": [
+                { "type": "image_generation" },
+                { "type": "function", "name": "lookup" }
+            ],
+            "include": ["image_generation_call.results", "message.output_text"]
+        });
+        let mut image_body = chat_body.clone();
+
+        suppress_codex_image_generation_for_provider(&provider, "/v1/responses", &mut chat_body);
+        suppress_codex_image_generation_for_provider(
+            &provider,
+            "/v1/images/generations",
+            &mut image_body,
+        );
+
+        assert_eq!(
+            chat_body["tools"],
+            json!([{ "type": "function", "name": "lookup" }])
+        );
+        assert_eq!(chat_body["include"], json!(["message.output_text"]));
+        assert_eq!(image_body["tools"][0]["type"], "image_generation");
+    }
+
+    #[test]
+    fn codex_provider_passthrough_image_generation_mode_keeps_chat_payload() {
+        let mut provider = test_provider_with_type(None);
+        provider.meta = Some(crate::provider::ProviderMeta {
+            codex_image_generation_mode: Some("passthrough".to_string()),
+            ..Default::default()
+        });
+        let mut body = json!({
+            "tools": [{ "type": "image_generation" }],
+            "tool_choice": { "type": "image_generation" }
+        });
+        let original = body.clone();
+
+        suppress_codex_image_generation_for_provider(&provider, "/v1/responses", &mut body);
+
+        assert_eq!(body, original);
     }
 
     #[test]

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -165,6 +165,7 @@ impl ConfigService {
 
         crate::codex_config::write_codex_provider_live_with_catalog(
             &provider.settings_config,
+            provider.meta.as_ref(),
             provider.category.as_deref(),
             auth,
             cfg_text,

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -769,6 +769,7 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
 
             crate::codex_config::write_codex_provider_live_with_catalog(
                 &provider.settings_config,
+                provider.meta.as_ref(),
                 provider.category.as_deref(),
                 auth,
                 config_str,

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2151,6 +2151,7 @@ impl ProxyService {
 
             crate::codex_config::write_codex_provider_live_with_catalog(
                 &effective_settings,
+                provider.meta.as_ref(),
                 provider.category.as_deref(),
                 auth,
                 config_str,
@@ -2420,6 +2421,7 @@ impl ProxyService {
 
         crate::codex_config::write_codex_provider_live_with_catalog(
             config,
+            provider.meta.as_ref(),
             provider.category.as_deref(),
             auth,
             config_str,

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -39,6 +39,7 @@ import type {
   CodexApiFormat,
   CodexCatalogModel,
   CodexChatReasoning,
+  CodexImageGenerationMode,
   ProviderCategory,
 } from "@/types";
 
@@ -75,6 +76,8 @@ interface CodexFormFieldsProps {
   onApiFormatChange: (format: CodexApiFormat) => void;
   codexChatReasoning?: CodexChatReasoning;
   onCodexChatReasoningChange?: (value: CodexChatReasoning) => void;
+  imageGenerationMode: CodexImageGenerationMode;
+  onImageGenerationModeChange: (value: CodexImageGenerationMode) => void;
 
   // Model Catalog
   catalogModels?: CodexCatalogModel[];
@@ -160,6 +163,8 @@ export function CodexFormFields({
   onApiFormatChange,
   codexChatReasoning = {},
   onCodexChatReasoningChange,
+  imageGenerationMode,
+  onImageGenerationModeChange,
   catalogModels = [],
   onCatalogModelsChange,
   speedTestEndpoints,
@@ -458,6 +463,63 @@ export function CodexFormFields({
                     })}
                   </p>
                 </div>
+              </div>
+            )}
+
+            {String(category) !== "official" && (
+              <div
+                className={cn(
+                  "flex items-center justify-between gap-4",
+                  shouldShowSpeedTest && "border-t border-border-default pt-3",
+                )}
+              >
+                <div className="space-y-1">
+                  <FormLabel>
+                    {t("codexConfig.imageGenerationToggle", {
+                      defaultValue: "Codex 生图策略",
+                    })}
+                  </FormLabel>
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    {t("codexConfig.imageGenerationHint", {
+                      defaultValue:
+                        "启用会让 Codex 暴露生图工具；仅图片端点会保护普通聊天请求，避免上游因 image_generation 注入返回 403/502。",
+                    })}
+                  </p>
+                </div>
+                <Select
+                  value={imageGenerationMode}
+                  onValueChange={(value) =>
+                    onImageGenerationModeChange(
+                      value as CodexImageGenerationMode,
+                    )
+                  }
+                >
+                  <SelectTrigger className="w-40 shrink-0">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="enabled">
+                      {t("codexConfig.imageGenerationEnabled", {
+                        defaultValue: "启用",
+                      })}
+                    </SelectItem>
+                    <SelectItem value="chat">
+                      {t("codexConfig.imageGenerationChat", {
+                        defaultValue: "仅图片端点",
+                      })}
+                    </SelectItem>
+                    <SelectItem value="passthrough">
+                      {t("codexConfig.imageGenerationPassthrough", {
+                        defaultValue: "透传",
+                      })}
+                    </SelectItem>
+                    <SelectItem value="disabled">
+                      {t("codexConfig.imageGenerationDisabled", {
+                        defaultValue: "关闭全部",
+                      })}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
             )}
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -22,6 +22,7 @@ import type {
   CodexApiFormat,
   CodexCatalogModel,
   CodexChatReasoning,
+  CodexImageGenerationMode,
   ClaudeApiKeyField,
 } from "@/types";
 import {
@@ -130,6 +131,19 @@ type PresetEntry = {
     | OpenClawProviderPreset
     | HermesProviderPreset;
 };
+
+function resolveCodexImageGenerationMode(
+  meta: ProviderMeta | undefined,
+  category: ProviderCategory | undefined,
+): CodexImageGenerationMode {
+  if (meta?.codexImageGenerationMode) {
+    return meta.codexImageGenerationMode;
+  }
+  if (meta?.supportsImageGeneration !== undefined) {
+    return meta.supportsImageGeneration ? "enabled" : "disabled";
+  }
+  return String(category) === "official" ? "enabled" : "disabled";
+}
 
 const codexApiFormatFromWireApi = (
   wireApi: string | undefined,
@@ -310,6 +324,8 @@ function ProviderFormFull({
     isPartner?: boolean;
     partnerPromotionKey?: string;
     suggestedDefaults?: OpenClawSuggestedDefaults;
+    supportsImageGeneration?: boolean;
+    codexImageGenerationMode?: CodexImageGenerationMode;
   } | null>(null);
   const [isEndpointModalOpen, setIsEndpointModalOpen] = useState(false);
   const [isCodexEndpointModalOpen, setIsCodexEndpointModalOpen] =
@@ -379,6 +395,14 @@ function ProviderFormFull({
       ),
     });
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
+    setCodexImageGenerationMode(
+      appId === "codex"
+        ? resolveCodexImageGenerationMode(
+            initialData?.meta,
+            initialData?.category,
+          )
+        : "disabled",
+    );
     setCustomUserAgent(initialData?.meta?.customUserAgent ?? "");
     setLocalProxyHeadersOverride(
       formatRequestOverrideObject(
@@ -549,6 +573,15 @@ function ProviderFormFull({
   const [codexChatReasoning, setCodexChatReasoning] =
     useState<CodexChatReasoning>(
       () => initialData?.meta?.codexChatReasoning ?? {},
+    );
+  const [codexImageGenerationMode, setCodexImageGenerationMode] =
+    useState<CodexImageGenerationMode>(() =>
+      appId === "codex"
+        ? resolveCodexImageGenerationMode(
+            initialData?.meta,
+            initialData?.category,
+          )
+        : "disabled",
     );
   const [customUserAgent, setCustomUserAgent] = useState<string>(
     () => initialData?.meta?.customUserAgent ?? "",
@@ -1475,6 +1508,10 @@ function ProviderFormFull({
         localCodexApiFormat === "openai_chat"
           ? normalizeCodexChatReasoningForSave(codexChatReasoning)
           : undefined,
+      supportsImageGeneration:
+        appId === "codex" ? codexImageGenerationMode !== "disabled" : undefined,
+      codexImageGenerationMode:
+        appId === "codex" ? codexImageGenerationMode : undefined,
       customUserAgent:
         (appId === "claude" || appId === "codex") && category !== "official"
           ? customUserAgent.trim() || undefined
@@ -1620,6 +1657,7 @@ function ProviderFormFull({
         const template = getCodexCustomTemplate();
         resetCodexConfig(template.auth, template.config);
         setCodexChatReasoning({});
+        setCodexImageGenerationMode("disabled");
         setLocalCodexApiFormat(
           codexApiFormatFromWireApi(extractCodexWireApi(template.config)) ??
             "openai_responses",
@@ -1652,6 +1690,14 @@ function ProviderFormFull({
       category: entry.preset.category,
       isPartner: entry.preset.isPartner,
       partnerPromotionKey: entry.preset.partnerPromotionKey,
+      supportsImageGeneration:
+        appId === "codex"
+          ? (entry.preset as CodexProviderPreset).supportsImageGeneration
+          : undefined,
+      codexImageGenerationMode:
+        appId === "codex"
+          ? (entry.preset as CodexProviderPreset).codexImageGenerationMode
+          : undefined,
     });
 
     if (appId === "codex") {
@@ -1661,6 +1707,12 @@ function ProviderFormFull({
 
       resetCodexConfig(auth, config, preset.modelCatalog ?? []);
       setCodexChatReasoning(preset.codexChatReasoning ?? {});
+      setCodexImageGenerationMode(
+        preset.codexImageGenerationMode ??
+          ((preset.supportsImageGeneration ?? preset.isOfficial === true)
+            ? "enabled"
+            : "disabled"),
+      );
       setLocalCodexApiFormat(
         preset.apiFormat ??
           codexApiFormatFromWireApi(extractCodexWireApi(config)) ??
@@ -2142,6 +2194,8 @@ function ProviderFormFull({
               onApiFormatChange={handleCodexApiFormatChange}
               codexChatReasoning={codexChatReasoning}
               onCodexChatReasoningChange={setCodexChatReasoning}
+              imageGenerationMode={codexImageGenerationMode}
+              onImageGenerationModeChange={setCodexImageGenerationMode}
               catalogModels={codexCatalogModels}
               onCatalogModelsChange={setCodexCatalogModels}
               speedTestEndpoints={speedTestEndpoints}

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -6,6 +6,7 @@ import type {
   CodexApiFormat,
   CodexCatalogModel,
   CodexChatReasoning,
+  CodexImageGenerationMode,
 } from "../types";
 import type { PresetTheme } from "./claudeProviderPresets";
 
@@ -36,6 +37,10 @@ export interface CodexProviderPreset {
   modelCatalog?: CodexCatalogModel[];
   // Codex Responses -> Chat Completions reasoning capability defaults
   codexChatReasoning?: CodexChatReasoning;
+  // Whether the upstream provider/group allows Codex image generation
+  supportsImageGeneration?: boolean;
+  // Codex image_generation handling mode
+  codexImageGenerationMode?: CodexImageGenerationMode;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,12 @@ export interface CodexChatReasoning {
   outputFormat?: CodexChatReasoningOutputFormat;
 }
 
+export type CodexImageGenerationMode =
+  | "enabled"
+  | "disabled"
+  | "chat"
+  | "passthrough";
+
 export interface LocalProxyRequestOverrides {
   headers?: Record<string, string>;
   body?: Record<string, unknown>;
@@ -222,6 +228,10 @@ export interface ProviderMeta {
   codexFastMode?: boolean;
   // Codex Responses -> Chat Completions reasoning capability metadata
   codexChatReasoning?: CodexChatReasoning;
+  // Whether the upstream provider/group allows Codex image generation
+  supportsImageGeneration?: boolean;
+  // Codex image_generation handling mode. Overrides supportsImageGeneration when set.
+  codexImageGenerationMode?: CodexImageGenerationMode;
   // Custom User-Agent for local proxy routing. Only applied by the local proxy.
   customUserAgent?: string;
   // Local proxy request overrides. Only applied by the local proxy after route transforms.


### PR DESCRIPTION
## Summary
- add provider-scoped Codex image generation handling modes: enabled, disabled, chat, passthrough
- keep Codex image_generation feature enabled for chat/passthrough while stripping image_generation from non-image endpoints in chat mode
- preserve backward compatibility with supportsImageGeneration metadata

## Notes
- this PR is based on upstream v3.16.5 and intentionally contains only the image generation handling change
- the separate macOS test-build workflow used in the fork is not included

## Validation
- fork CI was iterated through TypeScript, Prettier, rustfmt, and clippy fixes up to commit d39f090a
