### PR TITLE
feat(codex): per-provider unify session history option

### DIFF
--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -16,6 +16,7 @@ use crate::settings::{
 };
 use chrono::{Local, Utc};
 use rusqlite::{backup::Backup, params_from_iter, Connection};
+use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashSet};
@@ -2627,4 +2628,148 @@ model_provider = "aihubmix"
         let ids = collect_source_model_provider_ids(&db).expect("collect ids");
         assert!(!ids.contains("my-local-relay"));
     }
+}
+
+/// 统一会话历史改写结果
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnifyResult {
+    pub target: String,
+    pub jsonl_changed: usize,
+    pub jsonl_scanned: usize,
+    pub state_changed: usize,
+    pub errors: Vec<String>,
+}
+
+/// 将所有 Codex 会话历史的 model_provider 统一改写为指定值。
+///
+/// 用于供应商级"统一会话历史"功能：切换到启用了该选项的供应商后，
+/// 把所有 JSONL 会话和 state DB 的 model_provider 统一改写为当前供应商的 provider ID，
+/// 这样重启 Codex 后无论之前用的是哪个供应商，所有会话都可见。
+pub fn unify_all_codex_sessions_to_provider(target_provider_id: &str) -> UnifyResult {
+    let mut result = UnifyResult {
+        target: target_provider_id.to_string(),
+        jsonl_changed: 0,
+        jsonl_scanned: 0,
+        state_changed: 0,
+        errors: Vec::new(),
+    };
+
+    if target_provider_id.trim().is_empty() {
+        result.errors.push("target_provider_id 为空".to_string());
+        return result;
+    }
+
+    let codex_dir = get_codex_config_dir();
+    let target = target_provider_id.to_string();
+
+    // 改写 JSONL 会话文件
+    let mut jsonl_files = Vec::new();
+    collect_jsonl_files(&codex_dir.join("sessions"), &mut jsonl_files, 0, 8);
+    collect_jsonl_files(&codex_dir.join("archived_sessions"), &mut jsonl_files, 0, 4);
+    result.jsonl_scanned = jsonl_files.len();
+
+    for file_path in &jsonl_files {
+        match rewrite_codex_session_file_unify(file_path, &codex_dir, &target) {
+            Ok(true) => result.jsonl_changed += 1,
+            Ok(false) => {}
+            Err(e) => result.errors.push(format!(
+                "JSONL 改写失败 {}: {e}",
+                file_path.file_name().unwrap_or_default().to_string_lossy()
+            )),
+        }
+    }
+
+    // 改写 state DB
+    let config_text = read_codex_config_text().unwrap_or_default();
+    for db_path in codex_state_db_paths(&codex_dir, &config_text) {
+        match unify_codex_state_db(&db_path, &target) {
+            Ok(n) => result.state_changed += n,
+            Err(e) => result.errors.push(format!(
+                "State DB 改写失败 {}: {e}",
+                db_path.file_name().unwrap_or_default().to_string_lossy()
+            )),
+        }
+    }
+
+    log::info!(
+        "[UnifyHistory] 统一会话历史完成: target={target}, jsonl_scanned={}, jsonl_changed={}, state_rows={}, errors={}",
+        result.jsonl_scanned, result.jsonl_changed, result.state_changed, result.errors.len()
+    );
+
+    result
+}
+
+fn rewrite_codex_session_file_unify(
+    path: &Path,
+    _codex_dir: &Path,
+    target_provider_id: &str,
+) -> Result<bool, AppError> {
+    let content = fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
+    let mut rewritten = String::with_capacity(content.len());
+    let mut changed = false;
+
+    for segment in content.split_inclusive('\n') {
+        let (line, newline) = segment
+            .strip_suffix('\n')
+            .map(|line| (line, "\n"))
+            .unwrap_or((segment, ""));
+
+        if line.contains("\"session_meta\"") && line.contains("\"model_provider\"") {
+            if let Ok(mut value) = serde_json::from_str::<Value>(line) {
+                if value.get("type").and_then(Value::as_str) == Some("session_meta") {
+                    if let Some(payload) = value.get_mut("payload").and_then(Value::as_object_mut) {
+                        let current = payload.get("model_provider").and_then(Value::as_str);
+                        if current.is_some() && current != Some(target_provider_id) {
+                            payload.insert(
+                                "model_provider".to_string(),
+                                Value::String(target_provider_id.to_string()),
+                            );
+                            if let Ok(new_line) = serde_json::to_string(&value) {
+                                rewritten.push_str(&new_line);
+                                rewritten.push_str(newline);
+                                changed = true;
+                                continue;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        rewritten.push_str(line);
+        rewritten.push_str(newline);
+    }
+
+    if changed {
+        atomic_write(path, rewritten.as_bytes())?;
+    }
+
+    Ok(changed)
+}
+
+fn unify_codex_state_db(db_path: &Path, target_provider_id: &str) -> Result<usize, AppError> {
+    if !db_path.exists() {
+        return Ok(0);
+    }
+
+    let conn = Connection::open(db_path)
+        .map_err(|e| AppError::Database(format!("打开 Codex state DB 失败: {e}")))?;
+    conn.busy_timeout(Duration::from_secs(5))
+        .map_err(|e| AppError::Database(format!("设置 Codex state DB busy_timeout 失败: {e}")))?;
+
+    // 强制 WAL checkpoint，确保 Codex 正在运行时 WAL 中的数据也被合并到主库
+    let _ = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)", []);
+
+    if !Database::table_exists(&conn, "threads")?
+        || !Database::has_column(&conn, "threads", "model_provider")?
+    {
+        return Ok(0);
+    }
+
+    let changed = conn.execute(
+        "UPDATE threads SET model_provider = ? WHERE model_provider != ?",
+        rusqlite::params![target_provider_id, target_provider_id],
+    )?;
+    Ok(changed)
 }

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -541,6 +541,13 @@ pub struct ProviderMeta {
     /// 用于多账号支持，关联到特定的 GitHub 账号
     #[serde(rename = "githubAccountId", skip_serializing_if = "Option::is_none")]
     pub github_account_id: Option<String>,
+    /// 切换到此供应商时，将所有 Codex 会话历史的 model_provider 统一改写为当前供应商。
+    /// 启用后切换供应商重启 Codex 即可看到全部历史会话。
+    #[serde(
+        rename = "unifySessionHistory",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub unify_session_history: Option<bool>,
 }
 
 /// 解析 Provider 级自定义 User-Agent 字符串（单一真理来源）。

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -113,6 +113,9 @@ pub struct ProviderService;
 #[serde(rename_all = "camelCase")]
 pub struct SwitchResult {
     pub warnings: Vec<String>,
+    /// 统一会话历史改写结果（仅 Codex 供应商启用 unifySessionHistory 时非空）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unify_history: Option<crate::codex_history_migration::UnifyResult>,
 }
 
 #[cfg(test)]
@@ -2819,6 +2822,39 @@ impl ProviderService {
                     );
                 }
             }
+
+            // 供应商级"统一会话历史"：编辑当前 Codex 供应商并启用此选项时，
+            // 也需要触发统一改写（覆盖"已在该供应商上、仅编辑配置"的场景）。
+            if matches!(app_type, AppType::Codex) {
+                if let Some(true) = provider.meta.as_ref().and_then(|m| m.unify_session_history) {
+                    let target_id = crate::codex_config::read_codex_config_text()
+                        .ok()
+                        .and_then(|text| {
+                            text.parse::<toml_edit::DocumentMut>().ok().and_then(|doc| {
+                                doc.get("model_provider")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.trim().to_string())
+                                    .filter(|s| !s.is_empty())
+                            })
+                        })
+                        .unwrap_or_else(|| "openai".to_string());
+
+                    log::info!(
+                        "[Update] 供应商 '{}' 启用了统一会话历史（编辑触发），目标 provider: {target_id}",
+                        provider.id
+                    );
+                    let unify =
+                        crate::codex_history_migration::unify_all_codex_sessions_to_provider(
+                            &target_id,
+                        );
+                    if !unify.errors.is_empty() {
+                        log::warn!(
+                            "[Update] 统一会话历史部分失败: errors={}",
+                            unify.errors.join("; ")
+                        );
+                    }
+                }
+            }
         }
 
         Ok(true)
@@ -3045,9 +3081,41 @@ impl ProviderService {
             )
             .map_err(|e| AppError::Message(format!("热切换失败: {e}")))?;
 
+            // 供应商级"统一会话历史"：代理接管热切换路径也需要触发
+            let mut result = SwitchResult::default();
+            if matches!(app_type, AppType::Codex) {
+                let provider = providers.get(id);
+                if let Some(true) = provider
+                    .and_then(|p| p.meta.as_ref())
+                    .and_then(|m| m.unify_session_history)
+                {
+                    let target_id = crate::codex_config::read_codex_config_text()
+                        .ok()
+                        .and_then(|text| {
+                            text.parse::<toml_edit::DocumentMut>().ok().and_then(|doc| {
+                                doc.get("model_provider")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.trim().to_string())
+                                    .filter(|s| !s.is_empty())
+                            })
+                        })
+                        .unwrap_or_else(|| "openai".to_string());
+
+                    log::info!(
+                        "[HotSwitch] 供应商 '{}' 启用了统一会话历史，目标 provider: {target_id}",
+                        id
+                    );
+                    let unify =
+                        crate::codex_history_migration::unify_all_codex_sessions_to_provider(
+                            &target_id,
+                        );
+                    result.unify_history = Some(unify);
+                }
+            }
+
             // The proxy server will route requests to the new provider via is_current.
             // MCP sync is intentionally skipped while Live config is owned by takeover.
-            return Ok(SwitchResult::default());
+            return Ok(result);
         }
 
         // Normal mode: full switch with Live config write
@@ -3166,6 +3234,33 @@ impl ProviderService {
                 ),
                 Ok(false) => {}
                 Err(e) => log::warn!("Failed to clean stale Codex auth.json: {e}"),
+            }
+        }
+
+        // 供应商级"统一会话历史"：切换到启用了此选项的 Codex 供应商后，
+        // 将所有历史会话的 model_provider 统一改写为当前供应商的 provider ID。
+        if matches!(app_type, AppType::Codex) {
+            if let Some(true) = provider.meta.as_ref().and_then(|m| m.unify_session_history) {
+                let target_id = crate::codex_config::read_codex_config_text()
+                    .ok()
+                    .and_then(|text| {
+                        text.parse::<toml_edit::DocumentMut>().ok().and_then(|doc| {
+                            doc.get("model_provider")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                        })
+                    })
+                    .unwrap_or_else(|| "openai".to_string());
+
+                log::info!(
+                    "[Switch] 供应商 '{}' 启用了统一会话历史，目标 provider: {target_id}",
+                    provider.id
+                );
+                let unify = crate::codex_history_migration::unify_all_codex_sessions_to_provider(
+                    &target_id,
+                );
+                result.unify_history = Some(unify);
             }
         }
 

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -21,6 +21,7 @@ import {
   ChevronDown,
   ChevronRight,
   Download,
+  History,
   Loader2,
   Plus,
   Trash2,
@@ -36,6 +37,7 @@ import {
 } from "@/lib/api/model-fetch";
 import { CustomUserAgentField } from "./CustomUserAgentField";
 import { LocalProxyRequestOverridesField } from "./LocalProxyRequestOverridesField";
+import { ToggleRow } from "@/components/ui/toggle-row";
 import { cn } from "@/lib/utils";
 import type {
   ClaudeApiKeyField,
@@ -116,6 +118,10 @@ interface CodexFormFieldsProps {
   onLocalProxyHeadersOverrideChange: (value: string) => void;
   localProxyBodyOverride: string;
   onLocalProxyBodyOverrideChange: (value: string) => void;
+
+  // Unify session history on switch
+  unifySessionHistory: boolean;
+  onUnifySessionHistoryChange: (value: boolean) => void;
 }
 
 type CodexCatalogRow = CodexCatalogModel & { rowId: string };
@@ -210,6 +216,8 @@ export function CodexFormFields({
   onLocalProxyHeadersOverrideChange,
   localProxyBodyOverride,
   onLocalProxyBodyOverrideChange,
+  unifySessionHistory,
+  onUnifySessionHistoryChange,
 }: CodexFormFieldsProps) {
   const { t } = useTranslation();
 
@@ -1079,6 +1087,23 @@ export function CodexFormFields({
                   bodyJson={localProxyBodyOverride}
                   onHeadersJsonChange={onLocalProxyHeadersOverrideChange}
                   onBodyJsonChange={onLocalProxyBodyOverrideChange}
+                />
+              </div>
+              <div className="border-t border-border-default pt-3">
+                <ToggleRow
+                  icon={<History className="h-4 w-4 text-sky-500" />}
+                  title={t("providerForm.unifySessionHistory", {
+                    defaultValue: "统一会话历史",
+                  })}
+                  description={t(
+                    "providerForm.unifySessionHistoryDescription",
+                    {
+                      defaultValue:
+                        "切换到此供应商时，将所有历史会话的 provider 统一为当前供应商，重启 Codex 后可看到全部会话。",
+                    },
+                  )}
+                  checked={unifySessionHistory}
+                  onCheckedChange={onUnifySessionHistoryChange}
                 />
               </div>
             </div>

--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -157,6 +157,9 @@ export function GrokBuildProviderForm({
   const [endpointAutoSelect, setEndpointAutoSelect] = useState(
     initialData?.meta?.endpointAutoSelect ?? true,
   );
+  const [unifySessionHistory, setUnifySessionHistory] = useState<boolean>(
+    initialData?.meta?.unifySessionHistory ?? false,
+  );
   const [isEndpointModalOpen, setIsEndpointModalOpen] = useState(false);
   const [presetEndpoints, setPresetEndpoints] = useState<string[]>([]);
   const [draftCustomEndpoints, setDraftCustomEndpoints] = useState<string[]>(
@@ -403,6 +406,7 @@ export function GrokBuildProviderForm({
       impersonateClaudeCode,
       promptCacheRouting,
       codexChatReasoning,
+      unifySessionHistory,
       customUserAgent: customUserAgent.trim() || undefined,
       localProxyRequestOverrides: requestOverrides.overrides,
       maxOutputTokens:
@@ -555,6 +559,8 @@ export function GrokBuildProviderForm({
               onCodexChatReasoningChange={setCodexChatReasoning}
               promptCacheRouting={promptCacheRouting}
               onPromptCacheRoutingChange={setPromptCacheRouting}
+              unifySessionHistory={unifySessionHistory}
+              onUnifySessionHistoryChange={setUnifySessionHistory}
               speedTestEndpoints={speedTestEndpoints}
               customUserAgent={customUserAgent}
               onCustomUserAgentChange={setCustomUserAgent}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -365,6 +365,7 @@ function ProviderFormFull({
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
     setPromptCacheRouting(initialData?.meta?.promptCacheRouting ?? "auto");
     setCustomUserAgent(initialData?.meta?.customUserAgent ?? "");
+    setUnifySessionHistory(initialData?.meta?.unifySessionHistory ?? false);
     setLocalProxyHeadersOverride(
       formatRequestOverrideObject(
         initialData?.meta?.localProxyRequestOverrides?.headers,
@@ -554,6 +555,9 @@ function ProviderFormFull({
     );
   const [customUserAgent, setCustomUserAgent] = useState<string>(
     () => initialData?.meta?.customUserAgent ?? "",
+  );
+  const [unifySessionHistory, setUnifySessionHistory] = useState<boolean>(
+    () => initialData?.meta?.unifySessionHistory ?? false,
   );
   const [localProxyHeadersOverride, setLocalProxyHeadersOverride] =
     useState<string>(() =>
@@ -1599,6 +1603,7 @@ function ProviderFormFull({
         (appId === "claude" || appId === "codex") && category !== "official"
           ? customUserAgent.trim() || undefined
           : undefined,
+      unifySessionHistory: appId === "codex" ? unifySessionHistory : undefined,
       localProxyRequestOverrides: shouldApplyLocalProxyRequestOverrides
         ? overridesResult.overrides
         : undefined,
@@ -1658,6 +1663,9 @@ function ProviderFormFull({
 
     if (!isCodexOauthProvider && "codexFastMode" in nextMeta) {
       delete nextMeta.codexFastMode;
+    }
+    if (appId !== "codex" && "unifySessionHistory" in nextMeta) {
+      delete nextMeta.unifySessionHistory;
     }
 
     payload.meta = nextMeta;
@@ -2328,6 +2336,8 @@ function ProviderFormFull({
               onLocalProxyHeadersOverrideChange={setLocalProxyHeadersOverride}
               localProxyBodyOverride={localProxyBodyOverride}
               onLocalProxyBodyOverrideChange={setLocalProxyBodyOverride}
+              unifySessionHistory={unifySessionHistory}
+              onUnifySessionHistoryChange={setUnifySessionHistory}
             />
           )}
 

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -290,15 +290,87 @@ export function useProviderActions(
         const result = await switchProviderMutation.mutateAsync(provider.id);
         await syncClaudePlugin(provider);
 
-        // Show backfill warning if present
+        // 处理 warnings：区分 backfill 和统一会话历史
         if (result?.warnings?.length) {
-          toast.warning(
-            t("notifications.backfillWarning", {
-              defaultValue:
-                "切换成功，但旧供应商配置回填失败，您手动修改的配置可能未保存",
-            }),
-            { duration: 5000 },
+          const backfillWarnings = result.warnings.filter(
+            (w) => !w.startsWith("unify_session_history:"),
           );
+          if (backfillWarnings.length) {
+            toast.warning(
+              t("notifications.backfillWarning", {
+                defaultValue:
+                  "切换成功，但旧供应商配置回填失败，您手动修改的配置可能未保存",
+              }),
+              { duration: 5000 },
+            );
+          }
+        }
+
+        // 统一会话历史反馈
+        if (result?.unifyHistory) {
+          const h = result.unifyHistory;
+          if (h.errors.length === 0) {
+            toast.success(
+              t("notifications.unifyHistoryDone", {
+                defaultValue: "统一会话历史完成",
+              }),
+              {
+                description: t("notifications.unifyHistoryDetail", {
+                  defaultValue:
+                    "已将 {{state}} 条记录和 {{jsonl}} 个文件的 provider 改写为 {{target}}，重启 Codex 后生效。",
+                  target: h.target,
+                  state: String(h.stateChanged),
+                  jsonl: String(h.jsonlChanged),
+                }),
+                duration: 5000,
+              },
+            );
+          } else if (h.stateChanged > 0 || h.jsonlChanged > 0) {
+            toast.warning(
+              t("notifications.unifyHistoryPartial", {
+                defaultValue: "统一会话历史部分成功",
+              }),
+              {
+                description: t("notifications.unifyHistoryPartialDetail", {
+                  defaultValue:
+                    "已改写 {{state}} 条记录、{{jsonl}} 个文件，但有 {{errors}} 个文件失败：{{detail}}",
+                  state: String(h.stateChanged),
+                  jsonl: String(h.jsonlChanged),
+                  errors: String(h.errors.length),
+                  detail: h.errors.slice(0, 3).join("; "),
+                }),
+                duration: 8000,
+                closeButton: true,
+                action: {
+                  label: t("common.copy", { defaultValue: "复制" }),
+                  onClick: () => {
+                    navigator.clipboard
+                      ?.writeText(h.errors.join("\n"))
+                      .catch(() => undefined);
+                  },
+                },
+              },
+            );
+          } else {
+            toast.error(
+              t("notifications.unifyHistoryFailed", {
+                defaultValue: "统一会话历史失败",
+              }),
+              {
+                description: h.errors.slice(0, 3).join("; "),
+                duration: 8000,
+                closeButton: true,
+                action: {
+                  label: t("common.copy", { defaultValue: "复制" }),
+                  onClick: () => {
+                    navigator.clipboard
+                      ?.writeText(h.errors.join("\n"))
+                      .catch(() => undefined);
+                  },
+                },
+              },
+            );
+          }
         }
 
         // 若已弹过 proxyRequired 警告则不再弹 success

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1007,6 +1007,8 @@
   },
   "providerForm": {
     "supplierName": "Provider Name",
+    "unifySessionHistory": "Unify Session History",
+    "unifySessionHistoryDescription": "When switching to this provider, all session history will be unified to the current provider. After restarting Codex, all sessions will be visible.",
     "supplierNameRequired": "Provider Name *",
     "supplierNamePlaceholder": "e.g., Anthropic Official",
     "websiteUrl": "Website URL",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1007,6 +1007,8 @@
   },
   "providerForm": {
     "supplierName": "供应商名称",
+    "unifySessionHistory": "统一会话历史",
+    "unifySessionHistoryDescription": "切换到此供应商时，将所有历史会话的 provider 统一为当前供应商，重启 Codex 后可看到全部会话。",
     "supplierNameRequired": "供应商名称 *",
     "supplierNamePlaceholder": "例如：Anthropic 官方",
     "websiteUrl": "官网地址",

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -17,8 +17,17 @@ export interface ProviderSwitchEvent {
   providerId: string;
 }
 
+export interface UnifyHistoryResult {
+  target: string;
+  jsonlChanged: number;
+  jsonlScanned: number;
+  stateChanged: number;
+  errors: string[];
+}
+
 export interface SwitchResult {
   warnings: string[];
+  unifyHistory?: UnifyHistoryResult;
 }
 
 export interface OpenTerminalOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,6 +231,8 @@ export interface ProviderMeta {
   providerType?: string;
   // GitHub Copilot 关联账号 ID（旧字段，保留兼容读取）
   githubAccountId?: string;
+  // 切换到此供应商时统一所有 Codex 会话历史的 model_provider
+  unifySessionHistory?: boolean;
 }
 
 // Skill 同步方式


### PR DESCRIPTION
## Summary / 概述

在 Codex 供应商配置中增加"统一会话历史"开关。启用后，切换到该供应商时自动将所有历史会话的 `model_provider` 统一改写为当前值，用户无需开全局统一开关即可看到全部历史会话。

## 使用场景

- 从官方 OpenAI provider 切到第三方 provider 后想看到原有会话
- 多个第三方 provider 频繁切换，每个独立控制是否统一
- 代理接管模式下热切换也能触发

## 改动

| 层 | 文件 | 说明 |
|---|------|------|
| 后端 | `provider.rs` | ProviderMeta 增加 `unifySessionHistory` |
| 后端 | `codex_history_migration.rs` | `unify_all_codex_sessions_to_provider()` 改写 JSONL + state DB，带 WAL checkpoint |
| 后端 | `services/provider/mod.rs` | `switch_normal` / `hot_switch` / `update` 三处触发；`SwitchResult` 增加结构化 `unifyHistory` |
| 前端 | `types.ts` / `providers.ts` | 类型同步 |
| 前端 | `CodexFormFields.tsx` / `ProviderForm.tsx` | 高级选项区 ToggleRow |
| 前端 | `useProviderActions.ts` | 三态 toast（成功/部分失败/全部失败） |
| i18n | `zh.json` / `en.json` | 文案 |

## Checklist

- [x] `pnpm typecheck` passes
- [x] `cargo build` passes
- [ ] `pnpm format:check` passes (not run)
- [ ] Updated i18n files if user-facing text changed