### PR TITLE
fix(codex): respect user-owned model_catalog_json when generating catalog

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1248,7 +1248,22 @@ fn set_codex_model_catalog_json_field(
 
     match catalog_path {
         Some(_) => {
-            doc["model_catalog_json"] = toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
+            // Only claim the pointer when it is absent or already cc-switch-owned.
+            // A user-managed external catalog file (custom filename or path) is
+            // left untouched, mirroring the None arm's ownership rule that
+            // `resolve_cc_switch_catalog_path` relies on.
+            let is_cc_switch_owned = doc
+                .get("model_catalog_json")
+                .and_then(|item| item.as_str())
+                .map(|path| {
+                    Path::new(path).file_name().and_then(|name| name.to_str())
+                        == Some(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME)
+                })
+                .unwrap_or(true);
+            if is_cc_switch_owned {
+                doc["model_catalog_json"] =
+                    toml_edit::value(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME);
+            }
         }
         None => {
             let should_remove = doc
@@ -4215,6 +4230,44 @@ model = "glm-5"
             parsed.get("model_catalog_json").and_then(|v| v.as_str()),
             Some("/Users/me/.codex/my-custom-catalog.json"),
             "None arm should NOT remove user-owned catalog"
+        );
+    }
+
+    #[test]
+    fn set_catalog_json_some_preserves_user_owned_catalog() {
+        // When CC Switch generates a catalog (Some arm), it must still respect a
+        // user-managed external catalog file instead of clobbering it with the
+        // cc-switch-owned filename. Only an absent or cc-switch-owned pointer is
+        // claimed; this mirrors the None arm's ownership rule.
+        let input = r#"model_provider = "custom"
+model = "glm-5"
+model_catalog_json = "/Users/me/.codex/my-custom-catalog.json"
+"#;
+        let catalog_path = Path::new("/tmp/cc-switch-model-catalog.json");
+        let result = set_codex_model_catalog_json_field(input, Some(catalog_path)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        assert_eq!(
+            parsed.get("model_catalog_json").and_then(|v| v.as_str()),
+            Some("/Users/me/.codex/my-custom-catalog.json"),
+            "Some arm should NOT clobber a user-owned catalog (full path)"
+        );
+    }
+
+    #[test]
+    fn set_catalog_json_some_preserves_user_owned_relative_filename() {
+        // A bare custom filename (no directory component) is also user-owned
+        // and must be preserved by the Some arm.
+        let input = r#"model_provider = "custom"
+model = "glm-5"
+model_catalog_json = "my-custom-catalog.json"
+"#;
+        let catalog_path = Path::new("/tmp/cc-switch-model-catalog.json");
+        let result = set_codex_model_catalog_json_field(input, Some(catalog_path)).unwrap();
+        let parsed: toml::Value = toml::from_str(&result).unwrap();
+        assert_eq!(
+            parsed.get("model_catalog_json").and_then(|v| v.as_str()),
+            Some("my-custom-catalog.json"),
+            "Some arm should NOT clobber a relative user-owned catalog"
         );
     }
 


### PR DESCRIPTION
## Problem

In the Codex provider configuration, `model_catalog_json` is always overwritten with `cc-switch-model-catalog.json` in the generated `config.toml`, regardless of whether the user specified a custom catalog filename or full path. This means any user-managed external catalog file is silently discarded on every config write.

## Root Cause

`set_codex_model_catalog_json_field` in `src-tauri/src/codex_config.rs` has two arms:

- **`None` arm**: already checks ownership — it only removes the pointer when it points at the cc-switch-owned file, preserving user-managed external catalogs.
- **`Some` arm**: unconditionally writes the cc-switch-owned filename, clobbering any user-provided value.

The `Some` arm lacks the ownership check that the `None` arm already implements, causing the inconsistency.

## Fix

Mirror the `None` arm's ownership rule in the `Some` arm: only claim the `model_catalog_json` pointer when it is **absent** or **already cc-switch-owned**. A user-managed external catalog file (custom filename or path) is left untouched.

This is consistent with the existing design documented in `resolve_cc_switch_catalog_path`, which explicitly distinguishes cc-switch-owned vs user-owned catalog pointers.

## Testing

- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` — all existing catalog tests pass (no regression)
- [x] Added two tests covering the `Some` arm with user-owned catalogs:
  - `set_catalog_json_some_preserves_user_owned_catalog` (full path)
  - `set_catalog_json_some_preserves_user_owned_relative_filename` (bare filename)
- [x] Verified manually: a custom `model_catalog_json` value is now preserved in `config.toml` after switching providers

```
running 8 tests
test codex_config::tests::set_catalog_json_none_removes_relative_path ... ok
test codex_config::tests::set_catalog_json_none_preserves_user_owned_catalog ... ok
test codex_config::tests::set_catalog_json_field_writes_filename_ignoring_unc_path ... ok
test codex_config::tests::set_catalog_json_none_removes_cc_switch_owned_by_filename ... ok
test codex_config::tests::model_catalog_json_field_writes_relative_filename ... ok
test codex_config::tests::set_catalog_json_field_writes_filename_for_any_path ... ok
test codex_config::tests::set_catalog_json_some_preserves_user_owned_catalog ... ok
test codex_config::tests::set_catalog_json_some_preserves_user_owned_relative_filename ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured
```