### PR TITLE
feat: add DeepSeek V4 support to supports_reasoning_effort

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -66,6 +66,7 @@ pub fn supports_reasoning_effort(model: &str) -> bool {
             .strip_prefix("gpt-")
             .and_then(|rest| rest.chars().next())
             .is_some_and(|c| c.is_ascii_digit() && c >= '5')
+        || model.to_lowercase().contains("deepseek-v4")
 }
 
 /// Resolve the appropriate OpenAI `reasoning_effort` from an Anthropic request body.
@@ -195,7 +196,10 @@ pub fn anthropic_to_openai_with_reasoning_content(
 
     // Map Anthropic thinking → OpenAI reasoning_effort
     if supports_reasoning_effort(model) {
-        if let Some(effort) = resolve_reasoning_effort(&body) {
+        if model.to_lowercase().contains("deepseek") {
+            // DeepSeek: always max reasoning
+            result["reasoning_effort"] = json!("max");
+        } else if let Some(effort) = resolve_reasoning_effort(&body) {
             result["reasoning_effort"] = json!(effort);
         }
     }
@@ -1560,6 +1564,9 @@ mod tests {
         assert!(supports_reasoning_effort("gpt-5"));
         assert!(supports_reasoning_effort("gpt-5.4"));
         assert!(supports_reasoning_effort("gpt-5-codex"));
+        assert!(supports_reasoning_effort("deepseek-v4-flash"));
+        assert!(supports_reasoning_effort("deepseek-v4-pro"));
+        assert!(supports_reasoning_effort("DeepSeek-V4-Flash"));
         assert!(!supports_reasoning_effort("gpt-4o"));
         assert!(!supports_reasoning_effort("claude-sonnet-4-6"));
     }


### PR DESCRIPTION
Adds DeepSeek V4 models (deepseek-v4-flash, deepseek-v4-pro) to `supports_reasoning_effort()` and defaults to `max` reasoning effort for DeepSeek models.

**Changes:**
- `supports_reasoning_effort()`: add `|| model.to_lowercase().contains("deepseek-v4")`
- `anthropic_to_openai_with_reasoning_content()`: DeepSeek always gets `reasoning_effort: "max"`
- Tests: 3 new assertions for deepseek-v4-flash, deepseek-v4-pro, DeepSeek-V4-Flash

**Why max by default?**
When Claude Desktop sends requests through 3p mode with MAX thinking intensity, the `thinking` parameter may vary (`adaptive`/ `enabled` + budget). For DeepSeek models, always using `max` ensures the highest reasoning quality regardless of the UI setting.

**Tested:**
- ✅ Unit tests pass (test_supports_reasoning_effort)
- ✅ Verified with OpenCode Go + DeepSeek V4 Flash via direct API call
- ✅ Capture proxy confirmed reasoning_effort: max in outbound requests