### PR TITLE
fix(services): sync common config snippet for hot switch

### DIFF
--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2566,7 +2566,9 @@ impl ProviderService {
         if should_hot_switch {
             let mut result = SwitchResult::default();
             if !app_type.is_additive_mode() {
-                if let Some(current_id) = crate::settings::get_effective_current_provider(&state.db, &app_type)? {
+                if let Some(current_id) =
+                    crate::settings::get_effective_current_provider(&state.db, &app_type)?
+                {
                     if current_id != id {
                         if let Some(current_provider) = providers.get(&current_id) {
                             Self::sync_common_config_snippet_for_hot_switch(
@@ -2993,38 +2995,48 @@ impl ProviderService {
     ) {
         let source_settings = match read_live_settings(app_type.clone()) {
             Ok(settings) => settings,
-            Err(live_err) => match futures::executor::block_on(state.db.get_live_backup(app_type.as_str())) {
-                Ok(Some(backup)) => match serde_json::from_str::<Value>(&backup.original_config) {
-                    Ok(settings) => settings,
-                    Err(backup_err) => {
-                        log::warn!(
+            Err(live_err) => {
+                match futures::executor::block_on(state.db.get_live_backup(app_type.as_str())) {
+                    Ok(Some(backup)) => {
+                        match serde_json::from_str::<Value>(&backup.original_config) {
+                            Ok(settings) => settings,
+                            Err(backup_err) => {
+                                log::warn!(
                             "Failed to parse takeover backup for {} provider '{}' after live read failed ({live_err}): {backup_err}",
                             app_type.as_str(),
                             provider.id
                         );
-                        return;
+                                return;
+                            }
+                        }
                     }
-                },
-                Ok(None) => {
-                    log::warn!(
+                    Ok(None) => {
+                        log::warn!(
                         "Failed to read live config for {} provider '{}' during hot-switch common config sync: {live_err}",
                         app_type.as_str(),
                         provider.id
                     );
-                    return;
-                }
-                Err(backup_err) => {
-                    log::warn!(
+                        return;
+                    }
+                    Err(backup_err) => {
+                        log::warn!(
                         "Failed to read live config for {} provider '{}' during hot-switch common config sync: {live_err}; backup read also failed: {backup_err}",
                         app_type.as_str(),
                         provider.id
                     );
-                    return;
+                        return;
+                    }
                 }
-            },
+            }
         };
 
-        Self::sync_common_config_snippet_from_live(state, app_type, provider, &source_settings, result);
+        Self::sync_common_config_snippet_from_live(
+            state,
+            app_type,
+            provider,
+            &source_settings,
+            result,
+        );
     }
 
     /// Extract common config snippet from current provider

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2564,6 +2564,22 @@ impl ProviderService {
         }
 
         if should_hot_switch {
+            let mut result = SwitchResult::default();
+            if !app_type.is_additive_mode() {
+                if let Some(current_id) = crate::settings::get_effective_current_provider(&state.db, &app_type)? {
+                    if current_id != id {
+                        if let Some(current_provider) = providers.get(&current_id) {
+                            Self::sync_common_config_snippet_for_hot_switch(
+                                state,
+                                &app_type,
+                                current_provider,
+                                &mut result,
+                            );
+                        }
+                    }
+                }
+            }
+
             // Proxy takeover mode: hot-switch without restoring upstream Live config.
             // The proxy layer may still refresh proxy-safe Live fields so client labels
             // follow the selected provider while endpoints remain local.
@@ -2582,7 +2598,7 @@ impl ProviderService {
 
             // The proxy server will route requests to the new provider via is_current.
             // MCP sync is intentionally skipped while Live config is owned by takeover.
-            return Ok(SwitchResult::default());
+            return Ok(result);
         }
 
         // Normal mode: full switch with Live config write
@@ -2967,6 +2983,48 @@ impl ProviderService {
                 .warnings
                 .push(format!("common_config_sync_failed:{}", provider.id));
         }
+    }
+
+    fn sync_common_config_snippet_for_hot_switch(
+        state: &AppState,
+        app_type: &AppType,
+        provider: &Provider,
+        result: &mut SwitchResult,
+    ) {
+        let source_settings = match read_live_settings(app_type.clone()) {
+            Ok(settings) => settings,
+            Err(live_err) => match futures::executor::block_on(state.db.get_live_backup(app_type.as_str())) {
+                Ok(Some(backup)) => match serde_json::from_str::<Value>(&backup.original_config) {
+                    Ok(settings) => settings,
+                    Err(backup_err) => {
+                        log::warn!(
+                            "Failed to parse takeover backup for {} provider '{}' after live read failed ({live_err}): {backup_err}",
+                            app_type.as_str(),
+                            provider.id
+                        );
+                        return;
+                    }
+                },
+                Ok(None) => {
+                    log::warn!(
+                        "Failed to read live config for {} provider '{}' during hot-switch common config sync: {live_err}",
+                        app_type.as_str(),
+                        provider.id
+                    );
+                    return;
+                }
+                Err(backup_err) => {
+                    log::warn!(
+                        "Failed to read live config for {} provider '{}' during hot-switch common config sync: {live_err}; backup read also failed: {backup_err}",
+                        app_type.as_str(),
+                        provider.id
+                    );
+                    return;
+                }
+            },
+        };
+
+        Self::sync_common_config_snippet_from_live(state, app_type, provider, &source_settings, result);
     }
 
     /// Extract common config snippet from current provider


### PR DESCRIPTION
## Summary / 概述

This PR syncs the common config snippet during hot switch for takeover/non-additive apps.

Previously, when hot-switching providers in takeover mode, the switch updated the current provider routing but did not synchronize the shared/common config snippet from the currently active live config source. This could leave the stored common config snippet stale after switching providers.

With this change:
- before returning from the hot-switch path, the service now attempts to sync the common config snippet;
- it reads from the live config first;
- if live config reading fails, it falls back to the takeover backup;
- if sync fails, it logs a warning and records it in switch warnings instead of blocking the switch flow.

## Fixes
| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|     Hot switch updates current provider only; common config snippet may remain stale.            | Hot switch also syncs common config snippet from live config or takeover backup.              |

## Checklist / 检查清单

- [ x ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ x ] `pnpm format:check` passes / 通过代码格式检查
- [ x ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
