### PR TITLE
Fix/codex chat default max output tokens

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1358,7 +1358,10 @@ impl RequestForwarder {
                 );
             }
             super::providers::apply_codex_chat_upstream_model(provider, &mut mapped_body);
-            super::providers::apply_codex_chat_default_max_output_tokens(provider, &mut mapped_body);
+            super::providers::apply_codex_chat_default_max_output_tokens(
+                provider,
+                &mut mapped_body,
+            );
             let reasoning_config =
                 super::providers::resolve_codex_chat_reasoning_config(provider, &mapped_body);
             super::providers::transform_codex_chat::responses_to_chat_completions_with_reasoning(

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1358,6 +1358,7 @@ impl RequestForwarder {
                 );
             }
             super::providers::apply_codex_chat_upstream_model(provider, &mut mapped_body);
+            super::providers::apply_codex_chat_default_max_output_tokens(provider, &mut mapped_body);
             let reasoning_config =
                 super::providers::resolve_codex_chat_reasoning_config(provider, &mapped_body);
             super::providers::transform_codex_chat::responses_to_chat_completions_with_reasoning(

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -427,6 +427,7 @@ fn codex_provider_default_max_output_tokens(provider: &Provider) -> Option<u64> 
         .settings_config
         .get("max_output_tokens")
         .and_then(|v| v.as_u64())
+        .filter(|&n| n > 0)
         .or_else(|| {
             provider
                 .settings_config
@@ -1112,6 +1113,23 @@ wire_api = "responses"
     fn test_default_max_output_tokens_skipped_when_not_configured() {
         let provider = create_provider(json!({
             "base_url": "https://api.example.com/v1/chat/completions"
+        }));
+        let mut body = json!({
+            "model": "glm-4.6",
+            "input": "ping"
+        });
+
+        let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+
+        assert!(!injected);
+        assert!(body.get("max_output_tokens").is_none());
+    }
+
+    #[test]
+    fn test_default_max_output_tokens_skipped_when_zero() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.example.com/v1/chat/completions",
+            "max_output_tokens": 0
         }));
         let mut body = json!({
             "model": "glm-4.6",

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -1030,7 +1030,10 @@ wire_api = "chat"
         let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
 
         assert!(injected);
-        assert_eq!(body.get("max_output_tokens").and_then(|v| v.as_u64()), Some(8192));
+        assert_eq!(
+            body.get("max_output_tokens").and_then(|v| v.as_u64()),
+            Some(8192)
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -164,8 +164,13 @@ pub fn apply_codex_chat_default_max_output_tokens(
     if !codex_provider_uses_chat_completions(provider) {
         return false;
     }
-    // Client already specified a limit - respect it.
-    if body.get("max_output_tokens").is_some() {
+    // Client already specified a limit via any of the three fields
+    // accepted by the Responses->Chat converter - respect it and don't
+    // inject a conflicting default.
+    if body.get("max_output_tokens").is_some()
+        || body.get("max_tokens").is_some()
+        || body.get("max_completion_tokens").is_some()
+    {
         return false;
     }
     let Some(default) = codex_provider_default_max_output_tokens(provider) else {
@@ -1143,5 +1148,93 @@ wire_api = "responses"
 
         assert!(!injected);
         assert!(body.get("max_output_tokens").is_none());
+    }
+
+    // --- Conversion-level regression tests ---
+    // Verify that apply_codex_chat_default_max_output_tokens + the Responses->Chat
+    // converter never produce conflicting limit fields in the final output.
+
+    #[test]
+    fn conversion_default_injected_non_o_series_uses_max_tokens() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.example.com/v1/chat/completions",
+            "max_output_tokens": 8192
+        }));
+        let mut body = json!({
+            "model": "glm-4.6",
+            "input": "ping"
+        });
+
+        apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+        let result = super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(body, None).unwrap();
+
+        // Non-o-series: max_output_tokens maps to max_tokens only.
+        assert_eq!(result.get("max_tokens").and_then(|v| v.as_u64()), Some(8192));
+        assert!(result.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn conversion_default_injected_o_series_uses_max_completion_tokens() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.example.com/v1/chat/completions",
+            "max_output_tokens": 8192
+        }));
+        let mut body = json!({
+            "model": "o3",
+            "input": "ping"
+        });
+
+        apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+        let result = super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(body, None).unwrap();
+
+        // O-series: max_output_tokens maps to max_completion_tokens only.
+        assert_eq!(result.get("max_completion_tokens").and_then(|v| v.as_u64()), Some(8192));
+        assert!(result.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn conversion_client_max_tokens_no_conflict_with_default() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.example.com/v1/chat/completions",
+            "max_output_tokens": 8192
+        }));
+        let mut body = json!({
+            "model": "glm-4.6",
+            "input": "ping",
+            "max_tokens": 2048
+        });
+
+        let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+        assert!(!injected);
+
+        let result = super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(body, None).unwrap();
+
+        // Client's max_tokens preserved; no conflicting max_completion_tokens.
+        assert_eq!(result.get("max_tokens").and_then(|v| v.as_u64()), Some(2048));
+        assert!(result.get("max_completion_tokens").is_none());
+        assert!(result.get("max_output_tokens").is_none());
+    }
+
+    #[test]
+    fn conversion_client_max_completion_tokens_no_conflict_with_default() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.example.com/v1/chat/completions",
+            "max_output_tokens": 8192
+        }));
+        let mut body = json!({
+            "model": "o3",
+            "input": "ping",
+            "max_completion_tokens": 2048
+        });
+
+        let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+        assert!(!injected);
+
+        let result = super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(body, None).unwrap();
+
+        // Client's max_completion_tokens preserved; no conflicting max_tokens.
+        assert_eq!(result.get("max_completion_tokens").and_then(|v| v.as_u64()), Some(2048));
+        assert!(result.get("max_tokens").is_none());
+        assert!(result.get("max_output_tokens").is_none());
     }
 }

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -1166,10 +1166,17 @@ wire_api = "responses"
         });
 
         apply_codex_chat_default_max_output_tokens(&provider, &mut body);
-        let result = super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(body, None).unwrap();
+        let result =
+            super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(
+                body, None,
+            )
+            .unwrap();
 
         // Non-o-series: max_output_tokens maps to max_tokens only.
-        assert_eq!(result.get("max_tokens").and_then(|v| v.as_u64()), Some(8192));
+        assert_eq!(
+            result.get("max_tokens").and_then(|v| v.as_u64()),
+            Some(8192)
+        );
         assert!(result.get("max_completion_tokens").is_none());
     }
 
@@ -1185,10 +1192,17 @@ wire_api = "responses"
         });
 
         apply_codex_chat_default_max_output_tokens(&provider, &mut body);
-        let result = super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(body, None).unwrap();
+        let result =
+            super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(
+                body, None,
+            )
+            .unwrap();
 
         // O-series: max_output_tokens maps to max_completion_tokens only.
-        assert_eq!(result.get("max_completion_tokens").and_then(|v| v.as_u64()), Some(8192));
+        assert_eq!(
+            result.get("max_completion_tokens").and_then(|v| v.as_u64()),
+            Some(8192)
+        );
         assert!(result.get("max_tokens").is_none());
     }
 
@@ -1207,10 +1221,17 @@ wire_api = "responses"
         let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
         assert!(!injected);
 
-        let result = super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(body, None).unwrap();
+        let result =
+            super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(
+                body, None,
+            )
+            .unwrap();
 
         // Client's max_tokens preserved; no conflicting max_completion_tokens.
-        assert_eq!(result.get("max_tokens").and_then(|v| v.as_u64()), Some(2048));
+        assert_eq!(
+            result.get("max_tokens").and_then(|v| v.as_u64()),
+            Some(2048)
+        );
         assert!(result.get("max_completion_tokens").is_none());
         assert!(result.get("max_output_tokens").is_none());
     }
@@ -1230,10 +1251,17 @@ wire_api = "responses"
         let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
         assert!(!injected);
 
-        let result = super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(body, None).unwrap();
+        let result =
+            super::super::transform_codex_chat::responses_to_chat_completions_with_reasoning(
+                body, None,
+            )
+            .unwrap();
 
         // Client's max_completion_tokens preserved; no conflicting max_tokens.
-        assert_eq!(result.get("max_completion_tokens").and_then(|v| v.as_u64()), Some(2048));
+        assert_eq!(
+            result.get("max_completion_tokens").and_then(|v| v.as_u64()),
+            Some(2048)
+        );
         assert!(result.get("max_tokens").is_none());
         assert!(result.get("max_output_tokens").is_none());
     }

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -147,6 +147,34 @@ pub fn apply_codex_chat_upstream_model(
     Some(upstream_model)
 }
 
+/// For Codex Chat providers, inject a provider-configured default
+/// `max_output_tokens` when the client (e.g. Codex CLI) omits it.
+///
+/// Many OpenAI-compatible upstreams default to a low `max_tokens` (e.g. 4096)
+/// when the parameter is absent. With high-reasoning models the entire budget
+/// can be consumed by thinking, leaving `last_agent_message: null`. This
+/// mirrors `apply_codex_chat_upstream_model` by reading the default from the
+/// provider's `settings_config` (direct field or TOML `config` string) and
+/// writing it into the request body before the Responses->Chat conversion,
+/// so the existing mapping logic in `transform_codex_chat` picks it up.
+pub fn apply_codex_chat_default_max_output_tokens(
+    provider: &Provider,
+    body: &mut JsonValue,
+) -> bool {
+    if !codex_provider_uses_chat_completions(provider) {
+        return false;
+    }
+    // Client already specified a limit - respect it.
+    if body.get("max_output_tokens").is_some() {
+        return false;
+    }
+    let Some(default) = codex_provider_default_max_output_tokens(provider) else {
+        return false;
+    };
+    body["max_output_tokens"] = JsonValue::Number(default.into());
+    true
+}
+
 pub fn resolve_codex_chat_reasoning_config(
     provider: &Provider,
     body: &JsonValue,
@@ -389,6 +417,31 @@ fn extract_codex_model_from_toml(config_text: &str) -> Option<String> {
         .map(str::trim)
         .filter(|model| !model.is_empty())
         .map(ToString::to_string)
+}
+
+/// Extract a provider-level `max_output_tokens` default, checking the
+/// `settings_config.max_output_tokens` field first, then falling back to the
+/// TOML `config` string (top-level `max_output_tokens` key).
+fn codex_provider_default_max_output_tokens(provider: &Provider) -> Option<u64> {
+    provider
+        .settings_config
+        .get("max_output_tokens")
+        .and_then(|v| v.as_u64())
+        .or_else(|| {
+            provider
+                .settings_config
+                .get("config")
+                .and_then(|v| v.as_str())
+                .and_then(extract_codex_max_output_tokens_from_toml)
+        })
+}
+
+fn extract_codex_max_output_tokens_from_toml(config_text: &str) -> Option<u64> {
+    let doc = config_text.parse::<TomlValue>().ok()?;
+    doc.get("max_output_tokens")
+        .and_then(|v| v.as_integer())
+        .filter(|n| *n > 0)
+        .map(|n| n as u64)
 }
 
 fn extract_codex_base_url_from_toml(config_text: &str) -> Option<String> {
@@ -960,5 +1013,114 @@ wire_api = "chat"
         assert_eq!(config.thinking_param.as_deref(), Some("enable_thinking"));
         assert_eq!(config.supports_effort, Some(false));
         assert_eq!(config.output_format.as_deref(), Some("reasoning_content"));
+    }
+
+    #[test]
+    fn test_default_max_output_tokens_injected_from_settings_config() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.example.com/v1/chat/completions",
+            "max_output_tokens": 8192
+        }));
+        let mut body = json!({
+            "model": "glm-4.6",
+            "input": "ping"
+        });
+
+        let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+
+        assert!(injected);
+        assert_eq!(body.get("max_output_tokens").and_then(|v| v.as_u64()), Some(8192));
+    }
+
+    #[test]
+    fn test_default_max_output_tokens_injected_from_toml_config() {
+        let provider = create_provider(json!({
+            "config": r#"
+model_provider = "glm"
+model = "glm-4.6"
+max_output_tokens = 16384
+
+[model_providers.glm]
+name = "GLM"
+base_url = "https://api.example.com/v1/chat/completions"
+wire_api = "chat"
+"#
+        }));
+        let mut body = json!({
+            "model": "glm-4.6",
+            "input": "ping"
+        });
+
+        let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+
+        assert!(injected);
+        assert_eq!(
+            body.get("max_output_tokens").and_then(|v| v.as_u64()),
+            Some(16384)
+        );
+    }
+
+    #[test]
+    fn test_default_max_output_tokens_skipped_when_client_specified() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.example.com/v1/chat/completions",
+            "max_output_tokens": 8192
+        }));
+        let mut body = json!({
+            "model": "glm-4.6",
+            "input": "ping",
+            "max_output_tokens": 2048
+        });
+
+        let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+
+        assert!(!injected);
+        // Client value preserved, not overwritten.
+        assert_eq!(
+            body.get("max_output_tokens").and_then(|v| v.as_u64()),
+            Some(2048)
+        );
+    }
+
+    #[test]
+    fn test_default_max_output_tokens_skipped_when_not_chat_provider() {
+        // wire_api = "responses" -> not a chat completions provider
+        let provider = create_provider(json!({
+            "config": r#"
+model_provider = "openai"
+model = "o3"
+max_output_tokens = 8192
+
+[model_providers.openai]
+name = "OpenAI"
+base_url = "https://api.openai.com/v1"
+wire_api = "responses"
+"#
+        }));
+        let mut body = json!({
+            "model": "o3",
+            "input": "ping"
+        });
+
+        let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+
+        assert!(!injected);
+        assert!(body.get("max_output_tokens").is_none());
+    }
+
+    #[test]
+    fn test_default_max_output_tokens_skipped_when_not_configured() {
+        let provider = create_provider(json!({
+            "base_url": "https://api.example.com/v1/chat/completions"
+        }));
+        let mut body = json!({
+            "model": "glm-4.6",
+            "input": "ping"
+        });
+
+        let injected = apply_codex_chat_default_max_output_tokens(&provider, &mut body);
+
+        assert!(!injected);
+        assert!(body.get("max_output_tokens").is_none());
     }
 }

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -45,12 +45,12 @@ pub use claude::{
     normalize_anthropic_messages_for_provider, transform_claude_request_for_api_format,
     ClaudeAdapter,
 };
+pub use codex::apply_codex_chat_default_max_output_tokens;
 pub use codex::CodexAdapter;
 pub use codex::{
     apply_codex_chat_upstream_model, codex_provider_upstream_model,
     resolve_codex_chat_reasoning_config, should_convert_codex_responses_to_chat,
 };
-pub use codex::apply_codex_chat_default_max_output_tokens;
 pub use gemini::GeminiAdapter;
 
 /// 供应商类型枚举

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -50,6 +50,7 @@ pub use codex::{
     apply_codex_chat_upstream_model, codex_provider_upstream_model,
     resolve_codex_chat_reasoning_config, should_convert_codex_responses_to_chat,
 };
+pub use codex::apply_codex_chat_default_max_output_tokens;
 pub use gemini::GeminiAdapter;
 
 /// 供应商类型枚举


### PR DESCRIPTION
## feat(codex): inject provider-configured default max_output_tokens for Codex Chat conversion

### Summary

Fixes #5155 

When Codex CLI sends requests through cc-switch's Responses to Chat Completions conversion path, it typically omits max_output_tokens. OpenAI-compatible upstreams (e.g. Volces GLM, DeepSeek) then default to a low max_tokens (often 4096). With high-reasoning models, the entire budget can be consumed by thinking, leaving no room for the actual answer (last_agent_message: null).

This PR adds a provider-level max_output_tokens default. When configured and the client omits max_output_tokens, cc-switch injects the default into the request body before the Responses to Chat conversion, so the existing mapping logic in transform_codex_chat.rs picks it up naturally.

### Changes

- src-tauri/src/proxy/providers/codex.rs: New apply_codex_chat_default_max_output_tokens function following the same pattern as apply_codex_chat_upstream_model, plus helper functions and 5 unit tests
- src-tauri/src/proxy/providers/mod.rs: Re-export the new function
- src-tauri/src/proxy/forwarder.rs: Call the new function right after apply_codex_chat_upstream_model, before the Responses to Chat conversion

### How it works

Codex CLI (no max_output_tokens) -> cc-switch forwarder -> apply_codex_chat_upstream_model (existing) -> apply_codex_chat_default_max_output_tokens (NEW) -> responses_to_chat_completions_with_reasoning (existing) -> upstream API (receives max_tokens, no longer defaults to 4096)

### Configuration

Users can set the default in two ways:

Option A - Direct field in settings_config JSON:

{ "max_output_tokens": 8192, "base_url": "https://..." }

Option B - TOML config string (Codex CLI format):

model_provider = "glm"
model = "glm-4.6"
max_output_tokens = 8192

[model_providers.glm]
name = "GLM"
base_url = "https://..."
wire_api = "chat"

### Backward Compatibility

- No max_output_tokens configured = no change in behavior
- Client-specified max_output_tokens is always preserved (never overwritten)
- Only applies to providers using Chat Completions wire_api (same guard as apply_codex_chat_upstream_model)

### Testing

- [x] Unit tests added in codex.rs covering all code paths
- [x] cargo fmt --check passes
- [x] cargo clippy passes
- [x] cargo test passes
