### PR TITLE
fix(usage): prevent Codex subagent replay overcounting and add rescan

### DIFF
--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -278,49 +278,15 @@ pub fn delete_model_pricing(state: State<'_, AppState>, model_id: String) -> Res
 pub fn sync_session_usage(
     state: State<'_, AppState>,
 ) -> Result<crate::services::session_usage::SessionSyncResult, AppError> {
-    // 同步 Claude 会话日志
-    let mut result = crate::services::session_usage::sync_claude_session_logs(&state.db)?;
+    crate::services::session_usage::sync_all_session_usage(&state.db)
+}
 
-    // 同步 Codex 使用数据
-    match crate::services::session_usage_codex::sync_codex_usage(&state.db) {
-        Ok(codex_result) => {
-            result.imported += codex_result.imported;
-            result.skipped += codex_result.skipped;
-            result.files_scanned += codex_result.files_scanned;
-            result.errors.extend(codex_result.errors);
-        }
-        Err(e) => {
-            result.errors.push(format!("Codex 同步失败: {e}"));
-        }
-    }
-
-    // 同步 Gemini 使用数据
-    match crate::services::session_usage_gemini::sync_gemini_usage(&state.db) {
-        Ok(gemini_result) => {
-            result.imported += gemini_result.imported;
-            result.skipped += gemini_result.skipped;
-            result.files_scanned += gemini_result.files_scanned;
-            result.errors.extend(gemini_result.errors);
-        }
-        Err(e) => {
-            result.errors.push(format!("Gemini 同步失败: {e}"));
-        }
-    }
-
-    // 同步 OpenCode 使用数据
-    match crate::services::session_usage_opencode::sync_opencode_usage(&state.db) {
-        Ok(opencode_result) => {
-            result.imported += opencode_result.imported;
-            result.skipped += opencode_result.skipped;
-            result.files_scanned += opencode_result.files_scanned;
-            result.errors.extend(opencode_result.errors);
-        }
-        Err(e) => {
-            result.errors.push(format!("OpenCode 同步失败: {e}"));
-        }
-    }
-
-    Ok(result)
+/// 清除可重建的会话用量数据并全量重扫
+#[tauri::command]
+pub fn rebuild_session_usage(
+    state: State<'_, AppState>,
+) -> Result<crate::services::session_usage::SessionSyncResult, AppError> {
+    crate::services::session_usage::rebuild_session_usage(&state.db)
 }
 
 /// 获取数据来源分布

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1088,6 +1088,17 @@ pub fn run() {
                         }
                     }
 
+                    fn run_session_sync(name: &str, db: &crate::database::Database) {
+                        match crate::services::session_usage::sync_all_session_usage(db) {
+                            Ok(result) => {
+                                for error in result.errors {
+                                    log::warn!("{name}: {error}");
+                                }
+                            }
+                            Err(error) => log::warn!("{name} failed: {error}"),
+                        }
+                    }
+
                     let db = &db_for_session_sync;
 
                     // 首次同步
@@ -1095,22 +1106,7 @@ pub fn run() {
                         "Usage cost startup backfill",
                         db.backfill_missing_usage_costs(),
                     );
-                    run_step(
-                        "Session usage initial sync",
-                        crate::services::session_usage::sync_claude_session_logs(db),
-                    );
-                    run_step(
-                        "Codex usage initial sync",
-                        crate::services::session_usage_codex::sync_codex_usage(db),
-                    );
-                    run_step(
-                        "Gemini usage initial sync",
-                        crate::services::session_usage_gemini::sync_gemini_usage(db),
-                    );
-                    run_step(
-                        "OpenCode usage initial sync",
-                        crate::services::session_usage_opencode::sync_opencode_usage(db),
-                    );
+                    run_session_sync("Session usage initial sync", db);
 
                     // 定期同步
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
@@ -1119,22 +1115,7 @@ pub fn run() {
                     interval.tick().await; // skip immediate first tick
                     loop {
                         interval.tick().await;
-                        run_step(
-                            "Session usage periodic sync",
-                            crate::services::session_usage::sync_claude_session_logs(db),
-                        );
-                        run_step(
-                            "Codex usage periodic sync",
-                            crate::services::session_usage_codex::sync_codex_usage(db),
-                        );
-                        run_step(
-                            "Gemini usage periodic sync",
-                            crate::services::session_usage_gemini::sync_gemini_usage(db),
-                        );
-                        run_step(
-                            "OpenCode usage periodic sync",
-                            crate::services::session_usage_opencode::sync_opencode_usage(db),
-                        );
+                        run_session_sync("Session usage periodic sync", db);
                     }
                 });
             });
@@ -1406,6 +1387,7 @@ pub fn run() {
             commands::check_provider_limits,
             // Session usage sync
             commands::sync_session_usage,
+            commands::rebuild_session_usage,
             commands::get_usage_data_sources,
             // Stream health check
             commands::stream_check_provider,

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -22,10 +22,13 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::time::SystemTime;
 
+static SESSION_USAGE_SYNC_LOCK: Mutex<()> = Mutex::new(());
+
 /// 同步结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionSyncResult {
     pub imported: u32,
@@ -41,6 +44,100 @@ pub struct DataSourceSummary {
     pub data_source: String,
     pub request_count: u32,
     pub total_cost_usd: String,
+}
+
+/// 串行同步所有本地会话来源，避免手动重建与后台同步交错写入。
+pub fn sync_all_session_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    let _guard = SESSION_USAGE_SYNC_LOCK
+        .lock()
+        .map_err(|_| AppError::Database("会话用量同步锁已损坏".to_string()))?;
+    Ok(sync_all_session_usage_unlocked(db))
+}
+
+/// 清除可由本地会话日志恢复的统计数据并立即全量重扫。
+/// 代理请求日志、会话原文件、账号配置和其他应用数据均不受影响。
+pub fn rebuild_session_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    let _guard = SESSION_USAGE_SYNC_LOCK
+        .lock()
+        .map_err(|_| AppError::Database("会话用量同步锁已损坏".to_string()))?;
+
+    clear_rebuildable_session_usage(db)?;
+    let result = sync_all_session_usage_unlocked(db);
+    crate::usage_events::notify_log_recorded();
+    Ok(result)
+}
+
+type SessionSyncFn = fn(&Database) -> Result<SessionSyncResult, AppError>;
+
+fn sync_all_session_usage_unlocked(db: &Database) -> SessionSyncResult {
+    let syncers: [(&str, SessionSyncFn); 4] = [
+        ("Claude", sync_claude_session_logs),
+        (
+            "Codex",
+            crate::services::session_usage_codex::sync_codex_usage,
+        ),
+        (
+            "Gemini",
+            crate::services::session_usage_gemini::sync_gemini_usage,
+        ),
+        (
+            "OpenCode",
+            crate::services::session_usage_opencode::sync_opencode_usage,
+        ),
+    ];
+    let mut combined = SessionSyncResult::default();
+
+    for (source, sync) in syncers {
+        match sync(db) {
+            Ok(result) => {
+                combined.imported += result.imported;
+                combined.skipped += result.skipped;
+                combined.files_scanned += result.files_scanned;
+                combined.errors.extend(result.errors);
+            }
+            Err(error) => combined.errors.push(format!("{source} 同步失败: {error}")),
+        }
+    }
+
+    combined
+}
+
+fn clear_rebuildable_session_usage(db: &Database) -> Result<(), AppError> {
+    let mut conn = lock_conn!(db.conn);
+    let transaction = conn
+        .transaction()
+        .map_err(|error| AppError::Database(format!("开始重建会话用量失败: {error}")))?;
+
+    let detail_rows = transaction
+        .execute(
+            "DELETE FROM proxy_request_logs
+             WHERE data_source IN (
+                'session_log', 'codex_db', 'codex_session',
+                'gemini_session', 'opencode_session'
+             )",
+            [],
+        )
+        .map_err(|error| AppError::Database(format!("清除会话用量明细失败: {error}")))?;
+    let rollup_rows = transaction
+        .execute(
+            "DELETE FROM usage_daily_rollups
+             WHERE provider_id IN (
+                '_session', '_codex_session', '_gemini_session', '_opencode_session'
+             )",
+            [],
+        )
+        .map_err(|error| AppError::Database(format!("清除会话用量汇总失败: {error}")))?;
+    let cursor_rows = transaction
+        .execute("DELETE FROM session_log_sync", [])
+        .map_err(|error| AppError::Database(format!("清除会话扫描进度失败: {error}")))?;
+
+    transaction
+        .commit()
+        .map_err(|error| AppError::Database(format!("提交会话用量重建失败: {error}")))?;
+    log::info!(
+        "[SESSION-SYNC] 已重置会话用量: 明细 {detail_rows} 条, 汇总 {rollup_rows} 条, 游标 {cursor_rows} 条"
+    );
+    Ok(())
 }
 
 /// 从 JSONL 中解析出的 assistant 消息使用数据
@@ -693,6 +790,75 @@ mod tests {
             row.get(0)
         })?;
         assert_eq!(count, 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_clear_rebuildable_session_usage_preserves_proxy_data() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        {
+            let conn = lock_conn!(db.conn);
+            for (request_id, provider_id, data_source) in [
+                ("proxy", "custom-provider", "proxy"),
+                ("claude-session", "_session", "session_log"),
+                ("legacy-codex", "_codex_session", "codex_db"),
+                ("codex-session", "_codex_session", "codex_session"),
+                ("gemini-session", "_gemini_session", "gemini_session"),
+                ("opencode-session", "_opencode_session", "opencode_session"),
+            ] {
+                conn.execute(
+                    "INSERT INTO proxy_request_logs (
+                        request_id, provider_id, app_type, model,
+                        latency_ms, status_code, created_at, data_source
+                     ) VALUES (?1, ?2, 'codex', 'test-model', 0, 200, 1, ?3)",
+                    rusqlite::params![request_id, provider_id, data_source],
+                )?;
+            }
+
+            for provider_id in [
+                "custom-provider",
+                "_session",
+                "_codex_session",
+                "_gemini_session",
+                "_opencode_session",
+            ] {
+                conn.execute(
+                    "INSERT INTO usage_daily_rollups (
+                        date, app_type, provider_id, model
+                     ) VALUES ('2026-07-01', 'codex', ?1, ?1)",
+                    [provider_id],
+                )?;
+            }
+
+            conn.execute(
+                "INSERT INTO session_log_sync (
+                    file_path, last_modified, last_line_offset, last_synced_at
+                 ) VALUES ('/tmp/session.jsonl', 1, 10, 1)",
+                [],
+            )?;
+        }
+
+        clear_rebuildable_session_usage(&db)?;
+
+        let conn = lock_conn!(db.conn);
+        let detail_ids = conn
+            .prepare("SELECT request_id FROM proxy_request_logs ORDER BY request_id")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(detail_ids, vec!["proxy"]);
+
+        let rollup_providers = conn
+            .prepare("SELECT provider_id FROM usage_daily_rollups ORDER BY provider_id")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(rollup_providers, vec!["custom-provider"]);
+
+        let cursor_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM session_log_sync", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(cursor_count, 0);
 
         Ok(())
     }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -58,6 +58,7 @@ struct FileParseState {
     current_model: String,
     prev_total: Option<CumulativeTokens>,
     event_index: u32,
+    carries_history_snapshot: bool,
     history_replay_boundary: Option<i64>,
 }
 
@@ -66,6 +67,7 @@ struct FileParseState {
 struct CodexSessionIdentity {
     thread_id: String,
     carries_history_snapshot: bool,
+    is_subagent: bool,
 }
 
 fn parse_codex_session_identity(payload: &serde_json::Value) -> Option<CodexSessionIdentity> {
@@ -81,19 +83,21 @@ fn parse_codex_session_identity(payload: &serde_json::Value) -> Option<CodexSess
         .get("session_id")
         .or_else(|| payload.get("sessionId"))
         .and_then(|value| value.as_str());
+    let is_subagent = payload
+        .get("source")
+        .and_then(|source| source.get("subagent"))
+        .is_some()
+        || session_id.is_some_and(|session_id| session_id != thread_id);
     let carries_history_snapshot = payload
         .get("forked_from_id")
         .and_then(|value| value.as_str())
         .is_some_and(|value| !value.is_empty())
-        || payload
-            .get("source")
-            .and_then(|source| source.get("subagent"))
-            .is_some()
-        || session_id.is_some_and(|session_id| session_id != thread_id);
+        || is_subagent;
 
     Some(CodexSessionIdentity {
         thread_id,
         carries_history_snapshot,
+        is_subagent,
     })
 }
 
@@ -123,6 +127,8 @@ fn read_codex_session_identity(file_path: &Path) -> Option<CodexSessionIdentity>
 
 /// fork/子代理日志会先重放父线程历史，再以接管事件开始当前线程。
 /// 返回接管事件所在行；此前的 token_count 只用于恢复累计值基线。
+/// 子代理复制的历史中也可能包含旧的 `thread_settings_applied`，因此只有真实的
+/// `inter_agent_communication*` 才能标记子代理开始执行。
 fn codex_history_replay_boundary(
     file_path: &Path,
     identity: Option<&CodexSessionIdentity>,
@@ -148,7 +154,8 @@ fn codex_history_replay_boundary(
             continue;
         };
         let is_replay_boundary = event_type.starts_with("inter_agent_communication")
-            || (event_type == "event_msg"
+            || (!identity.is_some_and(|identity| identity.is_subagent)
+                && event_type == "event_msg"
                 && value
                     .get("payload")
                     .and_then(|payload| payload.get("type"))
@@ -163,9 +170,10 @@ fn codex_history_replay_boundary(
 }
 
 fn is_history_snapshot_event(state: &FileParseState, line_offset: i64) -> bool {
-    state
-        .history_replay_boundary
-        .is_some_and(|boundary| line_offset < boundary)
+    state.carries_history_snapshot
+        && state
+            .history_replay_boundary
+            .is_none_or(|boundary| line_offset < boundary)
 }
 
 fn get_codex_sync_state(db: &Database, file_path: &Path) -> Result<(i64, i64), AppError> {
@@ -408,10 +416,13 @@ fn sync_single_codex_file(db: &Database, file_path: &Path) -> Result<(u32, u32),
     let history_replay_boundary = codex_history_replay_boundary(file_path, identity.as_ref());
 
     let mut state = FileParseState {
-        thread_id: identity.map(|identity| identity.thread_id),
+        thread_id: identity.as_ref().map(|identity| identity.thread_id.clone()),
         current_model: "unknown".to_string(),
         prev_total: None,
         event_index: 0,
+        carries_history_snapshot: identity
+            .as_ref()
+            .is_some_and(|identity| identity.carries_history_snapshot),
         history_replay_boundary,
     };
 
@@ -765,6 +776,22 @@ mod tests {
         })
     }
 
+    fn thread_settings_applied() -> serde_json::Value {
+        serde_json::json!({
+            "timestamp": "2026-07-10T03:00:03Z",
+            "type": "event_msg",
+            "payload": { "type": "thread_settings_applied" }
+        })
+    }
+
+    fn inter_agent_boundary() -> serde_json::Value {
+        serde_json::json!({
+            "timestamp": "2026-07-10T03:00:04Z",
+            "type": "inter_agent_communication_metadata",
+            "payload": { "message": "You have 100 weighted tokens left" }
+        })
+    }
+
     #[test]
     fn test_delta_first_event() {
         let prev = None;
@@ -882,6 +909,7 @@ mod tests {
 
         assert_eq!(identity.thread_id, "child");
         assert!(identity.carries_history_snapshot);
+        assert!(identity.is_subagent);
     }
 
     #[test]
@@ -895,12 +923,9 @@ mod tests {
                 session_meta("child", "parent"),
                 turn_context(),
                 token_count(1_000, 900, 100),
+                thread_settings_applied(),
                 token_count(1_200, 1_000, 120),
-                serde_json::json!({
-                    "timestamp": "2026-07-10T03:00:03Z",
-                    "type": "event_msg",
-                    "payload": { "type": "thread_settings_applied" }
-                }),
+                inter_agent_boundary(),
                 token_count(1_300, 1_050, 150),
             ],
         );
@@ -921,6 +946,33 @@ mod tests {
     }
 
     #[test]
+    fn test_subagent_without_takeover_boundary_does_not_import_replay() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let child = temp.path().join("child-pending.jsonl");
+        write_jsonl(
+            &child,
+            &[
+                session_meta("child-pending", "parent"),
+                turn_context(),
+                token_count(1_000, 900, 100),
+                thread_settings_applied(),
+                token_count(1_200, 1_000, 120),
+            ],
+        );
+
+        assert_eq!(sync_single_codex_file(&db, &child)?, (0, 2));
+
+        let conn = lock_conn!(db.conn);
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM proxy_request_logs", [], |row| {
+            row.get(0)
+        })?;
+        assert_eq!(count, 0);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_subagents_under_same_parent_use_distinct_request_ids() -> Result<(), AppError> {
         let db = Database::memory()?;
         let temp = tempdir().unwrap();
@@ -931,6 +983,7 @@ mod tests {
             &[
                 session_meta("child-a", "parent"),
                 turn_context(),
+                inter_agent_boundary(),
                 token_count(100, 50, 10),
             ],
         );
@@ -939,6 +992,7 @@ mod tests {
             &[
                 session_meta("child-b", "parent"),
                 turn_context(),
+                inter_agent_boundary(),
                 token_count(200, 100, 20),
             ],
         );

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -19,6 +19,8 @@ import {
   RefreshCw,
   Coins,
   LayoutGrid,
+  Loader2,
+  RotateCcw,
 } from "lucide-react";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import {
@@ -43,6 +45,10 @@ import { getLocaleFromLanguage } from "./format";
 import { getUsageRangePresetLabel, resolveUsageRange } from "@/lib/usageRange";
 import { UsageDateRangePicker } from "./UsageDateRangePicker";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { usageApi } from "@/lib/api/usage";
+import { toast } from "sonner";
 
 const APP_FILTER_OPTIONS: AppTypeFilter[] = ["all", ...KNOWN_APP_TYPES];
 
@@ -93,6 +99,8 @@ export function UsageDashboard({
   const [refreshIntervalMs, setRefreshIntervalMs] = useState(() =>
     normalizeRefreshInterval(savedRefreshIntervalMs),
   );
+  const [rebuildingSessionUsage, setRebuildingSessionUsage] = useState(false);
+  const [showRebuildConfirm, setShowRebuildConfirm] = useState(false);
 
   useEffect(() => {
     setRefreshIntervalMs(normalizeRefreshInterval(savedRefreshIntervalMs));
@@ -134,6 +142,37 @@ export function UsageDashboard({
         error,
       );
       setRefreshIntervalMs(previous);
+    }
+  };
+
+  const handleRebuildSessionUsage = async () => {
+    setShowRebuildConfirm(false);
+    setRebuildingSessionUsage(true);
+    try {
+      const result = await usageApi.rebuildSessionUsage();
+      await queryClient.invalidateQueries({ queryKey: usageKeys.all });
+
+      if (result.errors.length > 0) {
+        toast.warning(
+          t("usage.sessionSync.rebuildPartial", {
+            count: result.errors.length,
+          }),
+          { description: result.errors.slice(0, 3).join("\n") },
+        );
+      } else {
+        toast.success(
+          t("usage.sessionSync.rebuilt", {
+            count: result.imported,
+            files: result.filesScanned,
+          }),
+        );
+      }
+    } catch (error) {
+      toast.error(t("usage.sessionSync.rebuildFailed"), {
+        description: String(error),
+      });
+    } finally {
+      setRebuildingSessionUsage(false);
     }
   };
 
@@ -321,6 +360,22 @@ export function UsageDashboard({
               </SelectContent>
             </Select>
 
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 gap-1.5 px-3 text-xs"
+              onClick={() => setShowRebuildConfirm(true)}
+              disabled={rebuildingSessionUsage}
+              title={t("usage.sessionSync.rebuildTrigger")}
+            >
+              {rebuildingSessionUsage ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RotateCcw className="h-3.5 w-3.5" />
+              )}
+              {t("usage.sessionSync.rebuild")}
+            </Button>
+
             <UsageDateRangePicker
               selection={range}
               triggerLabel={rangeLabel}
@@ -429,6 +484,15 @@ export function UsageDashboard({
           </AccordionContent>
         </AccordionItem>
       </Accordion>
+
+      <ConfirmDialog
+        isOpen={showRebuildConfirm}
+        title={t("usage.sessionSync.rebuildTitle")}
+        message={t("usage.sessionSync.rebuildMessage")}
+        confirmText={t("usage.sessionSync.rebuildConfirm")}
+        onConfirm={() => void handleRebuildSessionUsage()}
+        onCancel={() => setShowRebuildConfirm(false)}
+      />
     </motion.div>
   );
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1477,7 +1477,15 @@
       "resync": "Sync",
       "imported": "Imported {{count}} records from session logs",
       "upToDate": "Session logs are up to date",
-      "failed": "Session sync failed"
+      "failed": "Session sync failed",
+      "rebuild": "Rescan",
+      "rebuildTrigger": "Clear imported usage and rescan session logs",
+      "rebuildTitle": "Rescan session usage?",
+      "rebuildMessage": "Imported session usage and scan progress will be cleared, then rebuilt from local Claude, Codex, Gemini, and OpenCode logs. Chat files, proxy request logs, and settings will not be deleted.",
+      "rebuildConfirm": "Clear and Rescan",
+      "rebuilt": "Rescanned {{files}} files and rebuilt {{count}} records",
+      "rebuildPartial": "Rescan completed with {{count}} session log errors",
+      "rebuildFailed": "Session usage rescan failed"
     },
     "totalRecords": "{{total}} records total",
     "goToPage": "Go",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1477,7 +1477,15 @@
       "resync": "同期",
       "imported": "セッションログから {{count}} 件のレコードをインポートしました",
       "upToDate": "セッションログは最新です",
-      "failed": "セッション同期に失敗しました"
+      "failed": "セッション同期に失敗しました",
+      "rebuild": "再スキャン",
+      "rebuildTrigger": "インポート済みの使用量を消去してセッションログを再スキャン",
+      "rebuildTitle": "セッション使用量を再スキャンしますか？",
+      "rebuildMessage": "インポート済みのセッション使用量とスキャン進捗を消去し、ローカルの Claude、Codex、Gemini、OpenCode ログから再構築します。チャットファイル、プロキシリクエストログ、設定は削除されません。",
+      "rebuildConfirm": "消去して再スキャン",
+      "rebuilt": "{{files}} 個のファイルを再スキャンし、{{count}} 件のレコードを再構築しました",
+      "rebuildPartial": "再スキャンは完了しましたが、{{count}} 件のセッションログエラーがありました",
+      "rebuildFailed": "セッション使用量の再スキャンに失敗しました"
     },
     "totalRecords": "全 {{total}} 件",
     "goToPage": "移動",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1449,7 +1449,15 @@
       "resync": "同步",
       "imported": "從工作階段日誌匯入了 {{count}} 筆紀錄",
       "upToDate": "工作階段日誌已是最新",
-      "failed": "工作階段同步失敗"
+      "failed": "工作階段同步失敗",
+      "rebuild": "重新掃描",
+      "rebuildTrigger": "清除已匯入的用量並重新掃描工作階段日誌",
+      "rebuildTitle": "重新掃描工作階段用量？",
+      "rebuildMessage": "已匯入的工作階段用量與掃描進度將被清除，然後從本機 Claude、Codex、Gemini 與 OpenCode 日誌重新建構。聊天檔案、代理請求日誌與設定不會被刪除。",
+      "rebuildConfirm": "清除並重新掃描",
+      "rebuilt": "已掃描 {{files}} 個檔案並重新建構 {{count}} 筆紀錄",
+      "rebuildPartial": "重新掃描完成，但有 {{count}} 個工作階段日誌錯誤",
+      "rebuildFailed": "重新掃描工作階段用量失敗"
     },
     "totalRecords": "共 {{total}} 筆紀錄",
     "goToPage": "跳轉",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1477,7 +1477,15 @@
       "resync": "同步",
       "imported": "从会话日志导入了 {{count}} 条记录",
       "upToDate": "会话日志已是最新",
-      "failed": "会话同步失败"
+      "failed": "会话同步失败",
+      "rebuild": "重新扫描",
+      "rebuildTrigger": "清除已导入的用量并重新扫描会话日志",
+      "rebuildTitle": "重新扫描会话用量？",
+      "rebuildMessage": "已导入的会话用量和扫描进度将被清除，然后从本地 Claude、Codex、Gemini 和 OpenCode 日志重新构建。聊天文件、代理请求日志和设置不会被删除。",
+      "rebuildConfirm": "清除并重新扫描",
+      "rebuilt": "已扫描 {{files}} 个文件并重建 {{count}} 条记录",
+      "rebuildPartial": "重新扫描完成，但有 {{count}} 个会话日志错误",
+      "rebuildFailed": "重新扫描会话用量失败"
     },
     "totalRecords": "共 {{total}} 条记录",
     "goToPage": "跳转",

--- a/src/lib/api/usage.ts
+++ b/src/lib/api/usage.ts
@@ -180,6 +180,10 @@ export const usageApi = {
     return invoke("sync_session_usage");
   },
 
+  rebuildSessionUsage: async (): Promise<SessionSyncResult> => {
+    return invoke("rebuild_session_usage");
+  },
+
   getDataSourceBreakdown: async (): Promise<DataSourceSummary[]> => {
     return invoke("get_usage_data_sources");
   },

--- a/tests/components/UsageDashboard.test.tsx
+++ b/tests/components/UsageDashboard.test.tsx
@@ -12,15 +12,49 @@ import { UsageDashboard } from "@/components/usage/UsageDashboard";
 
 const useProviderStatsMock = vi.hoisted(() => vi.fn());
 const useModelStatsMock = vi.hoisted(() => vi.fn());
+const rebuildSessionUsageMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+const toastWarningMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback ?? key,
+    t: (key: string, fallback?: string) =>
+      typeof fallback === "string" ? fallback : key,
     i18n: {
       resolvedLanguage: "en",
       language: "en",
     },
   }),
+}));
+
+vi.mock("@/lib/api/usage", () => ({
+  usageApi: { rebuildSessionUsage: rebuildSessionUsageMock },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    warning: toastWarningMock,
+    error: toastErrorMock,
+  },
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    confirmText,
+    onConfirm,
+  }: {
+    isOpen: boolean;
+    confirmText: string;
+    onConfirm: () => void;
+  }) =>
+    isOpen ? (
+      <button type="button" onClick={onConfirm}>
+        {confirmText}
+      </button>
+    ) : null,
 }));
 
 vi.mock("framer-motion", () => ({
@@ -98,11 +132,14 @@ const renderDashboard = (props: ComponentProps<typeof UsageDashboard> = {}) => {
       queries: { retry: false },
     },
   });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <UsageDashboard {...props} />
-    </QueryClientProvider>,
-  );
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <UsageDashboard {...props} />
+      </QueryClientProvider>,
+    ),
+  };
 };
 
 describe("UsageDashboard", () => {
@@ -111,6 +148,12 @@ describe("UsageDashboard", () => {
     useModelStatsMock.mockReset();
     useProviderStatsMock.mockReturnValue({ data: [] });
     useModelStatsMock.mockReturnValue({ data: [] });
+    rebuildSessionUsageMock.mockResolvedValue({
+      imported: 42,
+      skipped: 3,
+      filesScanned: 7,
+      errors: [],
+    });
   });
 
   it("uses the saved refresh interval when mounted", () => {
@@ -151,5 +194,31 @@ describe("UsageDashboard", () => {
     await waitFor(() =>
       expect(screen.getByTestId("select-30000")).toBeInTheDocument(),
     );
+  });
+
+  it("confirms before rebuilding session usage", async () => {
+    const { queryClient } = renderDashboard();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "usage.sessionSync.rebuild" }),
+    );
+    expect(rebuildSessionUsageMock).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "usage.sessionSync.rebuildConfirm",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(rebuildSessionUsageMock).toHaveBeenCalledTimes(1),
+    );
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["usage"],
+      }),
+    );
+    expect(toastSuccessMock).toHaveBeenCalledWith("usage.sessionSync.rebuilt");
   });
 });


### PR DESCRIPTION
## Summary / 概述

- Prevent Codex subagent rollouts from importing copied parent token history as new usage.
- Serialize startup, periodic, manual, and rebuild syncs so a rescan cannot race with background ingestion.
- Add a confirmed **Rescan** action that clears only reconstructible session-derived usage, rollups, and cursors, then rebuilds them from local Claude, Codex, Gemini, and OpenCode logs.

Codex subagent rollouts contain a parent-history snapshot. That copied history may already contain `thread_settings_applied`, while the real child takeover is marked later by a top-level `inter_agent_communication*` event. The previous parser treated the copied settings event as the replay boundary and inserted the remaining parent history again.

This change continues consuming replayed cumulative token events to restore the delta baseline and stable event index, but only inserts subagent usage after the real takeover marker. A snapshot with no takeover marker remains baseline-only.

The rescan runs under the same sync mutex and clears session-derived rows in one transaction. It preserves raw chat files, proxy request logs, providers, settings, and other application data.

## Related Issue / 关联 Issue

Related to #4177 and #2571.

This takes a different approach from #5341: it does not filter usage by `active_thread_id`, so it preserves child usage in the legacy/fork scenario called out during that PR's review. Instead, it suppresses insertion only while parsing the copied pre-takeover snapshot.

## Screenshots / 截图

Not included. The UI change is a single Rescan button using the existing confirmation dialog.

## Testing / 测试

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (1,978 library tests passed, 2 ignored; all integration targets passed)
- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] `pnpm exec vitest run tests/components/UsageDashboard.test.tsx`
- [x] Read-only audit against real local Codex rollouts using an in-memory database

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
