### PR TITLE
feat(presets): add Byesu provider preset (Claude & Codex)

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1274,6 +1274,18 @@ export const providerPresets: ProviderPreset[] = [
     icon: "pipellm",
   },
   {
+    name: "Byesu",
+    websiteUrl: "https://byesu.com",
+    apiKeyUrl: "https://byesu.com/console/token",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://byesu.com",
+        ANTHROPIC_AUTH_TOKEN: "",
+      },
+    },
+    category: "aggregator",
+  },
+  {
     name: "Xiaomi MiMo",
     websiteUrl: "https://platform.xiaomimimo.com",
     apiKeyUrl: "https://platform.xiaomimimo.com/#/console/api-keys",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1509,4 +1509,12 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
     endpointCandidates: ["https://api.therouter.ai/v1"],
     category: "aggregator",
   },
+  {
+    name: "Byesu",
+    websiteUrl: "https://byesu.com",
+    apiKeyUrl: "https://byesu.com/console/token",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig("byesu", "https://byesu.com/v1", "gpt-5.5"),
+    category: "aggregator",
+  },
 ];

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1514,7 +1514,11 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
     websiteUrl: "https://byesu.com",
     apiKeyUrl: "https://byesu.com/console/token",
     auth: generateThirdPartyAuth(""),
-    config: generateThirdPartyConfig("byesu", "https://byesu.com/v1", "gpt-5.5"),
+    config: generateThirdPartyConfig(
+      "byesu",
+      "https://byesu.com/v1",
+      "gpt-5.5",
+    ),
     category: "aggregator",
   },
 ];


### PR DESCRIPTION
## What

Adds **Byesu** (https://byesu.com) as an aggregator provider preset for **Claude Code** and **Codex**.

- Claude: `ANTHROPIC_BASE_URL = https://byesu.com` (Anthropic wire format)
- Codex: `generateThirdPartyConfig("byesu", "https://byesu.com/v1", "gpt-5.5")` (Responses wire API)

## Notes

- Entry shape mirrors the existing aggregator entries (`category: "aggregator"`, no icon — falls back to inference).
- Values match the manual setup we already document for our users at https://docs.byesu.com/clients/cc-switch (which also covers your `ccswitch://` deep-link import — thanks for that!).
- No partner flag set.

感谢维护这么棒的工具!