### PR TITLE
feat: preserve custom Codex catalog reasoning

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -420,6 +420,7 @@ fn extract_codex_top_level_u64(config_text: &str, field: &str) -> Option<u64> {
 
 fn codex_catalog_model_entry(
     template: &Value,
+    reasoning_template: &Value,
     spec: &CodexCatalogModelSpec,
     priority: usize,
     profile: CodexCatalogToolProfile,
@@ -439,6 +440,22 @@ fn codex_catalog_model_entry(
     entry_obj.insert("service_tiers".to_string(), json!([]));
     entry_obj.insert("availability_nux".to_string(), Value::Null);
     entry_obj.insert("upgrade".to_string(), Value::Null);
+
+    let default_reasoning_level = spec.default_reasoning_level.as_ref().map_or_else(
+        || reasoning_template.get("default_reasoning_level").cloned(),
+        |level| Some(json!(level)),
+    );
+    if let Some(level) = default_reasoning_level {
+        entry_obj.insert("default_reasoning_level".to_string(), level);
+    }
+    let supported_reasoning_levels = spec.supported_reasoning_levels.clone().or_else(|| {
+        reasoning_template
+            .get("supported_reasoning_levels")
+            .cloned()
+    });
+    if let Some(levels) = supported_reasoning_levels {
+        entry_obj.insert("supported_reasoning_levels".to_string(), levels);
+    }
 
     if profile == CodexCatalogToolProfile::NativeResponses {
         // Native `/responses` gateways reject Codex's freeform `apply_patch`
@@ -497,6 +514,66 @@ struct CodexCatalogModelSpec {
     /// back to the template default when absent. Only consulted for
     /// `NativeResponses`.
     base_instructions: Option<String>,
+    /// Optional per-model Codex reasoning default. When omitted, generated
+    /// entries inherit the reasoning metadata from the real Codex model template
+    /// instead of the native tool-compatibility template.
+    default_reasoning_level: Option<String>,
+    /// Optional per-model Codex reasoning capabilities. Stored as the exact
+    /// catalog JSON shape so descriptions survive round-trips.
+    supported_reasoning_levels: Option<Value>,
+}
+
+fn normalize_codex_reasoning_levels(
+    value: Option<&Value>,
+    template: Option<&Value>,
+) -> Option<Value> {
+    let levels = value?.as_array()?;
+    let mut normalized = Vec::new();
+
+    for level in levels {
+        if let Some(effort) = level.as_str().map(str::trim).filter(|s| !s.is_empty()) {
+            if let Some(template_level) = find_reasoning_level_by_effort(template, effort) {
+                normalized.push(template_level.clone());
+            } else {
+                normalized.push(json!({
+                    "description": effort,
+                    "effort": effort,
+                }));
+            }
+            continue;
+        }
+
+        if let Some(obj) = level.as_object() {
+            let Some(effort) = obj
+                .get("effort")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            else {
+                continue;
+            };
+            let mut normalized_obj = obj.clone();
+            normalized_obj.insert("effort".to_string(), json!(effort));
+            normalized.push(Value::Object(normalized_obj));
+        }
+    }
+
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(Value::Array(normalized))
+    }
+}
+
+fn find_reasoning_level_by_effort<'a>(
+    template: Option<&'a Value>,
+    effort: &str,
+) -> Option<&'a Value> {
+    template?
+        .get("supported_reasoning_levels")
+        .and_then(|value| value.as_array())?
+        .iter()
+        .find(|level| level.get("effort").and_then(|value| value.as_str()) == Some(effort))
 }
 
 fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCatalogModelSpec> {
@@ -566,6 +643,20 @@ fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCa
             .filter(|text| !text.is_empty())
             .map(str::to_string);
 
+        let default_reasoning_level = model_config
+            .get("defaultReasoningLevel")
+            .or_else(|| model_config.get("default_reasoning_level"))
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_string);
+        let supported_reasoning_levels = normalize_codex_reasoning_levels(
+            model_config
+                .get("supportedReasoningLevels")
+                .or_else(|| model_config.get("supported_reasoning_levels")),
+            None,
+        );
+
         specs.push(CodexCatalogModelSpec {
             model: model.to_string(),
             display_name: display_name.to_string(),
@@ -573,6 +664,8 @@ fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCa
             supports_parallel_tool_calls,
             input_modalities,
             base_instructions,
+            default_reasoning_level,
+            supported_reasoning_levels,
         });
     }
 
@@ -845,12 +938,15 @@ fn load_codex_model_catalog_template() -> Result<Value, AppError> {
 fn codex_model_catalog_from_specs(
     specs: &[CodexCatalogModelSpec],
     template: &Value,
+    reasoning_template: &Value,
     profile: CodexCatalogToolProfile,
 ) -> Value {
     let entries: Vec<Value> = specs
         .iter()
         .enumerate()
-        .map(|(index, spec)| codex_catalog_model_entry(template, spec, index, profile))
+        .map(|(index, spec)| {
+            codex_catalog_model_entry(template, reasoning_template, spec, index, profile)
+        })
         .collect();
 
     json!({ "models": entries })
@@ -869,12 +965,21 @@ fn codex_model_catalog_from_settings(
     // Native providers use the bundled clean template (no freeform apply_patch,
     // no cache dependency); proxy-chat providers keep cloning Codex's gpt-5.5
     // entry so the proxy can rewrite custom<->function tools as before.
-    let template = match profile {
-        CodexCatalogToolProfile::NativeResponses => load_codex_native_responses_template(),
-        CodexCatalogToolProfile::ProxyChat => load_codex_model_catalog_template()?,
+    let (template, reasoning_template) = match profile {
+        CodexCatalogToolProfile::NativeResponses => (
+            load_codex_native_responses_template(),
+            load_codex_model_catalog_template()?,
+        ),
+        CodexCatalogToolProfile::ProxyChat => {
+            let template = load_codex_model_catalog_template()?;
+            (template.clone(), template)
+        }
     };
     Ok(Some(codex_model_catalog_from_specs(
-        &specs, &template, profile,
+        &specs,
+        &template,
+        &reasoning_template,
+        profile,
     )))
 }
 
@@ -2332,8 +2437,12 @@ base_url = "https://production.api/v1"
             }
         });
         let specs = codex_catalog_model_specs(&settings, r#"model_context_window = 128000"#);
-        let catalog =
-            codex_model_catalog_from_specs(&specs, &template, CodexCatalogToolProfile::ProxyChat);
+        let catalog = codex_model_catalog_from_specs(
+            &specs,
+            &template,
+            &template,
+            CodexCatalogToolProfile::ProxyChat,
+        );
         let models = catalog
             .get("models")
             .and_then(|value| value.as_array())
@@ -2456,6 +2565,79 @@ base_url = "https://production.api/v1"
     }
 
     #[test]
+    fn native_responses_catalog_inherits_full_codex_reasoning_by_default() {
+        let settings = json!({
+            "modelCatalog": {
+                "models": [{ "model": "gpt-5.5" }]
+            }
+        });
+
+        let catalog = codex_model_catalog_from_settings(
+            &settings,
+            "",
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("native catalog generation should not error")
+        .expect("non-empty modelCatalog must yield a catalog");
+
+        let entry = &catalog["models"][0];
+        assert_eq!(
+            entry
+                .get("default_reasoning_level")
+                .and_then(|v| v.as_str()),
+            Some("medium"),
+            "native tool cleanup must not downgrade Codex reasoning defaults"
+        );
+        let efforts: Vec<&str> = entry["supported_reasoning_levels"]
+            .as_array()
+            .expect("supported reasoning levels")
+            .iter()
+            .filter_map(|level| level.get("effort").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(efforts, vec!["low", "medium", "high", "xhigh"]);
+        assert!(
+            entry.get("apply_patch_tool_type").is_none(),
+            "native entries must still suppress the freeform apply_patch tool"
+        );
+    }
+
+    #[test]
+    fn native_responses_catalog_keeps_explicit_reasoning_overrides() {
+        let settings = json!({
+            "modelCatalog": {
+                "models": [{
+                    "model": "vendor-thinking-toggle",
+                    "defaultReasoningLevel": "high",
+                    "supportedReasoningLevels": ["none", "high"]
+                }]
+            }
+        });
+
+        let catalog = codex_model_catalog_from_settings(
+            &settings,
+            "",
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("native catalog generation should not error")
+        .expect("non-empty modelCatalog must yield a catalog");
+
+        let entry = &catalog["models"][0];
+        assert_eq!(
+            entry
+                .get("default_reasoning_level")
+                .and_then(|v| v.as_str()),
+            Some("high")
+        );
+        let efforts: Vec<&str> = entry["supported_reasoning_levels"]
+            .as_array()
+            .expect("supported reasoning levels")
+            .iter()
+            .filter_map(|level| level.get("effort").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(efforts, vec!["none", "high"]);
+    }
+
+    #[test]
     fn native_responses_catalog_always_carries_base_instructions() {
         // Regression guard for the "missing field `base_instructions`" parse
         // error: Codex refuses to load a model catalog whose entries lack
@@ -2495,6 +2677,8 @@ base_url = "https://production.api/v1"
             supports_parallel_tool_calls: None,
             input_modalities: None,
             base_instructions: None,
+            default_reasoning_level: None,
+            supported_reasoning_levels: None,
         }];
         // Using a gpt-5.5-shaped template under ProxyChat must NOT strip
         // apply_patch_tool_type. (The native template lacks it, so synthesize
@@ -2503,6 +2687,7 @@ base_url = "https://production.api/v1"
         proxy_template["apply_patch_tool_type"] = json!("freeform");
         let catalog = codex_model_catalog_from_specs(
             &specs,
+            &proxy_template,
             &proxy_template,
             CodexCatalogToolProfile::ProxyChat,
         );

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -370,6 +370,8 @@ fn extract_claude_config_env(
 
 /// Build Codex settings configuration
 fn build_codex_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
+    let mut settings = extract_codex_inline_config(request).unwrap_or_else(|| json!({}));
+
     let provider_display_name = request
         .name
         .as_deref()
@@ -417,12 +419,49 @@ requires_openai_auth = true
 "#
     );
 
-    json!({
-        "auth": {
-            "OPENAI_API_KEY": request.api_key,
-        },
-        "config": config_toml
-    })
+    let settings_obj = settings
+        .as_object_mut()
+        .expect("inline Codex settings must be an object");
+    let auth = settings_obj
+        .entry("auth")
+        .or_insert_with(|| json!({}))
+        .as_object_mut();
+    if let Some(auth) = auth {
+        auth.insert(
+            "OPENAI_API_KEY".to_string(),
+            json!(request.api_key.clone().unwrap_or_default()),
+        );
+    } else {
+        settings_obj.insert(
+            "auth".to_string(),
+            json!({ "OPENAI_API_KEY": request.api_key.clone().unwrap_or_default() }),
+        );
+    }
+
+    if !settings_obj
+        .get("config")
+        .and_then(|value| value.as_str())
+        .is_some_and(|text| !text.trim().is_empty())
+    {
+        settings_obj.insert("config".to_string(), json!(config_toml));
+    }
+
+    settings
+}
+
+fn extract_codex_inline_config(request: &DeepLinkImportRequest) -> Option<serde_json::Value> {
+    let config_b64 = request.config.as_ref()?;
+    let format = request.config_format.as_deref().unwrap_or("json");
+    if format != "json" {
+        return None;
+    }
+
+    let decoded = decode_base64_param("config", config_b64).ok()?;
+    let json_str = std::str::from_utf8(&decoded).ok()?;
+    let value: serde_json::Value = serde_json::from_str(json_str).ok()?;
+
+    value.as_object()?;
+    Some(value)
 }
 
 /// Build Gemini settings configuration
@@ -829,6 +868,7 @@ fn extract_codex_base_url(toml_value: &toml::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::prelude::*;
 
     fn hermes_request() -> DeepLinkImportRequest {
         DeepLinkImportRequest {
@@ -932,6 +972,59 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("https://api.example.com/v1")
         );
+    }
+
+    #[test]
+    fn build_codex_settings_preserves_inline_model_catalog() {
+        let inline_config = json!({
+            "auth": { "OPENAI_API_KEY": "sk-old" },
+            "config": "model_provider = \"custom\"\nmodel = \"gpt-5.5\"\nmodel_catalog_json = \"cc-switch-model-catalog.json\"\n\n[model_providers.custom]\nbase_url = \"https://api.example.com/v1\"\nwire_api = \"responses\"\nrequires_openai_auth = true",
+            "apiFormat": "openai_responses",
+            "modelCatalog": {
+                "models": [{
+                    "model": "deepseek-v4-flash",
+                    "default_reasoning_level": "medium",
+                    "supported_reasoning_levels": [
+                        { "effort": "low", "description": "Low" },
+                        { "effort": "medium", "description": "Medium" },
+                        { "effort": "high", "description": "High" },
+                        { "effort": "xhigh", "description": "Extra high" }
+                    ]
+                }]
+            }
+        });
+        let request = DeepLinkImportRequest {
+            resource: "provider".to_string(),
+            app: Some("codex".to_string()),
+            name: Some("My Relay".to_string()),
+            endpoint: Some("https://api.example.com/v1".to_string()),
+            api_key: Some("sk-new".to_string()),
+            model: Some("gpt-5.5".to_string()),
+            config: Some(BASE64_STANDARD.encode(inline_config.to_string().as_bytes())),
+            config_format: Some("json".to_string()),
+            ..Default::default()
+        };
+
+        let settings = build_codex_settings(&request);
+
+        assert_eq!(settings["apiFormat"], "openai_responses");
+        assert_eq!(settings["auth"]["OPENAI_API_KEY"], "sk-new");
+        assert!(settings["config"]
+            .as_str()
+            .expect("config text")
+            .contains("model_catalog_json"));
+        let models = settings["modelCatalog"]["models"]
+            .as_array()
+            .expect("modelCatalog models");
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0]["model"], "deepseek-v4-flash");
+        let efforts: Vec<&str> = models[0]["supported_reasoning_levels"]
+            .as_array()
+            .expect("reasoning levels")
+            .iter()
+            .filter_map(|level| level.get("effort").and_then(|value| value.as_str()))
+            .collect();
+        assert_eq!(efforts, vec!["low", "medium", "high", "xhigh"]);
     }
 
     #[test]

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -109,6 +109,12 @@ function createCatalogRow(seed?: Partial<CodexCatalogModel>): CodexCatalogRow {
     ...(seed?.baseInstructions
       ? { baseInstructions: seed.baseInstructions }
       : {}),
+    ...(seed?.defaultReasoningLevel
+      ? { defaultReasoningLevel: seed.defaultReasoningLevel }
+      : {}),
+    ...(seed?.supportedReasoningLevels
+      ? { supportedReasoningLevels: seed.supportedReasoningLevels }
+      : {}),
   };
 }
 
@@ -131,6 +137,10 @@ function catalogRowsMatchModels(
       (row.supportsParallelToolCalls ?? null) ===
         (incoming.supportsParallelToolCalls ?? null) &&
       (row.baseInstructions ?? "") === (incoming.baseInstructions ?? "") &&
+      (row.defaultReasoningLevel ?? "") ===
+        (incoming.defaultReasoningLevel ?? "") &&
+      JSON.stringify(row.supportedReasoningLevels ?? []) ===
+        JSON.stringify(incoming.supportedReasoningLevels ?? []) &&
       JSON.stringify(row.inputModalities ?? []) ===
         JSON.stringify(incoming.inputModalities ?? [])
     );

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -175,6 +175,19 @@ export const normalizeCodexCatalogModelsForSave = (
     );
 
     const baseInstructions = item.baseInstructions?.trim();
+    const defaultReasoningLevel = item.defaultReasoningLevel?.trim();
+    const supportedReasoningLevels = item.supportedReasoningLevels
+      ?.map((level) => {
+        if (typeof level === "string") return level.trim();
+        const effort = typeof level.effort === "string" ? level.effort.trim() : "";
+        return {
+          effort,
+          ...(typeof level.description === "string" && level.description.trim()
+            ? { description: level.description.trim() }
+            : {}),
+        };
+      })
+      .filter((level) => (typeof level === "string" ? level : level.effort));
 
     normalized.push({
       model,
@@ -188,6 +201,12 @@ export const normalizeCodexCatalogModelsForSave = (
         ? { inputModalities }
         : {}),
       ...(baseInstructions ? { baseInstructions } : {}),
+      ...(defaultReasoningLevel
+        ? { defaultReasoningLevel }
+        : {}),
+      ...(supportedReasoningLevels && supportedReasoningLevels.length > 0
+        ? { supportedReasoningLevels }
+        : {}),
     });
   }
 

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -88,6 +88,19 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
                 : typeof item?.base_instructions === "string"
                   ? item.base_instructions
                   : undefined;
+            const defaultReasoningLevel =
+              typeof item?.defaultReasoningLevel === "string"
+                ? item.defaultReasoningLevel
+                : typeof item?.default_reasoning_level === "string"
+                  ? item.default_reasoning_level
+                  : undefined;
+            const supportedReasoningLevels = Array.isArray(
+              item?.supportedReasoningLevels,
+            )
+              ? item.supportedReasoningLevels
+              : Array.isArray(item?.supported_reasoning_levels)
+                ? item.supported_reasoning_levels
+                : undefined;
             return {
               model: typeof item?.model === "string" ? item.model : "",
               displayName:
@@ -109,6 +122,8 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
                 : {}),
               ...(inputModalities ? { inputModalities } : {}),
               ...(baseInstructions ? { baseInstructions } : {}),
+              ...(defaultReasoningLevel ? { defaultReasoningLevel } : {}),
+              ...(supportedReasoningLevels ? { supportedReasoningLevels } : {}),
             };
           })
           .filter((item: CodexCatalogModel) => item.model.trim()),

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,6 +267,17 @@ export interface CodexCatalogModel {
   // Codex requires this field in every catalog entry; when omitted the backend
   // falls back to a neutral default. e.g. MiMo "developed by Xiaomi".
   baseInstructions?: string;
+  // Optional Codex model-catalog reasoning metadata. Hidden in the compact row UI
+  // for now, but preserved so generated catalogs do not collapse all models to a
+  // single thinking level after load -> save.
+  defaultReasoningLevel?: string;
+  supportedReasoningLevels?: Array<
+    | string
+    | {
+        effort: string;
+        description?: string;
+      }
+  >;
 }
 
 // Claude 认证字段类型

--- a/tests/components/ProviderForm.codexCatalog.test.ts
+++ b/tests/components/ProviderForm.codexCatalog.test.ts
@@ -16,7 +16,7 @@ describe("ProviderForm Codex catalog helpers", () => {
     ]);
   });
 
-  it("preserves native-profile overrides (parallel tool calls + input modalities + base instructions)", () => {
+  it("preserves native-profile overrides and reasoning metadata", () => {
     expect(
       normalizeCodexCatalogModelsForSave([
         {
@@ -27,6 +27,11 @@ describe("ProviderForm Codex catalog helpers", () => {
           inputModalities: ["text", "image"],
           baseInstructions:
             "  You are Codex, a coding agent based on MiniMax-M3.  ",
+          defaultReasoningLevel: " medium ",
+          supportedReasoningLevels: [
+            "low",
+            { effort: " high ", description: "Deep thinking" },
+          ],
         },
         // false must be preserved (not dropped as falsy); empty modalities dropped;
         // empty/whitespace baseInstructions dropped
@@ -45,6 +50,11 @@ describe("ProviderForm Codex catalog helpers", () => {
         supportsParallelToolCalls: true,
         inputModalities: ["text", "image"],
         baseInstructions: "You are Codex, a coding agent based on MiniMax-M3.",
+        defaultReasoningLevel: "medium",
+        supportedReasoningLevels: [
+          "low",
+          { effort: "high", description: "Deep thinking" },
+        ],
       },
       { model: "mimo-v2.5-pro", supportsParallelToolCalls: false },
     ]);

--- a/tests/hooks/useCodexConfigState.catalog.test.ts
+++ b/tests/hooks/useCodexConfigState.catalog.test.ts
@@ -23,6 +23,8 @@ describe("useCodexConfigState catalog load", () => {
               supportsParallelToolCalls: true,
               inputModalities: ["text", "image"],
               baseInstructions: "You are Codex, based on MiniMax-M3.",
+              defaultReasoningLevel: "medium",
+              supportedReasoningLevels: ["low", "medium", "high", "xhigh"],
             },
           ],
         },
@@ -39,6 +41,8 @@ describe("useCodexConfigState catalog load", () => {
         supportsParallelToolCalls: true,
         inputModalities: ["text", "image"],
         baseInstructions: "You are Codex, based on MiniMax-M3.",
+        defaultReasoningLevel: "medium",
+        supportedReasoningLevels: ["low", "medium", "high", "xhigh"],
       },
     ]);
   });
@@ -57,6 +61,11 @@ describe("useCodexConfigState catalog load", () => {
               supports_parallel_tool_calls: false,
               input_modalities: ["text"],
               base_instructions: "You are MiMo, developed by Xiaomi.",
+              default_reasoning_level: "high",
+              supported_reasoning_levels: [
+                { effort: "none", description: "Disable Thinking" },
+                { effort: "high", description: "Enabled Thinking" },
+              ],
             },
           ],
         },
@@ -73,6 +82,11 @@ describe("useCodexConfigState catalog load", () => {
         supportsParallelToolCalls: false,
         inputModalities: ["text"],
         baseInstructions: "You are MiMo, developed by Xiaomi.",
+        defaultReasoningLevel: "high",
+        supportedReasoningLevels: [
+          { effort: "none", description: "Disable Thinking" },
+          { effort: "high", description: "Enabled Thinking" },
+        ],
       },
     ]);
   });


### PR DESCRIPTION
## Summary\n- preserve Codex model catalog reasoning metadata when loading and saving provider configs\n- project custom default/supported reasoning levels into generated Codex model catalogs\n- keep NativeResponses tool compatibility without downgrading Codex reasoning defaults to none/high\n\n## Tests\n- cargo test codex_model_catalog --manifest-path src-tauri/Cargo.toml\n- ./node_modules/.bin/vitest run tests/components/ProviderForm.codexCatalog.test.ts tests/hooks/useCodexConfigState.catalog.test.ts\n- ./node_modules/.bin/tsc --noEmit