### PR TITLE
Fix/homebrew npm path

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -388,8 +388,9 @@ fn build_tool_lifecycle_command(
         lines.push("set -e".to_string());
         lines.push("set -o pipefail".to_string());
         // 非交互式 bash 默认 PATH 不含 Homebrew 目录(macOS ARM: /opt/homebrew/bin),
-        // 导致 npm/node 等工具找不到 Homebrew 安装的版本。将常见 Homebrew bin 目录加入 PATH 兜底。
-        lines.push("export PATH=\"/opt/homebrew/bin:/usr/local/bin:$PATH\"".to_string());
+        // 导致 npm/node 等工具找不到 Homebrew 安装的版本。将常见 Homebrew bin 目录追加为兜底,
+        // 避免覆盖继承 PATH 中优先级更高的 nvm/fnm/mise/Volta 等 Node 工具链。
+        lines.push("export PATH=\"$PATH:/opt/homebrew/bin:/usr/local/bin\"".to_string());
     }
 
     #[cfg(target_os = "windows")]
@@ -3556,14 +3557,32 @@ mod tests {
 
     #[cfg(not(target_os = "windows"))]
     #[test]
-    fn lifecycle_script_adds_homebrew_bins_before_npm_install() {
+    fn lifecycle_script_preserves_custom_node_path_before_homebrew_fallbacks() {
         let script = build_tool_lifecycle_command(&["codex"], ToolLifecycleAction::Install, None)
             .expect("Codex install script should build");
 
         assert!(script.starts_with(
-            "set -e\nset -o pipefail\nexport PATH=\"/opt/homebrew/bin:/usr/local/bin:$PATH\"\n"
+            "set -e\nset -o pipefail\nexport PATH=\"$PATH:/opt/homebrew/bin:/usr/local/bin\"\n"
         ));
         assert!(script.contains("npm i -g @openai/codex@latest"));
+
+        let export_line = script
+            .lines()
+            .find(|line| line.starts_with("export PATH="))
+            .expect("lifecycle script should export PATH");
+        let inherited_path = "/Users/me/.nvm/versions/node/v22.14.0/bin:/usr/bin:/bin";
+        let output = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(format!("{export_line}\nprintf '%s' \"$PATH\""))
+            .env("PATH", inherited_path)
+            .output()
+            .expect("PATH export should be executable by a POSIX shell");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8(output.stdout).expect("PATH output should be UTF-8"),
+            format!("{inherited_path}:/opt/homebrew/bin:/usr/local/bin")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -387,6 +387,9 @@ fn build_tool_lifecycle_command(
         // 仍应让管道前段失败参与整条脚本判定。
         lines.push("set -e".to_string());
         lines.push("set -o pipefail".to_string());
+        // 非交互式 bash 默认 PATH 不含 Homebrew 目录(macOS ARM: /opt/homebrew/bin),
+        // 导致 npm/node 等工具找不到 Homebrew 安装的版本。将常见 Homebrew bin 目录加入 PATH 兜底。
+        lines.push("export PATH=\"/opt/homebrew/bin:/usr/local/bin:$PATH\"".to_string());
     }
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -3554,6 +3554,18 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn lifecycle_script_adds_homebrew_bins_before_npm_install() {
+        let script = build_tool_lifecycle_command(&["codex"], ToolLifecycleAction::Install, None)
+            .expect("Codex install script should build");
+
+        assert!(script.starts_with(
+            "set -e\nset -o pipefail\nexport PATH=\"/opt/homebrew/bin:/usr/local/bin:$PATH\"\n"
+        ));
+        assert!(script.contains("npm i -g @openai/codex@latest"));
+    }
+
     #[test]
     fn test_build_provider_command_line_uses_user_shell_environment() {
         assert_eq!(


### PR DESCRIPTION
## Summary / 概述
- Add Homebrew binary directories to POSIX lifecycle scripts before invoking CLI installation commands.
- Fix `npm: command not found` when CC Switch is launched as a macOS GUI app and npm is installed through Homebrew.
- Add a regression test covering the generated Codex installation script.
<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue
N/A
<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|---|---|
| <img src="https://github.com/user-attachments/assets/db50dc77-5ccc-4073-b61d-3d760f5e0c1a" alt="修改前：安装 Gemini CLI 时提示 npm command not found" width="900" /> | <img src="https://github.com/user-attachments/assets/261ffcf9-81ef-4607-a9d6-2365be3946f3" alt="修改后：Gemini CLI 安装成功" width="900" /> |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
