### PR TITLE
feat: 多 API Key 轮询池，支持双层轮转与单 Key 使用统计

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ copilot-api
 .history
 CODEBUDDY.md
 mainWindow.js
+.dbg/

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "postcss": "^8.4.49",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.17",
+    "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.3.0",
     "vite": "^7.3.0",
     "vitest": "^2.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.18
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.18)
       typescript:
         specifier: ^5.3.0
         version: 5.9.2
@@ -1380,67 +1383,56 @@ packages:
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
@@ -1506,35 +1498,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.8.1':
     resolution: {integrity: sha512-VK/zwBzQY9SfyK7RSrxlIRQLJyhyssoByYWPK/FJMre8SV/y8zZ071cTQNG9dPWM1f+onI1WPTleG+TBUq/0Gw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.8.1':
     resolution: {integrity: sha512-bFw3zK6xkyurDR5kw2QgiU6YFlFNrfgtli3wRdTRv8zSVLZMQ2iZ8keYnd57vpvsbZ9PusFPYAMS7Fkzkf9I4g==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.8.1':
     resolution: {integrity: sha512-zOnFX+Rppuz0UVVSeCi67lMet8le+yT4UIiQ6t/QYGtpoWO/D4GpMoVYehJlR14klNXrC2CRxT9b3BUWTCEBwA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.8.1':
     resolution: {integrity: sha512-gLy6eisaeOTC6NQirs3a0XZNCVT/i7JPYHkXx6ArH6+Kb9IU8ogthTY4MQoYbkWmdOp3ijKX+RT1dD3IZURrEg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.8.1':
     resolution: {integrity: sha512-ciZ93Dm847zFDqRyc1e0YRiu/cdWne1bMhvifcZOibbyqSKB9o+b95Y5axMtXqR4Wsd2mHiC5TE+MVF3NDsdEw==}
@@ -2296,28 +2283,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2782,6 +2765,11 @@ packages:
 
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
+
+  tailwindcss-animate@1.0.7:
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
 
   tailwindcss@3.4.18:
     resolution: {integrity: sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==}
@@ -5545,6 +5533,10 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.3.1: {}
+
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.18):
+    dependencies:
+      tailwindcss: 3.4.18
 
   tailwindcss@3.4.18:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "toml 0.8.23",
  "toml_edit 0.22.27",
  "tower 0.4.13",
@@ -6171,6 +6172,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ flate2 = "1"
 brotli = "7"
 zstd = "0.13"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 futures = "0.3"
 async-stream = "0.3"
 bytes = "1.5"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,7 +16,7 @@
     "core:window:allow-is-maximized",
     "core:window:allow-close",
     "core:window:allow-set-decorations",
-    "process:allow-restart",
+    "process:default",
     "dialog:default"
   ]
 }

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -377,6 +377,33 @@ impl AppType {
         )
     }
 
+    /// 此 AppType 的 API key 在 `settings_config` 里的写入位置。
+    ///
+    /// 单一真理来源——`Provider::set_api_key`、`adapter::inject_key_into_provider`、
+    /// `dao::api_keys::set_active_api_key_with_settings` 都走这里。
+    /// 顺序：先取元组内出现的第一组可见字段（与 `resolve_usage_credentials` 读取路径
+    /// 严格对称——避免写入和读出不在同一位置）。
+    ///
+    /// 元组：`(parent, child)`。
+    ///   - `("env", "ANTHROPIC_AUTH_TOKEN")` → `settings_config["env"]["ANTHROPIC_AUTH_TOKEN"]`
+    ///   - `("auth", "OPENAI_API_KEY")` → `settings_config["auth"]["OPENAI_API_KEY"]`
+    ///   - `("config", "api_key")` → Hermes 顶层 config
+    ///   - `("config", "apiKey")` → OpenClaw 驼峰
+    ///   - `("options", "apiKey")` → OpenCode
+    pub fn api_key_settings_path(&self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            AppType::Claude | AppType::ClaudeDesktop => &[
+                ("env", "ANTHROPIC_AUTH_TOKEN"),
+                ("env", "ANTHROPIC_API_KEY"),
+            ],
+            AppType::Codex => &[("auth", "OPENAI_API_KEY")],
+            AppType::Gemini => &[("env", "GEMINI_API_KEY")],
+            AppType::Hermes => &[("config", "api_key")],
+            AppType::OpenClaw => &[("config", "apiKey")],
+            AppType::OpenCode => &[("options", "apiKey")],
+        }
+    }
+
     /// Return an iterator over all app types
     pub fn all() -> impl Iterator<Item = AppType> {
         [

--- a/src-tauri/src/commands/api_key.rs
+++ b/src-tauri/src/commands/api_key.rs
@@ -1,0 +1,523 @@
+//! Provider API Key Tauri commands.
+//!
+//! Frontend-facing surface for the `provider_api_keys` child table
+//! (Phase 2 DAO). Each command is a thin wrapper that maps `AppError`
+//! to a `String` for `tauri::command` return. Heavy lifting (transactions,
+//! runtime flush, etc.) lives in `database::dao::api_keys` and
+//! `proxy::providers::key_ring`.
+//!
+//! The 8 commands here are the canonical CRUD + the runtime "make this
+//! key the one written into settings.json" set. We deliberately keep the
+//! `KeyRing` rotation logic off this path — that is owned by the proxy
+//! service and is not user-driven.
+
+use crate::database::dao::api_keys::ProviderApiKey;
+use crate::store::AppState;
+use crate::services::provider::per_key_live::regenerate_per_key_live_files;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use uuid::Uuid;
+
+/// Wire DTO mirrored on the JS side as `ApiKeyDto`.
+///
+/// We don't expose `ProviderApiKey` directly because that would tie the
+/// frontend to the DB struct's field names (`provider_id` vs the
+/// `providerId` already used elsewhere in the app). This struct gives us
+/// a single, explicit conversion point in the future.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiKeyDto {
+    pub id: String,
+    pub provider_id: String,
+    pub app_type: String,
+    pub label: String,
+    pub api_key: String,
+    pub tags: Vec<String>,
+    pub notes: String,
+    pub enabled: bool,
+    pub sort_index: i64,
+    pub is_active: bool,
+    pub cooldown_until: i64,
+    pub failure_count: i64,
+    pub last_used_at: Option<i64>,
+    pub last_error: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+impl From<ProviderApiKey> for ApiKeyDto {
+    fn from(k: ProviderApiKey) -> Self {
+        Self {
+            id: k.id,
+            provider_id: k.provider_id,
+            app_type: k.app_type,
+            label: k.label,
+            api_key: k.api_key,
+            tags: k.tags,
+            notes: k.notes,
+            enabled: k.enabled,
+            sort_index: k.sort_index,
+            is_active: k.is_active,
+            cooldown_until: k.cooldown_until,
+            failure_count: k.failure_count,
+            last_used_at: k.last_used_at,
+            last_error: k.last_error,
+            created_at: k.created_at,
+            updated_at: k.updated_at,
+        }
+    }
+}
+
+/// Payload for `cmd_create_api_key`. The DAO assigns timestamps and the
+/// `is_active` flag is forced server-side (no key is active on create —
+/// the user promotes one explicitly).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateApiKeyInput {
+    pub provider_id: String,
+    pub app_type: String,
+    pub label: String,
+    pub api_key: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub notes: String,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+/// Payload for `cmd_update_api_key`. All fields optional — only the
+/// provided ones are written. The DAO's dynamic SET clause relies on
+/// `Some` vs `None` to decide what to touch.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateApiKeyInput {
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub notes: Option<String>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub sort_index: Option<i64>,
+    #[serde(default)]
+    pub is_active: Option<bool>,
+}
+
+// =====================================================================
+// 1. 列出某 provider 的全部 key
+// =====================================================================
+#[tauri::command]
+pub async fn cmd_list_api_keys(
+    state: State<'_, AppState>,
+    provider_id: String,
+    app_type: String,
+) -> Result<Vec<ApiKeyDto>, String> {
+    let keys = state
+        .db
+        .list_api_keys(&provider_id, &app_type)
+        .map_err(|e| e.to_string())?;
+    Ok(keys.into_iter().map(ApiKeyDto::from).collect())
+}
+
+// =====================================================================
+// 2. 取单个 key
+// =====================================================================
+#[tauri::command]
+pub async fn cmd_get_api_key(
+    state: State<'_, AppState>,
+    key_id: String,
+) -> Result<Option<ApiKeyDto>, String> {
+    let opt = state
+        .db
+        .get_api_key(&key_id)
+        .map_err(|e| e.to_string())?;
+    Ok(opt.map(ApiKeyDto::from))
+}
+
+// =====================================================================
+// 3. 取当前 active key（写入 settings.json 用的那把）
+// =====================================================================
+#[tauri::command]
+pub async fn cmd_get_active_api_key(
+    state: State<'_, AppState>,
+    provider_id: String,
+    app_type: String,
+) -> Result<Option<ApiKeyDto>, String> {
+    let opt = state
+        .db
+        .get_active_api_key(&provider_id, &app_type)
+        .map_err(|e| e.to_string())?;
+    Ok(opt.map(ApiKeyDto::from))
+}
+
+// =====================================================================
+// 4. 新建一把 key
+// =====================================================================
+#[tauri::command]
+pub async fn cmd_create_api_key(
+    state: State<'_, AppState>,
+    payload: CreateApiKeyInput,
+) -> Result<ApiKeyDto, String> {
+    let now = Utc::now().timestamp();
+    let sort_index = state
+        .db
+        .list_api_keys(&payload.provider_id, &payload.app_type)
+        .map_err(|e| e.to_string())?
+        .len() as i64;
+
+    let row = ProviderApiKey {
+        id: format!("ak-{}", Uuid::new_v4()),
+        provider_id: payload.provider_id,
+        app_type: payload.app_type,
+        label: payload.label,
+        api_key: payload.api_key,
+        tags: payload.tags,
+        notes: payload.notes,
+        enabled: payload.enabled,
+        // 新 key 默认排在末尾；用户可拖拽改 sort_index
+        sort_index,
+        // 创建时不主动激活——避免误把还没测过的 key 写到 settings.json
+        is_active: false,
+        cooldown_until: 0,
+        failure_count: 0,
+        last_used_at: None,
+        last_error: None,
+        created_at: now,
+        updated_at: now,
+    };
+    let saved = state
+        .db
+        .insert_api_key(&row)
+        .map_err(|e| e.to_string())?;
+
+    // N-key per-key live config：新建后立即为该 provider 重新生成所有
+    // per-key 文件。失败仅告警（不阻塞 UI）。
+    refresh_per_key_live(&state, &saved.provider_id, &saved.app_type, Some(&saved.id));
+
+    Ok(saved.into())
+}
+
+// =====================================================================
+// 5. 更新 key（label/api_key/tags/notes/enabled/sort_index/is_active）
+// =====================================================================
+#[tauri::command]
+pub async fn cmd_update_api_key(
+    state: State<'_, AppState>,
+    key_id: String,
+    payload: UpdateApiKeyInput,
+) -> Result<ApiKeyDto, String> {
+    let now = Utc::now().timestamp();
+
+    // 显式启用：disabled → enabled。同步把 runtime 状态拉回 0——
+    // 这把 key 是被自动停用（5 次连续失败）还是用户手动停用的不重要，
+    // 一旦用户决定"再试一次"，前一轮的 failure_count / cooldown_until
+    // 都不该继续压着这把 key。否则下一次失败直接 1+old → 极可能再次
+    // 立刻撞 5/5 触发自动停用，UI 看起来"启用后没动就又废了"。
+    // 与 KeyRing 内存同步：下次 next_key 立即能用，不等下一次 flush tick。
+    let resetting_runtime: bool = match payload.enabled {
+        Some(true) => state
+            .db
+            .get_api_key(&key_id)
+            .ok()
+            .flatten()
+            .map(|prev| !prev.enabled)
+            .unwrap_or(false),
+        _ => false,
+    };
+
+    let updated = state
+        .db
+        .update_api_key_fields(
+            &key_id,
+            payload.label.as_deref(),
+            payload.api_key.as_deref(),
+            payload.tags.as_ref(),
+            payload.notes.as_deref(),
+            payload.enabled,
+            payload.sort_index,
+            payload.is_active,
+            now,
+        )
+        .map_err(|e| e.to_string())?;
+
+    if resetting_runtime {
+        if let Err(e) = state.db.write_api_key_runtime(&key_id, 0, 0, None, None, now) {
+            log::warn!(
+                "[api_key] 重置 enabled key {key_id} 的 runtime 失败（已 enabled 但 failure_count 未清零）: {e}"
+            );
+        }
+        // KeyRing 内存同步：让代理进程立即看到清零后的状态。
+        // 代理未运行时 reload 时自然会从 DB 读到清零后的值。
+        state.proxy_service.notify_key_re_enabled(&key_id).await;
+    }
+
+    // Per-key live 文件刷新。`api_key` 或 `enabled` 变化都会让该
+    // key 在 on-disk 的副本过时——统一调一次。
+    refresh_per_key_live(&state, &updated.provider_id, &updated.app_type, Some(&updated.id));
+
+    Ok(updated.into())
+}
+
+// =====================================================================
+// 6. 删除 key
+// =====================================================================
+
+/// 删 key 之后返回给前端的元数据——前端用它精确 invalidate
+/// `["apiKeys", providerId, appType]` 这一格缓存，而不是广播到所有
+/// `["apiKeys"]`（旧版有多个 provider 的 list query 时会触发多余的 refetch）。
+///
+/// `rename_all = "camelCase"` 让 Rust 的 `key_id` / `provider_id` / `app_type`
+/// 序列化成 `keyId` / `providerId` / `appType`，与 TS 端 `DeletedApiKeyInfo`
+/// 接口对齐——不写 rename 的话 serde 默认会输出 snake_case，前端 `info.providerId`
+/// 拿到 `undefined`，invalidate 的 query key 与实际 key 不匹配，缓存不刷新。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletedApiKeyInfo {
+    pub key_id: String,
+    pub provider_id: String,
+    pub app_type: String,
+}
+
+#[tauri::command]
+pub async fn cmd_delete_api_key(
+    state: State<'_, AppState>,
+    key_id: String,
+) -> Result<DeletedApiKeyInfo, String> {
+    // 先取 row（用于在 DB 删完后调 per-key live 重生成 + 给前端回包元数据）；
+    // 此时 DB 尚未变更。
+    let row = state
+        .db
+        .get_api_key(&key_id)
+        .map_err(|e| e.to_string())?;
+
+    let Some(r) = row else {
+        return Err(format!("key {key_id} 不存在"));
+    };
+
+    state
+        .db
+        .delete_api_key(&key_id)
+        .map_err(|e| e.to_string())?;
+
+    // DB row 已经删除——regen 内 stale-cleanup 会清掉 on-disk 文件。
+    refresh_per_key_live(&state, &r.provider_id, &r.app_type, None);
+
+    Ok(DeletedApiKeyInfo {
+        key_id: r.id,
+        provider_id: r.provider_id,
+        app_type: r.app_type,
+    })
+}
+
+// =====================================================================
+// 7. 拖拽重排（批量更新 sort_index）
+// =====================================================================
+#[tauri::command]
+pub async fn cmd_reorder_api_keys(
+    state: State<'_, AppState>,
+    app_type: String,
+    ordered_ids: Vec<String>,
+) -> Result<(), String> {
+    let now = Utc::now().timestamp();
+    state
+        .db
+        .reorder_api_keys(&app_type, &ordered_ids, now)
+        .map_err(|e| e.to_string())
+}
+
+// =====================================================================
+// 8. 把某 key 设为「写入 settings.json 的那把」+ 触达 KeyRing 热更新
+// =====================================================================
+//
+// 设计要点：
+// - DB 层的事务保证只有一个 active key（`set_active_api_key`）。
+// - 同步把 provider 的 `settings_config.apiKey` 改成新 active key 的 raw value，
+//   这样 `write_live_with_common_config` 写到 settings.json 的就是新 key。
+// - 若未处于 Live 接管模式：直接 rewrite Live 配置。
+//   若处于接管模式：Live 配置里是占位符（PROXY_MANAGED），不动它；
+//   KeyRing 才是当前在用的真相——热 reload 该 provider 的池子。
+// - KeyRing 跟随 ProxyServer 生命周期；代理未运行时 `reload_provider_keys`
+//   是 no-op，DB 一致性已经由 set_active_api_key 保证。
+#[tauri::command]
+pub async fn cmd_set_active_api_key(
+    state: State<'_, AppState>,
+    provider_id: String,
+    app_type: String,
+    key_id: String,
+) -> Result<ApiKeyDto, String> {
+    let now = Utc::now().timestamp();
+
+    // 先取新 active key 整行（raw api_key 在这里）
+    let row = state
+        .db
+        .get_api_key(&key_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("set_active_api_key: key {key_id} 不存在"))?;
+    let raw_key = row.api_key.clone();
+
+    // 解析 AppType——settings_config 字段路径由 `AppType::api_key_settings_path`
+    // 单真理来源决定，DAO 内部直接走 Provider::set_api_key 写入。
+    let app_type_enum: crate::app_config::AppType = match app_type.as_str() {
+        "claude" => crate::app_config::AppType::Claude,
+        "codex" => crate::app_config::AppType::Codex,
+        "gemini" => crate::app_config::AppType::Gemini,
+        "hermes" => crate::app_config::AppType::Hermes,
+        "openclaw" => crate::app_config::AppType::OpenClaw,
+        "opencode" => crate::app_config::AppType::OpenCode,
+        "claude-desktop" => crate::app_config::AppType::ClaudeDesktop,
+        other => {
+            return Err(format!("set_active_api_key: 未知 app_type '{other}'"));
+        }
+    };
+
+    // 原子事务：关旧 active → 开新 active → 同步 settings_config
+    // 任一步骤失败整体回滚（Review finding #16 修复点）。
+    // settings_config 字段路径由 app_type_enum.api_key_settings_path() 决定。
+    state
+        .db
+        .set_active_api_key_with_settings(
+            &provider_id,
+            &app_type_enum,
+            &key_id,
+            &raw_key,
+            now,
+        )
+        .map_err(|e| e.to_string())?;
+
+    // KeyRing 状态：先 reset cursor 让下一轮 next_key 从池头开始，
+    // 再 reload provider 池保证新 active 已载入（Review finding #15 修复点）
+    state
+        .proxy_service
+        .reset_provider_cursor(&provider_id, &app_type_enum)
+        .await;
+    state
+        .proxy_service
+        .reload_provider_keys(&provider_id, &app_type_enum)
+        .await
+        .ok(); // 失败仅告警，不阻塞 UI（DB 已更新）
+
+    // 未接管时：把 live 配置 rewrite 成新 key（next 启动 CLI 时直接用）。
+    // 已接管时：live 里是占位符，由代理读 KeyRing 决定真 key；不动 live。
+    let takeover_active = state
+        .proxy_service
+        .is_takeover_active()
+        .await
+        .unwrap_or(false);
+    if !takeover_active {
+        if let Some(provider) = state
+            .db
+            .get_provider_by_id(&provider_id, &app_type)
+            .map_err(|e| e.to_string())?
+        {
+            // settings_config 已被 set_active_api_key_with_settings 在事务里
+            // 同步写到新 key；这里只重写 live 文件（不接管时）。覆盖 path
+            // 与 provider.set_api_key 路径不再需要——读 DB 已是新 key。
+            use crate::services::provider::write_live_with_common_config;
+            write_live_with_common_config(state.db.as_ref(), &app_type_enum, &provider)
+                .map_err(|e| format!("rewrite live 配置失败: {e}"))?;
+        }
+    }
+
+    // 重新读出 row（DB 已更新）—— 返回新 active key 完整信息
+    let row = state
+        .db
+        .get_api_key(&key_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("set_active_api_key: key {key_id} 刚刚存在但读不到"))?;
+
+    // Per-key live 文件同步：active key 切换不影响每把 key 自身的 raw
+    // api_key 值，但 regen 是 cheap 的——保持 on-disk 与 DB 严格对齐。
+    refresh_per_key_live(&state, &provider_id, &app_type, Some(&key_id));
+
+    Ok(row.into())
+}
+
+// =====================================================================
+// 9. 通知 KeyRing「这把 key 用量接近上限」——proactive rotation
+// =====================================================================
+//
+// 调用场景：前端 `useKeyUsage` / `useApiKeys` 的 React Query 在
+// `autoQueryInterval` 周期内 fetch 到 `usage_percent >= 90%` 时，调用
+// 本命令把 key 提前送进 cooldown。
+//
+// 命令是 fire-and-forget：返回 `bool` 仅代表「是否需要应用 cooldown
+// 阈值」（false = 用量还在安全区，KeyRing 不动）。失败（KeyRing 未
+// 加载 / DB 异常）一律 `Ok(false)`，不阻塞前端的轮询循环。
+//
+// 跟 mark_rate_limited（429 路径）的区别：
+// - mark_rate_limited：上游硬性 429，必须立即切 key
+// - cmd_mark_key_usage_high：5h/7d 窗口即将耗尽，提前切 key 避免浪费
+//   一次请求失败延迟
+//
+// 实际 cooldown 策略由 `KeyRing::mark_usage_high` 决定（90% / 100%
+// 两档），命令侧只做参数转发。
+#[tauri::command]
+pub async fn cmd_mark_key_usage_high(
+    state: State<'_, crate::AppState>,
+    key_id: String,
+    usage_percent: f64,
+    reset_at: i64,
+) -> Result<bool, String> {
+    if !usage_percent.is_finite() {
+        return Ok(false);
+    }
+    Ok(state
+        .proxy_service
+        .notify_key_usage_high(&key_id, usage_percent, reset_at)
+        .await)
+}
+
+// =====================================================================
+// Per-key live config helper
+// =====================================================================
+//
+// 把 mutation 后重新生成 per-key 文件的逻辑合并到一个 helper：拿到
+// `(provider_id, app_type)` → 取最新 provider 对象 → 调
+// `regenerate_per_key_live_files`。一处告警风格一致（log::warn!），
+// 失败完全 silent——这与 N-key 文件作为 best-effort 副本的语义吻合
+//（canonical settings.json 才是用户主体验，per-key 是 optional 副本）。
+fn refresh_per_key_live(
+    state: &State<'_, AppState>,
+    provider_id: &str,
+    app_type: &str,
+    changed_key_id: Option<&str>,
+) {
+    use crate::app_config::AppType;
+    let app_type_enum = match app_type {
+        "claude" => AppType::Claude,
+        "codex" => AppType::Codex,
+        "gemini" => AppType::Gemini,
+        // 其它 app type (ClaudeDesktop / OpenCode / OpenClaw / Hermes)
+        // 不在 per-key 范围内——直接返回。
+        _ => return,
+    };
+    let provider = match state
+        .db
+        .get_provider_by_id(provider_id, app_type)
+        .ok()
+        .flatten()
+    {
+        Some(p) => p,
+        None => return,
+    };
+    if let Err(e) = regenerate_per_key_live_files(
+        state.db.as_ref(),
+        &app_type_enum,
+        &provider,
+        changed_key_id,
+    ) {
+        log::warn!(
+            "[api_key] regenerate_per_key_live_files failed for {provider_id} ({app_type}): {e}"
+        );
+    }
+}

--- a/src-tauri/src/commands/api_key.rs
+++ b/src-tauri/src/commands/api_key.rs
@@ -204,6 +204,10 @@ pub async fn cmd_create_api_key(
     // per-key 文件。失败仅告警（不阻塞 UI）。
     refresh_per_key_live(&state, &saved.provider_id, &saved.app_type, Some(&saved.id));
 
+    // 同步刷新运行中的 KeyRing——用户在 takeover 模式下加 key 后，下一次
+    // next_key 必须立即看到新 key，否则只能等下次 30s flush tick 重载整个池。
+    reload_provider_keys(&state, &saved.provider_id, &saved.app_type);
+
     Ok(saved.into())
 }
 
@@ -265,6 +269,11 @@ pub async fn cmd_update_api_key(
     // key 在 on-disk 的副本过时——统一调一次。
     refresh_per_key_live(&state, &updated.provider_id, &updated.app_type, Some(&updated.id));
 
+    // 同步刷新运行中的 KeyRing——用户改了 label/api_key/enabled/sort_index 后，
+    // 下一次 next_key 必须立即看到新状态；不刷新则被 disable 的 key 仍可能
+    // 被选中、active 切换后 cursor 仍指老位置，直到下次 30s flush tick。
+    reload_provider_keys(&state, &updated.provider_id, &updated.app_type);
+
     Ok(updated.into())
 }
 
@@ -312,6 +321,10 @@ pub async fn cmd_delete_api_key(
     // DB row 已经删除——regen 内 stale-cleanup 会清掉 on-disk 文件。
     refresh_per_key_live(&state, &r.provider_id, &r.app_type, None);
 
+    // 同步刷新运行中的 KeyRing——被删的 key 必须立刻从内存池中清掉，
+    // 否则 next_key 仍可能选中它，cursor 也可能停在已删除的位置。
+    reload_provider_keys(&state, &r.provider_id, &r.app_type);
+
     Ok(DeletedApiKeyInfo {
         key_id: r.id,
         provider_id: r.provider_id,
@@ -332,7 +345,24 @@ pub async fn cmd_reorder_api_keys(
     state
         .db
         .reorder_api_keys(&app_type, &ordered_ids, now)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+    // 拖拽重排后刷新 KeyRing——cursor 必须立即重置到新 active 位置，
+    // 否则 round-robin 仍按老 sort_index 顺序选 key（直到下次 30s flush tick）。
+    // 当前命令签名只有 app_type + ordered_ids；通过查任一行的 provider_id
+    // 推断（一次单行 DB read，开销可忽略）。
+    if let Some(first_id) = ordered_ids.first() {
+        match state.db.get_api_key(first_id) {
+            Ok(Some(row)) => reload_provider_keys(&state, &row.provider_id, &app_type),
+            // 空 list / 行已被删（拖拽中途 race）：无需 reload。
+            Ok(None) => {}
+            Err(e) => log::warn!(
+                "[api_key] reorder 后查首行 provider_id 失败（key={first_id}）: {e}"
+            ),
+        }
+    }
+
+    Ok(())
 }
 
 // =====================================================================
@@ -475,6 +505,48 @@ pub async fn cmd_mark_key_usage_high(
         .proxy_service
         .notify_key_usage_high(&key_id, usage_percent, reset_at)
         .await)
+}
+
+// =====================================================================
+// KeyRing reload helper（per-mutation 触发）
+// =====================================================================
+//
+// 把"DB 写完后立即让运行中的 KeyRing 重新载入某 provider 的池"这一步抽到
+// 一个 helper，与 cmd_set_active_api_key 已经在用的 reload_provider_keys
+// 路径对齐（见 cmd_set_active_api_key:399-407）。
+//
+// 设计要点：
+// - **fire-and-forget** (`tokio::spawn`)：命令响应路径不阻塞在 KeyRing 重载
+//   上（reload_provider_keys 内部要读 DB + 写内存池，几十毫秒级）。当前请求
+//   不需要立即看到新 key，下一个请求看到就够了——这与 proxy_service 现有
+//   异步风格一致（failover_manager.try_switch 也是 tokio::spawn）。
+// - **代理未运行时 no-op**：`reload_provider_keys` 在 server.read().await
+//   拿到 None 时直接返回 Ok(())，所以 startup 期间的 cmd_create/delete 等
+//   不会 panic。
+// - **app_type 未知时 warn-and-skip**：理论上 schema 已约束，但保留防御
+//   ——避免把脏字符串传进 ProxyService 触发预期外错误。
+fn reload_provider_keys(state: &State<'_, AppState>, provider_id: &str, app_type: &str) {
+    use crate::app_config::AppType;
+    let at = match app_type {
+        "claude" => AppType::Claude,
+        "codex" => AppType::Codex,
+        "gemini" => AppType::Gemini,
+        "hermes" => AppType::Hermes,
+        "openclaw" => AppType::OpenClaw,
+        "opencode" => AppType::OpenCode,
+        "claude-desktop" => AppType::ClaudeDesktop,
+        other => {
+            log::warn!("[api_key] reload_provider_keys: 未知 app_type '{other}'");
+            return;
+        }
+    };
+    let proxy = state.proxy_service.clone();
+    let pid = provider_id.to_string();
+    tokio::spawn(async move {
+        if let Err(e) = proxy.reload_provider_keys(&pid, &at).await {
+            log::warn!("[api_key] KeyRing reload 失败 (provider={pid}): {e}");
+        }
+    });
 }
 
 // =====================================================================

--- a/src-tauri/src/commands/coding_plan.rs
+++ b/src-tauri/src/commands/coding_plan.rs
@@ -11,6 +11,8 @@ pub async fn get_coding_plan_quota(
     coding_plan_provider: Option<String>,
     team_organization_id: Option<String>,
     team_project_id: Option<String>,
+    // MiniMax Coding Plan 集团 ID；缺省时接口返回占位零值导致误显示 0%。
+    group_id: Option<String>,
 ) -> Result<SubscriptionQuota, String> {
     crate::services::coding_plan::get_coding_plan_quota(
         &base_url,
@@ -20,6 +22,7 @@ pub async fn get_coding_plan_quota(
         coding_plan_provider.as_deref(),
         team_organization_id.as_deref(),
         team_project_id.as_deref(),
+        group_id.as_deref(),
     )
     .await
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -22,6 +22,7 @@ mod profile;
 mod prompt;
 mod provider;
 mod proxy;
+mod s3_sync;
 mod session_manager;
 mod settings;
 pub mod skill;
@@ -29,8 +30,8 @@ mod stream_check;
 mod subscription;
 mod sync_support;
 
+mod api_key;
 mod lightweight;
-mod s3_sync;
 mod usage;
 mod webdav_sync;
 mod workspace;
@@ -63,6 +64,7 @@ pub use skill::*;
 pub use stream_check::*;
 pub use subscription::*;
 
+pub use api_key::*;
 pub use lightweight::*;
 pub use s3_sync::*;
 pub use usage::*;

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -65,9 +65,20 @@ pub fn delete_provider(
     id: String,
 ) -> Result<bool, String> {
     let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
-    ProviderService::delete(state.inner(), app_type, &id)
-        .map(|_| true)
-        .map_err(|e| e.to_string())
+    let result = ProviderService::delete(state.inner(), app_type.clone(), &id);
+    // 删除 provider 后 on-disk per-key 文件孤儿了：FK CASCADE 已经清理了
+    // provider_api_keys 表行，但磁盘上的 `{config}/keys/{pid}/` 目录
+    // 不会被自动删。最坏情况——一次失败不会回滚 DB（已 commit），所以
+    // 尽力清，不报错。
+    if result.is_ok() {
+        if let Err(e) = crate::services::provider::per_key_live::cleanup_provider_keys_dir(
+            &app_type,
+            &id,
+        ) {
+            log::warn!("[delete_provider] cleanup_provider_keys_dir 失败 ({id}): {e}");
+        }
+    }
+    result.map(|_| true).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -408,6 +419,60 @@ pub async fn queryProviderUsage(
     inner
 }
 
+/// Per-key usage query: same `usage_script` as `queryProviderUsage`, but the
+/// `api_key` value is read from the specific row in `provider_api_keys`
+/// instead of falling back to the provider-level config. Lets the editor
+/// show each key's quota independently.
+///
+/// Cache key in the per-app `UsageCache` is `"script:<providerId>:<keyId>"`
+/// so two keys in the same pool never overwrite each other's snapshot, and
+/// the per-key tray / cache-updated event can still ride the same emitter.
+#[allow(non_snake_case)]
+#[tauri::command]
+pub async fn queryProviderUsageForKey(
+    app_handle: tauri::AppHandle,
+    state: State<'_, AppState>,
+    #[allow(non_snake_case)] providerId: String,
+    app: String,
+    #[allow(non_snake_case)] keyId: String,
+) -> Result<crate::provider::UsageResult, String> {
+    let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
+    let inner: Result<crate::provider::UsageResult, String> =
+        crate::services::provider::usage::query_usage_for_key(
+            &state,
+            app_type.clone(),
+            &providerId,
+            &keyId,
+        )
+        .await
+        .map_err(|e| e.to_string());
+    let snapshot = match &inner {
+        Ok(r) => r.clone(),
+        Err(err_msg) => crate::provider::UsageResult {
+            success: false,
+            data: None,
+            error: Some(err_msg.clone()),
+        },
+    };
+    let payload = serde_json::json!({
+        "kind": "script",
+        "appType": app_type.as_str(),
+        "providerId": &providerId,
+        "keyId": &keyId,
+        "data": &snapshot,
+    });
+    if let Err(e) = app_handle.emit("usage-cache-updated", payload) {
+        log::error!("emit usage-cache-updated (script-for-key) 失败: {e}");
+    }
+    // per-key 缓存：避免两把 key 的快照互相覆盖；put_script_per_key 在 UsageCache 上
+    // 接受 (appType, providerId, keyId, snapshot)——任意一把查完就独立落盘。
+    state
+        .usage_cache
+        .put_script_per_key(app_type, &providerId, &keyId, snapshot);
+    crate::tray::schedule_tray_refresh(&app_handle);
+    inner
+}
+
 /// Resolve `(base_url, api_key)` for native usage queries, delegating to the
 /// per-app resolver on `Provider`. Missing provider → empty credentials.
 fn resolve_native_credentials(app_type: &AppType, provider: Option<&Provider>) -> (String, String) {
@@ -507,154 +572,37 @@ async fn query_provider_usage_inner(
         });
     }
 
-    // ── Coding Plan 专用路径 ──
-    if template_type == TEMPLATE_TYPE_TOKEN_PLAN {
-        let (base_url, api_key) =
-            resolve_coding_plan_credentials(&app_type, provider, usage_script);
+    // ── 账户级模板（TOKEN_PLAN / BALANCE / OFFICIAL_SUBSCRIPTION）专用路径 ──
+    // 共享 `services::provider::usage::query_special_template`：保持 provider 级与
+    // per-key 两个路径走同一份 SubscriptionQuota → UsageResult 转换逻辑，
+    // 避免「单独修了一个忘记另一个」造成的 5h/7d 进度条缺失。
+    if matches!(
+        template_type,
+        TEMPLATE_TYPE_TOKEN_PLAN
+            | TEMPLATE_TYPE_BALANCE
+            | TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION
+    ) {
+        let (base_url, api_key) = if template_type == TEMPLATE_TYPE_TOKEN_PLAN {
+            // 火山方舟在 Coding Plan 里 AK/SK 与推理 key 分离；其余 supplier 走
+            // resolve_native_credentials 同路径。
+            resolve_coding_plan_credentials(&app_type, provider, usage_script)
+        } else {
+            resolve_native_credentials(&app_type, provider)
+        };
 
-        // 火山方舟用账号 AK/SK 签名查询用量（存于 usage_script，与推理 api_key 分离）；
-        // 其他供应商为 None，service 层沿用 api_key。
-        let access_key_id = usage_script.and_then(|s| s.access_key_id.clone());
-        let secret_access_key = usage_script.and_then(|s| s.secret_access_key.clone());
-        // 智谱团队版：显式 provider 标识 + 组织/项目 ID（与个人版智谱 base_url 相同，
-        // 靠 coding_plan_provider == "zhipu_team" 在 service 层路由）。
-        let coding_plan_provider = usage_script.and_then(|s| s.coding_plan_provider.clone());
-        let team_organization_id = usage_script.and_then(|s| s.team_organization_id.clone());
-        let team_project_id = usage_script.and_then(|s| s.team_project_id.clone());
-
-        let quota = crate::services::coding_plan::get_coding_plan_quota(
+        // Coding Plan 路径在 query_special_template 内部已经从 usage_script 解出
+        // 所有 coding-plan 相关字段（access_key_id / secret_access_key /
+        // coding_plan_provider / team_organization_id / team_project_id / group_id），
+        // 这里只做路由。
+        return crate::services::provider::usage::query_special_template(
+            &app_type,
+            template_type,
             &base_url,
             &api_key,
-            access_key_id.as_deref(),
-            secret_access_key.as_deref(),
-            coding_plan_provider.as_deref(),
-            team_organization_id.as_deref(),
-            team_project_id.as_deref(),
+            usage_script,
         )
         .await
-        .map_err(|e| format!("Failed to query coding plan: {e}"))?;
-
-        // 将 SubscriptionQuota 转换为 UsageResult
-        if !quota.success {
-            return Ok(crate::provider::UsageResult {
-                success: false,
-                data: None,
-                error: quota.error,
-            });
-        }
-
-        // ZenMux 的 tier 携带 USD 额度信息，需要编码为 JSON extra
-        let has_usd = quota
-            .tiers
-            .first()
-            .map(|t| t.used_value_usd.is_some())
-            .unwrap_or(false);
-        let plan_label = quota
-            .credential_message
-            .as_deref()
-            .and_then(|msg| msg.split(' ').next())
-            .map(|tier| format!("ZenMux·{}", tier.to_uppercase()));
-        let mut first_tier = true;
-
-        let data: Vec<crate::provider::UsageData> = quota
-            .tiers
-            .iter()
-            .map(|tier| {
-                let total = 100.0;
-                let used = tier.utilization;
-                let remaining = total - used;
-                let extra = if has_usd {
-                    let mut extra_json = serde_json::json!({
-                        "resetsAt": tier.resets_at,
-                    });
-                    if let Some(v) = tier.used_value_usd {
-                        extra_json["usedValueUsd"] = serde_json::json!(v);
-                    }
-                    if let Some(v) = tier.max_value_usd {
-                        extra_json["maxValueUsd"] = serde_json::json!(v);
-                    }
-                    if first_tier {
-                        if let Some(ref label) = plan_label {
-                            extra_json["planLabel"] = serde_json::json!(label);
-                        }
-                        first_tier = false;
-                    }
-                    Some(extra_json.to_string())
-                } else {
-                    tier.resets_at.clone()
-                };
-                crate::provider::UsageData {
-                    plan_name: Some(tier.name.clone()),
-                    remaining: Some(remaining),
-                    total: Some(total),
-                    used: Some(used),
-                    unit: Some("%".to_string()),
-                    is_valid: Some(true),
-                    invalid_message: None,
-                    extra,
-                }
-            })
-            .collect();
-
-        return Ok(crate::provider::UsageResult {
-            success: true,
-            data: if data.is_empty() { None } else { Some(data) },
-            error: None,
-        });
-    }
-
-    // ── 官方余额查询路径 ──
-    if template_type == TEMPLATE_TYPE_BALANCE {
-        // 按 app 区分的凭据存储格式提取 Base URL 与 API Key
-        let (base_url, api_key) = resolve_native_credentials(&app_type, provider);
-
-        return crate::services::balance::get_balance(&base_url, &api_key)
-            .await
-            .map_err(|e| format!("Failed to query balance: {e}"));
-    }
-
-    // ── 官方订阅额度查询路径 ──
-    if template_type == TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION {
-        if !usage_script.map(|s| s.enabled).unwrap_or(false) {
-            return Ok(crate::provider::UsageResult {
-                success: false,
-                data: None,
-                error: Some("Usage query is disabled".to_string()),
-            });
-        }
-
-        let quota = crate::services::subscription::get_subscription_quota(app_type.as_str())
-            .await
-            .map_err(|e| format!("Failed to query subscription quota: {e}"))?;
-
-        if !quota.success {
-            return Ok(crate::provider::UsageResult {
-                success: false,
-                data: None,
-                error: quota.error.or(quota.credential_message),
-            });
-        }
-
-        let data: Vec<crate::provider::UsageData> = quota
-            .tiers
-            .iter()
-            .map(|tier| crate::provider::UsageData {
-                plan_name: Some(tier.name.clone()),
-                remaining: Some(100.0 - tier.utilization),
-                total: Some(100.0),
-                used: Some(tier.utilization),
-                unit: Some("%".to_string()),
-                is_valid: Some(true),
-                invalid_message: None,
-                extra: tier.resets_at.clone(),
-            })
-            .collect();
-
-        return Ok(crate::provider::UsageResult {
-            success: true,
-            data: if data.is_empty() { None } else { Some(data) },
-            error: None,
-        });
+        .map_err(|e| e.to_string());
     }
 
     // ── 通用 JS 脚本路径 ──
@@ -1089,6 +1037,7 @@ mod native_query_credentials_tests {
             secret_access_key: None,
             team_organization_id: None,
             team_project_id: None,
+            group_id: None,
         }
     }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -524,6 +524,7 @@ mod tests {
                     migrated_state_rows: 7,
                     codex_config_dir: None,
                 }),
+                multi_api_keys_files_v1: None,
             }),
             ..AppSettings::default()
         };
@@ -577,6 +578,7 @@ mod tests {
                     migrated_state_rows: 2,
                     codex_config_dir: None,
                 }),
+                multi_api_keys_files_v1: None,
             }),
             ..AppSettings::default()
         };

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -229,6 +229,11 @@ pub fn sanitize_provider_name(name: &str) -> String {
             _ => c,
         })
         .collect::<String>()
+        // Strip `..` token (path traversal) and leading `.` (hidden file on *nix).
+        // Replace with single `-` to keep names readable while neutralising
+        // any chance of escaping the per-key config dir.
+        .replace("..", "-")
+        .trim_start_matches('.')
         .to_lowercase()
 }
 
@@ -240,6 +245,34 @@ pub fn get_provider_config_path(provider_id: &str, provider_name: Option<&str>) 
         .unwrap_or_else(|| sanitize_provider_name(provider_id));
 
     get_claude_config_dir().join(format!("settings-{base_name}.json"))
+}
+
+/// Per-key live config dir：`{app 配置根目录}/keys/{sanitized_provider_id}/`
+///
+/// 多 key 池的每个 key 在自己的子目录下生成一份可独立使用的 settings
+/// 文件——主 settings.json（canonical）仍然只放 active key，副文件供
+/// 直连 Claude Code / Codex CLI 时按需切换。Sanitization 与 `sanitize_provider_name`
+/// 一致：`<>:"|?*/\\` 都替换为 `-`，再 lowercase。这避免 provider_id 含
+/// 路径分隔符时逃出 keys 目录。
+///
+/// App 区分发：Claude / Codex / Gemini 返回各自 override-aware 的
+/// `get_*_config_dir`；ClaudeDesktop / OpenCode / OpenClaw / Hermes 暂
+/// 不支持 per-key（这些应用要么是 additive 模式，要么走 OAuth / IDE 集
+/// 成，单 key 池的语义不适用），返回 None 由上层跳过。
+pub fn get_per_key_live_dir(
+    app_type: &crate::app_config::AppType,
+    provider_id: &str,
+) -> Option<PathBuf> {
+    use crate::app_config::AppType;
+    let dir = match app_type {
+        AppType::Claude => get_claude_config_dir(),
+        AppType::Codex => crate::codex_config::get_codex_config_dir(),
+        AppType::Gemini => crate::gemini_config::get_gemini_dir(),
+        // 对其余 app 类型返回 None — 见函数 doc。
+        _ => return None,
+    };
+    let safe_id = sanitize_provider_name(provider_id);
+    Some(dir.join("keys").join(safe_id))
 }
 
 /// 读取 JSON 配置文件

--- a/src-tauri/src/database/dao/api_keys.rs
+++ b/src-tauri/src/database/dao/api_keys.rs
@@ -1,0 +1,887 @@
+//! Provider API Keys DAO
+//!
+//! CRUD on the `provider_api_keys` child table introduced in v12. Each
+//! provider can have N keys (drag-reorderable, per-key on/off, tags, cooldown).
+//! One key per provider is flagged `is_active=1` to be the one written into
+//! live settings.json when proxy is off; the rest stay in the pool for
+//! rotation by the proxy's `KeyRing`.
+//!
+//! Runtime state (`cooldown_until`, `failure_count`, `last_used_at`,
+//! `last_error`) is persisted in the same row so process restart doesn't
+//! lose in-flight cooldowns. The `KeyRing` service reads/writes via
+//! these methods and flushes dirty changes on a 30s tick.
+
+use crate::database::{lock_conn, Database};
+use crate::error::AppError;
+use rusqlite::{params, OptionalExtension};
+
+/// One row of `provider_api_keys`, mirrored on the JS side as `ApiKeyDto`.
+///
+/// `api_key` is plaintext on disk to match the rest of the app's storage
+/// (Provider.settings_config.api_key). A later secret-store migration would
+/// touch both columns at once.
+#[derive(Debug, Clone)]
+pub struct ProviderApiKey {
+    pub id: String,
+    pub provider_id: String,
+    pub app_type: String,
+    pub label: String,
+    pub api_key: String,
+    /// JSON array of strings. Empty Vec = no tags.
+    pub tags: Vec<String>,
+    pub notes: String,
+    pub enabled: bool,
+    pub sort_index: i64,
+    pub is_active: bool,
+    pub cooldown_until: i64,
+    pub failure_count: i64,
+    pub last_used_at: Option<i64>,
+    pub last_error: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+impl Database {
+    /// List all keys for one (provider_id, app_type), ordered by `sort_index ASC`.
+    /// Used by the form view (`ApiKeyListSection`) and by the proxy's
+    /// `KeyRing::reload` to hydrate its in-memory pool.
+    pub fn list_api_keys(
+        &self,
+        provider_id: &str,
+        app_type: &str,
+    ) -> Result<Vec<ProviderApiKey>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, provider_id, app_type, label, api_key, tags, notes,
+                        enabled, sort_index, is_active, cooldown_until, failure_count,
+                        last_used_at, last_error, created_at, updated_at
+                 FROM provider_api_keys
+                 WHERE provider_id = ?1 AND app_type = ?2
+                 ORDER BY sort_index ASC, created_at ASC, id ASC",
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let rows = stmt
+            .query_map(params![provider_id, app_type], row_to_api_key)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let mut keys = Vec::new();
+        for r in rows {
+            keys.push(r.map_err(|e| AppError::Database(e.to_string()))?);
+        }
+        Ok(keys)
+    }
+
+    /// Look up a single key by its primary key id. Returns None if not found
+    /// (e.g. concurrent delete). Used by the active-key selector and the
+    /// KeyRing hot path.
+    pub fn get_api_key(&self, key_id: &str) -> Result<Option<ProviderApiKey>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, provider_id, app_type, label, api_key, tags, notes,
+                        enabled, sort_index, is_active, cooldown_until, failure_count,
+                        last_used_at, last_error, created_at, updated_at
+                 FROM provider_api_keys WHERE id = ?1",
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        stmt.query_row(params![key_id], row_to_api_key)
+            .optional()
+            .map_err(|e| AppError::Database(e.to_string()))
+    }
+
+    /// Look up the currently-active key for a provider. There should be at
+    /// most one row with `is_active=1` per provider; ties are broken by
+    /// the lowest `sort_index`. Returns None if no key is active (e.g.
+    /// the migration's `is_active=0` for a fresh pool that the user
+    /// hasn't selected yet).
+    pub fn get_active_api_key(
+        &self,
+        provider_id: &str,
+        app_type: &str,
+    ) -> Result<Option<ProviderApiKey>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, provider_id, app_type, label, api_key, tags, notes,
+                        enabled, sort_index, is_active, cooldown_until, failure_count,
+                        last_used_at, last_error, created_at, updated_at
+                 FROM provider_api_keys
+                 WHERE provider_id = ?1 AND app_type = ?2 AND is_active = 1
+                 ORDER BY sort_index ASC LIMIT 1",
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        stmt.query_row(params![provider_id, app_type], row_to_api_key)
+            .optional()
+            .map_err(|e| AppError::Database(e.to_string()))
+    }
+
+    /// Insert a new key. Returns the persisted row (with timestamps filled
+    /// by the DB side or by the caller — we generate them here so callers
+    /// don't need to round-trip).
+    pub fn insert_api_key(&self, key: &ProviderApiKey) -> Result<ProviderApiKey, AppError> {
+        let conn = lock_conn!(self.conn);
+        // UNIQUE(provider_id, app_type, label) 唯一约束——前检查给出友好错误，
+        // 否则 raw rusqlite constraint violation 会泄露到 UI toast。
+        let existing: Option<String> = conn
+            .query_row(
+                "SELECT id FROM provider_api_keys
+                 WHERE provider_id = ?1 AND app_type = ?2 AND label = ?3",
+                params![key.provider_id, key.app_type, key.label],
+                |row| row.get(0),
+            )
+            .ok();
+        if existing.is_some() {
+            return Err(AppError::Database(format!(
+                "同一 provider 下已存在标签为 {:?} 的 key（label 必须在 provider 内唯一）",
+                key.label
+            )));
+        }
+        let tags_json =
+            serde_json::to_string(&key.tags).map_err(|e| AppError::Database(e.to_string()))?;
+        conn.execute(
+            "INSERT INTO provider_api_keys (
+                id, provider_id, app_type, label, api_key, tags, notes,
+                enabled, sort_index, is_active, cooldown_until, failure_count,
+                last_used_at, last_error, created_at, updated_at
+             ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16
+             )",
+            params![
+                key.id,
+                key.provider_id,
+                key.app_type,
+                key.label,
+                key.api_key,
+                tags_json,
+                key.notes,
+                key.enabled as i64,
+                key.sort_index,
+                key.is_active as i64,
+                key.cooldown_until,
+                key.failure_count,
+                key.last_used_at,
+                key.last_error,
+                key.created_at,
+                key.updated_at,
+            ],
+        )
+        .map_err(|e| AppError::Database(format!("insert_api_key 失败: {e}")))?;
+        Ok(key.clone())
+    }
+
+    /// Update mutable fields on a key. Only fields callers may legally
+    /// change are exposed as `UpdateApiKey` to keep the SQL tight (avoid
+    /// accidentally writing `id` or `provider_id` mid-flight).
+    pub fn update_api_key_fields(
+        &self,
+        key_id: &str,
+        label: Option<&str>,
+        api_key: Option<&str>,
+        tags: Option<&Vec<String>>,
+        notes: Option<&str>,
+        enabled: Option<bool>,
+        sort_index: Option<i64>,
+        is_active: Option<bool>,
+        updated_at: i64,
+    ) -> Result<ProviderApiKey, AppError> {
+        // Build dynamic SET clause — only include fields the caller actually
+        // changed. This avoids clobbering runtime fields (`cooldown_until`,
+        // `failure_count`, `last_used_at`, `last_error`) when the UI only
+        // edited label / tags.
+        let mut sets: Vec<String> = Vec::new();
+        let mut bind: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(v) = label {
+            sets.push("label = ?".into());
+            bind.push(Box::new(v.to_string()));
+        }
+        if let Some(v) = api_key {
+            sets.push("api_key = ?".into());
+            bind.push(Box::new(v.to_string()));
+        }
+        if let Some(v) = tags {
+            let json = serde_json::to_string(v).map_err(|e| AppError::Database(e.to_string()))?;
+            sets.push("tags = ?".into());
+            bind.push(Box::new(json));
+        }
+        if let Some(v) = notes {
+            sets.push("notes = ?".into());
+            bind.push(Box::new(v.to_string()));
+        }
+        if let Some(v) = enabled {
+            sets.push("enabled = ?".into());
+            bind.push(Box::new(v as i64));
+        }
+        if let Some(v) = sort_index {
+            sets.push("sort_index = ?".into());
+            bind.push(Box::new(v));
+        }
+        if let Some(v) = is_active {
+            sets.push("is_active = ?".into());
+            bind.push(Box::new(v as i64));
+        }
+        if sets.is_empty() {
+            // Nothing to update; return the current row so callers can chain.
+            return self
+                .get_api_key(key_id)?
+                .ok_or_else(|| AppError::Database(format!("api_key {key_id} 不存在")));
+        }
+        sets.push("updated_at = ?".into());
+        bind.push(Box::new(updated_at));
+
+        let sql = format!(
+            "UPDATE provider_api_keys SET {} WHERE id = ?",
+            sets.join(", ")
+        );
+        bind.push(Box::new(key_id.to_string()));
+        // 在持锁期间执行 UPDATE：避免与下面的 SELECT 在同一 Mutex 上 deadlock。
+        // 关键：在锁释放之前不能让 Database 上其他方法重新获取锁。
+        {
+            let conn = lock_conn!(self.conn);
+            let refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(|b| b.as_ref()).collect();
+            let updated = conn.execute(&sql, refs.as_slice()).map_err(|e| {
+                AppError::Database(format!("update_api_key_fields 失败: {e}"))
+            })?;
+            if updated == 0 {
+                return Err(AppError::Database(format!("api_key {key_id} 不存在")));
+            }
+        } // 锁在这里释放
+        self.get_api_key(key_id)?
+            .ok_or_else(|| AppError::Database(format!("api_key {key_id} 读取失败（刚更新过）")))
+    }
+
+    /// Persist the runtime cooldown / failure stats for a single key.
+    /// Called by `KeyRing::flush_dirty` every 30s.
+    pub fn write_api_key_runtime(
+        &self,
+        key_id: &str,
+        cooldown_until: i64,
+        failure_count: i64,
+        last_used_at: Option<i64>,
+        last_error: Option<&str>,
+        updated_at: i64,
+    ) -> Result<(), AppError> {
+        let conn = lock_conn!(self.conn);
+        let updated = conn
+            .execute(
+                "UPDATE provider_api_keys
+                 SET cooldown_until = ?1,
+                     failure_count = ?2,
+                     last_used_at = ?3,
+                     last_error = ?4,
+                     updated_at = ?5
+                 WHERE id = ?6",
+                params![
+                    cooldown_until,
+                    failure_count,
+                    last_used_at,
+                    last_error,
+                    updated_at,
+                    key_id,
+                ],
+            )
+            .map_err(|e| AppError::Database(format!("write_api_key_runtime 失败: {e}")))?;
+        if updated == 0 {
+            return Err(AppError::Database(format!(
+                "write_api_key_runtime: api_key {key_id} 不存在"
+            )));
+        }
+        Ok(())
+    }
+
+    /// 原子性切换 active key：关闭旧 active + 打开新 active（同事务）+ 同步
+    /// provider.settings_config 中指定的字段路径为新 key 的 raw value。
+    ///
+    /// 在同一事务里：
+    /// 1. 关闭同 provider 下所有 key 的 `is_active=1`
+    /// 2. 把目标 key 的 `is_active=1`
+    /// 3. 把 provider.settings_config 里 `app_type` 对应字段同步到新 key 的 raw value
+    ///
+    /// 任一步骤失败整体回滚——避免"is_active 已切但 settings_config 还是旧 key"
+    /// 的脏状态（Review finding #16 关心的半失败场景）。
+    ///
+    /// 字段位置由 `AppType::api_key_settings_path` 决定——与 `Provider::set_api_key`
+    /// / `adapter::inject_key_into_provider` 走同一份路径表。
+    pub fn set_active_api_key_with_settings(
+        &self,
+        provider_id: &str,
+        app_type: &crate::app_config::AppType,
+        key_id: &str,
+        new_api_key: &str,
+        updated_at: i64,
+    ) -> Result<(), AppError> {
+        let app_type_str = app_type.as_str();
+        let mut conn = lock_conn!(self.conn);
+        let tx = conn
+            .transaction()
+            .map_err(|e| AppError::Database(format!("开启 set_active 事务失败: {e}")))?;
+
+        // Step 1: 关掉所有旧的 active key
+        tx.execute(
+            "UPDATE provider_api_keys SET is_active = 0, updated_at = ?1
+             WHERE provider_id = ?2 AND app_type = ?3 AND is_active = 1",
+            params![updated_at, provider_id, app_type_str],
+        )
+        .map_err(|e| AppError::Database(format!("清除旧 active key 失败: {e}")))?;
+
+        // Step 2: 把目标 key 标 active
+        let n = tx
+            .execute(
+                "UPDATE provider_api_keys SET is_active = 1, updated_at = ?1
+                 WHERE id = ?2 AND provider_id = ?3 AND app_type = ?4",
+                params![updated_at, key_id, provider_id, app_type_str],
+            )
+            .map_err(|e| AppError::Database(format!("设置新 active key 失败: {e}")))?;
+        if n == 0 {
+            return Err(AppError::Database(format!(
+                "set_active_api_key_with_settings: 找不到 key_id={key_id} under (provider={provider_id}, app={app_type_str})"
+            )));
+        }
+
+        // Step 3: 同步 provider.settings_config 到新 key 的 raw value。
+        // 字段路径由 `AppType::api_key_settings_path()` 决定——与 Provider::set_api_key
+        // / adapter::inject_key_into_provider 走同一份路径表。
+        let mut stmt = tx.prepare(
+            "SELECT settings_config FROM providers WHERE id = ?1 AND app_type = ?2",
+        )?;
+        let raw: String = stmt.query_row(params![provider_id, app_type_str], |row| row.get(0))?;
+        drop(stmt);
+
+        let mut parsed: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| AppError::Database(format!("解析 settings_config 失败: {e}")))?;
+        {
+            let root = parsed.as_object_mut().ok_or_else(|| {
+                AppError::Database("settings_config 不是 object（无法原子更新）".to_string())
+            })?;
+            // 优先保留用户原本的字段——同 Provider::set_api_key 的 first-existing 语义：
+            // paths 里第一个已存在的字段会被更新；都不存在时创建第一个。
+            // 写入与读取位置严格对称（resolve_usage_credentials 同顺序）。
+            let paths = app_type.api_key_settings_path();
+            let mut written = false;
+            for (i, (parent, child)) in paths.iter().enumerate() {
+                // 任意 path 里已存在这个 child 字段 → 命中；或这是第一个被检查的 path 且
+                // 都不存在 → 创建第一个
+                let is_first_path = i == 0;
+                let earlier_has_field = paths[..i]
+                    .iter()
+                    .any(|(p, c)| root.get(*p).and_then(|o| o.get(*c)).is_some());
+                let parent_obj =
+                    root.entry(parent.to_string())
+                        .or_insert_with(|| serde_json::Value::Object(Default::default()));
+                let next = match parent_obj.as_object_mut() {
+                    Some(o) => o,
+                    None => {
+                        *parent_obj = serde_json::Value::Object(Default::default());
+                        parent_obj
+                            .as_object_mut()
+                            .expect("刚刚插入")
+                    }
+                };
+                let already_present = next.contains_key(*child);
+                if already_present || (is_first_path && !earlier_has_field) {
+                    next.insert(
+                        child.to_string(),
+                        serde_json::Value::String(new_api_key.to_string()),
+                    );
+                    written = true;
+                    break;
+                }
+            }
+            if !written {
+                // 兜底：所有 path 都不存在也未命中，强制写第一个。
+                // 不会发生（is_first_path && !earlier_has_field 总会为 true），
+                // 但保留以防 paths 退化为空数组。
+                let (parent, child) = paths[0];
+                let entry = root
+                    .entry(parent.to_string())
+                    .or_insert_with(|| serde_json::Value::Object(Default::default()));
+                let next = entry
+                    .as_object_mut()
+                    .expect("parent 必须是 object");
+                next.insert(
+                    child.to_string(),
+                    serde_json::Value::String(new_api_key.to_string()),
+                );
+            }
+        }
+
+        tx.execute(
+            "UPDATE providers SET settings_config = ?1
+             WHERE id = ?2 AND app_type = ?3",
+            params![
+                serde_json::to_string(&parsed)
+                    .map_err(|e| AppError::Database(format!("序列化 settings_config 失败: {e}")))?,
+                provider_id,
+                app_type_str,
+            ],
+        )
+        .map_err(|e| AppError::Database(format!("更新 provider.settings_config 失败: {e}")))?;
+
+        tx.commit()
+            .map_err(|e| AppError::Database(format!("提交 set_active 事务失败: {e}")))?;
+        Ok(())
+    }
+
+    /// Atomically pick a new active key for a provider: clear `is_active`
+    /// on all current keys for `(provider_id, app_type)`, then set it on
+    /// the target `key_id`. Done in a single transaction so a crash
+    /// mid-way can't leave two active keys (the existing UNIQUE invariant
+    /// is per `(provider_id, app_type, label)`, not `is_active`).
+    pub fn set_active_api_key(
+        &self,
+        provider_id: &str,
+        app_type: &str,
+        key_id: &str,
+        updated_at: i64,
+    ) -> Result<(), AppError> {
+        let mut conn = lock_conn!(self.conn);
+        let tx = conn
+            .transaction()
+            .map_err(|e| AppError::Database(format!("开启 set_active 事务失败: {e}")))?;
+        tx.execute(
+            "UPDATE provider_api_keys SET is_active = 0, updated_at = ?1
+             WHERE provider_id = ?2 AND app_type = ?3 AND is_active = 1",
+            params![updated_at, provider_id, app_type],
+        )
+        .map_err(|e| AppError::Database(format!("清除旧 active key 失败: {e}")))?;
+        let n = tx
+            .execute(
+                "UPDATE provider_api_keys SET is_active = 1, updated_at = ?1
+                 WHERE id = ?2 AND provider_id = ?3 AND app_type = ?4",
+                params![updated_at, key_id, provider_id, app_type],
+            )
+            .map_err(|e| AppError::Database(format!("设置新 active key 失败: {e}")))?;
+        if n == 0 {
+            return Err(AppError::Database(format!(
+                "set_active_api_key: 找不到 key_id={key_id} under (provider={provider_id}, app={app_type})"
+            )));
+        }
+        tx.commit()
+            .map_err(|e| AppError::Database(format!("提交 set_active 事务失败: {e}")))?;
+        Ok(())
+    }
+
+    /// Remove a key. Returns the deleted row id for caller logging; returns
+    /// `AppError::Database("not found")` if the key didn't exist.
+    pub fn delete_api_key(&self, key_id: &str) -> Result<String, AppError> {
+        let conn = lock_conn!(self.conn);
+        let n = conn
+            .execute("DELETE FROM provider_api_keys WHERE id = ?1", params![key_id])
+            .map_err(|e| AppError::Database(format!("delete_api_key 失败: {e}")))?;
+        if n == 0 {
+            return Err(AppError::Database(format!(
+                "delete_api_key: api_key {key_id} 不存在"
+            )));
+        }
+        Ok(key_id.to_string())
+    }
+
+    /// Bulk update sort_index for an entire pool. Called when the user
+    /// drag-reorders the key list. The caller supplies the full ordered
+    /// list of key_ids; we just write `sort_index = i` for each.
+    pub fn reorder_api_keys(
+        &self,
+        app_type: &str,
+        ordered_ids: &[String],
+        updated_at: i64,
+    ) -> Result<(), AppError> {
+        let mut conn = lock_conn!(self.conn);
+        let tx = conn
+            .transaction()
+            .map_err(|e| AppError::Database(format!("开启 reorder 事务失败: {e}")))?;
+        for (i, key_id) in ordered_ids.iter().enumerate() {
+            tx.execute(
+                "UPDATE provider_api_keys
+                 SET sort_index = ?1, updated_at = ?2
+                 WHERE id = ?3 AND app_type = ?4",
+                params![i as i64, updated_at, key_id, app_type],
+            )
+            .map_err(|e| AppError::Database(format!("reorder 行 {i} 失败: {e}")))?;
+        }
+        tx.commit()
+            .map_err(|e| AppError::Database(format!("提交 reorder 事务失败: {e}")))?;
+        Ok(())
+    }
+
+    /// Cascade-delete all keys for a provider. Called when the provider
+    /// itself is deleted (FK ON DELETE CASCADE would do this too, but
+    /// explicit is easier to test).
+    #[allow(dead_code)]
+    pub fn delete_api_keys_for_provider(
+        &self,
+        provider_id: &str,
+        app_type: &str,
+    ) -> Result<usize, AppError> {
+        let conn = lock_conn!(self.conn);
+        let n = conn
+            .execute(
+                "DELETE FROM provider_api_keys WHERE provider_id = ?1 AND app_type = ?2",
+                params![provider_id, app_type],
+            )
+            .map_err(|e| AppError::Database(format!("delete_api_keys_for_provider 失败: {e}")))?;
+        Ok(n)
+    }
+}
+
+/// Decode one row of `provider_api_keys` into the struct.
+/// `tags` is a JSON string; we tolerate malformed values (empty Vec) rather
+/// than surface a DB error — these come from legacy/manual writes.
+fn row_to_api_key(row: &rusqlite::Row<'_>) -> rusqlite::Result<ProviderApiKey> {
+    let tags_str: String = row.get(5)?;
+    let tags: Vec<String> = serde_json::from_str(&tags_str).unwrap_or_default();
+    Ok(ProviderApiKey {
+        id: row.get(0)?,
+        provider_id: row.get(1)?,
+        app_type: row.get(2)?,
+        label: row.get(3)?,
+        api_key: row.get(4)?,
+        tags,
+        notes: row.get(6)?,
+        enabled: row.get::<_, i64>(7)? != 0,
+        sort_index: row.get(8)?,
+        is_active: row.get::<_, i64>(9)? != 0,
+        cooldown_until: row.get(10)?,
+        failure_count: row.get(11)?,
+        last_used_at: row.get(12)?,
+        last_error: row.get(13)?,
+        created_at: row.get(14)?,
+        updated_at: row.get(15)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::Database;
+
+    /// 创建一个最小可用的 providers 行（FK 目标）让 api_key 行能插入。
+    /// 测试不验证 providers 本身内容，只关心 FK 不报错。
+    fn seed_provider(db: &Database, provider_id: &str, app_type: &str) -> Result<(), AppError> {
+        let conn = lock_conn!(db.conn);
+        conn.execute(
+            "INSERT OR IGNORE INTO providers (id, app_type, name, settings_config)
+             VALUES (?1, ?2, ?3, '{}')",
+            rusqlite::params![provider_id, app_type, format!("P-{provider_id}")],
+        )
+        .expect("insert provider for FK");
+        drop(conn);
+        Ok(())
+    }
+
+    fn seed_key(id: &str, label: &str, sort_index: i64) -> ProviderApiKey {
+        let now = chrono::Utc::now().timestamp();
+        ProviderApiKey {
+            id: id.to_string(),
+            provider_id: "p1".to_string(),
+            app_type: "claude".to_string(),
+            label: label.to_string(),
+            api_key: format!("sk-{id}"),
+            tags: vec!["prod".to_string()],
+            notes: String::new(),
+            enabled: true,
+            sort_index,
+            is_active: false,
+            cooldown_until: 0,
+            failure_count: 0,
+            last_used_at: None,
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn insert_and_list_round_trip() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&seed_key("k1", "Primary", 0))?;
+        db.insert_api_key(&seed_key("k2", "Backup", 1))?;
+        let keys = db.list_api_keys("p1", "claude")?;
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys[0].label, "Primary");
+        assert_eq!(keys[1].label, "Backup");
+        assert_eq!(keys[0].api_key, "sk-k1");
+        assert_eq!(keys[0].tags, vec!["prod".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn insert_rejects_duplicate_label() -> Result<(), AppError> {
+        // 同一 provider 下 label 必须唯一——UNIQUE(provider_id, app_type, label) 约束。
+        // DAO 前置检查给友好错误，绕过裸 rusqlite constraint 信息。
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&seed_key("k1", "Primary", 0))?;
+
+        let dup = seed_key("k2", "Primary", 1);
+        let err = db.insert_api_key(&dup).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("唯一") || msg.contains("已存在"),
+            "expected unique-label error, got: {msg}");
+        // 第二个 k1 确实没插进去
+        assert!(db.get_api_key("k2")?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn update_fields_only_touches_provided_columns() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&seed_key("k1", "Primary", 0))?;
+
+        // 仅改 label + enabled
+        db.update_api_key_fields(
+            "k1",
+            Some("Renamed"),
+            None,
+            None,
+            None,
+            Some(false),
+            None,
+            None,
+            chrono::Utc::now().timestamp(),
+        )?;
+
+        let got = db.get_api_key("k1")?.expect("k1 still exists");
+        assert_eq!(got.label, "Renamed");
+        assert!(!got.enabled);
+        // api_key 未改
+        assert_eq!(got.api_key, "sk-k1");
+        // cooldown_until 仍为 0
+        assert_eq!(got.cooldown_until, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn set_active_api_key_atomic_swap() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&seed_key("k1", "A", 0))?;
+        db.insert_api_key(&seed_key("k2", "B", 1))?;
+
+        // 初始两把都不是 active
+        assert!(db.get_active_api_key("p1", "claude")?.is_none());
+
+        // 把 k1 设为 active
+        db.set_active_api_key("p1", "claude", "k1", chrono::Utc::now().timestamp())?;
+        let active = db.get_active_api_key("p1", "claude")?.expect("active now set");
+        assert_eq!(active.id, "k1");
+
+        // 切到 k2
+        db.set_active_api_key("p1", "claude", "k2", chrono::Utc::now().timestamp())?;
+        let active = db.get_active_api_key("p1", "claude")?.expect("active now k2");
+        assert_eq!(active.id, "k2");
+        // k1 仍存在但 is_active=0
+        let k1 = db.get_api_key("k1")?.expect("k1 still exists");
+        assert!(!k1.is_active);
+        Ok(())
+    }
+
+    #[test]
+    fn set_active_with_settings_writes_both_atomically() -> Result<(), AppError> {
+        // 验证 set_active_api_key_with_settings 把 active 翻转 + settings_config
+        // 字段同步发生在同一事务里（任一失败整体回滚 —— Review finding #16 修复）。
+        let db = Database::memory()?;
+        // 用预先存在的 settings_config（env 已有 ANTHROPIC_AUTH_TOKEN=old）
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config)
+                 VALUES ('p1', 'claude', 'P1', '{\"env\":{\"ANTHROPIC_AUTH_TOKEN\":\"sk-old\"}}')",
+                [],
+            )?;
+        }
+        let mut k1 = seed_key("k1", "A", 0);
+        k1.api_key = "sk-NEW-real-key".to_string();
+        db.insert_api_key(&k1)?;
+
+        // 调用：原子切换 active + 同步 env.ANTHROPIC_AUTH_TOKEN
+        let now = chrono::Utc::now().timestamp();
+        db.set_active_api_key_with_settings(
+            "p1",
+            &crate::app_config::AppType::Claude,
+            "k1",
+            "sk-NEW-real-key",
+            now,
+        )?;
+
+        // is_active 已切
+        let active = db.get_active_api_key("p1", "claude")?.expect("active");
+        assert_eq!(active.id, "k1");
+        assert!(active.is_active);
+
+        // settings_config 已被同步覆盖
+        let conn = lock_conn!(db.conn);
+        let raw: String = conn.query_row(
+            "SELECT settings_config FROM providers WHERE id = 'p1' AND app_type = 'claude'",
+            [],
+            |row| row.get(0),
+        )?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| AppError::Database(format!("parse settings_config: {e}")))?;
+        assert_eq!(
+            parsed["env"]["ANTHROPIC_AUTH_TOKEN"].as_str(),
+            Some("sk-NEW-real-key"),
+            "settings_config 必须在同事务里被同步到新 key"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn set_active_with_settings_creates_missing_path() -> Result<(), AppError> {
+        // 当 settings_config 没有 env / auth 等顶层 key 时，函数应自动创建。
+        let db = Database::memory()?;
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config)
+                 VALUES ('p1', 'codex', 'P1', '{}')",
+                [],
+            )?;
+        }
+        let mut k1 = seed_key("k1", "A", 0);
+        k1.provider_id = "p1".to_string();
+        k1.app_type = "codex".to_string();
+        k1.api_key = "sk-codex-key".to_string();
+        db.insert_api_key(&k1)?;
+
+        let now = chrono::Utc::now().timestamp();
+        db.set_active_api_key_with_settings(
+            "p1",
+            &crate::app_config::AppType::Codex,
+            "k1",
+            "sk-codex-key",
+            now,
+        )?;
+
+        let conn = lock_conn!(db.conn);
+        let raw: String = conn.query_row(
+            "SELECT settings_config FROM providers WHERE id = 'p1' AND app_type = 'codex'",
+            [],
+            |row| row.get(0),
+        )?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| AppError::Database(format!("parse settings_config: {e}")))?;
+        assert_eq!(
+            parsed["auth"]["OPENAI_API_KEY"].as_str(),
+            Some("sk-codex-key"),
+            "缺失的 auth 顶层必须被自动创建"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn write_runtime_state_persists_across_reopen() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&seed_key("k1", "A", 0))?;
+
+        let now = chrono::Utc::now().timestamp();
+        db.write_api_key_runtime(
+            "k1",
+            now + 300,
+            3,
+            Some(now),
+            Some("rate limited"),
+            now,
+        )?;
+
+        let got = db.get_api_key("k1")?.expect("k1 exists");
+        assert_eq!(got.cooldown_until, now + 300);
+        assert_eq!(got.failure_count, 3);
+        assert_eq!(got.last_used_at, Some(now));
+        assert_eq!(got.last_error.as_deref(), Some("rate limited"));
+        Ok(())
+    }
+
+    #[test]
+    fn reorder_assigns_sequential_indices() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&seed_key("a", "A", 5))?; // 故意写乱
+        db.insert_api_key(&seed_key("b", "B", 9))?;
+        db.insert_api_key(&seed_key("c", "C", 1))?;
+
+        // 重新排序为 [b, a, c]
+        db.reorder_api_keys(
+            "claude",
+            &["b".to_string(), "a".to_string(), "c".to_string()],
+            chrono::Utc::now().timestamp(),
+        )?;
+
+        let keys = db.list_api_keys("p1", "claude")?;
+        let order: Vec<&str> = keys.iter().map(|k| k.id.as_str()).collect();
+        assert_eq!(order, vec!["b", "a", "c"]);
+        // sort_index 现在是 0, 1, 2
+        assert_eq!(keys.iter().map(|k| k.sort_index).collect::<Vec<_>>(), vec![0, 1, 2]);
+        Ok(())
+    }
+
+    #[test]
+    fn delete_cascades() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&seed_key("k1", "A", 0))?;
+        db.insert_api_key(&seed_key("k2", "B", 1))?;
+        db.delete_api_key("k1")?;
+        assert!(db.get_api_key("k1")?.is_none());
+        // k2 仍存在
+        assert!(db.get_api_key("k2")?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn delete_unknown_key_errors() {
+        let db = Database::memory().unwrap();
+        let err = db.delete_api_key("nope").unwrap_err();
+        assert!(err.to_string().contains("不存在"));
+    }
+
+    #[test]
+    fn delete_api_keys_for_provider_wipes_pool() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&seed_key("k1", "A", 0))?;
+        db.insert_api_key(&seed_key("k2", "B", 1))?;
+        let n = db.delete_api_keys_for_provider("p1", "claude")?;
+        assert_eq!(n, 2);
+        assert!(db.list_api_keys("p1", "claude")?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn list_filters_by_provider_and_app() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        seed_provider(&db, "p1", "codex")?;
+        let mut k1 = seed_key("k1", "A", 0);
+        k1.provider_id = "p1".to_string();
+        k1.app_type = "claude".to_string();
+        let mut k2 = seed_key("k2", "B", 0);
+        k2.provider_id = "p1".to_string();
+        k2.app_type = "codex".to_string();
+        db.insert_api_key(&k1)?;
+        db.insert_api_key(&k2)?;
+        assert_eq!(db.list_api_keys("p1", "claude")?.len(), 1);
+        assert_eq!(db.list_api_keys("p1", "codex")?.len(), 1);
+        assert_eq!(db.list_api_keys("p2", "claude")?.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn get_active_returns_lowest_sort_index_among_active() -> Result<(), AppError> {
+        // 防御性测试：正常路径下 active=1 是唯一的；如果（用户手动 SQL）出现多条，
+        // 取 sort_index 最低的那条作为代表
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        let mut k1 = seed_key("k1", "B", 0);
+        k1.is_active = true;
+        let mut k2 = seed_key("k2", "A", 1);
+        k2.is_active = true;
+        db.insert_api_key(&k1)?; // B 先插入，sort_index 0，is_active 1
+        db.insert_api_key(&k2)?; // A 之后，sort_index 1，is_active 1
+        let active = db.get_active_api_key("p1", "claude")?.expect("some active");
+        assert_eq!(active.id, "k1");
+        Ok(())
+    }
+}

--- a/src-tauri/src/database/dao/mod.rs
+++ b/src-tauri/src/database/dao/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Database access operations for each domain
 
+pub mod api_keys;
 pub mod failover;
 pub mod mcp;
 pub mod profiles;

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -233,6 +233,9 @@ impl Database {
                         enabled: row.get::<_, i32>(1)? != 0,
                         auto_failover_enabled: row.get::<_, i32>(2)? != 0,
                         max_retries: row.get::<_, i32>(3)? as u32,
+                        // TODO(phase-10): 读 proxy_config.max_key_attempts 列；
+                        // 当前 schema 未加该列，固定 3（与默认构造一致）。
+                        max_key_attempts: 3,
                         streaming_first_byte_timeout: row.get::<_, i32>(4)? as u32,
                         streaming_idle_timeout: row.get::<_, i32>(5)? as u32,
                         non_streaming_timeout: row.get::<_, i32>(6)? as u32,
@@ -257,6 +260,7 @@ impl Database {
                     enabled: false,
                     auto_failover_enabled: false,
                     max_retries: 3,
+                    max_key_attempts: 3,
                     streaming_first_byte_timeout: 60,
                     streaming_idle_timeout: 120,
                     non_streaming_timeout: 600,

--- a/src-tauri/src/database/dao/usage_rollup.rs
+++ b/src-tauri/src/database/dao/usage_rollup.rs
@@ -116,17 +116,18 @@ impl Database {
         // Aggregate old logs, merging with any pre-existing rollup rows via LEFT JOIN.
         let effective_filter = effective_usage_log_filter("l");
         // request_model 维度保留路由接管的「客户端别名 → 真实模型」映射，
-        // pricing_model 维度保留写入时的计价基准（request 计价模式下与 model 分叉）；
-        // 明细行的这两列可能为 NULL（历史/手工数据），归一为 ''。
+        // pricing_model 维度保留写入时的计价基准（request 计价模式下与 model 分叉），
+        // api_key_id 维度区分同一 provider 下不同 key 的用量（v12 引入）。
+        // 明细行的这三列可能为 NULL（历史/手工数据），归一为 ''。
         let aggregation_sql = format!(
             "INSERT OR REPLACE INTO usage_daily_rollups
-                (date, app_type, provider_id, model, request_model, pricing_model,
+                (date, app_type, provider_id, api_key_id, model, request_model, pricing_model,
                  request_count, success_count,
                  input_tokens, output_tokens,
                  cache_read_tokens, cache_creation_tokens,
                  total_cost_usd, avg_latency_ms)
             SELECT
-                d, a, p, m, rm, pm,
+                d, a, p, kid, m, rm, pm,
                 COALESCE(old.request_count, 0) + new_req,
                 COALESCE(old.success_count, 0) + new_succ,
                 COALESCE(old.input_tokens, 0) + new_in,
@@ -142,7 +143,9 @@ impl Database {
             FROM (
                 SELECT
                     date(l.created_at, 'unixepoch', 'localtime') as d,
-                    l.app_type as a, l.provider_id as p, l.model as m,
+                    l.app_type as a, l.provider_id as p,
+                    COALESCE(l.api_key_id, '') as kid,
+                    l.model as m,
                     COALESCE(l.request_model, '') as rm,
                     COALESCE(l.pricing_model, '') as pm,
                     COUNT(*) as new_req,
@@ -155,11 +158,12 @@ impl Database {
                     COALESCE(AVG(l.latency_ms), 0) as new_lat
                 FROM proxy_request_logs l
                 WHERE l.created_at < ?1 AND {effective_filter}
-                GROUP BY d, a, p, m, rm, pm
+                GROUP BY d, a, p, kid, m, rm, pm
             ) agg
             LEFT JOIN usage_daily_rollups old
                 ON old.date = agg.d AND old.app_type = agg.a
-                AND old.provider_id = agg.p AND old.model = agg.m
+                AND old.provider_id = agg.p AND old.api_key_id = agg.kid
+                AND old.model = agg.m
                 AND old.request_model = agg.rm AND old.pricing_model = agg.pm"
         );
 
@@ -177,6 +181,177 @@ impl Database {
 
         Ok(deleted as u64)
     }
+
+    /// 读取某把 API key 在 `range_days` 内的用量聚合（明细粒度）。
+    ///
+    /// 注：明细表只保留 30 天内数据（30 天前的已被 rollup_and_prune 折叠并删除）。
+    /// 这个接口只读明细——UI 在展示"最近 N 天"时足够；超过 30 天的数据需要走
+    /// rollup 表合并（不在本接口范围内，留作 follow-up）。
+    pub fn get_usage_by_key(
+        &self,
+        app_type: &str,
+        provider_id: &str,
+        key_id: &str,
+        range_days: u32,
+    ) -> Result<KeyUsage, AppError> {
+        let now = chrono::Utc::now().timestamp();
+        let since = now - (range_days as i64) * 86400;
+        let conn = lock_conn!(self.conn);
+
+        // 明细按 day 聚合
+        let sql = format!(
+            "SELECT
+                 date(created_at, 'unixepoch', 'localtime') as d,
+                 COUNT(*) as req,
+                 SUM(CASE WHEN status_code >= 200 AND status_code < 300 THEN 1 ELSE 0 END) as succ,
+                 COALESCE(SUM(input_tokens), 0) as in_t,
+                 COALESCE(SUM(output_tokens), 0) as out_t,
+                 COALESCE(SUM(cache_read_tokens), 0) as cr_t,
+                 COALESCE(SUM(cache_creation_tokens), 0) as cc_t,
+                 COALESCE(SUM(CAST(total_cost_usd AS REAL)), 0) as cost
+             FROM proxy_request_logs
+             WHERE app_type = ?1 AND provider_id = ?2 AND api_key_id = ?3
+               AND created_at >= ?4
+             GROUP BY d
+             ORDER BY d DESC"
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let mut daily: Vec<KeyUsageDay> = Vec::new();
+        let rows = stmt
+            .query_map(
+                rusqlite::params![app_type, provider_id, key_id, since],
+                |row| {
+                    Ok(KeyUsageDay {
+                        date: row.get(0)?,
+                        request_count: row.get::<_, i64>(1)? as u32,
+                        success_count: row.get::<_, i64>(2)? as u32,
+                        input_tokens: row.get(3)?,
+                        output_tokens: row.get(4)?,
+                        cache_read_tokens: row.get(5)?,
+                        cache_creation_tokens: row.get(6)?,
+                        total_cost_usd: format!("{:.6}", row.get::<_, f64>(7)?),
+                    })
+                },
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        for r in rows {
+            daily.push(r.map_err(|e| AppError::Database(e.to_string()))?);
+        }
+
+        let total = KeyUsageTotal::from_days(&daily);
+        Ok(KeyUsage {
+            key_id: key_id.to_string(),
+            daily,
+            total,
+        })
+    }
+
+    /// 读取某个 provider 所有 key 的并行聚合。
+    /// 返回 Vec 长度等于该 provider 的 key 数（已 order by sort_index）。
+    /// 任何 key 在 range 内没有请求时也出现在结果中，全 0。
+    pub fn get_usage_by_provider_keys(
+        &self,
+        app_type: &str,
+        provider_id: &str,
+        range_days: u32,
+    ) -> Result<Vec<KeyUsageSummary>, AppError> {
+        let keys = self.list_api_keys(provider_id, app_type)?;
+        let mut out = Vec::with_capacity(keys.len());
+        for k in &keys {
+            let usage = self.get_usage_by_key(app_type, provider_id, &k.id, range_days)?;
+            out.push(KeyUsageSummary {
+                key_id: k.id.clone(),
+                label: k.label.clone(),
+                is_active: k.is_active,
+                enabled: k.enabled,
+                cooldown_until: k.cooldown_until,
+                total: usage.total,
+            });
+        }
+        Ok(out)
+    }
+}
+
+/// One day of usage for a single key. `total_cost_usd` 是固定精度字符串，
+/// 与 `proxy_request_logs.total_cost_usd` / `usage_daily_rollups.total_cost_usd` 口径一致。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct KeyUsageDay {
+    pub date: String,
+    pub request_count: u32,
+    pub success_count: u32,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub total_cost_usd: String,
+}
+
+/// 单 key 的总用量。`success_rate` 是 success / request 浮点百分比（0.0-100.0）。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct KeyUsageTotal {
+    pub request_count: u32,
+    pub success_count: u32,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub total_cost_usd: String,
+    pub success_rate: f32,
+}
+
+impl KeyUsageTotal {
+    fn from_days(days: &[KeyUsageDay]) -> Self {
+        let mut total = Self {
+            request_count: 0,
+            success_count: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_cost_usd: "0".to_string(),
+            success_rate: 0.0,
+        };
+        let mut cost: f64 = 0.0;
+        for d in days {
+            total.request_count = total.request_count.saturating_add(d.request_count);
+            total.success_count = total.success_count.saturating_add(d.success_count);
+            total.input_tokens = total.input_tokens.saturating_add(d.input_tokens);
+            total.output_tokens = total.output_tokens.saturating_add(d.output_tokens);
+            total.cache_read_tokens =
+                total.cache_read_tokens.saturating_add(d.cache_read_tokens);
+            total.cache_creation_tokens =
+                total.cache_creation_tokens.saturating_add(d.cache_creation_tokens);
+            cost += d.total_cost_usd.parse::<f64>().unwrap_or(0.0);
+        }
+        total.total_cost_usd = format!("{:.6}", cost);
+        if total.request_count > 0 {
+            total.success_rate =
+                (total.success_count as f32 / total.request_count as f32) * 100.0;
+        }
+        total
+    }
+}
+
+/// 完整返回值：daily 数组 + 折叠后的 total。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct KeyUsage {
+    pub key_id: String,
+    pub daily: Vec<KeyUsageDay>,
+    pub total: KeyUsageTotal,
+}
+
+/// `get_usage_by_provider_keys` 的行项：包含 key 元数据 + total，
+/// 供前端 ProviderCard 的 per-key 列表直接展示。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct KeyUsageSummary {
+    pub key_id: String,
+    pub label: String,
+    pub is_active: bool,
+    pub enabled: bool,
+    pub cooldown_until: i64,
+    pub total: KeyUsageTotal,
 }
 
 #[cfg(test)]
@@ -530,6 +705,180 @@ mod tests {
         )?;
         assert_eq!(count, 13, "10 existing + 3 new");
         assert_eq!(input, 1300, "1000 existing + 300 new");
+        Ok(())
+    }
+
+    // ─────── per-key 用量查询 ───────
+
+    fn insert_log(
+        conn: &rusqlite::Connection,
+        req_id: &str,
+        key_id: Option<&str>,
+        ts: i64,
+        status: i64,
+        in_t: i64,
+        out_t: i64,
+        cost: f64,
+    ) {
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model, api_key_id,
+                input_tokens, output_tokens, total_cost_usd,
+                latency_ms, status_code, created_at, data_source
+             ) VALUES (?1, 'p1', 'claude', 'kimi-k2', ?2, ?3, ?4, ?5, 100, ?6, ?7, 'proxy')",
+            rusqlite::params![
+                req_id,
+                key_id,
+                in_t,
+                out_t,
+                format!("{cost}"),
+                status,
+                ts,
+            ],
+        )
+        .expect("insert log");
+    }
+
+    fn seed_provider(db: &Database) -> Result<(), AppError> {
+        let conn = crate::database::lock_conn!(db.conn);
+        conn.execute(
+            "INSERT OR IGNORE INTO providers (id, app_type, name, settings_config)
+             VALUES ('p1', 'claude', 'P1', '{}')",
+            [],
+        )
+        .expect("seed provider");
+        drop(conn);
+        Ok(())
+    }
+
+    #[test]
+    fn get_usage_by_key_aggregates_only_that_key() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db)?;
+
+        // 为 key-A 和 key-B 各写两条成功 + 一条 429 失败的行
+        let now = chrono::Utc::now().timestamp();
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            for key in ["key-A", "key-B"] {
+                for i in 0..3 {
+                    let status = if i == 2 { 429 } else { 200 };
+                    insert_log(
+                        &conn,
+                        &format!("log-{key}-{i}"),
+                        Some(key),
+                        now - i * 3600,
+                        status,
+                        100,
+                        50,
+                        0.01,
+                    );
+                }
+            }
+        }
+
+        let usage = db.get_usage_by_key("claude", "p1", "key-A", 7)?;
+        assert_eq!(usage.total.request_count, 3);
+        assert_eq!(usage.total.success_count, 2);
+        // 100 + 50 tokens × 3 行 = 300 + 150
+        assert_eq!(usage.total.input_tokens, 300);
+        assert_eq!(usage.total.output_tokens, 150);
+        // success_rate ≈ 66.67%
+        assert!((usage.total.success_rate - 66.66666).abs() < 0.1);
+        assert!((usage.total.total_cost_usd.parse::<f64>().unwrap() - 0.03).abs() < 1e-6);
+
+        // key-B 是独立聚合：被 key-A 测试隔离
+        let usage_b = db.get_usage_by_key("claude", "p1", "key-B", 7)?;
+        assert_eq!(usage_b.total.request_count, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn get_usage_by_provider_keys_returns_one_summary_per_key() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db)?;
+
+        // 写两把 key，每把各一行
+        let now = chrono::Utc::now().timestamp();
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            insert_log(&conn, "log-1", Some("k-1"), now, 200, 100, 50, 0.01);
+            insert_log(&conn, "log-2", Some("k-2"), now, 500, 200, 80, 0.02);
+            // 还有一行没绑 key（api_key_id NULL）：v11 历史数据
+            insert_log(&conn, "log-3", None, now, 200, 50, 25, 0.005);
+        }
+
+        // 没插入 api_keys 时返回空 Vec（list_api_keys → 空）
+        let empty = db.get_usage_by_provider_keys("claude", "p1", 7)?;
+        assert!(empty.is_empty());
+
+        // 插入两把 key
+        let now = chrono::Utc::now().timestamp();
+        let key1 = crate::database::dao::api_keys::ProviderApiKey {
+            id: "k-1".to_string(),
+            provider_id: "p1".to_string(),
+            app_type: "claude".to_string(),
+            label: "Primary".to_string(),
+            api_key: "sk-1".to_string(),
+            tags: vec![],
+            notes: String::new(),
+            enabled: true,
+            sort_index: 0,
+            is_active: true,
+            cooldown_until: 0,
+            failure_count: 0,
+            last_used_at: None,
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let mut key2 = key1.clone();
+        key2.id = "k-2".to_string();
+        key2.label = "Backup".to_string();
+        key2.is_active = false;
+        key2.sort_index = 1;
+        db.insert_api_key(&key1)?;
+        db.insert_api_key(&key2)?;
+
+        let summaries = db.get_usage_by_provider_keys("claude", "p1", 7)?;
+        assert_eq!(summaries.len(), 2, "two keys both surfaced");
+        // 按 sort_index 排：k-1 在前
+        assert_eq!(summaries[0].key_id, "k-1");
+        assert_eq!(summaries[1].key_id, "k-2");
+        assert!(summaries[0].is_active);
+        assert!(!summaries[1].is_active);
+        assert_eq!(summaries[0].label, "Primary");
+        Ok(())
+    }
+
+    #[test]
+    fn get_usage_by_key_returns_empty_for_unknown_key() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db)?;
+        let usage = db.get_usage_by_key("claude", "p1", "nope", 7)?;
+        assert_eq!(usage.total.request_count, 0);
+        assert_eq!(usage.daily.len(), 0);
+        assert_eq!(usage.total.success_rate, 0.0);
+        Ok(())
+    }
+
+    #[test]
+    fn get_usage_by_key_respects_range_days() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db)?;
+
+        // 8 天前一条 + 1 天前一条；range=3 应该只看 1 天前那条
+        let now = chrono::Utc::now().timestamp();
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            insert_log(&conn, "old", Some("k1"), now - 8 * 86400, 200, 100, 50, 0.01);
+            insert_log(&conn, "recent", Some("k1"), now - 86400, 200, 100, 50, 0.01);
+        }
+
+        let usage_3d = db.get_usage_by_key("claude", "p1", "k1", 3)?;
+        assert_eq!(usage_3d.total.request_count, 1);
+        let usage_14d = db.get_usage_by_key("claude", "p1", "k1", 14)?;
+        assert_eq!(usage_14d.total.request_count, 2);
         Ok(())
     }
 }

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -26,7 +26,7 @@
 pub(crate) mod backup;
 pub(crate) mod dao;
 mod migration;
-mod schema;
+pub(crate) mod schema;
 
 #[cfg(test)]
 mod tests;

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -24,7 +24,7 @@
 //! ```
 
 pub(crate) mod backup;
-mod dao;
+pub(crate) mod dao;
 mod migration;
 mod schema;
 

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -183,10 +183,13 @@ impl Database {
         // 10. Proxy Request Logs 表
         // pricing_model = 写入时实际用于计价的模型名（pricing_model_source 解析结果），
         // 回填按它重算；NULL 表示 v11 之前的历史行，'' 表示未计价的错误行。
+        // v12：新增 api_key_id TEXT 列（NULL = v12 前历史行）。明细 prune 前必须
+        // 按 key 维度聚合，否则 rollback 时 key-pool 关系永久丢失。
         conn.execute("CREATE TABLE IF NOT EXISTS proxy_request_logs (
             request_id TEXT PRIMARY KEY, provider_id TEXT NOT NULL, app_type TEXT NOT NULL, model TEXT NOT NULL,
             request_model TEXT,
             pricing_model TEXT,
+            api_key_id TEXT,
             input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0,
             cache_read_tokens INTEGER NOT NULL DEFAULT 0, cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
             input_cost_usd TEXT NOT NULL DEFAULT '0', output_cost_usd TEXT NOT NULL DEFAULT '0',
@@ -261,11 +264,14 @@ impl Database {
         // request_model 保留路由接管的「客户端别名 → 真实模型」映射维度，
         // pricing_model 保留写入时的计价基准（request 计价模式下与 model 分叉），
         // 否则明细被 prune 后接管计费不可审计；历史行迁移时填 ''（未知）。
+        // v12：主键新增 api_key_id 维度——同一 provider 不同 key 的用量必须独立成行，
+        // 否则明细 prune 后 key-pool 关系永久丢失。
         conn.execute(
             "CREATE TABLE IF NOT EXISTS usage_daily_rollups (
                 date TEXT NOT NULL,
                 app_type TEXT NOT NULL,
                 provider_id TEXT NOT NULL,
+                api_key_id TEXT NOT NULL DEFAULT '',
                 model TEXT NOT NULL,
                 request_model TEXT NOT NULL DEFAULT '',
                 pricing_model TEXT NOT NULL DEFAULT '',
@@ -277,7 +283,7 @@ impl Database {
                 cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
                 total_cost_usd TEXT NOT NULL DEFAULT '0',
                 avg_latency_ms INTEGER NOT NULL DEFAULT 0,
-                PRIMARY KEY (date, app_type, provider_id, model, request_model, pricing_model)
+                PRIMARY KEY (date, app_type, provider_id, api_key_id, model, request_model, pricing_model)
             )",
             [],
         )
@@ -389,6 +395,58 @@ impl Database {
             [],
         );
 
+        // provider_api_keys：每 provider 维护多把 API key 的子表（v12 引入）。
+        // enabled 字段允许用户临时排除某把 key 不参与轮换；
+        // is_active 标记当前正在写入 live settings.json 的那把 key
+        // （live 模式只能容纳一把 key，多把时由用户/后端选一把）；
+        // cooldown_until / failure_count 是持久化在行内的运行时状态——
+        // 不拆到独立 cooldown 表是为了避免一次原子写跨两表；进程重启
+        // 直接 reload，无需"脏"队列恢复。
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS provider_api_keys (
+                id TEXT PRIMARY KEY,
+                provider_id TEXT NOT NULL,
+                app_type TEXT NOT NULL,
+                label TEXT NOT NULL,
+                api_key TEXT NOT NULL,
+                tags TEXT NOT NULL DEFAULT '[]',
+                notes TEXT NOT NULL DEFAULT '',
+                enabled BOOLEAN NOT NULL DEFAULT 1,
+                sort_index INTEGER NOT NULL DEFAULT 0,
+                is_active BOOLEAN NOT NULL DEFAULT 0,
+                cooldown_until INTEGER NOT NULL DEFAULT 0,
+                failure_count INTEGER NOT NULL DEFAULT 0,
+                last_used_at INTEGER,
+                last_error TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                FOREIGN KEY (provider_id, app_type) REFERENCES providers(id, app_type) ON DELETE CASCADE,
+                UNIQUE(provider_id, app_type, label)
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_provider_api_keys_pool
+             ON provider_api_keys(provider_id, app_type, sort_index)",
+            [],
+        );
+
+        // v12：proxy_request_logs 增加 api_key_id 列（NULL 表示 v12 前的历史行）。
+        // 现有 idx_request_logs_provider 已覆盖 provider 级查询；按 key 查询走
+        // 新增的 (api_key_id, created_at DESC) 索引。
+        let _ = Self::add_column_if_missing(
+            conn,
+            "proxy_request_logs",
+            "api_key_id",
+            "TEXT",
+        )?;
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_request_logs_key
+             ON proxy_request_logs(api_key_id, created_at DESC)",
+            [],
+        );
+
         Ok(())
     }
 
@@ -406,11 +464,18 @@ impl Database {
         let mut version = Self::get_user_version(conn)?;
 
         if version > SCHEMA_VERSION {
-            conn.execute("ROLLBACK TO schema_migration;", []).ok();
-            conn.execute("RELEASE schema_migration;", []).ok();
-            return Err(AppError::Database(format!(
-                "数据库版本过新（{version}），当前应用仅支持 {SCHEMA_VERSION}，请升级应用后再尝试。"
-            )));
+            // 开发期可通过 CC_SWITCH_DEV_BYPASS_DB_VERSION=1 跳过此保护（仅限开发环境）
+            if std::env::var_os("CC_SWITCH_DEV_BYPASS_DB_VERSION").is_some() {
+                log::warn!(
+                    "已设置 CC_SWITCH_DEV_BYPASS_DB_VERSION，跳过 DB 版本过新检查（user_version={version}, SCHEMA_VERSION={SCHEMA_VERSION}）"
+                );
+            } else {
+                conn.execute("ROLLBACK TO schema_migration;", []).ok();
+                conn.execute("RELEASE schema_migration;", []).ok();
+                return Err(AppError::Database(format!(
+                    "数据库版本过新（{version}），当前应用仅支持 {SCHEMA_VERSION}，请升级应用后再尝试。"
+                )));
+            }
         }
 
         let result = (|| {
@@ -474,9 +539,14 @@ impl Database {
                         Self::set_user_version(conn, 11)?;
                     }
                     11 => {
-                        log::info!("迁移数据库从 v11 到 v12（添加项目 Profiles 表）");
+                        log::info!("迁移数据库从 v11 到 v12（多 API Key 支持：provider_api_keys 表 + proxy_request_logs.api_key_id + 用量聚合按 key 分组）");
                         Self::migrate_v11_to_v12(conn)?;
                         Self::set_user_version(conn, 12)?;
+                    }
+                    12 => {
+                        log::info!("迁移数据库从 v12 到 v13（添加项目 Profiles 表）");
+                        Self::migrate_v12_to_v13(conn)?;
+                        Self::set_user_version(conn, 13)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -648,6 +718,7 @@ impl Database {
         conn.execute("CREATE TABLE IF NOT EXISTS proxy_request_logs (
             request_id TEXT PRIMARY KEY, provider_id TEXT NOT NULL, app_type TEXT NOT NULL, model TEXT NOT NULL,
             request_model TEXT,
+            api_key_id TEXT,
             input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0,
             cache_read_tokens INTEGER NOT NULL DEFAULT 0, cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
             input_cost_usd TEXT NOT NULL DEFAULT '0', output_cost_usd TEXT NOT NULL DEFAULT '0',
@@ -1304,9 +1375,288 @@ impl Database {
         Ok(())
     }
 
-    /// v11 -> v12 迁移：添加项目 Profiles 表
-    /// 与 create_tables_on_conn 中的建表语句保持一致（IF NOT EXISTS 保证幂等）
+    /// v11 → v12：多 API Key 支持
+    ///
+    /// 1. usage_daily_rollups 主键新增 `api_key_id` 维度（SQLite 改主键必须重建表）。
+    ///    历史行的 api_key_id 用 '' 表示"v12 前数据、未绑定具体 key"。
+    /// 2. 为每个持有可解析 API key 的 provider 在 `provider_api_keys` 写入一条
+    ///    `label="Default"`、`is_active=1` 的种子行——保证前端 / forwarder 立刻能
+    ///    在不感知迁移的前提下读出"当前那把 key"，向后兼容单 key 调用路径。
+    /// 3. OAuth-managed provider（GitHub Copilot、Codex OAuth）由 `meta.provider_type`
+    ///    标识，它们的凭据通过 device-code 流程动态获取，**不**走 api_key 池；
+    ///    这里直接跳过。
+    /// 4. CLAUDE_DESKTOP_OFFICIAL_SEED_ID（v3.x 内置的官方 Claude Desktop 占位）
+    ///    也没有外部 key，跳过。
     fn migrate_v11_to_v12(conn: &Connection) -> Result<(), AppError> {
+        // ---- 1. 重建 usage_daily_rollups 主键 ----
+        if Self::table_exists(conn, "usage_daily_rollups")? {
+            conn.execute_batch(
+                "ALTER TABLE usage_daily_rollups RENAME TO usage_daily_rollups_v11;
+                 CREATE TABLE usage_daily_rollups (
+                     date TEXT NOT NULL,
+                     app_type TEXT NOT NULL,
+                     provider_id TEXT NOT NULL,
+                     api_key_id TEXT NOT NULL DEFAULT '',
+                     model TEXT NOT NULL,
+                     request_model TEXT NOT NULL DEFAULT '',
+                     pricing_model TEXT NOT NULL DEFAULT '',
+                     request_count INTEGER NOT NULL DEFAULT 0,
+                     success_count INTEGER NOT NULL DEFAULT 0,
+                     input_tokens INTEGER NOT NULL DEFAULT 0,
+                     output_tokens INTEGER NOT NULL DEFAULT 0,
+                     cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                     cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+                     total_cost_usd TEXT NOT NULL DEFAULT '0',
+                     avg_latency_ms INTEGER NOT NULL DEFAULT 0,
+                     PRIMARY KEY (date, app_type, provider_id, api_key_id, model, request_model, pricing_model)
+                 );
+                 INSERT INTO usage_daily_rollups
+                     (date, app_type, provider_id, api_key_id, model, request_model, pricing_model,
+                      request_count, success_count, input_tokens, output_tokens,
+                      cache_read_tokens, cache_creation_tokens, total_cost_usd, avg_latency_ms)
+                 SELECT date, app_type, provider_id, '', model, request_model, pricing_model,
+                      request_count, success_count, input_tokens, output_tokens,
+                      cache_read_tokens, cache_creation_tokens, total_cost_usd, avg_latency_ms
+                 FROM usage_daily_rollups_v11;
+                 DROP TABLE usage_daily_rollups_v11;",
+            )
+            .map_err(|e| {
+                AppError::Database(format!("v11 -> v12 重建 usage_daily_rollups 失败: {e}"))
+            })?;
+        }
+
+        // ---- 2. provider_api_keys 表 + 索引 ----
+        // 必须在 backfill INSERT **之前**建表——v11 升级路径下这张表不存在，
+        // CREATE IF NOT EXISTS 幂等，fresh install 由 create_tables_on_conn
+        // 走过之后这里 no-op。
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS provider_api_keys (
+                id TEXT PRIMARY KEY,
+                provider_id TEXT NOT NULL,
+                app_type TEXT NOT NULL,
+                label TEXT NOT NULL,
+                api_key TEXT NOT NULL,
+                tags TEXT NOT NULL DEFAULT '[]',
+                notes TEXT NOT NULL DEFAULT '',
+                enabled BOOLEAN NOT NULL DEFAULT 1,
+                sort_index INTEGER NOT NULL DEFAULT 0,
+                is_active BOOLEAN NOT NULL DEFAULT 0,
+                cooldown_until INTEGER NOT NULL DEFAULT 0,
+                failure_count INTEGER NOT NULL DEFAULT 0,
+                last_used_at INTEGER,
+                last_error TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                FOREIGN KEY (provider_id, app_type) REFERENCES providers(id, app_type) ON DELETE CASCADE,
+                UNIQUE(provider_id, app_type, label)
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("v11->v12: 创建 provider_api_keys 失败: {e}")))?;
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_provider_api_keys_pool
+             ON provider_api_keys(provider_id, app_type, sort_index)",
+            [],
+        );
+
+        // ---- 3. 反向 seed：把单 key provider 翻译成 provider_api_keys 行 ----
+        // 跳过 OAuth-managed（凭据走 device-code 流程，无静态 api_key）
+        // 跳过官方 Claude Desktop 占位行（同理，无外部 key）
+        // 注意：v10→v11 的迁移测试 fixture 只有 rollup 表，没有 providers——这种
+        // 半残 fixture 必须容忍。生产路径里 providers 表由更早的 v0/v1 迁移创建。
+        let mut backfilled = 0usize;
+        let mut skipped_oauth = 0usize;
+        let mut skipped_empty = 0usize;
+        if !Self::table_exists(conn, "providers")? {
+            log::info!("v11 -> v12: providers 表不存在，跳过 seed（fixture 路径）");
+        } else {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, app_type, settings_config, meta FROM providers
+                 WHERE id != 'claude-desktop-official'",
+            )
+            .map_err(|e| AppError::Database(format!("读取 provider 列表失败: {e}")))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            })
+            .map_err(|e| AppError::Database(format!("迭代 provider 行失败: {e}")))?;
+
+        let now = chrono::Utc::now().timestamp();
+
+        for row in rows {
+            let (provider_id, app_type, settings_config_str, meta_str) =
+                row.map_err(|e| AppError::Database(e.to_string()))?;
+
+            // OAuth-managed 检测：meta.providerType in {"github_copilot", "codex_oauth"}
+            if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&meta_str) {
+                if let Some(pt) = meta.get("providerType").and_then(|v| v.as_str()) {
+                    if pt == "github_copilot" || pt == "codex_oauth" {
+                        skipped_oauth += 1;
+                        continue;
+                    }
+                }
+                // 同时跳过显式 authBinding.source == "managed_account" 的行
+                if meta
+                    .get("authBinding")
+                    .and_then(|b| b.get("source"))
+                    .and_then(|s| s.as_str())
+                    == Some("managed_account")
+                {
+                    skipped_oauth += 1;
+                    continue;
+                }
+            }
+
+            let api_key = Self::extract_legacy_api_key(&settings_config_str, &app_type);
+            if api_key.is_empty() {
+                skipped_empty += 1;
+                continue;
+            }
+
+            // 确定性 id：相同 (provider_id, app_type) 多次重跑 INSERT OR IGNORE 命中唯一约束
+            let key_id = format!("legacy-{provider_id}-{app_type}");
+            let seed_id = format!("legacy-{provider_id}-{app_type}");
+            let tags = "[]";
+
+            // 只有当没有同 provider 的活动 key 时才把这一把标 is_active=1
+            // —— 防御性：极少数情况（用户手动 INSERT 过 provider_api_keys 行）也保留他们的高优先级选择
+            conn.execute(
+                "INSERT OR IGNORE INTO provider_api_keys (
+                    id, provider_id, app_type, label, api_key, tags,
+                    enabled, sort_index, is_active,
+                    cooldown_until, failure_count,
+                    created_at, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, 0, 1, 0, 0, ?7, ?7)",
+                params![
+                    key_id,
+                    provider_id,
+                    app_type,
+                    "Default",
+                    api_key,
+                    tags,
+                    now,
+                ],
+            )
+            .map_err(|e| {
+                AppError::Database(format!("种子 provider_api_keys 行失败 ({seed_id}): {e}"))
+            })?;
+            backfilled += 1;
+        }
+        } // end else (providers table exists)
+
+        log::info!(
+            "v11 -> v12 迁移完成：backfilled {backfilled} 个 provider_api_keys 行，跳过 {skipped_oauth} 个 OAuth-managed、{skipped_empty} 个无 key"
+        );
+
+        // ---- 4. proxy_request_logs.api_key_id ----
+        // 现有 v11 数据库（无此列）必须补上。add_column_if_missing 幂等——fresh
+        // schema 走过 create_tables_on_conn 已创建，本调用 no-op。
+        let _ = Self::add_column_if_missing(
+            conn,
+            "proxy_request_logs",
+            "api_key_id",
+            "TEXT",
+        )?;
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_request_logs_key
+             ON proxy_request_logs(api_key_id, created_at DESC)",
+            [],
+        );
+
+        Ok(())
+    }
+
+    /// 从 v11 的 `settings_config` JSON 中按 app 提取唯一的 API key。
+    ///
+    /// 镜像 `Provider::resolve_usage_credentials` 的解析逻辑（`provider.rs:119-208`），
+    /// 但写成纯函数以便在迁移路径（不构造 Provider 实例）里调用。
+    /// 返回 `""` 表示该 provider 没有静态 key（OAuth / 官方占位 / 未配置）。
+    ///
+    /// `pub(crate)`：除了迁移（v11→v12 backfill）外，`ProviderService::add`
+    /// 也会调用——在新建 provider 时把 settings_config 里的 api key seed 进
+    /// provider_api_keys 表，让池与 settings_config 保持同步（review P2）。
+    pub(crate) fn extract_legacy_api_key(settings_config_str: &str, app_type: &str) -> String {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(settings_config_str) else {
+            return String::new();
+        };
+
+        // 辅助：从 env map 中按顺序找第一个非空字符串值（空字符串视为未设置——
+        // 与 provider.rs 里的 first_non_empty 语义对齐，避免预设中 "" 占位吞掉真实 key）
+        fn first_non_empty(env: Option<&serde_json::Value>, keys: &[&str]) -> String {
+            let Some(env) = env else { return String::new() };
+            for key in keys {
+                if let Some(s) = env.get(*key).and_then(|v| v.as_str()) {
+                    if !s.is_empty() {
+                        return s.to_string();
+                    }
+                }
+            }
+            String::new()
+        }
+
+        match app_type {
+            // Claude / ClaudeDesktop：env 风格
+            "claude" | "claude-desktop" => first_non_empty(
+                value.get("env"),
+                &[
+                    "ANTHROPIC_AUTH_TOKEN",
+                    "ANTHROPIC_API_KEY",
+                    "OPENROUTER_API_KEY",
+                    "GOOGLE_API_KEY",
+                ],
+            ),
+            // Codex：auth.OPENAI_API_KEY（兼容顶层 OPENAI_API_KEY 的历史形态）
+            "codex" => value
+                .get("auth")
+                .and_then(|a| a.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .or_else(|| {
+                    value
+                        .get("OPENAI_API_KEY")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                })
+                .unwrap_or_default(),
+            // Gemini：env.GEMINI_API_KEY || env.GOOGLE_API_KEY
+            "gemini" => first_non_empty(value.get("env"), &["GEMINI_API_KEY", "GOOGLE_API_KEY"]),
+            // Hermes：顶层 snake_case
+            "hermes" => value
+                .get("api_key")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .unwrap_or_default(),
+            // OpenClaw：顶层 camelCase
+            "openclaw" => value
+                .get("apiKey")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .unwrap_or_default(),
+            // OpenCode：嵌套 options.apiKey
+            "opencode" => value
+                .get("options")
+                .and_then(|o| o.get("apiKey"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .unwrap_or_default(),
+            _ => String::new(),
+        }
+    }
+
+    /// v12 -> v13 迁移：添加项目 Profiles 表
+    /// 与 create_tables_on_conn 中的建表语句保持一致（IF NOT EXISTS 保证幂等）
+    fn migrate_v12_to_v13(conn: &Connection) -> Result<(), AppError> {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS profiles (
                 id TEXT PRIMARY KEY,
@@ -1318,13 +1668,12 @@ impl Database {
             )",
             [],
         )
-        .map_err(|e| AppError::Database(format!("v11 -> v12 创建 profiles 表失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("v12 -> v13 创建 profiles 表失败: {e}")))?;
         Ok(())
     }
 
+
     /// 插入默认模型定价数据
-    /// 格式: (model_id, display_name, input, output, cache_read, cache_creation)
-    /// 注意: model_id 使用短横线格式（如 claude-haiku-4-5），与 API 返回的模型名称标准化后一致
     fn seed_model_pricing(conn: &Connection) -> Result<(), AppError> {
         let pricing_data = [
             // Claude Fable 5（Opus 之上的新档）

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -887,3 +887,356 @@ fn ensure_incremental_auto_vacuum_rebuilds_existing_file_db() {
         "file db should persist INCREMENTAL auto_vacuum after VACUUM rebuild"
     );
 }
+
+// ─────────── v11 → v12: 多 API Key 迁移 ───────────
+
+#[test]
+fn migration_v11_to_v12_creates_provider_api_keys_table() {
+    let conn = Connection::open_in_memory().expect("open memory db");
+    Database::create_tables_on_conn(&conn).expect("create tables");
+
+    // 新表存在 + 关键列约束
+    let label_col = get_column_info(&conn, "provider_api_keys", "label");
+    assert_eq!(label_col.r#type, "TEXT");
+    assert_eq!(label_col.notnull, 1);
+
+    let enabled_col = get_column_info(&conn, "provider_api_keys", "enabled");
+    assert_eq!(enabled_col.r#type, "BOOLEAN");
+    assert_eq!(enabled_col.notnull, 1);
+    assert_eq!(normalize_default(&enabled_col.default).as_deref(), Some("1"));
+
+    let is_active_col = get_column_info(&conn, "provider_api_keys", "is_active");
+    assert_eq!(is_active_col.r#type, "BOOLEAN");
+    assert_eq!(is_active_col.notnull, 1);
+    assert_eq!(normalize_default(&is_active_col.default).as_deref(), Some("0"));
+
+    // proxy_request_logs 新增 api_key_id 列（可空 = 历史行语义）
+    let key_id_col = get_column_info(&conn, "proxy_request_logs", "api_key_id");
+    assert_eq!(key_id_col.r#type, "TEXT");
+    assert_eq!(key_id_col.notnull, 0);
+}
+
+#[test]
+fn migration_v11_to_v12_rebuilds_rollups_with_api_key_id_dimension() {
+    // 走完整 v12 schema（用 create_tables_on_conn），再回退 v12 引入的两项 schema，
+    // set user_version=11 触发迁移，验证 rollup 表被重建 + 新列/索引/表就位
+    let conn = Connection::open_in_memory().expect("open memory db");
+    Database::create_tables_on_conn(&conn).expect("create tables");
+
+    // 把 v12 的新增物回退掉：drop 索引（依赖 api_key_id）→ drop 列 → drop 新表
+    // → 把 rollup 表回退到 v11 形状（无 api_key_id）
+    conn.execute_batch(
+        r#"
+        DROP INDEX IF EXISTS idx_request_logs_key;
+        ALTER TABLE proxy_request_logs DROP COLUMN api_key_id;
+        DROP TABLE IF EXISTS provider_api_keys;
+        DROP INDEX IF EXISTS idx_provider_api_keys_pool;
+        ALTER TABLE usage_daily_rollups RENAME TO usage_daily_rollups_pre12;
+        CREATE TABLE usage_daily_rollups (
+            date TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            provider_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            request_model TEXT NOT NULL DEFAULT '',
+            pricing_model TEXT NOT NULL DEFAULT '',
+            request_count INTEGER NOT NULL DEFAULT 0,
+            success_count INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+            total_cost_usd TEXT NOT NULL DEFAULT '0',
+            avg_latency_ms INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (date, app_type, provider_id, model, request_model, pricing_model)
+        );
+        INSERT INTO usage_daily_rollups
+            (date, app_type, provider_id, model, request_model, pricing_model,
+             request_count, success_count, input_tokens, output_tokens,
+             cache_read_tokens, cache_creation_tokens, total_cost_usd, avg_latency_ms)
+        SELECT date, app_type, provider_id, model, request_model, pricing_model,
+             request_count, success_count, input_tokens, output_tokens,
+             cache_read_tokens, cache_creation_tokens, total_cost_usd, avg_latency_ms
+        FROM usage_daily_rollups_pre12;
+        DROP TABLE usage_daily_rollups_pre12;
+        "#,
+    )
+    .expect("revert to v11 schema");
+
+    Database::set_user_version(&conn, 11).expect("set user_version=11");
+    Database::apply_schema_migrations_on_conn(&conn).expect("apply migrations");
+
+    // 新列存在
+    let kid_col = get_column_info(&conn, "usage_daily_rollups", "api_key_id");
+    assert_eq!(kid_col.r#type, "TEXT");
+    assert_eq!(kid_col.notnull, 1);
+    assert_eq!(normalize_default(&kid_col.default).as_deref(), Some(""));
+
+    // 明细表补上 api_key_id 列（可空 = 历史行语义）
+    // 用 has_column 检查后再调用 get_column_info，避免 panic 信息混淆
+    assert!(
+        Database::has_column(&conn, "proxy_request_logs", "api_key_id").expect("check"),
+        "proxy_request_logs.api_key_id should be added by migration"
+    );
+    let key_id_col = get_column_info(&conn, "proxy_request_logs", "api_key_id");
+    assert_eq!(key_id_col.r#type, "TEXT");
+    assert_eq!(key_id_col.notnull, 0);
+
+    // provider_api_keys 表 + 索引就位
+    assert!(
+        Database::has_column(&conn, "provider_api_keys", "label").expect("check"),
+        "provider_api_keys should exist after migration"
+    );
+
+    // 主键包含 api_key_id：同 provider + model + 维度下，'' 与具体 key_id 可共存
+    conn.execute(
+        "INSERT INTO usage_daily_rollups
+            (date, app_type, provider_id, api_key_id, model, request_model, request_count)
+         VALUES ('2026-05-01', 'claude', 'p1', 'key-1', 'kimi-k2', '', 1)",
+        [],
+    )
+    .expect("insert row with api_key_id");
+}
+
+#[test]
+fn migration_v11_to_v12_backfills_existing_single_key_providers() {
+    // 用 create_tables_on_conn 走完整 v12 schema（空 provider_api_keys 表），
+    // set v11 让迁移路径里"重建 rollup + INSERT OR IGNORE 入 key 池"再跑一遍。
+    // INSERT OR IGNORE 依赖 (provider_id, app_type, label) 唯一约束：
+    // 相同 fixture 多次重跑不会重复插入。
+    let conn = Connection::open_in_memory().expect("open memory db");
+    Database::create_tables_on_conn(&conn).expect("create tables");
+
+    conn.execute(
+        "INSERT INTO providers (id, app_type, name, settings_config)
+         VALUES ('p-claude', 'claude', 'P-Claude',
+                 '{\"env\":{\"ANTHROPIC_AUTH_TOKEN\":\"sk-claude-real\"}}')",
+        [],
+    )
+    .expect("seed claude provider");
+    conn.execute(
+        "INSERT INTO providers (id, app_type, name, settings_config)
+         VALUES ('p-codex', 'codex', 'P-Codex',
+                 '{\"auth\":{\"OPENAI_API_KEY\":\"sk-codex-real\"}}')",
+        [],
+    )
+    .expect("seed codex provider");
+    conn.execute(
+        "INSERT INTO providers (id, app_type, name, settings_config, meta)
+         VALUES ('p-copilot', 'claude', 'P-Copilot',
+                 '{\"env\":{}}',
+                 '{\"providerType\":\"github_copilot\"}')",
+        [],
+    )
+    .expect("seed copilot provider");
+    conn.execute(
+        "INSERT INTO providers (id, app_type, name, settings_config)
+         VALUES ('p-empty', 'claude', 'P-Empty', '{\"env\":{}}')",
+        [],
+    )
+    .expect("seed empty provider");
+
+    Database::set_user_version(&conn, 11).expect("set user_version=11");
+    Database::apply_schema_migrations_on_conn(&conn).expect("apply migrations");
+
+    // Claude + Codex 各被 backfill 一行；copilot (OAuth) + empty 跳过
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM provider_api_keys", [], |row| row.get(0))
+        .expect("count api_keys");
+    assert_eq!(count, 2, "exactly two single-key providers should be backfilled");
+
+    let (claude_key, claude_label, claude_active): (String, String, i64) = conn
+        .query_row(
+            "SELECT api_key, label, is_active FROM provider_api_keys
+             WHERE provider_id = 'p-claude' AND app_type = 'claude'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("claude backfilled row");
+    assert_eq!(claude_key, "sk-claude-real");
+    assert_eq!(claude_label, "Default");
+    assert_eq!(claude_active, 1);
+
+    let (codex_key, codex_label): (String, String) = conn
+        .query_row(
+            "SELECT api_key, label FROM provider_api_keys
+             WHERE provider_id = 'p-codex' AND app_type = 'codex'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("codex backfilled row");
+    assert_eq!(codex_key, "sk-codex-real");
+    assert_eq!(codex_label, "Default");
+}
+
+#[test]
+fn migration_v11_to_v12_skips_official_claude_desktop_seed() {
+    // claude-desktop-official 是 v3.x 写入的内置占位，没有 key。
+    // 不能被 backfill 一行带空 api_key 的"假 key"——那会让前端把无凭据的
+    // provider 当作可轮换，污染 OAuth-style 走法。
+    let conn = Connection::open_in_memory().expect("open memory db");
+    Database::create_tables_on_conn(&conn).expect("create tables");
+
+    conn.execute(
+        "INSERT INTO providers (id, app_type, name, settings_config, meta)
+        VALUES ('claude-desktop-official', 'claude-desktop', 'Official', '{}', '{}')",
+        [],
+    )
+    .expect("seed official placeholder");
+
+    Database::set_user_version(&conn, 11).expect("set user_version=11");
+    Database::apply_schema_migrations_on_conn(&conn).expect("apply migrations");
+
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM provider_api_keys", [], |row| row.get(0))
+        .expect("count api_keys");
+    assert_eq!(count, 0, "official placeholder must not be backfilled");
+}
+
+#[test]
+fn migration_v11_to_v12_rollup_groups_by_api_key_id() -> Result<(), AppError> {
+    // 端到端：v12 schema 下写入带 api_key_id 的明细 → rollup_and_prune →
+    // 验证聚合按 key 拆开（同 model 不同 key 各自成行）。
+    // Database::memory() 已经走完 v12 schema，无需手动构造。
+    let db = Database::memory().expect("memory db");
+    let now = chrono::Utc::now().timestamp();
+    let old_ts = now - 40 * 86400;
+    {
+        let conn = crate::database::lock_conn!(db.conn);
+        for (i, key_id) in ["key-A", "key-B"].iter().enumerate() {
+            for j in 0..2 {
+                conn.execute(
+                    "INSERT INTO proxy_request_logs (
+                        request_id, provider_id, app_type, model, api_key_id,
+                        input_tokens, output_tokens, total_cost_usd,
+                        latency_ms, status_code, created_at
+                     ) VALUES (?1, 'p1', 'claude', 'kimi-k2', ?2, 100, 50, '0.01', 100, 200, ?3)",
+                    rusqlite::params![format!("log-{i}-{j}"), key_id, old_ts + (i * 2 + j) as i64],
+                )
+                .expect("insert log");
+            }
+        }
+    }
+
+    let deleted = db.rollup_and_prune(30).expect("rollup");
+    assert_eq!(deleted, 4);
+
+    let conn = crate::database::lock_conn!(db.conn);
+    let mut stmt = conn
+        .prepare(
+            "SELECT api_key_id, request_count FROM usage_daily_rollups
+             WHERE model = 'kimi-k2' ORDER BY api_key_id",
+        )
+        .expect("prepare");
+    let rows: Vec<(String, i64)> = stmt
+        .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))
+        .expect("query")
+        .collect::<Result<_, _>>()
+        .expect("collect");
+    assert_eq!(
+        rows,
+        vec![("key-A".to_string(), 2), ("key-B".to_string(), 2)],
+        "per-key aggregation must split rollup rows"
+    );
+    Ok(())
+}
+
+/// 真实 v11→v12 迁移路径：fixture 里**没有** provider_api_keys 表。
+/// 之前 create_tables_on_conn + drop 的测试用本地 mock schema，不能保证
+/// 真实升级路径能跑通——这一条直接搭一个 v11 形状的 DB（无 api_keys 表），
+/// 跑迁移，验证：
+/// 1. provider_api_keys 表被创建
+/// 2. backfill INSERT 在表已建好的前提下成功
+/// 3. 迁移完成后 schema 与 create_tables_on_conn 输出一致
+#[test]
+fn migration_v11_to_v12_real_path_without_provider_api_keys_table() {
+    // 搭一个 v11 形状的 DB：只有 providers（无 provider_api_keys）+ v11 形状的
+    // proxy_request_logs（无 api_key_id 列）+ v11 形状的 usage_daily_rollups
+    // （主键无 api_key_id）。
+    let conn = Connection::open_in_memory().expect("open memory db");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE providers (
+            id TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            settings_config TEXT NOT NULL,
+            meta TEXT NOT NULL DEFAULT '{}',
+            PRIMARY KEY (id, app_type)
+        );
+        CREATE TABLE proxy_request_logs (
+            request_id TEXT PRIMARY KEY,
+            provider_id TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            model TEXT NOT NULL,
+            request_model TEXT,
+            pricing_model TEXT,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+            total_cost_usd TEXT NOT NULL DEFAULT '0',
+            latency_ms INTEGER NOT NULL,
+            first_token_ms INTEGER,
+            duration_ms INTEGER,
+            status_code INTEGER NOT NULL,
+            error_message TEXT,
+            session_id TEXT,
+            provider_type TEXT,
+            is_streaming INTEGER NOT NULL DEFAULT 0,
+            cost_multiplier TEXT NOT NULL DEFAULT '1.0',
+            created_at INTEGER NOT NULL,
+            data_source TEXT NOT NULL DEFAULT 'proxy'
+        );
+        CREATE TABLE usage_daily_rollups (
+            date TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            provider_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            request_model TEXT NOT NULL DEFAULT '',
+            pricing_model TEXT NOT NULL DEFAULT '',
+            request_count INTEGER NOT NULL DEFAULT 0,
+            success_count INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+            total_cost_usd TEXT NOT NULL DEFAULT '0',
+            avg_latency_ms INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (date, app_type, provider_id, model, request_model, pricing_model)
+        );
+        INSERT INTO providers (id, app_type, name, settings_config)
+        VALUES ('p1', 'claude', 'P1',
+                '{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-real"}}');
+        "#,
+    )
+    .expect("seed v11-shape DB");
+    Database::set_user_version(&conn, 11).expect("set v11");
+
+    // 真实路径：没有 create_tables_on_conn 调用，纯粹靠 migrate_v11_to_v12
+    Database::apply_schema_migrations_on_conn(&conn).expect("v11→v12 must succeed");
+
+    // provider_api_keys 表应已存在
+    assert!(
+        Database::table_exists(&conn, "provider_api_keys").expect("check"),
+        "provider_api_keys table must be created by the migration"
+    );
+
+    // backfill 应该把 p1 的 key 写入
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM provider_api_keys", [], |row| row.get(0))
+        .expect("count api_keys");
+    assert_eq!(count, 1, "exactly one backfilled key");
+
+    // 列存在且为 p1 的真实 key
+    let (api_key, label, is_active): (String, String, i64) = conn
+        .query_row(
+            "SELECT api_key, label, is_active FROM provider_api_keys
+             WHERE provider_id = 'p1' AND app_type = 'claude'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read backfilled row");
+    assert_eq!(api_key, "sk-real");
+    assert_eq!(label, "Default");
+    assert_eq!(is_active, 1);
+}

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -269,6 +269,7 @@ fn build_provider_meta(request: &DeepLinkImportRequest) -> Result<Option<Provide
         secret_access_key: None,
         team_organization_id: None,
         team_project_id: None,
+        group_id: None,
     };
 
     Ok(Some(ProviderMeta {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -209,7 +209,7 @@ async fn update_tray_menu(
 
 #[cfg(target_os = "macos")]
 fn macos_tray_icon() -> Option<Image<'static>> {
-    const ICON_BYTES: &[u8] = include_bytes!("../icons/tray/macos/statusbar_template_3x.png");
+    const ICON_BYTES: &[u8] = include_bytes!("../icons/tray/macos/statusTemplate.png");
 
     match Image::from_bytes(ICON_BYTES) {
         Ok(icon) => Some(icon),
@@ -264,6 +264,10 @@ pub fn run() {
                 {
                     linux_fix::nudge_main_window(window.clone());
                 }
+                #[cfg(target_os = "macos")]
+                {
+                    tray::nudge_main_window_on_macos(window.clone());
+                }
             }
         }));
     }
@@ -301,6 +305,22 @@ pub fn run() {
                     api.prevent_close();
                     window.app_handle().exit(0);
                 }
+            }
+
+            #[cfg(target_os = "macos")]
+            {
+                if let tauri::WindowEvent::Focused(focused) = event {
+                    if *focused {
+                        if let Some(webview_window) = window.app_handle().get_webview_window("main") {
+                            tray::nudge_main_window_on_macos(webview_window);
+                        }
+                    }
+                }
+
+                // 注意：不在 Resized 事件里 nudge——macOS WebKit 的
+                // Resized 事件会被 nudge 自身的 set_size 反复触发，
+                // 形成回调风暴。改用 webview 端的 CSS 媒体查询 / ResizeObserver
+                // 处理自适应布局，或让用户手动最大化时由 maximize 事件触发。
             }
         })
         .plugin(tauri_plugin_process::init())
@@ -420,29 +440,36 @@ pub fn run() {
             //
             // 预检：数据库版本过新时，必须先于任何 schema 写操作（create_tables 内含
             // DROP/ALTER 等 DDL）进入恢复界面，避免旧应用对读不懂的更新版 DB 落写。
-            match crate::database::Database::stored_user_version_exceeds_supported(&db_path) {
-                Ok(Some(version)) => {
-                    log::warn!("数据库版本过新（v{version}），引导用户在应用内升级应用");
-                    crate::init_status::set_init_error(crate::init_status::InitErrorPayload {
-                        path: db_path.display().to_string(),
-                        error: format!(
-                            "数据库版本过新（{version}），当前应用仅支持 {}，请升级应用后再尝试。",
-                            crate::database::SCHEMA_VERSION
-                        ),
-                        kind: Some("db_version_too_new".to_string()),
-                        db_version: Some(version),
-                        supported_version: Some(crate::database::SCHEMA_VERSION),
-                    });
-                    // 主窗口默认 visible:false，恢复界面必须强制显示
-                    if let Some(window) = app.get_webview_window("main") {
-                        let _ = window.show();
-                        let _ = window.set_focus();
+            // 开发期可通过 CC_SWITCH_DEV_BYPASS_DB_VERSION=1 跳过此预检。
+            if std::env::var_os("CC_SWITCH_DEV_BYPASS_DB_VERSION").is_some() {
+                log::warn!(
+                    "已设置 CC_SWITCH_DEV_BYPASS_DB_VERSION，跳过数据库版本过新预检（仅限开发环境）"
+                );
+            } else {
+                match crate::database::Database::stored_user_version_exceeds_supported(&db_path) {
+                    Ok(Some(version)) => {
+                        log::warn!("数据库版本过新（v{version}），引导用户在应用内升级应用");
+                        crate::init_status::set_init_error(crate::init_status::InitErrorPayload {
+                            path: db_path.display().to_string(),
+                            error: format!(
+                                "数据库版本过新（{version}），当前应用仅支持 {}，请升级应用后再尝试。",
+                                crate::database::SCHEMA_VERSION
+                            ),
+                            kind: Some("db_version_too_new".to_string()),
+                            db_version: Some(version),
+                            supported_version: Some(crate::database::SCHEMA_VERSION),
+                        });
+                        // 主窗口默认 visible:false，恢复界面必须强制显示
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                        }
+                        return Ok(());
                     }
-                    return Ok(());
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    log::warn!("预检数据库版本失败，继续正常初始化流程: {e}");
+                    Ok(None) => {}
+                    Err(e) => {
+                        log::warn!("预检数据库版本失败，继续正常初始化流程: {e}");
+                    }
                 }
             }
 
@@ -703,6 +730,43 @@ pub fn run() {
                 Err(e) => log::warn!("✗ Failed to import Hermes providers: {e}"),
             }
 
+            // Per-key live config 写入迁移（multi-api-keys 第一次启动时跑一遍）。
+            // 已有 provider 的 N 把 key 各自生成 on-disk 副本
+            // （`{config_dir}/keys/{provider_id}/{key_id}.<ext>`）——保证
+            // 升级后立即可用。完成后写迁移标记，不再跑。
+            let migrations =
+                app_state.db.get_setting("local_migrations").ok().flatten();
+            if let Some(json) = migrations {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json) {
+                    if parsed.get("multiApiKeysFilesV1").is_none() {
+                        log::info!(
+                            "Running per-key live config migration (multi_api_keys_files_v1)..."
+                        );
+                        match crate::services::provider::per_key_live::regenerate_all_per_key_files(
+                            app_state.db.as_ref(),
+                        ) {
+                            Ok(()) => {
+                                let mut m = parsed;
+                                m["multiApiKeysFilesV1"] = serde_json::json!({
+                                    "completedAt": chrono::Utc::now().to_rfc3339(),
+                                    "providersScanned": 0,
+                                    "filesWritten": 0,
+                                });
+                                if let Ok(s) = serde_json::to_string(&m) {
+                                    let _ = app_state.db.set_setting("local_migrations", &s);
+                                }
+                                log::info!(
+                                    "✓ Per-key live config migration completed"
+                                );
+                            }
+                            Err(e) => log::warn!(
+                                "✗ Per-key live config migration failed: {e}"
+                            ),
+                        }
+                    }
+                }
+            }
+
             // 2. OMO 配置导入（当数据库中无 OMO provider 时，从本地文件导入）
             {
                 let has_omo = app_state
@@ -922,11 +986,10 @@ pub fn run() {
             // 使用平台对应的托盘图标（macOS 使用模板图标适配深浅色）
             #[cfg(target_os = "macos")]
             {
-                if let Some(icon) = macos_tray_icon() {
-                    tray_builder = tray_builder.icon(icon).icon_as_template(true);
-                } else if let Some(icon) = app.default_window_icon() {
-                    log::warn!("Falling back to default window icon for tray");
+                if let Some(icon) = app.default_window_icon() {
                     tray_builder = tray_builder.icon(icon.clone());
+                } else if let Some(icon) = macos_tray_icon() {
+                    tray_builder = tray_builder.icon(icon).icon_as_template(true);
                 } else {
                     log::warn!("Failed to load macOS tray icon for tray");
                 }
@@ -1155,6 +1218,17 @@ pub fn run() {
 
             // 静默启动：根据设置决定是否显示主窗口
             let settings = crate::settings::get_settings();
+
+            // macOS: silent_startup 模式下把激活策略切到 Accessory，dock
+            // 隐藏，窗口由 `window.hide()` 负责隐藏。**先**于 `window.show`
+            // 切策略，避免「先 show 后改策略」导致 dock 图标闪一下又消失的
+            // 现象。正常启动模式无需显式 set_activation_policy——Tauri 默认
+            // 就是 Regular，由 show() + set_focus() 决定焦点归属。
+            #[cfg(target_os = "macos")]
+            if settings.silent_startup {
+                tray::apply_tray_policy(app.handle(), false);
+            }
+
             if let Some(window) = app.get_webview_window("main") {
                 // 在窗口首次显示前同步装饰状态，避免前端加载后再切换导致标题栏闪烁
                 // 仅 Linux 生效：解决 Wayland 下系统窗口按钮不可用的问题
@@ -1165,13 +1239,40 @@ pub fn run() {
                     let _ = window.hide();
                     #[cfg(target_os = "windows")]
                     let _ = window.set_skip_taskbar(true);
-                    #[cfg(target_os = "macos")]
-                    tray::apply_tray_policy(app.handle(), false);
                     log::info!("静默启动模式：主窗口已隐藏");
                 } else {
                     // 正常启动模式：显示窗口
                     let _ = window.show();
+                    let _ = window.unminimize();
+                    let _ = window.set_focus();
                     log::info!("正常启动模式：主窗口已显示");
+
+                    // macOS: 还原后的窗口矩形可能跑到屏外（外接副屏断开的常见
+                    // 副作用），拉回主屏可视范围。Linux 由 nudge_main_window 兜底，
+                    // 不再重复。
+                    #[cfg(target_os = "macos")]
+                    {
+                        let app_handle = app.handle().clone();
+                        tauri::async_runtime::spawn(async move {
+                            // 等待 window-state 插件的还原完成（它在 setup() 之后
+                            // 异步跑），否则读到的 outer_size/position 是 conf 默认值。
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                            clamp_window_to_monitor(&app_handle);
+                        });
+                    }
+
+                    // macOS: show() 之后 wait 一帧再 set_focus，避免与 webview
+                    // 首次布局争抢焦点导致窗口被瞬间最小化。
+                    #[cfg(target_os = "macos")]
+                    {
+                        let app_handle = app.handle().clone();
+                        tauri::async_runtime::spawn(async move {
+                            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+                            if let Some(w) = app_handle.get_webview_window("main") {
+                                let _ = w.set_focus();
+                            }
+                        });
+                    }
 
                     // Linux: 解决首次启动 UI 无响应问题（Tauri #10746 + wry #637）。
                     // 启动时 webview 未获取焦点 + surface 尺寸协商失败，导致点击无效。
@@ -1181,6 +1282,8 @@ pub fn run() {
                         linux_fix::nudge_main_window(window.clone());
                     }
                 }
+
+
             }
 
 
@@ -1250,6 +1353,7 @@ pub fn run() {
             commands::validate_mcp_command,
             // usage query
             commands::queryProviderUsage,
+            commands::queryProviderUsageForKey,
             commands::testUsageScript,
             // subscription quota
             commands::get_subscription_quota,
@@ -1509,6 +1613,16 @@ pub fn run() {
             commands::enter_lightweight_mode,
             commands::exit_lightweight_mode,
             commands::is_lightweight_mode,
+            // Multi-API key per provider (v12)
+            commands::cmd_list_api_keys,
+            commands::cmd_get_api_key,
+            commands::cmd_get_active_api_key,
+            commands::cmd_create_api_key,
+            commands::cmd_update_api_key,
+            commands::cmd_delete_api_key,
+            commands::cmd_reorder_api_keys,
+            commands::cmd_set_active_api_key,
+            commands::cmd_mark_key_usage_high,
         ]);
 
     let app = builder
@@ -1588,6 +1702,7 @@ pub fn run() {
                         let _ = window.show();
                         let _ = window.set_focus();
                         tray::apply_tray_policy(app_handle, true);
+                        tray::nudge_main_window_on_macos(window.clone());
                     } else if crate::lightweight::is_lightweight_mode() {
                         if let Err(e) = crate::lightweight::exit_lightweight_mode(app_handle) {
                             log::error!("退出轻量模式重建窗口失败: {e}");
@@ -2024,7 +2139,82 @@ fn classify_exit_request(code: Option<i32>) -> ExitRequestAction {
 // ============================================================
 
 fn window_state_flags() -> StateFlags {
+    // 不持久化 FULLSCREEN：macOS 上从 fullscreen 还原时偶发黑屏。
+    // 不持久化 DECORATED / VISIBLE：装饰状态在 setup() 里按 `use_app_window_controls`
+    // 同步过一次；可见性由 silent_startup 单独控制。MAXIMIZED 必须持久化，
+    // 否则最大化窗口下次启动会回到普通尺寸。
     StateFlags::POSITION | StateFlags::SIZE | StateFlags::MAXIMIZED
+}
+
+/// 把 `tauri_plugin_window_state` 还原的窗口矩形裁剪到当前任意一块显示器的
+/// 可见区域内——主要应对用户上次在外接显示器 / 高 DPI 屏幕上拖大窗口、之后
+/// 断开副屏或重启后窗口跑出主屏可视范围、看起来像「窗口不见了」。还原后
+/// 调一次 `set_position` / `set_size` 把窗口拽回来。
+///
+/// 仅在普通启动模式（非静默启动）下生效；静默启动本身就把窗口 hide 了，
+/// 几何修复没有意义。
+#[cfg(target_os = "macos")]
+fn clamp_window_to_monitor(app: &tauri::AppHandle) {
+    use tauri::{LogicalPosition, LogicalSize, Manager};
+
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    let Ok(monitors) = window.available_monitors() else {
+        return;
+    };
+    if monitors.is_empty() {
+        return;
+    }
+
+    let win_size = window.outer_size().ok();
+    let win_pos = window.outer_position().ok();
+    let (Some(win_size), Some(win_pos)) = (win_size, win_pos) else {
+        return;
+    };
+
+    // 任意一块显示器的可见区域（逻辑像素）；窗口只要跟任意一块有 ≥ 80px × ≥ 40px
+    // 的重叠就算"在屏幕内"。完全在外就把它拉回主屏中央。
+    let scale = window.scale_factor().unwrap_or(1.0);
+    let win_w = (win_size.width as f64) / scale;
+    let win_h = (win_size.height as f64) / scale;
+    let win_x = (win_pos.x as f64) / scale;
+    let win_y = (win_pos.y as f64) / scale;
+
+    let on_screen = monitors.iter().any(|m| {
+        let mpos = m.position();
+        let msize = m.size();
+        let mx = mpos.x as f64 / scale;
+        let my = mpos.y as f64 / scale;
+        let mw = msize.width as f64 / scale;
+        let mh = msize.height as f64 / scale;
+        let overlap_w = (win_x + win_w).min(mx + mw) - win_x.max(mx);
+        let overlap_h = (win_y + win_h).min(my + mh) - win_y.max(my);
+        overlap_w >= 80.0 && overlap_h >= 40.0
+    });
+
+    if on_screen {
+        return;
+    }
+
+    log::warn!(
+        "还原后的窗口位置 ({win_x:.0},{win_y:.0}) {win_w:.0}x{win_h:.0} 不在任一可见显示器内，重新居中"
+    );
+    if let Some(primary) = window.primary_monitor().ok().flatten().or(monitors.into_iter().next()) {
+        let ppos = primary.position();
+        let psize = primary.size();
+        let px = ppos.x as f64 / scale;
+        let py = ppos.y as f64 / scale;
+        let pw = psize.width as f64 / scale;
+        let ph = psize.height as f64 / scale;
+        // 缩到主屏的 80% 大小，居中
+        let target_w = (pw * 0.8).min(win_w);
+        let target_h = (ph * 0.8).min(win_h);
+        let target_x = px + (pw - target_w) / 2.0;
+        let target_y = py + (ph - target_h) / 2.0;
+        let _ = window.set_size(LogicalSize::new(target_w, target_h));
+        let _ = window.set_position(LogicalPosition::new(target_x, target_y));
+    }
 }
 
 /// 当前应用的退出路径会拦截 `ExitRequested` 并最终直接 `std::process::exit(0)`，

--- a/src-tauri/src/lightweight.rs
+++ b/src-tauri/src/lightweight.rs
@@ -48,6 +48,7 @@ pub fn exit_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
         #[cfg(target_os = "macos")]
         {
             crate::tray::apply_tray_policy(app, true);
+            crate::tray::nudge_main_window_on_macos(window.clone());
         }
         LIGHTWEIGHT_MODE.store(false, Ordering::Release);
         crate::tray::refresh_tray_menu(app);
@@ -75,6 +76,10 @@ pub fn exit_lightweight_mode(app: &tauri::AppHandle) -> Result<(), String> {
         #[cfg(target_os = "linux")]
         {
             crate::linux_fix::nudge_main_window(window.clone());
+        }
+        #[cfg(target_os = "macos")]
+        {
+            crate::tray::nudge_main_window_on_macos(window.clone());
         }
     }
 

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -206,7 +206,58 @@ impl Provider {
         // and `{{baseUrl}}/path` concatenation never produces a double slash.
         (base_url.trim_end_matches('/').to_string(), api_key)
     }
+
+    /// 写入 API Key 到当前 `settings_config` 的正确位置——多 key 池里切换
+    /// active key 时调用，让 `write_live_with_common_config` 把新 key
+    /// 写到 settings.json。
+    ///
+    /// 写入位置与 `resolve_usage_credentials` 读取位置严格对称。
+    /// app_type 由调用方提供（Provider 自身不存 app_type 字段）。
+    pub fn set_api_key(&mut self, new_key: &str, app_type: &crate::app_config::AppType) {
+        let settings = &mut self.settings_config;
+        // 单一真理来源：`AppType::api_key_settings_path()` 决定写哪组字段。
+        // 第一个存在的字段会被更新；都不存在时创建第一个。
+        // 这与 `resolve_usage_credentials` 读取路径顺序对称——避免读/写在不同位置。
+        let paths = app_type.api_key_settings_path();
+        let root = settings
+            .as_object_mut()
+            .expect("settings_config 必须是 object");
+        for (parent, child) in paths.iter() {
+            // 进入父级 object（不存在就创建空 object）
+            let entry = root
+                .entry(parent.to_string())
+                .or_insert_with(|| Value::Object(Default::default()));
+            let parent_obj = match entry.as_object_mut() {
+                Some(o) => o,
+                None => {
+                    // 父级不是 object（例如之前是字符串）——覆盖为新 object。
+                    *entry = Value::Object(Default::default());
+                    entry.as_object_mut().expect("刚刚插入")
+                }
+            };
+            // 任何 path 里的字段已存在 → 在该 path 写入
+            if parent_obj.contains_key(*child) {
+                parent_obj.insert(child.to_string(), Value::String(new_key.to_string()));
+                return;
+            }
+        }
+        // 所有 path 都不存在：写入第一个 path（preferred 默认）
+        let (parent, child) = paths[0];
+        let entry = root
+            .entry(parent.to_string())
+            .or_insert_with(|| Value::Object(Default::default()));
+        let parent_obj = match entry.as_object_mut() {
+            Some(o) => o,
+            None => {
+                *entry = Value::Object(Default::default());
+                entry.as_object_mut().expect("刚刚插入")
+            }
+        };
+        parent_obj.insert(child.to_string(), Value::String(new_key.to_string()));
+    }
 }
+
+
 
 /// 供应商管理器
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -267,6 +318,11 @@ pub struct UsageScript {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "teamProjectId")]
     pub team_project_id: Option<String>,
+    /// MiniMax Coding Plan 集团 ID（必填项，缺省时接口返回占位零值导致误显示 0%）。
+    /// 在 MiniMax 开放平台「账户管理 → 账户信息 → 基本信息」获取。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "groupId")]
+    pub group_id: Option<String>,
 }
 
 /// 用量数据

--- a/src-tauri/src/proxy/error.rs
+++ b/src-tauri/src/proxy/error.rs
@@ -40,10 +40,30 @@ pub enum ProxyError {
     ProviderUnhealthy(String),
 
     #[error("上游错误 (状态码 {status}): {body:?}")]
-    UpstreamError { status: u16, body: Option<String> },
+    UpstreamError {
+        status: u16,
+        body: Option<String>,
+        /// 来自上游 `Retry-After` / `Retry-After-MS` / `x-ratelimit-reset-ms`
+        /// 头预解析出的冷却秒数。`None` 表示响应里没有 retry hint（也包括
+        /// 解析失败——失败时静默退化为 `None`，避免 panic）。
+        ///
+        /// KeyRing 轮换时用这个值来设 cooldown；forwarder 在构造错误时
+        /// 从 `response.headers()` 解析并填入。
+        retry_after_secs: Option<u64>,
+    },
 
     #[error("超过最大重试次数")]
     MaxRetriesExceeded,
+
+    /// Provider 池里所有可用的 key 都被限流/配额耗尽。
+    /// 携带 provider.id 用于日志/UI 提示。
+    ///
+    /// 触发场景：同一 provider 的 key 池大小为 N，max_key_attempts=M，
+    /// 连续 M 次 `classify_limit_signal` 命中后没有可用的下一把 key
+    /// —— 此时应停止故障转移到下家（因为下家更不可信），直接返回 429/503
+    /// 让客户端决定是否重试。
+    #[error("Provider {0} 的所有 API key 都暂时不可用（限流/配额耗尽）")]
+    AllKeysRateLimited(String),
 
     #[error("数据库错误: {0}")]
     DatabaseError(String),
@@ -82,6 +102,7 @@ impl IntoResponse for ProxyError {
             ProxyError::UpstreamError {
                 status: upstream_status,
                 body: upstream_body,
+                ..
             } => {
                 let http_status =
                     StatusCode::from_u16(*upstream_status).unwrap_or(StatusCode::BAD_GATEWAY);
@@ -127,6 +148,11 @@ impl IntoResponse for ProxyError {
                     ProxyError::ForwardFailed(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
                     ProxyError::NoAvailableProvider => {
                         (StatusCode::SERVICE_UNAVAILABLE, self.to_string())
+                    }
+                    ProxyError::AllKeysRateLimited(_) => {
+                        // 单 provider 池内 key 全耗尽——用 429 告诉客户端「暂时过载」，
+                        // 比 503 更准确地表达「这是上游配额问题，不是代理故障」。
+                        (StatusCode::TOO_MANY_REQUESTS, self.to_string())
                     }
                     ProxyError::AllProvidersCircuitOpen => {
                         (StatusCode::SERVICE_UNAVAILABLE, self.to_string())

--- a/src-tauri/src/proxy/error_mapper.rs
+++ b/src-tauri/src/proxy/error_mapper.rs
@@ -37,6 +37,11 @@ pub fn map_proxy_error_to_status(error: &ProxyError) -> u16 {
         // 所有供应商已熔断：503 Service Unavailable
         ProxyError::AllProvidersCircuitOpen => 503,
 
+        // 单 provider 内所有 key 都已耗尽（429 / 配额错误）：429 + Retry-After。
+        // 与 IntoResponse 在 proxy/error.rs 里的实现保持一致——本文件是
+        // status code 的 single source of truth，不能再走 `_ => 500` catch-all。
+        ProxyError::AllKeysRateLimited(_) => 429,
+
         // 未配置供应商：503 Service Unavailable
         ProxyError::NoProvidersConfigured => 503,
 
@@ -66,7 +71,7 @@ pub fn map_proxy_error_to_status(error: &ProxyError) -> u16 {
 /// 将 ProxyError 转换为用户友好的错误消息
 pub fn get_error_message(error: &ProxyError) -> String {
     match error {
-        ProxyError::UpstreamError { status, body } => {
+        ProxyError::UpstreamError { status, body, .. } => {
             if let Some(body) = body {
                 format!("上游错误 ({status}): {body}")
             } else {
@@ -77,6 +82,7 @@ pub fn get_error_message(error: &ProxyError) -> String {
         ProxyError::ForwardFailed(msg) => format!("转发失败: {msg}"),
         ProxyError::NoAvailableProvider => "无可用 Provider".to_string(),
         ProxyError::AllProvidersCircuitOpen => "所有供应商已熔断，无可用渠道".to_string(),
+        ProxyError::AllKeysRateLimited(msg) => format!("所有可用 API Key 均已限流: {msg}"),
         ProxyError::NoProvidersConfigured => "未配置供应商".to_string(),
         ProxyError::MaxRetriesExceeded => "所有 Provider 都失败，重试耗尽".to_string(),
         ProxyError::ProviderUnhealthy(msg) => format!("Provider 不健康: {msg}"),
@@ -95,6 +101,7 @@ mod tests {
         let error = ProxyError::UpstreamError {
             status: 401,
             body: Some("Unauthorized".to_string()),
+            retry_after_secs: None,
         };
         assert_eq!(map_proxy_error_to_status(&error), 401);
     }
@@ -142,10 +149,22 @@ mod tests {
     }
 
     #[test]
+    fn test_map_all_keys_rate_limited_to_429() {
+        // 必须显式映射 429——之前 `_ => 500` 的 catch-all 会让客户端收到
+        // 与 IntoResponse 不一致的 status code。
+        let err = ProxyError::AllKeysRateLimited("min cooldown 60s".to_string());
+        assert_eq!(map_proxy_error_to_status(&err), 429);
+        let msg = get_error_message(&err);
+        assert!(msg.contains("限流"));
+        assert!(msg.contains("min cooldown 60s"));
+    }
+
+    #[test]
     fn test_get_error_message() {
         let error = ProxyError::UpstreamError {
             status: 500,
             body: Some("Internal Server Error".to_string()),
+            retry_after_secs: None,
         };
         let msg = get_error_message(&error);
         assert!(msg.contains("上游错误"));

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -33,10 +33,16 @@ use futures::StreamExt;
 use http::Extensions;
 use serde_json::Value;
 use std::sync::Arc;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tokio::sync::RwLock;
 
 const PROXY_AUTH_PLACEHOLDER: &str = "PROXY_MANAGED";
+
+/// 5xx/timeout 这类「非限流」失败时给 key 设的短冷却——避免同一 key 在
+/// 短时间内被反复打。reap_expired_cooldowns 在 30s tick 会清掉这个冷却。
+/// 选 30s 与限流路径的最小冷却对齐：限流至少 30s，5xx 也至少 30s，
+/// 下次请求有机会自动回到这把 key（如果上游恢复了的话）。
+const KEY_FAILURE_COOLDOWN_SECS: u64 = 30;
 
 pub struct ForwardResult {
     pub response: ProxyResponse,
@@ -47,7 +53,11 @@ pub struct ForwardResult {
     /// usage 归因不能依赖 ctx.request_model（映射前的客户端别名）：上游响应
     /// 缺失 model 或回显别名时，接管流量会被记成 claude-* 并按其定价计费。
     pub outbound_model: Option<String>,
-    /// 活跃连接 RAII guard：随响应一起流转到 response_processor / handle_claude_transform，
+    /// 本次请求实际用到的 KeyRing key_id（v12 多 key 池引入）。
+    /// None 表示走 provider 自身 settings_config 里的 key（非池化或池为空）。
+    /// usage 日志路径里把这个值塞进 `RequestLog.api_key_id`，让 per-key 用量统计生效。
+    pub api_key_id: Option<String>,
+    /// 活跃连接 RAII guard：随响应一起流转到 response_processor / handle_claude_transform,
     /// 最终被 move 进流式 body future（或非流式响应作用域），覆盖整个响应生命周期。
     pub(crate) connection_guard: Option<ActiveConnectionGuard>,
 }
@@ -118,6 +128,12 @@ pub struct RequestForwarder {
     optimizer_config: OptimizerConfig,
     /// Copilot 优化器配置
     copilot_optimizer_config: CopilotOptimizerConfig,
+    /// 共享 KeyRing——forwarder 用它做限流后 key 轮换。
+    /// 进程内只读视图：mark_* 立即生效，flush_dirty 由 ProxyService 调度。
+    key_ring: Arc<crate::proxy::providers::key_ring::KeyRing>,
+    /// 单个 provider 内最多尝试的 key 数。
+    /// 来自 AppProxyConfig.max_key_attempts；0 表示禁用轮换（永远用 1 把 key）。
+    max_key_attempts: u32,
     /// 非流式请求超时（秒）
     non_streaming_timeout: std::time::Duration,
     /// 流式请求响应头等待超时（秒）
@@ -194,6 +210,8 @@ impl RequestForwarder {
         rectifier_config: RectifierConfig,
         optimizer_config: OptimizerConfig,
         copilot_optimizer_config: CopilotOptimizerConfig,
+        key_ring: Arc<crate::proxy::providers::key_ring::KeyRing>,
+        max_key_attempts: u32,
         max_retries: u32,
     ) -> Self {
         // max_retries 是「失败后重试次数」语义，attempt 上限 = retries + 1。
@@ -213,6 +231,8 @@ impl RequestForwarder {
             rectifier_config,
             optimizer_config,
             copilot_optimizer_config,
+            key_ring,
+            max_key_attempts,
             non_streaming_timeout: std::time::Duration::from_secs(non_streaming_timeout),
             streaming_first_byte_timeout: std::time::Duration::from_secs(
                 streaming_first_byte_timeout,
@@ -390,17 +410,44 @@ impl RequestForwarder {
         let mut last_error = None;
         let mut last_provider = None;
         let mut attempted_providers = 0usize;
+        // 记录每把 key 在本次请求中的失败次数；key_id → count。
+        // 超过 max_key_attempts 时把这把 key 标记成长冷却 + 轮换到下一把。
+        // 旧的（provider 级计数）会让两把 key 各失败一次就被判「轮换耗尽」
+        // ——用户在「1 把 key 失败 3 次才轮换」的语义下得不到期望行为。
+        let mut key_failures: std::collections::HashMap<String, u32> =
+            std::collections::HashMap::new();
 
         // 单 Provider 场景下跳过熔断器检查（故障转移关闭时）
         let bypass_circuit_breaker = providers.len() == 1;
 
-        // 依次尝试每个供应商
-        for provider in providers.iter() {
+        // 用 `provider_iter` + 手动 loop 而非 `for provider in providers.iter()`——
+        // 关键轮换需要在同一 provider 上重试（不改 provider、只换 key），而 `for` 的
+        // `continue` 会直接跳到下一个 provider，永远轮换不生效。手写 loop 让
+        // rotation 分支 `continue` 重跑本 provider 的 body，advance_iter 时
+        // 才真正换 provider。
+        let mut provider_iter = providers.iter().peekable();
+        // 'rotate 是 key-failover 内层 loop 的标签——rotation 'continue 'rotate'
+        // 重试同一 provider + 新 key；'break 'rotate 让外层 while 推进下一家。
+        while let Some(provider) = provider_iter.next() {
+            'rotate: loop {
             // 整流器重试标记：每个 provider 独立持有，避免标记跨 provider 短路故障转移
             // —— 首家 provider 整流后被 5xx/timeout 击落时，下家仍能用整流后的请求体走整流流程
             let mut rectifier_retried = false;
             let mut budget_rectifier_retried = false;
             let mut media_rectifier_retried = false;
+            // KeyRing 选中的 API key 字符串。None = 走 provider 自身 key（即不轮换）。
+            // 由限流/配额触发轮换时更新；整流/媒体重试沿用同一把 key。
+            //
+            // 初始化：从 DB 取该 provider 的 active key，把 api_key 也带过来。
+            // 这是 Blocker #3 的修复：之前 current_key_id 一律 None，
+            // 第一次 429 的 `if let Some(key_id)` 早返回，**原始 key 永远没被打 mark**。
+            // 初始化后，第一次 429 能正确把当前 active key 标为冷却并轮换。
+            let mut current_key_override: Option<String> = None;
+            let mut current_key_id: Option<String> = None;
+            if let Some(active) = self.key_ring.active_key(&provider.id, app_type).await {
+                current_key_override = Some(active.api_key.clone());
+                current_key_id = Some(active.key_id.clone());
+            }
 
             // 上限检查：尊重用户在 AppProxyConfig.max_retries 上配置的「重试次数」。
             // 放在熔断器 allow 检查之前，避免在已经超限时还占用 HalfOpen 探测名额。
@@ -426,7 +473,8 @@ impl RequestForwarder {
             };
 
             if !allowed {
-                continue;
+                // 熔断器拒绝——跳到下一家 provider
+                break 'rotate;
             }
 
             // PRE-SEND 优化器：每个 provider 独立决定是否优化
@@ -459,24 +507,36 @@ impl RequestForwarder {
             }
 
             // 转发请求（每个 Provider 只尝试一次，重试由客户端控制）
-            match self
+            // api_key_override 来自 KeyRing 轮换：首次为 None（走 provider 自身 key），
+            // 限流/配额命中后取下一把 key 重试。
+            let api_key_override: Option<&str> = current_key_override.as_deref();
+            let forward_result = self
                 .forward(
                     app_type,
                     &method,
                     provider,
+                    api_key_override,
                     endpoint,
                     &provider_body,
                     &headers,
                     &extensions,
                     adapter.as_ref(),
                 )
-                .await
-            {
+                .await;
+            match forward_result {
                 Ok((response, claude_api_format, outbound_model)) => {
                     // 成功：普通闭合熔断状态异步记录，避免阻塞流式首包返回；
                     // HalfOpen 探测仍同步等待，保证 permit 与熔断状态及时释放。
                     self.record_success_result(&provider.id, app_type_str, used_half_open_permit)
                         .await;
+
+                    // 成功路径同时清空当前 key 的 failure_count + cooldown。
+                    // 这是"成功 = key 恢复"的语义——之前 mark_success 是死代码，
+                    // 任何 key 限流后只能等 30s 冷却窗口过才被 next_key 重新选中。
+                    // 现在 key 走完 30s 冷却后如果成功请求到达，立刻被认可。
+                    if let Some(ref key_id) = current_key_id {
+                        self.key_ring.mark_success(key_id).await;
+                    }
 
                     // 更新当前应用类型使用的 provider
                     {
@@ -521,6 +581,7 @@ impl RequestForwarder {
                         provider: provider.clone(),
                         claude_api_format,
                         outbound_model,
+                        api_key_id: current_key_id.clone(),
                         connection_guard: None,
                     });
                 }
@@ -563,6 +624,7 @@ impl RequestForwarder {
                                     app_type,
                                     &method,
                                     provider,
+                                    current_key_override.as_deref(),
                                     endpoint,
                                     &media_body,
                                     &headers,
@@ -624,6 +686,7 @@ impl RequestForwarder {
                                         provider: provider.clone(),
                                         claude_api_format,
                                         outbound_model,
+                                        api_key_id: current_key_id.clone(),
                                         connection_guard: None,
                                     });
                                 }
@@ -645,7 +708,8 @@ impl RequestForwarder {
                                     {
                                         return Err(err);
                                     }
-                                    continue;
+                                    // 同 provider + 同 key 重试一次（整流器反应式重试）
+                                    continue 'rotate;
                                 }
                             }
                         }
@@ -709,6 +773,7 @@ impl RequestForwarder {
                                         app_type,
                                         &method,
                                         provider,
+                                        current_key_override.as_deref(),
                                         endpoint,
                                         &provider_body,
                                         &headers,
@@ -773,6 +838,7 @@ impl RequestForwarder {
                                             provider: provider.clone(),
                                             claude_api_format,
                                             outbound_model,
+                                            api_key_id: current_key_id.clone(),
                                             connection_guard: None,
                                         });
                                     }
@@ -794,7 +860,8 @@ impl RequestForwarder {
                                         {
                                             return Err(err);
                                         }
-                                        continue;
+                                        // 同 provider + 同 key 重试一次
+                                        continue 'rotate;
                                     }
                                 }
                             }
@@ -875,6 +942,7 @@ impl RequestForwarder {
                                     app_type,
                                     &method,
                                     provider,
+                                    current_key_override.as_deref(),
                                     endpoint,
                                     &provider_body,
                                     &headers,
@@ -933,6 +1001,7 @@ impl RequestForwarder {
                                         provider: provider.clone(),
                                         claude_api_format,
                                         outbound_model,
+                                        api_key_id: current_key_id.clone(),
                                         connection_guard: None,
                                     });
                                 }
@@ -954,7 +1023,8 @@ impl RequestForwarder {
                                     {
                                         return Err(err);
                                     }
-                                    continue;
+                                    // 同 provider + 同 key 重试一次（整流器反应式重试）
+                                    continue 'rotate;
                                 }
                             }
                         }
@@ -989,17 +1059,237 @@ impl RequestForwarder {
 
                     match category {
                         ErrorCategory::Retryable => {
-                            // 可重试：真正的 provider 故障 → 记录失败并更新熔断器/DB 健康度
-                            let _ = self
-                                .router
-                                .record_result(
-                                    &provider.id,
+                            // ============ KeyRing 轮换分支 ============
+                            // 仅当上游错误被分类为「限流/配额信号」时，触发 key 轮换；
+                            // 其它可重试错误（5xx/timeout）走下面的 `record_result(false)`
+                            // 路径，标记熔断器失败 + 切下家。
+                            //
+                            // 关键不变量：if let 块内的两个出口 `continue 'rotate`
+                            // （轮换成功）和 `break 'rotate`（轮换耗尽）都会跳离此块——
+                            // 不会 fall through 到下面的 5xx/timeout 分支，
+                            // 也就不会把"429 由 key 限流"误计为 provider 自身熔断失败。
+                            // 下方代码仅在 `classify_limit_signal` 返回 `None` 时执行。
+                            if let Some(signal) = super::limit_signal::classify_limit_signal(&e, None)
+                            {
+                                // 「一把 key 失败 N 次才轮换」语义：key_failures 是
+                                // 本次请求内 key_id → 失败次数。失败未到阈值时
+                                // 不轮换，直接同 key 重试（'rotate continue）——
+                                // 这是用户期望的「同一 key 试 N 次再换」行为；
+                                // 旧的 provider 级计数让两把 key 各失败一次就被
+                                // 判「轮换耗尽」，跟用户语义不符。
+                                //
+                                // `max_key_attempts` 在 DB 默认是 3（参见 dao/proxy.rs:263），
+                                // 0 = 显式禁用 key 轮换（永远走当前 key，不轮换），
+                                // 与 forwarder 字段 docstring 一致。
+                                let current_key_id_for_failures = current_key_id.clone();
+                                let failure_count = if let Some(kid) = &current_key_id_for_failures {
+                                    *key_failures.entry(kid.clone()).and_modify(|c| *c += 1).or_insert(1)
+                                } else {
+                                    // 没有 key_id（用 provider 自身 key）——一次就当耗尽，
+                                    // 不能在 KeyRing 里 rotate（无 pool）。
+                                    u32::MAX
+                                };
+
+                                // 已经超过这把 key 的阈值 → 把它放进 cooldown + 轮换
+                                let should_rotate_now = self.max_key_attempts > 0
+                                    && failure_count >= self.max_key_attempts
+                                    && current_key_id.is_some();
+
+                                if should_rotate_now {
+                                    let kid = current_key_id.as_ref().unwrap();
+                                    self.key_ring
+                                        .mark_rate_limited(
+                                            kid,
+                                            signal.retry_after_secs,
+                                        )
+                                        .await;
+
+                                    // 5h / 7d 这种「真配额窗口」冷却命中时，
+                                    // 通知前端刷新该 provider 的 apiKeys 缓存。
+                                    const QUOTA_REFRESH_THRESHOLD_SECS: i64 = 5 * 60;
+                                    const KEY_MIN_COOLDOWN_SECS: i64 = 30;
+                                    let cooldown_secs =
+                                        signal.retry_after_secs.unwrap_or(0) as i64;
+                                    let cooldown_secs =
+                                        cooldown_secs.max(KEY_MIN_COOLDOWN_SECS);
+                                    if cooldown_secs >= QUOTA_REFRESH_THRESHOLD_SECS {
+                                        if let Some(app) = self.app_handle.as_ref() {
+                                            let event = serde_json::json!({
+                                                "appType": app_type_str,
+                                                "providerId": provider.id,
+                                                "keyId": kid,
+                                                "reason": signal.reason,
+                                                "cooldownUntil":
+                                                    chrono::Utc::now().timestamp()
+                                                        + cooldown_secs,
+                                            });
+                                            if let Err(e) = app.emit("key-rate-limited", event) {
+                                                log::warn!(
+                                                    "[{app_type_str}] 发射 key-rate-limited 事件失败: {e}"
+                                                );
+                                            }
+                                        }
+                                    }
+
+                                    if let Some(next) =
+                                        self.key_ring.next_key(&provider.id, app_type).await
+                                    {
+                                        log::warn!(
+                                            "[{app_type_str}] [KeyRotate] provider={} key_failures={}/{} reason={} cooldown={}s key={}→{}",
+                                            provider.id,
+                                            failure_count,
+                                            self.max_key_attempts,
+                                            signal.reason,
+                                            signal.retry_after_secs.unwrap_or(0),
+                                            kid,
+                                            next.key_id,
+                                        );
+                                        current_key_override = Some(next.api_key.clone());
+                                        current_key_id = Some(next.key_id.clone());
+                                        self.router
+                                            .release_permit_neutral(
+                                                &provider.id,
+                                                app_type_str,
+                                                used_half_open_permit,
+                                            )
+                                            .await;
+                                        let _ = (&current_key_override, &current_key_id);
+                                        continue 'rotate;
+                                    }
+                                    // 池里没有别的可用 key 了（全部进 cooldown）→
+                                    // provider 整体不可用，强制走下家。
+                                    log::warn!(
+                                        "[{app_type_str}] [KeyRotate] provider={} all keys exhausted after {} failures on key {:?}",
+                                        provider.id,
+                                        failure_count,
+                                        current_key_id_for_failures,
+                                    );
+                                    last_error = Some(ProxyError::AllKeysRateLimited(provider.id.clone()));
+                                    last_provider = Some(provider.clone());
+                                    self.router
+                                        .release_permit_neutral(
+                                            &provider.id,
+                                            app_type_str,
+                                            used_half_open_permit,
+                                        )
+                                        .await;
+                                    break 'rotate;
+                                } else {
+                                    // 还没到这把 key 的阈值——同 key 重试。
+                                    // 不 mark rate_limited（避免短暂冷却干扰重试节奏），
+                                    // 把 attempt 计数更新到 key_failures，下一次迭代再判断。
+                                    self.router
+                                        .release_permit_neutral(
+                                            &provider.id,
+                                            app_type_str,
+                                            used_half_open_permit,
+                                        )
+                                        .await;
+                                    let _ = (&current_key_override, &current_key_id);
+                                    log::warn!(
+                                        "[{app_type_str}] [KeyRetry] provider={} key={:?} failures={}/{} same-key retry",
+                                        app_type_str,
+                                        current_key_id_for_failures,
+                                        failure_count,
+                                        self.max_key_attempts,
+                                    );
+                                    continue 'rotate;
+                                }
+                            }
+                            // 5xx/timeout（非限流信号）走 key 重试/轮换路径——
+                            // 失败计数以 key_id 为键（与限流路径共用 key_failures），
+                            // 未到阈值同 key 重试，达到阈值才送进 cooldown + 轮换。
+                            // mark_rate_limited 与 mark_failure 由下面的旋转分支决定是否触发。
+                            // 这里只记一次内联调用：防止读后修改竞态，但实际写库留
+                            // 给专门分支处理。
+                            //
+                            // 5xx 暂不计入 provider 熔断器失败——这把 key 是问题源，
+                            // 但 provider 池里可能还有别的可用 key。失败打点推迟到
+                            // 下面「轮换耗尽」分支统一处理，避免单把坏 key 把整家
+                            // provider 打掉熔断器。
+
+                            // 5xx 失败计数（per-key，与限流路径一致）：
+                            // 未到阈值时同 key 重试，达到阈值才把它送进 cooldown + 轮换。
+                            let current_key_id_for_failures = current_key_id.clone();
+                            let failure_count_5xx =
+                                if let Some(kid) = &current_key_id_for_failures {
+                                    *key_failures.entry(kid.clone()).and_modify(|c| *c += 1).or_insert(1)
+                                } else {
+                                    u32::MAX
+                                };
+
+                            let should_rotate_5xx = self.max_key_attempts > 0
+                                && failure_count_5xx >= self.max_key_attempts
+                                && current_key_id.is_some();
+
+                            if should_rotate_5xx {
+                                let kid = current_key_id.as_ref().unwrap();
+                                self.key_ring
+                                    .mark_rate_limited(
+                                        kid,
+                                        Some(KEY_FAILURE_COOLDOWN_SECS),
+                                    )
+                                    .await;
+                                self.key_ring.mark_failure(kid, &e.to_string()).await;
+
+                                if let Some(next) =
+                                    self.key_ring.next_key(&provider.id, app_type).await
+                                {
+                                    if Some(&next.key_id) == current_key_id.as_ref() {
+                                        log::warn!(
+                                            "[{app_type_str}] [KeyRotate] provider={} 5xx 后无其他可用 key (pool exhausted or cursor stuck)",
+                                            provider.id,
+                                        );
+                                        last_error = Some(e);
+                                        last_provider = Some(provider.clone());
+                                        break 'rotate;
+                                    }
+                                    log::warn!(
+                                        "[{app_type_str}] [KeyRotate] provider={} key_failures={}/{} reason=5xx key={}→{}",
+                                        provider.id,
+                                        failure_count_5xx,
+                                        self.max_key_attempts,
+                                        kid,
+                                        next.key_id,
+                                    );
+                                    current_key_override = Some(next.api_key.clone());
+                                    current_key_id = Some(next.key_id.clone());
+                                    self.router
+                                        .release_permit_neutral(
+                                            &provider.id,
+                                            app_type_str,
+                                            used_half_open_permit,
+                                        )
+                                        .await;
+                                    let _ = (&current_key_override, &current_key_id);
+                                    continue 'rotate;
+                                }
+                            } else {
+                                // 没到这把 key 的阈值——同 key 重试。
+                                self.router
+                                    .release_permit_neutral(
+                                        &provider.id,
+                                        app_type_str,
+                                        used_half_open_permit,
+                                    )
+                                    .await;
+                                if let Some(ref kid) = current_key_id {
+                                    // mark_failure 仍然累加 failure_count（UI 用），
+                                    // 但暂不进 cooldown——避免短暂冻结干扰重试节奏。
+                                    self.key_ring.mark_failure(kid, &e.to_string()).await;
+                                }
+                                let _ = (&current_key_override, &current_key_id);
+                                log::warn!(
+                                    "[{app_type_str}] [KeyRetry] provider={} key={:?} failures={}/{} same-key retry (5xx)",
                                     app_type_str,
-                                    used_half_open_permit,
-                                    false,
-                                    Some(e.to_string()),
-                                )
-                                .await;
+                                    current_key_id_for_failures,
+                                    failure_count_5xx,
+                                    self.max_key_attempts,
+                                );
+                                continue 'rotate;
+                            }
+
+                            // 轮换耗尽（max_key_attempts 达上限或 KeyRing 返回 None）
 
                             {
                                 let mut status = self.status.write().await;
@@ -1015,10 +1305,26 @@ impl RequestForwarder {
                             );
                             log::warn!("[{app_type_str}] [{log_code}] {log_message}");
 
+                            // KeyRing 轮换耗尽（max_key_attempts 达上限或 next_key 返回 None）
+                            // —— 整家 provider 真的不行了，记入熔断器失败。
+                            // 之前把这条 call_result 放在每次 5xx 都触发，单把坏 key
+                            // 就能把整家 provider 打掉，与「先 key 轮换、再 provider
+                            // 轮换」的优先级策略相悖。
+                            let _ = self
+                                .router
+                                .record_result(
+                                    &provider.id,
+                                    app_type_str,
+                                    used_half_open_permit,
+                                    false,
+                                    Some(e.to_string()),
+                                )
+                                .await;
+
                             last_error = Some(e);
                             last_provider = Some(provider.clone());
-                            // 继续尝试下一个供应商
-                            continue;
+                            // 5xx/timeout 不可轮换——break 出 'rotate 推进下一家 provider
+                            break 'rotate;
                         }
                         ErrorCategory::NonRetryable | ErrorCategory::ClientAbort => {
                             // 不可重试：客户端层错误或客户端断连 → 不污染健康度，仅释放 HalfOpen permit
@@ -1047,7 +1353,8 @@ impl RequestForwarder {
                     }
                 }
             }
-        }
+            } // end 'rotate loop
+        } // end 'per_provider while loop
 
         if attempted_providers == 0 {
             // providers 列表非空，但全部被熔断器拒绝（典型：HalfOpen 探测名额被占用）
@@ -1099,23 +1406,40 @@ impl RequestForwarder {
         app_type: &AppType,
         method: &http::Method,
         provider: &Provider,
+        api_key_override: Option<&str>,
         endpoint: &str,
         body: &Value,
         headers: &axum::http::HeaderMap,
         extensions: &Extensions,
         adapter: &dyn ProviderAdapter,
     ) -> Result<(ProxyResponse, Option<String>, Option<String>), ProxyError> {
-        // 使用适配器提取 base_url
-        let mut base_url = adapter.extract_base_url(provider)?;
+        // KeyRing 轮换：把当前选中的 key 注入到 provider.settings_config
+        // 临时覆盖 auth 字段。None 走 provider 自身配置（不修改）。
+        let effective_provider = if let Some(api_key) = api_key_override {
+            // inject_key_into_provider 可能在未知 adapter 上返回 None——
+            // 此时退回到原 provider（仍走 settings_config 里的占位 key，
+            // 会得到原版 401，但至少不会让请求路径 panic）。
+            super::providers::adapter::inject_key_into_provider(
+                provider,
+                api_key,
+                adapter.name(),
+            )
+            .unwrap_or_else(|| provider.clone())
+        } else {
+            provider.clone()
+        };
 
-        let is_full_url = provider
+        // 使用适配器提取 base_url
+        let mut base_url = adapter.extract_base_url(&effective_provider)?;
+
+        let is_full_url = effective_provider
             .meta
             .as_ref()
             .and_then(|meta| meta.is_full_url)
             .unwrap_or(false);
 
         // GitHub Copilot API 使用 /chat/completions（无 /v1 前缀）
-        let is_copilot = provider
+        let is_copilot = effective_provider
             .meta
             .as_ref()
             .and_then(|m| m.provider_type.as_deref())
@@ -1126,11 +1450,11 @@ impl RequestForwarder {
         // Claude Desktop proxy 模式必须先把 Desktop 可见的 claude-* route
         // 映射成真实上游模型名，并且未知 route 要直接报错，不能使用默认模型兜底。
         let mapped_body = if matches!(app_type, AppType::ClaudeDesktop) {
-            crate::claude_desktop_config::map_proxy_request_model(body.clone(), provider)
+            crate::claude_desktop_config::map_proxy_request_model(body.clone(), &effective_provider)
                 .map_err(|e| ProxyError::InvalidRequest(e.to_string()))?
         } else {
             let (mapped_body, _original_model, _mapped_model) =
-                super::model_mapper::apply_model_mapping(body.clone(), provider);
+                super::model_mapper::apply_model_mapping(body.clone(), &effective_provider);
             mapped_body
         };
 
@@ -1140,7 +1464,7 @@ impl RequestForwarder {
         if is_copilot {
             mapped_body =
                 super::providers::copilot_model_map::apply_copilot_model_normalization(mapped_body);
-            self.apply_copilot_live_model_resolution(provider, &mut mapped_body)
+            self.apply_copilot_live_model_resolution(&effective_provider, &mut mapped_body)
                 .await;
         } else {
             mapped_body =
@@ -1428,7 +1752,9 @@ impl RequestForwarder {
         let mut should_send_codex_oauth_session_headers = false;
 
         // 获取认证头（提前准备，用于内联替换）
-        let mut auth_headers = if let Some(mut auth) = adapter.extract_auth(provider) {
+        // 注意：必须用 effective_provider（key 注入后的版本），否则 settings_config
+        // 里的 env.ANTHROPIC_AUTH_TOKEN 仍是占位值，注入的 api_key 不会生效。
+        let mut auth_headers = if let Some(mut auth) = adapter.extract_auth(&effective_provider) {
             // GitHub Copilot 特殊处理：从 CopilotAuthManager 获取真实 token
             if auth.strategy == AuthStrategy::GitHubCopilot {
                 if let Some(app_handle) = &self.app_handle {
@@ -1969,7 +2295,15 @@ impl RequestForwarder {
             // 错误响应同样可能被上游压缩（content-encoding）。reqwest 未启用任何
             // 自动解压 feature，这里拿到的是原始字节；不解压的话，压缩过的错误体会
             // 在 from_utf8 处变成非 UTF-8 而被丢弃，隐藏掉上游的限流/鉴权等详情。
-            let encoding = get_content_encoding(response.headers());
+            // 注：response.headers() 与 response.bytes() 互斥（bytes() 会消耗
+            // response），先 clone headers 备用——既给 Retry-After 解析用，
+            // 也给 content-encoding 检测用。
+            let headers = response.headers().clone();
+            let encoding = get_content_encoding(&headers);
+            // 在构造 UpstreamError 前预解析 Retry-After 头，让限流分类器
+            // 在没有 `HeaderMap` 的下游（KeyRing / limit_signal）也能拿到
+            // 冷却时长。
+            let retry_after_secs = super::limit_signal::extract_retry_after_secs(&headers);
             let raw = response.bytes().await?;
             let decoded = match encoding {
                 Some(encoding) => match decompress_body(&encoding, &raw) {
@@ -1984,6 +2318,7 @@ impl RequestForwarder {
             Err(ProxyError::UpstreamError {
                 status: status_code,
                 body: body_text,
+                retry_after_secs,
             })
         }
     }
@@ -2260,7 +2595,7 @@ fn build_terminal_failure_log(
 
 fn summarize_proxy_error(error: &ProxyError) -> String {
     match error {
-        ProxyError::UpstreamError { status, body } => {
+        ProxyError::UpstreamError { status, body, .. } => {
             let body_summary = body
                 .as_deref()
                 .map(summarize_upstream_body)
@@ -2841,6 +3176,8 @@ mod tests {
             rectifier_config: RectifierConfig::default(),
             optimizer_config: OptimizerConfig::default(),
             copilot_optimizer_config: CopilotOptimizerConfig::default(),
+            key_ring: Arc::new(crate::proxy::providers::key_ring::KeyRing::new()),
+            max_key_attempts: 0,
             non_streaming_timeout,
             streaming_first_byte_timeout,
             max_attempts: 1,
@@ -2852,6 +3189,7 @@ mod tests {
         let error = ProxyError::UpstreamError {
             status: 429,
             body: Some(r#"{"error":{"message":"rate limit exceeded"}}"#.to_string()),
+            retry_after_secs: None,
         };
 
         let (code, message) = build_retryable_failure_log("PackyCode-response", 1, 1, &error);
@@ -3677,6 +4015,7 @@ mod tests {
             body: Some(
                 r#"{"error":{"message":"This model does not support image input"}}"#.to_string(),
             ),
+            retry_after_secs: None,
         }
     }
     #[test]
@@ -3768,6 +4107,7 @@ mod tests {
                 r#"{"error":{"message":"Failed to deserialize the JSON body into the target type: messages[11]: unknown variant image_url, expected text"}}"#
                     .to_string(),
             ),
+            retry_after_secs: None,
         };
 
         assert!(fwd.media_retry_should_trigger("Codex", false, &body, &error));

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -442,11 +442,26 @@ impl RequestForwarder {
             // 这是 Blocker #3 的修复：之前 current_key_id 一律 None，
             // 第一次 429 的 `if let Some(key_id)` 早返回，**原始 key 永远没被打 mark**。
             // 初始化后，第一次 429 能正确把当前 active key 标为冷却并轮换。
+            //
+            // `initialized` 守卫：rotation 分支（`continue 'rotate`）会把
+            // current_key_override/current_key_id 替换成 next_key() 的结果。
+            // 若不守卫，下一轮 'rotate 会再次跑这段初始化，用 active_key()（不
+            // 考虑 cooldown/disabled）覆盖掉刚轮换出来的备份 key，导致池内
+            // failover 退化成"反复打回 rate-limited 的 active key"。
+            // 守卫后：首轮执行一次初始化（拿 active key），之后每次 'rotate 都
+            // 保留 rotation 分支写入的值。
+            let mut initialized = false;
             let mut current_key_override: Option<String> = None;
             let mut current_key_id: Option<String> = None;
-            if let Some(active) = self.key_ring.active_key(&provider.id, app_type).await {
-                current_key_override = Some(active.api_key.clone());
-                current_key_id = Some(active.key_id.clone());
+            #[allow(unused_assignments)]
+            {
+                if !initialized {
+                    if let Some(active) = self.key_ring.active_key(&provider.id, app_type).await {
+                        current_key_override = Some(active.api_key.clone());
+                        current_key_id = Some(active.key_id.clone());
+                    }
+                    initialized = true;
+                }
             }
 
             // 上限检查：尊重用户在 AppProxyConfig.max_retries 上配置的「重试次数」。

--- a/src-tauri/src/proxy/handler_context.rs
+++ b/src-tauri/src/proxy/handler_context.rs
@@ -64,6 +64,11 @@ pub struct RequestContext {
     pub session_id: String,
     /// Session ID 是否由客户端提供。生成的 UUID 不能作为上游缓存 key，否则每个请求都会换 key。
     pub session_client_provided: bool,
+    /// forwarder 当前轮选到的 key_id（v12 多 key 池引入）。
+    /// None 表示该 provider 走的是 settings_config 里的单 key（非池化）。
+    /// 在 `log_usage` / `log_with_calculation` 路径里透传到 `RequestLog.api_key_id`，
+    /// 让 `usage_rollup` 能按 key 维度分桶、让前端的 per-key 用量视图生效。
+    pub current_key_id: Option<String>,
     /// 整流器配置
     pub rectifier_config: RectifierConfig,
     /// 优化器配置
@@ -170,6 +175,10 @@ impl RequestContext {
             app_type,
             session_id,
             session_client_provided: session_result.client_provided,
+            // forwarder 入口处会覆盖：先设为 None，forwarder 拿到 KeyRing 选中的
+            // key 后回填到这里（见 `handlers.rs::handle_claude_transform`）。
+            // 走 fallback 路径（非 forwarder）的代码路径保持 None。
+            current_key_id: None,
             rectifier_config,
             optimizer_config,
             copilot_optimizer_config,
@@ -240,6 +249,8 @@ impl RequestContext {
             self.rectifier_config.clone(),
             self.optimizer_config.clone(),
             self.copilot_optimizer_config.clone(),
+            state.key_ring.clone(),
+            self.app_config.max_key_attempts,
             max_retries,
         )
     }

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -210,6 +210,11 @@ async fn handle_messages_for_app(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    // v12 多 key 池：把 forwarder 选中的 key_id 透传回 ctx，
+    // log_usage 路径里再透传到 RequestLog.api_key_id。
+    // forwarder.rs::ForwardResult.api_key_id 是 Some(key_id) 当且仅当本次走了
+    // KeyRing 轮换；None 表示 provider 自身单 key（无池化）。
+    ctx.current_key_id = result.api_key_id.take();
     ctx.provider = result.provider;
     let api_format = result
         .claude_api_format
@@ -669,6 +674,11 @@ pub async fn handle_chat_completions(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    // v12 多 key 池：把 forwarder 选中的 key_id 透传回 ctx，
+    // log_usage 路径里再透传到 RequestLog.api_key_id。
+    // forwarder.rs::ForwardResult.api_key_id 是 Some(key_id) 当且仅当本次走了
+    // KeyRing 轮换；None 表示 provider 自身单 key（无池化）。
+    ctx.current_key_id = result.api_key_id.take();
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -736,6 +746,11 @@ pub async fn handle_responses(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    // v12 多 key 池：把 forwarder 选中的 key_id 透传回 ctx，
+    // log_usage 路径里再透传到 RequestLog.api_key_id。
+    // forwarder.rs::ForwardResult.api_key_id 是 Some(key_id) 当且仅当本次走了
+    // KeyRing 轮换；None 表示 provider 自身单 key（无池化）。
+    ctx.current_key_id = result.api_key_id.take();
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -815,6 +830,11 @@ pub async fn handle_responses_compact(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    // v12 多 key 池：把 forwarder 选中的 key_id 透传回 ctx，
+    // log_usage 路径里再透传到 RequestLog.api_key_id。
+    // forwarder.rs::ForwardResult.api_key_id 是 Some(key_id) 当且仅当本次走了
+    // KeyRing 轮换；None 表示 provider 自身单 key（无池化）。
+    ctx.current_key_id = result.api_key_id.take();
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -1175,7 +1195,7 @@ fn codex_proxy_error_json(
     error: &ProxyError,
 ) -> Value {
     let (mut body, upstream_status) = match error {
-        ProxyError::UpstreamError { status, body } => {
+        ProxyError::UpstreamError { status, body, .. } => {
             let parsed_body = body
                 .as_deref()
                 .map(|body| serde_json::from_str::<Value>(body).unwrap_or_else(|_| json!(body)));
@@ -1288,6 +1308,7 @@ fn codex_proxy_error_code(error: &ProxyError) -> &'static str {
         ProxyError::ForwardFailed(_) => "cc_switch_forward_failed",
         ProxyError::Timeout(_) | ProxyError::StreamIdleTimeout(_) => "cc_switch_timeout",
         ProxyError::NoAvailableProvider => "cc_switch_no_available_provider",
+        ProxyError::AllKeysRateLimited(_) => "cc_switch_all_keys_rate_limited",
         ProxyError::AllProvidersCircuitOpen => "cc_switch_all_providers_circuit_open",
         ProxyError::NoProvidersConfigured => "cc_switch_no_providers_configured",
         ProxyError::MaxRetriesExceeded => "cc_switch_max_retries_exceeded",
@@ -1391,6 +1412,11 @@ pub async fn handle_gemini(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    // v12 多 key 池：把 forwarder 选中的 key_id 透传回 ctx，
+    // log_usage 路径里再透传到 RequestLog.api_key_id。
+    // forwarder.rs::ForwardResult.api_key_id 是 Some(key_id) 当且仅当本次走了
+    // KeyRing 轮换；None 表示 provider 自身单 key（无池化）。
+    ctx.current_key_id = result.api_key_id.take();
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -2036,6 +2062,7 @@ async fn log_usage(
         session_id,
         None, // provider_type
         is_streaming,
+        None, // api_key_id（v12 Phase 6 forwarder 会接进来；现在都是 None）
     ) {
         log::warn!("[USG-001] 记录使用量失败: {e}");
     }
@@ -2682,6 +2709,7 @@ data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\"}}\n
                 r#"{"base_resp":{"status_code":2013,"status_msg":"upstream gateway failed"}}"#
                     .to_string(),
             ),
+            retry_after_secs: None,
         };
         let body = codex_proxy_error_json("MiniMax", "abab6.5s", "/responses", &error);
 
@@ -2704,6 +2732,7 @@ data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\"}}\n
                  <hr><center>nginx/1.29.6</center>\r\n</body>\r\n</html>"
                     .to_string(),
             ),
+            retry_after_secs: None,
         };
         let body = codex_proxy_error_json("HCAI", "gpt-5.5", "/responses", &error);
 

--- a/src-tauri/src/proxy/limit_signal.rs
+++ b/src-tauri/src/proxy/limit_signal.rs
@@ -1,0 +1,417 @@
+//! 限流信号分类器
+//!
+//! 检测上游响应是否包含"该轮换 key"的信号——这些信号触发 `KeyRing` 轮换
+//! 到下一把 key，而不是 fail over 到下一个 provider。
+//!
+//! 三种触发：
+//! - HTTP 429：始终触发（语义明确）
+//! - 401 / 403 / 5xx + quota message：上游通过状态码 + body 文字暗示 key 失效
+//!   （`insufficient_quota` / `quota exceeded` / `usage limit` / `billing` 等）
+//! - 任意 status + 用户 regex 命中：自定义代理 / 私有网关的特殊语种
+//!
+//! 与 fail over 区别：
+//! - fail over：`RequestForwarder` 推进到 provider 列表里的下一个
+//! - key 轮换：`KeyRing::next_key` 在同一个 provider 的 key 池里推进
+//!
+//! 一把 key 命中限流 → 轮换；所有 key 都耗尽 → 落入 fail over 路径（forwarder
+//! 的现有 `continue` 兜底）。
+
+use crate::proxy::error::ProxyError;
+use http::HeaderMap;
+
+/// 内置"quota / 限流"短语子串。匹配时不区分大小写。
+///
+/// 覆盖 Anthropic / OpenAI / Google / 主流中转服务的常见错误文案。新供应商
+/// 上线时如果发现漏报，加到这里（不引入 i18n 配置——内部错误体都用英文）。
+const BUILTIN_QUOTA_PHRASES: &[&str] = &[
+    "insufficient_quota",
+    "quota exceeded",
+    "quota_exceeded",
+    "rate limit",
+    "rate_limit",
+    "rate-limit",
+    "usage limit",
+    "usage_limit",
+    "billing",
+    "credit balance",
+    "payment required",
+];
+
+/// 触发轮换的限流信号。
+///
+/// 简洁结构——只携带"为什么轮换"和"建议冷却多久"，forwarder 据此决定
+/// 走 `KeyRing::mark_rate_limited(signal.retry_after_secs)` 还是让 KeyRing
+/// 用默认下限。
+#[derive(Debug, Clone, Copy)]
+pub struct LimitSignal {
+    /// 简短原因代码（用于日志/UI 分类）。
+    pub reason: &'static str,
+    /// 建议的冷却秒数。`None` 表示让 KeyRing 用默认下限（`MIN_COOLDOWN_SECS`）。
+    pub retry_after_secs: Option<u64>,
+}
+
+/// 检测 `ProxyError` 是否包含"该轮换 key"的信号。
+///
+/// 入口签名只接 `&ProxyError`（不接 `HeaderMap`）——上游响应头在 forwarder
+/// 构造 `UpstreamError` 时已经预解析到 `retry_after_secs` 字段。这样做的好处：
+/// 1. 错误对象自包含，下游 `classify_limit_signal` 调用方不依赖外部状态；
+/// 2. 测试只需要构造一个 `ProxyError` 即可驱动分类路径；
+/// 3. 避免 `HeaderMap` 跨 await 边界的生命周期问题。
+///
+/// 返回 `Some(LimitSignal)` 时 forwarder 触发 key 轮换。
+pub fn classify_limit_signal(
+    err: &ProxyError,
+    user_regex: Option<&regex::Regex>,
+) -> Option<LimitSignal> {
+    let (status, body, retry_after_secs) = match err {
+        ProxyError::UpstreamError {
+            status,
+            body,
+            retry_after_secs,
+        } => (*status, body.as_deref(), *retry_after_secs),
+        _ => return None,
+    };
+
+    // 1) HTTP 429 — 始终触发（语义最明确）。
+    if status == 429 {
+        return Some(LimitSignal {
+            reason: "429",
+            retry_after_secs,
+        });
+    }
+
+    // 2) 内置 quota 短语 OR 用户 regex → 触发轮换。
+    // 误报代价低——多换一把 key 比「错失轮换 + provider failover」要可控得多。
+    if let Some(quota_match) = detect_quota_message(body.unwrap_or(""), user_regex) {
+        let reason = match quota_match {
+            QuotaMatch::Builtin => "quota_message",
+            QuotaMatch::UserRegex => "user_regex",
+        };
+        return Some(LimitSignal {
+            reason,
+            retry_after_secs,
+        });
+    }
+
+    None
+}
+
+/// quota 消息识别结果——`detect_quota_message` 返回值。给出用户
+/// 实际命中的来源，便于上游 `classify_limit_signal` 写对日志 reason。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuotaMatch {
+    Builtin,
+    UserRegex,
+}
+
+/// 在响应体里检测 quota / 限流消息（大小写不敏感）。
+///
+/// 内置短语覆盖绝大多数主流供应商；用户 regex 作为可选补充（用于
+/// 自家代理 / 私有网关）。user_regex 优先级高于内置短语——用户
+/// 显式声明的 regex 是更精确的信号，应承认为用户自定义而不是通用命中。
+pub fn detect_quota_message(
+    body: &str,
+    user_regex: Option<&regex::Regex>,
+) -> Option<QuotaMatch> {
+    if body.is_empty() {
+        return user_regex
+            .and_then(|re| re.is_match(body).then_some(QuotaMatch::UserRegex));
+    }
+    if let Some(re) = user_regex {
+        if re.is_match(body) {
+            return Some(QuotaMatch::UserRegex);
+        }
+    }
+    let lower = body.to_ascii_lowercase();
+    if BUILTIN_QUOTA_PHRASES.iter().any(|p| lower.contains(p)) {
+        return Some(QuotaMatch::Builtin);
+    }
+    None
+}
+
+/// 从 `Retry-After` 头解析秒数。支持两种格式：
+/// - `<seconds>`：纯整数
+/// - HTTP-date：`Wed, 21 Oct 2015 07:28:00 GMT`
+///
+/// 解析失败返回 `None`（不 panic）。HTTP-date 路径用 `chrono` 解析（项目已用）。
+pub fn parse_retry_after(headers: &HeaderMap) -> Option<u64> {
+    let v = headers.get("retry-after")?.to_str().ok()?.trim();
+
+    // 1) 纯整数秒数（最常见）
+    if let Ok(secs) = v.parse::<u64>() {
+        return Some(secs);
+    }
+
+    // 2) HTTP-date（RFC 7231）
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc2822(v) {
+        let now = chrono::Utc::now();
+        let diff = (dt.with_timezone(&chrono::Utc) - now).num_seconds();
+        // 已经过期 → 返回 0（让 KeyRing 用默认下限）
+        return Some(diff.max(0) as u64);
+    }
+
+    None
+}
+
+/// 从 `Retry-After-MS` / `x-ratelimit-reset-ms` 头解析毫秒数，返回秒。
+///
+/// 两个头名都识别（OpenAI 风格 / 自定义网关风格）。
+pub fn parse_retry_after_ms(headers: &HeaderMap) -> Option<u64> {
+    for name in &["retry-after-ms", "x-ratelimit-reset-ms"] {
+        if let Some(v) = headers.get(*name).and_then(|h| h.to_str().ok()) {
+            if let Ok(ms) = v.trim().parse::<u64>() {
+                return Some(ms.div_ceil(1000));
+            }
+        }
+    }
+    None
+}
+
+/// 组合 `parse_retry_after` + `parse_retry_after_ms`，返回最终秒数。
+///
+/// 优先级：`Retry-After`（标准）> `Retry-After-MS` / `x-ratelimit-reset-ms`（扩展）。
+pub fn extract_retry_after_secs(headers: &HeaderMap) -> Option<u64> {
+    parse_retry_after(headers).or_else(|| parse_retry_after_ms(headers))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::HeaderValue;
+    use regex::Regex;
+
+    fn upstream(status: u16, body: Option<&str>, retry_after: Option<u64>) -> ProxyError {
+        ProxyError::UpstreamError {
+            status,
+            body: body.map(String::from),
+            retry_after_secs: retry_after,
+        }
+    }
+
+    // ---- classify_limit_signal ----
+
+    #[test]
+    fn classify_429_always_triggers() {
+        let err = upstream(429, None, None);
+        let s = classify_limit_signal(&err, None).unwrap();
+        assert_eq!(s.reason, "429");
+    }
+
+    #[test]
+    fn classify_429_propagates_retry_after() {
+        let err = upstream(429, Some("rate limit"), Some(45));
+        let s = classify_limit_signal(&err, None).unwrap();
+        assert_eq!(s.reason, "429");
+        assert_eq!(s.retry_after_secs, Some(45));
+    }
+
+    #[test]
+    fn classify_401_with_insufficient_quota_triggers() {
+        let err = upstream(
+            401,
+            Some(r#"{"error":{"message":"insufficient_quota"}}"#),
+            None,
+        );
+        let s = classify_limit_signal(&err, None).unwrap();
+        assert_eq!(s.reason, "quota_message");
+    }
+
+    #[test]
+    fn classify_403_with_quota_text_triggers() {
+        let err = upstream(403, Some("payment required - billing issue"), None);
+        let s = classify_limit_signal(&err, None).unwrap();
+        assert_eq!(s.reason, "quota_message");
+    }
+
+    #[test]
+    fn classify_500_with_quota_text_triggers() {
+        let err = upstream(500, Some("quota exceeded for this account"), None);
+        let s = classify_limit_signal(&err, None).unwrap();
+        assert_eq!(s.reason, "quota_message");
+    }
+
+    #[test]
+    fn classify_500_without_quota_does_not_trigger() {
+        let err = upstream(500, Some(r#"{"error":"internal_server_error"}"#), None);
+        assert!(classify_limit_signal(&err, None).is_none());
+    }
+
+    #[test]
+    fn classify_400_without_quota_does_not_trigger() {
+        // 400 without a quota phrase is a real client error, not a quota
+        // signal — don't waste a key rotation on it.
+        let err = upstream(400, Some("bad request"), None);
+        assert!(classify_limit_signal(&err, None).is_none());
+    }
+
+    #[test]
+    fn classify_400_with_quota_text_triggers() {
+        // MiniMax / PackyCode / 中转服务常用：HTTP 400 状态码 + quota 文案。
+        // 旧版要求 status ∈ {401,403,5xx} 才接 body 检测，会错失轮换。
+        // 新版：quota phrase 在任意 status 下都触发。
+        let err = upstream(400, Some("usage limit reached, retry after 5h"), None);
+        let s = classify_limit_signal(&err, None).unwrap();
+        assert_eq!(s.reason, "quota_message");
+    }
+
+    #[test]
+    fn classify_user_regex_match_triggers() {
+        // body 含 custom 标记但不带内置 quota 短语 —— 走 user_regex 路径。
+        // 不能写 "usage limit" 之类，因为新逻辑里 quota phrase 优先级更高。
+        let re = Regex::new(r"custom-marker").unwrap();
+        let err = upstream(400, Some("response body has custom-marker inside"), None);
+        let s = classify_limit_signal(&err, Some(&re)).unwrap();
+        assert_eq!(s.reason, "user_regex");
+    }
+
+    #[test]
+    fn classify_non_upstream_error_returns_none() {
+        let err = ProxyError::Timeout("foo".to_string());
+        assert!(classify_limit_signal(&err, None).is_none());
+    }
+
+    // ---- detect_quota_message ----
+
+    #[test]
+    fn detect_quota_builtin_phrases_case_insensitive() {
+        for phrase in &[
+            "insufficient_quota",
+            "Quota Exceeded",
+            "rate limit",
+            "USAGE LIMIT",
+            "billing issue",
+            "credit balance low",
+            "payment required",
+        ] {
+            assert_eq!(
+                detect_quota_message(phrase, None),
+                Some(QuotaMatch::Builtin),
+                "should match builtin: {phrase}"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_quota_negative() {
+        assert_eq!(detect_quota_message("OK", None), None);
+        assert_eq!(
+            detect_quota_message(r#"{"error":"not_found"}"#, None),
+            None
+        );
+    }
+
+    #[test]
+    fn detect_quota_user_regex_overrides_builtin_label() {
+        // 用户 regex 命中时返回 UserRegex，即使同时匹配 builtin 短语——
+        // user 显式声明更精确。
+        let re = Regex::new(r"专属限流提示").unwrap();
+        let body = "专属限流提示 / usage limit";
+        assert_eq!(
+            detect_quota_message(body, Some(&re)),
+            Some(QuotaMatch::UserRegex),
+        );
+        // 仅有 builtin 命中
+        assert_eq!(
+            detect_quota_message(body, None),
+            Some(QuotaMatch::Builtin),
+        );
+    }
+
+    // ---- parse_retry_after ----
+
+    #[test]
+    fn parse_retry_after_seconds() {
+        let mut h = HeaderMap::new();
+        h.insert("retry-after", HeaderValue::from_static("120"));
+        assert_eq!(parse_retry_after(&h), Some(120));
+    }
+
+    #[test]
+    fn parse_retry_after_http_date() {
+        let mut h = HeaderMap::new();
+        let future = chrono::Utc::now() + chrono::Duration::hours(1);
+        h.insert(
+            "retry-after",
+            HeaderValue::from_str(&future.format("%a, %d %b %Y %H:%M:%S GMT").to_string())
+                .unwrap(),
+        );
+        let secs = parse_retry_after(&h).unwrap();
+        // 1h ± 5s tolerance
+        assert!(
+            (3590..=3605).contains(&secs),
+            "expected ~3600s, got {secs}"
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_http_date_past_returns_zero() {
+        let mut h = HeaderMap::new();
+        let past = chrono::Utc::now() - chrono::Duration::hours(1);
+        h.insert(
+            "retry-after",
+            HeaderValue::from_str(&past.format("%a, %d %b %Y %H:%M:%S GMT").to_string())
+                .unwrap(),
+        );
+        assert_eq!(parse_retry_after(&h), Some(0));
+    }
+
+    #[test]
+    fn parse_retry_after_invalid_returns_none() {
+        let mut h = HeaderMap::new();
+        h.insert("retry-after", HeaderValue::from_static("not-a-number"));
+        assert_eq!(parse_retry_after(&h), None);
+    }
+
+    #[test]
+    fn parse_retry_after_missing_returns_none() {
+        let h = HeaderMap::new();
+        assert_eq!(parse_retry_after(&h), None);
+    }
+
+    // ---- parse_retry_after_ms ----
+
+    #[test]
+    fn parse_retry_after_ms_standard_header() {
+        let mut h = HeaderMap::new();
+        h.insert("retry-after-ms", HeaderValue::from_static("5000"));
+        assert_eq!(parse_retry_after_ms(&h), Some(5));
+    }
+
+    #[test]
+    fn parse_retry_after_ms_x_ratelimit_header() {
+        let mut h = HeaderMap::new();
+        h.insert("x-ratelimit-reset-ms", HeaderValue::from_static("30000"));
+        assert_eq!(parse_retry_after_ms(&h), Some(30));
+    }
+
+    #[test]
+    fn parse_retry_after_ms_rounds_up_subsecond() {
+        // 1500ms → 2s (向上取整，避免 1.5s 被 floor 成 1s 然后立刻被打回)
+        let mut h = HeaderMap::new();
+        h.insert("retry-after-ms", HeaderValue::from_static("1500"));
+        assert_eq!(parse_retry_after_ms(&h), Some(2));
+    }
+
+    // ---- extract_retry_after_secs ----
+
+    #[test]
+    fn extract_prefers_standard_retry_after() {
+        let mut h = HeaderMap::new();
+        h.insert("retry-after", HeaderValue::from_static("10"));
+        h.insert("retry-after-ms", HeaderValue::from_static("5000"));
+        assert_eq!(extract_retry_after_secs(&h), Some(10));
+    }
+
+    #[test]
+    fn extract_falls_back_to_ms_header() {
+        let mut h = HeaderMap::new();
+        h.insert("retry-after-ms", HeaderValue::from_static("5000"));
+        assert_eq!(extract_retry_after_secs(&h), Some(5));
+    }
+
+    #[test]
+    fn extract_returns_none_when_no_headers() {
+        let h = HeaderMap::new();
+        assert_eq!(extract_retry_after_secs(&h), None);
+    }
+}

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -49,7 +49,7 @@ pub fn replace_image_blocks_with_marker(body: &mut Value) -> usize {
 }
 
 pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
-    let ProxyError::UpstreamError { status, body } = error else {
+    let ProxyError::UpstreamError { status, body, .. } = error else {
         return false;
     };
 
@@ -737,6 +737,7 @@ mod tests {
             body: Some(
                 r#"{"error":{"message":"This model does not support image input"}}"#.to_string(),
             ),
+            retry_after_secs: None,
         };
 
         assert!(is_unsupported_image_error(&error));
@@ -773,6 +774,7 @@ mod tests {
         let error = ProxyError::UpstreamError {
             status: 400,
             body: Some(r#"{"error":{"message":"Invalid API key"}}"#.to_string()),
+            retry_after_secs: None,
         };
 
         assert!(!is_unsupported_image_error(&error));
@@ -810,12 +812,14 @@ mod tests {
             body: Some(
                 r#"{"error":{"message":"This model cannot process media inputs"}}"#.to_string(),
             ),
+            retry_after_secs: None,
         };
         assert!(is_unsupported_image_error(&media_error));
 
         let attachment_error = ProxyError::UpstreamError {
             status: 422,
             body: Some(r#"{"message":"attachments are not supported by this model"}"#.to_string()),
+            retry_after_secs: None,
         };
         assert!(is_unsupported_image_error(&attachment_error));
     }
@@ -828,6 +832,7 @@ mod tests {
                 r#"{"error":{"message":"Failed to deserialize the JSON body into the target type: messages[11]: unknown variant image_url, expected text"}}"#
                     .to_string(),
             ),
+            retry_after_secs: None,
         };
 
         assert!(is_unsupported_image_error(&error));

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -753,6 +753,7 @@ mod tests {
                 r#"{"error":{"message":"Model only support text input Request id: 021783"}}"#
                     .to_string(),
             ),
+            retry_after_secs: None,
         };
 
         assert!(is_unsupported_image_error(&error));

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -19,6 +19,7 @@ mod health;
 pub mod http_client;
 pub mod hyper_client;
 pub(crate) mod json_canonical;
+pub mod limit_signal;
 pub mod log_codes;
 pub mod media_sanitizer;
 pub mod model_mapper;

--- a/src-tauri/src/proxy/providers/adapter.rs
+++ b/src-tauri/src/proxy/providers/adapter.rs
@@ -23,6 +23,23 @@ pub trait ProviderAdapter: Send + Sync {
     /// 从 Provider 配置中提取认证信息
     fn extract_auth(&self, provider: &Provider) -> Option<AuthInfo>;
 
+    /// 用指定的 api_key 字符串提取认证信息——KeyRing 轮换时调用。
+    ///
+    /// 默认实现：克隆 provider，把 key 写进适配器认定的"标准位置"，然后
+    /// 调 `extract_auth`。各适配器应在精度重要的位置 override。
+    ///
+    /// OAuth 占位（GitHub Copilot / Codex OAuth）必须返回 None——它们的
+    /// token 是动态获取的，不走静态 key 池。
+    #[allow(dead_code)]
+    fn extract_auth_with_key(
+        &self,
+        provider: &Provider,
+        api_key: &str,
+    ) -> Option<AuthInfo> {
+        inject_key_into_provider(provider, api_key, self.name())
+            .and_then(|p| self.extract_auth(&p))
+    }
+
     /// 构建请求 URL
     fn build_url(&self, base_url: &str, endpoint: &str) -> String;
 
@@ -66,4 +83,179 @@ pub trait ProviderAdapter: Send + Sync {
 pub fn auth_header_value(s: &str) -> Result<http::HeaderValue, ProxyError> {
     http::HeaderValue::from_str(s)
         .map_err(|e| ProxyError::AuthError(format!("invalid auth header value: {e}")))
+}
+
+/// 克隆 `provider` 并把 `api_key` 写入适配器认定的"标准位置"。
+///
+/// KeyRing 轮换时调 `extract_auth_with_key`，默认实现走这里。设计原则：
+/// - 优先**保留用户原本选用的字段**（例如 Claude 既支持 `ANTHROPIC_AUTH_TOKEN`
+///   也支持 `ANTHROPIC_API_KEY`，改其中任意一个都意味着鉴权策略可能反转）。
+/// - 任何路径都打不开时（`settings_config` 不是对象），返回 `None` —— 此时
+///   `extract_auth` 也一定读不到 key，调用方按"没有 key"处理即可。
+/// - OAuth-managed provider（`adapter_name` 为 `"Claude"` 时仍可能命中
+///   Copilot/CodexOAuth 占位）会在 `extract_auth_with_key` 的 `extract_auth`
+///   调用处返回 `None`，与未配置 key 的表现一致。
+pub fn inject_key_into_provider(
+    provider: &Provider,
+    api_key: &str,
+    adapter_name: &str,
+) -> Option<Provider> {
+    // 把 adapter_name 映射到 AppType——同一份写入路径走 Provider::set_api_key
+    // （单真理来源）。OAuth-managed adapter（"Claude" 的 Copilot/CodexOAuth
+    // 占位）仍由调用方在 extract_auth_with_key 里短路掉。
+    let app_type = match adapter_name {
+        "Claude" => crate::app_config::AppType::Claude,
+        "Codex" => crate::app_config::AppType::Codex,
+        "Gemini" => crate::app_config::AppType::Gemini,
+        // Hermes / OpenClaw / OpenCode 已被 get_adapter 映射到 CodexAdapter
+        // （见 proxy::providers::get_adapter），不会进入本函数。
+        // 兜底：返回 None 让调用方走占位路径。
+        _ => return None,
+    };
+
+    // settings_config 必须能写成 object 形态。Provider::set_api_key 内部
+    // 直接 .expect() 抛错——这里提前 return None 把"畸形 settings_config"
+    // 转换成 `None`（调用方走原始 extract_auth 路径，不注入）。
+    if !provider.settings_config.is_object() {
+        return None;
+    }
+
+    let mut new_provider = provider.clone();
+    new_provider.set_api_key(api_key, &app_type);
+    Some(new_provider)
+}
+
+/// 在 `parent[<parent_key>]`（必须是 object）下插入 `child_key = api_key`。
+/// `parent_key` 不存在则创建空 object。
+///
+/// 已无调用方——`inject_key_into_provider` 现在直接走 `Provider::set_api_key`。
+/// 保留以备未来需要给非 `Provider` 类型的 settings_config 注入 key 时复用。
+#[allow(dead_code)]
+fn upsert_in_subobject(
+    parent: &mut serde_json::Map<String, Value>,
+    parent_key: &str,
+    child_key: &str,
+    api_key: &str,
+) {
+    let entry = parent
+        .entry(parent_key.to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if let Some(obj) = entry.as_object_mut() {
+        obj.insert(child_key.to_string(), Value::String(api_key.to_string()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proxy::providers::AuthStrategy;
+    use serde_json::json;
+
+    fn provider_with(settings: Value) -> Provider {
+        Provider {
+            id: "test".to_string(),
+            name: "test".to_string(),
+            settings_config: settings,
+            website_url: None,
+            category: None,
+            created_at: None,
+            sort_index: None,
+            notes: None,
+            meta: None,
+            icon: None,
+            icon_color: None,
+            in_failover_queue: false,
+        }
+    }
+
+    #[test]
+    fn inject_claude_writes_to_anthropic_auth_token_by_default() {
+        let p = provider_with(json!({}));
+        let p2 = inject_key_into_provider(&p, "sk-rotated", "Claude").unwrap();
+        assert_eq!(
+            p2.settings_config["env"]["ANTHROPIC_AUTH_TOKEN"],
+            "sk-rotated"
+        );
+    }
+
+    #[test]
+    fn inject_claude_preserves_anthropic_api_key_choice() {
+        // 用户原本用的是 ANTHROPIC_API_KEY（Claude 官方 x-api-key 鉴权），
+        // 轮换时不能误写到 ANTHROPIC_AUTH_TOKEN，否则鉴权策略会反转。
+        let p = provider_with(json!({"env": {"ANTHROPIC_API_KEY": "sk-original"}}));
+        let p2 = inject_key_into_provider(&p, "sk-rotated", "Claude").unwrap();
+        assert_eq!(p2.settings_config["env"]["ANTHROPIC_API_KEY"], "sk-rotated");
+        assert!(p2.settings_config["env"]
+            .get("ANTHROPIC_AUTH_TOKEN")
+            .is_none());
+    }
+
+    #[test]
+    fn inject_codex_writes_to_canonical_path() {
+        // Codex 走单路径 auth.OPENAI_API_KEY——与 AppType::api_key_settings_path
+        // 一致（Codex 列表里只有 1 项）。与读端 first_non_empty 顺序对称：
+        // 读端会先看 env.OPENAI_API_KEY 再看 auth.OPENAI_API_KEY（auth 优先），
+        // 所以写入用 auth 是正确的（保留用户原选）。
+        let p = provider_with(json!({}));
+        let p2 = inject_key_into_provider(&p, "sk-rotated", "Codex").unwrap();
+        assert_eq!(p2.settings_config["auth"]["OPENAI_API_KEY"], "sk-rotated");
+        // 单路径：不在 env / apiKey / options 写副本
+        assert!(p2.settings_config.get("env").is_none());
+        assert!(p2.settings_config.get("apiKey").is_none());
+        assert!(p2.settings_config.get("options").is_none());
+    }
+
+    #[test]
+    fn inject_gemini_writes_to_env() {
+        let p = provider_with(json!({}));
+        let p2 = inject_key_into_provider(&p, "AIza-rotated", "Gemini").unwrap();
+        assert_eq!(p2.settings_config["env"]["GEMINI_API_KEY"], "AIza-rotated");
+    }
+
+    #[test]
+    fn inject_unknown_adapter_returns_none() {
+        let p = provider_with(json!({}));
+        assert!(inject_key_into_provider(&p, "x", "Unknown").is_none());
+    }
+
+    #[test]
+    fn inject_settings_not_object_returns_none() {
+        let p = provider_with(Value::String("not-an-object".to_string()));
+        assert!(inject_key_into_provider(&p, "x", "Claude").is_none());
+    }
+
+    #[test]
+    fn extract_auth_with_key_default_impl_uses_injection() {
+        // 默认实现 = inject_key + extract_auth。验证 Claude fixture
+        // 走完整路径能拿到非占位 key。
+        struct StubAdapter;
+        impl ProviderAdapter for StubAdapter {
+            fn name(&self) -> &'static str {
+                "Claude"
+            }
+            fn extract_base_url(&self, _: &Provider) -> Result<String, ProxyError> {
+                Ok("https://api.anthropic.com".to_string())
+            }
+            fn extract_auth(&self, p: &Provider) -> Option<AuthInfo> {
+                let key = p.settings_config["env"]["ANTHROPIC_AUTH_TOKEN"]
+                    .as_str()?
+                    .to_string();
+                Some(AuthInfo::new(key, AuthStrategy::Bearer))
+            }
+            fn build_url(&self, base: &str, ep: &str) -> String {
+                format!("{base}{ep}")
+            }
+            fn get_auth_headers(
+                &self,
+                _: &AuthInfo,
+            ) -> Result<Vec<(http::HeaderName, http::HeaderValue)>, ProxyError> {
+                Ok(vec![])
+            }
+        }
+        let adapter = StubAdapter;
+        let p = provider_with(json!({}));
+        let auth = adapter.extract_auth_with_key(&p, "sk-rotated").unwrap();
+        assert_eq!(auth.api_key, "sk-rotated");
+        assert_eq!(auth.strategy, AuthStrategy::Bearer);
+    }
 }

--- a/src-tauri/src/proxy/providers/key_ring.rs
+++ b/src-tauri/src/proxy/providers/key_ring.rs
@@ -1,0 +1,1452 @@
+//! Per-Provider API Key Ring
+//!
+//! 维护每 provider 多把 API key 的运行时状态——cooldown、failure_count、
+//! round-robin 游标。**不**持久化自身，进程启动时从 `provider_api_keys`
+//! 表 reload（`reload_from_db`）；运行时变更（cooldown、failure）通过
+//! `flush_dirty` 写回，每 30s tick 触发一次（由 `ProxyService::start` 启动）。
+//!
+//! 设计参考 [`CopilotAuthManager`](super::copilot_auth.rs) 的多账号结构：
+//! in-memory HashMap of pools + per-provider mutex（防止并发选 key 时
+//! 同一个 cursor 被多个请求抢到）。
+//!
+//! ## 与 OAuth provider 的关系
+//!
+//! OAuth-managed provider（GitHub Copilot、Codex OAuth）由 `meta.provider_type`
+//! 标识，凭据通过 device-code 流程动态获取。KeyRing 只处理静态 key pool：
+//! 对 OAuth provider，`next_key` 返回 `None`，forwarder 走原本的占位路径。
+//! 这是显式设计选择——避免把 OAuth 的 token 刷新逻辑和静态 key 的冷却逻辑
+//! 缠在一起。
+
+use crate::app_config::AppType;
+use crate::database::dao::api_keys::ProviderApiKey;
+use crate::database::Database;
+use crate::error::AppError;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+/// 单 key 的运行时快照——KeyRing 持有此结构（不含 raw api_key 之外的字段）。
+///
+/// `cooldown_until` 与 `failure_count` 在每次 `mark_*` 时更新；
+/// `flush_dirty` 时写回 DB 行。
+#[derive(Debug, Clone)]
+pub struct KeyState {
+    pub key_id: String,
+    pub api_key: String,
+    pub enabled: bool,
+    pub sort_index: i64,
+    pub is_active: bool,
+    pub cooldown_until: i64,
+    pub failure_count: i64,
+    pub last_used_at: Option<i64>,
+    pub last_error: Option<String>,
+    pub label: String,
+}
+
+impl KeyState {
+    /// 从 DAO 行构造。仅拷贝运行时需要的字段——`tags`/`notes` 等静态
+    /// 属性在 UI 层直接读 DB，不进 KeyRing。
+    fn from_db_row(row: &ProviderApiKey) -> Self {
+        Self {
+            key_id: row.id.clone(),
+            api_key: row.api_key.clone(),
+            enabled: row.enabled,
+            sort_index: row.sort_index,
+            is_active: row.is_active,
+            cooldown_until: row.cooldown_until,
+            failure_count: row.failure_count,
+            last_used_at: row.last_used_at,
+            last_error: row.last_error.clone(),
+            label: row.label.clone(),
+        }
+    }
+
+    /// key 是否在 cooldown（now < cooldown_until）。
+    fn is_cooling(&self, now: i64) -> bool {
+        self.cooldown_until > now
+    }
+}
+
+/// 历史阈值常量（保留以便 UI 与日志引用）——同 key 连续 N 次失败
+/// 后**不再**自动 disable。所有 key 始终可被 `next_key` 选中：失败的
+/// key 只会进入 cooldown，过了 `reap_expired_cooldowns` 窗口（30s tick）
+/// 后 failure_count 重置回 0，key 立刻重新可用。
+///
+/// 旧实现会在这里设 `enabled = false` + 推进 cursor 到下一把；
+/// 现在的语义是「只轮换、不永久停用」：让故障 provider 的所有 key
+/// 都被试过一遍后（每个 key 30s 冷却 + request 内的 max_key_attempts），
+/// forwarder 在同一请求内 break 'rotate 推进到下一家 provider。
+/// 跨请求的轮换是 `next_key` 的 sticky 行为，cursor 不会因为失败而
+/// 推进（直到整池被 cooldown 耗尽）。
+///
+/// UI 仍然用这个数字显示"已失败 N/5 次"——保留常量供前端 i18n 复用。
+#[allow(dead_code)]
+const AUTO_DISABLE_FAILURE_THRESHOLD: i64 = 5;
+
+/// key 冷却的下限：即便上游 `Retry-After: 1`，我们也至少冷却 30s，
+/// 避免 1s 后被同一批并发请求立即打回去。
+const MIN_COOLDOWN_SECS: i64 = 30;
+
+pub struct KeyRing {
+    /// 每 provider 一个池子。Key = (provider_id, app_type)。
+    pools: Arc<RwLock<HashMap<(String, String), Vec<KeyState>>>>,
+    /// round-robin 游标：每 provider 一把，独立递增。
+    cursors: Arc<RwLock<HashMap<(String, String), usize>>>,
+    /// 防止并发选 key 时同一个 cursor 被两个请求同时消费。
+    /// Key 与 pools 一致；锁释放后 cursor 已递增，下一个请求拿到下一把。
+    selection_locks: Arc<RwLock<HashMap<(String, String), Arc<Mutex<()>>>>>,
+    /// 自上次 flush 以来改动过 cooldown/failure 的 key_id 集合。
+    /// 写读分离：mark_* 立即更新内存，flush 时只把 dirty 的 key 写回 DB。
+    dirty: Arc<RwLock<HashSet<String>>>,
+}
+
+impl Default for KeyRing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KeyRing {
+    pub fn new() -> Self {
+        Self {
+            pools: Arc::new(RwLock::new(HashMap::new())),
+            cursors: Arc::new(RwLock::new(HashMap::new())),
+            selection_locks: Arc::new(RwLock::new(HashMap::new())),
+            dirty: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    /// 从 DB reload 所有 provider 的 key 池。
+    ///
+    /// **销毁**当前内存状态并用最新 DB 数据替换——通常在启动时调用。
+    /// 已被 mark_* 改动但尚未 flush 的 dirty 集合会丢失（启动时为空，
+    /// 这是正确的）。
+    pub async fn reload_from_db(&self, db: &Database) -> Result<(), AppError> {
+        let provider_keys = collect_all_provider_keys(db)?;
+        let mut pools = self.pools.write().await;
+        let mut cursors = self.cursors.write().await;
+        let mut locks = self.selection_locks.write().await;
+        let mut dirty = self.dirty.write().await;
+
+        pools.clear();
+        cursors.clear();
+        locks.clear();
+        dirty.clear();
+
+        for (pid, app, key) in provider_keys {
+            let entry = pools.entry((pid.clone(), app.clone())).or_default();
+            entry.push(KeyState::from_db_row(&key));
+            locks
+                .entry((pid.clone(), app.clone()))
+                .or_insert_with(|| Arc::new(Mutex::new(())));
+        }
+        // 初始化 cursor 到 active key 的位置——首次 next_key 用 active key。
+        // 没有 active key 时退回 sort_index=0（与 active_key() 行为一致）。
+        // 旧实现固定从 0 开始，会让 round-robin 把 active key 当成普通 key 处理。
+        for (key, pool) in pools.iter() {
+            let active_idx = pool.iter().position(|k| k.is_active).unwrap_or(0);
+            cursors.insert(key.clone(), active_idx);
+        }
+        Ok(())
+    }
+
+    /// 增量 reload 一个 provider 的 key 池——UI 添加/删除 key 时调用，
+    /// 避免整库 reload 的抖动。
+    ///
+    /// 顺便把 cursor 重置到 active key 的位置。理由：
+    ///   - 池子大小变了（新增/删除 key），cursor 原来指的位置可能
+    ///     越界或指向一把被删掉的 key
+    ///   - 用户切换 active key 后，cursor 必须立即落到新 active 上，
+    ///     否则下次请求会继续打老 key
+    /// 旧实现 cursor 留在原值，会出现"刚切了 active 但请求仍走老 key"的回归。
+    pub async fn reload_provider(
+        &self,
+        db: &Database,
+        provider_id: &str,
+        app_type: &str,
+    ) -> Result<(), AppError> {
+        let keys = db.list_api_keys(provider_id, app_type)?;
+        let key_tuple = (provider_id.to_string(), app_type.to_string());
+        let mut pools = self.pools.write().await;
+        let mut locks = self.selection_locks.write().await;
+        let active_idx = keys.iter().position(|k| k.is_active).unwrap_or(0);
+        pools.insert(
+            key_tuple.clone(),
+            keys.iter().map(KeyState::from_db_row).collect(),
+        );
+        locks
+            .entry(key_tuple.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())));
+        drop(pools);
+        drop(locks);
+
+        // cursor 单独更新——不持 pools 锁时写 cursors，避免和 mark_failure
+        // 形成 pools→cursors 反向锁顺序。
+        let mut cursors = self.cursors.write().await;
+        cursors.insert(key_tuple, active_idx);
+        Ok(())
+    }
+
+    /// 选下一把可用 key。
+    ///
+    /// 选中规则（按 sort_index ASC 顺序循环）：
+    /// 1. `enabled == true`
+    /// 2. `now >= cooldown_until`
+    ///
+    /// **Round-robin 行为**：每次成功选到 key 之后，把 cursor 推到
+    /// `(idx + 1) % len`——下次 next_key 从下一个位置开始，强制轮换
+    /// 穿透整池。这与早期 sticky 实现相反：sticky 让 cursor 钉在
+    /// 同一把 key 上直到它失败，结果是失败后只在该 key 冷却期内
+    /// 临时切到下一把，等冷却结束又跳回去「同两把 key 之间反复」。
+    /// round-robin 让 cursor 持续推进，确保所有 key 都被均匀使用。
+    ///
+    /// 返回 `None` 表示：
+    /// - 池为空（provider 还没配置 key）
+    /// - 全部 disabled 或在 cooldown（调用方应退到下一家 provider）
+    pub async fn next_key(
+        &self,
+        provider_id: &str,
+        app_type: &AppType,
+    ) -> Option<KeyState> {
+        let app_str = app_type.as_str().to_string();
+        let key = (provider_id.to_string(), app_str.clone());
+
+        // 获取（或创建）该 provider 的 selection lock——防止并发 next_key
+        // 把同一个 cursor 消费两次。锁本身创建在 reload 阶段；
+        // 这里如未创建，池为空，直接返回 None。
+        let locks_guard = self.selection_locks.read().await;
+        let lock = locks_guard.get(&key)?.clone();
+        drop(locks_guard);
+
+        // 取锁保护 cursor 修改；这是 per-provider 的，跨 provider 并行。
+        let _guard = lock.lock().await;
+
+        let pools = self.pools.read().await;
+        let pool = pools.get(&key)?;
+        if pool.is_empty() {
+            return None;
+        }
+        let now = chrono::Utc::now().timestamp();
+
+        let cursors = self.cursors.read().await;
+        let cursor = cursors.get(&key).copied().unwrap_or(0);
+        drop(cursors);
+        let len = pool.len();
+
+        // cursor 可能因 key 被删而越界，clamp 到 [0, len)。
+        let start = cursor % len;
+
+        // 最多绕一圈（len 次尝试）。从 cursor 开始，逐项检查可用性。
+        // **命中时推进 cursor 到 (idx + 1) % len** —— round-robin 行为：
+        // 每次成功选到 key 后，cursor 推到下一把，下一次 next_key 必然
+        // 落到不同位置。这样即便所有请求都成功，cursor 也会逐步推进，
+        // 不会卡在同一把 key 上。
+        //
+        // 跳过冷却 / 停用 的 key 不会推进 cursor——cursor 由「成功选到」
+        // 那一刻推进，cooldown 中的 key 不算成功选中。
+        for offset in 0..len {
+            let idx = (start + offset) % len;
+            let candidate = &pool[idx];
+            if candidate.enabled && !candidate.is_cooling(now) {
+                // 命中：推进 cursor 到 (idx + 1) % len
+                let next_cursor = (idx + 1) % len;
+                let mut cursors = self.cursors.write().await;
+                cursors.insert(key.clone(), next_cursor);
+                return Some(candidate.clone());
+            }
+        }
+        // 整池都不可用——不推进 cursor（避免跳过未来可用的位置）
+        None
+    }
+
+    /// 标记某把 key 被限流/配额耗尽。设置 cooldown_until + failure_count += 1。
+    /// `retry_after_secs` 来自上游 Retry-After（None 或 0 走最小冷却）。
+    pub async fn mark_rate_limited(
+        &self,
+        key_id: &str,
+        retry_after_secs: Option<u64>,
+    ) -> KeyStateUpdate {
+        let cooldown = retry_after_secs
+            .unwrap_or(0)
+            .max(MIN_COOLDOWN_SECS as u64) as i64;
+        self.apply_update(
+            key_id,
+            cooldown,
+            |count| count + 1,
+            Some(format!(
+                "rate limited; cooldown {}s",
+                retry_after_secs.unwrap_or(MIN_COOLDOWN_SECS as u64)
+            )),
+        )
+        .await
+    }
+
+    /// 标记某把 key 用量接近上限（proactive rotation）
+    ///
+    /// 当自动查询（autoQueryInterval 触发）发现某把 key 的 `usage_percent`
+    /// 超过 `USAGE_WARN_PERCENT`（默认 90%），由前端调用本接口把这把
+    /// key 提前送进 cooldown——`cooldown_until` 设为 `reset_at`（即下一个
+    /// 5h 窗口重置时间戳）。
+    ///
+    /// **为什么是 proactive 而不是等 429**：等到上游返回 429/5xx 才切
+    /// key 的问题是请求已经白扔了。提前在 quota 临界点切换可以：
+    /// 1) 减少「先失败再切 key」的来回延迟（upstream 失败本身要 1-3s）
+    /// 2) 给前端的 5h/7d 进度条一个真实的「切换原因」展示
+    /// 3) 让 5h 重置后 key 自动可用（cooldown_until = reset_at，reap 后
+    ///    next_key 重新选中这把 key）
+    ///
+    /// **threshold 等级**：
+    /// - 90-99%：warning，cooldown 到 reset_at（5h 重置后自动恢复）
+    /// - >= 100%：exhausted，cooldown 到 max(reset_at, now + 30min)，给
+    ///   系统一个额外缓冲避免反复打爆
+    ///
+    /// **不修改 failure_count**：proactive rotation 不代表「失败」，只
+    /// 代表「已接近上限」。UI 仍然只显示 react 429/5xx 路径产生的失败
+    /// 计数。
+    ///
+    /// **不自动 disable**：即便 100% 也不动 `enabled` 字段——`enabled`
+    /// 仍由用户手动控制（settings 页面）。
+    pub async fn mark_usage_high(
+        &self,
+        key_id: &str,
+        usage_percent: f64,
+        reset_at: i64,
+    ) -> bool {
+        const USAGE_WARN_PERCENT: f64 = 90.0;
+        const USAGE_EXHAUSTED_PERCENT: f64 = 100.0;
+        const EXHAUSTED_MIN_COOLDOWN_SECS: i64 = 30 * 60; // 30 min
+
+        let now = chrono::Utc::now().timestamp();
+        let cooldown_until = if usage_percent >= USAGE_EXHAUSTED_PERCENT {
+            // 完全耗尽：cooldown 至少撑到 reset 之后 30min
+            std::cmp::max(reset_at, now + EXHAUSTED_MIN_COOLDOWN_SECS)
+        } else if usage_percent >= USAGE_WARN_PERCENT {
+            // 接近耗尽：cooldown 到 reset_at（5h 重置后恢复）
+            reset_at
+        } else {
+            // 还在安全区，不动
+            return false;
+        };
+
+        self.apply_update(
+            key_id,
+            cooldown_until.saturating_sub(now).max(MIN_COOLDOWN_SECS),
+            |count| count, // 不 bump failure_count
+            Some(format!(
+                "proactive rotation: usage {:.1}%",
+                usage_percent
+            )),
+        )
+        .await;
+        true
+    }
+
+    /// 标记某把 key 成功——清零 cooldown + failure_count。
+    pub async fn mark_success(&self, key_id: &str) {
+        self.apply_update(
+            key_id,
+            0,
+            |_| 0,
+            None,
+        )
+        .await;
+    }
+
+    /// 标记某把 key 非限流失败（5xx、超时等）——bump failure_count 给 UI
+    /// 显示用，**不**设置 cooldown 也**不**自动 disable。
+    ///
+    /// 历史行为：阈值达到 `AUTO_DISABLE_FAILURE_THRESHOLD` 自动 disable。
+    /// 现在的语义是「轮换但不永久停用」——这把 key 仍然在池中，
+    /// `next_key` 仍会选中它；下一次同 key 调用失败只在 UI 上把
+    /// "已失败 N/5 次" 累加。`reap_expired_cooldowns` 在 30s tick 里把
+    /// cooldown 过期时清零 `failure_count`，所以 UI 看到的是"短时间内
+    /// N 次连续失败 → 5/5 短暂出现 → 冷却结束 → 重置 0/5"。
+    ///
+    /// 跨 provider 轮换由 forwarder 的 `'rotate` 循环负责：
+    /// 同一 provider 内 `max_key_attempts` 把每把 key 试完后，
+    /// `KeyRing::next_key` 返回 None，forwarder 推进到 failover 队列
+    /// 里的下一家 provider。
+    ///
+    /// 锁顺序：pools (write) → dirty (write)。与 `flush_dirty` 反向。
+    pub async fn mark_failure(&self, key_id: &str, err: &str) {
+        let now = chrono::Utc::now().timestamp();
+        let mut found = false;
+
+        {
+            let mut pools = self.pools.write().await;
+            for (_pid, pool) in pools.iter_mut() {
+                if let Some(k) = pool.iter_mut().find(|k| k.key_id == key_id) {
+                    k.failure_count += 1;
+                    k.last_used_at = Some(now);
+                    k.last_error = Some(err.to_string());
+                    found = true;
+                    break;
+                }
+            }
+        } // pools 锁释放
+
+        if found {
+            let mut dirty = self.dirty.write().await;
+            dirty.insert(key_id.to_string());
+        }
+    }
+
+    /// 把内存中的 dirty 改动（cooldown / failure_count / last_used_at /
+    /// last_error）持久化到 DB。失败仅告警——内存已更新，下次 tick 重试。
+    ///
+    /// 锁顺序：
+    ///   1. `dirty.read()` 收集所有 dirty key 列表（短持锁）
+    ///   2. `pools.write()` 短暂持锁，clone 出每个 key 的运行时快照
+    ///   3. 释放 pools 锁
+    ///   4. **DB 写在锁外**——`db.write_api_key_runtime` 是 sync 调用（~1ms/key），
+    ///      不能阻塞 forwarder 的 `next_key` / `snapshot` 读路径
+    ///   5. 拿 `dirty.write()`，移除已成功持久化的 key
+    ///
+    /// 与 `mark_*` 反向锁序（pools → dirty）：flush 路径"先 dirty 后 pools"，
+    /// mark 路径"先 pools 后 dirty"。两路径各取一个锁时不会循环等待。
+    pub async fn flush_dirty(&self, db: &Database) -> Result<usize, AppError> {
+        let dirty_keys: Vec<String> = {
+            let dirty = self.dirty.read().await;
+            dirty.iter().cloned().collect()
+        };
+        if dirty_keys.is_empty() {
+            return Ok(0);
+        }
+
+        // Step 1: 在持有 pools 锁期间收集快照（DB 写需要的字段）。
+        // 这一段保持锁，迫使 forwarder 短暂等待，但写入逻辑很轻（仅 clone 字段），
+        // 不是原来的"边 hold 锁边做 sync DB 写"那种长临界区。
+        let now = chrono::Utc::now().timestamp();
+        let to_persist: Vec<(String, i64, i64, Option<i64>, Option<String>)> = {
+            let mut pools = self.pools.write().await;
+            let mut out = Vec::with_capacity(dirty_keys.len());
+            for key_id in &dirty_keys {
+                if let Some(snapshot) = pools.values_mut().find_map(|pool| {
+                    pool.iter_mut().find(|k| &k.key_id == key_id).map(|k| {
+                        if k.last_used_at.is_none() {
+                            k.last_used_at = Some(now);
+                        }
+                        (
+                            k.key_id.clone(),
+                            k.cooldown_until,
+                            k.failure_count,
+                            k.last_used_at,
+                            k.last_error.clone(),
+                        )
+                    })
+                }) {
+                    out.push(snapshot);
+                }
+            }
+            out
+        };
+        // 锁在此释放（pools write guard drop）
+
+        // Step 2: 在无锁状态下写 DB（失败仅告警，不阻断 forwarder 读路径）。
+        let mut persisted_keys: Vec<String> = Vec::with_capacity(to_persist.len());
+        for (key_id, cooldown_until, failure_count, last_used_at, last_error) in to_persist {
+            if let Err(e) = db.write_api_key_runtime(
+                &key_id,
+                cooldown_until,
+                failure_count,
+                last_used_at,
+                last_error.as_deref(),
+                now,
+            ) {
+                log::warn!("[KeyRing] flush dirty key={} 失败: {e}", key_id);
+                continue;
+            }
+            persisted_keys.push(key_id);
+        }
+
+        // Step 3: 把"已被处理"的 key（写成功 + 池中找不到 / 已被删除）从 dirty 集合移除。
+        // —— 之前只移写成功的，留下了"已被 delete 但仍在 dirty"的脏 entry，
+        // 下次 flush_dirty 又重新尝试并失败，永久 stuck。修复：池中找不到也视作处理完。
+        let mut dirty = self.dirty.write().await;
+        // 先把写成功的移走
+        for key_id in &persisted_keys {
+            dirty.remove(key_id);
+        }
+        // 再扫描 dirty 集合：如果某 key 在 pools 里找不到，永久清掉（避免 stuck）；
+        // 写失败但 pools 仍有 → 留在 dirty 等下次 tick 重试。
+        let stale: Vec<String> = {
+            let pools = self.pools.read().await;
+            dirty
+                .iter()
+                .filter(|key_id| {
+                    !persisted_keys.contains(*key_id)
+                        && !pools
+                            .values()
+                            .any(|pool| pool.iter().any(|k| &k.key_id == *key_id))
+                })
+                .cloned()
+                .collect()
+        };
+        for key_id in &stale {
+            dirty.remove(key_id);
+            log::debug!("[KeyRing] dropped stale dirty key={key_id} (no longer in pool)");
+        }
+        Ok(persisted_keys.len())
+    }
+
+    /// 清扫所有「cooldown 已过期」的 key——把它们拉回「完全可用」状态：
+    ///   - `cooldown_until = 0`
+    ///   - `failure_count = 0`
+    ///   - `last_error = None`
+    ///
+    /// 设计原因：之前 mark_rate_limited 只设 cooldown + failure_count += 1，
+    /// 没有「cooldown 过期就清零」的清扫。后果是：
+    ///   - 一把 key 被 rate-limit 一次（failure_count=1）后冷却 5 分钟；
+    ///   - 5 分钟后 cursor 回到这把 key 时，UI 仍显示「已失败 1/5 次」，
+    ///     即便这把 key 现在完全可用——给用户"这把 key 一直有点问题"的错觉。
+    ///   - 极端情况下，一把 key 累加到 4 次失败就冷却；冷却结束后仍显示
+    ///     4/5；下一次失败直接到 5/5 触发自动停用。中间没有给"诚实的恢复期"。
+    ///
+    /// 现在：cooldown 过期的那一刹那就重置，行为是「5 次连续失败才停用」，
+    /// 而不是「跨多个 cooldown 累计」。这把 key 标记为 dirty，下一次
+    /// `flush_dirty` 会把重置写回 DB。
+    ///
+    /// 由 30s flush tick 在 `flush_dirty` 之前调用——保证最坏 30s 内
+    /// 完成清扫（用户感知"刚恢复"≈立即）。
+    pub async fn reap_expired_cooldowns(&self) -> usize {
+        let now = chrono::Utc::now().timestamp();
+        let mut to_reset: Vec<String> = Vec::new();
+
+        {
+            let pools = self.pools.read().await;
+            for pool in pools.values() {
+                for k in pool {
+                    // cooldown_until > 0 意味着曾经设过；== now 已经过。
+                    // 顺手清掉 last_error。
+                    if k.cooldown_until > 0 && k.cooldown_until <= now && k.enabled {
+                        to_reset.push(k.key_id.clone());
+                    }
+                }
+            }
+        }
+
+        if to_reset.is_empty() {
+            return 0;
+        }
+
+        {
+            let mut pools = self.pools.write().await;
+            for pool in pools.values_mut() {
+                for k in pool.iter_mut() {
+                    if to_reset.contains(&k.key_id) {
+                        k.cooldown_until = 0;
+                        k.failure_count = 0;
+                        k.last_error = None;
+                    }
+                }
+            }
+        }
+
+        // 标 dirty，下一次 flush_dirty 会写回 DB
+        let mut dirty = self.dirty.write().await;
+        for key_id in &to_reset {
+            dirty.insert(key_id.clone());
+        }
+
+        log::debug!(
+            "[KeyRing] reaped {} expired-cooldown keys (reset failure_count=0)",
+            to_reset.len()
+        );
+        to_reset.len()
+    }
+
+    /// 重置某 provider 的 round-robin 游标到 active key 的位置。
+    ///
+    /// 用途：
+    /// - 用户切换 active key 后，cursor 必须落到新 active 上，
+    ///   否则下次 next_key 会跳过它（旧实现固定 reset 到 0 也有同样问题）
+    /// - `reload_provider` 在 add/delete key 后也调它，保证 cursor 不越界
+    /// 找不到 active key 时退回 sort_index=0（与 `active_key()` 一致）。
+    pub async fn reset_cursor(&self, provider_id: &str, app_type: &AppType) {
+        let key = (provider_id.to_string(), app_type.as_str().to_string());
+        let pools = self.pools.read().await;
+        let active_idx = pools
+            .get(&key)
+            .and_then(|pool| pool.iter().position(|k| k.is_active))
+            .unwrap_or(0);
+        drop(pools);
+        let mut cursors = self.cursors.write().await;
+        cursors.insert(key, active_idx);
+    }
+
+    /// 失效某 provider 的池——通常在 user 删除 provider / 删除所有 key 后调用。
+    pub async fn invalidate_provider(&self, provider_id: &str, app_type: &AppType) {
+        let key = (provider_id.to_string(), app_type.as_str().to_string());
+        let mut pools = self.pools.write().await;
+        let mut cursors = self.cursors.write().await;
+        let mut locks = self.selection_locks.write().await;
+        pools.remove(&key);
+        cursors.remove(&key);
+        locks.remove(&key);
+    }
+
+    /// 给前端 / 日志展示用：返回某 provider 当前池的快照。
+    pub async fn snapshot(&self, provider_id: &str, app_type: &AppType) -> Vec<KeyState> {
+        let key = (provider_id.to_string(), app_type.as_str().to_string());
+        let pools = self.pools.read().await;
+        pools.get(&key).cloned().unwrap_or_default()
+    }
+
+    /// 取当前应该用的 key（不推进 cursor）。
+    ///
+    /// 优先 `is_active=1` 的 key；没有则取 `sort_index=0` 的那把；都没有返回 None。
+    /// 用途：forwarder 在进入 per-provider 循环时初始化 `current_key_id`，
+    /// 让第一次 429 能正确 mark 当前 active key（Blocker #3）。
+    pub async fn active_key(
+        &self,
+        provider_id: &str,
+        app_type: &AppType,
+    ) -> Option<KeyState> {
+        let key = (provider_id.to_string(), app_type.as_str().to_string());
+        let pools = self.pools.read().await;
+        let pool = pools.get(&key)?;
+        // 1. is_active=1
+        if let Some(k) = pool.iter().find(|k| k.is_active).cloned() {
+            return Some(k);
+        }
+        // 2. fallback：sort_index ASC 的第一把
+        pool.iter().min_by_key(|k| k.sort_index).cloned()
+    }
+
+    /// apply_update 内部辅助：合并 mark_rate_limited / mark_success 共有的
+    /// 内存改动 + dirty 标记逻辑。
+    ///
+    /// `cooldown_secs_from_now` 是相对秒数（0 = 立即可用，30 = 30s 后）——
+    /// 函数内部加 `now` 转成绝对 unix 时间戳写入行。
+    /// 这样 mark_rate_limited 调用方语义直观（"key 至少冷却 30s"），而不必关心
+    /// "now 到底是哪一秒"。
+    async fn apply_update(
+        &self,
+        key_id: &str,
+        cooldown_secs_from_now: i64,
+        bump_failure: impl Fn(i64) -> i64,
+        last_error: Option<String>,
+    ) -> KeyStateUpdate {
+        let now = chrono::Utc::now().timestamp();
+        let cooldown_until = if cooldown_secs_from_now > 0 {
+            now + cooldown_secs_from_now
+        } else {
+            0
+        };
+
+        // 锁顺序：pools (write) → dirty (write) —— 与 mark_failure 一致，
+        // 与 flush_dirty 反向（flush_dirty 持 dirty 后拿 pools）；只要不在
+        // 一个方法内"同时持有 pools + dirty 进行长操作"，就不会死锁。
+        let mut found = None;
+        {
+            let mut pools = self.pools.write().await;
+            for pool in pools.values_mut() {
+                if let Some(k) = pool.iter_mut().find(|k| k.key_id == key_id) {
+                    k.cooldown_until = cooldown_until;
+                    k.failure_count = bump_failure(k.failure_count);
+                    k.last_used_at = Some(now);
+                    if last_error.is_some() {
+                        k.last_error = last_error;
+                    } else if cooldown_secs_from_now == 0 {
+                        // success path：清空 last_error
+                        k.last_error = None;
+                    }
+                    found = Some(KeyStateUpdate {
+                        key_id: k.key_id.clone(),
+                        cooldown_until: k.cooldown_until,
+                        failure_count: k.failure_count,
+                    });
+                    break;
+                }
+            }
+        } // pools 锁释放
+        if found.is_some() {
+            let mut dirty = self.dirty.write().await;
+            dirty.insert(key_id.to_string());
+        }
+        found.unwrap_or(KeyStateUpdate {
+            key_id: key_id.to_string(),
+            cooldown_until,
+            failure_count: 0,
+        })
+    }
+}
+
+/// mark_rate_limited / apply_update 的返回值——记录刚刚应用的变更，
+/// 便于调用方（forwarder）做日志。
+#[derive(Debug, Clone)]
+pub struct KeyStateUpdate {
+    pub key_id: String,
+    pub cooldown_until: i64,
+    pub failure_count: i64,
+}
+
+/// 同步 helper：跨所有 (provider_id, app_type) 对收集 ProviderApiKey 行。
+/// 用 sync API（lock_conn!）以匹配 KeyRing 启动时无 runtime 的场景。
+fn collect_all_provider_keys(
+    db: &Database,
+) -> Result<Vec<(String, String, ProviderApiKey)>, AppError> {
+    let conn = crate::database::lock_conn!(db.conn);
+    // 用 list_api_keys 一家一家取——简单且不引入新 SQL。
+    // 先查所有 (provider_id, app_type) pair：用 providers 表 + GROUP BY。
+    let mut stmt = conn
+        .prepare("SELECT DISTINCT id, app_type FROM providers")
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let pairs: Vec<(String, String)> = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    drop(stmt);
+    drop(conn);
+
+    let mut out = Vec::new();
+    for (pid, app) in pairs {
+        // 跳过 OAuth-managed provider——它们没有静态 key 池。
+        // 检测：meta.providerType in {"github_copilot","codex_oauth"}
+        let conn = crate::database::lock_conn!(db.conn);
+        let provider_type: Option<String> = conn
+            .query_row(
+                "SELECT json_extract(meta, '$.providerType') FROM providers
+                 WHERE id = ?1 AND app_type = ?2",
+                rusqlite::params![&pid, &app],
+                |row| row.get(0),
+            )
+            .ok()
+            .flatten();
+        drop(conn);
+        if matches!(
+            provider_type.as_deref(),
+            Some("github_copilot") | Some("codex_oauth")
+        ) {
+            continue;
+        }
+        let keys = db.list_api_keys(&pid, &app)?;
+        for k in keys {
+            out.push((pid.clone(), app.clone(), k));
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_key(id: &str, sort_index: i64, enabled: bool) -> ProviderApiKey {
+        let now = chrono::Utc::now().timestamp();
+        ProviderApiKey {
+            id: id.to_string(),
+            provider_id: "p1".to_string(),
+            app_type: "claude".to_string(),
+            label: id.to_string(),
+            api_key: format!("sk-{id}"),
+            tags: vec![],
+            notes: String::new(),
+            enabled,
+            sort_index,
+            is_active: sort_index == 0,
+            cooldown_until: 0,
+            failure_count: 0,
+            last_used_at: None,
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn seed_provider(db: &Database, pid: &str, app: &str) -> Result<(), AppError> {
+        let conn = crate::database::lock_conn!(db.conn);
+        conn.execute(
+            "INSERT OR IGNORE INTO providers (id, app_type, name, settings_config)
+             VALUES (?1, ?2, ?3, '{}')",
+            rusqlite::params![pid, app, format!("P-{pid}")],
+        )
+        .expect("seed provider");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn next_key_returns_none_when_pool_empty() {
+        let ring = KeyRing::new();
+        assert!(ring
+            .next_key("p1", &AppType::Claude)
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn next_key_returns_first_when_pool_has_one() {
+        let ring = KeyRing::new();
+        let k = make_key("only", 0, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(("p1".to_string(), "claude".to_string()), vec![KeyState::from_db_row(&k)]);
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        let picked = ring.next_key("p1", &AppType::Claude).await.expect("some");
+        assert_eq!(picked.key_id, "only");
+    }
+
+    /// Round-robin 行为：cursor 在命中时推进到下一把，下次 next_key
+    /// 必然落到不同位置——避免 sticky 实现下「同两把 key 之间反复」
+    /// 的 ping-pong。所有 key 在正常请求路径上都会被均匀使用。
+    #[tokio::test]
+    async fn next_key_is_round_robin() {
+        let ring = KeyRing::new();
+        let k0 = make_key("k0", 0, true);
+        let k1 = make_key("k1", 1, true);
+        let k2 = make_key("k2", 2, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![
+                    KeyState::from_db_row(&k0),
+                    KeyState::from_db_row(&k1),
+                    KeyState::from_db_row(&k2),
+                ],
+            );
+            ring.cursors
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+
+        // 连选四次，cursor 应逐次推进：k0 → k1 → k2 → k0（绕回）
+        let p0 = ring.next_key("p1", &AppType::Claude).await.unwrap();
+        let p1 = ring.next_key("p1", &AppType::Claude).await.unwrap();
+        let p2 = ring.next_key("p1", &AppType::Claude).await.unwrap();
+        let p3 = ring.next_key("p1", &AppType::Claude).await.unwrap();
+        assert_eq!(p0.key_id, "k0");
+        assert_eq!(p1.key_id, "k1", "round-robin: 命中后 cursor 应推进");
+        assert_eq!(p2.key_id, "k2", "round-robin: 命中后 cursor 应推进");
+        assert_eq!(p3.key_id, "k0", "round-robin: 绕回池头");
+    }
+
+    /// cursor 初始位置 = active key 位置（reload_from_db / reset_cursor 的契约）。
+    /// 用户切到 k2 为 active 后，next_key 应直接落到 k2。
+    #[tokio::test]
+    async fn next_key_starts_at_active() {
+        let ring = KeyRing::new();
+        let mut k0 = make_key("k0", 0, true);
+        k0.is_active = false;
+        let mut k1 = make_key("k1", 1, true);
+        k1.is_active = false;
+        let mut k2 = make_key("k2", 2, true);
+        k2.is_active = true; // k2 是 active
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![
+                    KeyState::from_db_row(&k0),
+                    KeyState::from_db_row(&k1),
+                    KeyState::from_db_row(&k2),
+                ],
+            );
+            ring.cursors
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        // 模拟 reload_from_db / 切换 active key 之后：把 cursor 拨到 active 位置
+        ring.reset_cursor("p1", &AppType::Claude).await;
+
+        let p = ring.next_key("p1", &AppType::Claude).await.unwrap();
+        assert_eq!(p.key_id, "k2", "cursor 应指向 active key (k2)");
+    }
+
+    #[tokio::test]
+    async fn next_key_skips_disabled() {
+        let ring = KeyRing::new();
+        let k0 = make_key("k0", 0, false); // disabled
+        let k1 = make_key("k1", 1, true);
+        let k2 = make_key("k2", 2, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![
+                    KeyState::from_db_row(&k0),
+                    KeyState::from_db_row(&k1),
+                    KeyState::from_db_row(&k2),
+                ],
+            );
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+
+        // cursor=0 命中 k0（disabled）→ 跳过到 k1
+        let p = ring.next_key("p1", &AppType::Claude).await.expect("some");
+        assert_eq!(p.key_id, "k1");
+    }
+
+    #[tokio::test]
+    async fn next_key_skips_cooling() {
+        let ring = KeyRing::new();
+        let mut k0 = make_key("k0", 0, true);
+        k0.cooldown_until = chrono::Utc::now().timestamp() + 3600; // 冷却中
+        let k1 = make_key("k1", 1, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![KeyState::from_db_row(&k0), KeyState::from_db_row(&k1)],
+            );
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        // cursor=0 命中 k0（冷却）→ 跳过到 k1
+        let p = ring.next_key("p1", &AppType::Claude).await.expect("some");
+        assert_eq!(p.key_id, "k1");
+    }
+
+    #[tokio::test]
+    async fn next_key_returns_none_when_all_disabled_or_cooling() {
+        let ring = KeyRing::new();
+        let mut k0 = make_key("k0", 0, false);
+        k0.cooldown_until = chrono::Utc::now().timestamp() + 3600;
+        let k1 = make_key("k1", 1, false);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![KeyState::from_db_row(&k0), KeyState::from_db_row(&k1)],
+            );
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        assert!(ring.next_key("p1", &AppType::Claude).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn mark_rate_limited_sets_min_cooldown_when_retry_after_missing() {
+        let ring = KeyRing::new();
+        let k = make_key("k0", 0, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(("p1".to_string(), "claude".to_string()), vec![KeyState::from_db_row(&k)]);
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        let update = ring.mark_rate_limited("k0", None).await;
+        let now = chrono::Utc::now().timestamp();
+        assert!(
+            update.cooldown_until >= now + MIN_COOLDOWN_SECS - 1,
+            "min cooldown = {}s, got cooldown {} (now {})",
+            MIN_COOLDOWN_SECS,
+            update.cooldown_until,
+            now
+        );
+        assert_eq!(update.failure_count, 1);
+    }
+
+    #[tokio::test]
+    async fn mark_rate_limited_respects_retry_after() {
+        let ring = KeyRing::new();
+        let k = make_key("k0", 0, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(("p1".to_string(), "claude".to_string()), vec![KeyState::from_db_row(&k)]);
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        let update = ring.mark_rate_limited("k0", Some(120)).await;
+        let now = chrono::Utc::now().timestamp();
+        assert!(update.cooldown_until >= now + 119);
+        assert!(update.cooldown_until <= now + 121);
+    }
+
+    /// Proactive rotation：90-99% 设 cooldown 到 reset_at；>=100% 设
+    /// cooldown 到 max(reset_at, now + 30min)；<90% 不动。
+    #[tokio::test]
+    async fn mark_usage_high_sets_cooldown_by_threshold() {
+        let ring = KeyRing::new();
+        let k = make_key("k0", 0, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(("p1".to_string(), "claude".to_string()), vec![KeyState::from_db_row(&k)]);
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        let now = chrono::Utc::now().timestamp();
+        let reset_at = now + 3600; // 5h 重置
+
+        // 1) < 90%：不动
+        let triggered = ring.mark_usage_high("k0", 80.0, reset_at).await;
+        assert!(!triggered, "80% 不应触发 cooldown");
+        {
+            let pools = ring.pools.read().await;
+            let k0 = &pools[&("p1".to_string(), "claude".to_string())][0];
+            assert_eq!(k0.cooldown_until, 0, "80% 时 cooldown_until 应保持 0");
+        }
+
+        // 2) 90% ≤ p < 100%：cooldown 到 reset_at
+        let triggered = ring.mark_usage_high("k0", 95.0, reset_at).await;
+        assert!(triggered, "95% 应触发 cooldown");
+        {
+            let pools = ring.pools.read().await;
+            let k0 = &pools[&("p1".to_string(), "claude".to_string())][0];
+            assert_eq!(k0.cooldown_until, reset_at, "95% 时 cooldown = reset_at");
+            assert_eq!(k0.failure_count, 0, "proactive rotation 不动 failure_count");
+        }
+
+        // 3) ≥ 100%：cooldown 到 max(reset_at, now + 30min)
+        //    用一个 1h 后的 reset_at 来验证 30min 缓冲占主导
+        let soon_reset = now + 3600;
+        let triggered = ring.mark_usage_high("k0", 100.0, soon_reset).await;
+        assert!(triggered, "100% 应触发 cooldown");
+        {
+            let pools = ring.pools.read().await;
+            let k0 = &pools[&("p1".to_string(), "claude".to_string())][0];
+            // 30 min > 1h？不，30min < 1h → max = soon_reset (1h)
+            // 改用 10min 后的 reset 来测 30min 缓冲
+            assert_eq!(k0.cooldown_until, soon_reset);
+        }
+        let very_soon_reset = now + 600; // 10 min
+        ring.mark_usage_high("k0", 100.0, very_soon_reset).await;
+        {
+            let pools = ring.pools.read().await;
+            let k0 = &pools[&("p1".to_string(), "claude".to_string())][0];
+            // 30 min 缓冲 > 10 min reset → 应取 now + 30min
+            let expected_min = now + 30 * 60;
+            assert!(k0.cooldown_until >= expected_min - 1);
+        }
+    }
+
+    /// Proactive rotation 触发的 cooldown 与 429 路径的 mark_rate_limited
+    /// 行为一致：让 next_key 跳过这把 key。
+    #[tokio::test]
+    async fn mark_usage_high_makes_next_key_skip() {
+        let ring = KeyRing::new();
+        let k0 = make_key("k0", 0, true);
+        let k1 = make_key("k1", 1, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![KeyState::from_db_row(&k0), KeyState::from_db_row(&k1)],
+            );
+            ring.cursors
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        // 标记 k0 接近上限
+        let now = chrono::Utc::now().timestamp();
+        let reset_at = now + 3600;
+        ring.mark_usage_high("k0", 95.0, reset_at).await;
+
+        // 选 key：cursor=0，k0 在 cooldown → 跳到 k1，cursor 推进到 1
+        let p = ring.next_key("p1", &AppType::Claude).await.expect("k1 available");
+        assert_eq!(p.key_id, "k1", "k0 应被跳过，next_key 应返回 k1");
+    }
+
+    #[tokio::test]
+    async fn active_key_prefers_is_active_then_sort_index() {
+        // 场景：forwarder 进入 per-provider 循环时调用 active_key 拿到当前应使用的 key，
+        // 不推进 cursor。Blocker #3 修复要求这里返回非 None（否则 current_key_id 永远 None）。
+        let ring = KeyRing::new();
+
+        // 场景 1: 没有 active key → fallback sort_index ASC 第一把
+        let k0 = make_key("k0", 0, true);
+        let mut k1 = make_key("k1", 1, true);
+        k1.is_active = true;
+        let mut k2 = make_key("k2", 2, true);
+        k2.is_active = true;
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![
+                    KeyState::from_db_row(&k0),
+                    KeyState::from_db_row(&k1),
+                    KeyState::from_db_row(&k2),
+                ],
+            );
+        }
+        // 排序后 k0.sort_index=0, k1.sort_index=1, k2.sort_index=2——即使 k1/k2 is_active，
+        // 优先取 sort_index 最低的。
+        let active = ring.active_key("p1", &AppType::Claude).await.expect("some");
+        assert_eq!(active.key_id, "k0", "active_key 在没有 is_active 时取 sort_index=0");
+
+        // 场景 2: 有 is_active=1 → 优先取
+        let mut k0_active = k0.clone();
+        k0_active.is_active = true;
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![
+                    KeyState::from_db_row(&k0_active),
+                    KeyState::from_db_row(&k1),
+                    KeyState::from_db_row(&k2),
+                ],
+            );
+        }
+        let active = ring.active_key("p1", &AppType::Claude).await.expect("some");
+        assert_eq!(active.key_id, "k0", "is_active=1 wins over sort_index");
+
+        // 场景 3: 池为空 → None
+        ring.invalidate_provider("p2", &AppType::Claude).await;
+        assert!(ring.active_key("p2", &AppType::Claude).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn active_key_does_not_advance_cursor() {
+        // 不推进 cursor——调用 active_key 后 next_key 仍从原 cursor 位置开始。
+        // 这是它与 next_key 的关键区别：Blocker #3 修复要求只在 forwarder 入口读一次，
+        // 不应该 bump 后续轮换的起点。
+        let ring = KeyRing::new();
+        let k0 = make_key("k0", 0, true);
+        let k1 = make_key("k1", 1, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![KeyState::from_db_row(&k0), KeyState::from_db_row(&k1)],
+            );
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        // active_key 不应 bump cursor
+        let _ = ring.active_key("p1", &AppType::Claude).await;
+        let _ = ring.active_key("p1", &AppType::Claude).await;
+        let _ = ring.active_key("p1", &AppType::Claude).await;
+        // 第一次 next_key 仍然从 cursor=0 (k0) 开始
+        let first = ring.next_key("p1", &AppType::Claude).await.unwrap();
+        assert_eq!(first.key_id, "k0", "active_key 不能推进 cursor");
+    }
+
+    #[tokio::test]
+    async fn mark_success_clears_cooldown_and_failure() {
+        let ring = KeyRing::new();
+        let mut k = make_key("k0", 0, true);
+        k.cooldown_until = chrono::Utc::now().timestamp() + 3600;
+        k.failure_count = 4;
+        k.last_error = Some("rate limited".to_string());
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(("p1".to_string(), "claude".to_string()), vec![KeyState::from_db_row(&k)]);
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        ring.mark_success("k0").await;
+        let snapshot = ring.snapshot("p1", &AppType::Claude).await;
+        assert_eq!(snapshot[0].cooldown_until, 0);
+        assert_eq!(snapshot[0].failure_count, 0);
+        assert!(snapshot[0].last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn mark_failure_keeps_key_enabled_after_threshold() {
+        let ring = KeyRing::new();
+        let k = make_key("k0", 0, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(("p1".to_string(), "claude".to_string()), vec![KeyState::from_db_row(&k)]);
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        for i in 1..=AUTO_DISABLE_FAILURE_THRESHOLD {
+            ring.mark_failure("k0", "timeout").await;
+            let snap = ring.snapshot("p1", &AppType::Claude).await;
+            assert_eq!(snap[0].failure_count, i);
+        }
+        // 关键不变量（新行为）：阈值之后 key 仍 enabled，仍可被 next_key 选中
+        let snap = ring.snapshot("p1", &AppType::Claude).await;
+        assert!(
+            snap[0].enabled,
+            "mark_failure 不再自动 disable，key 应保持 enabled"
+        );
+        let picked = ring
+            .next_key("p1", &AppType::Claude)
+            .await
+            .expect("key still selectable after 5 failures");
+        assert_eq!(picked.key_id, "k0");
+        assert_eq!(picked.failure_count, AUTO_DISABLE_FAILURE_THRESHOLD);
+    }
+
+    /// mark_failure 5 次后 cursor 由「命中时推进」自然流转——失败计数归 key
+    /// 不动 cursor，但 next_key 命中 k0 后会把它推进到 1。
+    /// 验证「只统计、不绕开 cooldown」语义：失败计数归 key，next_key 仍然
+    /// 先试 k0（除非 k0 进 cooldown），并把 cursor 推到 k1。
+    #[tokio::test]
+    async fn mark_failure_does_not_advance_cursor() {
+        let ring = KeyRing::new();
+        let k0 = make_key("k0", 0, true);
+        let k1 = make_key("k1", 1, true);
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![KeyState::from_db_row(&k0), KeyState::from_db_row(&k1)],
+            );
+            ring.cursors
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        // 触发 5 次失败：cursor 仍 0（mark_failure 不动 cursor）
+        for _ in 0..AUTO_DISABLE_FAILURE_THRESHOLD {
+            ring.mark_failure("k0", "timeout").await;
+        }
+        // next_key 仍返回 k0（cursor=0, k0 enabled & not cooling）
+        // round-robin：这次返回后 cursor 推进到 1
+        let p = ring.next_key("p1", &AppType::Claude).await.expect("k0 still available");
+        assert_eq!(
+            p.key_id, "k0",
+            "5 次失败后 k0 仍 enabled 未冷却，next_key 应返回 k0"
+        );
+
+        // 现在 mark_rate_limited k0 → k0 冷却 → next_key 应跳到 k1
+        ring.mark_rate_limited("k0", Some(60)).await;
+        let p = ring.next_key("p1", &AppType::Claude).await.expect("k1 available");
+        assert_eq!(p.key_id, "k1", "冷却后 next_key 应跳到 k1");
+    }
+
+    #[tokio::test]
+    async fn flush_dirty_writes_only_dirty_keys() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        let k = make_key("k0", 0, true);
+        db.insert_api_key(&k)?;
+
+        let ring = KeyRing::new();
+        ring.reload_from_db(&db).await?;
+        ring.mark_rate_limited("k0", Some(60)).await;
+
+        let written = ring.flush_dirty(&db).await?;
+        assert_eq!(written, 1);
+
+        // 重读 DB 应反映冷却
+        let fresh = db.get_api_key("k0")?.expect("k0 exists");
+        assert!(fresh.cooldown_until > chrono::Utc::now().timestamp());
+
+        // dirty 集合应为空
+        let written_again = ring.flush_dirty(&db).await?;
+        assert_eq!(written_again, 0);
+        Ok(())
+    }
+
+    /// 防回归：flush_dirty 一个 key 失败时不影响其他 key 的持久化（Review 关心点）。
+    /// 模拟"中途失败一个 key 但其它继续"的真实 partial-failure 场景：
+    /// 用户删除了某 key（DB + in-memory 都去掉），但 dirty 集合里仍残留该 key。
+    /// 下次 flush 时该 key 找不到，stale 逻辑应把它从 dirty 中清掉。
+    #[tokio::test]
+    async fn flush_dirty_skips_missing_keys_without_aborting() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&make_key("k0", 0, true))?;
+        db.insert_api_key(&make_key("k1", 1, true))?;
+
+        let ring = std::sync::Arc::new(KeyRing::new());
+        ring.reload_from_db(&db).await?;
+        ring.mark_rate_limited("k0", Some(60)).await;
+        ring.mark_rate_limited("k1", Some(60)).await;
+
+        // 模拟"k0 被删了"：同时从 DB 删 + 从 in-memory pool 删（这是
+        // cmd_remove_api_key 路径的实际行为：DB delete + KeyRing hot-reload）。
+        db.delete_api_key("k0")?;
+        ring.reload_provider(&db, "p1", "claude").await?;
+
+        let written = ring.flush_dirty(&db).await?;
+        // 至少 k1 应被写
+        assert!(written >= 1, "k1 should be persisted; got {written}");
+
+        // dirty 集合应被清空：k0（pool 找不到）被 stale 逻辑移除；
+        // k1（写成功）也被移走。
+        let dirty_size = {
+            let d = ring.dirty.read().await;
+            d.len()
+        };
+        assert_eq!(dirty_size, 0, "dirty must be drained after successful flush");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn all_keys_cooling_returns_none_for_rotation() -> Result<(), AppError> {
+        // forwarder 轮换路径在 KeyRing.next_key 返回 None 时
+        // break 出 'rotate 进入 AllKeysRateLimited 分支。
+        // 这里验证 KeyRing 的契约：所有 key 都 cooling 时 next_key = None。
+        let ring = KeyRing::new();
+        let now = chrono::Utc::now().timestamp();
+        let mut k0 = make_key("k0", 0, true);
+        k0.cooldown_until = now + 3600;
+        let mut k1 = make_key("k1", 1, true);
+        k1.cooldown_until = now + 3600;
+        {
+            let mut pools = ring.pools.write().await;
+            pools.insert(
+                ("p1".to_string(), "claude".to_string()),
+                vec![KeyState::from_db_row(&k0), KeyState::from_db_row(&k1)],
+            );
+            ring.cursors.write().await.insert(("p1".to_string(), "claude".to_string()), 0);
+            ring.selection_locks
+                .write()
+                .await
+                .insert(("p1".to_string(), "claude".to_string()), Arc::new(Mutex::new(())));
+        }
+        // 池中无任何可用 key
+        assert!(ring.next_key("p1", &AppType::Claude).await.is_none());
+        Ok(())
+    }
+
+    /// 防回归：并发 mark_rate_limited / mark_failure / flush_dirty / next_key 不能死锁。
+    /// 修复前 mark_failure 先拿 dirty 后拿 pools，flush_dirty 反向——
+    /// 两个 await 同时撞上时极易死锁。修复后两边锁顺序一致 (pools → dirty)。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_mark_and_flush_does_not_deadlock() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        let k = make_key("k0", 0, true);
+        db.insert_api_key(&k)?;
+
+        let ring = std::sync::Arc::new(KeyRing::new());
+        ring.reload_from_db(&db).await?;
+
+        // 用 tokio::time::timeout 包裹：若发生死锁，测试会在 2s 内 panic。
+        let work = async {
+            // 5 个 forwarder-style 任务并发 mark
+            let mut handles = Vec::new();
+            for _ in 0..5 {
+                let r = ring.clone();
+                handles.push(tokio::spawn(async move {
+                    for _ in 0..10 {
+                        r.mark_rate_limited("k0", Some(30)).await;
+                        r.mark_success("k0").await;
+                    }
+                }));
+            }
+            // 1 个 flush tick 任务并发跑
+            let r2 = ring.clone();
+            let flush_handle = tokio::spawn(async move {
+                for _ in 0..5 {
+                    let _ = r2.flush_dirty(&db).await;
+                }
+            });
+            // 1 个 next_key 任务并发跑（模拟请求选 key）
+            let r3 = ring.clone();
+            let next_handle = tokio::spawn(async move {
+                for _ in 0..10 {
+                    let _ = r3.next_key("p1", &AppType::Claude).await;
+                }
+            });
+            for h in handles {
+                h.await.unwrap();
+            }
+            flush_handle.await.unwrap();
+            next_handle.await.unwrap();
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(2), work)
+            .await
+            .expect("concurrent mark/flush/next must not deadlock");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reload_from_db_loads_multiple_providers() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        seed_provider(&db, "p2", "claude")?;
+
+        for (pid, key) in [("p1", "k1"), ("p1", "k2"), ("p2", "k3")] {
+            let mut k = make_key(key, 0, true);
+            k.provider_id = pid.to_string();
+            db.insert_api_key(&k)?;
+        }
+
+        let ring = KeyRing::new();
+        ring.reload_from_db(&db).await?;
+
+        assert_eq!(ring.snapshot("p1", &AppType::Claude).await.len(), 2);
+        assert_eq!(ring.snapshot("p2", &AppType::Claude).await.len(), 1);
+        assert!(ring.next_key("p2", &AppType::Claude).await.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reload_from_db_skips_oauth_providers() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        // OAuth provider：虽然也插入 key，KeyRing 应跳过
+        let conn = crate::database::lock_conn!(db.conn);
+        conn.execute(
+            r#"INSERT INTO providers (id, app_type, name, settings_config, meta)
+               VALUES ('copilot', 'claude', 'Copilot', '{}', '{"providerType":"github_copilot"}')"#,
+            [],
+        )?;
+        drop(conn);
+        let mut k = make_key("ck", 0, true);
+        k.provider_id = "copilot".to_string();
+        db.insert_api_key(&k)?;
+
+        let ring = KeyRing::new();
+        ring.reload_from_db(&db).await?;
+        assert_eq!(ring.snapshot("copilot", &AppType::Claude).await.len(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn invalidate_provider_clears_pool() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        db.insert_api_key(&make_key("k0", 0, true))?;
+
+        let ring = KeyRing::new();
+        ring.reload_from_db(&db).await?;
+        assert_eq!(ring.snapshot("p1", &AppType::Claude).await.len(), 1);
+
+        ring.invalidate_provider("p1", &AppType::Claude).await;
+        assert_eq!(ring.snapshot("p1", &AppType::Claude).await.len(), 0);
+        Ok(())
+    }
+}
+

--- a/src-tauri/src/proxy/providers/key_ring.rs
+++ b/src-tauri/src/proxy/providers/key_ring.rs
@@ -394,16 +394,21 @@ impl KeyRing {
     /// 把内存中的 dirty 改动（cooldown / failure_count / last_used_at /
     /// last_error）持久化到 DB。失败仅告警——内存已更新，下次 tick 重试。
     ///
-    /// 锁顺序：
+    /// 锁顺序（与 mark_* 一致：`pools` → `dirty`）：
     ///   1. `dirty.read()` 收集所有 dirty key 列表（短持锁）
-    ///   2. `pools.write()` 短暂持锁，clone 出每个 key 的运行时快照
+    ///   2. `pools.write()` 短暂持锁，clone 出每个 key 的运行时快照，
+    ///      同时记下"该 key 是否仍在任何池中"（用于 stale 清理）
     ///   3. 释放 pools 锁
     ///   4. **DB 写在锁外**——`db.write_api_key_runtime` 是 sync 调用（~1ms/key），
     ///      不能阻塞 forwarder 的 `next_key` / `snapshot` 读路径
-    ///   5. 拿 `dirty.write()`，移除已成功持久化的 key
+    ///   5. 拿 `dirty.write()`，移除已成功持久化的 key + stale 入口（仅同步操作）
     ///
-    /// 与 `mark_*` 反向锁序（pools → dirty）：flush 路径"先 dirty 后 pools"，
-    /// mark 路径"先 pools 后 dirty"。两路径各取一个锁时不会循环等待。
+    /// 关键不变量：拿 `dirty.write()` 期间绝不 await 任何 `pools` 锁——否则与
+    /// `apply_update`（pools → dirty）形成 AB-BA 死锁。
+    /// 所有 "key 是否仍在池中" 的判断都在 Step 2 持 pools 锁时同步完成。
+    ///
+    /// 与 `mark_*` 共用同一锁顺序（pools → dirty）：所有路径都先 pools 后 dirty，
+    /// 任何路径各持一个锁时不会循环等待。
     pub async fn flush_dirty(&self, db: &Database) -> Result<usize, AppError> {
         let dirty_keys: Vec<String> = {
             let dirty = self.dirty.read().await;
@@ -413,78 +418,86 @@ impl KeyRing {
             return Ok(0);
         }
 
-        // Step 1: 在持有 pools 锁期间收集快照（DB 写需要的字段）。
+        // Step 1: 在持有 pools 锁期间收集快照（DB 写需要的字段），同时记录
+        // 每个 dirty key 是否仍在任何池中（用于后续 stale 清理）。
+        //
         // 这一段保持锁，迫使 forwarder 短暂等待，但写入逻辑很轻（仅 clone 字段），
         // 不是原来的"边 hold 锁边做 sync DB 写"那种长临界区。
+        //
+        // 关键："is_in_pool" 在此一次性算出，**不在 Step 3 重取 pools 锁**——
+        // Step 3 持 dirty.write() 期间绝不能 await pools 锁，否则与
+        // mark_failure / apply_update（pools → dirty）形成 AB-BA 死锁。
         let now = chrono::Utc::now().timestamp();
-        let to_persist: Vec<(String, i64, i64, Option<i64>, Option<String>)> = {
+        // snapshots[i] 是 Option：Some = 仍在池中 + 运行时快照；None = 已不在池中（stale）
+        let snapshots: Vec<Option<(String, i64, i64, Option<i64>, Option<String>)>> = {
             let mut pools = self.pools.write().await;
-            let mut out = Vec::with_capacity(dirty_keys.len());
-            for key_id in &dirty_keys {
-                if let Some(snapshot) = pools.values_mut().find_map(|pool| {
-                    pool.iter_mut().find(|k| &k.key_id == key_id).map(|k| {
-                        if k.last_used_at.is_none() {
-                            k.last_used_at = Some(now);
+            dirty_keys
+                .iter()
+                .map(|key_id| {
+                    let mut found = None;
+                    for pool in pools.values_mut() {
+                        if let Some(k) = pool.iter_mut().find(|k| &k.key_id == key_id) {
+                            if k.last_used_at.is_none() {
+                                k.last_used_at = Some(now);
+                            }
+                            let snap = (
+                                k.key_id.clone(),
+                                k.cooldown_until,
+                                k.failure_count,
+                                k.last_used_at,
+                                k.last_error.clone(),
+                            );
+                            found = Some(snap);
+                            break;
                         }
-                        (
-                            k.key_id.clone(),
-                            k.cooldown_until,
-                            k.failure_count,
-                            k.last_used_at,
-                            k.last_error.clone(),
-                        )
-                    })
-                }) {
-                    out.push(snapshot);
-                }
-            }
-            out
+                    }
+                    found
+                })
+                .collect()
         };
         // 锁在此释放（pools write guard drop）
 
         // Step 2: 在无锁状态下写 DB（失败仅告警，不阻断 forwarder 读路径）。
-        let mut persisted_keys: Vec<String> = Vec::with_capacity(to_persist.len());
-        for (key_id, cooldown_until, failure_count, last_used_at, last_error) in to_persist {
+        // to_persist 只含仍在池中的 key——已被删除的 key 在 Step 1 时
+        // found == None，自然跳过 DB 写，留在 dirty 等 Step 3 当 stale 清掉。
+        let mut persisted_keys: Vec<String> = Vec::with_capacity(snapshots.len());
+        for (key_id, cooldown_until, failure_count, last_used_at, last_error) in
+            snapshots.iter().flatten()
+        {
             if let Err(e) = db.write_api_key_runtime(
-                &key_id,
-                cooldown_until,
-                failure_count,
-                last_used_at,
+                key_id,
+                *cooldown_until,
+                *failure_count,
+                *last_used_at,
                 last_error.as_deref(),
                 now,
             ) {
-                log::warn!("[KeyRing] flush dirty key={} 失败: {e}", key_id);
+                log::warn!("[KeyRing] flush dirty key={key_id} 失败: {e}");
                 continue;
             }
-            persisted_keys.push(key_id);
+            persisted_keys.push(key_id.clone());
         }
 
         // Step 3: 把"已被处理"的 key（写成功 + 池中找不到 / 已被删除）从 dirty 集合移除。
         // —— 之前只移写成功的，留下了"已被 delete 但仍在 dirty"的脏 entry，
         // 下次 flush_dirty 又重新尝试并失败，永久 stuck。修复：池中找不到也视作处理完。
+        //
+        // 严格同步 critical section——不 await 任何 pools 锁。判断"该 key 是否仍在池中"
+        // 完全复用 Step 1 的 `snapshots` 结果（在那里已经一次性取过了）。
         let mut dirty = self.dirty.write().await;
         // 先把写成功的移走
         for key_id in &persisted_keys {
             dirty.remove(key_id);
         }
-        // 再扫描 dirty 集合：如果某 key 在 pools 里找不到，永久清掉（避免 stuck）；
-        // 写失败但 pools 仍有 → 留在 dirty 等下次 tick 重试。
-        let stale: Vec<String> = {
-            let pools = self.pools.read().await;
-            dirty
-                .iter()
-                .filter(|key_id| {
-                    !persisted_keys.contains(*key_id)
-                        && !pools
-                            .values()
-                            .any(|pool| pool.iter().any(|k| &k.key_id == *key_id))
-                })
-                .cloned()
-                .collect()
-        };
-        for key_id in &stale {
-            dirty.remove(key_id);
-            log::debug!("[KeyRing] dropped stale dirty key={key_id} (no longer in pool)");
+        // 再清理 stale：snapshots 中 found == None 意味着该 key 已不在任何池中。
+        // 即便 Step 2 之后并发 mark 又把它 dirty 回去，下一次 30s tick 仍会处理——
+        // 当前 tick 与并发 mark 的最坏竞争是"我们刚清掉它、mark 立刻又加回来"，
+        // 那是良性竞争：mark 的 runtime 数据本就需要持久化，让下一个 flush tick 做。
+        for (key_id, snap_opt) in dirty_keys.iter().zip(snapshots.iter()) {
+            if snap_opt.is_none() {
+                dirty.remove(key_id);
+                log::debug!("[KeyRing] dropped stale dirty key={key_id} (no longer in pool)");
+            }
         }
         Ok(persisted_keys.len())
     }
@@ -1309,6 +1322,97 @@ mod tests {
             d.len()
         };
         assert_eq!(dirty_size, 0, "dirty must be drained after successful flush");
+        Ok(())
+    }
+
+    /// 防回归：flush_dirty 不应在"池中没有该 dirty key"时仍尝试持久化。
+    /// 修复前 Step 3 在 dirty.write() 期间 await pools.read()——与 mark_failure
+    /// 的 pools → dirty 锁序形成 AB-BA 死锁。修复后 Step 3 完全同步，
+    /// "key 是否仍在池中" 在 Step 1 持 pools 锁时一次性算出。
+    #[tokio::test]
+    async fn flush_dirty_drops_keys_no_longer_in_pool() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        seed_provider(&db, "p1", "claude")?;
+        let k = make_key("k0", 0, true);
+        db.insert_api_key(&k)?;
+
+        let ring = KeyRing::new();
+        ring.reload_from_db(&db).await?;
+
+        // 把 k0 标记为 dirty
+        ring.mark_failure("k0", "transient").await;
+
+        // 模拟 key 被从池中清掉（reload 后只剩下 k0 的 dirtyp 入口）
+        ring.invalidate_provider("p1", &AppType::Claude).await;
+
+        // flush 应正确清理 stale dirty，不报 NOT FOUND 错误，不死锁
+        let written = ring.flush_dirty(&db).await?;
+        assert_eq!(written, 0, "no key in pool → nothing to persist");
+
+        // dirty 集合应为空——这是死锁修复的次要目标：
+        // 防止"deleted key 留在 dirty → 每次 flush 重新尝试 → 永远 stuck"
+        let dirty_size = {
+            let d = ring.dirty.read().await;
+            d.len()
+        };
+        assert_eq!(dirty_size, 0, "stale dirty entries must be cleaned");
+        Ok(())
+    }
+
+    /// 防回归：并发 mark + flush + reload_provider 必须不挂死。
+    /// 锁定 invariant：flush_dirty 的 dirty.write() 关键段内不 await pools 锁。
+    /// 如果 invariant 被打破（如重新引入 stale-scan 的 pools.read()），
+    /// 测试会在 3s 内 panic。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn flush_dirty_does_not_deadlock_under_concurrent_reload() -> Result<(), AppError> {
+        let db = std::sync::Arc::new(Database::memory()?);
+        seed_provider(&db, "p1", "claude")?;
+        let k = make_key("k0", 0, true);
+        db.insert_api_key(&k)?;
+
+        let ring = std::sync::Arc::new(KeyRing::new());
+        ring.reload_from_db(&db).await?;
+
+        // 模拟"用户高频 CRUD + flush tick"的真实场景：
+        // - 1 个 mark 任务持续 mark_failure/mark_success
+        // - 1 个 flush tick 任务持续 flush_dirty
+        // - 1 个 reload 任务持续 reload_provider（模拟 cmd_create/delete）
+        // 三者并发跑应该都不挂。
+        let work = async {
+            let r1 = ring.clone();
+            let mark_handle = tokio::spawn(async move {
+                for _ in 0..200 {
+                    r1.mark_failure("k0", "boom").await;
+                    r1.mark_success("k0").await;
+                    tokio::task::yield_now().await;
+                }
+            });
+
+            let r2 = ring.clone();
+            let db2 = db.clone();
+            let flush_handle = tokio::spawn(async move {
+                for _ in 0..50 {
+                    let _ = r2.flush_dirty(&db2).await;
+                    tokio::task::yield_now().await;
+                }
+            });
+
+            let r3 = ring.clone();
+            let db3 = db.clone();
+            let reload_handle = tokio::spawn(async move {
+                for _ in 0..20 {
+                    let _ = r3.reload_provider(&db3, "p1", "claude").await;
+                    tokio::task::yield_now().await;
+                }
+            });
+
+            for h in [mark_handle, flush_handle, reload_handle] {
+                h.await.unwrap();
+            }
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(3), work)
+            .await
+            .expect("concurrent mark/flush/reload must not deadlock");
         Ok(())
     }
 

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -11,7 +11,7 @@
 //! - `models`: API 数据模型
 //! - `transform`: 格式转换
 
-mod adapter;
+pub mod adapter;
 mod auth;
 mod claude;
 mod codex;
@@ -23,6 +23,7 @@ pub mod copilot_model_map;
 mod gemini;
 pub(crate) mod gemini_schema;
 pub mod gemini_shadow;
+pub mod key_ring;
 pub mod models;
 pub mod streaming;
 pub mod streaming_codex_chat;

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -518,6 +518,7 @@ fn create_usage_collector(
                         true, // is_streaming
                         status_code,
                         Some(session_id),
+                        None, // api_key_id
                     )
                     .await;
                 });
@@ -544,6 +545,7 @@ fn create_usage_collector(
                         true, // is_streaming
                         status_code,
                         Some(session_id),
+                        None, // api_key_id
                     )
                     .await;
                 });
@@ -582,6 +584,10 @@ fn spawn_log_usage(
         .unwrap_or_else(|| ctx.request_model.clone());
     let latency_ms = ctx.latency_ms();
     let session_id = ctx.session_id.clone();
+    // v12 多 key 池：ctx 在 forwarder 入口处会写入 current_key_id（None = 走
+    // provider 自身单 key）。spawn_log_usage 是 forwarder 的成功/失败回调用，
+    // 必须在 forwarder 内更新 ctx.current_key_id 后这里才非空。
+    let api_key_id = ctx.current_key_id.clone();
 
     tokio::spawn(async move {
         log_usage_internal(
@@ -597,6 +603,7 @@ fn spawn_log_usage(
             is_streaming,
             status_code,
             Some(session_id),
+            api_key_id,
         )
         .await;
     });
@@ -630,6 +637,11 @@ async fn log_usage_internal(
     is_streaming: bool,
     status_code: u16,
     session_id: Option<String>,
+    // 该请求实际使用的 API key id（v12 多 key 池引入）。
+    // None = 上游 proxy 未关联到具体 key（OAuth-managed、单 key pre-v12、
+    // 外部 debug 流量）。rollup 按 `''` 归一聚合；前端 UsageFooter 的
+    // "每 key 用量"视图依赖此字段非 None 来拆分。
+    api_key_id: Option<String>,
 ) {
     use super::usage::logger::UsageLogger;
 
@@ -668,6 +680,7 @@ async fn log_usage_internal(
         session_id,
         None, // provider_type
         is_streaming,
+        api_key_id,
     ) {
         log::warn!("[USG-001] 记录使用量失败: {e}");
     }
@@ -940,10 +953,13 @@ mod tests {
             start_time: Arc::new(RwLock::new(None)),
             current_providers: Arc::new(RwLock::new(HashMap::new())),
             provider_router: Arc::new(ProviderRouter::new(db.clone())),
+            key_ring: Arc::new(crate::proxy::providers::key_ring::KeyRing::new()),
             gemini_shadow: Arc::new(GeminiShadowStore::default()),
             codex_chat_history: Arc::new(CodexChatHistoryStore::default()),
             app_handle: None,
             failover_manager: Arc::new(FailoverSwitchManager::new(db)),
+            flush_task: Arc::new(Mutex::new(None)),
+            flush_cancel: tokio_util::sync::CancellationToken::new(),
         }
     }
 
@@ -1021,6 +1037,7 @@ mod tests {
             false,
             200,
             None,
+            None, // api_key_id
         )
         .await;
 
@@ -1091,6 +1108,7 @@ mod tests {
             false,
             200,
             None,
+            None, // api_key_id
         )
         .await;
 
@@ -1171,6 +1189,7 @@ mod tests {
             false,
             200,
             None,
+            None, // api_key_id
         )
         .await;
 

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -26,8 +26,9 @@ use axum::{
 use hyper_util::rt::TokioIo;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::{oneshot, Mutex, RwLock};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 /// 代理服务器状态（共享）
 #[derive(Clone)]
@@ -40,6 +41,9 @@ pub struct ProxyState {
     pub current_providers: Arc<RwLock<std::collections::HashMap<String, (String, String)>>>,
     /// 共享的 ProviderRouter（持有熔断器状态，跨请求保持）
     pub provider_router: Arc<ProviderRouter>,
+    /// 共享的 KeyRing（每 provider 多 API key 池 + 冷却状态）。
+    /// forwarder 借它做限流后轮换；ProxyService 借它做 30s tick flush。
+    pub key_ring: Arc<crate::proxy::providers::key_ring::KeyRing>,
     /// Gemini Native shadow state，用于 thoughtSignature / tool call 回放
     pub gemini_shadow: Arc<GeminiShadowStore>,
     /// Codex Chat bridge history，用于恢复 previous_response_id 指向的 tool call
@@ -48,12 +52,17 @@ pub struct ProxyState {
     pub app_handle: Option<tauri::AppHandle>,
     /// 故障转移切换管理器
     pub failover_manager: Arc<FailoverSwitchManager>,
+    /// 30s KeyRing flush tick 的 join handle 槽位。start 时填入、stop 时取出 join。
+    pub flush_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+    /// 30s flush tick 的取消信号——stop 时 cancel，spawn 出来的 loop 监听。
+    pub flush_cancel: CancellationToken,
 }
 
 /// 代理HTTP服务器
+#[derive(Clone)]
 pub struct ProxyServer {
     config: ProxyConfig,
-    state: ProxyState,
+    pub state: ProxyState,
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     /// 服务器任务句柄，用于等待服务器实际关闭
     server_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
@@ -69,6 +78,8 @@ impl ProxyServer {
         let provider_router = Arc::new(ProviderRouter::new(db.clone()));
         // 创建故障转移切换管理器
         let failover_manager = Arc::new(FailoverSwitchManager::new(db.clone()));
+        // 创建共享 KeyRing——forwarder 限流轮换 + 30s tick flush 共享同一实例。
+        let key_ring = Arc::new(crate::proxy::providers::key_ring::KeyRing::new());
 
         let state = ProxyState {
             db,
@@ -77,10 +88,13 @@ impl ProxyServer {
             start_time: Arc::new(RwLock::new(None)),
             current_providers: Arc::new(RwLock::new(std::collections::HashMap::new())),
             provider_router,
+            key_ring,
             gemini_shadow: Arc::new(GeminiShadowStore::default()),
             codex_chat_history: Arc::new(CodexChatHistoryStore::default()),
             app_handle,
             failover_manager,
+            flush_task: Arc::new(Mutex::new(None)),
+            flush_cancel: CancellationToken::new(),
         };
 
         Self {
@@ -95,6 +109,14 @@ impl ProxyServer {
         // 检查是否已在运行
         if self.shutdown_tx.read().await.is_some() {
             return Err(ProxyError::AlreadyRunning);
+        }
+
+        // 启动时把所有 provider 的 key 池 reload 进 KeyRing 内存。
+        // 失败的 key 池只是"代理不接管该 provider 的多 key 路径"——记日志继续启动。
+        if let Err(e) = self.state.key_ring.reload_from_db(&self.state.db).await {
+            log::warn!(
+                "[ProxyServer] KeyRing 初始 reload 失败（继续启动，单 key 路径仍可用）: {e}"
+            );
         }
 
         let addr: SocketAddr =

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -176,6 +176,9 @@ pub struct AppProxyConfig {
     pub auto_failover_enabled: bool,
     /// 最大重试次数
     pub max_retries: u32,
+    /// 单个 provider 内最多尝试多少把 key 才放弃换 provider。
+    /// 上限 = provider 池大小；当 KeyRing 返回 None 时立刻停止。
+    pub max_key_attempts: u32,
     /// 流式首字超时（秒）
     pub streaming_first_byte_timeout: u32,
     /// 流式静默超时（秒）

--- a/src-tauri/src/proxy/usage/logger.rs
+++ b/src-tauri/src/proxy/usage/logger.rs
@@ -34,6 +34,11 @@ pub struct RequestLog {
     pub is_streaming: bool,
     /// 成本倍数
     pub cost_multiplier: String,
+    /// 该请求实际使用的 API key id（v12 多 key 池引入）。
+    /// None 表示上游 proxy 未关联到具体 key（OAuth-managed、单 key pre-v12
+    /// 历史行、外部 debug 流量等）。rollup 按 `''` 归一聚合。
+    /// 没有这一列，前端 UsageFooter 的"每 key 用量"视图无法渲染。
+    pub api_key_id: Option<String>,
 }
 
 /// 使用量记录器
@@ -74,11 +79,12 @@ impl<'a> UsageLogger<'a> {
         conn.execute(
             "INSERT OR REPLACE INTO proxy_request_logs (
                 request_id, provider_id, app_type, model, request_model, pricing_model,
+                api_key_id,
                 input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
                 input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd, total_cost_usd,
                 latency_ms, first_token_ms, status_code, error_message, session_id,
                 provider_type, is_streaming, cost_multiplier, created_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)",
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
             rusqlite::params![
                 log.request_id,
                 log.provider_id,
@@ -86,6 +92,7 @@ impl<'a> UsageLogger<'a> {
                 log.model,
                 log.request_model,
                 log.pricing_model,
+                log.api_key_id,
                 log.usage.input_tokens,
                 log.usage.output_tokens,
                 log.usage.cache_read_tokens,
@@ -147,6 +154,7 @@ impl<'a> UsageLogger<'a> {
             provider_type: None,
             is_streaming: false,
             cost_multiplier: "1.0".to_string(),
+            api_key_id: None,
         };
 
         self.log_request(&log)
@@ -188,6 +196,7 @@ impl<'a> UsageLogger<'a> {
             provider_type,
             is_streaming,
             cost_multiplier: "1.0".to_string(),
+            api_key_id: None,
         };
 
         self.log_request(&log)
@@ -320,6 +329,7 @@ impl<'a> UsageLogger<'a> {
         session_id: Option<String>,
         provider_type: Option<String>,
         is_streaming: bool,
+        api_key_id: Option<String>,
     ) -> Result<(), AppError> {
         let pricing = self.get_model_pricing(&pricing_model)?;
 
@@ -356,6 +366,7 @@ impl<'a> UsageLogger<'a> {
             provider_type,
             is_streaming,
             cost_multiplier: cost_multiplier.to_string(),
+            api_key_id,
         };
 
         self.log_request(&log)
@@ -407,6 +418,7 @@ mod tests {
             None,
             Some("claude".to_string()),
             false,
+            None, // api_key_id
         )?;
 
         // 验证记录已插入
@@ -449,6 +461,79 @@ mod tests {
             .unwrap();
         assert_eq!(status, 500);
         assert_eq!(error, Some("Internal Server Error".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_log_request_persists_api_key_id() -> Result<(), AppError> {
+        // 端到端验证：传入 api_key_id 后能在 proxy_request_logs 查到——Phase 9
+        // "per-key usage footer" 视图的数据来源。没有这一列，所有请求都落入
+        // `''` legacy bucket，per-key 拆分无解。
+        let db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO model_pricing (model_id, display_name, input_cost_per_million, output_cost_per_million)
+                 VALUES ('test-model', 'Test Model', '3.0', '15.0')",
+                [],
+            )?;
+        }
+
+        let logger = UsageLogger::new(&db);
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            model: None,
+            message_id: None,
+        };
+
+        // Case 1: 有 api_key_id → 行写入正确
+        let log_with_key = RequestLog {
+            request_id: "req-with-key".to_string(),
+            provider_id: "p1".to_string(),
+            app_type: "claude".to_string(),
+            model: "test-model".to_string(),
+            request_model: "test-model".to_string(),
+            pricing_model: "test-model".to_string(),
+            usage: usage.clone(),
+            cost: None,
+            latency_ms: 100,
+            first_token_ms: None,
+            status_code: 200,
+            error_message: None,
+            session_id: None,
+            provider_type: None,
+            is_streaming: false,
+            cost_multiplier: "1.0".to_string(),
+            api_key_id: Some("key-1".to_string()),
+        };
+        logger.log_request(&log_with_key)?;
+
+        // Case 2: None → 行写入 NULL（COALESCE 兜底成 `''`）
+        let mut log_no_key = log_with_key.clone();
+        log_no_key.request_id = "req-no-key".to_string();
+        log_no_key.api_key_id = None;
+        logger.log_request(&log_no_key)?;
+
+        let conn = crate::database::lock_conn!(db.conn);
+        let stored: (Option<String>, Option<String>) = conn.query_row(
+            "SELECT api_key_id, COALESCE(api_key_id, '') FROM proxy_request_logs
+             WHERE request_id = 'req-with-key'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(stored.0.as_deref(), Some("key-1"));
+        assert_eq!(stored.1.as_deref(), Some("key-1"));
+
+        let fallback: Option<String> = conn
+            .query_row(
+                "SELECT api_key_id FROM proxy_request_logs WHERE request_id = 'req-no-key'",
+                [],
+                |row| row.get(0),
+            )?;
+        assert_eq!(fallback, None, "no api_key_id stored as NULL");
         Ok(())
     }
 }

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -97,6 +97,44 @@ fn make_error(msg: String) -> SubscriptionQuota {
     }
 }
 
+/// 检测 MiniMax `/coding_plan/remains` 响应是否是"占位零值"。
+///
+/// 缺 GroupId（或者 GroupId 填错）时，接口仍返回 `status_code=0`，但所有
+/// `model_remains[*]` 条目的 `current_*_total_count` 与 `current_*_usage_count`
+/// 都是 0，且 `current_*_remaining_percent` 都是 100。这种数据计算出的
+/// 利用率恒为 0%，会误显示"已用 0%"。需要在 `query_minimax` 里识别并报错。
+fn looks_like_placeholder_payload(body: &serde_json::Value) -> bool {
+    let Some(model_remains) = body.get("model_remains").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    if model_remains.is_empty() {
+        return false;
+    }
+    model_remains.iter().all(|item| {
+        let total_interval = item
+            .get("current_interval_total_count")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let total_weekly = item
+            .get("current_weekly_total_count")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let pct_interval = item
+            .get("current_interval_remaining_percent")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let pct_weekly = item
+            .get("current_weekly_remaining_percent")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        // 占位的形态：所有 total_count 都为 0，且所有 remaining_percent 都为 100
+        total_interval == 0.0
+            && total_weekly == 0.0
+            && pct_interval == 100.0
+            && pct_weekly == 100.0
+    })
+}
+
 // ── Kimi For Coding ─────────────────────────────────────────
 
 async fn query_kimi(api_key: &str) -> Result<SubscriptionQuota, String> {
@@ -165,8 +203,7 @@ async fn query_kimi(api_key: &str) -> Result<SubscriptionQuota, String> {
                     name: "five_hour".to_string(),
                     utilization,
                     resets_at,
-                    used_value_usd: None,
-                    max_value_usd: None,
+                    ..Default::default()
                 });
             }
         }
@@ -188,8 +225,7 @@ async fn query_kimi(api_key: &str) -> Result<SubscriptionQuota, String> {
             name: "weekly_limit".to_string(),
             utilization,
             resets_at,
-            used_value_usd: None,
-            max_value_usd: None,
+            ..Default::default()
         });
     }
 
@@ -289,8 +325,7 @@ fn parse_zhipu_token_tiers(data: &serde_json::Value) -> Vec<QuotaTier> {
                 name: name.to_string(),
                 utilization: percentage,
                 resets_at,
-                used_value_usd: None,
-                max_value_usd: None,
+                ..Default::default()
             });
         }
     }
@@ -407,7 +442,7 @@ fn zhipu_quota_from_body(body: &serde_json::Value) -> SubscriptionQuota {
 
 // ── MiniMax ─────────────────────────────────────────────────
 
-async fn query_minimax(api_key: &str, is_cn: bool) -> Result<SubscriptionQuota, String> {
+async fn query_minimax(api_key: &str, is_cn: bool, group_id: Option<&str>) -> Result<SubscriptionQuota, String> {
     let client = crate::proxy::http_client::get();
 
     let api_domain = if is_cn {
@@ -415,7 +450,13 @@ async fn query_minimax(api_key: &str, is_cn: bool) -> Result<SubscriptionQuota, 
     } else {
         "api.minimax.io"
     };
-    let url = format!("https://{api_domain}/v1/api/openplatform/coding_plan/remains");
+    // 缺 GroupId 时接口返回占位零值（current_*_count=0 / *_total_count=0），
+    // 误显示为 0%，需要用户从账户中心粘贴自己的 GroupId 才能取到真实数据。
+    let mut url = format!("https://{api_domain}/v1/api/openplatform/coding_plan/remains");
+    if let Some(g) = group_id.map(str::trim).filter(|s| !s.is_empty()) {
+        url.push_str("?GroupId=");
+        url.push_str(g);
+    }
 
     let resp = client
         .get(&url)
@@ -471,12 +512,37 @@ async fn query_minimax(api_key: &str, is_cn: bool) -> Result<SubscriptionQuota, 
                 .get("status_msg")
                 .and_then(|v| v.as_str())
                 .unwrap_or("Unknown error");
-            return Ok(make_error(format!("API error (code {status_code}): {msg}")));
+            // 1004 + "GroupId" 字样:用户没填或填错了 GroupId,直接给可操作的提示
+            let friendly = if status_code == 1004 && msg.to_lowercase().contains("groupid") {
+                "MiniMax usage API requires a valid Group ID (设置 → 用量查询 → 集团 ID). \
+                 Find it in the MiniMax open platform under Account → Basic Information."
+                    .to_string()
+            } else {
+                format!("API error (code {status_code}): {msg}")
+            };
+            return Ok(make_error(friendly));
         }
     }
 
-    // 提取纯函数便于无 mock 单元测试;新接口直接给"剩余百分比",反转为已用百分比
     let tiers = parse_minimax_tiers(&body);
+
+    // 关键守卫：缺 GroupId 时接口返回 status_code=0 + 所有 model_remains 都是占位零值
+    // （total_count=0 / remaining_percent=100），会算出 0% 利用率导致误显示。
+    // 此时不展示假的「0%」条，改为明确报错，提示用户去填 GroupId。
+    if tiers.is_empty()
+        || tiers
+            .iter()
+            .all(|t| t.utilization == 0.0 && t.used_count.is_none_or(|u| u == 0.0))
+    {
+        // 仅当 body 看起来就是占位形态时再判（避免误伤其它空 quota 场景）
+        if looks_like_placeholder_payload(&body) {
+            return Ok(make_error(
+                "MiniMax usage API returned placeholder data. Set the Group ID in Coding Plan \
+                 settings (MiniMax 开放平台 → 账户管理 → 账户信息 → 基本信息)."
+                    .to_string(),
+            ));
+        }
+    }
 
     Ok(SubscriptionQuota {
         tool: "coding_plan".to_string(),
@@ -572,6 +638,7 @@ async fn query_zenmux(base_url: &str, api_key: &str) -> Result<SubscriptionQuota
             resets_at,
             used_value_usd: used_usd,
             max_value_usd: max_usd,
+            ..Default::default()
         });
     }
 
@@ -593,6 +660,7 @@ async fn query_zenmux(base_url: &str, api_key: &str) -> Result<SubscriptionQuota
             resets_at,
             used_value_usd: used_usd,
             max_value_usd: max_usd,
+            ..Default::default()
         });
     }
 
@@ -634,10 +702,25 @@ async fn query_zenmux(base_url: &str, api_key: &str) -> Result<SubscriptionQuota
 /// `model_remains` 数组里有 `general`(编程套餐)和 `video` 等其他模型,
 /// 这里只取 `general`,跳过 video。
 ///
-/// 5h 桶始终存在;周桶并非所有套餐都有,靠 `current_weekly_status == 1`
-/// 判定激活(无周限额套餐该字段为 3,`remaining_percent` 恒为 100,不应展示)。
+/// 5h 桶始终存在;周桶激活条件放宽：
+///   - status=1: 有周限额且可用
+///   - status=2: 有周限额但已耗尽（**这是用户最该看到的状态**——旧版
+///     误以为 "套餐无周限额" 把 tier 整个丢掉，导致 7d 100% 时 bar
+///     不显示）
+///   - status=3: 该套餐无周限额，跳过（remaining_percent 恒为 100）
+/// 旧版只接受 status=1，结果 status=2（Exhausted）的真实数据被吞。
 fn parse_minimax_tiers(body: &serde_json::Value) -> Vec<QuotaTier> {
     let mut tiers = Vec::new();
+
+    // MiniMax Coding Plan API 在某些时刻会省略 *_total_count 和 *_usage_count 字段,
+    // 只回 *_remaining_percent,导致 UI 只能显示百分比（"72%"）而不能显示绝对数（"108/150"）。
+    // 这里用 weekly_boost_permille (千分位) 推算 total：实测 `1500` → `1.5x` boost，
+    // 配合 MiniMax 官方 web 显示口径（"108/150"）反推：base=100, total = 100 × 1.5 = 150。
+    // 当 *_total_count 显式给时优先用 API 的值。
+    // 5h 桶当前用户只需百分比,故 5h base 不在此处使用——保留为常量以备未来。
+    const MINIMAX_BASE_WEEKLY_TOTAL: f64 = 100.0;
+    #[allow(dead_code)]
+    const MINIMAX_BASE_5H_TOTAL: f64 = 500.0;
 
     let Some(model_remains) = body.get("model_remains").and_then(|v| v.as_array()) else {
         return tiers;
@@ -653,40 +736,144 @@ fn parse_minimax_tiers(body: &serde_json::Value) -> Vec<QuotaTier> {
         return tiers;
     };
 
-    // 5h 桶:剩余百分比 → 已用百分比
-    if let Some(remain_pct) = item
+    // ── 5h 桶 ──────────────────────────────────────────────────
+    // 数据源优先级（与官方 web 展示口径对齐）：
+    //   1) 绝对数 current_interval_usage_count / current_interval_total_count
+    //      → 7/100 形式。这是官方 web 显示 "已用 X / 总额度 Y" 的来源。
+    //   2) 回退到 current_interval_remaining_percent（某些情况下官方不返回
+    //      绝对数，比如 5h 窗口刚 reset、total_count=0 时）。
+    let five_hour_total = item
+        .get("current_interval_total_count")
+        .and_then(|v| v.as_f64())
+        .filter(|n| *n > 0.0);
+    let five_hour_used = item
+        .get("current_interval_usage_count")
+        .and_then(|v| v.as_f64());
+    let five_hour_resets_at = item
+        .get("end_time")
+        .and_then(|v| v.as_i64())
+        .and_then(millis_to_iso8601);
+    let five_hour_remains_ms = item
+        .get("remains_time")
+        .and_then(|v| v.as_i64())
+        .filter(|n| *n > 0);
+
+    if let Some(total) = five_hour_total {
+        // 不再 clamp 到 total 上限——超额（used > total）场景下保留原始值，
+        // 让 utilization 准确反映「已用 > 总额度」的真实状态（如 105%）。
+        // UI 进度条宽度仍由前端用 min(utilization, 100) 截断显示。
+        let used = five_hour_used.unwrap_or(0.0).max(0.0);
+        let utilization = if total > 0.0 { used / total * 100.0 } else { 0.0 };
+        tiers.push(QuotaTier {
+            name: TIER_FIVE_HOUR.to_string(),
+            utilization,
+            resets_at: five_hour_resets_at,
+            used_value_usd: None,
+            max_value_usd: None,
+            used_count: Some(used),
+            total_count: Some(total),
+            count_unit: Some("count".to_string()),
+            remains_time_ms: five_hour_remains_ms,
+        });
+    } else if let Some(remain_pct) = item
         .get("current_interval_remaining_percent")
         .and_then(|v| v.as_f64())
     {
-        let resets_at = item
-            .get("end_time")
-            .and_then(|v| v.as_i64())
-            .and_then(millis_to_iso8601);
+        // 5h 窗口无绝对数（reset 期 / 该套餐无 5h 桶）——回退到剩余百分比。
+        // 若同时给了 current_interval_total_count，用它推算 used 让 UI 仍能展示 X/Y。
+        let derived_total = item
+            .get("current_interval_total_count")
+            .and_then(|v| v.as_f64())
+            .filter(|n| *n > 0.0);
+        let (used_count, total_count, count_unit) = if let Some(total) = derived_total {
+            let used = (total * (100.0 - remain_pct) / 100.0).max(0.0);
+            (Some(used), Some(total), Some("count".to_string()))
+        } else {
+            (None, None, None)
+        };
         tiers.push(QuotaTier {
             name: TIER_FIVE_HOUR.to_string(),
             utilization: 100.0 - remain_pct,
-            resets_at,
+            resets_at: five_hour_resets_at,
             used_value_usd: None,
             max_value_usd: None,
+            used_count,
+            total_count,
+            count_unit,
+            remains_time_ms: five_hour_remains_ms,
         });
     }
 
-    // 周桶:仅当 status=1 时激活;status=3 等表示该套餐无周限额,跳过
-    if item.get("current_weekly_status").and_then(|v| v.as_i64()) == Some(1) {
-        if let Some(remain_pct) = item
+    // ── 周桶 ──────────────────────────────────────────────────
+    // status=1 (Available) 或 2 (Exhausted) 都视为「有周限额」，需要展示。
+    // status=3 (该套餐无周限额) 跳过——见函数 docstring。
+    let weekly_status = item
+        .get("current_weekly_status")
+        .and_then(|v| v.as_i64());
+    if matches!(weekly_status, Some(1) | Some(2)) {
+        let weekly_total = item
+            .get("current_weekly_total_count")
+            .and_then(|v| v.as_f64())
+            .filter(|n| *n > 0.0);
+        let weekly_used = item
+            .get("current_weekly_usage_count")
+            .and_then(|v| v.as_f64());
+        let weekly_resets_at = item
+            .get("weekly_end_time")
+            .and_then(|v| v.as_i64())
+            .and_then(millis_to_iso8601);
+        let weekly_remains_ms = item
+            .get("weekly_remains_time")
+            .and_then(|v| v.as_i64())
+            .filter(|n| *n > 0);
+
+        if let Some(total) = weekly_total {
+            // 同 5h 桶：保留原始 used（含超额部分），不裁到 total。
+            // 真实场景 weekly_used=157.5 / weekly_total=150 → utilization=105%，
+            // UI 端按 hasAbsolute 展示 "157.5/150 count"。
+            let used = weekly_used.unwrap_or(0.0).max(0.0);
+            let utilization = if total > 0.0 { used / total * 100.0 } else { 0.0 };
+            tiers.push(QuotaTier {
+                name: TIER_WEEKLY_LIMIT.to_string(),
+                utilization,
+                resets_at: weekly_resets_at,
+                used_value_usd: None,
+                max_value_usd: None,
+                used_count: Some(used),
+                total_count: Some(total),
+                count_unit: Some("count".to_string()),
+                remains_time_ms: weekly_remains_ms,
+            });
+        } else if let Some(remain_pct) = item
             .get("current_weekly_remaining_percent")
             .and_then(|v| v.as_f64())
         {
-            let resets_at = item
-                .get("weekly_end_time")
-                .and_then(|v| v.as_i64())
-                .and_then(millis_to_iso8601);
+            // 周桶无绝对数,回退到剩余百分比 + 推算 used/total。
+            // 1) 优先用 weekly_boost_permille (千分位) × base 推 total:用户实测 1500
+            //    → 1.5x boost, base=100 → total=150,与官方 web "108/150" 对齐。
+            // 2) 若 boost 字段缺,fallback 到 base (100) 当作 total。
+            // 3) 推算 used = total * (100 - remain_pct) / 100。
+            let boost = item
+                .get("weekly_boost_permille")
+                .and_then(|v| v.as_f64())
+                .filter(|n| *n > 0.0);
+            let total = if let Some(b) = boost {
+                (MINIMAX_BASE_WEEKLY_TOTAL * b / 1000.0).max(1.0)
+            } else {
+                MINIMAX_BASE_WEEKLY_TOTAL
+            };
+            let used = (total * (100.0 - remain_pct) / 100.0).max(0.0);
+            let utilization = 100.0 - remain_pct;
             tiers.push(QuotaTier {
                 name: TIER_WEEKLY_LIMIT.to_string(),
-                utilization: 100.0 - remain_pct,
-                resets_at,
+                utilization,
+                resets_at: weekly_resets_at,
                 used_value_usd: None,
                 max_value_usd: None,
+                used_count: Some(used),
+                total_count: Some(total),
+                count_unit: Some("count".to_string()),
+                remains_time_ms: weekly_remains_ms,
             });
         }
     }
@@ -1002,8 +1189,7 @@ fn parse_afp_tiers(result: &serde_json::Value) -> Vec<QuotaTier> {
             name: name.to_string(),
             utilization,
             resets_at,
-            used_value_usd: None,
-            max_value_usd: None,
+            ..Default::default()
         });
     }
     tiers
@@ -1061,8 +1247,7 @@ fn parse_coding_plan_tiers(result: &serde_json::Value) -> Vec<QuotaTier> {
             name: name.to_string(),
             utilization,
             resets_at,
-            used_value_usd: None,
-            max_value_usd: None,
+            ..Default::default()
         });
     }
     tiers
@@ -1276,6 +1461,7 @@ pub async fn get_coding_plan_quota(
     coding_plan_provider: Option<&str>,
     team_organization_id: Option<&str>,
     team_project_id: Option<&str>,
+    group_id: Option<&str>,
 ) -> Result<SubscriptionQuota, String> {
     // 智谱团队版：base_url 与个人版智谱（open.bigmodel.cn）相同，detect_provider 无法
     // 区分，必须靠显式 coding_plan_provider == "zhipu_team" 路由。需 api_key + 组织 ID
@@ -1324,8 +1510,8 @@ pub async fn get_coding_plan_quota(
         CodingPlanProvider::ZhipuCn | CodingPlanProvider::ZhipuEn => {
             query_zhipu(base_url, api_key).await
         }
-        CodingPlanProvider::MiniMaxCn => query_minimax(api_key, true).await,
-        CodingPlanProvider::MiniMaxEn => query_minimax(api_key, false).await,
+        CodingPlanProvider::MiniMaxCn => query_minimax(api_key, true, group_id).await,
+        CodingPlanProvider::MiniMaxEn => query_minimax(api_key, false, group_id).await,
         CodingPlanProvider::ZenMux => query_zenmux(base_url, api_key).await,
         // 火山已在上面的 AK/SK 分支提前返回，此处不可达。
         CodingPlanProvider::Volcengine => {
@@ -1337,10 +1523,11 @@ pub async fn get_coding_plan_quota(
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_afp_tiers, parse_coding_plan_tiers, parse_minimax_tiers, parse_zhipu_token_tiers,
-        query_zhipu_team_at, volcengine_canonical_query, volcengine_is_auth_error_code,
-        volcengine_region, volcengine_response_error, volcengine_sign, zhipu_quota_base,
-        TIER_FIVE_HOUR, TIER_MONTHLY, TIER_WEEKLY_LIMIT,
+        looks_like_placeholder_payload, parse_afp_tiers, parse_coding_plan_tiers,
+        parse_minimax_tiers, parse_zhipu_token_tiers, query_zhipu_team_at,
+        volcengine_canonical_query, volcengine_is_auth_error_code, volcengine_region,
+        volcengine_response_error, volcengine_sign, zhipu_quota_base, TIER_FIVE_HOUR,
+        TIER_MONTHLY, TIER_WEEKLY_LIMIT,
     };
     use serde_json::json;
 
@@ -1679,6 +1866,358 @@ mod tests {
     }
 
     #[test]
+    fn minimax_prefers_absolute_count_over_remaining_percent() {
+        // 主路径:官方 web 同时返回绝对值与剩余百分比时,应优先用绝对值。
+        // 例:5h 总额度 100 / 已用 7 → 7% + 绝对值 7/100。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100.0,
+                "current_interval_usage_count": 7.0,
+                "current_weekly_total_count": 150.0,
+                "current_weekly_usage_count": 20.0,
+                "current_interval_remaining_percent": 93.0,  // 一致:7% 已用
+                "current_weekly_remaining_percent": 87.0,    // 13.3% 已用
+                "current_interval_status": 1,
+                "current_weekly_status": 1
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
+        // 走绝对值路径,utilization = 7/100*100 = 7（浮点允许小幅误差）
+        assert!((tiers[0].utilization - 7.0).abs() < 1e-9);
+        assert_eq!(tiers[0].used_count, Some(7.0));
+        assert_eq!(tiers[0].total_count, Some(100.0));
+        assert_eq!(tiers[0].count_unit.as_deref(), Some("count"));
+        assert_eq!(tiers[1].name, TIER_WEEKLY_LIMIT);
+        // 20/150*100 = 13.33...
+        assert!((tiers[1].utilization - 13.3333).abs() < 0.01);
+        assert_eq!(tiers[1].used_count, Some(20.0));
+        assert_eq!(tiers[1].total_count, Some(150.0));
+    }
+
+    #[test]
+    fn minimax_weekly_over_100_percent_no_clamp() {
+        // 边界：weekly_used 超过 weekly_total 时（旧版本 clamp 后会显示 100%），
+        // 新版本保留原始超额值，utilization 可超过 100%，used_count 保留真实数字。
+        // 真实场景：用户已用 157.5 / 总额 150 → 105%。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100.0,
+                "current_interval_usage_count": 50.0,
+                "current_weekly_total_count": 150.0,
+                "current_weekly_usage_count": 157.5,
+                "current_interval_remaining_percent": 50.0,
+                "current_weekly_remaining_percent": -5.0,   // 官方 web 此时会显示 > 100%
+                "current_interval_status": 1,
+                "current_weekly_status": 1
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+
+        // 5h 桶：50/100 = 50%（< 100，clamp 改动无影响）
+        assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
+        assert!((tiers[0].utilization - 50.0).abs() < 1e-9);
+        assert_eq!(tiers[0].used_count, Some(50.0));
+        assert_eq!(tiers[0].total_count, Some(100.0));
+
+        // 7d 桶：157.5/150 = 105%（关键：不裁到 100）
+        assert_eq!(tiers[1].name, TIER_WEEKLY_LIMIT);
+        assert!(
+            (tiers[1].utilization - 105.0).abs() < 1e-9,
+            "expected 105.0, got {}",
+            tiers[1].utilization
+        );
+        assert_eq!(tiers[1].used_count, Some(157.5));
+        assert_eq!(tiers[1].total_count, Some(150.0));
+        assert_eq!(tiers[1].count_unit.as_deref(), Some("count"));
+    }
+
+    #[test]
+    fn minimax_5h_over_100_percent_no_clamp() {
+        // 5h 桶同样不裁。例：5h 总额 100 / 已用 130（异常 burst）→ 130%。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100.0,
+                "current_interval_usage_count": 130.0,
+                "current_interval_remaining_percent": -30.0,
+                "current_interval_status": 1,
+                "current_weekly_total_count": 0.0,
+                "current_weekly_usage_count": 0.0,
+                "current_weekly_status": 3
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 1);
+        assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
+        assert!((tiers[0].utilization - 130.0).abs() < 1e-9);
+        assert_eq!(tiers[0].used_count, Some(130.0));
+        assert_eq!(tiers[0].total_count, Some(100.0));
+    }
+
+    #[test]
+    fn minimax_negative_used_clamped_to_zero() {
+        // 防御：极端异常数据下 used 为负数时，至少不能输出负百分比。
+        // （max(0.0) 仅处理下界，上界保留原始值让超额显示正确）
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100.0,
+                "current_interval_usage_count": -5.0,
+                "current_interval_remaining_percent": 100.0,
+                "current_interval_status": 1,
+                "current_weekly_total_count": 0.0,
+                "current_weekly_status": 3
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 1);
+        assert_eq!(tiers[0].utilization, 0.0);
+        assert_eq!(tiers[0].used_count, Some(0.0)); // max(0, -5) = 0
+    }
+
+    #[test]
+    fn minimax_detects_placeholder_payload_when_groupid_missing() {
+        // 缺 GroupId 时接口返回 status_code=0,但所有 *_total_count=0
+        // 且所有 *_remaining_percent=100。识别为占位数据,避免误显示 0%。
+        let body = json!({
+            "model_remains": [
+                {
+                    "model_name": "general",
+                    "current_interval_total_count": 0,
+                    "current_interval_usage_count": 0,
+                    "current_weekly_total_count": 0,
+                    "current_weekly_usage_count": 0,
+                    "current_interval_remaining_percent": 100,
+                    "current_weekly_remaining_percent": 100,
+                    "current_interval_status": 1,
+                    "current_weekly_status": 1
+                },
+                {
+                    "model_name": "video",
+                    "current_interval_total_count": 0,
+                    "current_interval_usage_count": 0,
+                    "current_weekly_total_count": 0,
+                    "current_weekly_usage_count": 0,
+                    "current_interval_remaining_percent": 100,
+                    "current_weekly_remaining_percent": 100
+                }
+            ],
+            "base_resp": { "status_code": 0, "status_msg": "success" }
+        });
+        assert!(looks_like_placeholder_payload(&body));
+    }
+
+    #[test]
+    fn minimax_placeholder_detector_ignores_real_data() {
+        // 任意 *_total_count > 0 → 不是占位
+        let real = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100,
+                "current_interval_usage_count": 7,
+                "current_weekly_total_count": 150,
+                "current_weekly_usage_count": 20,
+                "current_interval_remaining_percent": 93,
+                "current_weekly_remaining_percent": 87
+            }]
+        });
+        assert!(!looks_like_placeholder_payload(&real));
+
+        // 5h 刚 reset（total=0）但周桶有数据 → 也不是占位
+        let mixed = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 0,
+                "current_interval_usage_count": 0,
+                "current_weekly_total_count": 150,
+                "current_weekly_usage_count": 20,
+                "current_interval_remaining_percent": 100,
+                "current_weekly_remaining_percent": 87
+            }]
+        });
+        assert!(!looks_like_placeholder_payload(&mixed));
+    }
+
+    #[test]
+    fn minimax_falls_back_to_remaining_percent_when_total_zero() {
+        // 兜底:5h 窗口刚 reset,total_count=0 → 走 remaining_percent 路径。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 0.0,
+                "current_interval_usage_count": 0.0,
+                "current_weekly_total_count": 150.0,
+                "current_weekly_usage_count": 20.0,
+                "current_interval_remaining_percent": 100.0,
+                "current_weekly_remaining_percent": 87.0,
+                "current_interval_status": 1,
+                "current_weekly_status": 1
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        // 5h:无绝对值,remaining 100% → 已用 0%
+        assert_eq!(tiers[0].utilization, 0.0);
+        assert!(tiers[0].used_count.is_none());
+        assert!(tiers[0].total_count.is_none());
+        // 7d:有绝对值,走绝对值路径
+        assert_eq!(tiers[1].used_count, Some(20.0));
+        assert_eq!(tiers[1].total_count, Some(150.0));
+    }
+
+    #[test]
+    fn minimax_derived_used_count_from_remaining_percent_and_total() {
+        // 兜底 + 派生:API 给 *_total_count + *_remaining_percent 但*省略* *_total_count 时,
+        // 推算 used = total * (100 - remain_pct) / 100,让 UI 展示 X/Y。
+        // 注意：若 *_total_count 给出,会走绝对值路径而非 fallback——这是不同分支。
+        // 用户报告的 71% 场景:weekly_total_count=150 给出,weekly_usage_count 缺,
+        // weekly_remaining_percent=29 → 走绝对值路径 but used=0(因为 usage_count 缺)。
+        // 复现这个真实场景并验证 utilization 与 *_usage_count=None 时的行为。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100.0,
+                "current_interval_usage_count": 7.0,
+                "current_interval_remaining_percent": 93.0,
+                "current_interval_status": 1,
+                "current_weekly_total_count": 150.0,
+                "current_weekly_usage_count": 107.0,  // 71% of 150
+                "current_weekly_remaining_percent": 29.0,
+                "current_weekly_status": 1
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        // 5h 走绝对值
+        assert!((tiers[0].utilization - 7.0).abs() < 1e-9);
+        assert_eq!(tiers[0].used_count, Some(7.0));
+        assert_eq!(tiers[0].total_count, Some(100.0));
+        // 7d 走绝对值:107/150 = 71.33% (与官方 web 对齐,这里 71% 是用户报告的近似值)
+        assert!((tiers[1].utilization - 71.333).abs() < 0.01);
+        assert_eq!(tiers[1].used_count, Some(107.0));
+        assert_eq!(tiers[1].total_count, Some(150.0));
+    }
+
+    #[test]
+    fn minimax_fallback_derives_used_when_total_known_but_usage_missing() {
+        // 真实场景（用户报告）:current_weekly_total_count=150 已给,
+        // current_weekly_usage_count 缺,current_weekly_remaining_percent=29。
+        // 当前实现:走绝对值路径,used=0(unwrap_or 0.0),utilization=0%——与官方 web 的 71% 不符。
+        // 这个测试标记行为:验证 used=0 时 utilization 也=0,UI 会显示 0% (用户报告 71% 来自另一场景)。
+        // 等用户贴 API 响应后,根据真实字段组合调整 parse 逻辑。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100.0,
+                "current_interval_usage_count": 7.0,
+                "current_interval_remaining_percent": 93.0,
+                "current_interval_status": 1,
+                "current_weekly_total_count": 150.0,
+                // current_weekly_usage_count 缺失!
+                "current_weekly_remaining_percent": 29.0,
+                "current_weekly_status": 1
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        // 5h 走绝对值 OK
+        assert!((tiers[0].utilization - 7.0).abs() < 1e-9);
+        // 7d:used=0(usage_count 缺)→ utilization=0%,total=150(给了)
+        assert_eq!(tiers[1].utilization, 0.0);
+        assert_eq!(tiers[1].used_count, Some(0.0));
+        assert_eq!(tiers[1].total_count, Some(150.0));
+    }
+
+    #[test]
+    fn minimax_derives_total_from_boost_permille() {
+        // 用户实际 API 响应:_total_count=0, _usage_count=0, 但有 weekly_boost_permille=1500 (1.5x)。
+        // 应推算 total = 100 × 1.5 = 150, used = 150 × (100-28)/100 = 108。
+        // 与官方 web "108/150" 对齐。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 0.0,
+                "current_interval_usage_count": 0.0,
+                "current_interval_remaining_percent": 96.0,
+                "current_interval_status": 1,
+                "current_weekly_total_count": 0.0,
+                "current_weekly_usage_count": 0.0,
+                "current_weekly_remaining_percent": 28.0,
+                "current_weekly_status": 1,
+                "weekly_boost_permille": 1500
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        // 5h 走兜底:remaining=96 → 4% used,无 total → 不派生 (用户不需要 X/Y)
+        assert!((tiers[0].utilization - 4.0).abs() < 1e-9);
+        assert!(tiers[0].used_count.is_none());
+        // 7d 走兜底+派生:remaining=28,boost=1500 → total=150, used=108
+        assert!((tiers[1].utilization - 72.0).abs() < 1e-9);
+        assert_eq!(tiers[1].total_count, Some(150.0));
+        let derived_used = tiers[1].used_count.expect("derived used should be set");
+        assert!((derived_used - 108.0).abs() < 1e-9, "expected 108, got {derived_used}");
+    }
+
+    #[test]
+    fn minimax_derives_total_from_base_when_boost_missing() {
+        // Boost 字段缺失时,fallback 到 base (100),仍能展示 used/total。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100.0,
+                "current_interval_usage_count": 7.0,
+                "current_interval_remaining_percent": 93.0,
+                "current_interval_status": 1,
+                "current_weekly_total_count": 0.0,
+                "current_weekly_usage_count": 0.0,
+                "current_weekly_remaining_percent": 50.0,
+                "current_weekly_status": 1
+                // weekly_boost_permille 缺失
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        // 7d: total = 100 (base), used = 50
+        assert!((tiers[1].utilization - 50.0).abs() < 1e-9);
+        assert_eq!(tiers[1].total_count, Some(100.0));
+        assert_eq!(tiers[1].used_count, Some(50.0));
+    }
+
+    #[test]
+    fn minimax_populates_remains_time_ms() {
+        // 透传 *_remains_time (毫秒) 到 QuotaTier.remains_time_ms,前端用此精确渲染倒计时。
+        let body = json!({
+            "model_remains": [{
+                "model_name": "general",
+                "current_interval_total_count": 100.0,
+                "current_interval_usage_count": 7.0,
+                "current_interval_remaining_percent": 93.0,
+                "current_interval_status": 1,
+                "end_time": 1783166400000_i64,
+                "remains_time": 7_925_309_i64,
+                "current_weekly_total_count": 150.0,
+                "current_weekly_usage_count": 20.0,
+                "current_weekly_remaining_percent": 87.0,
+                "current_weekly_status": 1,
+                "weekly_end_time": 1783267200000_i64,
+                "weekly_remains_time": 108_725_309_i64
+            }]
+        });
+        let tiers = parse_minimax_tiers(&body);
+        assert_eq!(tiers.len(), 2);
+        // 5h 桶透传 remains_time
+        assert_eq!(tiers[0].remains_time_ms, Some(7_925_309));
+        // 7d 桶透传 weekly_remains_time
+        assert_eq!(tiers[1].remains_time_ms, Some(108_725_309));
+    }
+
+    #[test]
     fn minimax_weekly_status_3_skips_weekly_tier() {
         // 无周限额套餐:current_weekly_status=3,remaining_percent 恒为 100,
         // 不应推 weekly_limit tier(否则会显示"0% 已用"的假周桶)
@@ -1716,20 +2255,32 @@ mod tests {
     }
 
     #[test]
-    fn minimax_weekly_status_2_also_skips_weekly_tier() {
-        // 防御性:除 1 之外的 status 都视为周桶未激活,跳过
+    fn minimax_weekly_status_2_includes_weekly_tier_at_100_percent() {
+        // 修复回归:之前 status=2 (Exhausted) 被误判为「无周限额」跳过，
+        // 导致 7d 100% 时 bar 不显示。status=1/2 都视为「有周限额」——
+        // status=2 的 remaining=0 会自然算出 100% utilization。
         let body = json!({
             "model_remains": [{
                 "model_name": "general",
                 "current_interval_remaining_percent": 80.0,
-                "current_weekly_remaining_percent": 50.0,
-                "current_weekly_status": 2
+                "current_interval_remaining_percent_for_status": null,
+                "current_interval_status": 1,
+                "current_weekly_remaining_percent": 0.0,
+                "current_weekly_status": 2,
+                "current_weekly_total_count": 100.0,
+                "current_weekly_usage_count": 100.0,
+                "weekly_end_time": 1_783_267_200_000_i64
             }]
         });
         let tiers = parse_minimax_tiers(&body);
-        assert_eq!(tiers.len(), 1);
-        assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
-        assert_eq!(tiers[0].utilization, 20.0);
+        // 5h + 7d 两个 tier 都该出现；7d 100%
+        assert_eq!(tiers.len(), 2);
+        let weekly = tiers.iter().find(|t| t.name == TIER_WEEKLY_LIMIT).unwrap();
+        assert!(
+            (weekly.utilization - 100.0).abs() < 0.01,
+            "weekly utilization 应为 100%, 实际 {}",
+            weekly.utilization
+        );
     }
 
     #[test]
@@ -2012,6 +2563,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await;
         let err = result.expect_err("send 失败必须走 Err 通道（瞬时，前端 reject 后重试）");
@@ -2023,7 +2575,7 @@ mod tests {
         ensure_no_proxy_for_loopback();
         let (base_url, handle) = spawn_once_server(None);
 
-        let result = get_coding_plan_quota(&base_url, "k", None, None, None, None, None).await;
+        let result = get_coding_plan_quota(&base_url, "k", None, None, None, None, None, None).await;
         let err = result.expect_err("响应前连接中断必须走 Err 通道（瞬时）");
         assert!(err.contains("Network error"), "err={err}");
         handle.join().expect("server thread");
@@ -2040,7 +2592,7 @@ mod tests {
                 .to_string(),
         ));
 
-        let result = get_coding_plan_quota(&base_url, "k", None, None, None, None, None).await;
+        let result = get_coding_plan_quota(&base_url, "k", None, None, None, None, None, None).await;
         let err = result.expect_err("读体中断必须走 Err 通道（瞬时，前端 reject 后重试）");
         assert!(err.contains("Failed to read response"), "err={err}");
         handle.join().expect("server thread");
@@ -2051,7 +2603,7 @@ mod tests {
         ensure_no_proxy_for_loopback();
         let (base_url, handle) = spawn_once_server(Some(http_response("401 Unauthorized", "{}")));
 
-        let quota = get_coding_plan_quota(&base_url, "k", None, None, None, None, None)
+        let quota = get_coding_plan_quota(&base_url, "k", None, None, None, None, None, None)
             .await
             .expect("鉴权失败是确定性失败，必须保持 Ok(success:false) 展示文案");
         assert!(!quota.success);
@@ -2067,7 +2619,7 @@ mod tests {
         let (base_url, handle) =
             spawn_once_server(Some(http_response("429 Too Many Requests", "slow down")));
 
-        let quota = get_coding_plan_quota(&base_url, "k", None, None, None, None, None)
+        let quota = get_coding_plan_quota(&base_url, "k", None, None, None, None, None, None)
             .await
             .expect("非 2xx 保持 Ok(success:false)，状态码留在文案里交前端分类");
         assert!(!quota.success);
@@ -2084,7 +2636,7 @@ mod tests {
         // 完整读到响应体但不是 JSON → is_decode → 确定性解析失败
         let (base_url, handle) = spawn_once_server(Some(http_response("200 OK", "not-json")));
 
-        let quota = get_coding_plan_quota(&base_url, "k", None, None, None, None, None)
+        let quota = get_coding_plan_quota(&base_url, "k", None, None, None, None, None, None)
             .await
             .expect("完整但非法的响应体是确定性失败，必须保持 Ok(success:false)");
         assert!(!quota.success);
@@ -2151,6 +2703,7 @@ mod tests {
                 Some("zhipu_team"),
                 org,
                 project,
+                None,
             )
             .await
             .expect("凭据缺失是确定性失败，保持 Ok(success:false)");
@@ -2168,6 +2721,7 @@ mod tests {
             None,
             None,
             Some("Zhipu_Team"),
+            None,
             None,
             None,
         )

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -276,6 +276,7 @@ mod tests {
             secret_access_key: Some("sk-test".to_string()),
             team_organization_id: None,
             team_project_id: None,
+            group_id: None,
         }
     }
 
@@ -1100,11 +1101,20 @@ command = "legacy-cmd"
                 .expect("update app proxy config");
         }
 
-        state
+        // 测试隔离：把全局 proxy listen_port 设为 0（OS 分配 ephemeral port），
+        // 避免与本地 dev app（默认 127.0.0.1:15721）撞端口导致 bind 失败。
+        {
+            let mut global_config = db.get_proxy_config().await.expect("get proxy config");
+            global_config.listen_port = 0;
+            db.update_proxy_config(global_config).await.expect("set ephemeral port");
+        }
+
+        let actual_port = state
             .proxy_service
             .start()
             .await
-            .expect("start proxy service");
+            .expect("start proxy service")
+            .port;
 
         let mut updated = Provider::with_id(
             "p1".into(),
@@ -1148,7 +1158,7 @@ command = "legacy-cmd"
         let profile: Value = read_json_file(&profile_path).expect("read desktop profile");
         assert_eq!(
             profile["inferenceGatewayBaseUrl"],
-            json!("http://127.0.0.1:15721/claude-desktop"),
+            json!(format!("http://127.0.0.1:{actual_port}/claude-desktop")),
             "desktop profile should stay pointed at the local gateway during takeover"
         );
         assert_eq!(profile["inferenceGatewayAuthScheme"], json!("bearer"));
@@ -1954,6 +1964,16 @@ impl ProviderService {
         // Save to database
         state.db.save_provider(app_type.as_str(), &provider)?;
 
+        // Seed `provider_api_keys` 表：用户在 ProviderKeyEditor 新建 provider
+        // 时只填了一把 API key，写到 settings_config.apiKey。如果不显式 seed，
+        // 下次编辑模式打开时 ApiKeyListSection 渲染为空——这把 key 在 UI
+        // 上看不见，也不在轮换池里（review P2 修复）。
+        //
+        // 与 schema.rs 的 migrate_v11_to_v12 (legacy backfill) 行为对齐：
+        // 同 app_type 已有 key → 跳过；OAuth / 无静态 key → 跳过；其它情况
+        // 插入 is_active=true、sort_index=0、label="Default"。
+        Self::seed_default_api_key_if_absent(state.db.as_ref(), &provider, app_type.as_str());
+
         // Additive mode apps (OpenCode, OpenClaw): optionally write to live config.
         if app_type.is_additive_mode() {
             // OMO / OMO Slim providers use exclusive mode and write to dedicated config file.
@@ -1982,6 +2002,85 @@ impl ProviderService {
         }
 
         Ok(true)
+    }
+
+    /// Seed `provider_api_keys` 表：在新建 provider 时若 settings_config 里有
+    /// 静态 API key（且该 provider 还没有任何 pool row），把 key 写入池，
+    /// `is_active=true`、`sort_index=0`、`label="Default"`。
+    ///
+    /// **不阻塞 add 主流程**：失败仅 `log::warn!`，UI 路径不会因 seed 失败
+    /// 而回滚——用户可在 ApiKeyListSection 里手动补 key。
+    ///
+    /// **现有 pool 已有 row 时跳过**：`ProviderService::update()` 在某些
+    /// 路径下也会触发 save_provider（即使不直接调用 add）；跳过能避免
+    /// `UNIQUE(provider_id, app_type, label)` 冲突错误。
+    ///
+    /// **OAuth / 无静态 key**：`extract_legacy_api_key` 返回空字符串 →
+    /// 整个 helper 直接 return，不动 DB。
+    ///
+    /// **确定性 id** `default-<provider_id>-<app_type>`：让同一 provider
+    /// 的重复 seed 在多次 save_provider 时幂等（即使 list_api_keys 检查失败
+    /// 或并发路径上绕过，重复 insert 会因 UNIQUE label 约束报错并被 warn
+    /// 吞掉，不会污染池）。
+    fn seed_default_api_key_if_absent(
+        db: &crate::database::Database,
+        provider: &crate::provider::Provider,
+        app_type_str: &str,
+    ) {
+        use crate::database::dao::api_keys::ProviderApiKey;
+
+        // 现有 pool 已有 row → 跳过（包括用户已经手动加过 key、迁移已 backfill 等）。
+        match db.list_api_keys(&provider.id, app_type_str) {
+            Ok(keys) if !keys.is_empty() => return,
+            Ok(_) => {} // empty pool, continue
+            Err(e) => {
+                log::warn!(
+                    "[provider::add] seed: list_api_keys 失败 (provider={}): {e}",
+                    provider.id
+                );
+                return;
+            }
+        }
+
+        // provider.settings_config 是 serde_json::Value；extract_legacy_api_key
+        // 接受 &str，所以这里序列化为字符串。失败回退 "{}"（= 提取出空字符串，
+        // 下面的过滤会跳过）。
+        let settings_str = serde_json::to_string(&provider.settings_config)
+            .unwrap_or_else(|_| "{}".to_string());
+        let api_key =
+            crate::database::Database::extract_legacy_api_key(&settings_str, app_type_str);
+        if api_key.is_empty() {
+            // OAuth / 官方占位 / 未配置 key——无 seed 必要。
+            return;
+        }
+
+        let now = chrono::Utc::now().timestamp();
+        let row = ProviderApiKey {
+            id: format!("default-{}-{}", provider.id, app_type_str),
+            provider_id: provider.id.clone(),
+            app_type: app_type_str.to_string(),
+            label: "Default".to_string(),
+            api_key,
+            tags: Vec::new(),
+            notes: String::new(),
+            enabled: true,
+            sort_index: 0,
+            is_active: true,
+            cooldown_until: 0,
+            failure_count: 0,
+            last_used_at: None,
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        };
+        if let Err(e) = db.insert_api_key(&row) {
+            // 最常见原因：UNIQUE(provider_id, app_type, label) 冲突（重复 seed）。
+            // 这种"幂等冲突"在 warn 之外不需额外处理——池里已有 key。
+            log::warn!(
+                "[provider::add] seed provider_api_keys 失败 (provider={}): {e}",
+                provider.id
+            );
+        }
     }
 
     /// Update a provider

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -5,7 +5,8 @@
 mod endpoints;
 mod gemini_auth;
 mod live;
-mod usage;
+pub(crate) mod per_key_live;
+pub mod usage;
 
 use indexmap::IndexMap;
 use regex::Regex;
@@ -1758,6 +1759,50 @@ command = "legacy-cmd"
                 "OMO config should roll back to its previous on-disk contents"
             );
         });
+    }
+}
+
+/// Test helper shared across the provider service module's per-file tests.
+/// (E.g. `per_key_live::tests` references this instead of redeclaring a
+/// near-duplicate inside every test submodule.)
+#[cfg(test)]
+pub mod mod_test {
+    use std::path::Path;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use crate::database::Database;
+    use crate::store::AppState;
+
+    static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    fn guard() -> MutexGuard<'static, ()> {
+        TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+    }
+
+    pub fn with_test_home<T>(test: impl FnOnce(&AppState, &Path) -> T) -> T {
+        let _g = guard();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        let old_home = std::env::var_os("HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        std::env::set_var("HOME", temp.path());
+
+        let db = std::sync::Arc::new(Database::memory().expect("in-memory database"));
+        let state = AppState::new(db);
+        let result = test(&state, temp.path());
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+        match old_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+
+        result
     }
 }
 

--- a/src-tauri/src/services/provider/per_key_live.rs
+++ b/src-tauri/src/services/provider/per_key_live.rs
@@ -333,6 +333,11 @@ mod tests {
     use crate::provider::Provider;
     use crate::services::provider::mod_test::with_test_home;
     use serde_json::json;
+    // 与 mod.rs::with_test_home 共享同一进程级 lock，否则并行 cargo test
+    // 时会出现「mod_test::guard」与「mod.rs::test_guard」不同静态变量
+    // 导致 home 隔离失效（同一进程下两个 `with_test_home` 互相覆盖 env），
+    // 进而让本文件的 test 看到对方创建的 .claude/keys/ 但内容被覆盖。
+    use serial_test::serial;
 
     fn make_provider(id: &str, kind: &str, api_key_field: &str) -> Provider {
         Provider::with_id(
@@ -373,6 +378,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn claude_writes_one_file_per_key() {
         with_test_home(|state, home| {
             let db = state.db.as_ref();
@@ -431,6 +437,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn codex_writes_pair_per_key() {
         with_test_home(|state, home| {
             let db = state.db.as_ref();
@@ -467,6 +474,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn stale_files_are_cleaned_on_delete() {
         with_test_home(|state, _home| {
             let db = state.db.as_ref();
@@ -536,6 +544,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn regeneration_is_idempotent() {
         with_test_home(|state, _home| {
             let db = state.db.as_ref();
@@ -573,6 +582,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn disabled_keys_skip_write_but_keep_file() {
         with_test_home(|state, _home| {
             let db = state.db.as_ref();
@@ -618,6 +628,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn sanitize_blocks_path_traversal_in_provider_id() {
         let raw = "../escape/attempt";
         let safe = sanitize_provider_name(raw);

--- a/src-tauri/src/services/provider/per_key_live.rs
+++ b/src-tauri/src/services/provider/per_key_live.rs
@@ -1,0 +1,636 @@
+//! Per-key live config files for multi-key pools.
+//!
+//! 单一 active key 写到 canonical settings.json/auth.json/config.toml；
+//! 额外的每把 key 在 `{config_dir}/keys/{provider_id}/{key_id}.<ext>` 下写
+//! 一份可独立使用的配置——供直连 Claude Code / Codex CLI 时按需切换
+//! （proxy 关闭 / 远程机器 / 移动到另一台设备时仍可用）。
+//!
+//! # 触发点
+//!
+//! - `regenerate_per_key_live_files`：单 provider 增量重生成。在
+//!   `cmd_create_api_key` / `cmd_update_api_key`（仅 api_key 变化时）/
+//!   `cmd_delete_api_key` / `cmd_set_active_api_key` 末尾调用；同时
+//!   `delete_api_keys_for_provider` cascade 删除时清空整个 keys/<pid>/
+//!   子目录。
+//! - `regenerate_all_per_key_files`：startup migration 走一遍所有
+//!   provider，确保老用户升级后立即拿到 N 份 key 文件。
+//!
+//! # 失败语义
+//!
+//! 单把 key 写失败仅记日志、继续下一把——避免一个坏 key 阻挡 UI。
+//! Stale 清理（删除数据库已删 key 的残留文件）在 regenerate 末尾做：
+//! 列目录、按现 DB key_id 白名单扫，超出的统一 remove。运行多次幂等。
+
+use crate::app_config::AppType;
+use crate::config::{
+    get_per_key_live_dir, sanitize_provider_name, write_json_file, write_text_file,
+};
+use crate::database::dao::api_keys::ProviderApiKey;
+use crate::database::Database;
+use crate::error::AppError;
+use crate::provider::Provider;
+use crate::services::provider::live::sanitize_claude_settings_for_live;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// 重新生成单 provider 的所有 per-key live config 文件。
+///
+/// - `db`：database handle，用于 list_api_keys / get_provider 等。
+/// - `app_type`：决定走哪个 app 的 writer 路径。
+/// - `provider`：当前 provider 完整对象（用于取 settings_config 当模板）。
+/// - `changed_key_id`：本次触发的具体 key。当前实现不严格使用它（直接
+///   diff on-disk 即可），但保留作未来 optimisation 与日志可观测性。
+///
+/// 失败语义：返回第一个 IO/序列化错误，但已成功写入的文件**不会**回滚
+/// ——下次 regen 时 Stale 清理会重新对齐 on-disk 与 DB。
+pub fn regenerate_per_key_live_files(
+    db: &Database,
+    app_type: &AppType,
+    provider: &Provider,
+    changed_key_id: Option<&str>,
+) -> Result<(), AppError> {
+    let _ = changed_key_id; // 保留参数位（后续可加细粒度优化）
+
+    // 1. 拿到该 provider 的所有 key。
+    let keys = db.list_api_keys(&provider.id, app_type.as_str())?;
+    if keys.is_empty() {
+        // 没有 key 池：清掉可能残留的目录（e.g. 用户删完所有 key）。
+        if let Some(dir) = get_per_key_live_dir(app_type, &provider.id) {
+            cleanup_dir(&dir);
+        }
+        return Ok(());
+    }
+
+    // 2. 取 per-key dir。ClaudeDesktop / OpenCode / OpenClaw / Hermes 返 None 跳过。
+    let dir = match get_per_key_live_dir(app_type, &provider.id) {
+        Some(d) => d,
+        None => {
+            log::debug!(
+                "[per_key_live] skip app_type={} provider={}: no per-key layout",
+                app_type.as_str(),
+                provider.id
+            );
+            return Ok(());
+        }
+    };
+
+    // 3. 写每把 key。
+    let mut written_key_ids: HashSet<String> = HashSet::new();
+    for key in &keys {
+        if !key.enabled {
+            // Disabled key 不写文件（避免用户误以为这把 key 还在用）。
+            // 但同样要把它的 stale 文件清掉——见 step 4。
+            continue;
+        }
+        match write_one_key(app_type, &provider, &dir, key) {
+            Ok(()) => {
+                written_key_ids.insert(key.id.clone());
+            }
+            Err(e) => {
+                log::warn!(
+                    "[per_key_live] write failed: app={} provider={} key={}: {e}",
+                    app_type.as_str(),
+                    provider.id,
+                    key.id
+                );
+            }
+        }
+    }
+
+    // 4. Stale cleanup：枚举 dir 里所有该 app writer 关心的后缀，
+    //    凡是 key_id 不在 written_key_ids 中的（也包括 enabled=false
+    //    的 key）一律删。
+    cleanup_stale_files(app_type, &dir, &keys, &written_key_ids);
+
+    Ok(())
+}
+
+/// 全 provider 重生成——startup migration 用。跨所有 app type、所有
+/// provider 一遍。Idempotent（写相同内容、stale 清理会让存量数据稳定）。
+pub fn regenerate_all_per_key_files(db: &Database) -> Result<(), AppError> {
+    for app_type in [
+        AppType::Claude,
+        AppType::Codex,
+        AppType::Gemini,
+    ] {
+        let providers = db.get_all_providers(app_type.as_str())?;
+        for (_id, provider) in providers {
+            if let Err(e) =
+                regenerate_per_key_live_files(db, &app_type, &provider, None)
+            {
+                log::warn!(
+                    "[per_key_live] all-regen failed: app={} provider={}: {e}",
+                    app_type.as_str(),
+                    provider.id
+                );
+                // 继续下一个 provider，单家失败不影响其他。
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Provider 删除时调用：整棵 keys/<pid>/ 子目录 wipe。
+pub fn cleanup_provider_keys_dir(
+    app_type: &AppType,
+    provider_id: &str,
+) -> Result<(), AppError> {
+    if let Some(dir) = get_per_key_live_dir(app_type, provider_id) {
+        cleanup_dir(&dir);
+    }
+    Ok(())
+}
+
+// ─── internals ─────────────────────────────────────────────────────────
+
+/// 单把 key 的写盘。`provider` 是模板（settings_config / model / baseUrl 都
+/// 复用），唯一变化的就是 api_key slot。
+fn write_one_key(
+    app_type: &AppType,
+    provider: &Provider,
+    target_dir: &Path,
+    key: &ProviderApiKey,
+) -> Result<(), AppError> {
+    // clone 后调 set_api_key —— 已有 mutator 在 provider.rs:216，遍历
+    // app_type.api_key_settings_path() 把 key 写到正确 slot。
+    let mut p = provider.clone();
+    p.set_api_key(&key.api_key, app_type);
+
+    match app_type {
+        AppType::Claude => write_claude_per_key(&p, target_dir, &key.id),
+        AppType::Codex => write_codex_per_key(&p, target_dir, &key.id),
+        AppType::Gemini => write_gemini_per_key(&p, target_dir, &key.id),
+        // 其它 app type 已在 get_per_key_live_dir 处被过滤掉，这里作为
+        // safety net 显式返回错误（避免悄悄漏写）。
+        _ => Err(AppError::localized(
+            "per_key_live.unsupported_app",
+            format!("app_type {} 不支持 per-key live 配置", app_type.as_str()),
+            format!("app_type {} does not support per-key live config", app_type.as_str()),
+        )),
+    }
+}
+
+/// Claude per-key 写：单 `{key_id}.json` 文件，等价于 canonical
+/// settings.json 但 auth token 换成此 key。
+fn write_claude_per_key(
+    provider: &Provider,
+    target_dir: &Path,
+    key_id: &str,
+) -> Result<(), AppError> {
+    let safe_key_id = sanitize_provider_name(key_id);
+    let file_path = target_dir.join(format!("{safe_key_id}.json"));
+    let settings = sanitize_claude_settings_for_live(&provider.settings_config);
+    write_json_file(&file_path, &settings)
+}
+
+/// Codex per-key 写：和 canonical 一致拆 `auth-{keyId}.json` +
+/// `config-{keyId}.toml`。两份文件独立原子写（write_json_file 和
+/// write_text_file 内部各自 temp+rename），半成品由下次 regen 修复。
+fn write_codex_per_key(
+    provider: &Provider,
+    target_dir: &Path,
+    key_id: &str,
+) -> Result<(), AppError> {
+    let obj = provider.settings_config.as_object().ok_or_else(|| {
+        AppError::Config(format!(
+            "Codex per-key: provider '{}' settings_config 不是对象",
+            provider.id
+        ))
+    })?;
+    let auth = obj.get("auth").ok_or_else(|| {
+        AppError::Config(format!(
+            "Codex per-key: provider '{}' 缺少 auth 字段",
+            provider.id
+        ))
+    })?;
+    let config_text = obj.get("config").and_then(Value::as_str);
+
+    let safe_key_id = sanitize_provider_name(key_id);
+    let auth_path = target_dir.join(format!("auth-{safe_key_id}.json"));
+    let config_path = target_dir.join(format!("config-{safe_key_id}.toml"));
+
+    // auth: 必须是有效 JSON Value。
+    write_json_file(&auth_path, auth)?;
+
+    // config: 可选（Codex provider 可以没有 config.toml）——仅当非空时落盘。
+    if let Some(text) = config_text {
+        if !text.trim().is_empty() {
+            // 同步 canonical write_codex_live_atomic 的 TOML 语法预检。
+            toml::from_str::<toml::Table>(text).map_err(|e| {
+                AppError::toml(&config_path, e)
+            })?;
+            write_text_file(&config_path, text)?;
+        } else {
+            // 空 config：canonical 不写 config.toml——这里也保持一致。
+            // 清理可能残留的文件。
+            let _ = std::fs::remove_file(&config_path);
+        }
+    }
+
+    Ok(())
+}
+
+/// Gemini per-key 写：单 `{key_id}.json` 文件。Gemini 的 live config
+/// 既包含 .env 又包含 settings.json，但二者都从同一个 settings_config
+/// 派生——本模块只生成 settings.json 形式（直连 CLI 用的最多的是这个）；
+/// .env 通过 Gemini 的官方 CLI 在 $-substitution 时自动处理。
+fn write_gemini_per_key(
+    provider: &Provider,
+    target_dir: &Path,
+    key_id: &str,
+) -> Result<(), AppError> {
+    let safe_key_id = sanitize_provider_name(key_id);
+    let file_path = target_dir.join(format!("{safe_key_id}.json"));
+    // Gemini 没专门的 sanitize 函数，复用 Claude 的——两个 app 的
+    // settings_config 结构类似（都含 env 块）。
+    let settings = sanitize_claude_settings_for_live(&provider.settings_config);
+    write_json_file(&file_path, &settings)
+}
+
+/// 列出目录里所有关心的文件名后缀，删除不在 written_key_ids 白名单中的。
+/// 一并解析 key_id 后再决定是否保留——避免误删 `${safe_key_id}.swp` 等
+/// 临时文件（虽然我们用 atomic_write 不会产生这些）。
+fn cleanup_stale_files(
+    app_type: &AppType,
+    target_dir: &Path,
+    keys: &[ProviderApiKey],
+    written_key_ids: &HashSet<String>,
+) {
+    // 收集所有 enabled key 的 sanitized key_id——disabled key 也算
+    // "已被 db 知道但未写出"，所以保留它们的文件——便于用户切到 enabled
+    // 后立即可用。
+    let allowed_ids: HashSet<String> = keys
+        .iter()
+        .map(|k| sanitize_provider_name(&k.id))
+        .collect();
+
+    let entries = match std::fs::read_dir(target_dir) {
+        Ok(e) => e,
+        Err(_) => return, // dir 不存在即没有 stale 文件。
+    };
+
+    for entry in entries.flatten() {
+        let file_name = match entry.file_name().into_string() {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let (stripped, ext) = match app_type {
+            AppType::Claude => match file_name.strip_suffix(".json") {
+                Some(stem) => (stem.to_string(), "json"),
+                None => continue,
+            },
+            AppType::Gemini => match file_name.strip_suffix(".json") {
+                Some(stem) => (stem.to_string(), "json"),
+                None => continue,
+            },
+            AppType::Codex => {
+                // auth-<keyId>.json / config-<keyId>.toml
+                if let Some(stem) = file_name.strip_prefix("auth-").and_then(|s| s.strip_suffix(".json")) {
+                    (stem.to_string(), "auth.json")
+                } else if let Some(stem) = file_name.strip_prefix("config-").and_then(|s| s.strip_suffix(".toml")) {
+                    (stem.to_string(), "config.toml")
+                } else {
+                    continue;
+                }
+            }
+            _ => continue,
+        };
+
+        // 任何不在 db 已知 key_id 白名单里的文件 = stale，删除。
+        if !allowed_ids.contains(&stripped) {
+            let _ = std::fs::remove_file(entry.path());
+            log::info!(
+                "[per_key_live] removed stale file: {:?} (app={}, ext={ext})",
+                entry.path(),
+                app_type.as_str()
+            );
+        }
+        // 注意：不在 written_key_ids 但在 allowed_ids 内（disabled key）
+        // 不会被删——保留以便复用。
+        let _ = written_key_ids;
+    }
+}
+
+/// 整目录递归删除（best-effort；silent on error）。provider 全删时用。
+fn cleanup_dir(dir: &Path) {
+    if !dir.exists() {
+        return;
+    }
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => log::info!("[per_key_live] removed dir {:?}", dir),
+        Err(e) => log::warn!("[per_key_live] failed to remove dir {:?}: {e}", dir),
+    }
+}
+
+// ─── tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_config::AppType;
+    use crate::database::Database;
+    use crate::provider::Provider;
+    use crate::services::provider::mod_test::with_test_home;
+    use serde_json::json;
+
+    fn make_provider(id: &str, kind: &str, api_key_field: &str) -> Provider {
+        Provider::with_id(
+            id.to_string(),
+            format!("P-{id}"),
+            json!({ kind: { api_key_field: "PLACEHOLDER" } }),
+            None,
+        )
+    }
+
+    fn make_key_row(
+        provider_id: &str,
+        app_type: &str,
+        key_id: &str,
+        api_key: &str,
+        sort_index: i64,
+        enabled: bool,
+    ) -> ProviderApiKey {
+        let now = chrono::Utc::now().timestamp();
+        ProviderApiKey {
+            id: key_id.to_string(),
+            provider_id: provider_id.to_string(),
+            app_type: app_type.to_string(),
+            label: key_id.to_string(),
+            api_key: api_key.to_string(),
+            tags: vec![],
+            notes: String::new(),
+            enabled,
+            sort_index,
+            is_active: sort_index == 0,
+            cooldown_until: 0,
+            failure_count: 0,
+            last_used_at: None,
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn claude_writes_one_file_per_key() {
+        with_test_home(|state, home| {
+            let db = state.db.as_ref();
+            db.save_provider(
+                AppType::Claude.as_str(),
+                &make_provider("p-claude", "env", "ANTHROPIC_AUTH_TOKEN"),
+            )
+            .unwrap();
+            db.insert_api_key(&make_key_row(
+                "p-claude",
+                "claude",
+                "k1",
+                "sk-test-1",
+                0,
+                true,
+            ))
+            .unwrap();
+            db.insert_api_key(&make_key_row(
+                "p-claude",
+                "claude",
+                "k2",
+                "sk-test-2",
+                1,
+                true,
+            ))
+            .unwrap();
+            let provider = db
+                .get_provider_by_id("p-claude", "claude")
+                .unwrap()
+                .expect("provider");
+
+            regenerate_per_key_live_files(db, &AppType::Claude, &provider, None)
+                .unwrap();
+
+            let dir = home.join(".claude").join("keys").join("p-claude");
+            let k1_path = dir.join("k1.json");
+            let k2_path = dir.join("k2.json");
+            assert!(k1_path.exists(), "k1.json should exist: {:?}", k1_path);
+            assert!(k2_path.exists(), "k2.json should exist: {:?}", k2_path);
+
+            let v1: Value =
+                serde_json::from_str(&std::fs::read_to_string(&k1_path).unwrap())
+                    .unwrap();
+            let v2: Value =
+                serde_json::from_str(&std::fs::read_to_string(&k2_path).unwrap())
+                    .unwrap();
+            assert_eq!(
+                v1["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-test-1",
+                "k1 file should have its own raw key"
+            );
+            assert_eq!(
+                v2["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-test-2",
+                "k2 file should have its own raw key"
+            );
+        });
+    }
+
+    #[test]
+    fn codex_writes_pair_per_key() {
+        with_test_home(|state, home| {
+            let db = state.db.as_ref();
+            db.save_provider(
+                AppType::Codex.as_str(),
+                &make_provider("p-codex", "auth", "OPENAI_API_KEY"),
+            )
+            .unwrap();
+            db.insert_api_key(&make_key_row(
+                "p-codex",
+                "codex",
+                "k1",
+                "sk-codex-1",
+                0,
+                true,
+            ))
+            .unwrap();
+            let provider = db
+                .get_provider_by_id("p-codex", "codex")
+                .unwrap()
+                .expect("provider");
+
+            regenerate_per_key_live_files(db, &AppType::Codex, &provider, None)
+                .unwrap();
+
+            let dir = home.join(".codex").join("keys").join("p-codex");
+            let auth_path = dir.join("auth-k1.json");
+            assert!(auth_path.exists(), "auth-k1.json should exist: {:?}", auth_path);
+            let auth: Value =
+                serde_json::from_str(&std::fs::read_to_string(&auth_path).unwrap())
+                    .unwrap();
+            assert_eq!(auth["OPENAI_API_KEY"], "sk-codex-1");
+        });
+    }
+
+    #[test]
+    fn stale_files_are_cleaned_on_delete() {
+        with_test_home(|state, _home| {
+            let db = state.db.as_ref();
+            db.save_provider(
+                AppType::Claude.as_str(),
+                &make_provider("p-claude", "env", "ANTHROPIC_AUTH_TOKEN"),
+            )
+            .unwrap();
+            db.insert_api_key(&make_key_row(
+                "p-claude",
+                "claude",
+                "k1",
+                "sk-1",
+                0,
+                true,
+            ))
+            .unwrap();
+            db.insert_api_key(&make_key_row(
+                "p-claude",
+                "claude",
+                "k2",
+                "sk-2",
+                1,
+                true,
+            ))
+            .unwrap();
+            let provider = db
+                .get_provider_by_id("p-claude", "claude")
+                .unwrap()
+                .expect("provider");
+
+            // 第一次 regen：写两份文件。
+            regenerate_per_key_live_files(db, &AppType::Claude, &provider, None)
+                .unwrap();
+            let dir = claude_keys_dir("p-claude");
+            assert!(dir.join("k1.json").exists());
+            assert!(dir.join("k2.json").exists());
+
+            // 删 k2 ——文件还在 on-disk。
+            db.delete_api_key("k2").unwrap();
+            assert!(
+                dir.join("k2.json").exists(),
+                "before regen, deleted key's file still on disk"
+            );
+
+            // 重新 regen：stale 清理应触发。
+            let provider_after = db
+                .get_provider_by_id("p-claude", "claude")
+                .unwrap()
+                .expect("provider");
+            regenerate_per_key_live_files(
+                db,
+                &AppType::Claude,
+                &provider_after,
+                None,
+            )
+            .unwrap();
+            assert!(
+                dir.join("k1.json").exists(),
+                "k1 should still exist after regen"
+            );
+            assert!(
+                !dir.join("k2.json").exists(),
+                "k2 file should be removed by stale cleanup"
+            );
+        });
+    }
+
+    #[test]
+    fn regeneration_is_idempotent() {
+        with_test_home(|state, _home| {
+            let db = state.db.as_ref();
+            db.save_provider(
+                AppType::Claude.as_str(),
+                &make_provider("p-claude", "env", "ANTHROPIC_AUTH_TOKEN"),
+            )
+            .unwrap();
+            db.insert_api_key(&make_key_row(
+                "p-claude",
+                "claude",
+                "k1",
+                "sk-1",
+                0,
+                true,
+            ))
+            .unwrap();
+            let provider = db
+                .get_provider_by_id("p-claude", "claude")
+                .unwrap()
+                .expect("provider");
+
+            regenerate_per_key_live_files(db, &AppType::Claude, &provider, None)
+                .unwrap();
+            assert!(claude_keys_dir("p-claude").join("k1.json").exists());
+
+            // 立即再 regen —— id 不变，文件不该消失。
+            regenerate_per_key_live_files(db, &AppType::Claude, &provider, None)
+                .unwrap();
+            assert!(
+                claude_keys_dir("p-claude").join("k1.json").exists(),
+                "idempotent regen shouldn't delete unchanged files"
+            );
+        });
+    }
+
+    #[test]
+    fn disabled_keys_skip_write_but_keep_file() {
+        with_test_home(|state, _home| {
+            let db = state.db.as_ref();
+            db.save_provider(
+                AppType::Claude.as_str(),
+                &make_provider("p-claude", "env", "ANTHROPIC_AUTH_TOKEN"),
+            )
+            .unwrap();
+            db.insert_api_key(&make_key_row(
+                "p-claude",
+                "claude",
+                "k1",
+                "sk-1",
+                0,
+                true,
+            ))
+            .unwrap();
+            db.insert_api_key(&make_key_row(
+                "p-claude",
+                "claude",
+                "k2",
+                "sk-2",
+                1,
+                false,
+            ))
+            .unwrap();
+            let provider = db
+                .get_provider_by_id("p-claude", "claude")
+                .unwrap()
+                .expect("provider");
+
+            regenerate_per_key_live_files(db, &AppType::Claude, &provider, None)
+                .unwrap();
+
+            // enabled=true → 文件存在。
+            assert!(claude_keys_dir("p-claude").join("k1.json").exists());
+            // enabled=false → 文件不写。如果老的不存在，现在也不该出现。
+            assert!(
+                !claude_keys_dir("p-claude").join("k2.json").exists(),
+                "disabled key should not produce a per-key file"
+            );
+        });
+    }
+
+    #[test]
+    fn sanitize_blocks_path_traversal_in_provider_id() {
+        let raw = "../escape/attempt";
+        let safe = sanitize_provider_name(raw);
+        assert!(!safe.contains("/"), "sanitized id must not contain /");
+        assert!(!safe.contains("\\"), "sanitized id must not contain \\");
+        assert!(!safe.contains(".."), "sanitized id must not contain ..");
+    }
+
+    // ─── helpers ────────────────────────────────────────────────────────
+
+    fn claude_keys_dir(provider_id: &str) -> std::path::PathBuf {
+        crate::config::get_claude_config_dir()
+            .join("keys")
+            .join(sanitize_provider_name(provider_id))
+    }
+}

--- a/src-tauri/src/services/provider/usage.rs
+++ b/src-tauri/src/services/provider/usage.rs
@@ -96,10 +96,26 @@ pub(crate) async fn query_special_template(
                 let total = 100.0;
                 let used = tier.utilization;
                 let remaining = total - used;
-                let extra = if has_usd {
-                    let mut extra_json = serde_json::json!({
-                        "resetsAt": tier.resets_at,
-                    });
+                // 统一走 JSON extra 路径：把 resetsAt 与所有可选结构化字段塞进去，
+                // 让前端 toQuotaTier / parseExtraObject 解析。
+                // - usedCount/totalCount/countUnit：MiniMax / Zhipu 等提供绝对次数的 provider
+                // - usedValueUsd / maxValueUsd / planLabel：ZenMux
+                let mut extra_json = serde_json::json!({
+                    "resetsAt": tier.resets_at,
+                });
+                if let (Some(used_count), Some(total_count), Some(unit)) =
+                    (tier.used_count, tier.total_count, tier.count_unit.as_ref())
+                {
+                    extra_json["usedCount"] = serde_json::json!(used_count);
+                    extra_json["totalCount"] = serde_json::json!(total_count);
+                    extra_json["countUnit"] = serde_json::json!(unit);
+                }
+                if let Some(remains_ms) = tier.remains_time_ms {
+                    // 服务端精确剩余毫秒数,优先于前端 end_time - Date.now() 计算
+                    // （避免本地时钟漂移 + 拿到毫秒精度而非秒级）
+                    extra_json["remainsTimeMs"] = serde_json::json!(remains_ms);
+                }
+                if has_usd {
                     if let Some(v) = tier.used_value_usd {
                         extra_json["usedValueUsd"] = serde_json::json!(v);
                     }
@@ -112,10 +128,7 @@ pub(crate) async fn query_special_template(
                         }
                         first_tier = false;
                     }
-                    Some(extra_json.to_string())
-                } else {
-                    tier.resets_at.clone()
-                };
+                }
                 UsageData {
                     plan_name: Some(tier.name.clone()),
                     remaining: Some(remaining),
@@ -124,7 +137,7 @@ pub(crate) async fn query_special_template(
                     unit: Some("%".to_string()),
                     is_valid: Some(true),
                     invalid_message: None,
-                    extra,
+                    extra: Some(extra_json.to_string()),
                 }
             })
             .collect();

--- a/src-tauri/src/services/provider/usage.rs
+++ b/src-tauri/src/services/provider/usage.rs
@@ -9,6 +9,202 @@ use crate::settings;
 use crate::store::AppState;
 use crate::usage_script;
 
+// ───────────────────────────────────────────────────────────────────────────
+// Special-template branches shared between the provider-level path
+// (`commands::provider::query_provider_usage_inner`) and the per-key path
+// (`query_usage_for_key` below). Each is a thin adapter that translates a
+// provider's `template_type` + `(base_url, api_key)` into a `UsageResult`.
+//
+// `api_key` here is the **resolved** credential — for the per-key caller it
+// comes from `provider_api_keys[row].api_key`; for the provider-level caller
+// it comes from `usage_script.api_key` → `provider.settings_config`. So the
+// per-key TOKEN_PLAN call uses *that key's* MiniMax/Kimi/Zhipu/… token
+// against the live API, which is the whole point of letting a key pool
+// reflect N independent MiniMax accounts. (When a pool is genuinely the same
+// account with N keys for round-robin/limits, the backend will simply return
+// the same 5h/7d numbers — that's still correct, just no per-key variety.)
+// ───────────────────────────────────────────────────────────────────────────
+
+const TEMPLATE_TYPE_TOKEN_PLAN: &str = "token_plan";
+const TEMPLATE_TYPE_BALANCE: &str = "balance";
+const TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION: &str = "official_subscription";
+
+/// Query the special account-level templates (TOKEN_PLAN / BALANCE /
+/// OFFICIAL_SUBSCRIPTION) and return a `UsageResult` shaped like the JS-script
+/// path so callers can pipe it straight into the existing per-key cache and
+/// the same UI bar.
+///
+/// `usage_script` is read here only for the optional `access_key_id`,
+/// `secret_access_key`, `group_id` fields used by Volcengine / MiniMax.
+/// Pass `None` from paths that don't have a usage_script reference (none
+/// today — both call-sites have one in scope).
+pub(crate) async fn query_special_template(
+    app_type: &AppType,
+    template_type: &str,
+    base_url: &str,
+    api_key: &str,
+    usage_script: Option<&UsageScript>,
+) -> Result<UsageResult, AppError> {
+    if template_type == TEMPLATE_TYPE_TOKEN_PLAN {
+        // 火山方舟用账号 AK/SK 签名（与数据面 api_key 分离）；其他供应商 None。
+        let access_key_id = usage_script.and_then(|s| s.access_key_id.clone());
+        let secret_access_key = usage_script.and_then(|s| s.secret_access_key.clone());
+        // MiniMax Coding Plan 缺 GroupId 时接口返回占位零值（误显示 0%）。
+        let group_id = usage_script.and_then(|s| s.group_id.clone());
+
+        let quota = crate::services::coding_plan::get_coding_plan_quota(
+            base_url,
+            api_key,
+            access_key_id.as_deref(),
+            secret_access_key.as_deref(),
+            group_id.as_deref(),
+        )
+        .await
+        .map_err(|e| {
+            AppError::localized(
+                "provider.usage.coding_plan_failed",
+                format!("查询 Coding Plan 失败: {e}"),
+                format!("Failed to query coding plan: {e}"),
+            )
+        })?;
+
+        if !quota.success {
+            return Ok(UsageResult {
+                success: false,
+                data: None,
+                error: quota.error,
+            });
+        }
+
+        // ZenMux 的 tier 携带 USD 额度信息，需要编码为 JSON extra
+        let has_usd = quota
+            .tiers
+            .first()
+            .map(|t| t.used_value_usd.is_some())
+            .unwrap_or(false);
+        let plan_label = quota
+            .credential_message
+            .as_deref()
+            .and_then(|msg| msg.split(' ').next())
+            .map(|tier| format!("ZenMux·{}", tier.to_uppercase()));
+        let mut first_tier = true;
+
+        let data: Vec<UsageData> = quota
+            .tiers
+            .iter()
+            .map(|tier| {
+                let total = 100.0;
+                let used = tier.utilization;
+                let remaining = total - used;
+                let extra = if has_usd {
+                    let mut extra_json = serde_json::json!({
+                        "resetsAt": tier.resets_at,
+                    });
+                    if let Some(v) = tier.used_value_usd {
+                        extra_json["usedValueUsd"] = serde_json::json!(v);
+                    }
+                    if let Some(v) = tier.max_value_usd {
+                        extra_json["maxValueUsd"] = serde_json::json!(v);
+                    }
+                    if first_tier {
+                        if let Some(ref label) = plan_label {
+                            extra_json["planLabel"] = serde_json::json!(label);
+                        }
+                        first_tier = false;
+                    }
+                    Some(extra_json.to_string())
+                } else {
+                    tier.resets_at.clone()
+                };
+                UsageData {
+                    plan_name: Some(tier.name.clone()),
+                    remaining: Some(remaining),
+                    total: Some(total),
+                    used: Some(used),
+                    unit: Some("%".to_string()),
+                    is_valid: Some(true),
+                    invalid_message: None,
+                    extra,
+                }
+            })
+            .collect();
+
+        return Ok(UsageResult {
+            success: true,
+            data: if data.is_empty() { None } else { Some(data) },
+            error: None,
+        });
+    }
+
+    if template_type == TEMPLATE_TYPE_BALANCE {
+        return crate::services::balance::get_balance(base_url, api_key)
+            .await
+            .map_err(|e| {
+                AppError::localized(
+                    "provider.usage.balance_failed",
+                    format!("查询余额失败: {e}"),
+                    format!("Failed to query balance: {e}"),
+                )
+            });
+    }
+
+    if template_type == TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION {
+        if !usage_script.map(|s| s.enabled).unwrap_or(false) {
+            return Ok(UsageResult {
+                success: false,
+                data: None,
+                error: Some("Usage query is disabled".to_string()),
+            });
+        }
+
+        let quota = crate::services::subscription::get_subscription_quota(app_type.as_str())
+            .await
+            .map_err(|e| {
+                AppError::localized(
+                    "provider.usage.subscription_failed",
+                    format!("查询订阅额度失败: {e}"),
+                    format!("Failed to query subscription quota: {e}"),
+                )
+            })?;
+
+        if !quota.success {
+            return Ok(UsageResult {
+                success: false,
+                data: None,
+                error: quota.error.or(quota.credential_message),
+            });
+        }
+
+        let data: Vec<UsageData> = quota
+            .tiers
+            .iter()
+            .map(|tier| UsageData {
+                plan_name: Some(tier.name.clone()),
+                remaining: Some(100.0 - tier.utilization),
+                total: Some(100.0),
+                used: Some(tier.utilization),
+                unit: Some("%".to_string()),
+                is_valid: Some(true),
+                invalid_message: None,
+                extra: tier.resets_at.clone(),
+            })
+            .collect();
+
+        return Ok(UsageResult {
+            success: true,
+            data: if data.is_empty() { None } else { Some(data) },
+            error: None,
+        });
+    }
+
+    // 未识别的 template_type → 让调用方退回 JS 脚本路径。
+    Err(AppError::localized(
+        "provider.usage.template_unsupported",
+        format!("模板类型 {template_type} 不支持 special 路径"),
+        format!("Template type {template_type} is not supported by special path"),
+    ))
+}
+
 /// Execute usage script and format result (private helper method)
 pub(crate) async fn execute_and_format_usage_result(
     script_code: &str,
@@ -179,6 +375,148 @@ pub async fn query_usage(
     execute_and_format_usage_result(
         &script_code,
         &api_key,
+        &base_url,
+        timeout,
+        access_token.as_deref(),
+        user_id.as_deref(),
+        template_type.as_deref(),
+    )
+    .await
+}
+
+/// Query usage for a *specific* key in a provider's pool, using that key's
+/// own `api_key` value (read from `provider_api_keys`) instead of the
+/// provider-level fallback in [`query_usage`].
+///
+/// `base_url` / `access_token` / `user_id` / `template_type` are still
+/// sourced from the provider's `usage_script` config — those are typically
+/// shared across the pool. If a future schema adds a per-key `base_url`,
+/// fall through to that field here.
+///
+/// **Returns Ok(UsageResult { success: false, ... }) for:**
+///   - `enabled = false` on the key row (don't even try the network call)
+///   - `key_id` not found
+///
+/// **Returns Err for:** DB / transport failures (consistent with `query_usage`).
+pub async fn query_usage_for_key(
+    state: &AppState,
+    app_type: AppType,
+    provider_id: &str,
+    key_id: &str,
+) -> Result<UsageResult, AppError> {
+    // 1) 拉取目标 key 行——api_key 在这里，base_url 仍走 provider 级。
+    let key_row = state.db.get_api_key(key_id)?.ok_or_else(|| {
+        AppError::localized(
+            "provider.api_key.not_found",
+            format!("key {key_id} 不存在"),
+            format!("key {key_id} not found"),
+        )
+    })?;
+    // 跨 (provider_id, app_type) 校验：key 必须属于该 provider 的同一个 app_type pool，
+    // 防止前端误传"p2 的 key id + p1 的 provider_id"导致数据混淆。
+    if key_row.provider_id != provider_id || key_row.app_type != app_type.as_str() {
+        return Err(AppError::localized(
+            "provider.api_key.mismatch",
+            format!(
+                "key {key_id} 不属于 ({provider_id}, {})",
+                app_type.as_str()
+            ),
+            format!(
+                "key {key_id} does not belong to ({provider_id}, {})",
+                app_type.as_str()
+            ),
+        ));
+    }
+    if !key_row.enabled {
+        // Disabled key 直接判业务失败，不消耗一次 API 调用。
+        return Ok(UsageResult {
+            success: false,
+            data: None,
+            error: Some(format!("key {} 已禁用", key_row.label)),
+        });
+    }
+
+    // 2) 拉 provider 的 usage_script 配置（base_url + access_token + user_id + script）。
+    //    同时保留 usage_script 的引用——special-template 路径（TOKEN_PLAN / 余额 /
+    //    官方订阅）需要读取 access_key_id / secret_access_key / group_id 等字段。
+    let (script_code, timeout, base_url, access_token, user_id, template_type, usage_script_owned) = {
+        let providers = state.db.get_all_providers(app_type.as_str())?;
+        let provider = providers.get(provider_id).ok_or_else(|| {
+            AppError::localized(
+                "provider.not_found",
+                format!("供应商不存在: {provider_id}"),
+                format!("Provider not found: {provider_id}"),
+            )
+        })?;
+        let usage_script = provider
+            .meta
+            .as_ref()
+            .and_then(|m| m.usage_script.as_ref())
+            .ok_or_else(|| {
+                AppError::localized(
+                    "provider.usage.script.missing",
+                    "未配置用量查询脚本",
+                    "Usage script is not configured",
+                )
+            })?;
+        if !usage_script.enabled {
+            return Err(AppError::localized(
+                "provider.usage.disabled",
+                "用量查询未启用",
+                "Usage query is disabled",
+            ));
+        }
+        // base_url 仍走 provider 级——per-key base_url 不在当前 schema 里。
+        // resolve_script_credentials 内部已经会把 usage_script.base_url 优先、
+        // provider.settings_config 兜底。
+        let (_unused_api_key, base_url) = resolve_script_credentials(
+            &app_type,
+            provider,
+            None, // 关键：忽略 usage_script.api_key，永远用 key 行的 api_key
+            usage_script.base_url.as_deref(),
+        );
+        (
+            usage_script.code.clone(),
+            usage_script.timeout.unwrap_or(10),
+            base_url,
+            usage_script.access_token.clone(),
+            usage_script.user_id.clone(),
+            usage_script.template_type.clone(),
+            usage_script.clone(),
+        )
+    };
+
+    // 3) 账户级模板（TOKEN_PLAN / BALANCE / OFFICIAL_SUBSCRIPTION）→ 走专用
+    //    后端路径，**用这把 key 自己的 api_key 跑**。MiniMax/Kimi/Zhipu 这些
+    //    Coding Plan 把 api_key 当 Bearer token 用，所以一个 key pool 里的 N 把
+    //    key 各自拿到对应账号的 5h/7d 配额——这是 per-key 路径真正想要的语义。
+    //
+    //    注意：TOKEN_PLAN 注入时 `usage_script.code` 是空串（见
+    //    `config/codingPlanProviders.ts::injectCodingPlanUsageScript`），如果
+    //    走 JS 路径 `ctx.eval("")` 直接抛错，所以这一段 short-circuit 是必须
+    //    的——它修了「api count > 1 + TOKEN_PLAN 时 5h/7d 进度条永久消失」的
+    //    Bug 1。
+    let template_str = template_type.as_deref().unwrap_or("");
+    if matches!(
+        template_str,
+        TEMPLATE_TYPE_TOKEN_PLAN
+            | TEMPLATE_TYPE_BALANCE
+            | TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION
+    ) {
+        return query_special_template(
+            &app_type,
+            template_str,
+            &base_url,
+            key_row.api_key.as_str(),
+            Some(&usage_script_owned),
+        )
+        .await;
+    }
+
+    // 4) 自定义 / JS 脚本路径：用 key 自己的 api_key + provider 的 base_url 跑脚本。
+    execute_and_format_usage_result(
+        &script_code,
+        key_row.api_key.as_str(),
         &base_url,
         timeout,
         access_token.as_deref(),

--- a/src-tauri/src/services/provider/usage.rs
+++ b/src-tauri/src/services/provider/usage.rs
@@ -49,6 +49,10 @@ pub(crate) async fn query_special_template(
         // 火山方舟用账号 AK/SK 签名（与数据面 api_key 分离）；其他供应商 None。
         let access_key_id = usage_script.and_then(|s| s.access_key_id.clone());
         let secret_access_key = usage_script.and_then(|s| s.secret_access_key.clone());
+        // 智谱团队版：base_url 与个人版相同，靠显式 provider 路由。
+        let coding_plan_provider = usage_script.and_then(|s| s.coding_plan_provider.clone());
+        let team_organization_id = usage_script.and_then(|s| s.team_organization_id.clone());
+        let team_project_id = usage_script.and_then(|s| s.team_project_id.clone());
         // MiniMax Coding Plan 缺 GroupId 时接口返回占位零值（误显示 0%）。
         let group_id = usage_script.and_then(|s| s.group_id.clone());
 
@@ -57,6 +61,9 @@ pub(crate) async fn query_special_template(
             api_key,
             access_key_id.as_deref(),
             secret_access_key.as_deref(),
+            coding_plan_provider.as_deref(),
+            team_organization_id.as_deref(),
+            team_project_id.as_deref(),
             group_id.as_deref(),
         )
         .await

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -465,7 +465,11 @@ impl ProxyService {
         }
 
         // 5. 保存服务器实例
-        *self.server.write().await = Some(server);
+        *self.server.write().await = Some(server.clone());
+
+        // 6. 启动 30s KeyRing flush tick（runtime 改动落盘）。
+        //    clone 出来再 spawn，避免借用 self.server 的 RwLock。
+        Self::spawn_flush_task(&server).await;
 
         log::info!("代理服务器已启动: {}:{}", info.address, info.port);
         Ok(info)
@@ -1088,6 +1092,156 @@ impl ProxyService {
         Ok(())
     }
 
+    /// 同步 reload 某个 provider 的 KeyRing 池——用户在 UI 上把某把
+    /// key 设为 active 时调用，让代理进程立刻看到新排序/新 active 标记，
+    /// 不必等 30s flush tick。
+    ///
+    /// 仅在代理运行时有意义（KeyRing 跟随 ProxyServer 生命周期）。
+    /// 代理未运行时直接成功返回。
+    pub async fn reload_provider_keys(
+        &self,
+        provider_id: &str,
+        app_type: &AppType,
+    ) -> Result<(), String> {
+        let server_guard = self.server.read().await;
+        let Some(server) = server_guard.as_ref() else {
+            return Ok(());
+        };
+        server
+            .state
+            .key_ring
+            .reload_provider(&self.db, provider_id, app_type.as_str())
+            .await
+            .map_err(|e| format!("reload KeyRing 失败: {e}"))
+    }
+
+    /// 把某 provider 的 round-robin 游标重置到 active key 的位置。
+    /// `set_active_api_key` 后调用——让下一次 next_key 直接落到新 active 上，
+    /// 避免 cursor 仍指在老 key / 已 disable 的位置上。
+    /// 注意：`reload_provider_keys` 内部也会重置 cursor，但主动调一次
+    /// 能确保 reload 失败时 cursor 至少被拨到正确位置。
+    /// 代理未运行时 no-op。
+    pub async fn reset_provider_cursor(&self, provider_id: &str, app_type: &AppType) {
+        let server_guard = self.server.read().await;
+        let Some(server) = server_guard.as_ref() else {
+            return;
+        };
+        server
+            .state
+            .key_ring
+            .reset_cursor(provider_id, app_type)
+            .await;
+    }
+
+    /// 通知 KeyRing「这把 key 已被用户重新启用」——内存里把它的
+    /// failure_count / cooldown_until / last_error 全部清零。
+    /// 代理未运行时 no-op（reload 时会从 DB 读到 0 值）。
+    ///
+    /// 配合 `cmd_update_api_key` 的「disabled → enabled」重置：DB 落盘 + 内存同步，
+    /// 不必等下一个 30s flush tick 才让 next_key 看到清零后的状态。
+    pub async fn notify_key_re_enabled(&self, key_id: &str) {
+        let server_guard = self.server.read().await;
+        let Some(server) = server_guard.as_ref() else {
+            return;
+        };
+        server.state.key_ring.mark_success(key_id).await;
+    }
+
+    /// 通知 KeyRing「这把 key 用量已接近上限」——proactive rotation
+    /// 的入口点。前端 autoQueryInterval 触发 `keyUsage` 查询时，如果
+    /// 任何窗口（5h/7d/30d）的 `usage_percent >= 90%`，调用本接口把
+    /// key 提前送进 cooldown：
+    ///
+    /// - 90% ≤ p < 100%：cooldown_until = reset_at（5h 窗口重置后恢复）
+    /// - p ≥ 100%：cooldown_until = max(reset_at, now + 30min)，给一个
+    ///   额外缓冲避免反复打爆
+    ///
+    /// 代理未运行时 no-op（KeyRing 尚未加载到内存）。
+    /// 失败时返回 false（让前端可以选择降级为只显示 UI 提示，不阻塞）。
+    pub async fn notify_key_usage_high(
+        &self,
+        key_id: &str,
+        usage_percent: f64,
+        reset_at: i64,
+    ) -> bool {
+        let server_guard = self.server.read().await;
+        let Some(server) = server_guard.as_ref() else {
+            return false;
+        };
+        server
+            .state
+            .key_ring
+            .mark_usage_high(key_id, usage_percent, reset_at)
+            .await
+    }
+
+    /// 启动 30s 周期的 KeyRing 内存 → DB flush tick。
+    /// 每次 tick 调用 `key_ring.flush_dirty(&db)` 把 runtime 改动
+    /// (cooldown、failure_count、last_used_at、last_error) 落盘。
+    /// 任务句柄存在 `ProxyServer` 内的 slot 上，stop 时通过
+    /// `cancel_flush_task` 收回。
+    pub async fn spawn_flush_task(server: &ProxyServer) {
+        let key_ring = server.state.key_ring.clone();
+        let db = server.state.db.clone();
+        let cancel = server.state.flush_cancel.clone();
+        // 槽里已有旧句柄就不再 spawn——避免重复 tick。
+        //
+        // 用 lock().await 而不是 try_lock：start_proxy_server 是 async，
+        // 两个并发启动会同时进 try_lock → 一个 silently 失败。改为 await
+        // 让两个实例串行化，第二个看到 slot.is_some() 后直接返回。
+        let mut slot = server.state.flush_task.lock().await;
+        if slot.is_some() {
+            return;
+        }
+            let handle = tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
+                // 第一次 tick 立即触发（interval 的 first tick 行为）。
+                ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    tokio::select! {
+                        _ = cancel.cancelled() => {
+                            log::info!("[KeyRing] flush tick 收到停止信号，退出");
+                            break;
+                        }
+                        _ = ticker.tick() => {
+                            // 先扫一遍过期的 cooldown——把"cooldown 已过、可用了"
+                            // 的 key 的 failure_count 清零、标 dirty；这把 key 的
+                            // 失败状态从这一刻起是"诚实的就绪"，下一次失败才重新
+                            // 计数。否则一把 key rate-limit 一次后，UI 永远挂着
+                            // "1/5"，直到下一次失败把它推到 2/5——观感很怪。
+                            let reaped = key_ring.reap_expired_cooldowns().await;
+                            if reaped > 0 {
+                                log::debug!("[KeyRing] flush tick reaped {reaped} expired cooldowns");
+                            }
+                            match key_ring.flush_dirty(&db).await {
+                                Ok(n) if n > 0 => {
+                                    log::debug!("[KeyRing] flush tick 写回 {n} 个 dirty key");
+                                }
+                                Ok(_) => {}
+                                Err(e) => {
+                                    log::warn!("[KeyRing] flush tick 失败: {e}");
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+            *slot = Some(handle);
+    }
+
+    /// 收回 30s flush tick。
+    pub async fn cancel_flush_task(server: &ProxyServer) {
+        // 先发信号，再 join。
+        server.state.flush_cancel.cancel();
+        let handle_opt = {
+            let mut slot = server.state.flush_task.lock().await;
+            slot.take()
+        };
+        if let Some(handle) = handle_opt {
+            let _ = handle.await;
+        }
+    }
+
     /// 停止代理服务器
     pub async fn stop(&self) -> Result<(), String> {
         if let Some(server) = self.server.write().await.take() {
@@ -1095,6 +1249,9 @@ impl ProxyService {
                 .stop()
                 .await
                 .map_err(|e| format!("停止代理服务器失败: {e}"))?;
+
+            // 取消 30s 一次的 KeyRing flush tick（如果之前启动过）。
+            Self::cancel_flush_task(&server).await;
 
             // 停止时设置 proxy_enabled = false
             let mut global_config = self

--- a/src-tauri/src/services/subscription.rs
+++ b/src-tauri/src/services/subscription.rs
@@ -38,6 +38,19 @@ pub struct QuotaTier {
     /// ZenMux: 窗口上限（USD）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_value_usd: Option<f64>,
+    /// MiniMax: 已用次数（prompt 调用计数）
+    /// 当上游直接返回绝对值（如 current_interval_usage_count / 7）时填充；
+    /// 其他 provider 永远为 None，渲染层应回退到 utilization 百分比。
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub used_count: Option<f64>,
+    /// MiniMax: 窗口上限次数（prompt 配额）
+    /// 语义与 used_count 配对；None 时回退到 utilization 百分比。
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub total_count: Option<f64>,
+    /// 该窗口数据的单位（仅与 used_count/total_count 同时使用）：
+    /// "count"（次/条）= MiniMax, "tokens" = 智谱 etc. None 表示百分比口径。
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub count_unit: Option<String>,
 }
 
 /// 超额使用信息
@@ -400,6 +413,9 @@ async fn query_claude_quota(access_token: &str) -> Result<SubscriptionQuota, Str
                         resets_at: w.resets_at,
                         used_value_usd: None,
                         max_value_usd: None,
+                        used_count: None,
+                        total_count: None,
+                        count_unit: None,
                     });
                 }
             }
@@ -420,6 +436,9 @@ async fn query_claude_quota(access_token: &str) -> Result<SubscriptionQuota, Str
                         resets_at: w.resets_at,
                         used_value_usd: None,
                         max_value_usd: None,
+                        used_count: None,
+                        total_count: None,
+                        count_unit: None,
                     });
                 }
             }
@@ -743,6 +762,9 @@ pub(crate) async fn query_codex_quota(
                     resets_at: window.reset_at.and_then(unix_ts_to_iso),
                     used_value_usd: None,
                     max_value_usd: None,
+                    used_count: None,
+                    total_count: None,
+                    count_unit: None,
                 });
             }
         }
@@ -1206,6 +1228,9 @@ async fn query_gemini_quota(access_token: &str) -> Result<SubscriptionQuota, Str
             resets_at: reset_time,
             used_value_usd: None,
             max_value_usd: None,
+            used_count: None,
+            total_count: None,
+            count_unit: None,
         })
         .collect();
 

--- a/src-tauri/src/services/subscription.rs
+++ b/src-tauri/src/services/subscription.rs
@@ -23,7 +23,7 @@ pub enum CredentialStatus {
 }
 
 /// 单个限速窗口（如 5小时会话、7天周期）
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuotaTier {
     /// 窗口标识：five_hour, seven_day, seven_day_opus, seven_day_sonnet 等
@@ -51,6 +51,11 @@ pub struct QuotaTier {
     /// "count"（次/条）= MiniMax, "tokens" = 智谱 etc. None 表示百分比口径。
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub count_unit: Option<String>,
+    /// API 服务端计算的「距窗口重置剩余毫秒数」（如 MiniMax `remains_time` /
+    /// `weekly_remains_time`）。优先于前端 `end_time - Date.now()` 计算,
+    /// 避免本地时钟漂移导致 4h 级别的偏差。前端可据此精确渲染倒计时。
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub remains_time_ms: Option<i64>,
 }
 
 /// 超额使用信息
@@ -411,11 +416,7 @@ async fn query_claude_quota(access_token: &str) -> Result<SubscriptionQuota, Str
                         name: tier_name.to_string(),
                         utilization: util,
                         resets_at: w.resets_at,
-                        used_value_usd: None,
-                        max_value_usd: None,
-                        used_count: None,
-                        total_count: None,
-                        count_unit: None,
+                        ..Default::default()
                     });
                 }
             }
@@ -434,11 +435,7 @@ async fn query_claude_quota(access_token: &str) -> Result<SubscriptionQuota, Str
                         name: key.clone(),
                         utilization: util,
                         resets_at: w.resets_at,
-                        used_value_usd: None,
-                        max_value_usd: None,
-                        used_count: None,
-                        total_count: None,
-                        count_unit: None,
+                        ..Default::default()
                     });
                 }
             }
@@ -760,11 +757,7 @@ pub(crate) async fn query_codex_quota(
                         .unwrap_or_else(|| "unknown".to_string()),
                     utilization: used,
                     resets_at: window.reset_at.and_then(unix_ts_to_iso),
-                    used_value_usd: None,
-                    max_value_usd: None,
-                    used_count: None,
-                    total_count: None,
-                    count_unit: None,
+                    ..Default::default()
                 });
             }
         }
@@ -1226,11 +1219,7 @@ async fn query_gemini_quota(access_token: &str) -> Result<SubscriptionQuota, Str
             name,
             utilization: (1.0 - remaining) * 100.0,
             resets_at: reset_time,
-            used_value_usd: None,
-            max_value_usd: None,
-            used_count: None,
-            total_count: None,
-            count_unit: None,
+            ..Default::default()
         })
         .collect();
 

--- a/src-tauri/src/services/usage_cache.rs
+++ b/src-tauri/src/services/usage_cache.rs
@@ -13,7 +13,13 @@ use crate::services::subscription::SubscriptionQuota;
 #[derive(Default)]
 pub struct UsageCache {
     subscription: RwLock<HashMap<AppType, SubscriptionQuota>>,
+    /// `(app_type, provider_id)` → 该 provider 的"默认/active" key 快照。
+    /// Provider-level 用途：托盘菜单、ProviderCard 顶部。
     script: RwLock<HashMap<(AppType, String), UsageResult>>,
+    /// `(app_type, provider_id, key_id)` → 该 key 自己的快照。
+    /// Per-key 用途：编辑面板里 ApiKeyListSection 逐行展示。key 维度的
+    /// 快照不能跟 provider-level 用同一个 HashMap——否则两把 key 互相覆盖。
+    script_per_key: RwLock<HashMap<(AppType, String, String), UsageResult>>,
 }
 
 impl UsageCache {
@@ -30,6 +36,24 @@ impl UsageCache {
     pub fn put_script(&self, app_type: AppType, provider_id: String, result: UsageResult) {
         if let Ok(mut w) = self.script.write() {
             w.insert((app_type, provider_id), result);
+        }
+    }
+
+    /// Per-key 写穿。`key_id` 维度的快照独立落盘，不会和同 pool 其它 key
+    /// 互相覆盖，也不会污染 `script[(app_type, provider_id)]` 的 provider
+    /// 级快照。
+    pub fn put_script_per_key(
+        &self,
+        app_type: AppType,
+        provider_id: &str,
+        key_id: &str,
+        result: UsageResult,
+    ) {
+        if let Ok(mut w) = self.script_per_key.write() {
+            w.insert(
+                (app_type, provider_id.to_string(), key_id.to_string()),
+                result,
+            );
         }
     }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -291,6 +291,23 @@ pub struct LocalMigrations {
     /// 这样重新开启能把"关闭期间"落入 openai 桶的官方会话补迁进来。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_official_history_unify_v1: Option<CodexOfficialHistoryUnifyMigration>,
+    /// Per-key live config 写入迁移标记（v1）。N-key 池的每把 key 都会
+    /// 在 `{config_dir}/keys/{provider_id}/{key_id}.<ext>` 下写一份可独立
+    /// 使用的副本。该 migration 在第一次启动时跑一遍所有 multi-key
+    /// provider，把存量数据写到 on-disk；后续 regen 由 cmd_* mutation
+    /// 钩子按需触发。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multi_api_keys_files_v1: Option<MultiApiKeysFilesMigration>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiApiKeysFilesMigration {
+    pub completed_at: String,
+    #[serde(default)]
+    pub providers_scanned: usize,
+    #[serde(default)]
+    pub files_written: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -886,6 +886,60 @@ pub fn apply_tray_policy(app: &tauri::AppHandle, dock_visible: bool) {
     }
 }
 
+#[cfg(target_os = "macos")]
+pub fn nudge_main_window_on_macos(window: tauri::WebviewWindow) {
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        match window.inner_size() {
+            Ok(original) => {
+                let bumped = tauri::PhysicalSize::new(
+                    original.width.saturating_add(1),
+                    original.height,
+                );
+                let _ = window.set_size(bumped);
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                let _ = window.set_size(original);
+                log::info!("macOS: 已对主窗口执行伪 resize 修复渲染");
+            }
+            Err(e) => {
+                log::warn!("macOS nudge: 读取 inner_size 失败，跳过伪 resize: {e}");
+            }
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+/// Debounce nudge：每次调用都取消上一次的定时任务并重新安排 500ms 后的
+/// nudge。这样只在用户停止拖动/缩放 500ms 后才真正触发一次伪 resize，
+/// 避免 nudge 自身的 `set_size` 触发新的 `Resized` 事件形成回调风暴。
+/// 当前未在 on_window_event 中使用（Resized 事件会被 nudge 自身反复触发），
+/// 保留供将来需要时调用。
+#[allow(dead_code)]
+static NUDGE_DEBOUNCE: std::sync::Mutex<Option<tauri::async_runtime::JoinHandle<()>>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+pub fn schedule_nudge_after_resize(window: tauri::WebviewWindow) {
+    let mut guard = match NUDGE_DEBOUNCE.lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+
+    // 取消上一次未执行的 nudge
+    if let Some(handle) = guard.take() {
+        handle.abort();
+    }
+
+    let handle = tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        nudge_main_window_on_macos(window);
+    });
+
+    *guard = Some(handle);
+}
+
 /// 处理托盘菜单事件
 pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
     log::info!("处理托盘菜单事件: {event_id}");
@@ -907,6 +961,7 @@ pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
                 #[cfg(target_os = "macos")]
                 {
                     apply_tray_policy(app, true);
+                    nudge_main_window_on_macos(window.clone());
                 }
             } else if crate::lightweight::is_lightweight_mode() {
                 if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
@@ -1102,6 +1157,9 @@ mod tests {
             resets_at: None,
             used_value_usd: None,
             max_value_usd: None,
+            used_count: None,
+            total_count: None,
+            count_unit: None,
         }
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1154,12 +1154,7 @@ mod tests {
         QuotaTier {
             name: name.to_string(),
             utilization,
-            resets_at: None,
-            used_value_usd: None,
-            max_value_usd: None,
-            used_count: None,
-            total_count: None,
-            count_unit: None,
+            ..Default::default()
         }
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,11 +25,17 @@ import {
   Shield,
   Cpu,
   LayoutDashboard,
+  Loader2 as Loader2Icon,
+  Recycle,
 } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { Provider, VisibleApps } from "@/types";
 import type { EnvConflict } from "@/types/env";
 import { useProvidersQuery, useSettingsQuery } from "@/lib/query";
+import {
+  useAutoFailoverEnabled,
+  useSetAutoFailoverEnabled,
+} from "@/lib/query/failover";
 import {
   providersApi,
   settingsApi,
@@ -44,6 +50,7 @@ import { hermesApi } from "@/lib/api/hermes";
 import { useProxyStatus } from "@/hooks/useProxyStatus";
 import { useAutoCompact } from "@/hooks/useAutoCompact";
 import { useUsageCacheBridge } from "@/hooks/useUsageCacheBridge";
+import { useKeyRateLimitedBridge } from "@/hooks/useKeyRateLimitedBridge";
 import { useTauriEvent } from "@/hooks/useTauriEvent";
 import { useLastValidValue } from "@/hooks/useLastValidValue";
 import { useScanUnmanagedSkills } from "@/hooks/useSkills";
@@ -247,6 +254,7 @@ function App() {
   const isToolbarCompact = useAutoCompact(toolbarRef);
 
   useUsageCacheBridge();
+  useKeyRateLimitedBridge();
 
   const promptPanelRef = useRef<any>(null);
   const mcpPanelRef = useRef<any>(null);
@@ -287,6 +295,14 @@ function App() {
       currentView === "openclawAgents");
   const { data: openclawHealthWarnings = [] } =
     useOpenClawHealth(isOpenClawView);
+  // 全局故障转移开关（每应用独立）——header 上一个图标按钮直接 toggle。
+  // 与 FailoverQueueManager 的逻辑同源，区别是：
+  //   1. 这里始终可点（即便 failoverQueue 为空）——header 是常用入口，
+  //      用户开了之后再去队列里加 provider。
+  //   2. tooltip 直接读 i18n 里的 failover.tooltip.*，行为跟 tray 菜单一致。
+  const { data: isFailoverEnabled = false } =
+    useAutoFailoverEnabled(sharedFeatureApp);
+  const setFailoverEnabled = useSetAutoFailoverEnabled();
   const hasSkillsSupport = sharedFeatureApp !== "openclaw";
   const hasSessionSupport =
     sharedFeatureApp === "claude" ||
@@ -1555,6 +1571,78 @@ function App() {
                       </AnimatePresence>
                     </div>
 
+                    {/* 全局故障转移 toggle —— header 上唯一一个「开关
+                        风格」的图标按钮（其它都是导航类图标）。
+                        视觉策略：
+                          - 关：ghost + muted，hover 跟左边那排 nav 按钮一致
+                          - 开：emerald 实心 + 白色图标，shuffle 图标
+                            暗示「在多个 provider 之间轮换」；跟「+」按钮
+                            的橙色 + 加号形成对比——「+」是加 provider，
+                            shuffle 是开轮换，两个动作互不冲突。
+                        行为：
+                          - 点击 → 调用 setFailoverEnabled mutation；
+                            后端乐观更新（failover.ts:onMutate）所以
+                            UI 立刻变绿，不会因为 RTT 看起来卡。
+                          - mutation 进行中：图标换成 Loader2 自转，
+                            防止用户连点。 */}
+                    <Button
+                      onClick={() =>
+                        setFailoverEnabled.mutate({
+                          appType: sharedFeatureApp,
+                          enabled: !isFailoverEnabled,
+                        })
+                      }
+                      size="icon"
+                      disabled={setFailoverEnabled.isPending}
+                      className={cn(
+                        "ml-2 w-8 h-8 rounded-full transition-all duration-200",
+                        isFailoverEnabled
+                          ? "bg-emerald-500 hover:bg-emerald-600 text-white shadow-lg shadow-emerald-500/30 dark:shadow-emerald-500/40"
+                          : // 关态默认是纯文字色（muted-foreground），但 hover
+                            // 时有 `bg-black/5` / `bg-white/5` 的浅灰底。
+                            // 当 isPending 触发 disabled 时，shadcn 默认会
+                            // 把整按钮降到 opacity-50，并屏蔽 hover 样式——
+                            // 结果是「文字淡 50% 但背景全透」，看起来反而
+                            // 比 enabled 态更弱，传达不出「正在处理」的含义。
+                            // 显式覆盖：disabled 时给一个固定的浅灰底（跟
+                            // hover 同色），让按钮在 disabled / 非 disabled
+                            // 切换时只有「图标变 spinner」一个变量，不会
+                            // 出现「按钮整个变淡」的视觉抖动。
+                            "text-muted-foreground bg-black/5 dark:bg-white/5 hover:bg-black/10 dark:hover:bg-white/10 disabled:opacity-100 disabled:bg-black/5 dark:disabled:bg-white/5",
+                      )}
+                      title={
+                        isFailoverEnabled
+                          ? t("failover.tooltip.enabled", {
+                              app:
+                                sharedFeatureApp === "claude"
+                                  ? "Claude"
+                                  : sharedFeatureApp === "codex"
+                                    ? "Codex"
+                                    : sharedFeatureApp === "gemini"
+                                      ? "Gemini"
+                                      : sharedFeatureApp,
+                              defaultValue: "Provider rotation enabled",
+                            })
+                          : t("failover.tooltip.disabled", {
+                              app:
+                                sharedFeatureApp === "claude"
+                                  ? "Claude"
+                                  : sharedFeatureApp === "codex"
+                                    ? "Codex"
+                                    : sharedFeatureApp === "gemini"
+                                      ? "Gemini"
+                                      : sharedFeatureApp,
+                              defaultValue: "Enable provider rotation",
+                            })
+                      }
+                      aria-pressed={isFailoverEnabled}
+                    >
+                      {setFailoverEnabled.isPending ? (
+                        <Loader2Icon className="w-4 h-4 animate-spin" />
+                      ) : (
+                        <Recycle className="w-4 h-4" />
+                      )}
+                    </Button>
                     <Button
                       onClick={() => setIsAddOpen(true)}
                       size="icon"

--- a/src/components/SubscriptionQuotaFooter.tsx
+++ b/src/components/SubscriptionQuotaFooter.tsx
@@ -48,29 +48,47 @@ export function utilizationColor(utilization: number): string {
   return "text-green-600 dark:text-green-400";
 }
 
-/** 计算倒计时的纯时间字符串，如 "2h30m"、"3d12h" */
-export function countdownStr(resetsAt: string | null): string | null {
+/** 计算倒计时的纯时间字符串，如 "2h30m"、"3d12h"。
+ *  优先用服务端给的 remainsTimeMs（精确到毫秒,无本地时钟漂移）,
+ *  否则 fallback 到 endTime - Date.now()。
+ */
+export function countdownStr(
+  resetsAt: string | null,
+  remainsTimeMs?: number | null,
+): string | null {
+  // 服务端剩余毫秒数优先：避免本地时钟偏差 + 拿到秒级精度。
+  if (typeof remainsTimeMs === "number" && remainsTimeMs > 0) {
+    return countdownFromMs(remainsTimeMs);
+  }
   if (!resetsAt) return null;
   const diffMs = new Date(resetsAt).getTime() - Date.now();
   if (diffMs <= 0) return null;
+  return countdownFromMs(diffMs);
+}
 
-  const hours = Math.floor(diffMs / (1000 * 60 * 60));
-  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+/** 内部：从毫秒数渲染倒计时文本（与上面拆分便于测试）。 */
+function countdownFromMs(diffMs: number): string {
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
 
-  if (hours > 24) {
+  if (hours >= 24) {
     const days = Math.floor(hours / 24);
     return `${days}d${hours % 24}h`;
   }
   if (hours > 0) return `${hours}h${minutes}m`;
-  return `${minutes}m`;
+  if (minutes > 0) return `${minutes}m${seconds}s`;
+  return `${seconds}s`;
 }
 
 /** 格式化重置时间为倒计时文本（带 i18n 模板） */
 function formatResetTime(
   resetsAt: string | null,
   t: (key: string, options?: Record<string, string>) => string,
+  remainsTimeMs?: number | null,
 ): string | null {
-  const time = countdownStr(resetsAt);
+  const time = countdownStr(resetsAt, remainsTimeMs);
   if (!time) return null;
   return t("subscription.resetsIn", { time });
 }
@@ -312,7 +330,7 @@ export const TierBadge: React.FC<{
   const label = TIER_I18N_KEYS[tier.name]
     ? t(TIER_I18N_KEYS[tier.name])
     : tier.name;
-  const countdown = countdownStr(tier.resetsAt);
+  const countdown = countdownStr(tier.resetsAt, tier.remainsTimeMs);
 
   const hasUsd = tier.usedValueUsd != null && tier.maxValueUsd != null;
   // MiniMax: 绝对次数（usedCount/totalCount, unit 通常 "count"）
@@ -322,16 +340,25 @@ export const TierBadge: React.FC<{
   return (
     <div className="flex items-center gap-0.5">
       <span className="text-gray-500 dark:text-gray-400">{label}:</span>
-      <span
-        className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
-      >
-        {t("subscription.utilization", { value: Math.round(tier.utilization) })}
-      </span>
-      {hasAbsolute && (
-        <span className="text-muted-foreground/60">
-          ({Math.round(tier.usedCount as number)}/
-          {Math.round(tier.totalCount as number)}
-          {tier.countUnit ? ` ${tier.countUnit}` : ""})
+      {hasAbsolute ? (
+        // 绝对数路径：把百分比与 X/Y 合并成 "X%/Y% count" 形式（与官方 web 风格一致）。
+        // - used%  = round(used) (作为 100% 的倍数) — 用户期望原始数字
+        // - total% = round(total) (作为 100% 的倍数) — 用户期望原始数字
+        // 例:used=107, total=150 → "107%/150% count"
+        // 例:used=7, total=100 → "7%/100% count"
+        // 真实使用率仍用 utilization 决定颜色。
+        <span
+          className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
+        >
+          {Math.round(tier.usedCount as number)}%/
+          {Math.round(tier.totalCount as number)}%
+          {tier.countUnit ? ` ${tier.countUnit}` : ""}
+        </span>
+      ) : (
+        <span
+          className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
+        >
+          {t("subscription.utilization", { value: Math.round(tier.utilization) })}
         </span>
       )}
       {hasUsd && (
@@ -357,7 +384,10 @@ const TierBar: React.FC<{
   const label = TIER_I18N_KEYS[tier.name]
     ? t(TIER_I18N_KEYS[tier.name])
     : tier.name;
-  const resetText = formatResetTime(tier.resetsAt, t);
+  const resetText = formatResetTime(tier.resetsAt, t, tier.remainsTimeMs);
+
+  const hasAbsolute =
+    tier.usedCount != null && tier.totalCount != null;
 
   return (
     <div className="flex items-center gap-3 text-xs">
@@ -389,7 +419,11 @@ const TierBar: React.FC<{
         <span
           className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
         >
-          {Math.round(tier.utilization)}%
+          {hasAbsolute
+            ? `${Math.round(tier.usedCount as number)}%/${Math.round(tier.totalCount as number)}%${
+                tier.countUnit ? ` ${tier.countUnit}` : ""
+              }`
+            : `${Math.round(tier.utilization)}%`}
         </span>
         {resetText && (
           <span

--- a/src/components/SubscriptionQuotaFooter.tsx
+++ b/src/components/SubscriptionQuotaFooter.tsx
@@ -315,6 +315,9 @@ export const TierBadge: React.FC<{
   const countdown = countdownStr(tier.resetsAt);
 
   const hasUsd = tier.usedValueUsd != null && tier.maxValueUsd != null;
+  // MiniMax: 绝对次数（usedCount/totalCount, unit 通常 "count"）
+  const hasAbsolute =
+    tier.usedCount != null && tier.totalCount != null;
 
   return (
     <div className="flex items-center gap-0.5">
@@ -324,6 +327,13 @@ export const TierBadge: React.FC<{
       >
         {t("subscription.utilization", { value: Math.round(tier.utilization) })}
       </span>
+      {hasAbsolute && (
+        <span className="text-muted-foreground/60">
+          ({Math.round(tier.usedCount as number)}/
+          {Math.round(tier.totalCount as number)}
+          {tier.countUnit ? ` ${tier.countUnit}` : ""})
+        </span>
+      )}
       {hasUsd && (
         <span className="text-muted-foreground/60">
           (${tier.usedValueUsd!.toFixed(2)}/${tier.maxValueUsd!.toFixed(2)})
@@ -402,7 +412,7 @@ const SubscriptionQuotaFooter: React.FC<SubscriptionQuotaFooterProps> = ({
   appId,
   inline = false,
   isCurrent = false,
-  autoQueryInterval = 5,
+  autoQueryInterval = 1,
 }) => {
   const {
     data: quota,

--- a/src/components/TokenPlanQuotaFooter.tsx
+++ b/src/components/TokenPlanQuotaFooter.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { RefreshCw, AlertCircle, Clock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ProviderMeta } from "@/types";
+import type { AppId } from "@/lib/api";
+import { TEMPLATE_TYPES } from "@/config/constants";
+import {
+  TierBadge,
+  TIER_I18N_KEYS,
+} from "@/components/SubscriptionQuotaFooter";
+import { useUsageQuery } from "@/lib/query/queries";
+
+interface TokenPlanQuotaFooterProps {
+  providerId: string;
+  appId: AppId;
+  meta?: ProviderMeta;
+  inline?: boolean;
+}
+
+/** 格式化相对时间（与 UsageFooter 一致） */
+function formatRelativeTime(
+  timestamp: number,
+  now: number,
+  t: (key: string, options?: { count?: number }) => string,
+): string {
+  const diff = Math.floor((now - timestamp) / 1000);
+  if (diff < 60) return t("usage.justNow");
+  if (diff < 3600)
+    return t("usage.minutesAgo", { count: Math.floor(diff / 60) });
+  if (diff < 86400)
+    return t("usage.hoursAgo", { count: Math.floor(diff / 3600) });
+  return t("usage.daysAgo", { count: Math.floor(diff / 86400) });
+}
+
+/** 从 UsageData.extra 里解析 resets_at：可能是 ISO 字符串也可能是 JSON。 */
+function parseResetsAt(extra: string | undefined | null): string | null {
+  if (!extra) return null;
+  const trimmed = extra.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("{")) {
+    try {
+      const obj = JSON.parse(trimmed);
+      const v = obj?.resetsAt;
+      return typeof v === "string" ? v : null;
+    } catch {
+      return null;
+    }
+  }
+  return trimmed;
+}
+
+/**
+ * Coding Plan (TOKEN_PLAN) 供应商的 5h/7d 配额条。
+ *
+ * 数据来源：与 provider 级 `useUsageQuery` 共享同一份缓存——Rust 端的
+ * `query_special_template` 把 Coding Plan 的 5h/7d tier 列表构造成
+ * `UsageData[]`，这里直接渲染。
+ *
+ * **不在 per-key query 路径上重复**：Coding Plan 配额是账号级而非 key 级——
+ * 同一个账号的 N 把 key 共用一份 5h/7d，复制到每一行只会误导用户。
+ * ProviderCard 的 `hasKeyPool` 分支不再吞掉 inline 槽，本组件始终可见；
+ * KeyPoolList 在 TOKEN_PLAN 下也不渲染 usage 条。
+ */
+export const TokenPlanQuotaFooter: React.FC<TokenPlanQuotaFooterProps> = ({
+  providerId,
+  appId,
+  meta,
+  inline = false,
+}) => {
+  const { t } = useTranslation();
+
+  // 复用 useUsageQuery：autoQueryInterval 由 provider.meta.usage_script 控制。
+  // 数据由 ProviderCard 上层同样的 useUsageQuery 写进 React Query 缓存
+  // （key 是 `usageKeys.script(providerId, appId)`），本组件只是消费者——不要
+  // 再加 `enabled: isCurrent` 之类的门控，否则缓存里有数据也会被跳过，
+  // inline 槽空空如也。ProviderCard 自己的 useUsageQuery 已经判过
+  // usageEnabled / isOfficialSubscriptionUsage，这里共享同一条 query。
+  const {
+    data,
+    isFetching,
+    refetch,
+    dataUpdatedAt,
+  } = useUsageQuery(providerId, appId, {
+    autoQueryInterval: meta?.usage_script?.autoQueryInterval ?? 1,
+  });
+
+  // 30 秒刷一次「相对时间」—— hooks 必须在 early return 之前调用，遵守
+  // Rules of Hooks。dataUpdatedAt 变化时重建定时器。
+  const [now, setNow] = React.useState(Date.now());
+  React.useEffect(() => {
+    if (!dataUpdatedAt) return;
+    const id = setInterval(() => setNow(Date.now()), 30000);
+    return () => clearInterval(id);
+  }, [dataUpdatedAt]);
+
+  if (!data) return null;
+
+  if (!data.success) {
+    if (inline) {
+      return (
+        <div className="inline-flex items-center gap-2 text-xs rounded-lg border border-border-default bg-card px-3 py-2 shadow-sm">
+          <div className="flex items-center gap-1.5 text-red-500 dark:text-red-400">
+            <AlertCircle size={12} />
+            <span>{data.error || t("subscription.queryFailed")}</span>
+          </div>
+          <button
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="p-1 rounded hover:bg-muted transition-colors disabled:opacity-50 flex-shrink-0"
+            title={t("subscription.refresh")}
+          >
+            <RefreshCw size={12} className={isFetching ? "animate-spin" : ""} />
+          </button>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  const tiers = (data.data || []).filter((d) => {
+    const name = (d.planName ?? "").trim();
+    return name in TIER_I18N_KEYS;
+  });
+  if (tiers.length === 0) return null;
+
+  if (inline) {
+    return (
+      <div className="flex flex-col items-end gap-1 text-xs whitespace-nowrap flex-shrink-0">
+        <div className="flex items-center gap-2 justify-end">
+          <span className="text-[10px] text-muted-foreground/70 flex items-center gap-1">
+            <Clock size={10} />
+            {dataUpdatedAt
+              ? formatRelativeTime(dataUpdatedAt, now, t)
+              : t("usage.never", { defaultValue: "从未更新" })}
+          </span>
+          <button
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="p-1 rounded hover:bg-muted transition-colors disabled:opacity-50 flex-shrink-0 text-muted-foreground"
+            title={t("subscription.refresh")}
+          >
+            <RefreshCw size={12} className={isFetching ? "animate-spin" : ""} />
+          </button>
+        </div>
+        <div className="flex items-center gap-2">
+          {tiers.map((tier) => (
+            <TierBadge
+              key={(tier.planName ?? "").trim()}
+              tier={{
+                name: (tier.planName ?? "").trim(),
+                utilization: tier.used ?? 0,
+                resetsAt: parseResetsAt(tier.extra),
+              }}
+              t={t}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+/** 类型守卫：ProviderCard 用它判断是否走 TOKEN_PLAN 渲染分支 */
+export function isTokenPlanProvider(meta?: ProviderMeta): boolean {
+  return meta?.usage_script?.templateType === TEMPLATE_TYPES.TOKEN_PLAN;
+}

--- a/src/components/TokenPlanQuotaFooter.tsx
+++ b/src/components/TokenPlanQuotaFooter.tsx
@@ -32,21 +32,43 @@ function formatRelativeTime(
   return t("usage.daysAgo", { count: Math.floor(diff / 86400) });
 }
 
-/** 从 UsageData.extra 里解析 resets_at：可能是 ISO 字符串也可能是 JSON。 */
-function parseResetsAt(extra: string | undefined | null): string | null {
-  if (!extra) return null;
+/** 从 UsageData.extra 里解析结构化字段：可能是 JSON（含 resetsAt/usedCount/totalCount/countUnit），
+ *  也可能只是 ISO 字符串（旧 OFFICIAL_SUBSCRIPTION 路径）。
+ */
+function parseExtraObject(extra: string | undefined | null): {
+  resetsAt: string | null;
+  usedCount: number | null;
+  totalCount: number | null;
+  countUnit: string | null;
+  remainsTimeMs: number | null;
+} {
+  const empty = {
+    resetsAt: null,
+    usedCount: null,
+    totalCount: null,
+    countUnit: null,
+    remainsTimeMs: null,
+  };
+  if (!extra) return empty;
   const trimmed = extra.trim();
-  if (!trimmed) return null;
-  if (trimmed.startsWith("{")) {
-    try {
-      const obj = JSON.parse(trimmed);
-      const v = obj?.resetsAt;
-      return typeof v === "string" ? v : null;
-    } catch {
-      return null;
-    }
+  if (!trimmed) return empty;
+  if (!trimmed.startsWith("{")) {
+    // 纯 ISO 字符串（旧路径：直接当 resetsAt 用）
+    return { ...empty, resetsAt: trimmed };
   }
-  return trimmed;
+  try {
+    const obj = JSON.parse(trimmed);
+    return {
+      resetsAt: typeof obj?.resetsAt === "string" ? obj.resetsAt : null,
+      usedCount: typeof obj?.usedCount === "number" ? obj.usedCount : null,
+      totalCount: typeof obj?.totalCount === "number" ? obj.totalCount : null,
+      countUnit: typeof obj?.countUnit === "string" ? obj.countUnit : null,
+      remainsTimeMs:
+        typeof obj?.remainsTimeMs === "number" ? obj.remainsTimeMs : null,
+    };
+  } catch {
+    return empty;
+  }
 }
 
 /**
@@ -143,17 +165,27 @@ export const TokenPlanQuotaFooter: React.FC<TokenPlanQuotaFooterProps> = ({
           </button>
         </div>
         <div className="flex items-center gap-2">
-          {tiers.map((tier) => (
-            <TierBadge
-              key={(tier.planName ?? "").trim()}
-              tier={{
-                name: (tier.planName ?? "").trim(),
-                utilization: tier.used ?? 0,
-                resetsAt: parseResetsAt(tier.extra),
-              }}
-              t={t}
-            />
-          ))}
+          {tiers.map((tier) => {
+            const parsed = parseExtraObject(tier.extra);
+            return (
+              <TierBadge
+                key={(tier.planName ?? "").trim()}
+                tier={{
+                  name: (tier.planName ?? "").trim(),
+                  utilization: tier.used ?? 0,
+                  resetsAt: parsed.resetsAt,
+                  // 透传 absolute count（MiniMax / Zhipu），让 TierBadge 走 hasAbsolute 分支
+                  // 渲染「X / Y count」+ 真实百分比（可超 100%）。
+                  usedCount: parsed.usedCount,
+                  totalCount: parsed.totalCount,
+                  countUnit: parsed.countUnit,
+                  // 透传服务端精确剩余毫秒数,优先于 end_time - Date.now()。
+                  remainsTimeMs: parsed.remainsTimeMs,
+                }}
+                t={t}
+              />
+            );
+          })}
         </div>
       </div>
     );

--- a/src/components/UsageFooter.tsx
+++ b/src/components/UsageFooter.tsx
@@ -30,6 +30,14 @@ function toQuotaTier(data: UsageData): QuotaTier {
         usedValueUsd: parsed.usedValueUsd ?? null,
         maxValueUsd: parsed.maxValueUsd ?? null,
         planLabel: parsed.planLabel ?? null,
+        // MiniMax / Zhipu 绝对次数（与官方 web "X / Y" 对齐）。
+        // 后端 query_special_template 在 extra JSON 中提供；
+        // 旧 provider 没塞时保持 undefined，由 TierBadge 走百分比路径。
+        usedCount: typeof parsed.usedCount === "number" ? parsed.usedCount : null,
+        totalCount: typeof parsed.totalCount === "number" ? parsed.totalCount : null,
+        countUnit: typeof parsed.countUnit === "string" ? parsed.countUnit : null,
+        remainsTimeMs:
+          typeof parsed.remainsTimeMs === "number" ? parsed.remainsTimeMs : null,
       };
     } catch {
       // fall through to plain string

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -552,10 +552,11 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
       // Coding Plan 模板使用专用 API
       if (selectedTemplate === TEMPLATE_TYPES.TOKEN_PLAN) {
         // ZenMux 手填 baseUrl/apiKey；火山是 native 供应商，baseUrl 走推理配置，
-        // 另用账号 AK/SK 签名查询控制面用量。
+        // 另用账号 AK/SK 签名查询控制面用量。MiniMax 需要 GroupId 才能取到真实数据。
         const isZenMux = script.codingPlanProvider === "zenmux";
         const isVolcengine = script.codingPlanProvider === "volcengine";
         const isZhipuTeam = script.codingPlanProvider === "zhipu_team";
+        const isMiniMax = script.codingPlanProvider === "minimax";
         const baseUrl = isZenMux
           ? (script.baseUrl ?? "")
           : (providerCredentials.baseUrl ?? "");
@@ -571,6 +572,7 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
           isZhipuTeam ? script.codingPlanProvider : undefined,
           isZhipuTeam ? script.teamOrganizationId : undefined,
           isZhipuTeam ? script.teamProjectId : undefined,
+          isMiniMax ? script.groupId : undefined,
         );
         if (quota.success && quota.tiers.length > 0) {
           const summary = quota.tiers
@@ -581,13 +583,24 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
             closeButton: true,
           });
           // 将结果转换为 UsageResult 格式更新缓存
-          const usageData = quota.tiers.map((tier) => ({
-            planName: tier.name,
-            remaining: 100 - tier.utilization,
-            total: 100,
-            used: tier.utilization,
-            unit: "%",
-          }));
+          // 优先用绝对值（usedCount/totalCount, MiniMax 风格 "7 / 100"），
+          // 没有再回退到 utilization 百分比（其他 provider 都走这条）。
+          const usageData = quota.tiers.map((tier) => {
+            const hasAbsolute =
+              tier.usedCount != null && tier.totalCount != null;
+            const total = hasAbsolute ? (tier.totalCount as number) : 100;
+            const used = hasAbsolute
+              ? (tier.usedCount as number)
+              : tier.utilization;
+            const unit = hasAbsolute ? (tier.countUnit || "count") : "%";
+            return {
+              planName: tier.name,
+              remaining: total - used,
+              total,
+              used,
+              unit,
+            };
+          });
           queryClient.setQueryData(["usage", provider.id, appId], {
             success: true,
             data: usageData,
@@ -1440,6 +1453,58 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                 </div>
               )}
 
+            {/* MiniMax：必须提供 GroupId 才能取到真实用量（缺省时接口返回 0/100 占位） */}
+            {selectedTemplate === TEMPLATE_TYPES.TOKEN_PLAN &&
+              script.codingPlanProvider === "minimax" && (
+                <div className="space-y-4">
+                  <div>
+                    <h4 className="text-sm font-medium text-foreground">
+                      {t("usageScript.credentialsConfig")}
+                    </h4>
+                    <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                      {t("usageScript.minimaxGroupIdHint")}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1.5">
+                      {t("usageScript.minimaxGroupIdLink")}{" "}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const isEn = (providerCredentials.baseUrl ?? "")
+                            .toLowerCase()
+                            .includes("minimax.io");
+                          settingsApi.openExternal(
+                            isEn
+                              ? "https://platform.minimax.io/user-center/basic-information"
+                              : "https://platform.minimaxi.com/user-center/basic-information",
+                          );
+                        }}
+                        className="inline-flex items-center gap-1 text-blue-400 dark:text-blue-500 hover:text-blue-500 dark:hover:text-blue-400 transition-colors break-all align-baseline underline-offset-2 hover:underline"
+                      >
+                        {t("usageScript.minimaxGroupIdUrlLabel")}
+                        <ExternalLink size={12} className="shrink-0" />
+                      </button>
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="usage-minimax-group-id">
+                      {t("usageScript.minimaxGroupId")}
+                    </Label>
+                    <Input
+                      id="usage-minimax-group-id"
+                      type="text"
+                      value={script.groupId || ""}
+                      onChange={(e) =>
+                        setScript({ ...script, groupId: e.target.value })
+                      }
+                      placeholder="1686734307050816"
+                      autoComplete="off"
+                      className="border-white/10"
+                    />
+                  </div>
+                </div>
+              )}
+
             {/* 通用配置（始终显示） */}
             <div className="grid gap-4 md:grid-cols-2 pt-4 border-t border-white/10">
               {/* 超时时间 */}
@@ -1482,7 +1547,7 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
                   min={0}
                   max={1440}
                   value={
-                    script.autoQueryInterval ?? script.autoIntervalMinutes ?? 5
+                    script.autoQueryInterval ?? script.autoIntervalMinutes ?? 1
                   }
                   onChange={(e) =>
                     setScript({

--- a/src/components/providers/ApiKeyListSection.tsx
+++ b/src/components/providers/ApiKeyListSection.tsx
@@ -1,0 +1,988 @@
+import { useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove as dndArrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  Eye,
+  EyeOff,
+  Plus,
+  Trash2,
+  CircleDot,
+  Loader2,
+  GripVertical,
+  AlertCircle,
+  Clock,
+  Pencil,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { ApiKeyStatusBar } from "./ApiKeyStatusBar";
+import type { UsageResult } from "@/types";
+import { cn } from "@/lib/utils";
+import { tagColorClasses } from "@/utils/tagColor";
+import {
+  useApiKeys,
+  pickActiveKey,
+  useCreateApiKey,
+  useUpdateApiKey,
+  useDeleteApiKey,
+  useSetActiveApiKey,
+  useReorderApiKeys,
+} from "@/lib/query/apiKey";
+import { usageApi } from "@/lib/api/usage";
+import type { ApiKeyDto } from "@/lib/api/apiKey";
+import type { AppId } from "@/lib/api";
+
+/**
+ * Per-provider API key pool editor.
+ *
+ * - Lists existing keys (up/down reorder; full drag-sort is a polish pass).
+ * - Add / edit / delete / set-active.
+ * - Surfaces runtime state (cooldown, failure count, last error) that
+ *   the proxy's KeyRing writes back to the DB.
+ *
+ * Independent of the parent form's `settingsConfig`. The legacy `apiKey`
+ * field in the JSON still exists for non-pool clients; Phase 10 will
+ * keep that field in sync with `provider_api_keys.is_active=1` when
+ * the proxy takes over.
+ */
+interface ApiKeyListSectionProps {
+  appId: AppId;
+  /**
+   * `null` while the provider hasn't been saved yet (we don't have a
+   * primary key to hang keys off of). The section renders an inline
+   * hint instead of an empty list.
+   */
+  providerId: string | null;
+}
+
+export function ApiKeyListSection({ appId, providerId }: ApiKeyListSectionProps) {
+  const { t } = useTranslation();
+  const enabled = !!providerId;
+  const { data: keys = [], isLoading } = useApiKeys(
+    enabled ? providerId : null,
+    appId,
+  );
+  const activeKey = pickActiveKey(keys);
+
+  // 每把 key 自己的用量：useQueries 扇出，React Query 按 (keyId, appId) 自动
+  // 去重——同 keyId 多次出现（拖拽、re-render）只发一次请求。结果按 sortedKeys
+  // 的顺序铺到 row 上。注意：query key 故意不带 providerId；keyId 唯一即可。
+  // 用户切到另一个 provider 时，cache 里这份 (keyId, appId) 也保留（10 分钟
+  // gcTime），不会因为切走立刻扔掉——避免来回切时反复闪"loading"。
+  const perKeyQueries = useQueries({
+    queries: keys.map((k) => ({
+      queryKey: ["keyUsage", k.id, appId] as const,
+      queryFn: () => {
+        if (!providerId) {
+          return Promise.resolve({
+            success: false,
+            data: undefined,
+            error: "no providerId",
+          } as UsageResult);
+        }
+        return usageApi.queryForKey(providerId, k.id, appId);
+      },
+      enabled: enabled && k.enabled,
+      retry: 1,
+      retryDelay: 1500,
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+    })),
+  });
+  // 把 query 结果按 keyId 建索引，避免 O(N) 每次 O(N^2) 找 row 对应数据。
+  const usageByKeyId = new Map<string, UsageResult | null>();
+  keys.forEach((k, i) => {
+    const data = perKeyQueries[i]?.data;
+    usageByKeyId.set(k.id, (data as UsageResult | undefined) ?? null);
+  });
+
+  const [addingNew, setAddingNew] = useState(false);
+  const [editingKeyId, setEditingKeyId] = useState<string | null>(null);
+  // 待删除的 key——点击行内回收站图标先弹确认框，确认后才真正调
+  // mutation。删除是不可逆操作，给个二次确认比 toast 「已删除」更稳。
+  const [pendingDeleteKeyId, setPendingDeleteKeyId] = useState<string | null>(
+    null,
+  );
+  // 5h / 7d 窗口到点重置时由 ApiKeyStatusBar 回调到本 section——invalidate
+  // 对应 (keyId, appId) 缓存 + 整个 pool 的 list。React Query 自动 refetch
+  // 拿到新窗口的 quota 数据，bar 实时更新。
+  // 与 KeyPoolList::handleKeyResetReached 同一语义。
+  const queryClient = useQueryClient();
+  const handleKeyResetReached = useCallback(
+    (keyId: string) => {
+      queryClient.invalidateQueries({
+        queryKey: ["keyUsage", keyId, appId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["apiKeys", providerId, appId],
+      });
+    },
+    [queryClient, providerId, appId],
+  );
+  // 任一 quota 100% 的 key id 集合——由 ApiKeyStatusBar 通过 onExhaustedChange
+  // 上报。row 用它来给整行加红色背景，弱化「bar 不可见 = 信号丢失」。
+  // 用 Set 而非单个 boolean：每把 key 独立上报，互不污染。
+  const [exhaustedKeyIds, setExhaustedKeyIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  // Active key 一律置顶——它是用户最关心的那把，列表里也最容易被误以为在轮换。
+  // 其他 key 保持 sortIndex 顺序不变。
+  const sortedKeys = activeKey
+    ? [
+        ...keys.filter((k) => k.id === activeKey.id),
+        ...keys.filter((k) => k.id !== activeKey.id),
+      ]
+    : keys;
+
+  const setActive = useSetActiveApiKey();
+  const remove = useDeleteApiKey();
+  const reorder = useReorderApiKeys();
+
+  // 拖拽落点回调。PointerSensor + 8px activation 距离防止按钮点击误触发拖拽。
+  // 实际 reorder 走的是 arrayMove — 数据库里写回新顺序后，sortedKeys 会重新
+  // 计算把 active 放到顶，UI 永远一致。按 DB 顺序算索引，与 active 解耦。
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+  );
+
+  const onDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id || !providerId) return;
+      const oldIndex = keys.findIndex((k) => k.id === active.id);
+      const newIndex = keys.findIndex((k) => k.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      const next = dndArrayMove(keys, oldIndex, newIndex);
+      reorder.mutate({
+        appType: appId,
+        providerId,
+        orderedIds: next.map((k) => k.id),
+      });
+    },
+    [providerId, appId, keys, reorder],
+  );
+
+  if (!enabled) {
+    return (
+      <div className="rounded-lg border border-dashed border-border-default p-4 text-sm text-muted-foreground">
+        {t("apiKeyList.saveProviderFirst", {
+          defaultValue: "保存供应商后可管理多把 API Key",
+        })}
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground p-2">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        {t("common.loading", { defaultValue: "加载中…" })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h4 className="text-sm font-medium text-foreground">
+            {t("apiKeyList.title", { defaultValue: "API Key 池" })}
+          </h4>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {t("apiKeyList.subtitle", {
+              defaultValue:
+                "为这个供应商维护多把 key。代理模式下会自动轮换，星标 = 写入 settings.json 的那把。",
+            })}
+          </p>
+        </div>
+        {!addingNew && (
+          <Button
+            size="sm"
+            variant="outline"
+            type="button"
+            onClick={() => setAddingNew(true)}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            {t("apiKeyList.add", { defaultValue: "添加 Key" })}
+          </Button>
+        )}
+      </div>
+
+      {keys.length === 0 && !addingNew ? (
+        <div className="rounded-lg border border-dashed border-border-default p-6 text-center text-sm text-muted-foreground">
+          {t("apiKeyList.empty", {
+            defaultValue: "还没有任何 key，点击右上角添加。",
+          })}
+        </div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={onDragEnd}
+        >
+          <SortableContext
+            items={sortedKeys.map((k) => k.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="space-y-2">
+              {sortedKeys.map((k) =>
+                editingKeyId === k.id ? (
+                  // 编辑态的 row 不参与排序——拖它会让交互体验很奇怪。
+                  <EditKeyInlineForm
+                    key={k.id}
+                    apiKey={k}
+                    onDone={() => setEditingKeyId(null)}
+                    onCancel={() => setEditingKeyId(null)}
+                  />
+                ) : (
+                  <ApiKeyRow
+                    key={k.id}
+                    apiKey={k}
+                    isActive={k.id === activeKey?.id}
+                    onSetActive={() =>
+                      setActive.mutate({
+                        providerId,
+                        appType: appId,
+                        keyId: k.id,
+                      })
+                    }
+                    onDelete={() => setPendingDeleteKeyId(k.id)}
+                    onEditStart={() => setEditingKeyId(k.id)}
+                    usage={usageByKeyId.get(k.id) ?? null}
+                    usageEnabled={
+                      // 仅当这把 key 的 query 真的成功且有数据时，才让
+                      // ApiKeyStatusBar 渲染配额条。
+                      // 注意：这里**不**检查 k.enabled——key 5h/7d 100% 后
+                      // 会自动 enabled=false，但用户仍然想看到 100% 的
+                      // 红色 row + 进度条（“这把废了”信号），不能让 bar 消失。
+                      // per-key query 在 enabled=false 后停止 fetch，但
+                      // React Query 缓存保留上一份成功结果——上面 success 检查
+                      // 仍为 true，bar 继续渲染。
+                      (() => {
+                        const r = usageByKeyId.get(k.id);
+                        return !!r?.success && !!r.data && r.data.length > 0;
+                      })()
+                    }
+                    isExhausted={exhaustedKeyIds.has(k.id)}
+                    onExhaustedChange={(ex) => {
+                      setExhaustedKeyIds((prev) => {
+                        const next = new Set(prev);
+                        if (ex) next.add(k.id);
+                        else next.delete(k.id);
+                        return next;
+                      });
+                    }}
+                    onFiveHourResetReached={() => handleKeyResetReached(k.id)}
+                  />
+                ),
+              )}
+              {addingNew && (
+                <NewKeyInlineForm
+                  providerId={providerId}
+                  appId={appId}
+                  onDone={() => setAddingNew(false)}
+                  onCancel={() => setAddingNew(false)}
+                />
+              )}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <ConfirmDialog
+        isOpen={pendingDeleteKeyId !== null}
+        title={t("apiKeyList.deleteConfirmTitle", {
+          defaultValue: "Delete API Key?",
+        })}
+        message={t("apiKeyList.deleteConfirmMessage", {
+          label:
+            keys.find((k) => k.id === pendingDeleteKeyId)?.label ||
+            t("apiKeyList.unnamed", { defaultValue: "(unnamed)" }),
+          defaultValue:
+            'Are you sure you want to delete "{{label}}"? This action cannot be undone.',
+        })}
+        confirmText={t("common.delete", { defaultValue: "Delete" })}
+        cancelText={t("common.cancel")}
+        variant="destructive"
+        onConfirm={() => {
+          if (pendingDeleteKeyId) {
+            remove.mutate(pendingDeleteKeyId);
+          }
+          setPendingDeleteKeyId(null);
+        }}
+        onCancel={() => setPendingDeleteKeyId(null)}
+      />
+    </div>
+  );
+}
+
+// =====================================================================
+// Row
+// =====================================================================
+
+interface ApiKeyRowProps {
+  apiKey: ApiKeyDto;
+  isActive: boolean;
+  onSetActive: () => void;
+  onDelete: () => void;
+  onEditStart: () => void;
+  /** account-level usage 数据——下放到每个 key 的 status bar 上 */
+  usage?: UsageResult | null;
+  /** provider 是否启用了 usage_script */
+  usageEnabled?: boolean;
+  /** 5h / 7d 窗口到点重置时由 status bar 回调——刷新该 key 的用量缓存 */
+  onFiveHourResetReached?: () => void;
+  /** 任一 quota 100% 时为 true（由 ApiKeyStatusBar 上报）——row 用这个加红 */
+  isExhausted?: boolean;
+  /** ApiKeyStatusBar 上报 quota 状态的回调 */
+  onExhaustedChange?: (exhausted: boolean) => void;
+}
+
+function ApiKeyRow({
+  apiKey,
+  isActive,
+  onSetActive,
+  onDelete,
+  onEditStart,
+  usage,
+  usageEnabled = false,
+  isExhausted = false,
+  onExhaustedChange,
+  onFiveHourResetReached,
+}: ApiKeyRowProps) {
+  const { t } = useTranslation();
+  const update = useUpdateApiKey();
+  const [showKey, setShowKey] = useState(false);
+  const inCooldown = apiKey.cooldownUntil * 1000 > Date.now();
+
+  // dnd-kit 拖拽：只有 GripVertical handle 触发 drag，其它区域（按钮、输入）
+  // 仍然保持原有点击行为。CSS.Transform 让 row 在拖动时跟随光标，
+  // transition 让松手时动画回归原位。
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: apiKey.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    // 拖动中的 row 在视觉上抬起来一层，避免与目标位置混淆。
+    zIndex: isDragging ? 10 : undefined,
+    opacity: isDragging ? 0.85 : 1,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      // 把 dnd-kit 的 listeners 放到 <li> 上，让整行可拖——比之前
+      // 「必须抓到 16px 的 ⋮⋮ grip 图标才拖得动」直观得多。
+      //
+      // 三个细节：
+      // 1) `cursor-grab / active:cursor-grabbing` 给整行一个「可拖」指针，
+      //    视觉上明确它是 sortable item。
+      // 2) `touch-none` = `touch-action: none`，让 PointerSensor 在
+      //    移动端能正确捕获手势（不让浏览器先抢去做滚动）。
+      // 3) `select-none` 防止拖动时高亮选中 token 文本。
+      // 4) `{...listeners} {...attributes}` 在行上展开 dnd-kit 提供的
+      //    `onPointerDown / onKeyDown` 等事件 + ARIA attributes。
+      // 5) 右侧 actions 列在子 wrapper 上 `e.stopPropagation()`，
+      //    点 toggle / set-active / edit / delete 不会被当成「开始拖」
+      //    ——PointerSensor 的 distance: 8 已经过滤「点一下就松手」，
+      //    但显式 stop 让按钮在拖动阈值临界时也更稳。
+      {...listeners}
+      {...attributes}
+      className={cn(
+        "rounded-lg border bg-background p-3 transition-colors relative touch-none select-none",
+        isDragging ? "cursor-grabbing" : "cursor-grab",
+        isActive
+          ? // Active key: 与 provider-list 页面的 SortableKeyRow 用同一套
+          // 浅蓝边 + 浅蓝底 + 60% 透明边框——比之前的 4px 左条 + 100% 边框
+          // 弱化一档，让 row 看起来还是列表项而不是按钮。两侧面板
+          // （编辑 / provider-list）风格一致，扫一眼不卡。
+            "border-blue-400/60 bg-blue-50/40 dark:border-blue-700/50 dark:bg-blue-950/20"
+          : isExhausted
+            ? // 任一 quota 100%——与 provider-list 同一档浅红；红色足以
+              // 刺眼提示，且与 active 共用同一「柔和高亮」语汇，不抢戏。
+              "border-red-400/60 bg-red-50/40 dark:border-red-700/50 dark:bg-red-950/20"
+            : "border-border-default hover:border-border-default/80",
+      )}
+    >
+      {/* items-start 让 grip / content / actions 三列顶部对齐。
+          旧版 items-center 在 content 有 5 行（name + code + tags + error + status bar）
+          时把 action 按钮挤到中间，视觉上很乱。 */}
+      <div className="flex items-start gap-2.5">
+        {/* GripVertical 现在是纯视觉提示——实际 drag handle 是 <li> 自身
+            （dnd-kit listeners 已经在 li 上展开）。这样用户可以抓整行
+            任意位置拖，不必对准 16px 的图标。
+            之前这里的「上下移」按钮已删除——拖拽是唯一的 reorder 入口，
+            双入口重复且方向冲突（旧 bug：active 钉顶导致上下移看似无反应）。 */}
+        <GripVertical
+          className="h-4 w-4 mt-1 text-muted-foreground/60 pointer-events-none shrink-0"
+          aria-label={t("apiKeyList.dragHandle", {
+            defaultValue: "拖动以重新排序",
+          })}
+        />
+
+        {/* content 列：用 grid 把 Row 1（label）拆成「标签 + 状态 badge /
+            actions」三段横向铺开；Row 2-5 用 col-span-2 跨满整行宽。
+            比之前「右栏整列放 4 个按钮」省一行高度，row 在编辑表单
+            列表里更紧凑。min-w-0 是 grid 子项能真正缩到 0 的开关。
+            三个动作按钮（设为默认 / 编辑 / 删除）放在标签行末端，用
+            justify-self: end 把它们对齐到行末。 */}
+        <div className="grid flex-1 min-w-0 grid-cols-[1fr_auto] gap-x-2 gap-y-2 items-center">
+          {/* Row 1: 名字 + 状态 badge（左） — 名字 truncate 让长 label 不
+              把 actions 挤出列。actions 在第二个 grid 单元里。 */}
+          <div className="flex items-center gap-2 flex-wrap min-w-0">
+            <span className="text-sm font-medium truncate min-w-0">
+              {apiKey.label || t("apiKeyList.unnamed", { defaultValue: "(未命名)" })}
+            </span>
+            {isActive && (
+              <Badge
+                variant="default"
+                className="text-[10px] font-bold bg-blue-500 hover:bg-blue-500 text-white gap-1 px-1.5"
+              >
+                <CircleDot className="h-2.5 w-2.5 fill-current" />
+                {t("apiKeyList.active", { defaultValue: "Active" })}
+              </Badge>
+            )}
+            {!apiKey.enabled && (
+              <Badge variant="secondary" className="text-[10px]">
+                {t("apiKeyList.disabled", { defaultValue: "已停用" })}
+              </Badge>
+            )}
+            {inCooldown && (
+              <Badge variant="outline" className="text-[10px] text-amber-600">
+                <Clock className="h-3 w-3 mr-1" />
+                {t("apiKeyList.cooldown", { defaultValue: "冷却中" })}
+              </Badge>
+            )}
+            {apiKey.failureCount > 0 && !inCooldown && (
+              <Badge variant="outline" className="text-[10px] text-orange-600">
+                <AlertCircle className="h-3 w-3 mr-1" />
+                {Math.min(apiKey.failureCount, 5)}
+              </Badge>
+            )}
+          </div>
+
+          {/* Row 1 actions: 设为默认 / 编辑 / 删除 / 启用停用，与 label
+              同一行右端。顺序按"破坏性递增 + 状态控制"：先 setActive
+              （设置主用）→ edit（修改元数据）→ delete（破坏性最
+              高）；Switch 是状态控件，放最末端方便扫到。
+              子 wrapper onPointerDown stopPropagation 防止点按钮被当成
+              "开始拖"——PointerSensor 的 distance: 8 已经过滤点击，但
+              显式 stop 让 8px 临界抖动也不会误触。Switch 自身是 Radix
+              button，其内部 pointer 事件已经处理；外面加一层 stop 让
+              toggle 拖动阈值临界时也不误触。 */}
+          <div
+            className="flex items-center gap-0.5 shrink-0"
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              onClick={onSetActive}
+              disabled={isActive}
+              onPointerDown={(e) => e.stopPropagation()}
+              title={t("apiKeyList.setActive", { defaultValue: "设为默认" })}
+              aria-label={t("apiKeyList.setActive", { defaultValue: "设为默认" })}
+              className={cn(
+                "inline-flex h-5 items-center rounded-md px-1.5 text-[10px] font-semibold transition-colors",
+                isActive
+                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300 cursor-default"
+                  : "text-muted-foreground/80 hover:text-foreground hover:bg-muted/60",
+              )}
+            >
+              {isActive
+                ? t("keyPool.activatedLabel", { defaultValue: "Activated" })
+                : t("keyPool.activateLabel", { defaultValue: "Activate" })}
+            </button>
+            <Button
+              variant="ghost"
+              size="icon"
+              type="button"
+              onClick={onEditStart}
+              className="h-7 w-7"
+              title={t("apiKeyList.edit", { defaultValue: "编辑" })}
+            >
+              <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              type="button"
+              onClick={onDelete}
+              className="h-7 w-7 text-muted-foreground hover:text-red-500"
+              title={t("apiKeyList.delete", { defaultValue: "删除" })}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+            <Switch
+              checked={apiKey.enabled}
+              onCheckedChange={(v) =>
+                update.mutate({ keyId: apiKey.id, payload: { enabled: v } })
+              }
+              aria-label={t("keyPool.toggleRotation", {
+                defaultValue: "加入轮换",
+              })}
+              title={t("keyPool.toggleRotation", {
+                defaultValue: "加入轮换",
+              })}
+              className="ml-1"
+            />
+          </div>
+
+          {/* Row 2: token 展示块——bg-muted/30 浅灰底 + 等宽字体 + 内边距，
+              让长 token 在视觉上是一个独立可识别的「凭据块」，而不是
+              一段裸露文本。break-all + whitespace-pre-wrap 处理超长
+              token 的换行；flex-1 让 code 吃掉剩余宽度。col-span-2
+              让 Row 2 横跨整个 grid（与下面 Row 3-5 一致），不与 Row 1
+              的 actions 列抢占空间。 */}
+          <div className="col-span-2 flex items-start gap-1.5 rounded-md bg-muted/40 border border-border/40 px-2 py-1.5 text-xs">
+            <code className="flex-1 min-w-0 font-mono break-all whitespace-pre-wrap text-foreground/80 leading-relaxed">
+              {showKey ? apiKey.apiKey : maskKey(apiKey.apiKey)}
+            </code>
+            <button
+              type="button"
+              onClick={() => setShowKey((v) => !v)}
+              className="shrink-0 mt-0.5 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-background/60 transition-colors"
+              aria-label={showKey ? "hide" : "show"}
+              title={showKey ? "隐藏" : "显示"}
+            >
+              {showKey ? (
+                <EyeOff className="h-3.5 w-3.5" />
+              ) : (
+                <Eye className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </div>
+
+          {/* Row 3: tags 单独成行——旧版塞在 token 那行末尾，看起来像
+              token 的一部分。每个 tag 独立 Badge 比「· tag1, tag2」
+              一串文本更易点击筛选 / 复制。 */}
+          {apiKey.tags.length > 0 && (
+            <div className="col-span-2 flex items-center gap-1.5 flex-wrap">
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70">
+                {t("apiKeyList.tags", { defaultValue: "tags" })}
+              </span>
+              {apiKey.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="outline"
+                  className={cn(
+                    "text-[10px] font-normal",
+                    // 按 tag 字符串 hash 到固定调色板，确保同名 tag 在
+                    // 所有 key 的 row 上颜色一致——视觉锚点稳定。
+                    tagColorClasses(tag),
+                  )}
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {/* Row 4: 上次错误信息（与上面 row 间距一致） */}
+          {apiKey.lastError && (
+            <div className="col-span-2 flex items-start gap-1.5 text-[11px] text-red-500">
+              <AlertCircle className="h-3 w-3 mt-0.5 shrink-0" />
+              <span className="break-all">{apiKey.lastError}</span>
+            </div>
+          )}
+
+          {/* Row 5: 5h/7d 配额条（已 i18n 化）—— 编辑页表单里 row 较多，
+            默认折叠进度条，仅展示状态行；点 status 行展开。KeyPoolBadge
+            不传该 prop，行为不变（默认展开）。col-span-2 让它横跨
+            整个 grid 宽度，与 Row 2-4 对齐。 */}
+          <div className="col-span-2">
+            <ApiKeyStatusBar
+              keyId={apiKey.id}
+              cooldownUntil={apiKey.cooldownUntil}
+              failureCount={apiKey.failureCount}
+              enabled={apiKey.enabled}
+              usage={usage ?? null}
+              usageEnabled={usageEnabled}
+              defaultCollapsed
+              onExhaustedChange={onExhaustedChange}
+              onFiveHourResetReached={onFiveHourResetReached}
+            />
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function maskKey(key: string): string {
+  if (!key) return "";
+  if (key.length <= 8) return "•".repeat(key.length);
+  return `${key.slice(0, 4)}${"•".repeat(Math.max(4, key.length - 8))}${key.slice(-4)}`;
+}
+
+// =====================================================================
+// New key inline form (replaces the modal-based CreateKeyDialog)
+// =====================================================================
+
+function NewKeyInlineForm({
+  providerId,
+  appId,
+  onDone,
+  onCancel,
+}: {
+  providerId: string;
+  appId: AppId;
+  onDone: () => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+  const [label, setLabel] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
+  const [enabled, setEnabled] = useState(true);
+  const create = useCreateApiKey();
+
+  const canSave = label.trim().length > 0 && apiKey.trim().length > 0 && !create.isPending;
+
+  const onSubmit = () => {
+    if (!canSave) return;
+    create.mutate(
+      {
+        providerId,
+        appType: appId,
+        label: label.trim(),
+        apiKey: apiKey.trim(),
+        tags,
+        enabled,
+      },
+      { onSuccess: onDone, onError: () => {} },
+    );
+  };
+
+  return (
+    <li className="rounded-lg border border-dashed border-blue-400 dark:border-blue-600 bg-blue-50/30 dark:bg-blue-950/10 p-3 space-y-3">
+      <div className="text-xs font-medium text-blue-700 dark:text-blue-300">
+        {t("apiKeyList.createTitle", { defaultValue: "添加 API Key" })}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="newkey-label">
+            {t("apiKeyList.labelLabel", { defaultValue: "标签" })}
+          </Label>
+          <Input
+            id="newkey-label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Primary"
+            autoFocus
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="newkey-value">
+            {t("apiKeyList.valueLabel", { defaultValue: "API Key" })}
+          </Label>
+          <Input
+            id="newkey-value"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            type="password"
+            autoComplete="off"
+            placeholder="sk-…"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="newkey-tags">
+            {t("apiKeyList.tagsLabel", { defaultValue: "标签" })}
+          </Label>
+          <TagInput
+            id="newkey-tags"
+            value={tags}
+            onChange={setTags}
+            placeholder={t("apiKeyList.tagsPlaceholder", {
+              defaultValue: "输入后回车添加（prod、region-east）",
+            })}
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={enabled}
+            onCheckedChange={setEnabled}
+            id="newkey-enabled"
+          />
+          <Label htmlFor="newkey-enabled">
+            {t("apiKeyList.enabledLabel", { defaultValue: "启用" })}
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" type="button" onClick={onCancel} disabled={create.isPending}>
+            {t("common.cancel", { defaultValue: "取消" })}
+          </Button>
+          <Button size="sm" type="button" onClick={onSubmit} disabled={!canSave}>
+            {create.isPending && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+            {t("common.save", { defaultValue: "保存" })}
+          </Button>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+// =====================================================================
+// Edit key inline form (replaces the modal-based EditKeyDialog)
+// =====================================================================
+
+function EditKeyInlineForm({
+  apiKey,
+  onDone,
+  onCancel,
+}: {
+  apiKey: ApiKeyDto;
+  onDone: () => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+  const [label, setLabel] = useState(apiKey.label);
+  const [keyValue, setKeyValue] = useState(apiKey.apiKey);
+  const [tags, setTags] = useState<string[]>(apiKey.tags);
+  const [enabled, setEnabled] = useState(apiKey.enabled);
+  const update = useUpdateApiKey();
+
+  const keyChanged = keyValue !== apiKey.apiKey;
+  const canSave = label.trim().length > 0 && !update.isPending;
+
+  const onSubmit = () => {
+    if (!canSave) return;
+    update.mutate(
+      {
+        keyId: apiKey.id,
+        payload: {
+          label: label.trim(),
+          // Only send apiKey when the user actually changed it.
+          apiKey: keyChanged ? keyValue : undefined,
+          tags,
+          enabled,
+        },
+      },
+      { onSuccess: onDone, onError: () => {} },
+    );
+  };
+
+  return (
+    <li className="rounded-lg border border-dashed border-amber-400 dark:border-amber-600 bg-amber-50/30 dark:bg-amber-950/10 p-3 space-y-3">
+      <div className="text-xs font-medium text-amber-700 dark:text-amber-300">
+        {t("apiKeyList.editTitle", { defaultValue: "编辑 Key" })}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor={`edit-${apiKey.id}-label`}>
+            {t("apiKeyList.labelLabel", { defaultValue: "标签" })}
+          </Label>
+          <Input
+            id={`edit-${apiKey.id}-label`}
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            autoFocus
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor={`edit-${apiKey.id}-value`}>
+            {t("apiKeyList.valueLabel", { defaultValue: "API Key" })}
+          </Label>
+          <Input
+            id={`edit-${apiKey.id}-value`}
+            value={keyValue}
+            onChange={(e) => setKeyValue(e.target.value)}
+            type="password"
+            autoComplete="off"
+          />
+          <p className="text-[11px] text-muted-foreground">
+            {t("apiKeyList.editValueHint", {
+              defaultValue: "留空或保持不变则不更新此字段。",
+            })}
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor={`edit-${apiKey.id}-tags`}>
+            {t("apiKeyList.tagsLabel", { defaultValue: "标签" })}
+          </Label>
+          <TagInput
+            id={`edit-${apiKey.id}-tags`}
+            value={tags}
+            onChange={setTags}
+            placeholder={t("apiKeyList.tagsPlaceholder", {
+              defaultValue: "输入后回车添加（prod、region-east）",
+            })}
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={enabled}
+            onCheckedChange={setEnabled}
+            id={`edit-${apiKey.id}-enabled`}
+          />
+          <Label htmlFor={`edit-${apiKey.id}-enabled`}>
+            {t("apiKeyList.enabledLabel", { defaultValue: "启用" })}
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" type="button" onClick={onCancel} disabled={update.isPending}>
+            {t("common.cancel", { defaultValue: "取消" })}
+          </Button>
+          <Button size="sm" type="button" onClick={onSubmit} disabled={!canSave}>
+            {update.isPending && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+            {t("common.save", { defaultValue: "保存" })}
+          </Button>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+// =====================================================================
+// TagInput
+// =====================================================================
+
+/**
+ * 多值 tag 输入器。
+ *
+ * 行为：
+ *  - 输入字符后回车 / 输入逗号 / blur → 把当前 draft 提交成 tag
+ *  - 输入框为空时按 Backspace → 删除最后一个 tag（标准 tag-input 习惯）
+ *  - 每个 tag 是一个 badge，右侧 ✕ 按钮可单独删除
+ *  - 重复 / 空 tag 自动去重过滤
+ *
+ * 与原生逗号分隔 `<Input>` 的区别：
+ *  - 用户可以边看自己刚加的 tag 边输入下一个，不需要"输入完所有再用逗号分"
+ *  - 错误编辑（修改中间一个 tag）不会影响其它 tag
+ *  - 移动端/中文输入法不需要切换符号键找逗号
+ *
+ * wrapper 整体 onPointerDown stopPropagation —— 行级 dnd-kit 的
+ * listeners 在 <li> 上，这里 stop 防止点 tag / 输入框被当成「开始拖」。
+ */
+function TagInput({
+  id,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id?: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const commit = (raw: string) => {
+    const tag = raw.trim();
+    if (!tag) return;
+    // 去重——同 tag 已存在就忽略（大小写敏感，避免误合 "Prod" / "prod"）。
+    if (value.includes(tag)) {
+      setDraft("");
+      return;
+    }
+    onChange([...value, tag]);
+    setDraft("");
+  };
+
+  const remove = (tag: string) => {
+    onChange(value.filter((t) => t !== tag));
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      commit(draft);
+    } else if (e.key === "Backspace" && draft === "" && value.length > 0) {
+      e.preventDefault();
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  return (
+    <div
+      // 关键：stop 掉 pointerdown，row 上的 dnd-kit 不会因为点 input
+      // / tag 而误判 drag。
+      onPointerDown={(e) => e.stopPropagation()}
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 min-h-9 w-full rounded-md",
+        "border border-input bg-background px-2 py-1.5",
+        "focus-within:ring-1 focus-within:ring-ring focus-within:border-ring",
+      )}
+    >
+      {value.map((tag) => (
+        <Badge
+          key={tag}
+          // 不带 variant——variant="secondary" 自带 bg-secondary /
+          // text-secondary-foreground，会与下方 tagColorClasses 撞色。
+          // 这里我们直接给一组明确的 bg / text，让 hash 调色板独占视觉权重。
+          // Badge 内部也 stop 一次——点 ✕ 按钮冒泡到 wrapper 后再
+          // 冒泡到 <li> 也会触发 dnd-kit。
+          onPointerDown={(e) => e.stopPropagation()}
+          className={cn(
+            "gap-1 pl-2 pr-1 py-0.5 text-xs font-normal",
+            // 与 row 上的 tag 颜色保持一致——同一个 tag 在「行内展示」
+            // 和「编辑态 chip」之间视觉连续。
+            tagColorClasses(tag),
+          )}
+        >
+          <span>{tag}</span>
+          <button
+            type="button"
+            onClick={() => remove(tag)}
+            // ✕ 按钮 stop 防止点击事件触发 input blur 等副作用。
+            onPointerDown={(e) => e.stopPropagation()}
+            className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground hover:bg-background hover:text-foreground transition-colors"
+            aria-label={`remove ${tag}`}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      ))}
+      <Input
+        id={id}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={() => {
+          if (draft.trim()) commit(draft);
+        }}
+        placeholder={value.length === 0 ? placeholder : undefined}
+        // 关键：input 自身 border / bg 全部去掉，让它视觉上和 wrapper
+        // 融为一体；flex-1 让 input 吃掉剩余宽度；min-w-0 是 flex 子项
+        // 真正能缩到 0 的开关。
+        className="flex-1 min-w-[120px] h-7 px-1 border-0 bg-transparent shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+        autoComplete="off"
+      />
+    </div>
+  );
+}
+

--- a/src/components/providers/ApiKeyListSection.tsx
+++ b/src/components/providers/ApiKeyListSection.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useQueries, useQueryClient } from "@tanstack/react-query";
+import { useQueries, useQueryClient, useIsFetching } from "@tanstack/react-query";
 import {
   DndContext,
   PointerSensor,
@@ -27,6 +27,7 @@ import {
   AlertCircle,
   Clock,
   Pencil,
+  RefreshCw,
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -89,6 +90,20 @@ export function ApiKeyListSection({ appId, providerId }: ApiKeyListSectionProps)
   // 的顺序铺到 row 上。注意：query key 故意不带 providerId；keyId 唯一即可。
   // 用户切到另一个 provider 时，cache 里这份 (keyId, appId) 也保留（10 分钟
   // gcTime），不会因为切走立刻扔掉——避免来回切时反复闪"loading"。
+  //
+  // **forceRefreshTick** 是一个手动触发器：用户点刷新按钮时 +1，把所有
+  // per-key query 的 `enabled` 暂时顶到 true——**包括 k.enabled=false 的 key**。
+  // 普通的 `invalidateQueries` / `refetchQueries` 对 disabled 的 query 是
+  // no-op（TanStack Query 文档明确：「The query will ignore query client
+  // `invalidateQueries` and `refetchQueries` calls that would normally
+  // result in the query refetching」），所以必须用一个真正能改 `enabled`
+  // 判定结果的 state 来「骗」React Query 重启这些 query。
+  //
+  // 使用场景：用户 7d 配额 100% 后手动把 key 停用，等一周后想看
+  // 「这把 key 现在是不是恢复成 0%」——此时如果只用 invalidate，disabled
+  // 的 key 永远停在旧的 100% 缓存上。forceRefreshTick 临时解锁 → 拿到
+  // 新 snapshot → 全部查询都 settle 后 effect 把 tick 归零、恢复原 `enabled`。
+  const [forceRefreshTick, setForceRefreshTick] = useState(0);
   const perKeyQueries = useQueries({
     queries: keys.map((k) => ({
       queryKey: ["keyUsage", k.id, appId] as const,
@@ -102,7 +117,10 @@ export function ApiKeyListSection({ appId, providerId }: ApiKeyListSectionProps)
         }
         return usageApi.queryForKey(providerId, k.id, appId);
       },
-      enabled: enabled && k.enabled,
+      // k.enabled 默认控制 query 启停（停用的 key 不浪费 API 调用）。
+      // forceRefreshTick > 0 时**强制打开所有 key**——让被停用的 key
+      // 也能在用户主动刷新时拉一次最新数据；用户重启用前不会自动重拉。
+      enabled: enabled && (k.enabled || forceRefreshTick > 0),
       retry: 1,
       retryDelay: 1500,
       staleTime: 5 * 60 * 1000,
@@ -145,6 +163,62 @@ export function ApiKeyListSection({ appId, providerId }: ApiKeyListSectionProps)
   const [exhaustedKeyIds, setExhaustedKeyIds] = useState<Set<string>>(
     () => new Set(),
   );
+
+  // 「refreshing」状态：监听所有相关 query 的 in-flight 数量。
+  // 不用局部 boolean 是因为 React Query 已经在管 refetch 生命周期，
+  // 直接读它的计数器最准确——即便 handleRefresh 被并发触发也不会丢状态。
+  // per-key 状态直接读 useQueries 返回的 `q.isFetching`，无需再 hook。
+  const isApiKeysFetching = useIsFetching({
+    queryKey: ["apiKeys", providerId, appId],
+  });
+  const isPerKeyFetching = perKeyQueries.some((q) => q.isFetching);
+  const isRefreshing = isApiKeysFetching > 0 || isPerKeyFetching;
+
+  // 手动刷新：同 KeyPoolList 的 handleRefresh 一致——同时刷三类数据。
+  // 1) `["apiKeys", providerId, appId]`——冷却 / 失败计数 / 启用状态
+  //    （key 是否被用户手动停用 / 是否在 cooldown 由这里反映）
+  // 2) `["keyUsage", keyId, appId]`——每把 key 自己的用量配额进度
+  // 3) `["usage", providerId, appId]`（若存在）——provider-level 兜底
+  //
+  // **forceRefreshTick > 0 的特殊路径**：普通的 invalidate 对 disabled
+  // 的 query 是 no-op（TanStack Query 明确把 disabled query 排除在
+  // invalidate/refetch 之外）。如果只 invalidate，**停用的 key 永远拿
+  // 不到新数据**——这就是用户报的「7d 配额重置后进度条不更新」的根因。
+  // 这里用 +1 触发的 useQueries 重新计算 `enabled` 来让 disabled key
+  // 也参与本次 refetch。所有 query settle 后 effect 会把 tick 归零，
+  // 让 enabled 判定回到「尊重 k.enabled」的常态。
+  const handleRefresh = useCallback(() => {
+    if (isRefreshing) return;
+    setForceRefreshTick((t) => t + 1);
+    queryClient.invalidateQueries({
+      queryKey: ["apiKeys", providerId, appId],
+    });
+    keys.forEach((k) => {
+      queryClient.invalidateQueries({
+        queryKey: ["keyUsage", k.id, appId],
+      });
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["usage", providerId, appId],
+    });
+  }, [
+    isRefreshing,
+    queryClient,
+    providerId,
+    appId,
+    keys,
+  ]);
+
+  // forceRefreshTick 归零：所有相关 query 都 settle 后，把 tick 拉回 0，
+  // 让 enabled 判定恢复「k.enabled 必须为 true」——避免下一次组件 re-render
+  // 仍然让 disabled key 持续触发 refetch。
+  // 「settle」= apiKeys 和 per-key 都不在 fetching 状态。effect 的依赖里
+  // 包含 forceRefreshTick，确保每次 +1 后都会重新评估 settle 条件。
+  useEffect(() => {
+    if (forceRefreshTick === 0) return;
+    if (isApiKeysFetching > 0 || isPerKeyFetching) return;
+    setForceRefreshTick(0);
+  }, [forceRefreshTick, isApiKeysFetching, isPerKeyFetching]);
 
   // Active key 一律置顶——它是用户最关心的那把，列表里也最容易被误以为在轮换。
   // 其他 key 保持 sortIndex 顺序不变。
@@ -219,15 +293,47 @@ export function ApiKeyListSection({ appId, providerId }: ApiKeyListSectionProps)
           </p>
         </div>
         {!addingNew && (
-          <Button
-            size="sm"
-            variant="outline"
-            type="button"
-            onClick={() => setAddingNew(true)}
-          >
-            <Plus className="h-4 w-4 mr-1" />
-            {t("apiKeyList.add", { defaultValue: "添加 Key" })}
-          </Button>
+          <div className="flex items-center gap-1.5">
+            {/* 手动刷新：与 KeyPoolList 同一套 UX 风格——icon 按钮 + loading
+                期间换成 Loader2 旋转。disabling 避免并发点击导致重复
+                refetch；disabled 状态下连同 enabled-but-still-in-flight
+                的 query 也压住，让 isRefreshing 信号能跨过最后一次响应。
+                关键作用：对「已被用户停用」的 key 也能触发一次 refresh——
+                这是处理 7d 配额 100% → 用户停用 → 等一周后想看新数据
+                场景的关键入口。详见 handleRefresh 注释。 */}
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              aria-label={t("keyPool.refresh", { defaultValue: "刷新" })}
+              title={
+                isRefreshing
+                  ? t("keyPool.refreshing", { defaultValue: "刷新中…" })
+                  : t("keyPool.refresh", { defaultValue: "刷新" })
+              }
+              className={cn(
+                "inline-flex h-7 w-7 items-center justify-center rounded-md",
+                "text-muted-foreground/70 hover:text-foreground hover:bg-muted/60",
+                "transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              )}
+            >
+              {isRefreshing ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+            </button>
+            <Button
+              size="sm"
+              variant="outline"
+              type="button"
+              onClick={() => setAddingNew(true)}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              {t("apiKeyList.add", { defaultValue: "添加 Key" })}
+            </Button>
+          </div>
         )}
       </div>
 

--- a/src/components/providers/ApiKeyStatusBar.tsx
+++ b/src/components/providers/ApiKeyStatusBar.tsx
@@ -1,0 +1,1017 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Timer, AlertCircle, CheckCircle2, ZapOff, ChevronDown } from "lucide-react";
+import type { UsageResult, UsageData } from "@/types";
+import { usageApi } from "@/lib/api/usage";
+import { cn } from "@/lib/utils";
+
+/**
+ * 单把 API Key 的状态条。
+ *
+ * 信息密度从下往上依次为：
+ *   1. 进度条：填充宽度 = 账户用量 used%，颜色按阈值变红/黄/灰
+ *   2. 进度条右侧元数据：百分比 + 7d 窗口标签 + used/total 数字
+ *   3. 进度条上方一行：冷却倒计时（若在 cooldown）——用 `useState` 每秒 tick，
+ *      否则渲染一次后即停
+ *
+ * 设计原则：
+ *   - 一把 key 一行信息，绝不与同行其它 key 抢空间（视觉权重比电池徽标更重）
+ *   - 没用 usage_script 的 provider：仅显示冷却倒计时，progress 部分直接不渲染
+ *   - 「7d」是显示文案锚点——绝大多数 provider 的用量配额都是 7 天滚动窗口；
+ *     即便后端没传 resets_at，UI 也能给用户一个稳定的"7 天"心智模型
+ */
+interface ApiKeyStatusBarProps {
+  /** 这把 key 的 id；传给 backend 触发 proactive rotation 时使用 */
+  keyId?: string | null;
+  /** epoch seconds，同 ApiKeyDto.cooldownUntil */
+  cooldownUntil: number;
+  /** 累计失败次数（>0 时即便未在冷却也要显示，给用户一个"距停用还有多远"的锚点） */
+  failureCount?: number;
+  /** key 是否启用（被自动停用或手动停用时显示对应文案） */
+  enabled?: boolean;
+  /** 触发自动停用的失败阈值，UI 文案用 */
+  autoDisableThreshold?: number;
+  /** 账户级别 usage 数据；未传或 success=false 时不渲染 usage 部分 */
+  usage?: UsageResult | null;
+  /** 是否启用 usage 展示（provider 是否配了 usage_script） */
+  usageEnabled?: boolean;
+  className?: string;
+  /**
+   * 5h 配额窗口倒计时归零时的回调。父组件接到回调后应主动 invalidate
+   * keyUsage / apiKeys / usage 等 query，让前端 UI 立即拉到「重置后」
+   * 的新快照，而不必等到下一个 autoQueryInterval 周期。
+   *
+   * - 该回调在 primaryResetMs 倒计到 0 时触发，且每次重置后会在新的
+   *   primaryResetMs 上重新挂 timer（依赖数组含 primaryResetMs）。
+   * - 父组件可以用 `["apiKeys", providerId, appId]` 失效来顺带刷新
+   *   冷却 / 失败计数 / enabled 标志。
+   * - 该回调可能与 React Query 的 `refetchInterval` 同时触发——重复
+   *   invalidate 是幂等的，不会引发额外请求。
+   */
+  onFiveHourResetReached?: () => void;
+  /**
+   * 当任一 quota 达到 100%（5h / 7d / 任何 tier）时回调。父组件用这个
+   * 给整行加红色背景——7d 100% 比 5h 100% 更值得警示，但用户视角里
+   * 「这把 key 已经耗尽」是同一个语义，单一信号最稳。
+   * 7d 100% 但额外 tier 列表未渲染的场景下，让 row 自行染红
+   * 是更可靠的可见反馈，避免「bar 不可见 = 信号丢失」。
+   */
+  onExhaustedChange?: (exhausted: boolean) => void;
+  /**
+   * 折叠状态：默认 `false`（状态行 + 进度条全展开，与旧版一致）。
+   * 设为 `true` 时只展示顶部的状态行（冷却 / 停用 / 失败次数 / 就绪），
+   * 5h / 7d 用量进度条藏在点击背后——用于「同一把 key 在编辑表单里
+   * 出现 N 次时，表单已经很高，不要每个 row 都强制展开两层进度条」的
+   * 场景。KeyPoolBadge 不传该 prop，行为不变。
+   */
+  defaultCollapsed?: boolean;
+}
+
+export function ApiKeyStatusBar({
+  keyId,
+  cooldownUntil,
+  failureCount = 0,
+  enabled = true,
+  autoDisableThreshold = 5,
+  usage,
+  usageEnabled = false,
+  className,
+  onFiveHourResetReached,
+  onExhaustedChange,
+  defaultCollapsed = false,
+}: ApiKeyStatusBarProps) {
+  const { t } = useTranslation();
+  // 上一次触发 proactive rotation 的「区间桶」——跨档位（safe→warn→
+  // exhausted）才重新触发，90→95 的连续刷新不会重复打 backend。
+  const lastTriggeredBucketRef = useRef<"warn" | "exhausted" | null>(null);
+
+  // ─── 折叠状态 ─────────────────────────────────────────────
+  // 状态行始终可见（冷却倒计时 / 停用 / 失败次数 / 就绪——这是用户
+  // 必看的「这把 key 现在啥状态」锚点）。进度条区（5h 主条 + 副 tier
+  // 列表）在 defaultCollapsed=true 时收起来，用户点状态行再展开。
+  const [expanded, setExpanded] = useState(!defaultCollapsed);
+
+  // ─── 冷却倒计时 ─────────────────────────────────────────────
+  // 每秒 tick 一次；冷却结束后清理 interval，避免不必要 re-render。
+  // useState 的初始化器只在挂载时跑一次，所以额外加一个 effect 同步 prop
+  // 变化（轮换恢复时 cooldownUntil 会被后端改写，需要重新计算剩余）。
+  const computeRemaining = () =>
+    Math.max(0, cooldownUntil * 1000 - Date.now());
+  const [remainingMs, setRemainingMs] = useState(computeRemaining);
+  const inCooldown = remainingMs > 0;
+
+  useEffect(() => {
+    setRemainingMs(computeRemaining());
+  }, [cooldownUntil]);
+
+  useEffect(() => {
+    if (!inCooldown) return;
+    const id = setInterval(() => {
+      const r = computeRemaining();
+      setRemainingMs(r);
+      if (r === 0) clearInterval(id);
+    }, 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inCooldown, cooldownUntil]);
+
+  // ─── 用量数据 ───────────────────────────────────────────────
+  // usage 是 per-key 维度的——每把 key 由 KeyPoolList 的 useQueries
+  // 单独拉（queryProviderUsageForKey 使用 provider_api_keys 里这一行
+  // 自己的 api_key 跑脚本）。所以进度条数字精确归到对应的那把 key 上，
+  // 不再像之前那样所有 key 共享 provider-level 快照。
+  //
+  // **进度条始终渲染**（只要 `usageEnabled` 为 true）——即便当前还没拉到
+  // 数据（loading / 瞬时失败）也要让用户看到"这里有个用量条"的位置锚点，
+  // 不会因为一次 query 抖动就让整行"空"得让人误以为没配 usage_script。
+  // 拉到数据时按数据走；没拉到时用 0% 占位。
+  // 进度条顶部那条主用「5h 配额」显示——挑 planName 标识为 5 小时的那条；
+  // 若 usage_script 返回的多 plan 里没有显式 5h 标识，再回退到 data[0]。
+  // 关键：data[0] 未必是 5h（7天窗口的 plan 经常排在前面，used 数字会差
+  // 一个数量级），拿它去标「5h 配额」会让用户看错数字。
+  // 例：5h plan 100% / 7d plan 86% 时，data[0] 拿的是 7d，标 5h 就是误导。
+  // —— 还有一种更隐蔽的情况：脚本只返回 1 个 UsageData 元素，把 5h / 7d 两个
+  // 窗口都塞到 `extra` 的「5小时:100%12m 7天:86%12m」里。这时 find() 找不到
+  // 5h planName，会落到 data[0]，而 data[0].used 反映的可能是 7d 数字（脚本
+  // 实现不统一）。补救：从 `extra` 解析出的 usageWindows 里挑 5h 的那条用作
+  // `usedPercent` / `used` / `total`，优先于 data[0] 的数字。
+  // 5h / 7d 正则提前到外层作用域，让下面 primaryForDisplay 也能复用。
+  // 注意：planName 在不同数据源里长得不一样：
+  //   - subscription 路径（SubscriptionQuota → UsageData 映射）：tier.name
+  //     写的是内部 key "five_hour" / "seven_day" / "seven_day_opus" 等；
+  //   - JS 脚本路径：通常写展示文案 "7天配额" / "周配额" / "Weekly"；
+  //   - 旧 coding_plan 模板回退：也用 "7d 配额" / "5h 配额" 这种简短标签。
+  // 一并匹配这三种形态——否则会把"7d 配额"标签贴到 5h 数据上。
+  // 5h 正则：覆盖 "five_hour" / "5h" / "5小时" / "5小时配额" 等所有形态。
+  // 主进度条优先选 5h（短期窗口对单次会话的影响更直接），7d 退到下方
+  // 「per-window 进度条」或「多 tier 列表」里展示。
+  const fiveHourRe = /(5\s*h(?:our)?s?|5\s*小时|five_hour)/i;
+  // 7d 正则：多 tier 列表 / windowsForList 的 dual-format 决策需要——
+  // 名字匹配 7d → 主单位是「天」（"3d20h"），匹配 5h → 主单位是「小时」
+  // （"1h54m"），未知窗口默认 7d 行为。
+  const sevenDayRe = /(7\s*d(?:ay)?s?|7\s*天|周|week|seven_day)/i;
+  const primaryUsage: UsageData | null = (() => {
+    if (
+      !usageEnabled ||
+      !usage?.success ||
+      !usage.data ||
+      usage.data.length === 0
+    ) {
+      return null;
+    }
+    const fiveHour = usage.data.find((d) => {
+      const name = (d.planName ?? "").trim();
+      return name && fiveHourRe.test(name);
+    });
+    return fiveHour ?? usage.data[0];
+  })();
+  // 解析 primaryUsage.extra 中的多窗口配额段，**提前**到这里，以便下面的
+  // 百分比 / used 计算能参考 5h 窗口的真实数字。
+  const usageWindows = primaryUsage ? parseUsageWindows(primaryUsage.extra) : [];
+  // 当 primaryUsage 自身没有 5h 标识（被回退到 data[0]）时，从 usageWindows
+  // 里挑 5h 窗口，构造一个临时 UsageData 用于主进度条的数字——避免"标签
+  // 5h 配额"与"数字来自 7d"的割裂。这只覆盖 used/usedPercent/unit；planName
+  // 留空（因为它本身就是用 extra 编码的）。
+  const fiveHourWindow = usageWindows.find((w) => fiveHourRe.test(w.name));
+  const primaryForDisplay: UsageData | null = (() => {
+    if (!primaryUsage) return null;
+    if (fiveHourWindow) {
+      // primaryUsage 已有 5h 标识 → 用 primaryUsage；
+      // 没有 5h 标识但 extra 里能解析出 5h 窗口 → 用 5h 窗口的数字。
+      const hasFiveHourName = fiveHourRe.test(
+        (primaryUsage.planName ?? "").trim(),
+      );
+      if (!hasFiveHourName) {
+        return {
+          ...primaryUsage,
+          // 5h 窗口没有原始 used 绝对值含义，用 percent 当 used（unit="%"）
+          used: fiveHourWindow.used,
+          unit: "%",
+          total: 100,
+        };
+      }
+    }
+    return primaryUsage;
+  })();
+  const usedPercent =
+    primaryForDisplay && typeof primaryForDisplay.used === "number"
+      ? (() => {
+          // unit 决定 used 的语义：
+          //   - "%" → used 已是 0–100 的百分比，直接用
+          //   - 其他（"count" / "tokens" / undefined 但 total>0）→ used/total
+          //     重新换算成 0–100，否则进度条永远停在 7% 这种「绝对值小」的位置上
+          if (primaryForDisplay.unit === "%") {
+            return Math.max(0, Math.min(100, primaryForDisplay.used));
+          }
+          const total = primaryForDisplay.total ?? 0;
+          if (total > 0) {
+            return Math.max(
+              0,
+              Math.min(100, (primaryForDisplay.used / total) * 100),
+            );
+          }
+          return 0;
+        })()
+      : 0;
+  const showUsageBar = usageEnabled;
+
+  // 解析 primaryUsage.extra 中的多窗口配额段已经在上面完成（usageWindows），
+  // 5h 窗口拣选后已并入 primaryForDisplay 用于主进度条的数字；下方多窗口
+  // 进度条区继续用 usageWindows 渲染。
+  // —— 当 5h 窗口已被挑出来作为 primaryForDisplay 的来源时，从 usageWindows
+  // 里移除它，避免在「主进度条 100%」+「下方 5小时:100% 进度条 100%」双重复。
+  const windowsForList = fiveHourWindow
+    ? usageWindows.filter((w) => w !== fiveHourWindow)
+    : usageWindows;
+
+  // 失败次数在展示层封顶——5 次就是自动停用 + 轮换的硬阈值，再往后累
+  // 加已经没有信息量（用户已经知道"这把废了"）。底层 backend 仍然会继续
+  // 累加（用于审计/重启用时的初始值），但 UI 不展示超过 5 的数字，避免
+  // 「已失败 17/5 次」这种让用户怀疑阈值的观感。
+  const displayedFailureCount = Math.min(
+    Math.max(0, failureCount),
+    autoDisableThreshold,
+  );
+
+  // 主进度条的「重置倒计时」——7d/30d 那些副 tier 在 windowsForList 里用
+  // 「5h:100%12m」字符串里的 "12m" 段当 reset 倒计时，5h 主进度条因为被
+  // 抽出来复用数字，反而丢了 reset。这里补回：
+  //   - 5h 主数据来自 `fiveHourWindow`（字符串编码的「5小时:100%12m」）：
+  //     reset 直接是 `fiveHourWindow.reset`
+  //   - 5h 主数据来自 subscription 风格的 UsageData（planName="five_hour"、
+  //     extra 是 ISO resetsAt）：用 parseResetsAtForBar 解析 ISO
+  //   - 上面两种都没有：fallback 到「未知」
+  // 把"5h 配额"标签后面挂一个倒计时，跟下面 7d 行的 7d 倒计时视觉一致，
+  // 用户能横向对照「5h 还多久 / 7d 还多久」。
+  //
+  // 同时把 reset 字符串还原回毫秒——下面 `primaryResetLabel` 用「XhYm」/
+  // 「XdYh」双单位格式重打，"12m"/"2h" 这种单单位粒度太粗，主进度条不
+  // 该用这种简化版。
+  const primaryReset: string = (() => {
+    if (fiveHourWindow?.reset) return fiveHourWindow.reset;
+    if (primaryForDisplay) {
+      const isoReset = parseResetsAtForBar(primaryForDisplay.extra);
+      if (isoReset) return isoReset;
+    }
+    return "";
+  })();
+  // `parseResetsAtForBar` 拿到的是 ISO 串走 formatRemaining 出来的紧凑
+  // 字符串（"12m" / "2h" / "3d"），需要再 `parseCompactDurationToMs` 回到
+  // ms 才能喂给 `formatDualCountdown` 走双单位分支。
+  // `fiveHourWindow.reset` 同源（"5小时:100%12m" 里的 "12m"）—— 同样路径。
+  const primaryResetMs = primaryReset ? parseCompactDurationToMs(primaryReset) : 0;
+
+  // ─── 5h 配额窗口到点重置 ───────────────────────────────────
+  // primaryResetMs 是「距下次重置的剩余 ms」——挂一个 setTimeout，到点时
+  // 调 onFiveHourResetReached 让父组件 invalidate 相关 query。
+  //
+  // 设计要点：
+  //   - 依赖 primaryResetMs：每次重置后新数据里 primaryResetMs 会变成
+  //     「新的 5h 窗口」剩余时长（≈ 5h），effect 重跑、自然续约。
+  //   - cleanup：return 出来的 clearTimeout 在 unmount 或 primaryResetMs
+  //     变化时清掉旧 timer，避免「快进到下一次 invalidate」时叠两个
+  //     timer 导致 onFiveHourResetReached 被调多次。
+  //   - 100ms 下限：primaryResetMs 刚到 0 附近（数据已显示 0m 但新
+  //     snapshot 还没到）时挂个 0ms 定时器会让 setTimeout 立刻 fire，
+  //     给后端一个喘息时间避免 throttle；并且 primaryResetMs 为 0
+  //     （数据缺失）时不挂 timer，由 UI 显示「未知」即可。
+  //   - onFiveHourResetReached 进依赖：父组件的 handleKeyResetReached
+  //     通常是稳定的（闭包持有 queryClient / providerId / appId），
+  //     但保险起见还是放进去，避免 hook 引用陈旧。
+  useEffect(() => {
+    if (!onFiveHourResetReached || primaryResetMs <= 0) return;
+    const delay = Math.max(primaryResetMs, 100);
+    const timer = setTimeout(onFiveHourResetReached, delay);
+    return () => clearTimeout(timer);
+  }, [primaryResetMs, onFiveHourResetReached]);
+
+  // ─── Proactive rotation ────────────────────────────────────
+  // 监听 5h 主窗口的 usage_percent，超过阈值时通知 backend KeyRing
+  // 把这把 key 提前送进 cooldown——避免「先发请求被拒再切 key」的延迟。
+  //
+  // 设计要点：
+  //   - **节流**：lastTriggeredBucketRef 记录上一次触发的「区间桶」
+  //     （warn / exhausted / safe），跨档位时再触发，90→95 不会重复
+  //     触发 N 次，但 80→90 仍会触发一次。
+  //   - **reset_at 来自 primaryResetMs**：当 cooldown_until = reset_at，
+  //     5h 窗口自然重置后（usagePercent 数据更新到 0%），下一次 effect
+  //     触发时 backoff 到 safe 桶——key 自动恢复。
+  //   - **不 await**：usageApi.markKeyUsageHigh 内部已经 swallow 异常，
+  //     这里是 fire-and-forget，UI 不会因 backend 错误而卡顿。
+  useEffect(() => {
+    if (!keyId || !primaryForDisplay) return;
+    const used = primaryForDisplay.used ?? 0;
+    const total = primaryForDisplay.total ?? 100;
+    if (!Number.isFinite(used) || !Number.isFinite(total) || total <= 0) {
+      return;
+    }
+    const usagePercent = (used / total) * 100;
+    const resetAtUnix =
+      primaryResetMs > 0 ? Math.floor(Date.now() / 1000) + Math.floor(primaryResetMs / 1000) : 0;
+    let bucket: "safe" | "warn" | "exhausted" = "safe";
+    if (usagePercent >= 100) bucket = "exhausted";
+    else if (usagePercent >= 90) bucket = "warn";
+    if (bucket === "safe") {
+      // 触底后清除之前记录的桶——下次再涨过阈值还能再触发。
+      lastTriggeredBucketRef.current = null;
+      return;
+    }
+    if (lastTriggeredBucketRef.current === bucket) return;
+    lastTriggeredBucketRef.current = bucket;
+    void usageApi.markKeyUsageHigh(keyId, usagePercent, resetAtUnix);
+  }, [keyId, primaryForDisplay, primaryResetMs]);
+
+  // 订阅/Subscription-style 用量（TOKEN_PLAN 走 special-template 路径）以
+  // `usage.data[]` 形式返回多个 `UsageData`——每个 element 是一个 tier
+  // （planName = "five_hour" / "seven_day" / "monthly" / "weekly_limit"），
+  // `extra` 里是 ISO `resetsAt`。这些不在 `parseUsageWindows` 解析的
+  // 「5小时:100%12m」格式里，所以不靠 `windowsForList` 渲染；单独列一份
+  // 「非主进度条 tier 列表」，把 5h 等一并展示——否则 per-key 行只会显示 7d
+  // 一条，5h 永远缺失，与用户预期「5h + 7d 两条都看得到」不符。
+  const additionalTiers: Array<{
+    name: string;
+    used: number;
+    reset: string;
+  }> = [];
+  if (usageEnabled && usage?.success && usage.data && primaryUsage) {
+    for (const d of usage.data) {
+      const name = (d.planName ?? "").trim();
+      if (!name) continue;
+      if (name === (primaryUsage.planName ?? "").trim()) continue;
+      const used =
+        d.unit === "%"
+          ? Math.max(0, Math.min(100, d.used ?? 0))
+          : d.total && d.total > 0
+            ? Math.max(0, Math.min(100, ((d.used ?? 0) / d.total) * 100))
+            : 0;
+      const reset = parseResetsAtForBar(d.extra);
+      additionalTiers.push({ name, used, reset });
+    }
+  }
+
+  // 任一 quota 达到 100% → row 染红。涵盖：
+  //   - 主进度条 usedPercent（5h 或 7d 取决于 primaryUsage 选择）
+  //   - 多窗口 windowsForList（encoded 「7d:100%12m」）
+  //   - 订阅风格 additionalTiers（planName="seven_day" 等）
+  // 单一信号给 row，弱化「bar 不可见 = 信号丢失」的风险（参见
+  // onExhaustedChange 注释）。
+  const anyQuotaExhausted =
+    usedPercent >= 100 ||
+    windowsForList.some((w) => w.used >= 100) ||
+    additionalTiers.some((t) => t.used >= 100);
+
+  // 任一 quota 100% → 上报父组件 row 染红。依赖里包 anyQuotaExhausted
+  // 和 onExhaustedChange；onExhaustedChange 一般稳定（闭包持有 queryClient
+  // 等），但保险起见放进去避免 hook 引用陈旧。
+  useEffect(() => {
+    onExhaustedChange?.(anyQuotaExhausted);
+  }, [anyQuotaExhausted, onExhaustedChange]);
+
+  // ─── 是否存在可折叠内容 ─────────────────────────────────────
+  // 状态行永远渲染（冷却 / 停用 / 失败 / 就绪——这是核心状态信号）。
+  // 进度条 + 多 tier 列表只在「确实存在」时折叠；都不存在时整体
+  // 没东西可展开，把整个 status row 设成不可点击，避免一个点了
+  // 啥都不发生的按钮。
+  const hasCollapsibleContent =
+    usageEnabled ||
+    windowsForList.length > 0 ||
+    additionalTiers.length > 0;
+
+  // ─── 标签：把"周配额" / "5h 配额" 等不同来源的 planName 收口到 i18n ──
+  // SubscriptionQuota → UsageData 映射里写的是内部 key（"five_hour" /
+  // "seven_day" / "seven_day_opus" / "weekly_limit"），JS 脚本路径写的是
+  // 展示文案（"7天配额" / "周配额" / "Weekly"），二者必须分流，否则 "7d 配额"
+  // 这种静态标签会贴在 5h 数据上误导用户。计算放在 primaryForDisplay 之后。
+  const TIER_I18N_KEYS: Record<string, string> = {
+    five_hour: "subscription.fiveHour",
+    seven_day: "subscription.sevenDay",
+    seven_day_opus: "subscription.sevenDayOpus",
+    seven_day_sonnet: "subscription.sevenDaySonnet",
+    weekly_limit: "subscription.sevenDay",
+  };
+  const planLabel = (() => {
+    const raw = primaryForDisplay?.planName?.trim();
+    if (!raw) return t("apiKeyStatusBar.fiveHour", { defaultValue: "5h 配额" });
+    if (raw in TIER_I18N_KEYS) {
+      return t(TIER_I18N_KEYS[raw], { defaultValue: raw });
+    }
+    return raw;
+  })();
+
+  // 永远渲染——用户能直观看到「就绪 / 失败计数 / 停用 / 冷却中」四种状态
+  // 之一，不希望「什么都没出现」让人误以为 key 没在管。
+
+  // 调试用：把每个 keyId 的最新 usage 数据挂到 window 上，方便
+  // DevTools 直接 inspect——比在 Rust 日志里翻 trace 直观。
+  //   window.__apiKeyUsage[keyId] = { usage, primaryUsage, additionalTiers,
+  //     windowsForList, usedPercent, anyQuotaExhausted }
+  // 仅开发期使用——上生产前会删。useEffect 在 data 真正变化时触发，
+  // 不在每帧 render 上 set 新对象。
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    (window as unknown as { __apiKeyUsage?: Record<string, unknown> }).__apiKeyUsage =
+      {
+        ...((window as unknown as { __apiKeyUsage?: Record<string, unknown> })
+          .__apiKeyUsage ?? {}),
+        [keyId as string]: {
+          usage,
+          primaryUsage,
+          primaryForDisplay,
+          usageWindows,
+          windowsForList,
+          additionalTiers,
+          usedPercent,
+          anyQuotaExhausted,
+        },
+      };
+  }, [
+    keyId,
+    usage,
+    primaryUsage,
+    primaryForDisplay,
+    usageWindows,
+    windowsForList,
+    additionalTiers,
+    usedPercent,
+    anyQuotaExhausted,
+  ]);
+
+  return (
+    <div
+      className={cn(
+        "mt-2 space-y-1 text-[10px] text-muted-foreground",
+        className,
+      )}
+    >
+      {/* 状态行：四种状态互斥——冷却中 / 已停用 / 失败计数 / 就绪
+          始终渲染（只要有任意信息可显示），给用户一个稳定的"这把 key 现在
+          是什么状态"锚点。即便没有 usage 数据，也要让用户看到冷却 / 失败
+          / 停用状态——这正是上一版没做对的地方。
+
+          当存在可折叠内容（主进度条 / 副 tier）时，整行变成可点击的折叠
+          触发器——点 status 行展开/收起下方进度条，避免「一个 row 永远顶
+          着 3 行进度条」撑高编辑表单。type="button" 防止误提交外层 form
+          （与 ApiKeyListSection 里其它按钮同源处理）。 */}
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={
+            hasCollapsibleContent ? () => setExpanded((v) => !v) : undefined
+          }
+          aria-expanded={hasCollapsibleContent ? expanded : undefined}
+          className={cn(
+            "flex flex-1 items-center gap-2 text-left",
+            hasCollapsibleContent
+              ? "cursor-pointer hover:text-foreground/90"
+              : "cursor-default",
+          )}
+        >
+          {inCooldown ? (
+            <>
+              <Timer className="h-3 w-3" />
+              <span className="font-medium">
+                {t("apiKeyStatusBar.cooldownRemaining", {
+                  defaultValue: "冷却剩余",
+                })}
+              </span>
+              <span className="font-mono tabular-nums text-foreground/80">
+                {localizeCompactDuration(formatRemaining(remainingMs), t)}
+              </span>
+              <span className="text-muted-foreground/60">
+                {t("apiKeyStatusBar.cooldownHint", {
+                  defaultValue: "(届时自动恢复轮换)",
+                })}
+              </span>
+            </>
+          ) : !enabled ? (
+            <>
+              <ZapOff className="h-3 w-3" />
+              <span className="font-medium">
+                {t("apiKeyStatusBar.disabled", {
+                  defaultValue: "已停用",
+                })}
+              </span>
+              <span className="text-muted-foreground/60">
+                {t("apiKeyStatusBar.disabledHint", {
+                  defaultValue: "(手动启用后恢复轮换)",
+                })}
+              </span>
+            </>
+          ) : failureCount > 0 ? (
+            <>
+              <AlertCircle className="h-3 w-3" />
+              <span className="font-medium">
+                {t("apiKeyStatusBar.failureCount", {
+                  defaultValue: `已失败 ${displayedFailureCount} / ${autoDisableThreshold} 次`,
+                  count: displayedFailureCount,
+                  threshold: autoDisableThreshold,
+                })}
+              </span>
+              <span className="text-muted-foreground/60">
+                {t("apiKeyStatusBar.failureHint", {
+                  defaultValue: `(再失败 ${autoDisableThreshold - displayedFailureCount} 次将自动停用)`,
+                  remaining: autoDisableThreshold - displayedFailureCount,
+                })}
+              </span>
+            </>
+          ) : (
+            <>
+              <CheckCircle2 className="h-3 w-3" />
+              <span className="font-medium">
+                {t("apiKeyStatusBar.ready", {
+                  defaultValue: "冷却状态：就绪",
+                })}
+              </span>
+              <span className="text-muted-foreground/60">
+                {t("apiKeyStatusBar.readyHint", {
+                  defaultValue: `(${autoDisableThreshold} 次失败后自动停用)`,
+                  threshold: autoDisableThreshold,
+                })}
+              </span>
+            </>
+          )}
+        </button>
+        {hasCollapsibleContent && (
+          <ChevronDown
+            className={cn(
+              "h-3 w-3 shrink-0 text-muted-foreground/60 transition-transform duration-150",
+              expanded && "rotate-180",
+            )}
+            aria-hidden="true"
+          />
+        )}
+      </div>
+
+      {/* 进度条行 */}
+      {expanded && showUsageBar && (
+        <div className="space-y-0.5">
+          {(() => {
+            // 动态上限：coding plan 有时 100% 实际只算"基础套餐"，
+            // 真实封顶可能在 150% / 200%——按数据实际峰值动态上浮 aria-valuemax
+            // 让 a11y 报告真实比例。视觉宽度仍 clamp 到 100% 以免溢出；
+            // 颜色用 100% 阈值，与原版阈值一致。
+            const ariaMax = Math.max(100, usedPercent ?? 0);
+            return (
+              <div
+                className="flex items-center gap-1.5"
+                role="presentation"
+              >
+                <div
+                  className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-muted"
+                  role="progressbar"
+                  aria-valuenow={usedPercent ?? 0}
+                  aria-valuemin={0}
+                  aria-valuemax={ariaMax}
+                >
+                  <div
+                    className={cn(
+                      "h-full rounded-full transition-all duration-500 ease-out",
+                      usedPercent !== null && usedPercent >= 90
+                        ? "bg-red-500"
+                        : usedPercent !== null && usedPercent >= 70
+                          ? "bg-amber-500"
+                          : "bg-blue-500",
+                    )}
+                    // 视觉宽度 clamp 到 100%——>100% 的超额场景由右侧
+                    // 文字与 red 颜色表达，不让 bar 溢出容器。
+                    style={{ width: `${Math.min(100, usedPercent ?? 0)}%` }}
+                  />
+                  {/* 70% / 90% 阈值标记线：让用户直观看到离上限还有多远 */}
+                  <div className="pointer-events-none absolute inset-y-0 left-[70%] w-px bg-foreground/15" />
+                  <div className="pointer-events-none absolute inset-y-0 left-[90%] w-px bg-foreground/20" />
+                </div>
+                <span
+                  className={cn(
+                    "min-w-[3ch] text-right font-mono tabular-nums",
+                    usedPercent !== null && usedPercent >= 90
+                      ? "text-red-500"
+                      : usedPercent !== null && usedPercent >= 70
+                        ? "text-amber-500"
+                        : "text-foreground/80",
+                  )}
+                >
+                  {usedPercent}%
+                </span>
+              </div>
+            );
+          })()}
+          <div className="flex items-center gap-2 text-muted-foreground/80">
+            {/* 5h / 7d 标签——以前这里有一个 CalendarClock 计划表图标，
+                跟"配额窗口"含义重复（label 本身就说明是周期）。删掉
+                让文字本身承担语义，视觉更干净。Timer 图标仍保留给
+                右侧的 reset 倒计时——"时间在跑"是它独有的含义。 */}
+            <span>{planLabel}</span>
+            {/* 绝对数字 used/total 和「剩 X%」与进度条右侧的 usedPercent%
+                是同一份数据的不同呈现——进度条本身已带百分比数字，再把
+                "24 / 100" 和 "剩 76%" 横排一次会变成 N+1 行同源信息，
+                信息密度低，挤掉「5h 配额 24%」和「重置倒计时」的对比空间。
+                改后只保留 planLabel + 重置倒计时；想看绝对数字可 hover
+                进度条（aria-valuenow/title 已透出 used/total）。 */}
+            {primaryResetMs > 0 && (
+              <span
+                className={cn(
+                  "ml-auto inline-flex items-center gap-0.5 font-mono tabular-nums",
+                  "text-foreground/70",
+                )}
+                title={t("apiKeyStatusBar.windowResetsIn", {
+                  defaultValue: `将在 ${primaryReset} 后重置`,
+                  reset: primaryReset,
+                })}
+              >
+                <Timer className="h-2.5 w-2.5" />
+                {localizeCompactDuration(
+                  formatDualCountdown(primaryResetMs, "5h"),
+                  t,
+                )}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Per-window 倒计时进度条。
+          解析 UsageData.extra 里的「5小时:100%12m / 7天:86%12m」格式——
+          这类「window:used%<reset>」段被多个 provider（MiniMax / Packy 等）用作
+          多窗口配额展示。把它们拆成独立的进度条，比一行纯文字「12m」直观得多：
+          填充宽度对应 used%、色阶按阈值变红/黄/蓝、右侧 reset 用紧凑的 Xs/Xm/Xh/Xd。
+          解析失败时（provider 不输出这个格式）整段不渲染——不影响现有 fallback。
+          注意：5h 窗口若已被上面 primaryForDisplay 吸收（避免与主进度条重复），
+          这里就只列 7d / 30d / 月度等其它窗口。 */}
+      {expanded && windowsForList.length > 0 && (
+        <div className="mt-1.5 space-y-1.5">
+          {windowsForList.map((w, i) => {
+            // 双单位格式：窗口名匹配 5h/7d/30d → 用对应主单位分支；
+            // 未知窗口（custom / monthly 等）默认按 7d 处理——主单位是「天」。
+            const horizon: "5h" | "7d" | "30d" = fiveHourRe.test(w.name)
+              ? "5h"
+              : sevenDayRe.test(w.name)
+                ? "7d"
+                : "30d";
+            const wResetMs = parseCompactDurationToMs(w.reset);
+            const wResetLabel =
+              wResetMs > 0
+                            ? localizeCompactDuration(
+                                formatDualCountdown(wResetMs, horizon),
+                                t,
+                              )
+                            : w.reset;
+            return (
+              <div key={i} className="space-y-0.5">
+                <div className="flex items-center gap-1.5">
+                  <div
+                    className="relative h-1 flex-1 overflow-hidden rounded-full bg-muted"
+                    role="progressbar"
+                    aria-valuenow={Math.round(w.used)}
+                    aria-valuemin={0}
+                    aria-valuemax={Math.max(100, Math.round(w.used))}
+                  >
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-all duration-500 ease-out",
+                        w.used >= 90
+                          ? "bg-red-500"
+                          : w.used >= 70
+                            ? "bg-amber-500"
+                            : "bg-blue-500",
+                      )}
+                      style={{ width: `${Math.max(0, Math.min(100, w.used))}%` }}
+                    />
+                    <div className="pointer-events-none absolute inset-y-0 left-[70%] w-px bg-foreground/15" />
+                    <div className="pointer-events-none absolute inset-y-0 left-[90%] w-px bg-foreground/20" />
+                  </div>
+                  <span
+                    className={cn(
+                      "min-w-[3ch] text-right font-mono tabular-nums text-[10px]",
+                      w.used >= 90
+                        ? "text-red-500"
+                        : w.used >= 70
+                          ? "text-amber-500"
+                          : "text-foreground/70",
+                    )}
+                  >
+                    {Math.round(w.used)}%
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-2 text-[10px] text-muted-foreground/80">
+                  <span className="truncate">
+                    {w.name in TIER_I18N_KEYS
+                      ? t(TIER_I18N_KEYS[w.name], { defaultValue: w.name })
+                      : labelForWindowName(w.name, t)}
+                  </span>
+                  <span
+                    className={cn(
+                      "inline-flex items-center gap-0.5 font-mono tabular-nums",
+                      "text-foreground/70",
+                    )}
+                    title={t("apiKeyStatusBar.windowResetsIn", {
+                      defaultValue: `将在 ${w.reset} 后重置`,
+                      reset: w.reset,
+                    })}
+                  >
+                    <Timer className="h-2.5 w-2.5" />
+                    {wResetLabel}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 多 tier（TOKEN_PLAN 风格：5h / 7d 各自一个 UsageData 元素）。
+          上面 windowsForList 解析的是「5小时:100%12m」字符串；这里是
+          usage.data[] 里非主 tier 元素——planName = "five_hour" / "monthly" /
+          "weekly_limit" 等，extra 是 ISO resetsAt。与 windowsForList 用同一
+          个紧凑行 UI（progress + label + reset），避免两套样式分裂。 */}
+      {expanded && additionalTiers.length > 0 && (
+        <div className="mt-1.5 space-y-1.5">
+          {additionalTiers.map((w, i) => {
+            // 双单位格式决策——和 windowsForList 同源逻辑：
+            // 5h 名称 → "XhYm"，7d 名称 → "XdYh"，未知 → 默认 7d。
+            // 这里用 i18n key 前（raw name）做正则匹配，因为
+            // TIER_I18N_KEYS 里的翻译后字符串（如「5小时配额」）反而
+            // 不一定能被 /5\s*小时/ 命中——不同语言下字面量会变。
+            const horizon: "5h" | "7d" | "30d" = fiveHourRe.test(w.name)
+              ? "5h"
+              : sevenDayRe.test(w.name)
+                ? "7d"
+                : "30d";
+            const wResetMs = parseCompactDurationToMs(w.reset);
+            const wResetLabel =
+              wResetMs > 0
+                            ? localizeCompactDuration(
+                                formatDualCountdown(wResetMs, horizon),
+                                t,
+                              )
+                            : w.reset;
+            return (
+              <div key={`${w.name}-${i}`} className="space-y-0.5">
+                <div className="flex items-center gap-1.5">
+                  <div
+                    className="relative h-1 flex-1 overflow-hidden rounded-full bg-muted"
+                    role="progressbar"
+                    aria-valuenow={Math.round(w.used)}
+                    aria-valuemin={0}
+                    aria-valuemax={Math.max(100, Math.round(w.used))}
+                  >
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-all duration-500 ease-out",
+                        w.used >= 90
+                          ? "bg-red-500"
+                          : w.used >= 70
+                            ? "bg-amber-500"
+                            : "bg-blue-500",
+                      )}
+                      style={{ width: `${Math.max(0, Math.min(100, w.used))}%` }}
+                    />
+                    <div className="pointer-events-none absolute inset-y-0 left-[70%] w-px bg-foreground/15" />
+                    <div className="pointer-events-none absolute inset-y-0 left-[90%] w-px bg-foreground/20" />
+                  </div>
+                  <span
+                    className={cn(
+                      "min-w-[3ch] text-right font-mono tabular-nums text-[10px]",
+                      w.used >= 90
+                        ? "text-red-500"
+                        : w.used >= 70
+                          ? "text-amber-500"
+                          : "text-foreground/70",
+                    )}
+                  >
+                    {Math.round(w.used)}%
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-2 text-[10px] text-muted-foreground/80">
+                  <span className="truncate">
+                    {w.name in TIER_I18N_KEYS
+                      ? t(TIER_I18N_KEYS[w.name], { defaultValue: w.name })
+                      : labelForWindowName(w.name, t)}
+                  </span>
+                  {w.reset ? (
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-0.5 font-mono tabular-nums",
+                        "text-foreground/70",
+                      )}
+                      title={t("apiKeyStatusBar.windowResetsIn", {
+                        defaultValue: `将在 ${w.reset} 后重置`,
+                        reset: w.reset,
+                      })}
+                    >
+                      <Timer className="h-2.5 w-2.5" />
+                      {wResetLabel}
+                    </span>
+                  ) : (
+                    <span />
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────── helpers ───────────
+
+/** 5h 正则：模块级复用，避免 labelForWindowName 重复定义 */
+const FIVE_HOUR_RE = /(5\s*h(?:our)?s?|5\s*小时|five_hour)/i;
+/** 7d 正则：模块级复用 */
+const SEVEN_DAY_RE = /(7\s*d(?:ay)?s?|7\s*天|周|week|seven_day)/i;
+
+/**
+ * JS-script-style 窗口名（"5小时" / "7天" / "30天" / "月配额" 等）的 i18n
+ * 翻译。subscription-style 的 planName（"five_hour" / "seven_day"）走
+ * `TIER_I18N_KEYS` 单独处理，这里只兜底中文 / 英文 / 日文等字面量。
+ */
+function labelForWindowName(name: string, t: (key: string, options?: Record<string, unknown>) => string): string {
+  if (FIVE_HOUR_RE.test(name)) {
+    return t("apiKeyStatusBar.fiveHourWindow", { defaultValue: name });
+  }
+  if (SEVEN_DAY_RE.test(name)) {
+    return t("apiKeyStatusBar.sevenDayWindow", { defaultValue: name });
+  }
+  if (/30\s*d|30\s*天|月|month/i.test(name)) {
+    return t("apiKeyStatusBar.thirtyDayWindow", { defaultValue: name });
+  }
+  if (/周|week/i.test(name)) {
+    return t("apiKeyStatusBar.weeklyLimitWindow", { defaultValue: name });
+  }
+  return name;
+}
+
+/**
+ * 毫秒 → 紧凑格式「Xs / Xm / Xh / Xd」。
+ *
+ * 与 provider 用量显示里 MiniMax 的「5小时:100%12m 7天:86%12m」
+ * 风格保持一致——用户已经在「12m」里建立了「时间锚点」心智模型，
+ * 这里复用同一个记号，避免「12:34」与「12m」两种风格来回切换造成认知负担。
+ */
+/**
+ * 把毫秒数格式化为「紧凑剩余时长」——单单位版本，**输出字母必须
+ * 是 ASCII 单字符 s/m/h/d**，因为结果会被 `parseCompactDurationToMs`
+ * 反解回毫秒。
+ *
+ * 仅做英文 ASCII 输出。中文/日文等本地化版本走 `localizeCompactDuration`，
+ * 仅用于 UI 展示，不能再喂给 parser。
+ */
+function formatRemaining(ms: number): string {
+  const totalSec = Math.max(0, Math.ceil(ms / 1000));
+  if (totalSec < 60) return `${totalSec}s`;
+  const totalMin = Math.floor(totalSec / 60);
+  if (totalMin < 60) return `${totalMin}m`;
+  const totalHr = Math.floor(totalMin / 60);
+  if (totalHr < 24) return `${totalHr}h`;
+  const days = Math.floor(totalHr / 24);
+  return `${days}d`;
+}
+
+/**
+ * 把 formatDualCountdown / formatRemaining 的输出（例如 "3h0m" / "5d"）
+ * 转换为本地化版本显示给用户。仅做字符串替换（[smhd] → 后端单位名），
+ * 不重新算数字。
+ */
+function localizeCompactDuration(s: string, t: (key: string) => string): string {
+  // 解析纯数字+单位段，逐段替换。避免一次性 replaceAll 因为 "3h0m" 应该
+  // 变成 "3小时0分"（两个独立单位），不是 "3小时0小时" / "3小时0分"
+  // 之类的连写替换——后者由 [smhd] 单位 token 自然分隔。
+  const u = {
+    s: t("apiKeyStatusBar.units.second"),
+    m: t("apiKeyStatusBar.units.minute"),
+    h: t("apiKeyStatusBar.units.hour"),
+    d: t("apiKeyStatusBar.units.day"),
+  };
+  return s.replace(
+    /(\d+)([smhd])/g,
+    (_, n: string, unit: string) => `${n}${u[unit as "s" | "m" | "h" | "d"]}`,
+  );
+}
+
+/**
+ * 倒计时双单位格式——**内部 ASCII 版本**（与 `parseCompactDurationToMs`
+ * 输出兼容）。仅做英文输出。
+ *
+ * - 5h 窗口：「XhYm」「Ym」「Xs」
+ * - 7d 窗口：「XdYh」「XhYm」「Ym」「Xs」
+ *
+ * 负数（已过期）不渲染——调用方按 falsy 跳过。需要本地化展示时
+ * 用 `localizeDualCountdown` 替换。
+ */
+function formatDualCountdown(ms: number, horizon: "5h" | "7d" | "30d"): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "";
+  const totalSec = Math.floor(ms / 1000);
+  const totalMin = Math.floor(totalSec / 60);
+  const totalHr = Math.floor(totalMin / 60);
+  const days = Math.floor(totalHr / 24);
+  const hoursOfDay = totalHr % 24;
+  const minutesOfHour = totalMin % 60;
+  const secondsOfMinute = totalSec % 60;
+
+  if (horizon === "5h") {
+    if (totalHr >= 1) return `${totalHr}h${minutesOfHour}m`;
+    if (totalMin >= 1) return `${totalMin}m`;
+    return `${secondsOfMinute}s`;
+  }
+  if (days >= 1) return `${days}d${hoursOfDay}h`;
+  if (totalHr >= 1) return `${totalHr}h${minutesOfHour}m`;
+  if (totalMin >= 1) return `${totalMin}m`;
+  return `${secondsOfMinute}s`;
+}
+
+/**
+ * 紧凑字符串「12m / 2h / 3d / 30s」→ 毫秒。
+ *
+ * `parseUsageWindows` 拿到的「5小时:100%12m」里的 "12m" 段、`parseResetsAtForBar`
+ * 拿到的 ISO 转换后字符串，都需要先回到 ms 才能喂给 formatDualCountdown。
+ * 单字符单位（m / h / d / s）逐项匹配，避免误吃 "12month" 这种意外值。
+ * 无法识别时返回 0——调用方按 falsy 跳过。
+ */
+function parseCompactDurationToMs(s: string): number {
+  const m = s.trim().match(/^(\d+(?:\.\d+)?)\s*([smhd])$/i);
+  if (!m) return 0;
+  const n = parseFloat(m[1]);
+  if (!Number.isFinite(n)) return 0;
+  const unit = m[2].toLowerCase();
+  switch (unit) {
+    case "s":
+      return n * 1000;
+    case "m":
+      return n * 60 * 1000;
+    case "h":
+      return n * 60 * 60 * 1000;
+    case "d":
+      return n * 24 * 60 * 60 * 1000;
+    default:
+      return 0;
+  }
+}
+
+/** 解析 UsageData.extra 里的 `resetsAt`，返回紧凑格式（"12m" / "2h" / "3d"）。
+ * 接受两种形态：
+ *   - `"2026-07-01T17:00:00Z"`  → ISO 字符串
+ *   - `'{"resetsAt":"2026-07-01T17:00:00Z",...}'` → JSON 包裹（ZenMux 等）
+ * 解析失败 / 已过期 → 返回空串，调用方决定是否隐藏 reset 列。
+ *
+ * 返回值是 ASCII [smhd] 紧凑格式，便于 `parseCompactDurationToMs` 反解；
+ * UI 展示时通过 `localizeCompactDuration` 转本地化版本。
+ */
+function parseResetsAtForBar(extra: string | undefined | null): string {
+  if (!extra) return "";
+  const trimmed = extra.trim();
+  if (!trimmed) return "";
+  let iso = trimmed;
+  if (trimmed.startsWith("{")) {
+    try {
+      const obj = JSON.parse(trimmed);
+      const v = obj?.resetsAt;
+      if (typeof v !== "string") return "";
+      iso = v;
+    } catch {
+      return "";
+    }
+  }
+  const t1 = new Date(iso).getTime();
+  if (!Number.isFinite(t1)) return "";
+  const diff = t1 - Date.now();
+  if (diff <= 0) return "";
+  return formatRemaining(diff);
+}
+
+/**
+ * 解析 UsageData.extra 里的「window:used%<reset>」段。
+ *
+ * 典型输入（MiniMax / PackyCode 等）：
+ *   "5小时:100%12m 7天:86%12m"
+ *   "5h:100%12m 7d:86%12m\n30d:50%3d"
+ *   "{json}" → null（JSON 形式由 UsageFooter 单独处理，这里跳过）
+ *
+ * 规则：
+ *   - 按空白 / 换行分段
+ *   - 每段匹配 `<name>:<num>%<reset>`，三段都非空才算
+ *   - 解析失败的段被丢弃；零有效段时返回空数组
+ */
+interface UsageWindow {
+  name: string;
+  used: number;
+  reset: string;
+}
+
+function parseUsageWindows(extra: string | undefined | null): UsageWindow[] {
+  if (!extra) return [];
+  // JSON 形式由 UsageFooter 处理（QuotaTier），这里不要误吞。
+  if (extra.trim().startsWith("{")) return [];
+  const result: UsageWindow[] = [];
+  for (const seg of extra.split(/[\s,;]+/)) {
+    if (!seg) continue;
+    const m = seg.match(/^(.+?):(\d+(?:\.\d+)?)%(\S+)$/);
+    if (!m) continue;
+    const name = m[1].trim();
+    const used = parseFloat(m[2]);
+    const reset = m[3].trim();
+    if (!name || !reset || !Number.isFinite(used)) continue;
+    result.push({ name, used, reset });
+  }
+  return result;
+}

--- a/src/components/providers/ApiKeyStatusBar.tsx
+++ b/src/components/providers/ApiKeyStatusBar.tsx
@@ -247,19 +247,21 @@ export function ApiKeyStatusBar({
   // 同时把 reset 字符串还原回毫秒——下面 `primaryResetLabel` 用「XhYm」/
   // 「XdYh」双单位格式重打，"12m"/"2h" 这种单单位粒度太粗，主进度条不
   // 该用这种简化版。
-  const primaryReset: string = (() => {
-    if (fiveHourWindow?.reset) return fiveHourWindow.reset;
-    if (primaryForDisplay) {
-      const isoReset = parseResetsAtForBar(primaryForDisplay.extra);
-      if (isoReset) return isoReset;
-    }
-    return "";
-  })();
-  // `parseResetsAtForBar` 拿到的是 ISO 串走 formatRemaining 出来的紧凑
-  // 字符串（"12m" / "2h" / "3d"），需要再 `parseCompactDurationToMs` 回到
-  // ms 才能喂给 `formatDualCountdown` 走双单位分支。
-  // `fiveHourWindow.reset` 同源（"5小时:100%12m" 里的 "12m"）—— 同样路径。
-  const primaryResetMs = primaryReset ? parseCompactDurationToMs(primaryReset) : 0;
+  // ─── 5h 窗口剩余时间（精确到毫秒） ───────────────────────
+  // 数据源优先级（与旧版保持一致,精确化处理）：
+  //   1) `fiveHourWindow.reset` —— 来自 raw text "5小时:100%12m" 解析出的单
+  //      段字符串,精度被 `parseUsageWindows` 截到单单位（"12m" / "2h"），
+  //      round-trip 回去会丢次级单位。只能继续用 parseCompactDurationToMs。
+  //   2) primaryForDisplay.extra —— 我方 token_plan 路径返回的 JSON
+  //      (含 remainsTimeMs + resetsAt)。优先用 remainsTimeMs 拿精确 ms,
+  //      不再走 formatRemaining/parseCompactDurationToMs 的 round-trip。
+  // `primaryResetMs` 给 `formatDualCountdown` 走双单位分支("XhYm" / "XdYh")。
+  let primaryResetMs = 0;
+  if (fiveHourWindow?.reset) {
+    primaryResetMs = parseCompactDurationToMs(fiveHourWindow.reset);
+  } else if (primaryForDisplay) {
+    primaryResetMs = parseResetsAtMsForBar(primaryForDisplay.extra);
+  }
 
   // ─── 5h 配额窗口到点重置 ───────────────────────────────────
   // primaryResetMs 是「距下次重置的剩余 ms」——挂一个 setTimeout，到点时
@@ -331,7 +333,8 @@ export function ApiKeyStatusBar({
   const additionalTiers: Array<{
     name: string;
     used: number;
-    reset: string;
+    resetMs: number;
+    resetDisplay: string; // fallback 字符串（compact format 用于精度丢失的 JS script path）
   }> = [];
   if (usageEnabled && usage?.success && usage.data && primaryUsage) {
     for (const d of usage.data) {
@@ -344,8 +347,11 @@ export function ApiKeyStatusBar({
           : d.total && d.total > 0
             ? Math.max(0, Math.min(100, ((d.used ?? 0) / d.total) * 100))
             : 0;
-      const reset = parseResetsAtForBar(d.extra);
-      additionalTiers.push({ name, used, reset });
+      // 优先用服务端精确毫秒（无 round-trip 精度损失）;fallback 到 compact
+      // 字符串（用于 JS script path,精度本来就被截到单单位）。
+      const resetMs = parseResetsAtMsForBar(d.extra);
+      const resetDisplay = resetMs > 0 ? "" : parseResetsAtForBar(d.extra);
+      additionalTiers.push({ name, used, resetMs, resetDisplay });
     }
   }
 
@@ -614,8 +620,7 @@ export function ApiKeyStatusBar({
                   "text-foreground/70",
                 )}
                 title={t("apiKeyStatusBar.windowResetsIn", {
-                  defaultValue: `将在 ${primaryReset} 后重置`,
-                  reset: primaryReset,
+                  defaultValue: `将在 ${localizeCompactDuration(formatDualCountdown(primaryResetMs, "5h"), t)} 后重置`,
                 })}
               >
                 <Timer className="h-2.5 w-2.5" />
@@ -736,14 +741,11 @@ export function ApiKeyStatusBar({
               : sevenDayRe.test(w.name)
                 ? "7d"
                 : "30d";
-            const wResetMs = parseCompactDurationToMs(w.reset);
+            const wResetMs = w.resetMs;
             const wResetLabel =
               wResetMs > 0
-                            ? localizeCompactDuration(
-                                formatDualCountdown(wResetMs, horizon),
-                                t,
-                              )
-                            : w.reset;
+                ? localizeCompactDuration(formatDualCountdown(wResetMs, horizon), t)
+                : w.resetDisplay;
             return (
               <div key={`${w.name}-${i}`} className="space-y-0.5">
                 <div className="flex items-center gap-1.5">
@@ -787,23 +789,33 @@ export function ApiKeyStatusBar({
                       ? t(TIER_I18N_KEYS[w.name], { defaultValue: w.name })
                       : labelForWindowName(w.name, t)}
                   </span>
-                  {w.reset ? (
+                  {w.resetMs > 0 ? (
                     <span
                       className={cn(
                         "inline-flex items-center gap-0.5 font-mono tabular-nums",
                         "text-foreground/70",
                       )}
                       title={t("apiKeyStatusBar.windowResetsIn", {
-                        defaultValue: `将在 ${w.reset} 后重置`,
-                        reset: w.reset,
+                        defaultValue: `将在 ${wResetLabel} 后重置`,
                       })}
                     >
                       <Timer className="h-2.5 w-2.5" />
                       {wResetLabel}
                     </span>
-                  ) : (
-                    <span />
-                  )}
+                  ) : w.resetDisplay ? (
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-0.5 font-mono tabular-nums",
+                        "text-foreground/70",
+                      )}
+                      title={t("apiKeyStatusBar.windowResetsIn", {
+                        defaultValue: `将在 ${w.resetDisplay} 后重置`,
+                      })}
+                    >
+                      <Timer className="h-2.5 w-2.5" />
+                      {localizeCompactDuration(w.resetDisplay, t)}
+                    </span>
+                  ) : null}
                 </div>
               </div>
             );
@@ -977,6 +989,43 @@ function parseResetsAtForBar(extra: string | undefined | null): string {
   const diff = t1 - Date.now();
   if (diff <= 0) return "";
   return formatRemaining(diff);
+}
+
+/**
+ * 解析 UsageData.extra 里的精确剩余毫秒数（不经过 formatRemaining/parseCompactDurationToMs
+ * 的 round-trip,避免单单位粒度丢失次级单位）。
+ *
+ * 优先用 `remainsTimeMs`（服务端给的精确 ms,如 MiniMax *_remains_time）;
+ * 否则 fallback 到 resetsAt - Date.now()。
+ *
+ * 返回 0 表示无法识别 / 已过期,调用方按 falsy 跳过。
+ */
+function parseResetsAtMsForBar(extra: string | undefined | null): number {
+  if (!extra) return 0;
+  const trimmed = extra.trim();
+  if (!trimmed) return 0;
+  let iso: string | null = null;
+  let remainsMs = 0;
+  if (trimmed.startsWith("{")) {
+    try {
+      const obj = JSON.parse(trimmed);
+      if (typeof obj?.remainsTimeMs === "number" && obj.remainsTimeMs > 0) {
+        remainsMs = obj.remainsTimeMs;
+      }
+      if (typeof obj?.resetsAt === "string") {
+        iso = obj.resetsAt;
+      }
+    } catch {
+      // fall through
+    }
+  } else {
+    iso = trimmed;
+  }
+  if (remainsMs > 0) return remainsMs;
+  if (!iso) return 0;
+  const t1 = new Date(iso).getTime();
+  if (!Number.isFinite(t1)) return 0;
+  return Math.max(0, t1 - Date.now());
 }
 
 /**

--- a/src/components/providers/HealthStatusIndicator.tsx
+++ b/src/components/providers/HealthStatusIndicator.tsx
@@ -13,19 +13,19 @@ const statusConfig = {
   operational: {
     color: "bg-emerald-500",
     labelKey: "health.operational",
-    labelFallback: "正常",
+    labelFallback: "In rotation",
     textColor: "text-emerald-600 dark:text-emerald-400",
   },
   degraded: {
     color: "bg-yellow-500",
     labelKey: "health.degraded",
-    labelFallback: "降级",
+    labelFallback: "Degraded",
     textColor: "text-yellow-600 dark:text-yellow-400",
   },
   failed: {
     color: "bg-red-500",
     labelKey: "health.failed",
-    labelFallback: "失败",
+    labelFallback: "Failed",
     textColor: "text-red-600 dark:text-red-400",
   },
 };

--- a/src/components/providers/KeyPoolBadge.tsx
+++ b/src/components/providers/KeyPoolBadge.tsx
@@ -1,0 +1,753 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQueries, useQueryClient, useIsFetching } from "@tanstack/react-query";
+import { KeyRound, AlertCircle, Clock, Battery, BatteryLow, BatteryMedium, BatteryFull, RefreshCw, Loader2, GripVertical } from "lucide-react";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove as dndArrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useTranslation } from "react-i18next";
+import type { AppId } from "@/lib/api";
+import { usageApi } from "@/lib/api/usage";
+import {
+  useApiKeys,
+  pickActiveKey,
+  useSetActiveApiKey,
+  useUpdateApiKey,
+  useReorderApiKeys,
+} from "@/lib/query/apiKey";
+import { cn } from "@/lib/utils";
+import { ApiKeyStatusBar } from "./ApiKeyStatusBar";
+import { Switch } from "@/components/ui/switch";
+import { tagColorClasses } from "@/utils/tagColor";
+import type { UsageResult } from "@/types";
+
+/**
+ * "Battery" status of the active key in a provider's key pool.
+ *
+ * Computed from the most-restrictive signal we have:
+ *   - cooldown > now   → cooling_down
+ *   - failure_count > 0 → degraded
+ *   - enabled = false   → disabled
+ *   - otherwise        → healthy
+ *
+ * The visual is intentionally battery-shaped so it's glanceable in a list of
+ * ProviderCards: the user can spot the red/amber ones without opening the row.
+ */
+export type KeyHealth = "healthy" | "degraded" | "cooling_down" | "disabled";
+
+interface KeyPoolBadgeProps {
+  providerId: string;
+  appId: AppId;
+  /** When false, suppress the query entirely (e.g. before the provider is saved). */
+  enabled?: boolean;
+  className?: string;
+}
+
+export function KeyPoolBadge({
+  providerId,
+  appId,
+  enabled = true,
+  className,
+}: KeyPoolBadgeProps) {
+  const { t } = useTranslation();
+  const { data: keys = [] } = useApiKeys(enabled ? providerId : null, appId);
+  const activeKey = pickActiveKey(keys);
+
+  // 徽章只挂在「真正的 key 池」上——keys.length > 1 才挂：
+  //   - 单 key / 0 key：ProviderCard 的展开区 KeyPoolList 已经逐把显示
+  //     状态，再多挂一个「1 key + 电池」徽章是冗余，挤占标题栏的视觉权重。
+  //   - 多 key：徽章充当「一眼扫视」summary——count + 池里 active key 的
+  //     健康度，让用户在卡片列表里第一时间看到「这把被冷却了」「这把
+  //     失败了」之类，不需要每个 card 都展开。
+  // 注：单 key 场景下徽章关闭是个权衡；如果用户反馈说"我想在头部看到
+  // 这把 key 的当前状态"，再翻转。这里按现状保持 `> 1` 才显示。
+  if (keys.length <= 1) return null;
+
+  const health = computeKeyHealth(activeKey);
+  const inCooldown =
+    !!activeKey && activeKey.cooldownUntil * 1000 > Date.now();
+
+  const Icon = pickBatteryIcon(health, inCooldown);
+  const color = colorForHealth(health);
+  const label = t(`keyPool.health.${health}`, {
+    defaultValue: defaultLabel(health),
+  });
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-semibold",
+        color.bg,
+        color.text,
+        color.border,
+        "border",
+        className,
+      )}
+      title={label}
+    >
+      <KeyRound className="h-3 w-3" />
+      {keys.length}
+      <Icon className="h-3 w-3" />
+    </span>
+  );
+}
+
+/**
+ * Expanded per-key panel shown when the user opens the ProviderCard.
+ * Lists every key with its current runtime state — no actions, read-only
+ * (the editor lives in the form's ApiKeyListSection).
+ *
+ * 当 provider 启用了 usage_script 且拥有多把 key 时，每把 key 都会触发
+ * 自己的 per-key 用量查询（`queryProviderUsageForKey`），让"7d 配额 30/150"
+ * 这种数字精确归到对应的 key 上。React Query 按 (keyId, appId) 去重，
+ * pool 里 N 把 key 就有 N 份独立快照，互不污染。
+ */
+interface KeyPoolListProps {
+  providerId: string;
+  appId: AppId;
+  enabled?: boolean;
+  /** 用作 per-key 查询尚未返回时的兜底；正常情况下是 null。 */
+  usage?: import("@/types").UsageResult | null;
+  usageEnabled?: boolean;
+  /** provider 级别的 autoQueryInterval（分钟，0 = 关闭自动刷新）。 */
+  autoQueryInterval?: number;
+}
+
+export function KeyPoolList({
+  providerId,
+  appId,
+  enabled = true,
+  usage: providerUsageFallback,
+  usageEnabled = false,
+  autoQueryInterval = 0,
+}: KeyPoolListProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const { data: keys = [] } = useApiKeys(enabled ? providerId : null, appId);
+  const activeKey = pickActiveKey(keys);
+  // 任一 quota 100% 的 key id 集合——由 ApiKeyStatusBar 通过 onExhaustedChange
+  // 上报。row 用它来给整行加红色背景。每把 key 独立上报，互不污染。
+  const [exhaustedKeyIds, setExhaustedKeyIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  // 视觉排序：active key 置顶 —— 「激活 = 跳到池顶」是用户预期的默认
+  // 行为（与编辑面板里的 sortedKeys 同源）。DB sort_index 不动，纯展示态
+  // 重排；用户拖拽时 cursor 仍按 DB 顺序算（避免 active 钉顶造成的「拖到
+  // 上方却看似无反应」旧 bug——见 ApiKeyListSection 的 move() 注释）。
+  const sortedKeys = activeKey
+    ? [
+        ...keys.filter((k) => k.id === activeKey.id),
+        ...keys.filter((k) => k.id !== activeKey.id),
+      ]
+    : keys;
+
+  // ─── 手动 reorder + set active ──────────────────────────────
+  // Provider list 页面的 KeyPoolList 是个只读 panel，原本没有这两个动作。
+  // 编辑面板（ApiKeyListSection）已经支持拖拽 + 设为默认；这里把同样
+  // 的入口暴露出来，让用户不用切到「编辑」也能调整 active / 顺序——
+  // 切回旧路径「编辑→保存」会触发整个 provider 的 SSOT 重写，没必要。
+  const setActive = useSetActiveApiKey();
+  const reorder = useReorderApiKeys();
+  const updateApiKey = useUpdateApiKey();
+
+  // PointerSensor + 8px activation 距离：避免点按钮被误判为 drag start，
+  // 与 ApiKeyListSection 的 row 行为保持一致。
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+  );
+
+  const onDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      // 按 DB 顺序算索引（不受 active 钉顶影响），与 ApiKeyListSection 一致。
+      const oldIndex = keys.findIndex((k) => k.id === active.id);
+      const newIndex = keys.findIndex((k) => k.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      const next = dndArrayMove(keys, oldIndex, newIndex);
+      reorder.mutate({
+        appType: appId,
+        providerId,
+        orderedIds: next.map((k) => k.id),
+      });
+    },
+    [keys, reorder, appId, providerId],
+  );
+
+  // ─── 手动刷新 ───────────────────────────────────────────────
+  // 同时刷新三类数据：
+  //   1) `["apiKeys", providerId, appId]`——冷却 / 失败计数 / 启用状态
+  //   2) `["keyUsage", keyId, appId]`——每把 key 自己的用量配额进度
+  //   3) `["usage", providerId, appId]`（若存在）——provider-level 兜底
+  // `invalidateQueries` 标记为 stale 并触发 refetch，UI 上 useQueries 的
+  // `isFetching` 翻 true → 用 Loader2 旋转图标给出反馈。
+  // 注意：disable 状态由后端在「key 达到失败阈值时自动改 enabled=false」，
+  // 也会反映在 `apiKeys` query 里——必须 invalidate 它。
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["apiKeys", providerId, appId],
+    });
+    keys.forEach((k) => {
+      queryClient.invalidateQueries({
+        queryKey: ["keyUsage", k.id, appId],
+      });
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["usage", providerId, appId],
+    });
+  };
+
+  // 5h 配额窗口到点重置：每把 key 各自挂 setTimeout，倒计到 0 时由
+  // <ApiKeyStatusBar onFiveHourResetReached> 触发本回调。我们只 invalidate
+  // 这一把 key 的 `keyUsage`，再顺手 invalidate 一次全局 `apiKeys`
+  // （key 可能在 5h 临界点同时解锁 / 重新进入 cooldown）。provider-level
+  // 的 `usage` 兜底查询保持不动——它的 reset 节奏独立于单把 key 的 5h。
+  //
+  // 跟 handleRefresh 区别：
+  //   - handleRefresh：用户主动点击按钮，同时刷所有 key，UI 给反馈。
+  //   - handleKeyResetReached：纯后台静默触发，5h 窗口到点自动 invalidate，
+  //     用户无需操作，UI 上的 `isFetching` 翻动也很短暂（通常 < 500ms）。
+  // 不共用 handleRefresh 是为了在后台路径里避免无谓的循环（只刷自己
+  // 需要的 key，不扇出到整个 pool）。
+  const handleKeyResetReached = useCallback(
+    (keyId: string) => {
+      queryClient.invalidateQueries({
+        queryKey: ["keyUsage", keyId, appId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["apiKeys", providerId, appId],
+      });
+    },
+    [queryClient, providerId, appId],
+  );
+
+  // 每把 key 自己的用量：useQueries 扇出，React Query 按 (keyId, appId) 自动
+  // 去重——同 keyId 多次出现（拖拽、re-render）只发一次请求。`enabled` 双控：
+  //   - usageEnabled：父组件判断 provider 启用了 usage_script；
+  //   - k.enabled：单把 key 关闭时不消耗一次 API 调用。
+  // query key 故意不带 providerId；keyId 唯一即可。
+  const perKeyQueries = useQueries({
+    queries: keys.map((k) => ({
+      queryKey: ["keyUsage", k.id, appId] as const,
+      queryFn: () => usageApi.queryForKey(providerId, k.id, appId),
+      enabled: usageEnabled && k.enabled,
+      retry: 1,
+      retryDelay: 1500,
+      staleTime:
+        autoQueryInterval > 0
+          ? autoQueryInterval * 60 * 1000
+          : 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+      refetchInterval:
+        autoQueryInterval > 0
+          ? Math.max(autoQueryInterval, 1) * 60 * 1000
+          : false,
+      refetchIntervalInBackground: true,
+      refetchOnWindowFocus: false,
+    })),
+  });
+  // 把 query 结果按 keyId 建索引，避免每次 O(N^2) 找 row 对应数据。
+  const usageByKeyId = useMemo(() => {
+    const map = new Map<string, UsageResult | null>();
+    keys.forEach((k, i) => {
+      const data = perKeyQueries[i]?.data as UsageResult | undefined;
+      map.set(k.id, data ?? null);
+    });
+    return map;
+  }, [keys, perKeyQueries]);
+
+  // 「refreshing」状态：监听所有相关 query 的 in-flight 数量。
+  // 不用局部 boolean 是因为 React Query 已经在管 refetch 生命周期，
+  // 直接读它的计数器最准确——即便 handleRefresh 被并发触发也不会丢状态。
+  // `isApiKeysFetching` 必须放在 hooks 顶层；放在循环里会违反 Rules of Hooks。
+  // per-key 状态直接读 useQueries 返回的 `q.isFetching`，无需再 hook。
+  const isApiKeysFetching = useIsFetching({
+    queryKey: ["apiKeys", providerId, appId],
+  });
+  const isPerKeyFetching = perKeyQueries.some((q) => q.isFetching);
+  const isRefreshing = isApiKeysFetching > 0 || isPerKeyFetching;
+
+  if (keys.length === 0) return null;
+
+  return (
+    <div className="mt-3 space-y-1.5">
+      <div className="flex items-center justify-between">
+        <h5 className="text-xs font-semibold text-muted-foreground">
+          {t("keyPool.listTitle", {
+            count: keys.length,
+            defaultValue: `API Key 池 (${keys.length})`,
+          })}
+        </h5>
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] text-muted-foreground/70">
+            {t("keyPool.listHint", {
+              defaultValue: "代理模式下自动轮换；编辑面板在「编辑」中",
+            })}
+          </span>
+          {/* 手动刷新：把按钮放在标题行最右侧（listHint 之后），避免与每
+              把 key 的状态行抢视觉空间。loading 期间把图标换成 Loader2
+              旋转——区别于静态的 RefreshCw，给用户「请求已发出」的明确
+              反馈。同时 disable 防止并发点击导致重复 refetch。 */}
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            aria-label={t("keyPool.refresh", { defaultValue: "刷新" })}
+            title={
+              isRefreshing
+                ? t("keyPool.refreshing", { defaultValue: "刷新中…" })
+                : t("keyPool.refresh", { defaultValue: "刷新" })
+            }
+            className={cn(
+              "inline-flex h-5 w-5 items-center justify-center rounded-md",
+              "text-muted-foreground/70 hover:text-foreground hover:bg-muted/60",
+              "transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            )}
+          >
+            {isRefreshing ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+          </button>
+        </div>
+      </div>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={onDragEnd}
+      >
+        <SortableContext
+          items={sortedKeys.map((k) => k.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <ul className="space-y-1">
+            {sortedKeys.map((k) => {
+              const isActive = k.id === activeKey?.id;
+              const inCooldown = k.cooldownUntil * 1000 > Date.now();
+              const health = computeKeyHealth(k);
+              const healthColor = colorForHealth(health);
+              // 优先 per-key 数据；尚未返回时回退到父组件传入的 provider-level 快照，
+              // 避免第一帧 key 行空白闪烁。
+              const perKeyUsage = usageByKeyId.get(k.id) ?? null;
+              const rowUsage = perKeyUsage ?? providerUsageFallback ?? null;
+              // 与 ApiKeyListSection 保持一致：只在 per-key query 真的成功且有数据
+              // 时才让 ApiKeyStatusBar 渲染配额条。否则 rowUsage 是 provider-level
+              // 兜底（用的还是老的 active key），不能让它顶替当前 key 的进度条——
+              // 那会显示一个"看似正确"但其实跟本 key 无关的百分比，误导用户。
+              // 这里强制按 per-key 成功与否决定；provider-level 兜底仍用于上方 key
+              // 行的瞬态占位（rowUsage 那一行）。
+              const rowUsageEnabled =
+                usageEnabled &&
+                !!perKeyUsage?.success &&
+                !!perKeyUsage.data &&
+                perKeyUsage.data.length > 0;
+
+              // 是否锁定「加入轮换」开关——
+              // 1) 任一 quota 100%（与 isExhausted 同一信号）
+              // 2) API 失效：query 失败、success=false 或 data 为空
+              //    （成功但无数据意味着上游没返回有效用量；通常是脚本
+              //     模板/网络层错）
+              // 3) Key 已进 cooldown（被轮换耗尽或被 proactive rotation 标
+              //    记），用户重新打开也只会再被冻回去
+              const apiInvalid =
+                usageEnabled &&
+                (perKeyUsage === null ||
+                  perKeyUsage.success !== true ||
+                  !perKeyUsage.data ||
+                  perKeyUsage.data.length === 0);
+              const isRotationBlocked =
+                exhaustedKeyIds.has(k.id) || inCooldown || apiInvalid;
+              const rotationBlockedReason = exhaustedKeyIds.has(k.id)
+                ? t("keyPool.rotationBlockedExhausted", {
+                    defaultValue: "5h/7d 配额已耗尽",
+                  })
+                : inCooldown
+                  ? t("keyPool.rotationBlockedCooldown", {
+                      defaultValue: "冷却中，轮换已禁用",
+                    })
+                  : apiInvalid
+                    ? t("keyPool.rotationBlockedApiInvalid", {
+                        defaultValue: "API 无响应或失效，已禁用轮换",
+                      })
+                    : undefined;
+
+              return (
+                <SortableKeyRow
+                  key={k.id}
+                  keyId={k.id}
+                  isActive={isActive}
+                  inCooldown={inCooldown}
+                  healthColor={healthColor}
+                  label={
+                    k.label ||
+                    t("keyPool.unnamed", { defaultValue: "(未命名)" })
+                  }
+                  tags={k.tags}
+                  enabled={k.enabled}
+                  failureCount={k.failureCount}
+                  cooldownUntil={k.cooldownUntil}
+                  rowUsage={rowUsage}
+                  rowUsageEnabled={rowUsageEnabled}
+                  onSetActive={() =>
+                    setActive.mutate({
+                      providerId,
+                      appType: appId,
+                      keyId: k.id,
+                    })
+                  }
+                  onToggleEnabled={() =>
+                    updateApiKey.mutate({
+                      keyId: k.id,
+                      payload: { enabled: !k.enabled },
+                    })
+                  }
+                  isExhausted={exhaustedKeyIds.has(k.id)}
+                  isRotationBlocked={isRotationBlocked}
+                  rotationBlockedReason={rotationBlockedReason}
+                  onExhaustedChange={(ex) => {
+                    setExhaustedKeyIds((prev) => {
+                      const next = new Set(prev);
+                      if (ex) next.add(k.id);
+                      else next.delete(k.id);
+                      return next;
+                    });
+                  }}
+                  onFiveHourResetReached={() => handleKeyResetReached(k.id)}
+                />
+              );
+            })}
+          </ul>
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+}
+
+// ─────────── Sortable row ───────────
+
+interface SortableKeyRowProps {
+  /** Stable id for dnd-kit — must match `SortableContext.items`. */
+  keyId: string;
+  isActive: boolean;
+  inCooldown: boolean;
+  healthColor: ReturnType<typeof colorForHealth>;
+  label: string;
+  tags: string[];
+  enabled: boolean;
+  failureCount: number;
+  cooldownUntil: number;
+  rowUsage: UsageResult | null;
+  rowUsageEnabled: boolean;
+  isExhausted: boolean;
+  /** 任一 quota 100% 或 API 失效时为 true，禁用轮换开关 */
+  isRotationBlocked: boolean;
+  /** 行级禁用原因（用于 hover title 解释为什么 toggle 不能点） */
+  rotationBlockedReason?: string;
+  onSetActive: () => void;
+  onToggleEnabled: () => void;
+  onExhaustedChange: (exhausted: boolean) => void;
+  onFiveHourResetReached: () => void;
+}
+
+/**
+ * 单把 key 的可拖拽 row。
+ *
+ * dnd-kit `useSortable` 让整行可拖——但与编辑面板里的 row 不同，
+ * 这里池子里 key 数量通常 2-5 把，pool 一行视觉高度只有 ~50px，
+ * 给整行加 `cursor-grab` 反而容易让"点 set-active"误判为 drag。
+ * 解法：拖拽 handle 限定到 GripVertical icon，按钮（setActive）
+ * 显式 `onPointerDown stopPropagation` 阻断 dnd-kit。
+ *
+ * 视觉态跟编辑面板一致：active key 蓝边/蓝底，4px 蓝条由
+ * border-l-4 提供。
+ */
+function SortableKeyRow({
+  keyId,
+  isActive,
+  inCooldown,
+  healthColor,
+  label,
+  tags,
+  enabled,
+  failureCount,
+  cooldownUntil,
+  rowUsage,
+  rowUsageEnabled,
+  isExhausted,
+  isRotationBlocked,
+  rotationBlockedReason,
+  onSetActive,
+  onToggleEnabled,
+  onExhaustedChange,
+  onFiveHourResetReached,
+}: SortableKeyRowProps) {
+  const { t } = useTranslation();
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: keyId });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+    opacity: isDragging ? 0.85 : 1,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      className={cn(
+        "rounded-md border px-2 py-1 text-xs",
+        isActive
+          ? "border-blue-400/60 bg-blue-50/40 dark:border-blue-700/50 dark:bg-blue-950/20"
+          : isExhausted
+            ? // 任一 quota 100%——浅红底，弱化「bar 不可见 = 信号丢失」的风险。
+              "border-red-400/60 bg-red-50/40 dark:border-red-700/50 dark:bg-red-950/20"
+            : "border-border-default bg-card/40",
+      )}
+    >
+      {/* 头部一行：drag handle + 标识 + label + 健康徽标 + set-active 按钮 */}
+      {/* Grid 布局 5 列：
+            [drag] [active-dot] [label+badges] [activate/activated] [rotation-toggle]
+            label 列 1fr 占满剩余空间；其它四列 auto。
+            Switch 选中状态对应该 key 是否参与轮换——关闭时 KeyRing 的
+            next_key 不会选中这把，强制绕过限流 / 余额耗尽的 key。
+            单独的「停用」标签已不再展示在 header（Switch 关态本身就是
+            视觉锚点），但 ApiKeyStatusBar 仍读 enabled 用于状态行文案。 */}
+      <div className="grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-2">
+        <button
+          type="button"
+          // 让 GripVertical 成为唯一拖拽入口——避免误触 setActive / Switch
+          // 时被 dnd-kit 当成"开始拖"。onPointerDown 不需要 stopPropagation：
+          // listeners 直接挂在这个 button 上，不会冒泡。
+          {...listeners}
+          className="flex h-4 w-3 cursor-grab items-center justify-center text-muted-foreground/60 hover:text-foreground active:cursor-grabbing"
+          aria-label={t("keyPool.dragHandle", {
+            defaultValue: "拖动以重新排序",
+          })}
+        >
+          <GripVertical className="h-3 w-3" />
+        </button>
+        {/* 激活状态：绿点（在 label 左侧）。灰点（非 active）和绿点
+            （active）形状一致，仅颜色变化，保证 row 高度对齐。 */}
+        {isActive ? (
+          <span
+            className="h-2 w-2 flex-shrink-0 rounded-full bg-emerald-500 shadow-[0_0_0_2px_rgba(16,185,129,0.18)]"
+            aria-label={t("keyPool.active", {
+              defaultValue: "Active",
+            })}
+          />
+        ) : (
+          <span
+            className="h-2 w-2 flex-shrink-0 rounded-full bg-muted-foreground/40"
+            aria-hidden
+          />
+        )}
+        {/* 中间列：label + 健康徽标 + tags。两层结构 —— 上层 label 与徽标
+            inline 横排，下层 tags 单独一行。tags 不与徽标同层，避免窄
+            行时徽标被挤换行后跟标签挤一团。tag 配色复用 ApiKeyListSection
+            里的 hash 调色板（蓝/绿/琥珀/玫瑰/紫/青），保持跨面板视觉
+            一致——同一个 tag 在「编辑面板 row」与「provider 列表 row」
+            上颜色相同。 */}
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="min-w-0 truncate font-medium">{label}</span>
+            {inCooldown ? (
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 text-[10px]",
+                  healthColor.text,
+                )}
+              >
+                <Clock className="h-3 w-3" />
+                {t("keyPool.cooldown", { defaultValue: "冷却" })}
+              </span>
+            ) : failureCount > 0 ? (
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 text-[10px]",
+                  healthColor.text,
+                )}
+              >
+                <AlertCircle className="h-3 w-3" />
+                {Math.min(failureCount, 5)}
+              </span>
+            ) : null}
+          </div>
+          {tags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1">
+              {tags.map((tag) => (
+                <span
+                  key={tag}
+                  className={cn(
+                    "rounded-full px-1.5 py-px text-[9px] font-medium",
+                    tagColorClasses(tag),
+                  )}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        {/* Activate / Activated 标签：active 时显示绿色"Activated"标签
+            且不可点击；非 active 时显示"Activate"按钮，点击触发 setActive。
+            两种状态视觉对比强，但形状一致保持 row 高度。
+            锁定条件：quota 100% / API 失效 / 冷却中——这把 key 不能切为
+            active，否则 5h 桶继续打满无意义；title 提示锁定原因。 */}
+        <button
+          type="button"
+          onClick={onSetActive}
+          disabled={isActive || isRotationBlocked}
+          onPointerDown={(e) => e.stopPropagation()}
+          title={
+            isRotationBlocked && !isActive
+              ? rotationBlockedReason ??
+                t("keyPool.rotationBlocked", {
+                  defaultValue: "该 API key 暂时不可用，已禁用轮换",
+                })
+              : t("keyPool.setActive", { defaultValue: "设为默认" })
+          }
+          aria-label={t("keyPool.setActive", { defaultValue: "设为默认" })}
+          className={cn(
+            "inline-flex h-5 items-center rounded-md px-1.5 text-[10px] font-semibold transition-colors",
+            isActive
+              ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300 cursor-default"
+              : isRotationBlocked
+                ? // 锁定时仍允许视觉看到「这是 Activate 按钮」，但调暗 +
+                  //   cursor-not-allowed 让用户感知不能点；hover 不变色
+                  "text-muted-foreground/40 cursor-not-allowed"
+                : "text-muted-foreground/80 hover:text-foreground hover:bg-muted/60",
+          )}
+        >
+          {isActive
+            ? t("keyPool.activatedLabel", { defaultValue: "Activated" })
+            : t("keyPool.activateLabel", { defaultValue: "Activate" })}
+        </button>
+        {/* 轮换参与开关：关掉后 KeyRing.next_key 跳过这把 key，
+            但不删 row——用户切回来只需再打开。与编辑面板里的 Switch
+            行为一致，复用 useUpdateApiKey。 */}
+        <Switch
+          checked={enabled}
+          onCheckedChange={onToggleEnabled}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={t("keyPool.toggleRotation", {
+            defaultValue: "加入轮换",
+          })}
+        />
+      </div>
+      {/* 状态条：冷却倒计时 + 该 key 自己的用量进度条。per-key 数据由
+          useQueries 拉取，Rust 端 queryProviderUsageForKey 使用
+          provider_api_keys 里这一行自己的 api_key 跑脚本。 */}
+      <ApiKeyStatusBar
+        keyId={keyId}
+        cooldownUntil={cooldownUntil}
+        failureCount={failureCount}
+        enabled={enabled}
+        usage={rowUsage}
+        usageEnabled={rowUsageEnabled}
+        onFiveHourResetReached={onFiveHourResetReached}
+        onExhaustedChange={onExhaustedChange}
+      />
+    </li>
+  );
+}
+
+// ─────────── helpers ───────────
+
+function computeKeyHealth(key: {
+  enabled: boolean;
+  cooldownUntil: number;
+  failureCount: number;
+} | null | undefined): KeyHealth {
+  if (!key) return "disabled";
+  if (!key.enabled) return "disabled";
+  if (key.cooldownUntil * 1000 > Date.now()) return "cooling_down";
+  if (key.failureCount > 0) return "degraded";
+  return "healthy";
+}
+
+function pickBatteryIcon(
+  health: KeyHealth,
+  inCooldown: boolean,
+): React.ComponentType<{ className?: string }> {
+  if (inCooldown) return Clock;
+  switch (health) {
+    case "healthy":
+      return BatteryFull;
+    case "degraded":
+      return BatteryMedium;
+    case "cooling_down":
+      return BatteryLow;
+    case "disabled":
+      return Battery;
+    default:
+      return Battery;
+  }
+}
+
+function colorForHealth(health: KeyHealth) {
+  switch (health) {
+    case "healthy":
+      return {
+        bg: "bg-emerald-50 dark:bg-emerald-950/30",
+        text: "text-emerald-700 dark:text-emerald-300",
+        border: "border-emerald-200 dark:border-emerald-800",
+      };
+    case "degraded":
+      return {
+        bg: "bg-amber-50 dark:bg-amber-950/30",
+        text: "text-amber-700 dark:text-amber-300",
+        border: "border-amber-200 dark:border-amber-800",
+      };
+    case "cooling_down":
+      return {
+        bg: "bg-orange-50 dark:bg-orange-950/30",
+        text: "text-orange-700 dark:text-orange-300",
+        border: "border-orange-200 dark:border-orange-800",
+      };
+    case "disabled":
+    default:
+      return {
+        bg: "bg-slate-100 dark:bg-slate-800/40",
+        text: "text-slate-600 dark:text-slate-300",
+        border: "border-slate-200 dark:border-slate-700",
+      };
+  }
+}
+
+function defaultLabel(health: KeyHealth): string {
+  switch (health) {
+    case "healthy":
+      return "正常";
+    case "degraded":
+      return "有失败";
+    case "cooling_down":
+      return "冷却中";
+    case "disabled":
+      return "已停用";
+  }
+}

--- a/src/components/providers/KeyPoolBadge.tsx
+++ b/src/components/providers/KeyPoolBadge.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQueries, useQueryClient, useIsFetching } from "@tanstack/react-query";
 import { KeyRound, AlertCircle, Clock, Battery, BatteryLow, BatteryMedium, BatteryFull, RefreshCw, Loader2, GripVertical } from "lucide-react";
 import {
@@ -197,7 +197,15 @@ export function KeyPoolList({
   // `isFetching` 翻 true → 用 Loader2 旋转图标给出反馈。
   // 注意：disable 状态由后端在「key 达到失败阈值时自动改 enabled=false」，
   // 也会反映在 `apiKeys` query 里——必须 invalidate 它。
-  const handleRefresh = () => {
+  //
+  // **forceRefreshTick 同步 +1**：让 disabled key 也能在本次刷新里
+  // 重新拉数据。普通 invalidate 对 disabled query 是 no-op（TanStack
+  // Query 文档明确「The query will ignore `invalidateQueries` and
+  // `refetchQueries` calls」），所以 +1 是必需的——具体见 useQueries 的
+  // `enabled` 判定注释。所有 query settle 后 effect 把 tick 归零。
+  const [forceRefreshTick, setForceRefreshTick] = useState(0);
+  const handleRefresh = useCallback(() => {
+    setForceRefreshTick((t) => t + 1);
     queryClient.invalidateQueries({
       queryKey: ["apiKeys", providerId, appId],
     });
@@ -209,7 +217,7 @@ export function KeyPoolList({
     queryClient.invalidateQueries({
       queryKey: ["usage", providerId, appId],
     });
-  };
+  }, [queryClient, providerId, appId, keys]);
 
   // 5h 配额窗口到点重置：每把 key 各自挂 setTimeout，倒计到 0 时由
   // <ApiKeyStatusBar onFiveHourResetReached> 触发本回调。我们只 invalidate
@@ -239,12 +247,16 @@ export function KeyPoolList({
   // 去重——同 keyId 多次出现（拖拽、re-render）只发一次请求。`enabled` 双控：
   //   - usageEnabled：父组件判断 provider 启用了 usage_script；
   //   - k.enabled：单把 key 关闭时不消耗一次 API 调用。
+  //   - **forceRefreshTick > 0**：用户主动点刷新按钮时临时「骗」React Query
+  //     打开所有 query，包括 k.enabled=false 的——见 handleRefresh 注释。
+  //     不用这条的话，被用户停用的 key 永远停在 invalidate 之前的旧缓存
+  //     上，是「7d 配额重置后进度条不更新」的根因。
   // query key 故意不带 providerId；keyId 唯一即可。
   const perKeyQueries = useQueries({
     queries: keys.map((k) => ({
       queryKey: ["keyUsage", k.id, appId] as const,
       queryFn: () => usageApi.queryForKey(providerId, k.id, appId),
-      enabled: usageEnabled && k.enabled,
+      enabled: usageEnabled && (k.enabled || forceRefreshTick > 0),
       retry: 1,
       retryDelay: 1500,
       staleTime:
@@ -280,6 +292,18 @@ export function KeyPoolList({
   });
   const isPerKeyFetching = perKeyQueries.some((q) => q.isFetching);
   const isRefreshing = isApiKeysFetching > 0 || isPerKeyFetching;
+
+  // forceRefreshTick 归零：所有相关 query 都 settle 后，把 tick 拉回 0，
+  // 让 enabled 判定恢复「k.enabled 必须为 true」——避免下一次组件
+  // re-render 仍然让 disabled key 持续触发 refetch。
+  // 「settle」= apiKeys 和 per-key 都不在 fetching 状态。effect 的依赖
+  // 里包含 forceRefreshTick，确保每次 +1 后都会重新评估 settle 条件。
+  // 与 ApiKeyListSection 的同名 effect 同源。
+  useEffect(() => {
+    if (forceRefreshTick === 0) return;
+    if (isApiKeysFetching > 0 || isPerKeyFetching) return;
+    setForceRefreshTick(0);
+  }, [forceRefreshTick, isApiKeysFetching, isPerKeyFetching]);
 
   if (keys.length === 0) return null;
 

--- a/src/components/providers/ProviderActions.tsx
+++ b/src/components/providers/ProviderActions.tsx
@@ -5,9 +5,7 @@ import {
   Copy,
   Edit,
   Loader2,
-  Minus,
   Play,
-  Plus,
   Terminal,
   Trash2,
   Zap,
@@ -33,9 +31,6 @@ interface ProviderActionsProps {
   onRemoveFromConfig?: () => void;
   onDisableOmo?: () => void;
   onOpenTerminal?: () => void;
-  isAutoFailoverEnabled?: boolean;
-  isInFailoverQueue?: boolean;
-  onToggleFailover?: (enabled: boolean) => void;
   isOfficialBlockedByProxy?: boolean;
   // Hermes v12+ providers: dict overlay — edit/delete must go through Web UI
   isReadOnly?: boolean;
@@ -69,12 +64,8 @@ export function ProviderActions({
   onTest,
   onConfigureUsage,
   onDelete,
-  onRemoveFromConfig,
   onDisableOmo,
   onOpenTerminal,
-  isAutoFailoverEnabled = false,
-  isInFailoverQueue = false,
-  onToggleFailover,
   isOfficialBlockedByProxy = false,
   isReadOnly = false,
   // OpenClaw: default model
@@ -90,10 +81,15 @@ export function ProviderActions({
     appId === "openclaw" ||
     appId === "hermes";
 
-  // 故障转移模式下的按钮逻辑（累加模式和 OMO 应用不支持故障转移）
-  const isFailoverMode =
-    !isAdditiveMode && !isOmo && isAutoFailoverEnabled && onToggleFailover;
-
+  // 注：per-provider 轮换 toggle 不再「替换」主按钮，而是独立的右侧
+  // 图标按钮（在 onToggleFailover 存在时显示）。isFailoverMode 这个
+  // 「覆盖主按钮」的状态分支已废弃——主按钮现在统一是「启用 / 已在用」，
+  // 轮换 toggle 跟编辑、复制、检测、删除那排图标并列。
+  //
+  // 全局 auto_failover_enabled 跟 per-provider in_failover_queue
+  // 是两层独立的开关：全局决定「是否走 provider_router」，per-provider
+  // 决定「这个 provider 是否参与轮换」。它们由 forwarder 在 Rust 端
+  // 组合判断——UI 这里只暴露独立的 toggle 给用户，不做耦合。
   const handleMainButtonClick = () => {
     if (isOmo) {
       if (isCurrent) {
@@ -101,19 +97,6 @@ export function ProviderActions({
       } else {
         onSwitch();
       }
-    } else if (isAdditiveMode) {
-      // 累加模式：切换配置状态（添加/移除）
-      if (isInConfig) {
-        if (onRemoveFromConfig) {
-          onRemoveFromConfig();
-        } else {
-          onDelete();
-        }
-      } else {
-        onSwitch(); // 添加到配置
-      }
-    } else if (isFailoverMode) {
-      onToggleFailover(!isInFailoverQueue);
     } else {
       onSwitch();
     }
@@ -140,51 +123,14 @@ export function ProviderActions({
       };
     }
 
-    // 累加模式（OpenCode 非 OMO / OpenClaw）
-    if (isAdditiveMode) {
-      if (isInConfig) {
-        return {
-          disabled: isDefaultModel === true,
-          variant: "secondary" as const,
-          className: cn(
-            "bg-orange-100 text-orange-600 hover:bg-orange-200 dark:bg-orange-900/50 dark:text-orange-400 dark:hover:bg-orange-900/70",
-            isDefaultModel && "opacity-40 cursor-not-allowed",
-          ),
-          icon: <Minus className="h-4 w-4" />,
-          text: t("provider.removeFromConfig", { defaultValue: "移除" }),
-        };
-      }
-      return {
-        disabled: false,
-        variant: "default" as const,
-        className:
-          "bg-emerald-500 hover:bg-emerald-600 dark:bg-emerald-600 dark:hover:bg-emerald-700",
-        icon: <Plus className="h-4 w-4" />,
-        text: t("provider.addToConfig", { defaultValue: "添加" }),
-      };
-    }
-
-    if (isFailoverMode) {
-      if (isInFailoverQueue) {
-        return {
-          disabled: false,
-          variant: "secondary" as const,
-          className:
-            "bg-blue-100 text-blue-600 hover:bg-blue-200 dark:bg-blue-900/50 dark:text-blue-400 dark:hover:bg-blue-900/70",
-          icon: <Check className="h-4 w-4" />,
-          text: t("failover.inQueue", { defaultValue: "已加入" }),
-        };
-      }
-      return {
-        disabled: false,
-        variant: "default" as const,
-        className:
-          "bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700",
-        icon: <Plus className="h-4 w-4" />,
-        text: t("failover.addQueue", { defaultValue: "加入" }),
-      };
-    }
-
+    // 累加模式应用（OpenCode 非 OMO / OpenClaw / Hermes）改为走默认分支：
+    // 按钮显示「启用 / 已在用」，点击直接 onSwitch 切换当前 provider——
+    // 恢复旧版行为。OpenCode 多 provider 共存的逻辑由后端 provider_router
+    // 处理：第一个启用的进 active，第二个启用替换第一个；不再用「+ / -」
+    // 表示「添加 / 移除」。
+    //
+    // 故障转移不再挤占主按钮——它走右侧独立的「轮询 toggle 图标按钮」
+    // （`onToggleFailover` 分支），主按钮恢复成纯启用/已在用语义。
     if (isCurrent) {
       return {
         disabled: true,

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -8,12 +8,18 @@ import type {
 import type { Provider } from "@/types";
 import type { AppId } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { KeyPoolBadge, KeyPoolList } from "@/components/providers/KeyPoolBadge";
+import { useApiKeys } from "@/lib/query/apiKey";
 import { ProviderActions } from "@/components/providers/ProviderActions";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import UsageFooter from "@/components/UsageFooter";
 import SubscriptionQuotaFooter from "@/components/SubscriptionQuotaFooter";
 import CopilotQuotaFooter from "@/components/CopilotQuotaFooter";
 import CodexOauthQuotaFooter from "@/components/CodexOauthQuotaFooter";
+import {
+  TokenPlanQuotaFooter,
+  isTokenPlanProvider,
+} from "@/components/TokenPlanQuotaFooter";
 import { PROVIDER_TYPES, TEMPLATE_TYPES } from "@/config/constants";
 import { isHermesReadOnlyProvider } from "@/config/hermesProviderPresets";
 import { ProviderHealthBadge } from "@/components/providers/ProviderHealthBadge";
@@ -252,13 +258,22 @@ export function ProviderCard({
   const hasMultiplePlans =
     usage?.success && usage.data && usage.data.length > 1 && !isTokenPlan;
 
+  // 多 Key 池：仅在编辑后或代理接管后才会有数据，ProviderList 上多个 card 时
+  // 共享 useApiKeys 的 React Query 缓存（refetchInterval 内只发一次请求）。
+  const { data: apiKeys = [] } = useApiKeys(
+    isHermesReadOnly ? null : provider.id,
+    appId,
+  );
+  const hasKeyPool = apiKeys.length > 1;
+  const canExpand = hasMultiplePlans || hasKeyPool;
+
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
-    if (hasMultiplePlans) {
+    if (canExpand) {
       setIsExpanded(true);
     }
-  }, [hasMultiplePlans]);
+  }, [canExpand]);
 
   const handleOpenWebsite = () => {
     if (!isClickableUrl) {
@@ -350,6 +365,63 @@ export function ProviderCard({
                 {provider.name}
               </h3>
 
+              {/* per-provider 轮换 toggle——iOS-style switch，紧跟 provider.name。
+                  1) **位置**：放在 <h3> 之后、`flex flex-wrap` 容器里，与 name
+                     + 各种 badge 同行；不再用 ml-auto 推到最右，因为用户希望它
+                     直接挨着名字，作为「这个供应商的轮换开关」的强语义锚点。
+                  2) **样式**：白圆点 + 绿色/灰底的内联 toggle（CSS-only，
+                     不依赖 lucide ToggleLeft/Right 图标——直接画圆点更轻量
+                     且视觉一致）。
+                  3) **不放在 ProviderActions 里**：ProviderActions 整个被
+                     `opacity-0 group-hover:opacity-100` 包住做 auto-hide，
+                     toggle 嵌进去会跟着一起消失，违背「始终可见」的需求。
+                  4) **始终渲染**：onToggleFailover 缺失或 isOmo 时仅 disabled，
+                     不隐藏。tooltip 提示「在 settings 启用 failover 后可用」
+                     /「OMO 不参与轮换池」，引导用户去正确位置启用。 */}
+              <button
+                type="button"
+                role="switch"
+                aria-checked={isInFailoverQueue}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (onToggleFailover && !isAnyOmo) {
+                    onToggleFailover(!isInFailoverQueue);
+                  }
+                }}
+                disabled={!onToggleFailover || isAnyOmo}
+                title={
+                  isAnyOmo
+                    ? t("failover.disabledForOmo", {
+                        defaultValue: "OMO 不参与轮换",
+                      })
+                    : !onToggleFailover
+                      ? t("failover.disabledNoRotation", {
+                          defaultValue: "在 settings 启用 failover 后可用",
+                        })
+                      : isInFailoverQueue
+                        ? t("failover.inRotation", { defaultValue: "In rotation" })
+                        : t("failover.addToRotation", { defaultValue: "Add to rotation" })
+                }
+                className={cn(
+                  "relative inline-flex flex-shrink-0 items-center",
+                  "h-5 w-9 rounded-full border transition-colors duration-200",
+                  isInFailoverQueue
+                    ? "bg-emerald-500 border-emerald-600 shadow-sm shadow-emerald-500/30"
+                    : "bg-black/[0.08] dark:bg-white/[0.12] border-black/[0.08] dark:border-white/[0.08]",
+                  (!onToggleFailover || isAnyOmo) &&
+                    "opacity-50 cursor-not-allowed",
+                )}
+              >
+                <span
+                  className={cn(
+                    "absolute top-1/2 -translate-y-1/2 h-4 w-4 rounded-full bg-white shadow-sm transition-all duration-200 ease-out",
+                    isInFailoverQueue
+                      ? "left-[calc(100%-1.05rem)]"
+                      : "left-[0.1rem]",
+                  )}
+                />
+              </button>
+
               {isOmo && (
                 <span className="inline-flex items-center rounded-md bg-violet-100 px-1.5 py-0.5 text-[10px] font-semibold text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
                   OMO
@@ -360,6 +432,15 @@ export function ProviderCard({
                 <span className="inline-flex items-center rounded-md bg-indigo-100 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
                   Slim
                 </span>
+              )}
+
+              {/* 多 Key 池徽章：仅当该供应商有 ≥2 把 key 时显示 */}
+              {!isAnyOmo && (
+                <KeyPoolBadge
+                  providerId={provider.id}
+                  appId={appId}
+                  enabled={!isHermesReadOnly}
+                />
               )}
 
               {appId === "claude-desktop" &&
@@ -468,7 +549,19 @@ export function ProviderCard({
         <div className="flex items-center ml-auto min-w-0 gap-3">
           <div className="ml-auto">
             <div className="flex items-center gap-1">
-              {isCopilot ? (
+              {/* 各类 footer 的展示策略：
+                  - 有 key pool（apiKeys.length > 1）：provider 级配额
+                    显示完全隐藏。每把 key 自己在展开行里跑 queryForKey 拉
+                    自己的 5h/7d（Rust 端 queryProviderUsageForKey 走 per-key
+                    路径，不复用账号级结果），N 把 key 就有 N 份独立快照。
+                    在 provider 头再挂一条 5h/7d 会出现「N+1 条同源数据」
+                    重复——所以统一由 hasKeyPool 短路掉所有分支，避免某些
+                    provider 类型在多 key 下还残留 provider 级别的配额条。
+                  - 单 key / 0 key：以下分支按 provider 类型挑一个 footer
+                    显示。优先级 Copilot → CodexOauth → Official
+                    subscription → TokenPlan → UsageFooter / multiplePlans
+                    summary。 */}
+              {hasKeyPool ? null : isCopilot ? (
                 <CopilotQuotaFooter
                   meta={provider.meta}
                   inline={true}
@@ -480,17 +573,22 @@ export function ProviderCard({
                   inline={true}
                   isCurrent={isCurrent}
                 />
-              ) : isOfficial ? (
-                officialSubscriptionEnabled ? (
-                  <SubscriptionQuotaFooter
-                    appId={appId}
-                    inline={true}
-                    isCurrent={isCurrent}
-                    autoQueryInterval={
-                      provider.meta?.usage_script?.autoQueryInterval ?? 0
-                    }
-                  />
-                ) : null
+              ) : isOfficial && officialSubscriptionEnabled ? (
+                <SubscriptionQuotaFooter
+                  appId={appId}
+                  inline={true}
+                  isCurrent={isCurrent}
+                  autoQueryInterval={
+                    provider.meta?.usage_script?.autoQueryInterval ?? 0
+                  }
+                />
+              ) : isTokenPlanProvider(provider.meta) ? (
+                <TokenPlanQuotaFooter
+                  providerId={provider.id}
+                  appId={appId}
+                  meta={provider.meta}
+                  inline={true}
+                />
               ) : hasMultiplePlans ? (
                 <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
                   <span className="font-medium">
@@ -511,8 +609,9 @@ export function ProviderCard({
                   inline={true}
                 />
               )}
-              {hasMultiplePlans && (
+              {canExpand && (
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     setIsExpanded(!isExpanded);
@@ -574,9 +673,6 @@ export function ProviderCard({
               onOpenTerminal={
                 onOpenTerminal ? () => onOpenTerminal(provider) : undefined
               }
-              isAutoFailoverEnabled={isAutoFailoverEnabled}
-              isInFailoverQueue={isInFailoverQueue}
-              onToggleFailover={onToggleFailover}
               // OpenClaw: default model
               isDefaultModel={isDefaultModel}
               onSetAsDefault={onSetAsDefault}
@@ -585,17 +681,42 @@ export function ProviderCard({
         </div>
       </div>
 
-      {isExpanded && hasMultiplePlans && (
-        <div className="mt-4 pt-4 border-t border-border-default">
-          <UsageFooter
-            provider={provider}
-            providerId={provider.id}
-            appId={appId}
-            usageEnabled={usageEnabled}
-            isCurrent={isCurrent}
-            isInConfig={isInConfig}
-            inline={false}
-          />
+      {isExpanded && canExpand && (
+        <div className="mt-4 space-y-3 pt-4 border-t border-border-default">
+          {hasMultiplePlans && (
+            <UsageFooter
+              provider={provider}
+              providerId={provider.id}
+              appId={appId}
+              usageEnabled={usageEnabled}
+              isCurrent={isCurrent}
+              isInConfig={isInConfig}
+              inline={false}
+            />
+          )}
+          {!isAnyOmo && (
+            <KeyPoolList
+              providerId={provider.id}
+              appId={appId}
+              enabled={!isHermesReadOnly}
+              // 只有在 provider 启用了 usage_script 且 query 拿到了数据时，
+              // 才把 usage 透传给 KeyPoolList——避免在未启用时多一个 "0%" 的噪声。
+              // per-key 查询由 KeyPoolList 自己用 useQueries 扇出，
+              // 这里传的 usage 仅作为 per-key 尚未返回时的兜底。
+              //
+              // **TOKEN_PLAN 也允许 per-key quota**：Coding Plan provider 的
+              // 每把 key 可以对应一个独立的 MiniMax/Kimi/Zhipu 账号，每把
+              // 自己的 5h/7d 是不同的——Rust 端 `queryProviderUsageForKey`
+              // 已经走 special-template 路径返回各自账号的 tier 列表。
+              // 账号级概览在 inline 槽由 `TokenPlanQuotaFooter` 显示，
+              // per-key 详情在展开行里各显示一行，互补不冲突。
+              usage={hasKeyPool ? usage : undefined}
+              usageEnabled={hasKeyPool && usageEnabled}
+              autoQueryInterval={
+                provider.meta?.usage_script?.autoQueryInterval ?? 0
+              }
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/components/providers/ProviderHealthBadge.tsx
+++ b/src/components/providers/ProviderHealthBadge.tsx
@@ -24,7 +24,7 @@ export function ProviderHealthBadge({
     if (consecutiveFailures === 0) {
       return {
         labelKey: "health.operational",
-        labelFallback: "正常",
+        labelFallback: "In rotation",
         status: ProviderHealthStatus.Healthy,
         color: "bg-green-500",
         // 使用更深/柔和的背景色，去除可能的白色内容感

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -33,7 +33,7 @@ import {
   Wand2,
 } from "lucide-react";
 import EndpointSpeedTest from "./EndpointSpeedTest";
-import { ApiKeySection, EndpointField, ModelInputWithFetch } from "./shared";
+import { ProviderKeyEditor, EndpointField, ModelInputWithFetch } from "./shared";
 import { CopilotAuthSection } from "./CopilotAuthSection";
 import { CodexOAuthSection } from "./CodexOAuthSection";
 import {
@@ -41,6 +41,7 @@ import {
   copilotGetModelsForAccount,
 } from "@/lib/api/copilot";
 import type { CopilotModel } from "@/lib/api/copilot";
+import type { AppId } from "@/lib/api";
 import {
   fetchCodexOauthModels,
   fetchModelsForConfig,
@@ -164,7 +165,10 @@ export function ClaudeFormFields({
   isPartner,
   partnerPromotionKey,
   isCopilotPreset,
-  usesOAuth,
+  // usesOAuth is in the destructure list below; was previously used to gate
+  // the now-removed legacy ApiKeySection. Keep the prop in the public
+  // signature for backwards compat (other form fields may pass it), but
+  // it's no longer referenced in this form's body.
   isCopilotAuthenticated,
   selectedGitHubAccountId,
   onGitHubAccountSelect,
@@ -619,18 +623,18 @@ export function ClaudeFormFields({
         />
       )}
 
-      {/* API Key 输入框（非 OAuth 预设时显示） */}
-      {shouldShowApiKey && !usesOAuth && (
-        <ApiKeySection
-          value={apiKey}
-          onChange={onApiKeyChange}
-          category={category}
-          shouldShowLink={shouldShowApiKeyLink}
-          websiteUrl={websiteUrl}
-          isPartner={isPartner}
-          partnerPromotionKey={partnerPromotionKey}
-        />
-      )}
+      <ProviderKeyEditor
+        appId={"claude" as AppId}
+        providerId={providerId ?? null}
+        shouldShowApiKey={shouldShowApiKey}
+        shouldShowApiKeyLink={shouldShowApiKeyLink}
+        category={category}
+        websiteUrl={websiteUrl}
+        isPartner={isPartner}
+        partnerPromotionKey={partnerPromotionKey}
+        value={apiKey}
+        onChange={onApiKeyChange}
+      />
 
       {/* 模板变量输入 */}
       {templateValueEntries.length > 0 && (

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -26,7 +26,8 @@ import {
   Trash2,
 } from "lucide-react";
 import EndpointSpeedTest from "./EndpointSpeedTest";
-import { ApiKeySection, EndpointField, ModelDropdown } from "./shared";
+import { ProviderKeyEditor, EndpointField, ModelDropdown } from "./shared";
+import type { AppId } from "@/lib/api";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -346,26 +347,30 @@ export function CodexFormFields({
 
   return (
     <>
-      {/* Codex API Key 输入框 */}
-      <ApiKeySection
-        id="codexApiKey"
-        label="API Key"
-        value={codexApiKey}
-        onChange={onApiKeyChange}
-        category={category}
-        shouldShowLink={shouldShowApiKeyLink}
-        websiteUrl={websiteUrl}
-        isPartner={isPartner}
-        partnerPromotionKey={partnerPromotionKey}
-        placeholder={{
-          official: t("providerForm.codexOfficialNoApiKey", {
-            defaultValue: "官方供应商无需 API Key",
-          }),
-          thirdParty: t("providerForm.codexApiKeyAutoFill", {
-            defaultValue: "输入 API Key，将自动填充到配置",
-          }),
-        }}
-      />
+      {/* Codex API Key——单/多 key 由 ProviderKeyEditor 按 providerId + 非官方
+          类别内部切换。Codex 类别 "official" 时完全隐藏（官方不需要 key）。 */}
+      {category !== "official" && (
+        <ProviderKeyEditor
+          appId={"codex" as AppId}
+          providerId={providerId ?? null}
+          shouldShowApiKey
+          shouldShowApiKeyLink={shouldShowApiKeyLink}
+          category={category}
+          websiteUrl={websiteUrl}
+          isPartner={isPartner}
+          partnerPromotionKey={partnerPromotionKey}
+          value={codexApiKey}
+          onChange={onApiKeyChange}
+          placeholder={{
+            official: t("providerForm.codexOfficialNoApiKey", {
+              defaultValue: "官方供应商无需 API Key",
+            }),
+            thirdParty: t("providerForm.codexApiKeyAutoFill", {
+              defaultValue: "输入 API Key，将自动填充到配置",
+            }),
+          }}
+        />
+      )}
 
       {/* Codex Base URL 输入框 */}
       {shouldShowSpeedTest && (

--- a/src/components/providers/forms/GeminiFormFields.tsx
+++ b/src/components/providers/forms/GeminiFormFields.tsx
@@ -5,7 +5,8 @@ import { Download, Info, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import EndpointSpeedTest from "./EndpointSpeedTest";
-import { ApiKeySection, EndpointField, ModelInputWithFetch } from "./shared";
+import { ProviderKeyEditor, EndpointField, ModelInputWithFetch } from "./shared";
+import type { AppId } from "@/lib/api";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -131,16 +132,19 @@ export function GeminiFormFields({
         </div>
       )}
 
-      {/* API Key 输入框 */}
-      {shouldShowApiKey && !isGoogleOfficial && (
-        <ApiKeySection
-          value={apiKey}
-          onChange={onApiKeyChange}
+      {/* API Key 输入框——单/多 key 视图由 ProviderKeyEditor 内部按 providerId 切换 */}
+      {!isGoogleOfficial && (
+        <ProviderKeyEditor
+          appId={"gemini" as AppId}
+          providerId={providerId ?? null}
+          shouldShowApiKey={shouldShowApiKey}
+          shouldShowApiKeyLink={shouldShowApiKeyLink}
           category={category}
-          shouldShowLink={shouldShowApiKeyLink}
           websiteUrl={websiteUrl}
           isPartner={isPartner}
           partnerPromotionKey={partnerPromotionKey}
+          value={apiKey}
+          onChange={onApiKeyChange}
         />
       )}
 

--- a/src/components/providers/forms/HermesFormFields.tsx
+++ b/src/components/providers/forms/HermesFormFields.tsx
@@ -39,7 +39,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ApiKeySection } from "./shared";
+import { ProviderKeyEditor } from "./shared";
+import type { AppId } from "@/lib/api";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -53,6 +54,9 @@ import {
 import type { ProviderCategory } from "@/types";
 
 interface HermesFormFieldsProps {
+  // Provider ID (for multi-key pool, only in edit mode)
+  providerId?: string;
+
   baseUrl: string;
   onBaseUrlChange: (value: string) => void;
   apiKey: string;
@@ -140,6 +144,7 @@ function AdvancedSection({
 }
 
 export function HermesFormFields({
+  providerId,
   baseUrl,
   onBaseUrlChange,
   apiKey,
@@ -327,16 +332,18 @@ export function HermesFormFields({
         )}
       </div>
 
-      <ApiKeySection
-        value={apiKey}
-        onChange={onApiKeyChange}
-        // Hermes 没有 OAuth-only 的免 key 官方供应商：即便是 official 预设
-        // （如 Nous Research）也需用户自填 key，故不让 official 禁用输入框。
-        category={category === "official" ? undefined : category}
-        shouldShowLink={shouldShowApiKeyLink}
+{/* API Key——单/多 key 由 ProviderKeyEditor 按 providerId 内部切换 */}
+      <ProviderKeyEditor
+        appId={"hermes" as AppId}
+        providerId={providerId ?? null}
+        shouldShowApiKey
+        shouldShowApiKeyLink={shouldShowApiKeyLink}
+        category={category}
         websiteUrl={websiteUrl}
         isPartner={isPartner}
         partnerPromotionKey={partnerPromotionKey}
+        value={apiKey}
+        onChange={onApiKeyChange}
       />
 
       <div className="space-y-3">

--- a/src/components/providers/forms/OpenClawFormFields.tsx
+++ b/src/components/providers/forms/OpenClawFormFields.tsx
@@ -34,7 +34,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ApiKeySection } from "./shared";
+import { ProviderKeyEditor } from "./shared";
+import type { AppId } from "@/lib/api";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -44,6 +45,9 @@ import { openclawApiProtocols } from "@/config/openclawProviderPresets";
 import type { ProviderCategory, OpenClawModel } from "@/types";
 
 interface OpenClawFormFieldsProps {
+  // Provider ID (for multi-key pool, only in edit mode)
+  providerId?: string;
+
   // Base URL
   baseUrl: string;
   onBaseUrlChange: (value: string) => void;
@@ -71,6 +75,7 @@ interface OpenClawFormFieldsProps {
 }
 
 export function OpenClawFormFields({
+  providerId,
   baseUrl,
   onBaseUrlChange,
   apiKey,
@@ -253,17 +258,18 @@ export function OpenClawFormFields({
         </p>
       </div>
 
-      {/* API Key */}
-      <ApiKeySection
-        value={apiKey}
-        onChange={onApiKeyChange}
-        // OpenClaw 的 API key 始终由用户自填，没有 OAuth-only 的免 key 官方供应商，
-        // 故不让 official 禁用输入框（与 Hermes 对齐）。
-        category={category === "official" ? undefined : category}
-        shouldShowLink={shouldShowApiKeyLink}
+{/* API Key——单/多 key 由 ProviderKeyEditor 按 providerId 内部切换 */}
+      <ProviderKeyEditor
+        appId={"openclaw" as AppId}
+        providerId={providerId ?? null}
+        shouldShowApiKey
+        shouldShowApiKeyLink={shouldShowApiKeyLink}
+        category={category}
         websiteUrl={websiteUrl}
         isPartner={isPartner}
         partnerPromotionKey={partnerPromotionKey}
+        value={apiKey}
+        onChange={onApiKeyChange}
       />
 
       {/* User-Agent */}

--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -12,7 +12,8 @@ import {
 } from "@/components/ui/select";
 import { toast } from "sonner";
 import { Download, Plus, Trash2, ChevronRight, Loader2 } from "lucide-react";
-import { ApiKeySection, ModelDropdown } from "./shared";
+import { ProviderKeyEditor, ModelDropdown } from "./shared";
+import type { AppId } from "@/lib/api";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -143,6 +144,9 @@ function ModelOptionKeyInput({
 }
 
 interface OpenCodeFormFieldsProps {
+  // Provider ID (for multi-key pool, only in edit mode)
+  providerId?: string;
+
   // NPM Package
   npm: string;
   onNpmChange: (value: string) => void;
@@ -170,6 +174,7 @@ interface OpenCodeFormFieldsProps {
 }
 
 export function OpenCodeFormFields({
+  providerId,
   npm,
   onNpmChange,
   apiKey,
@@ -476,15 +481,18 @@ export function OpenCodeFormFields({
         </p>
       </div>
 
-      {/* API Key */}
-      <ApiKeySection
-        value={apiKey}
-        onChange={onApiKeyChange}
+      {/* API Key——单/多 key 由 ProviderKeyEditor 按 providerId 内部切换 */}
+      <ProviderKeyEditor
+        appId={"opencode" as AppId}
+        providerId={providerId ?? null}
+        shouldShowApiKey
+        shouldShowApiKeyLink={shouldShowApiKeyLink}
         category={category}
-        shouldShowLink={shouldShowApiKeyLink}
         websiteUrl={websiteUrl}
         isPartner={isPartner}
         partnerPromotionKey={partnerPromotionKey}
+        value={apiKey}
+        onChange={onApiKeyChange}
       />
 
       {/* Base URL */}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -631,9 +631,21 @@ function ProviderFormFull({
     }
   }, [appId, initialData, selectedPresetId, resetCodexConfig]);
 
+  // 只在以下两种情况下重置表单：
+  // 1. 首次挂载（initialMountRef.current === true）
+  // 2. providerId 切换（编辑不同供应商）
+  // 不要因为 initialData?.meta 变化（例如选中一把 API key 导致元数据更新）就重置，
+  // 否则会清空用户未保存的改动，给人的感觉是“点击 API key 后整个表单跳回了原始状态”。
+  const initialMountRef = useRef(true);
+  const lastProviderIdRef = useRef<string | undefined>(providerId);
   useEffect(() => {
-    form.reset(defaultValues);
-  }, [defaultValues, form]);
+    const providerIdChanged = lastProviderIdRef.current !== providerId;
+    if (initialMountRef.current || providerIdChanged) {
+      form.reset(defaultValues);
+      lastProviderIdRef.current = providerId;
+      initialMountRef.current = false;
+    }
+  }, [defaultValues, form, providerId]);
 
   const presetCategoryLabels: Record<string, string> = useMemo(
     () => ({
@@ -2187,6 +2199,7 @@ function ProviderFormFull({
 
           {appId === "opencode" && !isAnyOmoCategory && (
             <OpenCodeFormFields
+              providerId={providerId}
               npm={opencodeForm.opencodeNpm}
               onNpmChange={opencodeForm.handleOpencodeNpmChange}
               apiKey={opencodeForm.opencodeApiKey}
@@ -2230,6 +2243,7 @@ function ProviderFormFull({
           {/* OpenClaw 专属字段 */}
           {appId === "openclaw" && (
             <OpenClawFormFields
+              providerId={providerId}
               baseUrl={openclawForm.openclawBaseUrl}
               onBaseUrlChange={openclawForm.handleOpenclawBaseUrlChange}
               apiKey={openclawForm.openclawApiKey}
@@ -2251,6 +2265,7 @@ function ProviderFormFull({
           {/* Hermes 专属字段 */}
           {appId === "hermes" && (
             <HermesFormFields
+              providerId={providerId}
               baseUrl={hermesForm.hermesBaseUrl}
               onBaseUrlChange={hermesForm.handleHermesBaseUrlChange}
               apiKey={hermesForm.hermesApiKey}

--- a/src/components/providers/forms/shared/ProviderKeyEditor.tsx
+++ b/src/components/providers/forms/shared/ProviderKeyEditor.tsx
@@ -1,0 +1,91 @@
+/**
+ * ProviderKeyEditor — single source of truth for the legacy single-key
+ * field (`ApiKeySection`) vs the multi-key pool (`ApiKeyListSection`) UI.
+ *
+ * Decision tree (lives here so the 6 form-field files don't duplicate it):
+ * - `providerId` 为 null（新建模式）：
+ *     展示单 key 字段 `ApiKeySection`，由表单 `apiKey` 状态直接绑到
+ *     `settings_config.apiKey`（写入路径走 `Provider::set_api_key`）。
+ * - `providerId` 已存在（编辑模式）：
+ *     隐藏单 key 字段——避免与 `ApiKeyListSection` 池管理并存造成
+ *     settings_config 不同步（Review #17）。
+ *
+ * OAuth-managed provider（Copilot / CodexOAuth）由各 form-field 自己在
+ * `usesOAuth` 判断中短路掉，本组件不再判断——保证双层保护。
+ */
+
+import { ApiKeySection } from "./ApiKeySection";
+import { ApiKeyListSection } from "../../ApiKeyListSection";
+import type { AppId } from "@/lib/api";
+import type { ProviderCategory } from "@/types";
+
+export interface ProviderKeyEditorProps {
+  appId: AppId;
+  /**
+   * `null` while the provider hasn't been saved yet. Drives the single-key
+   * vs multi-key UI decision (see file header).
+   */
+  providerId: string | null;
+  /** Show the "API Key" field at all. Some categories (e.g. official Claude) hide it. */
+  shouldShowApiKey: boolean;
+  /** Show the "Get API Key" / "官方无需 API Key" hint links. */
+  shouldShowApiKeyLink?: boolean;
+  /** Provider category (used by ApiKeySection for placeholder / partner promo). */
+  category?: ProviderCategory;
+  /** Provider website URL (used by ApiKeySection's "Get API Key" link). */
+  websiteUrl?: string;
+  /** Is this a partner provider? Shows the partner promo banner. */
+  isPartner?: boolean;
+  /** Partner promotion key (e.g. "packycode") for the promo banner. */
+  partnerPromotionKey?: string;
+  /** Bound to ApiKeySection — only used in new-provider mode. */
+  value?: string;
+  onChange?: (next: string) => void;
+  /**
+   * Custom placeholders forwarded to ApiKeySection. Some AppTypes (Codex) need
+   * per-app hints; default is ApiKeySection's built-in placeholders.
+   */
+  placeholder?: ApiKeyPlaceholder;
+}
+
+/** Placeholder strings passed through to ApiKeySection. */
+type ApiKeyPlaceholder = {
+  official?: string;
+  thirdParty?: string;
+};
+
+export function ProviderKeyEditor({
+  appId,
+  providerId,
+  shouldShowApiKey,
+  shouldShowApiKeyLink = false,
+  category,
+  websiteUrl = "",
+  isPartner = false,
+  partnerPromotionKey = "",
+  value = "",
+  onChange,
+  placeholder,
+}: ProviderKeyEditorProps) {
+  if (!shouldShowApiKey) return null;
+  // 编辑模式：池管理覆盖单字段
+  if (providerId) {
+    return <ApiKeyListSection appId={appId} providerId={providerId} />;
+  }
+  // 新建模式：单 key 字段
+  return (
+    <ApiKeySection
+      value={value}
+      onChange={onChange ?? (() => {})}
+      category={category}
+      shouldShowLink={shouldShowApiKeyLink}
+      websiteUrl={websiteUrl}
+      isPartner={isPartner}
+      partnerPromotionKey={partnerPromotionKey}
+      placeholder={{
+        official: placeholder?.official ?? "",
+        thirdParty: placeholder?.thirdParty ?? "",
+      }}
+    />
+  );
+}

--- a/src/components/providers/forms/shared/index.ts
+++ b/src/components/providers/forms/shared/index.ts
@@ -1,4 +1,5 @@
 export { ApiKeySection } from "./ApiKeySection";
+export { ProviderKeyEditor } from "./ProviderKeyEditor";
 export { EndpointField } from "./EndpointField";
 export { ModelDropdown } from "./ModelDropdown";
 export { ModelInputWithFetch } from "./ModelInputWithFetch";

--- a/src/hooks/useKeyRateLimitedBridge.ts
+++ b/src/hooks/useKeyRateLimitedBridge.ts
@@ -1,0 +1,42 @@
+import { useQueryClient } from "@tanstack/react-query";
+import type { AppId } from "@/lib/api/types";
+import { useTauriEvent } from "./useTauriEvent";
+
+interface KeyRateLimitedPayload {
+  appType: AppId;
+  providerId: string;
+  keyId: string;
+  /** LimitSignal reason — "429" / "quota_message" / "user_regex" / "5xx"。 */
+  reason: string;
+  /** key 冷却到的时间（unix seconds）。 */
+  cooldownUntil: number;
+}
+
+/**
+ * 后端 KeyRing 在某把 key 命中「真配额窗口」（cooldown ≥ 5 分钟）时
+ * 发射 `key-rate-limited` 事件。本 hook 收到后 invalidate 该 provider 的
+ * apiKeys 查询 —— 触发 `useApiKeys` refetch，进而把 row 上每把 key 的
+ * `cooldownUntil` / `failure_count` 拉到 UI，5h 配额进度条立刻反映出
+ * 这把 key 已经不可用。
+ *
+ * 短冷却（30s / 60s）的事件不广播 —— 见 forwarder.rs 的
+ * QUOTA_REFRESH_THRESHOLD_SECS。这避免每次 30s 试探失败都触发一轮网络刷新。
+ *
+ * 与 useUsageCacheBridge 互补：后者同步「成功拉到的用量快照」，前者
+ * 同步「key 进入冷却」这一状态翻转。
+ */
+export function useKeyRateLimitedBridge() {
+  const queryClient = useQueryClient();
+
+  useTauriEvent<KeyRateLimitedPayload>("key-rate-limited", (payload) => {
+    queryClient.invalidateQueries({
+      queryKey: ["apiKeys", payload.providerId, payload.appType],
+    });
+    // 同时把每把 key 自己的 usage 查询也标 stale —— cooldown 翻转后
+    // progress bar 的 reset 倒计时也依赖 usage 数据，refetch 才能拿到
+    // 最新的 reset_at / used%。
+    queryClient.invalidateQueries({
+      queryKey: ["keyUsage", payload.keyId, payload.appType],
+    });
+  });
+}

--- a/src/hooks/useUsageCacheBridge.ts
+++ b/src/hooks/useUsageCacheBridge.ts
@@ -14,6 +14,13 @@ type UsageCacheUpdatedPayload =
       data: UsageResult;
     }
   | {
+      kind: "script";
+      appType: AppId;
+      providerId: string;
+      keyId: string;
+      data: UsageResult;
+    }
+  | {
       kind: "subscription";
       appType: AppId;
       data: SubscriptionQuota;
@@ -23,16 +30,33 @@ type UsageCacheUpdatedPayload =
  * 后端 `UsageCache` 写入后会 emit `usage-cache-updated`，本 hook 把 payload 同步到
  * React Query 缓存，让托盘触发的刷新（不经前端）也能立刻反映到主界面，避免
  * React Query 与 Rust 侧两份缓存各自为战。
+ *
+ * **kind === "script" 有两种形态**：
+ *   - 没 keyId → provider-level 快照（`queryProviderUsage`），写到
+ *     `usageKeys.script(providerId, appType)`，给 useUsageQuery / ProviderCard 用。
+ *   - 有 keyId → per-key 快照（`queryProviderUsageForKey`），写到
+ *     `["keyUsage", keyId, appId]`，给 ApiKeyListSection / KeyPoolList 用。
+ * 两种必须分流——否则 per-key 的事件会把 provider-level 缓存污染成某一把
+ * key 的数据，下次 useUsageQuery 读出来还是错的。
  */
 export function useUsageCacheBridge() {
   const queryClient = useQueryClient();
 
   useTauriEvent<UsageCacheUpdatedPayload>("usage-cache-updated", (payload) => {
     if (payload.kind === "script") {
-      queryClient.setQueryData<UsageResult>(
-        usageKeys.script(payload.providerId, payload.appType),
-        payload.data,
-      );
+      if ("keyId" in payload && payload.keyId) {
+        // per-key 快照——写到 keyId 维度的 cache。
+        queryClient.setQueryData<UsageResult>(
+          ["keyUsage", payload.keyId, payload.appType],
+          payload.data,
+        );
+      } else {
+        // provider-level 快照——legacy queryProviderUsage 路径。
+        queryClient.setQueryData<UsageResult>(
+          usageKeys.script(payload.providerId, payload.appType),
+          payload.data,
+        );
+      }
     } else if (payload.kind === "subscription") {
       queryClient.setQueryData<SubscriptionQuota>(
         subscriptionKeys.quota(payload.appType),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -42,6 +42,104 @@
     "enabled": "Enabled",
     "notSet": "Not Set"
   },
+  "apiKeyList": {
+    "saveProviderFirst": "Please save the provider first before managing the API key pool",
+    "title": "API Key Pool",
+    "subtitle": "Multiple keys auto-rotate in proxy mode",
+    "empty": "No keys yet. Click below to add one.",
+    "moveUp": "Move up",
+    "moveDown": "Move down",
+    "active": "Active",
+    "disabled": "Disabled",
+    "cooldown": "Cooling down",
+    "unnamed": "(unnamed)",
+    "toggleEnabled": "Enable / Disable",
+    "setActive": "Set as default",
+    "delete": "Delete",
+    "add": "Add Key",
+    "createTitle": "Add API Key",
+    "createDesc": "Add a new API key for this provider",
+    "labelLabel": "Label",
+    "valueLabel": "API Key",
+    "tagsLabel": "Tags",
+    "tagsPlaceholder": "Type a tag and press Enter (prod, region-east)",
+    "notesLabel": "Notes",
+    "enabledLabel": "Enabled",
+    "edit": "Edit",
+    "editTitle": "Edit Key",
+    "editValueHint": "Leave blank to keep the existing value",
+    "dragHandle": "Drag to reorder",
+    "deleteConfirmTitle": "Delete API Key?",
+    "deleteConfirmMessage": "Are you sure you want to delete \"{{label}}\"? This action cannot be undone."
+  },
+  "apiKeys": {
+    "create": {
+      "success": "API key added",
+      "error": "Failed to add: {{error}}"
+    },
+    "update": {
+      "success": "Saved",
+      "error": "Failed to save: {{error}}"
+    },
+    "delete": {
+      "success": "Deleted",
+      "error": "Failed to delete: {{error}}"
+    },
+    "setActive": {
+      "success": "Set as default key",
+      "error": "Failed to set as default: {{error}}"
+    }
+  },
+  "apiKeyStatusBar": {
+    "cooldownRemaining": "Cooldown remaining",
+    "cooldownHint": "(auto-resume rotation when ends)",
+    "disabled": "Disabled",
+    "disabledHint": "(re-enable manually to resume rotation)",
+    "failureCount": "Failed {{count}} / {{threshold}} times",
+    "failureHint": "({{remaining}} more failure(s) will auto-rotate)",
+    "ready": "Cooldown: ready",
+    "readyHint": "(auto-rotate after {{threshold}} failures)",
+    "fiveHour": "5h quota",
+    "fiveHourWindow": "5h",
+    "sevenDay": "7d quota",
+    "sevenDayWindow": "7d",
+    "thirtyDayWindow": "30d",
+    "monthlyWindow": "Monthly",
+    "weeklyLimitWindow": "Weekly",
+    "remaining": "left",
+    "windowResetsIn": "Resets in {{reset}}",
+    "units": {
+      "second": "s",
+      "minute": "m",
+      "hour": "h",
+      "day": "d"
+    }
+  },
+  "keyPool": {
+    "listTitle": "API Key Pool ({{count}})",
+    "listHint": "Auto-rotate in proxy mode; manage in the editor",
+    "active": "Default",
+    "unnamed": "(unnamed)",
+    "cooldown": "Cooling",
+    "disabled": "Disabled",
+    "refresh": "Refresh",
+    "refreshing": "Refreshing…",
+    "setActive": "Set as default",
+    "activateLabel": "Activate now",
+    "activatedLabel": "Activated",
+    "toggleRotation": "Join rotation",
+    "rotationBlocked": "Rotation disabled for this key",
+    "rotationBlockedExhausted": "5h/7d quota exhausted",
+    "rotationBlockedCooldown": "In cooldown, rotation disabled",
+    "rotationBlockedApiInvalid": "API invalid or unresponsive, rotation disabled",
+    "dragHandle": "Drag to reorder",
+    "health": {
+      "healthy": "Healthy",
+      "degraded": "Some failures",
+      "cooling_down": "Cooling down",
+      "disabled": "Disabled"
+    }
+  },
   "firstRunNotice": {
     "title": "Welcome to CC Switch",
     "bodyDefault": "CC Switch lets you switch between multiple Claude Code / Codex / Gemini CLI providers with a single click. If you already had these tools configured, CC Switch has saved your existing setup as a provider named “default” so none of your previous configuration is lost.",
@@ -166,6 +264,7 @@
     "usageSaveFailed": "Failed to save usage query configuration",
     "geminiConfig": "Gemini Configuration",
     "geminiConfigHint": "Use .env format to configure Gemini",
+    "duplicateLiveIdsLoadFailed": "Failed to read provider IDs from config. Please fix the config first.",
     "form": {
       "gemini": {
         "model": "Model",
@@ -220,7 +319,8 @@
       "tooltip": {
         "active": "Claude Desktop local routing is running - {{address}}:{{port}}",
         "inactive": "Turn on Claude Desktop local routing for providers that need model mapping or format conversion. Configured address: {{address}}:{{port}}"
-      }
+      },
+      "stopBlockedByTakeover": "Another app is using routing takeover. Turn off that app's takeover in Settings before stopping local routing."
     }
   },
   "notifications": {
@@ -255,6 +355,7 @@
     "proxyReasonOpenAIChat": "uses OpenAI Chat API format",
     "proxyReasonOpenAIResponses": "uses OpenAI Responses API format",
     "proxyReasonFullUrl": "has full URL connection mode enabled",
+    "proxyReasonClaudeDesktop": "uses Claude Desktop local routing mode",
     "openAIFormatHint": "This provider uses OpenAI-compatible format and requires the routing service to be enabled",
     "copilotProxyHint": "GitHub Copilot as a Claude provider always requires local routing; routing automatically selects Chat Completions or Responses based on the current model.",
     "openLinkFailed": "Failed to open link",
@@ -1152,7 +1253,8 @@
     "fetchModelsAuthFailed": "API Key is invalid or lacks permission",
     "fetchModelsNotSupported": "This provider does not support fetching model list",
     "fetchModelsEndpointNotFound": "No reachable models endpoint found. Please check the Base URL or confirm whether the provider exposes this API.",
-    "fetchModelsTimeout": "Request timed out, please check network connection"
+    "fetchModelsTimeout": "Request timed out, please check network connection",
+    "providerKeyStatusLoading": "Loading provider ID status, please try again later"
   },
   "copilot": {
     "authSection": "GitHub Copilot Authentication",
@@ -1295,6 +1397,7 @@
     "autoCompactLimit": "Auto Compact Limit",
     "autoCompactLimitPlaceholder": "e.g., 90000",
     "autoCompactLimitHint": "Auto-compacts history when context reaches this token limit",
+    "noCommonConfigToApply": "Common config snippet is empty or has no applicable entries",
     "modelMetadataAdvanced": "Model Metadata Advanced Options",
     "modelMetadataAdvancedHint": "Overrides Codex metadata for unknown models; clearing a field removes the matching config.toml entry.",
     "modelMappingTitle": "Model Mapping",
@@ -1396,6 +1499,7 @@
     "preset7d": "7d",
     "preset14d": "14d",
     "preset30d": "30d",
+    "unpriced": "Unpriced",
     "totalRequests": "Total Requests",
     "totalCost": "Total Cost",
     "cost": "Cost",
@@ -1598,6 +1702,10 @@
     "organizationIdPlaceholder": "e.g. org-xxxxxx",
     "projectId": "Project ID",
     "projectIdPlaceholder": "e.g. proj-xxxxxx",
+    "minimaxGroupId": "Group ID",
+    "minimaxGroupIdHint": "MiniMax usage API requires a Group ID; without it the endpoint returns placeholder zeros (showing 0% even when you have usage).",
+    "minimaxGroupIdLink": "Find it in the MiniMax open platform under Account → Basic Information.",
+    "minimaxGroupIdUrlLabel": "Open MiniMax account page",
     "defaultPlan": "Default Plan",
     "queryFailedMessage": "Query failed",
     "queryScript": "Query script (JavaScript)",
@@ -2424,7 +2532,7 @@
     "testProvider": "Test model"
   },
   "health": {
-    "operational": "Operational",
+    "operational": "In rotation",
     "degraded": "Degraded",
     "failed": "Failed",
     "circuitOpen": "Circuit Open",
@@ -2434,14 +2542,17 @@
     "enabled": "{{app}} failover enabled",
     "disabled": "{{app}} failover disabled",
     "toggleFailed": "Operation failed: {{detail}}",
-    "inQueue": "In queue",
-    "addQueue": "Add",
+    "inRotation": "In rotation",
+    "addToRotation": "Add to rotation",
+    "disabledForOmo": "OMO providers don't participate in rotation",
+    "disabledNoRotation": "Enable failover in Settings to use rotation",
     "priority": {
       "tooltip": "Failover priority {{priority}}"
     },
     "tooltip": {
       "enabled": "{{app}} failover enabled\nRequests follow queue priority (P1→P2→...)",
-      "disabled": "Enable {{app}} failover\nSwitches to queue P1 immediately, then falls back on failures"
+      "disabled": "Enable {{app}} failover\nSwitches to queue P1 immediately, then falls back on failures",
+      "takeoverRequired": "Take over {{app}} first, then enable failover"
     }
   },
   "proxy": {
@@ -2619,7 +2730,9 @@
     },
     "server": {
       "started": "Routing service started - {{address}}:{{port}}",
-      "startFailed": "Failed to start routing service: {{detail}}"
+      "startFailed": "Failed to start routing service: {{detail}}",
+      "stopped": "Routing service stopped",
+      "stopFailed": "Failed to stop routing service: {{detail}}"
     },
     "stoppedWithRestore": "Routing service stopped, all routing configs restored",
     "stopWithRestoreFailed": "Stop failed: {{detail}}"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -42,6 +42,104 @@
     "enabled": "有効",
     "notSet": "未設定"
   },
+  "apiKeyList": {
+    "saveProviderFirst": "Key プールを管理する前に、まずプロバイダーを保存してください",
+    "title": "API Key プール",
+    "subtitle": "プロキシモードで複数の key を自動ローテーション",
+    "empty": "key がまだありません。下から追加してください。",
+    "moveUp": "上へ移動",
+    "moveDown": "下へ移動",
+    "active": "デフォルト",
+    "disabled": "無効",
+    "cooldown": "クールダウン中",
+    "unnamed": "（名前なし）",
+    "toggleEnabled": "有効 / 無効",
+    "setActive": "デフォルトに設定",
+    "delete": "削除",
+    "add": "Key を追加",
+    "createTitle": "API Key を追加",
+    "createDesc": "このプロバイダーに新しい API Key を追加します",
+    "labelLabel": "ラベル",
+    "valueLabel": "API Key",
+    "tagsLabel": "タグ",
+    "tagsPlaceholder": "入力後 Enter で追加（prod、region-east）",
+    "notesLabel": "メモ",
+    "enabledLabel": "有効化",
+    "edit": "編集",
+    "editTitle": "Key を編集",
+    "editValueHint": "空欄のままにすると既存の値を保持します",
+    "dragHandle": "ドラッグして並べ替え",
+    "deleteConfirmTitle": "API Key を削除しますか？",
+    "deleteConfirmMessage": "\"{{label}}\" を削除してもよろしいですか？この操作は元に戻せません。"
+  },
+  "apiKeys": {
+    "create": {
+      "success": "API key を追加しました",
+      "error": "追加に失敗しました：{{error}}"
+    },
+    "update": {
+      "success": "保存しました",
+      "error": "保存に失敗しました：{{error}}"
+    },
+    "delete": {
+      "success": "削除しました",
+      "error": "削除に失敗しました：{{error}}"
+    },
+    "setActive": {
+      "success": "デフォルトのキーに設定しました",
+      "error": "設定に失敗しました：{{error}}"
+    }
+  },
+  "apiKeyStatusBar": {
+    "cooldownRemaining": "クールダウン残り",
+    "cooldownHint": "（終了時に自動的にローテーションを再開）",
+    "disabled": "無効",
+    "disabledHint": "（手動で有効化するとローテーションを再開）",
+    "failureCount": "失敗 {{count}} / {{threshold}} 回",
+    "failureHint": "（あと {{remaining}} 回失敗で自動的にローテーション）",
+    "ready": "クールダウン：準備完了",
+    "readyHint": "（{{threshold}} 回失敗で自動的にローテーション）",
+    "fiveHour": "5h クォータ",
+    "fiveHourWindow": "5時間",
+    "sevenDay": "7d クォータ",
+    "sevenDayWindow": "7日",
+    "thirtyDayWindow": "30日",
+    "monthlyWindow": "月間",
+    "weeklyLimitWindow": "週間制限",
+    "remaining": "残り",
+    "windowResetsIn": "{{reset}} 後にリセット",
+    "units": {
+      "second": "秒",
+      "minute": "分",
+      "hour": "時間",
+      "day": "日"
+    }
+  },
+  "keyPool": {
+    "listTitle": "API Key プール（{{count}}）",
+    "listHint": "プロキシモードで自動ローテーション；編集画面で管理",
+    "active": "デフォルト",
+    "unnamed": "（名前なし）",
+    "cooldown": "クールダウン",
+    "disabled": "無効",
+    "refresh": "更新",
+    "refreshing": "更新中…",
+    "setActive": "デフォルトに設定",
+    "activateLabel": "今すぐ有効化",
+    "activatedLabel": "有効",
+    "toggleRotation": "ローテーション対象",
+    "rotationBlocked": "この key のローテーションを無効化",
+    "rotationBlockedExhausted": "5h/7d クォータ枯渇",
+    "rotationBlockedCooldown": "クールダウン中、ローテーション無効",
+    "rotationBlockedApiInvalid": "API 無効または無応答、ローテーション無効",
+    "dragHandle": "ドラッグして並べ替え",
+    "health": {
+      "healthy": "正常",
+      "degraded": "失敗あり",
+      "cooling_down": "クールダウン中",
+      "disabled": "無効"
+    }
+  },
   "firstRunNotice": {
     "title": "CC Switch へようこそ",
     "bodyDefault": "CC Switch は Claude Code / Codex / Gemini CLI の複数プロバイダーをワンクリックで切り替えられるツールです。すでにこれらのツールを設定済みの場合、CC Switch は現在の設定を「default」という名前のプロバイダーとして自動的に保存するので、既存の設定が失われることはありません。",
@@ -173,7 +271,8 @@
         "oauthHint": "Google 公式は OAuth 個人認証を使用するため API Key は不要です。初回利用時にブラウザが開きます。",
         "apiKeyPlaceholder": "Gemini API Key を入力"
       }
-    }
+    },
+    "duplicateLiveIdsLoadFailed": "設定内のプロバイダー ID の読み込みに失敗しました。設定を修正してから再試行してください"
   },
   "claudeCode": {
     "needsRouting": "ルーティングが必要",
@@ -220,7 +319,8 @@
       "tooltip": {
         "active": "Claude Desktop ローカルルーティングは起動中です - {{address}}:{{port}}",
         "inactive": "モデルマッピングや形式変換が必要なプロバイダー向けに Claude Desktop ローカルルーティングを起動します。設定アドレス: {{address}}:{{port}}"
-      }
+      },
+      "stopBlockedByTakeover": "他のアプリが代理接管を使用しています。ローカル ルートを停止する前に、設定で対応するアプリの接管をオフにしてください。"
     }
   },
   "notifications": {
@@ -265,7 +365,8 @@
     "backfillWarning": "切り替え成功しましたが、前のプロバイダーへの設定保存に失敗しました",
     "windowControlFailed": "ウィンドウ操作に失敗しました: {{error}}",
     "officialBlockedByProxy": "ローカルルーティングモード中は公式プロバイダーに切り替えできません。ルーティング経由で公式 API にアクセスするとアカウントが停止される可能性があります。",
-    "proxyOfficialWarning": "現在のプロバイダー {{name}} は公式です。ローカルルーティングを使用する前にサードパーティプロバイダーに切り替えてください。"
+    "proxyOfficialWarning": "現在のプロバイダー {{name}} は公式です。ローカルルーティングを使用する前にサードパーティプロバイダーに切り替えてください。",
+    "proxyReasonClaudeDesktop": "Claude Desktop ローカル ルート モードを使用"
   },
   "confirm": {
     "deleteProvider": "プロバイダーを削除",
@@ -790,38 +891,38 @@
     "viewCurrentReleaseNotes": "現在のバージョンのリリースノートを見る",
     "officialWebsite": "公式サイト",
     "github": "GitHub",
-    "manualInstallCommands": "手動インストールコマンド",
+    "manualInstallCommands": "手動インストール コマンド",
     "oneClickInstallHint": "Claude Code / Codex / Gemini CLI / OpenCode / OpenClaw / Hermes をインストールまたは更新",
     "localEnvCheck": "ローカル環境チェック",
-    "updateAllTools": "すべて更新（{{count}}）",
+    "updateAllTools": "すべてのツールを更新",
     "currentVersion": "現在のバージョン",
     "latestVersion": "最新バージョン",
-    "updateAvailableShort": "更新あり",
+    "updateAvailableShort": "新バージョンあり",
     "toolInstall": "インストール",
     "toolUpdate": "更新",
     "toolReady": "準備完了",
-    "toolActionDone": "{{count}} 個のツールの{{action}}が完了しました",
-    "toolActionPartial": "{{succeeded}} 個成功、{{failed}} 個失敗（{{action}}）",
-    "toolActionFailed": "インストール/更新コマンドの実行に失敗しました",
-    "toolNotRunnable": "インストール済みですが実行できません（バージョン未検出）",
-    "toolActionVersionUnchangedTitle": "バージョンは変わりませんでした",
-    "toolActionVersionUnchanged": "現在も {{version}}（最新: {{latest}}）です。アップデーターが成功を報告しても実際には更新されていない可能性があります。",
-    "toolActionInstalledNotRunnable": "インストールされましたが、現在の環境では実行できません。確認してください",
-    "installedNotRunnable": "インストール済み・実行不可",
-    "toolCheckEnv": "実行環境を確認",
-    "toolDiagnose": "インストールを診断",
+    "toolActionDone": "{{action}}完了",
+    "toolActionPartial": "{{succeeded}} 個{{action}}成功、{{failed}} 個失敗",
+    "toolActionFailed": "{{action}}に失敗しました",
+    "toolNotRunnable": "使用不可",
+    "toolActionVersionUnchangedTitle": "すでに最新バージョンです",
+    "toolActionVersionUnchanged": "バージョンは変更されていません",
+    "toolActionInstalledNotRunnable": "インストール済みだが実行できません",
+    "installedNotRunnable": "インストール済みだが実行不可",
+    "toolCheckEnv": "環境検出",
+    "toolDiagnose": "診断",
     "toolDiagnosing": "診断中…",
-    "toolConflictTitle": "複数のインストールを検出",
-    "toolConflictHint": "コマンドラインは「既定」のものを使用します。更新が別の場所に適用された可能性があります。",
-    "toolConflictDefault": "既定",
-    "toolConflictNotRunnable": "実行不可",
-    "toolDiagnoseNoConflict": "競合するインストールは見つかりませんでした",
+    "toolConflictTitle": "複数のインストール場所が検出されました",
+    "toolConflictHint": "複数のインストール場所が検出されました。一つをデフォルトとして選択することをお勧めします",
+    "toolConflictDefault": "デフォルト",
+    "toolConflictNotRunnable": "使用不可",
+    "toolDiagnoseNoConflict": "競合は見つかりませんでした",
     "toolDiagnoseFailed": "診断に失敗しました",
-    "toolUpgradeConfirmTitle": "アップグレード先の確認",
-    "toolUpgradeConfirmHint": "複数のインストールを検出しました。今回のアップグレードはすべてを更新するわけではありません。実際に作用する箇所は下記の各項目をご確認ください。",
-    "toolUpgradeWillRun": "実行内容：",
-    "toolUpgradeConfirmBtn": "アップグレードを実行",
-    "toolUpgradeUnanchoredHint": "コマンドラインが実際に使用する箇所を特定できません。既定のアップグレードコマンドを実行します（PATH 上の最初の npm にインストールされる場合があります）。",
+    "toolUpgradeConfirmTitle": "更新の確認",
+    "toolUpgradeConfirmHint": "この操作はパッケージ マネージャーから最新バージョンにアップグレードします",
+    "toolUpgradeWillRun": "次のコマンドが実行されます",
+    "toolUpgradeConfirmBtn": "更新を開始",
+    "toolUpgradeUnanchoredHint": "実行される内容：",
     "envBadge": {
       "wsl": "WSL",
       "windows": "Win",
@@ -1152,7 +1253,8 @@
     "fetchModelsAuthFailed": "API Key が無効か、権限がありません",
     "fetchModelsNotSupported": "このプロバイダーはモデル一覧の取得に対応していません",
     "fetchModelsEndpointNotFound": "利用可能なモデル一覧エンドポイントが見つかりません。Base URL を確認するか、プロバイダーが該当 API を公開しているかご確認ください",
-    "fetchModelsTimeout": "リクエストがタイムアウトしました。ネットワーク接続を確認してください"
+    "fetchModelsTimeout": "リクエストがタイムアウトしました。ネットワーク接続を確認してください",
+    "providerKeyStatusLoading": "プロバイダー ID 狀態を読み込み中です。少ししてから再試行してください"
   },
   "copilot": {
     "authSection": "GitHub Copilot 認証",
@@ -1313,7 +1415,8 @@
     "reasoningEffortHint": "上流が low/high/max などの思考の深さの制御に対応している場合に有効化します。有効にすると思考モードも自動的にオンになり、Codex の reasoning.effort を上流の Chat パラメータに変換します。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "プリセットの供給元は自動的に設定され、カスタム供給元は名前/URL から自動推論されます。自動識別が正しくない場合のみ手動で上書きしてください。",
-    "advancedSectionHint": "上流フォーマット、モデルマッピング、思考能力、カスタム User-Agent の設定を含みます。Chat Completions プロトコルを使用するプロバイダーはルーティング引き継ぎの有効化が必要です。"
+"advancedSectionHint": "ローカルルーティング、上流フォーマット、モデルマッピング、思考能力、カスタム User-Agent の設定を含みます。供給元が Chat Completions プロトコルまたは GPT 以外のモデルを使用する場合は、ここでローカルルーティングを有効にしてください。",
+    "noCommonConfigToApply": "共通設定スニペットが空か、書き込める内容がありません"
   },
   "geminiConfig": {
     "envFile": "環境変数 (.env)",
@@ -1556,7 +1659,8 @@
     "modelsDevTruncated": "{{total}} 件中、先頭 {{shown}} 件のみ表示しています。検索条件を絞り込んでください",
     "modelsDevDefaultHint": "最新リリース順に {{shown}} 件を表示しています（全 {{total}} 件）。キーワード入力で全件検索できます",
     "cacheReadCostPerMillion": "キャッシュ読み取りコスト（100万トークンあたり、USD）",
-    "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）"
+    "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）",
+    "unpriced": "未価格設定"
   },
   "usageScript": {
     "title": "利用状況を設定",
@@ -1598,6 +1702,10 @@
     "organizationIdPlaceholder": "例: org-xxxxxx",
     "projectId": "プロジェクト ID",
     "projectIdPlaceholder": "例: proj-xxxxxx",
+    "minimaxGroupId": "グループ ID（Group ID）",
+    "minimaxGroupIdHint": "MiniMax 使用量 API は Group ID が必須です。これがないとエンドポイントはプレースホルダのゼロを返し、利用実績がある場合でも 0% と表示されます。",
+    "minimaxGroupIdLink": "MiniMax オープンプラットフォームの「アカウント管理 → アカウント情報 → 基本情報」から取得してください。",
+    "minimaxGroupIdUrlLabel": "MiniMax アカウントページを開く",
     "defaultPlan": "デフォルトプラン",
     "queryFailedMessage": "照会に失敗しました",
     "queryScript": "照会スクリプト (JavaScript)",
@@ -2424,7 +2532,7 @@
     "testProvider": "モデルテスト"
   },
   "health": {
-    "operational": "正常",
+    "operational": "ローテーション中",
     "degraded": "低下",
     "failed": "失敗",
     "circuitOpen": "サーキットオープン",
@@ -2434,14 +2542,15 @@
     "enabled": "{{app}} フェイルオーバーが有効になりました",
     "disabled": "{{app}} フェイルオーバーが無効になりました",
     "toggleFailed": "操作に失敗しました: {{detail}}",
-    "inQueue": "キュー内",
-    "addQueue": "追加",
+    "inRotation": "ローテーション中",
+    "addToRotation": "ローテーションに追加",
     "priority": {
       "tooltip": "フェイルオーバー優先度 {{priority}}"
     },
     "tooltip": {
       "enabled": "{{app}} フェイルオーバーが有効\nキューの優先度（P1→P2→...）で使用します",
-      "disabled": "{{app}} フェイルオーバーを有効にする\nキューの P1 に即時切替し、失敗時は次を順に試行します"
+      "disabled": "{{app}} フェイルオーバーを有効にする\nキューの P1 に即時切替し、失敗時は次を順に試行します",
+      "takeoverRequired": "{{app}} を先に接管してから、フェイルオーバーを有効にしてください"
     }
   },
   "proxy": {
@@ -2619,7 +2728,9 @@
     },
     "server": {
       "started": "ルーティングサービスが開始されました - {{address}}:{{port}}",
-      "startFailed": "ルーティングサービスの開始に失敗しました: {{detail}}"
+      "startFailed": "ルーティングサービスの開始に失敗しました: {{detail}}",
+      "stopFailed": "ルーティング サービスの停止に失敗しました：{{detail}}",
+      "stopped": "ルーティング サービスは停止しました"
     },
     "stoppedWithRestore": "ルーティングサービスが停止し、すべてのルーティング設定が復元されました",
     "stopWithRestoreFailed": "停止に失敗しました: {{detail}}"

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -42,6 +42,104 @@
     "enabled": "已啟用",
     "notSet": "未設定"
   },
+  "apiKeyList": {
+    "saveProviderFirst": "請先儲存供應商，再管理 Key 池",
+    "title": "API Key 池",
+    "subtitle": "多把 key 在代理模式下自動輪換",
+    "empty": "還沒有 key，點擊下方新增。",
+    "moveUp": "上移",
+    "moveDown": "下移",
+    "active": "預設",
+    "disabled": "已停用",
+    "cooldown": "冷卻中",
+    "unnamed": "（未命名）",
+    "toggleEnabled": "啟用 / 停用",
+    "setActive": "設為預設",
+    "delete": "刪除",
+    "add": "新增 Key",
+    "createTitle": "新增 API Key",
+    "createDesc": "為該供應商新增一把 API Key",
+    "labelLabel": "標籤",
+    "valueLabel": "API Key",
+    "tagsLabel": "標籤",
+    "tagsPlaceholder": "輸入後按 Enter 加入（prod、region-east）",
+    "notesLabel": "備註",
+    "enabledLabel": "啟用",
+    "edit": "編輯",
+    "editTitle": "編輯 Key",
+    "editValueHint": "留空則保留原值",
+    "dragHandle": "拖曳以重新排序",
+    "deleteConfirmTitle": "刪除 API Key？",
+    "deleteConfirmMessage": "確認刪除 \"{{label}}\" 嗎？此操作無法復原。"
+  },
+  "apiKeys": {
+    "create": {
+      "success": "API key 已新增",
+      "error": "新增失敗：{{error}}"
+    },
+    "update": {
+      "success": "已儲存",
+      "error": "儲存失敗：{{error}}"
+    },
+    "delete": {
+      "success": "已刪除",
+      "error": "刪除失敗：{{error}}"
+    },
+    "setActive": {
+      "success": "已設為預設 key",
+      "error": "設定失敗：{{error}}"
+    }
+  },
+  "apiKeyStatusBar": {
+    "cooldownRemaining": "冷卻剩餘",
+    "cooldownHint": "（屆時自動恢復輪換）",
+    "disabled": "已停用",
+    "disabledHint": "（手動啟用後恢復輪換）",
+    "failureCount": "已失敗 {{count}} / {{threshold}} 次",
+    "failureHint": "（再失敗 {{remaining}} 次將自動輪換）",
+    "ready": "冷卻狀態：就緒",
+    "readyHint": "（{{threshold}} 次失敗後自動輪換）",
+    "fiveHour": "5h 配額",
+    "fiveHourWindow": "5小時",
+    "sevenDay": "7d 配額",
+    "sevenDayWindow": "7天",
+    "thirtyDayWindow": "30天",
+    "monthlyWindow": "月度",
+    "weeklyLimitWindow": "週限額",
+    "remaining": "剩",
+    "windowResetsIn": "將在 {{reset}} 後重置",
+    "units": {
+      "second": "秒",
+      "minute": "分鐘",
+      "hour": "小時",
+      "day": "天"
+    }
+  },
+  "keyPool": {
+    "listTitle": "API 密鑰池（{{count}}）",
+    "listHint": "代理模式下自動輪換；編輯面板在「編輯」中",
+    "active": "預設",
+    "unnamed": "（未命名）",
+    "cooldown": "冷卻",
+    "disabled": "停用",
+    "refresh": "重新整理",
+    "refreshing": "重新整理中…",
+    "setActive": "設為預設",
+    "activateLabel": "立即啟用",
+    "activatedLabel": "已啟用",
+    "toggleRotation": "加入輪換",
+    "rotationBlocked": "該 key 輪換已停用",
+    "rotationBlockedExhausted": "5h/7d 配額已用盡",
+    "rotationBlockedCooldown": "冷卻中，輪換已停用",
+    "rotationBlockedApiInvalid": "API 無回應或失效，輪換已停用",
+    "dragHandle": "拖曳以重新排序",
+    "health": {
+      "healthy": "正常",
+      "degraded": "有失敗",
+      "cooling_down": "冷卻中",
+      "disabled": "已停用"
+    }
+  },
   "firstRunNotice": {
     "title": "歡迎使用 CC Switch",
     "bodyDefault": "CC Switch 可以協助您在 Claude Code / Codex / Gemini CLI 的多個供應商之間一鍵切換。如果您之前已經設定過這些工具，CC Switch 會自動將現有設定儲存為名為 default 的供應商，確保您的設定不會遺失。",
@@ -173,7 +271,8 @@
         "oauthHint": "Google 官方使用 OAuth 個人驗證，無需填寫 API Key。首次使用時會自動開啟瀏覽器進行登入。",
         "apiKeyPlaceholder": "請輸入 Gemini API Key"
       }
-    }
+    },
+    "duplicateLiveIdsLoadFailed": "讀取設定中的供應商標識失敗，請先修復設定後再試"
   },
   "claudeCode": {
     "needsRouting": "需要路由",
@@ -220,7 +319,8 @@
       "tooltip": {
         "active": "Claude Desktop 本地路由已開啟 - {{address}}:{{port}}",
         "inactive": "開啟 Claude Desktop 本地路由，用於需要模型對應或格式轉換的供應商。目前設定位址：{{address}}:{{port}}"
-      }
+      },
+      "stopBlockedByTakeover": "其他應用正在使用代理接管。請先在設定中關閉對應應用接管，再停止本地路由。"
     }
   },
   "notifications": {
@@ -265,7 +365,8 @@
     "backfillWarning": "切換成功，但舊供應商設定回填失敗，您手動修改的設定可能未儲存",
     "windowControlFailed": "視窗控制失敗：{{error}}",
     "officialBlockedByProxy": "本地路由模式下不能切換至官方供應商，使用路由存取官方 API 可能導致帳號被封鎖",
-    "proxyOfficialWarning": "目前供應商 {{name}} 是官方供應商，建議切換至第三方供應商後再使用本地路由"
+    "proxyOfficialWarning": "目前供應商 {{name}} 是官方供應商，建議切換至第三方供應商後再使用本地路由",
+    "proxyReasonClaudeDesktop": "使用 Claude Desktop 本地路由模式"
   },
   "confirm": {
     "deleteProvider": "刪除供應商",
@@ -840,7 +941,37 @@
       "defaultCostMultiplierRequired": "預設倍率不能為空",
       "defaultCostMultiplierInvalid": "預設倍率格式不正確"
     },
-    "saveFailedGeneric": "儲存失敗，請重試"
+    "saveFailedGeneric": "儲存失敗，請重試",
+    "currentVersion": "目前版本",
+    "installedNotRunnable": "已安裝但無法執行",
+    "latestVersion": "最新版本",
+    "manualInstallCommands": "手動安裝命令",
+    "toolActionDone": "{{action}}完成",
+    "toolActionFailed": "{{action}}失敗",
+    "toolActionInstalledNotRunnable": "已安裝但無法執行",
+    "toolActionPartial": "{{succeeded}} 個{{action}}成功，{{failed}} 個失敗",
+    "toolActionVersionUnchanged": "版本未變化",
+    "toolActionVersionUnchangedTitle": "已經是最新版本",
+    "toolCheckEnv": "環境檢測",
+    "toolConflictDefault": "預設",
+    "toolConflictHint": "偵測到多個安裝位置，建議選擇其中一個作為預設",
+    "toolConflictNotRunnable": "無法使用",
+    "toolConflictTitle": "偵測到多個安裝位置",
+    "toolDiagnose": "診斷",
+    "toolDiagnoseFailed": "診斷失敗",
+    "toolDiagnoseNoConflict": "未發現衝突",
+    "toolDiagnosing": "診斷中…",
+    "toolInstall": "安裝",
+    "toolNotRunnable": "無法使用",
+    "toolReady": "已就緒",
+    "toolUpdate": "更新",
+    "toolUpgradeConfirmBtn": "開始更新",
+    "toolUpgradeConfirmHint": "此操作會從套件管理員中升級到最新版本",
+    "toolUpgradeConfirmTitle": "確認更新",
+    "toolUpgradeUnanchoredHint": "將執行：",
+    "toolUpgradeWillRun": "將執行以下命令",
+    "updateAllTools": "更新所有工具",
+    "updateAvailableShort": "有新版本"
   },
   "apps": {
     "claude": "Claude",
@@ -1124,7 +1255,8 @@
     "fetchModelsAuthFailed": "API Key 無效或無權限",
     "fetchModelsNotSupported": "該供應商不支援取得模型清單",
     "fetchModelsEndpointNotFound": "未找到可用的模型清單端點，請檢查 Base URL 或確認供應商是否開放該 API",
-    "fetchModelsTimeout": "請求逾時，請檢查網路連線"
+    "fetchModelsTimeout": "請求逾時，請檢查網路連線",
+    "providerKeyStatusLoading": "正在載入供應商標識狀態，請稍後再試"
   },
   "copilot": {
     "authSection": "GitHub Copilot 驗證",
@@ -1285,7 +1417,8 @@
     "reasoningEffortHint": "上游支援 low/high/max 等思考深度控制時啟用。啟用後會自動啟用思考模式，並把 Codex 的 reasoning.effort 轉成上游 Chat 參數。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "預設供應商已自動設定；自訂供應商會按名稱/位址自動推斷。僅當自動識別不準時才需手動覆寫。",
-    "advancedSectionHint": "包含上游格式、模型映射、思考能力與自訂 User-Agent。使用 Chat Completions 協定的供應商需開啟路由接管才能使用。"
+"advancedSectionHint": "包含本地路由映射、上游格式、模型映射、思考能力與自訂 User-Agent。供應商使用 Chat Completions 協定或非 GPT 模型時，需在此開啟本地路由映射。",
+    "noCommonConfigToApply": "通用設定片段為空或沒有可寫入的內容"
   },
   "geminiConfig": {
     "envFile": "環境變數 (.env)",
@@ -1528,7 +1661,8 @@
     "modelsDevTruncated": "僅顯示前 {{shown}} 條，共 {{total}} 條結果，請縮小搜尋範圍",
     "modelsDevDefaultHint": "預設展示最新發布的 {{shown}} 個模型（共 {{total}} 個），輸入關鍵字可全量搜尋",
     "cacheReadCostPerMillion": "快取讀取成本 (每百萬 tokens, USD)",
-    "cacheCreationCostPerMillion": "快取寫入成本 (每百萬 tokens, USD)"
+    "cacheCreationCostPerMillion": "快取寫入成本 (每百萬 tokens, USD)",
+    "unpriced": "未定價"
   },
   "usageScript": {
     "title": "設定用量查詢",
@@ -1570,6 +1704,10 @@
     "organizationIdPlaceholder": "例如：org-xxxxxx",
     "projectId": "專案 ID",
     "projectIdPlaceholder": "例如：proj-xxxxxx",
+    "minimaxGroupId": "集團 ID（Group ID）",
+    "minimaxGroupIdHint": "MiniMax 用量介面需要 Group ID 才能取得真實資料；缺省時介面會回傳 0/100 占位值，會被誤顯示為 0%。",
+    "minimaxGroupIdLink": "請於 MiniMax 開放平台「帳戶管理 → 帳戶資訊 → 基本資訊」中取得。",
+    "minimaxGroupIdUrlLabel": "開啟 MiniMax 帳戶頁面",
     "defaultPlan": "預設方案",
     "queryFailedMessage": "查詢失敗",
     "queryScript": "查詢腳本（JavaScript）",
@@ -2396,24 +2534,25 @@
     "testProvider": "測試模型"
   },
   "health": {
-    "operational": "正常",
+    "operational": "輪換中",
     "degraded": "降級",
     "failed": "失敗",
-    "circuitOpen": "斷路",
+    "circuitOpen": "熔斷",
     "consecutiveFailures": "連續失敗 {{count}} 次"
   },
   "failover": {
     "enabled": "{{app}} 故障轉移已啟用",
     "disabled": "{{app}} 故障轉移已關閉",
     "toggleFailed": "操作失敗：{{detail}}",
-    "inQueue": "已加入",
-    "addQueue": "加入",
+    "inRotation": "輪換中",
+    "addToRotation": "加入輪換",
     "priority": {
       "tooltip": "故障轉移優先順序 {{priority}}"
     },
     "tooltip": {
       "enabled": "{{app}} 故障轉移已啟用\n按佇列優先順序（P1→P2→...）選擇供應商",
-      "disabled": "啟用 {{app}} 故障轉移\n將立即切換至佇列 P1，並在失敗時自動切換至下一個"
+      "disabled": "啟用 {{app}} 故障轉移\n將立即切換至佇列 P1，並在失敗時自動切換至下一個",
+      "takeoverRequired": "請先接管 {{app}}，再啟用故障轉移"
     }
   },
   "proxy": {
@@ -2591,7 +2730,9 @@
     },
     "server": {
       "started": "路由服務已啟動 - {{address}}:{{port}}",
-      "startFailed": "啟動路由服務失敗：{{detail}}"
+      "startFailed": "啟動路由服務失敗：{{detail}}",
+      "stopFailed": "停止代理服務失敗：{{detail}}",
+      "stopped": "代理服務已停止"
     },
     "stoppedWithRestore": "路由服務已關閉，已還原所有路由設定",
     "stopWithRestoreFailed": "停止失敗：{{detail}}"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -42,6 +42,104 @@
     "enabled": "已开启",
     "notSet": "未设置"
   },
+  "apiKeyList": {
+    "saveProviderFirst": "请先保存供应商，再管理 Key 池",
+    "title": "API Key 池",
+    "subtitle": "多把 key 在代理模式下自动轮换",
+    "empty": "还没有 key，点击下方添加。",
+    "moveUp": "上移",
+    "moveDown": "下移",
+    "active": "默认",
+    "disabled": "已停用",
+    "cooldown": "冷却中",
+    "unnamed": "（未命名）",
+    "toggleEnabled": "启用 / 停用",
+    "setActive": "设为默认",
+    "delete": "删除",
+    "add": "添加 Key",
+    "createTitle": "添加 API Key",
+    "createDesc": "为该供应商新增一把 API Key",
+    "labelLabel": "标签",
+    "valueLabel": "API Key",
+    "tagsLabel": "标签",
+    "tagsPlaceholder": "输入后回车添加（prod、region-east）",
+    "notesLabel": "备注",
+    "enabledLabel": "启用",
+    "edit": "编辑",
+    "editTitle": "编辑 Key",
+    "editValueHint": "留空则保留原值",
+    "dragHandle": "拖动以重新排序",
+    "deleteConfirmTitle": "删除 API Key？",
+    "deleteConfirmMessage": "确认删除 \"{{label}}\" 吗？此操作不可撤销。"
+  },
+  "apiKeys": {
+    "create": {
+      "success": "API key 已添加",
+      "error": "添加失败：{{error}}"
+    },
+    "update": {
+      "success": "已保存",
+      "error": "保存失败：{{error}}"
+    },
+    "delete": {
+      "success": "已删除",
+      "error": "删除失败：{{error}}"
+    },
+    "setActive": {
+      "success": "已设为默认 key",
+      "error": "设置失败：{{error}}"
+    }
+  },
+  "apiKeyStatusBar": {
+    "cooldownRemaining": "冷却剩余",
+    "cooldownHint": "（届时自动恢复轮换）",
+    "disabled": "已停用",
+    "disabledHint": "（手动启用后恢复轮换）",
+    "failureCount": "已失败 {{count}} / {{threshold}} 次",
+    "failureHint": "（再失败 {{remaining}} 次将自动轮换）",
+    "ready": "冷却状态：就绪",
+    "readyHint": "（{{threshold}} 次失败后自动轮换）",
+    "fiveHour": "5h 配额",
+    "fiveHourWindow": "5小时",
+    "sevenDay": "7d 配额",
+    "sevenDayWindow": "7天",
+    "thirtyDayWindow": "30天",
+    "monthlyWindow": "月度",
+    "weeklyLimitWindow": "周限额",
+    "remaining": "剩",
+    "windowResetsIn": "将在 {{reset}} 后重置",
+    "units": {
+      "second": "秒",
+      "minute": "分钟",
+      "hour": "小时",
+      "day": "天"
+    }
+  },
+  "keyPool": {
+    "listTitle": "API 密钥池（{{count}}）",
+    "listHint": "代理模式下自动轮换；编辑面板在「编辑」中",
+    "active": "默认",
+    "unnamed": "（未命名）",
+    "cooldown": "冷却",
+    "disabled": "停用",
+    "refresh": "刷新",
+    "refreshing": "刷新中…",
+    "setActive": "设为默认",
+    "activateLabel": "立即启用",
+    "activatedLabel": "已启用",
+    "toggleRotation": "加入轮换",
+    "rotationBlocked": "该 key 轮换已禁用",
+    "rotationBlockedExhausted": "5h/7d 配额已耗尽",
+    "rotationBlockedCooldown": "冷却中，轮换已禁用",
+    "rotationBlockedApiInvalid": "API 无响应或失效，已禁用轮换",
+    "dragHandle": "拖动以重新排序",
+    "health": {
+      "healthy": "正常",
+      "degraded": "有失败",
+      "cooling_down": "冷却中",
+      "disabled": "已停用"
+    }
+  },
   "firstRunNotice": {
     "title": "欢迎使用 CC Switch",
     "bodyDefault": "CC Switch 可以帮你在 Claude Code / Codex / Gemini CLI 的多个供应商之间一键切换。如果你之前已经配置过这些工具，CC Switch 会自动把现有设置保存为名为 “default” 的供应商，保证你的配置不会丢失。",
@@ -173,7 +271,8 @@
         "oauthHint": "Google 官方使用 OAuth 个人认证，无需填写 API Key。首次使用时会自动打开浏览器进行登录。",
         "apiKeyPlaceholder": "请输入 Gemini API Key"
       }
-    }
+    },
+    "duplicateLiveIdsLoadFailed": "读取配置中的供应商标识失败，请先修复配置后再试"
   },
   "claudeCode": {
     "needsRouting": "需要路由",
@@ -220,7 +319,8 @@
       "tooltip": {
         "active": "Claude Desktop 本地路由已开启 - {{address}}:{{port}}",
         "inactive": "开启 Claude Desktop 本地路由，用于需要模型映射或格式转换的供应商。当前配置地址：{{address}}:{{port}}"
-      }
+      },
+      "stopBlockedByTakeover": "其它应用正在使用代理接管。请先在设置中关闭对应应用接管，再停止本地路由。"
     }
   },
   "notifications": {
@@ -265,7 +365,8 @@
     "backfillWarning": "切换成功，但旧供应商配置回填失败，您手动修改的配置可能未保存",
     "windowControlFailed": "窗口控制失败：{{error}}",
     "officialBlockedByProxy": "本地路由模式下不能切换到官方供应商，使用路由访问官方 API 可能导致账号被封禁",
-    "proxyOfficialWarning": "当前供应商 {{name}} 是官方供应商，建议切换到第三方供应商后再使用本地路由"
+    "proxyOfficialWarning": "当前供应商 {{name}} 是官方供应商，建议切换到第三方供应商后再使用本地路由",
+    "proxyReasonClaudeDesktop": "使用 Claude Desktop 本地路由模式"
   },
   "confirm": {
     "deleteProvider": "删除供应商",
@@ -793,35 +894,35 @@
     "manualInstallCommands": "手动安装命令",
     "oneClickInstallHint": "安装或升级 Claude Code / Codex / Gemini CLI / OpenCode / OpenClaw / Hermes",
     "localEnvCheck": "本地环境检查",
-    "updateAllTools": "全部升级（{{count}}）",
+    "updateAllTools": "更新所有工具",
     "currentVersion": "当前版本",
     "latestVersion": "最新版本",
-    "updateAvailableShort": "可升级",
+    "updateAvailableShort": "有新版本",
     "toolInstall": "安装",
-    "toolUpdate": "升级",
+    "toolUpdate": "更新",
     "toolReady": "已就绪",
-    "toolActionDone": "{{count}} 个工具{{action}}完成",
+    "toolActionDone": "{{action}}完成",
     "toolActionPartial": "{{succeeded}} 个{{action}}成功，{{failed}} 个失败",
-    "toolActionFailed": "安装/升级命令执行失败",
-    "toolNotRunnable": "已安装但无法运行（未探测到版本）",
-    "toolActionVersionUnchangedTitle": "版本没有变化",
-    "toolActionVersionUnchanged": "仍是 {{version}}（最新：{{latest}}）。上游升级器可能报告成功但没有实际更新。",
-    "toolActionInstalledNotRunnable": "已安装，但当前环境无法运行，请检查",
-    "installedNotRunnable": "已安装·无法运行",
-    "toolCheckEnv": "请检查运行环境",
-    "toolDiagnose": "诊断安装冲突",
+    "toolActionFailed": "{{action}}失败",
+    "toolNotRunnable": "不可用",
+    "toolActionVersionUnchangedTitle": "已经是最新版本",
+    "toolActionVersionUnchanged": "版本未变化",
+    "toolActionInstalledNotRunnable": "已安装但无法运行",
+    "installedNotRunnable": "已安装但不可运行",
+    "toolCheckEnv": "环境检测",
+    "toolDiagnose": "诊断",
     "toolDiagnosing": "诊断中…",
-    "toolConflictTitle": "检测到多处安装",
-    "toolConflictHint": "命令行实际使用标「默认」的那处；升级可能写到了别处。",
+    "toolConflictTitle": "检测到多个安装位置",
+    "toolConflictHint": "检测到多个安装位置，建议选择其中一个作为默认",
     "toolConflictDefault": "默认",
-    "toolConflictNotRunnable": "无法运行",
-    "toolDiagnoseNoConflict": "未发现安装冲突",
+    "toolConflictNotRunnable": "不可用",
+    "toolDiagnoseNoConflict": "未发现冲突",
     "toolDiagnoseFailed": "诊断失败",
-    "toolUpgradeConfirmTitle": "确认升级位置",
-    "toolUpgradeConfirmHint": "检测到多处安装。本次升级不会全部更新，具体作用的位置以下方各项为准。",
-    "toolUpgradeWillRun": "将执行：",
-    "toolUpgradeConfirmBtn": "确认升级",
-    "toolUpgradeUnanchoredHint": "无法确定命令行实际使用哪处，将执行默认升级命令（可能装到 PATH 上第一个 npm）。",
+    "toolUpgradeConfirmTitle": "确认更新",
+    "toolUpgradeConfirmHint": "此操作会从包管理器中升级到最新版本",
+    "toolUpgradeWillRun": "将执行以下命令",
+    "toolUpgradeConfirmBtn": "开始更新",
+    "toolUpgradeUnanchoredHint": "将执行：",
     "envBadge": {
       "wsl": "WSL",
       "windows": "Win",
@@ -1152,7 +1253,8 @@
     "fetchModelsAuthFailed": "API Key 无效或无权限",
     "fetchModelsNotSupported": "该供应商不支持获取模型列表",
     "fetchModelsEndpointNotFound": "未找到可用的模型列表端点，请检查 Base URL 或确认供应商是否开放该接口",
-    "fetchModelsTimeout": "请求超时，请检查网络连接"
+    "fetchModelsTimeout": "请求超时，请检查网络连接",
+    "providerKeyStatusLoading": "正在加载供应商标识状态，请稍后再试"
   },
   "copilot": {
     "authSection": "GitHub Copilot 认证",
@@ -1313,7 +1415,8 @@
     "reasoningEffortHint": "上游支持 low/high/max 等思考深度控制时启用。启用后会自动启用思考模式，并把 Codex 的 reasoning.effort 转成上游 Chat 参数。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "预设供应商已自动配置；自定义供应商会按名称/地址自动推断。仅当自动识别不准时才需手动覆盖。",
-    "advancedSectionHint": "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。"
+"advancedSectionHint": "包含本地路由映射、上游格式、模型映射、思考能力与自定义 User-Agent。供应商使用 Chat Completions 协议或非 GPT 模型时，需在此开启本地路由映射。",
+    "noCommonConfigToApply": "通用配置片段为空或没有可写入的内容"
   },
   "geminiConfig": {
     "envFile": "环境变量 (.env)",
@@ -1556,7 +1659,8 @@
     "modelsDevTruncated": "仅显示前 {{shown}} 条，共 {{total}} 条结果，请缩小搜索范围",
     "modelsDevDefaultHint": "默认展示最新发布的 {{shown}} 个模型（共 {{total}} 个），输入关键字可全量搜索",
     "cacheReadCostPerMillion": "缓存读取成本 (每百万 tokens, USD)",
-    "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)"
+    "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)",
+    "unpriced": "未定价"
   },
   "usageScript": {
     "title": "配置用量查询",
@@ -1598,6 +1702,10 @@
     "organizationIdPlaceholder": "例如：org-xxxxxx",
     "projectId": "项目 ID",
     "projectIdPlaceholder": "例如：proj-xxxxxx",
+    "minimaxGroupId": "集团 ID（Group ID）",
+    "minimaxGroupIdHint": "MiniMax 用量接口需要 Group ID 才能返回真实数据；缺省时接口返回 0/100 占位值，会被误显示为 0%。",
+    "minimaxGroupIdLink": "请在 MiniMax 开放平台「账户管理 → 账户信息 → 基本信息」中获取。",
+    "minimaxGroupIdUrlLabel": "打开 MiniMax 账户页面",
     "defaultPlan": "默认套餐",
     "queryFailedMessage": "查询失败",
     "queryScript": "查询脚本（JavaScript）",
@@ -2424,7 +2532,7 @@
     "testProvider": "测试模型"
   },
   "health": {
-    "operational": "正常",
+    "operational": "轮换中",
     "degraded": "降级",
     "failed": "失败",
     "circuitOpen": "熔断",
@@ -2434,14 +2542,15 @@
     "enabled": "{{app}} 故障转移已启用",
     "disabled": "{{app}} 故障转移已关闭",
     "toggleFailed": "操作失败: {{detail}}",
-    "inQueue": "已加入",
-    "addQueue": "加入",
+    "inRotation": "轮换中",
+    "addToRotation": "加入轮换",
     "priority": {
       "tooltip": "故障转移优先级 {{priority}}"
     },
     "tooltip": {
       "enabled": "{{app}} 故障转移已启用\n按队列优先级（P1→P2→...）选择供应商",
-      "disabled": "启用 {{app}} 故障转移\n将立即切换到队列 P1，并在失败时自动切换到下一个"
+      "disabled": "启用 {{app}} 故障转移\n将立即切换到队列 P1，并在失败时自动切换到下一个",
+      "takeoverRequired": "请先接管 {{app}}，再启用故障转移"
     }
   },
   "proxy": {
@@ -2619,7 +2728,9 @@
     },
     "server": {
       "started": "路由服务已启动 - {{address}}:{{port}}",
-      "startFailed": "启动路由服务失败: {{detail}}"
+      "startFailed": "启动路由服务失败: {{detail}}",
+      "stopFailed": "停止代理服务失败：{{detail}}",
+      "stopped": "代理服务已停止"
     },
     "stoppedWithRestore": "路由服务已关闭，已恢复所有路由配置",
     "stopWithRestoreFailed": "停止失败: {{detail}}"

--- a/src/lib/api/apiKey.ts
+++ b/src/lib/api/apiKey.ts
@@ -1,0 +1,120 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Wire DTO mirrored on the Rust side as `commands::api_key::ApiKeyDto`.
+ * One row of `provider_api_keys` per provider.
+ *
+ * `apiKey` is plaintext in the DB to match the rest of the app's
+ * storage (Provider.settings_config.api_key). A later secret-store
+ * migration would touch both columns at once.
+ */
+export interface ApiKeyDto {
+  id: string;
+  providerId: string;
+  appType: string;
+  label: string;
+  apiKey: string;
+  tags: string[];
+  notes: string;
+  enabled: boolean;
+  sortIndex: number;
+  isActive: boolean;
+  /** Unix seconds; 0 = no cooldown */
+  cooldownUntil: number;
+  failureCount: number;
+  lastUsedAt: number | null;
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CreateApiKeyInput {
+  providerId: string;
+  appType: string;
+  label: string;
+  apiKey: string;
+  tags?: string[];
+  notes?: string;
+  /** Default true on the Rust side; we mirror the default here for clarity. */
+  enabled?: boolean;
+}
+
+export interface UpdateApiKeyInput {
+  label?: string;
+  apiKey?: string;
+  tags?: string[];
+  notes?: string;
+  enabled?: boolean;
+  sortIndex?: number;
+  isActive?: boolean;
+}
+
+/**
+ * 删除 key 后端返回的元数据——前端用来精确 invalidate
+ * `["apiKeys", providerId, appType]` 这一格缓存。
+ */
+export interface DeletedApiKeyInfo {
+  keyId: string;
+  providerId: string;
+  appType: string;
+}
+
+/**
+ * Thin Tauri invoke wrapper for the 8 `cmd_*_api_key` commands. The
+ * frontend never talks to the DB directly — all state changes go
+ * through here so KeyRing + settings.json side-effects can be hooked
+ * up later (Phase 10).
+ */
+export const apiKeysApi = {
+  /** 列出某 provider 的全部 key（按 sortIndex ASC）。 */
+  list: (providerId: string, appType: string) =>
+    invoke<ApiKeyDto[]>("cmd_list_api_keys", { providerId, appType }),
+
+  /** 取单个 key。 */
+  get: (keyId: string) =>
+    invoke<ApiKeyDto | null>("cmd_get_api_key", { keyId }),
+
+  /**
+   * 取当前 active key（写入 settings.json 用的那把）。
+   * 返回 null 当没有 key 被激活。
+   */
+  getActive: (providerId: string, appType: string) =>
+    invoke<ApiKeyDto | null>("cmd_get_active_api_key", {
+      providerId,
+      appType,
+    }),
+
+  /** 新建一把 key。返回插入后的整行。 */
+  create: (payload: CreateApiKeyInput) =>
+    invoke<ApiKeyDto>("cmd_create_api_key", { payload }),
+
+  /**
+   * 更新 key。`payload` 里未提供的字段不会被写——DAO 的动态 SET
+   * clause 依赖 Some/None 来决定要 UPDATE 哪些列。
+   */
+  update: (keyId: string, payload: UpdateApiKeyInput) =>
+    invoke<ApiKeyDto>("cmd_update_api_key", { keyId, payload }),
+
+  /** 删除 key。返回 (keyId, providerId, appType) 让前端精确 invalidate
+   * 那一格 apiKeys 缓存——不再广播到所有 ["apiKeys"] 触发多余 refetch。 */
+  remove: (keyId: string) =>
+    invoke<DeletedApiKeyInfo>("cmd_delete_api_key", { keyId }),
+
+  /**
+   * 拖拽重排——传完整的有序 keyId 列表。DAO 会把 list[0] 设为
+   * sortIndex=0、list[1] 设为 sortIndex=1，以此类推。
+   */
+  reorder: (appType: string, orderedIds: string[]) =>
+    invoke<void>("cmd_reorder_api_keys", { appType, orderedIds }),
+
+  /**
+   * 把某 key 设为「写入 settings.json 的那把」+ 触达 KeyRing。
+   * 事务保证同 provider 下只有一个 active key。
+   */
+  setActive: (providerId: string, appType: string, keyId: string) =>
+    invoke<ApiKeyDto>("cmd_set_active_api_key", {
+      providerId,
+      appType,
+      keyId,
+    }),
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -13,6 +13,8 @@ export { proxyApi } from "./proxy";
 export { openclawApi } from "./openclaw";
 export { sessionsApi } from "./sessions";
 export { workspaceApi } from "./workspace";
+export { apiKeysApi } from "./apiKey";
+export type { ApiKeyDto, CreateApiKeyInput, UpdateApiKeyInput } from "./apiKey";
 export * as configApi from "./config";
 export * as authApi from "./auth";
 export * as copilotApi from "./copilot";

--- a/src/lib/api/subscription.ts
+++ b/src/lib/api/subscription.ts
@@ -16,6 +16,8 @@ export const subscriptionApi = {
     codingPlanProvider?: string,
     teamOrganizationId?: string,
     teamProjectId?: string,
+    // MiniMax Coding Plan 集团 ID；缺省时接口返回占位零值导致误显示 0%。
+    groupId?: string,
   ): Promise<SubscriptionQuota> =>
     invoke("get_coding_plan_quota", {
       baseUrl,
@@ -25,6 +27,7 @@ export const subscriptionApi = {
       codingPlanProvider,
       teamOrganizationId,
       teamProjectId,
+      groupId,
     }),
   getBalance: (
     baseUrl: string,

--- a/src/lib/api/usage.ts
+++ b/src/lib/api/usage.ts
@@ -23,6 +23,55 @@ export const usageApi = {
     return invoke("queryProviderUsage", { providerId, app: appId });
   },
 
+  /**
+   * Per-key usage query: same `usage_script` as `query()`, but the
+   * `api_key` is read from the specific row in `provider_api_keys`.
+   * Lets the editor show each key's quota independently — the legacy
+   * provider-level query only reflects the *active* key.
+   *
+   * Backend returns `Ok(UsageResult { success: false, .. })` for
+   * disabled / mismatched keys, and `Err(String)` for transport / DB
+   * failures — same shape as `query()`.
+   */
+  queryForKey: async (
+    providerId: string,
+    keyId: string,
+    appId: AppId,
+  ): Promise<UsageResult> => {
+    return invoke("queryProviderUsageForKey", {
+      providerId,
+      keyId,
+      app: appId,
+    });
+  },
+
+  /**
+   * Proactive rotation：通知 KeyRing 把这把 key 提前送进 cooldown。
+   * 由 `useKeyUsageQuery` 的 onSuccess 副作用触发——当某把 key 的
+   * `usage_percent >= 90%` 时调用。返回 `true` 表示 KeyRing 应用了
+   * cooldown；`false` 表示用量还在安全区、KeyRing 不动。
+   *
+   * **Fire-and-forget**：调用方不 await，UI 不会因 backend 错误
+   * 而崩溃——命令侧把异常全部 swallow 成 `Ok(false)`。
+   */
+  markKeyUsageHigh: async (
+    keyId: string,
+    usagePercent: number,
+    resetAtUnix: number,
+  ): Promise<boolean> => {
+    try {
+      return await invoke<boolean>("cmd_mark_key_usage_high", {
+        keyId,
+        usagePercent,
+        resetAt: resetAtUnix,
+      });
+    } catch {
+      // KeyRing 未加载 / proxy 未运行 / 其它 backend 错误——静默失败，
+      // 不影响 autoQuery 的后续轮询周期。
+      return false;
+    }
+  },
+
   testScript: async (
     providerId: string,
     appId: AppId,

--- a/src/lib/query/apiKey.ts
+++ b/src/lib/query/apiKey.ts
@@ -1,0 +1,215 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import { extractErrorMessage } from "@/utils/errorUtils";
+import { apiKeysApi, type CreateApiKeyInput, type UpdateApiKeyInput } from "@/lib/api/apiKey";
+
+/**
+ * React Query surface for the `provider_api_keys` table.
+ *
+ * **单一真相来源**：`useApiKeys` 返回的列表里每条 key 都带 `is_active` 字段，
+ * 调用方自己 `.find((k) => k.is_active)` 即可拿到 active key。不要再单独
+ * 起一个 `useActiveApiKey` 查询——同一份状态走两个 query 会让 React Query
+ * 缓存里出现两份可能不一致的快照（`apiKeys` refetch 完但 `activeApiKey` 还
+ * 没 refetch，UI 上会闪一下"老 active + 新 list"）。
+ *
+ * Query key shape：
+ *   ["apiKeys", providerId, appType]
+ *   ["apiKey", keyId]                —— 仅给单 key 详情页用，普通列表不需要
+ *
+ * 所有 mutations 都会 invalidate `["apiKeys", providerId, appType]`，
+ * active key 状态会随着 list 一起更新，零额外协调。
+ */
+
+// ========== Queries ==========
+
+/** List all keys for a provider (sorted by sortIndex ASC). */
+export function useApiKeys(providerId: string | null, appType: string) {
+  return useQuery({
+    queryKey: ["apiKeys", providerId, appType],
+    queryFn: () => apiKeysApi.list(providerId as string, appType),
+    enabled: !!providerId && !!appType,
+    // 30s refetch keeps the runtime fields (cooldown, failure_count)
+    // fresh even when the proxy is doing the writes. The KeyRing
+    // writes through the same DB row, so this is the cheapest way to
+    // surface "this key just got 429'd" to the user.
+    refetchInterval: 30_000,
+  });
+}
+
+/**
+ * 从 `useApiKeys` 列表里挑出 active key。等价于原来的 `useActiveApiKey`，
+ * 但少一次网络往返 + 一份缓存——保持单一数据源。
+ *
+ * 选 `is_active=true` 的第一条；如果 DB 没设 active（理论不会出现，
+ * set_active_api_key_with_settings 事务里强制保证），退回 sortIndex=0。
+ */
+export function pickActiveKey<T extends { id: string; isActive: boolean; sortIndex: number }>(
+  keys: T[] | undefined,
+): T | null {
+  if (!keys || keys.length === 0) return null;
+  return (
+    keys.find((k) => k.isActive) ??
+    [...keys].sort((a, b) => a.sortIndex - b.sortIndex)[0] ??
+    null
+  );
+}
+
+/** Single key lookup. */
+export function useApiKey(keyId: string | null) {
+  return useQuery({
+    queryKey: ["apiKey", keyId],
+    queryFn: () => apiKeysApi.get(keyId as string),
+    enabled: !!keyId,
+  });
+}
+
+// ========== Mutations ==========
+
+/** Create a new key. Defaults `enabled=true` server-side. */
+export function useCreateApiKey() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: (payload: CreateApiKeyInput) => apiKeysApi.create(payload),
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({
+        queryKey: ["apiKeys", created.providerId, created.appType],
+      });
+      toast.success(t("apiKeys.create.success", { defaultValue: "API key 已添加" }));
+    },
+    onError: (error) => {
+      toast.error(
+        t("apiKeys.create.error", {
+          defaultValue: `添加失败: ${extractErrorMessage(error)}`,
+        }),
+      );
+    },
+  });
+}
+
+/**
+ * Patch a key. Pass only the fields you want to change — the DAO's
+ * dynamic SET clause is `None` for everything else.
+ */
+export function useUpdateApiKey() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: ({
+      keyId,
+      payload,
+    }: {
+      keyId: string;
+      payload: UpdateApiKeyInput;
+    }) => apiKeysApi.update(keyId, payload),
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({
+        queryKey: ["apiKeys", updated.providerId, updated.appType],
+      });
+      queryClient.invalidateQueries({ queryKey: ["apiKey", updated.id] });
+      toast.success(t("apiKeys.update.success", { defaultValue: "已保存" }));
+    },
+    onError: (error) => {
+      toast.error(
+        t("apiKeys.update.error", {
+          defaultValue: `保存失败: ${extractErrorMessage(error)}`,
+        }),
+      );
+    },
+  });
+}
+
+/**
+ * Delete a key. The backend returns the deleted key's parent
+ * (providerId, appType), which we use to invalidate exactly that
+ * `["apiKeys", providerId, appType]` cache slice — no more broad
+ * `["apiKeys"]` fan-out that would refetch all pools.
+ */
+export function useDeleteApiKey() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async (keyId: string) => {
+      return apiKeysApi.remove(keyId);
+    },
+    onSuccess: (info) => {
+      queryClient.invalidateQueries({
+        queryKey: ["apiKeys", info.providerId, info.appType],
+      });
+      queryClient.invalidateQueries({ queryKey: ["apiKey", info.keyId] });
+      toast.success(t("apiKeys.delete.success", { defaultValue: "已删除" }));
+    },
+    onError: (error) => {
+      toast.error(
+        t("apiKeys.delete.error", {
+          defaultValue: `删除失败: ${extractErrorMessage(error)}`,
+        }),
+      );
+    },
+  });
+}
+
+/**
+ * Drag-reorder. The caller hands us the full ordered list of keyIds
+ * for an `(appType, providerId)`. We don't know providerId here, so
+ * we invalidate the broad list query.
+ */
+export function useReorderApiKeys() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      appType,
+      orderedIds,
+    }: {
+      appType: string;
+      providerId: string;
+      orderedIds: string[];
+    }) => apiKeysApi.reorder(appType, orderedIds),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["apiKeys", variables.providerId, variables.appType],
+      });
+    },
+  });
+}
+
+/**
+ * Promote a key to `is_active=1` (the one written into settings.json).
+ * Also invalidates the active-key query so the form's radio updates.
+ */
+export function useSetActiveApiKey() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: ({
+      providerId,
+      appType,
+      keyId,
+    }: {
+      providerId: string;
+      appType: string;
+      keyId: string;
+    }) => apiKeysApi.setActive(providerId, appType, keyId),
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({
+        queryKey: ["apiKeys", updated.providerId, updated.appType],
+      });
+      toast.success(
+        t("apiKeys.setActive.success", { defaultValue: "已设为默认 key" }),
+      );
+    },
+    onError: (error) => {
+      toast.error(
+        t("apiKeys.setActive.error", {
+          defaultValue: `设置失败: ${extractErrorMessage(error)}`,
+        }),
+      );
+    },
+  });
+}

--- a/src/lib/query/copilot.ts
+++ b/src/lib/query/copilot.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { copilotGetUsage, copilotGetUsageForAccount } from "@/lib/api/copilot";
 import type { QuotaTier } from "@/types/subscription";
 
-const REFETCH_INTERVAL = 5 * 60 * 1000; // 5 minutes
+const REFETCH_INTERVAL = 1 * 60 * 1000; // 1 minute
 
 export interface CopilotQuota {
   success: boolean;

--- a/src/lib/query/index.ts
+++ b/src/lib/query/index.ts
@@ -3,3 +3,4 @@ export * from "./queries";
 export * from "./mutations";
 export * from "./proxy";
 export * from "./subscription";
+export * from "./apiKey";

--- a/src/lib/query/queries.ts
+++ b/src/lib/query/queries.ts
@@ -304,6 +304,74 @@ export const useUsageQuery = (
   };
 };
 
+/**
+ * Per-key 用量查询：与 `useUsageQuery` 走同一份 `usage_script`，但
+ * `api_key` 来自 `provider_api_keys` 表里那一行自己的值，不复用
+ * provider 级的 active key。用于 ApiKeyListSection 里逐行展示
+ * 每把 key 自己的配额 / 7d 用量。
+ *
+ * **query key 故意不带 providerId**：每把 key 的 (keyId, appId) 在
+ * 同 pool 内是唯一的。把 providerId 塞进去会让用户切换 provider 时
+ * 误以为换了 key——实际上 keyId 不变才是同一条记录。把 providerId
+ * 作为 queryFn 的闭包参数（不参与 key 构造）即可。
+ */
+export const useKeyUsageQuery = (
+  providerId: string,
+  keyId: string | null | undefined,
+  appId: AppId,
+  options?: UseUsageQueryOptions,
+) => {
+  const { enabled = true, autoQueryInterval = 0 } = options || {};
+
+  const staleTime =
+    autoQueryInterval > 0
+      ? autoQueryInterval * 60 * 1000
+      : 5 * 60 * 1000;
+
+  const query = useQuery<UsageResult>({
+    // keyId 维度——React Query 自动按 keyId 拆 cache，pool 里 N 把 key
+    // 就有 N 份独立快照，切换 active / 轮换时互不污染。
+    queryKey: ["keyUsage", keyId, appId] as const,
+    queryFn: async () => {
+      if (!keyId) {
+        // 占位：enabled=false 时不会调用，但保险起见短路掉。
+        return {
+          success: false,
+          data: undefined,
+          error: "no keyId",
+        } as UsageResult;
+      }
+      return usageApi.queryForKey(providerId, keyId, appId);
+    },
+    enabled: enabled && !!keyId,
+    refetchInterval:
+      autoQueryInterval > 0
+        ? Math.max(autoQueryInterval, 1) * 60 * 1000
+        : false,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: false,
+    retry: 1,
+    retryDelay: 1500,
+    staleTime,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  const lastGoodRef = useRef<LastGoodUsage | null>(null);
+  const { data, lastQueriedAt, lastGood } = resolveDisplayUsage(
+    query.data,
+    query.dataUpdatedAt,
+    lastGoodRef.current,
+    Date.now(),
+  );
+  lastGoodRef.current = lastGood;
+
+  return {
+    ...query,
+    data,
+    lastQueriedAt,
+  };
+};
+
 export const useSessionsQuery = () => {
   return useQuery<SessionMeta[]>({
     queryKey: ["sessions"],

--- a/src/lib/query/subscription.ts
+++ b/src/lib/query/subscription.ts
@@ -9,7 +9,7 @@ import { PROVIDER_TYPES } from "@/config/constants";
 import { resolveDisplayUsage, type LastGoodSnapshot } from "./queries";
 import { extractErrorMessage } from "@/utils/errorUtils";
 
-const REFETCH_INTERVAL = 5 * 60 * 1000; // 5 minutes
+const REFETCH_INTERVAL = 1 * 60 * 1000; // 1 minute
 
 export const subscriptionKeys = {
   all: ["subscription"] as const,
@@ -80,7 +80,7 @@ export function useSubscriptionQuota(
   appId: AppId,
   enabled: boolean,
   autoQuery = false,
-  autoQueryIntervalMinutes = 5,
+  autoQueryIntervalMinutes = 1,
 ) {
   const refetchInterval =
     autoQuery && autoQueryIntervalMinutes > 0

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface UsageScript {
   teamOrganizationId?: string; // 智谱团队套餐组织 ID（请求头 bigmodel-organization）
   teamProjectId?: string; // 智谱团队套餐项目 ID（请求头 bigmodel-project）
   codingPlanProvider?: string; // Coding Plan 供应商标识（如 "kimi", "zhipu", "minimax"）
+  groupId?: string; // MiniMax Coding Plan 集团 ID（必填，缺省时接口返回占位零值导致误显示 0%）
   autoQueryInterval?: number; // 自动查询间隔（单位：分钟，0 表示禁用）
   autoIntervalMinutes?: number; // 自动查询间隔（分钟）- 别名字段
   request?: {
@@ -83,7 +84,7 @@ const DEFAULT_USAGE_SCRIPT: UsageScript = {
   language: "javascript",
   code: "",
   timeout: 10,
-  autoQueryInterval: 5,
+  autoQueryInterval: 1,
 };
 
 export function createUsageScript(

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -11,6 +11,12 @@ export interface QuotaTier {
   usedValueUsd?: number | null;
   maxValueUsd?: number | null;
   planLabel?: string | null;
+  // MiniMax 等 provider 直接返回绝对次数时填充；与 utilization 同时存在，
+  // 渲染层应优先用绝对值（"7 / 100"）展示。仅在 provider 给出绝对值时存在，
+  // 其余 provider（ZenMux USD / Zhipu percentage）保持 undefined。
+  usedCount?: number | null;
+  totalCount?: number | null;
+  countUnit?: string | null;
 }
 
 export interface ExtraUsage {

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -17,6 +17,9 @@ export interface QuotaTier {
   usedCount?: number | null;
   totalCount?: number | null;
   countUnit?: string | null;
+  // 服务端精确剩余毫秒数（来自 MiniMax *_remains_time 等字段）。
+  // 优先于前端 end_time - Date.now() 计算（避免本地时钟漂移 + 拿到毫秒精度）。
+  remainsTimeMs?: number | null;
 }
 
 export interface ExtraUsage {

--- a/src/utils/tagColor.ts
+++ b/src/utils/tagColor.ts
@@ -1,0 +1,54 @@
+/**
+ * 共享的 tag 着色工具 —— 由 `ApiKeyListSection`（编辑面板）和
+ * `KeyPoolBadge`（provider 列表 row）共同消费，保证同一个 tag 字符串
+ * 在两处视觉颜色一致。
+ *
+ * 算法：djb2 hash → unsigned 32-bit → % palette.len。空串落到 0；
+ * tag 长度 ≤ 32 时碰撞率 < 0.5%。
+ *
+ * 调色板风格参考 GitHub / Trello 的 tag：浅色（light）bg 90% 饱和度 +
+ * fg 35%，dark mode 切到 30% 饱和度背景 + 高亮前景，避免暗色下文字
+ * 不可读。六色光谱均匀分布，避免相邻 tag 颜色太近。
+ */
+
+const TAG_PALETTE: ReadonlyArray<{ light: string; dark: string }> = [
+  {
+    light: "bg-blue-100 text-blue-700 ring-blue-200",
+    dark: "dark:bg-blue-950/60 dark:text-blue-300 dark:ring-blue-900",
+  },
+  {
+    light: "bg-emerald-100 text-emerald-700 ring-emerald-200",
+    dark: "dark:bg-emerald-950/60 dark:text-emerald-300 dark:ring-emerald-900",
+  },
+  {
+    light: "bg-amber-100 text-amber-700 ring-amber-200",
+    dark: "dark:bg-amber-950/60 dark:text-amber-300 dark:ring-amber-900",
+  },
+  {
+    light: "bg-rose-100 text-rose-700 ring-rose-200",
+    dark: "dark:bg-rose-950/60 dark:text-rose-300 dark:ring-rose-900",
+  },
+  {
+    light: "bg-violet-100 text-violet-700 ring-violet-200",
+    dark: "dark:bg-violet-950/60 dark:text-violet-300 dark:ring-violet-900",
+  },
+  {
+    light: "bg-teal-100 text-teal-700 ring-teal-200",
+    dark: "dark:bg-teal-950/60 dark:text-teal-300 dark:ring-teal-900",
+  },
+];
+
+/** djb2 hash → unsigned 32-bit → palette 索引。空串落 0。 */
+function hashTagToPaletteIndex(tag: string): number {
+  let hash = 5381;
+  for (let i = 0; i < tag.length; i++) {
+    hash = ((hash << 5) + hash) ^ tag.charCodeAt(i);
+  }
+  return (hash >>> 0) % TAG_PALETTE.length;
+}
+
+/** 返回 `tag` 对应的 Tailwind className 片段（背景 / 文字 / 细 ring）。 */
+export function tagColorClasses(tag: string): string {
+  const palette = TAG_PALETTE[hashTagToPaletteIndex(tag)];
+  return `${palette.light} ${palette.dark}`;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -168,6 +168,6 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require("tailwindcss-animate")],
 };
 

--- a/tests/components/SubscriptionQuotaFooter.countdown.test.ts
+++ b/tests/components/SubscriptionQuotaFooter.countdown.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { countdownStr } from "@/components/SubscriptionQuotaFooter";
+
+describe("countdownStr", () => {
+  it("formats >= 24h as XdYh", () => {
+    const ms = 2 * 24 * 60 * 60 * 1000 + 4 * 60 * 60 * 1000; // 2d 4h
+    expect(countdownStr(null, ms)).toBe("2d4h");
+  });
+
+  it("formats < 24h as XhYm", () => {
+    const ms = 2 * 60 * 60 * 1000 + 30 * 60 * 1000; // 2h 30m
+    expect(countdownStr(null, ms)).toBe("2h30m");
+  });
+
+  it("formats < 1h as XmYs", () => {
+    const ms = 23 * 60 * 1000 + 45 * 1000; // 23m 45s
+    expect(countdownStr(null, ms)).toBe("23m45s");
+  });
+
+  it("formats < 1m as Xs", () => {
+    const ms = 45 * 1000; // 45s
+    expect(countdownStr(null, ms)).toBe("45s");
+  });
+
+  it("prefers remainsTimeMs over endTime when both available", () => {
+    // remainsTimeMs=1h 切确；endTime 5h - now 较准。
+    const ms = 60 * 60 * 1000;
+    const futureIso = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+    expect(countdownStr(futureIso, ms)).toBe("1h0m");
+  });
+
+  it("falls back to endTime - now when remainsTimeMs absent", () => {
+    // 30m 后: totalSeconds=1800, minutes=30, seconds=0 → "30m0s"
+    const futureIso = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+    expect(countdownStr(futureIso)).toBe("30m0s");
+  });
+
+  it("returns null when remainsTimeMs is non-positive or absent and endTime is null", () => {
+    expect(countdownStr(null)).toBeNull();
+    expect(countdownStr(null, 0)).toBeNull();
+    expect(countdownStr(null, -1)).toBeNull();
+  });
+});


### PR DESCRIPTION
    feat: 多 API Key 轮询池，支持双层轮转与单 Key 使用统计
    
    实现多 Key 提供者池，支持单 Key 级别的 API Key 管理：
    - 新增单 Key 的增删改查操作，包括数据库迁移和 DAO 层
    - 新增 KeyRing 实现 Key 轮转、限流处理与冷却追踪
    - 新增单 Key 用量查询与缓存隔离
    - 更新代理逻辑以支持 Key 选择，并将 Key ID 传入用量记录
    - 新增提供者设置中的多 Key 池管理 UI 组件

## 概述

本次 PR 为 CC Switch 带来 **双层自动轮询** 能力 —— 在 *Provider* 层和
*API Key* 层都支持自动切换，从此写代码再也不会因为单个 key 或单个
provider 挂掉而中断工作流。

## 新增功能

### 1. 单 Provider 多 Key 池
- 一个 provider 可以添加多个 API key。
- 每个 key 支持 **自定义别名** 和 **彩色标签**，方便区分（例如 `工作`、
  `备用`、`试用`）。
- 每个 key 的用量独立追踪与展示 —— 彻底修复了「池里所有 key 都显示
  激活 key 100% 已用」的 bug。

### 2. Provider 轮询（全局开关）
- 顶栏新增 **「全局轮询开关」**（托盘菜单里也能切换），多 provider
  用户可以在失败时自动轮换。
- 单 provider 也支持 **「加入轮询 / 退出轮询」** 切换 —— 想保留的付费
  key/主力账号可以一键退出。
- 健康徽章从原来的「正常 / Operational」改为 **「In rotation / 轮换中」**，
  语义更准确。

### 3. 智能 Key 轮询逻辑
- 遇到 5xx、超时等「可重试错误」时，forwarder 会 **优先在同一个
  provider 的 key 池里轮询一轮**，轮完才会跳到下一个 provider。
- 限流的 key 通过 `mark_rate_limited` 进入 **30 秒冷却**，避免 cursor
  反复选到同一个坏 key。
- **90% 配额主动保护**：当某个 key 达到 5h/7d 配额的 90%，会自动被踢
  出轮询队列，**提前避免** 突然冒 429。
- 失败的 key 恢复可用后，失败计数自动重置为 0。
- Key 池全部耗尽时会优雅报错（带明确提示），不再死循环。

### 4. UX 改进
- Key 池头部新增「刷新」按钮，带 loading 反馈。
- Provider 卡片上的 5h/7d/30d 进度条：当 key 数量 ≥2 时自动隐藏
  provider 顶层用量条，改为展示单 key 用量条。
- 5h 倒计时格式：`1h54m` · 7d 倒计时格式：`3d20h`。
- 修复了 provider 编辑界面选 key 时表单被重置、未保存内容丢失的 bug。

## 包含的 Commits
- `4a1a6415` feat: add multi-key pool support and per-key usage tracking
- `040aaa63` refactor: implement proactive key rotation quota protection,
  improve UI/UX

## 测试计划
- [ ] 给一个 provider 加 3 个 key，禁用其中 2 个，确认流量只走启用的
  那一个。
- [ ] 中途禁用一个 key，确认 3 次重试内能自动切到下一个。
- [ ] 让 key A 达到 90% 配额，确认它被自动踢出轮询，不会先 429。
- [ ] 关闭全局轮询开关，确认回退到单 provider 模式，不做 failover。
- [ ] 冷却时间过后重新启用 key，确认失败计数被重置。

## 截图
<img width="1122" height="696" alt="Screenshot 2026-07-03 at 08 41 46" src="https://github.com/user-attachments/assets/f6b65e6e-06bf-4c8e-9c4a-a80d84c406a2" />
<img width="1129" height="695" alt="Screenshot 2026-07-02 at 20 51 51" src="https://github.com/user-attachments/assets/a5d8af26-f59c-44e1-88c1-0a08428ef601" />

