### PR TITLE
fix(hermes): use canonical custom provider slug on switch

### DIFF
--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -913,9 +913,11 @@ pub fn set_model_config(model: &HermesModelConfig) -> Result<HermesWriteOutcome,
 
 /// Apply the top-level `model:` defaults when switching to a Hermes provider.
 ///
-/// `model.provider` is **always** updated to the new provider id — without
-/// this, switching to a provider whose settings lack a `models` list would
-/// leave the runtime routing requests to the previously active provider.
+/// `model.provider` is **always** updated to the new provider's canonical
+/// `custom:<id>` reference — without this, switching to a provider whose
+/// settings lack a `models` list would leave runtime requests routed to the
+/// previously active provider. The prefix also prevents Hermes' static model
+/// detection from replacing the selected custom provider with a built-in one.
 ///
 /// `model.default` is only overwritten when the new provider declares at
 /// least one model; otherwise the previous default is preserved so users
@@ -940,10 +942,20 @@ pub fn apply_switch_defaults(
     let current = get_model_config()?.unwrap_or_default();
     let merged = HermesModelConfig {
         default: first_model_id.or(current.default.clone()),
-        provider: Some(provider_id.to_string()),
+        provider: Some(custom_provider_reference(provider_id)),
         ..current
     };
     set_model_config(&merged)
+}
+
+fn custom_provider_reference(provider_id: &str) -> String {
+    // Mirrors Hermes' custom_provider_slug normalization.
+    let normalized = provider_id.trim().to_lowercase().replace(' ', "-");
+    if normalized.starts_with("custom:") {
+        normalized
+    } else {
+        format!("custom:{normalized}")
+    }
 }
 
 // ============================================================================
@@ -2023,7 +2035,7 @@ custom_providers:
 
             let model = get_model_config().unwrap().unwrap();
             assert_eq!(model.default.as_deref(), Some("primary-model"));
-            assert_eq!(model.provider.as_deref(), Some("demo"));
+            assert_eq!(model.provider.as_deref(), Some("custom:demo"));
         });
     }
 
@@ -2049,7 +2061,7 @@ custom_providers:
 
             let model = get_model_config().unwrap().unwrap();
             assert_eq!(model.default.as_deref(), Some("new-model"));
-            assert_eq!(model.provider.as_deref(), Some("new-provider"));
+            assert_eq!(model.provider.as_deref(), Some("custom:new-provider"));
             // User-customized fields must survive the switch.
             assert_eq!(
                 model.base_url.as_deref(),
@@ -2082,7 +2094,7 @@ custom_providers:
             apply_switch_defaults("bare", &settings).unwrap();
 
             let model = get_model_config().unwrap().unwrap();
-            assert_eq!(model.provider.as_deref(), Some("bare"));
+            assert_eq!(model.provider.as_deref(), Some("custom:bare"));
             assert_eq!(model.default.as_deref(), Some("legacy-default"));
         });
     }
@@ -2105,10 +2117,51 @@ custom_providers:
 
             let model = get_model_config().unwrap().unwrap();
             // Provider always updates.
-            assert_eq!(model.provider.as_deref(), Some("edge"));
+            assert_eq!(model.provider.as_deref(), Some("custom:edge"));
             // First entry's id is whitespace-only → blank → fall back to old default
             // (we intentionally don't scan past the first entry for a default).
             assert_eq!(model.default.as_deref(), Some("prev-default"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn apply_switch_defaults_preserves_custom_prefix() {
+        with_test_home(|| {
+            let settings = serde_json::json!({
+                "models": [{ "id": "primary-model" }]
+            });
+            apply_switch_defaults("custom:demo", &settings).unwrap();
+
+            let model = get_model_config().unwrap().unwrap();
+            assert_eq!(model.provider.as_deref(), Some("custom:demo"));
+
+            apply_switch_defaults(" custom: Demo ", &settings).unwrap();
+
+            let model = get_model_config().unwrap().unwrap();
+            assert_eq!(model.provider.as_deref(), Some("custom:-demo"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn apply_switch_defaults_normalizes_imported_provider_name() {
+        with_test_home(|| {
+            let config_path = get_hermes_config_path();
+            fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+            fs::write(
+                &config_path,
+                "custom_providers:\n  - name: \" Demo Provider \"\n    base_url: https://api.example.com/v1\n",
+            )
+            .unwrap();
+
+            let providers = get_providers().unwrap();
+            let (provider_id, settings) = providers.iter().next().unwrap();
+            assert_eq!(provider_id, " Demo Provider ");
+            apply_switch_defaults(provider_id, settings).unwrap();
+
+            let model = get_model_config().unwrap().unwrap();
+            assert_eq!(model.provider.as_deref(), Some("custom:demo-provider"));
         });
     }
 

--- a/src/components/providers/ProviderActions.tsx
+++ b/src/components/providers/ProviderActions.tsx
@@ -114,6 +114,9 @@ export function ProviderActions({
     !isAdditiveMode && !isOmo && isAutoFailoverEnabled && onToggleFailover;
   const isMembershipMode = isAdditiveMode;
   const piStateChangeHint = t("pi.current.stateUnavailableHint");
+  const readOnlyHint = t("provider.managedByHermesHint", {
+    defaultValue: "由 Hermes 管理，请在 Hermes Web UI 中编辑",
+  });
 
   const handleMainButtonClick = () => {
     if (isOmo) {
@@ -141,6 +144,23 @@ export function ProviderActions({
   };
 
   const getMainButtonState = (): MainButtonState => {
+    if (isReadOnly) {
+      return {
+        disabled: true,
+        variant: "secondary" as const,
+        className: "opacity-40 cursor-not-allowed",
+        icon: isCurrent ? (
+          <Check className="h-4 w-4" />
+        ) : (
+          <Play className="h-4 w-4" />
+        ),
+        text: isCurrent
+          ? t("provider.inUse")
+          : t("provider.enable", { defaultValue: "启用" }),
+        title: readOnlyHint,
+      };
+    }
+
     if (isOmo) {
       if (isCurrent) {
         return {
@@ -266,9 +286,6 @@ export function ProviderActions({
       : isOmo || isAdditiveMode
         ? true
         : !isCurrent);
-  const readOnlyHint = t("provider.managedByHermesHint", {
-    defaultValue: "由 Hermes 管理，请在 Hermes Web UI 中编辑",
-  });
   const deleteHint =
     appId === "pi" && isStateChangeProtected
       ? piStateChangeHint
@@ -279,6 +296,7 @@ export function ProviderActions({
   return (
     <div className="flex items-center gap-1.5">
       {(appId === "openclaw" || appId === "hermes") &&
+        !isReadOnly &&
         isInConfig &&
         onSetAsDefault &&
         (() => {

--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -50,6 +50,34 @@ import { isTextEditableTarget } from "@/utils/domUtils";
 import { usePiCurrentState } from "@/lib/query/pi";
 import { isProxyAppId } from "@/config/appConfig";
 
+// Keep the UI's current-provider check aligned with Hermes' custom provider
+// reference normalization in the switch path.
+const hermesSlug = (value: string): string =>
+  value.trim().toLowerCase().replace(/ /g, "-");
+
+const HERMES_CUSTOM_PREFIX = "custom:";
+
+const normalizeHermesProviderReference = (reference: string): string => {
+  return hermesSlug(reference);
+};
+
+const hermesCustomProviderReference = (providerId: string): string => {
+  const normalized = hermesSlug(providerId);
+  return normalized.startsWith(HERMES_CUSTOM_PREFIX)
+    ? normalized
+    : `${HERMES_CUSTOM_PREFIX}${normalized}`;
+};
+
+const getHermesProviderReference = (provider: Provider): string => {
+  const providerKey = (provider.settingsConfig as Record<string, unknown>)
+    ?.provider_key;
+  const canonicalId =
+    typeof providerKey === "string" && providerKey.trim()
+      ? providerKey
+      : provider.id;
+  return hermesCustomProviderReference(canonicalId);
+};
+
 interface ProviderListProps {
   providers: Record<string, Provider>;
   currentProviderId: string;
@@ -117,6 +145,21 @@ export function ProviderList({
   // Hermes: 读取当前 model.provider，用于判断哪个供应商是"当前激活"（高亮）
   const { data: hermesModelConfig } = useHermesModelConfig(appId === "hermes");
   const hermesCurrentProviderId = hermesModelConfig?.provider;
+  const hermesCurrentProviderReference = hermesCurrentProviderId
+    ? normalizeHermesProviderReference(hermesCurrentProviderId)
+    : undefined;
+  const hermesCanonicalReferenceCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    if (!hermesLiveIds) return counts;
+
+    const liveProviderIds = new Set(hermesLiveIds);
+    for (const provider of Object.values(providers)) {
+      if (!liveProviderIds.has(provider.id)) continue;
+      const reference = getHermesProviderReference(provider);
+      counts.set(reference, (counts.get(reference) ?? 0) + 1);
+    }
+    return counts;
+  }, [hermesLiveIds, providers]);
 
   // 判断供应商是否已添加到配置（累加模式应用：OpenCode/OpenClaw/Hermes）
   const isProviderInConfig = useCallback(
@@ -441,8 +484,18 @@ export function ProviderList({
             const isOmoCurrent = isOmo && provider.id === (currentOmoId || "");
             const isOmoSlimCurrent =
               isOmoSlim && provider.id === (currentOmoSlimId || "");
+            const isHermesLive = hermesLiveIds?.includes(provider.id) ?? false;
+            const hermesProviderReference =
+              getHermesProviderReference(provider);
             const isHermesCurrent =
-              appId === "hermes" && hermesCurrentProviderId === provider.id;
+              appId === "hermes" &&
+              isHermesLive &&
+              hermesCurrentProviderId !== undefined &&
+              (hermesCurrentProviderId === provider.id ||
+                (hermesCurrentProviderReference === hermesProviderReference &&
+                  hermesCanonicalReferenceCounts.get(
+                    hermesProviderReference,
+                  ) === 1));
             const isCurrent =
               appId === "pi"
                 ? false

--- a/tests/components/ProviderActions.test.tsx
+++ b/tests/components/ProviderActions.test.tsx
@@ -66,6 +66,43 @@ describe("ProviderActions Pi provider switching", () => {
     expect(screen.queryByTitle("provider.duplicate")).not.toBeInTheDocument();
   });
 
+  it("blocks activation of Hermes providers managed by the providers dict", async () => {
+    const user = userEvent.setup();
+    const onSwitch = vi.fn();
+    const onSetAsDefault = vi.fn();
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+
+    render(
+      <ProviderActions
+        appId="hermes"
+        isCurrent={false}
+        isInConfig
+        isReadOnly
+        onSwitch={onSwitch}
+        onEdit={onEdit}
+        onDuplicate={vi.fn()}
+        onDelete={onDelete}
+        onSetAsDefault={onSetAsDefault}
+      />,
+    );
+
+    const activateButton = screen.getByRole("button", { name: "启用" });
+    expect(activateButton).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "已在用" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "common.edit" })).toBeDisabled();
+
+    await user.click(activateButton);
+    await user.click(screen.getByRole("button", { name: "common.edit" }));
+
+    expect(onSwitch).not.toHaveBeenCalled();
+    expect(onSetAsDefault).not.toHaveBeenCalled();
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
   it("enables a provider that is not in Pi", async () => {
     const user = userEvent.setup();
     const { onSwitch } = renderPiActions({});

--- a/tests/components/ProviderList.test.tsx
+++ b/tests/components/ProviderList.test.tsx
@@ -12,9 +12,18 @@ const TAURI_ENDPOINT = "http://tauri.local";
 const useDragSortMock = vi.fn();
 const useSortableMock = vi.fn();
 const providerCardRenderSpy = vi.fn();
+const useHermesLiveProviderIdsMock = vi.fn();
+const useHermesModelConfigMock = vi.fn();
 
 vi.mock("@/hooks/useDragSort", () => ({
   useDragSort: (...args: unknown[]) => useDragSortMock(...args),
+}));
+
+vi.mock("@/hooks/useHermes", () => ({
+  useHermesLiveProviderIds: (...args: unknown[]) =>
+    useHermesLiveProviderIdsMock(...args),
+  useHermesModelConfig: (...args: unknown[]) =>
+    useHermesModelConfigMock(...args),
 }));
 
 vi.mock("@/components/providers/ProviderCard", () => ({
@@ -128,6 +137,11 @@ beforeEach(() => {
   useDragSortMock.mockReset();
   useSortableMock.mockReset();
   providerCardRenderSpy.mockClear();
+  useHermesLiveProviderIdsMock.mockReset();
+  useHermesModelConfigMock.mockReset();
+
+  useHermesLiveProviderIdsMock.mockReturnValue({ data: undefined });
+  useHermesModelConfigMock.mockReturnValue({ data: undefined });
 
   useSortableMock.mockImplementation(({ id }: { id: string }) => ({
     setNodeRef: vi.fn(),
@@ -266,6 +280,199 @@ describe("ProviderList Component", () => {
       { a: providerA, b: providerB },
       "claude",
     );
+  });
+
+  it("marks a Hermes dictionary provider current by its canonical key", () => {
+    const provider = createProvider({
+      id: "Acme",
+      name: "Acme",
+      settingsConfig: { provider_key: "corp-key" },
+    });
+
+    useDragSortMock.mockReturnValue({
+      sortedProviders: [provider],
+      sensors: [],
+      handleDragEnd: vi.fn(),
+    });
+    useHermesLiveProviderIdsMock.mockReturnValue({ data: [provider.id] });
+    useHermesModelConfigMock.mockReturnValue({
+      data: { provider: "custom:corp-key", default: "acme-model" },
+    });
+
+    renderWithQueryClient(
+      <ProviderList
+        providers={{ [provider.id]: provider }}
+        currentProviderId=""
+        appId="hermes"
+        onSwitch={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onOpenWebsite={vi.fn()}
+      />,
+    );
+
+    const cardProps = providerCardRenderSpy.mock.calls[0][0];
+    expect(cardProps.isCurrent).toBe(true);
+    expect(cardProps.isDefaultModel).toBe(true);
+    expect(cardProps.isRemovalProtected).toBe(true);
+  });
+
+  it("normalizes a Hermes custom provider reference from the provider ID", () => {
+    const provider = createProvider({
+      id: "Demo Provider",
+      name: "Demo Provider",
+    });
+
+    useDragSortMock.mockReturnValue({
+      sortedProviders: [provider],
+      sensors: [],
+      handleDragEnd: vi.fn(),
+    });
+    useHermesLiveProviderIdsMock.mockReturnValue({ data: [provider.id] });
+    useHermesModelConfigMock.mockReturnValue({
+      data: { provider: "custom:demo-provider", default: "demo-model" },
+    });
+
+    renderWithQueryClient(
+      <ProviderList
+        providers={{ [provider.id]: provider }}
+        currentProviderId=""
+        appId="hermes"
+        onSwitch={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onOpenWebsite={vi.fn()}
+      />,
+    );
+
+    expect(providerCardRenderSpy.mock.calls[0][0].isCurrent).toBe(true);
+  });
+
+  it("does not treat a bare built-in Hermes provider as a custom provider", () => {
+    const provider = createProvider({
+      id: "OpenAI",
+      name: "OpenAI",
+    });
+
+    useDragSortMock.mockReturnValue({
+      sortedProviders: [provider],
+      sensors: [],
+      handleDragEnd: vi.fn(),
+    });
+    useHermesLiveProviderIdsMock.mockReturnValue({ data: [provider.id] });
+    useHermesModelConfigMock.mockReturnValue({
+      data: { provider: "openai", default: "gpt-4o" },
+    });
+
+    renderWithQueryClient(
+      <ProviderList
+        providers={{ [provider.id]: provider }}
+        currentProviderId=""
+        appId="hermes"
+        onSwitch={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onOpenWebsite={vi.fn()}
+      />,
+    );
+
+    expect(providerCardRenderSpy.mock.calls[0][0].isCurrent).toBe(false);
+  });
+
+  it("does not mark colliding Hermes slugs current", () => {
+    const spacedProvider = createProvider({
+      id: "Foo Bar",
+      name: "Foo Bar",
+    });
+    const dashedProvider = createProvider({
+      id: "foo-bar",
+      name: "foo-bar",
+    });
+
+    useDragSortMock.mockReturnValue({
+      sortedProviders: [spacedProvider, dashedProvider],
+      sensors: [],
+      handleDragEnd: vi.fn(),
+    });
+    useHermesLiveProviderIdsMock.mockReturnValue({
+      data: [spacedProvider.id, dashedProvider.id],
+    });
+    useHermesModelConfigMock.mockReturnValue({
+      data: { provider: "custom:foo-bar", default: "shared-model" },
+    });
+
+    renderWithQueryClient(
+      <ProviderList
+        providers={{
+          [spacedProvider.id]: spacedProvider,
+          [dashedProvider.id]: dashedProvider,
+        }}
+        currentProviderId=""
+        appId="hermes"
+        onSwitch={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onOpenWebsite={vi.fn()}
+      />,
+    );
+
+    for (const [props] of providerCardRenderSpy.mock.calls) {
+      expect(props.isCurrent).toBe(false);
+      expect(props.isDefaultModel).toBe(false);
+      expect(props.isRemovalProtected).toBe(false);
+    }
+  });
+
+  it("ignores a stale Hermes database row when matching the current provider", () => {
+    const staleProvider = createProvider({
+      id: "Foo Bar",
+      name: "Foo Bar",
+    });
+    const liveProvider = createProvider({
+      id: "foo-bar",
+      name: "foo-bar",
+    });
+
+    useDragSortMock.mockReturnValue({
+      sortedProviders: [staleProvider, liveProvider],
+      sensors: [],
+      handleDragEnd: vi.fn(),
+    });
+    useHermesLiveProviderIdsMock.mockReturnValue({
+      data: [liveProvider.id],
+    });
+    useHermesModelConfigMock.mockReturnValue({
+      data: { provider: "custom:foo-bar", default: "shared-model" },
+    });
+
+    renderWithQueryClient(
+      <ProviderList
+        providers={{
+          [staleProvider.id]: staleProvider,
+          [liveProvider.id]: liveProvider,
+        }}
+        currentProviderId=""
+        appId="hermes"
+        onSwitch={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+        onOpenWebsite={vi.fn()}
+      />,
+    );
+
+    const staleCardProps = providerCardRenderSpy.mock.calls[0][0];
+    const liveCardProps = providerCardRenderSpy.mock.calls[1][0];
+    expect(staleCardProps.isCurrent).toBe(false);
+    expect(staleCardProps.isDefaultModel).toBe(false);
+    expect(staleCardProps.isRemovalProtected).toBe(false);
+    expect(liveCardProps.isCurrent).toBe(true);
+    expect(liveCardProps.isDefaultModel).toBe(true);
+    expect(liveCardProps.isRemovalProtected).toBe(true);
   });
 
   it("filters providers with the search input", () => {


### PR DESCRIPTION
## Summary

- Write Hermes `model.provider` using the canonical `custom:<provider-id>` reference.
- Keep provider cards active for both canonical `custom:<id>` and legacy bare references.
- Avoid adding a second prefix when the value is already canonical.
- Add focused backend and ProviderList regression coverage.

## Related Issue

Fixes #5142

## Why

CC Switch stores writable Hermes providers under `custom_providers:`, but before this change `apply_switch_defaults()` wrote the bare provider ID to `model.provider`. Hermes only protects canonical `custom:` providers from static-provider auto-detection, so a model such as GLM could be reassigned to an unrelated built-in provider.

ProviderList now recognizes both the canonical runtime reference and legacy bare values when deriving the active/default card state. The change does not alter the stored provider ID, provider name, hot reload, or other Hermes configuration.

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm exec prettier --check tests/components/ProviderList.test.tsx`
- `pnpm exec vitest run tests/components/ProviderList.test.tsx` (5 passed)
- `pnpm exec vitest run tests/integration/App.test.tsx` (4 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml apply_switch_defaults`
- `cargo test --manifest-path src-tauri/Cargo.toml` (2005 passed, 2 ignored; all integration tests passed)
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes
- [x] No user-facing text changed; i18n updates are not required