### PR TITLE
docs(toolchain): align Rust version requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ There are many ways to contribute:
 ### Prerequisites
 
 - Node.js 18+ and pnpm 8+
-- Rust 1.85+ and Cargo
+- Rust 1.95 with Cargo, rustfmt, and clippy components
 - [Tauri 2.0 prerequisites](https://v2.tauri.app/start/prerequisites/)
 
 ### Quick Start
@@ -149,7 +149,7 @@ CC Switch supports three languages. When modifying user-facing text:
 ### 前提条件
 
 - Node.js 18+ 和 pnpm 8+
-- Rust 1.85+ 和 Cargo
+- Rust 1.95 和 Cargo，并安装 rustfmt、clippy 组件
 - [Tauri 2.0 开发环境](https://v2.tauri.app/start/prerequisites/)
 
 ### 快速开始

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Download the latest Linux build from the [Releases](../../releases) page:
 
 - Node.js 18+
 - pnpm 8+
-- Rust 1.85+
+- Rust 1.95 (with the rustfmt and clippy components)
 - Tauri CLI 2.8+
 
 ### Development Commands

--- a/README_DE.md
+++ b/README_DE.md
@@ -441,7 +441,7 @@ Laden Sie den neuesten Linux-Build von der Seite [Releases](../../releases) heru
 
 - Node.js 18+
 - pnpm 8+
-- Rust 1.85+
+- Rust 1.95 (mit den Komponenten rustfmt und clippy)
 - Tauri CLI 2.8+
 
 ### Entwicklungsbefehle

--- a/README_JA.md
+++ b/README_JA.md
@@ -441,7 +441,7 @@ paru -S cc-switch-bin
 
 - Node.js 18+
 - pnpm 8+
-- Rust 1.85+
+- Rust 1.95（rustfmt と clippy コンポーネントが必要）
 - Tauri CLI 2.8+
 
 ### 開発コマンド

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -444,7 +444,7 @@ paru -S cc-switch-bin
 
 - Node.js 18+
 - pnpm 8+
-- Rust 1.85+
+- Rust 1.95（需要 rustfmt 和 clippy 组件）
 - Tauri CLI 2.8+
 
 ### 开发命令


### PR DESCRIPTION
## Summary
- Update the localized README files and CONTRIBUTING.md from Rust 1.85+ to Rust 1.95.
- Document that the rustfmt and clippy components are required, matching rust-toolchain.toml.
- 中文简述：同步文档中的 Rust 版本要求，使其与根目录固定的 Rust 1.95 工具链及 rustfmt、clippy 组件保持一致。

## Verification
- git diff --check passed.
- Confirmed no Rust 1.85+ prerequisite remains in the updated developer documentation.

Closes #5449