### PR TITLE
fix(usage): prevent CPU spike after system resume on Windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1062,6 +1062,10 @@ pub fn run() {
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
                         PERIODIC_MAINTENANCE_INTERVAL_SECS,
                     ));
+                    // Windows 上 tokio 计时器在系统休眠期间照常累积，默认的 Burst 策略会在
+                    // 唤醒后一次性补发所有错过的 tick。Skip 策略丢弃错过的 tick，唤醒后仅按
+                    // 正常周期恢复。
+                    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                     interval.tick().await; // skip immediate first tick (already checked above)
                     loop {
                         interval.tick().await;
@@ -1082,53 +1086,55 @@ pub fn run() {
                         }
                     }
 
-                    let db = &db_for_session_sync;
+                    // 一轮会话用量同步会对成千上万个日志文件做阻塞式 stat + SQLite 查询，
+                    // 必须放到 spawn_blocking 线程执行（见下方调用），避免阻塞 tokio 异步
+                    // 运行时线程、拖累前端命令与其它异步任务。
+                    fn run_usage_sync(db: &crate::database::Database, phase: &str) {
+                        run_step(
+                            &format!("Session usage {phase} sync"),
+                            crate::services::session_usage::sync_claude_session_logs(db),
+                        );
+                        run_step(
+                            &format!("Codex usage {phase} sync"),
+                            crate::services::session_usage_codex::sync_codex_usage(db),
+                        );
+                        run_step(
+                            &format!("Gemini usage {phase} sync"),
+                            crate::services::session_usage_gemini::sync_gemini_usage(db),
+                        );
+                        run_step(
+                            &format!("OpenCode usage {phase} sync"),
+                            crate::services::session_usage_opencode::sync_opencode_usage(db),
+                        );
+                    }
 
-                    // 首次同步
-                    run_step(
-                        "Usage cost startup backfill",
-                        db.backfill_missing_usage_costs(),
-                    );
-                    run_step(
-                        "Session usage initial sync",
-                        crate::services::session_usage::sync_claude_session_logs(db),
-                    );
-                    run_step(
-                        "Codex usage initial sync",
-                        crate::services::session_usage_codex::sync_codex_usage(db),
-                    );
-                    run_step(
-                        "Gemini usage initial sync",
-                        crate::services::session_usage_gemini::sync_gemini_usage(db),
-                    );
-                    run_step(
-                        "OpenCode usage initial sync",
-                        crate::services::session_usage_opencode::sync_opencode_usage(db),
-                    );
+                    // 首次同步（含费用回填）——同样放到阻塞线程，避免拖住异步运行时。
+                    let db_initial = db_for_session_sync.clone();
+                    let _ = tauri::async_runtime::spawn_blocking(move || {
+                        run_step(
+                            "Usage cost startup backfill",
+                            db_initial.backfill_missing_usage_costs(),
+                        );
+                        run_usage_sync(&db_initial, "initial");
+                    })
+                    .await;
 
                     // 定期同步
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
                         SESSION_SYNC_INTERVAL_SECS,
                     ));
+                    // Windows 上 tokio 计时器在系统休眠期间照常累积，默认的 Burst 策略会在
+                    // 唤醒后一次性补发所有错过的 tick，导致密集触发上面这轮全量文件扫描、
+                    // CPU 飙升且不回落。Skip 策略丢弃错过的 tick，唤醒后仅按正常周期恢复。
+                    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                     interval.tick().await; // skip immediate first tick
                     loop {
                         interval.tick().await;
-                        run_step(
-                            "Session usage periodic sync",
-                            crate::services::session_usage::sync_claude_session_logs(db),
-                        );
-                        run_step(
-                            "Codex usage periodic sync",
-                            crate::services::session_usage_codex::sync_codex_usage(db),
-                        );
-                        run_step(
-                            "Gemini usage periodic sync",
-                            crate::services::session_usage_gemini::sync_gemini_usage(db),
-                        );
-                        run_step(
-                            "OpenCode usage periodic sync",
-                            crate::services::session_usage_opencode::sync_opencode_usage(db),
-                        );
+                        let db_cycle = db_for_session_sync.clone();
+                        let _ = tauri::async_runtime::spawn_blocking(move || {
+                            run_usage_sync(&db_cycle, "periodic");
+                        })
+                        .await;
                     }
                 });
             });


### PR DESCRIPTION
## Summary / 概述

Windows 上 tokio 计时器在系统休眠期间照常累积，默认的 Burst 策略会在唤醒后一次性补发所有错过的 tick，使 60 秒会话用量同步对成千上万个会话日志文件的全量扫描背靠背执行，单线程被打满且长时间不回落（tokio-rs/tokio#3184）。本 PR 从根因修复该问题：

- 两处 `tokio::time::interval`（24h 维护、60s 会话同步）改用 `MissedTickBehavior::Skip`，唤醒后仅按正常周期恢复，丢弃休眠期间累积的 tick；
- 会话同步的阻塞式文件扫描 + SQLite 调用移入 `tauri::async_runtime::spawn_blocking`，不再占用 tokio 异步 worker 线程。

## Related Issue / 关联 Issue

Fixes #5164

## Screenshots / 截图

无 UI 变化（纯后端修复）。实测：唤醒前补发风暴期间，主进程内单个线程占用一个逻辑核 100%（3 秒窗口 ~3047ms/3000ms），修复后唤醒即按正常 60s 节奏恢复。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（本 PR 未改前端代码）
- [x] `pnpm format:check` passes / 通过代码格式检查（未改前端代码）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（`cargo clippy -- -D warnings` 零警告）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本变更）

本地校验：`cargo fmt --check`、`cargo clippy -- -D warnings`、`cargo test` 均通过。