### PR TITLE
feat(claude): let the Haiku role declare 1M context support

### DIFF
--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -241,7 +241,6 @@ impl ProxyService {
             "ANTHROPIC_DEFAULT_HAIKU_MODEL",
             "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
             CLAUDE_TAKEOVER_HAIKU_MODEL,
-            false,
             haiku_model,
         );
         Self::push_claude_takeover_role_fields(
@@ -250,7 +249,6 @@ impl ProxyService {
             "ANTHROPIC_DEFAULT_SONNET_MODEL",
             "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
             CLAUDE_TAKEOVER_SONNET_MODEL,
-            true,
             sonnet_model,
         );
         Self::push_claude_takeover_role_fields(
@@ -259,7 +257,6 @@ impl ProxyService {
             "ANTHROPIC_DEFAULT_OPUS_MODEL",
             "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
             CLAUDE_TAKEOVER_OPUS_MODEL,
-            true,
             opus_model,
         );
         Self::push_claude_takeover_role_fields(
@@ -268,7 +265,6 @@ impl ProxyService {
             "ANTHROPIC_DEFAULT_FABLE_MODEL",
             "ANTHROPIC_DEFAULT_FABLE_MODEL_NAME",
             CLAUDE_TAKEOVER_FABLE_MODEL,
-            true,
             fable_model,
         );
         if let Some(subagent_model) = subagent_model {
@@ -283,7 +279,6 @@ impl ProxyService {
         model_key: &'static str,
         name_key: &'static str,
         takeover_model: &'static str,
-        supports_one_m: bool,
         upstream_model: Option<&str>,
     ) {
         let Some(upstream_model) = upstream_model else {
@@ -291,7 +286,7 @@ impl ProxyService {
         };
 
         let mut client_model = takeover_model.to_string();
-        if supports_one_m && Self::has_claude_one_m_marker(upstream_model) {
+        if Self::has_claude_one_m_marker(upstream_model) {
             client_model.push_str(CLAUDE_ONE_M_MARKER_FOR_CLIENT);
         }
         fields.push((model_key, client_model));
@@ -3423,6 +3418,52 @@ mod tests {
         );
         assert_env_str(env, "ANTHROPIC_API_KEY", Some(PROXY_TOKEN_PLACEHOLDER));
         assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", None);
+    }
+
+    #[test]
+    fn claude_takeover_propagates_haiku_one_m_declaration() {
+        // Haiku 与其余档一致：上游模型带 [1M] 时，写给 Claude Code 的接管别名
+        // 也必须带上标记，否则该档仍按 200K 处理、表单上的勾选形同虚设。
+        let provider = Provider::with_id(
+            "gateway".to_string(),
+            "Gateway".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://gateway.example.com",
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-5.2[1M]",
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME": "GLM 5.2",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.2[1M]",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.2"
+                }
+            }),
+            None,
+        );
+
+        let mut live_config = provider.settings_config.clone();
+        ProxyService::apply_claude_takeover_fields_for_provider(
+            &mut live_config,
+            "http://127.0.0.1:15721",
+            &provider,
+        );
+
+        let env = live_config
+            .get("env")
+            .and_then(|value| value.as_object())
+            .expect("env should exist");
+        assert_env_str(
+            env,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            Some("claude-haiku-4-5[1M]"),
+        );
+        assert_env_str(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME", Some("GLM 5.2"));
+        assert_env_str(
+            env,
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            Some("claude-sonnet-4-6[1M]"),
+        );
+        // 未声明 1M 的档不得被牵连。
+        assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", Some("claude-opus-4-8"));
+        assert_env_str(env, "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME", Some("glm-5.2"));
     }
 
     #[test]

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -598,7 +598,6 @@ export function ClaudeFormFields({
     modelField: ClaudeModelEnvField;
     displayNameField?: ClaudeModelEnvField;
     inputId: string;
-    supportsOneM: boolean;
   };
 
   const modelRoleRows: ModelRoleRow[] = [
@@ -610,7 +609,6 @@ export function ClaudeFormFields({
       modelField: "ANTHROPIC_DEFAULT_SONNET_MODEL",
       displayNameField: "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
       inputId: "claudeDefaultSonnetModel",
-      supportsOneM: true,
     },
     {
       role: "opus",
@@ -620,7 +618,6 @@ export function ClaudeFormFields({
       modelField: "ANTHROPIC_DEFAULT_OPUS_MODEL",
       displayNameField: "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME",
       inputId: "claudeDefaultOpusModel",
-      supportsOneM: true,
     },
     {
       role: "fable",
@@ -630,7 +627,6 @@ export function ClaudeFormFields({
       modelField: "ANTHROPIC_DEFAULT_FABLE_MODEL",
       displayNameField: "ANTHROPIC_DEFAULT_FABLE_MODEL_NAME",
       inputId: "claudeDefaultFableModel",
-      supportsOneM: true,
     },
     {
       role: "haiku",
@@ -640,7 +636,6 @@ export function ClaudeFormFields({
       modelField: "ANTHROPIC_DEFAULT_HAIKU_MODEL",
       displayNameField: "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
       inputId: "claudeDefaultHaikuModel",
-      supportsOneM: false,
     },
     {
       role: "subagent",
@@ -650,26 +645,21 @@ export function ClaudeFormFields({
       model: subagentModel,
       modelField: "CLAUDE_CODE_SUBAGENT_MODEL",
       inputId: "claudeCodeSubagentModel",
-      supportsOneM: true,
     },
   ];
 
   const handleRoleModelChange = (row: ModelRoleRow, value: string) => {
     const oldModelBase = stripClaudeOneMMarker(row.model).trim();
-    const normalizedValue = row.supportsOneM
-      ? value
-      : stripClaudeOneMMarker(value);
-    const nextModelBase = stripClaudeOneMMarker(normalizedValue).trim();
+    const nextModelBase = stripClaudeOneMMarker(value).trim();
     const displayName = row.displayName?.trim() ?? "";
     const shouldSyncDisplayName = !displayName || displayName === oldModelBase;
-    onModelChange(row.modelField, normalizedValue);
+    onModelChange(row.modelField, value);
     if (row.displayNameField && shouldSyncDisplayName) {
       onModelChange(row.displayNameField, nextModelBase);
     }
   };
 
   const handleRoleOneMChange = (row: ModelRoleRow, enabled: boolean) => {
-    if (!row.supportsOneM) return;
     handleRoleModelChange(row, setClaudeOneMMarker(row.model, enabled));
   };
 
@@ -914,14 +904,11 @@ export function ClaudeFormFields({
                         subagentModel;
                       if (value) {
                         for (const row of modelRoleRows) {
-                          const roleValue = row.supportsOneM
-                            ? value
-                            : stripClaudeOneMMarker(value);
-                          onModelChange(row.modelField, roleValue);
+                          onModelChange(row.modelField, value);
                           if (row.displayNameField) {
                             onModelChange(
                               row.displayNameField,
-                              stripClaudeOneMMarker(roleValue),
+                              stripClaudeOneMMarker(value),
                             );
                           }
                         }
@@ -995,8 +982,7 @@ export function ClaudeFormFields({
 
               {modelRoleRows.map((row) => {
                 const modelBase = stripClaudeOneMMarker(row.model);
-                const usesOneM =
-                  row.supportsOneM && hasClaudeOneMMarker(row.model);
+                const usesOneM = hasClaudeOneMMarker(row.model);
 
                 return (
                   <div
@@ -1038,24 +1024,20 @@ export function ClaudeFormFields({
                       (value) =>
                         handleRoleModelChange(
                           row,
-                          row.supportsOneM
-                            ? setClaudeOneMMarker(value, usesOneM)
-                            : stripClaudeOneMMarker(value),
+                          setClaudeOneMMarker(value, usesOneM),
                         ),
                     )}
-                    {row.supportsOneM && (
-                      <label className="flex h-9 items-center gap-2 text-sm text-muted-foreground">
-                        <Checkbox
-                          checked={usesOneM}
-                          onCheckedChange={(checked) =>
-                            handleRoleOneMChange(row, checked === true)
-                          }
-                        />
-                        {t("providerForm.modelOneMLabel", {
-                          defaultValue: "1M",
-                        })}
-                      </label>
-                    )}
+                    <label className="flex h-9 items-center gap-2 text-sm text-muted-foreground">
+                      <Checkbox
+                        checked={usesOneM}
+                        onCheckedChange={(checked) =>
+                          handleRoleOneMChange(row, checked === true)
+                        }
+                      />
+                      {t("providerForm.modelOneMLabel", {
+                        defaultValue: "1M",
+                      })}
+                    </label>
                   </div>
                 );
               })}

--- a/tests/components/ClaudeFormFields.test.tsx
+++ b/tests/components/ClaudeFormFields.test.tsx
@@ -121,6 +121,20 @@ const renderCodexOauthForm = (overrides: Partial<ClaudeFormFieldsProps> = {}) =>
     ...overrides,
   });
 
+/** 取某一档模型行（按输入框 id 定位）的 1M 复选框 */
+const getRoleOneMCheckbox = (container: HTMLElement, inputId: string) => {
+  const checkbox = container
+    .querySelector(`#${inputId}`)
+    ?.closest("div.grid")
+    ?.querySelector('[role="checkbox"]');
+
+  if (!checkbox) {
+    throw new Error(`未找到 ${inputId} 所在行的 1M 复选框`);
+  }
+
+  return checkbox;
+};
+
 describe("ClaudeFormFields", () => {
   beforeEach(() => {
     copilotApiMock.copilotGetModels.mockResolvedValue([]);
@@ -193,6 +207,66 @@ describe("ClaudeFormFields", () => {
     expect(onModelChange).toHaveBeenCalledWith(
       "CLAUDE_CODE_SUBAGENT_MODEL",
       "shared-model[1M]",
+    );
+  });
+
+  it("Haiku 档可以勾选声明支持 1M", () => {
+    const onModelChange = vi.fn();
+    const { container } = renderCopilotForm({
+      defaultHaikuModel: "glm-5.2",
+      defaultHaikuModelName: "GLM 5.2",
+      onModelChange,
+    });
+
+    fireEvent.click(getRoleOneMCheckbox(container, "claudeDefaultHaikuModel"));
+
+    expect(onModelChange).toHaveBeenCalledWith(
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+      "glm-5.2[1M]",
+    );
+  });
+
+  it("Haiku 档已带 [1M] 时复选框为选中态，取消后剥离标记", () => {
+    const onModelChange = vi.fn();
+    const { container } = renderCopilotForm({
+      defaultHaikuModel: "glm-5.2[1M]",
+      defaultHaikuModelName: "GLM 5.2",
+      onModelChange,
+    });
+
+    const checkbox = getRoleOneMCheckbox(container, "claudeDefaultHaikuModel");
+    expect(checkbox).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(checkbox);
+
+    expect(onModelChange).toHaveBeenCalledWith(
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+      "glm-5.2",
+    );
+  });
+
+  it("一键设置会把 [1M] 标记一并应用到 Haiku 档", () => {
+    const onModelChange = vi.fn();
+    renderCopilotForm({
+      claudeModel: "shared-model[1M]",
+      defaultSonnetModel: "",
+      defaultSonnetModelName: "",
+      onModelChange,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "一键设置",
+      }),
+    );
+
+    expect(onModelChange).toHaveBeenCalledWith(
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+      "shared-model[1M]",
+    );
+    expect(onModelChange).toHaveBeenCalledWith(
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
+      "shared-model",
     );
   });
 });


### PR DESCRIPTION
## Summary / 概述

The Claude Code model mapping table let Sonnet, Opus, Fable and Subagent declare 1M context support, but not Haiku. The row was gated behind a per-row `supportsOneM` flag whose only `false` value was Haiku, so the checkbox was not rendered and any `[1M]` marker reaching that row was stripped.

Nothing else in the pipeline had that restriction, which is what makes the gap an inconsistency rather than a deliberate guard:

- The **Claude Desktop** form already renders the same "声明支持 1M" checkbox for every route, Haiku included (`ClaudeDesktopProviderForm.tsx`, `ROLE_ORDER = ["sonnet", "opus", "fable", "haiku"]`).
- The **Claude Code → Claude Desktop import** already translates a `[1M]` marker on `ANTHROPIC_DEFAULT_HAIKU_MODEL` into `supports1m`, because `add_route` iterates `DEFAULT_PROXY_ROUTES` and handles the marker without inspecting the role (`commands/provider.rs`).
- The **proxy** strips the marker before forwarding upstream per request, also role-agnostically (`proxy/model_mapper.rs`).

This matters for third-party gateways, where the Haiku tier is routinely mapped to a long-context upstream model — exactly the case the routing guide already describes: "模型映射每行的 `1M` 复选框会向 Claude Code 声明该档支持 1M 上下文。仅当网关确实以 100 万 token 及以上的窗口服务该模型时才勾选。"

This follows the same shape as #5124, which added the checkbox to the fallback model field for the same reason.

## Changes / 改动

**1. Form (`ClaudeFormFields.tsx`)** — the Haiku row gets the 1M checkbox. Once Haiku is included, `supportsOneM` is `true` for every row, so the flag and the six branches guarding it are removed rather than left as always-true dead conditionals.

**2. Proxy takeover (`services/proxy.rs`)** — caught by Codex review, and the reason the form change alone was not enough. Under takeover CC Switch does not write the upstream model name into `~/.claude/settings.json`; it writes a stable Claude alias per role and appends `[1M]` only when the upstream model carries the marker. That append was gated on a `supports_one_m` argument that `build_claude_takeover_model_fields` passed as `false` for Haiku alone — the backend twin of the form gate, added by f93b935d ("Preserves the `[1M]` capability marker for Sonnet/Opus"). Without this, ticking the new checkbox saved `[1M]` into `ANTHROPIC_DEFAULT_HAIKU_MODEL` but the live config still received a bare `claude-haiku-4-5`, leaving the control inert in exactly the mode most third-party users run. Same treatment: the argument is now `true` at all four call sites, so it is removed.

One other user-visible consequence: **一键设置 (quick-set) now propagates a `[1M]` marker to the Haiku row** like it already does for the other tiers, instead of silently stripping it.

No behaviour outside the Haiku role changes.

## Related Issue / 关联 Issue

Fixes #5801

## Screenshots / 截图

No screenshot attached. The visual change is confined to one cell: the Haiku row of the model mapping table now renders the same `1M` checkbox the four other rows already have, filling the previously empty fourth grid column.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码） — `cargo fmt --check` and `cargo clippy -- -D warnings` both clean
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — N/A, reuses the existing `providerForm.modelOneMLabel` key in all four locales / 复用已有键，四种语言均无需新增

### Tests / 测试

Frontend: `pnpm test:unit` passes in full (83 files, 570 tests). Three tests added to `tests/components/ClaudeFormFields.test.tsx`, each verified to fail without the source change:

- Checking the Haiku 1M box appends the marker (`glm-5.2` → `glm-5.2[1M]`).
- A Haiku model already carrying `[1M]` renders checked, and unchecking strips the marker.
- Quick-set applies `[1M]` to the Haiku row while keeping the display name clean.

Backend: `claude_takeover_propagates_haiku_one_m_declaration` added to `services/proxy.rs`, pinning `claude-haiku-4-5[1M]` for a `glm-5.2[1M]` upstream and asserting a non-1M Opus row stays bare so the fix cannot over-apply. The takeover suite passes 11/11; `cargo test` is otherwise green (2264 passed — the single unrelated failure in my local run was `Address already in use` from a CC Switch instance already holding the proxy port).
