### PR TITLE
fix(usage): 修复 Codex 子代理使用量未计入统计

### DIFF
--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -9,7 +9,7 @@
 //! ```
 //!
 //! ## 解析的事件类型
-//! - `session_meta` → 提取 session_id
+//! - `session_meta` → 提取唯一 thread_id（子代理的 session_id 指向父线程）
 //! - `turn_context` → 提取当前 model
 //! - `event_msg` (type=token_count) → 提取累计 token 用量，计算 delta
 
@@ -23,10 +23,17 @@ use crate::services::session_usage::{
 };
 use crate::services::usage_stats::{find_model_pricing, should_skip_session_insert, DedupKey};
 use rust_decimal::Decimal;
+use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+
+const CODEX_SUBAGENT_USAGE_MIGRATION_KEY: &str = "codex_subagent_usage_thread_id_v1_migrated";
+const CODEX_SUBAGENT_SYNC_KEY_SUFFIX: &str = "#codex-thread-id-v1";
+/// fork/restore 与部分子代理日志会在文件创建时密集重放父线程历史。
+/// 这些 token_count 是基线快照，不是子线程的新请求。
+const FORK_HISTORY_SNAPSHOT_WINDOW_MS: i64 = 1_000;
 
 /// 累计 token 用量（跟踪 total_token_usage 字段）
 #[derive(Debug, Clone, Default)]
@@ -52,10 +59,126 @@ impl DeltaTokens {
 
 /// 单文件解析时的运行状态
 struct FileParseState {
-    session_id: Option<String>,
+    thread_id: Option<String>,
     current_model: String,
     prev_total: Option<CumulativeTokens>,
     event_index: u32,
+    seen_session_meta: bool,
+    carries_history_snapshot: bool,
+    session_started_at_ms: Option<i64>,
+}
+
+/// Codex 的现代子代理日志同时包含两个不同含义的 ID：
+///
+/// - `id`: 当前日志文件对应的唯一线程 ID；
+/// - `session_id`: 父线程 ID（主线程中两者相同）。
+///
+/// request_id 必须使用 thread_id，否则同一父线程下各文件从 1 开始的
+/// event_index 会互相碰撞，并被数据库的唯一约束当作重复记录丢弃。
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexSessionIdentity {
+    thread_id: String,
+    session_id: String,
+}
+
+impl CodexSessionIdentity {
+    fn is_subagent(&self) -> bool {
+        self.thread_id != self.session_id
+    }
+}
+
+fn parse_codex_session_identity(payload: &serde_json::Value) -> Option<CodexSessionIdentity> {
+    let thread_id = payload
+        .get("id")
+        .or_else(|| payload.get("thread_id"))
+        .or_else(|| payload.get("threadId"))
+        .or_else(|| payload.get("session_id"))
+        .or_else(|| payload.get("sessionId"))
+        .and_then(|value| value.as_str())?
+        .to_string();
+
+    let session_id = payload
+        .get("session_id")
+        .or_else(|| payload.get("sessionId"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| thread_id.clone());
+
+    Some(CodexSessionIdentity {
+        thread_id,
+        session_id,
+    })
+}
+
+fn read_codex_session_identity(file_path: &Path) -> Option<CodexSessionIdentity> {
+    let file = fs::File::open(file_path).ok()?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line.ok()?;
+        if !line.contains("\"session_meta\"") {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(&line).ok()?;
+        if value.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
+            continue;
+        }
+        return value.get("payload").and_then(parse_codex_session_identity);
+    }
+
+    None
+}
+
+fn codex_sync_state_key(file_path: &str, identity: Option<&CodexSessionIdentity>) -> String {
+    if identity.is_some_and(CodexSessionIdentity::is_subagent) {
+        // 旧版本用父 session_id 生成 request_id。为子代理使用新的同步键，
+        // 可让升级后的首次同步重新读取已经到达 EOF 的历史子代理文件。
+        format!("{file_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}")
+    } else {
+        file_path.to_string()
+    }
+}
+
+fn parse_timestamp_millis(timestamp: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|datetime| datetime.timestamp_millis())
+}
+
+fn json_timestamp_millis(value: &serde_json::Value) -> Option<i64> {
+    value
+        .get("timestamp")
+        .and_then(|value| value.as_str())
+        .and_then(parse_timestamp_millis)
+}
+
+fn session_meta_carries_history_snapshot(payload: &serde_json::Value) -> bool {
+    let has_fork_parent = payload
+        .get("forked_from_id")
+        .and_then(|value| value.as_str())
+        .is_some_and(|value| !value.is_empty());
+    let is_subagent = payload
+        .get("source")
+        .and_then(|source| source.get("subagent"))
+        .is_some()
+        || parse_codex_session_identity(payload).is_some_and(|identity| identity.is_subagent());
+
+    has_fork_parent || is_subagent
+}
+
+fn is_history_snapshot_event(state: &FileParseState, timestamp: Option<&str>) -> bool {
+    if !state.carries_history_snapshot {
+        return false;
+    }
+
+    let Some(session_started_at_ms) = state.session_started_at_ms else {
+        return false;
+    };
+    let Some(event_at_ms) = timestamp.and_then(parse_timestamp_millis) else {
+        return false;
+    };
+
+    event_at_ms <= session_started_at_ms + FORK_HISTORY_SNAPSHOT_WINDOW_MS
 }
 
 /// 归一化 Codex 模型名
@@ -147,20 +270,29 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     let codex_dir = get_codex_config_dir();
 
     let files = collect_codex_session_files(&codex_dir);
+    let files_with_identity: Vec<(PathBuf, Option<CodexSessionIdentity>)> = files
+        .into_iter()
+        .map(|path| {
+            let identity = read_codex_session_identity(&path);
+            (path, identity)
+        })
+        .collect();
+
+    repair_legacy_codex_subagent_usage(db, &files_with_identity)?;
 
     let mut result = SessionSyncResult {
         imported: 0,
         skipped: 0,
-        files_scanned: files.len() as u32,
+        files_scanned: files_with_identity.len() as u32,
         errors: vec![],
     };
 
-    if files.is_empty() {
+    if files_with_identity.is_empty() {
         return Ok(result);
     }
 
-    for file_path in &files {
-        match sync_single_codex_file(db, file_path) {
+    for (file_path, identity) in &files_with_identity {
+        match sync_single_codex_file(db, file_path, identity.as_ref()) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -183,6 +315,124 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     }
 
     Ok(result)
+}
+
+/// 修复旧版以父 session_id 作为 request_id 命名空间造成的历史碰撞。
+///
+/// 仅处理已经被旧同步器读取过、且父线程日志仍可从磁盘重建的会话：
+/// 1. 删除该父线程下无法区分主/子代理来源的旧 Codex session 行；
+/// 2. 清除相关文件的同步游标；
+/// 3. 当前同步轮次会用唯一 thread_id 重建准确记录。
+fn repair_legacy_codex_subagent_usage(
+    db: &Database,
+    files: &[(PathBuf, Option<CodexSessionIdentity>)],
+) -> Result<(), AppError> {
+    let mut conn = lock_conn!(db.conn);
+
+    let already_migrated = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1 AND value = 'true')",
+            rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(|e| AppError::Database(format!("查询 Codex 子代理用量迁移状态失败: {e}")))?;
+    if already_migrated {
+        return Ok(());
+    }
+
+    let rebuildable_thread_ids: HashSet<&str> = files
+        .iter()
+        .filter_map(|(_, identity)| {
+            identity
+                .as_ref()
+                .map(|identity| identity.thread_id.as_str())
+        })
+        .collect();
+    let mut affected_session_ids = HashSet::new();
+
+    {
+        let mut stmt = conn
+            .prepare(
+                "SELECT EXISTS(
+                    SELECT 1 FROM session_log_sync
+                    WHERE file_path = ?1 AND last_line_offset > 0
+                )",
+            )
+            .map_err(|e| AppError::Database(format!("准备 Codex 子代理同步状态查询失败: {e}")))?;
+
+        for (path, identity) in files {
+            let Some(identity) = identity else {
+                continue;
+            };
+            if !identity.is_subagent()
+                || !rebuildable_thread_ids.contains(identity.session_id.as_str())
+            {
+                continue;
+            }
+
+            let path = path.to_string_lossy();
+            let was_synced = stmt
+                .query_row(rusqlite::params![path.as_ref()], |row| {
+                    row.get::<_, bool>(0)
+                })
+                .map_err(|e| AppError::Database(format!("查询 Codex 子代理旧同步状态失败: {e}")))?;
+            if was_synced {
+                affected_session_ids.insert(identity.session_id.clone());
+            }
+        }
+    }
+
+    let tx = conn
+        .transaction()
+        .map_err(|e| AppError::Database(format!("开启 Codex 子代理用量修复事务失败: {e}")))?;
+
+    for session_id in &affected_session_ids {
+        tx.execute(
+            "DELETE FROM proxy_request_logs
+             WHERE data_source = 'codex_session' AND session_id = ?1",
+            rusqlite::params![session_id],
+        )
+        .map_err(|e| AppError::Database(format!("清理旧 Codex 子代理碰撞记录失败: {e}")))?;
+    }
+
+    if !affected_session_ids.is_empty() {
+        for (path, identity) in files {
+            let Some(identity) = identity else {
+                continue;
+            };
+            if !affected_session_ids.contains(&identity.thread_id)
+                && !affected_session_ids.contains(&identity.session_id)
+            {
+                continue;
+            }
+
+            let path = path.to_string_lossy();
+            let subagent_key = format!("{path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+            tx.execute(
+                "DELETE FROM session_log_sync WHERE file_path = ?1 OR file_path = ?2",
+                rusqlite::params![path.as_ref(), subagent_key],
+            )
+            .map_err(|e| AppError::Database(format!("重置 Codex 子代理同步游标失败: {e}")))?;
+        }
+    }
+
+    tx.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES (?1, 'true')",
+        rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
+    )
+    .map_err(|e| AppError::Database(format!("保存 Codex 子代理用量迁移状态失败: {e}")))?;
+
+    tx.commit()
+        .map_err(|e| AppError::Database(format!("提交 Codex 子代理用量修复失败: {e}")))?;
+
+    if !affected_session_ids.is_empty() {
+        log::info!(
+            "[CODEX-SYNC] 已重置 {} 个存在子代理 request_id 碰撞的历史会话",
+            affected_session_ids.len()
+        );
+    }
+
+    Ok(())
 }
 
 /// 收集所有 Codex 会话 JSONL 文件
@@ -229,8 +479,13 @@ fn collect_jsonl_recursive(dir: &Path, files: &mut Vec<PathBuf>, depth: u32, max
 }
 
 /// 同步单个 Codex JSONL 文件，返回 (imported, skipped)
-fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+fn sync_single_codex_file(
+    db: &Database,
+    file_path: &Path,
+    identity: Option<&CodexSessionIdentity>,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
+    let sync_state_key = codex_sync_state_key(&file_path_str, identity);
 
     // 获取文件元数据
     let metadata = fs::metadata(file_path)
@@ -238,7 +493,7 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
     let file_modified = metadata_modified_nanos(&metadata);
 
     // 检查同步状态
-    let (last_modified, last_offset) = get_sync_state(db, &file_path_str)?;
+    let (last_modified, last_offset) = get_sync_state(db, &sync_state_key)?;
 
     // 文件未变化则跳过
     if file_modified <= last_modified {
@@ -251,10 +506,13 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
     let reader = BufReader::new(file);
 
     let mut state = FileParseState {
-        session_id: None,
+        thread_id: identity.map(|identity| identity.thread_id.clone()),
         current_model: "unknown".to_string(),
         prev_total: None,
         event_index: 0,
+        seen_session_meta: false,
+        carries_history_snapshot: identity.is_some_and(CodexSessionIdentity::is_subagent),
+        session_started_at_ms: None,
     };
 
     let mut line_offset: i64 = 0;
@@ -296,16 +554,16 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
         };
 
         match event_type {
-            "session_meta" if state.session_id.is_none() => {
-                let payload = value.get("payload");
-                state.session_id = payload
-                    .and_then(|p| {
-                        p.get("session_id")
-                            .or_else(|| p.get("sessionId"))
-                            .or_else(|| p.get("id"))
-                    })
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+            "session_meta" if !state.seen_session_meta => {
+                state.seen_session_meta = true;
+                state.session_started_at_ms = json_timestamp_millis(&value);
+                if let Some(payload) = value.get("payload") {
+                    state.carries_history_snapshot = session_meta_carries_history_snapshot(payload);
+                    if state.thread_id.is_none() {
+                        state.thread_id = parse_codex_session_identity(payload)
+                            .map(|identity| identity.thread_id);
+                    }
+                }
             }
             "turn_context" => {
                 if let Some(payload) = value.get("payload") {
@@ -383,6 +641,21 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                     continue; // 跳过 task 边界的零 delta 事件
                 }
 
+                let timestamp = value
+                    .get("timestamp")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+
+                // 子代理/fork 文件开头可能重放父线程累计 token 历史。这里仍然
+                // 保留上方 prev_total 的更新，用它作为后续真实调用的 delta 基线，
+                // 但不为快照本身生成消费记录。
+                if is_history_snapshot_event(&state, timestamp.as_deref()) {
+                    if line_offset > last_offset {
+                        skipped += 1;
+                    }
+                    continue;
+                }
+
                 state.event_index += 1;
 
                 // 跳过已处理的行（但仍需解析以恢复状态）
@@ -391,21 +664,15 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
                 }
 
                 // 生成唯一 request_id
-                let session_id_str = state.session_id.as_deref().unwrap_or("unknown");
-                let request_id = format!("codex_session:{}:{}", session_id_str, state.event_index);
-
-                // 提取时间戳
-                let timestamp = value
-                    .get("timestamp")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                let thread_id = state.thread_id.as_deref().unwrap_or("unknown");
+                let request_id = format!("codex_session:{thread_id}:{}", state.event_index);
 
                 match insert_codex_session_entry(
                     db,
                     &request_id,
                     &delta,
                     &state.current_model,
-                    state.session_id.as_deref(),
+                    state.thread_id.as_deref(),
                     timestamp.as_deref(),
                 ) {
                     Ok(true) => imported += 1,
@@ -421,7 +688,7 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
     }
 
     // 更新同步状态
-    update_sync_state(db, &file_path_str, file_modified, line_offset)?;
+    update_sync_state(db, &sync_state_key, file_modified, line_offset)?;
 
     Ok((imported, skipped))
 }
@@ -549,6 +816,62 @@ fn find_codex_pricing(conn: &rusqlite::Connection, model_id: &str) -> Option<Mod
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+
+    fn write_codex_usage_log(
+        path: &Path,
+        thread_id: &str,
+        session_id: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) {
+        let lines = [
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": thread_id,
+                    "session_id": session_id,
+                    "parent_thread_id": (thread_id != session_id).then_some(session_id),
+                    "source": if thread_id == session_id {
+                        serde_json::Value::String("cli".to_string())
+                    } else {
+                        serde_json::json!({
+                            "subagent": {
+                                "thread_spawn": { "parent_thread_id": session_id, "depth": 1 }
+                            }
+                        })
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:01Z",
+                "type": "turn_context",
+                "payload": { "model": "gpt-5.6-sol" }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": input_tokens,
+                            "cached_input_tokens": input_tokens / 2,
+                            "output_tokens": output_tokens
+                        }
+                    }
+                }
+            }),
+        ];
+        let content = lines
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        fs::write(path, content).unwrap();
+    }
 
     #[test]
     fn test_delta_first_event() {
@@ -657,6 +980,241 @@ mod tests {
     fn test_collect_codex_session_files_nonexistent() {
         let files = collect_codex_session_files(Path::new("/nonexistent/path"));
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_subagent_identity_prefers_unique_thread_id() {
+        let payload = serde_json::json!({
+            "session_id": "parent-thread",
+            "id": "child-thread",
+            "parent_thread_id": "parent-thread",
+            "source": {
+                "subagent": {
+                    "thread_spawn": { "parent_thread_id": "parent-thread", "depth": 1 }
+                }
+            }
+        });
+
+        let identity = parse_codex_session_identity(&payload).unwrap();
+        assert_eq!(identity.thread_id, "child-thread");
+        assert_eq!(identity.session_id, "parent-thread");
+        assert!(identity.is_subagent());
+    }
+
+    #[test]
+    fn test_subagent_history_snapshot_is_baseline_not_usage() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let child = temp.path().join("child-history.jsonl");
+        let lines = [
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child",
+                    "session_id": "parent",
+                    "source": {
+                        "subagent": {
+                            "thread_spawn": { "parent_thread_id": "parent", "depth": 1 }
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.100Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 1000,
+                        "cached_input_tokens": 900,
+                        "output_tokens": 100
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.200Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 1200,
+                        "cached_input_tokens": 1000,
+                        "output_tokens": 120
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:02.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "model": "gpt-5.6-sol",
+                        "total_token_usage": {
+                            "input_tokens": 1300,
+                            "cached_input_tokens": 1050,
+                            "output_tokens": 150
+                        }
+                    }
+                }
+            }),
+        ];
+        fs::write(
+            &child,
+            lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n",
+        )
+        .unwrap();
+
+        let identity = read_codex_session_identity(&child).unwrap();
+        assert_eq!(
+            sync_single_codex_file(&db, &child, Some(&identity))?,
+            (1, 2)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let usage: (i64, i64, i64) = conn.query_row(
+            "SELECT input_tokens, cache_read_tokens, output_tokens
+             FROM proxy_request_logs
+             WHERE request_id = 'codex_session:child:1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(usage, (100, 50, 30));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_subagents_under_same_parent_get_unique_request_ids() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let child_a = temp.path().join("child-a.jsonl");
+        let child_b = temp.path().join("child-b.jsonl");
+        write_codex_usage_log(&child_a, "child-a", "parent", 100, 10);
+        write_codex_usage_log(&child_b, "child-b", "parent", 200, 20);
+
+        let identity_a = read_codex_session_identity(&child_a).unwrap();
+        let identity_b = read_codex_session_identity(&child_b).unwrap();
+        assert_eq!(
+            sync_single_codex_file(&db, &child_a, Some(&identity_a))?,
+            (1, 0)
+        );
+        assert_eq!(
+            sync_single_codex_file(&db, &child_b, Some(&identity_b))?,
+            (1, 0)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let request_ids = conn
+            .prepare(
+                "SELECT request_id FROM proxy_request_logs
+                 WHERE data_source = 'codex_session' ORDER BY request_id",
+            )?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            request_ids,
+            vec![
+                "codex_session:child-a:1".to_string(),
+                "codex_session:child-b:1".to_string()
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repair_resets_legacy_parent_collisions_and_reimports() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.jsonl");
+        let child = temp.path().join("child.jsonl");
+        write_codex_usage_log(&main, "parent", "parent", 100, 10);
+        write_codex_usage_log(&child, "child", "parent", 200, 20);
+
+        let main_identity = read_codex_session_identity(&main).unwrap();
+        let child_identity = read_codex_session_identity(&child).unwrap();
+        let files = vec![
+            (main.clone(), Some(main_identity.clone())),
+            (child.clone(), Some(child_identity.clone())),
+        ];
+
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, request_model,
+                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                    total_cost_usd, latency_ms, status_code, session_id, created_at, data_source
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    "codex_session:parent:1",
+                    "_codex_session",
+                    "codex",
+                    "gpt-5.6-sol",
+                    "gpt-5.6-sol",
+                    200,
+                    20,
+                    100,
+                    0,
+                    "0",
+                    0,
+                    200,
+                    "parent",
+                    1_752_116_402i64,
+                    "codex_session"
+                ],
+            )?;
+        }
+        let main_path = main.to_string_lossy().to_string();
+        let child_path = child.to_string_lossy().to_string();
+        update_sync_state(&db, &main_path, 1, 3)?;
+        update_sync_state(&db, &child_path, 1, 3)?;
+
+        repair_legacy_codex_subagent_usage(&db, &files)?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            let old_rows: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM proxy_request_logs
+                 WHERE request_id = 'codex_session:parent:1'",
+                [],
+                |row| row.get(0),
+            )?;
+            assert_eq!(old_rows, 0);
+
+            let old_sync_rows: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM session_log_sync WHERE file_path IN (?1, ?2)",
+                rusqlite::params![main_path, child_path],
+                |row| row.get(0),
+            )?;
+            assert_eq!(old_sync_rows, 0);
+        }
+
+        assert_eq!(
+            sync_single_codex_file(&db, &main, Some(&main_identity))?,
+            (1, 0)
+        );
+        assert_eq!(
+            sync_single_codex_file(&db, &child, Some(&child_identity))?,
+            (1, 0)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 2);
+
+        Ok(())
     }
 
     #[test]

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -569,16 +569,13 @@ fn repair_legacy_codex_subagent_usage(
         )
         .map_err(|e| AppError::Database(format!("复查 Codex 子代理迁移状态失败: {e}")))?;
 
-    let codex_rollup_dates = if migration_became_active {
-        HashSet::new()
-    } else {
-        tx.prepare("SELECT DISTINCT date FROM usage_daily_rollups WHERE app_type = 'codex'")
-            .and_then(|mut stmt| {
-                stmt.query_map([], |row| row.get::<_, String>(0))?
-                    .collect::<Result<HashSet<_>, _>>()
-            })
-            .map_err(|e| AppError::Database(format!("查询 Codex 历史汇总日期失败: {e}")))?
-    };
+    let codex_rollup_dates = tx
+        .prepare("SELECT DISTINCT date FROM usage_daily_rollups WHERE app_type = 'codex'")
+        .and_then(|mut stmt| {
+            stmt.query_map([], |row| row.get::<_, String>(0))?
+                .collect::<Result<HashSet<_>, _>>()
+        })
+        .map_err(|e| AppError::Database(format!("查询 Codex 历史汇总日期失败: {e}")))?;
 
     let synced_session_ids: HashSet<&str> = active_synced_subagent_paths
         .iter()
@@ -630,7 +627,16 @@ fn repair_legacy_codex_subagent_usage(
             continue;
         }
         if rebuilt_session_ids.contains(&session_id) {
-            late_rebuild_subagent_paths.insert(path);
+            let overlaps_rollup = file_rollup_coverage
+                .get(Path::new(&path))
+                .is_none_or(|coverage| coverage.may_overlap(&codex_rollup_dates));
+            if overlaps_rollup {
+                // 该文件的历史可能已经进入无 session 维度的日汇总，不能从头补回。
+                // 只迁移旧游标，后续仍可安全导入 offset 之后的新事件。
+                preserved_synced_subagent_paths.insert(path);
+            } else {
+                late_rebuild_subagent_paths.insert(path);
+            }
         } else {
             preserved_session_ids.insert(session_id);
             preserved_synced_subagent_paths.insert(path);
@@ -1844,6 +1850,146 @@ mod tests {
             vec![
                 "codex_session:child-a:1".to_string(),
                 "codex_session:child-b:1".to_string(),
+                "codex_session:parent:1".to_string(),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_late_sibling_with_rollup_only_imports_new_usage() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.jsonl");
+        let child_a = temp.path().join("child-a.jsonl");
+        let child_b = temp.path().join("child-b.jsonl");
+        write_codex_usage_log(&main, "parent", "parent", 100, 10);
+        write_codex_usage_log(&child_a, "child-a", "parent", 200, 20);
+
+        let child_b_lines = [
+            serde_json::json!({
+                "timestamp": "2025-07-10T03:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child-b",
+                    "session_id": "parent",
+                    "source": { "subagent": {} }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2025-07-10T03:00:01Z",
+                "type": "turn_context",
+                "payload": { "model": "gpt-5.6-sol" }
+            }),
+            serde_json::json!({
+                "timestamp": "2025-07-10T03:00:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 300,
+                        "cached_input_tokens": 150,
+                        "output_tokens": 30
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:03Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 400,
+                        "cached_input_tokens": 200,
+                        "output_tokens": 40
+                    }}
+                }
+            }),
+        ];
+        fs::write(
+            &child_b,
+            child_b_lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n",
+        )
+        .unwrap();
+
+        let main_identity = read_codex_session_identity(&main).unwrap();
+        let child_a_identity = read_codex_session_identity(&child_a).unwrap();
+        let child_b_identity = read_codex_session_identity(&child_b).unwrap();
+        insert_legacy_codex_usage_row(&db, "parent")?;
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "UPDATE proxy_request_logs
+                 SET provider_id = 'openai', data_source = 'proxy'
+                 WHERE request_id = 'codex_session:parent:1'",
+                [],
+            )?;
+        }
+        assert_eq!(db.rollup_and_prune(30)?, 1);
+
+        let main_path = main.to_string_lossy().to_string();
+        let child_a_path = child_a.to_string_lossy().to_string();
+        let child_b_path = child_b.to_string_lossy().to_string();
+        update_sync_state(&db, &main_path, 1, 3)?;
+        update_sync_state(&db, &child_a_path, 1, 3)?;
+        update_sync_state(&db, &child_b_path, 1, 3)?;
+
+        let first_files = vec![
+            (main.clone(), Some(main_identity.clone())),
+            (child_a.clone(), Some(child_a_identity.clone())),
+        ];
+        repair_legacy_codex_subagent_usage(&db, &first_files)?;
+        assert_eq!(
+            sync_single_codex_file(&db, &main, Some(&main_identity))?,
+            (1, 0)
+        );
+        assert_eq!(
+            sync_single_codex_file(&db, &child_a, Some(&child_a_identity))?,
+            (1, 0)
+        );
+
+        let all_files = vec![
+            (main, Some(main_identity)),
+            (child_a, Some(child_a_identity)),
+            (child_b.clone(), Some(child_b_identity.clone())),
+        ];
+        repair_legacy_codex_subagent_usage(&db, &all_files)?;
+
+        let subagent_key = format!("{child_b_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+        assert_eq!(get_sync_state(&db, &child_b_path)?, (0, 0));
+        assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
+        assert_eq!(
+            sync_single_codex_file(&db, &child_b, Some(&child_b_identity))?,
+            (1, 0)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let rollup_count: i64 = conn.query_row(
+            "SELECT request_count FROM usage_daily_rollups
+             WHERE app_type = 'codex' AND provider_id = 'openai'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(rollup_count, 1);
+
+        let request_ids = conn
+            .prepare(
+                "SELECT request_id FROM proxy_request_logs
+                 WHERE data_source = 'codex_session' ORDER BY request_id",
+            )?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            request_ids,
+            vec![
+                "codex_session:child-a:1".to_string(),
+                "codex_session:child-b:2".to_string(),
                 "codex_session:parent:1".to_string(),
             ]
         );

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -23,16 +23,12 @@ use crate::services::session_usage::{
 };
 use crate::services::usage_stats::{find_model_pricing, should_skip_session_insert, DedupKey};
 use rust_decimal::Decimal;
-use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-const CODEX_SUBAGENT_USAGE_MIGRATION_KEY: &str = "codex_subagent_usage_thread_id_v1_migrated";
-const CODEX_SUBAGENT_REBUILT_SESSION_KEY_PREFIX: &str =
-    "codex_subagent_usage_thread_id_v1_rebuilt:";
-const CODEX_SUBAGENT_SYNC_KEY_SUFFIX: &str = "#codex-thread-id-v1";
+const CODEX_THREAD_REQUEST_ID_PREFIX: &str = "codex_session:thread-v1";
 
 /// 累计 token 用量（跟踪 total_token_usage 字段）
 #[derive(Debug, Clone, Default)]
@@ -62,28 +58,14 @@ struct FileParseState {
     current_model: String,
     prev_total: Option<CumulativeTokens>,
     event_index: u32,
-    seen_session_meta: bool,
     history_replay_boundary: Option<i64>,
 }
 
-/// Codex 的现代子代理日志同时包含两个不同含义的 ID：
-///
-/// - `id`: 当前日志文件对应的唯一线程 ID；
-/// - `session_id`: 父线程 ID（主线程中两者相同）。
-///
-/// request_id 必须使用 thread_id，否则同一父线程下各文件从 1 开始的
-/// event_index 会互相碰撞，并被数据库的唯一约束当作重复记录丢弃。
+/// Codex 子代理日志中的 `id` 是当前线程的唯一 ID，`session_id` 则指向父线程。
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CodexSessionIdentity {
     thread_id: String,
-    session_id: String,
     carries_history_snapshot: bool,
-}
-
-impl CodexSessionIdentity {
-    fn is_subagent(&self) -> bool {
-        self.thread_id != self.session_id
-    }
 }
 
 fn parse_codex_session_identity(payload: &serde_json::Value) -> Option<CodexSessionIdentity> {
@@ -95,13 +77,10 @@ fn parse_codex_session_identity(payload: &serde_json::Value) -> Option<CodexSess
         .or_else(|| payload.get("sessionId"))
         .and_then(|value| value.as_str())?
         .to_string();
-
     let session_id = payload
         .get("session_id")
         .or_else(|| payload.get("sessionId"))
-        .and_then(|value| value.as_str())
-        .map(str::to_string)
-        .unwrap_or_else(|| thread_id.clone());
+        .and_then(|value| value.as_str());
     let carries_history_snapshot = payload
         .get("forked_from_id")
         .and_then(|value| value.as_str())
@@ -110,20 +89,18 @@ fn parse_codex_session_identity(payload: &serde_json::Value) -> Option<CodexSess
             .get("source")
             .and_then(|source| source.get("subagent"))
             .is_some()
-        || thread_id != session_id;
+        || session_id.is_some_and(|session_id| session_id != thread_id);
 
     Some(CodexSessionIdentity {
         thread_id,
-        session_id,
         carries_history_snapshot,
     })
 }
 
 fn read_codex_session_identity(file_path: &Path) -> Option<CodexSessionIdentity> {
     let file = fs::File::open(file_path).ok()?;
-    let reader = BufReader::new(file);
 
-    for line in reader.lines() {
+    for line in BufReader::new(file).lines() {
         let Ok(line) = line else {
             continue;
         };
@@ -144,71 +121,32 @@ fn read_codex_session_identity(file_path: &Path) -> Option<CodexSessionIdentity>
     None
 }
 
-fn codex_sync_state_key(file_path: &str, identity: Option<&CodexSessionIdentity>) -> String {
-    if identity.is_some_and(CodexSessionIdentity::is_subagent) {
-        // 旧版本用父 session_id 生成 request_id。为子代理使用新的同步键，
-        // 可让升级后的首次同步重新读取已经到达 EOF 的历史子代理文件。
-        format!("{file_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}")
-    } else {
-        file_path.to_string()
-    }
-}
-
-fn session_meta_carries_history_snapshot(payload: &serde_json::Value) -> bool {
-    let has_fork_parent = payload
-        .get("forked_from_id")
-        .and_then(|value| value.as_str())
-        .is_some_and(|value| !value.is_empty());
-    let is_subagent = payload
-        .get("source")
-        .and_then(|source| source.get("subagent"))
-        .is_some()
-        || parse_codex_session_identity(payload)
-            .is_some_and(|identity| identity.carries_history_snapshot);
-
-    has_fork_parent || is_subagent
-}
-
-/// fork/restore 日志会先重放父线程历史，再以明确的接管事件开始子线程。
-/// 返回接管事件所在行；该行之前的 token_count 只用于恢复累计值基线。
+/// fork/子代理日志会先重放父线程历史，再以接管事件开始当前线程。
+/// 返回接管事件所在行；此前的 token_count 只用于恢复累计值基线。
 fn codex_history_replay_boundary(
     file_path: &Path,
     identity: Option<&CodexSessionIdentity>,
 ) -> Option<i64> {
-    if identity.is_some_and(|identity| !identity.carries_history_snapshot) {
+    if !identity.is_some_and(|identity| identity.carries_history_snapshot) {
         return None;
     }
 
     let file = fs::File::open(file_path).ok()?;
-    let reader = BufReader::new(file);
-    let mut carries_history_snapshot =
-        identity.is_some_and(|identity| identity.carries_history_snapshot);
-
-    for (index, line) in reader.lines().enumerate() {
+    for (index, line) in BufReader::new(file).lines().enumerate() {
         let Ok(line) = line else {
             continue;
         };
-        if !line.contains("\"session_meta\"")
-            && !line.contains("\"thread_settings_applied\"")
+        if !line.contains("\"thread_settings_applied\"")
             && !line.contains("\"inter_agent_communication")
         {
             continue;
         }
-
         let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
             continue;
         };
         let Some(event_type) = value.get("type").and_then(|value| value.as_str()) else {
             continue;
         };
-
-        if event_type == "session_meta" {
-            if let Some(payload) = value.get("payload") {
-                carries_history_snapshot |= session_meta_carries_history_snapshot(payload);
-            }
-            continue;
-        }
-
         let is_replay_boundary = event_type.starts_with("inter_agent_communication")
             || (event_type == "event_msg"
                 && value
@@ -216,7 +154,7 @@ fn codex_history_replay_boundary(
                     .and_then(|payload| payload.get("type"))
                     .and_then(|value| value.as_str())
                     == Some("thread_settings_applied"));
-        if carries_history_snapshot && is_replay_boundary {
+        if is_replay_boundary {
             return Some(index as i64 + 1);
         }
     }
@@ -230,72 +168,48 @@ fn is_history_snapshot_event(state: &FileParseState, line_offset: i64) -> bool {
         .is_some_and(|boundary| line_offset < boundary)
 }
 
-struct CodexRollupDateCoverage {
-    dates: HashSet<String>,
-    unknown: bool,
-}
-
-impl CodexRollupDateCoverage {
-    fn from_file(file_path: &Path) -> Self {
-        match codex_file_rollup_date_candidates(file_path) {
-            Some(dates) => Self {
-                dates,
-                unknown: false,
-            },
-            None => Self {
-                dates: HashSet::new(),
-                unknown: true,
-            },
-        }
+fn get_codex_sync_state(db: &Database, file_path: &Path) -> Result<(i64, i64), AppError> {
+    let file_path_str = file_path.to_string_lossy().to_string();
+    let state = get_sync_state(db, &file_path_str)?;
+    if state != (0, 0)
+        || file_path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            != Some("archived_sessions")
+    {
+        return Ok(state);
     }
 
-    fn may_overlap(&self, rollup_dates: &HashSet<String>) -> bool {
-        !rollup_dates.is_empty()
-            && (self.unknown || self.dates.iter().any(|date| rollup_dates.contains(date)))
+    let Some(file_name) = file_path.file_name().and_then(|name| name.to_str()) else {
+        return Ok(state);
+    };
+    let slash_suffix = format!("/{file_name}");
+    let backslash_suffix = format!("\\{file_name}");
+    let conn = lock_conn!(db.conn);
+    let inherited = conn.query_row(
+        "SELECT last_modified, last_line_offset
+         FROM session_log_sync
+         WHERE file_path <> ?1
+           AND (substr(file_path, -length(?2)) = ?2
+                OR substr(file_path, -length(?3)) = ?3)
+         ORDER BY last_line_offset DESC, last_modified DESC
+         LIMIT 1",
+        rusqlite::params![file_path_str, slash_suffix, backslash_suffix],
+        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+    );
+    drop(conn);
+
+    match inherited {
+        Ok(inherited) => {
+            update_sync_state(db, &file_path_str, inherited.0, inherited.1)?;
+            Ok(inherited)
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(state),
+        Err(error) => Err(AppError::Database(format!(
+            "查询 Codex 归档文件同步状态失败: {error}"
+        ))),
     }
-}
-
-fn codex_file_rollup_date_candidates(file_path: &Path) -> Option<HashSet<String>> {
-    let file = fs::File::open(file_path).ok()?;
-    let mut dates = HashSet::new();
-
-    for line in BufReader::new(file).lines() {
-        let line = line.ok()?;
-        if !line.contains("\"token_count\"") {
-            continue;
-        }
-
-        let value = serde_json::from_str::<serde_json::Value>(&line).ok()?;
-        let is_usage_event = value.get("type").and_then(|value| value.as_str())
-            == Some("event_msg")
-            && value
-                .get("payload")
-                .and_then(|payload| payload.get("type"))
-                .and_then(|value| value.as_str())
-                == Some("token_count")
-            && value
-                .get("payload")
-                .and_then(|payload| payload.get("info"))
-                .is_some_and(|info| !info.is_null());
-        if !is_usage_event {
-            continue;
-        }
-
-        let timestamp = value.get("timestamp").and_then(|value| value.as_str())?;
-        let timestamp = chrono::DateTime::parse_from_rfc3339(timestamp).ok()?;
-        // rollup 只保留当时的本地日期，无法得知当时的时区。任意合法时区下，
-        // 一个时间点的本地日期只可能落在其 UTC 日期的前一天、当天或后一天。
-        // 检查这三个日期可避免用户在 rollup 后切换时区时漏判并重复导入。
-        let utc_date = timestamp.with_timezone(&chrono::Utc).date_naive();
-        for date in [utc_date.pred_opt(), Some(utc_date), utc_date.succ_opt()]
-            .into_iter()
-            .flatten()
-        {
-            dates.insert(date.format("%Y-%m-%d").to_string());
-        }
-    }
-
-    Some(dates)
 }
 
 /// 归一化 Codex 模型名
@@ -387,29 +301,20 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     let codex_dir = get_codex_config_dir();
 
     let files = collect_codex_session_files(&codex_dir);
-    let files_with_identity: Vec<(PathBuf, Option<CodexSessionIdentity>)> = files
-        .into_iter()
-        .map(|path| {
-            let identity = read_codex_session_identity(&path);
-            (path, identity)
-        })
-        .collect();
-
-    repair_legacy_codex_subagent_usage(db, &files_with_identity)?;
 
     let mut result = SessionSyncResult {
         imported: 0,
         skipped: 0,
-        files_scanned: files_with_identity.len() as u32,
+        files_scanned: files.len() as u32,
         errors: vec![],
     };
 
-    if files_with_identity.is_empty() {
+    if files.is_empty() {
         return Ok(result);
     }
 
-    for (file_path, identity) in &files_with_identity {
-        match sync_single_codex_file(db, file_path, identity.as_ref()) {
+    for file_path in &files {
+        match sync_single_codex_file(db, file_path) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -432,332 +337,6 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
     }
 
     Ok(result)
-}
-
-/// 修复旧版以父 session_id 作为 request_id 命名空间造成的历史碰撞。
-///
-/// 仅在会话日志日期未与 Codex 汇总日期重叠时，处理已经被旧同步器读取过、
-/// 且父线程日志仍可从磁盘重建的会话：
-/// 1. 删除该父线程下无法区分主/子代理来源的旧 Codex session 行；
-/// 2. 清除相关文件的同步游标；
-/// 3. 当前同步轮次会用唯一 thread_id 重建准确记录。
-///
-/// `usage_daily_rollups` 没有 session 维度，已有汇总行时无法只撤销受影响会话。
-/// 此时保留历史统计、迁移子代理游标并隔离旧 request_id，避免全量重导造成
-/// 永久双计，也避免旧子代理记录阻塞父线程后续新增用量。
-fn repair_legacy_codex_subagent_usage(
-    db: &Database,
-    files: &[(PathBuf, Option<CodexSessionIdentity>)],
-) -> Result<(), AppError> {
-    let (already_migrated, synced_subagent_paths) = {
-        let conn = lock_conn!(db.conn);
-        let already_migrated = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1 AND value = 'true')",
-                rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
-                |row| row.get::<_, bool>(0),
-            )
-            .map_err(|e| AppError::Database(format!("查询 Codex 子代理用量迁移状态失败: {e}")))?;
-        let mut stmt = conn
-            .prepare(
-                "SELECT EXISTS(
-                    SELECT 1 FROM session_log_sync
-                    WHERE file_path = ?1 AND last_line_offset > 0
-                )",
-            )
-            .map_err(|e| AppError::Database(format!("准备 Codex 子代理同步状态查询失败: {e}")))?;
-        let mut synced_paths = Vec::new();
-
-        for (path, identity) in files {
-            let Some(identity) = identity else {
-                continue;
-            };
-            if !identity.is_subagent() {
-                continue;
-            }
-
-            let path = path.to_string_lossy();
-            let was_synced = stmt
-                .query_row(rusqlite::params![path.as_ref()], |row| {
-                    row.get::<_, bool>(0)
-                })
-                .map_err(|e| AppError::Database(format!("查询 Codex 子代理旧同步状态失败: {e}")))?;
-            if was_synced {
-                synced_paths.push((path.into_owned(), identity.session_id.clone()));
-            }
-        }
-
-        (already_migrated, synced_paths)
-    };
-
-    if synced_subagent_paths.is_empty() {
-        // 空目录可能只是 CODEX_HOME 暂时不可用，不能永久关闭后续迁移。
-        if !already_migrated && !files.is_empty() {
-            let conn = lock_conn!(db.conn);
-            conn.execute(
-                "INSERT OR REPLACE INTO settings (key, value) VALUES (?1, 'true')",
-                rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
-            )
-            .map_err(|e| AppError::Database(format!("保存 Codex 子代理用量迁移状态失败: {e}")))?;
-        }
-        return Ok(());
-    }
-
-    let candidate_session_ids: HashSet<&str> = synced_subagent_paths
-        .iter()
-        .map(|(_, session_id)| session_id.as_str())
-        .collect();
-    let file_rollup_coverage: HashMap<PathBuf, CodexRollupDateCoverage> = files
-        .iter()
-        .filter(|(_, identity)| {
-            identity.as_ref().is_some_and(|identity| {
-                candidate_session_ids.contains(identity.thread_id.as_str())
-                    || candidate_session_ids.contains(identity.session_id.as_str())
-            })
-        })
-        .map(|(path, _)| (path.clone(), CodexRollupDateCoverage::from_file(path)))
-        .collect();
-
-    let rebuildable_thread_ids: HashSet<&str> = files
-        .iter()
-        .filter_map(|(_, identity)| {
-            identity
-                .as_ref()
-                .map(|identity| identity.thread_id.as_str())
-        })
-        .collect();
-
-    let mut conn = lock_conn!(db.conn);
-    let tx = conn
-        .transaction()
-        .map_err(|e| AppError::Database(format!("开启 Codex 子代理用量修复事务失败: {e}")))?;
-
-    // 文件扫描期间没有持有数据库锁。重新加锁后再确认旧游标仍存在，避免并发
-    // 同步已经完成迁移时重复处理同一文件。
-    let active_synced_subagent_paths = {
-        let mut stmt = tx
-            .prepare(
-                "SELECT EXISTS(
-                    SELECT 1 FROM session_log_sync
-                    WHERE file_path = ?1 AND last_line_offset > 0
-                )",
-            )
-            .map_err(|e| AppError::Database(format!("准备 Codex 子代理同步状态复查失败: {e}")))?;
-        let mut active_paths = Vec::new();
-        for (path, session_id) in synced_subagent_paths {
-            let was_synced = stmt
-                .query_row(rusqlite::params![path], |row| row.get::<_, bool>(0))
-                .map_err(|e| AppError::Database(format!("复查 Codex 子代理旧同步状态失败: {e}")))?;
-            if was_synced {
-                active_paths.push((path, session_id));
-            }
-        }
-        active_paths
-    };
-
-    if active_synced_subagent_paths.is_empty() {
-        tx.commit()
-            .map_err(|e| AppError::Database(format!("提交 Codex 子代理用量修复失败: {e}")))?;
-        return Ok(());
-    }
-
-    let migration_became_active = tx
-        .query_row(
-            "SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1 AND value = 'true')",
-            rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
-            |row| row.get::<_, bool>(0),
-        )
-        .map_err(|e| AppError::Database(format!("复查 Codex 子代理迁移状态失败: {e}")))?;
-
-    let codex_rollup_dates = tx
-        .prepare("SELECT DISTINCT date FROM usage_daily_rollups WHERE app_type = 'codex'")
-        .and_then(|mut stmt| {
-            stmt.query_map([], |row| row.get::<_, String>(0))?
-                .collect::<Result<HashSet<_>, _>>()
-        })
-        .map_err(|e| AppError::Database(format!("查询 Codex 历史汇总日期失败: {e}")))?;
-
-    let synced_session_ids: HashSet<&str> = active_synced_subagent_paths
-        .iter()
-        .map(|(_, session_id)| session_id.as_str())
-        .collect();
-    let rebuilt_session_ids = {
-        let mut stmt = tx
-            .prepare("SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1 AND value = 'true')")
-            .map_err(|e| AppError::Database(format!("准备 Codex 已重建会话查询失败: {e}")))?;
-        let mut rebuilt = HashSet::new();
-        for session_id in &synced_session_ids {
-            let key = format!("{CODEX_SUBAGENT_REBUILT_SESSION_KEY_PREFIX}{session_id}");
-            let was_rebuilt = stmt
-                .query_row([key], |row| row.get::<_, bool>(0))
-                .map_err(|e| AppError::Database(format!("查询 Codex 已重建会话失败: {e}")))?;
-            if was_rebuilt {
-                rebuilt.insert((*session_id).to_string());
-            }
-        }
-        rebuilt
-    };
-    let mut affected_session_ids = HashSet::new();
-    let mut late_rebuild_subagent_paths = HashSet::new();
-    let mut preserved_session_ids = HashSet::new();
-    let mut preserved_synced_subagent_paths = HashSet::new();
-
-    if !migration_became_active {
-        for session_id in synced_session_ids {
-            if !rebuildable_thread_ids.contains(session_id) {
-                continue;
-            }
-
-            let overlaps_rollup = files.iter().any(|(path, identity)| {
-                identity.as_ref().is_some_and(|identity| {
-                    (identity.thread_id == session_id || identity.session_id == session_id)
-                        && file_rollup_coverage
-                            .get(path)
-                            .is_none_or(|coverage| coverage.may_overlap(&codex_rollup_dates))
-                })
-            });
-            if !overlaps_rollup {
-                affected_session_ids.insert(session_id.to_string());
-            }
-        }
-    }
-
-    for (path, session_id) in active_synced_subagent_paths {
-        if affected_session_ids.contains(&session_id) {
-            continue;
-        }
-        if rebuilt_session_ids.contains(&session_id) {
-            let overlaps_rollup = file_rollup_coverage
-                .get(Path::new(&path))
-                .is_none_or(|coverage| coverage.may_overlap(&codex_rollup_dates));
-            if overlaps_rollup {
-                // 该文件的历史可能已经进入无 session 维度的日汇总，不能从头补回。
-                // 只迁移旧游标，后续仍可安全导入 offset 之后的新事件。
-                preserved_synced_subagent_paths.insert(path);
-            } else {
-                late_rebuild_subagent_paths.insert(path);
-            }
-        } else {
-            preserved_session_ids.insert(session_id);
-            preserved_synced_subagent_paths.insert(path);
-        }
-    }
-
-    for session_id in &affected_session_ids {
-        tx.execute(
-            "DELETE FROM proxy_request_logs
-             WHERE data_source = 'codex_session' AND session_id = ?1",
-            rusqlite::params![session_id],
-        )
-        .map_err(|e| AppError::Database(format!("清理旧 Codex 子代理碰撞记录失败: {e}")))?;
-    }
-
-    // 保留历史统计时不能继续让旧记录占用父线程的 request_id 命名空间。
-    // 旧子代理可能抢先写入 parent:N；父线程未来增长到同一个 N 时会被误判为
-    // 重复记录。仅重命名主键，不改变任何用量字段或汇总结果。
-    for session_id in &preserved_session_ids {
-        tx.execute(
-            "UPDATE proxy_request_logs
-             SET request_id = 'codex_session:legacy:' || rowid || ':' || request_id
-             WHERE data_source = 'codex_session' AND session_id = ?1
-               AND request_id NOT LIKE 'codex_session:legacy:%'",
-            rusqlite::params![session_id],
-        )
-        .map_err(|e| AppError::Database(format!("迁移保留的 Codex 旧请求 ID 失败: {e}")))?;
-    }
-
-    if !affected_session_ids.is_empty() {
-        for (path, identity) in files {
-            let Some(identity) = identity else {
-                continue;
-            };
-            if !affected_session_ids.contains(&identity.thread_id)
-                && !affected_session_ids.contains(&identity.session_id)
-            {
-                continue;
-            }
-
-            let path = path.to_string_lossy();
-            let subagent_key = format!("{path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
-            tx.execute(
-                "DELETE FROM session_log_sync WHERE file_path = ?1 OR file_path = ?2",
-                rusqlite::params![path.as_ref(), subagent_key],
-            )
-            .map_err(|e| AppError::Database(format!("重置 Codex 子代理同步游标失败: {e}")))?;
-        }
-
-        for session_id in &affected_session_ids {
-            let key = format!("{CODEX_SUBAGENT_REBUILT_SESSION_KEY_PREFIX}{session_id}");
-            tx.execute(
-                "INSERT OR REPLACE INTO settings (key, value) VALUES (?1, 'true')",
-                [key],
-            )
-            .map_err(|e| AppError::Database(format!("记录 Codex 已重建会话失败: {e}")))?;
-        }
-    }
-
-    // 同一父会话已完成精确重建时，迟到的兄弟子代理旧记录已随父命名空间
-    // 一并删除。清除该文件的新旧游标，让它从头按唯一 thread_id 补回历史。
-    for path in &late_rebuild_subagent_paths {
-        let subagent_key = format!("{path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
-        tx.execute(
-            "DELETE FROM session_log_sync WHERE file_path = ?1 OR file_path = ?2",
-            rusqlite::params![path, subagent_key],
-        )
-        .map_err(|e| AppError::Database(format!("重置迟到 Codex 子代理同步游标失败: {e}")))?;
-    }
-
-    // 父日志已不存在，或历史已进入无 session 维度的 rollup 时，无法安全重建
-    // 旧记录。保留旧统计，把旧游标复制到 thread_id 同步键，再删除 plain-path
-    // 游标作为该文件已处理的标记。以后恢复的遗漏文件仍可独立触发同一迁移。
-    for path in &preserved_synced_subagent_paths {
-        let subagent_key = format!("{path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
-        tx.execute(
-            "INSERT INTO session_log_sync (
-                file_path, last_modified, last_line_offset, last_synced_at
-             )
-             SELECT ?2, last_modified, last_line_offset, last_synced_at
-             FROM session_log_sync WHERE file_path = ?1
-             ON CONFLICT(file_path) DO UPDATE SET
-                last_modified = MAX(last_modified, excluded.last_modified),
-                last_line_offset = MAX(last_line_offset, excluded.last_line_offset),
-                last_synced_at = MAX(last_synced_at, excluded.last_synced_at)",
-            rusqlite::params![path, subagent_key],
-        )
-        .map_err(|e| AppError::Database(format!("迁移保留的 Codex 子代理同步游标失败: {e}")))?;
-        tx.execute("DELETE FROM session_log_sync WHERE file_path = ?1", [path])
-            .map_err(|e| AppError::Database(format!("清理 Codex 子代理旧同步游标失败: {e}")))?;
-    }
-
-    tx.execute(
-        "INSERT OR REPLACE INTO settings (key, value) VALUES (?1, 'true')",
-        rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
-    )
-    .map_err(|e| AppError::Database(format!("保存 Codex 子代理用量迁移状态失败: {e}")))?;
-
-    tx.commit()
-        .map_err(|e| AppError::Database(format!("提交 Codex 子代理用量修复失败: {e}")))?;
-
-    if !affected_session_ids.is_empty() {
-        log::info!(
-            "[CODEX-SYNC] 已重置 {} 个存在子代理 request_id 碰撞的历史会话",
-            affected_session_ids.len()
-        );
-    }
-    if !codex_rollup_dates.is_empty() && !preserved_synced_subagent_paths.is_empty() {
-        log::info!(
-            "[CODEX-SYNC] 检测到历史汇总，已保留旧统计并迁移 {} 个子代理同步游标",
-            preserved_synced_subagent_paths.len()
-        );
-    }
-    if !late_rebuild_subagent_paths.is_empty() {
-        log::info!(
-            "[CODEX-SYNC] 已重置 {} 个迟到子代理游标以补回历史用量",
-            late_rebuild_subagent_paths.len()
-        );
-    }
-
-    Ok(())
 }
 
 /// 收集所有 Codex 会话 JSONL 文件
@@ -804,13 +383,8 @@ fn collect_jsonl_recursive(dir: &Path, files: &mut Vec<PathBuf>, depth: u32, max
 }
 
 /// 同步单个 Codex JSONL 文件，返回 (imported, skipped)
-fn sync_single_codex_file(
-    db: &Database,
-    file_path: &Path,
-    identity: Option<&CodexSessionIdentity>,
-) -> Result<(u32, u32), AppError> {
+fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
-    let sync_state_key = codex_sync_state_key(&file_path_str, identity);
 
     // 获取文件元数据
     let metadata = fs::metadata(file_path)
@@ -818,42 +392,26 @@ fn sync_single_codex_file(
     let file_modified = metadata_modified_nanos(&metadata);
 
     // 检查同步状态
-    let (mut last_modified, mut last_offset) = get_sync_state(db, &sync_state_key)?;
-    if identity.is_some_and(CodexSessionIdentity::is_subagent) {
-        let legacy_state = get_sync_state(db, &file_path_str)?;
-        if legacy_state.1 > last_offset {
-            // 迁移可能在日志文件暂时缺失时完成。suffix 游标不存在时始终继承
-            // plain-path 旧游标，避免文件恢复后从头重导造成重复统计。
-            update_sync_state(db, &sync_state_key, legacy_state.0, legacy_state.1)?;
-            (last_modified, last_offset) = legacy_state;
-        }
-    }
+    let (last_modified, last_offset) = get_codex_sync_state(db, file_path)?;
 
     // 文件未变化则跳过
     if file_modified <= last_modified {
         return Ok((0, 0));
     }
 
+    let identity = read_codex_session_identity(file_path);
+
     // 打开文件逐行解析
     let file =
         fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
     let reader = BufReader::new(file);
-    let history_replay_boundary = codex_history_replay_boundary(file_path, identity);
-    if identity.is_some_and(|identity| identity.carries_history_snapshot)
-        && history_replay_boundary.is_none()
-    {
-        log::debug!(
-            "[CODEX-SYNC] fork/子代理日志未发现历史接管边界: {}",
-            file_path.display()
-        );
-    }
+    let history_replay_boundary = codex_history_replay_boundary(file_path, identity.as_ref());
 
     let mut state = FileParseState {
-        thread_id: identity.map(|identity| identity.thread_id.clone()),
+        thread_id: identity.map(|identity| identity.thread_id),
         current_model: "unknown".to_string(),
         prev_total: None,
         event_index: 0,
-        seen_session_meta: false,
         history_replay_boundary,
     };
 
@@ -896,14 +454,11 @@ fn sync_single_codex_file(
         };
 
         match event_type {
-            "session_meta" if !state.seen_session_meta => {
-                state.seen_session_meta = true;
-                if let Some(payload) = value.get("payload") {
-                    if state.thread_id.is_none() {
-                        state.thread_id = parse_codex_session_identity(payload)
-                            .map(|identity| identity.thread_id);
-                    }
-                }
+            "session_meta" if state.thread_id.is_none() => {
+                state.thread_id = value
+                    .get("payload")
+                    .and_then(parse_codex_session_identity)
+                    .map(|identity| identity.thread_id);
             }
             "turn_context" => {
                 if let Some(payload) = value.get("payload") {
@@ -981,18 +536,10 @@ fn sync_single_codex_file(
                     continue; // 跳过 task 边界的零 delta 事件
                 }
 
-                // request_id 的序号沿用旧解析器定义：每个非零 token delta 都占一位。
-                // replay 虽不计费，也必须占号，否则升级后追加事件会撞上旧主键。
+                // 所有非零事件都占据稳定序号，包括已同步事件与 replay 快照。
                 state.event_index += 1;
 
-                let timestamp = value
-                    .get("timestamp")
-                    .and_then(|value| value.as_str())
-                    .map(str::to_string);
-
-                // 子代理/fork 文件开头可能重放父线程累计 token 历史。这里仍然
-                // 保留上方 prev_total 的更新，用它作为后续真实调用的 delta 基线，
-                // 但不为快照本身生成消费记录。
+                // replay 快照更新了 prev_total，但不是当前线程的新用量。
                 if is_history_snapshot_event(&state, line_offset) {
                     if line_offset > last_offset {
                         skipped += 1;
@@ -1007,7 +554,16 @@ fn sync_single_codex_file(
 
                 // 生成唯一 request_id
                 let thread_id = state.thread_id.as_deref().unwrap_or("unknown");
-                let request_id = format!("codex_session:{thread_id}:{}", state.event_index);
+                let request_id = format!(
+                    "{CODEX_THREAD_REQUEST_ID_PREFIX}:{thread_id}:{}",
+                    state.event_index
+                );
+
+                // 提取时间戳
+                let timestamp = value
+                    .get("timestamp")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
 
                 match insert_codex_session_entry(
                     db,
@@ -1030,7 +586,7 @@ fn sync_single_codex_file(
     }
 
     // 更新同步状态
-    update_sync_state(db, &sync_state_key, file_modified, line_offset)?;
+    update_sync_state(db, &file_path_str, file_modified, line_offset)?;
 
     Ok((imported, skipped))
 }
@@ -1160,88 +716,53 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    fn write_codex_usage_log(
-        path: &Path,
-        thread_id: &str,
-        session_id: &str,
-        input_tokens: u64,
-        output_tokens: u64,
-    ) {
-        let lines = [
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": thread_id,
-                    "session_id": session_id,
-                    "parent_thread_id": (thread_id != session_id).then_some(session_id),
-                    "source": if thread_id == session_id {
-                        serde_json::Value::String("cli".to_string())
-                    } else {
-                        serde_json::json!({
-                            "subagent": {
-                                "thread_spawn": { "parent_thread_id": session_id, "depth": 1 }
-                            }
-                        })
-                    }
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:01Z",
-                "type": "turn_context",
-                "payload": { "model": "gpt-5.6-sol" }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:02Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": {
-                        "total_token_usage": {
-                            "input_tokens": input_tokens,
-                            "cached_input_tokens": input_tokens / 2,
-                            "output_tokens": output_tokens
-                        }
-                    }
-                }
-            }),
-        ];
-        let content = lines
+    fn write_jsonl(path: &Path, values: &[serde_json::Value]) {
+        let contents = values
             .iter()
             .map(serde_json::Value::to_string)
             .collect::<Vec<_>>()
             .join("\n")
             + "\n";
-        fs::write(path, content).unwrap();
+        fs::write(path, contents).unwrap();
     }
 
-    fn insert_legacy_codex_usage_row(db: &Database, session_id: &str) -> Result<(), AppError> {
-        let conn = lock_conn!(db.conn);
-        conn.execute(
-            "INSERT INTO proxy_request_logs (
-                request_id, provider_id, app_type, model, request_model,
-                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-                total_cost_usd, latency_ms, status_code, session_id, created_at, data_source
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            rusqlite::params![
-                format!("codex_session:{session_id}:1"),
-                "_codex_session",
-                "codex",
-                "gpt-5.6-sol",
-                "gpt-5.6-sol",
-                200,
-                20,
-                100,
-                0,
-                "0",
-                0,
-                200,
-                session_id,
-                1_752_116_402i64,
-                "codex_session"
-            ],
-        )?;
-        Ok(())
+    fn session_meta(thread_id: &str, session_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "timestamp": "2026-07-10T03:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": thread_id,
+                "session_id": session_id,
+                "source": if thread_id == session_id {
+                    serde_json::Value::String("cli".to_string())
+                } else {
+                    serde_json::json!({ "subagent": {} })
+                }
+            }
+        })
+    }
+
+    fn turn_context() -> serde_json::Value {
+        serde_json::json!({
+            "timestamp": "2026-07-10T03:00:01Z",
+            "type": "turn_context",
+            "payload": { "model": "gpt-5.6-sol" }
+        })
+    }
+
+    fn token_count(input: u64, cached: u64, output: u64) -> serde_json::Value {
+        serde_json::json!({
+            "timestamp": "2026-07-10T03:00:02Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": { "total_token_usage": {
+                    "input_tokens": input,
+                    "cached_input_tokens": cached,
+                    "output_tokens": output
+                }}
+            }
+        })
     }
 
     #[test]
@@ -1355,144 +876,42 @@ mod tests {
 
     #[test]
     fn test_subagent_identity_prefers_unique_thread_id() {
-        let payload = serde_json::json!({
-            "session_id": "parent-thread",
-            "id": "child-thread",
-            "parent_thread_id": "parent-thread",
-            "source": {
-                "subagent": {
-                    "thread_spawn": { "parent_thread_id": "parent-thread", "depth": 1 }
-                }
-            }
-        });
+        let identity =
+            parse_codex_session_identity(session_meta("child", "parent").get("payload").unwrap())
+                .unwrap();
 
-        let identity = parse_codex_session_identity(&payload).unwrap();
-        assert_eq!(identity.thread_id, "child-thread");
-        assert_eq!(identity.session_id, "parent-thread");
-        assert!(identity.is_subagent());
+        assert_eq!(identity.thread_id, "child");
         assert!(identity.carries_history_snapshot);
     }
 
     #[test]
-    fn test_identity_and_replay_boundary_skip_malformed_matching_lines() {
-        let temp = tempdir().unwrap();
-        let child = temp.path().join("child-malformed.jsonl");
-        let lines = [
-            "not-json session_meta".to_string(),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": "child",
-                    "session_id": "parent",
-                    "source": { "subagent": {} }
-                }
-            })
-            .to_string(),
-            "not-json thread_settings_applied".to_string(),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:01Z",
-                "type": "event_msg",
-                "payload": { "type": "thread_settings_applied" }
-            })
-            .to_string(),
-        ];
-        fs::write(&child, lines.join("\n") + "\n").unwrap();
-
-        let identity = read_codex_session_identity(&child).unwrap();
-        assert_eq!(identity.thread_id, "child");
-        assert_eq!(
-            codex_history_replay_boundary(&child, Some(&identity)),
-            Some(4)
-        );
-    }
-
-    #[test]
-    fn test_subagent_history_snapshot_is_baseline_not_usage() -> Result<(), AppError> {
+    fn test_subagent_replay_only_establishes_token_baseline() -> Result<(), AppError> {
         let db = Database::memory()?;
         let temp = tempdir().unwrap();
-        let child = temp.path().join("child-history.jsonl");
-        let lines = [
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.000Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": "child",
-                    "session_id": "parent",
-                    "source": {
-                        "subagent": {
-                            "thread_spawn": { "parent_thread_id": "parent", "depth": 1 }
-                        }
-                    }
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.100Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 1000,
-                        "cached_input_tokens": 900,
-                        "output_tokens": 100
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.200Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 1200,
-                        "cached_input_tokens": 1000,
-                        "output_tokens": 120
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.200Z",
-                "type": "event_msg",
-                "payload": { "type": "thread_settings_applied" }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.300Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": {
-                        "model": "gpt-5.6-sol",
-                        "total_token_usage": {
-                            "input_tokens": 1300,
-                            "cached_input_tokens": 1050,
-                            "output_tokens": 150
-                        }
-                    }
-                }
-            }),
-        ];
-        fs::write(
+        let child = temp.path().join("child.jsonl");
+        write_jsonl(
             &child,
-            lines
-                .iter()
-                .map(serde_json::Value::to_string)
-                .collect::<Vec<_>>()
-                .join("\n")
-                + "\n",
-        )
-        .unwrap();
-
-        let identity = read_codex_session_identity(&child).unwrap();
-        assert_eq!(
-            sync_single_codex_file(&db, &child, Some(&identity))?,
-            (1, 2)
+            &[
+                session_meta("child", "parent"),
+                turn_context(),
+                token_count(1_000, 900, 100),
+                token_count(1_200, 1_000, 120),
+                serde_json::json!({
+                    "timestamp": "2026-07-10T03:00:03Z",
+                    "type": "event_msg",
+                    "payload": { "type": "thread_settings_applied" }
+                }),
+                token_count(1_300, 1_050, 150),
+            ],
         );
+
+        assert_eq!(sync_single_codex_file(&db, &child)?, (1, 2));
 
         let conn = lock_conn!(db.conn);
         let usage: (i64, i64, i64) = conn.query_row(
             "SELECT input_tokens, cache_read_tokens, output_tokens
              FROM proxy_request_logs
-             WHERE request_id = 'codex_session:child:3'",
+             WHERE request_id = 'codex_session:thread-v1:child:3'",
             [],
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )?;
@@ -1502,482 +921,32 @@ mod tests {
     }
 
     #[test]
-    fn test_fork_replay_keeps_legacy_request_id_sequence() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let temp = tempdir().unwrap();
-        let fork = temp.path().join("fork.jsonl");
-        let lines = [
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": "fork",
-                    "session_id": "fork",
-                    "forked_from_id": "parent",
-                    "source": "cli"
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.100Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 100,
-                        "cached_input_tokens": 50,
-                        "output_tokens": 10
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.200Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 200,
-                        "cached_input_tokens": 100,
-                        "output_tokens": 20
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.300Z",
-                "type": "event_msg",
-                "payload": { "type": "thread_settings_applied" }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:01Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 300,
-                        "cached_input_tokens": 150,
-                        "output_tokens": 30
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:02Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 400,
-                        "cached_input_tokens": 200,
-                        "output_tokens": 40
-                    }}
-                }
-            }),
-        ];
-        fs::write(
-            &fork,
-            lines
-                .iter()
-                .map(serde_json::Value::to_string)
-                .collect::<Vec<_>>()
-                .join("\n")
-                + "\n",
-        )
-        .unwrap();
-
-        let identity = read_codex_session_identity(&fork).unwrap();
-        assert!(!identity.is_subagent());
-        assert_eq!(
-            codex_history_replay_boundary(&fork, Some(&identity)),
-            Some(4)
-        );
-
-        {
-            let conn = lock_conn!(db.conn);
-            for event_index in 1..=3 {
-                conn.execute(
-                    "INSERT INTO proxy_request_logs (
-                        request_id, provider_id, app_type, model, request_model,
-                        input_tokens, output_tokens, cache_read_tokens,
-                        total_cost_usd, latency_ms, status_code, session_id,
-                        created_at, data_source
-                    ) VALUES (?1, '_codex_session', 'codex', 'gpt-5.6-sol',
-                              'gpt-5.6-sol', 100, 10, 50, '0', 0, 200, 'fork',
-                              1752116402, 'codex_session')",
-                    [format!("codex_session:fork:{event_index}")],
-                )?;
-            }
-        }
-
-        let fork_path = fork.to_string_lossy().to_string();
-        update_sync_state(&db, &fork_path, 1, 5)?;
-        assert_eq!(sync_single_codex_file(&db, &fork, Some(&identity))?, (1, 0));
-
-        let conn = lock_conn!(db.conn);
-        let usage: (i64, i64, i64) = conn.query_row(
-            "SELECT input_tokens, cache_read_tokens, output_tokens
-             FROM proxy_request_logs WHERE request_id = 'codex_session:fork:4'",
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )?;
-        assert_eq!(usage, (100, 50, 10));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_fast_subagent_without_replay_boundary_counts_first_usage() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let temp = tempdir().unwrap();
-        let child = temp.path().join("fast-child.jsonl");
-        let lines = [
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.000Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": "fast-child",
-                    "session_id": "parent",
-                    "source": {
-                        "subagent": {
-                            "thread_spawn": {
-                                "parent_thread_id": "parent",
-                                "depth": 1
-                            }
-                        }
-                    }
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00.100Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 100,
-                        "cached_input_tokens": 50,
-                        "output_tokens": 10
-                    }}
-                }
-            }),
-        ];
-        fs::write(
-            &child,
-            lines
-                .iter()
-                .map(serde_json::Value::to_string)
-                .collect::<Vec<_>>()
-                .join("\n")
-                + "\n",
-        )
-        .unwrap();
-
-        let identity = read_codex_session_identity(&child).unwrap();
-        assert_eq!(codex_history_replay_boundary(&child, Some(&identity)), None);
-        assert_eq!(
-            sync_single_codex_file(&db, &child, Some(&identity))?,
-            (1, 0)
-        );
-
-        let conn = lock_conn!(db.conn);
-        let usage: (i64, i64) = conn.query_row(
-            "SELECT input_tokens, output_tokens FROM proxy_request_logs
-             WHERE request_id = 'codex_session:fast-child:1'",
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        )?;
-        assert_eq!(usage, (100, 10));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_subagents_under_same_parent_get_unique_request_ids() -> Result<(), AppError> {
+    fn test_subagents_under_same_parent_use_distinct_request_ids() -> Result<(), AppError> {
         let db = Database::memory()?;
         let temp = tempdir().unwrap();
         let child_a = temp.path().join("child-a.jsonl");
         let child_b = temp.path().join("child-b.jsonl");
-        write_codex_usage_log(&child_a, "child-a", "parent", 100, 10);
-        write_codex_usage_log(&child_b, "child-b", "parent", 200, 20);
-
-        let identity_a = read_codex_session_identity(&child_a).unwrap();
-        let identity_b = read_codex_session_identity(&child_b).unwrap();
-        assert_eq!(
-            sync_single_codex_file(&db, &child_a, Some(&identity_a))?,
-            (1, 0)
+        write_jsonl(
+            &child_a,
+            &[
+                session_meta("child-a", "parent"),
+                turn_context(),
+                token_count(100, 50, 10),
+            ],
         );
-        assert_eq!(
-            sync_single_codex_file(&db, &child_b, Some(&identity_b))?,
-            (1, 0)
-        );
-
-        let conn = lock_conn!(db.conn);
-        let request_ids = conn
-            .prepare(
-                "SELECT request_id FROM proxy_request_logs
-                 WHERE data_source = 'codex_session' ORDER BY request_id",
-            )?
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(
-            request_ids,
-            vec![
-                "codex_session:child-a:1".to_string(),
-                "codex_session:child-b:1".to_string()
-            ]
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_repair_resets_legacy_parent_collisions_and_reimports() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let temp = tempdir().unwrap();
-        let main = temp.path().join("main.jsonl");
-        let child = temp.path().join("child.jsonl");
-        write_codex_usage_log(&main, "parent", "parent", 100, 10);
-        write_codex_usage_log(&child, "child", "parent", 200, 20);
-
-        let main_identity = read_codex_session_identity(&main).unwrap();
-        let child_identity = read_codex_session_identity(&child).unwrap();
-        let files = vec![
-            (main.clone(), Some(main_identity.clone())),
-            (child.clone(), Some(child_identity.clone())),
-        ];
-
-        insert_legacy_codex_usage_row(&db, "parent")?;
-        let main_path = main.to_string_lossy().to_string();
-        let child_path = child.to_string_lossy().to_string();
-        update_sync_state(&db, &main_path, 1, 3)?;
-        update_sync_state(&db, &child_path, 1, 3)?;
-
-        repair_legacy_codex_subagent_usage(&db, &files)?;
-
-        {
-            let conn = lock_conn!(db.conn);
-            let old_rows: i64 = conn.query_row(
-                "SELECT COUNT(*) FROM proxy_request_logs
-                 WHERE request_id = 'codex_session:parent:1'",
-                [],
-                |row| row.get(0),
-            )?;
-            assert_eq!(old_rows, 0);
-
-            let old_sync_rows: i64 = conn.query_row(
-                "SELECT COUNT(*) FROM session_log_sync WHERE file_path IN (?1, ?2)",
-                rusqlite::params![main_path, child_path],
-                |row| row.get(0),
-            )?;
-            assert_eq!(old_sync_rows, 0);
-        }
-
-        assert_eq!(
-            sync_single_codex_file(&db, &main, Some(&main_identity))?,
-            (1, 0)
-        );
-        assert_eq!(
-            sync_single_codex_file(&db, &child, Some(&child_identity))?,
-            (1, 0)
-        );
-
-        let conn = lock_conn!(db.conn);
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'",
-            [],
-            |row| row.get(0),
-        )?;
-        assert_eq!(count, 2);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_repair_reimports_late_sibling_after_parent_rebuild() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let temp = tempdir().unwrap();
-        let main = temp.path().join("main.jsonl");
-        let child_a = temp.path().join("child-a.jsonl");
-        let child_b = temp.path().join("child-b.jsonl");
-        write_codex_usage_log(&main, "parent", "parent", 100, 10);
-        write_codex_usage_log(&child_a, "child-a", "parent", 200, 20);
-        write_codex_usage_log(&child_b, "child-b", "parent", 300, 30);
-
-        let main_identity = read_codex_session_identity(&main).unwrap();
-        let child_a_identity = read_codex_session_identity(&child_a).unwrap();
-        let child_b_identity = read_codex_session_identity(&child_b).unwrap();
-        insert_legacy_codex_usage_row(&db, "parent")?;
-
-        let main_path = main.to_string_lossy().to_string();
-        let child_a_path = child_a.to_string_lossy().to_string();
-        let child_b_path = child_b.to_string_lossy().to_string();
-        update_sync_state(&db, &main_path, 1, 3)?;
-        update_sync_state(&db, &child_a_path, 1, 3)?;
-        update_sync_state(&db, &child_b_path, 1, 3)?;
-
-        let first_files = vec![
-            (main.clone(), Some(main_identity.clone())),
-            (child_a.clone(), Some(child_a_identity.clone())),
-        ];
-        repair_legacy_codex_subagent_usage(&db, &first_files)?;
-        assert_eq!(
-            sync_single_codex_file(&db, &main, Some(&main_identity))?,
-            (1, 0)
-        );
-        assert_eq!(
-            sync_single_codex_file(&db, &child_a, Some(&child_a_identity))?,
-            (1, 0)
-        );
-
-        let all_files = vec![
-            (main, Some(main_identity)),
-            (child_a, Some(child_a_identity)),
-            (child_b.clone(), Some(child_b_identity.clone())),
-        ];
-        repair_legacy_codex_subagent_usage(&db, &all_files)?;
-        assert_eq!(get_sync_state(&db, &child_b_path)?, (0, 0));
-        assert_eq!(
-            sync_single_codex_file(&db, &child_b, Some(&child_b_identity))?,
-            (1, 0)
-        );
-
-        let conn = lock_conn!(db.conn);
-        let request_ids = conn
-            .prepare(
-                "SELECT request_id FROM proxy_request_logs
-                 WHERE data_source = 'codex_session' ORDER BY request_id",
-            )?
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(
-            request_ids,
-            vec![
-                "codex_session:child-a:1".to_string(),
-                "codex_session:child-b:1".to_string(),
-                "codex_session:parent:1".to_string(),
-            ]
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_late_sibling_with_rollup_only_imports_new_usage() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let temp = tempdir().unwrap();
-        let main = temp.path().join("main.jsonl");
-        let child_a = temp.path().join("child-a.jsonl");
-        let child_b = temp.path().join("child-b.jsonl");
-        write_codex_usage_log(&main, "parent", "parent", 100, 10);
-        write_codex_usage_log(&child_a, "child-a", "parent", 200, 20);
-
-        let child_b_lines = [
-            serde_json::json!({
-                "timestamp": "2025-07-10T03:00:00Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": "child-b",
-                    "session_id": "parent",
-                    "source": { "subagent": {} }
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2025-07-10T03:00:01Z",
-                "type": "turn_context",
-                "payload": { "model": "gpt-5.6-sol" }
-            }),
-            serde_json::json!({
-                "timestamp": "2025-07-10T03:00:02Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 300,
-                        "cached_input_tokens": 150,
-                        "output_tokens": 30
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:03Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 400,
-                        "cached_input_tokens": 200,
-                        "output_tokens": 40
-                    }}
-                }
-            }),
-        ];
-        fs::write(
+        write_jsonl(
             &child_b,
-            child_b_lines
-                .iter()
-                .map(serde_json::Value::to_string)
-                .collect::<Vec<_>>()
-                .join("\n")
-                + "\n",
-        )
-        .unwrap();
-
-        let main_identity = read_codex_session_identity(&main).unwrap();
-        let child_a_identity = read_codex_session_identity(&child_a).unwrap();
-        let child_b_identity = read_codex_session_identity(&child_b).unwrap();
-        insert_legacy_codex_usage_row(&db, "parent")?;
-        {
-            let conn = lock_conn!(db.conn);
-            conn.execute(
-                "UPDATE proxy_request_logs
-                 SET provider_id = 'openai', data_source = 'proxy'
-                 WHERE request_id = 'codex_session:parent:1'",
-                [],
-            )?;
-        }
-        assert_eq!(db.rollup_and_prune(30)?, 1);
-
-        let main_path = main.to_string_lossy().to_string();
-        let child_a_path = child_a.to_string_lossy().to_string();
-        let child_b_path = child_b.to_string_lossy().to_string();
-        update_sync_state(&db, &main_path, 1, 3)?;
-        update_sync_state(&db, &child_a_path, 1, 3)?;
-        update_sync_state(&db, &child_b_path, 1, 3)?;
-
-        let first_files = vec![
-            (main.clone(), Some(main_identity.clone())),
-            (child_a.clone(), Some(child_a_identity.clone())),
-        ];
-        repair_legacy_codex_subagent_usage(&db, &first_files)?;
-        assert_eq!(
-            sync_single_codex_file(&db, &main, Some(&main_identity))?,
-            (1, 0)
-        );
-        assert_eq!(
-            sync_single_codex_file(&db, &child_a, Some(&child_a_identity))?,
-            (1, 0)
+            &[
+                session_meta("child-b", "parent"),
+                turn_context(),
+                token_count(200, 100, 20),
+            ],
         );
 
-        let all_files = vec![
-            (main, Some(main_identity)),
-            (child_a, Some(child_a_identity)),
-            (child_b.clone(), Some(child_b_identity.clone())),
-        ];
-        repair_legacy_codex_subagent_usage(&db, &all_files)?;
-
-        let subagent_key = format!("{child_b_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
-        assert_eq!(get_sync_state(&db, &child_b_path)?, (0, 0));
-        assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
-        assert_eq!(
-            sync_single_codex_file(&db, &child_b, Some(&child_b_identity))?,
-            (1, 0)
-        );
+        assert_eq!(sync_single_codex_file(&db, &child_a)?, (1, 0));
+        assert_eq!(sync_single_codex_file(&db, &child_b)?, (1, 0));
 
         let conn = lock_conn!(db.conn);
-        let rollup_count: i64 = conn.query_row(
-            "SELECT request_count FROM usage_daily_rollups
-             WHERE app_type = 'codex' AND provider_id = 'openai'",
-            [],
-            |row| row.get(0),
-        )?;
-        assert_eq!(rollup_count, 1);
-
         let request_ids = conn
             .prepare(
                 "SELECT request_id FROM proxy_request_logs
@@ -1988,9 +957,8 @@ mod tests {
         assert_eq!(
             request_ids,
             vec![
-                "codex_session:child-a:1".to_string(),
-                "codex_session:child-b:2".to_string(),
-                "codex_session:parent:1".to_string(),
+                "codex_session:thread-v1:child-a:1",
+                "codex_session:thread-v1:child-b:1"
             ]
         );
 
@@ -1998,308 +966,25 @@ mod tests {
     }
 
     #[test]
-    fn test_repair_preserves_orphan_usage_and_migrates_cursor() -> Result<(), AppError> {
+    fn test_archived_log_inherits_cursor_and_only_imports_appended_usage() -> Result<(), AppError> {
         let db = Database::memory()?;
         let temp = tempdir().unwrap();
-        let child = temp.path().join("orphan-child.jsonl");
-        let lines = [
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": "child",
-                    "session_id": "missing-parent",
-                    "source": {
-                        "subagent": {
-                            "thread_spawn": {
-                                "parent_thread_id": "missing-parent",
-                                "depth": 1
-                            }
-                        }
-                    }
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:01Z",
-                "type": "turn_context",
-                "payload": { "model": "gpt-5.6-sol" }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:02Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 200,
-                        "cached_input_tokens": 100,
-                        "output_tokens": 20
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:03Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 300,
-                        "cached_input_tokens": 150,
-                        "output_tokens": 30
-                    }}
-                }
-            }),
-        ];
-        fs::write(
-            &child,
-            lines
-                .iter()
-                .map(serde_json::Value::to_string)
-                .collect::<Vec<_>>()
-                .join("\n")
-                + "\n",
-        )
-        .unwrap();
-
-        let identity = read_codex_session_identity(&child).unwrap();
-        let files = vec![(child.clone(), Some(identity.clone()))];
-        insert_legacy_codex_usage_row(&db, "missing-parent")?;
-
-        let child_path = child.to_string_lossy().to_string();
-        update_sync_state(&db, &child_path, 1, 3)?;
-        repair_legacy_codex_subagent_usage(&db, &files)?;
-
-        let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
-        assert_eq!(get_sync_state(&db, &child_path)?, (0, 0));
-        assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
-        assert_eq!(
-            sync_single_codex_file(&db, &child, Some(&identity))?,
-            (1, 0)
+        let sessions = temp.path().join("sessions");
+        let archived = temp.path().join("archived_sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        fs::create_dir_all(&archived).unwrap();
+        let source = sessions.join("rollout-parent.jsonl");
+        let archived_file = archived.join("rollout-parent.jsonl");
+        write_jsonl(
+            &archived_file,
+            &[
+                session_meta("parent", "parent"),
+                turn_context(),
+                token_count(100, 50, 10),
+                token_count(200, 100, 20),
+            ],
         );
 
-        let conn = lock_conn!(db.conn);
-        let request_ids = conn
-            .prepare(
-                "SELECT request_id FROM proxy_request_logs
-                 WHERE data_source = 'codex_session' ORDER BY request_id",
-            )?
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(request_ids.len(), 2);
-        assert!(request_ids.contains(&"codex_session:child:2".to_string()));
-        assert!(request_ids.iter().any(|request_id| {
-            request_id.starts_with("codex_session:legacy:")
-                && request_id.ends_with(":codex_session:missing-parent:1")
-        }));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_late_subagent_after_migration_activation_preserves_legacy_cursor(
-    ) -> Result<(), AppError> {
-        let db = Database::memory()?;
-        repair_legacy_codex_subagent_usage(&db, &[])?;
-        {
-            let conn = lock_conn!(db.conn);
-            let marker_exists: bool = conn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1)",
-                [CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
-                |row| row.get(0),
-            )?;
-            assert!(!marker_exists);
-        }
-
-        let temp = tempdir().unwrap();
-        let unrelated_main = temp.path().join("unrelated-main.jsonl");
-        write_codex_usage_log(&unrelated_main, "unrelated", "unrelated", 100, 10);
-        let unrelated_identity = read_codex_session_identity(&unrelated_main).unwrap();
-        repair_legacy_codex_subagent_usage(&db, &[(unrelated_main, Some(unrelated_identity))])?;
-
-        let child = temp.path().join("late-child.jsonl");
-        let child_lines = [
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:00Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": "late-child",
-                    "session_id": "missing-parent",
-                    "source": { "subagent": {} }
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:01Z",
-                "type": "turn_context",
-                "payload": { "model": "gpt-5.6-sol" }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:02Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 200,
-                        "cached_input_tokens": 100,
-                        "output_tokens": 20
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:03Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 300,
-                        "cached_input_tokens": 150,
-                        "output_tokens": 30
-                    }}
-                }
-            }),
-        ];
-        fs::write(
-            &child,
-            child_lines
-                .iter()
-                .map(serde_json::Value::to_string)
-                .collect::<Vec<_>>()
-                .join("\n")
-                + "\n",
-        )
-        .unwrap();
-
-        let identity = read_codex_session_identity(&child).unwrap();
-        let child_path = child.to_string_lossy().to_string();
-        insert_legacy_codex_usage_row(&db, "missing-parent")?;
-        update_sync_state(&db, &child_path, 1, 3)?;
-
-        repair_legacy_codex_subagent_usage(&db, &[(child.clone(), Some(identity.clone()))])?;
-
-        let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
-        assert_eq!(get_sync_state(&db, &child_path)?, (0, 0));
-        assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
-        assert_eq!(
-            sync_single_codex_file(&db, &child, Some(&identity))?,
-            (1, 0)
-        );
-
-        let conn = lock_conn!(db.conn);
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'",
-            [],
-            |row| row.get(0),
-        )?;
-        assert_eq!(count, 2);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_subagent_sync_falls_back_to_newer_plain_cursor() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let temp = tempdir().unwrap();
-        let child = temp.path().join("fallback-child.jsonl");
-        write_codex_usage_log(&child, "fallback-child", "parent", 200, 20);
-
-        let identity = read_codex_session_identity(&child).unwrap();
-        let child_path = child.to_string_lossy().to_string();
-        let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
-        update_sync_state(&db, &subagent_key, 1, 1)?;
-        update_sync_state(&db, &child_path, 2, 3)?;
-
-        assert_eq!(
-            sync_single_codex_file(&db, &child, Some(&identity))?,
-            (0, 0)
-        );
-        let (last_modified, last_offset) = get_sync_state(&db, &subagent_key)?;
-        assert!(last_modified > 2);
-        assert_eq!(last_offset, 3);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_repair_with_rollup_preserves_history_and_only_imports_new_usage() -> Result<(), AppError>
-    {
-        let db = Database::memory()?;
-        let temp = tempdir().unwrap();
-        let main = temp.path().join("main.jsonl");
-        let child = temp.path().join("child.jsonl");
-        write_codex_usage_log(&main, "parent", "parent", 100, 10);
-
-        let child_lines = [
-            serde_json::json!({
-                "timestamp": "2025-07-10T03:00:00Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": "child",
-                    "session_id": "parent",
-                    "source": {
-                        "subagent": {
-                            "thread_spawn": { "parent_thread_id": "parent", "depth": 1 }
-                        }
-                    }
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2025-07-10T03:00:01Z",
-                "type": "turn_context",
-                "payload": { "model": "gpt-5.6-sol" }
-            }),
-            serde_json::json!({
-                "timestamp": "2025-07-10T03:00:02Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 200,
-                        "cached_input_tokens": 100,
-                        "output_tokens": 20
-                    }}
-                }
-            }),
-            serde_json::json!({
-                "timestamp": "2026-07-10T03:00:03Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": { "total_token_usage": {
-                        "input_tokens": 300,
-                        "cached_input_tokens": 150,
-                        "output_tokens": 30
-                    }}
-                }
-            }),
-        ];
-        fs::write(
-            &child,
-            child_lines
-                .iter()
-                .map(serde_json::Value::to_string)
-                .collect::<Vec<_>>()
-                .join("\n")
-                + "\n",
-        )
-        .unwrap();
-
-        let main_identity = read_codex_session_identity(&main).unwrap();
-        let child_identity = read_codex_session_identity(&child).unwrap();
-        let files = vec![
-            (main.clone(), Some(main_identity)),
-            (child.clone(), Some(child_identity.clone())),
-        ];
-        insert_legacy_codex_usage_row(&db, "parent")?;
-        {
-            let conn = lock_conn!(db.conn);
-            conn.execute(
-                "UPDATE proxy_request_logs
-                 SET provider_id = 'openai', data_source = 'proxy'
-                 WHERE request_id = 'codex_session:parent:1'",
-                [],
-            )?;
-        }
-        assert_eq!(db.rollup_and_prune(30)?, 1);
-
-        // 模拟旧解析器中子代理抢占了父线程未来会使用的序号。
         {
             let conn = lock_conn!(db.conn);
             conn.execute(
@@ -2309,71 +994,35 @@ mod tests {
                     total_cost_usd, latency_ms, status_code, session_id,
                     created_at, data_source
                 ) VALUES ('codex_session:parent:2', '_codex_session', 'codex',
-                          'gpt-5.6-sol', 'gpt-5.6-sol', 50, 5, 25, '0', 0,
-                          200, 'parent', 1783652402, 'codex_session')",
+                          'gpt-5.6-sol', 'gpt-5.6-sol', 999, 99, 0, '0', 0,
+                          200, 'parent', 1, 'codex_session')",
                 [],
             )?;
         }
+        let source_path = source.to_string_lossy().to_string();
+        update_sync_state(&db, &source_path, 1, 3)?;
 
-        let new_parent_usage = serde_json::json!({
-            "timestamp": "2026-07-10T03:00:03Z",
-            "type": "event_msg",
-            "payload": {
-                "type": "token_count",
-                "info": { "total_token_usage": {
-                    "input_tokens": 200,
-                    "cached_input_tokens": 100,
-                    "output_tokens": 20
-                }}
-            }
-        });
-        let mut main_contents = fs::read_to_string(&main).unwrap();
-        main_contents.push_str(&new_parent_usage.to_string());
-        main_contents.push('\n');
-        fs::write(&main, main_contents).unwrap();
-
-        let main_path = main.to_string_lossy().to_string();
-        let child_path = child.to_string_lossy().to_string();
-        update_sync_state(&db, &main_path, 1, 3)?;
-        update_sync_state(&db, &child_path, 1, 3)?;
-
-        repair_legacy_codex_subagent_usage(&db, &files)?;
-
-        let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
-        assert_eq!(get_sync_state(&db, &main_path)?, (1, 3));
-        assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
-        assert_eq!(
-            sync_single_codex_file(&db, &main, files[0].1.as_ref())?,
-            (1, 0)
-        );
-        assert_eq!(
-            sync_single_codex_file(&db, &child, Some(&child_identity))?,
-            (1, 0)
-        );
+        assert_eq!(sync_single_codex_file(&db, &archived_file)?, (1, 0));
+        assert_eq!(sync_single_codex_file(&db, &archived_file)?, (0, 0));
 
         let conn = lock_conn!(db.conn);
-        let rollup_count: i64 = conn.query_row(
-            "SELECT request_count FROM usage_daily_rollups
-             WHERE app_type = 'codex' AND provider_id = 'openai'",
+        let old_row_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs
+             WHERE request_id = 'codex_session:parent:2'",
             [],
             |row| row.get(0),
         )?;
-        assert_eq!(rollup_count, 1);
-
-        let request_ids = conn
-            .prepare(
-                "SELECT request_id FROM proxy_request_logs
-                 WHERE data_source = 'codex_session' ORDER BY request_id",
-            )?
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(request_ids.len(), 3);
-        assert!(request_ids.contains(&"codex_session:child:2".to_string()));
-        assert!(request_ids.contains(&"codex_session:parent:2".to_string()));
-        assert!(request_ids.iter().any(|request_id| {
-            request_id.starts_with("codex_session:legacy:")
-                && request_id.ends_with(":codex_session:parent:2")
-        }));
+        assert_eq!(old_row_count, 1);
+        let usage: (i64, i64, i64) = conn.query_row(
+            "SELECT input_tokens, cache_read_tokens, output_tokens
+             FROM proxy_request_logs
+             WHERE request_id = 'codex_session:thread-v1:parent:2'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(usage, (100, 50, 10));
+        drop(conn);
+        assert_eq!(get_sync_state(&db, &archived_file.to_string_lossy())?.1, 4);
 
         Ok(())
     }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -31,9 +31,6 @@ use std::time::SystemTime;
 
 const CODEX_SUBAGENT_USAGE_MIGRATION_KEY: &str = "codex_subagent_usage_thread_id_v1_migrated";
 const CODEX_SUBAGENT_SYNC_KEY_SUFFIX: &str = "#codex-thread-id-v1";
-/// fork/restore 与部分子代理日志会在文件创建时密集重放父线程历史。
-/// 这些 token_count 是基线快照，不是子线程的新请求。
-const FORK_HISTORY_SNAPSHOT_WINDOW_MS: i64 = 1_000;
 
 /// 累计 token 用量（跟踪 total_token_usage 字段）
 #[derive(Debug, Clone, Default)]
@@ -64,8 +61,7 @@ struct FileParseState {
     prev_total: Option<CumulativeTokens>,
     event_index: u32,
     seen_session_meta: bool,
-    carries_history_snapshot: bool,
-    session_started_at_ms: Option<i64>,
+    history_replay_boundary: Option<i64>,
 }
 
 /// Codex 的现代子代理日志同时包含两个不同含义的 ID：
@@ -139,19 +135,6 @@ fn codex_sync_state_key(file_path: &str, identity: Option<&CodexSessionIdentity>
     }
 }
 
-fn parse_timestamp_millis(timestamp: &str) -> Option<i64> {
-    chrono::DateTime::parse_from_rfc3339(timestamp)
-        .ok()
-        .map(|datetime| datetime.timestamp_millis())
-}
-
-fn json_timestamp_millis(value: &serde_json::Value) -> Option<i64> {
-    value
-        .get("timestamp")
-        .and_then(|value| value.as_str())
-        .and_then(parse_timestamp_millis)
-}
-
 fn session_meta_carries_history_snapshot(payload: &serde_json::Value) -> bool {
     let has_fork_parent = payload
         .get("forked_from_id")
@@ -166,19 +149,54 @@ fn session_meta_carries_history_snapshot(payload: &serde_json::Value) -> bool {
     has_fork_parent || is_subagent
 }
 
-fn is_history_snapshot_event(state: &FileParseState, timestamp: Option<&str>) -> bool {
-    if !state.carries_history_snapshot {
-        return false;
+/// fork/restore 日志会先重放父线程历史，再以明确的接管事件开始子线程。
+/// 返回接管事件所在行；该行之前的 token_count 只用于恢复累计值基线。
+fn codex_history_replay_boundary(
+    file_path: &Path,
+    identity: Option<&CodexSessionIdentity>,
+) -> Option<i64> {
+    let file = fs::File::open(file_path).ok()?;
+    let reader = BufReader::new(file);
+    let mut carries_history_snapshot = identity.is_some_and(CodexSessionIdentity::is_subagent);
+
+    for (index, line) in reader.lines().enumerate() {
+        let line = line.ok()?;
+        if !line.contains("\"session_meta\"")
+            && !line.contains("\"thread_settings_applied\"")
+            && !line.contains("\"inter_agent_communication")
+        {
+            continue;
+        }
+
+        let value: serde_json::Value = serde_json::from_str(&line).ok()?;
+        let event_type = value.get("type").and_then(|value| value.as_str())?;
+
+        if event_type == "session_meta" {
+            if let Some(payload) = value.get("payload") {
+                carries_history_snapshot |= session_meta_carries_history_snapshot(payload);
+            }
+            continue;
+        }
+
+        let is_replay_boundary = event_type.starts_with("inter_agent_communication")
+            || (event_type == "event_msg"
+                && value
+                    .get("payload")
+                    .and_then(|payload| payload.get("type"))
+                    .and_then(|value| value.as_str())
+                    == Some("thread_settings_applied"));
+        if carries_history_snapshot && is_replay_boundary {
+            return Some(index as i64 + 1);
+        }
     }
 
-    let Some(session_started_at_ms) = state.session_started_at_ms else {
-        return false;
-    };
-    let Some(event_at_ms) = timestamp.and_then(parse_timestamp_millis) else {
-        return false;
-    };
+    None
+}
 
-    event_at_ms <= session_started_at_ms + FORK_HISTORY_SNAPSHOT_WINDOW_MS
+fn is_history_snapshot_event(state: &FileParseState, line_offset: i64) -> bool {
+    state
+        .history_replay_boundary
+        .is_some_and(|boundary| line_offset < boundary)
 }
 
 /// 归一化 Codex 模型名
@@ -349,6 +367,7 @@ fn repair_legacy_codex_subagent_usage(
         })
         .collect();
     let mut affected_session_ids = HashSet::new();
+    let mut orphaned_synced_subagent_paths = Vec::new();
 
     {
         let mut stmt = conn
@@ -364,9 +383,7 @@ fn repair_legacy_codex_subagent_usage(
             let Some(identity) = identity else {
                 continue;
             };
-            if !identity.is_subagent()
-                || !rebuildable_thread_ids.contains(identity.session_id.as_str())
-            {
+            if !identity.is_subagent() {
                 continue;
             }
 
@@ -377,7 +394,11 @@ fn repair_legacy_codex_subagent_usage(
                 })
                 .map_err(|e| AppError::Database(format!("查询 Codex 子代理旧同步状态失败: {e}")))?;
             if was_synced {
-                affected_session_ids.insert(identity.session_id.clone());
+                if rebuildable_thread_ids.contains(identity.session_id.as_str()) {
+                    affected_session_ids.insert(identity.session_id.clone());
+                } else {
+                    orphaned_synced_subagent_paths.push(path.into_owned());
+                }
             }
         }
     }
@@ -414,6 +435,21 @@ fn repair_legacy_codex_subagent_usage(
             )
             .map_err(|e| AppError::Database(format!("重置 Codex 子代理同步游标失败: {e}")))?;
         }
+    }
+
+    // 父日志已不存在时无法安全重建旧记录。保留旧行，并把旧游标复制到新的
+    // thread_id 同步键，避免升级后把整份子代理日志再次导入而重复计费。
+    for path in &orphaned_synced_subagent_paths {
+        let subagent_key = format!("{path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+        tx.execute(
+            "INSERT OR IGNORE INTO session_log_sync (
+                file_path, last_modified, last_line_offset, last_synced_at
+             )
+             SELECT ?2, last_modified, last_line_offset, last_synced_at
+             FROM session_log_sync WHERE file_path = ?1",
+            rusqlite::params![path, subagent_key],
+        )
+        .map_err(|e| AppError::Database(format!("迁移孤立 Codex 子代理同步游标失败: {e}")))?;
     }
 
     tx.execute(
@@ -504,6 +540,7 @@ fn sync_single_codex_file(
     let file =
         fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
     let reader = BufReader::new(file);
+    let history_replay_boundary = codex_history_replay_boundary(file_path, identity);
 
     let mut state = FileParseState {
         thread_id: identity.map(|identity| identity.thread_id.clone()),
@@ -511,8 +548,7 @@ fn sync_single_codex_file(
         prev_total: None,
         event_index: 0,
         seen_session_meta: false,
-        carries_history_snapshot: identity.is_some_and(CodexSessionIdentity::is_subagent),
-        session_started_at_ms: None,
+        history_replay_boundary,
     };
 
     let mut line_offset: i64 = 0;
@@ -556,9 +592,7 @@ fn sync_single_codex_file(
         match event_type {
             "session_meta" if !state.seen_session_meta => {
                 state.seen_session_meta = true;
-                state.session_started_at_ms = json_timestamp_millis(&value);
                 if let Some(payload) = value.get("payload") {
-                    state.carries_history_snapshot = session_meta_carries_history_snapshot(payload);
                     if state.thread_id.is_none() {
                         state.thread_id = parse_codex_session_identity(payload)
                             .map(|identity| identity.thread_id);
@@ -649,7 +683,7 @@ fn sync_single_codex_file(
                 // 子代理/fork 文件开头可能重放父线程累计 token 历史。这里仍然
                 // 保留上方 prev_total 的更新，用它作为后续真实调用的 delta 基线，
                 // 但不为快照本身生成消费记录。
-                if is_history_snapshot_event(&state, timestamp.as_deref()) {
+                if is_history_snapshot_event(&state, line_offset) {
                     if line_offset > last_offset {
                         skipped += 1;
                     }
@@ -873,6 +907,35 @@ mod tests {
         fs::write(path, content).unwrap();
     }
 
+    fn insert_legacy_codex_usage_row(db: &Database, session_id: &str) -> Result<(), AppError> {
+        let conn = lock_conn!(db.conn);
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model, request_model,
+                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                total_cost_usd, latency_ms, status_code, session_id, created_at, data_source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rusqlite::params![
+                format!("codex_session:{session_id}:1"),
+                "_codex_session",
+                "codex",
+                "gpt-5.6-sol",
+                "gpt-5.6-sol",
+                200,
+                20,
+                100,
+                0,
+                "0",
+                0,
+                200,
+                session_id,
+                1_752_116_402i64,
+                "codex_session"
+            ],
+        )?;
+        Ok(())
+    }
+
     #[test]
     fn test_delta_first_event() {
         let prev = None;
@@ -1045,7 +1108,12 @@ mod tests {
                 }
             }),
             serde_json::json!({
-                "timestamp": "2026-07-10T03:00:02.000Z",
+                "timestamp": "2026-07-10T03:00:00.200Z",
+                "type": "event_msg",
+                "payload": { "type": "thread_settings_applied" }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.300Z",
                 "type": "event_msg",
                 "payload": {
                     "type": "token_count",
@@ -1086,6 +1154,71 @@ mod tests {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )?;
         assert_eq!(usage, (100, 50, 30));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fast_subagent_without_replay_boundary_counts_first_usage() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let child = temp.path().join("fast-child.jsonl");
+        let lines = [
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "fast-child",
+                    "session_id": "parent",
+                    "source": {
+                        "subagent": {
+                            "thread_spawn": {
+                                "parent_thread_id": "parent",
+                                "depth": 1
+                            }
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.100Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 100,
+                        "cached_input_tokens": 50,
+                        "output_tokens": 10
+                    }}
+                }
+            }),
+        ];
+        fs::write(
+            &child,
+            lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n",
+        )
+        .unwrap();
+
+        let identity = read_codex_session_identity(&child).unwrap();
+        assert_eq!(codex_history_replay_boundary(&child, Some(&identity)), None);
+        assert_eq!(
+            sync_single_codex_file(&db, &child, Some(&identity))?,
+            (1, 0)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let usage: (i64, i64) = conn.query_row(
+            "SELECT input_tokens, output_tokens FROM proxy_request_logs
+             WHERE request_id = 'codex_session:fast-child:1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(usage, (100, 10));
 
         Ok(())
     }
@@ -1145,33 +1278,7 @@ mod tests {
             (child.clone(), Some(child_identity.clone())),
         ];
 
-        {
-            let conn = lock_conn!(db.conn);
-            conn.execute(
-                "INSERT INTO proxy_request_logs (
-                    request_id, provider_id, app_type, model, request_model,
-                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-                    total_cost_usd, latency_ms, status_code, session_id, created_at, data_source
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                rusqlite::params![
-                    "codex_session:parent:1",
-                    "_codex_session",
-                    "codex",
-                    "gpt-5.6-sol",
-                    "gpt-5.6-sol",
-                    200,
-                    20,
-                    100,
-                    0,
-                    "0",
-                    0,
-                    200,
-                    "parent",
-                    1_752_116_402i64,
-                    "codex_session"
-                ],
-            )?;
-        }
+        insert_legacy_codex_usage_row(&db, "parent")?;
         let main_path = main.to_string_lossy().to_string();
         let child_path = child.to_string_lossy().to_string();
         update_sync_state(&db, &main_path, 1, 3)?;
@@ -1213,6 +1320,103 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(count, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repair_preserves_orphan_usage_and_migrates_cursor() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let child = temp.path().join("orphan-child.jsonl");
+        let lines = [
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child",
+                    "session_id": "missing-parent",
+                    "source": {
+                        "subagent": {
+                            "thread_spawn": {
+                                "parent_thread_id": "missing-parent",
+                                "depth": 1
+                            }
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:01Z",
+                "type": "turn_context",
+                "payload": { "model": "gpt-5.6-sol" }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 200,
+                        "cached_input_tokens": 100,
+                        "output_tokens": 20
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:03Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 300,
+                        "cached_input_tokens": 150,
+                        "output_tokens": 30
+                    }}
+                }
+            }),
+        ];
+        fs::write(
+            &child,
+            lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n",
+        )
+        .unwrap();
+
+        let identity = read_codex_session_identity(&child).unwrap();
+        let files = vec![(child.clone(), Some(identity.clone()))];
+        insert_legacy_codex_usage_row(&db, "missing-parent")?;
+
+        let child_path = child.to_string_lossy().to_string();
+        update_sync_state(&db, &child_path, 1, 3)?;
+        repair_legacy_codex_subagent_usage(&db, &files)?;
+
+        let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+        assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
+        assert_eq!(
+            sync_single_codex_file(&db, &child, Some(&identity))?,
+            (1, 0)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let request_ids = conn
+            .prepare(
+                "SELECT request_id FROM proxy_request_logs
+                 WHERE data_source = 'codex_session' ORDER BY request_id",
+            )?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            request_ids,
+            vec![
+                "codex_session:child:2".to_string(),
+                "codex_session:missing-parent:1".to_string()
+            ]
+        );
 
         Ok(())
     }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -23,7 +23,7 @@ use crate::services::session_usage::{
 };
 use crate::services::usage_stats::{find_model_pricing, should_skip_session_insert, DedupKey};
 use rust_decimal::Decimal;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -75,6 +75,7 @@ struct FileParseState {
 struct CodexSessionIdentity {
     thread_id: String,
     session_id: String,
+    carries_history_snapshot: bool,
 }
 
 impl CodexSessionIdentity {
@@ -99,10 +100,20 @@ fn parse_codex_session_identity(payload: &serde_json::Value) -> Option<CodexSess
         .and_then(|value| value.as_str())
         .map(str::to_string)
         .unwrap_or_else(|| thread_id.clone());
+    let carries_history_snapshot = payload
+        .get("forked_from_id")
+        .and_then(|value| value.as_str())
+        .is_some_and(|value| !value.is_empty())
+        || payload
+            .get("source")
+            .and_then(|source| source.get("subagent"))
+            .is_some()
+        || thread_id != session_id;
 
     Some(CodexSessionIdentity {
         thread_id,
         session_id,
+        carries_history_snapshot,
     })
 }
 
@@ -111,15 +122,21 @@ fn read_codex_session_identity(file_path: &Path) -> Option<CodexSessionIdentity>
     let reader = BufReader::new(file);
 
     for line in reader.lines() {
-        let line = line.ok()?;
+        let Ok(line) = line else {
+            continue;
+        };
         if !line.contains("\"session_meta\"") {
             continue;
         }
-        let value: serde_json::Value = serde_json::from_str(&line).ok()?;
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
         if value.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
             continue;
         }
-        return value.get("payload").and_then(parse_codex_session_identity);
+        if let Some(identity) = value.get("payload").and_then(parse_codex_session_identity) {
+            return Some(identity);
+        }
     }
 
     None
@@ -144,7 +161,8 @@ fn session_meta_carries_history_snapshot(payload: &serde_json::Value) -> bool {
         .get("source")
         .and_then(|source| source.get("subagent"))
         .is_some()
-        || parse_codex_session_identity(payload).is_some_and(|identity| identity.is_subagent());
+        || parse_codex_session_identity(payload)
+            .is_some_and(|identity| identity.carries_history_snapshot);
 
     has_fork_parent || is_subagent
 }
@@ -155,12 +173,19 @@ fn codex_history_replay_boundary(
     file_path: &Path,
     identity: Option<&CodexSessionIdentity>,
 ) -> Option<i64> {
+    if identity.is_some_and(|identity| !identity.carries_history_snapshot) {
+        return None;
+    }
+
     let file = fs::File::open(file_path).ok()?;
     let reader = BufReader::new(file);
-    let mut carries_history_snapshot = identity.is_some_and(CodexSessionIdentity::is_subagent);
+    let mut carries_history_snapshot =
+        identity.is_some_and(|identity| identity.carries_history_snapshot);
 
     for (index, line) in reader.lines().enumerate() {
-        let line = line.ok()?;
+        let Ok(line) = line else {
+            continue;
+        };
         if !line.contains("\"session_meta\"")
             && !line.contains("\"thread_settings_applied\"")
             && !line.contains("\"inter_agent_communication")
@@ -168,8 +193,12 @@ fn codex_history_replay_boundary(
             continue;
         }
 
-        let value: serde_json::Value = serde_json::from_str(&line).ok()?;
-        let event_type = value.get("type").and_then(|value| value.as_str())?;
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let Some(event_type) = value.get("type").and_then(|value| value.as_str()) else {
+            continue;
+        };
 
         if event_type == "session_meta" {
             if let Some(payload) = value.get("payload") {
@@ -199,26 +228,42 @@ fn is_history_snapshot_event(state: &FileParseState, line_offset: i64) -> bool {
         .is_some_and(|boundary| line_offset < boundary)
 }
 
-fn codex_file_may_overlap_rollup_dates(file_path: &Path, rollup_dates: &HashSet<String>) -> bool {
-    if rollup_dates.is_empty() {
-        return false;
+struct CodexRollupDateCoverage {
+    dates: HashSet<String>,
+    unknown: bool,
+}
+
+impl CodexRollupDateCoverage {
+    fn from_file(file_path: &Path) -> Self {
+        match codex_file_rollup_date_candidates(file_path) {
+            Some(dates) => Self {
+                dates,
+                unknown: false,
+            },
+            None => Self {
+                dates: HashSet::new(),
+                unknown: true,
+            },
+        }
     }
 
-    let Ok(file) = fs::File::open(file_path) else {
-        return true;
-    };
+    fn may_overlap(&self, rollup_dates: &HashSet<String>) -> bool {
+        !rollup_dates.is_empty()
+            && (self.unknown || self.dates.iter().any(|date| rollup_dates.contains(date)))
+    }
+}
+
+fn codex_file_rollup_date_candidates(file_path: &Path) -> Option<HashSet<String>> {
+    let file = fs::File::open(file_path).ok()?;
+    let mut dates = HashSet::new();
 
     for line in BufReader::new(file).lines() {
-        let Ok(line) = line else {
-            return true;
-        };
+        let line = line.ok()?;
         if !line.contains("\"token_count\"") {
             continue;
         }
 
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
-            return true;
-        };
+        let value = serde_json::from_str::<serde_json::Value>(&line).ok()?;
         let is_usage_event = value.get("type").and_then(|value| value.as_str())
             == Some("event_msg")
             && value
@@ -234,26 +279,21 @@ fn codex_file_may_overlap_rollup_dates(file_path: &Path, rollup_dates: &HashSet<
             continue;
         }
 
-        let Some(timestamp) = value.get("timestamp").and_then(|value| value.as_str()) else {
-            return true;
-        };
-        let Ok(timestamp) = chrono::DateTime::parse_from_rfc3339(timestamp) else {
-            return true;
-        };
+        let timestamp = value.get("timestamp").and_then(|value| value.as_str())?;
+        let timestamp = chrono::DateTime::parse_from_rfc3339(timestamp).ok()?;
         // rollup 只保留当时的本地日期，无法得知当时的时区。任意合法时区下，
         // 一个时间点的本地日期只可能落在其 UTC 日期的前一天、当天或后一天。
         // 检查这三个日期可避免用户在 rollup 后切换时区时漏判并重复导入。
         let utc_date = timestamp.with_timezone(&chrono::Utc).date_naive();
-        let may_overlap = [utc_date.pred_opt(), Some(utc_date), utc_date.succ_opt()]
+        for date in [utc_date.pred_opt(), Some(utc_date), utc_date.succ_opt()]
             .into_iter()
             .flatten()
-            .any(|date| rollup_dates.contains(&date.format("%Y-%m-%d").to_string()));
-        if may_overlap {
-            return true;
+        {
+            dates.insert(date.format("%Y-%m-%d").to_string());
         }
     }
 
-    false
+    Some(dates)
 }
 
 /// 归一化 Codex 模型名
@@ -407,41 +447,15 @@ fn repair_legacy_codex_subagent_usage(
     db: &Database,
     files: &[(PathBuf, Option<CodexSessionIdentity>)],
 ) -> Result<(), AppError> {
-    let mut conn = lock_conn!(db.conn);
-
-    let already_migrated = conn
-        .query_row(
-            "SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1 AND value = 'true')",
-            rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
-            |row| row.get::<_, bool>(0),
-        )
-        .map_err(|e| AppError::Database(format!("查询 Codex 子代理用量迁移状态失败: {e}")))?;
-    if already_migrated {
-        return Ok(());
-    }
-
-    let codex_rollup_dates = conn
-        .prepare("SELECT DISTINCT date FROM usage_daily_rollups WHERE app_type = 'codex'")
-        .and_then(|mut stmt| {
-            stmt.query_map([], |row| row.get::<_, String>(0))?
-                .collect::<Result<HashSet<_>, _>>()
-        })
-        .map_err(|e| AppError::Database(format!("查询 Codex 历史汇总日期失败: {e}")))?;
-
-    let rebuildable_thread_ids: HashSet<&str> = files
-        .iter()
-        .filter_map(|(_, identity)| {
-            identity
-                .as_ref()
-                .map(|identity| identity.thread_id.as_str())
-        })
-        .collect();
-    let mut affected_session_ids = HashSet::new();
-    let mut preserved_session_ids = HashSet::new();
-    let mut preserved_synced_subagent_paths = HashSet::new();
-    let mut synced_subagent_paths = Vec::new();
-
-    {
+    let (already_migrated, synced_subagent_paths) = {
+        let conn = lock_conn!(db.conn);
+        let already_migrated = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1 AND value = 'true')",
+                rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(|e| AppError::Database(format!("查询 Codex 子代理用量迁移状态失败: {e}")))?;
         let mut stmt = conn
             .prepare(
                 "SELECT EXISTS(
@@ -450,6 +464,7 @@ fn repair_legacy_codex_subagent_usage(
                 )",
             )
             .map_err(|e| AppError::Database(format!("准备 Codex 子代理同步状态查询失败: {e}")))?;
+        let mut synced_paths = Vec::new();
 
         for (path, identity) in files {
             let Some(identity) = identity else {
@@ -466,41 +481,137 @@ fn repair_legacy_codex_subagent_usage(
                 })
                 .map_err(|e| AppError::Database(format!("查询 Codex 子代理旧同步状态失败: {e}")))?;
             if was_synced {
-                synced_subagent_paths.push((path.into_owned(), identity.session_id.clone()));
+                synced_paths.push((path.into_owned(), identity.session_id.clone()));
+            }
+        }
+
+        (already_migrated, synced_paths)
+    };
+
+    if synced_subagent_paths.is_empty() {
+        // 空目录可能只是 CODEX_HOME 暂时不可用，不能永久关闭后续迁移。
+        if !already_migrated && !files.is_empty() {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT OR REPLACE INTO settings (key, value) VALUES (?1, 'true')",
+                rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
+            )
+            .map_err(|e| AppError::Database(format!("保存 Codex 子代理用量迁移状态失败: {e}")))?;
+        }
+        return Ok(());
+    }
+
+    let candidate_session_ids: HashSet<&str> = synced_subagent_paths
+        .iter()
+        .map(|(_, session_id)| session_id.as_str())
+        .collect();
+    let file_rollup_coverage: HashMap<PathBuf, CodexRollupDateCoverage> = files
+        .iter()
+        .filter(|(_, identity)| {
+            identity.as_ref().is_some_and(|identity| {
+                candidate_session_ids.contains(identity.thread_id.as_str())
+                    || candidate_session_ids.contains(identity.session_id.as_str())
+            })
+        })
+        .map(|(path, _)| (path.clone(), CodexRollupDateCoverage::from_file(path)))
+        .collect();
+
+    let rebuildable_thread_ids: HashSet<&str> = files
+        .iter()
+        .filter_map(|(_, identity)| {
+            identity
+                .as_ref()
+                .map(|identity| identity.thread_id.as_str())
+        })
+        .collect();
+
+    let mut conn = lock_conn!(db.conn);
+    let tx = conn
+        .transaction()
+        .map_err(|e| AppError::Database(format!("开启 Codex 子代理用量修复事务失败: {e}")))?;
+
+    // 文件扫描期间没有持有数据库锁。重新加锁后再确认旧游标仍存在，避免并发
+    // 同步已经完成迁移时重复处理同一文件。
+    let active_synced_subagent_paths = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT EXISTS(
+                    SELECT 1 FROM session_log_sync
+                    WHERE file_path = ?1 AND last_line_offset > 0
+                )",
+            )
+            .map_err(|e| AppError::Database(format!("准备 Codex 子代理同步状态复查失败: {e}")))?;
+        let mut active_paths = Vec::new();
+        for (path, session_id) in synced_subagent_paths {
+            let was_synced = stmt
+                .query_row(rusqlite::params![path], |row| row.get::<_, bool>(0))
+                .map_err(|e| AppError::Database(format!("复查 Codex 子代理旧同步状态失败: {e}")))?;
+            if was_synced {
+                active_paths.push((path, session_id));
+            }
+        }
+        active_paths
+    };
+
+    if active_synced_subagent_paths.is_empty() {
+        tx.commit()
+            .map_err(|e| AppError::Database(format!("提交 Codex 子代理用量修复失败: {e}")))?;
+        return Ok(());
+    }
+
+    let migration_became_active = tx
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1 AND value = 'true')",
+            rusqlite::params![CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(|e| AppError::Database(format!("复查 Codex 子代理迁移状态失败: {e}")))?;
+
+    let codex_rollup_dates = if migration_became_active {
+        HashSet::new()
+    } else {
+        tx.prepare("SELECT DISTINCT date FROM usage_daily_rollups WHERE app_type = 'codex'")
+            .and_then(|mut stmt| {
+                stmt.query_map([], |row| row.get::<_, String>(0))?
+                    .collect::<Result<HashSet<_>, _>>()
+            })
+            .map_err(|e| AppError::Database(format!("查询 Codex 历史汇总日期失败: {e}")))?
+    };
+
+    let synced_session_ids: HashSet<&str> = active_synced_subagent_paths
+        .iter()
+        .map(|(_, session_id)| session_id.as_str())
+        .collect();
+    let mut affected_session_ids = HashSet::new();
+    let mut preserved_session_ids = HashSet::new();
+    let mut preserved_synced_subagent_paths = HashSet::new();
+
+    if !migration_became_active {
+        for session_id in synced_session_ids {
+            if !rebuildable_thread_ids.contains(session_id) {
+                continue;
+            }
+
+            let overlaps_rollup = files.iter().any(|(path, identity)| {
+                identity.as_ref().is_some_and(|identity| {
+                    (identity.thread_id == session_id || identity.session_id == session_id)
+                        && file_rollup_coverage
+                            .get(path)
+                            .is_none_or(|coverage| coverage.may_overlap(&codex_rollup_dates))
+                })
+            });
+            if !overlaps_rollup {
+                affected_session_ids.insert(session_id.to_string());
             }
         }
     }
 
-    let synced_session_ids: HashSet<&str> = synced_subagent_paths
-        .iter()
-        .map(|(_, session_id)| session_id.as_str())
-        .collect();
-    for session_id in synced_session_ids {
-        if !rebuildable_thread_ids.contains(session_id) {
-            continue;
-        }
-
-        let overlaps_rollup = files.iter().any(|(path, identity)| {
-            identity.as_ref().is_some_and(|identity| {
-                (identity.thread_id == session_id || identity.session_id == session_id)
-                    && codex_file_may_overlap_rollup_dates(path, &codex_rollup_dates)
-            })
-        });
-        if !overlaps_rollup {
-            affected_session_ids.insert(session_id.to_string());
-        }
-    }
-
-    for (path, session_id) in synced_subagent_paths {
+    for (path, session_id) in active_synced_subagent_paths {
         if !affected_session_ids.contains(&session_id) {
             preserved_session_ids.insert(session_id);
             preserved_synced_subagent_paths.insert(path);
         }
     }
-
-    let tx = conn
-        .transaction()
-        .map_err(|e| AppError::Database(format!("开启 Codex 子代理用量修复事务失败: {e}")))?;
 
     for session_id in &affected_session_ids {
         tx.execute(
@@ -517,8 +628,9 @@ fn repair_legacy_codex_subagent_usage(
     for session_id in &preserved_session_ids {
         tx.execute(
             "UPDATE proxy_request_logs
-             SET request_id = 'codex_session:legacy:' || request_id
-             WHERE data_source = 'codex_session' AND session_id = ?1",
+             SET request_id = 'codex_session:legacy:' || rowid || ':' || request_id
+             WHERE data_source = 'codex_session' AND session_id = ?1
+               AND request_id NOT LIKE 'codex_session:legacy:%'",
             rusqlite::params![session_id],
         )
         .map_err(|e| AppError::Database(format!("迁移保留的 Codex 旧请求 ID 失败: {e}")))?;
@@ -546,18 +658,25 @@ fn repair_legacy_codex_subagent_usage(
     }
 
     // 父日志已不存在，或历史已进入无 session 维度的 rollup 时，无法安全重建
-    // 旧记录。保留旧统计，并把旧游标复制到 thread_id 同步键，避免重复计费。
+    // 旧记录。保留旧统计，把旧游标复制到 thread_id 同步键，再删除 plain-path
+    // 游标作为该文件已处理的标记。以后恢复的遗漏文件仍可独立触发同一迁移。
     for path in &preserved_synced_subagent_paths {
         let subagent_key = format!("{path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
         tx.execute(
-            "INSERT OR IGNORE INTO session_log_sync (
+            "INSERT INTO session_log_sync (
                 file_path, last_modified, last_line_offset, last_synced_at
              )
              SELECT ?2, last_modified, last_line_offset, last_synced_at
-             FROM session_log_sync WHERE file_path = ?1",
+             FROM session_log_sync WHERE file_path = ?1
+             ON CONFLICT(file_path) DO UPDATE SET
+                last_modified = MAX(last_modified, excluded.last_modified),
+                last_line_offset = MAX(last_line_offset, excluded.last_line_offset),
+                last_synced_at = MAX(last_synced_at, excluded.last_synced_at)",
             rusqlite::params![path, subagent_key],
         )
         .map_err(|e| AppError::Database(format!("迁移保留的 Codex 子代理同步游标失败: {e}")))?;
+        tx.execute("DELETE FROM session_log_sync WHERE file_path = ?1", [path])
+            .map_err(|e| AppError::Database(format!("清理 Codex 子代理旧同步游标失败: {e}")))?;
     }
 
     tx.execute(
@@ -643,7 +762,16 @@ fn sync_single_codex_file(
     let file_modified = metadata_modified_nanos(&metadata);
 
     // 检查同步状态
-    let (last_modified, last_offset) = get_sync_state(db, &sync_state_key)?;
+    let (mut last_modified, mut last_offset) = get_sync_state(db, &sync_state_key)?;
+    if identity.is_some_and(CodexSessionIdentity::is_subagent) {
+        let legacy_state = get_sync_state(db, &file_path_str)?;
+        if legacy_state.1 > last_offset {
+            // 迁移可能在日志文件暂时缺失时完成。suffix 游标不存在时始终继承
+            // plain-path 旧游标，避免文件恢复后从头重导造成重复统计。
+            update_sync_state(db, &sync_state_key, legacy_state.0, legacy_state.1)?;
+            (last_modified, last_offset) = legacy_state;
+        }
+    }
 
     // 文件未变化则跳过
     if file_modified <= last_modified {
@@ -655,6 +783,14 @@ fn sync_single_codex_file(
         fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
     let reader = BufReader::new(file);
     let history_replay_boundary = codex_history_replay_boundary(file_path, identity);
+    if identity.is_some_and(|identity| identity.carries_history_snapshot)
+        && history_replay_boundary.is_none()
+    {
+        log::debug!(
+            "[CODEX-SYNC] fork/子代理日志未发现历史接管边界: {}",
+            file_path.display()
+        );
+    }
 
     let mut state = FileParseState {
         thread_id: identity.map(|identity| identity.thread_id.clone()),
@@ -1178,6 +1314,41 @@ mod tests {
         assert_eq!(identity.thread_id, "child-thread");
         assert_eq!(identity.session_id, "parent-thread");
         assert!(identity.is_subagent());
+        assert!(identity.carries_history_snapshot);
+    }
+
+    #[test]
+    fn test_identity_and_replay_boundary_skip_malformed_matching_lines() {
+        let temp = tempdir().unwrap();
+        let child = temp.path().join("child-malformed.jsonl");
+        let lines = [
+            "not-json session_meta".to_string(),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child",
+                    "session_id": "parent",
+                    "source": { "subagent": {} }
+                }
+            })
+            .to_string(),
+            "not-json thread_settings_applied".to_string(),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:01Z",
+                "type": "event_msg",
+                "payload": { "type": "thread_settings_applied" }
+            })
+            .to_string(),
+        ];
+        fs::write(&child, lines.join("\n") + "\n").unwrap();
+
+        let identity = read_codex_session_identity(&child).unwrap();
+        assert_eq!(identity.thread_id, "child");
+        assert_eq!(
+            codex_history_replay_boundary(&child, Some(&identity)),
+            Some(4)
+        );
     }
 
     #[test]
@@ -1633,6 +1804,7 @@ mod tests {
         repair_legacy_codex_subagent_usage(&db, &files)?;
 
         let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+        assert_eq!(get_sync_state(&db, &child_path)?, (0, 0));
         assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
         assert_eq!(
             sync_single_codex_file(&db, &child, Some(&identity))?,
@@ -1647,13 +1819,135 @@ mod tests {
             )?
             .query_map([], |row| row.get::<_, String>(0))?
             .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(request_ids.len(), 2);
+        assert!(request_ids.contains(&"codex_session:child:2".to_string()));
+        assert!(request_ids.iter().any(|request_id| {
+            request_id.starts_with("codex_session:legacy:")
+                && request_id.ends_with(":codex_session:missing-parent:1")
+        }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_late_subagent_after_migration_activation_preserves_legacy_cursor(
+    ) -> Result<(), AppError> {
+        let db = Database::memory()?;
+        repair_legacy_codex_subagent_usage(&db, &[])?;
+        {
+            let conn = lock_conn!(db.conn);
+            let marker_exists: bool = conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1)",
+                [CODEX_SUBAGENT_USAGE_MIGRATION_KEY],
+                |row| row.get(0),
+            )?;
+            assert!(!marker_exists);
+        }
+
+        let temp = tempdir().unwrap();
+        let unrelated_main = temp.path().join("unrelated-main.jsonl");
+        write_codex_usage_log(&unrelated_main, "unrelated", "unrelated", 100, 10);
+        let unrelated_identity = read_codex_session_identity(&unrelated_main).unwrap();
+        repair_legacy_codex_subagent_usage(&db, &[(unrelated_main, Some(unrelated_identity))])?;
+
+        let child = temp.path().join("late-child.jsonl");
+        let child_lines = [
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "late-child",
+                    "session_id": "missing-parent",
+                    "source": { "subagent": {} }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:01Z",
+                "type": "turn_context",
+                "payload": { "model": "gpt-5.6-sol" }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 200,
+                        "cached_input_tokens": 100,
+                        "output_tokens": 20
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:03Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 300,
+                        "cached_input_tokens": 150,
+                        "output_tokens": 30
+                    }}
+                }
+            }),
+        ];
+        fs::write(
+            &child,
+            child_lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n",
+        )
+        .unwrap();
+
+        let identity = read_codex_session_identity(&child).unwrap();
+        let child_path = child.to_string_lossy().to_string();
+        insert_legacy_codex_usage_row(&db, "missing-parent")?;
+        update_sync_state(&db, &child_path, 1, 3)?;
+
+        repair_legacy_codex_subagent_usage(&db, &[(child.clone(), Some(identity.clone()))])?;
+
+        let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+        assert_eq!(get_sync_state(&db, &child_path)?, (0, 0));
+        assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
         assert_eq!(
-            request_ids,
-            vec![
-                "codex_session:child:2".to_string(),
-                "codex_session:legacy:codex_session:missing-parent:1".to_string()
-            ]
+            sync_single_codex_file(&db, &child, Some(&identity))?,
+            (1, 0)
         );
+
+        let conn = lock_conn!(db.conn);
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_subagent_sync_falls_back_to_newer_plain_cursor() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let child = temp.path().join("fallback-child.jsonl");
+        write_codex_usage_log(&child, "fallback-child", "parent", 200, 20);
+
+        let identity = read_codex_session_identity(&child).unwrap();
+        let child_path = child.to_string_lossy().to_string();
+        let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+        update_sync_state(&db, &subagent_key, 1, 1)?;
+        update_sync_state(&db, &child_path, 2, 3)?;
+
+        assert_eq!(
+            sync_single_codex_file(&db, &child, Some(&identity))?,
+            (0, 0)
+        );
+        let (last_modified, last_offset) = get_sync_state(&db, &subagent_key)?;
+        assert!(last_modified > 2);
+        assert_eq!(last_offset, 3);
 
         Ok(())
     }
@@ -1808,14 +2102,13 @@ mod tests {
             )?
             .query_map([], |row| row.get::<_, String>(0))?
             .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(
-            request_ids,
-            vec![
-                "codex_session:child:2".to_string(),
-                "codex_session:legacy:codex_session:parent:2".to_string(),
-                "codex_session:parent:2".to_string(),
-            ]
-        );
+        assert_eq!(request_ids.len(), 3);
+        assert!(request_ids.contains(&"codex_session:child:2".to_string()));
+        assert!(request_ids.contains(&"codex_session:parent:2".to_string()));
+        assert!(request_ids.iter().any(|request_id| {
+            request_id.starts_with("codex_session:legacy:")
+                && request_id.ends_with(":codex_session:parent:2")
+        }));
 
         Ok(())
     }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -30,6 +30,8 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 const CODEX_SUBAGENT_USAGE_MIGRATION_KEY: &str = "codex_subagent_usage_thread_id_v1_migrated";
+const CODEX_SUBAGENT_REBUILT_SESSION_KEY_PREFIX: &str =
+    "codex_subagent_usage_thread_id_v1_rebuilt:";
 const CODEX_SUBAGENT_SYNC_KEY_SUFFIX: &str = "#codex-thread-id-v1";
 
 /// 累计 token 用量（跟踪 total_token_usage 字段）
@@ -582,7 +584,24 @@ fn repair_legacy_codex_subagent_usage(
         .iter()
         .map(|(_, session_id)| session_id.as_str())
         .collect();
+    let rebuilt_session_ids = {
+        let mut stmt = tx
+            .prepare("SELECT EXISTS(SELECT 1 FROM settings WHERE key = ?1 AND value = 'true')")
+            .map_err(|e| AppError::Database(format!("准备 Codex 已重建会话查询失败: {e}")))?;
+        let mut rebuilt = HashSet::new();
+        for session_id in &synced_session_ids {
+            let key = format!("{CODEX_SUBAGENT_REBUILT_SESSION_KEY_PREFIX}{session_id}");
+            let was_rebuilt = stmt
+                .query_row([key], |row| row.get::<_, bool>(0))
+                .map_err(|e| AppError::Database(format!("查询 Codex 已重建会话失败: {e}")))?;
+            if was_rebuilt {
+                rebuilt.insert((*session_id).to_string());
+            }
+        }
+        rebuilt
+    };
     let mut affected_session_ids = HashSet::new();
+    let mut late_rebuild_subagent_paths = HashSet::new();
     let mut preserved_session_ids = HashSet::new();
     let mut preserved_synced_subagent_paths = HashSet::new();
 
@@ -607,7 +626,12 @@ fn repair_legacy_codex_subagent_usage(
     }
 
     for (path, session_id) in active_synced_subagent_paths {
-        if !affected_session_ids.contains(&session_id) {
+        if affected_session_ids.contains(&session_id) {
+            continue;
+        }
+        if rebuilt_session_ids.contains(&session_id) {
+            late_rebuild_subagent_paths.insert(path);
+        } else {
             preserved_session_ids.insert(session_id);
             preserved_synced_subagent_paths.insert(path);
         }
@@ -655,6 +679,26 @@ fn repair_legacy_codex_subagent_usage(
             )
             .map_err(|e| AppError::Database(format!("重置 Codex 子代理同步游标失败: {e}")))?;
         }
+
+        for session_id in &affected_session_ids {
+            let key = format!("{CODEX_SUBAGENT_REBUILT_SESSION_KEY_PREFIX}{session_id}");
+            tx.execute(
+                "INSERT OR REPLACE INTO settings (key, value) VALUES (?1, 'true')",
+                [key],
+            )
+            .map_err(|e| AppError::Database(format!("记录 Codex 已重建会话失败: {e}")))?;
+        }
+    }
+
+    // 同一父会话已完成精确重建时，迟到的兄弟子代理旧记录已随父命名空间
+    // 一并删除。清除该文件的新旧游标，让它从头按唯一 thread_id 补回历史。
+    for path in &late_rebuild_subagent_paths {
+        let subagent_key = format!("{path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+        tx.execute(
+            "DELETE FROM session_log_sync WHERE file_path = ?1 OR file_path = ?2",
+            rusqlite::params![path, subagent_key],
+        )
+        .map_err(|e| AppError::Database(format!("重置迟到 Codex 子代理同步游标失败: {e}")))?;
     }
 
     // 父日志已不存在，或历史已进入无 session 维度的 rollup 时，无法安全重建
@@ -698,6 +742,12 @@ fn repair_legacy_codex_subagent_usage(
         log::info!(
             "[CODEX-SYNC] 检测到历史汇总，已保留旧统计并迁移 {} 个子代理同步游标",
             preserved_synced_subagent_paths.len()
+        );
+    }
+    if !late_rebuild_subagent_paths.is_empty() {
+        log::info!(
+            "[CODEX-SYNC] 已重置 {} 个迟到子代理游标以补回历史用量",
+            late_rebuild_subagent_paths.len()
         );
     }
 
@@ -1728,6 +1778,75 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(count, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repair_reimports_late_sibling_after_parent_rebuild() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.jsonl");
+        let child_a = temp.path().join("child-a.jsonl");
+        let child_b = temp.path().join("child-b.jsonl");
+        write_codex_usage_log(&main, "parent", "parent", 100, 10);
+        write_codex_usage_log(&child_a, "child-a", "parent", 200, 20);
+        write_codex_usage_log(&child_b, "child-b", "parent", 300, 30);
+
+        let main_identity = read_codex_session_identity(&main).unwrap();
+        let child_a_identity = read_codex_session_identity(&child_a).unwrap();
+        let child_b_identity = read_codex_session_identity(&child_b).unwrap();
+        insert_legacy_codex_usage_row(&db, "parent")?;
+
+        let main_path = main.to_string_lossy().to_string();
+        let child_a_path = child_a.to_string_lossy().to_string();
+        let child_b_path = child_b.to_string_lossy().to_string();
+        update_sync_state(&db, &main_path, 1, 3)?;
+        update_sync_state(&db, &child_a_path, 1, 3)?;
+        update_sync_state(&db, &child_b_path, 1, 3)?;
+
+        let first_files = vec![
+            (main.clone(), Some(main_identity.clone())),
+            (child_a.clone(), Some(child_a_identity.clone())),
+        ];
+        repair_legacy_codex_subagent_usage(&db, &first_files)?;
+        assert_eq!(
+            sync_single_codex_file(&db, &main, Some(&main_identity))?,
+            (1, 0)
+        );
+        assert_eq!(
+            sync_single_codex_file(&db, &child_a, Some(&child_a_identity))?,
+            (1, 0)
+        );
+
+        let all_files = vec![
+            (main, Some(main_identity)),
+            (child_a, Some(child_a_identity)),
+            (child_b.clone(), Some(child_b_identity.clone())),
+        ];
+        repair_legacy_codex_subagent_usage(&db, &all_files)?;
+        assert_eq!(get_sync_state(&db, &child_b_path)?, (0, 0));
+        assert_eq!(
+            sync_single_codex_file(&db, &child_b, Some(&child_b_identity))?,
+            (1, 0)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let request_ids = conn
+            .prepare(
+                "SELECT request_id FROM proxy_request_logs
+                 WHERE data_source = 'codex_session' ORDER BY request_id",
+            )?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            request_ids,
+            vec![
+                "codex_session:child-a:1".to_string(),
+                "codex_session:child-b:1".to_string(),
+                "codex_session:parent:1".to_string(),
+            ]
+        );
 
         Ok(())
     }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -199,6 +199,63 @@ fn is_history_snapshot_event(state: &FileParseState, line_offset: i64) -> bool {
         .is_some_and(|boundary| line_offset < boundary)
 }
 
+fn codex_file_may_overlap_rollup_dates(file_path: &Path, rollup_dates: &HashSet<String>) -> bool {
+    if rollup_dates.is_empty() {
+        return false;
+    }
+
+    let Ok(file) = fs::File::open(file_path) else {
+        return true;
+    };
+
+    for line in BufReader::new(file).lines() {
+        let Ok(line) = line else {
+            return true;
+        };
+        if !line.contains("\"token_count\"") {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            return true;
+        };
+        let is_usage_event = value.get("type").and_then(|value| value.as_str())
+            == Some("event_msg")
+            && value
+                .get("payload")
+                .and_then(|payload| payload.get("type"))
+                .and_then(|value| value.as_str())
+                == Some("token_count")
+            && value
+                .get("payload")
+                .and_then(|payload| payload.get("info"))
+                .is_some_and(|info| !info.is_null());
+        if !is_usage_event {
+            continue;
+        }
+
+        let Some(timestamp) = value.get("timestamp").and_then(|value| value.as_str()) else {
+            return true;
+        };
+        let Ok(timestamp) = chrono::DateTime::parse_from_rfc3339(timestamp) else {
+            return true;
+        };
+        // rollup 只保留当时的本地日期，无法得知当时的时区。任意合法时区下，
+        // 一个时间点的本地日期只可能落在其 UTC 日期的前一天、当天或后一天。
+        // 检查这三个日期可避免用户在 rollup 后切换时区时漏判并重复导入。
+        let utc_date = timestamp.with_timezone(&chrono::Utc).date_naive();
+        let may_overlap = [utc_date.pred_opt(), Some(utc_date), utc_date.succ_opt()]
+            .into_iter()
+            .flatten()
+            .any(|date| rollup_dates.contains(&date.format("%Y-%m-%d").to_string()));
+        if may_overlap {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// 归一化 Codex 模型名
 ///
 /// 处理规则（按顺序）：
@@ -337,10 +394,15 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
 
 /// 修复旧版以父 session_id 作为 request_id 命名空间造成的历史碰撞。
 ///
-/// 仅处理已经被旧同步器读取过、且父线程日志仍可从磁盘重建的会话：
+/// 仅在会话日志日期未与 Codex 汇总日期重叠时，处理已经被旧同步器读取过、
+/// 且父线程日志仍可从磁盘重建的会话：
 /// 1. 删除该父线程下无法区分主/子代理来源的旧 Codex session 行；
 /// 2. 清除相关文件的同步游标；
 /// 3. 当前同步轮次会用唯一 thread_id 重建准确记录。
+///
+/// `usage_daily_rollups` 没有 session 维度，已有汇总行时无法只撤销受影响会话。
+/// 此时保留历史统计、迁移子代理游标并隔离旧 request_id，避免全量重导造成
+/// 永久双计，也避免旧子代理记录阻塞父线程后续新增用量。
 fn repair_legacy_codex_subagent_usage(
     db: &Database,
     files: &[(PathBuf, Option<CodexSessionIdentity>)],
@@ -358,6 +420,14 @@ fn repair_legacy_codex_subagent_usage(
         return Ok(());
     }
 
+    let codex_rollup_dates = conn
+        .prepare("SELECT DISTINCT date FROM usage_daily_rollups WHERE app_type = 'codex'")
+        .and_then(|mut stmt| {
+            stmt.query_map([], |row| row.get::<_, String>(0))?
+                .collect::<Result<HashSet<_>, _>>()
+        })
+        .map_err(|e| AppError::Database(format!("查询 Codex 历史汇总日期失败: {e}")))?;
+
     let rebuildable_thread_ids: HashSet<&str> = files
         .iter()
         .filter_map(|(_, identity)| {
@@ -367,7 +437,9 @@ fn repair_legacy_codex_subagent_usage(
         })
         .collect();
     let mut affected_session_ids = HashSet::new();
-    let mut orphaned_synced_subagent_paths = Vec::new();
+    let mut preserved_session_ids = HashSet::new();
+    let mut preserved_synced_subagent_paths = HashSet::new();
+    let mut synced_subagent_paths = Vec::new();
 
     {
         let mut stmt = conn
@@ -394,12 +466,35 @@ fn repair_legacy_codex_subagent_usage(
                 })
                 .map_err(|e| AppError::Database(format!("查询 Codex 子代理旧同步状态失败: {e}")))?;
             if was_synced {
-                if rebuildable_thread_ids.contains(identity.session_id.as_str()) {
-                    affected_session_ids.insert(identity.session_id.clone());
-                } else {
-                    orphaned_synced_subagent_paths.push(path.into_owned());
-                }
+                synced_subagent_paths.push((path.into_owned(), identity.session_id.clone()));
             }
+        }
+    }
+
+    let synced_session_ids: HashSet<&str> = synced_subagent_paths
+        .iter()
+        .map(|(_, session_id)| session_id.as_str())
+        .collect();
+    for session_id in synced_session_ids {
+        if !rebuildable_thread_ids.contains(session_id) {
+            continue;
+        }
+
+        let overlaps_rollup = files.iter().any(|(path, identity)| {
+            identity.as_ref().is_some_and(|identity| {
+                (identity.thread_id == session_id || identity.session_id == session_id)
+                    && codex_file_may_overlap_rollup_dates(path, &codex_rollup_dates)
+            })
+        });
+        if !overlaps_rollup {
+            affected_session_ids.insert(session_id.to_string());
+        }
+    }
+
+    for (path, session_id) in synced_subagent_paths {
+        if !affected_session_ids.contains(&session_id) {
+            preserved_session_ids.insert(session_id);
+            preserved_synced_subagent_paths.insert(path);
         }
     }
 
@@ -414,6 +509,19 @@ fn repair_legacy_codex_subagent_usage(
             rusqlite::params![session_id],
         )
         .map_err(|e| AppError::Database(format!("清理旧 Codex 子代理碰撞记录失败: {e}")))?;
+    }
+
+    // 保留历史统计时不能继续让旧记录占用父线程的 request_id 命名空间。
+    // 旧子代理可能抢先写入 parent:N；父线程未来增长到同一个 N 时会被误判为
+    // 重复记录。仅重命名主键，不改变任何用量字段或汇总结果。
+    for session_id in &preserved_session_ids {
+        tx.execute(
+            "UPDATE proxy_request_logs
+             SET request_id = 'codex_session:legacy:' || request_id
+             WHERE data_source = 'codex_session' AND session_id = ?1",
+            rusqlite::params![session_id],
+        )
+        .map_err(|e| AppError::Database(format!("迁移保留的 Codex 旧请求 ID 失败: {e}")))?;
     }
 
     if !affected_session_ids.is_empty() {
@@ -437,9 +545,9 @@ fn repair_legacy_codex_subagent_usage(
         }
     }
 
-    // 父日志已不存在时无法安全重建旧记录。保留旧行，并把旧游标复制到新的
-    // thread_id 同步键，避免升级后把整份子代理日志再次导入而重复计费。
-    for path in &orphaned_synced_subagent_paths {
+    // 父日志已不存在，或历史已进入无 session 维度的 rollup 时，无法安全重建
+    // 旧记录。保留旧统计，并把旧游标复制到 thread_id 同步键，避免重复计费。
+    for path in &preserved_synced_subagent_paths {
         let subagent_key = format!("{path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
         tx.execute(
             "INSERT OR IGNORE INTO session_log_sync (
@@ -449,7 +557,7 @@ fn repair_legacy_codex_subagent_usage(
              FROM session_log_sync WHERE file_path = ?1",
             rusqlite::params![path, subagent_key],
         )
-        .map_err(|e| AppError::Database(format!("迁移孤立 Codex 子代理同步游标失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("迁移保留的 Codex 子代理同步游标失败: {e}")))?;
     }
 
     tx.execute(
@@ -465,6 +573,12 @@ fn repair_legacy_codex_subagent_usage(
         log::info!(
             "[CODEX-SYNC] 已重置 {} 个存在子代理 request_id 碰撞的历史会话",
             affected_session_ids.len()
+        );
+    }
+    if !codex_rollup_dates.is_empty() && !preserved_synced_subagent_paths.is_empty() {
+        log::info!(
+            "[CODEX-SYNC] 检测到历史汇总，已保留旧统计并迁移 {} 个子代理同步游标",
+            preserved_synced_subagent_paths.len()
         );
     }
 
@@ -675,6 +789,10 @@ fn sync_single_codex_file(
                     continue; // 跳过 task 边界的零 delta 事件
                 }
 
+                // request_id 的序号沿用旧解析器定义：每个非零 token delta 都占一位。
+                // replay 虽不计费，也必须占号，否则升级后追加事件会撞上旧主键。
+                state.event_index += 1;
+
                 let timestamp = value
                     .get("timestamp")
                     .and_then(|value| value.as_str())
@@ -689,8 +807,6 @@ fn sync_single_codex_file(
                     }
                     continue;
                 }
-
-                state.event_index += 1;
 
                 // 跳过已处理的行（但仍需解析以恢复状态）
                 if line_offset <= last_offset {
@@ -1149,11 +1265,132 @@ mod tests {
         let usage: (i64, i64, i64) = conn.query_row(
             "SELECT input_tokens, cache_read_tokens, output_tokens
              FROM proxy_request_logs
-             WHERE request_id = 'codex_session:child:1'",
+             WHERE request_id = 'codex_session:child:3'",
             [],
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )?;
         assert_eq!(usage, (100, 50, 30));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fork_replay_keeps_legacy_request_id_sequence() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let fork = temp.path().join("fork.jsonl");
+        let lines = [
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "fork",
+                    "session_id": "fork",
+                    "forked_from_id": "parent",
+                    "source": "cli"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.100Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 100,
+                        "cached_input_tokens": 50,
+                        "output_tokens": 10
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.200Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 200,
+                        "cached_input_tokens": 100,
+                        "output_tokens": 20
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:00.300Z",
+                "type": "event_msg",
+                "payload": { "type": "thread_settings_applied" }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:01Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 300,
+                        "cached_input_tokens": 150,
+                        "output_tokens": 30
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 400,
+                        "cached_input_tokens": 200,
+                        "output_tokens": 40
+                    }}
+                }
+            }),
+        ];
+        fs::write(
+            &fork,
+            lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n",
+        )
+        .unwrap();
+
+        let identity = read_codex_session_identity(&fork).unwrap();
+        assert!(!identity.is_subagent());
+        assert_eq!(
+            codex_history_replay_boundary(&fork, Some(&identity)),
+            Some(4)
+        );
+
+        {
+            let conn = lock_conn!(db.conn);
+            for event_index in 1..=3 {
+                conn.execute(
+                    "INSERT INTO proxy_request_logs (
+                        request_id, provider_id, app_type, model, request_model,
+                        input_tokens, output_tokens, cache_read_tokens,
+                        total_cost_usd, latency_ms, status_code, session_id,
+                        created_at, data_source
+                    ) VALUES (?1, '_codex_session', 'codex', 'gpt-5.6-sol',
+                              'gpt-5.6-sol', 100, 10, 50, '0', 0, 200, 'fork',
+                              1752116402, 'codex_session')",
+                    [format!("codex_session:fork:{event_index}")],
+                )?;
+            }
+        }
+
+        let fork_path = fork.to_string_lossy().to_string();
+        update_sync_state(&db, &fork_path, 1, 5)?;
+        assert_eq!(sync_single_codex_file(&db, &fork, Some(&identity))?, (1, 0));
+
+        let conn = lock_conn!(db.conn);
+        let usage: (i64, i64, i64) = conn.query_row(
+            "SELECT input_tokens, cache_read_tokens, output_tokens
+             FROM proxy_request_logs WHERE request_id = 'codex_session:fork:4'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(usage, (100, 50, 10));
 
         Ok(())
     }
@@ -1414,7 +1651,169 @@ mod tests {
             request_ids,
             vec![
                 "codex_session:child:2".to_string(),
-                "codex_session:missing-parent:1".to_string()
+                "codex_session:legacy:codex_session:missing-parent:1".to_string()
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repair_with_rollup_preserves_history_and_only_imports_new_usage() -> Result<(), AppError>
+    {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.jsonl");
+        let child = temp.path().join("child.jsonl");
+        write_codex_usage_log(&main, "parent", "parent", 100, 10);
+
+        let child_lines = [
+            serde_json::json!({
+                "timestamp": "2025-07-10T03:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "child",
+                    "session_id": "parent",
+                    "source": {
+                        "subagent": {
+                            "thread_spawn": { "parent_thread_id": "parent", "depth": 1 }
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2025-07-10T03:00:01Z",
+                "type": "turn_context",
+                "payload": { "model": "gpt-5.6-sol" }
+            }),
+            serde_json::json!({
+                "timestamp": "2025-07-10T03:00:02Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 200,
+                        "cached_input_tokens": 100,
+                        "output_tokens": 20
+                    }}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-10T03:00:03Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "total_token_usage": {
+                        "input_tokens": 300,
+                        "cached_input_tokens": 150,
+                        "output_tokens": 30
+                    }}
+                }
+            }),
+        ];
+        fs::write(
+            &child,
+            child_lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n",
+        )
+        .unwrap();
+
+        let main_identity = read_codex_session_identity(&main).unwrap();
+        let child_identity = read_codex_session_identity(&child).unwrap();
+        let files = vec![
+            (main.clone(), Some(main_identity)),
+            (child.clone(), Some(child_identity.clone())),
+        ];
+        insert_legacy_codex_usage_row(&db, "parent")?;
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "UPDATE proxy_request_logs
+                 SET provider_id = 'openai', data_source = 'proxy'
+                 WHERE request_id = 'codex_session:parent:1'",
+                [],
+            )?;
+        }
+        assert_eq!(db.rollup_and_prune(30)?, 1);
+
+        // 模拟旧解析器中子代理抢占了父线程未来会使用的序号。
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, request_model,
+                    input_tokens, output_tokens, cache_read_tokens,
+                    total_cost_usd, latency_ms, status_code, session_id,
+                    created_at, data_source
+                ) VALUES ('codex_session:parent:2', '_codex_session', 'codex',
+                          'gpt-5.6-sol', 'gpt-5.6-sol', 50, 5, 25, '0', 0,
+                          200, 'parent', 1783652402, 'codex_session')",
+                [],
+            )?;
+        }
+
+        let new_parent_usage = serde_json::json!({
+            "timestamp": "2026-07-10T03:00:03Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": { "total_token_usage": {
+                    "input_tokens": 200,
+                    "cached_input_tokens": 100,
+                    "output_tokens": 20
+                }}
+            }
+        });
+        let mut main_contents = fs::read_to_string(&main).unwrap();
+        main_contents.push_str(&new_parent_usage.to_string());
+        main_contents.push('\n');
+        fs::write(&main, main_contents).unwrap();
+
+        let main_path = main.to_string_lossy().to_string();
+        let child_path = child.to_string_lossy().to_string();
+        update_sync_state(&db, &main_path, 1, 3)?;
+        update_sync_state(&db, &child_path, 1, 3)?;
+
+        repair_legacy_codex_subagent_usage(&db, &files)?;
+
+        let subagent_key = format!("{child_path}{CODEX_SUBAGENT_SYNC_KEY_SUFFIX}");
+        assert_eq!(get_sync_state(&db, &main_path)?, (1, 3));
+        assert_eq!(get_sync_state(&db, &subagent_key)?, (1, 3));
+        assert_eq!(
+            sync_single_codex_file(&db, &main, files[0].1.as_ref())?,
+            (1, 0)
+        );
+        assert_eq!(
+            sync_single_codex_file(&db, &child, Some(&child_identity))?,
+            (1, 0)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let rollup_count: i64 = conn.query_row(
+            "SELECT request_count FROM usage_daily_rollups
+             WHERE app_type = 'codex' AND provider_id = 'openai'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(rollup_count, 1);
+
+        let request_ids = conn
+            .prepare(
+                "SELECT request_id FROM proxy_request_logs
+                 WHERE data_source = 'codex_session' ORDER BY request_id",
+            )?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            request_ids,
+            vec![
+                "codex_session:child:2".to_string(),
+                "codex_session:legacy:codex_session:parent:2".to_string(),
+                "codex_session:parent:2".to_string(),
             ]
         );
 


### PR DESCRIPTION
## 概述

当前 Codex 使用量导入逻辑会丢失大部分子代理的 Token 记录。

新版 Codex 子代理日志的 `session_meta.payload` 中包含两个不同含义的 ID：

- `id`：当前线程/子代理的唯一 ID
- `session_id`：父线程 ID

原有导入逻辑优先使用 `session_id`，并按以下格式生成请求 ID：

```text
codex_session:<session_id>:<event_index>
```

由于每个 JSONL 文件中的 `event_index` 都从 1 开始，同一父线程及其所有子代理会生成互相冲突的请求 ID。数据库唯一约束会将后续记录视为重复项，从而导致子代理使用量未计入统计。

本 PR 包含以下修改：

- 分别解析当前线程的唯一 ID 和父线程 ID；
- 使用唯一线程 ID 生成请求 ID，并将使用量归属到实际的子代理线程；
- 保留对旧版元数据字段及普通主线程日志的兼容；
- 过滤派生线程/子代理启动时重放的历史 Token 快照，但仍将其保留为后续增量计算的基线；
- 针对旧版逻辑已经导入的碰撞记录，增加一次性、定向的修复与重建。

### 升级及迁移行为

子代理文件使用带版本的同步状态键，使已经读取到文件末尾的日志能够在升级后重新导入。

一次性修复的范围经过严格限制：

1. 仅选择存在旧同步游标的子代理会话。
2. 仅在父线程源日志仍然存在、可以完整重建时进行修复。
3. 仅删除受影响且 `data_source = 'codex_session'` 的记录。
4. 仅重置相关同步游标，并从现有 JSONL 日志重新构建记录。
5. 写入迁移标记，确保修复不会重复执行。

普通 Codex 会话继续沿用原有同步键。代理请求统计、无关会话以及 Codex JSONL 源文件均不会被修改。

## 关联 Issue

Fixes #5184

## 测试

```text
cargo test --manifest-path src-tauri/Cargo.toml services::session_usage_codex::tests --lib
```

20 个目标测试全部通过。

新增回归测试覆盖：

- 优先使用唯一子线程 ID，而不是共享的父线程 ID；
- 同一父线程下的多个子代理能生成互不冲突的请求 ID；
- 派生线程/子代理启动时继承的历史快照只建立基线，不计为新用量；
- 旧版发生碰撞的记录及同步游标能够被定向修复并重新导入。

其他检查：

- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib`
- `git diff --check`
- 使用现有 Codex 会话日志完成升级烟雾测试，并验证迁移后的增量同步

## 截图

不适用——本次修改仅涉及后端使用量导入逻辑。

## 检查清单

- [x] `pnpm typecheck` 通过
- [x] `pnpm format:check` 通过
- [x] Rust 代码已通过 `cargo clippy`
- [x] 未修改用户可见文本，无需更新国际化文件