### PR TITLE
fix(codex): 嵌套工具缺省 parameters 兜底 + schema 根级 type 规范化回归测试

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1546,6 +1546,27 @@ mod tests {
     }
 
     #[test]
+    fn test_request_tool_parameters_root_combinator_normalized() {
+        // Tools whose parameters are a root-level JSON Schema combinator
+        // (oneOf/anyOf) without a root "type" must still produce an
+        // input_schema with type "object" — Anthropic and strict Anthropic-
+        // compatible gateways require it.
+        let input = json!({
+            "model": "claude",
+            "max_output_tokens": 100,
+            "input": [{ "role": "user", "content": "hi" }],
+            "tools": [
+                { "type": "function", "name": "automation_update", "description": "d",
+                  "parameters": { "oneOf": [{ "type": "object" }, { "type": "object" }] } }
+            ]
+        });
+        let result = responses_request_to_anthropic(input, 4096).unwrap();
+        let schema = &result["tools"][0]["input_schema"];
+        assert_eq!(schema["type"], "object");
+        assert!(schema.get("oneOf").is_some());
+    }
+
+    #[test]
     fn test_request_tool_choice_mapping() {
         // A function tool must be present, else tool_choice is (correctly) dropped.
         let base = |tc: Value| {

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1130,13 +1130,11 @@ fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option
             .get_mut("function")
             .and_then(|value| value.as_object_mut())
         {
-            // Ensure parameters.type is "object" for strict OpenAI-compatible providers
-            if let Some(params) = obj.get("parameters") {
-                let normalized = normalize_function_parameters(Some(params));
-                if normalized != *params {
-                    obj.insert("parameters".to_string(), normalized);
-                }
-            }
+            // Ensure parameters.type is "object" for strict OpenAI-compatible
+            // providers, and default to an empty object schema when the nested
+            // function omits parameters entirely.
+            let normalized = normalize_function_parameters(obj.get("parameters"));
+            obj.insert("parameters".to_string(), normalized);
 
             obj.insert("name".to_string(), json!(chat_name));
             if let Some(strict) = tool.get("strict").cloned() {
@@ -2009,6 +2007,108 @@ mod tests {
         assert_eq!(result["tool_choice"]["function"]["name"], "get_weather");
         assert_eq!(result["max_tokens"], 100);
         assert_eq!(result["reasoning_effort"], "high");
+    }
+
+    #[test]
+    fn function_tool_parameters_with_root_combinator_gets_object_type() {
+        // Codex tools may declare parameters as a root-level JSON Schema
+        // combinator (oneOf/anyOf) without a root "type" — e.g. Codex
+        // Desktop's codex_app/automation_update. Strict OpenAI-compatible
+        // upstreams (Kimi/Moonshot) reject those with HTTP 400:
+        // tools.function.parameters.type is required and must be "object".
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [{ "role": "user", "content": "hi" }],
+            "tools": [{
+                "type": "function",
+                "name": "automation_update",
+                "description": "d",
+                "parameters": {
+                    "oneOf": [
+                        { "type": "object", "properties": { "mode": { "type": "string" } }, "required": ["mode"] },
+                        { "type": "object", "properties": { "mode": { "type": "string" }, "name": { "type": "string" } }, "required": ["mode", "name"] }
+                    ]
+                }
+            }]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+
+        let parameters = &result["tools"][0]["function"]["parameters"];
+        assert_eq!(parameters["type"], "object");
+        assert!(parameters.get("oneOf").is_some());
+    }
+
+    #[test]
+    fn tool_search_output_tool_parameters_are_normalized() {
+        // Regression test for the real-world trigger: the model called
+        // tool_search, so the loaded tool definitions only exist inside the
+        // conversation history's tool_search_output item and are
+        // reconstructed from there.
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                { "role": "user", "content": "hi" },
+                {
+                    "type": "tool_search_call",
+                    "call_id": "tool_1",
+                    "status": "completed",
+                    "execution": "client",
+                    "arguments": {"limit": 5, "query": "automation"}
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_1",
+                    "status": "completed",
+                    "execution": "client",
+                    "tools": [{
+                        "type": "namespace",
+                        "name": "codex_app",
+                        "tools": [{
+                            "type": "function",
+                            "name": "automation_update",
+                            "description": "d",
+                            "strict": false,
+                            "parameters": { "oneOf": [{ "type": "object" }, { "type": "object" }] }
+                        }]
+                    }]
+                }
+            ],
+            "tools": [{
+                "type": "function",
+                "name": "exec_command",
+                "parameters": { "type": "object" }
+            }]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let tools = result["tools"].as_array().unwrap();
+        let loaded = tools
+            .iter()
+            .find(|tool| tool["function"]["name"] == "codex_app__automation_update")
+            .expect("tool_search_output tool should be reconstructed");
+
+        assert_eq!(loaded["function"]["parameters"]["type"], "object");
+        assert!(loaded["function"]["parameters"].get("oneOf").is_some());
+    }
+
+    #[test]
+    fn nested_function_tool_without_parameters_gets_default_schema() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [{ "role": "user", "content": "hi" }],
+            "tools": [{
+                "type": "function",
+                "function": { "name": "lookup", "description": "d" }
+            }]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"],
+            json!({ "type": "object", "properties": {} })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景

关联 issue：#5457

Codex 代理接管模式下，经 `tool_search` 动态加载的工具（如 Codex Desktop `codex_app/automation_update`）其 `parameters` 可能是根级无 `type` 的 JSON Schema 组合子（`oneOf`/`anyOf`），被 Kimi 等严格上游以 `tools.function.parameters.type is required and must be "object"` 400 拒绝。

chat 转换器主路径已由 #4706 修复（已合并、待发布）。本 PR 在其基础上补齐一个剩余缺口和关键回归测试。

## 改动

**`transform_codex_chat.rs`（1 处行为修正）**

嵌套 `function` 分支原先只在 `parameters` **存在**时才规范化；当嵌套 function 完全没有 `parameters` 字段时会原样透传，严格上游可能再次 400。现统一走 `normalize_function_parameters`（缺失时给默认 `{"type":"object","properties":{}}`），与 flat 分支行为对齐。

**回归测试（#4706 未覆盖的场景）**

- `function_tool_parameters_with_root_combinator_gets_object_type`：根级 `oneOf` 无 `type` → 补 `"type":"object"` 且 `oneOf` 原样保留；
- `tool_search_output_tool_parameters_are_normalized`：**真实触发路径**——工具定义只存在于会话历史的 `tool_search_output` 中（Codex `tool_search` 动态加载），重建后 schema 必须被规范化；
- `nested_function_tool_without_parameters_gets_default_schema`：嵌套 function 无 `parameters` → 默认空 object schema；
- `test_request_tool_parameters_root_combinator_normalized`（Anthropic 转换器）：`input_schema` 根级 `type` 规范化且保留 `oneOf`（Anthropic 及兼容网关同样要求根级 `type: "object"`）。

## 测试

- `cargo test --lib transform_codex`：123 passed / 0 failed（含 4 个新测试）
- `cargo fmt --check`、`cargo clippy --lib`：干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)
