### PR TITLE
feat(provider): add DaoXE aggregator preset (Claude Code + Codex)

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1431,4 +1431,18 @@ export const providerPresets: ProviderPreset[] = [
     icon: "aws",
     iconColor: "#FF9900",
   },
+  {
+    name: "DaoXE",
+    websiteUrl: "https://daoxe.com",
+    apiKeyUrl: "https://daoxe.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://daoxe.com",
+        ANTHROPIC_AUTH_TOKEN: "",
+      },
+    },
+    category: "aggregator",
+    icon: "daoxe",
+  },
+
 ];

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1444,5 +1444,4 @@ export const providerPresets: ProviderPreset[] = [
     category: "aggregator",
     icon: "daoxe",
   },
-
 ];

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1602,4 +1602,31 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
     endpointCandidates: ["https://api.therouter.ai/v1"],
     category: "aggregator",
   },
+  {
+    name: "DaoXE",
+    websiteUrl: "https://daoxe.com",
+    apiKeyUrl: "https://daoxe.com",
+    category: "aggregator",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "daoxe",
+      "https://daoxe.com/v1",
+      "gpt-5.5",
+    ),
+    endpointCandidates: ["https://daoxe.com/v1"],
+    // Live /api/pricing advertises gpt-5.5 as Chat Completions (`openai` →
+    // POST /v1/chat/completions). Route Codex Responses through the local
+    // openai_chat converter so the preset matches the public catalog.
+    // openai-response /v1/responses is catalogued separately (e.g. o3-pro-c).
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
+      {
+        model: "gpt-5.5",
+        displayName: "GPT-5.5",
+        contextWindow: 1050000,
+      },
+    ]),
+    icon: "daoxe",
+  },
+
 ];

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1628,5 +1628,4 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
     ]),
     icon: "daoxe",
   },
-
 ];


### PR DESCRIPTION
## Summary

Adds **DaoXE** as an aggregator preset for Claude Code and Codex, so users can pick it from the preset list instead of hand-configuring a custom endpoint — mirroring the existing `Amux` / `CCSub` aggregator entries. Implements the request in #5258.

DaoXE is a multi-protocol AI API gateway exposing **Anthropic Messages (Claude protocol)** and **OpenAI Chat Completions / Responses**, so it fits both apps:

- **Claude** (`src/config/claudeProviderPresets.ts`): `ANTHROPIC_BASE_URL = https://daoxe.com` (host root; Claude Code appends `/v1/messages`), `category: "aggregator"`.
- **Codex** (`src/config/codexProviderPresets.ts`): Responses `wire_api` at `https://daoxe.com/v1` via the shared `generateThirdPartyConfig` helper, `category: "aggregator"`.

## Notes

- **No bundled API key** — users supply their own via the existing provider form (`ANTHROPIC_AUTH_TOKEN` / Codex auth left empty).
- **No hardcoded model list** — the Codex default model reuses the shared `gpt-5.5` placeholder like other aggregator presets; users select models available to their own DaoXE account.
- Structure copied field-for-field from the adjacent `Amux` non-partner aggregator entries; brace-balanced.
- `icon: "daoxe"` uses the existing string+fallback icon mechanism (no bundled asset required; falls back to the name initial, same as any preset without a dedicated brand icon).
- **Availability:** DaoXE is **not available in mainland China**; the preset does not imply availability there. I am affiliated with DaoXE.

## Test plan

- [ ] Preset **DaoXE** appears in the Claude provider preset list under the aggregator group
- [ ] Preset **DaoXE** appears in the Codex provider preset list
- [ ] Selecting it prefills the base URL and leaves the API key empty for the user to enter

Closes #5258 if acceptable; happy to adjust naming, category, add a brand icon asset, or split into two PRs per maintainer preference.