### PR TITLE
fix(codex): preserve assistant turns across Responses conversion

### DIFF
--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -110,6 +110,14 @@ pub(crate) fn append_reasoning_content(message: &mut Map<String, Value>, reasoni
 
     match message.get_mut("reasoning_content") {
         Some(Value::String(existing)) if !existing.is_empty() => {
+            let existing_trimmed = existing.trim();
+            if existing_trimmed == reasoning || reasoning == "tool call" {
+                return false;
+            }
+            if existing_trimmed == "tool call" {
+                *existing = reasoning.to_string();
+                return true;
+            }
             existing.push_str("\n\n");
             existing.push_str(reasoning);
         }

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -839,6 +839,27 @@ fn flush_pending_tool_calls(
     // new assistant tool-call turn. Consecutive outputs do not enter here
     // because `pending_tool_calls` is empty after the first output.
     flush_pending_chat_tool_media(messages, pending_media);
+
+    let last_index = messages.len().checked_sub(1);
+    if let Some(last_message) = messages.last_mut() {
+        let can_merge = last_message.get("role").and_then(Value::as_str) == Some("assistant")
+            && last_message
+                .get("tool_calls")
+                .and_then(Value::as_array)
+                .is_none_or(Vec::is_empty);
+        if can_merge {
+            if let Some(obj) = last_message.as_object_mut() {
+                obj.insert(
+                    "tool_calls".to_string(),
+                    Value::Array(std::mem::take(pending_tool_calls)),
+                );
+            }
+            attach_pending_reasoning_to_assistant(last_message, pending_reasoning);
+            *last_assistant_index = last_index;
+            return;
+        }
+    }
+
     let mut message = json!({
         "role": "assistant",
         "content": null,
@@ -3804,6 +3825,92 @@ mod tests {
             result["usage"]["input_tokens_details"]["cache_write_tokens"],
             2
         );
+    }
+
+    #[test]
+    fn responses_chat_round_trip_preserves_combined_assistant_turn() {
+        let chat_response = json!({
+            "id": "chatcmpl_round_trip",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "kimi-k3",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning_content": "Need to inspect the file.",
+                    "content": "I will inspect it now.",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"README.md\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15
+            }
+        });
+
+        let response = chat_completion_to_response(chat_response).unwrap();
+        let request = json!({
+            "model": "kimi-k3",
+            "input": response["output"].clone()
+        });
+        let round_trip = responses_to_chat_completions(request).unwrap();
+        let messages = round_trip["messages"].as_array().unwrap();
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "one native assistant turn must stay one turn"
+        );
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["content"], "I will inspect it now.");
+        assert_eq!(
+            messages[0]["reasoning_content"],
+            "Need to inspect the file."
+        );
+        assert_eq!(messages[0]["tool_calls"][0]["id"], "call_1");
+    }
+
+    #[test]
+    fn responses_request_does_not_merge_tool_calls_across_user_boundary() {
+        let input = json!({
+            "model": "kimi-k3",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": "First answer."
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": "New turn."
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "arguments": "{\"path\":\"README.md\"}"
+                }
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages.len(), 3);
+        assert!(messages[0].get("tool_calls").is_none());
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[2]["role"], "assistant");
+        assert_eq!(messages[2]["tool_calls"][0]["id"], "call_1");
     }
 
     #[test]


### PR DESCRIPTION

## Summary / 概述

Preserve a single Chat assistant turn when a Responses history contains an adjacent assistant `message` followed by one or more `function_call` items.

The current round-trip converts one native assistant message containing `reasoning_content`, `content`, and `tool_calls` into two adjacent Chat assistant messages. The second message also receives a duplicate copy of the reasoning. This patch:

- merges pending tool calls into the immediately preceding assistant message when no user, tool, or media boundary intervenes;
- keeps the existing standalone assistant fallback for tool-only turns;
- keeps parallel tool calls in one batch;
- deduplicates identical reasoning and lets real reasoning replace the `tool call` fallback without dropping distinct reasoning;
- adds a Chat -> Responses -> Chat invariant test and a user-boundary regression test.

The change is limited to the Codex proxy conversion path. It does not change UI behavior, configuration, dependencies, or user-facing text.

## Impact / 影响

This is not only a cosmetic message-shape difference. Codex relies on the reconstructed Chat history when a Responses client is connected to a Chat Completions provider. After several converted turns, the current history repeatedly shows a text-only assistant reply followed by a separate tool-only assistant reply. The text-only message is a complete turn in Chat Completions semantics, while duplicated reasoning also pollutes preserved-thinking context. Together, these changes make tool-continuation decisions less reliable and can cause a long-running agent task to stop after emitting a progress sentence instead of issuing its next tool call.

I validated the behavioral impact independently with Kimi K3 using the same malformed history shape produced by this converter:

- native combined assistant history completed an eight-step tool task in 3/3 runs;
- three split-history variants completed it in 0/3 runs;
- an end-to-end Codex proxy binary completed only 3/8 steps before the turn-preserving fix, then stopped immediately after saying it would continue;
- the patched binary completed 8/8 steps in two consecutive runs and then stopped naturally.

The experiment did not inject synthetic `continue` messages or force `tool_choice`. The fix restores the provider's native assistant-turn structure, so Codex can continue when the model emits a tool call and still terminate normally on a genuine text-only final answer.

## Related Issue / 关联 Issue

Fixes #5860

## Screenshots / 截图

Not applicable. This is a backend protocol conversion fix.

## Validation / 验证

- `cargo fmt --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- all 77 `transform_codex_chat` module tests
- 2254 library tests passed, 2 ignored
- 91 other integration tests passed under `cargo test --no-fail-fast`
- the environment-sensitive `import_export_sync` binary passed 26/26 as an unprivileged user

## Checklist / 检查清单

- [x] `pnpm typecheck` not applicable; no TypeScript files changed / 不适用，未修改 TypeScript
- [x] `pnpm format:check` not applicable; no frontend files changed / 不适用，未修改前端文件
- [x] `cargo clippy` passes / Clippy 检查通过
- [x] i18n update not applicable; no user-facing text changed / 不适用，未修改用户可见文本
