### PR TITLE
fix(usage): keep dashboard refresh active when unfocused

### DIFF
--- a/src/lib/query/usage.ts
+++ b/src/lib/query/usage.ts
@@ -14,6 +14,19 @@ type UsageQueryOptions = {
   refetchIntervalInBackground?: boolean;
 };
 
+function getUsagePollingOptions(options?: UsageQueryOptions) {
+  const refetchInterval =
+    options?.refetchInterval ?? DEFAULT_REFETCH_INTERVAL_MS;
+
+  return {
+    refetchInterval,
+    // The dashboard is commonly left open while the user works in a CLI.
+    // Keep its opt-in polling alive after the window loses focus.
+    refetchIntervalInBackground:
+      options?.refetchIntervalInBackground ?? Boolean(refetchInterval),
+  };
+}
+
 type RequestLogsQueryArgs = {
   filters: LogFilters;
   range: UsageRangeSelection;
@@ -183,8 +196,7 @@ export function useUsageSummary(
         effective.model,
       );
     },
-    refetchInterval: options?.refetchInterval ?? DEFAULT_REFETCH_INTERVAL_MS,
-    refetchIntervalInBackground: options?.refetchIntervalInBackground ?? false,
+    ...getUsagePollingOptions(options),
   });
 }
 
@@ -210,8 +222,7 @@ export function useUsageSummaryByApp(
         filters?.model,
       );
     },
-    refetchInterval: options?.refetchInterval ?? DEFAULT_REFETCH_INTERVAL_MS,
-    refetchIntervalInBackground: options?.refetchIntervalInBackground ?? false,
+    ...getUsagePollingOptions(options),
   });
 }
 
@@ -239,8 +250,7 @@ export function useUsageTrends(
         effective.model,
       );
     },
-    refetchInterval: options?.refetchInterval ?? DEFAULT_REFETCH_INTERVAL_MS,
-    refetchIntervalInBackground: options?.refetchIntervalInBackground ?? false,
+    ...getUsagePollingOptions(options),
   });
 }
 
@@ -268,8 +278,7 @@ export function useProviderStats(
         effective.model,
       );
     },
-    refetchInterval: options?.refetchInterval ?? DEFAULT_REFETCH_INTERVAL_MS,
-    refetchIntervalInBackground: options?.refetchIntervalInBackground ?? false,
+    ...getUsagePollingOptions(options),
   });
 }
 
@@ -297,8 +306,7 @@ export function useModelStats(
         effective.model,
       );
     },
-    refetchInterval: options?.refetchInterval ?? DEFAULT_REFETCH_INTERVAL_MS,
-    refetchIntervalInBackground: options?.refetchIntervalInBackground ?? false,
+    ...getUsagePollingOptions(options),
   });
 }
 
@@ -326,8 +334,7 @@ export function useRequestLogs({
       const effectiveFilters = { ...filters, ...resolveUsageRange(range) };
       return usageApi.getRequestLogs(effectiveFilters, page, pageSize);
     },
-    refetchInterval: options?.refetchInterval ?? DEFAULT_REFETCH_INTERVAL_MS, // 每30秒自动刷新
-    refetchIntervalInBackground: options?.refetchIntervalInBackground ?? false,
+    ...getUsagePollingOptions(options),
   });
 }
 

--- a/tests/hooks/useUsageQueries.test.tsx
+++ b/tests/hooks/useUsageQueries.test.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useUsageSummary, usageKeys } from "@/lib/query/usage";
+
+const invokeMock = vi.fn().mockResolvedValue({});
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { queryClient, wrapper };
+}
+
+function getPollingOptions(queryClient: QueryClient) {
+  const query = queryClient.getQueryCache().find({
+    queryKey: usageKeys.summary(
+      "today",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ),
+  });
+
+  return query?.options as
+    | {
+        refetchInterval?: number | false;
+        refetchIntervalInBackground?: boolean;
+      }
+    | undefined;
+}
+
+describe("usage query polling", () => {
+  afterEach(() => {
+    invokeMock.mockClear();
+  });
+
+  // Regression coverage for issue #5996: the dashboard is often left behind
+  // the CLI window, so its configured polling must continue after blur.
+  it("keeps automatic refresh active while the app is in the background", () => {
+    const { queryClient, wrapper } = createWrapper();
+
+    renderHook(
+      () =>
+        useUsageSummary({ preset: "today" }, undefined, {
+          refetchInterval: 5_000,
+        }),
+      { wrapper },
+    );
+
+    const options = getPollingOptions(queryClient);
+
+    expect(options?.refetchInterval).toBe(5_000);
+    expect(options?.refetchIntervalInBackground).toBe(true);
+  });
+
+  it("does not enable background polling when automatic refresh is off", () => {
+    const { queryClient, wrapper } = createWrapper();
+
+    renderHook(
+      () =>
+        useUsageSummary({ preset: "today" }, undefined, {
+          refetchInterval: false,
+        }),
+      { wrapper },
+    );
+
+    const options = getPollingOptions(queryClient);
+
+    expect(options?.refetchInterval).toBe(false);
+    expect(options?.refetchIntervalInBackground).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Keep the Usage Dashboard's configured auto-refresh active when CC Switch loses focus. This matches the common workflow of leaving the dashboard open while working in a CLI.

The polling behavior is centralized for all usage queries. Turning auto-refresh off still disables foreground and background polling.

## Related Issue / 关联 Issue

Fixes #5996

## Screenshots / 截图

Not applicable. This changes query polling behavior without changing the UI.

## Verification / 验证

- Focused regression tests cover both enabled and disabled auto-refresh behavior.
- `pnpm test:unit`: 87 files, 584 tests passed.
- `pnpm build:renderer` passed.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码） — not applicable; no Rust code changed
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — not applicable; no user-facing text changed
