### PR TITLE
fix(claude): resolve custom-title resolution for long sessions

### DIFF
--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -549,7 +549,9 @@ mod tests {
             "\"timestamp\":\"2026-03-06T10:02:00Z\"}\n",
         );
         let needed = (20_000 - header.len()) / padding_line.len() + 5;
-        let padding: String = std::iter::repeat_n(padding_line, needed).collect::<Vec<_>>().concat();
+        let padding: String = std::iter::repeat_n(padding_line, needed)
+            .collect::<Vec<_>>()
+            .concat();
 
         std::fs::write(&path, format!("{}{}", header, padding)).expect("write");
 
@@ -563,8 +565,11 @@ mod tests {
         let path = temp.path().join("session-far-custom.jsonl");
 
         // A stubby line repeated to bulk the file past the old 16 KB threshold
-        // while keeping the line count low enough that the custom-title line
-        // remains within the tail_n=30 window of read_head_tail_lines.
+        // while keeping line count low enough for the custom-title line to
+        // remain within the tail_n=30 window of read_head_tail_lines.
+        // Custom-title sits ~20 KB from EOF so the old 16 KB tail window
+        // would miss it — but the new 128 KB window (or full-file read for
+        // files under the threshold) catches it.
         let bulk = "x".repeat(999); // ~1 KB per line
         let bulk_line = |i: usize| -> String {
             format!("{{\"type\":\"bulk\",\"i\":{i},\"pad\":\"{bulk}\"}}\n",)
@@ -582,15 +587,14 @@ mod tests {
         for i in 0..20 {
             file.push_str(&bulk_line(i));
         }
-        // custom-title placed ~few hundred bytes from EOF so it is
-        // guaranteed to be within the last 30 lines.
         file.push_str(concat!(
             "{\"type\":\"custom-title\",\"customTitle\":\"late-rename\",",
             "\"sessionId\":\"session-far\"}\n",
         ));
-        // A little padding after custom-title ensures the file size is
-        // comfortably above the old 16 KB small-file threshold.
-        for i in 20..30 {
+        // 20 bulk lines after custom-title (~20 KB) so the old 16 KB
+        // seek window would land past it. File stays < 128 KB so
+        // read_head_tail_lines takes the full-file path.
+        for i in 20..40 {
             file.push_str(&bulk_line(i));
         }
 

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -100,6 +100,15 @@ pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<boo
         ));
     }
 
+    // Guard against path traversal before any filesystem mutation:
+    // session_id must be a single safe component (no separators, not
+    // `.` or `..`) before we join it onto the jobs directory below.
+    if !is_safe_path_component(session_id) {
+        return Err(format!(
+            "Refusing to clean up jobs for unsafe session ID: {session_id}"
+        ));
+    }
+
     if let Some(stem) = path.file_stem() {
         let sibling = path.parent().unwrap_or_else(|| Path::new("")).join(stem);
         remove_path_if_exists(&sibling).map_err(|e| {
@@ -113,15 +122,6 @@ pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<boo
     // Clean up Claude Code jobs directory entries associated with this
     // session so the built-in agents panel (← key) does not show stale
     // entries after the session has been deleted.
-    //
-    // Guard against path traversal: session_id must be a single safe
-    // component (no separators, not `.` or `..`) before we join it onto
-    // the jobs directory.
-    if !is_safe_path_component(session_id) {
-        return Err(format!(
-            "Refusing to clean up jobs for unsafe session ID: {session_id}"
-        ));
-    }
     let jobs_dir = get_claude_config_dir().join("jobs");
     let jobs_subdir = jobs_dir.join(session_id);
     let jobs_file = jobs_dir.join(format!("{session_id}.json"));
@@ -228,9 +228,14 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
         // of scanning a few extra lines is negligible.
     }
 
-    // Extract last_active_at, summary, and custom-title from tail lines (reverse order)
+    // Extract last_active_at, summary, and custom-title from tail lines (reverse order).
+    // We use a separate tail_found_title flag (instead of guarding on
+    // custom_title.is_none()) so the tail can override a custom-title
+    // value that was set from the head — the most recent rename near
+    // EOF should always win.
     let mut last_active_at: Option<i64> = None;
     let mut summary: Option<String> = None;
+    let mut tail_found_title = false;
 
     for line in tail.iter().rev() {
         let value: Value = match serde_json::from_str(line) {
@@ -240,15 +245,19 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
         if last_active_at.is_none() {
             last_active_at = value.get("timestamp").and_then(parse_timestamp_to_ms);
         }
-        // Look for custom-title entry (take the last one, i.e. first in reverse)
-        if custom_title.is_none()
-            && value.get("type").and_then(Value::as_str) == Some("custom-title")
-        {
-            custom_title = value
+        // Look for custom-title entry (take the last one, i.e. first in reverse).
+        // Only the first non-empty title found in the tail (most recent
+        // chronologically) wins; empty entries are skipped.
+        if !tail_found_title && value.get("type").and_then(Value::as_str) == Some("custom-title") {
+            let new_title = value
                 .get("customTitle")
                 .and_then(Value::as_str)
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty());
+            if new_title.is_some() {
+                custom_title = new_title;
+                tail_found_title = true;
+            }
         }
         if summary.is_none() {
             if value.get("isMeta").and_then(Value::as_bool) == Some(true) {
@@ -261,9 +270,9 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
                 }
             }
         }
-        if last_active_at.is_some() && summary.is_some() && custom_title.is_some() {
-            break;
-        }
+        // No early break — tail_n is only 30 lines and we must scan all
+        // of them in case a custom-title rename falls behind the most
+        // recent last_active_at / summary lines.
     }
 
     let session_id = session_id.or_else(|| infer_session_id_from_filename(path));
@@ -559,7 +568,9 @@ mod tests {
         let path = temp.path().join("session-head-custom.jsonl");
 
         // custom-title in the head region (line 2, within first 10 lines),
-        // then enough padding to push the file past the small-file threshold.
+        // then enough padding to push the file past TAIL_WINDOW_BYTES (128 KB)
+        // so that read_head_tail_lines exercises its seek-and-read-tail path
+        // rather than the full-file-read path.
         let header = concat!(
             "{\"sessionId\":\"session-big\",\"cwd\":\"/tmp/project\",\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
             "{\"type\":\"custom-title\",\"customTitle\":\"my-rename\",\"sessionId\":\"session-big\"}\n",
@@ -571,7 +582,8 @@ mod tests {
             "padding padding padding padding padding\"},",
             "\"timestamp\":\"2026-03-06T10:02:00Z\"}\n",
         );
-        let needed = (20_000 - header.len()) / padding_line.len() + 5;
+        // Generate > 128 KB so the seek path is taken (TAIL_WINDOW_BYTES = 131_072)
+        let needed = (140_000 - header.len()) / padding_line.len() + 5;
         let padding: String = std::iter::repeat_n(padding_line, needed)
             .collect::<Vec<_>>()
             .concat();
@@ -625,6 +637,91 @@ mod tests {
 
         let meta = parse_session(&path).unwrap();
         assert_eq!(meta.title.as_deref(), Some("late-rename"));
+    }
+
+    #[test]
+    fn parse_session_tail_custom_title_overrides_head() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-tail-override.jsonl");
+
+        // Build a ~50-line file so head (first 10) and tail (last 30) are
+        // disjoint.  Head has an early rename at line 3; tail has a later
+        // rename at line 42 (within the last 30).  The tail rename must win.
+        let mut file = String::new();
+        file.push_str(concat!(
+            "{\"sessionId\":\"s\",\"cwd\":\"/tmp/project\",\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+            "{\"type\":\"custom-title\",\"customTitle\":\"early-rename\",\"sessionId\":\"s\"}\n",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"start\"},\"sessionId\":\"s\",\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
+        ));
+        // ~40 padding lines between head and the late rename
+        for i in 0..38 {
+            file.push_str(&format!(
+                "{{\"type\":\"assistant\",\"message\":{{\"role\":\"assistant\",\"content\":\"pad {i}\"}},\"sessionId\":\"s\",\"timestamp\":\"2026-03-06T10:{:02}:00Z\"}}\n",
+                (i + 2) % 60
+            ));
+        }
+        // Late rename — chronologically after the early one, within tail window
+        file.push_str(
+            "{\"type\":\"custom-title\",\"customTitle\":\"late-rename\",\"sessionId\":\"s\"}\n",
+        );
+        // A few more lines to push it into the tail region
+        for i in 38..46 {
+            file.push_str(&format!(
+                "{{\"type\":\"assistant\",\"message\":{{\"role\":\"assistant\",\"content\":\"pad {i}\"}},\"sessionId\":\"s\",\"timestamp\":\"2026-03-06T10:{:02}:00Z\"}}\n",
+                (i + 2) % 60
+            ));
+        }
+
+        std::fs::write(&path, file).expect("write");
+
+        let meta = parse_session(&path).unwrap();
+        assert_eq!(
+            meta.title.as_deref(),
+            Some("late-rename"),
+            "tail custom-title should override head custom-title"
+        );
+    }
+
+    #[test]
+    fn parse_session_custom_title_in_tail_of_large_file() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-tail-large.jsonl");
+
+        // custom-title only in the tail region of a file > 128 KB so that
+        // read_head_tail_lines uses the seek path to read the tail window.
+        let bulk = "x".repeat(999); // ~1 KB per line
+        let bulk_line = |i: usize| -> String {
+            format!("{{\"type\":\"bulk\",\"i\":{i},\"pad\":\"{bulk}\"}}\n")
+        };
+
+        let mut file = String::new();
+        file.push_str(concat!(
+            "{\"sessionId\":\"tail-big\",\"cwd\":\"/tmp/project\",",
+            "\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",",
+            "\"content\":\"start\"},\"sessionId\":\"tail-big\",",
+            "\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
+        ));
+        // ~135 KB of bulk lines, then custom-title, then ~5 KB more
+        for i in 0..135 {
+            file.push_str(&bulk_line(i));
+        }
+        file.push_str(concat!(
+            "{\"type\":\"custom-title\",\"customTitle\":\"tail-only-rename\",",
+            "\"sessionId\":\"tail-big\"}\n",
+        ));
+        for i in 135..140 {
+            file.push_str(&bulk_line(i));
+        }
+
+        std::fs::write(&path, file).expect("write");
+
+        let meta = parse_session(&path).unwrap();
+        assert_eq!(
+            meta.title.as_deref(),
+            Some("tail-only-rename"),
+            "custom-title in tail of >128KB file (seek path) should be found"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -191,11 +191,14 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
         // tail pass (reverse order, guarded) will still override this
         // value when a more recent rename falls in the tail window.
         if value.get("type").and_then(Value::as_str) == Some("custom-title") {
-            custom_title = value
+            let new_title = value
                 .get("customTitle")
                 .and_then(Value::as_str)
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty());
+            if new_title.is_some() {
+                custom_title = new_title;
+            }
         }
         // Extract first real user message as title candidate
         // Skip system-injected caveats and slash commands (e.g. /clear, /compact)
@@ -747,6 +750,31 @@ mod tests {
         assert!(
             err.contains("unsafe"),
             "error should mention unsafe session ID, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_session_empty_custom_title_does_not_clear_previous() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-empty-rename.jsonl");
+
+        // custom-title at line 2 with valid name, then another custom-title
+        // at line 4 with an empty/whitespace title.  The empty one must NOT
+        // overwrite the valid one.
+        let file = concat!(
+            "{\"sessionId\":\"session-empty\",\"cwd\":\"/tmp/project\",\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+            "{\"type\":\"custom-title\",\"customTitle\":\"valid-name\",\"sessionId\":\"session-empty\"}\n",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hello\"},\"sessionId\":\"session-empty\",\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
+            "{\"type\":\"custom-title\",\"customTitle\":\"   \",\"sessionId\":\"session-empty\"}\n",
+        );
+
+        std::fs::write(&path, file).expect("write");
+
+        let meta = parse_session(&path).unwrap();
+        assert_eq!(
+            meta.title.as_deref(),
+            Some("valid-name"),
+            "empty custom-title must not overwrite a previously valid one"
         );
     }
 }

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -110,6 +110,25 @@ pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<boo
         })?;
     }
 
+    // Clean up Claude Code jobs directory entries associated with this
+    // session so the built-in agents panel (← key) does not show stale
+    // entries after the session has been deleted.
+    let jobs_dir = get_claude_config_dir().join("jobs");
+    let jobs_subdir = jobs_dir.join(session_id);
+    let jobs_file = jobs_dir.join(format!("{session_id}.json"));
+    remove_path_if_exists(&jobs_subdir).map_err(|e| {
+        format!(
+            "Failed to delete Claude jobs directory {}: {e}",
+            jobs_subdir.display()
+        )
+    })?;
+    remove_path_if_exists(&jobs_file).map_err(|e| {
+        format!(
+            "Failed to delete Claude jobs file {}: {e}",
+            jobs_file.display()
+        )
+    })?;
+
     std::fs::remove_file(path).map_err(|e| {
         format!(
             "Failed to delete Claude session file {}: {e}",
@@ -131,6 +150,7 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
     let mut project_dir: Option<String> = None;
     let mut created_at: Option<i64> = None;
     let mut first_user_message: Option<String> = None;
+    let mut custom_title: Option<String> = None;
 
     // Extract metadata and first user message from head lines
     for line in &head {
@@ -152,6 +172,18 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
         }
         if created_at.is_none() {
             created_at = value.get("timestamp").and_then(parse_timestamp_to_ms);
+        }
+        // Extract custom-title from head region as well; when a session
+        // is renamed early and the conversation grows large the entry may
+        // be beyond the tail window altogether.
+        if custom_title.is_none()
+            && value.get("type").and_then(Value::as_str) == Some("custom-title")
+        {
+            custom_title = value
+                .get("customTitle")
+                .and_then(Value::as_str)
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
         }
         // Extract first real user message as title candidate
         // Skip system-injected caveats and slash commands (e.g. /clear, /compact)
@@ -187,7 +219,6 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
     // Extract last_active_at, summary, and custom-title from tail lines (reverse order)
     let mut last_active_at: Option<i64> = None;
     let mut summary: Option<String> = None;
-    let mut custom_title: Option<String> = None;
 
     for line in tail.iter().rev() {
         let value: Value = match serde_json::from_str(line) {
@@ -302,6 +333,7 @@ fn remove_path_if_exists(path: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::tempdir;
 
     #[test]
@@ -496,5 +528,123 @@ mod tests {
 
         let meta = parse_session(&path).unwrap();
         assert_eq!(meta.title.as_deref(), Some("帮我看看工作区的改动"));
+    }
+
+    #[test]
+    fn parse_session_custom_title_in_head_region_of_large_file() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-head-custom.jsonl");
+
+        // custom-title in the head region (line 2, within first 10 lines),
+        // then enough padding to push the file past the small-file threshold.
+        let header = concat!(
+            "{\"sessionId\":\"session-big\",\"cwd\":\"/tmp/project\",\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+            "{\"type\":\"custom-title\",\"customTitle\":\"my-rename\",\"sessionId\":\"session-big\"}\n",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hello\"},\"sessionId\":\"session-big\",\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
+        );
+        let padding_line = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",",
+            "\"content\":\"padding padding padding padding padding padding ",
+            "padding padding padding padding padding\"},",
+            "\"timestamp\":\"2026-03-06T10:02:00Z\"}\n",
+        );
+        let needed = (20_000 - header.len()) / padding_line.len() + 5;
+        let padding: String = std::iter::repeat_n(padding_line, needed).collect::<Vec<_>>().concat();
+
+        std::fs::write(&path, format!("{}{}", header, padding)).expect("write");
+
+        let meta = parse_session(&path).unwrap();
+        assert_eq!(meta.title.as_deref(), Some("my-rename"));
+    }
+
+    #[test]
+    fn parse_session_custom_title_beyond_old_tail_window() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-far-custom.jsonl");
+
+        // A stubby line repeated to bulk the file past the old 16 KB threshold
+        // while keeping the line count low enough that the custom-title line
+        // remains within the tail_n=30 window of read_head_tail_lines.
+        let bulk = "x".repeat(999); // ~1 KB per line
+        let bulk_line = |i: usize| -> String {
+            format!("{{\"type\":\"bulk\",\"i\":{i},\"pad\":\"{bulk}\"}}\n",)
+        };
+
+        let mut file = String::new();
+        file.push_str(concat!(
+            "{\"sessionId\":\"session-far\",\"cwd\":\"/tmp/project\",",
+            "\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",",
+            "\"content\":\"start\"},\"sessionId\":\"session-far\",",
+            "\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
+        ));
+        // ~20 bulk lines @ ~1 KB each → ~20 KB before the custom-title
+        for i in 0..20 {
+            file.push_str(&bulk_line(i));
+        }
+        // custom-title placed ~few hundred bytes from EOF so it is
+        // guaranteed to be within the last 30 lines.
+        file.push_str(concat!(
+            "{\"type\":\"custom-title\",\"customTitle\":\"late-rename\",",
+            "\"sessionId\":\"session-far\"}\n",
+        ));
+        // A little padding after custom-title ensures the file size is
+        // comfortably above the old 16 KB small-file threshold.
+        for i in 20..30 {
+            file.push_str(&bulk_line(i));
+        }
+
+        std::fs::write(&path, file).expect("write");
+
+        let meta = parse_session(&path).unwrap();
+        assert_eq!(meta.title.as_deref(), Some("late-rename"));
+    }
+
+    #[test]
+    #[serial]
+    fn delete_session_cleans_up_jobs_directory() {
+        let temp = tempdir().expect("tempdir");
+        let sessions_dir = temp.path().join("projects");
+        std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+
+        // Redirect Claude config dir under temp via CC_SWITCH_TEST_HOME so
+        // that get_claude_config_dir() returns temp/.claude.
+        let original = std::env::var_os("CC_SWITCH_TEST_HOME");
+        unsafe {
+            std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        }
+
+        // Lay out ~/.claude/jobs/{session_id}/ and ~/.claude/jobs/{session_id}.json
+        let jobs_dir = temp.path().join(".claude").join("jobs");
+        let jobs_subdir = jobs_dir.join("test-session-jobs");
+        std::fs::create_dir_all(&jobs_subdir).expect("create jobs subdir");
+        std::fs::write(jobs_subdir.join("state.json"), "{}").expect("write state.json");
+        let jobs_file = jobs_dir.join("test-session-jobs.json");
+        std::fs::write(&jobs_file, "{}").expect("write jobs file");
+
+        // Create session JSONL
+        let path = sessions_dir.join("test-session-jobs.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"sessionId\":\"test-session-jobs\",\"cwd\":\"/tmp/project\",",
+                "\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+                "{\"message\":{\"role\":\"user\",\"content\":\"hello\"},",
+                "\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
+            ),
+        )
+        .expect("write session");
+
+        delete_session(&sessions_dir, &path, "test-session-jobs").expect("delete session");
+
+        assert!(!path.exists(), "session JSONL should be deleted");
+        assert!(!jobs_subdir.exists(), "jobs subdirectory should be deleted");
+        assert!(!jobs_file.exists(), "jobs JSON file should be deleted");
+
+        // Restore env
+        match original {
+            Some(v) => unsafe { std::env::set_var("CC_SWITCH_TEST_HOME", v) },
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
     }
 }

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -113,6 +113,15 @@ pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<boo
     // Clean up Claude Code jobs directory entries associated with this
     // session so the built-in agents panel (← key) does not show stale
     // entries after the session has been deleted.
+    //
+    // Guard against path traversal: session_id must be a single safe
+    // component (no separators, not `.` or `..`) before we join it onto
+    // the jobs directory.
+    if !is_safe_path_component(session_id) {
+        return Err(format!(
+            "Refusing to clean up jobs for unsafe session ID: {session_id}"
+        ));
+    }
     let jobs_dir = get_claude_config_dir().join("jobs");
     let jobs_subdir = jobs_dir.join(session_id);
     let jobs_file = jobs_dir.join(format!("{session_id}.json"));
@@ -176,9 +185,12 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
         // Extract custom-title from head region as well; when a session
         // is renamed early and the conversation grows large the entry may
         // be beyond the tail window altogether.
-        if custom_title.is_none()
-            && value.get("type").and_then(Value::as_str) == Some("custom-title")
-        {
+        // NOTE: we intentionally do NOT guard with custom_title.is_none()
+        // here — the head lines are in chronological order, so a later
+        // rename within the head should overwrite an earlier one.  The
+        // tail pass (reverse order, guarded) will still override this
+        // value when a more recent rename falls in the tail window.
+        if value.get("type").and_then(Value::as_str) == Some("custom-title") {
             custom_title = value
                 .get("customTitle")
                 .and_then(Value::as_str)
@@ -207,13 +219,10 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
                 }
             }
         }
-        if session_id.is_some()
-            && project_dir.is_some()
-            && created_at.is_some()
-            && first_user_message.is_some()
-        {
-            break;
-        }
+        // Note: we intentionally do not break early in the head loop even
+        // when all fields are populated — a custom-title rename may appear
+        // after the first user message, and with head_n = 10 the overhead
+        // of scanning a few extra lines is negligible.
     }
 
     // Extract last_active_at, summary, and custom-title from tail lines (reverse order)
@@ -328,6 +337,17 @@ fn remove_path_if_exists(path: &Path) -> std::io::Result<()> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err),
     }
+}
+
+/// Returns true when `component` is a single safe filesystem name — no path
+/// separators, not `.` or `..`, and not empty.  Used to guard against path-
+/// traversal when joining a caller-supplied session id onto a directory.
+fn is_safe_path_component(component: &str) -> bool {
+    !component.is_empty()
+        && component != "."
+        && component != ".."
+        && !component.contains('/')
+        && !component.contains('\\')
 }
 
 #[cfg(test)]
@@ -650,5 +670,83 @@ mod tests {
             Some(v) => unsafe { std::env::set_var("CC_SWITCH_TEST_HOME", v) },
             None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
         }
+    }
+
+    #[test]
+    fn is_safe_path_component_accepts_normal_names() {
+        assert!(is_safe_path_component("abc"));
+        assert!(is_safe_path_component("session-12345"));
+        assert!(is_safe_path_component(
+            "48ed2288-f025-4d54-8b69-10b40d97b006"
+        ));
+        assert!(is_safe_path_component("a"));
+    }
+
+    #[test]
+    fn is_safe_path_component_rejects_traversal() {
+        assert!(!is_safe_path_component(""));
+        assert!(!is_safe_path_component("."));
+        assert!(!is_safe_path_component(".."));
+        assert!(!is_safe_path_component("../etc"));
+        assert!(!is_safe_path_component("a/b"));
+        assert!(!is_safe_path_component("c:\\windows"));
+        assert!(!is_safe_path_component("/etc/passwd"));
+    }
+
+    #[test]
+    fn parse_session_multiple_renames_in_head_uses_latest() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-multi-rename.jsonl");
+
+        // Two custom-title entries in the head region (lines 2 and 4);
+        // line 4 is chronologically later so its title should win.
+        let file = concat!(
+            "{\"sessionId\":\"session-renamed\",\"cwd\":\"/tmp/project\",\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+            "{\"type\":\"custom-title\",\"customTitle\":\"old-name\",\"sessionId\":\"session-renamed\"}\n",
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hello\"},\"sessionId\":\"session-renamed\",\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
+            "{\"type\":\"custom-title\",\"customTitle\":\"new-name\",\"sessionId\":\"session-renamed\"}\n",
+        );
+
+        std::fs::write(&path, file).expect("write");
+
+        let meta = parse_session(&path).unwrap();
+        assert_eq!(
+            meta.title.as_deref(),
+            Some("new-name"),
+            "the most recent custom-title (new-name at line 4) should win"
+        );
+    }
+
+    #[test]
+    fn delete_session_rejects_unsafe_session_id() {
+        let temp = tempdir().expect("tempdir");
+        let sessions_dir = temp.path().join("projects");
+        std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+
+        // Create a JSONL whose sessionId contains path traversal.
+        // The file itself has a normal name — the traversal lives in
+        // the JSONL content.
+        let path = sessions_dir.join("safe-name.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"sessionId\":\"../../etc\",\"cwd\":\"/tmp/project\",",
+                "\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
+                "{\"message\":{\"role\":\"user\",\"content\":\"hello\"},",
+                "\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
+            ),
+        )
+        .expect("write session");
+
+        let result = delete_session(&sessions_dir, &path, "../../etc");
+        assert!(
+            result.is_err(),
+            "should reject session_id with path traversal"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("unsafe"),
+            "error should mention unsafe session ID, got: {err}"
+        );
     }
 }

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -100,15 +100,6 @@ pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<boo
         ));
     }
 
-    // Guard against path traversal before any filesystem mutation:
-    // session_id must be a single safe component (no separators, not
-    // `.` or `..`) before we join it onto the jobs directory below.
-    if !is_safe_path_component(session_id) {
-        return Err(format!(
-            "Refusing to clean up jobs for unsafe session ID: {session_id}"
-        ));
-    }
-
     if let Some(stem) = path.file_stem() {
         let sibling = path.parent().unwrap_or_else(|| Path::new("")).join(stem);
         remove_path_if_exists(&sibling).map_err(|e| {
@@ -118,25 +109,6 @@ pub fn delete_session(_root: &Path, path: &Path, session_id: &str) -> Result<boo
             )
         })?;
     }
-
-    // Clean up Claude Code jobs directory entries associated with this
-    // session so the built-in agents panel (← key) does not show stale
-    // entries after the session has been deleted.
-    let jobs_dir = get_claude_config_dir().join("jobs");
-    let jobs_subdir = jobs_dir.join(session_id);
-    let jobs_file = jobs_dir.join(format!("{session_id}.json"));
-    remove_path_if_exists(&jobs_subdir).map_err(|e| {
-        format!(
-            "Failed to delete Claude jobs directory {}: {e}",
-            jobs_subdir.display()
-        )
-    })?;
-    remove_path_if_exists(&jobs_file).map_err(|e| {
-        format!(
-            "Failed to delete Claude jobs file {}: {e}",
-            jobs_file.display()
-        )
-    })?;
 
     std::fs::remove_file(path).map_err(|e| {
         format!(
@@ -351,21 +323,9 @@ fn remove_path_if_exists(path: &Path) -> std::io::Result<()> {
     }
 }
 
-/// Returns true when `component` is a single safe filesystem name — no path
-/// separators, not `.` or `..`, and not empty.  Used to guard against path-
-/// traversal when joining a caller-supplied session id onto a directory.
-fn is_safe_path_component(component: &str) -> bool {
-    !component.is_empty()
-        && component != "."
-        && component != ".."
-        && !component.contains('/')
-        && !component.contains('\\')
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use tempfile::tempdir;
 
     #[test]
@@ -725,75 +685,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
-    fn delete_session_cleans_up_jobs_directory() {
-        let temp = tempdir().expect("tempdir");
-        let sessions_dir = temp.path().join("projects");
-        std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
-
-        // Redirect Claude config dir under temp via CC_SWITCH_TEST_HOME so
-        // that get_claude_config_dir() returns temp/.claude.
-        let original = std::env::var_os("CC_SWITCH_TEST_HOME");
-        unsafe {
-            std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
-        }
-
-        // Lay out ~/.claude/jobs/{session_id}/ and ~/.claude/jobs/{session_id}.json
-        let jobs_dir = temp.path().join(".claude").join("jobs");
-        let jobs_subdir = jobs_dir.join("test-session-jobs");
-        std::fs::create_dir_all(&jobs_subdir).expect("create jobs subdir");
-        std::fs::write(jobs_subdir.join("state.json"), "{}").expect("write state.json");
-        let jobs_file = jobs_dir.join("test-session-jobs.json");
-        std::fs::write(&jobs_file, "{}").expect("write jobs file");
-
-        // Create session JSONL
-        let path = sessions_dir.join("test-session-jobs.jsonl");
-        std::fs::write(
-            &path,
-            concat!(
-                "{\"sessionId\":\"test-session-jobs\",\"cwd\":\"/tmp/project\",",
-                "\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
-                "{\"message\":{\"role\":\"user\",\"content\":\"hello\"},",
-                "\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
-            ),
-        )
-        .expect("write session");
-
-        delete_session(&sessions_dir, &path, "test-session-jobs").expect("delete session");
-
-        assert!(!path.exists(), "session JSONL should be deleted");
-        assert!(!jobs_subdir.exists(), "jobs subdirectory should be deleted");
-        assert!(!jobs_file.exists(), "jobs JSON file should be deleted");
-
-        // Restore env
-        match original {
-            Some(v) => unsafe { std::env::set_var("CC_SWITCH_TEST_HOME", v) },
-            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
-        }
-    }
-
-    #[test]
-    fn is_safe_path_component_accepts_normal_names() {
-        assert!(is_safe_path_component("abc"));
-        assert!(is_safe_path_component("session-12345"));
-        assert!(is_safe_path_component(
-            "48ed2288-f025-4d54-8b69-10b40d97b006"
-        ));
-        assert!(is_safe_path_component("a"));
-    }
-
-    #[test]
-    fn is_safe_path_component_rejects_traversal() {
-        assert!(!is_safe_path_component(""));
-        assert!(!is_safe_path_component("."));
-        assert!(!is_safe_path_component(".."));
-        assert!(!is_safe_path_component("../etc"));
-        assert!(!is_safe_path_component("a/b"));
-        assert!(!is_safe_path_component("c:\\windows"));
-        assert!(!is_safe_path_component("/etc/passwd"));
-    }
-
-    #[test]
     fn parse_session_multiple_renames_in_head_uses_latest() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("session-multi-rename.jsonl");
@@ -814,39 +705,6 @@ mod tests {
             meta.title.as_deref(),
             Some("new-name"),
             "the most recent custom-title (new-name at line 4) should win"
-        );
-    }
-
-    #[test]
-    fn delete_session_rejects_unsafe_session_id() {
-        let temp = tempdir().expect("tempdir");
-        let sessions_dir = temp.path().join("projects");
-        std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
-
-        // Create a JSONL whose sessionId contains path traversal.
-        // The file itself has a normal name — the traversal lives in
-        // the JSONL content.
-        let path = sessions_dir.join("safe-name.jsonl");
-        std::fs::write(
-            &path,
-            concat!(
-                "{\"sessionId\":\"../../etc\",\"cwd\":\"/tmp/project\",",
-                "\"timestamp\":\"2026-03-06T10:00:00Z\"}\n",
-                "{\"message\":{\"role\":\"user\",\"content\":\"hello\"},",
-                "\"timestamp\":\"2026-03-06T10:01:00Z\"}\n",
-            ),
-        )
-        .expect("write session");
-
-        let result = delete_session(&sessions_dir, &path, "../../etc");
-        assert!(
-            result.is_err(),
-            "should reject session_id with path traversal"
-        );
-        let err = result.unwrap_err();
-        assert!(
-            err.contains("unsafe"),
-            "error should mention unsafe session ID, got: {err}"
         );
     }
 

--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -8,6 +8,11 @@ use serde_json::Value;
 /// Maximum number of characters for session titles (shared across providers).
 pub const TITLE_MAX_CHARS: usize = 80;
 
+/// Size of the tail window (in bytes) used when reading the end of large
+/// session files.  Must be large enough to include custom-title entries that
+/// may be positioned at any point in a long-running renamed session.
+const TAIL_WINDOW_BYTES: u64 = 131_072; // 128 KB
+
 /// Read the first `head_n` lines and last `tail_n` lines from a file.
 /// For small files (< 16 KB), reads all lines once to avoid unnecessary seeking.
 pub fn read_head_tail_lines(
@@ -19,7 +24,7 @@ pub fn read_head_tail_lines(
     let file_len = file.metadata()?.len();
 
     // For small files, read all lines once and split
-    if file_len < 16_384 {
+    if file_len < TAIL_WINDOW_BYTES {
         let reader = BufReader::new(file);
         let all: Vec<String> = reader.lines().map_while(Result::ok).collect();
         let head = all.iter().take(head_n).cloned().collect();
@@ -33,7 +38,7 @@ pub fn read_head_tail_lines(
     let head: Vec<String> = reader.lines().take(head_n).map_while(Result::ok).collect();
 
     // Seek to last ~16 KB for tail lines
-    let seek_pos = file_len.saturating_sub(16_384);
+    let seek_pos = file_len.saturating_sub(TAIL_WINDOW_BYTES);
     let mut file2 = File::open(path)?;
     file2.seek(SeekFrom::Start(seek_pos))?;
     let tail_reader = BufReader::new(file2);

--- a/src-tauri/src/session_manager/providers/utils.rs
+++ b/src-tauri/src/session_manager/providers/utils.rs
@@ -14,7 +14,7 @@ pub const TITLE_MAX_CHARS: usize = 80;
 const TAIL_WINDOW_BYTES: u64 = 131_072; // 128 KB
 
 /// Read the first `head_n` lines and last `tail_n` lines from a file.
-/// For small files (< 16 KB), reads all lines once to avoid unnecessary seeking.
+/// For files under the tail-window threshold, reads all lines once instead of seeking.
 pub fn read_head_tail_lines(
     path: &Path,
     head_n: usize,
@@ -37,7 +37,7 @@ pub fn read_head_tail_lines(
     let reader = BufReader::new(file);
     let head: Vec<String> = reader.lines().take(head_n).map_while(Result::ok).collect();
 
-    // Seek to last ~16 KB for tail lines
+    // Seek to the tail window for the last lines of a large file
     let seek_pos = file_len.saturating_sub(TAIL_WINDOW_BYTES);
     let mut file2 = File::open(path)?;
     file2.seek(SeekFrom::Start(seek_pos))?;


### PR DESCRIPTION
---
## Summary / 概述

修复 Claude Code 会话重命名后标题显示错误的问题。

Claude Code 的会话重命名记录（`custom-title`）之前只从文件**尾部最后 16 KB** 扫描。长会话中单行可达 1.5 KB，16 KB 窗口仅覆盖约 10 行：会话早期重命名后再继续对话几十行，`custom-title` 记录就会被新内容顶出扫描窗口，标题退化为会话的首条用户消息（有时甚至是系统注入的重命名提醒文本）。

## 改动

### `utils.rs`
- 将硬编码的 16 KB 尾部窗口提取为命名常量 `TAIL_WINDOW_BYTES = 131_072`（128 KB），覆盖绝大多数实际会话。

### `claude.rs`
- **`parse_session()`**：从 head 区域（前 10 行）和 tail 区域同时提取 `custom-title`，确保不论重命名发生在会话的哪个阶段都能找到。
- 多次重命名时取**最新**一条：head 区按时间序取最后一条，tail 区靠近 EOF 的最新重命名覆盖 head 值。
- 空标题不覆盖之前有效的标题。

## Related Issue / 关联 Issue

Closes #5699
Closes #5700

## 验证

```bash
cargo test session_manager::providers::claude  # 16 passed, 0 failed
cargo clippy --all-targets                      # 0 warnings
cargo fmt --check                                # pass
```

### 新增测试
- `parse_session_custom_title_in_head_region_of_large_file` — custom-title 在 >16 KB 文件的 head 区域
- `parse_session_custom_title_beyond_old_tail_window` — custom-title 距 EOF 超过旧 16 KB 窗口
- `parse_session_tail_custom_title_overrides_head` — tail 区最新重命名覆盖 head 区早期重命名
- `parse_session_custom_title_in_tail_of_large_file` — custom-title 在 >128 KB 文件的 tail 区域（seek 路径）
- `parse_session_multiple_renames_in_head_uses_latest` — head 区多次重命名取最新
- `parse_session_empty_custom_title_does_not_clear_previous` — 空标题不覆盖有效标题

## Screenshots / 截图

本次为逻辑修复，无 UI 变化，不附截图。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
