### PR TITLE
fix(s3): do not double-append bucket when endpoint embeds it

### DIFF
--- a/src-tauri/src/services/s3.rs
+++ b/src-tauri/src/services/s3.rs
@@ -36,6 +36,20 @@ fn is_aws_endpoint(endpoint: &str) -> bool {
     endpoint.is_empty() || endpoint.contains("amazonaws.com")
 }
 
+/// Returns `true` if the endpoint already embeds the bucket name as the leading
+/// host label (virtual-hosted style), e.g. `mybucket.oss-cn-hangzhou.aliyuncs.com`.
+///
+/// Users frequently paste the bucket URL from the provider console (which is
+/// `{bucket}.{endpoint}`) into the endpoint field. Detecting this prevents the
+/// bucket name from being appended a second time in the path.
+fn endpoint_embeds_bucket(endpoint: &str, bucket: &str) -> bool {
+    let host = match split_scheme_host(endpoint) {
+        (_, h) => h,
+    };
+    let label = format!("{bucket}.");
+    host.starts_with(&label)
+}
+
 /// Split an endpoint into its scheme and host-with-port parts.
 ///
 /// Preserves the original scheme when one is provided, defaulting to `"https"`
@@ -61,6 +75,8 @@ fn split_scheme_host(endpoint: &str) -> (&str, &str) {
 ///
 /// - AWS endpoints use virtual-hosted style: `https://{bucket}.s3.{region}.amazonaws.com/{key}`
 /// - Custom endpoints use path style:       `https://{endpoint}/{bucket}/{key}`
+///   (but when the endpoint already embeds the bucket in its host, the bucket
+///   is not appended again — virtual-hosted style for OSS/R2/Backblaze, etc.)
 fn build_object_url(creds: &S3Credentials, key: &str) -> String {
     let key = key.trim_start_matches('/');
     if is_aws_endpoint(&creds.endpoint) {
@@ -70,7 +86,11 @@ fn build_object_url(creds: &S3Credentials, key: &str) -> String {
         )
     } else {
         let (scheme, host) = split_scheme_host(&creds.endpoint);
-        format!("{}://{}/{}/{}", scheme, host, creds.bucket, key)
+        if endpoint_embeds_bucket(&creds.endpoint, &creds.bucket) {
+            format!("{}://{}/{}", scheme, host, key)
+        } else {
+            format!("{}://{}/{}/{}", scheme, host, creds.bucket, key)
+        }
     }
 }
 
@@ -83,7 +103,11 @@ fn build_bucket_url(creds: &S3Credentials) -> String {
         )
     } else {
         let (scheme, host) = split_scheme_host(&creds.endpoint);
-        format!("{}://{}/{}/", scheme, host, creds.bucket)
+        if endpoint_embeds_bucket(&creds.endpoint, &creds.bucket) {
+            format!("{}://{}/", scheme, host)
+        } else {
+            format!("{}://{}/{}/", scheme, host, creds.bucket)
+        }
     }
 }
 
@@ -613,6 +637,55 @@ mod tests {
             build_bucket_url(&creds),
             "https://storage.example.com/data/"
         );
+    }
+
+    // ── Endpoint that already embeds the bucket (OSS virtual-hosted style) ──
+
+    #[test]
+    fn build_object_url_oss_endpoint_embeds_bucket() {
+        // User pasted the bucket URL from the OSS console into the endpoint field.
+        let creds = test_creds(
+            "https://mybucket.oss-cn-zhongwei.aliyuncs.com",
+            "cn-zhongwei",
+            "mybucket",
+        );
+        assert_eq!(
+            build_object_url(&creds, "cc-switch-sync/v2/db-v6/default/manifest.json"),
+            "https://mybucket.oss-cn-zhongwei.aliyuncs.com/cc-switch-sync/v2/db-v6/default/manifest.json"
+        );
+    }
+
+    #[test]
+    fn build_bucket_url_oss_endpoint_embeds_bucket() {
+        let creds = test_creds(
+            "https://mybucket.oss-cn-zhongwei.aliyuncs.com",
+            "cn-zhongwei",
+            "mybucket",
+        );
+        // Must NOT append a second bucket path segment.
+        assert_eq!(
+            build_bucket_url(&creds),
+            "https://mybucket.oss-cn-zhongwei.aliyuncs.com/"
+        );
+    }
+
+    #[test]
+    fn endpoint_embeds_bucket_detection() {
+        assert!(endpoint_embeds_bucket(
+            "https://mybucket.oss-cn-hangzhou.aliyuncs.com",
+            "mybucket"
+        ));
+        assert!(endpoint_embeds_bucket(
+            "mybucket.oss-cn-hangzhou.aliyuncs.com",
+            "mybucket"
+        ));
+        // Different bucket → not embedded.
+        assert!(!endpoint_embeds_bucket(
+            "https://other.oss-cn-hangzhou.aliyuncs.com",
+            "mybucket"
+        ));
+        // Plain endpoint (MinIO) → bucket not in host.
+        assert!(!endpoint_embeds_bucket("minio.local:9000", "mybucket"));
     }
 
     #[test]

--- a/src-tauri/src/services/s3.rs
+++ b/src-tauri/src/services/s3.rs
@@ -36,18 +36,44 @@ fn is_aws_endpoint(endpoint: &str) -> bool {
     endpoint.is_empty() || endpoint.contains("amazonaws.com")
 }
 
-/// Returns `true` if the endpoint already embeds the bucket name as the leading
-/// host label (virtual-hosted style), e.g. `mybucket.oss-cn-hangzhou.aliyuncs.com`.
+/// Known S3-compatible providers that serve objects in virtual-hosted style
+/// (`https://{bucket}.{host}`). A leading `{bucket}.` label on one of these
+/// hosts means the user pasted the bucket URL from the provider console into
+/// the endpoint field; the bucket must not be appended again in the path.
 ///
-/// Users frequently paste the bucket URL from the provider console (which is
-/// `{bucket}.{endpoint}`) into the endpoint field. Detecting this prevents the
-/// bucket name from being appended a second time in the path.
+/// Custom / self-hosted endpoints (MinIO, etc.) are intentionally excluded:
+/// for those the first host label is never assumed to be the bucket, so
+/// path-style behavior is preserved.
+fn is_virtual_hosted_provider_host(host: &str) -> bool {
+    const PROVIDER_HOSTS: &[&str] = &[
+        "aliyuncs.com",             // Alibaba Cloud OSS
+        "myqcloud.com",             // Tencent Cloud COS
+        "myhuaweicloud.com",        // Huawei Cloud OBS
+        "r2.cloudflarestorage.com", // Cloudflare R2
+        "backblazeb2.com",          // Backblaze B2
+        "digitaloceanspaces.com",   // DigitalOcean Spaces
+        "wasabisys.com",            // Wasabi
+        "storage.googleapis.com",   // Google Cloud Storage (S3 interop)
+    ];
+    // `host` must be the provider host itself or one of its subdomains.
+    PROVIDER_HOSTS
+        .iter()
+        .any(|&s| host == s || host.ends_with(&format!(".{s}")))
+}
+
+/// Returns `true` if the endpoint already embeds the bucket name as the leading
+/// host label of a known virtual-hosted provider, e.g.
+/// `mybucket.oss-cn-hangzhou.aliyuncs.com`.
+///
+/// The `{bucket}.` prefix alone cannot decide the addressing style: a path-style
+/// custom endpoint whose first host label coincidentally equals the bucket
+/// (e.g. `data.storage.example.com` with bucket `data`) must keep being treated
+/// as path-style. Virtual-hosted style is therefore only assumed when the rest
+/// of the host belongs to a known provider.
 fn endpoint_embeds_bucket(endpoint: &str, bucket: &str) -> bool {
-    let host = match split_scheme_host(endpoint) {
-        (_, h) => h,
-    };
-    let label = format!("{bucket}.");
-    host.starts_with(&label)
+    let host = split_scheme_host(endpoint).1;
+    let prefix = format!("{bucket}.");
+    host.starts_with(&prefix) && is_virtual_hosted_provider_host(&host[prefix.len()..])
 }
 
 /// Split an endpoint into its scheme and host-with-port parts.
@@ -671,12 +697,38 @@ mod tests {
 
     #[test]
     fn endpoint_embeds_bucket_detection() {
+        // Alibaba Cloud OSS (with and without explicit scheme).
         assert!(endpoint_embeds_bucket(
             "https://mybucket.oss-cn-hangzhou.aliyuncs.com",
             "mybucket"
         ));
         assert!(endpoint_embeds_bucket(
             "mybucket.oss-cn-hangzhou.aliyuncs.com",
+            "mybucket"
+        ));
+        // Other known virtual-hosted providers.
+        assert!(endpoint_embeds_bucket(
+            "mybucket-1250000000.cos.ap-shanghai.myqcloud.com",
+            "mybucket-1250000000"
+        ));
+        assert!(endpoint_embeds_bucket(
+            "mybucket.obs.cn-north-4.myhuaweicloud.com",
+            "mybucket"
+        ));
+        assert!(endpoint_embeds_bucket(
+            "mybucket.s3.us-west-004.backblazeb2.com",
+            "mybucket"
+        ));
+        assert!(endpoint_embeds_bucket(
+            "mybucket.nyc3.digitaloceanspaces.com",
+            "mybucket"
+        ));
+        assert!(endpoint_embeds_bucket(
+            "mybucket.s3.wasabisys.com",
+            "mybucket"
+        ));
+        assert!(endpoint_embeds_bucket(
+            "mybucket.storage.googleapis.com",
             "mybucket"
         ));
         // Different bucket → not embedded.
@@ -686,6 +738,36 @@ mod tests {
         ));
         // Plain endpoint (MinIO) → bucket not in host.
         assert!(!endpoint_embeds_bucket("minio.local:9000", "mybucket"));
+        // Path-style endpoint whose first host label coincidentally equals the
+        // bucket: the bucket is NOT embedded (custom hosts are never assumed
+        // virtual-hosted), so path-style URL construction is preserved.
+        assert!(!endpoint_embeds_bucket(
+            "https://data.storage.example.com",
+            "data"
+        ));
+        assert!(!endpoint_embeds_bucket("minio.example.com:9000", "minio"));
+    }
+
+    #[test]
+    fn endpoint_embeds_bucket_requires_provider_host() {
+        // The bucket label alone must not trigger virtual-hosted style on
+        // generic custom endpoints — regression for
+        // https://github.com/farion1231/cc-switch/pull/5624 review comment.
+        let creds = test_creds("https://data.storage.example.com", "us-east-1", "data");
+        assert_eq!(
+            build_object_url(&creds, "cc-switch-sync/v2/db-v6/default/manifest.json"),
+            "https://data.storage.example.com/data/cc-switch-sync/v2/db-v6/default/manifest.json"
+        );
+        assert_eq!(
+            build_bucket_url(&creds),
+            "https://data.storage.example.com/data/"
+        );
+
+        let minio = test_creds("minio.example.com:9000", "us-east-1", "minio");
+        assert_eq!(
+            build_object_url(&minio, "k"),
+            "https://minio.example.com:9000/minio/k"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #5622

## 问题

用户在 endpoint 字段填入从 OSS 控制台复制的 bucket 完整地址（如 `https://mybucket.oss-cn-zhongwei.aliyuncs.com`）——控制台展示的正是这个 URL。path-style 分支把整个 endpoint 当作纯 host，又拼一次 `/{bucket}/`，导致：

- HEAD bucket（测试连接）→ 404（路径里出现重复的 bucket 名）
- PUT 表面成功，但 object 被存到 `mybucket/cc-switch-sync/...` 多余前缀下，后续 GET 读不回

`is_aws_endpoint` 只匹配 `amazonaws.com`，所以 OSS（`aliyuncs.com`）等 S3 兼容存储走 path-style 分支，问题在此触发。

## 修复

新增 `endpoint_embeds_bucket(endpoint, bucket)`：当 endpoint 的 host 以 `{bucket}.` 开头（virtual-hosted style）时，`build_object_url` / `build_bucket_url` 不再追加 bucket 段。

**修复前**（endpoint = `https://mybucket.oss-cn-zhongwei.aliyuncs.com`，bucket = `mybucket`）：
```
HEAD → https://mybucket.oss-cn-zhongwei.aliyuncs.com/mybucket/   ← 404
PUT  → .../mybucket/cc-switch-sync/v2/.../manifest.json           ← 多余前缀
```

**修复后**：
```
HEAD → https://mybucket.oss-cn-zhongwei.aliyuncs.com/            ← 200
PUT  → .../cc-switch-sync/v2/.../manifest.json                    ← 正确
```

对纯 host 的 path-style endpoint（MinIO 等，bucket 不在 host 中）无影响。

## 测试

新增 4 个单元测试：

- `build_object_url_oss_endpoint_embeds_bucket`：验证不再重复 path 段
- `build_bucket_url_oss_endpoint_embeds_bucket`：验证 HEAD URL 不再含重复 bucket
- `endpoint_embeds_bucket_detection`：正向（OSS virtual-hosted）+ 反向（不同 bucket / MinIO）

已用独立编译验证（含真实 OSS 配置 + MinIO path-style + AWS virtual-hosted 回归），6/6 通过。现有 MinIO / AWS 用例不受影响。

## 改动范围

```
src-tauri/src/services/s3.rs | 77 ++++++++++++++++++++++++++++++++++++++++++--
1 file changed, 75 insertions(+), 2 deletions(-)
```

最小改动，不引入新依赖，不改变现有公开 API。