### PR TITLE
[codex] fix SQL backup import after file selection

### DIFF
--- a/src/components/settings/ImportExportSection.tsx
+++ b/src/components/settings/ImportExportSection.tsx
@@ -17,7 +17,6 @@ interface ImportExportSectionProps {
   errorMessage: string | null;
   backupId: string | null;
   isImporting: boolean;
-  onSelectFile: () => Promise<void>;
   onImport: () => Promise<void>;
   onExport: () => Promise<void>;
   onClear: () => void;
@@ -29,7 +28,6 @@ export function ImportExportSection({
   errorMessage,
   backupId,
   isImporting,
-  onSelectFile,
   onImport,
   onExport,
   onClear,
@@ -61,7 +59,7 @@ export function ImportExportSection({
             <Button
               type="button"
               className={`w-full h-auto py-3 px-4 bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white ${selectedFile && !isImporting ? "flex-col items-start" : "items-center"}`}
-              onClick={!selectedFile ? onSelectFile : onImport}
+              onClick={onImport}
               disabled={isImporting}
             >
               <div className="flex items-center gap-2 w-full justify-center">
@@ -73,11 +71,7 @@ export function ImportExportSection({
                   <FolderOpen className="h-4 w-4 flex-shrink-0" />
                 )}
                 <span className="font-medium">
-                  {isImporting
-                    ? t("settings.importing")
-                    : selectedFile
-                      ? t("settings.import")
-                      : t("settings.selectConfigFile")}
+                  {isImporting ? t("settings.importing") : t("settings.import")}
                 </span>
               </div>
               {selectedFile && !isImporting && (

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -98,7 +98,6 @@ export function SettingsPage({
     errorMessage,
     backupId,
     isImporting,
-    selectImportFile,
     importConfig,
     exportConfig,
     clearSelection,
@@ -386,7 +385,6 @@ export function SettingsPage({
                             errorMessage={errorMessage}
                             backupId={backupId}
                             isImporting={isImporting}
-                            onSelectFile={selectImportFile}
                             onImport={importConfig}
                             onExport={exportConfig}
                             onClear={clearSelection}

--- a/src/hooks/useImportExport.ts
+++ b/src/hooks/useImportExport.ts
@@ -66,23 +66,38 @@ export function useImportExport(
   }, [t]);
 
   const importConfig = useCallback(async () => {
-    if (!selectedFile) {
-      toast.error(
-        t("settings.selectFileFailed", {
-          defaultValue: "请选择有效的 SQL 备份文件",
-        }),
-      );
-      return;
+    if (isImporting) return;
+
+    let fileToImport = selectedFile;
+    if (!fileToImport) {
+      try {
+        const filePath = await settingsApi.openFileDialog();
+        if (!filePath) {
+          return;
+        }
+        fileToImport = filePath;
+        setSelectedFile(filePath);
+      } catch (error) {
+        console.error("[useImportExport] Failed to open file dialog", error);
+        toast.error(
+          t("settings.selectFileFailed", {
+            defaultValue: "选择文件失败",
+          }),
+        );
+        return;
+      }
     }
 
-    if (isImporting) return;
+    if (!fileToImport) {
+      return;
+    }
 
     setIsImporting(true);
     setStatus("importing");
     setErrorMessage(null);
 
     try {
-      const result = await settingsApi.importConfigFromFile(selectedFile);
+      const result = await settingsApi.importConfigFromFile(fileToImport);
       if (!result.success) {
         setStatus("error");
         const message =

--- a/src/hooks/useImportExport.ts
+++ b/src/hooks/useImportExport.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { settingsApi } from "@/lib/api";
@@ -39,6 +39,7 @@ export function useImportExport(
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [backupId, setBackupId] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
+  const importInFlightRef = useRef(false);
 
   const clearSelection = useCallback(() => {
     setSelectedFile("");
@@ -66,13 +67,15 @@ export function useImportExport(
   }, [t]);
 
   const importConfig = useCallback(async () => {
-    if (isImporting) return;
+    if (importInFlightRef.current || isImporting) return;
+    importInFlightRef.current = true;
 
     let fileToImport = selectedFile;
     if (!fileToImport) {
       try {
         const filePath = await settingsApi.openFileDialog();
         if (!filePath) {
+          importInFlightRef.current = false;
           return;
         }
         fileToImport = filePath;
@@ -84,11 +87,13 @@ export function useImportExport(
             defaultValue: "选择文件失败",
           }),
         );
+        importInFlightRef.current = false;
         return;
       }
     }
 
     if (!fileToImport) {
+      importInFlightRef.current = false;
       return;
     }
 
@@ -152,6 +157,7 @@ export function useImportExport(
       );
     } finally {
       setIsImporting(false);
+      importInFlightRef.current = false;
     }
   }, [isImporting, onImportSuccess, selectedFile, t]);
 

--- a/tests/components/ImportExportSection.test.tsx
+++ b/tests/components/ImportExportSection.test.tsx
@@ -15,7 +15,6 @@ describe("ImportExportSection Component", () => {
     errorMessage: null,
     backupId: null,
     isImporting: false,
-    onSelectFile: vi.fn(),
     onImport: vi.fn(),
     onExport: vi.fn(),
     onClear: vi.fn(),
@@ -23,28 +22,25 @@ describe("ImportExportSection Component", () => {
 
   beforeEach(() => {
     tMock.mockImplementation((key: string) => key);
-    baseProps.onSelectFile.mockReset();
     baseProps.onImport.mockReset();
     baseProps.onExport.mockReset();
     baseProps.onClear.mockReset();
   });
 
-  it("should disable import button and show placeholder when no file selected", () => {
+  it("should start import from the primary button when no file is selected", () => {
     render(<ImportExportSection {...baseProps} />);
 
-    // When no file selected, button shows "selectConfigFile" and clicking it opens file dialog
-    expect(
-      screen.getByRole("button", { name: /settings\.selectConfigFile/ }),
-    ).toBeInTheDocument();
+    const importButton = screen.getByRole("button", {
+      name: "settings.import",
+    });
+    expect(importButton).toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("button", { name: "settings.exportConfig" }),
     );
     expect(baseProps.onExport).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /settings\.selectConfigFile/ }),
-    );
-    expect(baseProps.onSelectFile).toHaveBeenCalledTimes(1);
+    fireEvent.click(importButton);
+    expect(baseProps.onImport).toHaveBeenCalledTimes(1);
   });
 
   it("should show filename and enable import/clear when file is selected", () => {

--- a/tests/hooks/useImportExport.test.tsx
+++ b/tests/hooks/useImportExport.test.tsx
@@ -74,17 +74,40 @@ describe("useImportExport Hook", () => {
     expect(result.current.status).toBe("idle");
   });
 
-  it("should show error and return early when no file is selected for import", async () => {
-    const { result } = renderHook(() =>
-      useImportExport({ onImportSuccess: vi.fn() }),
-    );
+  it("should open file dialog and import selected file in one action", async () => {
+    openFileDialogMock.mockResolvedValue("/config.sql");
+    importConfigMock.mockResolvedValue({
+      success: true,
+      backupId: "backup-123",
+    });
+    const onImportSuccess = vi.fn();
+    const { result } = renderHook(() => useImportExport({ onImportSuccess }));
 
     await act(async () => {
       await result.current.importConfig();
     });
 
-    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    expect(openFileDialogMock).toHaveBeenCalledTimes(1);
+    expect(importConfigMock).toHaveBeenCalledWith("/config.sql");
+    expect(result.current.selectedFile).toBe("/config.sql");
+    expect(result.current.status).toBe("success");
+    expect(result.current.backupId).toBe("backup-123");
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1);
+    expect(onImportSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep idle state when user cancels import file selection", async () => {
+    openFileDialogMock.mockResolvedValue(null);
+    const { result } = renderHook(() => useImportExport());
+
+    await act(async () => {
+      await result.current.importConfig();
+    });
+
+    expect(openFileDialogMock).toHaveBeenCalledTimes(1);
     expect(importConfigMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(result.current.selectedFile).toBe("");
     expect(result.current.status).toBe("idle");
   });
 

--- a/tests/hooks/useImportExport.test.tsx
+++ b/tests/hooks/useImportExport.test.tsx
@@ -96,6 +96,30 @@ describe("useImportExport Hook", () => {
     expect(onImportSuccess).toHaveBeenCalledTimes(1);
   });
 
+  it("should only open one file dialog while import selection is in flight", async () => {
+    let resolveFileDialog: (filePath: string | null) => void;
+    openFileDialogMock.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveFileDialog = resolve;
+        }),
+    );
+    importConfigMock.mockResolvedValue({ success: true });
+    const { result } = renderHook(() => useImportExport());
+
+    const firstImport = result.current.importConfig();
+    const secondImport = result.current.importConfig();
+
+    expect(openFileDialogMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFileDialog!("/config.sql");
+      await Promise.all([firstImport, secondImport]);
+    });
+
+    expect(importConfigMock).toHaveBeenCalledTimes(1);
+  });
+
   it("should keep idle state when user cancels import file selection", async () => {
     openFileDialogMock.mockResolvedValue(null);
     const { result } = renderHook(() => useImportExport());

--- a/tests/integration/SettingsDialog.test.tsx
+++ b/tests/integration/SettingsDialog.test.tsx
@@ -97,7 +97,6 @@ vi.mock("@/components/settings/ImportExportSection", () => ({
     selectedFile,
     errorMessage,
     isImporting,
-    onSelectFile,
     onImport,
     onExport,
     onClear,
@@ -105,8 +104,7 @@ vi.mock("@/components/settings/ImportExportSection", () => ({
     <div>
       <div data-testid="import-status">{status}</div>
       <div data-testid="selected-file">{selectedFile || "none"}</div>
-      <button onClick={onSelectFile}>settings.selectConfigFile</button>
-      <button onClick={onImport} disabled={!selectedFile || isImporting}>
+      <button onClick={onImport} disabled={isImporting}>
         {isImporting ? "settings.importing" : "settings.import"}
       </button>
       <button onClick={onExport}>settings.exportConfig</button>
@@ -168,12 +166,6 @@ describe("SettingsPage integration", () => {
 
     fireEvent.click(screen.getByText("settings.tabAdvanced"));
     fireEvent.click(screen.getByText("settings.advanced.data.title"));
-    fireEvent.click(screen.getByText("settings.selectConfigFile"));
-    await waitFor(() =>
-      expect(screen.getByTestId("selected-file").textContent).toContain(
-        "/mock/import-settings.json",
-      ),
-    );
 
     fireEvent.click(screen.getByText("settings.import"));
     await waitFor(() => expect(toastSuccessMock).toHaveBeenCalled());


### PR DESCRIPTION
## Summary / 概述

This PR makes the Advanced Settings SQL import flow start immediately after the user selects a backup file.

Previously, the primary import button first opened the file picker and only changed into an import confirmation button after a file was selected. Users then had to click the same button a second time to actually import the SQL backup. The import button now opens the file picker when needed and imports the selected file in the same action.

## Related Issue / 关联 Issue

Fixes #5017

## Screenshots / 截图

N/A - behavior-only change. The existing settings UI style is preserved.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

## Validation / 验证

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier --check src/components/settings/ImportExportSection.tsx src/components/settings/SettingsPage.tsx src/hooks/useImportExport.ts tests/components/ImportExportSection.test.tsx tests/hooks/useImportExport.test.tsx tests/integration/SettingsDialog.test.tsx`
- `./node_modules/.bin/vitest run tests/hooks/useImportExport.test.tsx tests/hooks/useImportExport.extra.test.tsx tests/components/ImportExportSection.test.tsx tests/components/SettingsDialog.test.tsx tests/integration/SettingsDialog.test.tsx`
- `./node_modules/.bin/vitest run`

Note: `pnpm` script wrappers in this local environment were blocked by pnpm build-script approval prompts, so checks were run through the already-installed local binaries. Full unit tests passed: 65 files, 396 tests.
