### PR TITLE
fix(sessions): cap transcript payloads and evict cached messages on close

### DIFF
--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -8,8 +8,8 @@ use crate::config::get_claude_config_dir;
 use crate::session_manager::{SessionMessage, SessionMeta};
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines, truncate_summary,
-    TITLE_MAX_CHARS,
+    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines,
+    truncate_message_content, truncate_summary, TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "claude";
@@ -79,7 +79,11 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
 
         let ts = value.get("timestamp").and_then(parse_timestamp_to_ms);
 
-        messages.push(SessionMessage { role, content, ts });
+        messages.push(SessionMessage {
+            role,
+            content: truncate_message_content(content),
+            ts,
+        });
     }
 
     Ok(messages)

--- a/src-tauri/src/session_manager/providers/codex.rs
+++ b/src-tauri/src/session_manager/providers/codex.rs
@@ -15,8 +15,8 @@ use crate::codex_state_db::codex_state_db_paths;
 use crate::session_manager::{SessionMessage, SessionMeta};
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines, truncate_summary,
-    TITLE_MAX_CHARS,
+    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines,
+    truncate_message_content, truncate_summary, TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "codex";
@@ -262,7 +262,11 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
 
         let ts = value.get("timestamp").and_then(parse_timestamp_to_ms);
 
-        messages.push(SessionMessage { role, content, ts });
+        messages.push(SessionMessage {
+            role,
+            content: truncate_message_content(content),
+            ts,
+        });
     }
 
     Ok(messages)

--- a/src-tauri/src/session_manager/providers/gemini.rs
+++ b/src-tauri/src/session_manager/providers/gemini.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::session_manager::{SessionMessage, SessionMeta};
 
-use super::utils::{parse_timestamp_to_ms, truncate_summary};
+use super::utils::{parse_timestamp_to_ms, truncate_message_content, truncate_summary};
 
 const PROVIDER_ID: &str = "gemini";
 
@@ -104,7 +104,7 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
 
         result.push(SessionMessage {
             role: role.to_string(),
-            content,
+            content: truncate_message_content(content),
             ts,
         });
     }

--- a/src-tauri/src/session_manager/providers/hermes.rs
+++ b/src-tauri/src/session_manager/providers/hermes.rs
@@ -9,7 +9,8 @@ use crate::hermes_config::get_hermes_dir;
 use crate::session_manager::{SessionMessage, SessionMeta};
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, read_head_tail_lines, truncate_summary, TITLE_MAX_CHARS,
+    extract_text, parse_timestamp_to_ms, read_head_tail_lines, truncate_message_content,
+    truncate_summary, TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "hermes";
@@ -221,7 +222,7 @@ pub fn load_messages_sqlite(source: &str) -> Result<Vec<SessionMessage>, String>
         let ts_ms = ts.and_then(|v| parse_timestamp_to_ms(&Value::Number(v.into())));
         messages.push(SessionMessage {
             role,
-            content,
+            content: truncate_message_content(content),
             ts: ts_ms,
         });
     }
@@ -478,7 +479,11 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
         }
 
         let ts = ts_val.and_then(parse_timestamp_to_ms);
-        messages.push(SessionMessage { role, content, ts });
+        messages.push(SessionMessage {
+            role,
+            content: truncate_message_content(content),
+            ts,
+        });
     }
 
     Ok(messages)

--- a/src-tauri/src/session_manager/providers/openclaw.rs
+++ b/src-tauri/src/session_manager/providers/openclaw.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 
 use super::utils::{
-    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines, truncate_summary,
-    TITLE_MAX_CHARS,
+    extract_text, parse_timestamp_to_ms, path_basename, read_head_tail_lines,
+    truncate_message_content, truncate_summary, TITLE_MAX_CHARS,
 };
 
 const PROVIDER_ID: &str = "openclaw";
@@ -116,7 +116,11 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
 
         let ts = value.get("timestamp").and_then(parse_timestamp_to_ms);
 
-        messages.push(SessionMessage { role, content, ts });
+        messages.push(SessionMessage {
+            role,
+            content: truncate_message_content(content),
+            ts,
+        });
     }
 
     Ok(messages)

--- a/src-tauri/src/session_manager/providers/opencode.rs
+++ b/src-tauri/src/session_manager/providers/opencode.rs
@@ -5,7 +5,9 @@ use serde_json::Value;
 
 use crate::session_manager::{SessionMessage, SessionMeta};
 
-use super::utils::{parse_timestamp_to_ms, path_basename, truncate_summary};
+use super::utils::{
+    parse_timestamp_to_ms, path_basename, truncate_message_content, truncate_summary,
+};
 
 const PROVIDER_ID: &str = "opencode";
 
@@ -216,7 +218,7 @@ pub fn load_messages(path: &Path) -> Result<Vec<SessionMessage>, String> {
         .into_iter()
         .map(|(ts, _, role, content)| SessionMessage {
             role,
-            content,
+            content: truncate_message_content(content),
             ts: if ts > 0 { Some(ts) } else { None },
         })
         .collect();
@@ -305,7 +307,7 @@ pub fn load_messages_sqlite(source: &str) -> Result<Vec<SessionMessage>, String>
 
         messages.push(SessionMessage {
             role,
-            content,
+            content: truncate_message_content(content),
             ts: Some(ts),
         });
     }

--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -7,6 +7,17 @@ use serde_json::Value;
 
 /// Maximum number of characters for session titles (shared across providers).
 pub const TITLE_MAX_CHARS: usize = 80;
+pub const MAX_MESSAGE_CONTENT_CHARS: usize = 10_000;
+
+pub fn truncate_message_content(mut content: String) -> String {
+    let Some((truncate_at, _)) = content.char_indices().nth(MAX_MESSAGE_CONTENT_CHARS) else {
+        return content;
+    };
+
+    content.truncate(truncate_at);
+    content.push_str("\n… [truncated]");
+    content
+}
 
 /// Read the first `head_n` lines and last `tail_n` lines from a file.
 /// For small files (< 16 KB), reads all lines once to avoid unnecessary seeking.
@@ -172,6 +183,44 @@ mod tests {
         assert_eq!(
             parse_timestamp_to_ms(&json!("1970-01-01T00:00:01Z")),
             Some(1_000)
+        );
+    }
+
+    #[test]
+    fn truncate_message_content_keeps_short_content() {
+        let content = "short content".to_string();
+
+        assert_eq!(truncate_message_content(content.clone()), content);
+    }
+
+    #[test]
+    fn truncate_message_content_caps_oversized_ascii_content() {
+        let content = "a".repeat(MAX_MESSAGE_CONTENT_CHARS + 1);
+        let truncated = truncate_message_content(content);
+
+        assert_eq!(
+            truncated,
+            format!("{}\n… [truncated]", "a".repeat(MAX_MESSAGE_CONTENT_CHARS))
+        );
+        assert_eq!(
+            truncated.chars().count(),
+            MAX_MESSAGE_CONTENT_CHARS + "\n… [truncated]".chars().count()
+        );
+    }
+
+    #[test]
+    fn truncate_message_content_handles_multibyte_boundary() {
+        let content = format!("{}🙂tail", "你".repeat(MAX_MESSAGE_CONTENT_CHARS - 1));
+        let truncated = truncate_message_content(content);
+        let expected = format!(
+            "{}🙂\n… [truncated]",
+            "你".repeat(MAX_MESSAGE_CONTENT_CHARS - 1)
+        );
+
+        assert_eq!(truncated, expected);
+        assert_eq!(
+            truncated.chars().count(),
+            MAX_MESSAGE_CONTENT_CHARS + "\n… [truncated]".chars().count()
         );
     }
 }

--- a/src/lib/query/queries.ts
+++ b/src/lib/query/queries.ts
@@ -321,5 +321,6 @@ export const useSessionMessagesQuery = (
     queryFn: async () => sessionsApi.getMessages(providerId!, sourcePath!),
     enabled: Boolean(providerId && sourcePath),
     staleTime: 30 * 1000,
+    gcTime: 0,
   });
 };


### PR DESCRIPTION
## Summary / 概述

Two complementary renderer-memory hygiene fixes for the Session Manager, found while investigating WebView memory growth (context in #4693):

**Rust — cap per-message content at extraction time.** `load_messages` previously shipped each message's extracted text verbatim to the WebView; a single `tool_result` / `function_call_output` can embed a multi-MB dump. Content is now capped at 10,000 chars (UTF-8-boundary safe, `… [truncated]` marker) at every `SessionMessage` construction site across all providers (claude, codex, gemini, hermes, openclaw, opencode). The UI already collapses messages above 3,000 chars, so nothing readable is lost in practice.

**Frontend — `gcTime: 0` on the `sessionMessages` query.** Each viewed transcript previously stayed in the react-query cache for the default 5 minutes after its last observer unmounted, so browsing N sessions kept N full transcripts alive even after closing the page. Transcripts are now dropped as soon as the view unmounts.

Measured on the largest real session files on my machine (probe: sum of `SessionMessage.content` bytes returned by `load_messages`):

| File | Raw JSONL | Messages | Content before | Content after |
|---|---:|---:|---:|---:|
| Codex session | 61.9 MB | 3,043 | 4.21 MB | 3.60 MB |
| Claude Code session | 25.9 MB | 1,021 | 353.4 KB | 353.3 KB |

Scope note: this PR bounds worst-case transcript payloads and stops closed views from pinning transcripts in cache. The dominant renderer-memory issue remains the hidden-in-tray WebView (#4693) — measured on an official v3.16.4 build sitting in the tray with zero interaction, the WebContent process grew from 344 MB to 415 MB physical footprint (+64 MB dirty WebKit malloc) over ~90 minutes after one Usage Statistics + Session Manager browsing session. WebKit's allocator keeps those pages resident, so allocation peaks become permanent RSS — lowering the peaks (this PR) and destroying the WebView when backgrounded (#4693) complement each other.

## Related Issue / 关联 Issue

Related to #4693, #4581.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed — note: the truncation marker `… [truncated]` is plain text inside message content; happy to wire it through i18n if maintainers prefer.

Verification run locally: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test session_manager` (64 passed), `tsc --noEmit`, `prettier --check`, `vitest run` (405 tests / 65 files passed).