### PR TITLE
fix(opencode): preserve model variant order

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -255,30 +255,90 @@ pub fn read_json_file<T: for<'a> Deserialize<'a>>(path: &Path) -> Result<T, AppE
 
 /// 递归排序 JSON 对象的键（按字母顺序），确保序列化输出是确定性的
 fn sort_json_keys(value: &Value) -> Value {
+    sort_json_keys_preserving_object_key_order(value, &[])
+}
+
+/// 递归排序 JSON 对象的键，但保留指定对象键所对应对象的直接键顺序。
+///
+/// 被保留对象的子值仍会递归排序，因此只影响该对象自身的直接键顺序。
+fn sort_json_keys_preserving_object_key_order(
+    value: &Value,
+    preserve_object_key_order_for: &[&str],
+) -> Value {
     match value {
         Value::Object(map) => {
             let mut sorted_map = Map::new();
             let mut keys: Vec<_> = map.keys().collect();
             keys.sort();
             for key in keys {
-                sorted_map.insert(key.clone(), sort_json_keys(&map[key]));
+                let child = &map[key];
+                let sorted_child = if preserve_object_key_order_for.contains(&key.as_str()) {
+                    sort_json_object_preserving_direct_key_order(
+                        child,
+                        preserve_object_key_order_for,
+                    )
+                } else {
+                    sort_json_keys_preserving_object_key_order(child, preserve_object_key_order_for)
+                };
+                sorted_map.insert(key.clone(), sorted_child);
             }
             Value::Object(sorted_map)
         }
-        Value::Array(arr) => Value::Array(arr.iter().map(sort_json_keys).collect()),
+        Value::Array(arr) => Value::Array(
+            arr.iter()
+                .map(|item| {
+                    sort_json_keys_preserving_object_key_order(item, preserve_object_key_order_for)
+                })
+                .collect(),
+        ),
         other => other.clone(),
+    }
+}
+
+fn sort_json_object_preserving_direct_key_order(
+    value: &Value,
+    preserve_object_key_order_for: &[&str],
+) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        sort_json_keys_preserving_object_key_order(
+                            value,
+                            preserve_object_key_order_for,
+                        ),
+                    )
+                })
+                .collect(),
+        ),
+        _ => sort_json_keys_preserving_object_key_order(value, preserve_object_key_order_for),
     }
 }
 
 /// 写入 JSON 配置文件（键按字母排序，确保确定性输出）
 pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppError> {
+    write_json_file_preserving_object_key_order(path, data, &[])
+}
+
+/// 写入 JSON 配置文件，并保留指定对象键所对应对象的直接键顺序。
+pub fn write_json_file_preserving_object_key_order<T: Serialize>(
+    path: &Path,
+    data: &T,
+    preserve_object_key_order_for: &[&str],
+) -> Result<(), AppError> {
     // 确保目录存在
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
     }
 
     let value = serde_json::to_value(data).map_err(|e| AppError::JsonSerialize { source: e })?;
-    let sorted_value = sort_json_keys(&value);
+    let sorted_value = if preserve_object_key_order_for.is_empty() {
+        sort_json_keys(&value)
+    } else {
+        sort_json_keys_preserving_object_key_order(&value, preserve_object_key_order_for)
+    };
     let json = serde_json::to_string_pretty(&sorted_value)
         .map_err(|e| AppError::JsonSerialize { source: e })?;
 
@@ -520,6 +580,63 @@ mod tests {
             serde_json::to_string(&sorted_a).unwrap(),
             serde_json::to_string(&sorted_b).unwrap(),
         );
+    }
+
+    #[test]
+    fn preserved_object_key_order_keeps_variants_order_but_sorts_other_objects() {
+        let input = serde_json::json!({
+            "z_top": 1,
+            "models": {
+                "example": {
+                    "z_model": 1,
+                    "variants": {
+                        "none": { "z_field": 1, "a_field": 2 },
+                        "low": { "z_field": 1, "a_field": 2 },
+                        "medium": { "z_field": 1, "a_field": 2 },
+                        "high": { "z_field": 1, "a_field": 2 },
+                        "xhigh": { "z_field": 1, "a_field": 2 },
+                        "max": { "z_field": 1, "a_field": 2 }
+                    },
+                    "a_model": 2
+                }
+            },
+            "a_top": 2
+        });
+
+        let sorted = sort_json_keys_preserving_object_key_order(&input, &["variants"]);
+        let top_level_keys: Vec<_> = sorted
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let model = &sorted["models"]["example"];
+        let model_keys: Vec<_> = model
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let variant_keys: Vec<_> = model["variants"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let variant_field_keys: Vec<_> = model["variants"]["none"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+
+        assert_eq!(top_level_keys, ["a_top", "models", "z_top"]);
+        assert_eq!(model_keys, ["a_model", "variants", "z_model"]);
+        assert_eq!(
+            variant_keys,
+            ["none", "low", "medium", "high", "xhigh", "max"]
+        );
+        assert_eq!(variant_field_keys, ["a_field", "z_field"]);
     }
 }
 

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -1,4 +1,4 @@
-use crate::config::write_json_file;
+use crate::config::write_json_file_preserving_object_key_order;
 use crate::error::AppError;
 use crate::provider::OpenCodeProviderConfig;
 use crate::settings::get_opencode_override_dir;
@@ -105,7 +105,7 @@ pub fn read_opencode_config() -> Result<Value, AppError> {
 
 pub fn write_opencode_config(config: &Value) -> Result<(), AppError> {
     let path = get_opencode_config_path();
-    write_json_file(&path, config)?;
+    write_json_file_preserving_object_key_order(&path, config, &["variants"])?;
 
     log::debug!("OpenCode config written to {path:?}");
     Ok(())


### PR DESCRIPTION
## Summary / 概述

- Preserve the insertion order of direct keys inside OpenCode model `variants`.
- Continue sorting surrounding JSON objects and fields inside each variant.
- Keep the default JSON writing and alphabetical sorting behavior unchanged.

## Related Issue / 关联 Issue

Fixes #5431

## Screenshots / 截图

N/A — backend JSON serialization fix.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes / 通过 Clippy 检查
- [x] No user-facing text changed; i18n update is not required / 未修改用户可见文本，无需更新国际化文件

## Testing / 测试

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- Regression test: `preserved_object_key_order_keeps_variants_order_but_sorts_other_objects`

Local Windows note: `pnpm format:check` reports CRLF warnings across unchanged frontend files. Frontend unit tests report 444 passing tests and two existing `App.test.tsx` failures; this PR has no frontend diff. The Linux PR CI is the authoritative check.
