### PR TITLE
feat(mcp): filter servers by app

### DIFF
--- a/src/components/common/AppCountBar.tsx
+++ b/src/components/common/AppCountBar.tsx
@@ -2,34 +2,80 @@ import React from "react";
 import { Badge } from "@/components/ui/badge";
 import type { AppId } from "@/lib/api/types";
 import { APP_IDS, APP_ICON_MAP } from "@/config/appConfig";
+import { cn } from "@/lib/utils";
+
+export type AppCountBarFilter = AppId | "all";
+
+const interactiveBadgeClass =
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-all outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0";
 
 interface AppCountBarProps {
   totalLabel: string;
   counts: Partial<Record<AppId, number>>;
   appIds?: AppId[];
+  selectedApp?: AppCountBarFilter;
+  onAppSelect?: (app: AppCountBarFilter) => void;
 }
 
 export const AppCountBar: React.FC<AppCountBarProps> = ({
   totalLabel,
   counts,
   appIds = APP_IDS,
+  selectedApp = "all",
+  onAppSelect,
 }) => {
+  const isInteractive = Boolean(onAppSelect);
+
   return (
     <div className="flex-shrink-0 py-4 glass rounded-xl border border-white/10 mb-4 px-6 flex items-center justify-between gap-4">
-      <Badge variant="outline" className="bg-background/50 h-7 px-3">
-        {totalLabel}
-      </Badge>
+      {isInteractive ? (
+        <button
+          type="button"
+          className={cn(
+            interactiveBadgeClass,
+            "bg-background/50 h-7 px-3 cursor-pointer hover:bg-foreground/10 hover:text-foreground active:bg-foreground/15 active:scale-[0.98]",
+          )}
+          onClick={() => onAppSelect?.("all")}
+        >
+          {totalLabel}
+        </button>
+      ) : (
+        <Badge variant="outline" className="bg-background/50 h-7 px-3">
+          {totalLabel}
+        </Badge>
+      )}
       <div className="flex items-center gap-2 overflow-x-auto no-scrollbar">
-        {appIds.map((app) => (
-          <Badge
-            key={app}
-            variant="secondary"
-            className={APP_ICON_MAP[app].badgeClass}
-          >
-            <span className="opacity-75">{APP_ICON_MAP[app].label}:</span>
-            <span className="font-bold ml-1">{counts[app] ?? 0}</span>
-          </Badge>
-        ))}
+        {appIds.map((app) =>
+          isInteractive ? (
+            <button
+              key={app}
+              type="button"
+              className={cn(
+                interactiveBadgeClass,
+                APP_ICON_MAP[app].badgeClass,
+                "cursor-pointer active:brightness-95 active:scale-[0.98] active:opacity-100",
+                selectedApp === app
+                  ? "font-semibold opacity-100"
+                  : "opacity-60 hover:opacity-100",
+              )}
+              onClick={() => onAppSelect?.(app)}
+              aria-pressed={selectedApp === app}
+              aria-label={`Filter by ${APP_ICON_MAP[app].label}`}
+            >
+              <span className="opacity-75">{APP_ICON_MAP[app].label}:</span>
+              <span className="font-bold ml-1">{counts[app] ?? 0}</span>
+            </button>
+          ) : (
+            <Badge
+              key={app}
+              variant="secondary"
+              className={APP_ICON_MAP[app].badgeClass}
+            >
+              <span className="opacity-75">{APP_ICON_MAP[app].label}:</span>
+              <span className="font-bold ml-1">{counts[app] ?? 0}</span>
+            </Badge>
+          ),
+        )}
       </div>
     </div>
   );

--- a/src/components/common/AppCountBar.tsx
+++ b/src/components/common/AppCountBar.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 export type AppCountBarFilter = AppId | "all";
 
 const interactiveBadgeClass =
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-all outline-none focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0";
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-all outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring";
 
 interface AppCountBarProps {
   totalLabel: string;

--- a/src/components/mcp/UnifiedMcpPanel.tsx
+++ b/src/components/mcp/UnifiedMcpPanel.tsx
@@ -18,9 +18,13 @@ import { settingsApi } from "@/lib/api";
 import { mcpPresets } from "@/config/mcpPresets";
 import { toast } from "sonner";
 import { MCP_APP_IDS } from "@/config/appConfig";
-import { AppCountBar } from "@/components/common/AppCountBar";
+import {
+  AppCountBar,
+  type AppCountBarFilter,
+} from "@/components/common/AppCountBar";
 import { AppToggleGroup } from "@/components/common/AppToggleGroup";
 import { ListItemRow } from "@/components/common/ListItemRow";
+import { filterMcpServers } from "./mcpFilter";
 
 interface UnifiedMcpPanelProps {
   onOpenChange: (open: boolean) => void;
@@ -38,6 +42,7 @@ const UnifiedMcpPanel = React.forwardRef<
   const { t } = useTranslation();
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [selectedApp, setSelectedApp] = useState<AppCountBarFilter>("all");
   const [confirmDialog, setConfirmDialog] = useState<{
     isOpen: boolean;
     title: string;
@@ -54,6 +59,11 @@ const UnifiedMcpPanel = React.forwardRef<
     if (!serversMap) return [];
     return Object.entries(serversMap);
   }, [serversMap]);
+
+  const filteredServerEntries = useMemo(
+    () => filterMcpServers(serverEntries, selectedApp),
+    [serverEntries, selectedApp],
+  );
 
   const enabledCounts = useMemo(() => {
     const counts = {
@@ -145,6 +155,8 @@ const UnifiedMcpPanel = React.forwardRef<
         totalLabel={t("mcp.serverCount", { count: serverEntries.length })}
         counts={enabledCounts}
         appIds={MCP_APP_IDS}
+        selectedApp={selectedApp}
+        onAppSelect={setSelectedApp}
       />
 
       <div className="flex-1 overflow-y-auto overflow-x-hidden pb-24">
@@ -164,10 +176,22 @@ const UnifiedMcpPanel = React.forwardRef<
               {t("mcp.emptyDescription")}
             </p>
           </div>
+        ) : filteredServerEntries.length === 0 ? (
+          <div className="text-center py-12">
+            <div className="w-16 h-16 mx-auto mb-4 bg-muted rounded-full flex items-center justify-center">
+              <Server size={24} className="text-muted-foreground" />
+            </div>
+            <h3 className="text-lg font-medium text-foreground mb-2">
+              {t("mcp.unifiedPanel.noMatchingServers")}
+            </h3>
+            <p className="text-muted-foreground text-sm">
+              {t("mcp.unifiedPanel.noMatchingServersDescription")}
+            </p>
+          </div>
         ) : (
           <TooltipProvider delayDuration={300}>
             <div className="rounded-xl border border-border-default overflow-hidden">
-              {serverEntries.map(([id, server], index) => (
+              {filteredServerEntries.map(([id, server], index) => (
                 <UnifiedMcpListItem
                   key={id}
                   id={id}
@@ -175,7 +199,7 @@ const UnifiedMcpPanel = React.forwardRef<
                   onToggleApp={handleToggleApp}
                   onEdit={handleEdit}
                   onDelete={handleDelete}
-                  isLast={index === serverEntries.length - 1}
+                  isLast={index === filteredServerEntries.length - 1}
                 />
               ))}
             </div>

--- a/src/components/mcp/mcpFilter.test.ts
+++ b/src/components/mcp/mcpFilter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { McpServer } from "@/types";
+import { filterMcpServers, type McpServerEntry } from "./mcpFilter";
+
+const defaultApps: McpServer["apps"] = {
+  claude: false,
+  codex: false,
+  gemini: false,
+  opencode: false,
+  openclaw: false,
+  hermes: false,
+};
+
+function createServer(
+  id: string,
+  apps: Partial<McpServer["apps"]> = {},
+): McpServer {
+  return {
+    id,
+    name: id,
+    server: { type: "stdio", command: "mock-server" },
+    apps: { ...defaultApps, ...apps },
+  };
+}
+
+describe("filterMcpServers", () => {
+  const entries: McpServerEntry[] = [
+    ["claude-mcp", createServer("claude-mcp", { claude: true })],
+    ["codex-mcp", createServer("codex-mcp", { codex: true })],
+    ["shared-mcp", createServer("shared-mcp", { claude: true, codex: true })],
+  ];
+
+  it("returns every server for the total filter", () => {
+    expect(filterMcpServers(entries, "all")).toBe(entries);
+  });
+
+  it("returns only servers enabled for the selected app", () => {
+    expect(filterMcpServers(entries, "claude").map(([id]) => id)).toEqual([
+      "claude-mcp",
+      "shared-mcp",
+    ]);
+    expect(filterMcpServers(entries, "codex").map(([id]) => id)).toEqual([
+      "codex-mcp",
+      "shared-mcp",
+    ]);
+  });
+
+  it("excludes servers that are disabled for the selected app", () => {
+    expect(filterMcpServers(entries, "gemini")).toEqual([]);
+  });
+});

--- a/src/components/mcp/mcpFilter.ts
+++ b/src/components/mcp/mcpFilter.ts
@@ -1,0 +1,13 @@
+import type { AppCountBarFilter } from "@/components/common/AppCountBar";
+import type { McpServer } from "@/types";
+
+export type McpServerEntry = [string, McpServer];
+
+export function filterMcpServers(
+  entries: McpServerEntry[],
+  filter: AppCountBarFilter,
+): McpServerEntry[] {
+  if (filter === "all") return entries;
+
+  return entries.filter(([, server]) => server.apps[filter] === true);
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1712,6 +1712,8 @@
       "deleteServer": "Delete Server",
       "deleteConfirm": "Are you sure you want to delete server \"{{id}}\"? This action cannot be undone.",
       "noServers": "No servers yet",
+      "noMatchingServers": "No MCP servers configured for this app",
+      "noMatchingServersDescription": "Switch apps or click the total button to view all MCP servers",
       "enabledApps": "Enabled Apps",
       "noImportFound": "No MCP servers to import found. All servers are already managed by CC Switch.",
       "importSuccess": "Successfully imported {{count}} MCP servers",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1712,6 +1712,8 @@
       "deleteServer": "サーバーを削除",
       "deleteConfirm": "サーバー「{{id}}」を削除しますか？この操作は元に戻せません。",
       "noServers": "まだサーバーがありません",
+      "noMatchingServers": "このアプリに設定された MCP サーバーはありません",
+      "noMatchingServersDescription": "アプリを切り替えるか、上部の合計ボタンをクリックしてすべての MCP サーバーを表示してください",
       "enabledApps": "有効なアプリ",
       "noImportFound": "インポートする MCP サーバーが見つかりませんでした。すべてのサーバーは CC Switch で管理されています。",
       "importSuccess": "{{count}} 個の MCP サーバーをインポートしました",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1684,6 +1684,8 @@
       "deleteServer": "刪除伺服器",
       "deleteConfirm": "確定要刪除伺服器 \"{{id}}\" 嗎？此操作無法復原。",
       "noServers": "暫無伺服器",
+      "noMatchingServers": "目前應用程式沒有已設定的 MCP 伺服器",
+      "noMatchingServersDescription": "切換應用程式或點擊頂部總數按鈕查看全部 MCP 伺服器",
       "enabledApps": "啟用的應用程式",
       "noImportFound": "未發現需要匯入的 MCP 伺服器。所有伺服器已在 CC Switch 統一管理中。",
       "importSuccess": "成功匯入 {{count}} 個 MCP 伺服器",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1712,6 +1712,8 @@
       "deleteServer": "删除服务器",
       "deleteConfirm": "确定要删除服务器 \"{{id}}\" 吗？此操作无法撤销。",
       "noServers": "暂无服务器",
+      "noMatchingServers": "当前应用没有已配置的 MCP 服务器",
+      "noMatchingServersDescription": "切换应用或点击顶部总数按钮查看全部 MCP 服务器",
       "enabledApps": "启用的应用",
       "noImportFound": "未发现需要导入的 MCP 服务器。所有服务器已在 CC Switch 统一管理中。",
       "importSuccess": "成功导入 {{count}} 个 MCP 服务器",

--- a/tests/components/UnifiedMcpPanel.test.tsx
+++ b/tests/components/UnifiedMcpPanel.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { McpServer, McpServersMap } from "@/types";
+
+import UnifiedMcpPanel from "@/components/mcp/UnifiedMcpPanel";
+
+const serversMock = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useMcp", () => ({
+  useAllMcpServers: () => serversMock(),
+  useToggleMcpApp: () => ({ mutateAsync: vi.fn() }),
+  useDeleteMcpServer: () => ({ mutateAsync: vi.fn() }),
+  useImportMcpFromApps: () => ({ mutateAsync: vi.fn() }),
+}));
+
+describe("UnifiedMcpPanel", () => {
+  beforeEach(() => {
+    serversMock.mockReturnValue({
+      data: {},
+      isLoading: false,
+    });
+  });
+
+  it("filters MCP servers by the selected app and restores the original total view", async () => {
+    const servers: McpServersMap = {
+      "claude-mcp": createMcpServer("claude-mcp", { claude: true }),
+      "codex-mcp": createMcpServer("codex-mcp", { codex: true }),
+      "shared-mcp": createMcpServer("shared-mcp", {
+        claude: true,
+        codex: true,
+      }),
+    };
+    serversMock.mockReturnValue({ data: servers, isLoading: false });
+
+    render(<UnifiedMcpPanel onOpenChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("claude-mcp")).toBeInTheDocument();
+      expect(screen.getByText("codex-mcp")).toBeInTheDocument();
+      expect(screen.getByText("shared-mcp")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter by Claude" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("claude-mcp")).toBeInTheDocument();
+      expect(screen.getByText("shared-mcp")).toBeInTheDocument();
+      expect(screen.queryByText("codex-mcp")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter by Codex" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("codex-mcp")).toBeInTheDocument();
+      expect(screen.getByText("shared-mcp")).toBeInTheDocument();
+      expect(screen.queryByText("claude-mcp")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "mcp.serverCount" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("claude-mcp")).toBeInTheDocument();
+      expect(screen.getByText("codex-mcp")).toBeInTheDocument();
+      expect(screen.getByText("shared-mcp")).toBeInTheDocument();
+    });
+  });
+});
+
+function createMcpServer(
+  id: string,
+  apps: Partial<McpServer["apps"]> = {},
+): McpServer {
+  return {
+    id,
+    name: id,
+    server: { type: "stdio", command: "mock-server" },
+    apps: {
+      claude: false,
+      codex: false,
+      gemini: false,
+      opencode: false,
+      openclaw: false,
+      hermes: false,
+      ...apps,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- 增加MCP页面不同应用的筛选
- Add app-based filtering to the MCP management page.
- Add filtered empty-state copy and interaction coverage.
- close #5446
## Verification
- Targeted MCP tests passed: 4 tests.
- pnpm typecheck passed.
- pnpm format:check passed.
- pnpm build:renderer passed.
- Full unit suite still has two existing App.test.tsx integration failures; the file passes in isolation with --testTimeout=15000.

## show
- 点击Claude的效果
<img width="966" height="754" alt="b316383d60b4cbb04d0b97b6910c522c" src="https://github.com/user-attachments/assets/31bef372-7930-4e23-906f-42289eeb740f" />

- 点击codex的效果
<img width="966" height="754" alt="15fddd47c6f65d43d159f4f0342bf5e0" src="https://github.com/user-attachments/assets/2a720ad9-7996-42a5-97f4-b169ec50a15c" />

-点击已配置1个 MCP 服务器的效果（默认）
<img width="966" height="754" alt="a8d7e49b8557220f32d6e9920a5cd409" src="https://github.com/user-attachments/assets/82e33541-6763-4f70-b7eb-c396abcb3889" />


