### PR TITLE
fix(proxy): map Claude effort by GPT-5 generation

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -1625,6 +1625,44 @@ mod tests {
     }
 
     #[test]
+    fn claude_desktop_proxy_preserves_model_effort_suffix_through_responses_transform() {
+        let mut provider = proxy_provider("proxy");
+        let meta = provider.meta.as_mut().expect("proxy meta");
+        meta.api_format = Some("openai_responses".to_string());
+        meta.claude_desktop_model_routes = std::collections::HashMap::from([(
+            "claude-sonnet-4-6".to_string(),
+            ClaudeDesktopModelRoute {
+                model: "gpt-5.6-sol(max)".to_string(),
+                label_override: Some("GPT-5.6 Sol".to_string()),
+                supports_1m: Some(false),
+            },
+        )]);
+
+        let mapped = map_proxy_request_model(
+            json!({
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1024,
+                "output_config": {"effort": "xhigh"},
+                "messages": [{"role": "user", "content": "Hello"}]
+            }),
+            &provider,
+        )
+        .expect("map desktop route");
+
+        let transformed = crate::proxy::providers::transform_claude_request_for_api_format(
+            mapped,
+            &provider,
+            "openai_responses",
+            None,
+            None,
+        )
+        .expect("transform desktop request");
+
+        assert_eq!(transformed["model"], json!("gpt-5.6-sol"));
+        assert_eq!(transformed["reasoning"]["effort"], json!("max"));
+    }
+
+    #[test]
     fn claude_desktop_proxy_maps_dated_role_alias_via_keyword() {
         // 复现反馈：Claude Desktop 子 agent 请求带发布日期后缀的完整官方名
         // （claude-haiku-4-5-20251001），与 manifest 的简短 route_id（claude-haiku-4-5）

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -104,6 +104,11 @@ fn gpt_5_minor(model: Option<&str>) -> Option<u32> {
 ///    - `disabled` / absent → `None`
 pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
     let gpt_5_minor = gpt_5_minor(body.get("model").and_then(Value::as_str));
+    let clamp_xhigh_to_high = body
+        .get("model")
+        .and_then(Value::as_str)
+        .is_some_and(is_openai_o_series)
+        || matches!(gpt_5_minor, Some(0 | 1));
 
     // --- Priority 1: explicit output_config.effort ---
     if let Some(effort) = body
@@ -114,10 +119,10 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
             "low" => Some("low"),
             "medium" => Some("medium"),
             "high" => Some("high"),
-            "xhigh" if matches!(gpt_5_minor, Some(0 | 1)) => Some("high"),
+            "xhigh" if clamp_xhigh_to_high => Some("high"),
             "xhigh" => Some("xhigh"),
             "max" if matches!(gpt_5_minor, Some(6)) => Some("max"),
-            "max" if matches!(gpt_5_minor, Some(0 | 1)) => Some("high"),
+            "max" if clamp_xhigh_to_high => Some("high"),
             "max" => Some("xhigh"),
             _ => None, // unknown value — do not inject
         };
@@ -126,7 +131,7 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
     // --- Priority 2: thinking.type + budget_tokens fallback ---
     let thinking = body.get("thinking")?;
     match thinking.get("type").and_then(|t| t.as_str()) {
-        Some("adaptive") if matches!(gpt_5_minor, Some(0 | 1)) => Some("high"),
+        Some("adaptive") if clamp_xhigh_to_high => Some("high"),
         Some("adaptive") => Some("xhigh"),
         Some("enabled") => {
             let budget = thinking.get("budget_tokens").and_then(|b| b.as_u64());
@@ -1702,6 +1707,23 @@ mod tests {
             assert_eq!(resolve_reasoning_effort(&xhigh_body), Some(xhigh));
             assert_eq!(resolve_reasoning_effort(&max_body), Some(max));
         }
+    }
+
+    #[test]
+    fn test_o_series_output_config_efforts_clamp_to_high() {
+        for effort in ["xhigh", "max"] {
+            let body = json!({
+                "model": "o3",
+                "output_config": {"effort": effort}
+            });
+            assert_eq!(resolve_reasoning_effort(&body), Some("high"));
+        }
+
+        let body = json!({
+            "model": "o4-mini",
+            "thinking": {"type": "adaptive"}
+        });
+        assert_eq!(resolve_reasoning_effort(&body), Some("high"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -68,18 +68,33 @@ pub fn supports_reasoning_effort(model: &str) -> bool {
             .is_some_and(|c| c.is_ascii_digit() && c >= '5')
 }
 
+fn gpt_5_minor(model: Option<&str>) -> Option<u32> {
+    let model = model?.to_ascii_lowercase();
+    let suffix = model.strip_prefix("gpt-5")?;
+    let Some(rest) = suffix.strip_prefix('.') else {
+        return Some(0);
+    };
+    let minor = rest
+        .split(|c: char| !c.is_ascii_digit())
+        .next()
+        .filter(|minor| !minor.is_empty())?;
+    minor.parse().ok()
+}
+
 /// Resolve the appropriate OpenAI `reasoning_effort` from an Anthropic request body.
 ///
 /// Priority:
-/// 1. Explicit `output_config.effort` — preserves the user's intent directly.
-///    `low`/`medium`/`high` map 1:1; `max` maps to `xhigh`
-///    (supported by mainstream GPT models). Unknown values are ignored.
+/// 1. Explicit `output_config.effort` — preserves the user's intent up to the
+///    target model's highest supported tier. GPT-5/5.1 top out at `high`,
+///    GPT-5.2–5.5 at `xhigh`, and GPT-5.6 supports `max`.
 /// 2. Fallback: `thinking.type` + `budget_tokens`:
-///    - `adaptive` → `xhigh` (adaptive = maximum reasoning effort)
+///    - `adaptive` → the model's highest supported tier (`high` or `xhigh`)
 ///    - `enabled` with budget → `low` (<4 000) / `medium` (4 000–15 999) / `high` (≥16 000)
 ///    - `enabled` without budget → `high` (conservative default)
 ///    - `disabled` / absent → `None`
 pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
+    let gpt_5_minor = gpt_5_minor(body.get("model").and_then(Value::as_str));
+
     // --- Priority 1: explicit output_config.effort ---
     if let Some(effort) = body
         .pointer("/output_config/effort")
@@ -89,14 +104,19 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
             "low" => Some("low"),
             "medium" => Some("medium"),
             "high" => Some("high"),
-            "max" => Some("xhigh"), // OpenAI xhigh = maximum reasoning effort
-            _ => None,              // unknown value — do not inject
+            "xhigh" if matches!(gpt_5_minor, Some(0 | 1)) => Some("high"),
+            "xhigh" => Some("xhigh"),
+            "max" if matches!(gpt_5_minor, Some(6)) => Some("max"),
+            "max" if matches!(gpt_5_minor, Some(0 | 1)) => Some("high"),
+            "max" => Some("xhigh"),
+            _ => None, // unknown value — do not inject
         };
     }
 
     // --- Priority 2: thinking.type + budget_tokens fallback ---
     let thinking = body.get("thinking")?;
     match thinking.get("type").and_then(|t| t.as_str()) {
+        Some("adaptive") if matches!(gpt_5_minor, Some(0 | 1)) => Some("high"),
         Some("adaptive") => Some("xhigh"),
         Some("enabled") => {
             let budget = thinking.get("budget_tokens").and_then(|b| b.as_u64());
@@ -1591,6 +1611,38 @@ mod tests {
     }
 
     #[test]
+    fn test_gpt_5_6_output_config_efforts_map_one_to_one() {
+        for effort in ["low", "medium", "high", "xhigh", "max"] {
+            let body = json!({
+                "model": "gpt-5.6-sol",
+                "output_config": {"effort": effort}
+            });
+            assert_eq!(resolve_reasoning_effort(&body), Some(effort));
+        }
+    }
+
+    #[test]
+    fn test_pre_gpt_5_6_output_config_efforts_clamp_to_supported_maximum() {
+        for (model, xhigh, max) in [
+            ("gpt-5", "high", "high"),
+            ("gpt-5.1", "high", "high"),
+            ("gpt-5.2", "xhigh", "xhigh"),
+            ("gpt-5.5", "xhigh", "xhigh"),
+        ] {
+            let xhigh_body = json!({
+                "model": model,
+                "output_config": {"effort": "xhigh"}
+            });
+            let max_body = json!({
+                "model": model,
+                "output_config": {"effort": "max"}
+            });
+            assert_eq!(resolve_reasoning_effort(&xhigh_body), Some(xhigh));
+            assert_eq!(resolve_reasoning_effort(&max_body), Some(max));
+        }
+    }
+
+    #[test]
     fn test_output_config_takes_priority_over_thinking() {
         // Even with thinking.adaptive present, explicit effort wins
         let body = json!({
@@ -1602,8 +1654,10 @@ mod tests {
 
     #[test]
     fn test_output_config_unknown_value_no_reasoning_effort() {
-        let body = json!({"output_config": {"effort": "turbo"}});
-        assert_eq!(resolve_reasoning_effort(&body), None);
+        for effort in ["turbo", "ultra", "ultracode"] {
+            let body = json!({"output_config": {"effort": effort}});
+            assert_eq!(resolve_reasoning_effort(&body), None);
+        }
     }
 
     #[test]
@@ -1634,6 +1688,15 @@ mod tests {
     fn test_thinking_adaptive_maps_xhigh() {
         let body = json!({"thinking": {"type": "adaptive"}});
         assert_eq!(resolve_reasoning_effort(&body), Some("xhigh"));
+    }
+
+    #[test]
+    fn test_gpt_5_1_adaptive_thinking_clamps_to_high() {
+        let body = json!({
+            "model": "gpt-5.1",
+            "thinking": {"type": "adaptive"}
+        });
+        assert_eq!(resolve_reasoning_effort(&body), Some("high"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -68,6 +68,16 @@ pub fn supports_reasoning_effort(model: &str) -> bool {
             .is_some_and(|c| c.is_ascii_digit() && c >= '5')
 }
 
+pub(crate) fn parse_model_effort_suffix(model: &str) -> Option<(&str, &str)> {
+    if !model.ends_with(')') {
+        return None;
+    }
+
+    let open = model.rfind('(')?;
+    let effort = &model[open + 1..model.len() - 1];
+    (open > 0 && !effort.is_empty()).then_some((&model[..open], effort))
+}
+
 fn gpt_5_minor(model: Option<&str>) -> Option<u32> {
     let model = model?.to_ascii_lowercase();
     let suffix = model.strip_prefix("gpt-5")?;
@@ -151,8 +161,18 @@ pub fn anthropic_to_openai_with_reasoning_content(
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
 
+    let (model, explicit_effort) = body
+        .get("model")
+        .and_then(Value::as_str)
+        .map(|model| {
+            parse_model_effort_suffix(model)
+                .map(|(model, effort)| (model, Some(effort)))
+                .unwrap_or((model, None))
+        })
+        .unwrap_or(("", None));
+
     // NOTE: 模型映射由上游统一处理（proxy::model_mapper），格式转换层只做结构转换。
-    if let Some(model) = body.get("model").and_then(|m| m.as_str()) {
+    if !model.is_empty() {
         result["model"] = json!(model);
     }
 
@@ -192,7 +212,6 @@ pub fn anthropic_to_openai_with_reasoning_content(
     result["messages"] = json!(messages);
 
     // 转换参数 — o-series 模型需要 max_completion_tokens
-    let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
     if let Some(v) = body.get("max_tokens") {
         if is_openai_o_series(model) {
             result["max_completion_tokens"] = v.clone();
@@ -215,7 +234,7 @@ pub fn anthropic_to_openai_with_reasoning_content(
 
     // Map Anthropic thinking → OpenAI reasoning_effort
     if supports_reasoning_effort(model) {
-        if let Some(effort) = resolve_reasoning_effort(&body) {
+        if let Some(effort) = explicit_effort.or_else(|| resolve_reasoning_effort(&body)) {
             result["reasoning_effort"] = json!(effort);
         }
     }
@@ -1618,6 +1637,49 @@ mod tests {
                 "output_config": {"effort": effort}
             });
             assert_eq!(resolve_reasoning_effort(&body), Some(effort));
+        }
+    }
+
+    #[test]
+    fn test_model_effort_suffix_overrides_claude_effort_for_openai_chat() {
+        let body = json!({
+            "model": "gpt-5.6-sol(max)",
+            "output_config": {"effort": "xhigh"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_openai(body).unwrap();
+
+        assert_eq!(result["model"], "gpt-5.6-sol");
+        assert_eq!(result["reasoning_effort"], "max");
+    }
+
+    #[test]
+    fn test_model_effort_suffix_forwards_unknown_value_for_openai_chat() {
+        let body = json!({
+            "model": "gpt-5.6-sol(foo)",
+            "output_config": {"effort": "high"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_openai(body).unwrap();
+
+        assert_eq!(result["model"], "gpt-5.6-sol");
+        assert_eq!(result["reasoning_effort"], "foo");
+    }
+
+    #[test]
+    fn test_model_effort_suffix_leaves_invalid_suffixes_unchanged() {
+        for model in ["gpt-5.6-sol()", "gpt-5.6-sol(max"] {
+            let body = json!({
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}]
+            });
+
+            let result = anthropic_to_openai(body).unwrap();
+
+            assert_eq!(result["model"], model);
+            assert!(result.get("reasoning_effort").is_none());
         }
     }
 

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -1297,17 +1297,22 @@ mod tests {
 
     #[test]
     fn test_model_effort_suffix_overrides_claude_effort_for_responses() {
-        let input = json!({
-            "model": "gpt-5.6-sol(max)",
-            "max_tokens": 1024,
-            "output_config": {"effort": "xhigh"},
-            "messages": [{"role": "user", "content": "Hello"}]
-        });
+        for (model, expected_model, effort) in [
+            ("gpt-5.5-sol(high)", "gpt-5.5-sol", "high"),
+            ("gpt-5.6-sol(max)", "gpt-5.6-sol", "max"),
+        ] {
+            let input = json!({
+                "model": model,
+                "max_tokens": 1024,
+                "output_config": {"effort": "xhigh"},
+                "messages": [{"role": "user", "content": "Hello"}]
+            });
 
-        let result = anthropic_to_responses(input, None, false, false).unwrap();
+            let result = anthropic_to_responses(input, None, false, false).unwrap();
 
-        assert_eq!(result["model"], "gpt-5.6-sol");
-        assert_eq!(result["reasoning"]["effort"], "max");
+            assert_eq!(result["model"], expected_model);
+            assert_eq!(result["reasoning"]["effort"], effort);
+        }
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -1273,6 +1273,32 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_gpt_5_6_output_config_max_sets_reasoning_max() {
+        let input = json!({
+            "model": "gpt-5.6-sol",
+            "max_tokens": 1024,
+            "output_config": {"effort": "max"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "max");
+    }
+
+    #[test]
+    fn test_responses_gpt_5_5_output_config_xhigh_sets_reasoning_xhigh() {
+        let input = json!({
+            "model": "gpt-5.5",
+            "max_tokens": 1024,
+            "output_config": {"effort": "xhigh"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+    }
+
+    #[test]
     fn test_responses_output_config_takes_priority_over_thinking() {
         let input = json!({
             "model": "gpt-5.4",

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -56,8 +56,18 @@ pub fn anthropic_to_responses(
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
 
+    let (model, explicit_effort) = body
+        .get("model")
+        .and_then(Value::as_str)
+        .map(|model| {
+            super::transform::parse_model_effort_suffix(model)
+                .map(|(model, effort)| (model, Some(effort)))
+                .unwrap_or((model, None))
+        })
+        .unwrap_or(("", None));
+
     // NOTE: 模型映射由上游统一处理（proxy::model_mapper），格式转换层只做结构转换。
-    if let Some(model) = body.get("model").and_then(|m| m.as_str()) {
+    if !model.is_empty() {
         result["model"] = json!(model);
     }
 
@@ -103,11 +113,11 @@ pub fn anthropic_to_responses(
     }
 
     // Map Anthropic thinking → OpenAI Responses reasoning.effort
-    if let Some(model_name) = body.get("model").and_then(|m| m.as_str()) {
-        if super::transform::supports_reasoning_effort(model_name) {
-            if let Some(effort) = super::transform::resolve_reasoning_effort(&body) {
-                result["reasoning"] = json!({ "effort": effort });
-            }
+    if super::transform::supports_reasoning_effort(model) {
+        if let Some(effort) =
+            explicit_effort.or_else(|| super::transform::resolve_reasoning_effort(&body))
+        {
+            result["reasoning"] = json!({ "effort": effort });
         }
     }
 
@@ -1283,6 +1293,36 @@ mod tests {
 
         let result = anthropic_to_responses(input, None, false, false).unwrap();
         assert_eq!(result["reasoning"]["effort"], "max");
+    }
+
+    #[test]
+    fn test_model_effort_suffix_overrides_claude_effort_for_responses() {
+        let input = json!({
+            "model": "gpt-5.6-sol(max)",
+            "max_tokens": 1024,
+            "output_config": {"effort": "xhigh"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+
+        assert_eq!(result["model"], "gpt-5.6-sol");
+        assert_eq!(result["reasoning"]["effort"], "max");
+    }
+
+    #[test]
+    fn test_model_effort_suffix_forwards_unknown_value_for_responses() {
+        let input = json!({
+            "model": "gpt-5.6-sol(foo)",
+            "max_tokens": 1024,
+            "output_config": {"effort": "high"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+
+        assert_eq!(result["model"], "gpt-5.6-sol");
+        assert_eq!(result["reasoning"]["effort"], "foo");
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Fix Claude Code → OpenAI Responses effort conversion so the proxy preserves supported API reasoning tiers instead of dropping `xhigh` or always demoting `max`.

- GPT-5 / GPT-5.1: clamp `xhigh` and `max` to `high`
- GPT-5.2–GPT-5.5: preserve `xhigh`; clamp `max` to `xhigh`
- GPT-5.6 Sol, Terra, and Luna: map `low`, `medium`, `high`, `xhigh`, and `max` one-to-one
- keep `ultra` / `ultracode` out of OpenAI Responses `reasoning.effort`
- apply the same cap to the adaptive-thinking fallback
- allow a final model suffix such as `gpt-5.6-sol(max)` to explicitly override the final effort

### Explicit model effort suffix

A final non-empty parenthesized suffix pins the final upstream effort and is removed from the forwarded model ID:

- `gpt-5.5(high)` → model `gpt-5.5`, effort `high`
- `gpt-5.6-sol(max)` → model `gpt-5.6-sol`, effort `max`
- `gpt-5.6-sol(foo)` → model `gpt-5.6-sol`, effort `foo`

The suffix takes precedence over Claude Code `output_config.effort` and thinking fallback. It is forwarded without validation or generation-based clamping, allowing future upstream effort values to work without a CC Switch update. Unsupported values are rejected by the upstream API. Empty or incomplete suffixes remain unchanged.

### `ultracode` and `ultra` scope

These labels are orchestration modes, not additional reasoning-effort values on this converter path:

- Claude Code `ultracode` combines `xhigh` reasoning with Claude Code dynamic workflows. Its model requests currently carry `output_config.effort = xhigh`; workflow orchestration remains in Claude Code.
- Codex `ultra` combines `max` reasoning with automatic task delegation. Codex exposes it for GPT-5.6 Sol and Terra, while Luna stops at `max`.
- The standard OpenAI Responses request produced by this converter supports reasoning effort through `max`. Injecting `ultra` would conflate Codex harness behavior with an API reasoning value.

The converter therefore preserves an incoming Claude Code `xhigh` request as GPT-5.6 `xhigh`. It must not promote every `xhigh` request to `max`, because the request body cannot distinguish ordinary `/effort xhigh` from an `xhigh` model call made while Claude Code `ultracode` is orchestrating a workflow.

This is separate from #5265: that PR updates Codex Desktop model catalogs and its reasoning picker, while this PR fixes the Anthropic Messages → OpenAI Responses request converter used by Claude Code local routing.

OpenAI API capability references:

- GPT-5 / GPT-5.1: up to `high`
- GPT-5.2–GPT-5.5: up to `xhigh`
- GPT-5.6 Sol / Terra / Luna: through `max`

## Related Issue / 关联 Issue

Fixes #3389

Related to #5265 and #5209, but does not overlap their Codex Desktop catalog path.

## Screenshots / 截图

Not applicable; request-conversion behavior is covered by unit and integration tests.

## Validation / 验证

- `cargo test --manifest-path src-tauri/Cargo.toml model_effort_suffix -- --nocapture` — 5 passed
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::providers::transform::tests` — 68 passed
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::providers::transform_responses::tests` — 67 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings` — passed
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — passed
- `git diff --check` — passed

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / not run; no frontend changes
- [ ] `pnpm format:check` passes / not run; no frontend changes
- [x] `cargo clippy` passes
- [x] Updated i18n files if user-facing text changed / not applicable
