### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ TeamoRouter also offers enterprise features including centralized billing, team 
 </tr>
 
 <tr>
+<td width="180"><a href="https://astraflow.ucloud-global.com"><img src="assets/partners/logos/ucloud.png" alt="Astraflow" width="150"></a></td>
+<td>Thanks to Astraflow by UCloud for sponsoring this project! Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models through global and China endpoints. Register via <a href="https://astraflow.ucloud-global.com">Astraflow Global</a> or <a href="https://astraflow.ucloud.cn">Astraflow China</a>.</td>
+</tr>
+
+<tr>
 <td width="180"><a href="https://crazyrouter.com/register?aff=OZcm&ref=cc-switch"><img src="assets/partners/logos/crazyrouter.png" alt="Crazyrouter" width="150"></a></td>
 <td>Thanks to Crazyrouter for sponsoring this project! Crazyrouter is a high-performance AI API aggregation platform — one API key for 300+ models including Claude Code, Codex, Gemini CLI, and more. All models at 55% of official pricing with auto-failover, smart routing, and unlimited concurrency. Crazyrouter offers an exclusive deal for CC Switch users: register via <a href="https://crazyrouter.com/register?aff=OZcm&ref=cc-switch">this link</a> and contact customer support to claim <strong>$2 free credit</strong>, plus enter promo code `CCSWITCH` on your first top-up for an extra <strong>30% bonus credit</strong>! </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ TeamoRouter also offers enterprise features including centralized billing, team 
 </tr>
 
 <tr>
+<td width="180"><a href="https://astraflow.ucloud-global.com"><img src="assets/partners/logos/ucloud.png" alt="Astraflow" width="150"></a></td>
+<td>Thanks to Astraflow by UCloud for sponsoring this project! Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models through global and China endpoints. Register via <a href="https://astraflow.ucloud-global.com">Astraflow Global</a> or <a href="https://astraflow.ucloud.cn">Astraflow China</a>.</td>
+</tr>
+
+<tr>
 <td width="180"><a href="https://crazyrouter.com/register?aff=OZcm&ref=cc-switch"><img src="assets/partners/logos/crazyrouter.png" alt="Crazyrouter" width="150"></a></td>
 <td>Thanks to Crazyrouter for sponsoring this project! Crazyrouter is a high-performance AI API aggregation platform — one API key for 300+ models including Claude Code, Codex, Gemini CLI, and more. All models at 55% of official pricing with auto-failover, smart routing, and unlimited concurrency. Crazyrouter offers an exclusive deal for CC Switch users: register via <a href="https://crazyrouter.com/register?aff=OZcm&ref=cc-switch">this link</a> and contact customer support to claim <strong>$2 free credit</strong>, plus enter promo code `CCSWITCH` on your first top-up for an extra <strong>30% bonus credit</strong>! </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ TeamoRouter also offers enterprise features including centralized billing, team 
 </tr>
 
 <tr>
+<td width="180"><a href="https://astraflow.ucloud-global.com"><img src="assets/partners/logos/ucloud.png" alt="Astraflow" width="150"></a></td>
+<td>Thanks to Astraflow by UCloud for sponsoring this project! Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models through global and China endpoints. Register via <a href="https://astraflow.ucloud-global.com">Astraflow Global</a> or <a href="https://astraflow.ucloud.cn">Astraflow China</a>.</td>
+</tr>
+
+<tr>
 <td width="180"><a href="https://crazyrouter.com/register?aff=OZcm&ref=cc-switch"><img src="assets/partners/logos/crazyrouter.png" alt="Crazyrouter" width="150"></a></td>
 <td>Thanks to Crazyrouter for sponsoring this project! Crazyrouter is a high-performance AI API aggregation platform — one API key for 300+ models including Claude Code, Codex, Gemini CLI, and more. All models at 55% of official pricing with auto-failover, smart routing, and unlimited concurrency. Crazyrouter offers an exclusive deal for CC Switch users: register via <a href="https://crazyrouter.com/register?aff=OZcm&ref=cc-switch">this link</a> and contact customer support to claim <strong>$2 free credit</strong>, plus enter promo code `CCSWITCH` on your first top-up for an extra <strong>30% bonus credit</strong>! </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ TeamoRouter also offers enterprise features including centralized billing, team 
 </tr>
 
 <tr>
+<td width="180"><a href="https://astraflow.ucloud-global.com"><img src="assets/partners/logos/ucloud.png" alt="Astraflow" width="150"></a></td>
+<td>Thanks to Astraflow by UCloud for sponsoring this project! Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models through global and China endpoints. Register via <a href="https://astraflow.ucloud-global.com">Astraflow Global</a> or <a href="https://astraflow.ucloud.cn">Astraflow China</a>.</td>
+</tr>
+
+<tr>
 <td width="180"><a href="https://crazyrouter.com/register?aff=OZcm&ref=cc-switch"><img src="assets/partners/logos/crazyrouter.png" alt="Crazyrouter" width="150"></a></td>
 <td>Thanks to Crazyrouter for sponsoring this project! Crazyrouter is a high-performance AI API aggregation platform — one API key for 300+ models including Claude Code, Codex, Gemini CLI, and more. All models at 55% of official pricing with auto-failover, smart routing, and unlimited concurrency. Crazyrouter offers an exclusive deal for CC Switch users: register via <a href="https://crazyrouter.com/register?aff=OZcm&ref=cc-switch">this link</a> and contact customer support to claim <strong>$2 free credit</strong>, plus enter promo code `CCSWITCH` on your first top-up for an extra <strong>30% bonus credit</strong>! </td>
 </tr>

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -157,6 +157,29 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#0052D9",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.umodelverse.ai/v1",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6",
+      },
+    },
+    category: "aggregator",
+    apiFormat: "openai_chat",
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "PatewayAI",
     websiteUrl: "https://pateway.ai",
     apiKeyUrl: "https://pateway.ai/?ch=etzpm8&aff=WB6M6F67#/",

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -134,6 +134,29 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#0052D9",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.umodelverse.ai/v1",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6",
+      },
+    },
+    category: "aggregator",
+    apiFormat: "openai_chat",
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "PatewayAI",
     websiteUrl: "https://pateway.ai",
     apiKeyUrl: "https://pateway.ai/?ch=etzpm8&aff=WB6M6F67#/",

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -180,6 +180,29 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#0052D9",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.umodelverse.ai/v1",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6",
+      },
+    },
+    category: "aggregator",
+    apiFormat: "openai_chat",
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "PatewayAI",
     websiteUrl: "https://pateway.ai",
     apiKeyUrl: "https://pateway.ai/?ch=etzpm8&aff=WB6M6F67#/",

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -111,6 +111,29 @@ export const providerPresets: ProviderPreset[] = [
     icon: "shengsuanyun",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.umodelverse.ai/v1",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6",
+      },
+    },
+    category: "aggregator",
+    apiFormat: "openai_chat",
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "PatewayAI",
     websiteUrl: "https://pateway.ai",
     apiKeyUrl: "https://pateway.ai/?ch=etzpm8&aff=WB6M6F67#/",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -224,6 +224,36 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     iconColor: "#0052D9",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "astraflow",
+      "https://api.umodelverse.ai/v1",
+      "o4-mini",
+    ),
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      { model: "gpt-5.5", displayName: "GPT-5.5", contextWindow: 128000 },
+      { model: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", contextWindow: 128000 },
+      { model: "qwen3.7-max", displayName: "Qwen3.7 Max", contextWindow: 128000 },
+      { model: "o4-mini", displayName: "o4-mini", contextWindow: 128000 },
+      {
+        model: "grok-4-fast-reasoning",
+        displayName: "Grok 4 Fast Reasoning",
+        contextWindow: 128000,
+      },
+    ]),
+    category: "aggregator",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "PatewayAI",
     websiteUrl: "https://pateway.ai",
     apiKeyUrl: "https://pateway.ai/?ch=etzpm8&aff=WB6M6F67#/",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -194,6 +194,36 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     iconColor: "#0052D9",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "astraflow",
+      "https://api.umodelverse.ai/v1",
+      "o4-mini",
+    ),
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      { model: "gpt-5.5", displayName: "GPT-5.5", contextWindow: 128000 },
+      { model: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", contextWindow: 128000 },
+      { model: "qwen3.7-max", displayName: "Qwen3.7 Max", contextWindow: 128000 },
+      { model: "o4-mini", displayName: "o4-mini", contextWindow: 128000 },
+      {
+        model: "grok-4-fast-reasoning",
+        displayName: "Grok 4 Fast Reasoning",
+        contextWindow: 128000,
+      },
+    ]),
+    category: "aggregator",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "PatewayAI",
     websiteUrl: "https://pateway.ai",
     apiKeyUrl: "https://pateway.ai/?ch=etzpm8&aff=WB6M6F67#/",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -134,6 +134,36 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     icon: "shengsuanyun",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "astraflow",
+      "https://api.umodelverse.ai/v1",
+      "o4-mini",
+    ),
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      { model: "gpt-5.5", displayName: "GPT-5.5", contextWindow: 128000 },
+      { model: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", contextWindow: 128000 },
+      { model: "qwen3.7-max", displayName: "Qwen3.7 Max", contextWindow: 128000 },
+      { model: "o4-mini", displayName: "o4-mini", contextWindow: 128000 },
+      {
+        model: "grok-4-fast-reasoning",
+        displayName: "Grok 4 Fast Reasoning",
+        contextWindow: 128000,
+      },
+    ]),
+    category: "aggregator",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "PatewayAI",
     websiteUrl: "https://pateway.ai",
     apiKeyUrl: "https://pateway.ai/?ch=etzpm8&aff=WB6M6F67#/",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -164,6 +164,36 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     iconColor: "#0052D9",
   },
   {
+    name: "Astraflow",
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    apiKeyUrl: "https://astraflow.ucloud-global.com",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "astraflow",
+      "https://api.umodelverse.ai/v1",
+      "o4-mini",
+    ),
+    endpointCandidates: [
+      "https://api.umodelverse.ai/v1",
+      "https://api.modelverse.cn/v1",
+    ],
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      { model: "gpt-5.5", displayName: "GPT-5.5", contextWindow: 128000 },
+      { model: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", contextWindow: 128000 },
+      { model: "qwen3.7-max", displayName: "Qwen3.7 Max", contextWindow: 128000 },
+      { model: "o4-mini", displayName: "o4-mini", contextWindow: 128000 },
+      {
+        model: "grok-4-fast-reasoning",
+        displayName: "Grok 4 Fast Reasoning",
+        contextWindow: 128000,
+      },
+    ]),
+    category: "aggregator",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+  },
+  {
     name: "PatewayAI",
     websiteUrl: "https://pateway.ai",
     apiKeyUrl: "https://pateway.ai/?ch=etzpm8&aff=WB6M6F67#/",

--- a/src/config/universalProviderPresets.ts
+++ b/src/config/universalProviderPresets.ts
@@ -156,6 +156,33 @@ export const universalProviderPresets: UniversalProviderPreset[] = [
       "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
   },
   {
+    name: "Astraflow",
+    providerType: "astraflow",
+    defaultApps: {
+      claude: true,
+      codex: true,
+      gemini: false,
+    },
+    defaultModels: {
+      claude: {
+        model: "claude-sonnet-4-6",
+        haikuModel: "claude-haiku-4-5-20251001",
+        sonnetModel: "claude-sonnet-4-6",
+        opusModel: "claude-opus-4-6",
+      },
+      codex: {
+        model: "o4-mini",
+        reasoningEffort: "high",
+      },
+      gemini: NEWAPI_DEFAULT_MODELS.gemini,
+    },
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+    description:
+      "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
+  },
+  {
     name: "自定义网关",
     providerType: "custom_gateway",
     defaultApps: {

--- a/src/config/universalProviderPresets.ts
+++ b/src/config/universalProviderPresets.ts
@@ -75,6 +75,33 @@ export const universalProviderPresets: UniversalProviderPreset[] = [
       "NewAPI 是一个可自部署的 API 网关，支持 Anthropic、OpenAI、Gemini 等多种协议",
   },
   {
+    name: "Astraflow",
+    providerType: "astraflow",
+    defaultApps: {
+      claude: true,
+      codex: true,
+      gemini: false,
+    },
+    defaultModels: {
+      claude: {
+        model: "claude-sonnet-4-6",
+        haikuModel: "claude-haiku-4-5-20251001",
+        sonnetModel: "claude-sonnet-4-6",
+        opusModel: "claude-opus-4-6",
+      },
+      codex: {
+        model: "o4-mini",
+        reasoningEffort: "high",
+      },
+      gemini: NEWAPI_DEFAULT_MODELS.gemini,
+    },
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+    description:
+      "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
+  },
+  {
     name: "自定义网关",
     providerType: "custom_gateway",
     defaultApps: {

--- a/src/config/universalProviderPresets.ts
+++ b/src/config/universalProviderPresets.ts
@@ -102,6 +102,33 @@ export const universalProviderPresets: UniversalProviderPreset[] = [
       "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
   },
   {
+    name: "Astraflow",
+    providerType: "astraflow",
+    defaultApps: {
+      claude: true,
+      codex: true,
+      gemini: false,
+    },
+    defaultModels: {
+      claude: {
+        model: "claude-sonnet-4-6",
+        haikuModel: "claude-haiku-4-5-20251001",
+        sonnetModel: "claude-sonnet-4-6",
+        opusModel: "claude-opus-4-6",
+      },
+      codex: {
+        model: "o4-mini",
+        reasoningEffort: "high",
+      },
+      gemini: NEWAPI_DEFAULT_MODELS.gemini,
+    },
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+    description:
+      "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
+  },
+  {
     name: "自定义网关",
     providerType: "custom_gateway",
     defaultApps: {

--- a/src/config/universalProviderPresets.ts
+++ b/src/config/universalProviderPresets.ts
@@ -129,6 +129,33 @@ export const universalProviderPresets: UniversalProviderPreset[] = [
       "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
   },
   {
+    name: "Astraflow",
+    providerType: "astraflow",
+    defaultApps: {
+      claude: true,
+      codex: true,
+      gemini: false,
+    },
+    defaultModels: {
+      claude: {
+        model: "claude-sonnet-4-6",
+        haikuModel: "claude-haiku-4-5-20251001",
+        sonnetModel: "claude-sonnet-4-6",
+        opusModel: "claude-opus-4-6",
+      },
+      codex: {
+        model: "o4-mini",
+        reasoningEffort: "high",
+      },
+      gemini: NEWAPI_DEFAULT_MODELS.gemini,
+    },
+    websiteUrl: "https://astraflow.ucloud-global.com",
+    icon: "ucloud",
+    iconColor: "#0052D9",
+    description:
+      "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
+  },
+  {
     name: "自定义网关",
     providerType: "custom_gateway",
     defaultApps: {


### PR DESCRIPTION
## Summary / 概述

- Add Astraflow provider presets for universal, Claude, and Codex configuration flows.
- Configure Astraflow global endpoint with China endpoint as an alternate candidate.
- Add representative Astraflow chat and reasoning model IDs.
- Add Astraflow to the README sponsor/provider table.

Notes:
- Astraflow is OpenAI-compatible, so this uses the existing preset/config adapter pattern without adding a new SDK or package.
- Gemini-native presets were not added because the provided Astraflow endpoints are OpenAI-compatible, not Gemini native endpoints.
- Embedding models from the runtime list were not added to chat-agent presets because these registries configure interactive coding/chat providers.

Sandbox verification:

<details><summary>Verification result</summary>

```text
iteration=0
ASTRAFLOW_OK
```

</details>

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

N/A

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| N/A             | N/A           |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件