### PR TITLE
fix(prompts): change Hermes default prompt filename from AGENTS.md to SOUL.md

### DIFF
--- a/src/components/prompts/PromptFormPanel.tsx
+++ b/src/components/prompts/PromptFormPanel.tsx
@@ -32,7 +32,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
     grokbuild: "AGENTS.md",
     opencode: "AGENTS.md",
     openclaw: "AGENTS.md",
-    hermes: "AGENTS.md",
+    hermes: "SOUL.md",
   };
   const filename = filenameMap[appId];
   const [name, setName] = useState("");


### PR DESCRIPTION
## Summary

Fixes #5777: Hermes agent uses `SOUL.md` as its identity file, but the default prompt filename in the app was hardcoded to `AGENTS.md`.

## Changes

- `src/components/prompts/PromptFormPanel.tsx`: `hermes: "AGENTS.md"` → `hermes: "SOUL.md"`

## Test plan

- N/A (single constant value change)
