### PR TITLE
feat: 默认精简 Claude Code 中转上下文

### DIFF
--- a/docs/user-manual/en/1-getting-started/1.5-settings.md
+++ b/docs/user-manual/en/1-getting-started/1.5-settings.md
@@ -79,6 +79,18 @@ When enabled, skips the Claude Code onboarding flow, suitable for users already 
 
 > **Note**: This option writes the `skipIntroduction` field to `~/.claude/settings.json`.
 
+### Slim Claude Code Context
+
+Enabled by default. When on, CC Switch injects three defaults whenever it writes the Claude Code live config (`~/.claude/settings.json`):
+
+- `disableBundledSkills: true` — disables Claude Code's bundled skills. The `claude-api` skill alone is ~867KB (~230K tokens), and its trigger-style description steers the model into loading the full body into context (including subagents) whenever a prompt mentions Claude/Anthropic/`[1m]` and similar terms — through third-party relays this burns large amounts of tokens and can outright fail with "Prompt is too long"
+- `enabledPlugins: { "anthropic-skills@inline": false }` — disables the anthropic-skills plugin shipped inline with the CLI
+- `env.ENABLE_TOOL_SEARCH: "true"` — turns on MCP tool search so tool schemas are discovered on demand instead of all being loaded into context (Claude Code keeps this off by default for non-official `ANTHROPIC_BASE_URL`, so it must be enabled explicitly)
+
+> 💡 **Note**: Values are injected only when the key is absent. Keys set explicitly in the provider or common config always win; on switch-away the injected values are stripped so they never fossilize into provider configs. Claude Code CLI and the Claude desktop app read the same `~/.claude/settings.json`, so both are covered.
+
+> ⚠️ **Caveat**: Some relays lack the `tool_reference` capability required by tool search. If MCP tools misbehave, set `"ENABLE_TOOL_SEARCH": "false"` explicitly in the provider config, or turn this toggle off.
+
 ### App Visibility
 
 Choose which applications to display in the app switcher. Each app can be toggled independently, but at least one must remain visible.

--- a/docs/user-manual/ja/1-getting-started/1.5-settings.md
+++ b/docs/user-manual/ja/1-getting-started/1.5-settings.md
@@ -79,6 +79,18 @@ v3.13.0 より、CC Switch に **軽量モード** が追加されました — 
 
 > **注意**：このオプションは `~/.claude/settings.json` の `skipIntroduction` フィールドに書き込まれます。
 
+### Claude Code コンテキストのスリム化
+
+デフォルトで有効。有効にすると、CC Switch は Claude Code の live 設定（`~/.claude/settings.json`）を書き込む際に次の 3 つのデフォルト値を注入します：
+
+- `disableBundledSkills: true` — Claude Code の内蔵スキルを無効化します。`claude-api` スキルだけで約 867KB（約 23 万トークン）あり、そのトリガー型説明文はプロンプトに Claude/Anthropic/`[1m]` などの語が現れると本文全体をコンテキストへ読み込むようモデルを誘導します（サブエージェントを含む）。サードパーティ中継では大量のトークンを消費し、"Prompt is too long" エラーの直接原因にもなります
+- `enabledPlugins: { "anthropic-skills@inline": false }` — CLI に内蔵配布される anthropic-skills プラグインを無効化します
+- `env.ENABLE_TOOL_SEARCH: "true"` — MCP tool search を有効化し、ツール定義を全量ロードせずオンデマンドで発見します（非公式 `ANTHROPIC_BASE_URL` では Claude Code はデフォルト無効のため、明示的な有効化が必要です）
+
+> 💡 **補足**：キーが存在しない場合のみ注入されます。プロバイダー設定や共通設定で明示的に書かれた同名キーが常に優先され、プロバイダー切替時には注入値が剥がされるため、プロバイダー設定に固着することはありません。Claude Code CLI と Claude デスクトップアプリは同じ `~/.claude/settings.json` を読むため、両方に適用されます。
+
+> ⚠️ **注意**：一部の中継は tool search に必要な `tool_reference` 機能に対応していません。MCP ツールに問題が出た場合は、プロバイダー設定に `"ENABLE_TOOL_SEARCH": "false"` を明示するか、このスイッチをオフにしてください。
+
 ### アプリの表示設定
 
 アプリ切り替えに表示するアプリを選択します。各アプリを個別にオン/オフできますが、少なくとも 1 つは有効にする必要があります。

--- a/docs/user-manual/zh/1-getting-started/1.5-settings.md
+++ b/docs/user-manual/zh/1-getting-started/1.5-settings.md
@@ -79,6 +79,18 @@ v3.13.0 起新增「轻量模式」——一种**仅托盘运行**的状态，�
 
 > ⚠️ **注意**：此选项会写入 `~/.claude/settings.json` 的 `skipIntroduction` 字段。
 
+### 精简 Claude Code 上下文
+
+默认开启。开启后，CC Switch 在写入 Claude Code live 配置（`~/.claude/settings.json`）时会注入三个默认值：
+
+- `disableBundledSkills: true` — 关闭 Claude Code 内置技能。其中 `claude-api` 技能约 867KB（约 23 万 token），其触发式描述会引导模型在提示词提到 Claude/Anthropic/`[1m]` 等字样时把全文载入上下文（包括子代理），在第三方中转场景下会消耗大量 token，甚至直接触发 "Prompt is too long" 报错
+- `enabledPlugins: { "anthropic-skills@inline": false }` — 关闭随 CLI 内置分发的 anthropic-skills 插件
+- `env.ENABLE_TOOL_SEARCH: "true"` — 开启 MCP tool search，工具描述不再全量进入上下文，改为按需发现（非官方 `ANTHROPIC_BASE_URL` 下 Claude Code 默认不启用该能力，需显式开启）
+
+> 💡 **说明**：只在键不存在时注入。供应商配置或通用配置里显式写过的同名键始终优先；切走供应商时注入值会被剥离，不会固化进供应商配置。Claude Code CLI 与 Claude 桌面端共读同一份 `~/.claude/settings.json`，两端同时生效。
+
+> ⚠️ **注意**：个别中转不支持 tool search 所需的 `tool_reference` 能力，如遇 MCP 工具异常，可在供应商配置中显式写 `"ENABLE_TOOL_SEARCH": "false"`，或关闭本开关。
+
 ### 应用可见性
 
 选择在应用切换器中显示哪些应用。每个应用可以独立开关，但至少保留一个。

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -68,6 +68,7 @@ pub async fn save_settings(
     let unify_codex_changed =
         merged.unify_codex_session_history != existing.unify_codex_session_history;
     let unify_codex_enabled = merged.unify_codex_session_history;
+    let slim_claude_changed = merged.slim_claude_context != existing.slim_claude_context;
     crate::settings::update_settings(merged).map_err(|e| e.to_string())?;
 
     // 统一会话开关变更时立即重写当前官方 Codex 供应商的 live 配置，
@@ -121,6 +122,23 @@ pub async fn save_settings(
             if let Err(err) = crate::settings::clear_codex_unify_migrate_existing() {
                 log::warn!("清除统一会话迁移意愿失败: {err}");
             }
+        }
+    }
+
+    // 精简 Claude Code 上下文开关变更时立即重写当前 Claude 供应商的 live
+    // 配置，不必等下一次切换才生效。失败时只回滚本开关字段并整体报失败：
+    // 设置若保持已切换状态而 live 未重写，开关会呈现"已开/关但不生效"。
+    if slim_claude_changed {
+        if let Err(err) = crate::services::provider::reapply_current_claude_live(state.inner()) {
+            log::warn!("精简 Claude 上下文开关变更后重写 live 配置失败，回滚设置: {err}");
+            let mut rollback = crate::settings::get_settings();
+            rollback.slim_claude_context = existing.slim_claude_context;
+            if let Err(rollback_err) = crate::settings::update_settings(rollback) {
+                log::error!("回滚精简 Claude 上下文开关设置失败: {rollback_err}");
+            }
+            return Err(format!(
+                "精简 Claude Code 上下文开关未生效（live 配置重写失败）: {err}"
+            ));
         }
     }
     Ok(true)

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -163,6 +163,101 @@ fn apply_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provi
     }
 }
 
+/// Claude Code 精简上下文注入的键值。内置 claude-api skill（经 inline 插件
+/// `anthropic-skills` 随 CLI 分发，约 867KB/23 万 token）的触发式描述会引导
+/// 模型在提示词提到 Claude/Anthropic/`[1m]` 等任意字样时把全文载入上下文
+/// （含子代理）；第三方中转场景下这会烧掉大量 token 甚至直接触发
+/// "Prompt is too long"。同时非官方 `ANTHROPIC_BASE_URL` 下 Claude Code
+/// 默认不启用 MCP tool search，需要显式写 `true` 才能让工具按需发现。
+pub(crate) const CLAUDE_SLIM_DISABLE_BUNDLED_SKILLS_KEY: &str = "disableBundledSkills";
+pub(crate) const CLAUDE_SLIM_ENABLED_PLUGINS_KEY: &str = "enabledPlugins";
+pub(crate) const CLAUDE_SLIM_INLINE_SKILLS_PLUGIN: &str = "anthropic-skills@inline";
+pub(crate) const CLAUDE_SLIM_TOOL_SEARCH_ENV_KEY: &str = "ENABLE_TOOL_SEARCH";
+pub(crate) const CLAUDE_SLIM_TOOL_SEARCH_ENV_VALUE: &str = "true";
+
+/// 按"精简 Claude Code 上下文"开关向 effective 设置注入默认值。
+/// 只在键**不存在**时注入：供应商存储配置和通用配置片段先于本函数合并进
+/// effective，因此二者显式写过的同名键（含显式 false/"false"）始终优先。
+pub(crate) fn apply_claude_slim_context_defaults(settings: &mut Value) {
+    let Some(root) = settings.as_object_mut() else {
+        return;
+    };
+
+    root.entry(CLAUDE_SLIM_DISABLE_BUNDLED_SKILLS_KEY.to_string())
+        .or_insert(Value::Bool(true));
+
+    let plugins = root
+        .entry(CLAUDE_SLIM_ENABLED_PLUGINS_KEY.to_string())
+        .or_insert_with(|| json!({}));
+    if let Some(plugins) = plugins.as_object_mut() {
+        plugins
+            .entry(CLAUDE_SLIM_INLINE_SKILLS_PLUGIN.to_string())
+            .or_insert(Value::Bool(false));
+    }
+
+    let env = root.entry("env".to_string()).or_insert_with(|| json!({}));
+    if let Some(env) = env.as_object_mut() {
+        env.entry(CLAUDE_SLIM_TOOL_SEARCH_ENV_KEY.to_string())
+            .or_insert(Value::String(CLAUDE_SLIM_TOOL_SEARCH_ENV_VALUE.to_string()));
+    }
+}
+
+/// 与 `apply_claude_slim_context_defaults` 对称：切走回填时剥掉注入产物，
+/// 否则默认值会固化成供应商的"用户显式值"，关闭开关后永远压住新行为
+/// （同 `strip_injected_codex_oauth_context_defaults` 的理由）。不看开关
+/// 状态、始终执行：开关中途关闭时 live 里可能仍残留注入键。仅当"值恰好
+/// 等于注入默认、且存储配置本来没有该键"时才剥；用户显式存储的值和手改
+/// live 成其他值的都保留。通用配置片段携带的同名键在本函数之前已由
+/// `remove_common_config_from_settings` 移除。
+pub(crate) fn strip_injected_claude_slim_context_defaults(
+    settings: &mut Value,
+    provider: &Provider,
+) {
+    let stored = &provider.settings_config;
+    let Some(root) = settings.as_object_mut() else {
+        return;
+    };
+
+    if stored.get(CLAUDE_SLIM_DISABLE_BUNDLED_SKILLS_KEY).is_none()
+        && root.get(CLAUDE_SLIM_DISABLE_BUNDLED_SKILLS_KEY) == Some(&Value::Bool(true))
+    {
+        root.remove(CLAUDE_SLIM_DISABLE_BUNDLED_SKILLS_KEY);
+    }
+
+    let stored_has_plugins_obj = stored.get(CLAUDE_SLIM_ENABLED_PLUGINS_KEY).is_some();
+    let stored_has_inline_entry = stored
+        .get(CLAUDE_SLIM_ENABLED_PLUGINS_KEY)
+        .and_then(Value::as_object)
+        .is_some_and(|plugins| plugins.contains_key(CLAUDE_SLIM_INLINE_SKILLS_PLUGIN));
+    if let Some(plugins) = root
+        .get_mut(CLAUDE_SLIM_ENABLED_PLUGINS_KEY)
+        .and_then(Value::as_object_mut)
+    {
+        if !stored_has_inline_entry
+            && plugins.get(CLAUDE_SLIM_INLINE_SKILLS_PLUGIN) == Some(&Value::Bool(false))
+        {
+            plugins.remove(CLAUDE_SLIM_INLINE_SKILLS_PLUGIN);
+        }
+        if plugins.is_empty() && !stored_has_plugins_obj {
+            root.remove(CLAUDE_SLIM_ENABLED_PLUGINS_KEY);
+        }
+    }
+
+    let stored_has_tool_search = stored
+        .pointer(&format!("/env/{CLAUDE_SLIM_TOOL_SEARCH_ENV_KEY}"))
+        .is_some();
+    if let Some(env) = root.get_mut("env").and_then(Value::as_object_mut) {
+        if !stored_has_tool_search
+            && env
+                .get(CLAUDE_SLIM_TOOL_SEARCH_ENV_KEY)
+                .and_then(Value::as_str)
+                == Some(CLAUDE_SLIM_TOOL_SEARCH_ENV_VALUE)
+        {
+            env.remove(CLAUDE_SLIM_TOOL_SEARCH_ENV_KEY);
+        }
+    }
+}
+
 pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
     let mut v = settings.clone();
     if let Some(obj) = v.as_object_mut() {
@@ -690,6 +785,9 @@ pub(crate) fn build_effective_settings_with_common_config(
     if matches!(app_type, AppType::Claude) {
         apply_codex_oauth_claude_context_defaults(&mut effective_settings, provider);
         apply_kimi_for_coding_context_defaults(&mut effective_settings, provider);
+        if crate::settings::get_settings().slim_claude_context {
+            apply_claude_slim_context_defaults(&mut effective_settings);
+        }
     }
 
     Ok(effective_settings)
@@ -831,6 +929,7 @@ fn restore_live_settings_for_provider_backfill(
         let mut settings = live_settings;
         strip_injected_codex_oauth_context_defaults(&mut settings, provider);
         strip_injected_kimi_for_coding_context_defaults(&mut settings, provider);
+        strip_injected_claude_slim_context_defaults(&mut settings, provider);
         return settings;
     }
     if matches!(app_type, AppType::GrokBuild) {
@@ -2034,6 +2133,112 @@ mod tests {
             effective["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"],
             json!("250000")
         );
+    }
+
+    #[test]
+    fn slim_context_defaults_injected_only_when_absent() {
+        let mut settings = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://relay.example.com"
+            }
+        });
+        apply_claude_slim_context_defaults(&mut settings);
+        assert_eq!(settings["disableBundledSkills"], json!(true));
+        assert_eq!(
+            settings["enabledPlugins"]["anthropic-skills@inline"],
+            json!(false)
+        );
+        assert_eq!(settings["env"]["ENABLE_TOOL_SEARCH"], json!("true"));
+
+        // 显式值（含显式"反向"值）一律不被覆盖
+        let mut explicit = json!({
+            "disableBundledSkills": false,
+            "enabledPlugins": { "anthropic-skills@inline": true },
+            "env": { "ENABLE_TOOL_SEARCH": "auto" }
+        });
+        apply_claude_slim_context_defaults(&mut explicit);
+        assert_eq!(explicit["disableBundledSkills"], json!(false));
+        assert_eq!(
+            explicit["enabledPlugins"]["anthropic-skills@inline"],
+            json!(true)
+        );
+        assert_eq!(explicit["env"]["ENABLE_TOOL_SEARCH"], json!("auto"));
+    }
+
+    #[test]
+    fn slim_context_strip_removes_only_injected_defaults() {
+        let provider = Provider::with_id(
+            "relay".to_string(),
+            "Relay".to_string(),
+            json!({
+                "env": { "ANTHROPIC_BASE_URL": "https://relay.example.com" }
+            }),
+            None,
+        );
+
+        // 注入后原样回填：三个键全部剥掉，空 enabledPlugins 对象一并移除
+        let mut injected = json!({
+            "env": { "ANTHROPIC_BASE_URL": "https://relay.example.com" }
+        });
+        apply_claude_slim_context_defaults(&mut injected);
+        strip_injected_claude_slim_context_defaults(&mut injected, &provider);
+        assert!(injected.get("disableBundledSkills").is_none());
+        assert!(injected.get("enabledPlugins").is_none());
+        assert!(injected["env"].get("ENABLE_TOOL_SEARCH").is_none());
+        assert_eq!(
+            injected["env"]["ANTHROPIC_BASE_URL"],
+            json!("https://relay.example.com")
+        );
+
+        // 用户手改 live 成非默认值：保留
+        let mut hand_edited = json!({
+            "disableBundledSkills": false,
+            "enabledPlugins": { "anthropic-skills@inline": true, "my-plugin@repo": true },
+            "env": { "ENABLE_TOOL_SEARCH": "auto" }
+        });
+        strip_injected_claude_slim_context_defaults(&mut hand_edited, &provider);
+        assert_eq!(hand_edited["disableBundledSkills"], json!(false));
+        assert_eq!(
+            hand_edited["enabledPlugins"]["anthropic-skills@inline"],
+            json!(true)
+        );
+        assert_eq!(hand_edited["env"]["ENABLE_TOOL_SEARCH"], json!("auto"));
+
+        // 非注入的插件条目保留，容器对象不删
+        let mut mixed = json!({
+            "enabledPlugins": { "anthropic-skills@inline": false, "my-plugin@repo": true }
+        });
+        strip_injected_claude_slim_context_defaults(&mut mixed, &provider);
+        assert!(mixed["enabledPlugins"]
+            .get("anthropic-skills@inline")
+            .is_none());
+        assert_eq!(mixed["enabledPlugins"]["my-plugin@repo"], json!(true));
+    }
+
+    #[test]
+    fn slim_context_strip_keeps_provider_owned_values() {
+        // 供应商存储配置里显式带这三个键（值恰与注入默认相同）：全部保留
+        let provider = Provider::with_id(
+            "relay".to_string(),
+            "Relay".to_string(),
+            json!({
+                "disableBundledSkills": true,
+                "enabledPlugins": { "anthropic-skills@inline": false },
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://relay.example.com",
+                    "ENABLE_TOOL_SEARCH": "true"
+                }
+            }),
+            None,
+        );
+        let mut live = provider.settings_config.clone();
+        strip_injected_claude_slim_context_defaults(&mut live, &provider);
+        assert_eq!(live["disableBundledSkills"], json!(true));
+        assert_eq!(
+            live["enabledPlugins"]["anthropic-skills@inline"],
+            json!(false)
+        );
+        assert_eq!(live["env"]["ENABLE_TOOL_SEARCH"], json!("true"));
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -105,6 +105,44 @@ pub fn reapply_current_codex_official_live(state: &AppState) -> Result<bool, App
     Ok(true)
 }
 
+/// "精简 Claude Code 上下文"开关变更后，立即按新开关状态重写当前 Claude
+/// 供应商的 live 配置，使开关即时生效（无需等下一次切换）。当前供应商不
+/// 存在时为 no-op。settings.json 与 MCP 所在的 ~/.claude.json 是两个文件，
+/// 重写前者不影响后者，无需重投影 MCP。
+pub fn reapply_current_claude_live(state: &AppState) -> Result<bool, AppError> {
+    let current_id = ProviderService::current(state, AppType::Claude)?;
+    if current_id.is_empty() {
+        return Ok(false);
+    }
+    let providers = state.db.get_all_providers(AppType::Claude.as_str())?;
+    let Some(provider) = providers.get(&current_id) else {
+        return Ok(false);
+    };
+
+    // 代理接管期间 live 归代理所有：与切换/保存路径一致，以 backup/占位符
+    // 为所有权信号，只更新备份，注入后的配置由接管释放时的恢复路径落盘。
+    let has_live_backup =
+        futures::executor::block_on(state.db.get_live_backup(AppType::Claude.as_str()))
+            .ok()
+            .flatten()
+            .is_some();
+    let live_taken_over = state
+        .proxy_service
+        .detect_takeover_in_live_config_for_app(&AppType::Claude);
+    if has_live_backup || live_taken_over {
+        futures::executor::block_on(
+            state
+                .proxy_service
+                .update_live_backup_from_provider(AppType::Claude.as_str(), provider),
+        )
+        .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
+        return Ok(true);
+    }
+
+    live::write_live_with_common_config(&state.db, &AppType::Claude, provider)?;
+    Ok(true)
+}
+
 /// Provider business logic service
 pub struct ProviderService;
 
@@ -1197,7 +1235,7 @@ GEMINI_TIMEOUT_MS=30000
             "includeCoAuthoredBy": false
         });
 
-        let snippet = ProviderService::extract_claude_common_config(&settings)
+        let snippet = ProviderService::extract_claude_common_config(&settings, false)
             .expect("extract should succeed");
         let value: Value = serde_json::from_str(&snippet).expect("snippet is valid JSON");
 
@@ -1274,7 +1312,7 @@ GEMINI_TIMEOUT_MS=30000
             "theme": "dark"
         });
 
-        let snippet = ProviderService::extract_claude_common_config(&settings)
+        let snippet = ProviderService::extract_claude_common_config(&settings, false)
             .expect("extract should succeed");
         let value: Value = serde_json::from_str(&snippet).expect("snippet is valid JSON");
         let env = value.get("env");
@@ -1302,6 +1340,60 @@ GEMINI_TIMEOUT_MS=30000
             Some("true")
         );
         assert_eq!(value.get("theme").and_then(|v| v.as_str()), Some("dark"));
+    }
+
+    /// 精简上下文开关开启时，注入产物不得被回收进共享片段（否则关闭开关后
+    /// 片段仍把这些键合并回每个供应商，开关失效）；ENABLE_TOOL_SEARCH 归
+    /// 通用配置编辑器的快捷开关所有，不剥。开关关闭时全部按普通共享键保留。
+    #[test]
+    fn extract_claude_common_config_strips_slim_injected_keys_only_when_enabled() {
+        let settings = json!({
+            "disableBundledSkills": true,
+            "enabledPlugins": { "anthropic-skills@inline": false },
+            "env": { "ENABLE_TOOL_SEARCH": "true" },
+            "theme": "dark"
+        });
+
+        let snippet = ProviderService::extract_claude_common_config(&settings, true)
+            .expect("extract should succeed");
+        let value: Value = serde_json::from_str(&snippet).expect("snippet is valid JSON");
+        assert!(value.get("disableBundledSkills").is_none());
+        assert!(value.get("enabledPlugins").is_none());
+        assert_eq!(
+            value
+                .pointer("/env/ENABLE_TOOL_SEARCH")
+                .and_then(|v| v.as_str()),
+            Some("true"),
+            "quick-toggle-owned ENABLE_TOOL_SEARCH must survive extraction"
+        );
+        assert_eq!(value.get("theme").and_then(|v| v.as_str()), Some("dark"));
+
+        // 非注入默认值（用户显式反向配置）不剥；用户自装插件条目保留
+        let user_settings = json!({
+            "disableBundledSkills": false,
+            "enabledPlugins": { "anthropic-skills@inline": false, "my-plugin@repo": true }
+        });
+        let snippet = ProviderService::extract_claude_common_config(&user_settings, true)
+            .expect("extract should succeed");
+        let value: Value = serde_json::from_str(&snippet).expect("snippet is valid JSON");
+        assert_eq!(value.get("disableBundledSkills"), Some(&json!(false)));
+        assert!(value
+            .pointer("/enabledPlugins/anthropic-skills@inline")
+            .is_none());
+        assert_eq!(
+            value.pointer("/enabledPlugins/my-plugin@repo"),
+            Some(&json!(true))
+        );
+
+        // 开关关闭：一切照旧进入片段
+        let snippet = ProviderService::extract_claude_common_config(&settings, false)
+            .expect("extract should succeed");
+        let value: Value = serde_json::from_str(&snippet).expect("snippet is valid JSON");
+        assert_eq!(value.get("disableBundledSkills"), Some(&json!(true)));
+        assert_eq!(
+            value.pointer("/enabledPlugins/anthropic-skills@inline"),
+            Some(&json!(false))
+        );
     }
 
     #[test]
@@ -3454,7 +3546,10 @@ impl ProviderService {
             .ok_or_else(|| AppError::Message(format!("Provider {current_id} not found")))?;
 
         match app_type {
-            AppType::Claude => Self::extract_claude_common_config(&provider.settings_config),
+            AppType::Claude => Self::extract_claude_common_config(
+                &provider.settings_config,
+                crate::settings::get_settings().slim_claude_context,
+            ),
             AppType::ClaudeDesktop => Ok(String::new()),
             AppType::Codex => Self::extract_codex_common_config(&provider.settings_config),
             AppType::Gemini => Self::extract_gemini_common_config(&provider.settings_config),
@@ -3471,7 +3566,10 @@ impl ProviderService {
         settings_config: &Value,
     ) -> Result<String, AppError> {
         match app_type {
-            AppType::Claude => Self::extract_claude_common_config(settings_config),
+            AppType::Claude => Self::extract_claude_common_config(
+                settings_config,
+                crate::settings::get_settings().slim_claude_context,
+            ),
             AppType::ClaudeDesktop => Ok(String::new()),
             AppType::Codex => Self::extract_codex_common_config(settings_config),
             AppType::Gemini => Self::extract_gemini_common_config(settings_config),
@@ -3551,7 +3649,18 @@ impl ProviderService {
     }
 
     /// Extract common config for Claude (JSON format)
-    fn extract_claude_common_config(settings: &Value) -> Result<String, AppError> {
+    ///
+    /// `slim_context_enabled` 为"精简 Claude Code 上下文"开关状态：开启时
+    /// live 里的 `disableBundledSkills: true` 与
+    /// `enabledPlugins["anthropic-skills@inline"]: false` 大概率是
+    /// `apply_claude_slim_context_defaults` 的注入产物，须从共享片段剥离
+    /// （同 Codex 提取器"注入内容不进共享片段"的处理），否则关闭开关后
+    /// 片段仍会把这两个键合并回每个供应商，开关失效。`ENABLE_TOOL_SEARCH`
+    /// 不在此剥：它归通用配置编辑器的快捷开关所有，剥掉会静默丢用户勾选。
+    fn extract_claude_common_config(
+        settings: &Value,
+        slim_context_enabled: bool,
+    ) -> Result<String, AppError> {
         let mut config = settings.clone();
 
         // 供应商专属的**非机密**字段（模型 + 端点），不应共享。凭据/机密不在此列举，
@@ -3618,6 +3727,32 @@ impl ProviderService {
             }
             for key in &sensitive {
                 obj.remove(key);
+            }
+        }
+
+        // 精简上下文开关开启时，剥离其注入产物（仅剥与注入默认完全一致的值，
+        // 用户显式改成其他值的保留）。
+        if slim_context_enabled {
+            if let Some(obj) = config.as_object_mut() {
+                if obj.get(live::CLAUDE_SLIM_DISABLE_BUNDLED_SKILLS_KEY) == Some(&Value::Bool(true))
+                {
+                    obj.remove(live::CLAUDE_SLIM_DISABLE_BUNDLED_SKILLS_KEY);
+                }
+                let mut remove_plugins_obj = false;
+                if let Some(plugins) = obj
+                    .get_mut(live::CLAUDE_SLIM_ENABLED_PLUGINS_KEY)
+                    .and_then(|v| v.as_object_mut())
+                {
+                    if plugins.get(live::CLAUDE_SLIM_INLINE_SKILLS_PLUGIN)
+                        == Some(&Value::Bool(false))
+                    {
+                        plugins.remove(live::CLAUDE_SLIM_INLINE_SKILLS_PLUGIN);
+                    }
+                    remove_plugins_obj = plugins.is_empty();
+                }
+                if remove_plugins_obj {
+                    obj.remove(live::CLAUDE_SLIM_ENABLED_PLUGINS_KEY);
+                }
             }
         }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -354,6 +354,12 @@ pub struct AppSettings {
     /// 是否跳过 Claude Code 初次安装确认
     #[serde(default)]
     pub skip_claude_onboarding: bool,
+    /// 写入 Claude Code live 配置时默认精简上下文：关闭内置技能
+    /// （含 ~867KB/约 23 万 token 的 claude-api）与内置 anthropic-skills
+    /// 插件，并显式开启 MCP tool search 让工具按需发现。默认开启；
+    /// 供应商/通用配置里显式写过的同名键始终优先（见 live.rs 注入器）。
+    #[serde(default = "default_slim_claude_context")]
+    pub slim_claude_context: bool,
     /// 是否开机自启
     #[serde(default)]
     pub launch_on_startup: bool,
@@ -502,6 +508,10 @@ fn default_show_profile_switcher() -> bool {
     true
 }
 
+fn default_slim_claude_context() -> bool {
+    true
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -510,6 +520,7 @@ impl Default for AppSettings {
             use_app_window_controls: false,
             enable_claude_plugin_integration: false,
             skip_claude_onboarding: false,
+            slim_claude_context: true,
             launch_on_startup: false,
             silent_startup: false,
             enable_local_proxy: false,

--- a/src/components/settings/WindowSettings.tsx
+++ b/src/components/settings/WindowSettings.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import type { SettingsFormState } from "@/hooks/useSettings";
-import { AppWindow, MonitorUp, Power, EyeOff } from "lucide-react";
+import { AppWindow, MonitorUp, Power, EyeOff, Feather } from "lucide-react";
 import { ToggleRow } from "@/components/ui/toggle-row";
 import { AnimatePresence, motion } from "framer-motion";
 import { isLinux } from "@/lib/platform";
@@ -65,6 +65,14 @@ export function WindowSettings({ settings, onChange }: WindowSettingsProps) {
           description={t("settings.skipClaudeOnboardingDescription")}
           checked={!!settings.skipClaudeOnboarding}
           onCheckedChange={(value) => onChange({ skipClaudeOnboarding: value })}
+        />
+
+        <ToggleRow
+          icon={<Feather className="h-4 w-4 text-emerald-500" />}
+          title={t("settings.slimClaudeContext")}
+          description={t("settings.slimClaudeContextDescription")}
+          checked={settings.slimClaudeContext ?? true}
+          onCheckedChange={(value) => onChange({ slimClaudeContext: value })}
         />
 
         <ToggleRow

--- a/src/hooks/useSettingsForm.ts
+++ b/src/hooks/useSettingsForm.ts
@@ -116,6 +116,7 @@ export function useSettingsForm(): UseSettingsFormResult {
         data.enableClaudePluginIntegration ?? false,
       silentStartup: data.silentStartup ?? false,
       skipClaudeOnboarding: data.skipClaudeOnboarding ?? false,
+      slimClaudeContext: data.slimClaudeContext ?? true,
       preserveCodexOfficialAuthOnSwitch:
         data.preserveCodexOfficialAuthOnSwitch ?? false,
       unifyCodexSessionHistory: data.unifyCodexSessionHistory ?? false,
@@ -144,6 +145,7 @@ export function useSettingsForm(): UseSettingsFormResult {
             useAppWindowControls: false,
             enableClaudePluginIntegration: false,
             skipClaudeOnboarding: false,
+            slimClaudeContext: true,
             preserveCodexOfficialAuthOnSwitch: false,
             unifyCodexSessionHistory: false,
             language: readPersistedLanguage(),
@@ -183,6 +185,7 @@ export function useSettingsForm(): UseSettingsFormResult {
           serverData.enableClaudePluginIntegration ?? false,
         silentStartup: serverData.silentStartup ?? false,
         skipClaudeOnboarding: serverData.skipClaudeOnboarding ?? false,
+        slimClaudeContext: serverData.slimClaudeContext ?? true,
         preserveCodexOfficialAuthOnSwitch:
           serverData.preserveCodexOfficialAuthOnSwitch ?? false,
         unifyCodexSessionHistory: serverData.unifyCodexSessionHistory ?? false,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -681,6 +681,8 @@
     "enableClaudePluginIntegrationDescription": "When enabled, the VS Code Claude Code extension provider will switch with this app",
     "skipClaudeOnboarding": "Skip Claude Code first-run confirmation",
     "skipClaudeOnboardingDescription": "When enabled, Claude Code will skip the first-run confirmation",
+    "slimClaudeContext": "Slim Claude Code context",
+    "slimClaudeContextDescription": "When applying a provider, disable Claude Code bundled skills (incl. the ~230K-token claude-api skill) and the built-in anthropic-skills plugin, and turn on MCP tool search for on-demand discovery. Keys set explicitly in the provider or common config always win",
     "codexAuth": "Codex App Enhancements",
     "preserveCodexOfficialAuthOnSwitch": "Keep official login for direct switches",
     "preserveCodexOfficialAuthOnSwitchDescription": "Controls third-party switches when local routing is off. Takeover routing always preserves the Codex official login.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -681,6 +681,8 @@
     "enableClaudePluginIntegrationDescription": "オンにすると VS Code の Claude Code 拡張のプロバイダーも同期します",
     "skipClaudeOnboarding": "Claude Code の初回確認をスキップ",
     "skipClaudeOnboardingDescription": "オンにすると Claude Code の初回インストール確認をスキップします",
+    "slimClaudeContext": "Claude Code コンテキストのスリム化",
+    "slimClaudeContextDescription": "プロバイダー適用時に Claude Code の内蔵スキル（約 23 万トークンの claude-api を含む）と内蔵 anthropic-skills プラグインを無効化し、MCP tool search によるオンデマンド発見を有効にします。プロバイダーや共通設定で明示的に設定したキーが常に優先されます",
     "codexAuth": "Codex アプリ拡張",
     "preserveCodexOfficialAuthOnSwitch": "直接切替時に公式ログインを保持",
     "preserveCodexOfficialAuthOnSwitchDescription": "ローカルルーティングが無効な場合のサードパーティ切替を制御します。ルーティング接管中は常に Codex の公式ログインを保持します。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -681,6 +681,8 @@
     "enableClaudePluginIntegrationDescription": "開啟後 VS Code Claude Code 外掛程式的供應商將隨本軟體切換",
     "skipClaudeOnboarding": "跳過 Claude Code 初次安裝確認",
     "skipClaudeOnboardingDescription": "開啟後跳過 Claude Code 初次安裝確認",
+    "slimClaudeContext": "精簡 Claude Code 上下文",
+    "slimClaudeContextDescription": "套用供應商設定時關閉 Claude Code 內建技能（含約 23 萬 token 的 claude-api）與內建 anthropic-skills 外掛，並開啟 MCP tool search 按需探索。供應商或通用設定裡明確寫過的同名鍵始終優先",
     "codexAuth": "Codex 應用增強",
     "preserveCodexOfficialAuthOnSwitch": "非接管切換時保留官方登入",
     "preserveCodexOfficialAuthOnSwitchDescription": "控制未開啟本機路由時切換第三方供應商是否保留 Codex 官方登入；路由接管期間一律保留",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -681,6 +681,8 @@
     "enableClaudePluginIntegrationDescription": "开启后 VS Code Claude Code 插件的供应商将随本软件切换",
     "skipClaudeOnboarding": "跳过 Claude Code 初次安装确认",
     "skipClaudeOnboardingDescription": "开启后跳过 Claude Code 初次安装确认",
+    "slimClaudeContext": "精简 Claude Code 上下文",
+    "slimClaudeContextDescription": "应用供应商配置时关闭 Claude Code 内置技能（含约 23 万 token 的 claude-api）与内置 anthropic-skills 插件，并开启 MCP tool search 按需发现。供应商或通用配置里显式写过的同名键始终优先",
     "codexAuth": "Codex 应用增强",
     "preserveCodexOfficialAuthOnSwitch": "非接管切换时保留官方登录",
     "preserveCodexOfficialAuthOnSwitchDescription": "控制未开启路由接管时切换第三方供应商是否保留 Codex 官方登录；路由接管期间始终保留",

--- a/src/lib/schemas/settings.ts
+++ b/src/lib/schemas/settings.ts
@@ -13,6 +13,7 @@ export const settingsSchema = z.object({
   minimizeToTrayOnClose: z.boolean(),
   enableClaudePluginIntegration: z.boolean().optional(),
   skipClaudeOnboarding: z.boolean().optional(),
+  slimClaudeContext: z.boolean().optional(),
   launchOnStartup: z.boolean().optional(),
   enableLocalProxy: z.boolean().optional(),
   usageDashboardRefreshIntervalMs: z.number().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -352,6 +352,9 @@ export interface Settings {
   enableClaudePluginIntegration?: boolean;
   // 跳过 Claude Code 初次安装确认（写入 ~/.claude.json 的 hasCompletedOnboarding）
   skipClaudeOnboarding?: boolean;
+  // 精简 Claude Code 上下文：写 live 配置时默认关闭内置技能（含约 23 万 token
+  // 的 claude-api）与内置 anthropic-skills 插件，并开启 MCP tool search 按需发现
+  slimClaudeContext?: boolean;
   // 是否开机自启
   launchOnStartup?: boolean;
   // 静默启动（程序启动时不显示主窗口）


### PR DESCRIPTION
## 关联 Issue

Closes #5869

## 做了什么

新增设备级开关「**精简 Claude Code 上下文**」（默认开启）。应用或切换 Claude 供应商时，在供应商配置和通用配置均未显式设置同名键的前提下，向 `~/.claude/settings.json` 注入：

```json
{
  "disableBundledSkills": true,
  "enabledPlugins": { "anthropic-skills@inline": false },
  "env": { "ENABLE_TOOL_SEARCH": "true" }
}
```

这解决两个中转场景下的默认上下文开销：

- 内置 `claude-api` skill 约 867 KB（约 23 万 token），其常驻触发描述会在提到 Claude / Anthropic / `claude-*` / `[1m]` 等内容时引导模型载入全文；200K 窗口会直接 `Prompt is too long`，1M 窗口也会产生显著 token 成本。
- 非官方 `ANTHROPIC_BASE_URL` 下 MCP tool search 默认关闭，工具 schema 会全量预载；显式开启后改为按需发现。

## 配置语义

- **显式配置优先**：仅在键不存在时注入；供应商配置或通用配置中的 `false`、`true` 及其他显式值均不覆盖。
- **对称回填**：切走供应商时，只剥离值仍等于注入默认且供应商原配置未持有的键，避免默认值固化为供应商配置；用户手改值和自装插件条目保留。
- **共享片段防固化**：开关开启时，通用配置提取器跳过注入产生的 bundled-skill / inline-plugin 默认值；`ENABLE_TOOL_SEARCH` 仍归现有通用配置快捷开关所有，不会被静默丢弃。
- **立即生效**：设置页切换开关后立即重写当前 Claude live 配置；代理接管期间遵循现有所有权规则，只更新 live backup，释放接管时再恢复落盘。
- Claude Code CLI 与桌面端共读 `~/.claude/settings.json`，因此无需修改独立的 Claude Desktop provider profile。

## UI 与文档

- 设置页新增开关及说明文案，覆盖简中、繁中、英文、日文。
- 用户手册补充英文、简中、日文说明及显式覆盖示例。

## 已知取舍

- `disableBundledSkills` 会关闭 `/code-review`、`/debug` 等 bundled skills（`/doctor` 不受影响）。需要这些技能的用户可以关闭本开关，或在配置中显式覆盖。
- 个别中转若不支持 tool search 所需能力，可显式配置 `"ENABLE_TOOL_SEARCH": "false"`，该值会优先于注入默认。
- 默认开启会在升级后的下一次供应商应用/切换时改变行为，文档中已说明。

## 验证

- 当前 PR 分支新增 Rust 定向单测：4 通过 / 0 失败，覆盖默认注入、对称剥离、供应商显式值保留、通用配置提取防固化。
- `cargo check`、`cargo clippy --all-targets -- -D warnings`、`cargo fmt --check` 通过。
- `tsc --noEmit`、`prettier --check` 通过。
- `vitest`：565 / 567 通过；2 个全量并行时序失败在干净基线同样复现，相关用例单独运行通过。
- `git diff --check` 通过。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
