### PR TITLE
fix(webdav): tolerate MKCOL 400 to unblock full sync chain

### DIFF
--- a/src-tauri/src/services/webdav.rs
+++ b/src-tauri/src/services/webdav.rs
@@ -204,9 +204,15 @@ pub async fn ensure_remote_directories(
             s if s == StatusCode::CREATED || s.is_success() => {
                 log::info!("[WebDAV] MKCOL ok: {}", redact_url(&dir_url));
             }
-            // Ambiguous — verify directory actually exists via PROPFIND
+            // Ambiguous — verify directory actually exists via PROPFIND.
+            // Some servers (e.g. several NAS WebDAV implementations) return
+            // `400 Bad Request` when MKCOL targets a path that already exists
+            // (e.g. an existing shared folder root) instead of the standard
+            // `405 Method Not Allowed`. Treat it as ambiguous and confirm with
+            // PROPFIND rather than failing outright.
             s if s == StatusCode::METHOD_NOT_ALLOWED
                 || s == StatusCode::CONFLICT
+                || s == StatusCode::BAD_REQUEST
                 || s.is_redirection() =>
             {
                 if !propfind_exists(&client, &dir_url, auth).await? {


### PR DESCRIPTION
Fixes #5621

## 问题

`ensure_remote_directories` 逐层 MKCOL 创建目录，第一层即 `remoteRoot` 的共享文件夹根（已存在）。部分 NAS WebDAV 对已存在集合的 MKCOL 返回 `400 Bad Request` 而非标准的 `405`，落入 catch-all 错误分支导致整个逐层建目录中止。由于 `upload()` / `download()` 都在 PUT/GET **之前**调用此函数（`webdav_sync.rs:71`，带 `?`），整个 WebDAV 同步链路——测试连接、上传、下载——全部失败。

## 修复

将 `StatusCode::BAD_REQUEST` 加入「模糊响应」集合，复用既有 `propfind_exists` 逻辑判定目录是否已存在，与 405/409 同等处理：

```rust
s if s == StatusCode::METHOD_NOT_ALLOWED
    || s == StatusCode::CONFLICT
    || s == StatusCode::BAD_REQUEST   // ← 新增
    || s.is_redirection() =>
{
    if !propfind_exists(&client, &dir_url, auth).await? {
        return Err(webdav_status_error("MKCOL", status, &dir_url));
    }
}
```

修复后，已存在的共享文件夹根会被 PROPFIND 确认存在、视为成功，逐层创建继续，PUT/GET 随后正常执行。`401 / 403 / 500 / 507` 等仍为硬错误。

## 测试

此改动位于含网络 IO 的 async 函数内，无法纯单元测试覆盖。已通过状态码分类逻辑独立验证：

| MKCOL 响应 | 修复前 | 修复后 |
|-----------|--------|--------|
| 201 Created | 成功 | 成功 |
| 405 Method Not Allowed | PROPFIND 验证 | PROPFIND 验证 |
| 409 Conflict | PROPFIND 验证 | PROPFIND 验证 |
| **400 Bad Request** | **报错（bug）** | **PROPFIND 验证（修复）** |
| 401 / 403 / 500 / 507 | 报错 | 报错（不变）|

## 改动范围

```
src-tauri/src/services/webdav.rs | 8 +++++++-
1 file changed, 7 insertions(+), 1 deletion(-)
```

最小改动，不引入新依赖，不改变现有公开 API。