### PR TITLE
fix(proxy): improve GitHub Copilot compatibility with modern Claude Code

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -87,6 +87,17 @@ impl Provider {
             || self.claude_base_url_contains("chatgpt.com/backend-api/codex")
     }
 
+    /// Whether the provider form's "auth field" was explicitly set to
+    /// ANTHROPIC_API_KEY. The form only persists `meta.apiKeyField` for the
+    /// non-default choice, so `None` means the default ANTHROPIC_AUTH_TOKEN.
+    pub fn claude_uses_api_key_field(&self) -> bool {
+        self.meta
+            .as_ref()
+            .and_then(|m| m.api_key_field.as_deref())
+            .map(|field| field.eq_ignore_ascii_case("ANTHROPIC_API_KEY"))
+            .unwrap_or(false)
+    }
+
     fn provider_type(&self) -> Option<&str> {
         self.meta.as_ref().and_then(|m| m.provider_type.as_deref())
     }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1183,6 +1183,15 @@ impl RequestForwarder {
                 super::providers::copilot_model_map::apply_copilot_model_normalization(mapped_body);
             self.apply_copilot_live_model_resolution(provider, &mut mapped_body)
                 .await;
+            // Strip the [1M] context marker after Copilot normalization/resolve.
+            // A user's mapped value (e.g. "gpt-5.6-sol[1M]") carries [1M] as a
+            // Claude Code context-capability declaration that upstream APIs reject
+            // as part of the model name. The preceding normalization step already
+            // rewrites claude-xxx[1M] into the "-1m" dash form Copilot accepts, and
+            // the strip helper only touches the "[1m]" bracket form, so "-1m"
+            // variants pass through unchanged.
+            mapped_body =
+                super::model_mapper::strip_one_m_suffix_for_upstream_from_body(mapped_body);
         } else if !codex_responses_to_anthropic {
             // Skip on the Codex→Anthropic path: stripping [1m] here would break both the
             // model-catalog match (apply_codex_upstream_model) and the transform's own

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -95,9 +95,15 @@ impl ProxyService {
         let auth_policy = if provider.uses_managed_account_auth() {
             // Codex 系（含仅凭 base_url 识别、无 provider_type meta 的）必须保留
             // ANTHROPIC_AUTH_TOKEN 占位符：Claude Code 缺该键会弹登录提示（#3784）。
-            // Copilot 维持仅 API_KEY 占位，避免与 /login 管理的 key 冲突（#1049）。
+            // Copilot 默认同样注入 AUTH_TOKEN 占位符：新版 Claude Code 会对
+            // ANTHROPIC_API_KEY 做 sk-ant-* 格式校验，PROXY_MANAGED 占位符被判
+            // 无效而提示 Not logged in；AUTH_TOKEN 作为第三方 Bearer 被直接信任，
+            // 并可抑制 OAuth 登录提示（#3289/#3784）。仅当供应商表单显式选择了
+            // ANTHROPIC_API_KEY（meta.apiKeyField）时才保留 API_KEY 占位，以规避
+            // 与 /login 管理的 key 冲突（#1049）。
             ClaudeTakeoverAuthPolicy::ManagedAccount {
-                keep_auth_token: !provider.is_github_copilot(),
+                keep_auth_token: !provider.is_github_copilot()
+                    || !provider.claude_uses_api_key_field(),
             }
         } else {
             ClaudeTakeoverAuthPolicy::PreserveExistingOrAuthToken
@@ -197,7 +203,9 @@ impl ProxyService {
                 // - Codex 系保留 AUTH_TOKEN：缺该键 Claude Code 会弹登录提示（#3784）。
                 //   无条件注入而非"已存在才保留"：热切换路径传入的是 provider
                 //   settings（预设不含该键），且旧版接管已把存量用户 live 中的键删光。
-                // - Copilot 仅 API_KEY：避免与 /login 管理的 key 冲突（#1049）。
+                // - Copilot 默认 AUTH_TOKEN（API_KEY 占位符会被新版 Claude Code 判为
+                //   无效 key 而 Not logged in，#3289）；仅当表单显式选择了
+                //   ANTHROPIC_API_KEY 时才用 API_KEY 占位以规避 /login key 冲突（#1049）。
                 if keep_auth_token {
                     env.insert(
                         "ANTHROPIC_AUTH_TOKEN".to_string(),
@@ -3304,7 +3312,7 @@ mod tests {
     }
 
     #[test]
-    fn managed_account_claude_takeover_uses_api_key_placeholder() {
+    fn managed_account_claude_takeover_uses_auth_token_placeholder() {
         let mut provider = Provider::with_id(
             "copilot".to_string(),
             "GitHub Copilot".to_string(),
@@ -3333,13 +3341,13 @@ mod tests {
             .and_then(|value| value.as_object())
             .expect("env should exist");
         assert_eq!(
-            env.get("ANTHROPIC_API_KEY")
+            env.get("ANTHROPIC_AUTH_TOKEN")
                 .and_then(|value| value.as_str()),
             Some(PROXY_TOKEN_PLACEHOLDER)
         );
         assert!(
-            env.get("ANTHROPIC_AUTH_TOKEN").is_none(),
-            "managed OAuth providers should avoid Claude Auth Token login semantics"
+            env.get("ANTHROPIC_API_KEY").is_none(),
+            "API_KEY placeholders are rejected by modern Claude Code's sk-ant-* validation (#3289)"
         );
     }
 
@@ -3421,8 +3429,8 @@ mod tests {
             "CLAUDE_CODE_SUBAGENT_MODEL",
             Some("claude-sonnet-4.6[1M]"),
         );
-        assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
-        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", None);
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_API_KEY", None);
     }
 
     #[test]
@@ -3675,7 +3683,7 @@ mod tests {
     }
 
     #[test]
-    fn managed_account_claude_takeover_copilot_removes_stale_auth_token() {
+    fn managed_account_claude_takeover_copilot_defaults_to_auth_token() {
         let mut provider = Provider::with_id(
             "copilot".to_string(),
             "GitHub Copilot".to_string(),
@@ -3688,6 +3696,47 @@ mod tests {
         );
         provider.meta = Some(ProviderMeta {
             provider_type: Some("github_copilot".to_string()),
+            ..Default::default()
+        });
+
+        let mut live_config = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://stale.example.com",
+                "ANTHROPIC_AUTH_TOKEN": "stale-token",
+                "ANTHROPIC_API_KEY": "stale-key"
+            }
+        });
+        ProxyService::apply_claude_takeover_fields_for_provider(
+            &mut live_config,
+            "http://127.0.0.1:15721",
+            &provider,
+        );
+
+        let env = live_config
+            .get("env")
+            .and_then(|value| value.as_object())
+            .expect("env should exist");
+        // Default Copilot takeover injects AUTH_TOKEN: the API_KEY placeholder is
+        // rejected by modern Claude Code's sk-ant-* validation ("Not logged in", #3289).
+        assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+        assert_env_str(env, "ANTHROPIC_API_KEY", None);
+    }
+
+    #[test]
+    fn managed_account_claude_takeover_copilot_honors_api_key_field_choice() {
+        let mut provider = Provider::with_id(
+            "copilot".to_string(),
+            "GitHub Copilot".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.githubcopilot.com"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            provider_type: Some("github_copilot".to_string()),
+            api_key_field: Some("ANTHROPIC_API_KEY".to_string()),
             ..Default::default()
         });
 
@@ -3707,6 +3756,8 @@ mod tests {
             .get("env")
             .and_then(|value| value.as_object())
             .expect("env should exist");
+        // Explicit API-key-field choice keeps the API_KEY placeholder to avoid
+        // conflicting with the /login-managed key (#1049).
         assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
         assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", None);
     }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -95,10 +95,11 @@ impl ProxyService {
         let auth_policy = if provider.uses_managed_account_auth() {
             // Codex 系（含仅凭 base_url 识别、无 provider_type meta 的）必须保留
             // ANTHROPIC_AUTH_TOKEN 占位符：Claude Code 缺该键会弹登录提示（#3784）。
-            // Copilot 默认同样注入 AUTH_TOKEN 占位符：新版 Claude Code 会对
-            // ANTHROPIC_API_KEY 做 sk-ant-* 格式校验，PROXY_MANAGED 占位符被判
-            // 无效而提示 Not logged in；AUTH_TOKEN 作为第三方 Bearer 被直接信任，
-            // 并可抑制 OAuth 登录提示（#3289/#3784）。仅当供应商表单显式选择了
+            // Copilot 默认同样注入 AUTH_TOKEN 占位符：Claude Code（实测 2.1.220）
+            // 对 ANTHROPIC_API_KEY 会弹"是否使用该自定义 key"确认框且默认
+            // "No (recommended)"，按默认走后占位符被忽略、落入 Not logged in
+            // （并非 sk-ant-* 格式校验——headless 下占位符原样出站）；AUTH_TOKEN
+            // 作为网关 Bearer 被直接信任，零弹窗。仅当供应商表单显式选择了
             // ANTHROPIC_API_KEY（meta.apiKeyField）时才保留 API_KEY 占位，以规避
             // 与 /login 管理的 key 冲突（#1049）。
             ClaudeTakeoverAuthPolicy::ManagedAccount {
@@ -203,9 +204,10 @@ impl ProxyService {
                 // - Codex 系保留 AUTH_TOKEN：缺该键 Claude Code 会弹登录提示（#3784）。
                 //   无条件注入而非"已存在才保留"：热切换路径传入的是 provider
                 //   settings（预设不含该键），且旧版接管已把存量用户 live 中的键删光。
-                // - Copilot 默认 AUTH_TOKEN（API_KEY 占位符会被新版 Claude Code 判为
-                //   无效 key 而 Not logged in，#3289）；仅当表单显式选择了
-                //   ANTHROPIC_API_KEY 时才用 API_KEY 占位以规避 /login key 冲突（#1049）。
+                // - Copilot 默认 AUTH_TOKEN：API_KEY 占位符会触发 Claude Code 的
+                //   自定义 key 确认框（默认 "No (recommended)"），按默认走即
+                //   Not logged in；仅当表单显式选择了 ANTHROPIC_API_KEY 时才用
+                //   API_KEY 占位以规避 /login key 冲突（#1049）。
                 if keep_auth_token {
                     env.insert(
                         "ANTHROPIC_AUTH_TOKEN".to_string(),
@@ -3347,7 +3349,7 @@ mod tests {
         );
         assert!(
             env.get("ANTHROPIC_API_KEY").is_none(),
-            "API_KEY placeholders are rejected by modern Claude Code's sk-ant-* validation (#3289)"
+            "API_KEY placeholders trigger Claude Code's custom-key approval prompt (defaults to No), landing users in Not logged in"
         );
     }
 
@@ -3716,8 +3718,9 @@ mod tests {
             .get("env")
             .and_then(|value| value.as_object())
             .expect("env should exist");
-        // Default Copilot takeover injects AUTH_TOKEN: the API_KEY placeholder is
-        // rejected by modern Claude Code's sk-ant-* validation ("Not logged in", #3289).
+        // Default Copilot takeover injects AUTH_TOKEN: the API_KEY placeholder
+        // triggers Claude Code's custom-key approval prompt (defaults to
+        // "No (recommended)"), which lands users in "Not logged in".
         assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
         assert_env_str(env, "ANTHROPIC_API_KEY", None);
     }


### PR DESCRIPTION
## Summary / 概述

  Improve GitHub Copilot provider compatibility with modern Claude Code.

  提升 GitHub Copilot Provider 与新版 Claude Code 的兼容性。

  This PR fixes two related issues in the Copilot proxy path:

  1. **Authentication placeholder**
     - Use `ANTHROPIC_AUTH_TOKEN=PROXY_MANAGED` by default for Copilot providers.
     - Modern Claude Code validates `ANTHROPIC_API_KEY` using the `sk-ant-*` format, causing the previous placeholder to report `Not logged in`.
     - Preserve `ANTHROPIC_API_KEY` behavior when users explicitly select that authentication field.

  2. **Model mapping with `[1M]`**
     - Strip Claude Code's local `[1M]` context marker from mapped model IDs before forwarding requests to Copilot.
     - For example, `claude-opus-4-8` mapped to `gpt-5.6-sol[1M]` is now forwarded upstream as `gpt-5.6-sol`.
     - Copilot-native `-1m` model variants remain unchanged.

  此 PR 修复 Copilot 代理路径中的两个相关问题：

  1. **认证占位符**
     - Copilot Provider 默认使用 `ANTHROPIC_AUTH_TOKEN=PROXY_MANAGED`。
     - 新版 Claude Code 会按照 `sk-ant-*` 格式校验 `ANTHROPIC_API_KEY`，导致原占位符触发 `Not logged in`。
     - 用户明确选择 `ANTHROPIC_API_KEY` 时仍保留原有行为。

  2. **带 `[1M]` 的模型映射**
     - 转发至 Copilot 前，移除映射模型名称中的 Claude Code 本地 `[1M]` 上下文标记。
     - 例如，`claude-opus-4-8` 映射为 `gpt-5.6-sol[1M]` 后，现在会以 `gpt-5.6-sol` 请求上游。
     - Copilot 原生的 `-1m` 模型变体不受影响。

  ### Verification / 验证

  Manually verified with a GitHub Copilot provider:

  - Haiku: `claude-haiku-4-5` → `gpt-5.6-sol`
  - Opus: `claude-opus-4-8` → `gpt-5.6-sol[1M]` → upstream receives `gpt-5.6-sol`
  - Authentication works without the Claude Code `Not logged in` error
  - Rust release compilation completed successfully
  - NSIS and MSI bundles were generated successfully

  已使用 GitHub Copilot Provider 手动验证：

  - Haiku：`claude-haiku-4-5` → `gpt-5.6-sol`
  - Opus：`claude-opus-4-8` → `gpt-5.6-sol[1M]` → 上游实际收到 `gpt-5.6-sol`
  - 认证正常，不再出现 Claude Code `Not logged in`
  - Rust release 编译成功
  - NSIS 和 MSI 安装包生成成功

  ## Related Issue / 关联 Issue

  N/A

  ## Screenshots / 截图

  N/A — this change only affects proxy authentication and request forwarding behavior.

  不适用——本次修改仅影响代理认证与请求转发行为。

  ## Checklist / 检查清单

  - [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
  - [ ] `pnpm format:check` passes / 通过代码格式检查
  - [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
  - [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
    - No user-facing text was changed, so no i18n update is required.
    - 未修改用户可见文本，因此无需更新国际化文件。