### PR TITLE
feat(s3): add virtual-hosted style support for Tencent COS

### DIFF
--- a/src-tauri/src/services/s3.rs
+++ b/src-tauri/src/services/s3.rs
@@ -27,6 +27,10 @@ pub(crate) struct S3Credentials {
     /// Custom endpoint host (e.g. `minio.example.com:9000`).
     /// Empty string means AWS official endpoint.
     pub endpoint: String,
+    /// Use path-style addressing (`endpoint/bucket/key`).
+    /// When false, virtual-hosted style is used (`bucket.endpoint/key`).
+    /// AWS endpoints always use virtual-hosted style regardless.
+    pub force_path_style: bool,
 }
 
 // ─── URL construction ────────────────────────────────────────
@@ -68,9 +72,12 @@ fn build_object_url(creds: &S3Credentials, key: &str) -> String {
             "https://{}.s3.{}.amazonaws.com/{}",
             creds.bucket, creds.region, key
         )
-    } else {
+    } else if creds.force_path_style {
         let (scheme, host) = split_scheme_host(&creds.endpoint);
         format!("{}://{}/{}/{}", scheme, host, creds.bucket, key)
+    } else {
+        let (scheme, host) = split_scheme_host(&creds.endpoint);
+        format!("{}://{}.{}/{}", scheme, creds.bucket, host, key)
     }
 }
 
@@ -81,9 +88,12 @@ fn build_bucket_url(creds: &S3Credentials) -> String {
             "https://{}.s3.{}.amazonaws.com/",
             creds.bucket, creds.region
         )
-    } else {
+    } else if creds.force_path_style {
         let (scheme, host) = split_scheme_host(&creds.endpoint);
         format!("{}://{}/{}/", scheme, host, creds.bucket)
+    } else {
+        let (scheme, host) = split_scheme_host(&creds.endpoint);
+        format!("{}://{}.{}/", scheme, creds.bucket, host)
     }
 }
 
@@ -589,6 +599,26 @@ mod tests {
     }
 
     #[test]
+    fn build_object_url_virtual_hosted_style_custom_endpoint() {
+        let mut creds = test_creds("cos.ap-beijing.myqcloud.com", "ap-beijing", "mybucket");
+        creds.force_path_style = false;
+        assert_eq!(
+            build_object_url(&creds, "path/to/file.json"),
+            "https://mybucket.cos.ap-beijing.myqcloud.com/path/to/file.json"
+        );
+    }
+
+    #[test]
+    fn build_bucket_url_virtual_hosted_style_custom_endpoint() {
+        let mut creds = test_creds("cos.ap-beijing.myqcloud.com", "ap-beijing", "mybucket");
+        creds.force_path_style = false;
+        assert_eq!(
+            build_bucket_url(&creds),
+            "https://mybucket.cos.ap-beijing.myqcloud.com/"
+        );
+    }
+
+    #[test]
     fn build_object_url_strips_leading_slash_from_key() {
         let creds = test_creds("", "us-east-1", "b");
         assert_eq!(
@@ -728,6 +758,7 @@ mod tests {
             region: "us-east-1".to_string(),
             bucket: "examplebucket".to_string(),
             endpoint: String::new(),
+            force_path_style: true,
         };
 
         let now = chrono::Utc.with_ymd_and_hms(2013, 5, 24, 0, 0, 0).unwrap();
@@ -768,6 +799,7 @@ mod tests {
             region: "us-east-1".to_string(),
             bucket: "b".to_string(),
             endpoint: String::new(),
+            force_path_style: true,
         };
 
         let now = chrono::Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
@@ -859,6 +891,7 @@ mod tests {
             region: region.to_string(),
             bucket: bucket.to_string(),
             endpoint: endpoint.to_string(),
+            force_path_style: true,
         }
     }
 }
@@ -876,6 +909,7 @@ mod integration_tests {
             region: std::env::var("S3_TEST_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
             bucket: std::env::var("S3_TEST_BUCKET").expect("S3_TEST_BUCKET env required"),
             endpoint: std::env::var("S3_TEST_ENDPOINT").unwrap_or_default(),
+            force_path_style: true,
         }
     }
 

--- a/src-tauri/src/services/s3_sync.rs
+++ b/src-tauri/src/services/s3_sync.rs
@@ -241,6 +241,7 @@ fn creds_for(settings: &S3SyncSettings) -> S3Credentials {
         region: settings.region.clone(),
         bucket: settings.bucket.clone(),
         endpoint: settings.endpoint.clone(),
+        force_path_style: settings.use_path_style,
     }
 }
 
@@ -315,5 +316,6 @@ mod tests {
         assert_eq!(creds.region, "us-west-2");
         assert_eq!(creds.bucket, "my-bucket");
         assert_eq!(creds.endpoint, "minio.local:9000");
+        assert_eq!(creds.force_path_style, true);
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -201,6 +201,8 @@ pub struct S3SyncSettings {
     pub remote_root: String,
     #[serde(default = "default_profile")]
     pub profile: String,
+    #[serde(default = "default_true")]
+    pub use_path_style: bool,
     #[serde(default)]
     pub status: WebDavSyncStatus,
 }
@@ -217,6 +219,7 @@ impl Default for S3SyncSettings {
             endpoint: String::new(),
             remote_root: default_remote_root(),
             profile: default_profile(),
+            use_path_style: true,
             status: WebDavSyncStatus::default(),
         }
     }

--- a/src/components/settings/WebdavSyncSection.tsx
+++ b/src/components/settings/WebdavSyncSection.tsx
@@ -289,6 +289,7 @@ export function WebdavSyncSection({
   const [s3Profile, setS3Profile] = useState(s3Config?.profile ?? "default");
   const [s3AutoSync, setS3AutoSync] = useState(s3Config?.autoSync ?? false);
   const [s3Enabled, setS3Enabled] = useState(s3Config?.enabled ?? false);
+  const [s3UsePathStyle, setS3UsePathStyle] = useState(s3Config?.usePathStyle ?? true);
   const [s3SecretTouched, setS3SecretTouched] = useState(false);
   const [s3Dirty, setS3Dirty] = useState(false);
   const [s3JustSaved, setS3JustSaved] = useState(false);
@@ -663,6 +664,11 @@ export function WebdavSyncSection({
   const handleS3PresetChange = useCallback(
     (id: string) => {
       setS3Preset(id);
+      if (id === "s3-cos") {
+        setS3UsePathStyle(false);
+      } else {
+        setS3UsePathStyle(true);
+      }
       markS3Dirty();
     },
     [markS3Dirty],
@@ -679,6 +685,7 @@ export function WebdavSyncSection({
       endpoint: s3Endpoint.trim() || undefined,
       remoteRoot: s3RemoteRoot.trim() || "cc-switch-sync",
       profile: s3Profile.trim() || "default",
+      usePathStyle: s3UsePathStyle,
     };
   }, [
     s3Enabled,
@@ -690,6 +697,7 @@ export function WebdavSyncSection({
     s3Endpoint,
     s3RemoteRoot,
     s3Profile,
+    s3UsePathStyle,
   ]);
 
   // ─── S3 Handlers ──────────────────────────────────────────
@@ -1350,6 +1358,27 @@ export function WebdavSyncSection({
                 className="text-xs flex-1"
                 disabled={isS3Loading}
               />
+            </div>
+
+            {/* Path Style Toggle */}
+            <div className="flex items-start gap-4">
+              <label className="w-40 text-xs font-medium text-foreground shrink-0">
+                {t("settings.s3Sync.usePathStyle")}
+                <span className="block text-[10px] font-normal text-muted-foreground">
+                  {t("settings.s3Sync.usePathStyleHint")}
+                </span>
+              </label>
+              <div className="pt-1">
+                <Switch
+                  checked={s3UsePathStyle}
+                  onCheckedChange={(checked) => {
+                    setS3UsePathStyle(checked);
+                    markS3Dirty();
+                  }}
+                  aria-label={t("settings.s3Sync.usePathStyle")}
+                  disabled={isS3Loading}
+                />
+              </div>
             </div>
 
             {/* Remote Root */}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -594,6 +594,8 @@
       "endpoint": "Endpoint (optional for AWS)",
       "endpointHint": "Required for most S3-compatible services",
       "endpointPlaceholder": "e.g. https://s3-compatible.example.com",
+      "usePathStyle": "Use Path-style addressing",
+      "usePathStyleHint": "Disable to use Virtual-hosted style (required for Tencent COS)",
       "remoteRoot": "Remote Root Directory",
       "remoteRootDefault": "Default: cc-switch-sync",
       "profile": "Sync Profile Name",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -594,6 +594,8 @@
       "endpoint": "エンドポイント（AWSは空欄可）",
       "endpointHint": "多くの S3 互換サービスでは必須です",
       "endpointPlaceholder": "例: https://s3-compatible.example.com",
+      "usePathStyle": "パススタイルを使用 (Path-style)",
+      "usePathStyleHint": "オフにすると Virtual-hosted スタイルになります（Tencent COS ではオフが必要）",
       "remoteRoot": "リモートルートディレクトリ",
       "remoteRootDefault": "デフォルト: cc-switch-sync",
       "profile": "同期プロファイル名",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -594,6 +594,8 @@
       "endpoint": "Endpoint（AWS 可留空）",
       "endpointHint": "多數 S3 相容服務需要填寫",
       "endpointPlaceholder": "例如 https://s3-compatible.example.com",
+      "usePathStyle": "使用路徑樣式 (Path-style)",
+      "usePathStyleHint": "關閉後使用 Virtual-hosted 樣式（騰訊雲 COS 需關閉此項）",
       "remoteRoot": "遠端根目錄",
       "remoteRootDefault": "預設: cc-switch-sync",
       "profile": "同步設定檔名稱",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -594,6 +594,8 @@
       "endpoint": "Endpoint（AWS 可留空）",
       "endpointHint": "多数 S3 兼容服务需要填写",
       "endpointPlaceholder": "例如 https://s3-compatible.example.com",
+      "usePathStyle": "使用路径样式 (Path-style)",
+      "usePathStyleHint": "关闭后使用 Virtual-hosted 样式（腾讯云 COS 需关闭此项）",
       "remoteRoot": "远程根目录",
       "remoteRootDefault": "默认: cc-switch-sync",
       "profile": "同步配置名",

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,6 +319,7 @@ export interface S3SyncSettings {
   endpoint?: string;
   remoteRoot?: string;
   profile?: string;
+  usePathStyle?: boolean;
   status?: WebDavSyncStatus;
 }
 


### PR DESCRIPTION
Add \use_path_style\ toggle to S3 sync settings to allow switching between path-style and virtual-hosted-style addressing for custom S3-compatible endpoints.

**Problem:** Tencent Cloud COS requires virtual-hosted style URLs (\https://bucket.cos.region.myqcloud.com/key\) but the current code always uses path-style URLs (\https://cos.region.myqcloud.com/bucket/key\) for custom endpoints, causing 403 errors.

**Solution:** Add a \use_path_style\ toggle (default: true for backward compatibility):
- When enabled (default): uses path-style addressing (\endpoint/bucket/key\)
- When disabled: uses virtual-hosted style (\ucket.endpoint/key\)
- Selecting the Tencent COS preset auto-disables path style
- AWS endpoints always use virtual-hosted style regardless of this setting

### Changes:
- \src-tauri/src/services/s3.rs\: Add \orce_path_style\ field to \S3Credentials\, update URL builders
- \src-tauri/src/settings.rs\: Add \use_path_style\ field to \S3SyncSettings\
- \src-tauri/src/services/s3_sync.rs\: Pass \use_path_style\ through \creds_for\
- \src/types.ts\: Add \usePathStyle\ to TypeScript interface
- \src/components/settings/WebdavSyncSection.tsx\: Add UI toggle switch, auto-set for COS preset
- i18n: Add translations for zh, en, zh-TW, ja