### PR TITLE
fix(usage): preserve codex rollup history through v16 migration

### DIFF
--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1518,9 +1518,36 @@ impl Database {
     /// v15 -> v16: remove Codex session rows and cursors so startup sync can
     /// rebuild them with fork-history alignment. Must stay connection-level:
     /// schema migration already owns the Database connection mutex.
+    ///
+    /// Reimport only covers dates whose source JSONL still exists on disk;
+    /// Codex rotates/deletes old session logs, so history older than that
+    /// cannot be rebuilt and was previously lost outright (GitHub issue
+    /// #5727). `snapshot_codex_rollups_before_reset` preserves the pre-reset
+    /// rows so `restore_unrecovered_codex_rollups` (called after the next
+    /// sync) can fill back in exactly the dates reimport couldn't recover,
+    /// without touching any row the corrected importer did produce.
     fn migrate_v15_to_v16(conn: &Connection) -> Result<(), AppError> {
+        Self::snapshot_codex_rollups_before_reset(conn)?;
         let codex_dir = crate::codex_config::get_codex_config_dir();
         crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)
+    }
+
+    /// Snapshot `_codex_session` rollup rows into a backup table before the
+    /// v16 reset wipes them, so history whose source JSONL has since been
+    /// deleted/rotated is not lost forever. See `migrate_v15_to_v16`.
+    fn snapshot_codex_rollups_before_reset(conn: &Connection) -> Result<(), AppError> {
+        if !Self::table_exists(conn, "usage_daily_rollups")?
+            || !Self::has_column(conn, "usage_daily_rollups", "provider_id")?
+        {
+            return Ok(());
+        }
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS usage_daily_rollups_codex_v15_backup AS
+                 SELECT * FROM usage_daily_rollups WHERE 0;
+             INSERT INTO usage_daily_rollups_codex_v15_backup
+                 SELECT * FROM usage_daily_rollups WHERE provider_id = '_codex_session';",
+        )
+        .map_err(|e| AppError::Database(format!("备份 Codex 历史用量失败: {e}")))
     }
 
     /// 插入默认模型定价数据
@@ -3080,6 +3107,16 @@ mod tests {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )?;
         assert_eq!(counts, (0, 1, 0, 1));
+
+        // The pre-reset row must survive in the snapshot table so a later
+        // sync can restore it if reimport can't recover that date (#5727).
+        let backup_row: (String, i64) = conn.query_row(
+            "SELECT date, COUNT(*) FROM usage_daily_rollups_codex_v15_backup
+             WHERE provider_id = '_codex_session' GROUP BY date",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(backup_row, ("2026-07-10".to_string(), 1));
         Ok(())
     }
 }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -516,7 +516,38 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
         );
     }
 
+    match restore_unrecovered_codex_rollups(db) {
+        Ok(restored) if restored > 0 => {
+            log::info!(
+                "[CODEX-SYNC] 从 v16 迁移前快照恢复了 {restored} 行重导入无法覆盖的历史用量"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => log::warn!("[CODEX-SYNC] 从 v16 迁移前快照恢复历史用量失败: {e}"),
+    }
+
     Ok(result)
+}
+
+/// Fill in `_codex_session` rollup rows the post-migration reimport could
+/// not recover (source JSONL already deleted/rotated away), using the
+/// snapshot `migrate_v15_to_v16` took before the v16 reset. `INSERT OR
+/// IGNORE` means this only ever fills gaps — a date the corrected importer
+/// did reimport already occupies that primary key and is left untouched.
+/// See `Database::migrate_v15_to_v16` and GitHub issue #5727.
+fn restore_unrecovered_codex_rollups(db: &Database) -> Result<u32, AppError> {
+    let conn = lock_conn!(db.conn);
+    if !sqlite_table_exists(&conn, "usage_daily_rollups_codex_v15_backup")? {
+        return Ok(0);
+    }
+    let restored = conn
+        .execute(
+            "INSERT OR IGNORE INTO usage_daily_rollups
+                 SELECT * FROM usage_daily_rollups_codex_v15_backup",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("恢复 Codex 历史用量失败: {e}")))?;
+    Ok(restored as u32)
 }
 
 /// 收集所有 Codex 会话 JSONL 文件
@@ -1937,6 +1968,56 @@ mod tests {
             assert_eq!((codex_rows, gemini_rows, codex_rollups), (0, 1, 0));
             assert_eq!(remaining_cursors, 2);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn restore_unrecovered_codex_rollups_fills_gaps_without_overwriting_reimported_rows(
+    ) -> Result<(), AppError> {
+        let db = Database::memory()?;
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute_batch(
+                "CREATE TABLE usage_daily_rollups_codex_v15_backup AS
+                     SELECT * FROM usage_daily_rollups WHERE 0;
+                 INSERT INTO usage_daily_rollups_codex_v15_backup
+                    (date, app_type, provider_id, model, request_model, pricing_model,
+                     request_count, success_count, input_tokens, output_tokens,
+                     cache_read_tokens, cache_creation_tokens, total_cost_usd,
+                     avg_latency_ms, input_token_semantics)
+                 VALUES
+                    -- unrecoverable: source JSONL is gone, only the reimport-era row exists live
+                    ('2026-05-10', 'codex', '_codex_session', 'gpt-5.4', '', '', 10, 10, 100, 50, 0, 0, '0', 0, 0),
+                    -- would-be stale: reimport already produced a corrected row for this date
+                    ('2026-07-10', 'codex', '_codex_session', 'gpt-5.4', '', '', 999, 999, 999, 999, 0, 0, '0', 0, 0);
+                 INSERT INTO usage_daily_rollups
+                    (date, app_type, provider_id, model, request_model, pricing_model,
+                     request_count, success_count, input_tokens, output_tokens,
+                     cache_read_tokens, cache_creation_tokens)
+                 VALUES
+                    ('2026-07-10', 'codex', '_codex_session', 'gpt-5.4', '', '', 5, 5, 20, 10, 0, 0);",
+            )?;
+        }
+
+        let restored = restore_unrecovered_codex_rollups(&db)?;
+        assert_eq!(restored, 1);
+
+        let conn = lock_conn!(db.conn);
+        let recovered_row_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM usage_daily_rollups WHERE date = '2026-05-10'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(recovered_row_count, 1);
+
+        // Reimported row for 2026-07-10 must win over the stale snapshot value.
+        let july_request_count: i64 = conn.query_row(
+            "SELECT request_count FROM usage_daily_rollups WHERE date = '2026-07-10'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(july_request_count, 5);
+
         Ok(())
     }
 

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -516,7 +516,18 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
         );
     }
 
-    match restore_unrecovered_codex_rollups(db) {
+    // A deferred file (missing/conflicting parent, no-meta billable file) means
+    // this scan is incomplete: some key that currently has zero detail rows
+    // may just be pending resolution, not genuinely unrecoverable. Restoring
+    // it now and having the deferred file's rows land later would double-count
+    // once rollup_and_prune additively merges them — so only restore on a scan
+    // that came back completely clean.
+    let restore_result = if result.deferred_files == 0 {
+        restore_unrecovered_codex_rollups(db)
+    } else {
+        Ok(0)
+    };
+    match restore_result {
         Ok(restored) if restored > 0 => {
             log::info!(
                 "[CODEX-SYNC] 从 v16 迁移前快照恢复了 {restored} 行重导入无法覆盖的历史用量"
@@ -531,9 +542,20 @@ pub fn sync_codex_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
 
 /// Fill in `_codex_session` rollup rows the post-migration reimport could
 /// not recover (source JSONL already deleted/rotated away), using the
-/// snapshot `migrate_v15_to_v16` took before the v16 reset. `INSERT OR
-/// IGNORE` means this only ever fills gaps — a date the corrected importer
-/// did reimport already occupies that primary key and is left untouched.
+/// snapshot `migrate_v15_to_v16` took before the v16 reset.
+///
+/// Reimport writes recovered events straight to `proxy_request_logs`, not
+/// to `usage_daily_rollups` — a rollup row only appears later, once
+/// `rollup_and_prune` aggregates detail rows past its retention window.
+/// So a key can be "reimported successfully" while still having no live
+/// rollup row yet; naively keying on the rollup table's primary key alone
+/// (plain `INSERT OR IGNORE ... SELECT *`) would restore the *stale*
+/// snapshot value for that key, and `rollup_and_prune`'s additive
+/// `COALESCE(old.request_count, 0) + new_req` merge would then double the
+/// day's totals once the fresh detail rows are eventually rolled up. The
+/// `NOT EXISTS` guard below excludes any key that already has matching
+/// `codex_session` detail rows — reimported-but-not-yet-rolled-up — so
+/// only genuinely unrecovered keys (no detail rows at all) get restored.
 /// See `Database::migrate_v15_to_v16` and GitHub issue #5727.
 fn restore_unrecovered_codex_rollups(db: &Database) -> Result<u32, AppError> {
     let conn = lock_conn!(db.conn);
@@ -543,7 +565,17 @@ fn restore_unrecovered_codex_rollups(db: &Database) -> Result<u32, AppError> {
     let restored = conn
         .execute(
             "INSERT OR IGNORE INTO usage_daily_rollups
-                 SELECT * FROM usage_daily_rollups_codex_v15_backup",
+             SELECT b.* FROM usage_daily_rollups_codex_v15_backup b
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM proxy_request_logs l
+                 WHERE l.data_source = 'codex_session'
+                   AND l.app_type = b.app_type
+                   AND l.provider_id = b.provider_id
+                   AND l.model = b.model
+                   AND COALESCE(l.request_model, '') = b.request_model
+                   AND COALESCE(l.pricing_model, '') = b.pricing_model
+                   AND date(l.created_at, 'unixepoch', 'localtime') = b.date
+             )",
             [],
         )
         .map_err(|e| AppError::Database(format!("恢复 Codex 历史用量失败: {e}")))?;
@@ -1975,28 +2007,67 @@ mod tests {
     fn restore_unrecovered_codex_rollups_fills_gaps_without_overwriting_reimported_rows(
     ) -> Result<(), AppError> {
         let db = Database::memory()?;
+
+        // Three dates, matching the three states a backup key can be in:
+        let now = chrono::Local::now();
+        let gone_date = (now - chrono::Duration::days(400))
+            .format("%Y-%m-%d")
+            .to_string();
+        // rolled up: reimport succeeded and rollup_and_prune already ran
+        let rolled_up_date = (now - chrono::Duration::days(60))
+            .format("%Y-%m-%d")
+            .to_string();
+        // pending: reimport succeeded but hasn't been rolled up into usage_daily_rollups yet
+        let pending_date = now.format("%Y-%m-%d").to_string();
+        let pending_ts = now.timestamp();
+
         {
             let conn = lock_conn!(db.conn);
             conn.execute_batch(
                 "CREATE TABLE usage_daily_rollups_codex_v15_backup AS
-                     SELECT * FROM usage_daily_rollups WHERE 0;
-                 INSERT INTO usage_daily_rollups_codex_v15_backup
-                    (date, app_type, provider_id, model, request_model, pricing_model,
-                     request_count, success_count, input_tokens, output_tokens,
-                     cache_read_tokens, cache_creation_tokens, total_cost_usd,
-                     avg_latency_ms, input_token_semantics)
-                 VALUES
-                    -- unrecoverable: source JSONL is gone, only the reimport-era row exists live
-                    ('2026-05-10', 'codex', '_codex_session', 'gpt-5.4', '', '', 10, 10, 100, 50, 0, 0, '0', 0, 0),
-                    -- would-be stale: reimport already produced a corrected row for this date
-                    ('2026-07-10', 'codex', '_codex_session', 'gpt-5.4', '', '', 999, 999, 999, 999, 0, 0, '0', 0, 0);
-                 INSERT INTO usage_daily_rollups
+                     SELECT * FROM usage_daily_rollups WHERE 0;",
+            )?;
+            let insert_backup = |date: &str, request_count: i64| -> Result<(), AppError> {
+                conn.execute(
+                    "INSERT INTO usage_daily_rollups_codex_v15_backup
+                        (date, app_type, provider_id, model, request_model, pricing_model,
+                         request_count, success_count, input_tokens, output_tokens,
+                         cache_read_tokens, cache_creation_tokens, total_cost_usd,
+                         avg_latency_ms, input_token_semantics)
+                     VALUES (?1, 'codex', '_codex_session', 'gpt-5.4', '', '', ?2, ?2,
+                             100, 50, 0, 0, '0', 0, 0)",
+                    rusqlite::params![date, request_count],
+                )
+                .map_err(|e| AppError::Database(e.to_string()))?;
+                Ok(())
+            };
+            // unrecoverable: source JSONL is gone, nothing live for this date at all
+            insert_backup(&gone_date, 10)?;
+            // would-be stale: reimport already produced a corrected, rolled-up row
+            insert_backup(&rolled_up_date, 999)?;
+            // would-be stale: reimport produced detail rows, but rollup_and_prune
+            // hasn't run yet — this is the case the reviewer flagged (#5739)
+            insert_backup(&pending_date, 999)?;
+
+            conn.execute(
+                "INSERT INTO usage_daily_rollups
                     (date, app_type, provider_id, model, request_model, pricing_model,
                      request_count, success_count, input_tokens, output_tokens,
                      cache_read_tokens, cache_creation_tokens)
-                 VALUES
-                    ('2026-07-10', 'codex', '_codex_session', 'gpt-5.4', '', '', 5, 5, 20, 10, 0, 0);",
-            )?;
+                 VALUES (?1, 'codex', '_codex_session', 'gpt-5.4', '', '', 5, 5, 20, 10, 0, 0)",
+                [&rolled_up_date],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, request_model, pricing_model,
+                    input_tokens, output_tokens, latency_ms, status_code, created_at, data_source
+                 ) VALUES ('pending-row', '_codex_session', 'codex', 'gpt-5.4', '', '',
+                           20, 10, 100, 200, ?1, 'codex_session')",
+                [pending_ts],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
         }
 
         let restored = restore_unrecovered_codex_rollups(&db)?;
@@ -2004,19 +2075,29 @@ mod tests {
 
         let conn = lock_conn!(db.conn);
         let recovered_row_count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM usage_daily_rollups WHERE date = '2026-05-10'",
-            [],
+            "SELECT COUNT(*) FROM usage_daily_rollups WHERE date = ?1",
+            [&gone_date],
             |row| row.get(0),
         )?;
         assert_eq!(recovered_row_count, 1);
 
-        // Reimported row for 2026-07-10 must win over the stale snapshot value.
-        let july_request_count: i64 = conn.query_row(
-            "SELECT request_count FROM usage_daily_rollups WHERE date = '2026-07-10'",
-            [],
+        // Already-rolled-up reimported row must win over the stale snapshot value.
+        let rolled_up_request_count: i64 = conn.query_row(
+            "SELECT request_count FROM usage_daily_rollups WHERE date = ?1",
+            [&rolled_up_date],
             |row| row.get(0),
         )?;
-        assert_eq!(july_request_count, 5);
+        assert_eq!(rolled_up_request_count, 5);
+
+        // Pending date must NOT get a rollup row yet — restoring it here would
+        // double-count once rollup_and_prune later aggregates the pending
+        // detail row on top of it.
+        let pending_row_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM usage_daily_rollups WHERE date = ?1",
+            [&pending_date],
+            |row| row.get(0),
+        )?;
+        assert_eq!(pending_row_count, 0);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary / 概述

`migrate_v15_to_v16` (added in eff1e0c) wipes every `_codex_session` row
from `usage_daily_rollups` on upgrade so the next sync can rebuild it
with the corrected fork-history importer. Reimport only covers dates
whose source JSONL still exists on disk, and Codex rotates/deletes old
session logs, so history older than that is silently and permanently
lost — the aggregated rollup row was the only surviving record of it,
since `rollup_and_prune` had already deleted the detail rows it was
built from.

This PR snapshots the pre-reset `_codex_session` rows into a backup
table (`usage_daily_rollups_codex_v15_backup`) before the wipe, then
has `sync_codex_usage` fill back in — via `INSERT OR IGNORE`, keyed on
the same primary key as the live table — exactly the dates the
corrected reimport couldn't recover. Any date the reimport *did*
successfully rebuild already occupies that primary key, so the
corrected/deduplicated reimported value always wins; the snapshot only
fills genuine gaps.

**Caveat (inherent to the bug, not this fix)**: this only protects
users who haven't yet run the v15→v16 migration on their live
database. Anyone who already upgraded past v16 before this change
ships has no snapshot to restore from — that history is already gone.
I recovered one such case (~155B tokens) manually from that user's own
daily auto-backup file, which is what turned up this root cause.

## Related Issue / 关联 Issue

Fixes #5727

## Testing / 测试

- Two new unit tests: `migrate_v15_to_v16_resets_only_codex_session_usage`
  (extended to assert the backup table receives the pre-reset row) and
  `restore_unrecovered_codex_rollups_fills_gaps_without_overwriting_reimported_rows`
  (asserts gap-filling behavior and that reimported data wins over a
  conflicting stale snapshot row).
- `cargo test` (2196 passed, 0 failed), `cargo fmt --check`, and
  `cargo clippy --all-targets` all pass locally.
- No frontend/UI or user-facing text changed.

## Checklist / 检查清单

- [x] `cargo fmt --check` passes / 通过代码格式检查
- [x] `cargo clippy` passes / 通过 Clippy 检查
- [x] `cargo test` passes (2196 passed) / 通过测试
- [x] `pnpm typecheck` passes (`tsc --noEmit`, exit 0 — no frontend files changed by this PR)
- [ ] i18n — not applicable, no user-facing text changed

## Update

An automated review ([comment](https://github.com/farion1231/cc-switch/pull/5739#discussion_r3646437962)) correctly flagged that the first version of this fix could double-count: reimport writes to `proxy_request_logs`, not directly to `usage_daily_rollups` (a rollup row only appears once `rollup_and_prune` aggregates detail rows later), so the original plain `INSERT OR IGNORE` couldn't distinguish "reimported but not yet rolled up" from "genuinely unrecoverable" and could restore a stale snapshot value on top of a date reimport actually recovered.

Fixed in the second commit: the restore now only applies to keys with zero matching `codex_session` rows in `proxy_request_logs` (`NOT EXISTS` guard), and the whole restore pass is skipped on any sync that returned deferred files (a deferred file means the current "zero detail rows" reading isn't authoritative yet). Added a test reproducing the exact race that would have failed against the first version.
