### PR TITLE
fix(provider): show and persist API Key when editing uncategorized providers

### DIFF
--- a/src/components/providers/forms/hooks/useApiKeyState.ts
+++ b/src/components/providers/forms/hooks/useApiKeyState.ts
@@ -60,15 +60,13 @@ export function useApiKeyState({
         initialConfig || "{}",
         key.trim(),
         {
-          // 最佳实践：仅在"新增模式"且"非官方类别"时补齐缺失字段
-          // - 新增模式：selectedPresetId !== null
-          // - 非官方类别：category !== undefined && category !== "official"
-          // - 官方类别：不创建字段（UI 也会禁用输入框）
-          // - 未传入 category：不创建字段（避免意外行为）
+          // 仅在"非官方/非云服务商类别"时补齐缺失字段
+          // - official：走 OAuth/订阅登录，不创建字段（UI 也会禁用输入框）
+          // - cloud_provider：走顶层 apiKey 或 IAM，不创建 env 字段
+          // - undefined（导入/旧版本数据未分类）：视为自定义，允许创建，
+          //   否则编辑模式下输入的 API Key 不会写入配置（#5041）
           createIfMissing:
-            selectedPresetId !== null &&
-            category !== undefined &&
-            category !== "official",
+            category !== "official" && category !== "cloud_provider",
           appType,
           apiKeyField,
         },
@@ -88,12 +86,17 @@ export function useApiKeyState({
 
   const showApiKey = useCallback(
     (config: string, isEditMode: boolean) => {
-      return (
-        selectedPresetId !== null ||
-        (isEditMode && hasApiKeyField(config, appType))
-      );
+      if (selectedPresetId !== null) return true;
+      if (!isEditMode) return false;
+      // 编辑模式：非官方/非云服务商类别（含 undefined 的导入/旧版本数据）
+      // 始终显示输入框，便于补填缺失的 API Key（#5041）；
+      // official / cloud_provider 仅在配置已有对应字段时显示
+      if (category !== "official" && category !== "cloud_provider") {
+        return true;
+      }
+      return hasApiKeyField(config, appType);
     },
-    [selectedPresetId, appType],
+    [selectedPresetId, category, appType],
   );
 
   return {

--- a/tests/hooks/useApiKeyState.test.tsx
+++ b/tests/hooks/useApiKeyState.test.tsx
@@ -1,0 +1,218 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useApiKeyState } from "@/components/providers/forms/hooks/useApiKeyState";
+
+describe("useApiKeyState", () => {
+  describe("showApiKey", () => {
+    it("shows the input whenever a preset is selected (add mode)", () => {
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange: vi.fn(),
+          selectedPresetId: "custom",
+          category: "custom",
+          appType: "claude",
+        }),
+      );
+
+      expect(result.current.showApiKey("{}", false)).toBe(true);
+    });
+
+    it("shows the input in edit mode for custom providers even without an API key field (#5041)", () => {
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange: vi.fn(),
+          selectedPresetId: null,
+          category: "custom",
+          appType: "claude",
+        }),
+      );
+
+      expect(result.current.showApiKey("{}", true)).toBe(true);
+    });
+
+    it("shows the input in edit mode when category is undefined (imported/legacy providers)", () => {
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange: vi.fn(),
+          selectedPresetId: null,
+          category: undefined,
+          appType: "claude",
+        }),
+      );
+
+      expect(result.current.showApiKey("{}", true)).toBe(true);
+    });
+
+    it("hides the input in edit mode for official providers without an API key field", () => {
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange: vi.fn(),
+          selectedPresetId: null,
+          category: "official",
+          appType: "claude",
+        }),
+      );
+
+      expect(result.current.showApiKey("{}", true)).toBe(false);
+    });
+
+    it("shows the input in edit mode for official providers when the config already has the field", () => {
+      const config = JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: "sk-1" } });
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: config,
+          onConfigChange: vi.fn(),
+          selectedPresetId: null,
+          category: "official",
+          appType: "claude",
+        }),
+      );
+
+      expect(result.current.showApiKey(config, true)).toBe(true);
+    });
+
+    it("hides the input in edit mode for cloud providers without an API key field", () => {
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange: vi.fn(),
+          selectedPresetId: null,
+          category: "cloud_provider",
+          appType: "claude",
+        }),
+      );
+
+      expect(result.current.showApiKey("{}", true)).toBe(false);
+    });
+  });
+
+  describe("handleApiKeyChange", () => {
+    it("creates the missing API key field in edit mode for custom providers (#5041)", () => {
+      let latestConfig = "{}";
+      const onConfigChange = vi.fn((config: string) => {
+        latestConfig = config;
+      });
+
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange,
+          selectedPresetId: null,
+          category: "custom",
+          appType: "claude",
+        }),
+      );
+
+      act(() => {
+        result.current.handleApiKeyChange("sk-new-key");
+      });
+
+      expect(JSON.parse(latestConfig).env.ANTHROPIC_AUTH_TOKEN).toBe(
+        "sk-new-key",
+      );
+    });
+
+    it("creates the missing API key field in edit mode when category is undefined", () => {
+      let latestConfig = "{}";
+      const onConfigChange = vi.fn((config: string) => {
+        latestConfig = config;
+      });
+
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange,
+          selectedPresetId: null,
+          category: undefined,
+          appType: "claude",
+        }),
+      );
+
+      act(() => {
+        result.current.handleApiKeyChange("sk-new-key");
+      });
+
+      expect(JSON.parse(latestConfig).env.ANTHROPIC_AUTH_TOKEN).toBe(
+        "sk-new-key",
+      );
+    });
+
+    it("respects apiKeyField when creating the missing field", () => {
+      let latestConfig = "{}";
+      const onConfigChange = vi.fn((config: string) => {
+        latestConfig = config;
+      });
+
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange,
+          selectedPresetId: null,
+          category: "custom",
+          appType: "claude",
+          apiKeyField: "ANTHROPIC_API_KEY",
+        }),
+      );
+
+      act(() => {
+        result.current.handleApiKeyChange("sk-new-key");
+      });
+
+      const env = JSON.parse(latestConfig).env;
+      expect(env.ANTHROPIC_API_KEY).toBe("sk-new-key");
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    });
+
+    it("does not create the field for official providers", () => {
+      const onConfigChange = vi.fn();
+
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig: "{}",
+          onConfigChange,
+          selectedPresetId: null,
+          category: "official",
+          appType: "claude",
+        }),
+      );
+
+      act(() => {
+        result.current.handleApiKeyChange("sk-new-key");
+      });
+
+      expect(onConfigChange).toHaveBeenCalledWith("{}");
+    });
+
+    it("updates the existing field for official providers without creating new ones", () => {
+      const initialConfig = JSON.stringify({
+        env: { ANTHROPIC_API_KEY: "sk-old" },
+      });
+      let latestConfig = initialConfig;
+      const onConfigChange = vi.fn((config: string) => {
+        latestConfig = config;
+      });
+
+      const { result } = renderHook(() =>
+        useApiKeyState({
+          initialConfig,
+          onConfigChange,
+          selectedPresetId: null,
+          category: "official",
+          appType: "claude",
+        }),
+      );
+
+      act(() => {
+        result.current.handleApiKeyChange("sk-updated");
+      });
+
+      const env = JSON.parse(latestConfig).env;
+      expect(env.ANTHROPIC_API_KEY).toBe("sk-updated");
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary / 概述

When editing a Claude (or Gemini) provider whose `category` is `undefined` — which is the case for providers created via import, older app versions, or manual JSON edits — and whose config does not yet contain an API key field (`ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY`), the edit form gives the user no way to add a key:

1. `showApiKey` in `useApiKeyState` only rendered the input in edit mode when `hasApiKeyField(config)` was already true, so the input never appeared.
2. Even when the input was visible, `createIfMissing` for `setApiKeyInConfig` required `selectedPresetId !== null` (add mode only) plus `category !== undefined`, so a typed key was silently dropped and never written into the config.

Codex is unaffected because `CodexFormFields` renders `ApiKeySection` unconditionally — which is also why the issue only reproduces on the Claude form.

This PR treats every category except `official` and `cloud_provider` (including `undefined`) as custom-like in `useApiKeyState`:

- **`showApiKey`**: in edit mode, always show the input for custom-like categories; `official` / `cloud_provider` keep the previous behavior (only shown when the config already has the field).
- **`createIfMissing`**: create the missing key field for custom-like categories (respecting the configured `apiKeyField`); never create for `official` / `cloud_provider`.

OAuth-based presets (GitHub Copilot / Codex OAuth) are unaffected: `ClaudeFormFields` independently hides the input via `!usesOAuth`, and the `cloud_provider` guard at the `ProviderForm` call site is preserved.

Added `tests/hooks/useApiKeyState.test.tsx` (11 cases) covering visibility and persistence for `custom` / `undefined` / `official` / `cloud_provider` categories, including the `apiKeyField` override and the official-provider "update existing field only" path.

## Related Issue / 关联 Issue

Fixes #5041

## Screenshots / 截图

N/A — behavior change is covered by unit tests (input visibility & config writes in edit mode).

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）— no Rust changes
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — no user-facing text changed

`pnpm test:unit`: 66 files / 408 tests passing.
