### PR TITLE
fix(proxy): treat empty choices as valid empty response to unblock auto-mode classifier

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -512,6 +512,72 @@ pub fn clean_schema(mut schema: Value) -> Value {
     schema
 }
 
+/// 将 OpenAI 格式的 `usage` 映射为 Anthropic 格式的 usage 对象。
+///
+/// OpenAI `prompt_tokens` 含缓存命中，Anthropic `input_tokens` 不含 → 减去 cache_read 与
+/// cache_creation，使 input 成为 fresh input。本路径以 app_type="claude" 记账（calculator
+/// 不再扣减），若不减则缓存会被计入 input 与各 cache 桶两次。三桶互斥，恒等：
+/// input + cache_read + cache_creation == prompt_tokens（inclusive 上游）。
+/// 与流式 build_anthropic_usage_json (#2774) 及 transform_gemini 的 saturating_sub 对称。
+/// 最终 cache_read：直传字段优先于 nested；cache_creation 仅来自直传字段（OpenAI 无此概念）。
+fn map_openai_usage_to_anthropic(usage: Option<&Value>) -> Value {
+    let usage = usage.cloned().unwrap_or(json!({}));
+    let cached = usage
+        .get("cache_read_input_tokens")
+        .and_then(|v| v.as_u64())
+        .or_else(|| {
+            usage
+                .pointer("/prompt_tokens_details/cached_tokens")
+                .and_then(|v| v.as_u64())
+        })
+        .unwrap_or(0);
+    let cache_creation = usage
+        .get("cache_creation_input_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let input_tokens = usage
+        .get("prompt_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0)
+        .saturating_sub(cached)
+        .saturating_sub(cache_creation) as u32;
+    let output_tokens = usage
+        .get("completion_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+
+    let mut usage_json = json!({
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens
+    });
+
+    if cached > 0 {
+        usage_json["cache_read_input_tokens"] = json!(cached);
+    }
+    if cache_creation > 0 {
+        usage_json["cache_creation_input_tokens"] = json!(cache_creation);
+    }
+    usage_json
+}
+
+/// 构造一个合法的空 content Anthropic 响应。
+///
+/// 用于上游返回成功但 `choices` 为空数组的场景（见 `openai_to_anthropic`）。
+/// 复用与主转换路径一致的 usage 映射，保证记账正确。
+fn empty_anthropic_response(body: &Value) -> Value {
+    let usage_json = map_openai_usage_to_anthropic(body.get("usage"));
+    json!({
+        "id": body.get("id").and_then(|i| i.as_str()).unwrap_or(""),
+        "type": "message",
+        "role": "assistant",
+        "content": [],
+        "model": body.get("model").and_then(|m| m.as_str()).unwrap_or(""),
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": usage_json
+    })
+}
+
 /// OpenAI 响应 → Anthropic 响应
 pub fn openai_to_anthropic(body: Value) -> Result<Value, ProxyError> {
     let choices = body
@@ -519,9 +585,15 @@ pub fn openai_to_anthropic(body: Value) -> Result<Value, ProxyError> {
         .and_then(|c| c.as_array())
         .ok_or_else(|| ProxyError::TransformError("No choices in response".to_string()))?;
 
-    let choice = choices
-        .first()
-        .ok_or_else(|| ProxyError::TransformError("Empty choices array".to_string()))?;
+    // 空 choices 是合法的上游成功响应，而非错误：例如 Claude Code auto-mode
+    // 分类器发送 max_tokens=1 请求时，GitHub Copilot 的 Claude 模型可能不产出任何
+    // 内容 token 而返回 `choices: []`（HTTP 200）。此前把它当 TransformError 抛出会
+    // 变成 422，导致 Claude Code 判定"分类器不可用"并锁死 auto mode 下的 Bash 等操作。
+    // 这里退化为一个合法的空 content Anthropic 响应（stop_reason=end_turn），
+    // 让客户端拿到 200 正常继续。usage 仍从上游透传以保证记账正确。
+    let Some(choice) = choices.first() else {
+        return Ok(empty_anthropic_response(&body));
+    };
 
     let message = choice
         .get("message")
@@ -647,48 +719,7 @@ pub fn openai_to_anthropic(body: Value) -> Result<Value, ProxyError> {
         .or(if has_tool_use { Some("tool_use") } else { None });
 
     // usage — map cache tokens from OpenAI format to Anthropic format
-    let usage = body.get("usage").cloned().unwrap_or(json!({}));
-    // OpenAI prompt_tokens 含缓存命中，Anthropic input_tokens 不含 → 减去 cache_read 与
-    // cache_creation，使 input 成为 fresh input。本路径以 app_type="claude" 记账（calculator
-    // 不再扣减），若不减则缓存会被计入 input 与各 cache 桶两次。三桶互斥，恒等：
-    // input + cache_read + cache_creation == prompt_tokens（inclusive 上游）。
-    // 与流式 build_anthropic_usage_json (#2774) 及 transform_gemini 的 saturating_sub 对称。
-    // 最终 cache_read：直传字段优先于 nested；cache_creation 仅来自直传字段（OpenAI 无此概念）。
-    let cached = usage
-        .get("cache_read_input_tokens")
-        .and_then(|v| v.as_u64())
-        .or_else(|| {
-            usage
-                .pointer("/prompt_tokens_details/cached_tokens")
-                .and_then(|v| v.as_u64())
-        })
-        .unwrap_or(0);
-    let cache_creation = usage
-        .get("cache_creation_input_tokens")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
-    let input_tokens = usage
-        .get("prompt_tokens")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0)
-        .saturating_sub(cached)
-        .saturating_sub(cache_creation) as u32;
-    let output_tokens = usage
-        .get("completion_tokens")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
-
-    let mut usage_json = json!({
-        "input_tokens": input_tokens,
-        "output_tokens": output_tokens
-    });
-
-    if cached > 0 {
-        usage_json["cache_read_input_tokens"] = json!(cached);
-    }
-    if cache_creation > 0 {
-        usage_json["cache_creation_input_tokens"] = json!(cache_creation);
-    }
+    let usage_json = map_openai_usage_to_anthropic(body.get("usage"));
 
     let result = json!({
         "id": body.get("id").and_then(|i| i.as_str()).unwrap_or(""),
@@ -1064,6 +1095,44 @@ mod tests {
         assert_eq!(result["stop_reason"], "end_turn");
         assert_eq!(result["usage"]["input_tokens"], 10);
         assert_eq!(result["usage"]["output_tokens"], 5);
+    }
+
+    #[test]
+    fn test_openai_to_anthropic_empty_choices_returns_valid_empty_message() {
+        // 上游成功返回但 choices 为空（如 Claude Code auto-mode 分类器发送
+        // max_tokens=1，GitHub Copilot 的 Claude 模型不产出内容 token 时会返回
+        // `choices: []` 且 HTTP 200）。必须退化为合法的空 content 响应而非报错，
+        // 否则 Claude Code 判定"分类器不可用"并锁死 auto mode 下的 Bash 操作。
+        let input = json!({
+            "id": "chatcmpl-empty",
+            "object": "chat.completion",
+            "model": "claude-opus-4.8",
+            "choices": [],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 0, "total_tokens": 12}
+        });
+
+        let result = openai_to_anthropic(input).expect("empty choices must not error");
+        assert_eq!(result["type"], "message");
+        assert_eq!(result["role"], "assistant");
+        assert_eq!(result["id"], "chatcmpl-empty");
+        assert_eq!(result["model"], "claude-opus-4.8");
+        assert!(result["content"].as_array().unwrap().is_empty());
+        assert_eq!(result["stop_reason"], "end_turn");
+        assert_eq!(result["usage"]["input_tokens"], 12);
+        assert_eq!(result["usage"]["output_tokens"], 0);
+    }
+
+    #[test]
+    fn test_openai_to_anthropic_missing_choices_still_errors() {
+        // choices 字段完全缺失（而非空数组）是畸形响应，应保留报错语义。
+        let input = json!({
+            "id": "chatcmpl-malformed",
+            "object": "chat.completion",
+            "model": "claude-opus-4.8",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0}
+        });
+
+        assert!(openai_to_anthropic(input).is_err());
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -512,14 +512,17 @@ pub fn clean_schema(mut schema: Value) -> Value {
     schema
 }
 
-/// 将 OpenAI 格式的 `usage` 映射为 Anthropic 格式的 usage 对象。
+/// Maps an OpenAI-format `usage` object into an Anthropic-format usage object.
 ///
-/// OpenAI `prompt_tokens` 含缓存命中，Anthropic `input_tokens` 不含 → 减去 cache_read 与
-/// cache_creation，使 input 成为 fresh input。本路径以 app_type="claude" 记账（calculator
-/// 不再扣减），若不减则缓存会被计入 input 与各 cache 桶两次。三桶互斥，恒等：
-/// input + cache_read + cache_creation == prompt_tokens（inclusive 上游）。
-/// 与流式 build_anthropic_usage_json (#2774) 及 transform_gemini 的 saturating_sub 对称。
-/// 最终 cache_read：直传字段优先于 nested；cache_creation 仅来自直传字段（OpenAI 无此概念）。
+/// OpenAI `prompt_tokens` is cache-inclusive while Anthropic `input_tokens` is not, so
+/// cache_read and cache_creation are subtracted to make `input` fresh input. This path
+/// accounts under app_type="claude" (the calculator no longer subtracts); without the
+/// subtraction, cached tokens would be double-counted in both `input` and the cache
+/// buckets. The three buckets are mutually exclusive and satisfy the identity:
+/// input + cache_read + cache_creation == prompt_tokens (upstream is inclusive).
+/// Symmetric with streaming `build_anthropic_usage_json` (#2774) and transform_gemini's
+/// saturating_sub. Final cache_read prefers the top-level field over the nested one;
+/// cache_creation comes only from the top-level field (OpenAI has no such concept).
 fn map_openai_usage_to_anthropic(usage: Option<&Value>) -> Value {
     let usage = usage.cloned().unwrap_or(json!({}));
     let cached = usage
@@ -560,10 +563,11 @@ fn map_openai_usage_to_anthropic(usage: Option<&Value>) -> Value {
     usage_json
 }
 
-/// 构造一个合法的空 content Anthropic 响应。
+/// Builds a valid empty-content Anthropic response.
 ///
-/// 用于上游返回成功但 `choices` 为空数组的场景（见 `openai_to_anthropic`）。
-/// 复用与主转换路径一致的 usage 映射，保证记账正确。
+/// Used when the upstream returns success but with an empty `choices` array
+/// (see `openai_to_anthropic`). Reuses the same usage mapping as the main
+/// conversion path to keep token accounting consistent.
 fn empty_anthropic_response(body: &Value) -> Value {
     let usage_json = map_openai_usage_to_anthropic(body.get("usage"));
     json!({
@@ -585,12 +589,14 @@ pub fn openai_to_anthropic(body: Value) -> Result<Value, ProxyError> {
         .and_then(|c| c.as_array())
         .ok_or_else(|| ProxyError::TransformError("No choices in response".to_string()))?;
 
-    // 空 choices 是合法的上游成功响应，而非错误：例如 Claude Code auto-mode
-    // 分类器发送 max_tokens=1 请求时，GitHub Copilot 的 Claude 模型可能不产出任何
-    // 内容 token 而返回 `choices: []`（HTTP 200）。此前把它当 TransformError 抛出会
-    // 变成 422，导致 Claude Code 判定"分类器不可用"并锁死 auto mode 下的 Bash 等操作。
-    // 这里退化为一个合法的空 content Anthropic 响应（stop_reason=end_turn），
-    // 让客户端拿到 200 正常继续。usage 仍从上游透传以保证记账正确。
+    // An empty choices array is a legal successful upstream response, not an error:
+    // e.g. when Claude Code's auto-mode classifier sends a max_tokens=1 request,
+    // GitHub Copilot's Claude models may emit no content token and return
+    // `choices: []` (HTTP 200). Previously this was thrown as a TransformError and
+    // surfaced as 422, causing Claude Code to declare the classifier "unavailable"
+    // and block Bash and other actions in auto mode. Degrade to a valid empty-content
+    // Anthropic response (stop_reason=end_turn) so the client gets a 200 and proceeds.
+    // Usage is still passed through from upstream to keep accounting correct.
     let Some(choice) = choices.first() else {
         return Ok(empty_anthropic_response(&body));
     };
@@ -1099,10 +1105,11 @@ mod tests {
 
     #[test]
     fn test_openai_to_anthropic_empty_choices_returns_valid_empty_message() {
-        // 上游成功返回但 choices 为空（如 Claude Code auto-mode 分类器发送
-        // max_tokens=1，GitHub Copilot 的 Claude 模型不产出内容 token 时会返回
-        // `choices: []` 且 HTTP 200）。必须退化为合法的空 content 响应而非报错，
-        // 否则 Claude Code 判定"分类器不可用"并锁死 auto mode 下的 Bash 操作。
+        // Upstream succeeds but returns empty choices (e.g. Claude Code's auto-mode
+        // classifier sends max_tokens=1 and GitHub Copilot's Claude models emit no
+        // content token, returning `choices: []` with HTTP 200). This must degrade to
+        // a valid empty-content response instead of erroring, otherwise Claude Code
+        // declares the classifier "unavailable" and blocks Bash actions in auto mode.
         let input = json!({
             "id": "chatcmpl-empty",
             "object": "chat.completion",
@@ -1124,7 +1131,8 @@ mod tests {
 
     #[test]
     fn test_openai_to_anthropic_missing_choices_still_errors() {
-        // choices 字段完全缺失（而非空数组）是畸形响应，应保留报错语义。
+        // A completely missing choices field (as opposed to an empty array) is a
+        // malformed response and should retain the error semantics.
         let input = json!({
             "id": "chatcmpl-malformed",
             "object": "chat.completion",


### PR DESCRIPTION
## Problem

In `permission-mode=auto`, Claude Code blocks Bash/edit actions with:

> `claude-opus-4-8[1m] is temporarily unavailable, so auto mode cannot determine the safety of Bash right now. Wait briefly and then try this action again.`

This is the symptom reported in #1678, and also surfaces in #4689 and #1847. The root cause was previously undiagnosed — a contributor in #1678 noted they could only reproduce it by *deliberately* failing the classifier request, never through the normal proxy flow.

## Root cause

Claude Code's auto-mode classifier issues a **`max_tokens=1`** request before every side-effecting action (Bash, edits, etc.) to judge its safety. GitHub Copilot's Claude models sometimes produce **zero content tokens** for such a request and return `choices: []` with **HTTP 200** (a legal successful response — the model simply spent its 1-token budget without emitting content).

`openai_to_anthropic` treated an empty `choices` array as a fatal `TransformError("Empty choices array")`, which surfaces to the client as **422**. Claude Code interprets any classifier failure as "classifier unavailable" and locks all side-effecting actions in auto mode. Because whether the model emits a content token under a 1-token budget is non-deterministic, the lockup appears intermittent, which made it hard to reproduce.

## Reproduction (against a GitHub Copilot Claude provider)

```bash
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:15721/v1/messages \
  -H 'content-type: application/json' -H 'x-api-key: PROXY_MANAGED' \
  -H 'anthropic-version: 2023-06-01' \
  -d '{"model":"claude-opus-4-8","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}'
```

- **Before:** `422 {"error":{"message":"格式转换错误: Empty choices array"}}` (10/10 on my Copilot enterprise account)
- **After:** `200` with a valid empty-content message (10/10)

`max_tokens=2` already returns `200`, confirming the trigger is specifically the 1-token budget the classifier uses.

## Fix

An empty `choices` array is a **legal successful** upstream response, so degrade to a valid empty-content Anthropic message (`content: []`, `stop_reason: "end_turn"`) instead of erroring. A **missing** `choices` field (a genuinely malformed response) still errors as before. The usage-mapping logic is extracted into a shared `map_openai_usage_to_anthropic` helper so both the normal and empty-choices paths account tokens identically.

## Tests

- `test_openai_to_anthropic_empty_choices_returns_valid_empty_message` (new) — empty `choices` yields a valid 200-equivalent message
- `test_openai_to_anthropic_missing_choices_still_errors` (new) — missing `choices` field still errors
- All 10 existing `openai_to_anthropic` tests still pass; `cargo fmt --check` and `cargo clippy --lib` are clean.

Refs #1678, #4689, #1847
