### PR TITLE
fix(proxy): update Claude takeover to Sonnet 5

### DIFF
--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -42,7 +42,7 @@ const CLAUDE_MODEL_OVERRIDE_ENV_KEYS: [&str; 12] = [
 ];
 
 const CLAUDE_TAKEOVER_HAIKU_MODEL: &str = "claude-haiku-4-5";
-const CLAUDE_TAKEOVER_SONNET_MODEL: &str = "claude-sonnet-4-6";
+const CLAUDE_TAKEOVER_SONNET_MODEL: &str = "claude-sonnet-5";
 const CLAUDE_TAKEOVER_OPUS_MODEL: &str = "claude-opus-4-8";
 const CLAUDE_TAKEOVER_FABLE_MODEL: &str = "claude-fable-5";
 // 写给 Claude Code 时沿用文档示例的大写形式；解析侧大小写不敏感。
@@ -2966,7 +2966,7 @@ mod tests {
         assert_env_str(
             env,
             "ANTHROPIC_DEFAULT_SONNET_MODEL",
-            Some("claude-sonnet-4-6"),
+            Some("claude-sonnet-5"),
         );
         assert_env_str(
             env,
@@ -3084,7 +3084,7 @@ mod tests {
         assert_env_str(
             env,
             "ANTHROPIC_DEFAULT_SONNET_MODEL",
-            Some("claude-sonnet-4-6"),
+            Some("claude-sonnet-5"),
         );
         assert_env_str(env, "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME", Some("gpt-5.4"));
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-4-8"));
@@ -4797,7 +4797,7 @@ model = "gpt-5.1-codex"
             live_env
                 .get("ANTHROPIC_DEFAULT_SONNET_MODEL")
                 .and_then(|v| v.as_str()),
-            Some("claude-sonnet-4-6[1M]"),
+            Some("claude-sonnet-5[1M]"),
             "Sonnet role should carry the local 1M declaration for Claude Code"
         );
         assert_eq!(


### PR DESCRIPTION
## What changed

- update the Claude proxy-takeover Sonnet sentinel from `claude-sonnet-4-6` to `claude-sonnet-5`
- update managed Codex/Copilot takeover and `[1M]` regression expectations

## Why

CC Switch v3.16.5 updated provider defaults and pricing to Claude Sonnet 5, but proxy takeover still writes `claude-sonnet-4-6` into Claude Code's live `ANTHROPIC_DEFAULT_SONNET_MODEL`.

The local proxy uses that value only as a Sonnet routing sentinel before mapping it to the provider-configured upstream model. Nevertheless, Claude Code validates and reports the sentinel as the selected model. With Sonnet 4.6 retired from the current Claude Code model menu, selecting the provider's Sonnet tier can therefore show or reject an obsolete model before the proxy mapping is useful.

Using `claude-sonnet-5` aligns takeover with the repository's current Sonnet default while preserving role-based routing, provider-specific `*_MODEL_NAME`, and `[1M]` behavior.

## Validation

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml managed_account_claude_takeover_sources -- --nocapture` (2 passed)
- full backend suite previously reached 1890 passed and 2 ignored; the only failure was an unrelated fixed-port test unable to bind 15721 while an installed CC Switch instance was running
