### PR TITLE
fix(proxy): accept x-api-key in Claude Desktop gateway auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to CC Switch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Claude Desktop gateway accepts `x-api-key` as a fallback to `Authorization: Bearer`**: `validate_claude_desktop_gateway_auth` in `src-tauri/src/proxy/handlers.rs` previously only accepted the gateway token via `Authorization: Bearer <token>`, but the Claude desktop app sends the token as `x-api-key` (Anthropic's published auth header convention). Requests from the desktop app were rejected with `401 "Claude Desktop gateway 缺少 Authorization 头"`, making Code mode fail with "Request failed · retrying" on the first message despite Cowork mode (and the bare `claude` CLI) working. The auth check now extracts the token from either header; `Authorization: Bearer` continues to work for clients that send it. A new `extract_gateway_token` pure helper holds the parsing logic and is covered by seven unit tests (Bearer / lowercase-bearer / no-prefix / x-api-key / both-present / whitespace-trim / missing-header).
+
 ## [3.16.5] - 2026-07-01
 
 Development since v3.16.4 reworks the Codex native-Responses path — restoring a generated model catalog for proxy-less direct-connect, decoupling model mapping from the local-routing toggle, and adding a host/model-prefix blacklist that disables Codex's built-in web_search on gateways that reject it — alongside a broad wave of new provider presets (Qiniu and Code0.ai across all seven apps, the FennoAI/ZetaAPI/TeamoRouter/NekoCode partners, and the non-partner Amux), Claude Sonnet 5 pricing plus a default-tier bump to it, a categorized two-level session view with group-level batch selection, live auto-sync of the shared Claude common config on switch, and a run of credential-safety, tool-detection, Doubao model-id, branding, and icon-size fixes.

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -253,25 +253,45 @@ fn validate_claude_desktop_gateway_auth(
 ) -> Result<(), ProxyError> {
     let expected = crate::claude_desktop_config::get_or_create_gateway_token(state.db.as_ref())
         .map_err(|e| ProxyError::AuthError(e.to_string()))?;
-    let Some(value) = headers.get(axum::http::header::AUTHORIZATION) else {
-        return Err(ProxyError::AuthError(
-            "Claude Desktop gateway 缺少 Authorization 头".to_string(),
-        ));
-    };
-    let value = value
-        .to_str()
-        .map_err(|_| ProxyError::AuthError("Authorization 头格式无效".to_string()))?;
-    let token = value
-        .strip_prefix("Bearer ")
-        .or_else(|| value.strip_prefix("bearer "))
-        .unwrap_or("")
-        .trim();
+
+    let token = extract_gateway_token(headers).ok_or_else(|| {
+        ProxyError::AuthError("Claude Desktop gateway 缺少 Authorization / x-api-key 头".to_string())
+    })?;
     if token != expected {
         return Err(ProxyError::AuthError(
             "Claude Desktop gateway token 无效".to_string(),
         ));
     }
     Ok(())
+}
+
+/// Extract the Claude Desktop gateway token from request headers.
+///
+/// The Claude desktop app sends the token as `x-api-key` (per Anthropic's
+/// published auth header convention). Other clients — and the desktop app's
+/// own explicit setting — may send `Authorization: Bearer <token>`. This
+/// helper accepts either and returns the raw token bytes, with no validity
+/// check; the caller is responsible for comparing to the expected token.
+fn extract_gateway_token(headers: &axum::http::HeaderMap) -> Option<String> {
+    // Prefer `Authorization` if present (more specific).
+    if let Some(value) = headers.get(axum::http::header::AUTHORIZATION) {
+        if let Ok(s) = value.to_str() {
+            // Accept either "Bearer " or "bearer " prefix; if neither is
+            // present, treat the whole value as the token (lenient parsing).
+            let token = s
+                .strip_prefix("Bearer ")
+                .or_else(|| s.strip_prefix("bearer "))
+                .unwrap_or(s)
+                .trim();
+            return Some(token.to_string());
+        }
+    }
+    if let Some(value) = headers.get("x-api-key") {
+        if let Ok(s) = value.to_str() {
+            return Some(s.trim().to_string());
+        }
+    }
+    None
 }
 
 /// Claude 格式转换处理（独有逻辑）
@@ -2045,8 +2065,8 @@ async fn log_usage(
 mod tests {
     use super::{
         body_looks_like_sse, body_snippet, chat_sse_to_response_value, codex_proxy_error_json,
-        responses_sse_to_response_value, should_use_claude_transform_streaming, transform,
-        upstream_body_parse_error,
+        extract_gateway_token, responses_sse_to_response_value,
+        should_use_claude_transform_streaming, transform, upstream_body_parse_error,
     };
     use crate::proxy::ProxyError;
 
@@ -2722,5 +2742,87 @@ data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\"}}\n
         assert_eq!(body["error"]["provider"], "HCAI");
         assert_eq!(body["error"]["model"], "gpt-5.5");
         assert_eq!(body["error"]["endpoint"], "/responses");
+    }
+
+    #[test]
+    fn extract_gateway_token_accepts_authorization_bearer() {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(
+            axum::http::header::AUTHORIZATION,
+            "Bearer ccs-test-token-123".parse().unwrap(),
+        );
+        assert_eq!(
+            extract_gateway_token(&h).as_deref(),
+            Some("ccs-test-token-123")
+        );
+    }
+
+    #[test]
+    fn extract_gateway_token_accepts_lowercase_bearer() {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(
+            axum::http::header::AUTHORIZATION,
+            "bearer ccs-test-token-123".parse().unwrap(),
+        );
+        assert_eq!(
+            extract_gateway_token(&h).as_deref(),
+            Some("ccs-test-token-123")
+        );
+    }
+
+    #[test]
+    fn extract_gateway_token_accepts_authorization_without_prefix() {
+        // Lenient parsing: if the client doesn't include the Bearer prefix,
+        // treat the whole value as the token.
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(
+            axum::http::header::AUTHORIZATION,
+            "ccs-test-token-123".parse().unwrap(),
+        );
+        assert_eq!(
+            extract_gateway_token(&h).as_deref(),
+            Some("ccs-test-token-123")
+        );
+    }
+
+    #[test]
+    fn extract_gateway_token_accepts_x_api_key() {
+        // This is what the Claude desktop app actually sends.
+        let mut h = axum::http::HeaderMap::new();
+        h.insert("x-api-key", "ccs-test-token-123".parse().unwrap());
+        assert_eq!(
+            extract_gateway_token(&h).as_deref(),
+            Some("ccs-test-token-123")
+        );
+    }
+
+    #[test]
+    fn extract_gateway_token_prefers_authorization_over_x_api_key() {
+        // If both are present, Authorization wins — the desktop app only
+        // sends one or the other, but a misbehaving client sending both
+        // should still succeed if either is valid.
+        let mut h = axum::http::HeaderMap::new();
+        h.insert(
+            axum::http::header::AUTHORIZATION,
+            "Bearer ccs-from-auth".parse().unwrap(),
+        );
+        h.insert("x-api-key", "ccs-from-x-api-key".parse().unwrap());
+        assert_eq!(extract_gateway_token(&h).as_deref(), Some("ccs-from-auth"));
+    }
+
+    #[test]
+    fn extract_gateway_token_trims_whitespace() {
+        let mut h = axum::http::HeaderMap::new();
+        h.insert("x-api-key", "  ccs-test-token-123  ".parse().unwrap());
+        assert_eq!(
+            extract_gateway_token(&h).as_deref(),
+            Some("ccs-test-token-123")
+        );
+    }
+
+    #[test]
+    fn extract_gateway_token_returns_none_when_no_auth_header() {
+        let h = axum::http::HeaderMap::new();
+        assert_eq!(extract_gateway_token(&h), None);
     }
 }


### PR DESCRIPTION
## Summary

The Claude desktop app sends the gateway token as `x-api-key: <token>` (per Anthropic's published auth header convention), but `validate_claude_desktop_gateway_auth` in `src-tauri/src/proxy/handlers.rs` only accepted it via `Authorization: Bearer <token>`. As a result, every request from Code mode was rejected with 401 and Code mode showed "Request failed · retrying" on the first message — while Cowork mode and the bare `claude` CLI worked because they don't go through `/claude-desktop`.

This PR makes the gateway accept either header. `Authorization: Bearer` continues to work for clients that send it; the desktop app's `x-api-key` form is now accepted too.

## Repro

1. Install cc-switch, point a Claude-app (or Claude-Desktop-app) provider at any third-party upstream
2. In the Claude desktop app, switch to **Code** mode and start a new session
3. Type `hi`
4. Observe: 401 from the gateway; UI shows "Request failed · retrying (5/10) · 14s" and the same error on every retry. Auto-compact also fails the same way, producing the "Compacting conversation · 25s" loop.

Curl probe (expected on the broken version, fixed after this PR):

```bash
$ curl -i -X POST http://127.0.0.1:15721/claude-desktop/v1/messages \
  -H "x-api-key: ccs-..." \
  -H "anthropic-version: 2023-06-01" \
  -d '{"model":"claude-sonnet-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
HTTP/1.1 401 Unauthorized
{"error":{"message":"认证失败: Claude Desktop gateway 缺少 Authorization 头","type":"proxy_error"}}
```

After this PR, the same probe returns 200.

## Fix

- Extract the token via a new pure helper `extract_gateway_token` that accepts either header. The validation function now calls the helper and compares to the expected token.
- `Authorization` is preferred when both are present (more specific), so other clients behave unchanged.
- For `Authorization`, the helper still strips `Bearer ` / `bearer ` prefix; if no prefix is present, the whole value is treated as the token (lenient parsing, matches the previous behavior for unexpected inputs).
- The error message is updated to mention both headers.

## Tests

Seven new unit tests cover the helper:
- `extract_gateway_token_accepts_authorization_bearer`
- `extract_gateway_token_accepts_lowercase_bearer`
- `extract_gateway_token_accepts_authorization_without_prefix`
- `extract_gateway_token_accepts_x_api_key`
- `extract_gateway_token_prefers_authorization_over_x_api_key`
- `extract_gateway_token_trims_whitespace`
- `extract_gateway_token_returns_none_when_no_auth_header`

## Files

- `src-tauri/src/proxy/handlers.rs` — patch + helper + tests
- `CHANGELOG.md` — Unreleased entry

## Backward compatibility

No behavioral change for any client that already sent `Authorization: Bearer`. The only addition is that the token is also accepted when sent as `x-api-key`, which Anthropic's own SDK and the Claude desktop app use as their native convention.
