### PR TITLE
fix(claude): align Kimi for Coding presets with real context windows

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -68,14 +68,23 @@ fn provider_env_targets_gpt56(provider_env: Option<&serde_json::Map<String, Valu
     saw_model
 }
 
+/// Kimi For Coding (`https://api.kimi.com/coding`, alias `kimi-for-coding`) and
+/// the Moonshot.cn-hosted Kimi (`https://api.moonshot.cn/anthropic`, alias
+/// `kimi-k2.7-code`) both serve a 256K context window, but Claude Code caps
+/// unknown non-Claude model ids at 200K unless `CLAUDE_CODE_MAX_CONTEXT_TOKENS`
+/// is set — and that env is ignored for `claude-`-prefixed ids. Match the
+/// Anthropic-protocol Kimi endpoints (and their trailing-slash variants) so
+/// both presets get the 256K context declared in their effective settings.
 fn is_kimi_for_coding_provider(provider: &Provider) -> bool {
-    provider
-        .settings_config
-        .pointer("/env/ANTHROPIC_BASE_URL")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .map(|url| url.trim_end_matches('/'))
-        == Some("https://api.kimi.com/coding")
+    matches!(
+        provider
+            .settings_config
+            .pointer("/env/ANTHROPIC_BASE_URL")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .map(|url| url.trim_end_matches('/')),
+        Some("https://api.kimi.com/coding") | Some("https://api.moonshot.cn/anthropic")
+    )
 }
 
 /// Claude Code assigns unknown non-Claude model ids a 200K context window.
@@ -133,11 +142,13 @@ fn apply_codex_oauth_claude_context_defaults(settings: &mut Value, provider: &Pr
     }
 }
 
-/// Kimi For Coding serves a 256K window, but Claude Code caps unknown models at
-/// 200K unless `CLAUDE_CODE_MAX_CONTEXT_TOKENS` is set — and that env is ignored
-/// for `claude-`-prefixed ids, so these defaults only bite when the provider also
-/// routes the endpoint's `kimi-for-coding` alias (the preset does). Keep the
-/// defaults provider-owned so an old shared snippet cannot override them.
+/// Kimi For Coding (`kimi-for-coding`) and the Moonshot.cn-hosted Kimi
+/// (`kimi-k2.7-code`) both serve a 256K context window, but Claude Code caps
+/// unknown models at 200K unless `CLAUDE_CODE_MAX_CONTEXT_TOKENS` is set —
+/// and that env is ignored for `claude-`-prefixed ids, so these defaults only
+/// bite when the provider also routes the endpoint's `kimi-for-coding` /
+/// `kimi-k2.7-code` alias (the presets do). Keep the defaults provider-owned
+/// so an old shared snippet cannot override them.
 fn apply_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provider) {
     if !is_kimi_for_coding_provider(provider) {
         return;

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -30,6 +30,25 @@ use super::normalize_claude_models_in_value;
 const CODEX_OAUTH_CLAUDE_MAX_CONTEXT_TOKENS: &str = "372000";
 const CODEX_OAUTH_CLAUDE_AUTO_COMPACT_WINDOW: &str = "372000";
 const KIMI_FOR_CODING_CONTEXT_TOKENS: &str = "262144";
+/// Kimi K3 (`kimi-k3` on the Moonshot platform, `k3` / `k3-256k` on Kimi Code)
+/// serves a 1M-token context window. Only applied on the Moonshot Anthropic
+/// endpoint where `kimi-k3` is selectable; the Kimi Code endpoint never
+/// serves K3, so it stays at the 256K default.
+const KIMI_K3_CONTEXT_TOKENS: &str = "1048576";
+
+/// Env keys that may carry the routed model id for an Anthropic-protocol Kimi
+/// provider. Mirrors `CODEX_OAUTH_MODEL_ENV_KEYS` — we only need to peek at
+/// `ANTHROPIC_MODEL` for the K3 detection, but multiple slots let a user pick
+/// any of the per-tier overrides (default-haiku/sonnet/opus) without us
+/// missing the model id.
+const KIMI_MODEL_ENV_KEYS: [&str; 6] = [
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+];
 
 /// Model env keys Claude Code may route requests through. The defaults above
 /// are calibrated against gpt-5.6's Codex catalog, so every configured model
@@ -149,6 +168,11 @@ fn apply_codex_oauth_claude_context_defaults(settings: &mut Value, provider: &Pr
 /// bite when the provider also routes the endpoint's `kimi-for-coding` /
 /// `kimi-k2.7-code` alias (the presets do). Keep the defaults provider-owned
 /// so an old shared snippet cannot override them.
+///
+/// The Moonshot endpoint (`api.moonshot.cn/anthropic`) now also serves K3
+/// (`kimi-k3`), a 1M-context model. Pick the default from the routed model
+/// rather than the endpoint alone: a provider that targets `kimi-k3` must
+/// get the 1M default; everything else (including K2.7) keeps 256K.
 fn apply_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provider) {
     if !is_kimi_for_coding_provider(provider) {
         return;
@@ -158,6 +182,7 @@ fn apply_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provi
         .settings_config
         .get("env")
         .and_then(Value::as_object);
+    let default_tokens = kimi_for_coding_default_context_tokens(provider_env);
     let Some(env) = settings.get_mut("env").and_then(Value::as_object_mut) else {
         return;
     };
@@ -169,9 +194,91 @@ fn apply_kimi_for_coding_context_defaults(settings: &mut Value, provider: &Provi
         let value = provider_env
             .and_then(|provider_env| provider_env.get(key))
             .cloned()
-            .unwrap_or_else(|| Value::String(KIMI_FOR_CODING_CONTEXT_TOKENS.to_string()));
+            .unwrap_or_else(|| Value::String(default_tokens.to_string()));
         env.insert(key.to_string(), value);
     }
+}
+
+/// Returns the fallback context window (as a string) for an Anthropic-protocol
+/// Kimi provider whose explicit `CLAUDE_CODE_MAX_CONTEXT_TOKENS` is unset.
+///
+/// - Kimi Code endpoint (`api.kimi.com/coding`) only serves 256K models, so it
+///   always falls back to 262144.
+/// - Moonshot endpoint (`api.moonshot.cn/anthropic`) serves both K2.7 (256K)
+///   and K3 (1M). When every configured model slot points at `kimi-k3` we
+///   fall back to 1048576; otherwise we stay at the K2.7 default.
+/// - If no model slot is set, default to the conservative 262144 — the
+///   provider can override via explicit env on next save.
+fn kimi_for_coding_default_context_tokens(
+    provider_env: Option<&serde_json::Map<String, Value>>,
+) -> &'static str {
+    let Some(env) = provider_env else {
+        return KIMI_FOR_CODING_CONTEXT_TOKENS;
+    };
+    let base_url = env
+        .get("ANTHROPIC_BASE_URL")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .map(|url| url.trim_end_matches('/'));
+    match base_url {
+        // Kimi Code service: never serves K3.
+        Some("https://api.kimi.com/coding") => KIMI_FOR_CODING_CONTEXT_TOKENS,
+        Some("https://api.moonshot.cn/anthropic") => {
+            if provider_env_targets_kimi_k3(Some(env)) {
+                KIMI_K3_CONTEXT_TOKENS
+            } else {
+                KIMI_FOR_CODING_CONTEXT_TOKENS
+            }
+        }
+        // Defensive default for any future endpoint that is_kimi_for_coding_provider
+        // matches — keep the conservative K2.7 window.
+        _ => KIMI_FOR_CODING_CONTEXT_TOKENS,
+    }
+}
+
+/// Returns true when at least one configured Kimi model slot is set AND every
+/// set slot targets `kimi-k3`. Empty slots are ignored so the user can leave
+/// tier-specific defaults unset without us losing the K3 signal.
+fn provider_env_targets_kimi_k3(
+    provider_env: Option<&serde_json::Map<String, Value>>,
+) -> bool {
+    let Some(env) = provider_env else {
+        return false;
+    };
+    let mut saw_model = false;
+    for key in KIMI_MODEL_ENV_KEYS {
+        let Some(value) = env.get(key) else {
+            continue;
+        };
+        let Some(model) = value.as_str() else {
+            return false;
+        };
+        let model = model.trim();
+        if model.is_empty() {
+            continue;
+        }
+        saw_model = true;
+        if !is_kimi_k3_model(model) {
+            return false;
+        }
+    }
+    saw_model
+}
+
+/// K3 model id matching — covers the Moonshot platform alias (`kimi-k3`),
+/// the Kimi Code service alias (`k3`), the cost-saving K3 256K tier
+/// (`k3-256k`), and the high-speed variant (`kimi-for-coding-highspeed`
+/// shares the K3 family prefix but stays at 256K — see below). Match is
+/// case-insensitive on the leading token, and the K3 256K / HighSpeed
+/// variants are explicitly excluded so we keep the 256K default for them.
+fn is_kimi_k3_model(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    let token = lower.split_whitespace().next().unwrap_or("");
+    // `k3-256k` keeps the 256K window — do not classify as full K3.
+    if token == "k3-256k" || token.starts_with("k3-256k") {
+        return false;
+    }
+    token == "kimi-k3" || token == "k3"
 }
 
 pub(crate) fn sanitize_claude_settings_for_live(settings: &Value) -> Value {
@@ -2625,5 +2732,126 @@ base_url = "https://a.example/v1"
 
         assert!(!config_text.contains("mcp_servers"));
         assert!(config_text.contains("model = \"grok-4.5\""));
+    }
+
+    // Codex P2 feedback on #6038: the Moonshot endpoint serves both K2.7
+    // (256K) and K3 (1M). Without an explicit `CLAUDE_CODE_MAX_CONTEXT_TOKENS`,
+    // the endpoint-only fallback was forcing every Moonshot provider to
+    // 262144 even when the user picked `kimi-k3`. With the model-aware
+    // default, an existing Moonshot provider whose `ANTHROPIC_MODEL`
+    // targets `kimi-k3` must now pick up the 1M window.
+    #[test]
+    fn moonshot_kimi_k3_provider_default_context_is_1m() {
+        let db = Database::memory().expect("create memory db");
+        let provider = Provider::with_id(
+            "moonshot-k3".to_string(),
+            "Moonshot K3".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.moonshot.cn/anthropic",
+                    "ANTHROPIC_MODEL": "kimi-k3"
+                }
+            }),
+            None,
+        );
+
+        let effective =
+            build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+                .expect("build effective settings");
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_MAX_CONTEXT_TOKENS"],
+            json!("1048576")
+        );
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"],
+            json!("1048576")
+        );
+    }
+
+    // Companion: a Moonshot provider whose model still points at K2.7 keeps
+    // the legacy 262144 default — the model-aware branch must not regress
+    // the K2.7 path.
+    #[test]
+    fn moonshot_kimi_k2_7_provider_default_context_is_256k() {
+        let db = Database::memory().expect("create memory db");
+        let provider = Provider::with_id(
+            "moonshot-k27".to_string(),
+            "Moonshot K2.7".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.moonshot.cn/anthropic",
+                    "ANTHROPIC_MODEL": "kimi-k2-0711-preview"
+                }
+            }),
+            None,
+        );
+
+        let effective =
+            build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+                .expect("build effective settings");
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_MAX_CONTEXT_TOKENS"],
+            json!("262144")
+        );
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"],
+            json!("262144")
+        );
+    }
+
+    // A Moonshot provider that has not set a model slot at all stays on the
+    // conservative K2.7 default — the user can still override via the explicit
+    // env keys and the new behaviour must not surprise them with a 1M window
+    // they never asked for.
+    #[test]
+    fn moonshot_provider_without_model_falls_back_to_256k() {
+        let db = Database::memory().expect("create memory db");
+        let provider = Provider::with_id(
+            "moonshot-bare".to_string(),
+            "Moonshot".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.moonshot.cn/anthropic"
+                }
+            }),
+            None,
+        );
+
+        let effective =
+            build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+                .expect("build effective settings");
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_MAX_CONTEXT_TOKENS"],
+            json!("262144")
+        );
+    }
+
+    // Tier-specific model slot: when only `ANTHROPIC_DEFAULT_HAIKU_MODEL`
+    // (not `ANTHROPIC_MODEL`) targets `kimi-k3`, the detection must still
+    // classify the provider as K3 and inject the 1M default. Without
+    // `ANTHROPIC_MODEL` set, the user's choice of tier-default signals the
+    // intended model family.
+    #[test]
+    fn moonshot_provider_with_only_tier_model_targeting_k3_picks_1m() {
+        let db = Database::memory().expect("create memory db");
+        let provider = Provider::with_id(
+            "moonshot-tier-k3".to_string(),
+            "Moonshot tier K3".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://api.moonshot.cn/anthropic",
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "kimi-k3"
+                }
+            }),
+            None,
+        );
+
+        let effective =
+            build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+                .expect("build effective settings");
+        assert_eq!(
+            effective["env"]["CLAUDE_CODE_MAX_CONTEXT_TOKENS"],
+            json!("1048576")
+        );
     }
 }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -239,9 +239,7 @@ fn kimi_for_coding_default_context_tokens(
 /// Returns true when at least one configured Kimi model slot is set AND every
 /// set slot targets `kimi-k3`. Empty slots are ignored so the user can leave
 /// tier-specific defaults unset without us losing the K3 signal.
-fn provider_env_targets_kimi_k3(
-    provider_env: Option<&serde_json::Map<String, Value>>,
-) -> bool {
+fn provider_env_targets_kimi_k3(provider_env: Option<&serde_json::Map<String, Value>>) -> bool {
     let Some(env) = provider_env else {
         return false;
     };

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -99,10 +99,48 @@ export const providerPresets: ProviderPreset[] = [
       env: {
         ANTHROPIC_BASE_URL: "https://api.moonshot.cn/anthropic",
         ANTHROPIC_AUTH_TOKEN: "",
+        // 必须显式路由端点别名 kimi-k2.7-code（与 Kimi For Coding / codex / hermes / opencode 预设一致）
+        // ——CLAUDE_CODE_MAX_CONTEXT_TOKENS 只对非 claude- 前缀模型 id 生效
         ANTHROPIC_MODEL: "kimi-k2.7-code",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "kimi-k2.7-code",
         ANTHROPIC_DEFAULT_SONNET_MODEL: "kimi-k2.7-code",
         ANTHROPIC_DEFAULT_OPUS_MODEL: "kimi-k2.7-code",
+        // 双键钉 256K：Claude Code 把未知 model id 兜底成 200K，钉住实际窗口
+        // 才能让状态栏和压缩点对齐到 kimi-k2.7-code 的真实 256K 上限。
+        // 压缩窗口=min(模型窗口,值)，与窗口同值时行为等价于不设，但显式钉住
+        // 可屏蔽远程实验下发的更小压缩点；调整直接改 JSON，不出表单字段。
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
+      },
+    },
+    category: "cn_official",
+    icon: "kimi",
+    iconColor: "#6366F1",
+  },
+  {
+    name: "Kimi K3 (Moonshot)",
+    primePartner: true,
+    websiteUrl: "https://platform.kimi.com?aff=cc-switch",
+    settingsConfig: {
+      env: {
+        // Moonshot 官方 Anthropic 协议端点（kimi-k3 id），跟 Kimi Code 服务
+        // （api.kimi.com/coding/ + id `k3`）是两套不同的 id/endpoint/API key。
+        // 同时保留两个预设是为了覆盖两种订阅渠道，避免互相覆盖。
+        ANTHROPIC_BASE_URL: "https://api.moonshot.cn/anthropic",
+        ANTHROPIC_AUTH_TOKEN: "",
+        // 必须显式路由端点别名 kimi-k3（与 codex / hermes / opencode / openclaw 预设一致）
+        // ——CLAUDE_CODE_MAX_CONTEXT_TOKENS 只对非 claude- 前缀模型 id 生效
+        ANTHROPIC_MODEL: "kimi-k3",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "kimi-k3",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "kimi-k3",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "kimi-k3",
+        // 双键钉 1M：kimi-k3 实际窗口 1,048,576 (2^20)，显式覆盖 262144 默认值
+        // 才能让状态栏和压缩点对齐到 1M 上限（K2.7 的 262144 默认是为
+        // kimi-k2.7-code / kimi-for-coding 设的，对 K3 不够大）。
+        // 压缩窗口=min(模型窗口,值)，与窗口同值时行为等价于不设，但显式钉住
+        // 可屏蔽远程实验下发的更小压缩点；调整直接改 JSON，不出表单字段。
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "1048576",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1048576",
       },
     },
     category: "cn_official",
@@ -126,6 +164,89 @@ export const providerPresets: ProviderPreset[] = [
         ANTHROPIC_DEFAULT_OPUS_MODEL: "kimi-for-coding",
         // 双键钉 256K：压缩窗口=min(模型窗口,值)，与窗口同值时行为等价于不设，
         // 但显式钉住可屏蔽远程实验下发的更小压缩点；调整直接改 JSON，不出表单字段
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
+      },
+    },
+    category: "cn_official",
+    icon: "kimi",
+    iconColor: "#6366F1",
+  },
+  {
+    name: "Kimi K3",
+    primePartner: true,
+    websiteUrl: "https://www.kimi.com/code/?aff=cc-switch",
+    settingsConfig: {
+      env: {
+        // Kimi Code 服务（Kimi For Coding 订阅渠道），id 来自
+        // https://www.kimi.com/code/docs/kimi-code/models
+        ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+        ANTHROPIC_AUTH_TOKEN: "",
+        // 必须显式路由端点别名 k3（与 codex/hermes/opencode/openclaw 的
+        // kimi-k3 不同，这是 Kimi Code 服务侧的 id，配套 endpoint 也是
+        // api.kimi.com/coding/，不是 api.moonshot.cn/anthropic）
+        // ——CLAUDE_CODE_MAX_CONTEXT_TOKENS 只对非 claude- 前缀模型 id 生效
+        ANTHROPIC_MODEL: "k3",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "k3",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "k3",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "k3",
+        // 双键钉 1M：k3 标准窗口 1,048,576（2^20），1M context 需 Allegretto+
+        // 订阅档；如订阅档位不够，K3 实际会被服务端裁到 256K，建议改用下面的
+        // "Kimi K3 256K" 预设。压缩窗口=min(模型窗口,值)，与窗口同值时
+        // 行为等价于不设，但显式钉住可屏蔽远程实验下发的更小压缩点；
+        // 调整直接改 JSON，不出表单字段。
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "1048576",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1048576",
+      },
+    },
+    category: "cn_official",
+    icon: "kimi",
+    iconColor: "#6366F1",
+  },
+  {
+    name: "Kimi K3 256K",
+    primePartner: true,
+    websiteUrl: "https://www.kimi.com/code/?aff=cc-switch",
+    settingsConfig: {
+      env: {
+        // Kimi Code 服务（Kimi For Coding 订阅渠道），id 来自
+        // https://www.kimi.com/code/docs/kimi-code/models
+        ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+        ANTHROPIC_AUTH_TOKEN: "",
+        // k3-256k 是 k3 的 256K 固定窗口变种，256K 之内质量与 k3 一致，
+        // 但 token 消耗约为 k3 (1M) 的一半——性价比更高，订阅档位要求更宽
+        ANTHROPIC_MODEL: "k3-256k",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "k3-256k",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "k3-256k",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "k3-256k",
+        // 双键钉 256K：参考 Kimi For Coding 入口的同值说明。
+        // 显式 262144 覆盖 backend 默认的 262144（与窗口同值时可作不设，
+        // 但显式钉住可屏蔽远程实验下发的更小压缩点）
+        CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
+      },
+    },
+    category: "cn_official",
+    icon: "kimi",
+    iconColor: "#6366F1",
+  },
+  {
+    name: "Kimi For Coding HighSpeed",
+    primePartner: true,
+    websiteUrl: "https://www.kimi.com/code/?aff=cc-switch",
+    settingsConfig: {
+      env: {
+        // Kimi Code 服务（Kimi For Coding 订阅渠道），id 来自
+        // https://www.kimi.com/code/docs/kimi-code/models
+        ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+        ANTHROPIC_AUTH_TOKEN: "",
+        // kimi-for-coding-highspeed 是 kimi-for-coding 的高速版，~5–6×
+        // 输出速度，~3× token 消耗，需 Allegretto+ 订阅档
+        ANTHROPIC_MODEL: "kimi-for-coding-highspeed",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "kimi-for-coding-highspeed",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "kimi-for-coding-highspeed",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "kimi-for-coding-highspeed",
+        // 双键钉 256K：参考 Kimi For Coding 入口的同值说明
         CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
         CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
       },


### PR DESCRIPTION
Fixes #5796

## Summary
Claude Code caps unknown non-Claude model ids at 200K, so Kimi's Anthropic-protocol presets display the wrong context unless each preset declares `CLAUDE_CODE_MAX_CONTEXT_TOKENS` / `CLAUDE_CODE_AUTO_COMPACT_WINDOW` explicitly. This brings every Kimi Claude Code preset in line with its actual window.

## Presets touched (src/config/claudeProviderPresets.ts)

| Preset | Endpoint | Model id | Context | Notes |
|---|---|---|---|---|
| `Kimi` *(modified)* | `api.moonshot.cn/anthropic` | `kimi-k2.7-code` | 256K | was missing — now pins 262144; fixes the 200K status bar |
| `Kimi K3 (Moonshot)` *(new)* | `api.moonshot.cn/anthropic` | `kimi-k3` | 1M | Moonshot-platform K3 |
| `Kimi For Coding` *(unchanged)* | `api.kimi.com/coding/` | `kimi-for-coding` | 256K | was already pinned |
| `Kimi K3` *(new)* | `api.kimi.com/coding/` | `k3` | 1M | Kimi Code service K3; distinct from `kimi-k3` (different endpoint + API key) |
| `Kimi K3 256K` *(new)* | `api.kimi.com/coding/` | `k3-256k` | 256K | half token cost of `k3`, broader tier availability |
| `Kimi For Coding HighSpeed` *(new)* | `api.kimi.com/coding/` | `kimi-for-coding-highspeed` | 256K | ~5–6× faster output, ~3× token cost |

The two `Kimi K3` presets cover different subscription channels (Moonshot platform vs Kimi Code service) — model ids and API keys are not interchangeable.

## Live settings pipeline (src-tauri/src/services/provider/live.rs)

- `is_kimi_for_coding_provider()` now matches both `api.kimi.com/coding` and `api.moonshot.cn/anthropic`, so `apply_kimi_for_coding_context_defaults` fires for all six Kimi presets.
- 1M presets (K3) override the 262144 default by writing an explicit env value in `settingsConfig` — the existing "explicit user values always win" branch handles this without further changes.

## Relation to #5836

#5836 is a broader design ask: derive the Kimi live default from the provider's model at runtime, plus fix an editor round-trip bug where backend-injected context defaults get persisted into the stored provider config. This PR is a **partial** fix for #5836 — it adds the K3 1M preset and routes the explicit-value path so the `k3` / `kimi-k3` presets get 1M. The dynamic-derivation redesign and the EditProviderDialog persistence fix are out of scope here and should land separately.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `cargo check` passes
- [x] `vitest run` — 86 files / 582 tests pass

## Source
Model IDs and context windows: https://www.kimi.com/code/docs/kimi-code/models