### PR TITLE
fix(codex): handle Chat content parts arrays and message snapshots

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -80,6 +80,7 @@ struct ChatToResponsesState {
     latest_usage: Option<Value>,
     finish_reason: Option<String>,
     tool_context: CodexToolContext,
+    last_message_snapshot: String,
     /// 本回合因缺少合法函数名而被丢弃的工具调用数（见 `finalize_tools`）。
     dropped_tool_calls: usize,
 }
@@ -102,6 +103,7 @@ impl Default for ChatToResponsesState {
             latest_usage: None,
             finish_reason: None,
             tool_context: CodexToolContext::default(),
+            last_message_snapshot: String::new(),
             dropped_tool_calls: 0,
         }
     }
@@ -170,6 +172,17 @@ impl ChatToResponsesState {
             if let Some(content) = message.get("content").and_then(chat_delta_content_text) {
                 if self.text.text.is_empty() {
                     events.extend(self.push_content_delta(&content));
+                    self.last_message_snapshot = content;
+                } else if let Some(remainder) = content.strip_prefix(&self.text.text) {
+                    if !remainder.is_empty() {
+                        events.extend(self.push_content_delta(remainder));
+                        self.last_message_snapshot = content;
+                    }
+                } else if let Some(remainder) = content.strip_prefix(&self.last_message_snapshot) {
+                    if !remainder.is_empty() {
+                        events.extend(self.push_content_delta(remainder));
+                        self.last_message_snapshot = content;
+                    }
                 }
             }
         }
@@ -792,10 +805,12 @@ fn chat_delta_content_text(value: &Value) -> Option<String> {
     let parts = value.as_array()?;
     let text: String = parts
         .iter()
-        .filter_map(|part| {
-            part.get("text")
+        .filter_map(|part| match part.get("type").and_then(|v| v.as_str()) {
+            Some(t) if t != "text" => None,
+            _ => part
+                .get("text")
                 .and_then(|v| v.as_str())
-                .or_else(|| part.as_str())
+                .or_else(|| part.as_str()),
         })
         .collect();
     (!text.is_empty()).then_some(text)
@@ -1024,6 +1039,47 @@ mod tests {
 
         assert!(output.contains("\"delta\":\"Full answer\""));
         assert!(output.contains("\"text\":\"Full answer\""));
+    }
+
+    #[tokio::test]
+    async fn reconciles_cumulative_message_snapshots() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_cum\",\"model\":\"gpt-5.4\",\"choices\":[{\"message\":{\"content\":\"Hel\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_cum\",\"model\":\"gpt-5.4\",\"choices\":[{\"message\":{\"content\":\"Hello\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("\"delta\":\"Hel\""));
+        assert!(output.contains("\"delta\":\"lo\""));
+        assert!(output.contains("\"text\":\"Hello\""));
+    }
+
+    #[tokio::test]
+    async fn appends_message_snapshot_remainder_after_partial_delta() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_rem\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_rem\",\"model\":\"gpt-5.4\",\"choices\":[{\"message\":{\"content\":\"Hello\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("\"delta\":\"Hel\""));
+        assert!(output.contains("\"delta\":\"lo\""));
+        assert!(output.contains("\"text\":\"Hello\""));
+    }
+
+    #[tokio::test]
+    async fn content_parts_array_ignores_non_text_parts() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_parts2\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":[{\"type\":\"image\",\"image_url\":\"x\"},{\"type\":\"text\",\"text\":\"Hi\"}]},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("\"delta\":\"Hi\""));
+        assert!(!output.contains("image_url"));
+        assert!(output.contains("\"text\":\"Hi\""));
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -150,10 +150,8 @@ impl ChatToResponsesState {
                 self.append_reasoning_to_active_tools(&reasoning);
             }
 
-            if let Some(content) = delta.get("content").and_then(|v| v.as_str()) {
-                if !content.is_empty() {
-                    events.extend(self.push_content_delta(content));
-                }
+            if let Some(content) = delta.get("content").and_then(chat_delta_content_text) {
+                events.extend(self.push_content_delta(&content));
             }
 
             if let Some(tool_calls) = delta.get("tool_calls").and_then(|v| v.as_array()) {
@@ -164,6 +162,14 @@ impl ChatToResponsesState {
                     events.extend(
                         self.push_tool_call_delta(tool_call, reasoning_for_tool_call.as_deref()),
                     );
+                }
+            }
+        }
+
+        if let Some(message) = choice.get("message") {
+            if let Some(content) = message.get("content").and_then(chat_delta_content_text) {
+                if self.text.text.is_empty() {
+                    events.extend(self.push_content_delta(&content));
                 }
             }
         }
@@ -779,6 +785,22 @@ fn chat_delta_reasoning_text(delta: &Value) -> Option<String> {
     extract_reasoning_field_text(delta)
 }
 
+fn chat_delta_content_text(value: &Value) -> Option<String> {
+    if let Some(text) = value.as_str() {
+        return (!text.is_empty()).then(|| text.to_string());
+    }
+    let parts = value.as_array()?;
+    let text: String = parts
+        .iter()
+        .filter_map(|part| {
+            part.get("text")
+                .and_then(|v| v.as_str())
+                .or_else(|| part.as_str())
+        })
+        .collect();
+    (!text.is_empty()).then_some(text)
+}
+
 enum ThinkPrefixDecision {
     NeedMore,
     Reasoning,
@@ -975,6 +997,33 @@ mod tests {
         assert!(output.contains("\"text\":\"Hello\""));
         assert!(output.contains("event: response.completed"));
         assert!(output.contains("\"input_tokens\":4"));
+    }
+
+    #[tokio::test]
+    async fn converts_content_parts_array_chat_sse_to_responses_sse() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_parts\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\"Hel\"}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_parts\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\"lo\"}]},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("\"delta\":\"Hel\""));
+        assert!(output.contains("\"delta\":\"lo\""));
+        assert!(output.contains("\"text\":\"Hello\""));
+    }
+
+    #[tokio::test]
+    async fn converts_message_snapshot_chat_sse_to_responses_sse() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_msg\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_msg\",\"model\":\"gpt-5.4\",\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"Full answer\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("\"delta\":\"Full answer\""));
+        assert!(output.contains("\"text\":\"Full answer\""));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary / 概述

CC Switch 的 Chat Completions → Responses 流式转换器（`streaming_codex_chat.rs`）之前只把 `delta.content` 当普通字符串处理。部分 Chat Completions 上游（本机用 OpenCode Go 复现）会把正文以 content parts 数组返回，或者把完整正文放在收尾块的 `choices[].message.content` 里。

这两种情况下，reasoning（`reasoning_content`）能正常流式输出，但可见正文被转换器丢弃，Codex 会正常进行思考，但一输出就触发中断。

本 PR：
- 新增 `chat_delta_content_text`，同时支持字符串和 `[{ "type": "text", "text": "..." }]` 数组两种 content 形态。
- 当 `delta` 里没有正文时，回退读取 `choices[].message.content`，避免 message-snapshot 形态的 SSE 丢失正文。
- 新增两个回归测试覆盖这两种上游格式。

## Related Issue / 关联 Issue

Related: #4341（Codex 接入第三方模型对话经常自动中断，正文丢失是其中一个根因）

## Screenshots / 截图

N/A — 纯后端代理转换修复，无 UI 变更。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（无前端变更）
- [x] `pnpm format:check` passes / 通过代码格式检查（无前端变更）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本变更）

## 本地验证

- `cargo fmt --check`：通过
- `rustc -Zunpretty=ast-tree` 全文件解析：通过
- `git diff --check`：通过
- 完整 `cargo test` 需 CI 运行（本机没有 `link.exe`）