### PR TITLE
fix(proxy): persist local routing master switch state

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1768,6 +1768,13 @@ async fn enabled_proxy_apps_on_startup(db: &database::Database) -> Vec<&'static 
 }
 
 async fn restore_proxy_state_on_startup(state: &store::AppState) {
+    // 根据保存的路由总开关状态自动恢复代理服务
+    if crate::settings::get_settings().proxy_enabled {
+        if let Err(e) = state.proxy_service.start().await {
+            log::error!("恢复路由总开关失败: {e}");
+        }
+    }
+
     // 收集需要恢复接管的应用列表（从 proxy_config.enabled 读取）
     let apps_to_restore = enabled_proxy_apps_on_startup(&state.db).await;
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -363,6 +363,9 @@ pub struct AppSettings {
     /// 是否在主页面启用本地代理功能（默认关闭）
     #[serde(default)]
     pub enable_local_proxy: bool,
+    /// 是否启用路由总开关（默认关闭）
+    #[serde(default)]
+    pub proxy_enabled: bool,
     /// User has confirmed the local proxy first-run notice
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy_confirmed: Option<bool>,
@@ -513,6 +516,7 @@ impl Default for AppSettings {
             launch_on_startup: false,
             silent_startup: false,
             enable_local_proxy: false,
+            proxy_enabled: false,
             proxy_confirmed: None,
             usage_confirmed: None,
             usage_dashboard_refresh_interval_ms: None,

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -44,10 +44,12 @@ export function ProxyTabContent({
   const handleToggleProxy = async (checked: boolean) => {
     try {
       if (!checked) {
+        await onAutoSave({ proxyEnabled: false });
         await stopWithRestore();
       } else if (!settings?.proxyConfirmed) {
         setShowProxyConfirm(true);
       } else {
+        await onAutoSave({ proxyEnabled: true });
         await startProxyServer();
       }
     } catch (error) {
@@ -58,7 +60,10 @@ export function ProxyTabContent({
   const handleProxyConfirm = async () => {
     setShowProxyConfirm(false);
     try {
-      await onAutoSave({ proxyConfirmed: true });
+      await onAutoSave({
+        proxyConfirmed: true,
+        proxyEnabled: true,
+      });
       await startProxyServer();
     } catch (error) {
       console.error("Proxy confirm failed:", error);

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -15,6 +15,7 @@ export const settingsSchema = z.object({
   skipClaudeOnboarding: z.boolean().optional(),
   launchOnStartup: z.boolean().optional(),
   enableLocalProxy: z.boolean().optional(),
+  proxyEnabled: z.boolean().optional(),
   usageDashboardRefreshIntervalMs: z.number().optional(),
   preserveCodexOfficialAuthOnSwitch: z.boolean().optional(),
   unifyCodexSessionHistory: z.boolean().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,6 +358,8 @@ export interface Settings {
   silentStartup?: boolean;
   // 是否启用主页面本地代理功能（默认关闭）
   enableLocalProxy?: boolean;
+  // 是否启用路由总开关（默认关闭）
+  proxyEnabled?: boolean;
   // User has confirmed the local proxy first-run notice
   proxyConfirmed?: boolean;
   // User has confirmed the usage query first-run notice


### PR DESCRIPTION
## Summary / 概述

Persist the user's explicit selection of **Settings → Routing → Local Routing → Routing Master Switch**, and restore the local routing service when CC Switch starts.

- Add `proxyEnabled` to `AppSettings`, defaulting to `false`.
- Save the state when the user explicitly enables or disables the routing master switch.
- Restore the local routing service during application startup when the saved state is enabled.
- Keep the existing per-app routing persistence unchanged.

This fixes the case where CC Switch starts automatically after login, but the standalone local routing service remains stopped.

记录用户在 **设置 → 路由 → 本地路由 → 路由总开关** 中的明确选择，并在 CC Switch 启动时恢复本地路由服务。

- 在 `AppSettings` 中增加默认值为 `false` 的 `proxyEnabled`。
- 用户明确打开或关闭路由总开关时保存状态。
- 应用启动时根据保存的状态恢复本地路由服务。
- 不改变现有的各应用独立路由状态及其恢复逻辑。

修复 CC Switch 已设置为开机启动，但独立的本地路由服务不会随之恢复的问题。

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

N/A — no UI changes.

## Verification / 验证

- [x] Windows unsigned Tauri build passed on GitHub Actions
  - https://github.com/cndaqiang/cc-switch/actions/runs/29303822006
- [x] TypeScript type check passed
- [x] Formatting check passed
- [x] Rust formatting check passed
- [x] Clippy passed with warnings treated as errors
  - https://github.com/cndaqiang/cc-switch/actions/runs/29305806924

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（N/A：无用户可见文本改动）