### PR TITLE
feat(codex): add configurable sub-agent defaults

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -248,6 +248,7 @@ pub fn write_codex_live_atomic(
         Some(s) => s.to_string(),
         None => String::new(),
     };
+    let cfg_text = crate::codex_subagents::apply_persisted_settings_to_config_text(&cfg_text)?;
     if !cfg_text.trim().is_empty() {
         toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;
     }
@@ -323,6 +324,7 @@ pub fn write_codex_live_config_atomic(config_text_opt: Option<&str>) -> Result<(
         Some(config_text) => config_text.to_string(),
         None => String::new(),
     };
+    let cfg_text = crate::codex_subagents::apply_persisted_settings_to_config_text(&cfg_text)?;
 
     if !cfg_text.trim().is_empty() {
         toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;

--- a/src-tauri/src/codex_subagents.rs
+++ b/src-tauri/src/codex_subagents.rs
@@ -1,0 +1,277 @@
+use std::collections::BTreeSet;
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use toml_edit::DocumentMut;
+
+use crate::config::{get_app_config_dir, read_json_file, write_json_file};
+use crate::error::AppError;
+
+const SETTINGS_FILE_NAME: &str = "codex-subagent-settings.json";
+const MAX_MODEL_LENGTH: usize = 256;
+
+pub const CODEX_REASONING_EFFORTS: [&str; 6] = ["low", "medium", "high", "xhigh", "max", "ultra"];
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSubagentSettings {
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexSubagentSettingsView {
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub available_models: Vec<String>,
+    pub config_path: String,
+}
+
+fn settings_path() -> std::path::PathBuf {
+    get_app_config_dir().join(SETTINGS_FILE_NAME)
+}
+
+fn normalize_settings(
+    model: Option<String>,
+    reasoning_effort: Option<String>,
+) -> Result<CodexSubagentSettings, AppError> {
+    let model = model
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if model
+        .as_ref()
+        .is_some_and(|value| value.chars().count() > MAX_MODEL_LENGTH)
+    {
+        return Err(AppError::InvalidInput(format!(
+            "Codex subagent model must be at most {MAX_MODEL_LENGTH} characters"
+        )));
+    }
+
+    let reasoning_effort = reasoning_effort
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if let Some(effort) = reasoning_effort.as_deref() {
+        if !CODEX_REASONING_EFFORTS.contains(&effort) {
+            return Err(AppError::InvalidInput(format!(
+                "Unsupported Codex subagent reasoning effort: {effort}"
+            )));
+        }
+    }
+
+    Ok(CodexSubagentSettings {
+        model,
+        reasoning_effort,
+    })
+}
+
+fn read_persisted_settings() -> Result<Option<CodexSubagentSettings>, AppError> {
+    let path = settings_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let settings: CodexSubagentSettings = read_json_file(&path)?;
+    normalize_settings(settings.model, settings.reasoning_effort).map(Some)
+}
+
+fn read_live_defaults(config_text: &str) -> CodexSubagentSettings {
+    let Ok(doc) = config_text.parse::<DocumentMut>() else {
+        return CodexSubagentSettings::default();
+    };
+
+    let Some(agents) = doc.get("agents").and_then(|item| item.as_table_like()) else {
+        return CodexSubagentSettings::default();
+    };
+
+    let model = agents
+        .get("default_subagent_model")
+        .and_then(|item| item.as_str())
+        .map(str::to_string);
+    let reasoning_effort = agents
+        .get("default_subagent_reasoning_effort")
+        .and_then(|item| item.as_str())
+        .map(str::to_string);
+
+    normalize_settings(model, reasoning_effort).unwrap_or_default()
+}
+
+fn available_models(config_text: &str) -> Vec<String> {
+    let mut models = BTreeSet::new();
+
+    if let Ok(doc) = config_text.parse::<DocumentMut>() {
+        if let Some(model) = doc.get("model").and_then(|item| item.as_str()) {
+            let model = model.trim();
+            if !model.is_empty() {
+                models.insert(model.to_string());
+            }
+        }
+    }
+
+    let catalog_path = crate::codex_config::get_codex_model_catalog_path();
+    if let Ok(catalog_text) = fs::read_to_string(catalog_path) {
+        if let Ok(catalog) = serde_json::from_str::<Value>(&catalog_text) {
+            if let Some(entries) = catalog.get("models").and_then(Value::as_array) {
+                for model in entries.iter().filter_map(|entry| {
+                    entry
+                        .get("slug")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                }) {
+                    models.insert(model.to_string());
+                }
+            }
+        }
+    }
+
+    models.into_iter().collect()
+}
+
+pub fn get_settings_view() -> Result<CodexSubagentSettingsView, AppError> {
+    let config_text = crate::codex_config::read_codex_config_text()?;
+    let settings = read_persisted_settings()?.unwrap_or_else(|| read_live_defaults(&config_text));
+
+    Ok(CodexSubagentSettingsView {
+        model: settings.model,
+        reasoning_effort: settings.reasoning_effort,
+        available_models: available_models(&config_text),
+        config_path: crate::codex_config::get_codex_config_path()
+            .to_string_lossy()
+            .to_string(),
+    })
+}
+
+pub fn apply_settings_to_config_text(
+    config_text: &str,
+    settings: &CodexSubagentSettings,
+) -> Result<String, AppError> {
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|error| AppError::Message(format!("Invalid Codex config.toml: {error}")))?;
+
+    let has_settings = settings.model.is_some() || settings.reasoning_effort.is_some();
+    if !has_settings {
+        if let Some(agents) = doc.get_mut("agents") {
+            let table = agents.as_table_like_mut().ok_or_else(|| {
+                AppError::Message("Codex config [agents] must be a TOML table".to_string())
+            })?;
+            table.remove("default_subagent_model");
+            table.remove("default_subagent_reasoning_effort");
+        }
+        return Ok(doc.to_string());
+    }
+
+    if doc.get("agents").is_none() {
+        doc["agents"] = toml_edit::table();
+    }
+
+    let agents = doc
+        .get_mut("agents")
+        .and_then(toml_edit::Item::as_table_like_mut)
+        .ok_or_else(|| {
+            AppError::Message("Codex config [agents] must be a TOML table".to_string())
+        })?;
+
+    match settings.model.as_deref() {
+        Some(model) => {
+            agents.insert("default_subagent_model", toml_edit::value(model));
+        }
+        None => {
+            agents.remove("default_subagent_model");
+        }
+    }
+    match settings.reasoning_effort.as_deref() {
+        Some(effort) => {
+            agents.insert(
+                "default_subagent_reasoning_effort",
+                toml_edit::value(effort),
+            );
+        }
+        None => {
+            agents.remove("default_subagent_reasoning_effort");
+        }
+    }
+
+    Ok(doc.to_string())
+}
+
+pub fn apply_persisted_settings_to_config_text(config_text: &str) -> Result<String, AppError> {
+    let Some(settings) = read_persisted_settings()? else {
+        return Ok(config_text.to_string());
+    };
+    apply_settings_to_config_text(config_text, &settings)
+}
+
+pub fn save_settings(
+    model: Option<String>,
+    reasoning_effort: Option<String>,
+) -> Result<CodexSubagentSettingsView, AppError> {
+    let settings = normalize_settings(model, reasoning_effort)?;
+    write_json_file(&settings_path(), &settings)?;
+
+    let config_text = crate::codex_config::read_codex_config_text()?;
+    let updated = apply_settings_to_config_text(&config_text, &settings)?;
+    crate::codex_config::write_codex_live_config_atomic(Some(&updated))?;
+
+    get_settings_view()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_settings_to_config_text, normalize_settings, CodexSubagentSettings};
+
+    #[test]
+    fn writes_subagent_defaults_without_touching_other_agents_fields() {
+        let input = "[agents]\nmax_threads = 4\n";
+        let settings = CodexSubagentSettings {
+            model: Some("gpt-5.6-sol".to_string()),
+            reasoning_effort: Some("ultra".to_string()),
+        };
+
+        let output = apply_settings_to_config_text(input, &settings).unwrap();
+
+        assert!(output.contains("max_threads = 4"));
+        assert!(output.contains("default_subagent_model = \"gpt-5.6-sol\""));
+        assert!(output.contains("default_subagent_reasoning_effort = \"ultra\""));
+    }
+
+    #[test]
+    fn removes_only_subagent_defaults_when_cleared() {
+        let input = "[agents]\nmax_threads = 4\ndefault_subagent_model = \"gpt-5.6-sol\"\ndefault_subagent_reasoning_effort = \"high\"\n";
+        let settings = CodexSubagentSettings::default();
+
+        let output = apply_settings_to_config_text(input, &settings).unwrap();
+
+        assert!(output.contains("max_threads = 4"));
+        assert!(!output.contains("default_subagent_model"));
+        assert!(!output.contains("default_subagent_reasoning_effort"));
+    }
+
+    #[test]
+    fn preserves_reasoning_effort_when_model_is_unset() {
+        let input = "model = \"gpt-5.6\"\n";
+        let settings = normalize_settings(None, Some("high".to_string())).unwrap();
+
+        let output = apply_settings_to_config_text(input, &settings).unwrap();
+
+        assert!(output.contains("default_subagent_reasoning_effort = \"high\""));
+        assert!(!output.contains("default_subagent_model"));
+    }
+
+    #[test]
+    fn creates_agents_table_when_config_is_empty() {
+        let settings = CodexSubagentSettings {
+            model: Some("gpt-5.6-terra".to_string()),
+            reasoning_effort: None,
+        };
+
+        let output = apply_settings_to_config_text("", &settings).unwrap();
+
+        assert!(output.contains("[agents]"));
+        assert!(output.contains("default_subagent_model = \"gpt-5.6-terra\""));
+    }
+}

--- a/src-tauri/src/codex_subagents.rs
+++ b/src-tauri/src/codex_subagents.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use toml_edit::DocumentMut;
 
-use crate::config::{get_app_config_dir, read_json_file, write_json_file};
+use crate::config::{
+    atomic_write, delete_file, get_app_config_dir, read_json_file, write_json_file,
+};
 use crate::error::AppError;
 
 const SETTINGS_FILE_NAME: &str = "codex-subagent-settings.json";
@@ -211,18 +213,93 @@ pub fn save_settings(
     reasoning_effort: Option<String>,
 ) -> Result<CodexSubagentSettingsView, AppError> {
     let settings = normalize_settings(model, reasoning_effort)?;
-    write_json_file(&settings_path(), &settings)?;
+    let sidecar_path = settings_path();
+    let previous_sidecar = if sidecar_path.exists() {
+        Some(fs::read(&sidecar_path).map_err(|error| AppError::io(&sidecar_path, error))?)
+    } else {
+        None
+    };
 
-    let config_text = crate::codex_config::read_codex_config_text()?;
-    let updated = apply_settings_to_config_text(&config_text, &settings)?;
-    crate::codex_config::write_codex_live_config_atomic(Some(&updated))?;
+    write_json_file(&sidecar_path, &settings)?;
+
+    let update_result = (|| {
+        let config_text = crate::codex_config::read_codex_config_text()?;
+        let updated = apply_settings_to_config_text(&config_text, &settings)?;
+        crate::codex_config::write_codex_live_config_atomic(Some(&updated))
+    })();
+
+    if let Err(error) = update_result {
+        let rollback_result = match previous_sidecar {
+            Some(contents) => atomic_write(&sidecar_path, &contents),
+            None => delete_file(&sidecar_path),
+        };
+
+        if let Err(rollback_error) = rollback_result {
+            return Err(AppError::Config(format!(
+                "Failed to update Codex subagent settings: {error}; failed to restore the previous settings sidecar: {rollback_error}"
+            )));
+        }
+
+        return Err(error);
+    }
 
     get_settings_view()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_settings_to_config_text, normalize_settings, CodexSubagentSettings};
+    use super::{
+        apply_settings_to_config_text, normalize_settings, read_persisted_settings, save_settings,
+        settings_path, CodexSubagentSettings,
+    };
+    use serial_test::serial;
+    use std::env;
+    use tempfile::TempDir;
+
+    struct TempHome {
+        #[allow(dead_code)]
+        dir: TempDir,
+        original_home: Option<String>,
+        original_userprofile: Option<String>,
+        original_test_home: Option<String>,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let dir = TempDir::new().expect("failed to create temp home");
+            let original_home = env::var("HOME").ok();
+            let original_userprofile = env::var("USERPROFILE").ok();
+            let original_test_home = env::var("CC_SWITCH_TEST_HOME").ok();
+
+            env::set_var("HOME", dir.path());
+            env::set_var("USERPROFILE", dir.path());
+            env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+
+            Self {
+                dir,
+                original_home,
+                original_userprofile,
+                original_test_home,
+            }
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            match &self.original_home {
+                Some(value) => env::set_var("HOME", value),
+                None => env::remove_var("HOME"),
+            }
+            match &self.original_userprofile {
+                Some(value) => env::set_var("USERPROFILE", value),
+                None => env::remove_var("USERPROFILE"),
+            }
+            match &self.original_test_home {
+                Some(value) => env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+        }
+    }
 
     #[test]
     fn writes_subagent_defaults_without_touching_other_agents_fields() {
@@ -273,5 +350,28 @@ mod tests {
 
         assert!(output.contains("[agents]"));
         assert!(output.contains("default_subagent_model = \"gpt-5.6-terra\""));
+    }
+
+    #[test]
+    #[serial]
+    fn save_settings_restores_previous_sidecar_when_config_update_fails() {
+        let _home = TempHome::new();
+        let previous = CodexSubagentSettings {
+            model: Some("gpt-5.6-sol".to_string()),
+            reasoning_effort: Some("high".to_string()),
+        };
+        crate::config::write_json_file(&settings_path(), &previous)
+            .expect("seed existing settings sidecar");
+        crate::config::write_text_file(
+            &crate::codex_config::get_codex_config_path(),
+            "[agents\ndefault_subagent_model = \"broken\"\n",
+        )
+        .expect("seed malformed config");
+
+        let error = save_settings(Some("gpt-5.6-terra".to_string()), Some("ultra".to_string()))
+            .expect_err("malformed config should reject the update");
+
+        assert!(error.to_string().contains("TOML"));
+        assert_eq!(read_persisted_settings().unwrap(), Some(previous));
     }
 }

--- a/src-tauri/src/commands/codex_subagents.rs
+++ b/src-tauri/src/commands/codex_subagents.rs
@@ -1,0 +1,16 @@
+#![allow(non_snake_case)]
+
+use crate::codex_subagents::{self, CodexSubagentSettingsView};
+
+#[tauri::command]
+pub async fn get_codex_subagent_settings() -> Result<CodexSubagentSettingsView, String> {
+    codex_subagents::get_settings_view().map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn save_codex_subagent_settings(
+    model: Option<String>,
+    reasoningEffort: Option<String>,
+) -> Result<CodexSubagentSettingsView, String> {
+    codex_subagents::save_settings(model, reasoningEffort).map_err(|error| error.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@
 mod auth;
 mod balance;
 mod codex_oauth;
+mod codex_subagents;
 mod coding_plan;
 mod config;
 mod copilot;
@@ -39,6 +40,7 @@ mod workspace;
 pub use auth::*;
 pub use balance::*;
 pub use codex_oauth::*;
+pub use codex_subagents::*;
 pub use coding_plan::*;
 pub use config::*;
 pub use copilot::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod claude_plugin;
 mod codex_config;
 mod codex_history_migration;
 mod codex_state_db;
+mod codex_subagents;
 mod commands;
 mod config;
 mod database;
@@ -1417,6 +1418,9 @@ pub fn run() {
             commands::apply_profile,
             // model list fetch (OpenAI-compatible /v1/models)
             commands::fetch_models_for_config,
+            // Codex subagent defaults
+            commands::get_codex_subagent_settings,
+            commands::save_codex_subagent_settings,
             // ours: endpoint speed test + custom endpoint management
             commands::test_api_endpoints,
             commands::get_custom_endpoints,

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2944,7 +2944,7 @@ impl ProxyService {
     }
 
     fn write_codex_live_verbatim(&self, config: &Value) -> Result<(), String> {
-        use crate::codex_config::{get_codex_auth_path, get_codex_config_path};
+        use crate::codex_config::get_codex_auth_path;
 
         let auth = config.get("auth");
         let config_str = config.get("config").and_then(|v| v.as_str());
@@ -2986,8 +2986,7 @@ impl ProxyService {
                     // Codex login. This is especially important when takeover
                     // switches from an API-key-backed official session to the
                     // built-in empty `codex-official` seed.
-                    let config_path = get_codex_config_path();
-                    crate::config::write_text_file(&config_path, cfg)
+                    crate::codex_config::write_codex_live_config_atomic(Some(cfg))
                         .map_err(|e| format!("写入 Codex config 失败: {e}"))?;
                 } else {
                     crate::codex_config::write_codex_live_atomic(auth, Some(cfg))
@@ -3000,8 +2999,7 @@ impl ProxyService {
                     .map_err(|e| format!("写入 Codex auth 失败: {e}"))?;
             }
             (None, Some(cfg)) => {
-                let config_path = get_codex_config_path();
-                crate::config::write_text_file(&config_path, cfg)
+                crate::codex_config::write_codex_live_config_atomic(Some(cfg))
                     .map_err(|e| format!("写入 Codex config 失败: {e}"))?;
             }
             (None, None) => {}
@@ -4244,6 +4242,38 @@ wire_api = "responses"
             crate::config::read_json_file(&crate::codex_config::get_codex_auth_path())
                 .expect("read auth");
         assert_eq!(live_auth, auth);
+    }
+
+    #[test]
+    #[serial]
+    fn codex_verbatim_restore_preserves_subagent_defaults_without_auth() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        crate::codex_subagents::save_settings(
+            Some("gpt-5.6-sol".to_string()),
+            Some("ultra".to_string()),
+        )
+        .expect("save subagent defaults");
+        let service = ProxyService::new(Arc::new(Database::memory().expect("init db")));
+
+        for snapshot in [
+            json!({
+                "auth": {},
+                "config": "model = \"gpt-5.4-mini\"\n"
+            }),
+            json!({
+                "config": "model = \"gpt-5.4\"\n"
+            }),
+        ] {
+            service
+                .write_codex_live_verbatim(&snapshot)
+                .expect("restore Codex snapshot");
+
+            let live_config =
+                crate::codex_config::read_codex_config_text().expect("read restored Codex config");
+            assert!(live_config.contains("default_subagent_model = \"gpt-5.6-sol\""));
+            assert!(live_config.contains("default_subagent_reasoning_effort = \"ultra\""));
+        }
     }
 
     #[tokio::test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Shield,
   Cpu,
   LayoutDashboard,
+  Bot,
 } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { Provider, VisibleApps } from "@/types";
@@ -1503,6 +1504,17 @@ function App() {
                             </>
                           ) : (
                             <>
+                              {activeApp === "codex" && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setCurrentView("agents")}
+                                  className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                  title={t("agents.title")}
+                                >
+                                  <Bot className="w-4 h-4" />
+                                </Button>
+                              )}
                               <Button
                                 variant="ghost"
                                 size="sm"

--- a/src/components/agents/AgentsPanel.tsx
+++ b/src/components/agents/AgentsPanel.tsx
@@ -1,21 +1,191 @@
-import { Bot } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Bot, Loader2, RotateCcw, Save } from "lucide-react";
+import { toast } from "sonner";
+import { codexSubagentsApi } from "@/lib/api/codexSubagents";
+import { extractErrorMessage } from "@/utils/errorUtils";
+import type { CodexSubagentSettingsView } from "@/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface AgentsPanelProps {
   onOpenChange: (open: boolean) => void;
 }
 
+const UNSET_SENTINEL = "__unset__";
+const REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max", "ultra"];
+
 export function AgentsPanel({}: AgentsPanelProps) {
+  const { t } = useTranslation();
+  const [settings, setSettings] = useState<CodexSubagentSettingsView | null>(
+    null,
+  );
+  const [model, setModel] = useState("");
+  const [reasoningEffort, setReasoningEffort] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void codexSubagentsApi
+      .getSettings()
+      .then((loaded) => {
+        if (cancelled) return;
+        setSettings(loaded);
+        setModel(loaded.model ?? "");
+        setReasoningEffort(loaded.reasoningEffort ?? "");
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          toast.error(t("agents.loadFailed"), {
+            description: extractErrorMessage(error) || undefined,
+          });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const saved = await codexSubagentsApi.saveSettings(
+        model.trim() || null,
+        reasoningEffort || null,
+      );
+      setSettings(saved);
+      setModel(saved.model ?? "");
+      setReasoningEffort(saved.reasoningEffort ?? "");
+      toast.success(t("agents.saveSuccess"));
+    } catch (error) {
+      toast.error(t("agents.saveFailed"), {
+        description: extractErrorMessage(error) || undefined,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleReset = () => {
+    setModel(settings?.model ?? "");
+    setReasoningEffort(settings?.reasoningEffort ?? "");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="px-6 flex flex-1 items-center justify-center min-h-[200px]">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
   return (
-    <div className="px-6 flex flex-col flex-1 min-h-0">
-      <div className="flex-1 glass-card rounded-xl p-8 flex flex-col items-center justify-center text-center space-y-4">
-        <div className="w-20 h-20 rounded-full bg-white/5 flex items-center justify-center mb-4 animate-pulse-slow">
-          <Bot className="w-10 h-10 text-muted-foreground" />
+    <div className="px-6 pt-4 pb-8 flex flex-col flex-1 min-h-0 overflow-y-auto">
+      <div className="rounded-xl border border-border bg-card p-5 max-w-3xl w-full">
+        <div className="flex items-start gap-3 mb-6">
+          <div className="rounded-lg bg-blue-500/10 p-2 text-blue-500">
+            <Bot className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-base font-semibold">
+              {t("agents.codexTitle")}
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              {t("agents.codexDescription")}
+            </p>
+          </div>
         </div>
-        <h3 className="text-xl font-semibold">Coming Soon</h3>
-        <p className="text-muted-foreground max-w-md">
-          The Agents management feature is currently under development. Stay
-          tuned for powerful autonomous capabilities.
-        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div>
+            <Label htmlFor="codex-subagent-model" className="mb-1.5 block">
+              {t("agents.modelLabel")}
+            </Label>
+            <Input
+              id="codex-subagent-model"
+              list="codex-subagent-model-options"
+              value={model}
+              onChange={(event) => setModel(event.target.value)}
+              placeholder={t("agents.modelPlaceholder")}
+              className="font-mono text-xs"
+            />
+            <datalist id="codex-subagent-model-options">
+              {settings?.availableModels.map((availableModel) => (
+                <option key={availableModel} value={availableModel} />
+              ))}
+            </datalist>
+            <p className="text-xs text-muted-foreground mt-1.5">
+              {t("agents.modelHint")}
+            </p>
+          </div>
+
+          <div>
+            <Label className="mb-1.5 block">{t("agents.reasoningLabel")}</Label>
+            <Select
+              value={reasoningEffort || UNSET_SENTINEL}
+              onValueChange={(value) =>
+                setReasoningEffort(value === UNSET_SENTINEL ? "" : value)
+              }
+            >
+              <SelectTrigger className="font-mono text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={UNSET_SENTINEL}>
+                  {t("agents.notSet")}
+                </SelectItem>
+                {REASONING_EFFORTS.map((effort) => (
+                  <SelectItem key={effort} value={effort}>
+                    {t(`agents.reasoning.${effort}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground mt-1.5">
+              {t("agents.reasoningHint")}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          <span>{t("agents.configPath")}: </span>
+          <span className="font-mono break-all">{settings?.configPath}</span>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 mt-6">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleReset}
+            disabled={isSaving}
+            title={t("agents.reset")}
+            aria-label={t("agents.reset")}
+          >
+            <RotateCcw className="h-4 w-4" />
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={isSaving}>
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4" />
+            )}
+            {t("common.save")}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2534,6 +2534,27 @@
     "skillsFailedDescription": "Open the Skills page and click \"Import Existing\" to import manually (or restart and try again)."
   },
   "agents": {
+    "codexTitle": "Codex sub-agent defaults",
+    "codexDescription": "Set the default model and reasoning effort used by Codex sub-agents.",
+    "modelLabel": "Sub-agent model",
+    "modelPlaceholder": "Enter a Codex model id",
+    "modelHint": "Leave empty to remove the default model.",
+    "reasoningLabel": "Reasoning effort",
+    "reasoningHint": "Leave unset to let Codex choose the default.",
+    "notSet": "Not set",
+    "configPath": "Codex config",
+    "reset": "Reset changes",
+    "saveSuccess": "Codex sub-agent settings saved",
+    "saveFailed": "Failed to save Codex sub-agent settings",
+    "loadFailed": "Failed to load Codex sub-agent settings",
+    "reasoning": {
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High",
+      "xhigh": "Extra high",
+      "max": "Maximum",
+      "ultra": "Ultra"
+    },
     "title": "Agents"
   },
   "health": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2534,6 +2534,27 @@
     "skillsFailedDescription": "Skills 画面で「既存をインポート」をクリックして手動でインポートしてください（または再起動して再試行）。"
   },
   "agents": {
+    "codexTitle": "Codex サブエージェントのデフォルト設定",
+    "codexDescription": "Codex サブエージェントが使用するモデルと思考強度を設定します。",
+    "modelLabel": "サブエージェントモデル",
+    "modelPlaceholder": "Codex モデル ID を入力",
+    "modelHint": "空欄にするとデフォルトモデルを削除します。",
+    "reasoningLabel": "思考強度",
+    "reasoningHint": "未設定の場合は Codex のデフォルト値を使用します。",
+    "notSet": "未設定",
+    "configPath": "Codex 設定",
+    "reset": "変更をリセット",
+    "saveSuccess": "Codex サブエージェント設定を保存しました",
+    "saveFailed": "Codex サブエージェント設定の保存に失敗しました",
+    "loadFailed": "Codex サブエージェント設定の読み込みに失敗しました",
+    "reasoning": {
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "xhigh": "非常に高い",
+      "max": "最大",
+      "ultra": "Ultra"
+    },
     "title": "エージェント"
   },
   "health": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2535,6 +2535,27 @@
     "skillsFailedDescription": "請開啟 Skills 頁面點擊「匯入現有」手動匯入（或重新啟動後再試）。"
   },
   "agents": {
+    "codexTitle": "Codex 子代理預設設定",
+    "codexDescription": "設定 Codex 子代理使用的預設模型與思考強度。",
+    "modelLabel": "子代理模型",
+    "modelPlaceholder": "輸入 Codex 模型 ID",
+    "modelHint": "留空即可移除預設模型。",
+    "reasoningLabel": "思考強度",
+    "reasoningHint": "留空則由 Codex 使用預設值。",
+    "notSet": "未設定",
+    "configPath": "Codex 設定",
+    "reset": "重設變更",
+    "saveSuccess": "Codex 子代理設定已儲存",
+    "saveFailed": "儲存 Codex 子代理設定失敗",
+    "loadFailed": "載入 Codex 子代理設定失敗",
+    "reasoning": {
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "xhigh": "特高",
+      "max": "最大",
+      "ultra": "Ultra"
+    },
     "title": "Agent"
   },
   "health": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2534,6 +2534,27 @@
     "skillsFailedDescription": "请打开 Skills 页面点击“导入已有”手动导入（或重启后再试）。"
   },
   "agents": {
+    "codexTitle": "Codex 子代理默认设置",
+    "codexDescription": "设置 Codex 子代理使用的默认模型和思考强度。",
+    "modelLabel": "子代理模型",
+    "modelPlaceholder": "输入 Codex 模型 ID",
+    "modelHint": "留空可移除默认模型。",
+    "reasoningLabel": "思考强度",
+    "reasoningHint": "留空则由 Codex 使用默认值。",
+    "notSet": "未设置",
+    "configPath": "Codex 配置",
+    "reset": "重置修改",
+    "saveSuccess": "Codex 子代理设置已保存",
+    "saveFailed": "保存 Codex 子代理设置失败",
+    "loadFailed": "加载 Codex 子代理设置失败",
+    "reasoning": {
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "xhigh": "特高",
+      "max": "最大",
+      "ultra": "Ultra"
+    },
     "title": "智能体"
   },
   "health": {

--- a/src/lib/api/codexSubagents.ts
+++ b/src/lib/api/codexSubagents.ts
@@ -1,0 +1,18 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { CodexSubagentSettingsView } from "@/types";
+
+export const codexSubagentsApi = {
+  getSettings(): Promise<CodexSubagentSettingsView> {
+    return invoke("get_codex_subagent_settings");
+  },
+
+  saveSettings(
+    model: string | null,
+    reasoningEffort: string | null,
+  ): Promise<CodexSubagentSettingsView> {
+    return invoke("save_codex_subagent_settings", {
+      model,
+      reasoningEffort,
+    });
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -271,6 +271,13 @@ export interface CodexCatalogModel {
   baseInstructions?: string;
 }
 
+export interface CodexSubagentSettingsView {
+  model: string | null;
+  reasoningEffort: string | null;
+  availableModels: string[];
+  configPath: string;
+}
+
 // Claude 认证字段类型
 export type ClaudeApiKeyField = "ANTHROPIC_AUTH_TOKEN" | "ANTHROPIC_API_KEY";
 


### PR DESCRIPTION
## Summary

- Add Codex Agents controls for the default sub-agent model and reasoning effort.
- Persist these defaults and merge them into `config.toml` while preserving unrelated `[agents]` fields.
- Add localized UI text and focused Rust coverage.

## Related Issue

Fixes #6007

## Validation

- TypeScript typecheck, Prettier, Rust formatting, Clippy, and four focused Rust tests passed.
- The existing full frontend Vitest suite still has three unrelated integration-test failures in the Tauri/jsdom and OpenClaw test setup.