### PR TITLE
fix(kimi): support K3 1M context in Claude Code

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -29,13 +29,13 @@ use super::normalize_claude_models_in_value;
 /// usable context.
 const CODEX_OAUTH_CLAUDE_MAX_CONTEXT_TOKENS: &str = "372000";
 const CODEX_OAUTH_CLAUDE_AUTO_COMPACT_WINDOW: &str = "372000";
-const KIMI_FOR_CODING_CONTEXT_TOKENS: &str = "262144";
+const KIMI_FOR_CODING_256K_CONTEXT_TOKENS: &str = "262144";
+const KIMI_K3_1M_CONTEXT_TOKENS: &str = "1048576";
 
-/// Model env keys Claude Code may route requests through. The defaults above
-/// are calibrated against gpt-5.6's Codex catalog, so every configured model
-/// must belong to that family before they are injected — gpt-5.5's upstream
-/// catalog oscillates between 272K and 372K and must not inherit them.
-const CODEX_OAUTH_MODEL_ENV_KEYS: [&str; 6] = [
+/// Model env keys Claude Code may route requests through. Context-window envs
+/// are global, so every configured route must support a model-specific default
+/// before that default may be injected.
+const CLAUDE_MODEL_ENV_KEYS: [&str; 6] = [
     "ANTHROPIC_MODEL",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL",
     "ANTHROPIC_DEFAULT_SONNET_MODEL",
@@ -49,7 +49,7 @@ fn provider_env_targets_gpt56(provider_env: Option<&serde_json::Map<String, Valu
         return false;
     };
     let mut saw_model = false;
-    for key in CODEX_OAUTH_MODEL_ENV_KEYS {
+    for key in CLAUDE_MODEL_ENV_KEYS {
         let Some(value) = env.get(key) else {
             continue;
         };
@@ -76,6 +76,43 @@ fn is_kimi_for_coding_provider(provider: &Provider) -> bool {
         .map(str::trim)
         .map(|url| url.trim_end_matches('/'))
         == Some("https://api.kimi.com/coding")
+}
+
+fn kimi_for_coding_context_tokens(provider: &Provider) -> Option<&'static str> {
+    if !is_kimi_for_coding_provider(provider) {
+        return None;
+    }
+
+    let provider_env = provider
+        .settings_config
+        .get("env")
+        .and_then(Value::as_object);
+    let all_routes_target_k3_1m = provider_env.is_some_and(|env| {
+        let mut saw_model = false;
+        for key in CLAUDE_MODEL_ENV_KEYS {
+            let Some(value) = env.get(key) else {
+                continue;
+            };
+            let Some(model) = value.as_str() else {
+                return false;
+            };
+            let model = model.trim();
+            if model.is_empty() {
+                continue;
+            }
+            saw_model = true;
+            if !model.eq_ignore_ascii_case("k3[1m]") {
+                return false;
+            }
+        }
+        saw_model
+    });
+
+    Some(if all_routes_target_k3_1m {
+        KIMI_K3_1M_CONTEXT_TOKENS
+    } else {
+        KIMI_FOR_CODING_256K_CONTEXT_TOKENS
+    })
 }
 
 /// Claude Code assigns unknown non-Claude model ids a 200K context window.
@@ -133,15 +170,15 @@ fn apply_codex_oauth_claude_context_defaults(settings: &mut Value, provider: &Pr
     }
 }
 
-/// Kimi For Coding serves a 256K window, but Claude Code caps unknown models at
-/// 200K unless `CLAUDE_CODE_MAX_CONTEXT_TOKENS` is set — and that env is ignored
-/// for `claude-`-prefixed ids, so these defaults only bite when the provider also
-/// routes the endpoint's `kimi-for-coding` alias (the preset does). Keep the
-/// defaults provider-owned so an old shared snippet cannot override them.
+/// Kimi's coding endpoint serves models with different windows: K2.7 Code and
+/// K3-256K use 256K, while Claude Code's explicit `k3[1m]` selector uses 1M.
+/// Claude Code caps unknown models at 200K unless MAX_CONTEXT_TOKENS is set, so
+/// derive the default from the provider-owned model id. Explicit provider env
+/// values still win, and an old shared snippet cannot override them.
 fn apply_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provider) {
-    if !is_kimi_for_coding_provider(provider) {
+    let Some(context_tokens) = kimi_for_coding_context_tokens(provider) else {
         return;
-    }
+    };
 
     let provider_env = provider
         .settings_config
@@ -158,7 +195,7 @@ fn apply_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provi
         let value = provider_env
             .and_then(|provider_env| provider_env.get(key))
             .cloned()
-            .unwrap_or_else(|| Value::String(KIMI_FOR_CODING_CONTEXT_TOKENS.to_string()));
+            .unwrap_or_else(|| Value::String(context_tokens.to_string()));
         env.insert(key.to_string(), value);
     }
 }
@@ -799,9 +836,9 @@ fn strip_injected_codex_oauth_context_defaults(settings: &mut Value, provider: &
 }
 
 fn strip_injected_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provider) {
-    if !is_kimi_for_coding_provider(provider) {
+    let Some(context_tokens) = kimi_for_coding_context_tokens(provider) else {
         return;
-    }
+    };
     let provider_env = provider
         .settings_config
         .get("env")
@@ -816,7 +853,7 @@ fn strip_injected_kimi_for_coding_context_defaults(settings: &mut Value, provide
         if provider_env.is_some_and(|provider_env| provider_env.contains_key(key)) {
             continue;
         }
-        if env.get(key).and_then(Value::as_str) == Some(KIMI_FOR_CODING_CONTEXT_TOKENS) {
+        if env.get(key).and_then(Value::as_str) == Some(context_tokens) {
             env.remove(key);
         }
     }
@@ -2008,6 +2045,63 @@ mod tests {
     }
 
     #[test]
+    fn kimi_k3_1m_effective_settings_use_model_specific_context() {
+        let db = Database::memory().expect("create memory db");
+        let provider = Provider::with_id(
+            "kimi-k3-1m".to_string(),
+            "Kimi K3 1M".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.kimi.com/coding/",
+                    "ANTHROPIC_MODEL": "k3[1M]"
+                }
+            }),
+            None,
+        );
+
+        let effective =
+            build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+                .expect("build effective settings");
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_MAX_CONTEXT_TOKENS"],
+            json!("1048576")
+        );
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"],
+            json!("1048576")
+        );
+    }
+
+    #[test]
+    fn kimi_k3_1m_default_requires_every_configured_route_to_support_1m() {
+        let db = Database::memory().expect("create memory db");
+        let provider = Provider::with_id(
+            "kimi-k3-mixed".to_string(),
+            "Kimi K3 Mixed".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.kimi.com/coding/",
+                    "ANTHROPIC_MODEL": "k3[1M]",
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "kimi-for-coding"
+                }
+            }),
+            None,
+        );
+
+        let effective =
+            build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+                .expect("build effective settings");
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_MAX_CONTEXT_TOKENS"],
+            json!("262144")
+        );
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"],
+            json!("262144")
+        );
+    }
+
+    #[test]
     fn kimi_for_coding_context_defaults_preserve_user_overrides() {
         let db = Database::memory().expect("create memory db");
         let provider = Provider::with_id(
@@ -2062,6 +2156,33 @@ mod tests {
             backfilled["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"],
             json!("262144")
         );
+    }
+
+    #[test]
+    fn kimi_k3_1m_backfill_strips_model_specific_injected_defaults() {
+        let db = Database::memory().expect("create memory db");
+        let provider = Provider::with_id(
+            "kimi-k3-1m".to_string(),
+            "Kimi K3 1M".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.kimi.com/coding/",
+                    "ANTHROPIC_MODEL": "k3[1M]"
+                }
+            }),
+            None,
+        );
+
+        let live = build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+            .expect("build effective settings");
+        let backfilled =
+            strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
+        assert!(backfilled["env"]
+            .get("CLAUDE_CODE_MAX_CONTEXT_TOKENS")
+            .is_none());
+        assert!(backfilled["env"]
+            .get("CLAUDE_CODE_AUTO_COMPACT_WINDOW")
+            .is_none());
     }
 
     #[test]

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -137,6 +137,49 @@ export function EditProviderDialog({
       unknown
     >;
 
+    const storedClaudeEnv =
+      provider?.settingsConfig?.env &&
+      typeof provider.settingsConfig.env === "object"
+        ? (provider.settingsConfig.env as Record<string, unknown>)
+        : undefined;
+    const isKimiCodingProvider =
+      appId === "claude" &&
+      typeof storedClaudeEnv?.ANTHROPIC_BASE_URL === "string" &&
+      storedClaudeEnv.ANTHROPIC_BASE_URL.trim().replace(/\/+$/, "") ===
+        "https://api.kimi.com/coding";
+
+    // Kimi context defaults may be injected only into Claude's live settings.
+    // They are provider-owned values, so the DB remains the SSOT in the editor:
+    // preserve an explicit stored override, and remove an injected-only live
+    // value when the provider did not store the key.
+    if (
+      isKimiCodingProvider &&
+      liveSettings &&
+      provider?.settingsConfig &&
+      typeof provider.settingsConfig === "object"
+    ) {
+      const merged = { ...base };
+      const liveEnv =
+        base.env && typeof base.env === "object"
+          ? { ...(base.env as Record<string, unknown>) }
+          : {};
+      const storedEnv = storedClaudeEnv ?? {};
+
+      for (const key of [
+        "CLAUDE_CODE_MAX_CONTEXT_TOKENS",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+      ]) {
+        if (Object.prototype.hasOwnProperty.call(storedEnv, key)) {
+          liveEnv[key] = storedEnv[key];
+        } else {
+          delete liveEnv[key];
+        }
+      }
+
+      merged.env = liveEnv;
+      return merged;
+    }
+
     // Codex 的 modelCatalog 是 cc-switch 私有字段，SSOT 在数据库。Live 的 config.toml
     // 仅在写入时投影出 model_catalog_json 指针；Codex.app 改写配置、代理接管/恢复周期、
     // 来回切换供应商都可能让 Live 丢失该投影，从而 read_live_settings 反解为空。

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -22,6 +22,38 @@ interface EditProviderDialogProps {
   isProxyTakeover?: boolean; // 代理接管模式下不读取 live（避免显示被接管后的代理配置）
 }
 
+const KIMI_MODEL_ENV_KEYS = [
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL",
+  "ANTHROPIC_DEFAULT_FABLE_MODEL",
+  "CLAUDE_CODE_SUBAGENT_MODEL",
+] as const;
+
+const KIMI_CONTEXT_ENV_KEYS = [
+  "CLAUDE_CODE_MAX_CONTEXT_TOKENS",
+  "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+] as const;
+
+function getKimiInjectedContextDefault(
+  storedEnv: Record<string, unknown>,
+): "262144" | "1048576" {
+  let sawModel = false;
+  for (const key of KIMI_MODEL_ENV_KEYS) {
+    const value = storedEnv[key];
+    if (value === undefined) continue;
+    if (typeof value !== "string") return "262144";
+
+    const model = value.trim();
+    if (!model) continue;
+    sawModel = true;
+    if (model.toLowerCase() !== "k3[1m]") return "262144";
+  }
+
+  return sawModel ? "1048576" : "262144";
+}
+
 export function EditProviderDialog({
   open,
   provider,
@@ -148,10 +180,10 @@ export function EditProviderDialog({
       storedClaudeEnv.ANTHROPIC_BASE_URL.trim().replace(/\/+$/, "") ===
         "https://api.kimi.com/coding";
 
-    // Kimi context defaults may be injected only into Claude's live settings.
-    // They are provider-owned values, so the DB remains the SSOT in the editor:
-    // preserve an explicit stored override, and remove an injected-only live
-    // value when the provider did not store the key.
+    // Keep this derivation symmetric with the backend's Kimi injection logic.
+    // Only strip a live value proven to be generated: the provider did not
+    // store the key and the value exactly matches its model-specific default.
+    // Any other live value may be a manual edit and must survive round-trip.
     if (
       isKimiCodingProvider &&
       liveSettings &&
@@ -164,14 +196,13 @@ export function EditProviderDialog({
           ? { ...(base.env as Record<string, unknown>) }
           : {};
       const storedEnv = storedClaudeEnv ?? {};
+      const injectedDefault = getKimiInjectedContextDefault(storedEnv);
 
-      for (const key of [
-        "CLAUDE_CODE_MAX_CONTEXT_TOKENS",
-        "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
-      ]) {
-        if (Object.prototype.hasOwnProperty.call(storedEnv, key)) {
-          liveEnv[key] = storedEnv[key];
-        } else {
+      for (const key of KIMI_CONTEXT_ENV_KEYS) {
+        if (
+          !Object.prototype.hasOwnProperty.call(storedEnv, key) &&
+          liveEnv[key] === injectedDefault
+        ) {
           delete liveEnv[key];
         }
       }

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -134,6 +134,30 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#6366F1",
   },
   {
+    name: "Kimi K3 (1M)",
+    primePartner: true,
+    websiteUrl: "https://www.kimi.com/code/?aff=cc-switch",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+        ANTHROPIC_AUTH_TOKEN: "",
+        // Claude Code requires the bracketed selector to request K3's 1M tier.
+        ANTHROPIC_MODEL: "k3[1m]",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "k3[1m]",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "k3[1m]",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "k3[1m]",
+        ANTHROPIC_DEFAULT_FABLE_MODEL: "k3[1m]",
+        CLAUDE_CODE_SUBAGENT_MODEL: "k3[1m]",
+        CLAUDE_CODE_EFFORT_LEVEL: "high",
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "1048576",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1048576",
+      },
+    },
+    category: "cn_official",
+    icon: "kimi",
+    iconColor: "#6366F1",
+  },
+  {
     name: "PackyCode",
     websiteUrl: "https://www.packyapi.ai",
     apiKeyUrl: "https://www.packyapi.ai/register?aff=cc-switch",

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -159,7 +159,69 @@ describe("EditProviderDialog", () => {
     });
   });
 
-  it("Claude 编辑器不把仅存在于 live 的 Kimi 上下文默认值固化进数据库", async () => {
+  it.each([
+    ["256K", { ANTHROPIC_MODEL: "kimi-for-coding" }, "262144"],
+    ["K3 1M", { ANTHROPIC_MODEL: "k3[1m]" }, "1048576"],
+    [
+      "mixed-route",
+      {
+        ANTHROPIC_MODEL: "k3[1m]",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "k2.7-code",
+      },
+      "262144",
+    ],
+  ])(
+    "Claude 编辑器不把仅存在于 live 的 Kimi %s 上下文默认值固化进数据库",
+    async (_case, modelEnv, injectedDefault) => {
+      const provider: Provider = {
+        id: "kimi",
+        name: "Kimi",
+        category: "cn_official",
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+            ...modelEnv,
+          },
+        },
+      };
+      const liveSettings = {
+        env: {
+          ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+          ...modelEnv,
+          CLAUDE_CODE_MAX_CONTEXT_TOKENS: injectedDefault,
+          CLAUDE_CODE_AUTO_COMPACT_WINDOW: injectedDefault,
+        },
+      };
+      const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+      apiMocks.getCurrent.mockResolvedValue(provider.id);
+      apiMocks.getLiveProviderSettings.mockResolvedValue(liveSettings);
+
+      render(
+        <EditProviderDialog
+          open
+          provider={provider}
+          onOpenChange={vi.fn()}
+          onSubmit={handleSubmit}
+          appId="claude"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+        ).toEqual(provider.settingsConfig);
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+      await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+      expect(handleSubmit.mock.calls[0][0].provider.settingsConfig).toEqual(
+        provider.settingsConfig,
+      );
+    },
+  );
+
+  it("Claude 编辑器保留数据库未存储的 Kimi live 手动上下文值", async () => {
     const provider: Provider = {
       id: "kimi",
       name: "Kimi",
@@ -175,8 +237,8 @@ describe("EditProviderDialog", () => {
       env: {
         ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
         ANTHROPIC_MODEL: "k3[1m]",
-        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
-        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "900000",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "880000",
       },
     };
     const handleSubmit = vi.fn().mockResolvedValue(undefined);
@@ -197,17 +259,17 @@ describe("EditProviderDialog", () => {
     await waitFor(() => {
       expect(
         JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
-      ).toEqual(provider.settingsConfig);
+      ).toEqual(liveSettings);
     });
 
     fireEvent.click(screen.getByRole("button", { name: "common.save" }));
     await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
     expect(handleSubmit.mock.calls[0][0].provider.settingsConfig).toEqual(
-      provider.settingsConfig,
+      liveSettings,
     );
   });
 
-  it("Claude 编辑器以数据库中的显式 Kimi 1M 窗口覆盖 live 默认值", async () => {
+  it("Claude 编辑器保留与数据库显式值不同的 Kimi live 手动上下文值", async () => {
     const provider: Provider = {
       id: "kimi",
       name: "Kimi",
@@ -225,8 +287,8 @@ describe("EditProviderDialog", () => {
       env: {
         ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
         ANTHROPIC_MODEL: "k3[1m]",
-        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
-        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "900000",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "880000",
       },
     };
 
@@ -246,7 +308,7 @@ describe("EditProviderDialog", () => {
     await waitFor(() => {
       expect(
         JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
-      ).toEqual(provider.settingsConfig);
+      ).toEqual(liveSettings);
     });
   });
 

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -159,6 +159,97 @@ describe("EditProviderDialog", () => {
     });
   });
 
+  it("Claude 编辑器不把仅存在于 live 的 Kimi 上下文默认值固化进数据库", async () => {
+    const provider: Provider = {
+      id: "kimi",
+      name: "Kimi",
+      category: "cn_official",
+      settingsConfig: {
+        env: {
+          ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+          ANTHROPIC_MODEL: "k3[1m]",
+        },
+      },
+    };
+    const liveSettings = {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+        ANTHROPIC_MODEL: "k3[1m]",
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
+      },
+    };
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockResolvedValue(liveSettings);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={handleSubmit}
+        appId="claude"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual(provider.settingsConfig);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+    expect(handleSubmit.mock.calls[0][0].provider.settingsConfig).toEqual(
+      provider.settingsConfig,
+    );
+  });
+
+  it("Claude 编辑器以数据库中的显式 Kimi 1M 窗口覆盖 live 默认值", async () => {
+    const provider: Provider = {
+      id: "kimi",
+      name: "Kimi",
+      category: "cn_official",
+      settingsConfig: {
+        env: {
+          ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+          ANTHROPIC_MODEL: "k3[1m]",
+          CLAUDE_CODE_MAX_CONTEXT_TOKENS: "1048576",
+          CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1048576",
+        },
+      },
+    };
+    const liveSettings = {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+        ANTHROPIC_MODEL: "k3[1m]",
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
+      },
+    };
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockResolvedValue(liveSettings);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="claude"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual(provider.settingsConfig);
+    });
+  });
+
   it("代理接管中编辑 Codex 供应商时展示数据库配置而不是读取 live 代理配置", async () => {
     const provider: Provider = {
       id: "deepseek",

--- a/tests/config/claudeProviderPresets.test.ts
+++ b/tests/config/claudeProviderPresets.test.ts
@@ -31,6 +31,31 @@ describe("Kimi For Coding Provider Preset", () => {
   });
 });
 
+describe("Kimi K3 1M Provider Preset", () => {
+  const kimiK3 = providerPresets.find(
+    (preset) => preset.name === "Kimi K3 (1M)",
+  );
+
+  it("uses Claude Code's explicit K3 1M selector on every route", () => {
+    const env = (kimiK3!.settingsConfig as any).env;
+    expect(kimiK3).toBeDefined();
+    expect(env).toMatchObject({
+      ANTHROPIC_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_FABLE_MODEL: "k3[1m]",
+      CLAUDE_CODE_SUBAGENT_MODEL: "k3[1m]",
+    });
+  });
+
+  it("pins both context knobs to 1M", () => {
+    const env = (kimiK3!.settingsConfig as any).env;
+    expect(env.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe("1048576");
+    expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("1048576");
+  });
+});
+
 describe("Codex Provider Preset", () => {
   const codex = providerPresets.find((p) => p.name === "Codex");
 


### PR DESCRIPTION
## Summary

- derive the Kimi Coding context defaults from every configured Claude Code model route
- keep the existing 256K behavior for `kimi-for-coding`, `k3-256k`, and mixed model routes
- add a `Kimi K3 (1M)` preset using Kimi's documented `k3[1m]` selector and 1,048,576-token context values
- prevent injected live-only Kimi defaults from being serialized back into the provider record while preserving explicit provider overrides

## Root cause

The backend recognized `https://api.kimi.com/coding` only at the endpoint level and unconditionally injected `262144` for both context environment variables. When the active provider was edited, the frontend preferred the effective live settings over the database record, so those generated values appeared in the editor and were persisted again on save.

Kimi's current Claude Code documentation distinguishes the plan/model combinations: K2.7 Code and K3-256K use 256K, while Allegretto and above can request K3's 1M window with `k3[1m]`.

## User impact

Allegretto and higher-plan users can select the new K3 1M preset or explicitly store the 1M values without CC Switch rewriting them to 256K. Lower-plan and 256K model configurations retain the existing defaults. Because the context environment variables are global, a provider with mixed routes stays conservatively at 256K.

## Validation

- `tsc --noEmit`
- Prettier check for frontend sources
- Vitest: 79 files, 526 tests passed
- `cargo fmt --check`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo test --lib`: 2247 passed, 2 ignored

Closes #5836