### PR TITLE
feat(plugins): unify Codex and Claude plugin management

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6126,6 +6126,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ arboard = "3.6"
 flate2 = "1"
 brotli = "7"
 zstd = "0.13"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync", "process"] }
 futures = "0.3"
 async-stream = "0.3"
 bytes = "1.5"

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1615,6 +1615,14 @@ fn build_tool_search_paths(tool: &str) -> Vec<std::path::PathBuf> {
     search_paths
 }
 
+/// Resolve the same executable candidate used by the tool diagnostics page.
+pub fn resolve_tool_executable(tool: &str) -> Option<std::path::PathBuf> {
+    build_tool_search_paths(tool)
+        .into_iter()
+        .flat_map(|dir| tool_executable_candidates(tool, &dir))
+        .find(|path| path.is_file())
+}
+
 #[cfg(target_os = "windows")]
 fn is_windows_command_script(path: &Path) -> bool {
     path.extension()

--- a/src-tauri/src/commands/plugin.rs
+++ b/src-tauri/src/commands/plugin.rs
@@ -1,6 +1,97 @@
 #![allow(non_snake_case)]
 
 use crate::config::ConfigStatus;
+use crate::services::plugin::{
+    self, PluginActionResult, PluginApp, PluginClientStatus, PluginMarketplace, PluginScope,
+    UnifiedPlugin,
+};
+
+#[tauri::command]
+pub async fn get_plugin_client_statuses() -> Vec<PluginClientStatus> {
+    let (codex, claude) = tokio::join!(
+        plugin::client_status(PluginApp::Codex),
+        plugin::client_status(PluginApp::Claude)
+    );
+    vec![codex, claude]
+}
+
+#[tauri::command]
+pub async fn list_plugins(
+    app: PluginApp,
+    include_available: bool,
+) -> Result<Vec<UnifiedPlugin>, String> {
+    plugin::list_plugins(app, include_available).await
+}
+
+#[tauri::command]
+pub async fn list_plugin_marketplaces(app: PluginApp) -> Result<Vec<PluginMarketplace>, String> {
+    plugin::list_marketplaces(app).await
+}
+
+#[tauri::command]
+pub async fn add_plugin_marketplace(
+    app: PluginApp,
+    source: String,
+) -> Result<PluginActionResult, String> {
+    plugin::add_marketplace(app, &source).await
+}
+
+#[tauri::command]
+pub async fn refresh_plugin_marketplace(
+    app: PluginApp,
+    name: String,
+) -> Result<PluginActionResult, String> {
+    plugin::refresh_marketplace(app, &name).await
+}
+
+#[tauri::command]
+pub async fn remove_plugin_marketplace(
+    app: PluginApp,
+    name: String,
+) -> Result<PluginActionResult, String> {
+    plugin::remove_marketplace(app, &name).await
+}
+
+#[tauri::command]
+pub async fn install_plugin(
+    app: PluginApp,
+    plugin_id: String,
+    scope: Option<PluginScope>,
+    project_path: Option<String>,
+) -> Result<PluginActionResult, String> {
+    plugin::install_plugin(app, &plugin_id, scope, project_path.as_deref()).await
+}
+
+#[tauri::command]
+pub async fn update_plugin(
+    app: PluginApp,
+    plugin_id: String,
+    scope: Option<PluginScope>,
+    project_path: Option<String>,
+) -> Result<PluginActionResult, String> {
+    plugin::update_plugin(app, &plugin_id, scope, project_path.as_deref()).await
+}
+
+#[tauri::command]
+pub async fn set_plugin_enabled(
+    app: PluginApp,
+    plugin_id: String,
+    enabled: bool,
+    scope: Option<PluginScope>,
+    project_path: Option<String>,
+) -> Result<PluginActionResult, String> {
+    plugin::set_plugin_enabled(app, &plugin_id, enabled, scope, project_path.as_deref()).await
+}
+
+#[tauri::command]
+pub async fn uninstall_plugin(
+    app: PluginApp,
+    plugin_id: String,
+    scope: Option<PluginScope>,
+    project_path: Option<String>,
+) -> Result<PluginActionResult, String> {
+    plugin::uninstall_plugin(app, &plugin_id, scope, project_path.as_deref()).await
+}
 
 /// Claude 插件：获取 ~/.claude/config.json 状态
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1342,6 +1342,17 @@ pub fn run() {
             commands::update_skill,
             commands::migrate_skill_storage,
             commands::search_skills_sh,
+            // Native Codex / Claude plugin management
+            commands::get_plugin_client_statuses,
+            commands::list_plugins,
+            commands::list_plugin_marketplaces,
+            commands::add_plugin_marketplace,
+            commands::refresh_plugin_marketplace,
+            commands::remove_plugin_marketplace,
+            commands::install_plugin,
+            commands::update_plugin,
+            commands::set_plugin_enabled,
+            commands::uninstall_plugin,
             // Skill management (legacy API compatibility)
             commands::get_skills,
             commands::get_skills_for_app,

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod env_manager;
 pub mod mcp;
 pub mod model_fetch;
 pub mod omo;
+pub mod plugin;
 pub mod profile;
 pub mod prompt;
 pub mod provider;

--- a/src-tauri/src/services/plugin.rs
+++ b/src-tauri/src/services/plugin.rs
@@ -89,6 +89,7 @@ pub struct PluginMarketplace {
     pub source_type: Option<String>,
     pub source: Option<String>,
     pub root: Option<String>,
+    pub supports_refresh: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -184,7 +185,19 @@ async fn run_cli(app: PluginApp, args: &[&str], cwd: Option<&str>) -> Result<Str
     if output.status.success() {
         Ok(stdout)
     } else {
-        Err(if stderr.is_empty() { stdout } else { stderr })
+        let message = if stderr.is_empty() { stdout } else { stderr };
+        Err(concise_cli_error(&message))
+    }
+}
+
+fn concise_cli_error(message: &str) -> String {
+    let lowercase = message.to_ascii_lowercase();
+    let end = lowercase.find("stack backtrace:").unwrap_or(message.len());
+    let summary = message[..end].trim();
+    if summary.is_empty() {
+        message.trim().to_string()
+    } else {
+        summary.to_string()
     }
 }
 
@@ -319,14 +332,20 @@ pub fn parse_marketplaces_json(
         .filter_map(|value| {
             let name = string_field(value, &["name"])?;
             let nested_source = value.get("marketplaceSource");
+            let source_type = string_field(value, &["sourceType", "source"])
+                .or_else(|| nested_source.and_then(|s| string_field(s, &["sourceType"])));
+            let supports_refresh = app == PluginApp::Claude
+                || source_type
+                    .as_deref()
+                    .is_some_and(|kind| kind.eq_ignore_ascii_case("git"));
             Some(PluginMarketplace {
                 name,
                 app,
-                source_type: string_field(value, &["sourceType", "source"])
-                    .or_else(|| nested_source.and_then(|s| string_field(s, &["sourceType"]))),
+                source_type,
                 source: string_field(value, &["url", "repo"])
                     .or_else(|| nested_source.and_then(|s| string_field(s, &["source"]))),
                 root: string_field(value, &["root", "installLocation"]),
+                supports_refresh,
             })
         })
         .collect())
@@ -446,6 +465,16 @@ pub async fn add_marketplace(app: PluginApp, source: &str) -> Result<PluginActio
 
 pub async fn refresh_marketplace(app: PluginApp, name: &str) -> Result<PluginActionResult, String> {
     validate_nonempty(name, "marketplace name")?;
+    let marketplace = list_marketplaces(app)
+        .await?
+        .into_iter()
+        .find(|marketplace| marketplace.name == name)
+        .ok_or_else(|| format!("Marketplace not found: {name}"))?;
+    if !marketplace.supports_refresh {
+        return Err(format!(
+            "Marketplace '{name}' is local or built in and cannot be refreshed manually"
+        ));
+    }
     let verb = if app == PluginApp::Codex {
         "upgrade"
     } else {
@@ -671,6 +700,51 @@ mod tests {
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].name, "ponytail");
         assert_eq!(parsed[0].source.as_deref(), Some("DietrichGebert/ponytail"));
+        assert!(parsed[0].supports_refresh);
+    }
+
+    #[test]
+    fn codex_only_refreshes_git_marketplaces() {
+        let marketplaces = serde_json::json!({
+            "marketplaces": [
+                {
+                    "name": "openai-bundled",
+                    "marketplaceSource": {
+                        "sourceType": "local",
+                        "source": "/tmp/openai-bundled"
+                    }
+                },
+                {
+                    "name": "openai-curated",
+                    "root": "/tmp/plugins"
+                },
+                {
+                    "name": "ponytail",
+                    "marketplaceSource": {
+                        "sourceType": "git",
+                        "source": "https://github.com/DietrichGebert/ponytail.git"
+                    }
+                }
+            ]
+        })
+        .to_string();
+
+        let parsed = parse_marketplaces_json(PluginApp::Codex, &marketplaces).unwrap();
+
+        assert!(!parsed[0].supports_refresh);
+        assert!(!parsed[1].supports_refresh);
+        assert!(parsed[2].supports_refresh);
+    }
+
+    #[test]
+    fn cli_errors_hide_rust_backtraces() {
+        let error = concise_cli_error(
+            "Error: marketplace is not configured as a Git marketplace\nStack backtrace:\n0: frame",
+        );
+        assert_eq!(
+            error,
+            "Error: marketplace is not configured as a Git marketplace"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/plugin.rs
+++ b/src-tauri/src/services/plugin.rs
@@ -81,6 +81,16 @@ pub struct UnifiedPlugin {
     pub supported_actions: PluginActions,
 }
 
+type PluginInstallationKey = (String, Option<String>, Option<String>);
+
+fn plugin_installation_key(plugin: &UnifiedPlugin) -> PluginInstallationKey {
+    (
+        plugin.plugin_id.clone(),
+        plugin.scope.clone(),
+        plugin.project_path.clone(),
+    )
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginMarketplace {
@@ -273,21 +283,31 @@ pub fn parse_plugins_json(
         .cloned()
         .unwrap_or_default();
 
-    let mut plugins = BTreeMap::<String, UnifiedPlugin>::new();
+    let mut available_plugins = BTreeMap::<String, UnifiedPlugin>::new();
     if include_available {
         for value in available_values {
             if let Some(plugin) = plugin_from_value(app, &value, false) {
-                plugins.insert(plugin.plugin_id.clone(), plugin);
+                available_plugins.insert(plugin.plugin_id.clone(), plugin);
             }
         }
     }
+    let mut plugins = BTreeMap::<PluginInstallationKey, UnifiedPlugin>::new();
+    let mut installed_ids = BTreeSet::new();
     for value in installed_values {
         if let Some(mut plugin) = plugin_from_value(app, &value, true) {
-            if let Some(available) = plugins.get(&plugin.plugin_id) {
+            if let Some(available) = available_plugins.get(&plugin.plugin_id) {
                 plugin.description = plugin.description.or_else(|| available.description.clone());
                 plugin.source = plugin.source.or_else(|| available.source.clone());
             }
-            plugins.insert(plugin.plugin_id.clone(), plugin);
+            installed_ids.insert(plugin.plugin_id.clone());
+            plugins.insert(plugin_installation_key(&plugin), plugin);
+        }
+    }
+    if include_available {
+        for available in available_plugins.into_values() {
+            if !installed_ids.contains(&available.plugin_id) {
+                plugins.insert(plugin_installation_key(&available), available);
+            }
         }
     }
     Ok(plugins.into_values().collect())
@@ -674,6 +694,37 @@ mod tests {
         let plugins = parse_plugins_json(PluginApp::Claude, claude, false).unwrap();
         assert_eq!(plugins[0].name, "ponytail");
         assert!(plugins[0].supported_actions.enable);
+    }
+
+    #[test]
+    fn preserves_claude_plugin_installs_across_scopes_and_projects() {
+        let claude = r#"[
+            {"id":"ponytail@ponytail","scope":"user","enabled":true},
+            {"id":"ponytail@ponytail","scope":"project","projectPath":"/tmp/project-a","enabled":false},
+            {"id":"ponytail@ponytail","scope":"project","projectPath":"/tmp/project-b","enabled":true},
+            {"id":"ponytail@ponytail","scope":"local","projectPath":"/tmp/project-a","enabled":true}
+        ]"#;
+
+        let plugins = parse_plugins_json(PluginApp::Claude, claude, false).unwrap();
+
+        assert_eq!(plugins.len(), 4);
+        assert!(plugins.iter().any(|plugin| {
+            plugin.scope.as_deref() == Some("user") && plugin.project_path.is_none()
+        }));
+        assert!(plugins.iter().any(|plugin| {
+            plugin.scope.as_deref() == Some("project")
+                && plugin.project_path.as_deref() == Some("/tmp/project-a")
+                && !plugin.enabled
+        }));
+        assert!(plugins.iter().any(|plugin| {
+            plugin.scope.as_deref() == Some("project")
+                && plugin.project_path.as_deref() == Some("/tmp/project-b")
+                && plugin.enabled
+        }));
+        assert!(plugins.iter().any(|plugin| {
+            plugin.scope.as_deref() == Some("local")
+                && plugin.project_path.as_deref() == Some("/tmp/project-a")
+        }));
     }
 
     #[test]

--- a/src-tauri/src/services/plugin.rs
+++ b/src-tauri/src/services/plugin.rs
@@ -1,7 +1,7 @@
 use crate::codex_config::{read_and_validate_codex_config_text, write_codex_live_config_atomic};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::process::Command;
@@ -280,6 +280,28 @@ pub fn parse_plugins_json(
     Ok(plugins.into_values().collect())
 }
 
+fn merge_contextual_plugin_states(
+    plugins: &mut [UnifiedPlugin],
+    contextual_plugins: &[UnifiedPlugin],
+    project_path: &str,
+) {
+    for plugin in plugins
+        .iter_mut()
+        .filter(|plugin| plugin.project_path.as_deref() == Some(project_path))
+    {
+        let Some(contextual) = contextual_plugins.iter().find(|candidate| {
+            candidate.plugin_id == plugin.plugin_id
+                && candidate.scope == plugin.scope
+                && candidate.project_path == plugin.project_path
+        }) else {
+            continue;
+        };
+        plugin.enabled = contextual.enabled;
+        plugin.supported_actions.enable = plugin.installed && !plugin.enabled;
+        plugin.supported_actions.disable = plugin.installed && plugin.enabled;
+    }
+}
+
 pub fn parse_marketplaces_json(
     app: PluginApp,
     raw: &str,
@@ -359,7 +381,28 @@ pub async fn list_plugins(
             run_cli(app, &["plugin", "list", "--available", "--json"], None).await?
         }
     };
-    parse_plugins_json(app, &raw, include_available)
+    let mut plugins = parse_plugins_json(app, &raw, include_available)?;
+    if app == PluginApp::Claude {
+        let project_paths = plugins
+            .iter()
+            .filter(|plugin| matches!(plugin.scope.as_deref(), Some("project" | "local")))
+            .filter_map(|plugin| plugin.project_path.clone())
+            .collect::<BTreeSet<_>>();
+        for project_path in project_paths {
+            if !Path::new(&project_path).is_dir() {
+                continue;
+            }
+            let Ok(contextual_raw) =
+                run_cli(app, &["plugin", "list", "--json"], Some(&project_path)).await
+            else {
+                continue;
+            };
+            if let Ok(contextual_plugins) = parse_plugins_json(app, &contextual_raw, false) {
+                merge_contextual_plugin_states(&mut plugins, &contextual_plugins, &project_path);
+            }
+        }
+    }
+    Ok(plugins)
 }
 
 pub async fn list_marketplaces(app: PluginApp) -> Result<Vec<PluginMarketplace>, String> {
@@ -628,6 +671,30 @@ mod tests {
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].name, "ponytail");
         assert_eq!(parsed[0].source.as_deref(), Some("DietrichGebert/ponytail"));
+    }
+
+    #[test]
+    fn merges_project_plugin_state_from_its_own_directory() {
+        let outside_project = r#"[{
+            "id":"ponytail@ponytail",
+            "scope":"project",
+            "enabled":false,
+            "projectPath":"/tmp/the_old_days"
+        }]"#;
+        let inside_project = r#"[{
+            "id":"ponytail@ponytail",
+            "scope":"project",
+            "enabled":true,
+            "projectPath":"/tmp/the_old_days"
+        }]"#;
+        let mut plugins = parse_plugins_json(PluginApp::Claude, outside_project, false).unwrap();
+        let contextual = parse_plugins_json(PluginApp::Claude, inside_project, false).unwrap();
+
+        merge_contextual_plugin_states(&mut plugins, &contextual, "/tmp/the_old_days");
+
+        assert!(plugins[0].enabled);
+        assert!(!plugins[0].supported_actions.enable);
+        assert!(plugins[0].supported_actions.disable);
     }
 
     #[test]

--- a/src-tauri/src/services/plugin.rs
+++ b/src-tauri/src/services/plugin.rs
@@ -1,0 +1,668 @@
+use crate::codex_config::{read_and_validate_codex_config_text, write_codex_live_config_atomic};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::process::Command;
+use tokio::time::timeout;
+use toml_edit::{value, DocumentMut};
+
+const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PluginApp {
+    Codex,
+    Claude,
+}
+
+impl PluginApp {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Codex => "codex",
+            Self::Claude => "claude",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PluginScope {
+    User,
+    Project,
+    Local,
+}
+
+impl PluginScope {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Project => "project",
+            Self::Local => "local",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginActions {
+    pub install: bool,
+    pub update: bool,
+    pub enable: bool,
+    pub disable: bool,
+    pub uninstall: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginClientStatus {
+    pub app: PluginApp,
+    pub available: bool,
+    pub version: Option<String>,
+    pub error: Option<String>,
+    pub supported_actions: PluginActions,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnifiedPlugin {
+    pub plugin_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub version: Option<String>,
+    pub app: PluginApp,
+    pub marketplace_name: String,
+    pub installed: bool,
+    pub enabled: bool,
+    pub scope: Option<String>,
+    pub project_path: Option<String>,
+    pub source: Option<String>,
+    pub supported_actions: PluginActions,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginMarketplace {
+    pub name: String,
+    pub app: PluginApp,
+    pub source_type: Option<String>,
+    pub source: Option<String>,
+    pub root: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginActionResult {
+    pub success: bool,
+    pub requires_restart: bool,
+    pub command_summary: String,
+}
+
+fn validate_nonempty(value: &str, label: &str) -> Result<(), String> {
+    if value.trim().is_empty()
+        || value.trim_start().starts_with('-')
+        || value.chars().any(char::is_control)
+    {
+        return Err(format!("Invalid {label}"));
+    }
+    #[cfg(target_os = "windows")]
+    if value
+        .chars()
+        .any(|ch| matches!(ch, '&' | '|' | '<' | '>' | '^' | '%' | '!'))
+    {
+        return Err(format!("Invalid {label}"));
+    }
+    Ok(())
+}
+
+fn validate_plugin_id(plugin_id: &str) -> Result<(), String> {
+    validate_nonempty(plugin_id, "plugin id")?;
+    let Some((name, marketplace)) = plugin_id.split_once('@') else {
+        return Err("Plugin id must use plugin@marketplace format".to_string());
+    };
+    if name.is_empty() || marketplace.is_empty() {
+        return Err("Plugin id must use plugin@marketplace format".to_string());
+    }
+    Ok(())
+}
+
+fn executable_for(app: PluginApp) -> PathBuf {
+    crate::commands::resolve_tool_executable(app.as_str())
+        .unwrap_or_else(|| PathBuf::from(app.as_str()))
+}
+
+#[cfg(target_os = "windows")]
+fn command_for(path: &Path, args: &[&str]) -> Result<Command, String> {
+    let is_script = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat"));
+    if is_script {
+        if path.to_string_lossy().chars().any(|ch| {
+            matches!(
+                ch,
+                '&' | '|' | '<' | '>' | '^' | '%' | '!' | '(' | ')' | ';' | ','
+            )
+        }) {
+            return Err("CLI path contains characters unsupported by cmd.exe".to_string());
+        }
+        let mut command = Command::new("cmd");
+        command.args(["/D", "/S", "/C"]).arg(path).args(args);
+        Ok(command)
+    } else {
+        let mut command = Command::new(path);
+        command.args(args);
+        Ok(command)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn command_for(path: &Path, args: &[&str]) -> Result<Command, String> {
+    let mut command = Command::new(path);
+    command.args(args);
+    Ok(command)
+}
+
+async fn run_cli(app: PluginApp, args: &[&str], cwd: Option<&str>) -> Result<String, String> {
+    let path = executable_for(app);
+    let mut command = command_for(&path, args)?;
+    if let Some(cwd) = cwd {
+        validate_nonempty(cwd, "project path")?;
+        if !Path::new(cwd).is_dir() {
+            return Err(format!("Project directory does not exist: {cwd}"));
+        }
+        command.current_dir(cwd);
+    }
+    command.kill_on_drop(true);
+    let output = timeout(CLI_TIMEOUT, command.output())
+        .await
+        .map_err(|_| format!("{} command timed out after 60 seconds", app.as_str()))?
+        .map_err(|e| format!("Failed to run {}: {e}", app.as_str()))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if output.status.success() {
+        Ok(stdout)
+    } else {
+        Err(if stderr.is_empty() { stdout } else { stderr })
+    }
+}
+
+fn string_field(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str).map(str::to_string))
+}
+
+fn source_summary(value: Option<&Value>) -> Option<String> {
+    let source = value?;
+    if let Some(text) = source.as_str() {
+        return Some(text.to_string());
+    }
+    string_field(source, &["url", "path", "source"])
+}
+
+fn plugin_from_value(
+    app: PluginApp,
+    value: &Value,
+    installed_default: bool,
+) -> Option<UnifiedPlugin> {
+    let plugin_id = string_field(value, &["pluginId", "id"])?;
+    let (fallback_name, fallback_marketplace) = plugin_id.split_once('@')?;
+    let fallback_name = fallback_name.to_string();
+    let fallback_marketplace = fallback_marketplace.to_string();
+    let installed = value
+        .get("installed")
+        .and_then(Value::as_bool)
+        .unwrap_or(installed_default);
+    let enabled = value
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(installed);
+    let marketplace_name =
+        string_field(value, &["marketplaceName"]).unwrap_or(fallback_marketplace);
+    Some(UnifiedPlugin {
+        plugin_id,
+        name: string_field(value, &["name"]).unwrap_or(fallback_name),
+        description: string_field(value, &["description"]),
+        version: string_field(value, &["version"]).filter(|version| version != "unknown"),
+        app,
+        marketplace_name,
+        installed,
+        enabled,
+        scope: string_field(value, &["scope"]),
+        project_path: string_field(value, &["projectPath"]),
+        source: source_summary(value.get("source")),
+        supported_actions: PluginActions {
+            install: !installed,
+            update: installed && app == PluginApp::Claude,
+            enable: installed && !enabled,
+            disable: installed && enabled,
+            uninstall: installed,
+        },
+    })
+}
+
+pub fn parse_plugins_json(
+    app: PluginApp,
+    raw: &str,
+    include_available: bool,
+) -> Result<Vec<UnifiedPlugin>, String> {
+    let root: Value = serde_json::from_str(raw).map_err(|e| format!("Invalid plugin JSON: {e}"))?;
+    let installed_values = root
+        .get("installed")
+        .and_then(Value::as_array)
+        .or_else(|| root.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let available_values = root
+        .get("available")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut plugins = BTreeMap::<String, UnifiedPlugin>::new();
+    if include_available {
+        for value in available_values {
+            if let Some(plugin) = plugin_from_value(app, &value, false) {
+                plugins.insert(plugin.plugin_id.clone(), plugin);
+            }
+        }
+    }
+    for value in installed_values {
+        if let Some(mut plugin) = plugin_from_value(app, &value, true) {
+            if let Some(available) = plugins.get(&plugin.plugin_id) {
+                plugin.description = plugin.description.or_else(|| available.description.clone());
+                plugin.source = plugin.source.or_else(|| available.source.clone());
+            }
+            plugins.insert(plugin.plugin_id.clone(), plugin);
+        }
+    }
+    Ok(plugins.into_values().collect())
+}
+
+pub fn parse_marketplaces_json(
+    app: PluginApp,
+    raw: &str,
+) -> Result<Vec<PluginMarketplace>, String> {
+    let root: Value =
+        serde_json::from_str(raw).map_err(|e| format!("Invalid marketplace JSON: {e}"))?;
+    let values = root
+        .get("marketplaces")
+        .and_then(Value::as_array)
+        .or_else(|| root.as_array())
+        .cloned()
+        .unwrap_or_default();
+    Ok(values
+        .iter()
+        .filter_map(|value| {
+            let name = string_field(value, &["name"])?;
+            let nested_source = value.get("marketplaceSource");
+            Some(PluginMarketplace {
+                name,
+                app,
+                source_type: string_field(value, &["sourceType", "source"])
+                    .or_else(|| nested_source.and_then(|s| string_field(s, &["sourceType"]))),
+                source: string_field(value, &["url", "repo"])
+                    .or_else(|| nested_source.and_then(|s| string_field(s, &["source"]))),
+                root: string_field(value, &["root", "installLocation"]),
+            })
+        })
+        .collect())
+}
+
+pub async fn client_status(app: PluginApp) -> PluginClientStatus {
+    let version = match run_cli(app, &["--version"], None).await {
+        Ok(version) => version,
+        Err(error) => {
+            return PluginClientStatus {
+                app,
+                available: false,
+                version: None,
+                error: Some(error),
+                supported_actions: PluginActions::default(),
+            };
+        }
+    };
+    match run_cli(app, &["plugin", "--help"], None).await {
+        Ok(_) => PluginClientStatus {
+            app,
+            available: true,
+            version: Some(version),
+            error: None,
+            supported_actions: PluginActions {
+                install: true,
+                update: app == PluginApp::Claude,
+                enable: true,
+                disable: true,
+                uninstall: true,
+            },
+        },
+        Err(error) => PluginClientStatus {
+            app,
+            available: false,
+            version: None,
+            error: Some(error),
+            supported_actions: PluginActions::default(),
+        },
+    }
+}
+
+pub async fn list_plugins(
+    app: PluginApp,
+    include_available: bool,
+) -> Result<Vec<UnifiedPlugin>, String> {
+    let raw = match app {
+        PluginApp::Codex => {
+            run_cli(app, &["plugin", "list", "--available", "--json"], None).await?
+        }
+        PluginApp::Claude => {
+            run_cli(app, &["plugin", "list", "--available", "--json"], None).await?
+        }
+    };
+    parse_plugins_json(app, &raw, include_available)
+}
+
+pub async fn list_marketplaces(app: PluginApp) -> Result<Vec<PluginMarketplace>, String> {
+    let raw = run_cli(app, &["plugin", "marketplace", "list", "--json"], None).await?;
+    parse_marketplaces_json(app, &raw)
+}
+
+fn action_result(summary: impl Into<String>, requires_restart: bool) -> PluginActionResult {
+    PluginActionResult {
+        success: true,
+        requires_restart,
+        command_summary: summary.into(),
+    }
+}
+
+pub async fn add_marketplace(app: PluginApp, source: &str) -> Result<PluginActionResult, String> {
+    validate_nonempty(source, "marketplace source")?;
+    match app {
+        PluginApp::Codex => {
+            run_cli(
+                app,
+                &["plugin", "marketplace", "add", source, "--json"],
+                None,
+            )
+            .await?;
+        }
+        PluginApp::Claude => {
+            run_cli(
+                app,
+                &["plugin", "marketplace", "add", source, "--scope", "user"],
+                None,
+            )
+            .await?;
+        }
+    }
+    Ok(action_result(
+        format!("{} plugin marketplace add <source>", app.as_str()),
+        false,
+    ))
+}
+
+pub async fn refresh_marketplace(app: PluginApp, name: &str) -> Result<PluginActionResult, String> {
+    validate_nonempty(name, "marketplace name")?;
+    let verb = if app == PluginApp::Codex {
+        "upgrade"
+    } else {
+        "update"
+    };
+    run_cli(app, &["plugin", "marketplace", verb, name], None).await?;
+    Ok(action_result(
+        format!("{} plugin marketplace {verb} {name}", app.as_str()),
+        false,
+    ))
+}
+
+pub async fn remove_marketplace(app: PluginApp, name: &str) -> Result<PluginActionResult, String> {
+    validate_nonempty(name, "marketplace name")?;
+    run_cli(app, &["plugin", "marketplace", "remove", name], None).await?;
+    Ok(action_result(
+        format!("{} plugin marketplace remove {name}", app.as_str()),
+        false,
+    ))
+}
+
+pub async fn install_plugin(
+    app: PluginApp,
+    plugin_id: &str,
+    scope: Option<PluginScope>,
+    project_path: Option<&str>,
+) -> Result<PluginActionResult, String> {
+    validate_plugin_id(plugin_id)?;
+    match app {
+        PluginApp::Codex => {
+            run_cli(app, &["plugin", "add", plugin_id, "--json"], None).await?;
+        }
+        PluginApp::Claude => {
+            let scope = scope.unwrap_or(PluginScope::User);
+            if scope != PluginScope::User && project_path.is_none() {
+                return Err("Project or local scope requires a project directory".to_string());
+            }
+            run_cli(
+                app,
+                &["plugin", "install", plugin_id, "--scope", scope.as_str()],
+                project_path,
+            )
+            .await?;
+        }
+    }
+    Ok(action_result(
+        format!("{} plugin install {plugin_id}", app.as_str()),
+        true,
+    ))
+}
+
+pub async fn update_plugin(
+    app: PluginApp,
+    plugin_id: &str,
+    scope: Option<PluginScope>,
+    project_path: Option<&str>,
+) -> Result<PluginActionResult, String> {
+    validate_plugin_id(plugin_id)?;
+    if app != PluginApp::Claude {
+        return Err(
+            "Codex does not support single-plugin updates; refresh its marketplace instead"
+                .to_string(),
+        );
+    }
+    let scope = scope.unwrap_or(PluginScope::User);
+    run_cli(
+        app,
+        &["plugin", "update", plugin_id, "--scope", scope.as_str()],
+        project_path,
+    )
+    .await?;
+    Ok(action_result(
+        format!("claude plugin update {plugin_id}"),
+        true,
+    ))
+}
+
+pub async fn uninstall_plugin(
+    app: PluginApp,
+    plugin_id: &str,
+    scope: Option<PluginScope>,
+    project_path: Option<&str>,
+) -> Result<PluginActionResult, String> {
+    validate_plugin_id(plugin_id)?;
+    let verb = if app == PluginApp::Codex {
+        "remove"
+    } else {
+        "uninstall"
+    };
+    let mut args = vec!["plugin", verb, plugin_id];
+    if app == PluginApp::Codex {
+        args.push("--json");
+    } else {
+        args.extend(["--scope", scope.unwrap_or(PluginScope::User).as_str()]);
+    }
+    run_cli(app, &args, project_path).await?;
+    Ok(action_result(
+        format!("{} plugin {verb} {plugin_id}", app.as_str()),
+        true,
+    ))
+}
+
+pub fn update_codex_plugin_enabled_toml(
+    raw: &str,
+    plugin_id: &str,
+    enabled: bool,
+) -> Result<String, String> {
+    validate_plugin_id(plugin_id)?;
+    let mut document = if raw.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        raw.parse::<DocumentMut>()
+            .map_err(|e| format!("TOML parse error: {e}"))?
+    };
+    if document.get("plugins").is_none() {
+        document["plugins"] = toml_edit::table();
+    }
+    let plugins = document["plugins"]
+        .as_table_mut()
+        .ok_or_else(|| "Codex plugins config is not a table".to_string())?;
+    if !plugins.contains_key(plugin_id) {
+        plugins[plugin_id] = toml_edit::table();
+    }
+    let plugin = plugins[plugin_id]
+        .as_table_mut()
+        .ok_or_else(|| format!("Codex plugin config is not a table: {plugin_id}"))?;
+    plugin["enabled"] = value(enabled);
+    Ok(document.to_string())
+}
+
+pub async fn set_plugin_enabled(
+    app: PluginApp,
+    plugin_id: &str,
+    enabled: bool,
+    scope: Option<PluginScope>,
+    project_path: Option<&str>,
+) -> Result<PluginActionResult, String> {
+    validate_plugin_id(plugin_id)?;
+    if app == PluginApp::Claude {
+        let verb = if enabled { "enable" } else { "disable" };
+        let scope = scope.unwrap_or(PluginScope::User);
+        run_cli(
+            app,
+            &["plugin", verb, plugin_id, "--scope", scope.as_str()],
+            project_path,
+        )
+        .await?;
+        return Ok(action_result(
+            format!("claude plugin {verb} {plugin_id}"),
+            true,
+        ));
+    }
+
+    let raw = read_and_validate_codex_config_text().map_err(|e| e.to_string())?;
+    let updated = update_codex_plugin_enabled_toml(&raw, plugin_id, enabled)?;
+    write_codex_live_config_atomic(Some(&updated)).map_err(|e| e.to_string())?;
+    Ok(action_result(
+        format!("codex config plugins.{plugin_id}.enabled={enabled}"),
+        true,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_codex_and_claude_shapes() {
+        let codex = serde_json::json!({
+            "installed": [{
+                "pluginId": "ponytail@ponytail",
+                "name": "ponytail",
+                "version": "1.0.0",
+                "installed": true,
+                "enabled": true
+            }],
+            "available": [{
+                "pluginId": "new@market",
+                "name": "new",
+                "description": "New plugin"
+            }]
+        })
+        .to_string();
+        let plugins = parse_plugins_json(PluginApp::Codex, &codex, true).unwrap();
+        assert_eq!(plugins.len(), 2);
+        assert!(plugins
+            .iter()
+            .any(|plugin| plugin.plugin_id == "ponytail@ponytail" && plugin.installed));
+
+        let claude = r#"[{
+            "id":"ponytail@ponytail",
+            "version":"1.0.0",
+            "scope":"user",
+            "enabled":false,
+            "futureField":true
+        }]"#;
+        let plugins = parse_plugins_json(PluginApp::Claude, claude, false).unwrap();
+        assert_eq!(plugins[0].name, "ponytail");
+        assert!(plugins[0].supported_actions.enable);
+    }
+
+    #[test]
+    fn parsers_tolerate_empty_missing_and_future_fields() {
+        assert!(parse_plugins_json(PluginApp::Codex, "{}", true)
+            .unwrap()
+            .is_empty());
+        assert!(parse_plugins_json(PluginApp::Claude, "[]", false)
+            .unwrap()
+            .is_empty());
+
+        let marketplaces = serde_json::json!({
+            "marketplaces": [{
+                "name": "ponytail",
+                "marketplaceSource": {
+                    "sourceType": "github",
+                    "source": "DietrichGebert/ponytail"
+                },
+                "futureField": { "ignored": true }
+            }, {}]
+        })
+        .to_string();
+        let parsed = parse_marketplaces_json(PluginApp::Claude, &marketplaces).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].name, "ponytail");
+        assert_eq!(parsed[0].source.as_deref(), Some("DietrichGebert/ponytail"));
+    }
+
+    #[test]
+    fn codex_toggle_preserves_other_config_and_hooks() {
+        let input = r#"# keep me
+[plugins."ponytail@ponytail"]
+enabled = true
+
+[hooks.state."ponytail@ponytail:hook"]
+trusted_hash = "sha256:abc"
+"#;
+        let output = update_codex_plugin_enabled_toml(input, "ponytail@ponytail", false).unwrap();
+        assert!(output.contains("# keep me"));
+        assert!(output.contains("enabled = false"));
+        assert!(output.contains("trusted_hash = \"sha256:abc\""));
+    }
+
+    #[test]
+    fn rejects_invalid_plugin_ids_and_toml() {
+        assert!(update_codex_plugin_enabled_toml("", "ponytail", true).is_err());
+        assert!(
+            update_codex_plugin_enabled_toml("not = [toml", "ponytail@ponytail", true).is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn project_scope_requires_directory_before_running_cli() {
+        let error = install_plugin(
+            PluginApp::Claude,
+            "ponytail@ponytail",
+            Some(PluginScope::Project),
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("requires a project directory"));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Shield,
   Cpu,
   LayoutDashboard,
+  Puzzle,
 } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { Provider, VisibleApps } from "@/types";
@@ -95,6 +96,7 @@ import ToolsPanel from "@/components/openclaw/ToolsPanel";
 import AgentsDefaultsPanel from "@/components/openclaw/AgentsDefaultsPanel";
 import OpenClawHealthBanner from "@/components/openclaw/OpenClawHealthBanner";
 import HermesMemoryPanel from "@/components/hermes/HermesMemoryPanel";
+import PluginsPage from "@/components/plugins/PluginsPage";
 
 type View =
   | "providers"
@@ -102,6 +104,7 @@ type View =
   | "prompts"
   | "skills"
   | "skillsDiscovery"
+  | "plugins"
   | "mcp"
   | "agents"
   | "universal"
@@ -147,6 +150,7 @@ const VALID_VIEWS: View[] = [
   "prompts",
   "skills",
   "skillsDiscovery",
+  "plugins",
   "mcp",
   "agents",
   "universal",
@@ -231,6 +235,16 @@ function App() {
     }
   }, [sharedFeatureApp, currentView]);
 
+  useEffect(() => {
+    if (
+      currentView === "plugins" &&
+      activeApp !== "claude" &&
+      activeApp !== "codex"
+    ) {
+      setCurrentView("providers");
+    }
+  }, [activeApp, currentView]);
+
   const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
   const [usageProvider, setUsageProvider] = useState<Provider | null>(null);
   const [confirmAction, setConfirmAction] = useState<{
@@ -288,6 +302,7 @@ function App() {
   const { data: openclawHealthWarnings = [] } =
     useOpenClawHealth(isOpenClawView);
   const hasSkillsSupport = sharedFeatureApp !== "openclaw";
+  const hasPluginSupport = activeApp === "claude" || activeApp === "codex";
   const hasSessionSupport =
     sharedFeatureApp === "claude" ||
     sharedFeatureApp === "codex" ||
@@ -929,6 +944,8 @@ function App() {
               onSourceChange={setSkillsDiscoverySource}
             />
           );
+        case "plugins":
+          return <PluginsPage />;
         case "mcp":
           return (
             <UnifiedMcpPanel
@@ -1171,6 +1188,7 @@ function App() {
                     })}
                   {currentView === "skills" && t("skills.title")}
                   {currentView === "skillsDiscovery" && t("skills.title")}
+                  {currentView === "plugins" && t("plugins.title")}
                   {currentView === "mcp" && t("mcp.unifiedPanel.title")}
                   {currentView === "agents" && t("agents.title")}
                   {currentView === "universal" &&
@@ -1524,6 +1542,21 @@ function App() {
                                 title={t("prompts.manage")}
                               >
                                 <Book className="w-4 h-4" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setCurrentView("plugins")}
+                                className={cn(
+                                  "text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5",
+                                  "transition-all duration-200 ease-in-out overflow-hidden",
+                                  hasPluginSupport
+                                    ? "opacity-100 w-8 scale-100 px-2"
+                                    : "opacity-0 w-0 scale-75 pointer-events-none px-0 -ml-1",
+                                )}
+                                title={t("plugins.manage")}
+                              >
+                                <Puzzle className="flex-shrink-0 w-4 h-4" />
                               </Button>
                               <Button
                                 variant="ghost"

--- a/src/components/plugins/PluginsPage.tsx
+++ b/src/components/plugins/PluginsPage.tsx
@@ -94,7 +94,9 @@ export default function PluginsPage() {
     for (const plugin of plugins) {
       if (appFilter !== "all" && plugin.app !== appFilter) continue;
       if (tab === "installed" && !plugin.installed) continue;
-      if (tab === "discover" && plugin.installed) continue;
+      if (tab === "discover" && plugin.installed && plugin.app !== "claude") {
+        continue;
+      }
       const haystack =
         `${plugin.name} ${plugin.pluginId} ${plugin.description ?? ""}`.toLowerCase();
       if (!haystack.includes(search.trim().toLowerCase())) continue;
@@ -206,18 +208,18 @@ export default function PluginsPage() {
             placeholder={t("plugins.search")}
             className="min-w-56 flex-1"
           />
-          <div className="flex items-center gap-1 rounded-lg bg-muted p-1">
-            {(["all", ...APPS] as const).map((app) => (
-              <Button
-                key={app}
-                size="sm"
-                variant={appFilter === app ? "secondary" : "ghost"}
-                onClick={() => setAppFilter(app)}
-              >
-                {app === "all" ? t("common.all") : t(`plugins.apps.${app}`)}
-              </Button>
-            ))}
-          </div>
+          <Tabs
+            value={appFilter}
+            onValueChange={(value) => setAppFilter(value as typeof appFilter)}
+          >
+            <TabsList>
+              {(["all", ...APPS] as const).map((app) => (
+                <TabsTrigger key={app} value={app}>
+                  {app === "all" ? t("common.all") : t(`plugins.apps.${app}`)}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
         </div>
 
         {sourceQueries.map((query, index) =>
@@ -277,7 +279,7 @@ export default function PluginsPage() {
                       {plugin.scope ? ` · ${plugin.scope}` : ""}
                     </span>
                     <div className="ml-auto flex items-center gap-2">
-                      {plugin.installed && (
+                      {tab === "installed" && plugin.installed && (
                         <Switch
                           checked={plugin.enabled}
                           disabled={mutation.isPending}
@@ -294,62 +296,68 @@ export default function PluginsPage() {
                           }
                         />
                       )}
-                      {plugin.supportedActions.update && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          disabled={mutation.isPending}
-                          onClick={() =>
-                            void run({
-                              action: "update",
-                              app: plugin.app,
-                              pluginId: plugin.pluginId,
-                              scope: plugin.scope,
-                              projectPath: plugin.projectPath,
-                            })
-                          }
-                        >
-                          <RefreshCw
-                            data-icon="inline-start"
-                            className="size-4"
-                          />
-                          {t("plugins.update")}
-                        </Button>
-                      )}
-                      {plugin.supportedActions.install && (
-                        <Button
-                          size="sm"
-                          disabled={mutation.isPending}
-                          onClick={() => {
-                            if (plugin.app === "claude") {
-                              setInstallScope("user");
-                              setInstallProjectPath("");
-                              setInstallTarget(plugin);
-                            } else {
-                              void install(plugin);
+                      {tab === "installed" &&
+                        plugin.supportedActions.update && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            disabled={mutation.isPending}
+                            onClick={() =>
+                              void run({
+                                action: "update",
+                                app: plugin.app,
+                                pluginId: plugin.pluginId,
+                                scope: plugin.scope,
+                                projectPath: plugin.projectPath,
+                              })
                             }
-                          }}
-                        >
-                          <Download
-                            data-icon="inline-start"
-                            className="size-4"
-                          />
-                          {t("plugins.install")}
-                        </Button>
-                      )}
-                      {plugin.supportedActions.uninstall && (
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          disabled={mutation.isPending}
-                          title={t("plugins.uninstall")}
-                          onClick={() =>
-                            setConfirmAction({ type: "uninstall", plugin })
-                          }
-                        >
-                          <Trash2 className="size-4 text-destructive" />
-                        </Button>
-                      )}
+                          >
+                            <RefreshCw
+                              data-icon="inline-start"
+                              className="size-4"
+                            />
+                            {t("plugins.update")}
+                          </Button>
+                        )}
+                      {tab === "discover" &&
+                        (plugin.supportedActions.install ||
+                          plugin.app === "claude") && (
+                          <Button
+                            size="sm"
+                            disabled={mutation.isPending}
+                            onClick={() => {
+                              if (plugin.app === "claude") {
+                                setInstallScope(
+                                  plugin.scope === "user" ? "project" : "user",
+                                );
+                                setInstallProjectPath("");
+                                setInstallTarget(plugin);
+                              } else {
+                                void install(plugin);
+                              }
+                            }}
+                          >
+                            <Download
+                              data-icon="inline-start"
+                              className="size-4"
+                            />
+                            {t("plugins.install")}
+                          </Button>
+                        )}
+                      {tab === "installed" &&
+                        plugin.supportedActions.uninstall && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            disabled={mutation.isPending}
+                            title={t("plugins.uninstall")}
+                            onClick={() =>
+                              setConfirmAction({ type: "uninstall", plugin })
+                            }
+                          >
+                            <Trash2 className="size-4 text-destructive" />
+                          </Button>
+                        )}
                     </div>
                   </div>
                 ))}
@@ -374,18 +382,18 @@ export default function PluginsPage() {
             </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-4 overflow-y-auto px-6 py-4">
-            <div className="flex gap-2">
-              {APPS.map((app) => (
-                <Button
-                  key={app}
-                  size="sm"
-                  variant={marketplaceApp === app ? "secondary" : "outline"}
-                  onClick={() => setMarketplaceApp(app)}
-                >
-                  {t(`plugins.apps.${app}`)}
-                </Button>
-              ))}
-            </div>
+            <Tabs
+              value={marketplaceApp}
+              onValueChange={(value) => setMarketplaceApp(value as PluginApp)}
+            >
+              <TabsList>
+                {APPS.map((app) => (
+                  <TabsTrigger key={app} value={app}>
+                    {t(`plugins.apps.${app}`)}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
             <div className="flex gap-2">
               <Input
                 value={marketplaceSource}

--- a/src/components/plugins/PluginsPage.tsx
+++ b/src/components/plugins/PluginsPage.tsx
@@ -53,6 +53,15 @@ type ConfirmAction =
   | { type: "uninstall"; plugin: UnifiedPlugin }
   | { type: "marketplace"; marketplace: PluginMarketplace };
 
+function pluginInstallationKey(plugin: UnifiedPlugin) {
+  return [
+    plugin.pluginId,
+    plugin.app,
+    plugin.scope ?? "",
+    plugin.projectPath ?? "",
+  ].join("\u0000");
+}
+
 export default function PluginsPage() {
   const { t } = useTranslation();
   const [tab, setTab] = useState<"installed" | "discover">("installed");
@@ -267,7 +276,7 @@ export default function PluginsPage() {
                 </div>
                 {entries.map((plugin) => (
                   <div
-                    key={`${plugin.pluginId}-${plugin.app}`}
+                    key={pluginInstallationKey(plugin)}
                     className="flex flex-wrap items-center gap-3 bg-muted/20 px-4 py-2"
                   >
                     <Badge variant="outline">
@@ -277,6 +286,7 @@ export default function PluginsPage() {
                       {plugin.version ?? t("plugins.unknownVersion")} ·{" "}
                       {plugin.marketplaceName}
                       {plugin.scope ? ` · ${plugin.scope}` : ""}
+                      {plugin.projectPath ? ` · ${plugin.projectPath}` : ""}
                     </span>
                     <div className="ml-auto flex items-center gap-2">
                       {tab === "installed" && plugin.installed && (

--- a/src/components/plugins/PluginsPage.tsx
+++ b/src/components/plugins/PluginsPage.tsx
@@ -1,0 +1,577 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Download,
+  FolderOpen,
+  Loader2,
+  Puzzle,
+  RefreshCw,
+  Store,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import {
+  usePluginMarketplaces,
+  usePluginMutation,
+  usePlugins,
+  usePluginStatuses,
+} from "@/hooks/usePlugins";
+import type {
+  PluginApp,
+  PluginMarketplace,
+  PluginScope,
+  UnifiedPlugin,
+} from "@/lib/api/plugins";
+import { settingsApi } from "@/lib/api";
+
+const APPS: PluginApp[] = ["codex", "claude"];
+
+type ConfirmAction =
+  | { type: "uninstall"; plugin: UnifiedPlugin }
+  | { type: "marketplace"; marketplace: PluginMarketplace };
+
+export default function PluginsPage() {
+  const { t } = useTranslation();
+  const [tab, setTab] = useState<"installed" | "discover">("installed");
+  const [appFilter, setAppFilter] = useState<"all" | PluginApp>("all");
+  const [search, setSearch] = useState("");
+  const [marketplacesOpen, setMarketplacesOpen] = useState(false);
+  const [marketplaceApp, setMarketplaceApp] = useState<PluginApp>("codex");
+  const [marketplaceSource, setMarketplaceSource] = useState("");
+  const [installTarget, setInstallTarget] = useState<UnifiedPlugin | null>(
+    null,
+  );
+  const [installScope, setInstallScope] = useState<PluginScope>("user");
+  const [installProjectPath, setInstallProjectPath] = useState("");
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(
+    null,
+  );
+
+  const statuses = usePluginStatuses();
+  const codexInstalled = usePlugins("codex", false);
+  const claudeInstalled = usePlugins("claude", false);
+  const codexAvailable = usePlugins("codex", true, tab === "discover");
+  const claudeAvailable = usePlugins("claude", true, tab === "discover");
+  const codexMarketplaces = usePluginMarketplaces("codex", marketplacesOpen);
+  const claudeMarketplaces = usePluginMarketplaces("claude", marketplacesOpen);
+  const mutation = usePluginMutation();
+
+  const sourceQueries =
+    tab === "discover"
+      ? [codexAvailable, claudeAvailable]
+      : [codexInstalled, claudeInstalled];
+  const loading = sourceQueries.some((query) => query.isLoading);
+
+  const groups = useMemo(() => {
+    const grouped = new Map<string, UnifiedPlugin[]>();
+    const plugins =
+      tab === "discover"
+        ? [...(codexAvailable.data ?? []), ...(claudeAvailable.data ?? [])]
+        : [...(codexInstalled.data ?? []), ...(claudeInstalled.data ?? [])];
+    for (const plugin of plugins) {
+      if (appFilter !== "all" && plugin.app !== appFilter) continue;
+      if (tab === "installed" && !plugin.installed) continue;
+      if (tab === "discover" && plugin.installed) continue;
+      const haystack =
+        `${plugin.name} ${plugin.pluginId} ${plugin.description ?? ""}`.toLowerCase();
+      if (!haystack.includes(search.trim().toLowerCase())) continue;
+      grouped.set(plugin.pluginId, [
+        ...(grouped.get(plugin.pluginId) ?? []),
+        plugin,
+      ]);
+    }
+    return [...grouped.entries()].slice(0, 200);
+  }, [
+    appFilter,
+    claudeAvailable.data,
+    claudeInstalled.data,
+    codexAvailable.data,
+    codexInstalled.data,
+    search,
+    tab,
+  ]);
+
+  const run = async (request: Parameters<typeof mutation.mutateAsync>[0]) => {
+    try {
+      const result = await mutation.mutateAsync(request);
+      toast.success(t("plugins.actionSuccess"), {
+        description: result.requiresRestart
+          ? t("plugins.restartHint")
+          : result.commandSummary,
+        closeButton: true,
+      });
+      return true;
+    } catch (error) {
+      toast.error(t("plugins.actionFailed"), {
+        description: String(error),
+        closeButton: true,
+      });
+      return false;
+    }
+  };
+
+  const install = async (
+    plugin: UnifiedPlugin,
+    scope?: PluginScope,
+    projectPath?: string,
+  ) => {
+    const ok = await run({
+      action: "install",
+      app: plugin.app,
+      pluginId: plugin.pluginId,
+      scope,
+      projectPath,
+    });
+    if (ok) setInstallTarget(null);
+  };
+
+  const marketplaces =
+    marketplaceApp === "codex"
+      ? (codexMarketplaces.data ?? [])
+      : (claudeMarketplaces.data ?? []);
+
+  return (
+    <div className="h-full overflow-y-auto px-6 pb-8 pt-4">
+      <div className="mx-auto flex max-w-5xl flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Tabs
+            value={tab}
+            onValueChange={(value) => setTab(value as typeof tab)}
+          >
+            <TabsList>
+              {(["installed", "discover"] as const).map((value) => (
+                <TabsTrigger key={value} value={value}>
+                  {t(`plugins.tabs.${value}`)}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+          <Button variant="outline" onClick={() => setMarketplacesOpen(true)}>
+            <Store data-icon="inline-start" className="size-4" />
+            {t("plugins.marketplaces.title")}
+          </Button>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {APPS.map((app) => {
+            const status = statuses.data?.find((item) => item.app === app);
+            return (
+              <div
+                key={app}
+                className="flex items-center justify-between rounded-lg border border-border-default bg-card px-4 py-3"
+              >
+                <div>
+                  <div className="font-medium">{t(`plugins.apps.${app}`)}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {status?.version ?? status?.error ?? t("plugins.detecting")}
+                  </div>
+                </div>
+                <Badge variant={status?.available ? "secondary" : "outline"}>
+                  {status?.available
+                    ? t("plugins.available")
+                    : t("plugins.unavailable")}
+                </Badge>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder={t("plugins.search")}
+            className="min-w-56 flex-1"
+          />
+          <div className="flex items-center gap-1 rounded-lg bg-muted p-1">
+            {(["all", ...APPS] as const).map((app) => (
+              <Button
+                key={app}
+                size="sm"
+                variant={appFilter === app ? "secondary" : "ghost"}
+                onClick={() => setAppFilter(app)}
+              >
+                {app === "all" ? t("common.all") : t(`plugins.apps.${app}`)}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        {sourceQueries.map((query, index) =>
+          query.error ? (
+            <Alert key={APPS[index]} variant="destructive">
+              <AlertDescription>
+                {t(`plugins.apps.${APPS[index]}`)}: {String(query.error)}
+              </AlertDescription>
+            </Alert>
+          ) : null,
+        )}
+
+        {loading ? (
+          <div className="flex justify-center py-16">
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : groups.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border-default py-16 text-center text-muted-foreground">
+            <Puzzle className="mx-auto mb-3 size-8 opacity-50" />
+            {t("plugins.empty")}
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-border-default bg-card">
+            {groups.map(([pluginId, entries], index) => (
+              <div
+                key={pluginId}
+                className={
+                  index + 1 < groups.length
+                    ? "border-b border-border-default"
+                    : ""
+                }
+              >
+                <div className="px-4 pb-2 pt-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{entries[0].name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {pluginId}
+                    </span>
+                  </div>
+                  {entries[0].description && (
+                    <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                      {entries[0].description}
+                    </p>
+                  )}
+                </div>
+                {entries.map((plugin) => (
+                  <div
+                    key={`${plugin.pluginId}-${plugin.app}`}
+                    className="flex flex-wrap items-center gap-3 bg-muted/20 px-4 py-2"
+                  >
+                    <Badge variant="outline">
+                      {t(`plugins.apps.${plugin.app}`)}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      {plugin.version ?? t("plugins.unknownVersion")} ·{" "}
+                      {plugin.marketplaceName}
+                      {plugin.scope ? ` · ${plugin.scope}` : ""}
+                    </span>
+                    <div className="ml-auto flex items-center gap-2">
+                      {plugin.installed && (
+                        <Switch
+                          checked={plugin.enabled}
+                          disabled={mutation.isPending}
+                          aria-label={t("plugins.enabled")}
+                          onCheckedChange={(enabled) =>
+                            void run({
+                              action: "setEnabled",
+                              app: plugin.app,
+                              pluginId: plugin.pluginId,
+                              enabled,
+                              scope: plugin.scope,
+                              projectPath: plugin.projectPath,
+                            })
+                          }
+                        />
+                      )}
+                      {plugin.supportedActions.update && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={mutation.isPending}
+                          onClick={() =>
+                            void run({
+                              action: "update",
+                              app: plugin.app,
+                              pluginId: plugin.pluginId,
+                              scope: plugin.scope,
+                              projectPath: plugin.projectPath,
+                            })
+                          }
+                        >
+                          <RefreshCw
+                            data-icon="inline-start"
+                            className="size-4"
+                          />
+                          {t("plugins.update")}
+                        </Button>
+                      )}
+                      {plugin.supportedActions.install && (
+                        <Button
+                          size="sm"
+                          disabled={mutation.isPending}
+                          onClick={() => {
+                            if (plugin.app === "claude") {
+                              setInstallScope("user");
+                              setInstallProjectPath("");
+                              setInstallTarget(plugin);
+                            } else {
+                              void install(plugin);
+                            }
+                          }}
+                        >
+                          <Download
+                            data-icon="inline-start"
+                            className="size-4"
+                          />
+                          {t("plugins.install")}
+                        </Button>
+                      )}
+                      {plugin.supportedActions.uninstall && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          disabled={mutation.isPending}
+                          title={t("plugins.uninstall")}
+                          onClick={() =>
+                            setConfirmAction({ type: "uninstall", plugin })
+                          }
+                        >
+                          <Trash2 className="size-4 text-destructive" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {groups.length === 200 && (
+          <p className="text-center text-xs text-muted-foreground">
+            {t("plugins.resultLimit")}
+          </p>
+        )}
+      </div>
+
+      <Dialog open={marketplacesOpen} onOpenChange={setMarketplacesOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{t("plugins.marketplaces.title")}</DialogTitle>
+            <DialogDescription>
+              {t("plugins.marketplaces.description")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4 overflow-y-auto px-6 py-4">
+            <div className="flex gap-2">
+              {APPS.map((app) => (
+                <Button
+                  key={app}
+                  size="sm"
+                  variant={marketplaceApp === app ? "secondary" : "outline"}
+                  onClick={() => setMarketplaceApp(app)}
+                >
+                  {t(`plugins.apps.${app}`)}
+                </Button>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <Input
+                value={marketplaceSource}
+                onChange={(event) => setMarketplaceSource(event.target.value)}
+                placeholder={t("plugins.marketplaces.sourcePlaceholder")}
+              />
+              <Button
+                disabled={!marketplaceSource.trim() || mutation.isPending}
+                onClick={async () => {
+                  const ok = await run({
+                    action: "addMarketplace",
+                    app: marketplaceApp,
+                    source: marketplaceSource.trim(),
+                  });
+                  if (ok) setMarketplaceSource("");
+                }}
+              >
+                {t("plugins.marketplaces.add")}
+              </Button>
+            </div>
+            <div className="divide-y divide-border-default rounded-lg border border-border-default">
+              {marketplaces.map((marketplace) => (
+                <div
+                  key={marketplace.name}
+                  className="flex items-center gap-3 px-3 py-2"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="font-medium">{marketplace.name}</div>
+                    <div className="truncate text-xs text-muted-foreground">
+                      {marketplace.source ??
+                        marketplace.root ??
+                        marketplace.sourceType}
+                    </div>
+                  </div>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    title={t("plugins.marketplaces.refresh")}
+                    onClick={() =>
+                      void run({
+                        action: "refreshMarketplace",
+                        app: marketplace.app,
+                        name: marketplace.name,
+                      })
+                    }
+                  >
+                    <RefreshCw className="size-4" />
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    title={t("common.delete")}
+                    onClick={() =>
+                      setConfirmAction({ type: "marketplace", marketplace })
+                    }
+                  >
+                    <Trash2 className="size-4 text-destructive" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setMarketplacesOpen(false)}
+            >
+              {t("common.close")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(installTarget)}
+        onOpenChange={(open) => !open && setInstallTarget(null)}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t("plugins.scope.title")}</DialogTitle>
+            <DialogDescription>{installTarget?.pluginId}</DialogDescription>
+          </DialogHeader>
+          <div className="px-6 py-4">
+            <Select
+              value={installScope}
+              onValueChange={(value) => setInstallScope(value as PluginScope)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {(["user", "project", "local"] as const).map((scope) => (
+                    <SelectItem key={scope} value={scope}>
+                      {t(`plugins.scope.${scope}`)}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            {installScope !== "user" && (
+              <div className="mt-3 flex gap-2">
+                <Input
+                  readOnly
+                  value={installProjectPath}
+                  placeholder={t("plugins.scope.projectPath")}
+                />
+                <Button
+                  variant="outline"
+                  onClick={async () => {
+                    const path = await settingsApi.pickDirectory(
+                      installProjectPath || undefined,
+                    );
+                    if (path) setInstallProjectPath(path);
+                  }}
+                >
+                  <FolderOpen data-icon="inline-start" className="size-4" />
+                  {t("plugins.scope.browse")}
+                </Button>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setInstallTarget(null)}>
+              {t("common.cancel")}
+            </Button>
+            <Button
+              disabled={mutation.isPending}
+              onClick={() => {
+                if (!installTarget) return;
+                if (installScope !== "user" && !installProjectPath) {
+                  toast.error(t("plugins.scope.projectPathRequired"));
+                  return;
+                }
+                void install(
+                  installTarget,
+                  installScope,
+                  installScope === "user" ? undefined : installProjectPath,
+                );
+              }}
+            >
+              {t("plugins.install")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {confirmAction && (
+        <ConfirmDialog
+          isOpen={true}
+          title={
+            confirmAction.type === "uninstall"
+              ? t("plugins.uninstall")
+              : t("plugins.marketplaces.remove")
+          }
+          message={
+            confirmAction.type === "uninstall"
+              ? t("plugins.uninstallConfirm", {
+                  name: confirmAction.plugin.name,
+                  app: t(`plugins.apps.${confirmAction.plugin.app}`),
+                })
+              : t("plugins.marketplaces.removeConfirm", {
+                  name: confirmAction.marketplace.name,
+                })
+          }
+          onCancel={() => setConfirmAction(null)}
+          onConfirm={() => {
+            const request =
+              confirmAction.type === "uninstall"
+                ? {
+                    action: "uninstall" as const,
+                    app: confirmAction.plugin.app,
+                    pluginId: confirmAction.plugin.pluginId,
+                    scope: confirmAction.plugin.scope,
+                    projectPath: confirmAction.plugin.projectPath,
+                  }
+                : {
+                    action: "removeMarketplace" as const,
+                    app: confirmAction.marketplace.app,
+                    name: confirmAction.marketplace.name,
+                  };
+            setConfirmAction(null);
+            void run(request);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/plugins/PluginsPage.tsx
+++ b/src/components/plugins/PluginsPage.tsx
@@ -374,14 +374,14 @@ export default function PluginsPage() {
       </div>
 
       <Dialog open={marketplacesOpen} onOpenChange={setMarketplacesOpen}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-2xl" zIndex="alert">
           <DialogHeader>
             <DialogTitle>{t("plugins.marketplaces.title")}</DialogTitle>
             <DialogDescription>
               {t("plugins.marketplaces.description")}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col gap-4 overflow-y-auto px-6 py-4">
+          <div className="flex min-h-0 flex-col gap-4 overflow-y-auto px-6 py-4">
             <Tabs
               value={marketplaceApp}
               onValueChange={(value) => setMarketplaceApp(value as PluginApp)}
@@ -428,20 +428,22 @@ export default function PluginsPage() {
                         marketplace.sourceType}
                     </div>
                   </div>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    title={t("plugins.marketplaces.refresh")}
-                    onClick={() =>
-                      void run({
-                        action: "refreshMarketplace",
-                        app: marketplace.app,
-                        name: marketplace.name,
-                      })
-                    }
-                  >
-                    <RefreshCw className="size-4" />
-                  </Button>
+                  {marketplace.supportsRefresh && (
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      title={t("plugins.marketplaces.refresh")}
+                      onClick={() =>
+                        void run({
+                          action: "refreshMarketplace",
+                          app: marketplace.app,
+                          name: marketplace.name,
+                        })
+                      }
+                    >
+                      <RefreshCw className="size-4" />
+                    </Button>
+                  )}
                   <Button
                     size="icon"
                     variant="ghost"

--- a/src/hooks/usePlugins.ts
+++ b/src/hooks/usePlugins.ts
@@ -1,0 +1,122 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  pluginsApi,
+  type PluginApp,
+  type PluginScope,
+} from "@/lib/api/plugins";
+
+export const pluginKeys = {
+  all: ["plugins"] as const,
+  statuses: ["plugins", "statuses"] as const,
+  list: (app: PluginApp, includeAvailable: boolean) =>
+    ["plugins", "list", app, includeAvailable] as const,
+  marketplaces: (app: PluginApp) => ["plugins", "marketplaces", app] as const,
+};
+
+export function usePluginStatuses() {
+  return useQuery({
+    queryKey: pluginKeys.statuses,
+    queryFn: pluginsApi.getClientStatuses,
+  });
+}
+
+export function usePlugins(
+  app: PluginApp,
+  includeAvailable: boolean,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: pluginKeys.list(app, includeAvailable),
+    queryFn: () => pluginsApi.list(app, includeAvailable),
+    enabled,
+  });
+}
+
+export function usePluginMarketplaces(app: PluginApp, enabled = true) {
+  return useQuery({
+    queryKey: pluginKeys.marketplaces(app),
+    queryFn: () => pluginsApi.listMarketplaces(app),
+    enabled,
+  });
+}
+
+export type PluginMutation =
+  | { action: "addMarketplace"; app: PluginApp; source: string }
+  | { action: "refreshMarketplace"; app: PluginApp; name: string }
+  | { action: "removeMarketplace"; app: PluginApp; name: string }
+  | {
+      action: "install";
+      app: PluginApp;
+      pluginId: string;
+      scope?: PluginScope;
+      projectPath?: string;
+    }
+  | {
+      action: "update";
+      app: PluginApp;
+      pluginId: string;
+      scope?: PluginScope;
+      projectPath?: string;
+    }
+  | {
+      action: "setEnabled";
+      app: PluginApp;
+      pluginId: string;
+      enabled: boolean;
+      scope?: PluginScope;
+      projectPath?: string;
+    }
+  | {
+      action: "uninstall";
+      app: PluginApp;
+      pluginId: string;
+      scope?: PluginScope;
+      projectPath?: string;
+    };
+
+export function usePluginMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (request: PluginMutation) => {
+      switch (request.action) {
+        case "addMarketplace":
+          return pluginsApi.addMarketplace(request.app, request.source);
+        case "refreshMarketplace":
+          return pluginsApi.refreshMarketplace(request.app, request.name);
+        case "removeMarketplace":
+          return pluginsApi.removeMarketplace(request.app, request.name);
+        case "install":
+          return pluginsApi.install(
+            request.app,
+            request.pluginId,
+            request.scope,
+            request.projectPath,
+          );
+        case "update":
+          return pluginsApi.update(
+            request.app,
+            request.pluginId,
+            request.scope,
+            request.projectPath,
+          );
+        case "setEnabled":
+          return pluginsApi.setEnabled(
+            request.app,
+            request.pluginId,
+            request.enabled,
+            request.scope,
+            request.projectPath,
+          );
+        case "uninstall":
+          return pluginsApi.uninstall(
+            request.app,
+            request.pluginId,
+            request.scope,
+            request.projectPath,
+          );
+      }
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: pluginKeys.all }),
+  });
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2179,6 +2179,45 @@
       "noSelection": "Please select environment variables to delete"
     }
   },
+  "plugins": {
+    "title": "Plugins",
+    "manage": "Manage plugins",
+    "tabs": { "installed": "Installed", "discover": "Discover" },
+    "apps": { "codex": "Codex", "claude": "Claude Code" },
+    "detecting": "Detecting client...",
+    "available": "Available",
+    "unavailable": "Unavailable",
+    "search": "Search plugin name, ID, or description...",
+    "empty": "No matching plugins",
+    "unknownVersion": "Unknown version",
+    "enabled": "Enable plugin",
+    "install": "Install",
+    "uninstall": "Uninstall",
+    "update": "Update",
+    "actionSuccess": "Plugin action completed",
+    "actionFailed": "Plugin action failed",
+    "restartHint": "Restart the client or start a new session. Plugins with hooks still require review and trust in the native client.",
+    "resultLimit": "Only the first 200 results are shown. Use search to narrow the list.",
+    "uninstallConfirm": "Uninstall \"{{name}}\" from {{app}}? The other client's installation is not affected.",
+    "scope": {
+      "title": "Choose Claude install scope",
+      "user": "User (all projects)",
+      "project": "Project (shared)",
+      "local": "Local (current project)",
+      "projectPath": "Choose a project directory",
+      "projectPathRequired": "Project and local scopes require a project directory",
+      "browse": "Browse"
+    },
+    "marketplaces": {
+      "title": "Plugin marketplaces",
+      "description": "Manage the native Codex and Claude Code marketplaces separately.",
+      "sourcePlaceholder": "GitHub owner/repo, Git URL, or local path",
+      "add": "Add",
+      "refresh": "Refresh",
+      "remove": "Remove marketplace",
+      "removeConfirm": "Removing marketplace \"{{name}}\" may also uninstall its plugins. Continue?"
+    }
+  },
   "skills": {
     "manage": "Skills",
     "title": "Skills Management",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2179,6 +2179,45 @@
       "noSelection": "削除する環境変数を選択してください"
     }
   },
+  "plugins": {
+    "title": "プラグイン",
+    "manage": "プラグインを管理",
+    "tabs": { "installed": "インストール済み", "discover": "探す" },
+    "apps": { "codex": "Codex", "claude": "Claude Code" },
+    "detecting": "クライアントを検出中...",
+    "available": "利用可能",
+    "unavailable": "利用不可",
+    "search": "プラグイン名、ID、説明を検索...",
+    "empty": "一致するプラグインがありません",
+    "unknownVersion": "不明なバージョン",
+    "enabled": "プラグインを有効化",
+    "install": "インストール",
+    "uninstall": "アンインストール",
+    "update": "更新",
+    "actionSuccess": "プラグイン操作が完了しました",
+    "actionFailed": "プラグイン操作に失敗しました",
+    "restartHint": "クライアントを再起動するか新しいセッションを開始してください。Hooks を含むプラグインはネイティブクライアントでの確認と信頼が必要です。",
+    "resultLimit": "最初の 200 件のみ表示しています。検索で絞り込んでください。",
+    "uninstallConfirm": "「{{name}}」を {{app}} からアンインストールしますか？もう一方のクライアントには影響しません。",
+    "scope": {
+      "title": "Claude のインストール範囲",
+      "user": "ユーザー（すべてのプロジェクト）",
+      "project": "プロジェクト（共有）",
+      "local": "ローカル（現在のプロジェクト）",
+      "projectPath": "プロジェクトディレクトリを選択",
+      "projectPathRequired": "プロジェクトとローカル範囲にはプロジェクトディレクトリが必要です",
+      "browse": "参照"
+    },
+    "marketplaces": {
+      "title": "プラグインマーケットプレイス",
+      "description": "Codex と Claude Code のネイティブ Marketplace を個別に管理します。",
+      "sourcePlaceholder": "GitHub owner/repo、Git URL、またはローカルパス",
+      "add": "追加",
+      "refresh": "更新",
+      "remove": "マーケットプレイスを削除",
+      "removeConfirm": "マーケットプレイス「{{name}}」を削除すると、そのプラグインも削除される場合があります。続行しますか？"
+    }
+  },
   "skills": {
     "manage": "Skills",
     "title": "Skills 管理",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2151,6 +2151,45 @@
       "noSelection": "請選擇要刪除的環境變數"
     }
   },
+  "plugins": {
+    "title": "外掛程式",
+    "manage": "管理外掛程式",
+    "tabs": { "installed": "已安裝", "discover": "探索" },
+    "apps": { "codex": "Codex", "claude": "Claude Code" },
+    "detecting": "正在偵測客戶端...",
+    "available": "可用",
+    "unavailable": "不可用",
+    "search": "搜尋外掛程式名稱、ID 或描述...",
+    "empty": "沒有符合的外掛程式",
+    "unknownVersion": "未知版本",
+    "enabled": "啟用外掛程式",
+    "install": "安裝",
+    "uninstall": "解除安裝",
+    "update": "更新",
+    "actionSuccess": "外掛程式操作成功",
+    "actionFailed": "外掛程式操作失敗",
+    "restartHint": "請重新啟動客戶端或建立新工作階段。包含 Hooks 的外掛程式仍需在原生客戶端中審核並信任。",
+    "resultLimit": "僅顯示前 200 筆，請使用搜尋縮小範圍。",
+    "uninstallConfirm": "確定要從 {{app}} 解除安裝「{{name}}」嗎？另一個客戶端不受影響。",
+    "scope": {
+      "title": "選擇 Claude 安裝範圍",
+      "user": "使用者（所有專案）",
+      "project": "專案（與協作者共用）",
+      "local": "本機（僅目前專案）",
+      "projectPath": "選擇專案目錄",
+      "projectPathRequired": "專案或本機範圍必須選擇專案目錄",
+      "browse": "瀏覽"
+    },
+    "marketplaces": {
+      "title": "外掛程式市集",
+      "description": "分別管理 Codex 與 Claude Code 的原生 Marketplace。",
+      "sourcePlaceholder": "GitHub owner/repo、Git URL 或本機路徑",
+      "add": "新增",
+      "refresh": "重新整理",
+      "remove": "移除市集",
+      "removeConfirm": "移除市集「{{name}}」可能同時解除安裝其外掛程式，是否繼續？"
+    }
+  },
   "skills": {
     "manage": "Skills",
     "title": "Skills 管理",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2179,6 +2179,45 @@
       "noSelection": "请选择要删除的环境变量"
     }
   },
+  "plugins": {
+    "title": "插件",
+    "manage": "管理插件",
+    "tabs": { "installed": "已安装", "discover": "发现" },
+    "apps": { "codex": "Codex", "claude": "Claude Code" },
+    "detecting": "正在检测客户端...",
+    "available": "可用",
+    "unavailable": "不可用",
+    "search": "搜索插件名称、ID 或描述...",
+    "empty": "没有匹配的插件",
+    "unknownVersion": "未知版本",
+    "enabled": "启用插件",
+    "install": "安装",
+    "uninstall": "卸载",
+    "update": "更新",
+    "actionSuccess": "插件操作成功",
+    "actionFailed": "插件操作失败",
+    "restartHint": "请重启客户端或新建会话。包含 Hooks 的插件仍需在原生客户端中审核并信任。",
+    "resultLimit": "仅显示前 200 项，请使用搜索缩小范围。",
+    "uninstallConfirm": "确定要从 {{app}} 卸载“{{name}}”吗？另一客户端中的安装不会受影响。",
+    "scope": {
+      "title": "选择 Claude 安装范围",
+      "user": "用户（所有项目）",
+      "project": "项目（与协作者共享）",
+      "local": "本地（仅当前项目）",
+      "projectPath": "选择项目目录",
+      "projectPathRequired": "项目或本地范围必须选择项目目录",
+      "browse": "浏览"
+    },
+    "marketplaces": {
+      "title": "插件市场",
+      "description": "分别管理 Codex 与 Claude Code 的原生 Marketplace。",
+      "sourcePlaceholder": "GitHub owner/repo、Git URL 或本地路径",
+      "add": "添加",
+      "refresh": "刷新",
+      "remove": "删除插件市场",
+      "removeConfirm": "删除插件市场“{{name}}”可能同时卸载来自该市场的插件，是否继续？"
+    }
+  },
   "skills": {
     "manage": "Skills",
     "title": "Skills 管理",

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -6,6 +6,16 @@ export { mcpApi } from "./mcp";
 export { profilesApi } from "./profiles";
 export { promptsApi } from "./prompts";
 export { skillsApi } from "./skills";
+export { pluginsApi } from "./plugins";
+export type {
+  PluginActionResult,
+  PluginActions,
+  PluginApp,
+  PluginClientStatus,
+  PluginMarketplace,
+  PluginScope,
+  UnifiedPlugin,
+} from "./plugins";
 export { usageApi } from "./usage";
 export { subscriptionApi } from "./subscription";
 export { vscodeApi } from "./vscode";

--- a/src/lib/api/plugins.ts
+++ b/src/lib/api/plugins.ts
@@ -40,6 +40,7 @@ export interface PluginMarketplace {
   sourceType?: string;
   source?: string;
   root?: string;
+  supportsRefresh: boolean;
 }
 
 export interface PluginActionResult {

--- a/src/lib/api/plugins.ts
+++ b/src/lib/api/plugins.ts
@@ -1,0 +1,114 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type PluginApp = "codex" | "claude";
+export type PluginScope = "user" | "project" | "local";
+
+export interface PluginActions {
+  install: boolean;
+  update: boolean;
+  enable: boolean;
+  disable: boolean;
+  uninstall: boolean;
+}
+
+export interface PluginClientStatus {
+  app: PluginApp;
+  available: boolean;
+  version?: string;
+  error?: string;
+  supportedActions: PluginActions;
+}
+
+export interface UnifiedPlugin {
+  pluginId: string;
+  name: string;
+  description?: string;
+  version?: string;
+  app: PluginApp;
+  marketplaceName: string;
+  installed: boolean;
+  enabled: boolean;
+  scope?: PluginScope;
+  projectPath?: string;
+  source?: string;
+  supportedActions: PluginActions;
+}
+
+export interface PluginMarketplace {
+  name: string;
+  app: PluginApp;
+  sourceType?: string;
+  source?: string;
+  root?: string;
+}
+
+export interface PluginActionResult {
+  success: boolean;
+  requiresRestart: boolean;
+  commandSummary: string;
+}
+
+export const pluginsApi = {
+  getClientStatuses: () =>
+    invoke<PluginClientStatus[]>("get_plugin_client_statuses"),
+  list: (app: PluginApp, includeAvailable: boolean) =>
+    invoke<UnifiedPlugin[]>("list_plugins", { app, includeAvailable }),
+  listMarketplaces: (app: PluginApp) =>
+    invoke<PluginMarketplace[]>("list_plugin_marketplaces", { app }),
+  addMarketplace: (app: PluginApp, source: string) =>
+    invoke<PluginActionResult>("add_plugin_marketplace", { app, source }),
+  refreshMarketplace: (app: PluginApp, name: string) =>
+    invoke<PluginActionResult>("refresh_plugin_marketplace", { app, name }),
+  removeMarketplace: (app: PluginApp, name: string) =>
+    invoke<PluginActionResult>("remove_plugin_marketplace", { app, name }),
+  install: (
+    app: PluginApp,
+    pluginId: string,
+    scope?: PluginScope,
+    projectPath?: string,
+  ) =>
+    invoke<PluginActionResult>("install_plugin", {
+      app,
+      pluginId,
+      scope,
+      projectPath,
+    }),
+  update: (
+    app: PluginApp,
+    pluginId: string,
+    scope?: PluginScope,
+    projectPath?: string,
+  ) =>
+    invoke<PluginActionResult>("update_plugin", {
+      app,
+      pluginId,
+      scope,
+      projectPath,
+    }),
+  setEnabled: (
+    app: PluginApp,
+    pluginId: string,
+    enabled: boolean,
+    scope?: PluginScope,
+    projectPath?: string,
+  ) =>
+    invoke<PluginActionResult>("set_plugin_enabled", {
+      app,
+      pluginId,
+      enabled,
+      scope,
+      projectPath,
+    }),
+  uninstall: (
+    app: PluginApp,
+    pluginId: string,
+    scope?: PluginScope,
+    projectPath?: string,
+  ) =>
+    invoke<PluginActionResult>("uninstall_plugin", {
+      app,
+      pluginId,
+      scope,
+      projectPath,
+    }),
+};

--- a/tests/components/PluginsPage.test.tsx
+++ b/tests/components/PluginsPage.test.tsx
@@ -8,6 +8,7 @@ const mutationMock = vi.hoisted(() => ({
   mutateAsync: vi.fn(),
 }));
 const pluginsMock = vi.hoisted(() => vi.fn());
+const marketplacesMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/hooks/usePlugins", () => ({
   usePluginStatuses: () => ({
@@ -17,7 +18,7 @@ vi.mock("@/hooks/usePlugins", () => ({
     ],
   }),
   usePlugins: pluginsMock,
-  usePluginMarketplaces: () => ({ data: [] }),
+  usePluginMarketplaces: marketplacesMock,
   usePluginMutation: () => mutationMock,
 }));
 
@@ -62,6 +63,7 @@ const projectInstalledClaudePlugin = {
 describe("PluginsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    marketplacesMock.mockReturnValue({ data: [] });
     pluginsMock.mockImplementation((app: string, includeAvailable: boolean) => {
       if (includeAvailable) return { data: [], isLoading: false };
       if (app === "claude") {
@@ -137,14 +139,60 @@ describe("PluginsPage", () => {
     await user.click(
       screen.getByRole("button", { name: "plugins.marketplaces.title" }),
     );
-    const dialog = within(screen.getByRole("dialog"));
+    const dialogElement = screen.getByRole("dialog");
+    const dialog = within(dialogElement);
     const codex = dialog.getByRole("tab", { name: "plugins.apps.codex" });
     const claude = dialog.getByRole("tab", { name: "plugins.apps.claude" });
     expect(codex).toHaveAttribute("data-state", "active");
+    expect(dialogElement).toHaveClass("z-[60]");
 
     await user.click(claude);
 
     expect(claude).toHaveAttribute("data-state", "active");
     expect(codex).toHaveAttribute("data-state", "inactive");
+  });
+
+  it("only offers refresh for supported marketplaces", async () => {
+    marketplacesMock.mockImplementation((app: string) => ({
+      data:
+        app === "codex"
+          ? [
+              {
+                name: "openai-bundled",
+                app: "codex",
+                sourceType: "local",
+                root: "/tmp/openai-bundled",
+                supportsRefresh: false,
+              },
+              {
+                name: "openai-curated",
+                app: "codex",
+                root: "/tmp/plugins",
+                supportsRefresh: false,
+              },
+              {
+                name: "ponytail",
+                app: "codex",
+                sourceType: "git",
+                source: "https://github.com/DietrichGebert/ponytail.git",
+                supportsRefresh: true,
+              },
+            ]
+          : [],
+    }));
+    const user = userEvent.setup();
+    render(<PluginsPage />);
+
+    await user.click(
+      screen.getByRole("button", { name: "plugins.marketplaces.title" }),
+    );
+
+    const dialog = within(screen.getByRole("dialog"));
+    expect(dialog.getAllByTitle("plugins.marketplaces.refresh")).toHaveLength(
+      1,
+    );
+    expect(dialog.getByText("openai-bundled")).toBeInTheDocument();
+    expect(dialog.getByText("openai-curated")).toBeInTheDocument();
+    expect(dialog.getByText("ponytail")).toBeInTheDocument();
   });
 });

--- a/tests/components/PluginsPage.test.tsx
+++ b/tests/components/PluginsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import PluginsPage from "@/components/plugins/PluginsPage";
@@ -52,6 +52,13 @@ const installedPlugin = {
   },
 };
 
+const projectInstalledClaudePlugin = {
+  ...installedPlugin,
+  app: "claude" as const,
+  scope: "project" as const,
+  projectPath: "/tmp/the_old_days",
+};
+
 describe("PluginsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -82,5 +89,62 @@ describe("PluginsPage", () => {
     await user.click(screen.getByText("common.cancel"));
 
     expect(mutationMock.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("keeps project-installed Claude plugins discoverable for another scope", async () => {
+    pluginsMock.mockImplementation((app: string, includeAvailable: boolean) => {
+      if (!includeAvailable || app === "codex") {
+        return { data: [], isLoading: false };
+      }
+      return { data: [projectInstalledClaudePlugin], isLoading: false };
+    });
+    const user = userEvent.setup();
+    render(<PluginsPage />);
+
+    await user.click(
+      screen.getByRole("tab", { name: "plugins.tabs.discover" }),
+    );
+    await user.type(screen.getByPlaceholderText("plugins.search"), "ponytail");
+
+    expect(screen.getByText("ponytail")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "plugins.install" }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("ponytail@ponytail");
+    expect(screen.getByRole("combobox")).toHaveTextContent(
+      "plugins.scope.user",
+    );
+  });
+
+  it("shows the selected client filter", async () => {
+    const user = userEvent.setup();
+    render(<PluginsPage />);
+
+    const all = screen.getByRole("tab", { name: "common.all" });
+    const claude = screen.getByRole("tab", {
+      name: "plugins.apps.claude",
+    });
+    expect(all).toHaveAttribute("data-state", "active");
+
+    await user.click(claude);
+
+    expect(claude).toHaveAttribute("data-state", "active");
+    expect(all).toHaveAttribute("data-state", "inactive");
+  });
+
+  it("uses the same selected state in marketplace client tabs", async () => {
+    const user = userEvent.setup();
+    render(<PluginsPage />);
+
+    await user.click(
+      screen.getByRole("button", { name: "plugins.marketplaces.title" }),
+    );
+    const dialog = within(screen.getByRole("dialog"));
+    const codex = dialog.getByRole("tab", { name: "plugins.apps.codex" });
+    const claude = dialog.getByRole("tab", { name: "plugins.apps.claude" });
+    expect(codex).toHaveAttribute("data-state", "active");
+
+    await user.click(claude);
+
+    expect(claude).toHaveAttribute("data-state", "active");
+    expect(codex).toHaveAttribute("data-state", "inactive");
   });
 });

--- a/tests/components/PluginsPage.test.tsx
+++ b/tests/components/PluginsPage.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PluginsPage from "@/components/plugins/PluginsPage";
+
+const mutationMock = vi.hoisted(() => ({
+  isPending: false,
+  mutateAsync: vi.fn(),
+}));
+const pluginsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/usePlugins", () => ({
+  usePluginStatuses: () => ({
+    data: [
+      { app: "codex", available: true, version: "codex 1" },
+      { app: "claude", available: false, error: "not installed" },
+    ],
+  }),
+  usePlugins: pluginsMock,
+  usePluginMarketplaces: () => ({ data: [] }),
+  usePluginMutation: () => mutationMock,
+}));
+
+vi.mock("@/lib/api", () => ({
+  settingsApi: { pickDirectory: vi.fn() },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const installedPlugin = {
+  pluginId: "ponytail@ponytail",
+  name: "ponytail",
+  version: "4.8.4",
+  app: "codex" as const,
+  marketplaceName: "ponytail",
+  installed: true,
+  enabled: true,
+  supportedActions: {
+    install: false,
+    update: false,
+    enable: false,
+    disable: true,
+    uninstall: true,
+  },
+};
+
+describe("PluginsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pluginsMock.mockImplementation((app: string, includeAvailable: boolean) => {
+      if (includeAvailable) return { data: [], isLoading: false };
+      if (app === "claude") {
+        return {
+          data: [],
+          isLoading: false,
+          error: new Error("claude failed"),
+        };
+      }
+      return { data: [installedPlugin], isLoading: false };
+    });
+  });
+
+  it("shows one client failure without hiding the other client", () => {
+    render(<PluginsPage />);
+    expect(screen.getByText("ponytail")).toBeInTheDocument();
+    expect(screen.getByText(/claude failed/)).toBeInTheDocument();
+  });
+
+  it("does not uninstall when confirmation is cancelled", async () => {
+    const user = userEvent.setup();
+    render(<PluginsPage />);
+
+    await user.click(screen.getByTitle("plugins.uninstall"));
+    await user.click(screen.getByText("common.cancel"));
+
+    expect(mutationMock.mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/PluginsPage.test.tsx
+++ b/tests/components/PluginsPage.test.tsx
@@ -58,6 +58,10 @@ const projectInstalledClaudePlugin = {
   app: "claude" as const,
   scope: "project" as const,
   projectPath: "/tmp/the_old_days",
+  supportedActions: {
+    ...installedPlugin.supportedActions,
+    update: true,
+  },
 };
 
 const scopedClaudePlugins = [
@@ -147,7 +151,7 @@ describe("PluginsPage", () => {
     render(<PluginsPage />);
 
     expect(screen.getByText(/user/)).toBeInTheDocument();
-    expect(screen.getByText(/\/tmp\/the_old_days/)).toBeInTheDocument();
+    expect(screen.getAllByText(/\/tmp\/the_old_days/)).toHaveLength(2);
     expect(screen.getByText(/\/tmp\/the_futures/)).toBeInTheDocument();
     expect(screen.getAllByRole("switch")).toHaveLength(4);
     expect(

--- a/tests/components/PluginsPage.test.tsx
+++ b/tests/components/PluginsPage.test.tsx
@@ -60,6 +60,26 @@ const projectInstalledClaudePlugin = {
   projectPath: "/tmp/the_old_days",
 };
 
+const scopedClaudePlugins = [
+  {
+    ...projectInstalledClaudePlugin,
+    scope: "user" as const,
+    projectPath: undefined,
+    enabled: true,
+  },
+  projectInstalledClaudePlugin,
+  {
+    ...projectInstalledClaudePlugin,
+    projectPath: "/tmp/the_futures",
+    enabled: false,
+  },
+  {
+    ...projectInstalledClaudePlugin,
+    scope: "local" as const,
+    projectPath: "/tmp/the_old_days",
+  },
+];
+
 describe("PluginsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -114,6 +134,39 @@ describe("PluginsPage", () => {
     expect(screen.getByRole("combobox")).toHaveTextContent(
       "plugins.scope.user",
     );
+  });
+
+  it("keeps every Claude installation of the same plugin actionable", async () => {
+    pluginsMock.mockImplementation((app: string, includeAvailable: boolean) => {
+      if (includeAvailable || app === "codex") {
+        return { data: [], isLoading: false };
+      }
+      return { data: scopedClaudePlugins, isLoading: false };
+    });
+    const user = userEvent.setup();
+    render(<PluginsPage />);
+
+    expect(screen.getByText(/user/)).toBeInTheDocument();
+    expect(screen.getByText(/\/tmp\/the_old_days/)).toBeInTheDocument();
+    expect(screen.getByText(/\/tmp\/the_futures/)).toBeInTheDocument();
+    expect(screen.getAllByRole("switch")).toHaveLength(4);
+    expect(
+      screen.getAllByRole("button", { name: "plugins.update" }),
+    ).toHaveLength(4);
+
+    const projectPath = screen.getByText(/\/tmp\/the_futures/);
+    const installationRow = projectPath.closest("div");
+    expect(installationRow).not.toBeNull();
+    await user.click(within(installationRow!).getByRole("switch"));
+
+    expect(mutationMock.mutateAsync).toHaveBeenCalledWith({
+      action: "setEnabled",
+      app: "claude",
+      pluginId: "ponytail@ponytail",
+      enabled: true,
+      scope: "project",
+      projectPath: "/tmp/the_futures",
+    });
   });
 
   it("shows the selected client filter", async () => {

--- a/tests/hooks/usePlugins.test.tsx
+++ b/tests/hooks/usePlugins.test.tsx
@@ -1,0 +1,71 @@
+import type { PropsWithChildren } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { pluginKeys, usePluginMutation, usePlugins } from "@/hooks/usePlugins";
+
+const listMock = vi.hoisted(() => vi.fn());
+const installMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api/plugins", () => ({
+  pluginsApi: {
+    list: listMock,
+    install: installMock,
+  },
+}));
+
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, wrapper };
+}
+
+describe("plugin queries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listMock.mockResolvedValue([]);
+    installMock.mockResolvedValue({
+      success: true,
+      requiresRestart: true,
+      commandSummary: "claude plugin install ponytail@ponytail",
+    });
+  });
+
+  it("keeps client and discovery queries independent", async () => {
+    const { wrapper } = setup();
+    const { result } = renderHook(() => usePlugins("codex", true), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(listMock).toHaveBeenCalledWith("codex", true);
+  });
+
+  it("passes Claude scope and invalidates plugin state after install", async () => {
+    const { client, wrapper } = setup();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => usePluginMutation(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        action: "install",
+        app: "claude",
+        pluginId: "ponytail@ponytail",
+        scope: "project",
+        projectPath: "/repo",
+      });
+    });
+
+    expect(installMock).toHaveBeenCalledWith(
+      "claude",
+      "ponytail@ponytail",
+      "project",
+      "/repo",
+    );
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: pluginKeys.all });
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Add a unified Plugins page for managing native Codex and Claude Code plugins and marketplaces.

- Detect each client independently and preserve partial results when one CLI is unavailable.
- List installed and discoverable plugins using their native `plugin@marketplace` identity.
- Manage marketplaces and plugin install, enable/disable, update, and uninstall actions.
- Keep native client configuration as the source of truth; do not add database or sync state.
- Preserve Codex TOML comments, unrelated fields, and Hook trust state when toggling plugins.
- Support Claude `user`, `project`, and `local` installation scopes.

## Related Issue / 关联 Issue

Related #2604

## Screenshots / 截图

### After / 修改后

<img width="1280" height="720" alt="plugins-page-pr" src="https://github.com/user-attachments/assets/78f94405-ef3a-4045-96eb-65b83969731d" />

## Testing / 测试

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` — 71 files, 433 tests passed
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml` — all tests passed
- `pnpm build:renderer`
- Verified the implemented command shapes against local Codex `0.144.0-alpha.4` and Claude Code `2.1.197` CLI help and read-only JSON list output.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (Rust code changed) / 通过 Clippy 检查（修改了 Rust 代码）
- [x] Updated all current locale files for user-facing text / 已更新全部现有语言文件
