### PR TITLE
fix(deeplink): add explicit Codex model to generated catalog

### DIFF
--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -387,12 +387,13 @@ fn build_codex_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
         provider_display_name
     };
 
-    // Model name: use deeplink model or default
-    let model_name = request
+    // Model name: use a non-empty deeplink model or the existing default.
+    let explicit_model = request
         .model
         .as_deref()
-        .unwrap_or("gpt-5-codex")
-        .to_string();
+        .map(str::trim)
+        .filter(|model| !model.is_empty());
+    let model_name = explicit_model.unwrap_or("gpt-5-codex").to_string();
 
     // Endpoint: normalize trailing slashes (use primary endpoint only)
     let endpoint = get_primary_endpoint(request)
@@ -419,12 +420,23 @@ requires_openai_auth = true
 "#
     );
 
-    json!({
+    let mut settings = json!({
         "auth": {
             "OPENAI_API_KEY": request.api_key,
         },
         "config": config_toml
-    })
+    });
+
+    // Codex Desktop only exposes named custom models when a model catalog is
+    // present. Reuse the existing simplified catalog format so the regular
+    // provider switch path can generate cc-switch-model-catalog.json.
+    if let Some(model) = explicit_model {
+        settings["modelCatalog"] = json!({
+            "models": [{ "model": model }]
+        });
+    }
+
+    settings
 }
 
 /// Build Gemini settings configuration
@@ -934,6 +946,56 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("https://api.example.com/v1")
         );
+    }
+
+    #[test]
+    fn build_codex_settings_adds_explicit_model_to_catalog() {
+        let request = DeepLinkImportRequest {
+            resource: "provider".to_string(),
+            app: Some("codex".to_string()),
+            name: Some("Sol Relay".to_string()),
+            endpoint: Some("https://api.example.com/v1".to_string()),
+            api_key: Some("sk-test".to_string()),
+            model: Some("gpt-5.6-sol".to_string()),
+            ..Default::default()
+        };
+
+        let settings = build_codex_settings(&request);
+
+        assert_eq!(
+            settings.get("modelCatalog"),
+            Some(&json!({
+                "models": [{ "model": "gpt-5.6-sol" }]
+            }))
+        );
+        assert!(
+            settings.get("apiFormat").is_none(),
+            "adding a catalog must not change the provider API format"
+        );
+    }
+
+    #[test]
+    fn build_codex_settings_without_non_empty_model_keeps_default_without_catalog() {
+        for model in [None, Some(" \t\n".to_string())] {
+            let request = DeepLinkImportRequest {
+                resource: "provider".to_string(),
+                app: Some("codex".to_string()),
+                name: Some("Default Relay".to_string()),
+                endpoint: Some("https://api.example.com/v1".to_string()),
+                api_key: Some("sk-test".to_string()),
+                model,
+                ..Default::default()
+            };
+
+            let settings = build_codex_settings(&request);
+            let config_text = settings
+                .get("config")
+                .and_then(|value| value.as_str())
+                .expect("config text");
+
+            assert!(config_text.contains("model = \"gpt-5-codex\""));
+            assert!(settings.get("modelCatalog").is_none());
+        }
     }
 
     #[test]

--- a/src-tauri/tests/deeplink_import.rs
+++ b/src-tauri/tests/deeplink_import.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use cc_switch_lib::{import_provider_from_deeplink, parse_deeplink_url, AppState, Database};
+use cc_switch_lib::{
+    import_provider_from_deeplink, parse_deeplink_url, AppState, AppType, Database, Provider,
+    ProviderService,
+};
+use serde_json::json;
 
 #[path = "support.rs"]
 mod support;
@@ -43,19 +47,55 @@ fn deeplink_import_claude_provider_persists_to_db() {
 }
 
 #[test]
-fn deeplink_import_codex_provider_builds_auth_and_config() {
+fn deeplink_import_codex_provider_builds_auth_config_and_catalog() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();
     let _home = ensure_test_home();
 
-    let url = "ccswitch://v1/import?resource=provider&app=codex&name=DeepLink%20Codex&homepage=https%3A%2F%2Fopenai.example&endpoint=https%3A%2F%2Fapi.openai.example%2Fv1&apiKey=sk-test-codex-key&model=gpt-4o&icon=openai";
+    let url = "ccswitch://v1/import?resource=provider&app=codex&name=DeepLink%20Codex&homepage=https%3A%2F%2Fopenai.example&endpoint=https%3A%2F%2Fapi.openai.example%2Fv1&apiKey=sk-test-codex-key&model=gpt-5.6-sol&icon=openai&enabled=true";
     let request = parse_deeplink_url(url).expect("parse deeplink url");
 
     let db = Arc::new(Database::memory().expect("create memory db"));
     let state = AppState::new(db.clone());
 
+    let existing_provider = Provider::with_id(
+        "existing-codex".to_string(),
+        "Existing Codex".to_string(),
+        json!({
+            "auth": {"OPENAI_API_KEY": "sk-existing-codex-key"},
+            "config": r#"model_provider = "custom"
+model = "gpt-5.5"
+
+[model_providers.custom]
+name = "Existing Codex"
+base_url = "https://existing.openai.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+        }),
+        None,
+    );
+    ProviderService::add(&state, AppType::Codex, existing_provider, true)
+        .expect("add existing Codex provider");
+    ProviderService::switch(&state, AppType::Codex, "existing-codex")
+        .expect("activate existing Codex provider");
+    assert_eq!(
+        db.get_current_provider(AppType::Codex.as_str())
+            .expect("read initial current Codex provider")
+            .as_deref(),
+        Some("existing-codex")
+    );
+
     let provider_id = import_provider_from_deeplink(&state, request.clone())
         .expect("import provider from deeplink");
+
+    assert_eq!(
+        db.get_current_provider(AppType::Codex.as_str())
+            .expect("read current Codex provider after deeplink import")
+            .as_deref(),
+        Some(provider_id.as_str()),
+        "enabled=true should switch from the existing provider to the imported provider"
+    );
 
     let providers = db.get_all_providers("codex").expect("get providers");
     let provider = providers
@@ -65,6 +105,14 @@ fn deeplink_import_codex_provider_builds_auth_and_config() {
     assert_eq!(provider.name, request.name.clone().unwrap());
     assert_eq!(provider.website_url.as_deref(), request.homepage.as_deref());
     assert_eq!(provider.icon.as_deref(), Some("openai"));
+    assert!(
+        provider
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.api_format.as_deref())
+            .is_none(),
+        "deeplink model catalog generation must not change api_format"
+    );
     let auth_value = provider
         .settings_config
         .pointer("/auth/OPENAI_API_KEY")
@@ -80,7 +128,41 @@ fn deeplink_import_codex_provider_builds_auth_and_config() {
         "config.toml content should contain endpoint"
     );
     assert!(
-        config_text.contains("model = \"gpt-4o\""),
+        config_text.contains("model = \"gpt-5.6-sol\""),
         "config.toml content should contain model setting"
     );
+
+    assert_eq!(
+        provider
+            .settings_config
+            .pointer("/modelCatalog/models/0/model")
+            .and_then(|value| value.as_str()),
+        Some("gpt-5.6-sol"),
+        "the explicit deeplink model should be persisted as a catalog entry"
+    );
+
+    let live_config = std::fs::read_to_string(ensure_test_home().join(".codex/config.toml"))
+        .expect("read generated Codex config");
+    assert!(
+        live_config.contains("model_catalog_json = \"cc-switch-model-catalog.json\""),
+        "switching to the imported provider should point Codex at the generated catalog"
+    );
+    assert!(
+        live_config.contains("model = \"gpt-5.6-sol\""),
+        "live config should come from the imported provider"
+    );
+
+    let catalog_text = std::fs::read_to_string(
+        ensure_test_home().join(".codex/cc-switch-model-catalog.json"),
+    )
+    .expect("read generated Codex model catalog");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&catalog_text).expect("parse generated Codex model catalog");
+    let generated_models = catalog["models"]
+        .as_array()
+        .expect("generated catalog models array");
+    assert_eq!(generated_models.len(), 1);
+    let generated_model = &generated_models[0];
+    assert_eq!(generated_model["slug"], "gpt-5.6-sol");
+    assert_eq!(generated_model["display_name"], "gpt-5.6-sol");
 }


### PR DESCRIPTION
## Summary / 概述

- add an explicit Codex deeplink model to the provider's simplified `modelCatalog`
- keep the existing `gpt-5-codex` fallback and omit the catalog when no non-empty model is supplied
- verify that `enabled=true` switches from an existing provider and writes the generated catalog used by Codex Desktop
- keep `api_format` unchanged and avoid hard-coding any GPT-5.6 model name in production code

This lets custom providers imported with `model=gpt-5.6-sol` appear as a named Codex Desktop model instead of only as `Custom`.

## Related Issue / 关联 Issue

Related to #5170

## Screenshots / 截图

Not applicable; this changes the Codex deeplink import and generated model catalog path.

## Verification / 验证

- `git diff --check`
- added unit coverage for explicit, missing, and whitespace-only Codex models
- added integration coverage for provider switching, persisted catalog settings, live `config.toml`, and generated catalog JSON
- local Rust execution was unavailable because this machine does not currently have Cargo; the new Rust tests and clippy are left for PR CI

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查 (no frontend changes)
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本（本 PR 无用户可见文本变更）
