### PR TITLE
fix: ensure takeover error detail is rendered in toast message

### DIFF
--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -95,7 +95,7 @@ export function ProxyPanel({
       toast.error(
         t("proxy.takeover.failed", {
           detail,
-          defaultValue: "切换接管状态失败",
+          defaultValue: `切换接管状态失败: ${detail}`,
         }),
       );
     }


### PR DESCRIPTION
The defaultValue in t('proxy.takeover.failed') did not include the {{detail}} placeholder, so if the i18n key was missing or the interpolation failed, the actual error detail would be lost and the raw {{detail}} template placeholder would be shown literally.

Fixes: ensure defaultValue includes the detail variable so the real error message is always displayed in the toast.

Closes: #2864

## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
