### PR TITLE
fix(codex): preserve context window for route-only configs

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1199,7 +1199,24 @@ fn codex_model_catalog_from_settings(
     config_text: &str,
     profile: CodexCatalogToolProfile,
 ) -> Result<Option<Value>, AppError> {
-    let specs = codex_catalog_model_specs(settings);
+    let mut specs = codex_catalog_model_specs(settings);
+    // A routed provider can have a complete config.toml (including its active
+    // model) without a form-level model catalog. Codex only exposes context
+    // management for models in model_catalog_json, so synthesize that one
+    // active model in this specific legacy/route-only shape. An explicitly
+    // present catalog, including { "models": [] }, remains authoritative.
+    if specs.is_empty() && settings.get("modelCatalog").is_none() {
+        if let Some(model) = codex_top_level_model(config_text) {
+            specs.push(CodexCatalogModelSpec {
+                model,
+                display_name: None,
+                context_window: None,
+                supports_parallel_tool_calls: None,
+                input_modalities: None,
+                base_instructions: None,
+            });
+        }
+    }
     if specs.is_empty() {
         return Ok(None);
     }
@@ -3429,6 +3446,60 @@ base_url = "https://production.api/v1"
         );
     }
 
+    #[test]
+    fn absent_model_catalog_uses_active_model_and_configured_context_window() {
+        let catalog = codex_model_catalog_from_settings(
+            &json!({}),
+            "model = \"claude-sonnet-4-6\"\nmodel_context_window = 200000\n",
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("catalog generation should not error")
+        .expect("the active model should be cataloged when modelCatalog is absent");
+
+        let entry = &catalog["models"][0];
+        assert_eq!(
+            entry.get("slug").and_then(Value::as_str),
+            Some("claude-sonnet-4-6")
+        );
+        assert_eq!(
+            entry.get("context_window").and_then(Value::as_u64),
+            Some(200_000)
+        );
+    }
+
+    #[test]
+    fn absent_model_catalog_defaults_active_model_context_window_to_128k() {
+        let catalog = codex_model_catalog_from_settings(
+            &json!({}),
+            "model = \"claude-sonnet-4-6\"\n",
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("catalog generation should not error")
+        .expect("the active model should be cataloged when modelCatalog is absent");
+
+        assert_eq!(
+            catalog["models"][0]
+                .get("context_window")
+                .and_then(Value::as_u64),
+            Some(128_000)
+        );
+    }
+
+    #[test]
+    fn explicit_empty_model_catalog_does_not_synthesize_active_model() {
+        let catalog = codex_model_catalog_from_settings(
+            &json!({ "modelCatalog": { "models": [] } }),
+            "model = \"claude-sonnet-4-6\"\n",
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("catalog generation should not error");
+
+        assert!(
+            catalog.is_none(),
+            "an explicit empty catalog must continue to clear the generated catalog"
+        );
+    }
+
     const DEEPSEEK_NATIVE_CONFIG: &str = r#"model = "deepseek-v4-flash"
 model_provider = "custom"
 
@@ -3746,12 +3817,12 @@ web_search = "disabled"
 
     #[test]
     fn anthropic_profile_disables_web_search_without_catalog() {
-        // Regression: even when no model catalog is generated (empty/absent
+        // Regression: even when no model catalog is generated (an explicit empty
         // modelCatalog), an Anthropic provider must still disable web_search — the
         // Responses→Anthropic transform drops the hosted tool, so leaving it on
         // exposes a dead tool. The None-catalog branch previously always left it on.
         let config = "model = \"claude-sonnet-4-6\"\n";
-        let settings = serde_json::json!({});
+        let settings = serde_json::json!({ "modelCatalog": { "models": [] } });
 
         let anthropic = prepare_codex_config_text_with_model_catalog(
             &settings,

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -136,7 +136,10 @@ command = "echo"
                 "Latest".to_string(),
                 json!({
                     "auth": {"OPENAI_API_KEY": "fresh-key"},
-                    "config": r#"[mcp_servers.latest]
+                    "config": r#"model = "claude-sonnet-4-6"
+model_context_window = 200000
+
+[mcp_servers.latest]
 type = "stdio"
 command = "say"
 "#
@@ -197,6 +200,24 @@ command = "say"
     assert!(
         config_text.contains("experimental_bearer_token"),
         "config.toml should carry the selected provider API key"
+    );
+    let catalog_path = cc_switch_lib::get_codex_config_path()
+        .parent()
+        .expect("Codex config has a parent")
+        .join("cc-switch-model-catalog.json");
+    let catalog: serde_json::Value = read_json_file(&catalog_path).expect("read generated catalog");
+    assert_eq!(
+        catalog["models"][0]
+            .get("slug")
+            .and_then(serde_json::Value::as_str),
+        Some("claude-sonnet-4-6"),
+        "a route-only Codex provider should catalog its configured active model"
+    );
+    assert_eq!(
+        catalog["models"][0]
+            .get("context_window")
+            .and_then(serde_json::Value::as_u64),
+        Some(200_000)
     );
 
     let current_id = state


### PR DESCRIPTION
## Summary
- Generate a one-model Codex catalog from the active top-level model when a routed provider has no `modelCatalog`.
- Preserve explicit empty catalogs as an intentional catalog clear.
- Carry the configured `model_context_window`, falling back to 128K.

Fixes #6090

## Tests
- `cargo fmt --all --check`
- `cargo test --lib absent_model_catalog -- --nocapture`
- `cargo test --lib explicit_empty_model_catalog -- --nocapture`
- `cargo test --test provider_service provider_service_switch_codex_updates_live_and_config -- --exact --nocapture`