### PR TITLE
[codex] Prevent custom API keys in official auth

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -398,6 +398,24 @@ pub fn codex_auth_has_oauth_login_material(auth: &Value) -> bool {
     })
 }
 
+pub(crate) fn sanitize_codex_official_auth(auth: &Value) -> Value {
+    let mut sanitized = auth.clone();
+    if let Some(obj) = sanitized.as_object_mut() {
+        // OAuth auth.json may carry OPENAI_API_KEY: null. Keep that canonical
+        // placeholder, but never let a provider key string enter official auth.
+        if obj.get("OPENAI_API_KEY").is_some_and(Value::is_string) {
+            obj.remove("OPENAI_API_KEY");
+        }
+    }
+    sanitized
+}
+
+pub(crate) fn sanitize_codex_official_settings(settings: &mut Value) {
+    if let Some(auth) = settings.get_mut("auth") {
+        *auth = sanitize_codex_official_auth(auth);
+    }
+}
+
 pub fn should_restore_codex_provider_token_for_backfill(
     category: Option<&str>,
     template_settings: &Value,
@@ -1540,7 +1558,8 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
 
 /// Route a Codex live write between full auth+config or config-only.
 ///
-/// Official providers with usable login material own `auth.json`. Third-party
+/// Official providers own an API-key-free `auth.json`. Their stored OAuth login
+/// wins; otherwise any OAuth login already in Live is retained. Third-party
 /// providers only touch `config.toml` when the compatibility setting is enabled
 /// so the user's ChatGPT login cache survives provider switches.
 ///
@@ -1561,11 +1580,23 @@ pub fn write_codex_live_for_provider(
         };
     let config_text = unified_official_config.as_deref().or(config_text);
 
-    let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
-        || (category != Some("official")
-            && !crate::settings::preserve_codex_official_auth_on_switch());
+    if category == Some("official") {
+        let stored_auth = sanitize_codex_official_auth(auth);
+        let official_auth = if codex_auth_has_oauth_login_material(&stored_auth) {
+            stored_auth
+        } else {
+            let auth_path = get_codex_auth_path();
+            if auth_path.exists() {
+                let live_auth: Value = read_json_file(&auth_path)?;
+                sanitize_codex_official_auth(&live_auth)
+            } else {
+                stored_auth
+            }
+        };
+        return write_codex_live_atomic(&official_auth, config_text);
+    }
 
-    if should_write_auth {
+    if !crate::settings::preserve_codex_official_auth_on_switch() {
         write_codex_live_atomic(auth, config_text)
     } else {
         let live_config = prepare_codex_provider_live_config(auth, config_text.unwrap_or(""))?;

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -630,6 +630,10 @@ fn restore_live_settings_for_provider_backfill(
         );
     }
 
+    if provider.category.as_deref() == Some("official") {
+        crate::codex_config::sanitize_codex_official_settings(&mut settings);
+    }
+
     // MCP 服务器归 DB mcp_servers 表所有，live 里的 [mcp_servers] 是同步投影；
     // 回填时剥掉，否则已删除的服务器会随供应商快照复活（逐条 reconcile 清不掉孤儿）。
     if let Err(err) = crate::codex_config::strip_codex_mcp_servers_from_settings(&mut settings) {
@@ -1970,6 +1974,46 @@ base_url = "https://a.example/v1"
             result.get("modelCatalog"),
             live_settings.get("modelCatalog"),
             "backfill must keep the Live-reconstructed catalog when the DB has none"
+        );
+    }
+
+    #[test]
+    fn codex_official_backfill_drops_third_party_api_key() {
+        let mut provider = Provider::with_id(
+            "official".to_string(),
+            "OpenAI Official".to_string(),
+            json!({
+                "auth": {},
+                "config": ""
+            }),
+            None,
+        );
+        provider.category = Some("official".to_string());
+
+        let live_settings = json!({
+            "auth": {
+                "auth_mode": "chatgpt",
+                "OPENAI_API_KEY": "third-party-key",
+                "tokens": {
+                    "access_token": "official-oauth-token"
+                }
+            },
+            "config": ""
+        });
+
+        let result =
+            restore_live_settings_for_provider_backfill(&AppType::Codex, &provider, live_settings);
+
+        assert!(
+            result.pointer("/auth/OPENAI_API_KEY").is_none(),
+            "official provider backfill must not store a third-party API key"
+        );
+        assert_eq!(
+            result
+                .pointer("/auth/tokens/access_token")
+                .and_then(Value::as_str),
+            Some("official-oauth-token"),
+            "official OAuth material must survive backfill"
         );
     }
 

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -882,6 +882,59 @@ requires_openai_auth = true
 }
 
 #[test]
+fn provider_service_switch_codex_official_drops_previous_custom_api_key() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    write_codex_live_atomic(
+        &json!({ "OPENAI_API_KEY": "third-party-key" }),
+        Some("model_provider = \"custom\"\n"),
+    )
+    .expect("seed custom provider live config");
+
+    let mut initial_config = MultiAppConfig::default();
+    {
+        let manager = initial_config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = "third-party".to_string();
+        manager.providers.insert(
+            "third-party".to_string(),
+            Provider::with_id(
+                "third-party".to_string(),
+                "Third Party".to_string(),
+                json!({
+                    "auth": { "OPENAI_API_KEY": "third-party-key" },
+                    "config": "model_provider = \"custom\"\n"
+                }),
+                None,
+            ),
+        );
+        let mut official = Provider::with_id(
+            "official".to_string(),
+            "OpenAI Official".to_string(),
+            json!({ "auth": {}, "config": "" }),
+            None,
+        );
+        official.category = Some("official".to_string());
+        manager.providers.insert("official".to_string(), official);
+    }
+
+    let state = create_test_state_with_config(&initial_config).expect("create test state");
+
+    ProviderService::switch(&state, AppType::Codex, "official")
+        .expect("switch to official provider");
+
+    let auth: serde_json::Value =
+        read_json_file(&cc_switch_lib::get_codex_auth_path()).expect("read official auth");
+    assert!(
+        auth.get("OPENAI_API_KEY").is_none(),
+        "official auth must not inherit the previous custom provider key"
+    );
+}
+
+#[test]
 fn reapply_codex_official_live_resyncs_mcp_servers() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();


### PR DESCRIPTION
## Summary

- remove string-valued `OPENAI_API_KEY` entries before writing official Codex auth
- preserve existing or provider-scoped ChatGPT OAuth login material
- prevent switch-time Live backfill from storing third-party keys in official providers
- add regression coverage for custom-to-official switching and official backfill

## Root cause

When an official provider had no stored OAuth material, switching only rewrote `config.toml`. The previous custom provider's `OPENAI_API_KEY` remained in Live `auth.json`. Editing or switching away from the official provider could then copy that key into the official provider record.

## Validation

- `cargo test --test provider_service` (34 passed)
- `cargo test codex_config::tests --lib` (58 passed)
- `cargo test services::provider::live::tests --lib` (11 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --lib --tests` (passes with pre-existing Windows warnings)
- `cargo test --lib` (1870 passed, 8 pre-existing unrelated Windows failures, 2 ignored)

Fixes #5143