### PR TITLE
fix: preserve provider entries when merging config arrays

### DIFF
--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -224,9 +224,7 @@ fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> boo
         matched_source_by_target: &mut [Option<usize>],
     ) -> bool {
         for (target_index, target_item) in target_arr.iter().enumerate() {
-            if seen[target_index]
-                || !json_is_subset(target_item, &source_arr[source_index])
-            {
+            if seen[target_index] || !json_is_subset(target_item, &source_arr[source_index]) {
                 continue;
             }
 
@@ -262,13 +260,9 @@ fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> boo
 
 fn json_remove_array_items(target_arr: &mut Vec<Value>, source_arr: &[Value]) {
     for source_item in source_arr {
-        if let Some(index) = target_arr
-            .iter()
-            .position(|target_item| {
-                json_is_subset(target_item, source_item)
-                    && json_is_subset(source_item, target_item)
-            })
-        {
+        if let Some(index) = target_arr.iter().position(|target_item| {
+            json_is_subset(target_item, source_item) && json_is_subset(source_item, target_item)
+        }) {
             target_arr.remove(index);
         }
     }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -216,17 +216,47 @@ fn json_is_subset(target: &Value, source: &Value) -> bool {
 }
 
 fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> bool {
-    let mut matched = vec![false; target_arr.len()];
+    fn try_match(
+        target_arr: &[Value],
+        source_arr: &[Value],
+        source_index: usize,
+        seen: &mut [bool],
+        matched_source_by_target: &mut [Option<usize>],
+    ) -> bool {
+        for (target_index, target_item) in target_arr.iter().enumerate() {
+            if seen[target_index]
+                || !json_is_subset(target_item, &source_arr[source_index])
+            {
+                continue;
+            }
 
-    source_arr.iter().all(|source_item| {
-        if let Some((index, _)) = target_arr.iter().enumerate().find(|(index, target_item)| {
-            !matched[*index] && json_is_subset(target_item, source_item)
-        }) {
-            matched[index] = true;
-            true
-        } else {
-            false
+            seen[target_index] = true;
+            let matched_source = matched_source_by_target[target_index];
+            if matched_source.is_none_or(|matched_source| {
+                try_match(
+                    target_arr,
+                    source_arr,
+                    matched_source,
+                    seen,
+                    matched_source_by_target,
+                )
+            }) {
+                matched_source_by_target[target_index] = Some(source_index);
+                return true;
+            }
         }
+        false
+    }
+
+    let mut matched_source_by_target = vec![None; target_arr.len()];
+    source_arr.iter().enumerate().all(|(source_index, _)| {
+        try_match(
+            target_arr,
+            source_arr,
+            source_index,
+            &mut vec![false; target_arr.len()],
+            &mut matched_source_by_target,
+        )
     })
 }
 
@@ -234,7 +264,10 @@ fn json_remove_array_items(target_arr: &mut Vec<Value>, source_arr: &[Value]) {
     for source_item in source_arr {
         if let Some(index) = target_arr
             .iter()
-            .position(|target_item| json_is_subset(target_item, source_item))
+            .position(|target_item| {
+                json_is_subset(target_item, source_item)
+                    && json_is_subset(source_item, target_item)
+            })
         {
             target_arr.remove(index);
         }
@@ -250,6 +283,37 @@ fn json_deep_merge(target: &mut Value, source: &Value) {
                     None => {
                         target_map.insert(key.clone(), source_value.clone());
                     }
+                }
+            }
+        }
+        (target_value, source_value) => {
+            *target_value = source_value.clone();
+        }
+    }
+}
+
+fn json_deep_merge_with_array_union(target: &mut Value, source: &Value) {
+    match (target, source) {
+        (Value::Object(target_map), Value::Object(source_map)) => {
+            for (key, source_value) in source_map {
+                match target_map.get_mut(key) {
+                    Some(target_value) => {
+                        json_deep_merge_with_array_union(target_value, source_value)
+                    }
+                    None => {
+                        target_map.insert(key.clone(), source_value.clone());
+                    }
+                }
+            }
+        }
+        (Value::Array(target_arr), Value::Array(source_arr)) => {
+            for source_item in source_arr {
+                let exists = target_arr.iter().any(|target_item| {
+                    json_is_subset(target_item, source_item)
+                        && json_is_subset(source_item, target_item)
+                });
+                if !exists {
+                    target_arr.push(source_item.clone());
                 }
             }
         }
@@ -278,6 +342,90 @@ fn json_deep_remove(target: &mut Value, source: &Value) {
                 remove_key = target_arr.is_empty();
             } else if json_is_subset(target_value, source_value) {
                 remove_key = true;
+            }
+        }
+
+        if remove_key {
+            target_map.remove(key);
+        }
+    }
+}
+
+fn json_deep_remove_preserving_original_arrays(
+    target: &mut Value,
+    source: &Value,
+    original: Option<&Value>,
+) {
+    let (Some(target_map), Some(source_map)) = (target.as_object_mut(), source.as_object()) else {
+        return;
+    };
+    let original_map = original.and_then(Value::as_object);
+
+    for (key, source_value) in source_map {
+        let mut remove_key = false;
+        let original_value = original_map.and_then(|map| map.get(key));
+
+        if let Some(target_value) = target_map.get_mut(key) {
+            if source_value.is_object() && target_value.is_object() {
+                json_deep_remove_preserving_original_arrays(
+                    target_value,
+                    source_value,
+                    original_value,
+                );
+                remove_key = original_value.is_none()
+                    && target_value.as_object().is_some_and(|obj| obj.is_empty());
+            } else if let (Some(target_arr), Some(source_arr)) =
+                (target_value.as_array_mut(), source_value.as_array())
+            {
+                let original_arr = original_value
+                    .and_then(Value::as_array)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]);
+                let mut processed_source_items: Vec<&Value> = Vec::new();
+                for source_item in source_arr {
+                    let already_processed = processed_source_items.iter().any(|processed_item| {
+                        json_is_subset(processed_item, source_item)
+                            && json_is_subset(source_item, processed_item)
+                    });
+                    if already_processed {
+                        continue;
+                    }
+                    processed_source_items.push(source_item);
+
+                    let original_count = original_arr
+                        .iter()
+                        .filter(|original_item| {
+                            json_is_subset(original_item, source_item)
+                                && json_is_subset(source_item, original_item)
+                        })
+                        .count();
+                    let injection_budget = usize::from(original_count == 0);
+                    let target_count = target_arr
+                        .iter()
+                        .filter(|target_item| {
+                            json_is_subset(target_item, source_item)
+                                && json_is_subset(source_item, target_item)
+                        })
+                        .count();
+                    let remove_count = target_count
+                        .saturating_sub(original_count)
+                        .min(injection_budget);
+                    for _ in 0..remove_count {
+                        if let Some(index) = target_arr.iter().rposition(|target_item| {
+                            json_is_subset(target_item, source_item)
+                                && json_is_subset(source_item, target_item)
+                        }) {
+                            target_arr.remove(index);
+                        }
+                    }
+                }
+                remove_key = original_value.is_none() && target_arr.is_empty();
+            } else if json_is_subset(target_value, source_value) {
+                if let Some(original_value) = original_value {
+                    *target_value = original_value.clone();
+                } else {
+                    remove_key = true;
+                }
             }
         }
 
@@ -610,6 +758,28 @@ pub(crate) fn remove_common_config_from_settings(
     }
 }
 
+fn remove_common_config_from_live_settings(
+    app_type: &AppType,
+    settings: &Value,
+    snippet: &str,
+    original_settings: &Value,
+) -> Result<Value, AppError> {
+    if !matches!(app_type, AppType::Claude) {
+        return remove_common_config_from_settings(app_type, settings, snippet);
+    }
+
+    let trimmed = snippet.trim();
+    if trimmed.is_empty() {
+        return Ok(settings.clone());
+    }
+
+    let source = serde_json::from_str::<Value>(trimmed)
+        .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
+    let mut result = settings.clone();
+    json_deep_remove_preserving_original_arrays(&mut result, &source, Some(original_settings));
+    Ok(result)
+}
+
 fn apply_common_config_to_settings(
     app_type: &AppType,
     settings: &Value,
@@ -625,7 +795,7 @@ fn apply_common_config_to_settings(
             let source = serde_json::from_str::<Value>(trimmed)
                 .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
             let mut result = settings.clone();
-            json_deep_merge(&mut result, &source);
+            json_deep_merge_with_array_union(&mut result, &source);
             Ok(result)
         }
         AppType::Codex => {
@@ -935,7 +1105,12 @@ pub(crate) fn strip_common_config_from_live_settings(
     let backfill_settings = if provider_uses_common_config(app_type, provider, snippet.as_deref()) {
         match snippet.as_deref() {
             Some(snippet_text) => {
-                match remove_common_config_from_settings(app_type, &live_settings, snippet_text) {
+                match remove_common_config_from_live_settings(
+                    app_type,
+                    &live_settings,
+                    snippet_text,
+                    &provider.settings_config,
+                ) {
                     Ok(settings) => settings,
                     Err(err) => {
                         log::warn!(
@@ -2753,6 +2928,148 @@ base_url = "https://a.example/v1"
         let stripped =
             remove_common_config_from_settings(&AppType::Claude, &applied, snippet).unwrap();
         assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn claude_common_config_apply_and_remove_roundtrip_for_overlapping_arrays() {
+        let settings = json!({
+            "permissions": {
+                "deny": ["WebSearch"]
+            }
+        });
+        let snippet = r#"{
+  "permissions": {
+    "deny": ["Read(~/.ssh/**)"]
+  }
+}"#;
+
+        let applied =
+            apply_common_config_to_settings(&AppType::Claude, &settings, snippet).unwrap();
+        assert_eq!(
+            applied["permissions"]["deny"],
+            json!(["WebSearch", "Read(~/.ssh/**)"])
+        );
+
+        let stripped =
+            remove_common_config_from_settings(&AppType::Claude, &applied, snippet).unwrap();
+        assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn claude_common_config_array_removal_preserves_richer_provider_items() {
+        let settings = json!({
+            "hooks": [{ "tool": "Read", "path": "x" }]
+        });
+        let snippet = r#"{
+  "hooks": [{ "tool": "Read" }]
+}"#;
+
+        let applied =
+            apply_common_config_to_settings(&AppType::Claude, &settings, snippet).unwrap();
+        assert_eq!(
+            applied["hooks"],
+            json!([{ "tool": "Read", "path": "x" }, { "tool": "Read" }])
+        );
+
+        let stripped =
+            remove_common_config_from_settings(&AppType::Claude, &applied, snippet).unwrap();
+        assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn claude_common_config_exact_array_overlap_preserves_provider_item_on_backfill() {
+        let db = Database::memory().expect("create memory db");
+        let snippet = r#"{
+  "permissions": {
+    "deny": ["WebSearch"]
+  }
+}"#;
+        db.set_config_snippet(AppType::Claude.as_str(), Some(snippet.to_string()))
+            .expect("save common config");
+
+        let settings = json!({
+            "permissions": {
+                "deny": ["WebSearch"]
+            }
+        });
+        let mut provider = Provider::with_id(
+            "claude-test".to_string(),
+            "Claude Test".to_string(),
+            settings.clone(),
+            None,
+        );
+        provider.meta = Some(crate::provider::ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        let live = build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+            .expect("build effective settings");
+        assert_eq!(live["permissions"]["deny"], json!(["WebSearch"]));
+
+        let backfilled =
+            strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
+        assert_eq!(backfilled, settings);
+
+        let live_with_user_duplicate = json!({
+            "permissions": {
+                "deny": ["WebSearch", "WebSearch"]
+            }
+        });
+        let backfilled = strip_common_config_from_live_settings(
+            &db,
+            &AppType::Claude,
+            &provider,
+            live_with_user_duplicate.clone(),
+        );
+        assert_eq!(backfilled, live_with_user_duplicate);
+    }
+
+    #[test]
+    fn claude_common_config_scalar_backfill_restores_original_nested_values() {
+        let db = Database::memory().expect("create memory db");
+        let snippet = r#"{
+  "env": {
+    "MODE": "shared",
+    "SAME": "x"
+  }
+}"#;
+        db.set_config_snippet(AppType::Claude.as_str(), Some(snippet.to_string()))
+            .expect("save common config");
+
+        let settings = json!({
+            "env": {
+                "MODE": "provider",
+                "SAME": "x"
+            }
+        });
+        let mut provider = Provider::with_id(
+            "claude-test".to_string(),
+            "Claude Test".to_string(),
+            settings.clone(),
+            None,
+        );
+        provider.meta = Some(crate::provider::ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        let live = build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+            .expect("build effective settings");
+        assert_eq!(live["env"]["MODE"], json!("shared"));
+        assert_eq!(live["env"]["SAME"], json!("x"));
+
+        let backfilled =
+            strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
+        assert_eq!(backfilled, settings);
+    }
+
+    #[test]
+    fn json_array_subset_matching_reassigns_broad_matches() {
+        let target = json!([{ "a": 1, "b": 2 }, { "a": 1 }]);
+        let source = json!([{ "a": 1 }, { "a": 1, "b": 2 }]);
+
+        assert!(json_is_subset(&target, &source));
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -216,6 +216,10 @@ fn json_is_subset(target: &Value, source: &Value) -> bool {
 }
 
 fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> bool {
+    // Bipartite matching with reassignment (Kuhn's algorithm) so each source
+    // element claims a distinct target element. Greedy first-match is not enough
+    // when a broader target element is claimed by an earlier source item that
+    // could also match a narrower target.
     fn try_match(
         target_arr: &[Value],
         source_arr: &[Value],
@@ -227,17 +231,10 @@ fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> boo
             if seen[target_index] || !json_is_subset(target_item, &source_arr[source_index]) {
                 continue;
             }
-
             seen[target_index] = true;
             let matched_source = matched_source_by_target[target_index];
-            if matched_source.is_none_or(|matched_source| {
-                try_match(
-                    target_arr,
-                    source_arr,
-                    matched_source,
-                    seen,
-                    matched_source_by_target,
-                )
+            if matched_source.is_none_or(|ms| {
+                try_match(target_arr, source_arr, ms, seen, matched_source_by_target)
             }) {
                 matched_source_by_target[target_index] = Some(source_index);
                 return true;
@@ -258,11 +255,16 @@ fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> boo
     })
 }
 
+fn json_arrays_equal(a: &Value, b: &Value) -> bool {
+    json_is_subset(a, b) && json_is_subset(b, a)
+}
+
 fn json_remove_array_items(target_arr: &mut Vec<Value>, source_arr: &[Value]) {
     for source_item in source_arr {
-        if let Some(index) = target_arr.iter().position(|target_item| {
-            json_is_subset(target_item, source_item) && json_is_subset(source_item, target_item)
-        }) {
+        if let Some(index) = target_arr
+            .iter()
+            .position(|target_item| json_arrays_equal(target_item, source_item))
+        {
             target_arr.remove(index);
         }
     }
@@ -280,32 +282,11 @@ fn json_deep_merge(target: &mut Value, source: &Value) {
                 }
             }
         }
-        (target_value, source_value) => {
-            *target_value = source_value.clone();
-        }
-    }
-}
-
-fn json_deep_merge_with_array_union(target: &mut Value, source: &Value) {
-    match (target, source) {
-        (Value::Object(target_map), Value::Object(source_map)) => {
-            for (key, source_value) in source_map {
-                match target_map.get_mut(key) {
-                    Some(target_value) => {
-                        json_deep_merge_with_array_union(target_value, source_value)
-                    }
-                    None => {
-                        target_map.insert(key.clone(), source_value.clone());
-                    }
-                }
-            }
-        }
         (Value::Array(target_arr), Value::Array(source_arr)) => {
             for source_item in source_arr {
-                let exists = target_arr.iter().any(|target_item| {
-                    json_is_subset(target_item, source_item)
-                        && json_is_subset(source_item, target_item)
-                });
+                let exists = target_arr
+                    .iter()
+                    .any(|target_item| json_arrays_equal(target_item, source_item));
                 if !exists {
                     target_arr.push(source_item.clone());
                 }
@@ -345,6 +326,14 @@ fn json_deep_remove(target: &mut Value, source: &Value) {
     }
 }
 
+/// Like `json_deep_remove` but preserves provider-owned array entries when
+/// stripping a common-config snippet from live settings.
+///
+/// When the live config was built by merging the snippet into the provider's
+/// original settings, a simple `json_deep_remove` would also strip entries
+/// that the provider already had before the merge. This variant receives the
+/// original provider settings and uses them to avoid removing entries that
+/// were already present in the original (i.e. not injected by the snippet).
 fn json_deep_remove_preserving_original_arrays(
     target: &mut Value,
     source: &Value,
@@ -361,62 +350,75 @@ fn json_deep_remove_preserving_original_arrays(
 
         if let Some(target_value) = target_map.get_mut(key) {
             if source_value.is_object() && target_value.is_object() {
-                json_deep_remove_preserving_original_arrays(
-                    target_value,
-                    source_value,
-                    original_value,
-                );
-                remove_key = original_value.is_none()
-                    && target_value.as_object().is_some_and(|obj| obj.is_empty());
-            } else if let (Some(target_arr), Some(source_arr)) =
-                (target_value.as_array_mut(), source_value.as_array())
-            {
-                let original_arr = original_value
-                    .and_then(Value::as_array)
-                    .map(Vec::as_slice)
-                    .unwrap_or(&[]);
-                let mut processed_source_items: Vec<&Value> = Vec::new();
-                for source_item in source_arr {
-                    let already_processed = processed_source_items.iter().any(|processed_item| {
-                        json_is_subset(processed_item, source_item)
-                            && json_is_subset(source_item, processed_item)
-                    });
-                    if already_processed {
-                        continue;
+                // Guard against type mismatch: if the original value for this
+                // key is not an object (e.g. scalar or array), the snippet
+                // changed the type. Restore the original wholesale instead of
+                // recursing with a None original map.
+                if original_value.is_some_and(|ov| !ov.is_object()) {
+                    if let Some(ov) = original_value {
+                        *target_value = ov.clone();
                     }
-                    processed_source_items.push(source_item);
+                } else {
+                    json_deep_remove_preserving_original_arrays(
+                        target_value,
+                        source_value,
+                        original_value,
+                    );
+                    remove_key = original_value.is_none()
+                        && target_value.as_object().is_some_and(|obj| obj.is_empty());
+                }
+            } else if source_value.is_array() && target_value.is_array() {
+                // Guard against type mismatch: if the original value for this
+                // key is not an array (e.g. scalar or object), the snippet
+                // changed the type. Restore the original wholesale instead of
+                // treating it as an empty array.
+                if original_value.is_some_and(|ov| !ov.is_array()) {
+                    if let Some(ov) = original_value {
+                        *target_value = ov.clone();
+                    }
+                } else if let (Some(target_arr), Some(source_arr)) =
+                    (target_value.as_array_mut(), source_value.as_array())
+                {
+                    let original_arr = original_value
+                        .and_then(Value::as_array)
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[]);
+                    let mut processed_source_items: Vec<&Value> = Vec::new();
+                    for source_item in source_arr {
+                        let already_processed = processed_source_items
+                            .iter()
+                            .any(|pi| json_arrays_equal(pi, source_item));
+                        if already_processed {
+                            continue;
+                        }
+                        processed_source_items.push(source_item);
 
-                    let original_count = original_arr
-                        .iter()
-                        .filter(|original_item| {
-                            json_is_subset(original_item, source_item)
-                                && json_is_subset(source_item, original_item)
-                        })
-                        .count();
-                    let injection_budget = usize::from(original_count == 0);
-                    let target_count = target_arr
-                        .iter()
-                        .filter(|target_item| {
-                            json_is_subset(target_item, source_item)
-                                && json_is_subset(source_item, target_item)
-                        })
-                        .count();
-                    let remove_count = target_count
-                        .saturating_sub(original_count)
-                        .min(injection_budget);
-                    for _ in 0..remove_count {
-                        if let Some(index) = target_arr.iter().rposition(|target_item| {
-                            json_is_subset(target_item, source_item)
-                                && json_is_subset(source_item, target_item)
-                        }) {
-                            target_arr.remove(index);
+                        let original_count = original_arr
+                            .iter()
+                            .filter(|oi| json_arrays_equal(oi, source_item))
+                            .count();
+                        // Only remove entries that were injected by the snippet,
+                        // not ones the provider already had.
+                        let injection_budget = usize::from(original_count == 0);
+                        let target_count = target_arr
+                            .iter()
+                            .filter(|ti| json_arrays_equal(ti, source_item))
+                            .count();
+                        let remove_count = target_count.min(injection_budget);
+                        for _ in 0..remove_count {
+                            if let Some(index) = target_arr
+                                .iter()
+                                .position(|ti| json_arrays_equal(ti, source_item))
+                            {
+                                target_arr.remove(index);
+                            }
                         }
                     }
+                    remove_key = original_value.is_none() && target_arr.is_empty();
                 }
-                remove_key = original_value.is_none() && target_arr.is_empty();
             } else if json_is_subset(target_value, source_value) {
-                if let Some(original_value) = original_value {
-                    *target_value = original_value.clone();
+                if let Some(ov) = original_value {
+                    *target_value = ov.clone();
                 } else {
                     remove_key = true;
                 }
@@ -752,28 +754,6 @@ pub(crate) fn remove_common_config_from_settings(
     }
 }
 
-fn remove_common_config_from_live_settings(
-    app_type: &AppType,
-    settings: &Value,
-    snippet: &str,
-    original_settings: &Value,
-) -> Result<Value, AppError> {
-    if !matches!(app_type, AppType::Claude) {
-        return remove_common_config_from_settings(app_type, settings, snippet);
-    }
-
-    let trimmed = snippet.trim();
-    if trimmed.is_empty() {
-        return Ok(settings.clone());
-    }
-
-    let source = serde_json::from_str::<Value>(trimmed)
-        .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
-    let mut result = settings.clone();
-    json_deep_remove_preserving_original_arrays(&mut result, &source, Some(original_settings));
-    Ok(result)
-}
-
 fn apply_common_config_to_settings(
     app_type: &AppType,
     settings: &Value,
@@ -789,7 +769,7 @@ fn apply_common_config_to_settings(
             let source = serde_json::from_str::<Value>(trimmed)
                 .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
             let mut result = settings.clone();
-            json_deep_merge_with_array_union(&mut result, &source);
+            json_deep_merge(&mut result, &source);
             Ok(result)
         }
         AppType::Codex => {
@@ -1076,6 +1056,32 @@ pub(crate) fn codex_managed_oauth_live_auth(
         refresh_token,
         last_refresh,
     )
+}
+
+/// Like `remove_common_config_from_settings` but for Claude uses the
+/// array-preserving variant that knows the original provider settings.
+/// This prevents stripping entries that the provider already had before
+/// the common-config snippet was merged in.
+fn remove_common_config_from_live_settings(
+    app_type: &AppType,
+    settings: &Value,
+    snippet: &str,
+    original_settings: &Value,
+) -> Result<Value, AppError> {
+    if !matches!(app_type, AppType::Claude) {
+        return remove_common_config_from_settings(app_type, settings, snippet);
+    }
+
+    let trimmed = snippet.trim();
+    if trimmed.is_empty() {
+        return Ok(settings.clone());
+    }
+
+    let source = serde_json::from_str::<Value>(trimmed)
+        .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
+    let mut result = settings.clone();
+    json_deep_remove_preserving_original_arrays(&mut result, &source, Some(original_settings));
+    Ok(result)
 }
 
 pub(crate) fn strip_common_config_from_live_settings(
@@ -2925,7 +2931,7 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
-    fn claude_common_config_apply_and_remove_roundtrip_for_overlapping_arrays() {
+    fn claude_common_config_array_union_preserves_provider_entries() {
         let settings = json!({
             "permissions": {
                 "deny": ["WebSearch"]
@@ -2950,7 +2956,7 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
-    fn claude_common_config_array_removal_preserves_richer_provider_items() {
+    fn claude_common_config_array_union_preserves_richer_provider_items() {
         let settings = json!({
             "hooks": [{ "tool": "Read", "path": "x" }]
         });
@@ -2971,7 +2977,7 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
-    fn claude_common_config_exact_array_overlap_preserves_provider_item_on_backfill() {
+    fn claude_common_config_live_backfill_preserves_provider_owned_array_entries() {
         let db = Database::memory().expect("create memory db");
         let snippet = r#"{
   "permissions": {
@@ -3004,23 +3010,10 @@ base_url = "https://a.example/v1"
         let backfilled =
             strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
         assert_eq!(backfilled, settings);
-
-        let live_with_user_duplicate = json!({
-            "permissions": {
-                "deny": ["WebSearch", "WebSearch"]
-            }
-        });
-        let backfilled = strip_common_config_from_live_settings(
-            &db,
-            &AppType::Claude,
-            &provider,
-            live_with_user_duplicate.clone(),
-        );
-        assert_eq!(backfilled, live_with_user_duplicate);
     }
 
     #[test]
-    fn claude_common_config_scalar_backfill_restores_original_nested_values() {
+    fn claude_common_config_scalar_backfill_restores_original_values() {
         let db = Database::memory().expect("create memory db");
         let snippet = r#"{
   "env": {
@@ -3051,7 +3044,6 @@ base_url = "https://a.example/v1"
         let live = build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
             .expect("build effective settings");
         assert_eq!(live["env"]["MODE"], json!("shared"));
-        assert_eq!(live["env"]["SAME"], json!("x"));
 
         let backfilled =
             strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
@@ -3064,6 +3056,43 @@ base_url = "https://a.example/v1"
         let source = json!([{ "a": 1 }, { "a": 1, "b": 2 }]);
 
         assert!(json_is_subset(&target, &source));
+    }
+
+    #[test]
+    fn claude_common_config_backfill_restores_original_on_type_mismatch_scalar_to_array() {
+        let original = json!({ "key": "scalar_value" });
+        let snippet = json!({ "key": ["item1"] });
+
+        // Simulate what merge does: scalar overwritten by array
+        let live = json!({ "key": ["item1"] });
+
+        let mut result = live.clone();
+        json_deep_remove_preserving_original_arrays(&mut result, &snippet, Some(&original));
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn claude_common_config_backfill_restores_original_on_type_mismatch_object_to_array() {
+        let original = json!({ "key": { "nested": "v" } });
+        let snippet = json!({ "key": ["item1"] });
+
+        let live = json!({ "key": ["item1"] });
+
+        let mut result = live.clone();
+        json_deep_remove_preserving_original_arrays(&mut result, &snippet, Some(&original));
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn claude_common_config_backfill_restores_original_on_type_mismatch_array_to_object() {
+        let original = json!({ "key": ["item1"] });
+        let snippet = json!({ "key": { "nested": "v" } });
+
+        let live = json!({ "key": { "nested": "v" } });
+
+        let mut result = live.clone();
+        json_deep_remove_preserving_original_arrays(&mut result, &snippet, Some(&original));
+        assert_eq!(result, original);
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -221,9 +221,7 @@ fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> boo
         matched_source_by_target: &mut [Option<usize>],
     ) -> bool {
         for (target_index, target_item) in target_arr.iter().enumerate() {
-            if seen[target_index]
-                || !json_is_subset(target_item, &source_arr[source_index])
-            {
+            if seen[target_index] || !json_is_subset(target_item, &source_arr[source_index]) {
                 continue;
             }
 
@@ -259,13 +257,9 @@ fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> boo
 
 fn json_remove_array_items(target_arr: &mut Vec<Value>, source_arr: &[Value]) {
     for source_item in source_arr {
-        if let Some(index) = target_arr
-            .iter()
-            .position(|target_item| {
-                json_is_subset(target_item, source_item)
-                    && json_is_subset(source_item, target_item)
-            })
-        {
+        if let Some(index) = target_arr.iter().position(|target_item| {
+            json_is_subset(target_item, source_item) && json_is_subset(source_item, target_item)
+        }) {
             target_arr.remove(index);
         }
     }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -213,17 +213,47 @@ fn json_is_subset(target: &Value, source: &Value) -> bool {
 }
 
 fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> bool {
-    let mut matched = vec![false; target_arr.len()];
+    fn try_match(
+        target_arr: &[Value],
+        source_arr: &[Value],
+        source_index: usize,
+        seen: &mut [bool],
+        matched_source_by_target: &mut [Option<usize>],
+    ) -> bool {
+        for (target_index, target_item) in target_arr.iter().enumerate() {
+            if seen[target_index]
+                || !json_is_subset(target_item, &source_arr[source_index])
+            {
+                continue;
+            }
 
-    source_arr.iter().all(|source_item| {
-        if let Some((index, _)) = target_arr.iter().enumerate().find(|(index, target_item)| {
-            !matched[*index] && json_is_subset(target_item, source_item)
-        }) {
-            matched[index] = true;
-            true
-        } else {
-            false
+            seen[target_index] = true;
+            let matched_source = matched_source_by_target[target_index];
+            if matched_source.is_none_or(|matched_source| {
+                try_match(
+                    target_arr,
+                    source_arr,
+                    matched_source,
+                    seen,
+                    matched_source_by_target,
+                )
+            }) {
+                matched_source_by_target[target_index] = Some(source_index);
+                return true;
+            }
         }
+        false
+    }
+
+    let mut matched_source_by_target = vec![None; target_arr.len()];
+    source_arr.iter().enumerate().all(|(source_index, _)| {
+        try_match(
+            target_arr,
+            source_arr,
+            source_index,
+            &mut vec![false; target_arr.len()],
+            &mut matched_source_by_target,
+        )
     })
 }
 
@@ -231,7 +261,10 @@ fn json_remove_array_items(target_arr: &mut Vec<Value>, source_arr: &[Value]) {
     for source_item in source_arr {
         if let Some(index) = target_arr
             .iter()
-            .position(|target_item| json_is_subset(target_item, source_item))
+            .position(|target_item| {
+                json_is_subset(target_item, source_item)
+                    && json_is_subset(source_item, target_item)
+            })
         {
             target_arr.remove(index);
         }
@@ -247,6 +280,37 @@ fn json_deep_merge(target: &mut Value, source: &Value) {
                     None => {
                         target_map.insert(key.clone(), source_value.clone());
                     }
+                }
+            }
+        }
+        (target_value, source_value) => {
+            *target_value = source_value.clone();
+        }
+    }
+}
+
+fn json_deep_merge_with_array_union(target: &mut Value, source: &Value) {
+    match (target, source) {
+        (Value::Object(target_map), Value::Object(source_map)) => {
+            for (key, source_value) in source_map {
+                match target_map.get_mut(key) {
+                    Some(target_value) => {
+                        json_deep_merge_with_array_union(target_value, source_value)
+                    }
+                    None => {
+                        target_map.insert(key.clone(), source_value.clone());
+                    }
+                }
+            }
+        }
+        (Value::Array(target_arr), Value::Array(source_arr)) => {
+            for source_item in source_arr {
+                let exists = target_arr.iter().any(|target_item| {
+                    json_is_subset(target_item, source_item)
+                        && json_is_subset(source_item, target_item)
+                });
+                if !exists {
+                    target_arr.push(source_item.clone());
                 }
             }
         }
@@ -275,6 +339,90 @@ fn json_deep_remove(target: &mut Value, source: &Value) {
                 remove_key = target_arr.is_empty();
             } else if json_is_subset(target_value, source_value) {
                 remove_key = true;
+            }
+        }
+
+        if remove_key {
+            target_map.remove(key);
+        }
+    }
+}
+
+fn json_deep_remove_preserving_original_arrays(
+    target: &mut Value,
+    source: &Value,
+    original: Option<&Value>,
+) {
+    let (Some(target_map), Some(source_map)) = (target.as_object_mut(), source.as_object()) else {
+        return;
+    };
+    let original_map = original.and_then(Value::as_object);
+
+    for (key, source_value) in source_map {
+        let mut remove_key = false;
+        let original_value = original_map.and_then(|map| map.get(key));
+
+        if let Some(target_value) = target_map.get_mut(key) {
+            if source_value.is_object() && target_value.is_object() {
+                json_deep_remove_preserving_original_arrays(
+                    target_value,
+                    source_value,
+                    original_value,
+                );
+                remove_key = original_value.is_none()
+                    && target_value.as_object().is_some_and(|obj| obj.is_empty());
+            } else if let (Some(target_arr), Some(source_arr)) =
+                (target_value.as_array_mut(), source_value.as_array())
+            {
+                let original_arr = original_value
+                    .and_then(Value::as_array)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]);
+                let mut processed_source_items: Vec<&Value> = Vec::new();
+                for source_item in source_arr {
+                    let already_processed = processed_source_items.iter().any(|processed_item| {
+                        json_is_subset(processed_item, source_item)
+                            && json_is_subset(source_item, processed_item)
+                    });
+                    if already_processed {
+                        continue;
+                    }
+                    processed_source_items.push(source_item);
+
+                    let original_count = original_arr
+                        .iter()
+                        .filter(|original_item| {
+                            json_is_subset(original_item, source_item)
+                                && json_is_subset(source_item, original_item)
+                        })
+                        .count();
+                    let injection_budget = usize::from(original_count == 0);
+                    let target_count = target_arr
+                        .iter()
+                        .filter(|target_item| {
+                            json_is_subset(target_item, source_item)
+                                && json_is_subset(source_item, target_item)
+                        })
+                        .count();
+                    let remove_count = target_count
+                        .saturating_sub(original_count)
+                        .min(injection_budget);
+                    for _ in 0..remove_count {
+                        if let Some(index) = target_arr.iter().rposition(|target_item| {
+                            json_is_subset(target_item, source_item)
+                                && json_is_subset(source_item, target_item)
+                        }) {
+                            target_arr.remove(index);
+                        }
+                    }
+                }
+                remove_key = original_value.is_none() && target_arr.is_empty();
+            } else if json_is_subset(target_value, source_value) {
+                if let Some(original_value) = original_value {
+                    *target_value = original_value.clone();
+                } else {
+                    remove_key = true;
+                }
             }
         }
 
@@ -605,6 +753,28 @@ pub(crate) fn remove_common_config_from_settings(
     }
 }
 
+fn remove_common_config_from_live_settings(
+    app_type: &AppType,
+    settings: &Value,
+    snippet: &str,
+    original_settings: &Value,
+) -> Result<Value, AppError> {
+    if !matches!(app_type, AppType::Claude) {
+        return remove_common_config_from_settings(app_type, settings, snippet);
+    }
+
+    let trimmed = snippet.trim();
+    if trimmed.is_empty() {
+        return Ok(settings.clone());
+    }
+
+    let source = serde_json::from_str::<Value>(trimmed)
+        .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
+    let mut result = settings.clone();
+    json_deep_remove_preserving_original_arrays(&mut result, &source, Some(original_settings));
+    Ok(result)
+}
+
 fn apply_common_config_to_settings(
     app_type: &AppType,
     settings: &Value,
@@ -620,7 +790,7 @@ fn apply_common_config_to_settings(
             let source = serde_json::from_str::<Value>(trimmed)
                 .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
             let mut result = settings.clone();
-            json_deep_merge(&mut result, &source);
+            json_deep_merge_with_array_union(&mut result, &source);
             Ok(result)
         }
         AppType::Codex => {
@@ -738,7 +908,12 @@ pub(crate) fn strip_common_config_from_live_settings(
     let backfill_settings = if provider_uses_common_config(app_type, provider, snippet.as_deref()) {
         match snippet.as_deref() {
             Some(snippet_text) => {
-                match remove_common_config_from_settings(app_type, &live_settings, snippet_text) {
+                match remove_common_config_from_live_settings(
+                    app_type,
+                    &live_settings,
+                    snippet_text,
+                    &provider.settings_config,
+                ) {
                     Ok(settings) => settings,
                     Err(err) => {
                         log::warn!(
@@ -2377,6 +2552,148 @@ base_url = "https://a.example/v1"
         let stripped =
             remove_common_config_from_settings(&AppType::Claude, &applied, snippet).unwrap();
         assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn claude_common_config_apply_and_remove_roundtrip_for_overlapping_arrays() {
+        let settings = json!({
+            "permissions": {
+                "deny": ["WebSearch"]
+            }
+        });
+        let snippet = r#"{
+  "permissions": {
+    "deny": ["Read(~/.ssh/**)"]
+  }
+}"#;
+
+        let applied =
+            apply_common_config_to_settings(&AppType::Claude, &settings, snippet).unwrap();
+        assert_eq!(
+            applied["permissions"]["deny"],
+            json!(["WebSearch", "Read(~/.ssh/**)"])
+        );
+
+        let stripped =
+            remove_common_config_from_settings(&AppType::Claude, &applied, snippet).unwrap();
+        assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn claude_common_config_array_removal_preserves_richer_provider_items() {
+        let settings = json!({
+            "hooks": [{ "tool": "Read", "path": "x" }]
+        });
+        let snippet = r#"{
+  "hooks": [{ "tool": "Read" }]
+}"#;
+
+        let applied =
+            apply_common_config_to_settings(&AppType::Claude, &settings, snippet).unwrap();
+        assert_eq!(
+            applied["hooks"],
+            json!([{ "tool": "Read", "path": "x" }, { "tool": "Read" }])
+        );
+
+        let stripped =
+            remove_common_config_from_settings(&AppType::Claude, &applied, snippet).unwrap();
+        assert_eq!(stripped, settings);
+    }
+
+    #[test]
+    fn claude_common_config_exact_array_overlap_preserves_provider_item_on_backfill() {
+        let db = Database::memory().expect("create memory db");
+        let snippet = r#"{
+  "permissions": {
+    "deny": ["WebSearch"]
+  }
+}"#;
+        db.set_config_snippet(AppType::Claude.as_str(), Some(snippet.to_string()))
+            .expect("save common config");
+
+        let settings = json!({
+            "permissions": {
+                "deny": ["WebSearch"]
+            }
+        });
+        let mut provider = Provider::with_id(
+            "claude-test".to_string(),
+            "Claude Test".to_string(),
+            settings.clone(),
+            None,
+        );
+        provider.meta = Some(crate::provider::ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        let live = build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+            .expect("build effective settings");
+        assert_eq!(live["permissions"]["deny"], json!(["WebSearch"]));
+
+        let backfilled =
+            strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
+        assert_eq!(backfilled, settings);
+
+        let live_with_user_duplicate = json!({
+            "permissions": {
+                "deny": ["WebSearch", "WebSearch"]
+            }
+        });
+        let backfilled = strip_common_config_from_live_settings(
+            &db,
+            &AppType::Claude,
+            &provider,
+            live_with_user_duplicate.clone(),
+        );
+        assert_eq!(backfilled, live_with_user_duplicate);
+    }
+
+    #[test]
+    fn claude_common_config_scalar_backfill_restores_original_nested_values() {
+        let db = Database::memory().expect("create memory db");
+        let snippet = r#"{
+  "env": {
+    "MODE": "shared",
+    "SAME": "x"
+  }
+}"#;
+        db.set_config_snippet(AppType::Claude.as_str(), Some(snippet.to_string()))
+            .expect("save common config");
+
+        let settings = json!({
+            "env": {
+                "MODE": "provider",
+                "SAME": "x"
+            }
+        });
+        let mut provider = Provider::with_id(
+            "claude-test".to_string(),
+            "Claude Test".to_string(),
+            settings.clone(),
+            None,
+        );
+        provider.meta = Some(crate::provider::ProviderMeta {
+            common_config_enabled: Some(true),
+            ..Default::default()
+        });
+
+        let live = build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
+            .expect("build effective settings");
+        assert_eq!(live["env"]["MODE"], json!("shared"));
+        assert_eq!(live["env"]["SAME"], json!("x"));
+
+        let backfilled =
+            strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
+        assert_eq!(backfilled, settings);
+    }
+
+    #[test]
+    fn json_array_subset_matching_reassigns_broad_matches() {
+        let target = json!([{ "a": 1, "b": 2 }, { "a": 1 }]);
+        let source = json!([{ "a": 1 }, { "a": 1, "b": 2 }]);
+
+        assert!(json_is_subset(&target, &source));
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -213,6 +213,10 @@ fn json_is_subset(target: &Value, source: &Value) -> bool {
 }
 
 fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> bool {
+    // Bipartite matching with reassignment (Kuhn's algorithm) so each source
+    // element claims a distinct target element. Greedy first-match is not enough
+    // when a broader target element is claimed by an earlier source item that
+    // could also match a narrower target.
     fn try_match(
         target_arr: &[Value],
         source_arr: &[Value],
@@ -224,17 +228,10 @@ fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> boo
             if seen[target_index] || !json_is_subset(target_item, &source_arr[source_index]) {
                 continue;
             }
-
             seen[target_index] = true;
             let matched_source = matched_source_by_target[target_index];
-            if matched_source.is_none_or(|matched_source| {
-                try_match(
-                    target_arr,
-                    source_arr,
-                    matched_source,
-                    seen,
-                    matched_source_by_target,
-                )
+            if matched_source.is_none_or(|ms| {
+                try_match(target_arr, source_arr, ms, seen, matched_source_by_target)
             }) {
                 matched_source_by_target[target_index] = Some(source_index);
                 return true;
@@ -255,11 +252,16 @@ fn json_array_contains_subset(target_arr: &[Value], source_arr: &[Value]) -> boo
     })
 }
 
+fn json_arrays_equal(a: &Value, b: &Value) -> bool {
+    json_is_subset(a, b) && json_is_subset(b, a)
+}
+
 fn json_remove_array_items(target_arr: &mut Vec<Value>, source_arr: &[Value]) {
     for source_item in source_arr {
-        if let Some(index) = target_arr.iter().position(|target_item| {
-            json_is_subset(target_item, source_item) && json_is_subset(source_item, target_item)
-        }) {
+        if let Some(index) = target_arr
+            .iter()
+            .position(|target_item| json_arrays_equal(target_item, source_item))
+        {
             target_arr.remove(index);
         }
     }
@@ -277,32 +279,11 @@ fn json_deep_merge(target: &mut Value, source: &Value) {
                 }
             }
         }
-        (target_value, source_value) => {
-            *target_value = source_value.clone();
-        }
-    }
-}
-
-fn json_deep_merge_with_array_union(target: &mut Value, source: &Value) {
-    match (target, source) {
-        (Value::Object(target_map), Value::Object(source_map)) => {
-            for (key, source_value) in source_map {
-                match target_map.get_mut(key) {
-                    Some(target_value) => {
-                        json_deep_merge_with_array_union(target_value, source_value)
-                    }
-                    None => {
-                        target_map.insert(key.clone(), source_value.clone());
-                    }
-                }
-            }
-        }
         (Value::Array(target_arr), Value::Array(source_arr)) => {
             for source_item in source_arr {
-                let exists = target_arr.iter().any(|target_item| {
-                    json_is_subset(target_item, source_item)
-                        && json_is_subset(source_item, target_item)
-                });
+                let exists = target_arr
+                    .iter()
+                    .any(|target_item| json_arrays_equal(target_item, source_item));
                 if !exists {
                     target_arr.push(source_item.clone());
                 }
@@ -342,6 +323,14 @@ fn json_deep_remove(target: &mut Value, source: &Value) {
     }
 }
 
+/// Like `json_deep_remove` but preserves provider-owned array entries when
+/// stripping a common-config snippet from live settings.
+///
+/// When the live config was built by merging the snippet into the provider's
+/// original settings, a simple `json_deep_remove` would also strip entries
+/// that the provider already had before the merge. This variant receives the
+/// original provider settings and uses them to avoid removing entries that
+/// were already present in the original (i.e. not injected by the snippet).
 fn json_deep_remove_preserving_original_arrays(
     target: &mut Value,
     source: &Value,
@@ -358,62 +347,75 @@ fn json_deep_remove_preserving_original_arrays(
 
         if let Some(target_value) = target_map.get_mut(key) {
             if source_value.is_object() && target_value.is_object() {
-                json_deep_remove_preserving_original_arrays(
-                    target_value,
-                    source_value,
-                    original_value,
-                );
-                remove_key = original_value.is_none()
-                    && target_value.as_object().is_some_and(|obj| obj.is_empty());
-            } else if let (Some(target_arr), Some(source_arr)) =
-                (target_value.as_array_mut(), source_value.as_array())
-            {
-                let original_arr = original_value
-                    .and_then(Value::as_array)
-                    .map(Vec::as_slice)
-                    .unwrap_or(&[]);
-                let mut processed_source_items: Vec<&Value> = Vec::new();
-                for source_item in source_arr {
-                    let already_processed = processed_source_items.iter().any(|processed_item| {
-                        json_is_subset(processed_item, source_item)
-                            && json_is_subset(source_item, processed_item)
-                    });
-                    if already_processed {
-                        continue;
+                // Guard against type mismatch: if the original value for this
+                // key is not an object (e.g. scalar or array), the snippet
+                // changed the type. Restore the original wholesale instead of
+                // recursing with a None original map.
+                if original_value.is_some_and(|ov| !ov.is_object()) {
+                    if let Some(ov) = original_value {
+                        *target_value = ov.clone();
                     }
-                    processed_source_items.push(source_item);
+                } else {
+                    json_deep_remove_preserving_original_arrays(
+                        target_value,
+                        source_value,
+                        original_value,
+                    );
+                    remove_key = original_value.is_none()
+                        && target_value.as_object().is_some_and(|obj| obj.is_empty());
+                }
+            } else if source_value.is_array() && target_value.is_array() {
+                // Guard against type mismatch: if the original value for this
+                // key is not an array (e.g. scalar or object), the snippet
+                // changed the type. Restore the original wholesale instead of
+                // treating it as an empty array.
+                if original_value.is_some_and(|ov| !ov.is_array()) {
+                    if let Some(ov) = original_value {
+                        *target_value = ov.clone();
+                    }
+                } else if let (Some(target_arr), Some(source_arr)) =
+                    (target_value.as_array_mut(), source_value.as_array())
+                {
+                    let original_arr = original_value
+                        .and_then(Value::as_array)
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[]);
+                    let mut processed_source_items: Vec<&Value> = Vec::new();
+                    for source_item in source_arr {
+                        let already_processed = processed_source_items
+                            .iter()
+                            .any(|pi| json_arrays_equal(pi, source_item));
+                        if already_processed {
+                            continue;
+                        }
+                        processed_source_items.push(source_item);
 
-                    let original_count = original_arr
-                        .iter()
-                        .filter(|original_item| {
-                            json_is_subset(original_item, source_item)
-                                && json_is_subset(source_item, original_item)
-                        })
-                        .count();
-                    let injection_budget = usize::from(original_count == 0);
-                    let target_count = target_arr
-                        .iter()
-                        .filter(|target_item| {
-                            json_is_subset(target_item, source_item)
-                                && json_is_subset(source_item, target_item)
-                        })
-                        .count();
-                    let remove_count = target_count
-                        .saturating_sub(original_count)
-                        .min(injection_budget);
-                    for _ in 0..remove_count {
-                        if let Some(index) = target_arr.iter().rposition(|target_item| {
-                            json_is_subset(target_item, source_item)
-                                && json_is_subset(source_item, target_item)
-                        }) {
-                            target_arr.remove(index);
+                        let original_count = original_arr
+                            .iter()
+                            .filter(|oi| json_arrays_equal(oi, source_item))
+                            .count();
+                        // Only remove entries that were injected by the snippet,
+                        // not ones the provider already had.
+                        let injection_budget = usize::from(original_count == 0);
+                        let target_count = target_arr
+                            .iter()
+                            .filter(|ti| json_arrays_equal(ti, source_item))
+                            .count();
+                        let remove_count = target_count.min(injection_budget);
+                        for _ in 0..remove_count {
+                            if let Some(index) = target_arr
+                                .iter()
+                                .position(|ti| json_arrays_equal(ti, source_item))
+                            {
+                                target_arr.remove(index);
+                            }
                         }
                     }
+                    remove_key = original_value.is_none() && target_arr.is_empty();
                 }
-                remove_key = original_value.is_none() && target_arr.is_empty();
             } else if json_is_subset(target_value, source_value) {
-                if let Some(original_value) = original_value {
-                    *target_value = original_value.clone();
+                if let Some(ov) = original_value {
+                    *target_value = ov.clone();
                 } else {
                     remove_key = true;
                 }
@@ -747,28 +749,6 @@ pub(crate) fn remove_common_config_from_settings(
     }
 }
 
-fn remove_common_config_from_live_settings(
-    app_type: &AppType,
-    settings: &Value,
-    snippet: &str,
-    original_settings: &Value,
-) -> Result<Value, AppError> {
-    if !matches!(app_type, AppType::Claude) {
-        return remove_common_config_from_settings(app_type, settings, snippet);
-    }
-
-    let trimmed = snippet.trim();
-    if trimmed.is_empty() {
-        return Ok(settings.clone());
-    }
-
-    let source = serde_json::from_str::<Value>(trimmed)
-        .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
-    let mut result = settings.clone();
-    json_deep_remove_preserving_original_arrays(&mut result, &source, Some(original_settings));
-    Ok(result)
-}
-
 fn apply_common_config_to_settings(
     app_type: &AppType,
     settings: &Value,
@@ -784,7 +764,7 @@ fn apply_common_config_to_settings(
             let source = serde_json::from_str::<Value>(trimmed)
                 .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
             let mut result = settings.clone();
-            json_deep_merge_with_array_union(&mut result, &source);
+            json_deep_merge(&mut result, &source);
             Ok(result)
         }
         AppType::Codex => {
@@ -879,6 +859,32 @@ pub(crate) fn write_live_with_common_config(
     }
 
     write_live_snapshot(app_type, &effective_provider)
+}
+
+/// Like `remove_common_config_from_settings` but for Claude uses the
+/// array-preserving variant that knows the original provider settings.
+/// This prevents stripping entries that the provider already had before
+/// the common-config snippet was merged in.
+fn remove_common_config_from_live_settings(
+    app_type: &AppType,
+    settings: &Value,
+    snippet: &str,
+    original_settings: &Value,
+) -> Result<Value, AppError> {
+    if !matches!(app_type, AppType::Claude) {
+        return remove_common_config_from_settings(app_type, settings, snippet);
+    }
+
+    let trimmed = snippet.trim();
+    if trimmed.is_empty() {
+        return Ok(settings.clone());
+    }
+
+    let source = serde_json::from_str::<Value>(trimmed)
+        .map_err(|e| AppError::Message(format!("Invalid Claude common config: {e}")))?;
+    let mut result = settings.clone();
+    json_deep_remove_preserving_original_arrays(&mut result, &source, Some(original_settings));
+    Ok(result)
 }
 
 pub(crate) fn strip_common_config_from_live_settings(
@@ -2549,7 +2555,7 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
-    fn claude_common_config_apply_and_remove_roundtrip_for_overlapping_arrays() {
+    fn claude_common_config_array_union_preserves_provider_entries() {
         let settings = json!({
             "permissions": {
                 "deny": ["WebSearch"]
@@ -2574,7 +2580,7 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
-    fn claude_common_config_array_removal_preserves_richer_provider_items() {
+    fn claude_common_config_array_union_preserves_richer_provider_items() {
         let settings = json!({
             "hooks": [{ "tool": "Read", "path": "x" }]
         });
@@ -2595,7 +2601,7 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
-    fn claude_common_config_exact_array_overlap_preserves_provider_item_on_backfill() {
+    fn claude_common_config_live_backfill_preserves_provider_owned_array_entries() {
         let db = Database::memory().expect("create memory db");
         let snippet = r#"{
   "permissions": {
@@ -2628,23 +2634,10 @@ base_url = "https://a.example/v1"
         let backfilled =
             strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
         assert_eq!(backfilled, settings);
-
-        let live_with_user_duplicate = json!({
-            "permissions": {
-                "deny": ["WebSearch", "WebSearch"]
-            }
-        });
-        let backfilled = strip_common_config_from_live_settings(
-            &db,
-            &AppType::Claude,
-            &provider,
-            live_with_user_duplicate.clone(),
-        );
-        assert_eq!(backfilled, live_with_user_duplicate);
     }
 
     #[test]
-    fn claude_common_config_scalar_backfill_restores_original_nested_values() {
+    fn claude_common_config_scalar_backfill_restores_original_values() {
         let db = Database::memory().expect("create memory db");
         let snippet = r#"{
   "env": {
@@ -2675,7 +2668,6 @@ base_url = "https://a.example/v1"
         let live = build_effective_settings_with_common_config(&db, &AppType::Claude, &provider)
             .expect("build effective settings");
         assert_eq!(live["env"]["MODE"], json!("shared"));
-        assert_eq!(live["env"]["SAME"], json!("x"));
 
         let backfilled =
             strip_common_config_from_live_settings(&db, &AppType::Claude, &provider, live);
@@ -2688,6 +2680,43 @@ base_url = "https://a.example/v1"
         let source = json!([{ "a": 1 }, { "a": 1, "b": 2 }]);
 
         assert!(json_is_subset(&target, &source));
+    }
+
+    #[test]
+    fn claude_common_config_backfill_restores_original_on_type_mismatch_scalar_to_array() {
+        let original = json!({ "key": "scalar_value" });
+        let snippet = json!({ "key": ["item1"] });
+
+        // Simulate what merge does: scalar overwritten by array
+        let live = json!({ "key": ["item1"] });
+
+        let mut result = live.clone();
+        json_deep_remove_preserving_original_arrays(&mut result, &snippet, Some(&original));
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn claude_common_config_backfill_restores_original_on_type_mismatch_object_to_array() {
+        let original = json!({ "key": { "nested": "v" } });
+        let snippet = json!({ "key": ["item1"] });
+
+        let live = json!({ "key": ["item1"] });
+
+        let mut result = live.clone();
+        json_deep_remove_preserving_original_arrays(&mut result, &snippet, Some(&original));
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn claude_common_config_backfill_restores_original_on_type_mismatch_array_to_object() {
+        let original = json!({ "key": ["item1"] });
+        let snippet = json!({ "key": { "nested": "v" } });
+
+        let live = json!({ "key": { "nested": "v" } });
+
+        let mut result = live.clone();
+        json_deep_remove_preserving_original_arrays(&mut result, &snippet, Some(&original));
+        assert_eq!(result, original);
     }
 
     #[test]

--- a/src/utils/providerConfigUtils.test.ts
+++ b/src/utils/providerConfigUtils.test.ts
@@ -300,6 +300,27 @@ describe("common config snippet prototype-pollution guards", () => {
     expect(hasCommonConfigSnippet(merged, snippet)).toBe(true);
   });
 
+  it("sanitizes forbidden keys inside array elements", () => {
+    const snippet = JSON.stringify({
+      hooks: [{ ["__proto__"]: { polluted: "YES" } }],
+    });
+
+    const merged = updateCommonConfigSnippet("{}", snippet, true).updatedConfig;
+    const mergedAgain = updateCommonConfigSnippet(
+      merged,
+      snippet,
+      true,
+    ).updatedConfig;
+    expect(JSON.parse(mergedAgain).hooks).toEqual([{}]);
+
+    const removed = updateCommonConfigSnippet(
+      mergedAgain,
+      snippet,
+      false,
+    ).updatedConfig;
+    expect(JSON.parse(removed)).toEqual({});
+  });
+
   it("still reports a genuinely applied snippet as applied", () => {
     // 守卫不能把正常判定也一起改坏
     expect(

--- a/src/utils/providerConfigUtils.test.ts
+++ b/src/utils/providerConfigUtils.test.ts
@@ -232,6 +232,17 @@ describe("common config array merging", () => {
     expect(JSON.parse(removed).permissions.deny).toEqual(["WebSearch"]);
     expect(hasCommonConfigSnippet(removed, commonSnippet)).toBe(false);
   });
+
+  it("does not reuse one target item for multiple snippet entries", () => {
+    const config = JSON.stringify({ hooks: [{ a: 1, b: 2 }] });
+    const snippet = JSON.stringify({ hooks: [{ a: 1 }, { a: 1, b: 2 }] });
+
+    expect(hasCommonConfigSnippet(config, snippet)).toBe(false);
+
+    const merged = updateCommonConfigSnippet(config, snippet, true).updatedConfig;
+    expect(JSON.parse(merged).hooks).toEqual([{ a: 1, b: 2 }, { a: 1 }]);
+    expect(hasCommonConfigSnippet(merged, snippet)).toBe(true);
+  });
 });
 
 describe("common config snippet prototype-pollution guards", () => {

--- a/src/utils/providerConfigUtils.test.ts
+++ b/src/utils/providerConfigUtils.test.ts
@@ -239,7 +239,11 @@ describe("common config array merging", () => {
 
     expect(hasCommonConfigSnippet(config, snippet)).toBe(false);
 
-    const merged = updateCommonConfigSnippet(config, snippet, true).updatedConfig;
+    const merged = updateCommonConfigSnippet(
+      config,
+      snippet,
+      true,
+    ).updatedConfig;
     expect(JSON.parse(merged).hooks).toEqual([{ a: 1, b: 2 }, { a: 1 }]);
     expect(hasCommonConfigSnippet(merged, snippet)).toBe(true);
   });

--- a/src/utils/providerConfigUtils.test.ts
+++ b/src/utils/providerConfigUtils.test.ts
@@ -190,6 +190,50 @@ name = "Example"
   });
 });
 
+describe("common config array merging", () => {
+  const providerConfig = JSON.stringify({
+    permissions: { deny: ["WebSearch"] },
+  });
+  const commonSnippet = JSON.stringify({
+    permissions: { deny: ["Read(~/.ssh/**)"] },
+  });
+
+  it("keeps provider entries and does not duplicate common entries", () => {
+    const merged = updateCommonConfigSnippet(
+      providerConfig,
+      commonSnippet,
+      true,
+    ).updatedConfig;
+    const mergedAgain = updateCommonConfigSnippet(
+      merged,
+      commonSnippet,
+      true,
+    ).updatedConfig;
+
+    expect(JSON.parse(mergedAgain).permissions.deny).toEqual([
+      "WebSearch",
+      "Read(~/.ssh/**)",
+    ]);
+    expect(hasCommonConfigSnippet(mergedAgain, commonSnippet)).toBe(true);
+  });
+
+  it("removes only the common entries when disabled", () => {
+    const merged = updateCommonConfigSnippet(
+      providerConfig,
+      commonSnippet,
+      true,
+    ).updatedConfig;
+    const removed = updateCommonConfigSnippet(
+      merged,
+      commonSnippet,
+      false,
+    ).updatedConfig;
+
+    expect(JSON.parse(removed).permissions.deny).toEqual(["WebSearch"]);
+    expect(hasCommonConfigSnippet(removed, commonSnippet)).toBe(false);
+  });
+});
+
 describe("common config snippet prototype-pollution guards", () => {
   // 污染是全局的：一旦漏进 Object.prototype，同文件后续用例会读到幽灵属性，
   // 失败点会飘到无关的断言上。每条用例后强制清干净。

--- a/src/utils/providerConfigUtils.test.ts
+++ b/src/utils/providerConfigUtils.test.ts
@@ -218,6 +218,17 @@ describe("common config array merging", () => {
     expect(JSON.parse(removed).permissions.deny).toEqual(["WebSearch"]);
     expect(hasCommonConfigSnippet(removed, commonSnippet)).toBe(false);
   });
+
+  it("does not reuse one target item for multiple snippet entries", () => {
+    const config = JSON.stringify({ hooks: [{ a: 1, b: 2 }] });
+    const snippet = JSON.stringify({ hooks: [{ a: 1 }, { a: 1, b: 2 }] });
+
+    expect(hasCommonConfigSnippet(config, snippet)).toBe(false);
+
+    const merged = updateCommonConfigSnippet(config, snippet, true).updatedConfig;
+    expect(JSON.parse(merged).hooks).toEqual([{ a: 1, b: 2 }, { a: 1 }]);
+    expect(hasCommonConfigSnippet(merged, snippet)).toBe(true);
+  });
 });
 
 describe("common config snippet prototype-pollution guards", () => {

--- a/src/utils/providerConfigUtils.test.ts
+++ b/src/utils/providerConfigUtils.test.ts
@@ -225,7 +225,11 @@ describe("common config array merging", () => {
 
     expect(hasCommonConfigSnippet(config, snippet)).toBe(false);
 
-    const merged = updateCommonConfigSnippet(config, snippet, true).updatedConfig;
+    const merged = updateCommonConfigSnippet(
+      config,
+      snippet,
+      true,
+    ).updatedConfig;
     expect(JSON.parse(merged).hooks).toEqual([{ a: 1, b: 2 }, { a: 1 }]);
     expect(hasCommonConfigSnippet(merged, snippet)).toBe(true);
   });

--- a/src/utils/providerConfigUtils.test.ts
+++ b/src/utils/providerConfigUtils.test.ts
@@ -176,6 +176,50 @@ name = "Example"
   });
 });
 
+describe("common config array merging", () => {
+  const providerConfig = JSON.stringify({
+    permissions: { deny: ["WebSearch"] },
+  });
+  const commonSnippet = JSON.stringify({
+    permissions: { deny: ["Read(~/.ssh/**)"] },
+  });
+
+  it("keeps provider entries and does not duplicate common entries", () => {
+    const merged = updateCommonConfigSnippet(
+      providerConfig,
+      commonSnippet,
+      true,
+    ).updatedConfig;
+    const mergedAgain = updateCommonConfigSnippet(
+      merged,
+      commonSnippet,
+      true,
+    ).updatedConfig;
+
+    expect(JSON.parse(mergedAgain).permissions.deny).toEqual([
+      "WebSearch",
+      "Read(~/.ssh/**)",
+    ]);
+    expect(hasCommonConfigSnippet(mergedAgain, commonSnippet)).toBe(true);
+  });
+
+  it("removes only the common entries when disabled", () => {
+    const merged = updateCommonConfigSnippet(
+      providerConfig,
+      commonSnippet,
+      true,
+    ).updatedConfig;
+    const removed = updateCommonConfigSnippet(
+      merged,
+      commonSnippet,
+      false,
+    ).updatedConfig;
+
+    expect(JSON.parse(removed).permissions.deny).toEqual(["WebSearch"]);
+    expect(hasCommonConfigSnippet(removed, commonSnippet)).toBe(false);
+  });
+});
+
 describe("common config snippet prototype-pollution guards", () => {
   // 污染是全局的：一旦漏进 Object.prototype，同文件后续用例会读到幽灵属性，
   // 失败点会飘到无关的断言上。每条用例后强制清干净。

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -28,8 +28,8 @@ const FORBIDDEN_MERGE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 /**
  * 递归剥掉禁键，得到"实际会被写进配置的那份片段"。
  *
- * 只给**读取侧**（`hasCommonConfigSnippet` / `hasTomlCommonConfigSnippet`）用，
- * 写入侧不需要——`deepMerge` / `deepRemove` 自身就跳过禁键，净化前后输出相同。
+ * 写入和读取侧都使用：数组元素会被整体插入，必须在进入遍历函数前净化；读取侧
+ * 也要比对同一份净化结果，避免开关状态与实际写入内容不一致。
  *
  * 之所以读取侧非做不可：两侧对禁键的处理**语义不同**。写入侧是"跳过这个键、
  * 继续处理其余字段"，而 `isSubset` 出于安全必须"见到禁键就整体否决"。于是
@@ -220,9 +220,10 @@ export const updateCommonConfigSnippet = (
     };
   }
 
-  // 这里不必净化：deepMerge / deepRemove 自身就跳过禁键，净化前后输出逐字节相同。
-  // 需要净化的是**读取侧**（hasCommonConfigSnippet），原因见 sanitizeSnippet。
-  const snippet = JSON.parse(snippetString) as Record<string, any>;
+  const snippet = sanitizeSnippet(JSON.parse(snippetString)) as Record<
+    string,
+    any
+  >;
 
   if (enabled) {
     const merged = deepMerge(deepClone(config), snippet);

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -133,8 +133,29 @@ const isSubset = (target: any, source: any): boolean => {
 
   if (Array.isArray(source)) {
     if (!Array.isArray(target)) return false;
-    return source.every((sourceItem) =>
-      target.some((targetItem) => isSubset(targetItem, sourceItem)),
+    // Relocate earlier matches when needed so each source item claims a distinct target.
+    const matchedSourceByTarget = new Array<number>(target.length).fill(-1);
+    const tryMatch = (sourceIndex: number, seen: boolean[]): boolean => {
+      for (let targetIndex = 0; targetIndex < target.length; targetIndex += 1) {
+        if (
+          seen[targetIndex] ||
+          !isSubset(target[targetIndex], source[sourceIndex])
+        ) {
+          continue;
+        }
+
+        seen[targetIndex] = true;
+        const matchedSource = matchedSourceByTarget[targetIndex];
+        if (matchedSource === -1 || tryMatch(matchedSource, seen)) {
+          matchedSourceByTarget[targetIndex] = sourceIndex;
+          return true;
+        }
+      }
+      return false;
+    };
+
+    return source.every((_, sourceIndex) =>
+      tryMatch(sourceIndex, new Array(target.length).fill(false)),
     );
   }
 

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -57,13 +57,24 @@ const deepMerge = (
   Object.entries(source).forEach(([key, value]) => {
     if (FORBIDDEN_MERGE_KEYS.has(key)) return;
 
-    if (isPlainObject(value)) {
+    if (Array.isArray(value)) {
+      if (!Array.isArray(target[key])) {
+        target[key] = [];
+      }
+      value.forEach((item) => {
+        const exists = target[key].some(
+          (existing: any) =>
+            isSubset(existing, item) && isSubset(item, existing),
+        );
+        if (!exists) target[key].push(item);
+      });
+    } else if (isPlainObject(value)) {
       if (!isPlainObject(target[key])) {
         target[key] = {};
       }
       deepMerge(target[key], value);
     } else {
-      // 直接覆盖非对象字段（数组/基础类型）
+      // 直接覆盖基础类型字段
       target[key] = value;
     }
   });
@@ -80,7 +91,18 @@ const deepRemove = (
     if (FORBIDDEN_MERGE_KEYS.has(key)) return;
     if (!(key in target)) return;
 
-    if (isPlainObject(value) && isPlainObject(target[key])) {
+    if (Array.isArray(value) && Array.isArray(target[key])) {
+      target[key] = target[key].filter(
+        (item: any) =>
+          !value.some(
+            (sourceItem) =>
+              isSubset(item, sourceItem) && isSubset(sourceItem, item),
+          ),
+      );
+      if (target[key].length === 0) {
+        delete target[key];
+      }
+    } else if (isPlainObject(value) && isPlainObject(target[key])) {
       // 只移除完全匹配的嵌套属性
       deepRemove(target[key], value);
       if (Object.keys(target[key]).length === 0) {
@@ -110,8 +132,10 @@ const isSubset = (target: any, source: any): boolean => {
   }
 
   if (Array.isArray(source)) {
-    if (!Array.isArray(target) || target.length !== source.length) return false;
-    return source.every((item, index) => isSubset(target[index], item));
+    if (!Array.isArray(target)) return false;
+    return source.every((sourceItem) =>
+      target.some((targetItem) => isSubset(targetItem, sourceItem)),
+    );
   }
 
   return target === source;

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -62,11 +62,11 @@ const deepMerge = (
         target[key] = [];
       }
       value.forEach((item) => {
-        const exists = target[key].some(
+        const exists = (target[key] as any[]).some(
           (existing: any) =>
             isSubset(existing, item) && isSubset(item, existing),
         );
-        if (!exists) target[key].push(item);
+        if (!exists) (target[key] as any[]).push(item);
       });
     } else if (isPlainObject(value)) {
       if (!isPlainObject(target[key])) {
@@ -92,15 +92,18 @@ const deepRemove = (
     if (!(key in target)) return;
 
     if (Array.isArray(value) && Array.isArray(target[key])) {
-      target[key] = target[key].filter(
-        (item: any) =>
-          !value.some(
-            (sourceItem) =>
-              isSubset(item, sourceItem) && isSubset(sourceItem, item),
-          ),
-      );
-      if (target[key].length === 0) {
+      const arr = [...(target[key] as any[])];
+      for (const sourceItem of value) {
+        const idx = arr.findIndex(
+          (item: any) =>
+            isSubset(item, sourceItem) && isSubset(sourceItem, item),
+        );
+        if (idx !== -1) arr.splice(idx, 1);
+      }
+      if (arr.length === 0) {
         delete target[key];
+      } else {
+        target[key] = arr;
       }
     } else if (isPlainObject(value) && isPlainObject(target[key])) {
       // 只移除完全匹配的嵌套属性
@@ -133,7 +136,9 @@ const isSubset = (target: any, source: any): boolean => {
 
   if (Array.isArray(source)) {
     if (!Array.isArray(target)) return false;
-    // Relocate earlier matches when needed so each source item claims a distinct target.
+    // Bipartite matching with reassignment so each source element claims a
+    // distinct target element. Greedy first-match fails when a broader target
+    // is claimed by an earlier source that could also match a narrower one.
     const matchedSourceByTarget = new Array<number>(target.length).fill(-1);
     const tryMatch = (sourceIndex: number, seen: boolean[]): boolean => {
       for (let targetIndex = 0; targetIndex < target.length; targetIndex += 1) {
@@ -143,7 +148,6 @@ const isSubset = (target: any, source: any): boolean => {
         ) {
           continue;
         }
-
         seen[targetIndex] = true;
         const matchedSource = matchedSourceByTarget[targetIndex];
         if (matchedSource === -1 || tryMatch(matchedSource, seen)) {
@@ -153,7 +157,6 @@ const isSubset = (target: any, source: any): boolean => {
       }
       return false;
     };
-
     return source.every((_, sourceIndex) =>
       tryMatch(sourceIndex, new Array(target.length).fill(false)),
     );


### PR DESCRIPTION
## Summary

- merge common-config arrays as a deduplicated union instead of replacing provider entries
- treat common-config arrays as subsets when detecting whether a snippet is applied
- remove only matching common-config array entries when disabling the snippet

## Root cause

`deepMerge` replaced arrays wholesale, while `isSubset` required equal length and order and `deepRemove` deleted the whole matching array. Applying a shared `permissions.deny` array therefore discarded provider-specific deny rules and disabling it could not restore them.

## Validation

- `pnpm exec vitest run src/utils/providerConfigUtils.test.ts` (22 tests passed)
- `pnpm typecheck`
- `pnpm exec prettier --check src/utils/providerConfigUtils.ts src/utils/providerConfigUtils.test.ts`
- `git diff --check`
- `ocr review --audience agent ...` (0 findings)

Closes #6141
