### PR TITLE
fix(ui): reduce idle GPU usage for route status

### DIFF
--- a/src/components/proxy/ClaudeDesktopRouteToggle.tsx
+++ b/src/components/proxy/ClaudeDesktopRouteToggle.tsx
@@ -84,7 +84,7 @@ export function ClaudeDesktopRouteToggle({
           className={cn(
             "h-4 w-4 transition-colors",
             isRunning
-              ? "text-emerald-500 animate-pulse"
+              ? "text-emerald-500 status-heartbeat"
               : "text-muted-foreground",
           )}
         />

--- a/src/components/proxy/FailoverToggle.tsx
+++ b/src/components/proxy/FailoverToggle.tsx
@@ -72,7 +72,7 @@ export function FailoverToggle({ className, activeApp }: FailoverToggleProps) {
           className={cn(
             "h-4 w-4 transition-colors",
             isEnabled
-              ? "text-emerald-500 animate-pulse"
+              ? "text-emerald-500 status-heartbeat"
               : "text-muted-foreground",
           )}
         />

--- a/src/components/proxy/ProxyToggle.tsx
+++ b/src/components/proxy/ProxyToggle.tsx
@@ -75,7 +75,7 @@ export function ProxyToggle({ className, activeApp }: ProxyToggleProps) {
           className={cn(
             "h-4 w-4 transition-colors",
             takeoverEnabled
-              ? "text-emerald-500 animate-pulse"
+              ? "text-emerald-500 status-heartbeat"
               : "text-muted-foreground",
           )}
         />

--- a/src/components/settings/ProxyTabContent.tsx
+++ b/src/components/settings/ProxyTabContent.tsx
@@ -118,7 +118,7 @@ export function ProxyTabContent({
                 className="gap-1.5 h-6 ml-auto mr-2"
               >
                 <Activity
-                  className={`h-3 w-3 ${isRunning ? "animate-pulse" : ""}`}
+                  className={`h-3 w-3 ${isRunning ? "status-heartbeat" : ""}`}
                 />
                 {isRunning
                   ? t("settings.advanced.proxy.running")

--- a/src/index.css
+++ b/src/index.css
@@ -145,6 +145,30 @@ html.dark {
   color-scheme: dark;
 }
 
+.status-heartbeat {
+  opacity: 1;
+  transition-property: color, opacity;
+  transition-duration: 150ms, 300ms;
+  transition-timing-function: ease, ease-out;
+}
+
+html[data-window-active="true"][data-status-heartbeat="true"]
+  .status-heartbeat {
+  opacity: 0.5;
+}
+
+html[data-window-active="false"] .status-heartbeat {
+  opacity: 1;
+  transition-duration: 0s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-heartbeat {
+    opacity: 1;
+    transition-property: color;
+  }
+}
+
 ::-webkit-scrollbar {
   display: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -167,6 +167,11 @@ html[data-window-active="false"] .status-heartbeat {
     opacity: 1;
     transition-property: color;
   }
+
+  html[data-window-active="true"][data-status-heartbeat="true"]
+    .status-heartbeat {
+    opacity: 1;
+  }
 }
 
 ::-webkit-scrollbar {

--- a/src/lib/windowActivity.ts
+++ b/src/lib/windowActivity.ts
@@ -1,4 +1,4 @@
-import { focusManager } from "@tanstack/react-query";
+import { isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 const HEARTBEAT_INTERVAL_MS = 3000;
@@ -33,7 +33,6 @@ function startHeartbeat() {
 
 function setWindowActive(active: boolean) {
   document.documentElement.dataset.windowActive = String(active);
-  focusManager.setFocused(active);
 
   if (active) {
     startHeartbeat();
@@ -52,9 +51,11 @@ export function initializeWindowActivity() {
   window.addEventListener("focus", () => setWindowActive(true));
   window.addEventListener("blur", () => setWindowActive(false));
 
-  void getCurrentWindow()
-    .onFocusChanged(({ payload }) => setWindowActive(payload))
-    .catch((error) => {
-      console.error("Failed to observe window focus changes", error);
-    });
+  if (isTauri()) {
+    void getCurrentWindow()
+      .onFocusChanged(({ payload }) => setWindowActive(payload))
+      .catch((error) => {
+        console.error("Failed to observe window focus changes", error);
+      });
+  }
 }

--- a/src/lib/windowActivity.ts
+++ b/src/lib/windowActivity.ts
@@ -1,0 +1,60 @@
+import { focusManager } from "@tanstack/react-query";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+const HEARTBEAT_INTERVAL_MS = 3000;
+const HEARTBEAT_DIM_MS = 300;
+
+let initialized = false;
+let heartbeatInterval: number | undefined;
+let heartbeatReset: number | undefined;
+
+function stopHeartbeat() {
+  if (heartbeatInterval !== undefined) {
+    window.clearInterval(heartbeatInterval);
+    heartbeatInterval = undefined;
+  }
+  if (heartbeatReset !== undefined) {
+    window.clearTimeout(heartbeatReset);
+    heartbeatReset = undefined;
+  }
+  delete document.documentElement.dataset.statusHeartbeat;
+}
+
+function startHeartbeat() {
+  stopHeartbeat();
+  heartbeatInterval = window.setInterval(() => {
+    document.documentElement.dataset.statusHeartbeat = "true";
+    heartbeatReset = window.setTimeout(() => {
+      delete document.documentElement.dataset.statusHeartbeat;
+      heartbeatReset = undefined;
+    }, HEARTBEAT_DIM_MS);
+  }, HEARTBEAT_INTERVAL_MS);
+}
+
+function setWindowActive(active: boolean) {
+  document.documentElement.dataset.windowActive = String(active);
+  focusManager.setFocused(active);
+
+  if (active) {
+    startHeartbeat();
+  } else {
+    stopHeartbeat();
+  }
+}
+
+export function initializeWindowActivity() {
+  if (initialized) return;
+  initialized = true;
+
+  setWindowActive(document.hasFocus());
+
+  // Browser focus events are a fallback for non-Tauri renderer tests and dev mode.
+  window.addEventListener("focus", () => setWindowActive(true));
+  window.addEventListener("blur", () => setWindowActive(false));
+
+  void getCurrentWindow()
+    .onFocusChanged(({ payload }) => setWindowActive(payload))
+    .catch((error) => {
+      console.error("Failed to observe window focus changes", error);
+    });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,7 @@ import {
   MODELS_DEV_SYNC_CONFIG_QUERY_KEY,
   syncModelsDevPricingOnStartup,
 } from "./lib/modelsDevAutoSync";
+import { initializeWindowActivity } from "@/lib/windowActivity";
 
 installGlobalErrorHandlers();
 
@@ -113,6 +114,8 @@ async function bootstrap() {
     // 忽略拉取错误，继续渲染
     reportFrontendError("get_init_error", e);
   }
+
+  initializeWindowActivity();
 
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>


### PR DESCRIPTION
## Summary

- replace continuously running route and failover status pulses with a short heartbeat every three seconds
- pause the cosmetic heartbeat when the CC Switch window loses focus
- guard the Tauri focus listener so browser-only renderer development still starts normally
- leave TanStack Query polling unchanged when a visible window is unfocused
- respect the user's reduced-motion preference

## Root cause

The active route indicators used Tailwind's infinite `animate-pulse`. WebView2 kept ticking and compositing that opacity animation even while the route service was idle. WebView2 also does not reliably update page visibility when its host window is minimized, so the heartbeat uses host window focus events when running in Tauri.

This keeps the active-state feedback while allowing the WebView2 GPU process to become idle between heartbeats and whenever the window is unfocused or minimized, without freezing background polling for visible windows.

Fixes #5760

## Validation

- `pnpm typecheck`
- `pnpm exec prettier --check src/lib/windowActivity.ts src/main.tsx`
- `git diff --check`
