### PR TITLE
fix(usage): curb macOS WebView memory growth

### DIFF
--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -123,9 +123,9 @@ export function UsageDashboard({
     }
   };
 
-  // 后端写入新日志时 emit `usage-log-recorded`，本 hook 立刻 invalidate 所有
-  // usage 查询，实现实时刷新（仅在 Dashboard 挂载时生效，离开页面自动取消监听）
-  useUsageEventBridge();
+  // 后端写入新日志时 emit `usage-log-recorded`，本 hook 会合并连续事件后刷新
+  // usage 查询；自动刷新关闭时也停止监听，避免 "--" 状态仍在后台重拉。
+  useUsageEventBridge(refreshIntervalMs > 0);
 
   const changeRefreshInterval = async (next: number) => {
     const normalized = normalizeRefreshInterval(next);

--- a/src/components/usage/UsageHero.tsx
+++ b/src/components/usage/UsageHero.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
 import { useUsageSummaryByApp } from "@/lib/query/usage";
+import { isMac } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { APP_ICON_MAP } from "@/config/appConfig";
 import type { AppId } from "@/lib/api/types";
@@ -37,6 +38,8 @@ interface UsageHeroProps {
   model?: string;
   refreshIntervalMs: number;
 }
+
+const ENABLE_PROGRESS_ANIMATION = !isMac();
 
 interface TitleTheme {
   /** Foreground color for the icon glyph (text-* class). */
@@ -348,9 +351,12 @@ export function UsageHero({
                 <div className="relative h-1.5 rounded-full bg-muted/60 overflow-hidden">
                   <motion.div
                     className="absolute inset-y-0 left-0 bg-emerald-500 rounded-full"
-                    initial={{ width: 0 }}
+                    initial={ENABLE_PROGRESS_ANIMATION ? { width: 0 } : false}
                     animate={{ width: `${hitPercent}%` }}
-                    transition={{ duration: 0.8, ease: "easeOut" }}
+                    transition={{
+                      duration: ENABLE_PROGRESS_ANIMATION ? 0.8 : 0,
+                      ease: "easeOut",
+                    }}
                   />
                 </div>
               </div>

--- a/src/components/usage/UsageTrendChart.tsx
+++ b/src/components/usage/UsageTrendChart.tsx
@@ -18,7 +18,10 @@ import {
   parseFiniteNumber,
 } from "./format";
 import { resolveUsageRange } from "@/lib/usageRange";
+import { isMac } from "@/lib/platform";
 import type { UsageRangeSelection } from "@/types/usage";
+
+const ENABLE_CHART_ANIMATIONS = !isMac();
 
 interface UsageTrendChartProps {
   range: UsageRangeSelection;
@@ -194,6 +197,7 @@ export function UsageTrendChart({
               fillOpacity={1}
               fill="url(#colorInput)"
               strokeWidth={2}
+              isAnimationActive={ENABLE_CHART_ANIMATIONS}
             />
             <Area
               yAxisId="tokens"
@@ -204,6 +208,7 @@ export function UsageTrendChart({
               fillOpacity={1}
               fill="url(#colorOutput)"
               strokeWidth={2}
+              isAnimationActive={ENABLE_CHART_ANIMATIONS}
             />
             <Area
               yAxisId="tokens"
@@ -214,6 +219,7 @@ export function UsageTrendChart({
               fillOpacity={1}
               fill="url(#colorCacheCreation)"
               strokeWidth={2}
+              isAnimationActive={ENABLE_CHART_ANIMATIONS}
             />
             <Area
               yAxisId="tokens"
@@ -224,6 +230,7 @@ export function UsageTrendChart({
               fillOpacity={1}
               fill="url(#colorCacheRead)"
               strokeWidth={2}
+              isAnimationActive={ENABLE_CHART_ANIMATIONS}
             />
             <Area
               yAxisId="cost"
@@ -234,6 +241,7 @@ export function UsageTrendChart({
               fill="none"
               strokeWidth={2}
               strokeDasharray="4 4"
+              isAnimationActive={ENABLE_CHART_ANIMATIONS}
             />
           </AreaChart>
         </ResponsiveContainer>

--- a/src/hooks/useUsageEventBridge.ts
+++ b/src/hooks/useUsageEventBridge.ts
@@ -3,28 +3,62 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useQueryClient } from "@tanstack/react-query";
 import { usageKeys } from "@/lib/query/usage";
 
+const USAGE_EVENT_INVALIDATION_THROTTLE_MS = 5000;
+
 /**
- * 监听后端 `usage-log-recorded` 事件，收到后立刻 invalidate 所有
- * UsageDashboard 相关查询，让用户无需等待 30s 轮询周期。
+ * 监听后端 `usage-log-recorded` 事件，合并短时间内的连续写入后 invalidate
+ * UsageDashboard 相关查询，让用户无需等待完整的轮询周期。
  *
  * 后端在 `proxy_request_logs` 写入新行时会 emit 该事件（200ms 防抖合并），
  * 来源覆盖代理日志、Claude/Codex/Gemini 会话同步、启动归档。
  *
  * 该 hook 只挂在 UsageDashboard 上，避免在主界面其他位置无意义触发。
  */
-export function useUsageEventBridge() {
+export function useUsageEventBridge(enabled = true) {
   const queryClient = useQueryClient();
 
   useEffect(() => {
+    if (!enabled) return;
+
     let unlisten: UnlistenFn | undefined;
     let disposed = false;
+    let trailingTimer: ReturnType<typeof setTimeout> | undefined;
+    let lastInvalidatedAt: number | undefined;
+
+    const invalidateUsageQueries = () => {
+      lastInvalidatedAt = Date.now();
+      void queryClient.invalidateQueries({
+        queryKey: usageKeys.all,
+        refetchType: "active",
+      });
+    };
+
+    const scheduleInvalidation = () => {
+      if (lastInvalidatedAt === undefined) {
+        invalidateUsageQueries();
+        return;
+      }
+
+      const elapsed = Date.now() - lastInvalidatedAt;
+      if (elapsed >= USAGE_EVENT_INVALIDATION_THROTTLE_MS) {
+        if (trailingTimer !== undefined) {
+          clearTimeout(trailingTimer);
+          trailingTimer = undefined;
+        }
+        invalidateUsageQueries();
+        return;
+      }
+
+      if (trailingTimer !== undefined) return;
+
+      trailingTimer = setTimeout(() => {
+        trailingTimer = undefined;
+        if (!disposed) invalidateUsageQueries();
+      }, USAGE_EVENT_INVALIDATION_THROTTLE_MS - elapsed);
+    };
 
     (async () => {
-      const off = await listen("usage-log-recorded", () => {
-        // invalidate 整个 usage 命名空间：summary / trends / providerStats /
-        // modelStats / logs 全部跟着重拉
-        queryClient.invalidateQueries({ queryKey: usageKeys.all });
-      });
+      const off = await listen("usage-log-recorded", scheduleInvalidation);
 
       if (disposed) {
         off();
@@ -35,7 +69,8 @@ export function useUsageEventBridge() {
 
     return () => {
       disposed = true;
+      if (trailingTimer !== undefined) clearTimeout(trailingTimer);
       unlisten?.();
     };
-  }, [queryClient]);
+  }, [enabled, queryClient]);
 }

--- a/tests/hooks/useUsageEventBridge.test.tsx
+++ b/tests/hooks/useUsageEventBridge.test.tsx
@@ -1,0 +1,113 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUsageEventBridge } from "@/hooks/useUsageEventBridge";
+import { usageKeys } from "@/lib/query/usage";
+
+const eventMocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+  unlisten: vi.fn(),
+  handler: undefined as ((event?: unknown) => void) | undefined,
+}));
+
+const queryClientMocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => eventMocks.listen(...args),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: queryClientMocks.invalidateQueries,
+    }),
+  };
+});
+
+describe("useUsageEventBridge", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-20T00:00:00Z"));
+    eventMocks.listen.mockReset();
+    eventMocks.unlisten.mockReset();
+    eventMocks.handler = undefined;
+    queryClientMocks.invalidateQueries.mockReset();
+    queryClientMocks.invalidateQueries.mockResolvedValue(undefined);
+    eventMocks.listen.mockImplementation(
+      async (_event: string, handler: (event?: unknown) => void) => {
+        eventMocks.handler = handler;
+        return eventMocks.unlisten;
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces bursts into at most one active-query refresh every five seconds", async () => {
+    const { unmount } = renderHook(() => useUsageEventBridge());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      eventMocks.handler?.();
+      eventMocks.handler?.();
+      eventMocks.handler?.();
+    });
+
+    expect(queryClientMocks.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(queryClientMocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: usageKeys.all,
+      refetchType: "active",
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+    expect(queryClientMocks.invalidateQueries).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(queryClientMocks.invalidateQueries).toHaveBeenCalledTimes(2);
+
+    unmount();
+    expect(eventMocks.unlisten).toHaveBeenCalledOnce();
+  });
+
+  it("does not subscribe when automatic refresh is disabled", async () => {
+    renderHook(() => useUsageEventBridge(false));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(eventMocks.listen).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending trailing refresh when unmounted", async () => {
+    const { unmount } = renderHook(() => useUsageEventBridge());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      eventMocks.handler?.();
+      eventMocks.handler?.();
+    });
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(queryClientMocks.invalidateQueries).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Reduce macOS WKWebView memory growth while the Usage Statistics dashboard remains open.

The dashboard receives `usage-log-recorded` events in addition to its regular polling interval. Each event invalidated the full usage query namespace, so a steady stream of new usage records repeatedly refetched all active dashboard queries. Those updates also restarted five Recharts `Area` animations and the cache-hit progress animation. On macOS, this produced sustained WebKit layer/backing-store churn.

This PR:

- throttles event-driven usage invalidations to at most once every 5 seconds;
- refetches active usage queries only and cancels the trailing timer on unmount;
- disables the event subscription when automatic refresh is turned off;
- disables recurring usage chart and progress animations on macOS while preserving them on other platforms;
- adds tests for burst coalescing, refresh-disabled behavior, and cleanup.

During local A/B diagnosis, the affected WebContent process reached about 2.17 GB physical footprint, including about 1.98 GB of graphics/layer memory across 375 regions. With only this targeted patch applied, two repeated rounds kept graphics memory around 34 MB / 117 regions rather than reproducing the original growth signature. This is intentionally a page-local mitigation, not a claim to resolve every WebView memory-growth path.

## Related Issue / 关联 Issue

Related to #4581. Detailed reproduction and measurements: https://github.com/farion1231/cc-switch/issues/4581#issuecomment-5042441212

Complementary to #4693 (hidden/tray WebView lifecycle) and #5105 (Session Manager payload/cache bounds).

## Screenshots / 截图

Not applicable — this changes refresh scheduling and macOS animation behavior without changing layout or text.

## Validation / 验证

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` — 80 test files, 525 tests
- `pnpm build:renderer`

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` not required (no Rust code changed) / 无 Rust 代码修改
- [x] No user-facing text changed; i18n updates are not required / 未修改用户可见文本
