### PR TITLE
fix(codex): avoid repeated deferred session reads

### DIFF
--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -53,7 +53,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 16;
+pub(crate) const SCHEMA_VERSION: i32 = 17;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -308,7 +308,23 @@ impl Database {
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-        // 19. Profiles 表（全应用共享的项目实体，payload 按 app 分槽快照
+        // 19. Codex Pending Sync 表
+        //
+        // deferred 文件不能只保存在进程内存中，否则每次重启都会重新完整读取。
+        // reason_json 同时保存父 rollout 依赖快照，用于只在依赖变化时重试。
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS codex_pending_sync (
+                file_path TEXT PRIMARY KEY,
+                child_modified INTEGER NOT NULL,
+                child_size INTEGER NOT NULL,
+                reason_json TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // 20. Profiles 表（全应用共享的项目实体，payload 按 app 分槽快照
         //     供应商/MCP/Skills/Prompt；各应用分组的 current 标记在 settings 表）
         conn.execute(
             "CREATE TABLE IF NOT EXISTS profiles (
@@ -510,6 +526,11 @@ impl Database {
                         log::info!("迁移数据库从 v15 到 v16（重建 Codex 会话用量）");
                         Self::migrate_v15_to_v16(conn)?;
                         Self::set_user_version(conn, 16)?;
+                    }
+                    16 => {
+                        log::info!("迁移数据库从 v16 到 v17（持久化 Codex deferred 状态）");
+                        Self::migrate_v16_to_v17(conn)?;
+                        Self::set_user_version(conn, 17)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -1521,6 +1542,23 @@ impl Database {
     fn migrate_v15_to_v16(conn: &Connection) -> Result<(), AppError> {
         let codex_dir = crate::codex_config::get_codex_config_dir();
         crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)
+    }
+
+    /// v16 -> v17: persist deferred Codex sync dependencies so unchanged
+    /// historical rollouts are not re-read on every timer tick or restart.
+    fn migrate_v16_to_v17(conn: &Connection) -> Result<(), AppError> {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS codex_pending_sync (
+                file_path TEXT PRIMARY KEY,
+                child_modified INTEGER NOT NULL,
+                child_size INTEGER NOT NULL,
+                reason_json TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("创建 codex_pending_sync 表失败: {e}")))?;
+        Ok(())
     }
 
     /// 插入默认模型定价数据
@@ -3222,7 +3260,7 @@ mod tests {
 
         Database::apply_schema_migrations_on_conn(&conn)?;
 
-        assert_eq!(Database::get_user_version(&conn)?, 16);
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
         let counts: (i64, i64, i64, i64) = conn.query_row(
             "SELECT
                 (SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'),
@@ -3233,6 +3271,42 @@ mod tests {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )?;
         assert_eq!(counts, (0, 1, 0, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_v16_to_v17_preserves_codex_usage_and_cursors() -> Result<(), AppError> {
+        let conn = Connection::open_in_memory()?;
+        Database::create_tables_on_conn(&conn)?;
+        conn.execute("DROP TABLE codex_pending_sync", [])?;
+        conn.execute_batch(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model, input_tokens,
+                output_tokens, cache_read_tokens, latency_ms, status_code,
+                created_at, data_source
+             ) VALUES
+                ('codex-row', '_codex_session', 'codex', 'gpt', 11, 3, 5, 0, 200, 1, 'codex_session');
+             INSERT INTO session_log_sync
+                (file_path, last_modified, last_line_offset, last_synced_at)
+             VALUES
+                ('/codex/sessions/rollout-old-00000000-0000-4000-8000-000000000001.jsonl', 9, 7, 1);",
+        )?;
+        Database::set_user_version(&conn, 16)?;
+
+        Database::apply_schema_migrations_on_conn(&conn)?;
+
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
+        assert!(Database::table_exists(&conn, "codex_pending_sync")?);
+        let values: (i64, i64, i64, i64) = conn.query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM proxy_request_logs WHERE request_id = 'codex-row'),
+                (SELECT input_tokens FROM proxy_request_logs WHERE request_id = 'codex-row'),
+                (SELECT COUNT(*) FROM session_log_sync),
+                (SELECT last_line_offset FROM session_log_sync LIMIT 1)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+        assert_eq!(values, (1, 11, 1, 7));
         Ok(())
     }
 }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -325,9 +325,12 @@ fn load_pending_entry(db: &Database, file_path: &str) -> Result<Option<PendingEn
             let reason = serde_json::from_str(&reason_json).map_err(|error| {
                 AppError::Database(format!("解析 Codex pending 状态失败: {error}"))
             })?;
+            let size = u64::try_from(size).map_err(|_| {
+                AppError::Database(format!("Codex pending child_size 超出范围: {size}"))
+            })?;
             Ok(Some(PendingEntry {
                 modified,
-                size: u64::try_from(size).unwrap_or(0),
+                size,
                 reason,
             }))
         }
@@ -345,6 +348,12 @@ fn save_pending_entry(
 ) -> Result<(), AppError> {
     let reason_json = serde_json::to_string(&entry.reason)
         .map_err(|source| AppError::JsonSerialize { source })?;
+    let child_size = i64::try_from(entry.size).map_err(|_| {
+        AppError::Database(format!(
+            "Codex pending 文件大小无法写入 SQLite INTEGER: {}",
+            entry.size
+        ))
+    })?;
     let updated_at = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|duration| duration.as_secs() as i64)
@@ -1695,6 +1704,57 @@ mod tests {
         db.create_tables()?;
         db.ensure_model_pricing_seeded()?;
         Ok(db)
+    }
+
+    #[test]
+    fn pending_entry_rejects_negative_child_size() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let file_path = "negative-child-size.jsonl";
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO codex_pending_sync
+                    (file_path, child_modified, child_size, reason_json, updated_at)
+                 VALUES (?1, 1, -1, ?2, 1)",
+                rusqlite::params![
+                    file_path,
+                    serde_json::to_string(&PendingReason::Stable("test".to_string())).unwrap()
+                ],
+            )?;
+        }
+
+        let error = load_pending_entry(&db, file_path).unwrap_err();
+        assert!(matches!(
+            error,
+            AppError::Database(message)
+                if message.contains("Codex pending child_size 超出范围: -1")
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn pending_entry_rejects_size_above_sqlite_integer_range() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let entry = PendingEntry {
+            modified: 1,
+            size: i64::MAX as u64 + 1,
+            reason: PendingReason::Stable("test".to_string()),
+        };
+
+        let error = save_pending_entry(&db, "oversized-child.jsonl", &entry).unwrap_err();
+        assert!(matches!(
+            error,
+            AppError::Database(message)
+                if message.contains("Codex pending 文件大小无法写入 SQLite INTEGER")
+        ));
+        let conn = lock_conn!(db.conn);
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM codex_pending_sync WHERE file_path = ?1",
+            ["oversized-child.jsonl"],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 0);
+        Ok(())
     }
 
     #[test]

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -145,6 +145,16 @@ impl ParentFileStamp {
     }
 }
 
+fn parent_file_was_closed_by_cutoff(stamp: ParentFileStamp, cutoff: &DateTime<Utc>) -> bool {
+    // `metadata_modified_nanos` uses 0 when the platform mtime is unavailable.
+    // Treat that sentinel as unknown instead of as the UNIX epoch; otherwise an
+    // unstable parent could bypass the BehindCutoff guard.
+    stamp.modified_nanos != 0
+        && cutoff
+            .timestamp_nanos_opt()
+            .is_some_and(|cutoff_nanos| stamp.modified_nanos <= cutoff_nanos)
+}
+
 #[cfg(windows)]
 fn windows_file_identity(file: &fs::File) -> Option<(u64, [u8; 16])> {
     let mut information = FILE_ID_INFO::default();
@@ -1040,11 +1050,8 @@ fn parent_signatures_before(
         ))
     })?;
     let stamp = ParentFileStamp::from_file(&file);
-    let file_was_closed_by_cutoff = stamp.is_some_and(|stamp| {
-        cutoff
-            .timestamp_nanos_opt()
-            .is_some_and(|cutoff_nanos| stamp.modified_nanos <= cutoff_nanos)
-    });
+    let file_was_closed_by_cutoff =
+        stamp.is_some_and(|stamp| parent_file_was_closed_by_cutoff(stamp, &cutoff));
     let allow_behind_cutoff = allow_behind_cutoff || file_was_closed_by_cutoff;
     let cached_timeline = stamp.and_then(|stamp| {
         replay_caches().lock().ok().and_then(|caches| {
@@ -2351,6 +2358,27 @@ mod tests {
             (replacement_stamp.size, replacement_stamp.modified_nanos)
         );
         assert_ne!(original_stamp, replacement_stamp);
+    }
+
+    #[test]
+    fn unknown_parent_mtime_does_not_mark_file_closed_by_cutoff() {
+        let cutoff = "2026-07-10T03:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let mut stamp = ParentFileStamp {
+            modified_nanos: 0,
+            size: 1,
+            #[cfg(unix)]
+            device: 1,
+            #[cfg(unix)]
+            inode: 1,
+            #[cfg(windows)]
+            volume_serial: 1,
+            #[cfg(windows)]
+            file_id: [0; 16],
+        };
+
+        assert!(!parent_file_was_closed_by_cutoff(stamp, &cutoff));
+        stamp.modified_nanos = 1;
+        assert!(parent_file_was_closed_by_cutoff(stamp, &cutoff));
     }
 
     #[test]

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -344,8 +344,7 @@ fn save_pending_entry(
     entry: &PendingEntry,
 ) -> Result<(), AppError> {
     let reason_json = serde_json::to_string(&entry.reason)
-        .map_err(|error| AppError::Config(format!("序列化 Codex pending 状态失败: {error}")))?;
-    let child_size = i64::try_from(entry.size).unwrap_or(i64::MAX);
+        .map_err(|source| AppError::JsonSerialize { source })?;
     let updated_at = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|duration| duration.as_secs() as i64)

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -26,6 +26,7 @@ use crate::services::usage_stats::{
 };
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -34,6 +35,8 @@ use std::os::unix::fs::MetadataExt;
 #[cfg(windows)]
 use std::os::windows::io::AsRawHandle;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::SystemTime;
 #[cfg(windows)]
@@ -42,6 +45,10 @@ use windows_sys::Win32::Storage::FileSystem::{
 };
 
 const CODEX_THREAD_REQUEST_ID_PREFIX: &str = "codex_session:thread-v1";
+const CODEX_JSONL_BUFFER_CAPACITY: usize = 256 * 1024;
+
+#[cfg(test)]
+static CODEX_FILE_PARSE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// 累计 token 用量（跟踪 total_token_usage 字段）
 #[derive(Debug, Clone, Default)]
@@ -86,7 +93,7 @@ struct TimestampedTokenSignature {
     signature: TokenUsageSignature,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 struct ParentFileStamp {
     modified_nanos: i64,
     size: u64,
@@ -98,6 +105,24 @@ struct ParentFileStamp {
     volume_serial: u64,
     #[cfg(windows)]
     file_id: [u8; 16],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ParentDependency {
+    path: String,
+    stamp: Option<ParentFileStamp>,
+}
+
+impl ParentDependency {
+    fn snapshot(path: &Path) -> Self {
+        let stamp = fs::File::open(path)
+            .ok()
+            .and_then(|file| ParentFileStamp::from_file(&file));
+        Self {
+            path: path.to_string_lossy().to_string(),
+            stamp,
+        }
+    }
 }
 
 impl ParentFileStamp {
@@ -151,21 +176,23 @@ impl ParentTokenTimeline {
         &self,
         parent_path: &Path,
         cutoff: DateTime<Utc>,
-    ) -> Result<Vec<TokenUsageSignature>, String> {
+        allow_behind_cutoff: bool,
+    ) -> Result<Vec<TokenUsageSignature>, ParentTimelineError> {
         if self.has_token_without_timestamp {
-            return Err(format!(
+            return Err(ParentTimelineError::Invalid(format!(
                 "父 rollout {} 的 token_count 缺少有效 timestamp",
                 parent_path.display()
-            ));
+            )));
         }
-        if self
-            .max_timestamp
-            .is_none_or(|timestamp| timestamp < cutoff)
+        if !allow_behind_cutoff
+            && self
+                .max_timestamp
+                .is_none_or(|timestamp| timestamp < cutoff)
         {
-            return Err(format!(
+            return Err(ParentTimelineError::BehindCutoff(format!(
                 "父 rollout {} 尚未写到 child fork 时刻",
                 parent_path.display()
-            ));
+            )));
         }
         Ok(self
             .events
@@ -174,6 +201,25 @@ impl ParentTokenTimeline {
             .map(|event| event.signature.clone())
             .collect())
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ParentTimelineError {
+    BehindCutoff(String),
+    Invalid(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParentResolveFailureKind {
+    BehindCutoff,
+    Retryable,
+}
+
+#[derive(Debug)]
+struct ParentResolveFailure {
+    kind: ParentResolveFailureKind,
+    reason: String,
+    dependencies: Vec<ParentDependency>,
 }
 
 #[derive(Debug)]
@@ -217,11 +263,20 @@ struct ParsedCodexFile {
     has_billable_tokens: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 enum PendingReason {
     MissingParent(String),
     Stable(String),
-    Retryable(String),
+    ParentBehindCutoff {
+        parent_id: String,
+        reason: String,
+        dependencies: Vec<ParentDependency>,
+    },
+    Retryable {
+        parent_id: String,
+        reason: String,
+        dependencies: Vec<ParentDependency>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,7 +290,6 @@ struct PendingEntry {
 struct CodexReplayCaches {
     parent_timelines: HashMap<PathBuf, CachedParentTimeline>,
     replay_prefixes: HashMap<PathBuf, CachedReplayPrefix>,
-    pending: HashMap<PathBuf, PendingEntry>,
 }
 
 static CODEX_REPLAY_CACHES: OnceLock<Mutex<CodexReplayCaches>> = OnceLock::new();
@@ -248,6 +302,96 @@ pub(crate) fn clear_codex_replay_caches() {
     if let Ok(mut caches) = replay_caches().lock() {
         *caches = CodexReplayCaches::default();
     }
+}
+
+fn load_pending_entry(db: &Database, file_path: &str) -> Result<Option<PendingEntry>, AppError> {
+    let conn = lock_conn!(db.conn);
+    let row = conn.query_row(
+        "SELECT child_modified, child_size, reason_json
+         FROM codex_pending_sync WHERE file_path = ?1",
+        [file_path],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        },
+    );
+    drop(conn);
+
+    match row {
+        Ok((modified, size, reason_json)) => {
+            let reason = serde_json::from_str(&reason_json).map_err(|error| {
+                AppError::Database(format!("解析 Codex pending 状态失败: {error}"))
+            })?;
+            Ok(Some(PendingEntry {
+                modified,
+                size: u64::try_from(size).unwrap_or(0),
+                reason,
+            }))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(error) => Err(AppError::Database(format!(
+            "查询 Codex pending 状态失败: {error}"
+        ))),
+    }
+}
+
+fn save_pending_entry(
+    db: &Database,
+    file_path: &str,
+    entry: &PendingEntry,
+) -> Result<(), AppError> {
+    let reason_json = serde_json::to_string(&entry.reason)
+        .map_err(|error| AppError::Config(format!("序列化 Codex pending 状态失败: {error}")))?;
+    let child_size = i64::try_from(entry.size).unwrap_or(i64::MAX);
+    let updated_at = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0);
+    let conn = lock_conn!(db.conn);
+    conn.execute(
+        "INSERT INTO codex_pending_sync
+            (file_path, child_modified, child_size, reason_json, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(file_path) DO UPDATE SET
+            child_modified = excluded.child_modified,
+            child_size = excluded.child_size,
+            reason_json = excluded.reason_json,
+            updated_at = excluded.updated_at",
+        rusqlite::params![
+            file_path,
+            entry.modified,
+            child_size,
+            reason_json,
+            updated_at
+        ],
+    )
+    .map_err(|error| AppError::Database(format!("保存 Codex pending 状态失败: {error}")))?;
+    Ok(())
+}
+
+fn delete_pending_entry(db: &Database, file_path: &str) -> Result<(), AppError> {
+    let conn = lock_conn!(db.conn);
+    conn.execute(
+        "DELETE FROM codex_pending_sync WHERE file_path = ?1",
+        [file_path],
+    )
+    .map_err(|error| AppError::Database(format!("清理 Codex pending 状态失败: {error}")))?;
+    Ok(())
+}
+
+fn snapshot_parent_dependencies(
+    parent_id: &str,
+    rollout_index: &RolloutIndex,
+) -> Vec<ParentDependency> {
+    rollout_index
+        .get(parent_id)
+        .into_iter()
+        .flatten()
+        .map(|path| ParentDependency::snapshot(path))
+        .collect()
 }
 
 fn is_rollout_filename(file_name: &str) -> bool {
@@ -352,6 +496,10 @@ pub(crate) fn reset_codex_usage_on_conn(
             )
             .map_err(|error| AppError::Database(format!("清理 Codex 同步 cursor 失败: {error}")))?;
         }
+    }
+    if sqlite_table_exists(conn, "codex_pending_sync")? {
+        conn.execute("DELETE FROM codex_pending_sync", [])
+            .map_err(|error| AppError::Database(format!("清理 Codex pending 状态失败: {error}")))?;
     }
     Ok(())
 }
@@ -697,9 +845,11 @@ fn parse_codex_file(
     file_path: &Path,
     root_thread_id: Option<String>,
 ) -> Result<ParsedCodexFile, AppError> {
+    #[cfg(test)]
+    CODEX_FILE_PARSE_COUNT.fetch_add(1, Ordering::SeqCst);
     let file =
         fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
-    let reader = BufReader::new(file);
+    let reader = BufReader::with_capacity(CODEX_JSONL_BUFFER_CAPACITY, file);
     let mut root_meta_seen = false;
     let mut root_timestamp = None;
     let mut parent = ParentResolution::None;
@@ -873,10 +1023,21 @@ fn parse_codex_file(
 fn parent_signatures_before(
     parent_path: &Path,
     cutoff: DateTime<Utc>,
-) -> Result<Vec<TokenUsageSignature>, String> {
-    let file = fs::File::open(parent_path)
-        .map_err(|error| format!("无法打开父 rollout {}: {error}", parent_path.display()))?;
+    allow_behind_cutoff: bool,
+) -> Result<Vec<TokenUsageSignature>, ParentTimelineError> {
+    let file = fs::File::open(parent_path).map_err(|error| {
+        ParentTimelineError::Invalid(format!(
+            "无法打开父 rollout {}: {error}",
+            parent_path.display()
+        ))
+    })?;
     let stamp = ParentFileStamp::from_file(&file);
+    let file_was_closed_by_cutoff = stamp.is_some_and(|stamp| {
+        cutoff
+            .timestamp_nanos_opt()
+            .is_some_and(|cutoff_nanos| stamp.modified_nanos <= cutoff_nanos)
+    });
+    let allow_behind_cutoff = allow_behind_cutoff || file_was_closed_by_cutoff;
     let cached_timeline = stamp.and_then(|stamp| {
         replay_caches().lock().ok().and_then(|caches| {
             caches
@@ -887,7 +1048,7 @@ fn parent_signatures_before(
         })
     });
     if let Some(timeline) = cached_timeline {
-        return timeline.signatures_before(parent_path, cutoff);
+        return timeline.signatures_before(parent_path, cutoff, allow_behind_cutoff);
     }
 
     let mut events = Vec::new();
@@ -896,7 +1057,7 @@ fn parent_signatures_before(
 
     // 必须扫描完整父文件，不能在首个未来时间戳处 break：rollout 写入顺序
     // 不承诺时间戳严格单调。缓存完整时间线后，不同 child cutoff 只需内存过滤。
-    for line in BufReader::new(file).lines() {
+    for line in BufReader::with_capacity(CODEX_JSONL_BUFFER_CAPACITY, file).lines() {
         let Ok(line) = line else {
             continue;
         };
@@ -941,7 +1102,7 @@ fn parent_signatures_before(
         max_timestamp,
         has_token_without_timestamp,
     });
-    let result = timeline.signatures_before(parent_path, cutoff);
+    let result = timeline.signatures_before(parent_path, cutoff, allow_behind_cutoff);
     if let (Some(stamp), Ok(mut caches)) = (stamp, replay_caches().lock()) {
         caches.parent_timelines.insert(
             parent_path.to_path_buf(),
@@ -958,22 +1119,54 @@ fn resolve_parent_signatures(
     parent_id: &str,
     cutoff: DateTime<Utc>,
     rollout_index: &RolloutIndex,
-) -> Result<Vec<TokenUsageSignature>, String> {
+    allow_behind_cutoff: bool,
+) -> Result<Vec<TokenUsageSignature>, ParentResolveFailure> {
     let Some(candidates) = rollout_index.get(parent_id) else {
-        return Err(format!("找不到父 rollout: {parent_id}"));
+        return Err(ParentResolveFailure {
+            kind: ParentResolveFailureKind::Retryable,
+            reason: format!("找不到父 rollout: {parent_id}"),
+            dependencies: Vec::new(),
+        });
     };
+
+    let dependencies = candidates
+        .iter()
+        .map(|candidate| ParentDependency::snapshot(candidate))
+        .collect::<Vec<_>>();
 
     let mut snapshots = Vec::with_capacity(candidates.len());
     for candidate in candidates {
-        snapshots.push(parent_signatures_before(candidate, cutoff)?);
+        match parent_signatures_before(candidate, cutoff, allow_behind_cutoff) {
+            Ok(snapshot) => snapshots.push(snapshot),
+            Err(ParentTimelineError::BehindCutoff(reason)) => {
+                return Err(ParentResolveFailure {
+                    kind: ParentResolveFailureKind::BehindCutoff,
+                    reason,
+                    dependencies,
+                });
+            }
+            Err(ParentTimelineError::Invalid(reason)) => {
+                return Err(ParentResolveFailure {
+                    kind: ParentResolveFailureKind::Retryable,
+                    reason,
+                    dependencies,
+                });
+            }
+        }
     }
     let Some(first) = snapshots.first() else {
-        return Err(format!("找不到父 rollout: {parent_id}"));
+        return Err(ParentResolveFailure {
+            kind: ParentResolveFailureKind::Retryable,
+            reason: format!("找不到父 rollout: {parent_id}"),
+            dependencies,
+        });
     };
     if snapshots.iter().skip(1).any(|snapshot| snapshot != first) {
-        return Err(format!(
-            "父 rollout UUID {parent_id} 对应多个内容不一致的文件"
-        ));
+        return Err(ParentResolveFailure {
+            kind: ParentResolveFailureKind::Retryable,
+            reason: format!("父 rollout UUID {parent_id} 对应多个内容不一致的文件"),
+            dependencies,
+        });
     }
     Ok(first.clone())
 }
@@ -995,37 +1188,33 @@ fn matching_replay_prefix(child: &[ParsedTokenEvent], parent: &[TokenUsageSignat
 }
 
 fn mark_deferred(
+    db: &Database,
     file_path: &Path,
     modified: i64,
     size: u64,
     reason: PendingReason,
-) -> CodexFileSyncResult {
+) -> Result<CodexFileSyncResult, AppError> {
+    let file_path_str = file_path.to_string_lossy().to_string();
     let entry = PendingEntry {
         modified,
         size,
         reason,
     };
-    let should_warn = replay_caches()
-        .lock()
-        .ok()
-        .and_then(|mut caches| {
-            caches
-                .pending
-                .insert(file_path.to_path_buf(), entry.clone())
-        })
-        .as_ref()
-        != Some(&entry);
+    let should_warn = load_pending_entry(db, &file_path_str)?.as_ref() != Some(&entry);
+    save_pending_entry(db, &file_path_str, &entry)?;
     if should_warn {
         let reason = match &entry.reason {
             PendingReason::MissingParent(parent) => format!("找不到父 rollout {parent}"),
-            PendingReason::Stable(reason) | PendingReason::Retryable(reason) => reason.clone(),
+            PendingReason::Stable(reason)
+            | PendingReason::ParentBehindCutoff { reason, .. }
+            | PendingReason::Retryable { reason, .. } => reason.clone(),
         };
         log::warn!("[CODEX-SYNC] deferred {}: {reason}", file_path.display());
     }
-    CodexFileSyncResult {
+    Ok(CodexFileSyncResult {
         deferred: true,
         ..CodexFileSyncResult::default()
-    }
+    })
 }
 
 /// 同步单个 Codex JSONL 文件。
@@ -1047,78 +1236,110 @@ fn sync_single_codex_file(
 
     // 文件未变化则跳过
     if file_modified <= last_modified {
+        delete_pending_entry(db, &file_path_str)?;
         return Ok(CodexFileSyncResult::default());
     }
 
-    if let Ok(mut caches) = replay_caches().lock() {
-        if let Some(pending) = caches.pending.get(file_path).cloned() {
-            if pending.modified == file_modified && pending.size == file_size {
-                match &pending.reason {
-                    PendingReason::MissingParent(parent) if !rollout_index.contains_key(parent) => {
-                        return Ok(CodexFileSyncResult {
-                            deferred: true,
-                            ..CodexFileSyncResult::default()
-                        });
-                    }
-                    PendingReason::Stable(_) => {
-                        return Ok(CodexFileSyncResult {
-                            deferred: true,
-                            ..CodexFileSyncResult::default()
-                        });
-                    }
-                    PendingReason::Retryable(_) => {
-                        caches.pending.remove(file_path);
-                    }
-                    _ => {
-                        caches.pending.remove(file_path);
+    let mut allow_behind_cutoff = false;
+    if let Some(pending) = load_pending_entry(db, &file_path_str)? {
+        if pending.modified == file_modified && pending.size == file_size {
+            match &pending.reason {
+                PendingReason::MissingParent(parent) if !rollout_index.contains_key(parent) => {
+                    return Ok(CodexFileSyncResult {
+                        deferred: true,
+                        ..CodexFileSyncResult::default()
+                    });
+                }
+                PendingReason::Stable(_) => {
+                    return Ok(CodexFileSyncResult {
+                        deferred: true,
+                        ..CodexFileSyncResult::default()
+                    });
+                }
+                PendingReason::ParentBehindCutoff {
+                    parent_id,
+                    dependencies,
+                    ..
+                } => {
+                    let current = snapshot_parent_dependencies(parent_id, rollout_index);
+                    if &current == dependencies {
+                        // 第二次看到完全相同的父文件快照时，父 rollout 可视为稳定。
+                        // 允许它早于 child fork 结束，并完成一次最终 replay 对齐。
+                        allow_behind_cutoff = true;
+                    } else {
+                        delete_pending_entry(db, &file_path_str)?;
                     }
                 }
+                PendingReason::Retryable {
+                    parent_id,
+                    dependencies,
+                    ..
+                } => {
+                    let current = snapshot_parent_dependencies(parent_id, rollout_index);
+                    if &current == dependencies {
+                        return Ok(CodexFileSyncResult {
+                            deferred: true,
+                            ..CodexFileSyncResult::default()
+                        });
+                    }
+                    delete_pending_entry(db, &file_path_str)?;
+                }
+                PendingReason::MissingParent(_) => {
+                    delete_pending_entry(db, &file_path_str)?;
+                }
             }
+        } else {
+            delete_pending_entry(db, &file_path_str)?;
         }
     }
 
     let parsed = parse_codex_file(file_path, thread_id_from_filename(file_path))?;
     if !parsed.has_billable_tokens {
         update_sync_state(db, &file_path_str, file_modified, parsed.line_offset)?;
+        delete_pending_entry(db, &file_path_str)?;
         return Ok(CodexFileSyncResult::default());
     }
     let Some(root_thread_id) = parsed.root_thread_id.as_deref() else {
-        return Ok(mark_deferred(
+        return mark_deferred(
+            db,
             file_path,
             file_modified,
             file_size,
             PendingReason::Stable("文件名缺少有效的尾部 UUID".to_string()),
-        ));
+        );
     };
     if !parsed.root_meta_seen {
-        return Ok(mark_deferred(
+        return mark_deferred(
+            db,
             file_path,
             file_modified,
             file_size,
             PendingReason::Stable("含计费 token 但尚无 session_meta".to_string()),
-        ));
+        );
     }
 
     let replay_prefix = match &parsed.parent {
         ParentResolution::None => 0,
         ParentResolution::Deferred(reason) => {
-            return Ok(mark_deferred(
+            return mark_deferred(
+                db,
                 file_path,
                 file_modified,
                 file_size,
                 PendingReason::Stable(reason.clone()),
-            ));
+            );
         }
         ParentResolution::Parent(parent_id) => {
             let Some(cutoff) = parsed.root_timestamp else {
-                return Ok(mark_deferred(
+                return mark_deferred(
+                    db,
                     file_path,
                     file_modified,
                     file_size,
                     PendingReason::Stable(
                         "parented rollout 的 root meta 缺少有效 timestamp".to_string(),
                     ),
-                ));
+                );
             };
             if let Ok(caches) = replay_caches().lock() {
                 if let Some(prefix) = caches
@@ -1130,23 +1351,43 @@ fn sync_single_codex_file(
                     prefix
                 } else {
                     drop(caches);
-                    let parent_signatures =
-                        match resolve_parent_signatures(parent_id, cutoff, rollout_index) {
-                            Ok(signatures) => signatures,
-                            Err(reason) => {
-                                let pending_reason = if rollout_index.contains_key(parent_id) {
-                                    PendingReason::Retryable(reason)
-                                } else {
-                                    PendingReason::MissingParent(parent_id.clone())
-                                };
-                                return Ok(mark_deferred(
-                                    file_path,
-                                    file_modified,
-                                    file_size,
-                                    pending_reason,
-                                ));
-                            }
-                        };
+                    let parent_signatures = match resolve_parent_signatures(
+                        parent_id,
+                        cutoff,
+                        rollout_index,
+                        allow_behind_cutoff,
+                    ) {
+                        Ok(signatures) => signatures,
+                        Err(failure) => {
+                            let pending_reason = if rollout_index.contains_key(parent_id) {
+                                match failure.kind {
+                                    ParentResolveFailureKind::BehindCutoff => {
+                                        PendingReason::ParentBehindCutoff {
+                                            parent_id: parent_id.clone(),
+                                            reason: failure.reason,
+                                            dependencies: failure.dependencies,
+                                        }
+                                    }
+                                    ParentResolveFailureKind::Retryable => {
+                                        PendingReason::Retryable {
+                                            parent_id: parent_id.clone(),
+                                            reason: failure.reason,
+                                            dependencies: failure.dependencies,
+                                        }
+                                    }
+                                }
+                            } else {
+                                PendingReason::MissingParent(parent_id.clone())
+                            };
+                            return mark_deferred(
+                                db,
+                                file_path,
+                                file_modified,
+                                file_size,
+                                pending_reason,
+                            );
+                        }
+                    };
                     let prefix = matching_replay_prefix(&parsed.token_events, &parent_signatures);
                     if let Ok(mut caches) = replay_caches().lock() {
                         caches.replay_prefixes.insert(
@@ -1161,16 +1402,17 @@ fn sync_single_codex_file(
                     prefix
                 }
             } else {
-                let parent_signatures = resolve_parent_signatures(parent_id, cutoff, rollout_index)
-                    .map_err(AppError::Config)?;
+                let parent_signatures = resolve_parent_signatures(
+                    parent_id,
+                    cutoff,
+                    rollout_index,
+                    allow_behind_cutoff,
+                )
+                .map_err(|failure| AppError::Config(failure.reason))?;
                 matching_replay_prefix(&parsed.token_events, &parent_signatures)
             }
         }
     };
-
-    if let Ok(mut caches) = replay_caches().lock() {
-        caches.pending.remove(file_path);
-    }
 
     let mut result = CodexFileSyncResult::default();
     for (token_offset, event) in parsed.token_events.iter().enumerate() {
@@ -1207,6 +1449,7 @@ fn sync_single_codex_file(
     }
 
     update_sync_state(db, &file_path_str, file_modified, parsed.line_offset)?;
+    delete_pending_entry(db, &file_path_str)?;
     Ok(result)
 }
 
@@ -1444,6 +1687,17 @@ mod tests {
         sync_single_codex_file(db, file, &build_rollout_index(&files))
     }
 
+    fn database_at(path: &Path) -> Result<Database, AppError> {
+        let conn = rusqlite::Connection::open(path)
+            .map_err(|error| AppError::Database(error.to_string()))?;
+        let db = Database {
+            conn: std::sync::Mutex::new(conn),
+        };
+        db.create_tables()?;
+        db.ensure_model_pricing_seeded()?;
+        Ok(db)
+    }
+
     #[test]
     fn test_delta_first_event() {
         let prev = None;
@@ -1598,6 +1852,234 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn historical_fork_parent_ended_before_cutoff_is_imported() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        CODEX_FILE_PARSE_COUNT.store(0, Ordering::SeqCst);
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let child = rollout_path(temp.path(), CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+            ],
+        );
+        let parent_file = fs::OpenOptions::new().write(true).open(&parent).unwrap();
+        let modified = SystemTime::UNIX_EPOCH
+            + std::time::Duration::from_secs(
+                "2026-07-10T03:00:02Z"
+                    .parse::<DateTime<Utc>>()
+                    .unwrap()
+                    .timestamp() as u64,
+            );
+        parent_file
+            .set_times(fs::FileTimes::new().set_modified(modified))
+            .unwrap();
+        drop(parent_file);
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
+                token_count_at(160, 80, 16, "2026-07-10T03:10:02Z"),
+            ],
+        );
+
+        let first = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert_eq!(
+            (first.imported, first.skipped, first.deferred),
+            (1, 1, false)
+        );
+        let second = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert_eq!(
+            (second.imported, second.skipped, second.deferred),
+            (0, 0, false)
+        );
+
+        let conn = lock_conn!(db.conn);
+        let values: (i64, i64) = conn.query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'),
+                (SELECT COUNT(*) FROM codex_pending_sync)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(values, (1, 0));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unchanged_parent_behind_cutoff_finishes_on_second_observation() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        CODEX_FILE_PARSE_COUNT.store(0, Ordering::SeqCst);
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let child = rollout_path(temp.path(), CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+            ],
+        );
+        let parent_file = fs::OpenOptions::new().write(true).open(&parent).unwrap();
+        let modified = SystemTime::UNIX_EPOCH
+            + std::time::Duration::from_secs(
+                "2026-07-10T04:00:00Z"
+                    .parse::<DateTime<Utc>>()
+                    .unwrap()
+                    .timestamp() as u64,
+            );
+        parent_file
+            .set_times(fs::FileTimes::new().set_modified(modified))
+            .unwrap();
+        drop(parent_file);
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
+                token_count_at(160, 80, 16, "2026-07-10T03:10:02Z"),
+            ],
+        );
+
+        let first = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert!(first.deferred);
+        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        clear_codex_replay_caches();
+
+        let second = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert_eq!(
+            (second.imported, second.skipped, second.deferred),
+            (1, 1, false)
+        );
+        assert_ne!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unchanged_retryable_is_not_reparsed() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        CODEX_FILE_PARSE_COUNT.store(0, Ordering::SeqCst);
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let child = rollout_path(temp.path(), CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_without_timestamp(100, 50, 10),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
+            ],
+        );
+
+        assert!(sync_test_file(&db, &child, &[&parent, &child])?.deferred);
+        let parses_after_first = CODEX_FILE_PARSE_COUNT.load(Ordering::SeqCst);
+        clear_codex_replay_caches();
+        assert!(sync_test_file(&db, &child, &[&parent, &child])?.deferred);
+        assert_eq!(
+            CODEX_FILE_PARSE_COUNT.load(Ordering::SeqCst),
+            parses_after_first
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn parent_change_retries_pending_child() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        CODEX_FILE_PARSE_COUNT.store(0, Ordering::SeqCst);
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let child = rollout_path(temp.path(), CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_without_timestamp(100, 50, 10),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:00:05Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:06Z"),
+                token_count_at(180, 80, 18, "2026-07-10T03:00:07Z"),
+            ],
+        );
+
+        assert!(sync_test_file(&db, &child, &[&parent, &child])?.deferred);
+        let parses_after_first = CODEX_FILE_PARSE_COUNT.load(Ordering::SeqCst);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                turn_context_at("2026-07-10T03:00:10Z"),
+            ],
+        );
+        clear_codex_replay_caches();
+
+        let recovered = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert_eq!((recovered.imported, recovered.deferred), (1, false));
+        assert!(CODEX_FILE_PARSE_COUNT.load(Ordering::SeqCst) > parses_after_first);
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pending_survives_database_reopen() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        CODEX_FILE_PARSE_COUNT.store(0, Ordering::SeqCst);
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("cc-switch-test.db");
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let child = rollout_path(temp.path(), CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_without_timestamp(100, 50, 10),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
+            ],
+        );
+
+        let db = database_at(&db_path)?;
+        assert!(sync_test_file(&db, &child, &[&parent, &child])?.deferred);
+        let parses_after_first = CODEX_FILE_PARSE_COUNT.load(Ordering::SeqCst);
+        drop(db);
+        clear_codex_replay_caches();
+
+        let reopened = database_at(&db_path)?;
+        assert!(sync_test_file(&reopened, &child, &[&parent, &child])?.deferred);
+        assert_eq!(
+            CODEX_FILE_PARSE_COUNT.load(Ordering::SeqCst),
+            parses_after_first
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_filtered_parent_events_use_subsequence_prefix_alignment() -> Result<(), AppError> {
         clear_codex_replay_caches();
         let db = Database::memory()?;
@@ -1647,10 +2129,20 @@ mod tests {
 
         let early = "2026-07-10T03:00:05Z".parse::<DateTime<Utc>>().unwrap();
         let late = "2026-07-10T03:00:15Z".parse::<DateTime<Utc>>().unwrap();
-        assert_eq!(parent_signatures_before(&parent, early).unwrap().len(), 1);
+        assert_eq!(
+            parent_signatures_before(&parent, early, false)
+                .unwrap()
+                .len(),
+            1
+        );
         let first_timeline =
             Arc::clone(&replay_caches().lock().unwrap().parent_timelines[&parent].timeline);
-        assert_eq!(parent_signatures_before(&parent, late).unwrap().len(), 2);
+        assert_eq!(
+            parent_signatures_before(&parent, late, false)
+                .unwrap()
+                .len(),
+            2
+        );
 
         let caches = replay_caches().lock().unwrap();
         assert_eq!(caches.parent_timelines.len(), 1);
@@ -1676,7 +2168,12 @@ mod tests {
                 turn_context_at("2026-07-10T03:00:20Z"),
             ],
         );
-        assert_eq!(parent_signatures_before(&parent, cutoff).unwrap().len(), 1);
+        assert_eq!(
+            parent_signatures_before(&parent, cutoff, false)
+                .unwrap()
+                .len(),
+            1
+        );
 
         write_jsonl(
             &parent,
@@ -1687,7 +2184,12 @@ mod tests {
                 turn_context_at("2026-07-10T03:00:20Z"),
             ],
         );
-        assert_eq!(parent_signatures_before(&parent, cutoff).unwrap().len(), 2);
+        assert_eq!(
+            parent_signatures_before(&parent, cutoff, false)
+                .unwrap()
+                .len(),
+            2
+        );
 
         let caches = replay_caches().lock().unwrap();
         assert_eq!(caches.parent_timelines.len(), 1);
@@ -1710,19 +2212,26 @@ mod tests {
             ],
         );
 
-        let first_error = parent_signatures_before(&parent, cutoff).unwrap_err();
-        assert!(first_error.contains("token_count 缺少有效 timestamp"));
+        let first_error = parent_signatures_before(&parent, cutoff, false).unwrap_err();
+        assert!(matches!(
+            &first_error,
+            ParentTimelineError::Invalid(reason)
+                if reason.contains("token_count 缺少有效 timestamp")
+        ));
         let cached_timeline =
             || Arc::clone(&replay_caches().lock().unwrap().parent_timelines[&parent].timeline);
         let first_timeline = cached_timeline();
 
-        let second_error = parent_signatures_before(&parent, cutoff).unwrap_err();
+        let second_error = parent_signatures_before(&parent, cutoff, false).unwrap_err();
         assert_eq!(second_error, first_error);
         assert!(Arc::ptr_eq(&first_timeline, &cached_timeline()));
 
         fs::remove_file(&parent).unwrap();
-        let open_error = parent_signatures_before(&parent, cutoff).unwrap_err();
-        assert!(open_error.contains("无法打开父 rollout"));
+        let open_error = parent_signatures_before(&parent, cutoff, false).unwrap_err();
+        assert!(matches!(
+            open_error,
+            ParentTimelineError::Invalid(reason) if reason.contains("无法打开父 rollout")
+        ));
     }
 
     #[test]
@@ -1746,10 +2255,15 @@ mod tests {
         let after = "2026-07-10T03:00:00.000000700Z"
             .parse::<DateTime<Utc>>()
             .unwrap();
-        assert!(parent_signatures_before(&parent, before)
+        assert!(parent_signatures_before(&parent, before, false)
             .unwrap()
             .is_empty());
-        assert_eq!(parent_signatures_before(&parent, after).unwrap().len(), 1);
+        assert_eq!(
+            parent_signatures_before(&parent, after, false)
+                .unwrap()
+                .len(),
+            1
+        );
         assert_eq!(replay_caches().lock().unwrap().parent_timelines.len(), 1);
     }
 
@@ -2220,6 +2734,15 @@ mod tests {
                     [path],
                 )?;
             }
+            conn.execute(
+                "INSERT INTO codex_pending_sync
+                    (file_path, child_modified, child_size, reason_json, updated_at)
+                 VALUES (?1, 1, 1, ?2, 1)",
+                rusqlite::params![
+                    current_codex.to_string_lossy().to_string(),
+                    serde_json::to_string(&PendingReason::Stable("test".to_string())).unwrap()
+                ],
+            )?;
 
             reset_codex_usage_on_conn(&conn, wide_dir)?;
             let codex_rows: i64 = conn.query_row(
@@ -2241,8 +2764,13 @@ mod tests {
                 conn.query_row("SELECT COUNT(*) FROM session_log_sync", [], |row| {
                     row.get(0)
                 })?;
+            let pending_rows: i64 =
+                conn.query_row("SELECT COUNT(*) FROM codex_pending_sync", [], |row| {
+                    row.get(0)
+                })?;
             assert_eq!((codex_rows, gemini_rows, codex_rollups), (0, 1, 0));
             assert_eq!(remaining_cursors, 2);
+            assert_eq!(pending_rows, 0);
         }
         Ok(())
     }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -145,16 +145,6 @@ impl ParentFileStamp {
     }
 }
 
-fn parent_file_was_closed_by_cutoff(stamp: ParentFileStamp, cutoff: &DateTime<Utc>) -> bool {
-    // `metadata_modified_nanos` uses 0 when the platform mtime is unavailable.
-    // Treat that sentinel as unknown instead of as the UNIX epoch; otherwise an
-    // unstable parent could bypass the BehindCutoff guard.
-    stamp.modified_nanos != 0
-        && cutoff
-            .timestamp_nanos_opt()
-            .is_some_and(|cutoff_nanos| stamp.modified_nanos <= cutoff_nanos)
-}
-
 #[cfg(windows)]
 fn windows_file_identity(file: &fs::File) -> Option<(u64, [u8; 16])> {
     let mut information = FILE_ID_INFO::default();
@@ -177,7 +167,10 @@ fn windows_file_identity(file: &fs::File) -> Option<(u64, [u8; 16])> {
 #[derive(Debug)]
 struct ParentTokenTimeline {
     events: Vec<TimestampedTokenSignature>,
-    max_timestamp: Option<DateTime<Utc>>,
+    max_finalized_timestamp: Option<DateTime<Utc>>,
+    ends_at_finalized_turn_boundary: bool,
+    unfinalized_activity_min_timestamp: Option<DateTime<Utc>>,
+    has_unfinalized_activity_without_timestamp: bool,
     has_token_without_timestamp: bool,
 }
 
@@ -186,7 +179,7 @@ impl ParentTokenTimeline {
         &self,
         parent_path: &Path,
         cutoff: DateTime<Utc>,
-        allow_behind_cutoff: bool,
+        parent_is_archived: bool,
     ) -> Result<Vec<TokenUsageSignature>, ParentTimelineError> {
         if self.has_token_without_timestamp {
             return Err(ParentTimelineError::Invalid(format!(
@@ -194,13 +187,22 @@ impl ParentTokenTimeline {
                 parent_path.display()
             )));
         }
-        if !allow_behind_cutoff
+        let unfinalized_activity_is_after_cutoff = !self.has_unfinalized_activity_without_timestamp
             && self
-                .max_timestamp
-                .is_none_or(|timestamp| timestamp < cutoff)
+                .unfinalized_activity_min_timestamp
+                .is_none_or(|timestamp| timestamp > cutoff);
+        let finalized_through_cutoff = self
+            .max_finalized_timestamp
+            .is_some_and(|timestamp| timestamp >= cutoff)
+            && unfinalized_activity_is_after_cutoff;
+        // A completed/aborted turn at or after the cutoff seals the parent
+        // prefix even if a newer turn is now active. A file that currently
+        // ends at a terminal boundary is also safe when the parent completed
+        // before the child was created and stayed idle in `sessions`.
+        if !parent_is_archived && !finalized_through_cutoff && !self.ends_at_finalized_turn_boundary
         {
             return Err(ParentTimelineError::BehindCutoff(format!(
-                "父 rollout {} 尚未写到 child fork 时刻",
+                "父 rollout {} 尚无覆盖 child fork 时刻的已完成 turn",
                 parent_path.display()
             )));
         }
@@ -419,6 +421,14 @@ fn is_rollout_filename(file_name: &str) -> bool {
     let stem = file_name.trim_end_matches(".jsonl");
     stem.get(stem.len().saturating_sub(36)..)
         .is_some_and(|candidate| uuid::Uuid::parse_str(candidate).is_ok())
+}
+
+fn is_archived_rollout_path(file_path: &Path) -> bool {
+    file_path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("archived_sessions"))
 }
 
 fn is_codex_cursor_path(file_path: &str, codex_dir: &Path) -> bool {
@@ -1041,7 +1051,6 @@ fn parse_codex_file(
 fn parent_signatures_before(
     parent_path: &Path,
     cutoff: DateTime<Utc>,
-    allow_behind_cutoff: bool,
 ) -> Result<Vec<TokenUsageSignature>, ParentTimelineError> {
     let file = fs::File::open(parent_path).map_err(|error| {
         ParentTimelineError::Invalid(format!(
@@ -1050,9 +1059,9 @@ fn parent_signatures_before(
         ))
     })?;
     let stamp = ParentFileStamp::from_file(&file);
-    let file_was_closed_by_cutoff =
-        stamp.is_some_and(|stamp| parent_file_was_closed_by_cutoff(stamp, &cutoff));
-    let allow_behind_cutoff = allow_behind_cutoff || file_was_closed_by_cutoff;
+    // Only archived rollouts are known to be closed. An old mtime or an
+    // unchanged snapshot can also describe a paused live writer.
+    let parent_is_archived = is_archived_rollout_path(parent_path);
     let cached_timeline = stamp.and_then(|stamp| {
         replay_caches().lock().ok().and_then(|caches| {
             caches
@@ -1063,33 +1072,79 @@ fn parent_signatures_before(
         })
     });
     if let Some(timeline) = cached_timeline {
-        return timeline.signatures_before(parent_path, cutoff, allow_behind_cutoff);
+        return timeline.signatures_before(parent_path, cutoff, parent_is_archived);
     }
 
     let mut events = Vec::new();
-    let mut max_timestamp: Option<DateTime<Utc>> = None;
+    let mut max_finalized_timestamp: Option<DateTime<Utc>> = None;
+    let mut ends_at_finalized_turn_boundary = false;
+    let mut unfinalized_activity_min_timestamp: Option<DateTime<Utc>> = None;
+    let mut has_unfinalized_activity_without_timestamp = false;
     let mut has_token_without_timestamp = false;
 
     // 必须扫描完整父文件，不能在首个未来时间戳处 break：rollout 写入顺序
     // 不承诺时间戳严格单调。缓存完整时间线后，不同 child cutoff 只需内存过滤。
-    for line in BufReader::with_capacity(CODEX_JSONL_BUFFER_CAPACITY, file).lines() {
-        let Ok(line) = line else {
+    // 父时间线不能像普通增量导入那样跳过坏行；半写入的 task_started/token_count
+    // 若被忽略，前一个 terminal event 会被误当成稳定文件尾。
+    let mut reader = BufReader::with_capacity(CODEX_JSONL_BUFFER_CAPACITY, file);
+    for (line_index, line) in (&mut reader).lines().enumerate() {
+        let line_number = line_index + 1;
+        let line = line.map_err(|error| {
+            ParentTimelineError::Invalid(format!(
+                "读取父 rollout {} 第 {line_number} 行失败: {error}",
+                parent_path.display()
+            ))
+        })?;
+        if line.trim().is_empty() {
             continue;
-        };
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
-            continue;
-        };
-        let timestamp = parse_timestamp(value.get("timestamp"));
-        if let Some(timestamp) = timestamp {
-            max_timestamp = Some(max_timestamp.map_or(timestamp, |current| current.max(timestamp)));
         }
-        if value.get("type").and_then(serde_json::Value::as_str) != Some("event_msg")
-            || value
-                .get("payload")
-                .and_then(|payload| payload.get("type"))
-                .and_then(serde_json::Value::as_str)
-                != Some("token_count")
-        {
+        let value = serde_json::from_str::<serde_json::Value>(&line).map_err(|error| {
+            ParentTimelineError::Invalid(format!(
+                "解析父 rollout {} 第 {line_number} 行失败: {error}",
+                parent_path.display()
+            ))
+        })?;
+        let timestamp = parse_timestamp(value.get("timestamp"));
+        let record_type = value.get("type").and_then(serde_json::Value::as_str);
+        let payload_type = value
+            .get("payload")
+            .and_then(|payload| payload.get("type"))
+            .and_then(serde_json::Value::as_str);
+
+        let is_terminal_event = record_type == Some("event_msg")
+            && matches!(payload_type, Some("task_complete" | "turn_aborted"));
+        let is_turn_activity = matches!(record_type, Some("turn_context" | "response_item"))
+            || (record_type == Some("event_msg")
+                && matches!(
+                    payload_type,
+                    Some("task_started" | "user_message" | "token_count")
+                ));
+
+        if is_terminal_event {
+            ends_at_finalized_turn_boundary = timestamp.is_some();
+            if let Some(timestamp) = timestamp {
+                max_finalized_timestamp = Some(
+                    max_finalized_timestamp.map_or(timestamp, |current| current.max(timestamp)),
+                );
+                unfinalized_activity_min_timestamp = None;
+                has_unfinalized_activity_without_timestamp = false;
+            } else {
+                unfinalized_activity_min_timestamp = None;
+                has_unfinalized_activity_without_timestamp = true;
+            }
+        } else if is_turn_activity {
+            ends_at_finalized_turn_boundary = false;
+            if let Some(timestamp) = timestamp {
+                unfinalized_activity_min_timestamp = Some(
+                    unfinalized_activity_min_timestamp
+                        .map_or(timestamp, |current| current.min(timestamp)),
+                );
+            } else {
+                has_unfinalized_activity_without_timestamp = true;
+            }
+        }
+
+        if record_type != Some("event_msg") || payload_type != Some("token_count") {
             continue;
         }
         let Some(info) = value
@@ -1112,12 +1167,23 @@ fn parent_signatures_before(
         });
     }
 
+    let final_stamp = ParentFileStamp::from_file(reader.get_ref());
+    if stamp.is_some() && final_stamp != stamp {
+        return Err(ParentTimelineError::Invalid(format!(
+            "父 rollout {} 在读取期间发生变化",
+            parent_path.display()
+        )));
+    }
+
     let timeline = Arc::new(ParentTokenTimeline {
         events,
-        max_timestamp,
+        max_finalized_timestamp,
+        ends_at_finalized_turn_boundary,
+        unfinalized_activity_min_timestamp,
+        has_unfinalized_activity_without_timestamp,
         has_token_without_timestamp,
     });
-    let result = timeline.signatures_before(parent_path, cutoff, allow_behind_cutoff);
+    let result = timeline.signatures_before(parent_path, cutoff, parent_is_archived);
     if let (Some(stamp), Ok(mut caches)) = (stamp, replay_caches().lock()) {
         caches.parent_timelines.insert(
             parent_path.to_path_buf(),
@@ -1134,7 +1200,6 @@ fn resolve_parent_signatures(
     parent_id: &str,
     cutoff: DateTime<Utc>,
     rollout_index: &RolloutIndex,
-    allow_behind_cutoff: bool,
 ) -> Result<Vec<TokenUsageSignature>, ParentResolveFailure> {
     let Some(candidates) = rollout_index.get(parent_id) else {
         return Err(ParentResolveFailure {
@@ -1151,7 +1216,7 @@ fn resolve_parent_signatures(
 
     let mut snapshots = Vec::with_capacity(candidates.len());
     for candidate in candidates {
-        match parent_signatures_before(candidate, cutoff, allow_behind_cutoff) {
+        match parent_signatures_before(candidate, cutoff) {
             Ok(snapshot) => snapshots.push(snapshot),
             Err(ParentTimelineError::BehindCutoff(reason)) => {
                 return Err(ParentResolveFailure {
@@ -1255,7 +1320,6 @@ fn sync_single_codex_file(
         return Ok(CodexFileSyncResult::default());
     }
 
-    let mut allow_behind_cutoff = false;
     if let Some(pending) = load_pending_entry(db, &file_path_str)? {
         if pending.modified == file_modified && pending.size == file_size {
             match &pending.reason {
@@ -1278,9 +1342,10 @@ fn sync_single_codex_file(
                 } => {
                     let current = snapshot_parent_dependencies(parent_id, rollout_index);
                     if &current == dependencies {
-                        // 第二次看到完全相同的父文件快照时，父 rollout 可视为稳定。
-                        // 允许它早于 child fork 结束，并完成一次最终 replay 对齐。
-                        allow_behind_cutoff = true;
+                        return Ok(CodexFileSyncResult {
+                            deferred: true,
+                            ..CodexFileSyncResult::default()
+                        });
                     } else {
                         delete_pending_entry(db, &file_path_str)?;
                     }
@@ -1366,43 +1431,39 @@ fn sync_single_codex_file(
                     prefix
                 } else {
                     drop(caches);
-                    let parent_signatures = match resolve_parent_signatures(
-                        parent_id,
-                        cutoff,
-                        rollout_index,
-                        allow_behind_cutoff,
-                    ) {
-                        Ok(signatures) => signatures,
-                        Err(failure) => {
-                            let pending_reason = if rollout_index.contains_key(parent_id) {
-                                match failure.kind {
-                                    ParentResolveFailureKind::BehindCutoff => {
-                                        PendingReason::ParentBehindCutoff {
-                                            parent_id: parent_id.clone(),
-                                            reason: failure.reason,
-                                            dependencies: failure.dependencies,
+                    let parent_signatures =
+                        match resolve_parent_signatures(parent_id, cutoff, rollout_index) {
+                            Ok(signatures) => signatures,
+                            Err(failure) => {
+                                let pending_reason = if rollout_index.contains_key(parent_id) {
+                                    match failure.kind {
+                                        ParentResolveFailureKind::BehindCutoff => {
+                                            PendingReason::ParentBehindCutoff {
+                                                parent_id: parent_id.clone(),
+                                                reason: failure.reason,
+                                                dependencies: failure.dependencies,
+                                            }
+                                        }
+                                        ParentResolveFailureKind::Retryable => {
+                                            PendingReason::Retryable {
+                                                parent_id: parent_id.clone(),
+                                                reason: failure.reason,
+                                                dependencies: failure.dependencies,
+                                            }
                                         }
                                     }
-                                    ParentResolveFailureKind::Retryable => {
-                                        PendingReason::Retryable {
-                                            parent_id: parent_id.clone(),
-                                            reason: failure.reason,
-                                            dependencies: failure.dependencies,
-                                        }
-                                    }
-                                }
-                            } else {
-                                PendingReason::MissingParent(parent_id.clone())
-                            };
-                            return mark_deferred(
-                                db,
-                                file_path,
-                                file_modified,
-                                file_size,
-                                pending_reason,
-                            );
-                        }
-                    };
+                                } else {
+                                    PendingReason::MissingParent(parent_id.clone())
+                                };
+                                return mark_deferred(
+                                    db,
+                                    file_path,
+                                    file_modified,
+                                    file_size,
+                                    pending_reason,
+                                );
+                            }
+                        };
                     let prefix = matching_replay_prefix(&parsed.token_events, &parent_signatures);
                     if let Ok(mut caches) = replay_caches().lock() {
                         caches.replay_prefixes.insert(
@@ -1417,13 +1478,8 @@ fn sync_single_codex_file(
                     prefix
                 }
             } else {
-                let parent_signatures = resolve_parent_signatures(
-                    parent_id,
-                    cutoff,
-                    rollout_index,
-                    allow_behind_cutoff,
-                )
-                .map_err(|failure| AppError::Config(failure.reason))?;
+                let parent_signatures = resolve_parent_signatures(parent_id, cutoff, rollout_index)
+                    .map_err(|failure| AppError::Config(failure.reason))?;
                 matching_replay_prefix(&parsed.token_events, &parent_signatures)
             }
         }
@@ -1597,6 +1653,7 @@ fn find_codex_pricing(conn: &rusqlite::Connection, model_id: &str) -> Option<Mod
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use tempfile::tempdir;
 
     const PARENT_ID: &str = "00000000-0000-4000-8000-000000000001";
@@ -1611,6 +1668,13 @@ mod tests {
             .join("\n")
             + "\n";
         fs::write(path, contents).unwrap();
+    }
+
+    fn append_jsonl(path: &Path, values: &[serde_json::Value]) {
+        let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+        for value in values {
+            writeln!(file, "{value}").unwrap();
+        }
     }
 
     fn rollout_path(dir: &Path, thread_id: &str) -> PathBuf {
@@ -1658,6 +1722,26 @@ mod tests {
 
     fn turn_context() -> serde_json::Value {
         turn_context_at("2026-07-10T03:00:01Z")
+    }
+
+    fn lifecycle_event_at(event_type: &str, timestamp: &str) -> serde_json::Value {
+        serde_json::json!({
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": { "type": event_type }
+        })
+    }
+
+    fn task_started_at(timestamp: &str) -> serde_json::Value {
+        lifecycle_event_at("task_started", timestamp)
+    }
+
+    fn task_complete_at(timestamp: &str) -> serde_json::Value {
+        lifecycle_event_at("task_complete", timestamp)
+    }
+
+    fn turn_aborted_at(timestamp: &str) -> serde_json::Value {
+        lifecycle_event_at("turn_aborted", timestamp)
     }
 
     fn token_count_at(input: u64, cached: u64, output: u64, timestamp: &str) -> serde_json::Value {
@@ -1886,7 +1970,7 @@ mod tests {
             &[
                 session_meta(PARENT_ID),
                 token_count_at(1_000, 900, 100, "2026-07-10T03:00:01Z"),
-                turn_context_at("2026-07-10T03:00:10Z"),
+                task_complete_at("2026-07-10T03:00:10Z"),
             ],
         );
         write_jsonl(
@@ -1918,13 +2002,17 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn historical_fork_parent_ended_before_cutoff_is_imported() -> Result<(), AppError> {
+    fn archived_fork_parent_ended_before_cutoff_is_imported() -> Result<(), AppError> {
         clear_codex_replay_caches();
         CODEX_FILE_PARSE_COUNT.store(0, Ordering::SeqCst);
         let db = Database::memory()?;
         let temp = tempdir().unwrap();
-        let parent = rollout_path(temp.path(), PARENT_ID);
-        let child = rollout_path(temp.path(), CHILD_A_ID);
+        let archived = temp.path().join("archived_sessions");
+        let sessions = temp.path().join("sessions");
+        fs::create_dir_all(&archived).unwrap();
+        fs::create_dir_all(&sessions).unwrap();
+        let parent = rollout_path(&archived, PARENT_ID);
+        let child = rollout_path(&sessions, CHILD_A_ID);
         write_jsonl(
             &parent,
             &[
@@ -1932,18 +2020,6 @@ mod tests {
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
             ],
         );
-        let parent_file = fs::OpenOptions::new().write(true).open(&parent).unwrap();
-        let modified = SystemTime::UNIX_EPOCH
-            + std::time::Duration::from_secs(
-                "2026-07-10T03:00:02Z"
-                    .parse::<DateTime<Utc>>()
-                    .unwrap()
-                    .timestamp() as u64,
-            );
-        parent_file
-            .set_times(fs::FileTimes::new().set_modified(modified))
-            .unwrap();
-        drop(parent_file);
         write_jsonl(
             &child,
             &[
@@ -1978,7 +2054,137 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn unchanged_parent_behind_cutoff_finishes_on_second_observation() -> Result<(), AppError> {
+    fn completed_live_parent_turn_before_cutoff_is_imported() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let sessions = temp.path().join("sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        let parent = rollout_path(&sessions, PARENT_ID);
+        let child = rollout_path(&sessions, CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                task_complete_at("2026-07-10T03:00:02Z"),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
+                token_count_at(160, 80, 16, "2026-07-10T03:10:02Z"),
+            ],
+        );
+
+        let result = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert_eq!(
+            (result.imported, result.skipped, result.deferred),
+            (1, 1, false)
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn turn_context_after_terminal_reopens_parent_boundary() {
+        clear_codex_replay_caches();
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let cutoff = "2026-07-10T03:10:00Z".parse::<DateTime<Utc>>().unwrap();
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                task_complete_at("2026-07-10T03:00:02Z"),
+                turn_context_at("2026-07-10T03:05:00Z"),
+            ],
+        );
+
+        assert!(matches!(
+            parent_signatures_before(&parent, cutoff),
+            Err(ParentTimelineError::BehindCutoff(_))
+        ));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn turn_aborted_after_cutoff_seals_prefix_before_next_turn() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let sessions = temp.path().join("sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        let parent = rollout_path(&sessions, PARENT_ID);
+        let child = rollout_path(&sessions, CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                turn_aborted_at("2026-07-10T03:10:01Z"),
+                task_started_at("2026-07-10T03:10:02Z"),
+                token_count_at(200, 100, 20, "2026-07-10T03:10:03Z"),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
+                token_count_at(160, 80, 16, "2026-07-10T03:10:02Z"),
+            ],
+        );
+
+        let result = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert_eq!(
+            (result.imported, result.skipped, result.deferred),
+            (1, 1, false)
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unfinalized_activity_at_cutoff_overrides_terminal_watermark() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let sessions = temp.path().join("sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        let parent = rollout_path(&sessions, PARENT_ID);
+        let child = rollout_path(&sessions, CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                task_complete_at("2026-07-10T03:10:01Z"),
+                task_started_at("2026-07-10T03:09:59Z"),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
+                token_count_at(160, 80, 16, "2026-07-10T03:10:02Z"),
+            ],
+        );
+
+        let result = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert!(result.deferred);
+        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unchanged_live_parent_behind_cutoff_remains_deferred_without_reparse() -> Result<(), AppError>
+    {
         clear_codex_replay_caches();
         CODEX_FILE_PARSE_COUNT.store(0, Ordering::SeqCst);
         let db = Database::memory()?;
@@ -1990,12 +2196,58 @@ mod tests {
             &[
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                turn_context_at("2026-07-10T03:20:00Z"),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
+                token_count_at(160, 80, 16, "2026-07-10T03:10:02Z"),
+            ],
+        );
+
+        let first = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert!(first.deferred);
+        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        let parses_after_first = CODEX_FILE_PARSE_COUNT.load(Ordering::SeqCst);
+        clear_codex_replay_caches();
+
+        let second = sync_test_file(&db, &child, &[&parent, &child])?;
+        assert!(second.deferred);
+        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        assert_eq!(
+            CODEX_FILE_PARSE_COUNT.load(Ordering::SeqCst),
+            parses_after_first
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn live_parent_pause_does_not_commit_child_before_delayed_event_arrives() -> Result<(), AppError>
+    {
+        clear_codex_replay_caches();
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let sessions = temp.path().join("sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        let parent = rollout_path(&sessions, PARENT_ID);
+        let child = rollout_path(&sessions, CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                task_complete_at("2026-07-10T03:00:02Z"),
+                task_started_at("2026-07-10T03:00:03Z"),
             ],
         );
         let parent_file = fs::OpenOptions::new().write(true).open(&parent).unwrap();
         let modified = SystemTime::UNIX_EPOCH
             + std::time::Duration::from_secs(
-                "2026-07-10T04:00:00Z"
+                "2026-07-10T03:00:02Z"
                     .parse::<DateTime<Utc>>()
                     .unwrap()
                     .timestamp() as u64,
@@ -2010,20 +2262,36 @@ mod tests {
                 session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:10:00Z"),
                 token_count_at(100, 50, 10, "2026-07-10T03:10:01Z"),
                 token_count_at(160, 80, 16, "2026-07-10T03:10:02Z"),
+                token_count_at(220, 110, 22, "2026-07-10T03:10:03Z"),
             ],
         );
 
         let first = sync_test_file(&db, &child, &[&parent, &child])?;
         assert!(first.deferred);
         assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+
+        append_jsonl(
+            &parent,
+            &[
+                token_count_at(160, 80, 16, "2026-07-10T03:00:05Z"),
+                task_complete_at("2026-07-10T03:10:01Z"),
+            ],
+        );
         clear_codex_replay_caches();
 
         let second = sync_test_file(&db, &child, &[&parent, &child])?;
         assert_eq!(
             (second.imported, second.skipped, second.deferred),
-            (1, 1, false)
+            (1, 2, false)
         );
-        assert_ne!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        let conn = lock_conn!(db.conn);
+        let usage: (i64, i64, i64) = conn.query_row(
+            "SELECT input_tokens, cache_read_tokens, output_tokens
+             FROM proxy_request_logs WHERE request_id = ?1",
+            [format!("{CODEX_THREAD_REQUEST_ID_PREFIX}:{CHILD_A_ID}:3")],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(usage, (60, 30, 6));
         Ok(())
     }
 
@@ -2094,7 +2362,7 @@ mod tests {
             &[
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
-                turn_context_at("2026-07-10T03:00:10Z"),
+                task_complete_at("2026-07-10T03:00:10Z"),
             ],
         );
         clear_codex_replay_caches();
@@ -2159,7 +2427,7 @@ mod tests {
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
                 token_count_at(200, 100, 20, "2026-07-10T03:00:02Z"),
                 token_count_at(300, 150, 30, "2026-07-10T03:00:03Z"),
-                turn_context_at("2026-07-10T03:00:10Z"),
+                task_complete_at("2026-07-10T03:00:10Z"),
             ],
         );
         write_jsonl(
@@ -2189,26 +2457,16 @@ mod tests {
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
                 token_count_at(200, 100, 20, "2026-07-10T03:00:10Z"),
-                turn_context_at("2026-07-10T03:00:20Z"),
+                task_complete_at("2026-07-10T03:00:20Z"),
             ],
         );
 
         let early = "2026-07-10T03:00:05Z".parse::<DateTime<Utc>>().unwrap();
         let late = "2026-07-10T03:00:15Z".parse::<DateTime<Utc>>().unwrap();
-        assert_eq!(
-            parent_signatures_before(&parent, early, false)
-                .unwrap()
-                .len(),
-            1
-        );
+        assert_eq!(parent_signatures_before(&parent, early).unwrap().len(), 1);
         let first_timeline =
             Arc::clone(&replay_caches().lock().unwrap().parent_timelines[&parent].timeline);
-        assert_eq!(
-            parent_signatures_before(&parent, late, false)
-                .unwrap()
-                .len(),
-            2
-        );
+        assert_eq!(parent_signatures_before(&parent, late).unwrap().len(), 2);
 
         let caches = replay_caches().lock().unwrap();
         assert_eq!(caches.parent_timelines.len(), 1);
@@ -2231,15 +2489,10 @@ mod tests {
             &[
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
-                turn_context_at("2026-07-10T03:00:20Z"),
+                task_complete_at("2026-07-10T03:00:20Z"),
             ],
         );
-        assert_eq!(
-            parent_signatures_before(&parent, cutoff, false)
-                .unwrap()
-                .len(),
-            1
-        );
+        assert_eq!(parent_signatures_before(&parent, cutoff).unwrap().len(), 1);
 
         write_jsonl(
             &parent,
@@ -2247,15 +2500,10 @@ mod tests {
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
                 token_count_at(200, 100, 20, "2026-07-10T03:00:10Z"),
-                turn_context_at("2026-07-10T03:00:20Z"),
+                task_complete_at("2026-07-10T03:00:20Z"),
             ],
         );
-        assert_eq!(
-            parent_signatures_before(&parent, cutoff, false)
-                .unwrap()
-                .len(),
-            2
-        );
+        assert_eq!(parent_signatures_before(&parent, cutoff).unwrap().len(), 2);
 
         let caches = replay_caches().lock().unwrap();
         assert_eq!(caches.parent_timelines.len(), 1);
@@ -2274,11 +2522,11 @@ mod tests {
             &[
                 session_meta(PARENT_ID),
                 token_count_without_timestamp(100, 50, 10),
-                turn_context_at("2026-07-10T03:00:20Z"),
+                task_complete_at("2026-07-10T03:00:20Z"),
             ],
         );
 
-        let first_error = parent_signatures_before(&parent, cutoff, false).unwrap_err();
+        let first_error = parent_signatures_before(&parent, cutoff).unwrap_err();
         assert!(matches!(
             &first_error,
             ParentTimelineError::Invalid(reason)
@@ -2288,16 +2536,48 @@ mod tests {
             || Arc::clone(&replay_caches().lock().unwrap().parent_timelines[&parent].timeline);
         let first_timeline = cached_timeline();
 
-        let second_error = parent_signatures_before(&parent, cutoff, false).unwrap_err();
+        let second_error = parent_signatures_before(&parent, cutoff).unwrap_err();
         assert_eq!(second_error, first_error);
         assert!(Arc::ptr_eq(&first_timeline, &cached_timeline()));
 
         fs::remove_file(&parent).unwrap();
-        let open_error = parent_signatures_before(&parent, cutoff, false).unwrap_err();
+        let open_error = parent_signatures_before(&parent, cutoff).unwrap_err();
         assert!(matches!(
             open_error,
             ParentTimelineError::Invalid(reason) if reason.contains("无法打开父 rollout")
         ));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn partial_parent_line_does_not_reuse_previous_terminal_boundary() {
+        clear_codex_replay_caches();
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let cutoff = "2026-07-10T03:10:00Z".parse::<DateTime<Utc>>().unwrap();
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                task_complete_at("2026-07-10T03:00:02Z"),
+            ],
+        );
+        let mut file = fs::OpenOptions::new().append(true).open(&parent).unwrap();
+        write!(
+            file,
+            "{{\"timestamp\":\"2026-07-10T03:05:00Z\",\"type\":\"event_msg\",\"payload\":{{\"type\":\"task_started\"}}"
+        )
+        .unwrap();
+        drop(file);
+
+        let error = parent_signatures_before(&parent, cutoff).unwrap_err();
+        assert!(matches!(
+            error,
+            ParentTimelineError::Invalid(reason)
+                if reason.contains("解析父 rollout") && reason.contains("第 4 行")
+        ));
+        assert!(replay_caches().lock().unwrap().parent_timelines.is_empty());
     }
 
     #[test]
@@ -2311,7 +2591,7 @@ mod tests {
             &[
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:00.000000500Z"),
-                turn_context_at("2026-07-10T03:00:00.000000900Z"),
+                task_complete_at("2026-07-10T03:00:00.000000900Z"),
             ],
         );
 
@@ -2321,15 +2601,10 @@ mod tests {
         let after = "2026-07-10T03:00:00.000000700Z"
             .parse::<DateTime<Utc>>()
             .unwrap();
-        assert!(parent_signatures_before(&parent, before, false)
+        assert!(parent_signatures_before(&parent, before)
             .unwrap()
             .is_empty());
-        assert_eq!(
-            parent_signatures_before(&parent, after, false)
-                .unwrap()
-                .len(),
-            1
-        );
+        assert_eq!(parent_signatures_before(&parent, after).unwrap().len(), 1);
         assert_eq!(replay_caches().lock().unwrap().parent_timelines.len(), 1);
     }
 
@@ -2361,27 +2636,6 @@ mod tests {
     }
 
     #[test]
-    fn unknown_parent_mtime_does_not_mark_file_closed_by_cutoff() {
-        let cutoff = "2026-07-10T03:00:00Z".parse::<DateTime<Utc>>().unwrap();
-        let mut stamp = ParentFileStamp {
-            modified_nanos: 0,
-            size: 1,
-            #[cfg(unix)]
-            device: 1,
-            #[cfg(unix)]
-            inode: 1,
-            #[cfg(windows)]
-            volume_serial: 1,
-            #[cfg(windows)]
-            file_id: [0; 16],
-        };
-
-        assert!(!parent_file_was_closed_by_cutoff(stamp, &cutoff));
-        stamp.modified_nanos = 1;
-        assert!(parent_file_was_closed_by_cutoff(stamp, &cutoff));
-    }
-
-    #[test]
     #[serial_test::serial]
     fn test_empty_fork_imports_no_parent_usage() -> Result<(), AppError> {
         clear_codex_replay_caches();
@@ -2395,7 +2649,7 @@ mod tests {
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
                 token_count_at(200, 100, 20, "2026-07-10T03:00:02Z"),
-                turn_context_at("2026-07-10T03:00:10Z"),
+                task_complete_at("2026-07-10T03:00:10Z"),
             ],
         );
         write_jsonl(
@@ -2467,6 +2721,7 @@ mod tests {
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
                 token_count_at(200, 100, 20, "2026-07-10T03:00:06Z"),
+                task_complete_at("2026-07-10T03:00:08Z"),
             ],
         );
         write_jsonl(
@@ -2511,7 +2766,7 @@ mod tests {
             &[
                 session_meta(PARENT_ID),
                 token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
-                turn_context_at("2026-07-10T03:00:10Z"),
+                task_complete_at("2026-07-10T03:00:10Z"),
             ],
         );
         let recovered = sync_test_file(&db, &child, &[&parent, &child])?;


### PR DESCRIPTION
## Summary / 概述

CC Switch periodically reads Codex rollout JSONL files and imports their token usage into the local database. This PR fixes a fork-history edge case that could leave historical rollout files permanently deferred and repeatedly read even when none of the files had changed.

CC Switch 会定期读取 Codex rollout JSONL 文件，并将 token usage 同步到本地数据库。本 PR 修复了 fork 会话历史中的一个边界情况：部分历史文件会长期停留在 deferred 状态，即使文件没有变化，后续同步仍可能反复读取它们。

### Root cause / 问题根因

A forked Codex session may contain token history replayed from its parent rollout. Before importing the child, the sync code resolves the parent timeline and removes the replayed prefix so those tokens are not counted twice.

Codex 的 fork 会话可能会重放父 rollout 中已有的 token history。同步 child 前，需要先解析父文件的 token timeline，并从 child 中去掉这段重放前缀，避免重复统计。

The previous readiness guard used the maximum timestamp of any parent event. That does not describe whether the parent turn is actually finalized. A completed parent can legitimately end before the child fork timestamp and remain under `sessions`, while a live parent can pause after writing a later `turn_context` or another non-terminal event and append a delayed token event afterwards.

旧 readiness guard 使用父文件中任意事件的最大时间戳，但这个时间戳不能说明当前 turn 是否真的结束。父 rollout 可能已经完成，但终止时间早于 child fork 且文件仍留在 `sessions`；也可能只是活跃写入器暂时停顿，已经写入较晚的 `turn_context` 等非终止事件，之后仍会补写时间戳更早的 token event。

File modification time and repeated unchanged snapshots are not valid substitutes for a lifecycle boundary either. An active writer may be paused for an arbitrary amount of time, and `metadata.modified()` may be unavailable. Treating either condition as proof of closure can advance the child cursor using an incomplete parent replay prefix and later double-count usage.

文件修改时间或“连续两次快照未变化”同样不能替代生命周期边界。活跃写入器可能暂停任意时长，`metadata.modified()` 也可能读取失败。如果把这些条件当成文件已关闭的证明，就可能基于不完整的父重放前缀推进 child cursor，随后在父文件补写时重复计费。

The old resolver classified this as `BehindCutoff` and deferred the child. Because a deferred file did not advance its synchronization cursor, a later periodic sync could open and parse the same child again, then scan its parent candidates again while attempting the same resolution.

旧解析器会把这种情况标记为 `BehindCutoff` 并推迟 child。deferred 文件不会推进同步游标，因此后续定时同步可能再次打开并解析同一个 child，同时重新扫描候选父文件，然后得到相同结果。

```text
completed parent ends before child cutoff
    -> parent is treated as "behind"
    -> child remains deferred
    -> sync cursor is not advanced
    -> later sync repeats the same JSONL reads
```

The existing deferred cache was process-local. It could not preserve the decision across restarts, and it did not keep a durable snapshot of the parent files that the decision depended on. Historical sessions could therefore generate disk reads without any new usage data being available.

原有 deferred cache 只存在于进程内存中，重启后会丢失，也没有持久记录本次判断所依赖的父文件状态。因此，即使没有新的 usage 数据，历史会话仍可能触发磁盘读取。

### Why this needs to be fixed / 为什么需要修复

Rollout files can grow to several megabytes, and a fork may require both the child and one or more parent files to be examined. Repeating those reads during background synchronization creates sustained disk activity while producing no new database rows. The problem is especially visible on installations with a long Codex history or several unresolved forks.

单个 rollout 文件可能达到数 MB。处理 fork 时，除了 child，还可能读取一个或多个候选父文件。后台同步如果重复执行这些读取，会持续占用磁盘，却不会产生新的数据库记录。Codex 历史较长或存在多个未解析 fork 时，这个问题会更明显。

### How it is fixed / 修复方式

1. **Use lifecycle finalization barriers instead of file timestamps**

   Active parent rollouts are accepted only when `task_complete` or `turn_aborted` proves that the relevant prefix is finalized, or when the current file snapshot ends at a valid terminal turn boundary. Activity after that boundary (`task_started`, `turn_context`, `user_message`, `response_item`, or `token_count`) is tracked, so activity at or before the child cutoff keeps the child deferred. Archived rollouts remain safe because `archived_sessions` files are immutable inputs.

   活跃父 rollout 只有在 `task_complete` 或 `turn_aborted` 证明相关前缀已经完成，或者当前文件快照确实停在有效的 turn 终止边界时，才允许用于 replay 对齐。终止边界后的 `task_started`、`turn_context`、`user_message`、`response_item`、`token_count` 会被继续跟踪；只要存在不晚于 child cutoff 的未完成活动，child 就保持 deferred。`archived_sessions` 中的归档文件作为不可变输入，可直接使用。

2. **Reject incomplete or changing parent snapshots**

   Parent timeline parsing is strict. Read errors and malformed/partially written JSONL lines defer the child instead of silently skipping data. The parent file stamp is checked again after the scan; if the file changed while it was being read, the result is discarded and retried after the dependency snapshot changes.

   父 timeline 使用严格解析。读取错误、损坏或尚未写完整的 JSONL 行不会被静默跳过，而是让 child 延后处理。扫描结束后还会再次核对父文件状态；如果文件在读取期间发生变化，本次结果会被丢弃，并在依赖快照变化后重试。

3. **Persist deferred decisions**

   A new `codex_pending_sync` table stores the child path, modification time, size, deferred reason, and parent dependency snapshot. Unchanged deferred files can now be skipped before opening and parsing their JSONL content. The state also survives application restarts.

   新增 `codex_pending_sync` 表，保存 child 路径、修改时间、文件大小、deferred 原因及父文件依赖快照。对于状态未变化的 deferred 文件，同步逻辑可以在打开 JSONL 前直接跳过；应用重启后，这些状态仍然有效。

4. **Retry only when an actual dependency changes**

   Parent dependencies are tracked by path, modification time, size, and platform file identity. On Windows this includes the volume serial number and file ID; on Unix it includes device and inode values. A deferred child is retried when the child changes, a missing parent appears, or one of the recorded parent files is modified or replaced.

   父依赖快照包含路径、修改时间、文件大小及平台文件标识。Windows 使用卷序列号和文件 ID，Unix 使用 device 和 inode。只有在 child 变化、缺失的父文件出现，或已记录的父文件被修改或替换时，才重新处理 deferred child。

5. **Reuse parsed parent timelines**

   The complete parent token timeline is cached using the parent file stamp. Multiple children that reference the same unchanged parent can filter the cached timeline in memory instead of rescanning the parent JSONL file.

   完整的父 token timeline 会按文件状态缓存。多个 child 引用同一个未变化的父文件时，可以直接在内存中筛选 timeline，不再重复扫描父 JSONL。

6. **Reduce read-call overhead**

   JSONL readers now use a 256 KiB buffer instead of the default 8 KiB buffer. This does not replace the skip logic above, but it reduces filesystem read-call overhead when a file genuinely needs to be parsed.

   JSONL reader 的缓冲区由默认的 8 KiB 调整为 256 KiB。这项修改不能代替前面的跳过逻辑，但能降低文件确实需要解析时的系统读取调用开销。

7. **Validate and clean up persisted pending state**

   Pending `child_size` values are range-checked in both SQLite directions instead of being silently rewritten, and JSON serialization uses the dedicated serialization error type. Pending entries are removed after a successful sync, when the normal sync cursor already covers the file, and when Codex usage data is reset.

   从 SQLite 读取及写入 pending `child_size` 时都会严格检查数值范围，不再静默改写；JSON 序列化错误也使用专用错误类型。文件同步成功、普通同步游标已经覆盖该文件，或 Codex usage 数据被重置时，会清理对应的 pending 记录。

### Database migration / 数据库迁移

The database schema version is increased from v16 to v17. The migration only creates the `codex_pending_sync` table with `CREATE TABLE IF NOT EXISTS`; it does not delete or rebuild existing usage data.

数据库 schema 由 v16 升级到 v17。迁移仅通过 `CREATE TABLE IF NOT EXISTS` 创建 `codex_pending_sync`，不会删除或重建现有 usage 数据。

The migration test verifies that existing Codex usage rows and `session_log_sync` cursors remain unchanged after upgrading from v16 to v17. Fresh databases create the same table as part of their initial schema.

迁移测试覆盖了 v16 到 v17 的升级过程，确认已有 Codex usage 记录和 `session_log_sync` 游标保持不变。新数据库也会在初始化 schema 时创建该表。

### Behavior change / 行为变化

| Scenario / 场景 | Before / 修改前 | After / 修改后 |
|---|---|---|
| Completed parent ends before child cutoff / 父 turn 在 child cutoff 前完成 | Parent may remain `BehindCutoff`; child stays deferred / 可能持续判定为 `BehindCutoff` | A valid terminal boundary is accepted even while the file remains in `sessions` / 即使文件仍在 `sessions`，有效终止边界也可用于对齐 |
| Live parent pauses or writes a non-terminal future timestamp / 活跃父文件暂停或写入较晚的非终止事件 | An arbitrary timestamp, old mtime, or repeated stable snapshot can be mistaken for completion / 任意时间戳、旧 mtime 或重复稳定快照可能被误判为完成 | Requires lifecycle finalization and rejects unfinalized activity at/before cutoff / 必须存在生命周期终止屏障，并拒绝 cutoff 前后的未完成活动 |
| Parent contains a partial line or changes during scanning / 父文件存在半行或扫描期间变化 | Relevant data may be skipped / 相关数据可能被跳过 | Discard the snapshot and retry without advancing the child cursor / 丢弃快照并延后重试，不推进 child cursor |
| Deferred child and dependencies are unchanged / deferred child 与依赖均未变化 | JSONL files may be reopened on later syncs or after restart / 后续同步或重启后可能重新读取 | Skip before parsing / 在解析前直接跳过 |
| Several children use the same parent / 多个 child 使用同一父文件 | Parent timeline may be scanned repeatedly / 可能重复扫描父 timeline | Reuse the cached timeline while the parent stamp is unchanged / 父文件未变化时复用缓存 |
| JSONL parsing / JSONL 解析 | 8 KiB buffer / 8 KiB 缓冲区 | 256 KiB buffer / 256 KiB 缓冲区 |

### Validation / 验证

- Codex session usage tests: 46/46 passed.
- Database schema and migration tests: 5/5 passed.
- `cargo clippy` completed without warnings.
- Rust library suite with the fixed-port proxy test excluded: 2251 passed, 2 ignored, 1 filtered out. The excluded test requires binding the same local proxy port used by the running CC Switch instance.
- TypeScript typecheck completed successfully with `tsc --noEmit`.
- Prettier format check passed for all matching frontend files.

## Related Issue / 关联 Issue

#5823 

## Screenshots / 截图

This is a backend synchronization and database migration change. It does not change the user interface.

本 PR 修改后端同步逻辑和数据库迁移，不涉及用户界面变化。

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| N/A             | N/A           |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（N/A：未修改用户可见文本）
