### PR TITLE
fix(claude): mirror API key into auth token

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -33,6 +33,31 @@ pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
     v
 }
 
+fn ensure_claude_auth_token_for_live(settings: &mut Value) {
+    let Some(env) = settings.get_mut("env").and_then(Value::as_object_mut) else {
+        return;
+    };
+
+    let has_auth_token = env
+        .get("ANTHROPIC_AUTH_TOKEN")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+    if has_auth_token {
+        return;
+    }
+
+    if let Some(api_key) = env
+        .get("ANTHROPIC_API_KEY")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+    {
+        env.insert("ANTHROPIC_AUTH_TOKEN".to_string(), Value::String(api_key));
+    }
+}
+
 pub(crate) fn provider_exists_in_live_config(
     app_type: &AppType,
     provider_id: &str,
@@ -740,7 +765,8 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
     match app_type {
         AppType::Claude => {
             let path = get_claude_settings_path();
-            let settings = sanitize_claude_settings_for_live(&provider.settings_config);
+            let mut settings = sanitize_claude_settings_for_live(&provider.settings_config);
+            ensure_claude_auth_token_for_live(&mut settings);
             write_json_file(&path, &settings)?;
         }
         AppType::ClaudeDesktop => {
@@ -1607,6 +1633,39 @@ pub fn remove_openclaw_provider_from_live(provider_id: &str) -> Result<(), AppEr
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn claude_live_settings_mirror_api_key_to_auth_token_only_for_live_output() {
+        let mut settings = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://example.com",
+                "ANTHROPIC_API_KEY": "sk-test"
+            }
+        });
+
+        ensure_claude_auth_token_for_live(&mut settings);
+
+        assert_eq!(settings["env"]["ANTHROPIC_API_KEY"], json!("sk-test"));
+        assert_eq!(settings["env"]["ANTHROPIC_AUTH_TOKEN"], json!("sk-test"));
+    }
+
+    #[test]
+    fn claude_live_settings_keep_existing_auth_token() {
+        let mut settings = json!({
+            "env": {
+                "ANTHROPIC_API_KEY": "sk-api-key",
+                "ANTHROPIC_AUTH_TOKEN": "sk-auth-token"
+            }
+        });
+
+        ensure_claude_auth_token_for_live(&mut settings);
+
+        assert_eq!(settings["env"]["ANTHROPIC_API_KEY"], json!("sk-api-key"));
+        assert_eq!(
+            settings["env"]["ANTHROPIC_AUTH_TOKEN"],
+            json!("sk-auth-token")
+        );
+    }
 
     #[test]
     fn claude_common_config_apply_and_remove_roundtrip_for_non_overlapping_fields() {


### PR DESCRIPTION
## Summary / 概述

Claude's auth check relies on `ANTHROPIC_AUTH_TOKEN`.
Claude 的授权检查会依赖 `ANTHROPIC_AUTH_TOKEN`。

When only `ANTHROPIC_API_KEY` exists, Claude clients can treat the config as unauthenticated. In VS Code's Claude extension, this can trigger a login prompt even though the provider API key is already configured.
当配置中只有 `ANTHROPIC_API_KEY` 时，Claude 客户端可能会误判为未授权。比如 VS Code，即使 `ANTHROPIC_API_KEY` 已经配置完成，Claude 插件仍然会强制弹出登录。

This PR mirrors `ANTHROPIC_API_KEY` into `ANTHROPIC_AUTH_TOKEN` when saving Claude configs, while keeping `ANTHROPIC_API_KEY` for preset compatibility.
本 PR 在保存 Claude 配置时，额外将 `ANTHROPIC_API_KEY` 同步写入 `ANTHROPIC_AUTH_TOKEN`。

## Related Issue / 关联 Issue

No related issue. I noticed this auth-check mismatch and fixed it directly.
无关联 Issue。我发现这个授权检查字段不一致的问题后直接进行了修复。

## Screenshots / 截图

Not applicable. No UI changes.
不适用，无 UI 变化。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件