### PR TITLE
fix(proxy): classify glm-5.2 as text-only in media sanitizer heuristic

### DIFF
--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -250,6 +250,7 @@ fn known_text_only_model(model: &str) -> bool {
         "deepseek-v4-flash",
         "deepseek-v4-pro",
         "glm-5.1",
+        "glm-5.2",
         "kat-coder",
         "kat-coder-pro",
         "kat-coder-pro v1",
@@ -492,6 +493,15 @@ mod tests {
         assert!(known_text_only_model("LongCat-2.0"));
         assert!(known_text_only_model("longcat/LongCat-2.0"));
         assert!(known_text_only_model("LongCat-Flash-Chat"));
+    }
+
+    #[test]
+    fn glm_models_are_classified_text_only() {
+        // GLM-5.1 and 5.2 are text-only; an aggregator vendor path segment
+        // and mixed case must not break classification.
+        assert!(known_text_only_model("glm-5.1"));
+        assert!(known_text_only_model("GLM-5.2"));
+        assert!(known_text_only_model("zai/GLM-5.2"));
     }
 
     #[test]


### PR DESCRIPTION
﻿## What

Adds `glm-5.2` to the curated `known_text_only_model` `EXACT_TAILS` list in `src-tauri/src/proxy/media_sanitizer.rs`, alongside the existing `glm-5.1` entry.

## Why

GLM-5.2 is a text-only model like GLM-5.1. Without it on the built-in list, when a provider has no explicit model-capability declaration (`modelCatalog` / `modalities`), images sent to a `glm-5.2` endpoint are only stripped *reactively* (after the upstream returns an unsupported-image error) instead of *predictively* before send. This drops GLM-5.2 into the pre-send heuristic path so images are stripped up front.

This list is the lowest-priority fallback (behind explicit provider capability declarations), so it only ever runs when the user has "Heuristic Text-Only Model Detection" enabled **and** the provider hasn't declared capabilities.

## Changes

- Add `glm-5.2` to `EXACT_TAILS` in `known_text_only_model`.
- Regression test `glm_models_are_classified_text_only` covering `glm-5.1`, mixed-case `GLM-5.2`, and an aggregator vendor-path prefix (`zai/GLM-5.2`).

## Verification

```
cd src-tauri
cargo test --lib proxy::media_sanitizer::   # 22 passed, 0 failed
```
