### PR TITLE
feat(codex): bidirectional session sync on provider switch (closes #5851)

### DIFF
--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -143,9 +143,9 @@ pub fn maybe_migrate_codex_third_party_history_provider_bucket(
     let backup_root = migration_backup_root(MIGRATION_NAME);
     let codex_dir = get_codex_config_dir();
     let migrated_jsonl_files =
-        migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root)?;
+        migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)?;
     let migrated_state_rows =
-        migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root)?;
+        migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)?;
 
     let source_provider_ids_vec: Vec<String> = source_provider_ids.iter().cloned().collect();
     crate::settings::mark_codex_third_party_history_provider_bucket_migrated(
@@ -237,9 +237,9 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
         std::iter::once(OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID.to_string()).collect();
     let backup_root = migration_backup_root(OFFICIAL_UNIFY_MIGRATION_NAME);
     let migrated_jsonl_files =
-        migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root)?;
+        migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)?;
     let migrated_state_rows =
-        migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root)?;
+        migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)?;
     // 备份代际记录来源目录，restore 据此只取当前目录的账本。
     write_backup_generation_meta(&backup_root, &codex_dir_key)?;
 
@@ -962,6 +962,7 @@ fn migrate_codex_jsonl_files(
     codex_dir: &Path,
     source_provider_ids: &BTreeSet<String>,
     backup_root: &Path,
+    target_provider_id: &str,
 ) -> Result<usize, AppError> {
     let mut files = Vec::new();
     collect_jsonl_files(&codex_dir.join("sessions"), &mut files, 0, 8);
@@ -975,6 +976,7 @@ fn migrate_codex_jsonl_files(
             codex_dir,
             &source_provider_ids,
             backup_root,
+            target_provider_id,
         )? {
             migrated += 1;
         }
@@ -1013,9 +1015,10 @@ fn rewrite_codex_session_file_for_provider_bucket(
     codex_dir: &Path,
     source_provider_ids: &HashSet<String>,
     backup_root: &Path,
+    target_provider_id: &str,
 ) -> Result<bool, AppError> {
     rewrite_codex_session_file_lines(path, codex_dir, backup_root, |line| {
-        rewrite_codex_session_meta_line(line, source_provider_ids)
+        rewrite_codex_session_meta_line(line, source_provider_ids, target_provider_id)
     })
 }
 
@@ -1075,6 +1078,7 @@ fn ensure_codex_session_file_unchanged(
 fn rewrite_codex_session_meta_line(
     line: &str,
     source_provider_ids: &HashSet<String>,
+    target_provider_id: &str,
 ) -> Option<String> {
     if !line.contains("\"session_meta\"") || !line.contains("\"model_provider\"") {
         return None;
@@ -1093,7 +1097,7 @@ fn rewrite_codex_session_meta_line(
 
     payload.insert(
         "model_provider".to_string(),
-        Value::String(CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string()),
+        Value::String(target_provider_id.to_string()),
     );
     serde_json::to_string(&value).ok()
 }
@@ -1102,6 +1106,7 @@ fn migrate_codex_state_dbs(
     codex_dir: &Path,
     source_provider_ids: &BTreeSet<String>,
     backup_root: &Path,
+    target_provider_id: &str,
 ) -> Result<usize, AppError> {
     let config_text = read_codex_config_text().unwrap_or_default();
     let mut migrated = 0;
@@ -1111,6 +1116,7 @@ fn migrate_codex_state_dbs(
             codex_dir,
             source_provider_ids,
             backup_root,
+            target_provider_id,
         )?;
     }
     Ok(migrated)
@@ -1121,6 +1127,7 @@ fn migrate_codex_state_db_provider_bucket(
     codex_dir: &Path,
     source_provider_ids: &BTreeSet<String>,
     backup_root: &Path,
+    target_provider_id: &str,
 ) -> Result<usize, AppError> {
     if !db_path.exists() || source_provider_ids.is_empty() {
         return Ok(0);
@@ -1156,7 +1163,7 @@ fn migrate_codex_state_db_provider_bucket(
     let update_sql =
         format!("UPDATE threads SET model_provider = ? WHERE model_provider IN ({placeholders})");
     let mut values = Vec::with_capacity(source_provider_ids.len() + 1);
-    values.push(CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string());
+    values.push(target_provider_id.to_string());
     values.extend(source_provider_ids.iter().cloned());
     let tx = conn
         .transaction()
@@ -1260,6 +1267,53 @@ fn copy_existing_file(source: &Path, target: &Path) -> Result<(), AppError> {
         fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
     }
     copy_file(source, target)
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CodexProviderSwitchSyncOutcome {
+    pub synced_jsonl_files: usize,
+    pub synced_state_rows: usize,
+    pub target_provider: String,
+    pub skipped_reason: Option<String>,
+}
+
+pub fn sync_codex_sessions_for_provider_switch(
+    provider_is_official: bool,
+) -> Result<CodexProviderSwitchSyncOutcome, AppError> {
+    if !crate::settings::unify_codex_session_history() {
+        return Ok(CodexProviderSwitchSyncOutcome {
+            skipped_reason: Some("unify_disabled".to_string()),
+            ..Default::default()
+        });
+    }
+
+    let target = if provider_is_official {
+        OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID
+    } else {
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID
+    };
+    let source = if provider_is_official {
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID
+    } else {
+        OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID
+    };
+
+    let codex_dir = get_codex_config_dir();
+    let source_provider_ids: BTreeSet<String> =
+        std::iter::once(source.to_string()).collect();
+
+    let backup_root = migration_backup_root("codex-session-sync-on-switch");
+    let synced_jsonl_files =
+        migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, target)?;
+    let synced_state_rows =
+        migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root, target)?;
+
+    Ok(CodexProviderSwitchSyncOutcome {
+        synced_jsonl_files,
+        synced_state_rows,
+        target_provider: target.to_string(),
+        skipped_reason: None,
+    })
 }
 
 fn relative_backup_path(path: &Path, root: &Path) -> PathBuf {
@@ -1474,7 +1528,7 @@ base_url = "https://proxy.example/v1"
         .expect("write session");
 
         let migrated_jsonl =
-            migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root)
+            migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
                 .expect("migrate jsonl");
         assert_eq!(migrated_jsonl, 1);
         let session_text = fs::read_to_string(&session_path).expect("read session");
@@ -1513,6 +1567,7 @@ base_url = "https://proxy.example/v1"
             &codex_dir,
             &source_provider_ids,
             &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
         )
         .expect("migrate state db");
         assert_eq!(migrated_state_rows, 3);
@@ -1642,7 +1697,7 @@ base_url = "https://proxy.example/v1"
         .expect("write session");
 
         let migrated_jsonl =
-            migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root)
+            migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
                 .expect("migrate jsonl");
         assert_eq!(migrated_jsonl, 1);
         let session_text = fs::read_to_string(&session_path).expect("read session");
@@ -1662,7 +1717,7 @@ base_url = "https://proxy.example/v1"
             .exists());
 
         // 第二次执行应当无事可做（幂等）
-        let rerun = migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root)
+        let rerun = migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
             .expect("rerun migrate jsonl");
         assert_eq!(rerun, 0);
 
@@ -1686,6 +1741,7 @@ base_url = "https://proxy.example/v1"
             &codex_dir,
             &source_provider_ids,
             &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
         )
         .expect("migrate state db");
         assert_eq!(migrated_state_rows, 1);
@@ -1967,6 +2023,7 @@ base_url = "https://proxy.example/v1"
             &codex_dir,
             &HashSet::from(["rightcode".to_string()]),
             &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
         )
         .expect("rewrite");
 
@@ -1999,6 +2056,7 @@ base_url = "https://proxy.example/v1"
             &codex_dir,
             &source_ids(&["some-trusted-provider"]),
             &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
         )
         .expect("migrate jsonl");
 
@@ -2034,6 +2092,7 @@ base_url = "https://proxy.example/v1"
             &codex_dir,
             &source_ids(&["rightcode"]),
             &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
         )
         .expect("migrate state db");
 
@@ -2076,6 +2135,7 @@ base_url = "https://proxy.example/v1"
             &codex_dir,
             &source_ids(&["rightcode", "aihubmix"]),
             &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
         )
         .expect("migrate state db");
 

--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -142,10 +142,18 @@ pub fn maybe_migrate_codex_third_party_history_provider_bucket(
 
     let backup_root = migration_backup_root(MIGRATION_NAME);
     let codex_dir = get_codex_config_dir();
-    let migrated_jsonl_files =
-        migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)?;
-    let migrated_state_rows =
-        migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)?;
+    let migrated_jsonl_files = migrate_codex_jsonl_files(
+        &codex_dir,
+        &source_provider_ids,
+        &backup_root,
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+    )?;
+    let migrated_state_rows = migrate_codex_state_dbs(
+        &codex_dir,
+        &source_provider_ids,
+        &backup_root,
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+    )?;
 
     let source_provider_ids_vec: Vec<String> = source_provider_ids.iter().cloned().collect();
     crate::settings::mark_codex_third_party_history_provider_bucket_migrated(
@@ -236,10 +244,18 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
     let source_provider_ids: BTreeSet<String> =
         std::iter::once(OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID.to_string()).collect();
     let backup_root = migration_backup_root(OFFICIAL_UNIFY_MIGRATION_NAME);
-    let migrated_jsonl_files =
-        migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)?;
-    let migrated_state_rows =
-        migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)?;
+    let migrated_jsonl_files = migrate_codex_jsonl_files(
+        &codex_dir,
+        &source_provider_ids,
+        &backup_root,
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+    )?;
+    let migrated_state_rows = migrate_codex_state_dbs(
+        &codex_dir,
+        &source_provider_ids,
+        &backup_root,
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+    )?;
     // 备份代际记录来源目录，restore 据此只取当前目录的账本。
     write_backup_generation_meta(&backup_root, &codex_dir_key)?;
 
@@ -1299,8 +1315,7 @@ pub fn sync_codex_sessions_for_provider_switch(
     };
 
     let codex_dir = get_codex_config_dir();
-    let source_provider_ids: BTreeSet<String> =
-        std::iter::once(source.to_string()).collect();
+    let source_provider_ids: BTreeSet<String> = std::iter::once(source.to_string()).collect();
 
     let backup_root = migration_backup_root("codex-session-sync-on-switch");
     let synced_jsonl_files =
@@ -1527,9 +1542,13 @@ base_url = "https://proxy.example/v1"
         )
         .expect("write session");
 
-        let migrated_jsonl =
-            migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
-                .expect("migrate jsonl");
+        let migrated_jsonl = migrate_codex_jsonl_files(
+            &codex_dir,
+            &source_provider_ids,
+            &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+        )
+        .expect("migrate jsonl");
         assert_eq!(migrated_jsonl, 1);
         let session_text = fs::read_to_string(&session_path).expect("read session");
         assert_eq!(
@@ -1696,9 +1715,13 @@ base_url = "https://proxy.example/v1"
         )
         .expect("write session");
 
-        let migrated_jsonl =
-            migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
-                .expect("migrate jsonl");
+        let migrated_jsonl = migrate_codex_jsonl_files(
+            &codex_dir,
+            &source_provider_ids,
+            &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+        )
+        .expect("migrate jsonl");
         assert_eq!(migrated_jsonl, 1);
         let session_text = fs::read_to_string(&session_path).expect("read session");
         assert_eq!(
@@ -1717,8 +1740,13 @@ base_url = "https://proxy.example/v1"
             .exists());
 
         // 第二次执行应当无事可做（幂等）
-        let rerun = migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root, CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
-            .expect("rerun migrate jsonl");
+        let rerun = migrate_codex_jsonl_files(
+            &codex_dir,
+            &source_provider_ids,
+            &backup_root,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+        )
+        .expect("rerun migrate jsonl");
         assert_eq!(rerun, 0);
 
         let state_db_path = codex_dir.join(CODEX_STATE_DB_FILENAME);

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::app_config::AppType;
+use crate::codex_history_migration::sync_codex_sessions_for_provider_switch;
 use crate::database::{validate_cost_multiplier, validate_pricing_source};
 use crate::error::AppError;
 use crate::provider::{Provider, UsageResult};
@@ -3205,6 +3206,35 @@ impl ProviderService {
         // （MCP 投影可自愈：下次切换 / 任一 MCP 启停都会重新投影）。
         if let Err(err) = McpService::sync_enabled_for_app(state, &app_type) {
             log::warn!("切换供应商后重投影 {app_type:?} MCP 失败（将在下次同步时自愈）: {err}");
+        }
+
+        if matches!(app_type, AppType::Codex) {
+            let provider_is_official =
+                provider.category.as_deref() == Some("official");
+            let sync_outcome = sync_codex_sessions_for_provider_switch(provider_is_official);
+            match sync_outcome {
+                Ok(outcome) => {
+                    if outcome.skipped_reason.is_some() {
+                        log::debug!(
+                            "Codex session sync on switch skipped: {:?}",
+                            outcome.skipped_reason
+                        );
+                    } else {
+                        log::info!(
+                            "Codex session sync on switch: {} jsonl files, {} state rows → {}",
+                            outcome.synced_jsonl_files,
+                            outcome.synced_state_rows,
+                            outcome.target_provider
+                        );
+                    }
+                }
+                Err(err) => {
+                    log::warn!("Codex session sync on switch failed: {err}");
+                    result
+                        .warnings
+                        .push(format!("session_sync_failed:{}", provider.id));
+                }
+            }
         }
 
         Ok(result)

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -3209,8 +3209,7 @@ impl ProviderService {
         }
 
         if matches!(app_type, AppType::Codex) {
-            let provider_is_official =
-                provider.category.as_deref() == Some("official");
+            let provider_is_official = provider.category.as_deref() == Some("official");
             let sync_outcome = sync_codex_sessions_for_provider_switch(provider_is_official);
             match sync_outcome {
                 Ok(outcome) => {


### PR DESCRIPTION
## Summary

This PR implements bidirectional session history synchronization that runs automatically on every Codex provider switch, eliminating the need for manual migration/restore when switching between official and third-party providers.

## Problem (issue #5851)

The current `unifyCodexSessionHistory` implementation uses a one-directional migrate/restore model:
- Enable unify → migrate all sessions from `"openai"` to `"custom"` (bulk operation)
- Disable unify → restore from backup ledger (another bulk operation)

This creates a friction point: switching providers requires waiting for migrations, and sessions created on one side are invisible on the other until the next migration runs.

## Solution

**`sync_codex_sessions_for_provider_switch()`** runs automatically after each Codex provider switch (when `unifyCodexSessionHistory` is enabled):

- **Switch to official** → all sessions with `model_provider = "custom"` are synced to `"openai"`
- **Switch to third-party** → all sessions with `model_provider = "openai"` are synced to `"custom"`

Both JSONL session files and `state_5.sqlite` `threads` table are updated atomically with pre-backup safety.

### Refactored internals

The migration functions (`migrate_codex_jsonl_files`, `migrate_codex_state_dbs`, etc.) now accept a `target_provider_id: &str` parameter, enabling bidirectional movement instead of always targeting `"custom"`. All existing callers pass `CC_SWITCH_CODEX_MODEL_PROVIDER_ID` to preserve original behavior.

## Changes

| File | Changes |
|------|---------|
| `src-tauri/src/codex_history_migration.rs` | Added `sync_codex_sessions_for_provider_switch()` (public), refactored 5 internal functions to accept target provider parameter |
| `src-tauri/src/services/provider/mod.rs` | Wired sync call into `switch_normal()` after MCP sync for Codex providers |

## Testing

- All 26 `codex_history_migration` tests pass
- `cargo clippy` — no warnings
- `cargo check` — no errors
- 954/955 provider service tests pass (1 pre-existing flaky test unrelated to this change)

## Checklist

- [x] `cargo clippy` passes
- [x] `cargo test` passes for modified modules
- [x] All existing callers updated with minimal diff
- [x] Errors from session sync are downgraded to warnings (non-blocking switch flow)
- [x] No new user-facing text requiring i18n changes