### PR TITLE
feat: 补齐统一供应商的 Claude Fable 与 Subagent 配置

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -616,6 +616,14 @@ pub struct ClaudeModelConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "opusModel")]
     pub opus_model: Option<String>,
+    /// Fable 默认模型
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fableModel")]
+    pub fable_model: Option<String>,
+    /// Subagent 默认模型
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "subagentModel")]
+    pub subagent_model: Option<String>,
 }
 
 /// Codex 模型配置
@@ -744,16 +752,29 @@ impl UniversalProvider {
             .and_then(|m| m.opus_model.clone())
             .unwrap_or_else(|| model.clone());
 
-        let settings_config = serde_json::json!({
-            "env": {
-                "ANTHROPIC_BASE_URL": self.base_url,
-                "ANTHROPIC_AUTH_TOKEN": self.api_key,
-                "ANTHROPIC_MODEL": model,
-                "ANTHROPIC_DEFAULT_HAIKU_MODEL": haiku,
-                "ANTHROPIC_DEFAULT_SONNET_MODEL": sonnet,
-                "ANTHROPIC_DEFAULT_OPUS_MODEL": opus,
-            }
+        let mut env = serde_json::json!({
+            "ANTHROPIC_BASE_URL": self.base_url,
+            "ANTHROPIC_AUTH_TOKEN": self.api_key,
+            "ANTHROPIC_MODEL": model,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": haiku,
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": sonnet,
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": opus,
         });
+
+        if let Some(fable) = models
+            .and_then(|m| m.fable_model.as_ref())
+            .filter(|value| !value.trim().is_empty())
+        {
+            env["ANTHROPIC_DEFAULT_FABLE_MODEL"] = serde_json::json!(fable);
+        }
+        if let Some(subagent) = models
+            .and_then(|m| m.subagent_model.as_ref())
+            .filter(|value| !value.trim().is_empty())
+        {
+            env["CLAUDE_CODE_SUBAGENT_MODEL"] = serde_json::json!(subagent);
+        }
+
+        let settings_config = serde_json::json!({ "env": env });
 
         Some(Provider {
             id: format!("universal-claude-{}", self.id),
@@ -1158,6 +1179,8 @@ mod tests {
             haiku_model: Some("claude-haiku".to_string()),
             sonnet_model: Some("claude-sonnet".to_string()),
             opus_model: Some("claude-opus".to_string()),
+            fable_model: Some("claude-fable".to_string()),
+            subagent_model: Some("claude-subagent".to_string()),
         });
 
         let provider = universal.to_claude_provider().expect("claude provider");
@@ -1193,6 +1216,53 @@ mod tests {
                 .and_then(|item| item.as_str()),
             Some("claude-opus")
         );
+        assert_eq!(
+            provider
+                .settings_config
+                .pointer("/env/ANTHROPIC_DEFAULT_FABLE_MODEL")
+                .and_then(|item| item.as_str()),
+            Some("claude-fable")
+        );
+        assert_eq!(
+            provider
+                .settings_config
+                .pointer("/env/CLAUDE_CODE_SUBAGENT_MODEL")
+                .and_then(|item| item.as_str()),
+            Some("claude-subagent")
+        );
+    }
+
+    #[test]
+    fn universal_provider_to_claude_provider_omits_missing_or_blank_optional_models() {
+        for (fable_model, subagent_model) in [
+            (None, None),
+            (Some("".to_string()), Some("   ".to_string())),
+        ] {
+            let mut universal = UniversalProvider::new(
+                "u1".to_string(),
+                "Universal".to_string(),
+                "newapi".to_string(),
+                "https://api.example.com".to_string(),
+                "api-key".to_string(),
+            );
+            universal.apps.claude = true;
+            universal.models.claude = Some(ClaudeModelConfig {
+                fable_model,
+                subagent_model,
+                ..Default::default()
+            });
+
+            let provider = universal.to_claude_provider().expect("claude provider");
+
+            assert!(provider
+                .settings_config
+                .pointer("/env/ANTHROPIC_DEFAULT_FABLE_MODEL")
+                .is_none());
+            assert!(provider
+                .settings_config
+                .pointer("/env/CLAUDE_CODE_SUBAGENT_MODEL")
+                .is_none());
+        }
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -124,7 +124,7 @@ mod tests {
     use crate::database::Database;
     #[cfg(any(target_os = "macos", windows))]
     use crate::provider::{ClaudeDesktopMode, ClaudeDesktopModelRoute};
-    use crate::provider::{ProviderMeta, UsageScript};
+    use crate::provider::{ClaudeModelConfig, ProviderMeta, UsageScript};
     use crate::proxy::types::ProxyConfig;
     use crate::store::AppState;
     use serde_json::json;
@@ -245,6 +245,79 @@ mod tests {
         }
 
         result
+    }
+
+    #[test]
+    fn sync_universal_to_apps_clears_stale_optional_claude_models() {
+        let db = Arc::new(Database::memory().expect("in-memory database"));
+        let state = AppState::new(db.clone());
+        let mut universal = UniversalProvider::new(
+            "u1".to_string(),
+            "Universal".to_string(),
+            "newapi".to_string(),
+            "https://api.example.com".to_string(),
+            "api-key".to_string(),
+        );
+        universal.apps.claude = true;
+        universal.models.claude = Some(ClaudeModelConfig {
+            fable_model: Some("claude-fable".to_string()),
+            subagent_model: Some("claude-subagent".to_string()),
+            ..Default::default()
+        });
+
+        ProviderService::upsert_universal(&state, universal.clone())
+            .expect("save universal provider");
+        ProviderService::sync_universal_to_apps(&state, &universal.id).expect("initial sync");
+
+        let generated_id = format!("universal-claude-{}", universal.id);
+        let mut generated = db
+            .get_provider_by_id(&generated_id, "claude")
+            .expect("query generated provider")
+            .expect("generated provider should exist");
+        assert_eq!(
+            generated
+                .settings_config
+                .pointer("/env/ANTHROPIC_DEFAULT_FABLE_MODEL")
+                .and_then(Value::as_str),
+            Some("claude-fable")
+        );
+        assert_eq!(
+            generated
+                .settings_config
+                .pointer("/env/CLAUDE_CODE_SUBAGENT_MODEL")
+                .and_then(Value::as_str),
+            Some("claude-subagent")
+        );
+        generated.settings_config["env"]["CUSTOM_ENV"] = json!("keep-me");
+        db.save_provider("claude", &generated)
+            .expect("save custom provider config");
+
+        universal.models.claude = Some(ClaudeModelConfig {
+            fable_model: None,
+            subagent_model: Some("   ".to_string()),
+            ..Default::default()
+        });
+        ProviderService::upsert_universal(&state, universal.clone())
+            .expect("update universal provider");
+        ProviderService::sync_universal_to_apps(&state, &universal.id)
+            .expect("sync cleared optional models");
+
+        let synced = db
+            .get_provider_by_id(&generated_id, "claude")
+            .expect("query synced provider")
+            .expect("synced provider should exist");
+        let env = synced
+            .settings_config
+            .get("env")
+            .and_then(Value::as_object)
+            .expect("generated provider env");
+
+        assert!(!env.contains_key("ANTHROPIC_DEFAULT_FABLE_MODEL"));
+        assert!(!env.contains_key("CLAUDE_CODE_SUBAGENT_MODEL"));
+        assert_eq!(
+            env.get("CUSTOM_ENV").and_then(Value::as_str),
+            Some("keep-me")
+        );
     }
 
     fn codex_settings(base_url: &str, api_key: &str) -> Value {
@@ -3927,6 +4000,7 @@ impl ProviderService {
             // 合并已有配置
             if let Some(existing) = state.db.get_provider_by_id(&claude_provider.id, "claude")? {
                 let mut merged = existing.settings_config.clone();
+                Self::remove_universal_claude_optional_models(&mut merged);
                 Self::merge_json(&mut merged, &claude_provider.settings_config);
                 claude_provider.settings_config = merged;
             }
@@ -3966,6 +4040,17 @@ impl ProviderService {
         }
 
         Ok(true)
+    }
+
+    /// 统一供应商可选 Claude 模型的清空需要具备删除语义。同步时先移除旧值，
+    /// 当前配置若仍有非空值，会在随后的 merge_json 中重新写入。
+    fn remove_universal_claude_optional_models(settings: &mut serde_json::Value) {
+        let Some(env) = settings.get_mut("env").and_then(Value::as_object_mut) else {
+            return;
+        };
+
+        env.remove("ANTHROPIC_DEFAULT_FABLE_MODEL");
+        env.remove("CLAUDE_CODE_SUBAGENT_MODEL");
     }
 
     /// 递归合并 JSON：base 为底，patch 覆盖同名字段

--- a/src/components/universal/UniversalProviderFormModal.tsx
+++ b/src/components/universal/UniversalProviderFormModal.tsx
@@ -133,15 +133,24 @@ export function UniversalProviderFormModal({
     const haiku = models.claude?.haikuModel || "claude-haiku-4-20250514";
     const sonnet = models.claude?.sonnetModel || "claude-sonnet-4-20250514";
     const opus = models.claude?.opusModel || "claude-sonnet-4-20250514";
+    const fable = models.claude?.fableModel;
+    const subagent = models.claude?.subagentModel;
+    const env: Record<string, string> = {
+      ANTHROPIC_BASE_URL: baseUrl,
+      ANTHROPIC_AUTH_TOKEN: apiKey,
+      ANTHROPIC_MODEL: model,
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: haiku,
+      ANTHROPIC_DEFAULT_SONNET_MODEL: sonnet,
+      ANTHROPIC_DEFAULT_OPUS_MODEL: opus,
+    };
+    if (fable?.trim()) {
+      env.ANTHROPIC_DEFAULT_FABLE_MODEL = fable;
+    }
+    if (subagent?.trim()) {
+      env.CLAUDE_CODE_SUBAGENT_MODEL = subagent;
+    }
     return {
-      env: {
-        ANTHROPIC_BASE_URL: baseUrl,
-        ANTHROPIC_AUTH_TOKEN: apiKey,
-        ANTHROPIC_MODEL: model,
-        ANTHROPIC_DEFAULT_HAIKU_MODEL: haiku,
-        ANTHROPIC_DEFAULT_SONNET_MODEL: sonnet,
-        ANTHROPIC_DEFAULT_OPUS_MODEL: opus,
-      },
+      env,
     };
   }, [claudeEnabled, baseUrl, apiKey, models.claude]);
 
@@ -532,10 +541,11 @@ requires_openai_auth = true`;
               </div>
               <div className="grid gap-3 sm:grid-cols-2">
                 <div className="space-y-1">
-                  <Label className="text-xs">
+                  <Label htmlFor="universal-claude-model" className="text-xs">
                     {t("universalProvider.model", { defaultValue: "主模型" })}
                   </Label>
                   <Input
+                    id="universal-claude-model"
                     value={models.claude?.model || ""}
                     onChange={(e) =>
                       updateModel("claude", "model", e.target.value)
@@ -544,8 +554,14 @@ requires_openai_auth = true`;
                   />
                 </div>
                 <div className="space-y-1">
-                  <Label className="text-xs">Haiku</Label>
+                  <Label
+                    htmlFor="universal-claude-haiku-model"
+                    className="text-xs"
+                  >
+                    Haiku
+                  </Label>
                   <Input
+                    id="universal-claude-haiku-model"
                     value={models.claude?.haikuModel || ""}
                     onChange={(e) =>
                       updateModel("claude", "haikuModel", e.target.value)
@@ -554,8 +570,14 @@ requires_openai_auth = true`;
                   />
                 </div>
                 <div className="space-y-1">
-                  <Label className="text-xs">Sonnet</Label>
+                  <Label
+                    htmlFor="universal-claude-sonnet-model"
+                    className="text-xs"
+                  >
+                    Sonnet
+                  </Label>
                   <Input
+                    id="universal-claude-sonnet-model"
                     value={models.claude?.sonnetModel || ""}
                     onChange={(e) =>
                       updateModel("claude", "sonnetModel", e.target.value)
@@ -564,13 +586,55 @@ requires_openai_auth = true`;
                   />
                 </div>
                 <div className="space-y-1">
-                  <Label className="text-xs">Opus</Label>
+                  <Label
+                    htmlFor="universal-claude-opus-model"
+                    className="text-xs"
+                  >
+                    Opus
+                  </Label>
                   <Input
+                    id="universal-claude-opus-model"
                     value={models.claude?.opusModel || ""}
                     onChange={(e) =>
                       updateModel("claude", "opusModel", e.target.value)
                     }
                     placeholder="claude-sonnet-4-20250514"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label
+                    htmlFor="universal-claude-fable-model"
+                    className="text-xs"
+                  >
+                    {t("providerForm.modelRoleFable", {
+                      defaultValue: "Fable",
+                    })}
+                  </Label>
+                  <Input
+                    id="universal-claude-fable-model"
+                    value={models.claude?.fableModel || ""}
+                    onChange={(e) =>
+                      updateModel("claude", "fableModel", e.target.value)
+                    }
+                    placeholder="claude-fable-5"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label
+                    htmlFor="universal-claude-subagent-model"
+                    className="text-xs"
+                  >
+                    {t("providerForm.modelRoleSubagent", {
+                      defaultValue: "Subagent",
+                    })}
+                  </Label>
+                  <Input
+                    id="universal-claude-subagent-model"
+                    value={models.claude?.subagentModel || ""}
+                    onChange={(e) =>
+                      updateModel("claude", "subagentModel", e.target.value)
+                    }
+                    placeholder="claude-sonnet-5"
                   />
                 </div>
               </div>

--- a/src/config/universalProviderPresets.ts
+++ b/src/config/universalProviderPresets.ts
@@ -45,6 +45,7 @@ const NEWAPI_DEFAULT_MODELS: UniversalProviderModels = {
     haikuModel: "claude-haiku-4-5-20251001",
     sonnetModel: "claude-sonnet-5",
     opusModel: "claude-opus-4-8",
+    fableModel: "claude-opus-4-8",
   },
   codex: {
     model: "gpt-5.5",

--- a/src/types.ts
+++ b/src/types.ts
@@ -546,6 +546,8 @@ export interface ClaudeModelConfig {
   haikuModel?: string;
   sonnetModel?: string;
   opusModel?: string;
+  fableModel?: string;
+  subagentModel?: string;
 }
 
 // Codex 模型配置

--- a/tests/components/UniversalProviderFormModal.test.tsx
+++ b/tests/components/UniversalProviderFormModal.test.tsx
@@ -1,0 +1,152 @@
+import type { ReactNode } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { UniversalProviderFormModal } from "@/components/universal/UniversalProviderFormModal";
+import type { UniversalProvider } from "@/types";
+
+vi.mock("@/hooks/useDarkMode", () => ({
+  useDarkMode: () => false,
+}));
+
+vi.mock("@/components/common/FullScreenPanel", () => ({
+  FullScreenPanel: ({
+    isOpen,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    children: ReactNode;
+    footer?: ReactNode;
+  }) =>
+    isOpen ? (
+      <div>
+        <div>{children}</div>
+        <div>{footer}</div>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/ProviderIcon", () => ({
+  ProviderIcon: () => null,
+}));
+
+vi.mock("@/components/JsonEditor", () => ({
+  default: ({ value }: { value: string }) => (
+    <textarea aria-label="config-preview" value={value} readOnly />
+  ),
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+function editingProvider(
+  claudeModels: UniversalProvider["models"]["claude"],
+): UniversalProvider {
+  return {
+    id: "universal-1",
+    name: "Universal",
+    providerType: "newapi",
+    apps: {
+      claude: true,
+      codex: false,
+      gemini: false,
+    },
+    baseUrl: "https://api.example.com",
+    apiKey: "sk-test",
+    models: {
+      claude: claudeModels,
+    },
+  };
+}
+
+describe("UniversalProviderFormModal", () => {
+  it("defaults Fable to Opus and saves explicitly configured Claude role models", async () => {
+    const onSave = vi.fn();
+
+    render(
+      <UniversalProviderFormModal isOpen onClose={() => {}} onSave={onSave} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Fable")).toHaveValue("claude-opus-4-8");
+    });
+    expect(screen.getByLabelText("Subagent")).toHaveValue("");
+
+    fireEvent.change(screen.getByLabelText("Fable"), {
+      target: { value: "claude-fable-custom" },
+    });
+    fireEvent.change(screen.getByLabelText("Subagent"), {
+      target: { value: "claude-subagent-custom" },
+    });
+    fireEvent.change(screen.getByLabelText("API 地址"), {
+      target: { value: "https://api.example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("API Key"), {
+      target: { value: "sk-test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "添加" }));
+
+    expect(onSave).toHaveBeenCalledOnce();
+    expect(onSave.mock.calls[0][0].models.claude).toMatchObject({
+      fableModel: "claude-fable-custom",
+      subagentModel: "claude-subagent-custom",
+    });
+  });
+
+  it("restores Fable and Subagent values and includes them in the Claude preview", async () => {
+    render(
+      <UniversalProviderFormModal
+        isOpen
+        onClose={() => {}}
+        onSave={() => {}}
+        editingProvider={editingProvider({
+          model: "claude-main",
+          haikuModel: "claude-haiku",
+          sonnetModel: "claude-sonnet",
+          opusModel: "claude-opus",
+          fableModel: "claude-fable",
+          subagentModel: "claude-subagent",
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Fable")).toHaveValue("claude-fable");
+    });
+    expect(screen.getByLabelText("Subagent")).toHaveValue("claude-subagent");
+
+    const preview = JSON.parse(
+      (screen.getByLabelText("config-preview") as HTMLTextAreaElement).value,
+    );
+    expect(preview.env).toMatchObject({
+      ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-fable",
+      CLAUDE_CODE_SUBAGENT_MODEL: "claude-subagent",
+    });
+  });
+
+  it("keeps optional role models blank for legacy providers and omits them from preview", async () => {
+    render(
+      <UniversalProviderFormModal
+        isOpen
+        onClose={() => {}}
+        onSave={() => {}}
+        editingProvider={editingProvider({
+          model: "claude-main",
+          opusModel: "claude-opus",
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Fable")).toHaveValue("");
+    });
+    expect(screen.getByLabelText("Subagent")).toHaveValue("");
+
+    const preview = JSON.parse(
+      (screen.getByLabelText("config-preview") as HTMLTextAreaElement).value,
+    );
+    expect(preview.env).not.toHaveProperty("ANTHROPIC_DEFAULT_FABLE_MODEL");
+    expect(preview.env).not.toHaveProperty("CLAUDE_CODE_SUBAGENT_MODEL");
+  });
+});


### PR DESCRIPTION
## 变更说明

统一供应商的 Claude 配置目前只提供 `model`、`haiku`、`sonnet` 和 `opus`，而直接添加 Claude 供应商时还支持 Fable 与 Subagent，导致统一供应商无法保存和同步这两个模型角色。

本 PR 补齐完整链路：

- 在前端和 Rust 的统一供应商模型结构中新增可选的 `fableModel` 与 `subagentModel`。
- 在统一供应商表单中增加 Fable、Subagent 输入框，并在 Claude 配置预览中展示对应环境变量。
- 同步 Claude 供应商时分别生成 `ANTHROPIC_DEFAULT_FABLE_MODEL` 和 `CLAUDE_CODE_SUBAGENT_MODEL`。
- 空值或纯空白值不会写入环境变量，避免产生无效配置。

## 默认值与兼容性

- 新建统一供应商时，Fable 默认跟随 Opus，符合现有 Fable → Opus 回退语义。
- Subagent 默认留空，仅在用户明确配置后写入。
- 现有统一供应商无需迁移；缺少新字段时继续沿用原有运行时回退行为。
- Codex、Gemini 和其他 Claude 配置保持不变。

## 测试

- `pnpm typecheck`
- `pnpm test:unit`（80 个测试文件、525 项测试通过）
- `pnpm format:check`
- 新增测试文件的 Prettier 检查
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml universal_provider_to_claude_provider --no-fail-fast`
