### PR TITLE
fix: extend max_completion_tokens handling to gpt-5+ models

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -54,11 +54,21 @@ pub(crate) fn strip_leading_anthropic_billing_header(text: &str) -> &str {
 }
 
 /// Detect OpenAI o-series reasoning models (o1, o3, o4-mini, etc.)
-/// These models require `max_completion_tokens` instead of `max_tokens`.
 pub fn is_openai_o_series(model: &str) -> bool {
     model.len() > 1
         && model.starts_with('o')
         && model.as_bytes().get(1).is_some_and(|b| b.is_ascii_digit())
+}
+
+/// Detect models that require `max_completion_tokens` instead of `max_tokens`.
+/// Covers o-series (o1, o3, o4-mini) and gpt-5+ (gpt-5, gpt-5.1, gpt-5-mini, etc.)
+pub fn requires_max_completion_tokens(model: &str) -> bool {
+    let normalized = model.to_lowercase();
+    is_openai_o_series(&normalized)
+        || normalized
+            .strip_prefix("gpt-")
+            .and_then(|rest| rest.chars().next())
+            .is_some_and(|c| c.is_ascii_digit() && c >= '5')
 }
 
 /// Detect Responses-compatible models that support reasoning effort.
@@ -70,11 +80,7 @@ pub fn is_openai_o_series(model: &str) -> bool {
 ///   model; retain the previous `grok-build-*` family for saved providers.
 pub fn supports_reasoning_effort(model: &str) -> bool {
     let normalized = model.to_lowercase();
-    is_openai_o_series(&normalized)
-        || normalized
-            .strip_prefix("gpt-")
-            .and_then(|rest| rest.chars().next())
-            .is_some_and(|c| c.is_ascii_digit() && c >= '5')
+    requires_max_completion_tokens(&normalized)
         || normalized == "grok-4.5"
         || normalized.starts_with("grok-4.5-")
         || normalized.starts_with("grok-build-")
@@ -183,10 +189,10 @@ pub fn anthropic_to_openai_with_reasoning_content(
     normalize_openai_system_messages(&mut messages);
     result["messages"] = json!(messages);
 
-    // 转换参数 — o-series 模型需要 max_completion_tokens
+    // 转换参数 — o-series 和 gpt-5+ 需要 max_completion_tokens
     let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
     if let Some(v) = body.get("max_tokens") {
-        if is_openai_o_series(model) {
+        if requires_max_completion_tokens(model) {
             result["max_completion_tokens"] = v.clone();
         } else {
             result["max_tokens"] = v.clone();
@@ -1739,6 +1745,23 @@ mod tests {
         assert!(!is_openai_o_series("openai-gpt"));
         assert!(!is_openai_o_series("o"));
         assert!(!is_openai_o_series(""));
+    }
+
+    #[test]
+    fn test_requires_max_completion_tokens() {
+        // o-series
+        assert!(requires_max_completion_tokens("o1"));
+        assert!(requires_max_completion_tokens("o3-mini"));
+        assert!(requires_max_completion_tokens("o4-mini"));
+        // gpt-5+
+        assert!(requires_max_completion_tokens("gpt-5"));
+        assert!(requires_max_completion_tokens("gpt-5.4"));
+        assert!(requires_max_completion_tokens("gpt-5-mini"));
+        assert!(requires_max_completion_tokens("gpt-5-codex"));
+        // not affected
+        assert!(!requires_max_completion_tokens("gpt-4o"));
+        assert!(!requires_max_completion_tokens("gpt-4-turbo"));
+        assert!(!requires_max_completion_tokens("claude-sonnet-4-6"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -1786,7 +1786,10 @@ mod tests {
         assert_eq!(known_max_output_tokens("gpt-4o"), Some(16_384));
         assert_eq!(known_max_output_tokens("gpt-4o-mini"), Some(16_384));
         assert_eq!(known_max_output_tokens("eastus-gpt-4o-01"), Some(16_384));
-        assert_eq!(known_max_output_tokens("swedencentral-gpt-4o"), Some(16_384));
+        assert_eq!(
+            known_max_output_tokens("swedencentral-gpt-4o"),
+            Some(16_384)
+        );
         // classic gpt-4
         assert_eq!(known_max_output_tokens("gpt-4-turbo"), Some(4_096));
         assert_eq!(known_max_output_tokens("gpt-4-0613"), Some(4_096));
@@ -1801,7 +1804,10 @@ mod tests {
     fn test_clamp_max_tokens() {
         // clamps when over the limit
         assert_eq!(clamp_max_tokens("gpt-4o", &json!(32000)), json!(16_384));
-        assert_eq!(clamp_max_tokens("eastus-gpt-4o-01", &json!(32000)), json!(16_384));
+        assert_eq!(
+            clamp_max_tokens("eastus-gpt-4o-01", &json!(32000)),
+            json!(16_384)
+        );
         // passes through when within limit
         assert_eq!(clamp_max_tokens("gpt-4o", &json!(1024)), json!(1024));
         // passes through for unknown models

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -60,6 +60,38 @@ pub fn is_openai_o_series(model: &str) -> bool {
         && model.as_bytes().get(1).is_some_and(|b| b.is_ascii_digit())
 }
 
+/// Known maximum output token limits for model families whose cap is below what
+/// Claude Code typically requests (32 000). Azure deployments often carry a
+/// regional prefix (e.g. "eastus-gpt-4o-01"), so matching uses `contains`.
+///
+/// Returns `None` for models with higher or unknown limits — those pass through
+/// unchanged.
+pub fn known_max_output_tokens(model: &str) -> Option<i64> {
+    let m = model.to_lowercase();
+    if m.contains("gpt-4o") || m.contains("gpt4o") {
+        Some(16_384) // gpt-4o family: 16 384 output tokens
+    } else if m.contains("gpt-4-turbo")
+        || (m.contains("gpt-4-") && !m.contains("gpt-4o") && !m.contains("gpt-4."))
+    {
+        Some(4_096) // classic gpt-4 and gpt-4-turbo: 4 096 output tokens
+    } else if m.contains("gpt-3.5") {
+        Some(4_096)
+    } else {
+        None
+    }
+}
+
+/// Clamp a JSON token value to a model's known output-token cap.
+/// Returns the original value when no cap is known or the value is already within bounds.
+pub fn clamp_max_tokens(model: &str, v: &serde_json::Value) -> serde_json::Value {
+    if let (Some(cap), Some(n)) = (known_max_output_tokens(model), v.as_i64()) {
+        if n > cap {
+            return json!(cap);
+        }
+    }
+    v.clone()
+}
+
 /// Detect models that require `max_completion_tokens` instead of `max_tokens`.
 /// Covers o-series (o1, o3, o4-mini) and gpt-5+ (gpt-5, gpt-5.1, gpt-5-mini, etc.)
 pub fn requires_max_completion_tokens(model: &str) -> bool {
@@ -189,13 +221,14 @@ pub fn anthropic_to_openai_with_reasoning_content(
     normalize_openai_system_messages(&mut messages);
     result["messages"] = json!(messages);
 
-    // 转换参数 — o-series 和 gpt-5+ 需要 max_completion_tokens
+    // 转换参数 — o-series 和 gpt-5+ 需要 max_completion_tokens；同时 clamp 到模型上限
     let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
     if let Some(v) = body.get("max_tokens") {
+        let clamped = clamp_max_tokens(model, v);
         if requires_max_completion_tokens(model) {
-            result["max_completion_tokens"] = v.clone();
+            result["max_completion_tokens"] = clamped;
         } else {
-            result["max_tokens"] = v.clone();
+            result["max_tokens"] = clamped;
         }
     }
     if let Some(v) = body.get("temperature") {
@@ -1745,6 +1778,36 @@ mod tests {
         assert!(!is_openai_o_series("openai-gpt"));
         assert!(!is_openai_o_series("o"));
         assert!(!is_openai_o_series(""));
+    }
+
+    #[test]
+    fn test_known_max_output_tokens() {
+        // gpt-4o family (including Azure regional deployments)
+        assert_eq!(known_max_output_tokens("gpt-4o"), Some(16_384));
+        assert_eq!(known_max_output_tokens("gpt-4o-mini"), Some(16_384));
+        assert_eq!(known_max_output_tokens("eastus-gpt-4o-01"), Some(16_384));
+        assert_eq!(known_max_output_tokens("swedencentral-gpt-4o"), Some(16_384));
+        // classic gpt-4
+        assert_eq!(known_max_output_tokens("gpt-4-turbo"), Some(4_096));
+        assert_eq!(known_max_output_tokens("gpt-4-0613"), Some(4_096));
+        // gpt-3.5
+        assert_eq!(known_max_output_tokens("gpt-3.5-turbo"), Some(4_096));
+        // no cap for gpt-5+ or unknown models
+        assert_eq!(known_max_output_tokens("gpt-5"), None);
+        assert_eq!(known_max_output_tokens("claude-sonnet-4-6"), None);
+    }
+
+    #[test]
+    fn test_clamp_max_tokens() {
+        // clamps when over the limit
+        assert_eq!(clamp_max_tokens("gpt-4o", &json!(32000)), json!(16_384));
+        assert_eq!(clamp_max_tokens("eastus-gpt-4o-01", &json!(32000)), json!(16_384));
+        // passes through when within limit
+        assert_eq!(clamp_max_tokens("gpt-4o", &json!(1024)), json!(1024));
+        // passes through for unknown models
+        assert_eq!(clamp_max_tokens("gpt-5", &json!(32000)), json!(32000));
+        // passes through non-integer values
+        assert_eq!(clamp_max_tokens("gpt-4o", &json!(null)), json!(null));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -291,7 +291,7 @@ pub fn responses_to_chat_completions_with_reasoning(
 
     let model = body.get("model").and_then(|v| v.as_str()).unwrap_or("");
     if let Some(max_tokens) = body.get("max_output_tokens") {
-        if super::transform::is_openai_o_series(model) {
+        if super::transform::requires_max_completion_tokens(model) {
             result["max_completion_tokens"] = max_tokens.clone();
         } else {
             result["max_tokens"] = max_tokens.clone();

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -291,14 +291,15 @@ pub fn responses_to_chat_completions_with_reasoning(
 
     let model = body.get("model").and_then(|v| v.as_str()).unwrap_or("");
     if let Some(max_tokens) = body.get("max_output_tokens") {
+        let clamped = super::transform::clamp_max_tokens(model, max_tokens);
         if super::transform::requires_max_completion_tokens(model) {
-            result["max_completion_tokens"] = max_tokens.clone();
+            result["max_completion_tokens"] = clamped;
         } else {
-            result["max_tokens"] = max_tokens.clone();
+            result["max_tokens"] = clamped;
         }
     }
     if let Some(max_tokens) = body.get("max_tokens") {
-        result["max_tokens"] = max_tokens.clone();
+        result["max_tokens"] = super::transform::clamp_max_tokens(model, max_tokens);
     }
     if let Some(max_tokens) = body.get("max_completion_tokens") {
         result["max_completion_tokens"] = max_tokens.clone();

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -332,7 +332,11 @@ pub fn anthropic_to_responses(
     if let Some(v) = body.get("max_tokens") {
         let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
         let clamped = super::transform::clamp_max_tokens(model, v);
-        let clamped = clamped.as_i64().map(|n| n.max(16)).map(|n| json!(n)).unwrap_or(clamped);
+        let clamped = clamped
+            .as_i64()
+            .map(|n| n.max(16))
+            .map(|n| json!(n))
+            .unwrap_or(clamped);
         result["max_output_tokens"] = clamped;
     }
 

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -328,9 +328,11 @@ pub fn anthropic_to_responses(
     }
 
     // max_tokens → max_output_tokens (Responses API uses max_output_tokens for all models)
-    // Clamp to >= 16: Claude Code may send 1 as a probe value, which OpenAI rejects.
+    // Clamp: >= 16 (OpenAI minimum) and <= model's known output-token cap.
     if let Some(v) = body.get("max_tokens") {
-        let clamped = v.as_i64().map(|n| n.max(16)).map(|n| json!(n)).unwrap_or_else(|| v.clone());
+        let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
+        let clamped = super::transform::clamp_max_tokens(model, v);
+        let clamped = clamped.as_i64().map(|n| n.max(16)).map(|n| json!(n)).unwrap_or(clamped);
         result["max_output_tokens"] = clamped;
     }
 

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -328,8 +328,10 @@ pub fn anthropic_to_responses(
     }
 
     // max_tokens → max_output_tokens (Responses API uses max_output_tokens for all models)
+    // Clamp to >= 16: Claude Code may send 1 as a probe value, which OpenAI rejects.
     if let Some(v) = body.get("max_tokens") {
-        result["max_output_tokens"] = v.clone();
+        let clamped = v.as_i64().map(|n| n.max(16)).map(|n| json!(n)).unwrap_or_else(|| v.clone());
+        result["max_output_tokens"] = clamped;
     }
 
     // 直接透传的参数
@@ -989,6 +991,27 @@ mod tests {
         assert_eq!(result["input"][0]["content"][0]["text"], "Hello");
         // stop_sequences should not appear
         assert!(result.get("stop_sequences").is_none());
+    }
+
+    #[test]
+    fn test_max_output_tokens_clamped_to_minimum() {
+        // Claude Code sends max_tokens=1 as a probe; OpenAI requires >= 16.
+        let input = json!({
+            "model": "gpt-4o",
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["max_output_tokens"], 16);
+
+        // Normal values pass through unchanged.
+        let input2 = json!({
+            "model": "gpt-4o",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let result2 = anthropic_to_responses(input2, None, false, false).unwrap();
+        assert_eq!(result2["max_output_tokens"], 1024);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Three bugs when using GPT models via cc-switch:

**1. openai_chat protocol** - gpt-5 and newer models reject `max_tokens` (reported in #5215):
> 400 Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.

**2. openai_responses protocol** - OpenAI rejects `max_output_tokens=1` (reported in #5215):
> Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 1 instead.

**3. All protocols** - models like gpt-4o reject oversized `max_tokens`:
> 400 max_tokens is too large: 32000. This model supports at most 16384 completion tokens.

Claude Code sends `max_tokens=32000` by default, exceeding gpt-4o's 16 384 output-token ceiling. Azure deployments with regional prefixes (e.g. `eastus-gpt-4o-01`) are affected too.

## Fix

**transform.rs**
- `requires_max_completion_tokens()`: covers o-series + gpt-5+ (replaces o-series-only check)
- `known_max_output_tokens()`: caps for gpt-4o (16 384), classic gpt-4 / gpt-4-turbo (4 096), gpt-3.5 (4 096); Azure regional prefixes handled via `contains`
- `clamp_max_tokens()`: applies the cap, passes through unknown models unchanged
- Apply clamp in `anthropic_to_openai_with_reasoning_content`

**transform_responses.rs** - clamp before the `>= 16` minimum guard; `supports_reasoning_effort()` delegates to `requires_max_completion_tokens`

**transform_codex_chat.rs** - apply clamp in the Responses?Chat bridge (per Codex review feedback)

## Tests

- `test_known_max_output_tokens`: gpt-4o family incl. Azure prefixes, gpt-4, gpt-3.5, gpt-5 (no cap), unknown
- `test_clamp_max_tokens`: over-limit clamped, within-limit passed through, non-integer passed through
- `test_requires_max_completion_tokens`: o-series, gpt-5+, negative cases
- `test_max_output_tokens_clamped_to_minimum`: probe value 1 ? 16, normal values pass through

Closes #5215