### PR TITLE
fix(proxy): strip inline <thinking> blocks on Codex chat-completions routes

### DIFF
--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -207,7 +207,13 @@ pub(crate) fn is_empty_value(value: &Value) -> bool {
     }
 }
 
-pub(crate) fn split_leading_think_block(text: &str) -> Option<(String, String)> {
+/// `strip_separator` 只对整段内容开头的 think 块成立：那里的换行是推理与正文之间的
+/// 分隔噪音。正文中间的 think 块后面紧跟的空白属于正文本身，抹掉会把
+/// `foo<thinking>x</thinking> bar` 粘成 `foobar`。
+pub(crate) fn split_leading_think_block(
+    text: &str,
+    strip_separator: bool,
+) -> Option<(String, String)> {
     let leading_ws_len = text.len() - text.trim_start().len();
     let after_ws = &text[leading_ws_len..];
     let open_tag = THINK_TAG_PAIRS
@@ -227,9 +233,16 @@ pub(crate) fn split_leading_think_block(text: &str) -> Option<(String, String)> 
         .min_by_key(|(close_start, _)| *close_start)?;
     let answer_start = close_start + close_tag.len();
 
+    let answer = &text[answer_start..];
+    let answer = if strip_separator {
+        strip_think_answer_separator(answer)
+    } else {
+        answer
+    };
+
     Some((
         text[body_start..close_start].trim().to_string(),
-        strip_think_answer_separator(&text[answer_start..]).to_string(),
+        answer.to_string(),
     ))
 }
 
@@ -280,7 +293,10 @@ pub(crate) fn split_all_think_blocks(text: &str) -> Option<(String, String)> {
     let mut rest = text.to_string();
 
     while let Some((open_at, _)) = find_think_open_tag(&rest) {
-        let Some((reasoning, tail)) = split_leading_think_block(&rest[open_at..]) else {
+        // 只有整段内容开头的那个块才吃掉后面的分隔空白。
+        let is_leading = answer.is_empty() && open_at == 0;
+        let Some((reasoning, tail)) = split_leading_think_block(&rest[open_at..], is_leading)
+        else {
             // 开标签没有闭合，剩下的整段留给正文，交由调用方兜底。
             break;
         };

--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -243,6 +243,62 @@ pub(crate) fn strip_leading_think_open_tag(text: &str) -> Option<String> {
     })
 }
 
+/// 最早出现的开标签位置。用于在正文中间发现新的 think 段（上游会在一次响应里
+/// 交替输出「推理 → 正文 → 推理 → 正文」）。
+pub(crate) fn find_think_open_tag(text: &str) -> Option<(usize, &'static str)> {
+    THINK_TAG_PAIRS
+        .iter()
+        .filter_map(|(open_tag, _)| text.find(open_tag).map(|index| (index, *open_tag)))
+        .min_by_key(|(index, _)| *index)
+}
+
+/// 末尾可能是半截开标签（如流式切到 `...正文<thin`）时，需要扣住不下发的字节数。
+/// 否则先当正文发出去，等标签补全就晚了。
+pub(crate) fn pending_think_open_prefix_len(text: &str) -> usize {
+    let longest = THINK_TAG_PAIRS
+        .iter()
+        .map(|(open_tag, _)| open_tag.len())
+        .max()
+        .unwrap_or(0);
+
+    (1..longest.saturating_sub(1).min(text.len()) + 1)
+        .rev()
+        .filter(|len| text.is_char_boundary(text.len() - len))
+        .find(|len| {
+            let suffix = &text[text.len() - len..];
+            THINK_TAG_PAIRS
+                .iter()
+                .any(|(open_tag, _)| open_tag.len() > suffix.len() && open_tag.starts_with(suffix))
+        })
+        .unwrap_or(0)
+}
+
+/// 剥离正文里的全部 think 段，返回（合并后的推理, 剩余正文）。非流式路径用。
+pub(crate) fn split_all_think_blocks(text: &str) -> Option<(String, String)> {
+    let mut reasoning_parts: Vec<String> = Vec::new();
+    let mut answer = String::new();
+    let mut rest = text.to_string();
+
+    while let Some((open_at, _)) = find_think_open_tag(&rest) {
+        let Some((reasoning, tail)) = split_leading_think_block(&rest[open_at..]) else {
+            // 开标签没有闭合，剩下的整段留给正文，交由调用方兜底。
+            break;
+        };
+        answer.push_str(&rest[..open_at]);
+        if !reasoning.is_empty() {
+            reasoning_parts.push(reasoning);
+        }
+        rest = tail;
+    }
+
+    if reasoning_parts.is_empty() {
+        return None;
+    }
+
+    answer.push_str(&rest);
+    Some((reasoning_parts.join("\n\n"), answer))
+}
+
 fn strip_think_answer_separator(text: &str) -> &str {
     text.trim_start_matches(['\r', '\n', '\t', ' '])
 }

--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -291,23 +291,29 @@ pub(crate) fn split_all_think_blocks(text: &str) -> Option<(String, String)> {
     let mut reasoning_parts: Vec<String> = Vec::new();
     let mut answer = String::new();
     let mut rest = text.to_string();
+    let mut stripped_any = false;
 
     while let Some((open_at, _)) = find_think_open_tag(&rest) {
-        // 只有整段内容开头的那个块才吃掉后面的分隔空白。
-        let is_leading = answer.is_empty() && open_at == 0;
+        // 开标签前只有空白时仍属于整段开头；这些空白和闭合标签后的空白都是
+        // 推理/正文分隔噪音，不能进入可见正文。
+        let prefix = &rest[..open_at];
+        let is_leading = answer.is_empty() && prefix.trim().is_empty();
         let Some((reasoning, tail)) = split_leading_think_block(&rest[open_at..], is_leading)
         else {
             // 开标签没有闭合，剩下的整段留给正文，交由调用方兜底。
             break;
         };
-        answer.push_str(&rest[..open_at]);
+        stripped_any = true;
+        if !is_leading {
+            answer.push_str(prefix);
+        }
         if !reasoning.is_empty() {
             reasoning_parts.push(reasoning);
         }
         rest = tail;
     }
 
-    if reasoning_parts.is_empty() {
+    if !stripped_any {
         return None;
     }
 

--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -1,7 +1,6 @@
 use serde_json::{json, Map, Value};
 
-const THINK_OPEN_TAG: &str = "<think>";
-const THINK_CLOSE_TAG: &str = "</think>";
+const THINK_TAG_PAIRS: [(&str, &str); 2] = [("<think>", "</think>"), ("<thinking>", "</thinking>")];
 
 // 穷举上游可能的 reasoning 回传字段，优先级：reasoning_content > reasoning(字符串/对象) > reasoning_details。
 // 不依赖 provider meta 的 outputFormat 声明，因此对各家 Chat 兼容接口都能兜底提取。
@@ -211,14 +210,22 @@ pub(crate) fn is_empty_value(value: &Value) -> bool {
 pub(crate) fn split_leading_think_block(text: &str) -> Option<(String, String)> {
     let leading_ws_len = text.len() - text.trim_start().len();
     let after_ws = &text[leading_ws_len..];
-    if !after_ws.starts_with(THINK_OPEN_TAG) {
-        return None;
-    }
+    let open_tag = THINK_TAG_PAIRS
+        .iter()
+        .find_map(|(open_tag, _)| after_ws.starts_with(open_tag).then_some(*open_tag))?;
 
-    let body_start = leading_ws_len + THINK_OPEN_TAG.len();
-    let close_relative = text[body_start..].find(THINK_CLOSE_TAG)?;
-    let close_start = body_start + close_relative;
-    let answer_start = close_start + THINK_CLOSE_TAG.len();
+    let body_start = leading_ws_len + open_tag.len();
+    // 上游偶尔会用不配对的标签收尾（如 <think> 开、</thinking> 闭）。只认配对的闭合标签
+    // 会让整段连正文一起被当成推理吞掉，所以取最早出现的任一闭合标签。
+    let (close_start, close_tag) = THINK_TAG_PAIRS
+        .iter()
+        .filter_map(|(_, close_tag)| {
+            text[body_start..]
+                .find(close_tag)
+                .map(|relative| (body_start + relative, *close_tag))
+        })
+        .min_by_key(|(close_start, _)| *close_start)?;
+    let answer_start = close_start + close_tag.len();
 
     Some((
         text[body_start..close_start].trim().to_string(),
@@ -229,9 +236,11 @@ pub(crate) fn split_leading_think_block(text: &str) -> Option<(String, String)> 
 pub(crate) fn strip_leading_think_open_tag(text: &str) -> Option<String> {
     let leading_ws_len = text.len() - text.trim_start().len();
     let after_ws = &text[leading_ws_len..];
-    after_ws
-        .strip_prefix(THINK_OPEN_TAG)
-        .map(|value| value.trim().to_string())
+    THINK_TAG_PAIRS.iter().find_map(|(open_tag, _)| {
+        after_ws
+            .strip_prefix(open_tag)
+            .map(|value| value.trim().to_string())
+    })
 }
 
 fn strip_think_answer_separator(text: &str) -> &str {

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -791,11 +791,14 @@ fn leading_think_prefix_decision(buffer: &str) -> ThinkPrefixDecision {
         return ThinkPrefixDecision::NeedMore;
     }
 
-    if trimmed.starts_with("<think>") {
+    if trimmed.starts_with("<think>") || trimmed.starts_with("<thinking>") {
         return ThinkPrefixDecision::Reasoning;
     }
 
-    if "<think>".starts_with(trimmed) {
+    if ["<think>", "<thinking>"]
+        .iter()
+        .any(|tag| tag.starts_with(trimmed))
+    {
         return ThinkPrefixDecision::NeedMore;
     }
 
@@ -1015,6 +1018,23 @@ mod tests {
         assert!(output.contains("\"reasoning_tokens\":3"));
         assert!(!output.contains("<think>"));
         assert!(!output.contains("</think>"));
+        assert!(output.contains("event: response.completed"));
+    }
+
+    #[tokio::test]
+    async fn converts_inline_thinking_chat_sse_to_reasoning_without_leaking_tags() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_codex\",\"created\":123,\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"<thinking>Checking\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_codex\",\"created\":123,\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"content\":\" final status</thinking>Done\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("event: response.reasoning_summary_text.delta"));
+        assert!(output.contains("Checking final status"));
+        assert!(output.contains("\"text\":\"Done\""));
+        assert!(!output.contains("<thinking>"));
+        assert!(!output.contains("</thinking>"));
         assert!(output.contains("event: response.completed"));
     }
 

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -1122,6 +1122,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inline_thinking_preserves_following_valid_tool_call() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_thinking_tool\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"content\":\"<thinking>Need the file contents</thinking>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_thinking_tool\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_read\",\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"notes.txt\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("Need the file contents"));
+        assert!(output.contains("event: response.function_call_arguments.done"));
+        assert!(output.contains("\"call_id\":\"call_read\""));
+        assert!(output.contains("\"name\":\"read_file\""));
+        assert!(!output.contains("<thinking>"));
+        assert!(!output.contains("event: response.failed"));
+        assert!(output.contains("event: response.completed"));
+    }
+
+    #[tokio::test]
     async fn converts_alternating_thinking_segments_without_leaking_tags() {
         let output = collect(vec![
             "data: {\"id\":\"chatcmpl_codex\",\"created\":123,\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"<thinking>first pass</thinking>partial answer<thin\"}}]}\n\n",

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -245,7 +245,7 @@ impl ChatToResponsesState {
 
         let mut events = Vec::new();
         if !reasoning.is_empty() {
-            events.extend(self.push_reasoning_delta(&reasoning));
+            events.extend(self.push_inline_reasoning_delta(&reasoning));
             events.extend(self.finalize_reasoning());
         }
 
@@ -310,7 +310,7 @@ impl ChatToResponsesState {
                 if let Some((reasoning, answer)) = split_all_think_blocks(&buffered) {
                     let mut events = Vec::new();
                     if !reasoning.is_empty() {
-                        events.extend(self.push_reasoning_delta(&reasoning));
+                        events.extend(self.push_inline_reasoning_delta(&reasoning));
                         events.extend(self.finalize_reasoning());
                     }
                     if !answer.is_empty() {
@@ -323,7 +323,7 @@ impl ChatToResponsesState {
                 if reasoning.is_empty() {
                     Vec::new()
                 } else {
-                    let mut events = self.push_reasoning_delta(&reasoning);
+                    let mut events = self.push_inline_reasoning_delta(&reasoning);
                     events.extend(self.finalize_reasoning());
                     events
                 }
@@ -377,6 +377,12 @@ impl ChatToResponsesState {
             delta,
         ));
 
+        events
+    }
+
+    fn push_inline_reasoning_delta(&mut self, delta: &str) -> Vec<Bytes> {
+        let events = self.push_reasoning_delta(delta);
+        self.append_reasoning_to_active_tools(delta);
         events
     }
 
@@ -1498,6 +1504,23 @@ mod tests {
         assert!(output.contains("event: response.output_item.done"));
         assert!(output.contains("\"type\":\"function_call\""));
         assert!(output.contains("\"reasoning_content\":\"Need file.\""));
+    }
+
+    #[tokio::test]
+    async fn preserves_late_inline_thinking_on_streamed_tool_call_items() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_tool_late_inline\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read_file\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool_late_inline\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"README.md\\\"}\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool_late_inline\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"content\":\"<thinking>Need file.</thinking>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool_late_inline\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("event: response.output_item.done"));
+        assert!(output.contains("\"type\":\"function_call\""));
+        assert!(output.contains("\"reasoning_content\":\"Need file.\""));
+        assert!(!output.contains("<thinking>"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -382,7 +382,7 @@ impl ChatToResponsesState {
 
     fn push_inline_reasoning_delta(&mut self, delta: &str) -> Vec<Bytes> {
         let events = self.push_reasoning_delta(delta);
-        self.append_reasoning_to_active_tools(delta);
+        self.append_reasoning_block_to_active_tools(delta);
         events
     }
 
@@ -593,6 +593,20 @@ impl ChatToResponsesState {
             } else {
                 state.reasoning_content.push_str(delta);
             }
+        }
+    }
+
+    fn append_reasoning_block_to_active_tools(&mut self, block: &str) {
+        let block = block.trim();
+        if block.is_empty() {
+            return;
+        }
+
+        for state in self.tools.values_mut().filter(|state| !state.done) {
+            if !state.reasoning_content.is_empty() {
+                state.reasoning_content.push_str("\n\n");
+            }
+            state.reasoning_content.push_str(block);
         }
     }
 
@@ -1520,6 +1534,32 @@ mod tests {
         assert!(output.contains("event: response.output_item.done"));
         assert!(output.contains("\"type\":\"function_call\""));
         assert!(output.contains("\"reasoning_content\":\"Need file.\""));
+        assert!(!output.contains("<thinking>"));
+    }
+
+    #[tokio::test]
+    async fn separates_multiple_inline_thinking_blocks_on_active_tool_calls() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_tool_multi_inline\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"content\":\"<thinking>first</thinking>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool_multi_inline\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"README.md\\\"}\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool_multi_inline\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"content\":\"<thinking>second</thinking>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool_multi_inline\",\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+        let events = parse_sse_events(&output);
+        let item = events
+            .iter()
+            .find(|event| {
+                event["type"] == "response.output_item.done"
+                    && event["item"]["type"] == "function_call"
+            })
+            .and_then(|event| event.get("item"))
+            .expect("completed function call item");
+
+        assert_eq!(item["type"], "function_call");
+        assert_eq!(item["reasoning_content"], "first\n\nsecond");
+        assert!(!output.contains("firstsecond"));
         assert!(!output.contains("<thinking>"));
     }
 

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -230,7 +230,12 @@ impl ChatToResponsesState {
     }
 
     fn drain_complete_inline_think(&mut self) -> Vec<Bytes> {
-        let Some((reasoning, answer)) = split_leading_think_block(&self.inline_think.buffer) else {
+        // 还没发过任何正文时，这就是整段内容开头的块，闭合标签后的换行是分隔噪音；
+        // 已经发过正文的话那些空白属于正文，抹掉会把前后两截粘在一起。
+        let strip_separator = !self.text.added && self.text_seq == 0;
+        let Some((reasoning, answer)) =
+            split_leading_think_block(&self.inline_think.buffer, strip_separator)
+        else {
             return Vec::new();
         };
 
@@ -1132,6 +1137,21 @@ mod tests {
         assert!(!output.contains("<thinking>"));
         assert!(!output.contains("</thinking>"));
         assert!(output.contains("event: response.completed"));
+    }
+
+    #[tokio::test]
+    async fn keeps_spacing_around_mid_text_thinking_block() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_codex\",\"created\":123,\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"foo<thinking>aside</thinking> bar\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        // 中间块后面的空格属于正文，不能当成推理/正文的分隔噪音抹掉。
+        assert!(output.contains("\"text\":\"foo\""));
+        assert!(output.contains("\"text\":\" bar\""));
+        assert!(!output.contains("\"text\":\"bar\""));
+        assert!(!output.contains("<thinking>"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -3,7 +3,8 @@
 use super::codex_responses_sse as sse;
 use super::{
     codex_chat_common::{
-        extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
+        extract_reasoning_field_text, find_think_open_tag, pending_think_open_prefix_len,
+        split_all_think_blocks, split_leading_think_block, strip_leading_think_open_tag,
     },
     transform_codex_chat::{
         chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
@@ -74,6 +75,8 @@ struct ChatToResponsesState {
     text: TextItemState,
     reasoning: ReasoningItemState,
     inline_think: InlineThinkState,
+    reasoning_seq: u32,
+    text_seq: u32,
     tools: BTreeMap<usize, ToolCallState>,
     next_tool_index_to_add: usize,
     output_items: Vec<(u32, Value)>,
@@ -96,6 +99,8 @@ impl Default for ChatToResponsesState {
             text: TextItemState::default(),
             reasoning: ReasoningItemState::default(),
             inline_think: InlineThinkState::default(),
+            reasoning_seq: 0,
+            text_seq: 0,
             tools: BTreeMap::new(),
             next_tool_index_to_add: 0,
             output_items: Vec::new(),
@@ -177,10 +182,9 @@ impl ChatToResponsesState {
 
     fn push_content_delta(&mut self, delta: &str) -> Vec<Bytes> {
         match self.inline_think.mode {
-            InlineThinkMode::Text => {
-                let mut events = self.finalize_reasoning();
-                events.extend(self.push_text_delta(delta));
-                events
+            InlineThinkMode::Text | InlineThinkMode::Reasoning => {
+                self.inline_think.buffer.push_str(delta);
+                self.pump_inline_think()
             }
             InlineThinkMode::Detecting => {
                 self.inline_think.buffer.push_str(delta);
@@ -188,22 +192,41 @@ impl ChatToResponsesState {
                     ThinkPrefixDecision::NeedMore => Vec::new(),
                     ThinkPrefixDecision::Reasoning => {
                         self.inline_think.mode = InlineThinkMode::Reasoning;
-                        self.drain_complete_inline_think()
+                        self.pump_inline_think()
                     }
                     ThinkPrefixDecision::Text => {
                         self.inline_think.mode = InlineThinkMode::Text;
-                        let text = std::mem::take(&mut self.inline_think.buffer);
-                        let mut events = self.finalize_reasoning();
-                        events.extend(self.push_text_delta(&text));
-                        events
+                        self.pump_inline_think()
                     }
                 }
             }
-            InlineThinkMode::Reasoning => {
-                self.inline_think.buffer.push_str(delta);
-                self.drain_complete_inline_think()
+        }
+    }
+
+    /// 反复推进缓冲：Reasoning 模式吃掉闭合的 think 段，Text 模式把正文放行到
+    /// 下一个开标签为止，直到没有新进展为止。上游可以在一次响应里交替输出多段。
+    fn pump_inline_think(&mut self) -> Vec<Bytes> {
+        let mut events = Vec::new();
+        loop {
+            match self.inline_think.mode {
+                InlineThinkMode::Detecting => break,
+                InlineThinkMode::Reasoning => {
+                    events.extend(self.drain_complete_inline_think());
+                    if self.inline_think.mode == InlineThinkMode::Reasoning {
+                        // 还没等到闭合标签，继续等后续分片。
+                        break;
+                    }
+                }
+                InlineThinkMode::Text => {
+                    let (text_events, stalled) = self.drain_text_until_think_open();
+                    events.extend(text_events);
+                    if stalled {
+                        break;
+                    }
+                }
             }
         }
+        events
     }
 
     fn drain_complete_inline_think(&mut self) -> Vec<Bytes> {
@@ -212,23 +235,59 @@ impl ChatToResponsesState {
         };
 
         self.inline_think.mode = InlineThinkMode::Text;
-        self.inline_think.buffer.clear();
+        // 余下内容回到缓冲而不是直接当正文下发，后面可能还藏着 think 段。
+        self.inline_think.buffer = answer;
 
         let mut events = Vec::new();
         if !reasoning.is_empty() {
             events.extend(self.push_reasoning_delta(&reasoning));
             events.extend(self.finalize_reasoning());
         }
-        if !answer.is_empty() {
-            events.extend(self.push_text_delta(&answer));
-        }
 
         events
     }
 
+    /// 返回 (事件, 是否已停滞)。停滞表示缓冲里暂时找不到开标签，只能等更多分片。
+    fn drain_text_until_think_open(&mut self) -> (Vec<Bytes>, bool) {
+        let mut events = Vec::new();
+
+        if let Some((open_at, _)) = find_think_open_tag(&self.inline_think.buffer) {
+            let leading = self.inline_think.buffer[..open_at].to_string();
+            self.inline_think.buffer.drain(..open_at);
+            if !leading.is_empty() {
+                events.extend(self.finalize_reasoning());
+                events.extend(self.push_text_delta(&leading));
+            }
+            // 新的一段推理要另起 item，先给当前正文条目收尾。
+            events.extend(self.finalize_text());
+            self.inline_think.mode = InlineThinkMode::Reasoning;
+            return (events, false);
+        }
+
+        let hold = pending_think_open_prefix_len(&self.inline_think.buffer);
+        let emit_len = self.inline_think.buffer.len() - hold;
+        if emit_len > 0 {
+            let text: String = self.inline_think.buffer.drain(..emit_len).collect();
+            events.extend(self.finalize_reasoning());
+            events.extend(self.push_text_delta(&text));
+        }
+
+        (events, true)
+    }
+
     fn flush_inline_think_at_boundary(&mut self) -> Vec<Bytes> {
         match self.inline_think.mode {
-            InlineThinkMode::Text => Vec::new(),
+            InlineThinkMode::Text => {
+                // 末尾可能扣着半截开标签，到边界就当普通正文放出去。
+                let text = std::mem::take(&mut self.inline_think.buffer);
+                if text.is_empty() {
+                    Vec::new()
+                } else {
+                    let mut events = self.finalize_reasoning();
+                    events.extend(self.push_text_delta(&text));
+                    events
+                }
+            }
             InlineThinkMode::Detecting => {
                 self.inline_think.mode = InlineThinkMode::Text;
                 let text = std::mem::take(&mut self.inline_think.buffer);
@@ -243,7 +302,7 @@ impl ChatToResponsesState {
             InlineThinkMode::Reasoning => {
                 let buffered = std::mem::take(&mut self.inline_think.buffer);
                 self.inline_think.mode = InlineThinkMode::Text;
-                if let Some((reasoning, answer)) = split_leading_think_block(&buffered) {
+                if let Some((reasoning, answer)) = split_all_think_blocks(&buffered) {
                     let mut events = Vec::new();
                     if !reasoning.is_empty() {
                         events.extend(self.push_reasoning_delta(&reasoning));
@@ -284,9 +343,19 @@ impl ChatToResponsesState {
     fn push_reasoning_delta(&mut self, delta: &str) -> Vec<Bytes> {
         let mut events = Vec::new();
 
+        if self.reasoning.done {
+            // 上一段已收尾，交替输出时要另起一个 reasoning item。
+            self.reasoning = ReasoningItemState::default();
+            self.reasoning_seq += 1;
+        }
+
         if !self.reasoning.added {
             let output_index = self.next_output_index();
-            let item_id = format!("rs_{}", self.response_id);
+            let item_id = if self.reasoning_seq == 0 {
+                format!("rs_{}", self.response_id)
+            } else {
+                format!("rs_{}_{}", self.response_id, self.reasoning_seq + 1)
+            };
             self.reasoning.output_index = Some(output_index);
             self.reasoning.item_id = item_id.clone();
             self.reasoning.added = true;
@@ -309,9 +378,18 @@ impl ChatToResponsesState {
     fn push_text_delta(&mut self, delta: &str) -> Vec<Bytes> {
         let mut events = Vec::new();
 
+        if self.text.done {
+            self.text = TextItemState::default();
+            self.text_seq += 1;
+        }
+
         if !self.text.added {
             let output_index = self.next_output_index();
-            let item_id = format!("{}_msg", self.response_id);
+            let item_id = if self.text_seq == 0 {
+                format!("{}_msg", self.response_id)
+            } else {
+                format!("{}_msg_{}", self.response_id, self.text_seq + 1)
+            };
             self.text.output_index = Some(output_index);
             self.text.item_id = item_id.clone();
             self.text.added = true;
@@ -1033,6 +1111,24 @@ mod tests {
         assert!(output.contains("event: response.reasoning_summary_text.delta"));
         assert!(output.contains("Checking final status"));
         assert!(output.contains("\"text\":\"Done\""));
+        assert!(!output.contains("<thinking>"));
+        assert!(!output.contains("</thinking>"));
+        assert!(output.contains("event: response.completed"));
+    }
+
+    #[tokio::test]
+    async fn converts_alternating_thinking_segments_without_leaking_tags() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_codex\",\"created\":123,\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"<thinking>first pass</thinking>partial answer<thin\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_codex\",\"created\":123,\"model\":\"gpt-5-codex\",\"choices\":[{\"delta\":{\"content\":\"king>second pass</thinking>final answer\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("first pass"));
+        assert!(output.contains("second pass"));
+        assert!(output.contains("partial answer"));
+        assert!(output.contains("final answer"));
         assert!(!output.contains("<thinking>"));
         assert!(!output.contains("</thinking>"));
         assert!(output.contains("event: response.completed"));

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -4230,6 +4230,60 @@ mod tests {
     }
 
     #[test]
+    fn chat_response_to_responses_splits_inline_thinking_content() {
+        let input = json!({
+            "id": "chatcmpl_thinking",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-5-codex",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "<thinking>\nChecking final status\n</thinking>\n\nDone"
+                },
+                "finish_reason": "stop"
+            }]
+        });
+
+        let result = chat_completion_to_response(input).unwrap();
+
+        assert_eq!(result["output"][0]["type"], "reasoning");
+        assert_eq!(
+            result["output"][0]["summary"][0]["text"],
+            "Checking final status"
+        );
+        assert_eq!(result["output"][1]["type"], "message");
+        assert_eq!(result["output"][1]["content"][0]["text"], "Done");
+    }
+
+    #[test]
+    fn chat_response_to_responses_splits_mismatched_think_tags() {
+        let input = json!({
+            "id": "chatcmpl_thinking",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-5-codex",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>Checking final status</thinking>Done"
+                },
+                "finish_reason": "stop"
+            }]
+        });
+
+        let result = chat_completion_to_response(input).unwrap();
+
+        assert_eq!(result["output"][0]["type"], "reasoning");
+        assert_eq!(
+            result["output"][0]["summary"][0]["text"],
+            "Checking final status"
+        );
+        assert_eq!(result["output"][1]["type"], "message");
+        assert_eq!(result["output"][1]["content"][0]["text"], "Done");
+    }
+
+    #[test]
     fn chat_response_length_maps_to_incomplete_response() {
         let input = json!({
             "id": "chatcmpl_2",

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -7,7 +7,7 @@
 use super::codex_chat_common::{
     append_reasoning_content, extract_reasoning_field_text, extract_reasoning_summary_text,
     response_function_call_item, response_function_call_item_with_namespace,
-    split_leading_think_block,
+    split_all_think_blocks,
 };
 use crate::provider::CodexChatReasoningConfig;
 use crate::proxy::{
@@ -1474,7 +1474,7 @@ fn chat_reasoning_text(message: &Value) -> Option<String> {
     }
 
     if let Some(content) = message.get("content").and_then(|v| v.as_str()) {
-        if let Some((reasoning, _answer)) = split_leading_think_block(content) {
+        if let Some((reasoning, _answer)) = split_all_think_blocks(content) {
             if !reasoning.is_empty() {
                 return Some(reasoning);
             }
@@ -1488,7 +1488,7 @@ fn chat_message_to_response_output_item(message: &Value, response_id: &str) -> O
     let mut content = Vec::new();
 
     if let Some(text) = message.get("content").and_then(|v| v.as_str()) {
-        let text = split_leading_think_block(text)
+        let text = split_all_think_blocks(text)
             .map(|(_reasoning, answer)| answer)
             .unwrap_or_else(|| text.to_string());
         if !text.is_empty() {

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -4033,6 +4033,33 @@ mod tests {
         assert!(err.to_string().contains("without a function name"));
     }
 
+    #[test]
+    fn inline_thinking_does_not_mask_unnamed_tool_call_error() {
+        let chat = json!({
+            "id": "chatcmpl_thinking_drop",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-5-codex",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "<thinking>Need another tool</thinking>",
+                    "tool_calls": [{
+                        "id": "call_bad",
+                        "type": "function",
+                        "function": {"arguments": "{}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let err = chat_completion_to_response_with_context(chat, &CodexToolContext::default())
+            .unwrap_err();
+        assert!(matches!(err, ProxyError::TransformError(_)));
+        assert!(err.to_string().contains("without a function name"));
+    }
+
     /// 只要还剩下一个合法工具调用，Codex 本来就会继续，行为保持不变。
     #[test]
     fn chat_response_keeps_valid_tool_call_beside_unnamed_one() {

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -4284,6 +4284,53 @@ mod tests {
     }
 
     #[test]
+    fn chat_response_to_responses_strips_empty_thinking_block() {
+        let input = json!({
+            "id": "chatcmpl_empty_thinking",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-5-codex",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "<thinking>  </thinking>Done"
+                },
+                "finish_reason": "stop"
+            }]
+        });
+
+        let result = chat_completion_to_response(input).unwrap();
+
+        assert_eq!(result["output"].as_array().unwrap().len(), 1);
+        assert_eq!(result["output"][0]["type"], "message");
+        assert_eq!(result["output"][0]["content"][0]["text"], "Done");
+    }
+
+    #[test]
+    fn chat_response_to_responses_strips_whitespace_around_leading_thinking_block() {
+        let input = json!({
+            "id": "chatcmpl_whitespace_thinking",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-5-codex",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "\n  <thinking>Checking</thinking>\n\nDone"
+                },
+                "finish_reason": "stop"
+            }]
+        });
+
+        let result = chat_completion_to_response(input).unwrap();
+
+        assert_eq!(result["output"][0]["type"], "reasoning");
+        assert_eq!(result["output"][0]["summary"][0]["text"], "Checking");
+        assert_eq!(result["output"][1]["type"], "message");
+        assert_eq!(result["output"][1]["content"][0]["text"], "Done");
+    }
+
+    #[test]
     fn chat_response_to_responses_splits_mismatched_think_tags() {
         let input = json!({
             "id": "chatcmpl_thinking",


### PR DESCRIPTION
## Summary

Fixes `<thinking>` markers leaking into the assistant's visible answer on Codex routes whose upstream speaks Chat Completions.

Two gaps in the inline-think handling, both in the `codex_chat` bridge:

1. Only `<think>` / `</think>` was recognized — `<thinking>` / `</thinking>` was passed through as ordinary text. Tag pairs now live in a `THINK_TAG_PAIRS` array that both the streaming and non-streaming paths match against.
2. Only the *leading* block was stripped. The streaming state machine now keeps scanning for an opening tag while in text mode, so a response that alternates reasoning → answer → reasoning → answer produces interleaved `reasoning` / `message` items instead of leaking every block after the first. The non-streaming path strips all blocks in one pass.

Also fixes a case found while testing: when a model opens with `<think>` and closes with `</thinking>`, the close-tag lookup no longer requires the matching pair, so the answer is no longer swallowed into the reasoning item.

Closes #6116

## Test plan

Unit tests (`cargo test --lib proxy::providers`, 685 passed) cover the standard block, a `<thinking>` tag split across SSE chunks (`<thin` + `king>`), mismatched open/close tags, and alternating multi-segment output.

Verified end to end through the local proxy against a mock Chat Completions upstream, checking the converted Responses SSE for each case:

| upstream content | reasoning | message text | tags leaked |
| --- | --- | --- | --- |
| `<thinking>…</thinking>` + answer | correct | answer only | none |
| tag split across chunks | correct | answer only | none |
| `<think>` open, `</thinking>` close | correct | answer only | none |
| open tag, never closed | correct | — | none |
| two alternating blocks | 2 items | 2 items | none |

Then confirmed against a real Chat Completions provider through Codex CLI — the tags that previously showed up in the answer are gone.

Rebased onto the latest `main` after the Chat bridge added dropped-tool-call guards. Added compatibility regressions proving inline `<thinking>` extraction preserves a following valid tool call and does not mask the existing unnamed-tool-call failure path.

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes (no new warnings)
- [x] `cargo fmt --check` passes
- [ ] i18n files updated — not applicable, no user-facing text changed

## Note on AI assistance

This change was written with AI assistance and reviewed and tested by me locally, against both a mock upstream and a real provider.




