### PR TITLE
feat: 支持 Claude 自定义思考强度映射

### DIFF
--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -53,7 +53,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 16;
+pub(crate) const SCHEMA_VERSION: i32 = 18;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -198,6 +198,8 @@ impl Database {
             request_id TEXT PRIMARY KEY, provider_id TEXT NOT NULL, app_type TEXT NOT NULL, model TEXT NOT NULL,
             request_model TEXT,
             pricing_model TEXT,
+            reasoning_effort TEXT,
+            reasoning_effort_source TEXT,
             input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0,
             cache_read_tokens INTEGER NOT NULL DEFAULT 0, cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
             input_token_semantics INTEGER NOT NULL DEFAULT 0,
@@ -510,6 +512,16 @@ impl Database {
                         log::info!("迁移数据库从 v15 到 v16（重建 Codex 会话用量）");
                         Self::migrate_v15_to_v16(conn)?;
                         Self::set_user_version(conn, 16)?;
+                    }
+                    16 => {
+                        log::info!("迁移数据库从 v16 到 v17（记录请求思考强度）");
+                        Self::migrate_v16_to_v17(conn)?;
+                        Self::set_user_version(conn, 17)?;
+                    }
+                    17 => {
+                        log::info!("迁移数据库从 v17 到 v18（记录路由前思考强度）");
+                        Self::migrate_v17_to_v18(conn)?;
+                        Self::set_user_version(conn, 18)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -1521,6 +1533,29 @@ impl Database {
     fn migrate_v15_to_v16(conn: &Connection) -> Result<(), AppError> {
         let codex_dir = crate::codex_config::get_codex_config_dir();
         crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)
+    }
+
+    /// v16 -> v17：记录最终出站请求的思考强度。
+    ///
+    /// NULL 表示历史行或请求没有携带 effort，避免把未知值伪装成默认值。
+    fn migrate_v16_to_v17(conn: &Connection) -> Result<(), AppError> {
+        if Self::table_exists(conn, "proxy_request_logs")? {
+            Self::add_column_if_missing(conn, "proxy_request_logs", "reasoning_effort", "TEXT")?;
+        }
+        Ok(())
+    }
+
+    /// v17 -> v18：记录模型路由命中前的思考强度，以展示映射关系。
+    fn migrate_v17_to_v18(conn: &Connection) -> Result<(), AppError> {
+        if Self::table_exists(conn, "proxy_request_logs")? {
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_logs",
+                "reasoning_effort_source",
+                "TEXT",
+            )?;
+        }
+        Ok(())
     }
 
     /// 插入默认模型定价数据
@@ -3080,7 +3115,7 @@ mod tests {
 
         Database::apply_schema_migrations_on_conn(&conn)?;
 
-        assert_eq!(Database::get_user_version(&conn)?, 16);
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
         let counts: (i64, i64, i64, i64) = conn.query_row(
             "SELECT
                 (SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'),
@@ -3091,6 +3126,42 @@ mod tests {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )?;
         assert_eq!(counts, (0, 1, 0, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_v16_to_v17_adds_reasoning_effort_column() -> Result<(), AppError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute(
+            "CREATE TABLE proxy_request_logs (request_id TEXT PRIMARY KEY)",
+            [],
+        )?;
+
+        Database::migrate_v16_to_v17(&conn)?;
+
+        assert!(Database::has_column(
+            &conn,
+            "proxy_request_logs",
+            "reasoning_effort"
+        )?);
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_v17_to_v18_adds_reasoning_effort_source_column() -> Result<(), AppError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute(
+            "CREATE TABLE proxy_request_logs (request_id TEXT PRIMARY KEY)",
+            [],
+        )?;
+
+        Database::migrate_v17_to_v18(&conn)?;
+
+        assert!(Database::has_column(
+            &conn,
+            "proxy_request_logs",
+            "reasoning_effort_source"
+        )?);
         Ok(())
     }
 }

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -392,6 +392,21 @@ pub struct CodexChatReasoningConfig {
     pub output_format: Option<String>,
 }
 
+/// Claude Messages -> OpenAI-compatible reasoning-effort overrides.
+///
+/// Keys are Claude-side effort values (`low`, `medium`, `high`, `xhigh`, `max`);
+/// values are the provider's accepted Chat Completions `reasoning_effort` or
+/// Responses `reasoning.effort` values.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ClaudeChatReasoningConfig {
+    #[serde(
+        rename = "effortMap",
+        default,
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub effort_map: HashMap<String, String>,
+}
+
 /// Local proxy request overrides applied after route/protocol transforms.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct LocalProxyRequestOverrides {
@@ -489,6 +504,12 @@ pub struct ProviderMeta {
     /// Codex Responses -> Chat Completions reasoning capability metadata.
     #[serde(rename = "codexChatReasoning", skip_serializing_if = "Option::is_none")]
     pub codex_chat_reasoning: Option<CodexChatReasoningConfig>,
+    /// Claude Messages -> OpenAI-compatible reasoning-effort overrides.
+    #[serde(
+        rename = "claudeChatReasoning",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub claude_chat_reasoning: Option<ClaudeChatReasoningConfig>,
     /// Codex → Anthropic path: whether to emulate the Claude Code client
     /// (User-Agent / anthropic-beta / x-app + injecting the Claude Code system
     /// prompt first line). Disabled by default; only an explicit `true` enables it.

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -65,6 +65,10 @@ pub struct ForwardResult {
     /// usage 归因不能依赖 ctx.request_model（映射前的客户端别名）：上游响应
     /// 缺失 model 或回显别名时，接管流量会被记成 claude-* 并按其定价计费。
     pub outbound_model: Option<String>,
+    /// 最终发往上游的思考强度，取自请求体所有转换和本地覆盖完成后的结果。
+    pub outbound_reasoning_effort: Option<String>,
+    /// 模型路由命中前的思考强度；用于使用统计展示路由后的映射关系。
+    pub outbound_reasoning_effort_source: Option<String>,
     /// 活跃连接 RAII guard：随响应一起流转到 response_processor / handle_claude_transform，
     /// 最终被 move 进流式 body future（或非流式响应作用域），覆盖整个响应生命周期。
     pub(crate) connection_guard: Option<ActiveConnectionGuard>,
@@ -490,7 +494,13 @@ impl RequestForwarder {
                 )
                 .await
             {
-                Ok((response, claude_api_format, outbound_model)) => {
+                Ok((
+                    response,
+                    claude_api_format,
+                    outbound_model,
+                    outbound_reasoning_effort,
+                    outbound_reasoning_effort_source,
+                )) => {
                     // 成功：普通闭合熔断状态异步记录，避免阻塞流式首包返回；
                     // HalfOpen 探测仍同步等待，保证 permit 与熔断状态及时释放。
                     self.record_success_result(&provider.id, app_type_str, used_half_open_permit)
@@ -539,6 +549,8 @@ impl RequestForwarder {
                         provider: provider.clone(),
                         claude_api_format,
                         outbound_model,
+                        outbound_reasoning_effort,
+                        outbound_reasoning_effort_source,
                         connection_guard: None,
                     });
                 }
@@ -589,7 +601,13 @@ impl RequestForwarder {
                                 )
                                 .await
                             {
-                                Ok((response, claude_api_format, outbound_model)) => {
+                                Ok((
+                                    response,
+                                    claude_api_format,
+                                    outbound_model,
+                                    outbound_reasoning_effort,
+                                    outbound_reasoning_effort_source,
+                                )) => {
                                     log::info!(
                                         "[{app_type_str}] [Media] Unsupported-image retry succeeded"
                                     );
@@ -642,6 +660,8 @@ impl RequestForwarder {
                                         provider: provider.clone(),
                                         claude_api_format,
                                         outbound_model,
+                                        outbound_reasoning_effort,
+                                        outbound_reasoning_effort_source,
                                         connection_guard: None,
                                     });
                                 }
@@ -735,7 +755,13 @@ impl RequestForwarder {
                                     )
                                     .await
                                 {
-                                    Ok((response, claude_api_format, outbound_model)) => {
+                                    Ok((
+                                        response,
+                                        claude_api_format,
+                                        outbound_model,
+                                        outbound_reasoning_effort,
+                                        outbound_reasoning_effort_source,
+                                    )) => {
                                         log::info!("[{app_type_str}] [RECT-002] 整流重试成功");
                                         self.record_success_result(
                                             &provider.id,
@@ -791,6 +817,8 @@ impl RequestForwarder {
                                             provider: provider.clone(),
                                             claude_api_format,
                                             outbound_model,
+                                            outbound_reasoning_effort,
+                                            outbound_reasoning_effort_source,
                                             connection_guard: None,
                                         });
                                     }
@@ -901,7 +929,13 @@ impl RequestForwarder {
                                 )
                                 .await
                             {
-                                Ok((response, claude_api_format, outbound_model)) => {
+                                Ok((
+                                    response,
+                                    claude_api_format,
+                                    outbound_model,
+                                    outbound_reasoning_effort,
+                                    outbound_reasoning_effort_source,
+                                )) => {
                                     log::info!("[{app_type_str}] [RECT-011] budget 整流重试成功");
                                     self.record_success_result(
                                         &provider.id,
@@ -951,6 +985,8 @@ impl RequestForwarder {
                                         provider: provider.clone(),
                                         claude_api_format,
                                         outbound_model,
+                                        outbound_reasoning_effort,
+                                        outbound_reasoning_effort_source,
                                         connection_guard: None,
                                     });
                                 }
@@ -1109,7 +1145,8 @@ impl RequestForwarder {
 
     /// 转发单个请求（使用适配器）
     ///
-    /// 成功时返回 `(response, claude_api_format, outbound_model)`，其中
+    /// 成功时返回 `(response, claude_api_format, outbound_model, outbound_reasoning_effort,
+    /// outbound_reasoning_effort_source)`，其中
     /// `outbound_model` 是最终发往上游的模型名（所有映射/改写之后）。
     #[allow(clippy::too_many_arguments)]
     async fn forward(
@@ -1122,7 +1159,16 @@ impl RequestForwarder {
         headers: &axum::http::HeaderMap,
         extensions: &Extensions,
         adapter: &dyn ProviderAdapter,
-    ) -> Result<(ProxyResponse, Option<String>, Option<String>), ProxyError> {
+    ) -> Result<
+        (
+            ProxyResponse,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ),
+        ProxyError,
+    > {
         // 使用适配器提取 base_url
         let mut base_url = adapter.extract_base_url(provider)?;
 
@@ -1159,13 +1205,17 @@ impl RequestForwarder {
         // 应用模型映射（独立于格式转换）
         // Claude Desktop proxy 模式必须先把 Desktop 可见的 claude-* route
         // 映射成真实上游模型名，并且未知 route 要直接报错，不能使用默认模型兜底。
-        let mapped_body = if matches!(app_type, AppType::ClaudeDesktop) {
-            crate::claude_desktop_config::map_proxy_request_model(body.clone(), provider)
-                .map_err(|e| ProxyError::InvalidRequest(e.to_string()))?
+        let inbound_reasoning_effort = extract_requested_reasoning_effort(&body);
+        let (mapped_body, model_was_routed) = if matches!(app_type, AppType::ClaudeDesktop) {
+            let mapped_body =
+                crate::claude_desktop_config::map_proxy_request_model(body.clone(), provider)
+                    .map_err(|e| ProxyError::InvalidRequest(e.to_string()))?;
+            let model_was_routed = body.get("model") != mapped_body.get("model");
+            (mapped_body, model_was_routed)
         } else {
-            let (mapped_body, _original_model, _mapped_model) =
+            let (mapped_body, _original_model, mapped_model) =
                 super::model_mapper::apply_model_mapping(body.clone(), provider);
-            mapped_body
+            (mapped_body, mapped_model.is_some())
         };
 
         // 与 CCH 对齐：请求前不做 thinking 主动改写（仅保留兼容入口）
@@ -1589,6 +1639,13 @@ impl RequestForwarder {
         {
             outbound_model = Some(m.to_string());
         }
+        let outbound_reasoning_effort = extract_outbound_reasoning_effort(&filtered_body);
+        let outbound_reasoning_effort_source =
+            if model_was_routed && outbound_reasoning_effort.is_some() {
+                inbound_reasoning_effort
+            } else {
+                None
+            };
         log_prompt_cache_trace(
             app_type,
             provider,
@@ -2301,7 +2358,13 @@ impl RequestForwarder {
                     response = self.validate_responses_stream_start(response).await?;
                 }
             }
-            Ok((response, resolved_claude_api_format, outbound_model))
+            Ok((
+                response,
+                resolved_claude_api_format,
+                outbound_model,
+                outbound_reasoning_effort,
+                outbound_reasoning_effort_source,
+            ))
         } else {
             let status_code = status.as_u16();
             // 错误响应同样可能被上游压缩（content-encoding）。reqwest 未启用任何
@@ -3283,6 +3346,51 @@ fn is_streaming_request(endpoint: &str, body: &Value, headers: &axum::http::Head
         .unwrap_or(false)
 }
 
+/// 从最终出站 body 提取实际发送的思考强度。
+///
+/// 同时覆盖 Chat Completions、Responses 与 Anthropic 的常见字段。此处刻意在
+/// `filtered_body` 定稿后调用，以反映格式转换和本地请求体覆盖的最终结果。
+fn extract_outbound_reasoning_effort(body: &Value) -> Option<String> {
+    [
+        body.get("reasoning_effort"),
+        body.pointer("/reasoning/effort"),
+        body.pointer("/output_config/effort"),
+        body.pointer("/thinking/effort"),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(|value| {
+        value
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
+/// 从入站请求读取用户指定的思考强度。
+///
+/// 这个值只会在模型路由实际改变模型时写入日志，用于与最终出站值组成
+/// `来源 -> 最终值`。转换器基于 `thinking` 预算推导出的强度不属于显式设置，
+/// 因而不作为映射来源显示。
+fn extract_requested_reasoning_effort(body: &Value) -> Option<String> {
+    [
+        body.pointer("/output_config/effort"),
+        body.get("reasoning_effort"),
+        body.pointer("/reasoning/effort"),
+        body.pointer("/thinking/effort"),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(|value| {
+        value
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
 #[cfg(test)]
 fn should_force_identity_encoding(
     endpoint: &str,
@@ -3622,6 +3730,50 @@ mod tests {
             streaming_first_byte_timeout,
             max_attempts: 1,
         }
+    }
+
+    #[test]
+    fn extracts_final_outbound_reasoning_effort_with_protocol_priority() {
+        assert_eq!(
+            extract_outbound_reasoning_effort(&json!({
+                "reasoning_effort": "max",
+                "reasoning": { "effort": "xhigh" },
+                "output_config": { "effort": "high" }
+            })),
+            Some("max".to_string())
+        );
+        assert_eq!(
+            extract_outbound_reasoning_effort(&json!({
+                "reasoning": { "effort": "ultra" }
+            })),
+            Some("ultra".to_string())
+        );
+        assert_eq!(
+            extract_outbound_reasoning_effort(&json!({
+                "output_config": { "effort": "xhigh" }
+            })),
+            Some("xhigh".to_string())
+        );
+        assert_eq!(extract_outbound_reasoning_effort(&json!({})), None);
+    }
+
+    #[test]
+    fn extracts_explicit_requested_reasoning_effort_with_protocol_priority() {
+        assert_eq!(
+            extract_requested_reasoning_effort(&json!({
+                "output_config": { "effort": "max" },
+                "reasoning_effort": "xhigh",
+                "reasoning": { "effort": "high" }
+            })),
+            Some("max".to_string())
+        );
+        assert_eq!(
+            extract_requested_reasoning_effort(&json!({
+                "reasoning": { "effort": "ultra" }
+            })),
+            Some("ultra".to_string())
+        );
+        assert_eq!(extract_requested_reasoning_effort(&json!({})), None);
     }
 
     #[test]

--- a/src-tauri/src/proxy/handler_context.rs
+++ b/src-tauri/src/proxy/handler_context.rs
@@ -53,6 +53,10 @@ pub struct RequestContext {
     /// usage 归因的兜底顺序：上游响应回显 → outbound_model → request_model。
     /// 不能直接用 request_model 兜底：接管场景下它是映射前的客户端别名。
     pub outbound_model: Option<String>,
+    /// 最终出站请求携带的思考强度。由 forwarder 在请求体定稿后回传，供使用统计展示。
+    pub outbound_reasoning_effort: Option<String>,
+    /// 模型路由命中前的显式思考强度。用于使用统计显示映射关系。
+    pub outbound_reasoning_effort_source: Option<String>,
     /// 日志标签（如 "Claude"、"Codex"、"Gemini"）
     pub tag: &'static str,
     /// 应用类型字符串（如 "claude"、"codex"、"gemini"）
@@ -165,6 +169,8 @@ impl RequestContext {
             current_provider_id,
             request_model,
             outbound_model: None,
+            outbound_reasoning_effort: None,
+            outbound_reasoning_effort_source: None,
             tag,
             app_type_str,
             app_type,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -216,6 +216,8 @@ async fn handle_messages_for_app(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.outbound_reasoning_effort = result.outbound_reasoning_effort.take();
+    ctx.outbound_reasoning_effort_source = result.outbound_reasoning_effort_source.take();
     ctx.provider = result.provider;
     let api_format = result
         .claude_api_format
@@ -287,6 +289,8 @@ struct ClaudeUsageLog {
     model: String,
     request_model: String,
     outbound_model: String,
+    reasoning_effort: Option<String>,
+    reasoning_effort_source: Option<String>,
     app_type: &'static str,
     provider_id: String,
     session_id: String,
@@ -320,6 +324,8 @@ fn prepare_claude_usage_log(
             .outbound_model
             .clone()
             .unwrap_or_else(|| ctx.request_model.clone()),
+        reasoning_effort: ctx.outbound_reasoning_effort.clone(),
+        reasoning_effort_source: ctx.outbound_reasoning_effort_source.clone(),
         app_type: ctx.app_type_str,
         provider_id: ctx.provider.id.clone(),
         session_id: ctx.session_id.clone(),
@@ -338,6 +344,8 @@ async fn write_claude_usage_log(state: &ProxyState, log: ClaudeUsageLog) {
         &log.model,
         &log.request_model,
         &log.outbound_model,
+        log.reasoning_effort,
+        log.reasoning_effort_source,
         log.usage,
         log.latency_ms,
         None,
@@ -433,6 +441,8 @@ async fn handle_claude_transform(
                 .outbound_model
                 .clone()
                 .unwrap_or_else(|| ctx.request_model.clone());
+            let reasoning_effort = ctx.outbound_reasoning_effort.clone();
+            let reasoning_effort_source = ctx.outbound_reasoning_effort_source.clone();
             let status_code = status.as_u16();
             let start_time = ctx.start_time;
             let session_id = ctx.session_id.clone();
@@ -456,6 +466,8 @@ async fn handle_claude_transform(
                         let session_id = session_id.clone();
                         let request_model = request_model.clone();
                         let outbound_model = fallback_model.clone();
+                        let reasoning_effort = reasoning_effort.clone();
+                        let reasoning_effort_source = reasoning_effort_source.clone();
 
                         tokio::spawn(async move {
                             log_usage(
@@ -465,6 +477,8 @@ async fn handle_claude_transform(
                                 &model,
                                 &request_model,
                                 &outbound_model,
+                                reasoning_effort,
+                                reasoning_effort_source,
                                 usage,
                                 latency_ms,
                                 first_token_ms,
@@ -747,6 +761,8 @@ pub async fn handle_chat_completions(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.outbound_reasoning_effort = result.outbound_reasoning_effort.take();
+    ctx.outbound_reasoning_effort_source = result.outbound_reasoning_effort_source.take();
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -842,6 +858,8 @@ async fn handle_responses_for_app(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.outbound_reasoning_effort = result.outbound_reasoning_effort.take();
+    ctx.outbound_reasoning_effort_source = result.outbound_reasoning_effort_source.take();
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -976,6 +994,8 @@ async fn handle_responses_compact_for_app(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.outbound_reasoning_effort = result.outbound_reasoning_effort.take();
+    ctx.outbound_reasoning_effort_source = result.outbound_reasoning_effort_source.take();
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -1119,6 +1139,8 @@ async fn handle_codex_responses_namespace_restore(
                     .outbound_model
                     .clone()
                     .unwrap_or_else(|| ctx.request_model.clone());
+                let reasoning_effort = ctx.outbound_reasoning_effort.clone();
+                let reasoning_effort_source = ctx.outbound_reasoning_effort_source.clone();
                 let app_type_str = ctx.app_type_str;
                 tokio::spawn({
                     let state = state.clone();
@@ -1133,6 +1155,8 @@ async fn handle_codex_responses_namespace_restore(
                             &model,
                             &request_model,
                             &outbound_model,
+                            reasoning_effort,
+                            reasoning_effort_source,
                             usage,
                             latency_ms,
                             None,
@@ -1205,6 +1229,8 @@ async fn handle_codex_chat_to_responses_transform(
                 .outbound_model
                 .clone()
                 .unwrap_or_else(|| ctx.request_model.clone());
+            let reasoning_effort = ctx.outbound_reasoning_effort.clone();
+            let reasoning_effort_source = ctx.outbound_reasoning_effort_source.clone();
             let app_type_str = ctx.app_type_str;
             let start_time = ctx.start_time;
             let session_id = ctx.session_id.clone();
@@ -1235,6 +1261,8 @@ async fn handle_codex_chat_to_responses_transform(
                     let provider_id = provider_id.clone();
                     let request_model = request_model.clone();
                     let outbound_model = fallback_model.clone();
+                    let reasoning_effort = reasoning_effort.clone();
+                    let reasoning_effort_source = reasoning_effort_source.clone();
                     let session_id = session_id.clone();
 
                     tokio::spawn(async move {
@@ -1245,6 +1273,8 @@ async fn handle_codex_chat_to_responses_transform(
                             &model,
                             &request_model,
                             &outbound_model,
+                            reasoning_effort,
+                            reasoning_effort_source,
                             usage,
                             latency_ms,
                             first_token_ms,
@@ -1352,6 +1382,8 @@ async fn handle_codex_chat_to_responses_transform(
             .outbound_model
             .clone()
             .unwrap_or_else(|| ctx.request_model.clone());
+        let reasoning_effort = ctx.outbound_reasoning_effort.clone();
+        let reasoning_effort_source = ctx.outbound_reasoning_effort_source.clone();
         let app_type_str = ctx.app_type_str;
         tokio::spawn({
             let state = state.clone();
@@ -1366,6 +1398,8 @@ async fn handle_codex_chat_to_responses_transform(
                     &model,
                     &request_model,
                     &outbound_model,
+                    reasoning_effort,
+                    reasoning_effort_source,
                     usage,
                     latency_ms,
                     None,
@@ -1517,6 +1551,8 @@ async fn handle_codex_anthropic_to_responses_transform(
             .outbound_model
             .clone()
             .unwrap_or_else(|| ctx.request_model.clone());
+        let reasoning_effort = ctx.outbound_reasoning_effort.clone();
+        let reasoning_effort_source = ctx.outbound_reasoning_effort_source.clone();
         let app_type_str = ctx.app_type_str;
         tokio::spawn({
             let state = state.clone();
@@ -1531,6 +1567,8 @@ async fn handle_codex_anthropic_to_responses_transform(
                     &model,
                     &request_model,
                     &outbound_model,
+                    reasoning_effort,
+                    reasoning_effort_source,
                     usage,
                     latency_ms,
                     None,
@@ -1584,6 +1622,8 @@ fn build_codex_anthropic_sse_response(
             .outbound_model
             .clone()
             .unwrap_or_else(|| ctx.request_model.clone());
+        let reasoning_effort = ctx.outbound_reasoning_effort.clone();
+        let reasoning_effort_source = ctx.outbound_reasoning_effort_source.clone();
         let app_type_str = ctx.app_type_str;
         let start_time = ctx.start_time;
         let session_id = ctx.session_id.clone();
@@ -1608,6 +1648,8 @@ fn build_codex_anthropic_sse_response(
                 let provider_id = provider_id.clone();
                 let request_model = request_model.clone();
                 let outbound_model = fallback_model.clone();
+                let reasoning_effort = reasoning_effort.clone();
+                let reasoning_effort_source = reasoning_effort_source.clone();
                 let session_id = session_id.clone();
 
                 tokio::spawn(async move {
@@ -1618,6 +1660,8 @@ fn build_codex_anthropic_sse_response(
                         &model,
                         &request_model,
                         &outbound_model,
+                        reasoning_effort,
+                        reasoning_effort_source,
                         usage,
                         latency_ms,
                         first_token_ms,
@@ -1984,6 +2028,8 @@ pub async fn handle_gemini(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.outbound_reasoning_effort = result.outbound_reasoning_effort.take();
+    ctx.outbound_reasoning_effort_source = result.outbound_reasoning_effort_source.take();
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -2607,6 +2653,8 @@ async fn log_usage(
     model: &str,
     request_model: &str,
     outbound_model: &str,
+    reasoning_effort: Option<String>,
+    reasoning_effort_source: Option<String>,
     usage: TokenUsage,
     latency_ms: u64,
     first_token_ms: Option<u64>,
@@ -2640,6 +2688,8 @@ async fn log_usage(
         model.to_string(),
         request_model.to_string(),
         pricing_model.to_string(),
+        reasoning_effort,
+        reasoning_effort_source,
         usage,
         multiplier,
         latency_ms,

--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -405,12 +405,19 @@ pub fn transform_claude_request_for_api_format(
             // Codex OAuth (ChatGPT Plus/Pro 反代) 需要在请求体里强制 store: false
             // + include: ["reasoning.encrypted_content"]，由 transform 层统一处理。
             let codex_fast_mode = provider.codex_fast_mode_enabled();
-            let mut result = super::transform_responses::anthropic_to_responses(
-                body,
-                cache_key,
-                is_codex_oauth,
-                codex_fast_mode,
-            )?;
+            let effort_map = provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.claude_chat_reasoning.as_ref())
+                .map(|config| &config.effort_map);
+            let mut result =
+                super::transform_responses::anthropic_to_responses_with_reasoning_effort_overrides(
+                    body,
+                    cache_key,
+                    is_codex_oauth,
+                    codex_fast_mode,
+                    effort_map,
+                )?;
             if provider.is_xai_oauth() {
                 const REASONING_MARKER: &str = "reasoning.encrypted_content";
                 let mut include = result
@@ -431,10 +438,17 @@ pub fn transform_claude_request_for_api_format(
         "openai_chat" => {
             let preserve_reasoning_content =
                 should_preserve_reasoning_content_for_openai_chat(provider, &body);
-            let mut result = super::transform::anthropic_to_openai_with_reasoning_content(
-                body,
-                preserve_reasoning_content,
-            )?;
+            let effort_map = provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.claude_chat_reasoning.as_ref())
+                .map(|config| &config.effort_map);
+            let mut result =
+                super::transform::anthropic_to_openai_with_reasoning_content_and_effort_overrides(
+                    body,
+                    preserve_reasoning_content,
+                    effort_map,
+                )?;
             // Inject prompt_cache_key only if explicitly configured in meta
             if let Some(key) = provider
                 .meta
@@ -1023,7 +1037,7 @@ impl ProviderAdapter for ClaudeAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::ProviderMeta;
+    use crate::provider::{ClaudeChatReasoningConfig, ProviderMeta};
     use serde_json::json;
 
     fn create_provider(config: serde_json::Value) -> Provider {
@@ -1792,6 +1806,75 @@ mod tests {
             transform_claude_request_for_api_format(body, &provider, "openai_chat", None, None)
                 .unwrap();
         assert!(transformed.get("stream_options").is_none());
+    }
+
+    #[test]
+    fn test_transform_openai_chat_uses_provider_effort_mapping_for_gpt_5_6_sol() {
+        let provider = create_provider_with_meta(
+            json!({
+                "env": { "ANTHROPIC_BASE_URL": "https://api.example.com" }
+            }),
+            ProviderMeta {
+                api_format: Some("openai_chat".to_string()),
+                claude_chat_reasoning: Some(ClaudeChatReasoningConfig {
+                    effort_map: std::collections::HashMap::from([(
+                        "max".to_string(),
+                        "max".to_string(),
+                    )]),
+                }),
+                ..Default::default()
+            },
+        );
+        let body = json!({
+            "model": "gpt-5.6-sol",
+            "output_config": { "effort": "max" },
+            "messages": [{ "role": "user", "content": "hello" }],
+            "max_tokens": 128
+        });
+
+        let transformed =
+            transform_claude_request_for_api_format(body, &provider, "openai_chat", None, None)
+                .unwrap();
+
+        assert_eq!(transformed["model"], "gpt-5.6-sol");
+        assert_eq!(transformed["reasoning_effort"], "max");
+    }
+
+    #[test]
+    fn test_transform_openai_responses_uses_provider_effort_mapping_for_gpt_5_6_sol() {
+        let provider = create_provider_with_meta(
+            json!({
+                "env": { "ANTHROPIC_BASE_URL": "https://api.example.com" }
+            }),
+            ProviderMeta {
+                api_format: Some("openai_responses".to_string()),
+                claude_chat_reasoning: Some(ClaudeChatReasoningConfig {
+                    effort_map: std::collections::HashMap::from([(
+                        "max".to_string(),
+                        "ultra".to_string(),
+                    )]),
+                }),
+                ..Default::default()
+            },
+        );
+        let body = json!({
+            "model": "gpt-5.6-sol",
+            "output_config": { "effort": "max" },
+            "messages": [{ "role": "user", "content": "hello" }],
+            "max_tokens": 128
+        });
+
+        let transformed = transform_claude_request_for_api_format(
+            body,
+            &provider,
+            "openai_responses",
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(transformed["model"], "gpt-5.6-sol");
+        assert_eq!(transformed["reasoning"]["effort"], "ultra");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -12,6 +12,7 @@ use crate::proxy::{
     },
 };
 use serde_json::{json, Value};
+use std::collections::HashMap;
 
 const ANTHROPIC_BILLING_HEADER_PREFIX: &str = "x-anthropic-billing-header:";
 
@@ -80,18 +81,17 @@ pub fn supports_reasoning_effort(model: &str) -> bool {
         || normalized.starts_with("grok-build-")
 }
 
-/// Resolve the appropriate OpenAI `reasoning_effort` from an Anthropic request body.
+/// Resolve the Claude-side reasoning effort from an Anthropic request body.
 ///
 /// Priority:
 /// 1. Explicit `output_config.effort` — preserves the user's intent directly.
-///    `low`/`medium`/`high` map 1:1; `max` maps to `xhigh`
-///    (supported by mainstream GPT models). Unknown values are ignored.
+///    `low`/`medium`/`high`/`xhigh`/`max` are recognized. Unknown values are ignored.
 /// 2. Fallback: `thinking.type` + `budget_tokens`:
 ///    - `adaptive` → `xhigh` (adaptive = maximum reasoning effort)
 ///    - `enabled` with budget → `low` (<4 000) / `medium` (4 000–15 999) / `high` (≥16 000)
 ///    - `enabled` without budget → `high` (conservative default)
 ///    - `disabled` / absent → `None`
-pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
+fn resolve_reasoning_effort_source(body: &Value) -> Option<&'static str> {
     // --- Priority 1: explicit output_config.effort ---
     if let Some(effort) = body
         .pointer("/output_config/effort")
@@ -101,8 +101,9 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
             "low" => Some("low"),
             "medium" => Some("medium"),
             "high" => Some("high"),
-            "max" => Some("xhigh"), // OpenAI xhigh = maximum reasoning effort
-            _ => None,              // unknown value — do not inject
+            "xhigh" => Some("xhigh"),
+            "max" => Some("max"),
+            _ => None, // unknown value — do not inject
         };
     }
 
@@ -123,6 +124,43 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
     }
 }
 
+/// Resolve the default OpenAI-compatible `reasoning_effort` from an Anthropic request body.
+///
+/// Mainstream OpenAI-compatible Chat Completions backends use `xhigh` as the highest
+/// accepted value, so Claude's `max` defaults to `xhigh` unless the selected provider
+/// explicitly overrides it.
+pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
+    match resolve_reasoning_effort_source(body)? {
+        "max" => Some("xhigh"),
+        effort => Some(effort),
+    }
+}
+
+/// Resolve a provider-specific OpenAI Chat Completions `reasoning_effort`.
+///
+/// Overrides apply to the original Claude-side effort, so a provider can intentionally
+/// map Claude `max` to a backend-specific `max` or `ultra` instead of the default `xhigh`.
+pub fn resolve_reasoning_effort_with_overrides(
+    body: &Value,
+    effort_map: Option<&HashMap<String, String>>,
+) -> Option<String> {
+    let source = resolve_reasoning_effort_source(body)?;
+    let default = resolve_reasoning_effort(body)?;
+
+    effort_map
+        .and_then(|map| map.get(source))
+        .filter(|effort| is_supported_chat_reasoning_effort(effort))
+        .cloned()
+        .or_else(|| Some(default.to_string()))
+}
+
+fn is_supported_chat_reasoning_effort(effort: &str) -> bool {
+    matches!(
+        effort,
+        "low" | "medium" | "high" | "xhigh" | "max" | "ultra"
+    )
+}
+
 /// Anthropic 请求 → OpenAI Chat Completions 请求
 ///
 /// 转换工具库 API：当前无生产调用方（连通性检查不再发真实请求，曾是其唯一 crate 内
@@ -140,6 +178,19 @@ pub fn anthropic_to_openai(body: Value) -> Result<Value, ProxyError> {
 pub fn anthropic_to_openai_with_reasoning_content(
     body: Value,
     preserve_reasoning_content: bool,
+) -> Result<Value, ProxyError> {
+    anthropic_to_openai_with_reasoning_content_and_effort_overrides(
+        body,
+        preserve_reasoning_content,
+        None,
+    )
+}
+
+/// Anthropic 请求 → OpenAI Chat Completions 请求，支持 provider 级思考强度覆盖。
+pub fn anthropic_to_openai_with_reasoning_content_and_effort_overrides(
+    body: Value,
+    preserve_reasoning_content: bool,
+    effort_map: Option<&HashMap<String, String>>,
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
 
@@ -207,7 +258,7 @@ pub fn anthropic_to_openai_with_reasoning_content(
 
     // Map Anthropic thinking → OpenAI reasoning_effort
     if supports_reasoning_effort(model) {
-        if let Some(effort) = resolve_reasoning_effort(&body) {
+        if let Some(effort) = resolve_reasoning_effort_with_overrides(&body, effort_map) {
             result["reasoning_effort"] = json!(effort);
         }
     }
@@ -1775,9 +1826,37 @@ mod tests {
     }
 
     #[test]
+    fn test_output_config_xhigh_maps_to_reasoning_effort_xhigh() {
+        let body = json!({"output_config": {"effort": "xhigh"}});
+        assert_eq!(resolve_reasoning_effort(&body), Some("xhigh"));
+    }
+
+    #[test]
     fn test_output_config_max_maps_to_reasoning_effort_xhigh() {
         let body = json!({"output_config": {"effort": "max"}});
         assert_eq!(resolve_reasoning_effort(&body), Some("xhigh"));
+    }
+
+    #[test]
+    fn test_custom_effort_override_maps_max_to_ultra() {
+        let body = json!({"output_config": {"effort": "max"}});
+        let effort_map = HashMap::from([("max".to_string(), "ultra".to_string())]);
+
+        assert_eq!(
+            resolve_reasoning_effort_with_overrides(&body, Some(&effort_map)),
+            Some("ultra".to_string())
+        );
+    }
+
+    #[test]
+    fn test_invalid_custom_effort_override_falls_back_to_default() {
+        let body = json!({"output_config": {"effort": "max"}});
+        let effort_map = HashMap::from([("max".to_string(), "unsupported".to_string())]);
+
+        assert_eq!(
+            resolve_reasoning_effort_with_overrides(&body, Some(&effort_map)),
+            Some("xhigh".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -16,6 +16,7 @@ use crate::proxy::{
     },
 };
 use serde_json::{json, Value};
+use std::collections::HashMap;
 
 use super::reasoning_bridge::{
     anthropic_block_from_openai_reasoning_item, openai_reasoning_item_from_anthropic_block,
@@ -295,6 +296,26 @@ pub fn anthropic_to_responses(
     is_codex_oauth: bool,
     codex_fast_mode: bool,
 ) -> Result<Value, ProxyError> {
+    anthropic_to_responses_with_reasoning_effort_overrides(
+        body,
+        cache_key,
+        is_codex_oauth,
+        codex_fast_mode,
+        None,
+    )
+}
+
+/// Anthropic 请求 → OpenAI Responses 请求，支持 provider 级思考强度覆盖。
+///
+/// 覆盖项以 Claude 入站的原始强度为键，因此可让支持扩展强度等级的
+/// Responses 后端将 Claude `max` 发送为 `max` 或 `ultra`。
+pub fn anthropic_to_responses_with_reasoning_effort_overrides(
+    body: Value,
+    cache_key: Option<&str>,
+    is_codex_oauth: bool,
+    codex_fast_mode: bool,
+    effort_map: Option<&HashMap<String, String>>,
+) -> Result<Value, ProxyError> {
     let mut result = json!({});
 
     // NOTE: 模型映射由上游统一处理（proxy::model_mapper），格式转换层只做结构转换。
@@ -346,7 +367,9 @@ pub fn anthropic_to_responses(
     // Map Anthropic thinking → OpenAI Responses reasoning.effort
     if let Some(model_name) = body.get("model").and_then(|m| m.as_str()) {
         if super::transform::supports_reasoning_effort(model_name) {
-            if let Some(effort) = super::transform::resolve_reasoning_effort(&body) {
+            if let Some(effort) =
+                super::transform::resolve_reasoning_effort_with_overrides(&body, effort_map)
+            {
                 result["reasoning"] = json!({ "effort": effort });
             }
         }

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -480,6 +480,8 @@ pub(crate) fn create_usage_collector(
         .outbound_model
         .clone()
         .unwrap_or_else(|| ctx.request_model.clone());
+    let reasoning_effort = ctx.outbound_reasoning_effort.clone();
+    let reasoning_effort_source = ctx.outbound_reasoning_effort_source.clone();
     // 用 ctx 的 app_type 而不是 parser_config 的：Claude Desktop 流式透传复用
     // CLAUDE_PARSER_CONFIG（app_type_str="claude"），按 parser_config 记账会把
     // claude-desktop 的行错记到 claude 名下，导致供应商计价覆盖解析不到。
@@ -503,6 +505,8 @@ pub(crate) fn create_usage_collector(
                 let session_id = session_id.clone();
                 let request_model = request_model.clone();
                 let outbound_model = fallback_model.clone();
+                let reasoning_effort = reasoning_effort.clone();
+                let reasoning_effort_source = reasoning_effort_source.clone();
 
                 tokio::spawn(async move {
                     log_usage_internal(
@@ -512,6 +516,8 @@ pub(crate) fn create_usage_collector(
                         &model,
                         &request_model,
                         &outbound_model,
+                        reasoning_effort,
+                        reasoning_effort_source,
                         usage,
                         latency_ms,
                         first_token_ms,
@@ -529,6 +535,8 @@ pub(crate) fn create_usage_collector(
                 let session_id = session_id.clone();
                 let request_model = request_model.clone();
                 let outbound_model = fallback_model.clone();
+                let reasoning_effort = reasoning_effort.clone();
+                let reasoning_effort_source = reasoning_effort_source.clone();
 
                 tokio::spawn(async move {
                     log_usage_internal(
@@ -538,6 +546,8 @@ pub(crate) fn create_usage_collector(
                         &model,
                         &request_model,
                         &outbound_model,
+                        reasoning_effort,
+                        reasoning_effort_source,
                         TokenUsage::default(),
                         latency_ms,
                         first_token_ms,
@@ -580,6 +590,8 @@ fn spawn_log_usage(
         .outbound_model
         .clone()
         .unwrap_or_else(|| ctx.request_model.clone());
+    let reasoning_effort = ctx.outbound_reasoning_effort.clone();
+    let reasoning_effort_source = ctx.outbound_reasoning_effort_source.clone();
     let latency_ms = ctx.latency_ms();
     let session_id = ctx.session_id.clone();
 
@@ -591,6 +603,8 @@ fn spawn_log_usage(
             &model,
             &request_model,
             &outbound_model,
+            reasoning_effort,
+            reasoning_effort_source,
             usage,
             latency_ms,
             None,
@@ -624,6 +638,8 @@ async fn log_usage_internal(
     model: &str,
     request_model: &str,
     outbound_model: &str,
+    reasoning_effort: Option<String>,
+    reasoning_effort_source: Option<String>,
     usage: TokenUsage,
     latency_ms: u64,
     first_token_ms: Option<u64>,
@@ -661,6 +677,8 @@ async fn log_usage_internal(
         model.to_string(),
         request_model.to_string(),
         pricing_model.to_string(),
+        reasoning_effort,
+        reasoning_effort_source,
         usage,
         multiplier,
         latency_ms,
@@ -1072,6 +1090,8 @@ mod tests {
             "resp-model",
             "req-model",
             "req-model",
+            Some("xhigh".to_string()),
+            Some("max".to_string()),
             usage,
             10,
             None,
@@ -1082,17 +1102,18 @@ mod tests {
         .await;
 
         let conn = crate::database::lock_conn!(db.conn);
-        let (model, request_model, total_cost, cost_multiplier): (String, String, String, String) =
+        let (model, request_model, reasoning_effort_source, total_cost, cost_multiplier): (String, String, Option<String>, String, String) =
             conn.query_row(
-                "SELECT model, request_model, total_cost_usd, cost_multiplier
+                "SELECT model, request_model, reasoning_effort_source, total_cost_usd, cost_multiplier
                  FROM proxy_request_logs WHERE provider_id = ?1",
                 ["provider-1"],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
 
         assert_eq!(model, "resp-model");
         assert_eq!(request_model, "req-model");
+        assert_eq!(reasoning_effort_source.as_deref(), Some("max"));
         assert_eq!(
             Decimal::from_str(&cost_multiplier).unwrap(),
             Decimal::from_str("2").unwrap()
@@ -1142,6 +1163,8 @@ mod tests {
             "resp-model",
             "req-model",
             "outbound-model",
+            Some("max".to_string()),
+            None,
             usage,
             10,
             None,
@@ -1222,6 +1245,8 @@ mod tests {
             "resp-model",
             "req-model",
             "req-model",
+            None,
+            None,
             usage,
             10,
             None,

--- a/src-tauri/src/proxy/usage/logger.rs
+++ b/src-tauri/src/proxy/usage/logger.rs
@@ -16,6 +16,8 @@ struct UsageSemantic {
     app_type: String,
     provider_id: String,
     model: String,
+    reasoning_effort: Option<String>,
+    reasoning_effort_source: Option<String>,
     input_token_semantics: i64,
     input_tokens: u32,
     output_tokens: u32,
@@ -30,6 +32,8 @@ impl UsageSemantic {
             app_type: log.app_type.clone(),
             provider_id: log.provider_id.clone(),
             model: log.model.clone(),
+            reasoning_effort: log.reasoning_effort.clone(),
+            reasoning_effort_source: log.reasoning_effort_source.clone(),
             input_token_semantics,
             input_tokens: log.usage.input_tokens,
             output_tokens: log.usage.output_tokens,
@@ -44,6 +48,8 @@ impl UsageSemantic {
             &self.app_type,
             &self.provider_id,
             &self.model,
+            &self.reasoning_effort,
+            &self.reasoning_effort_source,
             self.input_token_semantics,
             self.input_tokens,
             self.output_tokens,
@@ -72,6 +78,10 @@ pub struct RequestLog {
     /// 用 model/request_model 猜——路由接管下三者可能各不相同。
     /// 错误行（未计价）为空字符串。
     pub pricing_model: String,
+    /// 最终出站请求携带的思考强度；不存在时保持 NULL，以兼容历史/非推理请求。
+    pub reasoning_effort: Option<String>,
+    /// 模型路由命中前的思考强度；仅用于显示 `来源 -> 最终值`。
+    pub reasoning_effort_source: Option<String>,
     pub usage: TokenUsage,
     pub cost: Option<CostBreakdown>,
     pub latency_ms: u64,
@@ -168,13 +178,13 @@ impl<'a> UsageLogger<'a> {
         };
         let sql = format!(
             "{insert_verb} INTO proxy_request_logs (
-                request_id, provider_id, app_type, model, request_model, pricing_model,
+                request_id, provider_id, app_type, model, request_model, pricing_model, reasoning_effort, reasoning_effort_source,
                 input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
                 input_token_semantics,
                 input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd, total_cost_usd,
                 latency_ms, first_token_ms, status_code, error_message, session_id,
                 provider_type, is_streaming, cost_multiplier, created_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)"
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)"
         );
         let affected_rows = conn
             .execute(
@@ -186,6 +196,8 @@ impl<'a> UsageLogger<'a> {
                     log.model,
                     log.request_model,
                     log.pricing_model,
+                    log.reasoning_effort,
+                    log.reasoning_effort_source,
                     log.usage.input_tokens,
                     log.usage.output_tokens,
                     log.usage.cache_read_tokens,
@@ -227,7 +239,7 @@ impl<'a> UsageLogger<'a> {
         request_id: &str,
     ) -> Result<Option<(Option<String>, UsageSemantic)>, AppError> {
         conn.query_row(
-            "SELECT data_source, app_type, provider_id, model, input_token_semantics,
+            "SELECT data_source, app_type, provider_id, model, reasoning_effort, reasoning_effort_source, input_token_semantics,
                     input_tokens, output_tokens, cache_read_tokens,
                     cache_creation_tokens, status_code
              FROM proxy_request_logs WHERE request_id = ?1",
@@ -239,12 +251,14 @@ impl<'a> UsageLogger<'a> {
                         app_type: row.get(1)?,
                         provider_id: row.get(2)?,
                         model: row.get(3)?,
-                        input_token_semantics: row.get(4)?,
-                        input_tokens: row.get::<_, i64>(5)? as u32,
-                        output_tokens: row.get::<_, i64>(6)? as u32,
-                        cache_read_tokens: row.get::<_, i64>(7)? as u32,
-                        cache_creation_tokens: row.get::<_, i64>(8)? as u32,
-                        status_code: row.get::<_, i64>(9)? as u16,
+                        reasoning_effort: row.get(4)?,
+                        reasoning_effort_source: row.get(5)?,
+                        input_token_semantics: row.get(6)?,
+                        input_tokens: row.get::<_, i64>(7)? as u32,
+                        output_tokens: row.get::<_, i64>(8)? as u32,
+                        cache_read_tokens: row.get::<_, i64>(9)? as u32,
+                        cache_creation_tokens: row.get::<_, i64>(10)? as u32,
+                        status_code: row.get::<_, i64>(11)? as u16,
                     },
                 ))
             },
@@ -276,6 +290,8 @@ impl<'a> UsageLogger<'a> {
             request_model,
             // 错误行未经过计价，留空（回填的 has_usage 闸门也不会碰全 0 行）
             pricing_model: String::new(),
+            reasoning_effort: None,
+            reasoning_effort_source: None,
             usage: TokenUsage::default(),
             cost: None,
             latency_ms,
@@ -317,6 +333,8 @@ impl<'a> UsageLogger<'a> {
             request_model,
             // 错误行未经过计价，留空（回填的 has_usage 闸门也不会碰全 0 行）
             pricing_model: String::new(),
+            reasoning_effort: None,
+            reasoning_effort_source: None,
             usage: TokenUsage::default(),
             cost: None,
             latency_ms,
@@ -451,6 +469,8 @@ impl<'a> UsageLogger<'a> {
         model: String,
         request_model: String,
         pricing_model: String,
+        reasoning_effort: Option<String>,
+        reasoning_effort_source: Option<String>,
         usage: TokenUsage,
         cost_multiplier: Decimal,
         latency_ms: u64,
@@ -485,6 +505,8 @@ impl<'a> UsageLogger<'a> {
             model,
             request_model,
             pricing_model,
+            reasoning_effort,
+            reasoning_effort_source,
             usage,
             cost,
             latency_ms,
@@ -513,6 +535,8 @@ mod tests {
             model: "gpt-5.6".to_string(),
             request_model: "gpt-5.6".to_string(),
             pricing_model: "gpt-5.6".to_string(),
+            reasoning_effort: None,
+            reasoning_effort_source: None,
             usage: TokenUsage {
                 input_tokens,
                 output_tokens: 5,
@@ -534,7 +558,7 @@ mod tests {
     }
 
     #[test]
-    fn test_log_request() -> Result<(), AppError> {
+    fn test_log_request_persists_reasoning_effort() -> Result<(), AppError> {
         let db = Database::memory()?;
 
         // 插入测试定价
@@ -566,6 +590,8 @@ mod tests {
             "test-model".to_string(),
             "req-model".to_string(),
             "test-model".to_string(),
+            Some("max".to_string()),
+            Some("xhigh".to_string()),
             usage,
             Decimal::from(1),
             100,
@@ -578,15 +604,23 @@ mod tests {
 
         // 验证记录已插入
         let conn = crate::database::lock_conn!(db.conn);
-        let (count, request_model): (i64, String) = conn
+        let (count, request_model, reasoning_effort, reasoning_effort_source): (
+            i64,
+            String,
+            Option<String>,
+            Option<String>,
+        ) = conn
             .query_row(
-                "SELECT COUNT(*), request_model FROM proxy_request_logs WHERE request_id = 'req-123'",
+                "SELECT COUNT(*), request_model, reasoning_effort, reasoning_effort_source
+                 FROM proxy_request_logs WHERE request_id = 'req-123'",
                 [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
             )
             .unwrap();
         assert_eq!(count, 1);
         assert_eq!(request_model, "req-model");
+        assert_eq!(reasoning_effort.as_deref(), Some("max"));
+        assert_eq!(reasoning_effort_source.as_deref(), Some("xhigh"));
         Ok(())
     }
 
@@ -727,6 +761,8 @@ mod tests {
             model: "grok-4.5".to_string(),
             request_model: "grok-4.5".to_string(),
             pricing_model: String::new(),
+            reasoning_effort: None,
+            reasoning_effort_source: None,
             usage: TokenUsage::default(),
             cost: None,
             latency_ms: 1,

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -132,6 +132,12 @@ pub struct RequestLogDetail {
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_model: Option<String>,
+    /// 最终出站请求的思考强度；历史记录或无思考请求为空。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+    /// 模型路由命中前的显式思考强度；存在时前端展示映射关系。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort_source: Option<String>,
     pub cost_multiplier: String,
     pub input_tokens: u32,
     pub output_tokens: u32,
@@ -159,15 +165,15 @@ pub struct RequestLogDetail {
     pub pricing_model: Option<String>,
 }
 
-/// 把 26 列的查询结果映射为 `RequestLogDetail`。
+/// 把 28 列的查询结果映射为 `RequestLogDetail`。
 ///
-/// 调用方的 SELECT **必须**按以下顺序返回 26 列：
+/// 调用方的 SELECT **必须**按以下顺序返回 28 列：
 /// `request_id, provider_id, provider_name, app_type, model, request_model,
-///  cost_multiplier, input_tokens, output_tokens, cache_read_tokens,
-///  cache_creation_tokens, input_cost_usd, output_cost_usd, cache_read_cost_usd,
-///  cache_creation_cost_usd, total_cost_usd, is_streaming, latency_ms,
-///  first_token_ms, duration_ms, status_code, error_message, created_at,
-///  data_source, pricing_model, input_token_semantics`
+///  reasoning_effort, reasoning_effort_source, cost_multiplier, input_tokens,
+///  output_tokens, cache_read_tokens, cache_creation_tokens, input_cost_usd,
+///  output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd, total_cost_usd,
+///  is_streaming, latency_ms, first_token_ms, duration_ms, status_code,
+///  error_message, created_at, data_source, pricing_model, input_token_semantics`
 ///
 /// 不需要 provider_name 时（如 backfill）SELECT `NULL AS provider_name` 占位即可。
 fn row_to_request_log_detail(row: &rusqlite::Row<'_>) -> rusqlite::Result<RequestLogDetail> {
@@ -178,28 +184,30 @@ fn row_to_request_log_detail(row: &rusqlite::Row<'_>) -> rusqlite::Result<Reques
         app_type: row.get(3)?,
         model: row.get(4)?,
         request_model: row.get(5)?,
+        reasoning_effort: row.get(6)?,
+        reasoning_effort_source: row.get(7)?,
         cost_multiplier: row
-            .get::<_, Option<String>>(6)?
+            .get::<_, Option<String>>(8)?
             .unwrap_or_else(|| "1".to_string()),
-        input_tokens: row.get::<_, i64>(7)? as u32,
-        output_tokens: row.get::<_, i64>(8)? as u32,
-        cache_read_tokens: row.get::<_, i64>(9)? as u32,
-        cache_creation_tokens: row.get::<_, i64>(10)? as u32,
-        input_cost_usd: row.get(11)?,
-        output_cost_usd: row.get(12)?,
-        cache_read_cost_usd: row.get(13)?,
-        cache_creation_cost_usd: row.get(14)?,
-        total_cost_usd: row.get(15)?,
-        is_streaming: row.get::<_, i64>(16)? != 0,
-        latency_ms: row.get::<_, i64>(17)? as u64,
-        first_token_ms: row.get::<_, Option<i64>>(18)?.map(|v| v as u64),
-        duration_ms: row.get::<_, Option<i64>>(19)?.map(|v| v as u64),
-        status_code: row.get::<_, i64>(20)? as u16,
-        error_message: row.get(21)?,
-        created_at: row.get(22)?,
-        data_source: row.get(23)?,
-        pricing_model: row.get(24)?,
-        input_token_semantics: row.get::<_, i64>(25)?,
+        input_tokens: row.get::<_, i64>(9)? as u32,
+        output_tokens: row.get::<_, i64>(10)? as u32,
+        cache_read_tokens: row.get::<_, i64>(11)? as u32,
+        cache_creation_tokens: row.get::<_, i64>(12)? as u32,
+        input_cost_usd: row.get(13)?,
+        output_cost_usd: row.get(14)?,
+        cache_read_cost_usd: row.get(15)?,
+        cache_creation_cost_usd: row.get(16)?,
+        total_cost_usd: row.get(17)?,
+        is_streaming: row.get::<_, i64>(18)? != 0,
+        latency_ms: row.get::<_, i64>(19)? as u64,
+        first_token_ms: row.get::<_, Option<i64>>(20)?.map(|v| v as u64),
+        duration_ms: row.get::<_, Option<i64>>(21)?.map(|v| v as u64),
+        status_code: row.get::<_, i64>(22)? as u16,
+        error_message: row.get(23)?,
+        created_at: row.get(24)?,
+        data_source: row.get(25)?,
+        pricing_model: row.get(26)?,
+        input_token_semantics: row.get::<_, i64>(27)?,
     })
 }
 
@@ -1599,7 +1607,7 @@ impl Database {
         let logs_pname = provider_name_coalesce("l", "p");
         let sql = format!(
             "SELECT l.request_id, l.provider_id, {logs_pname} as provider_name, l.app_type, l.model,
-                    l.request_model, l.cost_multiplier,
+                    l.request_model, l.reasoning_effort, l.reasoning_effort_source, l.cost_multiplier,
                     l.input_tokens, l.output_tokens, l.cache_read_tokens, l.cache_creation_tokens,
                     l.input_cost_usd, l.output_cost_usd, l.cache_read_cost_usd, l.cache_creation_cost_usd, l.total_cost_usd,
                     l.is_streaming, l.latency_ms, l.first_token_ms, l.duration_ms,
@@ -1643,11 +1651,11 @@ impl Database {
         let detail_pname = provider_name_coalesce("l", "p");
         let detail_sql = format!(
             "SELECT l.request_id, l.provider_id, {detail_pname} as provider_name, l.app_type, l.model,
-                    l.request_model, l.cost_multiplier,
-                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-                    input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd, total_cost_usd,
-                    is_streaming, latency_ms, first_token_ms, duration_ms,
-                    status_code, error_message, created_at, l.data_source, l.pricing_model,
+                    l.request_model, l.reasoning_effort, l.reasoning_effort_source, l.cost_multiplier,
+                    l.input_tokens, l.output_tokens, l.cache_read_tokens, l.cache_creation_tokens,
+                    l.input_cost_usd, l.output_cost_usd, l.cache_read_cost_usd, l.cache_creation_cost_usd, l.total_cost_usd,
+                    l.is_streaming, l.latency_ms, l.first_token_ms, l.duration_ms,
+                    l.status_code, l.error_message, l.created_at, l.data_source, l.pricing_model,
                     l.input_token_semantics
              FROM proxy_request_logs l
              LEFT JOIN providers p ON l.provider_id = p.id AND l.app_type = p.app_type
@@ -1799,7 +1807,7 @@ impl Database {
     ) -> Result<u64, AppError> {
         const BASE_SQL: &str =
             "SELECT request_id, provider_id, NULL AS provider_name, app_type, model, request_model,
-                        cost_multiplier,
+                        reasoning_effort, reasoning_effort_source, cost_multiplier,
                         input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
                         input_cost_usd, output_cost_usd, cache_read_cost_usd,
                         cache_creation_cost_usd, total_cost_usd, is_streaming, latency_ms,
@@ -2414,6 +2422,32 @@ mod tests {
             )",
             [],
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn request_log_queries_include_reasoning_effort_mapping() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, reasoning_effort, reasoning_effort_source,
+                    latency_ms, status_code, created_at
+                 ) VALUES ('effort-log', 'provider-1', 'claude', 'gpt-5.6-sol', 'ultra', 'max', 10, 200, 1)",
+                [],
+            )?;
+        }
+
+        let logs = db.get_request_logs(&LogFilters::default(), 0, 10)?;
+        assert_eq!(logs.data[0].reasoning_effort.as_deref(), Some("ultra"));
+        assert_eq!(logs.data[0].reasoning_effort_source.as_deref(), Some("max"));
+
+        let detail = db
+            .get_request_detail("effort-log")?
+            .expect("request log exists");
+        assert_eq!(detail.reasoning_effort.as_deref(), Some("ultra"));
+        assert_eq!(detail.reasoning_effort_source.as_deref(), Some("max"));
         Ok(())
     }
 

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -52,6 +52,9 @@ import {
 import { CustomUserAgentField } from "./CustomUserAgentField";
 import { LocalProxyRequestOverridesField } from "./LocalProxyRequestOverridesField";
 import type {
+  ClaudeChatReasoning,
+  ClaudeChatReasoningSourceEffort,
+  ClaudeChatReasoningTargetEffort,
   ProviderCategory,
   ClaudeApiFormat,
   ClaudeApiKeyField,
@@ -70,6 +73,34 @@ import {
 interface EndpointCandidate {
   url: string;
 }
+
+const CLAUDE_REASONING_SOURCE_EFFORTS: ClaudeChatReasoningSourceEffort[] = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+
+const CLAUDE_REASONING_TARGET_EFFORTS: ClaudeChatReasoningTargetEffort[] = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+];
+
+const DEFAULT_CLAUDE_CHAT_EFFORT_MAP: Record<
+  ClaudeChatReasoningSourceEffort,
+  ClaudeChatReasoningTargetEffort
+> = {
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "xhigh",
+  max: "xhigh",
+};
 
 interface ClaudeFormFieldsProps {
   providerId?: string;
@@ -143,6 +174,8 @@ interface ClaudeFormFieldsProps {
   // API Format (for Claude-compatible providers that need request/response conversion)
   apiFormat: ClaudeApiFormat;
   onApiFormatChange: (format: ClaudeApiFormat) => void;
+  claudeChatReasoning?: ClaudeChatReasoning;
+  onClaudeChatReasoningChange?: (value: ClaudeChatReasoning) => void;
 
   // Auth Field (ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY)
   apiKeyField: ClaudeApiKeyField;
@@ -214,6 +247,8 @@ export function ClaudeFormFields({
   speedTestEndpoints,
   apiFormat,
   onApiFormatChange,
+  claudeChatReasoning = {},
+  onClaudeChatReasoningChange = () => undefined,
   apiKeyField,
   onApiKeyFieldChange,
   isFullUrl,
@@ -229,6 +264,10 @@ export function ClaudeFormFields({
   const hasRequestOverrides = Boolean(
     localProxyHeadersOverride.trim() || localProxyBodyOverride.trim(),
   );
+  const hasClaudeChatReasoningOverrides = Boolean(
+    claudeChatReasoning.effortMap &&
+      Object.keys(claudeChatReasoning.effortMap).length > 0,
+  );
   const hasAnyAdvancedValue = !!(
     claudeModel ||
     defaultHaikuModel ||
@@ -238,11 +277,15 @@ export function ClaudeFormFields({
     subagentModel ||
     (!isXaiOauthPreset && apiFormat !== "anthropic") ||
     apiKeyField !== "ANTHROPIC_AUTH_TOKEN" ||
+    hasClaudeChatReasoningOverrides ||
     customUserAgent ||
     hasRequestOverrides
   );
   const [advancedExpanded, setAdvancedExpanded] = useState(
     isXaiOauthPreset ? false : hasAnyAdvancedValue,
+  );
+  const [customReasoningExpanded, setCustomReasoningExpanded] = useState(
+    hasClaudeChatReasoningOverrides,
   );
 
   // 预设填充高级值后自动展开（仅从折叠→展开，不会自动折叠）
@@ -253,6 +296,32 @@ export function ClaudeFormFields({
       setAdvancedExpanded(true);
     }
   }, [hasAnyAdvancedValue, isXaiOauthPreset]);
+
+  // 已保存的自定义映射在再次编辑时直接展开，默认映射则保持收起。
+  useEffect(() => {
+    if (hasClaudeChatReasoningOverrides) {
+      setCustomReasoningExpanded(true);
+    }
+  }, [hasClaudeChatReasoningOverrides]);
+
+  const handleClaudeChatReasoningEffortChange = useCallback(
+    (
+      source: ClaudeChatReasoningSourceEffort,
+      target: ClaudeChatReasoningTargetEffort,
+    ) => {
+      const nextMap = { ...(claudeChatReasoning.effortMap ?? {}) };
+      if (target === DEFAULT_CLAUDE_CHAT_EFFORT_MAP[source]) {
+        delete nextMap[source];
+      } else {
+        nextMap[source] = target;
+      }
+
+      onClaudeChatReasoningChange(
+        Object.keys(nextMap).length > 0 ? { effortMap: nextMap } : {},
+      );
+    },
+    [claudeChatReasoning.effortMap, onClaudeChatReasoningChange],
+  );
 
   // Copilot 可用模型列表
   const [copilotModels, setCopilotModels] = useState<CopilotModel[]>([]);
@@ -859,6 +928,87 @@ export function ClaudeFormFields({
                 </p>
               </div>
             )}
+
+            {(apiFormat === "openai_chat" ||
+              apiFormat === "openai_responses") &&
+              !isXaiOauthPreset && (
+                <Collapsible
+                  open={customReasoningExpanded}
+                  onOpenChange={setCustomReasoningExpanded}
+                  className="border-t border-border-default pt-3"
+                >
+                  <CollapsibleTrigger asChild>
+                    <Button
+                      type="button"
+                      variant={null}
+                      size="sm"
+                      className="h-8 gap-1.5 px-0 text-sm font-medium text-foreground hover:opacity-70"
+                    >
+                      {customReasoningExpanded ? (
+                        <ChevronDown className="h-4 w-4" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4" />
+                      )}
+                      {t("providerForm.claudeChatReasoningCustomToggle", {
+                        defaultValue: "自定义思考强度映射",
+                      })}
+                    </Button>
+                  </CollapsibleTrigger>
+                  {!customReasoningExpanded && (
+                    <p className="mt-1 ml-1 text-xs text-muted-foreground">
+                      {t("providerForm.claudeChatReasoningDefaultHint", {
+                        defaultValue: "使用 CCS 默认映射（max -> xhigh）。",
+                      })}
+                    </p>
+                  )}
+                  <CollapsibleContent className="space-y-3 pt-2">
+                    <p className="text-xs leading-relaxed text-muted-foreground">
+                      {t("providerForm.claudeChatReasoningEffortMapHint", {
+                        defaultValue:
+                          "仅保存与 CCS 默认映射不同的值；未配置的强度始终使用默认映射。",
+                      })}
+                    </p>
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                      {CLAUDE_REASONING_SOURCE_EFFORTS.map((source) => {
+                        const value =
+                          claudeChatReasoning.effortMap?.[source] ??
+                          DEFAULT_CLAUDE_CHAT_EFFORT_MAP[source];
+                        const fieldId = `claude-chat-reasoning-${source}`;
+
+                        return (
+                          <div key={source} className="space-y-1.5">
+                            <FormLabel htmlFor={fieldId} className="text-xs">
+                              {source}
+                            </FormLabel>
+                            <Select
+                              value={value}
+                              onValueChange={(target) =>
+                                handleClaudeChatReasoningEffortChange(
+                                  source,
+                                  target as ClaudeChatReasoningTargetEffort,
+                                )
+                              }
+                            >
+                              <SelectTrigger id={fieldId} className="w-full">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {CLAUDE_REASONING_TARGET_EFFORTS.map(
+                                  (target) => (
+                                    <SelectItem key={target} value={target}>
+                                      {target}
+                                    </SelectItem>
+                                  ),
+                                )}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+              )}
 
             {/* 认证字段选择器 */}
             <div className="space-y-2">

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -21,6 +21,7 @@ import type {
   CodexApiFormat,
   CodexCatalogModel,
   CodexChatReasoning,
+  ClaudeChatReasoning,
   PromptCacheRoutingMode,
   ClaudeApiKeyField,
 } from "@/types";
@@ -214,6 +215,15 @@ const normalizeCodexChatReasoningForSave = (
   };
 };
 
+const normalizeClaudeChatReasoningForSave = (
+  value?: ClaudeChatReasoning,
+): ClaudeChatReasoning | undefined => {
+  const entries = Object.entries(value?.effortMap ?? {});
+  return entries.length > 0
+    ? { effortMap: Object.fromEntries(entries) }
+    : undefined;
+};
+
 type LocalProxyRequestOverridesBuildResult = ReturnType<
   typeof buildLocalProxyRequestOverrides
 >;
@@ -363,6 +373,7 @@ function ProviderFormFull({
       ),
     });
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
+    setClaudeChatReasoning(initialData?.meta?.claudeChatReasoning ?? {});
     setPromptCacheRouting(initialData?.meta?.promptCacheRouting ?? "auto");
     setCustomUserAgent(initialData?.meta?.customUserAgent ?? "");
     setLocalProxyHeadersOverride(
@@ -547,6 +558,10 @@ function ProviderFormFull({
   const [codexChatReasoning, setCodexChatReasoning] =
     useState<CodexChatReasoning>(
       () => initialData?.meta?.codexChatReasoning ?? {},
+    );
+  const [claudeChatReasoning, setClaudeChatReasoning] =
+    useState<ClaudeChatReasoning>(
+      () => initialData?.meta?.claudeChatReasoning ?? {},
     );
   const [promptCacheRouting, setPromptCacheRouting] =
     useState<PromptCacheRoutingMode>(
@@ -1588,6 +1603,13 @@ function ProviderFormFull({
         localCodexApiFormat === "openai_chat"
           ? normalizeCodexChatReasoningForSave(codexChatReasoning)
           : undefined,
+      claudeChatReasoning:
+        appId === "claude" &&
+        category !== "official" &&
+        (localApiFormat === "openai_chat" ||
+          localApiFormat === "openai_responses")
+          ? normalizeClaudeChatReasoningForSave(claudeChatReasoning)
+          : undefined,
       promptCacheRouting:
         appId === "codex" &&
         category !== "official" &&
@@ -1774,6 +1796,9 @@ function ProviderFormFull({
             "openai_responses",
         );
       }
+      if (appId === "claude") {
+        setClaudeChatReasoning({});
+      }
       if (appId === "gemini") {
         resetGeminiConfig({}, {});
       }
@@ -1927,6 +1952,8 @@ function ProviderFormFull({
     } else {
       setLocalApiFormat("anthropic");
     }
+
+    setClaudeChatReasoning({});
 
     setLocalApiKeyField(preset.apiKeyField ?? "ANTHROPIC_AUTH_TOKEN");
     setLocalIsFullUrl(false);
@@ -2263,6 +2290,8 @@ function ProviderFormFull({
               speedTestEndpoints={speedTestEndpoints}
               apiFormat={localApiFormat}
               onApiFormatChange={handleApiFormatChange}
+              claudeChatReasoning={claudeChatReasoning}
+              onClaudeChatReasoningChange={setClaudeChatReasoning}
               apiKeyField={localApiKeyField}
               onApiKeyFieldChange={handleApiKeyFieldChange}
               isFullUrl={localIsFullUrl}

--- a/src/components/usage/RequestDetailPanel.tsx
+++ b/src/components/usage/RequestDetailPanel.tsx
@@ -106,6 +106,18 @@ export function RequestDetailPanel({
                 </dt>
                 <dd>{request.appType}</dd>
               </div>
+              {request.reasoningEffort && (
+                <div>
+                  <dt className="text-muted-foreground">
+                    {t("usage.reasoningEffort", "思考强度")}
+                  </dt>
+                  <dd className="font-mono">
+                    {request.reasoningEffortSource
+                      ? `${request.reasoningEffortSource} -> ${request.reasoningEffort}`
+                      : request.reasoningEffort}
+                  </dd>
+                </div>
+              )}
               <div>
                 <dt className="text-muted-foreground">
                   {t("usage.model", "模型")}

--- a/src/components/usage/RequestLogTable.tsx
+++ b/src/components/usage/RequestLogTable.tsx
@@ -43,6 +43,16 @@ interface RequestLogTableProps {
   onRangeChange?: (range: UsageRangeSelection) => void;
 }
 
+function formatReasoningEffort(
+  reasoningEffort?: string,
+  reasoningEffortSource?: string,
+) {
+  if (!reasoningEffort) return "-";
+  return reasoningEffortSource
+    ? `${reasoningEffortSource} -> ${reasoningEffort}`
+    : reasoningEffort;
+}
+
 export function RequestLogTable({
   range,
   rangeLabel,
@@ -176,6 +186,9 @@ export function RequestLogTable({
                     {t("usage.timingInfo")}
                   </TableHead>
                   <TableHead className="text-center whitespace-nowrap">
+                    {t("usage.reasoningEffort", { defaultValue: "思考强度" })}
+                  </TableHead>
+                  <TableHead className="text-center whitespace-nowrap">
                     {t("usage.status")}
                   </TableHead>
                   <TableHead className="text-center whitespace-nowrap">
@@ -187,7 +200,7 @@ export function RequestLogTable({
                 {logs.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={9}
+                      colSpan={10}
                       className="text-center text-muted-foreground"
                     >
                       {t("usage.noData")}
@@ -296,6 +309,12 @@ export function RequestLogTable({
                             <span className="text-muted-foreground">
                               /{(log.firstTokenMs / 1000).toFixed(1)}s
                             </span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-center font-mono text-xs">
+                          {formatReasoningEffort(
+                            log.reasoningEffort,
+                            log.reasoningEffortSource,
                           )}
                         </TableCell>
                         <TableCell className="text-center">

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,28 @@ export type CodexChatReasoningOutputFormat =
   | "reasoning_details"
   | "think_tags";
 
+export type ClaudeChatReasoningSourceEffort =
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max";
+
+export type ClaudeChatReasoningTargetEffort =
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "ultra";
+
+/** Claude Messages -> OpenAI-compatible reasoning-effort overrides. */
+export interface ClaudeChatReasoning {
+  effortMap?: Partial<
+    Record<ClaudeChatReasoningSourceEffort, ClaudeChatReasoningTargetEffort>
+  >;
+}
+
 export interface CodexChatReasoning {
   supportsThinking?: boolean;
   supportsEffort?: boolean;
@@ -215,6 +237,8 @@ export interface ProviderMeta {
   codexFastMode?: boolean;
   // Codex Responses -> Chat Completions reasoning capability metadata
   codexChatReasoning?: CodexChatReasoning;
+  // Claude Messages -> OpenAI-compatible reasoning-effort overrides
+  claudeChatReasoning?: ClaudeChatReasoning;
   // Codex → Anthropic path: emulate the Claude Code client (disabled by default; only an explicit true enables it)
   impersonateClaudeCode?: boolean;
   // Codex → Anthropic path: override the Anthropic max_tokens (output ceiling).

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -14,6 +14,10 @@ export interface RequestLog {
   appType: string;
   model: string;
   requestModel?: string;
+  /** 最终出站请求携带的思考强度。 */
+  reasoningEffort?: string;
+  /** 模型路由命中前的思考强度；存在时日志显示映射关系。 */
+  reasoningEffortSource?: string;
   /** 写入时实际用于计价的模型名；路由接管 + request 计价模式下可能与 model 不同 */
   pricingModel?: string;
   costMultiplier: string;

--- a/tests/components/ClaudeFormFields.test.tsx
+++ b/tests/components/ClaudeFormFields.test.tsx
@@ -195,4 +195,59 @@ describe("ClaudeFormFields", () => {
       "shared-model[1M]",
     );
   });
+
+  it("默认收起自定义思考强度映射并保留 CCS 默认值", () => {
+    renderCopilotForm({
+      category: "third_party",
+      apiFormat: "openai_chat",
+    });
+
+    expect(
+      screen.getByText("使用 CCS 默认映射（max -> xhigh）。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("max")).not.toBeInTheDocument();
+  });
+
+  it("允许将 Claude max 映射为后端的 max", () => {
+    const onClaudeChatReasoningChange = vi.fn();
+    renderCopilotForm({
+      category: "third_party",
+      apiFormat: "openai_chat",
+      onClaudeChatReasoningChange,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "自定义思考强度映射" }));
+    fireEvent.click(screen.getByLabelText("max"));
+    fireEvent.click(screen.getByRole("option", { name: "max" }));
+
+    expect(onClaudeChatReasoningChange).toHaveBeenCalledWith({
+      effortMap: { max: "max" },
+    });
+  });
+
+  it("在 OpenAI Responses 格式中提供自定义映射", () => {
+    renderCopilotForm({
+      category: "third_party",
+      apiFormat: "openai_responses",
+    });
+
+    expect(
+      screen.getByRole("button", { name: "自定义思考强度映射" }),
+    ).toBeInTheDocument();
+  });
+
+  it("恢复 CCS 默认映射时不保留自定义配置", () => {
+    const onClaudeChatReasoningChange = vi.fn();
+    renderCopilotForm({
+      category: "third_party",
+      apiFormat: "openai_chat",
+      claudeChatReasoning: { effortMap: { max: "max" } },
+      onClaudeChatReasoningChange,
+    });
+
+    fireEvent.click(screen.getByLabelText("max"));
+    fireEvent.click(screen.getByRole("option", { name: "xhigh" }));
+
+    expect(onClaudeChatReasoningChange).toHaveBeenCalledWith({});
+  });
 });

--- a/tests/components/RequestLogTable.test.tsx
+++ b/tests/components/RequestLogTable.test.tsx
@@ -1,9 +1,33 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RequestLogTable } from "@/components/usage/RequestLogTable";
-import type { UsageRangeSelection } from "@/types/usage";
+import type { RequestLog, UsageRangeSelection } from "@/types/usage";
 
 const useRequestLogsMock = vi.hoisted(() => vi.fn());
+
+const requestLogWithEffort: RequestLog = {
+  requestId: "req-effort",
+  providerId: "provider-1",
+  providerName: "OpenAI Compatible",
+  appType: "claude",
+  model: "gpt-5.6-sol",
+  reasoningEffort: "xhigh",
+  reasoningEffortSource: "max",
+  costMultiplier: "1",
+  inputTokens: 100,
+  outputTokens: 50,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  inputCostUsd: "0.0001",
+  outputCostUsd: "0.0002",
+  cacheReadCostUsd: "0",
+  cacheCreationCostUsd: "0",
+  totalCostUsd: "0.0003",
+  isStreaming: false,
+  latencyMs: 100,
+  statusCode: 200,
+  createdAt: 1_710_000_000,
+};
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -157,5 +181,29 @@ describe("RequestLogTable", () => {
         }),
       );
     });
+  });
+
+  it("显示最终出站请求的思考强度", () => {
+    useRequestLogsMock.mockImplementationOnce(() => ({
+      data: {
+        data: [requestLogWithEffort],
+        total: 1,
+        page: 0,
+        pageSize: 20,
+      },
+      isLoading: false,
+    }));
+
+    render(
+      <RequestLogTable
+        range={{ preset: "today" }}
+        rangeLabel="Today"
+        appType="all"
+        refreshIntervalMs={0}
+      />,
+    );
+
+    expect(screen.getByText("思考强度")).toBeInTheDocument();
+    expect(screen.getByText("max -> xhigh")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 改动说明
- 支持 Claude Messages 转 OpenAI Chat Completions 与 Responses 时的供应商级思考强度映射
- 配置项默认使用 CCS 映射，按需覆盖 `max` 到 `max`、`ultra` 等后端扩展等级
- 请求日志展示模型路由命中时的思考强度映射关系，例如 `max -> xhigh`
- 新增数据库迁移，历史日志保持兼容

## 验证
- `pnpm typecheck`
- `pnpm test:unit -- tests/components/ClaudeFormFields.test.tsx tests/components/RequestLogTable.test.tsx`
- Claude / Responses 转换、使用量日志、数据库迁移定向 Rust 测试