### PR TITLE
feat(usage): import Claude Cowork desktop session logs

### DIFF
--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -281,6 +281,19 @@ pub fn sync_session_usage(
     // 同步 Claude 会话日志
     let mut result = crate::services::session_usage::sync_claude_session_logs(&state.db)?;
 
+    // 同步 Cowork 会话日志
+    match crate::services::session_usage_cowork::sync_cowork_usage(&state.db) {
+        Ok(cowork_result) => {
+            result.imported += cowork_result.imported;
+            result.skipped += cowork_result.skipped;
+            result.files_scanned += cowork_result.files_scanned;
+            result.errors.extend(cowork_result.errors);
+        }
+        Err(e) => {
+            result.errors.push(format!("Cowork 同步失败: {e}"));
+        }
+    }
+
     // 同步 Codex 使用数据
     match crate::services::session_usage_codex::sync_codex_usage(&state.db) {
         Ok(codex_result) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1111,6 +1111,10 @@ pub fn run() {
                         crate::services::session_usage::sync_claude_session_logs(db),
                     );
                     run_step(
+                        "Cowork usage initial sync",
+                        crate::services::session_usage_cowork::sync_cowork_usage(db),
+                    );
+                    run_step(
                         "Codex usage initial sync",
                         crate::services::session_usage_codex::sync_codex_usage(db),
                     );
@@ -1133,6 +1137,10 @@ pub fn run() {
                         run_step(
                             "Session usage periodic sync",
                             crate::services::session_usage::sync_claude_session_logs(db),
+                        );
+                        run_step(
+                            "Cowork usage periodic sync",
+                            crate::services::session_usage_cowork::sync_cowork_usage(db),
                         );
                         run_step(
                             "Codex usage periodic sync",

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod s3_auto_sync;
 pub mod s3_sync;
 pub mod session_usage;
 pub mod session_usage_codex;
+pub mod session_usage_cowork;
 pub mod session_usage_gemini;
 pub mod session_usage_opencode;
 pub mod skill;

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -82,7 +82,7 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
     for file_path in &jsonl_files {
         result.files_scanned += 1;
 
-        match sync_single_file(db, file_path) {
+        match sync_single_file(db, file_path, "session_log") {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -118,7 +118,10 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
 /// agent 多嵌套一层 `workflows/wf_<ID>/`。漏掉这一层会让 Workflow 的 token
 /// 用量完全不计入统计；`journal.jsonl` 不含 `type=="assistant"` 行，解析时
 /// 会被 `sync_single_file` 天然跳过，因此这里无需按文件名过滤。
-fn collect_jsonl_files(projects_dir: &Path) -> Vec<PathBuf> {
+///
+/// Cowork 会话沙箱内嵌的 projects 目录与此布局完全一致，
+/// session_usage_cowork 复用本函数。
+pub(crate) fn collect_jsonl_files(projects_dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
 
     let entries = match fs::read_dir(projects_dir) {
@@ -179,7 +182,14 @@ fn push_jsonl_children(dir: &Path, files: &mut Vec<PathBuf>) {
 }
 
 /// 同步单个 JSONL 文件，返回 (imported, skipped)
-fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+///
+/// `data_source` 写入 proxy_request_logs.data_source，用于区分来源
+/// （Claude Code 为 "session_log"，Cowork 为 "cowork_session_log"）。
+pub(crate) fn sync_single_file(
+    db: &Database,
+    file_path: &Path,
+    data_source: &str,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
     // 获取文件元数据
@@ -340,7 +350,7 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
             msg.message_id
         );
 
-        match insert_session_log_entry(db, &request_id, msg) {
+        match insert_session_log_entry(db, &request_id, msg, data_source) {
             Ok(true) => imported += 1,
             Ok(false) => skipped += 1,
             Err(e) => {
@@ -411,6 +421,7 @@ fn insert_session_log_entry(
     db: &Database,
     request_id: &str,
     msg: &ParsedAssistantUsage,
+    data_source: &str,
 ) -> Result<bool, AppError> {
     let conn = lock_conn!(db.conn);
 
@@ -504,11 +515,11 @@ fn insert_session_log_entry(
                 200i64,             // status_code: 会话日志中的请求只要产生计费 token 即视为成功
                 Option::<String>::None, // error_message
                 msg.session_id,
-                Some("session_log"), // provider_type
+                Some(data_source),  // provider_type: 与 data_source 同值，同 codex/gemini/opencode
                 1i64,               // is_streaming: Claude Code 通常使用流式
                 "1.0",              // cost_multiplier
                 created_at,
-                "session_log",      // data_source
+                data_source,
             ],
         )
         .map_err(|e| AppError::Database(format!("插入会话日志失败: {e}")))?;
@@ -685,7 +696,7 @@ mod tests {
             session_id: Some("session-1".to_string()),
         };
 
-        let inserted = insert_session_log_entry(&db, "session:msg_1", &msg)?;
+        let inserted = insert_session_log_entry(&db, "session:msg_1", &msg, "session_log")?;
         assert!(!inserted);
 
         let conn = lock_conn!(db.conn);
@@ -771,7 +782,7 @@ mod tests {
         let empty = r#"{"type":"assistant","message":{"id":"msg_empty","model":"claude-opus-4-8","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-06-07T13:01:24Z","sessionId":"session-wf"}"#;
         fs::write(&file, format!("{billable}\n{empty}\n")).unwrap();
 
-        let (imported, _skipped) = sync_single_file(&db, &file)?;
+        let (imported, _skipped) = sync_single_file(&db, &file, "session_log")?;
         assert_eq!(
             imported, 1,
             "有 cache 成本但无 stop_reason 的 message 必须被导入"

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -82,7 +82,7 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
     for file_path in &jsonl_files {
         result.files_scanned += 1;
 
-        match sync_single_file(db, file_path, "session_log") {
+        match sync_single_file(db, file_path, "session_log", "claude") {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -185,10 +185,13 @@ fn push_jsonl_children(dir: &Path, files: &mut Vec<PathBuf>) {
 ///
 /// `data_source` 写入 proxy_request_logs.data_source，用于区分来源
 /// （Claude Code 为 "session_log"，Cowork 为 "cowork_session_log"）。
+/// `app_type` 需与该流量走网关时 proxy 行的入口一致（Claude Code 为 "claude"，
+/// Cowork 为 "claude-desktop"），否则指纹去重因 app_type 不等而失效、产生双算。
 pub(crate) fn sync_single_file(
     db: &Database,
     file_path: &Path,
     data_source: &str,
+    app_type: &str,
 ) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
@@ -350,7 +353,7 @@ pub(crate) fn sync_single_file(
             msg.message_id
         );
 
-        match insert_session_log_entry(db, &request_id, msg, data_source) {
+        match insert_session_log_entry(db, &request_id, msg, data_source, app_type) {
             Ok(true) => imported += 1,
             Ok(false) => skipped += 1,
             Err(e) => {
@@ -422,6 +425,7 @@ fn insert_session_log_entry(
     request_id: &str,
     msg: &ParsedAssistantUsage,
     data_source: &str,
+    app_type: &str,
 ) -> Result<bool, AppError> {
     let conn = lock_conn!(db.conn);
 
@@ -441,7 +445,7 @@ fn insert_session_log_entry(
         });
 
     let dedup_key = DedupKey {
-        app_type: "claude",
+        app_type,
         model: &msg.model,
         input_tokens: msg.input_tokens,
         output_tokens: msg.output_tokens,
@@ -498,7 +502,7 @@ fn insert_session_log_entry(
             rusqlite::params![
                 request_id,
                 "_session",         // provider_id: 标记为会话来源
-                "claude",           // app_type
+                app_type,
                 msg.model,
                 msg.model,          // request_model = model
                 msg.input_tokens,
@@ -696,7 +700,8 @@ mod tests {
             session_id: Some("session-1".to_string()),
         };
 
-        let inserted = insert_session_log_entry(&db, "session:msg_1", &msg, "session_log")?;
+        let inserted =
+            insert_session_log_entry(&db, "session:msg_1", &msg, "session_log", "claude")?;
         assert!(!inserted);
 
         let conn = lock_conn!(db.conn);
@@ -782,7 +787,7 @@ mod tests {
         let empty = r#"{"type":"assistant","message":{"id":"msg_empty","model":"claude-opus-4-8","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-06-07T13:01:24Z","sessionId":"session-wf"}"#;
         fs::write(&file, format!("{billable}\n{empty}\n")).unwrap();
 
-        let (imported, _skipped) = sync_single_file(&db, &file, "session_log")?;
+        let (imported, _skipped) = sync_single_file(&db, &file, "session_log", "claude")?;
         assert_eq!(
             imported, 1,
             "有 cache 成本但无 stop_reason 的 message 必须被导入"

--- a/src-tauri/src/services/session_usage_cowork.rs
+++ b/src-tauri/src/services/session_usage_cowork.rs
@@ -1,0 +1,346 @@
+//! Claude Cowork（桌面版）会话日志使用追踪
+//!
+//! Cowork 会话不写入 ~/.claude/projects/，而是保存在 Claude 桌面应用的
+//! 数据目录下。每个会话沙箱内嵌一份与 Claude Code 完全同构的 transcript：
+//!
+//! ```text
+//! <Claude 桌面数据目录>/local-agent-mode-sessions/
+//!   <workspace-id>/<group-id>/
+//!     local_<id>.json          ← 会话元数据（标题等）
+//!     local_<id>/
+//!       audit.jsonl            ← 审计副本，见下方说明，必须排除
+//!       .claude/projects/<项目目录>/
+//!         <sessionId>.jsonl    ← 真正的 transcript，格式与 Claude Code 一致
+//!         <sessionId>/subagents/agent-*.jsonl   ← Task 子代理（与 Claude Code 布局一致）
+//!     agent/
+//!       local_<id>/            ← group 级常驻代理沙箱（如记忆维护，Windows 实测），
+//!                                内部结构同 local_<id>/，其消耗同样真实计费
+//! ```
+//!
+//! JSONL 记录格式（`type=="assistant"` + `message.usage`）与 ~/.claude/projects
+//! 完全一致，解析、去重、增量同步全部复用 session_usage；本模块只负责发现
+//! 各会话沙箱内嵌的 projects 目录。
+//!
+//! ## 为什么不扫 audit.jsonl
+//!
+//! `local_<id>/audit.jsonl` 是同一会话的审计副本，但其 usage 是流式起始
+//! 的部分快照（实测某会话实际 output 327K token，audit 中只有 10K），
+//! 计入会导致重复且错误的统计。实测它位于 `.claude/projects` 之外，扫内嵌
+//! projects 目录本就不会命中；收集时仍按文件名显式排除，不依赖这个布局巧合。
+
+use crate::config::get_home_dir;
+use crate::database::Database;
+use crate::error::AppError;
+use crate::services::session_usage::{collect_jsonl_files, sync_single_file, SessionSyncResult};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Cowork 会话写入 proxy_request_logs.data_source 的标记
+pub const COWORK_DATA_SOURCE: &str = "cowork_session_log";
+
+// 注：macOS/Windows 布局均已真机实测；Linux 路径按 Electron appData 约定
+// （Claude Desktop Linux beta 2026-06-30 发布，含 Cowork），目录不存在时同步为 no-op。
+
+/// Cowork 会话根目录
+///
+/// Claude 桌面版是 Electron 应用，会话目录挂在 userData（appData/Claude）下：
+///   macOS:   ~/Library/Application Support/Claude/
+///   Windows: %APPDATA%\Claude\（企业漫游配置可能重定向到 home 之外，优先读环境变量）
+///   Linux:   $XDG_CONFIG_HOME/Claude/ 或 ~/.config/Claude/（Linux beta 自 2026-06 起支持 Cowork）
+///
+/// 设置 CC_SWITCH_TEST_HOME 时忽略 APPDATA/XDG_CONFIG_HOME，一律从测试 home
+/// 拼固定子路径，避免测试触碰真实用户目录。
+fn cowork_sessions_dir() -> Option<PathBuf> {
+    let isolated = std::env::var("CC_SWITCH_TEST_HOME")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false);
+    let home = get_home_dir();
+
+    let app_data = if cfg!(target_os = "macos") {
+        home.join("Library/Application Support")
+    } else if cfg!(target_os = "windows") {
+        dir_from_env(std::env::var_os("APPDATA"), isolated)
+            .unwrap_or_else(|| home.join("AppData/Roaming"))
+    } else if cfg!(target_os = "linux") {
+        dir_from_env(std::env::var_os("XDG_CONFIG_HOME"), isolated)
+            .unwrap_or_else(|| home.join(".config"))
+    } else {
+        return None;
+    };
+
+    Some(app_data.join("Claude").join("local-agent-mode-sessions"))
+}
+
+/// 环境变量目录值 → PathBuf；测试隔离模式或值为空时返回 None（走 home 回退）。
+fn dir_from_env(value: Option<std::ffi::OsString>, isolated: bool) -> Option<PathBuf> {
+    if isolated {
+        return None;
+    }
+    let value = value?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(value))
+}
+
+/// 同步 Cowork 会话日志到使用统计数据库
+pub fn sync_cowork_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    let mut result = SessionSyncResult {
+        imported: 0,
+        skipped: 0,
+        files_scanned: 0,
+        errors: vec![],
+    };
+
+    let root = match cowork_sessions_dir() {
+        Some(dir) if dir.exists() => dir,
+        _ => return Ok(result),
+    };
+
+    for file_path in collect_cowork_jsonl_files(&root) {
+        result.files_scanned += 1;
+
+        match sync_single_file(db, &file_path, COWORK_DATA_SOURCE) {
+            Ok((imported, skipped)) => {
+                result.imported += imported;
+                result.skipped += skipped;
+            }
+            Err(e) => {
+                let msg = format!("{}: {e}", file_path.display());
+                log::warn!("[COWORK-SYNC] 文件解析失败: {msg}");
+                result.errors.push(msg);
+            }
+        }
+    }
+
+    if result.imported > 0 {
+        log::info!(
+            "[COWORK-SYNC] 同步完成: 导入 {} 条, 跳过 {} 条, 扫描 {} 个文件",
+            result.imported,
+            result.skipped,
+            result.files_scanned
+        );
+    }
+
+    Ok(result)
+}
+
+/// 收集所有 Cowork 会话沙箱内嵌 projects 目录下的 .jsonl 文件
+///
+/// 与 session_usage 一样按固定深度遍历，不递归：
+///   root/<workspace-id>/<group-id>/local_<id>/.claude/projects/          (会话沙箱)
+///   root/<workspace-id>/<group-id>/agent/local_<id>/.claude/projects/    (group 级常驻代理沙箱，Windows 实测)
+/// 命中的 projects 目录交给 collect_jsonl_files 复用收集，主会话与
+/// <sessionId>/subagents/ 下的 Task 子代理都在其中（布局与 Claude Code 一致）。
+fn collect_cowork_jsonl_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+
+    for workspace in read_child_dirs(root) {
+        for group in read_child_dirs(&workspace) {
+            for entry in read_child_dirs(&group) {
+                match entry.file_name().and_then(|n| n.to_str()) {
+                    Some(name) if name.starts_with("local_") => {
+                        push_sandbox_jsonl_files(&entry, &mut files);
+                    }
+                    // Windows 版在 group 级 agent/ 下有常驻代理沙箱（如 local_ditto_<id>/），
+                    // 其消耗同样真实计费，一并计入
+                    Some("agent") => {
+                        for agent_sandbox in read_child_dirs(&entry) {
+                            let is_sandbox = agent_sandbox
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .is_some_and(|n| n.starts_with("local_"));
+                            if is_sandbox {
+                                push_sandbox_jsonl_files(&agent_sandbox, &mut files);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    files
+}
+
+/// 收集单个会话沙箱内嵌 projects 目录下的 .jsonl 文件。
+fn push_sandbox_jsonl_files(sandbox: &Path, files: &mut Vec<PathBuf>) {
+    let projects = sandbox.join(".claude").join("projects");
+    if projects.is_dir() {
+        files.extend(
+            collect_jsonl_files(&projects)
+                .into_iter()
+                // audit.jsonl 无论在哪一层都不计入，见模块注释
+                .filter(|p| p.file_name().and_then(|n| n.to_str()) != Some("audit.jsonl")),
+        );
+    }
+}
+
+/// 返回 `dir` 下直接子层的所有目录（不递归）。
+fn read_child_dirs(dir: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                dirs.push(path);
+            }
+        }
+    }
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::lock_conn;
+
+    /// 构造一个仿真 Cowork 会话根目录，返回 (root, transcript 目录)
+    fn make_cowork_layout(tag: &str) -> (PathBuf, PathBuf) {
+        let root =
+            std::env::temp_dir().join(format!("cc-switch-cowork-{tag}-{}", uuid::Uuid::new_v4()));
+        let sandbox = root
+            .join("workspace-uuid")
+            .join("group-uuid")
+            .join("local_abc123");
+        let projects = sandbox
+            .join(".claude")
+            .join("projects")
+            .join("-sandbox-outputs");
+        fs::create_dir_all(&projects).unwrap();
+        (root, projects)
+    }
+
+    #[test]
+    fn test_dir_from_env_resolution() {
+        use std::ffi::OsString;
+
+        // 正常模式：非空环境变量生效（企业重定向的 APPDATA / 自定义 XDG_CONFIG_HOME）
+        assert_eq!(
+            dir_from_env(Some(OsString::from("/redirected/roaming")), false),
+            Some(PathBuf::from("/redirected/roaming"))
+        );
+        // 空值视为未设置 → 走 home 回退
+        assert_eq!(dir_from_env(Some(OsString::new()), false), None);
+        assert_eq!(dir_from_env(None, false), None);
+        // CC_SWITCH_TEST_HOME 隔离模式：忽略真实环境变量，测试不触碰真实用户目录
+        assert_eq!(
+            dir_from_env(Some(OsString::from("/redirected/roaming")), true),
+            None
+        );
+    }
+
+    #[test]
+    fn test_cowork_sessions_dir_shape() {
+        // 三个受支持平台上都应返回 …/Claude/local-agent-mode-sessions
+        let dir = cowork_sessions_dir().expect("当前平台应支持 Cowork 目录解析");
+        assert_eq!(
+            dir.file_name().and_then(|n| n.to_str()),
+            Some("local-agent-mode-sessions")
+        );
+        assert_eq!(
+            dir.parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str()),
+            Some("Claude")
+        );
+    }
+
+    #[test]
+    fn test_collect_excludes_audit_jsonl() {
+        let (root, projects) = make_cowork_layout("collect");
+        let sandbox = root
+            .join("workspace-uuid")
+            .join("group-uuid")
+            .join("local_abc123");
+
+        // 真正的 transcript + 子 agent
+        let subagents = projects.join("session-1").join("subagents");
+        fs::create_dir_all(&subagents).unwrap();
+        fs::write(projects.join("session-1.jsonl"), "{}").unwrap();
+        fs::write(subagents.join("agent-x.jsonl"), "{}").unwrap();
+        // audit.jsonl 放三个位置：实测位置（沙箱直下）+ 两个可扫描到的防御位置
+        fs::write(sandbox.join("audit.jsonl"), "{}").unwrap();
+        fs::write(projects.join("audit.jsonl"), "{}").unwrap();
+        fs::write(
+            projects
+                .join("session-1")
+                .join("subagents")
+                .join("audit.jsonl"),
+            "{}",
+        )
+        .unwrap();
+        // 非 local_ 前缀目录不是会话沙箱
+        let other = root
+            .join("workspace-uuid")
+            .join("group-uuid")
+            .join("skills");
+        fs::create_dir_all(other.join(".claude").join("projects")).unwrap();
+        fs::write(
+            other.join(".claude").join("projects").join("stray.jsonl"),
+            "{}",
+        )
+        .unwrap();
+        // Windows 版 group 级常驻代理沙箱：group/agent/local_ditto_<id>/
+        let ditto = root
+            .join("workspace-uuid")
+            .join("group-uuid")
+            .join("agent")
+            .join("local_ditto_xyz")
+            .join(".claude")
+            .join("projects")
+            .join("-ditto-outputs");
+        fs::create_dir_all(&ditto).unwrap();
+        fs::write(ditto.join("ditto-session.jsonl"), "{}").unwrap();
+
+        let files = collect_cowork_jsonl_files(&root);
+        let paths: Vec<String> = files
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(files.len(), 3, "只应收集沙箱内嵌 projects 下的 transcript");
+        assert!(paths.iter().any(|p| p.contains("session-1.jsonl")));
+        assert!(paths.iter().any(|p| p.contains("agent-x.jsonl")));
+        assert!(
+            paths.iter().any(|p| p.contains("ditto-session.jsonl")),
+            "Windows 的 agent/ 下常驻代理沙箱必须被收集"
+        );
+        assert!(
+            !paths.iter().any(|p| p.contains("audit.jsonl")),
+            "audit.jsonl 的 usage 是流式部分快照，绝不能计入"
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn test_sync_marks_cowork_data_source() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let (root, projects) = make_cowork_layout("sync");
+
+        let line = r#"{"type":"assistant","message":{"id":"msg_cowork1","model":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":200,"cache_read_input_tokens":5000,"cache_creation_input_tokens":100},"stop_reason":"end_turn"},"timestamp":"2026-06-27T11:17:00Z","sessionId":"cowork-session-1"}"#;
+        fs::write(projects.join("session-1.jsonl"), format!("{line}\n")).unwrap();
+
+        let mut imported = 0;
+        for file in collect_cowork_jsonl_files(&root) {
+            let (i, _) = sync_single_file(&db, &file, COWORK_DATA_SOURCE)?;
+            imported += i;
+        }
+        assert_eq!(imported, 1);
+
+        let conn = lock_conn!(db.conn);
+        let (data_source, app_type): (String, String) = conn.query_row(
+            "SELECT data_source, app_type FROM proxy_request_logs WHERE request_id = 'session:msg_cowork1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(data_source, COWORK_DATA_SOURCE);
+        assert_eq!(app_type, "claude");
+        drop(conn);
+
+        fs::remove_dir_all(&root).ok();
+        Ok(())
+    }
+}

--- a/src-tauri/src/services/session_usage_cowork.rs
+++ b/src-tauri/src/services/session_usage_cowork.rs
@@ -38,6 +38,14 @@ use std::path::{Path, PathBuf};
 /// Cowork 会话写入 proxy_request_logs.data_source 的标记
 pub const COWORK_DATA_SOURCE: &str = "cowork_session_log";
 
+/// Cowork 会话行的 app_type。
+///
+/// 与 Desktop 网关 proxy 行的入口（`handle_claude_desktop_messages` →
+/// `"claude-desktop"`）保持一致，指纹去重才能按原始 app_type 精确匹配，
+/// 避免走网关的 Cowork 流量被 proxy 行和会话行双算。读侧展示/筛选由
+/// `folded_app_type_sql` 折叠进 `claude`，UI 分类不受影响。
+pub const COWORK_APP_TYPE: &str = "claude-desktop";
+
 // 注：macOS/Windows 布局均已真机实测；Linux 路径按 Electron appData 约定
 // （Claude Desktop Linux beta 2026-06-30 发布，含 Cowork），目录不存在时同步为 no-op。
 
@@ -100,7 +108,7 @@ pub fn sync_cowork_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     for file_path in collect_cowork_jsonl_files(&root) {
         result.files_scanned += 1;
 
-        match sync_single_file(db, &file_path, COWORK_DATA_SOURCE) {
+        match sync_single_file(db, &file_path, COWORK_DATA_SOURCE, COWORK_APP_TYPE) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -325,7 +333,7 @@ mod tests {
 
         let mut imported = 0;
         for file in collect_cowork_jsonl_files(&root) {
-            let (i, _) = sync_single_file(&db, &file, COWORK_DATA_SOURCE)?;
+            let (i, _) = sync_single_file(&db, &file, COWORK_DATA_SOURCE, COWORK_APP_TYPE)?;
             imported += i;
         }
         assert_eq!(imported, 1);
@@ -336,8 +344,11 @@ mod tests {
             [],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )?;
-        assert_eq!(data_source, COWORK_DATA_SOURCE);
-        assert_eq!(app_type, "claude");
+        assert_eq!(data_source, "cowork_session_log");
+        // 与 Desktop 网关 proxy 行一致，读侧由 folded_app_type_sql 折叠进 claude。
+        // 刻意用字面量而非 COWORK_APP_TYPE：常量被改动时测试必须变红，
+        // 否则去重口径会随常量一起漂移而无人察觉。
+        assert_eq!(app_type, "claude-desktop");
         drop(conn);
 
         fs::remove_dir_all(&root).ok();

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -299,7 +299,7 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
     let proxy_data_source = data_source_expr("proxy_dedup");
     format!(
         "NOT (
-            {data_source} IN ('session_log', 'codex_session', 'gemini_session', 'opencode_session')
+            {data_source} IN ('session_log', 'cowork_session_log', 'codex_session', 'gemini_session', 'opencode_session')
             AND EXISTS (
                 SELECT 1
                 FROM proxy_request_logs proxy_dedup
@@ -3404,6 +3404,83 @@ mod tests {
         assert_eq!(codex_session_count, Some(1));
         assert_eq!(gemini_session_count, None);
         assert_eq!(session_log_count, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_effective_usage_dedup_covers_cowork_session_rows() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            insert_usage_log(
+                &conn,
+                "claude-proxy",
+                "claude",
+                "openai-compatible",
+                "claude-sonnet-4-5",
+                "proxy",
+                25_000,
+                300,
+                60,
+                20,
+                5,
+                200,
+                "0.30",
+            )?;
+            // 与 proxy 行各字段一致（60 秒窗口内）的 Cowork 会话行 → 应被去重
+            insert_usage_log(
+                &conn,
+                "cowork-session-dup",
+                "claude",
+                "_session",
+                "claude-sonnet-4-5",
+                "cowork_session_log",
+                25_060,
+                300,
+                60,
+                20,
+                5,
+                200,
+                "0.30",
+            )?;
+            // cache_creation 不一致的 Cowork 行 → 不应被去重：Cowork transcript
+            // 提供真实 cache_creation 值，因此刻意不进 cache_creation==0 的
+            // codex/gemini/opencode 特例
+            insert_usage_log(
+                &conn,
+                "cowork-session-nocache",
+                "claude",
+                "_session",
+                "claude-sonnet-4-5",
+                "cowork_session_log",
+                25_061,
+                300,
+                60,
+                20,
+                0,
+                200,
+                "0.30",
+            )?;
+        }
+
+        let logs = db.get_request_logs(&LogFilters::default(), 0, 10)?;
+        let request_ids: Vec<&str> = logs
+            .data
+            .iter()
+            .map(|log| log.request_id.as_str())
+            .collect();
+        assert_eq!(logs.total, 2);
+        assert!(request_ids.contains(&"claude-proxy"));
+        assert!(
+            !request_ids.contains(&"cowork-session-dup"),
+            "与 proxy 完全匹配的 Cowork 会话行应被去重"
+        );
+        assert!(
+            request_ids.contains(&"cowork-session-nocache"),
+            "cache_creation 不匹配的 Cowork 行不应套用 0 值特例被去重"
+        );
 
         Ok(())
     }

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -3414,10 +3414,11 @@ mod tests {
 
         {
             let conn = lock_conn!(db.conn);
+            // Cowork 走 Desktop 网关时 proxy 行按入口记 app_type="claude-desktop"
             insert_usage_log(
                 &conn,
-                "claude-proxy",
-                "claude",
+                "desktop-proxy",
+                "claude-desktop",
                 "openai-compatible",
                 "claude-sonnet-4-5",
                 "proxy",
@@ -3429,11 +3430,12 @@ mod tests {
                 200,
                 "0.30",
             )?;
-            // 与 proxy 行各字段一致（60 秒窗口内）的 Cowork 会话行 → 应被去重
+            // 与 proxy 行各字段一致（60 秒窗口内）的 Cowork 会话行 → 应被去重；
+            // 会话行同样记 app_type="claude-desktop"，与网关入口对齐
             insert_usage_log(
                 &conn,
                 "cowork-session-dup",
-                "claude",
+                "claude-desktop",
                 "_session",
                 "claude-sonnet-4-5",
                 "cowork_session_log",
@@ -3451,7 +3453,7 @@ mod tests {
             insert_usage_log(
                 &conn,
                 "cowork-session-nocache",
-                "claude",
+                "claude-desktop",
                 "_session",
                 "claude-sonnet-4-5",
                 "cowork_session_log",
@@ -3472,14 +3474,31 @@ mod tests {
             .map(|log| log.request_id.as_str())
             .collect();
         assert_eq!(logs.total, 2);
-        assert!(request_ids.contains(&"claude-proxy"));
+        assert!(request_ids.contains(&"desktop-proxy"));
         assert!(
             !request_ids.contains(&"cowork-session-dup"),
-            "与 proxy 完全匹配的 Cowork 会话行应被去重"
+            "与 Desktop 网关 proxy 行完全匹配的 Cowork 会话行应被去重"
         );
         assert!(
             request_ids.contains(&"cowork-session-nocache"),
             "cache_creation 不匹配的 Cowork 行不应套用 0 值特例被去重"
+        );
+
+        // 读侧折叠：appType="claude" 筛选应包含 claude-desktop 的 Cowork 行
+        let claude_logs = db.get_request_logs(
+            &LogFilters {
+                app_type: Some("claude".to_string()),
+                ..LogFilters::default()
+            },
+            0,
+            10,
+        )?;
+        assert!(
+            claude_logs
+                .data
+                .iter()
+                .any(|log| log.request_id == "cowork-session-nocache"),
+            "claude-desktop 的 Cowork 行应折叠进 claude 筛选口径"
         );
 
         Ok(())

--- a/src/components/usage/DataSourceBar.tsx
+++ b/src/components/usage/DataSourceBar.tsx
@@ -14,6 +14,7 @@ interface DataSourceBarProps {
 const DATA_SOURCE_ICONS: Record<string, React.ReactNode> = {
   proxy: <Database className="h-3.5 w-3.5" />,
   session_log: <FileText className="h-3.5 w-3.5" />,
+  cowork_session_log: <FileText className="h-3.5 w-3.5" />,
   codex_db: <Database className="h-3.5 w-3.5" />,
   codex_session: <FileText className="h-3.5 w-3.5" />,
   gemini_session: <FileText className="h-3.5 w-3.5" />,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1479,6 +1479,7 @@
     "dataSource": {
       "proxy": "Routing",
       "session_log": "Session Log",
+      "cowork_session_log": "Cowork Session",
       "codex_db": "Codex DB",
       "codex_session": "Codex Session",
       "gemini_session": "Gemini Session",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1479,6 +1479,7 @@
     "dataSource": {
       "proxy": "ルーティング",
       "session_log": "セッションログ",
+      "cowork_session_log": "Cowork セッション",
       "codex_db": "Codex DB",
       "codex_session": "Codex セッション",
       "gemini_session": "Gemini セッション",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1451,6 +1451,7 @@
     "dataSource": {
       "proxy": "路由",
       "session_log": "工作階段日誌",
+      "cowork_session_log": "Cowork 工作階段日誌",
       "codex_db": "Codex 資料庫",
       "codex_session": "Codex 工作階段日誌",
       "gemini_session": "Gemini 工作階段日誌",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1479,6 +1479,7 @@
     "dataSource": {
       "proxy": "路由",
       "session_log": "会话日志",
+      "cowork_session_log": "Cowork 会话日志",
       "codex_db": "Codex 数据库",
       "codex_session": "Codex 会话日志",
       "gemini_session": "Gemini 会话日志",


### PR DESCRIPTION
## Summary / 概述

Fixes #4979 的实现。Cowork 会话的 transcript 藏在 Claude 桌面应用数据目录的会话沙箱里，格式和 `~/.claude/projects` 完全一样，所以这个 PR 主要是教 usage 同步去哪找文件：

- 新增 `session_usage_cowork.rs` 做目录发现，固定深度遍历，和现有几个 `session_usage_*` 一个风格。解析、去重、增量直接复用 `session_usage.rs`，只给 `sync_single_file` 加了个 `data_source` 参数。
- `audit.jsonl` 是同一会话的审计副本，usage 只有流式开头的部分快照（数字见 #4979），按文件名显式排除，有单测锁着。
- app_type 记 `"claude-desktop"`，与 Desktop 网关 proxy 行的入口一致（codex bot 抓到的双算问题，已修）；读侧由现有 `folded_app_type_sql` 折叠进 claude 分类，UI 不受影响。data_source 用 `"cowork_session_log"` 区分来源，请求日志的「来源」列可以看到（见截图）。你要是想分成独立 appType，说一声我改。
- 走 Gateway 代理的请求不会双算。查询侧 `effective_usage_log_filter` 加了新值，配了回归测试（含 cache_creation 不匹配不去重的场景）；插入侧 `should_skip_session_insert` 按 app_type 判断，claude-desktop 不在 cache_creation==0 特例里，天然精确匹配，所以只需要改查询侧。
- provider_type 与 data_source 同值，跟 codex/gemini/opencode 三个模块的惯例一致。

平台情况：

- **macOS**：本机 27 个 transcript、1799 条计费消息，导入结果和独立实现逐字段对过数，一致
- **Windows**：实测过目录布局和 JSONL 格式；`%APPDATA%` 优先读环境变量，企业重定向环境也能拿对目录
- **Linux**：桌面 beta（6 月底发布）带 Cowork，路径按 Electron userData 约定写的，和 [claude-desktop-debian](https://github.com/aaddrick/claude-desktop-debian) 在真实环境观察到的一致，但我手头没有 Linux 环境跑过——目录不存在时是 no-op，有 Linux beta 的朋友可以帮忙确认下

## Related Issue / 关联 Issue

Fixes #4979

## Screenshots / 截图
<img width="2224" height="1524" alt="image" src="https://github.com/user-attachments/assets/debe4960-6161-47e0-b3e8-040e6e29dcee" />

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 已更新国际化文件（en/zh/ja，顺手补了 zh-TW）


