### PR TITLE
fix(codex): use provider auth for third-party live routes

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1282,6 +1282,11 @@ fn set_codex_experimental_bearer_token(config_text: &str, token: &str) -> Result
             .and_then(|item| item.as_table_mut())
         {
             provider_table["experimental_bearer_token"] = toml_edit::value(token);
+            // A provider-scoped bearer token is the authentication source for
+            // this third-party live route. Codex 0.144+ otherwise interprets
+            // requires_openai_auth = true as an explicit request to use the
+            // preserved ChatGPT login instead of the selected provider.
+            provider_table["requires_openai_auth"] = toml_edit::value(false);
             return Ok(doc.to_string());
         }
     }
@@ -2241,6 +2246,41 @@ model = "gpt-5"
         assert!(
             parsed.get("model_providers").is_none(),
             "reserved provider tables should not be synthesized"
+        );
+    }
+
+    #[test]
+    fn prepare_provider_live_config_disables_openai_auth_for_custom_provider() {
+        let input = r#"model_provider = "custom"
+
+[model_providers.custom]
+name = "Third Party"
+base_url = "https://third-party.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+
+        let output =
+            prepare_codex_provider_live_config(&json!({"OPENAI_API_KEY": "sk-test"}), input)
+                .expect("prepare live config");
+        let parsed: toml::Value = toml::from_str(&output).expect("parse output");
+        let provider = parsed
+            .get("model_providers")
+            .and_then(|value| value.get("custom"))
+            .expect("custom provider");
+
+        assert_eq!(
+            provider
+                .get("experimental_bearer_token")
+                .and_then(|value| value.as_str()),
+            Some("sk-test")
+        );
+        assert_eq!(
+            provider
+                .get("requires_openai_auth")
+                .and_then(|value| value.as_bool()),
+            Some(false),
+            "third-party bearer auth must not fall back to the preserved ChatGPT login"
         );
     }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3430,6 +3430,15 @@ wire_api = "responses"
             live_config.contains(PROXY_TOKEN_PLACEHOLDER),
             "live config should carry the proxy placeholder token"
         );
+        let parsed_live: toml::Value =
+            toml::from_str(&live_config).expect("parse third-party live config");
+        assert_eq!(
+            parsed_live["model_providers"]["rightcode"]
+                .get("requires_openai_auth")
+                .and_then(toml::Value::as_bool),
+            Some(false),
+            "takeover bearer auth must not select the preserved ChatGPT login"
+        );
 
         crate::settings::update_settings(crate::settings::AppSettings::default())
             .expect("reset settings");

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -484,7 +484,8 @@ requires_openai_auth = true
             .and_then(|v| v.get("aihubmix"))
             .and_then(|v| v.get("requires_openai_auth"))
             .and_then(|v| v.as_bool()),
-        Some(true)
+        Some(false),
+        "provider-scoped bearer auth must not select the preserved ChatGPT login"
     );
 
     ProviderService::switch(&state, AppType::Codex, "plain-provider")


### PR DESCRIPTION
## Summary / 概述

- when CC Switch projects a third-party Codex API key into the active provider as experimental_bearer_token, explicitly set that provider's requires_openai_auth = false
- preserve the user's ChatGPT OAuth auth.json for Codex app features without allowing Codex 0.144+ to select the official subscription for third-party inference
- update the existing provider-switch integration expectation and add regression coverage for both direct preserved-auth switching and proxy takeover

Codex 0.144+ treats requires_openai_auth = true as an explicit request to use ChatGPT authentication. Before this change, CC Switch could show a custom/local model provider while the preserved official login was still selected for authentication, causing requests to use official quota or stall in the OpenAI login path.

This intentionally changes only generated live configuration. Stored provider templates remain unchanged so the legacy direct-switch path, where the third-party API key is written to auth.json, keeps its existing behavior. Official Codex proxy routes also continue to use requires_openai_auth = true.

The core fix and initial unit-test approach were originally proposed by @Micah-Zheng in #5222. This PR extracts that authentication change onto current main, updates the integration assertion that caused #5222's backend CI failure, and adds takeover-path coverage. The commit includes a Co-authored-by trailer.

## Related Issue / 关联 Issue

Fixes #4393

Related: #5222, #5345, #5293

## Verification / 验证

- cargo fmt --all -- --check
- cargo clippy --lib --tests -- -D warnings
- cargo test codex_config::tests --lib (64 passed)
- cargo test --test provider_service (33 passed)
- cargo test codex_custom_provider_live_write_preserves_oauth_auth_json --lib

## Screenshots / 截图

Not applicable; this is a backend live-config authentication fix with regression tests.

## Checklist / 检查清单

- [x] No frontend changes; TypeScript checks are not applicable
- [x] Rust formatting passes
- [x] Rust Clippy passes with warnings denied
- [x] Relevant unit and integration tests pass
- [x] No user-facing text changed; i18n updates are not required
