### PR TITLE
fix(usage): re-sync session files when size changes despite unchanged mtime

### DIFF
--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -53,7 +53,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 16;
+pub(crate) const SCHEMA_VERSION: i32 = 17;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -302,6 +302,7 @@ impl Database {
                 file_path TEXT PRIMARY KEY,
                 last_modified INTEGER NOT NULL,
                 last_line_offset INTEGER NOT NULL DEFAULT 0,
+                last_size INTEGER NOT NULL DEFAULT 0,
                 last_synced_at INTEGER NOT NULL
             )",
             [],
@@ -510,6 +511,11 @@ impl Database {
                         log::info!("迁移数据库从 v15 到 v16（重建 Codex 会话用量）");
                         Self::migrate_v15_to_v16(conn)?;
                         Self::set_user_version(conn, 16)?;
+                    }
+                    16 => {
+                        log::info!("迁移数据库从 v16 到 v17（会话日志同步增加文件大小校验）");
+                        Self::migrate_v16_to_v17(conn)?;
+                        Self::set_user_version(conn, 17)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -1521,6 +1527,28 @@ impl Database {
     fn migrate_v15_to_v16(conn: &Connection) -> Result<(), AppError> {
         let codex_dir = crate::codex_config::get_codex_config_dir();
         crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)
+    }
+
+    /// v16 -> v17: session_log_sync 增加 last_size 列
+    ///
+    /// 修复会话文件写入中 mtime 不更新导致的漏同步：同步器在文件写入的
+    /// 中间态（如只写了 13 行）读取后把该 mtime 记为完成态，文件最终版本
+    /// 的 mtime 不变（Windows 上 Codex/Claude Code 实测），于是每轮同步
+    /// 都判定"未变化"而跳过，之后写入的所有用量永久丢失。
+    /// 新增 last_size 后，跳过判定同时校验文件大小：mtime 相等但 size
+    /// 变大时仍会重读，用 last_line_offset 去重保证不重复导入。
+    fn migrate_v16_to_v17(conn: &Connection) -> Result<(), AppError> {
+        // 真实库在 v8 迁移已建该表；表缺失（如部分测试模拟库）则跳过，
+        // 反正没有同步状态数据需要补列
+        if Self::table_exists(conn, "session_log_sync")? {
+            Self::add_column_if_missing(
+                conn,
+                "session_log_sync",
+                "last_size",
+                "INTEGER NOT NULL DEFAULT 0",
+            )?;
+        }
+        Ok(())
     }
 
     /// 插入默认模型定价数据
@@ -3222,7 +3250,7 @@ mod tests {
 
         Database::apply_schema_migrations_on_conn(&conn)?;
 
-        assert_eq!(Database::get_user_version(&conn)?, 16);
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
         let counts: (i64, i64, i64, i64) = conn.query_row(
             "SELECT
                 (SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'),

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -260,7 +260,13 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
     let file_size = metadata.len() as i64;
 
     // 检查同步状态
-    let (last_modified, last_offset, last_size) = get_sync_state(db, &file_path_str)?;
+    let (last_modified, mut last_offset, last_size) = get_sync_state(db, &file_path_str)?;
+
+    // 文件被截断/替换（size 变小）时旧 cursor 失效：继续用旧 offset 过滤会
+    // 把替换后文件的所有行都跳过。此时从零重扫，request_id 幂等保证不重复导入。
+    if last_size > 0 && file_size < last_size {
+        last_offset = 0;
+    }
 
     // 文件未变化则跳过。mtime 相等不代表未变化：写入中的会话文件 mtime
     // 可能不更新（Windows 实测），若上次在写入中间态落盘，最终版本会因
@@ -424,10 +430,36 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
         }
     }
 
-    // 更新同步状态
-    update_sync_state(db, &file_path_str, file_modified, line_offset, file_size)?;
+    // 更新同步状态。末行未以换行符结束时视为未完成（写入方可能还在补写），
+    // 不推进 cursor，否则补全后该行会被 line_offset <= last_offset 永久跳过。
+    let synced_offset = if file_size > 0 && !file_ends_with_newline(file_path) {
+        line_offset.saturating_sub(1)
+    } else {
+        line_offset
+    };
+    update_sync_state(db, &file_path_str, file_modified, synced_offset, file_size)?;
 
     Ok((imported, skipped))
+}
+
+/// 文件最后一个字节是否为换行符（空文件视为完整）。
+fn file_ends_with_newline(file_path: &Path) -> bool {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Ok(mut file) = fs::File::open(file_path) else {
+        return true;
+    };
+    let Ok(len) = file.metadata().map(|m| m.len()) else {
+        return true;
+    };
+    if len == 0 {
+        return true;
+    }
+    if file.seek(SeekFrom::End(-1)).is_err() {
+        return true;
+    }
+    let mut last = [0u8; 1];
+    file.read_exact(&mut last).is_ok() && last[0] == b'\n'
 }
 
 /// 获取 session_log_sync 表中某条目的同步进度。
@@ -892,6 +924,35 @@ mod tests {
         )?;
         assert!(!empty_exists, "全 0 token 的 message 应被跳过");
         drop(conn);
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_partial_last_line_does_not_advance_cursor() -> Result<(), AppError> {
+        // 回归：末行无换行符时（写入方可能还在补写）cursor 不得包含该行，
+        // 否则补全后该行会因 line_offset <= last_offset 被永久跳过。
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("agent-partial.jsonl");
+
+        let billable = r#"{"type":"assistant","message":{"id":"msg_first","model":"claude-opus-4-8","usage":{"input_tokens":2,"output_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-06-07T13:01:23Z","sessionId":"session-p"}"#;
+        // 第一行完整，第二行半截（无换行符结尾）
+        fs::write(&file, format!("{billable}\n{{")).unwrap();
+
+        let (imported, _) = sync_single_file(&db, &file)?;
+        assert_eq!(imported, 1, "完整的第一行正常导入");
+        let (_, offset, _) = get_sync_state(&db, &file.to_string_lossy())?;
+        assert_eq!(offset, 1, "cursor 只推进到完整行");
+
+        // 写入方补全半截行 → size 变化触发重扫 → 该行导入一次
+        let full = r#"{"type":"assistant","message":{"id":"msg_second","model":"claude-opus-4-8","usage":{"input_tokens":3,"output_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-06-07T13:01:24Z","sessionId":"session-p"}"#;
+        fs::write(&file, format!("{billable}\n{full}\n")).unwrap();
+
+        let (imported2, _) = sync_single_file(&db, &file)?;
+        assert_eq!(imported2, 1, "补全后的行必须导入一次");
 
         fs::remove_dir_all(&tmp).ok();
         Ok(())

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -257,12 +257,15 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
     let file_modified = metadata_modified_nanos(&metadata);
+    let file_size = metadata.len() as i64;
 
     // 检查同步状态
-    let (last_modified, last_offset) = get_sync_state(db, &file_path_str)?;
+    let (last_modified, last_offset, last_size) = get_sync_state(db, &file_path_str)?;
 
-    // 文件未变化则跳过
-    if file_modified <= last_modified {
+    // 文件未变化则跳过。mtime 相等不代表未变化：写入中的会话文件 mtime
+    // 可能不更新（Windows 实测），若上次在写入中间态落盘，最终版本会因
+    // mtime 相等被误判跳过，故必须同时校验文件大小。
+    if file_modified <= last_modified && file_size == last_size {
         return Ok((0, 0));
     }
 
@@ -422,22 +425,30 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
     }
 
     // 更新同步状态
-    update_sync_state(db, &file_path_str, file_modified, line_offset)?;
+    update_sync_state(db, &file_path_str, file_modified, line_offset, file_size)?;
 
     Ok((imported, skipped))
 }
 
 /// 获取 session_log_sync 表中某条目的同步进度。
 ///
+/// 返回 (last_modified, last_line_offset, last_size)。
 /// Shared by all session_usage_* parsers.
-pub(crate) fn get_sync_state(db: &Database, file_path: &str) -> Result<(i64, i64), AppError> {
+pub(crate) fn get_sync_state(db: &Database, file_path: &str) -> Result<(i64, i64, i64), AppError> {
     let conn = lock_conn!(db.conn);
     let result = conn.query_row(
-        "SELECT last_modified, last_line_offset FROM session_log_sync WHERE file_path = ?1",
+        "SELECT last_modified, last_line_offset, last_size
+         FROM session_log_sync WHERE file_path = ?1",
         rusqlite::params![file_path],
-        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        },
     );
-    Ok(result.unwrap_or((0, 0)))
+    Ok(result.unwrap_or((0, 0, 0)))
 }
 
 /// 返回文件 mtime 的纳秒时间戳。
@@ -455,12 +466,16 @@ pub(crate) fn metadata_modified_nanos(metadata: &fs::Metadata) -> i64 {
 
 /// 更新 session_log_sync 表中某条目的同步进度。
 ///
-/// Shared by all session_usage_* parsers.
+/// `last_size` 是同步时文件的字节数，用于弥补 mtime 不可靠的场景
+/// （写入中的会话文件 mtime 可能不更新，见 migrate_v16_to_v17）。
+/// Shared by all session_usage_* parsers；非文件型同步方（如 opencode）
+/// 无 size 语义，传 0 即可。
 pub(crate) fn update_sync_state(
     db: &Database,
     file_path: &str,
     last_modified: i64,
     last_offset: i64,
+    last_size: i64,
 ) -> Result<(), AppError> {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -469,9 +484,9 @@ pub(crate) fn update_sync_state(
 
     let conn = lock_conn!(db.conn);
     conn.execute(
-        "INSERT OR REPLACE INTO session_log_sync (file_path, last_modified, last_line_offset, last_synced_at)
-         VALUES (?1, ?2, ?3, ?4)",
-        rusqlite::params![file_path, last_modified, last_offset, now],
+        "INSERT OR REPLACE INTO session_log_sync (file_path, last_modified, last_line_offset, last_size, last_synced_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![file_path, last_modified, last_offset, last_size, now],
     )
     .map_err(|e| AppError::Database(format!("更新同步状态失败: {e}")))?;
     Ok(())

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -302,6 +302,23 @@ fn sqlite_column_exists(
     .map_err(|error| AppError::Database(format!("查询列 {table}.{column} 失败: {error}")))
 }
 
+/// 删除某 thread 的全部会话用量记录。
+///
+/// 文件被截断/替换（size 变小）时，重扫前先清掉该 thread 的旧记录：
+/// event_index 会重新从 1 计数，若不清除，新内容会撞上旧 request_id
+/// 被 should_skip_session_insert 幂等跳过。
+fn delete_codex_thread_session_records(db: &Database, thread_id: &str) -> Result<(), AppError> {
+    let pattern = format!("{CODEX_THREAD_REQUEST_ID_PREFIX}:{thread_id}:%");
+    let conn = lock_conn!(db.conn);
+    conn.execute(
+        "DELETE FROM proxy_request_logs
+         WHERE request_id LIKE ?1 AND data_source = 'codex_session'",
+        rusqlite::params![pattern],
+    )
+    .map_err(|e| AppError::Database(format!("清理被替换会话的旧用量失败: {e}")))?;
+    Ok(())
+}
+
 pub(crate) fn reset_codex_usage_on_conn(
     conn: &rusqlite::Connection,
     codex_dir: &Path,
@@ -1011,6 +1028,36 @@ fn should_resync(last_modified: i64, last_size: i64, file_modified: i64, file_si
     file_modified > last_modified || file_size as i64 != last_size
 }
 
+/// 末行未以换行符结束时，cursor 不包含该行。
+///
+/// `BufRead::lines()` 会把无换行符的末尾片段作为完整行返回，解析器会为它
+/// 递增 line_offset 并（因 JSON 不完整）跳过。若把该 offset 持久化，写入方
+/// 补完同一物理行后即使 size 变化触发重扫，也会因 `line_offset <= last_offset`
+/// 永远错过这一行。因此只有以 `\n` 结尾的行才算"已消费"。
+fn complete_line_offset(file_path: &Path, parsed_offset: i64) -> Result<i64, AppError> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file =
+        fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
+    let len = file
+        .metadata()
+        .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?
+        .len();
+    if len == 0 {
+        return Ok(parsed_offset);
+    }
+    file.seek(SeekFrom::End(-1))
+        .map_err(|e| AppError::Config(format!("无法定位文件末尾: {e}")))?;
+    let mut last = [0u8; 1];
+    file.read_exact(&mut last)
+        .map_err(|e| AppError::Config(format!("无法读取文件末尾: {e}")))?;
+    if last[0] == b'\n' {
+        Ok(parsed_offset)
+    } else {
+        Ok(parsed_offset.saturating_sub(1))
+    }
+}
+
 fn mark_deferred(
     file_path: &Path,
     modified: i64,
@@ -1060,7 +1107,18 @@ fn sync_single_codex_file(
     let file_size = metadata.len();
 
     // 检查同步状态
-    let (last_modified, last_offset, last_size) = get_codex_sync_state(db, file_path)?;
+    let (last_modified, mut last_offset, last_size) = get_codex_sync_state(db, file_path)?;
+
+    // 文件被截断/替换（size 变小）时旧 cursor 失效：继续用旧 offset 过滤会
+    // 把替换后文件的所有行都跳过。此时从零重扫，并删除该 thread 的旧会话
+    // 记录——否则 event_index 重新计数会撞上旧 request_id 被幂等跳过，
+    // 替换后的新内容仍然丢失。
+    if last_size > 0 && file_size < last_size as u64 {
+        last_offset = 0;
+        if let Some(thread_id) = thread_id_from_filename(file_path) {
+            delete_codex_thread_session_records(db, &thread_id)?;
+        }
+    }
 
     // 文件未变化则跳过。mtime 相等不代表未变化：写入中的会话文件 mtime
     // 可能不更新（Windows 上 Codex 实测），若上次在写入中间态落盘（如只
@@ -1098,12 +1156,13 @@ fn sync_single_codex_file(
     }
 
     let parsed = parse_codex_file(file_path, thread_id_from_filename(file_path))?;
+    let synced_offset = complete_line_offset(file_path, parsed.line_offset)?;
     if !parsed.has_billable_tokens {
         update_sync_state(
             db,
             &file_path_str,
             file_modified,
-            parsed.line_offset,
+            synced_offset,
             file_size as i64,
         )?;
         return Ok(CodexFileSyncResult::default());
@@ -1236,7 +1295,7 @@ fn sync_single_codex_file(
         db,
         &file_path_str,
         file_modified,
-        parsed.line_offset,
+        synced_offset,
         file_size as i64,
     )?;
     Ok(result)
@@ -1420,6 +1479,72 @@ mod tests {
             1_755_960_000_000_000_000,
             13_000
         ));
+    }
+
+    #[test]
+    fn test_truncated_file_resets_cursor_and_reimports() -> Result<(), AppError> {
+        // 回归：文件被截断/替换（size 变小）后，旧 cursor 与旧 request_id
+        // 都会导致替换后的新内容丢失——cursor 必须重置，且该 thread 的旧
+        // 记录必须删除（否则 event_index 重新计数撞上旧 request_id 被跳过）。
+        let dir = tempdir().unwrap();
+        let db = Database::memory()?;
+        let path = rollout_path(dir.path(), CHILD_A_ID);
+        write_jsonl(
+            &path,
+            &[
+                session_meta(CHILD_A_ID),
+                turn_context(),
+                token_count(100, 50, 10),
+                token_count(200, 100, 20),
+            ],
+        );
+        assert_eq!(sync_test_file(&db, &path, &[&path])?.imported, 2);
+
+        // 同一路径被替换为更短内容（event_index 从 1 重新计数）
+        write_jsonl(
+            &path,
+            &[
+                session_meta(CHILD_A_ID),
+                turn_context(),
+                token_count(500, 250, 40),
+            ],
+        );
+        assert_eq!(sync_test_file(&db, &path, &[&path])?.imported, 1);
+
+        let conn = lock_conn!(db.conn);
+        let (count, input): (i64, i64) = conn.query_row(
+            "SELECT COUNT(*), SUM(input_tokens) FROM proxy_request_logs
+             WHERE request_id LIKE ?1 AND data_source = 'codex_session'",
+            [format!("{CODEX_THREAD_REQUEST_ID_PREFIX}:{CHILD_A_ID}:%")],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        drop(conn);
+        assert_eq!((count, input), (1, 500), "旧记录已清、新内容已导入");
+        Ok(())
+    }
+
+    #[test]
+    fn test_partial_last_line_does_not_advance_cursor() -> Result<(), AppError> {
+        // 回归：末行无换行符时（写入方可能还在补写）cursor 不得包含该行，
+        // 否则补全后该行会因 line_offset <= last_offset 被永久跳过。
+        let dir = tempdir().unwrap();
+        let db = Database::memory()?;
+        let path = rollout_path(dir.path(), CHILD_A_ID);
+        let meta = session_meta(CHILD_A_ID).to_string();
+        let ctx = turn_context().to_string();
+        let full_line = token_count(100, 50, 10).to_string();
+        // 第一行完整、第二行完整、第三行是截断的 JSON（无换行符结尾，解析必失败）
+        let partial = full_line[..full_line.len() / 2].to_string();
+        fs::write(&path, format!("{meta}\n{ctx}\n{partial}")).unwrap();
+
+        assert_eq!(sync_test_file(&db, &path, &[&path])?.imported, 0);
+        let (_, offset, _) = get_sync_state(&db, &path.to_string_lossy())?;
+        assert_eq!(offset, 2, "cursor 只推进到完整行");
+
+        // 写入方补全截断行（补全 + 换行）→ size 变化触发重扫 → 该行导入一次
+        fs::write(&path, format!("{meta}\n{ctx}\n{full_line}\n")).unwrap();
+        assert_eq!(sync_test_file(&db, &path, &[&path])?.imported, 1);
+        Ok(())
     }
 
     fn write_jsonl(path: &Path, values: &[serde_json::Value]) {

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -450,10 +450,10 @@ fn parse_token_signature(info: &serde_json::Value) -> Option<TokenUsageSignature
     (total.is_some() || last.is_some()).then_some(TokenUsageSignature { total, last })
 }
 
-fn get_codex_sync_state(db: &Database, file_path: &Path) -> Result<(i64, i64), AppError> {
+fn get_codex_sync_state(db: &Database, file_path: &Path) -> Result<(i64, i64, i64), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
     let state = get_sync_state(db, &file_path_str)?;
-    if state != (0, 0)
+    if state != (0, 0, 0)
         || file_path
             .parent()
             .and_then(Path::file_name)
@@ -470,7 +470,7 @@ fn get_codex_sync_state(db: &Database, file_path: &Path) -> Result<(i64, i64), A
     let backslash_suffix = format!("\\{file_name}");
     let conn = lock_conn!(db.conn);
     let inherited = conn.query_row(
-        "SELECT last_modified, last_line_offset
+        "SELECT last_modified, last_line_offset, last_size
          FROM session_log_sync
          WHERE file_path <> ?1
            AND (substr(file_path, -length(?2)) = ?2
@@ -478,13 +478,19 @@ fn get_codex_sync_state(db: &Database, file_path: &Path) -> Result<(i64, i64), A
          ORDER BY last_line_offset DESC, last_modified DESC
          LIMIT 1",
         rusqlite::params![file_path_str, slash_suffix, backslash_suffix],
-        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        },
     );
     drop(conn);
 
     match inherited {
         Ok(inherited) => {
-            update_sync_state(db, &file_path_str, inherited.0, inherited.1)?;
+            update_sync_state(db, &file_path_str, inherited.0, inherited.1, inherited.2)?;
             Ok(inherited)
         }
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(state),
@@ -994,6 +1000,17 @@ fn matching_replay_prefix(child: &[ParsedTokenEvent], parent: &[TokenUsageSignat
     matched
 }
 
+/// 判断文件是否需要重新同步。
+///
+/// mtime 不可靠：Windows 上会话文件在写入过程中 mtime 可能不更新，
+/// 若上次同步恰好读到写入中间态并记录该 mtime，文件最终版本会因
+/// `mtime <= last_modified` 被永久误判为"未变化"而漏同步（实测：56 MB
+/// 会话文件同步停在 13 行后 7000+ 行永久丢失）。因此只有当 mtime 和
+/// size 都未变化时才跳过；重读由 last_line_offset 去重保证不重复导入。
+fn should_resync(last_modified: i64, last_size: i64, file_modified: i64, file_size: u64) -> bool {
+    file_modified > last_modified || file_size as i64 != last_size
+}
+
 fn mark_deferred(
     file_path: &Path,
     modified: i64,
@@ -1043,10 +1060,13 @@ fn sync_single_codex_file(
     let file_size = metadata.len();
 
     // 检查同步状态
-    let (last_modified, last_offset) = get_codex_sync_state(db, file_path)?;
+    let (last_modified, last_offset, last_size) = get_codex_sync_state(db, file_path)?;
 
-    // 文件未变化则跳过
-    if file_modified <= last_modified {
+    // 文件未变化则跳过。mtime 相等不代表未变化：写入中的会话文件 mtime
+    // 可能不更新（Windows 上 Codex 实测），若上次在写入中间态落盘（如只
+    // 读到 13 行），最终版本会因 mtime 相等被永久误判为"未变化"而漏同步，
+    // 故必须同时校验文件大小。last_line_offset 去重保证重读不重复导入。
+    if !should_resync(last_modified, last_size, file_modified, file_size) {
         return Ok(CodexFileSyncResult::default());
     }
 
@@ -1079,7 +1099,13 @@ fn sync_single_codex_file(
 
     let parsed = parse_codex_file(file_path, thread_id_from_filename(file_path))?;
     if !parsed.has_billable_tokens {
-        update_sync_state(db, &file_path_str, file_modified, parsed.line_offset)?;
+        update_sync_state(
+            db,
+            &file_path_str,
+            file_modified,
+            parsed.line_offset,
+            file_size as i64,
+        )?;
         return Ok(CodexFileSyncResult::default());
     }
     let Some(root_thread_id) = parsed.root_thread_id.as_deref() else {
@@ -1206,7 +1232,13 @@ fn sync_single_codex_file(
         }
     }
 
-    update_sync_state(db, &file_path_str, file_modified, parsed.line_offset)?;
+    update_sync_state(
+        db,
+        &file_path_str,
+        file_modified,
+        parsed.line_offset,
+        file_size as i64,
+    )?;
     Ok(result)
 }
 
@@ -1344,6 +1376,51 @@ mod tests {
     const PARENT_ID: &str = "00000000-0000-4000-8000-000000000001";
     const CHILD_A_ID: &str = "00000000-0000-4000-8000-000000000002";
     const CHILD_B_ID: &str = "00000000-0000-4000-8000-000000000003";
+
+    #[test]
+    fn test_should_resync_mtime_same_size_grew() {
+        // 写入中的会话文件 mtime 不更新：上次同步停在中间态（13 行的小 size），
+        // 文件最终版本 mtime 不变但 size 变大 → 必须重读，否则 7000+ 行永久丢失
+        assert!(should_resync(
+            1_755_960_000_000_000_000,
+            96_000,
+            1_755_960_000_000_000_000,
+            56_945_631
+        ));
+    }
+
+    #[test]
+    fn test_should_resync_unchanged_file_skips() {
+        // mtime 和 size 都未变化 → 跳过（保持原有增量同步行为）
+        assert!(!should_resync(
+            1_755_960_000_000_000_000,
+            56_945_631,
+            1_755_960_000_000_000_000,
+            56_945_631
+        ));
+    }
+
+    #[test]
+    fn test_should_resync_mtime_grew() {
+        // mtime 变大 → 重读（原有行为）
+        assert!(should_resync(
+            1_755_960_000_000_000_000,
+            56_945_631,
+            1_755_960_000_000_000_100,
+            56_945_631
+        ));
+    }
+
+    #[test]
+    fn test_should_resync_size_shrunk() {
+        // size 变小（如文件被截断重写）→ 重读，offset 去重兜底
+        assert!(should_resync(
+            1_755_960_000_000_000_000,
+            56_945_631,
+            1_755_960_000_000_000_000,
+            13_000
+        ));
+    }
 
     fn write_jsonl(path: &Path, values: &[serde_json::Value]) {
         let contents = values
@@ -1848,7 +1925,7 @@ mod tests {
 
         let result = sync_test_file(&db, &child, &[&child])?;
         assert!(result.deferred);
-        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0, 0));
         Ok(())
     }
 
@@ -1903,7 +1980,7 @@ mod tests {
 
         let deferred = sync_test_file(&db, &child, &[&child])?;
         assert!(deferred.deferred);
-        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0, 0));
 
         write_jsonl(
             &parent,
@@ -1929,7 +2006,7 @@ mod tests {
 
         let result = sync_test_file(&db, &child, &[&child])?;
         assert!(result.deferred);
-        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0, 0));
 
         std::thread::sleep(std::time::Duration::from_millis(2));
         write_jsonl(
@@ -2053,7 +2130,7 @@ mod tests {
             )?;
         }
         let source_path = source.to_string_lossy().to_string();
-        update_sync_state(&db, &source_path, 1, 3)?;
+        update_sync_state(&db, &source_path, 1, 3, 0)?;
 
         assert_eq!(
             sync_test_file(&db, &archived_file, &[&archived_file])?.imported,

--- a/src-tauri/src/services/session_usage_gemini.rs
+++ b/src-tauri/src/services/session_usage_gemini.rs
@@ -131,12 +131,14 @@ fn sync_single_gemini_file(db: &Database, file_path: &Path) -> Result<(u32, u32)
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
     let file_modified = metadata_modified_nanos(&metadata);
+    let file_size = metadata.len() as i64;
 
     // 检查同步状态
-    let (last_modified, _last_offset) = get_sync_state(db, &file_path_str)?;
+    let (last_modified, _last_offset, last_size) = get_sync_state(db, &file_path_str)?;
 
-    // 文件未变化则跳过
-    if file_modified <= last_modified {
+    // 文件未变化则跳过。mtime 相等不代表未变化（写入中的会话文件 mtime
+    // 可能不更新），须同时校验文件大小，见 session_usage::update_sync_state。
+    if file_modified <= last_modified && file_size == last_size {
         return Ok((0, 0));
     }
 
@@ -211,7 +213,13 @@ fn sync_single_gemini_file(db: &Database, file_path: &Path) -> Result<(u32, u32)
     }
 
     // 更新同步状态
-    update_sync_state(db, &file_path_str, file_modified, gemini_msg_count)?;
+    update_sync_state(
+        db,
+        &file_path_str,
+        file_modified,
+        gemini_msg_count,
+        file_size,
+    )?;
 
     Ok((imported, skipped))
 }

--- a/src-tauri/src/services/session_usage_grokbuild.rs
+++ b/src-tauri/src/services/session_usage_grokbuild.rs
@@ -156,9 +156,11 @@ fn sync_single_grok_file(db: &Database, file_path: &Path) -> Result<SessionSyncR
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
     let file_modified = metadata_modified_nanos(&metadata);
+    let file_size = metadata.len() as i64;
 
-    let (last_modified, _last_offset) = get_sync_state(db, &file_path_str)?;
-    if file_modified <= last_modified {
+    let (last_modified, _last_offset, last_size) = get_sync_state(db, &file_path_str)?;
+    // mtime 相等不代表未变化（写入中的会话文件 mtime 可能不更新），须同时校验 size
+    if file_modified <= last_modified && file_size == last_size {
         return Ok(SessionSyncResult::default());
     }
 
@@ -254,7 +256,13 @@ fn sync_single_grok_file(db: &Database, file_path: &Path) -> Result<SessionSyncR
         // 不落同步状态：下一轮重读整个文件，把沉降后的事件补入。
         result.deferred_files += 1;
     } else {
-        update_sync_state(db, &file_path_str, file_modified, events.len() as i64)?;
+        update_sync_state(
+            db,
+            &file_path_str,
+            file_modified,
+            events.len() as i64,
+            file_size,
+        )?;
     }
 
     Ok(result)
@@ -822,7 +830,7 @@ mod tests {
         assert_eq!(result.deferred_files, 1);
         assert_eq!(query_rows(&db)?.len(), 1);
 
-        let (last_modified, _) = get_sync_state(&db, &path.to_string_lossy())?;
+        let (last_modified, _, _) = get_sync_state(&db, &path.to_string_lossy())?;
         assert_eq!(last_modified, 0, "延后时不得记录同步状态");
 
         // 下一轮重读：旧事件 UPSERT 无变化，新事件仍未沉降继续延后

--- a/src-tauri/src/services/session_usage_opencode.rs
+++ b/src-tauri/src/services/session_usage_opencode.rs
@@ -71,7 +71,7 @@ pub fn sync_opencode_usage(db: &Database) -> Result<SessionSyncResult, AppError>
         file_modified = file_modified.max(metadata_modified_nanos(&wal_meta));
     }
 
-    let (last_modified, _last_offset) = get_sync_state(db, &db_path_str)?;
+    let (last_modified, _last_offset, _last_size) = get_sync_state(db, &db_path_str)?;
 
     // 文件未变化则跳过
     if file_modified <= last_modified {
@@ -106,7 +106,7 @@ pub fn sync_opencode_usage(db: &Database) -> Result<SessionSyncResult, AppError>
     for (session_id, time_updated) in &sessions {
         // 检查会话是否需要重新同步
         let sync_key = format!("{db_path_str}:{session_id}");
-        let (sess_last_modified, _) = get_sync_state(db, &sync_key)?;
+        let (sess_last_modified, _, _) = get_sync_state(db, &sync_key)?;
         if *time_updated <= sess_last_modified {
             continue; // 会话未更新，跳过
         }
@@ -152,7 +152,7 @@ pub fn sync_opencode_usage(db: &Database) -> Result<SessionSyncResult, AppError>
         }
 
         // 更新会话级同步状态。失败时不要推进文件级状态，确保下次可重试。
-        if let Err(e) = update_sync_state(db, &sync_key, *time_updated, 0) {
+        if let Err(e) = update_sync_state(db, &sync_key, *time_updated, 0, 0) {
             let msg = format!("OpenCode 会话同步状态更新失败 {session_id}: {e}");
             log::warn!("[OPENCODE-SYNC] {msg}");
             result.errors.push(msg);
@@ -162,7 +162,7 @@ pub fn sync_opencode_usage(db: &Database) -> Result<SessionSyncResult, AppError>
 
     // 仅在本轮完全成功时推进文件级状态；否则保留下次重试入口。
     if !has_sync_errors {
-        update_sync_state(db, &db_path_str, file_modified, 0)?;
+        update_sync_state(db, &db_path_str, file_modified, 0, 0)?;
     }
 
     if result.imported > 0 {


### PR DESCRIPTION
## 问题

修复 #6023：Codex 用量统计从 08-01 晚上起停止记录。

根因：**Windows 上会话文件在写入过程中 mtime 可能不更新**（Codex 实测，56 MB 会话文件写完后 mtime 停在第一行写入时刻）。同步器恰好读到写入中间态（13 行）时，把该 mtime + offset 落盘为"已同步"状态；文件最终版本（7533 行）mtime 不变，之后每轮同步都判定"未变化"跳过——**中间态之后写入的所有用量永久丢失**。

## 修复

`session_log_sync` 增加 `last_size` 列（v16 → v17 迁移），跳过判定从只看 mtime 改为 **mtime 和 size 都未变化才跳过**：

```rust
fn should_resync(last_modified: i64, last_size: i64, file_modified: i64, file_size: u64) -> bool {
    file_modified > last_modified || file_size as i64 != last_size
}
```

- 重读由 `last_line_offset` 去重，不会重复导入
- 旧库迁移后 `last_size` 为 0，与实际不符 → 每个文件自动触发一次重读自愈
- codex / claude / gemini / grokbuild 四个文件型 parser 统一修复；opencode 用目录时间戳语义，不受影响
- 顺带修复测试里硬编码的 SCHEMA_VERSION 断言（改为常量）

## 测试

- 新增 `should_resync` 纯函数测试 ×4（mtime 相等 size 变大 → 重读；mtime+size 都不变 → 跳过；mtime 变大 → 重读；size 变小 → 重读）
- 全量 `cargo test`：2238 通过；4 个失败全部是 `services::model_pricing` 既有 flaky（stash 掉本改动后基线同样失败，与本 PR 无关）
- `cargo clippy -- -D warnings` 通过

## 证据链

- 日志每 60 秒 `[CODEX-SYNC] 导入 0 条, deferred 4 个`（deferred 4 为 07-10 孤儿文件，属正常 pending）
- `rollout-2026-08-01T19-39-08-...jsonl`：7533 行 / 56 MB，DB 同步 offset 停 13 行，文件 mtime 与 DB `last_modified` 纳秒级相等（文件写完后 mtime 未更新）
- 详见 #6023

Fixes #6023
