### PR TITLE
fix(proxy): preserve OpenRouter thinking signatures

### DIFF
--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -111,6 +111,14 @@ fn should_normalize_anthropic_tool_thinking_history(
         return false;
     }
 
+    // OpenRouter's Anthropic endpoint validates native thinking signatures.
+    // A routed model ID such as `moonshotai/kimi-k3` identifies the upstream
+    // model, not a direct Kimi endpoint, so direct-provider normalization must
+    // not strip those signatures or inject unsigned thinking placeholders.
+    if ClaudeAdapter::new().is_openrouter(provider) {
+        return false;
+    }
+
     if body
         .get("model")
         .and_then(|m| m.as_str())
@@ -2221,6 +2229,45 @@ mod tests {
         assert_eq!(content[0]["type"], "thinking");
         assert_eq!(content[0]["thinking"], ANTHROPIC_THINKING_PLACEHOLDER);
         assert_eq!(content[1]["type"], "tool_use");
+    }
+
+    #[test]
+    fn test_openrouter_kimi_anthropic_tool_history_preserves_signed_thinking() {
+        let provider = create_provider(json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
+                "ANTHROPIC_API_KEY": "test-key"
+            }
+        }));
+        let mut body = json!({
+            "model": "moonshotai/kimi-k3",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Need to inspect the file.",
+                        "signature": "openrouter-signature"
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "call_123",
+                        "name": "read_file",
+                        "input": {"path": "README.md"}
+                    }
+                ]
+            }]
+        });
+        let original = body.clone();
+
+        let changed = normalize_anthropic_tool_thinking_history_for_provider(
+            &mut body,
+            &provider,
+            "anthropic",
+        );
+
+        assert!(!changed);
+        assert_eq!(body, original);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

### What?

This PR prevents CC Switch from applying direct reasoning-provider thinking-history normalization to OpenRouter Anthropic routes.

It also adds a regression test covering an OpenRouter-routed Kimi model with assistant tool history containing a valid signed `thinking` block. The test requires the request to remain unchanged, including the signature.

### Why?

CC Switch normalizes Anthropic tool-call history for several reasoning providers. Direct Kimi, DeepSeek, and MiMo-compatible endpoints may require plain thinking content instead of Anthropic-signed thinking blocks.

The normalizer currently uses a shared model-name heuristic. An OpenRouter model ID such as `moonshotai/kimi-k3` therefore matches the Kimi hint even though the configured endpoint is OpenRouter.

That causes CC Switch to remove valid Anthropic thinking signatures before forwarding the request. OpenRouter's native Anthropic parser requires those signatures and rejects the resulting history with HTTP 400.

The endpoint and model name describe different parts of the route:

- The model ID identifies the routed upstream model.
- The configured endpoint determines which Anthropic compatibility rules apply.

### How?

`should_normalize_anthropic_tool_thinking_history` now checks the existing Claude adapter's OpenRouter endpoint classification before applying the reasoning-vendor model heuristic.

For an OpenRouter Anthropic route, the function returns without modifying history. This preserves:

- existing `thinking` signatures;
- signed tool-call history;
- native OpenRouter Anthropic request semantics.

The guard is intentionally placed only in the Anthropic tool-history normalizer. It does not change:

- direct Kimi normalization;
- direct DeepSeek or MiMo normalization;
- OpenAI Chat reasoning-content conversion;
- the reactive thinking rectifier;
- provider authentication or endpoint selection;
- model mapping;
- UI, configuration schema, or i18n.

The regression test uses:

- Base URL: `https://openrouter.ai/api`
- API format: `anthropic`
- Model: `moonshotai/kimi-k3`
- A signed `thinking` block followed by `tool_use`

Before the fix, the test fails because the normalizer removes the signature. After the fix, the request remains byte-for-byte equivalent to the input fixture.

The existing direct-Kimi regression test remains green, confirming that `https://api.kimi.com/coding` still receives its required missing-thinking normalization.

### Testing?

Passed:

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml kimi_anthropic_tool_history --lib`
- Backend suite with the unrelated fixed-port listener test skipped
- `pnpm typecheck`
- `pnpm format:check`
- Frontend suite excluding `tests/integration/App.test.tsx`
- `tests/integration/App.test.tsx`: 4/4 passed unchanged with a 15-second test timeout

The unfiltered backend run passed 1,997 tests before one existing proxy-service test encountered an occupied fixed gateway port. The changed provider-normalization tests passed in that run.

The default frontend command reached an existing five-second timeout in `App.test.tsx` on Windows. The same file passed all four tests unchanged when run with a 15-second timeout. No frontend code is changed by this PR.

### Anything Else?

This is deliberately narrower than globally stripping thinking history or broadening the reactive rectifier. OpenRouter receives its original valid signatures, while direct reasoning-provider compatibility behavior remains intact.

## Screenshots / 截图

Not applicable. This is a backend request-normalization change with no UI changes.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes
- [x] No i18n updates required because no user-facing text changed
