### PR TITLE
fix(gemini): update AGY `skills/` directory

### DIFF
--- a/docs/user-manual/en/3-extensions/3.3-skills.md
+++ b/docs/user-manual/en/3-extensions/3.3-skills.md
@@ -91,7 +91,7 @@ Click the "Refresh" button to re-scan repositories for the latest skills.
 |-------------|-------------------|
 | Claude | `~/.claude/skills/` |
 | Codex | `~/.codex/skills/` |
-| Gemini | `~/.gemini/skills/` |
+| Gemini / Antigravity | `~/.gemini/config/skills/` |
 | OpenCode | `~/.config/opencode/skills/` |
 | Hermes | `~/.hermes/skills/` |
 

--- a/docs/user-manual/ja/3-extensions/3.3-skills.md
+++ b/docs/user-manual/ja/3-extensions/3.3-skills.md
@@ -91,7 +91,7 @@ CC Switch は強力な検索とフィルタリング機能を提供していま�
 | -------- | --------------------- |
 | Claude   | `~/.claude/skills/`   |
 | Codex    | `~/.codex/skills/`    |
-| Gemini   | `~/.gemini/skills/`   |
+| Gemini / Antigravity | `~/.gemini/config/skills/` |
 | OpenCode | `~/.config/opencode/skills/` |
 | Hermes | `~/.hermes/skills/` |
 

--- a/docs/user-manual/zh/3-extensions/3.3-skills.md
+++ b/docs/user-manual/zh/3-extensions/3.3-skills.md
@@ -91,7 +91,7 @@ CC Switch 提供强大的搜索和过滤功能：
 | -------- | --------------------- |
 | Claude   | `~/.claude/skills/`   |
 | Codex    | `~/.codex/skills/`    |
-| Gemini   | `~/.gemini/skills/`   |
+| Gemini / Antigravity | `~/.gemini/config/skills/` |
 | OpenCode | `~/.config/opencode/skills/` |
 | Hermes | `~/.hermes/skills/` |
 

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -508,7 +508,7 @@ impl SkillService {
             }
             AppType::Gemini => {
                 if let Some(custom) = crate::settings::get_gemini_override_dir() {
-                    return Ok(custom.join("skills"));
+                    return Ok(custom.join("config").join("skills"));
                 }
             }
             AppType::GrokBuild => {
@@ -542,7 +542,7 @@ impl SkillService {
             AppType::Claude => home.join(".claude").join("skills"),
             AppType::ClaudeDesktop => home.join(".claude-desktop").join("skills"),
             AppType::Codex => home.join(".codex").join("skills"),
-            AppType::Gemini => home.join(".gemini").join("skills"),
+            AppType::Gemini => home.join(".gemini").join("config").join("skills"),
             AppType::GrokBuild => home.join(".grok").join("skills"),
             AppType::OpenCode => home.join(".config").join("opencode").join("skills"),
             AppType::OpenClaw => home.join(".openclaw").join("skills"),


### PR DESCRIPTION
## Summary / 概述

Google Gemini CLI已于 2026 年 6 月 18 日 停止维护，官方继任的AGY系列产品识别 `~/.gemini/config/skills/` 目录。
 如果之前通过*文件复制*的方式将skills存放在 `~/.gemini/skills/` 目录下，可能需要手动迁移skill文件。

[Where does Antigravity look for Agent Skills?](https://atamel.dev/posts/2026/07-01_where_agy_agent_skills/)

Location | AGY | AGY CLI | AGY IDE
-- | -- | -- | --
~/.gemini/antigravity/skills/code-review/ | ✅ | ❌ | ✅
~/.gemini/antigravity-cli/skills/code-review/ | ❌ | ✅ | ✅
~/.gemini/config/skills/code-review/ | ✅ | ✅ | ✅
~/.gemini/skills/code-review/ | ❌ | ✅ | ✅


## Related Issue / 关联 Issue

Fixes #5744 

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
