### PR TITLE
fix(env): 修复环境变量警告栏操作按钮无法点击

### DIFF
--- a/src/components/env/EnvWarningBanner.tsx
+++ b/src/components/env/EnvWarningBanner.tsx
@@ -111,7 +111,10 @@ export function EnvWarningBanner({
 
   return (
     <>
-      <div className="fixed top-0 left-0 right-0 z-[100] bg-yellow-50 dark:bg-yellow-950 border-b border-yellow-200 dark:border-yellow-900 shadow-lg animate-slide-down">
+      <div
+        data-tauri-no-drag
+        className="fixed top-0 left-0 right-0 z-[100] bg-yellow-50 dark:bg-yellow-950 border-b border-yellow-200 dark:border-yellow-900 shadow-lg animate-slide-down"
+      >
         <div className="container mx-auto px-4 py-3">
           <div className="flex items-start gap-3">
             <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-500 flex-shrink-0 mt-0.5" />
@@ -151,6 +154,7 @@ export function EnvWarningBanner({
                     variant="ghost"
                     size="icon"
                     onClick={onDismiss}
+                    aria-label={t("common.close")}
                     className="text-yellow-900 dark:text-yellow-100 hover:bg-yellow-100 dark:hover:bg-yellow-900/50"
                   >
                     <X className="h-4 w-4" />

--- a/tests/components/EnvWarningBanner.test.tsx
+++ b/tests/components/EnvWarningBanner.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EnvWarningBanner } from "@/components/env/EnvWarningBanner";
+import type { EnvConflict } from "@/types/env";
+
+const tMock = vi.fn((key: string) => key);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: tMock }),
+}));
+
+const conflicts: EnvConflict[] = [
+  {
+    varName: "OPENAI_API_KEY",
+    varValue: "test-key",
+    sourceType: "system",
+    sourcePath: "HKEY_CURRENT_USER\\Environment",
+  },
+];
+
+describe("EnvWarningBanner", () => {
+  it("keeps the banner interactive above the window drag region", () => {
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <EnvWarningBanner
+        conflicts={conflicts}
+        onDismiss={onDismiss}
+        onDeleted={vi.fn()}
+      />,
+    );
+
+    const banner = container.querySelector("[data-tauri-no-drag]");
+    expect(banner).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "common.close" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 问题

Windows 使用自定义标题栏时，环境变量警告栏会覆盖在窗口顶部拖动区域上。警告栏虽然视觉层级更高，但该区域仍按 `-webkit-app-region: drag` 参与窗口拖动命中测试，导致“展开”和“关闭”等操作按钮无法点击。

## 修改

- 将环境变量警告栏根节点显式标记为 `data-tauri-no-drag`，确保整个提醒区域保持可交互。
- 为关闭按钮补充可访问名称。
- 新增组件测试，覆盖非拖动区域标记和关闭回调。

## 影响范围

- 不改变警告栏现有视觉样式。
- 不改变环境变量检测、删除和本次会话关闭状态的逻辑。
- 不修改各平台的窗口拖动策略，只限定警告栏自身为可交互区域。

## 验证

- `pnpm test:unit -- tests/components/EnvWarningBanner.test.tsx`
- `pnpm typecheck`
- `pnpm build:renderer`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Windows Tauri 开发版中实际验证展开与关闭按钮可正常点击。

Closes #5294
