### PR TITLE
fix(hermes): persist default api_mode for UI-created custom providers

### DIFF
--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -808,6 +808,16 @@ pub fn set_provider(
     let mut normalized = provider_config;
     sanitize_hermes_provider_keys(&mut normalized);
 
+    // Inject default api_mode when missing (e.g. UI custom provider w/o explicit selection).
+    if let Some(obj) = normalized.as_object_mut() {
+        if !obj.contains_key("api_mode") {
+            obj.insert(
+                "api_mode".to_string(),
+                serde_json::Value::String("chat_completions".to_string()),
+            );
+        }
+    }
+
     // Normalize `models` from UI array to Hermes YAML dict before serializing.
     normalize_provider_models_for_write(&mut normalized);
 

--- a/src/components/providers/forms/hooks/useHermesFormState.ts
+++ b/src/components/providers/forms/hooks/useHermesFormState.ts
@@ -22,6 +22,7 @@ const HERMES_DEFAULT_CONFIG_OBJ = {
   name: "",
   base_url: "",
   api_key: "",
+  api_mode: "chat_completions",
 } as const;
 
 export const HERMES_DEFAULT_CONFIG = JSON.stringify(


### PR DESCRIPTION
## Summary

Fixes #4011: when creating a custom Hermes provider via the UI, if the user does not manually touch the API Mode dropdown, the `api_mode` field is missing from the saved config, causing connection tests to fail.

## Changes

1. **Frontend** — `src/components/providers/forms/hooks/useHermesFormState.ts`
   - Added `api_mode: "chat_completions"` to `HERMES_DEFAULT_CONFIG_OBJ`

2. **Backend** — `src-tauri/src/hermes_config.rs`
   - In `set_provider`, after `sanitize_hermes_provider_keys`, inject `api_mode = "chat_completions"` as a fallback when the key is missing

## Test plan

- Create a custom Hermes provider via UI without touching API Mode → saved config contains `api_mode: chat_completions`
- Connection test succeeds
- Existing Hermes providers with explicit `api_mode` are unaffected
