### PR TITLE
fix(proxy): survive Responses SSE stream drops and silent-reasoning stalls

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -112,3 +112,4 @@ strip = "symbols"
 [dev-dependencies]
 serial_test = "3"
 tempfile = "3"
+tokio = { version = "1", features = ["test-util"] }

--- a/src-tauri/src/proxy/error.rs
+++ b/src-tauri/src/proxy/error.rs
@@ -174,6 +174,24 @@ impl IntoResponse for ProxyError {
     }
 }
 
+/// 沿 `source()` 链拼接错误信息，用于日志与面向客户端的错误消息。
+///
+/// reqwest/hyper 的 `Display` 只输出最外层描述（如 "error decoding response body"），
+/// 真正的传输层原因（连接重置、TLS EOF 等）藏在 source 链里。
+pub fn error_chain_message(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut message = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        let cause_text = cause.to_string();
+        if !cause_text.is_empty() && !message.contains(&cause_text) {
+            message.push_str(": ");
+            message.push_str(&cause_text);
+        }
+        source = cause.source();
+    }
+    message
+}
+
 /// 错误分类
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorCategory {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -13,7 +13,7 @@ use super::{
     provider_router::ProviderRouter,
     providers::{
         codex_chat_history::CodexChatHistoryStore, gemini_shadow::GeminiShadowStore, get_adapter,
-        AuthInfo, AuthStrategy, ProviderAdapter, ProviderType,
+        streaming_retry::StreamReconnector, AuthInfo, AuthStrategy, ProviderAdapter, ProviderType,
     },
     thinking_budget_rectifier::{rectify_thinking_budget, should_rectify_thinking_budget},
     thinking_rectifier::{
@@ -68,6 +68,9 @@ pub struct ForwardResult {
     /// 活跃连接 RAII guard：随响应一起流转到 response_processor / handle_claude_transform，
     /// 最终被 move 进流式 body future（或非流式响应作用域），覆盖整个响应生命周期。
     pub(crate) connection_guard: Option<ActiveConnectionGuard>,
+    /// 流式 Responses 请求的上游重连工厂：下游转换层在流中断且尚未向客户端
+    /// 转发实质内容时用它做有界自动重连（见 providers::streaming_retry）。
+    pub(crate) stream_reconnect: Option<StreamReconnector>,
 }
 
 pub struct ForwardError {
@@ -490,7 +493,7 @@ impl RequestForwarder {
                 )
                 .await
             {
-                Ok((response, claude_api_format, outbound_model)) => {
+                Ok((response, claude_api_format, outbound_model, stream_reconnect)) => {
                     // 成功：普通闭合熔断状态异步记录，避免阻塞流式首包返回；
                     // HalfOpen 探测仍同步等待，保证 permit 与熔断状态及时释放。
                     self.record_success_result(&provider.id, app_type_str, used_half_open_permit)
@@ -540,6 +543,7 @@ impl RequestForwarder {
                         claude_api_format,
                         outbound_model,
                         connection_guard: None,
+                        stream_reconnect,
                     });
                 }
                 Err(e) => {
@@ -589,7 +593,12 @@ impl RequestForwarder {
                                 )
                                 .await
                             {
-                                Ok((response, claude_api_format, outbound_model)) => {
+                                Ok((
+                                    response,
+                                    claude_api_format,
+                                    outbound_model,
+                                    stream_reconnect,
+                                )) => {
                                     log::info!(
                                         "[{app_type_str}] [Media] Unsupported-image retry succeeded"
                                     );
@@ -643,6 +652,7 @@ impl RequestForwarder {
                                         claude_api_format,
                                         outbound_model,
                                         connection_guard: None,
+                                        stream_reconnect,
                                     });
                                 }
                                 Err(retry_err) => {
@@ -735,7 +745,12 @@ impl RequestForwarder {
                                     )
                                     .await
                                 {
-                                    Ok((response, claude_api_format, outbound_model)) => {
+                                    Ok((
+                                        response,
+                                        claude_api_format,
+                                        outbound_model,
+                                        stream_reconnect,
+                                    )) => {
                                         log::info!("[{app_type_str}] [RECT-002] 整流重试成功");
                                         self.record_success_result(
                                             &provider.id,
@@ -792,6 +807,7 @@ impl RequestForwarder {
                                             claude_api_format,
                                             outbound_model,
                                             connection_guard: None,
+                                            stream_reconnect,
                                         });
                                     }
                                     Err(retry_err) => {
@@ -901,7 +917,12 @@ impl RequestForwarder {
                                 )
                                 .await
                             {
-                                Ok((response, claude_api_format, outbound_model)) => {
+                                Ok((
+                                    response,
+                                    claude_api_format,
+                                    outbound_model,
+                                    stream_reconnect,
+                                )) => {
                                     log::info!("[{app_type_str}] [RECT-011] budget 整流重试成功");
                                     self.record_success_result(
                                         &provider.id,
@@ -952,6 +973,7 @@ impl RequestForwarder {
                                         claude_api_format,
                                         outbound_model,
                                         connection_guard: None,
+                                        stream_reconnect,
                                     });
                                 }
                                 Err(retry_err) => {
@@ -1109,8 +1131,9 @@ impl RequestForwarder {
 
     /// 转发单个请求（使用适配器）
     ///
-    /// 成功时返回 `(response, claude_api_format, outbound_model)`，其中
-    /// `outbound_model` 是最终发往上游的模型名（所有映射/改写之后）。
+    /// 成功时返回 `(response, claude_api_format, outbound_model, stream_reconnect)`，其中
+    /// `outbound_model` 是最终发往上游的模型名（所有映射/改写之后），
+    /// `stream_reconnect` 是流式 Responses 请求的上游重连工厂（供中断重试用）。
     #[allow(clippy::too_many_arguments)]
     async fn forward(
         &self,
@@ -1122,7 +1145,15 @@ impl RequestForwarder {
         headers: &axum::http::HeaderMap,
         extensions: &Extensions,
         adapter: &dyn ProviderAdapter,
-    ) -> Result<(ProxyResponse, Option<String>, Option<String>), ProxyError> {
+    ) -> Result<
+        (
+            ProxyResponse,
+            Option<String>,
+            Option<String>,
+            Option<StreamReconnector>,
+        ),
+        ProxyError,
+    > {
         // 使用适配器提取 base_url
         let mut base_url = adapter.extract_base_url(provider)?;
 
@@ -2212,6 +2243,88 @@ impl RequestForwarder {
             is_copilot,
         );
 
+        // 流式 Responses 请求提交给下游后，上游仍可能中途掐断 SSE。
+        // 在 headers/body 被移动之前捕获一份重放工厂，交给下游转换层做
+        // 有界重连（见 providers::streaming_retry）。工厂只是重放同一
+        // HTTP 请求；是否重试、重试多少次由转换层根据下游状态决定。
+        let stream_reconnect = if request_is_streaming
+            && matches!(
+                resolved_claude_api_format.as_deref(),
+                Some("openai_responses")
+            ) {
+            let first_byte_timeout = if self.streaming_first_byte_timeout.is_zero() {
+                timeout
+            } else {
+                self.streaming_first_byte_timeout
+            };
+            let connect: super::providers::streaming_retry::ConnectFn =
+                if is_socks_proxy || !preserve_exact_header_case {
+                    let url = url.clone();
+                    let method = method.clone();
+                    let headers = ordered_headers.clone();
+                    let body = body_bytes.clone();
+                    Box::new(move || {
+                        let url = url.clone();
+                        let method = method.clone();
+                        let headers = headers.clone();
+                        let body = body.clone();
+                        Box::pin(async move {
+                            let client = super::http_client::get();
+                            let mut request = client
+                                .request(method, &url)
+                                .timeout(std::time::Duration::from_secs(24 * 60 * 60));
+                            for (key, value) in &headers {
+                                request = request.header(key, value);
+                            }
+                            let response = request
+                                .body(body)
+                                .send()
+                                .await
+                                .map_err(map_reqwest_send_error)?;
+                            Ok(ProxyResponse::Reqwest(response))
+                        })
+                    })
+                } else {
+                    let url = url.clone();
+                    let target_for_log = target_for_log.clone();
+                    let method = method.clone();
+                    let headers = ordered_headers.clone();
+                    let extensions = extensions.clone();
+                    let body = body_bytes.clone();
+                    let upstream_proxy_url = upstream_proxy_url.clone();
+                    Box::new(move || {
+                        let url = url.clone();
+                        let target_for_log = target_for_log.clone();
+                        let method = method.clone();
+                        let headers = headers.clone();
+                        let extensions = extensions.clone();
+                        let body = body.clone();
+                        let upstream_proxy_url = upstream_proxy_url.clone();
+                        Box::pin(async move {
+                            let uri: http::Uri = url.parse().map_err(|e| {
+                                ProxyError::ForwardFailed(format!(
+                                    "Invalid upstream URL ({target_for_log}): {e}"
+                                ))
+                            })?;
+                            super::hyper_client::send_request(
+                                uri,
+                                &target_for_log,
+                                method,
+                                headers,
+                                extensions,
+                                body,
+                                timeout,
+                                upstream_proxy_url.as_deref(),
+                            )
+                            .await
+                        })
+                    })
+                };
+            Some(StreamReconnector::new(connect, first_byte_timeout))
+        } else {
+            None
+        };
+
         // 发送请求
         let response = if is_socks_proxy || !preserve_exact_header_case {
             // OpenAI / Copilot / Codex 类后端不依赖原始 header 大小写；走 reqwest
@@ -2301,7 +2414,12 @@ impl RequestForwarder {
                     response = self.validate_responses_stream_start(response).await?;
                 }
             }
-            Ok((response, resolved_claude_api_format, outbound_model))
+            Ok((
+                response,
+                resolved_claude_api_format,
+                outbound_model,
+                stream_reconnect,
+            ))
         } else {
             let status_code = status.as_u16();
             // 错误响应同样可能被上游压缩（content-encoding）。reqwest 未启用任何

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -27,7 +27,9 @@ use super::{
         },
         streaming_codex_chat::create_responses_sse_stream_from_chat_with_context,
         streaming_gemini::create_anthropic_sse_stream_from_gemini,
-        streaming_responses::create_anthropic_sse_stream_from_responses,
+        streaming_retry::{
+            create_resilient_anthropic_sse_stream_from_responses, StreamReconnector,
+        },
         transform, transform_codex_anthropic, transform_codex_chat,
         transform_codex_responses_namespace, transform_gemini, transform_responses,
     },
@@ -215,6 +217,7 @@ async fn handle_messages_for_app(
     };
 
     let connection_guard = result.connection_guard.take();
+    let stream_reconnect = result.stream_reconnect.take();
     ctx.outbound_model = result.outbound_model.take();
     ctx.provider = result.provider;
     let api_format = result
@@ -238,6 +241,7 @@ async fn handle_messages_for_app(
             is_stream,
             &api_format,
             connection_guard,
+            stream_reconnect,
         )
         .await;
     }
@@ -367,6 +371,7 @@ fn spawn_claude_usage_log(
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_claude_transform(
     response: super::hyper_client::ProxyResponse,
     ctx: &RequestContext,
@@ -375,6 +380,7 @@ async fn handle_claude_transform(
     is_stream: bool,
     api_format: &str,
     connection_guard: Option<ActiveConnectionGuard>,
+    stream_reconnect: Option<StreamReconnector>,
 ) -> Result<axum::response::Response, ProxyError> {
     let status = response.status();
     let is_codex_oauth = ctx
@@ -409,7 +415,14 @@ async fn handle_claude_transform(
         let sse_stream: Box<
             dyn futures::Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin,
         > = if api_format == "openai_responses" {
-            Box::new(Box::pin(create_anthropic_sse_stream_from_responses(stream)))
+            // Responses 上游会在提交后中途掐断 SSE；带重连工厂的包装器在下游
+            // 尚未收到实质内容时自动重试（上限 5 次），其余场景行为不变。
+            Box::new(Box::pin(
+                create_resilient_anthropic_sse_stream_from_responses(
+                    Box::pin(stream),
+                    stream_reconnect,
+                ),
+            ))
         } else if api_format == "gemini_native" {
             Box::new(Box::pin(create_anthropic_sse_stream_from_gemini(
                 stream,

--- a/src-tauri/src/proxy/hyper_client.rs
+++ b/src-tauri/src/proxy/hyper_client.rs
@@ -203,7 +203,7 @@ impl ProxyResponse {
                                 Some((Ok(Bytes::new()), body))
                             }
                         }
-                        Some(Err(e)) => Some((Err(std::io::Error::other(e.to_string())), body)),
+                        Some(Err(e)) => Some((Err(std::io::Error::other(e)), body)),
                         None => None,
                     }
                 })
@@ -214,9 +214,7 @@ impl ProxyResponse {
                     as std::pin::Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>
             }
             Self::Reqwest(r) => {
-                let stream = r
-                    .bytes_stream()
-                    .map(|r| r.map_err(|e| std::io::Error::other(e.to_string())));
+                let stream = r.bytes_stream().map(|r| r.map_err(std::io::Error::other));
                 Box::pin(stream)
             }
             Self::Buffered { body, .. } => Box::pin(futures::stream::once(async move { Ok(body) }))

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -31,6 +31,7 @@ pub mod streaming_codex_anthropic;
 pub mod streaming_codex_chat;
 pub mod streaming_gemini;
 pub mod streaming_responses;
+pub(crate) mod streaming_retry;
 pub mod transform;
 pub mod transform_codex_anthropic;
 pub mod transform_codex_chat;

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -627,13 +627,14 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                     }
                 }
                 Err(e) => {
-                    log::error!("Stream error: {e}");
+                    let chain = crate::proxy::error::error_chain_message(&e);
+                    log::error!("Stream error: {chain}");
                     stream_ended_with_error = true;
                     let error_event = json!({
                         "type": "error",
                         "error": {
                             "type": "stream_error",
-                            "message": format!("Stream error: {e}")
+                            "message": format!("Stream error: {chain}")
                         }
                     });
                     let sse_data = format!("event: error\ndata: {}\n\n",

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -24,7 +24,7 @@ fn response_object_from_event(data: &Value) -> &Value {
     data.get("response").unwrap_or(data)
 }
 
-fn anthropic_sse(event_name: &str, payload: &Value) -> Bytes {
+pub(crate) fn anthropic_sse(event_name: &str, payload: &Value) -> Bytes {
     Bytes::from(format!(
         "event: {event_name}\ndata: {}\n\n",
         serde_json::to_string(payload).unwrap_or_default()
@@ -50,7 +50,7 @@ fn responses_error_details(data: &Value, fallback: &str) -> (String, String) {
     (message, error_type)
 }
 
-fn anthropic_error_sse(message: &str, error_type: &str) -> Bytes {
+pub(crate) fn anthropic_error_sse(message: &str, error_type: &str) -> Bytes {
     anthropic_sse(
         "error",
         &json!({
@@ -58,6 +58,25 @@ fn anthropic_error_sse(message: &str, error_type: &str) -> Bytes {
             "error": {"type": error_type, "message": message}
         }),
     )
+}
+
+/// SSE 注释行标记：仅由本转换器在可安全重发整个请求的两种中断场景
+/// （传输层错误、无终止事件的过早 EOF）下随错误事件一起发出。
+///
+/// streaming_retry 依据该标记判定可重试。不能依据 error.type 判定：上游
+/// 语义性失败的 type 取自上游可控字段（见 `responses_error_details`），
+/// 恰好叫 "stream_error" 时会被误当成传输中断而错误地重试。
+/// SSE 规范规定以冒号开头的行是注释，客户端解析器会忽略。
+pub(crate) const RETRYABLE_STREAM_MARKER: &str = ": cc-switch-retryable-stream-interruption";
+
+/// 带 [`RETRYABLE_STREAM_MARKER`] 注释行的错误事件。
+pub(crate) fn retryable_stream_error_sse(message: &str, error_type: &str) -> Bytes {
+    let event = anthropic_error_sse(message, error_type);
+    let mut bytes = Vec::with_capacity(RETRYABLE_STREAM_MARKER.len() + 1 + event.len());
+    bytes.extend_from_slice(RETRYABLE_STREAM_MARKER.as_bytes());
+    bytes.push(b'\n');
+    bytes.extend_from_slice(&event);
+    Bytes::from(bytes)
 }
 
 /// Convert a compatible gateway's non-streaming Responses JSON into a complete
@@ -1461,17 +1480,12 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                     }
                 }
                 Err(e) => {
-                    log::error!("Responses stream error: {e}");
-                    let error_event = json!({
-                        "type": "error",
-                        "error": {
-                            "type": "stream_error",
-                            "message": format!("Stream error: {e}")
-                        }
-                    });
-                    let sse = format!("event: error\ndata: {}\n\n",
-                        serde_json::to_string(&error_event).unwrap_or_default());
-                    yield Ok(Bytes::from(sse));
+                    let chain = crate::proxy::error::error_chain_message(&e);
+                    log::error!("Responses stream error: {chain}");
+                    yield Ok(retryable_stream_error_sse(
+                        &format!("Stream error: {chain}"),
+                        "stream_error",
+                    ));
                     terminated = true;
                     break;
                 }
@@ -1526,7 +1540,7 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
             } else {
                 // A truncated tool/reasoning block cannot be safely finalized: tool
                 // JSON may be partial and thinking may be missing its signature.
-                yield Ok(anthropic_error_sse(
+                yield Ok(retryable_stream_error_sse(
                     "Responses upstream stream ended before a terminal event",
                     "stream_truncated",
                 ));

--- a/src-tauri/src/proxy/providers/streaming_retry.rs
+++ b/src-tauri/src/proxy/providers/streaming_retry.rs
@@ -18,6 +18,12 @@
 //! 与 #5546 在提交边界前的处理保持同一分界。可重试与否由转换器附加的
 //! [`RETRYABLE_STREAM_MARKER`] 注释行标识，而非事件里的 `error.type`——后者
 //! 逐字透传自上游可控字段，不可信。
+//!
+//! 包装器同时承担正常流转期间的思考期心跳：推理模型隐藏思考时上游可整段
+//! 无事件，`message_start` 之后上游每静默 [`KEEPALIVE_INTERVAL`] 即向下游发
+//! 一次 ping（至多 [`UPSTREAM_SILENCE_KEEPALIVE_LIMIT`]），防止下游空闲计时
+//! 器（本代理 120s passthrough 超时、Claude Code 字节级 stream watchdog）把
+//! 长思考误判为断流。
 
 use super::streaming_responses::{
     anthropic_error_sse, anthropic_sse, create_anthropic_sse_stream_from_responses,
@@ -36,12 +42,23 @@ use std::time::Duration;
 /// 与官方 Codex CLI 的 `stream_max_retries` 默认值对齐。
 pub(crate) const RESPONSES_STREAM_MAX_RETRIES: u32 = 5;
 
-/// 重连等待期间向下游发 keepalive 的间隔。
+/// 重连等待与正常流转静默期间向下游发 keepalive 的间隔。
 ///
 /// 退避（≤3.2s）+ 重连（≤60s）+ 等待重连后首个事件（≤60s）三段串联可超过
 /// 下游 `create_logged_passthrough_stream` 的单次 120s 空闲超时；每段内部
 /// 都合规也可能被外层掐掉。周期性 ping 喂空闲计时器，保住合法的重试窗口。
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// 正常流转期间容忍的上游连续静默上限，超过后停止心跳。
+///
+/// 推理模型（GPT-5 系）隐藏思考期间可能长时间不产出任何 SSE 事件——未请求
+/// reasoning summary 时全程零事件，请求了摘要其增量也可能明显滞后。这种
+/// 静默是合法的"仍在生成"状态，但下游无从分辨：本代理的 120s passthrough
+/// 空闲超时会先掐断，即便调大，Claude Code 自身的字节级 stream watchdog
+/// （2.1.157 实测 180s，当前版本默认 5 分钟）也会中止请求。心跳在此窗口内
+/// 持续喂两级计时器；超过上限说明连接大概率已死（如 TCP 黑洞），停止心跳
+/// 把裁决权交还给操作者配置的空闲超时，避免无限保活一条死流。
+const UPSTREAM_SILENCE_KEEPALIVE_LIMIT: Duration = Duration::from_secs(300);
 
 pub(crate) type ByteStream = Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>;
 type ConnectFuture = Pin<Box<dyn Future<Output = Result<ProxyResponse, ProxyError>> + Send>>;
@@ -171,6 +188,9 @@ fn retry_failure_reason(event: &ScannedEvent) -> String {
 /// 把 Responses 上游字节流转换为 Anthropic SSE，并在下游只收到协议脚手架
 /// （`message_start`/`ping`）时对可重试的流中断做有界自动重连。
 ///
+/// 无论是否带 `reconnector`，`message_start` 之后上游每静默
+/// [`KEEPALIVE_INTERVAL`] 就向下游发一次 ping（推理模型隐藏思考期间上游可
+/// 整段无事件），至多持续 [`UPSTREAM_SILENCE_KEEPALIVE_LIMIT`]。除此之外，
 /// `reconnector` 为 `None` 时行为与 `create_anthropic_sse_stream_from_responses`
 /// 完全一致。
 pub fn create_resilient_anthropic_sse_stream_from_responses(
@@ -179,9 +199,35 @@ pub fn create_resilient_anthropic_sse_stream_from_responses(
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     async_stream::stream! {
         let Some(reconnector) = reconnector else {
+            // 无重连工厂：不做重试，但思考期心跳与主循环保持同款语义。
             let translated = create_anthropic_sse_stream_from_responses(initial);
             futures::pin_mut!(translated);
-            while let Some(item) = translated.next().await {
+            let mut message_start_forwarded = false;
+            loop {
+                let mut silent = Duration::ZERO;
+                let next = loop {
+                    match tokio::time::timeout(KEEPALIVE_INTERVAL, translated.next()).await {
+                        Ok(item) => break item,
+                        Err(_) => {
+                            silent += KEEPALIVE_INTERVAL;
+                            if message_start_forwarded
+                                && silent <= UPSTREAM_SILENCE_KEEPALIVE_LIMIT
+                            {
+                                yield Ok(anthropic_sse("ping", &json!({"type": "ping"})));
+                            }
+                        }
+                    }
+                };
+                let Some(item) = next else { break };
+                if let Ok(chunk) = &item {
+                    if !message_start_forwarded
+                        && scan_chunk(&String::from_utf8_lossy(chunk))
+                            .iter()
+                            .any(|event| event.name == "message_start")
+                    {
+                        message_start_forwarded = true;
+                    }
+                }
                 yield item;
             }
             return;
@@ -238,7 +284,23 @@ pub fn create_resilient_anthropic_sse_stream_from_responses(
                     }
                     result
                 } else {
-                    translated.next().await
+                    // 正常流转期间的思考期心跳：上游静默时周期性向下游发 ping
+                    // （Anthropic 协议允许任意时刻出现 ping），超过
+                    // UPSTREAM_SILENCE_KEEPALIVE_LIMIT 后停发，让外层空闲超时接管。
+                    let mut silent = Duration::ZERO;
+                    loop {
+                        match tokio::time::timeout(KEEPALIVE_INTERVAL, translated.next()).await {
+                            Ok(item) => break item,
+                            Err(_) => {
+                                silent += KEEPALIVE_INTERVAL;
+                                if message_start_forwarded
+                                    && silent <= UPSTREAM_SILENCE_KEEPALIVE_LIMIT
+                                {
+                                    yield Ok(anthropic_sse("ping", &json!({"type": "ping"})));
+                                }
+                            }
+                        }
+                    }
                 };
                 let Some(item) = next else {
                     break;
@@ -388,6 +450,20 @@ mod tests {
             .collect();
         items.push(Err(std::io::Error::other("error decoding response body")));
         Box::pin(stream::iter(items))
+    }
+
+    /// head 立即到达，tail 在 `delay` 之后到达——模拟推理模型隐藏思考的静默窗口。
+    fn delayed_chunks(head: &str, delay: Duration, tail: &str) -> ByteStream {
+        let head = Bytes::from(head.to_string());
+        let tail = Bytes::from(tail.to_string());
+        Box::pin(
+            stream::once(async move { Ok::<_, std::io::Error>(head) }).chain(stream::once(
+                async move {
+                    tokio::time::sleep(delay).await;
+                    Ok(tail)
+                },
+            )),
+        )
     }
 
     fn streamed_response(parts: &[&str]) -> ProxyResponse {
@@ -680,6 +756,98 @@ mod tests {
         assert!(
             out.matches("event: ping").count() >= 3,
             "expected keepalive pings while awaiting first event: {out}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn thinking_silence_emits_keepalive_pings_without_retry() {
+        // message_start 之后上游静默 60 秒（推理模型隐藏思考）：期间必须周期性
+        // 发 ping 喂下游空闲计时器，且不得触发重连——静默不是中断。
+        let (reconnector, calls) = scripted_reconnector(vec![]);
+        let tail = [text_delta("ok"), completed()].concat();
+        let first = delayed_chunks(&created(), Duration::from_secs(60), &tail);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "must not reconnect");
+        assert!(out.contains("event: message_stop"));
+        assert!(!out.contains("event: error"), "unexpected error in: {out}");
+        let pings = out.matches("event: ping").count();
+        assert!(
+            pings >= 4,
+            "expected keepalive pings during thinking silence, got {pings}: {out}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn thinking_silence_keepalive_stops_at_limit() {
+        // 上游静默远超上限：心跳只覆盖前 300 秒，之后停发，
+        // 把死流的裁决权交还给外层空闲超时。
+        let (reconnector, calls) = scripted_reconnector(vec![]);
+        let tail = [text_delta("ok"), completed()].concat();
+        let silence = UPSTREAM_SILENCE_KEEPALIVE_LIMIT + Duration::from_secs(100);
+        let first = delayed_chunks(&created(), silence, &tail);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "must not reconnect");
+        assert!(out.contains("event: message_stop"));
+        let pings = out.matches("event: ping").count();
+        let cap =
+            (UPSTREAM_SILENCE_KEEPALIVE_LIMIT.as_secs() / KEEPALIVE_INTERVAL.as_secs()) as usize;
+        assert!(pings <= cap, "pings must stop at the limit, got {pings}");
+        assert!(
+            pings >= cap - 2,
+            "expected pings up to the limit, got {pings} (cap {cap})"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn no_keepalive_before_message_start() {
+        // message_start 之前（上游还没发 response.created）不发 ping：该阶段由
+        // 首包超时语义治理，提前 ping 会向客户端伪造"响应已开始"。
+        let (reconnector, calls) = scripted_reconnector(vec![]);
+        let body = [created(), text_delta("ok"), completed()].concat();
+        let first: ByteStream = Box::pin(stream::once(async move {
+            tokio::time::sleep(Duration::from_secs(45)).await;
+            Ok::<_, std::io::Error>(Bytes::from(body))
+        }));
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "must not reconnect");
+        assert!(
+            !out.contains("event: ping"),
+            "no pings before message_start: {out}"
+        );
+        assert!(out.contains("event: message_stop"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn thinking_silence_pings_flow_without_reconnector() {
+        // 心跳不依赖重连工厂：reconnector 为 None 的路径同样要保活思考期。
+        let tail = [text_delta("ok"), completed()].concat();
+        let first = delayed_chunks(&created(), Duration::from_secs(60), &tail);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first, None,
+        ))
+        .await;
+
+        assert!(out.contains("event: message_stop"));
+        assert!(!out.contains("event: error"), "unexpected error in: {out}");
+        let pings = out.matches("event: ping").count();
+        assert!(
+            pings >= 4,
+            "expected keepalive pings during thinking silence, got {pings}: {out}"
         );
     }
 

--- a/src-tauri/src/proxy/providers/streaming_retry.rs
+++ b/src-tauri/src/proxy/providers/streaming_retry.rs
@@ -1,0 +1,722 @@
+//! Responses SSE 流中断的有界自动重连
+//!
+//! forwarder 的语义预热（`validate_responses_stream_start`）只保护提交前的失败：
+//! 一旦上游发出第一个 productive 事件，响应就提交给下游客户端，此后上游掐断
+//! SSE（Cloudflare 空闲切断、连接池陈旧连接等）会直接以 `stream_error` 终止整轮
+//! 请求。官方 Codex CLI 对同类中断用 `stream_max_retries`（默认 5 次）整请求重发
+//! 吸收；本模块把同样的语义移植到代理侧。
+//!
+//! 代理与 CLI 的关键差异：CLI 重试时可以丢弃已渲染的部分输出重画 UI，代理无法
+//! 撤回已发给客户端的字节。因此重试只在下游尚未收到任何实质内容（至多收到
+//! `message_start`/`ping` 这类协议脚手架）时进行——这恰好覆盖最常见的中断窗口：
+//! 预热在 reasoning `output_item.added`（不向下游产出字节）后提交，随后模型长时间
+//! 静默思考，空闲切断发生时下游只收到过 `message_start`。重试用全新的转换器实例
+//! 重发同一上游请求，并抑制重复的 `message_start`，对客户端完全透明；一旦转发过
+//! 实质内容，行为与现状一致（错误事件透传）。
+//!
+//! 上游语义性失败（`response.failed`/`error` 事件）不重试：那是上游的明确判决，
+//! 与 #5546 在提交边界前的处理保持同一分界。可重试与否由转换器附加的
+//! [`RETRYABLE_STREAM_MARKER`] 注释行标识，而非事件里的 `error.type`——后者
+//! 逐字透传自上游可控字段，不可信。
+
+use super::streaming_responses::{
+    anthropic_error_sse, anthropic_sse, create_anthropic_sse_stream_from_responses,
+    RETRYABLE_STREAM_MARKER,
+};
+use crate::proxy::error::ProxyError;
+use crate::proxy::hyper_client::ProxyResponse;
+use crate::proxy::sse::{strip_sse_field, take_sse_block};
+use bytes::Bytes;
+use futures::stream::{Stream, StreamExt};
+use serde_json::{json, Value};
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+/// 与官方 Codex CLI 的 `stream_max_retries` 默认值对齐。
+pub(crate) const RESPONSES_STREAM_MAX_RETRIES: u32 = 5;
+
+/// 重连等待期间向下游发 keepalive 的间隔。
+///
+/// 退避（≤3.2s）+ 重连（≤60s）+ 等待重连后首个事件（≤60s）三段串联可超过
+/// 下游 `create_logged_passthrough_stream` 的单次 120s 空闲超时；每段内部
+/// 都合规也可能被外层掐掉。周期性 ping 喂空闲计时器，保住合法的重试窗口。
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+pub(crate) type ByteStream = Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>;
+type ConnectFuture = Pin<Box<dyn Future<Output = Result<ProxyResponse, ProxyError>> + Send>>;
+pub(crate) type ConnectFn = Box<dyn Fn() -> ConnectFuture + Send + Sync>;
+
+/// 重新向同一供应商发起原始上游请求的工厂。
+///
+/// 由 `Forwarder::forward` 在发出首次请求前捕获最终解析的 URL/headers/body 构造；
+/// 每次调用发出一条全新的上游连接（认证头沿用首次请求的令牌，重试窗口只有数秒，
+/// 不需要重新走令牌刷新）。
+pub struct StreamReconnector {
+    connect: ConnectFn,
+    first_byte_timeout: Duration,
+}
+
+impl StreamReconnector {
+    pub fn new(connect: ConnectFn, first_byte_timeout: Duration) -> Self {
+        Self {
+            connect,
+            first_byte_timeout,
+        }
+    }
+
+    async fn connect(&self) -> Result<ProxyResponse, ProxyError> {
+        if self.first_byte_timeout.is_zero() {
+            (self.connect)().await
+        } else {
+            tokio::time::timeout(self.first_byte_timeout, (self.connect)())
+                .await
+                .map_err(|_| {
+                    ProxyError::Timeout(format!(
+                        "Responses stream reconnect timed out after {}s",
+                        self.first_byte_timeout.as_secs()
+                    ))
+                })?
+        }
+    }
+}
+
+/// Codex CLI 的标称退避序列（无抖动）：200/400/800/1600/3200ms。
+fn backoff_delay(attempt: u32) -> Duration {
+    Duration::from_millis(200u64 << attempt.saturating_sub(1).min(4))
+}
+
+/// 单个转换器输出块里解析出的 Anthropic SSE 事件。
+struct ScannedEvent {
+    name: &'static str,
+    data: Option<Value>,
+    /// 事件在原始块文本中的完整片段（含结尾空行），用于选择性转发。
+    raw: String,
+}
+
+/// 转换器产出的块都是本进程自己构造的 `event: X\ndata: {...}\n\n` 文本；
+/// 这里做一次浅解析以便分类。解析失败的片段按"实质内容"保守处理。
+fn scan_chunk(chunk: &str) -> Vec<ScannedEvent> {
+    let mut buffer = chunk.to_string();
+    let mut events = Vec::new();
+    while let Some(block) = take_sse_block(&mut buffer) {
+        if block.trim().is_empty() {
+            continue;
+        }
+        let mut name = "";
+        let mut data_lines: Vec<&str> = Vec::new();
+        for line in block.lines() {
+            if let Some(event) = strip_sse_field(line, "event") {
+                name = event.trim();
+            } else if let Some(data) = strip_sse_field(line, "data") {
+                data_lines.push(data);
+            }
+        }
+        let data = serde_json::from_str::<Value>(&data_lines.join("\n")).ok();
+        let name = if name.is_empty() {
+            data.as_ref()
+                .and_then(|value| value.get("type"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+        } else {
+            name
+        };
+        // 分类只关心这四种身份，映射为静态名以避免借用局部 buffer。
+        let name_owned: &'static str = match name {
+            "message_start" => "message_start",
+            "ping" => "ping",
+            "error" => "error",
+            _ => "",
+        };
+        events.push(ScannedEvent {
+            name: name_owned,
+            data,
+            raw: format!("{block}\n\n"),
+        });
+    }
+    // 转换器只产出完整块；万一出现残块，按实质内容原样转发，绝不吞字节。
+    if !buffer.is_empty() {
+        events.push(ScannedEvent {
+            name: "",
+            data: None,
+            raw: buffer,
+        });
+    }
+    events
+}
+
+/// 只把携带 [`RETRYABLE_STREAM_MARKER`] 注释行的错误事件视为可重试。
+///
+/// 该标记仅由本进程的转换器在传输层中断（`stream_error`）与无终止事件的
+/// 过早 EOF（`stream_truncated`）时附加。不能改判 `error.type`：上游语义性
+/// 失败的 type 逐字透传自上游可控字段，恰好叫 "stream_error" 时会被误吸收。
+fn is_retryable_error_event(event: &ScannedEvent) -> bool {
+    event.name == "error"
+        && event
+            .raw
+            .lines()
+            .any(|line| line == RETRYABLE_STREAM_MARKER)
+}
+
+fn retry_failure_reason(event: &ScannedEvent) -> String {
+    event
+        .data
+        .as_ref()
+        .and_then(|data| data.pointer("/error/message"))
+        .and_then(Value::as_str)
+        .unwrap_or("Responses upstream stream failed")
+        .to_string()
+}
+
+/// 把 Responses 上游字节流转换为 Anthropic SSE，并在下游只收到协议脚手架
+/// （`message_start`/`ping`）时对可重试的流中断做有界自动重连。
+///
+/// `reconnector` 为 `None` 时行为与 `create_anthropic_sse_stream_from_responses`
+/// 完全一致。
+pub fn create_resilient_anthropic_sse_stream_from_responses(
+    initial: ByteStream,
+    reconnector: Option<StreamReconnector>,
+) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
+    async_stream::stream! {
+        let Some(reconnector) = reconnector else {
+            let translated = create_anthropic_sse_stream_from_responses(initial);
+            futures::pin_mut!(translated);
+            while let Some(item) = translated.next().await {
+                yield item;
+            }
+            return;
+        };
+
+        let mut attempt: u32 = 0;
+        let mut message_start_forwarded = false;
+        let mut content_forwarded = false;
+        let mut current: Option<ByteStream> = Some(initial);
+
+        'attempts: loop {
+            let byte_stream = match current.take() {
+                Some(stream) => stream,
+                None => break,
+            };
+            let translated = create_anthropic_sse_stream_from_responses(byte_stream);
+            futures::pin_mut!(translated);
+
+            // 本次尝试因可重试原因终止时的描述；None 表示尝试正常走完。
+            let mut fail_reason: Option<String> = None;
+            // 重连后的尝试对首个转换事件套用首包超时，防止上游连上后静默挂起。
+            let mut awaiting_first_item = attempt > 0;
+
+            loop {
+                let next = if awaiting_first_item && !reconnector.first_byte_timeout.is_zero() {
+                    let deadline =
+                        tokio::time::Instant::now() + reconnector.first_byte_timeout;
+                    let mut result = None;
+                    let mut timed_out = true;
+                    while tokio::time::Instant::now() < deadline {
+                        let tick =
+                            KEEPALIVE_INTERVAL.min(deadline - tokio::time::Instant::now());
+                        match tokio::time::timeout(tick, translated.next()).await {
+                            Ok(item) => {
+                                result = item;
+                                timed_out = false;
+                                break;
+                            }
+                            Err(_) => {
+                                if message_start_forwarded
+                                    && tokio::time::Instant::now() < deadline
+                                {
+                                    yield Ok(anthropic_sse("ping", &json!({"type": "ping"})));
+                                }
+                            }
+                        }
+                    }
+                    if timed_out {
+                        fail_reason = Some(format!(
+                            "reconnected stream produced no output within {}s",
+                            reconnector.first_byte_timeout.as_secs()
+                        ));
+                        break;
+                    }
+                    result
+                } else {
+                    translated.next().await
+                };
+                let Some(item) = next else {
+                    break;
+                };
+                awaiting_first_item = false;
+
+                let chunk = match item {
+                    Ok(chunk) => chunk,
+                    // 当前转换器从不产出 Err；防御性透传并终止。
+                    Err(error) => {
+                        yield Err(error);
+                        return;
+                    }
+                };
+                let text = String::from_utf8_lossy(&chunk);
+                let mut forward = String::new();
+                for event in scan_chunk(&text) {
+                    if !content_forwarded && is_retryable_error_event(&event) {
+                        fail_reason = Some(retry_failure_reason(&event));
+                        break;
+                    }
+                    if event.name == "message_start" {
+                        if message_start_forwarded {
+                            // 重连后的新一轮生成会重新产生 message_start；
+                            // 客户端已收到首轮的，抑制重复。
+                            continue;
+                        }
+                        message_start_forwarded = true;
+                    } else if event.name != "ping" {
+                        content_forwarded = true;
+                    }
+                    forward.push_str(&event.raw);
+                }
+                if !forward.is_empty() {
+                    yield Ok(Bytes::from(forward));
+                }
+                if fail_reason.is_some() {
+                    break;
+                }
+            }
+
+            let Some(mut reason) = fail_reason else {
+                // 尝试正常结束（成功完成，或不可重试的错误已透传）。
+                break 'attempts;
+            };
+
+            loop {
+                if attempt >= RESPONSES_STREAM_MAX_RETRIES {
+                    log::error!(
+                        "[Claude/Responses] stream failed after {attempt} reconnect attempt(s): {reason}"
+                    );
+                    yield Ok(anthropic_error_sse(
+                        &format!(
+                            "Responses upstream stream failed after {attempt} reconnect attempt(s): {reason}"
+                        ),
+                        "stream_error",
+                    ));
+                    break 'attempts;
+                }
+                attempt += 1;
+                log::warn!(
+                    "[Claude/Responses] upstream stream dropped before any content reached the client ({reason}); reconnecting (attempt {attempt}/{RESPONSES_STREAM_MAX_RETRIES})"
+                );
+                if message_start_forwarded {
+                    // 喂一下下游的空闲计时器（Anthropic 协议允许任意时刻出现 ping）。
+                    yield Ok(anthropic_sse("ping", &json!({"type": "ping"})));
+                }
+                tokio::time::sleep(backoff_delay(attempt)).await;
+                let connect_result = {
+                    let connect = reconnector.connect();
+                    futures::pin_mut!(connect);
+                    loop {
+                        match tokio::time::timeout(KEEPALIVE_INTERVAL, connect.as_mut()).await {
+                            Ok(result) => break result,
+                            Err(_) => {
+                                if message_start_forwarded {
+                                    yield Ok(anthropic_sse("ping", &json!({"type": "ping"})));
+                                }
+                            }
+                        }
+                    }
+                };
+                match connect_result {
+                    Ok(response) if response.status().is_success() => {
+                        current = Some(Box::pin(response.bytes_stream()));
+                        continue 'attempts;
+                    }
+                    Ok(response) => {
+                        reason = format!(
+                            "reconnect got HTTP {} from upstream",
+                            response.status().as_u16()
+                        );
+                    }
+                    Err(error) => {
+                        reason = format!("reconnect failed: {error}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    fn sse(event: &str, data: Value) -> String {
+        format!("event: {event}\ndata: {data}\n\n")
+    }
+
+    fn created() -> String {
+        sse(
+            "response.created",
+            json!({"type":"response.created","response":{"id":"resp_1","model":"gpt-5"}}),
+        )
+    }
+
+    fn text_delta(text: &str) -> String {
+        sse(
+            "response.output_text.delta",
+            json!({"type":"response.output_text.delta","delta": text}),
+        )
+    }
+
+    fn completed() -> String {
+        sse(
+            "response.completed",
+            json!({"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":3,"output_tokens":2}}}),
+        )
+    }
+
+    fn ok_chunks(parts: &[&str]) -> ByteStream {
+        let items: Vec<Result<Bytes, std::io::Error>> = parts
+            .iter()
+            .map(|part| Ok(Bytes::from(part.to_string())))
+            .collect();
+        Box::pin(stream::iter(items))
+    }
+
+    fn chunks_then_error(parts: &[&str]) -> ByteStream {
+        let mut items: Vec<Result<Bytes, std::io::Error>> = parts
+            .iter()
+            .map(|part| Ok(Bytes::from(part.to_string())))
+            .collect();
+        items.push(Err(std::io::Error::other("error decoding response body")));
+        Box::pin(stream::iter(items))
+    }
+
+    fn streamed_response(parts: &[&str]) -> ProxyResponse {
+        let items: Vec<Result<Bytes, std::io::Error>> = parts
+            .iter()
+            .map(|part| Ok(Bytes::from(part.to_string())))
+            .collect();
+        ProxyResponse::streamed(
+            http::StatusCode::OK,
+            http::HeaderMap::new(),
+            stream::iter(items),
+        )
+    }
+
+    /// 每次 connect 弹出脚本队列里的下一个结果。
+    fn scripted_reconnector(
+        script: Vec<Result<ProxyResponse, ProxyError>>,
+    ) -> (StreamReconnector, Arc<AtomicU32>) {
+        scripted_reconnector_with_timeout(script, Duration::ZERO)
+    }
+
+    fn scripted_reconnector_with_timeout(
+        script: Vec<Result<ProxyResponse, ProxyError>>,
+        first_byte_timeout: Duration,
+    ) -> (StreamReconnector, Arc<AtomicU32>) {
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_clone = calls.clone();
+        let script = Arc::new(Mutex::new(script));
+        let reconnector = StreamReconnector::new(
+            Box::new(move || {
+                calls_clone.fetch_add(1, Ordering::SeqCst);
+                let next = script
+                    .lock()
+                    .unwrap()
+                    .pop()
+                    .unwrap_or_else(|| Err(ProxyError::ForwardFailed("script empty".into())));
+                Box::pin(async move { next })
+            }),
+            first_byte_timeout,
+        );
+        (reconnector, calls)
+    }
+
+    async fn collect(stream: impl Stream<Item = Result<Bytes, std::io::Error>>) -> String {
+        futures::pin_mut!(stream);
+        let mut out = String::new();
+        while let Some(item) = stream.next().await {
+            out.push_str(&String::from_utf8_lossy(&item.unwrap()));
+        }
+        out
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transport_drop_before_content_retries_transparently() {
+        let retry_body = [created(), text_delta("hello"), completed()].concat();
+        let (reconnector, calls) =
+            scripted_reconnector(vec![Ok(streamed_response(&[retry_body.as_str()]))]);
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(out.matches("event: message_start").count(), 1);
+        assert!(out.contains("hello"));
+        assert!(out.contains("event: message_stop"));
+        assert!(!out.contains("event: error"), "unexpected error in: {out}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn premature_eof_without_terminal_event_retries() {
+        let retry_body = [created(), text_delta("ok"), completed()].concat();
+        let (reconnector, calls) =
+            scripted_reconnector(vec![Ok(streamed_response(&[retry_body.as_str()]))]);
+        // 干净 EOF：无传输错误，也没有任何终止事件（Codex CLI 同样视为可重试）。
+        let first = ok_chunks(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(out.contains("event: message_stop"));
+        assert!(!out.contains("event: error"), "unexpected error in: {out}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn no_retry_after_content_reached_client() {
+        let (reconnector, calls) = scripted_reconnector(vec![]);
+        let first = chunks_then_error(&[[created(), text_delta("partial")].concat().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "must not reconnect");
+        assert!(out.contains("partial"));
+        assert!(out.contains("\"type\":\"stream_error\""));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn upstream_semantic_failure_is_not_retried() {
+        let (reconnector, calls) = scripted_reconnector(vec![]);
+        let failed = sse(
+            "response.failed",
+            json!({"type":"response.failed","response":{"status":"failed","error":{"type":"server_error","message":"backend exploded"}}}),
+        );
+        let first = ok_chunks(&[[created(), failed].concat().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "must not reconnect");
+        assert!(out.contains("backend exploded"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn spoofed_stream_error_type_from_upstream_is_not_retried() {
+        let (reconnector, calls) = scripted_reconnector(vec![]);
+        // 上游语义性 error 事件的 error.type 逐字透传；恰好叫 "stream_error"
+        // 也不能触发重试——只有转换器附加了 marker 注释行的中断才可重试。
+        let spoofed = sse(
+            "error",
+            json!({"type":"error","error":{"type":"stream_error","message":"upstream says no"}}),
+        );
+        let first = ok_chunks(&[[created(), spoofed].concat().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "must not reconnect");
+        assert!(out.contains("upstream says no"), "got: {out}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn exhausts_bounded_retries_then_surfaces_error() {
+        // 每次重连都成功建立、随即掐断：耗尽全部 5 次后必须把错误交给客户端。
+        let script: Vec<Result<ProxyResponse, ProxyError>> = (0..5)
+            .map(|_| {
+                Ok(ProxyResponse::streamed(
+                    http::StatusCode::OK,
+                    http::HeaderMap::new(),
+                    stream::iter(vec![
+                        Ok(Bytes::from(created())),
+                        Err(std::io::Error::other("connection reset")),
+                    ]),
+                ))
+            })
+            .collect();
+        let (reconnector, calls) = scripted_reconnector(script);
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 5);
+        assert!(out.contains("after 5 reconnect attempt(s)"), "got: {out}");
+        assert_eq!(out.matches("event: message_start").count(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_failure_counts_as_attempt() {
+        let retry_body = [created(), text_delta("ok"), completed()].concat();
+        // 脚本按 pop() 逆序消费：两次失败后第三次成功。
+        let (reconnector, calls) = scripted_reconnector(vec![
+            Ok(streamed_response(&[retry_body.as_str()])),
+            Err(ProxyError::ForwardFailed("connect refused".into())),
+            Err(ProxyError::ForwardFailed("connect refused".into())),
+        ]);
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert!(out.contains("event: message_stop"));
+        assert!(!out.contains("event: error"), "unexpected error in: {out}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn non_success_reconnect_status_counts_as_attempt() {
+        let retry_body = [created(), text_delta("ok"), completed()].concat();
+        let (reconnector, calls) = scripted_reconnector(vec![
+            Ok(streamed_response(&[retry_body.as_str()])),
+            Ok(ProxyResponse::buffered(
+                http::StatusCode::BAD_GATEWAY,
+                http::HeaderMap::new(),
+                Bytes::new(),
+            )),
+        ]);
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(out.contains("event: message_stop"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn keepalive_ping_emitted_during_retry_when_message_start_sent() {
+        let retry_body = [created(), text_delta("ok"), completed()].concat();
+        let (reconnector, _calls) =
+            scripted_reconnector(vec![Ok(streamed_response(&[retry_body.as_str()]))]);
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert!(
+            out.contains("event: ping"),
+            "expected keepalive ping: {out}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn keepalive_pings_flow_during_slow_reconnect() {
+        // connect 挂 25 秒才成功：期间必须周期性发 ping，否则下游 passthrough
+        // 的 120s 空闲超时会在真实场景中掐掉这次合法的重试。
+        let retry_body = [created(), text_delta("ok"), completed()].concat();
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_clone = calls.clone();
+        let body = Arc::new(Mutex::new(Some(retry_body)));
+        let reconnector = StreamReconnector::new(
+            Box::new(move || {
+                calls_clone.fetch_add(1, Ordering::SeqCst);
+                let body = body.lock().unwrap().take().expect("single reconnect");
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_secs(25)).await;
+                    Ok(streamed_response(&[body.as_str()]))
+                })
+            }),
+            Duration::ZERO,
+        );
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(out.contains("event: message_stop"));
+        // 重连前 1 次 + 25 秒连接期间（10s/20s 处）至少 2 次。
+        assert!(
+            out.matches("event: ping").count() >= 3,
+            "expected keepalive pings during slow reconnect: {out}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn keepalive_pings_flow_while_awaiting_first_reconnected_event() {
+        // 重连秒回，但新流 30 秒后才产出首个事件；等待期间同样要发 ping。
+        let retry_body = [created(), text_delta("ok"), completed()].concat();
+        let delayed = ProxyResponse::streamed(
+            http::StatusCode::OK,
+            http::HeaderMap::new(),
+            stream::once(async move {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok(Bytes::from(retry_body))
+            }),
+        );
+        let (reconnector, calls) =
+            scripted_reconnector_with_timeout(vec![Ok(delayed)], Duration::from_secs(60));
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(out.contains("event: message_stop"));
+        assert!(
+            out.matches("event: ping").count() >= 3,
+            "expected keepalive pings while awaiting first event: {out}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn silent_reconnected_stream_times_out_and_retries_again() {
+        // 重连成功但新流静默挂起：首包超时后计入尝试次数并再次重连。
+        let retry_body = [created(), text_delta("ok"), completed()].concat();
+        let hanging = ProxyResponse::streamed(
+            http::StatusCode::OK,
+            http::HeaderMap::new(),
+            stream::pending::<Result<Bytes, std::io::Error>>(),
+        );
+        // pop() 逆序消费：先挂起流，再成功流。
+        let (reconnector, calls) = scripted_reconnector_with_timeout(
+            vec![Ok(streamed_response(&[retry_body.as_str()])), Ok(hanging)],
+            Duration::from_secs(5),
+        );
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first,
+            Some(reconnector),
+        ))
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(out.contains("event: message_stop"));
+        assert!(!out.contains("event: error"), "unexpected error in: {out}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn passthrough_without_reconnector_preserves_current_behavior() {
+        let first = chunks_then_error(&[created().as_str()]);
+        let out = collect(create_resilient_anthropic_sse_stream_from_responses(
+            first, None,
+        ))
+        .await;
+
+        assert!(out.contains("\"type\":\"stream_error\""));
+    }
+}

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -396,6 +396,9 @@ pub fn anthropic_to_responses(
     // - store: 必须显式为 false（ChatGPT 消费级后端不允许服务端持久化）
     // - include: 必须包含 "reasoning.encrypted_content"，
     //   否则多轮 reasoning 中间态会丢失（无服务端状态 + 无加密回传 = 上下文断链）
+    // - reasoning.summary: 已有 reasoning 对象（客户端开启 thinking）时兜底为
+    //   "auto"。不请求摘要时推理模型隐藏思考全程零 SSE 事件，长思考会被下游
+    //   空闲计时器误判为断流；摘要增量同时让客户端实时看到思考状态
     // - max_output_tokens / temperature / top_p: 必须删除
     //   （codex-rs 结构体根本没有这三个字段，OpenAI 自己的客户端不发它们）
     // - instructions / tools / parallel_tool_calls: 必填字段，缺则兜底默认值
@@ -423,6 +426,21 @@ pub fn anthropic_to_responses(
             includes.push(json!(REASONING_MARKER));
         }
         result["include"] = json!(includes);
+
+        // —— reasoning.summary: 请求推理摘要，让隐藏思考期间有事件可转发 ——
+        // 不请求 summary 时，推理模型思考期间 Responses SSE 没有任何应用事件，
+        // 一次困难问题的思考可静默数分钟；下游各级空闲计时器（本代理
+        // `create_logged_passthrough_stream` 的 120s 超时、Claude Code 的字节级
+        // stream watchdog）会把这种静默误判为断流并掐断请求。请求 "auto" 后
+        // 摘要增量由转换器映射为 thinking_delta，既保持字节流动又让客户端
+        // 实时显示思考状态。该字段在 codex-rs `Reasoning { effort, summary }`
+        // 协议契约内，ChatGPT 后端对 GPT-5 系推理模型均接受
+        // （官方模型目录 `supports_reasoning_summary_parameter` 默认为 true）。
+        if let Some(reasoning) = result.get_mut("reasoning").and_then(Value::as_object_mut) {
+            reasoning
+                .entry("summary".to_string())
+                .or_insert(json!("auto"));
+        }
 
         if let Some(obj) = result.as_object_mut() {
             // —— 删除 ChatGPT 反代不接受的字段 ——
@@ -2002,6 +2020,54 @@ mod tests {
 
         // include 必须包含 reasoning.encrypted_content（无服务端状态下保持多轮 reasoning）
         assert_eq!(result["include"], json!(["reasoning.encrypted_content"]));
+    }
+
+    #[test]
+    fn test_codex_oauth_requests_reasoning_summary() {
+        // 思考开启时必须请求 reasoning.summary："auto" 让隐藏思考期间有摘要
+        // 增量流下来，否则上游整段静默，下游空闲计时器会把长思考误判为断流。
+        let input = json!({
+            "model": "gpt-5.6",
+            "max_tokens": 1024,
+            "thinking": {"type": "adaptive"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, true, false).unwrap();
+
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+        assert_eq!(result["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn test_codex_oauth_thinking_disabled_omits_reasoning_entirely() {
+        // thinking 未开启 → 不注入 reasoning 对象，自然也没有 summary。
+        let input = json!({
+            "model": "gpt-5.6",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, true, false).unwrap();
+
+        assert!(result.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn test_non_codex_omits_reasoning_summary() {
+        // 回归护栏：通用 Responses 供应商不注入 summary——部分后端（或未通过
+        // 组织验证的 OpenAI 账号）会拒绝该参数，维持今日行为。
+        let input = json!({
+            "model": "gpt-5.6",
+            "max_tokens": 1024,
+            "thinking": {"type": "adaptive"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+        assert!(result["reasoning"].get("summary").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

codex_oauth（Responses API）上游会偶发在响应已提交、正文尚未走完时掐断 SSE 连接（本机 ~0.17% 的请求，详见 #5877），目前整轮请求直接以 `API Error: Stream error: error decoding response body` 失败。官方 Codex CLI 用 `stream_max_retries`（默认 5 次）整请求重发吸收同类中断；本 PR 把同样的语义移植到代理侧。

**补充定位（2026-07-29，commit 08ff77cb）：同一个"模型静默思考"窗口还有第二种失败模式，连上游中断都不需要。** cc-switch 从不向上游请求 `reasoning.summary`，推理模型隐藏思考期间 Responses SSE 零应用事件——GPT-5.6 系困难问题可静默数分钟；本代理的 120s passthrough 空闲超时会先掐断，即便调大，Claude Code 的字节级 stream watchdog（v2.1.157 实测 180s，见 anthropics/claude-code#66095；当前版本默认 5 分钟）也会中止整轮请求。本 PR 一并处理这两种失败。

**核心设计：只在还能安全重试时重试。** 代理与 CLI 的关键差异是 CLI 可以丢弃已渲染的部分输出重画 UI，代理无法撤回已发给客户端的字节。因此重连仅在下游至多收到过协议脚手架（`message_start` / `ping`）时进行——这恰好覆盖最常见的中断窗口：语义预热（#5546）在 reasoning `output_item.added` 后提交，随后模型长时间静默思考，空闲切断发生时下游只收到过 `message_start`。

具体行为：

- 新增 `streaming_retry.rs`：包装现有 Responses→Anthropic 转换器，对可重试中断做有界自动重连（上限 **5** 次，退避 200/400/800/1600/3200ms，与 Codex CLI 对齐）；重连用全新转换器实例重发同一上游请求，抑制重复的 `message_start`，对客户端完全透明。
- 可重试 = 传输层错误（`stream_error`）与无终止事件的过早 EOF（`stream_truncated`），由转换器附加的 SSE 注释行标记（`RETRYABLE_STREAM_MARKER`）识别——不信任 `error.type` 字符串，上游语义性失败的 type 逐字透传自上游可控字段，恰好叫 `stream_error` 也不会被误吸收。SSE 注释行按规范被客户端解析器忽略。
- 上游语义性失败（`response.failed` / `error` 事件）不重试；一旦实质内容已转发，行为与现状一致（错误透传）。
- 重连等待期间周期性向下游发 `ping` 喂空闲计时器：退避 + 重连 + 等待首包三段串联最长可超过 passthrough 的 120s 空闲超时，每段内部都合规也可能被外层掐掉（Anthropic 协议允许任意时刻出现 `ping`）。
- 重连后的尝试对首个转换事件套用首包超时，防止上游连上后静默挂起吃掉重试窗口。
- **codex_oauth 请求在 thinking 开启时兜底 `reasoning.summary: "auto"`**（08ff77cb）：该字段在 codex-rs `Reasoning { effort, summary }` 协议契约内，ChatGPT 后端对 GPT-5 系推理模型均接受（官方模型目录 `supports_reasoning_summary_parameter` 默认 true）。摘要增量由既有转换逻辑映射为 `thinking_delta`——Claude Code 从"静默卡死"变成实时显示思考状态，字节流动同时喂活各级空闲计时器。通用（非 codex）Responses 供应商不注入：部分后端 / 未通过组织验证的 OpenAI 账号会拒绝该参数，维持现状；thinking 未开启时也不注入（不强加客户端未选择的思考块）。
- **正常流转期间的思考期心跳**（08ff77cb）：`message_start` 之后上游每静默 10s，包装器向下游发一次 `ping`（ping 不计入"实质内容"，重试资格不受影响），覆盖通用 Responses 供应商与摘要增量滞后的间隙。连续静默超过 5 分钟后停发，把死流的裁决权交还给操作者配置的空闲超时——不会无限保活一条真正断掉的连接。
- 顺带修复可诊断性问题：`hyper_client.rs` 此前用 `std::io::Error::other(e.to_string())` 压平错误链，日志永远只有 `error decoding response body`；现在保留 source 链并新增 `error_chain_message()`，日志能看到真实传输层原因。

范围控制：重连器仅在 `claude_api_format == "openai_responses"` 的流式请求上构造，其余路径（openai_chat、gemini、透传等）零行为变化；`reasoning.summary` 注入仅限 codex_oauth；心跳仅存在于 Responses 转换包装器内部。

与已有工作的关系：#5545/#5546 的语义预热只保护提交前的失败，#5389/#5390、#3488、#5056 是请求级重试；本 PR 覆盖的是提交之后、内容到达下游之前这个此前无人处理的窗口，以及提交之后合法思考静默被误杀的问题。

**测试**：`streaming_retry.rs` 内置 17 个单测（`tokio::time` 虚拟时钟，0 真实等待）：透明重连、干净 EOF 重试、已转发内容后不重试、语义失败不重试、**伪造 `error.type == "stream_error"` 的语义错误不重试**、5 次上限耗尽后向客户端报错、连接失败/非 2xx 计入尝试次数、慢重连与等待首包期间的 keepalive ping、静默挂起流超时后再重试、无重连器时行为不变，以及新增 4 个思考期心跳测试（静默 60s 期间周期性 ping 且不触发重连、心跳在 5 分钟上限处停发、`message_start` 之前不发 ping、无重连器路径同样保活）。`transform_responses.rs` 新增 3 个单测（codex_oauth 注入 summary、thinking 未开启不注入、非 codex 不注入）。本机全量验证：`cargo fmt --check` / `clippy`（0 新告警）/ `cargo test --lib`（2258 passed，仅既有的 5 个与本 PR 无关的环境性失败：`model_pricing` 时间戳竞态 ×4、端口占用 ×1）、`pnpm typecheck` / `format:check` / `test:unit` 均符合基线。

---

**English summary:** The codex_oauth (Responses API) upstream occasionally severs committed SSE streams mid-body (~0.17% of requests, see #5877), currently failing the whole request. This PR ports the official Codex CLI's `stream_max_retries=5` semantics to the proxy side, with one crucial constraint: the proxy cannot un-send bytes, so reconnects happen only while the downstream client has received nothing beyond protocol scaffolding (`message_start`/`ping`) — which is exactly the common failure window (commit happens on a reasoning `output_item.added`, then the model thinks silently until an idle cut). Retryable interruptions (transport errors, premature EOF without a terminal event) are identified by a spec-ignored SSE comment marker attached by our own translator — never by the upstream-controlled `error.type` string, so upstream semantic failures are never absorbed. Keepalive pings during reconnect waits prevent the outer 120s idle timeout from killing a legal retry. Also preserves transport error source chains in logs (previously flattened to just "error decoding response body").

**Follow-up in the same PR (commit 08ff77cb):** the silent-thinking window kills requests even *without* an upstream cut — cc-switch never requested `reasoning.summary`, so GPT-5.x hidden thinking produces zero SSE events for minutes, and every downstream idle timer (the proxy's own 120s passthrough timeout; Claude Code's byte-level stream watchdog — 180s observed on v2.1.157 per anthropics/claude-code#66095, 5-minute default currently) misreads legal thinking as a dead stream. Fix: codex_oauth requests now default `reasoning.summary: "auto"` when thinking is enabled (summary deltas already translate to Anthropic `thinking_delta`, so Claude Code displays live thinking instead of stalling), and the retry wrapper emits a keepalive ping after every 10s of upstream silence post-`message_start`, capped at 5 consecutive minutes so a genuinely dead upstream still yields to the operator-configured idle timeout. Scoped strictly to streaming `openai_responses` requests; 17 unit tests on tokio's paused clock plus 3 transform tests.

> Per CONTRIBUTING's AI-assisted contribution policy: this fix was diagnosed and implemented with AI (Claude Fable 5). 已在本机跑通上述全部检查。

## Related Issue / 关联 Issue

Fixes #5877

## Screenshots / 截图

N/A（无 UI 变化 / no UI changes）

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 上游掐断 SSE → 整轮请求报 `Stream error: error decoding response body` | 下游未收到实质内容时自动重连（≤5 次），客户端无感 |
| GPT-5.6 长思考：上游合法静默 >120s → 代理空闲超时掐断，即便调大也会被 Claude Code watchdog 中止；思考过程不可见 | 思考摘要实时映射为 `thinking_delta`（codex_oauth），静默间隙有心跳 `ping`；思考全程可见，不再被误判为断流 |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本变化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
