### PR TITLE
feat: add grok-go Codex preset

### DIFF
--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -122,6 +122,40 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     iconColor: "#00A67E",
   },
   {
+    name: "grok-go",
+    websiteUrl: "https://github.com/RongleCat/grok-go",
+    apiKeyUrl: "https://github.com/RongleCat/grok-go",
+    category: "third_party",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "grok-go",
+      "http://127.0.0.1:8787/v1",
+      "grok-4-fast",
+    ),
+    endpointCandidates: ["http://127.0.0.1:8787/v1"],
+    apiFormat: "openai_responses",
+    modelCatalog: modelCatalog([
+      {
+        model: "grok-4",
+        displayName: "Grok 4",
+      },
+      {
+        model: "grok-4-fast",
+        displayName: "Grok 4 Fast",
+      },
+      {
+        model: "grok-3",
+        displayName: "Grok 3",
+      },
+      {
+        model: "grok-3-mini",
+        displayName: "Grok 3 Mini",
+      },
+    ]),
+    icon: "openai",
+    iconColor: "#111827",
+  },
+  {
     name: "Shengsuanyun",
     nameKey: "providerForm.presets.shengsuanyun",
     websiteUrl: "https://www.shengsuanyun.com/?from=CH_4HHXMRYF",


### PR DESCRIPTION
﻿## Summary

- Add a Codex provider preset for the local `grok-go` gateway.
- Default the preset to `http://127.0.0.1:8787/v1` with native Responses API mode.
- Seed common Grok model entries (`grok-4`, `grok-4-fast`, `grok-3`, `grok-3-mini`) so users can select them immediately or refresh from `/v1/models`.

## Why

Issue #5314 proposes the minimal integration path for `RongleCat/grok-go`: treat it as an OpenAI-compatible local provider instead of adding new protocol code. cc-switch already supports OpenAI-compatible Responses providers, so a preset is enough for the first step.

## Tests

- `E:\gateway_komi\cc-switch\node_modules\.bin\prettier.cmd --check src/config/codexProviderPresets.ts`
- `E:\gateway_komi\cc-switch\node_modules\.bin\tsc.cmd --noEmit`
- `git diff --check`
