### PR TITLE
fix(proxy): 为 Codex OAuth 启用并行工具调用

### DIFF
--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -378,6 +378,10 @@ pub fn anthropic_to_responses(
 
     if let Some(v) = body.get("tool_choice") {
         result["tool_choice"] = map_tool_choice_to_responses(v);
+        if let Some(disable_parallel) = v.get("disable_parallel_tool_use").and_then(Value::as_bool)
+        {
+            result["parallel_tool_calls"] = json!(!disable_parallel);
+        }
     }
 
     // Inject prompt_cache_key for improved cache routing on OpenAI-compatible endpoints
@@ -433,8 +437,10 @@ pub fn anthropic_to_responses(
             // —— 兜底必填字段（or_insert：客户端送了什么就保留，否则注入默认值）——
             obj.entry("instructions".to_string()).or_insert(json!(""));
             obj.entry("tools".to_string()).or_insert(json!([]));
+            // Anthropic 默认允许并行工具调用。优先保留上方已转换的显式设置，
+            // 否则允许支持该能力的 Codex 模型在同一响应中批量调用独立工具。
             obj.entry("parallel_tool_calls".to_string())
-                .or_insert(json!(false));
+                .or_insert(json!(true));
 
             // —— 强制覆盖 stream = true ——
             // 即便客户端误传 stream:false 也要覆盖，因为 codex-rs 永远 true，
@@ -2159,10 +2165,54 @@ mod tests {
         assert_eq!(result["tools"], json!([]), "tools 缺失时应兜底为空数组");
         assert_eq!(
             result["parallel_tool_calls"],
-            json!(false),
-            "parallel_tool_calls 应兜底为 false"
+            json!(true),
+            "parallel_tool_calls 应默认允许并行工具调用"
         );
         assert_eq!(result["stream"], json!(true), "stream 应被强制设为 true");
+    }
+
+    /// 验证 Anthropic 的并行工具开关会正确反向映射到 Responses 请求。
+    #[test]
+    fn test_codex_oauth_maps_anthropic_parallel_tool_choice() {
+        let enabled = anthropic_to_responses(
+            json!({
+                "model": "gpt-5.6-sol",
+                "tools": [{
+                    "name": "read_file",
+                    "input_schema": {"type": "object"}
+                }],
+                "tool_choice": {
+                    "type": "auto",
+                    "disable_parallel_tool_use": false
+                },
+                "messages": [{"role": "user", "content": "Read both files"}]
+            }),
+            None,
+            true,
+            true,
+        )
+        .unwrap();
+        assert_eq!(enabled["parallel_tool_calls"], json!(true));
+
+        let disabled = anthropic_to_responses(
+            json!({
+                "model": "gpt-5.6-sol",
+                "tools": [{
+                    "name": "read_file",
+                    "input_schema": {"type": "object"}
+                }],
+                "tool_choice": {
+                    "type": "auto",
+                    "disable_parallel_tool_use": true
+                },
+                "messages": [{"role": "user", "content": "Read one file"}]
+            }),
+            None,
+            true,
+            true,
+        )
+        .unwrap();
+        assert_eq!(disabled["parallel_tool_calls"], json!(false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

修复 Claude Code 通过 Codex OAuth 本地代理执行任务时，工具调用被强制串行化的问题。

根因是 Anthropic → Responses 请求转换在客户端未提供对应字段时，固定注入了：

```json
{
  "parallel_tool_calls": false
}
```

这会要求支持并行工具调用的 Codex 模型每个响应最多只生成一个工具调用，导致完成多步骤任务所需的模型回合数、网络往返和上下文重放量显著增加。

本 PR：

- 将 Codex OAuth 缺省的 `parallel_tool_calls` 改为 `true`；
- 将 Anthropic `tool_choice.disable_parallel_tool_use` 正确反向映射为 Responses `parallel_tool_calls`；
- 保留客户端显式禁用并行工具调用的行为；
- 添加启用和禁用两种情况的回归测试。

Responses → Anthropic 流式状态机已有交错多 `function_call` 测试，能够将多个调用转换为不同的 `tool_use` content block，因此无需修改响应转换逻辑。

## Related Issue / 关联 Issue

Fixes #5719

## Screenshots / 截图

不适用，本 PR 仅修改后端协议转换逻辑。

## Verification / 验证

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
  - 2196 passed
  - 0 failed
  - 2 ignored
- `test_streaming_conversion_interleaved_tool_deltas_by_item_id`
  - 1 passed

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未修改前端，由 CI 验证）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未修改前端，由 CI 验证）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 未修改用户可见文本，无需更新 i18n
