### PR TITLE
fix(proxy): detect prefixed GPT reasoning models

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -60,12 +60,25 @@ pub fn is_openai_o_series(model: &str) -> bool {
 /// - o-series: o1, o3, o4-mini, etc.
 /// - GPT-5+: gpt-5, gpt-5.1, gpt-5.4, gpt-5-codex, etc.
 pub fn supports_reasoning_effort(model: &str) -> bool {
-    is_openai_o_series(model)
-        || model
-            .to_lowercase()
-            .strip_prefix("gpt-")
-            .and_then(|rest| rest.chars().next())
-            .is_some_and(|c| c.is_ascii_digit() && c >= '5')
+    is_openai_o_series(model) || is_gpt_reasoning_model(model)
+}
+
+fn is_gpt_reasoning_model(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+
+    lower.match_indices("gpt-").any(|(index, _)| {
+        let has_boundary = index == 0
+            || lower[..index]
+                .chars()
+                .next_back()
+                .is_none_or(|c| !c.is_ascii_alphanumeric());
+        let starts_at_gpt_5_or_newer = lower[index + 4..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit() && c >= '5');
+
+        has_boundary && starts_at_gpt_5_or_newer
+    })
 }
 
 /// Resolve the appropriate OpenAI `reasoning_effort` from an Anthropic request body.
@@ -1566,7 +1579,13 @@ mod tests {
         assert!(supports_reasoning_effort("gpt-5"));
         assert!(supports_reasoning_effort("gpt-5.4"));
         assert!(supports_reasoning_effort("gpt-5-codex"));
+        assert!(supports_reasoning_effort("b-gpt-5.6-sol"));
+        assert!(supports_reasoning_effort("x-gpt-5.4"));
+        assert!(supports_reasoning_effort("B-GPT-5.6-SOL"));
+        assert!(supports_reasoning_effort("openai/gpt-5.4"));
         assert!(!supports_reasoning_effort("gpt-4o"));
+        assert!(!supports_reasoning_effort("b-gpt-4o"));
+        assert!(!supports_reasoning_effort("bgpt-5"));
         assert!(!supports_reasoning_effort("claude-sonnet-4-6"));
     }
 

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -1748,6 +1748,19 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_prefixed_gpt_5_model_sets_reasoning_effort() {
+        let input = json!({
+            "model": "b-gpt-5.6-sol",
+            "max_tokens": 1024,
+            "output_config": {"effort": "high"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "high");
+    }
+
+    #[test]
     fn test_responses_thinking_enabled_medium_budget_sets_reasoning_medium() {
         let input = json!({
             "model": "gpt-5.4",


### PR DESCRIPTION
﻿## What changed

- Update `supports_reasoning_effort()` so GPT-5+ models are detected when a provider prefixes the model id, for example `b-gpt-5.6-sol`, `x-gpt-5.4`, or `openai/gpt-5.4`.
- Keep GPT-4 and non-boundary false positives out of the reasoning-effort path.
- Add regression coverage for the shared helper and the OpenAI Responses conversion path, ensuring a prefixed GPT-5 model emits `reasoning.effort`.

## Why

- Fixes #5343.
- Some OpenAI-compatible providers namespace GPT models with a prefix. The old implementation used `strip_prefix("gpt-")`, so Claude Code `output_config.effort` was silently dropped for models such as `b-gpt-5.6-sol` even though the upstream model supports Responses reasoning effort.

## How tested

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`
- `pnpm typecheck`

Attempted but could not complete locally:

- `cargo test --manifest-path src-tauri/Cargo.toml --lib test_supports_reasoning_effort` timed out after 5 minutes while the existing local cargo build state was active.
- Retried with isolated `CARGO_TARGET_DIR=%TEMP%\cc-switch-cargo-target-prefixed`; it still timed out after 15 minutes before producing a test result.

## Risk and rollout

- Risk: Low. The change only broadens GPT-5+ reasoning-effort detection to namespaced/prefixed model ids and keeps GPT-4/non-GPT models negative.
- Rollback: Revert this commit to restore the previous strict prefix check.

## Notes for reviewers

Duplicate check performed before implementation/opening this PR:

- `gh issue view 5343 --comments`: issue is open, has no comments, and no linked development branch/PR is visible.
- `gh pr list --state all --search "5343"`: found #5219, which maps OpenAI token-limit parameters and does not change prefixed GPT reasoning detection.
- `gh pr list --state all --search "supports_reasoning_effort"`: found #5267 and #1672. #5267 changes GPT-5 generation effort caps/model effort suffixes; it leaves `supports_reasoning_effort()` requiring a leading `gpt-`. #1672 is about GPT-5 token parameter mapping.
- `gh issue list --state all --search "supports_reasoning_effort"`: found #5343 and #3185; #3185 is Azure OpenAI token parameter selection.
- `gh pr list --state all --search "b-gpt-5"`: found #5219 only; not this root cause.
- `gh issue list --state all --search "b-gpt-5"`: found #5343 plus unrelated provider/catalog issues.
- `gh pr list --state all --search "custom prefix gpt reasoning effort"`: no matching PRs.
- `gh issue list --state all --search "strip_prefix gpt reasoning"`: only #5343.
- `gh pr list --state all --search "reasoning effort prefixed model"`: found #3118, a broader Claude official API switching feature, not this converter guard.
