### PR TITLE
fix(mcp): rollback failed Codex projections

### DIFF
--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -7,6 +7,7 @@
 
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 use crate::app_config::{McpApps, McpConfig, McpServer, MultiAppConfig};
 use crate::error::AppError;
@@ -17,6 +18,14 @@ fn should_sync_codex_mcp() -> bool {
     // Codex 未安装/未初始化时：~/.codex 目录不存在。
     // 按用户偏好：目录缺失时跳过写入/删除，不创建任何文件或目录。
     crate::codex_config::get_codex_config_dir().exists()
+}
+
+/// Serialize the read-modify-write operations on Codex's shared config.toml.
+/// Individual MCP toggles can arrive concurrently from the UI; without this
+/// guard, each writer can parse the same old document and lose the other's row.
+fn codex_mcp_write_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 /// 返回已启用的 MCP 服务器（过滤 enabled==true）
@@ -287,6 +296,7 @@ pub fn sync_enabled_to_codex(config: &MultiAppConfig) -> Result<(), AppError> {
     if !should_sync_codex_mcp() {
         return Ok(());
     }
+    let _guard = codex_mcp_write_lock().lock()?;
     use toml_edit::{Item, Table};
 
     // 1) 收集启用项（Codex 维度）
@@ -424,6 +434,7 @@ pub fn sync_single_server_to_codex(
     if !should_sync_codex_mcp() {
         return Ok(());
     }
+    let _guard = codex_mcp_write_lock().lock()?;
 
     // 读取现有的 config.toml
     let config_path = crate::codex_config::get_codex_config_path();
@@ -467,6 +478,7 @@ pub fn remove_server_from_codex(id: &str) -> Result<(), AppError> {
     if !should_sync_codex_mcp() {
         return Ok(());
     }
+    let _guard = codex_mcp_write_lock().lock()?;
     let config_path = crate::codex_config::get_codex_config_path();
 
     if !config_path.exists() {

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -75,16 +75,35 @@ impl McpService {
         app: AppType,
         enabled: bool,
     ) -> Result<(), AppError> {
-        if let Some(server) = state
+        let previous_enabled = match state.db.get_all_mcp_servers()?.get(server_id) {
+            Some(server) => server.apps.is_enabled_for(&app),
+            None => return Ok(()),
+        };
+        let Some(server) = state
             .db
             .update_mcp_server_app_enabled(server_id, &app, enabled)?
-        {
-            // 同步到对应应用
-            if enabled {
-                Self::sync_server_to_app(state, &server, &app)?;
-            } else {
-                Self::remove_server_from_app(state, server_id, &app)?;
+        else {
+            return Ok(());
+        };
+
+        // 数据库是 UI 的事实来源。若 live 配置投影失败，恢复该应用的
+        // 原勾选状态，不能留下“已勾选但 config.toml 中没有”的假启用状态。
+        let projection = if enabled {
+            Self::sync_server_to_app(state, &server, &app)
+        } else {
+            Self::remove_server_from_app(state, server_id, &app)
+        };
+        if let Err(projection_error) = projection {
+            if let Err(rollback_error) =
+                state
+                    .db
+                    .update_mcp_server_app_enabled(server_id, &app, previous_enabled)
+            {
+                return Err(AppError::Message(format!(
+                    "MCP 投影失败: {projection_error}; 回滚数据库状态失败: {rollback_error}"
+                )));
             }
+            return Err(projection_error);
         }
 
         Ok(())

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -588,6 +588,67 @@ fn set_mcp_enabled_for_codex_writes_live_config() {
 }
 
 #[test]
+fn enabling_codex_mcp_rolls_back_database_when_live_config_is_invalid() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create codex dir");
+    let invalid_config = "model = \"gpt-5.5\"\ninvalid = [\n";
+    fs::write(codex_dir.join("config.toml"), invalid_config).expect("seed invalid config.toml");
+
+    let state = create_test_state().expect("create test state");
+    McpService::upsert_server(
+        &state,
+        McpServer {
+            id: "codex-server".to_string(),
+            name: "Codex Server".to_string(),
+            server: json!({
+                "type": "stdio",
+                "command": "echo"
+            }),
+            apps: McpApps {
+                claude: false,
+                codex: false,
+                gemini: false,
+                grokbuild: false,
+                opencode: false,
+                hermes: false,
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        },
+    )
+    .expect("insert disabled Codex MCP");
+
+    let err = McpService::toggle_app(&state, "codex-server", AppType::Codex, true)
+        .expect_err("an invalid live config must reject the toggle");
+    assert!(
+        err.to_string().contains("解析 config.toml 失败"),
+        "toggle should surface the live-config projection error: {err}"
+    );
+
+    let server = state
+        .db
+        .get_all_mcp_servers()
+        .expect("read MCP servers")
+        .shift_remove("codex-server")
+        .expect("server should remain in database");
+    assert!(
+        !server.apps.codex,
+        "failed Codex projection must restore the database/UI enabled state"
+    );
+    assert_eq!(
+        fs::read_to_string(codex_dir.join("config.toml")).expect("read invalid config"),
+        invalid_config,
+        "a failed projection must not overwrite the user's invalid config"
+    );
+}
+
+#[test]
 fn enabling_codex_mcp_skips_when_codex_dir_missing() {
     use support::create_test_state;
 


### PR DESCRIPTION
## Summary
- Serialize Codex MCP `config.toml` read-modify-write operations.
- Restore the previous app-enabled flag when live configuration projection fails.
- Cover an invalid `config.toml` so the database and UI do not report a false enablement.

Fixes #6097

## Tests
- `cargo fmt --all --check`
- `cargo test --test mcp_commands enabling_codex_mcp_rolls_back_database_when_live_config_is_invalid -- --exact --nocapture`
- `cargo test --test mcp_commands set_mcp_enabled_for_codex_writes_live_config -- --exact --nocapture`