### PR TITLE
fix: 修复配置文件为单文件 bind mount 时写入报 EBUSY 的问题(Flatpak/容器场景)

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -314,10 +314,9 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
         .as_nanos();
     tmp.push(format!("{file_name}.tmp.{ts}"));
 
-    {
-        let mut f = fs::File::create(&tmp).map_err(|e| AppError::io(&tmp, e))?;
-        f.write_all(data).map_err(|e| AppError::io(&tmp, e))?;
-        f.flush().map_err(|e| AppError::io(&tmp, e))?;
+    if let Err(e) = fs::write(&tmp, data) {
+        let _ = fs::remove_file(&tmp);
+        return Err(AppError::io(&tmp, e));
     }
 
     #[cfg(unix)]
@@ -335,20 +334,96 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
         if path.exists() {
             let _ = fs::remove_file(path);
         }
-        fs::rename(&tmp, path).map_err(|e| AppError::IoContext {
-            context: format!("原子替换失败: {} -> {}", tmp.display(), path.display()),
-            source: e,
-        })?;
+        if let Err(e) = fs::rename(&tmp, path) {
+            let _ = fs::remove_file(&tmp);
+            return Err(AppError::IoContext {
+                context: format!("原子替换失败: {} -> {}", tmp.display(), path.display()),
+                source: e,
+            });
+        }
     }
 
     #[cfg(not(windows))]
     {
-        fs::rename(&tmp, path).map_err(|e| AppError::IoContext {
-            context: format!("原子替换失败: {} -> {}", tmp.display(), path.display()),
-            source: e,
-        })?;
+        if let Err(e) = fs::rename(&tmp, path) {
+            let _ = fs::remove_file(&tmp);
+            // 单文件 bind mount（Flatpak/容器把宿主机文件挂进沙箱）下目标是挂载点，
+            // rename 无法替换挂载点，返回 EBUSY。事前无法可靠检测（同设备 bind mount
+            // 的 st_dev 与父目录相同），只能失败后回退为原地覆盖。
+            if is_resource_busy(&e) && path.exists() {
+                return overwrite_in_place_with_backup(path, data);
+            }
+            return Err(AppError::IoContext {
+                context: format!("原子替换失败: {} -> {}", tmp.display(), path.display()),
+                source: e,
+            });
+        }
     }
     Ok(())
+}
+
+/// rename 因目标被系统占用（如挂载点）而失败。EBUSY 在 Linux/macOS 上均为 16。
+#[cfg(not(windows))]
+fn is_resource_busy(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::ResourceBusy || err.raw_os_error() == Some(16)
+}
+
+/// bind mount 场景的回退写入：先备份原文件，再原地截断覆盖。
+///
+/// 该路径不具备 rename 的原子性：写入中途崩溃会留下半写文件。
+/// 因此覆盖前先把原内容备份到同目录，成功后删除备份；
+/// 失败时尝试用备份恢复原内容，并保留备份文件供手动恢复。
+/// 原地写入不更换 inode，目标文件的权限、xattr 与挂载关系均保持不变。
+#[cfg(not(windows))]
+fn overwrite_in_place_with_backup(path: &Path, data: &[u8]) -> Result<(), AppError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| AppError::Config("无效的路径".to_string()))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| AppError::Config("无效的文件名".to_string()))?
+        .to_string_lossy()
+        .to_string();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let backup = parent.join(format!("{file_name}.bak.{ts}"));
+
+    fs::copy(path, &backup).map_err(|e| AppError::IoContext {
+        context: format!("创建备份失败: {} -> {}", path.display(), backup.display()),
+        source: e,
+    })?;
+
+    match write_in_place(path, data) {
+        Ok(()) => {
+            let _ = fs::remove_file(&backup);
+            Ok(())
+        }
+        Err(e) => {
+            // 尽力恢复原内容；无论恢复是否成功都保留备份文件
+            let _ = fs::read(&backup).and_then(|orig| write_in_place(path, &orig));
+            Err(AppError::IoContext {
+                context: format!(
+                    "原地覆盖失败: {}（原内容已备份至 {}）",
+                    path.display(),
+                    backup.display()
+                ),
+                source: e,
+            })
+        }
+    }
+}
+
+/// 原地截断覆盖（不新建文件、不更换 inode）
+#[cfg(not(windows))]
+fn write_in_place(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let mut f = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)?;
+    f.write_all(data)?;
+    f.sync_all()
 }
 
 #[cfg(test)]
@@ -520,6 +595,98 @@ mod tests {
             serde_json::to_string(&sorted_a).unwrap(),
             serde_json::to_string(&sorted_b).unwrap(),
         );
+    }
+
+    fn leftover_files(dir: &Path, marker: &str) -> Vec<PathBuf> {
+        fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .map(|n| n.to_string_lossy().contains(marker))
+                    .unwrap_or(false)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing_file_and_leaves_no_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("config.json");
+        fs::write(&target, "old").unwrap();
+
+        atomic_write(&target, b"new").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+        assert!(leftover_files(dir.path(), ".tmp.").is_empty());
+    }
+
+    #[test]
+    fn atomic_write_cleans_temp_file_when_rename_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        // 目标是非空目录：rename 必然失败，且不属于 EBUSY 回退场景
+        let target = dir.path().join("occupied");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("keep"), "x").unwrap();
+
+        assert!(atomic_write(&target, b"data").is_err());
+        assert!(leftover_files(dir.path(), ".tmp.").is_empty());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn is_resource_busy_matches_ebusy_only() {
+        assert!(is_resource_busy(&std::io::Error::from_raw_os_error(16)));
+        assert!(!is_resource_busy(&std::io::Error::from_raw_os_error(2)));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn overwrite_in_place_writes_content_and_removes_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("config.json");
+        fs::write(&target, "old-content").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+
+        overwrite_in_place_with_backup(&target, b"new-content").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new-content");
+        assert!(leftover_files(dir.path(), ".bak.").is_empty());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "原地覆盖应保留目标文件权限");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn overwrite_in_place_keeps_original_and_backup_when_write_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("config.json");
+        fs::write(&target, "old-content").unwrap();
+        // 只读目标：打开写句柄失败，触发失败路径（root 用户不受权限限制，跳过）
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o400)).unwrap();
+        if fs::OpenOptions::new().write(true).open(&target).is_ok() {
+            return;
+        }
+
+        assert!(overwrite_in_place_with_backup(&target, b"new-content").is_err());
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "old-content");
+        let backups = leftover_files(dir.path(), ".bak.");
+        assert_eq!(backups.len(), 1, "失败时应保留备份文件");
+        assert_eq!(fs::read_to_string(&backups[0]).unwrap(), "old-content");
     }
 }
 


### PR DESCRIPTION
## Summary / 概述

**问题**:当 cc-switch 管理的配置文件(如 `~/.claude.json`)被以单文件 bind mount 的方式暴露给沙箱时(Flatpak 的 `--filesystem=~/.claude.json` 单文件透传、Docker/Podman 的单文件挂载都属于这种情况),任何配置写入都会失败:

```
原子替换失败: /home/user/.claude.json.tmp.XXXX -> /home/user/.claude.json: 设备或资源忙 (os error 16)
```

**根因**:`atomic_write()` 使用「写临时文件 + `rename()` 替换」实现原子写入,但按 `rename(2)` 的语义,目标是挂载点时 rename 会返回 `EBUSY`。单文件 bind mount 场景下目标文件正是挂载点,所以必然失败。这与 JSON 内容、文件权限无关。

**修复方式**(仅改 `src-tauri/src/config.rs`):

1. rename 成功的路径**行为完全不变**,仍是原子替换——这是绝大多数用户走的路径;
2. rename 失败且错误为 `EBUSY` 时,回退为带备份的原地覆盖:
   - 先把原文件内容复制到同目录的 `{文件名}.bak.{时间戳}`;
   - 以 truncate 方式原地写入新内容并 `sync_all()`(原地写不更换 inode,权限、xattr 和挂载关系都保持不变,这也是挂载点场景唯一可行的写法);
   - 成功后删除备份——**成功路径不留任何新文件**;
   - 失败时尽力从备份恢复原内容,并保留备份文件,错误信息中带上备份路径,把最坏情况从「数据丢失」变成「数据在旁边的 .bak 里」。
3. 顺带修复一个相关问题:此前 rename 失败时临时文件不会被清理,受此 bug 影响的用户每保存一次配置,`$HOME` 下就多一个 `.claude.json.tmp.XXXX` 残留文件。现在所有错误路径都会清理临时文件(Windows 分支同样处理)。

**为什么不做事前检测**:无法可靠判断目标是否为挂载点——同一文件系统内的 bind mount,其 `st_dev` 与父目录相同,检测不出来。先尝试 rename、失败后按错误码回退是唯一稳妥的方式。

`EBUSY` 判定同时匹配 `ErrorKind::ResourceBusy` 和 raw os error 16(EBUSY 在 Linux/macOS 上均为 16),兼容不同 libc。

**影响范围**:所有平台的成功路径零变化;仅在 Unix 且 rename 返回 EBUSY 时进入新逻辑。`atomic_write()` 是所有外部工具配置(Claude/Codex/Gemini/OpenCode 等)的统一写入口,修这一处即覆盖全部。

## Related Issue / 关联 Issue

上游暂无对应 issue。问题由 Flatpak 打包仓库报告:jing2uo/flatpark#44(含完整报错日志),打包方式为将宿主机 `~/.claude.json` 以单文件权限透传进沙箱。

## 验证 / Verification

- 新增 5 个单元测试:正常替换无临时文件残留、rename 失败时临时文件被清理、EBUSY 判定、回退写入(内容正确 + 备份删除 + 0o600 权限保留)、回退失败时原内容不变且备份保留;
- 在 user namespace 中用真实 `mount --bind` 复现了 EBUSY 错误,并验证修复后写入成功、内容透写到宿主机文件、无任何 `.tmp`/`.bak` 残留;
- 将修复后的二进制替换进实际的 Flatpak 应用(`com.ccswitch.desktop`)实测:激活/切换配置正常,不再报错。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes(未改动前端代码)
- [x] `pnpm format:check` passes(未改动前端代码)
- [x] `cargo clippy` passes([CI 构建与测试记录](https://github.com/jing2uo/cc-switch/actions/runs/28735713340))
- [x] 无用户可见文本改动,无需更新国际化文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
