### PR TITLE
feat(codex): support input modalities in model catalog

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -418,6 +418,22 @@ fn extract_codex_top_level_u64(config_text: &str, field: &str) -> Option<u64> {
         .filter(|value| *value > 0)
 }
 
+fn sanitize_codex_input_modalities<'a>(
+    items: impl IntoIterator<Item = &'a str>,
+) -> Option<Vec<String>> {
+    let mut modalities = Vec::new();
+    for item in items {
+        let normalized = item.trim().to_ascii_lowercase();
+        if (normalized == "text" || normalized == "image")
+            && !modalities.iter().any(|m| m == &normalized)
+        {
+            modalities.push(normalized);
+        }
+    }
+
+    (!modalities.is_empty()).then_some(modalities)
+}
+
 fn codex_catalog_model_entry(
     template: &Value,
     spec: &CodexCatalogModelSpec,
@@ -472,10 +488,19 @@ fn codex_catalog_model_entry(
         if let Some(parallel) = spec.supports_parallel_tool_calls {
             entry_obj.insert("supports_parallel_tool_calls".to_string(), json!(parallel));
         }
-        if let Some(modalities) = &spec.input_modalities {
-            entry_obj.insert("input_modalities".to_string(), json!(modalities));
-        }
     }
+
+    let modalities = spec
+        .input_modalities
+        .as_ref()
+        .and_then(|items| sanitize_codex_input_modalities(items.iter().map(String::as_str)))
+        .unwrap_or_else(|| vec!["text".to_string()]);
+    let supports_image = modalities.iter().any(|item| item == "image");
+    entry_obj.insert("input_modalities".to_string(), json!(modalities));
+    entry_obj.insert(
+        "supports_image_detail_original".to_string(),
+        json!(supports_image),
+    );
 
     entry
 }
@@ -549,14 +574,9 @@ fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCa
             .get("inputModalities")
             .or_else(|| model_config.get("input_modalities"))
             .and_then(|value| value.as_array())
-            .map(|items| {
-                items
-                    .iter()
-                    .filter_map(|item| item.as_str())
-                    .map(str::to_string)
-                    .collect::<Vec<_>>()
-            })
-            .filter(|items| !items.is_empty());
+            .and_then(|items| {
+                sanitize_codex_input_modalities(items.iter().filter_map(|item| item.as_str()))
+            });
 
         let base_instructions = model_config
             .get("baseInstructions")
@@ -2450,8 +2470,87 @@ base_url = "https://production.api/v1"
             "per-row inputModalities override must apply"
         );
         assert_eq!(
+            entry.get("supports_image_detail_original"),
+            Some(&json!(true)),
+            "image input modalities must enable original image detail support"
+        );
+        assert_eq!(
             entry.get("context_window").and_then(|v| v.as_u64()),
             Some(1_000_000)
+        );
+    }
+
+    #[test]
+    fn catalog_sanitizes_input_modalities_and_disables_image_detail_for_text_only() {
+        let settings = json!({
+            "modelCatalog": {
+                "models": [
+                    {
+                        "model": "text-only",
+                        "inputModalities": [" Text ", "audio", "text"]
+                    },
+                    {
+                        "model": "empty-modalities",
+                        "input_modalities": ["audio", " "]
+                    },
+                    {
+                        "model": "explicit-image",
+                        "inputModalities": ["text", "image"]
+                    },
+                    {
+                        "model": "legacy-missing-modalities"
+                    }
+                ]
+            }
+        });
+
+        let catalog =
+            codex_model_catalog_from_settings(&settings, "", CodexCatalogToolProfile::ProxyChat)
+                .expect("catalog generation should not error")
+                .expect("non-empty modelCatalog must yield a catalog");
+
+        let text_entry = &catalog["models"][0];
+        assert_eq!(text_entry.get("input_modalities"), Some(&json!(["text"])));
+        assert_eq!(
+            text_entry.get("supports_image_detail_original"),
+            Some(&json!(false)),
+            "explicit text-only modalities must override image-capable template defaults"
+        );
+
+        let empty_entry = &catalog["models"][1];
+        assert_eq!(
+            empty_entry.get("input_modalities"),
+            Some(&json!(["text"])),
+            "invalid or empty modalities must fall back to text-only"
+        );
+        assert_eq!(
+            empty_entry.get("supports_image_detail_original"),
+            Some(&json!(false)),
+            "invalid or empty modalities must not inherit image-capable template defaults"
+        );
+
+        let image_entry = &catalog["models"][2];
+        assert_eq!(
+            image_entry.get("input_modalities"),
+            Some(&json!(["text", "image"])),
+            "explicit image support must be preserved"
+        );
+        assert_eq!(
+            image_entry.get("supports_image_detail_original"),
+            Some(&json!(true)),
+            "explicit image support must keep image detail enabled"
+        );
+
+        let legacy_entry = &catalog["models"][3];
+        assert_eq!(
+            legacy_entry.get("input_modalities"),
+            Some(&json!(["text"])),
+            "legacy rows missing modalities must default to text-only"
+        );
+        assert_eq!(
+            legacy_entry.get("supports_image_detail_original"),
+            Some(&json!(false)),
+            "legacy rows missing modalities must not inherit image-capable template defaults"
         );
     }
 

--- a/src-tauri/src/services/codex_oauth_models.rs
+++ b/src-tauri/src/services/codex_oauth_models.rs
@@ -74,6 +74,7 @@ fn push_model_entry(models: &mut Vec<FetchedModel>, entry: &Value, fallback_id: 
         models.push(FetchedModel {
             id: id.to_string(),
             owned_by: Some("Codex".to_string()),
+            input_modalities: None,
         });
         return;
     }
@@ -83,6 +84,7 @@ fn push_model_entry(models: &mut Vec<FetchedModel>, entry: &Value, fallback_id: 
             models.push(FetchedModel {
                 id: id.to_string(),
                 owned_by: Some("Codex".to_string()),
+                input_modalities: None,
             });
         }
         return;
@@ -104,7 +106,11 @@ fn push_model_entry(models: &mut Vec<FetchedModel>, entry: &Value, fallback_id: 
     )
     .or_else(|| Some("Codex".to_string()));
 
-    models.push(FetchedModel { id, owned_by });
+    models.push(FetchedModel {
+        id,
+        owned_by,
+        input_modalities: None,
+    });
 }
 
 fn string_field(obj: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {

--- a/src-tauri/src/services/model_fetch.rs
+++ b/src-tauri/src/services/model_fetch.rs
@@ -7,6 +7,7 @@
 use reqwest::header::{HeaderValue, USER_AGENT};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::time::Duration;
 
 /// 获取到的模型信息
@@ -15,6 +16,8 @@ use std::time::Duration;
 pub struct FetchedModel {
     pub id: String,
     pub owned_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_modalities: Option<Vec<String>>,
 }
 
 /// OpenAI 兼容的 /v1/models 响应格式
@@ -27,6 +30,17 @@ struct ModelsResponse {
 struct ModelEntry {
     id: String,
     owned_by: Option<String>,
+    input: Option<Value>,
+    input_modalities: Option<Value>,
+    #[serde(rename = "inputModalities")]
+    input_modalities_camel: Option<Value>,
+    modalities: Option<Value>,
+    architecture: Option<Value>,
+    capabilities: Option<Value>,
+    vision: Option<bool>,
+    supports_image: Option<bool>,
+    #[serde(rename = "supportsImage")]
+    supports_image_camel: Option<bool>,
 }
 
 const FETCH_TIMEOUT_SECS: u64 = 15;
@@ -96,10 +110,7 @@ pub async fn fetch_models(
                 .data
                 .unwrap_or_default()
                 .into_iter()
-                .map(|m| FetchedModel {
-                    id: m.id,
-                    owned_by: m.owned_by,
-                })
+                .map(fetched_model_from_entry)
                 .collect();
 
             models.sort_by(|a, b| a.id.cmp(&b.id));
@@ -229,6 +240,79 @@ fn ends_with_version_segment(url: &str) -> bool {
     let last = url.rsplit('/').next().unwrap_or("");
     last.strip_prefix('v')
         .is_some_and(|digits| !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()))
+}
+
+fn fetched_model_from_entry(entry: ModelEntry) -> FetchedModel {
+    let input_modalities = parse_model_input_modalities(&entry);
+    FetchedModel {
+        id: entry.id,
+        owned_by: entry.owned_by,
+        input_modalities,
+    }
+}
+
+fn parse_model_input_modalities(entry: &ModelEntry) -> Option<Vec<String>> {
+    let mut candidates = vec![
+        entry.input.as_ref(),
+        entry.input_modalities.as_ref(),
+        entry.input_modalities_camel.as_ref(),
+        modality_value_or_input(entry.modalities.as_ref()),
+    ];
+    add_nested_modality_candidates(&mut candidates, entry.architecture.as_ref());
+    add_nested_modality_candidates(&mut candidates, entry.capabilities.as_ref());
+
+    for value in candidates.into_iter().flatten() {
+        if let Some(modalities) = sanitize_input_modalities(value) {
+            return Some(modalities);
+        }
+    }
+
+    let supports_image = entry
+        .vision
+        .or(entry.supports_image)
+        .or(entry.supports_image_camel)?;
+    Some(if supports_image {
+        vec!["text".to_string(), "image".to_string()]
+    } else {
+        vec!["text".to_string()]
+    })
+}
+
+fn add_nested_modality_candidates<'a>(
+    candidates: &mut Vec<Option<&'a Value>>,
+    value: Option<&'a Value>,
+) {
+    let Some(value) = value else {
+        return;
+    };
+
+    candidates.extend([
+        value.get("input_modalities"),
+        value.get("inputModalities"),
+        value.get("input"),
+        modality_value_or_input(Some(value.get("modalities").unwrap_or(value))),
+    ]);
+}
+
+fn modality_value_or_input(value: Option<&Value>) -> Option<&Value> {
+    value.and_then(|modalities| modalities.get("input").or(Some(modalities)))
+}
+
+fn sanitize_input_modalities(value: &Value) -> Option<Vec<String>> {
+    let mut modalities = Vec::new();
+    for item in value.as_array()? {
+        let Some(item) = item.as_str().map(str::trim).filter(|item| !item.is_empty()) else {
+            continue;
+        };
+        let normalized = item.to_ascii_lowercase();
+        if (normalized == "text" || normalized == "image")
+            && !modalities.iter().any(|m| m == &normalized)
+        {
+            modalities.push(normalized);
+        }
+    }
+
+    (!modalities.is_empty()).then_some(modalities)
 }
 
 #[cfg(test)]
@@ -457,6 +541,117 @@ mod tests {
         assert_eq!(data[0].id, "gpt-4");
         assert_eq!(data[0].owned_by.as_deref(), Some("openai"));
         assert_eq!(data[1].id, "claude-3-sonnet");
+    }
+
+    #[test]
+    fn test_parse_response_extracts_input_modalities_metadata() {
+        let json = r#"{
+            "object":"list",
+            "data":[
+                {"id":"array-input","input":[" Text ","IMAGE","audio","image"]},
+                {"id":"snake","input_modalities":["image","text"]},
+                {"id":"camel","inputModalities":["text"]},
+                {"id":"nested","modalities":{"input":["text","image"]}},
+                {"id":"array-modalities","modalities":["text","image"]},
+                {"id":"openrouter-architecture","architecture":{"input_modalities":["text","image"]}},
+                {"id":"camel-architecture","architecture":{"inputModalities":["image","text"]}},
+                {"id":"capabilities-wrapper","capabilities":{"input_modalities":["text","image"]}},
+                {"id":"vision-true","vision":true},
+                {"id":"supports-image-true","supports_image":true},
+                {"id":"supportsImage-false","supportsImage":false},
+                {"id":"empty","input":["audio"," "]},
+                {"id":"none"}
+            ]
+        }"#;
+        let resp: ModelsResponse = serde_json::from_str(json).unwrap();
+        let data = resp.data.unwrap();
+        let fetched: Vec<FetchedModel> = data.into_iter().map(fetched_model_from_entry).collect();
+
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "array-input")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string(), "image".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "snake")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["image".to_string(), "text".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "camel")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "nested")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string(), "image".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "array-modalities")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string(), "image".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "openrouter-architecture")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string(), "image".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "camel-architecture")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["image".to_string(), "text".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "capabilities-wrapper")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string(), "image".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "vision-true")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string(), "image".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "supports-image-true")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string(), "image".to_string()])
+        );
+        assert_eq!(
+            fetched
+                .iter()
+                .find(|m| m.id == "supportsImage-false")
+                .and_then(|m| m.input_modalities.as_ref()),
+            Some(&vec!["text".to_string()])
+        );
+        assert!(fetched
+            .iter()
+            .find(|m| m.id == "empty")
+            .is_some_and(|m| m.input_modalities.is_none()));
+        assert!(fetched
+            .iter()
+            .find(|m| m.id == "none")
+            .is_some_and(|m| m.input_modalities.is_none()));
     }
 
     #[test]

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -94,7 +94,28 @@ interface CodexFormFieldsProps {
 
 type CodexCatalogRow = CodexCatalogModel & { rowId: string };
 
+const normalizeCatalogInputModalities = (
+  inputModalities?: CodexCatalogModel["inputModalities"],
+): NonNullable<CodexCatalogModel["inputModalities"]> => {
+  const normalized: NonNullable<CodexCatalogModel["inputModalities"]> = [];
+  for (const modality of inputModalities ?? []) {
+    if (typeof modality !== "string") continue;
+    const value = modality.trim().toLowerCase();
+    if (
+      (value === "text" || value === "image") &&
+      !normalized.includes(value)
+    ) {
+      normalized.push(value);
+    }
+  }
+  return normalized;
+};
+
 function createCatalogRow(seed?: Partial<CodexCatalogModel>): CodexCatalogRow {
+  const inputModalities = normalizeCatalogInputModalities(
+    seed?.inputModalities,
+  );
+
   return {
     rowId: crypto.randomUUID(),
     model: seed?.model ?? "",
@@ -105,12 +126,24 @@ function createCatalogRow(seed?: Partial<CodexCatalogModel>): CodexCatalogRow {
     ...(seed?.supportsParallelToolCalls !== undefined
       ? { supportsParallelToolCalls: seed.supportsParallelToolCalls }
       : {}),
-    ...(seed?.inputModalities ? { inputModalities: seed.inputModalities } : {}),
+    inputModalities: inputModalities.length > 0 ? inputModalities : ["text"],
     ...(seed?.baseInstructions
       ? { baseInstructions: seed.baseInstructions }
       : {}),
   };
 }
+
+const catalogInputModeValue = (
+  row: CodexCatalogModel,
+): "text" | "text-image" =>
+  normalizeCatalogInputModalities(row.inputModalities).includes("image")
+    ? "text-image"
+    : "text";
+
+const catalogInputModalitiesForMode = (
+  mode: string,
+): CodexCatalogModel["inputModalities"] =>
+  mode === "text-image" ? ["text", "image"] : ["text"];
 
 // Compares rows (with rowId) to incoming models (without) by data fields only,
 // so both sync effects can use the same equality definition. Hidden native-profile
@@ -135,6 +168,38 @@ function catalogRowsMatchModels(
         JSON.stringify(incoming.inputModalities ?? [])
     );
   });
+}
+
+function applyFetchedModelModalitiesToCatalogRows(
+  rows: CodexCatalogRow[],
+  models: FetchedModel[],
+): CodexCatalogRow[] {
+  const modelsById = new Map(models.map((model) => [model.id, model]));
+  let changed = false;
+
+  const nextRows = rows.map((row) => {
+    const modelId = row.model.trim();
+    if (!modelId) return row;
+
+    const inputModalities = normalizeCatalogInputModalities(
+      modelsById.get(modelId)?.inputModalities,
+    );
+    if (inputModalities.length === 0) return row;
+
+    const currentInputModalities = normalizeCatalogInputModalities(
+      row.inputModalities,
+    );
+    if (
+      JSON.stringify(currentInputModalities) === JSON.stringify(inputModalities)
+    ) {
+      return row;
+    }
+
+    changed = true;
+    return { ...row, inputModalities };
+  });
+
+  return changed ? nextRows : rows;
 }
 
 export function CodexFormFields({
@@ -281,6 +346,9 @@ export function CodexFormFields({
     )
       .then((models) => {
         setFetchedModels(models);
+        setCatalogRows((rows) =>
+          applyFetchedModelModalitiesToCatalogRows(rows, models),
+        );
         if (models.length === 0) {
           toast.info(t("providerForm.fetchModelsEmpty"));
         } else {
@@ -558,7 +626,7 @@ export function CodexFormFields({
                   <p className="text-xs leading-relaxed text-muted-foreground">
                     {t("codexConfig.modelMappingHint", {
                       defaultValue:
-                        "选择模型角色后，CC Switch 会自动生成 Codex 兼容路由；菜单显示名可以填 DeepSeek、Kimi 等品牌模型，实际请求模型按右侧填写内容发送。",
+                        "选择模型角色后，CC Switch 会自动生成 Codex 兼容路由；输入类型会写入 Codex catalog，并影响图片请求是否按不支持图片降级。",
                     })}
                   </p>
                 </div>
@@ -566,7 +634,7 @@ export function CodexFormFields({
                 {catalogRows.length > 0 && (
                   <div className="space-y-2">
                     {/* 列头：md+ 显示 */}
-                    <div className="hidden grid-cols-[1fr_1fr_140px_36px] gap-2 px-1 text-xs font-medium text-muted-foreground md:grid">
+                    <div className="hidden grid-cols-[1fr_1fr_140px_140px_36px] gap-2 px-1 text-xs font-medium text-muted-foreground md:grid">
                       <span>
                         {t("codexConfig.catalogColumnDisplay", {
                           defaultValue: "菜单显示名",
@@ -582,13 +650,18 @@ export function CodexFormFields({
                           defaultValue: "上下文窗口",
                         })}
                       </span>
+                      <span>
+                        {t("codexConfig.catalogColumnInput", {
+                          defaultValue: "输入类型",
+                        })}
+                      </span>
                       <span />
                     </div>
 
                     {catalogRows.map((row, index) => (
                       <div
                         key={row.rowId}
-                        className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_1fr_140px_36px]"
+                        className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_1fr_140px_140px_36px]"
                       >
                         <Input
                           value={row.displayName ?? ""}
@@ -629,14 +702,22 @@ export function CodexFormFields({
                           {fetchedModels.length > 0 && (
                             <ModelDropdown
                               models={fetchedModels}
-                              onSelect={(id) =>
+                              onSelect={(id, selected) => {
+                                const inputModalities =
+                                  normalizeCatalogInputModalities(
+                                    selected?.inputModalities,
+                                  );
                                 handleUpdateCatalogRow(index, {
                                   model: id,
                                   displayName: row.displayName?.trim()
                                     ? row.displayName
                                     : id,
-                                })
-                              }
+                                  inputModalities:
+                                    inputModalities.length > 0
+                                      ? inputModalities
+                                      : ["text"],
+                                });
+                              }}
                             />
                           )}
                         </div>
@@ -663,6 +744,39 @@ export function CodexFormFields({
                             defaultValue: "上下文窗口",
                           })}
                         />
+                        <Select
+                          value={catalogInputModeValue(row)}
+                          onValueChange={(value) =>
+                            handleUpdateCatalogRow(index, {
+                              inputModalities:
+                                catalogInputModalitiesForMode(value),
+                            })
+                          }
+                        >
+                          <SelectTrigger
+                            aria-label={t("codexConfig.catalogColumnInput", {
+                              defaultValue: "输入类型",
+                            })}
+                            title={t("codexConfig.catalogInputHelp", {
+                              defaultValue:
+                                "影响 Codex catalog 的 input_modalities，并决定图片请求是否按不支持图片降级。",
+                            })}
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="text">
+                              {t("codexConfig.catalogInputText", {
+                                defaultValue: "文本",
+                              })}
+                            </SelectItem>
+                            <SelectItem value="text-image">
+                              {t("codexConfig.catalogInputTextImage", {
+                                defaultValue: "文本 + 图片",
+                              })}
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
                         <Button
                           type="button"
                           variant="ghost"

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -170,9 +170,17 @@ export const normalizeCodexCatalogModelsForSave = (
       ? Number.parseInt(rawContextWindow, 10)
       : undefined;
 
-    const inputModalities = item.inputModalities?.filter(
-      (m) => typeof m === "string" && m.trim(),
-    );
+    const inputModalities = item.inputModalities?.reduce<string[]>((acc, m) => {
+      if (typeof m !== "string") return acc;
+      const normalized = m.trim().toLowerCase();
+      if (
+        (normalized === "text" || normalized === "image") &&
+        !acc.includes(normalized)
+      ) {
+        acc.push(normalized);
+      }
+      return acc;
+    }, []);
 
     const baseInstructions = item.baseInstructions?.trim();
 

--- a/src/components/providers/forms/shared/ModelDropdown.tsx
+++ b/src/components/providers/forms/shared/ModelDropdown.tsx
@@ -15,7 +15,7 @@ export function ModelDropdown({
   onSelect,
 }: {
   models: FetchedModel[];
-  onSelect: (id: string) => void;
+  onSelect: (id: string, model?: FetchedModel) => void;
 }) {
   const grouped: Record<string, FetchedModel[]> = {};
   for (const model of models) {
@@ -41,7 +41,7 @@ export function ModelDropdown({
             {vi > 0 && <DropdownMenuSeparator />}
             <DropdownMenuLabel>{vendor}</DropdownMenuLabel>
             {grouped[vendor].map((m) => (
-              <DropdownMenuItem key={m.id} onSelect={() => onSelect(m.id)}>
+              <DropdownMenuItem key={m.id} onSelect={() => onSelect(m.id, m)}>
                 {m.id}
               </DropdownMenuItem>
             ))}

--- a/src/lib/api/model-fetch.ts
+++ b/src/lib/api/model-fetch.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 export interface FetchedModel {
   id: string;
   ownedBy: string | null;
+  inputModalities?: string[];
 }
 
 /**

--- a/tests/components/CodexFormFields.catalog.test.tsx
+++ b/tests/components/CodexFormFields.catalog.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps, PropsWithChildren } from "react";
+import { useForm } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CodexFormFields } from "@/components/providers/forms/CodexFormFields";
+import { Form } from "@/components/ui/form";
+import { fetchModelsForConfig } from "@/lib/api/model-fetch";
+
+vi.mock("@/lib/api/model-fetch", () => ({
+  fetchModelsForConfig: vi.fn(),
+  showFetchModelsError: vi.fn(),
+}));
+
+const FormShell = ({ children }: PropsWithChildren) => {
+  const form = useForm();
+
+  return <Form {...form}>{children}</Form>;
+};
+
+const renderCodexForm = (
+  overrides: Partial<ComponentProps<typeof CodexFormFields>> = {},
+) => {
+  const props: ComponentProps<typeof CodexFormFields> = {
+    codexApiKey: "",
+    onApiKeyChange: vi.fn(),
+    category: "custom",
+    shouldShowApiKeyLink: false,
+    websiteUrl: "",
+    shouldShowSpeedTest: false,
+    codexBaseUrl: "",
+    onBaseUrlChange: vi.fn(),
+    isFullUrl: false,
+    onFullUrlChange: vi.fn(),
+    isEndpointModalOpen: false,
+    onEndpointModalToggle: vi.fn(),
+    autoSelect: false,
+    onAutoSelectChange: vi.fn(),
+    apiFormat: "openai_chat",
+    onApiFormatChange: vi.fn(),
+    catalogModels: [],
+    onCatalogModelsChange: vi.fn(),
+    speedTestEndpoints: [],
+    customUserAgent: "",
+    onCustomUserAgentChange: vi.fn(),
+    localProxyHeadersOverride: "",
+    onLocalProxyHeadersOverrideChange: vi.fn(),
+    localProxyBodyOverride: "",
+    onLocalProxyBodyOverrideChange: vi.fn(),
+    ...overrides,
+  };
+
+  return render(
+    <FormShell>
+      <CodexFormFields {...props} />
+    </FormShell>,
+  );
+};
+
+describe("CodexFormFields catalog input modalities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes legacy catalog rows without inputModalities to explicit text", async () => {
+    const handleCatalogModelsChange = vi.fn();
+
+    renderCodexForm({
+      catalogModels: [{ model: "legacy-model" }],
+      onCatalogModelsChange: handleCatalogModelsChange,
+    });
+
+    await waitFor(() =>
+      expect(handleCatalogModelsChange).toHaveBeenCalledWith([
+        expect.objectContaining({
+          model: "legacy-model",
+          inputModalities: ["text"],
+        }),
+      ]),
+    );
+  });
+
+  it("does not crash when catalog inputModalities contains non-string values", () => {
+    expect(() =>
+      renderCodexForm({
+        catalogModels: [
+          {
+            model: "dirty-model",
+            inputModalities: [123] as unknown as string[],
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("resets stale input modalities to text when selecting a metadata-less fetched model", async () => {
+    vi.mocked(fetchModelsForConfig).mockResolvedValue([
+      {
+        id: "text-only-from-upstream",
+        ownedBy: "OpenAI Compatible",
+      },
+    ]);
+    const handleCatalogModelsChange = vi.fn();
+
+    const { container } = renderCodexForm({
+      codexApiKey: "test-key",
+      codexBaseUrl: "http://127.0.0.1:3011/v1",
+      catalogModels: [
+        {
+          model: "old-vision-model",
+          displayName: "Old Vision Model",
+          inputModalities: ["text", "image"],
+        },
+      ],
+      onCatalogModelsChange: handleCatalogModelsChange,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "providerForm.fetchModels" }),
+    );
+
+    await waitFor(() => expect(fetchModelsForConfig).toHaveBeenCalledOnce());
+
+    const modelInput = container.querySelector(
+      'input[value="old-vision-model"]',
+    );
+    const dropdownButton = modelInput?.parentElement?.querySelector("button");
+    expect(dropdownButton).toBeTruthy();
+    await userEvent.click(dropdownButton!);
+    await userEvent.click(await screen.findByText("text-only-from-upstream"));
+
+    await waitFor(() =>
+      expect(handleCatalogModelsChange).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          model: "text-only-from-upstream",
+          displayName: "Old Vision Model",
+          inputModalities: ["text"],
+        }),
+      ]),
+    );
+  });
+
+  it("auto-fills matching catalog row input modalities after fetching models", async () => {
+    vi.mocked(fetchModelsForConfig).mockResolvedValue([
+      {
+        id: "doubao-seed-2.0-pro",
+        ownedBy: "Volcengine",
+        inputModalities: ["text", "image"],
+      },
+    ]);
+    const handleCatalogModelsChange = vi.fn();
+
+    renderCodexForm({
+      codexApiKey: "test-key",
+      codexBaseUrl: "http://127.0.0.1:3011/v1",
+      catalogModels: [{ model: "doubao-seed-2.0-pro" }],
+      onCatalogModelsChange: handleCatalogModelsChange,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "providerForm.fetchModels" }),
+    );
+
+    await waitFor(() =>
+      expect(handleCatalogModelsChange).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          model: "doubao-seed-2.0-pro",
+          inputModalities: ["text", "image"],
+        }),
+      ]),
+    );
+  });
+});

--- a/tests/components/ProviderForm.codexCatalog.test.ts
+++ b/tests/components/ProviderForm.codexCatalog.test.ts
@@ -16,6 +16,28 @@ describe("ProviderForm Codex catalog helpers", () => {
     ]);
   });
 
+  it("sanitizes input modalities before saving", () => {
+    expect(
+      normalizeCodexCatalogModelsForSave([
+        {
+          model: "vision-model",
+          inputModalities: [
+            " Text ",
+            "IMAGE",
+            "audio",
+            "image",
+            " ",
+            "text",
+          ],
+        },
+        { model: "text-model", inputModalities: ["audio", " "] },
+      ]),
+    ).toEqual([
+      { model: "vision-model", inputModalities: ["text", "image"] },
+      { model: "text-model" },
+    ]);
+  });
+
   it("preserves native-profile overrides (parallel tool calls + input modalities + base instructions)", () => {
     expect(
       normalizeCodexCatalogModelsForSave([


### PR DESCRIPTION
## Summary

- Preserve Codex model catalog input modalities through the provider form pipeline.
- Parse upstream model capability metadata when fetching model lists.
- Auto-fill matching Codex catalog rows with fetched input modalities.
- Sanitize and normalize catalog rows so legacy entries default to text-only while image-capable models can be represented explicitly.

## Why

Some upstream model catalogs can expose whether a model supports image input. CC Switch previously normalized Codex catalog rows without carrying that capability through, so image-capable models could be treated as text-only after model-list fetch and catalog save flows.

## Validation

- `vitest run tests/components/CodexFormFields.catalog.test.tsx tests/components/ProviderForm.codexCatalog.test.ts --reporter=verbose`
