### PR TITLE
fix(providers): clear filter when closing provider search

### DIFF
--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -191,6 +191,10 @@ export function ProviderList({
   const [searchTerm, setSearchTerm] = useState("");
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const closeSearch = useCallback(() => {
+    setSearchTerm("");
+    setIsSearchOpen(false);
+  }, []);
   const { data: claudeDesktopStatus } = useQuery({
     queryKey: ["claudeDesktopStatus"],
     queryFn: () => providersApi.getClaudeDesktopStatus(),
@@ -259,13 +263,13 @@ export function ProviderList({
       }
 
       if (key === "escape") {
-        setIsSearchOpen(false);
+        closeSearch();
       }
     };
 
     globalThis.addEventListener("keydown", handleKeyDown);
     return () => globalThis.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [closeSearch]);
 
   useEffect(() => {
     if (isSearchOpen) {
@@ -498,7 +502,7 @@ export function ProviderList({
                   variant="ghost"
                   size="icon"
                   className="ml-auto"
-                  onClick={() => setIsSearchOpen(false)}
+                  onClick={closeSearch}
                   aria-label={t("provider.searchCloseAriaLabel", {
                     defaultValue: "Close provider search",
                   })}

--- a/tests/components/ProviderList.test.tsx
+++ b/tests/components/ProviderList.test.tsx
@@ -306,4 +306,54 @@ describe("ProviderList Component", () => {
       screen.getByText("No providers match your search."),
     ).toBeInTheDocument();
   });
+
+  it.each([
+    ["Escape", () => fireEvent.keyDown(window, { key: "Escape" })],
+    [
+      "close button",
+      () =>
+        fireEvent.click(
+          screen.getByRole("button", { name: "Close provider search" }),
+        ),
+    ],
+  ])(
+    "clears the active filter when closing search with %s",
+    (_, closeSearch) => {
+      const providerAlpha = createProvider({ id: "alpha", name: "Alpha Labs" });
+      const providerBeta = createProvider({ id: "beta", name: "Beta Works" });
+
+      useDragSortMock.mockReturnValue({
+        sortedProviders: [providerAlpha, providerBeta],
+        sensors: [],
+        handleDragEnd: vi.fn(),
+      });
+
+      renderWithQueryClient(
+        <ProviderList
+          providers={{ alpha: providerAlpha, beta: providerBeta }}
+          currentProviderId=""
+          appId="claude"
+          onSwitch={vi.fn()}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+          onDuplicate={vi.fn()}
+          onOpenWebsite={vi.fn()}
+        />,
+      );
+
+      fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+      fireEvent.change(
+        screen.getByPlaceholderText("Search name, notes, or URL..."),
+        { target: { value: "beta" } },
+      );
+      expect(
+        screen.queryByTestId("provider-card-alpha"),
+      ).not.toBeInTheDocument();
+
+      closeSearch();
+
+      expect(screen.getByTestId("provider-card-alpha")).toBeInTheDocument();
+      expect(screen.getByTestId("provider-card-beta")).toBeInTheDocument();
+    },
+  );
 });


### PR DESCRIPTION
## Summary / 概述

关闭供应商搜索框时同步清除当前搜索条件，使供应商列表立即恢复为完整列表。按 `Esc` 和点击关闭按钮现在使用相同的关闭逻辑。

## Related Issue / 关联 Issue

Fixes #5512

## Implementation / 实现

- 新增统一的 `closeSearch`，同时清空 `searchTerm` 并关闭搜索框。
- 按 `Esc` 和点击关闭按钮共用该函数。
- 保持搜索框打开时的过滤和清除行为不变。
- 未修改界面文案或 i18n 文件。

## Verification / 验证

- `vitest run tests/components/ProviderList.test.tsx`：6/6 通过。
- 新增回归测试，分别覆盖按 Esc 和点击关闭按钮。
- `tsc --noEmit`：通过。
- `prettier --check src/components/providers/ProviderList.tsx`：通过。
- `git diff --check`：通过。
- 全量单元测试共 464 条，463 条通过。`tests/hooks/useSettingsForm.test.tsx` 中有 1 条既有失败，期望 `showInTray=false`，实际为 `true`；本次改动未涉及该模块。