### PR TITLE
fix:merge MCP server configuration during import

### DIFF
--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -309,6 +309,7 @@ impl McpService {
                     let to_save = if let Some(existing_server) = existing.get(&server.id) {
                         let mut merged = existing_server.clone();
                         merged.apps.claude = true;
+                        merged.server = server.server.clone();
                         merged
                     } else {
                         // 真正的新服务器
@@ -347,6 +348,7 @@ impl McpService {
                     let to_save = if let Some(existing_server) = existing.get(&server.id) {
                         let mut merged = existing_server.clone();
                         merged.apps.codex = true;
+                        merged.server = server.server.clone();
                         merged
                     } else {
                         // 真正的新服务器
@@ -385,6 +387,7 @@ impl McpService {
                     let to_save = if let Some(existing_server) = existing.get(&server.id) {
                         let mut merged = existing_server.clone();
                         merged.apps.gemini = true;
+                        merged.server = server.server.clone();
                         merged
                     } else {
                         // 真正的新服务器
@@ -449,6 +452,7 @@ impl McpService {
                     let to_save = if let Some(existing_server) = existing.get(&server.id) {
                         let mut merged = existing_server.clone();
                         merged.apps.opencode = true;
+                        merged.server = server.server.clone();
                         merged
                     } else {
                         // 真正的新服务器

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -420,6 +420,7 @@ impl McpService {
                     let to_save = if let Some(existing_server) = existing.get(&server.id) {
                         let mut merged = existing_server.clone();
                         merged.apps.grokbuild = true;
+                        merged.server = server.server.clone();
                         merged
                     } else {
                         new_count += 1;
@@ -491,6 +492,7 @@ impl McpService {
                     let to_save = if let Some(existing_server) = existing.get(&server.id) {
                         let mut merged = existing_server.clone();
                         merged.apps.hermes = true;
+                        merged.server = server.server.clone();
                         merged
                     } else {
                         // 真正的新服务器


### PR DESCRIPTION
## Summary

Fixes MCP import so that existing server configurations are updated when re-importing from external applications.

## 1042

## Changes

- Updated `import_from_claude`
- Updated `import_from_codex`
- Updated `import_from_gemini`
- Updated `import_from_opencode`
- Existing server configuration is now refreshed while preserving app associations.

## Testing

- Imported an MCP server.
- Modified its configuration externally.
- Re-imported it.
- Verified that the updated configuration is reflected in CC Switch.