### PR TITLE
feat(presets): add XuanShu API provider

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1199,6 +1199,20 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#000000",
   },
   {
+    name: "XuanShu API",
+    websiteUrl: "https://www.xuanshuapi.com",
+    apiKeyUrl: "https://www.xuanshuapi.com/keys",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://www.xuanshuapi.com",
+        ANTHROPIC_AUTH_TOKEN: "",
+      },
+    },
+    category: "aggregator",
+    // Anthropic 兼容层挂在根路径，Base URL 不带 /v1
+    endpointCandidates: ["https://www.xuanshuapi.com"],
+  },
+  {
     name: "OpenRouter",
     websiteUrl: "https://openrouter.ai",
     apiKeyUrl: "https://openrouter.ai/keys",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1613,6 +1613,27 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
     icon: "pipellm",
   },
   {
+    name: "XuanShu API",
+    websiteUrl: "https://www.xuanshuapi.com",
+    apiKeyUrl: "https://www.xuanshuapi.com/keys",
+    auth: generateThirdPartyAuth(""),
+    // 官方教程使用 requires_openai_auth = false 并注入 actor header，
+    // 与 generateThirdPartyConfig 的默认值不同，故手写 TOML。
+    config: `model_provider = "xuanshu"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.xuanshu]
+name = "xuanshu"
+base_url = "https://www.xuanshuapi.com/v1"
+wire_api = "responses"
+requires_openai_auth = false
+http_headers = { "x-openai-actor-authorization" = "xuanshuapi.com" }`,
+    endpointCandidates: ["https://www.xuanshuapi.com/v1"],
+    category: "aggregator",
+  },
+  {
     name: "OpenRouter",
     websiteUrl: "https://openrouter.ai",
     apiKeyUrl: "https://openrouter.ai/keys",

--- a/src/config/geminiProviderPresets.ts
+++ b/src/config/geminiProviderPresets.ts
@@ -454,6 +454,23 @@ export const geminiProviderPresets: GeminiProviderPreset[] = [
     icon: "cherryin",
   },
   {
+    name: "XuanShu API",
+    websiteUrl: "https://www.xuanshuapi.com",
+    apiKeyUrl: "https://www.xuanshuapi.com/keys",
+    settingsConfig: {
+      env: {
+        GOOGLE_GEMINI_BASE_URL: "https://www.xuanshuapi.com",
+        GEMINI_API_KEY: "",
+        GEMINI_MODEL: "gemini-3-pro-preview",
+      },
+    },
+    baseURL: "https://www.xuanshuapi.com",
+    model: "gemini-3-pro-preview",
+    description: "XuanShu API",
+    category: "aggregator",
+    endpointCandidates: ["https://www.xuanshuapi.com"],
+  },
+  {
     name: "OpenRouter",
     websiteUrl: "https://openrouter.ai",
     apiKeyUrl: "https://openrouter.ai/keys",

--- a/src/config/hermesProviderPresets.ts
+++ b/src/config/hermesProviderPresets.ts
@@ -1052,6 +1052,23 @@ export const hermesProviderPresets: HermesProviderPreset[] = [
     },
   },
   {
+    name: "XuanShu API",
+    websiteUrl: "https://www.xuanshuapi.com",
+    apiKeyUrl: "https://www.xuanshuapi.com/keys",
+    settingsConfig: {
+      name: "xuanshu",
+      // Anthropic Messages 兼容层在根路径，不带 /v1
+      base_url: "https://www.xuanshuapi.com",
+      api_key: "",
+      api_mode: "anthropic_messages",
+      models: [{ id: "claude-opus-4-7", name: "Claude Opus 4.7" }],
+    },
+    category: "aggregator",
+    suggestedDefaults: {
+      model: { default: "claude-opus-4-7", provider: "xuanshu" },
+    },
+  },
+  {
     name: "OpenRouter",
     nameKey: "providerForm.presets.openrouter",
     websiteUrl: "https://openrouter.ai",

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -2265,6 +2265,40 @@ export const openclawProviderPresets: OpenClawProviderPreset[] = [
     },
   },
   {
+    name: "XuanShu API",
+    websiteUrl: "https://www.xuanshuapi.com",
+    apiKeyUrl: "https://www.xuanshuapi.com/keys",
+    settingsConfig: {
+      // Anthropic Messages 兼容层在根路径，不带 /v1
+      baseUrl: "https://www.xuanshuapi.com",
+      apiKey: "",
+      api: "anthropic-messages",
+      models: [
+        {
+          id: "claude-opus-4-6",
+          name: "Claude Opus 4.6",
+          contextWindow: 200000,
+        },
+      ],
+    },
+    category: "aggregator",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "",
+        editorValue: "",
+      },
+    },
+    suggestedDefaults: {
+      model: {
+        primary: "xuanshu/claude-opus-4-6",
+      },
+      modelCatalog: {
+        "xuanshu/claude-opus-4-6": { alias: "Opus" },
+      },
+    },
+  },
+  {
     name: "OpenRouter",
     websiteUrl: "https://openrouter.ai",
     apiKeyUrl: "https://openrouter.ai/keys",

--- a/src/config/opencodeProviderPresets.ts
+++ b/src/config/opencodeProviderPresets.ts
@@ -1901,6 +1901,33 @@ export const opencodeProviderPresets: OpenCodeProviderPreset[] = [
     },
   },
   {
+    name: "XuanShu API",
+    websiteUrl: "https://www.xuanshuapi.com",
+    apiKeyUrl: "https://www.xuanshuapi.com/keys",
+    settingsConfig: {
+      npm: "@ai-sdk/anthropic",
+      name: "XuanShu API",
+      options: {
+        // @ai-sdk/anthropic 会在 baseURL 后拼接 /messages
+        baseURL: "https://www.xuanshuapi.com/v1",
+        apiKey: "",
+      },
+      models: {
+        "claude-opus-4-7": { name: "Claude Opus 4.7" },
+        "claude-opus-4-6": { name: "Claude Opus 4.6" },
+        "claude-sonnet-4-6": { name: "Claude Sonnet 4.6" },
+      },
+    },
+    category: "aggregator",
+    templateValues: {
+      apiKey: {
+        label: "API Key",
+        placeholder: "",
+        editorValue: "",
+      },
+    },
+  },
+  {
     name: "OpenRouter",
     websiteUrl: "https://openrouter.ai",
     apiKeyUrl: "https://openrouter.ai/keys",

--- a/tests/config/xuanshuProviderPresets.test.ts
+++ b/tests/config/xuanshuProviderPresets.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { providerPresets } from "@/config/claudeProviderPresets";
+import { codexProviderPresets } from "@/config/codexProviderPresets";
+import { geminiProviderPresets } from "@/config/geminiProviderPresets";
+import { hermesProviderPresets } from "@/config/hermesProviderPresets";
+import { openclawProviderPresets } from "@/config/openclawProviderPresets";
+import { opencodeProviderPresets } from "@/config/opencodeProviderPresets";
+
+const NAME = "XuanShu API";
+const SITE = "https://www.xuanshuapi.com";
+
+describe("XuanShu API provider preset", () => {
+  it("points Claude Code at the root Anthropic endpoint without /v1", () => {
+    const preset = providerPresets.find((item) => item.name === NAME);
+    const env = (preset?.settingsConfig as { env: Record<string, string> }).env;
+
+    expect(preset?.websiteUrl).toBe(SITE);
+    expect(preset?.category).toBe("aggregator");
+    expect(preset?.endpointCandidates).toEqual([SITE]);
+    expect(env.ANTHROPIC_BASE_URL).toBe(SITE);
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("");
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  it("uses the Responses wire API for Codex without OpenAI auth", () => {
+    const preset = codexProviderPresets.find((item) => item.name === NAME);
+
+    expect(preset?.auth).toEqual({ OPENAI_API_KEY: "" });
+    expect(preset?.endpointCandidates).toEqual([`${SITE}/v1`]);
+    expect(preset?.config).toContain('model_provider = "xuanshu"');
+    expect(preset?.config).toContain(`base_url = "${SITE}/v1"`);
+    expect(preset?.config).toContain('wire_api = "responses"');
+    expect(preset?.config).toContain("requires_openai_auth = false");
+    expect(preset?.config).toContain("x-openai-actor-authorization");
+  });
+
+  it("uses the native Gemini endpoint at the root for Gemini CLI", () => {
+    const preset = geminiProviderPresets.find((item) => item.name === NAME);
+    const env = (preset?.settingsConfig as { env: Record<string, string> }).env;
+
+    expect(preset?.baseURL).toBe(SITE);
+    expect(env.GOOGLE_GEMINI_BASE_URL).toBe(SITE);
+    expect(env.GEMINI_API_KEY).toBe("");
+    expect(env.GEMINI_MODEL).toBe("gemini-3-pro-preview");
+  });
+
+  it("uses Anthropic Messages for Hermes", () => {
+    const preset = hermesProviderPresets.find((item) => item.name === NAME);
+
+    expect(preset?.settingsConfig).toMatchObject({
+      name: "xuanshu",
+      base_url: SITE,
+      api_key: "",
+      api_mode: "anthropic_messages",
+    });
+    expect(preset?.suggestedDefaults?.model).toEqual({
+      default: "claude-opus-4-7",
+      provider: "xuanshu",
+    });
+  });
+
+  it("uses Anthropic Messages for OpenClaw", () => {
+    const preset = openclawProviderPresets.find((item) => item.name === NAME);
+
+    expect(preset?.settingsConfig).toMatchObject({
+      baseUrl: SITE,
+      apiKey: "",
+      api: "anthropic-messages",
+    });
+    expect(preset?.suggestedDefaults?.model?.primary).toBe(
+      "xuanshu/claude-opus-4-6",
+    );
+  });
+
+  it("uses the Anthropic SDK against /v1 for OpenCode", () => {
+    const preset = opencodeProviderPresets.find((item) => item.name === NAME);
+
+    expect(preset?.settingsConfig.npm).toBe("@ai-sdk/anthropic");
+    expect(preset?.settingsConfig.options?.baseURL).toBe(`${SITE}/v1`);
+    expect(Object.keys(preset?.settingsConfig.models ?? {})).toContain(
+      "claude-opus-4-7",
+    );
+  });
+});


### PR DESCRIPTION
Closes #5873.

Adds a non-sponsor `XuanShu API` preset (玄枢API, https://www.xuanshuapi.com) with
`category: "aggregator"` across six surfaces.

### Why the Base URLs differ per surface

This is the part users get wrong when adding it as a custom provider, and the reason a
preset helps:

| Surface | Base URL | Verified |
|---|---|---|
| Claude Code / Hermes / OpenClaw (Anthropic Messages) | `https://www.xuanshuapi.com` (root, no `/v1`) | `POST /v1/messages` → 401 |
| Codex (OpenAI Responses) | `https://www.xuanshuapi.com/v1` | `POST /v1/responses` → 401 |
| OpenCode (`@ai-sdk/anthropic`) | `https://www.xuanshuapi.com/v1` (SDK appends `/messages`) | as above |
| Gemini CLI (native `v1beta`) | `https://www.xuanshuapi.com` (root) | `POST /v1beta/models/{model}:generateContent` → 401 |

401 rather than 404 on every path above — the routes exist and reject unauthenticated calls.

### Codex config is hand-written on purpose

`generateThirdPartyConfig` emits `requires_openai_auth = true` and no headers. The operator's
published Codex doc uses `requires_openai_auth = false` plus
`http_headers = { "x-openai-actor-authorization" = "xuanshuapi.com" }`, so reusing the helper
would emit a config that does not match their documented setup. Everything else follows the
existing non-sponsor entries.

### Sources

All values come from the operator's own published docs, not inferred:

- https://www.xuanshuapi.com/zh/docs/claude-code
- https://www.xuanshuapi.com/zh/docs/codex
- https://www.xuanshuapi.com/zh/docs/gemini-cli
- https://www.xuanshuapi.com/zh/docs/models

### Checks

- `pnpm typecheck` — clean
- `pnpm test:unit` — 84 files / 573 tests pass (including the 6 new cases)
- `pnpm format:check` — clean

`tests/config/xuanshuProviderPresets.test.ts` pins the per-surface Base URL split so a later
refactor cannot silently move Anthropic under `/v1`.

### Disclosure

I am affiliated with the provider. No `isPartner`, no `primePartner`, no affiliate or `utm_`
parameters in any URL — the entry sits in the non-sponsor section. Model IDs are the ones the
operator documents today; their catalog is per-key and per-group, so I kept the lists minimal
rather than claiming a full catalog. Happy to drop any surface you would rather not carry.
