### PR TITLE
feat(skills): allow inactive installation

### DIFF
--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -4,7 +4,7 @@
 //! - 支持三应用开关（Claude/Codex/Gemini）
 //! - SSOT 存储在 ~/.cc-switch/skills/
 
-use crate::app_config::{AppType, InstalledSkill, UnmanagedSkill};
+use crate::app_config::{AppType, InstalledSkill, SkillApps, UnmanagedSkill};
 use crate::error::format_skill_error;
 use crate::services::skill::{
     DiscoverableSkill, ImportSkillSelection, MigrationResult, Skill, SkillBackupEntry, SkillRepo,
@@ -48,18 +48,25 @@ pub fn delete_skill_backup(backup_id: String) -> Result<bool, String> {
 /// 参数：
 /// - skill: 从发现列表获取的技能信息
 /// - current_app: 当前选中的应用，安装后默认启用该应用
+/// - enable_for_current_app: 是否为当前应用启用；缺省保持旧行为
 #[tauri::command]
 pub async fn install_skill_unified(
     skill: DiscoverableSkill,
     current_app: String,
+    enable_for_current_app: Option<bool>,
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<InstalledSkill, String> {
     let app_type = parse_app_type(&current_app)?;
+    let initial_apps = if enable_for_current_app.unwrap_or(true) {
+        SkillApps::only(&app_type)
+    } else {
+        SkillApps::default()
+    };
 
     service
         .0
-        .install(&app_state.db, &skill, &app_type)
+        .install_with_apps(&app_state.db, &skill, initial_apps)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -604,6 +604,21 @@ impl SkillService {
         skill: &DiscoverableSkill,
         current_app: &AppType,
     ) -> Result<InstalledSkill> {
+        self.install_with_apps(db, skill, SkillApps::only(current_app))
+            .await
+    }
+
+    /// Install a Skill with an explicit initial app set.
+    ///
+    /// An empty set keeps the Skill managed in the SSOT and database without
+    /// projecting it into any consumer directory. Existing same-source rows
+    /// retain their current app flags and only merge explicitly requested apps.
+    pub async fn install_with_apps(
+        &self,
+        db: &Arc<Database>,
+        skill: &DiscoverableSkill,
+        initial_apps: SkillApps,
+    ) -> Result<InstalledSkill> {
         let ssot_dir = Self::get_ssot_dir()?;
 
         // 允许多级目录（如 a/b/c），但必须是安全的相对路径。
@@ -634,15 +649,21 @@ impl SkillService {
                 let same_repo = existing.repo_owner.as_deref() == Some(&skill.repo_owner)
                     && existing.repo_name.as_deref() == Some(&skill.repo_name);
                 if same_repo {
-                    // 同一仓库的同名 skill，返回现有记录（可能需要更新启用状态）
+                    // 同一仓库的同名 skill，仅合并显式请求的启用状态。
+                    // 空集合表示保持 inactive，不得隐式启用当前应用。
                     let mut updated = existing.clone();
-                    updated.apps.set_enabled_for(current_app, true);
+                    let requested_apps = initial_apps.enabled_apps();
+                    for app in &requested_apps {
+                        updated.apps.set_enabled_for(app, true);
+                    }
                     db.save_skill(&updated)?;
-                    Self::sync_to_app_dir(&updated.directory, current_app)?;
+                    for app in &requested_apps {
+                        Self::sync_to_app_dir(&updated.directory, app)?;
+                    }
                     log::info!(
-                        "Skill {} 已存在，更新 {:?} 启用状态",
+                        "Skill {} 已存在，合并 {} 个显式应用启用状态",
                         updated.name,
-                        current_app
+                        requested_apps.len()
                     );
                     return Ok(updated);
                 } else {
@@ -782,7 +803,7 @@ impl SkillService {
             repo_name: Some(skill.repo_name.clone()),
             repo_branch: Some(repo_branch),
             readme_url,
-            apps: SkillApps::only(current_app),
+            apps: initial_apps.clone(),
             installed_at: chrono::Utc::now().timestamp(),
             content_hash,
             updated_at: 0,
@@ -791,13 +812,16 @@ impl SkillService {
         // 保存到数据库
         db.save_skill(&installed_skill)?;
 
-        // 同步到当前应用目录
-        Self::sync_to_app_dir(&install_name, current_app)?;
+        // 仅同步到显式启用的应用目录；空集合保持完全 inactive。
+        let enabled_apps = initial_apps.enabled_apps();
+        for app in &enabled_apps {
+            Self::sync_to_app_dir(&install_name, app)?;
+        }
 
         log::info!(
-            "Skill {} 安装成功，已启用 {:?}",
+            "Skill {} 安装成功，已启用 {} 个应用",
             installed_skill.name,
-            current_app
+            enabled_apps.len()
         );
 
         Ok(installed_skill)
@@ -4164,6 +4188,94 @@ mod tests {
             content_hash: None,
             updated_at: 0,
         }
+    }
+
+    fn discoverable_skill(directory: &str) -> DiscoverableSkill {
+        DiscoverableSkill {
+            key: format!("owner/repo:{directory}"),
+            name: directory.to_string(),
+            description: "Test skill".to_string(),
+            directory: directory.to_string(),
+            readme_url: None,
+            repo_owner: "owner".to_string(),
+            repo_name: "repo".to_string(),
+            repo_branch: "main".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn install_with_empty_apps_persists_inactive_without_consumer_projection() {
+        let temp = tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+        let db = std::sync::Arc::new(Database::memory().expect("memory db"));
+        let skill = discoverable_skill("inactive-skill");
+
+        // Keep this unit test offline: the install path reuses an already materialized
+        // SSOT directory, while the assertions exercise the real DB and consumer roots.
+        let ssot_dir = SkillService::get_ssot_dir().expect("ssot dir");
+        write_skill(&ssot_dir.join(&skill.directory), &skill.name);
+
+        let installed = SkillService::new()
+            .install_with_apps(&db, &skill, SkillApps::default())
+            .await
+            .expect("inactive install");
+
+        assert!(installed.apps.is_empty(), "new row must remain disabled");
+        let persisted = db
+            .get_installed_skill(&installed.id)
+            .expect("query installed skill")
+            .expect("installed row");
+        assert!(
+            persisted.apps.is_empty(),
+            "database row must remain disabled"
+        );
+        for app in [AppType::Claude, AppType::Codex] {
+            let app_dir = SkillService::get_app_skills_dir(&app).expect("consumer root");
+            assert!(
+                !app_dir.join(&installed.directory).exists(),
+                "inactive install must not project to {app:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn install_with_empty_apps_does_not_enable_existing_same_source_skill() {
+        let temp = tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+        let db = std::sync::Arc::new(Database::memory().expect("memory db"));
+        let skill = discoverable_skill("existing-inactive-skill");
+        let mut existing = poisoned_skill(&skill.key, &skill.directory);
+        existing.name = skill.name.clone();
+        existing.repo_owner = Some(skill.repo_owner.clone());
+        existing.repo_name = Some(skill.repo_name.clone());
+        existing.repo_branch = Some(skill.repo_branch.clone());
+        db.save_skill(&existing).expect("seed existing skill");
+
+        let returned = SkillService::new()
+            .install_with_apps(&db, &skill, SkillApps::default())
+            .await
+            .expect("idempotent inactive install");
+
+        assert!(
+            returned.apps.is_empty(),
+            "same-source row must not be enabled"
+        );
+        let persisted = db
+            .get_installed_skill(&skill.key)
+            .expect("query existing skill")
+            .expect("existing row");
+        assert!(
+            persisted.apps.is_empty(),
+            "database flags must stay unchanged"
+        );
+        let claude_dir =
+            SkillService::get_app_skills_dir(&AppType::Claude).expect("claude consumer root");
+        assert!(
+            !claude_dir.join(&skill.directory).exists(),
+            "same-source inactive install must not project to Claude"
+        );
     }
 
     #[test]

--- a/src/components/skills/SkillsPage.tsx
+++ b/src/components/skills/SkillsPage.tsx
@@ -8,6 +8,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -99,6 +100,7 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
     const [filterStatus, setFilterStatus] = useState<
       "all" | "installed" | "uninstalled"
     >("all");
+    const [enableForCurrentApp, setEnableForCurrentApp] = useState(true);
 
     // skills.sh 搜索状态
     const [searchSource, setSearchSource] = useState<SkillsPageSource>("repos");
@@ -254,6 +256,7 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
         await installMutation.mutateAsync({
           skill,
           currentApp,
+          enableForCurrentApp,
         });
         toast.success(t("skills.installSuccess", { name: skill.name }), {
           closeButton: true,
@@ -524,6 +527,16 @@ export const SkillsPage = forwardRef<SkillsPageHandle, SkillsPageProps>(
                   </Button>
                 </>
               )}
+              <label className="flex shrink-0 cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+                <Checkbox
+                  checked={enableForCurrentApp}
+                  onCheckedChange={(checked) =>
+                    setEnableForCurrentApp(checked === true)
+                  }
+                  aria-label={t("skills.enableAfterInstall")}
+                />
+                <span>{t("skills.enableAfterInstall")}</span>
+              </label>
             </div>
 
             {/* 内容区域 */}

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -72,10 +72,12 @@ export function useInstallSkill() {
     mutationFn: ({
       skill,
       currentApp,
+      enableForCurrentApp = true,
     }: {
       skill: DiscoverableSkill;
       currentApp: AppId;
-    }) => skillsApi.installUnified(skill, currentApp),
+      enableForCurrentApp?: boolean;
+    }) => skillsApi.installUnified(skill, currentApp, enableForCurrentApp),
     onSuccess: (installedSkill, _vars, _ctx) => {
       const { skill } = _vars;
       // 直接更新 installed 缓存

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2273,6 +2273,7 @@
     "loading": "Loading...",
     "installed": "Installed",
     "install": "Install",
+    "enableAfterInstall": "Enable for current app after install",
     "installing": "Installing...",
     "uninstall": "Uninstall",
     "uninstalling": "Uninstalling...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2273,6 +2273,7 @@
     "loading": "読み込み中...",
     "installed": "インストール済み",
     "install": "インストール",
+    "enableAfterInstall": "インストール後に現在のアプリで有効化",
     "installing": "インストール中...",
     "uninstall": "アンインストール",
     "uninstalling": "アンインストール中...",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2274,6 +2274,7 @@
     "loading": "載入中...",
     "installed": "已安裝",
     "install": "安裝",
+    "enableAfterInstall": "安裝後為目前應用啟用",
     "installing": "安裝中...",
     "uninstall": "解除安裝",
     "uninstalling": "解除安裝中...",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2273,6 +2273,7 @@
     "loading": "加载中...",
     "installed": "已安装",
     "install": "安装",
+    "enableAfterInstall": "安装后为当前应用启用",
     "installing": "安装中...",
     "uninstall": "卸载",
     "uninstalling": "卸载中...",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -157,8 +157,13 @@ export const skillsApi = {
   async installUnified(
     skill: DiscoverableSkill,
     currentApp: AppId,
+    enableForCurrentApp = true,
   ): Promise<InstalledSkill> {
-    return await invoke("install_skill_unified", { skill, currentApp });
+    return await invoke("install_skill_unified", {
+      skill,
+      currentApp,
+      enableForCurrentApp,
+    });
   },
 
   /** 卸载 Skill（统一卸载） */

--- a/tests/components/SkillsPageInstall.test.tsx
+++ b/tests/components/SkillsPageInstall.test.tsx
@@ -196,6 +196,38 @@ describe("SkillsPage - skills.sh install (regression)", () => {
     expect(callArgs.skill.repoOwner).toBe("owner-b");
     expect(callArgs.skill.repoName).toBe("repo-b");
     expect(callArgs.skill.name).toBe("Agent Browser B");
+    expect(callArgs.currentApp).toBe("claude");
+    expect(callArgs.enableForCurrentApp).toBe(true);
+  });
+
+  it("can install a repository skill without enabling the current app", async () => {
+    const skill = makeDiscoverableSkill({ name: "Inactive Skill" });
+    discoverableSkillsMock = [skill];
+    skillReposMock = [makeSkillRepo()];
+
+    render(<SkillsPage initialApp="claude" />);
+    const user = userEvent.setup();
+
+    const enableAfterInstall = screen.getByRole("checkbox", {
+      name: "skills.enableAfterInstall",
+    });
+    expect(enableAfterInstall).toBeChecked();
+    await user.click(enableAfterInstall);
+
+    const card = screen.getByText("Inactive Skill").closest("div.glass-card");
+    expect(card).not.toBeNull();
+    const installButton = card!.querySelector(
+      "button:last-of-type",
+    ) as HTMLButtonElement;
+    await user.click(installButton);
+
+    await waitFor(() => {
+      expect(installMutateAsyncMock).toHaveBeenCalledWith({
+        skill,
+        currentApp: "claude",
+        enableForCurrentApp: false,
+      });
+    });
   });
 
   it("keeps skills.sh results when submitting the same query again", async () => {


### PR DESCRIPTION
## Summary / 概述

- keep the existing install-and-enable flow as the default
- add an explicit "Enable for current app after install" option to the Skills discovery page
- let `SkillService` install with an explicit initial `SkillApps` set
- persist empty app sets without projecting into any consumer directory
- avoid implicitly enabling an existing same-source Skill when the requested app set is empty

This removes the transient consumer exposure caused by an install-then-disable workflow while preserving compatibility for existing callers.

## Related Issue / 关联 Issue

Fixes #6082

## Scope boundary

This focused PR provides the single-Skill inactive-install primitive only. It does not claim cohort-wide atomic acquisition, dependency/digest verification, transaction journaling, or crash recovery; those need a separate design and failure matrix.

## Screenshots / 截图

Not attached yet; the PR is opened as a draft. The new checkbox is covered by an interaction test.

## Checklist / 检查清单

- [x] TypeScript typecheck passes
- [x] Prettier format check passes
- [x] Rust format check passes
- [x] `cargo clippy --all-targets` passes (one unrelated pre-existing `items_after_test_module` warning remains)
- [x] Updated all four locale files for user-facing text

## Verification / 验证

- `vitest run tests/components/SkillsPageInstall.test.tsx`: 8 passed
- `vitest run tests/integration/App.test.tsx`: 4 passed in isolation
- full `vitest run`: the Skills tests pass; two existing order-sensitive failures occur in `tests/integration/App.test.tsx` (timeout and duplicate `provider-list`), while that module passes when isolated
- `vite build`: passed
- `cargo test install_with_empty_apps --lib`: 2 passed
- `cargo build`: passed
- full `cargo test --lib`: 2245 passed, 1 failed, 2 ignored; the sole failure is `services::model_pricing::tests::reloads_manual_file_edits_and_deletion_tombstones`, and the identical failure was reproduced in a detached worktree at unchanged upstream `eb356e15bd898a434fde7ca74e5e3a2aec6c90e4`