### PR TITLE
feat: add skill filter for skills manager

### DIFF
--- a/src/components/skills/SkillsPage.tsx
+++ b/src/components/skills/SkillsPage.tsx
@@ -338,15 +338,18 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
       // 按搜索关键词筛选
       if (!searchQuery.trim()) return byStatus;
 
-      const query = searchQuery.toLowerCase();
+      const query = searchQuery.trim().toLowerCase();
       return byStatus.filter((skill) => {
         const name = skill.name?.toLowerCase() || "";
+        const desc = skill.description?.toLowerCase() || "";
         const repo =
           skill.repoOwner && skill.repoName
             ? `${skill.repoOwner}/${skill.repoName}`.toLowerCase()
             : "";
 
-        return name.includes(query) || repo.includes(query);
+        return (
+          name.includes(query) || desc.includes(query) || repo.includes(query)
+        );
       });
     }, [skills, searchQuery, filterRepo, filterStatus]);
 

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -1,13 +1,23 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Sparkles,
   Trash2,
   ExternalLink,
   RefreshCw,
+  Search,
   Loader2,
+  RotateCcw,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
@@ -81,6 +91,9 @@ const UnifiedSkillsPanel = React.forwardRef<
   const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
 
   const { data: skills, isLoading } = useInstalledSkills();
+  const [filterKeyword, setFilterKeyword] = useState("");
+  const [filterAuthor, setFilterAuthor] = useState<string | null>(null);
+  const [filterRepo, setFilterRepo] = useState<string | null>(null);
   const {
     data: skillBackups = [],
     refetch: refetchSkillBackups,
@@ -112,6 +125,60 @@ const UnifiedSkillsPanel = React.forwardRef<
     }
     return map;
   }, [skillUpdates]);
+
+  // 从已安装技能中提取所有作者选项
+  const authorOptions = useMemo(() => {
+    if (!skills) return [];
+    const set = new Set<string>();
+    skills.forEach((s) => {
+      if (s.repoOwner) set.add(s.repoOwner);
+    });
+    return Array.from(set).sort();
+  }, [skills]);
+
+  // 从已安装技能中提取所有仓库选项
+  const repoOptions = useMemo(() => {
+    if (!skills) return [];
+    const set = new Set<string>();
+    skills.forEach((s) => {
+      if (s.repoOwner && s.repoName) set.add(`${s.repoOwner}/${s.repoName}`);
+    });
+    return Array.from(set).sort();
+  }, [skills]);
+
+  // 清除已不在选项中的筛选值，避免筛选条件不可见却生效
+  useEffect(() => {
+    if (filterAuthor && !authorOptions.includes(filterAuthor))
+      setFilterAuthor(null);
+    if (filterRepo && !repoOptions.includes(filterRepo)) setFilterRepo(null);
+  }, [authorOptions, repoOptions, filterAuthor, filterRepo]);
+
+  // 过滤后的技能列表
+  const filteredSkills = useMemo(() => {
+    if (!skills) return [];
+    return skills.filter((skill) => {
+      // 作者筛选
+      if (filterAuthor && skill.repoOwner !== filterAuthor) return false;
+      // 仓库筛选
+      if (filterRepo) {
+        const repo = `${skill.repoOwner || ""}/${skill.repoName || ""}`;
+        if (repo !== filterRepo) return false;
+      }
+      // 关键词筛选（名称、描述、仓库）
+      if (filterKeyword.trim()) {
+        const q = filterKeyword.trim().toLowerCase();
+        const name = skill.name?.toLowerCase() || "";
+        const desc = skill.description?.toLowerCase() || "";
+        const repo =
+          skill.repoOwner && skill.repoName
+            ? `${skill.repoOwner}/${skill.repoName}`.toLowerCase()
+            : "";
+        if (!name.includes(q) && !desc.includes(q) && !repo.includes(q))
+          return false;
+      }
+      return true;
+    });
+  }, [skills, filterKeyword, filterAuthor, filterRepo]);
 
   const enabledCounts = useMemo(() => {
     const counts = {
@@ -349,11 +416,13 @@ const UnifiedSkillsPanel = React.forwardRef<
   return (
     <div className="px-6 flex flex-col flex-1 min-h-0 overflow-hidden">
       <div className="flex items-center justify-between">
-        <AppCountBar
-          totalLabel={t("skills.installed", { count: skills?.length || 0 })}
-          counts={enabledCounts}
-          appIds={SKILLS_APP_IDS}
-        />
+        <div className="mb-1 overflow-hidden">
+          <AppCountBar
+            totalLabel={t("skills.installed", { count: skills?.length || 0 })}
+            counts={enabledCounts}
+            appIds={SKILLS_APP_IDS}
+          />
+        </div>
         <div className="flex items-center gap-1.5">
           <div
             className="transition-all duration-300 ease-out overflow-hidden"
@@ -401,6 +470,87 @@ const UnifiedSkillsPanel = React.forwardRef<
         </div>
       </div>
 
+      {/* 筛选栏 */}
+      {skills && skills.length > 0 && (
+        <div className="flex flex-wrap gap-2 items-center pt-1 pb-4">
+          <div className="relative flex-1 min-w-[160px]">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder={t("skills.searchPlaceholder")}
+              aria-label={t("skills.searchPlaceholder")}
+              value={filterKeyword}
+              onChange={(e) => setFilterKeyword(e.target.value)}
+              className="pl-9 h-8 text-sm"
+            />
+          </div>
+          <div className="w-[140px]">
+            <Select
+              value={filterAuthor ?? "__all__"}
+              onValueChange={(v) => setFilterAuthor(v === "__all__" ? null : v)}
+            >
+              <SelectTrigger
+                className="h-8 text-sm bg-card border shadow-sm"
+                aria-label={t("skills.filter.author")}
+              >
+                <SelectValue placeholder={t("skills.filter.author")} />
+              </SelectTrigger>
+              <SelectContent className="bg-card shadow-lg max-h-64">
+                <SelectItem value="__all__">
+                  {t("skills.filter.allAuthors")}
+                </SelectItem>
+                {authorOptions.map((author) => (
+                  <SelectItem key={author} value={author} title={author}>
+                    <span className="truncate block max-w-[110px]">
+                      {author}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="w-[160px]">
+            <Select
+              value={filterRepo ?? "__all__"}
+              onValueChange={(v) => setFilterRepo(v === "__all__" ? null : v)}
+            >
+              <SelectTrigger
+                className="h-8 text-sm bg-card border shadow-sm"
+                aria-label={t("skills.filter.repo")}
+              >
+                <SelectValue placeholder={t("skills.filter.repo")} />
+              </SelectTrigger>
+              <SelectContent className="bg-card shadow-lg max-h-64">
+                <SelectItem value="__all__">
+                  {t("skills.filter.allRepos")}
+                </SelectItem>
+                {repoOptions.map((repo) => (
+                  <SelectItem key={repo} value={repo} title={repo}>
+                    <span className="truncate block max-w-[130px]">{repo}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {(filterKeyword || filterAuthor || filterRepo) && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 text-xs gap-1 text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                setFilterKeyword("");
+                setFilterAuthor(null);
+                setFilterRepo(null);
+              }}
+            >
+              <RotateCcw size={13} />
+              {t("skills.filter.clearFilter")}
+            </Button>
+          )}
+        </div>
+      )}
+
       <div className="flex-1 overflow-y-auto overflow-x-hidden pb-24">
         {isLoading ? (
           <div className="text-center py-12 text-muted-foreground">
@@ -418,10 +568,16 @@ const UnifiedSkillsPanel = React.forwardRef<
               {t("skills.noInstalledDescription")}
             </p>
           </div>
+        ) : filteredSkills.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-lg font-medium text-foreground">
+              {t("skills.noResults")}
+            </p>
+          </div>
         ) : (
           <TooltipProvider delayDuration={300}>
             <div className="rounded-xl border border-border-default overflow-hidden">
-              {skills.map((skill, index) => (
+              {filteredSkills.map((skill, index) => (
                 <InstalledSkillListItem
                   key={skill.id}
                   skill={skill}
@@ -433,7 +589,7 @@ const UnifiedSkillsPanel = React.forwardRef<
                   onToggleApp={handleToggleApp}
                   onUninstall={() => handleUninstall(skill)}
                   onUpdate={() => handleUpdateSkill(skill)}
-                  isLast={index === skills.length - 1}
+                  isLast={index === filteredSkills.length - 1}
                 />
               ))}
             </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2363,7 +2363,7 @@
       "skillCount": "{{count}} skills detected"
     },
     "search": "Search Skills",
-    "searchPlaceholder": "Search skill name or repo...",
+    "searchPlaceholder": "Search name, description or repo...",
     "searchSource": {
       "repos": "Repos",
       "skillssh": "skills.sh"
@@ -2383,7 +2383,10 @@
       "installed": "Installed",
       "uninstalled": "Not installed",
       "repo": "Filter by repo",
-      "allRepos": "All repos"
+      "allRepos": "All repos",
+      "author": "Filter by author",
+      "allAuthors": "All authors",
+      "clearFilter": "Clear filters"
     },
     "noResults": "No matching skills found",
     "noInstalled": "No skills installed",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2363,7 +2363,7 @@
       "skillCount": "{{count}} 件のスキルを検出"
     },
     "search": "スキルを検索",
-    "searchPlaceholder": "スキル名またはリポジトリで検索...",
+    "searchPlaceholder": "名前・説明・リポジトリで検索...",
     "searchSource": {
       "repos": "リポジトリ",
       "skillssh": "skills.sh"
@@ -2383,7 +2383,10 @@
       "installed": "インストール済み",
       "uninstalled": "未インストール",
       "repo": "リポジトリで絞り込み",
-      "allRepos": "すべてのリポジトリ"
+      "allRepos": "すべてのリポジトリ",
+      "author": "作成者で絞り込み",
+      "allAuthors": "すべての作成者",
+      "clearFilter": "フィルターをクリア"
     },
     "noResults": "一致するスキルが見つかりませんでした",
     "noInstalled": "インストールされたスキルがありません",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2334,7 +2334,7 @@
       "skillCount": "識別到 {{count}} 個技能"
     },
     "search": "搜尋技能",
-    "searchPlaceholder": "搜尋技能名稱或儲存庫名稱...",
+    "searchPlaceholder": "搜尋名稱、描述或儲存庫...",
     "searchSource": {
       "repos": "儲存庫",
       "skillssh": "skills.sh"
@@ -2354,7 +2354,10 @@
       "installed": "已安裝",
       "uninstalled": "未安裝",
       "repo": "儲存庫篩選",
-      "allRepos": "全部儲存庫"
+      "allRepos": "全部儲存庫",
+      "author": "作者篩選",
+      "allAuthors": "全部作者",
+      "clearFilter": "清除篩選"
     },
     "noResults": "未找到相符的技能",
     "noInstalled": "暫無已安裝的技能",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2363,7 +2363,7 @@
       "skillCount": "识别到 {{count}} 个技能"
     },
     "search": "搜索技能",
-    "searchPlaceholder": "搜索技能名称或仓库名称...",
+    "searchPlaceholder": "搜索名称、描述或仓库...",
     "searchSource": {
       "repos": "仓库",
       "skillssh": "skills.sh"
@@ -2383,7 +2383,10 @@
       "installed": "已安装",
       "uninstalled": "未安装",
       "repo": "仓库筛选",
-      "allRepos": "全部仓库"
+      "allRepos": "全部仓库",
+      "author": "作者筛选",
+      "allAuthors": "全部作者",
+      "clearFilter": "清除筛选"
     },
     "noResults": "未找到匹配的技能",
     "noInstalled": "暂无已安装的技能",

--- a/tests/components/SkillsPageInstall.test.tsx
+++ b/tests/components/SkillsPageInstall.test.tsx
@@ -337,3 +337,76 @@ describe("SkillsPage - skills.sh install (regression)", () => {
     ).toEqual(["manage-repos"]);
   });
 });
+
+describe("SkillsPage - repo search by description (regression)", () => {
+  beforeEach(() => {
+    installMutateAsyncMock.mockReset();
+    installMutateAsyncMock.mockResolvedValue({});
+    discoverableSkillsMock = [];
+    skillReposMock = [];
+    refetchDiscoverableMock.mockReset();
+    searchCache.clear();
+  });
+
+  it("matches skills by description keyword, not only name or repo", async () => {
+    discoverableSkillsMock = [
+      makeDiscoverableSkill({
+        key: "ci-helper:octocat:ci-helper",
+        name: "CI Helper",
+        description: "Automates CI pipelines",
+        directory: "ci-helper",
+        repoOwner: "octocat",
+        repoName: "ci-helper",
+      }),
+      makeDiscoverableSkill({
+        key: "code-review:octocat:code-review",
+        name: "Code Review",
+        description: "Reviews pull requests",
+        directory: "code-review",
+        repoOwner: "octocat",
+        repoName: "code-review",
+      }),
+    ];
+    skillReposMock = [makeSkillRepo()];
+
+    const user = userEvent.setup();
+    render(<SkillsPage initialApp="claude" />);
+
+    // Wait for the repo source to be active
+    const input = await screen.findByPlaceholderText(
+      "skills.searchPlaceholder",
+    );
+    await user.type(input, "pipelines");
+
+    await waitFor(() => {
+      expect(screen.getByText("CI Helper")).toBeInTheDocument();
+      expect(screen.queryByText("Code Review")).not.toBeInTheDocument();
+    });
+  });
+
+  it("trims whitespace before matching description", async () => {
+    discoverableSkillsMock = [
+      makeDiscoverableSkill({
+        key: "ci-helper:octocat:ci-helper",
+        name: "CI Helper",
+        description: "Automates CI pipelines",
+        directory: "ci-helper",
+        repoOwner: "octocat",
+        repoName: "ci-helper",
+      }),
+    ];
+    skillReposMock = [makeSkillRepo()];
+
+    const user = userEvent.setup();
+    render(<SkillsPage initialApp="claude" />);
+
+    const input = await screen.findByPlaceholderText(
+      "skills.searchPlaceholder",
+    );
+    await user.type(input, "  pipelines  ");
+
+    await waitFor(() => {
+      expect(screen.getByText("CI Helper")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -1,10 +1,16 @@
 import { createRef } from "react";
 import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import UnifiedSkillsPanel, {
   type UnifiedSkillsPanelHandle,
 } from "@/components/skills/UnifiedSkillsPanel";
+
+// Radix Select calls scrollIntoView which jsdom doesn't implement.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
 
 const scanUnmanagedMock = vi.fn();
 const toggleSkillAppMock = vi.fn();
@@ -13,6 +19,9 @@ const importSkillsMock = vi.fn();
 const installFromZipMock = vi.fn();
 const deleteSkillBackupMock = vi.fn();
 const restoreSkillBackupMock = vi.fn();
+
+// Mutable reference so per-describe blocks can override the installed skills.
+let mockInstalledSkills: unknown[] = [];
 
 vi.mock("sonner", () => ({
   toast: {
@@ -24,7 +33,7 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/hooks/useSkills", () => ({
   useInstalledSkills: () => ({
-    data: [],
+    data: mockInstalledSkills,
     isLoading: false,
   }),
   useSkillBackups: () => ({
@@ -77,6 +86,7 @@ vi.mock("@/hooks/useSkills", () => ({
 
 describe("UnifiedSkillsPanel", () => {
   beforeEach(() => {
+    mockInstalledSkills = [];
     scanUnmanagedMock.mockResolvedValue({
       data: [
         {
@@ -129,5 +139,355 @@ describe("UnifiedSkillsPanel", () => {
         },
       ]);
     });
+  });
+});
+
+const makeSkill = (
+  overrides: Partial<{
+    id: string;
+    name: string;
+    description: string;
+    repoOwner: string;
+    repoName: string;
+    directory: string;
+  }> = {},
+) => ({
+  id: overrides.id ?? "skill-alpha",
+  name: overrides.name ?? "Alpha Skill",
+  description: overrides.description ?? "Alpha description",
+  directory: overrides.directory ?? "alpha",
+  repoOwner: overrides.repoOwner ?? "octocat",
+  repoName: overrides.repoName ?? "alpha-skill",
+  repoBranch: "main",
+  apps: { claude: true, codex: false, gemini: false },
+  installedAt: 1000,
+  updatedAt: 1000,
+});
+
+describe("UnifiedSkillsPanel – filters", () => {
+  beforeEach(() => {
+    mockInstalledSkills = [
+      makeSkill({
+        id: "alpha",
+        name: "Alpha Skill",
+        description: "Copilot helper",
+        repoOwner: "octocat",
+        repoName: "alpha-skill",
+      }),
+      makeSkill({
+        id: "beta",
+        name: "Beta Skill",
+        description: "CI automation",
+        repoOwner: "octocat",
+        repoName: "beta-skill",
+      }),
+      makeSkill({
+        id: "gamma",
+        name: "Gamma Skill",
+        description: "Code review bot",
+        repoOwner: "another-user",
+        repoName: "gamma-skill",
+      }),
+    ];
+    scanUnmanagedMock.mockResolvedValue({ data: [] });
+    toggleSkillAppMock.mockReset();
+    uninstallSkillMock.mockReset();
+    importSkillsMock.mockReset();
+    installFromZipMock.mockReset();
+    deleteSkillBackupMock.mockReset();
+    restoreSkillBackupMock.mockReset();
+  });
+
+  it("shows all skills when no filter is active", async () => {
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha Skill")).toBeInTheDocument();
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+      expect(screen.getByText("Gamma Skill")).toBeInTheDocument();
+    });
+  });
+
+  it("filters skills by keyword in name", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    const input = await screen.findByPlaceholderText(
+      "skills.searchPlaceholder",
+    );
+    await user.type(input, "beta");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha Skill")).not.toBeInTheDocument();
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Gamma Skill")).not.toBeInTheDocument();
+    });
+  });
+
+  it("filters skills by keyword in description", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    const input = await screen.findByPlaceholderText(
+      "skills.searchPlaceholder",
+    );
+    await user.type(input, "automation");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha Skill")).not.toBeInTheDocument();
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Gamma Skill")).not.toBeInTheDocument();
+    });
+  });
+
+  it("filters skills by keyword in repo", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    const input = await screen.findByPlaceholderText(
+      "skills.searchPlaceholder",
+    );
+    await user.type(input, "gamma-skill");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha Skill")).not.toBeInTheDocument();
+      expect(screen.queryByText("Beta Skill")).not.toBeInTheDocument();
+      expect(screen.getByText("Gamma Skill")).toBeInTheDocument();
+    });
+  });
+
+  it("trims whitespace from keyword search (P2 regression)", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    const input = await screen.findByPlaceholderText(
+      "skills.searchPlaceholder",
+    );
+    await user.type(input, "  beta  ");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha Skill")).not.toBeInTheDocument();
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Gamma Skill")).not.toBeInTheDocument();
+    });
+  });
+
+  it("filters skills by author", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    // Open the author select — Radix SelectTrigger is role="combobox"
+    const comboboxes = await screen.findAllByRole("combobox");
+    const authorTrigger = comboboxes.find((el) =>
+      el.textContent?.includes("skills.filter.allAuthors"),
+    )!;
+    await user.click(authorTrigger);
+    await user.click(screen.getByText("another-user"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha Skill")).not.toBeInTheDocument();
+      expect(screen.queryByText("Beta Skill")).not.toBeInTheDocument();
+      expect(screen.getByText("Gamma Skill")).toBeInTheDocument();
+    });
+  });
+
+  it("filters skills by repo", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    // Open the repo select
+    const comboboxes = await screen.findAllByRole("combobox");
+    const repoTrigger = comboboxes.find((el) =>
+      el.textContent?.includes("skills.filter.allRepos"),
+    )!;
+    await user.click(repoTrigger);
+    // "octocat/alpha-skill" also appears in the skill card; the SelectItem
+    // is the second occurrence.
+    const repoItems = screen.getAllByText("octocat/alpha-skill");
+    await user.click(repoItems[1]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Beta Skill")).not.toBeInTheDocument();
+      expect(screen.queryByText("Gamma Skill")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when filters produce no results", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    const input = await screen.findByPlaceholderText(
+      "skills.searchPlaceholder",
+    );
+    await user.type(input, "zzz-no-match");
+
+    await waitFor(() => {
+      expect(screen.getByText("skills.noResults")).toBeInTheDocument();
+    });
+  });
+
+  it("selecting 'all' option after a filter resets to show all skills", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    await screen.findByText("Alpha Skill");
+
+    // Filter to another-user
+    const comboboxes = screen.getAllByRole("combobox");
+    const authorTrigger = comboboxes.find((el) =>
+      el.textContent?.includes("skills.filter.allAuthors"),
+    )!;
+    await user.click(authorTrigger);
+    await user.click(screen.getByText("another-user"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Gamma Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Alpha Skill")).not.toBeInTheDocument();
+    });
+
+    // Reset to "all authors"
+    const updatedComboboxes = screen.getAllByRole("combobox");
+    const updatedAuthorTrigger = updatedComboboxes.find((el) =>
+      el.textContent?.includes("another-user"),
+    )!;
+    await user.click(updatedAuthorTrigger);
+    await user.click(screen.getByText("skills.filter.allAuthors"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha Skill")).toBeInTheDocument();
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+      expect(screen.getByText("Gamma Skill")).toBeInTheDocument();
+    });
+  });
+
+  it("clears author filter when the selected author has no remaining skills", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    await screen.findByText("Alpha Skill");
+
+    // Filter to another-user
+    const comboboxes = screen.getAllByRole("combobox");
+    const authorTrigger = comboboxes.find((el) =>
+      el.textContent?.includes("skills.filter.allAuthors"),
+    )!;
+    await user.click(authorTrigger);
+    await user.click(screen.getByText("another-user"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Gamma Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Alpha Skill")).not.toBeInTheDocument();
+    });
+
+    // Simulate uninstalling the last skill from another-user
+    mockInstalledSkills = [
+      makeSkill({
+        id: "alpha",
+        name: "Alpha Skill",
+        description: "Copilot helper",
+        repoOwner: "octocat",
+        repoName: "alpha-skill",
+      }),
+      makeSkill({
+        id: "beta",
+        name: "Beta Skill",
+        description: "CI automation",
+        repoOwner: "octocat",
+        repoName: "beta-skill",
+      }),
+    ];
+
+    rerender(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    // Filter should be cleared — all remaining skills visible
+    await waitFor(() => {
+      expect(screen.getByText("Alpha Skill")).toBeInTheDocument();
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+    });
+  });
+
+  it("filter controls have accessible names", async () => {
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    await screen.findByText("Alpha Skill");
+
+    // Search input
+    const searchInput = screen.getByRole("textbox", {
+      name: /skills\.searchPlaceholder/i,
+    });
+    expect(searchInput).toHaveAttribute(
+      "placeholder",
+      "skills.searchPlaceholder",
+    );
+
+    // Author select (combobox) — use role + aria-label
+    const authorSelect = screen.getByRole("combobox", {
+      name: /skills\.filter\.author/i,
+    });
+    expect(authorSelect).toBeInTheDocument();
+
+    // Repo select (combobox) — use role + aria-label
+    const repoSelect = screen.getByRole("combobox", {
+      name: /skills\.filter\.repo/i,
+    });
+    expect(repoSelect).toBeInTheDocument();
+  });
+
+  it("clears all filters when the clear button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
+    );
+
+    await screen.findByText("Alpha Skill");
+
+    // Apply keyword filter
+    const searchInput = screen.getByRole("textbox", {
+      name: /skills\.searchPlaceholder/i,
+    });
+    await user.type(searchInput, "beta");
+
+    await waitFor(() => {
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Alpha Skill")).not.toBeInTheDocument();
+    });
+
+    // Click clear button
+    await user.click(screen.getByText("skills.filter.clearFilter"));
+
+    // All skills should be visible again
+    await waitFor(() => {
+      expect(screen.getByText("Alpha Skill")).toBeInTheDocument();
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+      expect(screen.getByText("Gamma Skill")).toBeInTheDocument();
+    });
+
+    // Input should be empty
+    expect(searchInput).toHaveValue("");
   });
 });


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->
新增功能：

为`Skill 管理`页面添加过滤器，方便用户快速筛选查找 skill

已添加单元测试函数，并且全部通过

相关更改：

因为支持从Skill的description中匹配查询，所以修改了i18n中的`skills.repo.searchPlaceholder`，由于使用这个i18n模板的还有Skill的发现页面（src/components/skills/SkillsPage.tsx），所以对该组件的逻辑进行修改，支持从description中查询，并添加相关单元测试

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #5348

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|       <img width="1233" height="712" alt="image" src="https://github.com/user-attachments/assets/48349420-075a-4c39-ab6a-eb41d43cb945" />       |        <img width="1233" height="712" alt="image" src="https://github.com/user-attachments/assets/b6e301aa-bc3d-442f-8a07-5f06469eca9e" />       |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
