### PR TITLE
feat(claude): add suppressReasoningEffort provider option

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -456,6 +456,17 @@ pub struct ProviderMeta {
     /// 是否将 base_url 视为完整 API 端点（不拼接 endpoint 路径）
     #[serde(rename = "isFullUrl", skip_serializing_if = "Option::is_none")]
     pub is_full_url: Option<bool>,
+    /// When `true`, suppresses `reasoning_effort` injection during
+    /// Anthropic → OpenAI Chat Completions conversion.
+    ///
+    /// Use for OpenAI-compatible endpoints (e.g. Azure OpenAI gpt-5.5,
+    /// gpt-5.6-*) that reject `reasoning_effort` when `tools` are present:
+    /// "400 Function tools with reasoning_effort are not supported ...".
+    #[serde(
+        rename = "suppressReasoningEffort",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub suppress_reasoning_effort: Option<bool>,
     /// Prompt cache key for OpenAI Responses-compatible endpoints.
     /// When set, injected into converted Responses requests to improve cache hit rate.
     /// If not set, Claude -> Responses conversions use a client-provided session/thread

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -410,9 +410,18 @@ pub fn transform_claude_request_for_api_format(
         "openai_chat" => {
             let preserve_reasoning_content =
                 should_preserve_reasoning_content_for_openai_chat(provider, &body);
+            // Some upstreams (e.g. Azure OpenAI gpt-5.5 / gpt-5.6-*) reject
+            // reasoning_effort together with tools on Chat Completions;
+            // the per-provider flag lets users skip the injection.
+            let suppress_reasoning_effort = provider
+                .meta
+                .as_ref()
+                .and_then(|m| m.suppress_reasoning_effort)
+                .unwrap_or(false);
             let mut result = super::transform::anthropic_to_openai_with_reasoning_content(
                 body,
                 preserve_reasoning_content,
+                suppress_reasoning_effort,
             )?;
             // Inject prompt_cache_key only if explicitly configured in meta
             if let Some(key) = provider

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -117,7 +117,7 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
 /// 消费者），但保留其转换逻辑与下方测试套件，供代理转换路径复用 / 未来接线。
 #[allow(dead_code)]
 pub fn anthropic_to_openai(body: Value) -> Result<Value, ProxyError> {
-    anthropic_to_openai_with_reasoning_content(body, false)
+    anthropic_to_openai_with_reasoning_content(body, false, false)
 }
 
 /// Anthropic 请求 → OpenAI Chat Completions 请求
@@ -125,9 +125,14 @@ pub fn anthropic_to_openai(body: Value) -> Result<Value, ProxyError> {
 /// `preserve_reasoning_content` 仅用于明确需要 Moonshot/Kimi/DeepSeek
 /// `reasoning_content` 兼容字段的 provider。默认转换保持通用 OpenAI-compatible
 /// 请求体，避免向严格后端发送未知字段。
+///
+/// `suppress_reasoning_effort` skips the `reasoning_effort` injection for
+/// providers whose upstream rejects `reasoning_effort` together with `tools`
+/// (e.g. Azure OpenAI gpt-5.5 / gpt-5.6-* on Chat Completions).
 pub fn anthropic_to_openai_with_reasoning_content(
     body: Value,
     preserve_reasoning_content: bool,
+    suppress_reasoning_effort: bool,
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
 
@@ -193,8 +198,9 @@ pub fn anthropic_to_openai_with_reasoning_content(
         result["stream"] = v.clone();
     }
 
-    // Map Anthropic thinking → OpenAI reasoning_effort
-    if supports_reasoning_effort(model) {
+    // Map Anthropic thinking → OpenAI reasoning_effort. Skip when the provider
+    // suppresses it (e.g. upstreams rejecting reasoning_effort with tools).
+    if supports_reasoning_effort(model) && !suppress_reasoning_effort {
         if let Some(effort) = resolve_reasoning_effort(&body) {
             result["reasoning_effort"] = json!(effort);
         }
@@ -1021,7 +1027,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai_with_reasoning_content(input, true).unwrap();
+        let result = anthropic_to_openai_with_reasoning_content(input, true, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert_eq!(msg["reasoning_content"], "I should call the tool.");
@@ -1042,7 +1048,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai_with_reasoning_content(input, true).unwrap();
+        let result = anthropic_to_openai_with_reasoning_content(input, true, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["role"], "assistant");
         assert_eq!(msg["reasoning_content"], "tool call");
@@ -1064,7 +1070,7 @@ mod tests {
             }]
         });
 
-        let result = anthropic_to_openai_with_reasoning_content(input, true).unwrap();
+        let result = anthropic_to_openai_with_reasoning_content(input, true, false).unwrap();
         let msg = &result["messages"][0];
         assert_eq!(msg["reasoning_content"], "[redacted thinking]");
         assert_eq!(msg["tool_calls"][0]["id"], "call_123");
@@ -1254,7 +1260,8 @@ mod tests {
                 "content": anthropic_response["content"].clone()
             }]
         });
-        let replayed = anthropic_to_openai_with_reasoning_content(follow_up_request, true).unwrap();
+        let replayed =
+            anthropic_to_openai_with_reasoning_content(follow_up_request, true, false).unwrap();
         let msg = &replayed["messages"][0];
 
         assert_eq!(
@@ -1655,6 +1662,33 @@ mod tests {
     }
 
     // ── Integration: anthropic_to_openai with resolve_reasoning_effort ──
+
+    #[test]
+    fn test_suppress_reasoning_effort_with_tools() {
+        let input = json!({
+            "model": "o5.6-luna",
+            "max_tokens": 100,
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "max"},
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"name": "bash", "description": "run",
+                       "input_schema": {"type": "object", "properties": {}}}]
+        });
+
+        let result = anthropic_to_openai_with_reasoning_content(input, false, true).unwrap();
+        assert!(
+            result.get("reasoning_effort").is_none(),
+            "reasoning_effort should not be injected when suppressed"
+        );
+        assert!(
+            result.get("tools").is_some(),
+            "tools should still be present"
+        );
+        assert!(
+            result.get("max_completion_tokens").is_some(),
+            "max_completion_tokens should still be set for o-series model"
+        );
+    }
 
     #[test]
     fn test_non_reasoning_model_no_reasoning_effort() {

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -144,6 +144,10 @@ interface ClaudeFormFieldsProps {
   isFullUrl: boolean;
   onFullUrlChange: (value: boolean) => void;
 
+  // Skip reasoning_effort injection (for upstreams rejecting it with tools)
+  suppressReasoningEffort: boolean;
+  onSuppressReasoningEffortChange: (value: boolean) => void;
+
   // Local proxy User-Agent override
   customUserAgent: string;
   onCustomUserAgentChange: (value: string) => void;
@@ -206,6 +210,8 @@ export function ClaudeFormFields({
   onApiKeyFieldChange,
   isFullUrl,
   onFullUrlChange,
+  suppressReasoningEffort,
+  onSuppressReasoningEffortChange,
   customUserAgent,
   onCustomUserAgentChange,
   localProxyHeadersOverride,
@@ -776,6 +782,27 @@ export function ClaudeFormFields({
                     defaultValue: "选择供应商 API 的输入格式",
                   })}
                 </p>
+                {apiFormat === "openai_chat" && (
+                  <div className="space-y-1 pt-1">
+                    <label className="flex items-center gap-2 text-sm">
+                      <Checkbox
+                        checked={suppressReasoningEffort}
+                        onCheckedChange={(checked) =>
+                          onSuppressReasoningEffortChange(checked === true)
+                        }
+                      />
+                      {t("providerForm.suppressReasoningEffort", {
+                        defaultValue: "不注入 reasoning_effort",
+                      })}
+                    </label>
+                    <p className="text-xs text-muted-foreground">
+                      {t("providerForm.suppressReasoningEffortHint", {
+                        defaultValue:
+                          "部分端点（如 Azure gpt-5.5/5.6）拒绝 reasoning_effort 与 tools 同时使用，开启后转换时跳过注入该字段",
+                      })}
+                    </p>
+                  </div>
+                )}
               </div>
             )}
 

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -316,6 +316,10 @@ function ProviderFormFull({
     if (!supportsFullUrl) return false;
     return initialData?.meta?.isFullUrl ?? false;
   });
+  const [localSuppressReasoningEffort, setLocalSuppressReasoningEffort] =
+    useState<boolean>(
+      () => initialData?.meta?.suppressReasoningEffort ?? false,
+    );
 
   const [pricingConfig, setPricingConfig] = useState<{
     enabled: boolean;
@@ -351,6 +355,9 @@ function ProviderFormFull({
     setEndpointAutoSelect(initialData?.meta?.endpointAutoSelect ?? true);
     setLocalIsFullUrl(
       supportsFullUrl ? (initialData?.meta?.isFullUrl ?? false) : false,
+    );
+    setLocalSuppressReasoningEffort(
+      initialData?.meta?.suppressReasoningEffort ?? false,
     );
     setPricingConfig({
       enabled:
@@ -1555,6 +1562,13 @@ function ProviderFormFull({
         supportsFullUrl && category !== "official" && localIsFullUrl
           ? true
           : undefined,
+      suppressReasoningEffort:
+        appId === "claude" &&
+        category !== "official" &&
+        localApiFormat === "openai_chat" &&
+        localSuppressReasoningEffort
+          ? true
+          : undefined,
     };
 
     if (!isCodexOauthProvider && "codexFastMode" in nextMeta) {
@@ -1831,6 +1845,7 @@ function ProviderFormFull({
 
     setLocalApiKeyField(preset.apiKeyField ?? "ANTHROPIC_AUTH_TOKEN");
     setLocalIsFullUrl(false);
+    setLocalSuppressReasoningEffort(false);
 
     form.reset({
       name: preset.nameKey ? t(preset.nameKey) : preset.name,
@@ -2159,6 +2174,8 @@ function ProviderFormFull({
               onApiKeyFieldChange={handleApiKeyFieldChange}
               isFullUrl={localIsFullUrl}
               onFullUrlChange={setLocalIsFullUrl}
+              suppressReasoningEffort={localSuppressReasoningEffort}
+              onSuppressReasoningEffortChange={setLocalSuppressReasoningEffort}
               customUserAgent={customUserAgent}
               onCustomUserAgentChange={setCustomUserAgent}
               localProxyHeadersOverride={localProxyHeadersOverride}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1093,6 +1093,8 @@
     "anthropicSmallFastModel": "Fast Model",
     "apiFormat": "API Format",
     "apiFormatHint": "Select the input format for the provider's API",
+    "suppressReasoningEffort": "Do not inject reasoning_effort",
+    "suppressReasoningEffortHint": "Some endpoints (e.g. Azure gpt-5.5/5.6) reject reasoning_effort together with tools; when enabled, the conversion skips injecting this field",
     "customUserAgent": "Custom User-Agent",
     "customUserAgentHint": "Only takes effect when local routing/proxy takeover is enabled; replaces the User-Agent in requests forwarded to the provider API.",
     "customUserAgentInvalid": "User-Agent must not contain control characters (e.g. line breaks); otherwise it will be ignored.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1093,6 +1093,8 @@
     "anthropicSmallFastModel": "高速モデル",
     "apiFormat": "API フォーマット",
     "apiFormatHint": "プロバイダー API の入力フォーマットを選択",
+    "suppressReasoningEffort": "reasoning_effort を注入しない",
+    "suppressReasoningEffortHint": "一部のエンドポイント（Azure gpt-5.5/5.6 など）は reasoning_effort と tools の併用を拒否します。有効にすると変換時にこのフィールドの注入をスキップします",
     "customUserAgent": "カスタム User-Agent",
     "customUserAgentHint": "ローカルルーティング/プロキシ引き継ぎが有効な場合にのみ適用され、プロバイダー API へ転送するリクエストの User-Agent を置き換えます。",
     "customUserAgentInvalid": "User-Agent に制御文字（改行など）を含めることはできません。含まれている場合は無視されます。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1065,6 +1065,8 @@
     "anthropicSmallFastModel": "快速模型",
     "apiFormat": "API 格式",
     "apiFormatHint": "選擇供應商 API 的輸入格式",
+    "suppressReasoningEffort": "不注入 reasoning_effort",
+    "suppressReasoningEffortHint": "部分端點（如 Azure gpt-5.5/5.6）拒絕 reasoning_effort 與 tools 同時使用，開啟後轉換時跳過注入該欄位",
     "customUserAgent": "自訂 User-Agent",
     "customUserAgentHint": "僅在開啟本地路由/代理接管後生效，會取代轉發至供應商 API 請求中的 User-Agent。",
     "customUserAgentInvalid": "User-Agent 不能包含控制字元（如換行字元），否則將被忽略。",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1093,6 +1093,8 @@
     "anthropicSmallFastModel": "快速模型",
     "apiFormat": "API 格式",
     "apiFormatHint": "选择供应商 API 的输入格式",
+    "suppressReasoningEffort": "不注入 reasoning_effort",
+    "suppressReasoningEffortHint": "部分端点（如 Azure gpt-5.5/5.6）拒绝 reasoning_effort 与 tools 同时使用，开启后转换时跳过注入该字段",
     "customUserAgent": "自定义 User-Agent",
     "customUserAgentHint": "仅在开启本地路由/代理接管后生效，会替换转发到供应商 API 请求中的 User-Agent。",
     "customUserAgentInvalid": "User-Agent 不能包含控制字符（如换行符），否则将被忽略。",

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,9 @@ export interface ProviderMeta {
   apiKeyField?: ClaudeApiKeyField;
   // 是否将 base_url 视为完整 API 端点（代理直接使用此 URL，不拼接路径）
   isFullUrl?: boolean;
+  // 抑制 Anthropic → OpenAI Chat 转换时的 reasoning_effort 注入
+  // （兼容拒绝 reasoning_effort 与 tools 并存的端点，如 Azure gpt-5.5/5.6）
+  suppressReasoningEffort?: boolean;
   // Prompt cache key for OpenAI Responses-compatible endpoints (improves cache hit rate)
   promptCacheKey?: string;
   // Session-based prompt-cache routing for Codex Responses -> Chat conversions.

--- a/tests/components/ClaudeFormFields.test.tsx
+++ b/tests/components/ClaudeFormFields.test.tsx
@@ -94,6 +94,8 @@ const renderCopilotForm = (overrides: Partial<ClaudeFormFieldsProps> = {}) => {
     onApiKeyFieldChange: vi.fn(),
     isFullUrl: false,
     onFullUrlChange: vi.fn(),
+    suppressReasoningEffort: false,
+    onSuppressReasoningEffortChange: vi.fn(),
     customUserAgent: "",
     onCustomUserAgentChange: vi.fn(),
     localProxyHeadersOverride: "",


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->
Problem:
Some OpenAI-compatible Chat Completions endpoints reject requests that
include both `reasoning_effort` and `tools` for newer reasoning models.
Observed on Azure OpenAI (Microsoft Foundry) deployments of gpt-5.5 and
gpt-5.6-luna/terra/sol behind an enterprise gateway:

  400 Function tools with reasoning_effort are not supported for {model}
  in /v1/chat/completions. Please use /v1/responses instead.

Since Claude Code always sends MCP tools, these models are currently
unusable via cc-switch Claude routing. These endpoints do not offer the
Responses API yet, so switching apiFormat to openai_responses is not an
option for them.

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #
Solution:
Add an opt-in `suppressReasoningEffort` flag to ProviderMeta (default
off). When enabled, the Anthropic→OpenAI Chat Completions transform
skips injecting `reasoning_effort`, allowing tools-based requests to
succeed. Follows the same pattern as existing per-provider
compatibility switches (isFullUrl, impersonateClaudeCode,
codexChatReasoning.effortValueMode).

Changes:
- provider.rs: add `suppress_reasoning_effort: Option<bool>` to ProviderMeta
- transform.rs: add `suppress_reasoning_effort` param to
  `anthropic_to_openai_with_reasoning_content()`, skip injection when true
- claude.rs: read the flag from provider.meta in the openai_chat branch
- UI: checkbox in the Claude provider form (visible only for
  apiFormat=openai_chat), with i18n strings (en/zh/zh-TW/ja)
- tests: new unit test for suppression; existing call sites updated

No behavior change for existing providers (defaults to false).

## Screenshots / 截图
<img width="1640" height="764" alt="image" src="https://github.com/user-attachments/assets/3317b3f6-6c9e-4ae3-a849-d558d091b536" />

<img width="1525" height="876" alt="image" src="https://github.com/user-attachments/assets/cc5da578-2097-4fe8-8b3b-aae29639455c" />


<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
