### PR TITLE
feat(usage): import Grok Build session usage + fix grokbuild filter i18n

### DIFF
--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -17,6 +17,7 @@ pub mod s3_sync;
 pub mod session_usage;
 pub mod session_usage_codex;
 pub mod session_usage_gemini;
+pub mod session_usage_grokbuild;
 pub mod session_usage_opencode;
 pub mod skill;
 pub mod speedtest;

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -86,6 +86,11 @@ pub fn sync_all_unlocked(db: &Database) -> SessionSyncResult {
         "OpenCode",
         crate::services::session_usage_opencode::sync_opencode_usage(db),
     );
+    merge_sync_step(
+        &mut result,
+        "Grok Build",
+        crate::services::session_usage_grokbuild::sync_grokbuild_usage(db),
+    );
     notify_sync_result(&result);
     result
 }

--- a/src-tauri/src/services/session_usage_grokbuild.rs
+++ b/src-tauri/src/services/session_usage_grokbuild.rs
@@ -15,7 +15,7 @@
 
 use crate::database::{lock_conn, Database};
 use crate::error::AppError;
-use crate::grok_config::get_grok_config_dir;
+use crate::grok_config::{extract_model_config, get_grok_config_dir};
 use crate::proxy::usage::calculator::{CostCalculator, ModelPricing};
 use crate::proxy::usage::parser::TokenUsage;
 use crate::services::session_usage::{
@@ -69,9 +69,10 @@ pub fn sync_grokbuild_usage(db: &Database) -> Result<SessionSyncResult, AppError
 
     result.files_scanned = 1;
 
-    let session_models = load_session_model_map(&grok_dir.join("sessions"));
+    let (profile_models, default_model) = load_config_model_maps(&grok_dir);
+    let session_models = load_session_model_map(&grok_dir.join("sessions"), &profile_models);
 
-    match sync_unified_log(db, &log_path, &session_models) {
+    match sync_unified_log(db, &log_path, &session_models, &default_model) {
         Ok((imported, skipped)) => {
             result.imported = imported;
             result.skipped = skipped;
@@ -100,6 +101,7 @@ fn sync_unified_log(
     db: &Database,
     file_path: &Path,
     session_models: &HashMap<String, String>,
+    default_model: &str,
 ) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
@@ -115,36 +117,55 @@ fn sync_unified_log(
 
     let file =
         fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
 
     let mut imported: u32 = 0;
     let mut skipped: u32 = 0;
+    // 仅推进到「以 \\n 结尾的完整行」；未写完的尾行留给下次同步，避免永久丢 usage。
     let mut line_offset: i64 = 0;
+    let mut committed_offset: i64 = last_offset;
+    let mut line_buf: Vec<u8> = Vec::new();
 
-    for line_result in reader.lines() {
+    loop {
+        line_buf.clear();
+        let bytes_read = reader
+            .read_until(b'\n', &mut line_buf)
+            .map_err(|e| AppError::Config(format!("读取 Grok Build 日志失败: {e}")))?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        // 没有换行符：当前是正在写入的半行，不推进游标
+        if !line_buf.ends_with(&[b'\n']) {
+            break;
+        }
+
         line_offset += 1;
         if line_offset <= last_offset {
             continue;
         }
 
-        let line = match line_result {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
+        let line = std::str::from_utf8(&line_buf).unwrap_or("").trim_end_matches(['\r', '\n']);
         if line.trim().is_empty() {
+            committed_offset = line_offset;
             continue;
         }
 
-        let value: Value = match serde_json::from_str(&line) {
+        let value: Value = match serde_json::from_str(line) {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(_) => {
+                // 完整行但 JSON 损坏：跳过并推进，避免卡死
+                committed_offset = line_offset;
+                continue;
+            }
         };
 
         let Some(turn) = parse_inference_done(&value, line_offset) else {
+            committed_offset = line_offset;
             continue;
         };
 
-        let model = resolve_model(&turn.session_id, session_models);
+        let model = resolve_model(&turn.session_id, session_models, default_model);
         let request_id = format!(
             "grokbuild_session:{}:L{}:i{}",
             turn.session_id, turn.line_offset, turn.loop_index
@@ -158,9 +179,10 @@ fn sync_unified_log(
                 skipped += 1;
             }
         }
+        committed_offset = line_offset;
     }
 
-    update_sync_state(db, &file_path_str, file_modified, line_offset)?;
+    update_sync_state(db, &file_path_str, file_modified, committed_offset)?;
     Ok((imported, skipped))
 }
 
@@ -215,8 +237,54 @@ fn json_u32(obj: &Value, key: &str) -> u32 {
         .unwrap_or(0)
 }
 
+/// 从 `~/.grok/config.toml` 读取 profile slug → 真实 model，以及默认模型。
+fn load_config_model_maps(grok_dir: &Path) -> (HashMap<String, String>, String) {
+    let config_path = grok_dir.join("config.toml");
+    let content = fs::read_to_string(&config_path).unwrap_or_default();
+    let profile_models = load_profile_model_map(&content);
+    let default_model = extract_model_config(&content)
+        .map(|cfg| normalize_model_id(&cfg.model, &profile_models))
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+    (profile_models, default_model)
+}
+
+/// 解析 `[model.<slug>] model = "..."` 映射（不限于 models.default）。
+fn load_profile_model_map(config_toml: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let Ok(document) = config_toml.parse::<toml::Value>() else {
+        return map;
+    };
+    let Some(models) = document
+        .as_table()
+        .and_then(|root| root.get("model"))
+        .and_then(|v| v.as_table())
+    else {
+        return map;
+    };
+
+    for (slug, value) in models {
+        let Some(model) = value
+            .as_table()
+            .and_then(|t| t.get("model"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        let slug = slug.trim();
+        if !slug.is_empty() {
+            map.insert(slug.to_string(), model.to_string());
+        }
+    }
+    map
+}
+
 /// 从 `~/.grok/sessions/**/summary.json` 构建 session_id → model 映射
-fn load_session_model_map(sessions_dir: &Path) -> HashMap<String, String> {
+fn load_session_model_map(
+    sessions_dir: &Path,
+    profile_models: &HashMap<String, String>,
+) -> HashMap<String, String> {
     let mut map = HashMap::new();
     if !sessions_dir.is_dir() {
         return map;
@@ -269,7 +337,7 @@ fn load_session_model_map(sessions_dir: &Path) -> HashMap<String, String> {
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
             {
-                map.insert(session_id, normalize_model_id(model));
+                map.insert(session_id, normalize_model_id(model, profile_models));
             }
         }
     }
@@ -277,24 +345,38 @@ fn load_session_model_map(sessions_dir: &Path) -> HashMap<String, String> {
     map
 }
 
-fn resolve_model(session_id: &str, session_models: &HashMap<String, String>) -> String {
+fn resolve_model(
+    session_id: &str,
+    session_models: &HashMap<String, String>,
+    default_model: &str,
+) -> String {
     session_models
         .get(session_id)
         .cloned()
-        .unwrap_or_else(|| DEFAULT_MODEL.to_string())
+        .unwrap_or_else(|| default_model.to_string())
 }
 
-/// 规范化模型 ID：别名映射 + 自定义 provider slug 回落
-fn normalize_model_id(raw: &str) -> String {
+/// 规范化模型 ID：别名映射 + 自定义 profile slug 解析
+fn normalize_model_id(raw: &str, profile_models: &HashMap<String, String>) -> String {
     let id = raw.trim();
     if id.is_empty() {
         return DEFAULT_MODEL.to_string();
     }
 
-    match id {
+    // `[model.cpa] model = "grok-4.3"` 时 summary 可能只记 profile slug
+    let resolved = if looks_like_provider_slug(id) {
+        profile_models
+            .get(id)
+            .map(String::as_str)
+            .unwrap_or(id)
+    } else {
+        id
+    };
+
+    match resolved {
         "grok-build" | "grok-code-fast-1" | "grok-build-0.1" => "grok-build-0.1".to_string(),
         "grok-composer-2-fast" | "grok-composer-2.5-fast" => "grok-composer-2.5-fast".to_string(),
-        // 用户自定义 [model.<slug>] 的 slug（如 cpa / heiyu）通常不是计费模型名
+        // 仍无法解析的 slug：回落默认，避免把 provider 名当成计费模型
         other if looks_like_provider_slug(other) => DEFAULT_MODEL.to_string(),
         other => other.to_string(),
     }
@@ -461,6 +543,13 @@ fn find_grokbuild_pricing(conn: &rusqlite::Connection, model_id: &str) -> Option
 mod tests {
     use super::*;
     use crate::database::Database;
+    use crate::services::session_usage::get_sync_state;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn empty_profiles() -> HashMap<String, String> {
+        HashMap::new()
+    }
 
     #[test]
     fn parse_inference_done_splits_cache_inclusive_prompt() {
@@ -500,12 +589,52 @@ mod tests {
 
     #[test]
     fn normalize_model_aliases_and_provider_slugs() {
-        assert_eq!(normalize_model_id("grok-build"), "grok-build-0.1");
-        assert_eq!(normalize_model_id("grok-code-fast-1"), "grok-build-0.1");
-        assert_eq!(normalize_model_id("grok-4.5"), "grok-4.5");
-        assert_eq!(normalize_model_id("cpa"), "grok-4.5");
-        assert_eq!(normalize_model_id("heiyu"), "grok-4.5");
-        assert_eq!(normalize_model_id("cursorlao"), "grok-4.5");
+        let profiles = empty_profiles();
+        assert_eq!(normalize_model_id("grok-build", &profiles), "grok-build-0.1");
+        assert_eq!(
+            normalize_model_id("grok-code-fast-1", &profiles),
+            "grok-build-0.1"
+        );
+        assert_eq!(normalize_model_id("grok-4.5", &profiles), "grok-4.5");
+        // 无 config 映射时 slug 回落默认
+        assert_eq!(normalize_model_id("cpa", &profiles), "grok-4.5");
+        assert_eq!(normalize_model_id("heiyu", &profiles), "grok-4.5");
+        assert_eq!(normalize_model_id("cursorlao", &profiles), "grok-4.5");
+    }
+
+    #[test]
+    fn normalize_resolves_profile_slug_via_config_map() {
+        let mut profiles = HashMap::new();
+        profiles.insert("cpa".into(), "grok-4.3".into());
+        profiles.insert("heiyu".into(), "grok-4.5".into());
+        assert_eq!(normalize_model_id("cpa", &profiles), "grok-4.3");
+        assert_eq!(normalize_model_id("heiyu", &profiles), "grok-4.5");
+        assert_eq!(normalize_model_id("unknown-slug", &profiles), "grok-4.5");
+    }
+
+    #[test]
+    fn load_profile_model_map_reads_all_model_tables() {
+        let toml = r#"
+[models]
+default = "cpa"
+
+[model.cpa]
+name = "CPA"
+model = "grok-4.3"
+base_url = "https://example.com"
+api_backend = "responses"
+context_window = 500000
+
+[model.heiyu]
+name = "Heiyu"
+model = "grok-4.5"
+base_url = "https://example.com"
+api_backend = "responses"
+context_window = 500000
+"#;
+        let map = load_profile_model_map(toml);
+        assert_eq!(map.get("cpa").map(String::as_str), Some("grok-4.3"));
+        assert_eq!(map.get("heiyu").map(String::as_str), Some("grok-4.5"));
     }
 
     #[test]
@@ -552,6 +681,83 @@ mod tests {
         assert_eq!(cache, 400);
         assert_eq!(output, 70); // 50 + 20 reasoning
         assert_eq!(semantics, INPUT_TOKEN_SEMANTICS_TOTAL);
+        Ok(())
+    }
+
+    #[test]
+    fn sync_does_not_commit_partial_trailing_line() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = TempDir::new().expect("tempdir");
+        let log_path = temp.path().join("unified.jsonl");
+
+        let complete = serde_json::json!({
+            "ts": "2026-07-22T01:00:00.000Z",
+            "sid": "sess-partial",
+            "msg": "shell.turn.inference_done",
+            "ctx": {
+                "loop_index": 0,
+                "prompt_tokens": 100,
+                "cached_prompt_tokens": 10,
+                "completion_tokens": 5,
+                "reasoning_tokens": 2
+            }
+        });
+        // 完整行 + 未写完的半行（模拟 Grok 仍在 append）
+        {
+            let mut file = fs::File::create(&log_path).expect("create log");
+            writeln!(file, "{complete}").expect("write complete");
+            write!(
+                file,
+                r#"{{"msg":"shell.turn.inference_done","sid":"sess-partial","ctx":{{"#
+            )
+            .expect("write partial");
+        }
+
+        let (imported, _) =
+            sync_unified_log(&db, &log_path, &HashMap::new(), DEFAULT_MODEL)?;
+        assert_eq!(imported, 1);
+
+        let path_str = log_path.to_string_lossy().to_string();
+        let (_, offset) = get_sync_state(&db, &path_str)?;
+        // 只提交完整行 1；半行不得推进游标
+        assert_eq!(offset, 1);
+
+        // 写成两行完整 JSONL，mtime 变化后二次同步应导入第二行
+        let complete2 = serde_json::json!({
+            "ts": "2026-07-22T01:00:01.000Z",
+            "sid": "sess-partial",
+            "msg": "shell.turn.inference_done",
+            "ctx": {
+                "loop_index": 1,
+                "prompt_tokens": 200,
+                "cached_prompt_tokens": 20,
+                "completion_tokens": 8,
+                "reasoning_tokens": 3
+            }
+        });
+        {
+            let mut file = fs::File::create(&log_path).expect("rewrite");
+            writeln!(file, "{complete}").expect("line1");
+            writeln!(file, "{complete2}").expect("line2");
+        }
+        // 确保 mtime 严格大于上次同步记录（极快写盘时可能撞纳秒）
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        {
+            let mut file = fs::OpenOptions::new()
+                .append(true)
+                .open(&log_path)
+                .expect("touch");
+            file.write_all(b"").ok();
+            file.flush().ok();
+        }
+
+        let (imported2, _) =
+            sync_unified_log(&db, &log_path, &HashMap::new(), DEFAULT_MODEL)?;
+        // 第一行已存在（skip），第二行新导入
+        assert_eq!(imported2, 1);
+
+        let (_, offset2) = get_sync_state(&db, &path_str)?;
+        assert_eq!(offset2, 2);
         Ok(())
     }
 

--- a/src-tauri/src/services/session_usage_grokbuild.rs
+++ b/src-tauri/src/services/session_usage_grokbuild.rs
@@ -1,0 +1,571 @@
+//! Grok Build 会话日志使用追踪
+//!
+//! 从 `~/.grok/logs/unified.jsonl` 中的 `shell.turn.inference_done` 事件
+//! 提取 token 使用数据，实现无代理模式下的 Grok Build 使用统计。
+//!
+//! ## 数据流
+//! ```text
+//! ~/.grok/logs/unified.jsonl → 增量解析 → 去重 → 费用计算 → proxy_request_logs 表
+//! ```
+//!
+//! ## Token 语义
+//! Grok 日志中的 `prompt_tokens` **包含** cache 读取部分（与 Codex / Gemini 相同）。
+//! 入库时保留 total input，并设置 `input_token_semantics = TOTAL`，
+//! 由 `CostCalculator::calculate_for_app("grokbuild", ...)` 扣减 cache。
+
+use crate::database::{lock_conn, Database};
+use crate::error::AppError;
+use crate::grok_config::get_grok_config_dir;
+use crate::proxy::usage::calculator::{CostCalculator, ModelPricing};
+use crate::proxy::usage::parser::TokenUsage;
+use crate::services::session_usage::{
+    get_sync_state, metadata_modified_nanos, update_sync_state, SessionSyncResult,
+};
+use crate::services::sql_helpers::INPUT_TOKEN_SEMANTICS_TOTAL;
+use crate::services::usage_stats::{find_model_pricing, should_skip_session_insert, DedupKey};
+use rust_decimal::Decimal;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::time::SystemTime;
+
+const APP_TYPE: &str = "grokbuild";
+const DATA_SOURCE: &str = "grok_session";
+const PROVIDER_ID: &str = "_grok_session";
+const DEFAULT_MODEL: &str = "grok-4.5";
+
+#[derive(Debug, Clone)]
+struct GrokTurnUsage {
+    session_id: String,
+    line_offset: i64,
+    loop_index: u64,
+    prompt_tokens: u32,
+    cached_prompt_tokens: u32,
+    completion_tokens: u32,
+    reasoning_tokens: u32,
+    model_elapsed_ms: Option<i64>,
+    timestamp: Option<String>,
+}
+
+/// 同步 Grok Build 使用数据
+pub fn sync_grokbuild_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    let grok_dir = get_grok_config_dir();
+    let log_path = grok_dir.join("logs").join("unified.jsonl");
+
+    let mut result = SessionSyncResult {
+        imported: 0,
+        skipped: 0,
+        files_scanned: 0,
+        suspected_duplicates: 0,
+        deferred_files: 0,
+        errors: vec![],
+    };
+
+    if !log_path.is_file() {
+        return Ok(result);
+    }
+
+    result.files_scanned = 1;
+
+    let session_models = load_session_model_map(&grok_dir.join("sessions"));
+
+    match sync_unified_log(db, &log_path, &session_models) {
+        Ok((imported, skipped)) => {
+            result.imported = imported;
+            result.skipped = skipped;
+        }
+        Err(e) => {
+            let msg = format!("Grok Build 会话日志解析失败 {}: {e}", log_path.display());
+            log::warn!("[GROKBUILD-SYNC] {msg}");
+            result.errors.push(msg);
+        }
+    }
+
+    if result.imported > 0 || !result.errors.is_empty() {
+        log::info!(
+            "[GROKBUILD-SYNC] 同步完成: 导入 {} 条, 跳过 {} 条, 扫描 {} 个文件, 错误 {} 条",
+            result.imported,
+            result.skipped,
+            result.files_scanned,
+            result.errors.len()
+        );
+    }
+
+    Ok(result)
+}
+
+fn sync_unified_log(
+    db: &Database,
+    file_path: &Path,
+    session_models: &HashMap<String, String>,
+) -> Result<(u32, u32), AppError> {
+    let file_path_str = file_path.to_string_lossy().to_string();
+
+    let metadata = fs::metadata(file_path)
+        .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
+    let file_modified = metadata_modified_nanos(&metadata);
+    let (last_modified, last_offset) = get_sync_state(db, &file_path_str)?;
+
+    // 文件未变化且已有进度时跳过整文件扫描
+    if file_modified <= last_modified && last_offset > 0 {
+        return Ok((0, 0));
+    }
+
+    let file =
+        fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
+    let reader = BufReader::new(file);
+
+    let mut imported: u32 = 0;
+    let mut skipped: u32 = 0;
+    let mut line_offset: i64 = 0;
+
+    for line_result in reader.lines() {
+        line_offset += 1;
+        if line_offset <= last_offset {
+            continue;
+        }
+
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let Some(turn) = parse_inference_done(&value, line_offset) else {
+            continue;
+        };
+
+        let model = resolve_model(&turn.session_id, session_models);
+        let request_id = format!(
+            "grokbuild_session:{}:L{}:i{}",
+            turn.session_id, turn.line_offset, turn.loop_index
+        );
+
+        match insert_grokbuild_session_entry(db, &request_id, &turn, &model) {
+            Ok(true) => imported += 1,
+            Ok(false) => skipped += 1,
+            Err(e) => {
+                log::warn!("[GROKBUILD-SYNC] 插入失败 ({request_id}): {e}");
+                skipped += 1;
+            }
+        }
+    }
+
+    update_sync_state(db, &file_path_str, file_modified, line_offset)?;
+    Ok((imported, skipped))
+}
+
+fn parse_inference_done(value: &Value, line_offset: i64) -> Option<GrokTurnUsage> {
+    if value.get("msg").and_then(|v| v.as_str()) != Some("shell.turn.inference_done") {
+        return None;
+    }
+
+    let ctx = value.get("ctx")?;
+    let session_id = value
+        .get("sid")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())?
+        .to_string();
+
+    let prompt_tokens = json_u32(ctx, "prompt_tokens");
+    let cached_prompt_tokens = json_u32(ctx, "cached_prompt_tokens");
+    let completion_tokens = json_u32(ctx, "completion_tokens");
+    let reasoning_tokens = json_u32(ctx, "reasoning_tokens");
+
+    if prompt_tokens == 0 && completion_tokens == 0 && reasoning_tokens == 0 {
+        return None;
+    }
+
+    Some(GrokTurnUsage {
+        session_id,
+        line_offset,
+        loop_index: ctx.get("loop_index").and_then(|v| v.as_u64()).unwrap_or(0),
+        prompt_tokens,
+        cached_prompt_tokens: cached_prompt_tokens.min(prompt_tokens),
+        completion_tokens,
+        reasoning_tokens,
+        model_elapsed_ms: ctx
+            .get("model_elapsed_ms")
+            .and_then(|v| v.as_i64())
+            .or_else(|| ctx.get("model_elapsed_ms").and_then(|v| v.as_u64()).map(|n| n as i64)),
+        timestamp: value
+            .get("ts")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    })
+}
+
+fn json_u32(obj: &Value, key: &str) -> u32 {
+    obj.get(key)
+        .and_then(|v| v.as_u64())
+        .map(|n| n.min(u32::MAX as u64) as u32)
+        .unwrap_or(0)
+}
+
+/// 从 `~/.grok/sessions/**/summary.json` 构建 session_id → model 映射
+fn load_session_model_map(sessions_dir: &Path) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    if !sessions_dir.is_dir() {
+        return map;
+    }
+
+    let walker = match fs::read_dir(sessions_dir) {
+        Ok(entries) => entries,
+        Err(_) => return map,
+    };
+
+    // sessions 目录结构: sessions/<encoded_cwd>/<session_id>/summary.json
+    for project_entry in walker.flatten() {
+        let project_path = project_entry.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        let session_dirs = match fs::read_dir(&project_path) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for session_entry in session_dirs.flatten() {
+            let session_path = session_entry.path();
+            if !session_path.is_dir() {
+                continue;
+            }
+            let summary_path = session_path.join("summary.json");
+            if !summary_path.is_file() {
+                continue;
+            }
+            let Ok(content) = fs::read_to_string(&summary_path) else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<Value>(&content) else {
+                continue;
+            };
+
+            let session_id = value
+                .get("info")
+                .and_then(|i| i.get("id"))
+                .and_then(|v| v.as_str())
+                .or_else(|| session_path.file_name().and_then(|n| n.to_str()))
+                .unwrap_or("")
+                .to_string();
+            if session_id.is_empty() {
+                continue;
+            }
+
+            if let Some(model) = value
+                .get("current_model_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                map.insert(session_id, normalize_model_id(model));
+            }
+        }
+    }
+
+    map
+}
+
+fn resolve_model(session_id: &str, session_models: &HashMap<String, String>) -> String {
+    session_models
+        .get(session_id)
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string())
+}
+
+/// 规范化模型 ID：别名映射 + 自定义 provider slug 回落
+fn normalize_model_id(raw: &str) -> String {
+    let id = raw.trim();
+    if id.is_empty() {
+        return DEFAULT_MODEL.to_string();
+    }
+
+    match id {
+        "grok-build" | "grok-code-fast-1" | "grok-build-0.1" => "grok-build-0.1".to_string(),
+        "grok-composer-2-fast" | "grok-composer-2.5-fast" => "grok-composer-2.5-fast".to_string(),
+        // 用户自定义 [model.<slug>] 的 slug（如 cpa / heiyu）通常不是计费模型名
+        other if looks_like_provider_slug(other) => DEFAULT_MODEL.to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn looks_like_provider_slug(id: &str) -> bool {
+    // 真实 Grok 模型 ID 通常以 grok- 开头；短 slug / 无连字符名多半是 provider 配置名
+    if id.starts_with("grok-") || id.starts_with("grok_") {
+        return false;
+    }
+    if id.contains('/') {
+        return false;
+    }
+    // 纯自定义短名：cpa, heiyu, cursorlao 等
+    id.len() <= 32
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && !id.contains("gpt-")
+        && !id.contains("claude")
+}
+
+fn insert_grokbuild_session_entry(
+    db: &Database,
+    request_id: &str,
+    turn: &GrokTurnUsage,
+    model: &str,
+) -> Result<bool, AppError> {
+    let conn = lock_conn!(db.conn);
+
+    let created_at = turn
+        .timestamp
+        .as_ref()
+        .and_then(|ts| {
+            chrono::DateTime::parse_from_rfc3339(ts)
+                .ok()
+                .map(|dt| dt.timestamp())
+                .or_else(|| {
+                    // unified.jsonl 使用 "2026-07-17T08:02:07.662Z" — 标准 RFC3339
+                    chrono::DateTime::parse_from_str(ts, "%Y-%m-%dT%H:%M:%S%.fZ")
+                        .ok()
+                        .map(|dt| dt.timestamp())
+                })
+        })
+        .unwrap_or_else(|| {
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0)
+        });
+
+    // prompt_tokens 已含 cache；output 合并 reasoning（与 Gemini thoughts 策略一致）
+    let input_tokens = turn.prompt_tokens;
+    let cache_read_tokens = turn.cached_prompt_tokens.min(input_tokens);
+    let output_tokens = turn.completion_tokens.saturating_add(turn.reasoning_tokens);
+
+    let dedup_key = DedupKey {
+        app_type: APP_TYPE,
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_creation_tokens: 0,
+        created_at,
+    };
+    if should_skip_session_insert(&conn, request_id, &dedup_key)? {
+        return Ok(false);
+    }
+
+    let usage = TokenUsage {
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_creation_tokens: 0,
+        model: Some(model.to_string()),
+        message_id: None,
+    };
+
+    let pricing = find_grokbuild_pricing(&conn, model);
+    let multiplier = Decimal::from(1);
+    let (input_cost, output_cost, cache_read_cost, cache_creation_cost, total_cost) =
+        match pricing {
+            Some(p) => {
+                let cost = CostCalculator::calculate_for_app(APP_TYPE, &usage, &p, multiplier);
+                (
+                    cost.input_cost.to_string(),
+                    cost.output_cost.to_string(),
+                    cost.cache_read_cost.to_string(),
+                    cost.cache_creation_cost.to_string(),
+                    cost.total_cost.to_string(),
+                )
+            }
+            None => (
+                "0".to_string(),
+                "0".to_string(),
+                "0".to_string(),
+                "0".to_string(),
+                "0".to_string(),
+            ),
+        };
+
+    conn.execute(
+        "INSERT INTO proxy_request_logs (
+            request_id, provider_id, app_type, model, request_model,
+            input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+            input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd, total_cost_usd,
+            latency_ms, first_token_ms, status_code, error_message, session_id,
+            provider_type, is_streaming, cost_multiplier, created_at, data_source,
+            input_token_semantics
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)
+        ON CONFLICT(request_id) DO UPDATE SET
+            model = excluded.model,
+            input_tokens = excluded.input_tokens,
+            output_tokens = excluded.output_tokens,
+            cache_read_tokens = excluded.cache_read_tokens,
+            input_cost_usd = excluded.input_cost_usd,
+            output_cost_usd = excluded.output_cost_usd,
+            cache_read_cost_usd = excluded.cache_read_cost_usd,
+            cache_creation_cost_usd = excluded.cache_creation_cost_usd,
+            total_cost_usd = excluded.total_cost_usd,
+            input_token_semantics = excluded.input_token_semantics
+        WHERE input_tokens != excluded.input_tokens
+           OR output_tokens != excluded.output_tokens
+           OR cache_read_tokens != excluded.cache_read_tokens
+           OR model != excluded.model",
+        rusqlite::params![
+            request_id,
+            PROVIDER_ID,
+            APP_TYPE,
+            model,
+            model,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            0i64,
+            input_cost,
+            output_cost,
+            cache_read_cost,
+            cache_creation_cost,
+            total_cost,
+            turn.model_elapsed_ms.unwrap_or(0),
+            Option::<i64>::None,
+            200i64,
+            Option::<String>::None,
+            Some(turn.session_id.clone()),
+            Some(DATA_SOURCE),
+            1i64,
+            "1.0",
+            created_at,
+            DATA_SOURCE,
+            INPUT_TOKEN_SEMANTICS_TOTAL,
+        ],
+    )
+    .map_err(|e| AppError::Database(format!("插入 Grok Build 会话日志失败: {e}")))?;
+
+    Ok(conn.changes() > 0)
+}
+
+fn find_grokbuild_pricing(conn: &rusqlite::Connection, model_id: &str) -> Option<ModelPricing> {
+    find_model_pricing(conn, model_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::Database;
+
+    #[test]
+    fn parse_inference_done_splits_cache_inclusive_prompt() {
+        let value = serde_json::json!({
+            "ts": "2026-07-17T08:02:07.662Z",
+            "src": "shell",
+            "sid": "019f6ed7-62a7-7561-b5d0-10d6205d9dc4",
+            "msg": "shell.turn.inference_done",
+            "ctx": {
+                "loop_index": 1,
+                "model_elapsed_ms": 19150,
+                "prompt_tokens": 152441,
+                "cached_prompt_tokens": 1280,
+                "completion_tokens": 250,
+                "reasoning_tokens": 134
+            }
+        });
+        let turn = parse_inference_done(&value, 42).expect("parse");
+        assert_eq!(turn.session_id, "019f6ed7-62a7-7561-b5d0-10d6205d9dc4");
+        assert_eq!(turn.line_offset, 42);
+        assert_eq!(turn.prompt_tokens, 152441);
+        assert_eq!(turn.cached_prompt_tokens, 1280);
+        assert_eq!(turn.completion_tokens, 250);
+        assert_eq!(turn.reasoning_tokens, 134);
+        assert_eq!(turn.loop_index, 1);
+    }
+
+    #[test]
+    fn parse_ignores_non_inference_events() {
+        let value = serde_json::json!({
+            "sid": "abc",
+            "msg": "turn.phase_transition",
+            "ctx": {"prompt_tokens": 1}
+        });
+        assert!(parse_inference_done(&value, 1).is_none());
+    }
+
+    #[test]
+    fn normalize_model_aliases_and_provider_slugs() {
+        assert_eq!(normalize_model_id("grok-build"), "grok-build-0.1");
+        assert_eq!(normalize_model_id("grok-code-fast-1"), "grok-build-0.1");
+        assert_eq!(normalize_model_id("grok-4.5"), "grok-4.5");
+        assert_eq!(normalize_model_id("cpa"), "grok-4.5");
+        assert_eq!(normalize_model_id("heiyu"), "grok-4.5");
+        assert_eq!(normalize_model_id("cursorlao"), "grok-4.5");
+    }
+
+    #[test]
+    fn insert_grokbuild_session_entry_roundtrip() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let turn = GrokTurnUsage {
+            session_id: "sess-1".into(),
+            line_offset: 10,
+            loop_index: 1,
+            prompt_tokens: 1000,
+            cached_prompt_tokens: 400,
+            completion_tokens: 50,
+            reasoning_tokens: 20,
+            model_elapsed_ms: Some(1200),
+            timestamp: Some("2026-07-22T01:00:00.000Z".into()),
+        };
+        let request_id = "grokbuild_session:sess-1:L10";
+        assert!(insert_grokbuild_session_entry(
+            &db,
+            request_id,
+            &turn,
+            "grok-4.5"
+        )?);
+
+        // second insert same id with same values → no change counted as skip-ish
+        assert!(!insert_grokbuild_session_entry(
+            &db,
+            request_id,
+            &turn,
+            "grok-4.5"
+        )?);
+
+        let conn = lock_conn!(db.conn);
+        let (app_type, data_source, input, cache, output, semantics): (
+            String,
+            String,
+            i64,
+            i64,
+            i64,
+            i64,
+        ) = conn.query_row(
+            "SELECT app_type, data_source, input_tokens, cache_read_tokens, output_tokens, input_token_semantics
+             FROM proxy_request_logs WHERE request_id = ?1",
+            rusqlite::params![request_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?)),
+        )?;
+        assert_eq!(app_type, "grokbuild");
+        assert_eq!(data_source, "grok_session");
+        assert_eq!(input, 1000);
+        assert_eq!(cache, 400);
+        assert_eq!(output, 70); // 50 + 20 reasoning
+        assert_eq!(semantics, INPUT_TOKEN_SEMANTICS_TOTAL);
+        Ok(())
+    }
+
+    #[test]
+    fn sync_skips_missing_log_file() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        // Point GROK home away by using a temp empty dir via override is hard;
+        // call internal path with nonexistent file via public API when no logs.
+        // When default ~/.grok/logs/unified.jsonl missing on CI, this returns empty.
+        let result = sync_grokbuild_usage(&db)?;
+        // Should not error; imported may be 0
+        assert!(result.errors.is_empty() || result.files_scanned <= 1);
+        Ok(())
+    }
+}

--- a/src-tauri/src/services/session_usage_grokbuild.rs
+++ b/src-tauri/src/services/session_usage_grokbuild.rs
@@ -196,7 +196,11 @@ fn parse_inference_done(value: &Value, line_offset: i64) -> Option<GrokTurnUsage
         model_elapsed_ms: ctx
             .get("model_elapsed_ms")
             .and_then(|v| v.as_i64())
-            .or_else(|| ctx.get("model_elapsed_ms").and_then(|v| v.as_u64()).map(|n| n as i64)),
+            .or_else(|| {
+                ctx.get("model_elapsed_ms")
+                    .and_then(|v| v.as_u64())
+                    .map(|n| n as i64)
+            }),
         timestamp: value
             .get("ts")
             .and_then(|v| v.as_str())
@@ -371,26 +375,26 @@ fn insert_grokbuild_session_entry(
 
     let pricing = find_grokbuild_pricing(&conn, model);
     let multiplier = Decimal::from(1);
-    let (input_cost, output_cost, cache_read_cost, cache_creation_cost, total_cost) =
-        match pricing {
-            Some(p) => {
-                let cost = CostCalculator::calculate_for_app(APP_TYPE, &usage, &p, multiplier);
-                (
-                    cost.input_cost.to_string(),
-                    cost.output_cost.to_string(),
-                    cost.cache_read_cost.to_string(),
-                    cost.cache_creation_cost.to_string(),
-                    cost.total_cost.to_string(),
-                )
-            }
-            None => (
-                "0".to_string(),
-                "0".to_string(),
-                "0".to_string(),
-                "0".to_string(),
-                "0".to_string(),
-            ),
-        };
+    let (input_cost, output_cost, cache_read_cost, cache_creation_cost, total_cost) = match pricing
+    {
+        Some(p) => {
+            let cost = CostCalculator::calculate_for_app(APP_TYPE, &usage, &p, multiplier);
+            (
+                cost.input_cost.to_string(),
+                cost.output_cost.to_string(),
+                cost.cache_read_cost.to_string(),
+                cost.cache_creation_cost.to_string(),
+                cost.total_cost.to_string(),
+            )
+        }
+        None => (
+            "0".to_string(),
+            "0".to_string(),
+            "0".to_string(),
+            "0".to_string(),
+            "0".to_string(),
+        ),
+    };
 
     conn.execute(
         "INSERT INTO proxy_request_logs (
@@ -520,18 +524,12 @@ mod tests {
         };
         let request_id = "grokbuild_session:sess-1:L10";
         assert!(insert_grokbuild_session_entry(
-            &db,
-            request_id,
-            &turn,
-            "grok-4.5"
+            &db, request_id, &turn, "grok-4.5"
         )?);
 
         // second insert same id with same values → no change counted as skip-ish
         assert!(!insert_grokbuild_session_entry(
-            &db,
-            request_id,
-            &turn,
-            "grok-4.5"
+            &db, request_id, &turn, "grok-4.5"
         )?);
 
         let conn = lock_conn!(db.conn);

--- a/src-tauri/src/services/session_usage_grokbuild.rs
+++ b/src-tauri/src/services/session_usage_grokbuild.rs
@@ -145,7 +145,9 @@ fn sync_unified_log(
             continue;
         }
 
-        let line = std::str::from_utf8(&line_buf).unwrap_or("").trim_end_matches(['\r', '\n']);
+        let line = std::str::from_utf8(&line_buf)
+            .unwrap_or("")
+            .trim_end_matches(['\r', '\n']);
         if line.trim().is_empty() {
             committed_offset = line_offset;
             continue;
@@ -365,10 +367,7 @@ fn normalize_model_id(raw: &str, profile_models: &HashMap<String, String>) -> St
 
     // `[model.cpa] model = "grok-4.3"` 时 summary 可能只记 profile slug
     let resolved = if looks_like_provider_slug(id) {
-        profile_models
-            .get(id)
-            .map(String::as_str)
-            .unwrap_or(id)
+        profile_models.get(id).map(String::as_str).unwrap_or(id)
     } else {
         id
     };
@@ -590,7 +589,10 @@ mod tests {
     #[test]
     fn normalize_model_aliases_and_provider_slugs() {
         let profiles = empty_profiles();
-        assert_eq!(normalize_model_id("grok-build", &profiles), "grok-build-0.1");
+        assert_eq!(
+            normalize_model_id("grok-build", &profiles),
+            "grok-build-0.1"
+        );
         assert_eq!(
             normalize_model_id("grok-code-fast-1", &profiles),
             "grok-build-0.1"
@@ -713,8 +715,7 @@ context_window = 500000
             .expect("write partial");
         }
 
-        let (imported, _) =
-            sync_unified_log(&db, &log_path, &HashMap::new(), DEFAULT_MODEL)?;
+        let (imported, _) = sync_unified_log(&db, &log_path, &HashMap::new(), DEFAULT_MODEL)?;
         assert_eq!(imported, 1);
 
         let path_str = log_path.to_string_lossy().to_string();
@@ -751,8 +752,7 @@ context_window = 500000
             file.flush().ok();
         }
 
-        let (imported2, _) =
-            sync_unified_log(&db, &log_path, &HashMap::new(), DEFAULT_MODEL)?;
+        let (imported2, _) = sync_unified_log(&db, &log_path, &HashMap::new(), DEFAULT_MODEL)?;
         // 第一行已存在（skip），第二行新导入
         assert_eq!(imported2, 1);
 

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -214,6 +214,7 @@ fn provider_name_coalesce(log_alias: &str, provider_alias: &str) -> String {
          WHEN '_codex_session' THEN 'Codex (Session)' \
          WHEN '_gemini_session' THEN 'Gemini (Session)' \
          WHEN '_opencode_session' THEN 'OpenCode (Session)' \
+         WHEN '_grok_session' THEN 'Grok Build (Session)' \
          ELSE {log_alias}.provider_id END)"
     )
 }
@@ -299,7 +300,7 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
     let proxy_data_source = data_source_expr("proxy_dedup");
     format!(
         "NOT (
-            {data_source} IN ('session_log', 'codex_session', 'gemini_session', 'opencode_session')
+            {data_source} IN ('session_log', 'codex_session', 'gemini_session', 'opencode_session', 'grok_session')
             AND EXISTS (
                 SELECT 1
                 FROM proxy_request_logs proxy_dedup
@@ -314,7 +315,7 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
                       proxy_dedup.cache_creation_tokens = {log_alias}.cache_creation_tokens
                       OR (
                           {log_alias}.cache_creation_tokens = 0
-                          AND {data_source} IN ('codex_session', 'gemini_session', 'opencode_session')
+                          AND {data_source} IN ('codex_session', 'gemini_session', 'opencode_session', 'grok_session')
                       )
                   )
                   AND proxy_dedup.created_at BETWEEN

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -1854,7 +1854,8 @@ impl Database {
         // 1. 历史 Codex/Gemini 行只包含 cache read；新 total 行还包含 cache write。
         // 2. Claude/Anthropic 的 input_tokens 已经是 fresh input，不能再次扣减
         // 3. 各项成本是基础成本（不含倍率），倍率只作用于最终总价
-        let cache_inclusive_app = matches!(log.app_type.as_str(), "codex" | "gemini");
+        // Grok Build session 与 Codex/Gemini 一样：input_tokens 含 cache（TOTAL 语义）
+        let cache_inclusive_app = matches!(log.app_type.as_str(), "codex" | "gemini" | "grokbuild");
         let billable_input_tokens =
             if !cache_inclusive_app || log.input_token_semantics == INPUT_TOKEN_SEMANTICS_FRESH {
                 log.input_tokens as u64
@@ -2610,6 +2611,61 @@ mod tests {
                 ("total-cache-semantics".to_string(), "1.000000".to_string()),
             ]
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_backfill_grokbuild_total_semantics_does_not_double_bill_cache() -> Result<(), AppError>
+    {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            // grok-4.5: input=$2/M, output=$6/M, cache_read=$0.50/M
+            // TOTAL: input=1_000_000 (含 cache_read 400_000), output=100_000
+            // billable input = 600_000 → $1.2; cache_read → $0.2; output → $0.6; total $2.0
+            insert_usage_log(
+                &conn,
+                "grokbuild-total-zero-cost",
+                "grokbuild",
+                "_grok_session",
+                "grok-4.5",
+                "grok_session",
+                1000,
+                1_000_000,
+                100_000,
+                400_000,
+                0,
+                200,
+                "0",
+            )?;
+            conn.execute(
+                "UPDATE proxy_request_logs
+                 SET input_token_semantics = ?1
+                 WHERE request_id = 'grokbuild-total-zero-cost'",
+                [INPUT_TOKEN_SEMANTICS_TOTAL],
+            )?;
+        }
+
+        assert_eq!(db.backfill_missing_usage_costs()?, 1);
+
+        let conn = lock_conn!(db.conn);
+        let (input_cost, cache_read_cost, output_cost, total_cost): (
+            String,
+            String,
+            String,
+            String,
+        ) = conn.query_row(
+            "SELECT input_cost_usd, cache_read_cost_usd, output_cost_usd, total_cost_usd
+             FROM proxy_request_logs WHERE request_id = 'grokbuild-total-zero-cost'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+        assert_eq!(input_cost, "1.200000");
+        assert_eq!(cache_read_cost, "0.200000");
+        assert_eq!(output_cost, "0.600000");
+        assert_eq!(total_cost, "2.000000");
 
         Ok(())
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1501,6 +1501,7 @@
       "claude": "Claude Code",
       "codex": "Codex",
       "gemini": "Gemini",
+      "grokbuild": "Grok Build",
       "opencode": "OpenCode"
     },
     "rawInputLabel": "Raw",
@@ -1511,7 +1512,8 @@
       "codex_db": "Codex DB",
       "codex_session": "Codex Session",
       "gemini_session": "Gemini Session",
-      "opencode_session": "OpenCode Session"
+      "opencode_session": "OpenCode Session",
+      "grok_session": "Grok Build Session"
     },
     "sessionSync": {
       "trigger": "Sync session logs",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1501,7 +1501,8 @@
       "claude": "Claude Code",
       "codex": "Codex",
       "gemini": "Gemini",
-      "opencode": "OpenCode"
+      "opencode": "OpenCode",
+      "grokbuild": "Grok Build"
     },
     "rawInputLabel": "原始",
     "dataSources": "データソース",
@@ -1511,7 +1512,8 @@
       "codex_db": "Codex DB",
       "codex_session": "Codex セッション",
       "gemini_session": "Gemini セッション",
-      "opencode_session": "OpenCode セッション"
+      "opencode_session": "OpenCode セッション",
+      "grok_session": "Grok Build セッション"
     },
     "sessionSync": {
       "trigger": "セッションログを同期",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1473,7 +1473,8 @@
       "claude": "Claude Code",
       "codex": "Codex",
       "gemini": "Gemini",
-      "opencode": "OpenCode"
+      "opencode": "OpenCode",
+      "grokbuild": "Grok Build"
     },
     "rawInputLabel": "原始",
     "dataSources": "資料來源",
@@ -1483,7 +1484,8 @@
       "codex_db": "Codex 資料庫",
       "codex_session": "Codex 工作階段日誌",
       "gemini_session": "Gemini 工作階段日誌",
-      "opencode_session": "OpenCode 工作階段日誌"
+      "opencode_session": "OpenCode 工作階段日誌",
+      "grok_session": "Grok Build 會話"
     },
     "sessionSync": {
       "trigger": "同步工作階段日誌",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1501,7 +1501,8 @@
       "claude": "Claude Code",
       "codex": "Codex",
       "gemini": "Gemini",
-      "opencode": "OpenCode"
+      "opencode": "OpenCode",
+      "grokbuild": "Grok Build"
     },
     "rawInputLabel": "原始",
     "dataSources": "数据来源",
@@ -1511,7 +1512,8 @@
       "codex_db": "Codex 数据库",
       "codex_session": "Codex 会话日志",
       "gemini_session": "Gemini 会话日志",
-      "opencode_session": "OpenCode 会话日志"
+      "opencode_session": "OpenCode 会话日志",
+      "grok_session": "Grok Build 会话"
     },
     "sessionSync": {
       "trigger": "同步会话日志",


### PR DESCRIPTION
## Summary

Fix Grok Build usage on **CC Switch 3.18.x** in two parts:

1. **Native session usage import** for Grok Build (`grokbuild`), so Usage is not stuck at 0 when users run Grok without local proxy.
2. **i18n**: replace raw key `usage.appFilter.grokbuild` with a proper display name; add `usage.dataSource.grok_session`.

## Problem (3.18.0)

- Usage → filter **Grok Build** shows all zeros while Codex works on the same machine.
- UI shows untranslated key: `usage.appFilter.grokbuild`.
- `KNOWN_APP_TYPES` already includes `grokbuild`, but locales only had `claude/codex/gemini/opencode`.
- No `session_usage_grokbuild` importer (only codex/gemini/opencode/claude).

Local evidence: `~/.grok/logs/unified.jsonl` already emits:

```json
{
  "msg": "shell.turn.inference_done",
  "ctx": {
    "prompt_tokens": 108754,
    "cached_prompt_tokens": 104320,
    "completion_tokens": 1050,
    "reasoning_tokens": 1047
  }
}
```

## Implementation

### Session import
- New `src-tauri/src/services/session_usage_grokbuild.rs`
- Source: `~/.grok/logs/unified.jsonl`
- Event: `shell.turn.inference_done`
- Incremental sync via `session_log_sync` (mtime + line offset)
- Persist:
  - `app_type = "grokbuild"`
  - `data_source = "grok_session"`
  - `provider_id = "_grok_session"`
  - `input_token_semantics = TOTAL` (prompt_tokens is cache-inclusive)
- Model resolve from `~/.grok/sessions/**/summary.json` (`current_model_id`), with alias/slug normalization (`cpa`/`heiyu` → `grok-4.5`)
- Cost via `CostCalculator::calculate_for_app("grokbuild", ...)`
- Hooked into `session_usage::sync_all_unlocked`
- Session↔proxy dedupe filter includes `grok_session`
- Provider display name: `Grok Build (Session)`

### i18n
Added to `en` / `zh` / `zh-TW` / `ja`:
- `usage.appFilter.grokbuild` → `Grok Build`
- `usage.dataSource.grok_session` → localized label

## Test plan

- [x] `cargo test session_usage_grokbuild` (5 tests passed)
- [x] Locale keys present in en/zh/zh-TW/ja
- [x] Manual: run Grok Build turn → Usage → Grok filter shows localized name + non-zero tokens after sync
- [x] Restart → no duplicate rows
- [x] Codex filter still correct

## Related

- Builds on #5453 (Grok Build first-class app)
- Historical context only: #4702 / unmerged #4703 (pre-`grokbuild` naming)