### PR TITLE
fix: avoid interactive shell when probing tool versions

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1065,7 +1065,11 @@ fn default_flag_for_shell(shell: &str) -> &'static str {
     match shell.rsplit('/').next().unwrap_or(shell) {
         "dash" | "sh" => "-c",
         "fish" => "-lc",
-        _ => "-lic",
+        _ => "-lc", // was "-lic": interactive flag sources .zshrc and may trigger
+                    // startup scripts like `neofetch` whose output pollutes stdout,
+                    // causing `extract_version` to return the wrong version number.
+                    // Login shell (-l) + command (-c) suffices to get the user's
+                    // PATH from .profile / .zprofile without side effects.
     }
 }
 
@@ -4926,9 +4930,9 @@ mod tests {
             assert_eq!(default_flag_for_shell("dash"), "-c");
             assert_eq!(default_flag_for_shell("/bin/dash"), "-c");
             assert_eq!(default_flag_for_shell("fish"), "-lc");
-            assert_eq!(default_flag_for_shell("bash"), "-lic");
-            assert_eq!(default_flag_for_shell("zsh"), "-lic");
-            assert_eq!(default_flag_for_shell("/usr/bin/zsh"), "-lic");
+            assert_eq!(default_flag_for_shell("bash"), "-lc");
+            assert_eq!(default_flag_for_shell("zsh"), "-lc");
+            assert_eq!(default_flag_for_shell("/usr/bin/zsh"), "-lc");
         }
 
         #[test]


### PR DESCRIPTION
## Problem

On macOS, the "本地环境检查" (Local Environment Check) shows version `26.5.2` for every tool. This is actually the **macOS version**, not the tool version.

**Root cause**: `default_flag_for_shell()` passes `-lic` (login + **interactive** + command) to zsh/bash when running `{tool} --version`. The interactive flag `-i` sources `.zshrc`, which commonly runs startup scripts like `neofetch`. The neofetch output contains `OS: macOS 26.5.2 arm64`, and `extract_version` regex picks `26.5.2` as the **first** version match.

## Fix

Changed `-lic` → `-lc` in `default_flag_for_shell()`.
- Login shell (`-l`) still sources `.zprofile` for Homebrew/npm PATH setup
- Removed `-i` avoids sourcing `.zshrc` and its side effects (neofetch, startup banners, etc.)
- Tools not found on the login-shell PATH fall back to `scan_cli_version()`

## Testing

- Updated `test_default_flag_for_shell` assertions