### PR TITLE
Add ArcRouter provider icon

### DIFF
--- a/src/icons/extracted/arcrouter.svg
+++ b/src/icons/extracted/arcrouter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none">
+  <rect width="200" height="200" rx="40" fill="#16181D"/>
+  <path d="M138 52c4.4-2.6 10 .6 10 5.8v84.4c0 5.2-5.6 8.4-10 5.8l-73-42.2c-4.4-2.6-4.4-9 0-11.6l73-42.2z" fill="#B9BCC1"/>
+</svg>

--- a/src/icons/extracted/index.ts
+++ b/src/icons/extracted/index.ts
@@ -2,6 +2,7 @@
 // Do not edit manually
 
 import _apikeyfun from "./apikeyfun.png";
+import _arcrouter from "./arcrouter.svg?url";
 import _apinebula from "./apinebula_icon.png";
 import _atlascloud from "./atlascloud_icon.png";
 import _claudeapi from "./ClaudeApi.png";
@@ -104,6 +105,7 @@ export const icons: Record<string, string> = {
 export const iconUrls: Record<string, string> = {
   apikeyfun: _apikeyfun,
   apinebula: _apinebula,
+  arcrouter: _arcrouter,
   atlascloud: _atlascloud,
   byteplus: _byteplus,
   ccsub: _ccsub,

--- a/src/icons/extracted/metadata.ts
+++ b/src/icons/extracted/metadata.ts
@@ -9,6 +9,21 @@ export const iconMetadata: Record<string, IconMetadata> = {
     keywords: ["aigocode", "aigo", "code", "third-party"],
     defaultColor: "#5B7FFF",
   },
+  arcrouter: {
+    name: "arcrouter",
+    displayName: "ArcRouter",
+    category: "ai-provider",
+    keywords: [
+      "arcrouter",
+      "arcrouter.ai",
+      "aggregator",
+      "relay",
+      "claude",
+      "codex",
+      "gateway",
+    ],
+    defaultColor: "#B9BCC1",
+  },
   apikeyfun: {
     name: "apikeyfun",
     displayName: "APIKEY.FUN",


### PR DESCRIPTION
Adds a provider icon for [ArcRouter](https://arcrouter.ai), an AI model API relay, following the same pattern as other relay provider icons (subrouter, zetaapi, teamorouter):

- `src/icons/extracted/arcrouter.svg` — the ArcRouter mark (SVG, served via `?url` like subrouter.svg)
- registered in `iconUrls` in `src/icons/extracted/index.ts`
- metadata entry in `src/icons/extracted/metadata.ts`

ArcRouter's CC Switch import deeplink already sends `icon=arcrouter`, so imported providers will pick the icon up automatically once this ships.

`npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)