### PR TITLE
perf(codex): cache parent rollout timelines across fork cutoffs

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -91,7 +91,11 @@ webkit2gtk = { version = "2.0.1", features = ["v2_16"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
-windows-sys = { version = "0.61", features = ["Win32_Globalization", "Win32_UI_Shell"] }
+windows-sys = { version = "0.61", features = [
+    "Win32_Globalization",
+    "Win32_Storage_FileSystem",
+    "Win32_UI_Shell",
+] }
 
 [target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
 rquickjs = { version = "0.8", features = ["bindgen"] }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::SystemTime;
 
 const CODEX_THREAD_REQUEST_ID_PREFIX: &str = "codex_session:thread-v1";
@@ -70,6 +70,28 @@ struct TokenCountersSignature {
 struct TokenUsageSignature {
     total: Option<TokenCountersSignature>,
     last: Option<TokenCountersSignature>,
+}
+
+#[derive(Debug)]
+struct TimestampedTokenSignature {
+    timestamp: DateTime<Utc>,
+    signature: TokenUsageSignature,
+}
+
+#[derive(Debug)]
+struct ParentTokenTimeline {
+    events: Vec<TimestampedTokenSignature>,
+    max_timestamp: Option<DateTime<Utc>>,
+}
+
+impl ParentTokenTimeline {
+    fn signatures_before(&self, cutoff: DateTime<Utc>) -> Vec<TokenUsageSignature> {
+        self.events
+            .iter()
+            .filter(|event| event.timestamp <= cutoff)
+            .map(|event| event.signature.clone())
+            .collect()
+    }
 }
 
 #[derive(Debug)]
@@ -116,7 +138,7 @@ struct PendingEntry {
 
 #[derive(Debug, Default)]
 struct CodexReplayCaches {
-    parent_signatures: HashMap<(PathBuf, i64), Vec<TokenUsageSignature>>,
+    parent_timelines: HashMap<(PathBuf, i64, u64), Arc<ParentTokenTimeline>>,
     replay_prefixes: HashMap<(PathBuf, i64, u64), usize>,
     pending: HashMap<PathBuf, PendingEntry>,
 }
@@ -757,20 +779,41 @@ fn parent_signatures_before(
     parent_path: &Path,
     cutoff: DateTime<Utc>,
 ) -> Result<Vec<TokenUsageSignature>, String> {
-    let cache_key = (parent_path.to_path_buf(), cutoff.timestamp_micros());
-    if let Ok(caches) = replay_caches().lock() {
-        if let Some(signatures) = caches.parent_signatures.get(&cache_key) {
-            return Ok(signatures.clone());
+    let metadata = fs::metadata(parent_path).map_err(|error| {
+        format!(
+            "无法读取父 rollout 元数据 {}: {error}",
+            parent_path.display()
+        )
+    })?;
+    let cache_key = (
+        parent_path.to_path_buf(),
+        metadata_modified_nanos(&metadata),
+        metadata.len(),
+    );
+    let cached_timeline = replay_caches()
+        .lock()
+        .ok()
+        .and_then(|caches| caches.parent_timelines.get(&cache_key).cloned());
+    if let Some(timeline) = cached_timeline {
+        if timeline
+            .max_timestamp
+            .is_none_or(|timestamp| timestamp < cutoff)
+        {
+            return Err(format!(
+                "父 rollout {} 尚未写到 child fork 时刻",
+                parent_path.display()
+            ));
         }
+        return Ok(timeline.signatures_before(cutoff));
     }
 
     let file = fs::File::open(parent_path)
         .map_err(|error| format!("无法打开父 rollout {}: {error}", parent_path.display()))?;
-    let mut signatures = Vec::new();
+    let mut events = Vec::new();
     let mut max_timestamp: Option<DateTime<Utc>> = None;
 
-    // 必须扫描完整父文件并逐行应用 cutoff，不能在首个未来时间戳处 break：
-    // rollout 写入顺序不承诺时间戳严格单调。
+    // 必须扫描完整父文件，不能在首个未来时间戳处 break：rollout 写入顺序
+    // 不承诺时间戳严格单调。缓存完整时间线后，不同 child cutoff 只需内存过滤。
     for line in BufReader::new(file).lines() {
         let Ok(line) = line else {
             continue;
@@ -807,9 +850,10 @@ fn parent_signatures_before(
                 parent_path.display()
             ));
         };
-        if timestamp <= cutoff {
-            signatures.push(signature);
-        }
+        events.push(TimestampedTokenSignature {
+            timestamp,
+            signature,
+        });
     }
 
     if max_timestamp.is_none_or(|timestamp| timestamp < cutoff) {
@@ -819,12 +863,19 @@ fn parent_signatures_before(
         ));
     }
 
+    let timeline = Arc::new(ParentTokenTimeline {
+        events,
+        max_timestamp,
+    });
     if let Ok(mut caches) = replay_caches().lock() {
         caches
-            .parent_signatures
-            .insert(cache_key, signatures.clone());
+            .parent_timelines
+            .retain(|(path, _, _), _| path != parent_path);
+        caches
+            .parent_timelines
+            .insert(cache_key, Arc::clone(&timeline));
     }
-    Ok(signatures)
+    Ok(timeline.signatures_before(cutoff))
 }
 
 fn resolve_parent_signatures(
@@ -1018,6 +1069,9 @@ fn sync_single_codex_file(
                         };
                     let prefix = matching_replay_prefix(&parsed.token_events, &parent_signatures);
                     if let Ok(mut caches) = replay_caches().lock() {
+                        caches
+                            .replay_prefixes
+                            .retain(|(path, _, _), _| path != file_path);
                         caches.replay_prefixes.insert(cache_key, prefix);
                     }
                     prefix
@@ -1477,6 +1531,65 @@ mod tests {
 
         let result = sync_test_file(&db, &child, &[&parent, &child])?;
         assert_eq!((result.imported, result.skipped), (1, 2));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parent_rollout_is_cached_once_across_fork_cutoffs() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                token_count_at(200, 100, 20, "2026-07-10T03:00:10Z"),
+                turn_context_at("2026-07-10T03:00:20Z"),
+            ],
+        );
+
+        let early = "2026-07-10T03:00:05Z".parse::<DateTime<Utc>>().unwrap();
+        let late = "2026-07-10T03:00:15Z".parse::<DateTime<Utc>>().unwrap();
+        assert_eq!(parent_signatures_before(&parent, early).unwrap().len(), 1);
+        assert_eq!(parent_signatures_before(&parent, late).unwrap().len(), 2);
+
+        let caches = replay_caches().lock().unwrap();
+        assert_eq!(caches.parent_timelines.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parent_rollout_cache_invalidates_after_append() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let cutoff = "2026-07-10T03:00:15Z".parse::<DateTime<Utc>>().unwrap();
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                turn_context_at("2026-07-10T03:00:20Z"),
+            ],
+        );
+        assert_eq!(parent_signatures_before(&parent, cutoff).unwrap().len(), 1);
+
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                token_count_at(200, 100, 20, "2026-07-10T03:00:10Z"),
+                turn_context_at("2026-07-10T03:00:20Z"),
+            ],
+        );
+        assert_eq!(parent_signatures_before(&parent, cutoff).unwrap().len(), 2);
+
+        let caches = replay_caches().lock().unwrap();
+        assert_eq!(caches.parent_timelines.len(), 1);
         Ok(())
     }
 

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -31,9 +31,15 @@ use std::fs;
 use std::io::{BufRead, BufReader};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::SystemTime;
+#[cfg(windows)]
+use windows_sys::Win32::Storage::FileSystem::{
+    FileIdInfo, GetFileInformationByHandleEx, FILE_ID_INFO,
+};
 
 const CODEX_THREAD_REQUEST_ID_PREFIX: &str = "codex_session:thread-v1";
 
@@ -88,19 +94,49 @@ struct ParentFileStamp {
     device: u64,
     #[cfg(unix)]
     inode: u64,
+    #[cfg(windows)]
+    volume_serial: u64,
+    #[cfg(windows)]
+    file_id: [u8; 16],
 }
 
 impl ParentFileStamp {
-    fn from_metadata(metadata: &fs::Metadata) -> Self {
-        Self {
-            modified_nanos: metadata_modified_nanos(metadata),
+    fn from_file(file: &fs::File) -> Option<Self> {
+        let metadata = file.metadata().ok()?;
+        #[cfg(windows)]
+        let (volume_serial, file_id) = windows_file_identity(file)?;
+        Some(Self {
+            modified_nanos: metadata_modified_nanos(&metadata),
             size: metadata.len(),
             #[cfg(unix)]
             device: metadata.dev(),
             #[cfg(unix)]
             inode: metadata.ino(),
-        }
+            #[cfg(windows)]
+            volume_serial,
+            #[cfg(windows)]
+            file_id,
+        })
     }
+}
+
+#[cfg(windows)]
+fn windows_file_identity(file: &fs::File) -> Option<(u64, [u8; 16])> {
+    let mut information = FILE_ID_INFO::default();
+    // SAFETY: `file` owns a live handle for this call, and `information` is a
+    // valid writable FILE_ID_INFO buffer of the size passed to Windows.
+    let succeeded = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileIdInfo,
+            std::ptr::addr_of_mut!(information).cast(),
+            std::mem::size_of::<FILE_ID_INFO>() as u32,
+        )
+    } != 0;
+    succeeded.then_some((
+        information.VolumeSerialNumber,
+        information.FileId.Identifier,
+    ))
 }
 
 #[derive(Debug)]
@@ -144,6 +180,13 @@ impl ParentTokenTimeline {
 struct CachedParentTimeline {
     stamp: ParentFileStamp,
     timeline: Arc<ParentTokenTimeline>,
+}
+
+#[derive(Debug)]
+struct CachedReplayPrefix {
+    modified: i64,
+    size: u64,
+    prefix: usize,
 }
 
 #[derive(Debug)]
@@ -191,7 +234,7 @@ struct PendingEntry {
 #[derive(Debug, Default)]
 struct CodexReplayCaches {
     parent_timelines: HashMap<PathBuf, CachedParentTimeline>,
-    replay_prefixes: HashMap<(PathBuf, i64, u64), usize>,
+    replay_prefixes: HashMap<PathBuf, CachedReplayPrefix>,
     pending: HashMap<PathBuf, PendingEntry>,
 }
 
@@ -833,10 +876,7 @@ fn parent_signatures_before(
 ) -> Result<Vec<TokenUsageSignature>, String> {
     let file = fs::File::open(parent_path)
         .map_err(|error| format!("无法打开父 rollout {}: {error}", parent_path.display()))?;
-    let stamp = file
-        .metadata()
-        .ok()
-        .map(|metadata| ParentFileStamp::from_metadata(&metadata));
+    let stamp = ParentFileStamp::from_file(&file);
     let cached_timeline = stamp.and_then(|stamp| {
         replay_caches().lock().ok().and_then(|caches| {
             caches
@@ -1080,10 +1120,14 @@ fn sync_single_codex_file(
                     ),
                 ));
             };
-            let cache_key = (file_path.to_path_buf(), file_modified, file_size);
             if let Ok(caches) = replay_caches().lock() {
-                if let Some(prefix) = caches.replay_prefixes.get(&cache_key) {
-                    *prefix
+                if let Some(prefix) = caches
+                    .replay_prefixes
+                    .get(file_path)
+                    .filter(|cached| cached.modified == file_modified && cached.size == file_size)
+                    .map(|cached| cached.prefix)
+                {
+                    prefix
                 } else {
                     drop(caches);
                     let parent_signatures =
@@ -1105,10 +1149,14 @@ fn sync_single_codex_file(
                         };
                     let prefix = matching_replay_prefix(&parsed.token_events, &parent_signatures);
                     if let Ok(mut caches) = replay_caches().lock() {
-                        caches
-                            .replay_prefixes
-                            .retain(|(path, _, _), _| path != file_path);
-                        caches.replay_prefixes.insert(cache_key, prefix);
+                        caches.replay_prefixes.insert(
+                            file_path.to_path_buf(),
+                            CachedReplayPrefix {
+                                modified: file_modified,
+                                size: file_size,
+                                prefix,
+                            },
+                        );
                     }
                     prefix
                 }
@@ -1506,6 +1554,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_thread_spawn_parent_strips_replay_and_keeps_live_usage() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;
@@ -1548,6 +1597,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_filtered_parent_events_use_subsequence_prefix_alignment() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;
@@ -1598,10 +1648,16 @@ mod tests {
         let early = "2026-07-10T03:00:05Z".parse::<DateTime<Utc>>().unwrap();
         let late = "2026-07-10T03:00:15Z".parse::<DateTime<Utc>>().unwrap();
         assert_eq!(parent_signatures_before(&parent, early).unwrap().len(), 1);
+        let first_timeline =
+            Arc::clone(&replay_caches().lock().unwrap().parent_timelines[&parent].timeline);
         assert_eq!(parent_signatures_before(&parent, late).unwrap().len(), 2);
 
         let caches = replay_caches().lock().unwrap();
         assert_eq!(caches.parent_timelines.len(), 1);
+        assert!(Arc::ptr_eq(
+            &first_timeline,
+            &caches.parent_timelines[&parent].timeline
+        ));
         Ok(())
     }
 
@@ -1697,7 +1753,7 @@ mod tests {
         assert_eq!(replay_caches().lock().unwrap().parent_timelines.len(), 1);
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
     fn test_parent_file_stamp_distinguishes_same_size_same_mtime_files() {
         let temp = tempdir().unwrap();
@@ -1706,7 +1762,8 @@ mod tests {
         let values = [session_meta(PARENT_ID), token_count(100, 50, 10)];
         write_jsonl(&parent, &values);
         write_jsonl(&replacement, &values);
-        let original_metadata = fs::metadata(&parent).unwrap();
+        let original_file = fs::File::open(&parent).unwrap();
+        let original_metadata = original_file.metadata().unwrap();
         let replacement_file = fs::OpenOptions::new()
             .write(true)
             .open(&replacement)
@@ -1714,9 +1771,8 @@ mod tests {
         replacement_file
             .set_times(fs::FileTimes::new().set_modified(original_metadata.modified().unwrap()))
             .unwrap();
-        let replacement_metadata = replacement_file.metadata().unwrap();
-        let original_stamp = ParentFileStamp::from_metadata(&original_metadata);
-        let replacement_stamp = ParentFileStamp::from_metadata(&replacement_metadata);
+        let original_stamp = ParentFileStamp::from_file(&original_file).unwrap();
+        let replacement_stamp = ParentFileStamp::from_file(&replacement_file).unwrap();
         assert_eq!(
             (original_stamp.size, original_stamp.modified_nanos),
             (replacement_stamp.size, replacement_stamp.modified_nanos)
@@ -1725,6 +1781,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_empty_fork_imports_no_parent_usage() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;
@@ -1770,6 +1827,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_conflicting_explicit_parents_are_deferred() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;
@@ -1795,6 +1853,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_parent_future_signature_cannot_extend_replay_prefix() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;
@@ -1826,6 +1885,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_missing_parent_is_deferred_and_recovered_without_child_change() -> Result<(), AppError>
     {
         clear_codex_replay_caches();
@@ -1859,6 +1919,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_billable_file_without_meta_is_deferred_without_cursor() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;
@@ -1885,6 +1946,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_non_billable_file_without_meta_advances_cursor() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;
@@ -1905,6 +1967,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_subagents_use_filename_thread_ids() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -29,6 +29,8 @@ use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::SystemTime;
@@ -78,20 +80,70 @@ struct TimestampedTokenSignature {
     signature: TokenUsageSignature,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ParentFileStamp {
+    modified_nanos: i64,
+    size: u64,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl ParentFileStamp {
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        Self {
+            modified_nanos: metadata_modified_nanos(metadata),
+            size: metadata.len(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct ParentTokenTimeline {
     events: Vec<TimestampedTokenSignature>,
     max_timestamp: Option<DateTime<Utc>>,
+    has_token_without_timestamp: bool,
 }
 
 impl ParentTokenTimeline {
-    fn signatures_before(&self, cutoff: DateTime<Utc>) -> Vec<TokenUsageSignature> {
-        self.events
+    fn signatures_before(
+        &self,
+        parent_path: &Path,
+        cutoff: DateTime<Utc>,
+    ) -> Result<Vec<TokenUsageSignature>, String> {
+        if self.has_token_without_timestamp {
+            return Err(format!(
+                "父 rollout {} 的 token_count 缺少有效 timestamp",
+                parent_path.display()
+            ));
+        }
+        if self
+            .max_timestamp
+            .is_none_or(|timestamp| timestamp < cutoff)
+        {
+            return Err(format!(
+                "父 rollout {} 尚未写到 child fork 时刻",
+                parent_path.display()
+            ));
+        }
+        Ok(self
+            .events
             .iter()
             .filter(|event| event.timestamp <= cutoff)
             .map(|event| event.signature.clone())
-            .collect()
+            .collect())
     }
+}
+
+#[derive(Debug)]
+struct CachedParentTimeline {
+    stamp: ParentFileStamp,
+    timeline: Arc<ParentTokenTimeline>,
 }
 
 #[derive(Debug)]
@@ -138,7 +190,7 @@ struct PendingEntry {
 
 #[derive(Debug, Default)]
 struct CodexReplayCaches {
-    parent_timelines: HashMap<(PathBuf, i64, u64), Arc<ParentTokenTimeline>>,
+    parent_timelines: HashMap<PathBuf, CachedParentTimeline>,
     replay_prefixes: HashMap<(PathBuf, i64, u64), usize>,
     pending: HashMap<PathBuf, PendingEntry>,
 }
@@ -779,38 +831,28 @@ fn parent_signatures_before(
     parent_path: &Path,
     cutoff: DateTime<Utc>,
 ) -> Result<Vec<TokenUsageSignature>, String> {
-    let metadata = fs::metadata(parent_path).map_err(|error| {
-        format!(
-            "无法读取父 rollout 元数据 {}: {error}",
-            parent_path.display()
-        )
-    })?;
-    let cache_key = (
-        parent_path.to_path_buf(),
-        metadata_modified_nanos(&metadata),
-        metadata.len(),
-    );
-    let cached_timeline = replay_caches()
-        .lock()
-        .ok()
-        .and_then(|caches| caches.parent_timelines.get(&cache_key).cloned());
-    if let Some(timeline) = cached_timeline {
-        if timeline
-            .max_timestamp
-            .is_none_or(|timestamp| timestamp < cutoff)
-        {
-            return Err(format!(
-                "父 rollout {} 尚未写到 child fork 时刻",
-                parent_path.display()
-            ));
-        }
-        return Ok(timeline.signatures_before(cutoff));
-    }
-
     let file = fs::File::open(parent_path)
         .map_err(|error| format!("无法打开父 rollout {}: {error}", parent_path.display()))?;
+    let stamp = file
+        .metadata()
+        .ok()
+        .map(|metadata| ParentFileStamp::from_metadata(&metadata));
+    let cached_timeline = stamp.and_then(|stamp| {
+        replay_caches().lock().ok().and_then(|caches| {
+            caches
+                .parent_timelines
+                .get(parent_path)
+                .filter(|entry| entry.stamp == stamp)
+                .map(|entry| Arc::clone(&entry.timeline))
+        })
+    });
+    if let Some(timeline) = cached_timeline {
+        return timeline.signatures_before(parent_path, cutoff);
+    }
+
     let mut events = Vec::new();
     let mut max_timestamp: Option<DateTime<Utc>> = None;
+    let mut has_token_without_timestamp = false;
 
     // 必须扫描完整父文件，不能在首个未来时间戳处 break：rollout 写入顺序
     // 不承诺时间戳严格单调。缓存完整时间线后，不同 child cutoff 只需内存过滤。
@@ -845,10 +887,8 @@ fn parent_signatures_before(
             continue;
         };
         let Some(timestamp) = timestamp else {
-            return Err(format!(
-                "父 rollout {} 的 token_count 缺少有效 timestamp",
-                parent_path.display()
-            ));
+            has_token_without_timestamp = true;
+            continue;
         };
         events.push(TimestampedTokenSignature {
             timestamp,
@@ -856,26 +896,22 @@ fn parent_signatures_before(
         });
     }
 
-    if max_timestamp.is_none_or(|timestamp| timestamp < cutoff) {
-        return Err(format!(
-            "父 rollout {} 尚未写到 child fork 时刻",
-            parent_path.display()
-        ));
-    }
-
     let timeline = Arc::new(ParentTokenTimeline {
         events,
         max_timestamp,
+        has_token_without_timestamp,
     });
-    if let Ok(mut caches) = replay_caches().lock() {
-        caches
-            .parent_timelines
-            .retain(|(path, _, _), _| path != parent_path);
-        caches
-            .parent_timelines
-            .insert(cache_key, Arc::clone(&timeline));
+    let result = timeline.signatures_before(parent_path, cutoff);
+    if let (Some(stamp), Ok(mut caches)) = (stamp, replay_caches().lock()) {
+        caches.parent_timelines.insert(
+            parent_path.to_path_buf(),
+            CachedParentTimeline {
+                stamp,
+                timeline: Arc::clone(&timeline),
+            },
+        );
     }
-    Ok(timeline.signatures_before(cutoff))
+    result
 }
 
 fn resolve_parent_signatures(
@@ -1339,6 +1375,15 @@ mod tests {
         token_count_at(input, cached, output, "2026-07-10T03:00:02Z")
     }
 
+    fn token_count_without_timestamp(input: u64, cached: u64, output: u64) -> serde_json::Value {
+        let mut value = token_count(input, cached, output);
+        value
+            .as_object_mut()
+            .expect("token_count must be an object")
+            .remove("timestamp");
+        value
+    }
+
     fn sync_test_file(
         db: &Database,
         file: &Path,
@@ -1591,6 +1636,92 @@ mod tests {
         let caches = replay_caches().lock().unwrap();
         assert_eq!(caches.parent_timelines.len(), 1);
         Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parent_rollout_content_error_cache_preserves_open_errors() {
+        clear_codex_replay_caches();
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let cutoff = "2026-07-10T03:00:05Z".parse::<DateTime<Utc>>().unwrap();
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_without_timestamp(100, 50, 10),
+                turn_context_at("2026-07-10T03:00:20Z"),
+            ],
+        );
+
+        let first_error = parent_signatures_before(&parent, cutoff).unwrap_err();
+        assert!(first_error.contains("token_count 缺少有效 timestamp"));
+        let cached_timeline =
+            || Arc::clone(&replay_caches().lock().unwrap().parent_timelines[&parent].timeline);
+        let first_timeline = cached_timeline();
+
+        let second_error = parent_signatures_before(&parent, cutoff).unwrap_err();
+        assert_eq!(second_error, first_error);
+        assert!(Arc::ptr_eq(&first_timeline, &cached_timeline()));
+
+        fs::remove_file(&parent).unwrap();
+        let open_error = parent_signatures_before(&parent, cutoff).unwrap_err();
+        assert!(open_error.contains("无法打开父 rollout"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parent_rollout_nanosecond_cutoffs_are_exact() {
+        clear_codex_replay_caches();
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:00.000000500Z"),
+                turn_context_at("2026-07-10T03:00:00.000000900Z"),
+            ],
+        );
+
+        let before = "2026-07-10T03:00:00.000000300Z"
+            .parse::<DateTime<Utc>>()
+            .unwrap();
+        let after = "2026-07-10T03:00:00.000000700Z"
+            .parse::<DateTime<Utc>>()
+            .unwrap();
+        assert!(parent_signatures_before(&parent, before)
+            .unwrap()
+            .is_empty());
+        assert_eq!(parent_signatures_before(&parent, after).unwrap().len(), 1);
+        assert_eq!(replay_caches().lock().unwrap().parent_timelines.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_parent_file_stamp_distinguishes_same_size_same_mtime_files() {
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let replacement = temp.path().join("replacement.jsonl");
+        let values = [session_meta(PARENT_ID), token_count(100, 50, 10)];
+        write_jsonl(&parent, &values);
+        write_jsonl(&replacement, &values);
+        let original_metadata = fs::metadata(&parent).unwrap();
+        let replacement_file = fs::OpenOptions::new()
+            .write(true)
+            .open(&replacement)
+            .unwrap();
+        replacement_file
+            .set_times(fs::FileTimes::new().set_modified(original_metadata.modified().unwrap()))
+            .unwrap();
+        let replacement_metadata = replacement_file.metadata().unwrap();
+        let original_stamp = ParentFileStamp::from_metadata(&original_metadata);
+        let replacement_stamp = ParentFileStamp::from_metadata(&replacement_metadata);
+        assert_eq!(
+            (original_stamp.size, original_stamp.modified_nanos),
+            (replacement_stamp.size, replacement_stamp.modified_nanos)
+        );
+        assert_ne!(original_stamp, replacement_stamp);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Build one timestamped token-signature timeline for each on-disk version of a Codex parent rollout and reuse it across child fork cutoffs.
- Preserve full-file parsing for non-monotonic timestamps, parent-completeness checks, and missing-timestamp validation.
- Invalidate timelines with descriptor metadata and platform file identity, while keeping only the latest child replay-prefix entry per path.
- Add regression coverage for actual cross-cutoff reuse, append and replacement invalidation, sub-microsecond cutoffs, and cached-content versus open-error behavior.

## Impact

On an anonymized 1,379-file corpus, the existing `(parent_path, cutoff)` cache produced 1,295 parent-cache entries for 67 unique parent paths. A file-size model estimated 473.449 GiB of JSONL input processing (87.141 GiB of source files plus 386.307 GiB of repeated parent parsing). Reusing one timeline per file version reduces the modeled total to 101.551 GiB, a 78.6% reduction.

A local synthetic benchmark with a 50,000-line, 35.53 MiB parent and 20 cutoffs took 27.37 seconds with forced reparsing and 1.38 seconds with timeline reuse (19.8x faster).

## Related issue

Fixes #5625

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test services::session_usage_codex::tests --lib` (33 passed)
- `cargo test --lib` on the latest `main` merge state (2,252 passed, 2 ignored)
- `cargo check --target x86_64-pc-windows-gnu --lib`
- Clean no-commit merge into the latest `main`
