### PR TITLE
feat: add seamless provider switching

### DIFF
--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -109,6 +109,27 @@ pub fn switch_provider(
     switch_provider_internal(&state, app_type, &id).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub async fn switch_provider_seamless(
+    state: State<'_, AppState>,
+    app: String,
+    id: String,
+) -> Result<SwitchResult, String> {
+    let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
+    ProviderService::switch_seamless(&state, app_type, &id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[cfg_attr(not(feature = "test-hooks"), doc(hidden))]
+pub async fn switch_provider_seamless_test_hook(
+    state: &AppState,
+    app_type: AppType,
+    id: &str,
+) -> Result<SwitchResult, AppError> {
+    ProviderService::switch_seamless(state, app_type, id).await
+}
+
 fn import_default_config_internal(state: &AppState, app_type: AppType) -> Result<bool, AppError> {
     let imported = ProviderService::import_default_config(state, app_type.clone())?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1195,6 +1195,7 @@ pub fn run() {
             commands::delete_provider,
             commands::remove_provider_from_live_config,
             commands::switch_provider,
+            commands::switch_provider_seamless,
             commands::import_default_config,
             commands::get_claude_desktop_status,
             commands::get_claude_desktop_default_routes,

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::app_config::AppType;
 use crate::database::{validate_cost_multiplier, validate_pricing_source};
 use crate::error::AppError;
-use crate::provider::{Provider, UsageResult};
+use crate::provider::{ClaudeDesktopMode, Provider, UsageResult};
 use crate::services::mcp::McpService;
 use crate::settings::CustomEndpoint;
 use crate::store::AppState;
@@ -113,6 +113,8 @@ pub struct ProviderService;
 #[serde(rename_all = "camelCase")]
 pub struct SwitchResult {
     pub warnings: Vec<String>,
+    pub seamless: bool,
+    pub restart_required: bool,
 }
 
 #[cfg(test)]
@@ -214,6 +216,40 @@ mod tests {
             .join("Claude-3p")
             .join("configLibrary")
             .join(format!("{PROFILE_ID}.json"))
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    fn claude_desktop_provider(id: &str, base_url: &str, mode: ClaudeDesktopMode) -> Provider {
+        let mut provider = Provider::with_id(
+            id.to_string(),
+            format!("Desktop {id}"),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": format!("token-{id}"),
+                    "ANTHROPIC_BASE_URL": base_url
+                }
+            }),
+            None,
+        );
+        provider.category = Some("custom".to_string());
+        provider.meta = Some(ProviderMeta {
+            api_format: Some("anthropic".to_string()),
+            claude_desktop_mode: Some(mode.clone()),
+            claude_desktop_model_routes: if matches!(mode, ClaudeDesktopMode::Proxy) {
+                std::collections::HashMap::from([(
+                    "claude-sonnet-4-6".to_string(),
+                    ClaudeDesktopModelRoute {
+                        model: format!("model-{id}"),
+                        label_override: None,
+                        supports_1m: None,
+                    },
+                )])
+            } else {
+                std::collections::HashMap::new()
+            },
+            ..Default::default()
+        });
+        provider
     }
 
     fn test_guard() -> std::sync::MutexGuard<'static, ()> {
@@ -1351,6 +1387,115 @@ requires_openai_auth = true
             json!([{ "name": "claude-sonnet-4-6", "labelOverride": "DeepSeek V4 Flash Updated", "supports1m": true }]),
             "provider edits should propagate into the Claude Desktop 3P profile during takeover"
         );
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[tokio::test]
+    #[serial]
+    async fn claude_desktop_seamless_switch_hot_switches_when_profile_already_uses_proxy() {
+        let home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let mut proxy_config = db.get_proxy_config().await.expect("get proxy config");
+        proxy_config.listen_port = 0;
+        db.update_proxy_config(proxy_config)
+            .await
+            .expect("use ephemeral proxy port");
+        let state = AppState::new(db.clone());
+        let provider_a =
+            claude_desktop_provider("proxy-a", "https://a.example.com", ClaudeDesktopMode::Proxy);
+        let provider_b =
+            claude_desktop_provider("proxy-b", "https://b.example.com", ClaudeDesktopMode::Proxy);
+        db.save_provider("claude-desktop", &provider_a)
+            .expect("save provider A");
+        db.save_provider("claude-desktop", &provider_b)
+            .expect("save provider B");
+        db.set_current_provider("claude-desktop", "proxy-a")
+            .expect("set DB current provider A");
+        crate::settings::set_current_provider(&AppType::ClaudeDesktop, Some("proxy-a"))
+            .expect("set local current provider A");
+
+        state
+            .proxy_service
+            .start()
+            .await
+            .expect("start proxy service");
+        crate::claude_desktop_config::apply_provider(&db, &provider_a)
+            .expect("write stable proxy profile");
+        let profile_path = claude_desktop_profile_path(home.dir.path());
+        let profile_before = fs::read(&profile_path).expect("read proxy profile before switch");
+
+        let result = ProviderService::switch_seamless(&state, AppType::ClaudeDesktop, "proxy-b")
+            .await
+            .expect("hot-switch Claude Desktop provider");
+
+        assert!(result.seamless);
+        assert!(!result.restart_required);
+        assert_eq!(
+            fs::read(&profile_path).expect("read proxy profile after switch"),
+            profile_before,
+            "proxy-to-proxy hot switching must not rewrite Desktop's cached profile"
+        );
+
+        state
+            .proxy_service
+            .stop()
+            .await
+            .expect("stop proxy service");
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[tokio::test]
+    #[serial]
+    async fn claude_desktop_seamless_switch_requires_one_restart_when_entering_proxy() {
+        let home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let mut proxy_config = db.get_proxy_config().await.expect("get proxy config");
+        proxy_config.listen_port = 0;
+        db.update_proxy_config(proxy_config)
+            .await
+            .expect("use ephemeral proxy port");
+        let state = AppState::new(db.clone());
+        let direct = claude_desktop_provider(
+            "direct-a",
+            "https://direct.example.com",
+            ClaudeDesktopMode::Direct,
+        );
+        let proxy = claude_desktop_provider(
+            "proxy-b",
+            "https://proxy.example.com",
+            ClaudeDesktopMode::Proxy,
+        );
+        db.save_provider("claude-desktop", &direct)
+            .expect("save direct provider");
+        db.save_provider("claude-desktop", &proxy)
+            .expect("save proxy provider");
+        db.set_current_provider("claude-desktop", "direct-a")
+            .expect("set DB current direct provider");
+        crate::settings::set_current_provider(&AppType::ClaudeDesktop, Some("direct-a"))
+            .expect("set local current direct provider");
+        crate::claude_desktop_config::apply_provider(&db, &direct).expect("write direct profile");
+
+        let result = ProviderService::switch_seamless(&state, AppType::ClaudeDesktop, "proxy-b")
+            .await
+            .expect("enter Claude Desktop proxy mode");
+
+        assert!(result.seamless);
+        assert!(result.restart_required);
+        let profile: Value =
+            read_json_file(&claude_desktop_profile_path(home.dir.path())).expect("read profile");
+        assert!(profile["inferenceGatewayBaseUrl"]
+            .as_str()
+            .is_some_and(|url| url.contains("/claude-desktop")));
+
+        state
+            .proxy_service
+            .stop()
+            .await
+            .expect("stop proxy service");
     }
 
     #[test]
@@ -2587,6 +2732,127 @@ impl ProviderService {
 
         // Normal mode: full switch with Live config write
         Self::switch_normal(state, app_type, id, &providers)
+    }
+
+    /// Switch a third-party Claude/Codex/Claude Desktop provider through a stable local proxy.
+    ///
+    /// The first activation writes a usable target configuration before enabling takeover.
+    /// Later switches only change the proxy target, so a running client uses the new provider
+    /// on its next request. Claude Desktop only takes this path for providers already configured
+    /// in local-routing mode.
+    pub async fn switch_seamless(
+        state: &AppState,
+        app_type: AppType,
+        id: &str,
+    ) -> Result<SwitchResult, AppError> {
+        if !matches!(
+            app_type,
+            AppType::Claude | AppType::Codex | AppType::ClaudeDesktop
+        ) {
+            return Self::switch(state, app_type, id);
+        }
+
+        let provider = state
+            .db
+            .get_provider_by_id(id, app_type.as_str())?
+            .ok_or_else(|| AppError::Message(format!("供应商 {id} 不存在")))?;
+
+        if matches!(app_type, AppType::ClaudeDesktop) {
+            if provider.category.as_deref() == Some("official")
+                || !matches!(
+                    crate::claude_desktop_config::provider_mode(&provider),
+                    ClaudeDesktopMode::Proxy
+                )
+            {
+                return Self::switch(state, app_type, id);
+            }
+
+            if !state.proxy_service.is_running().await {
+                state.proxy_service.start().await.map_err(|e| {
+                    AppError::Message(format!("启动 Claude Desktop 本地路由失败: {e}"))
+                })?;
+            }
+
+            let expected_proxy_url =
+                crate::claude_desktop_config::proxy_gateway_base_url_from_db(&state.db)?;
+            let profile_already_uses_proxy =
+                crate::claude_desktop_config::get_status(&state.db, true)
+                    .ok()
+                    .and_then(|status| status.actual_base_url)
+                    .is_some_and(|actual| actual == expected_proxy_url);
+
+            if profile_already_uses_proxy {
+                state
+                    .proxy_service
+                    .hot_switch_provider(app_type.as_str(), id)
+                    .await
+                    .map_err(|e| AppError::Message(format!("Claude Desktop 无感切换失败: {e}")))?;
+
+                return Ok(SwitchResult {
+                    seamless: true,
+                    restart_required: false,
+                    ..Default::default()
+                });
+            }
+
+            let mut result = Self::switch(state, app_type, id)?;
+            result.seamless = true;
+            result.restart_required = true;
+            return Ok(result);
+        }
+
+        if provider.category.as_deref() == Some("official") {
+            return Err(AppError::localized(
+                "switch.seamless.third_party_only",
+                "无感切换仅支持第三方供应商",
+                "Seamless switching only supports third-party providers",
+            ));
+        }
+
+        let proxy_config = state
+            .db
+            .get_proxy_config_for_app(app_type.as_str())
+            .await
+            .map_err(|e| AppError::Message(format!("读取代理接管状态失败: {e}")))?;
+        let has_backup = state
+            .db
+            .get_live_backup(app_type.as_str())
+            .await
+            .map_err(|e| AppError::Message(format!("读取 Live 备份失败: {e}")))?
+            .is_some();
+        let live_taken_over = state
+            .proxy_service
+            .detect_takeover_in_live_config_for_app(&app_type);
+        let has_takeover_signal = proxy_config.enabled || has_backup || live_taken_over;
+
+        if has_takeover_signal {
+            state
+                .proxy_service
+                .set_takeover_for_app(app_type.as_str(), true)
+                .await
+                .map_err(|e| AppError::Message(format!("恢复无感切换接管失败: {e}")))?;
+            state
+                .proxy_service
+                .hot_switch_provider(app_type.as_str(), id)
+                .await
+                .map_err(|e| AppError::Message(format!("无感切换失败: {e}")))?;
+
+            return Ok(SwitchResult {
+                seamless: true,
+                restart_required: !live_taken_over,
+                ..Default::default()
+            });
+        }
+
+        let mut result = Self::switch(state, app_type.clone(), id)?;
+        state
+            .proxy_service
+            .set_takeover_for_app(app_type.as_str(), true)
+            .await
+            .map_err(|e| AppError::Message(format!("启用无感切换接管失败: {e}")))?;
+        result.seamless = true;
+        result.restart_required = true;
+        Ok(result)
     }
 
     /// Normal switch flow (non-proxy mode)

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -155,6 +155,12 @@ export function useProviderActions(
   // 切换供应商
   const switchProvider = useCallback(
     async (provider: Provider) => {
+      const useSeamlessSwitch =
+        provider.category !== "official" &&
+        (activeApp === "claude" ||
+          activeApp === "codex" ||
+          (activeApp === "claude-desktop" &&
+            provider.meta?.claudeDesktopMode === "proxy"));
       const isCopilotProvider =
         activeApp === "claude" &&
         provider.meta?.providerType === "github_copilot";
@@ -181,7 +187,11 @@ export function useProviderActions(
 
       // Determine why this provider requires the proxy
       let proxyRequiredReason: string | null = null;
-      if (!isProxyRunning && provider.category !== "official") {
+      if (
+        !useSeamlessSwitch &&
+        !isProxyRunning &&
+        provider.category !== "official"
+      ) {
         if (isCopilotProvider) {
           proxyRequiredReason = t("notifications.proxyReasonCopilot", {
             defaultValue: "使用 GitHub Copilot 作为 Claude 供应商",
@@ -260,7 +270,10 @@ export function useProviderActions(
       }
 
       try {
-        const result = await switchProviderMutation.mutateAsync(provider.id);
+        const result = await switchProviderMutation.mutateAsync({
+          providerId: provider.id,
+          seamless: useSeamlessSwitch,
+        });
         await syncClaudePlugin(provider);
 
         // Show backfill warning if present
@@ -274,8 +287,26 @@ export function useProviderActions(
           );
         }
 
-        // 若已弹过 proxyRequired 警告则不再弹 success
-        if (!proxyRequiredReason) {
+        if (result?.seamless) {
+          toast.success(
+            result.restartRequired
+              ? t("notifications.seamlessSwitchActivated", {
+                  app:
+                    activeApp === "codex"
+                      ? "Codex"
+                      : activeApp === "claude-desktop"
+                        ? "Claude Desktop"
+                        : "Claude Code",
+                  defaultValue:
+                    "无感切换已启用。请重启一次 {{app}} 载入本地代理，之后切换无需重启",
+                })
+              : t("notifications.seamlessSwitchSuccess", {
+                  defaultValue: "切换成功，下一次请求使用新供应商，无需重启",
+                }),
+            { closeButton: true, duration: 6000 },
+          );
+        } else if (!proxyRequiredReason) {
+          // 若已弹过 proxyRequired 警告则不再弹 success
           let messageKey = "notifications.switchSuccess";
           let defaultMessage = "切换成功！";
           if (activeApp === "codex") {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -231,6 +231,8 @@
     "providerDeleted": "Provider deleted successfully",
     "switchSuccess": "Switch successful!",
     "codexRestartRequired": "Switched successfully. Restart the client to apply changes.",
+    "seamlessSwitchActivated": "Seamless switching is enabled. Restart {{app}} once to load the local proxy; later switches will not require a restart.",
+    "seamlessSwitchSuccess": "Switched successfully. The next request will use the new provider without a restart.",
     "claudeDesktopRestartRequired": "Switched successfully. Restart Claude Desktop to apply changes.",
     "claudeDesktopProxyRestartRequired": "Switched successfully. Keep CC Switch running and restart Claude Desktop to apply changes.",
     "addToConfigSuccess": "Added to config",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -231,6 +231,8 @@
     "providerDeleted": "プロバイダーを削除しました",
     "switchSuccess": "切り替え成功！",
     "codexRestartRequired": "切り替えました。反映するにはクライアントを再起動してください",
+    "seamlessSwitchActivated": "シームレス切り替えを有効にしました。ローカルプロキシを読み込むために {{app}} を一度再起動してください。以降の切り替えでは再起動は不要です。",
+    "seamlessSwitchSuccess": "切り替えました。次のリクエストから新しいプロバイダーが使用され、再起動は不要です。",
     "claudeDesktopRestartRequired": "切り替えました。反映するには Claude Desktop を再起動してください",
     "claudeDesktopProxyRestartRequired": "切り替えました。CC Switch を起動したまま Claude Desktop を再起動してください",
     "addToConfigSuccess": "設定に追加しました",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -231,6 +231,8 @@
     "providerDeleted": "供應商刪除成功",
     "switchSuccess": "切換成功！",
     "codexRestartRequired": "切換成功，請重新啟動客戶端以套用",
+    "seamlessSwitchActivated": "無感切換已啟用。請重新啟動一次 {{app}} 以載入本機代理，之後切換無需重新啟動",
+    "seamlessSwitchSuccess": "切換成功，下一次請求將使用新供應商，無需重新啟動",
     "claudeDesktopRestartRequired": "切換成功，重新啟動 Claude Desktop 後生效",
     "claudeDesktopProxyRestartRequired": "切換成功，請保持 CC Switch 執行，並重新啟動 Claude Desktop 後生效",
     "addToConfigSuccess": "已新增至設定",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -231,6 +231,8 @@
     "providerDeleted": "供应商删除成功",
     "switchSuccess": "切换成功！",
     "codexRestartRequired": "切换成功，请重启客户端以生效",
+    "seamlessSwitchActivated": "无感切换已启用。请重启一次 {{app}} 载入本地代理，之后切换无需重启",
+    "seamlessSwitchSuccess": "切换成功，下一次请求将使用新供应商，无需重启",
     "claudeDesktopRestartRequired": "切换成功，重启 Claude Desktop 后生效",
     "claudeDesktopProxyRestartRequired": "切换成功，请保持 CC Switch 运行，并重启 Claude Desktop 后生效",
     "addToConfigSuccess": "已添加到配置",

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -19,6 +19,8 @@ export interface ProviderSwitchEvent {
 
 export interface SwitchResult {
   warnings: string[];
+  seamless: boolean;
+  restartRequired: boolean;
 }
 
 export interface OpenTerminalOptions {
@@ -87,8 +89,15 @@ export const providersApi = {
     return await invoke("remove_provider_from_live_config", { id, app: appId });
   },
 
-  async switch(id: string, appId: AppId): Promise<SwitchResult> {
-    return await invoke("switch_provider", { id, app: appId });
+  async switch(
+    id: string,
+    appId: AppId,
+    seamless = false,
+  ): Promise<SwitchResult> {
+    return await invoke(
+      seamless ? "switch_provider_seamless" : "switch_provider",
+      { id, app: appId },
+    );
   },
 
   async importDefault(appId: AppId): Promise<boolean> {

--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -274,8 +274,17 @@ export const useSwitchProviderMutation = (appId: AppId) => {
     }): Promise<SwitchResult> => {
       return await providersApi.switch(providerId, appId, seamless);
     },
-    onSuccess: async () => {
+    onSuccess: async (result) => {
       await queryClient.invalidateQueries({ queryKey: ["providers", appId] });
+      if (result.seamless) {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["proxyStatus"] }),
+          queryClient.invalidateQueries({ queryKey: ["proxyRunning"] }),
+          queryClient.invalidateQueries({
+            queryKey: ["proxyTakeoverStatus"],
+          }),
+        ]);
+      }
       if (appId === "claude-desktop") {
         await queryClient.invalidateQueries({ queryKey: ["proxyStatus"] });
         await queryClient.invalidateQueries({

--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -265,8 +265,14 @@ export const useSwitchProviderMutation = (appId: AppId) => {
   const { t } = useTranslation();
 
   return useMutation({
-    mutationFn: async (providerId: string): Promise<SwitchResult> => {
-      return await providersApi.switch(providerId, appId);
+    mutationFn: async ({
+      providerId,
+      seamless = false,
+    }: {
+      providerId: string;
+      seamless?: boolean;
+    }): Promise<SwitchResult> => {
+      return await providersApi.switch(providerId, appId, seamless);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["providers", appId] });

--- a/tests/hooks/useProviderActions.test.tsx
+++ b/tests/hooks/useProviderActions.test.tsx
@@ -177,7 +177,11 @@ describe("useProviderActions", () => {
   });
 
   it("should not request plugin sync when switching non-Claude provider", async () => {
-    switchProviderMutateAsync.mockResolvedValueOnce(undefined);
+    switchProviderMutateAsync.mockResolvedValueOnce({
+      warnings: [],
+      seamless: true,
+      restartRequired: false,
+    });
     const { wrapper } = createWrapper();
     const provider = createProvider({ category: "custom" });
 
@@ -189,17 +193,47 @@ describe("useProviderActions", () => {
       await result.current.switchProvider(provider);
     });
 
-    expect(switchProviderMutateAsync).toHaveBeenCalledWith(provider.id);
+    expect(switchProviderMutateAsync).toHaveBeenCalledWith({
+      providerId: provider.id,
+      seamless: true,
+    });
     expect(settingsApiGetMock).not.toHaveBeenCalled();
     expect(settingsApiApplyMock).not.toHaveBeenCalled();
     expect(toastSuccessMock).toHaveBeenCalledWith(
-      "切换成功，请重启客户端以生效",
-      { closeButton: true },
+      "切换成功，下一次请求使用新供应商，无需重启",
+      { closeButton: true, duration: 6000 },
     );
   });
 
-  it("warns but still switches providers that require proxy when proxy is not running", async () => {
-    switchProviderMutateAsync.mockResolvedValueOnce(undefined);
+  it("explains the one-time restart when seamless takeover is first activated", async () => {
+    switchProviderMutateAsync.mockResolvedValueOnce({
+      warnings: [],
+      seamless: true,
+      restartRequired: true,
+    });
+    const { wrapper } = createWrapper();
+    const provider = createProvider({ category: "custom" });
+
+    const { result } = renderHook(() => useProviderActions("codex", false), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.switchProvider(provider);
+    });
+
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "无感切换已启用。请重启一次 Codex 载入本地代理，之后切换无需重启",
+      { closeButton: true, duration: 6000 },
+    );
+  });
+
+  it("automatically uses seamless switching for Claude third-party providers", async () => {
+    switchProviderMutateAsync.mockResolvedValueOnce({
+      warnings: [],
+      seamless: true,
+      restartRequired: false,
+    });
     const { wrapper } = createWrapper();
     const provider = createProvider({
       category: "custom",
@@ -216,18 +250,88 @@ describe("useProviderActions", () => {
       await result.current.switchProvider(provider);
     });
 
-    expect(toastWarningMock).toHaveBeenCalledTimes(1);
-    expect(switchProviderMutateAsync).toHaveBeenCalledWith(provider.id);
+    expect(toastWarningMock).not.toHaveBeenCalled();
+    expect(switchProviderMutateAsync).toHaveBeenCalledWith({
+      providerId: provider.id,
+      seamless: true,
+    });
   });
 
-  it("warns but still switches Codex full URL providers when proxy is not running", async () => {
-    switchProviderMutateAsync.mockResolvedValueOnce(undefined);
+  it("automatically uses seamless switching for Claude Desktop proxy providers", async () => {
+    switchProviderMutateAsync.mockResolvedValueOnce({
+      warnings: [],
+      seamless: true,
+      restartRequired: false,
+    });
     const { wrapper } = createWrapper();
     const provider = createProvider({
       category: "custom",
       meta: {
-        isFullUrl: true,
+        claudeDesktopMode: "proxy",
       },
+    });
+
+    const { result } = renderHook(
+      () => useProviderActions("claude-desktop", false),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.switchProvider(provider);
+    });
+
+    expect(toastWarningMock).not.toHaveBeenCalled();
+    expect(switchProviderMutateAsync).toHaveBeenCalledWith({
+      providerId: provider.id,
+      seamless: true,
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "切换成功，下一次请求使用新供应商，无需重启",
+      { closeButton: true, duration: 6000 },
+    );
+  });
+
+  it("keeps Claude Desktop direct providers on the restart-required normal path", async () => {
+    switchProviderMutateAsync.mockResolvedValueOnce({
+      warnings: [],
+      seamless: false,
+      restartRequired: false,
+    });
+    const { wrapper } = createWrapper();
+    const provider = createProvider({
+      category: "custom",
+      meta: { claudeDesktopMode: "direct" },
+    });
+
+    const { result } = renderHook(
+      () => useProviderActions("claude-desktop", false),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.switchProvider(provider);
+    });
+
+    expect(switchProviderMutateAsync).toHaveBeenCalledWith({
+      providerId: provider.id,
+      seamless: false,
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "切换成功，重启 Claude Desktop 后生效",
+      { closeButton: true },
+    );
+  });
+
+  it("automatically uses seamless switching for Codex full URL providers", async () => {
+    switchProviderMutateAsync.mockResolvedValueOnce({
+      warnings: [],
+      seamless: true,
+      restartRequired: false,
+    });
+    const { wrapper } = createWrapper();
+    const provider = createProvider({
+      category: "custom",
+      meta: { isFullUrl: true },
     });
 
     const { result } = renderHook(() => useProviderActions("codex", false), {
@@ -238,12 +342,19 @@ describe("useProviderActions", () => {
       await result.current.switchProvider(provider);
     });
 
-    expect(toastWarningMock).toHaveBeenCalledTimes(1);
-    expect(switchProviderMutateAsync).toHaveBeenCalledWith(provider.id);
+    expect(toastWarningMock).not.toHaveBeenCalled();
+    expect(switchProviderMutateAsync).toHaveBeenCalledWith({
+      providerId: provider.id,
+      seamless: true,
+    });
   });
 
-  it("warns when switching a Codex Anthropic-format provider without proxy", async () => {
-    switchProviderMutateAsync.mockResolvedValueOnce(undefined);
+  it("automatically uses seamless switching for Codex Anthropic-format providers", async () => {
+    switchProviderMutateAsync.mockResolvedValueOnce({
+      warnings: [],
+      seamless: true,
+      restartRequired: false,
+    });
     const { wrapper } = createWrapper();
     const provider = createProvider({
       category: "custom",
@@ -258,10 +369,11 @@ describe("useProviderActions", () => {
       await result.current.switchProvider(provider);
     });
 
-    expect(toastWarningMock).toHaveBeenCalledWith(
-      expect.stringContaining("Anthropic Messages"),
-    );
-    expect(switchProviderMutateAsync).toHaveBeenCalledWith(provider.id);
+    expect(toastWarningMock).not.toHaveBeenCalled();
+    expect(switchProviderMutateAsync).toHaveBeenCalledWith({
+      providerId: provider.id,
+      seamless: true,
+    });
   });
 
   it("allows the built-in Codex official provider during takeover", async () => {
@@ -281,7 +393,10 @@ describe("useProviderActions", () => {
       await result.current.switchProvider(provider);
     });
 
-    expect(switchProviderMutateAsync).toHaveBeenCalledWith("codex-official");
+    expect(switchProviderMutateAsync).toHaveBeenCalledWith({
+      providerId: "codex-official",
+      seamless: false,
+    });
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
 
@@ -341,7 +456,10 @@ describe("useProviderActions", () => {
       await result.current.switchProvider(provider);
     });
 
-    expect(switchProviderMutateAsync).toHaveBeenCalledWith(provider.id);
+    expect(switchProviderMutateAsync).toHaveBeenCalledWith({
+      providerId: provider.id,
+      seamless: false,
+    });
     expect(settingsApiGetMock).toHaveBeenCalledTimes(1);
     expect(settingsApiApplyMock).toHaveBeenCalledWith({ official: true });
   });

--- a/tests/hooks/useSwitchProviderMutation.test.tsx
+++ b/tests/hooks/useSwitchProviderMutation.test.tsx
@@ -1,0 +1,125 @@
+import type { ReactNode } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSwitchProviderMutation } from "@/lib/query/mutations";
+
+const apiMocks = vi.hoisted(() => ({
+  switch: vi.fn(),
+  updateTrayMenu: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  providersApi: {
+    switch: (...args: unknown[]) => apiMocks.switch(...args),
+    updateTrayMenu: (...args: unknown[]) => apiMocks.updateTrayMenu(...args),
+  },
+  sessionsApi: {},
+  settingsApi: {},
+}));
+
+vi.mock("@/hooks/useHermes", () => ({
+  invalidateHermesProviderCaches: vi.fn(),
+}));
+
+vi.mock("@/hooks/useOpenClaw", () => ({
+  openclawKeys: {
+    liveProviderIds: ["openclaw", "live-provider-ids"],
+    defaultModel: ["openclaw", "default-model"],
+    health: ["openclaw", "health"],
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { wrapper, invalidateSpy };
+}
+
+beforeEach(() => {
+  apiMocks.switch.mockReset();
+  apiMocks.updateTrayMenu.mockReset().mockResolvedValue(true);
+});
+
+describe("useSwitchProviderMutation", () => {
+  it("invalidates proxy state after a seamless switch", async () => {
+    apiMocks.switch.mockResolvedValue({
+      warnings: [],
+      seamless: true,
+      restartRequired: true,
+    });
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useSwitchProviderMutation("claude"), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        providerId: "provider-b",
+        seamless: true,
+      });
+    });
+
+    expect(apiMocks.switch).toHaveBeenCalledWith("provider-b", "claude", true);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["proxyStatus"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["proxyRunning"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["proxyTakeoverStatus"],
+    });
+  });
+
+  it("does not invalidate proxy state after a normal switch", async () => {
+    apiMocks.switch.mockResolvedValue({
+      warnings: [],
+      seamless: false,
+      restartRequired: false,
+    });
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useSwitchProviderMutation("codex"), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        providerId: "codex-official",
+        seamless: false,
+      });
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: ["proxyStatus"],
+    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: ["proxyRunning"],
+    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: ["proxyTakeoverStatus"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary / 概述

- Add an opt-in seamless switch command for third-party Claude Code and Codex providers.
- Automatically establish local proxy takeover on the first switch, then hot-switch later requests without restarting the client.
- Extend the same behavior to Claude Desktop providers configured in local-routing mode: first activation requires one restart, later proxy-to-proxy switches do not.
- Preserve normal restart behavior for Claude Desktop direct mode and official providers.
- Add localized success messages and focused frontend/backend regression tests.

## Related Issue / 关联 Issue

No linked issue.

## Screenshots / 截图

Not applicable; behavior is covered by switch notifications.

## Verification / 验证

- `pnpm typecheck`
- `pnpm vitest run tests/hooks/useProviderActions.test.tsx` (28 passed)
- `cargo test claude_desktop_seamless_switch --lib -- --nocapture` (2 passed)
- `cargo fmt --check`
- `cargo clippy --lib --all-targets -- -D warnings`
- Full frontend suite: 448/449 passed in the concurrent run; the single 5-second integration timeout passed when rerun alone with `--testTimeout=15000`.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件