### PR TITLE
fix: prevent empty tool_call id delta from overwriting accumulated ca…

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -356,7 +356,9 @@ impl ChatToResponsesState {
         {
             let state = self.tools.entry(chat_index).or_default();
             if let Some(id) = id_delta {
-                state.call_id = id;
+                if !id.is_empty() {
+                    state.call_id = id;
+                }
             }
             if let Some(ref name) = name_delta {
                 if !name.is_empty() {


### PR DESCRIPTION
## Summary / 概述

修复流式 Tool Call 转换时 `call_id` 被后续空 delta 覆盖的问题。

`push_tool_call_delta` 中 `name` 字段已有空值保护，但 `id`/`call_id` 仍缺少保护。当上游模型（如阿里云 DashScope 的 GLM、qwen）在首个 delta chunk 之后回空 `id` 时，累积的 `call_id` 被空字符串覆盖，导致 `response.output_item.done` 和 `response.completed` 中 `call_id` 为空，Codex 报 `unsupported call:`。

本次改动对 `id` 赋值增加非空判断，与 `name` 的保护逻辑保持一致。已在本地环境编译验证，修复后流式工具调用正常工作。

## Related Issue / 关联 Issue

Fixes #4671

## Screenshots / 截图

不涉及 UI 变更。

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| `response.output_item.done` 中 `call_id` 为空 | `call_id` 正确保留 |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件