### PR TITLE
docs: 新增 Flatpak 安装方式(通过 FlatPark 分发)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,19 @@ Download the latest Linux build from the [Releases](../../releases) page:
 - `CC-Switch-v{version}-Linux.rpm` (Fedora/RHEL/openSUSE)
 - `CC-Switch-v{version}-Linux.AppImage` (Universal)
 
-> **Flatpak**: Not included in official releases. You can build it yourself from the `.deb` — see [`flatpak/README.md`](flatpak/README.md) for instructions.
+**Install via Flatpak**
+
+Available on [FlatPark](https://flatpark.org/apps/com.ccswitch.desktop/):
+
+```bash
+# Add the FlatPark remote (one-time setup)
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+
+# Install CC Switch
+flatpak install flatpark com.ccswitch.desktop
+```
+
+> You can also build the Flatpak yourself from the `.deb` — see [`flatpak/README.md`](flatpak/README.md) for instructions.
 
 <details>
 <summary><strong>Architecture Overview</strong></summary>

--- a/README_DE.md
+++ b/README_DE.md
@@ -379,7 +379,19 @@ Laden Sie den neuesten Linux-Build von der Seite [Releases](../../releases) heru
 - `CC-Switch-v{version}-Linux.rpm` (Fedora/RHEL/openSUSE)
 - `CC-Switch-v{version}-Linux.AppImage` (universell)
 
-> **Flatpak**: Nicht in den offiziellen Releases enthalten. Sie können es selbst aus dem `.deb` bauen — eine Anleitung finden Sie unter [`flatpak/README.md`](flatpak/README.md).
+**Installation über Flatpak**
+
+Verfügbar auf [FlatPark](https://flatpark.org/apps/com.ccswitch.desktop/):
+
+```bash
+# FlatPark-Remote hinzufügen (einmalige Einrichtung)
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+
+# CC Switch installieren
+flatpak install flatpark com.ccswitch.desktop
+```
+
+> Sie können es auch selbst aus dem `.deb` bauen — eine Anleitung finden Sie unter [`flatpak/README.md`](flatpak/README.md).
 
 <details>
 <summary><strong>Architekturüberblick</strong></summary>

--- a/README_JA.md
+++ b/README_JA.md
@@ -379,7 +379,19 @@ paru -S cc-switch-bin
 - `CC-Switch-v{version}-Linux.rpm`（Fedora/RHEL/openSUSE）
 - `CC-Switch-v{version}-Linux.AppImage`（汎用）
 
-> **Flatpak**：公式リリースには含まれていません。`.deb` から自分でビルドできます — 手順は [`flatpak/README.md`](flatpak/README.md) を参照してください。
+**Flatpak でインストール**
+
+[FlatPark](https://flatpark.org/apps/com.ccswitch.desktop/) で公開されています：
+
+```bash
+# FlatPark リモートを追加（初回のみ）
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+
+# CC Switch をインストール
+flatpak install flatpark com.ccswitch.desktop
+```
+
+> `.deb` から自分でビルドすることもできます — 手順は [`flatpak/README.md`](flatpak/README.md) を参照してください。
 
 <details>
 <summary><strong>アーキテクチャ概要</strong></summary>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -382,7 +382,19 @@ paru -S cc-switch-bin
 - `CC-Switch-v{版本号}-Linux.rpm`（Fedora/RHEL/openSUSE）
 - `CC-Switch-v{版本号}-Linux.AppImage`（通用）
 
-> **Flatpak**：官方 Release 不包含 Flatpak 包。如需使用，可从 `.deb` 自行构建 — 参见 [`flatpak/README.md`](flatpak/README.md)。
+**通过 Flatpak 安装**
+
+已上架 [FlatPark](https://flatpark.org/apps/com.ccswitch.desktop/)：
+
+```bash
+# 添加 FlatPark 源（仅需一次）
+flatpak remote-add --if-not-exists flatpark https://dl.flatpark.org/flatpark.flatpakrepo
+
+# 安装 CC Switch
+flatpak install flatpark com.ccswitch.desktop
+```
+
+> 你也可以从 `.deb` 自行构建 Flatpak 包 — 参见 [`flatpak/README.md`](flatpak/README.md)。
 
 <details>
 <summary><strong>架构总览</strong></summary>


### PR DESCRIPTION
## 说明

我维护了 [FlatPark](https://flatpark.org/), 设计使用 extra-data 分发官方二进制, 不对产物做任何修改, 用户安装时会从官方下载。

CC Switch 目前已经上架:https://flatpark.org/apps/com.ccswitch.desktop/

### 为什么不是 Flathub

Flathub 要求开源软件必须从**源码构建**,并且明确**禁止 AI 辅助**参与打包流程,上架门槛较高。FlatPark 的上架流程则非常简单,可以快速把应用提供给用户。

### 对用户的价值

相比让用户自己下载 `.deb` 再手动构建 Flatpak,通过 FlatPark 分发能提供更简单的体验:

- 安装只需一条 `flatpak install` 命令
- **更新自动化**, 会跟随 flatpak update 自动更新, 自己构建还需要安装 flatpak builder 之类的工具
- 沙箱化运行,和系统其他 Flatpak 应用统一管理

### 关于授权

如果你同意这个分发,我会在 FlatPark 上给这个应用标注「开发者授权发布」的蓝色盾牌,表明这是经过官方认可的分发渠道。

本 PR 同步更新了 en / de / ja / zh 四个 README 的安装说明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
