### PR TITLE
fix(proxy): inject a single auth placeholder on managed Claude takeover

### DIFF
--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -189,15 +189,20 @@ impl ProxyService {
                 for key in token_keys {
                     env.remove(key);
                 }
-                env.insert(
-                    "ANTHROPIC_API_KEY".to_string(),
-                    json!(PROXY_TOKEN_PLACEHOLDER),
-                );
+                // 只注入一个认证键：两者同时存在会触发 Claude Code 的
+                // "Both ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY set" 警告（#4919）。
+                // - Codex 系保留 AUTH_TOKEN：缺该键 Claude Code 会弹登录提示（#3784）。
+                //   无条件注入而非"已存在才保留"：热切换路径传入的是 provider
+                //   settings（预设不含该键），且旧版接管已把存量用户 live 中的键删光。
+                // - Copilot 仅 API_KEY：避免与 /login 管理的 key 冲突（#1049）。
                 if keep_auth_token {
-                    // 无条件注入而非"已存在才保留"：热切换路径传入的是 provider
-                    // settings（预设不含该键），且旧版接管已把存量用户 live 中的键删光。
                     env.insert(
                         "ANTHROPIC_AUTH_TOKEN".to_string(),
+                        json!(PROXY_TOKEN_PLACEHOLDER),
+                    );
+                } else {
+                    env.insert(
+                        "ANTHROPIC_API_KEY".to_string(),
                         json!(PROXY_TOKEN_PLACEHOLDER),
                     );
                 }
@@ -3074,7 +3079,8 @@ mod tests {
         assert_env_str(env, "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME", Some("gpt-5.4"));
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-4-8"));
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME", Some("gpt-5.4"));
-        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
+        // Codex 系只保留 AUTH_TOKEN；双键会触发 Claude Code 告警（#4919）
+        assert_env_str(env, "ANTHROPIC_API_KEY", None);
         assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
     }
 
@@ -3107,7 +3113,7 @@ mod tests {
             .get("env")
             .and_then(|value| value.as_object())
             .expect("env should exist");
-        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_API_KEY", None);
         assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
     }
 
@@ -3139,8 +3145,47 @@ mod tests {
             .get("env")
             .and_then(|value| value.as_object())
             .expect("env should exist");
-        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_API_KEY", None);
         assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+    }
+
+    // #4919 复现场景：从第三方 Claude 供应商（live 已有 AUTH_TOKEN）切换到
+    // Codex 受管供应商时，只应保留 AUTH_TOKEN 占位符，不得同时写入 API_KEY。
+    #[test]
+    fn managed_account_claude_takeover_codex_from_third_party_keeps_single_auth_key() {
+        let mut provider = Provider::with_id(
+            "codex".to_string(),
+            "Codex".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://chatgpt.com/backend-api/codex"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            ..Default::default()
+        });
+
+        let mut live_config = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+                "ANTHROPIC_AUTH_TOKEN": "sk-third-party"
+            }
+        });
+        ProxyService::apply_claude_takeover_fields_for_provider(
+            &mut live_config,
+            "http://127.0.0.1:15721",
+            &provider,
+        );
+
+        let env = live_config
+            .get("env")
+            .and_then(|value| value.as_object())
+            .expect("env should exist");
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_API_KEY", None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Switching the Claude provider from a third-party (DeepSeek / MiMo / …) to a managed **Codex** provider writes **both** `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` (as `PROXY_MANAGED`) into `~/.claude/settings.json`, so every `claude` run warns:

> Both ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY set · auth may not work as expected

### Root cause

The double key is an accretion artifact in `apply_claude_takeover_fields_with_policy_and_models` (`services/proxy.rs`):

1. `61e68d75` made the `ManagedAccount` takeover policy inject **only** `ANTHROPIC_API_KEY` (Copilot, #1049).
2. `2d64d8c6` (PR #3789, fixing the Codex login-prompt issue #3784) added the unconditional `ANTHROPIC_AUTH_TOKEN` insert for Codex **on top**, without removing the `ANTHROPIC_API_KEY` insert.

Since then every Codex-managed takeover writes both keys — exactly what this issue reports (steps 3/4: Codex → both keys + warning; third-party → single `AUTH_TOKEN`, no warning).

### Fix

Inject exactly **one** placeholder per policy, preserving the intent of both prior fixes:

- Codex-managed (`keep_auth_token: true`) → only `ANTHROPIC_AUTH_TOKEN` (missing it triggers the Claude Code login prompt, #3784 — unchanged).
- Copilot (`keep_auth_token: false`) → only `ANTHROPIC_API_KEY` (avoids conflicting with the `/login`-managed key, #1049 — unchanged).

Local-proxy auth is unaffected: the forwarder resolves the `PROXY_MANAGED` placeholder regardless of which header the client sends (there is existing test coverage for `Authorization: Bearer PROXY_MANAGED`), and non-managed providers already run with `ANTHROPIC_AUTH_TOKEN` only.

### Tests

- Updated the three Codex managed-takeover tests to assert `ANTHROPIC_API_KEY` is **absent** (they previously locked in the double-key state).
- Added `managed_account_claude_takeover_codex_from_third_party_keeps_single_auth_key` reproducing the exact reported scenario: live config from a third-party provider (existing `AUTH_TOKEN`) switched to Codex → single `AUTH_TOKEN` placeholder, no `API_KEY`.
- Copilot regression assertions untouched and passing.

## Related Issue / 关联 Issue

Fixes #4919

## Screenshots / 截图

N/A — backend config-takeover change, covered by unit tests.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查 — no frontend changes
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — no user-facing text changed

## Verification / 验证

- `cargo fmt --check`
- `cargo clippy --lib` — no warnings
- `cargo test --lib` — 1752 passed, 0 failed
