### PR TITLE
fix(claude): expose Opus 5 in takeover mode

### DIFF
--- a/src-tauri/src/proxy/thinking_optimizer.rs
+++ b/src-tauri/src/proxy/thinking_optimizer.rs
@@ -80,6 +80,7 @@ pub(crate) fn uses_adaptive_thinking(model: &str) -> bool {
         "mythos-5",
         "mythos-preview",
         "sonnet-5",
+        "opus-5",
         "opus-4-8",
         "opus-4-7",
         "opus-4-6",
@@ -172,6 +173,7 @@ mod tests {
             "claude-sonnet-5",
             "anthropic/claude-fable-5",
             "claude-mythos-5",
+            "claude-opus-5",
             "claude-opus-4.8",
         ] {
             assert!(uses_adaptive_thinking(model), "model={model}");

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -43,7 +43,7 @@ const CLAUDE_MODEL_OVERRIDE_ENV_KEYS: [&str; 12] = [
 
 const CLAUDE_TAKEOVER_HAIKU_MODEL: &str = "claude-haiku-4-5";
 const CLAUDE_TAKEOVER_SONNET_MODEL: &str = "claude-sonnet-4-6";
-const CLAUDE_TAKEOVER_OPUS_MODEL: &str = "claude-opus-4-8";
+const CLAUDE_TAKEOVER_OPUS_MODEL: &str = "claude-opus-5";
 const CLAUDE_TAKEOVER_FABLE_MODEL: &str = "claude-fable-5";
 // 写给 Claude Code 时沿用文档示例的大写形式；解析侧大小写不敏感。
 const CLAUDE_ONE_M_MARKER_FOR_CLIENT: &str = "[1M]";
@@ -3410,7 +3410,7 @@ mod tests {
             "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
             Some("claude-sonnet-4.6"),
         );
-        assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-4-8"));
+        assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-5"));
         assert_env_str(
             env,
             "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
@@ -3524,7 +3524,7 @@ mod tests {
             Some("claude-sonnet-4-6"),
         );
         assert_env_str(env, "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME", Some("gpt-5.4"));
-        assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-4-8"));
+        assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-5"));
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME", Some("gpt-5.4"));
         // Codex 系只保留 AUTH_TOKEN；双键会触发 Claude Code 告警（#4919）
         assert_env_str(env, "ANTHROPIC_API_KEY", None);
@@ -5551,7 +5551,7 @@ model = "gpt-5.1-codex"
             live_env
                 .get("ANTHROPIC_DEFAULT_OPUS_MODEL")
                 .and_then(|v| v.as_str()),
-            Some("claude-opus-4-8[1M]"),
+            Some("claude-opus-5[1M]"),
             "Opus role should preserve the current provider 1M capability marker"
         );
         assert_eq!(

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -42,7 +42,7 @@ const CLAUDE_MODEL_OVERRIDE_ENV_KEYS: [&str; 12] = [
 ];
 
 const CLAUDE_TAKEOVER_HAIKU_MODEL: &str = "claude-haiku-4-5";
-const CLAUDE_TAKEOVER_SONNET_MODEL: &str = "claude-sonnet-4-6";
+const CLAUDE_TAKEOVER_SONNET_MODEL: &str = "claude-sonnet-5";
 const CLAUDE_TAKEOVER_OPUS_MODEL: &str = "claude-opus-5";
 const CLAUDE_TAKEOVER_FABLE_MODEL: &str = "claude-fable-5";
 // 写给 Claude Code 时沿用文档示例的大写形式；解析侧大小写不敏感。
@@ -3403,7 +3403,7 @@ mod tests {
         assert_env_str(
             env,
             "ANTHROPIC_DEFAULT_SONNET_MODEL",
-            Some("claude-sonnet-4-6"),
+            Some("claude-sonnet-5"),
         );
         assert_env_str(
             env,
@@ -3521,7 +3521,7 @@ mod tests {
         assert_env_str(
             env,
             "ANTHROPIC_DEFAULT_SONNET_MODEL",
-            Some("claude-sonnet-4-6"),
+            Some("claude-sonnet-5"),
         );
         assert_env_str(env, "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME", Some("gpt-5.4"));
         assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-5"));
@@ -5537,7 +5537,7 @@ model = "gpt-5.1-codex"
             live_env
                 .get("ANTHROPIC_DEFAULT_SONNET_MODEL")
                 .and_then(|v| v.as_str()),
-            Some("claude-sonnet-4-6[1M]"),
+            Some("claude-sonnet-5[1M]"),
             "Sonnet role should carry the local 1M declaration for Claude Code"
         );
         assert_eq!(


### PR DESCRIPTION
## Summary / 概述

Update Claude takeover mode to expose the current `claude-opus-5` role alias instead of the retired `claude-opus-4-8` alias.

This lets Claude Code select Opus 5 while CC Switch continues routing the stable client role to the provider's configured upstream model. Existing takeover and hot-switch assertions now cover both the normal and `[1M]` paths.

## Related Issue / 关联 Issue

Fixes #5876

## Screenshots / 截图

N/A — backend configuration output only.

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查 — N/A, no TypeScript changed
- [ ] `pnpm format:check` passes / 通过代码格式检查 — N/A, no frontend files changed
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — N/A, no user-facing text changed

Additional verification:

- `cargo fmt --check`
- `cargo test claude_takeover --lib` (10 passed)
- `cargo test hot_switch_provider_updates_claude_live_while_preserving_takeover_fields --lib` (1 passed)
- `git diff --check`
