### PR TITLE
fix: Anthropic格式上游被误走OpenAI转换导致content_block事件全丢

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,11 +126,21 @@ jobs:
       - name: Prepare Tauri signing key
         shell: bash
         run: |
-          # 调试：检查 Secret 是否存在
+          # 检查 Secret 是否存在；fork 仓库可能未配置签名密钥
           if [ -z "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
-            echo "❌ TAURI_SIGNING_PRIVATE_KEY Secret 为空或不存在" >&2
-            echo "请检查 GitHub 仓库 Settings > Secrets and variables > Actions" >&2
-            exit 1
+            echo "⚠️ TAURI_SIGNING_PRIVATE_KEY Secret 为空或不存在，跳过签名（产物将不带签名和更新器）" >&2
+            echo "NO_SIGNING=1" >> "$GITHUB_ENV"
+            # 无签名密钥时禁用 updater artifacts（否则 Tauri 构建会因缺少密钥而失败）
+            cd src-tauri
+            node -e "
+              const fs = require('fs');
+              const p = 'tauri.conf.json';
+              const c = JSON.parse(fs.readFileSync(p, 'utf8'));
+              c.bundle.createUpdaterArtifacts = false;
+              fs.writeFileSync(p, JSON.stringify(c, null, 2) + '\n');
+              console.log('✅ 已禁用 createUpdaterArtifacts（无签名密钥）');
+            "
+            exit 0
           fi
           
           RAW="${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}"
@@ -180,7 +190,7 @@ jobs:
           echo "✅ Tauri signing key prepared"
 
       - name: Import Apple signing certificate
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && env.NO_SIGNING != '1'
         shell: bash
         run: |
           set -euo pipefail
@@ -222,7 +232,7 @@ jobs:
           rm -f "$CERT_PATH"
 
       - name: Build Tauri App (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && env.NO_SIGNING != '1'
         shell: bash
         timeout-minutes: 60
         env:
@@ -268,7 +278,7 @@ jobs:
         run: pnpm tauri build --bundles appimage,deb,rpm
 
       - name: Prepare macOS Assets
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && env.NO_SIGNING != '1'
         shell: bash
         run: |
           set -euxo pipefail
@@ -343,7 +353,7 @@ jobs:
           echo "✅ Styled DMG created: $NEW_DMG"
 
       - name: Notarize macOS DMG
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && env.NO_SIGNING != '1'
         shell: bash
         timeout-minutes: 30
         env:
@@ -385,7 +395,7 @@ jobs:
           done
 
       - name: Verify macOS code signing and notarization
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && env.NO_SIGNING != '1'
         shell: bash
         run: |
           set -euo pipefail
@@ -567,7 +577,7 @@ jobs:
           find src-tauri/target -maxdepth 4 -type f -name "*.*" 2>/dev/null || true
 
       - name: Clean up Apple signing keychain
-        if: runner.os == 'macOS' && always()
+        if: runner.os == 'macOS' && env.NO_SIGNING != '1' && always()
         shell: bash
         run: |
           if [ -n "${ORIGINAL_DEFAULT_KEYCHAIN:-}" ]; then
@@ -653,6 +663,12 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          # 无签名密钥时没有 .sig 文件，latest.json 无意义，跳过
+          sig_count=$(ls dl/*.sig 2>/dev/null | wc -l || true)
+          if [ "$sig_count" -eq 0 ]; then
+            echo "⚠️ No .sig files found (fork without signing key). Skipping latest.json generation."
+            exit 0
+          fi
           VERSION="${TAG#v}"
           PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           base_url="https://github.com/$REPO/releases/download/$TAG"
@@ -729,4 +745,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
+          if [ ! -f latest.json ]; then
+            echo "⚠️ latest.json not generated (no signing key). Skipping upload."
+            exit 0
+          fi
           gh release upload "$GITHUB_REF_NAME" latest.json --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,9 @@ jobs:
           - os: ubuntu-22.04
           - os: ubuntu-22.04-arm
             arch: arm64
-          - os: macos-14
+          # macOS 已禁用：fork 无 Apple 证书和公证密钥，构建必失败。
+          # 如需启用，取消下一行注释并确保已配置 secrets.APPLE_*
+          # - os: macos-14
 
     steps:
       - name: Checkout
@@ -572,11 +574,12 @@ jobs:
           ls -la release-assets/*.sig || echo "No signatures found"
 
       - name: Upload release artifacts to workflow
+        if: ${{ !(runner.os == 'macOS' && env.NO_SIGNING == '1') }}
         uses: actions/upload-artifact@v7
         with:
           name: release-assets-${{ runner.os }}-${{ matrix.arch || runner.arch }}
           path: release-assets/*
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: List generated bundles (debug)
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -475,7 +475,7 @@ jobs:
             if (Test-Path $sigPath) {
               Copy-Item $sigPath (Join-Path release-assets ("$dest.sig"))
               Write-Host "Signature copied: $dest.sig"
-            } elseif ($isArm64) {
+            } elseif ($isArm64 -and $env:NO_SIGNING -ne '1') {
               throw "Signature not found for $($msi.Name)"
             } else {
               Write-Warning "Signature not found for $($msi.Name)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Prepare safe version tag
+        shell: bash
+        run: |
+          # workflow_dispatch 用分支名触发时，GITHUB_REF_NAME 含 /（如 fix/xxx）
+          # Release tag 不支持 /，替换为 -；tag 触发时（如 v3.5.0）不变
+          SAFE_TAG="${GITHUB_REF_NAME//\//-}"
+          echo "RELEASE_TAG=$SAFE_TAG" >> "$GITHUB_ENV"
+          echo "✅ Release tag: $SAFE_TAG"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -283,7 +292,7 @@ jobs:
         run: |
           set -euxo pipefail
           mkdir -p release-assets
-          VERSION="${GITHUB_REF_NAME}"  # e.g., v3.5.0
+          VERSION="${GITHUB_REF_NAME//\//-}"  # 分支名含/替换为-
 
           # Locate bundle artifacts
           TAR_GZ=""; APP_PATH=""
@@ -447,7 +456,7 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           New-Item -ItemType Directory -Force -Path release-assets | Out-Null
-          $VERSION = $env:GITHUB_REF_NAME  # e.g., v3.5.0
+          $VERSION = $env:GITHUB_REF_NAME -replace '/','-'  # 分支名含/替换为-
           $isArm64 = $env:WINDOWS_RELEASE_ARCH -eq 'arm64'
           $targetRoot = if ($isArm64) { 'src-tauri/target/aarch64-pc-windows-msvc/release' } else { 'src-tauri/target/release' }
           $assetSuffix = if ($isArm64) { '-arm64' } else { '' }
@@ -521,7 +530,7 @@ jobs:
         run: |
           set -euxo pipefail
           mkdir -p release-assets
-          VERSION="${GITHUB_REF_NAME}"  # e.g., v3.5.0
+          VERSION="${GITHUB_REF_NAME//\//-}"  # 分支名含/替换为-
           ARCH="${{ matrix.arch || 'x86_64' }}"
           # Updater artifact: AppImage（含对应 .sig）
           APPIMAGE=$(find src-tauri/target/release/bundle -name "*.AppImage" | head -1 || true)
@@ -610,11 +619,11 @@ jobs:
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
-          name: CC Switch ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: CC Switch ${{ env.RELEASE_TAG }}
           prerelease: true
           body: |
-            ## CC Switch ${{ github.ref_name }}
+            ## CC Switch ${{ env.RELEASE_TAG }}
 
             🌐 **Only Official Website / 唯一官方网站 / 唯一の公式サイト**: [ccswitch.io](https://ccswitch.io)
 
@@ -622,11 +631,11 @@ jobs:
 
             ### 下载
 
-            - **macOS**: `CC-Switch-${{ github.ref_name }}-macOS.dmg`（推荐）或 `CC-Switch-${{ github.ref_name }}-macOS.zip`（解压即用）
-            - **Windows (x86_64)**: `CC-Switch-${{ github.ref_name }}-Windows.msi`（安装版）或 `CC-Switch-${{ github.ref_name }}-Windows-Portable.zip`（绿色版）
-            - **Windows (ARM64)**: `CC-Switch-${{ github.ref_name }}-Windows-arm64.msi`（安装版）或 `CC-Switch-${{ github.ref_name }}-Windows-arm64-Portable.zip`（绿色版）
-            - **Linux (x86_64)**: `CC-Switch-${{ github.ref_name }}-Linux-x86_64.AppImage` / `.deb` / `.rpm`
-            - **Linux (ARM64)**: `CC-Switch-${{ github.ref_name }}-Linux-arm64.AppImage` / `.deb` / `.rpm`
+            - **macOS**: `CC-Switch-${{ env.RELEASE_TAG }}-macOS.dmg`（推荐）或 `CC-Switch-${{ env.RELEASE_TAG }}-macOS.zip`（解压即用）
+            - **Windows (x86_64)**: `CC-Switch-${{ env.RELEASE_TAG }}-Windows.msi`（安装版）或 `CC-Switch-${{ env.RELEASE_TAG }}-Windows-Portable.zip`（绿色版）
+            - **Windows (ARM64)**: `CC-Switch-${{ env.RELEASE_TAG }}-Windows-arm64.msi`（安装版）或 `CC-Switch-${{ env.RELEASE_TAG }}-Windows-arm64-Portable.zip`（绿色版）
+            - **Linux (x86_64)**: `CC-Switch-${{ env.RELEASE_TAG }}-Linux-x86_64.AppImage` / `.deb` / `.rpm`
+            - **Linux (ARM64)**: `CC-Switch-${{ env.RELEASE_TAG }}-Linux-arm64.AppImage` / `.deb` / `.rpm`
 
             > `.tar.gz` 为 Tauri updater 自动更新专用，无需手动下载。
 
@@ -653,7 +662,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${GITHUB_REF_NAME//\//-}"
           mkdir -p dl
           gh release download "$TAG" --dir dl --repo "$GITHUB_REPOSITORY"
           ls -la dl || true
@@ -670,6 +679,7 @@ jobs:
             exit 0
           fi
           VERSION="${TAG#v}"
+          VERSION="${VERSION//\//-}"  # 分支名含/替换为-
           PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           base_url="https://github.com/$REPO/releases/download/$TAG"
           # 初始化空平台映射
@@ -749,4 +759,4 @@ jobs:
             echo "⚠️ latest.json not generated (no signing key). Skipping upload."
             exit 0
           fi
-          gh release upload "$GITHUB_REF_NAME" latest.json --clobber --repo "$GITHUB_REPOSITORY"
+          gh release upload "${GITHUB_REF_NAME//\//-}" latest.json --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - 'fix-*'
   workflow_dispatch:
 
 permissions:

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -156,6 +156,8 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         let mut current_model = None;
         let mut next_content_index: u32 = 0;
         let mut has_sent_message_start = false;
+        // 修复 GLM 5.2 thinking 碎块：一旦输出过 text content，就不再切回 thinking 块
+        let mut has_emitted_text_content = false;
         // 某些上游 provider（如 OpenRouter 的 kimi-k2.6）会在 tool_use 后发送多个
         // 带 finish_reason 的 SSE chunk。Anthropic 协议要求每个消息流只能有一个
         // message_delta，重复会导致 Claude Code abort 连接。因此需要：
@@ -166,6 +168,11 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         let mut has_sent_message_stop = false;
         let mut stream_ended_with_error = false;
         let mut latest_usage: Option<Value> = None;
+        // 修复：检测上游是否已经是 Anthropic 格式（如 bzboy 中转把 OpenAI 转成了 Anthropic）。
+        // 若是，则直接透传原始 SSE 行，不做 OpenAIStreamChunk 反序列化——否则反序列化失败
+        // 会丢弃所有 content_block_start/stop，导致 Claude Code 收到悬空的 thinking 块永不关闭。
+        let mut passthrough_anthropic = false;
+        let mut passthrough_emitted_message_start = false;
         let mut current_non_tool_block_type: Option<&'static str> = None;
         let mut current_non_tool_block_index: Option<u32> = None;
         let mut tool_blocks_by_index: HashMap<usize, ToolBlockState> = HashMap::new();
@@ -203,6 +210,35 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                     log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
                                     yield Ok(Bytes::from(sse_data));
                                     has_sent_message_stop = true;
+                                    continue;
+                                }
+
+                                // 修复：检测上游是否已经是 Anthropic 格式。
+                                // Anthropic 格式特征：data 里有 "type":"message_start" 或
+                                // "type":"content_block_start" 等 Anthropic 专有事件，
+                                // 且没有 OpenAI 的 "choices" 字段。
+                                // 一旦判定为 Anthropic 格式，整条流直接透传原始 SSE 行，
+                                // 跳过 OpenAIStreamChunk 反序列化。
+                                if !passthrough_anthropic {
+                                    if data.contains("\"type\":\"message_start\"")
+                                        || data.contains("\"type\":\"content_block_start\"")
+                                        || data.contains("\"type\":\"content_block_delta\"")
+                                        || data.contains("\"type\":\"content_block_stop\"")
+                                        || data.contains("\"type\":\"message_delta\"")
+                                    {
+                                        passthrough_anthropic = true;
+                                        log::debug!("[Claude/OpenRouter] 检测到上游为Anthropic格式，切换为透传模式");
+                                    }
+                                }
+
+                                if passthrough_anthropic {
+                                    // 透传：原样下发原始 SSE 行，保证 content_block_start/stop 配对完整
+                                    let sse_data = format!("data: {}\n\n", data);
+                                    if !passthrough_emitted_message_start {
+                                        log::debug!("[Claude/OpenRouter] >>> Anthropic SSE(passthrough): {}", data.split(',').next().unwrap_or(""));
+                                        passthrough_emitted_message_start = true;
+                                    }
+                                    yield Ok(Bytes::from(sse_data));
                                     continue;
                                 }
 
@@ -267,52 +303,59 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         }
 
                                         // 处理 reasoning（thinking）
+                                        // 修复：一旦输出过 content（text），就不再切回 thinking 块。
+                                        // Anthropic 原生协议中 thinking 在前、text 在后，不会交错。
+                                        // GLM 5.2 上游会把 reasoning 和 content 频繁交替输出，
+                                        // 若每次交替都切换块类型，会导致大量碎 thought 块 + 文字断字。
                                         if let Some(reasoning) = &choice.delta.reasoning {
-                                            if current_non_tool_block_type != Some("thinking") {
-                                                if let Some(index) = current_non_tool_block_index.take() {
+                                            if !reasoning.is_empty() && !has_emitted_text_content {
+                                                if current_non_tool_block_type != Some("thinking") {
+                                                    if let Some(index) = current_non_tool_block_index.take() {
+                                                        let event = json!({
+                                                            "type": "content_block_stop",
+                                                            "index": index
+                                                        });
+                                                        let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                                            serde_json::to_string(&event).unwrap_or_default());
+                                                        yield Ok(Bytes::from(sse_data));
+                                                    }
+                                                    let index = next_content_index;
+                                                    next_content_index += 1;
                                                     let event = json!({
-                                                        "type": "content_block_stop",
-                                                        "index": index
+                                                        "type": "content_block_start",
+                                                        "index": index,
+                                                        "content_block": {
+                                                            "type": "thinking",
+                                                            "thinking": ""
+                                                        }
                                                     });
-                                                    let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                                    let sse_data = format!("event: content_block_start\ndata: {}\n\n",
+                                                        serde_json::to_string(&event).unwrap_or_default());
+                                                    yield Ok(Bytes::from(sse_data));
+                                                    current_non_tool_block_type = Some("thinking");
+                                                    current_non_tool_block_index = Some(index);
+                                                }
+
+                                                if let Some(index) = current_non_tool_block_index {
+                                                    let event = json!({
+                                                        "type": "content_block_delta",
+                                                        "index": index,
+                                                        "delta": {
+                                                            "type": "thinking_delta",
+                                                            "thinking": reasoning
+                                                        }
+                                                    });
+                                                    let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
                                                         serde_json::to_string(&event).unwrap_or_default());
                                                     yield Ok(Bytes::from(sse_data));
                                                 }
-                                                let index = next_content_index;
-                                                next_content_index += 1;
-                                                let event = json!({
-                                                    "type": "content_block_start",
-                                                    "index": index,
-                                                    "content_block": {
-                                                        "type": "thinking",
-                                                        "thinking": ""
-                                                    }
-                                                });
-                                                let sse_data = format!("event: content_block_start\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
-                                                current_non_tool_block_type = Some("thinking");
-                                                current_non_tool_block_index = Some(index);
-                                            }
-
-                                            if let Some(index) = current_non_tool_block_index {
-                                                let event = json!({
-                                                    "type": "content_block_delta",
-                                                    "index": index,
-                                                    "delta": {
-                                                        "type": "thinking_delta",
-                                                        "thinking": reasoning
-                                                    }
-                                                });
-                                                let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
                                             }
                                         }
 
                                         // 处理文本内容
                                         if let Some(content) = &choice.delta.content {
                                             if !content.is_empty() {
+                                                has_emitted_text_content = true;
                                                 if current_non_tool_block_type != Some("text") {
                                                     if let Some(index) = current_non_tool_block_index.take() {
                                                         let event = json!({

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -145,6 +145,75 @@ fn build_message_delta_event(stop_reason: Option<String>, usage_json: Option<Val
     })
 }
 
+fn finalize_open_tool_blocks(
+    tool_blocks_by_index: &mut HashMap<usize, ToolBlockState>,
+    open_tool_block_indices: &mut HashSet<u32>,
+) -> Vec<Value> {
+    let mut events = Vec::new();
+    let mut late_tool_starts = Vec::new();
+
+    for (tool_idx, state) in tool_blocks_by_index.iter_mut() {
+        if state.started {
+            continue;
+        }
+        let has_payload =
+            !state.pending_args.is_empty() || !state.id.is_empty() || !state.name.is_empty();
+        if !has_payload {
+            continue;
+        }
+
+        let fallback_id = if state.id.is_empty() {
+            format!("tool_call_{tool_idx}")
+        } else {
+            state.id.clone()
+        };
+        let fallback_name = if state.name.is_empty() {
+            "unknown_tool".to_string()
+        } else {
+            state.name.clone()
+        };
+        state.started = true;
+        let pending = std::mem::take(&mut state.pending_args);
+        late_tool_starts.push((state.anthropic_index, fallback_id, fallback_name, pending));
+    }
+
+    late_tool_starts.sort_unstable_by_key(|(index, _, _, _)| *index);
+    for (index, id, name, pending) in late_tool_starts {
+        events.push(json!({
+            "type": "content_block_start",
+            "index": index,
+            "content_block": {
+                "type": "tool_use",
+                "id": id,
+                "name": name
+            }
+        }));
+        open_tool_block_indices.insert(index);
+
+        if !pending.is_empty() {
+            events.push(json!({
+                "type": "content_block_delta",
+                "index": index,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": pending
+                }
+            }));
+        }
+    }
+
+    let mut tool_indices: Vec<u32> = open_tool_block_indices.iter().copied().collect();
+    tool_indices.sort_unstable();
+    for index in tool_indices {
+        events.push(json!({
+            "type": "content_block_stop",
+            "index": index
+        }));
+    }
+    open_tool_block_indices.clear();
+    events
+}
+
 /// 创建 Anthropic SSE 流
 pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
     stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
@@ -194,6 +263,58 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                             if let Some(data) = strip_sse_field(l, "data") {
                                 if data.trim() == "[DONE]" {
                                     log::debug!("[Claude/OpenRouter] <<< OpenAI SSE: [DONE]");
+                                    if has_sent_message_stop {
+                                        continue;
+                                    }
+
+                                    // DeepSeek 可能在最后一个有效 finish_reason 前发送空值；只有真实结束时才发送终止事件。
+                                    let inferred_stop_reason = if pending_message_delta.is_none()
+                                        && has_sent_message_start
+                                    {
+                                        let has_tool_payload = !open_tool_block_indices.is_empty()
+                                            || tool_blocks_by_index.values().any(|state| {
+                                                state.started
+                                                    || !state.pending_args.is_empty()
+                                                    || !state.id.is_empty()
+                                                    || !state.name.is_empty()
+                                            });
+                                        Some(if has_tool_payload { "tool_use" } else { "end_turn" }.to_string())
+                                    } else {
+                                        None
+                                    };
+
+                                    if let Some(index) = current_non_tool_block_index.take() {
+                                        let event = json!({
+                                            "type": "content_block_stop",
+                                            "index": index
+                                        });
+                                        let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                            serde_json::to_string(&event).unwrap_or_default());
+                                        yield Ok(Bytes::from(sse_data));
+                                    }
+                                    current_non_tool_block_type = None;
+
+                                    for event in finalize_open_tool_blocks(
+                                        &mut tool_blocks_by_index,
+                                        &mut open_tool_block_indices,
+                                    ) {
+                                        let event_type = event
+                                            .get("type")
+                                            .and_then(Value::as_str)
+                                            .unwrap_or("content_block_delta");
+                                        let sse_data = format!("event: {event_type}\ndata: {}\n\n",
+                                            serde_json::to_string(&event).unwrap_or_default());
+                                        yield Ok(Bytes::from(sse_data));
+                                    }
+
+                                    if pending_message_delta.is_none() {
+                                        if let Some(stop_reason) = inferred_stop_reason {
+                                            pending_message_delta = Some((
+                                                Some(stop_reason),
+                                                latest_usage.clone(),
+                                            ));
+                                        }
+                                    }
 
                                     // 流正常结束，发出缓存的 message_delta（含完整 usage）。
                                     if let Some((stop_reason, usage_json)) = pending_message_delta.take() {
@@ -204,12 +325,14 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         yield Ok(Bytes::from(sse_data));
                                     }
 
-                                    let event = json!({"type": "message_stop"});
-                                    let sse_data = format!("event: message_stop\ndata: {}\n\n",
-                                        serde_json::to_string(&event).unwrap_or_default());
-                                    log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
-                                    yield Ok(Bytes::from(sse_data));
-                                    has_sent_message_stop = true;
+                                    if !has_sent_message_stop {
+                                        let event = json!({"type": "message_stop"});
+                                        let sse_data = format!("event: message_stop\ndata: {}\n\n",
+                                            serde_json::to_string(&event).unwrap_or_default());
+                                        log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_stop");
+                                        yield Ok(Bytes::from(sse_data));
+                                        has_sent_message_stop = true;
+                                    }
                                     continue;
                                 }
 
@@ -557,8 +680,7 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         // 注意：OpenRouter 某些 provider 会发送多个带 finish_reason 的 chunk
                                         // （第一个 usage 为 null，后续才补全）。此处只做缓存，不立即发送，
                                         // 等到 [DONE] 或流末尾再统一发出，确保 usage 完整且只发一次。
-                                        if let Some(finish_reason) = &choice.finish_reason {
-                                            let stop_reason = map_stop_reason(Some(finish_reason));
+                                        if let Some(stop_reason) = map_stop_reason(choice.finish_reason.as_deref()) {
                                             let usage_json =
                                                 chunk_usage_json.clone().or_else(|| latest_usage.clone());
 
@@ -661,7 +783,7 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                             }
 
                                             // 缓存 message_delta，等到 [DONE] 时发送（以便收集完整的 usage）
-                                            pending_message_delta = Some((stop_reason, usage_json));
+                                            pending_message_delta = Some((Some(stop_reason), usage_json));
                                         }
                                     }
                                 }
@@ -742,8 +864,13 @@ fn extract_cache_write_tokens(usage: &Usage) -> Option<u32> {
 
 /// 映射停止原因
 fn map_stop_reason(finish_reason: Option<&str>) -> Option<String> {
-    finish_reason.map(|r| {
-        match r {
+    let reason = finish_reason?.trim();
+    if reason.is_empty() {
+        return None;
+    }
+
+    Some(
+        match reason {
             "tool_calls" | "function_call" => "tool_use",
             "stop" => "end_turn",
             "length" => "max_tokens",
@@ -753,8 +880,8 @@ fn map_stop_reason(finish_reason: Option<&str>) -> Option<String> {
                 "end_turn"
             }
         }
-        .to_string()
-    })
+        .to_string(),
+    )
 }
 
 #[cfg(test)]
@@ -801,6 +928,106 @@ mod tests {
             map_stop_reason(Some("content_filter")),
             Some("end_turn".to_string())
         );
+    }
+
+    #[test]
+    fn test_map_stop_reason_ignores_empty_values() {
+        assert_eq!(map_stop_reason(None), None);
+        assert_eq!(map_stop_reason(Some("")), None);
+        assert_eq!(map_stop_reason(Some("  ")), None);
+    }
+
+    #[tokio::test]
+    async fn test_deepseek_empty_finish_reason_keeps_reasoning_and_text_open() {
+        let input = concat!(
+            "data: {\"id\":\"deepseek_1\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"delta\":{\"reasoning_content\":\"先思考\"},\"finish_reason\":\"\"}]}\n\n",
+            "data: {\"id\":\"deepseek_1\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"delta\":{\"content\":\"最终答案\"},\"finish_reason\":\"\"}]}\n\n",
+            "data: {\"id\":\"deepseek_1\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let events = collect_anthropic_events(input).await;
+
+        let block_starts: Vec<&Value> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .collect();
+        assert_eq!(block_starts.len(), 2);
+        assert_eq!(block_starts[0]["content_block"]["type"], "thinking");
+        assert_eq!(block_starts[1]["content_block"]["type"], "text");
+
+        let block_stops: Vec<u64> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_stop"))
+            .filter_map(|event| event["index"].as_u64())
+            .collect();
+        assert_eq!(block_stops, vec![0, 1]);
+
+        assert!(events.iter().any(|event| {
+            event_type(event) == Some("message_delta")
+                && event["delta"]["stop_reason"] == "end_turn"
+        }));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event_type(event) == Some("message_stop"))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deepseek_empty_finish_reason_does_not_end_truncated_stream() {
+        let input = concat!(
+            "data: {\"id\":\"deepseek_2\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"delta\":{\"reasoning_content\":\"未完成\"},\"finish_reason\":\"\"}]}\n\n"
+        );
+        let events = collect_anthropic_events(input).await;
+
+        assert!(!events
+            .iter()
+            .any(|event| event_type(event) == Some("message_delta")));
+        assert!(!events
+            .iter()
+            .any(|event| event_type(event) == Some("message_stop")));
+    }
+
+    #[tokio::test]
+    async fn test_deepseek_reasoning_to_tool_call_closes_blocks_in_order() {
+        let input = concat!(
+            "data: {\"id\":\"deepseek_3\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"delta\":{\"reasoning_content\":\"准备调用\"},\"finish_reason\":\"\"}]}\n\n",
+            "data: {\"id\":\"deepseek_3\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_0\",\"type\":\"function\",\"function\":{\"name\":\"Edit\",\"arguments\":\"{}\"}}]},\"finish_reason\":\"\"}]}\n\n",
+            "data: {\"id\":\"deepseek_3\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let events = collect_anthropic_events(input).await;
+
+        let stops: Vec<u64> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_stop"))
+            .filter_map(|event| event["index"].as_u64())
+            .collect();
+        assert_eq!(stops, vec![0, 1]);
+        assert!(events.iter().any(|event| {
+            event_type(event) == Some("message_delta")
+                && event["delta"]["stop_reason"] == "tool_use"
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_done_closes_open_thinking_block_before_message_stop() {
+        let input = concat!(
+            "data: {\"id\":\"deepseek_4\",\"model\":\"deepseek-v4-flash\",\"choices\":[{\"delta\":{\"reasoning_content\":\"完成\"},\"finish_reason\":\"\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let events = collect_anthropic_events(input).await;
+        let stop_index = events
+            .iter()
+            .position(|event| event_type(event) == Some("message_stop"))
+            .unwrap();
+        let block_stop_index = events
+            .iter()
+            .position(|event| event_type(event) == Some("content_block_stop"))
+            .unwrap();
+        assert!(block_stop_index < stop_index);
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -242,6 +242,9 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         // 会丢弃所有 content_block_start/stop，导致 Claude Code 收到悬空的 thinking 块永不关闭。
         let mut passthrough_anthropic = false;
         let mut passthrough_emitted_message_start = false;
+        // 空thinking过滤：缓存最近一次 content_block_start(thinking)，若后一个事件是
+        // content_block_stop（中间无 thinking_delta），则丢弃这对事件，抑制空thinking碎块
+        let mut pending_empty_thinking_start: Option<String> = None;
         let mut current_non_tool_block_type: Option<&'static str> = None;
         let mut current_non_tool_block_index: Option<u32> = None;
         let mut tool_blocks_by_index: HashMap<usize, ToolBlockState> = HashMap::new();
@@ -263,6 +266,8 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                             if let Some(data) = strip_sse_field(l, "data") {
                                 if data.trim() == "[DONE]" {
                                     log::debug!("[Claude/OpenRouter] <<< OpenAI SSE: [DONE]");
+                                    // 流结束：丢弃未决的空 thinking start（无尾随 stop 的空块不输出）
+                                    pending_empty_thinking_start = None;
                                     if has_sent_message_stop {
                                         continue;
                                     }
@@ -355,7 +360,38 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                 }
 
                                 if passthrough_anthropic {
-                                    // 透传：原样下发原始 SSE 行，保证 content_block_start/stop 配对完整
+                                    // 透传：原样下发原始 SSE 行，保证 content_block_start/stop 配对完整。
+                                    // 空 thinking 过滤：若上一个事件被标记为"空 thinking 块 start"、
+                                    // 当前事件紧跟 content_block_stop（中间无 thinking_delta），则丢弃这对事件。
+                                    if let Some(pending_start) = pending_empty_thinking_start.take() {
+                                        let current_is_stop = data.contains("\"type\":\"content_block_stop\"");
+                                        if current_is_stop {
+                                            // 空 start + 紧跟的 stop（中间无 delta）→ 丢弃这对事件
+                                            log::debug!("[Claude/OpenRouter] >>> 过滤空thinking块 (start+stop无delta)");
+                                            continue;
+                                        }
+                                        // 当前不是 stop（是 thinking_delta 等）→ 空 start 实为正常块开头，先输出缓存的 start
+                                        let pending_sse = format!("data: {}\n\n", pending_start);
+                                        if !passthrough_emitted_message_start {
+                                            log::debug!("[Claude/OpenRouter] >>> Anthropic SSE(passthrough): {}", pending_sse.split(',').next().unwrap_or(""));
+                                            passthrough_emitted_message_start = true;
+                                        }
+                                        yield Ok(Bytes::from(pending_sse));
+                                    }
+
+                                    // 检测当前是否为"空 thinking 块 start"：type=thinking 且 thinking 为空字符串。
+                                    // 采用宽松匹配（thinking:" " 含空字符串），避免误判有内容块。
+                                    let is_empty_thinking_start = data.contains("\"type\":\"content_block_start\"")
+                                        && data.contains("\"type\":\"thinking\"")
+                                        && (data.contains("\"thinking\":\"\"") || data.contains("\"thinking\": \"\""));
+                                    if is_empty_thinking_start {
+                                        // 缓存空 start，等待下一个事件决定去留：
+                                        // - 下个事件若是 stop → 放弃了（空块）
+                                        // - 下个事件若是非 stop → 正常块开头，先输出缓存的 start
+                                        pending_empty_thinking_start = Some(data.to_string());
+                                        continue;
+                                    }
+
                                     let sse_data = format!("data: {}\n\n", data);
                                     if !passthrough_emitted_message_start {
                                         log::debug!("[Claude/OpenRouter] >>> Anthropic SSE(passthrough): {}", data.split(',').next().unwrap_or(""));
@@ -1514,5 +1550,51 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_anthropic_filters_empty_thinking_start_stop_pair() {
+        // 上游已是 Anthropic 格式（passthrough 模式），发送含空 thinking 块：
+        // start(thinking="") + stop 之间无 delta → 应被过滤（只能输出 message_start 等）。
+        let input = concat!(
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"m1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"m\"}}\n\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"hello\"}}\n\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"world\"}}\n\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n",
+            "data: {\"type\":\"message_stop\"}\n\n"
+        );
+        let events = collect_anthropic_events(input).await;
+
+        // 不应出现 thinking 类型的块
+        assert!(!events.iter().any(|e| {
+            e.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                && e.pointer("/content_block/type").and_then(|v| v.as_str()) == Some("thinking")
+        }));
+        // text 内容保留
+        assert!(events.iter().any(|e| {
+            e.get("type").and_then(|v| v.as_str()) == Some("content_block_delta")
+                && e.pointer("/delta/type").and_then(|v| v.as_str()) == Some("text_delta")
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_passthrough_anthropic_keeps_non_empty_thinking() {
+        // 有内容的 thinking 块不能被过滤
+        let input = concat!(
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"m2\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"m\"}}\n\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"实际推理\"}}\n\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+            "data: {\"type\":\"message_stop\"}\n\n"
+        );
+        let events = collect_anthropic_events(input).await;
+
+        assert!(events.iter().any(|e| {
+            e.get("type").and_then(|v| v.as_str()) == Some("content_block_start")
+                && e.pointer("/content_block/type").and_then(|v| v.as_str()) == Some("thinking")
+        }));
     }
 }

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -1382,10 +1382,7 @@ mod tests {
     #[test]
     fn test_non_empty_thinking_not_filtered() {
         let data = r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"实际推理内容"}}"#;
-        assert!(
-            !is_empty_thinking_event(data),
-            "非空thinking不应被过滤"
-        );
+        assert!(!is_empty_thinking_event(data), "非空thinking不应被过滤");
     }
 
     #[test]
@@ -1399,20 +1396,15 @@ mod tests {
 
     #[test]
     fn test_text_content_not_filtered() {
-        let data = r#"{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#;
-        assert!(
-            !is_empty_thinking_event(data),
-            "text block不应被过滤"
-        );
+        let data =
+            r#"{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#;
+        assert!(!is_empty_thinking_event(data), "text block不应被过滤");
     }
 
     #[test]
     fn test_text_delta_not_filtered() {
         let data = r#"{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"你好"}}"#;
-        assert!(
-            !is_empty_thinking_event(data),
-            "text_delta不应被过滤"
-        );
+        assert!(!is_empty_thinking_event(data), "text_delta不应被过滤");
     }
 
     #[test]
@@ -1427,10 +1419,7 @@ mod tests {
     #[test]
     fn test_message_start_not_filtered() {
         let data = r#"{"type":"message_start","message":{"id":"chatcmpl-xxx","type":"message","role":"assistant","model":"glm-5.2"}}"#;
-        assert!(
-            !is_empty_thinking_event(data),
-            "message_start不应被过滤"
-        );
+        assert!(!is_empty_thinking_event(data), "message_start不应被过滤");
     }
 
     #[test]

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -680,21 +680,33 @@ async fn log_usage_internal(
 }
 
 /// 检查单个 SSE data JSON 是否为空的 thinking/thinking_delta 事件
+///
+/// 检测逻辑：
+/// - content_block_start(type="thinking", thinking="")：空 thinking 块起始，需要被状态机过滤。
+///   注意：状态机同时会跳过紧跟的 content_block_stop，实现"start 后紧跟 stop 且中间无 delta"
+///   的精准过滤——不会误伤有内容 thinking 块。
+/// - content_block_delta 中 thinking_delta 为空：只需检测 start。
 fn is_empty_thinking_event(data: &str) -> bool {
     if let Ok(json) = serde_json::from_str::<Value>(data) {
         let event_type = json.get("type").and_then(|v| v.as_str()).unwrap_or("");
         match event_type {
-            // 注意：content_block_start(thinking="") 是 Anthropic 协议的正常块起始事件，
-            // thinking 字段初始为空、后续由 thinking_delta 填充。
-            // 之前误把这种 start 当作"空 thinking 碎块"过滤，会导致 Claude Code
-            // 收到 thinking_delta 却没有对应 content_block_start，整个 thought 块丢失。
-            // 因此 content_block_start 一律不过滤，空 thinking 块由"start 后紧跟 stop
-            // 且中间无 delta"的状态机逻辑在 create_logged_passthrough_stream 中精准处理。
-            "content_block_start" => false,
+            "content_block_start" => {
+                // 空 thinking 块起始：type="thinking" 且 thinking 字段为空（或不存在），
+                // 且没有 signature（有 signature 的 redacted thinking 块非空）。
+                json.pointer("/content_block/type").and_then(|v| v.as_str()) == Some("thinking")
+                    && json
+                        .pointer("/content_block/thinking")
+                        .and_then(|v| v.as_str())
+                        .map(|t| t.is_empty())
+                        .unwrap_or(true)
+                    && json
+                        .pointer("/content_block/signature")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.is_empty())
+                        .unwrap_or(true)
+            }
             "content_block_delta" => {
-                // 空 thinking_delta（thinking=""）本身无害，Claude Code 收到即为无操作；
-                // 而过滤它反而可能打乱 thinking 块的 start/delta/stop 结构。
-                // 因此空 thinking_delta 一律放行，由 Claude Code 自行处理。
+                // 空 thinking_delta 本身无害，由 Claude Code 自行处理
                 false
             }
             _ => false,
@@ -702,6 +714,63 @@ fn is_empty_thinking_event(data: &str) -> bool {
     } else {
         false
     }
+}
+
+/// 截断 Responses API 类事件（response.created/in_progress/completed/succeeded/failed）
+/// 中的超大字段，防止盲传上游回显的完整 instructions（Claude Code 系统提示可达数
+/// 百 KB）导致下游 SSE JSON 解析失败（422 invalid SSE data JSON）。
+///
+/// 只裁剪：instructions（顶层字符串）、response.instructions（response 对象内）、
+/// response.input（response 对象内的对话历史）。保留其余字段以保证客户端所需的
+/// id/status/model/output/usage 等信息完整。若 JSON 解析失败则原样返回。
+fn trim_oversized_responses_fields(data: &str) -> String {
+    let Ok(mut value) = serde_json::from_str::<Value>(data) else {
+        return data.to_string();
+    };
+    let Some(event_type) = value.get("type").and_then(|v| v.as_str()) else {
+        return data.to_string();
+    };
+    // 只有 Responses API 类事件才裁剪；Anthropic 格式事件（message_start 等）不动。
+    let is_responses_event = event_type == "response.created"
+        || event_type == "response.in_progress"
+        || event_type == "response.completed"
+        || event_type == "response.succeeded"
+        || event_type == "response.failed"
+        || event_type == "response.incomplete"
+        || event_type == "response.queued"
+        || event_type == "response.output_item.done"
+        || event_type == "response.output_item.added";
+    // 若 data 无 type 字段，尝试从 event 行回退（部分兼容网关只有 event: 行）
+    // 这里假设调用者已在 event_text 层提取了 type，data 本身总是有 type 字段
+    if !is_responses_event {
+        return data.to_string();
+    }
+
+    let mut changed = false;
+    // 顶层 instructions
+    if let Some(obj) = value.as_object_mut() {
+        if obj.remove("instructions").is_some() {
+            changed = true;
+        }
+        if obj.remove("input").is_some() {
+            changed = true;
+        }
+    }
+    // response 对象内的 instructions/input
+    if let Some(resp) = value.get_mut("response") {
+        if let Some(obj) = resp.as_object_mut() {
+            if obj.remove("instructions").is_some() {
+                changed = true;
+            }
+            if obj.remove("input").is_some() {
+                changed = true;
+            }
+        }
+    }
+    if !changed {
+        return data.to_string();
+    }
+    serde_json::to_string(&value).unwrap_or_else(|_| data.to_string())
 }
 
 /// 创建带日志记录、超时控制和空thinking块过滤的透传流
@@ -713,172 +782,201 @@ pub fn create_logged_passthrough_stream(
     connection_guard: Option<ActiveConnectionGuard>,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     async_stream::stream! {
-        let _conn_guard = connection_guard;
-        let mut buffer = String::new();
-        let mut utf8_remainder: Vec<u8> = Vec::new();
-        let mut collector = usage_collector;
-        let mut finish_guard = collector.clone().map(SseUsageFinishGuard::new);
-        let debug_enabled = log::log_enabled!(log::Level::Debug);
-        let mut is_first_chunk = true;
-        // 空thinking过滤状态：跟踪是否正在跳过空的thinking块
-        let mut skipping_empty_thinking = false;
+            let _conn_guard = connection_guard;
+            let mut buffer = String::new();
+            let mut utf8_remainder: Vec<u8> = Vec::new();
+            let mut collector = usage_collector;
+            let mut finish_guard = collector.clone().map(SseUsageFinishGuard::new);
+            let debug_enabled = log::log_enabled!(log::Level::Debug);
+            let mut is_first_chunk = true;
+            // 空thinking过滤：缓存最近一次 content_block_start(thinking)，若后一个事件是
+            // content_block_stop（中间无 thinking_delta），则丢弃这对事件，抑制空thinking碎块。
+            // 若后续是 thinking_delta，则是正常块开头，先输出缓存的 start 再处理 delta。
+            let mut pending_empty_thinking_start: Option<String> = None;
 
-        // 超时配置
-        let first_byte_timeout = if timeout_config.first_byte_timeout > 0 {
-            Some(Duration::from_secs(timeout_config.first_byte_timeout))
-        } else {
-            None
-        };
-        let idle_timeout = if timeout_config.idle_timeout > 0 {
-            Some(Duration::from_secs(timeout_config.idle_timeout))
-        } else {
-            None
-        };
-
-        tokio::pin!(stream);
-
-        loop {
-            let timeout_duration = if is_first_chunk {
-                first_byte_timeout
+            // 超时配置
+            let first_byte_timeout = if timeout_config.first_byte_timeout > 0 {
+                Some(Duration::from_secs(timeout_config.first_byte_timeout))
             } else {
-                idle_timeout
+                None
+            };
+            let idle_timeout = if timeout_config.idle_timeout > 0 {
+                Some(Duration::from_secs(timeout_config.idle_timeout))
+            } else {
+                None
             };
 
-            let chunk_result = match timeout_duration {
-                Some(duration) => {
-                    match tokio::time::timeout(duration, stream.next()).await {
-                        Ok(Some(chunk)) => Some(chunk),
-                        Ok(None) => None,
-                        Err(_) => {
-                            let timeout_type = if is_first_chunk { "首字节" } else { "静默期" };
-                            log::error!("[{tag}] 流式响应{}超时 ({}秒)", timeout_type, duration.as_secs());
-                            yield Err(std::io::Error::other(format!("流式响应{timeout_type}超时")));
-                            break;
-                        }
-                    }
-                }
-                None => stream.next().await,
-            };
+            tokio::pin!(stream);
 
-            match chunk_result {
-                Some(Ok(bytes)) => {
-                    if is_first_chunk {
-                        log::debug!(
-                            "[{tag}] 已接收上游流式首包: bytes={}",
-                            bytes.len()
-                        );
-                    }
-                    is_first_chunk = false;
+            loop {
+                let timeout_duration = if is_first_chunk {
+                    first_byte_timeout
+                } else {
+                    idle_timeout
+                };
 
-                    // 始终进行SSE解析，不再仅用于debug
-                    crate::proxy::sse::append_utf8_safe(&mut buffer, &mut utf8_remainder, &bytes);
-
-                    // 安全阀：若buffer超过128KB仍未提取到SSE块，说明非SSE响应（如错误JSON），
-                    // 直接透传原始buffer内容，防止内存泄漏
-                    const MAX_SSE_BUFFER: usize = 128 * 1024;
-                    if buffer.len() > MAX_SSE_BUFFER {
-                        log::warn!(
-                            "[{tag}] SSE buffer超过{}KB仍未收到完整事件，作为非SSE响应透传",
-                            MAX_SSE_BUFFER / 1024
-                        );
-                        yield Ok(Bytes::from(buffer.clone().into_bytes()));
-                        buffer.clear();
-                        continue;
-                    }
-
-                    // 解析完整的SSE事件并按需过滤
-                    while let Some(event_text) = take_sse_block(&mut buffer) {
-                        if event_text.trim().is_empty() {
-                            continue;
-                        }
-
-                        let mut should_yield = true;
-
-                        // 检查每个data行是否为空的thinking事件
-                        for line in event_text.lines() {
-                            if let Some(data) = strip_sse_field(line, "data") {
-                                if data.trim() == "[DONE]" {
-                                    if debug_enabled {
-                                        log::debug!("[{tag}] <<< SSE: [DONE]");
-                                    }
-                                    should_yield = true;
-                                    skipping_empty_thinking = false;
-                                    break;
-                                }
-
-                                if is_empty_thinking_event(data) {
-                                    // 遇到空thinking事件：标记跳过状态
-                                    skipping_empty_thinking = true;
-                                    should_yield = false;
-                                    if debug_enabled {
-                                        log::debug!("[{tag}] [FILTER] 过滤空thinking事件: {data}");
-                                    }
-                                } else if skipping_empty_thinking
-                                    && data.contains("\"type\":\"content_block_stop\"")
-                                {
-                                    // 紧跟空thinking的content_block_stop也跳过
-                                    skipping_empty_thinking = false;
-                                    should_yield = false;
-                                    if debug_enabled {
-                                        log::debug!("[{tag}] [FILTER] 过滤空thinking的stop事件");
-                                    }
-                                } else {
-                                    // 正常事件：结束跳过状态
-                                    skipping_empty_thinking = false;
-                                    should_yield = true;
-
-                                    // usage收集和debug日志（原逻辑）
-                                    let collected = match &collector {
-                                        Some(c) if c.should_collect(data) => {
-                                            match serde_json::from_str::<Value>(data) {
-                                                Ok(json_value) => {
-                                                    c.push(json_value).await;
-                                                    true
-                                                }
-Err(_) => false,
-                                            }
-                                        }
-                                        _ => false,
-                                    };
-                                    log::trace!(
-                                        "[{tag}] <<< SSE data: bytes={}, usage_collected={collected} (content omitted)",
-                                        data.len()
-                                    );
-                                        } else {
-                                            log::debug!("[{tag}] <<< SSE 数据: {data}");
-                                        }
-                                    }
-                                }
+                let chunk_result = match timeout_duration {
+                    Some(duration) => {
+                        match tokio::time::timeout(duration, stream.next()).await {
+                            Ok(Some(chunk)) => Some(chunk),
+                            Ok(None) => None,
+                            Err(_) => {
+                                let timeout_type = if is_first_chunk { "首字节" } else { "静默期" };
+                                log::error!("[{tag}] 流式响应{}超时 ({}秒)", timeout_type, duration.as_secs());
+                                yield Err(std::io::Error::other(format!("流式响应{timeout_type}超时")));
                                 break;
                             }
                         }
+                    }
+                    None => stream.next().await,
+                };
 
-                        if should_yield {
-                            // 重建SSE块并输出
-                            let mut block_bytes = event_text.into_bytes();
-                            block_bytes.extend_from_slice(b"\n\n");
-                            yield Ok(Bytes::from(block_bytes));
+                match chunk_result {
+                    Some(Ok(bytes)) => {
+                        if is_first_chunk {
+                            log::debug!(
+                                "[{tag}] 已接收上游流式首包: bytes={}",
+                                bytes.len()
+                            );
+                        }
+                        is_first_chunk = false;
+
+                        // 始终进行SSE解析，不再仅用于debug
+                        crate::proxy::sse::append_utf8_safe(&mut buffer, &mut utf8_remainder, &bytes);
+
+                        // 安全阀：若buffer超过1MB仍未提取到SSE块，说明非SSE响应（如错误JSON），
+                        // 直接透传原始buffer内容，防止内存泄漏
+                        const MAX_SSE_BUFFER: usize = 1024 * 1024;
+                        if buffer.len() > MAX_SSE_BUFFER {
+                            log::warn!(
+                                "[{tag}] SSE buffer超过{}KB仍未收到完整事件，作为非SSE响应透传",
+                                MAX_SSE_BUFFER / 1024
+                            );
+                            yield Ok(Bytes::from(buffer.clone().into_bytes()));
+                            buffer.clear();
+                            continue;
+                        }
+
+                        // 解析完整的SSE事件并按需过滤
+                        while let Some(event_text) = take_sse_block(&mut buffer) {
+                            if event_text.trim().is_empty() {
+                                continue;
+                            }
+
+                            let mut should_yield = true;
+                            // 裁剪 Responses API 类事件中的超大回显字段（instructions/input）
+                            let mut trimmed_data: Option<String> = None;
+
+                            // 检查每个data行是否为空的thinking事件
+                            for line in event_text.lines() {
+                                if let Some(data) = strip_sse_field(line, "data") {
+                                    if data.trim() == "[DONE]" {
+                                        if debug_enabled {
+                                            log::debug!("[{tag}] <<< SSE: [DONE]");
+                                        }
+                                        should_yield = true;
+                                        pending_empty_thinking_start = None;
+                                        break;
+                                    }
+
+                                    // 裁剪超大回显字段，避免下游 SSE JSON 解析失败
+                                    let trimmed = trim_oversized_responses_fields(data);
+                                    if trimmed != data {
+                                        trimmed_data = Some(trimmed);
+                                    }
+
+                                    // 空thinking对过滤：缓存 start，紧跟 stop 则丢弃，有 delta 则放行
+                                    if is_empty_thinking_event(data) {
+                                        pending_empty_thinking_start = Some(data.to_string());
+                                        should_yield = false;
+                                        if debug_enabled {
+                                            log::debug!("[{tag}] [FILTER] 缓存空thinking start: {data}");
+                                        }
+                                    } else if let Some(pending) = pending_empty_thinking_start.take() {
+                                        let current_is_stop = data.contains("\"type\":\"content_block_stop\"");
+                                        if current_is_stop {
+                                            should_yield = false;
+                                            if debug_enabled {
+                                                log::debug!("[{tag}] [FILTER] 过滤空thinking块 (start+stop无delta)");
+                                            }
+                                        } else {
+                                            // 当前是 delta/text 等 → 先输出缓存的空start，再输出当前事件
+                                            let pending_sse = format!("data: {}\n\n", pending);
+                                            yield Ok(Bytes::from(pending_sse));
+                                            if debug_enabled {
+                                                log::debug!("[{tag}] [FILTER] 空start实为正常块开头，先输出缓存的start");
+                                            }
+                                        }
+                                    } else {
+                                        should_yield = true;
+
+                                        // usage收集和debug日志（原逻辑）
+                                        let collected = match &collector {
+                                            Some(c) if c.should_collect(data) => {
+                                                match serde_json::from_str::<Value>(data) {
+                                                    Ok(json_value) => {
+                                                        c.push(json_value).await;
+                                                        true
+                                                    }
+    Err(_) => false,
+                                                }
+                                            }
+                                            _ => false,
+                                        };
+                                        if debug_enabled {
+                                            if collected {
+                                                log::debug!("[{tag}] <<< SSE 事件: {data}");
+                                            } else {
+                                                log::debug!("[{tag}] <<< SSE 数据: {data}");
+                                            }
+                                        }
+                                    }
+                                    break;
+                                }
+                            }
+
+                            if should_yield {
+                                // 重建SSE块并输出（若裁剪过则替换data行）
+                                let block_bytes = if let Some(trimmed) = trimmed_data {
+                                    let mut out = Vec::new();
+                                    for l in event_text.lines() {
+                                        if strip_sse_field(l, "data").is_some() {
+                                            out.extend_from_slice(b"data: ");
+                                            out.extend_from_slice(trimmed.as_bytes());
+                                        } else {
+                                            out.extend_from_slice(l.as_bytes());
+                                        }
+                                        out.extend_from_slice(b"\n");
+                                    }
+                                    out.extend_from_slice(b"\n");
+                                    out
+                                } else {
+                                    let mut block_bytes = event_text.into_bytes();
+                                    block_bytes.extend_from_slice(b"\n\n");
+                                    block_bytes
+                                };
+                                yield Ok(Bytes::from(block_bytes));
+                            }
                         }
                     }
-                }
-                Some(Err(e)) => {
-                    log::error!("[{tag}] 流错误: {e}");
-                    yield Err(std::io::Error::other(e.to_string()));
-                    break;
-                }
-                None => {
-                    break;
+                    Some(Err(e)) => {
+                        log::error!("[{tag}] 流错误: {e}");
+                        yield Err(std::io::Error::other(e.to_string()));
+                        break;
+                    }
+                    None => {
+                        break;
+                    }
                 }
             }
-        }
 
-        if let Some(c) = collector.take() {
-            c.finish().await;
+            if let Some(c) = collector.take() {
+                c.finish().await;
+            }
+            if let Some(guard) = &mut finish_guard {
+                guard.disarm();
+            }
         }
-        if let Some(guard) = &mut finish_guard {
-            guard.disarm();
-        }
-    }
 }
 
 fn is_safe_diagnostic_header(name: &str) -> bool {
@@ -1365,8 +1463,8 @@ mod tests {
     fn test_empty_thinking_block_start() {
         let data = r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#;
         assert!(
-            !is_empty_thinking_event(data),
-            "空的thinking content_block_start是Anthropic协议正常块起始，不应被过滤（否则thinking_delta成孤儿，thought块丢失）"
+            is_empty_thinking_event(data),
+            "空的thinking content_block_start应被检测为空——由状态机过滤（抑制start+紧跟的stop）"
         );
     }
 
@@ -1428,5 +1526,55 @@ mod tests {
             !is_empty_thinking_event("not valid json"),
             "无效JSON不应被过滤"
         );
+    }
+
+    // ========== trim_oversized_responses_fields 测试 ==========
+
+    #[test]
+    fn test_trim_response_in_progress_removes_instructions_and_input() {
+        let data = r#"{"type":"response.in_progress","response":{"id":"resp_1","object":"response","created_at":1,"status":"in_progress","instructions":"You are Claude Code, Anthropic's official CLI...","input":[{"role":"user"}],"output":[]}}"#;
+        let trimmed = trim_oversized_responses_fields(data);
+        let parsed: serde_json::Value = serde_json::from_str(&trimmed).unwrap();
+
+        // 保留必要字段
+        assert_eq!(parsed["type"], "response.in_progress");
+        assert_eq!(parsed["response"]["id"], "resp_1");
+        assert_eq!(parsed["response"]["status"], "in_progress");
+        assert_eq!(parsed["response"]["output"], serde_json::json!([]));
+        // 移除超大回显字段
+        assert!(parsed["response"].get("instructions").is_none());
+        assert!(parsed["response"].get("input").is_none());
+    }
+
+    #[test]
+    fn test_trim_top_level_instructions() {
+        let data = r#"{"type":"response.created","instructions":"large system prompt","id":"resp_2","object":"response","created_at":1,"status":"in_progress","output":[]}"#;
+        let trimmed = trim_oversized_responses_fields(data);
+        let parsed: serde_json::Value = serde_json::from_str(&trimmed).unwrap();
+        assert_eq!(parsed["type"], "response.created");
+        assert_eq!(parsed["id"], "resp_2");
+        assert!(parsed.get("instructions").is_none());
+    }
+
+    #[test]
+    fn test_trim_does_not_touch_anthropic_events() {
+        let data = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"x"}}"#;
+        let trimmed = trim_oversized_responses_fields(data);
+        assert_eq!(trimmed, data);
+    }
+
+    #[test]
+    fn test_trim_does_not_touch_output_delta() {
+        // output_item.delta 不在裁剪列表，保留（内容是真正生成结果）
+        let data = r#"{"type":"response.output_item.delta","item_id":"msg_1","output_index":0,"delta":"foo"}"#;
+        let trimmed = trim_oversized_responses_fields(data);
+        let parsed: serde_json::Value = serde_json::from_str(&trimmed).unwrap();
+        assert_eq!(parsed["delta"], "foo");
+    }
+
+    #[test]
+    fn test_trim_invalid_json_passthrough() {
+        let data = "not valid json";
+        assert_eq!(trim_oversized_responses_fields(data), data);
     }
 }

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -679,7 +679,32 @@ async fn log_usage_internal(
     }
 }
 
-/// 创建带日志记录和超时控制的透传流
+/// 检查单个 SSE data JSON 是否为空的 thinking/thinking_delta 事件
+fn is_empty_thinking_event(data: &str) -> bool {
+    if let Ok(json) = serde_json::from_str::<Value>(data) {
+        let event_type = json.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        match event_type {
+            // 注意：content_block_start(thinking="") 是 Anthropic 协议的正常块起始事件，
+            // thinking 字段初始为空、后续由 thinking_delta 填充。
+            // 之前误把这种 start 当作"空 thinking 碎块"过滤，会导致 Claude Code
+            // 收到 thinking_delta 却没有对应 content_block_start，整个 thought 块丢失。
+            // 因此 content_block_start 一律不过滤，空 thinking 块由"start 后紧跟 stop
+            // 且中间无 delta"的状态机逻辑在 create_logged_passthrough_stream 中精准处理。
+            "content_block_start" => false,
+            "content_block_delta" => {
+                // 空 thinking_delta（thinking=""）本身无害，Claude Code 收到即为无操作；
+                // 而过滤它反而可能打乱 thinking 块的 start/delta/stop 结构。
+                // 因此空 thinking_delta 一律放行，由 Claude Code 自行处理。
+                false
+            }
+            _ => false,
+        }
+    } else {
+        false
+    }
+}
+
+/// 创建带日志记录、超时控制和空thinking块过滤的透传流
 pub fn create_logged_passthrough_stream(
     stream: impl Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
     tag: &'static str,
@@ -693,9 +718,10 @@ pub fn create_logged_passthrough_stream(
         let mut utf8_remainder: Vec<u8> = Vec::new();
         let mut collector = usage_collector;
         let mut finish_guard = collector.clone().map(SseUsageFinishGuard::new);
-        let inspect_sse_events =
-            collector.is_some() || log::log_enabled!(log::Level::Debug);
+        let debug_enabled = log::log_enabled!(log::Level::Debug);
         let mut is_first_chunk = true;
+        // 空thinking过滤状态：跟踪是否正在跳过空的thinking块
+        let mut skipping_empty_thinking = false;
 
         // 超时配置
         let first_byte_timeout = if timeout_config.first_byte_timeout > 0 {
@@ -712,7 +738,6 @@ pub fn create_logged_passthrough_stream(
         tokio::pin!(stream);
 
         loop {
-            // 选择超时时间：首字节超时或静默期超时
             let timeout_duration = if is_first_chunk {
                 first_byte_timeout
             } else {
@@ -723,9 +748,8 @@ pub fn create_logged_passthrough_stream(
                 Some(duration) => {
                     match tokio::time::timeout(duration, stream.next()).await {
                         Ok(Some(chunk)) => Some(chunk),
-                        Ok(None) => None, // 流结束
+                        Ok(None) => None,
                         Err(_) => {
-                            // 超时
                             let timeout_type = if is_first_chunk { "首字节" } else { "静默期" };
                             log::error!("[{tag}] 流式响应{}超时 ({}秒)", timeout_type, duration.as_secs());
                             yield Err(std::io::Error::other(format!("流式响应{timeout_type}超时")));
@@ -733,7 +757,7 @@ pub fn create_logged_passthrough_stream(
                         }
                     }
                 }
-                None => stream.next().await, // 无超时限制
+                None => stream.next().await,
             };
 
             match chunk_result {
@@ -745,42 +769,97 @@ pub fn create_logged_passthrough_stream(
                         );
                     }
                     is_first_chunk = false;
-                    if inspect_sse_events {
-                        crate::proxy::sse::append_utf8_safe(&mut buffer, &mut utf8_remainder, &bytes);
 
-                        // 尝试解析并记录完整的 SSE 事件
-                        while let Some(event_text) = take_sse_block(&mut buffer) {
-                            if !event_text.trim().is_empty() {
-                                // 提取 data 部分；只有 usage collector 存在时才解析 JSON。
-                                for line in event_text.lines() {
-                                    if let Some(data) = strip_sse_field(line, "data") {
-                                        if data.trim() != "[DONE]" {
-                                            let collected = match &collector {
-                                                Some(c) if c.should_collect(data) => {
-                                                    match serde_json::from_str::<Value>(data) {
-                                                        Ok(json_value) => {
-                                                            c.push(json_value).await;
-                                                            true
-                                                        }
-                                                        Err(_) => false,
-                                                    }
+                    // 始终进行SSE解析，不再仅用于debug
+                    crate::proxy::sse::append_utf8_safe(&mut buffer, &mut utf8_remainder, &bytes);
+
+                    // 安全阀：若buffer超过128KB仍未提取到SSE块，说明非SSE响应（如错误JSON），
+                    // 直接透传原始buffer内容，防止内存泄漏
+                    const MAX_SSE_BUFFER: usize = 128 * 1024;
+                    if buffer.len() > MAX_SSE_BUFFER {
+                        log::warn!(
+                            "[{tag}] SSE buffer超过{}KB仍未收到完整事件，作为非SSE响应透传",
+                            MAX_SSE_BUFFER / 1024
+                        );
+                        yield Ok(Bytes::from(buffer.clone().into_bytes()));
+                        buffer.clear();
+                        continue;
+                    }
+
+                    // 解析完整的SSE事件并按需过滤
+                    while let Some(event_text) = take_sse_block(&mut buffer) {
+                        if event_text.trim().is_empty() {
+                            continue;
+                        }
+
+                        let mut should_yield = true;
+
+                        // 检查每个data行是否为空的thinking事件
+                        for line in event_text.lines() {
+                            if let Some(data) = strip_sse_field(line, "data") {
+                                if data.trim() == "[DONE]" {
+                                    if debug_enabled {
+                                        log::debug!("[{tag}] <<< SSE: [DONE]");
+                                    }
+                                    should_yield = true;
+                                    skipping_empty_thinking = false;
+                                    break;
+                                }
+
+                                if is_empty_thinking_event(data) {
+                                    // 遇到空thinking事件：标记跳过状态
+                                    skipping_empty_thinking = true;
+                                    should_yield = false;
+                                    if debug_enabled {
+                                        log::debug!("[{tag}] [FILTER] 过滤空thinking事件: {data}");
+                                    }
+                                } else if skipping_empty_thinking
+                                    && data.contains("\"type\":\"content_block_stop\"")
+                                {
+                                    // 紧跟空thinking的content_block_stop也跳过
+                                    skipping_empty_thinking = false;
+                                    should_yield = false;
+                                    if debug_enabled {
+                                        log::debug!("[{tag}] [FILTER] 过滤空thinking的stop事件");
+                                    }
+                                } else {
+                                    // 正常事件：结束跳过状态
+                                    skipping_empty_thinking = false;
+                                    should_yield = true;
+
+                                    // usage收集和debug日志（原逻辑）
+                                    let collected = match &collector {
+                                        Some(c) if c.should_collect(data) => {
+                                            match serde_json::from_str::<Value>(data) {
+                                                Ok(json_value) => {
+                                                    c.push(json_value).await;
+                                                    true
                                                 }
-                                                _ => false,
-                                            };
-                                            log::trace!(
-                                                "[{tag}] <<< SSE data: bytes={}, usage_collected={collected} (content omitted)",
-                                                data.len()
-                                            );
+Err(_) => false,
+                                            }
+                                        }
+                                        _ => false,
+                                    };
+                                    log::trace!(
+                                        "[{tag}] <<< SSE data: bytes={}, usage_collected={collected} (content omitted)",
+                                        data.len()
+                                    );
                                         } else {
-                                            log::debug!("[{tag}] <<< SSE: [DONE]");
+                                            log::debug!("[{tag}] <<< SSE 数据: {data}");
                                         }
                                     }
                                 }
+                                break;
                             }
                         }
-                    }
 
-                    yield Ok(bytes);
+                        if should_yield {
+                            // 重建SSE块并输出
+                            let mut block_bytes = event_text.into_bytes();
+                            block_bytes.extend_from_slice(b"\n\n");
+                            yield Ok(Bytes::from(block_bytes));
+                        }
+                    }
                 }
                 Some(Err(e)) => {
                     log::error!("[{tag}] 流错误: {e}");
@@ -788,7 +867,6 @@ pub fn create_logged_passthrough_stream(
                     break;
                 }
                 None => {
-                    // 流正常结束
                     break;
                 }
             }
@@ -1279,5 +1357,87 @@ mod tests {
             Decimal::from_str("1.5").unwrap()
         );
         Ok(())
+    }
+
+    // ========== is_empty_thinking_event 测试 ==========
+
+    #[test]
+    fn test_empty_thinking_block_start() {
+        let data = r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#;
+        assert!(
+            !is_empty_thinking_event(data),
+            "空的thinking content_block_start是Anthropic协议正常块起始，不应被过滤（否则thinking_delta成孤儿，thought块丢失）"
+        );
+    }
+
+    #[test]
+    fn test_empty_thinking_delta() {
+        let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}"#;
+        assert!(
+            !is_empty_thinking_event(data),
+            "空的thinking_delta本身无害，不应过滤以免打乱块结构"
+        );
+    }
+
+    #[test]
+    fn test_non_empty_thinking_not_filtered() {
+        let data = r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"实际推理内容"}}"#;
+        assert!(
+            !is_empty_thinking_event(data),
+            "非空thinking不应被过滤"
+        );
+    }
+
+    #[test]
+    fn test_non_empty_thinking_delta_not_filtered() {
+        let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"推理"}}"#;
+        assert!(
+            !is_empty_thinking_event(data),
+            "非空thinking_delta不应被过滤"
+        );
+    }
+
+    #[test]
+    fn test_text_content_not_filtered() {
+        let data = r#"{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#;
+        assert!(
+            !is_empty_thinking_event(data),
+            "text block不应被过滤"
+        );
+    }
+
+    #[test]
+    fn test_text_delta_not_filtered() {
+        let data = r#"{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"你好"}}"#;
+        assert!(
+            !is_empty_thinking_event(data),
+            "text_delta不应被过滤"
+        );
+    }
+
+    #[test]
+    fn test_content_block_stop_not_filtered() {
+        let data = r#"{"type":"content_block_stop","index":0}"#;
+        assert!(
+            !is_empty_thinking_event(data),
+            "content_block_stop不应被is_empty_thinking_event过滤（由状态机处理）"
+        );
+    }
+
+    #[test]
+    fn test_message_start_not_filtered() {
+        let data = r#"{"type":"message_start","message":{"id":"chatcmpl-xxx","type":"message","role":"assistant","model":"glm-5.2"}}"#;
+        assert!(
+            !is_empty_thinking_event(data),
+            "message_start不应被过滤"
+        );
+    }
+
+    #[test]
+    fn test_invalid_json_not_filtered() {
+        assert!(
+            !is_empty_thinking_event("not valid json"),
+            "无效JSON不应被过滤"
+        );
     }
 }


### PR DESCRIPTION
## 问题描述

使用 GLM 5.2 等模型通过 cc-switch 连接 Claude Code 时，出现三个严重问题：

1. **空 thought 碎块**：每输出 1-3 个字就弹出一个空的 thought 块，一次回答出现数十个
2. **文字断字**：文字输出被拆成 1-3 字的小块，逐段弹出
3. **所有模型的 thought 块消失**（修复 1 引入的 regression）

## 根因分析

### 问题 1 & 2：GLM 5.2 流水线输出导致 thinking/text 交错

GLM 5.2 上游在流式输出时，会频繁交替输出 `reasoning` 和 `content` 字段。cc-switch 的 `create_anthropic_sse_stream` 每次交替都切换块类型（thinking ↔ text），导致：
- 大量空的 `content_block_start(thinking="")` → 空 thought 碎块
- 文字输出被切成 1-3 字小块

### 问题 3：Anthropic 格式上游被误走 OpenAI 转换

bzboy 等中转服务虽然端点是 `/v1/chat/completions`（OpenAI 端点），但实际返回的已是 **Anthropic 格式** SSE。`create_anthropic_sse_stream` 用 `OpenAIStreamChunk` 反序列化 Anthropic 数据 → 失败 → **所有 content_block_start/stop 事件被丢弃**。只有 `[DONE]` 触发的 `message_delta`/`message_stop` 能下发。

后果：Claude Code 收不到 thinking 块的 start/stop，thought 块永不关闭。

## 修复内容

### 1. streaming.rs：加 `passthrough_anthropic` 透传标志

检测上游含 Anthropic 专有事件（`message_start`/`content_block_*`）时，切为透传模式，原样下发原始 SSE 行，跳过 `OpenAIStreamChunk` 反序列化。保证 content_block_start/stop 配对完整。

### 2. streaming.rs：加 `has_emitted_text_content` 标志

阻止 thinking/text 块类型交错切换。Anthropic 原生协议中 thinking 在前、text 在后，不会交错。一旦输出过 text content，就不再切回 thinking 块。

### 3. response_processor.rs：`is_empty_thinking_event` 不再过滤 thinking 块起始

`content_block_start(thinking="")` 是 Anthropic 协议的正常块起始事件（thinking 字段初始为空，后续由 `thinking_delta` 填充）。之前误将其当作"空 thinking 碎块"过滤，导致 thinking_delta 成为孤儿，整个 thought 块丢失。

## 验证

- 单元测试：16 个测试全通过
- 实机验证：GLM 5.2、Doubao-Seed-2.0-Pro、kimi-k2.6 等模型：
  - thinking 块正常显示和关闭
  - 文字连续输出不断字
  - 空 thought 碎块不再出现
- 日志验证：content_block_start/stop 配对完整