### PR TITLE
fix(proxy): support Codex alpha search passthrough

### DIFF
--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -936,6 +936,67 @@ pub async fn handle_responses_compact(
     .await
 }
 
+/// Handle the standalone Codex Alpha Search protocol without translating it
+/// through the Responses API bridge.
+pub async fn handle_alpha_search(
+    State(state): State<ProxyState>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    let (parts, req_body) = request.into_parts();
+    let method = parts.method.clone();
+    let uri = parts.uri;
+    let mut headers = parts.headers;
+    let extensions = parts.extensions;
+    let body_bytes = req_body
+        .collect()
+        .await
+        .map_err(|e| ProxyError::Internal(format!("Failed to read request body: {e}")))?
+        .to_bytes();
+    let body_bytes = decode_codex_request_body(&mut headers, body_bytes)?;
+    let body: Value = serde_json::from_slice(&body_bytes)
+        .map_err(|e| ProxyError::InvalidRequest(format!("Failed to parse request body: {e}")))?;
+
+    let mut ctx =
+        RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
+    let endpoint = endpoint_with_query(&uri, "/alpha/search");
+
+    let forwarder = ctx.create_forwarder(&state);
+    let mut result = match forwarder
+        .forward_with_retry(
+            &AppType::Codex,
+            method,
+            &endpoint,
+            body,
+            headers,
+            extensions,
+            ctx.get_providers(),
+        )
+        .await
+    {
+        Ok(result) => result,
+        Err(mut err) => {
+            if let Some(provider) = err.provider.take() {
+                ctx.provider = provider;
+            }
+            log_forward_error(&state, &ctx, false, &err.error);
+            return build_codex_proxy_error_response(&ctx, &endpoint, &err.error);
+        }
+    };
+
+    let connection_guard = result.connection_guard.take();
+    ctx.outbound_model = result.outbound_model.take();
+    ctx.provider = result.provider;
+
+    process_response(
+        result.response,
+        &ctx,
+        &state,
+        &CODEX_PARSER_CONFIG,
+        connection_guard,
+    )
+    .await
+}
+
 async fn handle_codex_chat_to_responses_transform(
     response: super::hyper_client::ProxyResponse,
     ctx: &RequestContext,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -344,6 +344,14 @@ impl ProxyServer {
                 "/codex/v1/responses/compact",
                 post(handlers::handle_responses_compact),
             )
+            // Codex standalone Alpha Search API (semantic passthrough)
+            .route("/alpha/search", post(handlers::handle_alpha_search))
+            .route("/v1/alpha/search", post(handlers::handle_alpha_search))
+            .route("/v1/v1/alpha/search", post(handlers::handle_alpha_search))
+            .route(
+                "/codex/v1/alpha/search",
+                post(handlers::handle_alpha_search),
+            )
             // Gemini API (支持带前缀和不带前缀)
             //
             // 用 `any(..)` 覆盖所有 HTTP 方法：除了 POST `:generateContent` /
@@ -391,5 +399,155 @@ impl ProxyServer {
             .provider_router
             .reset_provider_breaker(provider_id, app_type)
             .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::Provider;
+    use axum::http::{header, HeaderMap, StatusCode};
+    use serde_json::{json, Value};
+    use tokio::sync::Mutex;
+
+    #[derive(Debug)]
+    struct CapturedRequest {
+        path_and_query: String,
+        authorization: Option<String>,
+        body: Value,
+    }
+
+    #[tokio::test]
+    async fn alpha_search_routes_forward_to_canonical_upstream() {
+        let captured = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
+        let mock_app = Router::new().route(
+            "/v1/alpha/search",
+            post({
+                let captured = captured.clone();
+                move |request: axum::extract::Request| {
+                    let captured = captured.clone();
+                    async move {
+                        let (parts, body) = request.into_parts();
+                        let body = axum::body::to_bytes(body, 1024 * 1024)
+                            .await
+                            .expect("read mock request body");
+                        captured.lock().await.push(CapturedRequest {
+                            path_and_query: parts
+                                .uri
+                                .path_and_query()
+                                .map(|value| value.as_str().to_string())
+                                .unwrap_or_else(|| parts.uri.path().to_string()),
+                            authorization: parts
+                                .headers
+                                .get(header::AUTHORIZATION)
+                                .and_then(|value| value.to_str().ok())
+                                .map(ToString::to_string),
+                            body: serde_json::from_slice(&body).expect("parse mock request body"),
+                        });
+
+                        let mut headers = HeaderMap::new();
+                        headers.insert(
+                            header::CONTENT_TYPE,
+                            "application/json".parse().expect("content type"),
+                        );
+                        headers.insert(
+                            "x-upstream-request-id",
+                            "search-1".parse().expect("request id"),
+                        );
+                        (
+                            StatusCode::ACCEPTED,
+                            headers,
+                            r#"{"encrypted_output":"ciphertext"}"#,
+                        )
+                    }
+                }
+            }),
+        );
+        let mock_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind mock upstream");
+        let mock_addr = mock_listener.local_addr().expect("mock upstream address");
+        let mock_handle = tokio::spawn(async move {
+            axum::serve(mock_listener, mock_app)
+                .await
+                .expect("serve mock upstream");
+        });
+
+        let db = Arc::new(Database::memory().expect("memory database"));
+        let provider = Provider::with_id(
+            "alpha-search-upstream".to_string(),
+            "Alpha Search Upstream".to_string(),
+            json!({
+                "base_url": format!("http://{mock_addr}/v1"),
+                "auth": {"OPENAI_API_KEY": "upstream-secret"}
+            }),
+            None,
+        );
+        db.save_provider("codex", &provider)
+            .expect("save test provider");
+        db.set_current_provider("codex", &provider.id)
+            .expect("select test provider");
+
+        let proxy = ProxyServer::new(
+            ProxyConfig {
+                listen_port: 0,
+                enable_logging: false,
+                non_streaming_timeout: 10,
+                ..ProxyConfig::default()
+            },
+            db,
+            None,
+        );
+        let proxy_info = proxy.start().await.expect("start test proxy");
+        let client = reqwest::Client::new();
+        let aliases = [
+            "/alpha/search",
+            "/v1/alpha/search",
+            "/v1/v1/alpha/search",
+            "/codex/v1/alpha/search",
+        ];
+
+        for (index, path) in aliases.iter().enumerate() {
+            let response = client
+                .post(format!(
+                    "http://127.0.0.1:{}{}?client_version=0.144.1",
+                    proxy_info.port, path
+                ))
+                .header(header::AUTHORIZATION, "Bearer client-secret")
+                .json(&json!({
+                    "id": format!("search-{index}"),
+                    "model": "gpt-5.6-sol",
+                    "commands": {"search_query": [{"q": "test"}]}
+                }))
+                .send()
+                .await
+                .expect("send alpha search request");
+
+            assert_eq!(response.status(), StatusCode::ACCEPTED, "alias {path}");
+            assert_eq!(
+                response.text().await.expect("read proxy response"),
+                r#"{"encrypted_output":"ciphertext"}"#,
+                "alias {path}"
+            );
+        }
+
+        proxy.stop().await.expect("stop test proxy");
+        mock_handle.abort();
+
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), aliases.len());
+        for (index, request) in captured.iter().enumerate() {
+            assert_eq!(
+                request.path_and_query,
+                "/v1/alpha/search?client_version=0.144.1"
+            );
+            assert_eq!(
+                request.authorization.as_deref(),
+                Some("Bearer upstream-secret")
+            );
+            assert_eq!(request.body["id"], format!("search-{index}"));
+            assert_eq!(request.body["model"], "gpt-5.6-sol");
+            assert_eq!(request.body["commands"]["search_query"][0]["q"], "test");
+        }
     }
 }


### PR DESCRIPTION
## Summary / 概述

Add standalone Codex Alpha Search passthrough support to the local proxy.

Current Codex clients send Web Search requests to a separate `POST /alpha/search` protocol instead of `/responses`. CC Switch currently has no matching route, so the request stops at the Axum router with HTTP 404 even when the selected upstream supports Alpha Search.

This change:

- registers `/alpha/search`, `/v1/alpha/search`, `/v1/v1/alpha/search`, and `/codex/v1/alpha/search`;
- normalizes all aliases to the selected provider's canonical `/alpha/search` endpoint;
- preserves the query string and request body without Responses/Chat translation;
- reuses the existing Codex provider selection, model mapping, authentication, retry/failover, logging, and response pipeline;
- adds an isolated mock-upstream regression test covering all four aliases, upstream credential replacement, query preservation, model/search payload preservation, status, and encrypted response delivery.

## Related Issue / 关联 Issue

Fixes #5378

Related but distinct: #5363 covers Claude Code built-in WebSearch through the Responses translation path, while #5233 requests a Xiaomi MiMo `web_search` protocol bridge.

## Screenshots / 截图

Not applicable — backend-only proxy route fix.

## Validation / 验证

- `cargo test --manifest-path src-tauri/Cargo.toml alpha_search_routes_forward_to_canonical_upstream -- --nocapture`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests -- -D warnings`
- `cargo test --quiet --manifest-path src-tauri/Cargo.toml -- --skip update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active`
  - 1,976 passed, 2 ignored, 1 local-only fixed-port test skipped because an installed CC Switch instance was intentionally left running on port 15721.
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` — 69 files / 446 tests passed
- Built and tested on macOS arm64 against the current `main` branch.
- End-to-end verification through `CC Switch -> downstream gateway -> Codex OAuth proxy` completed three independent Web Search requests successfully after the patch.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（not applicable; no user-facing text changed）
