### PR TITLE
fix(provider): add [1m] suffix to DeepSeek ANTHROPIC_MODEL default for 1M context support

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -344,7 +344,7 @@ export const providerPresets: ProviderPreset[] = [
       env: {
         ANTHROPIC_BASE_URL: "https://api.deepseek.com/anthropic",
         ANTHROPIC_AUTH_TOKEN: "",
-        ANTHROPIC_MODEL: "deepseek-v4-pro",
+        ANTHROPIC_MODEL: "deepseek-v4-pro[1m]",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "deepseek-v4-flash",
         ANTHROPIC_DEFAULT_SONNET_MODEL: "deepseek-v4-pro",
         ANTHROPIC_DEFAULT_OPUS_MODEL: "deepseek-v4-pro",


### PR DESCRIPTION
## Summary

  Fix DeepSeek preset's `ANTHROPIC_MODEL` default value to include `[1m]` context window suffix, enabling 1M context by default in BYOK/direct mode.

  ## Problem

  The DeepSeek provider preset in `claudeProviderPresets.ts` sets `ANTHROPIC_MODEL` to `"deepseek-v4-pro"` without the  `[1m]` suffix. When users select this preset and use Claude Code in **direct/BYOK mode** (without local routing  proxy), the `/context` command shows only **200K** context window instead of the full **1M** that deepseek-v4-pro  supports.

  ## Root Cause

  - `[1m]` is Claude Code's client-side syntax for enabling 1M context window (defined as `ONE_M_CONTEXT_MARKER` in  cc-switch's own codebase at `src-tauri/src/claude_desktop_config.rs:33`)
  - Without it, Claude Code defaults to 200K context
  - Claude Code automatically strips `[1m]` before sending API requests

  ## Fix

  Changed `ANTHROPIC_MODEL: "deepseek-v4-pro"` to `ANTHROPIC_MODEL: "deepseek-v4-pro[1m]"` in the DeepSeek preset.

  ## Safety

  This fix is safe in both modes:
  - **Direct/BYOK mode**: Claude Code reads `[1m]` and enables 1M context
  - **Local routing/proxy mode**: The proxy's `strip_one_m_suffix_for_upstream()` automatically strips `[1m]` before  forwarding to upstream API (verified in `model_mapper.rs` tests)

  ## Impact

  - Only affects new provider creation using the DeepSeek preset
  - Does not affect existing providers
  - SONNET and OPUS model defaults intentionally kept without `[1m]` to avoid double `[1m]` display issue