### PR TITLE
feat(usage): 在趋势图提示框中显示真实消耗 Tokens

### DIFF
--- a/src/components/usage/UsageTrendChart.test.ts
+++ b/src/components/usage/UsageTrendChart.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { calculateTokensProcessed } from "./UsageTrendChart";
+
+describe("calculateTokensProcessed", () => {
+  it("includes input, output, cache creation, and cache read tokens", () => {
+    expect(
+      calculateTokensProcessed({
+        totalInputTokens: 47_431_464,
+        totalOutputTokens: 3_780_479,
+        totalCacheCreationTokens: 0,
+        totalCacheReadTokens: 1_569_037_696,
+      }),
+    ).toBe(1_620_249_639);
+  });
+});

--- a/src/components/usage/UsageTrendChart.tsx
+++ b/src/components/usage/UsageTrendChart.tsx
@@ -18,7 +18,24 @@ import {
   parseFiniteNumber,
 } from "./format";
 import { resolveUsageRange } from "@/lib/usageRange";
-import type { UsageRangeSelection } from "@/types/usage";
+import type { DailyStats, UsageRangeSelection } from "@/types/usage";
+
+export function calculateTokensProcessed(
+  stat: Pick<
+    DailyStats,
+    | "totalInputTokens"
+    | "totalOutputTokens"
+    | "totalCacheCreationTokens"
+    | "totalCacheReadTokens"
+  >,
+): number {
+  return (
+    stat.totalInputTokens +
+    stat.totalOutputTokens +
+    stat.totalCacheCreationTokens +
+    stat.totalCacheReadTokens
+  );
+}
 
 interface UsageTrendChartProps {
   range: UsageRangeSelection;
@@ -81,6 +98,7 @@ export function UsageTrendChart({
         outputTokens: stat.totalOutputTokens,
         cacheCreationTokens: stat.totalCacheCreationTokens,
         cacheReadTokens: stat.totalCacheReadTokens,
+        tokensProcessed: calculateTokensProcessed(stat),
         cost: cost ?? null,
       };
     }) || [];
@@ -89,9 +107,19 @@ export function UsageTrendChart({
 
   const CustomTooltip = ({ active, payload, label }: any) => {
     if (active && payload && payload.length) {
+      const tokensProcessed = payload[0]?.payload?.tokensProcessed;
+
       return (
         <div className="rounded-lg border bg-background/95 p-3 shadow-lg backdrop-blur-md">
           <p className="mb-2 font-medium">{label}</p>
+          <div className="mb-2 flex items-center justify-between gap-4 border-b border-border/60 pb-2 text-sm">
+            <span className="font-semibold">
+              {t("usage.realTotal", "真实消耗 Tokens")}:
+            </span>
+            <span className="font-semibold tabular-nums">
+              {fmtInt(tokensProcessed, dateLocale)}
+            </span>
+          </div>
           {payload.map((entry: any, index: number) => (
             <div
               key={index}


### PR DESCRIPTION
## 概述

- 在使用趋势图每个时间点的提示框中，醒目显示“真实消耗 Tokens”。
- 计算口径与页面顶部统计保持一致：输入 + 输出 + 缓存创建 + 缓存命中。
- 保留原有各项 Token 明细和成本展示。
- 复用现有的 `usage.realTotal` 国际化文案，不新增重复翻译。

## 原因

趋势图提示框此前只遍历展示各条曲线对应的数据，没有计算和展示四项 Token 的合计。因此在 7 天或自定义日期范围下，用户查看某一天的总消耗时必须手动相加。

本次修改只增加前端派生值和提示框展示，不改变趋势接口、数据库查询或原有曲线数据。

## 关联 Issue

Fixes #5466

## 验证

- `pnpm exec vitest run src/components/usage/UsageTrendChart.test.ts`：通过
- `pnpm test:unit`：70 个测试文件、447 项测试全部通过
- `pnpm typecheck`：通过
- `pnpm format:check`：通过
- `pnpm build:renderer`：通过

## 检查清单

- [x] TypeScript 类型检查通过
- [x] Prettier 格式检查通过
- [x] 已增加真实消耗 Token 计算的回归测试
- [x] 未修改 Rust 代码，无需运行 Cargo Clippy
- [x] 复用现有国际化文案，无需修改语言文件