### PR TITLE
feat(presets): add TokenRouter provider

### DIFF
--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -1093,6 +1093,21 @@ export const claudeDesktopProviderPresets: ClaudeDesktopProviderPreset[] = [
     iconColor: "#6566F1",
   },
   {
+    name: "TokenRouter",
+    websiteUrl: "https://tokenrouter.com",
+    category: "aggregator",
+    baseUrl: "https://api.tokenrouter.com",
+    mode: "proxy",
+    apiFormat: "anthropic",
+    modelRoutes: mappedRoutes(
+      "anthropic/claude-sonnet-5",
+      "anthropic/claude-opus-4.8",
+      "anthropic/claude-haiku-4.5",
+      true,
+    ),
+    endpointCandidates: ["https://api.tokenrouter.com"],
+  },
+  {
     name: "TheRouter",
     websiteUrl: "https://therouter.ai",
     apiKeyUrl: "https://dashboard.therouter.ai",

--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -1095,13 +1095,14 @@ export const claudeDesktopProviderPresets: ClaudeDesktopProviderPreset[] = [
   {
     name: "TokenRouter",
     websiteUrl: "https://tokenrouter.com",
+    apiKeyUrl: "https://tokenrouter.com",
     category: "aggregator",
     baseUrl: "https://api.tokenrouter.com",
     mode: "proxy",
     apiFormat: "anthropic",
     modelRoutes: mappedRoutes(
       "anthropic/claude-sonnet-5",
-      "anthropic/claude-opus-4.8",
+      "anthropic/claude-opus-5",
       "anthropic/claude-haiku-4.5",
       true,
     ),

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1202,6 +1202,22 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#6566F1",
   },
   {
+    name: "TokenRouter",
+    websiteUrl: "https://tokenrouter.com",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.tokenrouter.com",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "anthropic/claude-sonnet-5",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "anthropic/claude-haiku-4.5",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-sonnet-5",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-4.8",
+      },
+    },
+    category: "aggregator",
+    endpointCandidates: ["https://api.tokenrouter.com"],
+  },
+  {
     name: "TheRouter",
     websiteUrl: "https://therouter.ai",
     apiKeyUrl: "https://dashboard.therouter.ai",

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1204,6 +1204,7 @@ export const providerPresets: ProviderPreset[] = [
   {
     name: "TokenRouter",
     websiteUrl: "https://tokenrouter.com",
+    apiKeyUrl: "https://tokenrouter.com",
     settingsConfig: {
       env: {
         ANTHROPIC_BASE_URL: "https://api.tokenrouter.com",
@@ -1211,7 +1212,7 @@ export const providerPresets: ProviderPreset[] = [
         ANTHROPIC_MODEL: "anthropic/claude-sonnet-5",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "anthropic/claude-haiku-4.5",
         ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-sonnet-5",
-        ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-4.8",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-5",
       },
     },
     category: "aggregator",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1661,11 +1661,12 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
   {
     name: "TokenRouter",
     websiteUrl: "https://tokenrouter.com",
+    apiKeyUrl: "https://tokenrouter.com",
     auth: generateThirdPartyAuth(""),
     config: generateThirdPartyConfig(
       "tokenrouter",
       "https://api.tokenrouter.com/v1",
-      "gpt-5.5",
+      "gpt-5.6-sol",
     ),
     endpointCandidates: ["https://api.tokenrouter.com/v1"],
     category: "aggregator",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1659,6 +1659,18 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
     iconColor: "#6566F1",
   },
   {
+    name: "TokenRouter",
+    websiteUrl: "https://tokenrouter.com",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "tokenrouter",
+      "https://api.tokenrouter.com/v1",
+      "gpt-5.5",
+    ),
+    endpointCandidates: ["https://api.tokenrouter.com/v1"],
+    category: "aggregator",
+  },
+  {
     name: "TheRouter",
     websiteUrl: "https://therouter.ai",
     apiKeyUrl: "https://dashboard.therouter.ai",

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -1072,6 +1072,27 @@ export const hermesProviderPresets: HermesProviderPreset[] = [
     },
   },
   {
+    name: "TokenRouter",
+    websiteUrl: "https://tokenrouter.com",
+    settingsConfig: {
+      name: "tokenrouter",
+      base_url: "https://api.tokenrouter.com/v1",
+      api_key: "",
+      api_mode: "chat_completions",
+      models: [
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          context_length: 400000,
+        },
+      ],
+    },
+    category: "aggregator",
+    suggestedDefaults: {
+      model: { default: "gpt-5.5", provider: "tokenrouter" },
+    },
+  },
+  {
     name: "DeepSeek",
     nameKey: "providerForm.presets.deepseek",
     websiteUrl: "https://platform.deepseek.com",

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -1074,22 +1074,23 @@ export const hermesProviderPresets: HermesProviderPreset[] = [
   {
     name: "TokenRouter",
     websiteUrl: "https://tokenrouter.com",
+    apiKeyUrl: "https://tokenrouter.com",
     settingsConfig: {
       name: "tokenrouter",
       base_url: "https://api.tokenrouter.com/v1",
       api_key: "",
-      api_mode: "chat_completions",
+      api_mode: "codex_responses",
       models: [
         {
-          id: "gpt-5.5",
-          name: "GPT-5.5",
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
           context_length: 400000,
         },
       ],
     },
     category: "aggregator",
     suggestedDefaults: {
-      model: { default: "gpt-5.5", provider: "tokenrouter" },
+      model: { default: "gpt-5.6-sol", provider: "tokenrouter" },
     },
   },
   {

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -2274,14 +2274,15 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
   {
     name: "TokenRouter",
     websiteUrl: "https://tokenrouter.com",
+    apiKeyUrl: "https://tokenrouter.com",
     settingsConfig: {
       baseUrl: "https://api.tokenrouter.com/v1",
       apiKey: "",
-      api: "openai-completions",
+      api: "openai-responses",
       models: [
         {
-          id: "gpt-5.5",
-          name: "GPT-5.5",
+          id: "gpt-5.6-sol",
+          name: "GPT-5.6 Sol",
           contextWindow: 400000,
         },
       ],
@@ -2296,10 +2297,10 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     },
     suggestedDefaults: {
       model: {
-        primary: "tokenrouter/gpt-5.5",
+        primary: "tokenrouter/gpt-5.6-sol",
       },
       modelCatalog: {
-        "tokenrouter/gpt-5.5": { alias: "GPT-5.5" },
+        "tokenrouter/gpt-5.6-sol": { alias: "GPT-5.6 Sol" },
       },
     },
   },

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -2272,6 +2272,38 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     },
   },
   {
+    name: "TokenRouter",
+    websiteUrl: "https://tokenrouter.com",
+    settingsConfig: {
+      baseUrl: "https://api.tokenrouter.com/v1",
+      apiKey: "",
+      api: "openai-completions",
+      models: [
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          contextWindow: 400000,
+        },
+      ],
+    },
+    category: "aggregator",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "",
+        editorValue: "",
+      },
+    },
+    suggestedDefaults: {
+      model: {
+        primary: "tokenrouter/gpt-5.5",
+      },
+      modelCatalog: {
+        "tokenrouter/gpt-5.5": { alias: "GPT-5.5" },
+      },
+    },
+  },
+  {
     name: "TheRouter",
     websiteUrl: "https://therouter.ai",
     apiKeyUrl: "https://dashboard.therouter.ai",

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -1903,15 +1903,17 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
   {
     name: "TokenRouter",
     websiteUrl: "https://tokenrouter.com",
+    apiKeyUrl: "https://tokenrouter.com",
     settingsConfig: {
-      npm: "@ai-sdk/openai-compatible",
+      npm: "@ai-sdk/openai",
       name: "TokenRouter",
       options: {
         baseURL: "https://api.tokenrouter.com/v1",
         apiKey: "",
+        setCacheKey: true,
       },
       models: {
-        "gpt-5.5": { name: "GPT-5.5" },
+        "gpt-5.6-sol": { name: "GPT-5.6 Sol" },
       },
     },
     category: "aggregator",

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -1901,6 +1901,29 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     },
   },
   {
+    name: "TokenRouter",
+    websiteUrl: "https://tokenrouter.com",
+    settingsConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "TokenRouter",
+      options: {
+        baseURL: "https://api.tokenrouter.com/v1",
+        apiKey: "",
+      },
+      models: {
+        "gpt-5.5": { name: "GPT-5.5" },
+      },
+    },
+    category: "aggregator",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "",
+        editorValue: "",
+      },
+    },
+  },
+  {
     name: "TheRouter",
     websiteUrl: "https://therouter.ai",
     apiKeyUrl: "https://dashboard.therouter.ai",

--- a/tests/config/tokenrouterProviderPresets.test.ts
+++ b/tests/config/tokenrouterProviderPresets.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { claudeDesktopProviderPresets } from "@/config/claudeDesktopProviderPresets";
+import { providerPresets } from "@/config/claudeProviderPresets";
+import { codexProviderPresets } from "@/config/codexProviderPresets";
+import { geminiProviderPresets } from "@/config/geminiProviderPresets";
+import { hermesProviderPresets } from "@/config/hermesProviderPresets";
+import { openclawProviderPresets } from "@/config/openclawProviderPresets";
+import { opencodeProviderPresets } from "@/config/opencodeProviderPresets";
+
+describe("TokenRouter provider preset", () => {
+  it("uses the Anthropic-compatible root endpoint for Claude", () => {
+    const preset = providerPresets.find((item) => item.name === "TokenRouter");
+    const env = (
+      preset?.settingsConfig as {
+        env: Record<string, string>;
+      }
+    ).env;
+
+    expect(preset?.websiteUrl).toBe("https://tokenrouter.com");
+    expect(preset?.category).toBe("aggregator");
+    expect(preset?.endpointCandidates).toEqual(["https://api.tokenrouter.com"]);
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://api.tokenrouter.com");
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("");
+    expect(env.ANTHROPIC_MODEL).toBe("anthropic/claude-sonnet-5");
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("anthropic/claude-haiku-4.5");
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("anthropic/claude-sonnet-5");
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("anthropic/claude-opus-4.8");
+  });
+
+  it("uses Anthropic proxy routes for Claude Desktop", () => {
+    const preset = claudeDesktopProviderPresets.find(
+      (item) => item.name === "TokenRouter",
+    );
+
+    expect(preset?.baseUrl).toBe("https://api.tokenrouter.com");
+    expect(preset?.mode).toBe("proxy");
+    expect(preset?.apiFormat).toBe("anthropic");
+    expect(preset?.modelRoutes?.map((route) => route.upstreamModel)).toEqual([
+      "anthropic/claude-sonnet-5",
+      "anthropic/claude-opus-4.8",
+      "anthropic/claude-haiku-4.5",
+    ]);
+  });
+
+  it("uses the OpenAI Responses-compatible endpoint for Codex", () => {
+    const preset = codexProviderPresets.find(
+      (item) => item.name === "TokenRouter",
+    );
+
+    expect(preset).toBeDefined();
+    expect(preset?.websiteUrl).toBe("https://tokenrouter.com");
+    expect(preset?.category).toBe("aggregator");
+    expect(preset?.endpointCandidates).toEqual([
+      "https://api.tokenrouter.com/v1",
+    ]);
+    expect(preset?.auth).toEqual({ OPENAI_API_KEY: "" });
+    expect(preset?.config).toContain('model_provider = "custom"');
+    expect(preset?.config).toContain('model = "gpt-5.5"');
+    expect(preset?.config).toContain("[model_providers.custom]");
+    expect(preset?.config).toContain('name = "tokenrouter"');
+    expect(preset?.config).toContain(
+      'base_url = "https://api.tokenrouter.com/v1"',
+    );
+    expect(preset?.config).toContain('wire_api = "responses"');
+    expect(preset?.config).toContain("requires_openai_auth = true");
+  });
+
+  it("uses the OpenAI-compatible endpoint for OpenCode", () => {
+    const preset = opencodeProviderPresets.find(
+      (item) => item.name === "TokenRouter",
+    );
+
+    expect(preset?.settingsConfig.npm).toBe("@ai-sdk/openai-compatible");
+    expect(preset?.settingsConfig.options?.baseURL).toBe(
+      "https://api.tokenrouter.com/v1",
+    );
+    expect(preset?.settingsConfig.models).toEqual({
+      "gpt-5.5": { name: "GPT-5.5" },
+    });
+  });
+
+  it("uses Chat Completions for Hermes", () => {
+    const preset = hermesProviderPresets.find(
+      (item) => item.name === "TokenRouter",
+    );
+
+    expect(preset?.settingsConfig).toMatchObject({
+      name: "tokenrouter",
+      base_url: "https://api.tokenrouter.com/v1",
+      api_key: "",
+      api_mode: "chat_completions",
+    });
+    expect(preset?.suggestedDefaults?.model).toEqual({
+      default: "gpt-5.5",
+      provider: "tokenrouter",
+    });
+  });
+
+  it("uses OpenAI Completions for OpenClaw", () => {
+    const preset = openclawProviderPresets.find(
+      (item) => item.name === "TokenRouter",
+    );
+
+    expect(preset?.settingsConfig).toMatchObject({
+      baseUrl: "https://api.tokenrouter.com/v1",
+      apiKey: "",
+      api: "openai-completions",
+    });
+    expect(preset?.suggestedDefaults?.model?.primary).toBe(
+      "tokenrouter/gpt-5.5",
+    );
+  });
+
+  it("does not offer a broken Gemini preset without a native v1beta endpoint", () => {
+    expect(
+      geminiProviderPresets.some((item) => item.name === "TokenRouter"),
+    ).toBe(false);
+  });
+});

--- a/tests/config/tokenrouterProviderPresets.test.ts
+++ b/tests/config/tokenrouterProviderPresets.test.ts
@@ -17,6 +17,7 @@ describe("TokenRouter provider preset", () => {
     ).env;
 
     expect(preset?.websiteUrl).toBe("https://tokenrouter.com");
+    expect(preset?.apiKeyUrl).toBe("https://tokenrouter.com");
     expect(preset?.category).toBe("aggregator");
     expect(preset?.endpointCandidates).toEqual(["https://api.tokenrouter.com"]);
     expect(env.ANTHROPIC_BASE_URL).toBe("https://api.tokenrouter.com");
@@ -24,7 +25,7 @@ describe("TokenRouter provider preset", () => {
     expect(env.ANTHROPIC_MODEL).toBe("anthropic/claude-sonnet-5");
     expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("anthropic/claude-haiku-4.5");
     expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("anthropic/claude-sonnet-5");
-    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("anthropic/claude-opus-4.8");
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("anthropic/claude-opus-5");
   });
 
   it("uses Anthropic proxy routes for Claude Desktop", () => {
@@ -33,11 +34,12 @@ describe("TokenRouter provider preset", () => {
     );
 
     expect(preset?.baseUrl).toBe("https://api.tokenrouter.com");
+    expect(preset?.apiKeyUrl).toBe("https://tokenrouter.com");
     expect(preset?.mode).toBe("proxy");
     expect(preset?.apiFormat).toBe("anthropic");
     expect(preset?.modelRoutes?.map((route) => route.upstreamModel)).toEqual([
       "anthropic/claude-sonnet-5",
-      "anthropic/claude-opus-4.8",
+      "anthropic/claude-opus-5",
       "anthropic/claude-haiku-4.5",
     ]);
   });
@@ -49,13 +51,14 @@ describe("TokenRouter provider preset", () => {
 
     expect(preset).toBeDefined();
     expect(preset?.websiteUrl).toBe("https://tokenrouter.com");
+    expect(preset?.apiKeyUrl).toBe("https://tokenrouter.com");
     expect(preset?.category).toBe("aggregator");
     expect(preset?.endpointCandidates).toEqual([
       "https://api.tokenrouter.com/v1",
     ]);
     expect(preset?.auth).toEqual({ OPENAI_API_KEY: "" });
     expect(preset?.config).toContain('model_provider = "custom"');
-    expect(preset?.config).toContain('model = "gpt-5.5"');
+    expect(preset?.config).toContain('model = "gpt-5.6-sol"');
     expect(preset?.config).toContain("[model_providers.custom]");
     expect(preset?.config).toContain('name = "tokenrouter"');
     expect(preset?.config).toContain(
@@ -70,16 +73,18 @@ describe("TokenRouter provider preset", () => {
       (item) => item.name === "TokenRouter",
     );
 
-    expect(preset?.settingsConfig.npm).toBe("@ai-sdk/openai-compatible");
+    expect(preset?.settingsConfig.npm).toBe("@ai-sdk/openai");
     expect(preset?.settingsConfig.options?.baseURL).toBe(
       "https://api.tokenrouter.com/v1",
     );
+    expect(preset?.apiKeyUrl).toBe("https://tokenrouter.com");
+    expect(preset?.settingsConfig.options?.setCacheKey).toBe(true);
     expect(preset?.settingsConfig.models).toEqual({
-      "gpt-5.5": { name: "GPT-5.5" },
+      "gpt-5.6-sol": { name: "GPT-5.6 Sol" },
     });
   });
 
-  it("uses Chat Completions for Hermes", () => {
+  it("uses OpenAI Responses for Hermes", () => {
     const preset = hermesProviderPresets.find(
       (item) => item.name === "TokenRouter",
     );
@@ -88,15 +93,16 @@ describe("TokenRouter provider preset", () => {
       name: "tokenrouter",
       base_url: "https://api.tokenrouter.com/v1",
       api_key: "",
-      api_mode: "chat_completions",
+      api_mode: "codex_responses",
     });
+    expect(preset?.apiKeyUrl).toBe("https://tokenrouter.com");
     expect(preset?.suggestedDefaults?.model).toEqual({
-      default: "gpt-5.5",
+      default: "gpt-5.6-sol",
       provider: "tokenrouter",
     });
   });
 
-  it("uses OpenAI Completions for OpenClaw", () => {
+  it("uses OpenAI Responses for OpenClaw", () => {
     const preset = openclawProviderPresets.find(
       (item) => item.name === "TokenRouter",
     );
@@ -104,14 +110,15 @@ describe("TokenRouter provider preset", () => {
     expect(preset?.settingsConfig).toMatchObject({
       baseUrl: "https://api.tokenrouter.com/v1",
       apiKey: "",
-      api: "openai-completions",
+      api: "openai-responses",
     });
+    expect(preset?.apiKeyUrl).toBe("https://tokenrouter.com");
     expect(preset?.suggestedDefaults?.model?.primary).toBe(
-      "tokenrouter/gpt-5.5",
+      "tokenrouter/gpt-5.6-sol",
     );
   });
 
-  it("does not offer a broken Gemini preset without a native v1beta endpoint", () => {
+  it("omits Gemini until its native v1beta path is verified", () => {
     expect(
       geminiProviderPresets.some((item) => item.name === "TokenRouter"),
     ).toBe(false);


### PR DESCRIPTION
Closes #5319.

## Summary

Adds TokenRouter (`https://tokenrouter.com`, API `https://api.tokenrouter.com`) as a first-class aggregator preset for Claude Code, Claude Desktop, Codex, OpenCode, Hermes, and OpenClaw.

| Target | Transport | Endpoint | Default model |
| --- | --- | --- | --- |
| Claude Code | Anthropic Messages | `https://api.tokenrouter.com` | `anthropic/claude-sonnet-5` |
| Claude Desktop | Anthropic proxy routes | `https://api.tokenrouter.com` | Sonnet 5 / Opus 5 / Haiku 4.5 |
| Codex | OpenAI Responses | `https://api.tokenrouter.com/v1` | `gpt-5.6-sol` |
| OpenCode | `@ai-sdk/openai` (Responses) | `https://api.tokenrouter.com/v1` | `gpt-5.6-sol` |
| Hermes | `codex_responses` | `https://api.tokenrouter.com/v1` | `gpt-5.6-sol` |
| OpenClaw | `openai-responses` | `https://api.tokenrouter.com/v1` | `gpt-5.6-sol` |

The preset also supplies the TokenRouter website/API-key link, endpoint candidates, client-specific auth/config shape, model catalogs, and suggested defaults. Gemini is intentionally omitted until its native `v1beta` path is verified with the actual Gemini client.

## Why Responses for OpenAI clients

Live client tests showed that GPT-5.6 Sol rejects function tools plus `reasoning_effort` on `/v1/chat/completions`. The same clients work through `/v1/responses`, so OpenCode uses `@ai-sdk/openai`, Hermes uses `codex_responses`, and OpenClaw uses `openai-responses`.

## Verification

Live tests used a temporary Keychain-backed credential; no key or generated credential file is included in this branch.

| Verification | Result |
| --- | --- |
| `GET /v1/models` | HTTP 200; all configured model IDs present |
| Anthropic `/v1/messages` | HTTP 200 for Sonnet 5, Opus 5, and Haiku 4.5 |
| OpenAI `/v1/responses` | HTTP 200 for GPT-5.6 Sol |
| Claude Code 2.1.218 | real request returned `OK` with usage |
| Codex 0.145.0 | real request returned `OK` with usage |
| OpenCode | real request returned `OK` with usage |
| Hermes 0.17.0 | config validation and real request returned `OK` |
| OpenClaw 2026.7.1-2 on Node 24.15.0 | config validation and real request returned `OK` with usage |
| Claude Desktop | Anthropic endpoint/model routes verified; app E2E not run because the official download CDN timed out |

Project checks:

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` — 589/589 passed, including 7 TokenRouter preset tests
- `pnpm build:renderer`
- `cargo fmt --check`
- `cargo clippy --quiet -- -D warnings`

## Implementation notes

- Uses the Anthropic API root for Claude clients and `/v1` for OpenAI-compatible clients.
- Keeps aggregator-prefixed Claude IDs because TokenRouter routes those models by full ID.
- Reuses existing preset helpers such as `mappedRoutes`, `generateThirdPartyAuth`, and `generateThirdPartyConfig`.
- Does not modify shared editor/UI components.
