### PR TITLE
fix(usage): count DeepSeek cache-hit tokens in chat-format usage

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1839,6 +1839,11 @@ pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
                 .pointer("/input_tokens_details/cached_tokens")
                 .and_then(Value::as_u64)
         })
+        // DeepSeek Chat 的文档化缓存命中字段（与 usage/parser.rs 的处理对应），末位兜底。
+        // 官方端点目前把同值镜像进未文档化的 prompt_tokens_details.cached_tokens（上面的
+        // 标准字段已命中），故仅当上游只发文档字段、不发镜像时此兜底生效（如部分中转），
+        // 并防御未文档化镜像将来消失；上游发任一标准字段时行为零变化。
+        .or_else(|| usage.get("prompt_cache_hit_tokens").and_then(Value::as_u64))
         .unwrap_or(0);
     let cache_write = usage
         .pointer("/prompt_tokens_details/cache_write_tokens")
@@ -2536,6 +2541,28 @@ mod tests {
 
         assert_eq!(result["thinking"]["type"], "enabled");
         assert_eq!(result["reasoning_effort"], "max");
+    }
+
+    #[test]
+    fn chat_usage_to_responses_usage_maps_deepseek_cache_hit_tokens() {
+        // DeepSeek Chat 的文档化缓存命中字段也要进 Responses 的
+        // input_tokens_details（issue #6073 关联）：当上游只发该字段、不镜像
+        // prompt_tokens_details.cached_tokens 时（如部分中转），少了这个兜底，
+        // 路由模式下合成的 response.completed 里 cached_tokens 为 0，
+        // Codex 侧会话记录与本地日志都拿不到缓存命中。
+        let usage = json!({
+            "prompt_tokens": 1000,
+            "completion_tokens": 100,
+            "total_tokens": 1100,
+            "prompt_cache_hit_tokens": 600,
+            "prompt_cache_miss_tokens": 400
+        });
+
+        let result = chat_usage_to_responses_usage(Some(&usage));
+        assert_eq!(result["input_tokens"], 1000);
+        assert_eq!(result["output_tokens"], 100);
+        assert_eq!(result["input_tokens_details"]["cached_tokens"], 600);
+        assert_eq!(result["input_tokens_details"]["cache_write_tokens"], 0);
     }
 
     #[test]

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -14,6 +14,13 @@ fn openai_cache_read_tokens(usage: &Value) -> u32 {
         .get("cache_read_input_tokens")
         .or_else(|| usage.pointer("/input_tokens_details/cached_tokens"))
         .or_else(|| usage.pointer("/prompt_tokens_details/cached_tokens"))
+        // DeepSeek Chat 的文档化缓存命中字段，末位兜底：官方端点目前把同值
+        // 镜像进未文档化的 prompt_tokens_details.cached_tokens（上面标准字段
+        // 已命中），仅当上游只发文档字段、不发镜像时本兜底生效（如部分中转），
+        // 并防御未文档化镜像将来消失。prompt_tokens 本身已含命中+未命中
+        // （miss 见 prompt_cache_miss_tokens，仅作参考、无需在此扣减），
+        // 故命中数直接作 cache_read 即可。
+        .or_else(|| usage.get("prompt_cache_hit_tokens"))
         .and_then(Value::as_u64)
         .unwrap_or(0) as u32
 }
@@ -1015,6 +1022,79 @@ mod tests {
         assert_eq!(usage.output_tokens, 500);
         assert_eq!(usage.cache_read_tokens, 200);
         assert_eq!(usage.model, Some("gpt-4o".to_string()));
+    }
+
+    #[test]
+    fn test_openai_response_deepseek_cache_hit_fields() {
+        // DeepSeek Chat 格式（issue #6073 关联）：缓存命中/未命中单列在文档化的
+        // prompt_cache_hit_tokens / prompt_cache_miss_tokens，prompt_tokens 含两者。
+        // 当上游只发这套文档字段、不镜像 prompt_tokens_details.cached_tokens 时
+        // （如部分中转），缺了本兜底缓存命中会被记 0、费用相对官网按全价虚高。
+        let response = json!({
+            "model": "deepseek-v4-flash",
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 100,
+                "prompt_cache_hit_tokens": 600,
+                "prompt_cache_miss_tokens": 400,
+                "total_tokens": 1100
+            }
+        });
+
+        let usage = TokenUsage::from_openai_response(&response).unwrap();
+        assert_eq!(usage.input_tokens, 1000);
+        assert_eq!(usage.output_tokens, 100);
+        assert_eq!(usage.cache_read_tokens, 600);
+        assert_eq!(usage.cache_creation_tokens, 0);
+        assert_eq!(usage.model, Some("deepseek-v4-flash".to_string()));
+    }
+
+    #[test]
+    fn openai_cache_read_prefers_standard_field_over_deepseek_specific() {
+        // 两套字段同现时标准字段权威（含显式 0：Some(0) 短路 or_else 链）——
+        // 顺位是有意设计：某中转若硬编码 cached_tokens: 0 又透传
+        // prompt_cache_hit_tokens，仍读 0，与本兜底合入前行为一致。
+        let response = json!({
+            "model": "deepseek-v4-flash",
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 10,
+                "prompt_tokens_details": { "cached_tokens": 0 },
+                "prompt_cache_hit_tokens": 600
+            }
+        });
+        let usage = TokenUsage::from_openai_response(&response).unwrap();
+        assert_eq!(usage.cache_read_tokens, 0);
+    }
+
+    #[test]
+    fn test_openai_stream_deepseek_cache_hit_fields() {
+        // 流式路径：usage 在末尾 chunk 上，DeepSeek 缓存命中同样要被提取。
+        let events = vec![
+            json!({
+                "id": "chatcmpl-ds",
+                "model": "deepseek-v4-flash",
+                "choices": [{"delta": {"content": "Hi"}}]
+            }),
+            json!({
+                "id": "chatcmpl-ds",
+                "model": "deepseek-v4-flash",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 800,
+                    "completion_tokens": 50,
+                    "prompt_cache_hit_tokens": 512,
+                    "prompt_cache_miss_tokens": 288,
+                    "total_tokens": 850
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_openai_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 800);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_tokens, 512);
+        assert_eq!(usage.message_id.as_deref(), Some("chatcmpl-ds"));
     }
 
     #[test]


### PR DESCRIPTION
Related to #6073 (see "Scope" below).

## Problem

DeepSeek Chat defines cache hits through the **documented** fields `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`. CC Switch previously only read the standard/OpenAI-compatible cache fields, so responses that omit `prompt_tokens_details.cached_tokens` lost cache-hit accounting. This change adds the DeepSeek-documented field as a last-resort fallback. (The official endpoint currently also mirrors the value into the *undocumented* `prompt_tokens_details.cached_tokens` — verified 2026-08-05 against `api.deepseek.com`: two identical requests, second one returns both fields with the same value — which is why existing accounting was unaffected there.)

Two consumers gain the fallback:

1. **`openai_cache_read_tokens`** (`proxy/usage/parser.rs`) — the usage parser behind `proxy_request_logs`, driving the usage page and cost rollups.
2. **`chat_usage_to_responses_usage`** (`proxy/providers/transform_codex_chat.rs`) — synthesizes `response.completed` usage for Codex clients behind the routing proxy (shared by the streaming and non-streaming paths).

Rationale: align with the documented contract, defend against the undocumented mirror disappearing, and cover relays that only pass through the documented fields. Behavior is unchanged whenever the upstream sends any standard field — the DeepSeek field sits last in the `or_else` chain. `prompt_tokens` already includes hit+miss per the official docs, so the input total needs no adjustment; `prompt_cache_miss_tokens` is informational and intentionally not mapped.

## Tests

- `test_openai_response_deepseek_cache_hit_fields` — non-streaming parse: `prompt_tokens=1000, hit=600, miss=400` ⇒ `input=1000, cache_read=600`, no cache-write invented.
- `test_openai_stream_deepseek_cache_hit_fields` — streaming parse with usage in the final chunk.
- `chat_usage_to_responses_usage_maps_deepseek_cache_hit_tokens` — synthesized Responses usage carries `cached_tokens=600`.
- `openai_cache_read_prefers_standard_field_over_deepseek_specific` — when both field sets coexist, the standard field wins (an explicit `cached_tokens: 0` short-circuits the chain); precedence pinned as intentional design.

The first three fail if the fallback mapping is removed (verified by reverting).

## Scope

Issue #6073 reports two symptoms on v3.19.1 (Codex → DeepSeek): numbers diverging from DeepSeek's console, and stats freezing after a while. The freeze/mismatch pattern matches the Codex session-importer counter bugs fixed by #5854 (merged Aug 4 as `59a2bd10`, released in v3.19.2) — this PR does **not** re-address that. The reporter's native-Responses direct setup is unaffected by this change either way: the fallback only matters for Chat-format upstreams/relays that send *only* the documented DeepSeek fields. Official direct connections were never affected — the mirror field has always been present there.
