### PR TITLE
fix(ui): reset provider scroll when switching apps

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -244,9 +244,25 @@ function App() {
   const effectiveUsageProvider = useLastValidValue(usageProvider);
 
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const mainScrollRef = useRef<HTMLElement>(null);
+  const providerScrollContainerRef = useRef<HTMLDivElement>(null);
   const isToolbarCompact = useAutoCompact(toolbarRef);
 
   useUsageCacheBridge();
+
+  useEffect(() => {
+    if (currentView !== "providers") return;
+
+    if (mainScrollRef.current) {
+      mainScrollRef.current.scrollTop = 0;
+      mainScrollRef.current.scrollLeft = 0;
+    }
+
+    if (providerScrollContainerRef.current) {
+      providerScrollContainerRef.current.scrollTop = 0;
+      providerScrollContainerRef.current.scrollLeft = 0;
+    }
+  }, [activeApp, currentView]);
 
   const promptPanelRef = useRef<any>(null);
   const mcpPanelRef = useRef<any>(null);
@@ -965,7 +981,10 @@ function App() {
         default:
           return (
             <div className="px-6 flex flex-col flex-1 min-h-0 overflow-hidden">
-              <div className="flex-1 overflow-y-auto overflow-x-hidden pb-12 px-1">
+              <div
+                ref={providerScrollContainerRef}
+                className="flex-1 overflow-y-auto overflow-x-hidden pb-12 px-1"
+              >
                 <AnimatePresence mode="wait">
                   <motion.div
                     key={activeApp}
@@ -1035,7 +1054,7 @@ function App() {
       <AnimatePresence mode="wait">
         <motion.div
           key={currentView}
-          className="flex-1 min-h-0"
+          className="flex flex-1 min-h-0 flex-col"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -1570,7 +1589,10 @@ function App() {
         </div>
       </header>
 
-      <main className="flex-1 min-h-0 flex flex-col overflow-y-auto animate-fade-in">
+      <main
+        ref={mainScrollRef}
+        className="flex-1 min-h-0 flex flex-col overflow-y-auto animate-fade-in"
+      >
         {isOpenClawView && openclawHealthWarnings.length > 0 && (
           <OpenClawHealthBanner warnings={openclawHealthWarnings} />
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
@@ -256,8 +256,24 @@ function App() {
 
   const effectiveEditingProvider = useLastValidValue(editingProvider);
   const effectiveUsageProvider = useLastValidValue(usageProvider);
+  const mainScrollRef = useRef<HTMLElement>(null);
+  const providerScrollContainerRef = useRef<HTMLDivElement>(null);
 
   useUsageCacheBridge();
+
+  useLayoutEffect(() => {
+    if (currentView !== "providers") return;
+
+    for (const container of [
+      mainScrollRef.current,
+      providerScrollContainerRef.current,
+    ]) {
+      if (container) {
+        container.scrollTop = 0;
+        container.scrollLeft = 0;
+      }
+    }
+  }, [activeApp, currentView]);
 
   const promptPanelRef = useRef<PromptPanelHandle>(null);
   const [promptPrimaryAction, setPromptPrimaryAction] =
@@ -1090,7 +1106,10 @@ function App() {
         default:
           return (
             <div className="px-6 flex flex-col flex-1 min-h-0 overflow-hidden">
-              <div className="flex-1 overflow-y-auto overflow-x-hidden pb-12 px-1">
+              <div
+                ref={providerScrollContainerRef}
+                className="flex-1 overflow-y-auto overflow-x-hidden pb-12 px-1"
+              >
                 <AnimatePresence mode="wait">
                   <motion.div
                     key={activeApp}
@@ -1165,7 +1184,7 @@ function App() {
       <AnimatePresence mode="wait">
         <motion.div
           key={currentView}
-          className="flex-1 min-h-0"
+          className="flex flex-1 min-h-0 flex-col"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -1745,7 +1764,10 @@ function App() {
         </div>
       </header>
 
-      <main className="flex-1 min-h-0 flex flex-col overflow-y-auto animate-fade-in">
+      <main
+        ref={mainScrollRef}
+        className="flex-1 min-h-0 flex flex-col overflow-y-auto animate-fade-in"
+      >
         {isOpenClawView && openclawHealthWarnings.length > 0 && (
           <OpenClawHealthBanner warnings={openclawHealthWarnings} />
         )}

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -220,6 +220,48 @@ describe("App integration with MSW", () => {
     expect(toastSuccessMock).toHaveBeenCalled();
   });
 
+  it("resets provider view scroll when switching apps", async () => {
+    const { default: App } = await import("@/App");
+    const { container } = renderApp(App);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-list").textContent).toContain(
+        "claude-1",
+      ),
+    );
+
+    const mainScrollContainer = container.querySelector("main") as HTMLElement;
+    const providerScrollContainer = Array.from(
+      container.querySelectorAll<HTMLElement>(".overflow-y-auto"),
+    ).find(
+      (element) =>
+        element !== mainScrollContainer && element.className.includes("pb-12"),
+    );
+
+    expect(mainScrollContainer).not.toBeNull();
+    expect(providerScrollContainer).toBeDefined();
+
+    mainScrollContainer.scrollTop = 320;
+    mainScrollContainer.scrollLeft = 12;
+    providerScrollContainer!.scrollTop = 640;
+    providerScrollContainer!.scrollLeft = 24;
+
+    fireEvent.click(screen.getByText("switch-codex"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-list").textContent).toContain(
+        "codex-1",
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mainScrollContainer.scrollTop).toBe(0);
+      expect(mainScrollContainer.scrollLeft).toBe(0);
+      expect(providerScrollContainer!.scrollTop).toBe(0);
+      expect(providerScrollContainer!.scrollLeft).toBe(0);
+    });
+  });
+
   it("shows toast when auto sync fails in background", async () => {
     const { default: App } = await import("@/App");
     renderApp(App);

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -265,6 +265,46 @@ describe("App integration with MSW", () => {
     expect(toastSuccessMock).toHaveBeenCalled();
   }, 10_000);
 
+  it("resets provider view scroll when switching apps", async () => {
+    const { default: App } = await import("@/App");
+    const { container } = renderApp(App);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-list").textContent).toContain(
+        "claude-1",
+      ),
+    );
+
+    const mainScrollContainer = container.querySelector("main") as HTMLElement;
+    const providerScrollContainer = Array.from(
+      container.querySelectorAll<HTMLElement>(".overflow-y-auto"),
+    ).find(
+      (element) =>
+        element !== mainScrollContainer && element.className.includes("pb-12"),
+    );
+
+    expect(mainScrollContainer).not.toBeNull();
+    expect(providerScrollContainer).toBeDefined();
+
+    mainScrollContainer.scrollTop = 320;
+    mainScrollContainer.scrollLeft = 12;
+    providerScrollContainer!.scrollTop = 640;
+    providerScrollContainer!.scrollLeft = 24;
+
+    fireEvent.click(screen.getByText("switch-codex"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-list").textContent).toContain(
+        "codex-1",
+      ),
+    );
+
+    expect(mainScrollContainer.scrollTop).toBe(0);
+    expect(mainScrollContainer.scrollLeft).toBe(0);
+    expect(providerScrollContainer!.scrollTop).toBe(0);
+    expect(providerScrollContainer!.scrollLeft).toBe(0);
+  }, 10_000);
+
   it("shows toast when auto sync fails in background", async () => {
     const { default: App } = await import("@/App");
     renderApp(App);


### PR DESCRIPTION
## Summary / 概述

Reapply the provider scroll reset fix from #4397 on the latest `main` branch.

- Reset both the outer page scroll container and the provider-list scroll container before paint when the active app changes while the provider view is open.
- Keep the animated view wrapper in the flex layout chain so the provider list remains the intended scroll container.
- Add an integration regression test that scrolls both containers, switches apps, and verifies both axes return to the top-left.

## Root cause / 根因

The provider view reuses its parent scroll containers when switching apps. Only the animated provider content changes, so the previous app's `scrollTop` and `scrollLeft` values were retained. If the previous provider list was scrolled far enough, the next app could appear empty.

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| <img width="1217" height="1125" alt="image" src="https://github.com/user-attachments/assets/85c73376-518f-4efa-9991-0d67177684e7" /> | <img width="1217" height="1125" alt="image" src="https://github.com/user-attachments/assets/abb0149e-fb11-4def-8e16-f0c33bbe18da" /> |
| 当你有很多个提供商，超过一页的范围时，翻到某一个提供商底部后，无法查看其他提供商 | 可以查看其他提供商 |

## User impact / 用户影响

Switching to another app from a scrolled provider list now starts at the top, so its providers are immediately visible.

## Related PR / 关联 PR

Supersedes #4397, which is now closed.

## Validation / 验证

- [x] Reproduced on the latest `main`: the regression test failed with `scrollTop` remaining at `320`
- [x] TypeScript typecheck (`pnpm typecheck`)
- [x] Prettier check (`pnpm format:check`)
- [x] Targeted provider scroll regression test
- [x] Full unit suite in serial mode: 135 files, 1075 tests passed
- [x] `cargo clippy` not applicable; no Rust changes
- [x] i18n updates not applicable; no user-facing text changes
