### PR TITLE
fix(skills): preserve deleted default repositories

### DIFF
--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -232,32 +232,21 @@ impl Database {
         Ok(())
     }
 
-    /// 初始化默认的 Skill 仓库（启动时调用，补充缺失的默认仓库）
+    /// 初始化默认的 Skill 仓库（启动时调用，仅在仓库表为空时写入）
     pub fn init_default_skill_repos(&self) -> Result<usize, AppError> {
-        // 获取已有仓库列表
-        let existing = self.get_skill_repos()?;
-        let existing_keys: std::collections::HashSet<(String, String)> = existing
-            .iter()
-            .map(|r| (r.owner.clone(), r.name.clone()))
-            .collect();
+        if !self.get_skill_repos()?.is_empty() {
+            return Ok(0);
+        }
 
-        // 获取默认仓库列表
         let default_store = crate::services::skill::SkillStore::default();
         let mut count = 0;
 
-        // 仅插入缺失的默认仓库
         for repo in &default_store.repos {
-            let key = (repo.owner.clone(), repo.name.clone());
-            if !existing_keys.contains(&key) {
-                self.save_skill_repo(repo)?;
-                count += 1;
-                log::info!("补充默认 Skill 仓库: {}/{}", repo.owner, repo.name);
-            }
+            self.save_skill_repo(repo)?;
+            count += 1;
+            log::info!("初始化默认 Skill 仓库: {}/{}", repo.owner, repo.name);
         }
 
-        if count > 0 {
-            log::info!("补充默认 Skill 仓库完成，新增 {count} 个");
-        }
         Ok(count)
     }
 }

--- a/src-tauri/src/database/dao/skills.rs
+++ b/src-tauri/src/database/dao/skills.rs
@@ -232,9 +232,17 @@ impl Database {
         Ok(())
     }
 
-    /// 初始化默认的 Skill 仓库（启动时调用，仅在仓库表为空时写入）
+    /// 初始化默认的 Skill 仓库（启动时调用，每个数据库仅执行一次）
     pub fn init_default_skill_repos(&self) -> Result<usize, AppError> {
+        const INITIALIZED_KEY: &str = "default_skill_repos_initialized";
+
+        if self.get_bool_flag(INITIALIZED_KEY)? {
+            return Ok(0);
+        }
+
+        // 兼容升级前已经存在的用户选择，并记录初始化状态，避免以后删空后恢复默认值。
         if !self.get_skill_repos()?.is_empty() {
+            self.set_setting(INITIALIZED_KEY, "true")?;
             return Ok(0);
         }
 
@@ -247,6 +255,7 @@ impl Database {
             log::info!("初始化默认 Skill 仓库: {}/{}", repo.owner, repo.name);
         }
 
+        self.set_setting(INITIALIZED_KEY, "true")?;
         Ok(count)
     }
 }

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -156,18 +156,31 @@ fn deleted_default_skill_repo_is_not_restored() {
     let db = Database::memory().expect("create memory db");
 
     assert_eq!(db.init_default_skill_repos().expect("initialize repos"), 4);
-    db.delete_skill_repo("anthropics", "skills")
-        .expect("delete repo");
+    for repo in db.get_skill_repos().expect("get initialized repos") {
+        db.delete_skill_repo(&repo.owner, &repo.name)
+            .expect("delete repo");
+    }
+    assert!(db.get_skill_repos().expect("get deleted repos").is_empty());
 
     assert_eq!(
         db.init_default_skill_repos().expect("reinitialize repos"),
         0
     );
-    assert!(!db
-        .get_skill_repos()
-        .expect("get repos")
-        .iter()
-        .any(|repo| repo.owner == "anthropics" && repo.name == "skills"));
+    assert!(db.get_skill_repos().expect("get repos").is_empty());
+}
+
+#[test]
+fn existing_skill_repo_selection_is_not_supplemented() {
+    let db = Database::memory().expect("create memory db");
+    let default_store = crate::services::skill::SkillStore::default();
+    db.save_skill_repo(&default_store.repos[0])
+        .expect("save existing repo");
+
+    assert_eq!(db.init_default_skill_repos().expect("initialize repos"), 0);
+    assert_eq!(db.get_skill_repos().expect("get repos").len(), 1);
+    assert!(db
+        .get_bool_flag("default_skill_repos_initialized")
+        .expect("get initialized flag"));
 }
 
 #[test]

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -152,6 +152,25 @@ fn normalize_default(default: &Option<String>) -> Option<String> {
 }
 
 #[test]
+fn deleted_default_skill_repo_is_not_restored() {
+    let db = Database::memory().expect("create memory db");
+
+    assert_eq!(db.init_default_skill_repos().expect("initialize repos"), 4);
+    db.delete_skill_repo("anthropics", "skills")
+        .expect("delete repo");
+
+    assert_eq!(
+        db.init_default_skill_repos().expect("reinitialize repos"),
+        0
+    );
+    assert!(!db
+        .get_skill_repos()
+        .expect("get repos")
+        .iter()
+        .any(|repo| repo.owner == "anthropics" && repo.name == "skills"));
+}
+
+#[test]
 fn schema_migration_sets_user_version_when_missing() {
     let conn = Connection::open_in_memory().expect("open memory db");
 


### PR DESCRIPTION
## Summary

- initialize default skill repositories only when the repository table is empty
- keep a deleted default repository from being restored on the next app startup
- add a regression test for deleting a default repository and rerunning initialization

## Root cause

Startup initialization compared the configured repositories against every built-in default and reinserted any missing entry. As a result, deleting a built-in repository from repository management only lasted until the next startup.

## Validation

- `cargo check` passes