### PR TITLE
fix(codex): clarify invalid tool arguments errors

### DIFF
--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -2693,6 +2693,31 @@ data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\"}}\n
     }
 
     #[test]
+    fn codex_proxy_upstream_error_explains_minimax_invalid_tool_arguments() {
+        let error = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(
+                r#"{"base_resp":{"status_code":2013,"status_msg":"invalid params, invalid function arguments json string, tool_call_id: call_abc"}}"#
+                    .to_string(),
+            ),
+        };
+        let body = codex_proxy_error_json("MiniMax", "MiniMax-M3", "/responses", &error);
+
+        let message = body["error"]["message"].as_str().unwrap();
+        assert!(message.contains("CC Switch local proxy failed"));
+        assert!(message.contains("upstream_status: HTTP 400"));
+        assert!(message.contains("invalid function arguments json string"));
+        assert!(
+            message.contains("Diagnosis: upstream rejected tool call arguments as invalid JSON")
+        );
+        assert!(message.contains("failed to parse function arguments"));
+        assert_eq!(body["error"]["code"], 2013);
+        assert_eq!(body["error"]["param"], "function_call.arguments");
+        assert_eq!(body["error"]["type"], "upstream_tool_arguments_error");
+        assert_eq!(body["error"]["upstream_status"], 400);
+    }
+
+    #[test]
     fn codex_proxy_413_points_to_upstream_not_local_proxy() {
         // 模拟上游渠道商 nginx 因 client_max_body_size 返回的 413 HTML 页面
         // （见 issue #666：长上下文 / 大图 / 大日志撞上游体积上限）

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -6,7 +6,7 @@ use super::{
     },
     transform_codex_chat::{
         chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
-        response_id_from_chat_id, response_status_from_finish_reason,
+        normalize_chat_error_fields, response_id_from_chat_id, response_status_from_finish_reason,
         response_tool_call_item_from_chat_name, response_tool_call_item_id_from_chat_name,
         CodexToolContext,
     },
@@ -855,10 +855,26 @@ impl ChatToResponsesState {
     }
 
     fn failed_event(&mut self, message: String, error_type: Option<String>) -> Bytes {
+        self.failed_event_with_error(message, error_type, Value::Null, Value::Null)
+    }
+
+    fn failed_event_with_error(
+        &mut self,
+        message: String,
+        error_type: Option<String>,
+        code: Value,
+        param: Value,
+    ) -> Bytes {
         self.completed = true;
         let mut error = json!({ "message": message });
         if let Some(error_type) = error_type.filter(|value| !value.is_empty()) {
             error["type"] = json!(error_type);
+        }
+        if !code.is_null() {
+            error["code"] = code;
+        }
+        if !param.is_null() {
+            error["param"] = param;
         }
 
         let mut response = self.base_response("failed", self.completed_output_items());
@@ -962,8 +978,13 @@ pub fn create_responses_sse_stream_from_chat_with_context<E: std::error::Error +
                         };
 
                         if event_name.as_deref() == Some("error") || chunk.get("error").is_some() {
-                            let (message, error_type) = extract_chat_sse_error(&chunk);
-                            yield Ok(state.failed_event(message, error_type));
+                            let fields = extract_chat_sse_error(&chunk);
+                            yield Ok(state.failed_event_with_error(
+                                fields.message,
+                                Some(fields.error_type),
+                                fields.code,
+                                fields.param,
+                            ));
                             stream_failed = true;
                             break;
                         }
@@ -1008,26 +1029,14 @@ pub fn create_responses_sse_stream_from_chat_with_context<E: std::error::Error +
     }
 }
 
-fn extract_chat_sse_error(value: &Value) -> (String, Option<String>) {
-    let error = value.get("error").unwrap_or(value);
-    let message = error
-        .as_str()
-        .map(ToString::to_string)
-        .or_else(|| {
-            error
-                .get("message")
-                .or_else(|| error.get("detail"))
-                .and_then(|v| v.as_str())
-                .map(ToString::to_string)
-        })
-        .unwrap_or_else(|| error.to_string());
-    let error_type = error
-        .get("type")
-        .or_else(|| error.get("code"))
-        .and_then(|v| v.as_str())
-        .map(ToString::to_string);
-
-    (message, error_type)
+fn extract_chat_sse_error(value: &Value) -> super::transform_codex_chat::ChatErrorFields {
+    let mut fields = normalize_chat_error_fields(value);
+    if fields.error_type == "upstream_error" {
+        if let Some(code) = fields.code.as_str().filter(|value| !value.is_empty()) {
+            fields.error_type = code.to_string();
+        }
+    }
+    fields
 }
 
 fn sse_event(event: &str, data: Value) -> Bytes {
@@ -1313,6 +1322,24 @@ mod tests {
         assert!(output.contains("event: response.failed"));
         assert!(output.contains("bad request"));
         assert!(output.contains("invalid_request_error"));
+        assert!(!output.contains("event: response.completed"));
+    }
+
+    #[tokio::test]
+    async fn chat_sse_minimax_invalid_tool_arguments_error_is_enriched() {
+        let output = collect(vec![
+            "event: error\ndata: {\"base_resp\":{\"status_code\":2013,\"status_msg\":\"invalid params, invalid function arguments json string, tool_call_id: call_abc\"}}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("event: response.failed"));
+        assert!(output.contains("invalid function arguments json string"));
+        assert!(output.contains("Diagnosis: upstream rejected tool call arguments as invalid JSON"));
+        assert!(output.contains("failed to parse function arguments"));
+        assert!(output.contains("\"code\":2013"));
+        assert!(output.contains("\"param\":\"function_call.arguments\""));
+        assert!(output.contains("\"type\":\"upstream_tool_arguments_error\""));
         assert!(!output.contains("event: response.completed"));
     }
 

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -42,6 +42,7 @@ const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
 const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
 const CUSTOM_TOOL_INPUT_DESCRIPTION: &str = "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description.";
 const CUSTOM_TOOL_PRESERVED_METADATA_HEADING: &str = "Original tool definition:";
+const INVALID_TOOL_ARGUMENTS_DIAGNOSTIC: &str = "Diagnosis: upstream rejected tool call arguments as invalid JSON. For MiniMax-style 2013 errors, this usually means the upstream model emitted an incomplete tool-call arguments stream, such as a missing closing brace, before CC Switch received a complete JSON object. Check the Codex session log for `failed to parse function arguments` to confirm; retrying or switching provider is the practical fix.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodexToolKind {
@@ -1672,6 +1673,64 @@ pub(crate) fn response_status_from_finish_reason(finish_reason: Option<&str>) ->
     }
 }
 
+pub(crate) struct ChatErrorFields {
+    pub(crate) message: String,
+    pub(crate) error_type: String,
+    pub(crate) code: Value,
+    pub(crate) param: Value,
+}
+
+pub(crate) fn normalize_chat_error_fields(value: &Value) -> ChatErrorFields {
+    let source = value.get("error").unwrap_or(value);
+
+    let mut message = source
+        .get("message")
+        .or_else(|| source.get("detail"))
+        .or_else(|| source.get("status_msg"))
+        .or_else(|| source.pointer("/base_resp/status_msg"))
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string)
+        .or_else(|| source.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| {
+            // 没法从字段提取出文本，就把整个 JSON 序列化回去，方便用户排查。
+            serde_json::to_string(source).unwrap_or_else(|_| "Upstream error".to_string())
+        });
+
+    let mut error_type = source
+        .get("type")
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "upstream_error".to_string());
+
+    let code = source
+        .get("code")
+        .cloned()
+        .or_else(|| source.pointer("/base_resp/status_code").cloned())
+        .unwrap_or(serde_json::Value::Null);
+
+    let mut param = source
+        .get("param")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+
+    if is_invalid_tool_arguments_2013(&message, &code) {
+        message = format!("{message}. {INVALID_TOOL_ARGUMENTS_DIAGNOSTIC}");
+        if error_type.trim().is_empty() || error_type == "upstream_error" {
+            error_type = "upstream_tool_arguments_error".to_string();
+        }
+        if param.is_null() {
+            param = json!("function_call.arguments");
+        }
+    }
+
+    ChatErrorFields {
+        message,
+        error_type,
+        code,
+        param,
+    }
+}
+
 /// 把 Chat Completions 上游的错误体规整成 OpenAI Responses API 风格的错误对象。
 ///
 /// 兼容三类输入：
@@ -1704,46 +1763,31 @@ pub fn chat_error_to_response_error(body: Option<&Value>) -> Value {
         });
     }
 
-    let source = value.get("error").unwrap_or(value);
-
-    let message = source
-        .get("message")
-        .or_else(|| source.get("detail"))
-        .or_else(|| source.get("status_msg"))
-        .or_else(|| source.pointer("/base_resp/status_msg"))
-        .and_then(|v| v.as_str())
-        .map(ToString::to_string)
-        .or_else(|| source.as_str().map(ToString::to_string))
-        .unwrap_or_else(|| {
-            // 没法从字段提取出文本，就把整个 JSON 序列化回去，方便用户排查。
-            serde_json::to_string(source).unwrap_or_else(|_| "Upstream error".to_string())
-        });
-
-    let error_type = source
-        .get("type")
-        .and_then(|v| v.as_str())
-        .map(ToString::to_string)
-        .unwrap_or_else(|| "upstream_error".to_string());
-
-    let code = source
-        .get("code")
-        .cloned()
-        .or_else(|| source.pointer("/base_resp/status_code").cloned())
-        .unwrap_or(serde_json::Value::Null);
-
-    let param = source
-        .get("param")
-        .cloned()
-        .unwrap_or(serde_json::Value::Null);
+    let fields = normalize_chat_error_fields(value);
 
     json!({
         "error": {
-            "message": message,
-            "type": error_type,
-            "code": code,
-            "param": param,
+            "message": fields.message,
+            "type": fields.error_type,
+            "code": fields.code,
+            "param": fields.param,
         }
     })
+}
+
+fn is_invalid_tool_arguments_2013(message: &str, code: &Value) -> bool {
+    is_error_code_2013(code)
+        && message
+            .to_ascii_lowercase()
+            .contains("invalid function arguments json string")
+}
+
+fn is_error_code_2013(code: &Value) -> bool {
+    match code {
+        Value::Number(number) => number.as_i64() == Some(2013) || number.as_u64() == Some(2013),
+        Value::String(value) => value.trim() == "2013",
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -3024,6 +3068,28 @@ mod tests {
         assert_eq!(result["error"]["code"], 2013);
         // type 没有显式给出，应该回落到 upstream_error
         assert_eq!(result["error"]["type"], "upstream_error");
+    }
+
+    #[test]
+    fn chat_error_to_response_error_enriches_minimax_invalid_tool_arguments() {
+        let input = json!({
+            "base_resp": {
+                "status_code": 2013,
+                "status_msg": "invalid params, invalid function arguments json string, tool_call_id: call_abc"
+            }
+        });
+
+        let result = chat_error_to_response_error(Some(&input));
+
+        let message = result["error"]["message"].as_str().unwrap();
+        assert!(message.contains("invalid function arguments json string"));
+        assert!(
+            message.contains("Diagnosis: upstream rejected tool call arguments as invalid JSON")
+        );
+        assert!(message.contains("failed to parse function arguments"));
+        assert_eq!(result["error"]["code"], 2013);
+        assert_eq!(result["error"]["param"], "function_call.arguments");
+        assert_eq!(result["error"]["type"], "upstream_tool_arguments_error");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enrich MiniMax-style `status_code: 2013` tool argument JSON errors with a clear diagnostic for Codex `/responses` users.
- Share the same 2013 normalizer across non-streaming HTTP errors and streaming Chat SSE `event: error` failures.
- Preserve upstream error details while setting `param` to `function_call.arguments` for invalid tool argument payloads.

Fixes #5001

## Tests
- `cargo test --manifest-path src-tauri\Cargo.toml --lib chat_sse_minimax_invalid_tool_arguments_error_is_enriched`
- `cargo test --manifest-path src-tauri\Cargo.toml --lib chat_error_to_response_error`
- `cargo test --manifest-path src-tauri\Cargo.toml --lib chat_sse_error`
- `cargo test --manifest-path src-tauri\Cargo.toml --lib chat_sse_data_only_error_emits_failed_without_completed`
- `cargo fmt --manifest-path src-tauri\Cargo.toml --check`
- `git diff --check`
