### PR TITLE
test(codex): guard Bailian native Responses base URL

### DIFF
--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -354,6 +354,102 @@ requires_openai_auth = true
 }
 
 #[test]
+fn provider_service_add_update_preserves_codex_native_responses_v1_base_url() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let bailian_config = r#"model_provider = "custom"
+model = "qwen3-coder-plus"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.custom]
+name = "bailian"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+    let mut provider = Provider::with_id(
+        "bailian".to_string(),
+        "Bailian".to_string(),
+        json!({
+            "auth": {"OPENAI_API_KEY": "sk-bailian"},
+            "config": bailian_config,
+            "modelCatalog": {
+                "models": [
+                    {
+                        "model": "qwen3-coder-plus",
+                        "displayName": "Qwen3 Coder Plus",
+                        "contextWindow": 1048576
+                    }
+                ]
+            }
+        }),
+        Some("https://bailian.console.aliyun.com".to_string()),
+    );
+    provider.category = Some("cn_official".to_string());
+    provider.meta = Some(ProviderMeta {
+        api_format: Some("openai_responses".to_string()),
+        ..ProviderMeta::default()
+    });
+
+    let mut state_config = MultiAppConfig::default();
+    {
+        let manager = state_config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.current = String::new();
+    }
+    let state = create_test_state_with_config(&state_config).expect("create test state");
+
+    ProviderService::add(&state, AppType::Codex, provider.clone(), false)
+        .expect("add Bailian provider");
+
+    let saved_after_add = state
+        .db
+        .get_provider_by_id("bailian", AppType::Codex.as_str())
+        .expect("query provider after add")
+        .expect("provider should exist after add");
+    let stored_config_after_add = saved_after_add
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .expect("stored Codex config after add");
+    assert!(
+        stored_config_after_add
+            .contains("https://dashscope.aliyuncs.com/compatible-mode/v1"),
+        "stored config must keep Bailian's native Responses /v1 path after add, got: {stored_config_after_add}"
+    );
+
+    let live_after_add =
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read live config");
+    assert!(
+        live_after_add.contains("https://dashscope.aliyuncs.com/compatible-mode/v1"),
+        "live config must keep Bailian's native Responses /v1 path after add, got: {live_after_add}"
+    );
+
+    ProviderService::update(&state, AppType::Codex, None, saved_after_add.clone())
+        .expect("re-save Bailian provider");
+
+    let saved_after_update = state
+        .db
+        .get_provider_by_id("bailian", AppType::Codex.as_str())
+        .expect("query provider after update")
+        .expect("provider should still exist after update");
+    let stored_config_after_update = saved_after_update
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .expect("stored Codex config after update");
+    assert!(
+        stored_config_after_update
+            .contains("https://dashscope.aliyuncs.com/compatible-mode/v1"),
+        "stored config must keep Bailian's native Responses /v1 path after re-save, got: {stored_config_after_update}"
+    );
+}
+
+#[test]
 fn provider_service_switch_codex_preserves_oauth_and_backfills_api_key_from_live_token() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/tests/components/AddProviderDialog.test.tsx
+++ b/tests/components/AddProviderDialog.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AddProviderDialog } from "@/components/providers/AddProviderDialog";
 import type { ProviderFormValues } from "@/components/providers/forms/ProviderForm";
+import { codexProviderPresets } from "@/config/codexProviderPresets";
 
 vi.mock("@/components/ui/dialog", () => ({
   Dialog: ({ children }: { children: React.ReactNode }) => (
@@ -124,5 +125,56 @@ describe("AddProviderDialog", () => {
         lastUsed: undefined,
       },
     });
+  });
+
+  it("preserves Bailian Codex native Responses /v1 base_url when submitting a preset", async () => {
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+    const bailianIndex = codexProviderPresets.findIndex(
+      (preset) => preset.name === "Bailian",
+    );
+    const bailianPreset = codexProviderPresets[bailianIndex];
+
+    expect(bailianPreset).toBeDefined();
+
+    mockFormValues = {
+      name: "Bailian",
+      websiteUrl: bailianPreset.websiteUrl,
+      settingsConfig: JSON.stringify({
+        auth: bailianPreset.auth,
+        config: bailianPreset.config,
+        modelCatalog: { models: bailianPreset.modelCatalog },
+      }),
+      presetId: `codex-${bailianIndex}`,
+      presetCategory: bailianPreset.category,
+      meta: {
+        apiFormat: bailianPreset.apiFormat,
+      },
+    };
+
+    render(
+      <AddProviderDialog
+        open
+        onOpenChange={vi.fn()}
+        appId="codex"
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "common.add",
+      }),
+    );
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+
+    const submitted = handleSubmit.mock.calls[0][0];
+    expect(submitted.settingsConfig.config).toContain(
+      'base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"',
+    );
+    expect(submitted.meta?.apiFormat).toBe("openai_responses");
+    expect(submitted.meta?.custom_endpoints).toHaveProperty(
+      "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    );
   });
 });

--- a/tests/config/codexChatProviderPresets.test.ts
+++ b/tests/config/codexChatProviderPresets.test.ts
@@ -164,19 +164,47 @@ describe("Codex Chat provider presets", () => {
   it("uses native Responses API for migrated CN providers without local route mapping", () => {
     const nativeResponsesPresets = new Map<
       string,
-      { contextWindows: Record<string, number> }
+      { baseUrl: string; contextWindows: Record<string, number> }
     >([
       [
         "DouBaoSeed",
-        { contextWindows: { "doubao-seed-2-1-pro-260628": 262144 } },
+        {
+          baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+          contextWindows: { "doubao-seed-2-1-pro-260628": 262144 },
+        },
       ],
-      ["Bailian", { contextWindows: { "qwen3-coder-plus": 1048576 } }],
-      ["Longcat", { contextWindows: { "LongCat-2.0": 1048576 } }],
-      ["MiniMax", { contextWindows: { "MiniMax-M3": 1000000 } }],
-      ["MiniMax en", { contextWindows: { "MiniMax-M3": 1000000 } }],
+      [
+        "Bailian",
+        {
+          baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          contextWindows: { "qwen3-coder-plus": 1048576 },
+        },
+      ],
+      [
+        "Longcat",
+        {
+          baseUrl: "https://api.longcat.chat/openai/v1",
+          contextWindows: { "LongCat-2.0": 1048576 },
+        },
+      ],
+      [
+        "MiniMax",
+        {
+          baseUrl: "https://api.minimaxi.com/v1",
+          contextWindows: { "MiniMax-M3": 1000000 },
+        },
+      ],
+      [
+        "MiniMax en",
+        {
+          baseUrl: "https://api.minimax.io/v1",
+          contextWindows: { "MiniMax-M3": 1000000 },
+        },
+      ],
       [
         "Xiaomi MiMo",
         {
+          baseUrl: "https://api.xiaomimimo.com/v1",
           contextWindows: {
             "mimo-v2.5-pro": 1048576,
             "mimo-v2.5": 1048576,
@@ -186,6 +214,7 @@ describe("Codex Chat provider presets", () => {
       [
         "Xiaomi MiMo Token Plan (China)",
         {
+          baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
           contextWindows: {
             "mimo-v2.5-pro": 1048576,
             "mimo-v2.5": 1048576,
@@ -199,6 +228,8 @@ describe("Codex Chat provider presets", () => {
 
       expect(preset, `${name} preset`).toBeDefined();
       expect(preset?.apiFormat).toBe("openai_responses");
+      expect(extractCodexBaseUrl(preset?.config)).toBe(expected.baseUrl);
+      expect(preset?.endpointCandidates).toContain(expected.baseUrl);
       // 原生 Responses 预设现在带 modelCatalog：cc-switch 直连时据此生成
       // ~/.codex 的 model-catalogs.json（shell_command 编辑、不发 freeform
       // apply_patch）。带 catalog 不再强制开“本地路由映射”——前端已按


### PR DESCRIPTION
﻿## What changed

- Added regression coverage that Codex native Responses presets keep their configured `base_url` and endpoint candidates, including Bailian's `https://dashscope.aliyuncs.com/compatible-mode/v1` path.
- Added `AddProviderDialog` coverage for submitting the Bailian Codex preset without dropping `/v1` from the saved config or custom endpoint metadata.
- Added backend provider-service coverage for add/re-save preserving Bailian's `/compatible-mode/v1` URL in both stored and live Codex config.

## Why

- Refs #5276. Bailian native Responses expects Codex to call `/compatible-mode/v1/responses`; dropping `/v1` sends traffic to `/compatible-mode/responses` and causes 404s.
- This is a test-only guard around the preset, dialog submit, and provider-service persistence paths so future save logic cannot regress the native Responses base URL.

## How tested

- `pnpm vitest run tests/config/codexChatProviderPresets.test.ts tests/components/AddProviderDialog.test.tsx tests/utils/providerConfigUtils.codex.test.ts tests/components/ProviderForm.codexCatalog.test.ts`
- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --check` from `src-tauri` with `RUSTUP_TOOLCHAIN=1.95.0-x86_64-pc-windows-msvc`
- `pnpm test:unit` currently still fails in existing `tests/integration/App.test.tsx` cases: three 5000ms timeouts plus a duplicate `switch-openclaw` element assertion. The new/targeted tests above pass.
- Attempted `cargo test --test provider_service provider_service_add_update_preserves_codex_native_responses_v1_base_url`; it did not complete locally because the existing cargo/rustup build state held the run until timeout. No Rust test result was obtained beyond formatting.

## Risk and rollout

- Risk: Low; test-only change, no runtime behavior change.
- Rollback: Revert the three test additions.

## Notes for reviewers

Duplicate check performed before implementation/opening this PR:

- `gh issue view 5276 --comments`: issue is open, has no comments, and GitHub shows no linked development branch/PR.
- `gh pr list --state all --search "5276"`: no matching PRs.
- `gh pr list --state all --search "Bailian compatible-mode"`: found #4432, #3256, #4928, #3253; these cover Token Plan/model fetch/Claude Desktop auth paths, not Codex native Responses save/re-save of `base_url`.
- `gh pr list --state all --search "openai_responses base_url v1"`: found #5200 and #3118; both are broader/unrelated feature PRs.
- `gh pr list --state all --search "strip /v1 base_url"`: found #2608, which is about Gemini native fetch_models, not Bailian Codex native Responses persistence.
- `gh issue list --state all --search "Bailian compatible-mode"`: found #5276 plus unrelated Bailian/Responses issues (#4735, #5096, #4465, #4651, #2959).
- `gh pr list --state all --search "codexProviderPresets Bailian"`: only #4432, not the save/re-save path.
- `gh pr list --state all --search "AddProviderDialog Bailian"`: no results.
- `gh search commits "compatible-mode/v1"`: found 273cc48, which intentionally introduced the native Responses `/compatible-mode/v1/responses` preset behavior this PR guards.
