### PR TITLE
fix: preserve hot-switch config and proxy Codex images

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -999,7 +999,18 @@ fn apply_provider_to_paths_inner(
 
     write_deployment_mode(&paths.normal_config_path, "3p")?;
     write_deployment_mode(&paths.threep_config_path, "3p")?;
-    write_json_file(&paths.profile_path, &profile)?;
+    // Keep Claude Desktop-owned state when switching the gateway provider. A
+    // malformed old profile falls back to the fresh gateway profile so switching
+    // remains a recovery path for damaged local configuration.
+    let existing = read_json_or_empty(&paths.profile_path).unwrap_or_else(|error| {
+        log::warn!(
+            "Failed to read existing Claude Desktop gateway profile {}; replacing it: {error}",
+            paths.profile_path.display()
+        );
+        json!({})
+    });
+    let merged = merge_profile(&existing, &profile);
+    write_json_file(&paths.profile_path, &merged)?;
     write_meta(&paths.meta_path, Some(PROFILE_ID))?;
 
     Ok(())
@@ -1038,6 +1049,23 @@ fn build_gateway_profile(
     }
 
     profile
+}
+
+fn merge_profile(existing: &Value, new_profile: &Value) -> Value {
+    let mut merged = existing.clone();
+    let Some(merged_obj) = merged.as_object_mut() else {
+        return new_profile.clone();
+    };
+    let Some(new_obj) = new_profile.as_object() else {
+        return new_profile.clone();
+    };
+    for (key, value) in new_obj {
+        merged_obj.insert(key.clone(), value.clone());
+    }
+    if !new_obj.contains_key("inferenceModels") {
+        merged_obj.remove("inferenceModels");
+    }
+    merged
 }
 
 fn read_json_or_empty(path: &Path) -> Result<Value, AppError> {
@@ -1531,6 +1559,49 @@ mod tests {
         assert_eq!(
             profile["inferenceModels"],
             json!([{ "name": "claude-sonnet-4-6", "supports1m": true }])
+        );
+    }
+
+    #[test]
+    fn claude_desktop_apply_preserves_non_gateway_profile_fields() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+        write_json_file(
+            &paths.profile_path,
+            &json!({
+                "chatTabEnabled": true,
+                "managedMcpServers": [{ "name": "local" }],
+                "inferenceModels": [{ "name": "old-model" }]
+            }),
+        )
+        .expect("pre-write profile");
+
+        let db = test_db();
+        apply_provider_to_paths(&db, &direct_provider("direct"), &paths).expect("apply provider");
+
+        let profile: Value = read_json_file(&paths.profile_path).expect("read profile");
+        assert_eq!(profile["chatTabEnabled"], json!(true));
+        assert_eq!(profile["managedMcpServers"][0]["name"], json!("local"));
+        assert!(profile.get("inferenceModels").is_none());
+        assert_eq!(profile["inferenceProvider"], json!("gateway"));
+    }
+
+    #[test]
+    fn claude_desktop_apply_replaces_malformed_profile() {
+        let temp = TempDir::new().expect("tempdir");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(paths.profile_path.parent().expect("profile parent"))
+            .expect("create profile parent");
+        fs::write(&paths.profile_path, b"{").expect("write malformed profile");
+
+        let db = test_db();
+        apply_provider_to_paths(&db, &direct_provider("direct"), &paths).expect("apply provider");
+
+        let profile: Value = read_json_file(&paths.profile_path).expect("read repaired profile");
+        assert_eq!(profile["inferenceProvider"], json!("gateway"));
+        assert_eq!(
+            profile["inferenceGatewayBaseUrl"],
+            json!("https://gateway.example.com")
         );
     }
 

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -754,6 +754,72 @@ pub async fn handle_chat_completions(
     .await
 }
 
+/// Handle the legacy OpenAI Images API for Codex clients.
+///
+/// Images use the same provider selection, auth, model mapping, and raw response
+/// forwarding as Chat Completions, but must retain their own upstream path.
+pub async fn handle_images_generations(
+    State(state): State<ProxyState>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    let (parts, req_body) = request.into_parts();
+    let method = parts.method.clone();
+    let uri = parts.uri;
+    let mut headers = parts.headers;
+    let extensions = parts.extensions;
+    let body_bytes = req_body
+        .collect()
+        .await
+        .map_err(|e| ProxyError::Internal(format!("Failed to read request body: {e}")))?
+        .to_bytes();
+    let body_bytes = decode_codex_request_body(&mut headers, body_bytes)?;
+    let body: Value = serde_json::from_slice(&body_bytes)
+        .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+
+    let mut ctx =
+        RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
+    let endpoint = endpoint_with_query(&uri, "/images/generations");
+    let is_stream = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let forwarder = ctx.create_forwarder(&state);
+    let mut result = match forwarder
+        .forward_with_retry(
+            &AppType::Codex,
+            method,
+            &endpoint,
+            body,
+            headers,
+            extensions,
+            ctx.get_providers(),
+        )
+        .await
+    {
+        Ok(result) => result,
+        Err(mut err) => {
+            if let Some(provider) = err.provider.take() {
+                ctx.provider = provider;
+            }
+            log_forward_error(&state, &ctx, is_stream, &err.error);
+            return build_codex_proxy_error_response(&ctx, &endpoint, &err.error);
+        }
+    };
+
+    let connection_guard = result.connection_guard.take();
+    ctx.outbound_model = result.outbound_model.take();
+    ctx.provider = result.provider;
+    process_response(
+        result.response,
+        &ctx,
+        &state,
+        &OPENAI_PARSER_CONFIG,
+        connection_guard,
+    )
+    .await
+}
+
 /// 处理 /v1/responses 请求（OpenAI Responses API - Codex CLI 透传）
 pub async fn handle_responses(
     State(state): State<ProxyState>,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -322,6 +322,23 @@ impl ProxyServer {
             // OpenAI Models API (Codex CLI reachability check)
             .route("/models", get(handlers::handle_models))
             .route("/v1/models", get(handlers::handle_models))
+            // OpenAI Images API (Codex legacy image generation)
+            .route(
+                "/images/generations",
+                post(handlers::handle_images_generations),
+            )
+            .route(
+                "/v1/images/generations",
+                post(handlers::handle_images_generations),
+            )
+            .route(
+                "/v1/v1/images/generations",
+                post(handlers::handle_images_generations),
+            )
+            .route(
+                "/codex/v1/images/generations",
+                post(handlers::handle_images_generations),
+            )
             // OpenAI Responses API (Codex CLI，支持带前缀和不带前缀)
             .route("/responses", post(handlers::handle_responses))
             .route("/v1/responses", post(handlers::handle_responses))

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2564,6 +2564,24 @@ impl ProviderService {
         }
 
         if should_hot_switch {
+            let mut result = SwitchResult::default();
+            if !app_type.is_additive_mode() {
+                if let Some(current_id) =
+                    crate::settings::get_effective_current_provider(&state.db, &app_type)?
+                {
+                    if current_id != id {
+                        if let Some(current_provider) = providers.get(&current_id) {
+                            Self::sync_common_config_snippet_for_hot_switch(
+                                state,
+                                &app_type,
+                                current_provider,
+                                &mut result,
+                            );
+                        }
+                    }
+                }
+            }
+
             // Proxy takeover mode: hot-switch without restoring upstream Live config.
             // The proxy layer may still refresh proxy-safe Live fields so client labels
             // follow the selected provider while endpoints remain local.
@@ -2582,7 +2600,7 @@ impl ProviderService {
 
             // The proxy server will route requests to the new provider via is_current.
             // MCP sync is intentionally skipped while Live config is owned by takeover.
-            return Ok(SwitchResult::default());
+            return Ok(result);
         }
 
         // Normal mode: full switch with Live config write
@@ -2967,6 +2985,58 @@ impl ProviderService {
                 .warnings
                 .push(format!("common_config_sync_failed:{}", provider.id));
         }
+    }
+
+    fn sync_common_config_snippet_for_hot_switch(
+        state: &AppState,
+        app_type: &AppType,
+        provider: &Provider,
+        result: &mut SwitchResult,
+    ) {
+        let source_settings = match read_live_settings(app_type.clone()) {
+            Ok(settings) => settings,
+            Err(live_error) => {
+                match futures::executor::block_on(state.db.get_live_backup(app_type.as_str())) {
+                    Ok(Some(backup)) => {
+                        match serde_json::from_str::<Value>(&backup.original_config) {
+                            Ok(settings) => settings,
+                            Err(backup_error) => {
+                                log::warn!(
+                            "Failed to parse takeover backup for {} provider '{}' after live read failed ({live_error}): {backup_error}",
+                            app_type.as_str(),
+                            provider.id
+                        );
+                                return;
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        log::warn!(
+                        "Failed to read live config for {} provider '{}' during hot-switch common config sync: {live_error}",
+                        app_type.as_str(),
+                        provider.id
+                    );
+                        return;
+                    }
+                    Err(backup_error) => {
+                        log::warn!(
+                        "Failed to read live config for {} provider '{}' during hot-switch common config sync: {live_error}; backup read also failed: {backup_error}",
+                        app_type.as_str(),
+                        provider.id
+                    );
+                        return;
+                    }
+                }
+            }
+        };
+
+        Self::sync_common_config_snippet_from_live(
+            state,
+            app_type,
+            provider,
+            &source_settings,
+            result,
+        );
     }
 
     /// Extract common config snippet from current provider


### PR DESCRIPTION
## Summary
- Proxy the legacy Codex `POST /v1/images/generations` endpoint to the selected provider.
- Preserve Claude Desktop profile fields owned by the client while refreshing gateway fields; malformed old profiles fall back to a clean generated profile.
- Sync opted-in common config snippets when switching providers during proxy takeover, using the live config or takeover backup.

## Related issues
- Fixes #5429
- Fixes #5417
- Fixes #5412

## Validation
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib claude_desktop_config::tests::` (25 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::providers::codex::tests::` (37 passed)
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
