### PR TITLE
fix(codex): write absolute path for model_catalog_json

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1016,8 +1016,8 @@ fn set_codex_model_catalog_json_field(
         .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
 
     match catalog_path {
-        Some(_) => {
-            doc["model_catalog_json"] = toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
+        Some(path) => {
+            doc["model_catalog_json"] = toml_edit::value(path.to_string_lossy().to_string());
         }
         None => {
             let should_remove = doc


### PR DESCRIPTION
## Problem

`set_codex_model_catalog_json_field()` writes the relative filename `cc-switch-model-catalog.json` into `config.toml`, but Codex requires an absolute path for `AbsolutePathBuf` deserialization. This causes:

```
invalid configuration: AbsolutePathBuf deserialized without a base path
in `model_catalog_json`
```

## Fix

Replace the filename constant with `path.to_string_lossy()`, using the already-available `catalog_path: Option<&Path>` parameter to write the full absolute path.

## Compatibility

`resolve_cc_switch_catalog_path()` identifies cc-switch-owned files by matching the filename component, not the path prefix, so the stale guard, reverse parsing, and all downstream logic continue to work correctly with absolute paths.