### PR TITLE
feat(provider): add Modelsell OpenCode preset

### DIFF
--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -1548,6 +1548,36 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     },
   },
   {
+    name: "Modelsell",
+    websiteUrl: "https://modelsell.com",
+    apiKeyUrl: "https://modelsell.com/console/token",
+    settingsConfig: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "Modelsell",
+      options: {
+        baseURL: "https://modelsell.com/v1",
+        apiKey: "",
+        setCacheKey: true,
+      },
+      models: {},
+    },
+    category: "aggregator",
+    icon: "modelsell",
+    templateValues: {
+      baseURL: {
+        label: "Base URL",
+        placeholder: "https://modelsell.com/v1",
+        defaultValue: "https://modelsell.com/v1",
+        editorValue: "",
+      },
+      apiKey: {
+        label: "API Key",
+        placeholder: "sk-...",
+        editorValue: "",
+      },
+    },
+  },
+  {
     name: "KAT-Coder",
     websiteUrl: "https://console.streamlake.ai",
     apiKeyUrl: "https://console.streamlake.ai/console/api-key",

--- a/tests/config/modelsellProviderPresets.test.ts
+++ b/tests/config/modelsellProviderPresets.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { opencodeProviderPresets } from "@/config/opencodeProviderPresets";
+
+describe("Modelsell OpenCode provider preset", () => {
+  const preset = opencodeProviderPresets.find(
+    (provider) => provider.name === "Modelsell",
+  );
+
+  it("registers Modelsell as an OpenAI-compatible aggregator", () => {
+    expect(preset).toBeDefined();
+    expect(preset).toMatchObject({
+      websiteUrl: "https://modelsell.com",
+      apiKeyUrl: "https://modelsell.com/console/token",
+      category: "aggregator",
+      settingsConfig: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Modelsell",
+        options: {
+          baseURL: "https://modelsell.com/v1",
+          apiKey: "",
+          setCacheKey: true,
+        },
+      },
+    });
+  });
+
+  it("keeps model selection dynamic", () => {
+    expect(preset!.settingsConfig.models).toEqual({});
+  });
+
+  it("uses the Modelsell base URL in the editable template", () => {
+    expect(preset!.templateValues?.baseURL).toMatchObject({
+      placeholder: "https://modelsell.com/v1",
+      defaultValue: "https://modelsell.com/v1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Adds Modelsell as an OpenCode provider preset using CC Switch's existing OpenAI-compatible configuration and model-fetch flow.

- defaults the provider to `@ai-sdk/openai-compatible`
- sets `https://modelsell.com/v1` as the API base
- links the Modelsell website and API key page
- leaves `models` empty so users discover current model IDs through the existing `/models` fetch action rather than a hardcoded catalog
- adds focused regression coverage for provider metadata, endpoint defaults, and dynamic model selection

在 OpenCode Provider 预设中新增 Modelsell，复用现有 OpenAI 兼容与 `/models` 动态获取逻辑，不维护静态模型列表。

Disclosure: I represent Modelsell.

## Related Issue / 关联 Issue

Fixes #5813

## Screenshots / 截图

Not included. This is a provider-metadata addition using the existing preset selector and form controls; no new UI component or layout is introduced.

## Validation / 验证

- `pnpm exec vitest run tests/config/modelsellProviderPresets.test.ts` (3 passed)
- `pnpm test:unit` (80 files, 525 tests passed)
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm build:renderer`
- `git diff --check`

No live authenticated Modelsell API call was performed.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 未修改 Rust 代码
- [x] Updated i18n files if user-facing text changed / 未新增通用 UI 文案；品牌名复用现有预设字段
