### PR TITLE
feat(sessions): delete selected session with Delete/Backspace key

### DIFF
--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -54,6 +54,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { extractErrorMessage } from "@/utils/errorUtils";
+import { isTextEditableTarget } from "@/utils/domUtils";
 import { isMac } from "@/lib/platform";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { SessionItem } from "./SessionItem";
@@ -781,6 +782,42 @@ export function SessionManagerPage({ appId }: { appId: string }) {
     if (selectedDeletableSessions.length === 0) return;
     setDeleteTargets(selectedDeletableSessions);
   };
+
+  // Issue #6048: Delete/Backspace deletes the selected session (or the batch
+  // selection when in selection mode). Both paths open the existing confirm
+  // dialog, so a confirmation is always required before anything is removed.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Delete" && event.key !== "Backspace") return;
+      if (event.defaultPrevented) return;
+      // Don't hijack typing in inputs / search / contenteditable areas.
+      if (isTextEditableTarget(event.target)) return;
+      // Skip while a confirm dialog is already open or a deletion is running.
+      if (deleteTargets !== null || isDeleting) return;
+
+      if (selectionMode) {
+        if (selectedDeletableSessions.length === 0) return;
+        event.preventDefault();
+        setDeleteTargets(selectedDeletableSessions);
+        return;
+      }
+
+      if (!selectedSession || !selectedSession.sourcePath) return;
+      event.preventDefault();
+      setDeleteTargets([selectedSession]);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [
+    selectedSession,
+    selectionMode,
+    selectedDeletableSessions,
+    deleteTargets,
+    isDeleting,
+  ]);
 
   const exitSelectionMode = () => {
     setSelectionMode(false);

--- a/tests/components/SessionManagerPage.test.tsx
+++ b/tests/components/SessionManagerPage.test.tsx
@@ -680,4 +680,76 @@ describe("SessionManagerPage", () => {
     expect(toastErrorMock).not.toHaveBeenCalled();
     expect(toastSuccessMock).toHaveBeenCalled();
   });
+
+  it("opens the delete confirm dialog when pressing Delete with a session selected", async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Alpha Session" }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.keyDown(window, { key: "Delete" });
+
+    const dialog = await screen.findByTestId("confirm-dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText(/Alpha Session/)).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /删除会话/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("Alpha Session")).not.toBeInTheDocument(),
+    );
+    expect(toastSuccessMock).toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("does not delete when Delete is pressed while typing in the search input", async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Alpha Session" }),
+      ).toBeInTheDocument(),
+    );
+
+    openSearch();
+    const searchInput = screen.getByRole("textbox");
+
+    fireEvent.change(searchInput, { target: { value: "Alpha" } });
+    fireEvent.keyDown(searchInput, { key: "Backspace" });
+    fireEvent.keyDown(searchInput, { key: "Delete" });
+
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Alpha Session" }),
+    ).toBeInTheDocument();
+  });
+
+  it("triggers batch delete with Delete when in selection mode", async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Alpha Session" }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /批量管理/i }));
+    fireEvent.click(screen.getByRole("button", { name: /全选当前/i }));
+
+    fireEvent.keyDown(window, { key: "Delete" });
+
+    const dialog = await screen.findByTestId("confirm-dialog");
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: /删除所选会话/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha Session")).not.toBeInTheDocument();
+      expect(screen.queryByText("Beta Session")).not.toBeInTheDocument();
+    });
+    expect(toastSuccessMock).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #6048

Adds a keyboard shortcut so that pressing **Delete** (or **Backspace** on macOS, where the Delete key maps to Backspace) opens the existing delete confirmation dialog for the currently selected session in the Session Manager.

In **batch selection mode**, the same key opens the batch delete confirmation dialog instead.

## Behavior

| Mode | Key | Action |
| --- | --- | --- |
| Single selection | `Delete` / `Backspace` | Open confirm dialog for the selected session |
| Batch selection | `Delete` / `Backspace` | Open batch delete confirm dialog |

## Safety

The handler deliberately **reuses the existing confirmation flow** — nothing is removed without an explicit user confirmation, so there is no risk of accidental data loss from a stray key press.

Guards:
- Ignored while typing in inputs, the search box, or any `contenteditable` element (so Backspace keeps editing text).
- Skipped while a confirmation dialog is already open or a deletion is in progress (prevents stacking dialogs / double deletes).
- Only triggers when the selected session is actually deletable (has a `sourcePath`).
- Listener is bound while the Session Manager is mounted and cleaned up on unmount.

## Test

- `pnpm typecheck` ✅
- `pnpm format:check` ✅
- `pnpm test:unit` ✅ (session manager: 17/17, incl. 3 new tests)

### New tests

- `opens the delete confirm dialog when pressing Delete with a session selected`
- `does not delete when Delete is pressed while typing in the search input`
- `triggers batch delete with Delete when in selection mode`

## Checklist

- [x] Pass type check: `pnpm typecheck`
- [x] Pass format check: `pnpm format:check`
- [x] Pass unit tests: `pnpm test:unit`