### PR TITLE
fix(opencode): support unified OMO config

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -270,8 +270,11 @@ fn sort_json_keys(value: &Value) -> Value {
     }
 }
 
-/// 写入 JSON 配置文件（键按字母排序，确保确定性输出）
-pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppError> {
+/// 写入 JSON 配置文件并返回实际写入的字节。
+pub fn write_json_file_with_contents<T: Serialize>(
+    path: &Path,
+    data: &T,
+) -> Result<Vec<u8>, AppError> {
     // 确保目录存在
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
@@ -282,7 +285,14 @@ pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppErr
     let json = serde_json::to_string_pretty(&sorted_value)
         .map_err(|e| AppError::JsonSerialize { source: e })?;
 
-    atomic_write(path, json.as_bytes())
+    let contents = json.into_bytes();
+    atomic_write(path, &contents)?;
+    Ok(contents)
+}
+
+/// 写入 JSON 配置文件（键按字母排序，确保确定性输出）
+pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppError> {
+    write_json_file_with_contents(path, data).map(|_| ())
 }
 
 /// 原子写入文本文件（用于 TOML/纯文本）
@@ -302,7 +312,6 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
     let parent = path
         .parent()
         .ok_or_else(|| AppError::Config("无效的路径".to_string()))?;
-    let mut tmp = parent.to_path_buf();
     let file_name = path
         .file_name()
         .ok_or_else(|| AppError::Config("无效的文件名".to_string()))?
@@ -312,13 +321,38 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    tmp.push(format!("{file_name}.tmp.{ts}"));
+    static TEMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let (tmp, mut file) = (|| -> Result<(PathBuf, fs::File), AppError> {
+        let mut last_collision = None;
+        for _ in 0..16 {
+            let counter = TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let candidate = parent.join(format!(
+                "{file_name}.tmp.{}.{ts}.{counter}",
+                std::process::id()
+            ));
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&candidate)
+            {
+                Ok(file) => return Ok((candidate, file)),
+                Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {
+                    last_collision = Some((candidate, source));
+                }
+                Err(source) => return Err(AppError::io(&candidate, source)),
+            }
+        }
 
-    {
-        let mut f = fs::File::create(&tmp).map_err(|e| AppError::io(&tmp, e))?;
-        f.write_all(data).map_err(|e| AppError::io(&tmp, e))?;
-        f.flush().map_err(|e| AppError::io(&tmp, e))?;
+        let (candidate, source) = last_collision.expect("temporary filename loop must run");
+        Err(AppError::io(&candidate, source))
+    })()?;
+
+    if let Err(source) = file.write_all(data).and_then(|_| file.flush()) {
+        drop(file);
+        let _ = fs::remove_file(&tmp);
+        return Err(AppError::io(&tmp, source));
     }
+    drop(file);
 
     #[cfg(unix)]
     {
@@ -331,22 +365,85 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
 
     #[cfg(windows)]
     {
-        // Windows 上 rename 目标存在会失败，先移除再重命名（尽量接近原子性）
-        if path.exists() {
-            let _ = fs::remove_file(path);
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::ReplaceFileW;
+
+        let replaced: Vec<u16> = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let replacement: Vec<u16> = tmp
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let mut completed = false;
+        let mut last_error = None;
+
+        for _ in 0..3 {
+            // SAFETY: both path buffers are NUL-terminated UTF-16 and remain alive for the
+            // duration of the call. Backup, exclusion, and reserved pointers are intentionally null.
+            let replaced_ok = unsafe {
+                ReplaceFileW(
+                    replaced.as_ptr(),
+                    replacement.as_ptr(),
+                    std::ptr::null(),
+                    0,
+                    std::ptr::null(),
+                    std::ptr::null(),
+                )
+            };
+            if replaced_ok != 0 {
+                completed = true;
+                break;
+            }
+
+            let replace_error = std::io::Error::last_os_error();
+            if replace_error.kind() != std::io::ErrorKind::NotFound {
+                last_error = Some(replace_error);
+                break;
+            }
+
+            match fs::rename(&tmp, path) {
+                Ok(()) => {
+                    completed = true;
+                    break;
+                }
+                Err(source)
+                    if matches!(
+                        source.kind(),
+                        std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::PermissionDenied
+                    ) =>
+                {
+                    last_error = Some(source);
+                }
+                Err(source) => {
+                    last_error = Some(source);
+                    break;
+                }
+            }
         }
-        fs::rename(&tmp, path).map_err(|e| AppError::IoContext {
-            context: format!("原子替换失败: {} -> {}", tmp.display(), path.display()),
-            source: e,
-        })?;
+
+        if !completed {
+            let source = last_error.unwrap_or_else(std::io::Error::last_os_error);
+            let _ = fs::remove_file(&tmp);
+            return Err(AppError::IoContext {
+                context: format!("原子替换失败: {} -> {}", tmp.display(), path.display()),
+                source,
+            });
+        }
     }
 
     #[cfg(not(windows))]
     {
-        fs::rename(&tmp, path).map_err(|e| AppError::IoContext {
-            context: format!("原子替换失败: {} -> {}", tmp.display(), path.display()),
-            source: e,
-        })?;
+        if let Err(source) = fs::rename(&tmp, path) {
+            let _ = fs::remove_file(&tmp);
+            return Err(AppError::IoContext {
+                context: format!("原子替换失败: {} -> {}", tmp.display(), path.display()),
+                source,
+            });
+        }
     }
     Ok(())
 }
@@ -354,6 +451,29 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn atomic_write_preserves_destination_when_windows_replace_fails() {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, b"old contents").unwrap();
+        let held_file = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ)
+            .open(&path)
+            .unwrap();
+
+        let result = atomic_write(&path, b"new contents");
+
+        assert!(result.is_err());
+        drop(held_file);
+        assert_eq!(std::fs::read(&path).unwrap(), b"old contents");
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
 
     #[test]
     fn derive_mcp_path_from_override_uses_config_dir_for_custom_path() {

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -276,7 +276,15 @@ pub fn add_plugin(plugin_name: &str) -> Result<(), AppError> {
     write_opencode_config(&config)
 }
 
-pub fn remove_plugins_by_prefixes(prefixes: &[&str]) -> Result<(), AppError> {
+pub fn remove_plugins_by_prefixes(
+    prefixes: &[&str],
+) -> Result<(Option<Vec<u8>>, Option<Vec<u8>>), AppError> {
+    let path = get_opencode_config_path();
+    let previous_contents = if path.exists() {
+        Some(std::fs::read(&path).map_err(|e| AppError::io(&path, e))?)
+    } else {
+        None
+    };
     let mut config = read_opencode_config()?;
 
     if let Some(arr) = config.get_mut("plugin").and_then(|v| v.as_array_mut()) {
@@ -291,7 +299,20 @@ pub fn remove_plugins_by_prefixes(prefixes: &[&str]) -> Result<(), AppError> {
         }
     }
 
-    write_opencode_config(&config)
+    let current_contents = if path.exists() {
+        Some(std::fs::read(&path).map_err(|e| AppError::io(&path, e))?)
+    } else {
+        None
+    };
+    if current_contents != previous_contents {
+        return Err(AppError::Config(
+            "OpenCode config changed on disk. Please reload and try again.".to_string(),
+        ));
+    }
+
+    write_opencode_config(&config)?;
+    let expected_contents = Some(std::fs::read(&path).map_err(|e| AppError::io(&path, e))?);
+    Ok((previous_contents, expected_contents))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -1,14 +1,26 @@
-use crate::config::write_json_file;
+use crate::config::write_json_file_with_contents;
 use crate::error::AppError;
 use crate::provider::OpenCodeProviderConfig;
 use crate::settings::get_opencode_override_dir;
 use indexmap::IndexMap;
 use serde_json::{json, Map, Value};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 const STANDARD_OMO_PLUGIN_PREFIXES: [&str; 2] = ["oh-my-openagent", "oh-my-opencode"];
 const SLIM_OMO_PLUGIN_PREFIXES: [&str; 1] = ["oh-my-opencode-slim"];
-pub type ConfigFileVersions = (Option<Vec<u8>>, Option<Vec<u8>>);
+fn opencode_config_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn read_config_contents(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
+    match std::fs::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(AppError::io(path, err)),
+    }
+}
 
 fn matches_plugin_prefix(plugin_name: &str, prefix: &str) -> bool {
     plugin_name == prefix
@@ -86,16 +98,16 @@ pub fn get_opencode_env_path() -> PathBuf {
     get_opencode_dir().join(".env")
 }
 
-pub fn read_opencode_config() -> Result<Value, AppError> {
-    let path = get_opencode_config_path();
-
-    if !path.exists() {
-        return Ok(json!({
-            "$schema": "https://opencode.ai/config.json"
-        }));
-    }
-
-    let content = std::fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
+fn read_opencode_config_from_path(path: &Path) -> Result<Value, AppError> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(json!({
+                "$schema": "https://opencode.ai/config.json"
+            }));
+        }
+        Err(err) => return Err(AppError::io(path, err)),
+    };
     let value: Value = json5::from_str(&content).map_err(|e| {
         AppError::Config(format!(
             "Failed to parse OpenCode config: {}: {e}",
@@ -119,12 +131,18 @@ pub fn read_opencode_config() -> Result<Value, AppError> {
     Ok(value)
 }
 
-pub fn write_opencode_config(config: &Value) -> Result<(), AppError> {
-    let path = get_opencode_config_path();
-    write_json_file(&path, config)?;
+pub fn read_opencode_config() -> Result<Value, AppError> {
+    read_opencode_config_from_path(&get_opencode_config_path())
+}
+
+fn write_opencode_config_to_path_with_contents(
+    path: &Path,
+    config: &Value,
+) -> Result<Vec<u8>, AppError> {
+    let contents = write_json_file_with_contents(path, config)?;
 
     log::debug!("OpenCode config written to {path:?}");
-    Ok(())
+    Ok(contents)
 }
 
 pub fn get_providers() -> Result<Map<String, Value>, AppError> {
@@ -137,7 +155,9 @@ pub fn get_providers() -> Result<Map<String, Value>, AppError> {
 }
 
 pub fn set_provider(id: &str, config: Value) -> Result<(), AppError> {
-    let mut full_config = read_opencode_config()?;
+    let _guard = opencode_config_lock().lock()?;
+    let path = get_opencode_config_path();
+    let mut full_config = read_opencode_config_from_path(&path)?;
 
     // 判空要连「存在但不是对象」一起算：否则下面 as_object_mut 拿不到，
     // 写入会静默失效——界面显示添加成功而文件里没有。provider 段是 cc-switch
@@ -156,11 +176,13 @@ pub fn set_provider(id: &str, config: Value) -> Result<(), AppError> {
         providers.insert(id.to_string(), config);
     }
 
-    write_opencode_config(&full_config)
+    write_opencode_config_to_path_with_contents(&path, &full_config).map(|_| ())
 }
 
 pub fn remove_provider(id: &str) -> Result<(), AppError> {
-    let mut config = read_opencode_config()?;
+    let _guard = opencode_config_lock().lock()?;
+    let path = get_opencode_config_path();
+    let mut config = read_opencode_config_from_path(&path)?;
 
     if let Some(providers) = config.get_mut("provider").and_then(|v| v.as_object_mut()) {
         providers.remove(id);
@@ -168,7 +190,7 @@ pub fn remove_provider(id: &str) -> Result<(), AppError> {
         log::warn!("opencode.json 的 provider 不是对象，无法删除供应商 '{id}'");
     }
 
-    write_opencode_config(&config)
+    write_opencode_config_to_path_with_contents(&path, &config).map(|_| ())
 }
 
 pub fn get_typed_providers() -> Result<IndexMap<String, OpenCodeProviderConfig>, AppError> {
@@ -204,7 +226,9 @@ pub fn get_mcp_servers() -> Result<Map<String, Value>, AppError> {
 }
 
 pub fn set_mcp_server(id: &str, config: Value) -> Result<(), AppError> {
-    let mut full_config = read_opencode_config()?;
+    let _guard = opencode_config_lock().lock()?;
+    let path = get_opencode_config_path();
+    let mut full_config = read_opencode_config_from_path(&path)?;
 
     if !full_config.get("mcp").is_some_and(Value::is_object) {
         if full_config.get("mcp").is_some() {
@@ -217,11 +241,13 @@ pub fn set_mcp_server(id: &str, config: Value) -> Result<(), AppError> {
         mcp.insert(id.to_string(), config);
     }
 
-    write_opencode_config(&full_config)
+    write_opencode_config_to_path_with_contents(&path, &full_config).map(|_| ())
 }
 
 pub fn remove_mcp_server(id: &str) -> Result<(), AppError> {
-    let mut config = read_opencode_config()?;
+    let _guard = opencode_config_lock().lock()?;
+    let path = get_opencode_config_path();
+    let mut config = read_opencode_config_from_path(&path)?;
 
     if let Some(mcp) = config.get_mut("mcp").and_then(|v| v.as_object_mut()) {
         mcp.remove(id);
@@ -229,89 +255,98 @@ pub fn remove_mcp_server(id: &str) -> Result<(), AppError> {
         log::warn!("opencode.json 的 mcp 不是对象，无法删除服务器 '{id}'");
     }
 
-    write_opencode_config(&config)
+    write_opencode_config_to_path_with_contents(&path, &config).map(|_| ())
 }
 
-pub fn add_plugin(plugin_name: &str) -> Result<(), AppError> {
-    let mut config = read_opencode_config()?;
+pub fn add_plugin(path: &Path, plugin_name: &str) -> Result<(), AppError> {
+    let _guard = opencode_config_lock().lock()?;
+    let mut config = read_opencode_config_from_path(path)?;
     let normalized_plugin_name = canonicalize_plugin_name(plugin_name);
+    let target_is_omo =
+        matches_any_plugin_prefix(&normalized_plugin_name, &STANDARD_OMO_PLUGIN_PREFIXES)
+            || matches_any_plugin_prefix(&normalized_plugin_name, &SLIM_OMO_PLUGIN_PREFIXES);
+    let mut changed = false;
 
     let plugins = config.get_mut("plugin").and_then(|v| v.as_array_mut());
 
     match plugins {
         Some(arr) => {
-            // Mutual exclusion: standard OMO and OMO Slim cannot coexist as plugins
-            if matches_any_plugin_prefix(&normalized_plugin_name, &STANDARD_OMO_PLUGIN_PREFIXES) {
-                arr.retain(|v| {
-                    v.as_str()
-                        .map(|s| {
-                            !matches_any_plugin_prefix(s, &STANDARD_OMO_PLUGIN_PREFIXES)
-                                && !matches_any_plugin_prefix(s, &SLIM_OMO_PLUGIN_PREFIXES)
-                        })
-                        .unwrap_or(true)
-                });
-            } else if matches_any_plugin_prefix(&normalized_plugin_name, &SLIM_OMO_PLUGIN_PREFIXES)
-            {
-                arr.retain(|v| {
-                    v.as_str()
-                        .map(|s| {
-                            !matches_any_plugin_prefix(s, &STANDARD_OMO_PLUGIN_PREFIXES)
-                                && !matches_any_plugin_prefix(s, &SLIM_OMO_PLUGIN_PREFIXES)
-                        })
-                        .unwrap_or(true)
-                });
-            }
+            let mut found_target = false;
+            arr.retain(|value| {
+                let Some(existing_name) = value.as_str() else {
+                    return true;
+                };
+                if existing_name == normalized_plugin_name {
+                    if found_target {
+                        changed = true;
+                        return false;
+                    }
+                    found_target = true;
+                    return true;
+                }
 
-            let already_exists = arr
-                .iter()
-                .any(|v| v.as_str() == Some(normalized_plugin_name.as_str()));
-            if !already_exists {
+                // Standard OMO and OMO Slim are mutually exclusive.
+                if target_is_omo
+                    && (matches_any_plugin_prefix(existing_name, &STANDARD_OMO_PLUGIN_PREFIXES)
+                        || matches_any_plugin_prefix(existing_name, &SLIM_OMO_PLUGIN_PREFIXES))
+                {
+                    changed = true;
+                    return false;
+                }
+                true
+            });
+
+            if !found_target {
                 arr.push(Value::String(normalized_plugin_name));
+                changed = true;
             }
         }
         None => {
             config["plugin"] = json!([normalized_plugin_name]);
+            changed = true;
         }
     }
 
-    write_opencode_config(&config)
+    if !changed {
+        return Ok(());
+    }
+
+    write_opencode_config_to_path_with_contents(path, &config).map(|_| ())
 }
 
-pub fn remove_plugins_by_prefixes(prefixes: &[&str]) -> Result<ConfigFileVersions, AppError> {
-    let path = get_opencode_config_path();
-    let previous_contents = if path.exists() {
-        Some(std::fs::read(&path).map_err(|e| AppError::io(&path, e))?)
-    } else {
-        None
-    };
-    let mut config = read_opencode_config()?;
+pub fn remove_plugins_by_prefixes(path: &Path, prefixes: &[&str]) -> Result<bool, AppError> {
+    let _guard = opencode_config_lock().lock()?;
+    let previous_contents = read_config_contents(path)?;
+    let mut config = read_opencode_config_from_path(path)?;
 
+    let mut changed = false;
     if let Some(arr) = config.get_mut("plugin").and_then(|v| v.as_array_mut()) {
+        let previous_len = arr.len();
         arr.retain(|v| {
             v.as_str()
                 .map(|s| !matches_any_plugin_prefix(s, prefixes))
                 .unwrap_or(true)
         });
+        changed = arr.len() != previous_len;
 
-        if arr.is_empty() {
+        if changed && arr.is_empty() {
             config.as_object_mut().map(|obj| obj.remove("plugin"));
         }
     }
 
-    let current_contents = if path.exists() {
-        Some(std::fs::read(&path).map_err(|e| AppError::io(&path, e))?)
-    } else {
-        None
-    };
+    if !changed {
+        return Ok(false);
+    }
+
+    let current_contents = read_config_contents(path)?;
     if current_contents != previous_contents {
         return Err(AppError::Config(
             "OpenCode config changed on disk. Please reload and try again.".to_string(),
         ));
     }
 
-    write_opencode_config(&config)?;
-    let expected_contents = Some(std::fs::read(&path).map_err(|e| AppError::io(&path, e))?);
-    Ok((previous_contents, expected_contents))
+    write_opencode_config_to_path_with_contents(path, &config)?;
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -385,5 +420,49 @@ mod tests {
             config["model"], "keep-me",
             "unrelated user config must be preserved"
         );
+    }
+
+    #[test]
+    fn remove_missing_plugin_does_not_create_config_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("opencode.json");
+
+        let result = remove_plugins_by_prefixes(&path, &["oh-my-openagent"]).unwrap();
+
+        assert!(!result);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_missing_plugin_preserves_existing_source() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("opencode.json");
+        let original = r#"{
+  // Keep formatting when the target plugin is absent.
+  "plugin": ["unrelated-plugin"],
+  "theme": "dark",
+}"#;
+        std::fs::write(&path, original).unwrap();
+
+        let result = remove_plugins_by_prefixes(&path, &["oh-my-openagent"]).unwrap();
+
+        assert!(!result);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn add_existing_plugin_preserves_existing_source() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("opencode.json");
+        let original = r#"{
+  // Keep comments and formatting when the plugin is already configured.
+  plugin: ['oh-my-openagent@latest'],
+  theme: 'dark',
+}"#;
+        std::fs::write(&path, original).unwrap();
+
+        add_plugin(&path, "oh-my-openagent@latest").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
     }
 }

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 const STANDARD_OMO_PLUGIN_PREFIXES: [&str; 2] = ["oh-my-openagent", "oh-my-opencode"];
 const SLIM_OMO_PLUGIN_PREFIXES: [&str; 1] = ["oh-my-opencode-slim"];
+pub type ConfigFileVersions = (Option<Vec<u8>>, Option<Vec<u8>>);
 
 fn matches_plugin_prefix(plugin_name: &str, prefix: &str) -> bool {
     plugin_name == prefix
@@ -276,9 +277,7 @@ pub fn add_plugin(plugin_name: &str) -> Result<(), AppError> {
     write_opencode_config(&config)
 }
 
-pub fn remove_plugins_by_prefixes(
-    prefixes: &[&str],
-) -> Result<(Option<Vec<u8>>, Option<Vec<u8>>), AppError> {
+pub fn remove_plugins_by_prefixes(prefixes: &[&str]) -> Result<ConfigFileVersions, AppError> {
     let path = get_opencode_config_path();
     let previous_contents = if path.exists() {
         Some(std::fs::read(&path).map_err(|e| AppError::io(&path, e))?)

--- a/src-tauri/src/services/omo.rs
+++ b/src-tauri/src/services/omo.rs
@@ -221,11 +221,17 @@ impl UnifiedConfigDocument {
                 e.message
             ))
         })?;
-        json5::from_str::<Value>(&next_source).map_err(|e| {
+        let reparsed: Value = json5::from_str(&next_source).map_err(|e| {
             AppError::Config(format!(
                 "Refusing to write invalid OMO config after round-trip serialization: {e}"
             ))
         })?;
+        if reparsed != self.semantic {
+            return Err(AppError::Config(
+                "Refusing to write OMO config: serialized output does not match the intended state"
+                    .to_string(),
+            ));
+        }
 
         let next_contents = next_source.into_bytes();
         atomic_write(&self.path, &next_contents)?;
@@ -1454,6 +1460,28 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("omo.jsonc");
         let original = r#"{ /* keep */ "[opencode]": {"agents": {}} }"#;
+        std::fs::write(&path, original).unwrap();
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        document
+            .set_opencode_section(&serde_json::json!({"agents": {"new": {}}}))
+            .unwrap();
+
+        let result = document.save();
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn test_unified_config_write_rejects_parseable_semantic_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        let original = r#"{
+  /* block */
+  "[codex]": {"agents": {"reviewer": {}}},
+  // tail */
+  "[opencode]": {"agents": {}}
+}"#;
         std::fs::write(&path, original).unwrap();
         let mut document = UnifiedConfigDocument::load(&path).unwrap();
         document

--- a/src-tauri/src/services/omo.rs
+++ b/src-tauri/src/services/omo.rs
@@ -1,11 +1,13 @@
-use crate::config::{atomic_write, get_home_dir, write_json_file};
+use crate::config::{atomic_write, get_home_dir, write_json_file_with_contents};
 use crate::error::AppError;
 use crate::opencode_config::get_opencode_dir;
 use crate::provider::Provider;
 use crate::store::AppState;
 use json_five::rt::parser::{
-    from_str as rt_from_str, JSONObjectContext as RtJSONObjectContext, JSONText as RtJSONText,
-    JSONValue as RtJSONValue, KeyValuePairContext as RtKeyValuePairContext,
+    from_str as rt_from_str, ArrayValueContext as RtArrayValueContext,
+    JSONArrayContext as RtJSONArrayContext, JSONArrayValue as RtJSONArrayValue,
+    JSONKeyValuePair as RtJSONKeyValuePair, JSONObjectContext as RtJSONObjectContext,
+    JSONText as RtJSONText, JSONValue as RtJSONValue, KeyValuePairContext as RtKeyValuePairContext,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -23,8 +25,9 @@ pub struct OmoLocalFileData {
 }
 
 type OmoProfileData = (Option<Value>, Option<Value>, Option<Value>);
+type OptionalConfigFileVersions = Option<(Vec<u8>, Vec<u8>)>;
 
-const UNIFIED_CONFIG_FILENAME: &str = "omo.jsonc";
+const UNIFIED_CONFIG_FILENAMES: [&str; 2] = ["omo.jsonc", "omo.json"];
 const OPENCODE_SECTION_KEY: &str = "[opencode]";
 
 #[derive(Debug, PartialEq)]
@@ -44,12 +47,15 @@ impl OmoConfigLocation {
 struct UnifiedConfigDocument {
     path: PathBuf,
     original_source: String,
+    semantic: Value,
     text: RtJSONText,
 }
 
 impl UnifiedConfigDocument {
     fn load(path: &Path) -> Result<Self, AppError> {
         let original_source = std::fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
+        let semantic: Value = json5::from_str(&original_source)
+            .map_err(|e| AppError::Config(format!("Failed to parse OMO config: {e}")))?;
         let text = rt_from_str(&original_source).map_err(|e| {
             AppError::Config(format!(
                 "Failed to parse OMO config as round-trip JSON5: {}",
@@ -78,11 +84,29 @@ impl UnifiedConfigDocument {
         Ok(Self {
             path: path.to_path_buf(),
             original_source,
+            semantic,
             text,
         })
     }
 
-    fn set_opencode_section(&mut self, value: &Value) -> Result<(), AppError> {
+    fn set_opencode_section(&mut self, value: &Value) -> Result<bool, AppError> {
+        if !value.is_object() {
+            return Err(AppError::Config(
+                "OMO [opencode] section must be an object".to_string(),
+            ));
+        }
+        let path_display = self.path.display().to_string();
+        let line_ending = if self.original_source.contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        let current_section = self
+            .semantic
+            .as_object()
+            .ok_or_else(|| AppError::Config("OMO config root must be a JSON object".to_string()))?
+            .get(OPENCODE_SECTION_KEY)
+            .cloned();
         let RtJSONValue::JSONObject {
             key_value_pairs,
             context,
@@ -93,19 +117,69 @@ impl UnifiedConfigDocument {
             ));
         };
 
-        let child_indent = context
-            .as_ref()
-            .map(|ctx| extract_trailing_indent(&ctx.wsc.0))
-            .unwrap_or_default();
-        let pair = key_value_pairs
-            .iter_mut()
-            .find(|pair| json5_key_name(&pair.key) == Some(OPENCODE_SECTION_KEY))
-            .ok_or(AppError::OmoConfigNotFound)?;
-        pair.value = value_to_rt_value(value, &child_indent)?;
-        Ok(())
+        let existing_index = key_value_pairs
+            .iter()
+            .position(|pair| json5_key_name(&pair.key) == Some(OPENCODE_SECTION_KEY));
+        let (_, child_indent) = object_layout(key_value_pairs, context, "");
+
+        if let Some(current_section) = current_section {
+            if !current_section.is_object() {
+                return Err(AppError::Config(format!(
+                    "OMO [opencode] section must be an object: {path_display}"
+                )));
+            }
+            let Some(index) = existing_index else {
+                return Err(AppError::Config(format!(
+                    "OMO [opencode] section could not be located in round-trip document: {path_display}"
+                )));
+            };
+            if !matches!(
+                &key_value_pairs[index].value,
+                RtJSONValue::JSONObject { .. }
+            ) {
+                return Err(AppError::Config(format!(
+                    "OMO [opencode] section must be an object: {path_display}"
+                )));
+            }
+            if current_section == *value {
+                return Ok(false);
+            }
+
+            let changed = merge_rt_value(
+                &mut key_value_pairs[index].value,
+                &current_section,
+                value,
+                &child_indent,
+                line_ending,
+            )?;
+            self.semantic
+                .as_object_mut()
+                .expect("validated object root")
+                .insert(OPENCODE_SECTION_KEY.to_string(), value.clone());
+            Ok(changed)
+        } else {
+            if existing_index.is_some() {
+                return Err(AppError::Config(format!(
+                    "OMO [opencode] section is inconsistent in round-trip document: {path_display}"
+                )));
+            }
+            append_object_pair(
+                key_value_pairs,
+                context,
+                OPENCODE_SECTION_KEY,
+                value,
+                "",
+                line_ending,
+            )?;
+            self.semantic
+                .as_object_mut()
+                .expect("validated object root")
+                .insert(OPENCODE_SECTION_KEY.to_string(), value.clone());
+            Ok(true)
+        }
     }
 
-    fn remove_opencode_section(&mut self) -> Result<(), AppError> {
+    fn remove_opencode_section(&mut self) -> Result<bool, AppError> {
         let RtJSONValue::JSONObject {
             key_value_pairs,
             context,
@@ -116,41 +190,18 @@ impl UnifiedConfigDocument {
             ));
         };
 
-        let index = key_value_pairs
+        let Some(index) = key_value_pairs
             .iter()
             .position(|pair| json5_key_name(&pair.key) == Some(OPENCODE_SECTION_KEY))
-            .ok_or(AppError::OmoConfigNotFound)?;
-        let removed = key_value_pairs.remove(index);
-        let Some(removed_context) = removed.context else {
-            return Ok(());
+        else {
+            return Ok(false);
         };
-
-        if index < key_value_pairs.len() {
-            let after_comma = removed_context.wsc.3.unwrap_or_default();
-            if index == 0 {
-                ensure_object_context(context).wsc.0.push_str(&after_comma);
-            } else {
-                let previous = ensure_kvp_context(&mut key_value_pairs[index - 1]);
-                let separator = previous.wsc.3.take().unwrap_or_default();
-                previous.wsc.3 = Some(format!("{separator}{after_comma}"));
-            }
-        } else if index == 0 {
-            let object_context = ensure_object_context(context);
-            object_context.wsc.0.push_str(&removed_context.wsc.2);
-            if let Some(after_comma) = removed_context.wsc.3 {
-                object_context.wsc.0.push_str(&after_comma);
-            }
-        } else {
-            let previous = ensure_kvp_context(&mut key_value_pairs[index - 1]);
-            let separator = previous.wsc.3.take().unwrap_or_default();
-            if let Some(after_comma) = removed_context.wsc.3 {
-                previous.wsc.3 = Some(format!("{separator}{after_comma}"));
-            } else {
-                previous.wsc.2.push_str(&separator);
-                previous.wsc.2.push_str(&removed_context.wsc.2);
-            }
-        }
-        Ok(())
+        remove_object_pair_at(key_value_pairs, context, index);
+        self.semantic
+            .as_object_mut()
+            .expect("validated object root")
+            .remove(OPENCODE_SECTION_KEY);
+        Ok(true)
     }
 
     fn save(self) -> Result<Vec<u8>, AppError> {
@@ -163,13 +214,31 @@ impl UnifiedConfigDocument {
             ));
         }
 
-        let next_contents = self.text.to_string().into_bytes();
+        let next_source = self.text.to_string();
+        rt_from_str(&next_source).map_err(|e| {
+            AppError::Config(format!(
+                "Refusing to write invalid OMO config after round-trip serialization: {}",
+                e.message
+            ))
+        })?;
+        json5::from_str::<Value>(&next_source).map_err(|e| {
+            AppError::Config(format!(
+                "Refusing to write invalid OMO config after round-trip serialization: {e}"
+            ))
+        })?;
+
+        let next_contents = next_source.into_bytes();
         atomic_write(&self.path, &next_contents)?;
         Ok(next_contents)
     }
 }
 
 fn omo_write_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn omo_operation_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
 }
@@ -195,10 +264,367 @@ fn ensure_kvp_context(
     })
 }
 
-fn value_to_rt_value(value: &Value, parent_indent: &str) -> Result<RtJSONValue, AppError> {
+fn ensure_array_context(context: &mut Option<RtJSONArrayContext>) -> &mut RtJSONArrayContext {
+    context.get_or_insert_with(|| RtJSONArrayContext {
+        wsc: (String::new(),),
+    })
+}
+
+fn ensure_array_value_context(value: &mut RtJSONArrayValue) -> &mut RtArrayValueContext {
+    value.context.get_or_insert_with(|| RtArrayValueContext {
+        wsc: (String::new(), None),
+    })
+}
+
+fn object_layout(
+    pairs: &[RtJSONKeyValuePair],
+    context: &Option<RtJSONObjectContext>,
+    parent_indent: &str,
+) -> (bool, String) {
+    let mut is_multiline = false;
+    let mut child_indent = None;
+
+    if let Some(context) = context {
+        if context.wsc.0.contains('\n') {
+            is_multiline = true;
+            child_indent = Some(extract_trailing_indent(&context.wsc.0));
+        }
+    }
+    for pair in pairs {
+        if let Some(context) = &pair.context {
+            is_multiline |= context.wsc.0.contains('\n')
+                || context.wsc.1.contains('\n')
+                || context.wsc.2.contains('\n')
+                || context
+                    .wsc
+                    .3
+                    .as_ref()
+                    .is_some_and(|whitespace| whitespace.contains('\n'));
+            if child_indent.is_none() {
+                child_indent = context
+                    .wsc
+                    .3
+                    .as_ref()
+                    .filter(|whitespace| whitespace.contains('\n'))
+                    .map(|whitespace| extract_trailing_indent(whitespace));
+            }
+        }
+    }
+
+    let child_indent = child_indent
+        .filter(|indent| !indent.is_empty())
+        .unwrap_or_else(|| format!("{parent_indent}  "));
+    (is_multiline, child_indent)
+}
+
+fn array_layout(
+    values: &[RtJSONArrayValue],
+    context: &Option<RtJSONArrayContext>,
+    parent_indent: &str,
+) -> (bool, String) {
+    let mut is_multiline = false;
+    let mut child_indent = None;
+
+    if let Some(context) = context {
+        if context.wsc.0.contains('\n') {
+            is_multiline = true;
+            child_indent = Some(extract_trailing_indent(&context.wsc.0));
+        }
+    }
+    for value in values {
+        if let Some(context) = &value.context {
+            is_multiline |= context.wsc.0.contains('\n')
+                || context
+                    .wsc
+                    .1
+                    .as_ref()
+                    .is_some_and(|whitespace| whitespace.contains('\n'));
+            if child_indent.is_none() {
+                child_indent = context
+                    .wsc
+                    .1
+                    .as_ref()
+                    .filter(|whitespace| whitespace.contains('\n'))
+                    .map(|whitespace| extract_trailing_indent(whitespace));
+            }
+        }
+    }
+
+    let child_indent = child_indent
+        .filter(|indent| !indent.is_empty())
+        .unwrap_or_else(|| format!("{parent_indent}  "));
+    (is_multiline, child_indent)
+}
+
+fn remove_object_pair_at(
+    pairs: &mut Vec<RtJSONKeyValuePair>,
+    context: &mut Option<RtJSONObjectContext>,
+    index: usize,
+) {
+    let removed = pairs.remove(index);
+    let Some(removed_context) = removed.context else {
+        return;
+    };
+
+    if index < pairs.len() {
+        let after_comma = removed_context.wsc.3.unwrap_or_default();
+        if index == 0 {
+            ensure_object_context(context).wsc.0.push_str(&after_comma);
+        } else {
+            let previous = ensure_kvp_context(&mut pairs[index - 1]);
+            let separator = previous.wsc.3.take().unwrap_or_default();
+            previous.wsc.3 = Some(format!("{separator}{after_comma}"));
+        }
+    } else if index == 0 {
+        let object_context = ensure_object_context(context);
+        object_context.wsc.0.push_str(&removed_context.wsc.2);
+        if let Some(after_comma) = removed_context.wsc.3 {
+            object_context.wsc.0.push_str(&after_comma);
+        }
+    } else {
+        let previous = ensure_kvp_context(&mut pairs[index - 1]);
+        let separator = previous.wsc.3.take().unwrap_or_default();
+        if let Some(after_comma) = removed_context.wsc.3 {
+            previous.wsc.3 = Some(format!("{separator}{after_comma}"));
+        } else {
+            previous.wsc.2.push_str(&separator);
+            previous.wsc.2.push_str(&removed_context.wsc.2);
+        }
+    }
+}
+
+fn remove_array_value_at(
+    values: &mut Vec<RtJSONArrayValue>,
+    context: &mut Option<RtJSONArrayContext>,
+    index: usize,
+) {
+    let removed = values.remove(index);
+    let Some(removed_context) = removed.context else {
+        return;
+    };
+
+    if index < values.len() {
+        let after_comma = removed_context.wsc.1.unwrap_or_default();
+        if index == 0 {
+            ensure_array_context(context).wsc.0.push_str(&after_comma);
+        } else {
+            let previous = ensure_array_value_context(&mut values[index - 1]);
+            let separator = previous.wsc.1.take().unwrap_or_default();
+            previous.wsc.1 = Some(format!("{separator}{after_comma}"));
+        }
+    } else if index == 0 {
+        let array_context = ensure_array_context(context);
+        array_context.wsc.0.push_str(&removed_context.wsc.0);
+        if let Some(after_comma) = removed_context.wsc.1 {
+            array_context.wsc.0.push_str(&after_comma);
+        }
+    } else {
+        let previous = ensure_array_value_context(&mut values[index - 1]);
+        let separator = previous.wsc.1.take().unwrap_or_default();
+        if let Some(after_comma) = removed_context.wsc.1 {
+            previous.wsc.1 = Some(format!("{separator}{after_comma}"));
+        } else {
+            previous.wsc.0.push_str(&separator);
+            previous.wsc.0.push_str(&removed_context.wsc.0);
+        }
+    }
+}
+
+fn append_object_pair(
+    pairs: &mut Vec<RtJSONKeyValuePair>,
+    context: &mut Option<RtJSONObjectContext>,
+    key: &str,
+    value: &Value,
+    parent_indent: &str,
+    line_ending: &str,
+) -> Result<(), AppError> {
+    let (is_multiline, child_indent) = object_layout(pairs, context, parent_indent);
+    let separator = if is_multiline {
+        format!("{line_ending}{child_indent}")
+    } else {
+        String::new()
+    };
+    let mut pair = RtJSONKeyValuePair {
+        key: RtJSONValue::DoubleQuotedString(key.to_string()),
+        value: value_to_rt_value(value, &child_indent, line_ending)?,
+        context: Some(RtKeyValuePairContext {
+            wsc: (String::new(), " ".to_string(), String::new(), None),
+        }),
+    };
+
+    if let Some(previous) = pairs.last_mut() {
+        let previous_context = ensure_kvp_context(previous);
+        let closing_ws = previous_context
+            .wsc
+            .3
+            .take()
+            .unwrap_or_else(|| std::mem::take(&mut previous_context.wsc.2));
+        previous_context.wsc.3 = Some(separator);
+        ensure_kvp_context(&mut pair).wsc.2 = closing_ws;
+    } else {
+        let object_context = ensure_object_context(context);
+        let closing_ws = std::mem::take(&mut object_context.wsc.0);
+        object_context.wsc.0 = separator;
+        ensure_kvp_context(&mut pair).wsc.2 = closing_ws;
+    }
+
+    pairs.push(pair);
+    Ok(())
+}
+
+fn append_array_value(
+    values: &mut Vec<RtJSONArrayValue>,
+    context: &mut Option<RtJSONArrayContext>,
+    value: &Value,
+    parent_indent: &str,
+    line_ending: &str,
+) -> Result<(), AppError> {
+    let (is_multiline, child_indent) = array_layout(values, context, parent_indent);
+    let separator = if is_multiline {
+        format!("{line_ending}{child_indent}")
+    } else {
+        String::new()
+    };
+    let mut array_value = RtJSONArrayValue {
+        value: value_to_rt_value(value, &child_indent, line_ending)?,
+        context: Some(RtArrayValueContext {
+            wsc: (String::new(), None),
+        }),
+    };
+
+    if let Some(previous) = values.last_mut() {
+        let previous_context = ensure_array_value_context(previous);
+        let closing_ws = previous_context
+            .wsc
+            .1
+            .take()
+            .unwrap_or_else(|| std::mem::take(&mut previous_context.wsc.0));
+        previous_context.wsc.1 = Some(separator);
+        ensure_array_value_context(&mut array_value).wsc.0 = closing_ws;
+    } else {
+        let array_context = ensure_array_context(context);
+        let closing_ws = std::mem::take(&mut array_context.wsc.0);
+        array_context.wsc.0 = separator;
+        ensure_array_value_context(&mut array_value).wsc.0 = closing_ws;
+    }
+
+    values.push(array_value);
+    Ok(())
+}
+
+fn merge_rt_value(
+    round_trip: &mut RtJSONValue,
+    current: &Value,
+    desired: &Value,
+    parent_indent: &str,
+    line_ending: &str,
+) -> Result<bool, AppError> {
+    if current == desired {
+        return Ok(false);
+    }
+
+    match (round_trip, current, desired) {
+        (
+            RtJSONValue::JSONObject {
+                key_value_pairs,
+                context,
+            },
+            Value::Object(current),
+            Value::Object(desired),
+        ) => {
+            let (_, child_indent) = object_layout(key_value_pairs, context, parent_indent);
+            let mut changed = false;
+            let mut seen = std::collections::HashSet::new();
+            let mut index = 0;
+            while index < key_value_pairs.len() {
+                let key = json5_key_name(&key_value_pairs[index].key).map(str::to_string);
+                let Some(key) = key else {
+                    remove_object_pair_at(key_value_pairs, context, index);
+                    changed = true;
+                    continue;
+                };
+                let Some(desired_value) = desired.get(&key) else {
+                    remove_object_pair_at(key_value_pairs, context, index);
+                    changed = true;
+                    continue;
+                };
+                if !seen.insert(key.clone()) {
+                    remove_object_pair_at(key_value_pairs, context, index);
+                    changed = true;
+                    continue;
+                }
+
+                let current_value = current.get(&key).unwrap_or(&Value::Null);
+                changed |= merge_rt_value(
+                    &mut key_value_pairs[index].value,
+                    current_value,
+                    desired_value,
+                    &child_indent,
+                    line_ending,
+                )?;
+                index += 1;
+            }
+
+            for (key, desired_value) in desired {
+                if seen.contains(key) {
+                    continue;
+                }
+                append_object_pair(
+                    key_value_pairs,
+                    context,
+                    key,
+                    desired_value,
+                    parent_indent,
+                    line_ending,
+                )?;
+                changed = true;
+            }
+            Ok(changed)
+        }
+        (
+            RtJSONValue::JSONArray { values, context },
+            Value::Array(current),
+            Value::Array(desired),
+        ) => {
+            let (_, child_indent) = array_layout(values, context, parent_indent);
+            let common_len = values.len().min(current.len()).min(desired.len());
+            let mut changed = false;
+            for index in 0..common_len {
+                changed |= merge_rt_value(
+                    &mut values[index].value,
+                    &current[index],
+                    &desired[index],
+                    &child_indent,
+                    line_ending,
+                )?;
+            }
+            while values.len() > desired.len() {
+                let index = values.len() - 1;
+                remove_array_value_at(values, context, index);
+                changed = true;
+            }
+            while values.len() < desired.len() {
+                let index = values.len();
+                append_array_value(values, context, &desired[index], parent_indent, line_ending)?;
+                changed = true;
+            }
+            Ok(changed)
+        }
+        (round_trip, _, desired) => {
+            *round_trip = value_to_rt_value(desired, parent_indent, line_ending)?;
+            Ok(true)
+        }
+    }
+}
+
+fn value_to_rt_value(
+    value: &Value,
+    parent_indent: &str,
+    line_ending: &str,
+) -> Result<RtJSONValue, AppError> {
     let source = serde_json::to_string_pretty(value)
         .map_err(|e| AppError::Config(format!("Failed to serialize OMO section: {e}")))?;
-    let adjusted = reindent_json5_block(&source, parent_indent);
+    let adjusted = reindent_json5_block(&source, parent_indent, line_ending);
     let text = rt_from_str(&adjusted).map_err(|e| {
         AppError::Config(format!(
             "Failed to parse generated OMO section: {}",
@@ -208,7 +634,7 @@ fn value_to_rt_value(value: &Value, parent_indent: &str) -> Result<RtJSONValue, 
     Ok(text.value)
 }
 
-fn reindent_json5_block(source: &str, parent_indent: &str) -> String {
+fn reindent_json5_block(source: &str, parent_indent: &str, line_ending: &str) -> String {
     if parent_indent.is_empty() || !source.contains('\n') {
         return source.to_string();
     }
@@ -220,7 +646,7 @@ fn reindent_json5_block(source: &str, parent_indent: &str) -> String {
 
     let mut result = String::from(first_line);
     for line in lines {
-        result.push('\n');
+        result.push_str(line_ending);
         result.push_str(parent_indent);
         result.push_str(line);
     }
@@ -307,17 +733,16 @@ impl OmoService {
             return Ok(None);
         }
 
-        let path = home_dir.join(".omo").join(UNIFIED_CONFIG_FILENAME);
-        if !path.exists() {
-            return Ok(None);
+        let config_dir = home_dir.join(".omo");
+        for filename in UNIFIED_CONFIG_FILENAMES {
+            let path = config_dir.join(filename);
+            if path.try_exists().map_err(|e| AppError::io(&path, e))? {
+                UnifiedConfigDocument::load(&path)?;
+                return Ok(Some(path));
+            }
         }
 
-        UnifiedConfigDocument::load(&path)?;
-        let root = Self::read_jsonc_object(&path)?;
-        Ok(root
-            .get(OPENCODE_SECTION_KEY)
-            .and_then(Value::as_object)
-            .map(|_| path))
+        Ok(None)
     }
 
     fn find_config_location(
@@ -332,9 +757,12 @@ impl OmoService {
         Ok(Self::find_existing_config_path(v, legacy_dir).map(OmoConfigLocation::Legacy))
     }
 
-    fn config_location(v: &OmoVariant) -> Result<OmoConfigLocation, AppError> {
-        let legacy_dir = get_opencode_dir();
-        Ok(Self::find_config_location(v, &get_home_dir(), &legacy_dir)?
+    fn config_location(
+        v: &OmoVariant,
+        home_dir: &Path,
+        legacy_dir: &Path,
+    ) -> Result<OmoConfigLocation, AppError> {
+        Ok(Self::find_config_location(v, home_dir, legacy_dir)?
             .unwrap_or_else(|| OmoConfigLocation::Legacy(legacy_dir.join(v.preferred_filename))))
     }
 
@@ -356,20 +784,26 @@ impl OmoService {
     fn read_config_object(location: &OmoConfigLocation) -> Result<Map<String, Value>, AppError> {
         let mut root = Self::read_jsonc_object(location.path())?;
         match location {
-            OmoConfigLocation::Unified(_) => root
-                .remove(OPENCODE_SECTION_KEY)
-                .and_then(|value| value.as_object().cloned())
-                .ok_or(AppError::OmoConfigNotFound),
+            OmoConfigLocation::Unified(_) => match root.remove(OPENCODE_SECTION_KEY) {
+                None => Err(AppError::OmoConfigNotFound),
+                Some(Value::Object(section)) => Ok(section),
+                Some(_) => Err(AppError::Config(format!(
+                    "OMO [opencode] section must be an object: {}",
+                    location.path().display()
+                ))),
+            },
             OmoConfigLocation::Legacy(_) => Ok(root),
         }
     }
 
-    fn remove_unified_config_section(path: &Path) -> Result<(Vec<u8>, Vec<u8>), AppError> {
+    fn remove_unified_config_section(path: &Path) -> Result<OptionalConfigFileVersions, AppError> {
         let mut document = UnifiedConfigDocument::load(path)?;
         let previous_contents = document.original_source.as_bytes().to_vec();
-        document.remove_opencode_section()?;
+        if !document.remove_opencode_section()? {
+            return Ok(None);
+        }
         let expected_contents = document.save()?;
-        Ok((previous_contents, expected_contents))
+        Ok(Some((previous_contents, expected_contents)))
     }
 
     // ── Field extraction ───────────────────────────────────
@@ -415,24 +849,21 @@ impl OmoService {
     }
 
     fn snapshot_config_file(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
-        if !path.exists() {
-            return Ok(None);
+        match std::fs::read(path) {
+            Ok(contents) => Ok(Some(contents)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(AppError::io(path, err)),
         }
-
-        std::fs::read(path)
-            .map(Some)
-            .map_err(|e| AppError::io(path, e))
     }
 
     fn restore_config_file(path: &Path, snapshot: Option<&[u8]>) -> Result<(), AppError> {
         match snapshot {
             Some(bytes) => atomic_write(path, bytes),
-            None => {
-                if path.exists() {
-                    std::fs::remove_file(path).map_err(|e| AppError::io(path, e))?;
-                }
-                Ok(())
-            }
+            None => match std::fs::remove_file(path) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(AppError::io(path, err)),
+            },
         }
     }
 
@@ -456,8 +887,14 @@ impl OmoService {
         v: &OmoVariant,
         profile_data: Option<&OmoProfileData>,
     ) -> Result<(), AppError> {
+        let _operation_guard = omo_operation_lock().lock()?;
+        let plugin_config_path = crate::opencode_config::get_opencode_config_path();
+        let legacy_dir = plugin_config_path.parent().ok_or_else(|| {
+            AppError::Config("OpenCode config path has no parent directory".to_string())
+        })?;
+        let home_dir = get_home_dir();
         let merged = Self::build_config(v, profile_data);
-        let location = Self::config_location(v)?;
+        let location = Self::config_location(v, &home_dir, legacy_dir)?;
         let config_path = location.path().to_path_buf();
 
         if let Some(parent) = config_path.parent() {
@@ -467,66 +904,85 @@ impl OmoService {
         let (previous_contents, expected_contents) = match &location {
             OmoConfigLocation::Unified(path) => {
                 let mut document = UnifiedConfigDocument::load(path)?;
-                let previous_contents = Some(document.original_source.as_bytes().to_vec());
-                document.set_opencode_section(&merged)?;
-                let expected_contents = Some(document.save()?);
-                (previous_contents, expected_contents)
+                if document.set_opencode_section(&merged)? {
+                    let previous_contents = Some(document.original_source.as_bytes().to_vec());
+                    let expected_contents = Some(document.save()?);
+                    (previous_contents, expected_contents)
+                } else {
+                    (None, None)
+                }
             }
             OmoConfigLocation::Legacy(path) => {
+                let _guard = omo_write_lock().lock()?;
                 let previous_contents = Self::snapshot_config_file(path)?;
-                write_json_file(path, &merged)?;
-                let expected_contents = Self::snapshot_config_file(path)?;
+                let expected_contents = Some(write_json_file_with_contents(path, &merged)?);
                 (previous_contents, expected_contents)
             }
         };
-        if let Err(err) = crate::opencode_config::add_plugin(v.plugin_name) {
-            if let Err(rollback_err) = Self::restore_config_file_if_unchanged(
-                &config_path,
-                expected_contents.as_deref(),
-                previous_contents.as_deref(),
-            ) {
-                log::warn!(
-                    "Failed to roll back {} config after plugin sync error: {}",
-                    v.label,
-                    rollback_err
-                );
+        if let Err(err) = crate::opencode_config::add_plugin(&plugin_config_path, v.plugin_name) {
+            if expected_contents.is_some() {
+                if let Err(rollback_err) = Self::restore_config_file_if_unchanged(
+                    &config_path,
+                    expected_contents.as_deref(),
+                    previous_contents.as_deref(),
+                ) {
+                    log::warn!(
+                        "Failed to roll back {} config after plugin sync error: {}",
+                        v.label,
+                        rollback_err
+                    );
+                }
             }
             return Err(err);
         }
-        log::info!("{} config written to {config_path:?}", v.label);
+        if expected_contents.is_some() {
+            log::info!("{} config written to {config_path:?}", v.label);
+        }
         Ok(())
     }
 
     // ── Public API (variant-parameterized) ─────────────────
 
     pub fn delete_config_file(v: &OmoVariant) -> Result<(), AppError> {
-        let base_dir = get_opencode_dir();
-        let unified_path = Self::find_unified_config_path(v, &get_home_dir())?;
-        let legacy_paths: Vec<_> = Self::config_candidates(v, &base_dir)
-            .into_iter()
-            .filter(|path| path.exists())
-            .collect();
+        let _operation_guard = omo_operation_lock().lock()?;
         let plugin_config_path = crate::opencode_config::get_opencode_config_path();
+        let base_dir = plugin_config_path
+            .parent()
+            .ok_or_else(|| {
+                AppError::Config("OpenCode config path has no parent directory".to_string())
+            })?
+            .to_path_buf();
+        let unified_path = Self::find_unified_config_path(v, &get_home_dir())?;
+        let mut legacy_paths = Vec::new();
+        for path in Self::config_candidates(v, &base_dir) {
+            if path.try_exists().map_err(|e| AppError::io(&path, e))? {
+                legacy_paths.push(path);
+            }
+        }
 
         let mut applied_changes = Vec::new();
 
         let result = (|| -> Result<(), AppError> {
-            let (plugin_config_snapshot, plugin_config_expected) =
-                crate::opencode_config::remove_plugins_by_prefixes(v.plugin_prefixes)?;
-            applied_changes.push((
-                plugin_config_path,
-                plugin_config_snapshot,
-                plugin_config_expected,
-            ));
             if let Some(path) = &unified_path {
-                let (snapshot, expected_contents) = Self::remove_unified_config_section(path)?;
-                applied_changes.push((path.clone(), Some(snapshot), Some(expected_contents)));
+                if let Some((snapshot, expected_contents)) =
+                    Self::remove_unified_config_section(path)?
+                {
+                    applied_changes.push((path.clone(), Some(snapshot), Some(expected_contents)));
+                }
             }
             for path in &legacy_paths {
+                let _guard = omo_write_lock().lock()?;
                 let snapshot = Self::snapshot_config_file(path)?;
+                if snapshot.is_none() {
+                    continue;
+                }
                 std::fs::remove_file(path).map_err(|e| AppError::io(path, e))?;
                 applied_changes.push((path.clone(), snapshot, None));
             }
+            crate::opencode_config::remove_plugins_by_prefixes(
+                &plugin_config_path,
+                v.plugin_prefixes,
+            )?;
             Ok(())
         })();
 
@@ -545,10 +1001,10 @@ impl OmoService {
             return Err(err);
         }
 
-        let mut changed_paths = legacy_paths;
-        if let Some(path) = unified_path {
-            changed_paths.push(path);
-        }
+        let changed_paths: Vec<_> = applied_changes
+            .iter()
+            .map(|(path, _, _)| path.clone())
+            .collect();
         if !changed_paths.is_empty() {
             log::info!(
                 "{} config files updated or deleted: {changed_paths:?}",
@@ -735,19 +1191,41 @@ mod tests {
     }
 
     #[test]
-    fn test_find_config_location_falls_back_when_unified_has_no_opencode_block() {
+    fn test_find_config_location_uses_unified_when_opencode_block_is_missing() {
         let home = tempfile::tempdir().unwrap();
         let unified_path = home.path().join(".omo").join("omo.jsonc");
         let legacy_dir = home.path().join(".config").join("opencode");
-        let legacy_path = legacy_dir.join(STANDARD.preferred_filename);
         std::fs::create_dir_all(unified_path.parent().unwrap()).unwrap();
         std::fs::create_dir_all(&legacy_dir).unwrap();
         std::fs::write(&unified_path, r#"{"[codex]":{"agents":{}}}"#).unwrap();
-        std::fs::write(&legacy_path, r#"{"agents":{}}"#).unwrap();
+        std::fs::write(
+            legacy_dir.join(STANDARD.preferred_filename),
+            r#"{"agents":{}}"#,
+        )
+        .unwrap();
 
         let found = OmoService::find_config_location(&STANDARD, home.path(), &legacy_dir).unwrap();
 
-        assert_eq!(found, Some(OmoConfigLocation::Legacy(legacy_path)));
+        assert_eq!(found, Some(OmoConfigLocation::Unified(unified_path)));
+    }
+
+    #[test]
+    fn test_find_config_location_uses_unified_json_fallback() {
+        let home = tempfile::tempdir().unwrap();
+        let unified_path = home.path().join(".omo").join("omo.json");
+        let legacy_dir = home.path().join(".config").join("opencode");
+        std::fs::create_dir_all(unified_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        std::fs::write(&unified_path, r#"{"[opencode]":{"agents":{}}}"#).unwrap();
+        std::fs::write(
+            legacy_dir.join(STANDARD.preferred_filename),
+            r#"{"agents":{}}"#,
+        )
+        .unwrap();
+
+        let found = OmoService::find_config_location(&STANDARD, home.path(), &legacy_dir).unwrap();
+
+        assert_eq!(found, Some(OmoConfigLocation::Unified(unified_path)));
     }
 
     #[test]
@@ -769,6 +1247,22 @@ mod tests {
         assert_eq!(obj["agents"]["sisyphus"]["model"], "openai/gpt-5.3");
         assert!(!obj.contains_key("models"));
         assert!(!obj.contains_key("[codex]"));
+    }
+
+    #[test]
+    fn test_unified_config_rejects_non_object_opencode_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        let original = r#"{"[opencode]":[],"[codex]":{"agents":{}}}"#;
+        std::fs::write(&path, original).unwrap();
+
+        let read_result = OmoService::read_config_object(&OmoConfigLocation::Unified(path.clone()));
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        let write_result = document.set_opencode_section(&serde_json::json!({"agents": {}}));
+
+        assert!(read_result.is_err());
+        assert!(write_result.is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
     }
 
     #[test]
@@ -816,6 +1310,186 @@ mod tests {
     }
 
     #[test]
+    fn test_unified_config_semantic_noop_preserves_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        let original = r#"{
+  "[opencode]": {
+    // Keep this agent explanation and the original quoting.
+    agents: {'sisyphus': {model: 'openai/gpt-5.3'}},
+  },
+}"#;
+        std::fs::write(&path, original).unwrap();
+        let root: Value = json5::from_str(original).unwrap();
+        let desired = root[OPENCODE_SECTION_KEY].clone();
+
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        let changed = document.set_opencode_section(&desired).unwrap();
+
+        assert!(!changed);
+        assert_eq!(document.text.to_string(), original);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn test_unified_config_merge_preserves_nested_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        let original = r#"{
+  "[opencode]": {
+    // Keep the agents explanation.
+    "agents": {
+      "sisyphus": {
+        // Keep the model explanation.
+        "model": "old/model",
+        "temperature": 0.2
+      }
+    },
+    "disabled_agents": [
+      "one", // Keep the first array item explanation.
+      "two"
+    ]
+  }
+}"#;
+        std::fs::write(&path, original).unwrap();
+        let desired = serde_json::json!({
+            "agents": {
+                "sisyphus": {
+                    "model": "new/model",
+                    "temperature": 0.2
+                }
+            },
+            "disabled_agents": ["one", "two", "three"]
+        });
+
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        assert!(document.set_opencode_section(&desired).unwrap());
+        document.save().unwrap();
+
+        let source = std::fs::read_to_string(&path).unwrap();
+        let root = OmoService::read_jsonc_object(&path).unwrap();
+        assert_eq!(root[OPENCODE_SECTION_KEY], desired);
+        assert!(source.contains("// Keep the agents explanation."));
+        assert!(source.contains("// Keep the model explanation."));
+        assert!(source.contains("// Keep the first array item explanation."));
+    }
+
+    #[test]
+    fn test_unified_config_write_inserts_missing_opencode_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        std::fs::write(
+            &path,
+            r#"{
+  "_migrations": ["2026-07-opencode-config-unification"],
+  // Keep the Codex section in place.
+  "[codex]": {"agents": {"reviewer": {"model": "openai/gpt-5.4"}}}
+}"#,
+        )
+        .unwrap();
+
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        document
+            .set_opencode_section(&serde_json::json!({
+                "agents": {"sisyphus": {"model": "openai/gpt-5.3"}}
+            }))
+            .unwrap();
+        document.save().unwrap();
+
+        let source = std::fs::read_to_string(&path).unwrap();
+        let root = OmoService::read_jsonc_object(&path).unwrap();
+        assert_eq!(
+            root["[opencode]"]["agents"]["sisyphus"]["model"],
+            "openai/gpt-5.3"
+        );
+        assert_eq!(
+            root["[codex]"]["agents"]["reviewer"]["model"],
+            "openai/gpt-5.4"
+        );
+        assert!(source.contains("// Keep the Codex section in place."));
+    }
+
+    #[test]
+    fn test_disable_then_reenable_stays_on_unified_path() {
+        let home = tempfile::tempdir().unwrap();
+        let unified_path = home.path().join(".omo").join("omo.jsonc");
+        let legacy_dir = home.path().join(".config").join("opencode");
+        std::fs::create_dir_all(unified_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        std::fs::write(
+            &unified_path,
+            r#"{
+  "_migrations": ["2026-07-opencode-config-unification"],
+  "[opencode]": {"agents": {"old": {}}},
+  "[codex]": {"agents": {"reviewer": {}}}
+}"#,
+        )
+        .unwrap();
+
+        OmoService::remove_unified_config_section(&unified_path).unwrap();
+        let location =
+            OmoService::find_config_location(&STANDARD, home.path(), &legacy_dir).unwrap();
+        assert_eq!(
+            location,
+            Some(OmoConfigLocation::Unified(unified_path.clone()))
+        );
+
+        let mut document = UnifiedConfigDocument::load(&unified_path).unwrap();
+        document
+            .set_opencode_section(&serde_json::json!({"agents": {"new": {}}}))
+            .unwrap();
+        document.save().unwrap();
+
+        let root = OmoService::read_jsonc_object(&unified_path).unwrap();
+        assert!(root["[opencode]"]["agents"].get("new").is_some());
+        assert!(root.contains_key("[codex]"));
+        assert_eq!(
+            root["_migrations"],
+            serde_json::json!(["2026-07-opencode-config-unification"])
+        );
+    }
+
+    #[test]
+    fn test_unified_config_write_rejects_block_comment_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        let original = r#"{ /* keep */ "[opencode]": {"agents": {}} }"#;
+        std::fs::write(&path, original).unwrap();
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        document
+            .set_opencode_section(&serde_json::json!({"agents": {"new": {}}}))
+            .unwrap();
+
+        let result = document.save();
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn test_unified_config_write_preserves_crlf_line_endings() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        std::fs::write(&path, "{\r\n  \"[codex]\": {\"agents\": {}}\r\n}\r\n").unwrap();
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        document
+            .set_opencode_section(&serde_json::json!({
+                "agents": {"sisyphus": {"model": "openai/gpt-5.3"}}
+            }))
+            .unwrap();
+
+        document.save().unwrap();
+
+        let source = std::fs::read_to_string(&path).unwrap();
+        assert!(!source.replace("\r\n", "").contains('\n'));
+        assert_eq!(
+            OmoService::read_jsonc_object(&path).unwrap()["[opencode]"]["agents"]["sisyphus"]
+                ["model"],
+            "openai/gpt-5.3"
+        );
+    }
+
+    #[test]
     fn test_remove_unified_config_section_preserves_other_sections() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("omo.jsonc");
@@ -830,7 +1504,9 @@ mod tests {
         )
         .unwrap();
 
-        OmoService::remove_unified_config_section(&path).unwrap();
+        assert!(OmoService::remove_unified_config_section(&path)
+            .unwrap()
+            .is_some());
 
         let source = std::fs::read_to_string(&path).unwrap();
         let root = OmoService::read_jsonc_object(&path).unwrap();
@@ -838,6 +1514,11 @@ mod tests {
         assert!(root.contains_key("[codex]"));
         assert_eq!(root["_migrations"], serde_json::json!(["done"]));
         assert!(source.contains("// Keep this Codex explanation when disabling OpenCode OMO."));
+
+        assert!(OmoService::remove_unified_config_section(&path)
+            .unwrap()
+            .is_none());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), source);
     }
 
     #[test]

--- a/src-tauri/src/services/omo.rs
+++ b/src-tauri/src/services/omo.rs
@@ -1,11 +1,16 @@
-use crate::config::{atomic_write, write_json_file};
+use crate::config::{atomic_write, get_home_dir, write_json_file};
 use crate::error::AppError;
 use crate::opencode_config::get_opencode_dir;
 use crate::provider::Provider;
 use crate::store::AppState;
+use json_five::rt::parser::{
+    from_str as rt_from_str, JSONObjectContext as RtJSONObjectContext, JSONText as RtJSONText,
+    JSONValue as RtJSONValue, KeyValuePairContext as RtKeyValuePairContext,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,6 +23,218 @@ pub struct OmoLocalFileData {
 }
 
 type OmoProfileData = (Option<Value>, Option<Value>, Option<Value>);
+
+const UNIFIED_CONFIG_FILENAME: &str = "omo.jsonc";
+const OPENCODE_SECTION_KEY: &str = "[opencode]";
+
+#[derive(Debug, PartialEq)]
+enum OmoConfigLocation {
+    Unified(PathBuf),
+    Legacy(PathBuf),
+}
+
+impl OmoConfigLocation {
+    fn path(&self) -> &Path {
+        match self {
+            Self::Unified(path) | Self::Legacy(path) => path,
+        }
+    }
+}
+
+struct UnifiedConfigDocument {
+    path: PathBuf,
+    original_source: String,
+    text: RtJSONText,
+}
+
+impl UnifiedConfigDocument {
+    fn load(path: &Path) -> Result<Self, AppError> {
+        let original_source = std::fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
+        let text = rt_from_str(&original_source).map_err(|e| {
+            AppError::Config(format!(
+                "Failed to parse OMO config as round-trip JSON5: {}",
+                e.message
+            ))
+        })?;
+        let RtJSONValue::JSONObject {
+            key_value_pairs, ..
+        } = &text.value
+        else {
+            return Err(AppError::Config(
+                "OMO config root must be a JSON object".to_string(),
+            ));
+        };
+        if key_value_pairs
+            .iter()
+            .filter(|pair| json5_key_name(&pair.key) == Some(OPENCODE_SECTION_KEY))
+            .count()
+            > 1
+        {
+            return Err(AppError::Config(
+                "OMO config contains duplicate [opencode] sections".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            path: path.to_path_buf(),
+            original_source,
+            text,
+        })
+    }
+
+    fn set_opencode_section(&mut self, value: &Value) -> Result<(), AppError> {
+        let RtJSONValue::JSONObject {
+            key_value_pairs,
+            context,
+        } = &mut self.text.value
+        else {
+            return Err(AppError::Config(
+                "OMO config root must be a JSON object".to_string(),
+            ));
+        };
+
+        let child_indent = context
+            .as_ref()
+            .map(|ctx| extract_trailing_indent(&ctx.wsc.0))
+            .unwrap_or_default();
+        let pair = key_value_pairs
+            .iter_mut()
+            .find(|pair| json5_key_name(&pair.key) == Some(OPENCODE_SECTION_KEY))
+            .ok_or(AppError::OmoConfigNotFound)?;
+        pair.value = value_to_rt_value(value, &child_indent)?;
+        Ok(())
+    }
+
+    fn remove_opencode_section(&mut self) -> Result<(), AppError> {
+        let RtJSONValue::JSONObject {
+            key_value_pairs,
+            context,
+        } = &mut self.text.value
+        else {
+            return Err(AppError::Config(
+                "OMO config root must be a JSON object".to_string(),
+            ));
+        };
+
+        let index = key_value_pairs
+            .iter()
+            .position(|pair| json5_key_name(&pair.key) == Some(OPENCODE_SECTION_KEY))
+            .ok_or(AppError::OmoConfigNotFound)?;
+        let removed = key_value_pairs.remove(index);
+        let Some(removed_context) = removed.context else {
+            return Ok(());
+        };
+
+        if index < key_value_pairs.len() {
+            let after_comma = removed_context.wsc.3.unwrap_or_default();
+            if index == 0 {
+                ensure_object_context(context).wsc.0.push_str(&after_comma);
+            } else {
+                let previous = ensure_kvp_context(&mut key_value_pairs[index - 1]);
+                let separator = previous.wsc.3.take().unwrap_or_default();
+                previous.wsc.3 = Some(format!("{separator}{after_comma}"));
+            }
+        } else if index == 0 {
+            let object_context = ensure_object_context(context);
+            object_context.wsc.0.push_str(&removed_context.wsc.2);
+            if let Some(after_comma) = removed_context.wsc.3 {
+                object_context.wsc.0.push_str(&after_comma);
+            }
+        } else {
+            let previous = ensure_kvp_context(&mut key_value_pairs[index - 1]);
+            let separator = previous.wsc.3.take().unwrap_or_default();
+            if let Some(after_comma) = removed_context.wsc.3 {
+                previous.wsc.3 = Some(format!("{separator}{after_comma}"));
+            } else {
+                previous.wsc.2.push_str(&separator);
+                previous.wsc.2.push_str(&removed_context.wsc.2);
+            }
+        }
+        Ok(())
+    }
+
+    fn save(self) -> Result<Vec<u8>, AppError> {
+        let _guard = omo_write_lock().lock()?;
+        let current_source =
+            std::fs::read_to_string(&self.path).map_err(|e| AppError::io(&self.path, e))?;
+        if current_source != self.original_source {
+            return Err(AppError::Config(
+                "OMO config changed on disk. Please reload and try again.".to_string(),
+            ));
+        }
+
+        let next_contents = self.text.to_string().into_bytes();
+        atomic_write(&self.path, &next_contents)?;
+        Ok(next_contents)
+    }
+}
+
+fn omo_write_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn extract_trailing_indent(separator_ws: &str) -> String {
+    separator_ws
+        .rsplit_once('\n')
+        .map(|(_, tail)| tail.to_string())
+        .unwrap_or_default()
+}
+
+fn ensure_object_context(context: &mut Option<RtJSONObjectContext>) -> &mut RtJSONObjectContext {
+    context.get_or_insert_with(|| RtJSONObjectContext {
+        wsc: (String::new(),),
+    })
+}
+
+fn ensure_kvp_context(
+    pair: &mut json_five::rt::parser::JSONKeyValuePair,
+) -> &mut RtKeyValuePairContext {
+    pair.context.get_or_insert_with(|| RtKeyValuePairContext {
+        wsc: (String::new(), String::new(), String::new(), None),
+    })
+}
+
+fn value_to_rt_value(value: &Value, parent_indent: &str) -> Result<RtJSONValue, AppError> {
+    let source = serde_json::to_string_pretty(value)
+        .map_err(|e| AppError::Config(format!("Failed to serialize OMO section: {e}")))?;
+    let adjusted = reindent_json5_block(&source, parent_indent);
+    let text = rt_from_str(&adjusted).map_err(|e| {
+        AppError::Config(format!(
+            "Failed to parse generated OMO section: {}",
+            e.message
+        ))
+    })?;
+    Ok(text.value)
+}
+
+fn reindent_json5_block(source: &str, parent_indent: &str) -> String {
+    if parent_indent.is_empty() || !source.contains('\n') {
+        return source.to_string();
+    }
+
+    let mut lines = source.lines();
+    let Some(first_line) = lines.next() else {
+        return String::new();
+    };
+
+    let mut result = String::from(first_line);
+    for line in lines {
+        result.push('\n');
+        result.push_str(parent_indent);
+        result.push_str(line);
+    }
+    result
+}
+
+fn json5_key_name(key: &RtJSONValue) -> Option<&str> {
+    match key {
+        RtJSONValue::Identifier(name)
+        | RtJSONValue::DoubleQuotedString(name)
+        | RtJSONValue::SingleQuotedString(name) => Some(name),
+        _ => None,
+    }
+}
 
 // ── Variant descriptor ─────────────────────────────────────────
 
@@ -82,25 +299,75 @@ impl OmoService {
             .find(|path| path.exists())
     }
 
-    fn config_path(v: &OmoVariant) -> PathBuf {
-        let base_dir = get_opencode_dir();
-        Self::find_existing_config_path(v, &base_dir)
-            .unwrap_or_else(|| base_dir.join(v.preferred_filename))
+    fn find_unified_config_path(
+        v: &OmoVariant,
+        home_dir: &Path,
+    ) -> Result<Option<PathBuf>, AppError> {
+        if v.category != STANDARD.category {
+            return Ok(None);
+        }
+
+        let path = home_dir.join(".omo").join(UNIFIED_CONFIG_FILENAME);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        UnifiedConfigDocument::load(&path)?;
+        let root = Self::read_jsonc_object(&path)?;
+        Ok(root
+            .get(OPENCODE_SECTION_KEY)
+            .and_then(Value::as_object)
+            .map(|_| path))
     }
 
-    fn resolve_local_config_path(v: &OmoVariant) -> Result<PathBuf, AppError> {
-        Self::find_existing_config_path(v, &get_opencode_dir()).ok_or(AppError::OmoConfigNotFound)
+    fn find_config_location(
+        v: &OmoVariant,
+        home_dir: &Path,
+        legacy_dir: &Path,
+    ) -> Result<Option<OmoConfigLocation>, AppError> {
+        if let Some(path) = Self::find_unified_config_path(v, home_dir)? {
+            return Ok(Some(OmoConfigLocation::Unified(path)));
+        }
+
+        Ok(Self::find_existing_config_path(v, legacy_dir).map(OmoConfigLocation::Legacy))
+    }
+
+    fn config_location(v: &OmoVariant) -> Result<OmoConfigLocation, AppError> {
+        let legacy_dir = get_opencode_dir();
+        Ok(Self::find_config_location(v, &get_home_dir(), &legacy_dir)?
+            .unwrap_or_else(|| OmoConfigLocation::Legacy(legacy_dir.join(v.preferred_filename))))
+    }
+
+    fn resolve_local_config_location(v: &OmoVariant) -> Result<OmoConfigLocation, AppError> {
+        Self::find_config_location(v, &get_home_dir(), &get_opencode_dir())?
+            .ok_or(AppError::OmoConfigNotFound)
     }
 
     fn read_jsonc_object(path: &Path) -> Result<Map<String, Value>, AppError> {
         let content = std::fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
-        let cleaned = Self::strip_jsonc_comments(&content);
-        let parsed: Value = serde_json::from_str(&cleaned)
-            .map_err(|e| AppError::Config(format!("Failed to parse oh-my-opencode config: {e}")))?;
+        let parsed: Value = json5::from_str(&content)
+            .map_err(|e| AppError::Config(format!("Failed to parse OMO config: {e}")))?;
         parsed
             .as_object()
             .cloned()
             .ok_or_else(|| AppError::Config("Expected JSON object".to_string()))
+    }
+
+    fn read_config_object(location: &OmoConfigLocation) -> Result<Map<String, Value>, AppError> {
+        let mut root = Self::read_jsonc_object(location.path())?;
+        match location {
+            OmoConfigLocation::Unified(_) => root
+                .remove(OPENCODE_SECTION_KEY)
+                .and_then(|value| value.as_object().cloned())
+                .ok_or(AppError::OmoConfigNotFound),
+            OmoConfigLocation::Legacy(_) => Ok(root),
+        }
+    }
+
+    fn remove_unified_config_section(path: &Path) -> Result<Vec<u8>, AppError> {
+        let mut document = UnifiedConfigDocument::load(path)?;
+        document.remove_opencode_section()?;
+        document.save()
     }
 
     // ── Field extraction ───────────────────────────────────
@@ -167,23 +434,55 @@ impl OmoService {
         }
     }
 
+    fn restore_config_file_if_unchanged(
+        path: &Path,
+        expected_contents: Option<&[u8]>,
+        snapshot: Option<&[u8]>,
+    ) -> Result<(), AppError> {
+        let _guard = omo_write_lock().lock()?;
+        let current_contents = Self::snapshot_config_file(path)?;
+        if current_contents.as_deref() != expected_contents {
+            return Err(AppError::Config(format!(
+                "Config changed after CC Switch wrote it; refusing to roll back {}",
+                path.display()
+            )));
+        }
+        Self::restore_config_file(path, snapshot)
+    }
+
     fn write_profile_config(
         v: &OmoVariant,
         profile_data: Option<&OmoProfileData>,
     ) -> Result<(), AppError> {
         let merged = Self::build_config(v, profile_data);
-        let config_path = Self::config_path(v);
+        let location = Self::config_location(v)?;
+        let config_path = location.path().to_path_buf();
 
         if let Some(parent) = config_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
         }
 
-        let previous_contents = Self::snapshot_config_file(&config_path)?;
-        write_json_file(&config_path, &merged)?;
+        let (previous_contents, expected_contents) = match &location {
+            OmoConfigLocation::Unified(path) => {
+                let mut document = UnifiedConfigDocument::load(path)?;
+                let previous_contents = Some(document.original_source.as_bytes().to_vec());
+                document.set_opencode_section(&merged)?;
+                let expected_contents = Some(document.save()?);
+                (previous_contents, expected_contents)
+            }
+            OmoConfigLocation::Legacy(path) => {
+                let previous_contents = Self::snapshot_config_file(path)?;
+                write_json_file(path, &merged)?;
+                let expected_contents = Self::snapshot_config_file(path)?;
+                (previous_contents, expected_contents)
+            }
+        };
         if let Err(err) = crate::opencode_config::add_plugin(v.plugin_name) {
-            if let Err(rollback_err) =
-                Self::restore_config_file(&config_path, previous_contents.as_deref())
-            {
+            if let Err(rollback_err) = Self::restore_config_file_if_unchanged(
+                &config_path,
+                expected_contents.as_deref(),
+                previous_contents.as_deref(),
+            ) {
                 log::warn!(
                     "Failed to roll back {} config after plugin sync error: {}",
                     v.label,
@@ -200,17 +499,69 @@ impl OmoService {
 
     pub fn delete_config_file(v: &OmoVariant) -> Result<(), AppError> {
         let base_dir = get_opencode_dir();
-        let mut deleted_paths = Vec::new();
-        for config_path in Self::config_candidates(v, &base_dir) {
-            if config_path.exists() {
-                std::fs::remove_file(&config_path).map_err(|e| AppError::io(&config_path, e))?;
-                deleted_paths.push(config_path);
+        let unified_path = Self::find_unified_config_path(v, &get_home_dir())?;
+        let legacy_paths: Vec<_> = Self::config_candidates(v, &base_dir)
+            .into_iter()
+            .filter(|path| path.exists())
+            .collect();
+        let plugin_config_path = crate::opencode_config::get_opencode_config_path();
+
+        let plugin_config_snapshot = Self::snapshot_config_file(&plugin_config_path)?;
+        let unified_snapshot = unified_path
+            .as_ref()
+            .map(|path| Self::snapshot_config_file(path))
+            .transpose()?
+            .flatten();
+        let legacy_snapshots = legacy_paths
+            .iter()
+            .map(|path| Self::snapshot_config_file(path))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut applied_changes = Vec::new();
+
+        let result = (|| -> Result<(), AppError> {
+            crate::opencode_config::remove_plugins_by_prefixes(v.plugin_prefixes)?;
+            let plugin_config_expected = Self::snapshot_config_file(&plugin_config_path)?;
+            applied_changes.push((
+                plugin_config_path,
+                plugin_config_snapshot,
+                plugin_config_expected,
+            ));
+            if let Some(path) = &unified_path {
+                let expected_contents = Some(Self::remove_unified_config_section(path)?);
+                applied_changes.push((path.clone(), unified_snapshot, expected_contents));
             }
+            for (path, snapshot) in legacy_paths.iter().zip(legacy_snapshots) {
+                std::fs::remove_file(path).map_err(|e| AppError::io(path, e))?;
+                applied_changes.push((path.clone(), snapshot, None));
+            }
+            Ok(())
+        })();
+
+        if let Err(err) = result {
+            for (path, snapshot, expected_contents) in applied_changes.iter().rev() {
+                if let Err(rollback_err) = Self::restore_config_file_if_unchanged(
+                    path,
+                    expected_contents.as_deref(),
+                    snapshot.as_deref(),
+                ) {
+                    log::warn!(
+                        "Failed to roll back OMO disable change at {path:?}: {rollback_err}"
+                    );
+                }
+            }
+            return Err(err);
         }
-        if !deleted_paths.is_empty() {
-            log::info!("{} config files deleted: {deleted_paths:?}", v.label);
+
+        let mut changed_paths = legacy_paths;
+        if let Some(path) = unified_path {
+            changed_paths.push(path);
         }
-        crate::opencode_config::remove_plugins_by_prefixes(v.plugin_prefixes)?;
+        if !changed_paths.is_empty() {
+            log::info!(
+                "{} config files updated or deleted: {changed_paths:?}",
+                v.label
+            );
+        }
         Ok(())
     }
 
@@ -246,8 +597,8 @@ impl OmoService {
         state: &AppState,
         v: &OmoVariant,
     ) -> Result<crate::provider::Provider, AppError> {
-        let actual_path = Self::resolve_local_config_path(v)?;
-        let obj = Self::read_jsonc_object(&actual_path)?;
+        let location = Self::resolve_local_config_location(v)?;
+        let obj = Self::read_config_object(&location)?;
 
         let mut settings = Map::new();
         if let Some(agents) = obj.get("agents") {
@@ -297,13 +648,14 @@ impl OmoService {
     }
 
     pub fn read_local_file(v: &OmoVariant) -> Result<OmoLocalFileData, AppError> {
-        let actual_path = Self::resolve_local_config_path(v)?;
+        let location = Self::resolve_local_config_location(v)?;
+        let actual_path = location.path().to_path_buf();
         let metadata = std::fs::metadata(&actual_path).ok();
         let last_modified = metadata
             .and_then(|m| m.modified().ok())
             .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339());
 
-        let obj = Self::read_jsonc_object(&actual_path)?;
+        let obj = Self::read_config_object(&location)?;
 
         Ok(Self::build_local_file_data(
             v,
@@ -341,62 +693,6 @@ impl OmoService {
             last_modified,
         }
     }
-
-    fn strip_jsonc_comments(input: &str) -> String {
-        let mut result = String::with_capacity(input.len());
-        let mut chars = input.chars().peekable();
-        let mut in_string = false;
-        let mut escape = false;
-
-        while let Some(&c) = chars.peek() {
-            if in_string {
-                result.push(c);
-                chars.next();
-                if escape {
-                    escape = false;
-                } else if c == '\\' {
-                    escape = true;
-                } else if c == '"' {
-                    in_string = false;
-                }
-            } else if c == '"' {
-                in_string = true;
-                result.push(c);
-                chars.next();
-            } else if c == '/' {
-                chars.next();
-                match chars.peek() {
-                    Some('/') => {
-                        chars.next();
-                        while let Some(&nc) = chars.peek() {
-                            if nc == '\n' {
-                                break;
-                            }
-                            chars.next();
-                        }
-                    }
-                    Some('*') => {
-                        chars.next();
-                        while let Some(nc) = chars.next() {
-                            if nc == '*' {
-                                if let Some(&'/') = chars.peek() {
-                                    chars.next();
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    _ => {
-                        result.push('/');
-                    }
-                }
-            } else {
-                result.push(c);
-                chars.next();
-            }
-        }
-        result
-    }
 }
 
 #[cfg(test)]
@@ -404,18 +700,200 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_strip_jsonc_comments() {
-        let input = r#"{
+    fn test_read_jsonc_object_supports_comments_and_trailing_commas() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        std::fs::write(
+            &path,
+            r#"{
   // This is a comment
-  "key": "value", // inline comment
-  /* multi
-     line */
-  "key2": "val//ue"
-}"#;
-        let result = OmoService::strip_jsonc_comments(input);
-        let parsed: Value = serde_json::from_str(&result).unwrap();
+  "key": "value",
+  "key2": "val//ue",
+}"#,
+        )
+        .unwrap();
+
+        let parsed = OmoService::read_jsonc_object(&path).unwrap();
         assert_eq!(parsed["key"], "value");
         assert_eq!(parsed["key2"], "val//ue");
+    }
+
+    #[test]
+    fn test_find_config_location_prefers_unified_opencode_block() {
+        let home = tempfile::tempdir().unwrap();
+        let unified_path = home.path().join(".omo").join("omo.jsonc");
+        let legacy_dir = home.path().join(".config").join("opencode");
+        std::fs::create_dir_all(unified_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        std::fs::write(
+            &unified_path,
+            r#"{"[opencode]":{"agents":{}},"[codex]":{"agents":{}}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            legacy_dir.join(STANDARD.preferred_filename),
+            r#"{"agents":{}}"#,
+        )
+        .unwrap();
+
+        let found = OmoService::find_config_location(&STANDARD, home.path(), &legacy_dir).unwrap();
+
+        assert_eq!(found, Some(OmoConfigLocation::Unified(unified_path)));
+    }
+
+    #[test]
+    fn test_find_config_location_falls_back_when_unified_has_no_opencode_block() {
+        let home = tempfile::tempdir().unwrap();
+        let unified_path = home.path().join(".omo").join("omo.jsonc");
+        let legacy_dir = home.path().join(".config").join("opencode");
+        let legacy_path = legacy_dir.join(STANDARD.preferred_filename);
+        std::fs::create_dir_all(unified_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        std::fs::write(&unified_path, r#"{"[codex]":{"agents":{}}}"#).unwrap();
+        std::fs::write(&legacy_path, r#"{"agents":{}}"#).unwrap();
+
+        let found = OmoService::find_config_location(&STANDARD, home.path(), &legacy_dir).unwrap();
+
+        assert_eq!(found, Some(OmoConfigLocation::Legacy(legacy_path)));
+    }
+
+    #[test]
+    fn test_unified_config_reads_only_opencode_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        std::fs::write(
+            &path,
+            r#"{
+  "models": {"shared": {"model": "shared/model"}},
+  "[opencode]": {"agents": {"sisyphus": {"model": "openai/gpt-5.3"}}},
+  "[codex]": {"agents": {"reviewer": {"model": "openai/gpt-5.4"}}}
+}"#,
+        )
+        .unwrap();
+
+        let obj = OmoService::read_config_object(&OmoConfigLocation::Unified(path)).unwrap();
+
+        assert_eq!(obj["agents"]["sisyphus"]["model"], "openai/gpt-5.3");
+        assert!(!obj.contains_key("models"));
+        assert!(!obj.contains_key("[codex]"));
+    }
+
+    #[test]
+    fn test_unified_config_write_preserves_other_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        std::fs::write(
+            &path,
+            r#"{
+  // Migration state belongs to the shared document.
+  "_migrations": ["2026-07-opencode-config-unification"],
+  "[opencode]": {"agents": {"old": {"model": "old/model"}}},
+  // Codex settings must survive OpenCode profile switches.
+  "[codex]": {"agents": {"reviewer": {"model": "openai/gpt-5.4"}}}
+}"#,
+        )
+        .unwrap();
+        let profile_data = (
+            Some(serde_json::json!({"sisyphus": {"model": "openai/gpt-5.3"}})),
+            None,
+            None,
+        );
+        let config = OmoService::build_config(&STANDARD, Some(&profile_data));
+
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        document.set_opencode_section(&config).unwrap();
+        let _written_contents = document.save().unwrap();
+        let source = std::fs::read_to_string(&path).unwrap();
+        let document: Value = json5::from_str(&source).unwrap();
+
+        assert_eq!(
+            document["_migrations"],
+            serde_json::json!(["2026-07-opencode-config-unification"])
+        );
+        assert_eq!(
+            document["[codex]"]["agents"]["reviewer"]["model"],
+            "openai/gpt-5.4"
+        );
+        assert_eq!(
+            document["[opencode]"]["agents"]["sisyphus"]["model"],
+            "openai/gpt-5.3"
+        );
+        assert!(source.contains("// Migration state belongs to the shared document."));
+        assert!(source.contains("// Codex settings must survive OpenCode profile switches."));
+    }
+
+    #[test]
+    fn test_remove_unified_config_section_preserves_other_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        std::fs::write(
+            &path,
+            r#"{
+  "[opencode]": {"agents": {}},
+  // Keep this Codex explanation when disabling OpenCode OMO.
+  "[codex]": {"agents": {}},
+  "_migrations": ["done"]
+}"#,
+        )
+        .unwrap();
+
+        OmoService::remove_unified_config_section(&path).unwrap();
+
+        let source = std::fs::read_to_string(&path).unwrap();
+        let root = OmoService::read_jsonc_object(&path).unwrap();
+        assert!(!root.contains_key(OPENCODE_SECTION_KEY));
+        assert!(root.contains_key("[codex]"));
+        assert_eq!(root["_migrations"], serde_json::json!(["done"]));
+        assert!(source.contains("// Keep this Codex explanation when disabling OpenCode OMO."));
+    }
+
+    #[test]
+    fn test_unified_config_write_rejects_concurrent_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        std::fs::write(&path, r#"{"[opencode]":{"agents":{}}}"#).unwrap();
+        let mut document = UnifiedConfigDocument::load(&path).unwrap();
+        document
+            .set_opencode_section(&serde_json::json!({"agents": {"new": {}}}))
+            .unwrap();
+        let concurrent_source = r#"{"[opencode]":{"agents":{}},"[codex]":{"changed":true}}"#;
+        std::fs::write(&path, concurrent_source).unwrap();
+
+        let result = document.save();
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), concurrent_source);
+    }
+
+    #[test]
+    fn test_unified_config_rejects_duplicate_opencode_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        std::fs::write(
+            &path,
+            r#"{"[opencode]":{"agents":{"first":{}}},"[opencode]":{"agents":{"second":{}}}}"#,
+        )
+        .unwrap();
+
+        let result = UnifiedConfigDocument::load(&path);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rollback_refuses_to_overwrite_newer_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("omo.jsonc");
+        let original = br#"{"[opencode]":{"agents":{"old":{}}}}"#;
+        let written = br#"{"[opencode]":{"agents":{"ours":{}}}}"#;
+        let concurrent = br#"{"[opencode]":{"agents":{"theirs":{}}}}"#;
+        std::fs::write(&path, concurrent).unwrap();
+
+        let result =
+            OmoService::restore_config_file_if_unchanged(&path, Some(written), Some(original));
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), concurrent);
     }
 
     #[test]

--- a/src-tauri/src/services/omo.rs
+++ b/src-tauri/src/services/omo.rs
@@ -364,10 +364,12 @@ impl OmoService {
         }
     }
 
-    fn remove_unified_config_section(path: &Path) -> Result<Vec<u8>, AppError> {
+    fn remove_unified_config_section(path: &Path) -> Result<(Vec<u8>, Vec<u8>), AppError> {
         let mut document = UnifiedConfigDocument::load(path)?;
+        let previous_contents = document.original_source.as_bytes().to_vec();
         document.remove_opencode_section()?;
-        document.save()
+        let expected_contents = document.save()?;
+        Ok((previous_contents, expected_contents))
     }
 
     // ── Field extraction ───────────────────────────────────
@@ -506,31 +508,22 @@ impl OmoService {
             .collect();
         let plugin_config_path = crate::opencode_config::get_opencode_config_path();
 
-        let plugin_config_snapshot = Self::snapshot_config_file(&plugin_config_path)?;
-        let unified_snapshot = unified_path
-            .as_ref()
-            .map(|path| Self::snapshot_config_file(path))
-            .transpose()?
-            .flatten();
-        let legacy_snapshots = legacy_paths
-            .iter()
-            .map(|path| Self::snapshot_config_file(path))
-            .collect::<Result<Vec<_>, _>>()?;
         let mut applied_changes = Vec::new();
 
         let result = (|| -> Result<(), AppError> {
-            crate::opencode_config::remove_plugins_by_prefixes(v.plugin_prefixes)?;
-            let plugin_config_expected = Self::snapshot_config_file(&plugin_config_path)?;
+            let (plugin_config_snapshot, plugin_config_expected) =
+                crate::opencode_config::remove_plugins_by_prefixes(v.plugin_prefixes)?;
             applied_changes.push((
                 plugin_config_path,
                 plugin_config_snapshot,
                 plugin_config_expected,
             ));
             if let Some(path) = &unified_path {
-                let expected_contents = Some(Self::remove_unified_config_section(path)?);
-                applied_changes.push((path.clone(), unified_snapshot, expected_contents));
+                let (snapshot, expected_contents) = Self::remove_unified_config_section(path)?;
+                applied_changes.push((path.clone(), Some(snapshot), Some(expected_contents)));
             }
-            for (path, snapshot) in legacy_paths.iter().zip(legacy_snapshots) {
+            for path in &legacy_paths {
+                let snapshot = Self::snapshot_config_file(path)?;
                 std::fs::remove_file(path).map_err(|e| AppError::io(path, e))?;
                 applied_changes.push((path.clone(), snapshot, None));
             }


### PR DESCRIPTION
## Summary

- read and write standard OMO profiles from `~/.omo/omo.jsonc` when it contains an `[opencode]` block
- preserve unrelated shared settings, harness blocks, comments, and formatting while switching or disabling OMO profiles
- retain the legacy OpenCode config fallback when the unified block is absent, without changing OMO Slim behavior

## Root cause

CC Switch only searched the legacy `~/.config/opencode/oh-my-openagent.json[c]` files. Current OMO versions use the `[opencode]` block in `~/.omo/omo.jsonc`, so changes made in CC Switch were written to files OMO no longer reads.

Closes #5945
