### PR TITLE
feat(codex): support DeepSeek V4 Flash native Responses

### DIFF
--- a/docs/guides/codex-deepseek-routing-guide-en.md
+++ b/docs/guides/codex-deepseek-routing-guide-en.md
@@ -1,101 +1,97 @@
-# Using DeepSeek-Style Chat APIs in Codex: CC Switch Local Routing Guide
+# Using DeepSeek V4 Pro in Codex: CC Switch Local Routing Guide
 
-> Applies to CC Switch 3.16.0 and nearby versions. This guide is based on the repository documentation and code, and uses DeepSeek as an example of an OpenAI Chat Completions-compatible API. Screenshots are generated from the current frontend UI with de-identified sample data to avoid exposing a real API key or account balance.
+> **Important:** The built-in `DeepSeek` preset now contains only DeepSeek V4 Flash and connects directly through the native Responses API, so it **does not need local routing**. This guide applies only to the separate `DeepSeek V4 Pro` preset. V4 Pro currently uses Chat Completions and requires CC Switch to convert the protocol locally.
 
-## Why local routing is needed
+> Saved DeepSeek providers are not migrated automatically when a built-in preset changes. To use native Responses for Flash or the new Pro Chat configuration, select the corresponding preset again or create a new provider.
 
-The newer Codex CLI targets the OpenAI Responses API, while DeepSeek, Kimi, MiniMax, SiliconFlow, and many other providers expose the OpenAI Chat Completions shape, usually `/chat/completions`. These two protocols use different request bodies, streaming events, and response structures. If you put a Chat endpoint directly into Codex configuration, common results include an incorrect model list, 404/400 requests, or streaming responses that Codex cannot parse correctly.
+## Choose the right preset first
 
-CC Switch solves this by making Codex always talk to a local route and continue sending Responses API requests. The route detects whether the active provider is Chat-format, rewrites the request into Chat Completions for the upstream provider, and finally converts the Chat response back into the Responses shape that Codex understands.
+| Preset | Model | Upstream protocol | Local routing required |
+|--------|-------|-------------------|------------------------|
+| `DeepSeek` | `deepseek-v4-flash` | Native Responses | No |
+| `DeepSeek V4 Pro` | `deepseek-v4-pro` | Chat Completions | Yes |
 
-![Needs routing marker in the Codex provider list](../images/codex-deepseek-routing/01-codex-providers-require-routing.png)
+To use Flash, select `DeepSeek`, enter the API key, and save. Its Codex model catalog already declares function calling, freeform `apply_patch`, text Web Search, parallel tool calls, and `low` / `high` / `max` reasoning levels.
 
-The chain has four main steps:
+The remaining steps apply only to `DeepSeek V4 Pro`.
 
-1. When Codex routing is enabled, the local configuration is written as `http://127.0.0.1:15721/v1`, while `wire_api = "responses"` is kept in place.
-2. The provider's `meta.apiFormat = "openai_chat"` tells the route that the real upstream is Chat Completions.
-3. The route rewrites `/responses` or `/v1/responses` to `/chat/completions`, and converts the Responses request body into a Chat request body.
-4. After the upstream responds, the route converts the Chat JSON or SSE stream back into Responses JSON/SSE.
+## Why V4 Pro needs local routing
+
+Codex CLI uses the OpenAI Responses API, while the V4 Pro preset currently uses Chat Completions. CC Switch lets Codex keep sending Responses requests and converts the protocol in both directions:
+
+1. After Codex takeover is enabled, the live configuration points to `http://127.0.0.1:15721/v1` and keeps `wire_api = "responses"`.
+2. The `DeepSeek V4 Pro` preset is marked as Chat Completions format.
+3. The local route converts each Responses request into Chat Completions and sends it to DeepSeek.
+4. After DeepSeek responds, the route converts the JSON or SSE stream back into the Responses format Codex understands.
 
 ## Prerequisites
 
-Prepare these three things first:
+You need:
 
 - CC Switch installed and able to start.
-- Codex CLI installed and run at least once, so the `~/.codex/config.toml` directory structure exists.
-- An API key from DeepSeek or another Chat Completions provider.
+- Codex CLI installed and run at least once.
+- A DeepSeek API key.
 
-DeepSeek's official documentation currently lists the OpenAI-compatible base URL as `https://api.deepseek.com` (other providers often use a base URL with a `/v1` suffix), and the Chat API path as `/chat/completions`. CC Switch's DeepSeek preset already contains these details, so prefer the preset and do not manually assemble the endpoint path.
+The preset already contains `https://api.deepseek.com` and the correct model name. Do not append `/chat/completions` to the base URL manually.
 
-## Step 1: Add a Codex provider
+## Step 1: Add the V4 Pro provider
 
-Open CC Switch, switch to the top-level `Codex` tab, and click the plus button in the upper-right corner to add a provider.
+Open CC Switch, switch to the top-level `Codex` tab, and click the plus button:
 
-Choose the built-in `DeepSeek` preset. You only need to do two things:
+1. Select the `DeepSeek V4 Pro` preset.
+2. Enter the DeepSeek API key.
+3. Save the provider.
 
-- Enter your DeepSeek API key.
-- Save the provider.
+The preset configures the Chat Completions format, the `deepseek-v4-pro` model catalog, and reasoning parameters automatically. You normally do not need to edit the advanced configuration.
 
-![Local routing mapping in the DeepSeek Codex provider form](../images/codex-deepseek-routing/02-deepseek-codex-routing-form.png)
+## Step 2: Enable local routing and Codex takeover
 
-The preset already includes DeepSeek's request base URL, default model, model menu, thinking/reasoning parameters, and automatically enables `Needs Local Routing`. You can adjust the default model or model display names if needed; the protocol conversion is handled by the routing layer.
+Open the `Routing` page in Settings and expand `Local Routing`:
 
-## Step 2: Enable local routing and route Codex
+1. Turn on the main routing switch to start the local service. Its default address is `127.0.0.1:15721`.
+2. Enable `Codex` under application routing.
 
-Go to the `Routing` page in Settings, expand `Local Routing`, and complete two toggles:
+After takeover is enabled, the Codex live configuration points to the local route. The real API key remains in the CC Switch provider configuration and is injected while forwarding.
 
-1. Turn on the main routing switch to start the local service. The default address is `127.0.0.1:15721`.
-2. Turn on `Codex` under `Routing Enabled`. If you only want Codex to use local routing, you can leave Claude and Gemini off.
+## Step 3: Enable the provider and restart Codex
 
-![Enabling Codex routing on the local routing page](../images/codex-deepseek-routing/03-local-route-codex-takeover.png)
+Return to the Codex provider list and enable `DeepSeek V4 Pro`. The preset is marked as requiring routing, so keep local routing running while it is in use.
 
-After routing is enabled, CC Switch points Codex's live configuration to the local route and manages authentication with a placeholder. The real DeepSeek key stays in the CC Switch provider configuration and is injected by the local route while forwarding requests, so you do not need to expose the key in Codex's live configuration.
+Restart the Codex terminal session after switching. The process may have already loaded the old `config.toml`, and the `/model` menu usually reloads `model_catalog_json` only in a new process.
 
-## Step 3: Switch providers and restart Codex
+Inside Codex, use `/model` to confirm that the current model is `DeepSeek V4 Pro`. Then send a small request and verify that it appears in the CC Switch routing or request logs.
 
-Return to the Codex provider list and click `Enable` on the DeepSeek provider. If you see the `Needs Routing` marker, that provider must be used while routing is running; when the route is not started, CC Switch shows a prompt saying the routing service is required.
+## Migrating an older DeepSeek configuration
 
-After switching, restart the current Codex terminal session. This is recommended because:
+Older versions put Flash and Pro in one Chat preset. Existing providers keep their saved values after upgrading and do not switch protocols automatically:
 
-- The Codex process may already have read the old `config.toml`.
-- After `model_catalog_json` is generated, the `/model` menu usually needs a fresh process before it refreshes.
+- For Flash, select the `DeepSeek` preset again or create a new provider. It connects directly through native Responses and does not need local routing.
+- For Pro, select the `DeepSeek V4 Pro` preset again or create a new provider, and keep Codex local routing enabled.
 
-Inside Codex, use `/model` to check whether the current model comes from the DeepSeek preset, such as `DeepSeek V4 Flash`. The Codex app currently does not support multi-model selection, so it defaults to the first configured model. Then send a small test prompt and confirm that the request count increases in the routing panel, or that a Codex request appears in usage/request logs.
-
-## How to handle other Chat providers
-
-DeepSeek, Kimi, MiniMax, SiliconFlow, and other common Chat-format providers already have presets in CC Switch, so use presets first. Only choose custom configuration for providers that are not covered by presets; in that case, fill in the API key, base URL, and models according to the provider's documentation, and set `API Format` to `OpenAI Chat Completions (requires routing)`.
-
-If the upstream provider directly supports the OpenAI Responses API, you do not need to enable `Needs Local Routing`; CC Switch can connect through Responses directly without Chat conversion.
+Restart Codex after changing presets so the live configuration and model catalog are refreshed.
 
 ## FAQ
 
-**Codex reports 404 or cannot find `/responses`**
+**Do I need Codex local routing if I only use V4 Flash?**
 
-Usually Codex routing is not enabled, or the upstream Chat base URL was written directly into Codex manually. Check whether `~/.codex/config.toml` points to `http://127.0.0.1:15721/v1`.
+No. Select the main `DeepSeek` preset. Flash supports Responses natively, so CC Switch does not perform Chat protocol conversion.
 
-**DeepSeek upstream reports 404**
+**V4 Pro reports 404 or cannot find `/responses`**
 
-If you are using the built-in DeepSeek preset, first confirm that the active provider really comes from the preset and that Codex routing is enabled. Only custom providers require extra base URL checks: the base URL should be the service root, not the full endpoint path with `/chat/completions`.
+Confirm that `DeepSeek V4 Pro` is selected, the local routing service is running, and Codex application routing is enabled. Do not write DeepSeek's Chat base URL directly into Codex configuration.
 
-**`/model` does not show DeepSeek models**
+**`/model` does not show a DeepSeek model**
 
-Restart Codex after saving the provider. CC Switch generates `cc-switch-model-catalog.json` and writes its path to `model_catalog_json`, but a running Codex process may not hot-load the model catalog.
-The Codex app currently does not support multi-model selection, so it uses the first configured model by default.
+Restart Codex after saving and enabling the provider. A running Codex process may not hot-load the model catalog.
 
-**Routing is enabled, but requests still go to the wrong provider**
+**Routing is enabled, but requests go to the wrong provider**
 
-Confirm that all three states match: the current provider under the Codex tab is DeepSeek; the local routing service is running; and the Codex toggle is enabled under `Routing Enabled`.
-
-**Can I use an official OpenAI Codex account through local routing?**
-
-Not recommended. CC Switch blocks switching to official providers while local routing takeover is enabled, because accessing official APIs through a proxy may create account risk. Routing is mainly intended for third-party, aggregator, or protocol-conversion scenarios.
+Confirm that `DeepSeek V4 Pro` is enabled on the Codex tab, the main routing switch is on, and Codex is enabled under application routing.
 
 ## References
 
 - [CC Switch User Manual: Add Provider](../user-manual/en/2-providers/2.1-add.md)
 - [CC Switch User Manual: Proxy Service](../user-manual/en/4-proxy/4.1-service.md)
 - [CC Switch User Manual: App Routing](../user-manual/en/4-proxy/4.2-routing.md)
-- [DeepSeek API Docs: Your First API Call](https://api-docs.deepseek.com/)
-- [DeepSeek API Docs: Create Chat Completion](https://api-docs.deepseek.com/api/create-chat-completion)
-- [DeepSeek API Docs: Multi-round Conversation](https://api-docs.deepseek.com/guides/multi_round_chat)
+- [DeepSeek: Using the Responses API](https://api-docs.deepseek.com/guides/responses_api)
+- [DeepSeek: Integrate with Codex](https://api-docs.deepseek.com/quick_start/agent_integrations/codex)

--- a/docs/guides/codex-deepseek-routing-guide-ja.md
+++ b/docs/guides/codex-deepseek-routing-guide-ja.md
@@ -1,101 +1,97 @@
-# Codex で DeepSeek などの Chat 形式 API を使う: CC Switch ローカルルーティングガイド
+# Codex で DeepSeek V4 Pro を使う：CC Switch ローカルルーティングガイド
 
-> 対象バージョン: CC Switch 3.16.0 およびその前後のバージョン。本記事はリポジトリ内のドキュメントとコードをもとに整理し、OpenAI Chat Completions 互換 API の例として DeepSeek を使用します。スクリーンショットは現在のフロントエンド UI から、実際の API Key やアカウント残高が漏れないよう匿名化したサンプルデータで生成しています。
+> **重要：**内蔵の `DeepSeek` メインプリセットは DeepSeek V4 Flash のみを含み、ネイティブ Responses API へ直接接続するため、**ローカルルーティングは不要**です。このガイドは独立した `DeepSeek V4 Pro` プリセットだけを対象とします。V4 Pro は現在 Chat Completions を使用するため、CC Switch によるローカルでのプロトコル変換が必要です。
 
-## ローカルルーティングが必要な理由
+> 保存済みの DeepSeek プロバイダーは、内蔵プリセットの変更に伴って自動移行されません。Flash のネイティブ Responses または新しい Pro Chat 設定を使用するには、対応するプリセットを選び直すか、新しいプロバイダーを作成してください。
 
-新しい Codex CLI は OpenAI Responses API を前提にしています。一方で DeepSeek、Kimi、MiniMax、SiliconFlow など多くのプロバイダーが実際に公開しているのは OpenAI Chat Completions 形式、つまり `/chat/completions` です。この 2 つのプロトコルは、リクエストボディ、ストリーミングイベント、レスポンス構造が異なります。Chat エンドポイントをそのまま Codex 設定に入れると、モデル一覧が合わない、リクエストが 404/400 になる、ストリーミングレスポンスを Codex が正しく解析できない、といった問題が起きがちです。
+## 最初に正しいプリセットを選ぶ
 
-CC Switch では、Codex が常にローカルルートへ接続し、Responses API のままリクエストを送るようにします。ルート内部で現在のプロバイダーが Chat 形式かどうかを判定し、必要ならリクエストを Chat Completions に書き換えて上流へ送り、最後に Chat レスポンスを Codex が理解できる Responses 形式へ戻します。
+| プリセット | モデル | 上流プロトコル | ローカルルーティング |
+|------------|--------|----------------|----------------------|
+| `DeepSeek` | `deepseek-v4-flash` | ネイティブ Responses | 不要 |
+| `DeepSeek V4 Pro` | `deepseek-v4-pro` | Chat Completions | 必要 |
 
-![Codex プロバイダー一覧のローカルルーティング必須マーク](../images/codex-deepseek-routing/01-codex-providers-require-routing.png)
+Flash を使用する場合は、`DeepSeek` を選択して API Key を入力し、保存するだけです。Codex モデルカタログには function calling、freeform `apply_patch`、テキスト Web Search、並列ツール呼び出し、`low` / `high` / `max` の推論レベルがすでに宣言されています。
 
-この経路は主に 4 つのステップに分かれます：
+以降の手順は `DeepSeek V4 Pro` のみに適用されます。
 
-1. Codex ルーティングを有効にすると、ローカル設定は `http://127.0.0.1:15721/v1` に書き換えられ、`wire_api = "responses"` は維持されます。
-2. Provider の `meta.apiFormat = "openai_chat"` が、実際の上流は Chat Completions だとルートに伝えます。
-3. ルートは `/responses` または `/v1/responses` を `/chat/completions` に書き換え、Responses のリクエストボディを Chat のリクエストボディへ変換します。
-4. 上流から返ってきた後、ルートは Chat の JSON または SSE ストリームを Responses JSON/SSE へ変換して返します。
+## V4 Pro にローカルルーティングが必要な理由
+
+Codex CLI は OpenAI Responses API を使用しますが、V4 Pro プリセットは現在 Chat Completions を使用します。CC Switch は Codex からのリクエストを Responses のまま受け取り、双方向にプロトコルを変換します：
+
+1. Codex の引き継ぎを有効にすると、live 設定は `http://127.0.0.1:15721/v1` を指し、`wire_api = "responses"` は維持されます。
+2. `DeepSeek V4 Pro` プリセットは Chat Completions 形式として設定されています。
+3. ローカルルートが Responses リクエストを Chat Completions に変換し、DeepSeek へ送信します。
+4. DeepSeek の応答後、JSON または SSE ストリームを Codex が認識できる Responses 形式へ戻します。
 
 ## 事前準備
 
-先に次の 3 つを用意してください：
+必要なもの：
 
 - インストール済みで起動できる CC Switch。
-- インストール済みの Codex CLI。少なくとも 1 回は実行し、`~/.codex/config.toml` のディレクトリ構造が存在していること。
-- DeepSeek または同種の Chat Completions プロバイダーの API Key。
+- インストール済みで、少なくとも一度実行した Codex CLI。
+- DeepSeek API Key。
 
-DeepSeek 公式ドキュメントでは、OpenAI 互換 base URL は現在 `https://api.deepseek.com`（他のプロバイダーでは `/v1` 付きの base URL もよくあります）、Chat API のパスは `/chat/completions` と記載されています。CC Switch の DeepSeek プリセットにはこれらの情報がすでに入っているため、まずはプリセットを使い、エンドポイントパスを手で組み立てる必要はありません。
+プリセットには `https://api.deepseek.com` と正しいモデル名が設定済みです。base URL に `/chat/completions` を手動で追加しないでください。
 
-## Step 1: Codex プロバイダーを追加する
+## Step 1：V4 Pro プロバイダーを追加する
 
-CC Switch を開き、上部の `Codex` タブへ切り替え、右上のプラスボタンからプロバイダーを追加します。
+CC Switch を開き、上部の `Codex` タブへ切り替え、右上のプラスボタンをクリックします：
 
-内蔵プリセットの `DeepSeek` を選びます。必要なのは次の 2 つだけです：
+1. `DeepSeek V4 Pro` プリセットを選択します。
+2. DeepSeek API Key を入力します。
+3. プロバイダーを保存します。
 
-- DeepSeek API Key を入力する。
-- プロバイダーを保存する。
+このプリセットは Chat Completions 形式、`deepseek-v4-pro` モデルカタログ、推論パラメータを自動的に設定します。通常、高度な設定を手動で変更する必要はありません。
 
-![DeepSeek Codex プロバイダーフォームのローカルルーティング設定](../images/codex-deepseek-routing/02-deepseek-codex-routing-form.png)
+## Step 2：ローカルルーティングと Codex の引き継ぎを有効にする
 
-プリセットには DeepSeek のリクエスト先、デフォルトモデル、モデルメニュー、thinking/reasoning パラメータがすでに含まれており、`ローカルルーティングが必要` も自動的に有効になります。必要に応じてデフォルトモデルやモデル表示名を調整できますが、プロトコル変換はルーティング層に任せれば十分です。
+設定の `ルーティング` ページを開き、`ローカルルーティング` を展開します：
 
-## Step 2: ローカルルーティングを有効にして Codex をルーティングする
+1. ルーティング総スイッチをオンにしてローカルサービスを起動します。デフォルトアドレスは `127.0.0.1:15721` です。
+2. アプリケーションルーティングで `Codex` を有効にします。
 
-設定の `ルーティング` ページに入り、`ローカルルーティング` を展開して、次の 2 つのスイッチを設定します：
+引き継ぎを有効にすると、Codex の live 設定はローカルルートを指します。実際の API Key は CC Switch のプロバイダー設定に保持され、転送時に注入されます。
 
-1. `ルーティング総スイッチ` をオンにしてローカルサービスを起動します。デフォルトアドレスは `127.0.0.1:15721` です。
-2. `ルーティング有効` で `Codex` をオンにします。Codex だけをルーティングしたい場合は、Claude と Gemini はオフのままで構いません。
+## Step 3：プロバイダーを有効にして Codex を再起動する
 
-![ローカルルーティング画面で Codex ルーティングを有効化](../images/codex-deepseek-routing/03-local-route-codex-takeover.png)
+Codex プロバイダー一覧へ戻り、`DeepSeek V4 Pro` を有効にします。このプリセットにはルーティング必須の表示があるため、使用中はローカルルーティングを起動したままにしてください。
 
-ルーティングを有効にすると、CC Switch は Codex の live 設定をローカルルートへ向け、認証はプレースホルダーで管理します。実際の DeepSeek Key は CC Switch の Provider 設定内に残り、ローカルルートが転送時に注入します。そのため、Codex の live 設定に Key を露出させる必要はありません。
+切り替え後は Codex のターミナルセッションを再起動します。プロセスが古い `config.toml` をすでに読み込んでいる可能性があり、`/model` メニューも通常は新しいプロセスで `model_catalog_json` を再読み込みします。
 
-## Step 3: プロバイダーを切り替えて Codex を再起動する
+Codex で `/model` を実行し、現在のモデルが `DeepSeek V4 Pro` であることを確認します。次に小さなリクエストを送り、CC Switch のルーティングまたはリクエストログに表示されることを確認してください。
 
-Codex プロバイダー一覧に戻り、DeepSeek プロバイダーの `有効化` をクリックします。`ルーティングが必要` の表示が見える場合、そのプロバイダーはルーティング実行中に使う必要があります。ルーティングが起動していない場合、CC Switch は「ルーティングサービスが必要」という趣旨のメッセージを表示します。
+## 以前の DeepSeek 設定から移行する
 
-切り替え後は、現在の Codex ターミナルセッションを再起動することをおすすめします。理由は次のとおりです：
+以前のバージョンでは、Flash と Pro が一つの Chat プリセットに含まれていました。アップグレード後も既存プロバイダーは保存済みの値を保持し、プロトコルは自動的に切り替わりません：
 
-- Codex プロセスがすでに古い `config.toml` を読み込んでいる可能性があります。
-- `model_catalog_json` の生成後、`/model` メニューの更新には通常、新しいプロセスが必要です。
+- Flash を使う場合：`DeepSeek` プリセットを選び直すか、新しいプロバイダーを作成します。ネイティブ Responses へ直接接続するため、ローカルルーティングは不要です。
+- Pro を使う場合：`DeepSeek V4 Pro` プリセットを選び直すか、新しいプロバイダーを作成し、Codex ローカルルーティングを有効にしたまま使用します。
 
-Codex に入ったら、`/model` で現在のモデルが DeepSeek プリセット由来かどうかを確認します。たとえば `DeepSeek V4 Flash` などです。現在の Codex app は複数モデル選択に対応していないため、設定内の最初のモデルをデフォルトで使用します。その後、小さな質問を 1 つ送って、ルーティングパネルのリクエスト数が増えるか、usage / リクエストログに Codex リクエストが出るかを確認します。
-
-## 他の Chat プロバイダーの場合
-
-DeepSeek、Kimi、MiniMax、SiliconFlow など一般的な Chat 形式プロバイダーは CC Switch にプリセットがあるため、まずはプリセットを使ってください。プリセットにないプロバイダーだけ、カスタム設定を選びます。その場合は相手側のドキュメントに従って API Key、base URL、モデルを入力し、`API 形式` を `OpenAI Chat Completions (ルーティングが必要)` に設定します。
-
-上流が OpenAI Responses API を直接サポートしている場合は、`ローカルルーティングが必要` を有効にする必要はありません。その場合、CC Switch は Responses のまま直結でき、Chat 変換は行いません。
+プリセットを変更した後は Codex を再起動し、live 設定とモデルカタログを更新してください。
 
 ## よくある質問
 
-**Codex が 404 を返す、または `/responses` が見つからない**
+**V4 Flash だけを使う場合も Codex ローカルルーティングは必要ですか？**
 
-多くの場合、Codex ルーティングが有効になっていないか、上流 Chat base URL を手動で Codex に直接書いています。`~/.codex/config.toml` が `http://127.0.0.1:15721/v1` を指しているか確認してください。
+いいえ。メインの `DeepSeek` プリセットを選択してください。Flash は Responses をネイティブサポートするため、CC Switch は Chat プロトコル変換を行いません。
 
-**DeepSeek 上流が 404 を返す**
+**V4 Pro で 404、または `/responses` が見つからないエラーになる**
 
-内蔵 DeepSeek プリセットを使っている場合は、まず現在のプロバイダーが本当にプリセット由来であること、そして Codex ルーティングが有効であることを確認してください。カスタムプロバイダーを使っている場合だけ、base URL を追加で確認します。base URL はサービスのルートであり、`/chat/completions` 付きの完全なエンドポイントパスではありません。
+`DeepSeek V4 Pro` が選択され、ローカルルーティングサービスが実行中で、Codex のアプリケーションルーティングが有効であることを確認してください。DeepSeek の Chat base URL を Codex 設定へ直接書き込まないでください。
 
 **`/model` に DeepSeek モデルが表示されない**
 
-プロバイダーを保存した後、Codex を再起動してください。CC Switch は `cc-switch-model-catalog.json` を生成し、そのパスを `model_catalog_json` に書き込みますが、実行中の Codex プロセスがモデルカタログをホットロードするとは限りません。
-現在の Codex app は複数モデル選択に対応していないため、設定内の最初のモデルをデフォルトで使用します。
+プロバイダーを保存して有効にした後、Codex を再起動してください。実行中の Codex プロセスはモデルカタログをホットロードしない場合があります。
 
-**ルーティングを有効にしたのに、リクエストが別のプロバイダーへ行く**
+**ルーティングを有効にしても、別のプロバイダーへ送信される**
 
-次の 3 つの状態が一致しているか確認してください：Codex タブの現在のプロバイダーが DeepSeek であること、ローカルルーティングサービスが実行中であること、`ルーティング有効` で Codex スイッチがオンであること。
-
-**公式 OpenAI Codex アカウントをローカルルーティング経由で使えますか**
-
-おすすめしません。CC Switch はローカルルーティング有効中、公式プロバイダーへの切り替えをブロックします。プロキシ経由で公式 API にアクセスすると、アカウントリスクが発生する可能性があるためです。ルーティングは主にサードパーティ、集約サービス、またはプロトコル変換のための機能です。
+Codex タブで `DeepSeek V4 Pro` が有効であること、ルーティング総スイッチがオンであること、アプリケーションルーティングで Codex が有効であることを確認してください。
 
 ## 参考リンク
 
-- [CC Switch ユーザーマニュアル: プロバイダーの追加](../user-manual/ja/2-providers/2.1-add.md)
-- [CC Switch ユーザーマニュアル: プロキシサービス](../user-manual/ja/4-proxy/4.1-service.md)
-- [CC Switch ユーザーマニュアル: アプリケーションルーティング](../user-manual/ja/4-proxy/4.2-routing.md)
-- [DeepSeek API Docs: Your First API Call](https://api-docs.deepseek.com/)
-- [DeepSeek API Docs: Create Chat Completion](https://api-docs.deepseek.com/api/create-chat-completion)
-- [DeepSeek API Docs: Multi-round Conversation](https://api-docs.deepseek.com/guides/multi_round_chat)
+- [CC Switch ユーザーマニュアル：プロバイダーの追加](../user-manual/ja/2-providers/2.1-add.md)
+- [CC Switch ユーザーマニュアル：プロキシサービス](../user-manual/ja/4-proxy/4.1-service.md)
+- [CC Switch ユーザーマニュアル：アプリケーションルーティング](../user-manual/ja/4-proxy/4.2-routing.md)
+- [DeepSeek：Responses API の使用](https://api-docs.deepseek.com/guides/responses_api)
+- [DeepSeek：Codex との統合](https://api-docs.deepseek.com/quick_start/agent_integrations/codex)

--- a/docs/guides/codex-deepseek-routing-guide-zh.md
+++ b/docs/guides/codex-deepseek-routing-guide-zh.md
@@ -1,101 +1,97 @@
-# 在 Codex 中用 DeepSeek 这类 Chat 格式 API：CC Switch 本地路由攻略
+# 在 Codex 中使用 DeepSeek V4 Pro：CC Switch 本地路由指南
 
-> 适用版本：CC Switch 3.16.0 及附近版本。本文根据仓库内文档与代码整理，并用 DeepSeek 作为 OpenAI Chat Completions 兼容接口的示例。截图来自当前前端界面，使用去敏示例数据生成，避免泄露真实 API Key 或账户余额。
+> **重要：**内置的 `DeepSeek` 主预设现在只包含 DeepSeek V4 Flash，并通过原生 Responses API 直连，**不需要本地路由**。本指南只适用于独立的 `DeepSeek V4 Pro` 预设；该模型目前通过 Chat Completions 接入，需要 CC Switch 在本地完成协议转换。
 
-## 为什么需要本地路由
+> 已保存的 DeepSeek 供应商不会随内置预设自动迁移。要使用 Flash 原生 Responses 或新的 Pro Chat 配置，请重新选择对应预设，或新建供应商。
 
-新版 Codex CLI 面向的是 OpenAI Responses API，而 DeepSeek、Kimi、MiniMax、SiliconFlow 等很多供应商实际暴露的是 OpenAI Chat Completions 形态，也就是 `/chat/completions`。这两种协议的请求体、流式事件和返回结构不同，直接把 Chat 接口填进 Codex 配置里，常见结果就是模型列表不对、请求 404/400，或者流式响应无法被 Codex 正确解析。
+## 先选择正确的预设
 
-CC Switch 的做法是让 Codex 始终连本机路由，仍以 Responses API 发送请求；路由在内部识别当前供应商是否是 Chat 格式，再把请求改写成 Chat Completions 发给上游，最后把 Chat 响应转换回 Responses 形态返回给 Codex。
+| 预设 | 模型 | 上游协议 | 是否需要本地路由 |
+|------|------|----------|------------------|
+| `DeepSeek` | `deepseek-v4-flash` | 原生 Responses | 否 |
+| `DeepSeek V4 Pro` | `deepseek-v4-pro` | Chat Completions | 是 |
 
-![Codex 供应商列表里的需要路由标记](../images/codex-deepseek-routing/01-codex-providers-require-routing.png)
+如果要使用 Flash，选择 `DeepSeek`、填写 API Key 并保存即可。其 Codex 模型目录已经声明函数调用、freeform `apply_patch`、文本 Web Search、并行工具调用，以及 `low` / `high` / `max` 思考等级。
 
-这条链路主要分成四步：
+以下步骤仅针对 `DeepSeek V4 Pro`。
 
-1. Codex 接管时，本地配置会被写成 `http://127.0.0.1:15721/v1`，并强制保持 `wire_api = "responses"`。
-2. Provider 的 `meta.apiFormat = "openai_chat"` 会告诉路由：真实上游是 Chat Completions。
-3. 路由把 `/responses` 或 `/v1/responses` 改写到 `/chat/completions`，并把 Responses 请求体转换成 Chat 请求体。
-4. 上游返回后，路由再把 Chat 的 JSON 或 SSE 转回 Codex 能理解的 Responses JSON/SSE。
+## 为什么 V4 Pro 需要本地路由
+
+Codex CLI 使用 OpenAI Responses API，而 V4 Pro 预设目前走 Chat Completions。CC Switch 会让 Codex 继续发送 Responses 请求，再在本地完成双向转换：
+
+1. Codex 接管后，live 配置指向 `http://127.0.0.1:15721/v1`，并保留 `wire_api = "responses"`。
+2. `DeepSeek V4 Pro` 预设标记为 Chat Completions 格式。
+3. 本地路由把 Responses 请求转换成 Chat Completions 请求，并发送到 DeepSeek。
+4. DeepSeek 返回后，路由将 JSON 或 SSE 转回 Codex 能识别的 Responses 格式。
 
 ## 准备工作
 
-你需要先准备好三样东西：
+你需要：
 
 - 已安装并能启动的 CC Switch。
-- 已安装 Codex CLI，并至少运行过一次，让 `~/.codex/config.toml` 目录结构存在。
-- DeepSeek 或同类 Chat Completions 供应商的 API Key。
+- 已安装且至少运行过一次的 Codex CLI。
+- DeepSeek API Key。
 
-DeepSeek 官方文档目前写明 OpenAI 兼容 base URL 是 `https://api.deepseek.com`（其他供应商常见的是带 `/v1` 后缀的 base URL），Chat API 路径是 `/chat/completions`；CC Switch 的 DeepSeek 预设已经按这些信息配好，请优先使用预设，不需要手动拼接口路径。
+预设已包含 `https://api.deepseek.com` 和正确的模型名，不要手动把 `/chat/completions` 拼进 base URL。
 
-## 第一步：添加 Codex 供应商
+## 第一步：添加 V4 Pro 供应商
 
-打开 CC Switch，切到顶部的 `Codex` 标签，点击右上角的加号添加供应商。
+打开 CC Switch，切到顶部的 `Codex` 标签，点击右上角的加号：
 
-选择内置预设里的 `DeepSeek`，只需要做两件事：
+1. 选择 `DeepSeek V4 Pro` 预设。
+2. 填写 DeepSeek API Key。
+3. 保存供应商。
 
-- 填入 DeepSeek API Key。
-- 保存供应商。
-
-![DeepSeek Codex 供应商表单中的本地路由映射](../images/codex-deepseek-routing/02-deepseek-codex-routing-form.png)
-
-预设已经内置 DeepSeek 的请求地址、默认模型、模型菜单、thinking/reasoning 参数，并会自动打开 `需要本地路由映射`。你可以按需调整默认模型或模型显示名；协议转换交给路由层完成即可。
+该预设会自动配置 Chat Completions 格式、`deepseek-v4-pro` 模型目录和思考参数。通常不需要手动修改高级配置。
 
 ## 第二步：开启本地路由并接管 Codex
 
-进入设置里的 `路由` 页面，展开 `本地路由`，完成两个开关：
+进入设置里的 `路由` 页面，展开 `本地路由`：
 
-1. 打开 `路由总开关`，启动本地服务。默认地址是 `127.0.0.1:15721`。
-2. 在 `路由启用` 中打开 `Codex`。如果只想让 Codex 走路由，可以保持 Claude、Gemini 关闭。
+1. 打开路由总开关，启动本地服务。默认地址是 `127.0.0.1:15721`。
+2. 在应用路由中启用 `Codex`。
 
-![本地路由页面中启用 Codex 接管](../images/codex-deepseek-routing/03-local-route-codex-takeover.png)
+接管后，Codex 的 live 配置会指向本地路由。真实 API Key 仍保存在 CC Switch 的供应商配置里，由路由在转发时注入。
 
-接管后，CC Switch 会把 Codex 的 live 配置指向本机路由，并用占位符管理认证。真实 DeepSeek Key 仍保存在 CC Switch 的 Provider 配置里，由本地路由在转发时注入，不需要你把 Key 暴露给 Codex live 配置。
+## 第三步：启用供应商并重启 Codex
 
-## 第三步：切换供应商并重启 Codex
+回到 Codex 供应商列表，启用 `DeepSeek V4 Pro`。该预设会显示需要路由；使用期间应保持本地路由运行。
 
-回到 Codex 供应商列表，点击 DeepSeek 供应商的 `启用`。如果看到 `需要路由` 标记，说明这个供应商必须在路由运行时使用；没有启动路由时，CC Switch 会弹出“需要路由服务才能正常使用”的提示。
+切换后重启 Codex 终端会话。Codex 进程可能已经读取旧的 `config.toml`，而 `/model` 菜单通常也要在新进程中重新加载 `model_catalog_json`。
 
-切换后建议重启当前 Codex 终端会话。原因是：
+进入 Codex 后，用 `/model` 确认当前模型为 `DeepSeek V4 Pro`，再发送一个小请求，并在 CC Switch 的路由或请求日志中确认请求到达。
 
-- Codex 进程可能已经读取过旧的 `config.toml`。
-- `model_catalog_json` 生成后，`/model` 菜单通常需要新进程才能刷新。
+## 从旧 DeepSeek 配置迁移
 
-进入 Codex 后，可以用 `/model` 查看当前模型是否来自 DeepSeek 预设，例如 `DeepSeek V4 Flash`。目前 Codex app 不支持多模型选择时，会默认使用配置里的第一个模型。随后发一个小问题，确认路由面板的请求数增长，或者在用量/请求日志里看到 Codex 请求即可。
+旧版本把 Flash 和 Pro 放在同一个 Chat 预设中。升级后，已有供应商仍保留原来的保存值，不会自动切换协议：
 
-## 其它 Chat 供应商怎么处理
+- 使用 Flash：重新选择 `DeepSeek` 预设或新建供应商；它通过原生 Responses 直连，不需要本地路由。
+- 使用 Pro：重新选择 `DeepSeek V4 Pro` 预设或新建供应商，并保持 Codex 本地路由开启。
 
-DeepSeek、Kimi、MiniMax、SiliconFlow 等常见 Chat 格式供应商在 CC Switch 里已有预设，优先用预设即可。只有预设里没有的供应商，才需要选择自定义配置；这时按对方文档填 API Key、base URL 和模型，并把 `API 格式` 选为 `OpenAI Chat Completions (需开启路由)`。
-
-如果上游直接支持 OpenAI Responses API，就不需要打开 `需要本地路由映射`；这时 CC Switch 可以按 Responses 直连，不做 Chat 转换。
+切换预设后请重启 Codex，以刷新 live 配置和模型目录。
 
 ## 常见问题
 
-**Codex 报 404 或找不到 `/responses`**
+**我只使用 V4 Flash，也要开启 Codex 本地路由吗？**
 
-通常是没有开启 Codex 接管，或者你手动把上游 Chat base URL 直接写给了 Codex。检查 `~/.codex/config.toml` 是否指向 `http://127.0.0.1:15721/v1`。
+不需要。选择主 `DeepSeek` 预设即可。Flash 原生支持 Responses，CC Switch 不会做 Chat 协议转换。
 
-**DeepSeek 上游报 404**
+**V4 Pro 报 404 或找不到 `/responses`**
 
-如果用的是内置 DeepSeek 预设，先确认当前供应商确实来自预设，并且 Codex 路由已启用。只有在使用自定义供应商时，才需要额外检查 base URL：它应该是服务根地址，而不是带 `/chat/completions` 的完整接口路径。
+确认当前选中的是 `DeepSeek V4 Pro`，本地路由服务正在运行，并且 Codex 应用路由已启用。不要把 DeepSeek 的 Chat base URL 直接写给 Codex。
 
 **`/model` 看不到 DeepSeek 模型**
 
-保存供应商后重启 Codex。CC Switch 会生成 `cc-switch-model-catalog.json` 并把路径写入 `model_catalog_json`，但正在运行的 Codex 进程不一定会热加载模型目录。
-目前 Codex app 不支持多模型选择，默认使用配置的第一个模型。
+保存并启用供应商后重启 Codex。运行中的 Codex 进程不一定会热加载模型目录。
 
-**开了路由但请求仍走错供应商**
+**路由开启后请求仍走错供应商**
 
-确认三处状态一致：Codex 标签下当前供应商是 DeepSeek；本地路由服务正在运行；`路由启用` 里 Codex 开关已打开。
-
-**可以用官方 OpenAI Codex 账号走本地路由吗**
-
-不建议。CC Switch 会在本地路由接管模式下阻止切到官方供应商，因为用代理访问官方 API 可能带来账号风险。路由主要用于第三方、聚合或协议转换场景。
+确认 Codex 标签下启用的是 `DeepSeek V4 Pro`，路由总开关已打开，并且应用路由中的 Codex 开关已启用。
 
 ## 参考链接
 
 - [CC Switch 用户手册：添加供应商](../user-manual/zh/2-providers/2.1-add.md)
 - [CC Switch 用户手册：代理服务](../user-manual/zh/4-proxy/4.1-service.md)
 - [CC Switch 用户手册：应用路由](../user-manual/zh/4-proxy/4.2-routing.md)
-- [DeepSeek API 文档：Your First API Call](https://api-docs.deepseek.com/)
-- [DeepSeek API 文档：Create Chat Completion](https://api-docs.deepseek.com/api/create-chat-completion)
-- [DeepSeek API 文档：Multi-round Conversation](https://api-docs.deepseek.com/guides/multi_round_chat)
+- [DeepSeek：使用 Responses API](https://api-docs.deepseek.com/guides/responses_api)
+- [DeepSeek：集成 Codex](https://api-docs.deepseek.com/quick_start/agent_integrations/codex)

--- a/docs/user-manual/en/2-providers/2.1-add.md
+++ b/docs/user-manual/en/2-providers/2.1-add.md
@@ -76,6 +76,7 @@ Codex presets fall into two groups by upstream protocol.
 |-------------|-------------|
 | OpenAI Official | Log in with an OpenAI official account |
 | Azure OpenAI | Azure OpenAI service |
+| DeepSeek | DeepSeek V4 Flash with native Responses and direct connection |
 | AiHubMix | AiHubMix aggregation service |
 | DMXAPI | DMXAPI proxy service |
 | PackyCode | PackyCode proxy service |
@@ -86,7 +87,7 @@ Codex presets fall into two groups by upstream protocol.
 
 | Preset Name | Description |
 |-------------|-------------|
-| DeepSeek | DeepSeek models |
+| DeepSeek V4 Pro | DeepSeek V4 Pro (temporarily uses Chat Completions) |
 | Zhipu GLM / GLM en | Zhipu AI GLM models |
 | Kimi / Kimi For Coding | Moonshot Kimi models |
 | MiniMax / MiniMax en | MiniMax models |
@@ -105,6 +106,10 @@ Codex presets fall into two groups by upstream protocol.
 | Nvidia | Nvidia AI service |
 
 > 💡 When you pick a Chat Completions preset, the **Needs Local Routing** toggle and the model mapping table are configured automatically; see the "Codex Local Routing and Model Mapping" section below. The preset list is updated continuously — refer to the in-app list for the authoritative version.
+
+> The main DeepSeek preset now contains only V4 Flash and connects directly through the native Responses API, without local routing. Its Codex model catalog declares function calling, freeform `apply_patch`, text Web Search, parallel tool calls, and `low` / `high` / `max` reasoning levels. V4 Pro uses a separate Chat Completions preset until its native Responses integration is available.
+
+> ⚠️ Saved DeepSeek providers are not migrated automatically when a built-in preset changes. To move an older Chat-conversion configuration to native Responses for Flash, select the `DeepSeek` preset again or create a new provider.
 
 #### Gemini Presets
 
@@ -558,17 +563,17 @@ Additionally, the **Apply Common Config** checkbox enables merging a global conf
 
 ### Codex Local Routing and Model Mapping
 
-Some third-party providers only support the **OpenAI Chat Completions** protocol or use non-GPT model names (such as DeepSeek, Kimi, or MiniMax). Codex natively understands only the OpenAI Responses API and GPT-series models, so these providers need CC Switch to convert the protocol and models locally.
+Some third-party providers only support non-Responses protocols such as **OpenAI Chat Completions**, so CC Switch must convert the protocol locally. Routing depends on the upstream protocol, not the model name; non-GPT models with a Codex model catalog can also connect directly through a native Responses API.
 
 #### Needs Local Routing
 
 When editing a Codex provider, a **Needs Local Routing** toggle is available:
 
-- **When to enable**: the provider uses the Chat Completions protocol, or its model names are not Codex's default GPT series
+- **When to enable**: the provider uses Chat Completions or another protocol that must be converted to Responses
 - **When enabled**: CC Switch's local proxy converts the Responses requests Codex sends into upstream Chat Completions, then converts the response (including streaming SSE, reasoning content, and tool calls) back into Responses format
 - **Prerequisite**: [local routing](../4-proxy/4.1-service.md) must be running with Codex takeover enabled for conversion to take effect; keep local routing running while in use
 
-> 💡 When you pick a Chat-format preset such as DeepSeek or Kimi, this toggle is enabled by default — no manual setup needed.
+> 💡 When you pick a Chat-format preset such as `DeepSeek V4 Pro` or Kimi, this toggle is enabled by default — no manual setup is needed. V4 Flash in the main `DeepSeek` preset uses native Responses and does not need this toggle.
 
 #### Model Mapping
 
@@ -576,7 +581,7 @@ Once **Needs Local Routing** is enabled, a **Model Mapping** table appears below
 
 | Field | Description |
 |-------|-------------|
-| Model ID | The real upstream model name, e.g. `deepseek-v4-flash` |
+| Model ID | The real upstream model name, e.g. `deepseek-v4-pro` |
 | Display Name | (Optional) The name shown in the `/model` command |
 | Context Window | (Optional) The model's context length |
 
@@ -588,6 +593,8 @@ Once **Needs Local Routing** is enabled, a **Model Mapping** table appears below
 
 With Local Routing on, CC Switch **auto-detects** each provider's reasoning interface and converts Codex's outgoing reasoning request into a parameter the upstream understands — **no manual setup required**. Detection is based on the provider's name, base URL, and model:
 
+> V4 Flash in the main `DeepSeek` preset uses the `low` / `high` / `max` levels declared by its native Responses model catalog; it does not use the Chat parameter conversion described here. The rules below apply to providers that need local routing, including `DeepSeek V4 Pro`.
+
 - **Aggregator / hosting platforms first**: OpenRouter, SiliconFlow, etc. are handled by platform rules (the same model can expose a completely different reasoning interface on different platforms)
 - **Otherwise by model brand**: DeepSeek, Kimi / Moonshot, Zhipu GLM, Qwen, MiniMax, Xiaomi MiMo, StepFun each have their own rules
 
@@ -595,10 +602,10 @@ Providers fall into two reasoning-capability tiers:
 
 | Capability | Meaning | Example providers |
 |------------|---------|-------------------|
-| **Effort levels supported** | Reasoning strength is adjustable (low / medium / high, etc.) | DeepSeek, OpenRouter, StepFun (`step-3.5-flash-2603` only) |
+| **Effort levels supported** | Reasoning strength is adjustable (low / medium / high, etc.) | DeepSeek V4 Pro, OpenRouter, StepFun (`step-3.5-flash-2603` only) |
 | **On/off switch only** | Reasoning can only be turned on or off; **levels have no effect** | Kimi, Zhipu GLM, Qwen, MiniMax, Xiaomi MiMo, SiliconFlow |
 
-> ⚠️ **Effort levels do nothing for some providers**: if a provider only supports an on/off switch, changing the reasoning effort in Codex (`model_reasoning_effort` low / medium / high) has **no effect** — CC Switch does not forward the level to these upstreams (their API rejects the parameter, and sending it anyway may break the request). Their reasoning is **on by default** and works via on/off rather than tiering. Only providers with real effort levels (e.g. DeepSeek, OpenRouter) actually respond to a level change.
+> ⚠️ **Effort levels do nothing for some providers**: if a provider only supports an on/off switch, changing the reasoning effort in Codex (`model_reasoning_effort` low / medium / high) has **no effect** — CC Switch does not forward the level to these upstreams (their API rejects the parameter, and sending it anyway may break the request). Their reasoning is **on by default** and works via on/off rather than tiering. Only Chat providers with real effort levels (e.g. DeepSeek V4 Pro or OpenRouter) actually respond to a level change.
 
 > 💡 **Detection is keyword matching on name / base URL / model**, not a real capability probe. Official domains (e.g. `api.deepseek.com`, `api.moonshot.cn`) are always recognized; a relay that rewrites the domain and model name may not be detected, in which case no reasoning parameter is injected.
 

--- a/docs/user-manual/ja/2-providers/2.1-add.md
+++ b/docs/user-manual/ja/2-providers/2.1-add.md
@@ -76,6 +76,7 @@ Codex プリセットは上流プロトコルにより 2 種類に分かれま�
 |----------|------|
 | OpenAI 公式 | OpenAI 公式アカウントでログイン |
 | Azure OpenAI | Azure OpenAI サービス |
+| DeepSeek | ネイティブ Responses で直接接続する DeepSeek V4 Flash |
 | AiHubMix | AiHubMix 統合サービス |
 | DMXAPI | DMXAPI 中継サービス |
 | PackyCode | PackyCode 中継サービス |
@@ -86,7 +87,7 @@ Codex プリセットは上流プロトコルにより 2 種類に分かれま�
 
 | プリセット名 | 説明 |
 |----------|------|
-| DeepSeek | DeepSeek モデル |
+| DeepSeek V4 Pro | DeepSeek V4 Pro（当面は Chat Completions を使用） |
 | Zhipu GLM / GLM en | Zhipu AI の GLM モデル |
 | Kimi / Kimi For Coding | Moonshot Kimi モデル |
 | MiniMax / MiniMax en | MiniMax モデル |
@@ -105,6 +106,10 @@ Codex プリセットは上流プロトコルにより 2 種類に分かれま�
 | Nvidia | Nvidia AI サービス |
 
 > 💡 Chat Completions 系プリセットを選択すると、「ローカルルーティングが必要」トグルとモデルマッピング表が自動的に設定されます。詳細は下記の「Codex ローカルルーティングとモデルマッピング」セクションを参照してください。プリセット一覧は継続的に更新されます。アプリ内の表示を正としてください。
+
+> メインの DeepSeek プリセットは V4 Flash のみを含み、ネイティブ Responses API で直接接続するため、ローカルルーティングは不要です。Codex モデルカタログには function calling、freeform `apply_patch`、テキスト Web Search、並列ツール呼び出し、`low` / `high` / `max` の推論レベルが宣言されています。V4 Pro はネイティブ Responses 統合が利用可能になるまで、独立した Chat Completions プリセットを使用します。
+
+> ⚠️ 保存済みの DeepSeek プロバイダーは、内蔵プリセットの変更に伴って自動移行されません。以前の Chat 変換設定から Flash のネイティブ Responses へ切り替えるには、`DeepSeek` プリセットを選び直すか、新しいプロバイダーを作成してください。
 
 #### Gemini プリセット
 
@@ -558,17 +563,17 @@ Claude プロバイダーの編集時、JSON エディタの上部に **クイ�
 
 ### Codex ローカルルーティングとモデルマッピング
 
-一部の第三者プロバイダーは **OpenAI Chat Completions** プロトコルのみをサポートするか、非 GPT モデル名（DeepSeek、Kimi、MiniMax など）を使用します。Codex はネイティブには OpenAI Responses API と GPT 系列モデルのみを認識するため、これらのプロバイダーでは CC Switch がローカルでプロトコルとモデルを変換する必要があります。
+一部の第三者プロバイダーは **OpenAI Chat Completions** など、Responses 以外のプロトコルのみをサポートするため、CC Switch がローカルでプロトコルを変換する必要があります。ルーティングの要否はモデル名ではなく上流プロトコルで決まり、Codex モデルカタログを持つ非 GPT モデルもネイティブ Responses API へ直接接続できます。
 
 #### ローカルルーティングが必要
 
 Codex プロバイダーの編集時、**ローカルルーティングが必要** トグルが利用できます：
 
-- **有効にするタイミング**：プロバイダーが Chat Completions プロトコルを使用する、またはモデル名が Codex デフォルトの GPT 系列でない場合
+- **有効にするタイミング**：プロバイダーが Chat Completions など、Responses への変換が必要なプロトコルを使用する場合
 - **有効時**：CC Switch のローカルプロキシが、Codex の送信する Responses リクエストを上流の Chat Completions に変換し、レスポンス（ストリーミング SSE、推論内容、ツール呼び出しを含む）を Responses 形式に再変換します
 - **前提条件**：変換を有効にするには[ローカルルーティング](../4-proxy/4.1-service.md)を起動し、Codex の引き継ぎを有効にする必要があります。使用中はローカルルーティングを起動したままにしてください
 
-> 💡 DeepSeek や Kimi などの Chat 形式プリセットを選択すると、このトグルはデフォルトで有効になっており、手動設定は不要です。
+> 💡 `DeepSeek V4 Pro` や Kimi などの Chat 形式プリセットを選択すると、このトグルはデフォルトで有効になっており、手動設定は不要です。メインの `DeepSeek` プリセットに含まれる V4 Flash はネイティブ Responses のため、このトグルは不要です。
 
 #### モデルマッピング
 
@@ -576,7 +581,7 @@ Codex プロバイダーの編集時、**ローカルルーティングが必要
 
 | フィールド | 説明 |
 |------|------|
-| モデル ID | 上流の実際のモデル名（例：`deepseek-v4-flash`） |
+| モデル ID | 上流の実際のモデル名（例：`deepseek-v4-pro`） |
 | 表示名 | （任意）`/model` コマンドに表示される名称 |
 | コンテキストウィンドウ | （任意）モデルのコンテキスト長 |
 
@@ -588,6 +593,8 @@ Codex プロバイダーの編集時、**ローカルルーティングが必要
 
 ローカルルーティングを有効にすると、CC Switch はプロバイダーの「思考」（reasoning）インターフェースを**自動判定**し、Codex が送る思考リクエストを上流が理解できるパラメータに変換します（**手動設定は不要**）。判定はプロバイダーの名前・エンドポイント・モデル名に基づきます：
 
+> メインの `DeepSeek` プリセットに含まれる V4 Flash は、ネイティブ Responses モデルカタログで宣言された `low` / `high` / `max` レベルを使用し、ここで説明する Chat パラメータ変換を行いません。以下の規則は `DeepSeek V4 Pro` など、ローカルルーティングが必要なプロバイダーに適用されます。
+
 - **集約 / ホスティングプラットフォーム優先**：OpenRouter、SiliconFlow などはプラットフォーム規則で処理（同じモデルでもプラットフォームごとに思考インターフェースが全く異なる場合があるため）
 - **それ以外はモデルブランド別**：DeepSeek、Kimi / Moonshot、Zhipu GLM、Qwen、MiniMax、Xiaomi MiMo、StepFun などにそれぞれ規則あり
 
@@ -595,10 +602,10 @@ Codex プロバイダーの編集時、**ローカルルーティングが必要
 
 | 能力 | 意味 | 代表的なプロバイダー |
 |------|------|----------------------|
-| **思考レベル対応** | 思考の強度を調整可能（low / medium / high など） | DeepSeek、OpenRouter、StepFun（`step-3.5-flash-2603` のみ） |
+| **思考レベル対応** | 思考の強度を調整可能（low / medium / high など） | DeepSeek V4 Pro、OpenRouter、StepFun（`step-3.5-flash-2603` のみ） |
 | **オン / オフ切替のみ** | 思考のオン / オフのみ、**レベルは無効** | Kimi、Zhipu GLM、Qwen、MiniMax、Xiaomi MiMo、SiliconFlow |
 
-> ⚠️ **一部のプロバイダーでは思考レベルが効きません**：オン / オフ切替のみのプロバイダーでは、Codex で思考レベル（`model_reasoning_effort` の low / medium / high）を変えても**効果はありません**——CC Switch はこれらの上流にレベルを送りません（API がパラメータを受け付けず、無理に送るとリクエストが拒否される可能性があるため）。これらのプロバイダーの思考は**デフォルトでオン**で、「調整」ではなく「オン / オフ」で動作します。実際にレベル変更が効くのは、思考レベルに対応したプロバイダー（DeepSeek、OpenRouter など）だけです。
+> ⚠️ **一部のプロバイダーでは思考レベルが効きません**：オン / オフ切替のみのプロバイダーでは、Codex で思考レベル（`model_reasoning_effort` の low / medium / high）を変えても**効果はありません**——CC Switch はこれらの上流にレベルを送りません（API がパラメータを受け付けず、無理に送るとリクエストが拒否される可能性があるため）。これらのプロバイダーの思考は**デフォルトでオン**で、「調整」ではなく「オン / オフ」で動作します。実際にレベル変更が効くのは、思考レベルに対応した Chat プロバイダー（DeepSeek V4 Pro、OpenRouter など）だけです。
 
 > 💡 **判定は名前 / エンドポイント / モデル名のキーワードマッチング**であり、実際の能力探索ではありません。公式ドメイン（`api.deepseek.com`、`api.moonshot.cn` など）は常に認識されますが、ドメインとモデル名を書き換えた中継サービスでは判定できないことがあり、その場合は思考パラメータが一切注入されません。
 

--- a/docs/user-manual/zh/2-providers/2.1-add.md
+++ b/docs/user-manual/zh/2-providers/2.1-add.md
@@ -76,6 +76,7 @@ Codex 预设按上游协议分两类。
 |----------|------|
 | OpenAI 官方 | 使用 OpenAI 官方账号登录 |
 | Azure OpenAI | Azure OpenAI 服务 |
+| DeepSeek | DeepSeek V4 Flash，原生 Responses，可直接连接 |
 | AiHubMix | AiHubMix 聚合服务 |
 | DMXAPI | DMXAPI 中转服务 |
 | PackyCode | PackyCode 中转服务 |
@@ -86,7 +87,7 @@ Codex 预设按上游协议分两类。
 
 | 预设名称 | 说明 |
 |----------|------|
-| DeepSeek | DeepSeek 模型 |
+| DeepSeek V4 Pro | DeepSeek V4 Pro（暂走 Chat Completions） |
 | 智谱 GLM / GLM en | 智谱 AI 的 GLM 模型 |
 | Kimi / Kimi For Coding | Moonshot Kimi 模型 |
 | MiniMax / MiniMax en | MiniMax 模型 |
@@ -105,6 +106,10 @@ Codex 预设按上游协议分两类。
 | Nvidia | Nvidia AI 服务 |
 
 > 💡 选择 Chat Completions 类预设时，「需要本地路由映射」开关和模型映射表会自动配置好，无需手动设置；详见下文「Codex 本地路由与模型映射」一节。预设列表持续更新，以应用内实际显示为准。
+
+> DeepSeek 的主预设现在只包含 V4 Flash，并通过原生 Responses API 直连，无需本地路由。它的 Codex 模型目录已声明函数调用、freeform `apply_patch`、文本 Web Search、并行工具调用，以及 `low` / `high` / `max` 思考等级。V4 Pro 在原生 Responses 集成开放前使用独立的 Chat Completions 预设。
+
+> ⚠️ 已保存的 DeepSeek 供应商不会随内置预设自动迁移。要从旧的 Chat 转换配置切换到 Flash 原生 Responses，请重新选择 `DeepSeek` 预设或新建供应商。
 
 #### Gemini 预设
 
@@ -558,17 +563,17 @@ v3.13.0 起新增的高级选项。默认情况下，CC Switch 会把配置的 `
 
 ### Codex 本地路由与模型映射
 
-部分第三方供应商只支持 **OpenAI Chat Completions** 协议，或使用非 GPT 模型名（如 DeepSeek、Kimi、MiniMax）。Codex 原生只认 OpenAI Responses API 与 GPT 系列模型，因此这类供应商需要 CC Switch 在本地做协议与模型转换。
+部分第三方供应商只支持 **OpenAI Chat Completions** 等非 Responses 协议，因此需要 CC Switch 在本地做协议转换。是否需要路由取决于上游协议，而不是模型名；带有 Codex 模型目录的非 GPT 模型也可以通过原生 Responses API 直连。
 
 #### 需要本地路由映射
 
 编辑 Codex 供应商时，提供 **需要本地路由映射** 开关：
 
-- **何时打开**：供应商使用 Chat Completions 协议，或模型名不是 Codex 默认的 GPT 系列
+- **何时打开**：供应商使用 Chat Completions 等需要转换为 Responses 的协议
 - **打开后**：CC Switch 本地代理会把 Codex 发出的 Responses 请求转换为上游的 Chat Completions，再把响应（含流式 SSE、推理内容、工具调用）转换回 Responses 格式
 - **前提条件**：必须开启[本地路由服务](../4-proxy/4.1-service.md)并启用 Codex 接管，转换才会生效；使用过程中需保持本地路由开启
 
-> 💡 选择 DeepSeek、Kimi 等 Chat 格式预设时，此开关默认已打开，无需手动设置。
+> 💡 选择 `DeepSeek V4 Pro`、Kimi 等 Chat 格式预设时，此开关默认已打开，无需手动设置。主 `DeepSeek` 预设中的 V4 Flash 是原生 Responses，不需要打开此开关。
 
 #### 模型映射
 
@@ -576,7 +581,7 @@ v3.13.0 起新增的高级选项。默认情况下，CC Switch 会把配置的 `
 
 | 字段 | 说明 |
 |------|------|
-| 模型 ID | 上游真实模型名，如 `deepseek-v4-flash` |
+| 模型 ID | 上游真实模型名，如 `deepseek-v4-pro` |
 | 显示名称 | （可选）在 `/model` 命令中显示的名称 |
 | 上下文窗口 | （可选）模型的上下文长度 |
 
@@ -588,6 +593,8 @@ v3.13.0 起新增的高级选项。默认情况下，CC Switch 会把配置的 `
 
 开启本地路由后，CC Switch 会**自动识别**供应商的「思考」（reasoning）接口，把 Codex 发出的思考请求转换成上游能理解的参数，**无需手动配置**。识别依据是供应商的名称、端点和模型名：
 
+> 主 `DeepSeek` 预设中的 V4 Flash 直接使用原生 Responses 模型目录声明的 `low` / `high` / `max` 等级，不经过本节所述的 Chat 参数转换。以下规则适用于 `DeepSeek V4 Pro` 等需要本地路由的供应商。
+
 - **聚合 / 托管平台优先**：OpenRouter、SiliconFlow 等按平台规则处理（同一模型在不同平台上的思考接口可能完全不同）
 - **其余按模型品牌**：DeepSeek、Kimi / Moonshot、智谱 GLM、通义千问、MiniMax、小米 MiMo、阶跃星辰 StepFun 等各有对应规则
 
@@ -595,10 +602,10 @@ v3.13.0 起新增的高级选项。默认情况下，CC Switch 会把配置的 `
 
 | 能力 | 含义 | 代表供应商 |
 |------|------|-----------|
-| **支持思考等级** | 可调节思考强度（low / medium / high 等） | DeepSeek、OpenRouter、StepFun（仅 `step-3.5-flash-2603`） |
+| **支持思考等级** | 可调节思考强度（low / medium / high 等） | DeepSeek V4 Pro、OpenRouter、StepFun（仅 `step-3.5-flash-2603`） |
 | **仅支持思考开关** | 只能开 / 关思考，**等级无效** | Kimi、智谱 GLM、通义千问、MiniMax、小米 MiMo、SiliconFlow |
 
-> ⚠️ **思考等级对部分供应商无效**：如果供应商只支持「思考开关」，那么在 Codex 里调节思考等级（`model_reasoning_effort` 的 low / medium / high）**不会有任何效果**——CC Switch 不会把等级透传给这类上游（它们的接口不接受该参数，硬传可能导致请求被拒）。这类供应商的思考默认**开启**，靠「开 / 关」而非「调档」工作。只有支持思考等级的供应商（如 DeepSeek、OpenRouter），调节等级才真正生效。
+> ⚠️ **思考等级对部分供应商无效**：如果供应商只支持「思考开关」，那么在 Codex 里调节思考等级（`model_reasoning_effort` 的 low / medium / high）**不会有任何效果**——CC Switch 不会把等级透传给这类上游（它们的接口不接受该参数，硬传可能导致请求被拒）。这类供应商的思考默认**开启**，靠「开 / 关」而非「调档」工作。只有支持思考等级的 Chat 供应商（如 DeepSeek V4 Pro、OpenRouter），调节等级才真正生效。
 
 > 💡 **识别基于名称 / 端点 / 模型名的关键词匹配**，不是真正的能力探测。官方域名（如 `api.deepseek.com`、`api.moonshot.cn`）都能正确识别；如果你用的中转改写了域名和模型名，可能识别不到，此时不会注入任何思考参数。
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -119,10 +119,9 @@ const CODEX_MODEL_CATALOG_TEMPLATE_SLUG: &str = "gpt-5.5";
 /// - `ProxyChat`: cc-switch's proxy takes over and converts Responses<->Chat,
 ///   so the catalog keeps Codex's default tool set (incl. the freeform
 ///   `apply_patch` custom tool, which the proxy rewrites to a function tool).
-/// - `NativeResponses`: Codex talks directly to a provider's native
-///   `/responses` endpoint (no proxy). Such gateways (e.g. Xiaomi MiMo,
-///   MiniMax) reject `type=="custom"` tools, so the catalog must suppress the
-///   freeform `apply_patch` and rely on `shell_type="shell_command"` for edits.
+/// - `NativeResponses`：Codex 直连供应商的 `/responses`。默认按不支持
+///   `type=="custom"` 的网关保守生成；只有模型元数据显式声明时才恢复
+///   freeform `apply_patch`、Web Search 等原生能力。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodexCatalogToolProfile {
     ProxyChat,
@@ -146,8 +145,7 @@ impl CodexCatalogToolProfile {
     pub fn from_api_format(api_format: Option<&str>) -> Self {
         match api_format {
             Some("anthropic") => CodexCatalogToolProfile::Anthropic,
-            // Native (direct) Responses gateways reject Codex's freeform custom
-            // tools (apply_patch, etc.); strip them via the NativeResponses profile.
+            // 原生 Responses 默认使用保守工具集；模型级显式能力会在生成目录时恢复。
             Some("openai_responses") => CodexCatalogToolProfile::NativeResponses,
             _ => CodexCatalogToolProfile::ProxyChat,
         }
@@ -442,6 +440,85 @@ fn parse_codex_positive_u64(value: Option<&Value>) -> Option<u64> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexReasoningLevel {
+    effort: String,
+    description: String,
+}
+
+impl CodexReasoningLevel {
+    fn to_json(&self) -> Value {
+        json!({
+            "effort": self.effort,
+            "description": self.description,
+        })
+    }
+}
+
+fn codex_reasoning_levels_to_json(levels: &[CodexReasoningLevel]) -> Value {
+    Value::Array(levels.iter().map(CodexReasoningLevel::to_json).collect())
+}
+
+fn parse_codex_reasoning_levels(value: Option<&Value>) -> Option<Vec<CodexReasoningLevel>> {
+    let levels = value?.as_array()?;
+    let parsed = levels
+        .iter()
+        .filter_map(|level| {
+            let effort = level.get("effort")?.as_str()?.trim().to_string();
+            let description = level.get("description")?.as_str()?.trim().to_string();
+            if effort.is_empty() || description.is_empty() {
+                return None;
+            }
+            Some(CodexReasoningLevel {
+                effort,
+                description,
+            })
+        })
+        .collect::<Vec<_>>();
+    (!parsed.is_empty()).then_some(parsed)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexTruncationMode {
+    Tokens,
+    Bytes,
+}
+
+impl CodexTruncationMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Tokens => "tokens",
+            Self::Bytes => "bytes",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexTruncationPolicy {
+    mode: CodexTruncationMode,
+    limit: u64,
+}
+
+impl CodexTruncationPolicy {
+    fn to_json(&self) -> Value {
+        json!({
+            "mode": self.mode.as_str(),
+            "limit": self.limit,
+        })
+    }
+}
+
+fn parse_codex_truncation_policy(value: Option<&Value>) -> Option<CodexTruncationPolicy> {
+    let policy = value?.as_object()?;
+    let mode = match policy.get("mode")?.as_str()?.trim() {
+        "tokens" => CodexTruncationMode::Tokens,
+        "bytes" => CodexTruncationMode::Bytes,
+        _ => return None,
+    };
+    let limit = parse_codex_positive_u64(policy.get("limit"))?;
+    Some(CodexTruncationPolicy { mode, limit })
+}
+
 fn extract_codex_top_level_u64(config_text: &str, field: &str) -> Option<u64> {
     let doc = config_text.parse::<toml::Value>().ok()?;
     doc.get(field)
@@ -496,11 +573,9 @@ fn codex_catalog_model_entry(
     );
 
     if profile != CodexCatalogToolProfile::ProxyChat {
-        // Native `/responses` and Anthropic gateways reject / drop Codex's freeform
-        // `apply_patch` (type=="custom") tool. Strip any key that would make Codex
-        // emit a custom/freeform tool, and rely on shell_type="shell_command" for
-        // edits. Defensive even though the native template is already clean
-        // (guards against template drift / an accidental gpt-5.5 clone).
+        // 先删除会让 Codex 发出 custom / hosted tools 的模板字段，以保守能力集
+        // 为基线；NativeResponses 可在下方按模型显式元数据恢复，Anthropic 不恢复。
+        // 即使原生模板当前已清理，这里仍防止模板漂移或误用 GPT 模板。
         //
         // NOTE: `base_instructions` is NOT stripped — Codex's catalog parser
         // treats it as a REQUIRED field and refuses to load the file without
@@ -515,6 +590,7 @@ fn codex_catalog_model_entry(
             entry_obj.remove(key);
         }
         entry_obj.insert("shell_type".to_string(), json!("shell_command"));
+        entry_obj.insert("supports_search_tool".to_string(), json!(false));
 
         if let Some(base_instructions) = spec
             .base_instructions
@@ -527,12 +603,50 @@ fn codex_catalog_model_entry(
         if let Some(parallel) = spec.supports_parallel_tool_calls {
             entry_obj.insert("supports_parallel_tool_calls".to_string(), json!(parallel));
         }
+
+        // 仅原生 Responses 可以按模型显式恢复这些能力。Anthropic 桥接会
+        // 丢弃 custom / hosted tools，不能因为目录元数据而重新暴露它们。
+        if profile == CodexCatalogToolProfile::NativeResponses {
+            if let Some(tool_type) = &spec.apply_patch_tool_type {
+                entry_obj.insert("apply_patch_tool_type".to_string(), json!(tool_type));
+            }
+            if let Some(tool_type) = &spec.web_search_tool_type {
+                entry_obj.insert("web_search_tool_type".to_string(), json!(tool_type));
+            }
+            if let Some(supports_search) = spec.supports_search_tool {
+                entry_obj.insert("supports_search_tool".to_string(), json!(supports_search));
+            }
+            if let Some(levels) = &spec.supported_reasoning_levels {
+                entry_obj.insert(
+                    "supported_reasoning_levels".to_string(),
+                    codex_reasoning_levels_to_json(levels),
+                );
+            }
+            if let Some(default_level) = &spec.default_reasoning_level {
+                entry_obj.insert("default_reasoning_level".to_string(), json!(default_level));
+            }
+            if let Some(policy) = &spec.truncation_policy {
+                entry_obj.insert("truncation_policy".to_string(), policy.to_json());
+            }
+            if let Some(support_verbosity) = spec.support_verbosity {
+                entry_obj.insert("support_verbosity".to_string(), json!(support_verbosity));
+            }
+            if let Some(default_verbosity) = &spec.default_verbosity {
+                entry_obj.insert("default_verbosity".to_string(), json!(default_verbosity));
+            }
+            if let Some(version) = &spec.multi_agent_version {
+                entry_obj.insert("multi_agent_version".to_string(), json!(version));
+            }
+            if let Some(version) = &spec.minimal_client_version {
+                entry_obj.insert("minimal_client_version".to_string(), json!(version));
+            }
+        }
     }
 
     entry
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct CodexCatalogModelSpec {
     model: String,
     display_name: String,
@@ -550,6 +664,16 @@ struct CodexCatalogModelSpec {
     /// back to the template default when absent. Only consulted for
     /// `NativeResponses`.
     base_instructions: Option<String>,
+    apply_patch_tool_type: Option<String>,
+    web_search_tool_type: Option<String>,
+    supports_search_tool: Option<bool>,
+    supported_reasoning_levels: Option<Vec<CodexReasoningLevel>>,
+    default_reasoning_level: Option<String>,
+    truncation_policy: Option<CodexTruncationPolicy>,
+    support_verbosity: Option<bool>,
+    default_verbosity: Option<String>,
+    multi_agent_version: Option<String>,
+    minimal_client_version: Option<String>,
 }
 
 fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCatalogModelSpec> {
@@ -619,6 +743,67 @@ fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCa
             .filter(|text| !text.is_empty())
             .map(str::to_string);
 
+        let apply_patch_tool_type = model_config
+            .get("applyPatchToolType")
+            .or_else(|| model_config.get("apply_patch_tool_type"))
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| *value == "freeform")
+            .map(str::to_string);
+        let web_search_tool_type = model_config
+            .get("webSearchToolType")
+            .or_else(|| model_config.get("web_search_tool_type"))
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| matches!(*value, "text" | "text_and_image"))
+            .map(str::to_string);
+        let supports_search_tool = model_config
+            .get("supportsSearchTool")
+            .or_else(|| model_config.get("supports_search_tool"))
+            .and_then(|value| value.as_bool());
+        let supported_reasoning_levels = parse_codex_reasoning_levels(
+            model_config
+                .get("supportedReasoningLevels")
+                .or_else(|| model_config.get("supported_reasoning_levels")),
+        );
+        let default_reasoning_level = model_config
+            .get("defaultReasoningLevel")
+            .or_else(|| model_config.get("default_reasoning_level"))
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let truncation_policy = parse_codex_truncation_policy(
+            model_config
+                .get("truncationPolicy")
+                .or_else(|| model_config.get("truncation_policy")),
+        );
+        let support_verbosity = model_config
+            .get("supportVerbosity")
+            .or_else(|| model_config.get("support_verbosity"))
+            .and_then(|value| value.as_bool());
+        let default_verbosity = model_config
+            .get("defaultVerbosity")
+            .or_else(|| model_config.get("default_verbosity"))
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let multi_agent_version = model_config
+            .get("multiAgentVersion")
+            .or_else(|| model_config.get("multi_agent_version"))
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let minimal_client_version = model_config
+            .get("minimalClientVersion")
+            .or_else(|| model_config.get("minimal_client_version"))
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+
         specs.push(CodexCatalogModelSpec {
             model: model.to_string(),
             display_name: display_name.to_string(),
@@ -626,6 +811,16 @@ fn codex_catalog_model_specs(settings: &Value, config_text: &str) -> Vec<CodexCa
             supports_parallel_tool_calls,
             input_modalities,
             base_instructions,
+            apply_patch_tool_type,
+            web_search_tool_type,
+            supports_search_tool,
+            supported_reasoning_levels,
+            default_reasoning_level,
+            truncation_policy,
+            support_verbosity,
+            default_verbosity,
+            multi_agent_version,
+            minimal_client_version,
         });
     }
 
@@ -879,13 +1074,9 @@ fn load_codex_model_template_static() -> Option<Value> {
     }
 }
 
-/// Bundled clean template for native `/responses` providers. Unlike the
-/// gpt-5.5 template it carries NO freeform `apply_patch` / `web_search` tool
-/// declarations and no GPT-5 base_instructions, so Codex never emits a
-/// `type=="custom"` tool that native gateways (MiMo/MiniMax/…) reject. Edits
-/// flow through `shell_type="shell_command"` instead. We deliberately do NOT
-/// fall back to `models_cache.json` here (that would reintroduce gpt-5.5's
-/// freeform apply_patch).
+/// 原生 `/responses` 的保守基础模板。它不携带 freeform `apply_patch`、
+/// `web_search` 或 GPT-5 身份；支持这些能力的模型由行级元数据显式恢复。
+/// 这里不回退到 `models_cache.json`，避免意外继承 GPT 模型工具集。
 fn load_codex_native_responses_template() -> Value {
     let text = include_str!("resources/codex_native_responses_template.json");
     serde_json::from_str(text).expect("bundled codex native responses template must be valid JSON")
@@ -993,9 +1184,8 @@ fn codex_model_catalog_from_settings(
         return Ok(None);
     }
 
-    // Native providers use the bundled clean template (no freeform apply_patch,
-    // no cache dependency); proxy-chat providers keep cloning Codex's gpt-5.5
-    // entry so the proxy can rewrite custom<->function tools as before.
+    // 原生与 Anthropic profile 从保守模板开始；原生模型随后可按显式元数据
+    // 恢复能力。ProxyChat 继续复制 GPT 模板，由代理转换 custom<->function。
     let template = match profile {
         CodexCatalogToolProfile::NativeResponses | CodexCatalogToolProfile::Anthropic => {
             load_codex_native_responses_template()
@@ -1236,6 +1426,69 @@ fn build_simplified_catalog_from_texts(config_text: &str, catalog_text: &str) ->
             if !mods.is_empty() && mods != inferred {
                 obj.insert("inputModalities".to_string(), json!(mods));
             }
+        }
+
+        if let Some(tool_type) = entry
+            .get("apply_patch_tool_type")
+            .and_then(|v| v.as_str())
+            .filter(|value| *value == "freeform")
+        {
+            obj.insert("applyPatchToolType".to_string(), json!(tool_type));
+        }
+        if let Some(tool_type) = entry
+            .get("web_search_tool_type")
+            .and_then(|v| v.as_str())
+            .filter(|value| matches!(*value, "text" | "text_and_image"))
+        {
+            obj.insert("webSearchToolType".to_string(), json!(tool_type));
+        }
+        if let Some(supports_search) = entry.get("supports_search_tool").and_then(|v| v.as_bool()) {
+            obj.insert("supportsSearchTool".to_string(), json!(supports_search));
+        }
+        if let Some(levels) = parse_codex_reasoning_levels(entry.get("supported_reasoning_levels"))
+        {
+            obj.insert(
+                "supportedReasoningLevels".to_string(),
+                codex_reasoning_levels_to_json(&levels),
+            );
+        }
+        if let Some(default_level) = entry
+            .get("default_reasoning_level")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            obj.insert("defaultReasoningLevel".to_string(), json!(default_level));
+        }
+        if let Some(policy) = parse_codex_truncation_policy(entry.get("truncation_policy")) {
+            obj.insert("truncationPolicy".to_string(), policy.to_json());
+        }
+        if let Some(support_verbosity) = entry.get("support_verbosity").and_then(|v| v.as_bool()) {
+            obj.insert("supportVerbosity".to_string(), json!(support_verbosity));
+        }
+        if let Some(default_verbosity) = entry
+            .get("default_verbosity")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            obj.insert("defaultVerbosity".to_string(), json!(default_verbosity));
+        }
+        if let Some(version) = entry
+            .get("multi_agent_version")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            obj.insert("multiAgentVersion".to_string(), json!(version));
+        }
+        if let Some(version) = entry
+            .get("minimal_client_version")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            obj.insert("minimalClientVersion".to_string(), json!(version));
         }
 
         entries.push(Value::Object(obj));
@@ -2840,6 +3093,7 @@ base_url = "https://production.api/v1"
             supports_parallel_tool_calls: None,
             input_modalities: None,
             base_instructions: None,
+            ..Default::default()
         }];
         let catalog =
             codex_model_catalog_from_specs(&specs, &template, CodexCatalogToolProfile::ProxyChat);
@@ -3023,6 +3277,137 @@ base_url = "https://production.api/v1"
     }
 
     #[test]
+    fn catalog_structured_capability_parsers_reject_invalid_shapes() {
+        let levels = parse_codex_reasoning_levels(Some(&json!([
+            { "effort": " low ", "description": " Light reasoning " },
+            { "effort": "", "description": "missing effort" },
+            { "effort": "high", "description": "   " }
+        ])))
+        .expect("至少应保留一个有效 reasoning level");
+        assert_eq!(
+            levels,
+            vec![CodexReasoningLevel {
+                effort: "low".to_string(),
+                description: "Light reasoning".to_string(),
+            }]
+        );
+        assert_eq!(
+            codex_reasoning_levels_to_json(&levels),
+            json!([{ "effort": "low", "description": "Light reasoning" }])
+        );
+
+        assert_eq!(
+            parse_codex_truncation_policy(Some(&json!({
+                "mode": "tokens",
+                "limit": 10_000
+            }))),
+            Some(CodexTruncationPolicy {
+                mode: CodexTruncationMode::Tokens,
+                limit: 10_000,
+            })
+        );
+        assert!(parse_codex_truncation_policy(Some(&json!({
+            "mode": "characters",
+            "limit": 10_000
+        })))
+        .is_none());
+    }
+
+    #[test]
+    fn native_responses_profile_applies_explicit_catalog_capabilities() {
+        let settings = json!({
+            "modelCatalog": {
+                "models": [
+                    {
+                        "model": "deepseek-v4-flash",
+                        "displayName": "DeepSeek V4 Flash",
+                        "contextWindow": 1_048_576,
+                        "supportsParallelToolCalls": true,
+                        "inputModalities": ["text"],
+                        "applyPatchToolType": "freeform",
+                        "webSearchToolType": "text",
+                        "supportsSearchTool": true,
+                        "defaultReasoningLevel": "high",
+                        "supportedReasoningLevels": [
+                            {
+                                "effort": "low",
+                                "description": "Fast responses with lighter reasoning"
+                            },
+                            {
+                                "effort": "high",
+                                "description": "Extra high reasoning depth for complex problems"
+                            },
+                            {
+                                "effort": "max",
+                                "description": "Maximum reasoning depth for the hardest problems"
+                            }
+                        ],
+                        "truncationPolicy": { "mode": "tokens", "limit": 10_000 },
+                        "supportVerbosity": true,
+                        "defaultVerbosity": "low",
+                        "multiAgentVersion": "v2",
+                        "minimalClientVersion": "0.144.0"
+                    }
+                ]
+            }
+        });
+
+        let catalog = codex_model_catalog_from_settings(
+            &settings,
+            "",
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("native catalog generation should not error")
+        .expect("non-empty modelCatalog must yield a catalog");
+        let entry = &catalog["models"][0];
+
+        assert_eq!(entry["apply_patch_tool_type"], json!("freeform"));
+        assert_eq!(entry["web_search_tool_type"], json!("text"));
+        assert_eq!(entry["supports_search_tool"], json!(true));
+        assert_eq!(entry["supports_parallel_tool_calls"], json!(true));
+        assert_eq!(entry["input_modalities"], json!(["text"]));
+        assert_eq!(entry["default_reasoning_level"], json!("high"));
+        assert_eq!(
+            entry["supported_reasoning_levels"],
+            settings["modelCatalog"]["models"][0]["supportedReasoningLevels"]
+        );
+        assert_eq!(
+            entry["truncation_policy"],
+            json!({ "mode": "tokens", "limit": 10_000 })
+        );
+        assert_eq!(entry["support_verbosity"], json!(true));
+        assert_eq!(entry["default_verbosity"], json!("low"));
+        assert_eq!(entry["multi_agent_version"], json!("v2"));
+        assert_eq!(entry["minimal_client_version"], json!("0.144.0"));
+    }
+
+    #[test]
+    fn anthropic_profile_ignores_native_tool_capability_overrides() {
+        let settings = json!({
+            "modelCatalog": {
+                "models": [
+                    {
+                        "model": "deepseek-v4-flash",
+                        "applyPatchToolType": "freeform",
+                        "webSearchToolType": "text",
+                        "supportsSearchTool": true
+                    }
+                ]
+            }
+        });
+
+        let catalog =
+            codex_model_catalog_from_settings(&settings, "", CodexCatalogToolProfile::Anthropic)
+                .expect("Anthropic catalog generation should not error")
+                .expect("non-empty modelCatalog must yield a catalog");
+        let entry = &catalog["models"][0];
+
+        assert!(entry.get("apply_patch_tool_type").is_none());
+        assert!(entry.get("web_search_tool_type").is_none());
+        assert_eq!(entry["supports_search_tool"], json!(false));
+    }
+
+    #[test]
     fn catalog_infers_image_input_independently_of_tool_profile() {
         // Start from a deliberately text-only template to prove that every
         // profile overwrites template defaults with shared capability logic.
@@ -3038,6 +3423,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: None,
                 base_instructions: None,
+                ..Default::default()
             },
             CodexCatalogModelSpec {
                 model: "deepseek/deepseek-v4-pro".to_string(),
@@ -3046,6 +3432,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: None,
                 base_instructions: None,
+                ..Default::default()
             },
             CodexCatalogModelSpec {
                 model: "glm-5.2v".to_string(),
@@ -3054,6 +3441,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: None,
                 base_instructions: None,
+                ..Default::default()
             },
             CodexCatalogModelSpec {
                 model: "deepseek-v4-flash".to_string(),
@@ -3062,6 +3450,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: Some(vec!["text".to_string(), "image".to_string()]),
                 base_instructions: None,
+                ..Default::default()
             },
             CodexCatalogModelSpec {
                 model: "custom-text-alias".to_string(),
@@ -3070,6 +3459,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: Some(vec!["text".to_string()]),
                 base_instructions: None,
+                ..Default::default()
             },
         ];
 
@@ -3141,6 +3531,7 @@ base_url = "https://production.api/v1"
             supports_parallel_tool_calls: None,
             input_modalities: None,
             base_instructions: None,
+            ..Default::default()
         }];
         // Using a gpt-5.5-shaped template under ProxyChat must NOT strip
         // apply_patch_tool_type. (The native template lacks it, so synthesize
@@ -3190,9 +3581,7 @@ name = "any"
 
     #[test]
     fn native_web_search_field_disables_at_top_level() {
-        // Native `/responses` gateways reject the web_search tool, so the
-        // NativeResponses profile must write the top-level disable line even
-        // when sections are present (it must NOT land inside a section).
+        // 对拒绝 Web Search 的原生网关，禁用项必须写在顶层，不能落入 section。
         let input = r#"model_provider = "custom"
 
 [model_providers.custom]
@@ -3340,6 +3729,7 @@ web_search = "disabled"
                 "doubao-seed-2-1-pro-260628",
                 "https://ark.cn-beijing.volces.com/api/v3",
             ),
+            ("deepseek-v4-flash", "https://api.deepseek.com"),
             ("Pro/moonshotai/Kimi-K2.6", "https://api.siliconflow.cn/v1"),
         ] {
             assert!(
@@ -3482,6 +3872,53 @@ web_search = "disabled"
             Some(&json!(["text", "image"])),
             "an explicit image override for a registered text-only model must round-trip"
         );
+    }
+
+    #[test]
+    fn build_simplified_catalog_preserves_native_response_capabilities() {
+        let catalog = r#"{
+            "models": [
+                {
+                    "slug": "deepseek-v4-flash",
+                    "apply_patch_tool_type": "freeform",
+                    "web_search_tool_type": "text",
+                    "supports_search_tool": true,
+                    "supported_reasoning_levels": [
+                        { "effort": "low", "description": "Fast responses" },
+                        { "effort": "high", "description": "Deep reasoning" }
+                    ],
+                    "default_reasoning_level": "high",
+                    "truncation_policy": { "mode": "tokens", "limit": 10000 },
+                    "support_verbosity": true,
+                    "default_verbosity": "low",
+                    "multi_agent_version": "v2",
+                    "minimal_client_version": "0.144.0"
+                }
+            ]
+        }"#;
+
+        let result = build_simplified_catalog_from_texts("", catalog).expect("entry");
+        let entry = &result["models"][0];
+
+        assert_eq!(entry["applyPatchToolType"], json!("freeform"));
+        assert_eq!(entry["webSearchToolType"], json!("text"));
+        assert_eq!(entry["supportsSearchTool"], json!(true));
+        assert_eq!(
+            entry["supportedReasoningLevels"],
+            json!([
+                { "effort": "low", "description": "Fast responses" },
+                { "effort": "high", "description": "Deep reasoning" }
+            ])
+        );
+        assert_eq!(entry["defaultReasoningLevel"], json!("high"));
+        assert_eq!(
+            entry["truncationPolicy"],
+            json!({ "mode": "tokens", "limit": 10000 })
+        );
+        assert_eq!(entry["supportVerbosity"], json!(true));
+        assert_eq!(entry["defaultVerbosity"], json!("low"));
+        assert_eq!(entry["multiAgentVersion"], json!("v2"));
+        assert_eq!(entry["minimalClientVersion"], json!("0.144.0"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -3570,7 +3570,7 @@ mod tests {
     use super::*;
     use crate::database::Database;
     use crate::provider::LocalProxyRequestOverrides;
-    use axum::http::header::{HeaderValue, ACCEPT};
+    use axum::http::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
     use axum::http::HeaderMap;
     use bytes::Bytes;
     use http::StatusCode;
@@ -3932,6 +3932,133 @@ mod tests {
             prepared.bytes().await.unwrap(),
             Bytes::from_static(b"firstsecond")
         );
+    }
+
+    #[tokio::test]
+    async fn deepseek_native_responses_preserves_request_and_sse_for_both_paths() {
+        const SSE: &str = concat!(
+            ": keep-alive\n\n",
+            "event: response.output_text.delta\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"OK\",\"sequence_number\":1}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_test\",\"model\":\"deepseek-v4-flash\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}},\"sequence_number\":2}\n\n",
+        );
+
+        let (capture_tx, mut capture_rx) = tokio::sync::mpsc::channel(2);
+        let app = axum::Router::new().fallback(axum::routing::post({
+            let capture_tx = capture_tx.clone();
+            move |uri: http::Uri, body: axum::body::Bytes| {
+                let capture_tx = capture_tx.clone();
+                async move {
+                    let body: Value = serde_json::from_slice(&body).expect("上游应收到合法 JSON");
+                    capture_tx
+                        .send((uri.path().to_string(), body))
+                        .await
+                        .expect("测试接收端应保持在线");
+                    ([(CONTENT_TYPE, "text/event-stream")], SSE)
+                }
+            }
+        }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("应能绑定本地测试端口");
+        let address = listener.local_addr().expect("应能读取本地测试地址");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("本地测试上游应正常运行");
+        });
+
+        let base_url = format!("http://{address}");
+        let mut provider = test_provider_with_type(None);
+        provider.name = "DeepSeek".to_string();
+        provider.settings_config = json!({
+            "auth": { "OPENAI_API_KEY": "sk-test" },
+            "config": format!(r#"
+model_provider = "deepseek"
+model = "deepseek-v4-flash"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "{base_url}"
+wire_api = "responses"
+requires_openai_auth = true
+"#)
+        });
+        provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+
+        let request_body = json!({
+            "model": "deepseek-v4-flash",
+            "stream": true,
+            "input": [
+                { "role": "user", "content": "Use the workspace tool" },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "done"
+                }
+            ],
+            "reasoning": { "effort": "high" },
+            "tools": [
+                {
+                    "type": "namespace",
+                    "name": "workspace",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "read_file",
+                            "parameters": { "type": "object", "properties": {} }
+                        }
+                    ]
+                },
+                { "type": "custom", "name": "apply_patch" },
+                { "type": "web_search" }
+            ]
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let forwarder = test_forwarder(Duration::from_secs(2), Duration::from_secs(2));
+        let adapter = super::super::providers::CodexAdapter::new();
+
+        for endpoint in ["/responses", "/v1/responses"] {
+            let (response, api_format, outbound_model) = forwarder
+                .forward(
+                    &AppType::Codex,
+                    &http::Method::POST,
+                    &provider,
+                    endpoint,
+                    &request_body,
+                    &headers,
+                    &Extensions::new(),
+                    &adapter,
+                )
+                .await
+                .expect("DeepSeek 原生 Responses 应成功透传");
+
+            let (path, captured_body) =
+                tokio::time::timeout(Duration::from_secs(1), capture_rx.recv())
+                    .await
+                    .expect("应及时收到上游请求")
+                    .expect("上游捕获通道不应提前关闭");
+            assert_eq!(path, "/v1/responses");
+            assert_eq!(
+                captured_body, request_body,
+                "{endpoint} 的 Responses items、call_id、reasoning 与工具声明必须原样到达上游"
+            );
+            assert_eq!(api_format, None);
+            assert_eq!(outbound_model.as_deref(), Some("deepseek-v4-flash"));
+            assert_eq!(
+                response.bytes().await.expect("应能读取 SSE 响应"),
+                Bytes::from_static(SSE.as_bytes()),
+                "{endpoint} 的命名事件、keep-alive 与 sequence_number 必须原样返回"
+            );
+        }
+
+        server.abort();
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/handler_config.rs
+++ b/src-tauri/src/proxy/handler_config.rs
@@ -3,7 +3,9 @@
 //! 定义各 API 处理器的配置结构和使用量解析器
 
 use crate::app_config::AppType;
-use crate::proxy::usage::parser::TokenUsage;
+use crate::proxy::usage::parser::{
+    codex_stream_contains_terminal_event, is_codex_responses_terminal_event_type, TokenUsage,
+};
 use serde_json::Value;
 
 /// 使用量解析器类型别名
@@ -48,7 +50,7 @@ fn openai_stream_usage_event_filter(data: &str) -> bool {
 }
 
 pub fn codex_stream_usage_event_filter(data: &str) -> bool {
-    data.contains("\"response.completed\"") || data.contains("\"usage\"")
+    codex_stream_contains_terminal_event(data) || data.contains("\"usage\"")
 }
 
 fn gemini_stream_usage_event_filter(data: &str) -> bool {
@@ -97,11 +99,11 @@ fn codex_auto_model_extractor(events: &[Value], fallback_model: &str) -> String 
             return model;
         }
     }
-    // 回退：从 response.completed 事件中提取
+    // 回退：从 Responses 终态事件中提取
     events
         .iter()
         .find_map(|e| {
-            if e.get("type")?.as_str()? == "response.completed" {
+            if is_codex_responses_terminal_event_type(e.get("type")?.as_str()?) {
                 e.get("response")?
                     .get("model")?
                     .as_str()
@@ -226,3 +228,69 @@ pub const GEMINI_HANDLER_CONFIG: HandlerConfig = HandlerConfig {
     app_type_str: "gemini",
     parser_config: &GEMINI_PARSER_CONFIG,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_usage_filter_keeps_incomplete_without_usage() {
+        // 即使上游省略 usage，也要保留终态供实际模型提取器使用。
+        let event = r#"{"type":"response.incomplete","response":{"model":"deepseek-v4-flash"}}"#;
+
+        assert!(codex_stream_usage_event_filter(event));
+    }
+
+    #[test]
+    fn codex_usage_filter_keeps_failed_without_usage() {
+        // 失败终态可能没有 usage，但仍可能包含上游实际模型。
+        let event = r#"{"type":"response.failed","response":{"model":"deepseek-v4-flash"}}"#;
+
+        assert!(codex_stream_usage_event_filter(event));
+    }
+
+    #[test]
+    fn codex_model_extractor_reads_incomplete_response_model() {
+        let events = vec![serde_json::json!({
+            "type": "response.incomplete",
+            "response": {
+                "model": "deepseek-v4-flash"
+            }
+        })];
+
+        assert_eq!(
+            codex_auto_model_extractor(&events, "request-alias"),
+            "deepseek-v4-flash"
+        );
+    }
+
+    #[test]
+    fn codex_model_extractor_reads_failed_response_model() {
+        let events = vec![serde_json::json!({
+            "type": "response.failed",
+            "response": {
+                "model": "deepseek-v4-flash"
+            }
+        })];
+
+        assert_eq!(
+            codex_auto_model_extractor(&events, "request-alias"),
+            "deepseek-v4-flash"
+        );
+    }
+
+    #[test]
+    fn codex_model_extractor_falls_back_when_terminal_model_is_empty() {
+        let events = vec![serde_json::json!({
+            "type": "response.incomplete",
+            "response": {
+                "model": ""
+            }
+        })];
+
+        assert_eq!(
+            codex_auto_model_extractor(&events, "request-alias"),
+            "request-alias"
+        );
+    }
+}

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -1369,6 +1369,43 @@ wire_api = "chat"
     }
 
     #[test]
+    fn deepseek_native_responses_paths_bypass_protocol_and_namespace_transforms() {
+        let mut provider = create_provider(json!({
+            "auth": { "OPENAI_API_KEY": "sk-test" },
+            "config": r#"
+model_provider = "deepseek"
+model = "deepseek-v4-flash"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+        }));
+        provider.name = "DeepSeek".to_string();
+        provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+
+        for endpoint in ["/responses", "/v1/responses"] {
+            assert!(
+                !should_convert_codex_responses_to_chat(&provider, endpoint),
+                "{endpoint} 不应进入 Responses → Chat 转换"
+            );
+            assert!(
+                !should_convert_codex_responses_to_anthropic(&provider, endpoint),
+                "{endpoint} 不应进入 Responses → Anthropic 转换"
+            );
+        }
+        assert!(
+            !provider_needs_responses_namespace_flatten(&provider),
+            "DeepSeek 原生 Responses 支持 custom/web_search，不能套用 xAI namespace 清洗"
+        );
+    }
+
+    #[test]
     fn test_apply_codex_chat_upstream_model_uses_provider_config_model() {
         let mut provider = create_provider(json!({
             "config": r#"

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -9,6 +9,20 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+const CODEX_RESPONSES_TERMINAL_EVENT_TYPES: [&str; 3] = [
+    "response.completed",
+    "response.incomplete",
+    "response.failed",
+];
+
+pub(crate) fn is_codex_responses_terminal_event_type(event_type: &str) -> bool {
+    CODEX_RESPONSES_TERMINAL_EVENT_TYPES.contains(&event_type)
+}
+
+pub(crate) fn codex_stream_contains_terminal_event(data: &str) -> bool {
+    data.split('"').any(is_codex_responses_terminal_event_type)
+}
+
 fn openai_cache_read_tokens(usage: &Value) -> u32 {
     usage
         .get("cache_read_input_tokens")
@@ -305,12 +319,12 @@ impl TokenUsage {
     pub fn from_codex_stream_events_auto(events: &[Value]) -> Option<Self> {
         log::debug!("[Codex] 智能解析流式事件，共 {} 个事件", events.len());
 
-        // 先尝试 Codex Responses API 格式 (response.completed 事件)
+        // 先尝试 Codex Responses API 格式；所有终态都可能携带已产生的 usage。
         for event in events {
             if let Some(event_type) = event.get("type").and_then(|v| v.as_str()) {
-                if event_type == "response.completed" {
+                if is_codex_responses_terminal_event_type(event_type) {
                     if let Some(response) = event.get("response") {
-                        log::debug!("[Codex] 找到 response.completed 事件");
+                        log::debug!("[Codex] 找到 Responses 终态事件: {event_type}");
                         return Self::from_codex_response_auto(response);
                     }
                 }
@@ -1070,6 +1084,86 @@ mod tests {
         assert_eq!(usage.output_tokens, 500);
         assert_eq!(usage.cache_read_tokens, 200);
         assert_eq!(usage.model, Some("o3".to_string()));
+    }
+
+    #[test]
+    fn test_codex_stream_events_auto_incomplete_format() {
+        // Responses 被输出上限截断时仍会在终态携带完整 usage，不能漏记。
+        let events = vec![json!({
+            "type": "response.incomplete",
+            "response": {
+                "id": "resp_incomplete",
+                "status": "incomplete",
+                "model": "deepseek-v4-flash",
+                "incomplete_details": {
+                    "reason": "max_output_tokens"
+                },
+                "usage": {
+                    "input_tokens": 23,
+                    "output_tokens": 8,
+                    "input_tokens_details": {
+                        "cached_tokens": 7
+                    }
+                }
+            }
+        })];
+
+        let usage = TokenUsage::from_codex_stream_events_auto(&events).unwrap();
+        assert_eq!(usage.input_tokens, 23);
+        assert_eq!(usage.output_tokens, 8);
+        assert_eq!(usage.cache_read_tokens, 7);
+        assert_eq!(usage.model.as_deref(), Some("deepseek-v4-flash"));
+        assert_eq!(usage.message_id.as_deref(), Some("resp_incomplete"));
+    }
+
+    #[test]
+    fn test_codex_stream_events_auto_failed_format_with_usage() {
+        // 上游失败前已经消耗 token 时，response.failed 中的完整 usage 仍应计入。
+        let events = vec![json!({
+            "type": "response.failed",
+            "response": {
+                "id": "resp_failed",
+                "status": "failed",
+                "model": "deepseek-v4-flash",
+                "error": {
+                    "type": "server_error",
+                    "message": "upstream failed"
+                },
+                "usage": {
+                    "input_tokens": 31,
+                    "output_tokens": 5,
+                    "input_tokens_details": {
+                        "cached_tokens": 11
+                    }
+                }
+            }
+        })];
+
+        let usage = TokenUsage::from_codex_stream_events_auto(&events).unwrap();
+        assert_eq!(usage.input_tokens, 31);
+        assert_eq!(usage.output_tokens, 5);
+        assert_eq!(usage.cache_read_tokens, 11);
+        assert_eq!(usage.model.as_deref(), Some("deepseek-v4-flash"));
+        assert_eq!(usage.message_id.as_deref(), Some("resp_failed"));
+    }
+
+    #[test]
+    fn test_codex_stream_events_auto_failed_without_usage_is_none() {
+        // 没有完整 usage 的失败终态不能凭空合成 token 数。
+        let events = vec![json!({
+            "type": "response.failed",
+            "response": {
+                "id": "resp_failed_without_usage",
+                "status": "failed",
+                "model": "deepseek-v4-flash",
+                "error": {
+                    "type": "server_error",
+                    "message": "upstream failed"
+                }
+            }
+        })];
+
+        assert!(TokenUsage::from_codex_stream_events_auto(&events).is_none());
     }
 
     #[test]

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -46,6 +46,10 @@ import type {
   ProviderCategory,
 } from "@/types";
 import type { AppId } from "@/lib/api";
+import {
+  codexCatalogCapabilitiesEqual,
+  normalizeCodexCatalogCapabilities,
+} from "@/utils/codexCatalogCapabilities";
 
 interface EndpointCandidate {
   url: string;
@@ -126,22 +130,12 @@ function createCatalogRow(seed?: Partial<CodexCatalogModel>): CodexCatalogRow {
     model: seed?.model ?? "",
     displayName: seed?.displayName ?? "",
     contextWindow: seed?.contextWindow ?? "",
-    // Carry native-profile overrides verbatim (not user-editable in the row UI,
-    // but must survive load->save so the official catalog fidelity is kept).
-    ...(seed?.supportsParallelToolCalls !== undefined
-      ? { supportsParallelToolCalls: seed.supportsParallelToolCalls }
-      : {}),
-    ...(seed?.inputModalities ? { inputModalities: seed.inputModalities } : {}),
-    ...(seed?.baseInstructions
-      ? { baseInstructions: seed.baseInstructions }
-      : {}),
+    // 隐藏能力不可在行 UI 中编辑，但必须随可见字段一起完成 load→save。
+    ...normalizeCodexCatalogCapabilities(seed),
   };
 }
 
-// Compares rows (with rowId) to incoming models (without) by data fields only,
-// so both sync effects can use the same equality definition. Hidden native-profile
-// fields are included so switching between providers with identical visible fields
-// but different base_instructions / tools / modalities still rebuilds the rows.
+// 仅比较持久化字段；切换到可见字段相同、隐藏能力不同的预设时也要重建行。
 function catalogRowsMatchModels(
   rows: CodexCatalogModel[],
   models: CodexCatalogModel[],
@@ -154,11 +148,7 @@ function catalogRowsMatchModels(
       (row.displayName ?? "") === (incoming.displayName ?? "") &&
       String(row.contextWindow ?? "") ===
         String(incoming.contextWindow ?? "") &&
-      (row.supportsParallelToolCalls ?? null) ===
-        (incoming.supportsParallelToolCalls ?? null) &&
-      (row.baseInstructions ?? "") === (incoming.baseInstructions ?? "") &&
-      JSON.stringify(row.inputModalities ?? []) ===
-        JSON.stringify(incoming.inputModalities ?? [])
+      codexCatalogCapabilitiesEqual(row, incoming)
     );
   });
 }

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -68,6 +68,7 @@ import {
 } from "@/utils/providerConfigUtils";
 import { isNonNegativeDecimalString } from "@/types/usage";
 import { getCodexCustomTemplate } from "@/config/codexTemplates";
+import { normalizeCodexCatalogCapabilities } from "@/utils/codexCatalogCapabilities";
 import CodexConfigEditor from "./CodexConfigEditor";
 import { CommonConfigEditor } from "./CommonConfigEditor";
 import GeminiConfigEditor from "./GeminiConfigEditor";
@@ -155,24 +156,14 @@ export const normalizeCodexCatalogModelsForSave = (
       ? Number.parseInt(rawContextWindow, 10)
       : undefined;
 
-    const inputModalities = item.inputModalities?.filter(
-      (m) => typeof m === "string" && m.trim(),
-    );
-
-    const baseInstructions = item.baseInstructions?.trim();
+    const capabilities = normalizeCodexCatalogCapabilities(item);
 
     normalized.push({
       model,
       ...(displayName ? { displayName } : {}),
       ...(contextWindow && contextWindow > 0 ? { contextWindow } : {}),
-      // Native Responses profile overrides (ignored by the chat/proxy profile).
-      ...(typeof item.supportsParallelToolCalls === "boolean"
-        ? { supportsParallelToolCalls: item.supportsParallelToolCalls }
-        : {}),
-      ...(inputModalities && inputModalities.length > 0
-        ? { inputModalities }
-        : {}),
-      ...(baseInstructions ? { baseInstructions } : {}),
+      // 原生 Responses profile 的隐藏能力；Chat/代理 profile 会忽略这些字段。
+      ...capabilities,
     });
   }
 

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -8,6 +8,7 @@ import {
   updateCodexExperimentalBearerToken,
 } from "@/utils/providerConfigUtils";
 import { normalizeTomlText } from "@/utils/textNormalization";
+import { normalizeCodexCatalogCapabilities } from "@/utils/codexCatalogCapabilities";
 import type { CodexCatalogModel } from "@/types";
 
 interface UseCodexConfigStateProps {
@@ -70,49 +71,30 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
         : [];
       setCodexCatalogModels(
         rawCatalogModels
-          .map((item: any) => {
-            // 隐藏字段（原生 Responses profile 用）不在行 UI 暴露，但必须 load→save
-            // 原样保留，否则编辑保存 MiMo/MiniMax 等会丢官方 base_instructions、
-            // 并行工具、图像模态。DB SSOT 为 camelCase、live 反解兜底可能为 snake_case，
-            // 双格式兼容（与 displayName/contextWindow 一致）。
-            const supportsParallelToolCalls =
-              typeof item?.supportsParallelToolCalls === "boolean"
-                ? item.supportsParallelToolCalls
-                : typeof item?.supports_parallel_tool_calls === "boolean"
-                  ? item.supports_parallel_tool_calls
-                  : undefined;
-            const inputModalities = Array.isArray(item?.inputModalities)
-              ? item.inputModalities
-              : Array.isArray(item?.input_modalities)
-                ? item.input_modalities
-                : undefined;
-            const baseInstructions =
-              typeof item?.baseInstructions === "string"
-                ? item.baseInstructions
-                : typeof item?.base_instructions === "string"
-                  ? item.base_instructions
-                  : undefined;
+          .map((item: unknown) => {
+            const source =
+              typeof item === "object" && item !== null && !Array.isArray(item)
+                ? (item as Record<string, unknown>)
+                : {};
+            // 隐藏能力不在行 UI 暴露，但必须在加载、编辑和保存之间完整保留。
+            const capabilities = normalizeCodexCatalogCapabilities(source);
             return {
-              model: typeof item?.model === "string" ? item.model : "",
+              model: typeof source.model === "string" ? source.model : "",
               displayName:
-                typeof item?.displayName === "string"
-                  ? item.displayName
-                  : typeof item?.display_name === "string"
-                    ? item.display_name
+                typeof source.displayName === "string"
+                  ? source.displayName
+                  : typeof source.display_name === "string"
+                    ? source.display_name
                     : "",
               contextWindow:
-                typeof item?.contextWindow === "string" ||
-                typeof item?.contextWindow === "number"
-                  ? item.contextWindow
-                  : typeof item?.context_window === "string" ||
-                      typeof item?.context_window === "number"
-                    ? item.context_window
+                typeof source.contextWindow === "string" ||
+                typeof source.contextWindow === "number"
+                  ? source.contextWindow
+                  : typeof source.context_window === "string" ||
+                      typeof source.context_window === "number"
+                    ? source.context_window
                     : "",
-              ...(supportsParallelToolCalls !== undefined
-                ? { supportsParallelToolCalls }
-                : {}),
-              ...(inputModalities ? { inputModalities } : {}),
-              ...(baseInstructions ? { baseInstructions } : {}),
+              ...capabilities,
             };
           })
           .filter((item: CodexCatalogModel) => item.model.trim()),

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -37,7 +37,7 @@ export interface CodexProviderPreset {
   providerType?: "xai_oauth";
   // OAuth 预设：隐藏 API Key 输入，保存前要求已登录托管账号
   requiresOAuth?: boolean;
-  // Codex Chat 本地路由模式下的模型目录
+  // Codex 生成模型目录所需的模型与隐藏能力元数据
   modelCatalog?: CodexCatalogModel[];
   // Codex Responses -> Chat Completions reasoning capability defaults
   codexChatReasoning?: CodexChatReasoning;
@@ -77,35 +77,10 @@ requires_openai_auth = true`;
 }
 
 function modelCatalog(
-  models: Array<
-    | string
-    | {
-        model: string;
-        displayName?: string;
-        contextWindow?: number;
-        // Native Responses (direct) overrides for the generated
-        // model-catalogs.json. Omitted input modalities are inferred by the
-        // backend: confirmed text-only models stay text-only; everything else
-        // defaults to text+image.
-        supportsParallelToolCalls?: boolean;
-        inputModalities?: string[];
-        // Vendor's OFFICIAL base_instructions; omit to inherit the neutral
-        // template default. Required by Codex, so the backend always emits one.
-        baseInstructions?: string;
-      }
-  >,
+  models: Array<string | CodexCatalogModel>,
 ): CodexCatalogModel[] {
   return models.map((entry) =>
-    typeof entry === "string"
-      ? { model: entry }
-      : {
-          model: entry.model,
-          displayName: entry.displayName,
-          contextWindow: entry.contextWindow,
-          supportsParallelToolCalls: entry.supportsParallelToolCalls,
-          inputModalities: entry.inputModalities,
-          baseInstructions: entry.baseInstructions,
-        },
+    typeof entry === "string" ? { model: entry } : { ...entry },
   );
 }
 
@@ -969,17 +944,60 @@ requires_openai_auth = true`,
       "deepseek-v4-flash",
     ),
     endpointCandidates: ["https://api.deepseek.com"],
-    apiFormat: "openai_chat",
+    apiFormat: "openai_responses",
     modelCatalog: modelCatalog([
       {
         model: "deepseek-v4-flash",
         displayName: "DeepSeek V4 Flash",
-        contextWindow: 1000000,
+        contextWindow: 1048576,
+        supportsParallelToolCalls: true,
+        inputModalities: ["text"],
+        applyPatchToolType: "freeform",
+        webSearchToolType: "text",
+        supportsSearchTool: true,
+        supportVerbosity: true,
+        defaultVerbosity: "low",
+        defaultReasoningLevel: "high",
+        supportedReasoningLevels: [
+          {
+            effort: "low",
+            description: "Fast responses with lighter reasoning",
+          },
+          {
+            effort: "high",
+            description: "Extra high reasoning depth for complex problems",
+          },
+          {
+            effort: "max",
+            description: "Maximum reasoning depth for the hardest problems",
+          },
+        ],
+        truncationPolicy: { mode: "tokens", limit: 10000 },
+        multiAgentVersion: "v2",
+        minimalClientVersion: "0.144.0",
       },
+    ]),
+    category: "cn_official",
+    icon: "deepseek",
+    iconColor: "#1E88E5",
+  },
+  {
+    name: "DeepSeek V4 Pro",
+    websiteUrl: "https://platform.deepseek.com",
+    apiKeyUrl: "https://platform.deepseek.com/api_keys",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "deepseek",
+      "https://api.deepseek.com",
+      "deepseek-v4-pro",
+    ),
+    endpointCandidates: ["https://api.deepseek.com"],
+    apiFormat: "openai_chat",
+    modelCatalog: modelCatalog([
       {
         model: "deepseek-v4-pro",
         displayName: "DeepSeek V4 Pro",
-        contextWindow: 1000000,
+        contextWindow: 1048576,
       },
     ]),
     codexChatReasoning: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,6 +269,24 @@ export interface CodexCatalogModel {
   // Codex requires this field in every catalog entry; when omitted the backend
   // falls back to a neutral default. e.g. MiMo "developed by Xiaomi".
   baseInstructions?: string;
+  // 原生 Responses 模型显式声明后，后端才会恢复对应的 Codex 工具能力；
+  // 未声明时继续使用保守模板，避免不兼容网关收到 custom / hosted tools。
+  applyPatchToolType?: "freeform";
+  webSearchToolType?: "text" | "text_and_image";
+  supportsSearchTool?: boolean;
+  supportVerbosity?: boolean;
+  defaultVerbosity?: string;
+  supportedReasoningLevels?: Array<{
+    effort: string;
+    description: string;
+  }>;
+  defaultReasoningLevel?: string;
+  truncationPolicy?: {
+    mode: "tokens" | "bytes";
+    limit: number;
+  };
+  multiAgentVersion?: string;
+  minimalClientVersion?: string;
 }
 
 // Claude 认证字段类型

--- a/src/utils/codexCatalogCapabilities.ts
+++ b/src/utils/codexCatalogCapabilities.ts
@@ -1,0 +1,157 @@
+import type { CodexCatalogModel } from "@/types";
+
+type CapabilityKey =
+  | "supportsParallelToolCalls"
+  | "inputModalities"
+  | "baseInstructions"
+  | "applyPatchToolType"
+  | "webSearchToolType"
+  | "supportsSearchTool"
+  | "supportVerbosity"
+  | "defaultVerbosity"
+  | "supportedReasoningLevels"
+  | "defaultReasoningLevel"
+  | "truncationPolicy"
+  | "multiAgentVersion"
+  | "minimalClientVersion";
+
+export type CodexCatalogCapabilities = Pick<CodexCatalogModel, CapabilityKey>;
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const readAlias = (
+  source: Record<string, unknown>,
+  camelCase: string,
+  snakeCase: string,
+): unknown => source[camelCase] ?? source[snakeCase];
+
+const normalizeString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized || undefined;
+};
+
+/**
+ * 统一解析模型目录中的隐藏能力字段。
+ * 数据库使用 camelCase，Codex 实时目录反解时可能提供 snake_case。
+ */
+export function normalizeCodexCatalogCapabilities(
+  value: unknown,
+): CodexCatalogCapabilities {
+  const source = asRecord(value) ?? {};
+  const supportsParallelToolCalls = readAlias(
+    source,
+    "supportsParallelToolCalls",
+    "supports_parallel_tool_calls",
+  );
+  const rawInputModalities = readAlias(
+    source,
+    "inputModalities",
+    "input_modalities",
+  );
+  const inputModalities = Array.isArray(rawInputModalities)
+    ? rawInputModalities.flatMap((item) => {
+        const modality = normalizeString(item);
+        return modality ? [modality] : [];
+      })
+    : [];
+  const baseInstructions = normalizeString(
+    readAlias(source, "baseInstructions", "base_instructions"),
+  );
+  const rawApplyPatchToolType = readAlias(
+    source,
+    "applyPatchToolType",
+    "apply_patch_tool_type",
+  );
+  const applyPatchToolType =
+    rawApplyPatchToolType === "freeform" ? "freeform" : undefined;
+  const rawWebSearchToolType = readAlias(
+    source,
+    "webSearchToolType",
+    "web_search_tool_type",
+  );
+  const webSearchToolType =
+    rawWebSearchToolType === "text" || rawWebSearchToolType === "text_and_image"
+      ? rawWebSearchToolType
+      : undefined;
+  const supportsSearchTool = readAlias(
+    source,
+    "supportsSearchTool",
+    "supports_search_tool",
+  );
+  const supportVerbosity = readAlias(
+    source,
+    "supportVerbosity",
+    "support_verbosity",
+  );
+  const defaultVerbosity = normalizeString(
+    readAlias(source, "defaultVerbosity", "default_verbosity"),
+  );
+  const rawReasoningLevels = readAlias(
+    source,
+    "supportedReasoningLevels",
+    "supported_reasoning_levels",
+  );
+  const supportedReasoningLevels = Array.isArray(rawReasoningLevels)
+    ? rawReasoningLevels.flatMap((item) => {
+        const level = asRecord(item);
+        const effort = normalizeString(level?.effort);
+        const description = normalizeString(level?.description);
+        return effort && description ? [{ effort, description }] : [];
+      })
+    : [];
+  const defaultReasoningLevel = normalizeString(
+    readAlias(source, "defaultReasoningLevel", "default_reasoning_level"),
+  );
+  const rawTruncationPolicy = asRecord(
+    readAlias(source, "truncationPolicy", "truncation_policy"),
+  );
+  const rawTruncationMode = rawTruncationPolicy?.mode;
+  const rawTruncationLimit = rawTruncationPolicy?.limit;
+  const truncationPolicy: CodexCatalogModel["truncationPolicy"] =
+    (rawTruncationMode === "tokens" || rawTruncationMode === "bytes") &&
+    typeof rawTruncationLimit === "number" &&
+    Number.isInteger(rawTruncationLimit) &&
+    rawTruncationLimit > 0
+      ? { mode: rawTruncationMode, limit: rawTruncationLimit }
+      : undefined;
+  const multiAgentVersion = normalizeString(
+    readAlias(source, "multiAgentVersion", "multi_agent_version"),
+  );
+  const minimalClientVersion = normalizeString(
+    readAlias(source, "minimalClientVersion", "minimal_client_version"),
+  );
+
+  return {
+    ...(typeof supportsParallelToolCalls === "boolean"
+      ? { supportsParallelToolCalls }
+      : {}),
+    ...(inputModalities.length > 0 ? { inputModalities } : {}),
+    ...(baseInstructions ? { baseInstructions } : {}),
+    ...(applyPatchToolType ? { applyPatchToolType } : {}),
+    ...(webSearchToolType ? { webSearchToolType } : {}),
+    ...(typeof supportsSearchTool === "boolean" ? { supportsSearchTool } : {}),
+    ...(typeof supportVerbosity === "boolean" ? { supportVerbosity } : {}),
+    ...(defaultVerbosity ? { defaultVerbosity } : {}),
+    ...(supportedReasoningLevels.length > 0
+      ? { supportedReasoningLevels }
+      : {}),
+    ...(defaultReasoningLevel ? { defaultReasoningLevel } : {}),
+    ...(truncationPolicy ? { truncationPolicy } : {}),
+    ...(multiAgentVersion ? { multiAgentVersion } : {}),
+    ...(minimalClientVersion ? { minimalClientVersion } : {}),
+  };
+}
+
+export function codexCatalogCapabilitiesEqual(
+  left: unknown,
+  right: unknown,
+): boolean {
+  return (
+    JSON.stringify(normalizeCodexCatalogCapabilities(left)) ===
+    JSON.stringify(normalizeCodexCatalogCapabilities(right))
+  );
+}

--- a/src/utils/providerCapabilities.test.ts
+++ b/src/utils/providerCapabilities.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "vitest";
 import type { Provider } from "@/types";
 import type { AppId } from "@/lib/api";
+import {
+  codexProviderPresets,
+  type CodexProviderPreset,
+} from "@/config/codexProviderPresets";
 import { providerNeedsRouting } from "@/utils/providerCapabilities";
+import {
+  extractCodexModelName,
+  extractCodexWireApi,
+} from "@/utils/providerConfigUtils";
 
 function mkProvider(overrides: Partial<Provider> = {}): Provider {
   return { id: "p1", name: "Test", settingsConfig: {}, ...overrides };
@@ -10,6 +18,30 @@ function mkProvider(overrides: Partial<Provider> = {}): Provider {
 // wire_api 取自 config.toml；chat_completions 需转换（需路由），responses 直连。
 const codexConfig = (wireApi: "chat_completions" | "responses") =>
   `model_provider = "custom"\n\n[model_providers.custom]\nname = "X"\nbase_url = "https://x.example/v1"\nwire_api = "${wireApi}"\n`;
+
+function requireCodexPreset(name: string): CodexProviderPreset {
+  const preset = codexProviderPresets.find((item) => item.name === name);
+  if (!preset) throw new Error(`缺少 Codex 预设：${name}`);
+  return preset;
+}
+
+function providerFromCodexPreset(preset: CodexProviderPreset): Provider {
+  return mkProvider({
+    id: `codex-preset-${preset.name}`,
+    name: preset.name,
+    category: preset.category,
+    settingsConfig: {
+      auth: preset.auth,
+      config: preset.config,
+      modelCatalog: { models: preset.modelCatalog ?? [] },
+    },
+    meta: {
+      apiFormat: preset.apiFormat,
+      providerType: preset.providerType,
+      codexChatReasoning: preset.codexChatReasoning,
+    },
+  });
+}
 
 describe("providerNeedsRouting", () => {
   it("官方供应商一律不需要路由（即便 providerType 是 OAuth）", () => {
@@ -174,6 +206,42 @@ describe("providerNeedsRouting", () => {
           mkProvider({ settingsConfig: { config: codexConfig("responses") } }),
         ),
       ).toBe(false);
+    });
+  });
+
+  describe("DeepSeek 真实 Codex 预设路由", () => {
+    it("Flash 原生 Responses 直连，Pro 通过 OpenAI Chat 本地路由", () => {
+      const flashPreset = requireCodexPreset("DeepSeek");
+      const proPreset = requireCodexPreset("DeepSeek V4 Pro");
+
+      // Codex 对两者都发送 Responses；apiFormat 决定是否转换成上游 Chat。
+      expect(extractCodexWireApi(flashPreset.config)).toBe("responses");
+      expect(extractCodexWireApi(proPreset.config)).toBe("responses");
+      expect(flashPreset.apiFormat).toBe("openai_responses");
+      expect(proPreset.apiFormat).toBe("openai_chat");
+
+      expect(
+        providerNeedsRouting("codex", providerFromCodexPreset(flashPreset)),
+      ).toBe(false);
+      expect(
+        providerNeedsRouting("codex", providerFromCodexPreset(proPreset)),
+      ).toBe(true);
+    });
+
+    it("Flash 与 Pro 的默认模型和模型目录彼此隔离", () => {
+      const flashPreset = requireCodexPreset("DeepSeek");
+      const proPreset = requireCodexPreset("DeepSeek V4 Pro");
+
+      expect(extractCodexModelName(flashPreset.config)).toBe(
+        "deepseek-v4-flash",
+      );
+      expect(extractCodexModelName(proPreset.config)).toBe("deepseek-v4-pro");
+      expect(flashPreset.modelCatalog?.map((model) => model.model)).toEqual([
+        "deepseek-v4-flash",
+      ]);
+      expect(proPreset.modelCatalog?.map((model) => model.model)).toEqual([
+        "deepseek-v4-pro",
+      ]);
     });
   });
 

--- a/tests/components/ProviderForm.codexCatalog.test.ts
+++ b/tests/components/ProviderForm.codexCatalog.test.ts
@@ -1,5 +1,66 @@
-import { describe, expect, it } from "vitest";
+import {
+  createElement,
+  type ComponentProps,
+  type PropsWithChildren,
+} from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
 import { normalizeCodexCatalogModelsForSave } from "@/components/providers/forms/ProviderForm";
+import { CodexFormFields } from "@/components/providers/forms/CodexFormFields";
+import { Form } from "@/components/ui/form";
+
+const FormShell = ({ children }: PropsWithChildren) => {
+  const form = useForm();
+  return createElement(Form, { ...form, children });
+};
+
+type CodexFormFieldsProps = ComponentProps<typeof CodexFormFields>;
+
+const renderCodexForm = (overrides: Partial<CodexFormFieldsProps> = {}) => {
+  const props: CodexFormFieldsProps = {
+    codexApiKey: "",
+    onApiKeyChange: vi.fn(),
+    shouldShowApiKeyLink: false,
+    websiteUrl: "",
+    shouldShowSpeedTest: false,
+    codexBaseUrl: "https://api.deepseek.com",
+    onBaseUrlChange: vi.fn(),
+    isFullUrl: false,
+    onFullUrlChange: vi.fn(),
+    isEndpointModalOpen: false,
+    onEndpointModalToggle: vi.fn(),
+    autoSelect: false,
+    onAutoSelectChange: vi.fn(),
+    codexModel: "deepseek-v4-flash",
+    onModelChange: vi.fn(),
+    apiFormat: "openai_responses",
+    onApiFormatChange: vi.fn(),
+    anthropicAuthField: "ANTHROPIC_AUTH_TOKEN",
+    onAnthropicAuthFieldChange: vi.fn(),
+    impersonateClaudeCode: false,
+    onImpersonateClaudeCodeChange: vi.fn(),
+    maxOutputTokens: "",
+    onMaxOutputTokensChange: vi.fn(),
+    promptCacheRouting: "auto",
+    onPromptCacheRoutingChange: vi.fn(),
+    catalogModels: [],
+    onCatalogModelsChange: vi.fn(),
+    speedTestEndpoints: [],
+    customUserAgent: "",
+    onCustomUserAgentChange: vi.fn(),
+    localProxyHeadersOverride: "",
+    onLocalProxyHeadersOverrideChange: vi.fn(),
+    localProxyBodyOverride: "",
+    onLocalProxyBodyOverrideChange: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    props,
+    ...render(createElement(CodexFormFields, props), { wrapper: FormShell }),
+  };
+};
 
 describe("ProviderForm Codex catalog helpers", () => {
   it("normalizes catalog rows and removes empty or duplicate models", () => {
@@ -47,6 +108,200 @@ describe("ProviderForm Codex catalog helpers", () => {
         baseInstructions: "You are Codex, a coding agent based on MiniMax-M3.",
       },
       { model: "mimo-v2.5-pro", supportsParallelToolCalls: false },
+    ]);
+  });
+
+  it("preserves valid native Responses catalog capabilities", () => {
+    expect(
+      normalizeCodexCatalogModelsForSave([
+        {
+          model: "deepseek-v4-flash",
+          applyPatchToolType: "freeform",
+          webSearchToolType: "text",
+          supportsSearchTool: true,
+          supportVerbosity: true,
+          defaultVerbosity: "low",
+          supportedReasoningLevels: [
+            { effort: "low", description: "Light reasoning" },
+            { effort: "high", description: "Deep reasoning" },
+          ],
+          defaultReasoningLevel: "high",
+          truncationPolicy: { mode: "tokens", limit: 10000 },
+          multiAgentVersion: "v2",
+          minimalClientVersion: "0.144.0",
+        },
+      ]),
+    ).toEqual([
+      {
+        model: "deepseek-v4-flash",
+        applyPatchToolType: "freeform",
+        webSearchToolType: "text",
+        supportsSearchTool: true,
+        supportVerbosity: true,
+        defaultVerbosity: "low",
+        supportedReasoningLevels: [
+          { effort: "low", description: "Light reasoning" },
+          { effort: "high", description: "Deep reasoning" },
+        ],
+        defaultReasoningLevel: "high",
+        truncationPolicy: { mode: "tokens", limit: 10000 },
+        multiAgentVersion: "v2",
+        minimalClientVersion: "0.144.0",
+      },
+    ]);
+  });
+
+  it("normalizes capability strings and drops malformed hidden metadata", () => {
+    expect(
+      normalizeCodexCatalogModelsForSave([
+        {
+          model: "deepseek-v4-flash",
+          applyPatchToolType: "function",
+          webSearchToolType: "video",
+          supportsSearchTool: false,
+          supportedReasoningLevels: [
+            { effort: " low ", description: " Light reasoning " },
+            { effort: "", description: "Missing effort" },
+            { effort: "high", description: "   " },
+            null,
+          ],
+          defaultReasoningLevel: " high ",
+          truncationPolicy: { mode: "tokens", limit: -1 },
+          multiAgentVersion: " v2 ",
+          minimalClientVersion: " 0.144.0 ",
+        } as any,
+      ]),
+    ).toEqual([
+      {
+        model: "deepseek-v4-flash",
+        supportsSearchTool: false,
+        supportedReasoningLevels: [
+          { effort: "low", description: "Light reasoning" },
+        ],
+        defaultReasoningLevel: "high",
+        multiAgentVersion: "v2",
+        minimalClientVersion: "0.144.0",
+      },
+    ]);
+  });
+
+  it("keeps hidden catalog capabilities when a visible row field is edited", async () => {
+    const onCatalogModelsChange = vi.fn();
+    const catalogModel = {
+      model: "deepseek-v4-flash",
+      displayName: "DeepSeek V4 Flash",
+      contextWindow: 1048576,
+      supportsParallelToolCalls: true,
+      inputModalities: ["text"],
+      applyPatchToolType: "freeform" as const,
+      webSearchToolType: "text" as const,
+      supportsSearchTool: true,
+      supportVerbosity: true,
+      defaultVerbosity: "low",
+      supportedReasoningLevels: [
+        { effort: "low", description: "Light reasoning" },
+        { effort: "high", description: "Deep reasoning" },
+      ],
+      defaultReasoningLevel: "high",
+      truncationPolicy: { mode: "tokens" as const, limit: 10000 },
+      multiAgentVersion: "v2",
+      minimalClientVersion: "0.144.0",
+    };
+
+    renderCodexForm({ catalogModels: [catalogModel], onCatalogModelsChange });
+
+    fireEvent.change(screen.getByDisplayValue("DeepSeek V4 Flash"), {
+      target: { value: "DeepSeek Flash" },
+    });
+
+    await waitFor(() => expect(onCatalogModelsChange).toHaveBeenCalled());
+    expect(onCatalogModelsChange.mock.lastCall?.[0]).toEqual([
+      { ...catalogModel, displayName: "DeepSeek Flash" },
+    ]);
+  });
+
+  it("refreshes rows when structured hidden capabilities change", async () => {
+    const onCatalogModelsChange = vi.fn();
+    const initialModel = {
+      model: "deepseek-v4-flash",
+      displayName: "DeepSeek V4 Flash",
+      supportedReasoningLevels: [
+        { effort: "low", description: "Light reasoning" },
+      ],
+      truncationPolicy: { mode: "tokens" as const, limit: 10000 },
+    };
+    const updatedModel = {
+      ...initialModel,
+      supportedReasoningLevels: [
+        { effort: "high", description: "Deep reasoning" },
+        { effort: "max", description: "Maximum reasoning" },
+      ],
+      truncationPolicy: { mode: "tokens" as const, limit: 20000 },
+    };
+    const { props, rerender } = renderCodexForm({
+      catalogModels: [initialModel],
+      onCatalogModelsChange,
+    });
+
+    rerender(
+      createElement(CodexFormFields, {
+        ...props,
+        catalogModels: [updatedModel],
+      }),
+    );
+    fireEvent.change(screen.getByDisplayValue("DeepSeek V4 Flash"), {
+      target: { value: "DeepSeek Flash" },
+    });
+
+    await waitFor(() => expect(onCatalogModelsChange).toHaveBeenCalled());
+    expect(onCatalogModelsChange.mock.lastCall?.[0]).toEqual([
+      {
+        ...updatedModel,
+        displayName: "DeepSeek Flash",
+        contextWindow: "",
+      },
+    ]);
+  });
+
+  it("refreshes rows when scalar hidden capabilities change", async () => {
+    const onCatalogModelsChange = vi.fn();
+    const initialModel = {
+      model: "deepseek-v4-flash",
+      displayName: "DeepSeek V4 Flash",
+    };
+    const updatedModel = {
+      ...initialModel,
+      applyPatchToolType: "freeform" as const,
+      webSearchToolType: "text" as const,
+      supportsSearchTool: true,
+      supportVerbosity: true,
+      defaultVerbosity: "low",
+      defaultReasoningLevel: "high",
+      multiAgentVersion: "v2",
+      minimalClientVersion: "0.144.0",
+    };
+    const { props, rerender } = renderCodexForm({
+      catalogModels: [initialModel],
+      onCatalogModelsChange,
+    });
+
+    rerender(
+      createElement(CodexFormFields, {
+        ...props,
+        catalogModels: [updatedModel],
+      }),
+    );
+    fireEvent.change(screen.getByDisplayValue("DeepSeek V4 Flash"), {
+      target: { value: "DeepSeek Flash" },
+    });
+
+    await waitFor(() => expect(onCatalogModelsChange).toHaveBeenCalled());
+    expect(onCatalogModelsChange.mock.lastCall?.[0]).toEqual([
+      {
+        ...updatedModel,
+        displayName: "DeepSeek Flash",
+        contextWindow: "",
+      },
     ]);
   });
 });

--- a/tests/config/codexChatProviderPresets.test.ts
+++ b/tests/config/codexChatProviderPresets.test.ts
@@ -25,13 +25,10 @@ const expectedChatPresets = new Map<
     },
   ],
   [
-    "DeepSeek",
+    "DeepSeek V4 Pro",
     {
       baseUrl: "https://api.deepseek.com",
-      contextWindows: {
-        "deepseek-v4-flash": 1000000,
-        "deepseek-v4-pro": 1000000,
-      },
+      contextWindows: { "deepseek-v4-pro": 1048576 },
     },
   ],
   [
@@ -129,6 +126,48 @@ const expectedChatPresets = new Map<
 ]);
 
 describe("Codex Chat provider presets", () => {
+  it("declares DeepSeek V4 Flash native Responses capabilities", () => {
+    const flash = codexProviderPresets.find((item) => item.name === "DeepSeek");
+    const pro = codexProviderPresets.find(
+      (item) => item.name === "DeepSeek V4 Pro",
+    );
+
+    expect(flash?.modelCatalog).toEqual([
+      {
+        model: "deepseek-v4-flash",
+        displayName: "DeepSeek V4 Flash",
+        contextWindow: 1048576,
+        supportsParallelToolCalls: true,
+        inputModalities: ["text"],
+        applyPatchToolType: "freeform",
+        webSearchToolType: "text",
+        supportsSearchTool: true,
+        supportVerbosity: true,
+        defaultVerbosity: "low",
+        defaultReasoningLevel: "high",
+        supportedReasoningLevels: [
+          {
+            effort: "low",
+            description: "Fast responses with lighter reasoning",
+          },
+          {
+            effort: "high",
+            description: "Extra high reasoning depth for complex problems",
+          },
+          {
+            effort: "max",
+            description: "Maximum reasoning depth for the hardest problems",
+          },
+        ],
+        truncationPolicy: { mode: "tokens", limit: 10000 },
+        multiAgentVersion: "v2",
+        minimalClientVersion: "0.144.0",
+      },
+    ]);
+    expect(pro?.apiFormat).toBe("openai_chat");
+    expect(pro?.codexChatReasoning).toBeDefined();
+  });
+
   it("enables session-based prompt cache routing for Kimi Coding", () => {
     const preset = codexProviderPresets.find(
       (item) => item.name === "Kimi For Coding",
@@ -170,6 +209,7 @@ describe("Codex Chat provider presets", () => {
         "DouBaoSeed",
         { contextWindows: { "doubao-seed-2-1-pro-260628": 262144 } },
       ],
+      ["DeepSeek", { contextWindows: { "deepseek-v4-flash": 1048576 } }],
       ["Bailian", { contextWindows: { "qwen3-coder-plus": 1048576 } }],
       ["Longcat", { contextWindows: { "LongCat-2.0": 1048576 } }],
       ["MiniMax", { contextWindows: { "MiniMax-M3": 1000000 } }],
@@ -199,10 +239,9 @@ describe("Codex Chat provider presets", () => {
 
       expect(preset, `${name} preset`).toBeDefined();
       expect(preset?.apiFormat).toBe("openai_responses");
-      // 原生 Responses 预设现在带 modelCatalog：cc-switch 直连时据此生成
-      // ~/.codex 的 model-catalogs.json（shell_command 编辑、不发 freeform
-      // apply_patch）。带 catalog 不再强制开“本地路由映射”——前端已按
-      // apiFormat 解耦（openai_responses 默认不开接管）。
+      // 原生 Responses 预设带 modelCatalog：cc-switch 直连时据此生成
+      // ~/.codex 的 model-catalogs.json。目录以保守能力为默认值，模型可按
+      // 显式元数据恢复原生工具。带 catalog 不再强制开“本地路由映射”。
       expect((preset?.modelCatalog ?? []).length).toBeGreaterThan(0);
       expect(
         Object.fromEntries(

--- a/tests/hooks/useCodexConfigState.catalog.test.ts
+++ b/tests/hooks/useCodexConfigState.catalog.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect } from "vitest";
 import { useCodexConfigState } from "@/components/providers/forms/hooks/useCodexConfigState";
 
 // 回归：编辑已存在的原生 Responses 供应商时，读回 modelCatalog 必须保留隐藏字段
-// (supportsParallelToolCalls / inputModalities / baseInstructions)，否则保存会
-// 把它们剥掉，导致生成的 Codex catalog 丢官方 base_instructions、并行工具、图像模态。
+// 各类隐藏 capability，否则保存会把它们剥掉，导致生成的 Codex catalog
+// 丢官方工具、reasoning、截断与版本能力。
 //
 // 注意：initialData 必须是稳定引用（hook 的 init effect 依赖 [initialData]）。
 // 写成内联字面量会每次 re-render 产生新引用 → effect 反复 setState → 死循环 OOM。
@@ -23,6 +23,19 @@ describe("useCodexConfigState catalog load", () => {
               supportsParallelToolCalls: true,
               inputModalities: ["text", "image"],
               baseInstructions: "You are Codex, based on MiniMax-M3.",
+              applyPatchToolType: "freeform",
+              webSearchToolType: "text",
+              supportsSearchTool: true,
+              supportVerbosity: true,
+              defaultVerbosity: "low",
+              supportedReasoningLevels: [
+                { effort: "low", description: "Light reasoning" },
+                { effort: "high", description: "Deep reasoning" },
+              ],
+              defaultReasoningLevel: "high",
+              truncationPolicy: { mode: "tokens", limit: 10000 },
+              multiAgentVersion: "v2",
+              minimalClientVersion: "0.144.0",
             },
           ],
         },
@@ -39,6 +52,19 @@ describe("useCodexConfigState catalog load", () => {
         supportsParallelToolCalls: true,
         inputModalities: ["text", "image"],
         baseInstructions: "You are Codex, based on MiniMax-M3.",
+        applyPatchToolType: "freeform",
+        webSearchToolType: "text",
+        supportsSearchTool: true,
+        supportVerbosity: true,
+        defaultVerbosity: "low",
+        supportedReasoningLevels: [
+          { effort: "low", description: "Light reasoning" },
+          { effort: "high", description: "Deep reasoning" },
+        ],
+        defaultReasoningLevel: "high",
+        truncationPolicy: { mode: "tokens", limit: 10000 },
+        multiAgentVersion: "v2",
+        minimalClientVersion: "0.144.0",
       },
     ]);
   });
@@ -57,6 +83,19 @@ describe("useCodexConfigState catalog load", () => {
               supports_parallel_tool_calls: false,
               input_modalities: ["text"],
               base_instructions: "You are MiMo, developed by Xiaomi.",
+              apply_patch_tool_type: "freeform",
+              web_search_tool_type: "text_and_image",
+              supports_search_tool: false,
+              support_verbosity: true,
+              default_verbosity: "low",
+              supported_reasoning_levels: [
+                { effort: "low", description: "Light reasoning" },
+                { effort: "max", description: "Maximum reasoning" },
+              ],
+              default_reasoning_level: "max",
+              truncation_policy: { mode: "bytes", limit: 8192 },
+              multi_agent_version: "v2",
+              minimal_client_version: "0.144.0",
             },
           ],
         },
@@ -73,6 +112,61 @@ describe("useCodexConfigState catalog load", () => {
         supportsParallelToolCalls: false,
         inputModalities: ["text"],
         baseInstructions: "You are MiMo, developed by Xiaomi.",
+        applyPatchToolType: "freeform",
+        webSearchToolType: "text_and_image",
+        supportsSearchTool: false,
+        supportVerbosity: true,
+        defaultVerbosity: "low",
+        supportedReasoningLevels: [
+          { effort: "low", description: "Light reasoning" },
+          { effort: "max", description: "Maximum reasoning" },
+        ],
+        defaultReasoningLevel: "max",
+        truncationPolicy: { mode: "bytes", limit: 8192 },
+        multiAgentVersion: "v2",
+        minimalClientVersion: "0.144.0",
+      },
+    ]);
+  });
+
+  it("normalizes reasoning levels and rejects malformed structured capabilities", () => {
+    const initialData = {
+      settingsConfig: {
+        auth: {},
+        config: "",
+        modelCatalog: {
+          models: [
+            {
+              model: "deepseek-v4-flash",
+              applyPatchToolType: "function",
+              webSearchToolType: "video",
+              supportsSearchTool: "yes",
+              supportedReasoningLevels: [
+                { effort: " low ", description: " Light reasoning " },
+                { effort: "", description: "Missing effort" },
+                { effort: "max", description: "   " },
+                null,
+              ],
+              defaultReasoningLevel: 42,
+              truncationPolicy: { mode: "tokens", limit: 0 },
+              multiAgentVersion: {},
+              minimalClientVersion: false,
+            },
+          ],
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useCodexConfigState({ initialData }));
+
+    expect(result.current.codexCatalogModels).toEqual([
+      {
+        model: "deepseek-v4-flash",
+        displayName: "",
+        contextWindow: "",
+        supportedReasoningLevels: [
+          { effort: "low", description: "Light reasoning" },
+        ],
       },
     ]);
   });


### PR DESCRIPTION
## Summary / 概述

- Split the DeepSeek Codex preset by protocol: `deepseek-v4-flash` now uses native Responses, while `deepseek-v4-pro` keeps the existing Chat Completions conversion path.
- Generate and round-trip the official Flash catalog capabilities, including reasoning levels, verbosity, freeform `apply_patch`, Web Search, truncation, and client/version metadata.
- Preserve native Responses request bodies and SSE bytes for both `/responses` and `/v1/responses`, and account for `response.incomplete` / `response.failed` terminal usage and model metadata.
- Update the English, Chinese, and Japanese provider/routing documentation, including the saved-provider migration note.

## Related Issue / 关联 Issue

Related to #5959
Related to #5805

## Screenshots / 截图

N/A — provider configuration, backend routing/catalog behavior, tests, and documentation only.

## Verification / 验证

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` (591 passed)
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- DeepSeek native routing/passthrough tests (2 passed)
- `cargo test --lib -- --skip update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active` (2246 passed, 2 ignored; the skipped pre-existing test binds the desktop app's already-occupied local proxy port)
- Live DeepSeek smoke tests with a one-time key: both Responses paths, streaming reasoning, function-tool round trip, custom `apply_patch`, Web Search, incomplete response, and official Python/Node SDKs. No key was persisted.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

fixed #5959 