### PR TITLE
feat(pi): add safe official Pi provider management

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -33,6 +33,7 @@ impl McpApps {
             AppType::OpenClaw => false, // OpenClaw doesn't support MCP
             AppType::Hermes => self.hermes,
             AppType::ClaudeDesktop => false,
+            AppType::Pi => false,
         }
     }
 
@@ -47,6 +48,7 @@ impl McpApps {
             AppType::OpenClaw => {} // OpenClaw doesn't support MCP, ignore
             AppType::Hermes => self.hermes = enabled,
             AppType::ClaudeDesktop => {} // Claude Desktop 3P provider config doesn't support MCP here
+            AppType::Pi => {}            // Pi Agent MCP sync is not supported
         }
     }
 
@@ -114,6 +116,7 @@ impl SkillApps {
             AppType::Hermes => self.hermes,
             AppType::OpenClaw => false, // OpenClaw doesn't support Skills
             AppType::ClaudeDesktop => false,
+            AppType::Pi => false,
         }
     }
 
@@ -128,6 +131,7 @@ impl SkillApps {
             AppType::Hermes => self.hermes = enabled,
             AppType::OpenClaw => {} // OpenClaw doesn't support Skills, ignore
             AppType::ClaudeDesktop => {} // Claude Desktop 3P profiles don't use CC Switch skill sync
+            AppType::Pi => {}            // Pi Agent skill sync is not supported
         }
     }
 
@@ -306,6 +310,9 @@ pub struct McpRoot {
     /// Hermes MCP 配置（实际使用 config.yaml）
     #[serde(default, skip_serializing_if = "McpConfig::is_empty")]
     pub hermes: McpConfig,
+    /// Pi Agent does not support MCP sync; retained only so AppType matches are total.
+    #[serde(default, skip_serializing_if = "McpConfig::is_empty")]
+    pub pi: McpConfig,
 }
 
 impl Default for McpRoot {
@@ -322,6 +329,7 @@ impl Default for McpRoot {
             opencode: McpConfig::default(),
             openclaw: McpConfig::default(),
             hermes: McpConfig::default(),
+            pi: McpConfig::default(),
         }
     }
 }
@@ -381,6 +389,7 @@ pub enum AppType {
     OpenCode,
     OpenClaw,
     Hermes,
+    Pi,
 }
 
 impl AppType {
@@ -394,6 +403,7 @@ impl AppType {
             AppType::OpenCode => "opencode",
             AppType::OpenClaw => "openclaw",
             AppType::Hermes => "hermes",
+            AppType::Pi => "pi",
         }
     }
 
@@ -419,6 +429,7 @@ impl AppType {
             AppType::OpenCode,
             AppType::OpenClaw,
             AppType::Hermes,
+            AppType::Pi,
         ]
         .into_iter()
     }
@@ -438,10 +449,11 @@ impl FromStr for AppType {
             "opencode" => Ok(AppType::OpenCode),
             "openclaw" => Ok(AppType::OpenClaw),
             "hermes" => Ok(AppType::Hermes),
+            "pi" => Ok(AppType::Pi),
             other => Err(AppError::localized(
                 "unsupported_app",
-                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes。"),
-                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes."),
+                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi。"),
+                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi."),
             )),
         }
     }
@@ -481,6 +493,7 @@ impl CommonConfigSnippets {
             AppType::OpenCode => self.opencode.as_ref(),
             AppType::OpenClaw => self.openclaw.as_ref(),
             AppType::Hermes => self.hermes.as_ref(),
+            AppType::Pi => None,
         }
     }
 
@@ -495,6 +508,7 @@ impl CommonConfigSnippets {
             AppType::OpenCode => self.opencode = snippet,
             AppType::OpenClaw => self.openclaw = snippet,
             AppType::Hermes => self.hermes = snippet,
+            AppType::Pi => {}
         }
     }
 }
@@ -539,6 +553,7 @@ impl Default for MultiAppConfig {
         apps.insert("opencode".to_string(), ProviderManager::default());
         apps.insert("openclaw".to_string(), ProviderManager::default());
         apps.insert("hermes".to_string(), ProviderManager::default());
+        apps.insert("pi".to_string(), ProviderManager::default());
 
         Self {
             version: 2,
@@ -619,12 +634,14 @@ impl MultiAppConfig {
             }
         }
 
-        // 确保 gemini 应用存在（兼容旧配置文件）
-        if !config.apps.contains_key("gemini") {
-            config
-                .apps
-                .insert("gemini".to_string(), ProviderManager::default());
-            updated = true;
+        // 确保后续版本新增的应用存在（兼容旧配置文件）
+        for app_id in ["gemini", "pi"] {
+            if !config.apps.contains_key(app_id) {
+                config
+                    .apps
+                    .insert(app_id.to_string(), ProviderManager::default());
+                updated = true;
+            }
         }
 
         // 执行 MCP 迁移（v3.6.x → v3.7.0）
@@ -702,6 +719,7 @@ impl MultiAppConfig {
             AppType::OpenCode => &self.mcp.opencode,
             AppType::OpenClaw => &self.mcp.openclaw,
             AppType::Hermes => &self.mcp.hermes,
+            AppType::Pi => &self.mcp.pi,
         }
     }
 
@@ -716,6 +734,7 @@ impl MultiAppConfig {
             AppType::OpenCode => &mut self.mcp.opencode,
             AppType::OpenClaw => &mut self.mcp.openclaw,
             AppType::Hermes => &mut self.mcp.hermes,
+            AppType::Pi => &mut self.mcp.pi,
         }
     }
 
@@ -846,6 +865,7 @@ impl MultiAppConfig {
             AppType::OpenCode => &mut config.prompts.opencode.prompts,
             AppType::OpenClaw => &mut config.prompts.openclaw.prompts,
             AppType::Hermes => &mut config.prompts.hermes.prompts,
+            AppType::Pi => unreachable!("Pi prompt import is not supported"),
         };
 
         prompts.insert(id, prompt);
@@ -889,6 +909,7 @@ impl MultiAppConfig {
                 AppType::OpenCode => &self.mcp.opencode.servers,
                 AppType::OpenClaw => continue, // OpenClaw MCP is still in development, skip
                 AppType::Hermes => continue,   // Hermes didn't exist in v3.6.x, skip
+                AppType::Pi => continue,       // Pi Agent MCP sync is not supported
             };
 
             for (id, entry) in old_servers {
@@ -1019,6 +1040,25 @@ mod tests {
             AppType::ClaudeDesktop
         );
         assert_eq!(AppType::ClaudeDesktop.as_str(), "claude-desktop");
+    }
+
+    #[test]
+    fn app_type_parses_pi() {
+        assert_eq!("pi".parse::<AppType>().unwrap(), AppType::Pi);
+        assert_eq!(AppType::Pi.as_str(), "pi");
+        assert!(
+            AppType::all().any(|app| app == AppType::Pi),
+            "Pi should be included in global app iteration"
+        );
+    }
+
+    #[test]
+    fn default_config_contains_pi_provider_manager() {
+        let config = MultiAppConfig::default();
+        assert!(
+            config.get_manager(&AppType::Pi).is_some(),
+            "default config should include a Pi provider manager"
+        );
     }
 
     struct TempHome {

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -418,6 +418,15 @@ impl AppType {
         )
     }
 
+    /// Whether multiple providers coexist in the application's live registry.
+    ///
+    /// Pi is intentionally included here even though it is not an additive-mode
+    /// app: it keeps an additive provider registry while also tracking an active
+    /// default provider/model.
+    pub fn uses_additive_provider_registry(&self) -> bool {
+        self.is_additive_mode() || matches!(self, AppType::Pi)
+    }
+
     /// Return an iterator over all app types
     pub fn all() -> impl Iterator<Item = AppType> {
         [
@@ -1050,6 +1059,8 @@ mod tests {
             AppType::all().any(|app| app == AppType::Pi),
             "Pi should be included in global app iteration"
         );
+        assert!(!AppType::Pi.is_additive_mode());
+        assert!(AppType::Pi.uses_additive_provider_registry());
     }
 
     #[test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -135,6 +135,14 @@ pub async fn get_config_status(
 
             Ok(ConfigStatus { exists, path })
         }
+        AppType::Pi => {
+            let models_path = crate::pi_config::get_pi_models_path();
+            let settings_path = crate::pi_config::get_pi_settings_path();
+            let exists = models_path.exists() || settings_path.exists();
+            let path = crate::pi_config::get_pi_dir().to_string_lossy().to_string();
+
+            Ok(ConfigStatus { exists, path })
+        }
     }
 }
 
@@ -156,6 +164,7 @@ pub async fn get_config_dir(app: String) -> Result<String, String> {
         AppType::OpenCode => crate::opencode_config::get_opencode_dir(),
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
+        AppType::Pi => crate::pi_config::get_pi_dir(),
     };
 
     Ok(dir.to_string_lossy().to_string())
@@ -174,6 +183,7 @@ pub async fn open_config_folder(handle: AppHandle, app: String) -> Result<bool, 
         AppType::OpenCode => crate::opencode_config::get_opencode_dir(),
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
+        AppType::Pi => crate::pi_config::get_pi_dir(),
     };
 
     if !config_dir.exists() {

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -81,10 +81,10 @@ fn parse_provider_deeplink(
     // Validate app type
     if !matches!(
         app.as_str(),
-        "claude" | "codex" | "gemini" | "grokbuild" | "opencode" | "openclaw" | "hermes"
+        "claude" | "codex" | "gemini" | "grokbuild" | "opencode" | "openclaw" | "hermes" | "pi"
     ) {
         return Err(AppError::InvalidInput(format!(
-            "Invalid app type: must be 'claude', 'codex', 'gemini', 'grokbuild', 'opencode', 'openclaw', or 'hermes', got '{app}'"
+            "Invalid app type: must be 'claude', 'codex', 'gemini', 'grokbuild', 'opencode', 'openclaw', 'hermes', or 'pi', got '{app}'"
         )));
     }
 

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -152,6 +152,7 @@ pub(crate) fn build_provider_from_request(
         AppType::OpenCode => build_opencode_settings(request),
         AppType::OpenClaw => build_additive_app_settings(request),
         AppType::Hermes => build_hermes_settings(request),
+        AppType::Pi => build_pi_settings(request),
     };
 
     // Build usage script configuration if provided
@@ -542,6 +543,56 @@ fn build_additive_app_settings(request: &DeepLinkImportRequest) -> serde_json::V
     json!(config)
 }
 
+/// Build settings for Pi Agent.
+/// Format: { baseUrl, apiKey, api, models, defaultModel }
+fn build_pi_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
+    let endpoint = get_primary_endpoint(request);
+    let mut config = extract_pi_config_object(request).unwrap_or_default();
+
+    if !endpoint.is_empty() {
+        config.insert("baseUrl".to_string(), json!(endpoint));
+        config.remove("baseURL");
+        config.remove("base_url");
+    }
+
+    if let Some(api_key) = &request.api_key {
+        config.insert("apiKey".to_string(), json!(api_key));
+        config.remove("api_key");
+    }
+
+    config
+        .entry("api".to_string())
+        .or_insert_with(|| json!("openai-completions"));
+
+    if let Some(model) = &request.model {
+        config.insert(
+            "models".to_string(),
+            json!([{ "id": model, "name": model }]),
+        );
+        config.insert("defaultModel".to_string(), json!(model));
+    }
+
+    json!(config)
+}
+
+fn extract_pi_config_object(
+    request: &DeepLinkImportRequest,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let config_b64 = request.config.as_ref()?;
+    let decoded = decode_base64_param("config", config_b64).ok()?;
+    let content = std::str::from_utf8(&decoded).ok()?;
+    let value = match request.config_format.as_deref().unwrap_or("json") {
+        "json" => serde_json::from_str(content).ok()?,
+        "toml" => {
+            let value: toml::Value = toml::from_str(content).ok()?;
+            serde_json::to_value(value).ok()?
+        }
+        _ => return None,
+    };
+
+    value.as_object().cloned()
+}
+
 /// Build Hermes provider settings (snake_case YAML-native fields).
 ///
 /// Hermes' `custom_providers:` entries use `base_url` / `api_key` / `api_mode`
@@ -646,7 +697,7 @@ pub fn parse_and_merge_config(
         "gemini" => merge_gemini_config(&mut merged, &config_value)?,
         "grokbuild" => merge_grokbuild_config(&mut merged, &config_value)?,
         // Additive mode apps use JSON config directly; pass through as-is
-        "openclaw" | "opencode" | "hermes" => {
+        "openclaw" | "opencode" | "hermes" | "pi" => {
             merge_additive_config(&mut merged, &config_value)?;
         }
         "" => {
@@ -917,6 +968,7 @@ fn merge_additive_config(
     if request.endpoint.as_ref().is_none_or(|s| s.is_empty()) {
         if let Some(base_url) = config
             .get("baseUrl")
+            .or_else(|| config.get("baseURL"))
             .or_else(|| config.get("base_url"))
             .or_else(|| config.get("options").and_then(|o| o.get("baseURL")))
             .and_then(|v| v.as_str())
@@ -1178,5 +1230,30 @@ mod tests {
         let obj = settings.as_object().unwrap();
         assert!(obj.contains_key("baseUrl"));
         assert!(obj.contains_key("apiKey"));
+    }
+
+    #[test]
+    fn build_pi_settings_uses_pi_protocol_defaults() {
+        let request = DeepLinkImportRequest {
+            resource: "provider".to_string(),
+            app: Some("pi".to_string()),
+            name: Some("Pi Provider".to_string()),
+            endpoint: Some("https://api.example.com/v1".to_string()),
+            api_key: Some("sk-pi".to_string()),
+            model: Some("gpt-5.5".to_string()),
+            ..Default::default()
+        };
+
+        let provider = build_provider_from_request(&AppType::Pi, &request).unwrap();
+        let obj = provider.settings_config.as_object().unwrap();
+
+        assert_eq!(obj.get("baseUrl").unwrap(), "https://api.example.com/v1");
+        assert_eq!(obj.get("apiKey").unwrap(), "sk-pi");
+        assert_eq!(obj.get("api").unwrap(), "openai-completions");
+        assert_eq!(
+            provider.settings_config.pointer("/models/0/id"),
+            Some(&json!("gpt-5.5"))
+        );
+        assert_eq!(obj.get("defaultModel"), Some(&json!("gpt-5.5")));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ mod model_capabilities;
 mod openclaw_config;
 mod opencode_config;
 mod panic_hook;
+pub mod pi_config;
 mod prompt;
 mod prompt_files;
 mod provider;

--- a/src-tauri/src/pi_config.rs
+++ b/src-tauri/src/pi_config.rs
@@ -1,0 +1,271 @@
+//! Pi Agent live configuration helpers.
+//!
+//! Pi keeps model providers in `models.json` and the active provider/model in
+//! `settings.json` under `~/.pi/agent` by default.
+
+use serde_json::{json, Map, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::config::{get_home_dir, write_json_file};
+use crate::error::AppError;
+use crate::provider::Provider;
+
+pub fn get_pi_dir() -> PathBuf {
+    if let Some(override_dir) = crate::settings::get_pi_override_dir() {
+        return override_dir;
+    }
+
+    if let Some(raw) = std::env::var_os("PI_CODING_AGENT_DIR") {
+        let value = raw.to_string_lossy();
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+
+    get_home_dir().join(".pi").join("agent")
+}
+
+pub fn get_pi_models_path() -> PathBuf {
+    get_pi_dir().join("models.json")
+}
+
+pub fn get_pi_settings_path() -> PathBuf {
+    get_pi_dir().join("settings.json")
+}
+
+fn read_json_or_empty_object(path: &Path) -> Result<Value, AppError> {
+    if !path.exists() {
+        return Ok(Value::Object(Map::new()));
+    }
+
+    let content = fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
+    if content.trim().is_empty() {
+        return Ok(Value::Object(Map::new()));
+    }
+
+    serde_json::from_str(&content).map_err(|e| AppError::json(path, e))
+}
+
+fn object_mut<'a>(
+    value: &'a mut Value,
+    path: &Path,
+    description: &str,
+) -> Result<&'a mut Map<String, Value>, AppError> {
+    value.as_object_mut().ok_or_else(|| {
+        AppError::Config(format!(
+            "{description} must be a JSON object: {}",
+            path.display()
+        ))
+    })
+}
+
+fn first_string<'a>(object: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn model_ids_from_config(config: &Value) -> Vec<String> {
+    config
+        .get("models")
+        .and_then(Value::as_array)
+        .map(|models| {
+            models
+                .iter()
+                .filter_map(|model| match model {
+                    Value::String(id) => Some(id.as_str()),
+                    Value::Object(obj) => obj.get("id").and_then(Value::as_str),
+                    _ => None,
+                })
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn normalized_models_from_config(config: &Value) -> Option<Vec<Value>> {
+    config
+        .get("models")
+        .and_then(Value::as_array)
+        .map(|models| {
+            models
+                .iter()
+                .filter_map(|model| match model {
+                    Value::String(id) => {
+                        let id = id.trim();
+                        (!id.is_empty()).then(|| Value::String(id.to_string()))
+                    }
+                    Value::Object(object) => {
+                        let id = object.get("id").and_then(Value::as_str)?.trim();
+                        if id.is_empty() {
+                            return None;
+                        }
+
+                        let mut normalized = object.clone();
+                        normalized.insert("id".to_string(), Value::String(id.to_string()));
+                        Some(Value::Object(normalized))
+                    }
+                    _ => None,
+                })
+                .collect()
+        })
+}
+
+fn normalize_provider_config(config: &Value) -> Result<Value, AppError> {
+    let Some(source) = config.as_object() else {
+        return Err(AppError::Config(
+            "Pi provider settings must be a JSON object".to_string(),
+        ));
+    };
+
+    let mut output = source.clone();
+
+    if let Some(base_url) = first_string(source, &["baseUrl", "baseURL"]) {
+        output.insert("baseUrl".to_string(), Value::String(base_url.to_string()));
+        output.remove("baseURL");
+    }
+
+    if let Some(models) = normalized_models_from_config(config) {
+        output.insert("models".to_string(), Value::Array(models));
+    }
+
+    // Pi stores the selected model in settings.json, not per provider.
+    output.remove("defaultModel");
+
+    Ok(Value::Object(output))
+}
+
+fn default_model_for_provider(config: &Value) -> Option<String> {
+    config
+        .get("defaultModel")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| model_ids_from_config(config).into_iter().next())
+}
+
+pub fn write_pi_live_provider(provider: &Provider) -> Result<(), AppError> {
+    let models_path = get_pi_models_path();
+    let settings_path = get_pi_settings_path();
+
+    let mut models_root = read_json_or_empty_object(&models_path)?;
+    let root = object_mut(&mut models_root, &models_path, "Pi models.json root")?;
+    let providers = root
+        .entry("providers".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    object_mut(providers, &models_path, "Pi models.json providers")?.insert(
+        provider.id.clone(),
+        normalize_provider_config(&provider.settings_config)?,
+    );
+    write_json_file(&models_path, &models_root)?;
+
+    let mut settings_root = read_json_or_empty_object(&settings_path)?;
+    let settings = object_mut(&mut settings_root, &settings_path, "Pi settings.json root")?;
+    settings.insert(
+        "defaultProvider".to_string(),
+        Value::String(provider.id.clone()),
+    );
+    if let Some(default_model) = default_model_for_provider(&provider.settings_config) {
+        settings.insert("defaultModel".to_string(), Value::String(default_model));
+    } else {
+        settings.remove("defaultModel");
+    }
+    write_json_file(&settings_path, &settings_root)?;
+
+    Ok(())
+}
+
+fn provider_models_for_form(provider_config: &Value) -> Value {
+    let models = provider_config
+        .get("models")
+        .and_then(Value::as_array)
+        .map(|models| {
+            models
+                .iter()
+                .filter_map(|model| match model {
+                    Value::String(id) => Some(json!({ "id": id })),
+                    Value::Object(obj) => Some(Value::Object(obj.clone())),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Value::Array(models)
+}
+
+pub fn read_pi_live_settings() -> Result<Value, AppError> {
+    let models_path = get_pi_models_path();
+    let settings_path = get_pi_settings_path();
+    let models_root = read_json_or_empty_object(&models_path)?;
+    let settings_root = read_json_or_empty_object(&settings_path)?;
+
+    let default_provider = settings_root
+        .get("defaultProvider")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if default_provider.is_empty() {
+        return Err(AppError::Config(
+            "Pi settings.json does not define defaultProvider".to_string(),
+        ));
+    }
+
+    let provider_config = models_root
+        .get("providers")
+        .and_then(Value::as_object)
+        .and_then(|providers| providers.get(default_provider))
+        .ok_or_else(|| {
+            AppError::Config(format!(
+                "Pi models.json does not define provider '{default_provider}'"
+            ))
+        })?;
+
+    let mut form_config = provider_config.clone();
+    if let Some(obj) = form_config.as_object_mut() {
+        if let Some(base_url) = obj.get("baseURL").cloned() {
+            obj.insert("baseUrl".to_string(), base_url);
+        }
+        obj.insert(
+            "models".to_string(),
+            provider_models_for_form(provider_config),
+        );
+    }
+
+    Ok(json!({
+        "defaultProvider": default_provider,
+        "defaultModel": settings_root.get("defaultModel").cloned().unwrap_or(Value::Null),
+        "providerConfig": form_config
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_provider_config_writes_pi_base_url_key() {
+        let config = json!({
+            "baseURL": "https://api.example.com/v1",
+            "apiKey": "sk-test",
+            "api": "openai-completions",
+            "models": []
+        });
+
+        let normalized = normalize_provider_config(&config).unwrap();
+
+        assert_eq!(
+            normalized.get("baseUrl"),
+            Some(&json!("https://api.example.com/v1"))
+        );
+        assert!(
+            normalized.get("baseURL").is_none(),
+            "Pi models.json must use baseUrl, not baseURL"
+        );
+    }
+}

--- a/src-tauri/src/pi_config.rs
+++ b/src-tauri/src/pi_config.rs
@@ -1,8 +1,14 @@
 //! Pi Agent live configuration helpers.
 //!
-//! Pi keeps model providers in `models.json` and the active provider/model in
-//! `settings.json` under `~/.pi/agent` by default.
+//! Pi keeps model providers in `models.json`, credentials in `auth.json`, and
+//! the active provider/model in `settings.json` under `~/.pi/agent` by default.
 
+use json_five::rt::parser::{
+    from_str as parse_round_trip, JSONKeyValuePair, JSONObjectContext,
+    JSONText as RoundTripDocument, JSONValue as RoundTripValue, KeyValuePairContext,
+};
+use json_five::tokenize::TokType;
+use json_five::{source_to_tokens, tokens_to_source};
 use serde_json::{json, Map, Value};
 use std::collections::HashSet;
 use std::fs;
@@ -10,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::config::{atomic_write, get_app_config_dir, get_home_dir, write_json_file};
+use crate::config::{atomic_write, get_app_config_dir, get_home_dir};
 use crate::error::AppError;
 use crate::provider::Provider;
 
@@ -19,12 +25,26 @@ struct JsonFileSnapshot {
     path: PathBuf,
     raw: Option<Vec<u8>>,
     value: Value,
+    kind: JsonFileKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum JsonFileKind {
+    ModelsJsonc,
+    Json,
 }
 
 #[derive(Clone, Copy)]
 struct PendingDocument<'a> {
     snapshot: &'a JsonFileSnapshot,
-    next: &'a Value,
+    next: &'a [u8],
+    secure_if_new: bool,
+}
+
+#[derive(Clone, Debug)]
+enum ModelsMutation {
+    Upsert { provider_id: String, config: Value },
+    Remove { provider_id: String },
 }
 
 fn pi_config_lock() -> &'static Mutex<()> {
@@ -62,7 +82,91 @@ pub fn get_pi_settings_path() -> PathBuf {
     get_pi_dir().join("settings.json")
 }
 
-fn read_snapshot(path: &Path) -> Result<JsonFileSnapshot, AppError> {
+pub fn get_pi_auth_path() -> PathBuf {
+    get_pi_dir().join("auth.json")
+}
+
+fn jsonc_error(path: &Path, message: impl std::fmt::Display) -> AppError {
+    AppError::Config(format!(
+        "Pi models.json is not valid Pi JSONC (double-quoted JSON with // comments and trailing commas): {}: {message}",
+        path.display()
+    ))
+}
+
+fn parse_pi_jsonc(path: &Path, raw: &[u8]) -> Result<Value, AppError> {
+    let source = std::str::from_utf8(raw)
+        .map_err(|error| jsonc_error(path, format!("invalid UTF-8: {error}")))?;
+    let tokens = source_to_tokens(source).map_err(|error| jsonc_error(path, error))?;
+
+    for token in &tokens {
+        let unsupported = match token.tok_type {
+            TokType::Name => Some("unquoted object keys"),
+            TokType::SingleQuotedString => Some("single-quoted strings"),
+            TokType::BlockComment => Some("block comments"),
+            TokType::Infinity | TokType::Nan | TokType::Hexadecimal | TokType::Plus => {
+                Some("JSON5 number syntax")
+            }
+            _ => None,
+        };
+        if let Some(feature) = unsupported {
+            return Err(jsonc_error(
+                path,
+                format!(
+                    "{feature} are not supported (line {})",
+                    token.context.as_ref().map_or(1, |ctx| ctx.start_lineno)
+                ),
+            ));
+        }
+    }
+
+    let mut json_tokens = Vec::with_capacity(tokens.len());
+    for (index, token) in tokens.iter().enumerate() {
+        if token.tok_type == TokType::LineComment {
+            let mut replacement = token.clone();
+            replacement.lexeme = token
+                .lexeme
+                .chars()
+                .filter(|character| matches!(character, '\r' | '\n'))
+                .collect();
+            json_tokens.push(replacement);
+            continue;
+        }
+        if token.tok_type == TokType::Comma {
+            let next_significant = tokens[index + 1..].iter().find(|candidate| {
+                !matches!(
+                    candidate.tok_type,
+                    TokType::Whitespace | TokType::LineComment
+                )
+            });
+            if next_significant.is_some_and(|candidate| {
+                matches!(
+                    candidate.tok_type,
+                    TokType::RightBrace | TokType::RightBracket
+                )
+            }) {
+                continue;
+            }
+        }
+        json_tokens.push(token.clone());
+    }
+
+    let json_source = tokens_to_source(&json_tokens);
+    serde_json::from_str(&json_source).map_err(|error| jsonc_error(path, error))
+}
+
+fn parse_snapshot_value(path: &Path, raw: &[u8], kind: JsonFileKind) -> Result<Value, AppError> {
+    if raw.iter().all(|byte| byte.is_ascii_whitespace()) {
+        return Ok(Value::Object(Map::new()));
+    }
+    match kind {
+        JsonFileKind::ModelsJsonc => parse_pi_jsonc(path, raw),
+        JsonFileKind::Json => {
+            serde_json::from_slice(raw).map_err(|error| AppError::json(path, error))
+        }
+    }
+}
+
+fn read_snapshot(path: &Path, kind: JsonFileKind) -> Result<JsonFileSnapshot, AppError> {
     let raw = match fs::read(path) {
         Ok(raw) => Some(raw),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
@@ -70,19 +174,19 @@ fn read_snapshot(path: &Path) -> Result<JsonFileSnapshot, AppError> {
     };
     let value = match raw.as_deref() {
         None => Value::Object(Map::new()),
-        Some(raw) if raw.iter().all(|byte| byte.is_ascii_whitespace()) => Value::Object(Map::new()),
-        Some(raw) => serde_json::from_slice(raw).map_err(|error| AppError::json(path, error))?,
+        Some(raw) => parse_snapshot_value(path, raw, kind)?,
     };
 
     Ok(JsonFileSnapshot {
         path: path.to_path_buf(),
         raw,
         value,
+        kind,
     })
 }
 
-fn read_json_or_empty_object(path: &Path) -> Result<Value, AppError> {
-    read_snapshot(path).map(|snapshot| snapshot.value)
+fn read_json_or_empty_object(path: &Path, kind: JsonFileKind) -> Result<Value, AppError> {
+    read_snapshot(path, kind).map(|snapshot| snapshot.value)
 }
 
 fn current_raw(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
@@ -177,12 +281,23 @@ fn create_backup(snapshots: &[&JsonFileSnapshot]) -> Result<(), AppError> {
     cleanup_backups(&backup_root)
 }
 
+fn write_pending_document(document: &PendingDocument<'_>) -> Result<(), AppError> {
+    atomic_write(&document.snapshot.path, document.next)?;
+    #[cfg(unix)]
+    if document.secure_if_new && document.snapshot.raw.is_none() {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&document.snapshot.path, fs::Permissions::from_mode(0o600))
+            .map_err(|error| AppError::io(&document.snapshot.path, error))?;
+    }
+    Ok(())
+}
+
 fn apply_documents_with<F>(documents: &[PendingDocument<'_>], mut writer: F) -> Result<(), AppError>
 where
-    F: FnMut(&Path, &Value) -> Result<(), AppError>,
+    F: FnMut(&PendingDocument<'_>) -> Result<(), AppError>,
 {
     for (index, document) in documents.iter().enumerate() {
-        if let Err(operation_error) = writer(&document.snapshot.path, document.next) {
+        if let Err(operation_error) = writer(document) {
             let rollback_errors = documents[..=index]
                 .iter()
                 .rev()
@@ -205,38 +320,293 @@ where
     Ok(())
 }
 
-fn commit_documents(
-    models_snapshot: &JsonFileSnapshot,
-    models_next: &Value,
-    settings: Option<(&JsonFileSnapshot, &Value)>,
+fn serialize_json(value: &Value) -> Result<Vec<u8>, AppError> {
+    serde_json::to_vec_pretty(value).map_err(|source| AppError::JsonSerialize { source })
+}
+
+fn round_trip_key_name(key: &RoundTripValue) -> Option<String> {
+    let RoundTripValue::DoubleQuotedString(raw) = key else {
+        return None;
+    };
+    serde_json::from_str::<String>(&format!("\"{raw}\"")).ok()
+}
+
+fn parse_round_trip_value(value: &Value, base_indent: usize) -> Result<RoundTripValue, AppError> {
+    let source =
+        serde_json::to_string_pretty(value).map_err(|source| AppError::JsonSerialize { source })?;
+    let indent = " ".repeat(base_indent);
+    let source = source.replace('\n', &format!("\n{indent}"));
+    parse_round_trip(&source)
+        .map(|document| document.value)
+        .map_err(|error| AppError::Config(format!("Failed to build Pi models.json value: {error}")))
+}
+
+fn parse_round_trip_key(key: &str) -> Result<RoundTripValue, AppError> {
+    let source = serde_json::to_string(key).map_err(|source| AppError::JsonSerialize { source })?;
+    parse_round_trip(&source)
+        .map(|document| document.value)
+        .map_err(|error| AppError::Config(format!("Failed to build Pi provider key: {error}")))
+}
+
+fn separator_for(wsc: &str, indent: usize) -> String {
+    if wsc.is_empty() || wsc.contains('\n') || wsc.contains('\r') {
+        format!("\n{}", " ".repeat(indent))
+    } else {
+        " ".to_string()
+    }
+}
+
+fn object_parts_mut(
+    value: &mut RoundTripValue,
+) -> Result<(&mut Vec<JSONKeyValuePair>, &mut JSONObjectContext), AppError> {
+    match value {
+        RoundTripValue::JSONObject {
+            key_value_pairs,
+            context: Some(context),
+        } => Ok((key_value_pairs, context)),
+        _ => Err(AppError::Config(
+            "Pi models.json providers must be a JSON object".to_string(),
+        )),
+    }
+}
+
+fn append_object_pair(
+    object: &mut RoundTripValue,
+    key: &str,
+    value: RoundTripValue,
+    child_indent: usize,
 ) -> Result<(), AppError> {
-    let models_changed = models_next != &models_snapshot.value;
-    let settings_changed = settings.is_some_and(|(snapshot, next)| next != &snapshot.value);
-    if !models_changed && !settings_changed {
+    let (pairs, object_context) = object_parts_mut(object)?;
+    let default_closing = format!("\n{}", " ".repeat(child_indent.saturating_sub(2)));
+
+    let new_context = if let Some(last) = pairs.last_mut() {
+        let context = last.context.as_mut().ok_or_else(|| {
+            AppError::Config("Pi models.json round-trip context is missing".to_string())
+        })?;
+        let had_trailing_comma = context.wsc.3.is_some();
+        let closing = if let Some(after_comma) = context.wsc.3.take() {
+            after_comma
+        } else {
+            std::mem::take(&mut context.wsc.2)
+        };
+        let separator = separator_for(&closing, child_indent);
+        context.wsc.3 = Some(separator);
+
+        if had_trailing_comma {
+            KeyValuePairContext {
+                wsc: (String::new(), " ".to_string(), String::new(), Some(closing)),
+            }
+        } else {
+            KeyValuePairContext {
+                wsc: (String::new(), " ".to_string(), closing, None),
+            }
+        }
+    } else {
+        let closing = if object_context.wsc.0.is_empty() {
+            default_closing
+        } else {
+            std::mem::take(&mut object_context.wsc.0)
+        };
+        object_context.wsc.0 = separator_for(&closing, child_indent);
+        KeyValuePairContext {
+            wsc: (String::new(), " ".to_string(), closing, None),
+        }
+    };
+
+    pairs.push(JSONKeyValuePair {
+        key: parse_round_trip_key(key)?,
+        value,
+        context: Some(new_context),
+    });
+    Ok(())
+}
+
+fn find_object_pair_index(pairs: &[JSONKeyValuePair], key: &str) -> Option<usize> {
+    pairs
+        .iter()
+        .position(|pair| round_trip_key_name(&pair.key).as_deref() == Some(key))
+}
+
+fn upsert_round_trip_provider(
+    document: &mut RoundTripDocument,
+    provider_id: &str,
+    config: &Value,
+) -> Result<(), AppError> {
+    let (root_pairs, _) = object_parts_mut(&mut document.value)
+        .map_err(|_| AppError::Config("Pi models.json root must be a JSON object".to_string()))?;
+    let providers_index = find_object_pair_index(root_pairs, "providers");
+    if let Some(index) = providers_index {
+        let provider_value = parse_round_trip_value(config, 4)?;
+        let (provider_pairs, _) = object_parts_mut(&mut root_pairs[index].value)?;
+        if let Some(provider_index) = find_object_pair_index(provider_pairs, provider_id) {
+            provider_pairs[provider_index].value = provider_value;
+        } else {
+            append_object_pair(&mut root_pairs[index].value, provider_id, provider_value, 4)?;
+        }
         return Ok(());
     }
 
-    // Every loaded document is an observed dependency. For example, removal
-    // reads settings.json even though it only writes models.json.
-    ensure_unchanged(models_snapshot)?;
-    if let Some((settings_snapshot, _)) = settings {
-        ensure_unchanged(settings_snapshot)?;
+    let mut providers = RoundTripValue::JSONObject {
+        key_value_pairs: Vec::new(),
+        context: Some(JSONObjectContext {
+            wsc: (String::new(),),
+        }),
+    };
+    append_object_pair(
+        &mut providers,
+        provider_id,
+        parse_round_trip_value(config, 4)?,
+        4,
+    )?;
+    append_object_pair(&mut document.value, "providers", providers, 2)
+}
+
+fn remove_round_trip_provider(
+    document: &mut RoundTripDocument,
+    provider_id: &str,
+) -> Result<(), AppError> {
+    let (root_pairs, _) = object_parts_mut(&mut document.value)
+        .map_err(|_| AppError::Config("Pi models.json root must be a JSON object".to_string()))?;
+    let Some(providers_index) = find_object_pair_index(root_pairs, "providers") else {
+        return Ok(());
+    };
+    let (provider_pairs, provider_context) =
+        object_parts_mut(&mut root_pairs[providers_index].value)?;
+    let Some(remove_index) = find_object_pair_index(provider_pairs, provider_id) else {
+        return Ok(());
+    };
+
+    let removed = provider_pairs.remove(remove_index);
+    let removed_context = removed.context.ok_or_else(|| {
+        AppError::Config("Pi models.json round-trip context is missing".to_string())
+    })?;
+    if remove_index < provider_pairs.len() {
+        let following_trivia = removed_context.wsc.3.unwrap_or(removed_context.wsc.2);
+        let next_context = provider_pairs[remove_index]
+            .context
+            .as_mut()
+            .ok_or_else(|| {
+                AppError::Config("Pi models.json round-trip context is missing".to_string())
+            })?;
+        next_context.wsc.0 = format!("{following_trivia}{}", next_context.wsc.0);
+        return Ok(());
     }
 
-    let mut documents = Vec::with_capacity(2);
-    if models_changed {
+    let closing = removed_context.wsc.3.unwrap_or(removed_context.wsc.2);
+    if let Some(previous) = provider_pairs.last_mut() {
+        let context = previous.context.as_mut().ok_or_else(|| {
+            AppError::Config("Pi models.json round-trip context is missing".to_string())
+        })?;
+        context.wsc.2.push_str(&closing);
+        context.wsc.3 = None;
+    } else {
+        provider_context.wsc.0.push_str(&closing);
+    }
+    Ok(())
+}
+
+fn render_models_jsonc(
+    snapshot: &JsonFileSnapshot,
+    next: &Value,
+    mutations: &[ModelsMutation],
+) -> Result<Vec<u8>, AppError> {
+    if next == &snapshot.value {
+        return Ok(snapshot.raw.clone().unwrap_or_default());
+    }
+
+    let Some(raw) = snapshot
+        .raw
+        .as_deref()
+        .filter(|raw| !raw.iter().all(|byte| byte.is_ascii_whitespace()))
+    else {
+        return serialize_json(next);
+    };
+    let source = std::str::from_utf8(raw)
+        .map_err(|error| jsonc_error(&snapshot.path, format!("invalid UTF-8: {error}")))?;
+    let mut document =
+        parse_round_trip(source).map_err(|error| jsonc_error(&snapshot.path, error))?;
+    for mutation in mutations {
+        match mutation {
+            ModelsMutation::Upsert {
+                provider_id,
+                config,
+            } => upsert_round_trip_provider(&mut document, provider_id, config)?,
+            ModelsMutation::Remove { provider_id } => {
+                remove_round_trip_provider(&mut document, provider_id)?
+            }
+        }
+    }
+
+    let rendered = document.to_string().into_bytes();
+    let reparsed = parse_pi_jsonc(&snapshot.path, &rendered)?;
+    if reparsed != *next {
+        return Err(AppError::Config(
+            "Refusing to write Pi models.json because round-trip output changed unrelated data"
+                .to_string(),
+        ));
+    }
+    Ok(rendered)
+}
+
+fn commit_documents(
+    models_snapshot: &JsonFileSnapshot,
+    models_next: &Value,
+    auth_snapshot: &JsonFileSnapshot,
+    auth_next: &Value,
+    settings_snapshot: &JsonFileSnapshot,
+    settings_next: &Value,
+    models_mutations: &[ModelsMutation],
+) -> Result<(), AppError> {
+    let models_changed = models_next != &models_snapshot.value;
+    let auth_changed = auth_next != &auth_snapshot.value;
+    let settings_changed = settings_next != &settings_snapshot.value;
+    if !models_changed && !auth_changed && !settings_changed {
+        return Ok(());
+    }
+
+    for snapshot in [auth_snapshot, models_snapshot, settings_snapshot] {
+        ensure_unchanged(snapshot)?;
+    }
+
+    let auth_raw = auth_changed
+        .then(|| serialize_json(auth_next))
+        .transpose()?;
+    let models_raw = models_changed
+        .then(|| render_models_jsonc(models_snapshot, models_next, models_mutations))
+        .transpose()?;
+    let settings_raw = settings_changed
+        .then(|| serialize_json(settings_next))
+        .transpose()?;
+
+    let mut documents = Vec::with_capacity(3);
+    if let Some(next) = auth_raw.as_deref() {
+        parse_snapshot_value(&auth_snapshot.path, next, auth_snapshot.kind)?;
         documents.push(PendingDocument {
-            snapshot: models_snapshot,
-            next: models_next,
+            snapshot: auth_snapshot,
+            next,
+            secure_if_new: true,
         });
     }
-    if let Some((settings_snapshot, settings_next)) = settings {
-        if settings_changed {
-            documents.push(PendingDocument {
-                snapshot: settings_snapshot,
-                next: settings_next,
-            });
+    if let Some(next) = models_raw.as_deref() {
+        let reparsed = parse_snapshot_value(&models_snapshot.path, next, models_snapshot.kind)?;
+        if reparsed != *models_next {
+            return Err(AppError::Config(
+                "Refusing to write Pi models.json because it failed validation".to_string(),
+            ));
         }
+        documents.push(PendingDocument {
+            snapshot: models_snapshot,
+            next,
+            secure_if_new: false,
+        });
+    }
+    if let Some(next) = settings_raw.as_deref() {
+        parse_snapshot_value(&settings_snapshot.path, next, settings_snapshot.kind)?;
+        documents.push(PendingDocument {
+            snapshot: settings_snapshot,
+            next,
+            secure_if_new: false,
+        });
     }
 
     let snapshots = documents
@@ -244,28 +614,42 @@ fn commit_documents(
         .map(|document| document.snapshot)
         .collect::<Vec<_>>();
     create_backup(&snapshots)?;
-    apply_documents_with(&documents, write_json_file)
+    for snapshot in [auth_snapshot, models_snapshot, settings_snapshot] {
+        ensure_unchanged(snapshot)?;
+    }
+    apply_documents_with(&documents, |document| {
+        ensure_unchanged(document.snapshot)?;
+        write_pending_document(document)
+    })
 }
 
-fn mutate_pi_documents<F>(include_settings: bool, mutate: F) -> Result<(), AppError>
+fn mutate_pi_documents<F>(mutate: F) -> Result<(), AppError>
 where
-    F: FnOnce(&mut Value, Option<&mut Value>) -> Result<(), AppError>,
+    F: FnOnce(&mut Value, &mut Value, &mut Value, &mut Vec<ModelsMutation>) -> Result<(), AppError>,
 {
     let _guard = lock_pi_config()?;
-    let models_snapshot = read_snapshot(&get_pi_models_path())?;
-    let settings_snapshot = include_settings
-        .then(|| read_snapshot(&get_pi_settings_path()))
-        .transpose()?;
+    let models_snapshot = read_snapshot(&get_pi_models_path(), JsonFileKind::ModelsJsonc)?;
+    let auth_snapshot = read_snapshot(&get_pi_auth_path(), JsonFileKind::Json)?;
+    let settings_snapshot = read_snapshot(&get_pi_settings_path(), JsonFileKind::Json)?;
     let mut models_next = models_snapshot.value.clone();
-    let mut settings_next = settings_snapshot
-        .as_ref()
-        .map(|snapshot| snapshot.value.clone());
+    let mut auth_next = auth_snapshot.value.clone();
+    let mut settings_next = settings_snapshot.value.clone();
+    let mut models_mutations = Vec::new();
 
-    mutate(&mut models_next, settings_next.as_mut())?;
+    mutate(
+        &mut models_next,
+        &mut auth_next,
+        &mut settings_next,
+        &mut models_mutations,
+    )?;
     commit_documents(
         &models_snapshot,
         &models_next,
-        settings_snapshot.as_ref().zip(settings_next.as_ref()),
+        &auth_snapshot,
+        &auth_next,
+        &settings_snapshot,
+        &settings_next,
+        &models_mutations,
     )
 }
 
@@ -289,13 +673,6 @@ fn first_string<'a>(object: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a
         .filter(|value| !value.is_empty())
 }
 
-const PI_SUPPORTED_APIS: [&str; 4] = [
-    "openai-completions",
-    "openai-responses",
-    "anthropic-messages",
-    "google-generative-ai",
-];
-
 fn validate_pi_api(value: Option<&Value>, field: &str) -> Result<(), AppError> {
     let Some(value) = value else {
         return Ok(());
@@ -303,9 +680,9 @@ fn validate_pi_api(value: Option<&Value>, field: &str) -> Result<(), AppError> {
     let api = value
         .as_str()
         .ok_or_else(|| AppError::Config(format!("Pi provider field '{field}' must be a string")))?;
-    if !PI_SUPPORTED_APIS.contains(&api) {
+    if api.trim().is_empty() {
         return Err(AppError::Config(format!(
-            "Pi provider field '{field}' uses unsupported API '{api}'"
+            "Pi provider field '{field}' must not be empty"
         )));
     }
     Ok(())
@@ -412,25 +789,18 @@ pub(crate) fn validate_pi_provider_config(config: &Value) -> Result<(), AppError
     // hard-code those contextual requirements.
     let mut model_ids = HashSet::with_capacity(models.len());
     for (index, model) in models.iter().enumerate() {
-        let id = match model {
-            // Accept the legacy shorthand already supported by CC Switch and
-            // normalize it during writes.
-            Value::String(id) => id.trim(),
-            Value::Object(model) => {
-                let id = model.get("id").and_then(Value::as_str).ok_or_else(|| {
-                    AppError::Config(format!(
-                        "Pi provider field 'models[{index}].id' must be a string"
-                    ))
-                })?;
-                validate_pi_api(model.get("api"), &format!("models[{index}].api"))?;
-                id.trim()
-            }
-            _ => {
-                return Err(AppError::Config(format!(
-                    "Pi provider field 'models[{index}]' must be an object or string"
-                )));
-            }
-        };
+        let model = model.as_object().ok_or_else(|| {
+            AppError::Config(format!(
+                "Pi provider field 'models[{index}]' must be an object with an id"
+            ))
+        })?;
+        let id = model.get("id").and_then(Value::as_str).ok_or_else(|| {
+            AppError::Config(format!(
+                "Pi provider field 'models[{index}].id' must be a string"
+            ))
+        })?;
+        validate_pi_api(model.get("api"), &format!("models[{index}].api"))?;
+        let id = id.trim();
         if id.is_empty() {
             return Err(AppError::Config(format!(
                 "Pi provider field 'models[{index}].id' must not be empty"
@@ -453,11 +823,7 @@ fn model_ids_from_config(config: &Value) -> Vec<String> {
         .map(|models| {
             models
                 .iter()
-                .filter_map(|model| match model {
-                    Value::String(id) => Some(id.as_str()),
-                    Value::Object(obj) => obj.get("id").and_then(Value::as_str),
-                    _ => None,
-                })
+                .filter_map(|model| model.get("id").and_then(Value::as_str))
                 .map(str::trim)
                 .filter(|id| !id.is_empty())
                 .map(ToOwned::to_owned)
@@ -473,22 +839,16 @@ fn normalized_models_from_config(config: &Value) -> Option<Vec<Value>> {
         .map(|models| {
             models
                 .iter()
-                .filter_map(|model| match model {
-                    Value::String(id) => {
-                        let id = id.trim();
-                        (!id.is_empty()).then(|| Value::String(id.to_string()))
+                .filter_map(|model| {
+                    let object = model.as_object()?;
+                    let id = object.get("id").and_then(Value::as_str)?.trim();
+                    if id.is_empty() {
+                        return None;
                     }
-                    Value::Object(object) => {
-                        let id = object.get("id").and_then(Value::as_str)?.trim();
-                        if id.is_empty() {
-                            return None;
-                        }
 
-                        let mut normalized = object.clone();
-                        normalized.insert("id".to_string(), Value::String(id.to_string()));
-                        Some(Value::Object(normalized))
-                    }
-                    _ => None,
+                    let mut normalized = object.clone();
+                    normalized.insert("id".to_string(), Value::String(id.to_string()));
+                    Some(Value::Object(normalized))
                 })
                 .collect()
         })
@@ -515,6 +875,9 @@ fn normalize_provider_config(config: &Value) -> Result<Value, AppError> {
 
     // Pi stores the selected model in settings.json, not per provider.
     output.remove("defaultModel");
+    // Pi's managed API keys live in auth.json. Legacy inline keys are migrated
+    // the next time the provider is updated by CC Switch.
+    output.remove("apiKey");
 
     Ok(Value::Object(output))
 }
@@ -545,6 +908,7 @@ fn insert_provider(
     models_path: &Path,
     provider: &Provider,
     overwrite_existing: bool,
+    mutations: &mut Vec<ModelsMutation>,
 ) -> Result<(), AppError> {
     let providers = providers_mut(models_root, models_path)?;
     if providers.contains_key(&provider.id) && !overwrite_existing {
@@ -554,10 +918,65 @@ fn insert_provider(
         )));
     }
 
-    providers.insert(
-        provider.id.clone(),
-        normalize_provider_config(&provider.settings_config)?,
-    );
+    let normalized = normalize_provider_config(&provider.settings_config)?;
+    providers.insert(provider.id.clone(), normalized.clone());
+    mutations.push(ModelsMutation::Upsert {
+        provider_id: provider.id.clone(),
+        config: normalized,
+    });
+    Ok(())
+}
+
+fn update_provider_auth(auth_root: &mut Value, provider: &Provider) -> Result<(), AppError> {
+    let auth_path = get_pi_auth_path();
+    let auth = object_mut(auth_root, &auth_path, "Pi auth.json root")?;
+    let requested_key = provider
+        .settings_config
+        .get("apiKey")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+
+    match auth.get_mut(&provider.id) {
+        Some(credential) => {
+            let credential_type = credential.get("type").and_then(Value::as_str);
+            if credential_type != Some("api_key") {
+                if requested_key.is_empty() {
+                    return Ok(());
+                }
+                return Err(AppError::Config(format!(
+                    "Pi provider '{}' uses OAuth or an unsupported credential type in auth.json. CC Switch will not overwrite it with an API key.",
+                    provider.id
+                )));
+            }
+            if requested_key.is_empty() {
+                auth.remove(&provider.id);
+            } else {
+                *credential = json!({ "type": "api_key", "key": requested_key });
+            }
+        }
+        None if !requested_key.is_empty() => {
+            auth.insert(
+                provider.id.clone(),
+                json!({ "type": "api_key", "key": requested_key }),
+            );
+        }
+        None => {}
+    }
+    Ok(())
+}
+
+fn remove_provider_auth(auth_root: &mut Value, provider_id: &str) -> Result<(), AppError> {
+    let auth_path = get_pi_auth_path();
+    let auth = object_mut(auth_root, &auth_path, "Pi auth.json root")?;
+    if auth
+        .get(provider_id)
+        .and_then(|credential| credential.get("type"))
+        .and_then(Value::as_str)
+        == Some("api_key")
+    {
+        auth.remove(provider_id);
+    }
     Ok(())
 }
 
@@ -581,13 +1000,15 @@ pub fn upsert_pi_live_provider(
     provider: &Provider,
     overwrite_existing: bool,
 ) -> Result<(), AppError> {
-    mutate_pi_documents(false, |models_root, _| {
+    mutate_pi_documents(|models_root, auth_root, _, mutations| {
         insert_provider(
             models_root,
             &get_pi_models_path(),
             provider,
             overwrite_existing,
-        )
+            mutations,
+        )?;
+        update_provider_auth(auth_root, provider)
     })
 }
 
@@ -596,17 +1017,16 @@ pub fn activate_pi_live_provider(
     provider: &Provider,
     overwrite_existing: bool,
 ) -> Result<(), AppError> {
-    mutate_pi_documents(true, |models_root, settings_root| {
+    mutate_pi_documents(|models_root, auth_root, settings_root, mutations| {
         insert_provider(
             models_root,
             &get_pi_models_path(),
             provider,
             overwrite_existing,
+            mutations,
         )?;
-        select_provider(
-            settings_root.expect("settings requested for Pi provider activation"),
-            provider,
-        )
+        update_provider_auth(auth_root, provider)?;
+        select_provider(settings_root, provider)
     })
 }
 
@@ -620,16 +1040,14 @@ pub fn sync_pi_live_providers(
     providers: &[&Provider],
     active_provider: Option<&Provider>,
 ) -> Result<(), AppError> {
-    mutate_pi_documents(active_provider.is_some(), |models_root, settings_root| {
+    mutate_pi_documents(|models_root, auth_root, settings_root, mutations| {
         let models_path = get_pi_models_path();
         for provider in providers {
-            insert_provider(models_root, &models_path, provider, true)?;
+            insert_provider(models_root, &models_path, provider, true, mutations)?;
+            update_provider_auth(auth_root, provider)?;
         }
         if let Some(active_provider) = active_provider {
-            select_provider(
-                settings_root.expect("settings requested for Pi provider sync"),
-                active_provider,
-            )?;
+            select_provider(settings_root, active_provider)?;
         }
         Ok(())
     })
@@ -638,7 +1056,7 @@ pub fn sync_pi_live_providers(
 pub fn pi_provider_exists(provider_id: &str) -> Result<bool, AppError> {
     let _guard = lock_pi_config()?;
     let models_path = get_pi_models_path();
-    let models_root = read_json_or_empty_object(&models_path)?;
+    let models_root = read_json_or_empty_object(&models_path, JsonFileKind::ModelsJsonc)?;
     let root = models_root.as_object().ok_or_else(|| {
         AppError::Config(format!(
             "Pi models.json root must be a JSON object: {}",
@@ -654,8 +1072,7 @@ pub fn pi_provider_exists(provider_id: &str) -> Result<bool, AppError> {
 /// Remove a managed provider, but never leave Pi's default pointing at a
 /// provider that no longer exists.
 pub fn remove_pi_live_provider(provider_id: &str) -> Result<(), AppError> {
-    mutate_pi_documents(true, |models_root, settings_root| {
-        let settings_root = settings_root.expect("settings requested for Pi provider removal");
+    mutate_pi_documents(|models_root, auth_root, settings_root, mutations| {
         if settings_root.get("defaultProvider").and_then(Value::as_str) == Some(provider_id) {
             return Err(AppError::Config(format!(
                 "Cannot remove active Pi provider '{provider_id}'. Switch first."
@@ -663,6 +1080,10 @@ pub fn remove_pi_live_provider(provider_id: &str) -> Result<(), AppError> {
         }
 
         providers_mut(models_root, &get_pi_models_path())?.remove(provider_id);
+        mutations.push(ModelsMutation::Remove {
+            provider_id: provider_id.to_string(),
+        });
+        remove_provider_auth(auth_root, provider_id)?;
         Ok(())
     })
 }
@@ -674,11 +1095,7 @@ fn provider_models_for_form(provider_config: &Value) -> Value {
         .map(|models| {
             models
                 .iter()
-                .filter_map(|model| match model {
-                    Value::String(id) => Some(json!({ "id": id })),
-                    Value::Object(obj) => Some(Value::Object(obj.clone())),
-                    _ => None,
-                })
+                .filter_map(|model| model.as_object().cloned().map(Value::Object))
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
@@ -686,48 +1103,138 @@ fn provider_models_for_form(provider_config: &Value) -> Value {
     Value::Array(models)
 }
 
-pub fn read_pi_live_settings() -> Result<Value, AppError> {
+fn provider_config_for_storage(
+    provider_id: &str,
+    provider_config: &Value,
+    auth_root: &Value,
+    default_model: Option<&str>,
+) -> Result<Value, AppError> {
+    validate_pi_provider_config(provider_config)?;
+    let mut form_config = provider_config.clone();
+    let object = form_config.as_object_mut().ok_or_else(|| {
+        AppError::Config(format!(
+            "Pi provider '{provider_id}' in models.json must be a JSON object"
+        ))
+    })?;
+    if let Some(base_url) = object.get("baseURL").cloned() {
+        object.insert("baseUrl".to_string(), base_url);
+    }
+    object.insert(
+        "models".to_string(),
+        provider_models_for_form(provider_config),
+    );
+    if let Some(api_key) = auth_root
+        .get(provider_id)
+        .filter(|credential| credential.get("type").and_then(Value::as_str) == Some("api_key"))
+        .and_then(|credential| credential.get("key"))
+        .and_then(Value::as_str)
+    {
+        object.insert("apiKey".to_string(), Value::String(api_key.to_string()));
+    }
+    if let Some(default_model) = default_model {
+        object.insert(
+            "defaultModel".to_string(),
+            Value::String(default_model.to_string()),
+        );
+    }
+    Ok(form_config)
+}
+
+#[derive(Debug)]
+pub struct PiLiveRegistry {
+    pub providers: Vec<Provider>,
+    pub default_provider: Option<String>,
+}
+
+pub fn read_pi_live_providers() -> Result<PiLiveRegistry, AppError> {
     let _guard = lock_pi_config()?;
     let models_path = get_pi_models_path();
+    let auth_path = get_pi_auth_path();
     let settings_path = get_pi_settings_path();
-    let models_root = read_json_or_empty_object(&models_path)?;
-    let settings_root = read_json_or_empty_object(&settings_path)?;
-
+    let models_root = read_json_or_empty_object(&models_path, JsonFileKind::ModelsJsonc)?;
+    let auth_root = read_json_or_empty_object(&auth_path, JsonFileKind::Json)?;
+    let settings_root = read_json_or_empty_object(&settings_path, JsonFileKind::Json)?;
+    if !auth_root.is_object() {
+        return Err(AppError::Config(format!(
+            "Pi auth.json root must be a JSON object: {}",
+            auth_path.display()
+        )));
+    }
+    if !settings_root.is_object() {
+        return Err(AppError::Config(format!(
+            "Pi settings.json root must be a JSON object: {}",
+            settings_path.display()
+        )));
+    }
     let default_provider = settings_root
         .get("defaultProvider")
         .and_then(Value::as_str)
-        .unwrap_or_default();
-    if default_provider.is_empty() {
-        return Err(AppError::Config(
-            "Pi settings.json does not define defaultProvider".to_string(),
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let default_model = settings_root
+        .get("defaultModel")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let providers = models_root
+        .get("providers")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            AppError::Config(format!(
+                "Pi models.json does not define a providers object: {}",
+                models_path.display()
+            ))
+        })?;
+
+    let mut imported = Vec::with_capacity(providers.len());
+    for (provider_id, provider_config) in providers {
+        let selected_model = (default_provider.as_deref() == Some(provider_id.as_str()))
+            .then_some(default_model)
+            .flatten();
+        let settings_config =
+            provider_config_for_storage(provider_id, provider_config, &auth_root, selected_model)?;
+        let name = provider_config
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(provider_id)
+            .to_string();
+        imported.push(Provider::with_id(
+            provider_id.clone(),
+            name,
+            settings_config,
+            None,
         ));
     }
 
-    let provider_config = models_root
-        .get("providers")
-        .and_then(Value::as_object)
-        .and_then(|providers| providers.get(default_provider))
+    Ok(PiLiveRegistry {
+        providers: imported,
+        default_provider,
+    })
+}
+
+pub fn read_pi_live_settings() -> Result<Value, AppError> {
+    let registry = read_pi_live_providers()?;
+    let default_provider = registry.default_provider.ok_or_else(|| {
+        AppError::Config("Pi settings.json does not define defaultProvider".to_string())
+    })?;
+    let provider = registry
+        .providers
+        .into_iter()
+        .find(|provider| provider.id == default_provider)
         .ok_or_else(|| {
             AppError::Config(format!(
                 "Pi models.json does not define provider '{default_provider}'"
             ))
         })?;
-
-    let mut form_config = provider_config.clone();
-    if let Some(obj) = form_config.as_object_mut() {
-        if let Some(base_url) = obj.get("baseURL").cloned() {
-            obj.insert("baseUrl".to_string(), base_url);
-        }
-        obj.insert(
-            "models".to_string(),
-            provider_models_for_form(provider_config),
-        );
-    }
+    let default_model = provider.settings_config.get("defaultModel").cloned();
 
     Ok(json!({
         "defaultProvider": default_provider,
-        "defaultModel": settings_root.get("defaultModel").cloned().unwrap_or(Value::Null),
-        "providerConfig": form_config
+        "defaultModel": default_model.unwrap_or(Value::Null),
+        "providerConfig": provider.settings_config
     }))
 }
 
@@ -756,6 +1263,10 @@ mod tests {
             normalized.get("baseURL").is_none(),
             "Pi models.json must use baseUrl, not baseURL"
         );
+        assert!(
+            normalized.get("apiKey").is_none(),
+            "Pi API keys must be stored in auth.json"
+        );
         assert_eq!(
             normalized.pointer("/futurePiField/keep"),
             Some(&json!(true)),
@@ -764,8 +1275,12 @@ mod tests {
     }
 
     #[test]
-    fn validates_all_official_pi_apis_without_requiring_an_api_key() {
-        for api in PI_SUPPORTED_APIS {
+    fn accepts_non_empty_pi_and_extension_api_identifiers() {
+        for api in [
+            "openai-completions",
+            "openai-codex-responses",
+            "extension-owned-api",
+        ] {
             validate_pi_provider_config(&json!({
                 "baseUrl": "https://api.example.com/v1",
                 "api": api,
@@ -806,14 +1321,7 @@ mod tests {
     #[test]
     fn rejects_invalid_pi_provider_schema() {
         let cases = [
-            (
-                json!({
-                    "baseUrl": "https://api.example.com/v1",
-                    "api": "openai-chat",
-                    "models": [{ "id": "model-1" }]
-                }),
-                "unsupported API",
-            ),
+            (json!({ "api": "" }), "must not be empty"),
             (
                 json!({
                     "baseUrl": "",
@@ -827,6 +1335,13 @@ mod tests {
                     "models": [{ "name": "missing-id" }]
                 }),
                 "models[0].id",
+            ),
+            (
+                json!({
+                    "baseUrl": "https://api.example.com/v1",
+                    "models": ["legacy-shorthand"]
+                }),
+                "must be an object with an id",
             ),
             (
                 json!({
@@ -867,55 +1382,389 @@ mod tests {
     }
 
     #[test]
-    fn detects_external_changes_after_snapshot() {
-        let dir = tempdir().expect("create temp dir");
-        let path = dir.path().join("models.json");
-        fs::write(&path, br#"{"providers":{}}"#).expect("seed models");
-        let snapshot = read_snapshot(&path).expect("snapshot models");
+    fn pi_jsonc_accepts_line_comments_and_trailing_commas_only() {
+        let path = Path::new("models.json");
+        let parsed = parse_pi_jsonc(
+            path,
+            br#"{
+  // registry comment
+  "providers": {
+    "custom": {
+      "models": [{ "id": "model-1", },],
+    },
+  },
+}"#,
+        )
+        .expect("Pi JSONC should parse");
+        assert_eq!(
+            parsed.pointer("/providers/custom/models/0/id"),
+            Some(&json!("model-1"))
+        );
 
-        fs::write(&path, br#"{"providers":{"external":{}}}"#).expect("edit models");
-        let error = ensure_unchanged(&snapshot).expect_err("external edit must be detected");
-
-        assert!(error.to_string().contains("changed on disk"));
+        for invalid in [
+            "{'providers': {}}",
+            "{providers: {}}",
+            "{/* comment */ \"providers\": {}}",
+        ] {
+            assert!(
+                parse_pi_jsonc(path, invalid.as_bytes()).is_err(),
+                "full JSON5 syntax must be rejected: {invalid}"
+            );
+        }
     }
 
     #[test]
-    fn rolls_back_models_when_settings_write_fails() {
+    fn round_trip_replaces_only_the_target_provider() {
         let dir = tempdir().expect("create temp dir");
+        let path = dir.path().join("models.json");
+        let original = r#"// file comment
+{
+  "futureRoot": { "keep": true },
+  "providers": {
+    // other provider comment
+    "other": { "future": 42 },
+    "target": {
+      // comments inside the replaced provider are not guaranteed
+      "baseUrl": "https://old.example/v1",
+      "models": [{ "id": "old" }],
+    },
+  },
+}
+// trailing file comment
+"#;
+        fs::write(&path, original).expect("seed models");
+        let snapshot = read_snapshot(&path, JsonFileKind::ModelsJsonc).expect("snapshot models");
+        let mut next = snapshot.value.clone();
+        let config = json!({
+            "baseUrl": "https://new.example/v1",
+            "api": "extension-api",
+            "models": [{ "id": "new" }]
+        });
+        next.pointer_mut("/providers/target")
+            .map(|target| *target = config.clone())
+            .expect("target provider");
+        let rendered = render_models_jsonc(
+            &snapshot,
+            &next,
+            &[ModelsMutation::Upsert {
+                provider_id: "target".to_string(),
+                config,
+            }],
+        )
+        .expect("render models");
+        let rendered = String::from_utf8(rendered).expect("utf-8 models");
+
+        assert!(rendered.contains("// file comment"));
+        assert!(rendered.contains("// other provider comment"));
+        assert!(rendered.contains("// trailing file comment"));
+        assert!(rendered.contains("\"futureRoot\": { \"keep\": true }"));
+        assert!(rendered.contains("\"other\": { \"future\": 42 }"));
+        assert!(!rendered.contains("https://old.example/v1"));
+        assert_eq!(
+            parse_pi_jsonc(&path, rendered.as_bytes()).expect("reparse rendered models"),
+            next
+        );
+    }
+
+    #[test]
+    fn round_trip_adds_and_removes_a_provider_without_losing_surrounding_comments() {
+        let dir = tempdir().expect("create temp dir");
+        let path = dir.path().join("models.json");
+        let original = r#"// file comment
+{
+  "providers": {
+    // existing provider comment
+    "existing": { "future": true },
+  },
+  "futureRoot": 42,
+}
+// trailing file comment
+"#;
+        fs::write(&path, original).expect("seed models");
+        let snapshot = read_snapshot(&path, JsonFileKind::ModelsJsonc).expect("snapshot models");
+        let config = json!({
+            "baseUrl": "https://new.example/v1",
+            "api": "extension-api",
+            "models": [{ "id": "new" }]
+        });
+        let mut with_added = snapshot.value.clone();
+        with_added
+            .pointer_mut("/providers")
+            .and_then(Value::as_object_mut)
+            .expect("providers object")
+            .insert("added".to_string(), config.clone());
+        let added = render_models_jsonc(
+            &snapshot,
+            &with_added,
+            &[ModelsMutation::Upsert {
+                provider_id: "added".to_string(),
+                config,
+            }],
+        )
+        .expect("add provider");
+        let added_text = String::from_utf8(added.clone()).expect("utf-8 models");
+        for comment in [
+            "// file comment",
+            "// existing provider comment",
+            "// trailing file comment",
+        ] {
+            assert!(added_text.contains(comment), "missing {comment}");
+        }
+        assert_eq!(
+            parse_pi_jsonc(&path, &added).expect("parse added provider"),
+            with_added
+        );
+
+        fs::write(&path, added).expect("seed added models");
+        let added_snapshot =
+            read_snapshot(&path, JsonFileKind::ModelsJsonc).expect("snapshot added models");
+        let mut with_removed = added_snapshot.value.clone();
+        with_removed
+            .pointer_mut("/providers")
+            .and_then(Value::as_object_mut)
+            .expect("providers object")
+            .remove("added");
+        let removed = render_models_jsonc(
+            &added_snapshot,
+            &with_removed,
+            &[ModelsMutation::Remove {
+                provider_id: "added".to_string(),
+            }],
+        )
+        .expect("remove provider");
+        let removed_text = String::from_utf8(removed.clone()).expect("utf-8 models");
+        for comment in [
+            "// file comment",
+            "// existing provider comment",
+            "// trailing file comment",
+        ] {
+            assert!(removed_text.contains(comment), "missing {comment}");
+        }
+        assert_eq!(
+            parse_pi_jsonc(&path, &removed).expect("parse removed provider"),
+            with_removed
+        );
+    }
+
+    #[test]
+    fn round_trip_removes_a_nonfinal_provider_without_losing_the_next_comment() {
+        let cases = [
+            (
+                "leading",
+                r#"{
+  "providers": {
+    "remove": { "models": [{ "id": "old" }] },
+    // comment owned by the provider that remains
+    "keep": { "future": true },
+  },
+}
+"#,
+            ),
+            (
+                "middle",
+                r#"{
+  "providers": {
+    "first": { "future": "first" },
+    "remove": { "models": [{ "id": "old" }] },
+    // comment owned by the provider that remains
+    "keep": { "future": true },
+  },
+}
+"#,
+            ),
+        ];
+
+        for (case, original) in cases {
+            let dir = tempdir().expect("create temp dir");
+            let path = dir.path().join("models.json");
+            fs::write(&path, original).expect("seed models");
+            let snapshot =
+                read_snapshot(&path, JsonFileKind::ModelsJsonc).expect("snapshot models");
+            let mut next = snapshot.value.clone();
+            next.pointer_mut("/providers")
+                .and_then(Value::as_object_mut)
+                .expect("providers object")
+                .remove("remove");
+
+            let removed = render_models_jsonc(
+                &snapshot,
+                &next,
+                &[ModelsMutation::Remove {
+                    provider_id: "remove".to_string(),
+                }],
+            )
+            .unwrap_or_else(|error| panic!("remove {case} provider: {error}"));
+            let removed_text = String::from_utf8(removed.clone()).expect("utf-8 models");
+
+            assert!(
+                removed_text.contains("// comment owned by the provider that remains"),
+                "{case} removal lost the next provider's comment"
+            );
+            assert_eq!(
+                parse_pi_jsonc(&path, &removed).expect("parse removed provider"),
+                next,
+                "{case} removal changed the semantic configuration"
+            );
+        }
+    }
+
+    #[test]
+    fn auth_updates_protect_oauth_and_clear_only_api_keys() {
+        let oauth = json!({
+            "type": "oauth",
+            "accessToken": "keep-oauth"
+        });
+        let mut auth = json!({ "oauth-provider": oauth.clone() });
+        let empty_provider = Provider::with_id(
+            "oauth-provider".to_string(),
+            "OAuth".to_string(),
+            json!({ "apiKey": "" }),
+            None,
+        );
+        update_provider_auth(&mut auth, &empty_provider).expect("empty key preserves OAuth");
+        assert_eq!(auth.get("oauth-provider"), Some(&oauth));
+
+        let key_provider = Provider::with_id(
+            "oauth-provider".to_string(),
+            "OAuth".to_string(),
+            json!({ "apiKey": "replace" }),
+            None,
+        );
+        assert!(update_provider_auth(&mut auth, &key_provider)
+            .expect_err("OAuth replacement must be blocked")
+            .to_string()
+            .contains("will not overwrite"));
+        assert_eq!(auth.get("oauth-provider"), Some(&oauth));
+
+        auth.as_object_mut().expect("auth object").insert(
+            "api-provider".to_string(),
+            json!({ "type": "api_key", "key": "old" }),
+        );
+        remove_provider_auth(&mut auth, "api-provider").expect("remove API key");
+        remove_provider_auth(&mut auth, "oauth-provider").expect("preserve OAuth on delete");
+        assert!(auth.get("api-provider").is_none());
+        assert_eq!(auth.get("oauth-provider"), Some(&oauth));
+    }
+
+    #[test]
+    fn transaction_detects_external_changes_to_each_pi_file() {
+        for changed_file in ["models", "auth", "settings"] {
+            let dir = tempdir().expect("create temp dir");
+            let models_path = dir.path().join("models.json");
+            let auth_path = dir.path().join("auth.json");
+            let settings_path = dir.path().join("settings.json");
+            let original_models = br#"{"providers":{}}"#;
+            let original_auth = br#"{}"#;
+            let original_settings = br#"{}"#;
+            fs::write(&models_path, original_models).expect("seed models");
+            fs::write(&auth_path, original_auth).expect("seed auth");
+            fs::write(&settings_path, original_settings).expect("seed settings");
+            let models_snapshot =
+                read_snapshot(&models_path, JsonFileKind::ModelsJsonc).expect("snapshot models");
+            let auth_snapshot =
+                read_snapshot(&auth_path, JsonFileKind::Json).expect("snapshot auth");
+            let settings_snapshot =
+                read_snapshot(&settings_path, JsonFileKind::Json).expect("snapshot settings");
+            let mut models_next = models_snapshot.value.clone();
+            models_next
+                .pointer_mut("/providers")
+                .and_then(Value::as_object_mut)
+                .expect("providers object")
+                .insert("managed".to_string(), json!({}));
+            let external = match changed_file {
+                "models" => br#"{"providers":{"external":{}}}"#.as_slice(),
+                "auth" => br#"{"external":{"type":"api_key","key":"external"}}"#.as_slice(),
+                "settings" => br#"{"defaultProvider":"external"}"#.as_slice(),
+                _ => unreachable!(),
+            };
+            let changed_path = match changed_file {
+                "models" => &models_path,
+                "auth" => &auth_path,
+                "settings" => &settings_path,
+                _ => unreachable!(),
+            };
+            fs::write(changed_path, external).expect("simulate external edit");
+
+            let error = commit_documents(
+                &models_snapshot,
+                &models_next,
+                &auth_snapshot,
+                &auth_snapshot.value,
+                &settings_snapshot,
+                &settings_snapshot.value,
+                &[ModelsMutation::Upsert {
+                    provider_id: "managed".to_string(),
+                    config: json!({}),
+                }],
+            )
+            .expect_err("external edit must abort the entire transaction");
+
+            assert!(error.to_string().contains("changed on disk"));
+            assert_eq!(fs::read(changed_path).unwrap(), external);
+            if changed_file != "models" {
+                assert_eq!(fs::read(&models_path).unwrap(), original_models);
+            }
+            if changed_file != "auth" {
+                assert_eq!(fs::read(&auth_path).unwrap(), original_auth);
+            }
+            if changed_file != "settings" {
+                assert_eq!(fs::read(&settings_path).unwrap(), original_settings);
+            }
+        }
+    }
+
+    #[test]
+    fn rolls_back_auth_and_models_when_settings_write_fails() {
+        let dir = tempdir().expect("create temp dir");
+        let auth_path = dir.path().join("auth.json");
         let models_path = dir.path().join("models.json");
         let settings_path = dir.path().join("settings.json");
+        let original_auth = br#"{"old":{"type":"api_key","key":"old"}}"#;
         let original_models = br#"{"providers":{"old":{}}}"#;
         let original_settings = br#"{"defaultProvider":"old"}"#;
+        fs::write(&auth_path, original_auth).expect("seed auth");
         fs::write(&models_path, original_models).expect("seed models");
         fs::write(&settings_path, original_settings).expect("seed settings");
-        let models_snapshot = read_snapshot(&models_path).expect("snapshot models");
-        let settings_snapshot = read_snapshot(&settings_path).expect("snapshot settings");
-        let models_next = json!({"providers": {"old": {}, "new": {}}});
-        let settings_next = json!({"defaultProvider": "new"});
+        let auth_snapshot = read_snapshot(&auth_path, JsonFileKind::Json).expect("snapshot auth");
+        let models_snapshot =
+            read_snapshot(&models_path, JsonFileKind::ModelsJsonc).expect("snapshot models");
+        let settings_snapshot =
+            read_snapshot(&settings_path, JsonFileKind::Json).expect("snapshot settings");
+        let auth_next = br#"{"new":{"type":"api_key","key":"new"}}"#;
+        let models_next = br#"{"providers":{"new":{}}}"#;
+        let settings_next = br#"{"defaultProvider":"new"}"#;
         let documents = [
             PendingDocument {
+                snapshot: &auth_snapshot,
+                next: auth_next,
+                secure_if_new: false,
+            },
+            PendingDocument {
                 snapshot: &models_snapshot,
-                next: &models_next,
+                next: models_next,
+                secure_if_new: false,
             },
             PendingDocument {
                 snapshot: &settings_snapshot,
-                next: &settings_next,
+                next: settings_next,
+                secure_if_new: false,
             },
         ];
 
-        let error = apply_documents_with(&documents, |path, value| {
-            if path == settings_path {
+        let error = apply_documents_with(&documents, |document| {
+            if document.snapshot.path == settings_path {
                 return Err(AppError::Message(
                     "injected settings write failure".to_string(),
                 ));
             }
-            write_json_file(path, value)
+            atomic_write(&document.snapshot.path, document.next)
         })
         .expect_err("settings write should fail");
 
         assert!(error
             .to_string()
             .contains("injected settings write failure"));
+        assert_eq!(fs::read(&auth_path).unwrap(), original_auth);
         assert_eq!(fs::read(&models_path).unwrap(), original_models);
         assert_eq!(fs::read(&settings_path).unwrap(), original_settings);
     }

--- a/src-tauri/src/pi_config.rs
+++ b/src-tauri/src/pi_config.rs
@@ -4,6 +4,7 @@
 //! `settings.json` under `~/.pi/agent` by default.
 
 use serde_json::{json, Map, Value};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -288,6 +289,163 @@ fn first_string<'a>(object: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a
         .filter(|value| !value.is_empty())
 }
 
+const PI_SUPPORTED_APIS: [&str; 4] = [
+    "openai-completions",
+    "openai-responses",
+    "anthropic-messages",
+    "google-generative-ai",
+];
+
+fn validate_pi_api(value: Option<&Value>, field: &str) -> Result<(), AppError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let api = value
+        .as_str()
+        .ok_or_else(|| AppError::Config(format!("Pi provider field '{field}' must be a string")))?;
+    if !PI_SUPPORTED_APIS.contains(&api) {
+        return Err(AppError::Config(format!(
+            "Pi provider field '{field}' uses unsupported API '{api}'"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_pi_headers(value: Option<&Value>, field: &str) -> Result<(), AppError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let headers = value.as_object().ok_or_else(|| {
+        AppError::Config(format!("Pi provider field '{field}' must be an object"))
+    })?;
+    if let Some((name, _)) = headers
+        .iter()
+        .find(|(name, value)| name.trim().is_empty() || !value.is_string())
+    {
+        return Err(AppError::Config(format!(
+            "Pi provider header '{field}.{name}' must have a non-empty name and string value"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate the Pi fields CC Switch understands while allowing unknown fields
+/// to pass through for forward compatibility with newer Pi releases.
+pub(crate) fn validate_pi_provider_config(config: &Value) -> Result<(), AppError> {
+    let source = config.as_object().ok_or_else(|| {
+        AppError::Config("Pi provider settings must be a JSON object".to_string())
+    })?;
+
+    let mut base_urls = Vec::with_capacity(2);
+    for field in ["baseUrl", "baseURL"] {
+        if let Some(value) = source.get(field) {
+            let base_url = value.as_str().ok_or_else(|| {
+                AppError::Config(format!("Pi provider field '{field}' must be a string"))
+            })?;
+            let base_url = base_url.trim();
+            if base_url.is_empty() {
+                return Err(AppError::Config(format!(
+                    "Pi provider field '{field}' must not be empty"
+                )));
+            }
+            base_urls.push((field, base_url));
+        }
+    }
+    if base_urls.len() == 2 && base_urls[0].1 != base_urls[1].1 {
+        return Err(AppError::Config(
+            "Pi provider fields 'baseUrl' and 'baseURL' must not conflict".to_string(),
+        ));
+    }
+
+    validate_pi_api(source.get("api"), "api")?;
+    if source.get("apiKey").is_some_and(|value| !value.is_string()) {
+        return Err(AppError::Config(
+            "Pi provider field 'apiKey' must be a string".to_string(),
+        ));
+    }
+    if let Some(oauth) = source.get("oauth") {
+        if oauth.as_str() != Some("radius") {
+            return Err(AppError::Config(
+                "Pi provider field 'oauth' currently supports only 'radius'".to_string(),
+            ));
+        }
+        if base_urls.is_empty() {
+            return Err(AppError::Config(
+                "Pi provider field 'baseUrl' is required when 'oauth' is configured".to_string(),
+            ));
+        }
+    }
+    if source
+        .get("authHeader")
+        .is_some_and(|value| !value.is_boolean())
+    {
+        return Err(AppError::Config(
+            "Pi provider field 'authHeader' must be a boolean".to_string(),
+        ));
+    }
+    validate_pi_headers(source.get("headers"), "headers")?;
+    for field in ["compat", "modelOverrides"] {
+        if source.get(field).is_some_and(|value| !value.is_object()) {
+            return Err(AppError::Config(format!(
+                "Pi provider field '{field}' must be an object"
+            )));
+        }
+    }
+
+    if source
+        .get("defaultModel")
+        .is_some_and(|value| !value.is_string())
+    {
+        return Err(AppError::Config(
+            "Pi provider field 'defaultModel' must be a string".to_string(),
+        ));
+    }
+    let Some(models_value) = source.get("models") else {
+        return Ok(());
+    };
+    let models = models_value.as_array().ok_or_else(|| {
+        AppError::Config("Pi provider field 'models' must be an array".to_string())
+    })?;
+
+    // Whether baseUrl/api/defaultModel may be inherited depends on Pi's
+    // evolving built-in provider catalog, so this fragment validator must not
+    // hard-code those contextual requirements.
+    let mut model_ids = HashSet::with_capacity(models.len());
+    for (index, model) in models.iter().enumerate() {
+        let id = match model {
+            // Accept the legacy shorthand already supported by CC Switch and
+            // normalize it during writes.
+            Value::String(id) => id.trim(),
+            Value::Object(model) => {
+                let id = model.get("id").and_then(Value::as_str).ok_or_else(|| {
+                    AppError::Config(format!(
+                        "Pi provider field 'models[{index}].id' must be a string"
+                    ))
+                })?;
+                validate_pi_api(model.get("api"), &format!("models[{index}].api"))?;
+                id.trim()
+            }
+            _ => {
+                return Err(AppError::Config(format!(
+                    "Pi provider field 'models[{index}]' must be an object or string"
+                )));
+            }
+        };
+        if id.is_empty() {
+            return Err(AppError::Config(format!(
+                "Pi provider field 'models[{index}].id' must not be empty"
+            )));
+        }
+        if !model_ids.insert(id) {
+            return Err(AppError::Config(format!(
+                "Pi provider contains duplicate model id '{id}'"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 fn model_ids_from_config(config: &Value) -> Vec<String> {
     config
         .get("models")
@@ -342,6 +500,7 @@ fn normalize_provider_config(config: &Value) -> Result<Value, AppError> {
             "Pi provider settings must be a JSON object".to_string(),
         ));
     };
+    validate_pi_provider_config(config)?;
 
     let mut output = source.clone();
 
@@ -583,7 +742,8 @@ mod tests {
             "baseURL": "https://api.example.com/v1",
             "apiKey": "sk-test",
             "api": "openai-completions",
-            "models": []
+            "models": [],
+            "futurePiField": { "keep": true }
         });
 
         let normalized = normalize_provider_config(&config).unwrap();
@@ -596,6 +756,114 @@ mod tests {
             normalized.get("baseURL").is_none(),
             "Pi models.json must use baseUrl, not baseURL"
         );
+        assert_eq!(
+            normalized.pointer("/futurePiField/keep"),
+            Some(&json!(true)),
+            "unknown Pi fields must survive normalization"
+        );
+    }
+
+    #[test]
+    fn validates_all_official_pi_apis_without_requiring_an_api_key() {
+        for api in PI_SUPPORTED_APIS {
+            validate_pi_provider_config(&json!({
+                "baseUrl": "https://api.example.com/v1",
+                "api": api,
+                "models": [{ "id": "model-1" }]
+            }))
+            .unwrap_or_else(|error| panic!("{api} should be accepted: {error}"));
+        }
+
+        validate_pi_provider_config(&json!({
+            "baseUrl": "https://api.example.com/v1",
+            "models": [{ "id": "model-1", "api": "anthropic-messages" }]
+        }))
+        .expect("model-level API should satisfy Pi's API requirement");
+    }
+
+    #[test]
+    fn allows_builtin_overrides_and_future_fields() {
+        validate_pi_provider_config(&json!({
+            "baseUrl": "https://proxy.example.com/v1",
+            "oauth": "radius",
+            "authHeader": true,
+            "headers": { "x-route": "$PI_ROUTE" },
+            "compat": { "supportsDeveloperRole": false },
+            "modelOverrides": {
+                "known-model": { "contextWindow": 200000 }
+            },
+            "futurePiField": { "enabled": true }
+        }))
+        .expect("built-in overrides and unknown future fields should be accepted");
+
+        validate_pi_provider_config(&json!({
+            "models": [{ "id": "custom-model" }],
+            "defaultModel": "built-in-model"
+        }))
+        .expect("built-in providers may inherit endpoint, API, and model catalog entries");
+    }
+
+    #[test]
+    fn rejects_invalid_pi_provider_schema() {
+        let cases = [
+            (
+                json!({
+                    "baseUrl": "https://api.example.com/v1",
+                    "api": "openai-chat",
+                    "models": [{ "id": "model-1" }]
+                }),
+                "unsupported API",
+            ),
+            (
+                json!({
+                    "baseUrl": "",
+                    "api": "openai-completions"
+                }),
+                "baseUrl",
+            ),
+            (
+                json!({
+                    "baseUrl": "https://api.example.com/v1",
+                    "models": [{ "name": "missing-id" }]
+                }),
+                "models[0].id",
+            ),
+            (
+                json!({
+                    "baseUrl": "https://api.example.com/v1",
+                    "api": "openai-completions",
+                    "models": [{ "id": "same" }, { "id": "same" }]
+                }),
+                "duplicate model id",
+            ),
+            (
+                json!({
+                    "baseUrl": "https://api.example.com/v1",
+                    "api": "openai-completions",
+                    "models": [{ "id": "model-1" }],
+                    "defaultModel": 42
+                }),
+                "defaultModel",
+            ),
+            (
+                json!({
+                    "baseUrl": "https://api.example.com/v1",
+                    "api": "openai-completions",
+                    "headers": { "x-route": 42 },
+                    "models": [{ "id": "model-1" }]
+                }),
+                "string value",
+            ),
+        ];
+
+        for (config, expected) in cases {
+            let error =
+                validate_pi_provider_config(&config).expect_err("invalid config must be rejected");
+            assert!(
+                error.to_string().contains(expected),
+                "expected '{expected}' in error, got {error}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/pi_config.rs
+++ b/src-tauri/src/pi_config.rs
@@ -150,23 +150,41 @@ fn default_model_for_provider(config: &Value) -> Option<String> {
         .or_else(|| model_ids_from_config(config).into_iter().next())
 }
 
-pub fn write_pi_live_provider(provider: &Provider) -> Result<(), AppError> {
-    let models_path = get_pi_models_path();
-    let settings_path = get_pi_settings_path();
-
-    let mut models_root = read_json_or_empty_object(&models_path)?;
-    let root = object_mut(&mut models_root, &models_path, "Pi models.json root")?;
+fn providers_mut<'a>(
+    models_root: &'a mut Value,
+    models_path: &Path,
+) -> Result<&'a mut Map<String, Value>, AppError> {
+    let root = object_mut(models_root, models_path, "Pi models.json root")?;
     let providers = root
         .entry("providers".to_string())
         .or_insert_with(|| Value::Object(Map::new()));
-    object_mut(providers, &models_path, "Pi models.json providers")?.insert(
+    object_mut(providers, models_path, "Pi models.json providers")
+}
+
+fn insert_provider(
+    models_root: &mut Value,
+    models_path: &Path,
+    provider: &Provider,
+    overwrite_existing: bool,
+) -> Result<(), AppError> {
+    let providers = providers_mut(models_root, models_path)?;
+    if providers.contains_key(&provider.id) && !overwrite_existing {
+        return Err(AppError::Config(format!(
+            "Pi provider '{}' already exists in models.json and is not managed by CC Switch",
+            provider.id
+        )));
+    }
+
+    providers.insert(
         provider.id.clone(),
         normalize_provider_config(&provider.settings_config)?,
     );
-    write_json_file(&models_path, &models_root)?;
+    Ok(())
+}
 
-    let mut settings_root = read_json_or_empty_object(&settings_path)?;
-    let settings = object_mut(&mut settings_root, &settings_path, "Pi settings.json root")?;
+fn select_provider(settings_root: &mut Value, provider: &Provider) -> Result<(), AppError> {
+    let settings_path = get_pi_settings_path();
+    let settings = object_mut(settings_root, &settings_path, "Pi settings.json root")?;
     settings.insert(
         "defaultProvider".to_string(),
         Value::String(provider.id.clone()),
@@ -176,9 +194,94 @@ pub fn write_pi_live_provider(provider: &Provider) -> Result<(), AppError> {
     } else {
         settings.remove("defaultModel");
     }
-    write_json_file(&settings_path, &settings_root)?;
-
     Ok(())
+}
+
+/// Add or update a provider in Pi's additive registry without selecting it.
+pub fn upsert_pi_live_provider(
+    provider: &Provider,
+    overwrite_existing: bool,
+) -> Result<(), AppError> {
+    let models_path = get_pi_models_path();
+    let mut models_root = read_json_or_empty_object(&models_path)?;
+    insert_provider(&mut models_root, &models_path, provider, overwrite_existing)?;
+    write_json_file(&models_path, &models_root)?;
+    Ok(())
+}
+
+/// Add or update a provider and select it as Pi's default provider/model.
+pub fn activate_pi_live_provider(
+    provider: &Provider,
+    overwrite_existing: bool,
+) -> Result<(), AppError> {
+    let models_path = get_pi_models_path();
+    let settings_path = get_pi_settings_path();
+    let mut models_root = read_json_or_empty_object(&models_path)?;
+    insert_provider(&mut models_root, &models_path, provider, overwrite_existing)?;
+    let mut settings_root = read_json_or_empty_object(&settings_path)?;
+    select_provider(&mut settings_root, provider)?;
+
+    write_json_file(&models_path, &models_root)?;
+    write_json_file(&settings_path, &settings_root)?;
+    Ok(())
+}
+
+/// Compatibility wrapper retained for callers that mean "activate".
+pub fn write_pi_live_provider(provider: &Provider) -> Result<(), AppError> {
+    activate_pi_live_provider(provider, true)
+}
+
+/// Synchronize all CC Switch-managed providers and the selected default.
+pub fn sync_pi_live_providers(
+    providers: &[&Provider],
+    active_provider: Option<&Provider>,
+) -> Result<(), AppError> {
+    let models_path = get_pi_models_path();
+    let mut models_root = read_json_or_empty_object(&models_path)?;
+    for provider in providers {
+        insert_provider(&mut models_root, &models_path, provider, true)?;
+    }
+    write_json_file(&models_path, &models_root)?;
+
+    if let Some(active_provider) = active_provider {
+        let settings_path = get_pi_settings_path();
+        let mut settings_root = read_json_or_empty_object(&settings_path)?;
+        select_provider(&mut settings_root, active_provider)?;
+        write_json_file(&settings_path, &settings_root)?;
+    }
+    Ok(())
+}
+
+pub fn pi_provider_exists(provider_id: &str) -> Result<bool, AppError> {
+    let models_path = get_pi_models_path();
+    let models_root = read_json_or_empty_object(&models_path)?;
+    let root = models_root.as_object().ok_or_else(|| {
+        AppError::Config(format!(
+            "Pi models.json root must be a JSON object: {}",
+            models_path.display()
+        ))
+    })?;
+    Ok(root
+        .get("providers")
+        .and_then(Value::as_object)
+        .is_some_and(|providers| providers.contains_key(provider_id)))
+}
+
+/// Remove a managed provider, but never leave Pi's default pointing at a
+/// provider that no longer exists.
+pub fn remove_pi_live_provider(provider_id: &str) -> Result<(), AppError> {
+    let settings_path = get_pi_settings_path();
+    let settings_root = read_json_or_empty_object(&settings_path)?;
+    if settings_root.get("defaultProvider").and_then(Value::as_str) == Some(provider_id) {
+        return Err(AppError::Config(format!(
+            "Cannot remove active Pi provider '{provider_id}'. Switch first."
+        )));
+    }
+
+    let models_path = get_pi_models_path();
+    let mut models_root = read_json_or_empty_object(&models_path)?;
+    providers_mut(&mut models_root, &models_path)?.remove(provider_id);
+    write_json_file(&models_path, &models_root)
 }
 
 fn provider_models_for_form(provider_config: &Value) -> Value {

--- a/src-tauri/src/pi_config.rs
+++ b/src-tauri/src/pi_config.rs
@@ -7,8 +7,9 @@ use serde_json::{json, Map, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::config::{atomic_write, get_home_dir, write_json_file};
+use crate::config::{atomic_write, get_app_config_dir, get_home_dir, write_json_file};
 use crate::error::AppError;
 use crate::provider::Provider;
 
@@ -111,6 +112,70 @@ fn restore_snapshot(snapshot: &JsonFileSnapshot) -> Result<(), AppError> {
     }
 }
 
+fn cleanup_backups(backup_root: &Path) -> Result<(), AppError> {
+    let retain = crate::settings::effective_backup_retain_count();
+    let mut entries = fs::read_dir(backup_root)
+        .map_err(|error| AppError::io(backup_root, error))?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir())
+        .collect::<Vec<_>>();
+    if entries.len() <= retain {
+        return Ok(());
+    }
+
+    entries.sort_by_key(|entry| entry.metadata().and_then(|meta| meta.modified()).ok());
+    let remove_count = entries.len().saturating_sub(retain);
+    for entry in entries.into_iter().take(remove_count) {
+        if let Err(error) = fs::remove_dir_all(entry.path()) {
+            log::warn!(
+                "Failed to remove old Pi backup {}: {error}",
+                entry.path().display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn create_backup(snapshots: &[&JsonFileSnapshot]) -> Result<(), AppError> {
+    if snapshots.iter().all(|snapshot| snapshot.raw.is_none()) {
+        return Ok(());
+    }
+
+    let backup_root = get_app_config_dir().join("backups").join("pi");
+    fs::create_dir_all(&backup_root).map_err(|error| AppError::io(&backup_root, error))?;
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let base_name = format!("pi_{timestamp}");
+    let mut backup_dir = backup_root.join(&base_name);
+    let mut suffix = 1;
+    while backup_dir.exists() {
+        backup_dir = backup_root.join(format!("{base_name}_{suffix}"));
+        suffix += 1;
+    }
+    fs::create_dir_all(&backup_dir).map_err(|error| AppError::io(&backup_dir, error))?;
+
+    for snapshot in snapshots {
+        let Some(raw) = snapshot.raw.as_deref() else {
+            continue;
+        };
+        let filename = snapshot
+            .path
+            .file_name()
+            .ok_or_else(|| AppError::Config("Invalid Pi config filename".to_string()))?;
+        let backup_path = backup_dir.join(filename);
+        atomic_write(&backup_path, raw)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&backup_path, fs::Permissions::from_mode(0o600))
+                .map_err(|error| AppError::io(&backup_path, error))?;
+        }
+    }
+    cleanup_backups(&backup_root)
+}
+
 fn apply_documents_with<F>(documents: &[PendingDocument<'_>], mut writer: F) -> Result<(), AppError>
 where
     F: FnMut(&Path, &Value) -> Result<(), AppError>,
@@ -173,6 +238,11 @@ fn commit_documents(
         }
     }
 
+    let snapshots = documents
+        .iter()
+        .map(|document| document.snapshot)
+        .collect::<Vec<_>>();
+    create_backup(&snapshots)?;
     apply_documents_with(&documents, write_json_file)
 }
 

--- a/src-tauri/src/pi_config.rs
+++ b/src-tauri/src/pi_config.rs
@@ -6,10 +6,35 @@
 use serde_json::{json, Map, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
-use crate::config::{get_home_dir, write_json_file};
+use crate::config::{atomic_write, get_home_dir, write_json_file};
 use crate::error::AppError;
 use crate::provider::Provider;
+
+#[derive(Debug)]
+struct JsonFileSnapshot {
+    path: PathBuf,
+    raw: Option<Vec<u8>>,
+    value: Value,
+}
+
+#[derive(Clone, Copy)]
+struct PendingDocument<'a> {
+    snapshot: &'a JsonFileSnapshot,
+    next: &'a Value,
+}
+
+fn pi_config_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn lock_pi_config() -> Result<std::sync::MutexGuard<'static, ()>, AppError> {
+    pi_config_lock()
+        .lock()
+        .map_err(|_| AppError::Message("Pi configuration write lock is poisoned".to_string()))
+}
 
 pub fn get_pi_dir() -> PathBuf {
     if let Some(override_dir) = crate::settings::get_pi_override_dir() {
@@ -35,17 +60,142 @@ pub fn get_pi_settings_path() -> PathBuf {
     get_pi_dir().join("settings.json")
 }
 
+fn read_snapshot(path: &Path) -> Result<JsonFileSnapshot, AppError> {
+    let raw = match fs::read(path) {
+        Ok(raw) => Some(raw),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(AppError::io(path, error)),
+    };
+    let value = match raw.as_deref() {
+        None => Value::Object(Map::new()),
+        Some(raw) if raw.iter().all(|byte| byte.is_ascii_whitespace()) => Value::Object(Map::new()),
+        Some(raw) => serde_json::from_slice(raw).map_err(|error| AppError::json(path, error))?,
+    };
+
+    Ok(JsonFileSnapshot {
+        path: path.to_path_buf(),
+        raw,
+        value,
+    })
+}
+
 fn read_json_or_empty_object(path: &Path) -> Result<Value, AppError> {
-    if !path.exists() {
-        return Ok(Value::Object(Map::new()));
+    read_snapshot(path).map(|snapshot| snapshot.value)
+}
+
+fn current_raw(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
+    match fs::read(path) {
+        Ok(raw) => Ok(Some(raw)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(AppError::io(path, error)),
+    }
+}
+
+fn ensure_unchanged(snapshot: &JsonFileSnapshot) -> Result<(), AppError> {
+    if current_raw(&snapshot.path)? != snapshot.raw {
+        return Err(AppError::Config(format!(
+            "Pi configuration changed on disk while CC Switch was updating it: {}. Reload and try again.",
+            snapshot.path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn restore_snapshot(snapshot: &JsonFileSnapshot) -> Result<(), AppError> {
+    match &snapshot.raw {
+        Some(raw) => atomic_write(&snapshot.path, raw),
+        None if snapshot.path.exists() => {
+            fs::remove_file(&snapshot.path).map_err(|error| AppError::io(&snapshot.path, error))
+        }
+        None => Ok(()),
+    }
+}
+
+fn apply_documents_with<F>(documents: &[PendingDocument<'_>], mut writer: F) -> Result<(), AppError>
+where
+    F: FnMut(&Path, &Value) -> Result<(), AppError>,
+{
+    for (index, document) in documents.iter().enumerate() {
+        if let Err(operation_error) = writer(&document.snapshot.path, document.next) {
+            let rollback_errors = documents[..=index]
+                .iter()
+                .rev()
+                .filter_map(|document| {
+                    restore_snapshot(document.snapshot)
+                        .err()
+                        .map(|error| format!("{}: {error}", document.snapshot.path.display()))
+                })
+                .collect::<Vec<_>>();
+            return if rollback_errors.is_empty() {
+                Err(operation_error)
+            } else {
+                Err(AppError::Message(format!(
+                    "{operation_error}; rollback also failed for {}",
+                    rollback_errors.join(", ")
+                )))
+            };
+        }
+    }
+    Ok(())
+}
+
+fn commit_documents(
+    models_snapshot: &JsonFileSnapshot,
+    models_next: &Value,
+    settings: Option<(&JsonFileSnapshot, &Value)>,
+) -> Result<(), AppError> {
+    let models_changed = models_next != &models_snapshot.value;
+    let settings_changed = settings.is_some_and(|(snapshot, next)| next != &snapshot.value);
+    if !models_changed && !settings_changed {
+        return Ok(());
     }
 
-    let content = fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
-    if content.trim().is_empty() {
-        return Ok(Value::Object(Map::new()));
+    // Every loaded document is an observed dependency. For example, removal
+    // reads settings.json even though it only writes models.json.
+    ensure_unchanged(models_snapshot)?;
+    if let Some((settings_snapshot, _)) = settings {
+        ensure_unchanged(settings_snapshot)?;
     }
 
-    serde_json::from_str(&content).map_err(|e| AppError::json(path, e))
+    let mut documents = Vec::with_capacity(2);
+    if models_changed {
+        documents.push(PendingDocument {
+            snapshot: models_snapshot,
+            next: models_next,
+        });
+    }
+    if let Some((settings_snapshot, settings_next)) = settings {
+        if settings_changed {
+            documents.push(PendingDocument {
+                snapshot: settings_snapshot,
+                next: settings_next,
+            });
+        }
+    }
+
+    apply_documents_with(&documents, write_json_file)
+}
+
+fn mutate_pi_documents<F>(include_settings: bool, mutate: F) -> Result<(), AppError>
+where
+    F: FnOnce(&mut Value, Option<&mut Value>) -> Result<(), AppError>,
+{
+    let _guard = lock_pi_config()?;
+    let models_snapshot = read_snapshot(&get_pi_models_path())?;
+    let settings_snapshot = include_settings
+        .then(|| read_snapshot(&get_pi_settings_path()))
+        .transpose()?;
+    let mut models_next = models_snapshot.value.clone();
+    let mut settings_next = settings_snapshot
+        .as_ref()
+        .map(|snapshot| snapshot.value.clone());
+
+    mutate(&mut models_next, settings_next.as_mut())?;
+    commit_documents(
+        &models_snapshot,
+        &models_next,
+        settings_snapshot.as_ref().zip(settings_next.as_ref()),
+    )
 }
 
 fn object_mut<'a>(
@@ -202,11 +352,14 @@ pub fn upsert_pi_live_provider(
     provider: &Provider,
     overwrite_existing: bool,
 ) -> Result<(), AppError> {
-    let models_path = get_pi_models_path();
-    let mut models_root = read_json_or_empty_object(&models_path)?;
-    insert_provider(&mut models_root, &models_path, provider, overwrite_existing)?;
-    write_json_file(&models_path, &models_root)?;
-    Ok(())
+    mutate_pi_documents(false, |models_root, _| {
+        insert_provider(
+            models_root,
+            &get_pi_models_path(),
+            provider,
+            overwrite_existing,
+        )
+    })
 }
 
 /// Add or update a provider and select it as Pi's default provider/model.
@@ -214,16 +367,18 @@ pub fn activate_pi_live_provider(
     provider: &Provider,
     overwrite_existing: bool,
 ) -> Result<(), AppError> {
-    let models_path = get_pi_models_path();
-    let settings_path = get_pi_settings_path();
-    let mut models_root = read_json_or_empty_object(&models_path)?;
-    insert_provider(&mut models_root, &models_path, provider, overwrite_existing)?;
-    let mut settings_root = read_json_or_empty_object(&settings_path)?;
-    select_provider(&mut settings_root, provider)?;
-
-    write_json_file(&models_path, &models_root)?;
-    write_json_file(&settings_path, &settings_root)?;
-    Ok(())
+    mutate_pi_documents(true, |models_root, settings_root| {
+        insert_provider(
+            models_root,
+            &get_pi_models_path(),
+            provider,
+            overwrite_existing,
+        )?;
+        select_provider(
+            settings_root.expect("settings requested for Pi provider activation"),
+            provider,
+        )
+    })
 }
 
 /// Compatibility wrapper retained for callers that mean "activate".
@@ -236,23 +391,23 @@ pub fn sync_pi_live_providers(
     providers: &[&Provider],
     active_provider: Option<&Provider>,
 ) -> Result<(), AppError> {
-    let models_path = get_pi_models_path();
-    let mut models_root = read_json_or_empty_object(&models_path)?;
-    for provider in providers {
-        insert_provider(&mut models_root, &models_path, provider, true)?;
-    }
-    write_json_file(&models_path, &models_root)?;
-
-    if let Some(active_provider) = active_provider {
-        let settings_path = get_pi_settings_path();
-        let mut settings_root = read_json_or_empty_object(&settings_path)?;
-        select_provider(&mut settings_root, active_provider)?;
-        write_json_file(&settings_path, &settings_root)?;
-    }
-    Ok(())
+    mutate_pi_documents(active_provider.is_some(), |models_root, settings_root| {
+        let models_path = get_pi_models_path();
+        for provider in providers {
+            insert_provider(models_root, &models_path, provider, true)?;
+        }
+        if let Some(active_provider) = active_provider {
+            select_provider(
+                settings_root.expect("settings requested for Pi provider sync"),
+                active_provider,
+            )?;
+        }
+        Ok(())
+    })
 }
 
 pub fn pi_provider_exists(provider_id: &str) -> Result<bool, AppError> {
+    let _guard = lock_pi_config()?;
     let models_path = get_pi_models_path();
     let models_root = read_json_or_empty_object(&models_path)?;
     let root = models_root.as_object().ok_or_else(|| {
@@ -270,18 +425,17 @@ pub fn pi_provider_exists(provider_id: &str) -> Result<bool, AppError> {
 /// Remove a managed provider, but never leave Pi's default pointing at a
 /// provider that no longer exists.
 pub fn remove_pi_live_provider(provider_id: &str) -> Result<(), AppError> {
-    let settings_path = get_pi_settings_path();
-    let settings_root = read_json_or_empty_object(&settings_path)?;
-    if settings_root.get("defaultProvider").and_then(Value::as_str) == Some(provider_id) {
-        return Err(AppError::Config(format!(
-            "Cannot remove active Pi provider '{provider_id}'. Switch first."
-        )));
-    }
+    mutate_pi_documents(true, |models_root, settings_root| {
+        let settings_root = settings_root.expect("settings requested for Pi provider removal");
+        if settings_root.get("defaultProvider").and_then(Value::as_str) == Some(provider_id) {
+            return Err(AppError::Config(format!(
+                "Cannot remove active Pi provider '{provider_id}'. Switch first."
+            )));
+        }
 
-    let models_path = get_pi_models_path();
-    let mut models_root = read_json_or_empty_object(&models_path)?;
-    providers_mut(&mut models_root, &models_path)?.remove(provider_id);
-    write_json_file(&models_path, &models_root)
+        providers_mut(models_root, &get_pi_models_path())?.remove(provider_id);
+        Ok(())
+    })
 }
 
 fn provider_models_for_form(provider_config: &Value) -> Value {
@@ -304,6 +458,7 @@ fn provider_models_for_form(provider_config: &Value) -> Value {
 }
 
 pub fn read_pi_live_settings() -> Result<Value, AppError> {
+    let _guard = lock_pi_config()?;
     let models_path = get_pi_models_path();
     let settings_path = get_pi_settings_path();
     let models_root = read_json_or_empty_object(&models_path)?;
@@ -350,6 +505,7 @@ pub fn read_pi_live_settings() -> Result<Value, AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn normalize_provider_config_writes_pi_base_url_key() {
@@ -370,5 +526,59 @@ mod tests {
             normalized.get("baseURL").is_none(),
             "Pi models.json must use baseUrl, not baseURL"
         );
+    }
+
+    #[test]
+    fn detects_external_changes_after_snapshot() {
+        let dir = tempdir().expect("create temp dir");
+        let path = dir.path().join("models.json");
+        fs::write(&path, br#"{"providers":{}}"#).expect("seed models");
+        let snapshot = read_snapshot(&path).expect("snapshot models");
+
+        fs::write(&path, br#"{"providers":{"external":{}}}"#).expect("edit models");
+        let error = ensure_unchanged(&snapshot).expect_err("external edit must be detected");
+
+        assert!(error.to_string().contains("changed on disk"));
+    }
+
+    #[test]
+    fn rolls_back_models_when_settings_write_fails() {
+        let dir = tempdir().expect("create temp dir");
+        let models_path = dir.path().join("models.json");
+        let settings_path = dir.path().join("settings.json");
+        let original_models = br#"{"providers":{"old":{}}}"#;
+        let original_settings = br#"{"defaultProvider":"old"}"#;
+        fs::write(&models_path, original_models).expect("seed models");
+        fs::write(&settings_path, original_settings).expect("seed settings");
+        let models_snapshot = read_snapshot(&models_path).expect("snapshot models");
+        let settings_snapshot = read_snapshot(&settings_path).expect("snapshot settings");
+        let models_next = json!({"providers": {"old": {}, "new": {}}});
+        let settings_next = json!({"defaultProvider": "new"});
+        let documents = [
+            PendingDocument {
+                snapshot: &models_snapshot,
+                next: &models_next,
+            },
+            PendingDocument {
+                snapshot: &settings_snapshot,
+                next: &settings_next,
+            },
+        ];
+
+        let error = apply_documents_with(&documents, |path, value| {
+            if path == settings_path {
+                return Err(AppError::Message(
+                    "injected settings write failure".to_string(),
+                ));
+            }
+            write_json_file(path, value)
+        })
+        .expect_err("settings write should fail");
+
+        assert!(error
+            .to_string()
+            .contains("injected settings write failure"));
+        assert_eq!(fs::read(&models_path).unwrap(), original_models);
+        assert_eq!(fs::read(&settings_path).unwrap(), original_settings);
     }
 }

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -10,7 +10,7 @@ use crate::opencode_config::get_opencode_dir;
 
 /// 返回指定应用所使用的提示词文件路径。
 pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
-    if matches!(app, AppType::ClaudeDesktop) {
+    if matches!(app, AppType::ClaudeDesktop | AppType::Pi) {
         return Err(AppError::localized(
             "app.prompts_unsupported",
             "当前应用暂不支持 Prompts",
@@ -26,7 +26,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::OpenCode => get_opencode_dir(),
         AppType::OpenClaw => get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
-        AppType::ClaudeDesktop => unreachable!("handled above"),
+        AppType::ClaudeDesktop | AppType::Pi => unreachable!("handled above"),
     };
 
     let filename = match app {
@@ -34,7 +34,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Codex => "AGENTS.md",
         AppType::Gemini => "GEMINI.md",
         AppType::GrokBuild | AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => "AGENTS.md",
-        AppType::ClaudeDesktop => unreachable!("handled above"),
+        AppType::ClaudeDesktop | AppType::Pi => unreachable!("handled above"),
     };
 
     Ok(base_dir.join(filename))

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -196,6 +196,10 @@ impl Provider {
                 str_at(settings.get("baseUrl")),
                 str_at(settings.get("apiKey")),
             ),
+            AppType::Pi => (
+                str_at(settings.get("baseUrl").or_else(|| settings.get("baseURL"))),
+                str_at(settings.get("apiKey")),
+            ),
             // OpenCode (OMO) nests credentials under `options` (the SDK options object).
             AppType::OpenCode => {
                 let options = settings.get("options");

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -205,7 +205,10 @@ impl ProviderType {
                 ProviderType::Gemini
             }
             AppType::GrokBuild => ProviderType::Codex,
-            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => ProviderType::Codex,
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
+                // These apps don't support proxy, fallback to Codex-like type
+                ProviderType::Codex
+            }
         }
     }
 
@@ -259,7 +262,10 @@ pub fn get_adapter(app_type: &AppType) -> Box<dyn ProviderAdapter> {
         AppType::Codex => Box::new(CodexAdapter::new()),
         AppType::Gemini => Box::new(GeminiAdapter::new()),
         AppType::GrokBuild => Box::new(CodexAdapter::new()),
-        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => Box::new(CodexAdapter::new()),
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
+            // These apps don't support proxy, fallback to Codex adapter
+            Box::new(CodexAdapter::new())
+        }
     }
 }
 

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -138,6 +138,9 @@ impl ConfigService {
             AppType::Hermes => {
                 // Hermes uses additive mode, no live sync needed
             }
+            AppType::Pi => {
+                crate::pi_config::write_pi_live_provider(&provider)?;
+            }
         }
 
         Ok(())

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -147,6 +147,9 @@ impl McpService {
             AppType::Hermes => {
                 mcp::sync_single_server_to_hermes(&Default::default(), &server.id, &server.server)?;
             }
+            AppType::Pi => {
+                log::debug!("Pi Agent MCP sync is not supported, skipping");
+            }
         }
         Ok(())
     }
@@ -182,6 +185,9 @@ impl McpService {
             }
             AppType::Hermes => {
                 mcp::remove_server_from_hermes(id)?;
+            }
+            AppType::Pi => {
+                log::debug!("Pi Agent MCP sync is not supported, skipping remove");
             }
         }
         Ok(())
@@ -227,7 +233,10 @@ impl McpService {
         servers: &IndexMap<String, McpServer>,
         app: &AppType,
     ) -> Result<(), AppError> {
-        if matches!(app, AppType::OpenClaw | AppType::ClaudeDesktop) {
+        if matches!(
+            app,
+            AppType::OpenClaw | AppType::ClaudeDesktop | AppType::Pi
+        ) {
             return Ok(());
         }
 

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -186,6 +186,7 @@ pub(crate) fn provider_exists_in_live_config(
             .map(|providers| providers.contains_key(provider_id)),
         AppType::Hermes => crate::hermes_config::get_providers()
             .map(|providers| providers.contains_key(provider_id)),
+        AppType::Pi => crate::pi_config::pi_provider_exists(provider_id),
         _ => Ok(false),
     }
 }
@@ -1166,7 +1167,7 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
             log::debug!("Hermes provider '{}' written to live config", provider.id);
         }
         AppType::Pi => {
-            crate::pi_config::write_pi_live_provider(provider)?;
+            crate::pi_config::upsert_pi_live_provider(provider, true)?;
             log::debug!("Pi provider '{}' written to live config", provider.id);
         }
     }
@@ -1206,11 +1207,36 @@ fn sync_all_providers_to_live(state: &AppState, app_type: &AppType) -> Result<()
     Ok(())
 }
 
+fn sync_pi_providers_to_live(state: &AppState) -> Result<(), AppError> {
+    let app_type = AppType::Pi;
+    let providers = state.db.get_all_providers(app_type.as_str())?;
+    let managed = providers
+        .values()
+        .filter(|provider| {
+            provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.live_config_managed)
+                != Some(false)
+        })
+        .collect::<Vec<_>>();
+    let current_id = crate::settings::get_effective_current_provider(&state.db, &app_type)?;
+    let active = current_id.as_deref().and_then(|id| {
+        managed
+            .iter()
+            .copied()
+            .find(|provider| provider.id.as_str() == id)
+    });
+    crate::pi_config::sync_pi_live_providers(&managed, active)
+}
+
 pub(crate) fn sync_current_provider_for_app_to_live(
     state: &AppState,
     app_type: &AppType,
 ) -> Result<(), AppError> {
-    if app_type.is_additive_mode() {
+    if matches!(app_type, AppType::Pi) {
+        sync_pi_providers_to_live(state)?;
+    } else if app_type.is_additive_mode() {
         sync_all_providers_to_live(state, app_type)?;
     } else {
         let current_id = match crate::settings::get_effective_current_provider(&state.db, app_type)?
@@ -1285,7 +1311,9 @@ fn sync_current_provider_for_app_respecting_takeover(
 pub fn sync_current_to_live(state: &AppState) -> Result<(), AppError> {
     // Sync providers based on mode
     for app_type in AppType::all() {
-        if app_type.is_additive_mode() {
+        if matches!(app_type, AppType::Pi) {
+            sync_pi_providers_to_live(state)?;
+        } else if app_type.is_additive_mode() {
             // Additive mode: sync ALL providers
             sync_all_providers_to_live(state, &app_type)?;
         } else {
@@ -1598,6 +1626,12 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
         }
         .to_string(),
     );
+    if matches!(app_type, AppType::Pi) {
+        provider
+            .meta
+            .get_or_insert_with(Default::default)
+            .live_config_managed = Some(true);
+    }
 
     state.db.save_provider(app_type.as_str(), &provider)?;
     state

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -527,7 +527,8 @@ fn settings_contain_common_config(app_type: &AppType, settings: &Value, snippet:
         | AppType::OpenCode
         | AppType::OpenClaw
         | AppType::Hermes
-        | AppType::ClaudeDesktop => false,
+        | AppType::ClaudeDesktop
+        | AppType::Pi => false,
     }
 }
 
@@ -601,7 +602,8 @@ pub(crate) fn remove_common_config_from_settings(
         | AppType::OpenCode
         | AppType::OpenClaw
         | AppType::Hermes
-        | AppType::ClaudeDesktop => Ok(settings.clone()),
+        | AppType::ClaudeDesktop
+        | AppType::Pi => Ok(settings.clone()),
     }
 }
 
@@ -660,7 +662,8 @@ fn apply_common_config_to_settings(
         | AppType::OpenCode
         | AppType::OpenClaw
         | AppType::Hermes
-        | AppType::ClaudeDesktop => Ok(settings.clone()),
+        | AppType::ClaudeDesktop
+        | AppType::Pi => Ok(settings.clone()),
     }
 }
 
@@ -1162,6 +1165,10 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
             crate::hermes_config::set_provider(&provider.id, provider.settings_config.clone())?;
             log::debug!("Hermes provider '{}' written to live config", provider.id);
         }
+        AppType::Pi => {
+            crate::pi_config::write_pi_live_provider(provider)?;
+            log::debug!("Pi provider '{}' written to live config", provider.id);
+        }
     }
     Ok(())
 }
@@ -1417,7 +1424,25 @@ pub fn read_live_settings(app_type: AppType) -> Result<Value, AppError> {
             let config = crate::hermes_config::yaml_to_json(&yaml_config)?;
             Ok(config)
         }
+        AppType::Pi => crate::pi_config::read_pi_live_settings(),
     }
+}
+
+fn pi_provider_config_from_live_settings(live_settings: Value) -> Value {
+    let mut provider_config = live_settings
+        .get("providerConfig")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    if let Some(default_model) = live_settings.get("defaultModel").cloned() {
+        if !default_model.is_null() {
+            if let Some(obj) = provider_config.as_object_mut() {
+                obj.insert("defaultModel".to_string(), default_model);
+            }
+        }
+    }
+
+    provider_config
 }
 
 /// Import default configuration from live files
@@ -1455,6 +1480,7 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
         ));
     }
 
+    let mut imported_provider_id = "default".to_string();
     let settings_config = match app_type {
         AppType::Codex => crate::codex_config::read_codex_live_settings()?,
         AppType::GrokBuild => {
@@ -1525,6 +1551,15 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
                 "config": config_obj
             })
         }
+        AppType::Pi => {
+            let live_settings = crate::pi_config::read_pi_live_settings()?;
+            imported_provider_id = live_settings
+                .get("defaultProvider")
+                .and_then(Value::as_str)
+                .unwrap_or("default")
+                .to_string();
+            pi_provider_config_from_live_settings(live_settings)
+        }
         // OpenCode, OpenClaw and Hermes use additive mode and are handled by early return above
         AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => {
             unreachable!("additive mode apps are handled by early return")
@@ -1532,8 +1567,8 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
     };
 
     let mut provider = Provider::with_id(
-        "default".to_string(),
-        "default".to_string(),
+        imported_provider_id.clone(),
+        imported_provider_id,
         settings_config,
         None,
     );
@@ -2614,5 +2649,30 @@ base_url = "https://a.example/v1"
 
         assert!(!config_text.contains("mcp_servers"));
         assert!(config_text.contains("model = \"grok-4.5\""));
+    }
+
+    #[test]
+    fn pi_import_provider_config_preserves_default_model() {
+        let live_settings = json!({
+            "defaultProvider": "packy",
+            "defaultModel": "gpt-5.5-mini",
+            "providerConfig": {
+                "baseUrl": "https://api.packy.example/v1",
+                "apiKey": "sk-packy",
+                "api": "openai-chat",
+                "models": [
+                    { "id": "gpt-5.5" },
+                    { "id": "gpt-5.5-mini" }
+                ]
+            }
+        });
+
+        let provider_config = pi_provider_config_from_live_settings(live_settings);
+
+        assert_eq!(
+            provider_config.get("defaultModel"),
+            Some(&json!("gpt-5.5-mini")),
+            "Pi import must preserve settings.json defaultModel inside stored provider config"
+        );
     }
 }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -2693,7 +2693,7 @@ base_url = "https://a.example/v1"
             "providerConfig": {
                 "baseUrl": "https://api.packy.example/v1",
                 "apiKey": "sk-packy",
-                "api": "openai-chat",
+                "api": "openai-completions",
                 "models": [
                     { "id": "gpt-5.5" },
                     { "id": "gpt-5.5-mini" }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1456,21 +1456,36 @@ pub fn read_live_settings(app_type: AppType) -> Result<Value, AppError> {
     }
 }
 
-fn pi_provider_config_from_live_settings(live_settings: Value) -> Value {
-    let mut provider_config = live_settings
-        .get("providerConfig")
-        .cloned()
-        .unwrap_or_else(|| json!({}));
-
-    if let Some(default_model) = live_settings.get("defaultModel").cloned() {
-        if !default_model.is_null() {
-            if let Some(obj) = provider_config.as_object_mut() {
-                obj.insert("defaultModel".to_string(), default_model);
-            }
-        }
+fn import_pi_providers_from_live(state: &AppState) -> Result<bool, AppError> {
+    let registry = crate::pi_config::read_pi_live_providers()?;
+    if registry.providers.is_empty() {
+        return Ok(false);
     }
 
-    provider_config
+    let imported_ids = registry
+        .providers
+        .iter()
+        .map(|provider| provider.id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    for mut provider in registry.providers {
+        provider.category = Some("custom".to_string());
+        provider
+            .meta
+            .get_or_insert_with(Default::default)
+            .live_config_managed = Some(true);
+        state.db.save_provider(AppType::Pi.as_str(), &provider)?;
+    }
+
+    if let Some(default_provider) = registry
+        .default_provider
+        .filter(|provider_id| imported_ids.contains(provider_id))
+    {
+        state
+            .db
+            .set_current_provider(AppType::Pi.as_str(), &default_provider)?;
+        crate::settings::set_current_provider(&AppType::Pi, Some(&default_provider))?;
+    }
+    Ok(true)
 }
 
 /// Import default configuration from live files
@@ -1508,7 +1523,11 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
         ));
     }
 
-    let mut imported_provider_id = "default".to_string();
+    if matches!(app_type, AppType::Pi) {
+        return import_pi_providers_from_live(state);
+    }
+
+    let imported_provider_id = "default".to_string();
     let settings_config = match app_type {
         AppType::Codex => crate::codex_config::read_codex_live_settings()?,
         AppType::GrokBuild => {
@@ -1579,15 +1598,7 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
                 "config": config_obj
             })
         }
-        AppType::Pi => {
-            let live_settings = crate::pi_config::read_pi_live_settings()?;
-            imported_provider_id = live_settings
-                .get("defaultProvider")
-                .and_then(Value::as_str)
-                .unwrap_or("default")
-                .to_string();
-            pi_provider_config_from_live_settings(live_settings)
-        }
+        AppType::Pi => unreachable!("Pi imports its complete provider registry above"),
         // OpenCode, OpenClaw and Hermes use additive mode and are handled by early return above
         AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => {
             unreachable!("additive mode apps are handled by early return")
@@ -1626,13 +1637,6 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
         }
         .to_string(),
     );
-    if matches!(app_type, AppType::Pi) {
-        provider
-            .meta
-            .get_or_insert_with(Default::default)
-            .live_config_managed = Some(true);
-    }
-
     state.db.save_provider(app_type.as_str(), &provider)?;
     state
         .db
@@ -2683,30 +2687,5 @@ base_url = "https://a.example/v1"
 
         assert!(!config_text.contains("mcp_servers"));
         assert!(config_text.contains("model = \"grok-4.5\""));
-    }
-
-    #[test]
-    fn pi_import_provider_config_preserves_default_model() {
-        let live_settings = json!({
-            "defaultProvider": "packy",
-            "defaultModel": "gpt-5.5-mini",
-            "providerConfig": {
-                "baseUrl": "https://api.packy.example/v1",
-                "apiKey": "sk-packy",
-                "api": "openai-completions",
-                "models": [
-                    { "id": "gpt-5.5" },
-                    { "id": "gpt-5.5-mini" }
-                ]
-            }
-        });
-
-        let provider_config = pi_provider_config_from_live_settings(live_settings);
-
-        assert_eq!(
-            provider_config.get("defaultModel"),
-            Some(&json!("gpt-5.5-mini")),
-            "Pi import must preserve settings.json defaultModel inside stored provider config"
-        );
     }
 }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -703,21 +703,20 @@ mod tests {
     }
 
     #[test]
-    fn validate_provider_settings_uses_pi_schema_validator() {
+    fn validate_provider_settings_accepts_extension_owned_pi_api() {
         let provider = Provider::with_id(
             "pi-custom".into(),
             "Pi Custom".into(),
             json!({
                 "baseUrl": "https://example.com/v1",
-                "api": "openai-chat",
+                "api": "extension-owned-api",
                 "models": [{ "id": "model-1" }]
             }),
             None,
         );
 
-        let error = ProviderService::validate_provider_settings(&AppType::Pi, &provider)
-            .expect_err("unsupported Pi API must be rejected at the service boundary");
-        assert!(error.to_string().contains("unsupported API"));
+        ProviderService::validate_provider_settings(&AppType::Pi, &provider)
+            .expect("non-empty extension-owned Pi APIs should pass the service boundary");
     }
 
     #[test]
@@ -2586,27 +2585,16 @@ impl ProviderService {
         state.db.save_provider(app_type.as_str(), &provider)?;
 
         // Pi combines an additive provider registry with an active default.
+        // Adding to the registry must not select it; selection is an explicit
+        // switch operation, including for the first provider.
         if matches!(app_type, AppType::Pi) {
             if !add_to_live {
                 return Ok(true);
             }
 
-            let current = crate::settings::get_effective_current_provider(&state.db, &app_type)?;
-            let live_result = if current.is_none() {
-                crate::pi_config::activate_pi_live_provider(&provider, false)
-            } else {
-                crate::pi_config::upsert_pi_live_provider(&provider, false)
-            };
-            if let Err(error) = live_result {
+            if let Err(error) = crate::pi_config::upsert_pi_live_provider(&provider, false) {
                 let _ = state.db.delete_provider(app_type.as_str(), &provider.id);
                 return Err(error);
-            }
-
-            if current.is_none() {
-                state
-                    .db
-                    .set_current_provider(app_type.as_str(), &provider.id)?;
-                crate::settings::set_current_provider(&app_type, Some(&provider.id))?;
             }
             return Ok(true);
         }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -703,6 +703,24 @@ mod tests {
     }
 
     #[test]
+    fn validate_provider_settings_uses_pi_schema_validator() {
+        let provider = Provider::with_id(
+            "pi-custom".into(),
+            "Pi Custom".into(),
+            json!({
+                "baseUrl": "https://example.com/v1",
+                "api": "openai-chat",
+                "models": [{ "id": "model-1" }]
+            }),
+            None,
+        );
+
+        let error = ProviderService::validate_provider_settings(&AppType::Pi, &provider)
+            .expect_err("unsupported Pi API must be rejected at the service boundary");
+        assert!(error.to_string().contains("unsupported API"));
+    }
+
+    #[test]
     fn extract_gemini_common_config_strips_credentials_keeps_shareable() {
         // Gemini 的共享片段会被 deep-merge 回**其它** Gemini 供应商的 env
         // (live.rs::apply_common_config_to_settings)，因此任何凭据都不得进入片段。
@@ -4382,13 +4400,7 @@ impl ProviderService {
                 }
             }
             AppType::Pi => {
-                if !provider.settings_config.is_object() {
-                    return Err(AppError::localized(
-                        "provider.pi.settings.not_object",
-                        "Pi Agent 配置必须是 JSON 对象",
-                        "Pi Agent configuration must be a JSON object",
-                    ));
-                }
+                crate::pi_config::validate_pi_provider_config(&provider.settings_config)?;
             }
         }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -3462,6 +3462,7 @@ impl ProviderService {
             AppType::OpenCode => Self::extract_opencode_common_config(&provider.settings_config),
             AppType::OpenClaw => Self::extract_openclaw_common_config(&provider.settings_config),
             AppType::Hermes => Ok(String::new()), // Hermes doesn't use common config snippets
+            AppType::Pi => Ok(String::new()),     // Pi doesn't use common config snippets
         }
     }
 
@@ -3479,6 +3480,7 @@ impl ProviderService {
             AppType::OpenCode => Self::extract_opencode_common_config(settings_config),
             AppType::OpenClaw => Self::extract_openclaw_common_config(settings_config),
             AppType::Hermes => Ok(String::new()), // Hermes doesn't use common config snippets
+            AppType::Pi => Ok(String::new()),     // Pi doesn't use common config snippets
         }
     }
 
@@ -4244,6 +4246,15 @@ impl ProviderService {
                     ));
                 }
             }
+            AppType::Pi => {
+                if !provider.settings_config.is_object() {
+                    return Err(AppError::localized(
+                        "provider.pi.settings.not_object",
+                        "Pi Agent 配置必须是 JSON 对象",
+                        "Pi Agent configuration must be a JSON object",
+                    ));
+                }
+            }
         }
 
         // Validate and clean UsageScript configuration (common for all app types)
@@ -4448,7 +4459,7 @@ impl ProviderService {
 
                 Ok((api_key, base_url))
             }
-            AppType::OpenClaw | AppType::Hermes => {
+            AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
                 // OpenClaw/Hermes use apiKey and baseUrl directly on the object
                 let api_key = provider
                     .settings_config
@@ -4466,6 +4477,7 @@ impl ProviderService {
                 let base_url = provider
                     .settings_config
                     .get("baseUrl")
+                    .or_else(|| provider.settings_config.get("baseURL"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2560,12 +2560,38 @@ impl ProviderService {
         Self::validate_provider_settings(&app_type, &provider)?;
         normalize_provider_common_config_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
         Self::normalize_usage_script_credential_overrides(&app_type, &mut provider);
-        if app_type.is_additive_mode() {
+        if app_type.uses_additive_provider_registry() {
             Self::set_provider_live_config_managed(&mut provider, add_to_live);
         }
 
         // Save to database
         state.db.save_provider(app_type.as_str(), &provider)?;
+
+        // Pi combines an additive provider registry with an active default.
+        if matches!(app_type, AppType::Pi) {
+            if !add_to_live {
+                return Ok(true);
+            }
+
+            let current = crate::settings::get_effective_current_provider(&state.db, &app_type)?;
+            let live_result = if current.is_none() {
+                crate::pi_config::activate_pi_live_provider(&provider, false)
+            } else {
+                crate::pi_config::upsert_pi_live_provider(&provider, false)
+            };
+            if let Err(error) = live_result {
+                let _ = state.db.delete_provider(app_type.as_str(), &provider.id);
+                return Err(error);
+            }
+
+            if current.is_none() {
+                state
+                    .db
+                    .set_current_provider(app_type.as_str(), &provider.id)?;
+                crate::settings::set_current_provider(&app_type, Some(&provider.id))?;
+            }
+            return Ok(true);
+        }
 
         // Additive mode apps (OpenCode, OpenClaw): optionally write to live config.
         if app_type.is_additive_mode() {
@@ -2684,6 +2710,50 @@ impl ProviderService {
                 crate::settings::set_current_provider(&app_type, Some(provider.id.as_str()))?;
             }
 
+            return Ok(true);
+        }
+
+        if matches!(app_type, AppType::Pi) {
+            let existing = existing_provider.as_ref().ok_or_else(|| {
+                AppError::Message(format!(
+                    "Provider '{}' does not exist in app '{}'",
+                    provider.id,
+                    app_type.as_str()
+                ))
+            })?;
+            let live_config_managed = match Self::provider_live_config_managed(existing) {
+                Some(managed) => managed,
+                None => crate::pi_config::pi_provider_exists(&provider.id)?,
+            };
+            Self::set_provider_live_config_managed(&mut provider, live_config_managed);
+
+            if !live_config_managed {
+                state.db.save_provider(app_type.as_str(), &provider)?;
+                return Ok(true);
+            }
+
+            let is_current = crate::settings::get_effective_current_provider(&state.db, &app_type)?
+                .as_deref()
+                == Some(provider.id.as_str());
+            let write_provider = |value: &Provider| {
+                if is_current {
+                    crate::pi_config::activate_pi_live_provider(value, true)
+                } else {
+                    crate::pi_config::upsert_pi_live_provider(value, true)
+                }
+            };
+
+            write_provider(&provider)?;
+            if let Err(error) = state.db.save_provider(app_type.as_str(), &provider) {
+                if let Err(rollback_error) = write_provider(existing) {
+                    log::warn!(
+                        "Failed to roll back Pi provider '{}' after DB save error: {}",
+                        provider.id,
+                        rollback_error
+                    );
+                }
+                return Err(error);
+            }
             return Ok(true);
         }
 
@@ -2887,6 +2957,32 @@ impl ProviderService {
             ));
         }
 
+        if matches!(app_type, AppType::Pi) {
+            let existing = state.db.get_provider_by_id(id, app_type.as_str())?;
+            let live_config_managed = existing
+                .as_ref()
+                .and_then(Self::provider_live_config_managed)
+                == Some(true);
+            if live_config_managed {
+                crate::pi_config::remove_pi_live_provider(id)?;
+            }
+            if let Err(error) = state.db.delete_provider(app_type.as_str(), id) {
+                if live_config_managed {
+                    if let Some(existing) = existing.as_ref() {
+                        if let Err(rollback_error) =
+                            crate::pi_config::upsert_pi_live_provider(existing, true)
+                        {
+                            log::warn!(
+                                "Failed to restore Pi provider '{id}' after DB delete error: {rollback_error}"
+                            );
+                        }
+                    }
+                }
+                return Err(error);
+            }
+            return Ok(());
+        }
+
         state.db.delete_provider(app_type.as_str(), id)
     }
 
@@ -2934,6 +3030,16 @@ impl ProviderService {
             }
             AppType::Hermes => {
                 remove_hermes_provider_from_live(id)?;
+            }
+            AppType::Pi => {
+                let current =
+                    crate::settings::get_effective_current_provider(&state.db, &app_type)?;
+                if current.as_deref() == Some(id) {
+                    return Err(AppError::Message(
+                        "Cannot remove the active Pi provider from live config".to_string(),
+                    ));
+                }
+                crate::pi_config::remove_pi_live_provider(id)?;
             }
             _ => {
                 return Err(AppError::Message(format!(
@@ -3130,6 +3236,33 @@ impl ProviderService {
             }
         }
 
+        let pi_live_preapplied = if matches!(app_type, AppType::Pi) {
+            let overwrite_existing = match Self::provider_live_config_managed(provider) {
+                Some(managed) => managed,
+                None => crate::pi_config::pi_provider_exists(&provider.id)?,
+            };
+            let mut managed_provider = provider.clone();
+            let marker_changed = Self::provider_live_config_managed(provider) != Some(true);
+            if marker_changed {
+                Self::set_provider_live_config_managed(&mut managed_provider, true);
+                state
+                    .db
+                    .save_provider(app_type.as_str(), &managed_provider)?;
+            }
+
+            if let Err(error) =
+                crate::pi_config::activate_pi_live_provider(provider, overwrite_existing)
+            {
+                if marker_changed {
+                    let _ = state.db.save_provider(app_type.as_str(), provider);
+                }
+                return Err(error);
+            }
+            true
+        } else {
+            false
+        };
+
         // Additive mode apps skip setting is_current (no such concept)
         if !app_type.is_additive_mode() {
             // Update local settings (device-level, takes priority)
@@ -3140,7 +3273,9 @@ impl ProviderService {
         }
 
         // Sync to live (write_gemini_live handles security flag internally for Gemini)
-        write_live_with_common_config(state.db.as_ref(), &app_type, provider)?;
+        if !pi_live_preapplied {
+            write_live_with_common_config(state.db.as_ref(), &app_type, provider)?;
+        }
 
         // Hermes is additive, so "switching" doesn't overwrite a live config file
         // — we instead update the top-level `model:` section to point at this

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -565,6 +565,7 @@ impl SkillService {
                     return Ok(custom.join("skills"));
                 }
             }
+            AppType::Pi => {}
         }
 
         // 默认路径：回退到用户主目录下的标准位置。
@@ -581,6 +582,7 @@ impl SkillService {
             AppType::OpenCode => home.join(".config").join("opencode").join("skills"),
             AppType::OpenClaw => home.join(".openclaw").join("skills"),
             AppType::Hermes => crate::hermes_config::get_hermes_dir().join("skills"),
+            AppType::Pi => crate::pi_config::get_pi_dir().join("skills"),
         })
     }
 
@@ -1662,7 +1664,7 @@ impl SkillService {
     /// - Symlink: 仅使用 symlink
     /// - Copy: 仅使用文件复制
     pub fn sync_to_app_dir(directory: &str, app: &AppType) -> Result<()> {
-        if matches!(app, AppType::ClaudeDesktop) {
+        if matches!(app, AppType::ClaudeDesktop | AppType::Pi) {
             return Ok(());
         }
 
@@ -1837,7 +1839,7 @@ impl SkillService {
 
     /// 从应用目录删除 Skill（支持 symlink 和真实目录）
     pub fn remove_from_app(directory: &str, app: &AppType) -> Result<()> {
-        if matches!(app, AppType::ClaudeDesktop) {
+        if matches!(app, AppType::ClaudeDesktop | AppType::Pi) {
             return Ok(());
         }
 
@@ -1858,7 +1860,7 @@ impl SkillService {
 
     /// 同步所有已启用的 Skills 到指定应用
     pub fn sync_to_app(db: &Arc<Database>, app: &AppType) -> Result<()> {
-        if matches!(app, AppType::ClaudeDesktop) {
+        if matches!(app, AppType::ClaudeDesktop | AppType::Pi) {
             return Ok(());
         }
 
@@ -2744,6 +2746,9 @@ impl SkillService {
         }
 
         for app in AppType::all() {
+            if matches!(app, AppType::Pi) {
+                continue;
+            }
             let app_dir = match Self::get_app_skills_dir(&app) {
                 Ok(dir) => dir,
                 Err(_) => continue,
@@ -3472,6 +3477,9 @@ pub fn migrate_skills_to_ssot(db: &Arc<Database>) -> Result<usize> {
 
     // 扫描各应用目录
     for app in AppType::all() {
+        if matches!(app, AppType::Pi) {
+            continue;
+        }
         let app_dir = match SkillService::get_app_skills_dir(&app) {
             Ok(d) => d,
             Err(_) => continue,

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -181,6 +181,7 @@ impl StreamCheckService {
             }
             AppType::OpenClaw => Self::extract_openclaw_base_url(provider),
             AppType::Hermes => Self::extract_hermes_base_url(provider),
+            AppType::Pi => Self::extract_pi_base_url(provider),
             AppType::ClaudeDesktop => ClaudeAdapter::new()
                 .extract_base_url(provider)
                 .map_err(|e| AppError::Message(format!("Failed to extract base_url: {e}"))),
@@ -188,6 +189,18 @@ impl StreamCheckService {
                 .extract_base_url(provider)
                 .map_err(|e| AppError::Message(format!("Failed to extract base_url: {e}"))),
         }
+    }
+
+    fn extract_pi_base_url(provider: &Provider) -> Result<String, AppError> {
+        provider
+            .settings_config
+            .get("baseUrl")
+            .or_else(|| provider.settings_config.get("baseURL"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| AppError::Message("Pi provider baseUrl is missing".to_string()))
     }
 
     /// 轻量可达性探测：GET `base_url`，收到任意 HTTP 响应即可达。

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -46,7 +46,7 @@ pub struct VisibleApps {
     pub openclaw: bool,
     #[serde(default)]
     pub hermes: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub pi: bool,
 }
 
@@ -61,7 +61,7 @@ impl Default for VisibleApps {
             opencode: true,
             openclaw: true,
             hermes: false, // 默认不显示，需用户手动启用
-            pi: true,
+            pi: false,     // 默认不显示，需用户手动启用
         }
     }
 }
@@ -1189,6 +1189,10 @@ mod tests {
         .expect("visible apps");
 
         assert!(visible.is_visible(&AppType::ClaudeDesktop));
+        assert!(
+            !visible.is_visible(&AppType::Pi),
+            "Pi remains opt-in when older settings have no Pi field"
+        );
     }
 
     #[test]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -46,6 +46,8 @@ pub struct VisibleApps {
     pub openclaw: bool,
     #[serde(default)]
     pub hermes: bool,
+    #[serde(default = "default_true")]
+    pub pi: bool,
 }
 
 impl Default for VisibleApps {
@@ -59,6 +61,7 @@ impl Default for VisibleApps {
             opencode: true,
             openclaw: true,
             hermes: false, // 默认不显示，需用户手动启用
+            pi: true,
         }
     }
 }
@@ -75,6 +78,7 @@ impl VisibleApps {
             AppType::OpenCode => self.opencode,
             AppType::OpenClaw => self.openclaw,
             AppType::Hermes => self.hermes,
+            AppType::Pi => self.pi,
         }
     }
 }
@@ -450,6 +454,9 @@ pub struct AppSettings {
     /// 当前 Hermes 供应商 ID（本地存储，保持结构一致）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_hermes: Option<String>,
+    /// 当前 Pi Agent 供应商 ID（本地存储，保持结构一致）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_pi: Option<String>,
 
     // ===== Skill 同步设置 =====
     /// Skill 同步方式：auto（默认，优先 symlink）、symlink、copy
@@ -544,6 +551,7 @@ impl Default for AppSettings {
             current_provider_opencode: None,
             current_provider_openclaw: None,
             current_provider_hermes: None,
+            current_provider_pi: None,
             skill_sync_method: SyncMethod::default(),
             skill_storage_location: SkillStorageLocation::default(),
             webdav_sync: None,
@@ -988,6 +996,7 @@ pub fn get_current_provider(app_type: &AppType) -> Option<String> {
         AppType::OpenCode => settings.current_provider_opencode.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw.clone(),
         AppType::Hermes => settings.current_provider_hermes.clone(),
+        AppType::Pi => settings.current_provider_pi.clone(),
     }
 }
 
@@ -1006,6 +1015,7 @@ pub fn set_current_provider(app_type: &AppType, id: Option<&str>) -> Result<(), 
         AppType::OpenCode => settings.current_provider_opencode = id_owned.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw = id_owned.clone(),
         AppType::Hermes => settings.current_provider_hermes = id_owned.clone(),
+        AppType::Pi => settings.current_provider_pi = id_owned.clone(),
     })
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -422,6 +422,8 @@ pub struct AppSettings {
     pub openclaw_config_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hermes_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pi_config_dir: Option<String>,
 
     // ===== 当前供应商 ID（设备级）=====
     /// 当前 Claude 供应商 ID（本地存储，优先于数据库 is_current）
@@ -533,6 +535,7 @@ impl Default for AppSettings {
             opencode_config_dir: None,
             openclaw_config_dir: None,
             hermes_config_dir: None,
+            pi_config_dir: None,
             current_provider_claude: None,
             current_provider_claude_desktop: None,
             current_provider_codex: None,
@@ -609,6 +612,13 @@ impl AppSettings {
 
         self.hermes_config_dir = self
             .hermes_config_dir
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        self.pi_config_dir = self
+            .pi_config_dir
             .as_ref()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
@@ -929,6 +939,14 @@ pub fn get_hermes_override_dir() -> Option<PathBuf> {
     let settings = settings_store().read().ok()?;
     settings
         .hermes_config_dir
+        .as_ref()
+        .map(|p| resolve_override_path(p))
+}
+
+pub fn get_pi_override_dir() -> Option<PathBuf> {
+    let settings = settings_store().read().ok()?;
+    settings
+        .pi_config_dir
         .as_ref()
         .map(|p| resolve_override_path(p))
 }

--- a/src-tauri/tests/app_config_load.rs
+++ b/src-tauri/tests/app_config_load.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use cc_switch_lib::{AppError, MultiAppConfig};
+use cc_switch_lib::{AppError, AppType, MultiAppConfig};
 
 mod support;
 use support::{ensure_test_home, reset_test_fs, test_mutex};
@@ -104,4 +104,37 @@ fn load_valid_v2_config_succeeds() {
         .get_manager(&cc_switch_lib::AppType::Claude)
         .is_some());
     assert!(loaded.get_manager(&cc_switch_lib::AppType::Codex).is_some());
+}
+
+#[test]
+fn load_v2_config_backfills_missing_pi_manager_and_persists_it() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+    let path = cfg_path();
+    fs::create_dir_all(path.parent().unwrap()).expect("create cfg dir");
+
+    let mut value = serde_json::to_value(MultiAppConfig::default()).expect("serialize config");
+    value.as_object_mut().expect("config root").remove("pi");
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(&value).expect("serialize legacy v2 config"),
+    )
+    .expect("write legacy v2 config");
+
+    let loaded = MultiAppConfig::load().expect("legacy v2 config should load");
+    assert!(
+        loaded.get_manager(&AppType::Pi).is_some(),
+        "loading an existing v2 config should add the Pi provider manager"
+    );
+
+    let persisted: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("read migrated config"))
+            .expect("parse migrated config");
+    assert!(
+        persisted
+            .get("pi")
+            .is_some_and(serde_json::Value::is_object),
+        "the Pi provider manager migration should be persisted"
+    );
 }

--- a/src-tauri/tests/deeplink_import.rs
+++ b/src-tauri/tests/deeplink_import.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use cc_switch_lib::{import_provider_from_deeplink, parse_deeplink_url, AppState, Database};
+use serde_json::json;
 
 #[path = "support.rs"]
 mod support;
@@ -83,4 +85,51 @@ fn deeplink_import_codex_provider_builds_auth_and_config() {
         config_text.contains("model = \"gpt-4o\""),
         "config.toml content should contain model setting"
     );
+}
+
+#[test]
+fn deeplink_import_pi_provider_preserves_pi_specific_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let inline_config = json!({
+        "baseUrl": "https://api.example.com/v1",
+        "apiKey": "sk-test-pi-key",
+        "api": "anthropic-messages",
+        "models": [{
+            "id": "claude-sonnet-4",
+            "name": "Claude Sonnet 4",
+            "contextWindow": 200000
+        }],
+        "defaultModel": "claude-sonnet-4",
+        "customHeader": "preserve-me"
+    });
+    let encoded = URL_SAFE_NO_PAD.encode(inline_config.to_string());
+    let url = format!(
+        "ccswitch://v1/import?resource=provider&app=pi&name=DeepLink%20Pi&config={encoded}&configFormat=json"
+    );
+    let request = parse_deeplink_url(&url).expect("parse Pi deeplink url");
+
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let state = AppState::new(db.clone());
+    let provider_id =
+        import_provider_from_deeplink(&state, request).expect("import Pi provider from deeplink");
+
+    let providers = db.get_all_providers("pi").expect("get Pi providers");
+    let provider = providers
+        .get(&provider_id)
+        .expect("Pi provider created via deeplink");
+
+    assert_eq!(provider.settings_config["api"], "anthropic-messages");
+    assert_eq!(
+        provider.settings_config["models"][0]["name"],
+        "Claude Sonnet 4"
+    );
+    assert_eq!(
+        provider.settings_config["models"][0]["contextWindow"],
+        200000
+    );
+    assert_eq!(provider.settings_config["defaultModel"], "claude-sonnet-4");
+    assert_eq!(provider.settings_config["customHeader"], "preserve-me");
 }

--- a/src-tauri/tests/pi_config.rs
+++ b/src-tauri/tests/pi_config.rs
@@ -1,0 +1,285 @@
+use serde_json::json;
+use serial_test::serial;
+use std::ffi::OsString;
+use std::fs;
+use tempfile::TempDir;
+
+struct TempHome {
+    #[allow(dead_code)]
+    dir: TempDir,
+    original_home: Option<OsString>,
+    original_userprofile: Option<OsString>,
+    original_test_home: Option<OsString>,
+    original_pi_dir: Option<OsString>,
+}
+
+impl TempHome {
+    fn new() -> Self {
+        let dir = TempDir::new().expect("failed to create temp home");
+        let original_home = std::env::var_os("HOME");
+        let original_userprofile = std::env::var_os("USERPROFILE");
+        let original_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        let original_pi_dir = std::env::var_os("PI_CODING_AGENT_DIR");
+
+        std::env::set_var("HOME", dir.path());
+        std::env::set_var("USERPROFILE", dir.path());
+        std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+        std::env::remove_var("PI_CODING_AGENT_DIR");
+
+        Self {
+            dir,
+            original_home,
+            original_userprofile,
+            original_test_home,
+            original_pi_dir,
+        }
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        match &self.original_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match &self.original_userprofile {
+            Some(value) => std::env::set_var("USERPROFILE", value),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        match &self.original_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+        match &self.original_pi_dir {
+            Some(value) => std::env::set_var("PI_CODING_AGENT_DIR", value),
+            None => std::env::remove_var("PI_CODING_AGENT_DIR"),
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn writes_provider_and_defaults_without_clobbering_existing_pi_config() {
+    let home = TempHome::new();
+    let pi_dir = home.dir.path().join(".pi").join("agent");
+    fs::create_dir_all(&pi_dir).expect("create pi config dir");
+    fs::write(
+        pi_dir.join("models.json"),
+        r#"{
+  "providers": {
+    "existing": {
+      "baseURL": "https://existing.example/v1",
+      "apiKey": "keep",
+      "models": ["existing-model"]
+    }
+  },
+  "metadata": {
+    "keep": true
+  }
+}"#,
+    )
+    .expect("seed models.json");
+    fs::write(
+        pi_dir.join("settings.json"),
+        r#"{
+  "defaultProvider": "existing",
+  "defaultModel": "existing-model",
+  "theme": "dark"
+}"#,
+    )
+    .expect("seed settings.json");
+
+    let provider = cc_switch_lib::Provider::with_id(
+        "packy".to_string(),
+        "Packy".to_string(),
+        json!({
+            "baseUrl": "https://api.packy.example/v1",
+            "apiKey": "sk-packy",
+            "api": "openai-chat",
+            "models": [
+                {
+                    "id": "gpt-5.5",
+                    "name": "GPT 5.5",
+                    "contextWindow": 400000
+                },
+                { "id": "gpt-5.5-mini", "name": "GPT 5.5 Mini" }
+            ],
+            "defaultModel": "gpt-5.5-mini"
+        }),
+        None,
+    );
+
+    cc_switch_lib::pi_config::write_pi_live_provider(&provider).expect("write pi live");
+
+    let models: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(pi_dir.join("models.json")).unwrap()).unwrap();
+    assert_eq!(
+        models.pointer("/providers/existing/apiKey"),
+        Some(&json!("keep")),
+        "existing provider should be preserved"
+    );
+    assert_eq!(models.pointer("/metadata/keep"), Some(&json!(true)));
+    assert_eq!(
+        models.pointer("/providers/packy/baseUrl"),
+        Some(&json!("https://api.packy.example/v1"))
+    );
+    assert!(
+        models.pointer("/providers/packy/baseURL").is_none(),
+        "new Pi providers should use the canonical baseUrl key"
+    );
+    assert_eq!(
+        models.pointer("/providers/packy/models/1/id"),
+        Some(&json!("gpt-5.5-mini")),
+        "Pi provider model ids should be preserved"
+    );
+    assert_eq!(
+        models.pointer("/providers/packy/models/0/name"),
+        Some(&json!("GPT 5.5")),
+        "Pi provider model display names should be preserved"
+    );
+    assert_eq!(
+        models.pointer("/providers/packy/models/0/contextWindow"),
+        Some(&json!(400000)),
+        "Pi provider model metadata should be preserved"
+    );
+    assert!(
+        models.pointer("/providers/packy/defaultModel").is_none(),
+        "defaultModel is a settings.json concern and should not be written into provider config"
+    );
+
+    let settings: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(pi_dir.join("settings.json")).unwrap()).unwrap();
+    assert_eq!(
+        settings.pointer("/defaultProvider"),
+        Some(&json!("packy")),
+        "switch should update Pi default provider"
+    );
+    assert_eq!(
+        settings.pointer("/defaultModel"),
+        Some(&json!("gpt-5.5-mini")),
+        "switch should use explicit defaultModel"
+    );
+    assert_eq!(
+        settings.pointer("/theme"),
+        Some(&json!("dark")),
+        "unrelated settings should be preserved"
+    );
+}
+
+#[test]
+#[serial]
+fn read_live_settings_returns_current_provider_fragment() {
+    let home = TempHome::new();
+    let pi_dir = home.dir.path().join(".pi").join("agent");
+    fs::create_dir_all(&pi_dir).expect("create pi config dir");
+    fs::write(
+        pi_dir.join("models.json"),
+        r#"{
+  "providers": {
+    "packy": {
+      "baseURL": "https://api.packy.example/v1",
+      "apiKey": "sk-packy",
+      "api": "openai-chat",
+      "models": ["gpt-5.5"]
+    }
+  }
+}"#,
+    )
+    .expect("seed models.json");
+    fs::write(
+        pi_dir.join("settings.json"),
+        r#"{
+  "defaultProvider": "packy",
+  "defaultModel": "gpt-5.5"
+}"#,
+    )
+    .expect("seed settings.json");
+
+    let settings = cc_switch_lib::pi_config::read_pi_live_settings().expect("read pi live");
+
+    assert_eq!(settings["defaultProvider"], json!("packy"));
+    assert_eq!(settings["defaultModel"], json!("gpt-5.5"));
+    assert_eq!(
+        settings.pointer("/providerConfig/baseUrl"),
+        Some(&json!("https://api.packy.example/v1"))
+    );
+    assert_eq!(
+        settings.pointer("/providerConfig/models/0/id"),
+        Some(&json!("gpt-5.5")),
+        "model ids should be converted into the CC Switch form shape"
+    );
+}
+
+#[test]
+#[serial]
+fn write_provider_clears_stale_default_model_when_no_model_can_be_derived() {
+    let home = TempHome::new();
+    let pi_dir = home.dir.path().join(".pi").join("agent");
+    fs::create_dir_all(&pi_dir).expect("create pi config dir");
+    fs::write(pi_dir.join("models.json"), r#"{"providers":{}}"#).expect("seed models.json");
+    fs::write(
+        pi_dir.join("settings.json"),
+        r#"{
+  "defaultProvider": "old",
+  "defaultModel": "old-model"
+}"#,
+    )
+    .expect("seed settings.json");
+
+    let provider = cc_switch_lib::Provider::with_id(
+        "empty".to_string(),
+        "Empty".to_string(),
+        json!({
+            "baseUrl": "https://api.example.com/v1",
+            "apiKey": "sk-empty",
+            "api": "openai-chat",
+            "models": []
+        }),
+        None,
+    );
+
+    cc_switch_lib::pi_config::write_pi_live_provider(&provider).expect("write pi live");
+
+    let settings: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(pi_dir.join("settings.json")).unwrap()).unwrap();
+    assert_eq!(settings.pointer("/defaultProvider"), Some(&json!("empty")));
+    assert!(
+        settings.pointer("/defaultModel").is_none(),
+        "stale defaultModel from the previous provider must not survive"
+    );
+}
+
+#[test]
+#[serial]
+fn write_provider_rejects_existing_non_object_pi_files() {
+    let home = TempHome::new();
+    let pi_dir = home.dir.path().join(".pi").join("agent");
+    fs::create_dir_all(&pi_dir).expect("create pi config dir");
+    fs::write(pi_dir.join("models.json"), "[]").expect("seed invalid models root");
+    fs::write(pi_dir.join("settings.json"), r#"{}"#).expect("seed settings.json");
+
+    let provider = cc_switch_lib::Provider::with_id(
+        "packy".to_string(),
+        "Packy".to_string(),
+        json!({
+            "baseUrl": "https://api.packy.example/v1",
+            "apiKey": "sk-packy",
+            "api": "openai-chat",
+            "models": [{ "id": "gpt-5.5" }]
+        }),
+        None,
+    );
+
+    let err = cc_switch_lib::pi_config::write_pi_live_provider(&provider)
+        .expect_err("non-object Pi config root should be rejected");
+    assert!(
+        err.to_string().contains("must be a JSON object"),
+        "unexpected error: {err}"
+    );
+
+    assert_eq!(
+        fs::read_to_string(pi_dir.join("models.json")).unwrap(),
+        "[]",
+        "invalid-but-existing user file should not be overwritten"
+    );
+}

--- a/src-tauri/tests/pi_config.rs
+++ b/src-tauri/tests/pi_config.rs
@@ -70,7 +70,7 @@ fn writes_provider_and_defaults_without_clobbering_existing_pi_config() {
     "existing": {
       "baseURL": "https://existing.example/v1",
       "apiKey": "keep",
-      "models": ["existing-model"]
+      "models": [{ "id": "existing-model" }]
     }
   },
   "metadata": {
@@ -146,6 +146,30 @@ fn writes_provider_and_defaults_without_clobbering_existing_pi_config() {
         models.pointer("/providers/packy/defaultModel").is_none(),
         "defaultModel is a settings.json concern and should not be written into provider config"
     );
+    assert!(
+        models.pointer("/providers/packy/apiKey").is_none(),
+        "managed API keys must not be written inline"
+    );
+
+    let auth: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(pi_dir.join("auth.json")).unwrap()).unwrap();
+    assert_eq!(
+        auth.pointer("/packy"),
+        Some(&json!({ "type": "api_key", "key": "sk-packy" }))
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            fs::metadata(pi_dir.join("auth.json"))
+                .expect("auth metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600,
+            "new auth.json must be private"
+        );
+    }
 
     let settings: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(pi_dir.join("settings.json")).unwrap()).unwrap();
@@ -217,7 +241,7 @@ fn read_live_settings_returns_current_provider_fragment() {
       "baseURL": "https://api.packy.example/v1",
       "apiKey": "sk-packy",
       "api": "openai-completions",
-      "models": ["gpt-5.5"]
+      "models": [{ "id": "gpt-5.5" }]
     }
   }
 }"#,
@@ -243,7 +267,171 @@ fn read_live_settings_returns_current_provider_fragment() {
     assert_eq!(
         settings.pointer("/providerConfig/models/0/id"),
         Some(&json!("gpt-5.5")),
-        "model ids should be converted into the CC Switch form shape"
+        "model ids should retain the CC Switch form shape"
+    );
+    assert_eq!(
+        settings.pointer("/providerConfig/apiKey"),
+        Some(&json!("sk-packy")),
+        "legacy inline keys remain readable until a managed update migrates them"
+    );
+}
+
+#[test]
+#[serial]
+fn managed_update_migrates_a_legacy_inline_key_to_auth_json() {
+    let home = TempHome::new();
+    let pi_dir = home.dir.path().join(".pi").join("agent");
+    fs::create_dir_all(&pi_dir).expect("create pi config dir");
+    fs::write(
+        pi_dir.join("models.json"),
+        r#"// keep this file comment
+{
+  "providers": {
+    "packy": {
+      "baseUrl": "https://api.packy.example/v1",
+      "apiKey": "legacy-inline",
+      "api": "openai-completions",
+      "models": [{ "id": "gpt-5.5" }],
+    },
+  },
+}
+"#,
+    )
+    .expect("seed models");
+    fs::write(
+        pi_dir.join("settings.json"),
+        r#"{"defaultProvider":"packy","defaultModel":"gpt-5.5"}"#,
+    )
+    .expect("seed settings");
+
+    let live = cc_switch_lib::pi_config::read_pi_live_settings().expect("read legacy provider");
+    let provider = cc_switch_lib::Provider::with_id(
+        "packy".to_string(),
+        "Packy".to_string(),
+        live["providerConfig"].clone(),
+        None,
+    );
+    cc_switch_lib::pi_config::upsert_pi_live_provider(&provider, true).expect("migrate legacy key");
+
+    let models_text = fs::read_to_string(pi_dir.join("models.json")).expect("read models");
+    assert!(models_text.contains("// keep this file comment"));
+    let models = cc_switch_lib::pi_config::read_pi_live_settings().expect("re-read provider");
+    assert_eq!(
+        models.pointer("/providerConfig/apiKey"),
+        Some(&json!("legacy-inline")),
+        "the migrated auth key remains available to the form"
+    );
+    let raw_models = fs::read_to_string(pi_dir.join("models.json")).expect("read raw models");
+    assert!(
+        !raw_models.contains("\"apiKey\""),
+        "the managed provider must no longer contain an inline key"
+    );
+    let auth: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(pi_dir.join("auth.json")).unwrap()).unwrap();
+    assert_eq!(
+        auth.pointer("/packy"),
+        Some(&json!({ "type": "api_key", "key": "legacy-inline" }))
+    );
+}
+
+#[test]
+#[serial]
+fn pi_directory_override_takes_priority_over_environment_and_default() {
+    struct ResetSettings;
+    impl Drop for ResetSettings {
+        fn drop(&mut self) {
+            let _ = cc_switch_lib::update_settings(cc_switch_lib::AppSettings::default());
+        }
+    }
+
+    let home = TempHome::new();
+    let _reset_settings = ResetSettings;
+    let env_dir = home.dir.path().join("pi-from-env");
+    std::env::set_var("PI_CODING_AGENT_DIR", &env_dir);
+    assert_eq!(cc_switch_lib::pi_config::get_pi_dir(), env_dir);
+
+    let override_dir = home.dir.path().join("pi-from-settings");
+    cc_switch_lib::update_settings(cc_switch_lib::AppSettings {
+        pi_config_dir: Some(override_dir.to_string_lossy().to_string()),
+        ..Default::default()
+    })
+    .expect("set Pi directory override");
+    assert_eq!(
+        cc_switch_lib::pi_config::get_pi_dir(),
+        override_dir,
+        "the explicit CC Switch directory must win over PI_CODING_AGENT_DIR"
+    );
+
+    cc_switch_lib::update_settings(cc_switch_lib::AppSettings::default())
+        .expect("clear Pi directory override");
+    std::env::remove_var("PI_CODING_AGENT_DIR");
+    assert_eq!(
+        cc_switch_lib::pi_config::get_pi_dir(),
+        home.dir.path().join(".pi").join("agent")
+    );
+}
+
+#[test]
+#[serial]
+fn auth_json_api_key_takes_priority_and_oauth_is_never_overwritten() {
+    let home = TempHome::new();
+    let pi_dir = home.dir.path().join(".pi").join("agent");
+    fs::create_dir_all(&pi_dir).expect("create pi config dir");
+    fs::write(
+        pi_dir.join("models.json"),
+        r#"{
+  "providers": {
+    "packy": {
+      "baseUrl": "https://api.packy.example/v1",
+      "apiKey": "legacy-inline",
+      "api": "openai-completions",
+      "models": [{ "id": "gpt-5.5" }]
+    }
+  }
+}"#,
+    )
+    .expect("seed models");
+    fs::write(
+        pi_dir.join("auth.json"),
+        r#"{
+  "packy": {
+    "type": "oauth",
+    "accessToken": "keep-oauth"
+  }
+}"#,
+    )
+    .expect("seed auth");
+    fs::write(
+        pi_dir.join("settings.json"),
+        r#"{"defaultProvider":"packy","defaultModel":"gpt-5.5"}"#,
+    )
+    .expect("seed settings");
+
+    let live = cc_switch_lib::pi_config::read_pi_live_settings().expect("read OAuth provider");
+    assert_eq!(
+        live.pointer("/providerConfig/apiKey"),
+        Some(&json!("legacy-inline")),
+        "non-api-key auth entries must not be exposed as API keys"
+    );
+    let mut provider = cc_switch_lib::Provider::with_id(
+        "packy".to_string(),
+        "Packy".to_string(),
+        live["providerConfig"].clone(),
+        None,
+    );
+    provider.settings_config["apiKey"] = json!("new-key");
+    let error = cc_switch_lib::pi_config::write_pi_live_provider(&provider)
+        .expect_err("OAuth must not be overwritten");
+    assert!(error.to_string().contains("will not overwrite"));
+
+    provider.settings_config["apiKey"] = json!("");
+    cc_switch_lib::pi_config::write_pi_live_provider(&provider)
+        .expect("an empty key preserves OAuth while updating models");
+    let auth: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(pi_dir.join("auth.json")).unwrap()).unwrap();
+    assert_eq!(
+        auth.pointer("/packy/accessToken"),
+        Some(&json!("keep-oauth"))
     );
 }
 

--- a/src-tauri/tests/pi_config.rs
+++ b/src-tauri/tests/pi_config.rs
@@ -95,7 +95,7 @@ fn writes_provider_and_defaults_without_clobbering_existing_pi_config() {
         json!({
             "baseUrl": "https://api.packy.example/v1",
             "apiKey": "sk-packy",
-            "api": "openai-chat",
+            "api": "openai-completions",
             "models": [
                 {
                     "id": "gpt-5.5",
@@ -216,7 +216,7 @@ fn read_live_settings_returns_current_provider_fragment() {
     "packy": {
       "baseURL": "https://api.packy.example/v1",
       "apiKey": "sk-packy",
-      "api": "openai-chat",
+      "api": "openai-completions",
       "models": ["gpt-5.5"]
     }
   }
@@ -269,7 +269,7 @@ fn write_provider_clears_stale_default_model_when_no_model_can_be_derived() {
         json!({
             "baseUrl": "https://api.example.com/v1",
             "apiKey": "sk-empty",
-            "api": "openai-chat",
+            "api": "openai-completions",
             "models": []
         }),
         None,
@@ -301,7 +301,7 @@ fn write_provider_rejects_existing_non_object_pi_files() {
         json!({
             "baseUrl": "https://api.packy.example/v1",
             "apiKey": "sk-packy",
-            "api": "openai-chat",
+            "api": "openai-completions",
             "models": [{ "id": "gpt-5.5" }]
         }),
         None,

--- a/src-tauri/tests/pi_config.rs
+++ b/src-tauri/tests/pi_config.rs
@@ -164,6 +164,43 @@ fn writes_provider_and_defaults_without_clobbering_existing_pi_config() {
         Some(&json!("dark")),
         "unrelated settings should be preserved"
     );
+
+    let backup_root = home
+        .dir
+        .path()
+        .join(".cc-switch")
+        .join("backups")
+        .join("pi");
+    let backup_dirs = fs::read_dir(&backup_root)
+        .expect("read Pi backups")
+        .map(|entry| entry.expect("read Pi backup entry").path())
+        .collect::<Vec<_>>();
+    assert_eq!(backup_dirs.len(), 1, "one activation creates one backup");
+    let backup_models: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(backup_dirs[0].join("models.json")).expect("read backed-up models"),
+    )
+    .expect("parse backed-up models");
+    let backup_settings: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(backup_dirs[0].join("settings.json")).expect("read backed-up settings"),
+    )
+    .expect("parse backed-up settings");
+    assert_eq!(
+        backup_models.pointer("/providers/existing/apiKey"),
+        Some(&json!("keep"))
+    );
+    assert_eq!(
+        backup_settings.pointer("/defaultProvider"),
+        Some(&json!("existing"))
+    );
+
+    cc_switch_lib::pi_config::write_pi_live_provider(&provider).expect("repeat no-op write");
+    assert_eq!(
+        fs::read_dir(&backup_root)
+            .expect("re-read Pi backups")
+            .count(),
+        1,
+        "a no-op activation must not create another backup"
+    );
 }
 
 #[test]

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -95,6 +95,66 @@ fn grokbuild_import_and_switch_write_live_config() {
 }
 
 #[test]
+fn pi_default_import_preserves_live_provider_identity() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    let pi_dir = home.join(".pi").join("agent");
+    std::fs::create_dir_all(&pi_dir).expect("create Pi config dir");
+    std::fs::write(
+        pi_dir.join("models.json"),
+        serde_json::to_string_pretty(&json!({
+            "providers": {
+                "packy": {
+                    "baseURL": "https://api.packy.example/v1",
+                    "apiKey": "sk-packy",
+                    "api": "openai-chat",
+                    "models": [{ "id": "gpt-5.5", "name": "GPT 5.5" }]
+                }
+            }
+        }))
+        .expect("serialize Pi models"),
+    )
+    .expect("seed Pi models.json");
+    std::fs::write(
+        pi_dir.join("settings.json"),
+        serde_json::to_string_pretty(&json!({
+            "defaultProvider": "packy",
+            "defaultModel": "gpt-5.5"
+        }))
+        .expect("serialize Pi settings"),
+    )
+    .expect("seed Pi settings.json");
+
+    let state = create_test_state().expect("create test state");
+    assert!(
+        import_default_config_test_hook(&state, AppType::Pi).expect("import Pi default config"),
+        "Pi live config should be imported"
+    );
+
+    let providers = state
+        .db
+        .get_all_providers(AppType::Pi.as_str())
+        .expect("get Pi providers");
+    assert!(
+        providers.contains_key("packy"),
+        "the imported provider should keep Pi's defaultProvider id"
+    );
+    assert!(
+        !providers.contains_key("default"),
+        "Pi import must not invent a replacement provider id"
+    );
+    assert_eq!(
+        state
+            .db
+            .get_current_provider(AppType::Pi.as_str())
+            .expect("get current Pi provider")
+            .as_deref(),
+        Some("packy")
+    );
+}
+
+#[test]
 fn codex_startup_import_fresh_install_imports_once_and_syncs_current_setting() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -123,7 +123,7 @@ fn pi_default_import_preserves_live_provider_identity() {
                 "packy": {
                     "baseURL": "https://api.packy.example/v1",
                     "apiKey": "sk-packy",
-                    "api": "openai-chat",
+                    "api": "openai-completions",
                     "models": [{ "id": "gpt-5.5", "name": "GPT 5.5" }]
                 }
             }

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -35,6 +35,21 @@ context_window = 500000
     )
 }
 
+fn pi_provider(id: &str, model: &str) -> Provider {
+    Provider::with_id(
+        id.to_string(),
+        id.to_string(),
+        json!({
+            "baseUrl": format!("https://{id}.example/v1"),
+            "apiKey": format!("sk-{id}"),
+            "api": "openai-completions",
+            "models": [{ "id": model }],
+            "defaultModel": model
+        }),
+        None,
+    )
+}
+
 #[test]
 fn grokbuild_import_and_switch_write_live_config() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
@@ -145,12 +160,156 @@ fn pi_default_import_preserves_live_provider_identity() {
         "Pi import must not invent a replacement provider id"
     );
     assert_eq!(
+        providers["packy"]
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.live_config_managed),
+        Some(true),
+        "an explicitly imported Pi provider is managed by CC Switch"
+    );
+    assert_eq!(
         state
             .db
             .get_current_provider(AppType::Pi.as_str())
             .expect("get current Pi provider")
             .as_deref(),
         Some("packy")
+    );
+}
+
+#[test]
+fn pi_add_preserves_registry_and_switches_default_separately() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    let state = create_test_state().expect("create test state");
+
+    ProviderService::add(
+        &state,
+        AppType::Pi,
+        pi_provider("cc-switch-one", "model-one"),
+        true,
+    )
+    .expect("add first Pi provider");
+    ProviderService::add(
+        &state,
+        AppType::Pi,
+        pi_provider("cc-switch-two", "model-two"),
+        true,
+    )
+    .expect("add second Pi provider");
+
+    let pi_dir = home.join(".pi").join("agent");
+    let models: serde_json::Value =
+        read_json_file(&pi_dir.join("models.json")).expect("read Pi models");
+    assert!(models.pointer("/providers/cc-switch-one").is_some());
+    assert!(models.pointer("/providers/cc-switch-two").is_some());
+
+    let settings: serde_json::Value =
+        read_json_file(&pi_dir.join("settings.json")).expect("read Pi settings");
+    assert_eq!(
+        settings.get("defaultProvider"),
+        Some(&json!("cc-switch-one")),
+        "adding another provider must not implicitly switch Pi"
+    );
+
+    switch_provider_test_hook(&state, AppType::Pi, "cc-switch-two").expect("switch Pi provider");
+
+    let models: serde_json::Value =
+        read_json_file(&pi_dir.join("models.json")).expect("read switched Pi models");
+    assert!(
+        models.pointer("/providers/cc-switch-one").is_some(),
+        "switching must not remove the previous Pi provider"
+    );
+    let settings: serde_json::Value =
+        read_json_file(&pi_dir.join("settings.json")).expect("read switched Pi settings");
+    assert_eq!(
+        settings.get("defaultProvider"),
+        Some(&json!("cc-switch-two"))
+    );
+    assert_eq!(settings.get("defaultModel"), Some(&json!("model-two")));
+}
+
+#[test]
+fn pi_delete_removes_only_managed_inactive_provider() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    let state = create_test_state().expect("create test state");
+
+    ProviderService::add(
+        &state,
+        AppType::Pi,
+        pi_provider("cc-switch-one", "model-one"),
+        true,
+    )
+    .expect("add first Pi provider");
+    ProviderService::add(
+        &state,
+        AppType::Pi,
+        pi_provider("cc-switch-two", "model-two"),
+        true,
+    )
+    .expect("add second Pi provider");
+    switch_provider_test_hook(&state, AppType::Pi, "cc-switch-two").expect("switch Pi provider");
+
+    ProviderService::delete(&state, AppType::Pi, "cc-switch-one")
+        .expect("delete inactive Pi provider");
+    let models: serde_json::Value =
+        read_json_file(&home.join(".pi/agent/models.json")).expect("read Pi models");
+    assert!(models.pointer("/providers/cc-switch-one").is_none());
+    assert!(models.pointer("/providers/cc-switch-two").is_some());
+
+    ProviderService::delete(&state, AppType::Pi, "cc-switch-two")
+        .expect_err("active Pi provider deletion must be blocked");
+}
+
+#[test]
+fn pi_add_rejects_an_unmanaged_live_key_collision() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    let pi_dir = home.join(".pi").join("agent");
+    std::fs::create_dir_all(&pi_dir).expect("create Pi config dir");
+    std::fs::write(
+        pi_dir.join("models.json"),
+        serde_json::to_vec_pretty(&json!({
+            "providers": {
+                "external": {
+                    "baseUrl": "https://external.example/v1",
+                    "apiKey": "keep-me",
+                    "api": "openai-completions",
+                    "models": [{ "id": "external-model" }]
+                }
+            }
+        }))
+        .expect("serialize Pi models"),
+    )
+    .expect("seed Pi models");
+    let state = create_test_state().expect("create test state");
+
+    ProviderService::add(
+        &state,
+        AppType::Pi,
+        pi_provider("external", "cc-switch-model"),
+        true,
+    )
+    .expect_err("unmanaged Pi key collision must be rejected");
+
+    assert!(
+        state
+            .db
+            .get_provider_by_id("external", AppType::Pi.as_str())
+            .expect("query Pi provider")
+            .is_none(),
+        "failed live registration must roll back the DB row"
+    );
+    let models: serde_json::Value =
+        read_json_file(&pi_dir.join("models.json")).expect("read Pi models");
+    assert_eq!(
+        models.pointer("/providers/external/apiKey"),
+        Some(&json!("keep-me")),
+        "CC Switch must not overwrite an unmanaged Pi provider"
     );
 }
 

--- a/src-tauri/tests/provider_commands.rs
+++ b/src-tauri/tests/provider_commands.rs
@@ -110,7 +110,7 @@ fn grokbuild_import_and_switch_write_live_config() {
 }
 
 #[test]
-fn pi_default_import_preserves_live_provider_identity() {
+fn pi_default_import_reads_the_full_registry_and_maps_the_current_provider() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();
     let home = ensure_test_home();
@@ -122,15 +122,28 @@ fn pi_default_import_preserves_live_provider_identity() {
             "providers": {
                 "packy": {
                     "baseURL": "https://api.packy.example/v1",
-                    "apiKey": "sk-packy",
                     "api": "openai-completions",
                     "models": [{ "id": "gpt-5.5", "name": "GPT 5.5" }]
+                },
+                "secondary": {
+                    "baseUrl": "https://secondary.example/v1",
+                    "api": "extension-owned-api",
+                    "models": [{ "id": "secondary-model" }]
                 }
             }
         }))
         .expect("serialize Pi models"),
     )
     .expect("seed Pi models.json");
+    std::fs::write(
+        pi_dir.join("auth.json"),
+        serde_json::to_string_pretty(&json!({
+            "packy": { "type": "api_key", "key": "sk-packy" },
+            "secondary": { "type": "api_key", "key": "sk-secondary" }
+        }))
+        .expect("serialize Pi auth"),
+    )
+    .expect("seed Pi auth.json");
     std::fs::write(
         pi_dir.join("settings.json"),
         serde_json::to_string_pretty(&json!({
@@ -156,6 +169,10 @@ fn pi_default_import_preserves_live_provider_identity() {
         "the imported provider should keep Pi's defaultProvider id"
     );
     assert!(
+        providers.contains_key("secondary"),
+        "Pi import must include non-default providers"
+    );
+    assert!(
         !providers.contains_key("default"),
         "Pi import must not invent a replacement provider id"
     );
@@ -166,6 +183,25 @@ fn pi_default_import_preserves_live_provider_identity() {
             .and_then(|meta| meta.live_config_managed),
         Some(true),
         "an explicitly imported Pi provider is managed by CC Switch"
+    );
+    assert_eq!(
+        providers["packy"].settings_config.get("apiKey"),
+        Some(&json!("sk-packy"))
+    );
+    assert_eq!(
+        providers["packy"].settings_config.get("defaultModel"),
+        Some(&json!("gpt-5.5"))
+    );
+    assert_eq!(
+        providers["secondary"].settings_config.get("apiKey"),
+        Some(&json!("sk-secondary"))
+    );
+    assert!(
+        providers["secondary"]
+            .settings_config
+            .get("defaultModel")
+            .is_none(),
+        "only Pi's selected provider receives settings.json.defaultModel"
     );
     assert_eq!(
         state
@@ -205,12 +241,17 @@ fn pi_add_preserves_registry_and_switches_default_separately() {
     assert!(models.pointer("/providers/cc-switch-one").is_some());
     assert!(models.pointer("/providers/cc-switch-two").is_some());
 
-    let settings: serde_json::Value =
-        read_json_file(&pi_dir.join("settings.json")).expect("read Pi settings");
+    assert!(
+        !pi_dir.join("settings.json").exists(),
+        "adding providers must not create or change Pi defaults"
+    );
     assert_eq!(
-        settings.get("defaultProvider"),
-        Some(&json!("cc-switch-one")),
-        "adding another provider must not implicitly switch Pi"
+        state
+            .db
+            .get_current_provider(AppType::Pi.as_str())
+            .expect("read Pi current provider"),
+        None,
+        "adding providers must not select a CC Switch current item"
     );
 
     switch_provider_test_hook(&state, AppType::Pi, "cc-switch-two").expect("switch Pi provider");
@@ -259,9 +300,23 @@ fn pi_delete_removes_only_managed_inactive_provider() {
         read_json_file(&home.join(".pi/agent/models.json")).expect("read Pi models");
     assert!(models.pointer("/providers/cc-switch-one").is_none());
     assert!(models.pointer("/providers/cc-switch-two").is_some());
+    let auth: serde_json::Value =
+        read_json_file(&home.join(".pi/agent/auth.json")).expect("read Pi auth");
+    assert!(auth.get("cc-switch-one").is_none());
+    assert_eq!(
+        auth.pointer("/cc-switch-two/key"),
+        Some(&json!("sk-cc-switch-two"))
+    );
 
     ProviderService::delete(&state, AppType::Pi, "cc-switch-two")
         .expect_err("active Pi provider deletion must be blocked");
+    let auth: serde_json::Value =
+        read_json_file(&home.join(".pi/agent/auth.json")).expect("re-read Pi auth");
+    assert_eq!(
+        auth.pointer("/cc-switch-two/key"),
+        Some(&json!("sk-cc-switch-two")),
+        "failed deletion must preserve the active provider credential"
+    );
 }
 
 #[test]

--- a/src-tauri/tests/support.rs
+++ b/src-tauri/tests/support.rs
@@ -34,6 +34,7 @@ pub fn reset_test_fs() {
         ".grok",
         ".config",
         ".openclaw",
+        ".pi",
         "profiles",
     ] {
         let path = home.join(sub);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,7 +207,7 @@ function App() {
     opencode: true,
     openclaw: true,
     hermes: true,
-    pi: true,
+    pi: false,
   };
 
   const getFirstVisibleApp = (): AppId => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,16 @@ const VALID_APPS: AppId[] = [
   "opencode",
   "openclaw",
   "hermes",
+  "pi",
 ];
+
+type ProxySupportedAppId = "claude" | "codex" | "gemini" | "grokbuild";
+
+const isProxySupportedApp = (app: AppId): app is ProxySupportedAppId =>
+  app === "claude" ||
+  app === "codex" ||
+  app === "gemini" ||
+  app === "grokbuild";
 
 const getInitialApp = (): AppId => {
   const saved = localStorage.getItem(STORAGE_KEY) as AppId | null;
@@ -198,6 +207,7 @@ function App() {
     opencode: true,
     openclaw: true,
     hermes: true,
+    pi: true,
   };
 
   const getFirstVisibleApp = (): AppId => {
@@ -209,6 +219,7 @@ function App() {
     if (visibleApps.opencode) return "opencode";
     if (visibleApps.openclaw) return "openclaw";
     if (visibleApps.hermes) return "hermes";
+    if (visibleApps.pi) return "pi";
     return "claude"; // fallback
   };
 
@@ -220,6 +231,18 @@ function App() {
 
   // Fallback from sessions view when switching to an app without session support
   useEffect(() => {
+    if (
+      sharedFeatureApp === "pi" &&
+      (currentView === "prompts" ||
+        currentView === "skills" ||
+        currentView === "skillsDiscovery" ||
+        currentView === "mcp" ||
+        currentView === "sessions")
+    ) {
+      setCurrentView("providers");
+      return;
+    }
+
     if (
       currentView === "sessions" &&
       sharedFeatureApp !== "claude" &&
@@ -264,7 +287,10 @@ function App() {
     takeoverStatus,
     status: proxyStatus,
   } = useProxyStatus();
-  const isCurrentAppTakeoverActive = takeoverStatus?.[activeApp] || false;
+  const hasProxySupport = isProxySupportedApp(activeApp);
+  const isCurrentAppTakeoverActive = hasProxySupport
+    ? takeoverStatus?.[activeApp] || false
+    : false;
   const activeProviderId = useMemo(() => {
     const target = proxyStatus?.active_targets?.find(
       (t) => t.app_type === activeApp,
@@ -287,7 +313,10 @@ function App() {
       currentView === "openclawAgents");
   const { data: openclawHealthWarnings = [] } =
     useOpenClawHealth(isOpenClawView);
-  const hasSkillsSupport = sharedFeatureApp !== "openclaw";
+  const hasSkillsSupport =
+    sharedFeatureApp !== "openclaw" && sharedFeatureApp !== "pi";
+  const hasPromptSupport = sharedFeatureApp !== "pi";
+  const hasMcpSupport = sharedFeatureApp !== "pi";
   const hasSessionSupport =
     sharedFeatureApp === "claude" ||
     sharedFeatureApp === "codex" ||
@@ -1256,12 +1285,14 @@ function App() {
                   {activeApp === "claude-desktop" ? (
                     <ClaudeDesktopRouteToggle />
                   ) : (
-                    settingsData?.enableLocalProxy && (
+                    settingsData?.enableLocalProxy &&
+                    isProxySupportedApp(activeApp) && (
                       <ProxyToggle activeApp={activeApp} />
                     )
                   )}
                   {activeApp !== "claude-desktop" &&
-                    settingsData?.enableFailoverToggle && (
+                    settingsData?.enableFailoverToggle &&
+                    isProxySupportedApp(activeApp) && (
                       <FailoverToggle activeApp={activeApp} />
                     )}
                 </div>
@@ -1518,15 +1549,17 @@ function App() {
                               >
                                 <Wrench className="flex-shrink-0 w-4 h-4" />
                               </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setCurrentView("prompts")}
-                                className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
-                                title={t("prompts.manage")}
-                              >
-                                <Book className="w-4 h-4" />
-                              </Button>
+                              {hasPromptSupport && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setCurrentView("prompts")}
+                                  className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                  title={t("prompts.manage")}
+                                >
+                                  <Book className="w-4 h-4" />
+                                </Button>
+                              )}
                               <Button
                                 variant="ghost"
                                 size="sm"
@@ -1542,15 +1575,17 @@ function App() {
                               >
                                 <History className="flex-shrink-0 w-4 h-4" />
                               </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setCurrentView("mcp")}
-                                className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
-                                title={t("mcp.title")}
-                              >
-                                <McpIcon size={16} />
-                              </Button>
+                              {hasMcpSupport && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setCurrentView("mcp")}
+                                  className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                  title={t("mcp.title")}
+                                >
+                                  <McpIcon size={16} />
+                                </Button>
+                              )}
                             </>
                           )}
                         </motion.div>

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -26,6 +26,7 @@ const ALL_APPS: AppId[] = [
   "opencode",
   "openclaw",
   "hermes",
+  "pi",
 ];
 const STORAGE_KEY = "cc-switch-last-app";
 
@@ -49,6 +50,7 @@ export function AppSwitcher({
     opencode: "opencode",
     openclaw: "openclaw",
     hermes: "hermes",
+    pi: "pi",
   };
   const appDisplayName: Record<AppId, string> = {
     claude: "Claude Code",
@@ -59,12 +61,13 @@ export function AppSwitcher({
     opencode: "OpenCode",
     openclaw: "OpenClaw",
     hermes: "Hermes",
+    pi: "Pi Agent",
   };
 
   // Filter apps based on visibility settings (default all visible)
   const appsToShow = ALL_APPS.filter((app) => {
     if (!visibleApps) return true;
-    return visibleApps[app];
+    return visibleApps[app] ?? true;
   });
 
   return (

--- a/src/components/mcp/UnifiedMcpPanel.tsx
+++ b/src/components/mcp/UnifiedMcpPanel.tsx
@@ -55,7 +55,7 @@ const UnifiedMcpPanel = React.forwardRef<
     return Object.entries(serversMap);
   }, [serversMap]);
 
-  const enabledCounts = useMemo(() => {
+  const enabledCounts = useMemo((): Partial<Record<AppId, number>> => {
     const counts = {
       claude: 0,
       "claude-desktop": 0,
@@ -68,7 +68,7 @@ const UnifiedMcpPanel = React.forwardRef<
     };
     serverEntries.forEach(([_, server]) => {
       for (const app of MCP_APP_IDS) {
-        if (server.apps[app]) counts[app]++;
+        if (server.apps[app]) counts[app] = (counts[app] ?? 0) + 1;
       }
     });
     return counts;

--- a/src/components/prompts/PromptFormPanel.tsx
+++ b/src/components/prompts/PromptFormPanel.tsx
@@ -24,7 +24,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
 }) => {
   const { t } = useTranslation();
   const appName = t(`apps.${appId}`);
-  const filenameMap: Record<AppId, string> = {
+  const filenameMap: Partial<Record<AppId, string>> = {
     claude: "CLAUDE.md",
     "claude-desktop": "CLAUDE.md",
     codex: "AGENTS.md",
@@ -34,7 +34,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
     openclaw: "AGENTS.md",
     hermes: "AGENTS.md",
   };
-  const filename = filenameMap[appId];
+  const filename = filenameMap[appId] ?? "AGENTS.md";
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");

--- a/src/components/providers/forms/EndpointSpeedTest.tsx
+++ b/src/components/providers/forms/EndpointSpeedTest.tsx
@@ -18,6 +18,7 @@ const ENDPOINT_TIMEOUT_SECS: Record<AppId, number> = {
   opencode: 8,
   openclaw: 8,
   hermes: 8,
+  pi: 8,
 };
 
 interface TestResult {

--- a/src/components/providers/forms/PiFormFields.tsx
+++ b/src/components/providers/forms/PiFormFields.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { FormLabel } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ApiKeySection } from "./shared";
+import type { OpenClawModel, ProviderCategory } from "@/types";
+
+interface PiFormFieldsProps {
+  baseUrl: string;
+  onBaseUrlChange: (value: string) => void;
+  apiKey: string;
+  onApiKeyChange: (value: string) => void;
+  category?: ProviderCategory;
+  shouldShowApiKeyLink: boolean;
+  websiteUrl: string;
+  isPartner?: boolean;
+  partnerPromotionKey?: string;
+  api: string;
+  onApiChange: (value: string) => void;
+  models: OpenClawModel[];
+  onModelsChange: (models: OpenClawModel[]) => void;
+  defaultModel: string;
+  onDefaultModelChange: (model: string) => void;
+}
+
+const PI_API_PROTOCOLS = [
+  { value: "openai-completions", label: "OpenAI Chat Completions" },
+  { value: "anthropic-messages", label: "Anthropic Messages" },
+];
+
+const createModelKey = () => crypto.randomUUID();
+
+export function PiFormFields({
+  baseUrl,
+  onBaseUrlChange,
+  apiKey,
+  onApiKeyChange,
+  category,
+  shouldShowApiKeyLink,
+  websiteUrl,
+  isPartner,
+  partnerPromotionKey,
+  api,
+  onApiChange,
+  models,
+  onModelsChange,
+  defaultModel,
+  onDefaultModelChange,
+}: PiFormFieldsProps) {
+  const { t } = useTranslation();
+  const [modelKeys, setModelKeys] = useState<string[]>(() =>
+    models.map(() => createModelKey()),
+  );
+
+  useEffect(() => {
+    setModelKeys((current) => {
+      if (current.length === models.length) return current;
+      if (current.length > models.length)
+        return current.slice(0, models.length);
+      return [
+        ...current,
+        ...Array.from({ length: models.length - current.length }, () =>
+          createModelKey(),
+        ),
+      ];
+    });
+  }, [models.length]);
+
+  const addModel = () => {
+    setModelKeys((current) => [...current, createModelKey()]);
+    onModelsChange([...models, { id: "", name: "" }]);
+  };
+
+  const updateModel = (
+    index: number,
+    field: keyof OpenClawModel,
+    value: string,
+  ) => {
+    const next = [...models];
+    next[index] = { ...next[index], [field]: value };
+    onModelsChange(next);
+  };
+
+  const removeModel = (index: number) => {
+    setModelKeys((current) =>
+      current.filter((_, keyIndex) => keyIndex !== index),
+    );
+    const next = [...models];
+    next.splice(index, 1);
+    onModelsChange(next);
+  };
+
+  const selectableModelIds = Array.from(
+    new Set(
+      models
+        .map((model) => model.id?.trim())
+        .filter((id): id is string => !!id),
+    ),
+  );
+
+  return (
+    <>
+      <div className="space-y-2">
+        <FormLabel htmlFor="pi-api">
+          {t("pi.apiProtocol", { defaultValue: "API 协议" })}
+        </FormLabel>
+        <Select value={api} onValueChange={onApiChange}>
+          <SelectTrigger id="pi-api">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PI_API_PROTOCOLS.map((protocol) => (
+              <SelectItem key={protocol.value} value={protocol.value}>
+                {protocol.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <FormLabel htmlFor="pi-baseurl">
+          {t("pi.baseUrl", { defaultValue: "API 端点" })}
+        </FormLabel>
+        <Input
+          id="pi-baseurl"
+          value={baseUrl}
+          onChange={(event) => onBaseUrlChange(event.target.value)}
+          placeholder="https://api.example.com/v1"
+        />
+      </div>
+
+      <ApiKeySection
+        value={apiKey}
+        onChange={onApiKeyChange}
+        category={category === "official" ? undefined : category}
+        shouldShowLink={shouldShowApiKeyLink}
+        websiteUrl={websiteUrl}
+        isPartner={isPartner}
+        partnerPromotionKey={partnerPromotionKey}
+      />
+
+      <div className="space-y-2">
+        <FormLabel htmlFor="pi-default-model">
+          {t("pi.defaultModel", { defaultValue: "默认模型" })}
+        </FormLabel>
+        <Select value={defaultModel} onValueChange={onDefaultModelChange}>
+          <SelectTrigger id="pi-default-model">
+            <SelectValue
+              placeholder={t("pi.defaultModelPlaceholder", {
+                defaultValue: "选择默认模型",
+              })}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {selectableModelIds.map((id) => (
+              <SelectItem key={id} value={id}>
+                {id}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <FormLabel>{t("pi.models", { defaultValue: "模型列表" })}</FormLabel>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addModel}
+            className="h-7 gap-1"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("pi.addModel", { defaultValue: "添加模型" })}
+          </Button>
+        </div>
+
+        <div className="space-y-2">
+          {models.map((model, index) => (
+            <div
+              key={modelKeys[index] ?? `${model.id}-${index}`}
+              className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-end gap-2"
+            >
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">
+                  {t("pi.modelId", { defaultValue: "模型 ID" })}
+                </label>
+                <Input
+                  value={model.id}
+                  onChange={(event) =>
+                    updateModel(index, "id", event.target.value)
+                  }
+                  placeholder="gpt-5.5"
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">
+                  {t("pi.modelName", { defaultValue: "显示名称" })}
+                </label>
+                <Input
+                  value={model.name}
+                  onChange={(event) =>
+                    updateModel(index, "name", event.target.value)
+                  }
+                  placeholder="GPT 5.5"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeModel(index)}
+                className="h-9 w-9 text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/providers/forms/PiFormFields.tsx
+++ b/src/components/providers/forms/PiFormFields.tsx
@@ -34,7 +34,9 @@ interface PiFormFieldsProps {
 
 const PI_API_PROTOCOLS = [
   { value: "openai-completions", label: "OpenAI Chat Completions" },
+  { value: "openai-responses", label: "OpenAI Responses" },
   { value: "anthropic-messages", label: "Anthropic Messages" },
+  { value: "google-generative-ai", label: "Google Generative AI" },
 ];
 
 const createModelKey = () => crypto.randomUUID();

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -53,6 +53,7 @@ import {
 import { OpenCodeFormFields } from "./OpenCodeFormFields";
 import { OpenClawFormFields } from "./OpenClawFormFields";
 import { HermesFormFields } from "./HermesFormFields";
+import { PiFormFields } from "./PiFormFields";
 import type { UniversalProviderPreset } from "@/config/universalProviderPresets";
 import {
   applyTemplateValues,
@@ -105,6 +106,7 @@ import {
   useOmoDraftState,
   useOpenclawFormState,
   useHermesFormState,
+  usePiFormState,
   useCopilotAuth,
   useCodexOauth,
   useXaiOauth,
@@ -117,6 +119,7 @@ import {
   GEMINI_DEFAULT_CONFIG,
   OPENCODE_DEFAULT_CONFIG,
   OPENCLAW_DEFAULT_CONFIG,
+  PI_DEFAULT_CONFIG,
   normalizePricingSource,
 } from "./helpers/opencodeFormUtils";
 import { HERMES_DEFAULT_CONFIG } from "./hooks/useHermesFormState";
@@ -394,7 +397,9 @@ function ProviderFormFull({
                 ? OPENCLAW_DEFAULT_CONFIG
                 : appId === "hermes"
                   ? HERMES_DEFAULT_CONFIG
-                  : CLAUDE_DEFAULT_CONFIG,
+                  : appId === "pi"
+                    ? PI_DEFAULT_CONFIG
+                    : CLAUDE_DEFAULT_CONFIG,
       icon: initialData?.icon ?? "",
       iconColor: initialData?.iconColor ?? "",
     }),
@@ -708,6 +713,8 @@ function ProviderFormFull({
         id: `hermes-${index}`,
         preset,
       }));
+    } else if (appId === "pi") {
+      return [];
     }
     return providerPresets
       .filter((p) => !p.hidden)
@@ -925,6 +932,13 @@ function ProviderFormFull({
     data: hermesLiveProviderIds = [],
     isLoading: isHermesLiveProviderIdsLoading,
   } = useHermesLiveProviderIds(appId === "hermes");
+
+  const piForm = usePiFormState({
+    initialData,
+    appId,
+    onSettingsConfigChange: (config) => form.setValue("settingsConfig", config),
+    getSettingsConfig: () => form.getValues("settingsConfig"),
+  });
 
   const additiveExistingProviderKeys = useMemo(() => {
     if (appId === "opencode" && !isAnyOmoCategory) {
@@ -1748,6 +1762,19 @@ function ProviderFormFull({
     formWebsiteUrl: form.watch("websiteUrl") || "",
   });
 
+  const {
+    shouldShowApiKeyLink: shouldShowPiApiKeyLink,
+    websiteUrl: piWebsiteUrl,
+    isPartner: isPiPartner,
+    partnerPromotionKey: piPartnerPromotionKey,
+  } = useApiKeyLink({
+    appId: "pi",
+    category,
+    selectedPresetId,
+    presetEntries,
+    formWebsiteUrl: form.watch("websiteUrl") || "",
+  });
+
   // 使用端点测速候选 hook
   const speedTestEndpoints = useSpeedTestEndpoints({
     appId,
@@ -2448,6 +2475,27 @@ function ProviderFormFull({
             />
           )}
 
+          {/* Pi Agent 专属字段 */}
+          {appId === "pi" && (
+            <PiFormFields
+              baseUrl={piForm.piBaseUrl}
+              onBaseUrlChange={piForm.handlePiBaseUrlChange}
+              apiKey={piForm.piApiKey}
+              onApiKeyChange={piForm.handlePiApiKeyChange}
+              category={category}
+              shouldShowApiKeyLink={shouldShowPiApiKeyLink}
+              websiteUrl={piWebsiteUrl}
+              isPartner={isPiPartner}
+              partnerPromotionKey={piPartnerPromotionKey}
+              api={piForm.piApi}
+              onApiChange={piForm.handlePiApiChange}
+              models={piForm.piModels}
+              onModelsChange={piForm.handlePiModelsChange}
+              defaultModel={piForm.piDefaultModel}
+              onDefaultModelChange={piForm.handlePiDefaultModelChange}
+            />
+          )}
+
           {/* 配置编辑器：Codex、Claude、Gemini 分别使用不同的编辑器 */}
           {appId === "codex" ? (
             <>
@@ -2536,7 +2584,7 @@ function ProviderFormFull({
               </div>
               {settingsConfigErrorField}
             </>
-          ) : appId === "openclaw" || appId === "hermes" ? (
+          ) : appId === "openclaw" || appId === "hermes" || appId === "pi" ? (
             <>
               <div className="space-y-2">
                 <Label htmlFor="settingsConfig">
@@ -2552,7 +2600,17 @@ function ProviderFormFull({
   "base_url": "https://api.example.com/v1",
   "api_key": ""
 }`
-                      : `{
+                      : appId === "pi"
+                        ? `{
+  "baseUrl": "https://api.example.com/v1",
+  "apiKey": "your-api-key-here",
+  "api": "openai-completions",
+  "models": [
+    { "id": "gpt-5.5", "name": "GPT 5.5" }
+  ],
+  "defaultModel": "gpt-5.5"
+}`
+                        : `{
   "baseUrl": "https://api.example.com/v1",
   "apiKey": "your-api-key-here",
   "api": "openai-completions",
@@ -2598,7 +2656,8 @@ function ProviderFormFull({
           {!isAnyOmoCategory &&
             appId !== "opencode" &&
             appId !== "openclaw" &&
-            appId !== "hermes" && (
+            appId !== "hermes" &&
+            appId !== "pi" && (
               <ProviderAdvancedConfig
                 pricingConfig={pricingConfig}
                 onPricingConfigChange={setPricingConfig}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
@@ -410,6 +410,13 @@ function ProviderFormFull({
     resolver: zodResolver(providerSchema),
     defaultValues,
     mode: "onSubmit",
+  });
+  const piSettingsConfig = useWatch({
+    control: form.control,
+    name: "settingsConfig",
+    defaultValue: defaultValues.settingsConfig,
+    disabled: appId !== "pi",
+    exact: true,
   });
   const { isSubmitting } = form.formState;
 
@@ -934,10 +941,9 @@ function ProviderFormFull({
   } = useHermesLiveProviderIds(appId === "hermes");
 
   const piForm = usePiFormState({
-    initialData,
     appId,
-    onSettingsConfigChange: (config) => form.setValue("settingsConfig", config),
-    getSettingsConfig: () => form.getValues("settingsConfig"),
+    settingsConfig: piSettingsConfig,
+    onSettingsConfigChange: handleSettingsConfigChange,
   });
 
   const additiveExistingProviderKeys = useMemo(() => {

--- a/src/components/providers/forms/helpers/opencodeFormUtils.test.ts
+++ b/src/components/providers/forms/helpers/opencodeFormUtils.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { PI_DEFAULT_CONFIG } from "./opencodeFormUtils";
+
+describe("PI_DEFAULT_CONFIG", () => {
+  it("uses Pi's supported OpenAI Chat Completions API identifier", () => {
+    const config = JSON.parse(PI_DEFAULT_CONFIG);
+
+    expect(config.api).toBe("openai-completions");
+  });
+});

--- a/src/components/providers/forms/helpers/opencodeFormUtils.ts
+++ b/src/components/providers/forms/helpers/opencodeFormUtils.ts
@@ -67,6 +67,18 @@ export const OPENCLAW_DEFAULT_CONFIG = JSON.stringify(
   2,
 );
 
+export const PI_DEFAULT_CONFIG = JSON.stringify(
+  {
+    baseUrl: "",
+    apiKey: "",
+    api: "openai-completions",
+    models: [{ id: "gpt-5.5", name: "GPT 5.5" }],
+    defaultModel: "gpt-5.5",
+  },
+  null,
+  2,
+);
+
 // ── Pure functions ───────────────────────────────────────────────────
 
 export function isKnownOpencodeOptionKey(key: string): boolean {

--- a/src/components/providers/forms/hooks/index.ts
+++ b/src/components/providers/forms/hooks/index.ts
@@ -17,6 +17,7 @@ export { useOpencodeFormState } from "./useOpencodeFormState";
 export { useOmoDraftState } from "./useOmoDraftState";
 export { useOpenclawFormState } from "./useOpenclawFormState";
 export { useHermesFormState } from "./useHermesFormState";
+export { usePiFormState } from "./usePiFormState";
 export { useCopilotAuth } from "./useCopilotAuth";
 export { useCodexOauth } from "./useCodexOauth";
 export { useXaiOauth } from "./useXaiOauth";

--- a/src/components/providers/forms/hooks/useApiKeyLink.ts
+++ b/src/components/providers/forms/hooks/useApiKeyLink.ts
@@ -87,7 +87,8 @@ export function useApiKeyLink({
       appId === "gemini" ||
       appId === "opencode" ||
       appId === "openclaw" ||
-      appId === "hermes"
+      appId === "hermes" ||
+      appId === "pi"
         ? shouldShowApiKeyLink
         : false,
     websiteUrl: getWebsiteUrl,

--- a/src/components/providers/forms/hooks/usePiFormState.ts
+++ b/src/components/providers/forms/hooks/usePiFormState.ts
@@ -1,24 +1,20 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { AppId } from "@/lib/api";
 import type { OpenClawModel } from "@/types";
 import { PI_DEFAULT_CONFIG } from "../helpers/opencodeFormUtils";
 
 interface UsePiFormStateParams {
-  initialData?: {
-    settingsConfig?: Record<string, unknown>;
-  };
-  appId: AppId | "pi";
+  appId: AppId;
+  settingsConfig: string;
   onSettingsConfigChange: (config: string) => void;
-  getSettingsConfig: () => string;
 }
 
 interface PiProviderConfig {
-  baseUrl?: string;
-  baseURL?: string;
-  apiKey?: string;
-  api?: string;
-  models?: OpenClawModel[];
-  defaultModel?: string;
+  baseUrl: string;
+  apiKey: string;
+  api: string;
+  models: OpenClawModel[];
+  defaultModel: string;
 }
 
 export interface PiFormState {
@@ -34,53 +30,120 @@ export interface PiFormState {
   handlePiDefaultModelChange: (model: string) => void;
 }
 
-function parsePiConfig(
-  initialData: UsePiFormStateParams["initialData"],
-): PiProviderConfig {
+function parsePiConfig(rawConfig: string): PiProviderConfig | null {
   try {
-    return JSON.parse(
-      initialData?.settingsConfig
-        ? JSON.stringify(initialData.settingsConfig)
-        : PI_DEFAULT_CONFIG,
-    ) as PiProviderConfig;
+    const parsed = JSON.parse(rawConfig || PI_DEFAULT_CONFIG);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const config = parsed as Record<string, unknown>;
+    for (const field of [
+      "baseUrl",
+      "baseURL",
+      "apiKey",
+      "api",
+      "defaultModel",
+    ]) {
+      if (config[field] !== undefined && typeof config[field] !== "string") {
+        return null;
+      }
+    }
+
+    const models: OpenClawModel[] = [];
+    if (config.models !== undefined) {
+      if (!Array.isArray(config.models)) return null;
+      for (const entry of config.models) {
+        if (typeof entry === "string") {
+          models.push({ id: entry, name: entry });
+          continue;
+        }
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return null;
+        }
+        const model = entry as Record<string, unknown>;
+        if (
+          typeof model.id !== "string" ||
+          (model.name !== undefined && typeof model.name !== "string")
+        ) {
+          return null;
+        }
+        models.push({
+          ...model,
+          id: model.id,
+          name: typeof model.name === "string" ? model.name : model.id,
+        } as OpenClawModel);
+      }
+    }
+
+    const baseUrl =
+      typeof config.baseUrl === "string"
+        ? config.baseUrl
+        : typeof config.baseURL === "string"
+          ? config.baseURL
+          : "";
+    const defaultModel =
+      typeof config.defaultModel === "string"
+        ? config.defaultModel
+        : models[0]?.id || "";
+
+    return {
+      baseUrl,
+      apiKey: typeof config.apiKey === "string" ? config.apiKey : "",
+      api: typeof config.api === "string" ? config.api : "openai-completions",
+      models,
+      defaultModel,
+    };
   } catch {
-    return JSON.parse(PI_DEFAULT_CONFIG) as PiProviderConfig;
+    return null;
   }
 }
 
 export function usePiFormState({
-  initialData,
   appId,
+  settingsConfig,
   onSettingsConfigChange,
-  getSettingsConfig,
 }: UsePiFormStateParams): PiFormState {
-  const initial = parsePiConfig(initialData);
+  const fallback = parsePiConfig(PI_DEFAULT_CONFIG) as PiProviderConfig;
+  const initial =
+    appId === "pi" ? parsePiConfig(settingsConfig) || fallback : fallback;
 
   const [piBaseUrl, setPiBaseUrl] = useState(() => {
     if (appId !== "pi") return "";
-    return initial.baseUrl || initial.baseURL || "";
+    return initial.baseUrl;
   });
   const [piApiKey, setPiApiKey] = useState(() => {
     if (appId !== "pi") return "";
-    return initial.apiKey || "";
+    return initial.apiKey;
   });
   const [piApi, setPiApi] = useState(() => {
     if (appId !== "pi") return "openai-completions";
-    return initial.api || "openai-completions";
+    return initial.api;
   });
   const [piModels, setPiModels] = useState<OpenClawModel[]>(() => {
     if (appId !== "pi") return [];
-    return initial.models || [];
+    return initial.models;
   });
   const [piDefaultModel, setPiDefaultModel] = useState(() => {
     if (appId !== "pi") return "";
-    return initial.defaultModel || initial.models?.[0]?.id || "";
+    return initial.defaultModel || initial.models[0]?.id || "";
   });
+
+  useEffect(() => {
+    if (appId !== "pi") return;
+    const config = parsePiConfig(settingsConfig);
+    if (!config) return;
+
+    setPiBaseUrl(config.baseUrl);
+    setPiApiKey(config.apiKey);
+    setPiApi(config.api);
+    setPiModels(config.models);
+    setPiDefaultModel(config.defaultModel || config.models[0]?.id || "");
+  }, [appId, settingsConfig]);
 
   const updatePiConfig = useCallback(
     (updater: (config: Record<string, unknown>) => void) => {
       try {
-        const parsed = JSON.parse(getSettingsConfig() || PI_DEFAULT_CONFIG);
+        const parsed = JSON.parse(settingsConfig || PI_DEFAULT_CONFIG);
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
           return;
         }
@@ -91,7 +154,7 @@ export function usePiFormState({
         // Leave invalid JSON editor content untouched while the user is editing.
       }
     },
-    [getSettingsConfig, onSettingsConfigChange],
+    [settingsConfig, onSettingsConfigChange],
   );
 
   const handlePiBaseUrlChange = useCallback(

--- a/src/components/providers/forms/hooks/usePiFormState.ts
+++ b/src/components/providers/forms/hooks/usePiFormState.ts
@@ -1,0 +1,168 @@
+import { useCallback, useState } from "react";
+import type { AppId } from "@/lib/api";
+import type { OpenClawModel } from "@/types";
+import { PI_DEFAULT_CONFIG } from "../helpers/opencodeFormUtils";
+
+interface UsePiFormStateParams {
+  initialData?: {
+    settingsConfig?: Record<string, unknown>;
+  };
+  appId: AppId | "pi";
+  onSettingsConfigChange: (config: string) => void;
+  getSettingsConfig: () => string;
+}
+
+interface PiProviderConfig {
+  baseUrl?: string;
+  baseURL?: string;
+  apiKey?: string;
+  api?: string;
+  models?: OpenClawModel[];
+  defaultModel?: string;
+}
+
+export interface PiFormState {
+  piBaseUrl: string;
+  piApiKey: string;
+  piApi: string;
+  piModels: OpenClawModel[];
+  piDefaultModel: string;
+  handlePiBaseUrlChange: (baseUrl: string) => void;
+  handlePiApiKeyChange: (apiKey: string) => void;
+  handlePiApiChange: (api: string) => void;
+  handlePiModelsChange: (models: OpenClawModel[]) => void;
+  handlePiDefaultModelChange: (model: string) => void;
+}
+
+function parsePiConfig(
+  initialData: UsePiFormStateParams["initialData"],
+): PiProviderConfig {
+  try {
+    return JSON.parse(
+      initialData?.settingsConfig
+        ? JSON.stringify(initialData.settingsConfig)
+        : PI_DEFAULT_CONFIG,
+    ) as PiProviderConfig;
+  } catch {
+    return JSON.parse(PI_DEFAULT_CONFIG) as PiProviderConfig;
+  }
+}
+
+export function usePiFormState({
+  initialData,
+  appId,
+  onSettingsConfigChange,
+  getSettingsConfig,
+}: UsePiFormStateParams): PiFormState {
+  const initial = parsePiConfig(initialData);
+
+  const [piBaseUrl, setPiBaseUrl] = useState(() => {
+    if (appId !== "pi") return "";
+    return initial.baseUrl || initial.baseURL || "";
+  });
+  const [piApiKey, setPiApiKey] = useState(() => {
+    if (appId !== "pi") return "";
+    return initial.apiKey || "";
+  });
+  const [piApi, setPiApi] = useState(() => {
+    if (appId !== "pi") return "openai-completions";
+    return initial.api || "openai-completions";
+  });
+  const [piModels, setPiModels] = useState<OpenClawModel[]>(() => {
+    if (appId !== "pi") return [];
+    return initial.models || [];
+  });
+  const [piDefaultModel, setPiDefaultModel] = useState(() => {
+    if (appId !== "pi") return "";
+    return initial.defaultModel || initial.models?.[0]?.id || "";
+  });
+
+  const updatePiConfig = useCallback(
+    (updater: (config: Record<string, unknown>) => void) => {
+      try {
+        const parsed = JSON.parse(getSettingsConfig() || PI_DEFAULT_CONFIG);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return;
+        }
+        const config = parsed as Record<string, unknown>;
+        updater(config);
+        onSettingsConfigChange(JSON.stringify(config, null, 2));
+      } catch {
+        // Leave invalid JSON editor content untouched while the user is editing.
+      }
+    },
+    [getSettingsConfig, onSettingsConfigChange],
+  );
+
+  const handlePiBaseUrlChange = useCallback(
+    (baseUrl: string) => {
+      setPiBaseUrl(baseUrl);
+      updatePiConfig((config) => {
+        config.baseUrl = baseUrl.trim().replace(/\/+$/, "");
+        delete config.baseURL;
+      });
+    },
+    [updatePiConfig],
+  );
+
+  const handlePiApiKeyChange = useCallback(
+    (apiKey: string) => {
+      setPiApiKey(apiKey);
+      updatePiConfig((config) => {
+        config.apiKey = apiKey;
+      });
+    },
+    [updatePiConfig],
+  );
+
+  const handlePiApiChange = useCallback(
+    (api: string) => {
+      setPiApi(api);
+      updatePiConfig((config) => {
+        config.api = api;
+      });
+    },
+    [updatePiConfig],
+  );
+
+  const handlePiModelsChange = useCallback(
+    (models: OpenClawModel[]) => {
+      setPiModels(models);
+      const selectableModelIds = models
+        .map((model) => model.id.trim())
+        .filter(Boolean);
+      const nextDefaultModel = selectableModelIds.includes(piDefaultModel)
+        ? piDefaultModel
+        : selectableModelIds[0] || "";
+      setPiDefaultModel(nextDefaultModel);
+      updatePiConfig((config) => {
+        config.models = models;
+        config.defaultModel = nextDefaultModel;
+      });
+    },
+    [piDefaultModel, updatePiConfig],
+  );
+
+  const handlePiDefaultModelChange = useCallback(
+    (model: string) => {
+      setPiDefaultModel(model);
+      updatePiConfig((config) => {
+        config.defaultModel = model;
+      });
+    },
+    [updatePiConfig],
+  );
+
+  return {
+    piBaseUrl,
+    piApiKey,
+    piApi,
+    piModels,
+    piDefaultModel,
+    handlePiBaseUrlChange,
+    handlePiApiKeyChange,
+    handlePiApiChange,
+    handlePiModelsChange,
+    handlePiDefaultModelChange,
+  };
+}

--- a/src/components/providers/forms/hooks/usePiFormState.ts
+++ b/src/components/providers/forms/hooks/usePiFormState.ts
@@ -53,10 +53,6 @@ function parsePiConfig(rawConfig: string): PiProviderConfig | null {
     if (config.models !== undefined) {
       if (!Array.isArray(config.models)) return null;
       for (const entry of config.models) {
-        if (typeof entry === "string") {
-          models.push({ id: entry, name: entry });
-          continue;
-        }
         if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
           return null;
         }

--- a/src/components/proxy/FailoverToggle.tsx
+++ b/src/components/proxy/FailoverToggle.tsx
@@ -13,11 +13,12 @@ import {
 import { useProxyStatus } from "@/hooks/useProxyStatus";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
-import type { AppId } from "@/lib/api";
+
+type ProxySupportedAppId = "claude" | "codex" | "gemini" | "grokbuild";
 
 interface FailoverToggleProps {
   className?: string;
-  activeApp: AppId;
+  activeApp: ProxySupportedAppId;
 }
 
 export function FailoverToggle({ className, activeApp }: FailoverToggleProps) {

--- a/src/components/proxy/ProxyToggle.tsx
+++ b/src/components/proxy/ProxyToggle.tsx
@@ -10,11 +10,12 @@ import { Switch } from "@/components/ui/switch";
 import { useProxyStatus } from "@/hooks/useProxyStatus";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
-import type { AppId } from "@/lib/api";
+
+type ProxySupportedAppId = "claude" | "codex" | "gemini" | "grokbuild";
 
 interface ProxyToggleProps {
   className?: string;
-  activeApp: AppId;
+  activeApp: ProxySupportedAppId;
 }
 
 export function ProxyToggle({ className, activeApp }: ProxyToggleProps) {

--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -30,7 +30,20 @@ const APP_CONFIG: Array<{
   { id: "opencode", icon: "opencode", nameKey: "apps.opencode" },
   { id: "openclaw", icon: "openclaw", nameKey: "apps.openclaw" },
   { id: "hermes", icon: "hermes", nameKey: "apps.hermes" },
+  { id: "pi", icon: "pi", nameKey: "apps.pi" },
 ];
+
+const DEFAULT_VISIBLE_APPS: VisibleApps = {
+  claude: true,
+  "claude-desktop": true,
+  codex: true,
+  gemini: true,
+  grokbuild: true,
+  opencode: true,
+  openclaw: true,
+  hermes: true,
+  pi: true,
+};
 
 export function AppVisibilitySettings({
   settings,
@@ -38,15 +51,9 @@ export function AppVisibilitySettings({
 }: AppVisibilitySettingsProps) {
   const { t } = useTranslation();
 
-  const visibleApps: VisibleApps = settings.visibleApps ?? {
-    claude: true,
-    "claude-desktop": true,
-    codex: true,
-    gemini: true,
-    grokbuild: true,
-    opencode: true,
-    openclaw: true,
-    hermes: true,
+  const visibleApps: VisibleApps = {
+    ...DEFAULT_VISIBLE_APPS,
+    ...settings.visibleApps,
   };
 
   // Count how many apps are currently visible

--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -42,7 +42,7 @@ const DEFAULT_VISIBLE_APPS: VisibleApps = {
   opencode: true,
   openclaw: true,
   hermes: true,
-  pi: true,
+  pi: false,
 };
 
 export function AppVisibilitySettings({

--- a/src/components/settings/DirectorySettings.tsx
+++ b/src/components/settings/DirectorySettings.tsx
@@ -21,6 +21,7 @@ interface DirectorySettingsProps {
   opencodeDir?: string;
   openclawDir?: string;
   hermesDir?: string;
+  piDir?: string;
   onDirectoryChange: (app: DirectoryAppId, value?: string) => void;
   onBrowseDirectory: (app: DirectoryAppId) => Promise<void>;
   onResetDirectory: (app: DirectoryAppId) => Promise<void>;
@@ -39,6 +40,7 @@ export function DirectorySettings({
   opencodeDir,
   openclawDir,
   hermesDir,
+  piDir,
   onDirectoryChange,
   onBrowseDirectory,
   onResetDirectory,
@@ -170,6 +172,17 @@ export function DirectorySettings({
           onChange={(val) => onDirectoryChange("hermes", val)}
           onBrowse={() => onBrowseDirectory("hermes")}
           onReset={() => onResetDirectory("hermes")}
+        />
+
+        <DirectoryInput
+          label={t("settings.piConfigDir")}
+          description={undefined}
+          value={piDir}
+          resolvedValue={resolvedDirs.pi}
+          placeholder={t("settings.browsePlaceholderPi")}
+          onChange={(val) => onDirectoryChange("pi", val)}
+          onBrowse={() => onBrowseDirectory("pi")}
+          onReset={() => onResetDirectory("pi")}
         />
       </section>
     </div>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -356,6 +356,7 @@ export function SettingsPage({
                             opencodeDir={settings.opencodeConfigDir}
                             openclawDir={settings.openclawConfigDir}
                             hermesDir={settings.hermesConfigDir}
+                            piDir={settings.piConfigDir}
                             onDirectoryChange={updateDirectory}
                             onBrowseDirectory={browseDirectory}
                             onResetDirectory={resetDirectory}

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -113,7 +113,7 @@ const UnifiedSkillsPanel = React.forwardRef<
     return map;
   }, [skillUpdates]);
 
-  const enabledCounts = useMemo(() => {
+  const enabledCounts = useMemo((): Partial<Record<AppId, number>> => {
     const counts = {
       claude: 0,
       "claude-desktop": 0,
@@ -127,7 +127,7 @@ const UnifiedSkillsPanel = React.forwardRef<
     if (!skills) return counts;
     skills.forEach((skill) => {
       for (const app of SKILLS_APP_IDS) {
-        if (skill.apps[app]) counts[app]++;
+        if (skill.apps[app]) counts[app] = (counts[app] ?? 0) + 1;
       }
     });
     return counts;

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -24,10 +24,14 @@ export const APP_IDS: AppId[] = [
   "opencode",
   "openclaw",
   "hermes",
+  "pi",
 ];
 
+export type SkillsAppId = Exclude<AppId, "openclaw" | "pi">;
+export type McpAppId = SkillsAppId;
+
 /** App IDs shown in Skills panels (excludes OpenClaw — it doesn't support Skills) */
-export const SKILLS_APP_IDS: AppId[] = [
+export const SKILLS_APP_IDS: SkillsAppId[] = [
   "claude",
   "codex",
   "gemini",
@@ -37,7 +41,7 @@ export const SKILLS_APP_IDS: AppId[] = [
 ];
 
 /** App IDs shown in MCP panels (excludes OpenClaw) */
-export const MCP_APP_IDS: AppId[] = [...SKILLS_APP_IDS];
+export const MCP_APP_IDS: McpAppId[] = [...SKILLS_APP_IDS];
 
 export const APP_ICON_MAP: Record<AppId, AppConfig> = {
   claude: {
@@ -124,5 +128,15 @@ export const APP_ICON_MAP: Record<AppId, AppConfig> = {
       "bg-violet-500/10 ring-1 ring-violet-500/20 hover:bg-violet-500/20 text-violet-600 dark:text-violet-400",
     badgeClass:
       "bg-violet-500/10 text-violet-700 dark:text-violet-300 hover:bg-violet-500/20 border-0 gap-1.5",
+  },
+  pi: {
+    label: "Pi Agent",
+    icon: (
+      <ProviderIcon icon="pi" name="Pi Agent" size={14} showFallback={false} />
+    ),
+    activeClass:
+      "bg-cyan-500/10 ring-1 ring-cyan-500/20 hover:bg-cyan-500/20 text-cyan-600 dark:text-cyan-400",
+    badgeClass:
+      "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 hover:bg-cyan-500/20 border-0 gap-1.5",
   },
 };

--- a/src/hooks/useDirectorySettings.ts
+++ b/src/hooks/useDirectorySettings.ts
@@ -13,7 +13,8 @@ type AppDirectoryKey =
   | "grokbuild"
   | "opencode"
   | "openclaw"
-  | "hermes";
+  | "hermes"
+  | "pi";
 type DirectoryKey = "appConfig" | AppDirectoryKey;
 
 export interface ResolvedDirectories {
@@ -25,6 +26,7 @@ export interface ResolvedDirectories {
   opencode: string;
   openclaw: string;
   hermes: string;
+  pi: string;
 }
 
 // Single source of truth for per-app directory metadata.
@@ -39,6 +41,7 @@ const APP_DIRECTORY_META: Record<
   opencode: { key: "opencode", defaultFolder: ".config/opencode" },
   openclaw: { key: "openclaw", defaultFolder: ".openclaw" },
   hermes: { key: "hermes", defaultFolder: ".hermes" },
+  pi: { key: "pi", defaultFolder: ".pi/agent" },
 };
 
 const DIRECTORY_KEY_TO_SETTINGS_FIELD: Record<
@@ -52,6 +55,7 @@ const DIRECTORY_KEY_TO_SETTINGS_FIELD: Record<
   opencode: "opencodeConfigDir",
   openclaw: "openclawConfigDir",
   hermes: "hermesConfigDir",
+  pi: "piConfigDir",
 };
 
 const sanitizeDir = (value?: string | null): string | undefined => {
@@ -138,6 +142,7 @@ export function useDirectorySettings({
     opencode: "",
     openclaw: "",
     hermes: "",
+    pi: "",
   });
   const [isLoading, setIsLoading] = useState(true);
 
@@ -150,6 +155,7 @@ export function useDirectorySettings({
     opencode: "",
     openclaw: "",
     hermes: "",
+    pi: "",
   });
   const initialAppConfigDirRef = useRef<string | undefined>(undefined);
 
@@ -169,6 +175,7 @@ export function useDirectorySettings({
           opencodeDir,
           openclawDir,
           hermesDir,
+          piDir,
           defaultAppConfig,
           defaultClaudeDir,
           defaultCodexDir,
@@ -177,6 +184,7 @@ export function useDirectorySettings({
           defaultOpencodeDir,
           defaultOpenclawDir,
           defaultHermesDir,
+          defaultPiDir,
         ] = await Promise.all([
           settingsApi.getAppConfigDirOverride(),
           settingsApi.getConfigDir("claude"),
@@ -186,6 +194,7 @@ export function useDirectorySettings({
           settingsApi.getConfigDir("opencode"),
           settingsApi.getConfigDir("openclaw"),
           settingsApi.getConfigDir("hermes"),
+          settingsApi.getConfigDir("pi"),
           computeDefaultAppConfigDir(),
           computeDefaultConfigDir("claude"),
           computeDefaultConfigDir("codex"),
@@ -194,6 +203,7 @@ export function useDirectorySettings({
           computeDefaultConfigDir("opencode"),
           computeDefaultConfigDir("openclaw"),
           computeDefaultConfigDir("hermes"),
+          computeDefaultConfigDir("pi"),
         ]);
 
         if (!active) return;
@@ -209,6 +219,7 @@ export function useDirectorySettings({
           opencode: defaultOpencodeDir ?? "",
           openclaw: defaultOpenclawDir ?? "",
           hermes: defaultHermesDir ?? "",
+          pi: defaultPiDir ?? "",
         };
 
         setAppConfigDir(normalizedOverride);
@@ -223,6 +234,7 @@ export function useDirectorySettings({
           opencode: opencodeDir || defaultsRef.current.opencode,
           openclaw: openclawDir || defaultsRef.current.openclaw,
           hermes: hermesDir || defaultsRef.current.hermes,
+          pi: piDir || defaultsRef.current.pi,
         });
       } catch (error) {
         console.error(
@@ -365,6 +377,7 @@ export function useDirectorySettings({
         opencode: overrides?.opencode ?? defaultsRef.current.opencode,
         openclaw: overrides?.openclaw ?? defaultsRef.current.openclaw,
         hermes: overrides?.hermes ?? defaultsRef.current.hermes,
+        pi: overrides?.pi ?? defaultsRef.current.pi,
       });
     },
     [],

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -114,6 +114,7 @@ export function useSettings(): UseSettingsResult {
       opencode: sanitizeDir(data?.opencodeConfigDir),
       openclaw: sanitizeDir(data?.openclawConfigDir),
       hermes: sanitizeDir(data?.hermesConfigDir),
+      pi: sanitizeDir(data?.piConfigDir),
     });
     setRequiresRestart(false);
   }, [
@@ -195,6 +196,7 @@ export function useSettings(): UseSettingsResult {
         const sanitizedOpenclawDir = sanitizeDir(
           mergedSettings.openclawConfigDir,
         );
+        const sanitizedPiDir = sanitizeDir(mergedSettings.piConfigDir);
         const {
           webdavSync: _ignoredWebdavSync,
           s3Sync: _ignoredS3Sync,
@@ -209,6 +211,7 @@ export function useSettings(): UseSettingsResult {
           grokConfigDir: sanitizedGrokDir,
           opencodeConfigDir: sanitizedOpencodeDir,
           openclawConfigDir: sanitizedOpenclawDir,
+          piConfigDir: sanitizedPiDir,
           language: mergedSettings.language,
         };
 
@@ -328,6 +331,7 @@ export function useSettings(): UseSettingsResult {
         const sanitizedOpenclawDir = sanitizeDir(
           mergedSettings.openclawConfigDir,
         );
+        const sanitizedPiDir = sanitizeDir(mergedSettings.piConfigDir);
         const previousAppDir = initialAppConfigDir;
         const previousClaudeDir = sanitizeDir(data?.claudeConfigDir);
         const previousCodexDir = sanitizeDir(data?.codexConfigDir);
@@ -335,6 +339,7 @@ export function useSettings(): UseSettingsResult {
         const previousGrokDir = sanitizeDir(data?.grokConfigDir);
         const previousOpencodeDir = sanitizeDir(data?.opencodeConfigDir);
         const previousOpenclawDir = sanitizeDir(data?.openclawConfigDir);
+        const previousPiDir = sanitizeDir(data?.piConfigDir);
         const {
           webdavSync: _ignoredWebdavSync,
           s3Sync: _ignoredS3Sync,
@@ -349,6 +354,7 @@ export function useSettings(): UseSettingsResult {
           grokConfigDir: sanitizedGrokDir,
           opencodeConfigDir: sanitizedOpencodeDir,
           openclawConfigDir: sanitizedOpenclawDir,
+          piConfigDir: sanitizedPiDir,
           language: mergedSettings.language,
         };
 
@@ -436,6 +442,7 @@ export function useSettings(): UseSettingsResult {
         const grokDirChanged = sanitizedGrokDir !== previousGrokDir;
         const opencodeDirChanged = sanitizedOpencodeDir !== previousOpencodeDir;
         const openclawDirChanged = sanitizedOpenclawDir !== previousOpenclawDir;
+        const piDirChanged = sanitizedPiDir !== previousPiDir;
         if (
           !pluginSynced &&
           (claudeDirChanged ||
@@ -443,7 +450,8 @@ export function useSettings(): UseSettingsResult {
             geminiDirChanged ||
             grokDirChanged ||
             opencodeDirChanged ||
-            openclawDirChanged)
+            openclawDirChanged ||
+            piDirChanged)
         ) {
           const syncResult = await syncCurrentProvidersLiveSafe();
           if (!syncResult.ok) {

--- a/src/hooks/useSettingsForm.ts
+++ b/src/hooks/useSettingsForm.ts
@@ -125,6 +125,7 @@ export function useSettingsForm(): UseSettingsFormResult {
       grokConfigDir: sanitizeDir(data.grokConfigDir),
       opencodeConfigDir: sanitizeDir(data.opencodeConfigDir),
       openclawConfigDir: sanitizeDir(data.openclawConfigDir),
+      piConfigDir: sanitizeDir(data.piConfigDir),
       language: normalizedLanguage,
     };
 
@@ -192,6 +193,7 @@ export function useSettingsForm(): UseSettingsFormResult {
         grokConfigDir: sanitizeDir(serverData.grokConfigDir),
         opencodeConfigDir: sanitizeDir(serverData.opencodeConfigDir),
         openclawConfigDir: sanitizeDir(serverData.openclawConfigDir),
+        piConfigDir: sanitizeDir(serverData.piConfigDir),
         language: normalizedLanguage,
       };
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -767,6 +767,8 @@
     "openclawConfigDirDescription": "Override OpenClaw configuration directory (openclaw.json).",
     "hermesConfigDir": "Hermes Configuration Directory",
     "hermesConfigDirDescription": "Override Hermes configuration directory (config.yaml).",
+    "piConfigDir": "Pi Agent Configuration Directory",
+    "piConfigDirDescription": "Override Pi Agent configuration directory (models.json and settings.json).",
     "browsePlaceholderClaude": "e.g., /home/<your-username>/.claude",
     "browsePlaceholderCodex": "e.g., /home/<your-username>/.codex",
     "browsePlaceholderGemini": "e.g., /home/<your-username>/.gemini",
@@ -774,6 +776,7 @@
     "browsePlaceholderOpencode": "e.g., /home/<your-username>/.config/opencode",
     "browsePlaceholderOpenclaw": "e.g., /home/<your-username>/.openclaw",
     "browsePlaceholderHermes": "e.g., /home/<your-username>/.hermes",
+    "browsePlaceholderPi": "e.g., /home/<your-username>/.pi/agent",
     "browseDirectory": "Browse Directory",
     "resetDefault": "Reset to default directory (takes effect after saving)",
     "checkForUpdates": "Check for Updates",
@@ -884,7 +887,8 @@
     "grokbuild": "Grok Build",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "pi": "Pi Agent"
   },
   "grokBuild": {
     "apiBackend": "API backend",
@@ -2151,6 +2155,16 @@
     },
     "primaryModel": "Primary Model",
     "fallbackModel": "Fallback Model"
+  },
+  "pi": {
+    "apiProtocol": "API Protocol",
+    "baseUrl": "API Endpoint",
+    "defaultModel": "Default Model",
+    "defaultModelPlaceholder": "Select default model",
+    "models": "Models",
+    "addModel": "Add Model",
+    "modelId": "Model ID",
+    "modelName": "Display Name"
   },
   "hermes": {
     "form": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -767,6 +767,8 @@
     "openclawConfigDirDescription": "OpenClaw の設定ディレクトリ（openclaw.json）を上書きします。",
     "hermesConfigDir": "Hermes 設定ディレクトリ",
     "hermesConfigDirDescription": "Hermes の設定ディレクトリ（config.yaml）を上書きします。",
+    "piConfigDir": "Pi Agent 設定ディレクトリ",
+    "piConfigDirDescription": "Pi Agent の設定ディレクトリ（models.json と settings.json）を上書きします。",
     "browsePlaceholderClaude": "例: /home/<your-username>/.claude",
     "browsePlaceholderCodex": "例: /home/<your-username>/.codex",
     "browsePlaceholderGemini": "例: /home/<your-username>/.gemini",
@@ -774,6 +776,7 @@
     "browsePlaceholderOpencode": "例: /home/<your-username>/.config/opencode",
     "browsePlaceholderOpenclaw": "例: /home/<your-username>/.openclaw",
     "browsePlaceholderHermes": "例: /home/<your-username>/.hermes",
+    "browsePlaceholderPi": "例: /home/<your-username>/.pi/agent",
     "browseDirectory": "ディレクトリを選択",
     "resetDefault": "デフォルトに戻す（保存後に反映）",
     "checkForUpdates": "アップデートを確認",
@@ -884,7 +887,8 @@
     "grokbuild": "Grok Build",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "pi": "Pi Agent"
   },
   "grokBuild": {
     "apiBackend": "API Backend",
@@ -2151,6 +2155,16 @@
     },
     "primaryModel": "プライマリモデル",
     "fallbackModel": "フォールバックモデル"
+  },
+  "pi": {
+    "apiProtocol": "API プロトコル",
+    "baseUrl": "API エンドポイント",
+    "defaultModel": "デフォルトモデル",
+    "defaultModelPlaceholder": "デフォルトモデルを選択",
+    "models": "モデル一覧",
+    "addModel": "モデルを追加",
+    "modelId": "モデル ID",
+    "modelName": "表示名"
   },
   "hermes": {
     "form": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -767,6 +767,8 @@
     "openclawConfigDirDescription": "覆寫 OpenClaw 設定目錄 (openclaw.json)。",
     "hermesConfigDir": "Hermes 設定目錄",
     "hermesConfigDirDescription": "覆寫 Hermes 設定目錄 (config.yaml)。",
+    "piConfigDir": "Pi Agent 設定目錄",
+    "piConfigDirDescription": "覆寫 Pi Agent 設定目錄 (models.json 與 settings.json)。",
     "browsePlaceholderClaude": "例如：/home/<您的帳號>/.claude",
     "browsePlaceholderCodex": "例如：/home/<您的帳號>/.codex",
     "browsePlaceholderGemini": "例如：/home/<您的帳號>/.gemini",
@@ -774,6 +776,7 @@
     "browsePlaceholderOpencode": "例如：/home/<您的帳號>/.config/opencode",
     "browsePlaceholderOpenclaw": "例如：/home/<您的帳號>/.openclaw",
     "browsePlaceholderHermes": "例如：/home/<您的帳號>/.hermes",
+    "browsePlaceholderPi": "例如：/home/<您的帳號>/.pi/agent",
     "browseDirectory": "瀏覽目錄",
     "resetDefault": "還原預設目錄（需儲存後生效）",
     "checkForUpdates": "檢查更新",
@@ -885,7 +888,8 @@
     "grokbuild": "Grok Build",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "pi": "Pi Agent"
   },
   "grokBuild": {
     "apiBackend": "API Backend",
@@ -2152,6 +2156,16 @@
     },
     "primaryModel": "預設模型",
     "fallbackModel": "備用模型"
+  },
+  "pi": {
+    "apiProtocol": "API 協議",
+    "baseUrl": "API 端點",
+    "defaultModel": "預設模型",
+    "defaultModelPlaceholder": "選擇預設模型",
+    "models": "模型清單",
+    "addModel": "新增模型",
+    "modelId": "模型 ID",
+    "modelName": "顯示名稱"
   },
   "hermes": {
     "form": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -767,6 +767,8 @@
     "openclawConfigDirDescription": "覆盖 OpenClaw 配置目录 (openclaw.json)。",
     "hermesConfigDir": "Hermes 配置目录",
     "hermesConfigDirDescription": "覆盖 Hermes 配置目录 (config.yaml)。",
+    "piConfigDir": "Pi Agent 配置目录",
+    "piConfigDirDescription": "覆盖 Pi Agent 配置目录 (models.json 和 settings.json)。",
     "browsePlaceholderClaude": "例如：/home/<你的用户名>/.claude",
     "browsePlaceholderCodex": "例如：/home/<你的用户名>/.codex",
     "browsePlaceholderGemini": "例如：/home/<你的用户名>/.gemini",
@@ -774,6 +776,7 @@
     "browsePlaceholderOpencode": "例如：/home/<你的用户名>/.config/opencode",
     "browsePlaceholderOpenclaw": "例如：/home/<你的用户名>/.openclaw",
     "browsePlaceholderHermes": "例如：/home/<你的用户名>/.hermes",
+    "browsePlaceholderPi": "例如：/home/<你的用户名>/.pi/agent",
     "browseDirectory": "浏览目录",
     "resetDefault": "恢复默认目录（需保存后生效）",
     "checkForUpdates": "检查更新",
@@ -884,7 +887,8 @@
     "grokbuild": "Grok Build",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "pi": "Pi Agent"
   },
   "grokBuild": {
     "apiBackend": "API Backend",
@@ -2151,6 +2155,16 @@
     },
     "primaryModel": "默认模型",
     "fallbackModel": "回退模型"
+  },
+  "pi": {
+    "apiProtocol": "API 协议",
+    "baseUrl": "API 端点",
+    "defaultModel": "默认模型",
+    "defaultModelPlaceholder": "选择默认模型",
+    "models": "模型列表",
+    "addModel": "添加模型",
+    "modelId": "模型 ID",
+    "modelName": "显示名称"
   },
   "hermes": {
     "form": {

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -7,4 +7,5 @@ export type AppId =
   | "grokbuild"
   | "opencode"
   | "openclaw"
-  | "hermes";
+  | "hermes"
+  | "pi";

--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -84,6 +84,10 @@ export const useAddProviderMutation = (appId: AppId) => {
           }
           id = providerInput.providerKey;
         }
+      } else if (appId === "pi") {
+        // Pi provider IDs are user-visible registry keys. Namespace generated
+        // IDs so they remain recognizable and avoid external-key collisions.
+        id = `cc-switch-${generateUUID()}`;
       } else {
         id = generateUUID();
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,7 @@ export interface VisibleApps {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  pi: boolean;
 }
 
 // WebDAV 同步状态
@@ -403,6 +404,8 @@ export interface Settings {
   openclawConfigDir?: string;
   // 覆盖 Hermes 配置目录（可选）
   hermesConfigDir?: string;
+  // 覆盖 Pi Agent 配置目录（可选）
+  piConfigDir?: string;
 
   // ===== 当前供应商 ID（设备级）=====
   // 当前 Claude 供应商 ID（优先于数据库 is_current）
@@ -413,6 +416,8 @@ export interface Settings {
   currentProviderCodex?: string;
   // 当前 Gemini 供应商 ID（优先于数据库 is_current）
   currentProviderGemini?: string;
+  // 当前 Pi Agent 供应商 ID（优先于数据库 is_current）
+  currentProviderPi?: string;
 
   // ===== Skill 同步设置 =====
   // Skill 同步方式：auto（默认，优先 symlink）、symlink、copy

--- a/tests/components/AppVisibilitySettings.test.tsx
+++ b/tests/components/AppVisibilitySettings.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AppVisibilitySettings } from "@/components/settings/AppVisibilitySettings";
+import type { SettingsFormState } from "@/hooks/useSettings";
+
+describe("AppVisibilitySettings", () => {
+  it("keeps Pi hidden until the user enables it", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <AppVisibilitySettings
+        settings={{} as SettingsFormState}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByText("apps.pi"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        visibleApps: expect.objectContaining({ pi: true }),
+      }),
+    );
+  });
+});

--- a/tests/components/PiFormFields.test.tsx
+++ b/tests/components/PiFormFields.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { PiFormFields } from "@/components/providers/forms/PiFormFields";
+import { Form } from "@/components/ui/form";
+
+function TestForm() {
+  const form = useForm();
+
+  return (
+    <Form {...form}>
+      <PiFormFields
+        baseUrl="https://api.example.com/v1"
+        onBaseUrlChange={vi.fn()}
+        apiKey="sk-test"
+        onApiKeyChange={vi.fn()}
+        shouldShowApiKeyLink={false}
+        websiteUrl="https://example.com"
+        api="openai-chat"
+        onApiChange={vi.fn()}
+        models={[
+          { id: "duplicate-model", name: "First" },
+          { id: "duplicate-model", name: "Second" },
+        ]}
+        onModelsChange={vi.fn()}
+        defaultModel="duplicate-model"
+        onDefaultModelChange={vi.fn()}
+      />
+    </Form>
+  );
+}
+
+describe("PiFormFields", () => {
+  it("deduplicates model ids in the default-model selector", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    const user = userEvent.setup();
+    render(<TestForm />);
+
+    const selects = screen.getAllByRole("combobox");
+    await user.click(selects[1]);
+
+    expect(
+      await screen.findAllByRole("option", { name: "duplicate-model" }),
+    ).toHaveLength(1);
+  });
+});

--- a/tests/config/piAppConfig.test.tsx
+++ b/tests/config/piAppConfig.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import {
+  APP_ICON_MAP,
+  APP_IDS,
+  MCP_APP_IDS,
+  SKILLS_APP_IDS,
+} from "@/config/appConfig";
+
+describe("Pi frontend capability boundaries", () => {
+  it("registers Pi for providers but not unsupported shared features", () => {
+    expect(APP_IDS).toContain("pi");
+    expect(APP_ICON_MAP.pi.label).toBe("Pi Agent");
+    expect(SKILLS_APP_IDS).not.toContain("pi");
+    expect(MCP_APP_IDS).not.toContain("pi");
+  });
+});

--- a/tests/hooks/useAddProviderMutation.test.tsx
+++ b/tests/hooks/useAddProviderMutation.test.tsx
@@ -69,6 +69,31 @@ beforeEach(() => {
 });
 
 describe("useAddProviderMutation", () => {
+  it("namespaces generated Pi registry keys", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddProviderMutation("pi"), {
+      wrapper,
+    });
+
+    const provider = await act(async () =>
+      result.current.mutateAsync({
+        name: "Pi Relay",
+        settingsConfig: {
+          baseUrl: "https://pi.example/v1",
+          api: "openai-completions",
+          models: [{ id: "model-a" }],
+        },
+      }),
+    );
+
+    expect(provider.id).toBe("cc-switch-generated-uuid");
+    expect(apiMocks.add).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "cc-switch-generated-uuid" }),
+      "pi",
+      undefined,
+    );
+  });
+
   it("duplicates Claude Desktop official providers with a fresh id", async () => {
     const { wrapper } = createWrapper();
     const { result } = renderHook(

--- a/tests/hooks/useDirectorySettings.test.tsx
+++ b/tests/hooks/useDirectorySettings.test.tsx
@@ -72,7 +72,8 @@ describe("useDirectorySettings", () => {
       if (app === "grokbuild") return "/remote/grok";
       if (app === "opencode") return "/remote/opencode";
       if (app === "openclaw") return "/remote/openclaw";
-      return "/remote/hermes";
+      if (app === "hermes") return "/remote/hermes";
+      return "/remote/pi";
     });
     selectConfigDirectoryMock.mockReset();
   });
@@ -96,6 +97,7 @@ describe("useDirectorySettings", () => {
       opencode: "/remote/opencode",
       openclaw: "/remote/openclaw",
       hermes: "/remote/hermes",
+      pi: "/remote/pi",
     });
   });
 
@@ -255,6 +257,7 @@ describe("useDirectorySettings", () => {
         grokbuild: "/server/grok",
         opencode: "/server/opencode",
         openclaw: "/server/openclaw",
+        pi: "/server/pi",
       });
     });
 
@@ -264,5 +267,6 @@ describe("useDirectorySettings", () => {
     expect(result.current.resolvedDirs.grokbuild).toBe("/server/grok");
     expect(result.current.resolvedDirs.opencode).toBe("/server/opencode");
     expect(result.current.resolvedDirs.openclaw).toBe("/server/openclaw");
+    expect(result.current.resolvedDirs.pi).toBe("/server/pi");
   });
 });

--- a/tests/hooks/usePiFormState.test.tsx
+++ b/tests/hooks/usePiFormState.test.tsx
@@ -1,0 +1,40 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePiFormState } from "@/components/providers/forms/hooks/usePiFormState";
+
+describe("usePiFormState", () => {
+  it("updates the selected default model even while the JSON editor is invalid", () => {
+    const initialData = {
+      settingsConfig: {
+        baseUrl: "https://api.example.com/v1",
+        apiKey: "sk-test",
+        api: "openai-chat",
+        models: [
+          { id: "old-model", name: "Old Model" },
+          { id: "next-model", name: "Next Model" },
+        ],
+        defaultModel: "old-model",
+      },
+    };
+    const onSettingsConfigChange = vi.fn();
+    const getSettingsConfig = () => "{ invalid json";
+
+    const { result } = renderHook(() =>
+      usePiFormState({
+        initialData,
+        appId: "pi",
+        onSettingsConfigChange,
+        getSettingsConfig,
+      }),
+    );
+
+    act(() => {
+      result.current.handlePiModelsChange([
+        { id: "next-model", name: "Next Model" },
+      ]);
+    });
+
+    expect(result.current.piDefaultModel).toBe("next-model");
+    expect(onSettingsConfigChange).not.toHaveBeenCalled();
+  });
+});

--- a/tests/hooks/usePiFormState.test.tsx
+++ b/tests/hooks/usePiFormState.test.tsx
@@ -2,32 +2,46 @@ import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { usePiFormState } from "@/components/providers/forms/hooks/usePiFormState";
 
+const PI_CONFIG_A = JSON.stringify({
+  baseUrl: "https://a.example/v1",
+  api: "openai-completions",
+  models: [{ id: "model-a", name: "Model A" }],
+  defaultModel: "model-a",
+});
+
+const PI_CONFIG_B = JSON.stringify({
+  baseURL: "https://b.example/v1",
+  apiKey: "$PI_KEY",
+  api: "google-generative-ai",
+  models: ["gemma-4"],
+  defaultModel: "gemma-4",
+});
+
 describe("usePiFormState", () => {
   it("updates the selected default model even while the JSON editor is invalid", () => {
-    const initialData = {
-      settingsConfig: {
-        baseUrl: "https://api.example.com/v1",
-        apiKey: "sk-test",
-        api: "openai-chat",
-        models: [
-          { id: "old-model", name: "Old Model" },
-          { id: "next-model", name: "Next Model" },
-        ],
-        defaultModel: "old-model",
-      },
-    };
+    const validConfig = JSON.stringify({
+      baseUrl: "https://api.example.com/v1",
+      apiKey: "sk-test",
+      api: "openai-completions",
+      models: [
+        { id: "old-model", name: "Old Model" },
+        { id: "next-model", name: "Next Model" },
+      ],
+      defaultModel: "old-model",
+    });
     const onSettingsConfigChange = vi.fn();
-    const getSettingsConfig = () => "{ invalid json";
 
-    const { result } = renderHook(() =>
-      usePiFormState({
-        initialData,
-        appId: "pi",
-        onSettingsConfigChange,
-        getSettingsConfig,
-      }),
+    const { result, rerender } = renderHook(
+      ({ settingsConfig }) =>
+        usePiFormState({
+          appId: "pi",
+          settingsConfig,
+          onSettingsConfigChange,
+        }),
+      { initialProps: { settingsConfig: validConfig } },
     );
 
+    rerender({ settingsConfig: "{ invalid json" });
     act(() => {
       result.current.handlePiModelsChange([
         { id: "next-model", name: "Next Model" },
@@ -36,5 +50,54 @@ describe("usePiFormState", () => {
 
     expect(result.current.piDefaultModel).toBe("next-model");
     expect(onSettingsConfigChange).not.toHaveBeenCalled();
+  });
+
+  it("hydrates structured fields when raw JSON changes", () => {
+    const onSettingsConfigChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ settingsConfig }) =>
+        usePiFormState({
+          appId: "pi",
+          settingsConfig,
+          onSettingsConfigChange,
+        }),
+      { initialProps: { settingsConfig: PI_CONFIG_A } },
+    );
+
+    rerender({ settingsConfig: PI_CONFIG_B });
+
+    expect(result.current.piBaseUrl).toBe("https://b.example/v1");
+    expect(result.current.piApiKey).toBe("$PI_KEY");
+    expect(result.current.piApi).toBe("google-generative-ai");
+    expect(result.current.piModels).toEqual([
+      { id: "gemma-4", name: "gemma-4" },
+    ]);
+    expect(result.current.piDefaultModel).toBe("gemma-4");
+  });
+
+  it("preserves unknown Pi fields during structured edits", () => {
+    const onSettingsConfigChange = vi.fn();
+    const { result } = renderHook(() =>
+      usePiFormState({
+        appId: "pi",
+        settingsConfig: JSON.stringify({
+          baseUrl: "https://api.example.com/v1",
+          api: "openai-completions",
+          models: [{ id: "model-1", name: "Model 1" }],
+          headers: { "x-route": "$PI_ROUTE" },
+          futurePiField: { enabled: true },
+        }),
+        onSettingsConfigChange,
+      }),
+    );
+
+    act(() => {
+      result.current.handlePiApiChange("openai-responses");
+    });
+
+    const updated = JSON.parse(onSettingsConfigChange.mock.calls.at(-1)?.[0]);
+    expect(updated.api).toBe("openai-responses");
+    expect(updated.headers).toEqual({ "x-route": "$PI_ROUTE" });
+    expect(updated.futurePiField).toEqual({ enabled: true });
   });
 });

--- a/tests/hooks/usePiFormState.test.tsx
+++ b/tests/hooks/usePiFormState.test.tsx
@@ -13,7 +13,7 @@ const PI_CONFIG_B = JSON.stringify({
   baseURL: "https://b.example/v1",
   apiKey: "$PI_KEY",
   api: "google-generative-ai",
-  models: ["gemma-4"],
+  models: [{ id: "gemma-4" }],
   defaultModel: "gemma-4",
 });
 

--- a/tests/msw/state.ts
+++ b/tests/msw/state.ts
@@ -73,6 +73,7 @@ const createDefaultProviders = (): ProvidersByApp => ({
   opencode: {},
   openclaw: {},
   hermes: {},
+  pi: {},
 });
 
 const createDefaultCurrent = (): CurrentProviderState => ({
@@ -84,6 +85,7 @@ const createDefaultCurrent = (): CurrentProviderState => ({
   opencode: "",
   openclaw: "",
   hermes: "",
+  pi: "",
 });
 
 let providers = createDefaultProviders();
@@ -197,6 +199,7 @@ let mcpConfigs: McpConfigState = {
   opencode: {},
   openclaw: {},
   hermes: {},
+  pi: {},
 };
 
 const cloneProviders = (value: ProvidersByApp) =>
@@ -266,6 +269,7 @@ export const resetProviderState = () => {
     opencode: {},
     openclaw: {},
     hermes: {},
+    pi: {},
   };
 };
 


### PR DESCRIPTION
## Summary / 概述

This PR adds focused first-class support for the official Pi Coding Agent. It keeps Pi opt-in, reuses the existing provider UI, imports the complete Pi provider registry, and treats provider selection as an explicit operation.

Pi's three configuration files are handled according to their actual ownership and syntax:

- `models.json` is parsed as Pi's JSONC subset (`//` comments and trailing commas), then updated through a round-trip AST so unrelated providers, root fields, comments, and ordering survive.
- API keys are stored in `auth.json`; legacy inline keys migrate on managed updates, while OAuth and unknown credential types are never overwritten or deleted.
- `auth.json`, `models.json`, and `settings.json` share one lock and rollback transaction, with external-change detection before commit and before each write.

The first release intentionally excludes Oh My Pi, MCP, Skills, Prompts, Sessions, updater work, proxy/failover support, and any global secrets refactor.

## Related Issue / 关联 Issue

Related to #1855 and #5848. This intentionally does not close the central tracker.

## Existing Pi PRs / 现有 Pi PR 对比

Status checked on 2026-07-31:

| PR | Current state | Useful input | Why this PR differs |
|---|---|---|---|
| #3077 | Closed; 60 files | Early broad integration | Keeps MCP, Skills, and prompts out of the first release |
| #3490 | Open, conflicting; CI failing | Directory override and environment detection | Avoids bundling Sessions, MCP, Skills, and Prompts |
| #5022 | Open, conflicting | External modification protection | Uses the existing provider UI instead of a separate runtime/panel |
| #5181 | Open, conflicting; its latest frontend and three backend jobs passed | Best engineering baseline: lifecycle, transactions, backups, forms, tests | Adds complete import, strict JSONC preservation, `auth.json`, and three-file safety |
| #5598 | Open, conflicting; 144 files | `baseUrl`, raw validation, delete protection | Excludes Oh My Pi, updater, secrets, and unrelated refactors |

The ten #5181 commits are retained with their original author information. Thanks to #3490, #5022, #5181, and #5598 for the implementation and review input incorporated here.

## Key Differences From #5181 / 相对 #5181 的增量

- Imports every `models.json.providers` entry and maps only `settings.json.defaultProvider` as current.
- Adds strict Pi-compatible JSONC validation and comment-preserving target updates.
- Moves managed API keys to `auth.json`, including inline-key migration and OAuth ownership guards.
- Extends the transaction from two files to all three, including byte-level conflict checks, reverse rollback, change-only backups, no-op handling, and Unix `0600` for new auth files.
- Rejects unmanaged live key collisions and makes all selection changes explicit.
- Defaults Pi to hidden for both fresh and pre-Pi settings files.

## Test Evidence / 测试证据

Local checks passed on 2026-07-31:

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` (91 files, 590 tests)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (full suite; 2252 passed, 2 ignored in the library target, all integration targets passed)

Dedicated coverage includes Pi JSONC acceptance/rejection, round-trip comment and unknown-field retention, complete registry import, explicit switching, unmanaged collisions, inline-key migration, API key permissions, OAuth overwrite/delete protection, all three external-change checks, rollback, backups, no-op writes, and directory precedence.

The [upstream CI run for the current head](https://github.com/farion1231/cc-switch/actions/runs/30622232011) is awaiting maintainer approval for a forked workflow (`action_required`, no jobs started). This is not a test failure. The PR should remain a draft until Linux, Windows, and macOS CI are green and the branch is conflict-free against current `main`.

## Screenshots / 截图

Not included: Pi uses the existing provider management surface; the only visibility change is that Pi is opt-in under application visibility settings.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / Pi strings are present in all four locale files
- [x] Official Pi only; no Oh My Pi or unrelated feature expansion
- [ ] Linux, Windows, and macOS CI pass (currently awaiting maintainer workflow approval)
