### PR TITLE
fix(tests): isolate LOCALAPPDATA so tests stop writing the real Claude Desktop config

### DIFF
--- a/src-tauri/tests/support.rs
+++ b/src-tauri/tests/support.rs
@@ -18,6 +18,11 @@ pub fn ensure_test_home() -> &'static Path {
         std::env::set_var("HOME", &base);
         #[cfg(windows)]
         std::env::set_var("USERPROFILE", &base);
+        // Claude Desktop 的配置目录在 Windows 上只读 LOCALAPPDATA（见 claude_desktop_config.rs
+        // 的 windows_local_app_data_dir），既不认 CC_SWITCH_TEST_HOME 也不认 HOME。不覆盖它，
+        // 涉及 Claude Desktop 供应商切换的测试会写进开发者真实的桌面版配置。
+        #[cfg(windows)]
+        std::env::set_var("LOCALAPPDATA", base.join("AppData").join("Local"));
         base
     })
     .as_path()


### PR DESCRIPTION
## Summary / 概述

On Windows, `tests/support.rs` isolates `CC_SWITCH_TEST_HOME`, `HOME` and `USERPROFILE` — but Claude Desktop's config paths resolve from `LOCALAPPDATA`, which honors none of those. `tests/profile_roundtrip.rs` switches the ClaudeDesktop provider to a fixture pointing at `https://desktop.test`, so `cargo test` writes that gateway into the developer's **real** Claude Desktop config: `deploymentMode` flips to `"3p"` in both config files, and a CC Switch 3P profile carrying `inferenceGatewayBaseUrl: https://desktop.test` lands in `configLibrary`.

The desktop app then boots into the separate `%LOCALAPPDATA%\Claude-3p\` data root — login state, Recents and local sessions all vanish from view — and every request fails against the unreachable host. All 7 tests pass, exit code is 0, nothing is printed.

macOS is unaffected: `macos_paths_from_home(&get_home_dir())` goes through `get_home_dir()`, which already honors `CC_SWITCH_TEST_HOME`. Linux CI never runs the two Desktop tests either, since they are gated behind `#[cfg(any(target_os = "macos", windows))]`. That combination is why CI has always been green while only Windows contributors are affected.

## Related Issue / 关联 Issue

Fixes #6077

## Changes / 改动

**`src-tauri/tests/support.rs`** — override `LOCALAPPDATA` alongside the three variables `ensure_test_home()` already sets:

```rust
#[cfg(windows)]
std::env::set_var("LOCALAPPDATA", base.join("AppData").join("Local"));
```

Windows-only, mirroring the `#[cfg(windows)]` `USERPROFILE` line directly above it.

`windows_local_app_data_dir()` reads the variable directly and only falls back to `get_home_dir()` when it is absent, so redirecting it into the test home is sufficient — no production code changes are needed, and no test assertions change.

## Screenshots / 截图

N/A — the symptom is filesystem state, covered by the byte-size and hash comparisons under Testing.

## Testing / 测试

Windows 11 (26200), Claude Desktop 1.24012.9.0 (Microsoft Store / MSIX build) installed and signed in to official 1P mode.

**Reproduced before the fix** by redirecting `LOCALAPPDATA` to a scratch directory and running the test binary directly, so the real config stayed untouched:

```powershell
$env:LOCALAPPDATA = "$env:TEMP\ccs-isolated\AppData\Local"
& target\debug\deps\profile_roundtrip-<hash>.exe --test-threads=1
```

The scratch directory received exactly the four files `apply_provider_to_paths_inner` writes, byte sizes matching what had actually been written into my real config earlier the same day:

| File | Isolated repro | Real config when polluted |
|------|---------------|--------------------------|
| `Claude\claude_desktop_config.json` | 28 | 28 |
| `Claude-3p\configLibrary\_meta.json` | 167 | 167 |
| `Claude-3p\configLibrary\<PROFILE_ID>.json` | 252 | 252 |
| `Claude-3p\claude_desktop_config.json` | 28 | 1245 — the real file already held desktop-written `preferences`, and `write_deployment_mode` merges into existing JSON |

The written profile was byte-identical to the one found in my real `configLibrary`:

```json
{
  "coworkEgressAllowedHosts": ["*"],
  "disableDeploymentModeChooser": true,
  "inferenceGatewayApiKey": "dk-2",
  "inferenceGatewayAuthScheme": "bearer",
  "inferenceGatewayBaseUrl": "https://desktop.test",
  "inferenceProvider": "gateway"
}
```

**After the fix**, ran `cargo test --test profile_roundtrip` with **no** environment overrides (`LOCALAPPDATA` at its real value):

| Path | SHA256 (first 16) before | After |
|------|-------------------------|-------|
| `%LOCALAPPDATA%\Claude\claude_desktop_config.json` | `99609383E133FB4E` | unchanged |
| `%LOCALAPPDATA%\Claude-3p\claude_desktop_config.json` | `A5110EEE3135DCAA` | unchanged |
| `%LOCALAPPDATA%\Claude-3p\configLibrary\_meta.json` | `498CA50AB1B22EB0` | unchanged |

`deploymentMode` stayed `1p` in both files, `configLibrary` kept only its empty `_meta.json`, and the four files landed inside `%TEMP%\cc-switch-test-home\AppData\Local\` instead. Result: 7 passed / 0 failed.

One note for anyone reproducing: the fixture token in the written profile is `dk-1` or `dk-2` depending on test execution order — `profile_snapshot_apply_roundtrip_restores_configuration` switches to `d2`, while `claude_desktop_profile_scope_is_independent` restores `d1`. Both tests pollute.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
  - Exit code 0. The 4 warnings printed are all pre-existing in `src/` — `gemini_mcp.rs:52`, `proxy/providers/codex_oauth_auth.rs:203`, `tray.rs:734`, `prompt_files.rs:45` — and unrelated to this change, which touches only `tests/support.rs`.
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
  - Not applicable — test-only change, no user-facing text.

Also run: `cargo fmt --check` (pass).
