### PR TITLE
fix(deeplink): preserve custom Codex config fields

### DIFF
--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -431,6 +431,7 @@ requires_openai_auth = true
                 Ok(doc) => doc,
                 Err(_) => return build_codex_settings_without_common(request, provider_config),
             };
+            strip_codex_deeplink_profile_routing(&mut common_doc);
             let provider_doc = provider_config
                 .parse::<toml_edit::DocumentMut>()
                 .expect("generated Codex provider config must be valid TOML");
@@ -471,6 +472,37 @@ fn extract_codex_common_config(request: &DeepLinkImportRequest) -> Option<String
     let decoded = decode_base64_param("config", config_b64).ok()?;
     let config: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
     ProviderService::extract_common_config_snippet_from_settings(AppType::Codex, &config).ok()
+}
+
+fn strip_codex_deeplink_profile_routing(doc: &mut toml_edit::DocumentMut) {
+    const PROVIDER_SPECIFIC_FIELDS: &[&str] = &[
+        "model_provider",
+        "model",
+        "base_url",
+        "wire_api",
+        "experimental_bearer_token",
+        "model_catalog_json",
+    ];
+
+    let Some(profiles) = doc
+        .get_mut("profiles")
+        .and_then(|item| item.as_table_like_mut())
+    else {
+        return;
+    };
+
+    let profile_names: Vec<String> = profiles.iter().map(|(name, _)| name.to_string()).collect();
+    for profile_name in profile_names {
+        let Some(profile) = profiles
+            .get_mut(&profile_name)
+            .and_then(|item| item.as_table_like_mut())
+        else {
+            continue;
+        };
+        for field in PROVIDER_SPECIFIC_FIELDS {
+            profile.remove(field);
+        }
+    }
 }
 
 /// Build Gemini settings configuration

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -405,8 +405,14 @@ fn build_codex_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
     let model_name = toml_edit::Value::from(model_name.as_str()).to_string();
     let endpoint = toml_edit::Value::from(endpoint.as_str()).to_string();
 
-    // Build config.toml content
-    let config_toml = format!(
+    // Preserve safe common Codex settings carried by the inline config. This
+    // uses the same sanitizer as provider switching, so credentials, routing,
+    // model catalog paths, and CC Switch-managed MCP entries are excluded.
+    let common_config = extract_codex_common_config(request);
+
+    // Keep the historical template byte-for-byte stable when no inline config
+    // is present. Existing provider deeplinks should not churn stored config.
+    let provider_config = format!(
         r#"model_provider = "custom"
 model = {model_name}
 model_reasoning_effort = "high"
@@ -419,6 +425,22 @@ wire_api = "responses"
 requires_openai_auth = true
 "#
     );
+    let config_toml = match common_config {
+        Some(common) if !common.trim().is_empty() => {
+            let mut common_doc = match common.parse::<toml_edit::DocumentMut>() {
+                Ok(doc) => doc,
+                Err(_) => return build_codex_settings_without_common(request, provider_config),
+            };
+            let provider_doc = provider_config
+                .parse::<toml_edit::DocumentMut>()
+                .expect("generated Codex provider config must be valid TOML");
+            for (key, item) in provider_doc.as_table().iter() {
+                common_doc[key] = item.clone();
+            }
+            common_doc.to_string()
+        }
+        _ => provider_config,
+    };
 
     json!({
         "auth": {
@@ -426,6 +448,29 @@ requires_openai_auth = true
         },
         "config": config_toml
     })
+}
+
+fn build_codex_settings_without_common(
+    request: &DeepLinkImportRequest,
+    config_toml: String,
+) -> serde_json::Value {
+    json!({
+        "auth": {
+            "OPENAI_API_KEY": request.api_key,
+        },
+        "config": config_toml
+    })
+}
+
+fn extract_codex_common_config(request: &DeepLinkImportRequest) -> Option<String> {
+    let config_b64 = request.config.as_ref()?;
+    if request.config_format.as_deref().unwrap_or("json") != "json" {
+        return None;
+    }
+
+    let decoded = decode_base64_param("config", config_b64).ok()?;
+    let config: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    ProviderService::extract_common_config_snippet_from_settings(AppType::Codex, &config).ok()
 }
 
 /// Build Gemini settings configuration

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -534,6 +534,126 @@ experimental_bearer_token = "sk-rightcode"
 }
 
 #[test]
+fn test_build_codex_provider_preserves_safe_common_config() {
+    use super::provider::build_provider_from_request;
+
+    let config_toml = r#"model_provider = "old"
+model = "old-model"
+model_catalog_json = "/tmp/stale-catalog.json"
+experimental_bearer_token = "sk-stale-top-level"
+web_search = "live"
+
+[features]
+standalone_web_search = true
+
+[tools.web_search]
+context_size = "high"
+
+[model_providers.old]
+name = "Old"
+base_url = "https://old.example/v1"
+wire_api = "chat"
+experimental_bearer_token = "sk-stale-provider"
+
+[mcp_servers.stale]
+command = "should-not-survive"
+"#;
+    let config_json = serde_json::json!({
+        "auth": {"OPENAI_API_KEY": "sk-stale-auth"},
+        "config": config_toml,
+    })
+    .to_string();
+    let request = DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("codex".to_string()),
+        name: Some("Imported Provider".to_string()),
+        homepage: Some("https://example.com".to_string()),
+        endpoint: Some("https://api.example.com/v1".to_string()),
+        api_key: Some("sk-url-wins".to_string()),
+        model: Some("gpt-url-wins".to_string()),
+        config: Some(BASE64_STANDARD.encode(config_json.as_bytes())),
+        config_format: Some("json".to_string()),
+        ..Default::default()
+    };
+
+    let merged = parse_and_merge_config(&request).unwrap();
+    let provider = build_provider_from_request(&AppType::Codex, &merged).unwrap();
+    assert_eq!(
+        provider.settings_config["auth"]["OPENAI_API_KEY"],
+        "sk-url-wins"
+    );
+
+    let config = provider.settings_config["config"].as_str().unwrap();
+    let parsed = toml::from_str::<toml::Value>(config).expect("persisted config must be TOML");
+    assert_eq!(parsed["web_search"].as_str(), Some("live"));
+    assert_eq!(
+        parsed["features"]["standalone_web_search"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(
+        parsed["tools"]["web_search"]["context_size"].as_str(),
+        Some("high")
+    );
+    assert_eq!(parsed["model_provider"].as_str(), Some("custom"));
+    assert_eq!(parsed["model"].as_str(), Some("gpt-url-wins"));
+    assert_eq!(
+        parsed["model_providers"]["custom"]["name"].as_str(),
+        Some("Imported Provider")
+    );
+    assert_eq!(
+        parsed["model_providers"]["custom"]["base_url"].as_str(),
+        Some("https://api.example.com/v1")
+    );
+    assert_eq!(
+        parsed["model_providers"]["custom"]["wire_api"].as_str(),
+        Some("responses")
+    );
+    assert!(parsed.get("model_catalog_json").is_none());
+    assert!(parsed.get("experimental_bearer_token").is_none());
+    assert!(parsed.get("mcp_servers").is_none());
+    assert!(parsed["model_providers"]
+        .as_table()
+        .is_some_and(|providers| providers.len() == 1));
+    assert!(!config.contains("sk-stale"));
+}
+
+#[test]
+fn test_build_codex_provider_without_config_unchanged() {
+    use super::provider::build_provider_from_request;
+
+    let request = DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("codex".to_string()),
+        name: Some("Plain".to_string()),
+        homepage: Some("https://example.com".to_string()),
+        endpoint: Some("https://api.example.com/v1".to_string()),
+        api_key: Some("sk-test".to_string()),
+        model: Some("gpt-test".to_string()),
+        ..Default::default()
+    };
+
+    let provider = build_provider_from_request(&AppType::Codex, &request).unwrap();
+    assert_eq!(
+        provider.settings_config["config"].as_str(),
+        Some(
+            r#"model_provider = "custom"
+model = "gpt-test"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.custom]
+name = "Plain"
+base_url = "https://api.example.com/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+        )
+    );
+}
+
+#[test]
 fn test_parse_and_merge_config_grokbuild() {
     let config_toml = r#"[models]
 default = "grok-profile"

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -542,12 +542,27 @@ model = "old-model"
 model_catalog_json = "/tmp/stale-catalog.json"
 experimental_bearer_token = "sk-stale-top-level"
 web_search = "live"
+profile = "work"
 
 [features]
 standalone_web_search = true
 
 [tools.web_search]
 context_size = "high"
+
+[profiles.work]
+model_provider = "old"
+model = "old-profile-model"
+base_url = "https://profile-old.example/v1"
+wire_api = "chat"
+experimental_bearer_token = "sk-stale-profile"
+model_catalog_json = "/tmp/stale-profile-catalog.json"
+model_reasoning_effort = "medium"
+
+[profiles.later]
+model_provider = "old"
+model = "later-old-model"
+model_verbosity = "low"
 
 [model_providers.old]
 name = "Old"
@@ -597,6 +612,33 @@ command = "should-not-survive"
     );
     assert_eq!(parsed["model_provider"].as_str(), Some("custom"));
     assert_eq!(parsed["model"].as_str(), Some("gpt-url-wins"));
+    assert_eq!(parsed["profile"].as_str(), Some("work"));
+    for profile_name in ["work", "later"] {
+        let profile = parsed["profiles"][profile_name]
+            .as_table()
+            .expect("profile settings must be preserved");
+        for field in [
+            "model_provider",
+            "model",
+            "base_url",
+            "wire_api",
+            "experimental_bearer_token",
+            "model_catalog_json",
+        ] {
+            assert!(
+                !profile.contains_key(field),
+                "profile {profile_name} must not retain {field}"
+            );
+        }
+    }
+    assert_eq!(
+        parsed["profiles"]["work"]["model_reasoning_effort"].as_str(),
+        Some("medium")
+    );
+    assert_eq!(
+        parsed["profiles"]["later"]["model_verbosity"].as_str(),
+        Some("low")
+    );
     assert_eq!(
         parsed["model_providers"]["custom"]["name"].as_str(),
         Some("Imported Provider")


### PR DESCRIPTION
## Summary / 概述

- Preserve sanitized common Codex settings from provider deeplink config payloads.
- Keep URL endpoint, model, API key, provider name, and generated routing fields authoritative.
- Strip provider tables, credentials, model catalog paths, and CC Switch-managed MCP settings through the existing common-config sanitizer.
- Keep provider deeplinks without config byte-for-byte unchanged.

## Related Issue / 关联 Issue

Fixes #5510

## Screenshots / 截图

Not applicable; this change affects backend deeplink config construction.

## Tests / 测试

- pnpm typecheck
- pnpm format:check
- pnpm test:unit (72 files, 462 tests)
- cargo fmt --check
- cargo clippy --lib --tests -- -D warnings
- cargo test --lib deeplink (39 tests)
- cargo test (2018 passed, 2 ignored, plus integration suites)

## Checklist / 检查清单

- [x] pnpm typecheck passes / 通过 TypeScript 类型检查
- [x] pnpm format:check passes / 通过代码格式检查
- [x] cargo clippy passes (Rust code changed) / 通过 Clippy 检查
- [x] No user-facing text changed; i18n updates are not required / 未修改用户可见文本，无需更新国际化文件