### PR TITLE
fix(codex): avoid replaying synthetic reasoning items

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -279,28 +279,10 @@ impl ChatToResponsesState {
     }
 
     fn push_reasoning_delta(&mut self, delta: &str) -> Vec<Bytes> {
-        let mut events = Vec::new();
-
-        if !self.reasoning.added {
-            let output_index = self.next_output_index();
-            let item_id = format!("rs_{}", self.response_id);
-            self.reasoning.output_index = Some(output_index);
-            self.reasoning.item_id = item_id.clone();
-            self.reasoning.added = true;
-
-            events.push(sse::reasoning_item_added(output_index, &item_id));
-            events.push(sse::reasoning_summary_part_added(output_index, &item_id));
-        }
-
+        // Keep reasoning for same-provider tool-call continuation, but do not
+        // expose a synthetic Responses item whose ID was never persisted.
         self.reasoning.text.push_str(delta);
-        let output_index = self.reasoning.output_index.unwrap_or(0);
-        events.push(sse::reasoning_summary_text_delta(
-            output_index,
-            &self.reasoning.item_id,
-            delta,
-        ));
-
-        events
+        Vec::new()
     }
 
     fn push_text_delta(&mut self, delta: &str) -> Vec<Bytes> {
@@ -890,7 +872,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn converts_reasoning_content_chat_sse_to_responses_reasoning_events() {
+    async fn omits_unpersisted_reasoning_items_from_chat_sse() {
         let output = collect(vec![
             "data: {\"id\":\"chatcmpl_reason\",\"created\":123,\"model\":\"deepseek-reasoner\",\"choices\":[{\"delta\":{\"reasoning_content\":\"Need context. \"}}]}\n\n",
             "data: {\"id\":\"chatcmpl_reason\",\"created\":123,\"model\":\"deepseek-reasoner\",\"choices\":[{\"delta\":{\"reasoning\":\"Now answer. \"}}]}\n\n",
@@ -899,17 +881,11 @@ mod tests {
         ])
         .await;
 
-        assert!(output.contains("event: response.reasoning_summary_part.added"));
-        assert!(output.contains("event: response.reasoning_summary_text.delta"));
-        assert!(output.contains("event: response.reasoning_summary_text.done"));
-        assert!(output.contains("Need context. Now answer. "));
-        assert!(output.contains("\"type\":\"reasoning\""));
+        assert!(!output.contains("event: response.reasoning_summary_part.added"));
+        assert!(!output.contains("event: response.reasoning_summary_text.delta"));
+        assert!(!output.contains("\"type\":\"reasoning\""));
         assert!(output.contains("\"text\":\"Done\""));
         assert!(output.contains("\"reasoning_tokens\":3"));
-
-        let reasoning_pos = output.find("\"type\":\"reasoning\"").unwrap();
-        let message_pos = output.find("\"type\":\"message\"").unwrap();
-        assert!(reasoning_pos < message_pos);
     }
 
     #[tokio::test]
@@ -921,8 +897,7 @@ mod tests {
         ])
         .await;
 
-        assert!(output.contains("event: response.reasoning_summary_text.delta"));
-        assert!(output.contains("Need context."));
+        assert!(!output.contains("event: response.reasoning_summary_text.delta"));
         assert!(output.contains("\"text\":\"pong\""));
         assert!(output.contains("\"reasoning_tokens\":3"));
         assert!(!output.contains("<think>"));

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1401,11 +1401,9 @@ pub(crate) fn chat_completion_to_response_with_context(
 
     let reasoning = chat_reasoning_text(message);
     let mut output = Vec::new();
-    if let Some(reasoning_item) =
-        chat_reasoning_to_response_output_item(reasoning.as_deref(), &response_id)
-    {
-        output.push(reasoning_item);
-    }
+    // Chat Completions reasoning has no persisted Responses item behind it.
+    // Emitting a synthetic `rs_*` item makes Codex replay an ID that strict
+    // Responses providers cannot resolve when `store` is false.
     if let Some(message_item) = chat_message_to_response_output_item(message, &response_id) {
         output.push(message_item);
     }
@@ -1430,25 +1428,6 @@ pub(crate) fn chat_completion_to_response_with_context(
     }
 
     Ok(response)
-}
-
-fn chat_reasoning_to_response_output_item(
-    reasoning: Option<&str>,
-    response_id: &str,
-) -> Option<Value> {
-    let reasoning = reasoning?;
-    if reasoning.is_empty() {
-        return None;
-    }
-
-    Some(json!({
-        "id": format!("rs_{response_id}"),
-        "type": "reasoning",
-        "summary": [{
-            "type": "summary_text",
-            "text": reasoning
-        }]
-    }))
 }
 
 fn chat_reasoning_text(message: &Value) -> Option<String> {
@@ -2590,7 +2569,7 @@ mod tests {
     }
 
     #[test]
-    fn chat_response_to_responses_extracts_reasoning_details() {
+    fn chat_response_to_responses_omits_unpersisted_reasoning_details() {
         let input = json!({
             "id": "chatcmpl_minimax",
             "object": "chat.completion",
@@ -2610,12 +2589,9 @@ mod tests {
 
         let result = chat_completion_to_response(input).unwrap();
 
-        assert_eq!(result["output"][0]["type"], "reasoning");
-        assert_eq!(
-            result["output"][0]["summary"][0]["text"],
-            "Need to inspect the code."
-        );
-        assert_eq!(result["output"][1]["content"][0]["text"], "Done");
+        assert_eq!(result["output"].as_array().unwrap().len(), 1);
+        assert_eq!(result["output"][0]["type"], "message");
+        assert_eq!(result["output"][0]["content"][0]["text"], "Done");
     }
 
     #[test]
@@ -3784,17 +3760,12 @@ mod tests {
 
         assert_eq!(result["id"], "resp_chatcmpl_1");
         assert_eq!(result["status"], "completed");
-        assert_eq!(result["output"][0]["type"], "reasoning");
+        assert_eq!(result["output"][0]["type"], "message");
+        assert_eq!(result["output"][0]["content"][0]["text"], "Let me check.");
+        assert_eq!(result["output"][1]["type"], "function_call");
+        assert_eq!(result["output"][1]["call_id"], "call_1");
         assert_eq!(
-            result["output"][0]["summary"][0]["text"],
-            "I should check the weather before answering."
-        );
-        assert_eq!(result["output"][1]["type"], "message");
-        assert_eq!(result["output"][1]["content"][0]["text"], "Let me check.");
-        assert_eq!(result["output"][2]["type"], "function_call");
-        assert_eq!(result["output"][2]["call_id"], "call_1");
-        assert_eq!(
-            result["output"][2]["reasoning_content"],
+            result["output"][1]["reasoning_content"],
             "I should check the weather before answering."
         );
         assert_eq!(result["usage"]["input_tokens"], 10);
@@ -4005,13 +3976,9 @@ mod tests {
 
         let result = chat_completion_to_response(input).unwrap();
 
-        assert_eq!(result["output"][0]["type"], "reasoning");
-        assert_eq!(
-            result["output"][0]["summary"][0]["text"],
-            "I should answer with pong."
-        );
-        assert_eq!(result["output"][1]["type"], "message");
-        assert_eq!(result["output"][1]["content"][0]["text"], "pong");
+        assert_eq!(result["output"].as_array().unwrap().len(), 1);
+        assert_eq!(result["output"][0]["type"], "message");
+        assert_eq!(result["output"][0]["content"][0]["text"], "pong");
         assert_eq!(
             result["usage"]["output_tokens_details"]["reasoning_tokens"],
             18


### PR DESCRIPTION
## Summary / 概述

- Stop Chat Completions to Responses conversion from emitting synthetic `reasoning` output items with locally generated `rs_*` IDs.
- Suppress the equivalent streaming reasoning item/summary events while still accumulating reasoning text for converted tool-call continuation.
- Prevent Codex from replaying an ID that never existed at the native Responses upstream after switching providers with `store=false`.

## Root Cause / 根因

The Chat bridge currently makes `rs_{response_id}` look like a persisted Responses item in both non-streaming JSON and streaming SSE. Codex records that output and may later replay it as an item reference. After switching back to an official/native Responses provider, the upstream tries to resolve the local synthetic ID and returns HTTP 404 because `store` is false.

This change keeps final text, tool calls, usage, and tool-call `reasoning_content`, but no longer advertises Chat-only reasoning as a replayable Responses item.

## Related Issue / 关联 Issue

Fixes #5825

Related: #5740 handles the separate invalid `resp_*_msg` message-ID problem. This PR deliberately leaves message-ID generation to that broader fix to avoid duplicate implementation.

## Validation / 验证

Focused validation on the same `ccda04bf` base commit before separating the overlapping #5740 message-ID changes:

- `cargo fmt --check`: passed
- non-streaming converter tests: 7 passed
- streaming converter tests: 19 passed
- verifies no reasoning item/events are emitted
- verifies reasoning remains attached to tool calls
- verifies inline `<think>` text does not leak and final text/usage remain intact
- `git diff --check`: passed on this focused branch

## Screenshots / 截图

Not applicable; this is a proxy protocol fix with no UI changes.

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes (not applicable; no frontend changes)
- [ ] `pnpm format:check` passes (not applicable; no frontend changes)
- [ ] `cargo clippy` passes (pending CI/toolchain availability; Draft PR)
- [x] Updated i18n files if user-facing text changed (not applicable; no user-facing text changes)