### PR TITLE
stop skipping Claude MCP sync when config dir doesn't exist

### DIFF
--- a/src-tauri/src/mcp/claude.rs
+++ b/src-tauri/src/mcp/claude.rs
@@ -8,9 +8,11 @@ use crate::error::AppError;
 
 use super::validation::{extract_server_spec, validate_server_spec};
 
+/// Check if Claude's config locations exist on disk.
+/// Used only for removal (remove_server_from_claude) — sync operations
+/// should NOT guard on this to avoid silently skipping deployment when
+/// Claude Code hasn't been launched yet.
 fn should_sync_claude_mcp() -> bool {
-    // Claude 未安装/未初始化时：通常 ~/.claude 目录与 ~/.claude.json 都不存在。
-    // 按用户偏好：此时跳过写入/删除，不创建任何文件或目录。
     crate::config::get_claude_config_dir().exists() || crate::config::get_claude_mcp_path().exists()
 }
 
@@ -37,11 +39,13 @@ fn collect_enabled_servers(cfg: &McpConfig) -> HashMap<String, Value> {
     out
 }
 
-/// 将 config.json 中 enabled==true 的项投影写入 ~/.claude.json
+/// Project enabled servers from config.json into ~/.claude.json.
 pub fn sync_enabled_to_claude(config: &MultiAppConfig) -> Result<(), AppError> {
-    if !should_sync_claude_mcp() {
-        return Ok(());
-    }
+    // Don't guard with should_sync_claude_mcp() — when ~/.claude/ or
+    // ~/.claude.json don't exist yet (fresh Claude Code install that
+    // hasn't been launched), the guard would silently skip the write,
+    // and MCP configs configured in CC Switch are never deployed.
+    // set_mcp_servers_map already handles parent directory creation.
     let enabled = collect_enabled_servers(&config.mcp.claude);
     crate::claude_mcp::set_mcp_servers_map(&enabled)
 }
@@ -113,37 +117,37 @@ pub fn import_from_claude(config: &mut MultiAppConfig) -> Result<usize, AppError
     Ok(changed)
 }
 
-/// 将单个 MCP 服务器同步到 Claude live 配置
+/// Sync a single MCP server into Claude's live config (~/.claude.json).
 pub fn sync_single_server_to_claude(
     _config: &MultiAppConfig,
     id: &str,
     server_spec: &Value,
 ) -> Result<(), AppError> {
-    if !should_sync_claude_mcp() {
-        return Ok(());
-    }
-    // 读取现有的 MCP 配置
+    // Don't guard with should_sync_claude_mcp() — see sync_enabled_to_claude.
+    // Read the existing MCP config
     let current = crate::claude_mcp::read_mcp_servers_map()?;
 
-    // 创建新的 HashMap，包含现有的所有服务器 + 当前要同步的服务器
+    // Merge the server we're syncing with existing servers
     let mut updated = current;
     updated.insert(id.to_string(), server_spec.clone());
 
-    // 写回
+    // Write back
     crate::claude_mcp::set_mcp_servers_map(&updated)
 }
 
-/// 从 Claude live 配置中移除单个 MCP 服务器
+/// Remove a single MCP server from Claude's live config (~/.claude.json).
+/// If the config doesn't exist, there's nothing to remove — return Ok early.
 pub fn remove_server_from_claude(id: &str) -> Result<(), AppError> {
     if !should_sync_claude_mcp() {
+        log::debug!("Skipping MCP removal from Claude: config does not exist");
         return Ok(());
     }
-    // 读取现有的 MCP 配置
+    // Read the existing MCP config
     let mut current = crate::claude_mcp::read_mcp_servers_map()?;
 
-    // 移除指定服务器
+    // Remove the specified server
     current.remove(id);
 
-    // 写回
+    // Write back
     crate::claude_mcp::set_mcp_servers_map(&current)
 }

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -855,14 +855,15 @@ fn enabling_gemini_mcp_skips_when_gemini_dir_missing() {
 }
 
 #[test]
-fn enabling_claude_mcp_skips_when_claude_config_absent() {
+fn enabling_claude_mcp_creates_config_when_claude_config_absent() {
     use support::create_test_state;
 
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();
     let home = ensure_test_home();
 
-    // 确认 Claude 相关目录/文件都不存在（模拟“未安装/未运行过 Claude”）
+    // Verify Claude config locations don't exist (simulating fresh Claude install
+    // that hasn't been launched yet)
     assert!(
         !home.join(".claude").exists(),
         "~/.claude should not exist in fresh test environment"
@@ -874,7 +875,11 @@ fn enabling_claude_mcp_skips_when_claude_config_absent() {
 
     let state = create_test_state().expect("create test state");
 
-    // 先插入一个未启用 Claude 的 MCP 服务器（避免 upsert 触发同步）
+    // Insert a server with Claude disabled first, then toggle on.
+    // Previously the toggle was silently skipped (the old guard refused to
+    // create ~/.claude.json), so users who configured CC Switch before ever
+    // launching Claude Code never got their MCP servers deployed.
+    // After the fix: toggle creates ~/.claude.json with the enabled server.
     McpService::upsert_server(
         &state,
         McpServer {
@@ -900,13 +905,25 @@ fn enabling_claude_mcp_skips_when_claude_config_absent() {
     )
     .expect("insert server without syncing");
 
-    // 启用 Claude：配置缺失时应跳过写入（不创建 ~/.claude.json）
+    // Toggle Claude on — should now CREATE the config instead of skipping
     McpService::toggle_app(&state, "claude-server", AppType::Claude, true)
-        .expect("toggle claude should succeed even when ~/.claude is missing");
+        .expect("toggle claude should succeed and create ~/.claude.json");
 
     assert!(
-        !home.join(".claude.json").exists(),
-        "~/.claude.json should still not exist after skipped sync"
+        home.join(".claude.json").exists(),
+        "~/.claude.json should now exist — toggle must create it rather than silently skip"
+    );
+
+    // Verify the server was actually written
+    let text = fs::read_to_string(home.join(".claude.json")).expect("read ~/.claude.json");
+    let value: serde_json::Value = serde_json::from_str(&text).expect("parse ~/.claude.json");
+    let servers = value
+        .get("mcpServers")
+        .and_then(|v| v.as_object())
+        .expect("mcpServers object");
+    assert!(
+        servers.contains_key("claude-server"),
+        "claude-server should be present in ~/.claude.json after toggle"
     );
 }
 


### PR DESCRIPTION
The guard function should_sync_claude_mcp() was used to skip both sync and remove operations when ~/.claude/ or ~/.claude.json don't exist yet. This meant users who configured CC Switch before ever launching Claude Code never had their MCP servers deployed — the sync returned Ok without writing anything.

Fix: remove the guard from sync_enabled_to_claude and sync_single_server_to_claude. The underlying write_json_value already handles creating parent directories. Keep the guard only on remove_server_from_claude (nothing to remove from a nonexistent file).

Updated the corresponding integration test to verify that the config file IS created when toggling a server onto a fresh Claude install.

## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|                 |               |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
