### PR TITLE
feat(grok): add independent Grok Build management and routing

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -25,6 +25,7 @@ impl McpApps {
         match app {
             AppType::Claude => self.claude,
             AppType::Codex => self.codex,
+            AppType::Grok => false,
             AppType::Gemini => self.gemini,
             AppType::OpenCode => self.opencode,
             AppType::OpenClaw => false, // OpenClaw doesn't support MCP
@@ -38,6 +39,7 @@ impl McpApps {
         match app {
             AppType::Claude => self.claude = enabled,
             AppType::Codex => self.codex = enabled,
+            AppType::Grok => {}
             AppType::Gemini => self.gemini = enabled,
             AppType::OpenCode => self.opencode = enabled,
             AppType::OpenClaw => {} // OpenClaw doesn't support MCP, ignore
@@ -94,6 +96,7 @@ impl SkillApps {
         match app {
             AppType::Claude => self.claude,
             AppType::Codex => self.codex,
+            AppType::Grok => false,
             AppType::Gemini => self.gemini,
             AppType::OpenCode => self.opencode,
             AppType::Hermes => self.hermes,
@@ -107,6 +110,7 @@ impl SkillApps {
         match app {
             AppType::Claude => self.claude = enabled,
             AppType::Codex => self.codex = enabled,
+            AppType::Grok => {}
             AppType::Gemini => self.gemini = enabled,
             AppType::OpenCode => self.opencode = enabled,
             AppType::Hermes => self.hermes = enabled,
@@ -270,6 +274,8 @@ pub struct McpRoot {
     #[serde(default, skip_serializing_if = "McpConfig::is_empty")]
     pub codex: McpConfig,
     #[serde(default, skip_serializing_if = "McpConfig::is_empty")]
+    pub grok: McpConfig,
+    #[serde(default, skip_serializing_if = "McpConfig::is_empty")]
     pub gemini: McpConfig,
     /// OpenCode MCP 配置（v4.0.0+，实际使用 opencode.json）
     #[serde(default, skip_serializing_if = "McpConfig::is_empty")]
@@ -291,6 +297,7 @@ impl Default for McpRoot {
             claude: McpConfig::default(),
             claude_desktop: McpConfig::default(),
             codex: McpConfig::default(),
+            grok: McpConfig::default(),
             gemini: McpConfig::default(),
             opencode: McpConfig::default(),
             openclaw: McpConfig::default(),
@@ -321,6 +328,8 @@ pub struct PromptRoot {
     #[serde(default)]
     pub codex: PromptConfig,
     #[serde(default)]
+    pub grok: PromptConfig,
+    #[serde(default)]
     pub gemini: PromptConfig,
     #[serde(default)]
     pub opencode: PromptConfig,
@@ -347,6 +356,7 @@ pub enum AppType {
     )]
     ClaudeDesktop,
     Codex,
+    Grok,
     Gemini,
     OpenCode,
     OpenClaw,
@@ -359,6 +369,7 @@ impl AppType {
             AppType::Claude => "claude",
             AppType::ClaudeDesktop => "claude-desktop",
             AppType::Codex => "codex",
+            AppType::Grok => "grok",
             AppType::Gemini => "gemini",
             AppType::OpenCode => "opencode",
             AppType::OpenClaw => "openclaw",
@@ -383,6 +394,7 @@ impl AppType {
             AppType::Claude,
             AppType::ClaudeDesktop,
             AppType::Codex,
+            AppType::Grok,
             AppType::Gemini,
             AppType::OpenCode,
             AppType::OpenClaw,
@@ -401,14 +413,15 @@ impl FromStr for AppType {
             "claude" => Ok(AppType::Claude),
             "claude-desktop" | "claude_desktop" | "claudedesktop" => Ok(AppType::ClaudeDesktop),
             "codex" => Ok(AppType::Codex),
+            "grok" => Ok(AppType::Grok),
             "gemini" => Ok(AppType::Gemini),
             "opencode" => Ok(AppType::OpenCode),
             "openclaw" => Ok(AppType::OpenClaw),
             "hermes" => Ok(AppType::Hermes),
             other => Err(AppError::localized(
                 "unsupported_app",
-                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, opencode, openclaw, hermes。"),
-                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, gemini, opencode, openclaw, hermes."),
+                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, grok, gemini, opencode, openclaw, hermes。"),
+                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, grok, gemini, opencode, openclaw, hermes."),
             )),
         }
     }
@@ -443,6 +456,7 @@ impl CommonConfigSnippets {
             AppType::Claude => self.claude.as_ref(),
             AppType::ClaudeDesktop => None,
             AppType::Codex => self.codex.as_ref(),
+            AppType::Grok => None,
             AppType::Gemini => self.gemini.as_ref(),
             AppType::OpenCode => self.opencode.as_ref(),
             AppType::OpenClaw => self.openclaw.as_ref(),
@@ -456,6 +470,7 @@ impl CommonConfigSnippets {
             AppType::Claude => self.claude = snippet,
             AppType::ClaudeDesktop => {}
             AppType::Codex => self.codex = snippet,
+            AppType::Grok => {}
             AppType::Gemini => self.gemini = snippet,
             AppType::OpenCode => self.opencode = snippet,
             AppType::OpenClaw => self.openclaw = snippet,
@@ -499,6 +514,7 @@ impl Default for MultiAppConfig {
         apps.insert("claude".to_string(), ProviderManager::default());
         apps.insert("claude-desktop".to_string(), ProviderManager::default());
         apps.insert("codex".to_string(), ProviderManager::default());
+        apps.insert("grok".to_string(), ProviderManager::default());
         apps.insert("gemini".to_string(), ProviderManager::default());
         apps.insert("opencode".to_string(), ProviderManager::default());
         apps.insert("openclaw".to_string(), ProviderManager::default());
@@ -591,6 +607,13 @@ impl MultiAppConfig {
             updated = true;
         }
 
+        if !config.apps.contains_key("grok") {
+            config
+                .apps
+                .insert("grok".to_string(), ProviderManager::default());
+            updated = true;
+        }
+
         // 执行 MCP 迁移（v3.6.x → v3.7.0）
         let migrated = config.migrate_mcp_to_unified()?;
         if migrated {
@@ -661,6 +684,7 @@ impl MultiAppConfig {
             AppType::Claude => &self.mcp.claude,
             AppType::ClaudeDesktop => &self.mcp.claude_desktop,
             AppType::Codex => &self.mcp.codex,
+            AppType::Grok => &self.mcp.grok,
             AppType::Gemini => &self.mcp.gemini,
             AppType::OpenCode => &self.mcp.opencode,
             AppType::OpenClaw => &self.mcp.openclaw,
@@ -674,6 +698,7 @@ impl MultiAppConfig {
             AppType::Claude => &mut self.mcp.claude,
             AppType::ClaudeDesktop => &mut self.mcp.claude_desktop,
             AppType::Codex => &mut self.mcp.codex,
+            AppType::Grok => &mut self.mcp.grok,
             AppType::Gemini => &mut self.mcp.gemini,
             AppType::OpenCode => &mut self.mcp.opencode,
             AppType::OpenClaw => &mut self.mcp.openclaw,
@@ -800,6 +825,7 @@ impl MultiAppConfig {
             AppType::Claude => &mut config.prompts.claude.prompts,
             AppType::ClaudeDesktop => &mut config.prompts.claude_desktop.prompts,
             AppType::Codex => &mut config.prompts.codex.prompts,
+            AppType::Grok => &mut config.prompts.grok.prompts,
             AppType::Gemini => &mut config.prompts.gemini.prompts,
             AppType::OpenCode => &mut config.prompts.opencode.prompts,
             AppType::OpenClaw => &mut config.prompts.openclaw.prompts,
@@ -842,6 +868,7 @@ impl MultiAppConfig {
                 AppType::Claude => &self.mcp.claude.servers,
                 AppType::ClaudeDesktop => continue, // Claude Desktop 3P profiles don't use MCP here
                 AppType::Codex => &self.mcp.codex.servers,
+                AppType::Grok => continue,
                 AppType::Gemini => &self.mcp.gemini.servers,
                 AppType::OpenCode => &self.mcp.opencode.servers,
                 AppType::OpenClaw => continue, // OpenClaw MCP is still in development, skip

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -17,6 +17,37 @@ pub async fn get_claude_config_status() -> Result<ConfigStatus, String> {
 
 use std::str::FromStr;
 
+#[tauri::command]
+pub async fn read_grok_global_config() -> Result<serde_json::Value, String> {
+    let path = crate::grok_config::get_grok_config_path();
+    let exists = path.exists();
+    let content = if exists {
+        std::fs::read_to_string(&path).map_err(|e| e.to_string())?
+    } else {
+        String::new()
+    };
+    Ok(serde_json::json!({
+        "path": path.to_string_lossy(),
+        "content": content,
+        "exists": exists,
+    }))
+}
+
+#[tauri::command]
+pub async fn write_grok_global_config(content: String) -> Result<(), String> {
+    crate::grok_config::write_grok_config_text(&content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn merge_grok_profile_into_global_config(profile_content: String) -> Result<(), String> {
+    crate::grok_config::merge_grok_profile_into_live(&profile_content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn apply_grok_privacy_protection() -> Result<String, String> {
+    crate::grok_config::apply_privacy_protection_live().map_err(|e| e.to_string())
+}
+
 fn invalid_json_format_error(error: serde_json::Error) -> String {
     let lang = settings::get_settings()
         .language
@@ -90,6 +121,14 @@ pub async fn get_config_status(
 
             Ok(ConfigStatus { exists, path })
         }
+        AppType::Grok => {
+            let config_path = crate::grok_config::get_grok_config_path();
+            let exists = config_path.exists();
+            let path = crate::grok_config::get_grok_config_dir()
+                .to_string_lossy()
+                .to_string();
+            Ok(ConfigStatus { exists, path })
+        }
         AppType::Gemini => {
             let env_path = crate::gemini_config::get_gemini_env_path();
             let exists = env_path.exists();
@@ -142,6 +181,7 @@ pub async fn get_config_dir(app: String) -> Result<String, String> {
             crate::claude_desktop_config::get_config_library_path().map_err(|e| e.to_string())?
         }
         AppType::Codex => codex_config::get_codex_config_dir(),
+        AppType::Grok => crate::grok_config::get_grok_config_dir(),
         AppType::Gemini => crate::gemini_config::get_gemini_dir(),
         AppType::OpenCode => crate::opencode_config::get_opencode_dir(),
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
@@ -159,6 +199,7 @@ pub async fn open_config_folder(handle: AppHandle, app: String) -> Result<bool, 
             crate::claude_desktop_config::get_config_library_path().map_err(|e| e.to_string())?
         }
         AppType::Codex => codex_config::get_codex_config_dir(),
+        AppType::Grok => crate::grok_config::get_grok_config_dir(),
         AppType::Gemini => crate::gemini_config::get_gemini_dir(),
         AppType::OpenCode => crate::opencode_config::get_opencode_dir(),
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -22,6 +22,7 @@ pub async fn stop_proxy_server(state: tauri::State<'_, AppState>) -> Result<(), 
     let takeover = state.proxy_service.get_takeover_status().await?;
     if takeover.claude
         || takeover.codex
+        || takeover.grok
         || takeover.gemini
         || takeover.opencode
         || takeover.openclaw

--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -327,6 +327,7 @@ impl Database {
             match app_type {
                 "claude" => (6, 90, 180, 8, 3, 90, 0.7, 15),
                 "codex" => (3, 60, 120, 4, 2, 60, 0.6, 10),
+                "grok" => (3, 60, 120, 4, 2, 60, 0.6, 10),
                 "gemini" => (5, 60, 120, 4, 2, 60, 0.6, 10),
                 _ => (3, 60, 120, 4, 2, 60, 0.6, 10), // 默认值
             };
@@ -382,6 +383,18 @@ impl Database {
                 circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
                 circuit_error_rate_threshold, circuit_min_requests
             ) VALUES ('codex', 3, 60, 120, 600, 4, 2, 60, 0.6, 10)",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // grok: 默认配置
+        conn.execute(
+            "INSERT OR IGNORE INTO proxy_config (
+                app_type, max_retries,
+                streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
+                circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
+                circuit_error_rate_threshold, circuit_min_requests
+            ) VALUES ('grok', 3, 60, 120, 600, 4, 2, 60, 0.6, 10)",
             [],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -52,7 +52,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 13;
+pub(crate) const SCHEMA_VERSION: i32 = 14;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -120,9 +120,9 @@ impl Database {
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-        // 8. Proxy Config 表（三行结构，app_type 主键）
+        // 8. Proxy Config 表（每应用一行，app_type 主键）
         conn.execute("CREATE TABLE IF NOT EXISTS proxy_config (
-            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','gemini')),
+            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','grok','gemini')),
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 15721, enable_logging INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
@@ -136,7 +136,7 @@ impl Database {
             created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now'))
         )", []).map_err(|e| AppError::Database(e.to_string()))?;
 
-        // 初始化三行数据（每应用不同默认值）
+        // 初始化每应用数据（每应用不同默认值）
         //
         // 兼容旧数据库：
         // - 老版本 proxy_config 是单例表（没有 app_type 列），此时不能执行三行 seed insert；
@@ -151,6 +151,25 @@ impl Database {
                 [],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
+            let proxy_config_supports_grok = conn
+                .query_row(
+                    "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'proxy_config'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .map(|sql| sql.contains("'grok'"))
+                .unwrap_or(false);
+            if proxy_config_supports_grok {
+                conn.execute(
+                    "INSERT OR IGNORE INTO proxy_config (app_type, max_retries,
+                    streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
+                    circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
+                    circuit_error_rate_threshold, circuit_min_requests)
+                    VALUES ('grok', 3, 60, 120, 600, 4, 2, 60, 0.6, 10)",
+                    [],
+                )
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            }
             conn.execute(
                 "INSERT OR IGNORE INTO proxy_config (app_type, max_retries,
                 streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
@@ -485,6 +504,11 @@ impl Database {
                         Self::migrate_v12_to_v13(conn)?;
                         Self::set_user_version(conn, 13)?;
                     }
+                    13 => {
+                        log::info!("迁移数据库从 v13 到 v14（添加 Grok 代理配置）");
+                        Self::migrate_v13_to_v14(conn)?;
+                        Self::set_user_version(conn, 14)?;
+                    }
                     _ => {
                         return Err(AppError::Database(format!(
                             "未知的数据库版本 {version}，无法迁移到 {SCHEMA_VERSION}"
@@ -786,6 +810,19 @@ impl Database {
                 old_cb.4,
             ),
             (
+                "grok",
+                get_bool("proxy_takeover_grok"),
+                get_bool("auto_failover_enabled_grok"),
+                3,
+                old_config.4,
+                old_config.5,
+                old_cb.0,
+                old_cb.1,
+                old_cb.2,
+                old_cb.3,
+                old_cb.4,
+            ),
+            (
                 "gemini",
                 get_bool("proxy_takeover_gemini"),
                 get_bool("auto_failover_enabled_gemini"),
@@ -803,7 +840,7 @@ impl Database {
         // 创建新表
         conn.execute("DROP TABLE IF EXISTS proxy_config_new", [])?;
         conn.execute("CREATE TABLE proxy_config_new (
-            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','gemini')),
+            app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','grok','gemini')),
             proxy_enabled INTEGER NOT NULL DEFAULT 0, listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
             listen_port INTEGER NOT NULL DEFAULT 15721, enable_logging INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 0, auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
@@ -1351,6 +1388,109 @@ impl Database {
                 "INTEGER NOT NULL DEFAULT 0",
             )?;
         }
+        Ok(())
+    }
+
+    /// v13 -> v14：扩展 proxy_config 的 app_type CHECK，并初始化 Grok 行。
+    fn migrate_v13_to_v14(conn: &Connection) -> Result<(), AppError> {
+        if !Self::table_exists(conn, "proxy_config")? {
+            return Ok(());
+        }
+
+        let table_sql = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'proxy_config'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .map_err(|e| AppError::Database(format!("读取 proxy_config 定义失败: {e}")))?;
+
+        if !table_sql.contains("'grok'") {
+            conn.execute_batch(
+                "ALTER TABLE proxy_config RENAME TO proxy_config_v13;
+                 CREATE TABLE proxy_config (
+                     app_type TEXT PRIMARY KEY CHECK (app_type IN ('claude','codex','grok','gemini')),
+                     proxy_enabled INTEGER NOT NULL DEFAULT 0,
+                     listen_address TEXT NOT NULL DEFAULT '127.0.0.1',
+                     listen_port INTEGER NOT NULL DEFAULT 15721,
+                     enable_logging INTEGER NOT NULL DEFAULT 1,
+                     enabled INTEGER NOT NULL DEFAULT 0,
+                     auto_failover_enabled INTEGER NOT NULL DEFAULT 0,
+                     max_retries INTEGER NOT NULL DEFAULT 3,
+                     streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60,
+                     streaming_idle_timeout INTEGER NOT NULL DEFAULT 120,
+                     non_streaming_timeout INTEGER NOT NULL DEFAULT 600,
+                     circuit_failure_threshold INTEGER NOT NULL DEFAULT 4,
+                     circuit_success_threshold INTEGER NOT NULL DEFAULT 2,
+                     circuit_timeout_seconds INTEGER NOT NULL DEFAULT 60,
+                     circuit_error_rate_threshold REAL NOT NULL DEFAULT 0.6,
+                     circuit_min_requests INTEGER NOT NULL DEFAULT 10,
+                     default_cost_multiplier TEXT NOT NULL DEFAULT '1',
+                     pricing_model_source TEXT NOT NULL DEFAULT 'response',
+                     created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                     live_takeover_active INTEGER NOT NULL DEFAULT 0
+                 );",
+            )
+            .map_err(|e| AppError::Database(format!("v13 -> v14 重建 proxy_config 失败: {e}")))?;
+
+            let columns = [
+                ("app_type", "'codex'"),
+                ("proxy_enabled", "0"),
+                ("listen_address", "'127.0.0.1'"),
+                ("listen_port", "15721"),
+                ("enable_logging", "1"),
+                ("enabled", "0"),
+                ("auto_failover_enabled", "0"),
+                ("max_retries", "3"),
+                ("streaming_first_byte_timeout", "60"),
+                ("streaming_idle_timeout", "120"),
+                ("non_streaming_timeout", "600"),
+                ("circuit_failure_threshold", "4"),
+                ("circuit_success_threshold", "2"),
+                ("circuit_timeout_seconds", "60"),
+                ("circuit_error_rate_threshold", "0.6"),
+                ("circuit_min_requests", "10"),
+                ("default_cost_multiplier", "'1'"),
+                ("pricing_model_source", "'response'"),
+                ("created_at", "datetime('now')"),
+                ("updated_at", "datetime('now')"),
+                ("live_takeover_active", "0"),
+            ];
+            let names = columns.iter().map(|(name, _)| *name).collect::<Vec<_>>();
+            let mut values = Vec::with_capacity(columns.len());
+            for (name, fallback) in columns {
+                values.push(if Self::has_column(conn, "proxy_config_v13", name)? {
+                    name.to_string()
+                } else {
+                    fallback.to_string()
+                });
+            }
+            conn.execute(
+                &format!(
+                    "INSERT INTO proxy_config ({}) SELECT {} FROM proxy_config_v13",
+                    names.join(", "),
+                    values.join(", ")
+                ),
+                [],
+            )
+            .map_err(|e| AppError::Database(format!("v13 -> v14 复制 proxy_config 失败: {e}")))?;
+            conn.execute("DROP TABLE proxy_config_v13", [])
+                .map_err(|e| {
+                    AppError::Database(format!("v13 -> v14 清理旧 proxy_config 失败: {e}"))
+                })?;
+        }
+
+        conn.execute(
+            "INSERT OR IGNORE INTO proxy_config (app_type, max_retries,
+             streaming_first_byte_timeout, streaming_idle_timeout, non_streaming_timeout,
+             circuit_failure_threshold, circuit_success_threshold, circuit_timeout_seconds,
+             circuit_error_rate_threshold, circuit_min_requests)
+             VALUES ('grok', 3, 60, 120, 600, 4, 2, 60, 0.6, 10)",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("初始化 Grok proxy_config 失败: {e}")))?;
+
         Ok(())
     }
 
@@ -2766,7 +2906,7 @@ mod tests {
 
         Database::apply_schema_migrations_on_conn(&conn)?;
 
-        assert_eq!(Database::get_user_version(&conn)?, 13);
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
         assert!(Database::has_column(
             &conn,
             "proxy_request_logs",

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -170,6 +170,41 @@ fn schema_migration_sets_user_version_when_missing() {
 }
 
 #[test]
+fn schema_migration_accepts_v13_database_with_existing_grok_config() {
+    let conn = Connection::open_in_memory().expect("open memory db");
+    Database::create_tables_on_conn(&conn).expect("create v3.17 tables");
+    conn.execute(
+        "INSERT INTO profiles (id, name, payload) VALUES ('keep', 'Keep', '{}')",
+        [],
+    )
+    .expect("seed profile");
+    Database::set_user_version(&conn, 13).expect("set v13");
+
+    Database::apply_schema_migrations_on_conn(&conn).expect("migrate v13 to current");
+
+    assert_eq!(
+        Database::get_user_version(&conn).expect("read migrated version"),
+        SCHEMA_VERSION
+    );
+    let profile_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM profiles WHERE id = 'keep'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query profile");
+    assert_eq!(profile_count, 1);
+    let grok_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM proxy_config WHERE app_type = 'grok'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query grok proxy config");
+    assert_eq!(grok_count, 1);
+}
+
+#[test]
 fn schema_migration_rejects_future_version() {
     let conn = Connection::open_in_memory().expect("open memory db");
     Database::create_tables_on_conn(&conn).expect("create tables");
@@ -517,7 +552,7 @@ fn schema_create_tables_repairs_legacy_proxy_config_singleton_to_per_app() {
     let count: i32 = conn
         .query_row("SELECT COUNT(*) FROM proxy_config", [], |r| r.get(0))
         .expect("count rows");
-    assert_eq!(count, 3, "per-app proxy_config should have 3 rows");
+    assert_eq!(count, 4, "per-app proxy_config should have 4 rows");
 
     // 新结构下应能按 app_type 查询
     let _: i32 = conn
@@ -653,11 +688,11 @@ fn migration_from_v3_8_schema_v1_to_current_schema_v3() {
         "skills migration snapshot should preserve legacy app mapping"
     );
 
-    // v3.9+ 新增：proxy_config 三行 seed 必须存在（否则 UI 会查不到默认值）
+    // proxy_config 四行 seed 必须存在（否则 UI 会查不到默认值）
     let proxy_rows: i64 = conn
         .query_row("SELECT COUNT(*) FROM proxy_config", [], |r| r.get(0))
         .expect("count proxy_config rows");
-    assert_eq!(proxy_rows, 3);
+    assert_eq!(proxy_rows, 4);
 
     // model_pricing 应具备默认数据（迁移时会 seed）
     let pricing_rows: i64 = conn

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -144,6 +144,7 @@ pub(crate) fn build_provider_from_request(
     let settings_config = match app_type {
         AppType::Claude | AppType::ClaudeDesktop => build_claude_settings(request),
         AppType::Codex => build_codex_settings(request),
+        AppType::Grok => build_grok_settings(request),
         AppType::Gemini => build_gemini_settings(request),
         AppType::OpenCode => build_opencode_settings(request),
         AppType::OpenClaw => build_additive_app_settings(request),
@@ -424,6 +425,22 @@ requires_openai_auth = true
             "OPENAI_API_KEY": request.api_key,
         },
         "config": config_toml
+    })
+}
+
+fn build_grok_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
+    let model = request.model.as_deref().unwrap_or("grok-4.5");
+    let endpoint = get_primary_endpoint(request);
+    let name = request.name.as_deref().unwrap_or(model);
+    let config = format!(
+        "[models]\ndefault = \"ccswitch\"\n\n[model.ccswitch]\nmodel = {}\nbase_url = {}\nname = {}\napi_backend = \"responses\"\n",
+        toml_edit::Value::from(model),
+        toml_edit::Value::from(endpoint),
+        toml_edit::Value::from(name),
+    );
+    json!({
+        "auth": { "OPENAI_API_KEY": request.api_key },
+        "config": config,
     })
 }
 

--- a/src-tauri/src/grok_config.rs
+++ b/src-tauri/src/grok_config.rs
@@ -714,7 +714,8 @@ default_reasoning_effort = "high"
 [model.old]
 model = "old-model"
 "#;
-        let profile = provider().settings_config["config"]
+        let provider = provider();
+        let profile = provider.settings_config["config"]
             .as_str()
             .expect("profile config");
         let merged = merge_grok_profile_config_text(existing, profile).expect("merge profile");

--- a/src-tauri/src/grok_config.rs
+++ b/src-tauri/src/grok_config.rs
@@ -1,0 +1,850 @@
+//! Grok Build 配置文件管理。
+//!
+//! Grok Build 将供应商连接信息保存在 `config.toml` 的 `[endpoints]`、
+//! `[models]`、`[subagents]` 与 `[model.*]` 中。CC Switch 只重写这些
+//! 供应商字段，UI、MCP、遥测等其它配置始终原样保留。
+
+use crate::config::{get_home_dir, write_text_file};
+use crate::error::AppError;
+use crate::provider::Provider;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml_edit::{value, DocumentMut, Item, Table};
+
+pub const CC_SWITCH_GROK_MODEL_ID: &str = "ccswitch";
+pub const GROK_PROXY_TOKEN_PLACEHOLDER: &str = "PROXY_MANAGED";
+
+/// 获取 Grok Build 配置目录。
+///
+/// 优先级与 Grok Build 自身约定保持一致：`GROK_CONFIG`、`GROK_HOME`、
+/// CC Switch 设置覆盖、最后回退到 `~/.grok`。
+pub fn get_grok_config_dir() -> PathBuf {
+    if let Some(path) = std::env::var_os("GROK_CONFIG").filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(path);
+        return path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+    }
+    if let Some(path) = std::env::var_os("GROK_HOME").filter(|value| !value.is_empty()) {
+        return PathBuf::from(path);
+    }
+    if let Some(custom) = crate::settings::get_grok_override_dir() {
+        return custom;
+    }
+    get_home_dir().join(".grok")
+}
+
+pub fn get_grok_config_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("GROK_CONFIG").filter(|value| !value.is_empty()) {
+        return PathBuf::from(path);
+    }
+    get_grok_config_dir().join("config.toml")
+}
+
+pub fn get_grok_backup_dir() -> PathBuf {
+    get_home_dir().join(".grok_switch").join("backups")
+}
+
+fn backup_current_config(path: &Path, next_text: &str) -> Result<(), AppError> {
+    let Ok(current) = fs::read(path) else {
+        return Ok(());
+    };
+    if current == next_text.as_bytes() {
+        return Ok(());
+    }
+
+    let backup_dir = get_grok_backup_dir();
+    fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+    let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S-%3f");
+    let backup_path = backup_dir.join(format!("config-{stamp}.toml"));
+    fs::write(&backup_path, current).map_err(|e| AppError::io(&backup_path, e))?;
+
+    let mut backups = fs::read_dir(&backup_dir)
+        .map_err(|e| AppError::io(&backup_dir, e))?
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry.file_name().to_string_lossy().starts_with("config-")
+                && entry.path().extension().and_then(|ext| ext.to_str()) == Some("toml")
+        })
+        .collect::<Vec<_>>();
+    backups.sort_by_key(|entry| entry.file_name());
+    let remove_count = backups.len().saturating_sub(10);
+    for entry in backups.into_iter().take(remove_count) {
+        fs::remove_file(entry.path()).map_err(|e| AppError::io(entry.path(), e))?;
+    }
+    Ok(())
+}
+
+pub fn read_grok_config_text() -> Result<String, AppError> {
+    let path = get_grok_config_path();
+    if !path.exists() {
+        return Err(AppError::localized(
+            "grok.live.missing",
+            "Grok Build 配置文件不存在",
+            "Grok Build configuration file is missing",
+        ));
+    }
+    std::fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))
+}
+
+pub fn write_grok_config_text(text: &str) -> Result<(), AppError> {
+    let path = get_grok_config_path();
+    validate_config_toml(text)?;
+    backup_current_config(&path, text)?;
+    write_text_file(&path, text)
+}
+
+pub fn validate_config_toml(text: &str) -> Result<(), AppError> {
+    text.parse::<DocumentMut>().map(|_| ()).map_err(|e| {
+        AppError::localized(
+            "provider.grok.config.invalid_toml",
+            format!("Grok config.toml 格式错误: {e}"),
+            format!("Invalid Grok config.toml: {e}"),
+        )
+    })
+}
+
+fn auth_api_key(settings: &Value) -> Option<String> {
+    let auth = settings.get("auth")?.as_object()?;
+    ["OPENAI_API_KEY", "XAI_API_KEY", "GROK_API_KEY"]
+        .into_iter()
+        .find_map(|key| auth.get(key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(ToString::to_string)
+}
+
+fn api_backend_from_format(format: Option<&str>) -> Option<&'static str> {
+    let normalized = format?.trim().to_ascii_lowercase();
+    if matches!(
+        normalized.as_str(),
+        "chat" | "chat_completions" | "chat-completions" | "openai_chat" | "openai-chat"
+    ) {
+        Some("chat_completions")
+    } else if matches!(
+        normalized.as_str(),
+        "responses" | "openai_responses" | "openai-responses"
+    ) {
+        Some("responses")
+    } else {
+        None
+    }
+}
+
+pub fn api_format_from_backend(backend: Option<&str>) -> &'static str {
+    match backend
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("chat") | Some("chat_completions") | Some("chat-completions") => "openai_chat",
+        _ => "openai_responses",
+    }
+}
+
+fn selected_model_table(doc: &DocumentMut) -> Option<Table> {
+    let active = doc
+        .get("models")
+        .and_then(|item| item.get("default"))
+        .and_then(Item::as_value)
+        .and_then(|value| value.as_str());
+    if let Some(table) = active.and_then(|name| {
+        doc.get("model")
+            .and_then(|item| item.get(name))
+            .and_then(Item::as_table)
+    }) {
+        return Some(table.clone());
+    }
+    if let Some(table) = doc
+        .get("model")
+        .and_then(|item| item.get(CC_SWITCH_GROK_MODEL_ID))
+        .and_then(Item::as_table)
+    {
+        return Some(table.clone());
+    }
+    doc.get("model")
+        .and_then(Item::as_table)
+        .and_then(|models| models.iter().find_map(|(_, item)| item.as_table()))
+        .cloned()
+}
+
+fn provider_config_doc(provider: &Provider) -> Result<DocumentMut, AppError> {
+    let config_text = provider
+        .settings_config
+        .get("config")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            AppError::localized(
+                "provider.grok.config.missing",
+                "Grok 供应商缺少 config 配置",
+                "Grok provider is missing config",
+            )
+        })?;
+    config_text.parse::<DocumentMut>().map_err(|e| {
+        AppError::localized(
+            "provider.grok.config.invalid_toml",
+            format!("Grok config.toml 格式错误: {e}"),
+            format!("Invalid Grok config.toml: {e}"),
+        )
+    })
+}
+
+fn provider_model_table(provider: &Provider) -> Result<Table, AppError> {
+    let doc = provider_config_doc(provider)?;
+    selected_model_table(&doc).ok_or_else(|| {
+        AppError::localized(
+            "provider.grok.model.missing",
+            "Grok 供应商配置缺少 [model.ccswitch] 模型定义",
+            "Grok provider config is missing the [model.ccswitch] model definition",
+        )
+    })
+}
+
+fn set_owned_key(live: &mut DocumentMut, provider: &DocumentMut, section: &str, key: &str) {
+    if let Some(item) = provider.get(section).and_then(|item| item.get(key)) {
+        live[section][key] = item.clone();
+    } else if let Some(table) = live.get_mut(section).and_then(Item::as_table_like_mut) {
+        table.remove(key);
+    }
+}
+
+fn merge_profile_doc(live_doc: &mut DocumentMut, profile_doc: &DocumentMut) {
+    for (section, keys) in [
+        ("endpoints", &["models_base_url"][..]),
+        ("models", &["default", "web_search"][..]),
+        ("subagents", &["default_model"][..]),
+    ] {
+        for key in keys {
+            set_owned_key(live_doc, profile_doc, section, key);
+        }
+    }
+    live_doc.as_table_mut().remove("model");
+    if let Some(models) = profile_doc.get("model") {
+        live_doc["model"] = models.clone();
+    }
+}
+
+/// 将 Grok Profile 管理的段落加入现有全局配置，同时保留其它全局设置。
+pub fn merge_grok_profile_config_text(
+    existing_text: &str,
+    profile_text: &str,
+) -> Result<String, AppError> {
+    let mut live_doc = if existing_text.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        existing_text.parse::<DocumentMut>().map_err(|e| {
+            AppError::localized(
+                "grok.live.invalid_toml",
+                format!("现有 Grok config.toml 格式错误: {e}"),
+                format!("Existing Grok config.toml is invalid: {e}"),
+            )
+        })?
+    };
+    let profile_doc = profile_text.parse::<DocumentMut>().map_err(|e| {
+        AppError::localized(
+            "provider.grok.config.invalid_toml",
+            format!("Grok Profile TOML 格式错误: {e}"),
+            format!("Invalid Grok Profile TOML: {e}"),
+        )
+    })?;
+    selected_model_table(&profile_doc).ok_or_else(|| {
+        AppError::localized(
+            "provider.grok.model.missing",
+            "Grok Profile 缺少 [model.*] 模型定义",
+            "Grok Profile is missing a [model.*] model definition",
+        )
+    })?;
+
+    merge_profile_doc(&mut live_doc, &profile_doc);
+    Ok(live_doc.to_string())
+}
+
+pub fn merge_grok_profile_into_live(profile_text: &str) -> Result<(), AppError> {
+    let existing = fs::read_to_string(get_grok_config_path()).unwrap_or_default();
+    let next = merge_grok_profile_config_text(&existing, profile_text)?;
+    write_grok_config_text(&next)
+}
+
+/// 删除所有供应商拥有的字段，让 Grok 回退到 `grok login` 管理的官方账号。
+pub fn use_official_auth_config_text(text: &str) -> Result<String, AppError> {
+    let mut doc = if text.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        text.parse::<DocumentMut>().map_err(|e| {
+            AppError::localized(
+                "grok.live.invalid_toml",
+                format!("现有 Grok config.toml 格式错误: {e}"),
+                format!("Existing Grok config.toml is invalid: {e}"),
+            )
+        })?
+    };
+    for (section, keys) in [
+        ("endpoints", &["models_base_url"][..]),
+        ("models", &["default", "web_search"][..]),
+        ("subagents", &["default_model"][..]),
+    ] {
+        if let Some(table) = doc.get_mut(section).and_then(Item::as_table_like_mut) {
+            for key in keys {
+                table.remove(key);
+            }
+        }
+    }
+    doc.as_table_mut().remove("model");
+    Ok(doc.to_string())
+}
+
+pub fn apply_privacy_protection_config_text(text: &str) -> Result<String, AppError> {
+    let mut doc = if text.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        text.parse::<DocumentMut>().map_err(|e| {
+            AppError::localized(
+                "grok.live.invalid_toml",
+                format!("Grok config.toml 格式错误: {e}"),
+                format!("Invalid Grok config.toml: {e}"),
+            )
+        })?
+    };
+    doc["features"]["telemetry"] = value(false);
+    doc["telemetry"]["trace_upload"] = value(false);
+    doc["telemetry"]["mixpanel_enabled"] = value(false);
+    doc["harness"]["disable_codebase_upload"] = value(true);
+    Ok(doc.to_string())
+}
+
+pub fn apply_privacy_protection_live() -> Result<String, AppError> {
+    let existing = fs::read_to_string(get_grok_config_path()).unwrap_or_default();
+    let next = apply_privacy_protection_config_text(&existing)?;
+    write_grok_config_text(&next)?;
+    Ok(next)
+}
+
+/// 将供应商 Profile patch 到一份 Grok 配置文本中。
+///
+/// 修改 `[endpoints].models_base_url`、`[models].default/web_search`、
+/// `[subagents].default_model` 与全部 `[model.*]`；其它段落原样保留。
+/// 调用者可覆盖 `base_url`、`api_key` 与 `api_backend`，用于本地代理接管。
+pub fn patch_config_text_for_provider(
+    existing_text: &str,
+    provider: &Provider,
+    base_url_override: Option<&str>,
+    api_key_override: Option<&str>,
+    api_backend_override: Option<&str>,
+) -> Result<String, AppError> {
+    let mut live_doc = if existing_text.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        existing_text.parse::<DocumentMut>().map_err(|e| {
+            AppError::localized(
+                "grok.live.invalid_toml",
+                format!("现有 Grok config.toml 格式错误: {e}"),
+                format!("Existing Grok config.toml is invalid: {e}"),
+            )
+        })?
+    };
+    if provider.category.as_deref() == Some("official") {
+        return use_official_auth_config_text(existing_text);
+    }
+
+    let mut provider_doc = provider_config_doc(provider)?;
+    provider_model_table(provider)?;
+
+    let api_key = api_key_override
+        .map(ToString::to_string)
+        .or_else(|| auth_api_key(&provider.settings_config));
+    let fallback_backend = api_backend_override.or_else(|| {
+        api_backend_from_format(
+            provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.api_format.as_deref()),
+        )
+    });
+    if let Some(models) = provider_doc.get_mut("model").and_then(Item::as_table_mut) {
+        for (_, item) in models.iter_mut() {
+            let Some(model) = item.as_table_mut() else {
+                continue;
+            };
+            if let Some(base_url) = base_url_override {
+                model["base_url"] = value(base_url);
+            }
+            if let Some(api_key) = api_key.as_deref() {
+                if api_key_override.is_some()
+                    || (model.get("api_key").is_none() && model.get("env_key").is_none())
+                {
+                    model["api_key"] = value(api_key);
+                }
+            }
+            if let Some(backend) = fallback_backend {
+                if api_backend_override.is_some() || model.get("api_backend").is_none() {
+                    model["api_backend"] = value(backend);
+                }
+            }
+        }
+    }
+
+    if let Some(base_url) = base_url_override {
+        provider_doc["endpoints"]["models_base_url"] = value(base_url);
+    }
+    merge_profile_doc(&mut live_doc, &provider_doc);
+    Ok(live_doc.to_string())
+}
+
+pub fn write_grok_provider_live(provider: &Provider) -> Result<(), AppError> {
+    let existing = std::fs::read_to_string(get_grok_config_path()).unwrap_or_default();
+    let patched = patch_config_text_for_provider(&existing, provider, None, None, None)?;
+    write_grok_config_text(&patched)
+}
+
+pub fn write_grok_takeover_live(provider: &Provider, proxy_base_url: &str) -> Result<(), AppError> {
+    let existing = std::fs::read_to_string(get_grok_config_path()).unwrap_or_default();
+    let patched = patch_config_text_for_provider(
+        &existing,
+        provider,
+        Some(proxy_base_url),
+        Some(GROK_PROXY_TOKEN_PLACEHOLDER),
+        None,
+    )?;
+    write_grok_config_text(&patched)
+}
+
+/// 将 Grok live 配置转换为供应商存储格式 `{ auth, config }`。
+pub fn settings_from_config_text(text: &str) -> Result<Value, AppError> {
+    let mut doc = text.parse::<DocumentMut>().map_err(|e| {
+        AppError::localized(
+            "grok.live.invalid_toml",
+            format!("Grok config.toml 格式错误: {e}"),
+            format!("Invalid Grok config.toml: {e}"),
+        )
+    })?;
+    selected_model_table(&doc).ok_or_else(|| {
+        AppError::localized(
+            "grok.live.model_missing",
+            "Grok config.toml 中未找到当前模型配置",
+            "The active model is missing from Grok config.toml",
+        )
+    })?;
+
+    let default_model = doc
+        .get("models")
+        .and_then(|item| item.get("default"))
+        .and_then(Item::as_value)
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string);
+    let mut api_key = String::new();
+    if let Some(models) = doc.get_mut("model").and_then(Item::as_table_mut) {
+        if let Some(name) = default_model.as_deref() {
+            if let Some(model) = models.get(name).and_then(Item::as_table) {
+                api_key = model
+                    .get("api_key")
+                    .and_then(Item::as_value)
+                    .and_then(|value| value.as_str())
+                    .map(ToString::to_string)
+                    .or_else(|| {
+                        model
+                            .get("env_key")
+                            .and_then(Item::as_value)
+                            .and_then(|value| value.as_str())
+                            .and_then(|name| std::env::var(name).ok())
+                    })
+                    .unwrap_or_default();
+            }
+        }
+        if api_key.is_empty() {
+            api_key = models
+                .iter()
+                .filter_map(|(_, item)| item.as_table())
+                .find_map(|model| {
+                    model
+                        .get("api_key")
+                        .and_then(Item::as_value)
+                        .and_then(|value| value.as_str())
+                        .map(ToString::to_string)
+                })
+                .unwrap_or_default();
+        }
+        for (_, item) in models.iter_mut() {
+            let Some(model) = item.as_table_mut() else {
+                continue;
+            };
+            let same_as_profile_key = model
+                .get("api_key")
+                .and_then(Item::as_value)
+                .and_then(|value| value.as_str())
+                == Some(api_key.as_str());
+            if same_as_profile_key {
+                model.remove("api_key");
+            }
+        }
+    }
+
+    let mut provider_doc = DocumentMut::new();
+    for (section, keys) in [
+        ("endpoints", &["models_base_url"][..]),
+        ("models", &["default", "web_search"][..]),
+        ("subagents", &["default_model"][..]),
+    ] {
+        for key in keys {
+            if let Some(item) = doc.get(section).and_then(|item| item.get(key)) {
+                provider_doc[section][key] = item.clone();
+            }
+        }
+    }
+    if let Some(models) = doc.get("model") {
+        provider_doc["model"] = models.clone();
+    }
+
+    Ok(json!({
+        "auth": { "OPENAI_API_KEY": api_key },
+        "config": provider_doc.to_string(),
+    }))
+}
+
+pub fn read_grok_live_settings() -> Result<Value, AppError> {
+    settings_from_config_text(&read_grok_config_text()?)
+}
+
+pub fn infer_api_format_from_settings(settings: &Value) -> &'static str {
+    let backend = settings
+        .get("config")
+        .and_then(Value::as_str)
+        .and_then(|text| text.parse::<DocumentMut>().ok())
+        .and_then(|doc| selected_model_table(&doc))
+        .and_then(|table| {
+            table
+                .get("api_backend")
+                .and_then(Item::as_value)
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string)
+        });
+    api_format_from_backend(backend.as_deref())
+}
+
+pub fn config_text_has_proxy_placeholder(text: &str) -> bool {
+    text.parse::<DocumentMut>()
+        .ok()
+        .and_then(|doc| {
+            doc.get("model").and_then(Item::as_table).map(|models| {
+                models.iter().any(|(_, item)| {
+                    item.as_table()
+                        .and_then(|table| table.get("api_key"))
+                        .and_then(Item::as_value)
+                        .and_then(|value| value.as_str())
+                        == Some(GROK_PROXY_TOKEN_PLACEHOLDER)
+                })
+            })
+        })
+        .unwrap_or(false)
+}
+
+pub fn active_base_url(text: &str) -> Option<String> {
+    let doc = text.parse::<DocumentMut>().ok()?;
+    selected_model_table(&doc)
+        .and_then(|table| {
+            table
+                .get("base_url")
+                .and_then(Item::as_value)
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string)
+        })
+        .or_else(|| {
+            doc.get("endpoints")
+                .and_then(|item| item.get("models_base_url"))
+                .and_then(Item::as_value)
+                .and_then(|value| value.as_str())
+                .map(ToString::to_string)
+        })
+}
+
+pub fn cleanup_takeover_config_text(text: &str) -> Result<String, AppError> {
+    let mut doc = text.parse::<DocumentMut>().map_err(|e| {
+        AppError::localized(
+            "grok.live.invalid_toml",
+            format!("Grok config.toml 格式错误: {e}"),
+            format!("Invalid Grok config.toml: {e}"),
+        )
+    })?;
+    let managed_names = doc
+        .get("model")
+        .and_then(Item::as_table)
+        .map(|models| {
+            models
+                .iter()
+                .filter_map(|(name, item)| {
+                    let managed = item
+                        .as_table()
+                        .and_then(|table| table.get("api_key"))
+                        .and_then(Item::as_value)
+                        .and_then(|value| value.as_str())
+                        == Some(GROK_PROXY_TOKEN_PLACEHOLDER);
+                    managed.then(|| name.to_string())
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !managed_names.is_empty() {
+        if let Some(models) = doc.get_mut("model").and_then(Item::as_table_like_mut) {
+            for name in &managed_names {
+                models.remove(name);
+            }
+        }
+        for (section, key) in [
+            ("models", "default"),
+            ("models", "web_search"),
+            ("subagents", "default_model"),
+        ] {
+            let selected_is_managed = doc
+                .get(section)
+                .and_then(|item| item.get(key))
+                .and_then(Item::as_value)
+                .and_then(|value| value.as_str())
+                .is_some_and(|name| managed_names.iter().any(|managed| managed == name));
+            if selected_is_managed {
+                if let Some(table) = doc.get_mut(section).and_then(Item::as_table_like_mut) {
+                    table.remove(key);
+                }
+            }
+        }
+        if let Some(endpoints) = doc.get_mut("endpoints").and_then(Item::as_table_like_mut) {
+            endpoints.remove("models_base_url");
+        }
+    }
+    Ok(doc.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{Provider, ProviderMeta};
+
+    fn provider() -> Provider {
+        let mut provider = Provider::with_id(
+            "xai".to_string(),
+            "xAI".to_string(),
+            json!({
+                "auth": { "OPENAI_API_KEY": "xai-key" },
+                "config": r#"[endpoints]
+models_base_url = "https://api.x.ai/v1"
+
+[models]
+default = "fast"
+web_search = "search"
+
+[subagents]
+default_model = "fast"
+
+[model.fast]
+model = "grok-4.5"
+base_url = "https://api.x.ai/v1"
+name = "Grok 4.5"
+api_backend = "responses"
+context_window = 500000
+supports_backend_search = true
+
+[model.search]
+model = "grok-4.5"
+base_url = "https://api.x.ai/v1"
+api_backend = "responses"
+supports_backend_search = true
+"#,
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+        provider
+    }
+
+    #[test]
+    fn patch_replaces_provider_sections_and_preserves_unrelated_config() {
+        let existing = r#"[hints]
+project_picker_disabled = true
+
+[models]
+default = "cli"
+default_reasoning_effort = "high"
+
+[model.cli]
+model = "old"
+base_url = "https://old.example/v1"
+api_key = "old-key"
+api_backend = "responses"
+
+[mcp_servers.keep]
+url = "https://example.test/mcp"
+"#;
+        let patched = patch_config_text_for_provider(existing, &provider(), None, None, None)
+            .expect("patch Grok config");
+        let doc = patched
+            .parse::<DocumentMut>()
+            .expect("parse patched config");
+
+        assert_eq!(doc["models"]["default"].as_str(), Some("fast"));
+        assert_eq!(doc["models"]["web_search"].as_str(), Some("search"));
+        assert_eq!(doc["subagents"]["default_model"].as_str(), Some("fast"));
+        assert_eq!(
+            doc["models"]["default_reasoning_effort"].as_str(),
+            Some("high")
+        );
+        assert!(doc["model"].get("cli").is_none());
+        assert_eq!(doc["model"]["fast"]["api_key"].as_str(), Some("xai-key"));
+        assert_eq!(
+            doc["endpoints"]["models_base_url"].as_str(),
+            Some("https://api.x.ai/v1")
+        );
+        assert_eq!(
+            doc["mcp_servers"]["keep"]["url"].as_str(),
+            Some("https://example.test/mcp")
+        );
+    }
+
+    #[test]
+    fn merge_profile_into_global_config_preserves_unmanaged_sections() {
+        let existing = r#"[features]
+telemetry = false
+
+[models]
+default = "old"
+default_reasoning_effort = "high"
+
+[model.old]
+model = "old-model"
+"#;
+        let profile = provider().settings_config["config"]
+            .as_str()
+            .expect("profile config");
+        let merged = merge_grok_profile_config_text(existing, profile).expect("merge profile");
+        let doc = merged.parse::<DocumentMut>().expect("parse merged config");
+
+        assert_eq!(doc["features"]["telemetry"].as_bool(), Some(false));
+        assert_eq!(
+            doc["models"]["default_reasoning_effort"].as_str(),
+            Some("high")
+        );
+        assert_eq!(doc["models"]["default"].as_str(), Some("fast"));
+        assert!(doc["model"].get("old").is_none());
+        assert!(doc["model"]["fast"].is_table());
+    }
+
+    #[test]
+    fn live_import_preserves_multi_model_profile_and_moves_shared_key_to_auth() {
+        let settings = settings_from_config_text(
+            r#"[endpoints]
+models_base_url = "https://api.example/v1"
+
+[models]
+default = "cli"
+web_search = "search"
+
+[subagents]
+default_model = "cli"
+
+[model.cli]
+model = "grok-4.5"
+base_url = "https://api.example/v1"
+api_key = "secret"
+api_backend = "chat_completions"
+
+[model.search]
+model = "grok-4.5-search"
+base_url = "https://api.example/v1"
+api_key = "secret"
+api_backend = "responses"
+supports_backend_search = true
+"#,
+        )
+        .expect("import Grok config");
+
+        assert_eq!(settings["auth"]["OPENAI_API_KEY"], "secret");
+        let config = settings["config"].as_str().expect("config string");
+        let config_doc = config
+            .parse::<DocumentMut>()
+            .expect("parse provider config");
+        assert_eq!(config_doc["models"]["default"].as_str(), Some("cli"));
+        assert_eq!(config_doc["models"]["web_search"].as_str(), Some("search"));
+        assert!(config_doc["model"]["cli"].is_table());
+        assert!(config_doc["model"]["search"].is_table());
+        assert!(!config.contains("secret"));
+        assert_eq!(infer_api_format_from_settings(&settings), "openai_chat");
+    }
+
+    #[test]
+    fn takeover_routes_every_profile_model_without_changing_backend() {
+        let patched = patch_config_text_for_provider(
+            "[features]\ntelemetry = false\n",
+            &provider(),
+            Some("http://127.0.0.1:15721/grok/v1"),
+            Some(GROK_PROXY_TOKEN_PLACEHOLDER),
+            None,
+        )
+        .expect("patch takeover config");
+        let doc = patched.parse::<DocumentMut>().expect("parse takeover");
+        for name in ["fast", "search"] {
+            assert_eq!(
+                doc["model"][name]["base_url"].as_str(),
+                Some("http://127.0.0.1:15721/grok/v1")
+            );
+            assert_eq!(
+                doc["model"][name]["api_key"].as_str(),
+                Some(GROK_PROXY_TOKEN_PLACEHOLDER)
+            );
+            assert_eq!(
+                doc["model"][name]["api_backend"].as_str(),
+                Some("responses")
+            );
+        }
+        assert_eq!(doc["features"]["telemetry"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn official_auth_removes_only_provider_owned_fields() {
+        let cleaned = use_official_auth_config_text(
+            r#"[features]
+telemetry = false
+
+[models]
+default = "custom"
+web_search = "custom"
+default_reasoning_effort = "high"
+
+[model.custom]
+model = "grok-4.5"
+api_key = "secret"
+"#,
+        )
+        .expect("clean provider overrides");
+        let doc = cleaned
+            .parse::<DocumentMut>()
+            .expect("parse official config");
+        assert!(doc.get("model").is_none());
+        assert!(doc["models"].get("default").is_none());
+        assert_eq!(
+            doc["models"]["default_reasoning_effort"].as_str(),
+            Some("high")
+        );
+        assert_eq!(doc["features"]["telemetry"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn privacy_protection_preserves_provider_profile() {
+        let protected = apply_privacy_protection_config_text(
+            &provider().settings_config["config"].as_str().unwrap(),
+        )
+        .expect("apply privacy protection");
+        let doc = protected
+            .parse::<DocumentMut>()
+            .expect("parse protected config");
+        assert_eq!(doc["features"]["telemetry"].as_bool(), Some(false));
+        assert_eq!(doc["telemetry"]["trace_upload"].as_bool(), Some(false));
+        assert_eq!(doc["telemetry"]["mixpanel_enabled"].as_bool(), Some(false));
+        assert_eq!(
+            doc["harness"]["disable_codebase_upload"].as_bool(),
+            Some(true)
+        );
+        assert!(doc["model"]["fast"].is_table());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod deeplink;
 mod error;
 mod gemini_config;
 mod gemini_mcp;
+mod grok_config;
 pub mod hermes_config;
 mod init_status;
 mod lightweight;
@@ -1219,6 +1220,10 @@ pub fn run() {
             commands::set_common_config_snippet,
             commands::update_toml_common_config_snippet,
             commands::extract_common_config_snippet,
+            commands::read_grok_global_config,
+            commands::write_grok_global_config,
+            commands::merge_grok_profile_into_global_config,
+            commands::apply_grok_privacy_protection,
             commands::read_live_provider_settings,
             commands::get_settings,
             commands::save_settings,
@@ -1743,7 +1748,7 @@ pub(crate) fn remove_tray_icon_before_exit(app_handle: &tauri::AppHandle) {
 async fn restore_proxy_state_on_startup(state: &store::AppState) {
     // 收集需要恢复接管的应用列表（从 proxy_config.enabled 读取）
     let mut apps_to_restore = Vec::new();
-    for app_type in ["claude", "codex", "gemini"] {
+    for app_type in ["claude", "codex", "grok", "gemini"] {
         if let Ok(config) = state.db.get_proxy_config_for_app(app_type).await {
             if config.enabled {
                 apps_to_restore.push(app_type);

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -21,6 +21,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
     let base_dir: PathBuf = match app {
         AppType::Claude => get_base_dir_with_fallback(get_claude_settings_path(), ".claude")?,
         AppType::Codex => get_base_dir_with_fallback(get_codex_auth_path(), ".codex")?,
+        AppType::Grok => crate::grok_config::get_grok_config_dir(),
         AppType::Gemini => get_gemini_dir(),
         AppType::OpenCode => get_opencode_dir(),
         AppType::OpenClaw => get_openclaw_dir(),
@@ -31,6 +32,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
     let filename = match app {
         AppType::Claude => "CLAUDE.md",
         AppType::Codex => "AGENTS.md",
+        AppType::Grok => "AGENTS.md",
         AppType::Gemini => "GEMINI.md",
         AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => "AGENTS.md",
         AppType::ClaudeDesktop => unreachable!("handled above"),

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -157,6 +157,17 @@ impl Provider {
                     .unwrap_or_default();
                 (base_url, api_key)
             }
+            AppType::Grok => {
+                let auth = settings.get("auth");
+                let api_key =
+                    first_non_empty(auth, &["OPENAI_API_KEY", "XAI_API_KEY", "GROK_API_KEY"]);
+                let base_url = settings
+                    .get("config")
+                    .and_then(Value::as_str)
+                    .and_then(crate::grok_config::active_base_url)
+                    .unwrap_or_default();
+                (base_url, api_key)
+            }
             // Gemini uses Google-specific env keys (with a legacy GOOGLE_API_KEY fallback).
             AppType::Gemini => {
                 let env = settings.get("env");

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -754,6 +754,97 @@ pub async fn handle_chat_completions(
     .await
 }
 
+async fn handle_openai_passthrough_for_app(
+    state: ProxyState,
+    request: axum::extract::Request,
+    app_type: AppType,
+    tag: &'static str,
+    app_type_str: &'static str,
+    default_endpoint: &'static str,
+) -> Result<axum::response::Response, ProxyError> {
+    let (parts, req_body) = request.into_parts();
+    let method = parts.method.clone();
+    let uri = parts.uri;
+    let mut headers = parts.headers;
+    let extensions = parts.extensions;
+    let body_bytes = req_body
+        .collect()
+        .await
+        .map_err(|e| ProxyError::Internal(format!("Failed to read request body: {e}")))?
+        .to_bytes();
+    let body_bytes = decode_codex_request_body(&mut headers, body_bytes)?;
+    let body: Value = serde_json::from_slice(&body_bytes)
+        .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+
+    let mut ctx =
+        RequestContext::new(&state, &body, &headers, app_type.clone(), tag, app_type_str).await?;
+    let endpoint = endpoint_with_query(&uri, default_endpoint);
+    let is_stream = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let forwarder = ctx.create_forwarder(&state);
+    let mut result = match forwarder
+        .forward_with_retry(
+            &app_type,
+            method,
+            &endpoint,
+            body,
+            headers,
+            extensions,
+            ctx.get_providers(),
+        )
+        .await
+    {
+        Ok(result) => result,
+        Err(mut err) => {
+            if let Some(provider) = err.provider.take() {
+                ctx.provider = provider;
+            }
+            log_forward_error(&state, &ctx, is_stream, &err.error);
+            return build_codex_proxy_error_response(&ctx, &endpoint, &err.error);
+        }
+    };
+
+    let connection_guard = result.connection_guard.take();
+    ctx.outbound_model = result.outbound_model.take();
+    ctx.provider = result.provider;
+    process_response(
+        result.response,
+        &ctx,
+        &state,
+        &OPENAI_PARSER_CONFIG,
+        connection_guard,
+    )
+    .await
+}
+
+/// Grok Build Chat Completions：原生透传，不进入 Codex Responses 转换链。
+pub async fn handle_grok_chat_completions(
+    State(state): State<ProxyState>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    handle_openai_passthrough_for_app(
+        state,
+        request,
+        AppType::Grok,
+        "Grok",
+        "grok",
+        "/chat/completions",
+    )
+    .await
+}
+
+/// Grok Build Responses：xAI 原生 Responses 透传，不转换为 Chat Completions。
+pub async fn handle_grok_responses(
+    State(state): State<ProxyState>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    handle_openai_passthrough_for_app(state, request, AppType::Grok, "Grok", "grok", "/responses")
+        .await
+}
+
 /// 处理 /v1/responses 请求（OpenAI Responses API - Codex CLI 透传）
 pub async fn handle_responses(
     State(state): State<ProxyState>,

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -175,7 +175,7 @@ impl ProviderType {
                 }
                 ProviderType::Claude
             }
-            AppType::Codex => ProviderType::Codex,
+            AppType::Codex | AppType::Grok => ProviderType::Codex,
             AppType::Gemini => {
                 // 检测是否为 CLI 模式（OAuth）
                 let adapter = GeminiAdapter::new();
@@ -244,7 +244,7 @@ impl std::str::FromStr for ProviderType {
 pub fn get_adapter(app_type: &AppType) -> Box<dyn ProviderAdapter> {
     match app_type {
         AppType::Claude | AppType::ClaudeDesktop => Box::new(ClaudeAdapter::new()),
-        AppType::Codex => Box::new(CodexAdapter::new()),
+        AppType::Codex | AppType::Grok => Box::new(CodexAdapter::new()),
         AppType::Gemini => Box::new(GeminiAdapter::new()),
         AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => {
             // These apps don't support proxy, fallback to Codex adapter

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -327,6 +327,13 @@ impl ProxyServer {
             .route("/v1/responses", post(handlers::handle_responses))
             .route("/v1/v1/responses", post(handlers::handle_responses))
             .route("/codex/v1/responses", post(handlers::handle_responses))
+            // Grok Build 独立 OpenAI-compatible 路由。Responses 与 Chat 均原生透传，
+            // 不复用 Codex 的 Responses -> Chat 转换分支。
+            .route(
+                "/grok/v1/chat/completions",
+                post(handlers::handle_grok_chat_completions),
+            )
+            .route("/grok/v1/responses", post(handlers::handle_grok_responses))
             // OpenAI Responses Compact API (Codex CLI 远程压缩，透传)
             .route(
                 "/responses/compact",

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -112,6 +112,7 @@ pub struct ProxyServerInfo {
 pub struct ProxyTakeoverStatus {
     pub claude: bool,
     pub codex: bool,
+    pub grok: bool,
     pub gemini: bool,
     pub opencode: bool,
     pub openclaw: bool,

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -120,6 +120,7 @@ impl ConfigService {
 
         match app_type {
             AppType::Codex => Self::sync_codex_live(config, &current_id, &provider)?,
+            AppType::Grok => crate::grok_config::write_grok_provider_live(&provider)?,
             AppType::Claude => Self::sync_claude_live(config, &current_id, &provider)?,
             AppType::ClaudeDesktop => {
                 // Claude Desktop 3P profiles are managed by claude_desktop_config.

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -119,6 +119,9 @@ impl McpService {
                 // Codex uses TOML format, must use the correct function
                 mcp::sync_single_server_to_codex(&Default::default(), &server.id, &server.server)?;
             }
+            AppType::Grok => {
+                log::debug!("Grok MCP sync is not managed by CC Switch, skipping");
+            }
             AppType::Gemini => {
                 mcp::sync_single_server_to_gemini(&Default::default(), &server.id, &server.server)?;
             }
@@ -161,6 +164,9 @@ impl McpService {
                 log::debug!("Claude Desktop 3P profiles do not use CC Switch MCP sync, skipping");
             }
             AppType::Codex => mcp::remove_server_from_codex(id)?,
+            AppType::Grok => {
+                log::debug!("Grok MCP sync is not managed by CC Switch, skipping");
+            }
             AppType::Gemini => mcp::remove_server_from_gemini(id)?,
             AppType::OpenCode => {
                 mcp::remove_server_from_opencode(id)?;

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -523,7 +523,11 @@ fn settings_contain_common_config(app_type: &AppType, settings: &Value, snippet:
             }
             _ => false,
         },
-        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::ClaudeDesktop => false,
+        AppType::Grok
+        | AppType::OpenCode
+        | AppType::OpenClaw
+        | AppType::Hermes
+        | AppType::ClaudeDesktop => false,
     }
 }
 
@@ -593,9 +597,11 @@ pub(crate) fn remove_common_config_from_settings(
             }
             Ok(result)
         }
-        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::ClaudeDesktop => {
-            Ok(settings.clone())
-        }
+        AppType::Grok
+        | AppType::OpenCode
+        | AppType::OpenClaw
+        | AppType::Hermes
+        | AppType::ClaudeDesktop => Ok(settings.clone()),
     }
 }
 
@@ -650,9 +656,11 @@ fn apply_common_config_to_settings(
             }
             Ok(result)
         }
-        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::ClaudeDesktop => {
-            Ok(settings.clone())
-        }
+        AppType::Grok
+        | AppType::OpenCode
+        | AppType::OpenClaw
+        | AppType::Hermes
+        | AppType::ClaudeDesktop => Ok(settings.clone()),
     }
 }
 
@@ -932,6 +940,9 @@ pub(crate) enum LiveSnapshot {
         auth: Option<Value>,
         config: Option<String>,
     },
+    Grok {
+        config: Option<String>,
+    },
     Gemini {
         env: Option<HashMap<String, String>>,
         config: Option<Value>,
@@ -963,6 +974,14 @@ impl LiveSnapshot {
                     crate::config::write_text_file(&config_path, text)?;
                 } else if config_path.exists() {
                     delete_file(&config_path)?;
+                }
+            }
+            LiveSnapshot::Grok { config } => {
+                let path = crate::grok_config::get_grok_config_path();
+                if let Some(text) = config {
+                    crate::config::write_text_file(&path, text)?;
+                } else if path.exists() {
+                    delete_file(&path)?;
                 }
             }
             LiveSnapshot::Gemini { env, .. } => {
@@ -1032,6 +1051,9 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
                 config_str,
                 profile,
             )?;
+        }
+        AppType::Grok => {
+            crate::grok_config::write_grok_provider_live(provider)?;
         }
         AppType::Gemini => {
             // Delegate to write_gemini_live which handles env file writing correctly
@@ -1303,6 +1325,7 @@ pub fn read_live_settings(app_type: AppType) -> Result<Value, AppError> {
             }
             Ok(result)
         }
+        AppType::Grok => crate::grok_config::read_grok_live_settings(),
         AppType::Claude => {
             let path = get_claude_settings_path();
             if !path.exists() {
@@ -1435,6 +1458,7 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
 
     let settings_config = match app_type {
         AppType::Codex => crate::codex_config::read_codex_live_settings()?,
+        AppType::Grok => crate::grok_config::read_grok_live_settings()?,
         AppType::Claude => {
             let settings_path = get_claude_settings_path();
             if !settings_path.exists() {
@@ -1526,6 +1550,16 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
         }
         .to_string(),
     );
+
+    if matches!(app_type, AppType::Grok) {
+        provider
+            .meta
+            .get_or_insert_with(Default::default)
+            .api_format = Some(
+            crate::grok_config::infer_api_format_from_settings(&provider.settings_config)
+                .to_string(),
+        );
+    }
 
     state.db.save_provider(app_type.as_str(), &provider)?;
     state

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2992,6 +2992,7 @@ impl ProviderService {
             AppType::Claude => Self::extract_claude_common_config(&provider.settings_config),
             AppType::ClaudeDesktop => Ok(String::new()),
             AppType::Codex => Self::extract_codex_common_config(&provider.settings_config),
+            AppType::Grok => Ok(String::new()),
             AppType::Gemini => Self::extract_gemini_common_config(&provider.settings_config),
             AppType::OpenCode => Self::extract_opencode_common_config(&provider.settings_config),
             AppType::OpenClaw => Self::extract_openclaw_common_config(&provider.settings_config),
@@ -3008,6 +3009,7 @@ impl ProviderService {
             AppType::Claude => Self::extract_claude_common_config(settings_config),
             AppType::ClaudeDesktop => Ok(String::new()),
             AppType::Codex => Self::extract_codex_common_config(settings_config),
+            AppType::Grok => Ok(String::new()),
             AppType::Gemini => Self::extract_gemini_common_config(settings_config),
             AppType::OpenCode => Self::extract_opencode_common_config(settings_config),
             AppType::OpenClaw => Self::extract_openclaw_common_config(settings_config),
@@ -3475,6 +3477,40 @@ impl ProviderService {
                     }
                 }
             }
+            AppType::Grok => {
+                let settings = provider.settings_config.as_object().ok_or_else(|| {
+                    AppError::localized(
+                        "provider.grok.settings.not_object",
+                        "Grok 配置必须是 JSON 对象",
+                        "Grok configuration must be a JSON object",
+                    )
+                })?;
+                let auth = settings.get("auth").ok_or_else(|| {
+                    AppError::localized(
+                        "provider.grok.auth.missing",
+                        format!("供应商 {} 缺少 auth 配置", provider.id),
+                        format!("Provider {} is missing auth configuration", provider.id),
+                    )
+                })?;
+                if !auth.is_object() {
+                    return Err(AppError::localized(
+                        "provider.grok.auth.not_object",
+                        "Grok auth 配置必须是 JSON 对象",
+                        "Grok auth configuration must be a JSON object",
+                    ));
+                }
+                let config = settings
+                    .get("config")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        AppError::localized(
+                            "provider.grok.config.missing",
+                            "Grok config 字段必须是 TOML 字符串",
+                            "Grok config must be a TOML string",
+                        )
+                    })?;
+                crate::grok_config::validate_config_toml(config)?;
+            }
             AppType::Gemini => {
                 use crate::gemini_config::validate_gemini_settings;
                 validate_gemini_settings(&provider.settings_config)?
@@ -3637,6 +3673,45 @@ impl ProviderService {
                     ));
                 };
 
+                Ok((api_key, base_url))
+            }
+            AppType::Grok => {
+                let auth = provider
+                    .settings_config
+                    .get("auth")
+                    .and_then(Value::as_object)
+                    .ok_or_else(|| {
+                        AppError::localized(
+                            "provider.grok.auth.missing",
+                            "配置格式错误: 缺少 auth",
+                            "Invalid configuration: missing auth section",
+                        )
+                    })?;
+                let api_key = ["OPENAI_API_KEY", "XAI_API_KEY", "GROK_API_KEY"]
+                    .into_iter()
+                    .find_map(|key| auth.get(key).and_then(Value::as_str))
+                    .map(str::trim)
+                    .filter(|key| !key.is_empty())
+                    .ok_or_else(|| {
+                        AppError::localized(
+                            "provider.grok.api_key.missing",
+                            "缺少 API Key",
+                            "API key is missing",
+                        )
+                    })?
+                    .to_string();
+                let config = provider
+                    .settings_config
+                    .get("config")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let base_url = crate::grok_config::active_base_url(config).ok_or_else(|| {
+                    AppError::localized(
+                        "provider.grok.base_url.missing",
+                        "Grok config.toml 中缺少 base_url 配置",
+                        "base_url is missing from Grok config.toml",
+                    )
+                })?;
                 Ok((api_key, base_url))
             }
             AppType::Gemini => {

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -598,6 +598,12 @@ impl ProxyService {
             .await
             .map(|c| c.enabled)
             .unwrap_or(false);
+        let grok_enabled = self
+            .db
+            .get_proxy_config_for_app("grok")
+            .await
+            .map(|c| c.enabled)
+            .unwrap_or(false);
         let gemini_enabled = self
             .db
             .get_proxy_config_for_app("gemini")
@@ -611,6 +617,7 @@ impl ProxyService {
         Ok(ProxyTakeoverStatus {
             claude: claude_enabled,
             codex: codex_enabled,
+            grok: grok_enabled,
             gemini: gemini_enabled,
             opencode: opencode_enabled,
             openclaw: openclaw_enabled,
@@ -852,6 +859,7 @@ impl ProxyService {
         let live_config = match app_type {
             AppType::Claude => self.read_claude_live()?,
             AppType::Codex => self.read_codex_live()?,
+            AppType::Grok => self.read_grok_live()?,
             AppType::Gemini => self.read_gemini_live()?,
             _ => return Err("该应用不支持代理功能".to_string()),
         };
@@ -1019,6 +1027,43 @@ impl ProxyService {
                     }
                 }
             }
+            AppType::Grok => {
+                let provider_id =
+                    crate::settings::get_effective_current_provider(&self.db, &AppType::Grok)
+                        .map_err(|e| format!("获取 Grok 当前供应商失败: {e}"))?;
+                if let Some(provider_id) = provider_id {
+                    if let Ok(Some(mut provider)) = self.db.get_provider_by_id(&provider_id, "grok")
+                    {
+                        if let Some(config_text) = live_config.get("config").and_then(Value::as_str)
+                        {
+                            let settings =
+                                crate::grok_config::settings_from_config_text(config_text)
+                                    .map_err(|e| format!("解析 Grok Live 配置失败: {e}"))?;
+                            let token = settings
+                                .pointer("/auth/OPENAI_API_KEY")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default();
+                            if !token.is_empty()
+                                && token != crate::grok_config::GROK_PROXY_TOKEN_PLACEHOLDER
+                            {
+                                provider.settings_config = settings;
+                                provider
+                                    .meta
+                                    .get_or_insert_with(Default::default)
+                                    .api_format = Some(
+                                    crate::grok_config::infer_api_format_from_settings(
+                                        &provider.settings_config,
+                                    )
+                                    .to_string(),
+                                );
+                                self.db
+                                    .save_provider("grok", &provider)
+                                    .map_err(|e| format!("同步 Grok Token 到数据库失败: {e}"))?;
+                            }
+                        }
+                    }
+                }
+            }
             AppType::Gemini => {
                 let provider_id =
                     crate::settings::get_effective_current_provider(&self.db, &AppType::Gemini)
@@ -1090,6 +1135,11 @@ impl ProxyService {
                 .await?;
         }
 
+        if let Ok(live_config) = self.read_grok_live() {
+            self.sync_live_config_to_provider(&AppType::Grok, &live_config)
+                .await?;
+        }
+
         if let Ok(live_config) = self.read_gemini_live() {
             self.sync_live_config_to_provider(&AppType::Gemini, &live_config)
                 .await?;
@@ -1147,7 +1197,7 @@ impl ProxyService {
             .map_err(|e| format!("清除接管状态失败: {e}"))?;
 
         // 4. 清除所有应用的 enabled 状态（用户手动关闭，不需要下次自动恢复）
-        for app_type in ["claude", "codex", "gemini"] {
+        for app_type in ["claude", "codex", "grok", "gemini"] {
             if let Ok(mut config) = self.db.get_proxy_config_for_app(app_type).await {
                 if config.enabled {
                     config.enabled = false;
@@ -1244,6 +1294,20 @@ impl ProxyService {
             }
         }
 
+        // Grok Build
+        if let Ok(config) = self.read_grok_live() {
+            if Self::live_has_proxy_placeholder_for_app(&AppType::Grok, &config) {
+                log::warn!("grok Live 已被代理接管，不备份；下次 stop 会从 SSOT 重建 Live");
+            } else {
+                let json_str = serde_json::to_string(&config)
+                    .map_err(|e| format!("序列化 Grok 配置失败: {e}"))?;
+                self.db
+                    .save_live_backup("grok", &json_str)
+                    .await
+                    .map_err(|e| format!("备份 Grok 配置失败: {e}"))?;
+            }
+        }
+
         // Gemini
         if let Ok(config) = self.read_gemini_live() {
             if Self::live_has_proxy_placeholder_for_app(&AppType::Gemini, &config) {
@@ -1267,6 +1331,7 @@ impl ProxyService {
         let (app_type_str, config) = match app_type {
             AppType::Claude => ("claude", self.read_claude_live()?),
             AppType::Codex => ("codex", self.read_codex_live()?),
+            AppType::Grok => ("grok", self.read_grok_live()?),
             AppType::Gemini => ("gemini", self.read_gemini_live()?),
             _ => return Err("该应用不支持代理功能".to_string()),
         };
@@ -1339,6 +1404,7 @@ impl ProxyService {
     /// 因此不需要在 URL 中添加应用前缀。
     async fn takeover_live_configs(&self) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+        let proxy_grok_base_url = format!("{}/grok/v1", proxy_url.trim_end_matches('/'));
 
         // Claude: 修改 ANTHROPIC_BASE_URL，使用占位符替代真实 Token（代理会注入真实 Token）
         if let Ok(mut live_config) = self.read_claude_live() {
@@ -1366,6 +1432,13 @@ impl ProxyService {
             log::info!("Codex Live 配置已接管，代理地址: {proxy_codex_base_url}");
         }
 
+        if self.read_grok_live().is_ok() {
+            let grok_provider = self.require_current_provider_for_app(&AppType::Grok)?;
+            crate::grok_config::write_grok_takeover_live(&grok_provider, &proxy_grok_base_url)
+                .map_err(|e| format!("写入 Grok 接管配置失败: {e}"))?;
+            log::info!("Grok Live 配置已接管，代理地址: {proxy_grok_base_url}");
+        }
+
         // Gemini: 修改 GOOGLE_GEMINI_BASE_URL，使用占位符替代真实 Token（代理会注入真实 Token）
         if let Ok(mut live_config) = self.read_gemini_live() {
             if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
@@ -1388,6 +1461,7 @@ impl ProxyService {
     /// 接管指定应用的 Live 配置（严格模式：目标配置不存在则返回错误）
     async fn takeover_live_config_strict(&self, app_type: &AppType) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+        let proxy_grok_base_url = format!("{}/grok/v1", proxy_url.trim_end_matches('/'));
 
         match app_type {
             AppType::Claude => {
@@ -1415,6 +1489,13 @@ impl ProxyService {
                 self.write_codex_takeover_live_for_provider(&live_config, Some(&codex_provider))?;
                 log::info!("Codex Live 配置已接管，代理地址: {proxy_codex_base_url}");
             }
+            AppType::Grok => {
+                self.read_grok_live()?;
+                let provider = self.require_current_provider_for_app(&AppType::Grok)?;
+                crate::grok_config::write_grok_takeover_live(&provider, &proxy_grok_base_url)
+                    .map_err(|e| format!("写入 Grok 接管配置失败: {e}"))?;
+                log::info!("Grok Live 配置已接管，代理地址: {proxy_grok_base_url}");
+            }
             AppType::Gemini => {
                 let mut live_config = self.read_gemini_live()?;
 
@@ -1440,6 +1521,7 @@ impl ProxyService {
     /// 接管指定应用的 Live 配置（尽力而为：配置不存在/读取失败则跳过）
     async fn takeover_live_config_best_effort(&self, app_type: &AppType) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
+        let proxy_grok_base_url = format!("{}/grok/v1", proxy_url.trim_end_matches('/'));
 
         match app_type {
             AppType::Claude => {
@@ -1480,6 +1562,15 @@ impl ProxyService {
                     )?;
                 }
             }
+            AppType::Grok if self.read_grok_live().is_ok() => {
+                if let Ok(Some(provider)) = self.get_current_provider_for_app(&AppType::Grok) {
+                    let _ = crate::grok_config::write_grok_takeover_live(
+                        &provider,
+                        &proxy_grok_base_url,
+                    );
+                }
+            }
+            AppType::Grok => {}
             AppType::Gemini => {
                 if let Ok(mut live_config) = self.read_gemini_live() {
                     if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
@@ -1519,6 +1610,14 @@ impl ProxyService {
                     log::info!("Codex Live 配置已恢复");
                 }
             }
+            AppType::Grok => {
+                if let Ok(Some(backup)) = self.db.get_live_backup("grok").await {
+                    let config: Value = serde_json::from_str(&backup.original_config)
+                        .map_err(|e| format!("解析 Grok 备份失败: {e}"))?;
+                    self.write_grok_live(&config)?;
+                    log::info!("Grok Live 配置已恢复");
+                }
+            }
             AppType::Gemini => {
                 if let Ok(Some(backup)) = self.db.get_live_backup("gemini").await {
                     let config: Value = serde_json::from_str(&backup.original_config)
@@ -1537,7 +1636,12 @@ impl ProxyService {
     async fn restore_live_configs(&self) -> Result<(), String> {
         let mut errors = Vec::new();
 
-        for app_type in [AppType::Claude, AppType::Codex, AppType::Gemini] {
+        for app_type in [
+            AppType::Claude,
+            AppType::Codex,
+            AppType::Grok,
+            AppType::Gemini,
+        ] {
             if let Err(e) = self
                 .restore_live_config_for_app_with_fallback(&app_type)
                 .await
@@ -1625,6 +1729,7 @@ impl ProxyService {
         match app_type {
             AppType::Claude => self.write_claude_live(config),
             AppType::Codex => self.write_codex_live(config),
+            AppType::Grok => self.write_grok_live(config),
             AppType::Gemini => self.write_gemini_live(config),
             _ => Err("该应用不支持代理功能".to_string()),
         }
@@ -1638,6 +1743,10 @@ impl ProxyService {
             },
             AppType::Codex => match self.read_codex_live() {
                 Ok(config) => Self::is_codex_live_taken_over(&config),
+                Err(_) => false,
+            },
+            AppType::Grok => match self.read_grok_live() {
+                Ok(config) => Self::is_grok_live_taken_over(&config),
                 Err(_) => false,
             },
             AppType::Gemini => match self.read_gemini_live() {
@@ -1693,6 +1802,7 @@ impl ProxyService {
         match app_type {
             AppType::Claude => self.cleanup_claude_takeover_placeholders_in_live(),
             AppType::Codex => self.cleanup_codex_takeover_placeholders_in_live(),
+            AppType::Grok => self.cleanup_grok_takeover_placeholders_in_live(),
             AppType::Gemini => self.cleanup_gemini_takeover_placeholders_in_live(),
             _ => Ok(()),
         }
@@ -1776,6 +1886,16 @@ impl ProxyService {
                     });
                 Ok(Self::is_codex_live_taken_over(&config) && base_url_matches)
             }
+            AppType::Grok => {
+                let config = self.read_grok_live()?;
+                let proxy_grok_base_url = format!("{}/grok/v1", proxy_url.trim_end_matches('/'));
+                let base_url_matches = config
+                    .get("config")
+                    .and_then(Value::as_str)
+                    .and_then(crate::grok_config::active_base_url)
+                    .is_some_and(|url| Self::proxy_urls_match(&url, &proxy_grok_base_url));
+                Ok(Self::is_grok_live_taken_over(&config) && base_url_matches)
+            }
             AppType::Gemini => {
                 let config = self.read_gemini_live()?;
                 let base_url_matches = config
@@ -1846,6 +1966,18 @@ impl ProxyService {
         Ok(())
     }
 
+    fn cleanup_grok_takeover_placeholders_in_live(&self) -> Result<(), String> {
+        let config = self.read_grok_live()?;
+        let text = config
+            .get("config")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let cleaned = crate::grok_config::cleanup_takeover_config_text(text)
+            .map_err(|e| format!("清理 Grok 接管占位符失败: {e}"))?;
+        crate::grok_config::write_grok_config_text(&cleaned)
+            .map_err(|e| format!("写入 Grok 配置失败: {e}"))
+    }
+
     /// Remove local proxy base_url from TOML（委托给 codex_config 共享实现）
     fn remove_local_toml_base_url(toml_str: &str) -> String {
         crate::codex_config::remove_codex_toml_base_url_if(toml_str, Self::is_local_proxy_url)
@@ -1878,7 +2010,7 @@ impl ProxyService {
     /// 检查是否处于 Live 接管模式
     pub async fn is_takeover_active(&self) -> Result<bool, String> {
         let status = self.get_takeover_status().await?;
-        Ok(status.claude || status.codex || status.gemini)
+        Ok(status.claude || status.codex || status.grok || status.gemini)
     }
 
     /// 从异常退出中恢复（启动时调用）
@@ -1918,6 +2050,12 @@ impl ProxyService {
 
         if let Ok(config) = self.read_codex_live() {
             if Self::is_codex_live_taken_over(&config) {
+                return true;
+            }
+        }
+
+        if let Ok(config) = self.read_grok_live() {
+            if Self::is_grok_live_taken_over(&config) {
                 return true;
             }
         }
@@ -1978,6 +2116,13 @@ impl ProxyService {
                 .is_some_and(crate::codex_config::codex_config_has_official_proxy_route)
     }
 
+    fn is_grok_live_taken_over(config: &Value) -> bool {
+        config
+            .get("config")
+            .and_then(Value::as_str)
+            .is_some_and(crate::grok_config::config_text_has_proxy_placeholder)
+    }
+
     fn is_gemini_live_taken_over(config: &Value) -> bool {
         let env = match config.get("env").and_then(|v| v.as_object()) {
             Some(env) => env,
@@ -1996,6 +2141,7 @@ impl ProxyService {
         match app_type {
             AppType::Claude => Self::is_claude_live_taken_over(config),
             AppType::Codex => Self::is_codex_live_taken_over(config),
+            AppType::Grok => Self::is_grok_live_taken_over(config),
             AppType::Gemini => Self::is_gemini_live_taken_over(config),
             _ => false,
         }
@@ -2067,11 +2213,47 @@ impl ProxyService {
             .map_err(|e| format!("注入统一会话路由失败: {e}"))?;
         }
 
+        if matches!(app_type_enum, AppType::Grok) {
+            let existing_text = self
+                .db
+                .get_live_backup("grok")
+                .await
+                .ok()
+                .flatten()
+                .and_then(|backup| serde_json::from_str::<Value>(&backup.original_config).ok())
+                .and_then(|value| {
+                    value
+                        .get("config")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .or_else(|| {
+                    self.read_grok_live().ok().and_then(|value| {
+                        value
+                            .get("config")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+                })
+                .unwrap_or_default();
+            let patched = crate::grok_config::patch_config_text_for_provider(
+                &existing_text,
+                provider,
+                None,
+                None,
+                None,
+            )
+            .map_err(|e| format!("构建 Grok 备份失败: {e}"))?;
+            effective_settings = json!({ "config": patched });
+        }
+
         let backup_json = match app_type_enum {
             AppType::Claude => serde_json::to_string(&effective_settings)
                 .map_err(|e| format!("序列化 Claude 配置失败: {e}"))?,
             AppType::Codex => serde_json::to_string(&effective_settings)
                 .map_err(|e| format!("序列化 Codex 配置失败: {e}"))?,
+            AppType::Grok => serde_json::to_string(&effective_settings)
+                .map_err(|e| format!("序列化 Grok 配置失败: {e}"))?,
             AppType::Gemini => {
                 // Gemini takeover 仅修改 .env；settings.json（含 mcpServers）保持原样。
                 let env_backup = if let Some(env) = effective_settings.get("env") {
@@ -2161,6 +2343,11 @@ impl ProxyService {
             } else if live_taken_over && matches!(app_type_enum, AppType::Codex) {
                 self.sync_codex_live_from_provider_while_proxy_active(&provider)
                     .await?;
+            } else if live_taken_over && matches!(app_type_enum, AppType::Grok) {
+                let (proxy_url, _) = self.build_proxy_urls().await?;
+                let proxy_grok_base_url = format!("{}/grok/v1", proxy_url.trim_end_matches('/'));
+                crate::grok_config::write_grok_takeover_live(&provider, &proxy_grok_base_url)
+                    .map_err(|e| format!("更新 Grok 接管配置失败: {e}"))?;
             }
         }
 
@@ -2442,6 +2629,21 @@ impl ProxyService {
     fn read_codex_live(&self) -> Result<Value, String> {
         crate::codex_config::read_codex_live_settings()
             .map_err(|e| format!("读取 Codex Live 配置失败: {e}"))
+    }
+
+    fn read_grok_live(&self) -> Result<Value, String> {
+        crate::grok_config::read_grok_config_text()
+            .map(|config| json!({ "config": config }))
+            .map_err(|e| format!("读取 Grok Live 配置失败: {e}"))
+    }
+
+    fn write_grok_live(&self, config: &Value) -> Result<(), String> {
+        let text = config
+            .get("config")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "Grok 配置缺少 config 字段".to_string())?;
+        crate::grok_config::write_grok_config_text(text)
+            .map_err(|e| format!("写入 Grok Live 配置失败: {e}"))
     }
 
     fn write_codex_live(&self, config: &Value) -> Result<(), String> {

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -516,6 +516,7 @@ impl SkillService {
                     return Ok(custom.join("skills"));
                 }
             }
+            AppType::Grok => {}
             AppType::Gemini => {
                 if let Some(custom) = crate::settings::get_gemini_override_dir() {
                     return Ok(custom.join("skills"));
@@ -549,6 +550,7 @@ impl SkillService {
             AppType::Claude => home.join(".claude").join("skills"),
             AppType::ClaudeDesktop => home.join(".claude-desktop").join("skills"),
             AppType::Codex => home.join(".codex").join("skills"),
+            AppType::Grok => home.join(".grok").join("skills"),
             AppType::Gemini => home.join(".gemini").join("skills"),
             AppType::OpenCode => home.join(".config").join("opencode").join("skills"),
             AppType::OpenClaw => home.join(".openclaw").join("skills"),

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -38,6 +38,8 @@ pub struct VisibleApps {
     #[serde(default = "default_true")]
     pub codex: bool,
     #[serde(default = "default_true")]
+    pub grok: bool,
+    #[serde(default = "default_true")]
     pub gemini: bool,
     #[serde(default = "default_true")]
     pub opencode: bool,
@@ -53,6 +55,7 @@ impl Default for VisibleApps {
             claude: true,
             claude_desktop: true,
             codex: true,
+            grok: true,
             gemini: true,
             opencode: true,
             openclaw: true,
@@ -68,6 +71,7 @@ impl VisibleApps {
             AppType::Claude => self.claude,
             AppType::ClaudeDesktop => self.claude_desktop,
             AppType::Codex => self.codex,
+            AppType::Grok => self.grok,
             AppType::Gemini => self.gemini,
             AppType::OpenCode => self.opencode,
             AppType::OpenClaw => self.openclaw,
@@ -410,6 +414,8 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_config_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grok_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gemini_config_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opencode_config_dir: Option<String>,
@@ -428,6 +434,9 @@ pub struct AppSettings {
     /// 当前 Codex 供应商 ID（本地存储，优先于数据库 is_current）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_codex: Option<String>,
+    /// 当前 Grok Build 供应商 ID
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_grok: Option<String>,
     /// 当前 Gemini 供应商 ID（本地存储，优先于数据库 is_current）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_gemini: Option<String>,
@@ -520,6 +529,7 @@ impl Default for AppSettings {
             visible_apps: None,
             claude_config_dir: None,
             codex_config_dir: None,
+            grok_config_dir: None,
             gemini_config_dir: None,
             opencode_config_dir: None,
             openclaw_config_dir: None,
@@ -527,6 +537,7 @@ impl Default for AppSettings {
             current_provider_claude: None,
             current_provider_claude_desktop: None,
             current_provider_codex: None,
+            current_provider_grok: None,
             current_provider_gemini: None,
             current_provider_opencode: None,
             current_provider_openclaw: None,
@@ -564,6 +575,13 @@ impl AppSettings {
 
         self.codex_config_dir = self
             .codex_config_dir
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        self.grok_config_dir = self
+            .grok_config_dir
             .as_ref()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
@@ -875,6 +893,14 @@ pub fn get_codex_override_dir() -> Option<PathBuf> {
         .map(|p| resolve_override_path(p))
 }
 
+pub fn get_grok_override_dir() -> Option<PathBuf> {
+    let settings = settings_store().read().ok()?;
+    settings
+        .grok_config_dir
+        .as_ref()
+        .map(|p| resolve_override_path(p))
+}
+
 pub fn get_gemini_override_dir() -> Option<PathBuf> {
     let settings = settings_store().read().ok()?;
     settings
@@ -939,6 +965,7 @@ pub fn get_current_provider(app_type: &AppType) -> Option<String> {
         AppType::Claude => settings.current_provider_claude.clone(),
         AppType::ClaudeDesktop => settings.current_provider_claude_desktop.clone(),
         AppType::Codex => settings.current_provider_codex.clone(),
+        AppType::Grok => settings.current_provider_grok.clone(),
         AppType::Gemini => settings.current_provider_gemini.clone(),
         AppType::OpenCode => settings.current_provider_opencode.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw.clone(),
@@ -956,6 +983,7 @@ pub fn set_current_provider(app_type: &AppType, id: Option<&str>) -> Result<(), 
         AppType::Claude => settings.current_provider_claude = id_owned.clone(),
         AppType::ClaudeDesktop => settings.current_provider_claude_desktop = id_owned.clone(),
         AppType::Codex => settings.current_provider_codex = id_owned.clone(),
+        AppType::Grok => settings.current_provider_grok = id_owned.clone(),
         AppType::Gemini => settings.current_provider_gemini = id_owned.clone(),
         AppType::OpenCode => settings.current_provider_opencode = id_owned.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw = id_owned.clone(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,6 +130,7 @@ const VALID_APPS: AppId[] = [
   "opencode",
   "openclaw",
   "hermes",
+  "grok",
 ];
 
 const getInitialApp = (): AppId => {
@@ -197,6 +198,7 @@ function App() {
     opencode: true,
     openclaw: true,
     hermes: true,
+    grok: true,
   };
 
   const getFirstVisibleApp = (): AppId => {
@@ -207,6 +209,7 @@ function App() {
     if (visibleApps.opencode) return "opencode";
     if (visibleApps.openclaw) return "openclaw";
     if (visibleApps.hermes) return "hermes";
+    if (visibleApps.grok) return "grok";
     return "claude"; // fallback
   };
 

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -26,6 +26,7 @@ const ALL_APPS: AppId[] = [
   "opencode",
   "openclaw",
   "hermes",
+  "grok",
 ];
 const STORAGE_KEY = "cc-switch-last-app";
 
@@ -49,6 +50,7 @@ export function AppSwitcher({
     opencode: "opencode",
     openclaw: "openclaw",
     hermes: "hermes",
+    grok: "xai",
   };
   const appDisplayName: Record<AppId, string> = {
     claude: "Claude Code",
@@ -58,6 +60,7 @@ export function AppSwitcher({
     opencode: "OpenCode",
     openclaw: "OpenClaw",
     hermes: "Hermes",
+    grok: "Grok Build",
   };
 
   // Filter apps based on visibility settings (default all visible)

--- a/src/components/mcp/UnifiedMcpPanel.tsx
+++ b/src/components/mcp/UnifiedMcpPanel.tsx
@@ -64,6 +64,7 @@ const UnifiedMcpPanel = React.forwardRef<
       opencode: 0,
       openclaw: 0,
       hermes: 0,
+      grok: 0,
     };
     serverEntries.forEach(([_, server]) => {
       for (const app of MCP_APP_IDS) {

--- a/src/components/prompts/PromptFormModal.tsx
+++ b/src/components/prompts/PromptFormModal.tsx
@@ -37,6 +37,7 @@ const PromptFormModal: React.FC<PromptFormModalProps> = ({
     gemini: "GEMINI.md",
     opencode: "AGENTS.md",
     hermes: "AGENTS.md",
+    grok: "AGENTS.md",
   };
   const filename = filenameMap[appId as Exclude<AppId, "openclaw">];
   const [name, setName] = useState("");

--- a/src/components/prompts/PromptFormPanel.tsx
+++ b/src/components/prompts/PromptFormPanel.tsx
@@ -32,6 +32,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
     opencode: "AGENTS.md",
     openclaw: "AGENTS.md",
     hermes: "AGENTS.md",
+    grok: "AGENTS.md",
   };
   const filename = filenameMap[appId];
   const [name, setName] = useState("");

--- a/src/components/providers/AddProviderDialog.tsx
+++ b/src/components/providers/AddProviderDialog.tsx
@@ -16,6 +16,7 @@ import { UniversalProviderFormModal } from "@/components/universal/UniversalProv
 import { UniversalProviderPanel } from "@/components/universal";
 import { providerPresets } from "@/config/claudeProviderPresets";
 import { codexProviderPresets } from "@/config/codexProviderPresets";
+import { grokProviderPresets } from "@/config/grokProviderPresets";
 import { geminiProviderPresets } from "@/config/geminiProviderPresets";
 import { claudeDesktopProviderPresets } from "@/config/claudeDesktopProviderPresets";
 import { extractCodexBaseUrl } from "@/utils/providerConfigUtils";
@@ -198,6 +199,10 @@ export function AddProviderDialog({
                 preset.endpointCandidates.forEach(addUrl);
               }
             }
+          } else if (appId === "grok") {
+            const presetIndex = parseInt(values.presetId.replace("grok-", ""));
+            const preset = grokProviderPresets[presetIndex];
+            preset?.endpointCandidates?.forEach(addUrl);
           } else if (appId === "gemini") {
             const presets = geminiProviderPresets;
             const presetIndex = parseInt(
@@ -242,7 +247,7 @@ export function AddProviderDialog({
           if (env?.ANTHROPIC_BASE_URL) {
             addUrl(env.ANTHROPIC_BASE_URL);
           }
-        } else if (appId === "codex") {
+        } else if (appId === "codex" || appId === "grok") {
           const config = parsedConfig.config as string | undefined;
           if (config) {
             const extractedBaseUrl = extractCodexBaseUrl(config);

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -226,13 +226,18 @@ export function ProviderCard({
     appId === "hermes" && isHermesReadOnlyProvider(provider.settingsConfig);
   const isCodexOauth =
     provider.meta?.providerType === PROVIDER_TYPES.CODEX_OAUTH;
-  const codexNeedsRouting = useMemo(() => {
-    if (appId !== "codex" || provider.category === "official") return false;
+  const openAiCompatibleNeedsRouting = useMemo(() => {
+    if (
+      (appId !== "codex" && appId !== "grok") ||
+      provider.category === "official"
+    )
+      return false;
     if (
       provider.meta?.apiFormat === "openai_chat" ||
-      provider.meta?.apiFormat === "anthropic"
+      (appId === "codex" && provider.meta?.apiFormat === "anthropic")
     )
       return true;
+    if (appId === "grok") return false;
     const config = (provider.settingsConfig as Record<string, any>)?.config;
     return (
       typeof config === "string" &&
@@ -396,7 +401,7 @@ export function ProviderCard({
                   </span>
                 )}
 
-              {codexNeedsRouting && (
+              {openAiCompatibleNeedsRouting && (
                 <span className="inline-flex items-center rounded-md bg-sky-100 px-1.5 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
                   {t("codex.needsRouting", {
                     defaultValue: "需要路由",

--- a/src/components/providers/forms/CodexConfigEditor.tsx
+++ b/src/components/providers/forms/CodexConfigEditor.tsx
@@ -1,9 +1,16 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { CodexAuthSection, CodexConfigSection } from "./CodexConfigSections";
 import { CodexCommonConfigModal } from "./CodexCommonConfigModal";
+import { GrokGlobalConfigModal } from "./GrokGlobalConfigModal";
+import { configApi } from "@/lib/api";
 
 interface CodexConfigEditorProps {
+  appId?: "codex" | "grok";
+
+  showCodexFeatures?: boolean;
+
   authValue: string;
 
   configValue: string;
@@ -42,6 +49,8 @@ interface CodexConfigEditorProps {
 }
 
 const CodexConfigEditor: React.FC<CodexConfigEditorProps> = ({
+  appId = "codex",
+  showCodexFeatures = true,
   authValue,
   configValue,
   providerName,
@@ -63,6 +72,21 @@ const CodexConfigEditor: React.FC<CodexConfigEditorProps> = ({
 }) => {
   const { t } = useTranslation();
   const [isCommonConfigModalOpen, setIsCommonConfigModalOpen] = useState(false);
+  const [isGrokGlobalConfigOpen, setIsGrokGlobalConfigOpen] = useState(false);
+  const [isAddingGrokGlobalConfig, setIsAddingGrokGlobalConfig] =
+    useState(false);
+
+  const handleAddGrokGlobalConfig = async () => {
+    setIsAddingGrokGlobalConfig(true);
+    try {
+      await configApi.mergeGrokProfileIntoGlobalConfig(configValue);
+      toast.success(t("grokConfig.addedToGlobalConfig"));
+    } catch (error) {
+      toast.error(String(error));
+    } finally {
+      setIsAddingGrokGlobalConfig(false);
+    }
+  };
 
   const handleCloseCommonConfigModal = () => {
     onCommonConfigErrorClear();
@@ -81,6 +105,7 @@ const CodexConfigEditor: React.FC<CodexConfigEditorProps> = ({
 
       {/* Auth JSON Section */}
       <CodexAuthSection
+        appId={appId}
         value={authValue}
         onChange={onAuthChange}
         onBlur={onAuthBlur}
@@ -90,6 +115,7 @@ const CodexConfigEditor: React.FC<CodexConfigEditorProps> = ({
 
       {/* Config TOML Section */}
       <CodexConfigSection
+        appId={appId}
         value={configValue}
         onChange={onConfigChange}
         providerName={providerName}
@@ -100,18 +126,30 @@ const CodexConfigEditor: React.FC<CodexConfigEditorProps> = ({
         commonConfigError={commonConfigError}
         configError={configError}
         isProxyTakeover={isProxyTakeover}
+        showCodexFeatures={showCodexFeatures}
+        onEditGrokGlobalConfig={() => setIsGrokGlobalConfigOpen(true)}
+        onAddGrokGlobalConfig={handleAddGrokGlobalConfig}
+        isAddingGrokGlobalConfig={isAddingGrokGlobalConfig}
       />
 
       {/* Common Config Modal */}
-      <CodexCommonConfigModal
-        isOpen={isCommonConfigModalOpen}
-        onClose={handleCloseCommonConfigModal}
-        value={commonConfigSnippet}
-        onSave={onCommonConfigSnippetChange}
-        error={commonConfigError}
-        onExtract={onExtract}
-        isExtracting={isExtracting}
-      />
+      {showCodexFeatures && (
+        <CodexCommonConfigModal
+          isOpen={isCommonConfigModalOpen}
+          onClose={handleCloseCommonConfigModal}
+          value={commonConfigSnippet}
+          onSave={onCommonConfigSnippetChange}
+          error={commonConfigError}
+          onExtract={onExtract}
+          isExtracting={isExtracting}
+        />
+      )}
+      {appId === "grok" && (
+        <GrokGlobalConfigModal
+          isOpen={isGrokGlobalConfigOpen}
+          onClose={() => setIsGrokGlobalConfigOpen(false)}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/providers/forms/CodexConfigSections.tsx
+++ b/src/components/providers/forms/CodexConfigSections.tsx
@@ -25,6 +25,7 @@ import {
 */
 
 interface CodexAuthSectionProps {
+  appId?: "codex" | "grok";
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;
@@ -36,6 +37,7 @@ interface CodexAuthSectionProps {
  * CodexAuthSection - Auth JSON editor section
  */
 export const CodexAuthSection: React.FC<CodexAuthSectionProps> = ({
+  appId = "codex",
   value,
   onChange,
   onBlur,
@@ -73,13 +75,20 @@ export const CodexAuthSection: React.FC<CodexAuthSectionProps> = ({
         htmlFor="codexAuth"
         className="block text-sm font-medium text-foreground"
       >
-        {t("codexConfig.authJson")}
+        {t(appId === "grok" ? "grokConfig.authJson" : "codexConfig.authJson", {
+          defaultValue:
+            appId === "grok" ? "Grok API Key (JSON) *" : "auth.json (JSON) *",
+        })}
       </label>
 
       <JsonEditor
         value={value}
         onChange={handleChange}
-        placeholder={t("codexConfig.authJsonPlaceholder")}
+        placeholder={t(
+          appId === "grok"
+            ? "grokConfig.authJsonPlaceholder"
+            : "codexConfig.authJsonPlaceholder",
+        )}
         darkMode={isDarkMode}
         rows={6}
         showValidation={true}
@@ -93,9 +102,17 @@ export const CodexAuthSection: React.FC<CodexAuthSectionProps> = ({
       {!error && (
         <p className="text-xs text-muted-foreground">
           {t(
-            isProxyTakeover
-              ? "codexConfig.authJsonStorageHint"
-              : "codexConfig.authJsonHint",
+            appId === "grok"
+              ? "grokConfig.authJsonHint"
+              : isProxyTakeover
+                ? "codexConfig.authJsonStorageHint"
+                : "codexConfig.authJsonHint",
+            {
+              defaultValue:
+                appId === "grok"
+                  ? "供应商共享 API Key；每个 [model.*] 也可单独设置 api_key 或 env_key"
+                  : undefined,
+            },
           )}
         </p>
       )}
@@ -104,6 +121,11 @@ export const CodexAuthSection: React.FC<CodexAuthSectionProps> = ({
 };
 
 interface CodexConfigSectionProps {
+  appId?: "codex" | "grok";
+  showCodexFeatures?: boolean;
+  onEditGrokGlobalConfig?: () => void;
+  onAddGrokGlobalConfig?: () => void;
+  isAddingGrokGlobalConfig?: boolean;
   value: string;
   onChange: (value: string) => void;
   providerName?: string;
@@ -120,6 +142,11 @@ interface CodexConfigSectionProps {
  * CodexConfigSection - Config TOML editor section
  */
 export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
+  appId = "codex",
+  showCodexFeatures = true,
+  onEditGrokGlobalConfig,
+  onAddGrokGlobalConfig,
+  isAddingGrokGlobalConfig = false,
   value,
   onChange,
   providerName,
@@ -274,58 +301,92 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
           htmlFor="codexConfig"
           className="block text-sm font-medium text-foreground"
         >
-          {t("codexConfig.configToml")}
+          {t(
+            appId === "grok"
+              ? "grokConfig.profileToml"
+              : "codexConfig.configToml",
+            { defaultValue: "config.toml (TOML)" },
+          )}
         </label>
 
-        <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-1">
-          <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
-            <input
-              type="checkbox"
-              checked={goalModeEnabled}
-              onChange={(e) => handleGoalModeToggle(e.target.checked)}
-              className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
-            />
-            {t("codexConfig.enableGoalMode")}
-          </label>
-
-          {showRemoteCompaction && (
-            <label
-              className="inline-flex cursor-pointer items-center gap-2 text-sm text-muted-foreground"
-              title={t("codexConfig.remoteCompactionHint")}
-            >
+        {showCodexFeatures && (
+          <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-1">
+            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
               <input
                 type="checkbox"
-                checked={remoteCompactionEnabled}
-                onChange={(e) => handleRemoteCompactionToggle(e.target.checked)}
+                checked={goalModeEnabled}
+                onChange={(e) => handleGoalModeToggle(e.target.checked)}
                 className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
               />
-              {t("codexConfig.enableRemoteCompaction")}
+              {t("codexConfig.enableGoalMode")}
             </label>
-          )}
 
-          <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
-            <input
-              type="checkbox"
-              checked={useCommonConfig}
-              onChange={(e) => onCommonConfigToggle(e.target.checked)}
-              className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
-            />
-            {t("codexConfig.writeCommonConfig")}
-          </label>
+            {showRemoteCompaction && (
+              <label
+                className="inline-flex cursor-pointer items-center gap-2 text-sm text-muted-foreground"
+                title={t("codexConfig.remoteCompactionHint")}
+              >
+                <input
+                  type="checkbox"
+                  checked={remoteCompactionEnabled}
+                  onChange={(e) =>
+                    handleRemoteCompactionToggle(e.target.checked)
+                  }
+                  className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
+                />
+                {t("codexConfig.enableRemoteCompaction")}
+              </label>
+            )}
+
+            <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={useCommonConfig}
+                onChange={(e) => onCommonConfigToggle(e.target.checked)}
+                className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
+              />
+              {t("codexConfig.writeCommonConfig")}
+            </label>
+          </div>
+        )}
+      </div>
+
+      {showCodexFeatures && (
+        <div className="flex items-center justify-end">
+          <button
+            type="button"
+            onClick={onEditCommonConfig}
+            className="text-xs text-blue-500 dark:text-blue-400 hover:underline"
+          >
+            {t("codexConfig.editCommonConfig")}
+          </button>
         </div>
-      </div>
+      )}
+      {appId === "grok" && onEditGrokGlobalConfig && (
+        <div className="flex items-center justify-end gap-3">
+          {onAddGrokGlobalConfig && (
+            <button
+              type="button"
+              onClick={onAddGrokGlobalConfig}
+              disabled={isAddingGrokGlobalConfig}
+              className="text-xs text-blue-500 hover:underline disabled:cursor-not-allowed disabled:opacity-50 dark:text-blue-400"
+            >
+              {isAddingGrokGlobalConfig
+                ? t("common.saving")
+                : t("grokConfig.addToGlobalConfig")}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onEditGrokGlobalConfig}
+            className="text-xs text-blue-500 hover:underline dark:text-blue-400"
+          >
+            {t("grokConfig.editGlobalConfig")}
+          </button>
+        </div>
+      )}
 
-      <div className="flex items-center justify-end">
-        <button
-          type="button"
-          onClick={onEditCommonConfig}
-          className="text-xs text-blue-500 dark:text-blue-400 hover:underline"
-        >
-          {t("codexConfig.editCommonConfig")}
-        </button>
-      </div>
-
-      {commonConfigError && (
+      {showCodexFeatures && commonConfigError && (
         <p className="text-xs text-red-500 dark:text-red-400 text-right">
           {commonConfigError}
         </p>
@@ -376,9 +437,17 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
       {!configError && (
         <p className="text-xs text-muted-foreground">
           {t(
-            isProxyTakeover
-              ? "codexConfig.configTomlStorageHint"
-              : "codexConfig.configTomlHint",
+            appId === "grok"
+              ? "grokConfig.profileTomlHint"
+              : isProxyTakeover
+                ? "codexConfig.configTomlStorageHint"
+                : "codexConfig.configTomlHint",
+            {
+              defaultValue:
+                appId === "grok"
+                  ? "管理 endpoints、models、subagents 和 model.*；切换时保留其它 Grok 全局配置"
+                  : undefined,
+            },
           )}
         </p>
       )}

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -49,6 +49,7 @@ interface EndpointCandidate {
 }
 
 interface CodexFormFieldsProps {
+  appId?: "codex" | "grok";
   providerId?: string;
   // API Key
   codexApiKey: string;
@@ -155,6 +156,7 @@ function catalogRowsMatchModels(
 }
 
 export function CodexFormFields({
+  appId = "codex",
   providerId,
   codexApiKey,
   onApiKeyChange,
@@ -198,6 +200,8 @@ export function CodexFormFields({
   onLocalProxyBodyOverrideChange,
 }: CodexFormFieldsProps) {
   const { t } = useTranslation();
+  const defaultModelI18nPrefix =
+    appId === "grok" ? "grokConfig" : "codexConfig";
 
   const [fetchedModels, setFetchedModels] = useState<FetchedModel[]>([]);
   const [isFetchingModels, setIsFetchingModels] = useState(false);
@@ -479,9 +483,13 @@ export function CodexFormFields({
               id="codexDefaultModel"
               value={codexModel}
               onChange={(event) => onModelChange(event.target.value)}
-              placeholder={t("codexConfig.defaultModelPlaceholder", {
-                defaultValue: "例如: gpt-5.6",
-              })}
+              placeholder={t(
+                `${defaultModelI18nPrefix}.defaultModelPlaceholder`,
+                {
+                  defaultValue:
+                    appId === "grok" ? "例如: grok-4.5" : "例如: gpt-5.6",
+                },
+              )}
               className="flex-1"
             />
             <Button
@@ -507,9 +515,11 @@ export function CodexFormFields({
             )}
           </div>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            {t("codexConfig.defaultModelHint", {
+            {t(`${defaultModelI18nPrefix}.defaultModelHint`, {
               defaultValue:
-                "Codex 默认请求的模型，随时可改，无需等待预设更新。留空且配置了模型映射时，默认使用映射第一行。",
+                appId === "grok"
+                  ? "Grok Build 默认使用的模型，可随时修改。留空时保留当前 Profile 的默认模型。"
+                  : "Codex 默认请求的模型，随时可改，无需等待预设更新。留空且配置了模型映射时，默认使用映射第一行。",
             })}
           </p>
           {isDefaultModelOutsideCatalog && (
@@ -560,10 +570,15 @@ export function CodexFormFields({
           </CollapsibleTrigger>
           {!advancedExpanded && (
             <p className="mt-1 ml-1 text-xs text-muted-foreground">
-              {t("codexConfig.advancedSectionHint", {
-                defaultValue:
-                  "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。",
-              })}
+              {appId === "grok"
+                ? t("grokConfig.advancedSectionHint", {
+                    defaultValue:
+                      "包含 Grok 原生 API Backend、User-Agent 与本地代理请求覆盖。",
+                  })
+                : t("codexConfig.advancedSectionHint", {
+                    defaultValue:
+                      "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。",
+                  })}
             </p>
           )}
           <CollapsibleContent className="space-y-3 pt-3">
@@ -600,11 +615,13 @@ export function CodexFormFields({
                           defaultValue: "Responses（原生）",
                         })}
                       </SelectItem>
-                      <SelectItem value="anthropic">
-                        {t("codexConfig.upstreamFormatAnthropic", {
-                          defaultValue: "Anthropic Messages（需开启路由）",
-                        })}
-                      </SelectItem>
+                      {appId === "codex" && (
+                        <SelectItem value="anthropic">
+                          {t("codexConfig.upstreamFormatAnthropic", {
+                            defaultValue: "Anthropic Messages（需开启路由）",
+                          })}
+                        </SelectItem>
+                      )}
                     </SelectContent>
                   </Select>
                   <p className="text-xs leading-relaxed text-muted-foreground">
@@ -615,7 +632,7 @@ export function CodexFormFields({
                   </p>
                 </div>
 
-                {isAnthropicFormat && (
+                {appId === "codex" && isAnthropicFormat && (
                   <div className="space-y-1.5">
                     <FormLabel htmlFor="codex-anthropic-auth-field">
                       {t("codexConfig.anthropicAuthFieldLabel", {
@@ -657,7 +674,7 @@ export function CodexFormFields({
                   </div>
                 )}
 
-                {isAnthropicFormat && (
+                {appId === "codex" && isAnthropicFormat && (
                   <div className="flex items-center justify-between gap-4 border-t border-border-default pt-3">
                     <div className="space-y-1">
                       <FormLabel>
@@ -682,7 +699,7 @@ export function CodexFormFields({
                   </div>
                 )}
 
-                {isAnthropicFormat && (
+                {appId === "codex" && isAnthropicFormat && (
                   <div className="space-y-1.5 border-t border-border-default pt-3">
                     <FormLabel htmlFor="codex-anthropic-max-output-tokens">
                       {t("codexConfig.maxOutputTokensLabel", {
@@ -1007,7 +1024,7 @@ export function CodexFormFields({
       {/* 端点测速弹窗 - Codex */}
       {shouldShowSpeedTest && isEndpointModalOpen && (
         <EndpointSpeedTest
-          appId="codex"
+          appId={appId}
           providerId={providerId}
           value={codexBaseUrl}
           onChange={onBaseUrlChange}

--- a/src/components/providers/forms/EndpointSpeedTest.tsx
+++ b/src/components/providers/forms/EndpointSpeedTest.tsx
@@ -17,6 +17,7 @@ const ENDPOINT_TIMEOUT_SECS: Record<AppId, number> = {
   opencode: 8,
   openclaw: 8,
   hermes: 8,
+  grok: 12,
 };
 
 interface TestResult {

--- a/src/components/providers/forms/GrokGlobalConfigModal.tsx
+++ b/src/components/providers/forms/GrokGlobalConfigModal.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+import { Loader2, Save, ShieldCheck } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import { FullScreenPanel } from "@/components/common/FullScreenPanel";
+import { Button } from "@/components/ui/button";
+import JsonEditor from "@/components/JsonEditor";
+import { configApi } from "@/lib/api";
+
+interface GrokGlobalConfigModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function GrokGlobalConfigModal({
+  isOpen,
+  onClose,
+}: GrokGlobalConfigModalProps) {
+  const { t } = useTranslation();
+  const [content, setContent] = useState("");
+  const [path, setPath] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    setIsDarkMode(document.documentElement.classList.contains("dark"));
+    const observer = new MutationObserver(() =>
+      setIsDarkMode(document.documentElement.classList.contains("dark")),
+    );
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setIsLoading(true);
+    configApi
+      .readGrokGlobalConfig()
+      .then((result) => {
+        setContent(result.content);
+        setPath(result.path);
+      })
+      .catch((error) => toast.error(String(error)))
+      .finally(() => setIsLoading(false));
+  }, [isOpen]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await configApi.writeGrokGlobalConfig(content);
+      toast.success(t("grokConfig.globalConfigSaved"));
+      onClose();
+    } catch (error) {
+      toast.error(String(error));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handlePrivacy = async () => {
+    setIsSaving(true);
+    try {
+      const next = await configApi.applyGrokPrivacyProtection();
+      setContent(next);
+      toast.success(t("grokConfig.privacyApplied"));
+    } catch (error) {
+      toast.error(String(error));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <FullScreenPanel
+      isOpen={isOpen}
+      title={t("grokConfig.editGlobalConfig")}
+      onClose={onClose}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handlePrivacy}
+            disabled={isLoading || isSaving}
+            className="gap-2"
+          >
+            <ShieldCheck className="h-4 w-4" />
+            {t("grokConfig.applyPrivacy")}
+          </Button>
+          <Button type="button" variant="outline" onClick={onClose}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={isLoading || isSaving}
+            className="gap-2"
+          >
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4" />
+            )}
+            {t("common.save")}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div className="rounded-lg border border-blue-200 bg-blue-50/50 p-3 text-sm dark:border-blue-800 dark:bg-blue-950/30">
+          <p className="font-medium text-blue-800 dark:text-blue-300">
+            {t("grokConfig.globalConfigTitle")}
+          </p>
+          <p className="mt-1 text-xs text-blue-700/80 dark:text-blue-400/80">
+            {t("grokConfig.globalConfigHint")}
+          </p>
+          <p className="mt-1 break-all text-xs text-muted-foreground">{path}</p>
+        </div>
+        {isLoading ? (
+          <div className="flex justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        ) : (
+          <JsonEditor
+            value={content}
+            onChange={setContent}
+            placeholder="# ~/.grok/config.toml"
+            darkMode={isDarkMode}
+            rows={22}
+            showValidation={false}
+            language="javascript"
+          />
+        )}
+      </div>
+    </FullScreenPanel>
+  );
+}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -33,6 +33,10 @@ import {
   type CodexProviderPreset,
 } from "@/config/codexProviderPresets";
 import {
+  getGrokCustomTemplate,
+  grokProviderPresets,
+} from "@/config/grokProviderPresets";
+import {
   geminiProviderPresets,
   type GeminiProviderPreset,
 } from "@/config/geminiProviderPresets";
@@ -67,6 +71,10 @@ import {
   setCodexModelName as setCodexModelNameInConfig,
 } from "@/utils/providerConfigUtils";
 import { isNonNegativeDecimalString } from "@/types/usage";
+import {
+  extractGrokApiBackend,
+  setGrokApiBackend,
+} from "@/utils/grokConfigUtils";
 import { getCodexCustomTemplate } from "@/config/codexTemplates";
 import CodexConfigEditor from "./CodexConfigEditor";
 import { CommonConfigEditor } from "./CommonConfigEditor";
@@ -271,6 +279,7 @@ function ProviderFormFull({
   const showCommonConfigNotice =
     settingsData != null && settingsData.commonConfigConfirmed !== true;
   const isDarkMode = useDarkMode();
+  const isCodexLike = appId === "codex" || appId === "grok";
 
   const handleCommonConfigConfirm = async () => {
     try {
@@ -307,7 +316,7 @@ function ProviderFormFull({
   const [endpointAutoSelect, setEndpointAutoSelect] = useState<boolean>(
     () => initialData?.meta?.endpointAutoSelect ?? true,
   );
-  const supportsFullUrl = appId === "claude" || appId === "codex";
+  const supportsFullUrl = appId === "claude" || isCodexLike;
   const [localIsFullUrl, setLocalIsFullUrl] = useState<boolean>(() => {
     if (!supportsFullUrl) return false;
     return initialData?.meta?.isFullUrl ?? false;
@@ -379,7 +388,7 @@ function ProviderFormFull({
       notes: initialData?.notes ?? "",
       settingsConfig: initialData?.settingsConfig
         ? JSON.stringify(initialData.settingsConfig, null, 2)
-        : appId === "codex"
+        : isCodexLike
           ? CODEX_DEFAULT_CONFIG
           : appId === "gemini"
             ? GEMINI_DEFAULT_CONFIG
@@ -567,8 +576,19 @@ function ProviderFormFull({
     handleCodexModelChange,
     handleCodexConfigChange: originalHandleCodexConfigChange,
     resetCodexConfig,
-  } = useCodexConfigState({ initialData });
+  } = useCodexConfigState({
+    appId: appId === "grok" ? "grok" : "codex",
+    initialData: isCodexLike ? initialData : undefined,
+  });
 
+  const initialGrokBackend =
+    appId === "grok"
+      ? extractGrokApiBackend(
+          typeof initialData?.settingsConfig?.config === "string"
+            ? initialData.settingsConfig.config
+            : "",
+        )
+      : undefined;
   const initialCodexApiFormat: CodexApiFormat =
     initialData?.meta?.apiFormat === "openai_chat"
       ? "openai_chat"
@@ -576,13 +596,17 @@ function ProviderFormFull({
         ? "anthropic"
         : initialData?.meta?.apiFormat === "openai_responses"
           ? "openai_responses"
-          : (codexApiFormatFromWireApi(
-              extractCodexWireApi(
-                typeof initialData?.settingsConfig?.config === "string"
-                  ? initialData.settingsConfig.config
-                  : "",
-              ),
-            ) ?? "openai_responses");
+          : initialGrokBackend === "chat_completions"
+            ? "openai_chat"
+            : initialGrokBackend === "responses"
+              ? "openai_responses"
+              : (codexApiFormatFromWireApi(
+                  extractCodexWireApi(
+                    typeof initialData?.settingsConfig?.config === "string"
+                      ? initialData.settingsConfig.config
+                      : "",
+                  ),
+                ) ?? "openai_responses");
 
   const [localCodexApiFormat, setLocalCodexApiFormat] =
     useState<CodexApiFormat>(initialCodexApiFormat);
@@ -623,6 +647,15 @@ function ProviderFormFull({
   const handleCodexApiFormatChange = useCallback(
     (format: CodexApiFormat) => {
       setLocalCodexApiFormat(format);
+      if (appId === "grok") {
+        setCodexConfig((prev) =>
+          setGrokApiBackend(
+            prev,
+            format === "openai_chat" ? "chat_completions" : "responses",
+          ),
+        );
+        return;
+      }
       // wire_api is always "responses" for Codex; format controls proxy-layer conversion
       setCodexConfig((prev) => {
         const updated = setCodexWireApi(prev, "responses");
@@ -630,12 +663,13 @@ function ProviderFormFull({
         return updated;
       });
     },
-    [setCodexConfig, debouncedValidate],
+    [appId, setCodexConfig, debouncedValidate],
   );
 
   useEffect(() => {
-    if (appId === "codex" && !initialData && selectedPresetId === "custom") {
-      const template = getCodexCustomTemplate();
+    if (isCodexLike && !initialData && selectedPresetId === "custom") {
+      const template =
+        appId === "grok" ? getGrokCustomTemplate() : getCodexCustomTemplate();
       resetCodexConfig(template.auth, template.config);
       setCodexChatReasoning({});
       setPromptCacheRouting("auto");
@@ -669,6 +703,11 @@ function ProviderFormFull({
     if (appId === "codex") {
       return codexProviderPresets.map<PresetEntry>((preset, index) => ({
         id: `codex-${index}`,
+        preset,
+      }));
+    } else if (appId === "grok") {
+      return grokProviderPresets.map<PresetEntry>((preset, index) => ({
+        id: `grok-${index}`,
         preset,
       }));
     } else if (appId === "gemini") {
@@ -741,6 +780,7 @@ function ProviderFormFull({
     handleExtract: handleCodexExtract,
     clearCommonConfigError: clearCodexCommonConfigError,
   } = useCodexCommonConfig({
+    enabled: appId === "codex",
     codexConfig,
     onConfigChange: handleCodexConfigChange,
     initialData: appId === "codex" ? initialData : undefined,
@@ -989,7 +1029,7 @@ function ProviderFormFull({
   const [isCommonConfigModalOpen, setIsCommonConfigModalOpen] = useState(false);
 
   const shouldApplyLocalProxyRequestOverrides =
-    (appId === "claude" || appId === "codex") && category !== "official";
+    (appId === "claude" || isCodexLike) && category !== "official";
 
   const handleSubmit = async (values: ProviderFormData) => {
     const overridesResult = shouldApplyLocalProxyRequestOverrides
@@ -1208,7 +1248,7 @@ function ProviderFormFull({
             }),
           );
         }
-      } else if (appId === "codex") {
+      } else if (isCodexLike) {
         if (!codexBaseUrl.trim()) {
           issues.push(
             t("providerForm.endpointRequired", {
@@ -1316,6 +1356,15 @@ function ProviderFormFull({
         }
         settingsConfig = JSON.stringify(configObj);
       } catch (err) {
+        settingsConfig = values.settingsConfig.trim();
+      }
+    } else if (appId === "grok") {
+      try {
+        settingsConfig = JSON.stringify({
+          auth: JSON.parse(codexAuth || "{}"),
+          config: codexConfig ?? "",
+        });
+      } catch {
         settingsConfig = values.settingsConfig.trim();
       }
     } else if (appId === "gemini") {
@@ -1500,7 +1549,7 @@ function ProviderFormFull({
           ? promptCacheRouting
           : undefined,
       customUserAgent:
-        (appId === "claude" || appId === "codex") && category !== "official"
+        (appId === "claude" || isCodexLike) && category !== "official"
           ? customUserAgent.trim() || undefined
           : undefined,
       localProxyRequestOverrides: shouldApplyLocalProxyRequestOverrides
@@ -1516,7 +1565,7 @@ function ProviderFormFull({
       apiFormat:
         appId === "claude" && category !== "official"
           ? localApiFormat
-          : appId === "codex" && category !== "official"
+          : isCodexLike && category !== "official"
             ? localCodexApiFormat
             : undefined,
       apiKeyField:
@@ -1661,8 +1710,9 @@ function ProviderFormFull({
       setActivePreset(null);
       form.reset(defaultValues);
 
-      if (appId === "codex") {
-        const template = getCodexCustomTemplate();
+      if (isCodexLike) {
+        const template =
+          appId === "grok" ? getGrokCustomTemplate() : getCodexCustomTemplate();
         resetCodexConfig(template.auth, template.config);
         setCodexChatReasoning({});
         setPromptCacheRouting("auto");
@@ -1700,7 +1750,7 @@ function ProviderFormFull({
       partnerPromotionKey: entry.preset.partnerPromotionKey,
     });
 
-    if (appId === "codex") {
+    if (isCodexLike) {
       const preset = entry.preset as CodexProviderPreset;
       const auth = preset.auth ?? {};
       const config = preset.config ?? "";
@@ -2164,8 +2214,9 @@ function ProviderFormFull({
             />
           )}
 
-          {appId === "codex" && (
+          {isCodexLike && (
             <CodexFormFields
+              appId={appId === "grok" ? "grok" : "codex"}
               providerId={providerId}
               codexApiKey={codexApiKey}
               onApiKeyChange={handleCodexApiKeyChange}
@@ -2196,12 +2247,18 @@ function ProviderFormFull({
               onImpersonateClaudeCodeChange={setLocalCodexImpersonateClaudeCode}
               maxOutputTokens={localCodexMaxOutputTokens}
               onMaxOutputTokensChange={setLocalCodexMaxOutputTokens}
-              codexChatReasoning={codexChatReasoning}
-              onCodexChatReasoningChange={setCodexChatReasoning}
+              codexChatReasoning={
+                appId === "codex" ? codexChatReasoning : undefined
+              }
+              onCodexChatReasoningChange={
+                appId === "codex" ? setCodexChatReasoning : undefined
+              }
               promptCacheRouting={promptCacheRouting}
               onPromptCacheRoutingChange={setPromptCacheRouting}
-              catalogModels={codexCatalogModels}
-              onCatalogModelsChange={setCodexCatalogModels}
+              catalogModels={appId === "codex" ? codexCatalogModels : []}
+              onCatalogModelsChange={
+                appId === "codex" ? setCodexCatalogModels : undefined
+              }
               speedTestEndpoints={speedTestEndpoints}
               customUserAgent={customUserAgent}
               onCustomUserAgentChange={setCustomUserAgent}
@@ -2330,9 +2387,11 @@ function ProviderFormFull({
           )}
 
           {/* 配置编辑器：Codex、Claude、Gemini 分别使用不同的编辑器 */}
-          {appId === "codex" ? (
+          {isCodexLike ? (
             <>
               <CodexConfigEditor
+                appId={appId === "grok" ? "grok" : "codex"}
+                showCodexFeatures={appId === "codex"}
                 authValue={codexAuth}
                 configValue={codexConfig}
                 providerName={form.watch("name")}

--- a/src/components/providers/forms/hooks/useCodexCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useCodexCommonConfig.ts
@@ -31,6 +31,7 @@ const DEFAULT_CODEX_COMMON_CONFIG_SNIPPET = `# Common Codex config
 # Add your common TOML configuration here`;
 
 interface UseCodexCommonConfigProps {
+  enabled?: boolean;
   codexConfig: string;
   onConfigChange: (config: string) => void;
   initialData?: {
@@ -45,6 +46,7 @@ interface UseCodexCommonConfigProps {
  * 从 config.json 读取和保存，支持从 localStorage 平滑迁移
  */
 export function useCodexCommonConfig({
+  enabled = true,
   codexConfig,
   onConfigChange,
   initialData,
@@ -119,6 +121,11 @@ export function useCodexCommonConfig({
 
   // 初始化：从 config.json 加载，支持从 localStorage 迁移
   useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
+
     let mounted = true;
 
     const loadSnippet = async () => {
@@ -167,11 +174,12 @@ export function useCodexCommonConfig({
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [enabled]);
 
   // 初始化时检查通用配置片段（编辑模式）
   useEffect(() => {
     if (
+      !enabled ||
       !initialData?.settingsConfig ||
       isLoading ||
       hasInitializedEditMode.current
@@ -241,6 +249,7 @@ export function useCodexCommonConfig({
   }, [
     codexConfig,
     commonConfigSnippet,
+    enabled,
     initialData,
     initialEnabled,
     isLoading,
@@ -251,7 +260,7 @@ export function useCodexCommonConfig({
 
   // 新建模式：如果通用配置片段存在且有效，默认启用
   useEffect(() => {
-    if (initialData || isLoading || hasInitializedNewMode.current) {
+    if (!enabled || initialData || isLoading || hasInitializedNewMode.current) {
       return;
     }
 
@@ -303,6 +312,7 @@ export function useCodexCommonConfig({
     isLoading,
     isTomlOpStale,
     codexConfig,
+    enabled,
     onConfigChange,
     parseCommonConfigSnippet,
   ]);
@@ -310,6 +320,8 @@ export function useCodexCommonConfig({
   // 处理通用配置开关
   const handleCommonConfigToggle = useCallback(
     async (checked: boolean) => {
+      if (!enabled) return;
+
       // 在同步校验之前领号：即使本次走同步早退分支，也要让更早发出、
       // 仍在飞的异步结果作废，避免它晚到后把开关翻回去。
       const seq = ++tomlOpSeqRef.current;
@@ -358,6 +370,7 @@ export function useCodexCommonConfig({
       codexConfig,
       commonConfigSnippet,
       isTomlOpStale,
+      enabled,
       onConfigChange,
       parseCommonConfigSnippet,
       t,
@@ -367,6 +380,8 @@ export function useCodexCommonConfig({
   // 处理通用配置片段变化
   const handleCommonConfigSnippetChange = useCallback(
     async (value: string): Promise<boolean> => {
+      if (!enabled) return false;
+
       // 与 handleCommonConfigToggle 同一套序号：连续保存或保存与开关
       // 交错时，只允许最后一次操作的结果落地。
       const seq = ++tomlOpSeqRef.current;
@@ -475,6 +490,7 @@ export function useCodexCommonConfig({
       commonConfigSnippet,
       codexConfig,
       isTomlOpStale,
+      enabled,
       onConfigChange,
       parseCommonConfigSnippet,
       t,
@@ -484,7 +500,7 @@ export function useCodexCommonConfig({
 
   // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）
   useEffect(() => {
-    if (isUpdatingFromCommonConfig.current || isLoading) {
+    if (!enabled || isUpdatingFromCommonConfig.current || isLoading) {
       return;
     }
     const parsedSnippet = parseCommonConfigSnippet(commonConfigSnippet);
@@ -497,10 +513,18 @@ export function useCodexCommonConfig({
       commonConfigSnippet,
     );
     setUseCommonConfig(hasCommon);
-  }, [codexConfig, commonConfigSnippet, isLoading, parseCommonConfigSnippet]);
+  }, [
+    codexConfig,
+    commonConfigSnippet,
+    enabled,
+    isLoading,
+    parseCommonConfigSnippet,
+  ]);
 
   // 从编辑器当前内容提取通用配置片段
   const handleExtract = useCallback(async () => {
+    if (!enabled) return;
+
     setIsExtracting(true);
     setCommonConfigError("");
 
@@ -529,7 +553,7 @@ export function useCodexCommonConfig({
     } finally {
       setIsExtracting(false);
     }
-  }, [codexConfig, t]);
+  }, [codexConfig, enabled, t]);
 
   const clearCommonConfigError = useCallback(() => {
     setCommonConfigError("");

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -8,9 +8,11 @@ import {
   updateCodexExperimentalBearerToken,
 } from "@/utils/providerConfigUtils";
 import { normalizeTomlText } from "@/utils/textNormalization";
+import { extractGrokBaseUrl, setGrokBaseUrl } from "@/utils/grokConfigUtils";
 import type { CodexCatalogModel } from "@/types";
 
 interface UseCodexConfigStateProps {
+  appId?: "codex" | "grok";
   initialData?: {
     settingsConfig?: Record<string, unknown>;
   };
@@ -33,7 +35,10 @@ function pickCodexApiKey(
  * 管理 Codex 配置状态
  * Codex 配置包含两部分：auth.json (JSON) 和 config.toml (TOML 字符串)
  */
-export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
+export function useCodexConfigState({
+  appId = "codex",
+  initialData,
+}: UseCodexConfigStateProps) {
   const [codexAuth, setCodexAuthState] = useState("");
   const [codexConfig, setCodexConfigState] = useState("");
   const [codexApiKey, setCodexApiKey] = useState("");
@@ -119,23 +124,29 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       );
 
       // 提取 Base URL
-      const initialBaseUrl = extractCodexBaseUrl(configStr);
+      const initialBaseUrl =
+        appId === "grok"
+          ? extractGrokBaseUrl(configStr)
+          : extractCodexBaseUrl(configStr);
       if (initialBaseUrl) {
         setCodexBaseUrl(initialBaseUrl);
       }
 
       setCodexApiKey(pickCodexApiKey(auth, configStr));
     }
-  }, [initialData]);
+  }, [appId, initialData]);
 
   // 与 TOML 配置保持基础 URL 同步
   useEffect(() => {
     if (isUpdatingCodexBaseUrlRef.current) {
       return;
     }
-    const extracted = extractCodexBaseUrl(codexConfig) || "";
+    const extracted =
+      (appId === "grok"
+        ? extractGrokBaseUrl(codexConfig)
+        : extractCodexBaseUrl(codexConfig)) || "";
     setCodexBaseUrl((prev) => (prev === extracted ? prev : extracted));
-  }, [codexConfig]);
+  }, [appId, codexConfig]);
 
   // 与 TOML 配置保持默认模型同步（顶层 model 键）
   useEffect(() => {
@@ -217,11 +228,13 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       } catch {
         // ignore
       }
-      setCodexConfig((prev) =>
-        updateCodexExperimentalBearerToken(prev, trimmed),
-      );
+      if (appId === "codex") {
+        setCodexConfig((prev) =>
+          updateCodexExperimentalBearerToken(prev, trimmed),
+        );
+      }
     },
-    [codexAuth, setCodexAuth, setCodexConfig],
+    [appId, codexAuth, setCodexAuth, setCodexConfig],
   );
 
   // 处理 Codex Base URL 变化
@@ -231,12 +244,16 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       setCodexBaseUrl(sanitized);
 
       isUpdatingCodexBaseUrlRef.current = true;
-      setCodexConfig((prev) => setCodexBaseUrlInConfig(prev, sanitized));
+      setCodexConfig((prev) =>
+        appId === "grok"
+          ? setGrokBaseUrl(prev, sanitized)
+          : setCodexBaseUrlInConfig(prev, sanitized),
+      );
       setTimeout(() => {
         isUpdatingCodexBaseUrlRef.current = false;
       }, 0);
     },
-    [setCodexConfig],
+    [appId, setCodexConfig],
   );
 
   // 处理默认模型变化（写回 TOML 顶层 model；清空则删掉该行，交回 Codex 内置默认）
@@ -263,13 +280,16 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       setCodexConfig(normalized);
 
       if (!isUpdatingCodexBaseUrlRef.current) {
-        const extracted = extractCodexBaseUrl(normalized) || "";
+        const extracted =
+          (appId === "grok"
+            ? extractGrokBaseUrl(normalized)
+            : extractCodexBaseUrl(normalized)) || "";
         if (extracted !== codexBaseUrl) {
           setCodexBaseUrl(extracted);
         }
       }
     },
-    [setCodexConfig, codexBaseUrl],
+    [appId, setCodexConfig, codexBaseUrl],
   );
 
   // 重置配置（用于预设切换）
@@ -284,12 +304,15 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       setCodexConfig(config);
       setCodexCatalogModels(modelCatalogModels);
 
-      const baseUrl = extractCodexBaseUrl(config);
+      const baseUrl =
+        appId === "grok"
+          ? extractGrokBaseUrl(config)
+          : extractCodexBaseUrl(config);
       setCodexBaseUrl(baseUrl || "");
 
       setCodexApiKey(pickCodexApiKey(auth, config));
     },
-    [setCodexAuth, setCodexConfig, setCodexCatalogModels],
+    [appId, setCodexAuth, setCodexConfig, setCodexCatalogModels],
   );
 
   return {

--- a/src/components/providers/forms/hooks/useProviderCategory.ts
+++ b/src/components/providers/forms/hooks/useProviderCategory.ts
@@ -7,6 +7,7 @@ import { geminiProviderPresets } from "@/config/geminiProviderPresets";
 import { opencodeProviderPresets } from "@/config/opencodeProviderPresets";
 import { openclawProviderPresets } from "@/config/openclawProviderPresets";
 import { hermesProviderPresets } from "@/config/hermesProviderPresets";
+import { grokProviderPresets } from "@/config/grokProviderPresets";
 
 interface UseProviderCategoryProps {
   appId: AppId;
@@ -46,7 +47,7 @@ export function useProviderCategory({
 
     // 从预设 ID 提取索引
     const match = selectedPresetId.match(
-      /^(claude|codex|gemini|opencode|openclaw|hermes)-(\d+)$/,
+      /^(claude|codex|gemini|opencode|openclaw|hermes|grok)-(\d+)$/,
     );
     if (!match) return;
 
@@ -59,6 +60,11 @@ export function useProviderCategory({
         setCategory(
           preset.category || (preset.isOfficial ? "official" : undefined),
         );
+      }
+    } else if (type === "grok" && appId === "grok") {
+      const preset = grokProviderPresets[index];
+      if (preset) {
+        setCategory(preset.category || undefined);
       }
     } else if (type === "claude" && appId === "claude") {
       const preset = providerPresets[index];

--- a/src/components/proxy/FailoverToggle.tsx
+++ b/src/components/proxy/FailoverToggle.tsx
@@ -38,7 +38,9 @@ export function FailoverToggle({ className, activeApp }: FailoverToggleProps) {
       ? "Claude"
       : activeApp === "codex"
         ? "Codex"
-        : "Gemini";
+        : activeApp === "grok"
+          ? "Grok Build"
+          : "Gemini";
 
   const tooltipText = !takeoverEnabled
     ? t("failover.tooltip.takeoverRequired", {

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -272,30 +272,32 @@ export function ProxyPanel({
                     defaultValue: "应用接管",
                   })}
                 </p>
-                <div className="grid gap-2 sm:grid-cols-3">
-                  {(["claude", "codex", "gemini"] as const).map((appType) => {
-                    const isEnabled =
-                      takeoverStatus?.[
-                        appType as keyof typeof takeoverStatus
-                      ] ?? false;
-                    return (
-                      <div
-                        key={appType}
-                        className="flex items-center justify-between rounded-md border border-primary/20 bg-background/60 px-3 py-2"
-                      >
-                        <span className="text-sm font-medium capitalize">
-                          {appType}
-                        </span>
-                        <Switch
-                          checked={isEnabled}
-                          onCheckedChange={(checked) =>
-                            handleTakeoverChange(appType, checked)
-                          }
-                          disabled={setTakeoverForApp.isPending}
-                        />
-                      </div>
-                    );
-                  })}
+                <div className="grid gap-2 sm:grid-cols-4">
+                  {(["claude", "codex", "gemini", "grok"] as const).map(
+                    (appType) => {
+                      const isEnabled =
+                        takeoverStatus?.[
+                          appType as keyof typeof takeoverStatus
+                        ] ?? false;
+                      return (
+                        <div
+                          key={appType}
+                          className="flex items-center justify-between rounded-md border border-primary/20 bg-background/60 px-3 py-2"
+                        >
+                          <span className="text-sm font-medium">
+                            {appType === "grok" ? "Grok Build" : appType}
+                          </span>
+                          <Switch
+                            checked={isEnabled}
+                            onCheckedChange={(checked) =>
+                              handleTakeoverChange(appType, checked)
+                            }
+                            disabled={setTakeoverForApp.isPending}
+                          />
+                        </div>
+                      );
+                    },
+                  )}
                 </div>
                 <p className="text-xs text-muted-foreground">
                   {t("proxy.takeover.hint", {

--- a/src/components/proxy/ProxyToggle.tsx
+++ b/src/components/proxy/ProxyToggle.tsx
@@ -39,7 +39,9 @@ export function ProxyToggle({ className, activeApp }: ProxyToggleProps) {
         ? "Codex"
         : activeApp === "gemini"
           ? "Gemini"
-          : "OpenCode";
+          : activeApp === "grok"
+            ? "Grok Build"
+            : "OpenCode";
 
   const tooltipText = takeoverEnabled
     ? isRunning

--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -29,6 +29,7 @@ const APP_CONFIG: Array<{
   { id: "opencode", icon: "opencode", nameKey: "apps.opencode" },
   { id: "openclaw", icon: "openclaw", nameKey: "apps.openclaw" },
   { id: "hermes", icon: "hermes", nameKey: "apps.hermes" },
+  { id: "grok", icon: "xai", nameKey: "apps.grok" },
 ];
 
 export function AppVisibilitySettings({
@@ -45,6 +46,7 @@ export function AppVisibilitySettings({
     opencode: true,
     openclaw: true,
     hermes: true,
+    grok: true,
   };
 
   // Count how many apps are currently visible

--- a/src/components/settings/DirectorySettings.tsx
+++ b/src/components/settings/DirectorySettings.tsx
@@ -20,6 +20,7 @@ interface DirectorySettingsProps {
   opencodeDir?: string;
   openclawDir?: string;
   hermesDir?: string;
+  grokDir?: string;
   onDirectoryChange: (app: DirectoryAppId, value?: string) => void;
   onBrowseDirectory: (app: DirectoryAppId) => Promise<void>;
   onResetDirectory: (app: DirectoryAppId) => Promise<void>;
@@ -37,6 +38,7 @@ export function DirectorySettings({
   opencodeDir,
   openclawDir,
   hermesDir,
+  grokDir,
   onDirectoryChange,
   onBrowseDirectory,
   onResetDirectory,
@@ -157,6 +159,21 @@ export function DirectorySettings({
           onChange={(val) => onDirectoryChange("hermes", val)}
           onBrowse={() => onBrowseDirectory("hermes")}
           onReset={() => onResetDirectory("hermes")}
+        />
+
+        <DirectoryInput
+          label={t("settings.grokConfigDir", {
+            defaultValue: "Grok Build 配置目录",
+          })}
+          description={undefined}
+          value={grokDir}
+          resolvedValue={resolvedDirs.grok}
+          placeholder={t("settings.browsePlaceholderGrok", {
+            defaultValue: "选择 .grok 目录",
+          })}
+          onChange={(val) => onDirectoryChange("grok", val)}
+          onBrowse={() => onBrowseDirectory("grok")}
+          onReset={() => onResetDirectory("grok")}
         />
       </section>
     </div>

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -172,43 +172,46 @@ export function ProxyTabContent({
               )}
 
               <Tabs defaultValue="claude" className="w-full">
-                <TabsList className="grid w-full grid-cols-3">
+                <TabsList className="grid w-full grid-cols-4">
                   <TabsTrigger value="claude">Claude</TabsTrigger>
                   <TabsTrigger value="codex">Codex</TabsTrigger>
                   <TabsTrigger value="gemini">Gemini</TabsTrigger>
+                  <TabsTrigger value="grok">Grok Build</TabsTrigger>
                 </TabsList>
-                {(["claude", "codex", "gemini"] as const).map((appType) => {
-                  const failoverDisabled =
-                    !isRunning || !(takeoverStatus?.[appType] ?? false);
-                  return (
-                    <TabsContent
-                      key={appType}
-                      value={appType}
-                      className="mt-4 space-y-6"
-                    >
-                      <div className="space-y-4">
-                        <div>
-                          <h4 className="text-sm font-semibold">
-                            {t("proxy.failoverQueue.title")}
-                          </h4>
-                          <p className="text-xs text-muted-foreground">
-                            {t("proxy.failoverQueue.description")}
-                          </p>
+                {(["claude", "codex", "gemini", "grok"] as const).map(
+                  (appType) => {
+                    const failoverDisabled =
+                      !isRunning || !(takeoverStatus?.[appType] ?? false);
+                    return (
+                      <TabsContent
+                        key={appType}
+                        value={appType}
+                        className="mt-4 space-y-6"
+                      >
+                        <div className="space-y-4">
+                          <div>
+                            <h4 className="text-sm font-semibold">
+                              {t("proxy.failoverQueue.title")}
+                            </h4>
+                            <p className="text-xs text-muted-foreground">
+                              {t("proxy.failoverQueue.description")}
+                            </p>
+                          </div>
+                          <FailoverQueueManager
+                            appType={appType}
+                            disabled={failoverDisabled}
+                          />
                         </div>
-                        <FailoverQueueManager
-                          appType={appType}
-                          disabled={failoverDisabled}
-                        />
-                      </div>
-                      <div className="border-t border-border/50 pt-6">
-                        <AutoFailoverConfigPanel
-                          appType={appType}
-                          disabled={failoverDisabled}
-                        />
-                      </div>
-                    </TabsContent>
-                  );
-                })}
+                        <div className="border-t border-border/50 pt-6">
+                          <AutoFailoverConfigPanel
+                            appType={appType}
+                            disabled={failoverDisabled}
+                          />
+                        </div>
+                      </TabsContent>
+                    );
+                  },
+                )}
               </Tabs>
             </div>
           </AccordionContent>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -355,6 +355,7 @@ export function SettingsPage({
                             opencodeDir={settings.opencodeConfigDir}
                             openclawDir={settings.openclawConfigDir}
                             hermesDir={settings.hermesConfigDir}
+                            grokDir={settings.grokConfigDir}
                             onDirectoryChange={updateDirectory}
                             onBrowseDirectory={browseDirectory}
                             onResetDirectory={resetDirectory}

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -122,6 +122,7 @@ const UnifiedSkillsPanel = React.forwardRef<
       opencode: 0,
       openclaw: 0,
       hermes: 0,
+      grok: 0,
     };
     if (!skills) return counts;
     skills.forEach((skill) => {

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -23,6 +23,7 @@ export const APP_IDS: AppId[] = [
   "opencode",
   "openclaw",
   "hermes",
+  "grok",
 ];
 
 /** App IDs shown in Skills panels (excludes OpenClaw — it doesn't support Skills) */
@@ -107,5 +108,20 @@ export const APP_ICON_MAP: Record<AppId, AppConfig> = {
       "bg-violet-500/10 ring-1 ring-violet-500/20 hover:bg-violet-500/20 text-violet-600 dark:text-violet-400",
     badgeClass:
       "bg-violet-500/10 text-violet-700 dark:text-violet-300 hover:bg-violet-500/20 border-0 gap-1.5",
+  },
+  grok: {
+    label: "Grok Build",
+    icon: (
+      <ProviderIcon
+        icon="xai"
+        name="Grok Build"
+        size={14}
+        showFallback={false}
+      />
+    ),
+    activeClass:
+      "bg-slate-500/10 ring-1 ring-slate-500/20 hover:bg-slate-500/20 text-slate-700 dark:text-slate-300",
+    badgeClass:
+      "bg-slate-500/10 text-slate-700 dark:text-slate-300 hover:bg-slate-500/20 border-0 gap-1.5",
   },
 };

--- a/src/config/grokProviderPresets.ts
+++ b/src/config/grokProviderPresets.ts
@@ -1,0 +1,82 @@
+import {
+  generateThirdPartyAuth,
+  type CodexProviderPreset,
+} from "./codexProviderPresets";
+
+const quote = (value: string) => JSON.stringify(value);
+
+export function generateGrokProfileConfig(
+  baseUrl: string,
+  model = "grok-4.5",
+  backend: "responses" | "chat_completions" = "responses",
+): string {
+  return `[endpoints]
+models_base_url = ${quote(baseUrl)}
+
+[models]
+default = ${quote(model)}
+web_search = ${quote(model)}
+
+[subagents]
+default_model = ${quote(model)}
+
+[model.${quote(model)}]
+model = ${quote(model)}
+base_url = ${quote(baseUrl)}
+api_backend = ${quote(backend)}
+supports_backend_search = true
+context_window = 500000
+`;
+}
+
+/** Grok Build Profile 预设；TOML 结构与 Grok Build 原生配置一致。 */
+export const grokProviderPresets: CodexProviderPreset[] = [
+  {
+    name: "Grok 官方账号 (OAuth)",
+    websiteUrl: "https://grok.com",
+    auth: {},
+    config: "",
+    isOfficial: true,
+    category: "official",
+    icon: "xai",
+  },
+  {
+    name: "xAI API (Responses)",
+    websiteUrl: "https://x.ai/api",
+    apiKeyUrl: "https://console.x.ai",
+    auth: generateThirdPartyAuth(""),
+    config: generateGrokProfileConfig(
+      "https://api.x.ai/v1",
+      "grok-4.5",
+      "responses",
+    ),
+    endpointCandidates: ["https://api.x.ai/v1"],
+    apiFormat: "openai_responses",
+    category: "third_party",
+    icon: "xai",
+  },
+  {
+    name: "OpenAI 兼容接口",
+    websiteUrl: "",
+    auth: generateThirdPartyAuth(""),
+    config: generateGrokProfileConfig(
+      "https://api.example.com/v1",
+      "grok-model",
+      "chat_completions",
+    ),
+    apiFormat: "openai_chat",
+    category: "third_party",
+    icon: "xai",
+  },
+];
+
+export function getGrokCustomTemplate() {
+  return {
+    auth: generateThirdPartyAuth(""),
+    config: generateGrokProfileConfig(
+      "https://api.x.ai/v1",
+      "grok-4.5",
+      "responses",
+    ),
+  };
+}

--- a/src/hooks/useDirectorySettings.ts
+++ b/src/hooks/useDirectorySettings.ts
@@ -12,7 +12,8 @@ type AppDirectoryKey =
   | "gemini"
   | "opencode"
   | "openclaw"
-  | "hermes";
+  | "hermes"
+  | "grok";
 type DirectoryKey = "appConfig" | AppDirectoryKey;
 
 export interface ResolvedDirectories {
@@ -23,6 +24,7 @@ export interface ResolvedDirectories {
   opencode: string;
   openclaw: string;
   hermes: string;
+  grok: string;
 }
 
 // Single source of truth for per-app directory metadata.
@@ -36,6 +38,7 @@ const APP_DIRECTORY_META: Record<
   opencode: { key: "opencode", defaultFolder: ".config/opencode" },
   openclaw: { key: "openclaw", defaultFolder: ".openclaw" },
   hermes: { key: "hermes", defaultFolder: ".hermes" },
+  grok: { key: "grok", defaultFolder: ".grok" },
 };
 
 const DIRECTORY_KEY_TO_SETTINGS_FIELD: Record<
@@ -48,6 +51,7 @@ const DIRECTORY_KEY_TO_SETTINGS_FIELD: Record<
   opencode: "opencodeConfigDir",
   openclaw: "openclawConfigDir",
   hermes: "hermesConfigDir",
+  grok: "grokConfigDir",
 };
 
 const sanitizeDir = (value?: string | null): string | undefined => {
@@ -133,6 +137,7 @@ export function useDirectorySettings({
     opencode: "",
     openclaw: "",
     hermes: "",
+    grok: "",
   });
   const [isLoading, setIsLoading] = useState(true);
 
@@ -144,6 +149,7 @@ export function useDirectorySettings({
     opencode: "",
     openclaw: "",
     hermes: "",
+    grok: "",
   });
   const initialAppConfigDirRef = useRef<string | undefined>(undefined);
 
@@ -162,6 +168,7 @@ export function useDirectorySettings({
           opencodeDir,
           openclawDir,
           hermesDir,
+          grokDir,
           defaultAppConfig,
           defaultClaudeDir,
           defaultCodexDir,
@@ -169,6 +176,7 @@ export function useDirectorySettings({
           defaultOpencodeDir,
           defaultOpenclawDir,
           defaultHermesDir,
+          defaultGrokDir,
         ] = await Promise.all([
           settingsApi.getAppConfigDirOverride(),
           settingsApi.getConfigDir("claude"),
@@ -177,6 +185,7 @@ export function useDirectorySettings({
           settingsApi.getConfigDir("opencode"),
           settingsApi.getConfigDir("openclaw"),
           settingsApi.getConfigDir("hermes"),
+          settingsApi.getConfigDir("grok"),
           computeDefaultAppConfigDir(),
           computeDefaultConfigDir("claude"),
           computeDefaultConfigDir("codex"),
@@ -184,6 +193,7 @@ export function useDirectorySettings({
           computeDefaultConfigDir("opencode"),
           computeDefaultConfigDir("openclaw"),
           computeDefaultConfigDir("hermes"),
+          computeDefaultConfigDir("grok"),
         ]);
 
         if (!active) return;
@@ -198,6 +208,7 @@ export function useDirectorySettings({
           opencode: defaultOpencodeDir ?? "",
           openclaw: defaultOpenclawDir ?? "",
           hermes: defaultHermesDir ?? "",
+          grok: defaultGrokDir ?? "",
         };
 
         setAppConfigDir(normalizedOverride);
@@ -211,6 +222,7 @@ export function useDirectorySettings({
           opencode: opencodeDir || defaultsRef.current.opencode,
           openclaw: openclawDir || defaultsRef.current.openclaw,
           hermes: hermesDir || defaultsRef.current.hermes,
+          grok: grokDir || defaultsRef.current.grok,
         });
       } catch (error) {
         console.error(
@@ -352,6 +364,7 @@ export function useDirectorySettings({
         opencode: overrides?.opencode ?? defaultsRef.current.opencode,
         openclaw: overrides?.openclaw ?? defaultsRef.current.openclaw,
         hermes: overrides?.hermes ?? defaultsRef.current.hermes,
+        grok: overrides?.grok ?? defaultsRef.current.grok,
       });
     },
     [],

--- a/src/hooks/useProxyStatus.ts
+++ b/src/hooks/useProxyStatus.ts
@@ -132,7 +132,9 @@ export function useProxyStatus() {
             ? "Codex"
             : variables.appType === "gemini"
               ? "Gemini"
-              : "OpenCode";
+              : variables.appType === "grok"
+                ? "Grok Build"
+                : "OpenCode";
 
       toast.success(
         variables.enabled

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -113,6 +113,7 @@ export function useSettings(): UseSettingsResult {
       opencode: sanitizeDir(data?.opencodeConfigDir),
       openclaw: sanitizeDir(data?.openclawConfigDir),
       hermes: sanitizeDir(data?.hermesConfigDir),
+      grok: sanitizeDir(data?.grokConfigDir),
     });
     setRequiresRestart(false);
   }, [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -876,7 +876,8 @@
     "gemini": "Gemini",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "grok": "Grok Build"
   },
   "sessionManager": {
     "title": "Session Manager",
@@ -1246,6 +1247,24 @@
     "pricingModelSourceRequest": "Request model",
     "pricingModelSourceResponse": "Response model",
     "pricingModelSourceHint": "Choose whether to match pricing by request model or response model"
+  },
+  "grokConfig": {
+    "authJson": "Grok API Key (JSON) *",
+    "authJsonPlaceholder": "{\n  \"OPENAI_API_KEY\": \"xai-your-api-key\"\n}",
+    "authJsonHint": "Shared provider API key; each [model.*] may also define api_key or env_key",
+    "profileToml": "Grok Profile (TOML)",
+    "profileTomlHint": "Manages endpoints, models, subagents and model.* while preserving other global Grok settings",
+    "defaultModelPlaceholder": "e.g. grok-4.5",
+    "defaultModelHint": "The model used by Grok Build by default. Change it anytime, or leave it blank to preserve the current Profile default.",
+    "advancedSectionHint": "Includes the native Grok API backend, User-Agent and local proxy request overrides.",
+    "editGlobalConfig": "Edit Grok Global Config",
+    "addToGlobalConfig": "Add to Global Config",
+    "addedToGlobalConfig": "The current Grok Profile was added to the global config",
+    "globalConfigTitle": "Grok Build global config.toml",
+    "globalConfigHint": "Edits the live local config. Provider switches only replace endpoints, models, subagents and model.*; other settings are preserved and every save is backed up.",
+    "globalConfigSaved": "Grok global config saved",
+    "applyPrivacy": "Apply Privacy Protection",
+    "privacyApplied": "Privacy protection settings applied"
   },
   "codexConfig": {
     "authJson": "auth.json (JSON) *",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -876,7 +876,8 @@
     "gemini": "Gemini",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "grok": "Grok Build"
   },
   "sessionManager": {
     "title": "セッション管理",
@@ -1246,6 +1247,24 @@
     "pricingModelSourceRequest": "リクエストモデル",
     "pricingModelSourceResponse": "レスポンスモデル",
     "pricingModelSourceHint": "リクエストモデルまたはレスポンスモデルで価格を照合するかを選択"
+  },
+  "grokConfig": {
+    "authJson": "Grok API Key (JSON) *",
+    "authJsonPlaceholder": "{\n  \"OPENAI_API_KEY\": \"xai-your-api-key\"\n}",
+    "authJsonHint": "プロバイダー共通 API Key。各 [model.*] に api_key または env_key も設定できます",
+    "profileToml": "Grok Profile (TOML)",
+    "profileTomlHint": "endpoints、models、subagents、model.* を管理し、その他の Grok グローバル設定は保持します",
+    "defaultModelPlaceholder": "例: grok-4.5",
+    "defaultModelHint": "Grok Build がデフォルトで使用するモデルです。いつでも変更でき、空欄の場合は現在の Profile のデフォルトを保持します。",
+    "advancedSectionHint": "Grok ネイティブ API Backend、User-Agent、ローカルプロキシ上書きを含みます。",
+    "editGlobalConfig": "Grok グローバル設定を編集",
+    "addToGlobalConfig": "グローバル設定に追加",
+    "addedToGlobalConfig": "現在の Grok Profile をグローバル設定に追加しました",
+    "globalConfigTitle": "Grok Build グローバル config.toml",
+    "globalConfigHint": "ローカルの実設定を編集します。プロバイダー切替では endpoints、models、subagents、model.* のみ置換し、その他の設定は保持され、保存時に自動バックアップされます。",
+    "globalConfigSaved": "Grok グローバル設定を保存しました",
+    "applyPrivacy": "プライバシー保護を適用",
+    "privacyApplied": "プライバシー保護設定を適用しました"
   },
   "codexConfig": {
     "authJson": "auth.json (JSON) *",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -847,7 +847,8 @@
     "gemini": "Gemini",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "grok": "Grok Build"
   },
   "sessionManager": {
     "title": "工作階段管理",
@@ -1218,6 +1219,24 @@
     "pricingModelSourceRequest": "請求模型",
     "pricingModelSourceResponse": "回傳模型",
     "pricingModelSourceHint": "選擇依請求模型還是回傳模型進行定價比對"
+  },
+  "grokConfig": {
+    "authJson": "Grok API Key (JSON) *",
+    "authJsonPlaceholder": "{\n  \"OPENAI_API_KEY\": \"xai-your-api-key\"\n}",
+    "authJsonHint": "供應商共用 API Key；每個 [model.*] 也可獨立設定 api_key 或 env_key",
+    "profileToml": "Grok Profile (TOML)",
+    "profileTomlHint": "管理 endpoints、models、subagents 和 model.*；切換時保留其他 Grok 全域設定",
+    "defaultModelPlaceholder": "例如: grok-4.5",
+    "defaultModelHint": "Grok Build 預設使用的模型，可隨時修改。留空時保留目前 Profile 的預設模型。",
+    "advancedSectionHint": "包含 Grok 原生 API Backend、User-Agent 與本機代理請求覆寫。",
+    "editGlobalConfig": "編輯 Grok 全域設定",
+    "addToGlobalConfig": "加入全域設定",
+    "addedToGlobalConfig": "目前 Grok Profile 已加入全域設定",
+    "globalConfigTitle": "Grok Build 全域 config.toml",
+    "globalConfigHint": "這裡編輯本機實際設定。供應商切換只替換 endpoints、models、subagents 與 model.*，其他設定會保留；每次儲存都會自動備份。",
+    "globalConfigSaved": "Grok 全域設定已儲存",
+    "applyPrivacy": "套用隱私保護",
+    "privacyApplied": "隱私保護設定已寫入"
   },
   "codexConfig": {
     "authJson": "auth.json (JSON) *",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -876,7 +876,8 @@
     "gemini": "Gemini",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "grok": "Grok Build"
   },
   "sessionManager": {
     "title": "会话管理",
@@ -1246,6 +1247,24 @@
     "pricingModelSourceRequest": "请求模型",
     "pricingModelSourceResponse": "返回模型",
     "pricingModelSourceHint": "选择按请求模型还是返回模型进行定价匹配"
+  },
+  "grokConfig": {
+    "authJson": "Grok API Key (JSON) *",
+    "authJsonPlaceholder": "{\n  \"OPENAI_API_KEY\": \"xai-your-api-key\"\n}",
+    "authJsonHint": "供应商共享 API Key；每个 [model.*] 也可单独设置 api_key 或 env_key",
+    "profileToml": "Grok Profile (TOML)",
+    "profileTomlHint": "管理 endpoints、models、subagents 和 model.*；切换时保留其它 Grok 全局配置",
+    "defaultModelPlaceholder": "例如: grok-4.5",
+    "defaultModelHint": "Grok Build 默认使用的模型，可随时修改。留空时保留当前 Profile 的默认模型。",
+    "advancedSectionHint": "包含 Grok 原生 API Backend、User-Agent 与本地代理请求覆盖。",
+    "editGlobalConfig": "编辑 Grok 全局配置",
+    "addToGlobalConfig": "加入全局配置",
+    "addedToGlobalConfig": "当前 Grok Profile 已加入全局配置",
+    "globalConfigTitle": "Grok Build 全局 config.toml",
+    "globalConfigHint": "这里编辑本机实际配置。供应商切换只替换 endpoints、models、subagents 与 model.*，其它设置会保留；每次保存都会自动备份。",
+    "globalConfigSaved": "Grok 全局配置已保存",
+    "applyPrivacy": "应用隐私保护",
+    "privacyApplied": "隐私保护配置已写入"
   },
   "codexConfig": {
     "authJson": "auth.json (JSON) *",

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -3,6 +3,30 @@ import { invoke } from "@tauri-apps/api/core";
 
 export type AppType = "claude" | "codex" | "gemini" | "omo" | "omo_slim";
 
+export interface GrokGlobalConfig {
+  path: string;
+  content: string;
+  exists: boolean;
+}
+
+export async function readGrokGlobalConfig(): Promise<GrokGlobalConfig> {
+  return invoke<GrokGlobalConfig>("read_grok_global_config");
+}
+
+export async function writeGrokGlobalConfig(content: string): Promise<void> {
+  return invoke("write_grok_global_config", { content });
+}
+
+export async function mergeGrokProfileIntoGlobalConfig(
+  profileContent: string,
+): Promise<void> {
+  return invoke("merge_grok_profile_into_global_config", { profileContent });
+}
+
+export async function applyGrokPrivacyProtection(): Promise<string> {
+  return invoke<string>("apply_grok_privacy_protection");
+}
+
 /**
  * 获取 Claude 通用配置片段（已废弃，使用 getCommonConfigSnippet）
  * @returns 通用配置片段（JSON 字符串），如果不存在则返回 null

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -9,7 +9,8 @@ export type AppType =
   | "gemini"
   | "opencode"
   | "openclaw"
-  | "hermes";
+  | "hermes"
+  | "grok";
 
 /** Skill 应用启用状态 */
 export interface SkillApps {
@@ -20,6 +21,7 @@ export interface SkillApps {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  grok?: boolean;
 }
 
 /** 已安装的 Skill（v3.10.0+ 统一结构） */

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -6,4 +6,5 @@ export type AppId =
   | "gemini"
   | "opencode"
   | "openclaw"
-  | "hermes";
+  | "hermes"
+  | "grok";

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,6 +283,7 @@ export interface VisibleApps {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  grok: boolean;
 }
 
 // WebDAV 同步状态
@@ -400,6 +401,8 @@ export interface Settings {
   openclawConfigDir?: string;
   // 覆盖 Hermes 配置目录（可选）
   hermesConfigDir?: string;
+  // 覆盖 Grok Build 配置目录（可选）
+  grokConfigDir?: string;
 
   // ===== 当前供应商 ID（设备级）=====
   // 当前 Claude 供应商 ID（优先于数据库 is_current）
@@ -410,6 +413,8 @@ export interface Settings {
   currentProviderCodex?: string;
   // 当前 Gemini 供应商 ID（优先于数据库 is_current）
   currentProviderGemini?: string;
+  // 当前 Grok Build 供应商 ID
+  currentProviderGrok?: string;
 
   // ===== Skill 同步设置 =====
   // Skill 同步方式：auto（默认，优先 symlink）、symlink、copy
@@ -491,6 +496,7 @@ export interface McpApps {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  grok?: boolean;
 }
 
 // MCP 服务器条目（v3.7.0 统一结构）

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -49,6 +49,7 @@ export interface ProxyTakeoverStatus {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  grok: boolean;
 }
 
 export interface ProviderHealth {

--- a/src/utils/grokConfigUtils.ts
+++ b/src/utils/grokConfigUtils.ts
@@ -1,0 +1,118 @@
+import { parse as parseToml } from "smol-toml";
+import { normalizeTomlText } from "@/utils/textNormalization";
+
+type TomlObject = Record<string, unknown>;
+
+function parseGrokConfig(config: string): TomlObject | null {
+  try {
+    return parseToml(normalizeTomlText(config)) as TomlObject;
+  } catch {
+    return null;
+  }
+}
+
+export function extractGrokBaseUrl(config: string): string {
+  const parsed = parseGrokConfig(config);
+  const endpoints = parsed?.endpoints as TomlObject | undefined;
+  if (typeof endpoints?.models_base_url === "string") {
+    return endpoints.models_base_url;
+  }
+  const models = parsed?.models as TomlObject | undefined;
+  const modelRoot = parsed?.model as TomlObject | undefined;
+  const selected =
+    typeof models?.default === "string" ? models.default : undefined;
+  const selectedModel = selected
+    ? (modelRoot?.[selected] as TomlObject | undefined)
+    : undefined;
+  return typeof selectedModel?.base_url === "string"
+    ? selectedModel.base_url
+    : "";
+}
+
+export function extractGrokApiBackend(config: string): string | undefined {
+  const parsed = parseGrokConfig(config);
+  const models = parsed?.models as TomlObject | undefined;
+  const modelRoot = parsed?.model as TomlObject | undefined;
+  const selected =
+    typeof models?.default === "string" ? models.default : undefined;
+  const selectedModel = selected
+    ? (modelRoot?.[selected] as TomlObject | undefined)
+    : undefined;
+  return typeof selectedModel?.api_backend === "string"
+    ? selectedModel.api_backend
+    : undefined;
+}
+
+function setSectionString(
+  config: string,
+  section: string,
+  key: string,
+  nextValue: string,
+): string {
+  const normalized = normalizeTomlText(config).replace(/\r\n/g, "\n");
+  const lines = normalized ? normalized.split("\n") : [];
+  const sectionHeader = `[${section}]`;
+  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  const assignment = `${key} = ${JSON.stringify(nextValue)}`;
+
+  if (sectionStart < 0) {
+    if (!nextValue) return normalized;
+    const prefix = normalized.trimEnd();
+    return `${prefix}${prefix ? "\n\n" : ""}${sectionHeader}\n${assignment}\n`;
+  }
+
+  let sectionEnd = lines.length;
+  for (let index = sectionStart + 1; index < lines.length; index += 1) {
+    if (/^\s*\[[^\]]+\]\s*$/.test(lines[index])) {
+      sectionEnd = index;
+      break;
+    }
+  }
+  const keyPattern = new RegExp(`^\\s*${key}\\s*=`);
+  const keyIndex = lines
+    .slice(sectionStart + 1, sectionEnd)
+    .findIndex((line) => keyPattern.test(line));
+  if (keyIndex >= 0) {
+    const absoluteIndex = sectionStart + 1 + keyIndex;
+    if (nextValue) lines[absoluteIndex] = assignment;
+    else lines.splice(absoluteIndex, 1);
+  } else if (nextValue) {
+    lines.splice(sectionStart + 1, 0, assignment);
+  }
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function setGrokBaseUrl(config: string, baseUrl: string): string {
+  return setSectionString(
+    config,
+    "endpoints",
+    "models_base_url",
+    baseUrl.trim(),
+  );
+}
+
+export function setGrokApiBackend(
+  config: string,
+  backend: "responses" | "chat_completions",
+): string {
+  const lines = normalizeTomlText(config).replace(/\r\n/g, "\n").split("\n");
+  const starts: number[] = [];
+  lines.forEach((line, index) => {
+    if (/^\s*\[model\.[^\]]+\]\s*$/.test(line)) starts.push(index);
+  });
+  for (let offset = starts.length - 1; offset >= 0; offset -= 1) {
+    const start = starts[offset];
+    const end =
+      lines.findIndex(
+        (line, index) => index > start && /^\s*\[[^\]]+\]\s*$/.test(line),
+      ) || lines.length;
+    const actualEnd = end < 0 ? lines.length : end;
+    const keyIndex = lines
+      .slice(start + 1, actualEnd)
+      .findIndex((line) => /^\s*api_backend\s*=/.test(line));
+    const assignment = `api_backend = ${JSON.stringify(backend)}`;
+    if (keyIndex >= 0) lines[start + 1 + keyIndex] = assignment;
+    else lines.splice(start + 1, 0, assignment);
+  }
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/tests/components/CommonConfigModalBehavior.test.tsx
+++ b/tests/components/CommonConfigModalBehavior.test.tsx
@@ -131,6 +131,49 @@ describe("Common config modals", () => {
     expect(disabledConfig).not.toContain("goals = true");
   });
 
+  it("separates Grok global config from Codex-only controls", () => {
+    render(
+      <CodexConfigEditor
+        appId="grok"
+        showCodexFeatures={false}
+        authValue="{}"
+        configValue={'[model.ccswitch]\nmodel = "grok-4.5"'}
+        onAuthChange={() => {}}
+        onConfigChange={() => {}}
+        useCommonConfig={false}
+        onCommonConfigToggle={() => {}}
+        commonConfigSnippet=""
+        onCommonConfigSnippetChange={() => true}
+        onCommonConfigErrorClear={() => {}}
+        commonConfigError=""
+        authError=""
+        configError=""
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: /codexConfig.editCommonConfig|编辑通用配置/,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /grokConfig.editGlobalConfig|编辑 Grok 全局配置/,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /grokConfig.addToGlobalConfig|加入全局配置/,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", {
+        name: "codexConfig.enableGoalMode",
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
   it("keeps the Gemini common config modal closed after user closes it with an error present", async () => {
     render(
       <GeminiConfigEditor

--- a/tests/config/codexChatProviderPresets.test.ts
+++ b/tests/config/codexChatProviderPresets.test.ts
@@ -161,10 +161,10 @@ describe("Codex Chat provider presets", () => {
     }
   });
 
-  it("uses native Responses API for migrated CN providers without local route mapping", () => {
+  it("uses native Responses API for providers without protocol conversion", () => {
     const nativeResponsesPresets = new Map<
       string,
-      { contextWindows: Record<string, number> }
+      { baseUrl?: string; contextWindows: Record<string, number> }
     >([
       [
         "DouBaoSeed",

--- a/tests/config/grokProviderPresets.test.ts
+++ b/tests/config/grokProviderPresets.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parse as parseToml } from "smol-toml";
+import {
+  generateGrokProfileConfig,
+  grokProviderPresets,
+} from "@/config/grokProviderPresets";
+import {
+  extractGrokApiBackend,
+  extractGrokBaseUrl,
+  setGrokApiBackend,
+  setGrokBaseUrl,
+} from "@/utils/grokConfigUtils";
+
+describe("Grok Build provider presets", () => {
+  it("provides official OAuth, Responses and Chat profile templates", () => {
+    expect(
+      grokProviderPresets.some(
+        (preset) => preset.category === "official" && preset.config === "",
+      ),
+    ).toBe(true);
+    const responses = grokProviderPresets.find(
+      (preset) => preset.name === "xAI API (Responses)",
+    );
+    expect(extractGrokBaseUrl(responses?.config ?? "")).toBe(
+      "https://api.x.ai/v1",
+    );
+    expect(extractGrokApiBackend(responses?.config ?? "")).toBe("responses");
+    const parsed = parseToml(responses?.config ?? "") as any;
+    expect(parsed.models.default).toBe("grok-4.5");
+    expect(parsed.models.web_search).toBe("grok-4.5");
+    expect(parsed.subagents.default_model).toBe("grok-4.5");
+    expect(parsed.model["grok-4.5"].supports_backend_search).toBe(true);
+  });
+
+  it("updates Grok endpoint and every model backend without Codex wire_api", () => {
+    const profile = `${generateGrokProfileConfig(
+      "https://old.example/v1",
+      "first.model",
+    )}\n[model.second]\nmodel = "second"\napi_backend = "responses"\n`;
+    const updated = setGrokApiBackend(
+      setGrokBaseUrl(profile, "https://new.example/v1"),
+      "chat_completions",
+    );
+    const parsed = parseToml(updated) as any;
+    expect(parsed.endpoints.models_base_url).toBe("https://new.example/v1");
+    expect(parsed.model["first.model"].api_backend).toBe("chat_completions");
+    expect(parsed.model.second.api_backend).toBe("chat_completions");
+    expect(updated).not.toContain("wire_api");
+  });
+});

--- a/tests/hooks/useDirectorySettings.test.tsx
+++ b/tests/hooks/useDirectorySettings.test.tsx
@@ -70,6 +70,7 @@ describe("useDirectorySettings", () => {
       if (app === "gemini") return "/remote/gemini";
       if (app === "opencode") return "/remote/opencode";
       if (app === "openclaw") return "/remote/openclaw";
+      if (app === "grok") return "/remote/grok";
       return "/remote/hermes";
     });
     selectConfigDirectoryMock.mockReset();
@@ -93,6 +94,7 @@ describe("useDirectorySettings", () => {
       opencode: "/remote/opencode",
       openclaw: "/remote/openclaw",
       hermes: "/remote/hermes",
+      grok: "/remote/grok",
     });
   });
 

--- a/tests/msw/state.ts
+++ b/tests/msw/state.ts
@@ -72,6 +72,7 @@ const createDefaultProviders = (): ProvidersByApp => ({
   opencode: {},
   openclaw: {},
   hermes: {},
+  grok: {},
 });
 
 const createDefaultCurrent = (): CurrentProviderState => ({
@@ -82,6 +83,7 @@ const createDefaultCurrent = (): CurrentProviderState => ({
   opencode: "",
   openclaw: "",
   hermes: "",
+  grok: "",
 });
 
 let providers = createDefaultProviders();
@@ -194,6 +196,7 @@ let mcpConfigs: McpConfigState = {
   opencode: {},
   openclaw: {},
   hermes: {},
+  grok: {},
 };
 
 const cloneProviders = (value: ProvidersByApp) =>
@@ -262,6 +265,7 @@ export const resetProviderState = () => {
     opencode: {},
     openclaw: {},
     hermes: {},
+    grok: {},
   };
 };
 


### PR DESCRIPTION
## Summary

Adds Grok Build as an independent CC Switch application, separate from Codex configuration and routing.

This PR is based on the CC Switch v3.17.0 release commit `3d176b98cc0bfd151a42882e88ab59b62083b92f`. It intentionally excludes the Codex reasoning continuation implementation, which remains in #5056.

## What changed

- Add a top-level Grok application with independent providers, current selection, directory settings and proxy state.
- Scan and manage `~/.grok/config.toml`, with `GROK_CONFIG`, `GROK_HOME` and directory override support.
- Preserve unmanaged global Grok settings while switching provider-owned `endpoints`, `models`, `subagents` and `model.*` sections.
- Add an explicit "Add to Global Config" action that structurally merges the current Profile into the live global config and creates an automatic backup.
- Support multi-model Profiles, web search, subagents, per-model API keys, extra headers and privacy protection.
- Add dedicated `/grok/v1/responses` and `/grok/v1/chat/completions` proxy routes.
- Forward xAI-compatible Responses natively without converting them to Chat Completions.
- Support official OAuth fallback and Responses/Chat Completions provider selection.
- Add schema v14 migration for the independent Grok proxy configuration, including idempotent migration from development databases that already contain the Grok row.
- Add Grok-specific default-model copy and placeholders in all bundled locales.

## Validation

Passed locally:

- `pnpm typecheck`
- `pnpm format:check`
- 14 focused frontend tests for Grok presets, directory handling and config modal behavior
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- Verified the PR tree contains no `codex_continue` files or continuation-specific changes

The complete frontend, Clippy and Rust test suites will run in GitHub Actions.