### PR TITLE
fix(claude-desktop): preserve non-gateway profile fields on provider switch

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -999,7 +999,12 @@ fn apply_provider_to_paths_inner(
 
     write_deployment_mode(&paths.normal_config_path, "3p")?;
     write_deployment_mode(&paths.threep_config_path, "3p")?;
-    write_json_file(&paths.profile_path, &profile)?;
+    // Merge with the existing profile instead of overwriting it wholesale, so
+    // non-gateway fields Claude Desktop / the user set (managedMcpServers,
+    // chatTabEnabled, autoModeEnabled, ...) survive a provider switch.
+    let existing = read_json_or_empty(&paths.profile_path)?;
+    let merged = merge_profile(&existing, &profile);
+    write_json_file(&paths.profile_path, &merged)?;
     write_meta(&paths.meta_path, Some(PROFILE_ID))?;
 
     Ok(())
@@ -1038,6 +1043,38 @@ fn build_gateway_profile(
     }
 
     profile
+}
+
+/// Merge a freshly-built gateway profile with whatever is already on disk.
+///
+/// `build_gateway_profile` rebuilds only the gateway-related fields on every
+/// switch. Writing that object directly would discard non-gateway fields that
+/// Claude Desktop or the user relies on -- `managedMcpServers`,
+/// `chatTabEnabled`, `autoModeEnabled`, `inferenceCredentialKind`, and the
+/// like -- which can trigger a Claude Desktop UI/session reset that wipes
+/// plugin marketplaces, skills, and MCP state (issue #3329).
+///
+/// Strategy: start from the existing profile, overwrite every key the new
+/// profile carries (so gateway fields are always refreshed), and preserve any
+/// other key already on disk. `inferenceModels` is gateway-owned but
+/// conditionally written by `build_gateway_profile`; when the new profile
+/// omits it we drop any stale value so the previous provider's model mappings
+/// do not leak across a switch.
+fn merge_profile(existing: &Value, new_profile: &Value) -> Value {
+    let mut merged = existing.clone();
+    let Some(merged_obj) = merged.as_object_mut() else {
+        return new_profile.clone();
+    };
+    let Some(new_obj) = new_profile.as_object() else {
+        return new_profile.clone();
+    };
+    for (key, value) in new_obj {
+        merged_obj.insert(key.clone(), value.clone());
+    }
+    if !new_obj.contains_key("inferenceModels") {
+        merged_obj.remove("inferenceModels");
+    }
+    merged
 }
 
 fn read_json_or_empty(path: &Path) -> Result<Value, AppError> {
@@ -1512,6 +1549,69 @@ mod tests {
             .expect("entries")
             .iter()
             .any(|entry| entry["id"] == json!(PROFILE_ID) && entry["name"] == json!(PROFILE_NAME)));
+    }
+
+    #[test]
+    fn claude_desktop_apply_preserves_non_gateway_profile_fields() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+
+        // Simulate a profile Claude Desktop / the user already wrote, carrying
+        // non-gateway fields that cc-switch does not own.
+        let existing = json!({
+            "inferenceGatewayBaseUrl": "https://old.example.com",
+            "inferenceGatewayApiKey": "old-token",
+            "chatTabEnabled": true,
+            "autoModeEnabled": true,
+            "inferenceCredentialKind": "static",
+            "managedMcpServers": [
+                { "name": "opencli", "url": "http://127.0.0.1:31337/" }
+            ]
+        });
+        write_json_file(&paths.profile_path, &existing).expect("pre-write profile");
+
+        let provider = direct_provider("direct");
+        let db = test_db();
+        apply_provider_to_paths(&db, &provider, &paths).expect("apply provider");
+
+        let profile: Value = read_json_file(&paths.profile_path).expect("read profile");
+
+        // Gateway fields are refreshed to the new provider's values.
+        assert_eq!(
+            profile["inferenceGatewayBaseUrl"],
+            json!("https://gateway.example.com")
+        );
+        assert_eq!(profile["inferenceGatewayApiKey"], json!("test-token"));
+        assert_eq!(profile["inferenceProvider"], json!("gateway"));
+
+        // Non-gateway fields are preserved across the switch.
+        assert_eq!(profile["chatTabEnabled"], json!(true));
+        assert_eq!(profile["autoModeEnabled"], json!(true));
+        assert_eq!(profile["inferenceCredentialKind"], json!("static"));
+        assert_eq!(profile["managedMcpServers"][0]["name"], json!("opencli"));
+    }
+
+    #[test]
+    fn claude_desktop_apply_clears_stale_inference_models_when_new_provider_has_none() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+
+        // Previous provider carried model mappings; new provider (direct_provider
+        // with no model routes) must not leak them.
+        let existing = json!({
+            "inferenceGatewayBaseUrl": "https://old.example.com",
+            "inferenceModels": [
+                { "name": "claude-sonnet-4-6", "labelOverride": "old-label" }
+            ]
+        });
+        write_json_file(&paths.profile_path, &existing).expect("pre-write profile");
+
+        let provider = direct_provider("direct");
+        let db = test_db();
+        apply_provider_to_paths(&db, &provider, &paths).expect("apply provider");
+
+        let profile: Value = read_json_file(&paths.profile_path).expect("read profile");
+        assert!(profile.get("inferenceModels").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Switching the Claude Desktop provider through CC Switch wipes non-gateway fields from the configLibrary profile (`configLibrary/00000000-0000-4000-8000-000000157210.json`), which triggers a Claude Desktop UI/session reset that clears plugin marketplaces, skills, and MCP state. Users have to re-add them after every switch.

Reported in #3329.

## Root cause

`apply_provider_to_paths_inner` rebuilds only the gateway-related fields on every switch (`build_gateway_profile`) and writes that object as a **full overwrite** of the profile:

```rust
let profile = build_gateway_profile(...);   // only 6 gateway fields (+ conditional inferenceModels)
write_json_file(&paths.profile_path, &profile)?;   // wholesale overwrite
```

`build_gateway_profile` never carries `managedMcpServers`, `chatTabEnabled`, `autoModeEnabled`, `inferenceCredentialKind`, etc., so those keys vanish from disk on each switch.

## Fix

Merge the freshly-built gateway profile with the existing on-disk profile instead of overwriting:

- Start from the existing profile.
- Overwrite every key the new profile carries (gateway fields are always refreshed).
- Preserve any other key already on disk.
- `inferenceModels` is gateway-owned but conditionally written by `build_gateway_profile`; when the new profile omits it, drop any stale value so the previous provider's model mappings don't leak across a switch.

This mirrors the existing intent that "Claude Desktop 3P profiles do not use CC Switch MCP sync" — CC Switch only owns the gateway fields, everything else belongs to Claude Desktop / the user and must survive a switch.

## Scope

- Only touches the `AppType::ClaudeDesktop` switch path (`apply_provider_to_paths_inner`).
- Claude Code / Codex / Gemini switch paths are unaffected.
- The official-provider restore path (`restore_official_at_paths_inner`, which deletes the profile) is unchanged.
- The `with_rollback` snapshot/restore is unaffected: snapshots are taken before `apply_provider_to_paths_inner` runs, so the merge reads the same pre-switch state and rollback still restores the original on failure.

## Tests

- `claude_desktop_apply_preserves_non_gateway_profile_fields` — pre-writes a profile with `chatTabEnabled`, `autoModeEnabled`, `inferenceCredentialKind`, `managedMcpServers`; applies a provider; asserts gateway fields are refreshed **and** non-gateway fields survive.
- `claude_desktop_apply_clears_stale_inference_models_when_new_provider_has_none` — asserts a stale `inferenceModels` from the previous provider is cleared when the new provider has no model routes.
- Existing `claude_desktop_apply_writes_3p_profile_and_meta` still holds: on a fresh tempdir the existing profile is empty, so the merge result equals the new profile.

Fixes #3329

🤖 Generated with [Claude Code](https://claude.com/claude-code)