### PR TITLE
feat: add request/response detail capture with detail panel in usage logs

### DIFF
--- a/src-tauri/src/commands/detail_capture.rs
+++ b/src-tauri/src/commands/detail_capture.rs
@@ -1,0 +1,76 @@
+//! Request/response detail capture queries
+//!
+//! Query raw body from proxy_request_log_details table for display in detail panel.
+
+use crate::error::AppError;
+use serde::{Deserialize, Serialize};
+
+/// Request/response detail payload
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestLogDetailPayload {
+    pub request_id: String,
+    pub request_headers: Option<String>,
+    pub request_body: Option<String>,
+    pub response_headers: Option<String>,
+    pub response_body: Option<String>,
+}
+
+/// Get request/response detail payload
+///
+/// Tries full schema columns first (*_json / *_full), falls back to simplified 5-column schema.
+#[tauri::command]
+pub fn get_request_detail_payload(
+    state: tauri::State<'_, crate::AppState>,
+    request_id: String,
+) -> Result<Option<RequestLogDetailPayload>, AppError> {
+    let conn = crate::database::lock_conn!(state.db.conn);
+
+    // 1) Full schema (my-ccs-dev / production)
+    let full = conn.query_row(
+        "SELECT request_id,
+                request_headers_json,
+                COALESCE(request_body_full, request_body_preview),
+                response_headers_json,
+                COALESCE(response_body_full, response_body_preview)
+         FROM proxy_request_log_details
+         WHERE request_id = ?",
+        [&request_id],
+        |row| {
+            Ok(RequestLogDetailPayload {
+                request_id: row.get(0)?,
+                request_headers: row.get(1)?,
+                request_body: row.get(2)?,
+                response_headers: row.get(3)?,
+                response_body: row.get(4)?,
+            })
+        },
+    );
+    match full {
+        Ok(payload) => return Ok(Some(payload)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(_) => {}
+    }
+
+    // 2) Simplified 5-column schema (early branch version)
+    let simple = conn.query_row(
+        "SELECT request_id, request_headers, request_body, response_headers, response_body
+         FROM proxy_request_log_details
+         WHERE request_id = ?",
+        [&request_id],
+        |row| {
+            Ok(RequestLogDetailPayload {
+                request_id: row.get(0)?,
+                request_headers: row.get(1)?,
+                request_body: row.get(2)?,
+                response_headers: row.get(3)?,
+                response_body: row.get(4)?,
+            })
+        },
+    );
+    match simple {
+        Ok(payload) => Ok(Some(payload)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(AppError::Database(e.to_string())),
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -30,10 +30,10 @@ mod subscription;
 mod sync_support;
 mod xai_oauth;
 
+mod detail_capture;
 mod lightweight;
 mod s3_sync;
 mod usage;
-mod detail_capture;
 mod webdav_sync;
 mod workspace;
 
@@ -66,9 +66,9 @@ pub use stream_check::*;
 pub use subscription::*;
 pub use xai_oauth::*;
 
+pub use detail_capture::*;
 pub use lightweight::*;
 pub use s3_sync::*;
 pub use usage::*;
-pub use detail_capture::*;
 pub use webdav_sync::*;
 pub use workspace::*;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -33,6 +33,7 @@ mod xai_oauth;
 mod lightweight;
 mod s3_sync;
 mod usage;
+mod detail_capture;
 mod webdav_sync;
 mod workspace;
 
@@ -68,5 +69,6 @@ pub use xai_oauth::*;
 pub use lightweight::*;
 pub use s3_sync::*;
 pub use usage::*;
+pub use detail_capture::*;
 pub use webdav_sync::*;
 pub use workspace::*;

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -116,7 +116,28 @@ pub fn get_request_detail(
     state: State<'_, AppState>,
     request_id: String,
 ) -> Result<Option<RequestLogDetail>, AppError> {
-    state.db.get_request_detail(&request_id)
+    let result = state.db.get_request_detail(&request_id)?;
+
+    if result.is_none() {
+        // Diagnostic logging: help debug why a list entry has no matching detail record
+        let conn = state
+            .db
+            .conn
+            .lock()
+            .map_err(|e| AppError::Database(format!("Mutex lock failed: {e}")))?;
+        let sample_id: Result<String, _> = conn.query_row(
+            "SELECT request_id FROM proxy_request_logs LIMIT 1",
+            [],
+            |row| row.get(0),
+        );
+        log::warn!(
+            "[DETAIL-NOTFOUND] request_id='{request_id}' (len={}), sample_row_id='{:?}'",
+            request_id.len(),
+            sample_id,
+        );
+    }
+
+    Ok(result)
 }
 
 /// 获取模型定价列表

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1352,7 +1352,7 @@ impl Database {
         Ok(())
     }
 
-    /// v11 -> v12 迁移：添加项目 Profiles 表
+    /// v11 -> v12 迁移：添加项目 Profiles 表和请求详情记录表
     /// 与 create_tables_on_conn 中的建表语句保持一致（IF NOT EXISTS 保证幂等）
     fn migrate_v11_to_v12(conn: &Connection) -> Result<(), AppError> {
         conn.execute(
@@ -1366,7 +1366,68 @@ impl Database {
             )",
             [],
         )
-        .map_err(|e| AppError::Database(format!("v11 -> v12 创建 profiles 表失败: {e}")))?;
+        .map_err(|e| AppError::Database(format!("v11 -> v12: create profiles table failed: {e}")))?;
+
+        // Align with my-ccs-dev / production DB full detail table schema.
+        // IF NOT EXISTS: leaves existing full tables untouched; creates full columns for new DBs.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS proxy_request_log_details (
+                request_id TEXT PRIMARY KEY,
+                log_level TEXT NOT NULL,
+                route_trace_json TEXT,
+                mapping_json TEXT,
+                request_headers_json TEXT,
+                request_body_preview TEXT,
+                request_body_full TEXT,
+                response_headers_json TEXT,
+                response_body_preview TEXT,
+                response_body_full TEXT,
+                upstream_error_json TEXT,
+                created_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("Failed to create proxy_request_log_details table: {e}")))?;
+
+        // Upgrade old 5-column tables to full 12-column schema (add missing columns)
+        if Self::table_exists(conn, "proxy_request_log_details")? {
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "log_level",
+                "TEXT NOT NULL DEFAULT 'full'",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "route_trace_json", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "mapping_json", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "request_headers_json", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "request_body_preview", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "request_body_full", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "response_headers_json", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "response_body_preview", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "response_body_full", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "upstream_error_json", "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn, "proxy_request_log_details", "created_at",
+                "INTEGER NOT NULL DEFAULT 0",
+            )?;
+        }
+
         Ok(())
     }
 

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1366,7 +1366,9 @@ impl Database {
             )",
             [],
         )
-        .map_err(|e| AppError::Database(format!("v11 -> v12: create profiles table failed: {e}")))?;
+        .map_err(|e| {
+            AppError::Database(format!("v11 -> v12: create profiles table failed: {e}"))
+        })?;
 
         // Align with my-ccs-dev / production DB full detail table schema.
         // IF NOT EXISTS: leaves existing full tables untouched; creates full columns for new DBs.
@@ -1387,43 +1389,73 @@ impl Database {
             )",
             [],
         )
-        .map_err(|e| AppError::Database(format!("Failed to create proxy_request_log_details table: {e}")))?;
+        .map_err(|e| {
+            AppError::Database(format!(
+                "Failed to create proxy_request_log_details table: {e}"
+            ))
+        })?;
 
         // Upgrade old 5-column tables to full 12-column schema (add missing columns)
         if Self::table_exists(conn, "proxy_request_log_details")? {
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "log_level",
+                conn,
+                "proxy_request_log_details",
+                "log_level",
                 "TEXT NOT NULL DEFAULT 'full'",
             )?;
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "route_trace_json", "TEXT",
+                conn,
+                "proxy_request_log_details",
+                "route_trace_json",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(conn, "proxy_request_log_details", "mapping_json", "TEXT")?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "request_headers_json",
+                "TEXT",
             )?;
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "mapping_json", "TEXT",
+                conn,
+                "proxy_request_log_details",
+                "request_body_preview",
+                "TEXT",
             )?;
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "request_headers_json", "TEXT",
+                conn,
+                "proxy_request_log_details",
+                "request_body_full",
+                "TEXT",
             )?;
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "request_body_preview", "TEXT",
+                conn,
+                "proxy_request_log_details",
+                "response_headers_json",
+                "TEXT",
             )?;
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "request_body_full", "TEXT",
+                conn,
+                "proxy_request_log_details",
+                "response_body_preview",
+                "TEXT",
             )?;
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "response_headers_json", "TEXT",
+                conn,
+                "proxy_request_log_details",
+                "response_body_full",
+                "TEXT",
             )?;
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "response_body_preview", "TEXT",
+                conn,
+                "proxy_request_log_details",
+                "upstream_error_json",
+                "TEXT",
             )?;
             Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "response_body_full", "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "upstream_error_json", "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn, "proxy_request_log_details", "created_at",
+                conn,
+                "proxy_request_log_details",
+                "created_at",
                 "INTEGER NOT NULL DEFAULT 0",
             )?;
         }

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -402,6 +402,97 @@ impl Database {
             [],
         );
 
+        // Request/response detail table (full 12-column schema).
+        // Created here (not only in migrations) so already-migrated databases
+        // at the latest SCHEMA_VERSION still get the table and its columns.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS proxy_request_log_details (
+                request_id TEXT PRIMARY KEY,
+                log_level TEXT NOT NULL,
+                route_trace_json TEXT,
+                mapping_json TEXT,
+                request_headers_json TEXT,
+                request_body_preview TEXT,
+                request_body_full TEXT,
+                response_headers_json TEXT,
+                response_body_preview TEXT,
+                response_body_full TEXT,
+                upstream_error_json TEXT,
+                created_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .map_err(|e| {
+            AppError::Database(format!(
+                "Failed to create proxy_request_log_details table: {e}"
+            ))
+        })?;
+
+        // Upgrade old 5-column detail tables to full 12-column schema (add missing columns)
+        if Self::table_exists(conn, "proxy_request_log_details")? {
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "log_level",
+                "TEXT NOT NULL DEFAULT 'full'",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "route_trace_json",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(conn, "proxy_request_log_details", "mapping_json", "TEXT")?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "request_headers_json",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "request_body_preview",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "request_body_full",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "response_headers_json",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "response_body_preview",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "response_body_full",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "upstream_error_json",
+                "TEXT",
+            )?;
+            Self::add_column_if_missing(
+                conn,
+                "proxy_request_log_details",
+                "created_at",
+                "INTEGER NOT NULL DEFAULT 0",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -1370,95 +1461,8 @@ impl Database {
             AppError::Database(format!("v11 -> v12: create profiles table failed: {e}"))
         })?;
 
-        // Align with my-ccs-dev / production DB full detail table schema.
-        // IF NOT EXISTS: leaves existing full tables untouched; creates full columns for new DBs.
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS proxy_request_log_details (
-                request_id TEXT PRIMARY KEY,
-                log_level TEXT NOT NULL,
-                route_trace_json TEXT,
-                mapping_json TEXT,
-                request_headers_json TEXT,
-                request_body_preview TEXT,
-                request_body_full TEXT,
-                response_headers_json TEXT,
-                response_body_preview TEXT,
-                response_body_full TEXT,
-                upstream_error_json TEXT,
-                created_at INTEGER NOT NULL
-            )",
-            [],
-        )
-        .map_err(|e| {
-            AppError::Database(format!(
-                "Failed to create proxy_request_log_details table: {e}"
-            ))
-        })?;
-
-        // Upgrade old 5-column tables to full 12-column schema (add missing columns)
-        if Self::table_exists(conn, "proxy_request_log_details")? {
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "log_level",
-                "TEXT NOT NULL DEFAULT 'full'",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "route_trace_json",
-                "TEXT",
-            )?;
-            Self::add_column_if_missing(conn, "proxy_request_log_details", "mapping_json", "TEXT")?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "request_headers_json",
-                "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "request_body_preview",
-                "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "request_body_full",
-                "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "response_headers_json",
-                "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "response_body_preview",
-                "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "response_body_full",
-                "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "upstream_error_json",
-                "TEXT",
-            )?;
-            Self::add_column_if_missing(
-                conn,
-                "proxy_request_log_details",
-                "created_at",
-                "INTEGER NOT NULL DEFAULT 0",
-            )?;
-        }
+        // NOTE: proxy_request_log_details is created in create_tables_on_conn so it
+        // applies to databases already at the latest SCHEMA_VERSION.
 
         Ok(())
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1532,6 +1532,7 @@ pub fn run() {
             commands::get_model_stats,
             commands::get_request_logs,
             commands::get_request_detail,
+            commands::get_request_detail_payload,
             commands::get_model_pricing,
             commands::update_model_pricing,
             commands::update_model_pricing_batch,

--- a/src-tauri/src/proxy/handler_context.rs
+++ b/src-tauri/src/proxy/handler_context.rs
@@ -70,6 +70,8 @@ pub struct RequestContext {
     pub optimizer_config: OptimizerConfig,
     /// Copilot 优化器配置
     pub copilot_optimizer_config: CopilotOptimizerConfig,
+    /// Raw request body JSON string (for detail capture)
+    pub request_body: String,
 }
 
 impl RequestContext {
@@ -157,6 +159,8 @@ impl RequestContext {
             session_id
         );
 
+        let request_body = serde_json::to_string(body).unwrap_or_default();
+
         Ok(Self {
             start_time,
             app_config,
@@ -170,6 +174,7 @@ impl RequestContext {
             app_type,
             session_id,
             session_client_provided: session_result.client_provided,
+            request_body,
             rectifier_config,
             optimizer_config,
             copilot_optimizer_config,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -38,10 +38,10 @@ use super::{
         process_response, read_decoded_body, strip_entity_headers_for_rebuilt_body,
         strip_hop_by_hop_response_headers, usage_logging_enabled, SseUsageCollector,
     },
-    usage::logger::UsageLogger,
     server::ProxyState,
     sse::{strip_sse_field, take_sse_block},
     types::*,
+    usage::logger::UsageLogger,
     usage::parser::TokenUsage,
     ProxyError,
 };
@@ -652,7 +652,13 @@ async fn handle_claude_transform(
         .map(|c| c.capture_details)
         .unwrap_or(false)
     {
-        let request_id = uuid::Uuid::new_v4().to_string();
+        let usage = TokenUsage::from_claude_response(&anthropic_response);
+        let dedup_scope =
+            super::usage::parser::dedup_scope_for_app(ctx.app_type_str, &ctx.provider.id);
+        let request_id = usage
+            .as_ref()
+            .map(|u| u.dedup_request_id(dedup_scope))
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let response_headers_json =
             serde_json::to_string(&header_map_to_json(&response_headers)).unwrap_or_default();
         if let Err(e) = UsageLogger::new(&state.db).save_detail_capture(
@@ -1104,7 +1110,10 @@ async fn handle_codex_responses_namespace_restore(
         let capture_response_headers = response_headers.clone();
 
         let usage_collector = create_usage_collector(
-            ctx, state, status.as_u16(), &CODEX_PARSER_CONFIG,
+            ctx,
+            state,
+            status.as_u16(),
+            &CODEX_PARSER_CONFIG,
             request_id_for_detail.clone(),
         );
         let logged_stream = create_logged_passthrough_stream(
@@ -1452,7 +1461,13 @@ async fn handle_codex_chat_to_responses_transform(
         .map(|c| c.capture_details)
         .unwrap_or(false)
     {
-        let request_id = uuid::Uuid::new_v4().to_string();
+        let usage = TokenUsage::from_codex_response_auto(&responses_response);
+        let dedup_scope =
+            super::usage::parser::dedup_scope_for_app(ctx.app_type_str, &ctx.provider.id);
+        let request_id = usage
+            .as_ref()
+            .map(|u| u.dedup_request_id(dedup_scope))
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let response_headers_json =
             serde_json::to_string(&header_map_to_json(&response_headers)).unwrap_or_default();
         if let Err(e) = UsageLogger::new(&state.db).save_detail_capture(

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -7,6 +7,8 @@
 //! - 各 handler 只保留独特的业务逻辑
 //! - Claude 的格式转换逻辑保留在此文件（用于 OpenRouter 旧接口回退）
 
+use std::sync::Arc;
+
 use super::{
     content_encoding::{decompress_body, get_content_encoding, is_supported_content_encoding},
     error_mapper::{get_error_message, map_proxy_error_to_status},
@@ -32,10 +34,11 @@ use super::{
         transform_codex_responses_namespace, transform_gemini, transform_responses,
     },
     response_processor::{
-        create_logged_passthrough_stream, create_usage_collector, process_response,
-        read_decoded_body, strip_entity_headers_for_rebuilt_body,
+        create_logged_passthrough_stream, create_usage_collector, header_map_to_json,
+        process_response, read_decoded_body, strip_entity_headers_for_rebuilt_body,
         strip_hop_by_hop_response_headers, usage_logging_enabled, SseUsageCollector,
     },
+    usage::logger::UsageLogger,
     server::ProxyState,
     sse::{strip_sse_field, take_sse_block},
     types::*,
@@ -405,6 +408,7 @@ async fn handle_claude_transform(
 
     if use_streaming {
         // 根据 api_format 选择流式转换器
+        let capture_response_headers = response.headers().clone();
         let stream = response.bytes_stream();
         let sse_stream: Box<
             dyn futures::Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin,
@@ -486,12 +490,19 @@ async fn handle_claude_transform(
         // 获取流式超时配置
         let timeout_config = ctx.streaming_timeout_config();
 
+        // Streaming capture request_id channel (shared with usage collector for ID retrieval on save)
+        let request_id_for_detail = Arc::new(std::sync::Mutex::new(None::<String>));
+
         let logged_stream = create_logged_passthrough_stream(
             sse_stream,
             "Claude/OpenRouter",
             usage_collector,
             timeout_config,
             connection_guard,
+            state.clone(),
+            ctx.request_body.clone(),
+            capture_response_headers,
+            request_id_for_detail,
         );
 
         let mut headers = axum::http::HeaderMap::new();
@@ -632,6 +643,28 @@ async fn handle_claude_transform(
         log::error!("[Claude] 序列化响应失败: {e}");
         ProxyError::TransformError(format!("Failed to serialize response: {e}"))
     })?;
+
+    // Record request/response detail (only when capture_details is enabled;
+    // stores upstream raw body for troubleshooting)
+    if state
+        .db
+        .get_log_config()
+        .map(|c| c.capture_details)
+        .unwrap_or(false)
+    {
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let response_headers_json =
+            serde_json::to_string(&header_map_to_json(&response_headers)).unwrap_or_default();
+        if let Err(e) = UsageLogger::new(&state.db).save_detail_capture(
+            &request_id,
+            None,
+            Some(&ctx.request_body),
+            Some(&response_headers_json),
+            Some(&body_str),
+        ) {
+            log::warn!("[Claude] Failed to save non-streaming response detail: {e}");
+        }
+    }
 
     let body = axum::body::Body::from(response_body);
     builder.body(body).map_err(|e| {
@@ -1065,14 +1098,25 @@ async fn handle_codex_responses_namespace_restore(
                 response.bytes_stream(),
                 restore_map,
             );
-        let usage_collector =
-            create_usage_collector(ctx, state, status.as_u16(), &CODEX_PARSER_CONFIG);
+        // 流式 capture 的 request_id 传递通道
+        let request_id_for_detail = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+        let request_body = ctx.request_body.clone();
+        let capture_response_headers = response_headers.clone();
+
+        let usage_collector = create_usage_collector(
+            ctx, state, status.as_u16(), &CODEX_PARSER_CONFIG,
+            request_id_for_detail.clone(),
+        );
         let logged_stream = create_logged_passthrough_stream(
             restore_stream,
             ctx.tag,
             usage_collector,
             ctx.streaming_timeout_config(),
             connection_guard,
+            state.clone(),
+            request_body,
+            capture_response_headers,
+            request_id_for_detail,
         );
 
         let body = axum::body::Body::from_stream(logged_stream);
@@ -1192,6 +1236,7 @@ async fn handle_codex_chat_to_responses_transform(
     }
 
     if is_stream || response.is_sse() {
+        let capture_response_headers = response.headers().clone();
         let stream = response.bytes_stream();
         let sse_stream = create_responses_sse_stream_from_chat_with_context(stream, tool_context);
         let sse_stream = record_responses_sse_stream(sse_stream, state.codex_chat_history.clone());
@@ -1260,12 +1305,19 @@ async fn handle_codex_chat_to_responses_transform(
             None
         };
 
+        // Streaming capture request_id channel (shared with usage collector for ID retrieval on save)
+        let request_id_for_detail = Arc::new(std::sync::Mutex::new(None::<String>));
+
         let logged_stream = create_logged_passthrough_stream(
             sse_stream,
             ctx.tag,
             usage_collector,
             ctx.streaming_timeout_config(),
             connection_guard,
+            state.clone(),
+            ctx.request_body.clone(),
+            capture_response_headers,
+            request_id_for_detail,
         );
 
         let mut headers = axum::http::HeaderMap::new();
@@ -1391,6 +1443,28 @@ async fn handle_codex_chat_to_responses_transform(
         axum::http::header::CONTENT_TYPE,
         axum::http::HeaderValue::from_static("application/json"),
     );
+
+    // Record request/response detail (only when capture_details is enabled;
+    // stores upstream raw body for troubleshooting)
+    if state
+        .db
+        .get_log_config()
+        .map(|c| c.capture_details)
+        .unwrap_or(false)
+    {
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let response_headers_json =
+            serde_json::to_string(&header_map_to_json(&response_headers)).unwrap_or_default();
+        if let Err(e) = UsageLogger::new(&state.db).save_detail_capture(
+            &request_id,
+            None,
+            Some(&ctx.request_body),
+            Some(&response_headers_json),
+            Some(&body_str),
+        ) {
+            log::warn!("[Codex] Failed to save non-streaming response detail: {e}");
+        }
+    }
 
     let response_body = serde_json::to_vec(&responses_response).map_err(|e| {
         log::error!("[Codex] 序列化 Responses 响应失败: {e}");
@@ -1639,6 +1713,10 @@ fn build_codex_anthropic_sse_response(
         usage_collector,
         ctx.streaming_timeout_config(),
         connection_guard,
+        state.clone(),
+        String::new(),
+        axum::http::HeaderMap::new(),
+        Arc::new(std::sync::Mutex::new(None)),
     );
 
     let mut headers = axum::http::HeaderMap::new();

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -427,10 +427,14 @@ async fn handle_claude_transform(
         };
 
         // 创建使用量收集器；关闭 usage logging 时不要再解析转换后的 SSE。
+        // 流式 capture 的 request_id 通道：与 usage collector 共享，collector 解析出
+        // usage 时同步写入，供流结束落详情取用（与 usage 行关联）。
+        let request_id_for_detail = Arc::new(std::sync::Mutex::new(None::<String>));
         let usage_collector = if usage_logging_enabled(state) {
             let state = state.clone();
             let provider_id = ctx.provider.id.clone();
             let request_model = ctx.request_model.clone();
+            let request_id_sink = request_id_for_detail.clone();
             // 上游/转换层未回显模型时，优先用映射后的出站模型兜底（路由接管真值），
             // 其次才是客户端请求别名。空字符串视为缺失（转换器对无回显上游会合成 ""）。
             let fallback_model = ctx
@@ -460,6 +464,12 @@ async fn handle_claude_transform(
                         let session_id = session_id.clone();
                         let request_model = request_model.clone();
                         let outbound_model = fallback_model.clone();
+                        let dedup_scope =
+                            super::usage::parser::dedup_scope_for_app(app_type_str, &provider_id);
+                        let rid = usage.dedup_request_id(dedup_scope);
+                        if let Ok(mut guard) = request_id_sink.lock() {
+                            *guard = Some(rid.clone());
+                        }
 
                         tokio::spawn(async move {
                             log_usage(
@@ -489,9 +499,6 @@ async fn handle_claude_transform(
 
         // 获取流式超时配置
         let timeout_config = ctx.streaming_timeout_config();
-
-        // Streaming capture request_id channel (shared with usage collector for ID retrieval on save)
-        let request_id_for_detail = Arc::new(std::sync::Mutex::new(None::<String>));
 
         let logged_stream = create_logged_passthrough_stream(
             sse_stream,
@@ -1250,10 +1257,14 @@ async fn handle_codex_chat_to_responses_transform(
         let sse_stream = create_responses_sse_stream_from_chat_with_context(stream, tool_context);
         let sse_stream = record_responses_sse_stream(sse_stream, state.codex_chat_history.clone());
 
+        // 流式 capture 的 request_id 通道：与 usage collector 共享，collector 解析出
+        // usage 时同步写入，供流结束落详情取用（与 usage 行关联）。
+        let request_id_for_detail = Arc::new(std::sync::Mutex::new(None::<String>));
         let usage_collector = if usage_logging_enabled(state) {
             let state = state.clone();
             let provider_id = ctx.provider.id.clone();
             let request_model = ctx.request_model.clone();
+            let request_id_sink = request_id_for_detail.clone();
             // 接管/模型覆写场景的归因兜底：出站真值优先于客户端请求别名
             let fallback_model = ctx
                 .outbound_model
@@ -1290,6 +1301,12 @@ async fn handle_codex_chat_to_responses_transform(
                     let request_model = request_model.clone();
                     let outbound_model = fallback_model.clone();
                     let session_id = session_id.clone();
+                    let dedup_scope =
+                        super::usage::parser::dedup_scope_for_app(app_type_str, &provider_id);
+                    let rid = usage.dedup_request_id(dedup_scope);
+                    if let Ok(mut guard) = request_id_sink.lock() {
+                        *guard = Some(rid.clone());
+                    }
 
                     tokio::spawn(async move {
                         log_usage(
@@ -1313,9 +1330,6 @@ async fn handle_codex_chat_to_responses_transform(
         } else {
             None
         };
-
-        // Streaming capture request_id channel (shared with usage collector for ID retrieval on save)
-        let request_id_for_detail = Arc::new(std::sync::Mutex::new(None::<String>));
 
         let logged_stream = create_logged_passthrough_stream(
             sse_stream,
@@ -1520,6 +1534,7 @@ async fn handle_codex_anthropic_to_responses_transform(
     // explicit JSON media type. Explicit JSON is buffered below so 2xx error
     // envelopes and gateways that ignore stream:true can be converted faithfully.
     if response.is_sse() || (is_stream && !response.is_json()) {
+        let capture_headers = response.headers().clone();
         let stream = response.bytes_stream();
         let sse_stream =
             create_responses_sse_stream_from_anthropic_with_context(stream, codex_tool_context);
@@ -1529,6 +1544,7 @@ async fn handle_codex_anthropic_to_responses_transform(
             state,
             status,
             connection_guard,
+            capture_headers,
         );
     }
 
@@ -1577,6 +1593,7 @@ async fn handle_codex_anthropic_to_responses_transform(
             state,
             status,
             connection_guard,
+            response_headers.clone(),
         );
     }
 
@@ -1664,11 +1681,16 @@ fn build_codex_anthropic_sse_response(
     state: &ProxyState,
     status: StatusCode,
     connection_guard: Option<ActiveConnectionGuard>,
+    response_headers: axum::http::HeaderMap,
 ) -> Result<axum::response::Response, ProxyError> {
+    // 流式 capture 的 request_id 通道：与 usage collector 共享，collector 解析出
+    // usage 时同步写入，供流结束落详情取用（与 usage 行关联）。
+    let request_id_for_detail = Arc::new(std::sync::Mutex::new(None::<String>));
     let usage_collector = if usage_logging_enabled(state) {
         let state = state.clone();
         let provider_id = ctx.provider.id.clone();
         let request_model = ctx.request_model.clone();
+        let request_id_sink = request_id_for_detail.clone();
         let fallback_model = ctx
             .outbound_model
             .clone()
@@ -1698,6 +1720,12 @@ fn build_codex_anthropic_sse_response(
                 let request_model = request_model.clone();
                 let outbound_model = fallback_model.clone();
                 let session_id = session_id.clone();
+                let dedup_scope =
+                    super::usage::parser::dedup_scope_for_app(app_type_str, &provider_id);
+                let rid = usage.dedup_request_id(dedup_scope);
+                if let Ok(mut guard) = request_id_sink.lock() {
+                    *guard = Some(rid.clone());
+                }
 
                 tokio::spawn(async move {
                     log_usage(
@@ -1729,9 +1757,9 @@ fn build_codex_anthropic_sse_response(
         ctx.streaming_timeout_config(),
         connection_guard,
         state.clone(),
-        String::new(),
-        axum::http::HeaderMap::new(),
-        Arc::new(std::sync::Mutex::new(None)),
+        ctx.request_body.clone(),
+        response_headers,
+        request_id_for_detail,
     );
 
     let mut headers = axum::http::HeaderMap::new();

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -168,6 +168,8 @@ pub async fn handle_streaming(
 
     let mut response_headers = response.headers().clone();
     strip_hop_by_hop_response_headers(&mut response_headers);
+    // capture needs a response headers clone (passed to stream end for saving)
+    let capture_response_headers = response_headers.clone();
 
     let mut builder = axum::response::Response::builder().status(status);
 
@@ -179,8 +181,15 @@ pub async fn handle_streaming(
     // 创建字节流
     let stream = response.bytes_stream();
 
+    // Streaming capture request_id channel (shared with usage collector for ID retrieval on save)
+    let request_id_for_detail = Arc::new(std::sync::Mutex::new(None::<String>));
+    let request_body = ctx.request_body.clone();
+
     // 创建使用量收集器；关闭 usage logging 时不要在流式热路径上解析每个 SSE event。
-    let usage_collector = create_usage_collector(ctx, state, status.as_u16(), parser_config);
+    let usage_collector = create_usage_collector(
+        ctx, state, status.as_u16(), parser_config,
+        request_id_for_detail.clone(),
+    );
 
     // 获取流式超时配置
     let timeout_config = ctx.streaming_timeout_config();
@@ -192,6 +201,10 @@ pub async fn handle_streaming(
         usage_collector,
         timeout_config,
         connection_guard,
+        state.clone(),
+        request_body,
+        capture_response_headers,
+        request_id_for_detail,
     );
 
     let body = axum::body::Body::from_stream(logged_stream);
@@ -231,6 +244,9 @@ pub async fn handle_non_streaming(
     );
 
     // 解析并记录使用量。关闭 usage logging 时直接跳过，避免非流式响应整包 JSON parse。
+    // Also used for capture_details: get request_id from usage to correlate detail records.
+    let mut request_id_for_detail: Option<String> = None;
+
     if usage_logging_enabled(state) {
         if let Ok(json_value) = serde_json::from_slice::<Value>(&body_bytes) {
             // 解析使用量
@@ -251,6 +267,10 @@ pub async fn handle_non_streaming(
                     .or_else(|| ctx.outbound_model.clone())
                     .unwrap_or_else(|| ctx.request_model.clone());
 
+                let dedup_scope =
+                    (ctx.app_type_str != "claude").then_some((ctx.app_type_str, ctx.provider.id.as_str()));
+                request_id_for_detail = Some(usage.dedup_request_id(dedup_scope));
+
                 spawn_log_usage(
                     state,
                     ctx,
@@ -259,6 +279,7 @@ pub async fn handle_non_streaming(
                     &ctx.request_model,
                     status.as_u16(),
                     false,
+                    request_id_for_detail.clone(),
                 );
             } else {
                 let model = json_value
@@ -276,6 +297,7 @@ pub async fn handle_non_streaming(
                     &ctx.request_model,
                     status.as_u16(),
                     false,
+                    None,
                 );
                 log::debug!(
                     "[{}] 未能解析 usage 信息，跳过记录",
@@ -296,10 +318,35 @@ pub async fn handle_non_streaming(
                 &ctx.request_model,
                 status.as_u16(),
                 false,
+                None,
             );
         }
     } else {
         log::debug!("[{}] usage logging 已关闭，跳过非流式 usage 解析", ctx.tag);
+    }
+
+    // Record request/response detail (only when capture_details is enabled)
+    let capture_details = state.db.get_log_config()
+        .map(|c| c.capture_details)
+        .unwrap_or(false);
+    if capture_details {
+        let request_id = request_id_for_detail
+            .take()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        use super::usage::logger::UsageLogger;
+        let logger = UsageLogger::new(&state.db);
+        let response_body_str = String::from_utf8_lossy(&body_bytes);
+        let response_headers_json = serde_json::to_string(&header_map_to_json(&response_headers))
+            .unwrap_or_default();
+        if let Err(e) = logger.save_detail_capture(
+            &request_id,
+            None,
+            Some(&ctx.request_body),
+            Some(&response_headers_json),
+            Some(&response_body_str),
+        ) {
+            log::warn!("Failed to save non-streaming response detail: {e}");
+        }
     }
 
     // 构建响应
@@ -461,6 +508,7 @@ pub(crate) fn create_usage_collector(
     state: &ProxyState,
     status_code: u16,
     parser_config: &UsageParserConfig,
+    request_id_for_detail: Arc<std::sync::Mutex<Option<String>>>,
 ) -> Option<SseUsageCollector> {
     let logging_enabled = state
         .config
@@ -498,6 +546,14 @@ pub(crate) fn create_usage_collector(
                 let model = model_extractor(&events, &fallback_model);
                 let latency_ms = start_time.elapsed().as_millis() as u64;
 
+                // Extract request_id synchronously for streaming capture
+                let dedup_scope =
+                    (app_type_str != "claude").then_some((app_type_str, provider_id.as_str()));
+                let rid = usage.dedup_request_id(dedup_scope);
+                if let Ok(mut guard) = request_id_for_detail.lock() {
+                    *guard = Some(rid.clone());
+                }
+
                 let state = state.clone();
                 let provider_id = provider_id.clone();
                 let session_id = session_id.clone();
@@ -518,6 +574,7 @@ pub(crate) fn create_usage_collector(
                         true, // is_streaming
                         status_code,
                         Some(session_id),
+                        None, // streaming request_id resolved inside dedup_request_id
                     )
                     .await;
                 });
@@ -544,6 +601,7 @@ pub(crate) fn create_usage_collector(
                         true, // is_streaming
                         status_code,
                         Some(session_id),
+                        None, // streaming request_id resolved inside dedup_request_id
                     )
                     .await;
                 });
@@ -562,6 +620,7 @@ fn spawn_log_usage(
     request_model: &str,
     status_code: u16,
     is_streaming: bool,
+    request_id: Option<String>,
 ) {
     // Check enable_logging before spawning the log task
     if let Ok(config) = state.config.try_read() {
@@ -597,6 +656,7 @@ fn spawn_log_usage(
             is_streaming,
             status_code,
             Some(session_id),
+            request_id,
         )
         .await;
     });
@@ -630,6 +690,7 @@ async fn log_usage_internal(
     is_streaming: bool,
     status_code: u16,
     session_id: Option<String>,
+    request_id: Option<String>,
 ) {
     use super::usage::logger::UsageLogger;
 
@@ -643,7 +704,7 @@ async fn log_usage_internal(
     };
 
     let dedup_scope = super::usage::parser::dedup_scope_for_app(app_type, provider_id);
-    let request_id = usage.dedup_request_id(dedup_scope);
+    let request_id = request_id.unwrap_or_else(|| usage.dedup_request_id(dedup_scope));
 
     log::debug!(
         "[{app_type}] 记录请求日志: id={request_id}, provider={provider_id}, model={model}, streaming={is_streaming}, status={status_code}, latency_ms={latency_ms}, first_token_ms={first_token_ms:?}, session={}, input={}, output={}, cache_read={}, cache_creation={}",
@@ -681,6 +742,10 @@ pub fn create_logged_passthrough_stream(
     usage_collector: Option<SseUsageCollector>,
     timeout_config: StreamingTimeoutConfig,
     connection_guard: Option<ActiveConnectionGuard>,
+    state: ProxyState,
+    request_body: String,
+    response_headers: axum::http::HeaderMap,
+    request_id_sink: Arc<std::sync::Mutex<Option<String>>>,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     async_stream::stream! {
         let _conn_guard = connection_guard;
@@ -688,11 +753,21 @@ pub fn create_logged_passthrough_stream(
         let mut utf8_remainder: Vec<u8> = Vec::new();
         let mut collector = usage_collector;
         let mut finish_guard = collector.clone().map(SseUsageFinishGuard::new);
+        // Whether to save detail records: determines if SSE data should be parsed into JSON event arrays
+        let capture_details = state
+            .db
+            .get_log_config()
+            .map(|c| c.capture_details)
+            .unwrap_or(false);
         let inspect_sse_events =
-            collector.is_some() || log::log_enabled!(log::Level::Debug);
+            collector.is_some() || capture_details || log::log_enabled!(log::Level::Debug);
         let mut is_first_chunk = true;
 
-        // 超时配置
+        // Raw SSE text fallback; when capture is enabled, prefer parsed JSON event arrays
+        let mut raw_response = String::new();
+        let mut sse_events: Vec<Value> = Vec::new();
+
+        // Timeout configuration
         let first_byte_timeout = if timeout_config.first_byte_timeout > 0 {
             Some(Duration::from_secs(timeout_config.first_byte_timeout))
         } else {
@@ -740,25 +815,35 @@ pub fn create_logged_passthrough_stream(
                         );
                     }
                     is_first_chunk = false;
+
+                    // Fallback: save raw SSE text even when JSON parsing fails
+                    if capture_details {
+                        if let Ok(chunk_text) = std::str::from_utf8(&bytes) {
+                            raw_response.push_str(chunk_text);
+                        }
+                    }
+
                     if inspect_sse_events {
                         crate::proxy::sse::append_utf8_safe(&mut buffer, &mut utf8_remainder, &bytes);
 
-                        // 尝试解析并记录完整的 SSE 事件
+                        // Parse complete SSE events: shared between usage collection and detail JSON rebuild
                         while let Some(event_text) = take_sse_block(&mut buffer) {
                             if !event_text.trim().is_empty() {
-                                // 提取 data 部分；只有 usage collector 存在时才解析 JSON。
                                 for line in event_text.lines() {
                                     if let Some(data) = strip_sse_field(line, "data") {
                                         if data.trim() != "[DONE]" {
-                                            let collected = match &collector {
-                                                Some(c) if c.should_collect(data) => {
-                                                    match serde_json::from_str::<Value>(data) {
-                                                        Ok(json_value) => {
-                                                            c.push(json_value).await;
-                                                            true
-                                                        }
-                                                        Err(_) => false,
-                                                    }
+                                            let parsed = serde_json::from_str::<Value>(data).ok();
+                                            if let Some(ref json_value) = parsed {
+                                                if capture_details {
+                                                    sse_events.push(json_value.clone());
+                                                }
+                                            }
+                                            let collected = match (&collector, &parsed) {
+                                                (Some(c), Some(json_value))
+                                                    if c.should_collect(data) =>
+                                                {
+                                                    c.push(json_value.clone()).await;
+                                                    true
                                                 }
                                                 _ => false,
                                             };
@@ -795,7 +880,48 @@ pub fn create_logged_passthrough_stream(
         if let Some(guard) = &mut finish_guard {
             guard.disarm();
         }
+
+        // Streaming capture: prefer SSE data events rebuilt as JSON array, fall back to raw SSE on parse failure
+        if capture_details {
+            let request_id = request_id_sink
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            use super::usage::logger::UsageLogger;
+            let logger = UsageLogger::new(&state.db);
+            let response_headers_json =
+                serde_json::to_string(&header_map_to_json(&response_headers))
+                    .unwrap_or_default();
+            let response_body_for_store = if sse_events.is_empty() {
+                raw_response
+            } else {
+                let events_json = Value::Array(sse_events);
+                serde_json::to_string_pretty(&events_json)
+                    .or_else(|_| serde_json::to_string(&events_json))
+                    .unwrap_or(raw_response)
+            };
+            if let Err(e) = logger.save_detail_capture(
+                &request_id,
+                None,
+                Some(&request_body),
+                Some(&response_headers_json),
+                Some(&response_body_for_store),
+            ) {
+                log::warn!("Failed to save streaming response detail: {e}");
+            }
+        }
     }
+}
+
+/// Convert HeaderMap to JSON Value (for storing request/response headers)
+pub fn header_map_to_json(headers: &HeaderMap) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for (key, value) in headers.iter() {
+        let value_str = value.to_str().unwrap_or("<non-utf8>").to_string();
+        map.insert(key.to_string(), serde_json::Value::String(value_str));
+    }
+    serde_json::Value::Object(map)
 }
 
 fn is_safe_diagnostic_header(name: &str) -> bool {

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -270,8 +270,8 @@ pub async fn handle_non_streaming(
                     .or_else(|| ctx.outbound_model.clone())
                     .unwrap_or_else(|| ctx.request_model.clone());
 
-                let dedup_scope = (ctx.app_type_str != "claude")
-                    .then_some((ctx.app_type_str, ctx.provider.id.as_str()));
+                let dedup_scope =
+                    super::usage::parser::dedup_scope_for_app(ctx.app_type_str, &ctx.provider.id);
                 request_id_for_detail = Some(usage.dedup_request_id(dedup_scope));
 
                 spawn_log_usage(
@@ -553,7 +553,7 @@ pub(crate) fn create_usage_collector(
 
                 // Extract request_id synchronously for streaming capture
                 let dedup_scope =
-                    (app_type_str != "claude").then_some((app_type_str, provider_id.as_str()));
+                    super::usage::parser::dedup_scope_for_app(app_type_str, provider_id.as_str());
                 let rid = usage.dedup_request_id(dedup_scope);
                 if let Ok(mut guard) = request_id_for_detail.lock() {
                     *guard = Some(rid.clone());
@@ -564,6 +564,7 @@ pub(crate) fn create_usage_collector(
                 let session_id = session_id.clone();
                 let request_model = request_model.clone();
                 let outbound_model = fallback_model.clone();
+                let rid_for_log = rid.clone();
 
                 tokio::spawn(async move {
                     log_usage_internal(
@@ -579,7 +580,7 @@ pub(crate) fn create_usage_collector(
                         true, // is_streaming
                         status_code,
                         Some(session_id),
-                        None, // streaming request_id resolved inside dedup_request_id
+                        Some(rid_for_log),
                     )
                     .await;
                 });
@@ -1211,6 +1212,7 @@ mod tests {
             false,
             200,
             None,
+            None,
         )
         .await;
 
@@ -1280,6 +1282,7 @@ mod tests {
             None,
             false,
             200,
+            None,
             None,
         )
         .await;
@@ -1360,6 +1363,7 @@ mod tests {
             None,
             false,
             200,
+            None,
             None,
         )
         .await;

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -187,7 +187,10 @@ pub async fn handle_streaming(
 
     // 创建使用量收集器；关闭 usage logging 时不要在流式热路径上解析每个 SSE event。
     let usage_collector = create_usage_collector(
-        ctx, state, status.as_u16(), parser_config,
+        ctx,
+        state,
+        status.as_u16(),
+        parser_config,
         request_id_for_detail.clone(),
     );
 
@@ -267,8 +270,8 @@ pub async fn handle_non_streaming(
                     .or_else(|| ctx.outbound_model.clone())
                     .unwrap_or_else(|| ctx.request_model.clone());
 
-                let dedup_scope =
-                    (ctx.app_type_str != "claude").then_some((ctx.app_type_str, ctx.provider.id.as_str()));
+                let dedup_scope = (ctx.app_type_str != "claude")
+                    .then_some((ctx.app_type_str, ctx.provider.id.as_str()));
                 request_id_for_detail = Some(usage.dedup_request_id(dedup_scope));
 
                 spawn_log_usage(
@@ -326,7 +329,9 @@ pub async fn handle_non_streaming(
     }
 
     // Record request/response detail (only when capture_details is enabled)
-    let capture_details = state.db.get_log_config()
+    let capture_details = state
+        .db
+        .get_log_config()
         .map(|c| c.capture_details)
         .unwrap_or(false);
     if capture_details {
@@ -336,8 +341,8 @@ pub async fn handle_non_streaming(
         use super::usage::logger::UsageLogger;
         let logger = UsageLogger::new(&state.db);
         let response_body_str = String::from_utf8_lossy(&body_bytes);
-        let response_headers_json = serde_json::to_string(&header_map_to_json(&response_headers))
-            .unwrap_or_default();
+        let response_headers_json =
+            serde_json::to_string(&header_map_to_json(&response_headers)).unwrap_or_default();
         if let Err(e) = logger.save_detail_capture(
             &request_id,
             None,
@@ -612,6 +617,7 @@ pub(crate) fn create_usage_collector(
 }
 
 /// 异步记录使用量
+#[allow(clippy::too_many_arguments)]
 fn spawn_log_usage(
     state: &ProxyState,
     ctx: &RequestContext,
@@ -736,6 +742,7 @@ async fn log_usage_internal(
 }
 
 /// 创建带日志记录和超时控制的透传流
+#[allow(clippy::too_many_arguments)]
 pub fn create_logged_passthrough_stream(
     stream: impl Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
     tag: &'static str,

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -509,6 +509,7 @@ mod tests {
         let config = LogConfig {
             enabled: false,
             level: "debug".to_string(),
+            capture_details: false,
         };
         assert_eq!(config.to_level_filter(), log::LevelFilter::Off);
     }
@@ -518,10 +519,12 @@ mod tests {
         let config = LogConfig {
             enabled: true,
             level: "debug".to_string(),
+            capture_details: true,
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: LogConfig = serde_json::from_str(&json).unwrap();
         assert!(parsed.enabled);
         assert_eq!(parsed.level, "debug");
+        assert!(parsed.capture_details);
     }
 }

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -340,6 +340,9 @@ pub struct LogConfig {
     /// 日志级别: error, warn, info, debug, trace
     #[serde(default = "default_log_level")]
     pub level: String,
+    /// 是否记录完整请求/响应体（默认关闭，仅建议调试时开启）
+    #[serde(default)]
+    pub capture_details: bool,
 }
 
 impl Default for LogConfig {
@@ -347,6 +350,7 @@ impl Default for LogConfig {
         Self {
             enabled: true,
             level: "info".to_string(),
+            capture_details: false,
         }
     }
 }

--- a/src-tauri/src/proxy/usage/logger.rs
+++ b/src-tauri/src/proxy/usage/logger.rs
@@ -332,6 +332,66 @@ impl<'a> UsageLogger<'a> {
         self.log_request(&log)
     }
 
+    /// Save request/response detail payload (raw body).
+    ///
+    /// Only called when `LogConfig.capture_details = true`.
+    /// Writes to the full proxy_request_log_details schema columns
+    /// (request_body_full / request_headers_json etc.), compatible with my-ccs-dev history tables.
+    /// Also cleans up detail records older than 30 days.
+    pub fn save_detail_capture(
+        &self,
+        request_id: &str,
+        request_headers: Option<&str>,
+        request_body: Option<&str>,
+        response_headers: Option<&str>,
+        response_body: Option<&str>,
+    ) -> Result<(), AppError> {
+        let conn = crate::database::lock_conn!(self.db.conn);
+        let created_at = chrono::Utc::now().timestamp();
+        conn.execute(
+            "INSERT OR REPLACE INTO proxy_request_log_details (
+                request_id, log_level, route_trace_json, mapping_json,
+                request_headers_json, request_body_preview, request_body_full,
+                response_headers_json, response_body_preview, response_body_full,
+                upstream_error_json, created_at
+             ) VALUES (?1, 'full', NULL, NULL, ?2, NULL, ?3, ?4, NULL, ?5, NULL, ?6)",
+            rusqlite::params![
+                request_id,
+                request_headers,
+                request_body,
+                response_headers,
+                response_body,
+                created_at,
+            ],
+        )
+        .map_err(|e| AppError::Database(format!("Failed to save request detail: {e}")))?;
+
+        // Prefer cleanup by detail table's own created_at column;
+        // fall back to joining proxy_request_logs for old simplified tables without the column
+        let deleted = conn
+            .execute(
+                "DELETE FROM proxy_request_log_details
+                 WHERE created_at IS NOT NULL
+                   AND created_at < unixepoch('now') - 2592000",
+                [],
+            )
+            .or_else(|_| {
+                conn.execute(
+                    "DELETE FROM proxy_request_log_details WHERE request_id IN (
+                        SELECT request_id FROM proxy_request_logs
+                        WHERE created_at < unixepoch('now') - 2592000
+                    )",
+                    [],
+                )
+            })
+            .unwrap_or(0);
+        if deleted > 0 {
+            log::debug!("Cleaned up {deleted} expired request detail records");
+        }
+
+        Ok(())
+    }
+
     /// 获取模型定价
     pub fn get_model_pricing(&self, model_id: &str) -> Result<Option<ModelPricing>, AppError> {
         let conn = crate::database::lock_conn!(self.db.conn);

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -1653,10 +1653,10 @@ impl Database {
         let detail_sql = format!(
             "SELECT l.request_id, l.provider_id, {detail_pname} as provider_name, l.app_type, l.model,
                     l.request_model, l.cost_multiplier,
-                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-                    input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd, total_cost_usd,
-                    is_streaming, latency_ms, first_token_ms, duration_ms,
-                    status_code, error_message, created_at, l.data_source, l.pricing_model,
+                    l.input_tokens, l.output_tokens, l.cache_read_tokens, l.cache_creation_tokens,
+                    l.input_cost_usd, l.output_cost_usd, l.cache_read_cost_usd, l.cache_creation_cost_usd, l.total_cost_usd,
+                    l.is_streaming, l.latency_ms, l.first_token_ms, l.duration_ms,
+                    l.status_code, l.error_message, l.created_at, l.data_source, l.pricing_model,
                     l.input_token_semantics
              FROM proxy_request_logs l
              LEFT JOIN providers p ON l.provider_id = p.id AND l.app_type = p.app_type

--- a/src/components/settings/LogConfigPanel.tsx
+++ b/src/components/settings/LogConfigPanel.tsx
@@ -19,6 +19,7 @@ export function LogConfigPanel() {
   const [config, setConfig] = useState<LogConfig>({
     enabled: true,
     level: "info",
+    captureDetails: false,
   });
   const [isLoading, setIsLoading] = useState(true);
 
@@ -84,6 +85,23 @@ export function LogConfigPanel() {
             ))}
           </SelectContent>
         </Select>
+      </div>
+
+      {/* 请求/响应体捕获开关 */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <Label>{t("settings.advanced.logConfig.captureDetails")}</Label>
+          <p className="text-xs text-muted-foreground">
+            {t("settings.advanced.logConfig.captureDetailsDescription")}
+          </p>
+        </div>
+        <Switch
+          checked={config.captureDetails}
+          disabled={!config.enabled}
+          onCheckedChange={(checked) =>
+            handleChange({ captureDetails: checked })
+          }
+        />
       </div>
 
       {/* 日志级别说明 */}

--- a/src/components/usage/RequestDetailPanel.tsx
+++ b/src/components/usage/RequestDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dialog,
@@ -5,7 +6,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useRequestDetail } from "@/lib/query/usage";
+import { useRequestDetailPayload } from "@/lib/api/detailCapture";
 import { getFreshInputTokens, isUnpricedUsage } from "@/types/usage";
 
 interface RequestDetailPanelProps {
@@ -18,7 +21,9 @@ export function RequestDetailPanel({
   onClose,
 }: RequestDetailPanelProps) {
   const { t, i18n } = useTranslation();
-  const { data: request, isLoading } = useRequestDetail(requestId);
+  const { data: request, isLoading, error } = useRequestDetail(requestId);
+  const { data: payload } = useRequestDetailPayload(requestId);
+  const [activeTab, setActiveTab] = useState("overview");
   const dateLocale =
     i18n.language === "zh"
       ? "zh-CN"
@@ -31,8 +36,28 @@ export function RequestDetailPanel({
   if (isLoading) {
     return (
       <Dialog open onOpenChange={onClose}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-3xl">
           <div className="h-[400px] animate-pulse rounded bg-gray-100" />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  if (error) {
+    return (
+      <Dialog open onOpenChange={onClose}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>{t("usage.requestDetail", "请求详情")}</DialogTitle>
+          </DialogHeader>
+          <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+            <h3 className="mb-2 font-semibold text-red-800">
+              {t("usage.error", "错误")}
+            </h3>
+            <p className="text-sm text-red-700 font-mono whitespace-pre-wrap break-all">
+              {error instanceof Error ? error.message : String(error)}
+            </p>
+          </div>
         </DialogContent>
       </Dialog>
     );
@@ -41,7 +66,7 @@ export function RequestDetailPanel({
   if (!request) {
     return (
       <Dialog open onOpenChange={onClose}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-3xl">
           <DialogHeader>
             <DialogTitle>{t("usage.requestDetail", "请求详情")}</DialogTitle>
           </DialogHeader>
@@ -57,268 +82,352 @@ export function RequestDetailPanel({
   const isCacheInclusive = request.inputTokens !== freshInput;
   const unpriced = isUnpricedUsage(request);
 
+  const hasRequestDetail = payload?.requestBody || payload?.requestHeaders;
+  const hasResponseDetail = payload?.responseBody || payload?.responseHeaders;
+
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+      <DialogContent className="max-w-3xl max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>{t("usage.requestDetail", "请求详情")}</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4">
-          {/* 基本信息 */}
-          <div className="rounded-lg border p-4">
-            <h3 className="mb-3 font-semibold">
-              {t("usage.basicInfo", "基本信息")}
-            </h3>
-            <dl className="grid grid-cols-2 gap-3 text-sm">
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.requestId", "请求ID")}
-                </dt>
-                <dd className="font-mono">{request.requestId}</dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.time", "时间")}
-                </dt>
-                <dd>
-                  {new Date(request.createdAt * 1000).toLocaleString(
-                    dateLocale,
-                  )}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.provider", "供应商")}
-                </dt>
-                <dd className="text-sm">
-                  <span className="font-medium">
-                    {request.providerName || t("usage.unknownProvider", "未知")}
-                  </span>
-                  <span className="ml-2 font-mono text-xs text-muted-foreground">
-                    {request.providerId}
-                  </span>
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.appType", "应用类型")}
-                </dt>
-                <dd>{request.appType}</dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.model", "模型")}
-                </dt>
-                <dd className="font-mono">{request.model}</dd>
-                {request.requestModel &&
-                  request.requestModel !== request.model && (
-                    <>
-                      <dt className="mt-1 text-muted-foreground">
-                        {t("usage.requestModel", "请求模型")}
-                      </dt>
-                      <dd className="font-mono text-xs">
-                        {request.requestModel}
-                      </dd>
-                    </>
-                  )}
-                {request.pricingModel &&
-                  request.pricingModel !== request.model && (
-                    <>
-                      <dt className="mt-1 text-muted-foreground">
-                        {t("usage.pricingModel", "计价模型")}
-                      </dt>
-                      <dd className="font-mono text-xs">
-                        {request.pricingModel}
-                      </dd>
-                    </>
-                  )}
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.status", "状态")}
-                </dt>
-                <dd>
-                  <span
-                    className={`inline-flex rounded-full px-2 py-1 text-xs ${
-                      request.statusCode >= 200 && request.statusCode < 300
-                        ? "bg-green-100 text-green-800"
-                        : "bg-red-100 text-red-800"
-                    }`}
-                  >
-                    {request.statusCode}
-                  </span>
-                </dd>
-              </div>
-            </dl>
-          </div>
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="flex-1 flex flex-col min-h-0"
+        >
+          <TabsList>
+            <TabsTrigger value="overview">
+              {t("usage.detailTabs.overview", "概览")}
+            </TabsTrigger>
+            <TabsTrigger value="request" disabled={!hasRequestDetail}>
+              {t("usage.detailTabs.request", "请求详情")}
+            </TabsTrigger>
+            <TabsTrigger value="response" disabled={!hasResponseDetail}>
+              {t("usage.detailTabs.response", "响应详情")}
+            </TabsTrigger>
+          </TabsList>
 
-          {/* Token 使用量 */}
-          <div className="rounded-lg border p-4">
-            <h3 className="mb-3 font-semibold">
-              {t("usage.tokenUsage", "Token 使用量")}
-            </h3>
-            <dl className="grid grid-cols-2 gap-3 text-sm">
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.inputTokens", "输入 Tokens")}
-                </dt>
-                <dd className="font-mono">
-                  {freshInput.toLocaleString()}
-                  {isCacheInclusive && (
-                    <span className="ml-2 text-xs text-muted-foreground/70 font-normal">
-                      ({t("usage.rawInputLabel", "原始")}:{" "}
-                      {request.inputTokens.toLocaleString()})
-                    </span>
-                  )}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.outputTokens", "输出 Tokens")}
-                </dt>
-                <dd className="font-mono">
-                  {request.outputTokens.toLocaleString()}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.cacheReadTokens", "缓存读取")}
-                </dt>
-                <dd className="font-mono">
-                  {request.cacheReadTokens.toLocaleString()}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.cacheCreationTokens", "缓存写入")}
-                </dt>
-                <dd className="font-mono">
-                  {request.cacheCreationTokens.toLocaleString()}
-                </dd>
-              </div>
-              <div className="col-span-2">
-                <dt className="text-muted-foreground">
-                  {t("usage.totalTokens", "总计")}
-                </dt>
-                <dd className="text-lg font-semibold">
-                  {(freshInput + request.outputTokens).toLocaleString()}
-                </dd>
-              </div>
-            </dl>
-          </div>
-
-          {/* 成本明细 */}
-          <div className="rounded-lg border p-4">
-            <h3 className="mb-3 font-semibold">
-              {t("usage.costBreakdown", "成本明细")}
-            </h3>
-            <dl className="grid grid-cols-2 gap-3 text-sm">
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.inputCost", "输入成本")}
-                  <span className="ml-1 text-xs">
-                    ({t("usage.baseCost", "基础")})
-                  </span>
-                </dt>
-                <dd className="font-mono">
-                  ${parseFloat(request.inputCostUsd).toFixed(6)}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.outputCost", "输出成本")}
-                  <span className="ml-1 text-xs">
-                    ({t("usage.baseCost", "基础")})
-                  </span>
-                </dt>
-                <dd className="font-mono">
-                  ${parseFloat(request.outputCostUsd).toFixed(6)}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.cacheReadCost", "缓存读取成本")}
-                  <span className="ml-1 text-xs">
-                    ({t("usage.baseCost", "基础")})
-                  </span>
-                </dt>
-                <dd className="font-mono">
-                  ${parseFloat(request.cacheReadCostUsd).toFixed(6)}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.cacheCreationCost", "缓存写入成本")}
-                  <span className="ml-1 text-xs">
-                    ({t("usage.baseCost", "基础")})
-                  </span>
-                </dt>
-                <dd className="font-mono">
-                  ${parseFloat(request.cacheCreationCostUsd).toFixed(6)}
-                </dd>
-              </div>
-              {/* 显示成本倍率（如果不等于1） */}
-              {request.costMultiplier &&
-                parseFloat(request.costMultiplier) !== 1 && (
-                  <div className="col-span-2 border-t pt-3">
+          {/* 概览 Tab */}
+          <TabsContent value="overview" className="flex-1 overflow-y-auto min-h-0">
+            <div className="space-y-4">
+              {/* 基本信息 */}
+              <div className="rounded-lg border p-4">
+                <h3 className="mb-3 font-semibold">
+                  {t("usage.basicInfo", "基本信息")}
+                </h3>
+                <dl className="grid grid-cols-2 gap-3 text-sm">
+                  <div>
                     <dt className="text-muted-foreground">
-                      {t("usage.costMultiplier", "成本倍率")}
+                      {t("usage.requestId", "请求ID")}
                     </dt>
-                    <dd className="font-mono">×{request.costMultiplier}</dd>
+                    <dd className="font-mono">{request.requestId}</dd>
                   </div>
-                )}
-              <div
-                className={`col-span-2 ${request.costMultiplier && parseFloat(request.costMultiplier) !== 1 ? "" : "border-t"} pt-3`}
-              >
-                <dt className="text-muted-foreground">
-                  {t("usage.totalCost", "总成本")}
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.time", "时间")}
+                    </dt>
+                    <dd>
+                      {new Date(request.createdAt * 1000).toLocaleString(
+                        dateLocale,
+                      )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.provider", "供应商")}
+                    </dt>
+                    <dd className="text-sm">
+                      <span className="font-medium">
+                        {request.providerName || t("usage.unknownProvider", "未知")}
+                      </span>
+                      <span className="ml-2 font-mono text-xs text-muted-foreground">
+                        {request.providerId}
+                      </span>
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.appType", "应用类型")}
+                    </dt>
+                    <dd>{request.appType}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.model", "模型")}
+                    </dt>
+                    <dd className="font-mono">{request.model}</dd>
+                    {request.requestModel &&
+                      request.requestModel !== request.model && (
+                        <>
+                          <dt className="mt-1 text-muted-foreground">
+                            {t("usage.requestModel", "请求模型")}
+                          </dt>
+                          <dd className="font-mono text-xs">
+                            {request.requestModel}
+                          </dd>
+                        </>
+                      )}
+                    {request.pricingModel &&
+                      request.pricingModel !== request.model && (
+                        <>
+                          <dt className="mt-1 text-muted-foreground">
+                            {t("usage.pricingModel", "计价模型")}
+                          </dt>
+                          <dd className="font-mono text-xs">
+                            {request.pricingModel}
+                          </dd>
+                        </>
+                      )}
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.status", "状态")}
+                    </dt>
+                    <dd>
+                      <span
+                        className={`inline-flex rounded-full px-2 py-1 text-xs ${
+                          request.statusCode >= 200 && request.statusCode < 300
+                            ? "bg-green-100 text-green-800"
+                            : "bg-red-100 text-red-800"
+                        }`}
+                      >
+                        {request.statusCode}
+                      </span>
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+
+              {/* Token 使用量 */}
+              <div className="rounded-lg border p-4">
+                <h3 className="mb-3 font-semibold">
+                  {t("usage.tokenUsage", "Token 使用量")}
+                </h3>
+                <dl className="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.inputTokens", "输入 Tokens")}
+                    </dt>
+                    <dd className="font-mono">
+                      {freshInput.toLocaleString()}
+                      {isCacheInclusive && (
+                        <span className="ml-2 text-xs text-muted-foreground/70 font-normal">
+                          ({t("usage.rawInputLabel", "原始")}:{" "}
+                          {request.inputTokens.toLocaleString()})
+                        </span>
+                      )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.outputTokens", "输出 Tokens")}
+                    </dt>
+                    <dd className="font-mono">
+                      {request.outputTokens.toLocaleString()}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.cacheReadTokens", "缓存读取")}
+                    </dt>
+                    <dd className="font-mono">
+                      {request.cacheReadTokens.toLocaleString()}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.cacheCreationTokens", "缓存写入")}
+                    </dt>
+                    <dd className="font-mono">
+                      {request.cacheCreationTokens.toLocaleString()}
+                    </dd>
+                  </div>
+                  <div className="col-span-2">
+                    <dt className="text-muted-foreground">
+                      {t("usage.totalTokens", "总计")}
+                    </dt>
+                    <dd className="text-lg font-semibold">
+                      {(freshInput + request.outputTokens).toLocaleString()}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+
+              {/* 成本明细 */}
+              <div className="rounded-lg border p-4">
+                <h3 className="mb-3 font-semibold">
+                  {t("usage.costBreakdown", "成本明细")}
+                </h3>
+                <dl className="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.inputCost", "输入成本")}
+                      <span className="ml-1 text-xs">
+                        ({t("usage.baseCost", "基础")})
+                      </span>
+                    </dt>
+                    <dd className="font-mono">
+                      ${parseFloat(request.inputCostUsd).toFixed(6)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.outputCost", "输出成本")}
+                      <span className="ml-1 text-xs">
+                        ({t("usage.baseCost", "基础")})
+                      </span>
+                    </dt>
+                    <dd className="font-mono">
+                      ${parseFloat(request.outputCostUsd).toFixed(6)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.cacheReadCost", "缓存读取成本")}
+                      <span className="ml-1 text-xs">
+                        ({t("usage.baseCost", "基础")})
+                      </span>
+                    </dt>
+                    <dd className="font-mono">
+                      ${parseFloat(request.cacheReadCostUsd).toFixed(6)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.cacheCreationCost", "缓存写入成本")}
+                      <span className="ml-1 text-xs">
+                        ({t("usage.baseCost", "基础")})
+                      </span>
+                    </dt>
+                    <dd className="font-mono">
+                      ${parseFloat(request.cacheCreationCostUsd).toFixed(6)}
+                    </dd>
+                  </div>
                   {request.costMultiplier &&
                     parseFloat(request.costMultiplier) !== 1 && (
-                      <span className="ml-1 text-xs">
-                        ({t("usage.withMultiplier", "含倍率")})
-                      </span>
+                      <div className="col-span-2 border-t pt-3">
+                        <dt className="text-muted-foreground">
+                          {t("usage.costMultiplier", "成本倍率")}
+                        </dt>
+                        <dd className="font-mono">×{request.costMultiplier}</dd>
+                      </div>
                     )}
-                </dt>
-                <dd
-                  className={`text-lg font-semibold ${
-                    unpriced ? "text-muted-foreground" : "text-primary"
-                  }`}
-                >
-                  {unpriced
-                    ? t("usage.unpriced", "未定价")
-                    : `$${parseFloat(request.totalCostUsd).toFixed(6)}`}
-                </dd>
+                  <div
+                    className={`col-span-2 ${request.costMultiplier && parseFloat(request.costMultiplier) !== 1 ? "" : "border-t"} pt-3`}
+                  >
+                    <dt className="text-muted-foreground">
+                      {t("usage.totalCost", "总成本")}
+                      {request.costMultiplier &&
+                        parseFloat(request.costMultiplier) !== 1 && (
+                          <span className="ml-1 text-xs">
+                            ({t("usage.withMultiplier", "含倍率")})
+                          </span>
+                        )}
+                    </dt>
+                    <dd
+                      className={`text-lg font-semibold ${
+                        unpriced ? "text-muted-foreground" : "text-primary"
+                      }`}
+                    >
+                      {unpriced
+                        ? t("usage.unpriced", "未定价")
+                        : `$${parseFloat(request.totalCostUsd).toFixed(6)}`}
+                    </dd>
+                  </div>
+                </dl>
               </div>
-            </dl>
-          </div>
 
-          {/* 性能信息 */}
-          <div className="rounded-lg border p-4">
-            <h3 className="mb-3 font-semibold">
-              {t("usage.performance", "性能信息")}
-            </h3>
-            <dl className="grid grid-cols-2 gap-3 text-sm">
-              <div>
-                <dt className="text-muted-foreground">
-                  {t("usage.latency", "延迟")}
-                </dt>
-                <dd className="font-mono">{request.latencyMs}ms</dd>
+              {/* 性能信息 */}
+              <div className="rounded-lg border p-4">
+                <h3 className="mb-3 font-semibold">
+                  {t("usage.performance", "性能信息")}
+                </h3>
+                <dl className="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <dt className="text-muted-foreground">
+                      {t("usage.latency", "延迟")}
+                    </dt>
+                    <dd className="font-mono">{request.latencyMs}ms</dd>
+                  </div>
+                </dl>
               </div>
-            </dl>
-          </div>
 
-          {/* 错误信息 */}
-          {request.errorMessage && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-              <h3 className="mb-2 font-semibold text-red-800">
-                {t("usage.errorMessage", "错误信息")}
-              </h3>
-              <p className="text-sm text-red-700">{request.errorMessage}</p>
+              {/* 错误信息 */}
+              {request.errorMessage && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+                  <h3 className="mb-2 font-semibold text-red-800">
+                    {t("usage.errorMessage", "错误信息")}
+                  </h3>
+                  <p className="text-sm text-red-700">{request.errorMessage}</p>
+                </div>
+              )}
             </div>
-          )}
-        </div>
+          </TabsContent>
+
+          {/* 请求详情 Tab */}
+          <TabsContent value="request" className="flex-1 overflow-y-auto min-h-0">
+            <div className="space-y-4">
+              {payload?.requestHeaders && (
+                <div className="rounded-lg border p-4">
+                  <h3 className="mb-3 font-semibold">
+                    {t("usage.detailTabs.requestHeaders", "请求头")}
+                  </h3>
+                  <pre className="max-h-60 overflow-auto rounded bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-all">
+                    {payload.requestHeaders}
+                  </pre>
+                </div>
+              )}
+              {payload?.requestBody && (
+                <div className="rounded-lg border p-4">
+                  <h3 className="mb-3 font-semibold">
+                    {t("usage.detailTabs.requestBody", "请求体")}
+                  </h3>
+                  <pre className="max-h-96 overflow-auto rounded bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-all">
+                    {formatJson(payload.requestBody)}
+                  </pre>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          {/* 响应详情 Tab */}
+          <TabsContent value="response" className="flex-1 overflow-y-auto min-h-0">
+            <div className="space-y-4">
+              {payload?.responseHeaders && (
+                <div className="rounded-lg border p-4">
+                  <h3 className="mb-3 font-semibold">
+                    {t("usage.detailTabs.responseHeaders", "响应头")}
+                  </h3>
+                  <pre className="max-h-60 overflow-auto rounded bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-all">
+                    {payload.responseHeaders}
+                  </pre>
+                </div>
+              )}
+              {payload?.responseBody && (
+                <div className="rounded-lg border p-4">
+                  <h3 className="mb-3 font-semibold">
+                    {t("usage.detailTabs.responseBody", "响应体")}
+                  </h3>
+                  <pre className="max-h-96 overflow-auto rounded bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-all">
+                    {formatJson(payload.responseBody)}
+                  </pre>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
       </DialogContent>
     </Dialog>
   );
+}
+
+/** Try to pretty-print a JSON string; fall back to raw text. */
+function formatJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
 }

--- a/src/components/usage/RequestDetailPanel.tsx
+++ b/src/components/usage/RequestDetailPanel.tsx
@@ -110,7 +110,10 @@ export function RequestDetailPanel({
           </TabsList>
 
           {/* 概览 Tab */}
-          <TabsContent value="overview" className="flex-1 overflow-y-auto min-h-0">
+          <TabsContent
+            value="overview"
+            className="flex-1 overflow-y-auto min-h-0"
+          >
             <div className="space-y-4">
               {/* 基本信息 */}
               <div className="rounded-lg border p-4">
@@ -140,7 +143,8 @@ export function RequestDetailPanel({
                     </dt>
                     <dd className="text-sm">
                       <span className="font-medium">
-                        {request.providerName || t("usage.unknownProvider", "未知")}
+                        {request.providerName ||
+                          t("usage.unknownProvider", "未知")}
                       </span>
                       <span className="ml-2 font-mono text-xs text-muted-foreground">
                         {request.providerId}
@@ -367,7 +371,10 @@ export function RequestDetailPanel({
           </TabsContent>
 
           {/* 请求详情 Tab */}
-          <TabsContent value="request" className="flex-1 overflow-y-auto min-h-0">
+          <TabsContent
+            value="request"
+            className="flex-1 overflow-y-auto min-h-0"
+          >
             <div className="space-y-4">
               {payload?.requestHeaders && (
                 <div className="rounded-lg border p-4">
@@ -393,7 +400,10 @@ export function RequestDetailPanel({
           </TabsContent>
 
           {/* 响应详情 Tab */}
-          <TabsContent value="response" className="flex-1 overflow-y-auto min-h-0">
+          <TabsContent
+            value="response"
+            className="flex-1 overflow-y-auto min-h-0"
+          >
             <div className="space-y-4">
               {payload?.responseHeaders && (
                 <div className="rounded-lg border p-4">

--- a/src/components/usage/RequestLogTable.tsx
+++ b/src/components/usage/RequestLogTable.tsx
@@ -24,7 +24,8 @@ import {
   type LogFilters,
   type UsageRangeSelection,
 } from "@/types/usage";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { RequestDetailPanel } from "./RequestDetailPanel";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { UsageDateRangePicker } from "./UsageDateRangePicker";
 import {
   fmtInt,
@@ -59,6 +60,7 @@ export function RequestLogTable({
   const [statusCode, setStatusCode] = useState<number | undefined>(undefined);
   const [page, setPage] = useState(0);
   const [pageInput, setPageInput] = useState("");
+  const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
   const pageSize = 20;
 
   const effectiveFilters: LogFilters = {
@@ -71,7 +73,7 @@ export function RequestLogTable({
     statusCode,
   };
 
-  const { data: result, isLoading } = useRequestLogs({
+  const { data: result, isLoading, refetch, isRefetching } = useRequestLogs({
     filters: effectiveFilters,
     range,
     page,
@@ -197,7 +199,11 @@ export function RequestLogTable({
                   logs.map((log) => {
                     const unpriced = isUnpricedUsage(log);
                     return (
-                      <TableRow key={log.requestId}>
+                      <TableRow
+                        key={log.requestId}
+                        className="cursor-pointer"
+                        onClick={() => setSelectedRequestId(log.requestId)}
+                      >
                         <TableCell className="text-center whitespace-nowrap text-xs px-1.5">
                           {new Date(log.createdAt * 1000).toLocaleString(
                             locale,
@@ -321,7 +327,18 @@ export function RequestLogTable({
           </div>
 
           <div className="flex items-center justify-between text-sm text-muted-foreground">
-            <span>{t("usage.totalRecords", { total })}</span>
+            <div className="flex items-center gap-2">
+              <span>{t("usage.totalRecords", { total })}</span>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 w-7 p-0"
+                onClick={() => refetch()}
+                disabled={isRefetching}
+              >
+                <RefreshCw className={`h-3.5 w-3.5 ${isRefetching ? "animate-spin" : ""}`} />
+              </Button>
+            </div>
             <div className="flex items-center gap-1">
               <Button
                 size="sm"
@@ -398,6 +415,13 @@ export function RequestLogTable({
             </div>
           </div>
         </>
+      )}
+
+      {selectedRequestId && (
+        <RequestDetailPanel
+          requestId={selectedRequestId}
+          onClose={() => setSelectedRequestId(null)}
+        />
       )}
     </div>
   );

--- a/src/components/usage/RequestLogTable.tsx
+++ b/src/components/usage/RequestLogTable.tsx
@@ -60,7 +60,9 @@ export function RequestLogTable({
   const [statusCode, setStatusCode] = useState<number | undefined>(undefined);
   const [page, setPage] = useState(0);
   const [pageInput, setPageInput] = useState("");
-  const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
+  const [selectedRequestId, setSelectedRequestId] = useState<string | null>(
+    null,
+  );
   const pageSize = 20;
 
   const effectiveFilters: LogFilters = {
@@ -73,7 +75,12 @@ export function RequestLogTable({
     statusCode,
   };
 
-  const { data: result, isLoading, refetch, isRefetching } = useRequestLogs({
+  const {
+    data: result,
+    isLoading,
+    refetch,
+    isRefetching,
+  } = useRequestLogs({
     filters: effectiveFilters,
     range,
     page,
@@ -336,7 +343,9 @@ export function RequestLogTable({
                 onClick={() => refetch()}
                 disabled={isRefetching}
               >
-                <RefreshCw className={`h-3.5 w-3.5 ${isRefetching ? "animate-spin" : ""}`} />
+                <RefreshCw
+                  className={`h-3.5 w-3.5 ${isRefetching ? "animate-spin" : ""}`}
+                />
               </Button>
             </div>
             <div className="flex items-center gap-1">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -422,7 +422,9 @@
           "info": "General operation info (default)",
           "debug": "Detailed info including SSE stream and request/response",
           "trace": "All logs, most verbose"
-        }
+        },
+        "captureDetails": "Record request/response body",
+        "captureDetailsDescription": "Record full request and response body for debugging (enable only when needed)"
       }
     },
     "language": "Language",
@@ -1580,6 +1582,15 @@
     "withMultiplier": "with multiplier",
     "requestDetail": "Request Detail",
     "requestNotFound": "Request not found",
+    "detailTabs": {
+      "overview": "Overview",
+      "request": "Request Details",
+      "response": "Response Details",
+      "requestHeaders": "Request Headers",
+      "requestBody": "Request Body",
+      "responseHeaders": "Response Headers",
+      "responseBody": "Response Body"
+    },
     "basicInfo": "Basic Info",
     "tokenUsage": "Token Usage",
     "cacheCreationCost": "Cache Creation Cost",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -422,7 +422,9 @@
           "info": "一般的な操作情報（デフォルト）",
           "debug": "SSE ストリームとリクエスト/レスポンスを含む詳細情報",
           "trace": "すべてのログ、最も詳細"
-        }
+        },
+        "captureDetails": "リクエスト/レスポンス本体を記録",
+        "captureDetailsDescription": "デバッグ用に完全なリクエスト/レスポンス本体を記録（必要な時のみ有効化）"
       }
     },
     "language": "言語",
@@ -1580,6 +1582,15 @@
     "withMultiplier": "倍率込み",
     "requestDetail": "リクエスト詳細",
     "requestNotFound": "リクエストが見つかりません",
+    "detailTabs": {
+      "overview": "概要",
+      "request": "リクエスト詳細",
+      "response": "レスポンス詳細",
+      "requestHeaders": "リクエストヘッダー",
+      "requestBody": "リクエスト本体",
+      "responseHeaders": "レスポンスヘッダー",
+      "responseBody": "レスポンス本体"
+    },
     "basicInfo": "基本情報",
     "tokenUsage": "Token 使用量",
     "cacheCreationCost": "キャッシュ作成コスト",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -422,7 +422,9 @@
           "info": "一般操作資訊（預設）",
           "debug": "詳細資訊，包含 SSE 串流與請求/回應詳情",
           "trace": "全部日誌，最詳細"
-        }
+        },
+        "captureDetails": "記錄請求/回應體",
+        "captureDetailsDescription": "記錄完整的請求和回應體用於除錯（僅在需要時開啟）"
       }
     },
     "language": "介面語言",
@@ -1581,6 +1583,15 @@
     "withMultiplier": "含倍率",
     "requestDetail": "請求詳情",
     "requestNotFound": "請求未找到",
+    "detailTabs": {
+      "overview": "概覽",
+      "request": "請求詳情",
+      "response": "回應詳情",
+      "requestHeaders": "請求頭",
+      "requestBody": "請求體",
+      "responseHeaders": "回應頭",
+      "responseBody": "回應體"
+    },
     "basicInfo": "基本資訊",
     "tokenUsage": "Token 使用量",
     "cacheCreationCost": "快取寫入成本",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -422,7 +422,9 @@
           "info": "一般操作信息（默认）",
           "debug": "详细信息，包含 SSE 流和请求/响应详情",
           "trace": "全部日志，最详细"
-        }
+        },
+        "captureDetails": "记录请求/响应体",
+        "captureDetailsDescription": "记录完整的请求和响应体用于调试（仅在需要时开启）"
       }
     },
     "language": "界面语言",
@@ -1580,6 +1582,15 @@
     "withMultiplier": "含倍率",
     "requestDetail": "请求详情",
     "requestNotFound": "请求未找到",
+    "detailTabs": {
+      "overview": "概览",
+      "request": "请求详情",
+      "response": "响应详情",
+      "requestHeaders": "请求头",
+      "requestBody": "请求体",
+      "responseHeaders": "响应头",
+      "responseBody": "响应体"
+    },
     "basicInfo": "基本信息",
     "tokenUsage": "Token 使用量",
     "cacheCreationCost": "缓存写入成本",

--- a/src/lib/api/detailCapture.ts
+++ b/src/lib/api/detailCapture.ts
@@ -1,0 +1,24 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useQuery } from "@tanstack/react-query";
+
+export interface RequestLogDetailPayload {
+  requestId: string;
+  requestHeaders: string | null;
+  requestBody: string | null;
+  responseHeaders: string | null;
+  responseBody: string | null;
+}
+
+export function getRequestDetailPayload(
+  requestId: string,
+): Promise<RequestLogDetailPayload | null> {
+  return invoke("get_request_detail_payload", { requestId });
+}
+
+export function useRequestDetailPayload(requestId: string) {
+  return useQuery({
+    queryKey: ["usage", "detail-payload", requestId],
+    queryFn: () => getRequestDetailPayload(requestId),
+    enabled: !!requestId,
+  });
+}

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -338,6 +338,7 @@ export interface OptimizerConfig {
 export interface LogConfig {
   enabled: boolean;
   level: "error" | "warn" | "info" | "debug" | "trace";
+  captureDetails: boolean;
 }
 
 export interface BackupEntry {


### PR DESCRIPTION
## Summary
- Adds per-request detail capture recording raw request/response headers and body to `proxy_request_log_details`
- Three-tab detail panel (Overview / Request / Response) accessible from request log table
- Streaming SSE events rebuilt as clean JSON array instead of raw SSE text
- Detail capture is independent of usage logging (`capture_details` toggle in LogConfig, off by default)
- Full 12-column schema with auto-migration for old 5-column tables

## Test plan
- [x] Enable `captureDetails` in Settings → Log Config
- [x] Make API requests (streaming + non-streaming) through the proxy
- [x] Click a request row in Usage Log → verify detail panel shows Overview / Request / Response tabs
- [x] Verify streaming responses show parsed JSON array (not raw SSE)
- [ ] Disable `captureDetails` → verify NO new detail rows are written
- [ ] Verify 30-day auto-cleanup of old detail records

Closes #5905
