### PR TITLE
fix(proxy): repair Responses message item IDs

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1521,6 +1521,27 @@ impl RequestForwarder {
             mapped_body
         };
 
+        // Codex may replay message items produced by an older CC Switch
+        // Chat/Anthropic conversion. Those versions generated IDs such as
+        // `resp_*_msg`, but strict Responses upstreams require message item IDs
+        // to start with `msg_`. IDs are optional for input messages, so remove
+        // only invalid message IDs on the native Responses passthrough path.
+        if matches!(app_type, AppType::Codex | AppType::GrokBuild)
+            && !codex_responses_to_chat
+            && !codex_responses_to_anthropic
+        {
+            let removed = super::providers::codex_message_items::sanitize_invalid_message_item_ids(
+                &mut request_body,
+            );
+            if removed > 0 {
+                log::debug!(
+                    "[Codex] Removed {removed} invalid replayed message item ID(s) \
+                     before native Responses passthrough (provider={})",
+                    provider.id
+                );
+            }
+        }
+
         // Native Responses passthrough to a strict third-party gateway (xAI):
         // flatten Codex's private `namespace`/plugin tool declarations into
         // top-level function tools so the upstream's strict serde parser does

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1524,18 +1524,19 @@ impl RequestForwarder {
         // Codex may replay message items produced by an older CC Switch
         // Chat/Anthropic conversion. Those versions generated IDs such as
         // `resp_*_msg`, but strict Responses upstreams require message item IDs
-        // to start with `msg_`. IDs are optional for input messages, so remove
-        // only invalid message IDs on the native Responses passthrough path.
+        // to start with `msg_`. Normalize known legacy IDs so paired reasoning
+        // items remain valid; remove only unknown invalid message IDs.
         if matches!(app_type, AppType::Codex | AppType::GrokBuild)
             && !codex_responses_to_chat
             && !codex_responses_to_anthropic
         {
-            let removed = super::providers::codex_message_items::sanitize_invalid_message_item_ids(
-                &mut request_body,
-            );
-            if removed > 0 {
+            let sanitized =
+                super::providers::codex_message_items::sanitize_invalid_message_item_ids(
+                    &mut request_body,
+                );
+            if sanitized > 0 {
                 log::debug!(
-                    "[Codex] Removed {removed} invalid replayed message item ID(s) \
+                    "[Codex] Sanitized {sanitized} invalid replayed message item ID(s) \
                      before native Responses passthrough (provider={})",
                     provider.id
                 );

--- a/src-tauri/src/proxy/providers/codex_message_items.rs
+++ b/src-tauri/src/proxy/providers/codex_message_items.rs
@@ -1,0 +1,93 @@
+//! Helpers for Responses API message item IDs.
+//!
+//! A Responses `message` item ID, when present, must use the `msg_` prefix.
+//! Converted Chat/Anthropic responses are later replayed by Codex as input, so
+//! generating response-scoped IDs such as `resp_*_msg` makes old tasks fail
+//! against strict Responses upstreams.
+
+use serde_json::Value;
+use std::fmt::Display;
+
+pub(crate) fn response_message_item_id(response_id: &str) -> String {
+    let suffix = response_id.strip_prefix("resp_").unwrap_or(response_id);
+    format!("msg_{suffix}")
+}
+
+pub(crate) fn indexed_response_message_item_id(
+    response_id: &str,
+    output_index: impl Display,
+) -> String {
+    format!("{}_{output_index}", response_message_item_id(response_id))
+}
+
+/// Remove invalid IDs from replayed message inputs before native Responses
+/// passthrough. The ID is optional for an input message, while forwarding a
+/// non-`msg_` value is rejected by strict upstreams.
+pub(crate) fn sanitize_invalid_message_item_ids(body: &mut Value) -> usize {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return 0;
+    };
+
+    let mut removed = 0;
+    for item in input.iter_mut().filter_map(Value::as_object_mut) {
+        if item.get("type").and_then(Value::as_str) != Some("message") {
+            continue;
+        }
+
+        let invalid = item
+            .get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.starts_with("msg_"));
+        if invalid {
+            item.remove("id");
+            removed += 1;
+        }
+    }
+
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn generated_message_ids_use_the_responses_prefix() {
+        assert_eq!(
+            response_message_item_id("resp_chatcmpl_1"),
+            "msg_chatcmpl_1"
+        );
+        assert_eq!(
+            indexed_response_message_item_id("resp_anthropic_1", 2),
+            "msg_anthropic_1_2"
+        );
+    }
+
+    #[test]
+    fn sanitizer_removes_only_invalid_message_ids() {
+        let mut body = json!({
+            "input": [
+                {"type": "message", "id": "resp_abc_msg", "role": "assistant", "content": []},
+                {"type": "message", "id": "legacy-uuid", "role": "assistant", "content": []},
+                {"type": "message", "id": "msg_valid", "role": "assistant", "content": []},
+                {"type": "message", "role": "user", "content": []},
+                {"type": "function_call", "id": "resp_abc_msg", "call_id": "call_1"}
+            ]
+        });
+
+        assert_eq!(sanitize_invalid_message_item_ids(&mut body), 2);
+        assert!(body["input"][0].get("id").is_none());
+        assert!(body["input"][1].get("id").is_none());
+        assert_eq!(body["input"][2]["id"], "msg_valid");
+        assert!(body["input"][3].get("id").is_none());
+        assert_eq!(body["input"][4]["id"], "resp_abc_msg");
+    }
+
+    #[test]
+    fn sanitizer_ignores_non_array_input() {
+        let mut body = json!({"input": "hello"});
+        assert_eq!(sanitize_invalid_message_item_ids(&mut body), 0);
+        assert_eq!(body["input"], "hello");
+    }
+}

--- a/src-tauri/src/proxy/providers/codex_message_items.rs
+++ b/src-tauri/src/proxy/providers/codex_message_items.rs
@@ -20,31 +20,55 @@ pub(crate) fn indexed_response_message_item_id(
     format!("{}_{output_index}", response_message_item_id(response_id))
 }
 
-/// Remove invalid IDs from replayed message inputs before native Responses
-/// passthrough. The ID is optional for an input message, while forwarding a
-/// non-`msg_` value is rejected by strict upstreams.
+fn normalize_legacy_message_item_id(id: &str) -> Option<String> {
+    let suffix = id.strip_prefix("resp_")?;
+
+    if let Some(response_suffix) = suffix.strip_suffix("_msg") {
+        return (!response_suffix.is_empty()).then(|| format!("msg_{response_suffix}"));
+    }
+
+    let (response_suffix, output_index) = suffix.rsplit_once("_msg_")?;
+    if response_suffix.is_empty()
+        || output_index.is_empty()
+        || !output_index.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    Some(format!("msg_{response_suffix}_{output_index}"))
+}
+
+/// Sanitize invalid IDs on replayed message inputs before native Responses
+/// passthrough. IDs produced by older CC Switch conversions are rewritten to
+/// the current `msg_` form so reasoning/message pairs remain intact. Unknown
+/// invalid IDs are removed because an ID is optional for an input message.
 pub(crate) fn sanitize_invalid_message_item_ids(body: &mut Value) -> usize {
     let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
         return 0;
     };
 
-    let mut removed = 0;
+    let mut sanitized = 0;
     for item in input.iter_mut().filter_map(Value::as_object_mut) {
         if item.get("type").and_then(Value::as_str) != Some("message") {
             continue;
         }
 
-        let invalid = item
-            .get("id")
-            .and_then(Value::as_str)
-            .is_some_and(|id| !id.starts_with("msg_"));
-        if invalid {
-            item.remove("id");
-            removed += 1;
+        let Some(id) = item.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        if id.starts_with("msg_") {
+            continue;
         }
+
+        if let Some(normalized) = normalize_legacy_message_item_id(id) {
+            item.insert("id".to_string(), Value::String(normalized));
+        } else {
+            item.remove("id");
+        }
+        sanitized += 1;
     }
 
-    removed
+    sanitized
 }
 
 #[cfg(test)]
@@ -65,12 +89,34 @@ mod tests {
     }
 
     #[test]
-    fn sanitizer_removes_only_invalid_message_ids() {
+    fn sanitizer_preserves_reasoning_message_pairs_by_rewriting_legacy_ids() {
         let mut body = json!({
             "input": [
-                {"type": "message", "id": "resp_abc_msg", "role": "assistant", "content": []},
+                {"type": "reasoning", "id": "rs_resp_chatcmpl_1", "summary": []},
+                {"type": "message", "id": "resp_chatcmpl_1_msg", "role": "assistant", "content": []},
+                {"type": "reasoning", "id": "rs_resp_anthropic_1_2", "summary": []},
+                {"type": "message", "id": "resp_anthropic_1_msg_2", "role": "assistant", "content": []},
+                {"type": "reasoning", "id": "rs_valid", "summary": []},
+                {"type": "message", "id": "msg_valid", "role": "assistant", "content": []}
+            ]
+        });
+
+        assert_eq!(sanitize_invalid_message_item_ids(&mut body), 2);
+        assert_eq!(body["input"].as_array().unwrap().len(), 6);
+        assert_eq!(body["input"][0]["id"], "rs_resp_chatcmpl_1");
+        assert_eq!(body["input"][1]["id"], "msg_chatcmpl_1");
+        assert_eq!(body["input"][2]["id"], "rs_resp_anthropic_1_2");
+        assert_eq!(body["input"][3]["id"], "msg_anthropic_1_2");
+        assert_eq!(body["input"][4]["id"], "rs_valid");
+        assert_eq!(body["input"][5]["id"], "msg_valid");
+    }
+
+    #[test]
+    fn sanitizer_removes_only_unknown_invalid_message_ids() {
+        let mut body = json!({
+            "input": [
                 {"type": "message", "id": "legacy-uuid", "role": "assistant", "content": []},
-                {"type": "message", "id": "msg_valid", "role": "assistant", "content": []},
+                {"type": "message", "id": "resp_abc_msg_index", "role": "assistant", "content": []},
                 {"type": "message", "role": "user", "content": []},
                 {"type": "function_call", "id": "resp_abc_msg", "call_id": "call_1"}
             ]
@@ -79,9 +125,8 @@ mod tests {
         assert_eq!(sanitize_invalid_message_item_ids(&mut body), 2);
         assert!(body["input"][0].get("id").is_none());
         assert!(body["input"][1].get("id").is_none());
-        assert_eq!(body["input"][2]["id"], "msg_valid");
-        assert!(body["input"][3].get("id").is_none());
-        assert_eq!(body["input"][4]["id"], "resp_abc_msg");
+        assert!(body["input"][2].get("id").is_none());
+        assert_eq!(body["input"][3]["id"], "resp_abc_msg");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -17,6 +17,7 @@ mod claude;
 mod codex;
 pub(crate) mod codex_chat_common;
 pub mod codex_chat_history;
+pub(crate) mod codex_message_items;
 pub mod codex_oauth_auth;
 pub(crate) mod codex_responses_sse;
 pub mod copilot_auth;

--- a/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
@@ -7,6 +7,7 @@
 //! this set of events.
 
 use super::codex_responses_sse as sse;
+use super::codex_message_items::indexed_response_message_item_id;
 use super::transform_codex_anthropic::{
     build_responses_usage_from_anthropic, map_anthropic_stop_reason_to_status,
     responses_reasoning_item_from_anthropic_block,
@@ -176,7 +177,8 @@ impl AnthropicToResponsesState {
         match block_type {
             "text" => {
                 let output_index = self.next_output_index();
-                let item_id = format!("{}_msg_{output_index}", self.response_id);
+                let item_id =
+                    indexed_response_message_item_id(&self.response_id, output_index);
                 events.push(sse::message_item_added(output_index, &item_id));
                 events.push(sse::message_content_part_added(output_index, &item_id));
                 self.blocks.insert(

--- a/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
@@ -6,8 +6,8 @@
 //! those in `streaming_codex_chat.rs` (Chat → Responses); the Codex client only recognizes
 //! this set of events.
 
-use super::codex_responses_sse as sse;
 use super::codex_message_items::indexed_response_message_item_id;
+use super::codex_responses_sse as sse;
 use super::transform_codex_anthropic::{
     build_responses_usage_from_anthropic, map_anthropic_stop_reason_to_status,
     responses_reasoning_item_from_anthropic_block,
@@ -177,8 +177,7 @@ impl AnthropicToResponsesState {
         match block_type {
             "text" => {
                 let output_index = self.next_output_index();
-                let item_id =
-                    indexed_response_message_item_id(&self.response_id, output_index);
+                let item_id = indexed_response_message_item_id(&self.response_id, output_index);
                 events.push(sse::message_item_added(output_index, &item_id));
                 events.push(sse::message_content_part_added(output_index, &item_id));
                 self.blocks.insert(

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -1,6 +1,7 @@
 //! OpenAI Chat Completions SSE → OpenAI Responses SSE conversion.
 
 use super::codex_responses_sse as sse;
+use super::codex_message_items::response_message_item_id;
 use super::{
     codex_chat_common::{
         extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
@@ -308,7 +309,7 @@ impl ChatToResponsesState {
 
         if !self.text.added {
             let output_index = self.next_output_index();
-            let item_id = format!("{}_msg", self.response_id);
+            let item_id = response_message_item_id(&self.response_id);
             self.text.output_index = Some(output_index);
             self.text.item_id = item_id.clone();
             self.text.added = true;

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -1,7 +1,7 @@
 //! OpenAI Chat Completions SSE → OpenAI Responses SSE conversion.
 
-use super::codex_responses_sse as sse;
 use super::codex_message_items::response_message_item_id;
+use super::codex_responses_sse as sse;
 use super::{
     codex_chat_common::{
         extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -14,6 +14,7 @@ use super::transform_codex_chat::{
     build_codex_tool_context_from_request, response_tool_call_item_from_chat_name,
     response_tool_call_item_id_from_chat_name, CodexToolContext,
 };
+use super::codex_message_items::indexed_response_message_item_id;
 use super::transform_responses::{sanitize_anthropic_tool_use_input, TOOL_RESULT_ERROR_MARKER};
 use crate::proxy::error::ProxyError;
 use crate::proxy::json_canonical::canonical_json_string;
@@ -1296,7 +1297,7 @@ pub(crate) fn anthropic_response_to_responses_with_context(
         if !text_parts.is_empty() {
             let idx = output.len();
             output.push(json!({
-                "id": format!("{response_id}_msg_{idx}"),
+                "id": indexed_response_message_item_id(&response_id, idx),
                 "type": "message",
                 "status": "completed",
                 "role": "assistant",

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -10,11 +10,11 @@
 //! - `transform_responses.rs`: Anthropic request → Responses request, Responses response → Anthropic response
 //! - this module:               Responses request → Anthropic request, Anthropic response → Responses response
 
+use super::codex_message_items::indexed_response_message_item_id;
 use super::transform_codex_chat::{
     build_codex_tool_context_from_request, response_tool_call_item_from_chat_name,
     response_tool_call_item_id_from_chat_name, CodexToolContext,
 };
-use super::codex_message_items::indexed_response_message_item_id;
 use super::transform_responses::{sanitize_anthropic_tool_use_input, TOOL_RESULT_ERROR_MARKER};
 use crate::proxy::error::ProxyError;
 use crate::proxy::json_canonical::canonical_json_string;

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -9,6 +9,7 @@ use super::codex_chat_common::{
     response_function_call_item, response_function_call_item_with_namespace,
     split_leading_think_block,
 };
+use super::codex_message_items::response_message_item_id;
 use crate::provider::CodexChatReasoningConfig;
 use crate::proxy::{
     error::ProxyError,
@@ -1525,7 +1526,7 @@ fn chat_message_to_response_output_item(message: &Value, response_id: &str) -> O
     }
 
     Some(json!({
-        "id": format!("{response_id}_msg"),
+        "id": response_message_item_id(response_id),
         "type": "message",
         "status": "completed",
         "role": "assistant",


### PR DESCRIPTION
## Summary / 概述

- Generate valid `msg_*` IDs for Responses `message` output items in all Chat and Anthropic conversion paths, both streaming and non-streaming.
- Normalize replayed native Responses input by rewriting CC Switch's known legacy `resp_*_msg` / `resp_*_msg_N` IDs to the matching `msg_*` / `msg_*_N` form.
- Preserve reasoning/message pairs, valid `msg_*` IDs, and IDs belonging to other item types such as `function_call`; remove IDs only for unknown invalid message IDs.

## Root cause and impact / 根因与影响

CC Switch's Chat/Anthropic-to-Responses bridges synthesized message item IDs as `resp_*_msg` or `resp_*_msg_N`. Codex persisted those output items in task history. When an affected task was later continued through a native Responses provider, Codex replayed the stored item and a strict upstream rejected it:

```text
Invalid 'input[n].id': 'resp_..._msg'.
Expected an ID that begins with 'msg'.
```

This made old tasks fail with HTTP 400 while new tasks continued to work. Correcting only future ID generation would not recover already affected tasks, so native Responses passthrough also normalizes the exact legacy shapes generated by CC Switch. Deterministic rewriting preserves any adjacent Responses `reasoning` / assistant `message` pair; unknown invalid message IDs are still removed instead of being guessed.

## Related Issue / 关联 Issue

Fixes #5730

Related historical report: #5338

## Validation / 验证

Reporter-provided macOS integration validation against an affected Kiri Relay task:

- ordinary native Responses request: HTTP 200
- replay containing a legacy `resp_*_msg` message ID: HTTP 200
- tool call and tool-result round trip: HTTP 200
- previously affected old Codex task continued successfully

Review follow-up validation on Windows:

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- focused `codex_message_items` tests: 4 passed
- library tests excluding one known fixed-port environment conflict: 2182 passed, 0 failed, 2 ignored
- `git diff --check`
- GitHub CI will run formatting, Clippy, and tests on Linux, Windows, and macOS

## Screenshots / 截图

Not applicable; this is a proxy protocol fix with no UI changes.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本变更）