### PR TITLE
fix(proxy): strip stop param for GitHub Copilot to unblock auto mode classifier

### DIFF
--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -346,11 +346,7 @@ pub fn transform_claude_request_for_api_format(
     // Copilot 场景：优先从 metadata.user_id 提取 session ID 作为 cache key
     // 格式: "uuid_sessionId" → 提取 "_" 后面的部分作为 session 标识
     // 同一会话的请求共享 cache key，提升 Copilot 缓存命中率
-    let is_copilot = provider
-        .meta
-        .as_ref()
-        .and_then(|m| m.provider_type.as_deref())
-        == Some("github_copilot")
+    let is_copilot = provider.is_github_copilot()
         || provider
             .settings_config
             .get("baseUrl")
@@ -1931,6 +1927,30 @@ mod tests {
                 ..Default::default()
             },
         );
+        let body = json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "max_tokens": 64,
+            "stop_sequences": ["\n\nHuman:"]
+        });
+
+        let transformed =
+            transform_claude_request_for_api_format(body, &provider, "openai_chat", None, None)
+                .unwrap();
+
+        assert!(transformed.get("stop").is_none());
+    }
+
+    #[test]
+    fn test_transform_claude_request_openai_chat_strips_stop_for_copilot_env_url() {
+        // 兼容旧/手动 Copilot provider：即使没有 meta.provider_type，
+        // 只要 ANTHROPIC_BASE_URL 指向 Copilot，也应移除 stop。
+        let provider = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://api.githubcopilot.com",
+                "ANTHROPIC_API_KEY": "test-key"
+            }
+        }));
         let body = json!({
             "model": "claude-sonnet-4-6",
             "messages": [{ "role": "user", "content": "hello" }],

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -426,6 +426,16 @@ pub fn transform_claude_request_for_api_format(
             // 不在 SSE 末尾吐 usage → 转换出的 Anthropic message_delta 全 0 →
             // 整笔 input/output/cache 漏记（与 Codex Responses→Chat 路径同源）。
             super::transform::inject_openai_stream_include_usage(&mut result);
+            // GitHub Copilot 的 OpenAI Chat 端点不支持 `stop` 参数，携带该字段会
+            // 直接返回 400。Claude Code auto mode 的 classifier 请求会带
+            // stop_sequences（转换后即为 stop），导致 classifier 在 Copilot 下
+            // 始终不可用（Issue #5175）。仅在 Copilot 路径移除该字段，其它
+            // OpenAI 兼容上游（如 OpenRouter）继续保留 stop 语义。
+            if is_copilot {
+                if let Some(obj) = result.as_object_mut() {
+                    obj.remove("stop");
+                }
+            }
             Ok(result)
         }
         "gemini_native" => super::transform_gemini::anthropic_to_gemini_with_shadow(
@@ -1902,6 +1912,58 @@ mod tests {
             "You are helpful."
         );
         assert_eq!(transformed["generationConfig"]["maxOutputTokens"], 64);
+    }
+
+    #[test]
+    fn test_transform_claude_request_openai_chat_strips_stop_for_copilot() {
+        // Issue #5175: GitHub Copilot 的 OpenAI Chat 端点不支持 `stop` 参数，
+        // 携带该字段会返回 400，导致 Claude Code auto mode 的 classifier
+        // 请求（携带 stop_sequences）始终失败。修复后 Copilot 路径应移除转换出的 stop。
+        let provider = create_provider_with_meta(
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.githubcopilot.com",
+                    "ANTHROPIC_API_KEY": "test-key"
+                }
+            }),
+            ProviderMeta {
+                provider_type: Some("github_copilot".to_string()),
+                ..Default::default()
+            },
+        );
+        let body = json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "max_tokens": 64,
+            "stop_sequences": ["\n\nHuman:"]
+        });
+
+        let transformed =
+            transform_claude_request_for_api_format(body, &provider, "openai_chat", None, None)
+                .unwrap();
+
+        assert!(transformed.get("stop").is_none());
+    }
+
+    #[test]
+    fn test_transform_claude_request_openai_chat_keeps_stop_for_generic_provider() {
+        // 非 Copilot 的 OpenAI 兼容上游（如 OpenRouter）应继续保留 stop 语义，
+        // 确认修复未影响其它 provider。
+        let provider = create_provider(json!({
+            "env": { "ANTHROPIC_BASE_URL": "https://openrouter.ai/api/v1" }
+        }));
+        let body = json!({
+            "model": "moonshotai/kimi-k2",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "max_tokens": 64,
+            "stop_sequences": ["\n\nHuman:"]
+        });
+
+        let transformed =
+            transform_claude_request_for_api_format(body, &provider, "openai_chat", None, None)
+                .unwrap();
+
+        assert_eq!(transformed["stop"], json!(["\n\nHuman:"]));
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Fixes #5175

Claude Code auto mode 下,使用 GitHub Copilot 作为 provider 时,任何需要 classifier 判断安全性的操作(如执行 Bash 命令)都会报错：

```
claude-sonnet-4-6[1M] is temporarily unavailable, so auto mode
cannot determine the safety of Bash right now.
```

普通对话(Sonnet 档模型)完全正常,只有 classifier 请求失败。

## 根因

代理在把 Claude Code 请求转发给 GitHub Copilot 时，会做 Anthropic → OpenAI Chat 格式转换。`src-tauri/src/proxy/providers/transform.rs` 中的 `anthropic_to_openai_with_reasoning_content` 会无条件把 Anthropic 的 `stop_sequences` 映射为 OpenAI 的 `stop` 字段。

但 GitHub Copilot 的 OpenAI Chat Completions 端点（`api.githubcopilot.com`）不支持 `stop` 参数，携带该字段会直接返回 HTTP 400。

Claude Code auto mode 的安全性 classifier 请求会携带 `stop_sequences`（转换后即为 `stop`），因此在 Copilot 路径下必然失败；而普通对话请求不带 `stop_sequences`，所以能正常工作——这与 issue 描述的现象完全吻合。

## 修复

在 `transform_claude_request_for_api_format`（`src-tauri/src/proxy/providers/claude.rs`）的 `openai_chat` 分支中，转换完成后仅在 `is_copilot` 为真时移除转换出的 `stop` 字段。该函数中已有的 `is_copilot` 判定逻辑（`meta.provider_type == "github_copilot"` 或 `baseUrl` 包含 `githubcopilot.com`）被直接复用，其它 OpenAI 兼容上游（如 OpenRouter）不受影响，继续保留 `stop` 语义。

## 测试

- 新增单元测试：
  - `test_transform_claude_request_openai_chat_strips_stop_for_copilot`：验证 Copilot provider 下 `stop_sequences` 转换后 `stop` 被正确移除
  - `test_transform_claude_request_openai_chat_keeps_stop_for_generic_provider`：验证非 Copilot（如 OpenRouter）provider 下 `stop` 依然保留，避免回归
- `cargo test --lib proxy::providers::claude` — 65 passed
- `cargo test --lib proxy::` — 1098 passed（整个 proxy 模块无回归）
- `cargo fmt --check` — 无差异
- `cargo clippy --lib --all-features -- -D warnings` — 无警告

### 用户测试说明

已在 Claude Code 中实际使用 auto mode 模式运行任务，持续超过 60 分钟，期间未再出现 classifier unavailable 的异常报错。