### PR TITLE
fix(proxy): keep buffered Read streams alive

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -837,6 +837,12 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                     tool_had_delta.insert(index);
 
                                     if tool_name_by_index.get(&index).map(String::as_str) == Some("Read") {
+                                        // Read arguments are buffered until `.done` so empty `pages`
+                                        // values can be removed before they reach Claude Code. Keep
+                                        // the downstream Anthropic stream alive while that buffering
+                                        // is in progress; otherwise a long but active upstream tool
+                                        // call looks idle to the client and trips its stream watchdog.
+                                        yield Ok(anthropic_sse("ping", &json!({"type":"ping"})));
                                         continue;
                                     }
 
@@ -1799,6 +1805,34 @@ mod tests {
         assert!(merged.contains("\"name\":\"Read\""));
         assert!(merged.contains("\"partial_json\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\",\\\"limit\\\":2000,\\\"offset\\\":0}"));
         assert!(!merged.contains("\\\"pages\\\":\\\"\\\""));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_read_tool_emits_keepalive_while_buffering_args() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_read\",\"model\":\"gpt-5.5\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_read\",\"type\":\"function_call\",\"call_id\":\"call_read\",\"name\":\"Read\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_read\",\"delta\":\"{\\\"file_path\\\":\"}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_read\",\"delta\":\"\\\"/tmp/demo.py\\\"}\"}\n\n"
+        );
+
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(input))]);
+        let merged = create_anthropic_sse_stream_from_responses(upstream)
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
+            .collect::<String>();
+
+        assert_eq!(merged.matches("event: ping").count(), 2);
+        assert_eq!(merged.matches("\"type\":\"ping\"").count(), 2);
+        assert!(!merged.contains("\"type\":\"input_json_delta\""));
+        assert!(merged.contains("event: error"));
+        assert!(merged.contains("stream_truncated"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary / 概述

- emit Anthropic `ping` events while OpenAI Responses `Read` tool arguments are buffered
- preserve the existing empty `pages: ""` sanitation and emit the sanitized input only once on `.done`
- add a regression test for an incomplete multi-delta `Read` stream

## Root cause / 根因

The Responses → Anthropic converter buffers every `Read` argument delta so it can remove an incompatible empty `pages` field after the complete JSON arrives. Unlike other tools, the `Read` branch previously emitted nothing downstream between `content_block_start` and `response.function_call_arguments.done`.

A long or incomplete Codex tool-argument stream therefore remained active upstream but looked idle to Claude Code. Claude Code eventually closed the HTTP 200 stream with `API Error: The operation timed out.`

Anthropic `ping` is a protocol-safe keepalive and does not expose the unsanitized partial JSON to Claude Code.

## Impact / 影响

Long-running `Read` tool calls now keep the downstream stream active while CC Switch waits for the complete arguments. Normal calls still remove empty `pages` values, and truncated streams still end with the existing explicit `stream_truncated` error.

Fixes #5389

## Validation / 验证

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::providers::streaming_responses::tests` — 22 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`

## Checklist / 检查清单

- [x] Rust formatting passes
- [x] Focused proxy tests pass
- [x] Cargo Clippy passes
- [x] No user-facing text or i18n changes
