### PR TITLE
fix(codex): use provider auth for third-party live routes

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1857,7 +1857,17 @@ pub fn restore_codex_provider_token_for_backfill(
         return Ok(());
     };
 
+    // Strip live-only projection state that prepare_codex_provider_live_config
+    // may have written: the bearer token itself, and the requires_openai_auth =
+    // false flip that keeps Codex 0.144+ from selecting preserved ChatGPT auth.
     let cleaned_config = remove_codex_experimental_bearer_token(&config_text)?;
+    let cleaned_config = restore_codex_requires_openai_auth_from_template(
+        &cleaned_config,
+        template_settings
+            .get("config")
+            .and_then(|value| value.as_str())
+            .unwrap_or(""),
+    )?;
 
     if let Some(obj) = settings.as_object_mut() {
         obj.insert("config".to_string(), Value::String(cleaned_config));
@@ -1874,6 +1884,62 @@ pub fn restore_codex_provider_token_for_backfill(
     }
 
     Ok(())
+}
+
+/// Restore `requires_openai_auth` on the active provider table from the stored
+/// template, undoing the live-only `false` written alongside a projected bearer
+/// token. If the template has no explicit value, drop the live-projected flag
+/// so stored provider config does not keep a synthetic default.
+fn restore_codex_requires_openai_auth_from_template(
+    live_config: &str,
+    template_config: &str,
+) -> Result<String, AppError> {
+    if live_config.trim().is_empty() {
+        return Ok(live_config.to_string());
+    }
+
+    let mut live_doc = live_config
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+
+    let Some(provider_id) = active_codex_model_provider_id(&live_doc) else {
+        return Ok(live_config.to_string());
+    };
+    if !is_custom_codex_model_provider_id(&provider_id) {
+        return Ok(live_config.to_string());
+    }
+
+    let template_flag = template_config
+        .parse::<DocumentMut>()
+        .ok()
+        .and_then(|doc| {
+            doc.get("model_providers")
+                .and_then(|item| item.as_table())
+                .and_then(|table| table.get(provider_id.as_str()))
+                .and_then(|item| item.as_table())
+                .and_then(|table| table.get("requires_openai_auth"))
+                .and_then(|item| item.as_bool())
+        });
+
+    let Some(provider_table) = live_doc
+        .get_mut("model_providers")
+        .and_then(|item| item.as_table_mut())
+        .and_then(|table| table.get_mut(provider_id.as_str()))
+        .and_then(|item| item.as_table_mut())
+    else {
+        return Ok(live_config.to_string());
+    };
+
+    match template_flag {
+        Some(flag) => {
+            provider_table["requires_openai_auth"] = toml_edit::value(flag);
+        }
+        None => {
+            provider_table.remove("requires_openai_auth");
+        }
+    }
+
+    Ok(live_doc.to_string())
 }
 
 pub fn restore_codex_settings_for_backfill(
@@ -2382,6 +2448,64 @@ experimental_bearer_token = "stale-table-key"
         assert_eq!(
             extract_codex_experimental_bearer_token(input).as_deref(),
             Some("top-level-key")
+        );
+    }
+
+    #[test]
+    fn restore_provider_token_restores_requires_openai_auth_from_template() {
+        let mut settings = json!({
+            "auth": {
+                "OPENAI_API_KEY": null,
+                "tokens": {"access_token": "oauth"}
+            },
+            "config": r#"model_provider = "custom"
+
+[model_providers.custom]
+name = "Third Party"
+base_url = "https://third-party.example/v1"
+wire_api = "responses"
+requires_openai_auth = false
+experimental_bearer_token = "sk-live"
+"#
+        });
+        let template = json!({
+            "auth": {"OPENAI_API_KEY": "sk-stored"},
+            "config": r#"model_provider = "custom"
+
+[model_providers.custom]
+name = "Third Party"
+base_url = "https://third-party.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+        });
+
+        restore_codex_provider_token_for_backfill(&mut settings, &template)
+            .expect("restore provider token");
+
+        assert_eq!(
+            settings
+                .pointer("/auth/OPENAI_API_KEY")
+                .and_then(|v| v.as_str()),
+            Some("sk-live")
+        );
+        let restored_config = settings
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("config string");
+        assert!(
+            !restored_config.contains("experimental_bearer_token"),
+            "live bearer token must not leak into stored provider config"
+        );
+        let parsed: toml::Value = toml::from_str(restored_config).expect("parse restored config");
+        assert_eq!(
+            parsed
+                .get("model_providers")
+                .and_then(|v| v.get("custom"))
+                .and_then(|v| v.get("requires_openai_auth"))
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "stored template requires_openai_auth must survive live projection backfill"
         );
     }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1368,6 +1368,11 @@ fn set_codex_experimental_bearer_token(config_text: &str, token: &str) -> Result
             .and_then(|item| item.as_table_mut())
         {
             provider_table["experimental_bearer_token"] = toml_edit::value(token);
+            // A provider-scoped bearer token is the authentication source for
+            // this third-party live route. Codex 0.144+ otherwise interprets
+            // requires_openai_auth = true as an explicit request to use the
+            // preserved ChatGPT login instead of the selected provider.
+            provider_table["requires_openai_auth"] = toml_edit::value(false);
             return Ok(doc.to_string());
         }
     }
@@ -2304,6 +2309,41 @@ base_url = "https://single.example.com/v1"
         assert!(
             err.to_string().contains("config.toml"),
             "error should explain missing config.toml, got: {err}"
+        );
+    }
+
+    #[test]
+    fn prepare_provider_live_config_disables_openai_auth_for_custom_provider() {
+        let input = r#"model_provider = "custom"
+
+[model_providers.custom]
+name = "Third Party"
+base_url = "https://third-party.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+
+        let output =
+            prepare_codex_provider_live_config(&json!({"OPENAI_API_KEY": "sk-test"}), input)
+                .expect("prepare live config");
+        let parsed: toml::Value = toml::from_str(&output).expect("parse output");
+        let provider = parsed
+            .get("model_providers")
+            .and_then(|value| value.get("custom"))
+            .expect("custom provider");
+
+        assert_eq!(
+            provider
+                .get("experimental_bearer_token")
+                .and_then(|value| value.as_str()),
+            Some("sk-test")
+        );
+        assert_eq!(
+            provider
+                .get("requires_openai_auth")
+                .and_then(|value| value.as_bool()),
+            Some(false),
+            "third-party bearer auth must not fall back to the preserved ChatGPT login"
         );
     }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3889,6 +3889,15 @@ wire_api = "responses"
             live_config.contains(PROXY_TOKEN_PLACEHOLDER),
             "live config should carry the proxy placeholder token"
         );
+        let parsed_live: toml::Value =
+            toml::from_str(&live_config).expect("parse third-party live config");
+        assert_eq!(
+            parsed_live["model_providers"]["rightcode"]
+                .get("requires_openai_auth")
+                .and_then(toml::Value::as_bool),
+            Some(false),
+            "takeover bearer auth must not select the preserved ChatGPT login"
+        );
 
         crate::settings::update_settings(crate::settings::AppSettings::default())
             .expect("reset settings");

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -485,7 +485,8 @@ requires_openai_auth = true
             .and_then(|v| v.get("aihubmix"))
             .and_then(|v| v.get("requires_openai_auth"))
             .and_then(|v| v.as_bool()),
-        Some(true)
+        Some(false),
+        "provider-scoped bearer auth must not select the preserved ChatGPT login"
     );
 
     ProviderService::switch(&state, AppType::Codex, "plain-provider")

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -523,6 +523,22 @@ requires_openai_auth = true
             .contains("experimental_bearer_token"),
         "stored provider config should stay clean; bridge token is generated only for live config"
     );
+    let stored_bridge_config = stored_bridge
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    let parsed_stored: toml::Value =
+        toml::from_str(stored_bridge_config).expect("parse stored bridge config");
+    assert_eq!(
+        parsed_stored
+            .get("model_providers")
+            .and_then(|v| v.get("aihubmix"))
+            .and_then(|v| v.get("requires_openai_auth"))
+            .and_then(|v| v.as_bool()),
+        Some(true),
+        "backfill must restore template requires_openai_auth, not keep live-projected false"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary / 概述

- When CC Switch projects a third-party Codex API key into the active provider as `experimental_bearer_token`, also set that provider's `requires_openai_auth = false`
- Keep the user's ChatGPT OAuth `auth.json` for Codex app features (remote control / official plugins), without letting Codex 0.144+ select official subscription auth for third-party inference
- Update the existing provider-switch integration expectation and add regression coverage for direct preserved-auth switching and proxy takeover

Codex 0.144+ treats `requires_openai_auth = true` as an explicit request to use ChatGPT authentication. Before this change, CC Switch could show a custom/local model provider while the preserved official login was still selected for authentication, causing requests to use official quota or stall in the OpenAI login path.

This intentionally changes only **generated live configuration**. Stored provider templates remain unchanged so the legacy direct-switch path (API key written to `auth.json`) keeps existing behavior. Official Codex proxy routes also continue to use `requires_openai_auth = true`.

This rebases the approach from #5469 / #5222 onto current `main` (those PRs are behind main).

## Related Issue / 关联 Issue

Fixes #4393

Related: #3596, #5222, #5469, #5345, #5293

## Verification / 验证

- `cargo test --lib prepare_provider_live_config_disables_openai_auth_for_custom_provider`
- `cargo test --lib codex_config::tests` (69 passed)
- `cargo test --test provider_service preserves_oauth_and_backfills`
- `cargo test --lib codex_custom_provider`

## Checklist / 检查清单

- [x] No frontend changes; TypeScript checks are not applicable
- [x] Rust unit/integration tests covering the auth path pass
- [x] Focused change only — live config projection for third-party Codex routes