### PR TITLE
fix(prompt): protect external edits before clearing or overwriting live file

### DIFF
--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -34,7 +34,15 @@ impl PromptService {
     ///
     /// live 为空（文件不存在、被外部删除或内容全为空白）时一律不动 DB：空文件不
     /// 表达"用户想清空提示词"这个意图，若据此回填会把已启用项的内容抹成空串。
-    fn backfill_live_if_dirty(state: &AppState, app: AppType) -> Result<bool, AppError> {
+    ///
+    /// `exclude_id`：若不一致的合并目标恰好是这个 id（即将被调用方自己的写入覆盖
+    /// 的那一条），跳过合并、强制走备份分支——否则合并进去的内容会在紧随其后的
+    /// 保存里被覆盖，等于没保护。
+    fn backfill_live_if_dirty(
+        state: &AppState,
+        app: AppType,
+        exclude_id: Option<&str>,
+    ) -> Result<bool, AppError> {
         let target_path = prompt_file_path(&app)?;
         let live = if target_path.exists() {
             std::fs::read_to_string(&target_path).unwrap_or_default()
@@ -59,10 +67,10 @@ impl PromptService {
             return Ok(false);
         }
 
-        // 不一致：有 enabled 项 → 回填；无 → 创建一次备份（去重）
+        // 不一致：有 enabled 项（且不是被排除的 id）→ 回填；否则 → 创建一次备份（去重）
         if let Some((enabled_id, enabled_prompt)) = prompts
             .iter()
-            .find(|(_, p)| p.enabled)
+            .find(|(id, p)| p.enabled && exclude_id != Some(id.as_str()))
             .map(|(id, p)| (id.clone(), p.clone()))
         {
             let mut updated = enabled_prompt;
@@ -104,6 +112,11 @@ impl PromptService {
         // 检查是否为已启用的提示词
         let is_enabled = prompt.enabled;
 
+        if is_enabled {
+            // 覆盖 live 文件前先保护外部修改；这条即将被本次编辑覆盖，不能合并回它自己
+            Self::backfill_live_if_dirty(state, app.clone(), Some(&prompt.id))?;
+        }
+
         state.db.save_prompt(app.as_str(), &prompt)?;
 
         if is_enabled {
@@ -117,7 +130,7 @@ impl PromptService {
 
             if !any_enabled {
                 // 所有提示词都已禁用，清空前先保留 live 文件的外部修改
-                Self::backfill_live_if_dirty(state, app.clone())?;
+                Self::backfill_live_if_dirty(state, app.clone(), None)?;
                 let target_path = prompt_file_path(&app)?;
                 if target_path.exists() {
                     write_text_file(&target_path, "")?;
@@ -143,7 +156,7 @@ impl PromptService {
 
     pub fn enable_prompt(state: &AppState, app: AppType, id: &str) -> Result<(), AppError> {
         // 写入前先保留 live 文件的外部修改（若与 DB 期望内容不一致）
-        Self::backfill_live_if_dirty(state, app.clone())?;
+        Self::backfill_live_if_dirty(state, app.clone(), None)?;
 
         // 启用目标提示词并写入文件
         let target_path = prompt_file_path(&app)?;
@@ -324,7 +337,7 @@ mod tests {
             std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
             write_text_file(&target_path, "hello").unwrap();
 
-            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone(), None).unwrap();
             assert!(!dirty);
 
             let prompts = state.db.get_prompts(app.as_str()).unwrap();
@@ -342,7 +355,7 @@ mod tests {
             state.db.save_prompt(app.as_str(), &prompt).unwrap();
 
             // live 文件不存在：不能把空内容当作"用户清空了文件"回填进 DB
-            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone(), None).unwrap();
             assert!(!dirty);
             let prompts = state.db.get_prompts(app.as_str()).unwrap();
             assert_eq!(prompts.get("p1").unwrap().content, "db content");
@@ -352,7 +365,7 @@ mod tests {
             std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
             write_text_file(&target_path, "   \n").unwrap();
 
-            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone(), None).unwrap();
             assert!(!dirty);
             let prompts = state.db.get_prompts(app.as_str()).unwrap();
             assert_eq!(prompts.len(), 1);
@@ -372,7 +385,7 @@ mod tests {
             std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
             write_text_file(&target_path, "manually edited content").unwrap();
 
-            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone(), None).unwrap();
             assert!(dirty);
 
             let prompts = state.db.get_prompts(app.as_str()).unwrap();
@@ -396,7 +409,7 @@ mod tests {
             std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
             write_text_file(&target_path, "manually edited content").unwrap();
 
-            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone(), None).unwrap();
             assert!(dirty);
 
             let prompts = state.db.get_prompts(app.as_str()).unwrap();
@@ -419,7 +432,7 @@ mod tests {
             std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
             write_text_file(&target_path, "manually edited content").unwrap();
 
-            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone(), None).unwrap();
             assert!(dirty);
 
             let prompts = state.db.get_prompts(app.as_str()).unwrap();
@@ -449,6 +462,54 @@ mod tests {
 
             let live = std::fs::read_to_string(&target_path).unwrap();
             assert_eq!(live, "");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn upsert_prompt_backs_up_external_edit_when_editing_enabled_prompt() {
+        with_test_home(|state| {
+            let app = AppType::Claude;
+            let prompt = make_prompt("p1", "A", true);
+            state.db.save_prompt(app.as_str(), &prompt).unwrap();
+
+            let target_path = prompt_file_path(&app).unwrap();
+            std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+            write_text_file(&target_path, "C").unwrap(); // 手动改过 live 文件
+
+            let edited = make_prompt("p1", "B", true); // 表单编辑与外部修改 "C" 无关
+            PromptService::upsert_prompt(state, app.clone(), "p1", edited).unwrap();
+
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert_eq!(prompts.get("p1").unwrap().content, "B");
+            assert!(prompts
+                .values()
+                .any(|p| p.id.starts_with("backup-") && p.content == "C"));
+
+            let live = std::fs::read_to_string(&target_path).unwrap();
+            assert_eq!(live, "B");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn upsert_prompt_is_noop_when_editing_enabled_prompt_without_external_change() {
+        with_test_home(|state| {
+            let app = AppType::Claude;
+            let prompt = make_prompt("p1", "A", true);
+            state.db.save_prompt(app.as_str(), &prompt).unwrap();
+
+            let target_path = prompt_file_path(&app).unwrap();
+            std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+            write_text_file(&target_path, "A").unwrap(); // live 与编辑前的 DB 内容一致，没有外部修改
+
+            // 用户主动把内容从 "A" 改成 "B" 并保存，这是正常编辑，不是外部修改
+            let edited = make_prompt("p1", "B", true);
+            PromptService::upsert_prompt(state, app.clone(), "p1", edited).unwrap();
+
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert_eq!(prompts.len(), 1); // 不应该产生多余的 backup-*
+            assert_eq!(prompts.get("p1").unwrap().content, "B");
         });
     }
 }

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -25,6 +25,69 @@ impl PromptService {
         state.db.get_prompts(app.as_str())
     }
 
+    /// 写入 live 文件前调用：若 live 文件与 DB 期望内容不一致（存在外部/手动修改），
+    /// 将 live 内容回填到当前已启用的提示词，或创建一条禁用备份（去重）。
+    /// 返回是否发生过不一致（true = 已回填或已备份）。
+    ///
+    /// "DB 期望内容"定义：当前 enabled 提示词的 content；若无 enabled 项则为空串。
+    /// 仅在 `live.trim() != expected.trim()` 时才动作，避免无谓的回填与冗余备份。
+    fn backfill_live_if_dirty(state: &AppState, app: AppType) -> Result<bool, AppError> {
+        let target_path = prompt_file_path(&app)?;
+        let live = if target_path.exists() {
+            std::fs::read_to_string(&target_path).unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        // 计算 DB 期望内容
+        let prompts = state.db.get_prompts(app.as_str())?;
+        let expected = prompts
+            .values()
+            .find(|p| p.enabled)
+            .map(|p| p.content.clone())
+            .unwrap_or_default();
+
+        // 一致：无需处理
+        if live.trim() == expected.trim() {
+            return Ok(false);
+        }
+
+        // 不一致：有 enabled 项 → 回填；无 → 创建一次备份（去重）
+        if let Some((enabled_id, enabled_prompt)) = prompts
+            .iter()
+            .find(|(_, p)| p.enabled)
+            .map(|(id, p)| (id.clone(), p.clone()))
+        {
+            let mut updated = enabled_prompt;
+            updated.content = live;
+            updated.updated_at = Some(get_unix_timestamp()?);
+            log::info!("回填 live 提示词内容到已启用项: {enabled_id}");
+            state.db.save_prompt(app.as_str(), &updated)?;
+        } else {
+            // 没有已启用的提示词，则创建一次备份（避免重复备份）
+            let content_exists = prompts.values().any(|p| p.content.trim() == live.trim());
+            if !content_exists {
+                let timestamp = get_unix_timestamp()?;
+                let backup = Prompt {
+                    id: format!("backup-{timestamp}"),
+                    name: format!(
+                        "原始提示词 {}",
+                        chrono::Local::now().format("%Y-%m-%d %H:%M")
+                    ),
+                    content: live,
+                    description: Some("自动备份的原始提示词".to_string()),
+                    enabled: false,
+                    created_at: Some(timestamp),
+                    updated_at: Some(timestamp),
+                };
+                log::info!("回填 live 提示词内容，创建备份: {}", backup.id);
+                state.db.save_prompt(app.as_str(), &backup)?;
+            }
+        }
+
+        Ok(true)
+    }
+
     pub fn upsert_prompt(
         state: &AppState,
         app: AppType,
@@ -46,7 +109,8 @@ impl PromptService {
             let any_enabled = prompts.values().any(|p| p.enabled);
 
             if !any_enabled {
-                // 所有提示词都已禁用，清空文件
+                // 所有提示词都已禁用，清空前先保留 live 文件的外部修改
+                Self::backfill_live_if_dirty(state, app.clone())?;
                 let target_path = prompt_file_path(&app)?;
                 if target_path.exists() {
                     write_text_file(&target_path, "")?;
@@ -71,56 +135,11 @@ impl PromptService {
     }
 
     pub fn enable_prompt(state: &AppState, app: AppType, id: &str) -> Result<(), AppError> {
-        // 回填当前 live 文件内容到已启用的提示词，或创建备份
-        let target_path = prompt_file_path(&app)?;
-        if target_path.exists() {
-            if let Ok(live_content) = std::fs::read_to_string(&target_path) {
-                if !live_content.trim().is_empty() {
-                    let mut prompts = state.db.get_prompts(app.as_str())?;
-
-                    // 尝试回填到当前已启用的提示词
-                    if let Some((enabled_id, enabled_prompt)) = prompts
-                        .iter_mut()
-                        .find(|(_, p)| p.enabled)
-                        .map(|(id, p)| (id.clone(), p))
-                    {
-                        let timestamp = get_unix_timestamp()?;
-                        enabled_prompt.content = live_content.clone();
-                        enabled_prompt.updated_at = Some(timestamp);
-                        log::info!("回填 live 提示词内容到已启用项: {enabled_id}");
-                        state.db.save_prompt(app.as_str(), enabled_prompt)?;
-                    } else {
-                        // 没有已启用的提示词，则创建一次备份（避免重复备份）
-                        let content_exists = prompts
-                            .values()
-                            .any(|p| p.content.trim() == live_content.trim());
-                        if !content_exists {
-                            let timestamp = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_secs() as i64;
-                            let backup_id = format!("backup-{timestamp}");
-                            let backup_prompt = Prompt {
-                                id: backup_id.clone(),
-                                name: format!(
-                                    "原始提示词 {}",
-                                    chrono::Local::now().format("%Y-%m-%d %H:%M")
-                                ),
-                                content: live_content,
-                                description: Some("自动备份的原始提示词".to_string()),
-                                enabled: false,
-                                created_at: Some(timestamp),
-                                updated_at: Some(timestamp),
-                            };
-                            log::info!("回填 live 提示词内容，创建备份: {backup_id}");
-                            state.db.save_prompt(app.as_str(), &backup_prompt)?;
-                        }
-                    }
-                }
-            }
-        }
+        // 写入前先保留 live 文件的外部修改（若与 DB 期望内容不一致）
+        Self::backfill_live_if_dirty(state, app.clone())?;
 
         // 启用目标提示词并写入文件
+        let target_path = prompt_file_path(&app)?;
         let mut prompts = state.db.get_prompts(app.as_str())?;
 
         for prompt in prompts.values_mut() {
@@ -238,5 +257,164 @@ impl PromptService {
 
         log::info!("自动导入完成: {}", app.as_str());
         Ok(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::Database;
+    use crate::store::AppState;
+    use serial_test::serial;
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+    }
+
+    fn with_test_home<T>(test: impl FnOnce(&AppState) -> T) -> T {
+        let _guard = test_guard();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+
+        let db = Arc::new(Database::memory().expect("in-memory database"));
+        let state = AppState::new(db);
+        let result = test(&state);
+
+        match old_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+
+        result
+    }
+
+    fn make_prompt(id: &str, content: &str, enabled: bool) -> Prompt {
+        Prompt {
+            id: id.to_string(),
+            name: id.to_string(),
+            content: content.to_string(),
+            description: None,
+            enabled,
+            created_at: Some(0),
+            updated_at: Some(0),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn backfill_is_noop_when_live_matches_expected() {
+        with_test_home(|state| {
+            let app = AppType::Claude;
+            let prompt = make_prompt("p1", "hello", true);
+            state.db.save_prompt(app.as_str(), &prompt).unwrap();
+
+            let target_path = prompt_file_path(&app).unwrap();
+            std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+            write_text_file(&target_path, "hello").unwrap();
+
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            assert!(!dirty);
+
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert_eq!(prompts.len(), 1);
+            assert_eq!(prompts.get("p1").unwrap().content, "hello");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn backfill_updates_enabled_prompt_when_live_differs() {
+        with_test_home(|state| {
+            let app = AppType::Claude;
+            let prompt = make_prompt("p1", "old content", true);
+            state.db.save_prompt(app.as_str(), &prompt).unwrap();
+
+            let target_path = prompt_file_path(&app).unwrap();
+            std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+            write_text_file(&target_path, "manually edited content").unwrap();
+
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            assert!(dirty);
+
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert_eq!(prompts.len(), 1);
+            assert_eq!(
+                prompts.get("p1").unwrap().content,
+                "manually edited content"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn backfill_creates_backup_when_no_enabled_prompt() {
+        with_test_home(|state| {
+            let app = AppType::Claude;
+            let prompt = make_prompt("p1", "some disabled content", false);
+            state.db.save_prompt(app.as_str(), &prompt).unwrap();
+
+            let target_path = prompt_file_path(&app).unwrap();
+            std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+            write_text_file(&target_path, "manually edited content").unwrap();
+
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            assert!(dirty);
+
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert_eq!(prompts.len(), 2);
+            assert!(prompts
+                .values()
+                .any(|p| p.id.starts_with("backup-") && p.content == "manually edited content"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn backfill_skips_duplicate_backup_when_content_already_exists() {
+        with_test_home(|state| {
+            let app = AppType::Claude;
+            let prompt = make_prompt("p1", "manually edited content", false);
+            state.db.save_prompt(app.as_str(), &prompt).unwrap();
+
+            let target_path = prompt_file_path(&app).unwrap();
+            std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+            write_text_file(&target_path, "manually edited content").unwrap();
+
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            assert!(dirty);
+
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert_eq!(prompts.len(), 1);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn upsert_prompt_backs_up_external_content_before_clearing() {
+        with_test_home(|state| {
+            let app = AppType::Claude;
+            let prompt = make_prompt("p1", "old content", true);
+            state.db.save_prompt(app.as_str(), &prompt).unwrap();
+
+            let target_path = prompt_file_path(&app).unwrap();
+            std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+            write_text_file(&target_path, "manually edited content").unwrap();
+
+            let disabled = make_prompt("p1", "old content", false);
+            PromptService::upsert_prompt(state, app.clone(), "p1", disabled).unwrap();
+
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert!(prompts
+                .values()
+                .any(|p| p.id.starts_with("backup-") && p.content == "manually edited content"));
+
+            let live = std::fs::read_to_string(&target_path).unwrap();
+            assert_eq!(live, "");
+        });
     }
 }

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -31,6 +31,9 @@ impl PromptService {
     ///
     /// "DB 期望内容"定义：当前 enabled 提示词的 content；若无 enabled 项则为空串。
     /// 仅在 `live.trim() != expected.trim()` 时才动作，避免无谓的回填与冗余备份。
+    ///
+    /// live 为空（文件不存在、被外部删除或内容全为空白）时一律不动 DB：空文件不
+    /// 表达"用户想清空提示词"这个意图，若据此回填会把已启用项的内容抹成空串。
     fn backfill_live_if_dirty(state: &AppState, app: AppType) -> Result<bool, AppError> {
         let target_path = prompt_file_path(&app)?;
         let live = if target_path.exists() {
@@ -38,6 +41,10 @@ impl PromptService {
         } else {
             String::new()
         };
+
+        if live.trim().is_empty() {
+            return Ok(false);
+        }
 
         // 计算 DB 期望内容
         let prompts = state.db.get_prompts(app.as_str())?;
@@ -323,6 +330,33 @@ mod tests {
             let prompts = state.db.get_prompts(app.as_str()).unwrap();
             assert_eq!(prompts.len(), 1);
             assert_eq!(prompts.get("p1").unwrap().content, "hello");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn backfill_is_noop_when_live_is_empty_or_missing() {
+        with_test_home(|state| {
+            let app = AppType::Claude;
+            let prompt = make_prompt("p1", "db content", true);
+            state.db.save_prompt(app.as_str(), &prompt).unwrap();
+
+            // live 文件不存在：不能把空内容当作"用户清空了文件"回填进 DB
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            assert!(!dirty);
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert_eq!(prompts.get("p1").unwrap().content, "db content");
+
+            // live 文件存在但为空：同样不回填
+            let target_path = prompt_file_path(&app).unwrap();
+            std::fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+            write_text_file(&target_path, "   \n").unwrap();
+
+            let dirty = PromptService::backfill_live_if_dirty(state, app.clone()).unwrap();
+            assert!(!dirty);
+            let prompts = state.db.get_prompts(app.as_str()).unwrap();
+            assert_eq!(prompts.len(), 1);
+            assert_eq!(prompts.get("p1").unwrap().content, "db content");
         });
     }
 


### PR DESCRIPTION
## Summary / 概述

`enable_prompt` already backfills/backs up external edits to the live prompt file before overwriting it (introduced in #225). This PR:

1. Extracts that logic into a shared `PromptService::backfill_live_if_dirty` helper, and adds a consistency check so it's a no-op when the live file already matches the DB's expected content (previously `enable_prompt` would always run the backfill/backup dance even with no drift, creating redundant DB writes / backup entries).
2. Applies the same protection to `upsert_prompt`'s "clear file when all prompts are disabled" branch (added in adb868d0), which currently writes an empty string unconditionally and silently discards any external edits made outside cc-switch.

This does not change the "DB is authoritative" design — it only closes a gap where a write path added after #225 didn't reuse the backfill/backup protection that already exists elsewhere in this file.

对应中文说明：`enable_prompt` 里已经有"写入前把外部修改回填/备份"的逻辑（#225 引入）。这次改动把它抽成一个共享的 `backfill_live_if_dirty` helper，补上"内容一致时应跳过"的判断（避免每次启用都产生冗余写入/备份），并把同样的保护应用到 `upsert_prompt` 里"全部禁用时清空文件"这个分支（adb868d0 引入）——目前这个分支会无条件清空文件，直接丢弃用户在 cc-switch 之外对该文件做的任何修改。不改变"以数据库为准"的设计，只是把后来新增的写入路径补齐到跟 `enable_prompt` 一样的保护水平。

## Related Issue / 关联 Issue

None filed yet — happy to open one first if maintainer prefers that workflow before review.

## Screenshots / 截图

Not applicable — backend-only logic fix, no UI change.

## Checklist / 检查清单

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes (no new warnings introduced)
- [x] `cargo test` passes (5 new unit tests added covering: no-op when consistent, backfill into enabled prompt, backup creation when no enabled prompt, backup dedupe, and upsert-clears-after-backup)
- [ ] Updated i18n files if user-facing text changed — not applicable, no user-facing text changed