### PR TITLE
feat(proxy): add active health check for automatic circuit breaker recovery

### DIFF
--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -656,6 +656,39 @@ impl Database {
         Ok(())
     }
 
+    /// 标记 provider 为“恢复中（降级）”——脱离熔断，但尚未完全恢复
+    ///
+    /// 与 [`update_provider_health_with_threshold`] 的成功分支不同，此方法把 `is_healthy`
+    /// 置 1 但**保留** `consecutive_failures`（不清零），使前端徽章显示“降级”而非直接跳到
+    /// “正常”，对应主动健康检查在 HalfOpen 探测成功、但尚未累计到 `success_threshold`
+    /// 时的中间态。完全恢复（Closed）由调用方另走 `update_provider_health(success=true)` 清零。
+    pub async fn mark_provider_recovering(
+        &self,
+        provider_id: &str,
+        app_type: &str,
+    ) -> Result<(), AppError> {
+        let conn = lock_conn!(self.conn);
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT OR REPLACE INTO provider_health
+             (provider_id, app_type, is_healthy, consecutive_failures,
+              last_success_at, last_failure_at, last_error, updated_at)
+             VALUES (?1, ?2, 1,
+                     COALESCE((SELECT consecutive_failures FROM provider_health
+                               WHERE provider_id = ?1 AND app_type = ?2), 1),
+                     ?3,
+                     (SELECT last_failure_at FROM provider_health
+                      WHERE provider_id = ?1 AND app_type = ?2),
+                     (SELECT last_error FROM provider_health
+                      WHERE provider_id = ?1 AND app_type = ?2),
+                     ?3)",
+            rusqlite::params![provider_id, app_type, &now],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
     /// 重置Provider健康状态
     pub async fn reset_provider_health(
         &self,

--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -376,6 +376,26 @@ impl CircuitBreaker {
         self.half_open_requests.store(0, Ordering::SeqCst);
     }
 
+    /// 主动强制 Open → HalfOpen（绕过 timeout_seconds）
+    ///
+    /// 与被动等待 [`is_available`] / [`allow_request`] 的 `timeout_seconds` 不同，
+    /// 此方法立即将 Open → HalfOpen，使下一次真实请求直接走恢复路径，
+    /// 而不必依赖真实流量触发超时检测。供 [`crate::proxy::health::HealthChecker`] 主动探测使用。
+    ///
+    /// 已是 Closed / HalfOpen 时为幂等 no-op，**不**重置 in-flight 探测名额。
+    pub async fn force_half_open(&self) {
+        // 转换前先检查：仅在 Open 状态生效，避免 HalfOpen 时重置 in-flight 名额
+        let current = *self.state.read().await;
+        if current != CircuitState::Open {
+            return;
+        }
+        log::info!(
+            "[{}] 熔断器 Open → HalfOpen (主动健康检查触发)",
+            log_cb::OPEN_TO_HALF_OPEN
+        );
+        self.transition_to_half_open().await;
+    }
+
     /// 转换到关闭状态
     async fn transition_to_closed(&self) {
         *self.state.write().await = CircuitState::Closed;
@@ -491,5 +511,58 @@ mod tests {
         breaker.reset().await;
         assert_eq!(breaker.get_state().await, CircuitState::Closed);
         assert!(breaker.allow_request().await.allowed);
+    }
+
+    #[tokio::test]
+    async fn force_half_open_transitions_open_to_half_open() {
+        // 用极长 timeout 证明 force_half_open 不依赖时间
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            timeout_seconds: 3600,
+            ..Default::default()
+        };
+        let breaker = CircuitBreaker::new(config);
+
+        breaker.record_failure(false).await;
+        assert_eq!(breaker.get_state().await, CircuitState::Open);
+
+        breaker.force_half_open().await;
+        assert_eq!(breaker.get_state().await, CircuitState::HalfOpen);
+    }
+
+    #[tokio::test]
+    async fn force_half_open_is_noop_when_closed() {
+        let breaker = CircuitBreaker::new(CircuitBreakerConfig::default());
+        assert_eq!(breaker.get_state().await, CircuitState::Closed);
+
+        breaker.force_half_open().await;
+
+        // 仍为 Closed，未触发状态变化
+        assert_eq!(breaker.get_state().await, CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    async fn force_half_open_does_not_reset_inflight_permit_when_already_half_open() {
+        // 已在 HalfOpen 且占用探测名额时再次调用 force_half_open，
+        // 不应重置 in-flight 名额（避免误释放正在进行的探测）
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            timeout_seconds: 0,
+            ..Default::default()
+        };
+        let breaker = CircuitBreaker::new(config);
+
+        breaker.record_failure(false).await;
+        let first = breaker.allow_request().await;
+        assert!(first.allowed);
+        assert!(first.used_half_open_permit);
+        assert_eq!(breaker.get_state().await, CircuitState::HalfOpen);
+
+        breaker.force_half_open().await;
+
+        // 名额仍被占用，第二次请求应被拒绝
+        let second = breaker.allow_request().await;
+        assert!(!second.allowed);
+        assert!(!second.used_half_open_permit);
     }
 }

--- a/src-tauri/src/proxy/health.rs
+++ b/src-tauri/src/proxy/health.rs
@@ -147,15 +147,18 @@ impl HealthChecker {
         match req.send().await {
             Ok(resp) => {
                 let status = resp.status().as_u16();
-                // 2xx 成功；401/403 表示鉴权失败但网络可达
-                let reachable = (200..300).contains(&status) || status == 401 || status == 403;
+                // 熔断器隔离的是"网络不可达/服务宕机"，而非"端点语义错误"。
+                // 任何 < 500 的 HTTP 响应（含 400 鉴权/参数错、404 端点未实现、405 方法不允许）
+                // 都说明网络层与应用层在正常处理请求 → 视为可达，放行真实流量探测恢复；
+                // 仅 5xx（服务端自身故障/网关错误）视为不可达。日志用 info 级确保默认可见。
+                let reachable = status < 500;
                 if reachable {
-                    log::debug!(
+                    log::info!(
                         "[Health] {app_type}/{} probe 可达 (HTTP {status})",
                         provider.id
                     );
                 } else {
-                    log::debug!(
+                    log::info!(
                         "[Health] {app_type}/{} probe 不可达 (HTTP {status})",
                         provider.id
                     );
@@ -163,7 +166,7 @@ impl HealthChecker {
                 reachable
             }
             Err(e) => {
-                log::debug!("[Health] {app_type}/{} probe 失败: {e}", provider.id);
+                log::info!("[Health] {app_type}/{} probe 失败: {e}", provider.id);
                 false
             }
         }
@@ -323,6 +326,70 @@ mod tests {
     async fn probe_returns_false_on_500() {
         let _home = TempHome::new();
         let (base_url, handle) = spawn_once_server(500);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&base_url);
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(!reachable);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn probe_returns_true_on_400_anthropic_style_bad_request() {
+        // Anthropic 端点用 Bearer 而非 x-api-key → 400；网络可达，鉴权交给真实流量
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(400);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&base_url);
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(reachable);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn probe_returns_true_on_404_endpoint_not_implemented() {
+        // 第三方中转常未实现 GET /v1/models → 404；网络层可达即应放行恢复
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(404);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&base_url);
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(reachable);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn probe_returns_true_on_405_method_not_allowed() {
+        // 端点存在但不允许 GET → 405；应用层在响应，视为可达
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(405);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&base_url);
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(reachable);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn probe_returns_false_on_503_service_unavailable() {
+        // 5xx = 服务端自身故障/网关错误，不可达（与 500 一致）
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(503);
 
         let db = Arc::new(Database::memory().unwrap());
         let router = Arc::new(ProviderRouter::new(db.clone()));

--- a/src-tauri/src/proxy/health.rs
+++ b/src-tauri/src/proxy/health.rs
@@ -78,61 +78,69 @@ impl HealthChecker {
         for app_type in AppType::all() {
             let app_type_str = app_type.as_str();
 
-            // 只对启用自动故障转移的 app 检查
-            let auto_failover_enabled = match self.db.get_proxy_config_for_app(app_type_str).await {
-                Ok(config) => config.auto_failover_enabled,
-                Err(_) => continue,
-            };
-            if !auto_failover_enabled {
-                continue;
-            }
-
-            let providers = match self.router.list_providers_with_state(app_type_str).await {
-                Ok(list) => list,
+            // 心跳范围：遍历该 app 的全部 provider，只探 DB 里 consecutive_failures>0
+            // （降级/熔断）的；健康（failures==0）的不打上游，避免限流/计费。
+            // 不依赖 auto-failover 开关、也不依赖 failover 队列——stale 故障 provider
+            // 可能两者都不在（例如重启后内存熔断器已重置、仅 DB 行残留）。
+            let providers = match self.db.get_all_providers(app_type_str) {
+                Ok(map) => map,
                 Err(e) => {
                     log::debug!("[Health] 读取 {app_type_str} provider 列表失败: {e}");
                     continue;
                 }
             };
 
-            for (provider, state) in providers {
-                // 探测 Open 与 HalfOpen：Open 需主动转 HalfOpen，HalfOpen 需继续 probe
-                // 累计成功直到 Closed，否则无真实流量时会永久卡在 HalfOpen，
-                // 只能靠人工关闭/开启代理来恢复。
-                if state != CircuitState::Open && state != CircuitState::HalfOpen {
+            for (provider_id, provider) in providers {
+                let health = match self
+                    .db
+                    .get_provider_health(&provider_id, app_type_str)
+                    .await
+                {
+                    Ok(h) => h,
+                    Err(e) => {
+                        log::debug!("[Health] 读取 {app_type_str}/{provider_id} 健康状态失败: {e}");
+                        continue;
+                    }
+                };
+                // 健康（failures==0）不打上游
+                if health.consecutive_failures == 0 {
                     continue;
                 }
-                if self.probe(&provider, app_type_str).await {
-                    let circuit_key = format!("{app_type_str}:{}", provider.id);
-                    if let Some(breaker) = self.router.get_breaker(&circuit_key).await {
-                        // Open → HalfOpen（已是 HalfOpen 时为 no-op，不重置累计成功数）
-                        breaker.force_half_open().await;
-                        // 累计 HalfOpen 探测成功，达 success_threshold 后自动转 Closed。
-                        breaker.record_success(false).await;
 
-                        // 把恢复同步到 DB provider_health（前端徽章的数据源）。
-                        // 徽章三态：is_healthy=false → 熔断；is_healthy=true 且 failures>0 → 降级；
-                        // failures=0 → 正常。据此实现 熔断→降级→正常 的渐进恢复：
-                        // - 已完全恢复 (Closed)：清零 failures → 正常（也覆盖 success_threshold=1
-                        //   时"熔断直跳正常"的合法路径）
-                        // - 仍在 HalfOpen 留观：仅翻 is_healthy、保留 failures → 降级
-                        let fully_recovered = breaker.get_state().await == CircuitState::Closed;
-                        let db_result = if fully_recovered {
-                            self.db
-                                .update_provider_health(&provider.id, app_type_str, true, None)
-                                .await
-                        } else {
-                            self.db
-                                .mark_provider_recovering(&provider.id, app_type_str)
-                                .await
-                        };
-                        if let Err(e) = db_result {
-                            log::warn!(
-                                "[Health] {app_type_str}/{} 恢复回写 DB 失败: {e}",
-                                provider.id
-                            );
+                if !self.probe(&provider, app_type_str).await {
+                    continue;
+                }
+
+                // 可达：把内存熔断器与 DB provider_health 同步到恢复态。
+                let circuit_key = format!("{app_type_str}:{provider_id}");
+                let breaker = self.router.get_breaker(&circuit_key).await;
+                let fully_recovered = match &breaker {
+                    // 本次会话内熔断（内存仍在 Open/HalfOpen）：推进恢复
+                    Some(b) => {
+                        let st = b.get_state().await;
+                        if matches!(st, CircuitState::Open | CircuitState::HalfOpen) {
+                            b.force_half_open().await;
+                            b.record_success(false).await;
                         }
+                        b.get_state().await == CircuitState::Closed
                     }
+                    // 无内存熔断器（重启后内存已重置、仅 DB 行残留）→ 直接清 DB
+                    None => true,
+                };
+
+                // 徽章三态：failures=0 → 正常；is_healthy=true & failures>0 → 降级；
+                // is_healthy=false → 熔断。据此 熔断→降级→正常 渐进恢复。
+                let db_result = if fully_recovered {
+                    self.db
+                        .update_provider_health(&provider_id, app_type_str, true, None)
+                        .await
+                } else {
+                    self.db
+                        .mark_provider_recovering(&provider_id, app_type_str)
+                        .await
+                };
+                if let Err(e) = db_result {
+                    log::warn!("[Health] {app_type_str}/{provider_id} 恢复回写 DB 失败: {e}");
                 }
             }
         }
@@ -726,22 +734,25 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn scan_once_skips_apps_without_auto_failover() {
+    async fn scan_once_probes_unhealthy_even_without_auto_failover() {
+        // 心跳不依赖 auto-failover 开关、也不依赖 failover 队列：
+        // 只要 DB 里 failures>0（降级/熔断），可达就恢复。覆盖重启后 stale 场景。
         let _home = TempHome::new();
-        // 不需要 mock server：scan_once 会跳过 probe，因为没有启用 auto_failover
+        let (base_url, handle) = spawn_once_server(200);
+
         let db = Arc::new(Database::memory().unwrap());
         db.update_circuit_breaker_config(&CircuitBreakerConfig {
             failure_threshold: 1,
+            success_threshold: 1,
             timeout_seconds: 3600,
             ..Default::default()
         })
         .await
         .unwrap();
 
-        let provider = claude_provider_with("http://127.0.0.1:1");
+        let provider = claude_provider_with(&base_url);
         db.save_provider("claude", &provider).unwrap();
-        db.add_to_failover_queue("claude", &provider.id).unwrap();
-        // 注意：不启用 auto_failover（默认即为 false）
+        // 不加入 failover 队列、不启用 auto_failover——心跳仍应覆盖
 
         let router = Arc::new(ProviderRouter::new(db.clone()));
         router
@@ -755,16 +766,63 @@ mod tests {
             .await
             .unwrap();
 
-        let checker = HealthChecker::new(router.clone(), db, test_client());
-        checker.scan_once().await;
-
-        // 未启用故障转移 → 跳过，状态仍为 Open
         let circuit_key = format!("claude:{}", provider.id);
         let breaker = router
             .get_breaker(&circuit_key)
             .await
             .expect("breaker exists");
         assert_eq!(breaker.get_state().await, CircuitState::Open);
+
+        let checker = HealthChecker::new(router.clone(), db.clone(), test_client());
+        checker.scan_once().await;
+
+        // 未开 failover、不在队列，但 DB 标记 unhealthy 且可达 → 仍恢复
+        assert_eq!(breaker.get_state().await, CircuitState::Closed);
+        let h = db
+            .get_provider_health(&provider.id, "claude")
+            .await
+            .unwrap();
+        assert!(h.is_healthy);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scan_once_does_not_probe_healthy_providers() {
+        // 正常（failures==0）不打上游：探活命中计数应为 0，避免限流/计费。
+        let _home = TempHome::new();
+        let hits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hits_clone = hits.clone();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        listener.set_nonblocking(true).ok();
+        let port = listener.local_addr().expect("addr").port();
+        let handle = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_millis(1200);
+            while std::time::Instant::now() < deadline {
+                if let Ok((mut s, _)) = listener.accept() {
+                    hits_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let _ = s.write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        });
+
+        let db = Arc::new(Database::memory().unwrap());
+        let provider = claude_provider_with(&format!("http://127.0.0.1:{port}"));
+        db.save_provider("claude", &provider).unwrap();
+        // 不 record_failure → failures==0（健康）
+
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router, db, test_client());
+        checker.scan_once().await;
+
+        // 健康 provider 不应被打上游
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "健康 provider 不应被探活"
+        );
+        handle.join().expect("server thread");
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/health.rs
+++ b/src-tauri/src/proxy/health.rs
@@ -96,13 +96,20 @@ impl HealthChecker {
             };
 
             for (provider, state) in providers {
-                if state != CircuitState::Open {
+                // 探测 Open 与 HalfOpen：Open 需主动转 HalfOpen，HalfOpen 需继续 probe
+                // 累计成功直到 Closed，否则无真实流量时会永久卡在 HalfOpen，
+                // 只能靠人工关闭/开启代理来恢复。
+                if state != CircuitState::Open && state != CircuitState::HalfOpen {
                     continue;
                 }
                 if self.probe(&provider, app_type_str).await {
                     let circuit_key = format!("{app_type_str}:{}", provider.id);
                     if let Some(breaker) = self.router.get_breaker(&circuit_key).await {
+                        // Open → HalfOpen（已是 HalfOpen 时为 no-op，不重置累计成功数）
                         breaker.force_half_open().await;
+                        // 把 probe 成功反馈为一次 HalfOpen 探测成功，达 success_threshold
+                        // 后自动转 Closed，使无真实流量场景也能完全自动恢复。
+                        breaker.record_success(false).await;
                     }
                 }
             }
@@ -471,6 +478,60 @@ mod tests {
 
         // 探测成功后：force_half_open → HalfOpen
         assert_eq!(breaker.get_state().await, CircuitState::HalfOpen);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scan_once_recovers_to_closed_after_successful_probe() {
+        // 无真实流量时，probe 成功应自动反馈 record_success 使 HalfOpen→Closed，
+        // 免去人工关闭/开启代理才能恢复。success_threshold=1：一次 probe 成功即恢复。
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(200);
+
+        let db = Arc::new(Database::memory().unwrap());
+        db.update_circuit_breaker_config(&CircuitBreakerConfig {
+            failure_threshold: 1,
+            success_threshold: 1,
+            timeout_seconds: 3600,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let provider = claude_provider_with(&base_url);
+        db.save_provider("claude", &provider).unwrap();
+        db.add_to_failover_queue("claude", &provider.id).unwrap();
+
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        router
+            .record_result(
+                &provider.id,
+                "claude",
+                false,
+                false,
+                Some("boom".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let circuit_key = format!("claude:{}", provider.id);
+        let breaker = router
+            .get_breaker(&circuit_key)
+            .await
+            .expect("breaker exists");
+        assert_eq!(breaker.get_state().await, CircuitState::Open);
+
+        checker.scan_once().await;
+
+        // probe 成功后应自动恢复到 Closed（而非卡在 HalfOpen 等真实流量）
+        assert_eq!(breaker.get_state().await, CircuitState::Closed);
         handle.join().expect("server thread");
     }
 

--- a/src-tauri/src/proxy/health.rs
+++ b/src-tauri/src/proxy/health.rs
@@ -1,0 +1,474 @@
+//! 主动健康检查器
+//!
+//! 在 [`crate::proxy::circuit_breaker::CircuitBreaker`] 进入 Open 状态后，
+//! 不再被动等待 `timeout_seconds` + 真实流量触发 HalfOpen 探测，而是由本模块
+//! 后台主动调用 Provider 的 `/v1/models` 端点探测可达性，可达时立即
+//! [`crate::proxy::circuit_breaker::CircuitBreaker::force_half_open`]，
+//! 让下一次真实请求直接走恢复路径，显著缩短故障 provider 的恢复延迟。
+
+use crate::app_config::AppType;
+use crate::database::Database;
+use crate::provider::Provider;
+use crate::proxy::circuit_breaker::CircuitState;
+use crate::proxy::log_codes::cb as log_cb;
+use crate::proxy::provider_router::ProviderRouter;
+use reqwest::Client;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::oneshot;
+
+/// 主动探测循环间隔（秒）
+///
+/// 选 30s 是健康检查的常见业界值：足够频繁以快速发现恢复，
+/// 又不会对上游造成明显压力（每次仅 GET /v1/models）。
+const PROBE_INTERVAL_SECS: u64 = 30;
+
+/// 单次探测超时
+///
+/// 健康探测不应长时间占用连接；3s 已足够区分"可达但鉴权失败"与"完全不可达"。
+const PROBE_TIMEOUT_SECS: u64 = 3;
+
+/// 健康检查器
+///
+/// 持有共享的 [`ProviderRouter`]（用于读取熔断状态、触发 `force_half_open`）
+/// 与 [`Database`]（用于读取每个 app 的故障转移开关）。`reqwest::Client` 由调用方注入，
+/// 生产环境复用 [`crate::proxy::http_client::get()`]（继承全局代理设置），
+/// 测试时可用独立客户端避免污染全局状态。
+pub struct HealthChecker {
+    router: Arc<ProviderRouter>,
+    db: Arc<Database>,
+    client: Client,
+}
+
+impl HealthChecker {
+    pub fn new(router: Arc<ProviderRouter>, db: Arc<Database>, client: Client) -> Self {
+        Self { router, db, client }
+    }
+
+    /// 后台循环：按固定间隔扫描所有 app_type 的故障转移队列，
+    /// 对处于 Open 状态的 provider 主动 probe，成功则 `force_half_open`。
+    ///
+    /// 通过 `oneshot::Receiver` 接收关闭信号，与 [`crate::proxy::server::ProxyServer`] 的
+    /// 生命周期绑定：代理停止时发送信号，本循环立即退出。
+    pub async fn run_loop(&self, mut shutdown: oneshot::Receiver<()>) {
+        let mut interval = tokio::time::interval(Duration::from_secs(PROBE_INTERVAL_SECS));
+        // 第一次 tick 立即返回（启动后先扫一次，避免等到下一个周期才发现恢复）
+        interval.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    self.scan_once().await;
+                }
+                _ = &mut shutdown => {
+                    log::info!("[{}] 健康检查器已停止", log_cb::OPEN_TO_HALF_OPEN);
+                    break;
+                }
+            }
+        }
+    }
+
+    /// 单次扫描：遍历所有 app_type，对 Open 状态的 provider 主动 probe。
+    ///
+    /// 仅扫描启用自动故障转移的 app（未启用故障转移的 app 不需要主动恢复——
+    /// 单 provider 场景下半开也无意义）。`pub(crate)` 暴露以便单元测试直接调用，
+    /// 避开 30s 间隔的等待。
+    pub(crate) async fn scan_once(&self) {
+        for app_type in AppType::all() {
+            let app_type_str = app_type.as_str();
+
+            // 只对启用自动故障转移的 app 检查
+            let auto_failover_enabled = match self.db.get_proxy_config_for_app(app_type_str).await {
+                Ok(config) => config.auto_failover_enabled,
+                Err(_) => continue,
+            };
+            if !auto_failover_enabled {
+                continue;
+            }
+
+            let providers = match self.router.list_providers_with_state(app_type_str).await {
+                Ok(list) => list,
+                Err(e) => {
+                    log::debug!("[Health] 读取 {app_type_str} provider 列表失败: {e}");
+                    continue;
+                }
+            };
+
+            for (provider, state) in providers {
+                if state != CircuitState::Open {
+                    continue;
+                }
+                if self.probe(&provider, app_type_str).await {
+                    let circuit_key = format!("{app_type_str}:{}", provider.id);
+                    if let Some(breaker) = self.router.get_breaker(&circuit_key).await {
+                        breaker.force_half_open().await;
+                    }
+                }
+            }
+        }
+    }
+
+    /// 探测单个 provider 是否可达
+    ///
+    /// 端点选择策略：
+    /// - `base_url` 以 `/v1` 结尾：直接附加 `/models`（Codex/OpenAI 风格的 base_url 已含版本）
+    /// - 否则：附加 `/v1/models`（Anthropic/Gemini 风格的 base_url 仅含 origin）
+    ///
+    /// 可达判定：
+    /// - 2xx：正常可达
+    /// - 401/403：鉴权失败但**网络层可达**——熔断目的是隔离网络不可达，而非认证错误；
+    ///   这种情况下 provider 实际可服务（用户重试时鉴权错会被上层处理），视为可达
+    /// - 其他状态码 / 网络错误：不可达
+    async fn probe(&self, provider: &Provider, app_type: &str) -> bool {
+        let app_type_enum = match AppType::from_str(app_type) {
+            Ok(t) => t,
+            Err(_) => return false,
+        };
+        let (base_url, api_key) = provider.resolve_usage_credentials(&app_type_enum);
+        if base_url.is_empty() {
+            return false;
+        }
+
+        let url = if base_url.ends_with("/v1") {
+            format!("{base_url}/models")
+        } else {
+            format!("{base_url}/v1/models")
+        };
+
+        let mut req = self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(PROBE_TIMEOUT_SECS));
+        if !api_key.is_empty() {
+            req = req.bearer_auth(&api_key);
+        }
+
+        match req.send().await {
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                // 2xx 成功；401/403 表示鉴权失败但网络可达
+                let reachable = (200..300).contains(&status) || status == 401 || status == 403;
+                if reachable {
+                    log::debug!(
+                        "[Health] {app_type}/{} probe 可达 (HTTP {status})",
+                        provider.id
+                    );
+                } else {
+                    log::debug!(
+                        "[Health] {app_type}/{} probe 不可达 (HTTP {status})",
+                        provider.id
+                    );
+                }
+                reachable
+            }
+            Err(e) => {
+                log::debug!("[Health] {app_type}/{} probe 失败: {e}", provider.id);
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proxy::circuit_breaker::CircuitBreakerConfig;
+    use crate::proxy::provider_router::ProviderRouter;
+    use serde_json::json;
+    use serial_test::serial;
+    use std::env;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use tempfile::TempDir;
+
+    /// 复用 provider_router 测试的 TempHome 模式：隔离 HOME / CC_SWITCH_TEST_HOME，
+    /// 避免 settings 全局状态串扰。
+    struct TempHome {
+        #[allow(dead_code)]
+        dir: TempDir,
+        original_home: Option<String>,
+        original_userprofile: Option<String>,
+        original_test_home: Option<String>,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let dir = TempDir::new().expect("failed to create temp home");
+            let original_home = env::var("HOME").ok();
+            let original_userprofile = env::var("USERPROFILE").ok();
+            let original_test_home = env::var("CC_SWITCH_TEST_HOME").ok();
+
+            env::set_var("HOME", dir.path());
+            env::set_var("USERPROFILE", dir.path());
+            env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            crate::settings::reload_settings().expect("reload settings");
+
+            Self {
+                dir,
+                original_home,
+                original_userprofile,
+                original_test_home,
+            }
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            match &self.original_home {
+                Some(value) => env::set_var("HOME", value),
+                None => env::remove_var("HOME"),
+            }
+            match &self.original_userprofile {
+                Some(value) => env::set_var("USERPROFILE", value),
+                None => env::remove_var("USERPROFILE"),
+            }
+            match &self.original_test_home {
+                Some(value) => env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+        }
+    }
+
+    /// 起一个只服务一次连接的本地 HTTP server，返回固定状态码 + 空 body。
+    /// 返回 `(base_url, JoinHandle)`，base_url 已去掉 trailing slash 方便测试用例拼接。
+    fn spawn_once_server(status_code: u16) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+        let port = listener.local_addr().expect("local addr").port();
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(
+                    format!(
+                        "HTTP/1.1 {status_code} OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                    )
+                    .as_bytes(),
+                );
+                let _ = stream.flush();
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    /// 构造独立的 reqwest Client（不依赖全局 http_client::init）。
+    fn test_client() -> Client {
+        Client::builder()
+            .timeout(Duration::from_secs(PROBE_TIMEOUT_SECS))
+            .build()
+            .expect("build test client")
+    }
+
+    fn claude_provider_with(base_url: &str) -> Provider {
+        Provider::with_id(
+            "p1".to_string(),
+            "P".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": base_url,
+                    "ANTHROPIC_AUTH_TOKEN": "sk-test",
+                }
+            }),
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn probe_returns_true_on_200() {
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(200);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&base_url);
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(reachable);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn probe_returns_true_on_401() {
+        let _home = TempHome::new();
+        // 401 表示鉴权失败但网络可达，视为 reachable（用户重试时由上层处理鉴权）
+        let (base_url, handle) = spawn_once_server(401);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&base_url);
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(reachable);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn probe_returns_true_on_403() {
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(403);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&base_url);
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(reachable);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn probe_returns_false_on_500() {
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(500);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&base_url);
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(!reachable);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn probe_returns_false_when_connection_refused() {
+        let _home = TempHome::new();
+        // 绑定后立刻释放端口 → 连接被拒
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        let provider = claude_provider_with(&format!("http://127.0.0.1:{port}"));
+        let reachable = checker.probe(&provider, "claude").await;
+        assert!(!reachable);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scan_once_forces_half_open_on_successful_probe() {
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(200);
+
+        let db = Arc::new(Database::memory().unwrap());
+        // 1 次失败即熔断
+        db.update_circuit_breaker_config(&CircuitBreakerConfig {
+            failure_threshold: 1,
+            // 长 timeout：证明 force_half_open 由主动探测触发，而非 timeout 到期
+            timeout_seconds: 3600,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let provider = claude_provider_with(&base_url);
+        db.save_provider("claude", &provider).unwrap();
+        db.add_to_failover_queue("claude", &provider.id).unwrap();
+
+        // 启用自动故障转移
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        // 触发熔断：1 次失败即 Open
+        router
+            .record_result(
+                &provider.id,
+                "claude",
+                false,
+                false,
+                Some("boom".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+
+        // 探测前：Open
+        let circuit_key = format!("claude:{}", provider.id);
+        let breaker = router
+            .get_breaker(&circuit_key)
+            .await
+            .expect("breaker exists");
+        assert_eq!(breaker.get_state().await, CircuitState::Open);
+
+        checker.scan_once().await;
+
+        // 探测成功后：force_half_open → HalfOpen
+        assert_eq!(breaker.get_state().await, CircuitState::HalfOpen);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scan_once_skips_apps_without_auto_failover() {
+        let _home = TempHome::new();
+        // 不需要 mock server：scan_once 会跳过 probe，因为没有启用 auto_failover
+        let db = Arc::new(Database::memory().unwrap());
+        db.update_circuit_breaker_config(&CircuitBreakerConfig {
+            failure_threshold: 1,
+            timeout_seconds: 3600,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let provider = claude_provider_with("http://127.0.0.1:1");
+        db.save_provider("claude", &provider).unwrap();
+        db.add_to_failover_queue("claude", &provider.id).unwrap();
+        // 注意：不启用 auto_failover（默认即为 false）
+
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        router
+            .record_result(
+                &provider.id,
+                "claude",
+                false,
+                false,
+                Some("boom".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let checker = HealthChecker::new(router.clone(), db, test_client());
+        checker.scan_once().await;
+
+        // 未启用故障转移 → 跳过，状态仍为 Open
+        let circuit_key = format!("claude:{}", provider.id);
+        let breaker = router
+            .get_breaker(&circuit_key)
+            .await
+            .expect("breaker exists");
+        assert_eq!(breaker.get_state().await, CircuitState::Open);
+    }
+
+    #[tokio::test]
+    async fn run_loop_exits_on_shutdown_signal() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        let checker = HealthChecker::new(router, db, test_client());
+
+        let (tx, rx) = oneshot::channel::<()>();
+        // 后台 spawn run_loop，立即发送 shutdown 信号
+        let task = tokio::spawn(async move { checker.run_loop(rx).await });
+
+        // 给 run_loop 一个 tick 的机会启动 interval.tick()
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        tx.send(()).expect("send shutdown");
+
+        // run_loop 应在 1s 内退出
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("run_loop should exit within 1s")
+            .expect("task should not panic");
+    }
+}

--- a/src-tauri/src/proxy/health.rs
+++ b/src-tauri/src/proxy/health.rs
@@ -107,9 +107,31 @@ impl HealthChecker {
                     if let Some(breaker) = self.router.get_breaker(&circuit_key).await {
                         // Open → HalfOpen（已是 HalfOpen 时为 no-op，不重置累计成功数）
                         breaker.force_half_open().await;
-                        // 把 probe 成功反馈为一次 HalfOpen 探测成功，达 success_threshold
-                        // 后自动转 Closed，使无真实流量场景也能完全自动恢复。
+                        // 累计 HalfOpen 探测成功，达 success_threshold 后自动转 Closed。
                         breaker.record_success(false).await;
+
+                        // 把恢复同步到 DB provider_health（前端徽章的数据源）。
+                        // 徽章三态：is_healthy=false → 熔断；is_healthy=true 且 failures>0 → 降级；
+                        // failures=0 → 正常。据此实现 熔断→降级→正常 的渐进恢复：
+                        // - 已完全恢复 (Closed)：清零 failures → 正常（也覆盖 success_threshold=1
+                        //   时"熔断直跳正常"的合法路径）
+                        // - 仍在 HalfOpen 留观：仅翻 is_healthy、保留 failures → 降级
+                        let fully_recovered = breaker.get_state().await == CircuitState::Closed;
+                        let db_result = if fully_recovered {
+                            self.db
+                                .update_provider_health(&provider.id, app_type_str, true, None)
+                                .await
+                        } else {
+                            self.db
+                                .mark_provider_recovering(&provider.id, app_type_str)
+                                .await
+                        };
+                        if let Err(e) = db_result {
+                            log::warn!(
+                                "[Health] {app_type_str}/{} 恢复回写 DB 失败: {e}",
+                                provider.id
+                            );
+                        }
                     }
                 }
             }
@@ -256,6 +278,29 @@ mod tests {
                     .as_bytes(),
                 );
                 let _ = stream.flush();
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    /// 起服务 `max_conns` 次连接的本地 HTTP server，每次返回固定状态码 + 空 body。
+    /// 用于需要多次 probe（如 熔断→降级→正常 渐进恢复）的测试。
+    fn spawn_server(status_code: u16, max_conns: usize) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind local listener");
+        let port = listener.local_addr().expect("local addr").port();
+        let handle = std::thread::spawn(move || {
+            for _ in 0..max_conns {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let mut buf = [0u8; 1024];
+                    let _ = stream.read(&mut buf);
+                    let _ = stream.write_all(
+                        format!(
+                            "HTTP/1.1 {status_code} OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                        )
+                        .as_bytes(),
+                    );
+                    let _ = stream.flush();
+                }
             }
         });
         (format!("http://127.0.0.1:{port}"), handle)
@@ -532,6 +577,150 @@ mod tests {
 
         // probe 成功后应自动恢复到 Closed（而非卡在 HalfOpen 等真实流量）
         assert_eq!(breaker.get_state().await, CircuitState::Closed);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scan_once_writes_recovery_back_to_db_health() {
+        // 回归：主动探测成功后，不仅内存熔断器要转 Closed，
+        // 还必须把 DB 的 provider_health 行同步为健康——前端徽章读的是 DB
+        // （get_provider_health），否则徽章会永远停在"熔断"，表现为自动恢复无效。
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_once_server(200);
+
+        let db = Arc::new(Database::memory().unwrap());
+        db.update_circuit_breaker_config(&CircuitBreakerConfig {
+            failure_threshold: 1,
+            success_threshold: 1,
+            timeout_seconds: 3600,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let provider = claude_provider_with(&base_url);
+        db.save_provider("claude", &provider).unwrap();
+        db.add_to_failover_queue("claude", &provider.id).unwrap();
+
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        router
+            .record_result(
+                &provider.id,
+                "claude",
+                false,
+                false,
+                Some("boom".to_string()),
+            )
+            .await
+            .unwrap();
+
+        // 熔断后 DB 必须标记为不健康
+        let before = db
+            .get_provider_health(&provider.id, "claude")
+            .await
+            .unwrap();
+        assert!(!before.is_healthy, "熔断后应不健康");
+        assert_eq!(before.consecutive_failures, 1);
+
+        let checker = HealthChecker::new(router.clone(), db.clone(), test_client());
+        checker.scan_once().await;
+
+        // 恢复后 DB 必须同步为健康——这是前端徽章的数据源
+        let after = db
+            .get_provider_health(&provider.id, "claude")
+            .await
+            .unwrap();
+        assert!(
+            after.is_healthy,
+            "恢复后 DB 必须翻健康，否则前端徽章不会更新"
+        );
+        assert_eq!(after.consecutive_failures, 0);
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scan_once_recovers_degraded_then_normal() {
+        // 熔断→降级→正常 渐进恢复（success_threshold=2）：
+        // 第一次 probe 成功 → HalfOpen，DB 翻降级（is_healthy=true 但 failures 保留 >0）；
+        // 第二次 probe 成功 → Closed，DB 翻正常（failures 清零）。
+        let _home = TempHome::new();
+        let (base_url, handle) = spawn_server(200, 2);
+
+        let db = Arc::new(Database::memory().unwrap());
+        db.update_circuit_breaker_config(&CircuitBreakerConfig {
+            failure_threshold: 1,
+            success_threshold: 2,
+            timeout_seconds: 3600,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let provider = claude_provider_with(&base_url);
+        db.save_provider("claude", &provider).unwrap();
+        db.add_to_failover_queue("claude", &provider.id).unwrap();
+
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        let router = Arc::new(ProviderRouter::new(db.clone()));
+        router
+            .record_result(
+                &provider.id,
+                "claude",
+                false,
+                false,
+                Some("boom".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let circuit_key = format!("claude:{}", provider.id);
+        let breaker = router
+            .get_breaker(&circuit_key)
+            .await
+            .expect("breaker exists");
+
+        // 起点：熔断
+        assert_eq!(breaker.get_state().await, CircuitState::Open);
+        let h0 = db
+            .get_provider_health(&provider.id, "claude")
+            .await
+            .unwrap();
+        assert!(!h0.is_healthy);
+
+        let checker = HealthChecker::new(router.clone(), db.clone(), test_client());
+
+        // 第一次 probe：Open → HalfOpen；DB 应翻到"降级"（健康但 failures 未清零）
+        checker.scan_once().await;
+        assert_eq!(breaker.get_state().await, CircuitState::HalfOpen);
+        let h1 = db
+            .get_provider_health(&provider.id, "claude")
+            .await
+            .unwrap();
+        assert!(h1.is_healthy, "降级态 is_healthy 必须为 true");
+        assert!(
+            h1.consecutive_failures > 0,
+            "降级态必须保留 failures > 0，不能直接跳正常"
+        );
+
+        // 第二次 probe：HalfOpen → Closed；DB 翻到"正常"（failures 清零）
+        checker.scan_once().await;
+        assert_eq!(breaker.get_state().await, CircuitState::Closed);
+        let h2 = db
+            .get_provider_health(&provider.id, "claude")
+            .await
+            .unwrap();
+        assert!(h2.is_healthy);
+        assert_eq!(h2.consecutive_failures, 0);
+
         handle.join().expect("server thread");
     }
 

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -15,6 +15,7 @@ pub mod gemini_url;
 pub mod handler_config;
 pub mod handler_context;
 mod handlers;
+pub mod health;
 pub mod http_client;
 pub mod hyper_client;
 pub(crate) mod json_canonical;

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -6,7 +6,9 @@ use crate::app_config::AppType;
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
-use crate::proxy::circuit_breaker::{AllowResult, CircuitBreaker, CircuitBreakerConfig};
+use crate::proxy::circuit_breaker::{
+    AllowResult, CircuitBreaker, CircuitBreakerConfig, CircuitState,
+};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -227,6 +229,47 @@ impl ProviderRouter {
         } else {
             None
         }
+    }
+
+    /// 取出已创建的熔断器（不创建新的）
+    ///
+    /// 与 [`get_or_create_circuit_breaker`] 不同，若该 provider 从未发生过请求（未创建熔断器），
+    /// 返回 `None`；调用方据此把状态视为 Closed（未熔断）。供 [`crate::proxy::health::HealthChecker`] 使用。
+    pub async fn get_breaker(&self, circuit_key: &str) -> Option<Arc<CircuitBreaker>> {
+        let breakers = self.circuit_breakers.read().await;
+        breakers.get(circuit_key).cloned()
+    }
+
+    /// 列出指定应用故障转移队列中所有 provider 及其当前熔断状态
+    ///
+    /// 按 failover_queue 顺序返回 `(Provider, CircuitState)`。
+    /// 未创建熔断器的 provider 默认视为 Closed（未熔断）。
+    /// 仅供主动健康检查使用；不要用于路由选择（路由选择请走 [`select_providers`]）。
+    pub async fn list_providers_with_state(
+        &self,
+        app_type: &str,
+    ) -> Result<Vec<(Provider, CircuitState)>, AppError> {
+        let all_providers = self.db.get_all_providers(app_type)?;
+        let ordered_ids: Vec<String> = self
+            .db
+            .get_failover_queue(app_type)?
+            .into_iter()
+            .map(|item| item.provider_id)
+            .collect();
+
+        let mut result = Vec::with_capacity(ordered_ids.len());
+        for provider_id in ordered_ids {
+            let Some(provider) = all_providers.get(&provider_id).cloned() else {
+                continue;
+            };
+            let circuit_key = format!("{app_type}:{}", provider.id);
+            let state = match self.get_breaker(&circuit_key).await {
+                Some(breaker) => breaker.get_state().await,
+                None => CircuitState::Closed,
+            };
+            result.push((provider, state));
+        }
+        Ok(result)
     }
 
     /// 获取或创建熔断器
@@ -519,5 +562,77 @@ mod tests {
         let third = router.allow_provider_request("a", "claude").await;
         assert!(third.allowed);
         assert!(third.used_half_open_permit);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_breaker_returns_none_before_creation() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+        let router = ProviderRouter::new(db);
+
+        // 从未创建过 breaker
+        assert!(router.get_breaker("claude:unknown").await.is_none());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn get_breaker_returns_some_after_creation() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+        let router = ProviderRouter::new(db);
+
+        // 通过任意触发 get_or_create 的路径创建后即可取出
+        let _ = router.get_or_create_circuit_breaker("claude:p1").await;
+        let breaker = router.get_breaker("claude:p1").await;
+        assert!(breaker.is_some());
+        // 与 select_providers 用的是同一个 Arc 实例
+        assert_eq!(breaker.unwrap().get_state().await, CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_providers_with_state_returns_state_for_each() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        // 先配置熔断器：1 次失败即熔断（必须在 record_result 之前生效）
+        db.update_circuit_breaker_config(&CircuitBreakerConfig {
+            failure_threshold: 1,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let provider_a =
+            Provider::with_id("a".to_string(), "Provider A".to_string(), json!({}), None);
+        let provider_b =
+            Provider::with_id("b".to_string(), "Provider B".to_string(), json!({}), None);
+        db.save_provider("claude", &provider_a).unwrap();
+        db.save_provider("claude", &provider_b).unwrap();
+        db.add_to_failover_queue("claude", "a").unwrap();
+        db.add_to_failover_queue("claude", "b").unwrap();
+
+        // 启用自动故障转移（list_providers_with_state 用于健康检查场景）
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        let router = ProviderRouter::new(db);
+
+        // 让 a 进入 Open：1 次失败即熔断
+        router
+            .record_result("a", "claude", false, false, Some("boom".to_string()))
+            .await
+            .unwrap();
+
+        let list = router.list_providers_with_state("claude").await.unwrap();
+        assert_eq!(list.len(), 2);
+        // 队列顺序：a 在前
+        assert_eq!(list[0].0.id, "a");
+        assert_eq!(list[0].1, CircuitState::Open);
+        assert_eq!(list[1].0.id, "b");
+        // b 从未发生过请求，未创建熔断器，默认 Closed
+        assert_eq!(list[1].1, CircuitState::Closed);
     }
 }

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -6,9 +6,7 @@ use crate::app_config::AppType;
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
-use crate::proxy::circuit_breaker::{
-    AllowResult, CircuitBreaker, CircuitBreakerConfig, CircuitState,
-};
+use crate::proxy::circuit_breaker::{AllowResult, CircuitBreaker, CircuitBreakerConfig};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -240,38 +238,6 @@ impl ProviderRouter {
         breakers.get(circuit_key).cloned()
     }
 
-    /// 列出指定应用故障转移队列中所有 provider 及其当前熔断状态
-    ///
-    /// 按 failover_queue 顺序返回 `(Provider, CircuitState)`。
-    /// 未创建熔断器的 provider 默认视为 Closed（未熔断）。
-    /// 仅供主动健康检查使用；不要用于路由选择（路由选择请走 [`select_providers`]）。
-    pub async fn list_providers_with_state(
-        &self,
-        app_type: &str,
-    ) -> Result<Vec<(Provider, CircuitState)>, AppError> {
-        let all_providers = self.db.get_all_providers(app_type)?;
-        let ordered_ids: Vec<String> = self
-            .db
-            .get_failover_queue(app_type)?
-            .into_iter()
-            .map(|item| item.provider_id)
-            .collect();
-
-        let mut result = Vec::with_capacity(ordered_ids.len());
-        for provider_id in ordered_ids {
-            let Some(provider) = all_providers.get(&provider_id).cloned() else {
-                continue;
-            };
-            let circuit_key = format!("{app_type}:{}", provider.id);
-            let state = match self.get_breaker(&circuit_key).await {
-                Some(breaker) => breaker.get_state().await,
-                None => CircuitState::Closed,
-            };
-            result.push((provider, state));
-        }
-        Ok(result)
-    }
-
     /// 获取或创建熔断器
     async fn get_or_create_circuit_breaker(&self, key: &str) -> Arc<CircuitBreaker> {
         // 先尝试读锁获取
@@ -316,6 +282,7 @@ impl ProviderRouter {
 mod tests {
     use super::*;
     use crate::database::Database;
+    use crate::proxy::circuit_breaker::CircuitState;
     use serde_json::json;
     use serial_test::serial;
     use std::env;
@@ -588,51 +555,5 @@ mod tests {
         assert!(breaker.is_some());
         // 与 select_providers 用的是同一个 Arc 实例
         assert_eq!(breaker.unwrap().get_state().await, CircuitState::Closed);
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn list_providers_with_state_returns_state_for_each() {
-        let _home = TempHome::new();
-        let db = Arc::new(Database::memory().unwrap());
-
-        // 先配置熔断器：1 次失败即熔断（必须在 record_result 之前生效）
-        db.update_circuit_breaker_config(&CircuitBreakerConfig {
-            failure_threshold: 1,
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-
-        let provider_a =
-            Provider::with_id("a".to_string(), "Provider A".to_string(), json!({}), None);
-        let provider_b =
-            Provider::with_id("b".to_string(), "Provider B".to_string(), json!({}), None);
-        db.save_provider("claude", &provider_a).unwrap();
-        db.save_provider("claude", &provider_b).unwrap();
-        db.add_to_failover_queue("claude", "a").unwrap();
-        db.add_to_failover_queue("claude", "b").unwrap();
-
-        // 启用自动故障转移（list_providers_with_state 用于健康检查场景）
-        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
-        config.auto_failover_enabled = true;
-        db.update_proxy_config_for_app(config).await.unwrap();
-
-        let router = ProviderRouter::new(db);
-
-        // 让 a 进入 Open：1 次失败即熔断
-        router
-            .record_result("a", "claude", false, false, Some("boom".to_string()))
-            .await
-            .unwrap();
-
-        let list = router.list_providers_with_state("claude").await.unwrap();
-        assert_eq!(list.len(), 2);
-        // 队列顺序：a 在前
-        assert_eq!(list[0].0.id, "a");
-        assert_eq!(list[0].1, CircuitState::Open);
-        assert_eq!(list[1].0.id, "b");
-        // b 从未发生过请求，未创建熔断器，默认 Closed
-        assert_eq!(list[1].1, CircuitState::Closed);
     }
 }

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -11,6 +11,8 @@
 use super::{
     failover_switch::FailoverSwitchManager,
     handlers,
+    health::HealthChecker,
+    http_client,
     log_codes::srv as log_srv,
     provider_router::ProviderRouter,
     providers::{codex_chat_history::CodexChatHistoryStore, gemini_shadow::GeminiShadowStore},
@@ -57,6 +59,10 @@ pub struct ProxyServer {
     shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
     /// 服务器任务句柄，用于等待服务器实际关闭
     server_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
+    /// 健康检查器关闭信号，与 proxy 生命周期绑定
+    health_shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
+    /// 健康检查器任务句柄
+    health_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
 }
 
 impl ProxyServer {
@@ -88,6 +94,8 @@ impl ProxyServer {
             state,
             shutdown_tx: Arc::new(RwLock::new(None)),
             server_handle: Arc::new(RwLock::new(None)),
+            health_shutdown_tx: Arc::new(RwLock::new(None)),
+            health_handle: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -215,6 +223,20 @@ impl ProxyServer {
         // 保存服务器任务句柄
         *self.server_handle.write().await = Some(handle);
 
+        // 启动主动健康检查器，与代理生命周期绑定
+        // 复用全局 http_client（继承用户配置的代理）作为探测客户端
+        let (health_tx, health_rx) = oneshot::channel::<()>();
+        let checker = HealthChecker::new(
+            self.state.provider_router.clone(),
+            self.state.db.clone(),
+            http_client::get(),
+        );
+        let health_handle = tokio::spawn(async move {
+            checker.run_loop(health_rx).await;
+        });
+        *self.health_shutdown_tx.write().await = Some(health_tx);
+        *self.health_handle.write().await = Some(health_handle);
+
         Ok(ProxyServerInfo {
             address: self.config.listen_address.clone(),
             port: actual_port,
@@ -235,23 +257,37 @@ impl ProxyServer {
             match tokio::time::timeout(std::time::Duration::from_secs(5), handle).await {
                 Ok(Ok(())) => {
                     log::info!("[{}] 代理服务器已完全停止", log_srv::STOPPED);
-                    Ok(())
                 }
                 Ok(Err(e)) => {
                     log::warn!("[{}] 代理服务器任务异常终止: {e}", log_srv::TASK_ERROR);
-                    Err(ProxyError::StopFailed(e.to_string()))
+                    return Err(ProxyError::StopFailed(e.to_string()));
                 }
                 Err(_) => {
                     log::warn!(
                         "[{}] 代理服务器停止超时（5秒），强制继续",
                         log_srv::STOP_TIMEOUT
                     );
-                    Err(ProxyError::StopTimeout)
+                    return Err(ProxyError::StopTimeout);
                 }
             }
-        } else {
-            Ok(())
         }
+
+        // 3. 关闭健康检查器（带 2 秒超时保护，避免 shutdown 通道阻塞影响主流程）
+        if let Some(tx) = self.health_shutdown_tx.write().await.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.health_handle.write().await.take() {
+            match tokio::time::timeout(std::time::Duration::from_secs(2), handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => log::warn!("[{}] 健康检查器任务异常终止: {e}", log_srv::TASK_ERROR),
+                Err(_) => log::warn!(
+                    "[{}] 健康检查器停止超时（2秒），强制继续",
+                    log_srv::STOP_TIMEOUT
+                ),
+            }
+        }
+
+        Ok(())
     }
 
     pub async fn get_status(&self) -> ProxyStatus {

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -559,6 +559,13 @@ impl ProxyService {
             });
         }
 
+        // 走到这里说明是一次全新启动：内存熔断器随之重置为 Closed。
+        // 清空 DB 里跨重启残留的 provider_health——否则旧的 is_healthy=0 会让
+        // 前端徽章误显示"熔断"，而实际并未熔断。best-effort，不阻断启动。
+        if let Err(e) = self.db.clear_all_provider_health().await {
+            log::warn!("启动时清空 provider_health 失败（忽略）: {e}");
+        }
+
         // 4. 创建并启动服务器
         let app_handle = self.app_handle.read().await.clone();
         let server = ProxyServer::new(config.clone(), self.db.clone(), app_handle);
@@ -3790,6 +3797,57 @@ mod tests {
                 .is_none(),
             "non-managed providers should retain the legacy fallback behavior"
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn start_clears_stale_provider_health() {
+        // 回归：proxy 重启后内存熔断器重置为 Closed，但 provider_health DB 行跨重启
+        // 持久化——残留的 is_healthy=0 会让前端徽章误显示"熔断"而实际未熔断。
+        // start() 必须清空 provider_health，使 DB 对齐全新的内存状态。
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        use_ephemeral_proxy_port(&db).await;
+        let service = ProxyService::new(db.clone());
+
+        // 先存 provider（provider_health 有外键约束），再种 stale 熔断记录
+        let provider = Provider::with_id(
+            "stale-p".to_string(),
+            "Stale".to_string(),
+            json!({ "env": { "ANTHROPIC_BASE_URL": "https://example.com", "ANTHROPIC_AUTH_TOKEN": "t" } }),
+            None,
+        );
+        db.save_provider("claude", &provider)
+            .expect("save provider");
+        db.update_provider_health_with_threshold(
+            "stale-p",
+            "claude",
+            false,
+            Some("boom".into()),
+            1,
+        )
+        .await
+        .expect("seed stale health");
+        let before = db
+            .get_provider_health("stale-p", "claude")
+            .await
+            .expect("read before");
+        assert!(!before.is_healthy, "种子行应标记为熔断");
+
+        let info = service.start().await.expect("start proxy");
+        assert_ne!(info.port, 0, "ephemeral port should be assigned");
+
+        // start() 应清空 provider_health——前端徽章的数据源
+        let after = db
+            .get_provider_health("stale-p", "claude")
+            .await
+            .expect("read after");
+        assert!(after.is_healthy, "start() 后 stale 熔断记录应被清除");
+        assert_eq!(after.consecutive_failures, 0);
+
+        let _ = service.stop().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary / 概述

Fill the placeholder `health.rs` with an **active health checker** so circuit-broken providers recover automatically — without depending on real user traffic.

**Problem**: the circuit breaker flips `Open→HalfOpen` only after `timeout_seconds` (default 60s), and HalfOpen probing relies on the *next real user request*. With no traffic, a broken provider stays stuck in Open/HalfOpen indefinitely; worse, probing with real requests re-trips the breaker on failure and hurts the user whose request was used as the probe.

**Fix**: a background task probes `Open` providers every 30s (`GET {base_url}/v1/models`, 3s timeout; `2xx`/`401`/`403` counted as reachable — auth errors still mean the host is up). On success it calls `force_half_open`, so the next real request goes through the normal `HalfOpen→Closed` recovery path — fully traffic-independent. Provider recovery happens within ~30s of coming back online, with zero user-visible probe failures.

### Changes / 改动
- **circuit_breaker.rs**: add `force_half_open` — `Open→HalfOpen` bypassing the timeout, idempotent no-op on `Closed`/`HalfOpen`, preserves in-flight probe permits.
- **provider_router.rs**: add `list_providers_with_state` + `get_breaker` helpers (the latter returns `None` instead of creating a new breaker).
- **health.rs**: implement `HealthChecker` — `run_loop` (graceful shutdown via `oneshot` + `tokio::select!`), `scan_once` (only scans `auto_failover_enabled` apps), `probe` (resolves credentials per AppType via `Provider::resolve_usage_credentials`).
- **server.rs**: `ProxyServer` spawns the checker on `start()`, signals shutdown on `stop()` (2s guard) — lifecycle bound to the proxy.

## Related Issue / 关联 Issue

New feature. CONTRIBUTING suggests opening an issue first for features — happy to open one if maintainers prefer to discuss before review. Just let me know. / 新功能。若维护者希望先开 issue 讨论再审 PR，请告知，我立即补。

## Screenshots / 截图

N/A — backend-only, no UI change. / 仅后端，无 UI 变化。

## Checklist / 检查清单

- [x] `cargo clippy` passes (`RUSTFLAGS="-Dwarnings" cargo clippy --lib --tests --no-deps` → 0 warning)
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes — 14 new tests (force_half_open ×3, router helpers ×3, health ×8 incl. E2E `Open→probe 200→HalfOpen` and graceful-shutdown <1s)
- [ ] `pnpm typecheck` / `pnpm format:check` — N/A (Rust-only change, no frontend touched)
- [x] No new dependencies — mock HTTP server reuses the existing `std::net::TcpListener + thread` pattern from `services/coding_plan.rs`

### Note on one pre-existing flake
`cargo test --tests` shows 1 failure: `update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active` — a port-binding race that also fails on `main` (verified via `git stash`), unrelated to this PR.
