### PR TITLE
ci: harden release supply chain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners for cc-switch
+#
+# Branch protection on `main` has "Require review from Code Owners" enabled.
+# With this file present, a PR cannot merge to `main` without an approval from
+# the owner below. This closes the gap where two collaborators could approve
+# each other's malicious PRs (a single non-owner approval is no longer enough).
+
+# Global fallback: every PR needs owner approval before merging to main.
+*                 @farion1231
+
+# Most sensitive paths — CI/signing/release and the Rust backend. Listed
+# explicitly so they stay locked even if the global rule above is relaxed later.
+/.github/         @farion1231
+/src-tauri/       @farion1231

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,74 @@
+# Configuration for actions/labeler v5
+# Automatically labels PRs based on changed file paths
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/**"
+          - "index.html"
+          - "vite.config.ts"
+          - "vitest.config.ts"
+          - "tailwind.config.cjs"
+          - "postcss.config.cjs"
+          - "tsconfig.json"
+          - "tsconfig.node.json"
+          - "components.json"
+          - "tests/**"
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src-tauri/**"
+
+i18n:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/locales/**"
+
+actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "pnpm-lock.yaml"
+          - "pnpm-workspace.yaml"
+          - "src-tauri/Cargo.toml"
+          - "src-tauri/Cargo.lock"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.md"
+          - "docs/**"
+          - "LICENSE"
+
+mcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/components/mcp/**"
+          - "src/lib/api/mcp.ts"
+          - "src-tauri/src/mcp/**"
+          - "src-tauri/src/claude_mcp.rs"
+          - "src-tauri/src/gemini_mcp.rs"
+          - "src-tauri/src/commands/mcp.rs"
+
+skills:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/components/skills/**"
+          - "src/lib/api/skills.ts"
+          - "src-tauri/src/commands/skill.rs"
+          - "src-tauri/src/services/skill.rs"
+          - "src-tauri/src/database/dao/skills.rs"
+
+proxy:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/components/proxy/**"
+          - "src/lib/api/proxy.ts"
+          - "src-tauri/src/proxy/**"
+          - "src-tauri/src/commands/proxy.rs"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Label PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   release:
     runs-on: ${{ matrix.os }}
+    environment: release
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,4 @@ flatpak-repo/
 copilot-api
 .history
 CODEBUDDY.md
-.github
 mainWindow.js

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -63,6 +63,19 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
 
     let message = extract_error_text(body);
     let message = message.to_ascii_lowercase();
+
+    // 自证性表述：这类短语本身就断言了"仅接受文本"，属于模态拒绝，无需再要求
+    // 错误提到 image/media 等字样——火山方舟等网关的报错是
+    // "Model only support text input"，全程不出现 image（issue #5025）。
+    // 国产网关的英文常缺三单 s，因此带 s / 不带 s 两种形式都要列。
+    const TEXT_ONLY_SELF_EVIDENT_HINTS: &[&str] = &["only support text", "only supports text"];
+    if TEXT_ONLY_SELF_EVIDENT_HINTS
+        .iter()
+        .any(|hint| message.contains(hint))
+    {
+        return true;
+    }
+
     let mentions_image = message.contains("image")
         || message.contains("vision")
         || message.contains("multimodal")
@@ -83,7 +96,6 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
         "doesn't support",
         "do not support",
         "don't support",
-        "only supports text",
         "text only",
         "text-only",
         "invalid content type",
@@ -250,6 +262,9 @@ fn known_text_only_model(model: &str) -> bool {
         "deepseek-v4-flash",
         "deepseek-v4-pro",
         "glm-5.1",
+        // 精确匹配而非 TAIL_PREFIXES：智谱视觉版沿用 4v/5v 命名（glm-5.2v），
+        // 前缀匹配会误剥未来多模态变体的图片。
+        "glm-5.2",
         "kat-coder",
         "kat-coder-pro",
         "kat-coder-pro v1",
@@ -725,6 +740,32 @@ mod tests {
         };
 
         assert!(is_unsupported_image_error(&error));
+    }
+
+    #[test]
+    fn detects_text_only_errors_without_image_mention() {
+        // 火山方舟真实报错（issue #5025）：不含 image/media 等字样，且英文缺
+        // 三单 s——旧逻辑的 mentions_image 门与 "only supports text" 提示都拦不住。
+        let error = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(
+                r#"{"error":{"message":"Model only support text input Request id: 021783"}}"#
+                    .to_string(),
+            ),
+        };
+
+        assert!(is_unsupported_image_error(&error));
+    }
+
+    #[test]
+    fn glm_52_is_classified_text_only() {
+        // issue #5025：火山 Coding Plan 的 GLM 5.2 是纯文本端点，
+        // 映射链 glm-5.2[1M] 归一化后尾部为 glm-5.2。
+        assert!(known_text_only_model("glm-5.2"));
+        assert!(known_text_only_model("GLM-5.2[1M]"));
+        assert!(known_text_only_model("zai-org/GLM-5.2"));
+        // 未来视觉版（智谱 4v/5v 命名惯例）不能被误判为纯文本。
+        assert!(!known_text_only_model("glm-5.2v"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Audit of the collaborator trust boundary: with ~5M installs behind the
auto-updater, "who can trigger a signed release" is a supply-chain edge.
A write collaborator could previously push a \`v*\` tag pointing at any
commit, which fires the release workflow, signs the build with the real
Tauri updater key + Apple Developer ID cert, and ships it via auto-update —
bypassing branch protection entirely.

## What this PR does

- **CODEOWNERS** — PRs to \`main\` now require owner review. Closes the gap
  where two collaborators could approve each other's malicious PR (a single
  non-owner approval is no longer enough). \`.github/\` and \`src-tauri/\` are
  also listed explicitly so they stay locked if the global rule is relaxed.
- **release environment gate** — the release job now runs under a \`release\`
  environment with a required reviewer, so signing secrets are only unlocked
  after manual approval.
- **.gitignore fix** — stop ignoring the entire \`.github\` directory. This had
  been silently swallowing \`labeler.yml\` and \`workflows/labeler.yml\`, which
  are now tracked.

## Already applied out-of-band (repo settings, live now)

- Tag ruleset \`protect-release-tags\`: creation/update/deletion of \`v*\` tags
  restricted to admins. Write collaborators can no longer trigger a release.
- \`release\` environment created with required reviewer.

## Reviewer notes / side effects

- Releasing now needs one manual approval in the Actions tab (**Review
  deployments → Approve**) before signing. One approval releases the whole
  matrix.
- Every PR now needs owner approval. If that's too heavy, drop the global
  \`* @farion1231\` line and keep only the sensitive paths.