### PR TITLE
fix: strip namespace from input items for native Responses passthrough

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1563,6 +1563,27 @@ impl RequestForwarder {
             );
         }
 
+        // Native Responses passthrough: strip `namespace` from `input[]` items.
+        // Codex 0.142+ sends `namespace` on `function_call` items in the `input`
+        // history when the client is configured with a custom `model_provider`.
+        // The official ChatGPT backend (`chatgpt.com/backend-api/codex`) rejects
+        // this redundant field with `unknown_parameter: input[N].namespace`.
+        // xAI is excluded because its namespace flatten (above) already rewrites
+        // namespace-qualified calls, removing the `namespace` field.
+        if matches!(app_type, AppType::Codex | AppType::GrokBuild)
+            && !codex_responses_to_chat
+            && !codex_responses_to_anthropic
+            && !super::providers::provider_needs_responses_namespace_flatten(provider)
+            && super::providers::transform_codex_responses_namespace::strip_namespace_from_input_items(
+                &mut request_body,
+            )
+        {
+            log::debug!(
+                "[Codex] Stripped namespace from input items for native Responses upstream (provider={})",
+                provider.id
+            );
+        }
+
         if matches!(app_type, AppType::Codex | AppType::GrokBuild) {
             self.apply_media_prevention(&mut request_body, provider);
         }

--- a/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
@@ -428,6 +428,33 @@ fn restore_sse_block(block: &str, map: &HashMap<String, NamespacedName>) -> Byte
     Bytes::from(out)
 }
 
+/// Strip `namespace` from every object in the `input` array of a native
+/// Responses request body.
+///
+/// Codex 0.142+ sends `namespace` on `function_call` items in the `input`
+/// history when the client is configured with a custom `model_provider`.
+/// The official ChatGPT backend (`chatgpt.com/backend-api/codex`) rejects
+/// this redundant field with `unknown_parameter: input[N].namespace`.
+/// The `namespace` for a function call can be inferred from the `tools`
+/// array, so stripping it from `input` items is safe and does not break
+/// tool matching.
+///
+/// Returns `true` if any `namespace` field was removed.
+pub(crate) fn strip_namespace_from_input_items(body: &mut Value) -> bool {
+    let Some(input) = body.get_mut("input").and_then(|v| v.as_array_mut()) else {
+        return false;
+    };
+    let mut changed = false;
+    for item in input.iter_mut() {
+        if let Some(obj) = item.as_object_mut() {
+            if obj.remove("namespace").is_some() {
+                changed = true;
+            }
+        }
+    }
+    changed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -619,5 +646,54 @@ mod tests {
         // Unrelated events preserved verbatim.
         assert!(collected.contains("\"delta\":\"hi\""));
         assert!(collected.contains("[DONE]"));
+    }
+
+    #[test]
+    fn strip_namespace_from_input_items_removes_namespace_fields() {
+        let mut body = json!({
+            "model": "gpt-5",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "read",
+                    "namespace": "mcp__files__",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "c1",
+                    "output": "file content"
+                },
+                {
+                    "type": "message",
+                    "content": "hello"
+                }
+            ]
+        });
+        assert!(strip_namespace_from_input_items(&mut body));
+        let input = body["input"].as_array().unwrap();
+        assert!(input[0].get("namespace").is_none());
+        assert_eq!(input[0]["name"], "read");
+        assert_eq!(input[0]["call_id"], "c1");
+        // Non-function_call items are untouched
+        assert_eq!(input[1]["type"], "function_call_output");
+        assert_eq!(input[2]["type"], "message");
+    }
+
+    #[test]
+    fn strip_namespace_noop_when_no_input_or_no_namespace() {
+        let mut no_input = json!({"model": "gpt-5"});
+        assert!(!strip_namespace_from_input_items(&mut no_input));
+
+        let mut no_namespace = json!({
+            "input": [
+                {"type": "function_call", "call_id": "c1", "name": "read", "arguments": "{}"}
+            ]
+        });
+        assert!(!strip_namespace_from_input_items(&mut no_namespace));
+
+        let mut empty_input = json!({"input": []});
+        assert!(!strip_namespace_from_input_items(&mut empty_input));
     }
 }


### PR DESCRIPTION
## Problem

When cc-switch takes over Codex (by setting a custom `model_provider` in config.toml), the Codex client sends `namespace` on `function_call` items in the `input[]` history array. The official ChatGPT backend (`chatgpt.com/backend-api/codex`) rejects this field with:

```
[ObjectParam] [input[115].namespace] [unknown_parameter] Unknown parameter: 'input[115].namespace'
```

This makes the Codex official subscription unusable through cc-switch, regardless of whether the "unify Codex session history" setting is enabled.

## Root Cause

When Codex uses a custom provider (which cc-switch sets up), it preserves `namespace` on `function_call` items in the `input[]` history. The official ChatGPT backend accepts `namespace`-typed tools in the `tools[]` array, but **rejects** `namespace` fields on individual `input[]` items.

The native Responses passthrough path (used by the official provider) does not strip this field, so the request is forwarded verbatim and the upstream rejects it.

## Fix

- Added `strip_namespace_from_input_items()` in `transform_codex_responses_namespace.rs`
  - Removes `namespace` from every object in the `input[]` array
  - The `namespace` for a function call can be inferred from the `tools[]` array, so stripping is safe
- Called in the native Responses passthrough path in `forwarder.rs`
  - Gated on: native passthrough (not Chat/Anthropic transform) + NOT xAI OAuth (which already handles namespace via `flatten_request_namespaces`)
- Added unit tests for the new function

## Testing

- `strip_namespace_from_input_items_removes_namespace_fields`: verifies namespace removal from input items
- `strip_namespace_noop_when_no_input_or_no_namespace`: verifies no-op on bodies without input array or without namespace fields
- Existing namespace flatten/restore tests continue to pass (unchanged)