### PR TITLE
feat(Claude for Office): local gateway with CORS/PNA and x-api-key auth

### DIFF
--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -704,6 +704,15 @@ pub fn map_proxy_request_model(mut body: Value, provider: &Provider) -> Result<V
         .iter()
         .find(|r| r.route_id == requested)
         .or_else(|| {
+            // Claude for Office 的模型列表把 labelOverride 作为 id 暴露，
+            // 请求回传时按 labelOverride 反查 route
+            routes.iter().find(|r| {
+                r.label_override
+                    .as_deref()
+                    .is_some_and(|label| label == requested)
+            })
+        })
+        .or_else(|| {
             routes
                 .iter()
                 .find(|r| is_compatible_opus_route_alias(&r.route_id, requested))
@@ -931,6 +940,44 @@ pub fn proxy_gateway_base_url_from_db(db: &Database) -> Result<String, AppError>
         proxy_origin_from_parts(&config.listen_address, config.listen_port),
         CLAUDE_DESKTOP_PROXY_PREFIX
     ))
+}
+
+/// Claude for Office 连接界面所需的 Gateway URL 与 token
+///
+/// URL 使用 /claude-office 前缀（该前缀带 CORS + Private Network Access 支持，
+/// 且接受 x-api-key 鉴权），token 与 Claude Desktop gateway 共用。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeOfficeGatewayInfo {
+    pub gateway_url: String,
+    pub token: String,
+    pub proxy_running: bool,
+}
+
+pub const CLAUDE_OFFICE_PROXY_PREFIX: &str = "/claude-office";
+
+pub fn claude_office_gateway_info(
+    db: &Database,
+    proxy_running: bool,
+) -> Result<ClaudeOfficeGatewayInfo, AppError> {
+    let config = futures::executor::block_on(db.get_proxy_config())?;
+    if config.listen_port == 0 {
+        return Err(AppError::Config(
+            "Claude for Office 代理地址需要真实监听端口；请先启动本地代理或使用固定端口"
+                .to_string(),
+        ));
+    }
+    let gateway_url = format!(
+        "{}{}",
+        proxy_origin_from_parts(&config.listen_address, config.listen_port),
+        CLAUDE_OFFICE_PROXY_PREFIX
+    );
+    let token = get_or_create_gateway_token(db)?;
+    Ok(ClaudeOfficeGatewayInfo {
+        gateway_url,
+        token,
+        proxy_running,
+    })
 }
 
 fn apply_provider_to_paths(

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -215,6 +215,15 @@ pub fn get_claude_desktop_default_routes(
 }
 
 #[tauri::command]
+pub async fn get_claude_office_gateway_info(
+    state: State<'_, AppState>,
+) -> Result<crate::claude_desktop_config::ClaudeOfficeGatewayInfo, String> {
+    let proxy_running = state.proxy_service.is_running().await;
+    crate::claude_desktop_config::claude_office_gateway_info(state.db.as_ref(), proxy_running)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub fn import_claude_desktop_providers_from_claude(
     state: State<'_, AppState>,
 ) -> Result<usize, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1325,6 +1325,7 @@ pub fn run() {
             commands::import_default_config,
             commands::get_claude_desktop_status,
             commands::get_claude_desktop_default_routes,
+            commands::get_claude_office_gateway_info,
             commands::import_claude_desktop_providers_from_claude,
             commands::ensure_claude_desktop_official_provider,
             commands::ensure_codex_official_provider,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -153,6 +153,45 @@ pub async fn handle_claude_desktop_models(
     Ok(Json(response))
 }
 
+/// Claude for Office 的 /v1/messages
+///
+/// 与 Claude Desktop 共用 provider namespace、模型路由和故障转移队列，
+/// 区别只在鉴权方式：Office 连接界面固定发送 `x-api-key`。
+pub async fn handle_claude_office_messages(
+    State(state): State<ProxyState>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    validate_claude_office_gateway_auth(&state, request.headers())?;
+    handle_messages_for_app(
+        state,
+        request,
+        AppType::ClaudeDesktop,
+        "Claude for Office",
+        "claude-desktop",
+        Some("/claude-office"),
+    )
+    .await
+}
+
+/// Claude for Office 的 /v1/models（连通性检查）
+pub async fn handle_claude_office_models(
+    State(state): State<ProxyState>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<Value>, ProxyError> {
+    validate_claude_office_gateway_auth(&state, &headers)?;
+    let providers = state
+        .provider_router
+        .select_providers("claude-desktop")
+        .await
+        .map_err(|e| ProxyError::DatabaseError(e.to_string()))?;
+    let provider = providers.first().ok_or(ProxyError::NoAvailableProvider)?;
+    // Office 客户端校验模型 id 命名规范（claude-* 风格），与 Desktop 共用
+    // route id 版本；labelOverride（真实模型名）版本会被客户端拒绝
+    let response = crate::claude_desktop_config::model_list_response(provider)
+        .map_err(|e| ProxyError::ConfigError(e.to_string()))?;
+    Ok(Json(response))
+}
+
 async fn handle_messages_for_app(
     state: ProxyState,
     request: axum::extract::Request,
@@ -278,6 +317,50 @@ fn validate_claude_desktop_gateway_auth(
         ));
     }
     Ok(())
+}
+
+/// Claude for Office gateway 鉴权
+///
+/// Office 连接界面只支持 x-api-key（无 bearer 选项），此处两种头都接受：
+/// `x-api-key` 优先，`Authorization: Bearer` 兜底（便于 curl 等工具调试）。
+fn validate_claude_office_gateway_auth(
+    state: &ProxyState,
+    headers: &axum::http::HeaderMap,
+) -> Result<(), ProxyError> {
+    let expected = crate::claude_desktop_config::get_or_create_gateway_token(state.db.as_ref())
+        .map_err(|e| ProxyError::AuthError(e.to_string()))?;
+    match extract_claude_office_gateway_token(headers) {
+        Some(token) if token == expected => Ok(()),
+        Some(_) => Err(ProxyError::AuthError(
+            "Claude for Office gateway token 无效".to_string(),
+        )),
+        None => Err(ProxyError::AuthError(
+            "Claude for Office gateway 缺少 x-api-key 头".to_string(),
+        )),
+    }
+}
+
+/// 从请求头提取 Claude for Office gateway token：x-api-key 优先，Bearer 兜底
+fn extract_claude_office_gateway_token(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get("x-api-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            headers
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| {
+                    value
+                        .strip_prefix("Bearer ")
+                        .or_else(|| value.strip_prefix("bearer "))
+                })
+                .map(str::trim)
+                .filter(|token| !token.is_empty())
+                .map(str::to_string)
+        })
 }
 
 /// Claude 格式转换处理（独有逻辑）
@@ -2657,10 +2740,68 @@ async fn log_usage(
 mod tests {
     use super::{
         body_looks_like_sse, chat_sse_to_response_value, classify_body_for_diagnostics,
-        codex_proxy_error_json, responses_sse_to_response_value,
-        should_use_claude_transform_streaming, transform, upstream_body_parse_error,
+        codex_proxy_error_json, extract_claude_office_gateway_token,
+        responses_sse_to_response_value, should_use_claude_transform_streaming, transform,
+        upstream_body_parse_error,
     };
     use crate::proxy::ProxyError;
+
+    #[test]
+    fn claude_office_token_prefers_x_api_key() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-api-key", "office-token".parse().unwrap());
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            "Bearer other-token".parse().unwrap(),
+        );
+        assert_eq!(
+            extract_claude_office_gateway_token(&headers),
+            Some("office-token".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_office_token_falls_back_to_bearer() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            "Bearer bearer-token".parse().unwrap(),
+        );
+        assert_eq!(
+            extract_claude_office_gateway_token(&headers),
+            Some("bearer-token".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_office_token_accepts_lowercase_bearer() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            "bearer lower-token".parse().unwrap(),
+        );
+        assert_eq!(
+            extract_claude_office_gateway_token(&headers),
+            Some("lower-token".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_office_token_rejects_empty_and_missing() {
+        let headers = axum::http::HeaderMap::new();
+        assert_eq!(extract_claude_office_gateway_token(&headers), None);
+
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-api-key", "   ".parse().unwrap());
+        assert_eq!(extract_claude_office_gateway_token(&headers), None);
+
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            "Basic dXNlcjpwYXNz".parse().unwrap(),
+        );
+        assert_eq!(extract_claude_office_gateway_token(&headers), None);
+    }
 
     #[test]
     fn body_looks_like_sse_detects_unlabeled_sse_prefixes() {

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -440,11 +440,34 @@ fn convert_message_to_openai(
                             None => String::new(),
                         }
                     };
-                    result.push(json!({
-                        "role": "tool",
-                        "tool_call_id": tool_use_id,
-                        "content": content_str
-                    }));
+                    // OpenAI 要求一个 tool_call 恰好一条 tool 消息。Anthropic 客户端可能把
+                    // 一次工具调用的结果拆成多个共用同一 tool_use_id 的 tool_result 块
+                    // （Office 的 read_slide_text 每页幻灯片一条），严格上游（DeepSeek）
+                    // 会把多出的 tool 消息判成孤儿 400。同 id 的后续块并入第一条。
+                    if let Some(existing) = result.iter_mut().find(|m| {
+                        m.get("role").and_then(|r| r.as_str()) == Some("tool")
+                            && m.get("tool_call_id").and_then(|i| i.as_str()) == Some(tool_use_id)
+                    }) {
+                        let prev = existing
+                            .get("content")
+                            .and_then(|c| c.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let merged = if prev.is_empty() {
+                            content_str
+                        } else if content_str.is_empty() {
+                            prev
+                        } else {
+                            format!("{prev}\n\n{content_str}")
+                        };
+                        existing["content"] = json!(merged);
+                    } else {
+                        result.push(json!({
+                            "role": "tool",
+                            "tool_call_id": tool_use_id,
+                            "content": content_str
+                        }));
+                    }
                 }
                 "thinking" => {
                     // 提取 thinking 内容，后续可作为 reasoning_content 传给需要它的上游。
@@ -1277,6 +1300,87 @@ mod tests {
         assert_eq!(messages[1]["role"], "tool");
         assert_eq!(messages[2]["role"], "user");
         assert_eq!(messages[2]["content"].as_array().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn test_duplicate_tool_result_blocks_merge_into_single_tool_message() {
+        // Office 的 read_slide_text 把一次工具调用的结果按页拆成多个共用同一
+        // tool_use_id 的 tool_result 块。严格上游（DeepSeek OpenAI 端点）要求
+        // 一个 tool_call 恰好一条 tool 消息，否则报 tool must follow tool_calls。
+        let input = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "..."},
+                        {"type": "tool_use", "id": "call_1", "name": "read_slide_text", "input": {"slide": 1}}
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "call_1", "content": "第16页内容"},
+                        {"type": "tool_result", "tool_use_id": "call_1", "content": "第17页内容"},
+                        {"type": "tool_result", "tool_use_id": "call_1", "content": "第18页内容"}
+                    ]
+                }
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        let tool_msgs: Vec<_> = messages
+            .iter()
+            .filter(|m| m["role"] == "tool")
+            .collect();
+        assert_eq!(tool_msgs.len(), 1, "duplicate tool_results must merge");
+        assert_eq!(tool_msgs[0]["tool_call_id"], "call_1");
+        assert_eq!(
+            tool_msgs[0]["content"],
+            "第16页内容\n\n第17页内容\n\n第18页内容"
+        );
+
+        // 只有一个 assistant tool_call，后面恰好跟一条 tool 消息
+        let assistant = messages
+            .iter()
+            .find(|m| m["role"] == "assistant")
+            .expect("assistant message");
+        assert_eq!(assistant["tool_calls"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_distinct_tool_result_ids_stay_separate() {
+        let input = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "call_1", "name": "a", "input": {}},
+                        {"type": "tool_use", "id": "call_2", "name": "b", "input": {}}
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "call_1", "content": "r1"},
+                        {"type": "tool_result", "tool_use_id": "call_2", "content": "r2"}
+                    ]
+                }
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+        let tool_msgs: Vec<_> = messages
+            .iter()
+            .filter(|m| m["role"] == "tool")
+            .collect();
+        assert_eq!(tool_msgs.len(), 2, "distinct ids must not merge");
+        assert_eq!(tool_msgs[0]["content"], "r1");
+        assert_eq!(tool_msgs[1]["content"], "r2");
     }
 
     #[test]

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -28,6 +28,22 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
 use tokio::task::JoinHandle;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+/// Claude for Office 专用的 CORS 层
+///
+/// Office 加载项运行在 WebView2 中，Origin 是 https://*.office.com（随租户/区域变化），
+/// 且从 HTTPS 公共页面访问本机地址属于 Private Network Access，预检里会带
+/// `Access-Control-Request-Private-Network: true`，必须回
+/// `Access-Control-Allow-Private-Network: true` 浏览器才放行实际请求。
+fn claude_office_cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::mirror_request())
+        .allow_methods([axum::http::Method::GET, axum::http::Method::POST])
+        .allow_headers(tower_http::cors::AllowHeaders::mirror_request())
+        .allow_private_network(true)
+        .max_age(std::time::Duration::from_secs(7200))
+}
 
 /// 代理服务器状态（共享）
 #[derive(Clone)]
@@ -305,6 +321,23 @@ impl ProxyServer {
                 "/claude-desktop/v1/messages",
                 post(handlers::handle_claude_desktop_messages),
             )
+            // Claude for Office 本地 gateway（Office 加载项跑在 WebView2 浏览器中，
+            // 只发 x-api-key 鉴权，且要求 CORS + Private Network Access 预检通过，
+            // 因此该前缀单独挂 CorsLayer；其余路由不开放 CORS）
+            .route(
+                "/claude-office/v1/models",
+                get(handlers::handle_claude_office_models),
+            )
+            .route(
+                "/claude-office/v1/messages",
+                post(handlers::handle_claude_office_messages),
+            )
+            // Office 取模型列表时可能用 OpenAI 风格的 /models 路径
+            .route(
+                "/claude-office/models",
+                get(handlers::handle_claude_office_models),
+            )
+            .layer(claude_office_cors_layer())
             // OpenAI Chat Completions API (Codex CLI，支持带前缀和不带前缀)
             .route("/chat/completions", post(handlers::handle_chat_completions))
             .route(

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -305,6 +305,27 @@ impl ProxyServer {
     }
 
     fn build_router(&self) -> Router {
+        // Claude for Office 本地 gateway（Office 加载项跑在 WebView2 浏览器中，
+        // 只发 x-api-key 鉴权，且要求 CORS + Private Network Access 预检通过）。
+        // 单独嵌套子 Router：CorsLayer 只作用于 /claude-office 前缀。若用
+        // Router::layer 挂在主路由上，axum 会把该层应用到之前注册的所有路由
+        // （含无鉴权的 /v1/messages），导致任意网页可跨站调用本机代理（PNA 劫持）。
+        let office_router = Router::new()
+            .route(
+                "/claude-office/v1/models",
+                get(handlers::handle_claude_office_models),
+            )
+            .route(
+                "/claude-office/v1/messages",
+                post(handlers::handle_claude_office_messages),
+            )
+            // Office 取模型列表时可能用 OpenAI 风格的 /models 路径
+            .route(
+                "/claude-office/models",
+                get(handlers::handle_claude_office_models),
+            )
+            .layer(claude_office_cors_layer());
+
         Router::new()
             // 健康检查
             .route("/health", get(handlers::health_check))
@@ -321,23 +342,7 @@ impl ProxyServer {
                 "/claude-desktop/v1/messages",
                 post(handlers::handle_claude_desktop_messages),
             )
-            // Claude for Office 本地 gateway（Office 加载项跑在 WebView2 浏览器中，
-            // 只发 x-api-key 鉴权，且要求 CORS + Private Network Access 预检通过，
-            // 因此该前缀单独挂 CorsLayer；其余路由不开放 CORS）
-            .route(
-                "/claude-office/v1/models",
-                get(handlers::handle_claude_office_models),
-            )
-            .route(
-                "/claude-office/v1/messages",
-                post(handlers::handle_claude_office_messages),
-            )
-            // Office 取模型列表时可能用 OpenAI 风格的 /models 路径
-            .route(
-                "/claude-office/models",
-                get(handlers::handle_claude_office_models),
-            )
-            .layer(claude_office_cors_layer())
+            .merge(office_router)
             // OpenAI Chat Completions API (Codex CLI，支持带前缀和不带前缀)
             .route("/chat/completions", post(handlers::handle_chat_completions))
             .route(

--- a/src/components/proxy/ClaudeOfficeConnectionCard.tsx
+++ b/src/components/proxy/ClaudeOfficeConnectionCard.tsx
@@ -1,0 +1,134 @@
+import { useQuery } from "@tanstack/react-query";
+import { Copy, ExternalLink, FileSpreadsheet } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { providersApi } from "@/lib/api/providers";
+import { useProxyStatus } from "@/hooks/useProxyStatus";
+import { cn } from "@/lib/utils";
+
+interface ClaudeOfficeConnectionCardProps {
+  className?: string;
+}
+
+/**
+ * Claude for Office 连接信息卡片
+ *
+ * 展示 /claude-office gateway 的 URL 和 token，供用户粘贴到
+ * Office 加载项的"Connect another way → Gateway"连接界面。
+ * 该前缀的代理路由带 CORS + Private Network Access 支持，且接受 x-api-key 鉴权。
+ */
+export function ClaudeOfficeConnectionCard({
+  className,
+}: ClaudeOfficeConnectionCardProps) {
+  const { t } = useTranslation();
+  const { isRunning } = useProxyStatus();
+
+  const { data: info, error } = useQuery({
+    queryKey: ["claudeOfficeGatewayInfo"],
+    queryFn: () => providersApi.getClaudeOfficeGatewayInfo(),
+    refetchInterval: 5000,
+    retry: false,
+  });
+
+  const copy = async (value: string, labelKey: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(
+        t("claudeOffice.copied", {
+          label: labelKey,
+          defaultValue: `${labelKey} 已复制`,
+        }),
+        { closeButton: true },
+      );
+    } catch {
+      toast.error(t("claudeOffice.copyFailed", { defaultValue: "复制失败" }));
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-card/50 p-4 space-y-3",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-background ring-1 ring-border">
+          <FileSpreadsheet className="h-4 w-4 text-emerald-500" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-medium leading-none">
+            {t("claudeOffice.title", { defaultValue: "Claude for Office" })}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {t("claudeOffice.description", {
+              defaultValue:
+                "在 Office 加载项的「Connect another way → Gateway」中填入以下信息",
+            })}
+          </p>
+        </div>
+      </div>
+
+      {!isRunning && (
+        <p className="text-xs text-yellow-600 dark:text-yellow-400">
+          {t("claudeOffice.proxyNotRunning", {
+            defaultValue: "本地代理服务未运行，请先启动代理服务",
+          })}
+        </p>
+      )}
+
+      {error ? (
+        <p className="text-xs text-muted-foreground">
+          {t("claudeOffice.loadFailed", {
+            defaultValue: "连接信息暂不可用，请先启动代理服务",
+          })}
+        </p>
+      ) : info ? (
+        <div className="space-y-2">
+          <div>
+            <p className="text-xs text-muted-foreground mb-1">
+              {t("claudeOffice.gatewayUrl", { defaultValue: "Gateway URL" })}
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 text-xs bg-background px-3 py-2 rounded border border-border/60 truncate">
+                {info.gatewayUrl}
+              </code>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => copy(info.gatewayUrl, "Gateway URL")}
+              >
+                <Copy className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground mb-1">
+              {t("claudeOffice.token", { defaultValue: "Token" })}
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 text-xs bg-background px-3 py-2 rounded border border-border/60 truncate">
+                {info.token}
+              </code>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => copy(info.token, "Token")}
+              >
+                <Copy className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground flex items-center gap-1">
+            <ExternalLink className="h-3 w-3" />
+            {t("claudeOffice.hint", {
+              defaultValue:
+                "与 Claude Desktop 共用供应商配置与故障转移队列，切换供应商对两者同时生效",
+            })}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/proxy/ProxyPanel.tsx
+++ b/src/components/proxy/ProxyPanel.tsx
@@ -19,6 +19,7 @@ import { useProxyStatus } from "@/hooks/useProxyStatus";
 import { toast } from "sonner";
 import { useFailoverQueue } from "@/lib/query/failover";
 import { ProviderHealthBadge } from "@/components/providers/ProviderHealthBadge";
+import { ClaudeOfficeConnectionCard } from "@/components/proxy/ClaudeOfficeConnectionCard";
 import { useProviderHealth } from "@/lib/query/failover";
 import {
   useProxyTakeoverStatus,
@@ -414,6 +415,9 @@ export function ProxyPanel({
                   />
                 </div>
               </div>
+
+              {/* [5.5] Claude for Office 连接信息 */}
+              <ClaudeOfficeConnectionCard />
 
               {/* [6] Provider queues */}
               {(claudeQueue.length > 0 ||

--- a/src/components/proxy/index.ts
+++ b/src/components/proxy/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { ProxyPanel } from "./ProxyPanel";
+export { ClaudeOfficeConnectionCard } from "./ClaudeOfficeConnectionCard";

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -225,6 +225,17 @@
       }
     }
   },
+  "claudeOffice": {
+    "title": "Claude for Office",
+    "description": "Paste the following into the Office add-in under \"Connect another way → Gateway\"",
+    "proxyNotRunning": "Local proxy is not running. Start the proxy service first.",
+    "loadFailed": "Connection info unavailable. Start the proxy service first.",
+    "gatewayUrl": "Gateway URL",
+    "token": "Token",
+    "copied": "{{label}} copied",
+    "copyFailed": "Copy failed",
+    "hint": "Shares provider config and failover queue with Claude Desktop; switching providers applies to both."
+  },
   "notifications": {
     "providerAdded": "Provider added",
     "providerSaved": "Provider configuration saved",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -225,6 +225,17 @@
       }
     }
   },
+  "claudeOffice": {
+    "title": "Claude for Office",
+    "description": "Office アドインの「Connect another way → Gateway」に以下の情報を入力してください",
+    "proxyNotRunning": "ローカルプロキシが起動していません。先にプロキシサービスを開始してください",
+    "loadFailed": "接続情報を取得できません。先にプロキシサービスを開始してください",
+    "gatewayUrl": "Gateway URL",
+    "token": "Token",
+    "copied": "{{label}} をコピーしました",
+    "copyFailed": "コピーに失敗しました",
+    "hint": "Claude Desktop とプロバイダー設定・フェイルオーバーキューを共有します。切り替えは両方に適用されます。"
+  },
   "notifications": {
     "providerAdded": "プロバイダーを追加しました",
     "providerSaved": "プロバイダー設定を保存しました",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -225,6 +225,17 @@
       }
     }
   },
+  "claudeOffice": {
+    "title": "Claude for Office",
+    "description": "在 Office 增益集的「Connect another way → Gateway」中填入以下資訊",
+    "proxyNotRunning": "本機代理服務未執行，請先啟動代理服務",
+    "loadFailed": "連線資訊暫不可用，請先啟動代理服務",
+    "gatewayUrl": "Gateway URL",
+    "token": "Token",
+    "copied": "{{label}} 已複製",
+    "copyFailed": "複製失敗",
+    "hint": "與 Claude Desktop 共用供應商設定與故障轉移佇列，切換供應商對兩者同時生效"
+  },
   "notifications": {
     "providerAdded": "供應商已新增",
     "providerSaved": "供應商設定已儲存",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -225,6 +225,17 @@
       }
     }
   },
+  "claudeOffice": {
+    "title": "Claude for Office",
+    "description": "在 Office 加载项的「Connect another way → Gateway」中填入以下信息",
+    "proxyNotRunning": "本地代理服务未运行，请先启动代理服务",
+    "loadFailed": "连接信息暂不可用，请先启动代理服务",
+    "gatewayUrl": "Gateway URL",
+    "token": "Token",
+    "copied": "{{label}} 已复制",
+    "copyFailed": "复制失败",
+    "hint": "与 Claude Desktop 共用供应商配置与故障转移队列，切换供应商对两者同时生效"
+  },
   "notifications": {
     "providerAdded": "供应商已添加",
     "providerSaved": "供应商配置已保存",

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -46,6 +46,12 @@ export interface ClaudeDesktopDefaultRoute {
   supports1m: boolean;
 }
 
+export interface ClaudeOfficeGatewayInfo {
+  gatewayUrl: string;
+  token: string;
+  proxyRunning: boolean;
+}
+
 export const providersApi = {
   async getAll(appId: AppId): Promise<Record<string, Provider>> {
     return await invoke("get_providers", { app: appId });
@@ -117,6 +123,10 @@ export const providersApi = {
 
   async getClaudeDesktopDefaultRoutes(): Promise<ClaudeDesktopDefaultRoute[]> {
     return await invoke("get_claude_desktop_default_routes");
+  },
+
+  async getClaudeOfficeGatewayInfo(): Promise<ClaudeOfficeGatewayInfo> {
+    return await invoke("get_claude_office_gateway_info");
   },
 
   async updateTrayMenu(): Promise<boolean> {


### PR DESCRIPTION
## Summary / 概述

Adds support for the **Claude for Office** add-in (Word/PowerPoint/etc.) to the local gateway, alongside the existing Claude Desktop 3P gateway.

为本地网关新增 **Claude for Office** 加载项（Word/PowerPoint 等）支持，复用现有 Claude Desktop 3P 网关体系。

**Problem / 问题**: The Office add-in runs inside WebView2, so unlike native clients it (1) sends CORS + Private Network Access preflights that the proxy didn't answer (`Failed to fetch`), and (2) only offers `x-api-key` auth (no Bearer option) in its "Connect another way → Gateway" UI.

**Changes / 改动**:

- New routes `/claude-office/v1/messages`, `/claude-office/v1/models` (+ `/claude-office/models` fallback), sharing the `claude-desktop` provider namespace, model routes and failover queue
  新增 `/claude-office` 路由，与 claude-desktop 共用供应商配置、模型映射与故障转移队列
- Scoped `CorsLayer` on that prefix only: mirrors Origin and request headers, emits `Access-Control-Allow-Private-Network: true` for the PNA preflight; other routes stay CORS-free
  仅该前缀挂 CORS 层（回显 Origin、镜像请求头、响应 PNA 预检），其余路由不受影响
- Auth accepts `x-api-key` (Office's fixed scheme) with `Authorization: Bearer` fallback, reusing the claude-desktop gateway token
  鉴权接受 x-api-key（Office 固定方式），Bearer 兜底，与 Claude Desktop 共用 token
- Model list reuses the route-id version: the Office client validates model ids client-side and only accepts `claude-*` names (verified against the real add-in)
  模型列表使用 route id 版本——Office 客户端只接受 claude-* 命名（已实测验证）
- New `get_claude_office_gateway_info` command + a "Claude for Office" card on the proxy settings page with one-click copy of gateway URL and token
  新增 `get_claude_office_gateway_info` 命令和代理设置页的连接信息卡片（一键复制 URL/token）
- Merge duplicate `tool_result` blocks in the Anthropic → OpenAI request transform: Office's `read_slide_text` splits one tool invocation into multiple `tool_result` blocks sharing the same `tool_use_id` (one per slide). The Anthropic API tolerates this, but strict OpenAI-compatible upstreams (DeepSeek `/v1/chat/completions`) reject the extra tool messages with `tool must follow tool_calls`. Same-id blocks now merge into one tool message (content joined with `\n\n`); distinct ids are unaffected. Regression tests included.
  合并 Anthropic → OpenAI 请求转换中的重复 `tool_result` 块：Office 的 read_slide_text 会把一次工具调用拆成多个共用同一 tool_use_id 的 tool_result（每页一条）。Anthropic API 容忍，但严格的 OpenAI 兼容上游（DeepSeek）会把多余的 tool 消息判为孤儿 400。同 id 的块合并为一条 tool 消息（内容 \n\n 拼接），不同 id 不受影响。附回归测试。
- Scope the permissive CORS layer to `/claude-office` only (Codex review P1): axum `Router::layer` applies to every route registered before the call, so the origin-mirroring + PNA layer was also covering `/health`, `/status`, and the unauthenticated `/v1/messages` — letting any web page pass the private-network preflight and drive the user's provider. The three Office routes now live in a nested router carrying the CorsLayer; all other routes emit no `Access-Control-*` headers (verified with preflight curls against both groups).
  将宽松的 CORS 层限定到仅 `/claude-office`（Codex 评审 P1）：axum `Router::layer` 会作用于之前注册的所有路由，导致镜像 Origin + PNA 层也覆盖了无鉴权的 `/v1/messages` 等——任意网页可过预检并操作用户的 provider。3 个 Office 路由拆进嵌套子 Router 单独挂 CorsLayer，其余路由不再返回任何 Access-Control-* 头（已对两组路由分别发预检验证）。

Verified end-to-end on Windows 11 + Microsoft 365: preflight passes, model list loads, `/v1/messages` proxies through to upstream providers, and multi-slide tool invocations complete against a strict OpenAI-compatible upstream (DeepSeek).
已在 Windows 11 + Microsoft 365 上端到端验证：预检通过、模型列表加载、消息请求正常转发，且多页幻灯片工具调用在严格 OpenAI 兼容上游（DeepSeek）上完整跑通。

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| Office add-in: "Could not reach gateway. Check the URL and your network connection." (`Failed to fetch`) | Connected successfully; model dropdown populated from `/claude-office/v1/models`; messages proxied upstream |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 (en / zh / zh-TW / ja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

