### PR TITLE
fix(pricing): correct MiniMax M3 rates

### DIFF
--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -2165,7 +2165,7 @@ impl Database {
                 "0.06",
                 "0.375",
             ),
-            ("minimax-m3", "MiniMax M3", "0.60", "2.40", "0.12", "0"),
+            ("minimax-m3", "MiniMax M3", "0.30", "1.20", "0.06", "0"),
             // GLM (智谱)
             ("glm-4.7", "GLM-4.7", "0.6", "2.2", "0.11", "0"),
             ("glm-4.6", "GLM-4.6", "0.6", "2.2", "0.11", "0"),
@@ -2429,6 +2429,19 @@ impl Database {
 
     fn repair_current_model_pricing(conn: &Connection) -> Result<(), AppError> {
         let pricing_fixes = [
+            // 2026-07-29 MiniMax M3 permanent 50% discount for the standard context tier.
+            (
+                "minimax-m3",
+                "MiniMax M3",
+                "0.30",
+                "1.20",
+                "0.06",
+                "0",
+                "0.60",
+                "2.40",
+                "0.12",
+                "0",
+            ),
             // 2026-07-12 GPT-5.6 家族 cache write=1.25× 输入价（OpenAI 5.6 起的新规），
             // 修正早期 seed 的 0 值；只匹配未被用户改过的行
             (

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -892,6 +892,40 @@ fn model_pricing_seed_repairs_known_outdated_builtin_prices() {
 }
 
 #[test]
+fn minimax_m3_pricing_repairs_old_but_preserves_custom_prices() {
+    const OLD: &str = "UPDATE model_pricing SET input_cost_per_million = '0.60', output_cost_per_million = '2.40', cache_read_cost_per_million = '0.12' WHERE model_id = 'minimax-m3'";
+    const CUSTOM: &str = "UPDATE model_pricing SET input_cost_per_million = '9', output_cost_per_million = '2.40', cache_read_cost_per_million = '0.12' WHERE model_id = 'minimax-m3'";
+
+    fn price(conn: &Connection) -> String {
+        conn.query_row(
+            "SELECT input_cost_per_million || '/' || output_cost_per_million || '/' ||
+                    cache_read_cost_per_million || '/' || cache_creation_cost_per_million
+             FROM model_pricing WHERE model_id = 'minimax-m3'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query MiniMax M3 price")
+    }
+
+    let db = Database::memory().expect("create memory db");
+    {
+        let conn = db.conn.lock().expect("lock conn");
+        assert_eq!(price(&conn), "0.30/1.20/0.06/0");
+        conn.execute(OLD, []).expect("restore old MiniMax M3 price");
+    }
+    db.ensure_model_pricing_seeded().expect("repair old price");
+    {
+        let conn = db.conn.lock().expect("lock conn");
+        assert_eq!(price(&conn), "0.30/1.20/0.06/0");
+        conn.execute(CUSTOM, []).expect("set custom price");
+    }
+    db.ensure_model_pricing_seeded()
+        .expect("preserve custom price");
+    let conn = db.conn.lock().expect("lock conn");
+    assert_eq!(price(&conn), "9/2.40/0.12/0");
+}
+
+#[test]
 fn ensure_incremental_auto_vacuum_rebuilds_existing_file_db() {
     let temp = NamedTempFile::new().expect("create temp db file");
     let path = temp.path().to_path_buf();


### PR DESCRIPTION
## Summary / 概述

Use MiniMax M3's permanent discounted standard-tier rates for new databases, and repair existing rows only when all pricing fields still match the old built-in values. User-customized pricing remains untouched.

## Related Issue / 关联 Issue

Fixes #5841

## Screenshots / 截图

N/A — backend-only pricing data change.

## Testing / 测试

- `cargo test minimax_m3_pricing_repairs_old_but_preserves_custom_prices --lib` — passed
- `cargo test database::tests::model_pricing --lib` — passed
- `cargo clippy --lib` — passed
- `rustfmt --check --edition 2021 src/database/schema.rs src/database/tests.rs` — passed

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查 — N/A, no TypeScript changes
- [ ] `pnpm format:check` passes / 通过代码格式检查 — N/A, no frontend changes
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — N/A, no user-facing text changed