### PR TITLE
fix(proxy): normalize null tool parameters in Responses→Chat conversion (#5300)

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1114,6 +1114,21 @@ fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option
             if let Some(strict) = tool.get("strict").cloned() {
                 obj.entry("strict".to_string()).or_insert(strict);
             }
+            // Codex's Automations/Scheduled functions can declare
+            // `parameters: null` (e.g. `codex_app__automation_update`). A JSON
+            // `null` is distinct from a missing key: `.cloned()` yields
+            // `Some(Null)`, so it would pass through verbatim and downstream
+            // providers that strictly validate the function schema (DeepSeek)
+            // reject it with HTTP 400 "schema must be a JSON Schema of 'type:
+            // object', got 'type: null'". Normalize an explicit null (or a
+            // missing parameters field) to a minimal valid object schema.
+            // (#5300)
+            let parameters = obj
+                .get("parameters")
+                .cloned()
+                .filter(|v| !v.is_null())
+                .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+            obj.insert("parameters".to_string(), parameters);
         }
         return Some(chat_tool);
     }
@@ -1121,7 +1136,15 @@ fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option
     let mut function = json!({
         "name": chat_name,
         "description": tool.get("description").cloned().unwrap_or(Value::Null),
-        "parameters": tool.get("parameters").cloned().unwrap_or_else(|| json!({}))
+        // Same null/missing normalization as the `function`-object branch above:
+        // `tool.get("parameters")` returns `Some(Null)` for an explicit null,
+        // which would bypass the `unwrap_or_else` fallback and forward `null`
+        // to the provider. Treat null and missing identically (#5300).
+        "parameters": tool
+            .get("parameters")
+            .cloned()
+            .filter(|v| !v.is_null())
+            .unwrap_or_else(|| json!({"type": "object", "properties": {}}))
     });
     if let Some(strict) = tool.get("strict") {
         function["strict"] = strict.clone();
@@ -1981,6 +2004,80 @@ mod tests {
         assert_eq!(result["tool_choice"]["function"]["name"], "get_weather");
         assert_eq!(result["max_tokens"], 100);
         assert_eq!(result["reasoning_effort"], "high");
+    }
+
+    #[test]
+    fn responses_request_to_chat_normalizes_null_tool_parameters_for_strict_schemas() {
+        // #5300: Codex's Automations functions (e.g. `codex_app__automation_update`)
+        // declare `parameters: null` instead of a valid JSON Schema. DeepSeek
+        // strictly validates the function schema and rejected the forwarded
+        // `null` with HTTP 400 "schema must be a JSON Schema of 'type: object',
+        // got 'type: null'". Both tool shapes Codex emits must normalize null
+        // (and a missing parameters field) to a minimal valid object schema.
+        // Flat form — the parameters field sits on the tool itself.
+        let flat = json!({
+            "model": "deepseek-v4-pro",
+            "input": [{"role": "user", "content": "run the automation"}],
+            "tools": [{
+                "type": "function",
+                "name": "codex_app__automation_update",
+                "description": "Update an automation",
+                "parameters": null
+            }]
+        });
+        let result = responses_to_chat_completions(flat).unwrap();
+        assert_eq!(result["tools"][0]["function"]["name"], "codex_app__automation_update");
+        let params = &result["tools"][0]["function"]["parameters"];
+        assert_eq!(params["type"], "object");
+        assert!(params["properties"].is_object());
+        assert_eq!(params["properties"].as_object().unwrap().len(), 0);
+        // A null parameters must never survive into the converted request.
+        assert!(!params.is_null());
+
+        // Nested form — the tool carries a `function` object whose parameters
+        // is null (the other conversion branch).
+        let nested = json!({
+            "model": "deepseek-v4-pro",
+            "input": [{"role": "user", "content": "run the automation"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "codex_app__automation_update",
+                    "description": "Update an automation",
+                    "parameters": null
+                }
+            }]
+        });
+        let result = responses_to_chat_completions(nested).unwrap();
+        assert_eq!(result["tools"][0]["function"]["name"], "codex_app__automation_update");
+        let params = &result["tools"][0]["function"]["parameters"];
+        assert_eq!(params["type"], "object");
+        assert!(params["properties"].is_object());
+        assert!(!params.is_null());
+
+        // A real schema is preserved unchanged (regression guard).
+        let real = json!({
+            "model": "deepseek-v4-pro",
+            "input": [{"role": "user", "content": "hi"}],
+            "tools": [{
+                "type": "function",
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"]
+                }
+            }]
+        });
+        let result = responses_to_chat_completions(real).unwrap();
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"]["properties"]["city"]["type"],
+            "string"
+        );
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"]["required"][0],
+            "city"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #5300. When routing Codex → DeepSeek, multi-step/tool-calling tasks failed with HTTP 400 because Codex's Automations/Scheduled functions (e.g. `codex_app__automation_update`) declare `parameters: null` instead of a valid JSON Schema, and CC Switch forwarded the `null` verbatim in the Responses→Chat Completions conversion. DeepSeek strictly validates the function schema and rejects it:

```
Invalid schema for function 'codex_app__automation_update':
schema must be a JSON Schema of 'type: "object"', got 'type: null'.
```

Simple chats (`"hello"`) don't trigger it; any task that causes Codex to emit a tools array with a null-parameters function does.

## Root cause

A JSON `null` is distinct from a missing key. `tool.get("parameters")` returns `Some(Null)` for an explicit `null`, which **bypasses** `.unwrap_or_else(...)` — so the null passed through unchanged. Both conversion branches in `responses_function_tool_to_chat_tool` had this shape (the flat `name`/`description`/`parameters` form and the nested `function`-object form).

## Fix

In `responses_function_tool_to_chat_tool` (`src-tauri/src/proxy/providers/transform_codex_chat.rs`), normalize an explicit `null` **or** a missing `parameters` field to a minimal valid object schema `{"type":"object","properties":{}}` in both conversion branches. This is the exact transformation the reporter proposed in the issue. A real schema is preserved unchanged.

## Tests

Added `responses_request_to_chat_normalizes_null_tool_parameters_for_strict_schemas` covering:
- the flat form (`parameters: null` on the tool itself) → normalized to `{"type":"object","properties":{}}`
- the nested `function`-object form (`function.parameters: null`) → same normalization
- a real schema (`properties`/`required`) → preserved unchanged (regression guard)

1093 proxy tests pass; `cargo clippy --lib -- -D warnings` clean.
