### PR TITLE
fix(tray): refresh after provider deep-link import

### DIFF
--- a/src/components/DeepLinkImportDialog.tsx
+++ b/src/components/DeepLinkImportDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { DeepLinkImportRequest, deeplinkApi } from "@/lib/api/deeplink";
+import { providersApi } from "@/lib/api/providers";
 import {
   Dialog,
   DialogContent,
@@ -136,6 +137,14 @@ export function DeepLinkImportDialog() {
           await queryClient.invalidateQueries({
             queryKey: ["providers", request.app],
           });
+          try {
+            await providersApi.updateTrayMenu();
+          } catch (trayError) {
+            console.error(
+              "Failed to update tray menu after deep link import",
+              trayError,
+            );
+          }
           toast.success(t("deeplink.importSuccess"), {
             description: t("deeplink.importSuccessDescription", {
               name: request.name,


### PR DESCRIPTION
## Bug

After importing a provider through a deep link, the main window reflects the new provider and its active state, but the system tray menu keeps the previous provider list and checked state until another provider switch occurs.

The deep-link import path refreshed the main-window provider query but did not rebuild the tray menu.

## Fix

Refresh the tray menu after a successful provider deep-link import. If the tray refresh fails, log the error without reporting the already successful provider import as failed.

Fixes #5255