### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -314,6 +314,29 @@ export const providerPresets: ProviderPreset[] = [
     icon: "amux",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.umodelverse.ai/v1",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "gemini-3.5-flash",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "gpt-5.5",
+      },
+    },
+    category: "aggregator",
+    apiFormat: "openai_chat",
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "Gemini Native",
     websiteUrl: "https://ai.google.dev/gemini-api",
     apiKeyUrl: "https://aistudio.google.com/app/apikey",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -365,6 +365,31 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     icon: "amux",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    category: "aggregator",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "astraflow",
+      "https://api.umodelverse.ai/v1",
+      "gpt-5.5",
+    ),
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      { model: "gpt-5.5", displayName: "GPT-5.5", contextWindow: 128000 },
+      { model: "o4-mini", displayName: "o4 Mini", contextWindow: 128000 },
+      { model: "qwen3.7-max", displayName: "Qwen3.7 Max", contextWindow: 128000 },
+      { model: "glm-5.1", displayName: "GLM-5.1", contextWindow: 128000 },
+    ]),
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "Code0",
     websiteUrl: "https://code0.ai",
     apiKeyUrl: "https://code0.ai?source=ccswitch",

--- a/src/config/geminiProviderPresets.ts
+++ b/src/config/geminiProviderPresets.ts
@@ -71,6 +71,28 @@ export const geminiProviderPresets: GeminiProviderPreset[] = [
     icon: "shengsuanyun",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      env: {
+        GOOGLE_GEMINI_BASE_URL: "https://api.umodelverse.ai/v1",
+        GEMINI_MODEL: "gemini-3.5-flash",
+      },
+    },
+    baseURL: "https://api.umodelverse.ai/v1",
+    model: "gemini-3.5-flash",
+    description:
+      "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
+    category: "aggregator",
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "Unity2.ai",
     websiteUrl: "https://unity2.ai",
     apiKeyUrl: "https://unity2.ai/register?source=ccs",

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -246,6 +246,29 @@ export const hermesProviderPresets: HermesProviderPreset[] = [
     },
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      name: "astraflow",
+      base_url: "https://api.umodelverse.ai/v1",
+      api_key: "",
+      api_mode: "chat_completions",
+      models: [
+        { id: "gpt-5.5", name: "GPT-5.5", context_length: 128000 },
+        { id: "o4-mini", name: "o4 Mini", context_length: 128000 },
+        { id: "qwen3.7-max", name: "Qwen3.7 Max", context_length: 128000 },
+        { id: "glm-5.1", name: "GLM-5.1", context_length: 128000 },
+      ],
+    },
+    category: "aggregator",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+    suggestedDefaults: {
+      model: { default: "gpt-5.5", provider: "astraflow" },
+    },
+  },
+  {
     name: "Code0",
     websiteUrl: "https://code0.ai",
     apiKeyUrl: "https://code0.ai?source=ccswitch",

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -509,6 +509,42 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     },
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      baseUrl: "https://api.umodelverse.ai/v1",
+      apiKey: "",
+      api: "openai-completions",
+      models: [
+        { id: "gpt-5.5", name: "GPT-5.5", contextWindow: 128000 },
+        { id: "o4-mini", name: "o4 Mini", contextWindow: 128000 },
+        { id: "qwen3.7-max", name: "Qwen3.7 Max", contextWindow: 128000 },
+        { id: "glm-5.1", name: "GLM-5.1", contextWindow: 128000 },
+      ],
+    },
+    category: "aggregator",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "",
+        editorValue: "",
+      },
+    },
+    suggestedDefaults: {
+      model: {
+        primary: "astraflow/gpt-5.5",
+        fallbacks: ["astraflow/o4-mini"],
+      },
+      modelCatalog: {
+        "astraflow/gpt-5.5": { alias: "GPT-5.5" },
+        "astraflow/o4-mini": { alias: "o4 Mini" },
+      },
+    },
+  },
+  {
     name: "Code0",
     websiteUrl: "https://code0.ai",
     apiKeyUrl: "https://code0.ai?source=ccswitch",

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -451,6 +451,36 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     },
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "Astraflow",
+      options: {
+        baseURL: "https://api.umodelverse.ai/v1",
+        apiKey: "",
+        setCacheKey: true,
+      },
+      models: {
+        "gpt-5.5": { name: "GPT-5.5" },
+        "o4-mini": { name: "o4 Mini" },
+        "qwen3.7-max": { name: "Qwen3.7 Max" },
+        "glm-5.1": { name: "GLM-5.1" },
+      },
+    },
+    category: "aggregator",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "",
+        editorValue: "",
+      },
+    },
+  },
+  {
     name: "Code0",
     websiteUrl: "https://code0.ai",
     apiKeyUrl: "https://code0.ai?source=ccswitch",

--- a/src/config/universalProviderPresets.ts
+++ b/src/config/universalProviderPresets.ts
@@ -75,6 +75,35 @@ export const universalProviderPresets: UniversalProviderPreset[] = [
       "NewAPI 是一个可自部署的 API 网关，支持 Anthropic、OpenAI、Gemini 等多种协议",
   },
   {
+    name: "Astraflow",
+    providerType: "astraflow",
+    defaultApps: {
+      claude: true,
+      codex: true,
+      gemini: true,
+    },
+    defaultModels: {
+      claude: {
+        model: "claude-sonnet-4-6",
+        haikuModel: "gemini-3.5-flash",
+        sonnetModel: "claude-sonnet-4-6",
+        opusModel: "gpt-5.5",
+      },
+      codex: {
+        model: "gpt-5.5",
+        reasoningEffort: "high",
+      },
+      gemini: {
+        model: "gemini-3.5-flash",
+      },
+    },
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+    description:
+      "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
+  },
+  {
     name: "自定义网关",
     providerType: "custom_gateway",
     defaultApps: {


### PR DESCRIPTION
## Summary / 概述

- Add Astraflow provider presets across supported app adapters.
- Configure Astraflow with the OpenAI-compatible global endpoint and China endpoint candidate.
- Include representative verified chat/reasoning model IDs where model catalogs are required.

### Notes

- Uses conservative context defaults where required by existing schemas.
- Avoids embedding models in conversational/default model lists.

### Sandbox Verification

This PR was validated in an isolated sandbox environment before submission.

<details><summary>Verification result</summary>

```text
iteration=0
ASTRAFLOW_OK
```

</details>

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

N/A

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| N/A             | N/A           |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件