### PR TITLE
fix(claude-desktop): default direct auth to API key

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -318,15 +318,21 @@ pub fn direct_gateway_credentials(
         .to_string();
 
     let api_key = env
-        .get("ANTHROPIC_AUTH_TOKEN")
+        .get("ANTHROPIC_API_KEY")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
+        .or_else(|| {
+            env.get("ANTHROPIC_AUTH_TOKEN")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
         .ok_or_else(|| {
             AppError::localized(
-                "claude_desktop.provider.auth_token_missing",
-                "Claude Desktop 直连供应商缺少 ANTHROPIC_AUTH_TOKEN（Bearer Token）",
-                "Claude Desktop direct provider is missing ANTHROPIC_AUTH_TOKEN (Bearer Token)",
+                "claude_desktop.provider.api_key_missing",
+                "Claude Desktop 直连供应商缺少 ANTHROPIC_API_KEY",
+                "Claude Desktop direct provider is missing ANTHROPIC_API_KEY",
             )
         })?
         .to_string();
@@ -2206,7 +2212,7 @@ mod tests {
         });
         assert!(!is_compatible_direct_provider(&full_url));
 
-        let missing_bearer = Provider::with_id(
+        let api_key_provider = Provider::with_id(
             "x-api-key".to_string(),
             "x-api-key".to_string(),
             json!({
@@ -2217,6 +2223,50 @@ mod tests {
             }),
             None,
         );
-        assert!(!is_compatible_direct_provider(&missing_bearer));
+        assert!(is_compatible_direct_provider(&api_key_provider));
+        assert_eq!(
+            direct_gateway_credentials(&api_key_provider)
+                .expect("ANTHROPIC_API_KEY should be accepted")
+                .api_key,
+            "sk-ant"
+        );
+
+        let both_fields = Provider::with_id(
+            "both-fields".to_string(),
+            "both-fields".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://gateway.example.com",
+                    "ANTHROPIC_API_KEY": "current-key",
+                    "ANTHROPIC_AUTH_TOKEN": "legacy-token"
+                }
+            }),
+            None,
+        );
+        assert_eq!(
+            direct_gateway_credentials(&both_fields)
+                .expect("ANTHROPIC_API_KEY should take precedence")
+                .api_key,
+            "current-key"
+        );
+
+        let empty_api_key = Provider::with_id(
+            "empty-api-key".to_string(),
+            "empty-api-key".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://gateway.example.com",
+                    "ANTHROPIC_API_KEY": " ",
+                    "ANTHROPIC_AUTH_TOKEN": "legacy-token"
+                }
+            }),
+            None,
+        );
+        assert_eq!(
+            direct_gateway_credentials(&empty_api_key)
+                .expect("empty ANTHROPIC_API_KEY should fall back to the legacy token")
+                .api_key,
+            "legacy-token"
+        );
     }
 }

--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -84,6 +84,10 @@ export type ClaudeDesktopProviderFormValues = ProviderFormData & {
 
 type ApiKeyField = "ANTHROPIC_AUTH_TOKEN" | "ANTHROPIC_API_KEY";
 
+function defaultApiKeyField(mode: "direct" | "proxy"): ApiKeyField {
+  return mode === "direct" ? "ANTHROPIC_API_KEY" : "ANTHROPIC_AUTH_TOKEN";
+}
+
 type PresetEntry = {
   id: string;
   preset: ClaudeDesktopProviderPreset;
@@ -276,7 +280,9 @@ export function ClaudeDesktopProviderForm({
   const [apiKeyField, setApiKeyField] = useState<ApiKeyField>(() =>
     envString(initialData?.settingsConfig, "ANTHROPIC_API_KEY")
       ? "ANTHROPIC_API_KEY"
-      : "ANTHROPIC_AUTH_TOKEN",
+      : envString(initialData?.settingsConfig, "ANTHROPIC_AUTH_TOKEN")
+        ? "ANTHROPIC_AUTH_TOKEN"
+        : defaultApiKeyField(initialMode),
   );
   const [selectedGitHubAccountId, setSelectedGitHubAccountId] = useState<
     string | null
@@ -427,7 +433,7 @@ export function ClaudeDesktopProviderForm({
 
     setBaseUrl(preset.baseUrl);
     setApiKey("");
-    setApiKeyField(preset.apiKeyField ?? "ANTHROPIC_AUTH_TOKEN");
+    setApiKeyField(preset.apiKeyField ?? defaultApiKeyField(preset.mode));
     setApiFormat(preset.apiFormat ?? "anthropic");
 
     const presetMode =
@@ -462,7 +468,7 @@ export function ClaudeDesktopProviderForm({
       form.reset(defaultValues);
       setBaseUrl("");
       setApiKey("");
-      setApiKeyField("ANTHROPIC_AUTH_TOKEN");
+      setApiKeyField(defaultApiKeyField("direct"));
       setApiFormat("anthropic");
       didSeedDefaultRoutes.current = false;
       setMode("direct");

--- a/src/config/claudeDesktopProviderPresets.ts
+++ b/src/config/claudeDesktopProviderPresets.ts
@@ -51,6 +51,7 @@ export interface ClaudeDesktopProviderPreset {
   partnerPromotionKey?: string;
 
   baseUrl: string;
+  // Defaults to API_KEY for direct mode and AUTH_TOKEN for proxy upstreams.
   apiKeyField?: "ANTHROPIC_AUTH_TOKEN" | "ANTHROPIC_API_KEY";
 
   mode: "direct" | "proxy";

--- a/tests/components/ClaudeDesktopProviderForm.test.tsx
+++ b/tests/components/ClaudeDesktopProviderForm.test.tsx
@@ -30,6 +30,27 @@ function renderForm(
 }
 
 describe("ClaudeDesktopProviderForm", () => {
+  it("新建自定义直连供应商默认保存 ANTHROPIC_API_KEY", async () => {
+    const onSubmit = vi.fn();
+    renderForm(undefined, onSubmit);
+
+    fireEvent.change(screen.getByLabelText("provider.name"), {
+      target: { value: "Custom Direct" },
+    });
+    fireEvent.change(screen.getByLabelText("API Key"), {
+      target: { value: "sk-test" },
+    });
+    fireEvent.change(screen.getByLabelText("providerForm.apiEndpoint"), {
+      target: { value: "https://api.example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const settingsConfig = JSON.parse(onSubmit.mock.calls[0][0].settingsConfig);
+    expect(settingsConfig.env.ANTHROPIC_API_KEY).toBe("sk-test");
+    expect(settingsConfig.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  });
+
   it.each(["github_copilot", "codex_oauth", "xai_oauth"])(
     "托管 OAuth %s 即使旧数据是 direct 也强制开启模型映射",
     (providerType) => {


### PR DESCRIPTION
## Summary / 概述

- Default new custom and preset direct-mode Claude Desktop providers to `ANTHROPIC_API_KEY`.
- Prefer `ANTHROPIC_API_KEY` for direct credential extraction while accepting legacy `ANTHROPIC_AUTH_TOKEN`.
- Preserve proxy-mode upstream authentication defaults.

The form and Rust direct-provider validator previously defaulted to or required the Claude Code-style token field. As a result, a direct Claude Desktop provider could be saved under the wrong environment variable, while an `ANTHROPIC_API_KEY`-only provider was rejected.

## Related Issue / 关联 Issue

Fixes #5669

Related to #3162

## Screenshots / 截图

Not applicable. This changes generated provider configuration and credential validation.

## Validation / 验证

- Frontend Vitest suite: 523 passed
- Claude Desktop form suite: 11 passed
- Claude Desktop Rust module tests: 23 passed
- Rust library suite: 2,088 passed, 2 ignored
- TypeScript typecheck
- Prettier check
- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`

## Checklist / 检查清单

- [x] I have tested my changes locally / 已在本地测试
- [x] Existing legacy token configs remain supported / 旧 token 配置仍兼容
- [x] Proxy-mode authentication semantics remain unchanged / 代理模式认证语义未改变
- [x] No user-facing text or translation changes / 无用户可见文案或翻译改动
