### PR TITLE
feat: support multiple active Codex prompts

### DIFF
--- a/src-tauri/src/services/profile.rs
+++ b/src-tauri/src/services/profile.rs
@@ -9,7 +9,7 @@
 //! - 供应商：`ProviderService::switch`（内建代理接管热切换与接管下禁切官方）
 //! - MCP：`McpService::toggle_app`（改标志 + 单 server 物化）
 //! - Skills：`SkillService::toggle_app`（改标志 + 单 skill 物化）
-//! - Prompt：`PromptService::enable_prompt`（互斥激活 + 原子写 live）
+//! - Prompt：`PromptService::enable_prompt`（启用并原子写入 live 文件）
 //!
 //! apply 为 best-effort：单项失败收集为 warning 继续，不整体回滚。
 
@@ -94,6 +94,36 @@ pub struct PerApp<T> {
     pub codex: T,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum PromptIds {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl PromptIds {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            Self::Single(id) => vec![id],
+            Self::Multiple(ids) => ids,
+        }
+    }
+}
+
+fn deserialize_prompt_slots<'de, D>(
+    deserializer: D,
+) -> Result<PerApp<Option<Vec<String>>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let prompt_slots = PerApp::<Option<PromptIds>>::deserialize(deserializer)?;
+    Ok(PerApp {
+        claude: prompt_slots.claude.map(PromptIds::into_vec),
+        claude_desktop: prompt_slots.claude_desktop.map(PromptIds::into_vec),
+        codex: prompt_slots.codex.map(PromptIds::into_vec),
+    })
+}
+
 impl<T> PerApp<T> {
     pub fn get(&self, app: &AppType) -> Option<&T> {
         match app {
@@ -128,8 +158,9 @@ pub struct ProfilePayload {
     pub mcp: PerApp<Option<Vec<String>>>,
     /// 每 app 启用的 Skill id 集合
     pub skills: PerApp<Option<Vec<String>>>,
-    /// 每 app 激活的 prompt id
-    pub prompts: PerApp<Option<String>>,
+    /// 每 app 激活的 prompt id；反序列化时兼容旧版的单个字符串。
+    #[serde(deserialize_with = "deserialize_prompt_slots")]
+    pub prompts: PerApp<Option<Vec<String>>>,
 }
 
 impl ProfilePayload {
@@ -225,12 +256,14 @@ impl ProfileService {
                 );
             }
             if let Some(slot) = payload.prompts.get_mut(app) {
-                *slot = state
+                let enabled = state
                     .db
                     .get_prompts(app.as_str())?
                     .values()
-                    .find(|p| p.enabled)
-                    .map(|p| p.id.clone());
+                    .filter(|p| p.enabled)
+                    .map(|p| p.id.clone())
+                    .collect::<Vec<_>>();
+                *slot = Some(enabled);
             }
         }
         Ok(payload)
@@ -434,20 +467,37 @@ impl ProfileService {
             }
 
             // 5. Prompt（None = 不动；已激活则幂等跳过，避免无谓的文件写与备份）
-            if let Some(Some(target_prompt)) = payload.prompts.get(app) {
+            if let Some(Some(target_prompts)) = payload.prompts.get(app) {
                 let prompts = state.db.get_prompts(app_str)?;
-                match prompts.get(target_prompt) {
-                    None => warnings.push(format!(
-                        "[{app_str}] prompt '{target_prompt}' no longer exists, skipped"
-                    )),
-                    Some(p) if p.enabled => {}
-                    Some(_) => {
+                let target_ids: std::collections::HashSet<&str> =
+                    target_prompts.iter().map(String::as_str).collect();
+
+                for (id, prompt) in prompts.iter() {
+                    if prompt.enabled && !target_ids.contains(id.as_str()) {
+                        let mut disabled = prompt.clone();
+                        disabled.enabled = false;
                         if let Err(e) =
-                            PromptService::enable_prompt(state, app.clone(), target_prompt)
+                            PromptService::upsert_prompt(state, app.clone(), id, disabled)
                         {
-                            warnings.push(format!(
-                                "[{app_str}] enable prompt '{target_prompt}' failed: {e}"
-                            ));
+                            warnings.push(format!("[{app_str}] disable prompt '{id}' failed: {e}"));
+                        }
+                    }
+                }
+
+                for target_prompt in target_prompts {
+                    match prompts.get(target_prompt) {
+                        None => warnings.push(format!(
+                            "[{app_str}] prompt '{target_prompt}' no longer exists, skipped"
+                        )),
+                        Some(p) if p.enabled => {}
+                        Some(_) => {
+                            if let Err(e) =
+                                PromptService::enable_prompt(state, app.clone(), target_prompt)
+                            {
+                                warnings.push(format!(
+                                    "[{app_str}] enable prompt '{target_prompt}' failed: {e}"
+                                ));
+                            }
                         }
                     }
                 }
@@ -494,7 +544,7 @@ mod tests {
             prompts: PerApp {
                 claude: None,
                 claude_desktop: None,
-                codex: Some("pr1".into()),
+                codex: Some(vec!["pr1".into()]),
             },
         };
         let json = serde_json::to_string(&payload).unwrap();
@@ -523,6 +573,17 @@ mod tests {
 
         let empty: ProfilePayload = serde_json::from_str("{}").unwrap();
         assert_eq!(empty, ProfilePayload::default());
+    }
+
+    #[test]
+    fn test_payload_accepts_legacy_single_prompt_ids() {
+        let payload: ProfilePayload = serde_json::from_str(
+            r#"{"prompts":{"claude":"legacy-prompt","codex":["first","second"]}}"#,
+        )
+        .expect("legacy prompt payload should deserialize");
+
+        assert_eq!(payload.prompts.claude, Some(ids(&["legacy-prompt"])));
+        assert_eq!(payload.prompts.codex, Some(ids(&["first", "second"])));
     }
 
     #[test]
@@ -591,7 +652,7 @@ mod tests {
 
     #[test]
     fn test_per_app_get_only_supports_profile_apps() {
-        let per: PerApp<Option<String>> = PerApp::default();
+        let per: PerApp<Option<Vec<String>>> = PerApp::default();
         assert!(per.get(&AppType::Claude).is_some());
         assert!(per.get(&AppType::ClaudeDesktop).is_some());
         assert!(per.get(&AppType::Codex).is_some());

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -21,8 +21,8 @@ fn enabled_prompt_content(prompts: &IndexMap<String, Prompt>) -> String {
     prompts
         .values()
         .filter(|prompt| prompt.enabled)
-        .map(|prompt| prompt.content.trim())
-        .filter(|content| !content.is_empty())
+        .map(|prompt| prompt.content.as_str())
+        .filter(|content| !content.trim().is_empty())
         .collect::<Vec<_>>()
         .join("\n\n")
 }
@@ -317,5 +317,47 @@ impl PromptService {
 
         log::info!("自动导入完成: {}", app.as_str());
         Ok(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::enabled_prompt_content;
+    use crate::prompt::Prompt;
+    use indexmap::IndexMap;
+
+    #[test]
+    fn enabled_prompt_content_preserves_prompt_whitespace_when_composing() {
+        let prompts = IndexMap::from([
+            (
+                "first".to_string(),
+                Prompt {
+                    id: "first".to_string(),
+                    name: "First".to_string(),
+                    content: "  first prompt  ".to_string(),
+                    description: None,
+                    enabled: true,
+                    created_at: None,
+                    updated_at: None,
+                },
+            ),
+            (
+                "second".to_string(),
+                Prompt {
+                    id: "second".to_string(),
+                    name: "Second".to_string(),
+                    content: "second prompt".to_string(),
+                    description: None,
+                    enabled: true,
+                    created_at: None,
+                    updated_at: None,
+                },
+            ),
+        ]);
+
+        assert_eq!(
+            enabled_prompt_content(&prompts),
+            "  first prompt  \n\nsecond prompt"
+        );
     }
 }

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -17,6 +17,55 @@ fn get_unix_timestamp() -> Result<i64, AppError> {
 
 pub struct PromptService;
 
+fn enabled_prompt_content(prompts: &IndexMap<String, Prompt>) -> String {
+    prompts
+        .values()
+        .filter(|prompt| prompt.enabled)
+        .map(|prompt| prompt.content.trim())
+        .filter(|content| !content.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn backup_diverged_live_content(
+    state: &AppState,
+    app: &AppType,
+    target_path: &std::path::Path,
+    prompts: &IndexMap<String, Prompt>,
+) -> Result<(), AppError> {
+    let Ok(live_content) = std::fs::read_to_string(target_path) else {
+        return Ok(());
+    };
+
+    if live_content.trim().is_empty()
+        || live_content.trim() == enabled_prompt_content(prompts).trim()
+        || prompts
+            .values()
+            .any(|prompt| prompt.content.trim() == live_content.trim())
+    {
+        return Ok(());
+    }
+
+    let timestamp = get_unix_timestamp()?;
+    let backup_id = format!("backup-{timestamp}");
+    let backup_prompt = Prompt {
+        id: backup_id.clone(),
+        name: format!(
+            "Original prompt {}",
+            chrono::Local::now().format("%Y-%m-%d %H:%M")
+        ),
+        content: live_content,
+        description: Some(
+            "Automatically backed up before overwriting the live prompt file".to_string(),
+        ),
+        enabled: false,
+        created_at: Some(timestamp),
+        updated_at: Some(timestamp),
+    };
+    log::info!("Backed up diverged live prompt content: {backup_id}");
+    state.db.save_prompt(app.as_str(), &backup_prompt)
+}
+
 impl PromptService {
     pub fn get_prompts(
         state: &AppState,
@@ -31,26 +80,39 @@ impl PromptService {
         _id: &str,
         prompt: Prompt,
     ) -> Result<(), AppError> {
-        // 检查是否为已启用的提示词
         let is_enabled = prompt.enabled;
+        let prompt_content = prompt.content.clone();
+        let target_path = prompt_file_path(&app)?;
+        let mut prompts = state.db.get_prompts(app.as_str())?;
 
-        state.db.save_prompt(app.as_str(), &prompt)?;
+        if matches!(app, AppType::Codex) {
+            backup_diverged_live_content(state, &app, &target_path, &prompts)?;
+        }
+
+        if is_enabled && !matches!(app, AppType::Codex) {
+            for existing_prompt in prompts.values_mut() {
+                existing_prompt.enabled = false;
+            }
+        }
+
+        prompts.insert(prompt.id.clone(), prompt);
+
+        for prompt in prompts.values() {
+            state.db.save_prompt(app.as_str(), prompt)?;
+        }
 
         if is_enabled {
-            // 启用提示词：写入内容到文件
-            let target_path = prompt_file_path(&app)?;
-            write_text_file(&target_path, &prompt.content)?;
+            let content = if matches!(app, AppType::Codex) {
+                enabled_prompt_content(&prompts)
+            } else {
+                prompt_content
+            };
+            write_text_file(&target_path, &content)?;
         } else {
-            // 禁用提示词：检查是否还有其他已启用的提示词
-            let prompts = state.db.get_prompts(app.as_str())?;
-            let any_enabled = prompts.values().any(|p| p.enabled);
-
-            if !any_enabled {
-                // 所有提示词都已禁用，清空文件
-                let target_path = prompt_file_path(&app)?;
-                if target_path.exists() {
-                    write_text_file(&target_path, "")?;
-                }
+            if matches!(app, AppType::Codex) && target_path.exists() {
+                write_text_file(&target_path, &enabled_prompt_content(&prompts))?;
+            } else if !prompts.values().any(|p| p.enabled) && target_path.exists() {
+                write_text_file(&target_path, "")?;
             }
         }
 
@@ -71,6 +133,7 @@ impl PromptService {
     }
 
     pub fn enable_prompt(state: &AppState, app: AppType, id: &str) -> Result<(), AppError> {
+        let allow_multiple = matches!(app, AppType::Codex);
         // 回填当前 live 文件内容到已启用的提示词，或创建备份
         let target_path = prompt_file_path(&app)?;
         if target_path.exists() {
@@ -78,18 +141,23 @@ impl PromptService {
                 if !live_content.trim().is_empty() {
                     let mut prompts = state.db.get_prompts(app.as_str())?;
 
-                    // 尝试回填到当前已启用的提示词
-                    if let Some((enabled_id, enabled_prompt)) = prompts
-                        .iter_mut()
-                        .find(|(_, p)| p.enabled)
-                        .map(|(id, p)| (id.clone(), p))
-                    {
+                    // A generated file with multiple enabled prompts must not be
+                    // imported back into one prompt, or later enables would duplicate it.
+                    let enabled_count = prompts.values().filter(|p| p.enabled).count();
+                    if enabled_count == 1 {
+                        let (enabled_id, enabled_prompt) = prompts
+                            .iter_mut()
+                            .find(|(_, p)| p.enabled)
+                            .map(|(id, p)| (id.clone(), p))
+                            .expect("enabled_count guarantees one enabled prompt");
                         let timestamp = get_unix_timestamp()?;
                         enabled_prompt.content = live_content.clone();
                         enabled_prompt.updated_at = Some(timestamp);
                         log::info!("回填 live 提示词内容到已启用项: {enabled_id}");
                         state.db.save_prompt(app.as_str(), enabled_prompt)?;
-                    } else {
+                    } else if enabled_count == 0
+                        || live_content.trim() != enabled_prompt_content(&prompts).trim()
+                    {
                         // 没有已启用的提示词，则创建一次备份（避免重复备份）
                         let content_exists = prompts
                             .values()
@@ -123,17 +191,28 @@ impl PromptService {
         // 启用目标提示词并写入文件
         let mut prompts = state.db.get_prompts(app.as_str())?;
 
-        for prompt in prompts.values_mut() {
-            prompt.enabled = false;
+        if !allow_multiple {
+            for prompt in prompts.values_mut() {
+                prompt.enabled = false;
+            }
         }
 
         if let Some(prompt) = prompts.get_mut(id) {
             prompt.enabled = true;
-            write_text_file(&target_path, &prompt.content)?; // 原子写入
-            state.db.save_prompt(app.as_str(), prompt)?;
         } else {
             return Err(AppError::InvalidInput(format!("提示词 {id} 不存在")));
         }
+
+        let content = if allow_multiple {
+            enabled_prompt_content(&prompts)
+        } else {
+            prompts
+                .get(id)
+                .expect("target prompt exists after enabling")
+                .content
+                .clone()
+        };
+        write_text_file(&target_path, &content)?;
 
         // Save all prompts to disable others
         for (_, prompt) in prompts.iter() {

--- a/src-tauri/tests/profile_roundtrip.rs
+++ b/src-tauri/tests/profile_roundtrip.rs
@@ -185,7 +185,7 @@ fn profile_snapshot_apply_roundtrip_restores_configuration() {
         payload.skills.claude,
         Some(vec!["local:test-skill".to_string()])
     );
-    assert_eq!(payload.prompts.claude.as_deref(), Some("pr1"));
+    assert_eq!(payload.prompts.claude, Some(vec!["pr1".to_string()]));
     assert_eq!(
         payload.providers.codex, None,
         "codex side not captured when creating from the claude group"
@@ -410,7 +410,7 @@ fn profile_apply_reports_dangling_references_and_continues() {
         "providers": { "claude": "ghost-provider" },
         "mcp": { "claude": ["m1", "ghost-mcp"] },
         "skills": { "claude": ["ghost-skill"] },
-        "prompts": { "claude": "ghost-prompt" }
+        "prompts": { "claude": ["ghost-prompt"] }
     });
     let profile = cc_switch_lib::Profile {
         id: "dangling-test".to_string(),
@@ -586,7 +586,7 @@ fn switching_profile_autosaves_previous_profile_state() {
         serde_json::from_str(&saved_a.payload).expect("parse project A payload");
     assert_eq!(payload_a.providers.claude.as_deref(), Some("p2"));
     assert_eq!(payload_a.mcp.claude, Some(vec!["m2".to_string()]));
-    assert_eq!(payload_a.prompts.claude.as_deref(), Some("pr2"));
+    assert_eq!(payload_a.prompts.claude, Some(vec!["pr2".to_string()]));
 
     // ---- 在 B 下改回状态 X，再切换回 A ----
     ProviderService::switch(&state, AppType::Claude, "p1").expect("switch to p1");
@@ -640,7 +640,7 @@ fn switching_profile_autosaves_previous_profile_state() {
         serde_json::from_str(&saved_b.payload).expect("parse project B payload");
     assert_eq!(payload_b.providers.claude.as_deref(), Some("p1"));
     assert_eq!(payload_b.mcp.claude, Some(vec!["m1".to_string()]));
-    assert_eq!(payload_b.prompts.claude.as_deref(), Some("pr1"));
+    assert_eq!(payload_b.prompts.claude, Some(vec!["pr1".to_string()]));
 }
 
 #[test]
@@ -810,5 +810,71 @@ fn claude_desktop_profile_scope_is_independent() {
             .as_deref(),
         Some(project.id.as_str()),
         "desktop scope marker set"
+    );
+}
+
+#[test]
+fn upsert_prompt_keeps_non_codex_prompts_exclusive() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    fs::create_dir_all(home.join(".claude")).expect("create Claude prompt directory");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_prompt(AppType::Claude.as_str(), &prompt("first", true))
+        .expect("save first prompt");
+
+    PromptService::upsert_prompt(&state, AppType::Claude, "second", prompt("second", true))
+        .expect("upsert enabled second prompt");
+
+    let prompts = state
+        .db
+        .get_prompts(AppType::Claude.as_str())
+        .expect("read prompts");
+    assert!(prompts.get("second").expect("second prompt").enabled);
+    assert!(
+        !prompts.get("first").expect("first prompt").enabled,
+        "non-Codex upsert must disable the previously enabled prompt"
+    );
+}
+
+#[test]
+fn upsert_prompt_backs_up_manual_codex_content_before_recomposing() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create Codex prompt directory");
+
+    let state = create_test_state().expect("create test state");
+    state
+        .db
+        .save_prompt(AppType::Codex.as_str(), &prompt("first", true))
+        .expect("save first prompt");
+    state
+        .db
+        .save_prompt(AppType::Codex.as_str(), &prompt("second", true))
+        .expect("save second prompt");
+
+    let live_path = codex_dir.join("AGENTS.md");
+    fs::write(&live_path, "# manual Codex instruction\n").expect("write manual AGENTS.md");
+
+    let mut updated = prompt("first", true);
+    updated.content = "# updated first prompt\n".to_string();
+    PromptService::upsert_prompt(&state, AppType::Codex, "first", updated)
+        .expect("upsert enabled Codex prompt");
+
+    let prompts = state
+        .db
+        .get_prompts(AppType::Codex.as_str())
+        .expect("read prompts");
+    assert!(prompts
+        .values()
+        .any(|prompt| { !prompt.enabled && prompt.content == "# manual Codex instruction\n" }));
+    assert_eq!(
+        fs::read_to_string(live_path).expect("read recomposed AGENTS.md"),
+        "# updated first prompt\n\n# prompt second"
     );
 }

--- a/src/components/prompts/PromptPanel.tsx
+++ b/src/components/prompts/PromptPanel.tsx
@@ -97,16 +97,18 @@ const PromptPanel = React.forwardRef<PromptPanelHandle, PromptPanelProps>(
 
     const promptEntries = useMemo(() => Object.entries(prompts), [prompts]);
 
-    const enabledPrompt = promptEntries.find(([_, p]) => p.enabled);
+    const enabledPrompts = promptEntries.filter(([_, p]) => p.enabled);
 
     return (
       <div className="flex flex-col flex-1 min-h-0 px-6">
         <div className="flex-shrink-0 py-4 glass rounded-xl border border-white/10 mb-4 px-6">
           <div className="text-sm text-muted-foreground">
             {t("prompts.count", { count: promptEntries.length })} ·{" "}
-            {enabledPrompt
-              ? t("prompts.enabledName", { name: enabledPrompt[1].name })
-              : t("prompts.noneEnabled")}
+            {appId === "codex" && enabledPrompts.length > 0
+              ? t("prompts.enabledCount", { count: enabledPrompts.length })
+              : enabledPrompts[0]
+                ? t("prompts.enabledName", { name: enabledPrompts[0][1].name })
+                : t("prompts.noneEnabled")}
           </div>
         </div>
 

--- a/src/hooks/usePromptActions.ts
+++ b/src/hooks/usePromptActions.ts
@@ -78,14 +78,16 @@ export function usePromptActions(appId: AppId) {
       // Optimistic update
       const previousPrompts = prompts;
 
-      // 如果要启用当前提示词，先禁用其他所有提示词
-      if (enabled) {
+      // Enabling a prompt should preserve any other enabled prompts.
+      if (enabled && appId === "codex") {
+        setPrompts((prev) => ({
+          ...prev,
+          [id]: { ...prev[id], enabled: true },
+        }));
+      } else if (enabled) {
         const updatedPrompts = Object.keys(prompts).reduce(
           (acc, key) => {
-            acc[key] = {
-              ...prompts[key],
-              enabled: key === id,
-            };
+            acc[key] = { ...prompts[key], enabled: key === id };
             return acc;
           },
           {} as Record<string, Prompt>,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1926,6 +1926,7 @@
     "enabled": "Enabled",
     "enable": "Enable",
     "enabledName": "Enabled: {{name}}",
+    "enabledCount": "{{count}} enabled",
     "noneEnabled": "No prompt enabled",
     "currentFile": "Current {{filename}} Content",
     "empty": "No prompts yet",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1926,6 +1926,7 @@
     "enabled": "有効",
     "enable": "有効化",
     "enabledName": "有効: {{name}}",
+    "enabledCount": "{{count}} 件のプロンプトが有効",
     "noneEnabled": "有効なプロンプトがありません",
     "currentFile": "現在の {{filename}} の内容",
     "empty": "まだプロンプトがありません",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1898,6 +1898,7 @@
     "enabled": "已啟用",
     "enable": "啟用",
     "enabledName": "已啟用：{{name}}",
+    "enabledCount": "已啟用 {{count}} 個",
     "noneEnabled": "未啟用任何提示詞",
     "currentFile": "目前 {{filename}} 內容",
     "empty": "暫無提示詞",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1926,6 +1926,7 @@
     "enabled": "已启用",
     "enable": "启用",
     "enabledName": "已启用: {{name}}",
+    "enabledCount": "已启用 {{count}} 个",
     "noneEnabled": "未启用任何提示词",
     "currentFile": "当前 {{filename}} 内容",
     "empty": "暂无提示词",

--- a/src/lib/api/profiles.ts
+++ b/src/lib/api/profiles.ts
@@ -27,7 +27,7 @@ export interface ProfilePayload {
   providers: PerApp<string | null>;
   mcp: PerApp<string[] | null>;
   skills: PerApp<string[] | null>;
-  prompts: PerApp<string | null>;
+  prompts: PerApp<string[] | null>;
 }
 
 export interface Profile {

--- a/tests/config/promptsLocales.test.ts
+++ b/tests/config/promptsLocales.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import en from "@/i18n/locales/en.json";
+import ja from "@/i18n/locales/ja.json";
+import zhTW from "@/i18n/locales/zh-TW.json";
+import zh from "@/i18n/locales/zh.json";
+
+describe("prompt locale coverage", () => {
+  it.each([
+    ["en", en],
+    ["ja", ja],
+    ["zh", zh],
+    ["zh-TW", zhTW],
+  ])(
+    "defines the enabled prompt count label in %s",
+    (_locale, translations) => {
+      expect(translations.prompts.enabledCount).toEqual(expect.any(String));
+      expect(translations.prompts.enabledCount.trim()).not.toBe("");
+    },
+  );
+});

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -218,7 +218,7 @@ describe("App integration with MSW", () => {
 
     expect(toastErrorMock).not.toHaveBeenCalled();
     expect(toastSuccessMock).toHaveBeenCalled();
-  });
+  }, 15000);
 
   it("shows toast when auto sync fails in background", async () => {
     const { default: App } = await import("@/App");


### PR DESCRIPTION
## Summary
- Allow Codex to compose all enabled prompts into `AGENTS.md`; other apps remain mutually exclusive.
- Store all enabled prompt IDs in profile snapshots while accepting legacy single-ID payloads.
- Back up manual Codex instructions before a composed file overwrites them.

## Validation
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` (all Rust unit and integration tests)
- `pnpm typecheck`
- `pnpm format:check`
- `vitest run --maxWorkers=1 --minWorkers=1` (522/522 tests)

Closes #4885