### PR TITLE
fix(provider): preserve live common config on add/update/sync/reapply write paths

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1264,6 +1264,7 @@ pub(crate) fn sync_current_provider_for_app_to_live(
 
         let providers = state.db.get_all_providers(app_type.as_str())?;
         if let Some(provider) = providers.get(&current_id) {
+            let _ = sync_common_config_snippet_from_live_simple(state, app_type, provider);
             write_live_with_common_config(state.db.as_ref(), app_type, provider)?;
         }
     }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -695,6 +695,56 @@ pub(crate) fn build_effective_settings_with_common_config(
     Ok(effective_settings)
 }
 
+/// Re-extract the common-config snippet from the current live settings and
+/// persist it to the DB, so a subsequent [`write_live_with_common_config`]
+/// preserves live-side changes to whitelisted common fields.
+///
+/// Thin, `SwitchResult`-free sibling of
+/// [`ProviderService::sync_common_config_snippet_from_live`]: reads live
+/// once, delegates to the shared `_core`, and logs any warnings via
+/// `log::warn!` (non-switch paths have no `SwitchResult` to carry them in).
+///
+/// No-op for additive-mode apps (they don't use common-config snippets —
+/// matches the switch path's scope guard). Respects the user's explicit
+/// `_cleared` flag. All failures are non-fatal: log a warning and return
+/// `Ok(())`, never blocking the caller's write (same contract as the switch
+/// path).
+pub(crate) fn sync_common_config_snippet_from_live_simple(
+    state: &AppState,
+    app_type: &AppType,
+    provider: &Provider,
+) -> Result<(), AppError> {
+    if app_type.is_additive_mode() {
+        return Ok(());
+    }
+    let live_config = match read_live_settings(app_type.clone()) {
+        Ok(v) => v,
+        Err(err) => {
+            log::warn!(
+                "Failed to read live settings for {} pre-write common-config sync: {err}",
+                app_type.as_str()
+            );
+            return Ok(());
+        }
+    };
+    let mut warnings: Vec<String> = Vec::new();
+    crate::services::provider::ProviderService::sync_common_config_snippet_from_live_core(
+        state,
+        app_type,
+        provider,
+        &live_config,
+        &mut warnings,
+    );
+    for w in warnings {
+        log::warn!(
+            "common-config pre-write sync ({}, provider '{}'): {w}",
+            app_type.as_str(),
+            provider.id
+        );
+    }
+    Ok(())
+}
+
 pub(crate) fn write_live_with_common_config(
     db: &Database,
     app_type: &AppType,

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1316,6 +1316,7 @@ fn sync_current_provider_for_app_respecting_takeover(
         return Ok(());
     }
 
+    let _ = sync_common_config_snippet_from_live_simple(state, app_type, provider);
     write_live_with_common_config(state.db.as_ref(), app_type, provider)
 }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2346,7 +2346,8 @@ impl ProviderService {
                     }
                 }
             } else {
-                let _ = live::sync_common_config_snippet_from_live_simple(state, &app_type, &provider);
+                let _ =
+                    live::sync_common_config_snippet_from_live_simple(state, &app_type, &provider);
                 write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
                 // 重写 live 后只重投影本应用的 MCP：全量 sync_all_enabled 会把
                 // 无关应用的 live 损坏（如 ~/.claude.json 坏 JSON）牵连进保存

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2922,7 +2922,7 @@ impl ProviderService {
     ///
     /// Scope, opt-in, `_cleared` guard, and "skip when unchanged" semantics
     /// are identical to the switch path — see the doc on the wrapper.
-    fn sync_common_config_snippet_from_live_core(
+    pub(crate) fn sync_common_config_snippet_from_live_core(
         state: &AppState,
         app_type: &AppType,
         provider: &Provider,

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2128,6 +2128,7 @@ impl ProviderService {
             state
                 .db
                 .set_current_provider(app_type.as_str(), &provider.id)?;
+            let _ = live::sync_common_config_snippet_from_live_simple(state, &app_type, &provider);
             write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
         }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -89,6 +89,7 @@ pub fn reapply_current_codex_official_live(state: &AppState) -> Result<bool, App
         return Ok(true);
     }
 
+    let _ = live::sync_common_config_snippet_from_live_simple(state, &AppType::Codex, provider);
     live::write_live_with_common_config(&state.db, &AppType::Codex, provider)?;
     // 重写 live 会整体替换 config.toml（有意设计），[mcp_servers] 随之丢失，
     // 写完必须立刻从 DB 重新投影启用的 MCP。只投影 Codex 而非
@@ -2345,6 +2346,7 @@ impl ProviderService {
                     }
                 }
             } else {
+                let _ = live::sync_common_config_snippet_from_live_simple(state, &app_type, &provider);
                 write_live_with_common_config(state.db.as_ref(), &app_type, &provider)?;
                 // 重写 live 后只重投影本应用的 MCP：全量 sync_all_enabled 会把
                 // 无关应用的 live 损坏（如 ~/.claude.json 坏 JSON）牵连进保存

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2905,6 +2905,30 @@ impl ProviderService {
         live_config: &Value,
         result: &mut SwitchResult,
     ) {
+        Self::sync_common_config_snippet_from_live_core(
+            state,
+            app_type,
+            provider,
+            live_config,
+            &mut result.warnings,
+        );
+    }
+
+    /// Core of [`sync_common_config_snippet_from_live`]: re-extract the
+    /// common-config snippet from `live_config` and persist it to the DB,
+    /// pushing any non-fatal warnings into `warnings`. Shared by the switch
+    /// path (via the wrapper above) and the pre-write sync helper in
+    /// `live.rs` (which has no `SwitchResult`).
+    ///
+    /// Scope, opt-in, `_cleared` guard, and "skip when unchanged" semantics
+    /// are identical to the switch path — see the doc on the wrapper.
+    fn sync_common_config_snippet_from_live_core(
+        state: &AppState,
+        app_type: &AppType,
+        provider: &Provider,
+        live_config: &Value,
+        warnings: &mut Vec<String>,
+    ) {
         // 作用域限定 Claude + Codex（见函数文档）。
         if !matches!(app_type, AppType::Claude | AppType::Codex) {
             return;
@@ -2965,9 +2989,7 @@ impl ProviderService {
                 app_type.as_str(),
                 provider.id
             );
-            result
-                .warnings
-                .push(format!("common_config_sync_failed:{}", provider.id));
+            warnings.push(format!("common_config_sync_failed:{}", provider.id));
         }
     }
 

--- a/src-tauri/tests/common_config_sync_nonswitch.rs
+++ b/src-tauri/tests/common_config_sync_nonswitch.rs
@@ -74,15 +74,13 @@ fn add_new_provider_preserves_live_statusline_via_common_config() {
     let state = create_test_state_with_config(&config).expect("create test state");
 
     // No current provider → add() takes the `current.is_none()` branch and writes live.
-    ProviderService::add(&state, AppType::Claude, provider.clone(), true)
-        .expect("add provider");
+    ProviderService::add(&state, AppType::Claude, provider.clone(), true).expect("add provider");
 
     // The shared statusLine must survive the write, sourced from the refreshed snippet.
     let live_after: serde_json::Value =
         read_json_file(&get_claude_settings_path()).expect("read live after add");
     assert_eq!(
-        live_after["statusLine"]["command"],
-        "node /custom/statusline.mjs",
+        live_after["statusLine"]["command"], "node /custom/statusline.mjs",
         "add() must preserve the live-side shared statusLine via pre-write snippet sync"
     );
 }
@@ -107,14 +105,12 @@ fn update_current_provider_preserves_live_statusline_via_common_config() {
     let state = create_test_state_with_config(&config).expect("create test state");
 
     // update() with no takeover → takes the `else` branch and writes live.
-    ProviderService::update(&state, AppType::Claude, None, provider)
-        .expect("update provider");
+    ProviderService::update(&state, AppType::Claude, None, provider).expect("update provider");
 
     let live_after: serde_json::Value =
         read_json_file(&get_claude_settings_path()).expect("read live after update");
     assert_eq!(
-        live_after["statusLine"]["command"],
-        "node /custom/statusline.mjs",
+        live_after["statusLine"]["command"], "node /custom/statusline.mjs",
         "update() must preserve the live-side shared statusLine via pre-write snippet sync"
     );
 }

--- a/src-tauri/tests/common_config_sync_nonswitch.rs
+++ b/src-tauri/tests/common_config_sync_nonswitch.rs
@@ -1,0 +1,88 @@
+use serde_json::json;
+
+use cc_switch_lib::{
+    get_claude_settings_path, read_json_file, AppType, MultiAppConfig, Provider, ProviderMeta,
+    ProviderService,
+};
+
+#[path = "support.rs"]
+mod support;
+use support::{create_test_state_with_config, ensure_test_home, reset_test_fs, test_mutex};
+
+/// Seed `~/.claude/settings.json` with a live settings blob carrying a
+/// distinctive `statusLine` — a *shared* config field that the common-config
+/// snippet is meant to carry — plus provider-specific env keys (model + key)
+/// that the extractor strips. The provider's own `settings_config` will NOT
+/// carry this statusLine, so it only survives the write if the snippet is
+/// refreshed from live before the write (the pre-write sync under test).
+fn seed_dirty_claude_live(statusline_command: &str) {
+    let live = json!({
+        "env": {
+            "ANTHROPIC_MODEL": "live-model-not-shared",
+            "ANTHROPIC_API_KEY": "live-key-not-shared"
+        },
+        "statusLine": { "command": statusline_command, "type": "command" }
+    });
+    let settings_path = get_claude_settings_path();
+    std::fs::create_dir_all(settings_path.parent().expect("settings dir")).expect("create dir");
+    std::fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&live).expect("serialize live"),
+    )
+    .expect("write live settings");
+}
+
+/// A Claude provider opted into common-config sharing, whose `settings_config`
+/// holds provider-specific env (model + key) but NO `statusLine`. The
+/// statusLine only reaches live through the common-config snippet.
+fn claude_provider_with_common_config(provider_id: &str) -> Provider {
+    let mut provider = Provider::with_id(
+        provider_id.to_string(),
+        provider_id.to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_API_KEY": "provider-key",
+                "ANTHROPIC_MODEL": "provider-model"
+            }
+        }),
+        None,
+    );
+    provider.meta = Some(ProviderMeta {
+        common_config_enabled: Some(true),
+        ..ProviderMeta::default()
+    });
+    provider
+}
+
+#[test]
+fn add_new_provider_preserves_live_statusline_via_common_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    // Live has a statusLine the provider's settings_config does not carry.
+    seed_dirty_claude_live("node /custom/statusline.mjs");
+
+    let mut config = MultiAppConfig::default();
+    let provider = claude_provider_with_common_config("p1");
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.providers.insert("p1".to_string(), provider.clone());
+    }
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    // No current provider → add() takes the `current.is_none()` branch and writes live.
+    ProviderService::add(&state, AppType::Claude, provider.clone(), true)
+        .expect("add provider");
+
+    // The shared statusLine must survive the write, sourced from the refreshed snippet.
+    let live_after: serde_json::Value =
+        read_json_file(&get_claude_settings_path()).expect("read live after add");
+    assert_eq!(
+        live_after["statusLine"]["command"],
+        "node /custom/statusline.mjs",
+        "add() must preserve the live-side shared statusLine via pre-write snippet sync"
+    );
+}

--- a/src-tauri/tests/common_config_sync_nonswitch.rs
+++ b/src-tauri/tests/common_config_sync_nonswitch.rs
@@ -148,6 +148,40 @@ fn sync_current_provider_to_live_preserves_live_statusline_via_common_config() {
 }
 
 #[test]
+fn global_sync_current_to_live_preserves_live_statusline_via_common_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    seed_dirty_claude_live("node /custom/statusline.mjs");
+
+    let mut config = MultiAppConfig::default();
+    let provider = claude_provider_with_common_config("p1");
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert("p1".to_string(), provider);
+    }
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    // Global entry point (manual "sync current providers" command and
+    // post-import sync) routes switch-mode apps through
+    // sync_current_provider_for_app_respecting_takeover, whose non-takeover
+    // branch must also refresh the snippet before writing.
+    ProviderService::sync_current_to_live(&state).expect("global sync current to live");
+
+    let live_after: serde_json::Value =
+        read_json_file(&get_claude_settings_path()).expect("read live after global sync");
+    assert_eq!(
+        live_after["statusLine"]["command"],
+        "node /custom/statusline.mjs",
+        "sync_current_to_live must preserve the live-side shared statusLine via pre-write snippet sync"
+    );
+}
+
+#[test]
 fn reapply_codex_official_preserves_live_shared_config_field() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/src-tauri/tests/common_config_sync_nonswitch.rs
+++ b/src-tauri/tests/common_config_sync_nonswitch.rs
@@ -1,8 +1,8 @@
 use serde_json::json;
 
 use cc_switch_lib::{
-    get_claude_settings_path, read_json_file, AppType, MultiAppConfig, Provider, ProviderMeta,
-    ProviderService,
+    get_claude_settings_path, get_codex_config_path, read_json_file, write_codex_live_atomic,
+    AppType, MultiAppConfig, Provider, ProviderMeta, ProviderService,
 };
 
 #[path = "support.rs"]
@@ -84,5 +84,177 @@ fn add_new_provider_preserves_live_statusline_via_common_config() {
         live_after["statusLine"]["command"],
         "node /custom/statusline.mjs",
         "add() must preserve the live-side shared statusLine via pre-write snippet sync"
+    );
+}
+
+#[test]
+fn update_current_provider_preserves_live_statusline_via_common_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    seed_dirty_claude_live("node /custom/statusline.mjs");
+
+    let mut config = MultiAppConfig::default();
+    let provider = claude_provider_with_common_config("p1");
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert("p1".to_string(), provider.clone());
+    }
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    // update() with no takeover → takes the `else` branch and writes live.
+    ProviderService::update(&state, AppType::Claude, None, provider)
+        .expect("update provider");
+
+    let live_after: serde_json::Value =
+        read_json_file(&get_claude_settings_path()).expect("read live after update");
+    assert_eq!(
+        live_after["statusLine"]["command"],
+        "node /custom/statusline.mjs",
+        "update() must preserve the live-side shared statusLine via pre-write snippet sync"
+    );
+}
+
+#[test]
+fn sync_current_provider_to_live_preserves_live_statusline_via_common_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    seed_dirty_claude_live("node /custom/statusline.mjs");
+
+    let mut config = MultiAppConfig::default();
+    let provider = claude_provider_with_common_config("p1");
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Claude)
+            .expect("claude manager");
+        manager.current = "p1".to_string();
+        manager.providers.insert("p1".to_string(), provider);
+    }
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    // No takeover → sync_current_provider_for_app reaches the non-takeover write.
+    ProviderService::sync_current_provider_for_app(&state, AppType::Claude)
+        .expect("sync current provider");
+
+    let live_after: serde_json::Value =
+        read_json_file(&get_claude_settings_path()).expect("read live after sync");
+    assert_eq!(
+        live_after["statusLine"]["command"],
+        "node /custom/statusline.mjs",
+        "sync_current_provider_for_app must preserve the live-side shared statusLine via pre-write snippet sync"
+    );
+}
+
+#[test]
+fn reapply_codex_official_preserves_live_shared_config_field() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    // Seed Codex live (auth.json + config.toml) with a shared field
+    // (model_reasoning_effort) that the extractor keeps but the provider's
+    // settings_config does not carry.
+    let live_auth = json!({
+        "auth_mode": "chatgpt",
+        "OPENAI_API_KEY": null,
+        "tokens": { "access_token": "official-oauth-token", "account_id": "acct" }
+    });
+    write_codex_live_atomic(&live_auth, Some("model_reasoning_effort = \"high\"\n"))
+        .expect("seed codex live with shared field");
+
+    let mut config = MultiAppConfig::default();
+    {
+        let manager = config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        let mut official = Provider::with_id(
+            "official-provider".to_string(),
+            "Official".to_string(),
+            json!({
+                "auth": {
+                    "auth_mode": "chatgpt",
+                    "OPENAI_API_KEY": null,
+                    "tokens": { "access_token": "official-oauth-token", "account_id": "acct" }
+                },
+                "config": ""
+            }),
+            None,
+        );
+        official.category = Some("official".to_string());
+        official.meta = Some(ProviderMeta {
+            common_config_enabled: Some(true),
+            ..ProviderMeta::default()
+        });
+        manager.current = "official-provider".to_string();
+        manager
+            .providers
+            .insert("official-provider".to_string(), official);
+    }
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    cc_switch_lib::reapply_current_codex_official_live(&state).expect("reapply official live");
+
+    let live_toml =
+        std::fs::read_to_string(get_codex_config_path()).expect("read config.toml after reapply");
+    assert!(
+        live_toml.contains("model_reasoning_effort"),
+        "reapply must preserve the live-side Codex shared field via pre-write snippet sync, got: {live_toml}"
+    );
+}
+
+#[test]
+fn sync_simple_is_noop_for_additive_mode_app() {
+    // Additive-mode apps (OpenCode/OpenClaw) don't use common-config snippets;
+    // the helper must no-op without touching the snippet DB or live file.
+    // Mirrors the switch path's Claude+Codex-only scope guard.
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let mut config = MultiAppConfig::default();
+    let provider = Provider::with_id(
+        "opencode-p1".to_string(),
+        "OpenCode P1".to_string(),
+        json!({}),
+        None,
+    );
+    {
+        let manager = config
+            .get_manager_mut(&AppType::OpenCode)
+            .expect("opencode manager");
+        manager.current = "opencode-p1".to_string();
+        manager
+            .providers
+            .insert("opencode-p1".to_string(), provider.clone());
+    }
+    let state = create_test_state_with_config(&config).expect("create test state");
+
+    // Pre-set a snippet so we can detect if the helper wrongly overwrites it.
+    state
+        .db
+        .set_config_snippet(
+            AppType::OpenCode.as_str(),
+            Some(r#"{"marker":"preset"}"#.to_string()),
+        )
+        .expect("set preset snippet");
+
+    // Drive the OpenCode sync path — additive mode, helper must no-op.
+    ProviderService::sync_current_provider_for_app(&state, AppType::OpenCode)
+        .expect("sync opencode current provider");
+
+    let snippet = state
+        .db
+        .get_config_snippet(AppType::OpenCode.as_str())
+        .expect("get snippet")
+        .expect("snippet present");
+    assert!(
+        snippet.contains("preset"),
+        "additive-mode sync must not touch the common-config snippet, got: {snippet}"
     );
 }


### PR DESCRIPTION
Closes #3631

## Summary / 概述

`write_live_with_common_config` merges `provider.settings_config` with the DB common-config snippet and rewrites the whole live file. The snippet carries *shared* config (`statusLine`, `enabledPlugins`, `hooks`, `permissions`, non-sensitive custom env — `extract_*_common_config` strips provider-specific model/endpoint keys and credentials, keeping the rest). On `main`, only the **switch** path refreshes the snippet from live before writing (`sync_common_config_snippet_from_live`, added in the 7-08 autosync work). The other **4 non-switch write paths** reuse a stale snippet, so shared config the user changed in-app gets overwritten by `provider.settings_config` (which doesn't carry those keys) and is lost.

`write_live_with_common_config` 把 `provider.settings_config` 与数据库中的 common-config snippet 合并后整文件重写 live。snippet 承载**共享配置**（`statusLine`、`enabledPlugins`、`hooks`、`permissions`、非敏感自定义 env——`extract_*_common_config` 会剥掉 provider 专属的模型/端点键与凭据，保留其余）。当前 `main` 上只有 **switch 路径**在写盘前从 live 刷新 snippet（7-08 的 autosync 改动新增的 `sync_common_config_snippet_from_live`）。另外 **4 条非 switch 写盘路径**仍用陈旧 snippet，导致用户在应用内改的共享配置被 `provider.settings_config`（不含这些键）整文件覆盖丢失。

> **Note**: Supersedes #3728 (closed). #3728 took a "wrap the write function" approach against an older `main` and diverged from the autosync architecture `main` has since adopted (`ProviderService` method + inline switch-path sync + `SwitchResult`), leaving it `mergeable_state=dirty`. This PR redoes the fix along `main`'s current route with zero conflict. `main` 已合入 switch 路径的 sync（#3728 的 Bug 2/3 在 switch 路径上已解决），本 PR 补齐其余 4 条非 switch 写盘路径。

### The gap / 缺口

The write paths that call `write_live_with_common_config` without a preceding snippet refresh:

调用 `write_live_with_common_config` 但写盘前未刷新 snippet 的路径：

- `ProviderService::add` — the `current.is_none()` branch (exclusive-mode new provider)
- `ProviderService::update` — the non-takeover `is_current` else branch
- `sync_current_provider_for_app_to_live` (`live.rs`) — the non-additive branch (startup-restore / manual sync / takeover-release)
- `reapply_current_codex_official_live` — the non-takeover Codex branch

### The fix / 修复内容

1. **Refactor**: extract the body of `sync_common_config_snippet_from_live` into `sync_common_config_snippet_from_live_core(state, app_type, provider, live_config, &mut Vec<String>)`; the original becomes a two-line delegate. Switch-path behavior is byte-identical. / 把 `sync_common_config_snippet_from_live` 的 body 抽到 `_core`，原方法变两行委托，switch 路径行为字节不变。

2. **New thin helper**: `sync_common_config_snippet_from_live_simple(state, app_type, provider)` in `live.rs` — no-op for additive-mode apps; otherwise reads live once, delegates to `_core`, and routes warnings through `log::warn!`. Read/extract failures are non-fatal (warn + return `Ok`), never blocking the write — same contract as the switch path. / 新增无 `SwitchResult` 的薄 helper：additive 应用直接 no-op；否则读一次 live → 委托 `_core` → warnings 走 `log::warn!`。read/extract 失败均非致命（记 warn + 返回 Ok，绝不阻断写盘），与 switch 路径同一契约。

3. **Wire the 4 paths**: one line before each `write_live_with_common_config` call. Takeover/proxy branches, the switch path, MCP per-app projection, and the whitelist are all untouched (`statusLine` etc. already enter the snippet — no whitelist change needed). / 4 条路径写盘前各 +1 行调用；takeover/proxy 分支、switch 路径、MCP per-app 投影、白名单均不动（`statusLine` 等本就进 snippet，无需改白名单）。

## Related Issue / 关联 Issue

Closes #3631

Supersedes #3728 (closed)

Complements the `settings.local.json` workaround discussed in #3631 (that one is a zero-code, project-scoped self-help; this is the code-side root fix covering all non-switch write paths). / 与 #3631 中讨论的 `settings.local.json` workaround 互补（那是用户侧零侵入自救，仅项目级生效；本 PR 是代码侧根治，覆盖全部非 switch 写盘路径）。

## Screenshots / 截图

不适用（Rust 后端逻辑修复，无 UI 变化）/ N/A (Rust backend logic fix, no UI change)

## Checklist / 检查清单

- [x] 无前端 TypeScript 修改，`pnpm typecheck` 不适用
- [x] 无前端代码修改，`pnpm format:check` 不适用
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] 无用户可见文本修改，国际化文件无需更新

## Note on Tests / 测试说明

New regression test file `src-tauri/tests/common_config_sync_nonswitch.rs` with 5 tests:

新增回归测试文件 `src-tauri/tests/common_config_sync_nonswitch.rs`，含 5 个测试：

- `add` / `update` / `sync_current_provider_for_app` (Claude): seed a dirty live with a distinctive `statusLine`, assert it survives the save via pre-write sync. / seed 带 distinctive `statusLine` 的 dirty live，断言 statusLine 经 pre-write sync 存活。
- `reapply` (Codex): seed `config.toml` with the extractor-retained shared key `model_reasoning_effort`, assert it survives. / seed config.toml 含提取器保留的共享键 `model_reasoning_effort`，断言存活。
- Negative (OpenCode, additive mode): the snippet is untouched (no-op). / 负向：OpenCode（additive）snippet 不被触碰。

Full verification / 完整验证:

- `cargo test`: **2183 unit + all integration tests, 0 failures** (incl. the switch-path regressions in `provider_service`, e.g. `switch_claude_syncs_*_into_common_config`, `switch_claude_respects_explicitly_cleared_common_config`). / 全套 `cargo test`：2183 单元 + 全部集成测试 0 失败（含 `provider_service` 的 switch 路径回归）。
- `cargo clippy --all-targets -- -D warnings`: clean / 干净
- `cargo fmt --check`: clean / 干净

Co-authored-by: Qwen3.8-Max-Preview <noreply@qwen.ai>