### PR TITLE
fix(codex-chat): attach reasoning forward for responses bridge

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -588,7 +588,8 @@ fn append_responses_input_as_chat_messages(
     );
     // 整个 input 处理完毕后仍剩余的 pending reasoning 属于「真正的尾部」思考
     // （其后已没有任何可前向附挂的 message / function_call），回溯附挂到最后一条
-    // assistant；目标已有非空 reasoning_content 时守卫跳过，避免重复拼接污染。
+    // assistant；目标已有 reasoning_content 时追加，以保留同一 turn 的 embedded
+    // reasoning 与 trailing reasoning。
     attach_pending_reasoning_to_previous_assistant(
         messages,
         last_assistant_index,
@@ -691,9 +692,9 @@ fn append_responses_item_as_chat_message(
                 return Ok(());
             } else {
                 // 非 assistant 的回合边界消息（user 等）：pending reasoning 不再直接
-                // 丢弃，优先回溯附挂到上一条 assistant（守卫：其已有 reasoning_content
-                // 时跳过）。reasoning 不允许跨 user 回合泄漏到之后的 assistant 消息；
-                // 无上一条 assistant 可附挂时自然丢弃（等同原行为）。
+                // 丢弃，优先回溯附挂到上一条 assistant；其已有 reasoning_content 时
+                // 追加尾部 reasoning。reasoning 不允许跨 user 回合泄漏到之后的
+                // assistant 消息；无上一条 assistant 可附挂时自然丢弃（等同原行为）。
                 attach_pending_reasoning_to_previous_assistant(
                     messages,
                     *last_assistant_index,
@@ -787,8 +788,8 @@ fn responses_message_item_to_chat_message(
         attach_pending_reasoning_to_assistant(&mut message, pending_reasoning);
     } else {
         // 非 assistant 的回合边界消息（user 等）：pending reasoning 不再直接丢弃，
-        // 回溯附挂到上一条 assistant（守卫：其已有 reasoning_content 时跳过），
-        // 防止 reasoning 跨 user 回合泄漏到之后的 assistant 消息。
+        // 回溯附挂到上一条 assistant；其已有 reasoning_content 时追加尾部
+        // reasoning，同时防止 reasoning 跨 user 回合泄漏到之后的 assistant 消息。
         attach_pending_reasoning_to_previous_assistant(
             messages,
             last_assistant_index,

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -932,9 +932,10 @@ fn ensure_tool_call_reasoning_content(message: &mut Value) {
 /// 2. user 等回合边界消息到达时 pending_reasoning 非空——reasoning 不允许
 ///    跨 user 回合泄漏到之后的 assistant 消息，也不能直接丢弃可归属的思考。
 ///
-/// 守卫：目标消息已有非空 reasoning_content 时不再追加，避免把新一轮思考
-/// 拼进旧消息造成交叉污染。无论是否附挂成功，pending 都会被消费（拿走），
-/// 绝不留到下一条 assistant。
+/// 这里已经处于尾部/边界收尾点，不是普通 reasoning 的前向归属路径；
+/// 若目标已有 reasoning_content，追加尾部 reasoning 以保留同一 assistant turn
+/// 中同时出现的 embedded reasoning 与尾随 reasoning。无论是否附挂成功，
+/// pending 都会被消费（拿走），绝不留到下一条 assistant。
 fn attach_pending_reasoning_to_previous_assistant(
     messages: &mut [Value],
     last_assistant_index: Option<usize>,
@@ -953,14 +954,6 @@ fn attach_pending_reasoning_to_previous_assistant(
     if message.get("role").and_then(|v| v.as_str()) != Some("assistant") {
         return;
     }
-    let already_has_reasoning = message
-        .get("reasoning_content")
-        .and_then(|v| v.as_str())
-        .is_some_and(|text| !text.trim().is_empty());
-    if already_has_reasoning {
-        return;
-    }
-
     if let Some(obj) = message.as_object_mut() {
         append_reasoning_content(obj, reasoning);
     }
@@ -2567,6 +2560,44 @@ mod tests {
             messages[0]["reasoning_content"],
             "I need to preserve thinking history."
         );
+    }
+
+    #[test]
+    fn responses_request_to_chat_preserves_trailing_reasoning_after_embedded_reasoning() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "reasoning_content": "Embedded thought.",
+                    "content": "Done."
+                },
+                {
+                    "type": "reasoning",
+                    "summary": [
+                        {"type": "summary_text", "text": "Trailing thought."}
+                    ]
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": "Continue"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["content"], "Done.");
+        assert_eq!(
+            messages[0]["reasoning_content"],
+            "Embedded thought.\n\nTrailing thought."
+        );
+        assert_eq!(messages[1]["role"], "user");
+        assert!(messages[1].get("reasoning_content").is_none());
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -586,6 +586,14 @@ fn append_responses_input_as_chat_messages(
         &mut pending_reasoning,
         &mut last_assistant_index,
     );
+    // 整个 input 处理完毕后仍剩余的 pending reasoning 属于「真正的尾部」思考
+    // （其后已没有任何可前向附挂的 message / function_call），回溯附挂到最后一条
+    // assistant；目标已有非空 reasoning_content 时守卫跳过，避免重复拼接污染。
+    attach_pending_reasoning_to_previous_assistant(
+        messages,
+        last_assistant_index,
+        &mut pending_reasoning,
+    );
     backfill_tool_call_reasoning_placeholders(messages);
     Ok(())
 }
@@ -650,12 +658,14 @@ fn append_responses_item_as_chat_message(
             }));
         }
         Some("reasoning") => {
-            let reasoning = responses_reasoning_item_text(item);
-            let attached_to_previous = pending_tool_calls.is_empty()
-                && attach_reasoning_to_last_assistant(messages, *last_assistant_index, &reasoning);
-            if !attached_to_previous {
-                append_pending_reasoning(pending_reasoning, reasoning);
-            }
+            // reasoning 一律先进入 pending_reasoning，前向附挂到其后的
+            // message / function_call（后者经 flush_pending_tool_calls 消费）。
+            // 此前这里在 pending_tool_calls 为空时直接回溯附挂到上一条 assistant，
+            // 会把新一轮的思考错拼进旧消息，导致紧跟的纯文本 assistant 丢失
+            // reasoning_content，思考型模型（kimi 等）多轮对话因此中途"断片"。
+            // 真正的尾部剩余由 input 结束时的收尾逻辑、或回合边界消息（user 等）
+            // 到达时回溯附挂，见 attach_pending_reasoning_to_previous_assistant。
+            append_pending_reasoning(pending_reasoning, responses_reasoning_item_text(item));
         }
         Some("input_text" | "input_image" | "input_file" | "input_audio") => {
             flush_pending_tool_calls(
@@ -679,8 +689,16 @@ fn append_responses_item_as_chat_message(
                 update_last_assistant_index(messages, &message, last_assistant_index);
                 messages.push(message);
                 return Ok(());
-            } else if pending_reasoning.is_some() {
-                pending_reasoning.take();
+            } else {
+                // 非 assistant 的回合边界消息（user 等）：pending reasoning 不再直接
+                // 丢弃，优先回溯附挂到上一条 assistant（守卫：其已有 reasoning_content
+                // 时跳过）。reasoning 不允许跨 user 回合泄漏到之后的 assistant 消息；
+                // 无上一条 assistant 可附挂时自然丢弃（等同原行为）。
+                attach_pending_reasoning_to_previous_assistant(
+                    messages,
+                    *last_assistant_index,
+                    pending_reasoning,
+                );
             }
             update_last_assistant_index(messages, &message, last_assistant_index);
             messages.push(message);
@@ -693,7 +711,12 @@ fn append_responses_item_as_chat_message(
                 last_assistant_index,
             );
             if item.get("role").is_some() || item.get("content").is_some() {
-                let message = responses_message_item_to_chat_message(item, pending_reasoning);
+                let message = responses_message_item_to_chat_message(
+                    item,
+                    pending_reasoning,
+                    messages,
+                    *last_assistant_index,
+                );
                 update_last_assistant_index(messages, &message, last_assistant_index);
                 messages.push(message);
             }
@@ -706,7 +729,12 @@ fn append_responses_item_as_chat_message(
                 last_assistant_index,
             );
             if item.get("role").is_some() || item.get("content").is_some() {
-                let message = responses_message_item_to_chat_message(item, pending_reasoning);
+                let message = responses_message_item_to_chat_message(
+                    item,
+                    pending_reasoning,
+                    messages,
+                    *last_assistant_index,
+                );
                 update_last_assistant_index(messages, &message, last_assistant_index);
                 messages.push(message);
             }
@@ -739,6 +767,8 @@ fn flush_pending_tool_calls(
 fn responses_message_item_to_chat_message(
     item: &Value,
     pending_reasoning: &mut Option<String>,
+    messages: &mut [Value],
+    last_assistant_index: Option<usize>,
 ) -> Value {
     let role = item.get("role").and_then(|v| v.as_str()).unwrap_or("user");
     let chat_role = responses_role_to_chat_role(role);
@@ -755,8 +785,15 @@ fn responses_message_item_to_chat_message(
     if chat_role == "assistant" {
         append_pending_reasoning(pending_reasoning, responses_message_reasoning_text(item));
         attach_pending_reasoning_to_assistant(&mut message, pending_reasoning);
-    } else if pending_reasoning.is_some() {
-        pending_reasoning.take();
+    } else {
+        // 非 assistant 的回合边界消息（user 等）：pending reasoning 不再直接丢弃，
+        // 回溯附挂到上一条 assistant（守卫：其已有 reasoning_content 时跳过），
+        // 防止 reasoning 跨 user 回合泄漏到之后的 assistant 消息。
+        attach_pending_reasoning_to_previous_assistant(
+            messages,
+            last_assistant_index,
+            pending_reasoning,
+        );
     }
 
     message
@@ -850,8 +887,8 @@ fn attach_pending_reasoning_to_assistant(
 
 /// 在所有 input 处理完毕后，对仍缺 `reasoning_content` 的 assistant tool-call 消息补占位。
 /// 必须作为管线末端的最终兜底执行：真实 reasoning 可能以尾随 `reasoning` item 的形式经
-/// `attach_reasoning_to_last_assistant` 回填，过早注入占位会被 `append_reasoning_content`
-/// 追加而污染真实思考。
+/// `attach_pending_reasoning_to_previous_assistant` 回填，过早注入占位会被
+/// `append_reasoning_content` 追加而污染真实思考。
 fn backfill_tool_call_reasoning_placeholders(messages: &mut [Value]) {
     for message in messages.iter_mut() {
         let is_assistant_tool_call = message.get("role").and_then(|value| value.as_str())
@@ -887,34 +924,46 @@ fn ensure_tool_call_reasoning_content(message: &mut Value) {
     }
 }
 
-fn attach_reasoning_to_last_assistant(
+/// 将仍未消费的 pending reasoning 回溯附挂到上一条 assistant 消息。
+///
+/// 只允许两种「真正的尾部」场景调用：
+/// 1. 整个 input 处理完毕后 pending_reasoning 仍有剩余——其后已没有任何可
+///    前向附挂的 message / function_call；
+/// 2. user 等回合边界消息到达时 pending_reasoning 非空——reasoning 不允许
+///    跨 user 回合泄漏到之后的 assistant 消息，也不能直接丢弃可归属的思考。
+///
+/// 守卫：目标消息已有非空 reasoning_content 时不再追加，避免把新一轮思考
+/// 拼进旧消息造成交叉污染。无论是否附挂成功，pending 都会被消费（拿走），
+/// 绝不留到下一条 assistant。
+fn attach_pending_reasoning_to_previous_assistant(
     messages: &mut [Value],
     last_assistant_index: Option<usize>,
-    reasoning: &Option<String>,
-) -> bool {
-    let Some(reasoning) = reasoning
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    else {
-        return true;
+    pending_reasoning: &mut Option<String>,
+) {
+    let Some(reasoning) = pending_reasoning.take() else {
+        return;
     };
-    let Some(index) = last_assistant_index else {
-        return false;
-    };
-    let Some(message) = messages.get_mut(index) else {
-        return false;
+    let reasoning = reasoning.trim();
+    if reasoning.is_empty() {
+        return;
+    }
+    let Some(message) = last_assistant_index.and_then(|index| messages.get_mut(index)) else {
+        return;
     };
     if message.get("role").and_then(|v| v.as_str()) != Some("assistant") {
-        return false;
+        return;
+    }
+    let already_has_reasoning = message
+        .get("reasoning_content")
+        .and_then(|v| v.as_str())
+        .is_some_and(|text| !text.trim().is_empty());
+    if already_has_reasoning {
+        return;
     }
 
     if let Some(obj) = message.as_object_mut() {
         append_reasoning_content(obj, reasoning);
-        return true;
     }
-
-    false
 }
 
 fn responses_message_reasoning_text(item: &Value) -> Option<String> {
@@ -2641,6 +2690,106 @@ mod tests {
         assert_eq!(messages[0]["tool_calls"][0]["id"], "call_1");
         assert_eq!(messages[0]["reasoning_content"], "Need to read a file.");
         assert_eq!(messages[1]["role"], "tool");
+    }
+
+    #[test]
+    fn responses_request_to_chat_attaches_reasoning_forward_to_following_assistant() {
+        // 回归：reasoning 必须前向附挂到其后的 assistant 消息，不得回溯拼进
+        // 上一条 assistant。此前多轮序列 [r1, m1, r2, m2] 中 r2 会被拼到 m1
+        // 尾部、 m2 丢失 reasoning_content，思考型模型（kimi 等）因此中途"断片"。
+        let input = json!({
+            "model": "kimi-k2-thinking",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "first thought"}]
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": "First answer."
+                },
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "second thought"}]
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": "Second answer."
+                },
+                {
+                    "role": "user",
+                    "content": "Continue"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["content"], "First answer.");
+        assert_eq!(messages[0]["reasoning_content"], "first thought");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[1]["content"], "Second answer.");
+        assert_eq!(messages[1]["reasoning_content"], "second thought");
+        assert_eq!(messages[2]["role"], "user");
+        assert!(messages[2].get("reasoning_content").is_none());
+    }
+
+    #[test]
+    fn responses_request_to_chat_keeps_reasoning_on_final_answer_after_tool_call() {
+        // 回归（Kimi 契约）：[reasoning, function_call, output, reasoning, message]
+        // 最后一个纯文本 assistant 必须保留自己的 reasoning_content，且该 reasoning
+        // 不得被回溯拼进前面的 tool-call 消息（否则上游历史里 tool-call 消息的思考
+        // 被污染、最终答复消息反而没有 reasoning_content）。
+        let input = json!({
+            "model": "kimi-k2-thinking",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "need to read a file"}]
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{\"path\":\"README.md\"}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "Readme content"
+                },
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "now I can answer"}]
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": "The file says hello."
+                },
+                {
+                    "role": "user",
+                    "content": "Continue"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(messages[0]["reasoning_content"], "need to read a file");
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[2]["role"], "assistant");
+        assert_eq!(messages[2]["content"], "The file says hello.");
+        assert_eq!(messages[2]["reasoning_content"], "now I can answer");
+        assert_eq!(messages[3]["role"], "user");
+        assert!(messages[3].get("reasoning_content").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

This PR fixes the Codex Responses-to-Chat bridge so `reasoning` items are attached forward to their following assistant message or tool-call message, instead of being retroactively appended to the previous assistant message.

Before this change, multi-turn histories like `[r1, m1, r2, m2]` could become:

```text
m1.reasoning_content = "r1\n\nr2"
m2.reasoning_content = <missing>
```

For Kimi K2/K3-style reasoning models, this breaks the multi-turn tool-call contract and may contribute to long Codex tasks stopping with a short text message instead of continuing with tool calls. A patched Kimi K3 end-to-end run is still pending, so this PR does not claim that the conversion bug is the only possible cause.

The fix keeps the existing tool-call flushing path intact, but changes reasoning ownership:

- `reasoning` first enters `pending_reasoning`.
- The next assistant message or pending tool-call assistant consumes it.
- Truly trailing pending reasoning is attached backward only at input end or at a non-assistant turn boundary.
- At those trailing/boundary points, trailing reasoning is appended to an existing `reasoning_content` value when both belong to the same assistant turn.

## Related Issue / 关联 Issue

Fixes #5506

Also related:

- #4966: Codex Desktop + third-party Chat Completions models stop early without tool calls.
- #4341: same symptom family.
- #3881: adjacent but orthogonal. This PR fixes where reasoning attaches; #3881 controls how much historical reasoning is retained. Applying attachment ownership first should make trimming safer because each assistant message carries only its own reasoning.

## Screenshots / 截图

Not applicable. This is a backend conversion fix.

## What changed

- Removed the eager backward attachment from the `Some("reasoning")` branch.
- Added `attach_pending_reasoning_to_previous_assistant()` for true trailing/boundary cases.
- Replaced two previous `pending_reasoning.take()` drop points with boundary-aware backward attachment.
- Passed `messages` and `last_assistant_index` into `responses_message_item_to_chat_message()` so non-assistant boundaries can resolve pending reasoning safely.
- Updated the `backfill_tool_call_reasoning_placeholders()` comment to reference the new helper.
- Added three focused regression tests:
  - `responses_request_to_chat_preserves_trailing_reasoning_after_embedded_reasoning`
  - `responses_request_to_chat_attaches_reasoning_forward_to_following_assistant`
  - `responses_request_to_chat_keeps_reasoning_on_final_answer_after_tool_call`

## Verification

I do not currently have Rust/Cargo available on this machine, so I have not run `cargo test` or `cargo clippy` locally yet.

The initial commit `6830d2e` passed the repository's Linux, macOS, and Windows CI. Codex review then identified the embedded-plus-trailing regression addressed by `c60d9db`. After maintainer approval, `c60d9db` passed the full frontend and Linux, macOS, and Windows backend CI, including Rust formatting, Clippy, and tests.

I refreshed the local Python port to match the behavioral fix commit `c60d9db` and reran the relevant reasoning pipeline component scenarios:

- All 13 component-level scenarios pass under the fixed behavior.
- The old behavior reproduces the corruption in the new regression scenarios:
  - `[r1, m1, r2, m2, user]`
  - `[r1, function_call, output, r2, final_message, user]`
  - a longer mixed message/tool-call chain.
- The review scenario `[assistant(embedded reasoning), trailing reasoning, user]` preserves both reasoning parts.
- The behavioral patch reverses to base `997be22b` and reapplies to `c60d9db` with exact SHA-256 matches.

Validation output summary:

```text
FIXED 全部通过: YES
BUGGY 在新回归场景全部复现失败: YES
RESULT: ALL GREEN
```

This `ALL GREEN` result is a Python component-level port check, not end-to-end validation. Current PR head `b56acac` is a comment-only follow-up that aligns three stale comments with the reviewed behavior. CI run `29671721855` passed on this exact head: TypeScript type checking, frontend formatting and unit tests, plus Rust formatting, Clippy, and tests on Linux, macOS, and Windows. Real Kimi K3 end-to-end verification remains pending.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

No user-facing text was changed, so no i18n files were needed.
