### PR TITLE
fix(hermes): add prompts management button to Hermes toolbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1434,6 +1434,15 @@ function App() {
                               <Button
                                 variant="ghost"
                                 size="sm"
+                                onClick={() => setCurrentView("prompts")}
+                                className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                title={t("prompts.manage")}
+                              >
+                                <Book className="w-4 h-4" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
                                 onClick={() => setCurrentView("hermesMemory")}
                                 className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
                                 title={t("hermes.memory.title")}


### PR DESCRIPTION
## Summary / 概述

为 Hermes 工具栏添加 Prompts（📖）管理按钮。
Claude、Codex、OpenCode 等 agent type 均有此按钮，
唯独 Hermes 缺失，导致用户无法在 UI 中管理 SOUL.md 提示词模板。

## Related Issue / 关联 Issue

Fixes #5778

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| <img width="738" height="72" alt="image" src="https://github.com/user-attachments/assets/470e79c5-c44b-4d05-bcbd-2164f8599c39" /> | <img width="687" height="124" alt="image" src="https://github.com/user-attachments/assets/4ad5aea6-cdcb-4a71-84a3-4dee58e8ea86" /> |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes（无 Rust 改动）
- [x] Updated i18n files（无用户可见文本改动）