### PR TITLE
fix(codex): preserve OAuth in Responses proxy mode

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1712,6 +1712,43 @@ pub fn update_codex_toml_field(toml_str: &str, field: &str, value: &str) -> Resu
     Ok(doc.to_string())
 }
 
+/// Update a boolean capability on the active Codex model provider.
+///
+/// Proxy takeover uses this for transport capabilities that describe the
+/// local proxy rather than the selected upstream. In particular, the local
+/// HTTP proxy does not implement the Responses WebSocket transport, so
+/// leaving an official provider's `supports_websockets = true` in the live
+/// config causes repeated 405 retries before Codex falls back to HTTP.
+pub fn update_codex_active_provider_bool_field(
+    toml_str: &str,
+    field: &str,
+    value: bool,
+) -> Result<String, String> {
+    let mut doc = toml_str
+        .parse::<DocumentMut>()
+        .map_err(|e| format!("TOML parse error: {e}"))?;
+    let provider_key = doc
+        .get("model_provider")
+        .and_then(|item| item.as_str())
+        .ok_or_else(|| "Codex config has no active model_provider".to_string())?
+        .to_string();
+
+    if doc.get("model_providers").is_none() {
+        doc["model_providers"] = toml_edit::table();
+    }
+    let providers = doc["model_providers"]
+        .as_table_mut()
+        .ok_or_else(|| "model_providers is not a TOML table".to_string())?;
+    if !providers.contains_key(&provider_key) {
+        providers[&provider_key] = toml_edit::table();
+    }
+    let provider = providers[&provider_key]
+        .as_table_mut()
+        .ok_or_else(|| format!("model_providers.{provider_key} is not a TOML table"))?;
+    provider[field] = toml_edit::value(value);
+    Ok(doc.to_string())
+}
+
 /// Remove `base_url` from the active model_provider section only if it matches `predicate`.
 /// Also removes top-level `base_url` if it matches.
 /// Used by proxy cleanup to strip local proxy URLs without touching user-configured URLs.

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -157,6 +157,22 @@ impl RequestForwarder {
         replaced_images
     }
 
+    fn strip_hosted_image_namespace_tools(body: &mut Value) -> usize {
+        let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
+            return 0;
+        };
+        let original_len = tools.len();
+        tools.retain(|tool| {
+            !(tool.get("type").and_then(Value::as_str) == Some("namespace")
+                && tool.get("name").and_then(Value::as_str) == Some("image_gen"))
+        });
+        let removed = original_len.saturating_sub(tools.len());
+        if removed > 0 {
+            log::debug!("[Codex] Removed {removed} hosted image_gen namespace tool(s)");
+        }
+        removed
+    }
+
     /// 反应式 media 重试判定：上游因图片输入报错后，是否应替换图片块并对同一供应商重试一次。
     ///
     /// 受 `enabled && request_media_fallback` 管辖；不涉及 `request_media_heuristic`——
@@ -1482,6 +1498,9 @@ impl RequestForwarder {
         };
 
         if matches!(app_type, AppType::Codex) {
+            if !super::providers::codex_provider_supports_hosted_namespaces(provider) {
+                Self::strip_hosted_image_namespace_tools(&mut request_body);
+            }
             self.apply_media_prevention(&mut request_body, provider);
         }
 
@@ -3299,6 +3318,26 @@ mod tests {
             serde_json::to_string(&prepared).unwrap(),
             r#"{"a":2,"tools":[{"name":"lookup","parameters":{"properties":{"_id":{"type":"string"},"a":{"type":"string"},"b":{"type":"number"}},"type":"object"}}],"z":1}"#
         );
+    }
+
+    #[test]
+    fn strip_hosted_image_namespace_tools_preserves_other_response_tools() {
+        let mut body = json!({
+            "tools": [
+                {
+                    "type": "namespace",
+                    "name": "image_gen",
+                    "tools": [{"type": "function", "name": "imagegen"}]
+                },
+                {"type": "function", "name": "shell_command"}
+            ]
+        });
+
+        let removed = RequestForwarder::strip_hosted_image_namespace_tools(&mut body);
+
+        assert_eq!(removed, 1);
+        assert_eq!(body["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(body["tools"][0]["name"], "shell_command");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -73,6 +73,42 @@ pub fn codex_provider_uses_chat_completions(provider: &Provider) -> bool {
         .unwrap_or(false)
 }
 
+/// Whether the upstream is an OpenAI-owned Responses endpoint that supports
+/// hosted namespace tools such as `image_gen` natively.
+///
+/// Third-party Responses relays may inject their own image tool when they see
+/// Codex's hosted namespace declaration, producing a duplicate-tool error.
+/// Keep the namespace for OpenAI API and ChatGPT OAuth traffic, and let the
+/// forwarder remove it only for non-OpenAI upstreams.
+pub fn codex_provider_supports_hosted_namespaces(provider: &Provider) -> bool {
+    if provider.is_codex_oauth() {
+        return true;
+    }
+
+    codex_provider_base_url(provider).is_some_and(|base_url| {
+        url::Url::parse(&base_url)
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
+            .is_some_and(|host| host == "api.openai.com")
+    })
+}
+
+fn codex_provider_base_url(provider: &Provider) -> Option<String> {
+    provider
+        .settings_config
+        .get("base_url")
+        .or_else(|| provider.settings_config.get("baseURL"))
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
+        .or_else(|| {
+            provider
+                .settings_config
+                .get("config")
+                .and_then(|value| value.as_str())
+                .and_then(extract_codex_base_url_from_toml)
+        })
+}
+
 pub fn should_convert_codex_responses_to_chat(provider: &Provider, endpoint: &str) -> bool {
     let path = endpoint
         .split_once('?')
@@ -715,6 +751,32 @@ mod tests {
 
         let url = adapter.extract_base_url(&provider).unwrap();
         assert_eq!(url, "https://api.openai.com/v1");
+    }
+
+    #[test]
+    fn hosted_namespaces_are_preserved_only_for_openai_upstreams() {
+        let openai = create_provider(json!({
+            "base_url": "https://api.openai.com/v1"
+        }));
+        let relay = create_provider(json!({
+            "base_url": "https://relay.example/v1"
+        }));
+
+        assert!(codex_provider_supports_hosted_namespaces(&openai));
+        assert!(!codex_provider_supports_hosted_namespaces(&relay));
+    }
+
+    #[test]
+    fn codex_oauth_preserves_hosted_namespaces() {
+        let mut provider = create_provider(json!({
+            "base_url": "https://chatgpt.com/backend-api/codex"
+        }));
+        provider.meta = Some(crate::provider::ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            ..Default::default()
+        });
+
+        assert!(codex_provider_supports_hosted_namespaces(&provider));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -50,7 +50,8 @@ pub use claude::{
 };
 pub use codex::CodexAdapter;
 pub use codex::{
-    apply_codex_chat_upstream_model, apply_codex_upstream_model, codex_provider_upstream_model,
+    apply_codex_chat_upstream_model, apply_codex_upstream_model,
+    codex_provider_supports_hosted_namespaces, codex_provider_upstream_model,
     resolve_codex_catalog_tool_profile, resolve_codex_chat_reasoning_config,
     should_convert_codex_responses_to_anthropic, should_convert_codex_responses_to_chat,
 };

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -42,6 +42,7 @@ const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
 const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
 const CUSTOM_TOOL_INPUT_DESCRIPTION: &str = "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description.";
 const CUSTOM_TOOL_PRESERVED_METADATA_HEADING: &str = "Original tool definition:";
+const HOSTED_IMAGE_NAMESPACE: &str = "image_gen";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodexToolKind {
@@ -198,6 +199,9 @@ impl CodexToolContext {
         let Some(namespace) = namespace_tool.get("name").and_then(|v| v.as_str()) else {
             return;
         };
+        if namespace == HOSTED_IMAGE_NAMESPACE {
+            return;
+        }
         let Some(children) = namespace_tool
             .get("tools")
             .or_else(|| namespace_tool.get("children"))
@@ -317,6 +321,10 @@ pub fn responses_to_chat_completions_with_reasoning(
         result["tool_choice"] = responses_tool_choice_to_chat(tool_choice, &tool_context);
     }
 
+    if let Some(response_format) = responses_text_format_to_chat_response_format(&body) {
+        result["response_format"] = response_format;
+    }
+
     for key in EXTRA_CHAT_PASSTHROUGH_FIELDS {
         if let Some(value) = body.get(*key) {
             result[*key] = value.clone();
@@ -344,6 +352,23 @@ pub fn responses_to_chat_completions_with_reasoning(
     super::transform::inject_openai_stream_include_usage(&mut result);
 
     Ok(result)
+}
+
+fn responses_text_format_to_chat_response_format(body: &Value) -> Option<Value> {
+    let format = body.pointer("/text/format")?.as_object()?;
+    match format.get("type").and_then(Value::as_str)? {
+        "json_schema" => {
+            let mut json_schema = format.clone();
+            json_schema.remove("type");
+            Some(json!({
+                "type": "json_schema",
+                "json_schema": json_schema
+            }))
+        }
+        "json_object" => Some(json!({ "type": "json_object" })),
+        "text" => Some(json!({ "type": "text" })),
+        _ => None,
+    }
 }
 
 fn apply_reasoning_options(
@@ -1753,6 +1778,56 @@ pub fn chat_error_to_response_error(body: Option<&Value>) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn responses_request_maps_text_json_schema_to_chat_response_format() {
+        let input = json!({
+            "model": "gpt-5.5",
+            "input": "Generate a thread title",
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "thread_title",
+                    "strict": true,
+                    "schema": {
+                        "type": "object",
+                        "properties": { "title": { "type": "string" } },
+                        "required": ["title"],
+                        "additionalProperties": false
+                    }
+                }
+            }
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+
+        assert_eq!(result["response_format"]["type"], "json_schema");
+        assert_eq!(
+            result["response_format"]["json_schema"]["name"],
+            "thread_title"
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_skips_hosted_image_namespace_tools() {
+        let input = json!({
+            "model": "gpt-5.5",
+            "tools": [{
+                "type": "namespace",
+                "name": "image_gen",
+                "tools": [{"type": "function", "name": "imagegen"}]
+            }],
+            "tool_choice": "auto",
+            "parallel_tool_calls": true,
+            "input": "Draw an image."
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+
+        assert!(result.get("tools").is_none());
+        assert!(result.get("tool_choice").is_none());
+        assert!(result.get("parallel_tool_calls").is_none());
+    }
 
     #[test]
     fn responses_request_with_stream_injects_include_usage() {

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2348,6 +2348,16 @@ impl ProxyService {
         let mut updated =
             crate::codex_config::update_codex_toml_field(&updated, "wire_api", "responses")
                 .unwrap_or(updated);
+        // The local proxy currently supports Responses over HTTP/SSE, not the
+        // WebSocket transport. Provider configs imported from official login
+        // can carry `supports_websockets = true`; disable it only in the live
+        // takeover projection to avoid five 405 retries before HTTP fallback.
+        updated = crate::codex_config::update_codex_active_provider_bool_field(
+            &updated,
+            "supports_websockets",
+            false,
+        )
+        .unwrap_or(updated);
 
         if let Some(upstream_model) =
             provider.and_then(crate::proxy::providers::codex_provider_upstream_model)
@@ -4269,6 +4279,7 @@ model = "gpt-5.1-codex"
 name = "Chat Only"
 base_url = "https://chat-only.example/v1"
 wire_api = "chat"
+supports_websockets = true
 "#;
 
         let proxy_url = "http://127.0.0.1:5000/v1";
@@ -4289,6 +4300,12 @@ wire_api = "chat"
         assert_eq!(
             provider.get("wire_api").and_then(|v| v.as_str()),
             Some("responses")
+        );
+        assert_eq!(
+            provider
+                .get("supports_websockets")
+                .and_then(|v| v.as_bool()),
+            Some(false)
         );
     }
 


### PR DESCRIPTION
﻿## What changed

- preserve the existing ChatGPT OAuth payload while Codex proxy takeover writes third-party routing credentials to the live provider config
- keep the local client-facing protocol on `wire_api = "responses"`
- disable only the local Responses WebSocket capability because the proxy currently serves Responses over HTTP/SSE, avoiding repeated 405 retries before HTTP fallback
- strip the hosted `image_gen` namespace only for non-OpenAI Codex upstreams that may inject a conflicting image tool
- preserve hosted namespaces for `api.openai.com` and Codex OAuth providers
- skip hosted `image_gen` when converting Responses tools to Chat Completions, since Chat cannot represent hosted namespace semantics safely
- map Responses `text.format` to Chat Completions `response_format` during protocol conversion

## Root cause

Recent Codex clients send a hosted namespace tool shaped like:

```json
{"type":"namespace","name":"image_gen","tools":[{"type":"function","name":"imagegen"}]}
```

Some third-party relays inject their own hosted image tool after seeing that declaration, producing a duplicate/conflicting-tool error. Disabling official-login preservation appeared to avoid the failure, but unnecessarily replaced the user's ChatGPT OAuth state.

The live proxy projection could also inherit `supports_websockets = true` from an official provider config even though CC Switch's local proxy serves Responses over HTTP/SSE.

## Review-driven scope corrections

After review, this PR intentionally does **not** rewrite `/responses/compact`, hard-code provider/model mappings, append local `compaction_trigger` items, or synthesize `encrypted_content`. Native standalone compaction remains a transparent upstream capability and unsupported providers return their real upstream error.

## Impact

Codex can retain ChatGPT OAuth login state while routing model traffic through a third-party Responses provider. Official OpenAI hosted image capabilities remain intact, while affected third-party relays no longer receive the conflicting hosted namespace declaration.

Fixes #5171

## Validation

Passed:

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff origin/main --check`
- hosted namespace policy tests: 2 passed
- `strip_hosted_image_namespace_tools_preserves_other_response_tools`
- `responses_request_to_chat_skips_hosted_image_namespace_tools`
- `responses_request_maps_text_json_schema_to_chat_response_format`
- `apply_codex_proxy_toml_config_forces_local_responses_wire_api`
- compact routing classification regression test

Full library run: 1,862 passed, 9 failed, 2 ignored. The nine failures are outside this diff: existing Windows updater expectation mismatches plus environment-sensitive SQLite/occupied proxy-port tests. All tests added or directly affected by this PR pass.

Windows integration evidence from the reported setup:

- real Codex request forwarded through `/v1/responses`
- `codex login status` remained `Logged in using ChatGPT`
- OAuth auth-file content hash remained unchanged
- no local WebSocket 405 retry was observed
