### PR TITLE
fix(webdav): send default User-Agent for reverse-proxy compatibility

### DIFF
--- a/src-tauri/src/services/webdav.rs
+++ b/src-tauri/src/services/webdav.rs
@@ -3,6 +3,7 @@
 //! Low-level HTTP primitives for WebDAV operations (PUT, GET, HEAD, MKCOL, PROPFIND).
 //! The sync protocol logic lives in [`super::webdav_sync`].
 
+use reqwest::header::USER_AGENT;
 use reqwest::{Method, RequestBuilder, StatusCode, Url};
 use std::time::Duration;
 
@@ -13,6 +14,12 @@ use futures::StreamExt;
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 /// Timeout for large file transfers (PUT/GET of db.sql, skills.zip).
 const TRANSFER_TIMEOUT_SECS: u64 = 300;
+
+/// Default User-Agent for WebDAV requests.
+///
+/// Cloudflare and some reverse proxies reject requests without a User-Agent
+/// (HTTP 403 "Missing required headers"). reqwest does not send one by default.
+const WEBDAV_USER_AGENT: &str = concat!("cc-switch/", env!("CARGO_PKG_VERSION"), " WebDAV");
 
 /// Auth pair: `(username, Some(password))`.
 pub type WebDavAuth = Option<(String, Option<String>)>;
@@ -93,8 +100,12 @@ pub fn auth_from_credentials(username: &str, password: &str) -> WebDavAuth {
     Some((user.to_string(), Some(password.to_string())))
 }
 
-/// Apply Basic-Auth to a request builder if auth is present.
+/// Apply shared WebDAV request headers and Basic-Auth if present.
+///
+/// Always sets a User-Agent so reverse proxies (e.g. Cloudflare) that require
+/// it do not reject the request with 403.
 fn apply_auth(builder: RequestBuilder, auth: &WebDavAuth) -> RequestBuilder {
+    let builder = builder.header(USER_AGENT, WEBDAV_USER_AGENT);
     match auth {
         Some((user, pass)) => builder.basic_auth(user, pass.as_deref()),
         None => builder,
@@ -516,6 +527,13 @@ mod tests {
         assert!(auth_from_credentials("  ", "pass").is_none());
         let auth = auth_from_credentials(" user ", "pass");
         assert_eq!(auth, Some(("user".to_string(), Some("pass".to_string()))));
+    }
+
+    #[test]
+    fn webdav_user_agent_is_nonempty_product_token() {
+        assert!(WEBDAV_USER_AGENT.starts_with("cc-switch/"));
+        assert!(WEBDAV_USER_AGENT.contains(" WebDAV"));
+        assert!(!WEBDAV_USER_AGENT.chars().any(|c| c.is_control()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- WebDAV transport used the shared `reqwest` client, which does not send a `User-Agent` by default.
- Cloudflare and similar reverse proxies may reject those requests with `403 Access denied: Missing required headers`.
- Attach a stable `cc-switch/<version> WebDAV` User-Agent on all WebDAV requests via `apply_auth`.

## Root cause
Verified against a Cloudflare-fronted WebDAV endpoint with the same `reqwest` stack:

| Request | Result |
|---|---|
| `reqwest` default (no User-Agent) | `403 Missing required headers` |
| `reqwest` + `User-Agent: cc-switch/3.17.0 WebDAV` | `207` PROPFIND / `201` PUT |
| `curl` default (sends its own UA) | success, which can mask the bug |

## Test plan
- [x] Reproduce 403 with bare `reqwest` against Cloudflare-proxied WebDAV
- [x] Confirm 207/201 after adding User-Agent header
- [x] Unit test for `WEBDAV_USER_AGENT` product token
- [ ] Manual: Settings → Advanced cloud sync → WebDAV → save & test against Cloudflare reverse proxy
- [ ] Manual: upload/download still works for direct WebDAV URLs (Jianguoyun / Nextcloud)