### PR TITLE
fix(proxy): preserve multimodal tool_result output for Responses API

### DIFF
--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -477,11 +477,7 @@ fn convert_messages_to_input(messages: &[Value]) -> Result<Vec<Value>, ProxyErro
                                 .get("tool_use_id")
                                 .and_then(|i| i.as_str())
                                 .unwrap_or("");
-                            let output = match block.get("content") {
-                                Some(Value::String(s)) => s.clone(),
-                                Some(v) => canonical_json_string(v),
-                                None => String::new(),
-                            };
+                            let output = convert_tool_result_output(block.get("content"));
 
                             input.push(json!({
                                 "type": "function_call_output",
@@ -515,6 +511,55 @@ fn convert_messages_to_input(messages: &[Value]) -> Result<Vec<Value>, ProxyErro
     }
 
     Ok(input)
+}
+
+/// Convert Anthropic tool-result content without flattening multimodal blocks
+/// into JSON text. Responses API function outputs accept either a plain string
+/// or an array of input content items.
+fn convert_tool_result_output(content: Option<&Value>) -> Value {
+    match content {
+        Some(Value::String(text)) => Value::String(text.clone()),
+        Some(value @ Value::Array(blocks)) => {
+            let converted = blocks
+                .iter()
+                .map(convert_tool_result_content_block)
+                .collect::<Option<Vec<_>>>();
+
+            match converted {
+                Some(items) if !items.is_empty() => Value::Array(items),
+                _ => Value::String(canonical_json_string(value)),
+            }
+        }
+        Some(value) => Value::String(canonical_json_string(value)),
+        None => Value::String(String::new()),
+    }
+}
+
+fn convert_tool_result_content_block(block: &Value) -> Option<Value> {
+    match block.get("type").and_then(Value::as_str) {
+        Some("text") => block
+            .get("text")
+            .and_then(Value::as_str)
+            .map(|text| json!({ "type": "input_text", "text": text })),
+        Some("image") => {
+            let source = block.get("source")?;
+
+            if let Some(url) = source.get("url").and_then(Value::as_str) {
+                return Some(json!({ "type": "input_image", "image_url": url }));
+            }
+
+            let data = source.get("data").and_then(Value::as_str)?;
+            let media_type = source
+                .get("media_type")
+                .and_then(Value::as_str)
+                .unwrap_or("image/png");
+            Some(json!({
+                "type": "input_image",
+                "image_url": format!("data:{media_type};base64,{data}")
+            }))
+        }
+        _ => None,
+    }
 }
 
 /// OpenAI Responses 响应 → Anthropic 响应
@@ -894,6 +939,66 @@ mod tests {
         assert_eq!(input_arr[0]["type"], "function_call_output");
         assert_eq!(input_arr[0]["call_id"], "call_123");
         assert_eq!(input_arr[0]["output"], "Sunny, 25°C");
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_tool_result_preserves_multimodal_output() {
+        let input = json!({
+            "model": "gpt-4o",
+            "max_tokens": 1024,
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "call_read_image",
+                    "content": [
+                        {"type": "text", "text": "Rendered preview"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/jpeg",
+                                "data": "abc123"
+                            }
+                        }
+                    ]
+                }]
+            }]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        let output = result["input"][0]["output"].as_array().unwrap();
+
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0]["type"], "input_text");
+        assert_eq!(output[0]["text"], "Rendered preview");
+        assert_eq!(output[1]["type"], "input_image");
+        assert_eq!(output[1]["image_url"], "data:image/jpeg;base64,abc123");
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_tool_result_preserves_unknown_json_output() {
+        let content = json!([{
+            "kind": "custom",
+            "payload": {"ok": true}
+        }]);
+        let input = json!({
+            "model": "gpt-4o",
+            "max_tokens": 1024,
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "call_custom",
+                    "content": content.clone()
+                }]
+            }]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        let output = result["input"][0]["output"].as_str().unwrap();
+
+        assert_eq!(serde_json::from_str::<Value>(output).unwrap(), content);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve Anthropic `tool_result.content` text and image blocks as structured OpenAI Responses API `input_text` / `input_image` items in `function_call_output.output`.
- Keep plain string outputs unchanged.
- Fall back to the existing canonical JSON string behavior when a structured block is unsupported, so no result data is silently dropped.
- Add regression coverage for multimodal output and unknown JSON compatibility.

Fixes #2224.

This is an alternative to #2264. That PR moves images into a separate user message because it assumes `function_call_output.output` is text-only. The current Codex Responses endpoint accepts a structured input-content array here; retaining the image in `function_call_output.output` keeps it associated with its `call_id` and avoids adding a synthetic user turn. This was verified end-to-end against the original failing request.

Related: #4724 fixes the same base64-as-text failure class in the reverse Responses-to-ChatCompletions adapter.

## Root cause

`convert_messages_to_input` serialized every non-string Anthropic tool result with `canonical_json_string`:

```rust
Some(v) => canonical_json_string(v)
```

For a Claude Code `Read` result containing an image block, that converted the entire base64 payload into ordinary JSON text. The upstream model then tokenized the base64 instead of receiving an image, inflating the prompt until it returned a context-window error.

## Compatibility

- String output remains a string.
- Arrays containing supported Anthropic `text` and `image` blocks become structured Responses input content.
- Base64 and URL image sources are supported.
- Empty, malformed, mixed-unknown, and non-array JSON values retain the previous canonical JSON string fallback.

## User impact

Claude Code can pass images returned by tools through the Codex/OpenAI Responses route without turning the base64 payload into hundreds of thousands of text tokens.

## Verification

- Regression test reproduced the pre-fix failure and passes with this change.
- `cargo test proxy::providers::transform_responses::tests --lib`: 65 passed.
- `cargo fmt -- --check`: passed.
- `cargo clippy --all-targets`: passed with existing repository warnings only.
- Full `cargo test --lib`: 1,870 passed, 8 failed, 2 ignored. The failures are unchanged Windows/local-environment tests outside this module (six anchored CLI-upgrade tests and two local SQLite-home tests).

End-to-end A/B using the original Claude Code image tool result:

| | Official v3.16.5 | Patched build |
|---|---:|---:|
| Request size | 674,086 chars | 674,086 chars |
| Image base64 | 673,468 chars | 673,468 chars |
| Result | HTTP 422 context-window error | HTTP 200 |
| Reported input tokens | n/a | 3,555 |

