### PR TITLE
fix(codex): strip image generation tools from responses

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ onlyBuiltDependencies:
 
 ignoredBuiltDependencies:
   - msw
+
+allowBuilds:
+  '@tailwindcss/oxide': true
+  esbuild: true
+  msw: false

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -478,6 +478,12 @@ pub struct ProviderMeta {
     /// Codex Responses -> Chat Completions reasoning capability metadata.
     #[serde(rename = "codexChatReasoning", skip_serializing_if = "Option::is_none")]
     pub codex_chat_reasoning: Option<CodexChatReasoningConfig>,
+    /// Codex Responses request sanitizer: strip image-generation tool declarations before upstream.
+    #[serde(
+        rename = "stripCodexImageGenerationTools",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub strip_codex_image_generation_tools: Option<bool>,
     /// Custom User-Agent for local proxy routing.
     #[serde(rename = "customUserAgent", skip_serializing_if = "Option::is_none")]
     pub custom_user_agent: Option<String>,
@@ -1010,6 +1016,22 @@ mod tests {
         let overrides = decoded.local_proxy_request_overrides.unwrap();
         assert_eq!(overrides.headers.get("X-Test"), Some(&"yes".to_string()));
         assert_eq!(overrides.body.unwrap()["temperature"], 0.2);
+    }
+
+    #[test]
+    fn provider_meta_roundtrips_strip_codex_image_generation_tools() {
+        let meta = ProviderMeta {
+            strip_codex_image_generation_tools: Some(false),
+            ..ProviderMeta::default()
+        };
+
+        let value = serde_json::to_value(&meta).expect("serialize ProviderMeta");
+        assert_eq!(value["stripCodexImageGenerationTools"], false);
+        assert!(value.get("strip_codex_image_generation_tools").is_none());
+
+        let decoded: ProviderMeta =
+            serde_json::from_value(value).expect("deserialize ProviderMeta");
+        assert_eq!(decoded.strip_codex_image_generation_tools, Some(false));
     }
 
     #[test]

--- a/src-tauri/src/proxy/body_filter.rs
+++ b/src-tauri/src/proxy/body_filter.rs
@@ -18,6 +18,12 @@
 use serde_json::Value;
 use std::collections::HashSet;
 
+const IMAGE_GENERATION_TOOL_TYPES: &[&str] = &[
+    "image_generation",
+    "image_generation_call",
+    "image_generation_preview",
+];
+
 /// 过滤私有参数（以 `_` 开头的字段）
 ///
 /// 递归遍历 JSON 结构，移除所有以下划线开头的字段。
@@ -70,6 +76,17 @@ pub fn filter_private_params_with_whitelist(body: Value, whitelist: &[String]) -
     filter_recursive_with_whitelist(body, &mut Vec::new(), &mut Vec::new(), &whitelist_set)
 }
 
+/// 移除 Codex Responses 请求中会触发部分上游生图权限校验的工具声明。
+///
+/// - 移除 `type` 为 `image_generation` / `image_generation_call` /
+///   `image_generation_preview` 的对象
+/// - 移除 `name` 中包含 `image_generation`（大小写不敏感）的对象
+pub fn strip_image_generation_tools(body: Value) -> (Value, usize) {
+    let mut removed = 0;
+    let filtered = strip_image_generation_recursive(body, &mut removed);
+    (filtered, removed)
+}
+
 /// 递归过滤实现（支持白名单）
 fn filter_recursive_with_whitelist(
     value: Value,
@@ -115,6 +132,58 @@ fn filter_recursive_with_whitelist(
         ),
         other => other,
     }
+}
+
+fn strip_image_generation_recursive(value: Value, removed: &mut usize) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(
+            items
+                .into_iter()
+                .filter_map(|item| {
+                    if is_image_generation_tool_object(&item) {
+                        *removed += 1;
+                        None
+                    } else {
+                        Some(strip_image_generation_recursive(item, removed))
+                    }
+                })
+                .collect(),
+        ),
+        Value::Object(map) => {
+            let filtered: serde_json::Map<String, Value> = map
+                .into_iter()
+                .filter_map(|(key, child)| {
+                    if is_image_generation_tool_object(&child) {
+                        *removed += 1;
+                        None
+                    } else {
+                        Some((key, strip_image_generation_recursive(child, removed)))
+                    }
+                })
+                .collect();
+            Value::Object(filtered)
+        }
+        other => other,
+    }
+}
+
+fn is_image_generation_tool_object(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+
+    if object
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|value_type| IMAGE_GENERATION_TOOL_TYPES.contains(&value_type))
+    {
+        return true;
+    }
+
+    object
+        .get("name")
+        .and_then(Value::as_str)
+        .is_some_and(|name| name.to_ascii_lowercase().contains("image_generation"))
 }
 
 fn matches_schema_name_map(key: &str) -> bool {
@@ -335,5 +404,59 @@ mod tests {
         let output2 = filter_private_params_with_whitelist(input, &[]);
 
         assert_eq!(output1, output2);
+    }
+
+    #[test]
+    fn test_strip_image_generation_tools_removes_codex_proxy_tool_types() {
+        let input = json!({
+            "model": "gpt-5-codex",
+            "tools": [
+                {"type": "function", "name": "shell"},
+                {"type": "image_generation"},
+                {"type": "image_generation_call"},
+                {"type": "image_generation_preview"}
+            ],
+            "tool_choice": {"type": "image_generation"}
+        });
+
+        let (output, removed) = strip_image_generation_tools(input);
+
+        assert_eq!(removed, 4);
+        assert_eq!(
+            output["tools"],
+            json!([{"type": "function", "name": "shell"}])
+        );
+        assert!(output.get("tool_choice").is_none());
+    }
+
+    #[test]
+    fn test_strip_image_generation_tools_removes_nested_name_matches() {
+        let input = json!({
+            "metadata": {
+                "keep": true,
+                "nested": {
+                    "name": "preview_image_generation_tool",
+                    "description": "drop me"
+                }
+            },
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "hello"},
+                        {"name": "IMAGE_GENERATION_helper", "enabled": true}
+                    ]
+                }
+            ]
+        });
+
+        let (output, removed) = strip_image_generation_tools(input);
+
+        assert_eq!(removed, 2);
+        assert_eq!(output["metadata"], json!({"keep": true}));
+        assert_eq!(
+            output["input"][0]["content"],
+            json!([{"type": "input_text", "text": "hello"}])
+        );
     }
 }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -4,7 +4,7 @@
 
 use super::hyper_client::ProxyResponse;
 use super::{
-    body_filter::filter_private_params_with_whitelist,
+    body_filter::{filter_private_params_with_whitelist, strip_image_generation_tools},
     content_encoding::{decompress_body, get_content_encoding},
     error::*,
     failover_switch::FailoverSwitchManager,
@@ -1302,6 +1302,14 @@ impl RequestForwarder {
         };
         let codex_responses_to_chat = matches!(app_type, AppType::Codex)
             && super::providers::should_convert_codex_responses_to_chat(provider, endpoint);
+        if matches!(app_type, AppType::Codex) {
+            mapped_body = strip_codex_image_generation_tools_for_endpoint(
+                app_type,
+                provider,
+                endpoint,
+                mapped_body,
+            );
+        }
         let (effective_endpoint, passthrough_query) = if codex_responses_to_chat {
             rewrite_codex_responses_endpoint_to_chat(endpoint)
         } else if needs_transform && adapter.name() == "Claude" {
@@ -1398,6 +1406,12 @@ impl RequestForwarder {
                 .and_then(|meta| meta.local_proxy_request_overrides.as_ref())
             {
                 if apply_local_proxy_body_overrides(&mut filtered_body, overrides) {
+                    filtered_body = strip_codex_image_generation_tools_for_endpoint(
+                        app_type,
+                        provider,
+                        endpoint,
+                        filtered_body,
+                    );
                     filtered_body = prepare_upstream_request_body(filtered_body);
                 }
             }
@@ -2733,6 +2747,42 @@ fn prepare_upstream_request_body(request_body: Value) -> Value {
     canonicalize_value(filter_private_params_with_whitelist(request_body, &[]))
 }
 
+fn strip_codex_image_generation_tools_for_endpoint(
+    app_type: &AppType,
+    provider: &Provider,
+    endpoint: &str,
+    body: Value,
+) -> Value {
+    if !matches!(app_type, AppType::Codex) || !is_codex_responses_endpoint(endpoint) {
+        return body;
+    }
+
+    if provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.strip_codex_image_generation_tools)
+        == Some(false)
+    {
+        return body;
+    }
+
+    let (filtered, removed) = strip_image_generation_tools(body);
+    if removed > 0 {
+        log::info!(
+            "[Codex] Stripped {removed} image-generation tool declaration(s) from {endpoint}"
+        );
+    }
+    filtered
+}
+
+fn is_codex_responses_endpoint(endpoint: &str) -> bool {
+    let (path, _) = split_endpoint_and_query(endpoint);
+    matches!(
+        path,
+        "/responses" | "/v1/responses" | "/responses/compact" | "/v1/responses/compact"
+    )
+}
+
 fn log_prompt_cache_trace(
     app_type: &AppType,
     provider: &Provider,
@@ -2989,6 +3039,80 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&prepared).unwrap(),
             r#"{"a":2,"tools":[{"name":"lookup","parameters":{"properties":{"_id":{"type":"string"},"a":{"type":"string"},"b":{"type":"number"}},"type":"object"}}],"z":1}"#
+        );
+    }
+
+    #[test]
+    fn codex_responses_body_strips_image_generation_tools_only_for_codex() {
+        let body = json!({
+            "model": "gpt-5-codex",
+            "tools": [
+                {"type": "function", "name": "shell"},
+                {"type": "image_generation"}
+            ]
+        });
+
+        let stripped = strip_codex_image_generation_tools_for_endpoint(
+            &AppType::Codex,
+            &test_provider_with_type(None),
+            "/responses?trace=1",
+            body.clone(),
+        );
+        assert_eq!(
+            stripped["tools"],
+            json!([{"type": "function", "name": "shell"}])
+        );
+
+        let untouched_claude = strip_codex_image_generation_tools_for_endpoint(
+            &AppType::Claude,
+            &test_provider_with_type(None),
+            "/v1/messages",
+            body.clone(),
+        );
+        assert_eq!(untouched_claude, body);
+
+        let untouched_codex_models = strip_codex_image_generation_tools_for_endpoint(
+            &AppType::Codex,
+            &test_provider_with_type(None),
+            "/v1/models",
+            body.clone(),
+        );
+        assert_eq!(untouched_codex_models, body);
+    }
+
+    #[test]
+    fn codex_responses_body_respects_image_generation_strip_toggle() {
+        let body = json!({
+            "model": "gpt-5-codex",
+            "tools": [
+                {"type": "function", "name": "shell"},
+                {"type": "image_generation"}
+            ]
+        });
+        let mut disabled_provider = test_provider_with_type(None);
+        disabled_provider.meta = Some(crate::provider::ProviderMeta {
+            strip_codex_image_generation_tools: Some(false),
+            ..Default::default()
+        });
+
+        let untouched = strip_codex_image_generation_tools_for_endpoint(
+            &AppType::Codex,
+            &disabled_provider,
+            "/responses",
+            body.clone(),
+        );
+        assert_eq!(untouched, body);
+
+        let default_provider = test_provider_with_type(None);
+        let stripped = strip_codex_image_generation_tools_for_endpoint(
+            &AppType::Codex,
+            &default_provider,
+            "/responses",
+            body,
+        );
+        assert_eq!(
+            stripped["tools"],
+            json!([{"type": "function", "name": "shell"}])
         );
     }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1020,6 +1020,12 @@ base_url = "http://localhost:8080"
         db.save_live_backup("claude-desktop", "{}")
             .await
             .expect("seed live backup");
+        db.update_proxy_config(ProxyConfig {
+            listen_port: 0,
+            ..Default::default()
+        })
+        .await
+        .expect("use ephemeral proxy port");
         {
             let mut config = db
                 .get_proxy_config_for_app("claude-desktop")
@@ -1031,7 +1037,7 @@ base_url = "http://localhost:8080"
                 .expect("update app proxy config");
         }
 
-        state
+        let proxy_info = state
             .proxy_service
             .start()
             .await
@@ -1079,7 +1085,10 @@ base_url = "http://localhost:8080"
         let profile: Value = read_json_file(&profile_path).expect("read desktop profile");
         assert_eq!(
             profile["inferenceGatewayBaseUrl"],
-            json!("http://127.0.0.1:15721/claude-desktop"),
+            json!(format!(
+                "http://127.0.0.1:{}/claude-desktop",
+                proxy_info.port
+            )),
             "desktop profile should stay pointed at the local gateway during takeover"
         );
         assert_eq!(profile["inferenceGatewayAuthScheme"], json!("bearer"));

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -83,7 +83,9 @@ interface CodexFormFieldsProps {
   // Speed Test Endpoints
   speedTestEndpoints: EndpointCandidate[];
 
-  // Local proxy User-Agent override
+  // Local proxy request behavior
+  stripCodexImageGenerationTools: boolean;
+  onStripCodexImageGenerationToolsChange: (value: boolean) => void;
   customUserAgent: string;
   onCustomUserAgentChange: (value: string) => void;
   localProxyHeadersOverride: string;
@@ -163,6 +165,8 @@ export function CodexFormFields({
   catalogModels = [],
   onCatalogModelsChange,
   speedTestEndpoints,
+  stripCodexImageGenerationTools,
+  onStripCodexImageGenerationToolsChange,
   customUserAgent,
   onCustomUserAgentChange,
   localProxyHeadersOverride,
@@ -185,13 +189,15 @@ export function CodexFormFields({
   const supportsEffort = codexChatReasoning.supportsEffort === true;
 
   // 高级区在有任何可见配置时自动展开（仅折叠→展开，不会自动折叠）：自定义 UA /
-  // 请求覆盖 / 已填模型映射 / 原生 Responses（需维护 catalog）/ 已配置思考能力。
+  // 请求覆盖 / 已填模型映射 / 原生 Responses（需维护 catalog）/ 已配置思考能力 /
+  // 手动关闭 Codex 生图工具过滤。
   const hasRequestOverrides = Boolean(
     localProxyHeadersOverride.trim() || localProxyBodyOverride.trim(),
   );
   const hasAnyAdvancedValue =
     !!customUserAgent ||
     hasRequestOverrides ||
+    !stripCodexImageGenerationTools ||
     catalogModels.length > 0 ||
     apiFormat === "openai_responses" ||
     supportsThinking ||
@@ -694,6 +700,28 @@ export function CodexFormFields({
                 value={customUserAgent}
                 onChange={onCustomUserAgentChange}
               />
+              <div className="flex items-center justify-between gap-4 border-t border-border-default pt-3">
+                <div className="space-y-1">
+                  <FormLabel>
+                    {t("codexConfig.stripImageGenerationToolsToggle", {
+                      defaultValue: "过滤生图工具声明",
+                    })}
+                  </FormLabel>
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    {t("codexConfig.stripImageGenerationToolsHint", {
+                      defaultValue:
+                        "开启后，Codex Responses 请求发往上游前会移除 image_generation 相关工具声明，避免部分中转站因生图权限检查直接返回 403。",
+                    })}
+                  </p>
+                </div>
+                <Switch
+                  checked={stripCodexImageGenerationTools}
+                  onCheckedChange={onStripCodexImageGenerationToolsChange}
+                  aria-label={t("codexConfig.stripImageGenerationToolsToggle", {
+                    defaultValue: "过滤生图工具声明",
+                  })}
+                />
+              </div>
               <div className="border-t border-border-default pt-3">
                 <LocalProxyRequestOverridesField
                   headersJson={localProxyHeadersOverride}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -379,6 +379,9 @@ function ProviderFormFull({
       ),
     });
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
+    setStripCodexImageGenerationTools(
+      initialData?.meta?.stripCodexImageGenerationTools ?? true,
+    );
     setCustomUserAgent(initialData?.meta?.customUserAgent ?? "");
     setLocalProxyHeadersOverride(
       formatRequestOverrideObject(
@@ -550,6 +553,10 @@ function ProviderFormFull({
   const [codexChatReasoning, setCodexChatReasoning] =
     useState<CodexChatReasoning>(
       () => initialData?.meta?.codexChatReasoning ?? {},
+    );
+  const [stripCodexImageGenerationTools, setStripCodexImageGenerationTools] =
+    useState<boolean>(
+      () => initialData?.meta?.stripCodexImageGenerationTools ?? true,
     );
   const [customUserAgent, setCustomUserAgent] = useState<string>(
     () => initialData?.meta?.customUserAgent ?? "",
@@ -1476,6 +1483,10 @@ function ProviderFormFull({
         localCodexApiFormat === "openai_chat"
           ? normalizeCodexChatReasoningForSave(codexChatReasoning)
           : undefined,
+      stripCodexImageGenerationTools:
+        appId === "codex" && !stripCodexImageGenerationTools
+          ? false
+          : undefined,
       customUserAgent:
         (appId === "claude" || appId === "codex") && category !== "official"
           ? customUserAgent.trim() || undefined
@@ -2147,6 +2158,10 @@ function ProviderFormFull({
               catalogModels={codexCatalogModels}
               onCatalogModelsChange={setCodexCatalogModels}
               speedTestEndpoints={speedTestEndpoints}
+              stripCodexImageGenerationTools={stripCodexImageGenerationTools}
+              onStripCodexImageGenerationToolsChange={
+                setStripCodexImageGenerationTools
+              }
               customUserAgent={customUserAgent}
               onCustomUserAgentChange={setCustomUserAgent}
               localProxyHeadersOverride={localProxyHeadersOverride}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1313,6 +1313,8 @@
     "reasoningEffortHint": "Enable when the upstream supports thinking-depth control such as low/high/max. Enabling this also turns on thinking mode and converts Codex's reasoning.effort into the upstream Chat parameter.",
     "reasoningGroupTitle": "Reasoning Capability",
     "reasoningSectionHint": "Preset providers are configured automatically; custom providers are inferred from name/URL. Override manually only when auto-detection is wrong.",
+    "stripImageGenerationToolsToggle": "Strip image-generation tool declarations",
+    "stripImageGenerationToolsHint": "When enabled, Codex Responses requests have image_generation tool declarations removed before they are sent upstream, avoiding 403 errors from relays that check image-generation permissions.",
     "advancedSectionHint": "Includes upstream format, model mapping, reasoning overrides and custom User-Agent. Providers using the Chat Completions protocol require routing takeover to be enabled."
   },
   "geminiConfig": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1313,6 +1313,8 @@
     "reasoningEffortHint": "上流が low/high/max などの思考の深さの制御に対応している場合に有効化します。有効にすると思考モードも自動的にオンになり、Codex の reasoning.effort を上流の Chat パラメータに変換します。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "プリセットの供給元は自動的に設定され、カスタム供給元は名前/URL から自動推論されます。自動識別が正しくない場合のみ手動で上書きしてください。",
+    "stripImageGenerationToolsToggle": "画像生成ツール宣言を除去",
+    "stripImageGenerationToolsHint": "有効にすると、Codex Responses リクエストを上流へ送る前に image_generation 関連のツール宣言を除去し、画像生成権限チェックによる一部リレーの 403 エラーを回避します。",
     "advancedSectionHint": "上流フォーマット、モデルマッピング、思考能力、カスタム User-Agent の設定を含みます。Chat Completions プロトコルを使用するプロバイダーはルーティング引き継ぎの有効化が必要です。"
   },
   "geminiConfig": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1285,6 +1285,8 @@
     "reasoningEffortHint": "上游支援 low/high/max 等思考深度控制時啟用。啟用後會自動啟用思考模式，並把 Codex 的 reasoning.effort 轉成上游 Chat 參數。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "預設供應商已自動設定；自訂供應商會按名稱/位址自動推斷。僅當自動識別不準時才需手動覆寫。",
+    "stripImageGenerationToolsToggle": "過濾生圖工具宣告",
+    "stripImageGenerationToolsHint": "開啟後，Codex Responses 請求送往上游前會移除 image_generation 相關工具宣告，避免部分中轉站因生圖權限檢查直接返回 403。",
     "advancedSectionHint": "包含上游格式、模型映射、思考能力與自訂 User-Agent。使用 Chat Completions 協定的供應商需開啟路由接管才能使用。"
   },
   "geminiConfig": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1313,6 +1313,8 @@
     "reasoningEffortHint": "上游支持 low/high/max 等思考深度控制时启用。启用后会自动启用思考模式，并把 Codex 的 reasoning.effort 转成上游 Chat 参数。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "预设供应商已自动配置；自定义供应商会按名称/地址自动推断。仅当自动识别不准时才需手动覆盖。",
+    "stripImageGenerationToolsToggle": "过滤生图工具声明",
+    "stripImageGenerationToolsHint": "开启后，Codex Responses 请求发往上游前会移除 image_generation 相关工具声明，避免部分中转站因生图权限检查直接返回 403。",
     "advancedSectionHint": "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。"
   },
   "geminiConfig": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,6 +222,8 @@ export interface ProviderMeta {
   codexFastMode?: boolean;
   // Codex Responses -> Chat Completions reasoning capability metadata
   codexChatReasoning?: CodexChatReasoning;
+  // Strip Codex image-generation tool declarations from Responses requests.
+  stripCodexImageGenerationTools?: boolean;
   // Custom User-Agent for local proxy routing. Only applied by the local proxy.
   customUserAgent?: string;
   // Local proxy request overrides. Only applied by the local proxy after route transforms.

--- a/tests/components/ProviderForm.codexMeta.test.tsx
+++ b/tests/components/ProviderForm.codexMeta.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderForm } from "@/components/providers/forms/ProviderForm";
+
+describe("ProviderForm Codex meta", () => {
+  it("preserves explicit image-generation strip opt-out when saving official Codex providers", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="codex"
+          submitLabel="Save"
+          onSubmit={handleSubmit}
+          onCancel={vi.fn()}
+          showButtons={false}
+          initialData={{
+            name: "OpenAI",
+            category: "official",
+            settingsConfig: {
+              auth: {},
+              config: 'model_provider = "openai"\n',
+            },
+            meta: {
+              stripCodexImageGenerationTools: false,
+            },
+          }}
+        />
+        <button type="submit" form="provider-form">
+          Submit
+        </button>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+    expect(
+      handleSubmit.mock.calls[0][0].meta?.stripCodexImageGenerationTools,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary / 概述

- Strip Codex Responses image-generation tool declarations before forwarding requests upstream to avoid upstream image-generation permission checks on non-image requests.
- Limit the sanitizer to Codex `/responses` and `/responses/compact` requests so Claude and other Codex endpoints are unaffected.
- Add a Codex provider-level advanced toggle, enabled by default, with localized UI copy for all existing locales.
- Configure explicit pnpm build approvals for the current workspace and make the Claude Desktop takeover test use an ephemeral proxy port, so local verification does not depend on runtime-specific pnpm behavior or `127.0.0.1:15721` being free.

## Related Issue / 关联 Issue

Fixes #4309

## Screenshots / 截图

N/A - this adds one advanced Codex provider switch using the existing switch-row styling.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

## Validation Notes / 验证说明

Passed locally:

- `CI=true corepack pnpm@10.12.3 install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` (66 files / 406 tests)
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml` (full backend suite: 1767 lib tests passed, 2 ignored, plus integration test targets passed)
- `git diff --check`

