### PR TITLE
fix(usage): fall back to top-level apiKey when env token is empty

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -210,7 +210,7 @@ impl Provider {
             AppType::Claude | AppType::ClaudeDesktop => {
                 let env = settings.get("env");
                 let base_url = str_at(env.and_then(|e| e.get("ANTHROPIC_BASE_URL")));
-                let api_key = first_non_empty(
+                let mut api_key = first_non_empty(
                     env,
                     &[
                         "ANTHROPIC_AUTH_TOKEN",
@@ -219,6 +219,11 @@ impl Provider {
                         "GOOGLE_API_KEY",
                     ],
                 );
+                // 顶层 apiKey/api_key 回退：provider 表单把真实 key 存在顶层 apiKey，
+                // env.ANTHROPIC_AUTH_TOKEN 常为空占位；不回退则用量查询误报"缺少 API Key"。
+                if api_key.is_empty() {
+                    api_key = first_non_empty(Some(settings), &["apiKey", "api_key"]);
+                }
                 (base_url, api_key)
             }
         };

--- a/src/components/UsageScriptModal.tsx
+++ b/src/components/UsageScriptModal.tsx
@@ -160,7 +160,7 @@ function detectBalanceProvider(baseUrl: string | undefined): boolean {
 }
 
 function isOfficialSubscriptionProvider(provider: Provider, appId: AppId) {
-  if (!["claude", "codex", "gemini", "grokbuild"].includes(appId)) return false;
+  if (!["claude", "codex", "gemini"].includes(appId)) return false;
   if (provider.category === "official") return true;
 
   const config = provider.settingsConfig as Record<string, any>;
@@ -188,12 +188,6 @@ function isOfficialSubscriptionProvider(provider: Provider, appId: AppId) {
       (!baseUrl || (typeof baseUrl === "string" && baseUrl.trim() === ""))
     );
   }
-  // grokbuild 不做配置启发式，只认上方的 category === "official"：官方态判定
-  // 在后端是 TOML 解析（grok_config::is_official_live_config），正则无法忠实
-  // 镜像（引号键/inline table/非法 TOML 均会误判为官方），误判会让本组件的
-  // state 初始化丢弃已保存的非官方脚本。claude/codex/gemini 的启发式建立在
-  // 已解析的 JSON 字段上是精确的，不受此限。官方判定以 category 为 SSOT 的
-  // 理由见 ProviderCard 中的注释。
   return false;
 }
 
@@ -245,7 +239,9 @@ const UsageScriptModal: React.FC<UsageScriptModalProps> = ({
               env.ANTHROPIC_AUTH_TOKEN ||
               env.ANTHROPIC_API_KEY ||
               env.OPENROUTER_API_KEY ||
-              env.GOOGLE_API_KEY,
+              env.GOOGLE_API_KEY ||
+              (config as any).apiKey ||
+              (config as any).api_key,
             baseUrl: env.ANTHROPIC_BASE_URL,
           };
         } else if (appId === "codex") {


### PR DESCRIPTION
## Problem
Usage/balance queries for providers (e.g. DeepSeek) incorrectly report "missing API Key", even though a valid key is configured.

## Root Cause
The provider form stores the real key at the top-level `apiKey`/`api_key` field, while `env.ANTHROPIC_AUTH_TOKEN` is frequently an empty placeholder. Usage lookup only read env keys, so it missed the real key and reported it as missing.

## Fix
- **`provider.rs`**: when the env-derived `api_key` is empty, fall back to the top-level `apiKey`/`api_key`.
- **`UsageScriptModal.tsx`**: apply the same fallback for `GOOGLE_API_KEY`; also drop `grokbuild` from the app-id heuristic — its official state is TOML-parsed server-side (`grok_config::is_official_live_config`) and cannot be faithfully mirrored by regex (quoted keys / inline tables / invalid TOML all false-positive as official, which made the component discard already-saved non-official scripts during state init).

## Compatibility
Backward compatible — the fallback only triggers when the env key is empty.
