### PR TITLE
feat: show scrollbars in session manager

### DIFF
--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -1621,7 +1621,7 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                         </div>
                         <div
                           ref={scrollContainerRef}
-                          className="flex-1 overflow-y-auto px-4 pb-4 min-w-0"
+                          className="scrollbar-visible flex-1 overflow-y-auto px-4 pb-4 pr-2 min-w-0"
                         >
                           {isLoadingMessages ? (
                             <div className="flex items-center justify-center py-12">

--- a/src/components/sessions/SessionToc.tsx
+++ b/src/components/sessions/SessionToc.tsx
@@ -107,7 +107,7 @@ export function SessionTocDialog({
             <X className="size-4 text-muted-foreground" />
           </DialogClose>
         </DialogHeader>
-        <div className="overflow-y-auto max-h-[calc(70vh-80px)]">
+        <div className="scrollbar-visible overflow-y-auto max-h-[calc(70vh-80px)] pr-2">
           <div className="p-3 pb-4 space-y-1">
             {items.map((item, tocIndex) => (
               <button

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,32 @@ html.dark {
     overflow-x: hidden;
   }
 
+  .scrollbar-visible {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--muted-foreground) / 0.45) transparent;
+    -ms-overflow-style: auto;
+  }
+
+  .scrollbar-visible::-webkit-scrollbar {
+    display: block;
+    width: 10px;
+    height: 10px;
+  }
+
+  .scrollbar-visible::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .scrollbar-visible::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--muted-foreground) / 0.35);
+    border: 2px solid transparent;
+    border-radius: 9999px;
+    background-clip: content-box;
+  }
+
+  .scrollbar-visible::-webkit-scrollbar-thumb:hover {
+    background-color: hsl(var(--muted-foreground) / 0.55);
+  }
   .border-default {
     border-width: 1px;
     border-color: hsl(var(--border));


### PR DESCRIPTION
## Background / 背景

Session Manager supports browsing local CLI session logs. For sessions with many messages, users may need to jump through a long conversation history or open the conversation table of contents dialog to navigate between user turns.

会话管理用于浏览本地 CLI 会话日志。当某个会话包含大量消息时，用户经常需要在很长的“对话记录”中快速跳转，或者打开“对话目录”弹窗在不同用户消息之间定位。

The app currently hides native scrollbars globally:

当前应用在全局样式中隐藏了原生滚动条：

- `scrollbar-width: none`
- `::-webkit-scrollbar { display: none; }`

That keeps the UI clean, but in long Session Manager views it also removes the scrollbar drag target. As a result, users can only rely on wheel / touchpad scrolling, which is inefficient when the conversation history or TOC dialog contains many entries.

这样可以让界面更简洁，但在会话管理的长内容场景中，也会导致没有可拖拽的滚动条。对话记录或目录弹窗条目很多时，用户只能依赖鼠标滚轮或触控板慢慢滚动，效率较低。

## What changed / 改动内容

This PR adds a scoped opt-in scrollbar utility and applies it only to the Session Manager scroll containers that need fast navigation.

本 PR 新增一个局部 opt-in 的滚动条工具类，并且只应用在会话管理中需要快速导航的滚动容器上。

Changed files / 修改文件：

- `src/index.css`
  - Adds `.scrollbar-visible`.
  - 新增 `.scrollbar-visible` 工具类。
  - The utility restores a thin visible scrollbar for containers that explicitly opt in.
  - 该工具类只为显式使用它的容器恢复细滚动条。
  - It does not change the global hidden-scrollbar behavior.
  - 不改变应用全局隐藏滚动条的行为。

- `src/components/sessions/SessionManagerPage.tsx`
  - Applies `.scrollbar-visible` to the conversation history message list.
  - 将 `.scrollbar-visible` 应用到“对话记录”消息列表。
  - This gives long message histories a visible scrollbar that users can drag.
  - 当消息很多时，用户可以直接拖拽可见滚动条快速定位。

- `src/components/sessions/SessionToc.tsx`
  - Applies `.scrollbar-visible` to the narrow-window TOC dialog list.
  - 将 `.scrollbar-visible` 应用到窄窗口下的“对话目录”弹窗列表。
  - This gives long popup TOC lists a visible scrollbar that users can drag.
  - 当目录项很多时，弹窗内也可以通过可见滚动条快速滚动。

## Scope / 影响范围

This intentionally does not change existing scroll areas that already have a scrollbar implementation, such as the main session list or the desktop TOC sidebar.

本 PR 不修改已经有滚动条实现的区域，例如左侧主会话列表和桌面宽屏下的目录侧边栏。

The change is limited to:

本次改动仅限于：

- Conversation History message list
- “对话记录”消息列表
- Narrow-window Conversation TOC dialog
- 窄窗口下的“对话目录”弹窗

## Testing / 验证

- `node_modules/.bin/tsc.cmd --noEmit`
- `node_modules/.bin/vitest.cmd run tests/components/SessionManagerPage.test.tsx`
- `node_modules/.bin/prettier.cmd --check src/index.css src/components/sessions/SessionToc.tsx src/components/sessions/SessionManagerPage.tsx`
- `node_modules/.bin/vite.cmd build`