### PR TITLE
fix(windows): restore taskbar icon when relaunching via shortcut while app is in tray

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -156,6 +156,10 @@ fn handle_deeplink_url(
 
             if focus_main_window {
                 if let Some(window) = app.get_webview_window("main") {
+                    #[cfg(target_os = "windows")]
+                    {
+                        let _ = window.set_skip_taskbar(false);
+                    }
                     let _ = window.unminimize();
                     let _ = window.show();
                     let _ = window.set_focus();
@@ -257,6 +261,10 @@ pub fn run() {
 
             // Show and focus window regardless
             if let Some(window) = app.get_webview_window("main") {
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = window.set_skip_taskbar(false);
+                }
                 let _ = window.unminimize();
                 let _ = window.show();
                 let _ = window.set_focus();
@@ -1580,10 +1588,6 @@ pub fn run() {
                 // macOS 在 Dock 图标被点击并重新激活应用时会触发 Reopen 事件，这里手动恢复主窗口
                 RunEvent::Reopen { .. } => {
                     if let Some(window) = app_handle.get_webview_window("main") {
-                        #[cfg(target_os = "windows")]
-                        {
-                            let _ = window.set_skip_taskbar(false);
-                        }
                         let _ = window.unminimize();
                         let _ = window.show();
                         let _ = window.set_focus();


### PR DESCRIPTION
 ## Summary / 概述

  On Windows, when the main window is closed to the system tray (with **Minimize to tray on close** enabled), re-launching the app via its **desktop
  shortcut or Start Menu entry** shows the window on screen but **no icon appears in the taskbar**.

  **Root cause:** The single-instance callback — triggered when a second launch is detected while the app is already running in the tray — calls `show()`
  without first calling `set_skip_taskbar(false)`. The flag was left as `true` from when the window was hidden to the tray. The tray menu "Open main window"
  action already handles this correctly; these two paths were inconsistent.

  ## Changes / 修改内容

  - **fix:** Add `set_skip_taskbar(false)` before `unminimize()`/`show()` in the single-instance callback (`lib.rs`) — the path triggered by relaunching via
  desktop shortcut while the app is in the tray
  - **fix:** Same addition in `handle_deeplink_url()` with `focus_main_window=true` — the path triggered by `ccswitch://` deep-link events while the app is
  tray-only
  - **chore:** Remove dead code — `#[cfg(target_os = "windows")]` nested inside `#[cfg(target_os = "macos")]` in the `Reopen` handler, which could never
  compile on any platform

  ## Related Issue / 关联 Issue

  Fixes #

  ## Screenshots / 截图

  | Before / 修改前 | After / 修改后 |
  |-----------------|---------------|
  | # | # |

  ## Checklist / 检查清单

  - [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
  - [ ] `pnpm format:check` passes / 通过代码格式检查
  - [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
  - [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
