### PR TITLE
[codex] Fix Codex fork usage import

### DIFF
--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -52,10 +52,27 @@ impl DeltaTokens {
 
 /// 单文件解析时的运行状态
 struct FileParseState {
-    session_id: Option<String>,
+    root_session_id: Option<String>,
+    active_session_id: Option<String>,
     current_model: String,
     prev_total: Option<CumulativeTokens>,
     event_index: u32,
+}
+
+impl FileParseState {
+    fn is_active_root_session(&self) -> bool {
+        match (&self.root_session_id, &self.active_session_id) {
+            (Some(root), Some(active)) => root == active,
+            (None, _) => true,
+            _ => false,
+        }
+    }
+
+    fn session_id_for_insert(&self) -> Option<&str> {
+        self.root_session_id
+            .as_deref()
+            .or(self.active_session_id.as_deref())
+    }
 }
 
 /// 归一化 Codex 模型名
@@ -140,6 +157,17 @@ fn parse_cumulative_tokens(total_usage: &serde_json::Value) -> Option<Cumulative
             .and_then(|v| v.as_u64())
             .unwrap_or(0),
     })
+}
+
+fn parse_session_id(payload: Option<&serde_json::Value>) -> Option<String> {
+    payload
+        .and_then(|p| {
+            p.get("session_id")
+                .or_else(|| p.get("sessionId"))
+                .or_else(|| p.get("id"))
+        })
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
 }
 
 /// 同步 Codex 使用数据（从 JSONL 会话日志）
@@ -251,7 +279,8 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
     let reader = BufReader::new(file);
 
     let mut state = FileParseState {
-        session_id: None,
+        root_session_id: None,
+        active_session_id: None,
         current_model: "unknown".to_string(),
         prev_total: None,
         event_index: 0,
@@ -296,16 +325,12 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
         };
 
         match event_type {
-            "session_meta" if state.session_id.is_none() => {
-                let payload = value.get("payload");
-                state.session_id = payload
-                    .and_then(|p| {
-                        p.get("session_id")
-                            .or_else(|| p.get("sessionId"))
-                            .or_else(|| p.get("id"))
-                    })
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+            "session_meta" => {
+                let session_id = parse_session_id(value.get("payload"));
+                if state.root_session_id.is_none() {
+                    state.root_session_id = session_id.clone();
+                }
+                state.active_session_id = session_id;
             }
             "turn_context" => {
                 if let Some(payload) = value.get("payload") {
@@ -385,13 +410,23 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
 
                 state.event_index += 1;
 
+                // Fork 后的 Codex 会话文件会包含复制来的父会话历史。
+                // token_count 归属到最近的前置 session_meta 片段，只有属于
+                // 本文件根 session 的事件才导入。非根片段仍会在上面更新
+                // prev_total，这样子会话第一条真实 delta 会基于复制历史后的
+                // 累计值计算。event_index 保持文件内 token_count 的全局序号，
+                // 避免导入器升级后 request_id 变化。
+                if !state.is_active_root_session() {
+                    continue;
+                }
+
                 // 跳过已处理的行（但仍需解析以恢复状态）
                 if line_offset <= last_offset {
                     continue;
                 }
 
                 // 生成唯一 request_id
-                let session_id_str = state.session_id.as_deref().unwrap_or("unknown");
+                let session_id_str = state.session_id_for_insert().unwrap_or("unknown");
                 let request_id = format!("codex_session:{}:{}", session_id_str, state.event_index);
 
                 // 提取时间戳
@@ -405,7 +440,7 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                     &request_id,
                     &delta,
                     &state.current_model,
-                    state.session_id.as_deref(),
+                    state.session_id_for_insert(),
                     timestamp.as_deref(),
                 ) {
                     Ok(true) => imported += 1,
@@ -709,6 +744,326 @@ mod tests {
             row.get(0)
         })?;
         assert_eq!(count, 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_codex_fork_skips_parent_history_and_imports_child_delta() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("fork.jsonl");
+
+        let lines = vec![
+            serde_json::json!({
+                "timestamp": "2026-07-04T08:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child-session",
+                    "session_id": "child-session",
+                    "forked_from_id": "parent-session"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T07:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "parent-session",
+                    "session_id": "parent-session"
+                }
+            }),
+            serde_json::json!({
+                "type": "turn_context",
+                "payload": {
+                    "model": "gpt-5.5"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T08:00:01Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 1000,
+                            "cached_input_tokens": 400,
+                            "output_tokens": 50
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T08:00:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 1500,
+                            "cached_input_tokens": 800,
+                            "output_tokens": 80
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T08:01:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child-session",
+                    "session_id": "child-session",
+                    "forked_from_id": "parent-session"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T08:01:01Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 1500,
+                            "cached_input_tokens": 800,
+                            "output_tokens": 80
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T08:01:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 1900,
+                            "cached_input_tokens": 1000,
+                            "output_tokens": 90
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T08:01:03Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 2200,
+                            "cached_input_tokens": 1100,
+                            "output_tokens": 120
+                        }
+                    }
+                }
+            }),
+        ];
+        let content = lines
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&file, format!("{content}\n")).expect("write fixture");
+
+        let (imported, skipped) = sync_single_codex_file(&db, &file)?;
+        assert_eq!(imported, 2);
+        assert_eq!(skipped, 0);
+
+        let conn = lock_conn!(db.conn);
+        let rows = {
+            let mut stmt = conn.prepare(
+                "SELECT request_id, session_id, input_tokens, cache_read_tokens, output_tokens
+                 FROM proxy_request_logs
+                 ORDER BY request_id",
+            )?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, u32>(2)?,
+                        row.get::<_, u32>(3)?,
+                        row.get::<_, u32>(4)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            rows
+        };
+
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "codex_session:child-session:3".to_string(),
+                    "child-session".to_string(),
+                    400,
+                    200,
+                    10,
+                ),
+                (
+                    "codex_session:child-session:4".to_string(),
+                    "child-session".to_string(),
+                    300,
+                    100,
+                    30,
+                ),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_codex_nested_fork_skips_ancestor_segments() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("nested-fork.jsonl");
+
+        let lines = vec![
+            serde_json::json!({
+                "timestamp": "2026-07-04T09:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "grandchild-session",
+                    "session_id": "grandchild-session",
+                    "forked_from_id": "child-session"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T08:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child-session",
+                    "session_id": "child-session",
+                    "forked_from_id": "parent-session"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T07:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "parent-session",
+                    "session_id": "parent-session"
+                }
+            }),
+            serde_json::json!({
+                "type": "turn_context",
+                "payload": {
+                    "model": "gpt-5.5"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T09:00:01Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 1000,
+                            "cached_input_tokens": 500,
+                            "output_tokens": 50
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T09:00:02Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child-session",
+                    "session_id": "child-session",
+                    "forked_from_id": "parent-session"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T09:00:03Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 1300,
+                            "cached_input_tokens": 700,
+                            "output_tokens": 70
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T09:01:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "grandchild-session",
+                    "session_id": "grandchild-session",
+                    "forked_from_id": "child-session"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T09:01:01Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 1300,
+                            "cached_input_tokens": 700,
+                            "output_tokens": 70
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-04T09:01:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 1500,
+                            "cached_input_tokens": 800,
+                            "output_tokens": 95
+                        }
+                    }
+                }
+            }),
+        ];
+        let content = lines
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&file, format!("{content}\n")).expect("write fixture");
+
+        let (imported, skipped) = sync_single_codex_file(&db, &file)?;
+        assert_eq!(imported, 1);
+        assert_eq!(skipped, 0);
+
+        let conn = lock_conn!(db.conn);
+        let row = conn.query_row(
+            "SELECT request_id, session_id, input_tokens, cache_read_tokens, output_tokens
+             FROM proxy_request_logs",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, u32>(2)?,
+                    row.get::<_, u32>(3)?,
+                    row.get::<_, u32>(4)?,
+                ))
+            },
+        )?;
+
+        assert_eq!(
+            row,
+            (
+                "codex_session:grandchild-session:3".to_string(),
+                "grandchild-session".to_string(),
+                200,
+                100,
+                25,
+            )
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #2571
Fixes #4177
Fixes #4981

## Summary

Fix Codex session usage import for forked conversations.

Codex fork JSONL files can contain copied parent or ancestor history before returning to the fork's own session segment. The importer previously kept only the first `session_meta`, so copied parent history was counted again under the fork session.

<details>
<summary>中文说明</summary>

## 概述

修复 Codex fork 会话的使用量导入问题。

Codex fork 之后的 JSONL 里会先带上父会话/祖先会话的历史片段，然后再回到 fork 自己的会话片段。旧导入逻辑只读取第一个 `session_meta`，因此会把复制来的父会话历史重复计入 fork 会话，导致用量统计明显偏高。

## 根因

解析器把 JSONL 文件里的第一个 `session_meta` 当作整份文件后续所有 `token_count` 的 session id。对于 fork 文件，第一个 id 是 fork 本身，但后面很多事件实际属于复制进来的父分支或祖先分支片段。

## 修复

本次修复同时跟踪：

- 文件根 session id
- 当前激活的 `session_meta` 片段

只有属于根 session 片段的 token delta 会入库。非根片段仍然会推进累计 token 状态，这样 fork 自己的第一条真实增量会基于复制历史后的累计值正确计算。同时保留文件内 token_count 序号，避免已有安装升级后 request_id 重新编号导致冲突。

## 截图

### 有 fork 对话的情况

左侧：本地已安装原版，重复统计了 fork 文件中的父会话历史。  
右侧：修复后的测试版，使用独立 DB，但扫描同一份真实 `~/.codex/sessions`。

![Fork conversation comparison](https://raw.githubusercontent.com/Venti0325/cc-switch/codex/pr-4982-assets/pr-assets/4982/fork-regression-before-after.png)

### 无 fork 对话的对照情况

在之前某一天没有 fork 对话时，原版和修复后的测试版统计结果一致。

![No-fork control comparison](https://raw.githubusercontent.com/Venti0325/cc-switch/codex/pr-4982-assets/pr-assets/4982/no-fork-control-before-after.png)

## 验证

- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --check`
- `cargo test services::session_usage_codex --lib`
- `cargo clippy --lib -- -D warnings`
- 本地使用真实嵌套 fork JSONL 复算：
  - 子 fork：旧逻辑导入 39 行，修复后只导入 2 行根片段记录
  - 嵌套 fork：旧逻辑导入 39 行，修复后只导入 2 行根片段记录
  - 原始非 fork 会话统计保持不变

## 检查清单

- [x] `pnpm typecheck` 通过 TypeScript 类型检查
- [x] `pnpm format:check` 通过代码格式检查
- [x] `cargo clippy` 通过 Clippy 检查（如修改了 Rust 代码）
- [x] 如修改了用户可见文本，已更新国际化文件

</details>

## Root Cause

The parser treated the first `session_meta` in a JSONL file as the session id for all later `token_count` events. For forked files, that first id belongs to the fork, while many following events may actually belong to copied parent or ancestor segments.

## Fix

This change tracks both:

- the file root session id
- the currently active `session_meta` segment

Only token deltas from the root session segment are imported. Non-root segments still update cumulative token state, so the first real fork delta is computed against the copied history baseline. The file-wide event index is also preserved so request IDs stay stable for existing installs.

## Screenshots

### Fork conversation case

Left: installed original build, over-counting copied fork history.  
Right: fixed test build, using a separate DB while scanning the same real `~/.codex/sessions`.

![Fork conversation comparison](https://raw.githubusercontent.com/Venti0325/cc-switch/codex/pr-4982-assets/pr-assets/4982/fork-regression-before-after.png)

### No-fork control case

On a previous day without fork conversations, the original build and fixed test build produce the same totals.

![No-fork control comparison](https://raw.githubusercontent.com/Venti0325/cc-switch/codex/pr-4982-assets/pr-assets/4982/no-fork-control-before-after.png)

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --check`
- `cargo test services::session_usage_codex --lib`
- `cargo clippy --lib -- -D warnings`
- Replayed real nested Codex fork JSONL files locally:
  - child fork: old logic imported 39 rows; fixed logic imports 2 root-segment rows
  - nested fork: old logic imported 39 rows; fixed logic imports 2 root-segment rows
  - original non-fork session remains unchanged

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes (if Rust code changed)
- [x] Updated i18n files if user-facing text changed