### PR TITLE
feat(tray): 新增在任务栏处右键一键查看自己今日所用 Token

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -3518,6 +3518,14 @@ pub async fn set_window_theme(window: tauri::Window, theme: String) -> Result<()
     window.set_theme(tauri_theme).map_err(|e| e.to_string())
 }
 
+/// 取出并清除托盘"待打开用量页"标记。
+/// 轻量模式下点击今日用量行时窗口尚未重建，事件会早于前端监听注册而丢失，
+/// 因此改为落标记、由前端挂载后调用本命令消费。
+#[tauri::command]
+pub fn take_pending_tray_navigation() -> bool {
+    crate::tray::take_pending_open_usage()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -278,49 +278,7 @@ pub fn delete_model_pricing(state: State<'_, AppState>, model_id: String) -> Res
 pub fn sync_session_usage(
     state: State<'_, AppState>,
 ) -> Result<crate::services::session_usage::SessionSyncResult, AppError> {
-    // 同步 Claude 会话日志
-    let mut result = crate::services::session_usage::sync_claude_session_logs(&state.db)?;
-
-    // 同步 Codex 使用数据
-    match crate::services::session_usage_codex::sync_codex_usage(&state.db) {
-        Ok(codex_result) => {
-            result.imported += codex_result.imported;
-            result.skipped += codex_result.skipped;
-            result.files_scanned += codex_result.files_scanned;
-            result.errors.extend(codex_result.errors);
-        }
-        Err(e) => {
-            result.errors.push(format!("Codex 同步失败: {e}"));
-        }
-    }
-
-    // 同步 Gemini 使用数据
-    match crate::services::session_usage_gemini::sync_gemini_usage(&state.db) {
-        Ok(gemini_result) => {
-            result.imported += gemini_result.imported;
-            result.skipped += gemini_result.skipped;
-            result.files_scanned += gemini_result.files_scanned;
-            result.errors.extend(gemini_result.errors);
-        }
-        Err(e) => {
-            result.errors.push(format!("Gemini 同步失败: {e}"));
-        }
-    }
-
-    // 同步 OpenCode 使用数据
-    match crate::services::session_usage_opencode::sync_opencode_usage(&state.db) {
-        Ok(opencode_result) => {
-            result.imported += opencode_result.imported;
-            result.skipped += opencode_result.skipped;
-            result.files_scanned += opencode_result.files_scanned;
-            result.errors.extend(opencode_result.errors);
-        }
-        Err(e) => {
-            result.errors.push(format!("OpenCode 同步失败: {e}"));
-        }
-    }
-
-    Ok(result)
+    crate::services::session_usage::sync_all_session_usage(&state.db)
 }
 
 /// 获取数据来源分布

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1201,6 +1201,7 @@ pub fn run() {
             commands::open_config_folder,
             commands::pick_directory,
             commands::open_external,
+            commands::take_pending_tray_navigation,
             commands::get_init_error,
             commands::get_migration_result,
             commands::get_skills_migration_result,

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -561,6 +561,44 @@ pub fn get_data_source_breakdown(db: &Database) -> Result<Vec<DataSourceSummary>
     Ok(summaries)
 }
 
+/// 一次性同步所有来源（Claude/Codex/Gemini/OpenCode）的会话用量。
+/// Claude 源失败直接返回错误（与历史行为一致）；其余源失败仅记入 errors。
+pub fn sync_all_session_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    let mut result = sync_claude_session_logs(db)?;
+
+    match crate::services::session_usage_codex::sync_codex_usage(db) {
+        Ok(r) => {
+            result.imported += r.imported;
+            result.skipped += r.skipped;
+            result.files_scanned += r.files_scanned;
+            result.errors.extend(r.errors);
+        }
+        Err(e) => result.errors.push(format!("Codex 同步失败: {e}")),
+    }
+
+    match crate::services::session_usage_gemini::sync_gemini_usage(db) {
+        Ok(r) => {
+            result.imported += r.imported;
+            result.skipped += r.skipped;
+            result.files_scanned += r.files_scanned;
+            result.errors.extend(r.errors);
+        }
+        Err(e) => result.errors.push(format!("Gemini 同步失败: {e}")),
+    }
+
+    match crate::services::session_usage_opencode::sync_opencode_usage(db) {
+        Ok(r) => {
+            result.imported += r.imported;
+            result.skipped += r.skipped;
+            result.files_scanned += r.files_scanned;
+            result.errors.extend(r.errors);
+        }
+        Err(e) => result.errors.push(format!("OpenCode 同步失败: {e}")),
+    }
+
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -40,12 +40,28 @@ static TRAY_SECTION_SUBMENUS: Lazy<
     std::sync::Mutex<std::collections::HashMap<AppType, Submenu<tauri::Wry>>>,
 > = Lazy::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
+/// "今日用量"菜单项句柄，用于 usage 更新时就地改 label。
+/// `create_tray_menu` 每次重建覆盖写入。
+static TRAY_TODAY_USAGE_ITEM: Lazy<std::sync::Mutex<Option<MenuItem<tauri::Wry>>>> =
+    Lazy::new(|| std::sync::Mutex::new(None));
+
+/// 轻量模式下点击"今日用量"时主窗口尚未重建，`tray-open-usage` 事件会早于
+/// 前端监听注册而丢失，改为落一个待消费标记，由前端挂载后主动拉取。
+static PENDING_OPEN_USAGE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// 取出并清除"待打开用量页"标记（`take_pending_tray_navigation` 命令调用）。
+pub fn take_pending_open_usage() -> bool {
+    PENDING_OPEN_USAGE.swap(false, std::sync::atomic::Ordering::AcqRel)
+}
+
 /// 托盘菜单文本（国际化）
 #[derive(Clone, Copy)]
 pub struct TrayTexts {
     pub show_main: &'static str,
     pub open_website: &'static str,
     pub no_providers_label: &'static str,
+    pub today_prefix: &'static str,
     pub lightweight_mode: &'static str,
     pub quit: &'static str,
     pub _auto_label: &'static str,
@@ -58,6 +74,7 @@ impl TrayTexts {
                 show_main: "Open main window",
                 open_website: "Open Official Website",
                 no_providers_label: "(no providers)",
+                today_prefix: "Today",
                 lightweight_mode: "Lightweight Mode",
                 quit: "Quit",
                 _auto_label: "Auto (Failover)",
@@ -66,6 +83,7 @@ impl TrayTexts {
                 show_main: "メインウィンドウを開く",
                 open_website: "公式サイトを開く",
                 no_providers_label: "(プロバイダーなし)",
+                today_prefix: "本日",
                 lightweight_mode: "軽量モード",
                 quit: "終了",
                 _auto_label: "自動 (フェイルオーバー)",
@@ -74,6 +92,7 @@ impl TrayTexts {
                 show_main: "開啟主介面",
                 open_website: "開啟官方網站",
                 no_providers_label: "(無供應商)",
+                today_prefix: "今日",
                 lightweight_mode: "輕量模式",
                 quit: "退出",
                 _auto_label: "自動 (故障轉移)",
@@ -82,6 +101,7 @@ impl TrayTexts {
                 show_main: "打开主界面",
                 open_website: "打开官方网站",
                 no_providers_label: "(无供应商)",
+                today_prefix: "今日",
                 lightweight_mode: "轻量模式",
                 quit: "退出",
                 _auto_label: "自动 (故障转移)",
@@ -102,6 +122,7 @@ pub struct TrayAppSection {
 /// Auto 菜单项后缀
 pub const AUTO_SUFFIX: &str = "auto";
 pub const TRAY_ID: &str = "cc-switch";
+pub const USAGE_TODAY_ID: &str = "usage_today";
 
 pub const TRAY_SECTIONS: [TrayAppSection; 3] = [
     TrayAppSection {
@@ -191,6 +212,113 @@ fn labeled_tier_parts(entries: &[(&str, f64)]) -> Vec<(&'static str, f64)> {
         }
     }
     parts
+}
+
+/// u64 千分位格式化（8432 → "8,432"）。
+fn add_thousands_separators(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// 换算后的值 < 100 保留一位小数（尾零省略），≥ 100 取整加千分位。
+fn format_scaled(value: f64) -> String {
+    if value < 100.0 {
+        let rounded = (value * 10.0).round() / 10.0;
+        if rounded.fract() == 0.0 {
+            format!("{}", rounded.trunc() as u64)
+        } else {
+            format!("{rounded:.1}")
+        }
+    } else {
+        add_thousands_separators(value.round() as u64)
+    }
+}
+
+/// 今日 token 数按语言本地化：zh 万/亿、zh-TW 萬/億、ja 万/億、en K/M/B。
+fn format_token_count(tokens: u64, language: &str) -> String {
+    if language == "en" {
+        if tokens < 1_000 {
+            return tokens.to_string();
+        }
+        let (value, unit) = if tokens >= 1_000_000_000 {
+            (tokens as f64 / 1e9, "B")
+        } else if tokens >= 1_000_000 {
+            (tokens as f64 / 1e6, "M")
+        } else {
+            (tokens as f64 / 1e3, "K")
+        };
+        return format!("{}{unit}", format_scaled(value));
+    }
+
+    let (wan, yi) = match language {
+        "zh-TW" => ("萬", "億"),
+        "ja" => ("万", "億"),
+        _ => ("万", "亿"),
+    };
+    if tokens < 10_000 {
+        add_thousands_separators(tokens)
+    } else if tokens < 100_000_000 {
+        format!("{}{wan}", format_scaled(tokens as f64 / 1e4))
+    } else {
+        format!("{}{yi}", format_scaled(tokens as f64 / 1e8))
+    }
+}
+
+/// 美元费用两位小数 + 千分位；解析失败按 $0.00 兜底。
+fn format_cost_usd(cost: &str) -> String {
+    let value = cost.parse::<f64>().unwrap_or(0.0).max(0.0);
+    let total_cents = (value * 100.0).round() as u64;
+    format!(
+        "${}.{:02}",
+        add_thousands_separators(total_cents / 100),
+        total_cents % 100
+    )
+}
+
+/// 拼装"今日用量"整行文案，如 "今日 · 1,234万 tokens · $12.34"。
+fn format_today_usage_label(
+    summary: &crate::services::usage_stats::UsageSummary,
+    language: &str,
+    prefix: &str,
+) -> String {
+    format!(
+        "{prefix} · {} tokens · {}",
+        format_token_count(summary.real_total_tokens, language),
+        format_cost_usd(&summary.total_cost)
+    )
+}
+
+/// 本地时区今日 0 点的 Unix 秒时间戳；夏令时等歧义场景返回 None。
+fn local_midnight_ts() -> Option<i64> {
+    use chrono::TimeZone;
+    let now = chrono::Local::now();
+    let midnight = now.date_naive().and_hms_opt(0, 0, 0)?;
+    chrono::Local
+        .from_local_datetime(&midnight)
+        .single()
+        .map(|dt| dt.timestamp())
+}
+
+/// 查询今日汇总并渲染整行文案；查库失败时渲染 0 值行并记日志。
+fn today_usage_label(app_state: &AppState, language: &str, prefix: &str) -> String {
+    let summary = local_midnight_ts().and_then(|start| {
+        app_state
+            .db
+            .get_usage_summary(Some(start), None, None, None, None)
+            .map_err(|e| log::warn!("[Tray] 查询今日用量失败: {e}"))
+            .ok()
+    });
+    match summary {
+        Some(s) => format_today_usage_label(&s, language, prefix),
+        None => format!("{prefix} · 0 tokens · $0.00"),
+    }
 }
 
 fn tier_pct(data: &crate::provider::UsageData) -> Option<f64> {
@@ -493,7 +621,8 @@ pub fn create_tray_menu(
     app_state: &AppState,
 ) -> Result<Menu<tauri::Wry>, AppError> {
     let app_settings = crate::settings::get_settings();
-    let tray_texts = TrayTexts::from_language(app_settings.language.as_deref().unwrap_or("zh"));
+    let language = app_settings.language.as_deref().unwrap_or("zh").to_string();
+    let tray_texts = TrayTexts::from_language(&language);
 
     // Get visible apps setting, default to all visible
     let visible_apps = app_settings.visible_apps.unwrap_or_default();
@@ -600,6 +729,15 @@ pub fn create_tray_menu(
         menu_builder = menu_builder.separator();
     }
 
+    // 今日用量信息行（#4977）：本地库查询，点击跳转主界面用量页。
+    let today_label = today_usage_label(app_state, &language, tray_texts.today_prefix);
+    let today_item = MenuItem::with_id(app, USAGE_TODAY_ID, &today_label, true, None::<&str>)
+        .map_err(|e| AppError::Message(format!("创建今日用量菜单失败: {e}")))?;
+    menu_builder = menu_builder.item(&today_item).separator();
+    *TRAY_TODAY_USAGE_ITEM
+        .lock()
+        .unwrap_or_else(|p| p.into_inner()) = Some(today_item);
+
     let lightweight_item = CheckMenuItem::with_id(
         app,
         "lightweight_mode",
@@ -663,6 +801,28 @@ fn update_tray_usage_labels(app: &tauri::AppHandle) {
             log::debug!("[Tray] 更新{}子菜单标题失败: {e}", section.log_name);
         }
     }
+
+    // 今日用量行：查询成功才更新，失败保留旧文本（与订阅后缀行为一致）。
+    let language = crate::settings::get_settings()
+        .language
+        .unwrap_or_else(|| "zh".to_string());
+    let texts = TrayTexts::from_language(&language);
+    let guard = TRAY_TODAY_USAGE_ITEM
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    if let Some(item) = guard.as_ref() {
+        if let Some(start) = local_midnight_ts() {
+            if let Ok(summary) = app_state
+                .db
+                .get_usage_summary(Some(start), None, None, None, None)
+            {
+                let label = format_today_usage_label(&summary, &language, texts.today_prefix);
+                if let Err(e) = item.set_text(&label) {
+                    log::debug!("[Tray] 更新今日用量标题失败: {e}");
+                }
+            }
+        }
+    }
 }
 
 pub fn refresh_tray_menu(app: &tauri::AppHandle) {
@@ -698,32 +858,46 @@ pub fn apply_tray_policy(app: &tauri::AppHandle, dock_visible: bool) {
     }
 }
 
+/// 显示主窗口：还原/聚焦；轻量模式下重建窗口。
+fn show_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        #[cfg(target_os = "windows")]
+        {
+            let _ = window.set_skip_taskbar(false);
+        }
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+        #[cfg(target_os = "linux")]
+        {
+            crate::linux_fix::nudge_main_window(window.clone());
+        }
+        #[cfg(target_os = "macos")]
+        {
+            apply_tray_policy(app, true);
+        }
+    } else if crate::lightweight::is_lightweight_mode() {
+        if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
+            log::error!("退出轻量模式重建窗口失败: {e}");
+        }
+    }
+}
+
 /// 处理托盘菜单事件
 pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
     log::info!("处理托盘菜单事件: {event_id}");
 
     match event_id {
-        "show_main" => {
-            if let Some(window) = app.get_webview_window("main") {
-                #[cfg(target_os = "windows")]
-                {
-                    let _ = window.set_skip_taskbar(false);
-                }
-                let _ = window.unminimize();
-                let _ = window.show();
-                let _ = window.set_focus();
-                #[cfg(target_os = "linux")]
-                {
-                    crate::linux_fix::nudge_main_window(window.clone());
-                }
-                #[cfg(target_os = "macos")]
-                {
-                    apply_tray_policy(app, true);
-                }
-            } else if crate::lightweight::is_lightweight_mode() {
-                if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
-                    log::error!("退出轻量模式重建窗口失败: {e}");
-                }
+        "show_main" => show_main_window(app),
+        id if id == USAGE_TODAY_ID => {
+            let window_missing = app.get_webview_window("main").is_none();
+            show_main_window(app);
+            if window_missing {
+                // 窗口重建路径（轻量模式）：事件必然早于前端监听注册，
+                // 改走待消费标记，前端挂载后通过命令拉取。
+                PENDING_OPEN_USAGE.store(true, std::sync::atomic::Ordering::Release);
+            } else if let Err(e) = app.emit("tray-open-usage", ()) {
+                log::error!("发射 tray-open-usage 事件失败: {e}");
             }
         }
         "open_website" => {
@@ -807,6 +981,24 @@ pub(crate) async fn refresh_all_usage_in_tray(app: &tauri::AppHandle) {
         return;
     };
 
+    // 增量同步会话日志（#4977）：让"今日用量"行反映最新数据。
+    // 按文件 mtime + 行偏移增量扫描，无新数据时近乎零开销；
+    // 失败不阻塞后续查询，降级为展示库内现有数据。
+    let db = app_state.db.clone();
+    match tauri::async_runtime::spawn_blocking(move || {
+        crate::services::session_usage::sync_all_session_usage(&db)
+    })
+    .await
+    {
+        Ok(Ok(result)) => {
+            if !result.errors.is_empty() {
+                log::warn!("[Tray] 会话用量同步部分失败: {:?}", result.errors);
+            }
+        }
+        Ok(Err(e)) => log::warn!("[Tray] 会话用量同步失败: {e}"),
+        Err(e) => log::warn!("[Tray] 会话用量同步任务失败: {e}"),
+    }
+
     // 与 `create_tray_menu` 保持一致：用户隐藏的 app 不参与外部 API 查询，
     // 避免在未使用的 app 上浪费请求、撞 rate limit 或反复触发鉴权失败日志。
     let visible_apps = crate::settings::get_settings()
@@ -873,6 +1065,9 @@ pub(crate) async fn refresh_all_usage_in_tray(app: &tauri::AppHandle) {
     }
 
     join_all(script_futures).await;
+
+    // 同步/查询完成后就地更新今日用量行（50ms 合窗防抖）。
+    schedule_tray_refresh(app);
 }
 
 #[cfg(test)]
@@ -1209,5 +1404,81 @@ mod tests {
     fn script_summary_empty_data_returns_none() {
         let r = usage_result(true, vec![]);
         assert!(format_script_summary(&r).is_none());
+    }
+
+    fn summary_with(tokens: u64, cost: &str) -> crate::services::usage_stats::UsageSummary {
+        crate::services::usage_stats::UsageSummary {
+            total_requests: 1,
+            total_cost: cost.to_string(),
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_creation_tokens: 0,
+            total_cache_read_tokens: 0,
+            success_rate: 100.0,
+            real_total_tokens: tokens,
+            cache_hit_rate: 0.0,
+        }
+    }
+
+    #[test]
+    fn token_count_zh_uses_wan_and_yi() {
+        use super::format_token_count;
+        assert_eq!(format_token_count(0, "zh"), "0");
+        assert_eq!(format_token_count(9_999, "zh"), "9,999");
+        assert_eq!(format_token_count(10_000, "zh"), "1万");
+        assert_eq!(format_token_count(120_000, "zh"), "12万"); // 尾零省略
+        assert_eq!(format_token_count(123_000, "zh"), "12.3万");
+        assert_eq!(format_token_count(994_000, "zh"), "99.4万");
+        assert_eq!(format_token_count(1_000_000, "zh"), "100万");
+        assert_eq!(format_token_count(12_345_678, "zh"), "1,235万");
+        assert_eq!(format_token_count(100_000_000, "zh"), "1亿");
+        assert_eq!(format_token_count(120_000_000, "zh"), "1.2亿");
+        assert_eq!(format_token_count(12_300_000_000, "zh"), "123亿");
+    }
+
+    #[test]
+    fn token_count_zh_tw_and_ja_glyphs() {
+        use super::format_token_count;
+        assert_eq!(format_token_count(120_000, "zh-TW"), "12萬");
+        assert_eq!(format_token_count(120_000_000, "zh-TW"), "1.2億");
+        assert_eq!(format_token_count(120_000, "ja"), "12万");
+        assert_eq!(format_token_count(120_000_000, "ja"), "1.2億");
+    }
+
+    #[test]
+    fn token_count_en_uses_kmb() {
+        use super::format_token_count;
+        assert_eq!(format_token_count(843, "en"), "843");
+        assert_eq!(format_token_count(999, "en"), "999");
+        assert_eq!(format_token_count(1_000, "en"), "1K");
+        assert_eq!(format_token_count(9_940, "en"), "9.9K");
+        assert_eq!(format_token_count(99_900, "en"), "99.9K");
+        assert_eq!(format_token_count(100_000, "en"), "100K");
+        assert_eq!(format_token_count(12_300_000, "en"), "12.3M");
+        assert_eq!(format_token_count(1_200_000_000, "en"), "1.2B");
+    }
+
+    #[test]
+    fn cost_usd_two_decimals_with_separators() {
+        use super::format_cost_usd;
+        assert_eq!(format_cost_usd("0"), "$0.00");
+        assert_eq!(format_cost_usd("12.34"), "$12.34");
+        assert_eq!(format_cost_usd("12.345678"), "$12.35");
+        assert_eq!(format_cost_usd("1234.567"), "$1,234.57");
+        assert_eq!(format_cost_usd("not-a-number"), "$0.00");
+    }
+
+    #[test]
+    fn today_usage_label_full_line() {
+        use super::format_today_usage_label;
+        let s = summary_with(12_340_000, "12.34");
+        assert_eq!(
+            format_today_usage_label(&s, "zh", "今日"),
+            "今日 · 1,234万 tokens · $12.34"
+        );
+        assert_eq!(
+            format_today_usage_label(&s, "en", "Today"),
+            "Today · 12.3M tokens · $12.34"
+        );
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -426,6 +426,24 @@ function App() {
     },
   );
 
+  useTauriEvent("tray-open-usage", () => {
+    setSettingsDefaultTab("usage");
+    setCurrentView("settings");
+  });
+
+  useEffect(() => {
+    // 轻量模式下点击托盘"今日用量"时窗口需要重建，事件会早于监听注册而丢失，
+    // 后端改为落待消费标记，挂载后拉取一次。
+    invoke<boolean>("take_pending_tray_navigation")
+      .then((pending) => {
+        if (pending) {
+          setSettingsDefaultTab("usage");
+          setCurrentView("settings");
+        }
+      })
+      .catch(() => {});
+  }, []);
+
   useEffect(() => {
     let active = true;
     let unlistenResize: (() => void) | undefined;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,6 +176,8 @@ function App() {
   const [skillsDiscoverySource, setSkillsDiscoverySource] =
     useState<SkillsPageSource>("repos");
   const [settingsDefaultTab, setSettingsDefaultTab] = useState("general");
+  // 导航令牌：设置页已打开且 defaultTab 值未变时，令牌变化强制重新应用 Tab
+  const [settingsNavToken, setSettingsNavToken] = useState(0);
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
 
@@ -428,6 +430,7 @@ function App() {
 
   useTauriEvent("tray-open-usage", () => {
     setSettingsDefaultTab("usage");
+    setSettingsNavToken((n) => n + 1);
     setCurrentView("settings");
   });
 
@@ -438,6 +441,7 @@ function App() {
       .then((pending) => {
         if (pending) {
           setSettingsDefaultTab("usage");
+          setSettingsNavToken((n) => n + 1);
           setCurrentView("settings");
         }
       })
@@ -900,6 +904,7 @@ function App() {
               onOpenChange={() => setCurrentView("providers")}
               onImportSuccess={handleImportSuccess}
               defaultTab={settingsDefaultTab}
+              navToken={settingsNavToken}
             />
           );
         case "prompts":

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -63,6 +63,8 @@ interface SettingsDialogProps {
   onOpenChange: (open: boolean) => void;
   onImportSuccess?: () => void | Promise<void>;
   defaultTab?: string;
+  /** 导航令牌：值变化时强制重新应用 defaultTab（用于设置页已打开时的重复导航） */
+  navToken?: number;
 }
 
 export function SettingsPage({
@@ -70,6 +72,7 @@ export function SettingsPage({
   onOpenChange,
   onImportSuccess,
   defaultTab = "general",
+  navToken,
 }: SettingsDialogProps) {
   const { t } = useTranslation();
   const {
@@ -116,7 +119,7 @@ export function SettingsPage({
       setActiveTab(defaultTab);
       resetStatus();
     }
-  }, [open, resetStatus, defaultTab]);
+  }, [open, resetStatus, defaultTab, navToken]);
 
   useEffect(() => {
     if (requiresRestart) {


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

在系统托盘右键菜单中新增一行 "今日 · X tokens · $Y"信息栏。一键查看今日全机各工具的 Token 消耗与等价费用：

- 数据来自本地用量库（与用量仪表盘同源同口径，含 cache 的 real total tokens）
- 复用现有托盘刷新管线：悬停/点击图标时（既有 10 秒节流内）顺带增量同步会话日志，随后就地 `set_text` 更新，不重建菜单
- 点击该行打开主界面并跳转到"使用统计"Tab
- 数字按语言本地化：简中 万/亿、繁中 萬/億、日文 万/億、英文 K/M/B，格式化为纯函数并附单元测试
- 前置小重构：将四源会话同步逻辑从 command 抽为 `sync_all_session_usage`，供命令与托盘两处复用（行为不变）

托盘文案按现有架构硬编码于 `TrayTexts`（四语言均已提供），不涉及 locales JSON。

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #4977

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|         <img width="330" height="240" alt="image" src="https://github.com/user-attachments/assets/993c093e-f932-4a2a-8d90-fe7ed047bade" />      |       <img width="330" height="266" alt="image" src="https://github.com/user-attachments/assets/75d6bbc7-e7b4-40e7-8776-ab28e9152416" />        |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（托盘文案位于 `TrayTexts`，已覆盖 zh/zh-TW/en/ja 四语言）

## Testing / 测试说明

- 自动化：`cargo fmt --check` / `cargo clippy` / `cargo test` 全量通过；`pnpm typecheck` / `pnpm format:check` / `pnpm test:unit`（388 个用例）全量通过；新增格式化函数单测覆盖四语言与数量级边界
- 手动（仅在 macOS 上实测）：托盘行显示与 0 值兜底、悬停触发增量同步与数字更新、点击跳转用量 Tab、轻量模式下点击（窗口重建后正确落在用量 Tab）、四语言切换后的文案与数字格式
- 托盘菜单使用 Tauri 跨平台 API，无平台特有代码路径，但 Windows/Linux 未实测
