### PR TITLE
docs: add Hermes Tweet cc-switch context

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Modern AI-powered coding relies on tools like Claude Code, Claude Desktop, Codex
 - **Unified MCP panel** — Manage MCP servers across Claude, Codex, Gemini, OpenCode, and Hermes with bidirectional sync and Deep Link import
 - **Prompts** — Markdown editor with cross-app sync (CLAUDE.md / AGENTS.md / GEMINI.md) and backfill protection
 - **Skills** — One-click install from GitHub repos or ZIP files, custom repository management, with symlink and file copy support
+- **Hermes Tweet context** - If your Hermes workspace uses [Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) for X/Twitter account, post, or trend context, CC Switch can keep the surrounding Hermes provider, prompts, MCP, and Skills setup in the same desktop workflow.
 
 ### Usage & Cost Tracking
 


### PR DESCRIPTION
## Summary

- Add a Hermes Tweet context note under MCP, Prompts & Skills.
- Point Hermes users to the existing CC Switch workflow for provider, prompt, MCP, and Skills setup when Hermes Tweet supplies X/Twitter context.

## Review Notes

- Native fit: cc-switch already supports Hermes, Hermes Skills, MCP, and plugin extension sync.
- Duplicate check: direct PR review found no existing Hermes Tweet or Xquik submission for this repo.
- License check: MIT.
- Scope: README-only documentation update.

## Validation

- `git diff --check`
