### PR TITLE
fix: map OpenAI token limit parameters by API and model

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -54,6 +54,25 @@ pub fn is_openai_o_series(model: &str) -> bool {
         && model.as_bytes().get(1).is_some_and(|b| b.is_ascii_digit())
 }
 
+/// Detect Chat Completions models that require `max_completion_tokens` instead
+/// of the legacy `max_tokens` parameter.
+///
+/// GPT-5+ (including `chat-latest`) and the o-series use the new field. GPT-4o,
+/// GPT-4.1, GPT-4, and
+/// GPT-3.5 retain `max_tokens` compatibility in the Chat Completions protocol.
+pub fn requires_openai_max_completion_tokens(model: &str) -> bool {
+    let normalized = model.trim().to_ascii_lowercase();
+    if is_openai_o_series(&normalized) || normalized == "chat-latest" {
+        return true;
+    }
+
+    normalized
+        .strip_prefix("gpt-")
+        .and_then(|rest| rest.split(|c| c == '.' || c == '-').next())
+        .and_then(|major| major.parse::<u32>().ok())
+        .is_some_and(|major| major >= 5)
+}
+
 /// Detect OpenAI models that support reasoning_effort.
 ///
 /// Supported families:
@@ -171,10 +190,11 @@ pub fn anthropic_to_openai_with_reasoning_content(
     normalize_openai_system_messages(&mut messages);
     result["messages"] = json!(messages);
 
-    // 转换参数 — o-series 模型需要 max_completion_tokens
+    // 转换参数 — GPT-5+（含 chat-latest）与 o-series Chat Completions 模型使用
+    // max_completion_tokens；GPT-4o/4.1/4/3.5 保持 max_tokens 兼容。
     let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
     if let Some(v) = body.get("max_tokens") {
-        if is_openai_o_series(model) {
+        if requires_openai_max_completion_tokens(model) {
             result["max_completion_tokens"] = v.clone();
         } else {
             result["max_tokens"] = v.clone();
@@ -721,6 +741,36 @@ mod tests {
         assert_eq!(result["max_tokens"], 1024);
         assert_eq!(result["messages"][0]["role"], "user");
         assert_eq!(result["messages"][0]["content"], "Hello");
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_gpt5_uses_max_completion_tokens() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+
+        assert_eq!(result["max_completion_tokens"], 1024);
+        assert!(result.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_gpt4_chat_models_keep_max_tokens() {
+        for model in ["gpt-4.1", "gpt-4o", "gpt-4", "gpt-3.5-turbo"] {
+            let input = json!({
+                "model": model,
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "Hello"}]
+            });
+
+            let result = anthropic_to_openai(input).unwrap();
+
+            assert_eq!(result["max_tokens"], 1024, "{model}");
+            assert!(result.get("max_completion_tokens").is_none(), "{model}");
+        }
     }
 
     #[test]
@@ -1470,6 +1520,20 @@ mod tests {
         assert!(!is_openai_o_series("openai-gpt"));
         assert!(!is_openai_o_series("o"));
         assert!(!is_openai_o_series(""));
+    }
+
+    #[test]
+    fn test_requires_openai_max_completion_tokens() {
+        assert!(requires_openai_max_completion_tokens("o3-mini"));
+        assert!(requires_openai_max_completion_tokens("gpt-5"));
+        assert!(requires_openai_max_completion_tokens("gpt-5.4"));
+        assert!(requires_openai_max_completion_tokens("chat-latest"));
+        assert!(requires_openai_max_completion_tokens("GPT-10-preview"));
+        assert!(!requires_openai_max_completion_tokens("gpt-4.1"));
+        assert!(!requires_openai_max_completion_tokens("gpt-4o"));
+        assert!(!requires_openai_max_completion_tokens("gpt-4"));
+        assert!(!requires_openai_max_completion_tokens("gpt-3.5-turbo"));
+        assert!(!requires_openai_max_completion_tokens("kimi-k2.5"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -86,9 +86,14 @@ pub fn anthropic_to_responses(
         result["input"] = json!(input);
     }
 
-    // max_tokens → max_output_tokens (Responses API uses max_output_tokens for all models)
+    // max_tokens → max_output_tokens (Responses API uses max_output_tokens for all models).
+    // Claude Desktop sends `max_tokens: 1` when probing a mapped model, but the
+    // OpenAI-compatible Responses API requires max_output_tokens >= 16.
     if let Some(v) = body.get("max_tokens") {
-        result["max_output_tokens"] = v.clone();
+        result["max_output_tokens"] = v
+            .as_u64()
+            .map(|value| json!(value.max(16)))
+            .unwrap_or_else(|| v.clone());
     }
 
     // 直接透传的参数
@@ -643,6 +648,19 @@ mod tests {
         assert_eq!(result["input"][0]["content"][0]["text"], "Hello");
         // stop_sequences should not appear
         assert!(result.get("stop_sequences").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_clamps_probe_max_tokens_to_api_minimum() {
+        let input = json!({
+            "model": "gpt-4o",
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+
+        assert_eq!(result["max_output_tokens"], 16);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Map Claude-to-OpenAI Chat Completions token limits by model family: GPT-5, chat-latest, and o-series use max_completion_tokens; GPT-4o/4.1/4/3.5 retain max_tokens.
- Keep Responses API on max_output_tokens and clamp Claude Desktop probe requests to the API minimum of 16.

## Tests
- Added conversion and model-selection unit tests.
- cargo test could not complete locally because the Windows Rust toolchain process stalled.