### PR TITLE
fix: allow multiple Codex global prompts

### DIFF
--- a/src-tauri/src/services/profile.rs
+++ b/src-tauri/src/services/profile.rs
@@ -9,7 +9,7 @@
 //! - 供应商：`ProviderService::switch`（内建代理接管热切换与接管下禁切官方）
 //! - MCP：`McpService::toggle_app`（改标志 + 单 server 物化）
 //! - Skills：`SkillService::toggle_app`（改标志 + 单 skill 物化）
-//! - Prompt：`PromptService::enable_prompt`（互斥激活 + 原子写 live）
+//! - Prompt：`PromptService::enable_prompt`（启用并原子写入 live 文件）
 //!
 //! apply 为 best-effort：单项失败收集为 warning 继续，不整体回滚。
 

--- a/src-tauri/src/services/profile.rs
+++ b/src-tauri/src/services/profile.rs
@@ -129,7 +129,7 @@ pub struct ProfilePayload {
     /// 每 app 启用的 Skill id 集合
     pub skills: PerApp<Option<Vec<String>>>,
     /// 每 app 激活的 prompt id
-    pub prompts: PerApp<Option<String>>,
+    pub prompts: PerApp<Option<Vec<String>>>,
 }
 
 impl ProfilePayload {
@@ -225,12 +225,14 @@ impl ProfileService {
                 );
             }
             if let Some(slot) = payload.prompts.get_mut(app) {
-                *slot = state
+                let enabled = state
                     .db
                     .get_prompts(app.as_str())?
                     .values()
-                    .find(|p| p.enabled)
-                    .map(|p| p.id.clone());
+                    .filter(|p| p.enabled)
+                    .map(|p| p.id.clone())
+                    .collect::<Vec<_>>();
+                *slot = Some(enabled);
             }
         }
         Ok(payload)
@@ -434,20 +436,39 @@ impl ProfileService {
             }
 
             // 5. Prompt（None = 不动；已激活则幂等跳过，避免无谓的文件写与备份）
-            if let Some(Some(target_prompt)) = payload.prompts.get(app) {
+            if let Some(Some(target_prompts)) = payload.prompts.get(app) {
                 let prompts = state.db.get_prompts(app_str)?;
-                match prompts.get(target_prompt) {
-                    None => warnings.push(format!(
-                        "[{app_str}] prompt '{target_prompt}' no longer exists, skipped"
-                    )),
-                    Some(p) if p.enabled => {}
-                    Some(_) => {
+                let target_ids: std::collections::HashSet<&str> =
+                    target_prompts.iter().map(String::as_str).collect();
+
+                for (id, prompt) in prompts.iter() {
+                    if prompt.enabled && !target_ids.contains(id.as_str()) {
+                        let mut disabled = prompt.clone();
+                        disabled.enabled = false;
                         if let Err(e) =
-                            PromptService::enable_prompt(state, app.clone(), target_prompt)
+                            PromptService::upsert_prompt(state, app.clone(), id, disabled)
                         {
                             warnings.push(format!(
-                                "[{app_str}] enable prompt '{target_prompt}' failed: {e}"
+                                "[{app_str}] disable prompt '{id}' failed: {e}"
                             ));
+                        }
+                    }
+                }
+
+                for target_prompt in target_prompts {
+                    match prompts.get(target_prompt) {
+                        None => warnings.push(format!(
+                            "[{app_str}] prompt '{target_prompt}' no longer exists, skipped"
+                        )),
+                        Some(p) if p.enabled => {}
+                        Some(_) => {
+                            if let Err(e) =
+                                PromptService::enable_prompt(state, app.clone(), target_prompt)
+                            {
+                                warnings.push(format!(
+                                    "[{app_str}] enable prompt '{target_prompt}' failed: {e}"
+                                ));
+                            }
                         }
                     }
                 }
@@ -494,7 +515,7 @@ mod tests {
             prompts: PerApp {
                 claude: None,
                 claude_desktop: None,
-                codex: Some("pr1".into()),
+                codex: Some(vec!["pr1".into()]),
             },
         };
         let json = serde_json::to_string(&payload).unwrap();
@@ -591,7 +612,7 @@ mod tests {
 
     #[test]
     fn test_per_app_get_only_supports_profile_apps() {
-        let per: PerApp<Option<String>> = PerApp::default();
+        let per: PerApp<Option<Vec<String>>> = PerApp::default();
         assert!(per.get(&AppType::Claude).is_some());
         assert!(per.get(&AppType::ClaudeDesktop).is_some());
         assert!(per.get(&AppType::Codex).is_some());

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -17,6 +17,16 @@ fn get_unix_timestamp() -> Result<i64, AppError> {
 
 pub struct PromptService;
 
+fn enabled_prompt_content(prompts: &IndexMap<String, Prompt>) -> String {
+    prompts
+        .values()
+        .filter(|prompt| prompt.enabled)
+        .map(|prompt| prompt.content.trim())
+        .filter(|content| !content.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
 impl PromptService {
     pub fn get_prompts(
         state: &AppState,
@@ -38,19 +48,15 @@ impl PromptService {
 
         if is_enabled {
             // 启用提示词：写入内容到文件
+            let prompts = state.db.get_prompts(app.as_str())?;
             let target_path = prompt_file_path(&app)?;
-            write_text_file(&target_path, &prompt.content)?;
+            write_text_file(&target_path, &enabled_prompt_content(&prompts))?;
         } else {
             // 禁用提示词：检查是否还有其他已启用的提示词
             let prompts = state.db.get_prompts(app.as_str())?;
-            let any_enabled = prompts.values().any(|p| p.enabled);
-
-            if !any_enabled {
-                // 所有提示词都已禁用，清空文件
-                let target_path = prompt_file_path(&app)?;
-                if target_path.exists() {
-                    write_text_file(&target_path, "")?;
-                }
+            let target_path = prompt_file_path(&app)?;
+            if target_path.exists() {
+                write_text_file(&target_path, &enabled_prompt_content(&prompts))?;
             }
         }
 
@@ -123,17 +129,13 @@ impl PromptService {
         // 启用目标提示词并写入文件
         let mut prompts = state.db.get_prompts(app.as_str())?;
 
-        for prompt in prompts.values_mut() {
-            prompt.enabled = false;
-        }
-
         if let Some(prompt) = prompts.get_mut(id) {
             prompt.enabled = true;
-            write_text_file(&target_path, &prompt.content)?; // 原子写入
-            state.db.save_prompt(app.as_str(), prompt)?;
         } else {
             return Err(AppError::InvalidInput(format!("提示词 {id} 不存在")));
         }
+
+        write_text_file(&target_path, &enabled_prompt_content(&prompts))?;
 
         // Save all prompts to disable others
         for (_, prompt) in prompts.iter() {

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -50,13 +50,20 @@ impl PromptService {
             // 启用提示词：写入内容到文件
             let prompts = state.db.get_prompts(app.as_str())?;
             let target_path = prompt_file_path(&app)?;
-            write_text_file(&target_path, &enabled_prompt_content(&prompts))?;
+            let content = if matches!(app, AppType::Codex) {
+                enabled_prompt_content(&prompts)
+            } else {
+                prompt.content.clone()
+            };
+            write_text_file(&target_path, &content)?;
         } else {
             // 禁用提示词：检查是否还有其他已启用的提示词
             let prompts = state.db.get_prompts(app.as_str())?;
             let target_path = prompt_file_path(&app)?;
-            if target_path.exists() {
+            if matches!(app, AppType::Codex) && target_path.exists() {
                 write_text_file(&target_path, &enabled_prompt_content(&prompts))?;
+            } else if !prompts.values().any(|p| p.enabled) && target_path.exists() {
+                write_text_file(&target_path, "")?;
             }
         }
 
@@ -77,6 +84,7 @@ impl PromptService {
     }
 
     pub fn enable_prompt(state: &AppState, app: AppType, id: &str) -> Result<(), AppError> {
+        let allow_multiple = matches!(app, AppType::Codex);
         // 回填当前 live 文件内容到已启用的提示词，或创建备份
         let target_path = prompt_file_path(&app)?;
         if target_path.exists() {
@@ -131,6 +139,12 @@ impl PromptService {
 
         // 启用目标提示词并写入文件
         let mut prompts = state.db.get_prompts(app.as_str())?;
+
+        if !allow_multiple {
+            for prompt in prompts.values_mut() {
+                prompt.enabled = false;
+            }
+        }
 
         if let Some(prompt) = prompts.get_mut(id) {
             prompt.enabled = true;

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -84,18 +84,21 @@ impl PromptService {
                 if !live_content.trim().is_empty() {
                     let mut prompts = state.db.get_prompts(app.as_str())?;
 
-                    // 尝试回填到当前已启用的提示词
-                    if let Some((enabled_id, enabled_prompt)) = prompts
-                        .iter_mut()
-                        .find(|(_, p)| p.enabled)
-                        .map(|(id, p)| (id.clone(), p))
-                    {
+                    // A generated file with multiple enabled prompts must not be
+                    // imported back into one prompt, or later enables would duplicate it.
+                    let enabled_count = prompts.values().filter(|p| p.enabled).count();
+                    if enabled_count == 1 {
+                        let (enabled_id, enabled_prompt) = prompts
+                            .iter_mut()
+                            .find(|(_, p)| p.enabled)
+                            .map(|(id, p)| (id.clone(), p))
+                            .expect("enabled_count guarantees one enabled prompt");
                         let timestamp = get_unix_timestamp()?;
                         enabled_prompt.content = live_content.clone();
                         enabled_prompt.updated_at = Some(timestamp);
                         log::info!("回填 live 提示词内容到已启用项: {enabled_id}");
                         state.db.save_prompt(app.as_str(), enabled_prompt)?;
-                    } else {
+                    } else if enabled_count == 0 {
                         // 没有已启用的提示词，则创建一次备份（避免重复备份）
                         let content_exists = prompts
                             .values()

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -106,7 +106,9 @@ impl PromptService {
                         enabled_prompt.updated_at = Some(timestamp);
                         log::info!("回填 live 提示词内容到已启用项: {enabled_id}");
                         state.db.save_prompt(app.as_str(), enabled_prompt)?;
-                    } else if enabled_count == 0 {
+                    } else if enabled_count == 0
+                        || live_content.trim() != enabled_prompt_content(&prompts).trim()
+                    {
                         // 没有已启用的提示词，则创建一次备份（避免重复备份）
                         let content_exists = prompts
                             .values()

--- a/src-tauri/tests/profile_roundtrip.rs
+++ b/src-tauri/tests/profile_roundtrip.rs
@@ -185,7 +185,7 @@ fn profile_snapshot_apply_roundtrip_restores_configuration() {
         payload.skills.claude,
         Some(vec!["local:test-skill".to_string()])
     );
-    assert_eq!(payload.prompts.claude.as_deref(), Some("pr1"));
+    assert_eq!(payload.prompts.claude, Some(vec!["pr1".to_string()]));
     assert_eq!(
         payload.providers.codex, None,
         "codex side not captured when creating from the claude group"
@@ -410,7 +410,7 @@ fn profile_apply_reports_dangling_references_and_continues() {
         "providers": { "claude": "ghost-provider" },
         "mcp": { "claude": ["m1", "ghost-mcp"] },
         "skills": { "claude": ["ghost-skill"] },
-        "prompts": { "claude": "ghost-prompt" }
+        "prompts": { "claude": ["ghost-prompt"] }
     });
     let profile = cc_switch_lib::Profile {
         id: "dangling-test".to_string(),
@@ -586,7 +586,7 @@ fn switching_profile_autosaves_previous_profile_state() {
         serde_json::from_str(&saved_a.payload).expect("parse project A payload");
     assert_eq!(payload_a.providers.claude.as_deref(), Some("p2"));
     assert_eq!(payload_a.mcp.claude, Some(vec!["m2".to_string()]));
-    assert_eq!(payload_a.prompts.claude.as_deref(), Some("pr2"));
+    assert_eq!(payload_a.prompts.claude, Some(vec!["pr2".to_string()]));
 
     // ---- 在 B 下改回状态 X，再切换回 A ----
     ProviderService::switch(&state, AppType::Claude, "p1").expect("switch to p1");
@@ -640,7 +640,7 @@ fn switching_profile_autosaves_previous_profile_state() {
         serde_json::from_str(&saved_b.payload).expect("parse project B payload");
     assert_eq!(payload_b.providers.claude.as_deref(), Some("p1"));
     assert_eq!(payload_b.mcp.claude, Some(vec!["m1".to_string()]));
-    assert_eq!(payload_b.prompts.claude.as_deref(), Some("pr1"));
+    assert_eq!(payload_b.prompts.claude, Some(vec!["pr1".to_string()]));
 }
 
 #[test]

--- a/src/components/prompts/PromptPanel.tsx
+++ b/src/components/prompts/PromptPanel.tsx
@@ -104,9 +104,11 @@ const PromptPanel = React.forwardRef<PromptPanelHandle, PromptPanelProps>(
         <div className="flex-shrink-0 py-4 glass rounded-xl border border-white/10 mb-4 px-6">
           <div className="text-sm text-muted-foreground">
             {t("prompts.count", { count: promptEntries.length })} ·{" "}
-            {enabledPrompts.length > 0
+            {appId === "codex" && enabledPrompts.length > 0
               ? t("prompts.enabledCount", { count: enabledPrompts.length })
-              : t("prompts.noneEnabled")}
+              : enabledPrompts[0]
+                ? t("prompts.enabledName", { name: enabledPrompts[0][1].name })
+                : t("prompts.noneEnabled")}
           </div>
         </div>
 

--- a/src/components/prompts/PromptPanel.tsx
+++ b/src/components/prompts/PromptPanel.tsx
@@ -97,15 +97,15 @@ const PromptPanel = React.forwardRef<PromptPanelHandle, PromptPanelProps>(
 
     const promptEntries = useMemo(() => Object.entries(prompts), [prompts]);
 
-    const enabledPrompt = promptEntries.find(([_, p]) => p.enabled);
+    const enabledPrompts = promptEntries.filter(([_, p]) => p.enabled);
 
     return (
       <div className="flex flex-col flex-1 min-h-0 px-6">
         <div className="flex-shrink-0 py-4 glass rounded-xl border border-white/10 mb-4 px-6">
           <div className="text-sm text-muted-foreground">
             {t("prompts.count", { count: promptEntries.length })} ·{" "}
-            {enabledPrompt
-              ? t("prompts.enabledName", { name: enabledPrompt[1].name })
+            {enabledPrompts.length > 0
+              ? t("prompts.enabledCount", { count: enabledPrompts.length })
               : t("prompts.noneEnabled")}
           </div>
         </div>

--- a/src/hooks/usePromptActions.ts
+++ b/src/hooks/usePromptActions.ts
@@ -78,19 +78,12 @@ export function usePromptActions(appId: AppId) {
       // Optimistic update
       const previousPrompts = prompts;
 
-      // 如果要启用当前提示词，先禁用其他所有提示词
+      // Enabling a prompt should preserve any other enabled prompts.
       if (enabled) {
-        const updatedPrompts = Object.keys(prompts).reduce(
-          (acc, key) => {
-            acc[key] = {
-              ...prompts[key],
-              enabled: key === id,
-            };
-            return acc;
-          },
-          {} as Record<string, Prompt>,
-        );
-        setPrompts(updatedPrompts);
+        setPrompts((prev) => ({
+          ...prev,
+          [id]: { ...prev[id], enabled: true },
+        }));
       } else {
         setPrompts((prev) => ({
           ...prev,

--- a/src/hooks/usePromptActions.ts
+++ b/src/hooks/usePromptActions.ts
@@ -79,11 +79,20 @@ export function usePromptActions(appId: AppId) {
       const previousPrompts = prompts;
 
       // Enabling a prompt should preserve any other enabled prompts.
-      if (enabled) {
+      if (enabled && appId === "codex") {
         setPrompts((prev) => ({
           ...prev,
           [id]: { ...prev[id], enabled: true },
         }));
+      } else if (enabled) {
+        const updatedPrompts = Object.keys(prompts).reduce(
+          (acc, key) => {
+            acc[key] = { ...prompts[key], enabled: key === id };
+            return acc;
+          },
+          {} as Record<string, Prompt>,
+        );
+        setPrompts(updatedPrompts);
       } else {
         setPrompts((prev) => ({
           ...prev,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1924,6 +1924,7 @@
     "enabled": "Enabled",
     "enable": "Enable",
     "enabledName": "Enabled: {{name}}",
+    "enabledCount": "{{count}} enabled",
     "noneEnabled": "No prompt enabled",
     "currentFile": "Current {{filename}} Content",
     "empty": "No prompts yet",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1924,6 +1924,7 @@
     "enabled": "已启用",
     "enable": "启用",
     "enabledName": "已启用: {{name}}",
+    "enabledCount": "已启用 {{count}} 个",
     "noneEnabled": "未启用任何提示词",
     "currentFile": "当前 {{filename}} 内容",
     "empty": "暂无提示词",

--- a/src/lib/api/profiles.ts
+++ b/src/lib/api/profiles.ts
@@ -27,7 +27,7 @@ export interface ProfilePayload {
   providers: PerApp<string | null>;
   mcp: PerApp<string[] | null>;
   skills: PerApp<string[] | null>;
-  prompts: PerApp<string | null>;
+  prompts: PerApp<string[] | null>;
 }
 
 export interface Profile {


### PR DESCRIPTION
## Summary

- allow multiple Codex global prompts to remain enabled
- concatenate enabled Markdown prompts in database order when writing `AGENTS.md`
- update the prompt panel to show the number of enabled prompts

## Testing

- `git diff --check` passed
- Rust tests could not run because `cargo` is not installed in the current environment
- TypeScript checks could not run because pnpm blocked dependency build scripts (`esbuild`/`msw`)

Closes #4885
