### PR TITLE
fix(claude): exclude workflow journal.jsonl from session list

### DIFF
--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -255,7 +255,7 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
 fn is_agent_session(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .map(|name| name.starts_with("agent-"))
+        .map(|name| name.starts_with("agent-") || name == "journal.jsonl")
         .unwrap_or(false)
 }
 
@@ -496,5 +496,27 @@ mod tests {
 
         let meta = parse_session(&path).unwrap();
         assert_eq!(meta.title.as_deref(), Some("帮我看看工作区的改动"));
+    }
+
+    #[test]
+    fn workflow_journal_log_is_excluded_from_sessions() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("journal.jsonl");
+        std::fs::write(
+            &path,
+            "{\"type\":\"started\",\"key\":\"k\",\"agentId\":\"a\"}\n",
+        )
+        .expect("write");
+
+        assert!(is_agent_session(&path));
+    }
+
+    #[test]
+    fn agent_session_files_are_still_excluded() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("agent-abc123.jsonl");
+        std::fs::write(&path, "{\"type\":\"user\",\"isSidechain\":true}\n").expect("write");
+
+        assert!(is_agent_session(&path));
     }
 }

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -519,4 +519,19 @@ mod tests {
 
         assert!(is_agent_session(&path));
     }
+
+    #[test]
+    fn real_session_file_is_not_excluded() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp
+            .path()
+            .join("8f8e7c8e-0000-0000-0000-000000000000.jsonl");
+        std::fs::write(
+            &path,
+            "{\"sessionId\":\"8f8e7c8e-0000-0000-0000-000000000000\"}\n",
+        )
+        .expect("write");
+
+        assert!(!is_agent_session(&path));
+    }
 }


### PR DESCRIPTION
---
## Summary / 概述

修复 Claude Code 会话列表中错误显示 Workflow 运行日志（`journal.jsonl`）为会话的问题。

Claude Code 的 Workflow（多代理编排）功能会在会话目录下生成运行日志 `subagents/workflows/wf_*/journal.jsonl`，其内容格式为 `{"type":"started"/"result", "key":..., "agentId":...}`，不含 `sessionId`/`timestamp`/`message` 等任何会话字段。

CC Switch 的 Claude 会话扫描（`collect_jsonl_files()`）会递归遍历 `~/.claude/projects/` 下所有 `*.jsonl`，目前仅通过 `is_agent_session()` 排除以 `agent-` 开头的文件，`journal.jsonl` 不在排除名单内。于是它被 `parse_session()` 解析为会话：标题回退为文件名（"journal"）、时间未知、内容为空，以幽灵会话的形式污染会话管理列表。每次运行 Workflow 都会产生一个新的幽灵记录。

**改动**（`src-tauri/src/session_manager/providers/claude.rs`）：

在 `is_agent_session()` 中补充对 `journal.jsonl` 的排除：

```rust
fn is_agent_session(path: &Path) -> bool {
    path.file_name()
        .and_then(|name| name.to_str())
        .map(|name| name.starts_with("agent-") || name == "journal.jsonl")
        .unwrap_or(false)
}
```

`journal.jsonl` 仅出现在 `subagents/workflows/wf_*/` 目录下，按文件名排除即可覆盖全部场景，且不影响用量统计（该统计独立于会话列表扫描）。

## Related Issue / 关联 Issue

Fixes #6042

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 会话列表出现 "journal" 幽灵会话（时间未知、内容为空） | 会话列表仅显示真实会话 |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
