### PR TITLE
fix(mcp): 修复 Codex 与 Claude MCP 开关幂等性

### DIFF
--- a/src-tauri/src/claude_mcp.rs
+++ b/src-tauri/src/claude_mcp.rs
@@ -351,6 +351,7 @@ pub fn set_mcp_servers_map(
     } else {
         serde_json::json!({})
     };
+    let before = root.clone();
 
     // 构建 mcpServers 对象：移除 UI 辅助字段（enabled/source），仅保留实际 MCP 规范
     // 检测目标路径是否为 WSL，若是则跳过 cmd /c 包装
@@ -359,7 +360,12 @@ pub fn set_mcp_servers_map(
         log::info!("检测到 WSL 路径，跳过 cmd /c 包装: {}", path.display());
     }
     let mut out: Map<String, Value> = Map::new();
-    for (id, spec) in servers.iter() {
+    let mut ids: Vec<&String> = servers.keys().collect();
+    ids.sort();
+    for id in ids {
+        let spec = servers
+            .get(id)
+            .expect("server id collected from the same map must exist");
         let mut obj = if let Some(map) = spec.as_object() {
             map.clone()
         } else {
@@ -397,6 +403,10 @@ pub fn set_mcp_servers_map(
             .as_object_mut()
             .ok_or_else(|| AppError::Config("~/.claude.json 根必须是对象".into()))?;
         obj.insert("mcpServers".into(), Value::Object(out));
+    }
+
+    if root == before {
+        return Ok(());
     }
 
     write_json_value(&path, &root)?;

--- a/src-tauri/src/mcp/claude.rs
+++ b/src-tauri/src/mcp/claude.rs
@@ -141,7 +141,9 @@ pub fn remove_server_from_claude(id: &str) -> Result<(), AppError> {
     let mut current = crate::claude_mcp::read_mcp_servers_map()?;
 
     // 移除指定服务器
-    current.remove(id);
+    if current.remove(id).is_none() {
+        return Ok(());
+    }
 
     // 写回
     crate::claude_mcp::set_mcp_servers_map(&current)

--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -338,6 +338,9 @@ pub fn sync_enabled_to_codex(config: &MultiAppConfig) -> Result<(), AppError> {
 
     // 6) 写回（仅改 TOML，不触碰 auth.json）；toml_edit 会尽量保留未改区域的注释/空白/顺序
     let new_text = doc.to_string();
+    if new_text == base_text {
+        return Ok(());
+    }
     let path = crate::codex_config::get_codex_config_path();
     crate::config::write_text_file(&path, &new_text)?;
     Ok(())
@@ -358,16 +361,17 @@ pub fn sync_single_server_to_codex(
     // 读取现有的 config.toml
     let config_path = crate::codex_config::get_codex_config_path();
 
-    let mut doc = if config_path.exists() {
+    let (mut doc, original_text) = if config_path.exists() {
         let content =
             std::fs::read_to_string(&config_path).map_err(|e| AppError::io(&config_path, e))?;
         // 解析失败必须报错而不是用空文档顶替：写回空文档会把用户
         // config.toml 里的其它段落（model/model_providers/注释等）整体清空
-        content
+        let doc = content
             .parse::<toml_edit::DocumentMut>()
-            .map_err(|e| AppError::McpValidation(format!("解析 config.toml 失败: {e}")))?
+            .map_err(|e| AppError::McpValidation(format!("解析 config.toml 失败: {e}")))?;
+        (doc, content)
     } else {
-        toml_edit::DocumentMut::new()
+        (toml_edit::DocumentMut::new(), String::new())
     };
 
     // 清理可能存在的错误格式 [mcp.servers]
@@ -393,6 +397,9 @@ pub fn sync_single_server_to_codex(
 
     // 写回文件
     let new_text = doc.to_string();
+    if new_text == original_text {
+        return Ok(());
+    }
     crate::config::write_text_file(&config_path, &new_text)?;
 
     Ok(())
@@ -413,27 +420,30 @@ pub fn remove_server_from_codex(id: &str) -> Result<(), AppError> {
     let content =
         std::fs::read_to_string(&config_path).map_err(|e| AppError::io(&config_path, e))?;
 
-    // 尝试解析现有配置，如果失败则直接返回（无法删除不存在的内容）
-    let mut doc = match content.parse::<toml_edit::DocumentMut>() {
-        Ok(doc) => doc,
-        Err(e) => {
-            log::warn!("解析 Codex config.toml 失败: {e}，跳过删除操作");
-            return Ok(());
-        }
-    };
+    // 无法解析时不能把“未删除”报告为成功；调用方需要据此恢复 DB 状态。
+    let mut doc = content
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|e| AppError::McpValidation(format!("解析 config.toml 失败: {e}")))?;
+
+    let mut changed = false;
 
     // 从正确的位置删除：[mcp_servers]
     if let Some(mcp_servers) = doc.get_mut("mcp_servers").and_then(|s| s.as_table_mut()) {
-        mcp_servers.remove(id);
+        changed |= mcp_servers.remove(id).is_some();
     }
 
     // 同时清理可能存在于错误位置的数据：[mcp.servers]（如果存在）
     if let Some(mcp_table) = doc.get_mut("mcp").and_then(|t| t.as_table_mut()) {
         if let Some(servers) = mcp_table.get_mut("servers").and_then(|s| s.as_table_mut()) {
             if servers.remove(id).is_some() {
+                changed = true;
                 log::warn!("从错误的 MCP 格式 [mcp.servers] 中清理了服务器 '{id}'");
             }
         }
+    }
+
+    if !changed {
+        return Ok(());
     }
 
     // 写回文件

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -72,18 +72,41 @@ impl McpService {
         app: AppType,
         enabled: bool,
     ) -> Result<(), AppError> {
-        let mut servers = state.db.get_all_mcp_servers()?;
+        let servers = state.db.get_all_mcp_servers()?;
+        let Some(previous) = servers.get(server_id).cloned() else {
+            return Ok(());
+        };
 
-        if let Some(server) = servers.get_mut(server_id) {
-            server.apps.set_enabled_for(&app, enabled);
-            state.db.save_mcp_server(server)?;
+        let mut desired = previous.clone();
+        let guarded_toggle = matches!(app, AppType::Claude | AppType::Codex);
+        let db_changed = previous.apps.is_enabled_for(&app) != enabled;
+        desired.apps.set_enabled_for(&app, enabled);
 
-            // 同步到对应应用
-            if enabled {
-                Self::sync_server_to_app(state, server, &app)?;
-            } else {
-                Self::remove_server_from_app(state, server_id, &app)?;
+        // 本次一致性保证仅覆盖 Codex 和 Claude Code；其它客户端保持原有 DB 写入行为。
+        if db_changed || !guarded_toggle {
+            state.db.save_mcp_server(&desired)?;
+        }
+
+        // 即使 DB 已经是目标状态，也要再次核对 live 配置，使重试可以修复历史不一致。
+        let live_result = if enabled {
+            Self::sync_server_to_app(state, &desired, &app)
+        } else {
+            Self::remove_server_from_app(state, server_id, &app)
+        };
+
+        if let Err(live_err) = live_result {
+            if !guarded_toggle || !db_changed {
+                return Err(live_err);
             }
+
+            // Codex/Claude live 失败时恢复完整旧记录，避免 UI 与客户端状态分裂。
+            if let Err(rollback_err) = state.db.save_mcp_server(&previous) {
+                return Err(AppError::Message(format!(
+                    "MCP live 配置更新失败: {live_err}; 同时恢复数据库状态失败: {rollback_err}"
+                )));
+            }
+
+            return Err(live_err);
         }
 
         Ok(())

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -15,6 +15,28 @@ use support::{
     create_test_state, create_test_state_with_config, ensure_test_home, reset_test_fs, test_mutex,
 };
 
+fn test_mcp_server(id: &str, claude: bool, codex: bool) -> McpServer {
+    McpServer {
+        id: id.to_string(),
+        name: id.to_string(),
+        server: json!({
+            "type": "stdio",
+            "command": "echo"
+        }),
+        apps: McpApps {
+            claude,
+            codex,
+            gemini: false,
+            opencode: false,
+            hermes: false,
+        },
+        description: None,
+        homepage: None,
+        docs: None,
+        tags: Vec::new(),
+    }
+}
+
 #[test]
 fn import_default_config_claude_persists_provider() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
@@ -403,6 +425,257 @@ fn set_mcp_enabled_for_codex_writes_live_config() {
     assert!(
         toml_text.contains("codex-server"),
         "codex config should include the enabled server definition"
+    );
+}
+
+#[test]
+fn codex_toggle_invalid_toml_restores_db_for_enable_and_disable() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    let config_path = codex_dir.join("config.toml");
+    let original = b"model = \"gpt-5\"\n[mcp_servers.echo]\ncommand = \"echo\"\nbroken = [\n";
+    fs::write(&config_path, original).expect("seed invalid Codex config");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_mcp_server(&test_mcp_server("echo", false, false))
+        .expect("seed disabled Codex MCP");
+
+    let enable_err = McpService::toggle_app(&state, "echo", AppType::Codex, true)
+        .expect_err("invalid TOML must reject enable");
+    assert!(
+        enable_err.to_string().contains("解析 config.toml 失败"),
+        "unexpected enable error: {enable_err}"
+    );
+    let after_enable = state
+        .db
+        .get_all_mcp_servers()
+        .expect("read MCP after enable");
+    assert!(
+        !after_enable.get("echo").expect("echo exists").apps.codex,
+        "failed enable must restore disabled DB state"
+    );
+    assert_eq!(
+        fs::read(&config_path).expect("read invalid config after enable"),
+        original,
+        "failed enable must not alter invalid TOML"
+    );
+
+    let mut enabled = after_enable.get("echo").expect("echo exists").clone();
+    enabled.apps.codex = true;
+    state
+        .db
+        .save_mcp_server(&enabled)
+        .expect("seed enabled Codex MCP");
+
+    let disable_err = McpService::toggle_app(&state, "echo", AppType::Codex, false)
+        .expect_err("invalid TOML must reject disable");
+    assert!(
+        disable_err.to_string().contains("解析 config.toml 失败"),
+        "unexpected disable error: {disable_err}"
+    );
+    let after_disable = state
+        .db
+        .get_all_mcp_servers()
+        .expect("read MCP after disable");
+    assert!(
+        after_disable.get("echo").expect("echo exists").apps.codex,
+        "failed disable must restore enabled DB state"
+    );
+    assert_eq!(
+        fs::read(&config_path).expect("read invalid config after disable"),
+        original,
+        "failed disable must not alter invalid TOML"
+    );
+}
+
+#[test]
+fn claude_toggle_invalid_json_restores_db_for_enable_and_disable() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let config_path = get_claude_mcp_path();
+    let original = br#"{"mcpServers":{"echo":{"command":"echo"}},"broken":"#;
+    fs::write(&config_path, original).expect("seed invalid Claude config");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_mcp_server(&test_mcp_server("echo", false, false))
+        .expect("seed disabled Claude MCP");
+
+    let enable_err = McpService::toggle_app(&state, "echo", AppType::Claude, true)
+        .expect_err("invalid JSON must reject enable");
+    assert!(
+        enable_err.to_string().contains("JSON 解析错误"),
+        "unexpected enable error: {enable_err}"
+    );
+    let after_enable = state
+        .db
+        .get_all_mcp_servers()
+        .expect("read MCP after enable");
+    assert!(
+        !after_enable.get("echo").expect("echo exists").apps.claude,
+        "failed enable must restore disabled DB state"
+    );
+    assert_eq!(
+        fs::read(&config_path).expect("read invalid config after enable"),
+        original,
+        "failed enable must not alter invalid JSON"
+    );
+
+    let mut enabled = after_enable.get("echo").expect("echo exists").clone();
+    enabled.apps.claude = true;
+    state
+        .db
+        .save_mcp_server(&enabled)
+        .expect("seed enabled Claude MCP");
+
+    let disable_err = McpService::toggle_app(&state, "echo", AppType::Claude, false)
+        .expect_err("invalid JSON must reject disable");
+    assert!(
+        disable_err.to_string().contains("JSON 解析错误"),
+        "unexpected disable error: {disable_err}"
+    );
+    let after_disable = state
+        .db
+        .get_all_mcp_servers()
+        .expect("read MCP after disable");
+    assert!(
+        after_disable.get("echo").expect("echo exists").apps.claude,
+        "failed disable must restore enabled DB state"
+    );
+    assert_eq!(
+        fs::read(&config_path).expect("read invalid config after disable"),
+        original,
+        "failed disable must not alter invalid JSON"
+    );
+}
+
+#[test]
+fn repeated_codex_toggle_preserves_unrelated_config_and_bytes() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    let config_path = codex_dir.join("config.toml");
+    fs::write(
+        &config_path,
+        r#"# retain this comment
+model = "gpt-5"
+custom_setting = "keep"
+
+[mcp_servers.external]
+type = "stdio"
+command = "external"
+"#,
+    )
+    .expect("seed Codex config");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_mcp_server(&test_mcp_server("managed", false, false))
+        .expect("seed managed MCP");
+
+    McpService::toggle_app(&state, "managed", AppType::Codex, true).expect("enable Codex MCP");
+    let enabled_once = fs::read(&config_path).expect("read enabled Codex config");
+    let enabled_text = String::from_utf8(enabled_once.clone()).expect("Codex config is UTF-8");
+    assert!(enabled_text.contains("[mcp_servers.managed]"));
+    assert!(enabled_text.contains("[mcp_servers.external]"));
+    assert!(enabled_text.contains("custom_setting = \"keep\""));
+    assert!(enabled_text.contains("# retain this comment"));
+
+    McpService::toggle_app(&state, "managed", AppType::Codex, true).expect("repeat Codex enable");
+    assert_eq!(
+        fs::read(&config_path).expect("read repeated Codex enable"),
+        enabled_once,
+        "repeated enable must not change Codex config bytes"
+    );
+
+    McpService::toggle_app(&state, "managed", AppType::Codex, false).expect("disable Codex MCP");
+    let disabled_once = fs::read(&config_path).expect("read disabled Codex config");
+    let disabled_text = String::from_utf8(disabled_once.clone()).expect("Codex config is UTF-8");
+    assert!(!disabled_text.contains("[mcp_servers.managed]"));
+    assert!(disabled_text.contains("[mcp_servers.external]"));
+    assert!(disabled_text.contains("custom_setting = \"keep\""));
+
+    McpService::toggle_app(&state, "managed", AppType::Codex, false).expect("repeat Codex disable");
+    assert_eq!(
+        fs::read(&config_path).expect("read repeated Codex disable"),
+        disabled_once,
+        "repeated disable must not change Codex config bytes"
+    );
+}
+
+#[test]
+fn repeated_claude_toggle_preserves_unrelated_config_and_bytes() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let config_path = get_claude_mcp_path();
+    fs::write(
+        &config_path,
+        serde_json::to_string_pretty(&json!({
+            "hasCompletedOnboarding": true,
+            "customSetting": "keep",
+            "mcpServers": {
+                "external": {
+                    "type": "stdio",
+                    "command": "external"
+                }
+            }
+        }))
+        .expect("serialize Claude config"),
+    )
+    .expect("seed Claude config");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_mcp_server(&test_mcp_server("managed", false, false))
+        .expect("seed managed MCP");
+
+    McpService::toggle_app(&state, "managed", AppType::Claude, true).expect("enable Claude MCP");
+    let enabled_once = fs::read(&config_path).expect("read enabled Claude config");
+    let enabled_value: serde_json::Value =
+        serde_json::from_slice(&enabled_once).expect("parse enabled Claude config");
+    assert!(enabled_value.pointer("/mcpServers/managed").is_some());
+    assert!(enabled_value.pointer("/mcpServers/external").is_some());
+    assert_eq!(enabled_value["hasCompletedOnboarding"], json!(true));
+    assert_eq!(enabled_value["customSetting"], json!("keep"));
+
+    McpService::toggle_app(&state, "managed", AppType::Claude, true).expect("repeat Claude enable");
+    assert_eq!(
+        fs::read(&config_path).expect("read repeated Claude enable"),
+        enabled_once,
+        "repeated enable must not change Claude config bytes"
+    );
+
+    McpService::toggle_app(&state, "managed", AppType::Claude, false).expect("disable Claude MCP");
+    let disabled_once = fs::read(&config_path).expect("read disabled Claude config");
+    let disabled_value: serde_json::Value =
+        serde_json::from_slice(&disabled_once).expect("parse disabled Claude config");
+    assert!(disabled_value.pointer("/mcpServers/managed").is_none());
+    assert!(disabled_value.pointer("/mcpServers/external").is_some());
+    assert_eq!(disabled_value["hasCompletedOnboarding"], json!(true));
+    assert_eq!(disabled_value["customSetting"], json!("keep"));
+
+    McpService::toggle_app(&state, "managed", AppType::Claude, false)
+        .expect("repeat Claude disable");
+    assert_eq!(
+        fs::read(&config_path).expect("read repeated Claude disable"),
+        disabled_once,
+        "repeated disable must not change Claude config bytes"
     );
 }
 


### PR DESCRIPTION
  ## 概述

  本 PR 修复 Codex 和 Claude Code 在启用、关闭 MCP 服务时的一致性与幂等问题。

  此前存在以下情况：

  - `McpService::toggle_app` 会先更新数据库，再修改客户端配置文件。配置解析或写入失败时，数据库状态可能与实际配置不一致。
  - Codex 关闭 MCP 时会忽略无效 TOML 错误，直接返回成功，但目标 MCP 配置仍然保留。
  - 重复执行已经完成的启用或关闭操作，仍可能改写配置文件。

  本 PR 包含以下修改：

  - Codex 或 Claude 配置更新失败时，恢复操作前的完整 MCP 数据库记录。
  - 如果配置更新和数据库恢复同时失败，返回包含两个失败原因的错误。
  - Codex 删除 MCP 配置时不再忽略 `config.toml` 解析错误。
  - 配置已经处于目标状态时，跳过 Codex 和 Claude 配置文件写入。
  - Claude MCP 配置使用稳定的服务器顺序。
  - 保留无关的 TOML/JSON 配置内容。
  - 保持客户端尚未初始化时不创建配置文件的现有行为。

  本次未修改 Provider、Proxy 或配置写入锁。

  新增 4 个集成回归测试，覆盖：

  - Codex 和 Claude 的启用与关闭。
  - 无效 TOML/JSON 的错误返回。
  - 配置更新失败后的数据库恢复。
  - 重复操作不改变文件内容。
  - 无关配置内容保持不变。

  ## 关联 Issue

  暂无关联 Issue。

  ## 截图

  不适用——本次仅修改后端配置写入逻辑。

  ## 检查清单

  - [x] `pnpm typecheck`：不适用，未修改前端代码
  - [x] `pnpm format:check`：不适用，未修改前端代码
  - [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` 通过
  - [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` 通过
  - [x] `cargo test --manifest-path src-tauri/Cargo.toml --test mcp_commands` 通过，共 23 项
  - [x] `cargo test --manifest-path src-tauri/Cargo.toml mcp` 通过
  - [x] `cargo test --manifest-path src-tauri/Cargo.toml` 完整测试通过
  - [x] 未修改用户可见文本，无需更新国际化文件