### PR TITLE
feat(proxy): optionally intercept Claude Desktop startup probe

### DIFF
--- a/src-tauri/src/proxy/claude_desktop_probe.rs
+++ b/src-tauri/src/proxy/claude_desktop_probe.rs
@@ -1,0 +1,64 @@
+use serde_json::{json, Value};
+
+const STARTUP_PROBE_MODEL: &str = "claude-haiku-4-5";
+
+pub(super) fn is_startup_probe(body: &Value) -> bool {
+    let Some(object) = body.as_object() else {
+        return false;
+    };
+
+    if !object
+        .keys()
+        .all(|key| matches!(key.as_str(), "model" | "max_tokens" | "messages" | "stream"))
+    {
+        return false;
+    }
+
+    if object.get("model").and_then(Value::as_str) != Some(STARTUP_PROBE_MODEL)
+        || object.get("max_tokens").and_then(Value::as_u64) != Some(1)
+        || object
+            .get("stream")
+            .is_some_and(|stream| stream.as_bool() != Some(false))
+    {
+        return false;
+    }
+
+    let Some(messages) = object.get("messages").and_then(Value::as_array) else {
+        return false;
+    };
+    let [message] = messages.as_slice() else {
+        return false;
+    };
+    let Some(message) = message.as_object() else {
+        return false;
+    };
+
+    message.len() == 2
+        && message.get("role").and_then(Value::as_str) == Some("user")
+        && message.get("content").and_then(Value::as_str) == Some(".")
+}
+
+pub(super) fn response(body: &Value) -> Value {
+    let model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or(STARTUP_PROBE_MODEL);
+
+    json!({
+        "id": "msg_cc_switch_startup_probe",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": "."}],
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": {
+            "input_tokens": 0,
+            "output_tokens": 0
+        }
+    })
+}
+
+#[cfg(test)]
+#[path = "claude_desktop_probe_tests.rs"]
+mod tests;

--- a/src-tauri/src/proxy/claude_desktop_probe_tests.rs
+++ b/src-tauri/src/proxy/claude_desktop_probe_tests.rs
@@ -1,0 +1,68 @@
+use super::*;
+use serde_json::json;
+
+fn startup_probe() -> Value {
+    json!({
+        "model": "claude-haiku-4-5",
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "."}]
+    })
+}
+
+#[test]
+fn recognizes_claude_desktop_startup_probe() {
+    assert!(is_startup_probe(&startup_probe()));
+
+    let mut non_streaming_probe = startup_probe();
+    non_streaming_probe["stream"] = json!(false);
+    assert!(is_startup_probe(&non_streaming_probe));
+}
+
+#[test]
+fn rejects_requests_that_are_not_the_exact_startup_probe() {
+    let mutations = [
+        ("model", json!("claude-sonnet-4-5")),
+        ("max_tokens", json!(2)),
+        ("messages", json!([{"role": "user", "content": "hello"}])),
+        ("stream", json!(true)),
+        ("system", json!("You are helpful")),
+    ];
+
+    for (field, value) in mutations {
+        let mut body = startup_probe();
+        body[field] = value;
+        assert!(!is_startup_probe(&body), "field {field} must not match");
+    }
+}
+
+#[test]
+fn rejects_probe_shape_with_additional_message_fields() {
+    let body = json!({
+        "model": "claude-haiku-4-5",
+        "max_tokens": 1,
+        "messages": [{
+            "role": "user",
+            "content": ".",
+            "cache_control": {"type": "ephemeral"}
+        }]
+    });
+
+    assert!(!is_startup_probe(&body));
+}
+
+#[test]
+fn builds_anthropic_compatible_local_response() {
+    assert_eq!(
+        response(&startup_probe()),
+        json!({
+            "id": "msg_cc_switch_startup_probe",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-haiku-4-5",
+            "content": [{"type": "text", "text": "."}],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 0, "output_tokens": 0}
+        })
+    );
+}

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -8,6 +8,7 @@
 //! - Claude 的格式转换逻辑保留在此文件（用于 OpenRouter 旧接口回退）
 
 use super::{
+    claude_desktop_probe,
     content_encoding::{decompress_body, get_content_encoding, is_supported_content_encoding},
     error_mapper::{get_error_message, map_proxy_error_to_status},
     forwarder::ActiveConnectionGuard,
@@ -173,6 +174,14 @@ async fn handle_messages_for_app(
         .to_bytes();
     let body: Value = serde_json::from_slice(&body_bytes)
         .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
+
+    if app_type == AppType::ClaudeDesktop
+        && crate::settings::get_settings().intercept_claude_desktop_startup_probe
+        && claude_desktop_probe::is_startup_probe(&body)
+    {
+        log::info!("[Claude Desktop] intercepted startup probe locally");
+        return Ok(Json(claude_desktop_probe::response(&body)).into_response());
+    }
 
     let mut ctx =
         RequestContext::new(&state, &body, &headers, app_type.clone(), tag, app_type_str).await?;

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -5,6 +5,7 @@
 pub mod body_filter;
 pub mod cache_injector;
 pub mod circuit_breaker;
+mod claude_desktop_probe;
 pub(crate) mod content_encoding;
 pub mod copilot_optimizer;
 pub mod error;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -363,6 +363,9 @@ pub struct AppSettings {
     /// 是否在主页面启用本地代理功能（默认关闭）
     #[serde(default)]
     pub enable_local_proxy: bool,
+    /// Answer Claude Desktop's fixed startup probe locally instead of forwarding it upstream.
+    #[serde(default)]
+    pub intercept_claude_desktop_startup_probe: bool,
     /// User has confirmed the local proxy first-run notice
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy_confirmed: Option<bool>,
@@ -513,6 +516,7 @@ impl Default for AppSettings {
             launch_on_startup: false,
             silent_startup: false,
             enable_local_proxy: false,
+            intercept_claude_desktop_startup_probe: false,
             proxy_confirmed: None,
             usage_confirmed: None,
             usage_dashboard_refresh_interval_ms: None,

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   Zap,
   Power,
+  ShieldCheck,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -34,6 +35,8 @@ import { extractErrorMessage } from "@/utils/errorUtils";
 interface ProxyPanelProps {
   enableLocalProxy: boolean;
   onEnableLocalProxyChange: (checked: boolean) => void;
+  interceptClaudeDesktopStartupProbe: boolean;
+  onInterceptClaudeDesktopStartupProbeChange: (checked: boolean) => void;
   onToggleProxy: (checked: boolean) => Promise<void>;
   isProxyPending: boolean;
 }
@@ -41,6 +44,8 @@ interface ProxyPanelProps {
 export function ProxyPanel({
   enableLocalProxy,
   onEnableLocalProxyChange,
+  interceptClaudeDesktopStartupProbe,
+  onInterceptClaudeDesktopStartupProbeChange,
   onToggleProxy,
   isProxyPending,
 }: ProxyPanelProps) {
@@ -256,6 +261,18 @@ export function ProxyPanel({
             disabled={isProxyPending}
           />
         </div>
+
+        <ToggleRow
+          icon={<ShieldCheck className="h-4 w-4 text-blue-500" />}
+          title={t(
+            "settings.advanced.proxy.interceptClaudeDesktopStartupProbe",
+          )}
+          description={t(
+            "settings.advanced.proxy.interceptClaudeDesktopStartupProbeDescription",
+          )}
+          checked={interceptClaudeDesktopStartupProbe}
+          onCheckedChange={onInterceptClaudeDesktopStartupProbeChange}
+        />
 
         {/* [3] App takeover switches — animated, visible only when proxy is running */}
         <AnimatePresence>

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -125,6 +125,12 @@ export function ProxyTabContent({
               onEnableLocalProxyChange={(checked) =>
                 onAutoSave({ enableLocalProxy: checked })
               }
+              interceptClaudeDesktopStartupProbe={
+                settings?.interceptClaudeDesktopStartupProbe ?? false
+              }
+              onInterceptClaudeDesktopStartupProbeChange={(checked) =>
+                onAutoSave({ interceptClaudeDesktopStartupProbe: checked })
+              }
               onToggleProxy={handleToggleProxy}
               isProxyPending={isProxyPending}
             />

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -340,6 +340,8 @@
         "enableFeatureDescription": "When enabled, the routing and failover toggles will appear at the top of the main page",
         "enableFailoverToggle": "Show Failover Toggle on Main Page",
         "enableFailoverToggleDescription": "When enabled, the failover toggle will appear independently at the top of the main page",
+        "interceptClaudeDesktopStartupProbe": "Block Claude Desktop Startup Probe",
+        "interceptClaudeDesktopStartupProbeDescription": "Answer the fixed one-token startup probe locally instead of forwarding it to the provider. Availability is checked on the first real request.",
         "running": "Running",
         "stopped": "Stopped"
       },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -340,6 +340,8 @@
         "enableFeatureDescription": "有効にすると、メインページ上部にルーティングとフェイルオーバーの切り替えが表示されます",
         "enableFailoverToggle": "メインページにフェイルオーバー切り替えを表示",
         "enableFailoverToggleDescription": "有効にすると、メインページ上部にフェイルオーバー切り替えが独立して表示されます",
+        "interceptClaudeDesktopStartupProbe": "Claude Desktop の起動プローブを遮断",
+        "interceptClaudeDesktopStartupProbeDescription": "固定の 1 トークン起動プローブにローカルで応答し、プロバイダーへ転送しません。可用性は最初の実リクエストで確認されます。",
         "running": "実行中",
         "stopped": "停止中"
       },

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -340,6 +340,8 @@
         "enableFeatureDescription": "開啟後，主頁面頂部將顯示路由和故障轉移開關",
         "enableFailoverToggle": "在主頁面顯示故障轉移開關",
         "enableFailoverToggleDescription": "開啟後，主頁面頂部將獨立顯示故障轉移開關",
+        "interceptClaudeDesktopStartupProbe": "攔截 Claude Desktop 啟動探測",
+        "interceptClaudeDesktopStartupProbeDescription": "在本機回應固定的一 Token 啟動探針，不再轉送給供應商；供應商是否可用將在第一次真實請求時確認。",
         "running": "執行中",
         "stopped": "已停止"
       },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -340,6 +340,8 @@
         "enableFeatureDescription": "开启后，主页面顶部将显示路由和故障转移开关",
         "enableFailoverToggle": "在主页面显示故障转移开关",
         "enableFailoverToggleDescription": "开启后，主页面顶部将独立显示故障转移开关",
+        "interceptClaudeDesktopStartupProbe": "拦截 Claude Desktop 启动测活",
+        "interceptClaudeDesktopStartupProbeDescription": "在本机响应固定的一 Token 启动探针，不再转发给供应商；供应商是否可用将在第一次真实请求时确认。",
         "running": "运行中",
         "stopped": "已停止"
       },

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -15,6 +15,7 @@ export const settingsSchema = z.object({
   skipClaudeOnboarding: z.boolean().optional(),
   launchOnStartup: z.boolean().optional(),
   enableLocalProxy: z.boolean().optional(),
+  interceptClaudeDesktopStartupProbe: z.boolean().optional(),
   usageDashboardRefreshIntervalMs: z.number().optional(),
   preserveCodexOfficialAuthOnSwitch: z.boolean().optional(),
   unifyCodexSessionHistory: z.boolean().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,6 +358,8 @@ export interface Settings {
   silentStartup?: boolean;
   // 是否启用主页面本地代理功能（默认关闭）
   enableLocalProxy?: boolean;
+  // 在本机响应 Claude Desktop 的固定启动探针，不转发给供应商
+  interceptClaudeDesktopStartupProbe?: boolean;
   // User has confirmed the local proxy first-run notice
   proxyConfirmed?: boolean;
   // User has confirmed the usage query first-run notice


### PR DESCRIPTION
## Summary

- add an opt-in setting to intercept Claude Desktop's fixed startup probe locally
- strictly match only the current non-streaming `claude-haiku-4-5` / `max_tokens: 1` / single `.` request shape
- return an Anthropic-compatible success response before provider selection, forwarding, failover, and usage logging
- expose the setting in Local Routing with English, Simplified Chinese, Traditional Chinese, and Japanese text

## Motivation

Claude Desktop currently sends a real inference request when a third-party profile starts:

```json
{
  model: claude-haiku-4-5,
  max_tokens: 1,
  messages: [{ role: user, content: . }]
}
```

Some community or公益 API providers explicitly disallow health-check inference. The existing model-discovery behavior only covers `GET /v1/models`, so this startup request is still forwarded upstream and may time out, consume quota, or violate provider policy.

## Safety

- disabled by default
- limited to the authenticated Claude Desktop gateway route
- rejects streaming requests, extra top-level fields, extra message fields, different models, different token limits, and different content
- all non-matching requests continue through the existing forwarding path unchanged
- when enabled, provider availability is deferred to the first real user request

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- TypeScript type check passed
- Prettier check passed
- targeted frontend tests: 18 passed
- focused Rust tests added for exact matching, near-miss forwarding, and response shape (also exercised by CI)