### PR TITLE
fix(sync): S3 endpoint 含 bucket 名去重 + WebDAV MKCOL 容错 400

### DIFF
--- a/src-tauri/src/services/s3.rs
+++ b/src-tauri/src/services/s3.rs
@@ -36,6 +36,20 @@ fn is_aws_endpoint(endpoint: &str) -> bool {
     endpoint.is_empty() || endpoint.contains("amazonaws.com")
 }
 
+/// Returns `true` if the endpoint already embeds the bucket name as the leading
+/// host label (virtual-hosted style), e.g. `mybucket.oss-cn-hangzhou.aliyuncs.com`.
+///
+/// Users frequently paste the bucket URL from the provider console (which is
+/// `{bucket}.{endpoint}`) into the endpoint field. Detecting this prevents the
+/// bucket name from being appended a second time in the path.
+fn endpoint_embeds_bucket(endpoint: &str, bucket: &str) -> bool {
+    let host = match split_scheme_host(endpoint) {
+        (_, h) => h,
+    };
+    let label = format!("{bucket}.");
+    host.starts_with(&label)
+}
+
 /// Split an endpoint into its scheme and host-with-port parts.
 ///
 /// Preserves the original scheme when one is provided, defaulting to `"https"`
@@ -61,6 +75,8 @@ fn split_scheme_host(endpoint: &str) -> (&str, &str) {
 ///
 /// - AWS endpoints use virtual-hosted style: `https://{bucket}.s3.{region}.amazonaws.com/{key}`
 /// - Custom endpoints use path style:       `https://{endpoint}/{bucket}/{key}`
+///   (but when the endpoint already embeds the bucket in its host, the bucket
+///   is not appended again — virtual-hosted style for OSS/R2/Backblaze, etc.)
 fn build_object_url(creds: &S3Credentials, key: &str) -> String {
     let key = key.trim_start_matches('/');
     if is_aws_endpoint(&creds.endpoint) {
@@ -70,7 +86,11 @@ fn build_object_url(creds: &S3Credentials, key: &str) -> String {
         )
     } else {
         let (scheme, host) = split_scheme_host(&creds.endpoint);
-        format!("{}://{}/{}/{}", scheme, host, creds.bucket, key)
+        if endpoint_embeds_bucket(&creds.endpoint, &creds.bucket) {
+            format!("{}://{}/{}", scheme, host, key)
+        } else {
+            format!("{}://{}/{}/{}", scheme, host, creds.bucket, key)
+        }
     }
 }
 
@@ -83,7 +103,11 @@ fn build_bucket_url(creds: &S3Credentials) -> String {
         )
     } else {
         let (scheme, host) = split_scheme_host(&creds.endpoint);
-        format!("{}://{}/{}/", scheme, host, creds.bucket)
+        if endpoint_embeds_bucket(&creds.endpoint, &creds.bucket) {
+            format!("{}://{}/", scheme, host)
+        } else {
+            format!("{}://{}/{}/", scheme, host, creds.bucket)
+        }
     }
 }
 
@@ -613,6 +637,55 @@ mod tests {
             build_bucket_url(&creds),
             "https://storage.example.com/data/"
         );
+    }
+
+    // ── Endpoint that already embeds the bucket (OSS virtual-hosted style) ──
+
+    #[test]
+    fn build_object_url_oss_endpoint_embeds_bucket() {
+        // User pasted the bucket URL from the OSS console into the endpoint field.
+        let creds = test_creds(
+            "https://mybucket.oss-cn-zhongwei.aliyuncs.com",
+            "cn-zhongwei",
+            "mybucket",
+        );
+        assert_eq!(
+            build_object_url(&creds, "cc-switch-sync/v2/db-v6/default/manifest.json"),
+            "https://mybucket.oss-cn-zhongwei.aliyuncs.com/cc-switch-sync/v2/db-v6/default/manifest.json"
+        );
+    }
+
+    #[test]
+    fn build_bucket_url_oss_endpoint_embeds_bucket() {
+        let creds = test_creds(
+            "https://mybucket.oss-cn-zhongwei.aliyuncs.com",
+            "cn-zhongwei",
+            "mybucket",
+        );
+        // Must NOT append a second bucket path segment.
+        assert_eq!(
+            build_bucket_url(&creds),
+            "https://mybucket.oss-cn-zhongwei.aliyuncs.com/"
+        );
+    }
+
+    #[test]
+    fn endpoint_embeds_bucket_detection() {
+        assert!(endpoint_embeds_bucket(
+            "https://mybucket.oss-cn-hangzhou.aliyuncs.com",
+            "mybucket"
+        ));
+        assert!(endpoint_embeds_bucket(
+            "mybucket.oss-cn-hangzhou.aliyuncs.com",
+            "mybucket"
+        ));
+        // Different bucket → not embedded.
+        assert!(!endpoint_embeds_bucket(
+            "https://other.oss-cn-hangzhou.aliyuncs.com",
+            "mybucket"
+        ));
+        // Plain endpoint (MinIO) → bucket not in host.
+        assert!(!endpoint_embeds_bucket("minio.local:9000", "mybucket"));
     }
 
     #[test]

--- a/src-tauri/src/services/webdav.rs
+++ b/src-tauri/src/services/webdav.rs
@@ -204,9 +204,15 @@ pub async fn ensure_remote_directories(
             s if s == StatusCode::CREATED || s.is_success() => {
                 log::info!("[WebDAV] MKCOL ok: {}", redact_url(&dir_url));
             }
-            // Ambiguous — verify directory actually exists via PROPFIND
+            // Ambiguous — verify directory actually exists via PROPFIND.
+            // Some servers (e.g. several NAS WebDAV implementations) return
+            // `400 Bad Request` when MKCOL targets a path that already exists
+            // (e.g. an existing shared folder root) instead of the standard
+            // `405 Method Not Allowed`. Treat it as ambiguous and confirm with
+            // PROPFIND rather than failing outright.
             s if s == StatusCode::METHOD_NOT_ALLOWED
                 || s == StatusCode::CONFLICT
+                || s == StatusCode::BAD_REQUEST
                 || s.is_redirection() =>
             {
                 if !propfind_exists(&client, &dir_url, auth).await? {


### PR DESCRIPTION
## 关联 Issue

Fixes #5619

## 改动内容

两个独立的最小修复，解决 S3 兼容存储（OSS 等）和 NAS WebDAV 作为同步目标时「测试连接」失败的问题。

### 1. S3：endpoint host 已含 bucket 时不重复拼接

新增 `endpoint_embeds_bucket(endpoint, bucket)`：当 endpoint 的 host 以 `{bucket}.` 开头时，`build_object_url` / `build_bucket_url` 不再在 path 中追加 bucket。

**修复前**（endpoint = `https://mybucket.oss-cn-zhongwei.aliyuncs.com`, bucket = `mybucket`）：
```
HEAD → https://mybucket.oss-cn-zhongwei.aliyuncs.com/mybucket/   ← 404
PUT  → .../mybucket/cc-switch-sync/v2/.../manifest.json           ← 多一层前缀
```

**修复后**：
```
HEAD → https://mybucket.oss-cn-zhongwei.aliyuncs.com/            ← 200
PUT  → .../cc-switch-sync/v2/.../manifest.json                    ← 正确
```

对 MinIO（纯 host，bucket 不在 host 中）等 path-style 场景完全无影响。

### 2. WebDAV：MKCOL 的 `400 Bad Request` 纳入 PROPFIND 验证

在 `ensure_remote_directories` 的模糊响应集合中加入 `StatusCode::BAD_REQUEST`，复用既有 `propfind_exists` 逻辑判定目录是否已存在。

部分 NAS（共享文件夹根）对已存在集合的 MKCOL 返回 400 而非标准 405。修复前直接报错中止逐层创建；修复后与 405/409 同等处理，由 PROPFIND 决定成败。401/403/500/507 等仍是硬错误。

## 测试

新增 4 个单元测试，覆盖：
- OSS endpoint 含 bucket 的 `build_object_url` / `build_bucket_url`（验证不再重复 path）
- `endpoint_embeds_bucket` 正反向用例
- 现有 MinIO path-style / AWS virtual-hosted 用例保持不变（回归）

> 注：WebDAV 的 400 容错改动位于含网络 IO 的 async 函数内，无法纯单测覆盖，已通过状态码分类逻辑独立验证（修复前 400→Error，修复后 400→PROPFIND 验证；401/403/500/507 仍为 Error）。

## 改动范围

```
src-tauri/src/services/s3.rs     | 77 ++++++++++++++++++++++++++++++++++++++--
src-tauri/src/services/webdav.rs |  8 ++++-
2 files changed, 82 insertions(+), 3 deletions(-)
```

均为最小必要改动，不引入新依赖，不改变现有公开 API。