### PR TITLE
fix: default Codex tool parameters to object schema

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -440,14 +440,17 @@ fn chat_tool_to_anthropic_tool(chat_tool: &Value) -> Option<Value> {
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|value| !value.is_empty())?;
-    let mut tool = json!({
-        "name": name,
-        "input_schema": function
-            .get("parameters")
-            .cloned()
-            .filter(|value| value.as_object().is_some_and(|object| !object.is_empty()))
-            .unwrap_or_else(|| json!({ "type": "object", "properties": {} }))
-    });
+    let mut input_schema = function
+        .get("parameters")
+        .cloned()
+        .filter(|value| value.as_object().is_some_and(|object| !object.is_empty()))
+        .unwrap_or_else(|| json!({ "type": "object", "properties": {} }));
+    if let Some(schema) = input_schema.as_object_mut() {
+        if schema.get("type").and_then(Value::as_str) != Some("object") {
+            schema.insert("type".to_string(), json!("object"));
+        }
+    }
+    let mut tool = json!({ "name": name, "input_schema": input_schema });
     if let Some(description) = function.get("description").and_then(|value| value.as_str()) {
         tool["description"] = json!(description);
     }
@@ -1543,6 +1546,44 @@ mod tests {
         assert_eq!(tools[0]["input_schema"]["type"], "object");
         assert!(tools[0].get("parameters").is_none());
         assert_eq!(tools[1]["name"], "apply_patch");
+    }
+
+    #[test]
+    fn test_request_tool_search_output_schema_defaults_root_type_to_object() {
+        let input = json!({
+            "model": "claude",
+            "max_output_tokens": 100,
+            "input": [
+                { "role": "user", "content": "hi" },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_demo123",
+                    "tools": [{
+                        "type": "function",
+                        "name": "demo_union_tool",
+                        "parameters": {
+                            "oneOf": [
+                                { "type": "object", "properties": { "mode": { "type": "string" } } },
+                                { "type": "object", "properties": { "name": { "type": "string" } } }
+                            ]
+                        }
+                    }]
+                }
+            ]
+        });
+
+        let result = responses_request_to_anthropic(input, 4096).unwrap();
+        let input_schema = &result["tools"][0]["input_schema"];
+
+        assert_eq!(input_schema["type"], "object");
+        assert_eq!(
+            input_schema["oneOf"][0]["properties"]["mode"]["type"],
+            "string"
+        );
+        assert_eq!(
+            input_schema["oneOf"][1]["properties"]["name"]["type"],
+            "string"
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1131,12 +1131,8 @@ fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option
             .and_then(|value| value.as_object_mut())
         {
             // Ensure parameters.type is "object" for strict OpenAI-compatible providers
-            if let Some(params) = obj.get("parameters") {
-                let normalized = normalize_function_parameters(Some(params));
-                if normalized != *params {
-                    obj.insert("parameters".to_string(), normalized);
-                }
-            }
+            let parameters = normalize_function_parameters(obj.get("parameters"));
+            obj.insert("parameters".to_string(), parameters);
 
             obj.insert("name".to_string(), json!(chat_name));
             if let Some(strict) = tool.get("strict").cloned() {
@@ -2009,6 +2005,140 @@ mod tests {
         assert_eq!(result["tool_choice"]["function"]["name"], "get_weather");
         assert_eq!(result["max_tokens"], 100);
         assert_eq!(result["reasoning_effort"], "high");
+    }
+
+    #[test]
+    fn responses_request_to_chat_defaults_null_tool_parameters() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "codex_app__automation_update",
+                "description": "Update an automation.",
+                "parameters": null
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_defaults_nested_null_tool_parameters() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "codex_app__automation_update",
+                    "description": "Update an automation.",
+                    "parameters": null
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_defaults_nested_missing_tool_parameters() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "codex_app__automation_update",
+                    "description": "Update an automation."
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_normalizes_explicit_null_tool_parameter_type() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "search",
+                "parameters": {
+                    "type": null,
+                    "properties": {
+                        "query": {"type": "string"}
+                    },
+                    "required": ["query"]
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(parameters["properties"]["query"]["type"], "string");
+        assert_eq!(parameters["required"], json!(["query"]));
+    }
+
+    #[test]
+    fn responses_request_to_chat_defaults_top_level_one_of_tool_parameters_to_object() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "lookup",
+                "parameters": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {"id": {"type": "string"}}
+                        },
+                        {
+                            "type": "object",
+                            "properties": {"slug": {"type": "string"}}
+                        }
+                    ]
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(
+            parameters["oneOf"],
+            json!([
+                {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}}
+                },
+                {
+                    "type": "object",
+                    "properties": {"slug": {"type": "string"}}
+                }
+            ])
+        );
     }
 
     #[test]


### PR DESCRIPTION
﻿## Summary

- Default Codex Responses function tool `parameters` to an object schema when missing or `null`.
- Apply the normalization to both direct Responses tools and nested OpenAI-style `function` tools.
- Cover the `codex_app__automation_update` style `parameters: null` regression reported in #5300.

## Root cause

Codex can emit function tools such as `codex_app__automation_update` with `parameters: null`. During Responses → Chat Completions conversion, cc-switch forwarded that value unchanged, and strict OpenAI-compatible upstreams such as DeepSeek reject it because function parameters must be a JSON Schema object.

## Tests

- `cargo test transform_codex_chat --lib --manifest-path E:\gateway_komi\cc-switch\src-tauri\Cargo.toml`
- `git diff --check`
