### PR TITLE
feat: Claude 订阅透传——未填模型 ID 的角色直接使用订阅额度

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -87,6 +87,15 @@ impl Provider {
             || self.claude_base_url_contains("chatgpt.com/backend-api/codex")
     }
 
+    /// Claude 订阅透传：开启后，未填模型 ID 的模型角色（模型映射解析不到的请求）
+    /// 由本地代理透传到官方上游，使用客户端自带的订阅登录凭据。
+    pub fn claude_subscription_passthrough_enabled(&self) -> bool {
+        self.meta
+            .as_ref()
+            .and_then(|m| m.claude_subscription_passthrough)
+            .unwrap_or(false)
+    }
+
     fn provider_type(&self) -> Option<&str> {
         self.meta.as_ref().and_then(|m| m.provider_type.as_deref())
     }
@@ -526,6 +535,13 @@ pub struct ProviderMeta {
     /// - "github_copilot": GitHub Copilot 供应商
     #[serde(rename = "providerType", skip_serializing_if = "Option::is_none")]
     pub provider_type: Option<String>,
+    /// Claude 订阅透传开关：未填模型 ID 的模型角色直接使用 Claude 订阅额度
+    /// （仅 Claude 应用、代理接管下生效）
+    #[serde(
+        rename = "claudeSubscriptionPassthrough",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub claude_subscription_passthrough: Option<bool>,
     /// GitHub Copilot 关联账号 ID（仅 github_copilot 供应商使用）
     /// 用于多账号支持，关联到特定的 GitHub 账号
     #[serde(rename = "githubAccountId", skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -56,6 +56,26 @@ fn validate_codex_official_authorization(headers: &http::HeaderMap) -> Result<()
     }
 }
 
+/// Claude 订阅透传要求客户端自带订阅登录凭据（CC Switch 不注入任何凭据）。
+/// 与 [`validate_codex_official_authorization`] 同一模式。
+fn validate_subscription_passthrough_authorization(
+    headers: &http::HeaderMap,
+) -> Result<(), ProxyError> {
+    let authorization = headers
+        .get(http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim);
+    match authorization {
+        None | Some("") => Err(ProxyError::AuthError(
+            "Claude 订阅透传需要客户端自带登录凭据，请先在 Claude Code 中完成订阅登录".to_string(),
+        )),
+        Some(value) if value.contains(PROXY_AUTH_PLACEHOLDER) => Err(ProxyError::AuthError(
+            "检测到代理占位符凭据，请重启 Claude Code 或新建会话以加载订阅登录".to_string(),
+        )),
+        Some(_) => Ok(()),
+    }
+}
+
 pub struct ForwardResult {
     pub response: ProxyResponse,
     pub provider: Provider,
@@ -414,6 +434,29 @@ impl RequestForwarder {
 
         // 依次尝试每个供应商
         for provider in providers.iter() {
+            // Claude 订阅透传：开关开启的供应商，未填模型 ID 的档位请求解析成
+            // 「Claude 订阅直连」合成供应商，转发到官方上游并保留客户端自带凭据。
+            // 解析放在熔断器 allow 之前，让熔断/健康记账落在合成 id 上——订阅额度
+            // 耗尽不应拉闸用户选中的真实供应商；「当前供应商」的身份展示与切换
+            // 判定仍以用户选中的供应商为准（identity_provider）。
+            let resolved_passthrough: Option<Provider> = if matches!(app_type, AppType::Claude) {
+                let request_model = body.get("model").and_then(Value::as_str);
+                let resolved =
+                    super::passthrough::resolve_subscription_passthrough(provider, request_model);
+                if resolved.is_some() {
+                    log::info!(
+                        "[{app_type_str}] [SubscriptionPassthrough] {} 未配置该档位模型，透传官方订阅 (model={})",
+                        provider.name,
+                        request_model.unwrap_or("-")
+                    );
+                }
+                resolved
+            } else {
+                None
+            };
+            let identity_provider: &Provider = provider;
+            let provider: &Provider = resolved_passthrough.as_ref().unwrap_or(provider);
+
             // 整流器重试标记：每个 provider 独立持有，避免标记跨 provider 短路故障转移
             // —— 首家 provider 整流后被 5xx/timeout 击落时，下家仍能用整流后的请求体走整流流程
             let mut rectifier_retried = false;
@@ -469,11 +512,12 @@ impl RequestForwarder {
             //
             // total_requests / last_request_at / active_connections 已由
             // forward_with_retry wrapper 在客户端请求维度统一处理，这里只刷
-            // 新「正在尝试哪个 provider」的展示字段。
+            // 新「正在尝试哪个 provider」的展示字段。展示身份用 identity_provider：
+            // 订阅透传解析出的合成供应商不应替代用户选中的供应商出现在 UI 上。
             {
                 let mut status = self.status.write().await;
-                status.current_provider = Some(provider.name.clone());
-                status.current_provider_id = Some(provider.id.clone());
+                status.current_provider = Some(identity_provider.name.clone());
+                status.current_provider_id = Some(identity_provider.id.clone());
             }
 
             // 转发请求（每个 Provider 只尝试一次，重试由客户端控制）
@@ -496,12 +540,13 @@ impl RequestForwarder {
                     self.record_success_result(&provider.id, app_type_str, used_half_open_permit)
                         .await;
 
-                    // 更新当前应用类型使用的 provider
+                    // 更新当前应用类型使用的 provider（身份 = 用户选中的供应商，
+                    // 订阅透传解析出的合成供应商不改变这里）
                     {
                         let mut current_providers = self.current_providers.write().await;
                         current_providers.insert(
                             app_type_str.to_string(),
-                            (provider.id.clone(), provider.name.clone()),
+                            (identity_provider.id.clone(), identity_provider.name.clone()),
                         );
                     }
 
@@ -510,16 +555,18 @@ impl RequestForwarder {
                         let mut status = self.status.write().await;
                         status.success_requests += 1;
                         status.last_error = None;
-                        let should_switch =
-                            self.current_provider_id_at_start.as_str() != provider.id.as_str();
+                        // 「切换当前供应商」按 identity 判断：透传解析出的合成供应商
+                        // 承接了请求不算切换，否则一次透传就会把用户选中的供应商改掉。
+                        let should_switch = self.current_provider_id_at_start.as_str()
+                            != identity_provider.id.as_str();
                         if should_switch {
                             status.failover_count += 1;
 
                             // 异步触发供应商切换，更新 UI/托盘，并把“当前供应商”同步为实际使用的 provider
                             let fm = self.failover_manager.clone();
                             let ah = self.app_handle.clone();
-                            let pid = provider.id.clone();
-                            let pname = provider.name.clone();
+                            let pid = identity_provider.id.clone();
+                            let pname = identity_provider.name.clone();
                             let at = app_type_str.to_string();
 
                             tokio::spawn(async move {
@@ -605,7 +652,10 @@ impl RequestForwarder {
                                             self.current_providers.write().await;
                                         current_providers.insert(
                                             app_type_str.to_string(),
-                                            (provider.id.clone(), provider.name.clone()),
+                                            (
+                                                identity_provider.id.clone(),
+                                                identity_provider.name.clone(),
+                                            ),
                                         );
                                     }
 
@@ -615,13 +665,13 @@ impl RequestForwarder {
                                         status.last_error = None;
                                         let should_switch =
                                             self.current_provider_id_at_start.as_str()
-                                                != provider.id.as_str();
+                                                != identity_provider.id.as_str();
                                         if should_switch {
                                             status.failover_count += 1;
                                             let fm = self.failover_manager.clone();
                                             let ah = self.app_handle.clone();
-                                            let pid = provider.id.clone();
-                                            let pname = provider.name.clone();
+                                            let pid = identity_provider.id.clone();
+                                            let pname = identity_provider.name.clone();
                                             let at = app_type_str.to_string();
 
                                             tokio::spawn(async move {
@@ -750,7 +800,10 @@ impl RequestForwarder {
                                                 self.current_providers.write().await;
                                             current_providers.insert(
                                                 app_type_str.to_string(),
-                                                (provider.id.clone(), provider.name.clone()),
+                                                (
+                                                    identity_provider.id.clone(),
+                                                    identity_provider.name.clone(),
+                                                ),
                                             );
                                         }
 
@@ -761,15 +814,15 @@ impl RequestForwarder {
                                             status.last_error = None;
                                             let should_switch =
                                                 self.current_provider_id_at_start.as_str()
-                                                    != provider.id.as_str();
+                                                    != identity_provider.id.as_str();
                                             if should_switch {
                                                 status.failover_count += 1;
 
                                                 // 异步触发供应商切换，更新 UI/托盘
                                                 let fm = self.failover_manager.clone();
                                                 let ah = self.app_handle.clone();
-                                                let pid = provider.id.clone();
-                                                let pname = provider.name.clone();
+                                                let pid = identity_provider.id.clone();
+                                                let pname = identity_provider.name.clone();
                                                 let at = app_type_str.to_string();
 
                                                 tokio::spawn(async move {
@@ -915,7 +968,10 @@ impl RequestForwarder {
                                             self.current_providers.write().await;
                                         current_providers.insert(
                                             app_type_str.to_string(),
-                                            (provider.id.clone(), provider.name.clone()),
+                                            (
+                                                identity_provider.id.clone(),
+                                                identity_provider.name.clone(),
+                                            ),
                                         );
                                     }
 
@@ -925,13 +981,13 @@ impl RequestForwarder {
                                         status.last_error = None;
                                         let should_switch =
                                             self.current_provider_id_at_start.as_str()
-                                                != provider.id.as_str();
+                                                != identity_provider.id.as_str();
                                         if should_switch {
                                             status.failover_count += 1;
                                             let fm = self.failover_manager.clone();
                                             let ah = self.app_handle.clone();
-                                            let pid = provider.id.clone();
-                                            let pname = provider.name.clone();
+                                            let pid = identity_provider.id.clone();
+                                            let pname = identity_provider.name.clone();
                                             let at = app_type_str.to_string();
                                             tokio::spawn(async move {
                                                 let _ = fm
@@ -1154,6 +1210,16 @@ impl RequestForwarder {
 
         if codex_official_auth_passthrough {
             validate_codex_official_authorization(headers)?;
+        }
+
+        // Claude 订阅透传：与 Codex 官方透传同一模式 —— 客户端自带的
+        // Authorization 必须原样送达官方上游。仅放行 Authorization；
+        // x-api-key / x-goog-api-key 仍然丢弃。
+        let subscription_auth_passthrough = matches!(app_type, AppType::Claude)
+            && super::passthrough::is_passthrough_provider(provider);
+
+        if subscription_auth_passthrough {
+            validate_subscription_passthrough_authorization(headers)?;
         }
 
         // 应用模型映射（独立于格式转换）
@@ -1965,7 +2031,10 @@ impl RequestForwarder {
                 // Codex send its native ChatGPT authorization, which must reach
                 // the fixed official upstream unchanged. Other credential
                 // headers are still discarded.
-                if codex_official_auth_passthrough && key_str.eq_ignore_ascii_case("authorization")
+                // Claude subscription passthrough follows the same pattern for
+                // the client's own subscription authorization.
+                if (codex_official_auth_passthrough || subscription_auth_passthrough)
+                    && key_str.eq_ignore_ascii_case("authorization")
                 {
                     saw_auth = true;
                     ordered_headers.append(key.clone(), value.clone());

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod json_canonical;
 pub mod log_codes;
 pub mod media_sanitizer;
 pub mod model_mapper;
+pub mod passthrough;
 pub mod provider_router;
 pub mod providers;
 pub mod response_handler;

--- a/src-tauri/src/proxy/model_mapper.rs
+++ b/src-tauri/src/proxy/model_mapper.rs
@@ -69,47 +69,63 @@ impl ModelMapping {
     pub fn map_model(&self, original_model: &str) -> String {
         let model_lower = original_model.to_lowercase();
 
-        // 1. 按模型类型匹配
-        if model_lower.contains("fable") {
-            if let Some(ref m) = self.fable_model {
-                return m.clone();
-            }
-            // 未单独配置 fable 档时归入 opus 档，与 Claude Code 官方
-            // 分类器降级方向一致（fable→opus），避免落到 default 失去层级。
+        // 未单独配置 fable 档时归入 opus 档，与 Claude Code 官方
+        // 分类器降级方向一致（fable→opus），避免落到 default 失去层级。
+        // 注意：订阅透传的档位判定用 `resolve`（不含这条降级）——
+        // 未填 fable 时透传真实订阅档，优于降级到第三方 opus。
+        if model_lower.contains("fable") && self.fable_model.is_none() {
             if let Some(ref m) = self.opus_model {
                 return m.clone();
+            }
+        }
+
+        self.resolve(original_model)
+            .unwrap_or_else(|| original_model.to_string())
+    }
+
+    /// 解析该模型在当前配置下映射到的目标；解析不到返回 `None`。
+    ///
+    /// 「已配置」的口径：档位自身的键、默认兜底模型（对所有请求兜底）、
+    /// 或与 subagent 模型精确匹配（保持原名）。fable→opus 的降级不算在内。
+    pub fn resolve(&self, original_model: &str) -> Option<String> {
+        let model_lower = original_model.to_lowercase();
+
+        // 1. 按模型档位匹配
+        if model_lower.contains("fable") {
+            if let Some(ref m) = self.fable_model {
+                return Some(m.clone());
             }
         }
         if model_lower.contains("haiku") {
             if let Some(ref m) = self.haiku_model {
-                return m.clone();
+                return Some(m.clone());
             }
         }
         if model_lower.contains("opus") {
             if let Some(ref m) = self.opus_model {
-                return m.clone();
+                return Some(m.clone());
             }
         }
         if model_lower.contains("sonnet") {
             if let Some(ref m) = self.sonnet_model {
-                return m.clone();
+                return Some(m.clone());
             }
         }
 
         if let Some(ref m) = self.subagent_model {
             if strip_one_m_suffix_for_upstream(original_model) == strip_one_m_suffix_for_upstream(m)
             {
-                return original_model.to_string();
+                return Some(original_model.to_string());
             }
         }
 
         // 2. 默认模型
         if let Some(ref m) = self.default_model {
-            return m.clone();
+            return Some(m.clone());
         }
 
-        // 3. 无映射，保持原样
-        original_model.to_string()
+        // 3. 无映射
+        None
     }
 }
 
@@ -394,6 +410,64 @@ mod tests {
         let (result, _, mapped) = apply_model_mapping(body, &provider);
         assert_eq!(result["model"], "sonnet-mapped");
         assert_eq!(mapped, Some("sonnet-mapped".to_string()));
+    }
+
+    #[test]
+    fn resolve_returns_none_without_any_mapping() {
+        let provider = create_provider_without_mapping();
+        let mapping = ModelMapping::from_provider(&provider);
+        assert_eq!(mapping.resolve("claude-sonnet-4-6"), None);
+        assert_eq!(mapping.resolve("claude-fable-5[1m]"), None);
+    }
+
+    #[test]
+    fn resolve_none_for_unconfigured_tier_without_default() {
+        let mut provider = create_provider_with_mapping();
+        provider.settings_config = json!({
+            "env": {
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": "haiku-mapped"
+            }
+        });
+        let mapping = ModelMapping::from_provider(&provider);
+        // haiku 档已配置 → 解析成功；sonnet 档未配置且无默认兜底 → 解析不到
+        assert_eq!(
+            mapping.resolve("claude-haiku-4-5"),
+            Some("haiku-mapped".to_string())
+        );
+        assert_eq!(mapping.resolve("claude-sonnet-4-6"), None);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default_model() {
+        let mut provider = create_provider_with_mapping();
+        provider.settings_config = json!({
+            "env": {
+                "ANTHROPIC_MODEL": "default-model"
+            }
+        });
+        let mapping = ModelMapping::from_provider(&provider);
+        assert_eq!(
+            mapping.resolve("claude-sonnet-4-6"),
+            Some("default-model".to_string())
+        );
+        assert_eq!(
+            mapping.resolve("some-unknown-model"),
+            Some("default-model".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_ignores_fable_to_opus_degrade_but_map_model_keeps_it() {
+        let mut provider = create_provider_with_mapping();
+        provider.settings_config = json!({
+            "env": {
+                "ANTHROPIC_DEFAULT_OPUS_MODEL": "opus-mapped"
+            }
+        });
+        let mapping = ModelMapping::from_provider(&provider);
+        // map_model 保持 fable→opus 降级；resolve 视 fable 档为未配置
+        assert_eq!(mapping.map_model("claude-fable-5"), "opus-mapped");
+        assert_eq!(mapping.resolve("claude-fable-5"), None);
     }
 
     #[test]

--- a/src-tauri/src/proxy/passthrough.rs
+++ b/src-tauri/src/proxy/passthrough.rs
@@ -1,0 +1,168 @@
+//! Claude 订阅透传（subscription passthrough）
+//!
+//! 供应商开启该开关后，**未填模型 ID 的模型角色**（即模型映射解析不到的
+//! 带档位请求）不再发给该供应商，而是转发到官方上游，并保留客户端自带的
+//! `Authorization` —— CC Switch 全程不经手、不存储任何 Claude 订阅凭据
+//! （与 Codex 官方供应商放行客户端自带 ChatGPT authorization 的既有做法一致）。
+//!
+//! 判定口径：
+//! - 请求模型带档位关键字（fable / opus / sonnet / haiku）才可能透传；
+//!   自定义模型名（如手动 `/model` 指定的第三方模型）照常发给供应商；
+//! - 档位自身的键或默认兜底模型（`ANTHROPIC_MODEL`）配置了即走供应商；
+//!   fable→opus 的降级**不算已配置**——订阅有真实 fable 档，优于降级。
+
+use crate::provider::Provider;
+use crate::proxy::model_mapper::ModelMapping;
+
+/// 透传解析出的合成供应商 id。
+///
+/// 该 id 不落库，只在单次请求的转发链路内存在；熔断器会按
+/// `"{app_type}:{该 id}"` 为透传通道独立记账——订阅额度耗尽
+/// 不应拉闸用户选中的真实供应商。
+pub const PASSTHROUGH_PROVIDER_ID: &str = "__claude_subscription_passthrough__";
+
+/// 判断是否为订阅透传的合成供应商。
+pub fn is_passthrough_provider(provider: &Provider) -> bool {
+    provider.id == PASSTHROUGH_PROVIDER_ID
+}
+
+/// 构造「Claude 订阅直连」合成供应商：指向官方上游、不含任何凭据。
+///
+/// 仅用于 Claude Code——已实测客户端会把自带的订阅 OAuth token 发给
+/// 自定义 base URL，代理只需原样放行 `Authorization`。
+fn official_subscription_provider() -> Provider {
+    Provider::with_id(
+        PASSTHROUGH_PROVIDER_ID.to_string(),
+        "Claude 订阅直连".to_string(),
+        serde_json::json!({
+            "env": { "ANTHROPIC_BASE_URL": "https://api.anthropic.com" }
+        }),
+        None,
+    )
+}
+
+/// 请求模型是否带 Claude 档位关键字。
+fn has_tier_keyword(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    ["fable", "opus", "sonnet", "haiku"]
+        .iter()
+        .any(|tier| lower.contains(tier))
+}
+
+/// 订阅透传判定 + 合成。
+///
+/// 供应商开启了订阅透传、请求模型带档位关键字、且该模型在供应商的模型
+/// 映射中解析不到（= 对应角色未填模型 ID）时，返回「Claude 订阅直连」
+/// 合成供应商；其余情况返回 `None`，照常走供应商自身。
+///
+/// 没有 `model` 字段的请求无从判定角色，一律照常走供应商。
+pub fn resolve_subscription_passthrough(
+    provider: &Provider,
+    model: Option<&str>,
+) -> Option<Provider> {
+    if !provider.claude_subscription_passthrough_enabled() {
+        return None;
+    }
+    let model = model.map(str::trim).filter(|m| !m.is_empty())?;
+    if !has_tier_keyword(model) {
+        return None;
+    }
+    if ModelMapping::from_provider(provider)
+        .resolve(model)
+        .is_some()
+    {
+        return None;
+    }
+    Some(official_subscription_provider())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::ProviderMeta;
+    use serde_json::json;
+
+    fn passthrough_provider_with_env(env: serde_json::Value) -> Provider {
+        let mut provider = Provider::with_id(
+            "prov".to_string(),
+            "Prov".to_string(),
+            json!({ "env": env }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            claude_subscription_passthrough: Some(true),
+            ..Default::default()
+        });
+        provider
+    }
+
+    #[test]
+    fn disabled_toggle_never_resolves() {
+        let mut provider = passthrough_provider_with_env(json!({}));
+        provider.meta = None;
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-fable-5")).is_none());
+    }
+
+    #[test]
+    fn unmapped_tier_resolves_to_official_subscription() {
+        let provider = passthrough_provider_with_env(json!({
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7"
+        }));
+
+        // sonnet 档已填 → 走供应商
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-sonnet-4-6")).is_none());
+
+        // opus 档未填 → 订阅直连（带 [1M] 修饰的模型名同样识别）
+        let resolved =
+            resolve_subscription_passthrough(&provider, Some("claude-opus-4-8")).expect("resolve");
+        assert!(is_passthrough_provider(&resolved));
+        assert_eq!(
+            resolved
+                .settings_config
+                .pointer("/env/ANTHROPIC_BASE_URL")
+                .and_then(|v| v.as_str()),
+            Some("https://api.anthropic.com")
+        );
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-fable-5[1m]")).is_some());
+    }
+
+    #[test]
+    fn default_model_covers_all_tiers() {
+        let provider = passthrough_provider_with_env(json!({
+            "ANTHROPIC_MODEL": "default-model"
+        }));
+        // 默认兜底模型对所有档位兜底 → 不透传
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-opus-4-8")).is_none());
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-fable-5")).is_none());
+    }
+
+    #[test]
+    fn fable_degrade_does_not_count_as_configured() {
+        let provider = passthrough_provider_with_env(json!({
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "opus-mapped"
+        }));
+        // opus 已填 → 走供应商；fable 未填 → 不降级，透传真实订阅档
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-opus-4-8")).is_none());
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-fable-5")).is_some());
+    }
+
+    #[test]
+    fn non_tier_models_and_missing_model_stay_on_provider() {
+        let provider = passthrough_provider_with_env(json!({}));
+        // 自定义模型名（无档位关键字）与缺失 model 的请求照常走供应商
+        assert!(resolve_subscription_passthrough(&provider, Some("deepseek-v4-pro")).is_none());
+        assert!(resolve_subscription_passthrough(&provider, None).is_none());
+        assert!(resolve_subscription_passthrough(&provider, Some("   ")).is_none());
+        // 全部角色未填 + 档位请求 → 全量透传
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-haiku-4-5")).is_some());
+    }
+
+    #[test]
+    fn subagent_exact_match_counts_as_configured() {
+        let provider = passthrough_provider_with_env(json!({
+            "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6"
+        }));
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-sonnet-4-6")).is_none());
+        assert!(resolve_subscription_passthrough(&provider, Some("claude-opus-4-8")).is_some());
+    }
+}

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -148,6 +148,13 @@ impl ProviderRouter {
         }
 
         // 3. 更新数据库健康状态（使用配置的阈值）
+        //
+        // 订阅透传的合成供应商不落库：provider_health 对 providers 表有外键
+        // （schema.rs），写合成 id 每次请求都会触发 FK 违约。熔断器（内存态）
+        // 已在上面按合成 id 记账，健康持久化跳过即可。
+        if provider_id == crate::proxy::passthrough::PASSTHROUGH_PROVIDER_ID {
+            return Ok(());
+        }
         self.db
             .update_provider_health_with_threshold(
                 provider_id,
@@ -519,5 +526,26 @@ mod tests {
         let third = router.allow_provider_request("a", "claude").await;
         assert!(third.allowed);
         assert!(third.used_half_open_permit);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_record_result_for_subscription_passthrough_skips_health_persistence() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+        let router = ProviderRouter::new(db);
+
+        // 合成 id 不在 providers 表中；健康持久化必须跳过，
+        // 否则 provider_health 的外键会让每次透传请求都报错
+        router
+            .record_result(
+                crate::proxy::passthrough::PASSTHROUGH_PROVIDER_ID,
+                "claude",
+                false,
+                false,
+                Some("fail".to_string()),
+            )
+            .await
+            .expect("passthrough result recording must not hit the provider_health FK");
     }
 }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -51,7 +51,13 @@ const CLAUDE_ONE_M_MARKER_FOR_CLIENT: &str = "[1M]";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ClaudeTakeoverAuthPolicy {
     PreserveExistingOrAuthToken,
-    ManagedAccount { keep_auth_token: bool },
+    ManagedAccount {
+        keep_auth_token: bool,
+    },
+    /// Claude 订阅透传：不注入任何认证键。写入 PROXY_MANAGED 会顶掉 Claude Code
+    /// 自身的订阅 OAuth（实测 ANTHROPIC_AUTH_TOKEN 优先级更高），
+    /// 透传档位就拿不到客户端自带凭据了（issue #5879）。
+    NativeClientAuth,
 }
 
 #[derive(Clone)]
@@ -99,6 +105,8 @@ impl ProxyService {
             ClaudeTakeoverAuthPolicy::ManagedAccount {
                 keep_auth_token: !provider.is_github_copilot(),
             }
+        } else if provider.claude_subscription_passthrough_enabled() {
+            ClaudeTakeoverAuthPolicy::NativeClientAuth
         } else {
             ClaudeTakeoverAuthPolicy::PreserveExistingOrAuthToken
         };
@@ -208,6 +216,15 @@ impl ProxyService {
                         "ANTHROPIC_API_KEY".to_string(),
                         json!(PROXY_TOKEN_PLACEHOLDER),
                     );
+                }
+            }
+            ClaudeTakeoverAuthPolicy::NativeClientAuth => {
+                // 不注入任何认证键：Claude Code 在无 key 时回退到自身订阅
+                // OAuth，并把该凭据发给代理（已在自定义 base URL 下实测）。
+                // 代价是未登录订阅的用户会看到登录提示（#3784 的行为），
+                // 这正是订阅透传所要求的登录态。
+                for key in token_keys {
+                    env.remove(key);
                 }
             }
         }
@@ -3301,6 +3318,68 @@ mod tests {
             .expect("serialize models_cache"),
         )
         .expect("write models_cache.json");
+    }
+
+    #[test]
+    fn subscription_passthrough_claude_takeover_writes_no_auth_keys() {
+        let mut provider = Provider::with_id(
+            "prov".to_string(),
+            "第三方供应商".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://relay.example.com",
+                    "ANTHROPIC_AUTH_TOKEN": "sk-relay",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7"
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            claude_subscription_passthrough: Some(true),
+            ..Default::default()
+        });
+
+        // live config 是切换后写入的该供应商配置；接管必须清掉全部认证键且
+        // 不写占位符：ANTHROPIC_AUTH_TOKEN=PROXY_MANAGED 会顶掉 Claude Code
+        // 自身的订阅 OAuth，透传档位就拿不到客户端自带凭据了。
+        let mut live_config = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://relay.example.com",
+                "ANTHROPIC_AUTH_TOKEN": "sk-relay",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7"
+            }
+        });
+        ProxyService::apply_claude_takeover_fields_for_provider(
+            &mut live_config,
+            "http://127.0.0.1:15721",
+            &provider,
+        );
+
+        let env = live_config
+            .get("env")
+            .and_then(|value| value.as_object())
+            .expect("env should exist");
+        assert_eq!(
+            env.get("ANTHROPIC_BASE_URL")
+                .and_then(|value| value.as_str()),
+            Some("http://127.0.0.1:15721")
+        );
+        for key in ["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"] {
+            assert!(
+                env.get(key).is_none(),
+                "subscription passthrough takeover must not write {key}, or Claude Code's own subscription OAuth is suppressed"
+            );
+        }
+        // 已填的角色照常写接管别名（/model 菜单仍能展示供应商模型）；
+        // 未填的角色不写别名，客户端会请求真实 claude-* 模型名，
+        // 代理正是据此判定该档位应透传订阅。
+        assert_eq!(
+            env.get("ANTHROPIC_DEFAULT_SONNET_MODEL")
+                .and_then(|value| value.as_str()),
+            Some("claude-sonnet-4-6")
+        );
+        assert!(env.get("ANTHROPIC_DEFAULT_OPUS_MODEL").is_none());
+        assert!(env.get("ANTHROPIC_DEFAULT_FABLE_MODEL").is_none());
     }
 
     #[test]

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/collapsible";
 import { toast } from "sonner";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
 import { FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import {
@@ -137,6 +138,10 @@ interface ClaudeFormFieldsProps {
   subagentModel: string;
   onModelChange: (field: ClaudeModelEnvField, value: string) => void;
 
+  // Claude 订阅透传：未填模型 ID 的角色直接使用 Claude 订阅额度
+  claudeSubscriptionPassthrough?: boolean;
+  onClaudeSubscriptionPassthroughChange?: (enabled: boolean) => void;
+
   // Speed Test Endpoints
   speedTestEndpoints: EndpointCandidate[];
 
@@ -211,6 +216,8 @@ export function ClaudeFormFields({
   defaultFableModelName,
   subagentModel,
   onModelChange,
+  claudeSubscriptionPassthrough,
+  onClaudeSubscriptionPassthroughChange,
   speedTestEndpoints,
   apiFormat,
   onApiFormatChange,
@@ -1103,6 +1110,29 @@ export function ClaudeFormFields({
                 })}
               </p>
             </div>
+
+            {onClaudeSubscriptionPassthroughChange && (
+              <div className="space-y-2 border-t pt-4">
+                <div className="flex items-center justify-between gap-4">
+                  <FormLabel htmlFor="claude-subscription-passthrough">
+                    {t("providerForm.subscriptionPassthroughLabel", {
+                      defaultValue: "Claude 订阅透传",
+                    })}
+                  </FormLabel>
+                  <Switch
+                    id="claude-subscription-passthrough"
+                    checked={claudeSubscriptionPassthrough ?? false}
+                    onCheckedChange={onClaudeSubscriptionPassthroughChange}
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t("providerForm.subscriptionPassthroughHint", {
+                    defaultValue:
+                      "开启后，上方未填写模型的角色直接使用 Claude 订阅额度：请求透传官方接口并保留 Claude Code 自带的订阅登录，CC Switch 不经手凭据。需开启本地代理接管，且已在 Claude Code 登录订阅。填写了默认兜底模型时所有请求仍会命中该供应商。",
+                  })}
+                </p>
+              </div>
+            )}
 
             <CustomUserAgentField
               id="claude-custom-user-agent"

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -243,6 +243,7 @@ export function ClaudeFormFields({
     defaultOpusModel ||
     defaultFableModel ||
     subagentModel ||
+    claudeSubscriptionPassthrough ||
     (!isXaiOauthPreset && apiFormat !== "anthropic") ||
     apiKeyField !== "ANTHROPIC_AUTH_TOKEN" ||
     customUserAgent ||
@@ -974,6 +975,29 @@ export function ClaudeFormFields({
               <p className="text-xs text-muted-foreground">
                 {t("providerForm.modelMappingHint")}
               </p>
+
+              {onClaudeSubscriptionPassthroughChange && (
+                <div className="space-y-2 pt-2">
+                  <div className="flex items-center justify-between gap-4">
+                    <FormLabel htmlFor="claude-subscription-passthrough">
+                      {t("providerForm.subscriptionPassthroughLabel", {
+                        defaultValue: "Claude 订阅透传",
+                      })}
+                    </FormLabel>
+                    <Switch
+                      id="claude-subscription-passthrough"
+                      checked={claudeSubscriptionPassthrough ?? false}
+                      onCheckedChange={onClaudeSubscriptionPassthroughChange}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {t("providerForm.subscriptionPassthroughHint", {
+                      defaultValue:
+                        "开启后，下方未填写模型的角色直接使用 Claude 订阅额度：请求透传官方接口并保留 Claude Code 自带的订阅登录，CC Switch 不经手凭据。需开启本地代理接管，且已在 Claude Code 登录订阅。填写了默认兜底模型时所有请求仍会命中该供应商。",
+                    })}
+                  </p>
+                </div>
+              )}
             </div>
 
             <div className="space-y-3">
@@ -1110,29 +1134,6 @@ export function ClaudeFormFields({
                 })}
               </p>
             </div>
-
-            {onClaudeSubscriptionPassthroughChange && (
-              <div className="space-y-2 border-t pt-4">
-                <div className="flex items-center justify-between gap-4">
-                  <FormLabel htmlFor="claude-subscription-passthrough">
-                    {t("providerForm.subscriptionPassthroughLabel", {
-                      defaultValue: "Claude 订阅透传",
-                    })}
-                  </FormLabel>
-                  <Switch
-                    id="claude-subscription-passthrough"
-                    checked={claudeSubscriptionPassthrough ?? false}
-                    onCheckedChange={onClaudeSubscriptionPassthroughChange}
-                  />
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  {t("providerForm.subscriptionPassthroughHint", {
-                    defaultValue:
-                      "开启后，上方未填写模型的角色直接使用 Claude 订阅额度：请求透传官方接口并保留 Claude Code 自带的订阅登录，CC Switch 不经手凭据。需开启本地代理接管，且已在 Claude Code 登录订阅。填写了默认兜底模型时所有请求仍会命中该供应商。",
-                  })}
-                </p>
-              </div>
-            )}
 
             <CustomUserAgentField
               id="claude-custom-user-agent"

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -365,6 +365,9 @@ function ProviderFormFull({
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
     setPromptCacheRouting(initialData?.meta?.promptCacheRouting ?? "auto");
     setCustomUserAgent(initialData?.meta?.customUserAgent ?? "");
+    setClaudeSubscriptionPassthrough(
+      initialData?.meta?.claudeSubscriptionPassthrough ?? false,
+    );
     setLocalProxyHeadersOverride(
       formatRequestOverrideObject(
         initialData?.meta?.localProxyRequestOverrides?.headers,
@@ -555,6 +558,10 @@ function ProviderFormFull({
   const [customUserAgent, setCustomUserAgent] = useState<string>(
     () => initialData?.meta?.customUserAgent ?? "",
   );
+  const [claudeSubscriptionPassthrough, setClaudeSubscriptionPassthrough] =
+    useState<boolean>(
+      () => initialData?.meta?.claudeSubscriptionPassthrough ?? false,
+    );
   const [localProxyHeadersOverride, setLocalProxyHeadersOverride] =
     useState<string>(() =>
       formatRequestOverrideObject(
@@ -1599,6 +1606,12 @@ function ProviderFormFull({
         (appId === "claude" || appId === "codex") && category !== "official"
           ? customUserAgent.trim() || undefined
           : undefined,
+      claudeSubscriptionPassthrough:
+        appId === "claude" &&
+        category !== "official" &&
+        claudeSubscriptionPassthrough
+          ? true
+          : undefined,
       localProxyRequestOverrides: shouldApplyLocalProxyRequestOverrides
         ? overridesResult.overrides
         : undefined,
@@ -2267,6 +2280,10 @@ function ProviderFormFull({
               onApiKeyFieldChange={handleApiKeyFieldChange}
               isFullUrl={localIsFullUrl}
               onFullUrlChange={setLocalIsFullUrl}
+              claudeSubscriptionPassthrough={claudeSubscriptionPassthrough}
+              onClaudeSubscriptionPassthroughChange={
+                setClaudeSubscriptionPassthrough
+              }
               customUserAgent={customUserAgent}
               onCustomUserAgentChange={setCustomUserAgent}
               localProxyHeadersOverride={localProxyHeadersOverride}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -998,7 +998,7 @@
   },
   "providerForm": {
     "subscriptionPassthroughLabel": "Claude subscription passthrough",
-    "subscriptionPassthroughHint": "When enabled, model roles left empty above use your Claude subscription quota directly: requests are passed through to the official API with Claude Code's own subscription login, and CC Switch never touches the credentials. Requires proxy takeover and an active subscription login in Claude Code. If the default fallback model is set, every request still goes to this provider.",
+    "subscriptionPassthroughHint": "When enabled, model roles left empty below use your Claude subscription quota directly: requests are passed through to the official API with Claude Code's own subscription login, and CC Switch never touches the credentials. Requires proxy takeover and an active subscription login in Claude Code. If the default fallback model is set, every request still goes to this provider.",
     "supplierName": "Provider Name",
     "supplierNameRequired": "Provider Name *",
     "supplierNamePlaceholder": "e.g., Anthropic Official",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -997,6 +997,8 @@
     "openReleaseNotesFailed": "Failed to open release notes:"
   },
   "providerForm": {
+    "subscriptionPassthroughLabel": "Claude subscription passthrough",
+    "subscriptionPassthroughHint": "When enabled, model roles left empty above use your Claude subscription quota directly: requests are passed through to the official API with Claude Code's own subscription login, and CC Switch never touches the credentials. Requires proxy takeover and an active subscription login in Claude Code. If the default fallback model is set, every request still goes to this provider.",
     "supplierName": "Provider Name",
     "supplierNameRequired": "Provider Name *",
     "supplierNamePlaceholder": "e.g., Anthropic Official",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -997,6 +997,8 @@
     "openReleaseNotesFailed": "リリースノートを開けませんでした:"
   },
   "providerForm": {
+    "subscriptionPassthroughLabel": "Claude サブスクリプション透過",
+    "subscriptionPassthroughHint": "有効にすると、上で未入力のモデルロールは Claude サブスクリプションの枠を直接使用します。リクエストは公式 API へ透過され、Claude Code 自身のサブスクリプションログインがそのまま使われます（CC Switch は資格情報に関与しません）。プロキシ引き継ぎが有効で、Claude Code でサブスクリプションにログインしている必要があります。既定フォールバックモデルを設定した場合、すべてのリクエストは引き続きこのプロバイダーに送られます。",
     "supplierName": "プロバイダー名",
     "supplierNameRequired": "プロバイダー名 *",
     "supplierNamePlaceholder": "例: Anthropic Official",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -998,7 +998,7 @@
   },
   "providerForm": {
     "subscriptionPassthroughLabel": "Claude サブスクリプション透過",
-    "subscriptionPassthroughHint": "有効にすると、上で未入力のモデルロールは Claude サブスクリプションの枠を直接使用します。リクエストは公式 API へ透過され、Claude Code 自身のサブスクリプションログインがそのまま使われます（CC Switch は資格情報に関与しません）。プロキシ引き継ぎが有効で、Claude Code でサブスクリプションにログインしている必要があります。既定フォールバックモデルを設定した場合、すべてのリクエストは引き続きこのプロバイダーに送られます。",
+    "subscriptionPassthroughHint": "有効にすると、下で未入力のモデルロールは Claude サブスクリプションの枠を直接使用します。リクエストは公式 API へ透過され、Claude Code 自身のサブスクリプションログインがそのまま使われます（CC Switch は資格情報に関与しません）。プロキシ引き継ぎが有効で、Claude Code でサブスクリプションにログインしている必要があります。既定フォールバックモデルを設定した場合、すべてのリクエストは引き続きこのプロバイダーに送られます。",
     "supplierName": "プロバイダー名",
     "supplierNameRequired": "プロバイダー名 *",
     "supplierNamePlaceholder": "例: Anthropic Official",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -969,7 +969,7 @@
   },
   "providerForm": {
     "subscriptionPassthroughLabel": "Claude 訂閱透傳",
-    "subscriptionPassthroughHint": "開啟後，上方未填寫模型的角色直接使用 Claude 訂閱額度：請求透傳官方介面並保留 Claude Code 自帶的訂閱登入，CC Switch 不經手憑證。需開啟代理接管，且已在 Claude Code 登入訂閱。填寫了備用模型時所有請求仍會命中該供應商。",
+    "subscriptionPassthroughHint": "開啟後，下方未填寫模型的角色直接使用 Claude 訂閱額度：請求透傳官方介面並保留 Claude Code 自帶的訂閱登入，CC Switch 不經手憑證。需開啟代理接管，且已在 Claude Code 登入訂閱。填寫了備用模型時所有請求仍會命中該供應商。",
     "supplierName": "供應商名稱",
     "supplierNameRequired": "供應商名稱 *",
     "supplierNamePlaceholder": "例如：Anthropic 官方",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -968,6 +968,8 @@
     "openReleaseNotesFailed": "開啟更新日誌失敗："
   },
   "providerForm": {
+    "subscriptionPassthroughLabel": "Claude 訂閱透傳",
+    "subscriptionPassthroughHint": "開啟後，上方未填寫模型的角色直接使用 Claude 訂閱額度：請求透傳官方介面並保留 Claude Code 自帶的訂閱登入，CC Switch 不經手憑證。需開啟代理接管，且已在 Claude Code 登入訂閱。填寫了備用模型時所有請求仍會命中該供應商。",
     "supplierName": "供應商名稱",
     "supplierNameRequired": "供應商名稱 *",
     "supplierNamePlaceholder": "例如：Anthropic 官方",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -998,7 +998,7 @@
   },
   "providerForm": {
     "subscriptionPassthroughLabel": "Claude 订阅透传",
-    "subscriptionPassthroughHint": "开启后，上方未填写模型的角色直接使用 Claude 订阅额度：请求透传官方接口并保留 Claude Code 自带的订阅登录，CC Switch 不经手凭据。需开启本地代理接管，且已在 Claude Code 登录订阅。填写了默认兜底模型时所有请求仍会命中该供应商。",
+    "subscriptionPassthroughHint": "开启后，下方未填写模型的角色直接使用 Claude 订阅额度：请求透传官方接口并保留 Claude Code 自带的订阅登录，CC Switch 不经手凭据。需开启本地代理接管，且已在 Claude Code 登录订阅。填写了默认兜底模型时所有请求仍会命中该供应商。",
     "supplierName": "供应商名称",
     "supplierNameRequired": "供应商名称 *",
     "supplierNamePlaceholder": "例如：Anthropic 官方",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -997,6 +997,8 @@
     "openReleaseNotesFailed": "打开更新日志失败:"
   },
   "providerForm": {
+    "subscriptionPassthroughLabel": "Claude 订阅透传",
+    "subscriptionPassthroughHint": "开启后，上方未填写模型的角色直接使用 Claude 订阅额度：请求透传官方接口并保留 Claude Code 自带的订阅登录，CC Switch 不经手凭据。需开启本地代理接管，且已在 Claude Code 登录订阅。填写了默认兜底模型时所有请求仍会命中该供应商。",
     "supplierName": "供应商名称",
     "supplierNameRequired": "供应商名称 *",
     "supplierNamePlaceholder": "例如：Anthropic 官方",

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,9 @@ export interface ProviderMeta {
   customUserAgent?: string;
   // Local proxy request overrides. Only applied by the local proxy after route transforms.
   localProxyRequestOverrides?: LocalProxyRequestOverrides;
+  // Claude 订阅透传：未填模型 ID 的模型角色直接使用 Claude 订阅额度
+  // （仅 Claude 应用、代理接管下生效）
+  claudeSubscriptionPassthrough?: boolean;
   // 供应商类型（用于识别 Copilot 等特殊供应商）
   providerType?: string;
   // GitHub Copilot 关联账号 ID（旧字段，保留兼容读取）

--- a/tests/components/ClaudeFormFields.test.tsx
+++ b/tests/components/ClaudeFormFields.test.tsx
@@ -43,65 +43,96 @@ const FormShell = ({ children }: PropsWithChildren) => {
   return <Form {...form}>{children}</Form>;
 };
 
+const getCopilotFormProps = (
+  overrides: Partial<ClaudeFormFieldsProps> = {},
+): ClaudeFormFieldsProps => ({
+  shouldShowApiKey: false,
+  apiKey: "",
+  onApiKeyChange: vi.fn(),
+  category: "official",
+  shouldShowApiKeyLink: false,
+  websiteUrl: "",
+  isCopilotPreset: true,
+  usesOAuth: true,
+  isCopilotAuthenticated: true,
+  selectedGitHubAccountId: "gh-1",
+  onGitHubAccountSelect: vi.fn(),
+  isCodexOauthPreset: false,
+  isCodexOauthAuthenticated: false,
+  selectedCodexAccountId: null,
+  onCodexAccountSelect: vi.fn(),
+  codexFastMode: false,
+  onCodexFastModeChange: vi.fn(),
+  templateValueEntries: [],
+  templateValues: {},
+  templatePresetName: "",
+  onTemplateValueChange: vi.fn(),
+  shouldShowSpeedTest: false,
+  baseUrl: "",
+  onBaseUrlChange: vi.fn(),
+  isEndpointModalOpen: false,
+  onEndpointModalToggle: vi.fn(),
+  onCustomEndpointsChange: vi.fn(),
+  autoSelect: false,
+  onAutoSelectChange: vi.fn(),
+  showEndpointTools: true,
+  shouldShowModelSelector: true,
+  claudeModel: "",
+  defaultHaikuModel: "",
+  defaultHaikuModelName: "",
+  defaultSonnetModel: "claude-sonnet",
+  defaultSonnetModelName: "Claude Sonnet",
+  defaultOpusModel: "",
+  defaultOpusModelName: "",
+  defaultFableModel: "",
+  defaultFableModelName: "",
+  subagentModel: "",
+  onModelChange: vi.fn(),
+  speedTestEndpoints: [],
+  apiFormat: "anthropic",
+  onApiFormatChange: vi.fn(),
+  apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+  onApiKeyFieldChange: vi.fn(),
+  isFullUrl: false,
+  onFullUrlChange: vi.fn(),
+  customUserAgent: "",
+  onCustomUserAgentChange: vi.fn(),
+  localProxyHeadersOverride: "",
+  onLocalProxyHeadersOverrideChange: vi.fn(),
+  localProxyBodyOverride: "",
+  onLocalProxyBodyOverrideChange: vi.fn(),
+  ...overrides,
+});
+
 const renderCopilotForm = (overrides: Partial<ClaudeFormFieldsProps> = {}) => {
-  const props: ClaudeFormFieldsProps = {
-    shouldShowApiKey: false,
-    apiKey: "",
-    onApiKeyChange: vi.fn(),
-    category: "official",
-    shouldShowApiKeyLink: false,
-    websiteUrl: "",
-    isCopilotPreset: true,
-    usesOAuth: true,
-    isCopilotAuthenticated: true,
-    selectedGitHubAccountId: "gh-1",
-    onGitHubAccountSelect: vi.fn(),
-    isCodexOauthPreset: false,
-    isCodexOauthAuthenticated: false,
-    selectedCodexAccountId: null,
-    onCodexAccountSelect: vi.fn(),
-    codexFastMode: false,
-    onCodexFastModeChange: vi.fn(),
-    templateValueEntries: [],
-    templateValues: {},
-    templatePresetName: "",
-    onTemplateValueChange: vi.fn(),
-    shouldShowSpeedTest: false,
-    baseUrl: "",
-    onBaseUrlChange: vi.fn(),
-    isEndpointModalOpen: false,
-    onEndpointModalToggle: vi.fn(),
-    onCustomEndpointsChange: vi.fn(),
-    autoSelect: false,
-    onAutoSelectChange: vi.fn(),
-    showEndpointTools: true,
-    shouldShowModelSelector: true,
-    claudeModel: "",
-    defaultHaikuModel: "",
-    defaultHaikuModelName: "",
-    defaultSonnetModel: "claude-sonnet",
-    defaultSonnetModelName: "Claude Sonnet",
-    defaultOpusModel: "",
-    defaultOpusModelName: "",
-    defaultFableModel: "",
-    defaultFableModelName: "",
-    subagentModel: "",
-    onModelChange: vi.fn(),
-    speedTestEndpoints: [],
-    apiFormat: "anthropic",
-    onApiFormatChange: vi.fn(),
-    apiKeyField: "ANTHROPIC_AUTH_TOKEN",
-    onApiKeyFieldChange: vi.fn(),
-    isFullUrl: false,
-    onFullUrlChange: vi.fn(),
-    customUserAgent: "",
-    onCustomUserAgentChange: vi.fn(),
-    localProxyHeadersOverride: "",
-    onLocalProxyHeadersOverrideChange: vi.fn(),
-    localProxyBodyOverride: "",
-    onLocalProxyBodyOverrideChange: vi.fn(),
+  const props = getCopilotFormProps(overrides);
+
+  return render(
+    <FormShell>
+      <ClaudeFormFields {...props} />
+    </FormShell>,
+  );
+};
+
+const getOrdinaryClaudeFormProps = (
+  overrides: Partial<ClaudeFormFieldsProps> = {},
+): ClaudeFormFieldsProps =>
+  getCopilotFormProps({
+    category: "custom",
+    isCopilotPreset: false,
+    usesOAuth: false,
+    isCopilotAuthenticated: false,
+    selectedGitHubAccountId: null,
+    defaultSonnetModel: "",
+    defaultSonnetModelName: "",
+    onClaudeSubscriptionPassthroughChange: vi.fn(),
     ...overrides,
-  };
+  });
+
+const renderOrdinaryClaudeForm = (
+  overrides: Partial<ClaudeFormFieldsProps> = {},
+) => {
+  const props = getOrdinaryClaudeFormProps(overrides);
 
   return render(
     <FormShell>
@@ -175,28 +206,84 @@ describe("ClaudeFormFields", () => {
     });
   });
 
-  it("订阅透传开关渲染当前状态并回传切换", () => {
+  it("在普通供应商模型映射提示后、映射行前渲染订阅透传开关", () => {
     const onToggle = vi.fn();
-    renderCopilotForm({
-      claudeSubscriptionPassthrough: false,
+    renderOrdinaryClaudeForm({
+      claudeSubscriptionPassthrough: true,
       onClaudeSubscriptionPassthroughChange: onToggle,
-      // 开关位于「高级选项」折叠区内；customUserAgent 属于
-      // hasAnyAdvancedValue 条件，可让折叠区初始即展开
-      customUserAgent: "test-agent",
     });
 
+    const hint = screen.getByText("providerForm.modelMappingHint");
     const toggle = screen.getByRole("switch", {
       name: "Claude 订阅透传",
     });
-    expect(toggle).toHaveAttribute("data-state", "unchecked");
+    const firstRole = screen.getByText("Sonnet");
+
+    expect(toggle).toHaveAttribute("data-state", "checked");
+    expect(
+      hint.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      toggle.compareDocumentPosition(firstRole) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
 
     fireEvent.click(toggle);
-    expect(onToggle).toHaveBeenCalledWith(true);
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it("启用订阅透传时自动展开高级选项", () => {
+    renderOrdinaryClaudeForm({
+      claudeModel: "",
+      defaultSonnetModel: "",
+      defaultSonnetModelName: "",
+      claudeSubscriptionPassthrough: true,
+      onClaudeSubscriptionPassthroughChange: vi.fn(),
+    });
+
+    expect(
+      screen.getByRole("switch", {
+        name: "Claude 订阅透传",
+      }),
+    ).toHaveAttribute("data-state", "checked");
+  });
+
+  it("透传从关闭变为启用时自动展开高级选项", () => {
+    const { rerender } = render(
+      <FormShell>
+        <ClaudeFormFields
+          {...({
+            ...getOrdinaryClaudeFormProps(),
+            claudeSubscriptionPassthrough: false,
+          } satisfies ClaudeFormFieldsProps)}
+        />
+      </FormShell>,
+    );
+
+    expect(
+      screen.queryByRole("switch", { name: "Claude 订阅透传" }),
+    ).toBeNull();
+
+    rerender(
+      <FormShell>
+        <ClaudeFormFields
+          {...({
+            ...getOrdinaryClaudeFormProps(),
+            claudeSubscriptionPassthrough: true,
+          } satisfies ClaudeFormFieldsProps)}
+        />
+      </FormShell>,
+    );
+
+    expect(
+      screen.getByRole("switch", { name: "Claude 订阅透传" }),
+    ).toHaveAttribute("data-state", "checked");
   });
 
   it("未接入订阅透传回调时不渲染开关", () => {
-    renderCopilotForm({
+    renderOrdinaryClaudeForm({
       customUserAgent: "test-agent",
+      onClaudeSubscriptionPassthroughChange: undefined,
     });
 
     expect(

--- a/tests/components/ClaudeFormFields.test.tsx
+++ b/tests/components/ClaudeFormFields.test.tsx
@@ -175,6 +175,37 @@ describe("ClaudeFormFields", () => {
     });
   });
 
+  it("订阅透传开关渲染当前状态并回传切换", () => {
+    const onToggle = vi.fn();
+    renderCopilotForm({
+      claudeSubscriptionPassthrough: false,
+      onClaudeSubscriptionPassthroughChange: onToggle,
+      // 开关位于「高级选项」折叠区内；customUserAgent 属于
+      // hasAnyAdvancedValue 条件，可让折叠区初始即展开
+      customUserAgent: "test-agent",
+    });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Claude 订阅透传",
+    });
+    expect(toggle).toHaveAttribute("data-state", "unchecked");
+
+    fireEvent.click(toggle);
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it("未接入订阅透传回调时不渲染开关", () => {
+    renderCopilotForm({
+      customUserAgent: "test-agent",
+    });
+
+    expect(
+      screen.queryByRole("switch", {
+        name: "Claude 订阅透传",
+      }),
+    ).toBeNull();
+  });
+
   it("一键设置会同时写入 Subagent 模型", () => {
     const onModelChange = vi.fn();
     renderCopilotForm({


### PR DESCRIPTION
## 关联 Issue

Closes #5879

> **2026-07-30 重写**：本 PR 最初实现的是「聚合供应商」（按档位路由到已有供应商的编排型功能）。重新考虑后我认为那越界了——跨供应商编排用户完全可以在 CC Switch 之外自行搭建，不适合做进 CC Switch（issue 已同步修订）。现缩减为单个开关级功能：**Claude 订阅透传**。diff 从 ~1.4k 行降到 ~380 行，无新增供应商类型、无预设、无删除联动。

## 做了什么

Claude 第三方供应商表单的模型映射区新增开关「**Claude 订阅透传**」（`meta.claudeSubscriptionPassthrough`）。开启后，**未填模型 ID 的模型角色直接使用 Claude 订阅额度**：这些请求透传官方上游并保留客户端自带的 `Authorization`——CC Switch 全程不经手、不存储任何 Claude 订阅凭据；已填的角色照常走该供应商。开关默认关闭，不改变任何既有行为。

典型用法：sonnet / haiku 角色填第三方模型，opus / fable / 默认兜底留空并开启开关——高频调用走第三方，高质量档位走订阅。

## 判定口径

复用现有模型映射的解析链（`model_mapper.rs`，本 PR 把 `map_model` 拆出 `ModelMapping::resolve() -> Option`）：

- 请求模型带档位关键字（fable / opus / sonnet / haiku）且解析不到映射 → 透传；
- 默认兜底模型已填 → 所有请求仍归该供应商（兜底语义不变）；
- 无档位关键字的自定义模型名（手动 `/model` 指定的第三方模型）→ 照常走供应商；
- fable→opus 降级**不算已配置**（`map_model` 保留降级，`resolve` 不含）：开透传的用户显然更希望 fable 走真订阅档，而不是降级成第三方 opus。

## 后端

- `proxy/passthrough.rs`（新增，含测试约 170 行）：合成「Claude 订阅直连」目标（指向官方上游、不含凭据、id 不落库）+ 判定函数。
- 转发集成在 `forward_with_retry_inner` 的 provider 尝试循环顶部，解析放在熔断器 allow 之前。**身份记账拆开**：熔断/健康记在合成 id 上——订阅额度耗尽不应拉闸用户选中的真实供应商；「当前供应商」的状态展示与 failover 切换判定仍以用户选中的供应商为准，四条成功路径（主路径 + 三条整流器重试路径）都已覆盖。
- **透传认证**：完全照搬 `codex_official_auth_passthrough` 的既有模式——仅放行 `Authorization`，`x-api-key` / `x-goog-api-key` 仍然丢弃；请求前校验凭据存在且不含 `PROXY_MANAGED`（报错提示重启客户端）。`anthropic-beta` 的重建逻辑本就保留客户端原值，订阅 OAuth 必需的 `oauth-2025-04-20` 能存活。
- **接管策略**：新增 `ClaudeTakeoverAuthPolicy::NativeClientAuth`——写代理 base URL、清掉全部认证键、不注入占位符（实测 `ANTHROPIC_AUTH_TOKEN=PROXY_MANAGED` 优先级高于 Claude Code 自身的订阅 OAuth，会把透传档位的凭据顶掉）。模型别名快照逻辑不变：已填角色照常写接管别名（/model 菜单仍显示供应商模型），未填角色不写——客户端因此对未填角色请求真实 claude-* 模型名，透传判定正以此为前提。
- 一个坑：`provider_health` 对 `providers` 有外键且 `PRAGMA foreign_keys=ON`，合成 id（`__claude_subscription_passthrough__`）不落库，健康持久化对它跳过（熔断器内存态照常记账），否则每次透传请求都会 FK 违约。

## 前端

`ClaudeFormFields` 模型映射区（默认兜底模型下方）新增 Switch + 说明文案，随表单读写 `meta.claudeSubscriptionPassthrough`；文案覆盖 zh / zh-TW / en / ja 四个语言。

## 范围与已知边界

- 仅 Claude Code、仅代理接管下生效；未接管时写入的仍是供应商自身配置，行为不变。
- 开关开启且未登录订阅时，接管因不写认证键会触发 Claude Code 的登录提示（#3784 的行为）——这正是透传所要求的登录态。「无认证键 + 真实订阅登录」的端到端组合在我机器上无法完整验证（无订阅登录），恳请有订阅的维护者确认；客户端把订阅 OAuth 发给自定义 base URL 的请求头形态已实测（见 issue）。
- legacy 的 `ANTHROPIC_SMALL_FAST_MODEL` 不计入档位判定（现有模型映射本就不读它）。

## 验证

- `cargo test --lib`：2251 通过 / 4 失败——失败均为 `services::model_pricing::tests::*`，与干净 main 上的既有环境性失败一致（本机端口/文件时间戳竞争，数量每轮 2–5 浮动）。新增 12 个单测覆盖判定口径、映射拆分等价性、接管策略、FK 跳过。
- `vitest`：568 / 569 通过，唯一失败为 `tests/integration/App.test.tsx` 的已知并行串扰（干净 main 同样复现，单独运行通过）；`ClaudeFormFields` 新增开关渲染/回调两条用例。
- `tsc --noEmit`、`prettier --check`、`cargo fmt --check` 通过。
