### PR TITLE
fix: refresh tray after deeplink provider import

### DIFF
--- a/src-tauri/src/commands/deeplink.rs
+++ b/src-tauri/src/commands/deeplink.rs
@@ -3,7 +3,7 @@ use crate::deeplink::{
     import_skill_from_deeplink, parse_deeplink_url, DeepLinkImportRequest,
 };
 use crate::store::AppState;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 /// Parse a deep link URL and return the parsed request for frontend confirmation
 #[tauri::command]
@@ -25,6 +25,7 @@ pub fn merge_deeplink_config(
 /// Import a provider from a deep link request (legacy, kept for compatibility)
 #[tauri::command]
 pub fn import_from_deeplink(
+    app: AppHandle,
     state: State<AppState>,
     request: DeepLinkImportRequest,
 ) -> Result<String, String> {
@@ -36,6 +37,7 @@ pub fn import_from_deeplink(
 
     let provider_id = import_provider_from_deeplink(&state, request).map_err(|e| e.to_string())?;
 
+    crate::tray::refresh_tray_menu(&app);
     log::info!("Successfully imported provider with ID: {provider_id}");
 
     Ok(provider_id)
@@ -44,6 +46,7 @@ pub fn import_from_deeplink(
 /// Import resource from a deep link request (unified handler)
 #[tauri::command]
 pub async fn import_from_deeplink_unified(
+    app: AppHandle,
     state: State<'_, AppState>,
     request: DeepLinkImportRequest,
 ) -> Result<serde_json::Value, String> {
@@ -53,6 +56,7 @@ pub async fn import_from_deeplink_unified(
         "provider" => {
             let provider_id =
                 import_provider_from_deeplink(&state, request).map_err(|e| e.to_string())?;
+            crate::tray::refresh_tray_menu(&app);
             Ok(serde_json::json!({
                 "type": "provider",
                 "id": provider_id


### PR DESCRIPTION
﻿## Summary

- Inject `AppHandle` into deep-link provider import commands.
- Refresh the system tray menu immediately after a provider is imported through a deep link.
- Covers both the legacy provider import command and the unified provider import path.

## Root cause

The deep-link provider import path updated provider data used by the main window, but did not rebuild the tray menu. As a result, newly imported providers and active-provider check state were stale until another provider switch triggered a tray refresh.

## Tests

- `cargo test deeplink --lib --manifest-path E:\gateway_komi\cc-switch\src-tauri\Cargo.toml`
- `git diff --check`
