### PR TITLE
fix(codex): sync live config when updating the current provider

### DIFF
--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2475,22 +2475,24 @@ impl ProviderService {
     ///
     /// Holds the per-app switch lock for the whole sample → mutate sequence so
     /// concurrent takeover enable/disable cannot interleave with a stale snapshot.
+    ///
+    /// Important: acquire the lock with a *discrete* `block_on`, then run the
+    /// body with discrete `block_on`s as well. Wrapping the whole body in
+    /// `block_on(async { ... })` nests executors when `write_live_with_common_config`
+    /// (Claude Desktop) itself calls `block_on` — that panics with EnterError
+    /// and is what broke the Windows/macOS-only Claude Desktop update test.
     fn sync_current_provider_live_after_update(
         state: &AppState,
         app_type: &AppType,
         provider: &Provider,
     ) -> Result<(), AppError> {
-        futures::executor::block_on(async {
-            let _guard = state
-                .proxy_service
-                .lock_switch_for_app(app_type.as_str())
-                .await;
-            Self::sync_current_provider_live_after_update_locked(state, app_type, provider).await
-        })
+        let _guard =
+            futures::executor::block_on(state.proxy_service.lock_switch_for_app(app_type.as_str()));
+        Self::sync_current_provider_live_after_update_locked(state, app_type, provider)
     }
 
     /// Caller must already hold the per-app switch lock for `app_type`.
-    async fn sync_current_provider_live_after_update_locked(
+    fn sync_current_provider_live_after_update_locked(
         state: &AppState,
         app_type: &AppType,
         provider: &Provider,
@@ -2503,13 +2505,11 @@ impl ProviderService {
         //
         // 必须在持锁后采样：takeover 启停与 hot_switch 共用同一把锁，
         // 持锁前的 has_live_backup / live_taken_over 快照可能已过期。
-        let has_live_backup = state
-            .db
-            .get_live_backup(app_type.as_str())
-            .await
-            .ok()
-            .flatten()
-            .is_some();
+        let has_live_backup =
+            futures::executor::block_on(state.db.get_live_backup(app_type.as_str()))
+                .ok()
+                .flatten()
+                .is_some();
         let live_taken_over = state
             .proxy_service
             .detect_takeover_in_live_config_for_app(app_type);
@@ -2523,32 +2523,33 @@ impl ProviderService {
                 write_live_with_common_config(state.db.as_ref(), app_type, provider)?;
             } else {
                 // 已持锁：走 inner，避免 update_live_backup_from_provider 再次拿锁死锁。
-                state
-                    .proxy_service
-                    .update_live_backup_from_provider_inner(app_type.as_str(), provider)
-                    .await
-                    .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
-            }
-
-            if state.proxy_service.is_running().await {
-                if matches!(app_type, AppType::Claude) {
+                futures::executor::block_on(
                     state
                         .proxy_service
-                        .sync_claude_live_from_provider_while_proxy_active(provider)
-                        .await
-                        .map_err(|e| {
-                            AppError::Message(format!("同步 Claude Live 配置失败: {e}"))
-                        })?;
+                        .update_live_backup_from_provider_inner(app_type.as_str(), provider),
+                )
+                .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
+            }
+
+            if futures::executor::block_on(state.proxy_service.is_running()) {
+                if matches!(app_type, AppType::Claude) {
+                    futures::executor::block_on(
+                        state
+                            .proxy_service
+                            .sync_claude_live_from_provider_while_proxy_active(provider),
+                    )
+                    .map_err(|e| AppError::Message(format!("同步 Claude Live 配置失败: {e}")))?;
                 } else if live_taken_over && matches!(app_type, AppType::Codex) {
                     // Codex model mappings are projected into a generated
                     // model_catalog_json file. Refresh takeover-owned Live
                     // immediately so adding/removing mappings cannot leave
                     // the previous catalog pointer and capabilities active.
-                    state
-                        .proxy_service
-                        .sync_codex_live_from_provider_while_proxy_active(provider)
-                        .await
-                        .map_err(|e| AppError::Message(format!("同步 Codex Live 配置失败: {e}")))?;
+                    futures::executor::block_on(
+                        state
+                            .proxy_service
+                            .sync_codex_live_from_provider_while_proxy_active(provider),
+                    )
+                    .map_err(|e| AppError::Message(format!("同步 Codex Live 配置失败: {e}")))?;
                 }
             }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1237,6 +1237,175 @@ requires_openai_auth = true
             .expect("stop proxy service");
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    #[serial]
+    #[allow(
+        clippy::await_holding_lock,
+        reason = "reproduces takeover/update interleaving while holding the shared switch lock"
+    )]
+    async fn update_current_codex_provider_does_not_overwrite_proxy_live_when_takeover_activates_concurrently(
+    ) {
+        // SaladDay race: update samples "backup exists, live not taken over" before the
+        // switch lock, waits for takeover to finish writing proxy live, then overwrites
+        // it with normal provider config. Holding the lock for the whole
+        // sample→mutate path and re-checking state under the lock must prevent that.
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let mut settings = crate::settings::get_settings();
+        settings.preserve_codex_official_auth_on_switch = true;
+        crate::settings::update_settings(settings).expect("enable official auth preservation");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+
+        let provider_config = r#"model_provider = "deepseek"
+model = "deepseek-chat"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com/v1"
+wire_api = "responses"
+"#;
+        let edited_config = r#"model_provider = "deepseek"
+model = "deepseek-reasoner"
+
+[model_providers.deepseek]
+name = "DeepSeek Edited"
+base_url = "https://api.deepseek.com/v1"
+wire_api = "responses"
+"#;
+        let proxy_live_config = r#"model_provider = "deepseek"
+model = "deepseek-chat"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+experimental_bearer_token = "PROXY_MANAGED"
+"#;
+        let oauth_auth = json!({
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "access_token": "oauth-access",
+                "id_token": "oauth-id"
+            }
+        });
+
+        let mut original = Provider::with_id(
+            "deepseek".into(),
+            "DeepSeek".into(),
+            json!({
+                "auth": { "OPENAI_API_KEY": "old-key" },
+                "config": provider_config
+            }),
+            None,
+        );
+        original.category = Some("custom".into());
+        db.save_provider("codex", &original).expect("save provider");
+        db.set_current_provider("codex", "deepseek")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("deepseek"))
+            .expect("set local current provider");
+
+        // Normal (non-proxy) live so a pre-lock snapshot would see live_taken_over=false.
+        crate::write_codex_live_atomic(&oauth_auth, Some(provider_config))
+            .expect("seed normal Codex live");
+
+        let mut updated = original.clone();
+        updated.name = "DeepSeek Edited".into();
+        updated.settings_config = json!({
+            "auth": { "OPENAI_API_KEY": "new-key" },
+            "config": edited_config
+        });
+
+        // Hold the shared per-app lock that takeover and update must serialize on.
+        let switch_guard = state.proxy_service.lock_switch_for_app("codex").await;
+
+        // Same ProxyService (same switch_locks) must be used on the update thread.
+        let update_state = AppState {
+            db: state.db.clone(),
+            proxy_service: state.proxy_service.clone(),
+            usage_cache: state.usage_cache.clone(),
+        };
+        let update_handle = std::thread::spawn(move || {
+            ProviderService::update(&update_state, AppType::Codex, Some("deepseek"), updated)
+        });
+
+        // Let the update thread finish the DB save and block on the switch lock.
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+
+        // Finish takeover activation under the lock (backup → proxy live → enabled).
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": oauth_auth,
+                "config": provider_config
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("seed live backup during takeover");
+        crate::write_codex_live_atomic(&oauth_auth, Some(proxy_live_config))
+            .expect("write proxy-owned live under switch lock");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("get proxy config");
+        proxy_config.enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable codex takeover");
+
+        drop(switch_guard);
+        let update_result = update_handle
+            .join()
+            .expect("update thread should not panic");
+        update_result.expect("update after concurrent takeover activation");
+
+        let live_config = fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read config.toml");
+        assert!(
+            live_config.contains("127.0.0.1")
+                && live_config.contains("/v1")
+                && live_config.contains("PROXY_MANAGED"),
+            "concurrent update must not clobber proxy-owned live; got:\n{live_config}"
+        );
+        assert!(
+            !live_config.contains("https://api.deepseek.com/v1"),
+            "normal provider base_url must not overwrite taken-over live; got:\n{live_config}"
+        );
+
+        let stored = db
+            .get_provider_by_id("deepseek", "codex")
+            .expect("reload")
+            .expect("exists");
+        assert_eq!(
+            stored
+                .settings_config
+                .get("auth")
+                .and_then(|v| v.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some("new-key")
+        );
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("get backup")
+            .expect("backup exists");
+        let backup_value: Value =
+            serde_json::from_str(&backup.original_config).expect("parse backup");
+        let backup_config = backup_value
+            .get("config")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            backup_config.contains("deepseek-reasoner")
+                && backup_config.contains("DeepSeek Edited")
+                && backup_config.contains("new-key"),
+            "under lock, update should still refresh restore backup; got:\n{backup_config}"
+        );
+    }
+
     #[cfg(any(target_os = "macos", windows))]
     #[tokio::test]
     #[serial]
@@ -2292,73 +2461,120 @@ impl ProviderService {
         let is_current = effective_current.as_deref() == Some(provider.id.as_str());
 
         if is_current {
-            // 如果 Claude 代理接管处于激活状态，并且代理服务正在运行：
-            // - 不直接走普通 Live 写入逻辑
-            // - 改为更新 Live 备份，并在 Claude 下同步代理安全的 Live 配置
-            let has_live_backup =
-                futures::executor::block_on(state.db.get_live_backup(app_type.as_str()))
-                    .ok()
-                    .flatten()
-                    .is_some();
-            let live_taken_over = state
+            // 当前供应商的 backup/live 决策与写入必须与 takeover 启停共用
+            // per-app switch lock，并在持锁后重新采样状态。否则会出现：
+            // update 先看到「有 backup、live 未接管」→ 等待锁 → takeover 写完
+            // 代理 live 并释放锁 → update 用过期快照把代理 live 覆盖成普通配置。
+            Self::sync_current_provider_live_after_update(state, &app_type, &provider)?;
+        }
+
+        Ok(true)
+    }
+
+    /// Sync live (and restore backup when needed) after saving the current provider.
+    ///
+    /// Holds the per-app switch lock for the whole sample → mutate sequence so
+    /// concurrent takeover enable/disable cannot interleave with a stale snapshot.
+    fn sync_current_provider_live_after_update(
+        state: &AppState,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<(), AppError> {
+        futures::executor::block_on(async {
+            let _guard = state
                 .proxy_service
-                .detect_takeover_in_live_config_for_app(&app_type);
-            // Backup or live placeholders mean the live file is currently owned
-            // by proxy takeover, including the short activation window before
-            // proxy_config.enabled is committed.
-            let should_sync_via_proxy = has_live_backup || live_taken_over;
+                .lock_switch_for_app(app_type.as_str())
+                .await;
+            Self::sync_current_provider_live_after_update_locked(state, app_type, provider).await
+        })
+    }
 
-            if should_sync_via_proxy {
-                if matches!(app_type, AppType::ClaudeDesktop) {
-                    write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
-                } else {
-                    futures::executor::block_on(
-                        state
-                            .proxy_service
-                            .update_live_backup_from_provider(app_type.as_str(), &provider),
-                    )
+    /// Caller must already hold the per-app switch lock for `app_type`.
+    async fn sync_current_provider_live_after_update_locked(
+        state: &AppState,
+        app_type: &AppType,
+        provider: &Provider,
+    ) -> Result<(), AppError> {
+        // 代理接管 / 残留 live 备份时：
+        // - 先更新 Live 备份（关闭接管后恢复到最新供应商配置）
+        // - Claude / Codex：代理运行中且 live 被接管时，同步代理安全的 live
+        // - Codex：仅有备份残留（live 已不在接管态）时仍应写入 config.toml，
+        //   否则会出现“保存成功但 live 仍是旧值”
+        //
+        // 必须在持锁后采样：takeover 启停与 hot_switch 共用同一把锁，
+        // 持锁前的 has_live_backup / live_taken_over 快照可能已过期。
+        let has_live_backup = state
+            .db
+            .get_live_backup(app_type.as_str())
+            .await
+            .ok()
+            .flatten()
+            .is_some();
+        let live_taken_over = state
+            .proxy_service
+            .detect_takeover_in_live_config_for_app(app_type);
+        // Backup or live placeholders mean the live file is currently owned
+        // by proxy takeover, including the short activation window before
+        // proxy_config.enabled is committed.
+        let should_sync_via_proxy = has_live_backup || live_taken_over;
+
+        if should_sync_via_proxy {
+            if matches!(app_type, AppType::ClaudeDesktop) {
+                write_live_with_common_config(state.db.as_ref(), app_type, provider)?;
+            } else {
+                // 已持锁：走 inner，避免 update_live_backup_from_provider 再次拿锁死锁。
+                state
+                    .proxy_service
+                    .update_live_backup_from_provider_inner(app_type.as_str(), provider)
+                    .await
                     .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
-                }
+            }
 
-                if futures::executor::block_on(state.proxy_service.is_running()) {
-                    if matches!(app_type, AppType::Claude) {
-                        futures::executor::block_on(
-                            state
-                                .proxy_service
-                                .sync_claude_live_from_provider_while_proxy_active(&provider),
-                        )
+            if state.proxy_service.is_running().await {
+                if matches!(app_type, AppType::Claude) {
+                    state
+                        .proxy_service
+                        .sync_claude_live_from_provider_while_proxy_active(provider)
+                        .await
                         .map_err(|e| {
                             AppError::Message(format!("同步 Claude Live 配置失败: {e}"))
                         })?;
-                    } else if live_taken_over && matches!(app_type, AppType::Codex) {
-                        // Codex model mappings are projected into a generated
-                        // model_catalog_json file. Refresh takeover-owned Live
-                        // immediately so adding/removing mappings cannot leave
-                        // the previous catalog pointer and capabilities active.
-                        futures::executor::block_on(
-                            state
-                                .proxy_service
-                                .sync_codex_live_from_provider_while_proxy_active(&provider),
-                        )
+                } else if live_taken_over && matches!(app_type, AppType::Codex) {
+                    // Codex model mappings are projected into a generated
+                    // model_catalog_json file. Refresh takeover-owned Live
+                    // immediately so adding/removing mappings cannot leave
+                    // the previous catalog pointer and capabilities active.
+                    state
+                        .proxy_service
+                        .sync_codex_live_from_provider_while_proxy_active(provider)
+                        .await
                         .map_err(|e| AppError::Message(format!("同步 Codex Live 配置失败: {e}")))?;
-                    }
                 }
-            } else {
-                write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
-                // 重写 live 后只重投影本应用的 MCP：全量 sync_all_enabled 会把
-                // 无关应用的 live 损坏（如 ~/.claude.json 坏 JSON）牵连进保存
-                // 流程。走到这里 DB 与 live 都已按新配置落盘，保存事实上已
-                // 成功；投影失败降级为警告，避免制造"保存失败"假象（MCP
-                // 投影可自愈：下次切换 / 任一 MCP 启停都会重新投影）。
-                if let Err(err) = McpService::sync_enabled_for_app(state, &app_type) {
+            }
+
+            // 备份残留但 live 已不在接管态：按普通路径写 live。
+            // 只重投影本应用 MCP，避免无关应用 live 损坏把成功的 Codex 保存变成失败。
+            if matches!(app_type, AppType::Codex) && has_live_backup && !live_taken_over {
+                write_live_with_common_config(state.db.as_ref(), app_type, provider)?;
+                if let Err(err) = McpService::sync_enabled_for_app(state, app_type) {
                     log::warn!(
                         "保存供应商后重投影 {app_type:?} MCP 失败（将在下次同步时自愈）: {err}"
                     );
                 }
             }
+        } else {
+            write_live_with_common_config(state.db.as_ref(), app_type, provider)?;
+            // 重写 live 后只重投影本应用的 MCP：全量 sync_all_enabled 会把
+            // 无关应用的 live 损坏（如 ~/.claude.json 坏 JSON）牵连进保存
+            // 流程。走到这里 DB 与 live 都已按新配置落盘，保存事实上已
+            // 成功；投影失败降级为警告，避免制造"保存失败"假象（MCP
+            // 投影可自愈：下次切换 / 任一 MCP 启停都会重新投影）。
+            if let Err(err) = McpService::sync_enabled_for_app(state, app_type) {
+                log::warn!("保存供应商后重投影 {app_type:?} MCP 失败（将在下次同步时自愈）: {err}");
+            }
         }
 
-        Ok(true)
+        Ok(())
     }
 
     /// Delete a provider

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2015,8 +2015,8 @@ impl ProxyService {
             .await
     }
 
-    /// 仅供已持有 per-app 切换锁的调用方使用。
-    async fn update_live_backup_from_provider_inner(
+    /// 仅供已持有 per-app 切换锁的调用方使用（避免在外层已持锁时再次 `lock_for_app` 死锁）。
+    pub(crate) async fn update_live_backup_from_provider_inner(
         &self,
         app_type: &str,
         provider: &Provider,

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -1691,6 +1691,322 @@ wire_api = "responses"
 }
 
 #[test]
+fn update_current_codex_provider_with_stale_live_backup_writes_config_toml() {
+    // Regression: editing the active Codex provider while a live backup row still
+    // exists (takeover fully off, live not proxy-owned) used to only refresh the
+    // backup and skip writing ~/.codex/config.toml. UI toast said "saved" but the
+    // on-disk config and reopened form (via live settings) kept the old values.
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    enable_codex_official_auth_preservation();
+    let _home = ensure_test_home();
+
+    let oauth_auth = json!({
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": "oauth-access",
+            "id_token": "oauth-id"
+        }
+    });
+    let old_config = r#"model_provider = "deepseek"
+model = "deepseek-chat"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com/v1"
+wire_api = "responses"
+"#;
+    let new_config = r#"model_provider = "deepseek"
+model = "deepseek-reasoner"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com/v1"
+wire_api = "responses"
+"#;
+
+    write_codex_live_atomic(&oauth_auth, Some(old_config)).expect("seed codex live");
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "deepseek".to_string();
+
+        let mut provider = Provider::with_id(
+            "deepseek".to_string(),
+            "DeepSeek".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "old-key"},
+                "config": old_config
+            }),
+            None,
+        );
+        provider.category = Some("custom".to_string());
+        manager.providers.insert("deepseek".to_string(), provider);
+    }
+
+    let state = create_test_state_with_config(&config).expect("create test state");
+    futures::executor::block_on(
+        state.db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": oauth_auth,
+                "config": old_config
+            }))
+            .expect("serialize backup"),
+        ),
+    )
+    .expect("seed stale Codex live backup without active takeover");
+
+    let mut updated = state
+        .db
+        .get_provider_by_id("deepseek", AppType::Codex.as_str())
+        .expect("load provider")
+        .expect("provider exists");
+    updated.settings_config = json!({
+        "auth": {"OPENAI_API_KEY": "new-key"},
+        "config": new_config
+    });
+
+    ProviderService::update(&state, AppType::Codex, Some("deepseek"), updated)
+        .expect("update current Codex provider");
+
+    let live_config =
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read config.toml");
+    assert!(
+        live_config.contains("deepseek-reasoner"),
+        "stale-backup path must still write the edited config.toml; got:\n{live_config}"
+    );
+    assert!(
+        live_config.contains("new-key") || live_config.contains("experimental_bearer_token"),
+        "edited API key must reach live config via experimental_bearer_token; got:\n{live_config}"
+    );
+    assert!(
+        !live_config.contains("deepseek-chat"),
+        "old model value must not remain in live config; got:\n{live_config}"
+    );
+
+    let stored = state
+        .db
+        .get_provider_by_id("deepseek", AppType::Codex.as_str())
+        .expect("reload provider")
+        .expect("provider exists");
+    assert_eq!(
+        stored
+            .settings_config
+            .get("auth")
+            .and_then(|v| v.get("OPENAI_API_KEY"))
+            .and_then(|v| v.as_str()),
+        Some("new-key"),
+        "database SSOT must store the edited API key"
+    );
+
+    let backup = futures::executor::block_on(state.db.get_live_backup("codex"))
+        .expect("get backup")
+        .expect("backup still exists");
+    let backup_value: serde_json::Value =
+        serde_json::from_str(&backup.original_config).expect("parse backup");
+    let backup_config = backup_value
+        .get("config")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        backup_config.contains("deepseek-reasoner"),
+        "restore backup should also reflect the edit"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[allow(
+    clippy::await_holding_lock,
+    reason = "this integration-style test must serialize global test HOME and settings mutations across async takeover calls"
+)]
+async fn update_current_codex_provider_during_takeover_syncs_proxy_live_and_backup() {
+    // Editing the active Codex provider while takeover owns live must refresh
+    // both the restore backup and the proxy-shaped live config (same as hot_switch).
+    // Main only reprojects takeover-owned Codex live while the proxy process is running.
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    enable_codex_official_auth_preservation();
+    let _home = ensure_test_home();
+
+    let oauth_auth = json!({
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": "oauth-access",
+            "id_token": "oauth-id"
+        }
+    });
+    let provider_config = r#"model_provider = "deepseek"
+model = "deepseek-chat"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com/v1"
+wire_api = "responses"
+"#;
+    let edited_config = r#"model_provider = "deepseek"
+model = "deepseek-reasoner"
+
+[model_providers.deepseek]
+name = "DeepSeek Edited"
+base_url = "https://api.deepseek.com/v1"
+wire_api = "responses"
+"#;
+    let proxy_live_config = r#"model_provider = "deepseek"
+model = "deepseek-chat"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+experimental_bearer_token = "PROXY_MANAGED"
+"#;
+
+    write_codex_live_atomic(&oauth_auth, Some(proxy_live_config))
+        .expect("seed taken-over Codex live config");
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "deepseek".to_string();
+
+        let mut provider = Provider::with_id(
+            "deepseek".to_string(),
+            "DeepSeek".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "old-key"},
+                "config": provider_config
+            }),
+            None,
+        );
+        provider.category = Some("custom".to_string());
+        manager.providers.insert("deepseek".to_string(), provider);
+    }
+
+    let state = create_test_state_with_config(&config).expect("create test state");
+    state
+        .db
+        .save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": oauth_auth,
+                "config": provider_config
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("seed Codex live backup");
+
+    // ProxyConfig is crate-internal; mutate via get/update so the integration
+    // test does not need the type in the public API surface.
+    let mut global = state
+        .db
+        .get_proxy_config()
+        .await
+        .expect("get global proxy config");
+    global.live_takeover_active = true;
+    global.listen_port = 0;
+    state
+        .db
+        .update_proxy_config(global)
+        .await
+        .expect("set global proxy takeover flags");
+    let mut proxy_config = state
+        .db
+        .get_proxy_config_for_app("codex")
+        .await
+        .expect("get proxy config");
+    proxy_config.enabled = true;
+    state
+        .db
+        .update_proxy_config_for_app(proxy_config)
+        .await
+        .expect("enable codex takeover");
+
+    state
+        .proxy_service
+        .start()
+        .await
+        .expect("start proxy service");
+    assert!(
+        state
+            .proxy_service
+            .detect_takeover_in_live_config_for_app(&AppType::Codex),
+        "seeded live must be recognized as takeover-owned before update"
+    );
+
+    let mut updated = state
+        .db
+        .get_provider_by_id("deepseek", AppType::Codex.as_str())
+        .expect("load provider")
+        .expect("provider exists");
+    updated.name = "DeepSeek Edited".to_string();
+    updated.settings_config = json!({
+        "auth": {"OPENAI_API_KEY": "new-key"},
+        "config": edited_config
+    });
+
+    let update_result = ProviderService::update(&state, AppType::Codex, Some("deepseek"), updated);
+    state
+        .proxy_service
+        .stop()
+        .await
+        .expect("stop proxy service");
+    update_result.expect("update current Codex provider under takeover");
+
+    let live_config =
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read config.toml");
+    assert!(
+        live_config.contains("127.0.0.1") && live_config.contains("/v1"),
+        "takeover live must stay pointed at the local proxy; got:\n{live_config}"
+    );
+    assert!(
+        live_config.contains("PROXY_MANAGED"),
+        "takeover live must keep the proxy bearer placeholder"
+    );
+    assert!(
+        live_config.contains("deepseek-reasoner")
+            && live_config.contains(r#"name = "DeepSeek Edited""#),
+        "takeover live must pick up edited model/label; got:\n{live_config}"
+    );
+    assert!(
+        !live_config.contains("https://api.deepseek.com/v1"),
+        "normal provider base_url must not overwrite taken-over live config"
+    );
+
+    let backup = state
+        .db
+        .get_live_backup("codex")
+        .await
+        .expect("get Codex backup")
+        .expect("backup exists");
+    let backup_value: serde_json::Value =
+        serde_json::from_str(&backup.original_config).expect("parse backup");
+    // preserve_codex_official_auth_on_switch keeps OAuth material in backup auth
+    // and projects the provider API key into config as experimental_bearer_token.
+    assert_eq!(
+        backup_value.get("auth"),
+        Some(&oauth_auth),
+        "restore backup must keep official OAuth auth under preserve-official-auth mode"
+    );
+    let backup_config = backup_value
+        .get("config")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        backup_config.contains("deepseek-reasoner")
+            && backup_config.contains("DeepSeek Edited")
+            && backup_config.contains("new-key"),
+        "restore backup config must be rebuilt from the edited provider (model/label/key); got:\n{backup_config}"
+    );
+}
+
+#[test]
 fn explicitly_cleared_common_snippet_is_not_auto_extracted() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();


### PR DESCRIPTION
## Summary / 摘要

Editing the **current** Codex provider previously only refreshed the live backup when a backup row or takeover markers were present. The DB save succeeded and the UI showed success, but `~/.codex/config.toml` (and the edit dialog re-read from live) stayed stale.

This aligns `ProviderService::update` with the existing `hot_switch` path for Codex:

- **Active proxy takeover**: rewrite proxy-shaped live via `sync_codex_live_from_provider_while_proxy_active`
- **Stale live backup only**: write normal live config + re-sync enabled MCP (same as hot_switch when backup exists but live is not taken over)

Adds regression tests for both paths.

## Related Issue / 相关 Issue

Related: #4423, #4849, #5174

(Does not auto-close — please confirm which issue(s) this fully addresses.)

## Screenshots / 截图

N/A (backend fix; no UI changes)

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查
- [x] Updated i18n files if user-facing text changed / 无用户可见文案变更，无需 i18n

### Local verification notes

- `cargo fmt --check` pass
- `cargo clippy` pass (only pre-existing warnings in unrelated files)
- `cargo test --test provider_service -- --test-threads=1`: **35 passed** (includes the two new regression tests)
- Full `cargo test` hit local Windows page-file mmap errors (os error 1455) after clippy; not a test assertion failure
- `pnpm test:unit`: 4 integration failures in `App.test.tsx` / `SettingsDialog.test.tsx` (timeouts / multiple elements / language text) — unrelated to this Rust-only change; 425 other unit tests passed
