### PR TITLE
fix(hermes): use SOUL.md instead of AGENTS.md for Hermes prompt filename

### DIFF
--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -33,7 +33,8 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Claude => "CLAUDE.md",
         AppType::Codex => "AGENTS.md",
         AppType::Gemini => "GEMINI.md",
-        AppType::GrokBuild | AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => "AGENTS.md",
+        AppType::GrokBuild | AppType::OpenCode | AppType::OpenClaw => "AGENTS.md",
+        AppType::Hermes => "SOUL.md",
         AppType::ClaudeDesktop => unreachable!("handled above"),
     };
 

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -41,6 +41,21 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
     Ok(base_dir.join(filename))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hermes_prompt_file_uses_soul_md() {
+        let path = prompt_file_path(&AppType::Hermes).expect("Hermes prompt path");
+
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("SOUL.md")
+        );
+    }
+}
+
 fn get_base_dir_with_fallback(
     primary_path: PathBuf,
     fallback_dir: &str,

--- a/src/components/prompts/PromptFormPanel.tsx
+++ b/src/components/prompts/PromptFormPanel.tsx
@@ -32,7 +32,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
     grokbuild: "AGENTS.md",
     opencode: "AGENTS.md",
     openclaw: "AGENTS.md",
-    hermes: "AGENTS.md",
+    hermes: "SOUL.md",
   };
   const filename = filenameMap[appId];
   const [name, setName] = useState("");


### PR DESCRIPTION
## Summary / 概述

修复 Hermes Prompt 模板的默认文件名：`AGENTS.md` → `SOUL.md`。
Hermes 使用 SOUL.md 作为 agent 身份文件，
见 NousResearch/hermes-agent 官方文档。

## Related Issue / 关联 Issue

Fixes #5777

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 不适用（代码常量修改） | 不适用 |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes（无 Rust 改动）
- [x] Updated i18n files（无用户可见文本改动）
